### PR TITLE
fix(daemon): buffer shim frames on sockets accepted before the channel FSM attaches

### DIFF
--- a/packages/daemon/src/shim/dialer.ts
+++ b/packages/daemon/src/shim/dialer.ts
@@ -18,6 +18,8 @@ export interface ShimDialerDeps {
   now?: () => number
   clock?: Clock
   dial?: (url: string, opts: { subprotocol: string; path: string }) => Promise<ShimTransport>
+  /** Per-dial reconnect backoff factory. Injected so tests reconnect in milliseconds. */
+  backoff?: () => Backoff
   credentialTtlMs?: number
   metrics?: ClusterMetrics
   log: { info: (message: string) => void; warn: (message: string) => void }
@@ -132,7 +134,7 @@ export class ShimDialer {
 
   private async supervise(dial: SupervisedDial, timeoutMs: number): Promise<void> {
     const deadline = this.clock.now() + timeoutMs
-    const backoff = new Backoff()
+    const backoff = this.deps.backoff?.() ?? new Backoff()
     let first = true
     while (!dial.stopped) {
       try {

--- a/packages/daemon/src/shim/server.ts
+++ b/packages/daemon/src/shim/server.ts
@@ -9,6 +9,35 @@ export interface ShimServerDeps {
   log?: { info: (message: string) => void; warn: (message: string) => void }
 }
 
+// A daemon socket accepted while the channel FSM is mid-backoff sits unclaimed; without
+// buffering, its hello frame fires with no listener and binding stalls until the daemon's
+// timeout. Capture inbound frames and a close until the first listener attaches, then replay.
+function bufferInbound(raw: ShimTransport): Pick<ShimTransport, 'onMessage' | 'onClose'> {
+  const frames: string[] = []
+  const messageListeners: Array<(text: string) => void> = []
+  const closeListeners: Array<(code: number, reason: string) => void> = []
+  let closed: { code: number; reason: string } | undefined
+  raw.onMessage((text) => {
+    if (messageListeners.length === 0) frames.push(text)
+    else for (const listener of messageListeners) listener(text)
+  })
+  raw.onClose((code, reason) => {
+    closed = { code, reason }
+    for (const listener of closeListeners) listener(code, reason)
+  })
+  return {
+    onMessage: (listener) => {
+      messageListeners.push(listener)
+      // Replay only on a live socket: a buffered hello answered after close would send into a dead peer.
+      if (messageListeners.length === 1 && !closed) for (const text of frames.splice(0)) listener(text)
+    },
+    onClose: (listener) => {
+      closeListeners.push(listener)
+      if (closed) listener(closed.code, closed.reason)
+    }
+  }
+}
+
 /** The sandbox-side WebSocket endpoint; one daemon channel may be active at a time. */
 export class ShimServer {
   private server?: Server
@@ -45,10 +74,11 @@ export class ShimServer {
       }
       wss.handleUpgrade(req, socket, head, (ws) => {
         const raw = new WsServerTransport(ws, req.socket.remoteAddress ?? 'unknown')
+        const inbound = bufferInbound(raw)
         const transport: ShimTransport = {
           send: (text) => raw.send(text),
-          onMessage: (listener) => raw.onMessage(listener),
-          onClose: (listener) => raw.onClose(listener),
+          onMessage: inbound.onMessage,
+          onClose: inbound.onClose,
           close: (code, reason) => {
             if (this.active === transport) this.active = undefined
             if (this.queued === transport) this.queued = undefined

--- a/packages/daemon/test/shim-dial-in.test.ts
+++ b/packages/daemon/test/shim-dial-in.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Backoff, ClientTransport } from '@agentconnect.md/connection'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import { ShimDialer } from '../src/shim/dialer.js'
 import { ShimServer } from '../src/shim/server.js'
 import { ShimSession } from '../src/shim/session.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
-import { SHIM_TOKEN_AUDIENCE } from '../src/shim/protocol.js'
+import { SHIM_SUBPROTOCOL, SHIM_TOKEN_AUDIENCE, SHIM_WS_PATH } from '../src/shim/protocol.js'
+
+// Zero-jitter millisecond backoff so reconnect tests never sleep real seconds.
+const fastBackoff = (): Backoff => new Backoff({ baseMs: 5, jitter: () => 0 })
 
 const clients: ShimClient[] = []
 const dialers: ShimDialer[] = []
@@ -16,7 +20,9 @@ afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.stop()))
 })
 
-async function sandbox(options: { handle?: (capability: string, payload: unknown) => Promise<unknown> } = {}) {
+async function sandbox(
+  options: { handle?: (capability: string, payload: unknown) => Promise<unknown>; backoff?: Backoff } = {}
+) {
   const server = new ShimServer()
   servers.push(server)
   const port = await server.start(0, '127.0.0.1')
@@ -27,6 +33,7 @@ async function sandbox(options: { handle?: (capability: string, payload: unknown
     readToken: () => 'projected-token',
     workspaceRoot: '/agent',
     ...(options.handle ? { handle: options.handle as never } : {}),
+    ...(options.backoff ? { backoff: options.backoff } : {}),
     log: { info: () => {}, warn: () => {} }
   })
   clients.push(client)
@@ -108,23 +115,47 @@ describe('sandbox shim dial-in', () => {
   })
 
   it('waits for the replacement connection while a bound channel is reconnecting', async () => {
-    const { endpoint, client } = await sandbox()
+    // Both reconnect loops run on injected zero-jitter backoffs, so the redial and the
+    // sandbox re-attach race each other every run instead of sleeping jittered seconds.
+    const { endpoint } = await sandbox({ backoff: fastBackoff() })
     const dialer = new ShimDialer({
       verifier: {
         reviewToken: async () => ({ authenticated: true, podName: 'sandbox-pod-1', podUid: 'pod-uid-1' })
       },
+      backoff: fastBackoff,
       log: { info: () => {}, warn: () => {} }
     })
     dialers.push(dialer)
 
     const first = await dialer.connect(endpoint, record(), 8_000)
     first.close('force reconnect')
-    await waitFor(() => dialer.connectionsFor('agent-a').length === 0 && client.binding() === undefined)
+    // The rebind can outrun a poll, so wait for the first connection to be dropped rather
+    // than for an observable zero-connection window.
+    await waitFor(() => !dialer.connectionsFor('agent-a').includes(first))
 
     const replacement = await dialer.connect(endpoint, record(), 8_000)
     expect(replacement).not.toBe(first)
     expect(dialer.connectionsFor('agent-a')).toEqual([replacement])
   }, 10_000)
+
+  it('replays frames that arrived while the accepted daemon socket was still unclaimed', async () => {
+    const server = new ShimServer()
+    servers.push(server)
+    const port = await server.start(0, '127.0.0.1')
+    const daemonSide = await ClientTransport.dial(`ws://127.0.0.1:${port}`, {
+      subprotocol: SHIM_SUBPROTOCOL,
+      path: SHIM_WS_PATH
+    })
+    // The hello lands before the channel FSM attaches — the queued-across-backoff case.
+    daemonSide.send(JSON.stringify({ type: 'shim/hello', agentId: 'agent-a', generation: 1 }))
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const accepted = await server.nextTransport()
+    const seen: string[] = []
+    accepted.onMessage((text) => seen.push(text))
+    await waitFor(() => seen.length === 1)
+    expect(JSON.parse(seen[0]!)).toMatchObject({ type: 'shim/hello', agentId: 'agent-a', generation: 1 })
+    daemonSide.close(1000, 'done')
+  })
 
   it('times out an accepted socket whose identity verification never completes', async () => {
     const { endpoint } = await sandbox()


### PR DESCRIPTION
## What

Fixes the flaky daemon test `shim-dial-in.test.ts > waits for the replacement connection while a bound channel is reconnecting`, which failed the Release workflow's Unit Test gate on two consecutive `main` pushes — by fixing the real race it was exposing in the shim's dial-in path.

## Why

After a bound shim channel drops, two reconnect loops race on independent jittered 1–2s backoffs: the daemon-side `ShimDialer` redials the sandbox, and the in-sandbox `ShimClient` FSM re-attaches via `ShimServer.nextTransport()`. When the daemon won the race (~half the time), `ShimServer` accepted the socket with **no message listener attached** and parked it in `queued`; the daemon's `shim/hello` was emitted into the void and dropped. The sandbox later claimed the queued socket and waited for a hello that had already gone by, so binding stalled for the daemon's full timeout. In the test this blew the 8s/10s budget (~40% failure rate on a loaded machine, confirmed by instrumentation with 100% correlation to the queued-with-no-waiter path); in production the same drop stalls a real daemon↔sandbox rebind whenever the redial lands during the shim's backoff sleep.

## How

- **`ShimServer`**: a `bufferInbound()` wrapper now attaches to the raw socket at accept time, buffering inbound frames (and a close) until the channel FSM's first listener attaches, then replays them. Frames are not replayed after a delivered close, so a late claimer cannot answer a dead peer.
- **`ShimDialer`**: new optional `backoff?: () => Backoff` dep (per-dial factory), mirroring the injection `ShimClient` already had.
- **Test**: the reconnect test injects zero-jitter 5ms backoffs on both sides, so it exercises the redial/re-attach race deterministically on every run instead of sleeping jittered real seconds (file runtime dropped from ~8.5s to ~0.5s). Its `waitFor` now waits for the first connection to be dropped rather than for a zero-connection window the fast rebind can outrun. A new regression test pins the frame replay at the `ShimServer` seam (verified red against the unfixed server).

## Verification

- Before: 4/10 isolated runs failed. After: 20/20 passes — 10 with the full daemon suite running as load, 10 unloaded.
- Red-green: both the reconnect test and the new regression test fail against the unfixed server and pass after the fix, so the test still pins the behavior it exists for.
- `tsc`, eslint, and the other `ShimServer` consumers (`shim-tunnel`, `cluster-acp-e2e`, `k8s-runtime-plane`) all pass. Remaining local full-suite failures reproduce identically on a clean tree (pre-existing environment issues; CI failed only this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)