### PR TITLE
fix(daemon): deliver continuation-turn replies to the origin platform (dual sinks)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -14710,7 +14710,9 @@ export class Daemon {
             })
           }
         }
-        if (!p.webchat.doneSent) {
+        // Continuation defers `done` until the platform apply chain settles below —
+        // the browser must not unlock its composer while the reply is still flushing.
+        if (!p.webchat.continuation && !p.webchat.doneSent) {
           p.webchat.doneSent = true
           p.webchat.sink.done({
             conversationId: p.webchat.conversationId,
@@ -14754,6 +14756,18 @@ export class Daemon {
       // through the core surface does not inherit its platform's closure, and a platform
       // that cannot amend a sent message simply registers none.
       await this.turnSurfaces.exact(p.platform)?.closeResponse?.(p)
+      // Continuation `done` fires only now, behind the platform apply/finalization
+      // boundary, so both sinks settle as ONE ordered turn: the console cannot admit
+      // a next turn (whose mirror posts immediately) ahead of this reply's flush.
+      if (p.webchat?.continuation && !p.webchat.doneSent) {
+        p.webchat.doneSent = true
+        p.webchat.sink.done({
+          conversationId: p.webchat.conversationId,
+          turnId: p.webchat.turnId,
+          ...(stopReason ? { stopReason } : {}),
+          ...(usage?.totalTokens !== undefined ? { usage: { used: usage.totalTokens } } : {})
+        })
+      }
       // The user-visible reply is now delivered. Enqueue provider work without
       // awaiting it: managed may distill, while external only commits its durable
       // capture outbox. Webchat carries the canonical per-turn id separately from
@@ -14817,17 +14831,10 @@ export class Daemon {
       failEvaluation(err)
       finalPhase = 'problem'
       if (p.webchat?.continuation) {
-        // Continuation: release any held stream text, close the browser stream with the
-        // terminal error; the platform branch below owns the visible notice + transcript.
+        // Continuation: release any held stream text; the platform branch below owns the
+        // visible notice + transcript, and the terminal-error `done` waits behind its
+        // apply-chain drain so the console cannot admit a next turn mid-flush.
         this.flushHeldWebchatText(p.webchat)
-        if (!p.webchat.doneSent) {
-          p.webchat.doneSent = true
-          p.webchat.sink.done({
-            conversationId: p.webchat.conversationId,
-            turnId: p.webchat.turnId,
-            error: turnFailureReason(err)
-          })
-        }
       } else if (p.webchat) {
         // Reply text (including a runtime's mirrored error text) already streamed to
         // the client via onAcpUpdate; the terminal done frame carries the reason.
@@ -14904,7 +14911,20 @@ export class Daemon {
             })
         }
         this.showActivity(replyConn, msg.channel, statusThread, '') // clear "is thinking…"
-        await p.applyChain
+        try {
+          await p.applyChain
+        } finally {
+          // Continuation closes the browser stream only after the platform failure
+          // actions drain (or terminally fail) — never before, so the sinks stay ordered.
+          if (p.webchat?.continuation && !p.webchat.doneSent) {
+            p.webchat.doneSent = true
+            p.webchat.sink.done({
+              conversationId: p.webchat.conversationId,
+              turnId: p.webchat.turnId,
+              error: turnFailureReason(err)
+            })
+          }
+        }
       }
       if (hookContext && !this.draining) {
         this.emitHookCompletion(hookContext, 'failed', { sessionId, reason: turnFailureCode(err) }, entry)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1800,6 +1800,9 @@ interface WebchatTurnContext {
    *  own to stream to (#753). Carried onto the completed `RdWebchatPost` so the
    *  browser knows this reply never streamed live and needs rendering from the post. */
   initiator?: 'agent'
+  /** Session-targeted continuation (§5.2): the webchat stream is an ADDITIONAL sink —
+   *  turn output/status/failure still follow the origin platform's ordinary rules. */
+  continuation?: true
   runtime?: WebchatRuntimeConfig
   worktree?: boolean
   /** Authority captured only from the relay's validated rd/msg envelope. It is
@@ -7403,6 +7406,7 @@ export class Daemon {
       return { accepted: false, turnId, reason: 'busy' }
     }
     const stream = this.createWebchatTurnStream(agentId, chatId, turnId, sink)
+    stream.continuation = true
     let settleMirror!: (mirrored: boolean) => void
     const mirrorAdmission = new Promise<boolean>((resolve) => {
       settleMirror = resolve
@@ -12634,7 +12638,8 @@ export class Daemon {
         turnId: ctx.webchat.turnId,
         error: reason
       })
-      return
+      // A continuation turn also surfaces the failure on the origin platform (§5.2).
+      if (!ctx.webchat.continuation) return
     }
     const notice = `⚠️ Agent failed to respond: ${reason}`
     if (ctx.replyConn) {
@@ -13840,7 +13845,12 @@ export class Daemon {
     // reply sink as `rd/chat`, so `conv`'s Slack actions never apply.
     // `none` output mode joins them: no status, status-bar, or reply reaches the channel;
     // only the converger's `recordOnly` body posts land in the transcript.
-    const replyConn = msg.headless || webchat || mode === 'none' ? undefined : this.replyConnFor(agentId, integrationId)
+    // A continuation turn keeps its platform reply connection: its webchat stream is
+    // an additional sink, not a replacement (§5.2 dual sinks).
+    const replyConn =
+      msg.headless || (webchat && !webchat.continuation) || mode === 'none'
+        ? undefined
+        : this.replyConnFor(agentId, integrationId)
     // Capture cold/warm BEFORE sessions.handle(), which boots the host via hostFor().
     const wasRunning = this.hostStarts.has(agentId)
     const statusThread = msg.thread ?? msg.msgId
@@ -14665,36 +14675,40 @@ export class Daemon {
           // A real reply that never diverged from the sentinel prefix mid-stream
           // (shorter than the sentinel) is still held — release it before commit.
           this.flushHeldWebchatText(p.webchat)
-          // Shares the strictly-monotonic clock with the inbound user message so a fast
-          // turn can't stamp both with the same ms and lose the reply to the unique index.
-          // The ts the row actually lands on (post-collision-bump) doubles as the reply
-          // post's canonical `at` (minted ONCE here, the origin) carried to every other
-          // participant's copy via rd/webchat-post.
-          const replyPostId = randomUUID()
-          const replyTs = this.appendWebchatTextRow(p.transcriptChannel, statusThread, monotonicTs(), {
-            postId: replyPostId,
-            sender: agentId,
-            text: p.webchat.replyText
-          })
-          // Fan the completed reply out as a canonical conversation post so the
-          // relay delivers it to the browser's message log and to the other
-          // participants' daemons as context (webchat-multi-agents.md §5.2).
-          // `hopCount` is this turn's own chain depth (§4.1: stamped on every body
-          // the author posts), which is what lets a receiving participant charge
-          // the ONE +1 continuation transition (§5.2a) — the same stamp the
-          // platform paths put on their outbound authorship metadata.
-          p.webchat.postSink?.({
-            conversationId: p.webchat.conversationId,
-            agentId,
-            post: {
+          // A continuation turn records its reply at the platform post boundary instead
+          // (appending here would duplicate the row), and its roster is fixed at one.
+          if (!p.webchat.continuation) {
+            // Shares the strictly-monotonic clock with the inbound user message so a fast
+            // turn can't stamp both with the same ms and lose the reply to the unique index.
+            // The ts the row actually lands on (post-collision-bump) doubles as the reply
+            // post's canonical `at` (minted ONCE here, the origin) carried to every other
+            // participant's copy via rd/webchat-post.
+            const replyPostId = randomUUID()
+            const replyTs = this.appendWebchatTextRow(p.transcriptChannel, statusThread, monotonicTs(), {
               postId: replyPostId,
+              sender: agentId,
+              text: p.webchat.replyText
+            })
+            // Fan the completed reply out as a canonical conversation post so the
+            // relay delivers it to the browser's message log and to the other
+            // participants' daemons as context (webchat-multi-agents.md §5.2).
+            // `hopCount` is this turn's own chain depth (§4.1: stamped on every body
+            // the author posts), which is what lets a receiving participant charge
+            // the ONE +1 continuation transition (§5.2a) — the same stamp the
+            // platform paths put on their outbound authorship metadata.
+            p.webchat.postSink?.({
               conversationId: p.webchat.conversationId,
-              author: { kind: 'agent', agentId, hopCount: p.sourceHopCount },
-              text: p.webchat.replyText,
-              at: Number(replyTs)
-            },
-            ...(p.webchat.initiator ? { initiator: p.webchat.initiator } : {})
-          })
+              agentId,
+              post: {
+                postId: replyPostId,
+                conversationId: p.webchat.conversationId,
+                author: { kind: 'agent', agentId, hopCount: p.sourceHopCount },
+                text: p.webchat.replyText,
+                at: Number(replyTs)
+              },
+              ...(p.webchat.initiator ? { initiator: p.webchat.initiator } : {})
+            })
+          }
         }
         if (!p.webchat.doneSent) {
           p.webchat.doneSent = true
@@ -14705,7 +14719,10 @@ export class Daemon {
             ...(usage?.totalTokens !== undefined ? { usage: { used: usage.totalTokens } } : {})
           })
         }
-      } else {
+      }
+      // A continuation turn ALSO flushes the platform finals — its reply posts to the
+      // origin thread under the ordinary output rules (§5.2 dual sinks).
+      if (!p.webchat || p.webchat.continuation) {
         const link = showFooter ? this.sessionLink(sessionId) : undefined
         const finalAttributionInfo = showFooter ? currentAttributionInfo() : undefined
         // A runtime may only publish its final session-scoped model during prompt.
@@ -14799,7 +14816,19 @@ export class Daemon {
       propagatingTurnError = true
       failEvaluation(err)
       finalPhase = 'problem'
-      if (p.webchat) {
+      if (p.webchat?.continuation) {
+        // Continuation: release any held stream text, close the browser stream with the
+        // terminal error; the platform branch below owns the visible notice + transcript.
+        this.flushHeldWebchatText(p.webchat)
+        if (!p.webchat.doneSent) {
+          p.webchat.doneSent = true
+          p.webchat.sink.done({
+            conversationId: p.webchat.conversationId,
+            turnId: p.webchat.turnId,
+            error: turnFailureReason(err)
+          })
+        }
+      } else if (p.webchat) {
         // Reply text (including a runtime's mirrored error text) already streamed to
         // the client via onAcpUpdate; the terminal done frame carries the reason.
         // Record what streamed so the session reads back with it, like the success
@@ -14845,7 +14874,8 @@ export class Daemon {
             ...(p.webchat.initiator ? { initiator: p.webchat.initiator } : {})
           })
         }
-      } else {
+      }
+      if (!p.webchat || p.webchat.continuation) {
         // Some runtimes narrate their terminal error into the message stream just
         // before rejecting the prompt — codex-acp mirrors quota exhaustion / auth
         // expiry as an agent_message_chunk — and that text is still sitting in the
@@ -15879,16 +15909,21 @@ export class Daemon {
     if (p.webchat) {
       // Webchat: skip a truly-empty frame (nothing for the web bar to show); the model /
       // usage lands on a later call. `sessionId` is always present, so exclude it.
-      if (!Object.entries(info).some(([k, v]) => k !== 'sessionId' && v !== undefined)) return
-      p.lastStatusBar = key
-      const wc = p.webchat
-      wc.sink.output({
-        conversationId: wc.conversationId,
-        turnId: wc.turnId,
-        index: wc.index++,
-        status: info
-      })
-    } else if (statusSurface === 'on-demand') {
+      const hasContent = Object.entries(info).some(([k, v]) => k !== 'sessionId' && v !== undefined)
+      if (hasContent) {
+        p.lastStatusBar = key
+        const wc = p.webchat
+        wc.sink.output({
+          conversationId: wc.conversationId,
+          turnId: wc.turnId,
+          index: wc.index++,
+          status: info
+        })
+      }
+      // A continuation turn also drives the origin platform's status surface below.
+      if (!p.webchat.continuation) return
+    }
+    if (statusSurface === 'on-demand') {
       // A declared on-demand platform (Telegram/Discord/Feishu) has no per-turn
       // status bar — session state is queried via `/status` (handleCommand).
       // Record the dedup key so the shared bookkeeping stays consistent, but emit
@@ -16164,7 +16199,9 @@ export class Daemon {
           index: p.webchat.index++,
           event: { kind: 'message', text }
         })
-      } else if (p.conn) {
+      }
+      // A continuation turn notifies the origin platform thread too (§5.2).
+      if ((!p.webchat || p.webchat.continuation) && p.conn) {
         this.enqueueApply(p, { kind: 'notice', text })
       }
     } catch (err) {
@@ -17104,8 +17141,9 @@ export class Daemon {
     // webchat streams its reply through the sink (→ relay `rd/chat`), one WebchatOutput
     // per mapped chunk, instead of driving the Slack renderer — but still records the
     // full activity log below, so a webchat session reads back like any other.
+    // A continuation turn drives BOTH: the browser sink and the platform renderer (§5.2).
     if (p.webchat) this.emitWebchatUpdate(p, update)
-    else if (!isHeadlessGithubFinal && !(p.stageAnswer && isAnswerChunk)) {
+    if ((!p.webchat || p.webchat.continuation) && !isHeadlessGithubFinal && !(p.stageAnswer && isAnswerChunk)) {
       for (const action of p.conv.onUpdate(update)) this.enqueueApply(p, action)
       this.armIdle(p)
       this.armFeishuStream(p)

--- a/packages/daemon/test/daemon-webchat-session-continuation.test.ts
+++ b/packages/daemon/test/daemon-webchat-session-continuation.test.ts
@@ -165,6 +165,25 @@ describe('webchat session-targeted continuation', () => {
     await daemon.stop()
   })
 
+  it('delivers the agent reply to the origin platform AND the browser sink (§5.2 dual sinks)', async () => {
+    const { daemon, d, postMessage } = await boot(() => 'dual-sink reply!')
+    const events: RdChatEvent[] = []
+
+    const ack = await d.handleRelayMsg(turn('to both'), (e) => events.push(e))
+    expect(ack).toMatchObject({ accepted: true })
+    await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
+    // The reply streamed to the browser sink…
+    expect(events.some((e) => e.kind === 'output')).toBe(true)
+    // …AND posted to the origin Slack thread under the ordinary output rules
+    // (the attributed human mirror is the other postMessage call).
+    await vi.waitFor(() => {
+      const texts = (postMessage.mock.calls as unknown[][]).map((c) => c[1])
+      expect(texts).toContain('dual-sink reply!')
+      expect(texts).toContain('[owner via console] to both')
+    }, WAIT)
+    await daemon.stop()
+  })
+
   it('refuses the turn when the platform mirror fails — the agent never consumes hidden input', async () => {
     const { daemon, d, prompts, postMessage } = await boot()
     postMessage.mockRejectedValue(new Error('channel_not_found'))

--- a/packages/daemon/test/daemon-webchat-session-continuation.test.ts
+++ b/packages/daemon/test/daemon-webchat-session-continuation.test.ts
@@ -166,21 +166,29 @@ describe('webchat session-targeted continuation', () => {
   })
 
   it('delivers the agent reply to the origin platform AND the browser sink (§5.2 dual sinks)', async () => {
+    const order: string[] = []
     const { daemon, d, postMessage } = await boot(() => 'dual-sink reply!')
+    postMessage.mockImplementation(async (...args: unknown[]) => {
+      order.push(`slack:${args[1]}`)
+      return '100.200000'
+    })
     const events: RdChatEvent[] = []
 
-    const ack = await d.handleRelayMsg(turn('to both'), (e) => events.push(e))
+    const ack = await d.handleRelayMsg(turn('to both'), (e) => {
+      if (e.kind === 'done') order.push('done')
+      events.push(e)
+    })
     expect(ack).toMatchObject({ accepted: true })
     await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
     // The reply streamed to the browser sink…
     expect(events.some((e) => e.kind === 'output')).toBe(true)
     // …AND posted to the origin Slack thread under the ordinary output rules
     // (the attributed human mirror is the other postMessage call).
-    await vi.waitFor(() => {
-      const texts = (postMessage.mock.calls as unknown[][]).map((c) => c[1])
-      expect(texts).toContain('dual-sink reply!')
-      expect(texts).toContain('[owner via console] to both')
-    }, WAIT)
+    expect(order).toContain('slack:[owner via console] to both')
+    expect(order).toContain('slack:dual-sink reply!')
+    // The browser `done` settles only AFTER the platform flush — the console must not
+    // unlock its composer (and mirror a next turn) ahead of this reply landing on Slack.
+    expect(order.indexOf('slack:dual-sink reply!')).toBeLessThan(order.indexOf('done'))
     await daemon.stop()
   })
 


### PR DESCRIPTION
## Problem

After https://github.com/agentconnect-md/agentconnect/pull/932, sending text from the console composer into a Slack-origin session posts the attributed human mirror to the Slack thread — but the agent's reply never appears on Slack (it only reaches the browser stream and the transcript).

## Root cause

The continuation path reused the daemon's webchat turn context, and every consumer of that context is **exclusive**: `dispatchOne` nulls `replyConn` whenever `entry.webchat` is set, `onAcpUpdate` streams to the browser sink *instead of* driving the platform converger, and the completion/failure paths skip the platform finals entirely. [webchat-cross-integration-continuation.md §5.2](docs/designs/webchat-cross-integration-continuation.md) requires **dual sinks** — "The webchat stream is an _additional_ sink, not a replacement" — but only the mirror half was implemented.

## Fix

Mark the continuation context (`WebchatTurnContext.continuation`) and make it drive both sinks:

- **Reply connection**: a continuation turn keeps its platform `replyConn` (output-mode `none` still suppresses, per §5.2).
- **Streaming**: `onAcpUpdate` feeds the browser sink *and* the platform converger.
- **Completion**: platform finals flush as usual; the webchat side still closes the browser turn with its `done` frame but skips its transcript append — the platform post boundary records the reply, so no duplicate row.
- **Failure**: the origin thread gets the ordinary failure notice/flushTerminal path; the browser stream closes with a terminal error `done`. `surfaceTurnFailure` (pre-prompt failures) now falls through to the platform notice for continuation turns.
- **Status bar / permission notices**: fan to both surfaces.

## Tests

- New: `delivers the agent reply to the origin platform AND the browser sink (§5.2 dual sinks)` — asserts both the mirror and the agent reply land on the Slack `postMessage` seam.
- `daemon-webchat-session-continuation` 7/7, plus `daemon-webchat`, `daemon-webchat-continuation`, `remote-webchat-grant`, `webchat-turn-refresh`, `turn-output-seam`, `turn-output-workflow`, `slack-status-actor` — all green. Full daemon suite: remaining failures are environmental only (runtime-matrix OAuth/API-key, sandbox shim), untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)