### PR TITLE
fix(web): collapse cloud daemon placement option

### DIFF
--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -334,9 +334,9 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     return () => el.removeEventListener('scroll', sync)
   }, [])
 
-  // Cloud is one pool-backed placement (stored as null); only local daemons are concrete candidates.
+  // Cloud is one null-valued UI choice; the server still receives one serving pool member.
   const daemonChoice = addAgentDaemonChoice(daemons, daemonId)
-  const { cloudAvailable, daemon, daemonId: placementDaemonId, localDaemons, value: effectiveDaemonId } = daemonChoice
+  const { cloudAvailable, daemon, localDaemons, placementDaemonId, value: effectiveDaemonId } = daemonChoice
   const cloudSelected = cloudAvailable && effectiveDaemonId === ''
   const daemonLabel = cloudSelected ? CLOUD_DAEMON_LABEL : daemon ? daemon.name : 'No daemons connected'
   const sandboxRequired = daemon?.caps.features.includes('sandbox-required') ?? false

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -8,6 +8,7 @@ import { useProfile } from '@/lib/profile'
 import { useOrgs } from '@/lib/org-context'
 import {
   FALLBACK_RUNTIME_IDS,
+  CLOUD_DAEMON_LABEL,
   approvalsReviewerDefault,
   loginRequiredRuntimeIds,
   agentSlugFinalize,
@@ -31,6 +32,7 @@ import {
   type ApprovalsReviewer,
   supportsModes
 } from '@/lib/data'
+import { addAgentDaemonChoice } from './add-agent-daemon-choice'
 import {
   fetchGithubBranches,
   fetchGithubInstallations,
@@ -332,13 +334,11 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     return () => el.removeEventListener('scroll', sync)
   }, [])
 
-  // Online daemons first (the ones that can host now); otherwise keep fetch order.
-  const sortedDaemons = [...daemons].sort((a, b) => Number(b.status === 'online') - Number(a.status === 'online'))
-  // Daemon is required — no "assign later". Default to (and self-correct to) the first
-  // available daemon (online ones sort first), so a valid one is always preselected.
-  const effectiveDaemonId = daemons.some((d) => d.daemonId === daemonId) ? daemonId : (sortedDaemons[0]?.daemonId ?? '')
-  const daemon = daemons.find((d) => d.daemonId === effectiveDaemonId)
-  const daemonLabel = daemon ? daemon.name : 'No daemons connected'
+  // Cloud is one pool-backed placement (stored as null); only local daemons are concrete candidates.
+  const daemonChoice = addAgentDaemonChoice(daemons, daemonId)
+  const { cloudAvailable, daemon, daemonId: placementDaemonId, localDaemons, value: effectiveDaemonId } = daemonChoice
+  const cloudSelected = cloudAvailable && effectiveDaemonId === ''
+  const daemonLabel = cloudSelected ? CLOUD_DAEMON_LABEL : daemon ? daemon.name : 'No daemons connected'
   const sandboxRequired = daemon?.caps.features.includes('sandbox-required') ?? false
   const sandboxSupported = sandboxRequired || (daemon?.caps.features.includes('sandbox') ?? false)
   const effectiveRunInSandbox = sandboxRequired || (sandboxSupported && runInSandbox)
@@ -803,7 +803,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
         runtime: effectiveRuntime,
         ...(selectedModel ? { model: selectedModel } : {}),
         ...(description.trim() ? { description: description.trim() } : {}),
-        daemonId: daemon.daemonId,
+        ...(placementDaemonId !== null ? { daemonId: placementDaemonId } : {}),
         outputMode,
         showFooter,
         showStatusBar,
@@ -965,8 +965,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                   onChange={(e) => setDescription(e.target.value)}
                 />
               </div>
-              {/* Daemon / Runtime / Model share one row: a 3-up sub-grid inside
-                  the 2-up Basics grid. */}
+              {/* Daemon / Runtime / Model share one 3-up row inside the Basics grid. */}
               <div className="desktop:col-span-2 grid grid-cols-1 gap-[14px] desktop:grid-cols-3">
                 <div className="fld">
                   <span className="fldlbl">Daemon</span>
@@ -981,7 +980,8 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                       className="absolute inset-0 cursor-pointer opacity-0"
                       aria-label="Daemon"
                     >
-                      {sortedDaemons.map((d) => (
+                      {cloudAvailable && <option value="">{CLOUD_DAEMON_LABEL}</option>}
+                      {localDaemons.map((d) => (
                         <option key={d.daemonId} value={d.daemonId}>
                           {d.name}
                           {d.status !== 'online' ? ` (${d.status})` : ''}

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.test.ts
@@ -24,6 +24,7 @@ describe('addAgentDaemonChoice', () => {
     expect(choice.value).toBe('')
     expect(choice.daemonId).toBeNull()
     expect(choice.daemon?.daemonId).toBe('cloud-serving')
+    expect(choice.placementDaemonId).toBe('cloud-serving')
     expect(choice.localDaemons.map((daemon) => daemon.daemonId)).toEqual(['local-1'])
   })
 
@@ -33,6 +34,7 @@ describe('addAgentDaemonChoice', () => {
     expect(choice.value).toBe('local-1')
     expect(choice.daemonId).toBe('local-1')
     expect(choice.daemon?.daemonId).toBe('local-1')
+    expect(choice.placementDaemonId).toBe('local-1')
   })
 
   it('requires and defaults to a local daemon when Cloud is unavailable', () => {
@@ -42,6 +44,15 @@ describe('addAgentDaemonChoice', () => {
     expect(choice.value).toBe('local-online')
     expect(choice.daemonId).toBe('local-online')
     expect(choice.daemon?.daemonId).toBe('local-online')
+    expect(choice.placementDaemonId).toBe('local-online')
+  })
+
+  it('falls back to a local daemon when no Cloud member is serving', () => {
+    const choice = addAgentDaemonChoice([row('cloud-offline', true, 'offline'), row('local-online')], '')
+
+    expect(choice.cloudAvailable).toBe(false)
+    expect(choice.value).toBe('local-online')
+    expect(choice.placementDaemonId).toBe('local-online')
   })
 
   it('has no valid choice when neither Cloud nor a local daemon exists', () => {
@@ -50,6 +61,7 @@ describe('addAgentDaemonChoice', () => {
       daemon: undefined,
       daemonId: null,
       localDaemons: [],
+      placementDaemonId: null,
       value: ''
     })
   })

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { addAgentDaemonChoice } from './add-agent-daemon-choice'
+
+type Row = {
+  cloud: boolean
+  daemonId: string
+  status: 'online' | 'offline'
+}
+
+const row = (daemonId: string, cloud = false, status: Row['status'] = 'online'): Row => ({
+  cloud,
+  daemonId,
+  status
+})
+
+describe('addAgentDaemonChoice', () => {
+  it('collapses frame-scoped members into one null-valued Cloud choice', () => {
+    const choice = addAgentDaemonChoice(
+      [row('cloud-stale', true, 'offline'), row('local-1'), row('cloud-serving', true)],
+      ''
+    )
+
+    expect(choice.cloudAvailable).toBe(true)
+    expect(choice.value).toBe('')
+    expect(choice.daemonId).toBeNull()
+    expect(choice.daemon?.daemonId).toBe('cloud-serving')
+    expect(choice.localDaemons.map((daemon) => daemon.daemonId)).toEqual(['local-1'])
+  })
+
+  it('keeps an explicitly selected local daemon when Cloud is available', () => {
+    const choice = addAgentDaemonChoice([row('cloud-1', true), row('local-1')], 'local-1')
+
+    expect(choice.value).toBe('local-1')
+    expect(choice.daemonId).toBe('local-1')
+    expect(choice.daemon?.daemonId).toBe('local-1')
+  })
+
+  it('requires and defaults to a local daemon when Cloud is unavailable', () => {
+    const choice = addAgentDaemonChoice([row('local-offline', false, 'offline'), row('local-online')], '')
+
+    expect(choice.cloudAvailable).toBe(false)
+    expect(choice.value).toBe('local-online')
+    expect(choice.daemonId).toBe('local-online')
+    expect(choice.daemon?.daemonId).toBe('local-online')
+  })
+
+  it('has no valid choice when neither Cloud nor a local daemon exists', () => {
+    expect(addAgentDaemonChoice([], '')).toMatchObject({
+      cloudAvailable: false,
+      daemon: undefined,
+      daemonId: null,
+      localDaemons: [],
+      value: ''
+    })
+  })
+})

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
@@ -1,0 +1,32 @@
+import type { DaemonRow } from '@/lib/data'
+
+type DaemonChoiceRow = Pick<DaemonRow, 'cloud' | 'daemonId' | 'status'>
+
+export interface AddAgentDaemonChoice<T extends DaemonChoiceRow> {
+  cloudAvailable: boolean
+  daemon: T | undefined
+  daemonId: string | null
+  localDaemons: T[]
+  value: string
+}
+
+const onlineFirst = <T extends DaemonChoiceRow>(daemons: T[]): T[] =>
+  [...daemons].sort((a, b) => Number(b.status === 'online') - Number(a.status === 'online'))
+
+export function addAgentDaemonChoice<T extends DaemonChoiceRow>(
+  daemons: T[],
+  selectedDaemonId: string
+): AddAgentDaemonChoice<T> {
+  const cloudDaemons = onlineFirst(daemons.filter((daemon) => daemon.cloud))
+  const localDaemons = onlineFirst(daemons.filter((daemon) => !daemon.cloud))
+  const selectedLocal = localDaemons.find((daemon) => daemon.daemonId === selectedDaemonId)
+  const value = selectedLocal?.daemonId ?? (cloudDaemons.length > 0 ? '' : (localDaemons[0]?.daemonId ?? ''))
+
+  return {
+    cloudAvailable: cloudDaemons.length > 0,
+    daemon: value ? localDaemons.find((candidate) => candidate.daemonId === value) : cloudDaemons[0],
+    daemonId: value || null,
+    localDaemons,
+    value
+  }
+}

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
@@ -7,6 +7,7 @@ export interface AddAgentDaemonChoice<T extends DaemonChoiceRow> {
   daemon: T | undefined
   daemonId: string | null
   localDaemons: T[]
+  placementDaemonId: string | null
   value: string
 }
 
@@ -17,16 +18,18 @@ export function addAgentDaemonChoice<T extends DaemonChoiceRow>(
   daemons: T[],
   selectedDaemonId: string
 ): AddAgentDaemonChoice<T> {
-  const cloudDaemons = onlineFirst(daemons.filter((daemon) => daemon.cloud))
+  const cloudDaemons = daemons.filter((daemon) => daemon.cloud && daemon.status === 'online')
   const localDaemons = onlineFirst(daemons.filter((daemon) => !daemon.cloud))
   const selectedLocal = localDaemons.find((daemon) => daemon.daemonId === selectedDaemonId)
   const value = selectedLocal?.daemonId ?? (cloudDaemons.length > 0 ? '' : (localDaemons[0]?.daemonId ?? ''))
+  const daemon = value ? localDaemons.find((candidate) => candidate.daemonId === value) : cloudDaemons[0]
 
   return {
     cloudAvailable: cloudDaemons.length > 0,
-    daemon: value ? localDaemons.find((candidate) => candidate.daemonId === value) : cloudDaemons[0],
+    daemon,
     daemonId: value || null,
     localDaemons,
+    placementDaemonId: daemon?.daemonId ?? null,
     value
   }
 }


### PR DESCRIPTION
## What changed

- Collapse install-wide frame-mode daemon members into one `AgentConnect Cloud` UI option.
- Keep the Cloud selector value null while resolving submission to one online serving pool member under the current Control Plane placement contract.
- Hide Cloud when no pool member is serving and require/default to a local daemon instead.
- Add focused unit coverage for Cloud, local, offline-fleet fallback, and empty-fleet selection.

## Why

The Add Agent picker exposed each Cloud Pod as a separate candidate, leaking replaceable infrastructure identities and producing duplicate labels. Cloud is one managed execution pool in the UI, while the current server contract still requires a concrete serving member to keep the created agent active and runnable.

## Impact

Users see one stable Cloud choice instead of one row per frame-mode member. Local-only and temporarily offline-Cloud deployments continue to require a concrete local daemon.

## Validation

- `pnpm --dir packages/web exec vitest run src/components/console/modals/add-agent-daemon-choice.test.ts`
- `pnpm --filter @agentconnect.md/web typecheck`
- ESLint and Prettier checks on the changed files
- Repository pre-push ESLint hook