### PR TITLE
feat(control-plane): duty_group ledger for k8s daemons

### DIFF
--- a/packages/control-plane/prisma/migrations/20260819000000_duty_group_ledger/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260819000000_duty_group_ledger/migration.sql
@@ -1,0 +1,33 @@
+-- K8s duty ledger: one claimable row per connected component of the
+-- agent↔daemon-held-bot graph, plus its derived membership projection.
+CREATE TABLE "duty_group" (
+    "id" UUID NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "holder" UUID,
+    "term" BIGINT NOT NULL DEFAULT 0,
+    "expiresAt" TIMESTAMPTZ(6),
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "duty_group_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TYPE "DutyMemberKind" AS ENUM ('agent', 'bot');
+
+CREATE TABLE "duty_group_member" (
+    "kind" "DutyMemberKind" NOT NULL,
+    "refId" UUID NOT NULL,
+    "groupId" UUID NOT NULL,
+    "orgId" TEXT NOT NULL,
+
+    CONSTRAINT "duty_group_member_pkey" PRIMARY KEY ("kind","refId")
+);
+
+CREATE INDEX "duty_group_orgId_idx" ON "duty_group"("orgId");
+CREATE INDEX "duty_group_holder_idx" ON "duty_group"("holder");
+CREATE INDEX "duty_group_expiresAt_idx" ON "duty_group"("expiresAt");
+CREATE INDEX "duty_group_member_groupId_idx" ON "duty_group_member"("groupId");
+CREATE INDEX "duty_group_member_orgId_idx" ON "duty_group_member"("orgId");
+
+ALTER TABLE "duty_group" ADD CONSTRAINT "duty_group_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "duty_group_member" ADD CONSTRAINT "duty_group_member_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "duty_group"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -108,6 +108,7 @@ model Org {
   sessionExternalAccess     SessionExternalAccessPolicy[]
   environmentEntries        OrganizationEnvironmentEntry[]
   clusterExecution          OrgClusterExecution?
+  dutyGroups                DutyGroup[]
 
   @@index([createdByUserId])
   @@map("org")
@@ -2840,4 +2841,57 @@ model PendingEnvelopeTeardown {
   createdAt    DateTime @default(now()) @db.Timestamptz(6)
 
   @@map("pending_envelope_teardown")
+}
+
+/// K8s duty ledger: one row per connected component of the
+/// agent↔daemon-held-bot graph (an enabled cron is an edge too), the only unit
+/// a k8s daemon ever claims. Deliberately NOT holder columns on Bot or
+/// Integration: per-row leases cannot express an atomic group claim, a botless
+/// cron-bearing agent has no Integration row to carry one, and two held groups
+/// merging need a single surviving holder recorded somewhere.
+///
+/// Vacancy is temporal, not referential: a group is grantable when
+/// `expiresAt` has passed (or it was never claimed / explicitly released), so a
+/// dead member simply stops renewing — `holder` carries no FK on purpose, since
+/// fencing always reads (holder, term) together and a row-level SetNull would
+/// vacate without a term bump.
+model DutyGroup {
+  id        String    @id @db.Uuid
+  orgId     String
+  holder    String?   @db.Uuid // member (daemon) the group is granted to; null ⇒ never claimed or released
+  term      BigInt    @default(0) // monotonic per group; bumped on EVERY grant/re-grant — the fencing token
+  expiresAt DateTime? @db.Timestamptz(6) // renewal horizon written by the granter; past ⇒ vacant and grantable
+  createdAt DateTime  @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime  @updatedAt @db.Timestamptz(6)
+
+  org     Org               @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  members DutyGroupMember[]
+
+  @@index([orgId])
+  @@index([holder])
+  @@index([expiresAt])
+  @@map("duty_group")
+}
+
+enum DutyMemberKind {
+  agent
+  bot
+}
+
+/// Derived membership projection (agentId|botId → group), recomputed from
+/// Integration and CronDef rows whenever an edge changes — never hand-written,
+/// so it needs no reconciliation of its own. The composite id makes "one home
+/// per agent / per bot" a database invariant, not a code promise.
+model DutyGroupMember {
+  kind    DutyMemberKind
+  refId   String         @db.Uuid // Agent.id or Bot.id, per kind (no FK: recompute owns lifecycle)
+  groupId String         @db.Uuid
+  orgId   String
+
+  group DutyGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
+
+  @@id([kind, refId])
+  @@index([groupId])
+  @@index([orgId])
+  @@map("duty_group_member")
 }

--- a/packages/control-plane/src/domain/duty.ts
+++ b/packages/control-plane/src/domain/duty.ts
@@ -1,0 +1,40 @@
+// Duty-ledger domain types (k8s daemons): the claim unit is a GROUP — a
+// connected component of the agent↔daemon-held-bot graph — never a single row.
+// Shared by the pure planner (orchestrator/dutyGroup.ts) and the repo port.
+
+export type DutyMemberKind = 'agent' | 'bot'
+
+export interface DutyMemberKey {
+  kind: DutyMemberKind
+  refId: string
+}
+
+export interface DutyGroupWrite {
+  groupId: string
+  members: DutyMemberKey[]
+  /** Non-null ⇒ the group is held and composition changed: re-grant to this holder at a bumped term. */
+  regrantTo: string | null
+}
+
+export interface DutyGroupCreate {
+  members: DutyMemberKey[]
+  /** Non-null ⇒ a pure split remainder of one held group: grant to that holder (no eviction). */
+  grantTo: string | null
+}
+
+export interface DutySupersession {
+  groupId: string
+  holder: string
+}
+
+/** The deterministic recompute output the repo applies transactionally. */
+export interface DutyReconcilePlan {
+  /** Groups whose composition is unchanged — no write at all. */
+  unchanged: string[]
+  writes: DutyGroupWrite[]
+  creates: DutyGroupCreate[]
+  /** Groups whose identity did not survive the recompute. */
+  deletes: string[]
+  /** Held groups whose members now live under a different holder (or nowhere): notify + teardown. */
+  superseded: DutySupersession[]
+}

--- a/packages/control-plane/src/orchestrator/dutyGroup.test.ts
+++ b/packages/control-plane/src/orchestrator/dutyGroup.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeDutyComponents,
+  planDutyReconcile,
+  type ComputedComponent,
+  type DutyMemberKey,
+  type ExistingDutyGroup
+} from './dutyGroup.js'
+
+const agent = (id: string): DutyMemberKey => ({ kind: 'agent', refId: id })
+const bot = (id: string): DutyMemberKey => ({ kind: 'bot', refId: id })
+const comp = (...members: DutyMemberKey[]): ComputedComponent => ({ members })
+
+describe('computeDutyComponents', () => {
+  it('joins an agent with its bots into one component', () => {
+    const out = computeDutyComponents(
+      [
+        { agentId: 'a1', botId: 'b1' },
+        { agentId: 'a1', botId: 'b2' }
+      ],
+      []
+    )
+    expect(out).toEqual([comp(agent('a1'), bot('b1'), bot('b2'))])
+  })
+
+  it('clusters every agent of a shared bot at that bot', () => {
+    const out = computeDutyComponents(
+      [
+        { agentId: 'a1', botId: 'shared' },
+        { agentId: 'a2', botId: 'shared' },
+        { agentId: 'a3', botId: 'other' }
+      ],
+      []
+    )
+    expect(out).toEqual([comp(agent('a1'), agent('a2'), bot('shared')), comp(agent('a3'), bot('other'))])
+  })
+
+  it('a shared bot transitively merges each agent’s other bots', () => {
+    const out = computeDutyComponents(
+      [
+        { agentId: 'a1', botId: 'shared' },
+        { agentId: 'a2', botId: 'shared' },
+        { agentId: 'a2', botId: 'tg' }
+      ],
+      []
+    )
+    expect(out).toEqual([comp(agent('a1'), agent('a2'), bot('shared'), bot('tg'))])
+  })
+
+  it('an enabled cron seeds a singleton component for a botless agent', () => {
+    const out = computeDutyComponents([{ agentId: 'a1', botId: 'b1' }], [{ agentId: 'lone' }, { agentId: 'a1' }])
+    expect(out).toEqual([comp(agent('a1'), bot('b1')), comp(agent('lone'))])
+  })
+
+  it('is deterministic regardless of input order', () => {
+    const edges = [
+      { agentId: 'a2', botId: 'b2' },
+      { agentId: 'a1', botId: 'b1' }
+    ]
+    expect(computeDutyComponents(edges, [])).toEqual(computeDutyComponents([...edges].reverse(), []))
+  })
+
+  it('dedupes repeated edges', () => {
+    const out = computeDutyComponents(
+      [
+        { agentId: 'a1', botId: 'b1' },
+        { agentId: 'a1', botId: 'b1' }
+      ],
+      []
+    )
+    expect(out).toEqual([comp(agent('a1'), bot('b1'))])
+  })
+})
+
+const held = (groupId: string, holder: string, ...members: DutyMemberKey[]): ExistingDutyGroup => ({
+  groupId,
+  held: true,
+  holder,
+  members
+})
+const vacant = (groupId: string, ...members: DutyMemberKey[]): ExistingDutyGroup => ({
+  groupId,
+  held: false,
+  holder: null,
+  members
+})
+
+describe('planDutyReconcile', () => {
+  it('reports identical composition as unchanged', () => {
+    const plan = planDutyReconcile([held('g1', 'm1', agent('a1'), bot('b1'))], [comp(agent('a1'), bot('b1'))])
+    expect(plan).toEqual({ unchanged: ['g1'], writes: [], creates: [], deletes: [], superseded: [] })
+  })
+
+  it('creates a vacant group for a brand-new component', () => {
+    const plan = planDutyReconcile([], [comp(agent('a1'), bot('b1'))])
+    expect(plan.creates).toEqual([{ members: [agent('a1'), bot('b1')], grantTo: null }])
+  })
+
+  it('re-grants the same holder when a held group gains a bot (no eviction)', () => {
+    const plan = planDutyReconcile(
+      [held('g1', 'm1', agent('a1'), bot('b1'))],
+      [comp(agent('a1'), bot('b1'), bot('b2'))]
+    )
+    expect(plan.writes).toEqual([{ groupId: 'g1', members: [agent('a1'), bot('b1'), bot('b2')], regrantTo: 'm1' }])
+    expect(plan.superseded).toEqual([])
+  })
+
+  it('rewrites a vacant group without a grant', () => {
+    const plan = planDutyReconcile([vacant('g1', agent('a1'), bot('b1'))], [comp(agent('a1'), bot('b1'), bot('b2'))])
+    expect(plan.writes).toEqual([{ groupId: 'g1', members: [agent('a1'), bot('b1'), bot('b2')], regrantTo: null }])
+  })
+
+  it('merge: the larger held group keeps the merged group; the other holder is superseded', () => {
+    const plan = planDutyReconcile(
+      [held('gBig', 'mBig', agent('a1'), agent('a2'), bot('shared')), held('gSmall', 'mSmall', agent('a3'), bot('tg'))],
+      [comp(agent('a1'), agent('a2'), agent('a3'), bot('shared'), bot('tg'))]
+    )
+    expect(plan.writes).toEqual([
+      { groupId: 'gBig', members: [agent('a1'), agent('a2'), agent('a3'), bot('shared'), bot('tg')], regrantTo: 'mBig' }
+    ])
+    expect(plan.deletes).toEqual(['gSmall'])
+    expect(plan.superseded).toEqual([{ groupId: 'gSmall', holder: 'mSmall' }])
+  })
+
+  it('merge tie on size breaks to the lower groupId', () => {
+    const plan = planDutyReconcile(
+      [held('g2', 'm2', agent('a2'), bot('b2')), held('g1', 'm1', agent('a1'), bot('b1'))],
+      [comp(agent('a1'), agent('a2'), bot('b1'), bot('b2'))]
+    )
+    expect(plan.writes[0].groupId).toBe('g1')
+    expect(plan.writes[0].regrantTo).toBe('m1')
+    expect(plan.superseded).toEqual([{ groupId: 'g2', holder: 'm2' }])
+  })
+
+  it('merge of two groups held by the SAME member supersedes nobody', () => {
+    const plan = planDutyReconcile(
+      [held('g1', 'm1', agent('a1'), bot('b1')), held('g2', 'm1', agent('a2'), bot('b2'))],
+      [comp(agent('a1'), agent('a2'), bot('b1'), bot('b2'))]
+    )
+    expect(plan.deletes).toEqual(['g2'])
+    expect(plan.superseded).toEqual([])
+  })
+
+  it('a held group beats a larger vacant group for the merged identity', () => {
+    const plan = planDutyReconcile(
+      [vacant('gVac', agent('a1'), agent('a2'), bot('b1')), held('gHeld', 'm1', agent('a3'), bot('b2'))],
+      [comp(agent('a1'), agent('a2'), agent('a3'), bot('b1'), bot('b2'))]
+    )
+    expect(plan.writes[0]).toMatchObject({ groupId: 'gHeld', regrantTo: 'm1' })
+    expect(plan.deletes).toEqual(['gVac'])
+  })
+
+  it('split: the id and holder follow the larger fragment; the remainder inherits the holder', () => {
+    const plan = planDutyReconcile(
+      [held('g1', 'm1', agent('a1'), agent('a2'), bot('shared'), bot('tg'))],
+      [comp(agent('a1'), agent('a2'), bot('shared')), comp(bot('tg'))]
+    )
+    expect(plan.writes).toEqual([
+      { groupId: 'g1', members: [agent('a1'), agent('a2'), bot('shared')], regrantTo: 'm1' }
+    ])
+    expect(plan.creates).toEqual([{ members: [bot('tg')], grantTo: 'm1' }])
+    expect(plan.superseded).toEqual([])
+  })
+
+  it('a fragment fed by two different held groups is created vacant', () => {
+    const plan = planDutyReconcile(
+      [held('g1', 'm1', agent('a1'), bot('b1'), bot('x1')), held('g2', 'm2', agent('a2'), bot('b2'), bot('x2'))],
+      [comp(agent('a1'), bot('b1')), comp(agent('a2'), bot('b2')), comp(agent('a3'), bot('x1'), bot('x2'))]
+    )
+    expect(plan.writes.map((w) => w.groupId).sort()).toEqual(['g1', 'g2'])
+    expect(plan.creates).toEqual([{ members: [agent('a3'), bot('x1'), bot('x2')], grantTo: null }])
+  })
+
+  it('deletes a group whose members all vanished and supersedes its holder', () => {
+    const plan = planDutyReconcile([held('g1', 'm1', agent('a1'), bot('b1'))], [])
+    expect(plan.deletes).toEqual(['g1'])
+    expect(plan.superseded).toEqual([{ groupId: 'g1', holder: 'm1' }])
+  })
+
+  it('a vanished vacant group is deleted silently', () => {
+    const plan = planDutyReconcile([vacant('g1', agent('a1'))], [])
+    expect(plan).toEqual({ unchanged: [], writes: [], creates: [], deletes: ['g1'], superseded: [] })
+  })
+
+  it('is deterministic under input reordering', () => {
+    const existing = [
+      held('g2', 'm2', agent('a2'), bot('b2')),
+      held('g1', 'm1', agent('a1'), bot('b1')),
+      vacant('g3', agent('a3'))
+    ]
+    const components = [
+      comp(agent('a1'), agent('a2'), bot('b1'), bot('b2')),
+      comp(agent('a3'), bot('b3')),
+      comp(agent('a4'))
+    ]
+    const a = planDutyReconcile(existing, components)
+    const b = planDutyReconcile([...existing].reverse(), [...components].reverse())
+    expect(a).toEqual(b)
+  })
+})

--- a/packages/control-plane/src/orchestrator/dutyGroup.ts
+++ b/packages/control-plane/src/orchestrator/dutyGroup.ts
@@ -1,0 +1,183 @@
+// Pure duty-group math for k8s daemons: connected components of the
+// agent↔daemon-held-bot graph (an enabled cron is an edge too), plus the
+// deterministic reconcile plan that maps freshly computed components onto the
+// persisted `duty_group` rows. No I/O — the repo applies the plan it returns.
+import type { DutyMemberKind, DutyMemberKey, DutyReconcilePlan } from '../domain/duty.js'
+
+export type { DutyMemberKind, DutyMemberKey, DutyReconcilePlan }
+
+/** An active Integration row whose bot the daemon itself connects (socket transport). */
+export interface DutyEdge {
+  agentId: string
+  botId: string
+}
+
+/** An enabled cron: the agent must belong to a claimable group even with no bots. */
+export interface CronSeed {
+  agentId: string
+}
+
+export interface ComputedComponent {
+  /** Canonically sorted, deduplicated membership. */
+  members: DutyMemberKey[]
+}
+
+export interface ExistingDutyGroup {
+  groupId: string
+  /** Live holdership as the caller judges it: holder set AND lease not expired. */
+  held: boolean
+  holder: string | null
+  members: DutyMemberKey[]
+}
+
+const keyOf = (m: DutyMemberKey): string => `${m.kind}:${m.refId}`
+
+const compareMembers = (a: DutyMemberKey, b: DutyMemberKey): number =>
+  a.kind === b.kind ? (a.refId < b.refId ? -1 : a.refId > b.refId ? 1 : 0) : a.kind < b.kind ? -1 : 1
+
+function canonical(members: Iterable<DutyMemberKey>): DutyMemberKey[] {
+  const seen = new Map<string, DutyMemberKey>()
+  for (const m of members) seen.set(keyOf(m), m)
+  return [...seen.values()].sort(compareMembers)
+}
+
+/** Union-find over agent/bot nodes; every edge joins, every seed guarantees a node. */
+export function computeDutyComponents(edges: DutyEdge[], seeds: CronSeed[]): ComputedComponent[] {
+  const parent = new Map<string, string>()
+  const find = (x: string): string => {
+    let r = x
+    while (parent.get(r) !== r) r = parent.get(r)!
+    // Path compression keeps repeated finds cheap on wide shared-bot groups.
+    let c = x
+    while (c !== r) {
+      const next = parent.get(c)!
+      parent.set(c, r)
+      c = next
+    }
+    return r
+  }
+  const add = (k: string) => {
+    if (!parent.has(k)) parent.set(k, k)
+  }
+  const union = (a: string, b: string) => {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra !== rb) parent.set(ra < rb ? rb : ra, ra < rb ? ra : rb)
+  }
+
+  for (const e of edges) {
+    const a = keyOf({ kind: 'agent', refId: e.agentId })
+    const b = keyOf({ kind: 'bot', refId: e.botId })
+    add(a)
+    add(b)
+    union(a, b)
+  }
+  for (const s of seeds) add(keyOf({ kind: 'agent', refId: s.agentId }))
+
+  const byRoot = new Map<string, DutyMemberKey[]>()
+  for (const k of parent.keys()) {
+    const root = find(k)
+    const [kind, refId] = [k.slice(0, k.indexOf(':')) as DutyMemberKind, k.slice(k.indexOf(':') + 1)]
+    const list = byRoot.get(root) ?? []
+    list.push({ kind, refId })
+    byRoot.set(root, list)
+  }
+  return [...byRoot.values()]
+    .map((members) => ({ members: canonical(members) }))
+    .sort((a, b) => compareMembers(a.members[0]!, b.members[0]!))
+}
+
+// The identity-assignment rule, stated once: existing groups are consumed in
+// (held first, larger first, lower groupId first) order, and each takes the
+// unassigned component holding most of its former members. This makes "the
+// holder of the larger group keeps the merged group, ties broken by lower
+// groupId" a corollary rather than a special case, covers splits (the id and
+// holder follow the largest fragment), and is fully deterministic — two
+// concurrent recomputes from the same rows produce byte-identical plans.
+export function planDutyReconcile(existing: ExistingDutyGroup[], components: ComputedComponent[]): DutyReconcilePlan {
+  const comps = components.map((c) => ({ members: canonical(c.members) }))
+  const memberToComp = new Map<string, number>()
+  comps.forEach((c, i) => c.members.forEach((m) => memberToComp.set(keyOf(m), i)))
+
+  const order = [...existing].sort((a, b) => {
+    if (a.held !== b.held) return a.held ? -1 : 1
+    if (a.members.length !== b.members.length) return b.members.length - a.members.length
+    return a.groupId < b.groupId ? -1 : 1
+  })
+
+  const compAssignee = new Map<number, ExistingDutyGroup>()
+  const groupAssignedComp = new Map<string, number>()
+  for (const g of order) {
+    const overlap = new Map<number, number>()
+    for (const m of g.members) {
+      const ci = memberToComp.get(keyOf(m))
+      if (ci !== undefined && !compAssignee.has(ci)) overlap.set(ci, (overlap.get(ci) ?? 0) + 1)
+    }
+    let best: number | null = null
+    for (const [ci, n] of overlap) {
+      if (best === null) best = ci
+      else {
+        const bn = overlap.get(best)!
+        // Most former members first; then the component with the smallest lead member.
+        if (n > bn || (n === bn && compareMembers(comps[ci]!.members[0]!, comps[best]!.members[0]!) < 0)) best = ci
+      }
+    }
+    if (best !== null) {
+      compAssignee.set(best, g)
+      groupAssignedComp.set(g.groupId, best)
+    }
+  }
+
+  const plan: DutyReconcilePlan = { unchanged: [], writes: [], creates: [], deletes: [], superseded: [] }
+
+  // Contributors: which held groups previously owned each component's members (split inheritance).
+  const memberToHeldGroup = new Map<string, ExistingDutyGroup>()
+  for (const g of existing) if (g.held) for (const m of g.members) memberToHeldGroup.set(keyOf(m), g)
+
+  comps.forEach((c, i) => {
+    const assigned = compAssignee.get(i)
+    if (assigned) {
+      const same =
+        assigned.members.length === c.members.length &&
+        assigned.members.every((m, j) => keyOf(m) === keyOf(c.members[j]!))
+      if (same) plan.unchanged.push(assigned.groupId)
+      else
+        plan.writes.push({
+          groupId: assigned.groupId,
+          members: c.members,
+          regrantTo: assigned.held ? assigned.holder : null
+        })
+      return
+    }
+    const contributors = new Set(c.members.map((m) => memberToHeldGroup.get(keyOf(m))).filter((g) => g !== undefined))
+    const sole = contributors.size === 1 ? [...contributors][0]! : null
+    plan.creates.push({ members: c.members, grantTo: sole ? sole.holder : null })
+  })
+
+  for (const g of existing) {
+    if (groupAssignedComp.has(g.groupId)) continue
+    plan.deletes.push(g.groupId)
+    if (!g.held || g.holder === null) continue
+    // Not superseded when every surviving member stays with the same holder —
+    // that is a re-grant elsewhere in the plan, not a loss.
+    const destinations = new Set<string | null>()
+    for (const m of g.members) {
+      const ci = memberToComp.get(keyOf(m))
+      if (ci === undefined) continue
+      const winner = compAssignee.get(ci)
+      if (winner) destinations.add(winner.held ? winner.holder : null)
+      else {
+        const create = plan.creates.find((cr) => cr.members.some((cm) => keyOf(cm) === keyOf(m)))
+        destinations.add(create?.grantTo ?? null)
+      }
+    }
+    const lost = destinations.size === 0 || [...destinations].some((h) => h !== g.holder)
+    if (lost) plan.superseded.push({ groupId: g.groupId, holder: g.holder })
+  }
+
+  plan.unchanged.sort()
+  plan.deletes.sort()
+  plan.writes.sort((a, b) => (a.groupId < b.groupId ? -1 : 1))
+  plan.superseded.sort((a, b) => (a.groupId < b.groupId ? -1 : 1))
+  return plan
+}

--- a/packages/control-plane/src/persistence/index.ts
+++ b/packages/control-plane/src/persistence/index.ts
@@ -68,6 +68,7 @@ export {
 } from './preset-agents.js'
 export { PresetAgentBackfill } from './preset-agent-backfill.js'
 export { PgCronRepo } from './repositories/cron.repo.js'
+export { PgDutyGroupRepo } from './repositories/duty-group.repo.js'
 export { PgHookRepo, PgHookSecretStore } from './repositories/hook.repo.js'
 export { PgRuntimeProfileRepo } from './repositories/runtime-profile.repo.js'
 export { PgAuditRepo } from './repositories/audit.repo.js'

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -40,6 +40,7 @@ import type {
   OrgId
 } from '../domain/ids.js'
 import type { SessionKey } from '../domain/sessionKey.js'
+import type { DutyMemberKey, DutyReconcilePlan } from '../domain/duty.js'
 import type {
   OrganizationEnvironmentAudience,
   OrganizationEnvironmentKind,
@@ -5061,4 +5062,66 @@ export interface OrgClusterExecutionRepo {
     defaults: ClusterExecutionDefaults,
     patch: ClusterExecutionPatch
   ): Promise<ClusterExecutionSettings>
+}
+
+// DutyGroupRepo (k8s daemons) — the CP-hosted duty ledger
+
+/** A ledger row plus its derived membership projection. */
+export interface DutyGroupRecord {
+  groupId: string
+  orgId: OrgId
+  holder: DaemonId | null
+  /** Monotonic per group; bumped on EVERY grant — the fencing token duty-scoped actions carry. */
+  term: bigint
+  /** Renewal horizon; past (or null with a holder never granted) ⇒ vacant and grantable. */
+  expiresAt: Date | null
+  members: DutyMemberKey[]
+}
+
+/** One freshly granted group as returned by a claim. */
+export interface DutyGrantRecord {
+  groupId: string
+  orgId: OrgId
+  term: bigint
+  members: DutyMemberKey[]
+}
+
+export interface AgentHomeClaim {
+  granted: boolean
+  groupId: string
+  term: bigint
+  /** The live holder — the caller when granted, the incumbent for a `not_holder` answer otherwise. */
+  holder: DaemonId | null
+}
+
+/** Pure plan callback run inside the reconcile transaction's org snapshot (orchestrator/dutyGroup.ts). */
+export type DutyReconcilePlanner = (existing: DutyGroupRecord[]) => DutyReconcilePlan
+
+export interface DutyGroupRepo {
+  /** Recompute input + console/introspection read. */
+  listForOrg(orgId: OrgId): Promise<DutyGroupRecord[]>
+  /** Everything one member currently holds (heartbeat digest reconciliation). */
+  listHeldBy(holder: DaemonId): Promise<DutyGroupRecord[]>
+  /** Snapshot → `planner` → apply, in ONE transaction under a per-org advisory
+   *  scope, so concurrent recomputes serialize CP-instance-wide. Composition
+   *  changes on held groups re-grant the same holder at a bumped term; the
+   *  returned plan carries the supersessions the caller must deliver. */
+  applyReconcile(
+    orgId: OrgId,
+    planner: DutyReconcilePlanner,
+    opts: { now: Date; leaseMs: number }
+  ): Promise<DutyReconcilePlan>
+  /** "Grant me up to `max` vacant groups": first valid claim wins (SKIP LOCKED),
+   *  each grant bumps the term. Install-wide — capacity gating is the caller's. */
+  claimVacant(holder: DaemonId, max: number, now: Date, leaseMs: number): Promise<DutyGrantRecord[]>
+  /** Batched renewal — one write per heartbeat covering every held group.
+   *  Term-preserving; a reassigned group simply stops matching. Returns the
+   *  renewed groupIds for digest comparison. */
+  renewHeld(holder: DaemonId, now: Date, leaseMs: number): Promise<string[]>
+  /** Explicit vacate (drain): holder-conditional, immediate, term kept. */
+  release(holder: DaemonId, groupIds: string[]): Promise<void>
+  /** First-trigger claim for a botless agent: creates the singleton home if none
+   *  exists ("claiming creates the lease"), grants if vacant, otherwise names
+   *  the incumbent. Idempotent for the current holder (no term churn). */
+  claimAgentHome(orgId: OrgId, agentId: AgentId, holder: DaemonId, now: Date, leaseMs: number): Promise<AgentHomeClaim>
 }

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -1,0 +1,231 @@
+// PgDutyGroupRepo — the CP-hosted duty ledger for k8s daemons.
+// One `duty_group` row per connected component; `(holder, term, expiresAt)` is
+// the lease. Every grant path bumps `term` (the fencing token); renewal never
+// does. Vacancy is temporal: `holder IS NULL` or a lapsed `expiresAt`.
+import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
+import type { DutyMemberKey, DutyReconcilePlan } from '../../domain/duty.js'
+import type { AgentHomeClaim, DutyGrantRecord, DutyGroupRecord, DutyGroupRepo, DutyReconcilePlanner } from '../ports.js'
+import type { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
+import { withTx } from '../prisma.js'
+
+// One recompute at a time per org: plan-then-apply reads its own snapshot, so
+// two concurrent recomputes of the same org must serialize, CP-instance-wide.
+async function lockOrgDutyScope(tx: Prisma.TransactionClient, orgId: string): Promise<void> {
+  const key = JSON.stringify(['duty-group-recompute', orgId])
+  await tx.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0)) IS NULL AS "locked"`)
+}
+
+// Serializes racing first-trigger claims for one agent; the write itself stays
+// vacancy-conditional because claimVacant grants under row locks, not this one.
+async function lockAgentHomeScope(tx: Prisma.TransactionClient, agentId: string): Promise<void> {
+  const key = JSON.stringify(['duty-agent-home', agentId])
+  await tx.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0)) IS NULL AS "locked"`)
+}
+
+type Row = { id: string; orgId: string; holder: string | null; term: bigint; expiresAt: Date | null }
+
+async function loadMembers(
+  db: Prisma.TransactionClient | PrismaClient,
+  groupIds: string[]
+): Promise<Map<string, DutyMemberKey[]>> {
+  if (groupIds.length === 0) return new Map()
+  const rows = await db.dutyGroupMember.findMany({
+    where: { groupId: { in: groupIds } },
+    orderBy: [{ kind: 'asc' }, { refId: 'asc' }]
+  })
+  const byGroup = new Map<string, DutyMemberKey[]>()
+  for (const m of rows) {
+    const list = byGroup.get(m.groupId) ?? []
+    list.push({ kind: m.kind, refId: m.refId })
+    byGroup.set(m.groupId, list)
+  }
+  return byGroup
+}
+
+function toRecord(row: Row, members: DutyMemberKey[]): DutyGroupRecord {
+  return {
+    groupId: row.id,
+    orgId: row.orgId as OrgId,
+    holder: (row.holder as DaemonId | null) ?? null,
+    term: row.term,
+    expiresAt: row.expiresAt,
+    members
+  }
+}
+
+export class PgDutyGroupRepo implements DutyGroupRepo {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly mintId: () => string = () => crypto.randomUUID()
+  ) {}
+
+  async listForOrg(orgId: OrgId): Promise<DutyGroupRecord[]> {
+    const rows = await this.prisma.dutyGroup.findMany({ where: { orgId }, orderBy: { id: 'asc' } })
+    const members = await loadMembers(
+      this.prisma,
+      rows.map((r) => r.id)
+    )
+    return rows.map((r) => toRecord(r, members.get(r.id) ?? []))
+  }
+
+  async listHeldBy(holder: DaemonId): Promise<DutyGroupRecord[]> {
+    const rows = await this.prisma.dutyGroup.findMany({ where: { holder }, orderBy: { id: 'asc' } })
+    const members = await loadMembers(
+      this.prisma,
+      rows.map((r) => r.id)
+    )
+    return rows.map((r) => toRecord(r, members.get(r.id) ?? []))
+  }
+
+  async applyReconcile(
+    orgId: OrgId,
+    planner: DutyReconcilePlanner,
+    opts: { now: Date; leaseMs: number }
+  ): Promise<DutyReconcilePlan> {
+    return withTx(this.prisma, async (tx) => {
+      await lockOrgDutyScope(tx, orgId)
+      const rows = await tx.dutyGroup.findMany({ where: { orgId }, orderBy: { id: 'asc' } })
+      const members = await loadMembers(
+        tx,
+        rows.map((r) => r.id)
+      )
+      const plan = planner(rows.map((r) => toRecord(r, members.get(r.id) ?? [])))
+      const expiresAt = new Date(opts.now.getTime() + opts.leaseMs)
+
+      // Phase order matters: frees before inserts, so a member moving between
+      // groups never trips the one-home-per-member primary key mid-plan.
+      if (plan.deletes.length > 0) await tx.dutyGroup.deleteMany({ where: { orgId, id: { in: plan.deletes } } })
+      const rewritten = plan.writes.map((w) => w.groupId)
+      if (rewritten.length > 0) await tx.dutyGroupMember.deleteMany({ where: { groupId: { in: rewritten } } })
+      const moved = [...plan.writes, ...plan.creates].flatMap((w) => w.members)
+      if (moved.length > 0)
+        await tx.dutyGroupMember.deleteMany({
+          where: { OR: moved.map((m) => ({ kind: m.kind, refId: m.refId })) }
+        })
+
+      for (const w of plan.writes) {
+        await tx.dutyGroupMember.createMany({
+          data: w.members.map((m) => ({ kind: m.kind, refId: m.refId, groupId: w.groupId, orgId }))
+        })
+        if (w.regrantTo !== null)
+          await tx.dutyGroup.update({
+            where: { id: w.groupId },
+            data: { holder: w.regrantTo, term: { increment: 1 }, expiresAt }
+          })
+      }
+      for (const c of plan.creates) {
+        const id = this.mintId()
+        await tx.dutyGroup.create({
+          data: {
+            id,
+            orgId,
+            holder: c.grantTo,
+            term: c.grantTo !== null ? 1n : 0n,
+            expiresAt: c.grantTo !== null ? expiresAt : null
+          }
+        })
+        await tx.dutyGroupMember.createMany({
+          data: c.members.map((m) => ({ kind: m.kind, refId: m.refId, groupId: id, orgId }))
+        })
+      }
+      return plan
+    })
+  }
+
+  async claimVacant(holder: DaemonId, max: number, now: Date, leaseMs: number): Promise<DutyGrantRecord[]> {
+    if (max <= 0) return []
+    const expiresAt = new Date(now.getTime() + leaseMs)
+    // First valid claim wins; SKIP LOCKED keeps racing claimants from queueing
+    // on each other's rows — they simply take disjoint vacancies.
+    const granted = await this.prisma.$queryRaw<Row[]>(Prisma.sql`
+      WITH picked AS (
+        SELECT id FROM "duty_group"
+        WHERE "holder" IS NULL OR "expiresAt" IS NULL OR "expiresAt" < ${now}
+        ORDER BY "orgId", id
+        LIMIT ${max}
+        FOR UPDATE SKIP LOCKED
+      )
+      UPDATE "duty_group" g
+      SET "holder" = ${holder}::uuid, "term" = g."term" + 1, "expiresAt" = ${expiresAt}, "updatedAt" = ${now}
+      FROM picked WHERE g.id = picked.id
+      RETURNING g.id, g."orgId", g."holder", g."term", g."expiresAt"
+    `)
+    const members = await loadMembers(
+      this.prisma,
+      granted.map((r) => r.id)
+    )
+    return granted.map((r) => ({
+      groupId: r.id,
+      orgId: r.orgId as OrgId,
+      term: r.term,
+      members: members.get(r.id) ?? []
+    }))
+  }
+
+  async renewHeld(holder: DaemonId, now: Date, leaseMs: number): Promise<string[]> {
+    const expiresAt = new Date(now.getTime() + leaseMs)
+    // Holder-conditional and term-preserving: a lapsed-but-unclaimed lease
+    // renews (the CP "confirms the same terms"); a reassigned one matches zero
+    // rows and the digest diff surfaces the supersession.
+    const rows = await this.prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
+      UPDATE "duty_group" SET "expiresAt" = ${expiresAt}, "updatedAt" = ${now}
+      WHERE "holder" = ${holder}::uuid
+      RETURNING id
+    `)
+    return rows.map((r) => r.id).sort()
+  }
+
+  async release(holder: DaemonId, groupIds: string[]): Promise<void> {
+    if (groupIds.length === 0) return
+    // Vacate immediately but keep `term` — monotonicity is the whole token.
+    await this.prisma.dutyGroup.updateMany({
+      where: { holder, id: { in: groupIds } },
+      data: { holder: null, expiresAt: null }
+    })
+  }
+
+  async claimAgentHome(
+    orgId: OrgId,
+    agentId: AgentId,
+    holder: DaemonId,
+    now: Date,
+    leaseMs: number
+  ): Promise<AgentHomeClaim> {
+    const expiresAt = new Date(now.getTime() + leaseMs)
+    return withTx(this.prisma, async (tx) => {
+      await lockAgentHomeScope(tx, agentId)
+      const member = await tx.dutyGroupMember.findUnique({ where: { kind_refId: { kind: 'agent', refId: agentId } } })
+      if (!member) {
+        // Claiming creates the lease: the first trigger for a botless agent.
+        const groupId = this.mintId()
+        await tx.dutyGroup.create({ data: { id: groupId, orgId, holder, term: 1n, expiresAt } })
+        await tx.dutyGroupMember.create({ data: { kind: 'agent', refId: agentId, groupId, orgId } })
+        return { granted: true, groupId, term: 1n, holder }
+      }
+      const row = await tx.dutyGroup.findUniqueOrThrow({ where: { id: member.groupId } })
+      const live = row.holder !== null && row.expiresAt !== null && row.expiresAt > now
+      if (live && row.holder === holder) {
+        // Idempotent re-claim: refresh the horizon, never churn the term.
+        await tx.dutyGroup.update({ where: { id: row.id }, data: { expiresAt } })
+        return { granted: true, groupId: row.id, term: row.term, holder }
+      }
+      if (live) return { granted: false, groupId: row.id, term: row.term, holder: row.holder as DaemonId }
+      // Vacancy-conditional even under the advisory lock: claimVacant grants
+      // under row locks, not this scope, so re-assert vacancy in the write.
+      const won = await tx.dutyGroup.updateMany({
+        where: {
+          id: row.id,
+          OR: [{ holder: null }, { expiresAt: null }, { expiresAt: { lt: now } }]
+        },
+        data: { holder, term: { increment: 1 }, expiresAt }
+      })
+      const after = await tx.dutyGroup.findUniqueOrThrow({ where: { id: row.id } })
+      return {
+        granted: won.count === 1,
+        groupId: after.id,
+        term: after.term,
+        holder: after.holder as DaemonId | null
+      }
+    })
+  }
+}

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -146,31 +146,36 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
   async claimVacant(holder: DaemonId, max: number, now: Date, leaseMs: number): Promise<DutyGrantRecord[]> {
     if (max <= 0) return []
     const expiresAt = new Date(now.getTime() + leaseMs)
-    // First valid claim wins; SKIP LOCKED keeps racing claimants from queueing
-    // on each other's rows — they simply take disjoint vacancies.
-    const granted = await this.prisma.$queryRaw<Row[]>(Prisma.sql`
-      WITH picked AS (
-        SELECT id FROM "duty_group"
-        WHERE "holder" IS NULL OR "expiresAt" IS NULL OR "expiresAt" < ${now}
-        ORDER BY "orgId", id
-        LIMIT ${max}
-        FOR UPDATE SKIP LOCKED
+    // One transaction, so the grant's row locks hold until the returned
+    // (term, members) snapshot is assembled — a reconcile cannot interleave and
+    // pair the old term with rewritten membership. First valid claim wins;
+    // SKIP LOCKED keeps racing claimants from queueing on each other's rows —
+    // they simply take disjoint vacancies.
+    return withTx(this.prisma, async (tx) => {
+      const granted = await tx.$queryRaw<Row[]>(Prisma.sql`
+        WITH picked AS (
+          SELECT id FROM "duty_group"
+          WHERE "holder" IS NULL OR "expiresAt" IS NULL OR "expiresAt" < ${now}
+          ORDER BY "orgId", id
+          LIMIT ${max}
+          FOR UPDATE SKIP LOCKED
+        )
+        UPDATE "duty_group" g
+        SET "holder" = ${holder}::uuid, "term" = g."term" + 1, "expiresAt" = ${expiresAt}, "updatedAt" = ${now}
+        FROM picked WHERE g.id = picked.id
+        RETURNING g.id, g."orgId", g."holder", g."term", g."expiresAt"
+      `)
+      const members = await loadMembers(
+        tx,
+        granted.map((r) => r.id)
       )
-      UPDATE "duty_group" g
-      SET "holder" = ${holder}::uuid, "term" = g."term" + 1, "expiresAt" = ${expiresAt}, "updatedAt" = ${now}
-      FROM picked WHERE g.id = picked.id
-      RETURNING g.id, g."orgId", g."holder", g."term", g."expiresAt"
-    `)
-    const members = await loadMembers(
-      this.prisma,
-      granted.map((r) => r.id)
-    )
-    return granted.map((r) => ({
-      groupId: r.id,
-      orgId: r.orgId as OrgId,
-      term: r.term,
-      members: members.get(r.id) ?? []
-    }))
+      return granted.map((r) => ({
+        groupId: r.id,
+        orgId: r.orgId as OrgId,
+        term: r.term,
+        members: members.get(r.id) ?? []
+      }))
+    })
   }
 
   async renewHeld(holder: DaemonId, now: Date, leaseMs: number): Promise<string[]> {

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -8,21 +8,32 @@ import type { AgentHomeClaim, DutyGrantRecord, DutyGroupRecord, DutyGroupRepo, D
 import type { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import { withTx } from '../prisma.js'
 
-// One recompute at a time per org: plan-then-apply reads its own snapshot, so
-// two concurrent recomputes of the same org must serialize, CP-instance-wide.
+// Serializes the writers that CREATE or REWRITE rows for an org (applyReconcile
+// and claimAgentHome) — row locks cannot fence rows that do not exist yet.
 async function lockOrgDutyScope(tx: Prisma.TransactionClient, orgId: string): Promise<void> {
   const key = JSON.stringify(['duty-group-recompute', orgId])
   await tx.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0)) IS NULL AS "locked"`)
 }
 
-// Serializes racing first-trigger claims for one agent; the write itself stays
-// vacancy-conditional because claimVacant grants under row locks, not this one.
-async function lockAgentHomeScope(tx: Prisma.TransactionClient, agentId: string): Promise<void> {
-  const key = JSON.stringify(['duty-agent-home', agentId])
-  await tx.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0)) IS NULL AS "locked"`)
+type Row = { id: string; orgId: string; holder: string | null; term: bigint; expiresAt: Date | null }
+
+// Row-locked snapshot: FOR UPDATE fences the lease writers the advisory scope
+// does not cover (claimVacant/renewHeld/release), so a plan can never be applied
+// over rows a concurrent grant has moved; SKIP LOCKED claimants simply pass by.
+async function lockOrgDutyRows(tx: Prisma.TransactionClient, orgId: string): Promise<Row[]> {
+  return tx.$queryRaw<Row[]>(Prisma.sql`
+    SELECT id, "orgId", "holder", "term", "expiresAt" FROM "duty_group"
+    WHERE "orgId" = ${orgId} ORDER BY id FOR UPDATE
+  `)
 }
 
-type Row = { id: string; orgId: string; holder: string | null; term: bigint; expiresAt: Date | null }
+async function lockDutyRow(tx: Prisma.TransactionClient, groupId: string): Promise<Row | null> {
+  const rows = await tx.$queryRaw<Row[]>(Prisma.sql`
+    SELECT id, "orgId", "holder", "term", "expiresAt" FROM "duty_group"
+    WHERE id = ${groupId}::uuid FOR UPDATE
+  `)
+  return rows[0] ?? null
+}
 
 async function loadMembers(
   db: Prisma.TransactionClient | PrismaClient,
@@ -84,7 +95,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
   ): Promise<DutyReconcilePlan> {
     return withTx(this.prisma, async (tx) => {
       await lockOrgDutyScope(tx, orgId)
-      const rows = await tx.dutyGroup.findMany({ where: { orgId }, orderBy: { id: 'asc' } })
+      const rows = await lockOrgDutyRows(tx, orgId)
       const members = await loadMembers(
         tx,
         rows.map((r) => r.id)
@@ -193,7 +204,9 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
   ): Promise<AgentHomeClaim> {
     const expiresAt = new Date(now.getTime() + leaseMs)
     return withTx(this.prisma, async (tx) => {
-      await lockAgentHomeScope(tx, agentId)
+      // Org scope fences row creation against applyReconcile; the FOR UPDATE row
+      // lock below fences the lease against claimVacant/renewHeld/release.
+      await lockOrgDutyScope(tx, orgId)
       const member = await tx.dutyGroupMember.findUnique({ where: { kind_refId: { kind: 'agent', refId: agentId } } })
       if (!member) {
         // Claiming creates the lease: the first trigger for a botless agent.
@@ -202,26 +215,39 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
         await tx.dutyGroupMember.create({ data: { kind: 'agent', refId: agentId, groupId, orgId } })
         return { granted: true, groupId, term: 1n, holder }
       }
-      const row = await tx.dutyGroup.findUniqueOrThrow({ where: { id: member.groupId } })
+      const row = await lockDutyRow(tx, member.groupId)
+      if (row === null) throw new Error(`duty group ${member.groupId} vanished under its member row`)
       const live = row.holder !== null && row.expiresAt !== null && row.expiresAt > now
       if (live && row.holder === holder) {
-        // Idempotent re-claim: refresh the horizon, never churn the term.
-        await tx.dutyGroup.update({ where: { id: row.id }, data: { expiresAt } })
-        return { granted: true, groupId: row.id, term: row.term, holder }
+        // Idempotent re-claim: refresh the horizon, never churn the term. CAS on
+        // (holder, term) besides the row lock, so a moved lease can never be
+        // extended by a stale reader; a miss falls through to report the row as
+        // it now stands.
+        const refreshed = await tx.dutyGroup.updateMany({
+          where: { id: row.id, holder, term: row.term },
+          data: { expiresAt }
+        })
+        if (refreshed.count === 1) return { granted: true, groupId: row.id, term: row.term, holder }
+      } else if (live) {
+        return { granted: false, groupId: row.id, term: row.term, holder: row.holder as DaemonId }
+      } else {
+        // Vacancy re-asserted in the write despite the row lock — belt and braces.
+        const won = await tx.dutyGroup.updateMany({
+          where: {
+            id: row.id,
+            OR: [{ holder: null }, { expiresAt: null }, { expiresAt: { lt: now } }]
+          },
+          data: { holder, term: { increment: 1 }, expiresAt }
+        })
+        if (won.count === 1) {
+          const granted = await tx.dutyGroup.findUniqueOrThrow({ where: { id: row.id } })
+          return { granted: true, groupId: granted.id, term: granted.term, holder }
+        }
       }
-      if (live) return { granted: false, groupId: row.id, term: row.term, holder: row.holder as DaemonId }
-      // Vacancy-conditional even under the advisory lock: claimVacant grants
-      // under row locks, not this scope, so re-assert vacancy in the write.
-      const won = await tx.dutyGroup.updateMany({
-        where: {
-          id: row.id,
-          OR: [{ holder: null }, { expiresAt: null }, { expiresAt: { lt: now } }]
-        },
-        data: { holder, term: { increment: 1 }, expiresAt }
-      })
       const after = await tx.dutyGroup.findUniqueOrThrow({ where: { id: row.id } })
+      const stillMine = after.holder === holder && after.expiresAt !== null && after.expiresAt > now
       return {
-        granted: won.count === 1,
+        granted: stillMine,
         groupId: after.id,
         term: after.term,
         holder: after.holder as DaemonId | null

--- a/packages/control-plane/test/repo/duty-group.repo.test.ts
+++ b/packages/control-plane/test/repo/duty-group.repo.test.ts
@@ -1,0 +1,250 @@
+// DutyGroupRepo — the k8s duty ledger (real Postgres).
+// Claims are CAS grants (first valid claim wins), renewal is holder-conditional
+// and term-preserving, and applyReconcile applies the pure planner's output
+// under a per-org advisory scope.
+import { describe, it, expect } from 'vitest'
+import { prisma } from '../setup.db.js'
+import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
+import { planDutyReconcile, computeDutyComponents } from '../../src/orchestrator/dutyGroup.js'
+import type { DutyGroupRecord } from '../../src/persistence/ports.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
+
+const ORG = OrgId(DEFAULT_ORG_ID)
+const M1 = DaemonId('d1111111-1111-4111-8111-111111111111')
+const M2 = DaemonId('d2222222-2222-4222-8222-222222222222')
+const A1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const A2 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
+const B1 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'
+const B2 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2'
+
+const T0 = new Date('2026-01-01T00:00:00Z')
+const LEASE_MS = 120_000
+const after = (ms: number) => new Date(T0.getTime() + ms)
+
+/** Deterministic id mint: g-1, g-2, … as UUID-shaped strings. */
+function minter() {
+  let n = 0
+  return () => `00000000-0000-4000-8000-${String(++n).padStart(12, '0')}`
+}
+
+const heldJudge = (now: Date) => (records: DutyGroupRecord[]) =>
+  records.map((r) => ({
+    groupId: r.groupId,
+    held: r.holder !== null && r.expiresAt !== null && r.expiresAt > now,
+    holder: r.holder,
+    members: r.members
+  }))
+
+function reconcile(repo: PgDutyGroupRepo, edges: { agentId: string; botId: string }[], seeds: string[], now: Date) {
+  const components = computeDutyComponents(
+    edges,
+    seeds.map((agentId) => ({ agentId }))
+  )
+  return repo.applyReconcile(ORG, (existing) => planDutyReconcile(heldJudge(now)(existing), components), {
+    now,
+    leaseMs: LEASE_MS
+  })
+}
+
+describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
+  it('reconcile creates vacant groups; claimVacant grants them with a term bump', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
+
+    const rows = await repo.listForOrg(ORG)
+    expect(rows).toHaveLength(2)
+    expect(rows.every((r) => r.holder === null && r.term === 0n && r.expiresAt === null)).toBe(true)
+
+    const grants = await repo.claimVacant(M1, 10, T0, LEASE_MS)
+    expect(grants).toHaveLength(2)
+    expect(grants.every((g) => g.term === 1n)).toBe(true)
+    expect(grants.map((g) => g.members)).toContainEqual([
+      { kind: 'agent', refId: A1 },
+      { kind: 'bot', refId: B1 }
+    ])
+  })
+
+  it('claimVacant respects max', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
+
+    expect(await repo.claimVacant(M1, 1, T0, LEASE_MS)).toHaveLength(1)
+    expect(await repo.claimVacant(M2, 10, T0, LEASE_MS)).toHaveLength(1)
+  })
+
+  it('racing claimants never receive the same group', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
+
+    const [g1, g2] = await Promise.all([repo.claimVacant(M1, 2, T0, LEASE_MS), repo.claimVacant(M2, 2, T0, LEASE_MS)])
+    const ids = [...g1, ...g2].map((g) => g.groupId)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids).toHaveLength(2)
+  })
+
+  it('an expired lease is grantable again at a higher term', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [], [A1], T0)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+
+    const late = after(LEASE_MS + 1)
+    const regrants = await repo.claimVacant(M2, 1, late, LEASE_MS)
+    expect(regrants).toHaveLength(1)
+    expect(regrants[0]!.term).toBe(2n)
+    const [row] = await repo.listHeldBy(M2)
+    expect(row!.holder).toBe(M2)
+  })
+
+  it('renewHeld refreshes the horizon term-free; a reassigned group stops matching', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [], [A1], T0)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+
+    const renewed = await repo.renewHeld(M1, after(10_000), LEASE_MS)
+    expect(renewed).toHaveLength(1)
+    const [row] = await repo.listHeldBy(M1)
+    expect(row!.term).toBe(1n)
+    expect(row!.expiresAt).toEqual(after(10_000 + LEASE_MS))
+
+    // Lapse, reassign to M2, then the old holder's renewal matches nothing.
+    const late = after(LEASE_MS * 2)
+    await repo.claimVacant(M2, 1, late, LEASE_MS)
+    expect(await repo.renewHeld(M1, after(LEASE_MS * 2 + 1000), LEASE_MS)).toEqual([])
+  })
+
+  it('a lapsed-but-unclaimed lease still renews at the same term (CP outage recovery)', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [], [A1], T0)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+
+    const renewed = await repo.renewHeld(M1, after(LEASE_MS * 3), LEASE_MS)
+    expect(renewed).toHaveLength(1)
+    const [row] = await repo.listHeldBy(M1)
+    expect(row!.term).toBe(1n)
+  })
+
+  it('release vacates immediately, keeps the term, and is holder-conditional', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [], [A1], T0)
+    const [grant] = await repo.claimVacant(M1, 1, T0, LEASE_MS)
+
+    await repo.release(M2, [grant!.groupId]) // not the holder — no-op
+    expect(await repo.listHeldBy(M1)).toHaveLength(1)
+
+    await repo.release(M1, [grant!.groupId])
+    expect(await repo.listHeldBy(M1)).toHaveLength(0)
+    const regrant = await repo.claimVacant(M2, 1, after(1), LEASE_MS)
+    expect(regrant[0]!.term).toBe(2n)
+  })
+
+  it('reconcile re-grants the incumbent at a bumped term when a held group gains a bot', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+
+    const plan = await reconcile(
+      repo,
+      [
+        { agentId: A1, botId: B1 },
+        { agentId: A1, botId: B2 }
+      ],
+      [],
+      after(1000)
+    )
+    expect(plan.superseded).toEqual([])
+    const [row] = await repo.listHeldBy(M1)
+    expect(row!.term).toBe(2n)
+    expect(row!.members).toHaveLength(3)
+  })
+
+  it('reconcile merge keeps the larger held group and reports the loser superseded', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
+    const grants1 = await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    const grants2 = await repo.claimVacant(M2, 1, T0, LEASE_MS)
+    const bigHolder = grants1[0]!.members.length > grants2[0]!.members.length ? M1 : M2
+
+    // A2 gains an integration on B1: the {A1,B1} pair and the {A2} singleton merge.
+    const plan = await reconcile(
+      repo,
+      [
+        { agentId: A1, botId: B1 },
+        { agentId: A2, botId: B1 }
+      ],
+      [],
+      after(1000)
+    )
+    expect(plan.superseded).toHaveLength(1)
+    const survivors = await repo.listForOrg(ORG)
+    expect(survivors).toHaveLength(1)
+    expect(survivors[0]!.holder).toBe(bigHolder)
+    expect(survivors[0]!.members).toHaveLength(3)
+  })
+
+  it('reconcile deletes groups whose edges vanished', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+
+    const plan = await reconcile(repo, [], [], after(1000))
+    expect(plan.deletes).toHaveLength(1)
+    expect(plan.superseded).toEqual([{ groupId: plan.deletes[0]!, holder: M1 }])
+    expect(await repo.listForOrg(ORG)).toEqual([])
+  })
+
+  it('reconcile leaves an unchanged held group untouched (no term churn)', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+
+    const plan = await reconcile(repo, [{ agentId: A1, botId: B1 }], [], after(1000))
+    expect(plan.unchanged).toHaveLength(1)
+    const [row] = await repo.listHeldBy(M1)
+    expect(row!.term).toBe(1n)
+  })
+})
+
+describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
+  it('claiming creates the lease for an unmapped agent', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    const claim = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    expect(claim).toMatchObject({ granted: true, term: 1n, holder: M1 })
+    const rows = await repo.listForOrg(ORG)
+    expect(rows[0]!.members).toEqual([{ kind: 'agent', refId: A1 }])
+  })
+
+  it('is idempotent for the current holder — horizon refreshed, term kept', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    const again = await repo.claimAgentHome(ORG, AgentId(A1), M1, after(10_000), LEASE_MS)
+    expect(again).toMatchObject({ granted: true, term: 1n, holder: M1 })
+    const [row] = await repo.listHeldBy(M1)
+    expect(row!.expiresAt).toEqual(after(10_000 + LEASE_MS))
+  })
+
+  it('names the incumbent instead of granting while the home is live', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    const won = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    const lost = await repo.claimAgentHome(ORG, AgentId(A1), M2, after(1000), LEASE_MS)
+    expect(lost).toEqual({ granted: false, groupId: won.groupId, term: 1n, holder: M1 })
+  })
+
+  it('grants an expired home to the new claimant at a bumped term', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    const claim = await repo.claimAgentHome(ORG, AgentId(A1), M2, after(LEASE_MS + 1), LEASE_MS)
+    expect(claim).toMatchObject({ granted: true, term: 2n, holder: M2 })
+  })
+
+  it('racing first claims resolve to exactly one home and one winner', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    const [c1, c2] = await Promise.all([
+      repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS),
+      repo.claimAgentHome(ORG, AgentId(A1), M2, T0, LEASE_MS)
+    ])
+    expect([c1.granted, c2.granted].filter(Boolean)).toHaveLength(1)
+    expect(c1.groupId).toBe(c2.groupId)
+    expect(await prisma.dutyGroup.count()).toBe(1)
+  })
+})

--- a/packages/control-plane/test/repo/duty-group.repo.test.ts
+++ b/packages/control-plane/test/repo/duty-group.repo.test.ts
@@ -193,6 +193,21 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
     expect(await repo.listForOrg(ORG)).toEqual([])
   })
 
+  it('a grant racing a reconcile is never silently destroyed', async () => {
+    // The reconcile deletes the group (its edges vanished). Whichever side
+    // commits first, the outcome must be coherent: a claimant that won the
+    // grant must be named superseded by the plan; a claimant that skipped the
+    // reconcile-locked row must get nothing and the plan supersedes nobody.
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
+
+    const [grants, plan] = await Promise.all([repo.claimVacant(M1, 1, T0, LEASE_MS), reconcile(repo, [], [], after(1))])
+    expect(plan.deletes).toHaveLength(1)
+    if (grants.length === 1) expect(plan.superseded).toEqual([{ groupId: grants[0]!.groupId, holder: M1 }])
+    else expect(plan.superseded).toEqual([])
+    expect(await repo.listForOrg(ORG)).toEqual([])
+  })
+
   it('reconcile leaves an unchanged held group untouched (no term churn)', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)


### PR DESCRIPTION
## What

The CP-hosted duty ledger for k8s daemons — the first slice of the dynamic-ownership workstream. **Ledger primitives only: nothing is wired into the runtime yet.** The heartbeat lease exchange, the daemon-side duty registry, and the rendezvous build on this in follow-up PRs.

- **`duty_group` table** — one claimable row per connected component of the agent↔daemon-held-bot graph, where active `Integration` rows on socket-transport bots are edges and an enabled `CronDef` is an edge too (a cron-bearing agent's group is claimable even while the agent sleeps). `(holder, term, expiresAt)` is the lease; the monotonic `term` bumps on every grant and never on renewal — it is the fencing token duty-scoped actions will carry.
- **`duty_group_member` projection** — derived `(agentId|botId → group)` mapping; the composite primary key makes one-home-per-agent/bot a database invariant rather than a code promise.
- **Pure planner** (`orchestrator/dutyGroup.ts`) — union-find component computation plus a deterministic identity-assignment rule: existing groups are consumed in (held, size desc, id asc) order and take the component holding most of their former members. "The larger held group keeps a merge, ties break to the lower groupId" falls out as a corollary; splits follow the same rule and never evict (fragments inherit their sole held contributor's holder); the plan names every superseded holder.
- **`PgDutyGroupRepo`** —
  - `claimVacant`: "grant me up to K" as one CAS statement (`FOR UPDATE SKIP LOCKED`), so racing claimants take disjoint vacancies;
  - `renewHeld`: one batched, holder-conditional, term-preserving write per heartbeat — a lapsed-but-unclaimed lease still renews (control-plane-outage recovery), a reassigned one silently stops matching;
  - `applyReconcile`: snapshot → planner → apply in one transaction under a per-org advisory scope; composition changes on held groups re-grant the same holder at a bumped term;
  - `claimAgentHome`: botless first triggers — claiming creates the lease, incumbent re-claims are idempotent (no term churn), losers are told the live holder;
  - `release`: explicit vacate for drains, holder-conditional, term kept.
- Vacancy is temporal, deliberately: `holder` has no FK, because a row-level SetNull would vacate without a term bump while fencing always reads (holder, term) together.

## Tests

- 19 unit tests on the pure math: component clustering (shared bots, transitive merges, cron seeds), merge determinism (size, tie-break, same-holder merges, held-beats-larger-vacant), splits, supersession classification, input-order invariance.
- 16 integration tests on real Postgres: CAS grant races stay disjoint, expired leases re-grant at a higher term, renewal semantics through a simulated control-plane outage, holder-conditional release, reconcile end-to-end (regrant / merge / delete / no-churn), and racing agent-home first claims resolving to exactly one winner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)