### PR TITLE
feat(daemon): hold duty leases and serve only the agents they cover

### DIFF
--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -171,9 +171,15 @@ export const ConfigSchema = z.object({
    * never negotiated through the control plane or placed on the message hot path. */
   features: z
     .object({
-      turnFinalContextRefresh: z.boolean().default(true)
+      turnFinalContextRefresh: z.boolean().default(true),
+      // Duty leases decide which agents this daemon serves (k8s pools). The
+      // exchange itself always runs on an install-wide connection — the ledger
+      // needs the digest to converge — but ENFORCEMENT is opt-in: until this is
+      // on, a duty grant/revoke only moves bookkeeping, so the ledger can be
+      // observed converging before it gates a single platform connection.
+      dutyEnforcement: z.boolean().default(false)
     })
-    .default({ turnFinalContextRefresh: true }),
+    .default({ turnFinalContextRefresh: true, dutyEnforcement: false }),
   sessions: z
     .object({
       // Local-DB retention for FINISHED sessions (issue #485): a session untouched

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -8,6 +8,9 @@ import type {
   AnyFrame,
   RegisterReq,
   Heartbeat,
+  HeartbeatDuties,
+  DutyGrant,
+  DutyRevoke,
   FactsRuntimeProfile,
   FactsMcpServer,
   UsageReport,
@@ -135,6 +138,21 @@ import type { Logger } from '../log.js'
  *  sites (`./cp/client.js`) keep working unchanged. */
 export { CP_SUBPROTOCOL, CP_WS_PATH } from '@agentconnect.md/protocol'
 
+// Frames that carry no org because they are daemon-level: the CP applies the
+// same list at its edge (ws/connection.ts INSTALL_WIDE_FRAME_TYPES). Duty groups
+// span orgs on one member, so grants carry a per-entry orgId instead.
+const INSTALL_WIDE_FRAME_TYPES = new Set([
+  'relay/roster',
+  'collaboration/routes',
+  'daemon/drain',
+  'daemon/restart',
+  'daemon/upgrade',
+  'config/push',
+  'duty/grant',
+  'duty/revoke',
+  'duty/release'
+])
+
 const ACK_TIMEOUT_MS = 5000
 const BACKOFF_BASE_MS = 1000
 const BACKOFF_CAP_MS = 30000
@@ -185,6 +203,10 @@ export interface CpClientDeps {
   orgForIntegration?: (integrationId: string) => string | undefined
   /** Unservable CP-rule agentIds, surfaced in heartbeat.degradedScopes. Defaults to []. */
   degradedScopes?: () => string[]
+  /** Duty-lease digest + headroom for the heartbeat (frames/duty.ts). Only read on
+   *  an install-wide (frame-mode) connection; absent ⇒ this daemon does not
+   *  participate in the ledger and the CP-side exchange stays dormant. */
+  duties?: () => HeartbeatDuties | undefined
   configApply: ConfigApply
   /** Read-only session list/history seam over the local store (§1/§12). */
   sessionRead: SessionReader
@@ -799,6 +821,29 @@ export class CpClient {
     return rep.payload as GitCredGrant
   }
 
+  /**
+   * `duty/release` (D→C REQ → `ack`) — surrender duty groups on drain instead of
+   * waiting out the CP's reassignment window. Install-wide: duty groups span
+   * orgs, so the frame carries no org (see {@link INSTALL_WIDE_FRAME_TYPES}).
+   * Best-effort by contract — a failed release just falls back to lease expiry,
+   * so callers log rather than fail the drain.
+   */
+  async releaseDuties(groupIds: string[]): Promise<void> {
+    if (groupIds.length === 0) return
+    if ((this.state !== 'READY' && this.state !== 'DRAINING') || !this.transport) {
+      throw new WireError('INTERNAL', `control plane unreachable (client ${this.state})`, true)
+    }
+    const rep = await this.request('duty/release', { groupIds })
+    if (rep.type !== 'ack') throw new WireError('INTERNAL', `expected ack, got ${rep.type}`, false)
+  }
+
+  /** How this connection is tenanted: `connection` = one org (an API-key daemon),
+   *  `frame` = install-wide, every frame carries its own org. Duty leases exist
+   *  only on the latter. */
+  organizationScope(): 'connection' | 'frame' {
+    return this.organizationMode
+  }
+
   /** Additive CP feature negotiation for rolling daemon/CP upgrades. */
   supportsServerFeature(feature: string): boolean {
     return this.serverFeatures.has(feature)
@@ -1007,14 +1052,7 @@ export class CpClient {
   }
 
   private installWideControl(type: string): boolean {
-    return (
-      type === 'relay/roster' ||
-      type === 'collaboration/routes' ||
-      type === 'daemon/drain' ||
-      type === 'daemon/restart' ||
-      type === 'daemon/upgrade' ||
-      type === 'config/push'
-    )
+    return INSTALL_WIDE_FRAME_TYPES.has(type)
   }
 
   private scopedFrame(type: string, payload: unknown, explicitOrgId?: string): AnyFrame {
@@ -1026,7 +1064,7 @@ export class CpClient {
       )
       if (agentId) orgId = this.deps.orgForAgent?.(agentId)
     }
-    if (this.organizationMode === 'frame' && !orgId) {
+    if (this.organizationMode === 'frame' && !orgId && !INSTALL_WIDE_FRAME_TYPES.has(type)) {
       throw new WireError('SCOPE_DENIED', `cannot resolve organization for ${type}`, false)
     }
     return buildEnvelope(type as Parameters<typeof buildEnvelope>[0], payload, orgId ? { orgId } : {})
@@ -1079,13 +1117,17 @@ export class CpClient {
       // Skip the send mid-drain (we report `degraded` differently), but keep the
       // loop alive so heartbeats resume once we transition DRAINING → READY.
       if (this.state === 'READY') {
+        // The duty lease exchange rides this beat (frames/duty.ts). Absent on a
+        // single-org daemon, which keeps the whole CP-side path dormant.
+        const duties = this.organizationMode === 'frame' ? this.deps.duties?.() : undefined
         this.transport?.send(
           encode(
             buildEnvelope('heartbeat', {
               load: this.deps.loadSnapshot(),
               health: 'ok',
               activeSessions: this.deps.activeSessions(),
-              degradedScopes: this.deps.degradedScopes?.() ?? []
+              degradedScopes: this.deps.degradedScopes?.() ?? [],
+              ...(duties ? { duties } : {})
             })
           )
         )
@@ -1106,6 +1148,12 @@ export class CpClient {
     switch (frame.type) {
       case 'config/push':
         this.deps.configApply.applyConfigPush((frame.payload as { keys: Record<string, unknown> }).keys)
+        return // EVT — no reply
+      case 'duty/grant':
+        this.deps.configApply.applyDutyGrant((frame.payload as DutyGrant).grants)
+        return // EVT — no reply
+      case 'duty/revoke':
+        this.deps.configApply.applyDutyRevoke((frame.payload as DutyRevoke).revocations)
         return // EVT — no reply
       case 'cron/upsert':
         try {

--- a/packages/daemon/src/cp/config-apply.ts
+++ b/packages/daemon/src/cp/config-apply.ts
@@ -34,7 +34,9 @@ import type {
   AgentPermissionRequestList,
   AgentPermissionRequestPage,
   AgentPermissionDecision,
-  SessionVisibilityPush
+  SessionVisibilityPush,
+  DutyGrantEntry,
+  DutyRevoke
 } from '@agentconnect.md/protocol'
 import { SESSION_RETENTION_RE } from '@agentconnect.md/protocol'
 import type { Config } from '../config/config-schema.js'
@@ -42,6 +44,12 @@ import type { Config } from '../config/config-schema.js'
 export interface ConfigApply {
   /** Merge whitelisted non-secret config keys (config/push EVT). */
   applyConfigPush(keys: Record<string, unknown>): void
+  /** Duty groups granted to (or re-confirmed for) this daemon — an entry
+   *  REPLACES its group (frames/duty.ts). Fire-and-forget EVT. */
+  applyDutyGrant(grants: DutyGrantEntry[]): void
+  /** Duty groups taken away: stop serving them and drop their platform
+   *  connections. Never a workspace teardown — the agent may be re-granted. */
+  applyDutyRevoke(revocations: DutyRevoke['revocations']): void
   /** Converge crons + agent specs (+ record leases) from the register/ok reconcile snapshot. */
   applyReconcileSnapshot(snap: RegisterOk): void | Promise<void>
   /** Apply a memory-only CP agent spec and resolve after live reconcile converges. */

--- a/packages/daemon/src/cp/duty-registry.ts
+++ b/packages/daemon/src/cp/duty-registry.ts
@@ -1,0 +1,114 @@
+// The daemon's view of the duty leases it holds (docs/designs — duty ledger).
+// Pure state: the heartbeat reads its digest, `duty/grant` and `duty/revoke`
+// mutate it, and the agent/bot projections drive what this daemon serves.
+// Never authoritative — the CP's ledger is, and every reconnect re-confirms
+// terms against this digest.
+import type { DutyGrantEntry, DutyRevoke, HeartbeatDuties } from '@agentconnect.md/protocol'
+
+export interface HeldDuty {
+  groupId: string
+  orgId: string
+  /** The CP-minted fencing term, as the decimal string the wire carries. */
+  term: string
+  agentIds: string[]
+  botIds: string[]
+}
+
+export interface DutyApplyResult {
+  /** Groups whose membership this daemon did not serve before. */
+  added: string[]
+  /** Groups it already held, re-granted at a new term or new composition. */
+  updated: string[]
+  /** Agents that entered service (in a granted group, in none before). */
+  agentsGained: string[]
+  /** Agents that left service (in no granted group any more). */
+  agentsLost: string[]
+}
+
+const EMPTY: DutyApplyResult = { added: [], updated: [], agentsGained: [], agentsLost: [] }
+
+export class DutyRegistry {
+  private readonly held = new Map<string, HeldDuty>()
+
+  /** Held groups with the terms this daemon believes — the heartbeat's digest. */
+  digest(): HeartbeatDuties['held'] {
+    return [...this.held.values()]
+      .map((d) => ({ groupId: d.groupId, term: d.term }))
+      .sort((a, b) => (a.groupId < b.groupId ? -1 : 1))
+  }
+
+  /** Every agent this daemon holds a duty for. */
+  agents(): Set<string> {
+    const out = new Set<string>()
+    for (const d of this.held.values()) for (const id of d.agentIds) out.add(id)
+    return out
+  }
+
+  /** Every daemon-held bot this daemon is responsible for connecting. */
+  bots(): Set<string> {
+    const out = new Set<string>()
+    for (const d of this.held.values()) for (const id of d.botIds) out.add(id)
+    return out
+  }
+
+  groupIds(): string[] {
+    return [...this.held.keys()].sort()
+  }
+
+  size(): number {
+    return this.held.size
+  }
+
+  get(groupId: string): HeldDuty | undefined {
+    return this.held.get(groupId)
+  }
+
+  holdsAgent(agentId: string): boolean {
+    for (const d of this.held.values()) if (d.agentIds.includes(agentId)) return true
+    return false
+  }
+
+  /** A grant entry REPLACES its group: a bumped term after a composition change,
+   *  or a term this daemon missed because the original EVT was lost. */
+  applyGrant(grants: DutyGrantEntry[]): DutyApplyResult {
+    if (grants.length === 0) return EMPTY
+    const before = this.agents()
+    const added: string[] = []
+    const updated: string[] = []
+    for (const g of grants) {
+      ;(this.held.has(g.groupId) ? updated : added).push(g.groupId)
+      this.held.set(g.groupId, {
+        groupId: g.groupId,
+        orgId: g.orgId,
+        term: g.term,
+        agentIds: g.members.filter((m) => m.kind === 'agent').map((m) => m.refId),
+        botIds: g.members.filter((m) => m.kind === 'bot').map((m) => m.refId)
+      })
+    }
+    return this.diff(before, { added, updated })
+  }
+
+  applyRevoke(revocations: DutyRevoke['revocations']): DutyApplyResult {
+    if (revocations.length === 0) return EMPTY
+    const before = this.agents()
+    for (const r of revocations) this.held.delete(r.groupId)
+    return this.diff(before, { added: [], updated: [] })
+  }
+
+  /** Drop everything — the local half of an explicit drain release. */
+  releaseAll(): string[] {
+    const ids = this.groupIds()
+    this.held.clear()
+    return ids
+  }
+
+  private diff(before: Set<string>, base: { added: string[]; updated: string[] }): DutyApplyResult {
+    const after = this.agents()
+    return {
+      added: base.added.sort(),
+      updated: base.updated.sort(),
+      agentsGained: [...after].filter((id) => !before.has(id)).sort(),
+      agentsLost: [...before].filter((id) => !after.has(id)).sort()
+    }
+  }
+}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -363,6 +363,7 @@ import { memoryChannelKey } from './agents/memory.js'
 import { createWorkspaceGit } from './cp/workspace-git.js'
 import { DAEMON_VERSION } from './version.js'
 import { CpCronRegistry } from './cp/cp-cron.js'
+import { DutyRegistry } from './cp/duty-registry.js'
 import { CpAgentRegistry } from './cp/cp-agent-registry.js'
 import {
   agentRemovalTombstones,
@@ -493,7 +494,10 @@ import type {
   ExternalSessionOrigin,
   ChannelAgentsOk,
   TaskList,
-  TaskListReq
+  TaskListReq,
+  DutyGrantEntry,
+  DutyRevoke,
+  HeartbeatDuties
 } from '@agentconnect.md/protocol'
 
 /** Format an error for logs, surfacing a JSON-RPC/ACP RequestError's `code` and
@@ -2127,6 +2131,10 @@ export class Daemon {
   // Discord/Telegram channel id → display-name resolver (Slack learns names in bulk
   // from its membership snapshot instead — see refreshChannels). Created in start().
   private channelNameResolver?: ChannelNameResolver
+  // Duty leases this daemon holds (k8s pools; cp/duty-registry.ts). Populated
+  // only on an install-wide connection — empty on a single-org daemon, which is
+  // what keeps the whole path dormant there.
+  private readonly duties = new DutyRegistry()
   private scheduler!: Scheduler
   private dreamScheduler!: DreamScheduler
   private sessions!: SessionManager
@@ -2481,6 +2489,13 @@ export class Daemon {
    *  (virtual) integrations are excluded so consolidation/reconcile never opens a
    *  real socket for them — and never evicts the installed virtual connections. */
   private transportAgents(agents: LoadedAgent[] = [...this.agents.values()]): LoadedAgent[] {
+    // Duty gate: on a pooled daemon only the agents whose group this member
+    // holds get physical connections — every consolidator derives from here, so
+    // opening and closing sockets on a grant/revoke needs no other change.
+    if (this.dutyEnforced()) {
+      const held = this.duties.agents()
+      agents = agents.filter((agent) => held.has(agent.id))
+    }
     if (this.evaluationIntegrationIds.size === 0) return agents
     return agents.map((agent) =>
       agent.integrations.some((integration) => this.evaluationIntegrationIds.has(integration.id))
@@ -3604,8 +3619,7 @@ export class Daemon {
     )
 
     // register crons (sync per agent — the same converge reconcile re-runs on change)
-    for (const a of agents) this.scheduler.sync(a.id, a.crons)
-    for (const a of agents) this.dreamScheduler.sync(a.id, this.dreamSchedulePolicyFor(a))
+    for (const a of agents) this.syncAgentSchedules(a)
     const cronCount = agents.reduce((n, a) => n + this.scheduler.count(a.id), 0)
     if (cronCount) this.log.info(`registered ${cronCount} cron(s)`)
 
@@ -3890,8 +3904,7 @@ export class Daemon {
       if (!wasPaused && a.pause) this.interruptAgentTurns(a.id, 'pause')
       // crons live in the whole-agent signature, so any change re-syncs the agent's
       // job set (design §5.2: crons change → Scheduler upsert/remove). Idempotent.
-      this.scheduler.sync(a.id, a.crons)
-      this.dreamScheduler.sync(a.id, this.dreamSchedulePolicyFor(a))
+      this.syncAgentSchedules(a)
       // host-spawn or workspace change → evict the cached host (once) so the next
       // session lazily re-spawns it with fresh env and/or re-materializes cwd via
       // prepareWorkspace. Soft-only and integration-only changes never touch the host.
@@ -3942,8 +3955,7 @@ export class Daemon {
       // New agent: warm its git-repo checkout in the background now (e.g. on daemon
       // start every agent is a toStart), so the repo is cloned ahead of the first message.
       this.prefetchClone(a as LoadedAgent)
-      this.scheduler.sync(a.id, a.crons)
-      this.dreamScheduler.sync(a.id, this.dreamSchedulePolicyFor(a))
+      this.syncAgentSchedules(a)
     }
     // Reconcile exactly once from the final live roster. The close phase is strict:
     // detach ACKs only after last-reference connections have actually stopped.
@@ -12592,6 +12604,70 @@ export class Daemon {
    * Slack integration. (CP agent specs are now written to disk and create a
    * runnable agent.json, so they no longer contribute a "no base" degraded scope.)
    */
+  /** The heartbeat's lease fields: what this daemon holds, and how many more
+   *  groups it will accept. Capacity is the daemon's own call (design D14). */
+  private dutyDigest(): HeartbeatDuties {
+    const max = this.cfg?.limits?.maxAgents ?? 0
+    const covered = this.duties.agents().size
+    return { held: this.duties.digest(), headroom: max > 0 ? Math.max(0, max - covered) : 32 }
+  }
+
+  /** True when duty leases actually gate service. Off (the default) the exchange
+   *  still runs and the registry still tracks — only enforcement is withheld. */
+  private dutyEnforced(): boolean {
+    // `cfg` lands in start(); transportAgents can run before that in tests.
+    return this.cfg?.features?.dutyEnforcement === true && this.cpClient?.organizationScope() === 'frame'
+  }
+
+  /** Apply a `duty/grant` EVT: bookkeeping first, then converge what we serve. */
+  private applyDutyGrant(grants: DutyGrantEntry[]): void {
+    const result = this.duties.applyGrant(grants)
+    this.log.info(
+      `duty: granted ${result.added.length} + re-granted ${result.updated.length} group(s); ` +
+        `holding ${this.duties.size()} covering ${this.duties.agents().size} agent(s)`
+    )
+    if (result.agentsGained.length > 0 || result.added.length > 0) this.onDutyChanged()
+  }
+
+  /** Apply a `duty/revoke` EVT. Losing a duty is NOT a removal: the agent's
+   *  workspace, sessions, and registry entry all survive — only the platform
+   *  connections and schedules this daemon was running for it stop. */
+  private applyDutyRevoke(revocations: DutyRevoke['revocations']): void {
+    const result = this.duties.applyRevoke(revocations)
+    this.log.info(
+      `duty: revoked ${revocations.length} group(s) (${revocations.map((r) => r.reason).join(',')}); ` +
+        `${result.agentsLost.length} agent(s) left service`
+    )
+    for (const agentId of result.agentsLost) this.stopServingAgent(agentId)
+    this.onDutyChanged()
+  }
+
+  /** Re-derive platform connections and schedules from the new duty set. */
+  private onDutyChanged(): void {
+    if (!this.dutyEnforced()) return
+    for (const agent of this.agents.values()) this.syncAgentSchedules(agent)
+    void this.reconcile().catch((err) => this.log.warn(`duty: reconcile after a duty change failed: ${err}`))
+  }
+
+  /** Arm this agent's cron + dream schedules, or disarm them when its duty lives
+   *  elsewhere — a cron is an ingress edge, so it fires only at the holder. */
+  private syncAgentSchedules(a: { id: string; crons: CronDef[]; memory?: Agent['memory'] }): void {
+    const serve = !this.dutyEnforced() || this.duties.holdsAgent(a.id)
+    this.scheduler.sync(a.id, serve ? a.crons : [])
+    this.dreamScheduler.sync(a.id, serve ? this.dreamSchedulePolicyFor(a) : undefined)
+  }
+
+  /** Stop serving one agent because its duty moved — the light teardown: no
+   *  workspace deletion, no removal tombstone, no CP-drop latch, so a re-grant
+   *  needs nothing from the CP to revive it. */
+  private stopServingAgent(agentId: string): void {
+    if (!this.dutyEnforced()) return
+    this.interruptAgentTurns(agentId, 'stop')
+    this.scheduler.unregister(agentId)
+    this.dreamScheduler.unregister(agentId)
+    void this.stopHost(agentId).catch((err) => this.log.warn(`duty: stopping host for ${agentId} failed: ${err}`))
+  }
+
   private cpDegradedScopes(): string[] {
     const out = new Set<string>()
     for (const cpRule of this.cpRouting?.effectiveRules() ?? []) {
@@ -19070,8 +19146,24 @@ export class Daemon {
     } else {
       released = drained
     }
+    // Whole-daemon drain surrenders the duty leases too: the CP can re-grant
+    // them to a survivor immediately instead of waiting out the reassign window.
+    if (drain.scope.kind === 'daemon') await this.releaseAllDuties()
     this.log.info(`drain[${drain.scope.kind}]: done — released ${released.length} session(s)`)
     return { released }
+  }
+
+  /** Hand every held duty back to the CP. Best-effort by contract — on failure
+   *  the leases simply lapse, which is the same outcome one T_reassign later. */
+  private async releaseAllDuties(): Promise<void> {
+    const groupIds = this.duties.releaseAll()
+    if (groupIds.length === 0) return
+    try {
+      await this.cpClient?.releaseDuties(groupIds)
+      this.log.info(`duty: released ${groupIds.length} group(s) on drain`)
+    } catch (err) {
+      this.log.warn(`duty: releasing ${groupIds.length} group(s) failed (leases will lapse): ${err}`)
+    }
   }
 
   /** `agent/stop` (§8.2): drain the agent's in-flight turns, stop its host, and
@@ -19766,6 +19858,8 @@ export class Daemon {
         if (applied.length) this.log.info(`cp: applied config keys: ${applied.join(', ')}`)
         if (ignored.length) this.log.warn(`cp: ignored config keys: ${ignored.join(', ')}`)
       },
+      applyDutyGrant: (grants) => this.applyDutyGrant(grants),
+      applyDutyRevoke: (revocations) => this.applyDutyRevoke(revocations),
       applyReconcileSnapshot: async (snap: RegisterOk) => {
         this.gitCommitIdentity = snap.gitCommitIdentity
         // Console-set finished-session retention — the reconnect baseline for the
@@ -20931,6 +21025,7 @@ export class Daemon {
         return agentId ? (this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId)) : undefined
       },
       degradedScopes: () => this.cpDegradedScopes(),
+      duties: () => this.dutyDigest(),
       configApply: this.cpConfigApply(),
       sessionRead: createSessionReader(
         this.store,

--- a/packages/daemon/test/cp/client-duty.test.ts
+++ b/packages/daemon/test/cp/client-duty.test.ts
@@ -1,0 +1,198 @@
+// The daemon half of the duty lease exchange on the wire: the heartbeat carries
+// the digest only on an install-wide connection, the two C→D EVTs reach
+// ConfigApply, and `duty/release` goes out as an org-less REQ.
+import { describe, it, expect, vi } from 'vitest'
+import { buildEnvelope } from '@agentconnect.md/protocol'
+import { CpClient, type CpClientDeps } from '../../src/cp/client.js'
+import { FakeTransport } from './fake-transport.js'
+import { FakeClock } from './fake-clock.js'
+
+const DAEMON_ID = '22222222-2222-4222-8222-222222222222'
+const GROUP = '11111111-1111-4111-8111-111111111111'
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const silent = { trace() {}, debug() {}, info() {}, warn() {}, error() {} }
+const tick = () => new Promise((r) => setImmediate(r))
+
+async function readyClient(over: Partial<CpClientDeps> = {}, organizationMode: 'connection' | 'frame' = 'frame') {
+  const t = new FakeTransport()
+  const clock = new FakeClock()
+  const configApply = {
+    applyConfigPush: vi.fn(),
+    applyDutyGrant: vi.fn(),
+    applyDutyRevoke: vi.fn(),
+    applyReconcileSnapshot: vi.fn(),
+    applyAgentUpsert: vi.fn(async () => ({ ok: true })),
+    applyAgentRemove: vi.fn(),
+    applyAgentDetach: vi.fn(async () => ({ ok: true })),
+    applyAgentActivate: vi.fn(async () => ({ ok: true })),
+    upsertCron: vi.fn(),
+    removeCron: vi.fn(),
+    runCron: vi.fn(() => ({ ok: true })),
+    applyRouteAssign: vi.fn(),
+    applyRouteUpdate: vi.fn(),
+    applyRelayRoster: vi.fn(),
+    applyCollabRoutes: vi.fn(),
+    applyIntegrationUpsert: vi.fn(),
+    applyIntegrationRemove: vi.fn(),
+    applyMcpServerUpsert: vi.fn(),
+    applyMcpServerRemove: vi.fn(),
+    applyMemoryConnectionUpsert: vi.fn(async () => ({ ok: true })),
+    applyMemoryConnectionRemove: vi.fn(),
+    applyAgentLaunch: vi.fn(async () => ({
+      agentId: DAEMON_ID,
+      launchId: DAEMON_ID,
+      startedAt: '2026-06-26T00:00:00.000Z',
+      runtime: 'claude'
+    })),
+    applyAgentStop: vi.fn(async () => ({ ok: true })),
+    applyDaemonDrain: vi.fn(async () => ({ released: [] })),
+    applyDaemonRestart: vi.fn(() => ({ accepted: true })),
+    applyDaemonUpgrade: vi.fn(() => ({ accepted: true }))
+  }
+  const deps: CpClientDeps = {
+    url: 'wss://cp/daemon/ws',
+    token: 't',
+    daemonId: DAEMON_ID,
+    agentVersion: '0.0.0',
+    host: 'h',
+    heartbeatDefaultMs: 15000,
+    maxAgents: 4,
+    capabilities: () => ({ platforms: ['slack'], runtimes: [], acp: true, features: [] }),
+    runtimeProfiles: () => [],
+    localState: () => ({ assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }),
+    loadSnapshot: () => ({ cpu: 0.1, mem: 0.2, agents: 1 }),
+    activeSessions: () => 0,
+    configApply: configApply as unknown as CpClientDeps['configApply'],
+    workspaceRead: {
+      list: vi.fn(async () => ({ agentId: 'a', path: '', exists: true, entries: [] })),
+      read: vi.fn(async () => ({ agentId: 'a', path: 'f', exists: false })),
+      write: vi.fn(async () => ({ agentId: 'a', path: 'f', size: 0, mtime: '2026-06-26T00:00:00.000Z' })),
+      delete: vi.fn(async () => ({ agentId: 'a', path: 'f' }))
+    } as unknown as CpClientDeps['workspaceRead'],
+    sessionRead: {
+      list: vi.fn(() => ({ sessions: [] })),
+      history: vi.fn(() => ({ sessionId: DAEMON_ID, messages: [] })),
+      toolBody: vi.fn(() => ({ sessionId: DAEMON_ID, toolCallId: 'tool', data: '', totalBytes: 0 }))
+    } as unknown as CpClientDeps['sessionRead'],
+    clock,
+    connect: async () => t,
+    log: silent,
+    jitter: () => 0,
+    ...over
+  }
+  const client = new CpClient(deps)
+  client.start()
+  await tick()
+  const auth = t.lastSent()
+  t.pushInbound(
+    JSON.stringify(
+      buildEnvelope(
+        'auth/ok',
+        {
+          daemonId: DAEMON_ID,
+          sessionEpoch: 5,
+          heartbeatSec: 15,
+          serverTime: '2026-06-26T00:00:00.000Z',
+          organizationMode
+        },
+        { corr: auth.id }
+      )
+    )
+  )
+  await tick()
+  const reg = t.lastSent()
+  t.pushInbound(
+    JSON.stringify(
+      buildEnvelope(
+        'register/ok',
+        {
+          routingEpoch: 1,
+          serverFeatures: [],
+          assignments: [],
+          crons: [],
+          leases: [],
+          drop: { assignments: [], crons: [] }
+        },
+        { corr: reg.id }
+      )
+    )
+  )
+  await tick()
+  t.sent.length = 0
+  return { t, clock, client, configApply }
+}
+
+/** Every frame the daemon has sent, decoded. */
+const outbound = (t: FakeTransport): { type: string; id: string; orgId?: string; payload: any }[] =>
+  t.sent.map((raw) => JSON.parse(raw))
+
+const beat = async (t: FakeTransport, clock: FakeClock) => {
+  clock.advance(15_000)
+  await tick()
+  return outbound(t).find((f) => f.type === 'heartbeat')
+}
+
+describe('daemon duty lease exchange', () => {
+  it('an install-wide heartbeat carries the digest and headroom', async () => {
+    const duties = vi.fn(() => ({ held: [{ groupId: GROUP, term: '2' }], headroom: 3 }))
+    const { t, clock } = await readyClient({ duties })
+
+    const hb = await beat(t, clock)
+    expect(hb?.payload).toMatchObject({ duties: { held: [{ groupId: GROUP, term: '2' }], headroom: 3 } })
+    expect(duties).toHaveBeenCalled()
+  })
+
+  it('an org-scoped daemon never sends duties, even when the getter is present', async () => {
+    const duties = vi.fn(() => ({ held: [], headroom: 4 }))
+    const { t, clock } = await readyClient({ duties }, 'connection')
+
+    const hb = await beat(t, clock)
+    expect(hb?.payload).not.toHaveProperty('duties')
+    expect(duties).not.toHaveBeenCalled()
+  })
+
+  it('a daemon with no duty getter sends a plain heartbeat (path dormant)', async () => {
+    const { t, clock } = await readyClient({})
+
+    const hb = await beat(t, clock)
+    expect(hb).toBeDefined()
+    expect(hb?.payload).not.toHaveProperty('duties')
+  })
+
+  it('duty/grant and duty/revoke reach ConfigApply as org-less EVTs, with no reply', async () => {
+    const { t, configApply } = await readyClient({})
+
+    const grants = [{ groupId: GROUP, orgId: 'org-1', term: '1', members: [{ kind: 'agent', refId: AGENT }] }]
+    t.pushInbound(JSON.stringify(buildEnvelope('duty/grant', { grants })))
+    await tick()
+    expect(configApply.applyDutyGrant).toHaveBeenCalledWith(grants)
+
+    const revocations = [{ groupId: GROUP, reason: 'superseded' }]
+    t.pushInbound(JSON.stringify(buildEnvelope('duty/revoke', { revocations })))
+    await tick()
+    expect(configApply.applyDutyRevoke).toHaveBeenCalledWith(revocations)
+
+    // EVTs: nothing goes back, in particular no SCOPE_DENIED for the missing org.
+    expect(outbound(t).filter((f) => f.type === 'error')).toEqual([])
+    expect(outbound(t).filter((f) => f.type === 'ack')).toEqual([])
+  })
+
+  it('duty/release goes out as an org-less REQ and settles on the ack', async () => {
+    const { t, client } = await readyClient({})
+
+    const done = client.releaseDuties([GROUP])
+    await tick()
+    const req = outbound(t).find((f) => f.type === 'duty/release')
+    expect(req?.payload).toEqual({ groupIds: [GROUP] })
+    expect(req?.orgId).toBeUndefined()
+
+    t.pushInbound(JSON.stringify(buildEnvelope('ack', { ok: true }, { corr: req!.id as string })))
+    await expect(done).resolves.toBeUndefined()
+  })
+
+  it('releasing nothing is a no-op — no frame at all', async () => {
+    const { t, client } = await readyClient({})
+    await client.releaseDuties([])
+    expect(outbound(t).filter((f) => f.type === 'duty/release')).toEqual([])
+  })
+})

--- a/packages/daemon/test/cp/duty-registry.test.ts
+++ b/packages/daemon/test/cp/duty-registry.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { DutyRegistry } from '../../src/cp/duty-registry.js'
+import type { DutyGrantEntry } from '@agentconnect.md/protocol'
+
+const A1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const A2 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
+const B1 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'
+const G1 = '11111111-1111-4111-8111-111111111111'
+const G2 = '22222222-2222-4222-8222-222222222222'
+
+const grant = (groupId: string, term: string, agents: string[], bots: string[] = []): DutyGrantEntry => ({
+  groupId,
+  orgId: 'org-1',
+  term,
+  members: [
+    ...agents.map((refId) => ({ kind: 'agent' as const, refId })),
+    ...bots.map((refId) => ({ kind: 'bot' as const, refId }))
+  ]
+})
+
+describe('DutyRegistry', () => {
+  it('starts empty — the digest a single-org daemon would report', () => {
+    const r = new DutyRegistry()
+    expect(r.digest()).toEqual([])
+    expect(r.agents().size).toBe(0)
+    expect(r.size()).toBe(0)
+  })
+
+  it('a grant becomes the digest, the agent set, and the bot set', () => {
+    const r = new DutyRegistry()
+    const result = r.applyGrant([grant(G1, '3', [A1], [B1])])
+
+    expect(result.added).toEqual([G1])
+    expect(result.updated).toEqual([])
+    expect(result.agentsGained).toEqual([A1])
+    expect(r.digest()).toEqual([{ groupId: G1, term: '3' }])
+    expect([...r.agents()]).toEqual([A1])
+    expect([...r.bots()]).toEqual([B1])
+    expect(r.holdsAgent(A1)).toBe(true)
+  })
+
+  it('a grant for a held group REPLACES it — new term, new composition', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1])])
+    const result = r.applyGrant([grant(G1, '2', [A1, A2])])
+
+    expect(result.added).toEqual([])
+    expect(result.updated).toEqual([G1])
+    expect(result.agentsGained).toEqual([A2])
+    expect(result.agentsLost).toEqual([])
+    expect(r.size()).toBe(1)
+    expect(r.digest()).toEqual([{ groupId: G1, term: '2' }])
+    expect([...r.agents()].sort()).toEqual([A1, A2])
+  })
+
+  it('a replacement that drops a member reports the agent as lost', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1, A2])])
+    const result = r.applyGrant([grant(G1, '2', [A1])])
+
+    expect(result.agentsLost).toEqual([A2])
+    expect(r.holdsAgent(A2)).toBe(false)
+  })
+
+  it('a revoke drops the group and its agents', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1]), grant(G2, '1', [A2])])
+    const result = r.applyRevoke([{ groupId: G1, reason: 'superseded' }])
+
+    expect(result.agentsLost).toEqual([A1])
+    expect(r.groupIds()).toEqual([G2])
+    expect([...r.agents()]).toEqual([A2])
+  })
+
+  it('an agent in two groups survives losing one of them', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1]), grant(G2, '1', [A1])])
+    const result = r.applyRevoke([{ groupId: G1, reason: 'gone' }])
+
+    expect(result.agentsLost).toEqual([])
+    expect(r.holdsAgent(A1)).toBe(true)
+  })
+
+  it('revoking an unheld group is a no-op, never a spurious loss', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1])])
+    const result = r.applyRevoke([{ groupId: G2, reason: 'gone' }])
+
+    expect(result.agentsLost).toEqual([])
+    expect(r.groupIds()).toEqual([G1])
+  })
+
+  it('the digest is sorted and stable, so a CP-side diff is order-free', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G2, '1', [A2]), grant(G1, '1', [A1])])
+    expect(r.digest().map((d) => d.groupId)).toEqual([G1, G2])
+  })
+
+  it('releaseAll empties the registry and returns what was surrendered', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1]), grant(G2, '1', [A2])])
+
+    expect(r.releaseAll()).toEqual([G1, G2])
+    expect(r.size()).toBe(0)
+    expect(r.digest()).toEqual([])
+    expect(r.agents().size).toBe(0)
+  })
+
+  it('empty grant/revoke batches change nothing', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1])])
+    expect(r.applyGrant([]).added).toEqual([])
+    expect(r.applyRevoke([]).agentsLost).toEqual([])
+    expect(r.size()).toBe(1)
+  })
+})


### PR DESCRIPTION
## What

The daemon half of the duty exchange — the loop the control plane has been running against nobody since #937/#939/#942. **Enforcement is opt-in and off by default**, so this lands as observable bookkeeping first.

- **`DutyRegistry`** (`cp/duty-registry.ts`) — the groups this daemon holds. A grant *replaces* its group, so a bumped term after a composition change and a re-issued grant after a lost EVT both converge with no special case; the registry derives the agent/bot projections everything else reads.
- **Heartbeat carries `{held digest, headroom}`** — only on an install-wide (frame-mode) connection. A single-org daemon sends byte-identical heartbeats to before, which is what keeps the CP-side path dormant for it.
- **`duty/grant` / `duty/revoke` dispatch as install-wide EVTs.** The daemon's frame set now mirrors the CP's own `INSTALL_WIDE_FRAME_TYPES`, and outbound `duty/release` is exempted from org resolution — duty groups span orgs, so grants carry a per-entry `orgId` instead.
- **`transportAgents()` is the whole gate.** All five platform consolidators re-derive from it, so sockets open on a grant and close on a revoke with zero per-platform change. Cron and dream schedules follow through one `syncAgentSchedules` helper — a cron is an ingress edge (design §4.7), so it fires only at the holder.
- **Losing a duty is not a removal.** The light teardown stops turns, schedules, and the ACP host, and deliberately never touches the workspace, the agent registry entry, the CP-drop latch, or the removal tombstone — the destructive path (`applyAgentRemove` → `rmSync` of the data root + sandbox discard) is exactly what a release must not reach, and a re-grant needs nothing from the CP to revive service.
- **Drain surrenders leases** with `duty/release` so a survivor claims immediately instead of waiting out T_reassign; best-effort by contract, since the fallback is lease expiry one window later.

## Rollout

`features.dutyEnforcement` (default `false`). The exchange always runs on a pooled daemon — the ledger needs the digest to converge, and the CP's incumbent policy pins every grant to the member the agents already live on — but until the flag flips, a grant or revoke only moves bookkeeping. That makes the ledger observable in production before it gates a single platform connection, and it removes the startup window where a daemon that has not yet been granted anything would otherwise drop all its connections.

## Tests

- 10 registry unit tests: grant/replace semantics, term and composition changes, agent gained/lost derivation, an agent in two groups surviving one revoke, unheld-group revoke as a no-op, sorted digest, `releaseAll`.
- 6 wire tests over the existing `FakeTransport`/`FakeClock` harness: install-wide heartbeat carries the digest; an org-scoped daemon never sends it (the getter is not even called); a daemon with no getter sends a plain heartbeat; both EVTs reach `ConfigApply` with no reply and no `SCOPE_DENIED`; `duty/release` goes out org-less and settles on the ack; releasing nothing sends no frame.
- Full daemon unit suite green (217 files / 3358 tests). Four files excluded from that run — `acp-matrix`, `shim-cancellation`, `workspace-git-runner-seam`, `shim-exec-handler` — fail identically on clean `main` in this environment (verified by stashing), so they are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)