### PR TITLE
fix(web): shimmer the live work line and stop blanking it on leading …

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -3195,3 +3195,31 @@
     animation-duration: 0.01ms;
   }
 }
+
+/* Live work line (SessionDetailView toggle row) — the running command rises in once,
+   then a looping text shimmer says "still running" until the step finishes. */
+.work-live {
+  background: linear-gradient(90deg, var(--text-tertiary) 0%, var(--text-primary) 50%, var(--text-tertiary) 100%);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation:
+    acRise 0.34s var(--ease-out, cubic-bezier(0.2, 0.8, 0.3, 1)) both,
+    workShimmer 1.8s linear infinite;
+}
+@keyframes workShimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .work-live {
+    animation: none;
+    background: none;
+    color: inherit;
+  }
+}

--- a/packages/web/src/components/console/dock/SessionDock.test.tsx
+++ b/packages/web/src/components/console/dock/SessionDock.test.tsx
@@ -771,6 +771,16 @@ describe('SessionDock with nothing to draw', () => {
     expect(mobileActions.filter((a) => a !== null)).toEqual([])
   })
 
+  it('draws an active custom loading placeholder even while every tab is loading', () => {
+    const tabs = withStatus('loading').map((tab) =>
+      tab.key === 'sessions' ? { ...tab, loadingPlaceholder: <div data-session-skeleton="" /> } : tab
+    )
+    render(dock({ tabs, activeKey: 'sessions' }))
+    expect(container.querySelector('[data-session-skeleton]')).not.toBeNull()
+    expect(container.querySelector('[data-dock-loading]')).not.toBeNull()
+    expect(container.querySelector('[role="tablist"]')).not.toBeNull()
+  })
+
   it('withholds them the same way once that tab has settled empty', () => {
     render(dock({ tabs: withStatus('empty') }))
     expect(container.querySelector('[role="tablist"]')).toBeNull()

--- a/packages/web/src/components/console/dock/SessionDock.tsx
+++ b/packages/web/src/components/console/dock/SessionDock.tsx
@@ -55,6 +55,8 @@ export interface DockTab {
   actionLabel?: string
   /** Content state; absent = `ready`. The dock draws the body for a non-ready tab, and withholds its chrome — never the reserved track — when every tab is non-ready. */
   status?: DockTabStatus
+  /** Custom `loading`-state body (e.g. a skeleton mirroring this tab's rows); the dock's generic spinner otherwise. */
+  loadingPlaceholder?: ReactNode
 }
 
 const TAB_BASE =
@@ -220,8 +222,9 @@ export function SessionDock({
 
   const active = tabs.find((tab) => tab.key === activeKey)
   const activeStatus = active?.status ?? 'ready'
+  const activeLoadingPlaceholder = activeStatus === 'loading' && Boolean(active?.loadingPlaceholder)
   // Nothing in any tab is nothing to open: withhold every control that opens a void, and draw no panel. The TRACK is still reserved — only the resize handle stays reachable in it.
-  const vacant = tabs.every((tab) => (tab.status ?? 'ready') !== 'ready')
+  const vacant = !activeLoadingPlaceholder && tabs.every((tab) => (tab.status ?? 'ready') !== 'ready')
   // Where the panel IS an overlay, and therefore a modal dialog: the same viewport read `dockWidthCeiling` gates the inline ceiling on, so both agree on the band.
   const overlayBand = viewportWidth > 0 && viewportWidth < DOCK_WIDE_MIN
 
@@ -525,10 +528,16 @@ export function SessionDock({
           >
             {/* Which of the two it is, is the whole difference between "wait" and "there is nothing here". */}
             {!vacant && activeStatus === 'loading' ? (
-              <div role="status" data-dock-loading="" className={PLACEHOLDER}>
-                <Icon name="loader" size={15} className="animate-spin" />
-                Loading…
-              </div>
+              active?.loadingPlaceholder ? (
+                <div role="status" aria-label="Loading" data-dock-loading="" className="flex min-h-0 flex-1 flex-col">
+                  {active.loadingPlaceholder}
+                </div>
+              ) : (
+                <div role="status" data-dock-loading="" className={PLACEHOLDER}>
+                  <Icon name="loader" size={15} className="animate-spin" />
+                  Loading…
+                </div>
+              )
             ) : null}
             {!vacant && activeStatus === 'empty' ? (
               <div data-dock-empty="" className={PLACEHOLDER}>

--- a/packages/web/src/components/console/dock/SessionsPanel.tsx
+++ b/packages/web/src/components/console/dock/SessionsPanel.tsx
@@ -77,6 +77,37 @@ export function sessionsTabStatus(wouldHide: boolean | null, inputsSettled: bool
   return wouldHide !== null && inputsSettled ? 'empty' : 'loading'
 }
 
+// First-load placeholder the dock draws while the tab is `loading`: same box and
+// row geometry as the real panel, so the swap to rows causes no layout shift.
+// Title widths cycle deterministically (no Math.random) so SSR and client match.
+const SKEL_TITLE_WIDTHS = ['w-3/5', 'w-2/5', 'w-1/2', 'w-3/4', 'w-1/3']
+export function SessionsPanelSkeleton({ rows = 8 }: { rows?: number }) {
+  return (
+    <div aria-hidden="true" className="flex min-h-0 flex-1 flex-col px-[13px] pt-3 pb-[10px]">
+      {/* Header: the "All sessions" escape link's footprint. */}
+      <div className="mb-[9px] flex flex-none items-center justify-end px-[9px] py-[3px]">
+        <span className="h-[12px] w-20 animate-pulse rounded-full bg-(--surface-active)" />
+      </div>
+      {/* Agent filter row: one chip plus the "+" picker button. */}
+      <div className="mb-[7px] flex flex-none items-center gap-[5px] px-[9px]">
+        <span className="h-[22px] w-24 animate-pulse rounded-md bg-(--surface-active)" />
+        <span className="h-[22px] w-[22px] flex-none animate-pulse rounded-sm bg-(--surface-active)" />
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-px overflow-hidden">
+        {Array.from({ length: rows }, (_, i) => (
+          <div key={i} className="flex w-full flex-none items-center gap-2 px-[9px] py-[6px]">
+            <span className="h-[18px] w-[18px] flex-none animate-pulse rounded-xs bg-(--surface-active)" />
+            <span
+              className={`h-[13px] ${SKEL_TITLE_WIDTHS[i % SKEL_TITLE_WIDTHS.length]} animate-pulse rounded-full bg-(--surface-active)`}
+            />
+            <span className="ml-auto h-[11px] w-10 flex-none animate-pulse rounded-full bg-(--surface-active)" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 export function SessionsPanel({
   sessions,
   current,

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -99,7 +99,7 @@ import { SessionVisibilityControl } from '@/components/console/SessionVisibility
 import { SessionAgentFocusMenu, type SessionAgentFocusOption } from '@/components/console/SessionAgentFocusMenu'
 import { useCrumbSlot } from '@/components/console/Shell'
 import { DockPanel, SessionDock, SessionDockSlot, type DockTab } from '@/components/console/dock/SessionDock'
-import { SessionsPanel, sessionsTabStatus } from '@/components/console/dock/SessionsPanel'
+import { SessionsPanel, SessionsPanelSkeleton, sessionsTabStatus } from '@/components/console/dock/SessionsPanel'
 import { FilesPanel, filesTabStatus } from '@/components/console/dock/FilesPanel'
 import { GitPanel, gitTabStatus, type GitPanelVerdict } from '@/components/console/dock/GitPanel'
 import { TasksPanel, tasksTabStatus, type TasksPanelVerdict } from '@/components/console/dock/TasksPanel'
@@ -2091,7 +2091,7 @@ export default function SessionDetailView() {
               (prSessionId !== null && (prVerdict.answer !== 'none' || (prBranchScoped && gitVerdict.changed !== null)))
       ).map((tab) =>
         tab.key === 'sessions'
-          ? { ...tab, status: sessionsStatus }
+          ? { ...tab, status: sessionsStatus, loadingPlaceholder: <SessionsPanelSkeleton /> }
           : tab.key === 'files'
             ? { ...tab, status: filesStatus }
             : tab.key === 'git'

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -561,7 +561,8 @@ function stripMdMarkers(s: string): string {
 function WorkStepRow({ step, sessionId, divider }: { step: FmtStep; sessionId?: string; divider: boolean }) {
   const [open, setOpen] = useState(false)
   // Tool rows keep their title in `code` (msgStep), so fall back to its first line.
-  const rawTitle = (step.text || step.code || '').split('\n', 1)[0]?.trim() || step.lane || 'Step'
+  // trimStart: reasoning text can open with blank lines, which must not blank the title.
+  const rawTitle = (step.text || step.code || '').trimStart().split('\n', 1)[0]?.trim() || step.lane || 'Step'
   const title = step.text ? stripMdMarkers(rawTitle) : rawTitle
   // Single-line code with no text IS the title — expanding must not repeat it.
   const codeBeyondTitle = !!step.code && (!!step.text || step.code.includes('\n'))
@@ -2603,6 +2604,20 @@ export default function SessionDetailView() {
     setComposerMenuOpen(null)
   }, [id])
 
+  // Continuable sessions have no image affordance — drop any staged attachment.
+  // Lives ABOVE the early returns (Rules of Hooks), so it re-derives `isContinuable`
+  // from raw values instead of the post-return flags below.
+  const continuableSessionId =
+    session &&
+    session.platform !== 'playground' &&
+    session.platform !== 'webchat' &&
+    currentSessionDetail?.canContinue === true
+      ? session.id
+      : null
+  useEffect(() => {
+    if (continuableSessionId) setPgImage(continuableSessionId)
+  }, [continuableSessionId, setPgImage])
+
   // A multi-participant conversation is surfaced ONLY at /conversations/:key
   // (merged-conversation-view.md §5.3): a session deep link into one redirects,
   // preserving whose perspective was linked as ?focus.
@@ -2818,9 +2833,6 @@ export default function SessionDetailView() {
   const pgBusy = sessionBusy
   const pgImage = getPgImage(session.id)
   const attachmentsEnabled = !isContinuable
-  useEffect(() => {
-    if (isContinuable) setPgImage(session.id)
-  }, [isContinuable, session.id, setPgImage])
   const pgQueue = getPgQueue(session.id)
   const hasSessionWorktree =
     focusedAgent?.workspace.mode === 'github' &&
@@ -4110,10 +4122,13 @@ export default function SessionDetailView() {
                         // While work runs, the toggle line also carries what is running RIGHT
                         // NOW — the live step's first line (tool rows keep the command in
                         // `code`) — so a collapsed panel still shows live progress.
-                        const liveLine =
+                        // trimStart skips the blank lines reasoning text can open with; a
+                        // reasoning line also drops its markdown markers (same as the row title).
+                        const liveRaw =
                           workRunning && liveStep
-                            ? (liveStep.text || liveStep.code)?.split('\n', 1)[0]?.trim()
+                            ? (liveStep.text || liveStep.code)?.trimStart().split('\n', 1)[0]?.trim()
                             : undefined
+                        const liveLine = liveRaw && liveStep?.text ? stripMdMarkers(liveRaw) : liveRaw
                         // Step identity for the fade-in key: two consecutive steps can show
                         // the SAME first line, and a keyed-by-text span would keep its DOM
                         // node and never replay the animation.
@@ -4189,7 +4204,7 @@ export default function SessionDetailView() {
                                         // Keyed by step identity + content: a new step (or a new
                                         // first line within one) remounts the span, replaying the
                                         // ac-rise fade-in (honors reduced-motion in globals.css).
-                                        <span key={liveKey} className="ac-rise min-w-0 truncate">
+                                        <span key={liveKey} className="work-live min-w-0 truncate">
                                           · {liveLine}
                                         </span>
                                       )}


### PR DESCRIPTION
…newlines

The session-detail work toggle already appends the running step to its summary line, but a one-shot fade-in reads as static text, and reasoning text that opens with blank lines blanked both the live line and the expanded row title (which then fell back to a bare "PLAN"). The live line now skips leading blank lines, strips markdown markers like the row title does, and carries a looping text shimmer (reduced-motion safe) while the step runs; row titles apply the same trimStart.

Also moves the continuation attachment-reset effect above the view's early returns — it sat below the loading/not-found returns, so the loading→loaded transition changed the hook order (Rules of Hooks error).