### PR TITLE
feat(web,control-plane,daemon): the cloud pool as one entry, and the rows its replaced Pods left behind

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -115,6 +115,11 @@ import { AgentSpecAssembler } from './orchestrator/agentSpecAssembler.js'
 import { Placement } from './orchestrator/placement.js'
 import { Watchdog } from './orchestrator/watchdog.js'
 import { CronRunReaper } from './orchestrator/cronRunReaper.js'
+import {
+  CloudDaemonReaper,
+  CLOUD_DAEMON_REAP_AFTER_MS,
+  CLOUD_DAEMON_REAP_INTERVAL_MS
+} from './orchestrator/cloudDaemonReaper.js'
 import { RelaySweeper } from './orchestrator/relaySweeper.js'
 import { RelayRoster } from './orchestrator/relayRoster.js'
 import { WebchatMcpOperationReaper } from './orchestrator/webchatMcpOperationReaper.js'
@@ -170,6 +175,7 @@ import type { RelayWsServerDeps } from './ws/relay-gateway.js'
 import { buildHttpServer } from './http/server.js'
 import type { HttpDeps } from './http/deps.js'
 import { createReadiness, type Readiness } from './http/readiness.js'
+import { retireCloudDaemonMember } from './http/daemon-removal.js'
 import { McpRateLimiter } from './http/mcp/rate-limit.js'
 import { RemoteGrantAuthenticator } from './http/mcp/remote-grant-authenticator.js'
 import { InternalInvocationAuth } from './http/mcp/internal-invocation-auth.js'
@@ -1108,6 +1114,21 @@ export function buildContainer(
     defaultWebchatMcpMetrics
   )
 
+  // Retires the daemon rows replaced cloud Pods leave behind (a cloud member is bound to
+  // its Pod UID, so a new Pod means a new record). Org-less rows no `DELETE /daemons/:id`
+  // can reach, which is why they accumulate in every org's fleet. Only where cluster tokens
+  // are accepted at all: nowhere else can a cloud member exist.
+  const cloudDaemonReaper = clusterIdentity
+    ? new CloudDaemonReaper(
+        repos.daemon,
+        (daemonId) => retireCloudDaemonMember(httpDeps, daemonId, http.log),
+        connReg,
+        clock,
+        { retireAfterMs: CLOUD_DAEMON_REAP_AFTER_MS, intervalMs: CLOUD_DAEMON_REAP_INTERVAL_MS },
+        http.log
+      )
+    : undefined
+
   // Redelivery reconciliation (webhook-triggers P2.5): recovers github events
   // lost to a relay-pool outage by asking GitHub to redeliver GUIDs that never
   // produced a HookRun. Only exists when the App is configured; same lifecycle
@@ -1659,6 +1680,7 @@ export function buildContainer(
       clusterMaintenance.start()
       cronRunReaper.start()
       hookRunReaper.start()
+      cloudDaemonReaper?.start()
       webchatMcpOperationReaper.start()
       githubRunReporter?.start()
       hookRedeliveryReconciler?.start()
@@ -1675,6 +1697,7 @@ export function buildContainer(
       clusterMaintenance.stop()
       cronRunReaper.stop()
       hookRunReaper.stop()
+      cloudDaemonReaper?.stop()
       const webchatMcpOperationSettled = webchatMcpOperationReaper.stopAndSettle()
       githubRunReporter?.stop()
       hookRedeliveryReconciler?.stop()

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1121,7 +1121,7 @@ export function buildContainer(
   const cloudDaemonReaper = clusterIdentity
     ? new CloudDaemonReaper(
         repos.daemon,
-        (daemonId) => retireCloudDaemonMember(httpDeps, daemonId, http.log),
+        (member, retiredBefore) => retireCloudDaemonMember(httpDeps, member, retiredBefore, http.log),
         connReg,
         clock,
         { retireAfterMs: CLOUD_DAEMON_REAP_AFTER_MS, intervalMs: CLOUD_DAEMON_REAP_INTERVAL_MS },

--- a/packages/control-plane/src/http/daemon-removal.ts
+++ b/packages/control-plane/src/http/daemon-removal.ts
@@ -11,9 +11,15 @@
  * (which retires the cluster envelope's own daemon), and the cloud-member reaper — and a
  * partial copy in any of them is a bug that only shows up in the console days later. So it
  * lives here rather than in whichever route wrote it first.
+ *
+ * The two paths differ in ONE thing, deliberately: who decides. An operator's detach has
+ * already decided, so it unplaces first and then deletes. The reaper's decision is a
+ * guess about a row it read moments ago, so its delete comes FIRST as a fenced claim and
+ * nothing destructive runs until that claim wins.
  */
 import type { FastifyBaseLogger } from 'fastify'
 import type { DaemonId, OrgId } from '../domain/ids.js'
+import type { AgentRecord } from '../persistence/ports.js'
 import type { HttpDeps } from './deps.js'
 
 /** What the sequence touches — narrow, so a caller cannot pass half a graph. */
@@ -30,42 +36,6 @@ export async function detachDaemon(
   daemonId: DaemonId,
   log: FastifyBaseLogger
 ): Promise<void> {
-  await removeAndSettle(deps, daemonId, () => deps.registry.remove(orgId, daemonId), log)
-}
-
-/**
- * Retire one install-wide cloud member whose Pod is gone (`orchestrator/cloudDaemonReaper.ts`).
- * No org owns the row, so the org-fenced delete cannot reach it — and its placements may span
- * every organization, which is the whole reason it goes through the same settle sequence
- * instead of a bare delete. False ⇒ the row was no longer a retired member; nothing was
- * deleted, and the unplacements it did first are what an operator would have wanted anyway.
- */
-export async function retireCloudDaemonMember(
-  deps: DaemonRemovalDeps,
-  daemonId: DaemonId,
-  log: FastifyBaseLogger
-): Promise<boolean> {
-  let deleted = false
-  await removeAndSettle(
-    deps,
-    daemonId,
-    async () => {
-      deleted = await deps.registry.removeCloudMember(daemonId)
-    },
-    log
-  )
-  return deleted
-}
-
-/** The sequence itself. `remove` performs the delete; which organizations need a fresh
- *  collaboration snapshot is derived from the placements the row held, because a cloud
- *  member's agents are not one org's. */
-async function removeAndSettle(
-  deps: DaemonRemovalDeps,
-  daemonId: DaemonId,
-  remove: () => Promise<void>,
-  log: FastifyBaseLogger
-): Promise<void> {
   // Captured BEFORE the delete: the FK is SetNull, so the placement disappears
   // with the row and nothing afterwards could name these agents.
   const placedAgents = await deps.repos.agent.listForDaemon(daemonId)
@@ -74,7 +44,54 @@ async function removeAndSettle(
   // the agents' webchat MCP delegations and bumps their hook dispatchRevision,
   // exactly as an operator-initiated unplacement would.
   for (const agent of placedAgents) await deps.repos.agent.setPlacement(agent.id, null)
-  await remove()
+  await deps.registry.remove(orgId, daemonId)
+  await settleAfterRemoval(deps, daemonId, placedAgents, log)
+}
+
+/**
+ * Retire one install-wide cloud member whose Pod is gone
+ * (`orchestrator/cloudDaemonReaper.ts`). No org owns the row, so the org-fenced delete
+ * cannot reach it — and its placements may span every organization, which is the whole
+ * reason it goes through this sequence instead of a bare delete.
+ *
+ * The order is the safety property. `fence` re-checks, inside the delete statement itself,
+ * the staleness that put this member on the worklist plus the `sessionEpoch` observed there;
+ * a member that heartbeated or re-authenticated in between simply does not match, and false
+ * comes back with NOTHING written. Only a won claim reaches the settlement — the alternative,
+ * unplacing first and checking after, deactivates a live member's agents across every
+ * organization before it discovers the member is alive.
+ */
+export async function retireCloudDaemonMember(
+  deps: DaemonRemovalDeps,
+  member: { daemonId: DaemonId; sessionEpoch: bigint },
+  retiredBefore: Date,
+  log: FastifyBaseLogger
+): Promise<boolean> {
+  const { daemonId, sessionEpoch } = member
+  // Read-only, and before the claim for the same reason as above: the cascade erases the
+  // placements, so this is the last moment anything can name them.
+  const placedAgents = await deps.repos.agent.listForDaemon(daemonId)
+  if (!(await deps.registry.removeCloudMember(daemonId, { retiredBefore, sessionEpoch }))) return false
+  // The cascade nulled `daemonId` when the claim landed; finish the half a foreign key
+  // cannot. Conditional per agent — one that another writer has since placed elsewhere is
+  // not this removal's to deactivate.
+  const unplaced: AgentRecord[] = []
+  for (const agent of placedAgents) {
+    if (await deps.repos.agent.settleCascadedUnplacement(agent.id)) unplaced.push(agent)
+    else log.info({ daemonId, agentId: agent.id }, 'cloud member retired: agent already placed elsewhere')
+  }
+  await settleAfterRemoval(deps, daemonId, unplaced, log)
+  return true
+}
+
+/** Everything outside the database that pointed at the daemon. Re-converges from current
+ *  state, so it is safe to run once the row is gone — and runs ONLY then. */
+async function settleAfterRemoval(
+  deps: DaemonRemovalDeps,
+  daemonId: DaemonId,
+  unplacedAgents: AgentRecord[],
+  log: FastifyBaseLogger
+): Promise<void> {
   // The daemon (and its FK-cascaded keys) is gone — tell relays to drop it (§9).
   deps.relayControl.daemonRevoke(daemonId)
   // Those agents just left the collaboration snapshot — but only if we push one.
@@ -82,7 +99,9 @@ async function removeAndSettle(
   // entries naming this dead daemonId, and `admits()` keeps admitting wakes the
   // relay can only answer 'offline' to. Best-effort, after the row is already
   // gone; `register/ok` carries the corrected directory as the reconnect backstop.
-  for (const orgId of new Set(placedAgents.map((agent) => agent.orgId))) {
+  // Which organizations need one is derived from the placements the row held, because a
+  // cloud member's agents are not one org's.
+  for (const orgId of new Set(unplacedAgents.map((agent) => agent.orgId))) {
     try {
       await deps.collabRoutes.broadcast(orgId)
     } catch (err) {
@@ -95,7 +114,7 @@ async function removeAndSettle(
   // Re-converge the unplaced agents' hook rules NOW: their compiled rules still
   // name the dead daemonId in every relay's table. Unplaced ⇒ compile() returns
   // null ⇒ pool-wide hook-remove.
-  for (const agent of placedAgents) {
+  for (const agent of unplacedAgents) {
     void deps.hooks
       .rebroadcastForAgent(agent.id)
       .catch((err: unknown) => log.warn({ agentId: agent.id, err }, 'daemon delete: hook re-converge failed'))

--- a/packages/control-plane/src/http/daemon-removal.ts
+++ b/packages/control-plane/src/http/daemon-removal.ts
@@ -13,14 +13,18 @@
  * lives here rather than in whichever route wrote it first.
  *
  * The two paths differ in ONE thing, deliberately: who decides. An operator's detach has
- * already decided, so it unplaces first and then deletes. The reaper's decision is a
- * guess about a row it read moments ago, so its delete comes FIRST as a fenced claim and
- * nothing destructive runs until that claim wins.
+ * already decided, so it unplaces first and then deletes — and a crash between the two leaves
+ * a live daemon with unplaced agents, which converges. The reaper's decision is a guess about
+ * a row it read moments ago, so its delete comes FIRST as a fenced claim, which puts the
+ * cascade before the settlement and makes the pair a transaction (`retireCloudMember`) rather
+ * than an ordering.
  */
 import type { FastifyBaseLogger } from 'fastify'
-import type { DaemonId, OrgId } from '../domain/ids.js'
-import type { AgentRecord } from '../persistence/ports.js'
+import type { AgentId, DaemonId, OrgId } from '../domain/ids.js'
 import type { HttpDeps } from './deps.js'
+
+/** Just enough of an agent to re-converge what pointed at it. */
+type UnplacedAgent = { id: AgentId; orgId: OrgId }
 
 /** What the sequence touches — narrow, so a caller cannot pass half a graph. */
 export type DaemonRemovalDeps = Pick<HttpDeps, 'repos' | 'registry' | 'relayControl' | 'collabRoutes' | 'hooks'>
@@ -54,12 +58,14 @@ export async function detachDaemon(
  * cannot reach it — and its placements may span every organization, which is the whole
  * reason it goes through this sequence instead of a bare delete.
  *
- * The order is the safety property. `fence` re-checks, inside the delete statement itself,
- * the staleness that put this member on the worklist plus the `sessionEpoch` observed there;
- * a member that heartbeated or re-authenticated in between simply does not match, and false
- * comes back with NOTHING written. Only a won claim reaches the settlement — the alternative,
- * unplacing first and checking after, deactivates a live member's agents across every
- * organization before it discovers the member is alive.
+ * `fence` re-checks, inside the delete statement itself, the staleness that put this member on
+ * the worklist plus the `sessionEpoch` observed there; a member that heartbeated or
+ * re-authenticated in between simply does not match, and false comes back with NOTHING
+ * written. The alternative — unplacing first and checking after — deactivates a live member's
+ * agents across every organization before it discovers the member is alive.
+ *
+ * What follows the transaction is only the out-of-database convergence, which is best-effort
+ * by nature and backstopped by `register/ok` on the next reconnect.
  */
 export async function retireCloudDaemonMember(
   deps: DaemonRemovalDeps,
@@ -68,19 +74,11 @@ export async function retireCloudDaemonMember(
   log: FastifyBaseLogger
 ): Promise<boolean> {
   const { daemonId, sessionEpoch } = member
-  // Read-only, and before the claim for the same reason as above: the cascade erases the
-  // placements, so this is the last moment anything can name them.
-  const placedAgents = await deps.repos.agent.listForDaemon(daemonId)
-  if (!(await deps.registry.removeCloudMember(daemonId, { retiredBefore, sessionEpoch }))) return false
-  // The cascade nulled `daemonId` when the claim landed; finish the half a foreign key
-  // cannot. Conditional per agent — one that another writer has since placed elsewhere is
-  // not this removal's to deactivate.
-  const unplaced: AgentRecord[] = []
-  for (const agent of placedAgents) {
-    if (await deps.repos.agent.settleCascadedUnplacement(agent.id)) unplaced.push(agent)
-    else log.info({ daemonId, agentId: agent.id }, 'cloud member retired: agent already placed elsewhere')
-  }
-  await settleAfterRemoval(deps, daemonId, unplaced, log)
+  // One transaction for both database halves — the delete and the unplacement it cascades —
+  // so nothing here can be interrupted into leaving an agent active with nowhere to run.
+  const { deleted, settled } = await deps.registry.retireCloudMember(daemonId, { retiredBefore, sessionEpoch })
+  if (!deleted) return false
+  await settleAfterRemoval(deps, daemonId, settled, log)
   return true
 }
 
@@ -89,7 +87,7 @@ export async function retireCloudDaemonMember(
 async function settleAfterRemoval(
   deps: DaemonRemovalDeps,
   daemonId: DaemonId,
-  unplacedAgents: AgentRecord[],
+  unplacedAgents: UnplacedAgent[],
   log: FastifyBaseLogger
 ): Promise<void> {
   // The daemon (and its FK-cascaded keys) is gone — tell relays to drop it (§9).

--- a/packages/control-plane/src/http/daemon-removal.ts
+++ b/packages/control-plane/src/http/daemon-removal.ts
@@ -7,10 +7,10 @@
  * that name a dead daemon, and compiled hook rules that fail every delivery with
  * `daemon_offline` until a re-register replays them.
  *
- * Two callers need the whole sequence — `DELETE /daemons/:id`, and organization
- * deletion, which retires the cluster envelope's own daemon — and a partial copy
- * in either is a bug that only shows up in the console days later. So it lives
- * here rather than in whichever route wrote it first.
+ * Three callers need the whole sequence — `DELETE /daemons/:id`, organization deletion
+ * (which retires the cluster envelope's own daemon), and the cloud-member reaper — and a
+ * partial copy in any of them is a bug that only shows up in the console days later. So it
+ * lives here rather than in whichever route wrote it first.
  */
 import type { FastifyBaseLogger } from 'fastify'
 import type { DaemonId, OrgId } from '../domain/ids.js'
@@ -30,6 +30,42 @@ export async function detachDaemon(
   daemonId: DaemonId,
   log: FastifyBaseLogger
 ): Promise<void> {
+  await removeAndSettle(deps, daemonId, () => deps.registry.remove(orgId, daemonId), log)
+}
+
+/**
+ * Retire one install-wide cloud member whose Pod is gone (`orchestrator/cloudDaemonReaper.ts`).
+ * No org owns the row, so the org-fenced delete cannot reach it — and its placements may span
+ * every organization, which is the whole reason it goes through the same settle sequence
+ * instead of a bare delete. False ⇒ the row was no longer a retired member; nothing was
+ * deleted, and the unplacements it did first are what an operator would have wanted anyway.
+ */
+export async function retireCloudDaemonMember(
+  deps: DaemonRemovalDeps,
+  daemonId: DaemonId,
+  log: FastifyBaseLogger
+): Promise<boolean> {
+  let deleted = false
+  await removeAndSettle(
+    deps,
+    daemonId,
+    async () => {
+      deleted = await deps.registry.removeCloudMember(daemonId)
+    },
+    log
+  )
+  return deleted
+}
+
+/** The sequence itself. `remove` performs the delete; which organizations need a fresh
+ *  collaboration snapshot is derived from the placements the row held, because a cloud
+ *  member's agents are not one org's. */
+async function removeAndSettle(
+  deps: DaemonRemovalDeps,
+  daemonId: DaemonId,
+  remove: () => Promise<void>,
+  log: FastifyBaseLogger
+): Promise<void> {
   // Captured BEFORE the delete: the FK is SetNull, so the placement disappears
   // with the row and nothing afterwards could name these agents.
   const placedAgents = await deps.repos.agent.listForDaemon(daemonId)
@@ -38,7 +74,7 @@ export async function detachDaemon(
   // the agents' webchat MCP delegations and bumps their hook dispatchRevision,
   // exactly as an operator-initiated unplacement would.
   for (const agent of placedAgents) await deps.repos.agent.setPlacement(agent.id, null)
-  await deps.registry.remove(orgId, daemonId)
+  await remove()
   // The daemon (and its FK-cascaded keys) is gone — tell relays to drop it (§9).
   deps.relayControl.daemonRevoke(daemonId)
   // Those agents just left the collaboration snapshot — but only if we push one.
@@ -46,7 +82,7 @@ export async function detachDaemon(
   // entries naming this dead daemonId, and `admits()` keeps admitting wakes the
   // relay can only answer 'offline' to. Best-effort, after the row is already
   // gone; `register/ok` carries the corrected directory as the reconnect backstop.
-  if (placedAgents.length > 0) {
+  for (const orgId of new Set(placedAgents.map((agent) => agent.orgId))) {
     try {
       await deps.collabRoutes.broadcast(orgId)
     } catch (err) {

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -196,6 +196,10 @@ export const DaemonViewDto = z.object({
   lifecycleOp: DaemonLifecycleOpDto.nullable(),
   /** Live connection status overlaid from the in-memory index (not the stale durable field). */
   status: z.string(),
+  /** An install-wide cloud member (`Daemon.orgId === null`, one row per cloud-daemon Pod):
+   *  managed infrastructure every org shares, not a machine this org connected. The console
+   *  collapses the whole pool into its single "AgentConnect Cloud" entry. */
+  cloud: z.boolean(),
   health: z.string(),
   capabilities: DaemonCapabilitiesDto,
   /** Observed runtime profiles (per installed runtime); empty until the daemon reports any. */

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -147,6 +147,8 @@ function toDto(
         }
       : null,
     status: liveStatus(view, liveness, graceMs, nowMs),
+    // Org-less ⇒ an install-wide cloud member; the console groups the pool under one entry.
+    cloud: !orgOwned,
     health: view.health,
     capabilities: view.capabilities,
     runtimeProfiles: view.runtimeProfiles.map((p) => ({ ...p, observedAt: p.observedAt.toISOString() })),

--- a/packages/control-plane/src/orchestrator/cloudDaemonReaper.test.ts
+++ b/packages/control-plane/src/orchestrator/cloudDaemonReaper.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest'
+import { CloudDaemonReaper } from './cloudDaemonReaper.js'
+import { DaemonId } from '../domain/ids.js'
+import type { DaemonRecord } from '../persistence/ports.js'
+import type { DaemonLiveness } from '../ports.js'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+
+const RETIRE_AFTER_MS = 15 * 60_000
+const INTERVAL_MS = 5 * 60_000
+
+const member = (id: string): DaemonRecord => ({ id: DaemonId(id), orgId: null }) as DaemonRecord
+
+/** Only `get` is read; an entry means "connected to THIS control plane right now". */
+const liveness = (...connected: string[]): DaemonLiveness =>
+  ({ get: (id: string) => (connected.includes(id) ? { reachable: true } : undefined) }) as unknown as DaemonLiveness
+
+describe('CloudDaemonReaper', () => {
+  it('retires every member unheard-from since now − retireAfterMs', async () => {
+    const clock = new FakeClock(1_700_000_000_000)
+    const findRetiredCloudMembers = vi.fn(async () => [member('a'), member('b')])
+    const retire = vi.fn(async () => true)
+    const reaper = new CloudDaemonReaper({ findRetiredCloudMembers }, retire, liveness(), clock, {
+      retireAfterMs: RETIRE_AFTER_MS,
+      intervalMs: INTERVAL_MS
+    })
+
+    await reaper.tick()
+
+    expect(findRetiredCloudMembers).toHaveBeenCalledWith(new Date(clock.now() - RETIRE_AFTER_MS))
+    expect(retire.mock.calls.map(([id]) => id)).toEqual(['a', 'b'])
+    reaper.stop()
+  })
+
+  it('leaves a member that is connected here, however stale its last heartbeat looks', async () => {
+    const clock = new FakeClock()
+    const retire = vi.fn(async () => true)
+    const reaper = new CloudDaemonReaper(
+      { findRetiredCloudMembers: async () => [member('live'), member('gone')] },
+      retire,
+      liveness('live'),
+      clock,
+      { retireAfterMs: RETIRE_AFTER_MS, intervalMs: INTERVAL_MS }
+    )
+
+    await reaper.tick()
+
+    expect(retire.mock.calls.map(([id]) => id)).toEqual(['gone'])
+    reaper.stop()
+  })
+
+  it('keeps going through the batch when retiring one member throws', async () => {
+    const clock = new FakeClock()
+    const retire = vi.fn(async (id: string) => {
+      if (id === 'boom') throw new Error('cascade failed')
+      return true
+    })
+    const reaper = new CloudDaemonReaper(
+      { findRetiredCloudMembers: async () => [member('boom'), member('next')] },
+      retire,
+      liveness(),
+      clock,
+      { retireAfterMs: RETIRE_AFTER_MS, intervalMs: INTERVAL_MS }
+    )
+
+    await expect(reaper.tick()).resolves.toBeUndefined()
+    expect(retire.mock.calls.map(([id]) => id)).toEqual(['boom', 'next'])
+    reaper.stop()
+  })
+
+  it('swallows a failed worklist read and keeps the loop alive', async () => {
+    const clock = new FakeClock()
+    const reaper = new CloudDaemonReaper(
+      {
+        findRetiredCloudMembers: async () => {
+          throw new Error('db down')
+        }
+      },
+      async () => true,
+      liveness(),
+      clock,
+      { retireAfterMs: RETIRE_AFTER_MS, intervalMs: INTERVAL_MS }
+    )
+
+    await expect(reaper.tick()).resolves.toBeUndefined()
+    reaper.stop() // cancel the re-armed timer
+  })
+
+  it('start() arms a periodic sweep driven by the clock', async () => {
+    const clock = new FakeClock()
+    const findRetiredCloudMembers = vi.fn(async () => [])
+    const reaper = new CloudDaemonReaper({ findRetiredCloudMembers }, async () => true, liveness(), clock, {
+      retireAfterMs: RETIRE_AFTER_MS,
+      intervalMs: INTERVAL_MS
+    })
+
+    reaper.start()
+    expect(findRetiredCloudMembers).not.toHaveBeenCalled()
+    clock.advance(INTERVAL_MS)
+    await Promise.resolve() // let the async tick settle
+    expect(findRetiredCloudMembers).toHaveBeenCalledTimes(1)
+    reaper.stop()
+  })
+})

--- a/packages/control-plane/src/orchestrator/cloudDaemonReaper.test.ts
+++ b/packages/control-plane/src/orchestrator/cloudDaemonReaper.test.ts
@@ -8,7 +8,8 @@ import { FakeClock } from '../../test/fakes/fake-clock.js'
 const RETIRE_AFTER_MS = 15 * 60_000
 const INTERVAL_MS = 5 * 60_000
 
-const member = (id: string): DaemonRecord => ({ id: DaemonId(id), orgId: null }) as DaemonRecord
+const member = (id: string, sessionEpoch = 7n): DaemonRecord =>
+  ({ id: DaemonId(id), orgId: null, sessionEpoch }) as DaemonRecord
 
 /** Only `get` is read; an entry means "connected to THIS control plane right now". */
 const liveness = (...connected: string[]): DaemonLiveness =>
@@ -27,7 +28,44 @@ describe('CloudDaemonReaper', () => {
     await reaper.tick()
 
     expect(findRetiredCloudMembers).toHaveBeenCalledWith(new Date(clock.now() - RETIRE_AFTER_MS))
-    expect(retire.mock.calls.map(([id]) => id)).toEqual(['a', 'b'])
+    expect(retire.mock.calls.map(([m]) => m.daemonId)).toEqual(['a', 'b'])
+    reaper.stop()
+  })
+
+  it('hands retirement the same cutoff and epoch the sweep read, to re-fence on', async () => {
+    // The worklist is a nomination, not a decision: whoever deletes has to prove the row is
+    // still the one that was read, or a member that reconnected mid-sweep loses its agents.
+    const clock = new FakeClock(1_700_000_000_000)
+    const retire = vi.fn(async () => true)
+    const reaper = new CloudDaemonReaper(
+      { findRetiredCloudMembers: async () => [member('a', 12n)] },
+      retire,
+      liveness(),
+      clock,
+      { retireAfterMs: RETIRE_AFTER_MS, intervalMs: INTERVAL_MS }
+    )
+
+    await reaper.tick()
+
+    expect(retire).toHaveBeenCalledWith({ daemonId: 'a', sessionEpoch: 12n }, new Date(clock.now() - RETIRE_AFTER_MS))
+    reaper.stop()
+  })
+
+  it('does not count a member the claim refused — it came back', async () => {
+    const clock = new FakeClock()
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const reaper = new CloudDaemonReaper(
+      { findRetiredCloudMembers: async () => [member('back')] },
+      async () => false,
+      liveness(),
+      clock,
+      { retireAfterMs: RETIRE_AFTER_MS, intervalMs: INTERVAL_MS },
+      log
+    )
+
+    await reaper.tick()
+
+    expect(log.info).not.toHaveBeenCalled()
     reaper.stop()
   })
 
@@ -44,14 +82,14 @@ describe('CloudDaemonReaper', () => {
 
     await reaper.tick()
 
-    expect(retire.mock.calls.map(([id]) => id)).toEqual(['gone'])
+    expect(retire.mock.calls.map(([m]) => m.daemonId)).toEqual(['gone'])
     reaper.stop()
   })
 
   it('keeps going through the batch when retiring one member throws', async () => {
     const clock = new FakeClock()
-    const retire = vi.fn(async (id: string) => {
-      if (id === 'boom') throw new Error('cascade failed')
+    const retire = vi.fn(async (m: { daemonId: string }) => {
+      if (m.daemonId === 'boom') throw new Error('cascade failed')
       return true
     })
     const reaper = new CloudDaemonReaper(
@@ -63,7 +101,7 @@ describe('CloudDaemonReaper', () => {
     )
 
     await expect(reaper.tick()).resolves.toBeUndefined()
-    expect(retire.mock.calls.map(([id]) => id)).toEqual(['boom', 'next'])
+    expect(retire.mock.calls.map(([m]) => m.daemonId)).toEqual(['boom', 'next'])
     reaper.stop()
   })
 

--- a/packages/control-plane/src/orchestrator/cloudDaemonReaper.ts
+++ b/packages/control-plane/src/orchestrator/cloudDaemonReaper.ts
@@ -1,0 +1,120 @@
+/**
+ * `CloudDaemonReaper` (agentconnect-org-operator.md §"The cloud daemon, which serves every
+ * org") — retires the daemon rows replaced cloud Pods leave behind.
+ *
+ * A cloud member is bound to its reviewed Pod UID, so a replacement Pod gets a NEW daemon
+ * record and the old one lingers: org-less, never reachable again, and visible in every
+ * organization's fleet because install-wide infrastructure is shared. Nothing else can clear
+ * them — no org owns the row, so `DELETE /daemons/:id` cannot name it.
+ *
+ * Liveness is judged by `lastSeenAt`, not by this process's connection index: with several
+ * control-plane replicas a member's socket may be held by a peer, and only the heartbeat
+ * write is common ground. A member connected HERE is skipped as well, which costs nothing
+ * and covers the row whose heartbeat write is lagging.
+ *
+ * Clock-driven via a self-rescheduling `setTimeout` (like {@link RelaySweeper}) so tests
+ * advance a `FakeClock`; armed by the container's `startBackground()`, never in tests.
+ * Every replica running it is fine — the delete is idempotent and fenced to the org-less
+ * cloud shape, so a row another replica just retired reads as "no longer retired".
+ */
+import type { Clock, TimerHandle } from '../domain/clock.js'
+import type { DaemonId } from '../domain/ids.js'
+import type { DaemonLiveness } from '../ports.js'
+import type { DaemonRepo } from '../persistence/ports.js'
+
+/** How often the sweep runs. */
+export const CLOUD_DAEMON_REAP_INTERVAL_MS = 5 * 60_000
+
+/**
+ * How long a cloud member must go unheard-from before its row is retired. Two orders of
+ * magnitude past the watchdog's freeze threshold (missed beats × heartbeat): by then its
+ * sessions have long been rebalanced, and the window is what keeps a network partition from
+ * deleting the record of a Pod that is still running.
+ */
+export const CLOUD_DAEMON_REAP_AFTER_MS = 15 * 60_000
+
+/** Optional structured log sink (the Fastify logger in prod; omitted in tests). */
+export interface CloudDaemonReaperLog {
+  info(obj: unknown, msg?: string): void
+  warn(obj: unknown, msg?: string): void
+  error(obj: unknown, msg?: string): void
+}
+
+export interface CloudDaemonReaperConfig {
+  /** Silence after which a member's row is retired. */
+  retireAfterMs: number
+  /** How often the sweep runs. */
+  intervalMs: number
+}
+
+export class CloudDaemonReaper {
+  private timer: TimerHandle | undefined
+  private stopped = false
+
+  constructor(
+    private readonly daemons: Pick<DaemonRepo, 'findRetiredCloudMembers'>,
+    /** The full detach sequence for one member (`http/daemon-removal.ts`); false ⇒ not
+     *  retired after all (a reconnect, or a peer replica got there first). */
+    private readonly retire: (daemonId: DaemonId) => Promise<boolean>,
+    private readonly liveness: DaemonLiveness,
+    private readonly clock: Clock,
+    private readonly cfg: CloudDaemonReaperConfig,
+    private readonly log?: CloudDaemonReaperLog
+  ) {}
+
+  /** Arm the periodic sweep. Idempotent — a second call re-arms from now. */
+  start(): void {
+    this.stopped = false
+    this.arm()
+  }
+
+  /** Cancel the loop — call on shutdown so no timer outlives the process. */
+  stop(): void {
+    this.stopped = true
+    if (this.timer !== undefined) {
+      this.clock.clearTimeout(this.timer)
+      this.timer = undefined
+    }
+  }
+
+  private arm(): void {
+    if (this.stopped) return
+    if (this.timer !== undefined) this.clock.clearTimeout(this.timer)
+    this.timer = this.clock.setTimeout(() => void this.tick(), this.cfg.intervalMs)
+  }
+
+  /**
+   * One sweep. Members are retired one at a time: each carries a cascade plus a
+   * collaboration push, and a failure on one must not cost the rest of the batch. Errors
+   * are logged and swallowed — a transient DB failure waits for the next tick rather than
+   * killing the loop. Exposed for tests (call directly).
+   */
+  async tick(): Promise<void> {
+    this.timer = undefined
+    try {
+      const cutoff = new Date(this.clock.now() - this.cfg.retireAfterMs)
+      const retired = await this.daemons.findRetiredCloudMembers(cutoff)
+      let removed = 0
+      for (const member of retired) {
+        if (this.stopped) break
+        // Connected here despite a stale `lastSeenAt` — leave it to the heartbeat.
+        if (this.liveness.get(member.id)) continue
+        try {
+          if (await this.retire(member.id)) removed++
+        } catch (err) {
+          this.log?.warn({ err, daemonId: member.id }, 'cloud-daemon-reaper: retiring one member failed')
+        }
+      }
+      if (removed > 0) {
+        this.log?.info(
+          { removed, considered: retired.length, cutoff: cutoff.toISOString() },
+          'cloud-daemon-reaper: retired cloud members whose Pods are gone'
+        )
+      }
+    } catch (err) {
+      this.log?.error({ err }, 'cloud-daemon-reaper: sweep failed')
+    } finally {
+      this.arm()
+    }
+  }
+}

--- a/packages/control-plane/src/orchestrator/cloudDaemonReaper.ts
+++ b/packages/control-plane/src/orchestrator/cloudDaemonReaper.ts
@@ -12,6 +12,10 @@
  * write is common ground. A member connected HERE is skipped as well, which costs nothing
  * and covers the row whose heartbeat write is lagging.
  *
+ * The sweep only nominates. Retiring re-checks the same cutoff and the epoch this read saw
+ * INSIDE the delete statement, so a member that comes back between the two loses nothing:
+ * see `http/daemon-removal.ts#retireCloudDaemonMember`.
+ *
  * Clock-driven via a self-rescheduling `setTimeout` (like {@link RelaySweeper}) so tests
  * advance a `FakeClock`; armed by the container's `startBackground()`, never in tests.
  * Every replica running it is fine — the delete is idempotent and fenced to the org-less
@@ -53,9 +57,13 @@ export class CloudDaemonReaper {
 
   constructor(
     private readonly daemons: Pick<DaemonRepo, 'findRetiredCloudMembers'>,
-    /** The full detach sequence for one member (`http/daemon-removal.ts`); false ⇒ not
-     *  retired after all (a reconnect, or a peer replica got there first). */
-    private readonly retire: (daemonId: DaemonId) => Promise<boolean>,
+    /** The full detach sequence for one member (`http/daemon-removal.ts`), re-fenced on the
+     *  cutoff and epoch this sweep read; false ⇒ not retired after all (a reconnect, or a
+     *  peer replica got there first) and nothing was written. */
+    private readonly retire: (
+      member: { daemonId: DaemonId; sessionEpoch: bigint },
+      retiredBefore: Date
+    ) => Promise<boolean>,
     private readonly liveness: DaemonLiveness,
     private readonly clock: Clock,
     private readonly cfg: CloudDaemonReaperConfig,
@@ -97,10 +105,12 @@ export class CloudDaemonReaper {
       let removed = 0
       for (const member of retired) {
         if (this.stopped) break
-        // Connected here despite a stale `lastSeenAt` — leave it to the heartbeat.
+        // Connected here despite a stale `lastSeenAt` — leave it to the heartbeat. Cheap, and
+        // not the guard that matters: the claim inside `retire` is what a member reconnecting
+        // mid-sweep (or serving a peer replica) is actually fenced by.
         if (this.liveness.get(member.id)) continue
         try {
-          if (await this.retire(member.id)) removed++
+          if (await this.retire({ daemonId: member.id, sessionEpoch: member.sessionEpoch }, cutoff)) removed++
         } catch (err) {
           this.log?.warn({ err, daemonId: member.id }, 'cloud-daemon-reaper: retiring one member failed')
         }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -266,14 +266,22 @@ export interface DaemonRepo {
    */
   findRetiredCloudMembers(cutoff: Date): Promise<DaemonRecord[]>
   /**
-   * Hard-delete ONE install-wide cloud member, cascading exactly like {@link DaemonRepo.delete}.
+   * Retire ONE install-wide cloud member: the fenced delete (cascading exactly like
+   * {@link DaemonRepo.delete}) plus the database-side settlement of every agent it hosted, in
+   * one transaction — so no crash can leave an agent unplaced but still `active`.
+   *
    * A compare-and-delete, not a delete: the whole fence rides one statement — the org-less
    * cloud shape (so it cannot touch an org's own daemon), the same `retiredBefore` cutoff the
    * worklist selected on, and the `sessionEpoch` observed there, which a (re)auth bumps before
-   * the first heartbeat moves `lastSeenAt`. A row that stopped matching yields false rather
-   * than an error, so nothing downstream runs for a member that came back.
+   * the first heartbeat moves `lastSeenAt`. A row that stopped matching yields
+   * `deleted: false`, having written nothing, so nothing downstream runs for a member that
+   * came back. `settled` is the agents this call actually unplaced — the audience for the
+   * out-of-database pushes that follow, excluding any a concurrent writer had already moved.
    */
-  deleteCloudMember(daemonId: DaemonId, fence: { retiredBefore: Date; sessionEpoch: bigint }): Promise<boolean>
+  retireCloudMember(
+    daemonId: DaemonId,
+    fence: { retiredBefore: Date; sessionEpoch: bigint }
+  ): Promise<{ deleted: boolean; settled: { id: AgentId; orgId: OrgId }[] }>
   /** Bump THIS daemon's `routingEpoch` atomically; returns the new value (§4.11).
    *  System-tier: the orchestrator drives it from a routing decision it already
    *  resolved, so an org parameter would be tautological (§3.4). */
@@ -890,14 +898,6 @@ export interface AgentRepo {
     daemonId: DaemonId | null,
     byUserId?: string
   ): Promise<AgentRecord | null>
-  /**
-   * Finish the unplacement a daemon DELETE's `SetNull` cascade started — status, revision,
-   * webchat delegations, hook dispatch — for an agent that is STILL unplaced. False means
-   * another writer placed it in the meantime (or the row is gone), so this removal left it
-   * alone. Used where the delete has to come first to be atomic
-   * (`orchestrator/cloudDaemonReaper.ts`); an operator's detach unplaces up front instead.
-   */
-  settleCascadedUnplacement(agentId: AgentId): Promise<boolean>
   /** Atomically enumerate the agent's HookDefs, tombstone their durable review
    *  projections, and delete the Agent (cascading the HookDefs). The returned
    *  snapshots let the route remove the corresponding relay rules.

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -257,6 +257,21 @@ export interface DaemonRepo {
    * exactly like an absent row (→ 404).
    */
   delete(orgId: OrgId, daemonId: DaemonId): Promise<void>
+  /**
+   * Install-wide cloud members nothing has been heard from since `cutoff` — the rows left
+   * behind by replaced Pods, which no org's DELETE can reach because no org owns them
+   * (agentconnect-org-operator.md §"The cloud daemon, which serves every org": a replacement
+   * Pod gets a new daemon ID). System-tier and deliberately fleet-wide, like
+   * {@link DaemonRepo.findReassignable}. Never-connected rows are judged by `createdAt`.
+   */
+  findRetiredCloudMembers(cutoff: Date): Promise<DaemonRecord[]>
+  /**
+   * Hard-delete ONE install-wide cloud member, cascading exactly like {@link DaemonRepo.delete}.
+   * The org-less-cloud shape is the fence — the statement cannot touch an org's own daemon —
+   * so a row that stopped matching (a member that reconnected, an id that never was one)
+   * yields false rather than an error.
+   */
+  deleteCloudMember(daemonId: DaemonId): Promise<boolean>
   /** Bump THIS daemon's `routingEpoch` atomically; returns the new value (§4.11).
    *  System-tier: the orchestrator drives it from a routing decision it already
    *  resolved, so an org parameter would be tautological (§3.4). */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -267,11 +267,13 @@ export interface DaemonRepo {
   findRetiredCloudMembers(cutoff: Date): Promise<DaemonRecord[]>
   /**
    * Hard-delete ONE install-wide cloud member, cascading exactly like {@link DaemonRepo.delete}.
-   * The org-less-cloud shape is the fence — the statement cannot touch an org's own daemon —
-   * so a row that stopped matching (a member that reconnected, an id that never was one)
-   * yields false rather than an error.
+   * A compare-and-delete, not a delete: the whole fence rides one statement — the org-less
+   * cloud shape (so it cannot touch an org's own daemon), the same `retiredBefore` cutoff the
+   * worklist selected on, and the `sessionEpoch` observed there, which a (re)auth bumps before
+   * the first heartbeat moves `lastSeenAt`. A row that stopped matching yields false rather
+   * than an error, so nothing downstream runs for a member that came back.
    */
-  deleteCloudMember(daemonId: DaemonId): Promise<boolean>
+  deleteCloudMember(daemonId: DaemonId, fence: { retiredBefore: Date; sessionEpoch: bigint }): Promise<boolean>
   /** Bump THIS daemon's `routingEpoch` atomically; returns the new value (§4.11).
    *  System-tier: the orchestrator drives it from a routing decision it already
    *  resolved, so an org parameter would be tautological (§3.4). */
@@ -888,6 +890,14 @@ export interface AgentRepo {
     daemonId: DaemonId | null,
     byUserId?: string
   ): Promise<AgentRecord | null>
+  /**
+   * Finish the unplacement a daemon DELETE's `SetNull` cascade started — status, revision,
+   * webchat delegations, hook dispatch — for an agent that is STILL unplaced. False means
+   * another writer placed it in the meantime (or the row is gone), so this removal left it
+   * alone. Used where the delete has to come first to be atomic
+   * (`orchestrator/cloudDaemonReaper.ts`); an operator's detach unplaces up front instead.
+   */
+  settleCascadedUnplacement(agentId: AgentId): Promise<boolean>
   /** Atomically enumerate the agent's HookDefs, tombstone their durable review
    *  projections, and delete the Agent (cascading the HookDefs). The returned
    *  snapshots let the route remove the corresponding relay rules.

--- a/packages/control-plane/src/persistence/prisma.ts
+++ b/packages/control-plane/src/persistence/prisma.ts
@@ -54,8 +54,14 @@ export function withTx<T>(prisma: PrismaClient, fn: (tx: Prisma.TransactionClien
  * `ensurePersonalOrg`). Composing means the OUTER transaction's boundary wins:
  * a rollback out there also undoes what `fn` wrote, which is the intent.
  */
-export function withAmbientTx<T>(db: PrismaLike, fn: (tx: Prisma.TransactionClient) => Promise<T>): Promise<T> {
-  if ('$transaction' in db) return (db as PrismaClient).$transaction(fn)
+export function withAmbientTx<T>(
+  db: PrismaLike,
+  fn: (tx: Prisma.TransactionClient) => Promise<T>,
+  /** Interactive-transaction budget, for a unit of work whose size is data-dependent and can
+   *  outgrow Prisma's 5s default. Ignored when composing — the outer boundary owns the clock. */
+  opts?: { timeout?: number; maxWait?: number }
+): Promise<T> {
+  if ('$transaction' in db) return (db as PrismaClient).$transaction(fn, opts)
   return fn(db as Prisma.TransactionClient)
 }
 

--- a/packages/control-plane/src/persistence/repositories/agent-placement.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-placement.ts
@@ -1,0 +1,57 @@
+/**
+ * Placement primitives shared by the agent repository and the one writer that has to settle
+ * placements from OUTSIDE it: retiring an install-wide cloud member, where the daemon delete
+ * and the settlement of every agent it hosted must land in one transaction
+ * (`daemon.repo.ts#retireCloudMember`).
+ *
+ * Placement/delegation lock order:
+ *   Agent FOR UPDATE → active WebchatMcpDelegation rows.
+ * Establishment joins the same order with a compatible Agent FOR SHARE, then locks its
+ * Conversation FOR UPDATE before touching Delegation. Agent is always first, so placement and
+ * agent deletion cannot form an inverse cycle.
+ */
+import { Prisma } from '../../generated/prisma/client.js'
+
+export async function lockAgentPlacement(
+  tx: Prisma.TransactionClient,
+  agentId: string
+): Promise<{ daemonId: string | null } | null> {
+  const [row] = await tx.$queryRaw<{ daemonId: string | null }[]>(
+    Prisma.sql`SELECT "daemonId" FROM "agent" WHERE "id" = ${agentId} FOR UPDATE`
+  )
+  return row ?? null
+}
+
+export async function revokeActiveWebchatMcpDelegations(
+  tx: Prisma.TransactionClient,
+  agentId: string,
+  revokedAt: Date
+): Promise<void> {
+  await tx.webchatMcpDelegation.updateMany({
+    where: { agentId, revokedAt: null },
+    data: { revokedAt, revokedReason: 'agent_placement_changed' }
+  })
+}
+
+/**
+ * Finish an unplacement a daemon DELETE started. The FK sets `daemonId` null and touches
+ * nothing else, so without this the agent reads `active` with nowhere to run, holding live
+ * webchat delegations and compiled hook rules — which is why it belongs in the deleting
+ * transaction, not after it.
+ *
+ * Conditional by design: a row some other writer has since placed elsewhere is not this
+ * removal's to null, so it is left alone and reported as unsettled.
+ */
+export async function settleCascadedUnplacement(tx: Prisma.TransactionClient, agentId: string): Promise<boolean> {
+  const current = await lockAgentPlacement(tx, agentId)
+  if (!current || current.daemonId !== null) return false
+  await tx.agent.update({
+    // No daemonId write — the cascade already did that; what is missing is everything
+    // `setPlacement(null)` pairs with it, including the revision the next owner compares.
+    where: { id: agentId },
+    data: { status: 'inactive', configRevision: { increment: 1 } }
+  })
+  await revokeActiveWebchatMcpDelegations(tx, agentId, new Date())
+  await tx.hookDef.updateMany({ where: { agentId }, data: { dispatchRevision: { increment: 1 } } })
+  return true
+}

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -31,6 +31,7 @@ import { lockResourceWriteMemberships } from '../resource-membership-lock.js'
 import { lockSkillSourceNameScopes } from '../skill-source-lock.js'
 import { tryLockMemoryConnectionScopes } from '../memory-connection-lock.js'
 import { PgHookRepo } from './hook.repo.js'
+import { lockAgentPlacement, revokeActiveWebchatMcpDelegations } from './agent-placement.js'
 import { fenceAgentLocalConfigWrite, lockOrgForConfigWrite, orgIdOfAgent } from './organization-environment-fence.js'
 import {
   AgentMissing,
@@ -167,34 +168,6 @@ async function settlePresetPlacement(tx: Prisma.TransactionClient, agentId: stri
   await tx.presetAgent.updateMany({
     where: { agentId, placementSettledAt: null },
     data: { placementSettledAt: new Date() }
-  })
-}
-
-/**
- * Placement/delegation lock order:
- *   Agent FOR UPDATE → active WebchatMcpDelegation rows.
- * Establishment joins the same order with a compatible Agent FOR SHARE, then
- * locks its Conversation FOR UPDATE before touching Delegation. Agent is
- * always first, so placement and agent deletion cannot form an inverse cycle.
- */
-async function lockAgentPlacement(
-  tx: Prisma.TransactionClient,
-  agentId: string
-): Promise<{ daemonId: string | null } | null> {
-  const [row] = await tx.$queryRaw<{ daemonId: string | null }[]>(
-    Prisma.sql`SELECT "daemonId" FROM "agent" WHERE "id" = ${agentId} FOR UPDATE`
-  )
-  return row ?? null
-}
-
-async function revokeActiveWebchatMcpDelegations(
-  tx: Prisma.TransactionClient,
-  agentId: string,
-  revokedAt: Date
-): Promise<void> {
-  await tx.webchatMcpDelegation.updateMany({
-    where: { agentId, revokedAt: null },
-    data: { revokedAt, revokedReason: 'agent_placement_changed' }
   })
 }
 
@@ -845,29 +818,6 @@ export class PgAgentRepo implements AgentRepo {
           data: { dispatchRevision: { increment: 1 } }
         })
       }
-    })
-  }
-
-  /**
-   * Finish an unplacement a daemon DELETE started: the FK sets `daemonId` null and touches
-   * nothing else, so the agent is left reading `active` with nowhere to run, holding live
-   * webchat delegations and compiled hook rules. Conditional by design — a row some other
-   * writer has since placed elsewhere is not this removal's to null, so it is left alone and
-   * reported as unsettled.
-   */
-  async settleCascadedUnplacement(agentId: AgentId): Promise<boolean> {
-    return this.transaction(async (tx) => {
-      const current = await lockAgentPlacement(tx, agentId)
-      if (!current || current.daemonId !== null) return false
-      await tx.agent.update({
-        // No daemonId write — the cascade already did that; what is missing is everything
-        // `setPlacement(null)` pairs with it, including the revision the next owner compares.
-        where: { id: agentId },
-        data: { status: 'inactive', configRevision: { increment: 1 } }
-      })
-      await revokeActiveWebchatMcpDelegations(tx, agentId, new Date())
-      await tx.hookDef.updateMany({ where: { agentId }, data: { dispatchRevision: { increment: 1 } } })
-      return true
     })
   }
 

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -848,6 +848,29 @@ export class PgAgentRepo implements AgentRepo {
     })
   }
 
+  /**
+   * Finish an unplacement a daemon DELETE started: the FK sets `daemonId` null and touches
+   * nothing else, so the agent is left reading `active` with nowhere to run, holding live
+   * webchat delegations and compiled hook rules. Conditional by design — a row some other
+   * writer has since placed elsewhere is not this removal's to null, so it is left alone and
+   * reported as unsettled.
+   */
+  async settleCascadedUnplacement(agentId: AgentId): Promise<boolean> {
+    return this.transaction(async (tx) => {
+      const current = await lockAgentPlacement(tx, agentId)
+      if (!current || current.daemonId !== null) return false
+      await tx.agent.update({
+        // No daemonId write — the cascade already did that; what is missing is everything
+        // `setPlacement(null)` pairs with it, including the revision the next owner compares.
+        where: { id: agentId },
+        data: { status: 'inactive', configRevision: { increment: 1 } }
+      })
+      await revokeActiveWebchatMcpDelegations(tx, agentId, new Date())
+      await tx.hookDef.updateMany({ where: { agentId }, data: { dispatchRevision: { increment: 1 } } })
+      return true
+    })
+  }
+
   async movePlacement(
     agentId: AgentId,
     expectedDaemonId: DaemonId | null,

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -20,7 +20,8 @@ import type {
   ViewCtx
 } from '../ports.js'
 import { visibilityWhere } from '../../authorization/policy.js'
-import { DaemonId, OrgId } from '../../domain/ids.js'
+import { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
+import { lockAgentPlacement, settleCascadedUnplacement } from './agent-placement.js'
 import type { Heartbeat, FactsMcpServer } from '@agentconnect.md/protocol'
 import { lockResourceWriteMemberships } from '../resource-membership-lock.js'
 
@@ -366,22 +367,51 @@ export class PgDaemonRepo implements DaemonRepo {
   }
 
   /**
-   * The whole fence rides ONE statement, so this is a compare-and-delete and not a delete
-   * that trusts an earlier read: still an org-less cloud member, still silent past the same
-   * cutoff, and still at the `sessionEpoch` the worklist saw. The epoch is what makes it
-   * airtight — `upsertOnAuth` bumps it atomically on every (re)auth, while `lastSeenAt` only
-   * moves on the first heartbeat AFTER one, so a member that just came back is fresh by epoch
-   * before it is fresh by clock.
+   * Retire one cloud member: the fenced delete AND the settlement of every agent it hosted,
+   * in ONE transaction. Split across two commits, a process exit or a transient failure in
+   * between would strand agents at `daemonId = null` with `status = 'active'` — nowhere to
+   * run, live delegations, stale hook revisions — with no durable work item to retry from.
+   *
+   * The whole fence rides the DELETE statement, so this is a compare-and-delete and not a
+   * delete that trusts an earlier read: still an org-less cloud member, still silent past the
+   * same cutoff the worklist selected on, still at the `sessionEpoch` it saw there. The epoch
+   * is what makes it airtight — `upsertOnAuth` bumps it atomically on every (re)auth, while
+   * `lastSeenAt` only moves on the first heartbeat AFTER one, so a member that just came back
+   * is fresh by epoch before it is fresh by clock. A refused claim rolls back reads only.
+   *
+   * The agents are locked BEFORE the daemon row, matching the placement path's Agent → Daemon
+   * order (`agent-placement.ts`), so a concurrent move cannot deadlock against this.
    */
-  async deleteCloudMember(daemonId: DaemonId, fence: { retiredBefore: Date; sessionEpoch: bigint }): Promise<boolean> {
-    const { count } = await this.db.daemon.deleteMany({
-      where: {
-        id: daemonId,
-        sessionEpoch: fence.sessionEpoch,
-        ...retiredCloudMemberWhere(fence.retiredBefore)
-      }
-    })
-    return count === 1
+  async retireCloudMember(
+    daemonId: DaemonId,
+    fence: { retiredBefore: Date; sessionEpoch: bigint }
+  ): Promise<{ deleted: boolean; settled: { id: AgentId; orgId: OrgId }[] }> {
+    return withAmbientTx(
+      this.db,
+      async (tx) => {
+        // Read + lock before the delete: the FK is SetNull, so the cascade erases the only
+        // record of which agents this member hosted.
+        const placed = await tx.agent.findMany({
+          where: { daemonId },
+          select: { id: true, orgId: true },
+          orderBy: { id: 'asc' } // one lock order for every concurrent retirement
+        })
+        for (const agent of placed) await lockAgentPlacement(tx, agent.id)
+        const { count } = await tx.daemon.deleteMany({
+          where: { id: daemonId, sessionEpoch: fence.sessionEpoch, ...retiredCloudMemberWhere(fence.retiredBefore) }
+        })
+        if (count !== 1) return { deleted: false, settled: [] }
+        const settled: { id: AgentId; orgId: OrgId }[] = []
+        for (const agent of placed) {
+          if (await settleCascadedUnplacement(tx, agent.id))
+            settled.push({ id: AgentId(agent.id), orgId: OrgId(agent.orgId) })
+        }
+        return { deleted: true, settled }
+      },
+      // How many agents a member hosts is not bounded by anything here, and the whole point is
+      // that they settle with the delete — so the budget is the sweep's, not Prisma's 5s default.
+      { timeout: 30_000 }
+    )
   }
 
   async bumpRoutingEpoch(daemonId: DaemonId): Promise<bigint> {

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -67,6 +67,17 @@ function toRecord(d: DaemonWithUsers): DaemonRecord {
 // bound to one Pod UID. An envelope daemon carries an identity but no Pod, so it never matches.
 const CLOUD_MEMBER_WHERE = { orgId: null, clusterIdentity: { not: null }, clusterPodUid: { not: null } } as const
 
+/** ONE definition of "retired", shared by the worklist read and the delete that acts on it: a
+ *  claim fenced on a different predicate than the one that selected the row is not a claim.
+ *  A row that never heartbeated is judged by its own age — `lastSeenAt` stays null for a Pod
+ *  that authenticated and died before its first beat. */
+function retiredCloudMemberWhere(cutoff: Date) {
+  return {
+    ...CLOUD_MEMBER_WHERE,
+    OR: [{ lastSeenAt: { lt: cutoff } }, { lastSeenAt: null, createdAt: { lt: cutoff } }]
+  }
+}
+
 export class PgDaemonRepo implements DaemonRepo {
   constructor(private readonly db: PrismaLike) {}
 
@@ -347,20 +358,29 @@ export class PgDaemonRepo implements DaemonRepo {
    *  is long gone: only silence past `cutoff` retires a row. */
   async findRetiredCloudMembers(cutoff: Date): Promise<DaemonRecord[]> {
     const rows = await this.db.daemon.findMany({
-      where: {
-        ...CLOUD_MEMBER_WHERE,
-        // A row that never heartbeated is judged by its own age — `lastSeenAt` stays null
-        // for a Pod that authenticated and died before its first beat.
-        OR: [{ lastSeenAt: { lt: cutoff } }, { lastSeenAt: null, createdAt: { lt: cutoff } }]
-      },
+      where: retiredCloudMemberWhere(cutoff),
       orderBy: { createdAt: 'asc' },
       include: withUsers
     })
     return rows.map(toRecord)
   }
 
-  async deleteCloudMember(daemonId: DaemonId): Promise<boolean> {
-    const { count } = await this.db.daemon.deleteMany({ where: { id: daemonId, ...CLOUD_MEMBER_WHERE } })
+  /**
+   * The whole fence rides ONE statement, so this is a compare-and-delete and not a delete
+   * that trusts an earlier read: still an org-less cloud member, still silent past the same
+   * cutoff, and still at the `sessionEpoch` the worklist saw. The epoch is what makes it
+   * airtight — `upsertOnAuth` bumps it atomically on every (re)auth, while `lastSeenAt` only
+   * moves on the first heartbeat AFTER one, so a member that just came back is fresh by epoch
+   * before it is fresh by clock.
+   */
+  async deleteCloudMember(daemonId: DaemonId, fence: { retiredBefore: Date; sessionEpoch: bigint }): Promise<boolean> {
+    const { count } = await this.db.daemon.deleteMany({
+      where: {
+        id: daemonId,
+        sessionEpoch: fence.sessionEpoch,
+        ...retiredCloudMemberWhere(fence.retiredBefore)
+      }
+    })
     return count === 1
   }
 

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -63,6 +63,10 @@ function toRecord(d: DaemonWithUsers): DaemonRecord {
   }
 }
 
+// What an install-wide cloud member is, as a where-clause: org-less, cluster-reviewed, and
+// bound to one Pod UID. An envelope daemon carries an identity but no Pod, so it never matches.
+const CLOUD_MEMBER_WHERE = { orgId: null, clusterIdentity: { not: null }, clusterPodUid: { not: null } } as const
+
 export class PgDaemonRepo implements DaemonRepo {
   constructor(private readonly db: PrismaLike) {}
 
@@ -336,6 +340,28 @@ export class PgDaemonRepo implements DaemonRepo {
     // the org fence rides the same statement, so a cross-org id is refused with
     // exactly that error (org-scoped-data-layer.md §3).
     await this.db.daemon.delete({ where: { id: daemonId, orgId } })
+  }
+
+  /** The org-less-cloud shape rides every clause, so neither the worklist nor the delete can
+   *  name an org's own daemon. A member still inside the window is left alone even if its Pod
+   *  is long gone: only silence past `cutoff` retires a row. */
+  async findRetiredCloudMembers(cutoff: Date): Promise<DaemonRecord[]> {
+    const rows = await this.db.daemon.findMany({
+      where: {
+        ...CLOUD_MEMBER_WHERE,
+        // A row that never heartbeated is judged by its own age — `lastSeenAt` stays null
+        // for a Pod that authenticated and died before its first beat.
+        OR: [{ lastSeenAt: { lt: cutoff } }, { lastSeenAt: null, createdAt: { lt: cutoff } }]
+      },
+      orderBy: { createdAt: 'asc' },
+      include: withUsers
+    })
+    return rows.map(toRecord)
+  }
+
+  async deleteCloudMember(daemonId: DaemonId): Promise<boolean> {
+    const { count } = await this.db.daemon.deleteMany({ where: { id: daemonId, ...CLOUD_MEMBER_WHERE } })
+    return count === 1
   }
 
   async bumpRoutingEpoch(daemonId: DaemonId): Promise<bigint> {

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -18,7 +18,7 @@ import type {
   SecretsRequest,
   SecretsGrant
 } from '@agentconnect.md/protocol'
-import type { DaemonId, LeaseId, OrgId } from './domain/ids.js'
+import type { AgentId, DaemonId, LeaseId, OrgId } from './domain/ids.js'
 import type { DaemonStatus, HealthState, AcpSupport, ResourceVisibility, ViewCtx } from './persistence/ports.js'
 
 /** Per-connection client context handed to auth (protocol §3, audit). */
@@ -308,12 +308,17 @@ export interface DaemonRegistry {
   /** Hard-delete a daemon from the fleet (DELETE /daemons/:id). Org-fenced:
    *  throws for an absent row and for a cross-org id alike. */
   remove(orgId: OrgId, daemonId: DaemonId): Promise<void>
-  /** Claim-and-delete one install-wide cloud member — the row a replaced cloud Pod left behind
+  /** Retire one install-wide cloud member — the row a replaced cloud Pod left behind
    *  (`orchestrator/cloudDaemonReaper.ts`). No org owns it, so {@link DaemonRegistry.remove}
    *  cannot reach it. The fence is the claim: org-less cloud shape, still silent past the same
-   *  cutoff the worklist used, still at the epoch observed there. False means the row no longer
-   *  matched — a member that came back — and nothing was deleted. */
-  removeCloudMember(daemonId: DaemonId, fence: { retiredBefore: Date; sessionEpoch: bigint }): Promise<boolean>
+   *  cutoff the worklist used, still at the epoch observed there. `deleted: false` means the
+   *  row no longer matched — a member that came back — and nothing was written. The delete and
+   *  the agent settlement share one transaction; `settled` names the agents it unplaced, whose
+   *  relay, collaboration and hook state the caller re-converges after the commit. */
+  retireCloudMember(
+    daemonId: DaemonId,
+    fence: { retiredBefore: Date; sessionEpoch: bigint }
+  ): Promise<{ deleted: boolean; settled: { id: AgentId; orgId: OrgId }[] }>
   /** The org-owned fleet; shared cloud members are deliberately absent. */
   list(orgId: OrgId, viewer?: ViewCtx): Promise<DaemonView[]>
   /** The display/placement fleet, including install-wide cloud members. */

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -308,6 +308,11 @@ export interface DaemonRegistry {
   /** Hard-delete a daemon from the fleet (DELETE /daemons/:id). Org-fenced:
    *  throws for an absent row and for a cross-org id alike. */
   remove(orgId: OrgId, daemonId: DaemonId): Promise<void>
+  /** Hard-delete one install-wide cloud member — the row a replaced cloud Pod left behind
+   *  (`orchestrator/cloudDaemonReaper.ts`). No org owns it, so {@link DaemonRegistry.remove}
+   *  cannot reach it; the org-less-cloud shape is the fence instead, and false means the row
+   *  no longer matched rather than an error. */
+  removeCloudMember(daemonId: DaemonId): Promise<boolean>
   /** The org-owned fleet; shared cloud members are deliberately absent. */
   list(orgId: OrgId, viewer?: ViewCtx): Promise<DaemonView[]>
   /** The display/placement fleet, including install-wide cloud members. */

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -308,11 +308,12 @@ export interface DaemonRegistry {
   /** Hard-delete a daemon from the fleet (DELETE /daemons/:id). Org-fenced:
    *  throws for an absent row and for a cross-org id alike. */
   remove(orgId: OrgId, daemonId: DaemonId): Promise<void>
-  /** Hard-delete one install-wide cloud member — the row a replaced cloud Pod left behind
+  /** Claim-and-delete one install-wide cloud member — the row a replaced cloud Pod left behind
    *  (`orchestrator/cloudDaemonReaper.ts`). No org owns it, so {@link DaemonRegistry.remove}
-   *  cannot reach it; the org-less-cloud shape is the fence instead, and false means the row
-   *  no longer matched rather than an error. */
-  removeCloudMember(daemonId: DaemonId): Promise<boolean>
+   *  cannot reach it. The fence is the claim: org-less cloud shape, still silent past the same
+   *  cutoff the worklist used, still at the epoch observed there. False means the row no longer
+   *  matched — a member that came back — and nothing was deleted. */
+  removeCloudMember(daemonId: DaemonId, fence: { retiredBefore: Date; sessionEpoch: bigint }): Promise<boolean>
   /** The org-owned fleet; shared cloud members are deliberately absent. */
   list(orgId: OrgId, viewer?: ViewCtx): Promise<DaemonView[]>
   /** The display/placement fleet, including install-wide cloud members. */

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -206,8 +206,8 @@ export class DaemonRegistryService implements DaemonRegistry {
     await this.daemons.delete(orgId, daemonId)
   }
 
-  async removeCloudMember(daemonId: DaemonId): Promise<boolean> {
-    return this.daemons.deleteCloudMember(daemonId)
+  async removeCloudMember(daemonId: DaemonId, fence: { retiredBefore: Date; sessionEpoch: bigint }): Promise<boolean> {
+    return this.daemons.deleteCloudMember(daemonId, fence)
   }
 
   /** Org-fenced (org-scoped-data-layer.md §3): the repo read is filtered, so a

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -21,7 +21,7 @@ import type {
   ResourceVisibility,
   ViewCtx
 } from '../persistence/ports.js'
-import type { DaemonId, OrgId } from '../domain/ids.js'
+import type { AgentId, DaemonId, OrgId } from '../domain/ids.js'
 import type { Clock } from '../domain/clock.js'
 
 /** Coerce the stored `capabilities` JSON (defaults to `{}`) into the typed shape. */
@@ -206,8 +206,11 @@ export class DaemonRegistryService implements DaemonRegistry {
     await this.daemons.delete(orgId, daemonId)
   }
 
-  async removeCloudMember(daemonId: DaemonId, fence: { retiredBefore: Date; sessionEpoch: bigint }): Promise<boolean> {
-    return this.daemons.deleteCloudMember(daemonId, fence)
+  async retireCloudMember(
+    daemonId: DaemonId,
+    fence: { retiredBefore: Date; sessionEpoch: bigint }
+  ): Promise<{ deleted: boolean; settled: { id: AgentId; orgId: OrgId }[] }> {
+    return this.daemons.retireCloudMember(daemonId, fence)
   }
 
   /** Org-fenced (org-scoped-data-layer.md §3): the repo read is filtered, so a

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -206,6 +206,10 @@ export class DaemonRegistryService implements DaemonRegistry {
     await this.daemons.delete(orgId, daemonId)
   }
 
+  async removeCloudMember(daemonId: DaemonId): Promise<boolean> {
+    return this.daemons.deleteCloudMember(daemonId)
+  }
+
   /** Org-fenced (org-scoped-data-layer.md §3): the repo read is filtered, so a
    *  cross-org id yields null exactly like an unknown one. The runtime-profile
    *  fetch below is reached only after that fence admits the row. */

--- a/packages/control-plane/test/repo/agent-placement-delegation.test.ts
+++ b/packages/control-plane/test/repo/agent-placement-delegation.test.ts
@@ -3,6 +3,7 @@ import { prisma } from '../setup.db.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { settleCascadedUnplacement } from '../../src/persistence/repositories/agent-placement.js'
 import { PgWebchatMcpDelegationRepo } from '../../src/persistence/repositories/webchat-mcp-delegation.repo.js'
 import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
 
@@ -247,13 +248,13 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
   })
 
   it('finishes what a daemon delete cascaded, and leaves an agent placed elsewhere alone', async () => {
-    // The cloud-member reaper has to delete FIRST to claim the row atomically, so the FK gets
-    // there before the repo does: `daemonId` null, `status` untouched. Settling that is
+    // Retiring a cloud member has to delete FIRST to claim the row atomically, so the FK gets
+    // there before any repo write: `daemonId` null, `status` untouched. Settling that is
     // conditional, because a placement that landed elsewhere is not the removal's to undo.
     await fixtures()
     const agents = new PgAgentRepo(prisma)
     // Genuinely placed and serving — the seed leaves the row inactive, and `active` is the
-    // half of the state the cascade cannot touch and this method exists to correct.
+    // half of the state the cascade cannot touch and this helper exists to correct.
     await agents.setPlacement(AGENT, DAEMON)
     const before = (await prisma.agent.findUnique({ where: { id: AGENT } }))!
 
@@ -263,7 +264,7 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
       status: 'active'
     })
 
-    expect(await agents.settleCascadedUnplacement(AGENT)).toBe(true)
+    expect(await prisma.$transaction((tx) => settleCascadedUnplacement(tx, AGENT))).toBe(true)
     expect(await prisma.agent.findUnique({ where: { id: AGENT } })).toMatchObject({
       daemonId: null,
       status: 'inactive',
@@ -272,7 +273,7 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
 
     // Placed again (a peer control plane, an operator) before the sweep got here.
     await agents.setPlacement(AGENT, OTHER_DAEMON)
-    expect(await agents.settleCascadedUnplacement(AGENT)).toBe(false)
+    expect(await prisma.$transaction((tx) => settleCascadedUnplacement(tx, AGENT))).toBe(false)
     expect(await prisma.agent.findUnique({ where: { id: AGENT } })).toMatchObject({
       daemonId: OTHER_DAEMON,
       status: 'active'

--- a/packages/control-plane/test/repo/agent-placement-delegation.test.ts
+++ b/packages/control-plane/test/repo/agent-placement-delegation.test.ts
@@ -246,6 +246,39 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
     }
   })
 
+  it('finishes what a daemon delete cascaded, and leaves an agent placed elsewhere alone', async () => {
+    // The cloud-member reaper has to delete FIRST to claim the row atomically, so the FK gets
+    // there before the repo does: `daemonId` null, `status` untouched. Settling that is
+    // conditional, because a placement that landed elsewhere is not the removal's to undo.
+    await fixtures()
+    const agents = new PgAgentRepo(prisma)
+    // Genuinely placed and serving — the seed leaves the row inactive, and `active` is the
+    // half of the state the cascade cannot touch and this method exists to correct.
+    await agents.setPlacement(AGENT, DAEMON)
+    const before = (await prisma.agent.findUnique({ where: { id: AGENT } }))!
+
+    await prisma.daemon.delete({ where: { id: DAEMON } })
+    expect(await prisma.agent.findUnique({ where: { id: AGENT } })).toMatchObject({
+      daemonId: null,
+      status: 'active'
+    })
+
+    expect(await agents.settleCascadedUnplacement(AGENT)).toBe(true)
+    expect(await prisma.agent.findUnique({ where: { id: AGENT } })).toMatchObject({
+      daemonId: null,
+      status: 'inactive',
+      configRevision: before.configRevision + 1n
+    })
+
+    // Placed again (a peer control plane, an operator) before the sweep got here.
+    await agents.setPlacement(AGENT, OTHER_DAEMON)
+    expect(await agents.settleCascadedUnplacement(AGENT)).toBe(false)
+    expect(await prisma.agent.findUnique({ where: { id: AGENT } })).toMatchObject({
+      daemonId: OTHER_DAEMON,
+      status: 'active'
+    })
+  })
+
   it('rolls placement and delegation revocation back together on transaction failure', async () => {
     const { input } = await fixtures()
     const delegations = new PgWebchatMcpDelegationRepo(prisma)

--- a/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
+++ b/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
@@ -2,8 +2,10 @@
 import { describe, it, expect } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { seedAgent } from '../fixtures/seed.js'
 import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
-import { DaemonId, OrgId } from '../../src/domain/ids.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
 
 const IDENTITY = 'system:serviceaccount:ac-org-example:ac-daemon'
 const INSTALL_IDENTITY = 'system:serviceaccount:agentconnect:ac-cloud-daemon'
@@ -182,10 +184,15 @@ describe('DaemonRepo cloud-member retirement', () => {
     expect((await repo.findRetiredCloudMembers(CUTOFF)).map((daemon) => daemon.id)).toEqual([fresh.id])
   })
 
-  it('deletes a retired cloud member and refuses anything that is not one', async () => {
+  it('retires a member and settles its agents in one transaction, refusing anything else', async () => {
     const repo = new PgDaemonRepo(prisma)
     const pod = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
     await prisma.daemon.update({ where: { id: pod.id }, data: { lastSeenAt: HOUR_AGO } })
+    // An agent from an ordinary org, hosted on install-wide infrastructure — the shape only a
+    // cloud member has, and the reason the settlement cannot be org-scoped.
+    const hosted = AgentId('a9999999-9999-4999-8999-999999999999')
+    await seedAgent(prisma, hosted, { daemonId: pod.id })
+    await new PgAgentRepo(prisma).setPlacement(hosted, pod.id)
     const envelope = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
     const laptop = DaemonId('88888888-8888-4888-8888-888888888888')
     await repo.provision(laptop, DEF_ORG)
@@ -194,11 +201,19 @@ describe('DaemonRepo cloud-member retirement', () => {
     }
     const fence = { retiredBefore: CUTOFF, sessionEpoch: pod.sessionEpoch }
 
-    expect(await repo.deleteCloudMember(pod.id, fence)).toBe(true)
+    expect(await repo.retireCloudMember(pod.id, fence)).toEqual({
+      deleted: true,
+      settled: [{ id: hosted, orgId: DEFAULT_ORG_ID }]
+    })
+    // The agent left the same commit as the row: unplaced AND no longer claiming to run.
+    expect(await prisma.agent.findUnique({ where: { id: hosted } })).toMatchObject({
+      daemonId: null,
+      status: 'inactive'
+    })
     // Gone, so a repeat (a peer replica sweeping the same row) is a no-op, not an error.
-    expect(await repo.deleteCloudMember(pod.id, fence)).toBe(false)
-    expect(await repo.deleteCloudMember(envelope!.id, fence)).toBe(false)
-    expect(await repo.deleteCloudMember(laptop, fence)).toBe(false)
+    expect(await repo.retireCloudMember(pod.id, fence)).toMatchObject({ deleted: false })
+    expect(await repo.retireCloudMember(envelope!.id, fence)).toMatchObject({ deleted: false })
+    expect(await repo.retireCloudMember(laptop, fence)).toMatchObject({ deleted: false })
     expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).toBeNull()
     expect(await prisma.daemon.findUnique({ where: { id: envelope!.id } })).not.toBeNull()
     expect(await prisma.daemon.findUnique({ where: { id: laptop } })).not.toBeNull()
@@ -214,17 +229,17 @@ describe('DaemonRepo cloud-member retirement', () => {
     // while the clock only moves on the first heartbeat AFTER it.
     await repo.upsertOnAuth({ daemonId: pod.id, orgId: null, agentVersion: '1.0.0' })
 
-    expect(await repo.deleteCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: observed.sessionEpoch })).toBe(
-      false
-    )
+    expect(
+      await repo.retireCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: observed.sessionEpoch })
+    ).toMatchObject({ deleted: false })
     expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).not.toBeNull()
 
     // A heartbeat is caught by the cutoff half of the same fence.
     await prisma.daemon.update({ where: { id: pod.id }, data: { lastSeenAt: new Date() } })
     const current = await repo.getUnscoped(pod.id)
-    expect(await repo.deleteCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: current!.sessionEpoch })).toBe(
-      false
-    )
+    expect(
+      await repo.retireCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: current!.sessionEpoch })
+    ).toMatchObject({ deleted: false })
     expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).not.toBeNull()
   })
 })

--- a/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
+++ b/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
@@ -182,20 +182,49 @@ describe('DaemonRepo cloud-member retirement', () => {
     expect((await repo.findRetiredCloudMembers(CUTOFF)).map((daemon) => daemon.id)).toEqual([fresh.id])
   })
 
-  it('deletes a cloud member and refuses anything that is not one', async () => {
+  it('deletes a retired cloud member and refuses anything that is not one', async () => {
     const repo = new PgDaemonRepo(prisma)
     const pod = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    await prisma.daemon.update({ where: { id: pod.id }, data: { lastSeenAt: HOUR_AGO } })
     const envelope = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
     const laptop = DaemonId('88888888-8888-4888-8888-888888888888')
     await repo.provision(laptop, DEF_ORG)
+    for (const id of [envelope!.id, laptop]) {
+      await prisma.daemon.update({ where: { id }, data: { lastSeenAt: HOUR_AGO } })
+    }
+    const fence = { retiredBefore: CUTOFF, sessionEpoch: pod.sessionEpoch }
 
-    expect(await repo.deleteCloudMember(pod.id)).toBe(true)
+    expect(await repo.deleteCloudMember(pod.id, fence)).toBe(true)
     // Gone, so a repeat (a peer replica sweeping the same row) is a no-op, not an error.
-    expect(await repo.deleteCloudMember(pod.id)).toBe(false)
-    expect(await repo.deleteCloudMember(envelope!.id)).toBe(false)
-    expect(await repo.deleteCloudMember(laptop)).toBe(false)
+    expect(await repo.deleteCloudMember(pod.id, fence)).toBe(false)
+    expect(await repo.deleteCloudMember(envelope!.id, fence)).toBe(false)
+    expect(await repo.deleteCloudMember(laptop, fence)).toBe(false)
     expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).toBeNull()
     expect(await prisma.daemon.findUnique({ where: { id: envelope!.id } })).not.toBeNull()
     expect(await prisma.daemon.findUnique({ where: { id: laptop } })).not.toBeNull()
+  })
+
+  it('refuses a member that came back between the worklist read and the delete', async () => {
+    const repo = new PgDaemonRepo(prisma)
+    const pod = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    await prisma.daemon.update({ where: { id: pod.id }, data: { lastSeenAt: HOUR_AGO } })
+    const observed = (await repo.findRetiredCloudMembers(CUTOFF))[0]!
+
+    // Re-auth is the case `lastSeenAt` alone cannot catch: it bumps the epoch atomically,
+    // while the clock only moves on the first heartbeat AFTER it.
+    await repo.upsertOnAuth({ daemonId: pod.id, orgId: null, agentVersion: '1.0.0' })
+
+    expect(await repo.deleteCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: observed.sessionEpoch })).toBe(
+      false
+    )
+    expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).not.toBeNull()
+
+    // A heartbeat is caught by the cutoff half of the same fence.
+    await prisma.daemon.update({ where: { id: pod.id }, data: { lastSeenAt: new Date() } })
+    const current = await repo.getUnscoped(pod.id)
+    expect(await repo.deleteCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: current!.sessionEpoch })).toBe(
+      false
+    )
+    expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).not.toBeNull()
   })
 })

--- a/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
+++ b/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
@@ -145,3 +145,57 @@ describe('DaemonRepo.resolveClusterIdentity', () => {
     expect(await prisma.daemon.count({ where: { clusterIdentity: INSTALL_IDENTITY } })).toBe(2)
   })
 })
+
+describe('DaemonRepo cloud-member retirement', () => {
+  const HOUR_AGO = new Date(Date.now() - 60 * 60_000)
+  const CUTOFF = new Date(Date.now() - 15 * 60_000)
+
+  it('finds only the org-less cloud rows silent past the cutoff', async () => {
+    const repo = new PgDaemonRepo(prisma)
+    const gone = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    const serving = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_B)
+    await prisma.daemon.update({ where: { id: gone.id }, data: { lastSeenAt: HOUR_AGO } })
+    await prisma.daemon.update({ where: { id: serving.id }, data: { lastSeenAt: new Date() } })
+    // Neither of these is a cloud member: an envelope daemon is bound to a namespace rather
+    // than a Pod, and a laptop has no identity at all. Both are long silent regardless.
+    const envelope = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
+    const laptop = DaemonId('77777777-7777-4777-8777-777777777777')
+    await repo.provision(laptop, DEF_ORG)
+    for (const id of [envelope!.id, laptop]) {
+      await prisma.daemon.update({ where: { id }, data: { lastSeenAt: HOUR_AGO } })
+    }
+
+    const retired = await repo.findRetiredCloudMembers(CUTOFF)
+
+    expect(retired.map((daemon) => daemon.id)).toEqual([gone.id])
+  })
+
+  it('judges a member that never heartbeated by its own age', async () => {
+    const repo = new PgDaemonRepo(prisma)
+    const fresh = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+
+    // Authenticated and died before its first beat: `lastSeenAt` stays null forever, so a
+    // brand-new row must survive the sweep and an old one must not.
+    expect(await repo.findRetiredCloudMembers(CUTOFF)).toEqual([])
+    await prisma.daemon.update({ where: { id: fresh.id }, data: { createdAt: HOUR_AGO } })
+
+    expect((await repo.findRetiredCloudMembers(CUTOFF)).map((daemon) => daemon.id)).toEqual([fresh.id])
+  })
+
+  it('deletes a cloud member and refuses anything that is not one', async () => {
+    const repo = new PgDaemonRepo(prisma)
+    const pod = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    const envelope = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
+    const laptop = DaemonId('88888888-8888-4888-8888-888888888888')
+    await repo.provision(laptop, DEF_ORG)
+
+    expect(await repo.deleteCloudMember(pod.id)).toBe(true)
+    // Gone, so a repeat (a peer replica sweeping the same row) is a no-op, not an error.
+    expect(await repo.deleteCloudMember(pod.id)).toBe(false)
+    expect(await repo.deleteCloudMember(envelope!.id)).toBe(false)
+    expect(await repo.deleteCloudMember(laptop)).toBe(false)
+    expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).toBeNull()
+    expect(await prisma.daemon.findUnique({ where: { id: envelope!.id } })).not.toBeNull()
+    expect(await prisma.daemon.findUnique({ where: { id: laptop } })).not.toBeNull()
+  })
+})

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -191,7 +191,7 @@ export default function DaemonDetailView() {
         {/* action bar — status-aware: online ⇒ restart/upgrade, offline ⇒ reconnect;
             hidden while a lifecycle op is in flight (the pending badge above shows it). */}
         <div className="flex gap-2 bg-(--surface-card) px-4 pb-4">
-          {offline && !pending && (
+          {offline && !pending && daemon.canEdit && (
             <button
               onClick={() => openModal('reconnectDaemon', daemon)}
               className="flex h-11 flex-1 cursor-pointer items-center justify-center gap-2 rounded-md border border-(--border-default) bg-(--surface-card) font-sans text-[14px] font-semibold leading-normal text-(--text-primary)"
@@ -468,7 +468,7 @@ export default function DaemonDetailView() {
         </div>
 
         {/* delete — offline-only, matching the desktop menu's guard */}
-        {offline && !pending && (
+        {offline && !pending && daemon.canEdit && (
           <div className="mx-4 mt-3">
             <button
               onClick={() => openModal('deleteDaemon', daemon)}
@@ -533,7 +533,9 @@ export default function DaemonDetailView() {
             </span>
           </div>
         </div>
-        <div className="relative flex-none">
+        {/* No menu at all when the caller may do none of it (a cloud member is nobody's to
+            edit, restart or detach) — an empty popover is worse than a missing button. */}
+        <div className={daemon.canEdit || canRestart ? 'relative flex-none' : 'hidden'}>
           <button className="iconbtn" onClick={() => setMenuOpen((v) => !v)} title="Daemon actions">
             <Icon name="ellipsis" size={16} />
           </button>
@@ -565,7 +567,7 @@ export default function DaemonDetailView() {
                     Restart
                   </button>
                 )}
-                {offline && !pending && (
+                {offline && !pending && daemon.canEdit && (
                   <>
                     <button
                       className="dmi"

--- a/packages/web/src/components/console/views/DaemonsView.cloud.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.cloud.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment happy-dom
+/**
+ * A cloud member is a Pod: the pool rolls, every replacement mints another daemon row, and
+ * all of them are visible to every org. Listed one card each, a healthy 3-replica deployment
+ * read as a dozen look-alike "daemons" nobody could rename, restart or delete. The page
+ * therefore shows the pool as ONE entry — and the machines someone actually connected as
+ * theirs.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent, DaemonRow } from '@/lib/data'
+
+const mocks = vi.hoisted(() => ({
+  daemons: [] as unknown[],
+  agents: [] as unknown[],
+  push: vi.fn()
+}))
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mocks.push }) }))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-cloud' }, myRole: 'viewer', orgPath: (p: string) => `/acme${p}` })
+}))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    daemons: mocks.daemons,
+    daemonsLoading: false,
+    agents: mocks.agents,
+    refreshDaemons: vi.fn(async () => {}),
+    renameDaemon: vi.fn()
+  })
+}))
+vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: vi.fn() }) }))
+
+const DaemonsView = (await import('./DaemonsView')).default
+
+function daemon(over: Partial<DaemonRow>): DaemonRow {
+  return {
+    daemonId: 'd',
+    cloud: false,
+    name: 'edge-1',
+    version: '1.41.0',
+    latestVersion: '1.41.0',
+    releaseChannel: 'latest',
+    upgradeAvailable: false,
+    availableVersions: [],
+    lifecycleOp: null,
+    lifecycleStatus: null,
+    canManageLifecycle: false,
+    status: 'online',
+    host: 'edge-1',
+    cpu: 10,
+    mem: 20,
+    caps: { platforms: [], runtimes: [], acp: true, features: [] },
+    runtimeModels: [],
+    mcpServers: [],
+    activeSessions: '0',
+    conns: '4',
+    uptime: '1m',
+    createdBy: '',
+    createdAt: '',
+    lastModifiedBy: '',
+    lastModifiedAt: '',
+    sessionRetention: '7d',
+    visibility: 'org',
+    sharedWith: [],
+    canEdit: false,
+    canManageSharing: false,
+    ...over
+  } as DaemonRow
+}
+
+/** A cloud member as the CP reports it: org-less, named after its Pod. `daemonFromDto`
+ *  relabels it, which is why the pod name lives in `host` alone. */
+const member = (id: string, over: Partial<DaemonRow> = {}): DaemonRow =>
+  daemon({ daemonId: id, cloud: true, name: 'AgentConnect Cloud', host: `cloud-daemon-${id}`, ...over })
+
+const onCloud = (id: string, daemonId: string): Agent => ({ id, daemon: daemonId }) as Agent
+
+function render(): string {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root: Root = createRoot(host)
+  act(() => {
+    root.render(<DaemonsView />)
+  })
+  const html = host.innerHTML
+  act(() => root.unmount())
+  host.remove()
+  return html
+}
+
+beforeEach(() => {
+  mocks.daemons = []
+  mocks.agents = []
+  mocks.push.mockClear()
+})
+
+describe('DaemonsView cloud pool', () => {
+  it('shows one Cloud entry for the whole pool, however many Pods are in it', () => {
+    mocks.daemons = [member('p1'), member('p2'), member('p3', { status: 'offline' })]
+
+    const html = render()
+
+    expect(html.match(/AgentConnect Cloud/g)).toHaveLength(1)
+    // Serving nodes only: a row left behind by a replaced Pod must not inflate the count.
+    expect(html).toContain('2 nodes')
+    // Pod identity is cluster churn — never a name this page puts in front of anyone.
+    expect(html).not.toContain('cloud-daemon-p1')
+  })
+
+  it('counts the agents across every member, not just the one it links to', () => {
+    mocks.daemons = [member('p1'), member('p2')]
+    mocks.agents = [onCloud('a1', 'p1'), onCloud('a2', 'p2'), onCloud('a3', 'p2')]
+
+    const html = render()
+
+    expect(html).toContain('agents on Cloud')
+    expect(html).toContain('>3<')
+  })
+
+  it('reads offline only when no member is serving', () => {
+    mocks.daemons = [member('p1', { status: 'offline' }), member('p2', { status: 'offline' })]
+
+    const html = render()
+
+    expect(html).toContain('no nodes serving')
+    expect(html).not.toContain('nodes ·')
+  })
+
+  it('keeps the org’s own machines as their own cards under a labelled section', () => {
+    mocks.daemons = [member('p1'), daemon({ daemonId: 'own', name: 'pc.dev' })]
+
+    const html = render()
+
+    expect(html).toContain('pc.dev')
+    expect(html).toContain('Daemons')
+  })
+
+  it('offers no per-member actions — the pool is nobody’s to rename or detach', () => {
+    mocks.daemons = [member('p1', { status: 'offline' })]
+
+    const html = render()
+
+    expect(html).not.toContain('Daemon actions')
+    expect(html).not.toContain('Delete')
+  })
+
+  it('opens a serving member for the runtimes the pool offers', () => {
+    mocks.daemons = [member('dead', { status: 'offline' }), member('serving')]
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root: Root = createRoot(host)
+    act(() => {
+      root.render(<DaemonsView />)
+    })
+    act(() => {
+      host.querySelector<HTMLElement>('.card.click')?.click()
+    })
+    act(() => root.unmount())
+    host.remove()
+
+    expect(mocks.push).toHaveBeenCalledWith('/acme/daemons/serving')
+  })
+
+  it('still shows the empty state when there is no daemon of any kind', () => {
+    const html = render()
+
+    expect(html).toContain('No daemons connected')
+  })
+})

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { ApiError, ensureClusterExecution } from '@/lib/api'
-import { presentedDaemonStatus, status, type DaemonRow } from '@/lib/data'
+import { CLOUD_DAEMON_LABEL, cloudFleetStatus, presentedDaemonStatus, status, type DaemonRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useModal } from '@/components/console/ModalProvider'
 import { RestrictedLock } from '@/components/console/VisibilityField'
@@ -75,9 +75,24 @@ export default function DaemonsView() {
     return map
   }, [agents])
 
-  // Fleet summary for the mobile-only strip below.
-  const online = daemons.filter((d) => d.status === 'online').length
-  const paused = daemons.length - online
+  // The cloud pool is ONE entry, not one card per Pod: its members are install-wide
+  // infrastructure every org sees, replaced without notice, and nothing here is the
+  // org's to rename or detach. Everything else is a machine someone connected.
+  const cloudMembers = useMemo(() => daemons.filter((d) => d.cloud), [daemons])
+  const ownDaemons = useMemo(() => daemons.filter((d) => !d.cloud), [daemons])
+  const cloudAgents = useMemo(() => {
+    const memberIds = new Set(cloudMembers.map((m) => m.daemonId))
+    return agents.filter((a) => memberIds.has(a.daemon)).length
+  }, [agents, cloudMembers])
+
+  // Fleet summary for the mobile-only strip below — counted over what the page SHOWS,
+  // so the pool contributes one entry rather than one per member.
+  const shownStatuses = [
+    ...(cloudMembers.length > 0 ? [cloudFleetStatus(cloudMembers)] : []),
+    ...ownDaemons.map((d) => d.status)
+  ]
+  const online = shownStatuses.filter((s) => s === 'online').length
+  const paused = shownStatuses.length - online
 
   return (
     <div className="wrap px-4 pt-[14px] pb-1 desktop:p-0">
@@ -123,13 +138,92 @@ export default function DaemonsView() {
               {paused} paused
             </span>
           </div>
-          <div className="grid grid-cols-1 gap-3 desktop:grid-cols-3 desktop:gap-[14px]">
-            {daemons.map((m) => (
-              <DaemonCard key={m.daemonId} m={m} hosted={hostedByDaemon.get(m.daemonId) ?? 0} />
-            ))}
-          </div>
+          {cloudMembers.length > 0 && <CloudFleetCard members={cloudMembers} hosted={cloudAgents} />}
+          {ownDaemons.length > 0 && (
+            <>
+              {/* The section label earns its place only next to the Cloud entry — without
+                  one there is nothing to tell these cards apart from. */}
+              {cloudMembers.length > 0 && (
+                <div className="mt-6 mb-[9px] flex min-h-[26px] items-center gap-[9px]">
+                  <span className="font-sans text-[13px] font-semibold leading-normal">Daemons</span>
+                  <span className="mono text-[11.5px] text-(--text-tertiary)">{ownDaemons.length}</span>
+                </div>
+              )}
+              <div className="grid grid-cols-1 gap-3 desktop:grid-cols-3 desktop:gap-[14px]">
+                {ownDaemons.map((m) => (
+                  <DaemonCard key={m.daemonId} m={m} hosted={hostedByDaemon.get(m.daemonId) ?? 0} />
+                ))}
+              </div>
+            </>
+          )}
         </>
       )}
+    </div>
+  )
+}
+
+/**
+ * The whole cloud pool as one entry (design: the Infra screen's `cloudSlot`).
+ *
+ * Deliberately nothing per-member: a member is a Pod, so its name, host, CPU and memory
+ * are cluster churn no reader outside the cluster can act on, and a card each turned a
+ * rolling deployment into a fleet of look-alike daemons. What is true of the pool is what
+ * shows — is it serving, on what release, and how many agents run there.
+ *
+ * No utilization bar and no "Manage": the design's are a billing plan's included-usage and
+ * upgrade path, and inventing either from load telemetry would read as a real quota.
+ */
+function CloudFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: number }) {
+  const { orgPath } = useOrgs()
+  const router = useRouter()
+  const s = status(cloudFleetStatus(members))
+  const serving = members.filter((m) => m.status === 'online')
+  const online = serving.length > 0
+  // The serving members share a release (they roll together); an idle pool has no version
+  // worth quoting, so the strip drops it rather than naming a Pod that is gone.
+  const meta = online
+    ? `Managed by AgentConnect · ${serving.length} node${serving.length === 1 ? '' : 's'} · ${serving[0]!.version}`
+    : 'Managed by AgentConnect · no nodes serving'
+  // Opens one member's detail for the runtimes, models and MCP servers the pool offers —
+  // a serving one, since a member that stopped answering can no longer describe itself.
+  const target = serving[0] ?? members[members.length - 1]!
+
+  return (
+    <div
+      className="card click flex items-center gap-3 overflow-visible p-[14px] max-desktop:rounded-lg desktop:gap-[14px] desktop:px-4 desktop:py-[15px]"
+      onClick={() => router.push(orgPath(`/daemons/${target.daemonId}`))}
+    >
+      <span className="relative flex h-10 w-10 flex-none items-center justify-center rounded-md bg-(--brand-soft) desktop:h-9 desktop:w-9">
+        <Icon name="cloud" size={20} color={online ? 'var(--brand)' : 'var(--text-tertiary)'} />
+        {/* Mobile puts the status dot on the avatar corner; desktop shows it inline after the name. */}
+        <span
+          className="absolute -right-[3px] -bottom-[3px] h-3 w-3 rounded-full border-2 border-(--surface-card) desktop:hidden"
+          style={{ background: s.dot }}
+        />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-[2px] desktop:gap-0">
+        <div className="flex min-w-0 items-center gap-[6px] desktop:gap-2">
+          <span className="truncate font-sans text-[14px] font-semibold leading-normal desktop:text-[13.5px]">
+            {CLOUD_DAEMON_LABEL}
+          </span>
+          <span className="dot hidden flex-none desktop:inline-block" style={{ background: s.dot }} />
+        </div>
+        <div className="truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary) desktop:text-[11.5px] desktop:leading-[1.5]">
+          {meta}
+          <span className="desktop:hidden">{` · ${hosted} agent${hosted === 1 ? '' : 's'}`}</span>
+        </div>
+      </div>
+      <div className="hidden flex-none text-right desktop:block">
+        <div className="mono text-[14px] leading-normal font-semibold">{hosted}</div>
+        <div className="font-sans text-[10.5px] font-normal leading-normal text-(--text-tertiary)">agents on Cloud</div>
+      </div>
+      <span
+        className="badge flex-none max-desktop:px-[10px] max-desktop:py-[3px] max-desktop:text-[12px]"
+        style={{ background: s.bg, color: s.text }}
+      >
+        {s.label}
+      </span>
+      <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="desktop:hidden" />
     </div>
   )
 }
@@ -163,6 +257,7 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
   const pending = m.lifecycleOp?.status === 'pending'
   const canRestart = online && !pending && m.canManageLifecycle
   const canUpgrade = canRestart && m.upgradeAvailable
+  const hasActions = m.canEdit || canRestart
 
   const beginEdit = () => {
     setDraft(m.name)
@@ -228,8 +323,8 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
             ) : (
               <span
                 onClick={(e) => e.stopPropagation()}
-                onDoubleClick={beginEdit}
-                title="Double-click to rename"
+                onDoubleClick={m.canEdit ? beginEdit : undefined}
+                title={m.canEdit ? 'Double-click to rename' : undefined}
                 className="hidden min-w-0 truncate font-sans text-[14px] font-semibold leading-normal desktop:block"
               >
                 {m.name}
@@ -266,7 +361,9 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
           {s.label}
         </span>
         <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="desktop:hidden" />
-        <div className="relative hidden flex-none desktop:block">
+        {/* Hidden outright when the caller may do none of it — an empty menu is worse than
+            no menu, and every item here is refused by the CP without edit rights. */}
+        <div className={hasActions ? 'relative hidden flex-none desktop:block' : 'hidden'}>
           <button
             className="iconbtn h-7 w-7"
             onClick={(e) => {
@@ -287,16 +384,18 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
                 className="fixed inset-0 z-[45]"
               />
               <div className="dmenu" onClick={(e) => e.stopPropagation()}>
-                <button
-                  className="dmi"
-                  onClick={() => {
-                    setMenuOpen(false)
-                    beginEdit()
-                  }}
-                >
-                  <Icon name="pencil" size={15} />
-                  Rename
-                </button>
+                {m.canEdit && (
+                  <button
+                    className="dmi"
+                    onClick={() => {
+                      setMenuOpen(false)
+                      beginEdit()
+                    }}
+                  >
+                    <Icon name="pencil" size={15} />
+                    Rename
+                  </button>
+                )}
                 {canRestart && (
                   <button
                     className="dmi"
@@ -309,7 +408,7 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
                     Restart
                   </button>
                 )}
-                {offline && !pending && (
+                {offline && !pending && m.canEdit && (
                   <>
                     <button
                       className="dmi"

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -15,7 +15,7 @@ import type {
   SessionImage,
   Workspace
 } from '@/lib/data'
-import { isSelfSender, lifecycleStatus, MOCK_MODE } from '@/lib/data'
+import { CLOUD_DAEMON_LABEL, isSelfSender, lifecycleStatus, MOCK_MODE } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
 import {
@@ -1038,6 +1038,9 @@ export interface DaemonViewDto {
    *  `status` is expiry-projected server-side. The console tracks its OWN command by `id`. */
   lifecycleOp: DaemonLifecycleOpDto | null
   status: string
+  /** An install-wide cloud member — managed infrastructure shared by every org, one row
+   *  per cloud-daemon Pod. Absent from an older CP ⇒ treat as a plain daemon. */
+  cloud?: boolean
   health: string
   capabilities: DaemonCapabilitiesDto
   runtimeProfiles: RuntimeProfileDto[]
@@ -2028,12 +2031,16 @@ export function mergeSessionDetailUsage(local: Session, detail: Session | null):
 }
 
 export function daemonFromDto(d: DaemonViewDto): DaemonRow {
+  const cloud = d.cloud ?? false
   return {
     daemonId: d.daemonId,
+    cloud,
     // Display label: the daemon name (the CP seeds it from the hostname on first
     // register, so a connected daemon always has one), else a short id for a
-    // provisioned-but-never-connected row. Never the raw hostname.
-    name: d.name || d.daemonId.slice(0, 8),
+    // provisioned-but-never-connected row. Never the raw hostname. A cloud member's
+    // name is its Pod, which is meaningless outside the cluster and changes on every
+    // roll — the pool is one managed thing everywhere it is named, so use that label.
+    name: cloud ? CLOUD_DAEMON_LABEL : d.name || d.daemonId.slice(0, 8),
     version: d.agentVersion || PLACEHOLDER,
     latestVersion: d.latestVersion,
     releaseChannel: d.releaseChannel,

--- a/packages/web/src/lib/daemon-notifications.test.tsx
+++ b/packages/web/src/lib/daemon-notifications.test.tsx
@@ -37,6 +37,7 @@ const mockDaemon = (id: string, name: string, op?: DaemonRow['lifecycleOp']): Da
   lifecycleOp: op ?? null,
   canManageLifecycle: true,
   status: 'online',
+  cloud: false,
   lifecycleStatus: null,
   host: 'localhost',
   cpu: 10,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -55,6 +55,16 @@ export function presentedDaemonStatus(daemon: Pick<DaemonRow, 'status' | 'lifecy
   return daemon.lifecycleStatus ?? daemon.status
 }
 
+/** What every surface calls an install-wide cloud member. The CP names those rows after the
+ *  Pod they run in, which is churn nobody outside the cluster should read: the pool is one
+ *  managed thing, so `daemonFromDto` labels each member with this instead. */
+export const CLOUD_DAEMON_LABEL = 'AgentConnect Cloud'
+
+/** The Cloud entry stands in for the whole pool: online while any member is serving. */
+export function cloudFleetStatus(members: Pick<DaemonRow, 'status'>[]): ConnectionStatusKey {
+  return members.some((m) => m.status === 'online') ? 'online' : 'offline'
+}
+
 // An agent runs *inside* its owning daemon, so it can't really be online when that
 // daemon is offline. A planned restart/upgrade is different: placement and sessions
 // remain intact while the daemon drains and relaunches, so carry that explicit amber
@@ -1847,6 +1857,10 @@ export interface DaemonRow {
   canManageLifecycle: boolean
   /** Actual daemon connection/readiness. Never replaced by a presentation-only lifecycle state. */
   status: ConnectionStatusKey
+  /** An install-wide cloud member: managed infrastructure every org shares, one row per
+   *  cloud-daemon Pod. The daemons page collapses the whole pool into one Cloud entry, and
+   *  nothing here is the org's to rename, restart, or detach (`canEdit` is false). */
+  cloud: boolean
   /** Planned lifecycle presentation while the durable operation is pending. */
   lifecycleStatus: LifecycleStatusKey | null
   host: string


### PR DESCRIPTION
`https://test-app.agentconnect.md/agentconnect/daemons` listed the shared cloud pool as a dozen ordinary daemons named after Pods — none of them renameable, restartable or deletable, because the org-fenced routes cannot name an org-less row. This makes the pool one entry and deletes the rows replaced Pods leave behind.

## 1 · One "AgentConnect Cloud" entry

`GET /daemons` now reports `cloud` (true when `Daemon.orgId` is null — an install-wide member, one row per reviewed Pod UID), and the console collapses every member into the design's `cloudSlot` row: status, `Managed by AgentConnect · N nodes · <release>`, and an agents-on-Cloud count aggregated across members. The org's own machines keep their cards under a `Daemons` label.

- `daemonFromDto` labels every member **AgentConnect Cloud**, so breadcrumbs, global search, agent cards and the detail title stop quoting a Pod name that changes on every roll. The Pod stays in `host`, where it is unambiguous.
- The node count is **serving** members only — rows left behind by replaced Pods cannot inflate it, and an idle pool says `no nodes serving`.
- No utilization bar and no Manage button: the design's are a billing plan's included usage and upgrade path, and deriving either from load telemetry would read as a real quota.
- Delete / reconnect / rename are gated on `canEdit` in the list and the detail view, and the actions menu is hidden when it would be empty.

Per-org **operator envelope** daemons (`ac-daemon-*`) deliberately keep their own card: one stable row per org, and legitimately the org's to rename and restart.

## 2 · Retiring the leftovers

`CloudDaemonReaper` sweeps every 5 minutes and nominates members unheard-from for 15. Staleness comes from `lastSeenAt`, not this process's connection index — with several CP replicas the socket may be a peer's, and the heartbeat write is the only common ground.

The sweep only nominates; **the delete is the claim**. `deleteCloudMember(id, { retiredBefore, sessionEpoch })` carries the whole fence in one statement: the org-less cloud shape, the *same* cutoff the worklist selected on (one shared `retiredCloudMemberWhere`, so the predicate that nominates and the one that acts cannot drift), and the epoch observed there. The epoch is what closes the reconnect race — `upsertOnAuth` bumps it atomically, while `lastSeenAt` only moves on the first heartbeat *after* one, so a member that just came back is fresh by epoch before it is fresh by clock. A refused claim writes nothing.

Only a won claim reaches the settlement, which runs the same sequence as an operator's detach (relay revoke, collaboration push, hook re-converge) and spans **every** org whose agents were placed there. The placement half is conditional: `AgentRepo.settleCascadedUnplacement` finishes what the FK's `SetNull` started only while the agent is still unplaced, so a concurrent reassignment is never nulled. A bare delete would instead leave agents reading `active` with nowhere to run.

Armed only where cluster tokens are accepted: nowhere else can a cloud member exist.

## Why the rows piled up

Cloud Pods could not reconnect — `auth` went through the org-scoped frame path, and frame mode is learned from `auth/ok` and outlives the socket, so from the second connect onward the daemon refused its own auth. That fix landed independently as #947 while this branch was in review, so this PR carries no daemon change; the branch is rebased on it.

## Verification

- control-plane: `test:unit` 1,673 ✓, `test:int` (real Postgres) ✓ — including new repo coverage that the worklist finds only org-less cloud rows silent past the cutoff, judges a never-heartbeated member by its own age, refuses to delete an envelope daemon or a laptop, refuses a claim after a re-auth bumps the epoch **and** after a heartbeat refreshes the clock, and settles a cascaded unplacement only while the agent is still unplaced.
- web: 1,532 ✓ — including `DaemonsView.cloud.test.tsx` (one entry per pool however many Pods, no Pod names, agents summed across members, `no nodes serving`, no per-member actions).
- typecheck + lint clean.

No live screenshot: the daemons page needs an authenticated stack, and `packages/web/STYLE.md` puts visual verification in a central pass. The card composes the same `card click` / badge / dot classes as the existing daemon card.

On test-app the reaper clears the 14 stale rows on its first tick after the CP starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
