### PR TITLE
fix(daemon): reconnect cloud authentication

### DIFF
--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -390,7 +390,8 @@ export class CpClient {
     if (this.lastAuthedEpoch > 0) {
       authPayload.resume = { lastEpoch: this.lastAuthedEpoch }
     }
-    const authOk = await this.request('auth', authPayload)
+    const auth = buildEnvelope('auth', authPayload)
+    const authOk = await this.correlator.request(auth, (encoded) => expectedTransport.send(encoded))
     const ok = authOk.payload as {
       daemonId: string
       sessionEpoch: number
@@ -775,15 +776,7 @@ export class CpClient {
     return this.correlator.request(frame, (e) => this.transport!.send(e))
   }
 
-  /**
-   * `gitcred/request` (D→C REQ) → grant payload. The FIRST post-handshake
-   * daemon-issued REQ, so unlike the handshake `request()` it is state-GATED:
-   * outside READY/DRAINING it fails immediately (the credential cache degrades
-   * to its unexpired copy or errors) — never queued, never a bare
-   * `transport!.send` on a dead socket. Single send + 10s budget: the default
-   * 5s×5 retransmit would blow every git-side timeout, and CP-side mint
-   * single-flight makes a later fresh request cheap anyway.
-   */
+  /** Request a short-lived git credential only while connected, with one send and a 10s timeout. */
   async requestGitCred(payload: GitCredRequest): Promise<GitCredGrant> {
     if ((this.state !== 'READY' && this.state !== 'DRAINING') || !this.transport) {
       throw new WireError('INTERNAL', `control plane unreachable (client ${this.state})`, true)

--- a/packages/daemon/test/cp/client-reconnect.test.ts
+++ b/packages/daemon/test/cp/client-reconnect.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { buildEnvelope } from '@agentconnect.md/protocol'
 import { CpClient, type CpClientDeps } from '../../src/cp/client.js'
 import { FakeTransport } from './fake-transport.js'
 import { FakeClock } from './fake-clock.js'
@@ -83,6 +84,64 @@ describe('CpClient reconnect', () => {
     clock.advance(1000)
     await tick()
     expect(connect).toHaveBeenCalledTimes(2)
+  })
+
+  it('authenticates without an organization after a frame-scoped connection drops', async () => {
+    const clock = new FakeClock()
+    const transports: FakeTransport[] = []
+    const connect = vi.fn(async () => {
+      const transport = new FakeTransport()
+      transports.push(transport)
+      return transport
+    })
+    const client = new CpClient(deps(connect, clock))
+    client.start()
+    await tick()
+
+    const first = transports[0]!
+    const firstAuth = first.lastSent()
+    first.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'auth/ok',
+          {
+            daemonId: DAEMON_ID,
+            sessionEpoch: 1,
+            heartbeatSec: 15,
+            serverTime: '2026-08-14T00:00:00.000Z',
+            organizationMode: 'frame'
+          },
+          { corr: firstAuth.id }
+        )
+      )
+    )
+    await tick()
+    const register = first.lastSent()
+    first.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'register/ok',
+          {
+            routingEpoch: 1,
+            assignments: [],
+            crons: [],
+            leases: [],
+            drop: { assignments: [], crons: [] }
+          },
+          { corr: register.id }
+        )
+      )
+    )
+    await tick()
+    expect(client.state).toBe('READY')
+
+    first.simulateClose(1012, 'restarting')
+    clock.advance(1000)
+    await tick()
+
+    const reconnectAuth = transports[1]!.lastSent()
+    expect(reconnectAuth.type).toBe('auth')
+    expect(reconnectAuth.orgId).toBeUndefined()
   })
 
   it('does NOT reconnect after a 4401 close', async () => {


### PR DESCRIPTION
## What changed

- build the daemon `auth` handshake as an install-scoped envelope instead of passing it through organization-scoped frame construction
- bind the authentication request to the transport for the current handshake
- add regression coverage for reconnecting after a frame-scoped cloud daemon connection drops

## Why

After a cloud daemon completed its first handshake, it retained `organizationMode: frame`. A later reconnect routed the member-scoped `auth` frame through `scopedFrame()`, which incorrectly required an organization and failed locally with `cannot resolve organization for auth` before sending anything to the control plane.

## Impact

Cloud daemons can authenticate again after a WebSocket interruption without requiring a Pod restart.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/cp/client-*.test.ts` (76 tests)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- ESLint on changed files and the repository pre-push hook
- Prettier check
- `git diff --check`