### PR TITLE
fix(web): unify cloud daemon picker

### DIFF
--- a/packages/web/src/components/console/DaemonSelect.test.tsx
+++ b/packages/web/src/components/console/DaemonSelect.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+
+import { act, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { DaemonSelect, type DaemonSelectOption } from './DaemonSelect'
+
+let root: Root | undefined
+let container: HTMLDivElement | undefined
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const options: DaemonSelectOption[] = [
+  {
+    value: 'cloud-1',
+    label: 'AgentConnect Cloud',
+    detail: 'Model usage included — no API key needed.',
+    cloud: true
+  },
+  { value: 'edge-1', label: 'edge-1', detail: 'Uses the credentials on this machine.' },
+  { value: 'edge-2', label: 'edge-2', detail: 'Offline — bring this machine online to use it.', disabled: true }
+]
+
+function Harness() {
+  const [value, setValue] = useState('cloud-1')
+  return <DaemonSelect value={value} options={options} onChange={setValue} />
+}
+
+async function mount() {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => root?.render(<Harness />))
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  container?.remove()
+  root = undefined
+  container = undefined
+})
+
+describe('DaemonSelect', () => {
+  it('renders Cloud first with its managed-runtime explanation', async () => {
+    await mount()
+    const trigger = container!.querySelector<HTMLButtonElement>('[aria-haspopup="listbox"]')!
+    await act(async () => trigger.click())
+    const rows = [...container!.querySelectorAll<HTMLButtonElement>('[role="option"]')]
+
+    expect(rows[0]?.dataset.cloud).toBe('true')
+    expect(rows[0]?.textContent).toContain('AgentConnect Cloud')
+    expect(rows[0]?.textContent).toContain('Model usage included — no API key needed.')
+    expect(rows).toHaveLength(3)
+  })
+
+  it('selects a local daemon and skips unavailable choices with the keyboard', async () => {
+    await mount()
+    const trigger = container!.querySelector<HTMLButtonElement>('[aria-haspopup="listbox"]')!
+    await act(async () => trigger.click())
+    const list = container!.querySelector<HTMLDivElement>('[role="listbox"]')!
+    await act(async () => {
+      list.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    })
+    await act(async () => {
+      list.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+
+    expect(trigger.textContent).toContain('edge-1')
+    expect(container!.querySelector('[role="listbox"]')).toBeNull()
+  })
+})

--- a/packages/web/src/components/console/DaemonSelect.tsx
+++ b/packages/web/src/components/console/DaemonSelect.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
+import { Icon } from '@/components/ui'
+
+export interface DaemonSelectOption {
+  value: string
+  label: string
+  detail: string
+  cloud?: boolean
+  disabled?: boolean
+}
+
+function enabledIndex(options: readonly DaemonSelectOption[], start: number, delta: 1 | -1): number {
+  if (!options.length) return -1
+  for (let step = 0; step < options.length; step += 1) {
+    const index = (start + delta * step + options.length) % options.length
+    if (!options[index]!.disabled) return index
+  }
+  return -1
+}
+
+export function DaemonSelect({
+  value,
+  options,
+  onChange,
+  ariaLabel = 'Daemon',
+  placeholder = 'No daemons connected'
+}: {
+  value: string
+  options: readonly DaemonSelectOption[]
+  onChange: (value: string) => void
+  ariaLabel?: string
+  placeholder?: string
+}) {
+  const selectedIndex = options.findIndex((option) => option.value === value)
+  const selected = selectedIndex >= 0 ? options[selectedIndex] : undefined
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(selectedIndex)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  const listboxId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    const frame = requestAnimationFrame(() => listRef.current?.focus())
+    return () => cancelAnimationFrame(frame)
+  }, [open])
+
+  const initialActiveIndex = () =>
+    selected && !selected.disabled ? selectedIndex : enabledIndex(options, Math.max(selectedIndex, 0), 1)
+
+  const closeAndFocus = () => {
+    setOpen(false)
+    requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+
+  const pick = (option: DaemonSelectOption) => {
+    if (option.disabled) return
+    onChange(option.value)
+    closeAndFocus()
+  }
+
+  const moveActive = (delta: 1 | -1) => {
+    setActiveIndex((current) => {
+      const start =
+        current < 0 ? (delta === 1 ? 0 : options.length - 1) : (current + delta + options.length) % options.length
+      return enabledIndex(options, start, delta)
+    })
+  }
+
+  const onTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+    event.preventDefault()
+    const start = event.key === 'ArrowDown' ? 0 : options.length - 1
+    setActiveIndex(enabledIndex(options, start, event.key === 'ArrowDown' ? 1 : -1))
+    setOpen(true)
+  }
+
+  const onListKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      moveActive(event.key === 'ArrowDown' ? 1 : -1)
+      return
+    }
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault()
+      const start = event.key === 'Home' ? 0 : options.length - 1
+      setActiveIndex(enabledIndex(options, start, event.key === 'Home' ? 1 : -1))
+      return
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      const active = options[activeIndex]
+      if (active) pick(active)
+      return
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      closeAndFocus()
+      return
+    }
+    if (event.key === 'Tab') setOpen(false)
+  }
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`inp relative w-full cursor-pointer text-left outline-none transition-[background-color,border-color,box-shadow] ${
+          open
+            ? 'border-(--border-focus) ring-[3px] ring-(--brand-ring)'
+            : 'hover:border-(--border-strong) hover:bg-(--surface-hover) focus-visible:border-(--border-focus) focus-visible:ring-[3px] focus-visible:ring-(--brand-ring)'
+        }`}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        disabled={options.length === 0}
+        onClick={() => {
+          setActiveIndex(initialActiveIndex())
+          setOpen((current) => !current)
+        }}
+        onKeyDown={onTriggerKeyDown}
+      >
+        <span className={`inline-flex min-w-0 items-center gap-2 ${selected ? '' : 'text-(--text-tertiary)'}`}>
+          {selected && (
+            <span
+              className={`flex h-6 w-6 flex-none items-center justify-center rounded-md ${
+                selected.cloud ? 'bg-(--brand-soft)' : 'bg-(--surface-sunken)'
+              }`}
+            >
+              <Icon
+                name={selected.cloud ? 'cloud' : selected.value ? 'server' : 'server-off'}
+                size={14}
+                color={selected.cloud ? 'var(--brand)' : 'var(--text-tertiary)'}
+              />
+            </span>
+          )}
+          <span className="truncate">{selected?.label ?? placeholder}</span>
+          {selected?.cloud && (
+            <span className="flex-none rounded-full bg-(--brand-soft) px-[7px] py-[2px] font-sans text-[10.5px] font-semibold leading-normal text-(--brand-soft-text)">
+              Cloud
+            </span>
+          )}
+        </span>
+        <Icon
+          name="chevron-down"
+          size={15}
+          color="var(--text-tertiary)"
+          className={`flex-none transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+      {open && options.length > 0 && (
+        <>
+          <div className="fscrim" onClick={() => setOpen(false)} />
+          <div
+            ref={listRef}
+            id={listboxId}
+            role="listbox"
+            tabIndex={-1}
+            aria-label={ariaLabel}
+            aria-activedescendant={activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined}
+            className="fmenu right-0 left-0 z-40 max-h-[360px] min-w-0 rounded-lg p-2 shadow-(--shadow-xl) outline-none"
+            onKeyDown={onListKeyDown}
+          >
+            {options.map((option, index) => {
+              const isSelected = option.value === value
+              const isActive = index === activeIndex
+              return (
+                <button
+                  key={`${option.cloud ? 'cloud' : 'daemon'}:${option.value}`}
+                  id={`${listboxId}-option-${index}`}
+                  type="button"
+                  role="option"
+                  tabIndex={-1}
+                  aria-selected={isSelected}
+                  aria-disabled={option.disabled || undefined}
+                  disabled={option.disabled}
+                  data-cloud={option.cloud || undefined}
+                  className={`fopt min-h-[58px] gap-[10px] rounded-md px-2 py-[7px] text-[13px] ${
+                    option.disabled
+                      ? 'cursor-not-allowed text-(--text-disabled) opacity-65'
+                      : isSelected
+                        ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
+                        : isActive
+                          ? 'bg-(--surface-hover)'
+                          : ''
+                  }`}
+                  onMouseEnter={() => !option.disabled && setActiveIndex(index)}
+                  onClick={() => pick(option)}
+                >
+                  <span className="flex w-4 flex-none items-center justify-center">
+                    {isSelected && <Icon name="check" size={16} color="var(--brand)" />}
+                  </span>
+                  <span
+                    className={`flex h-8 w-8 flex-none items-center justify-center rounded-md ${
+                      option.cloud ? 'bg-(--brand-soft)' : 'bg-(--surface-sunken)'
+                    }`}
+                  >
+                    <Icon
+                      name={option.cloud ? 'cloud' : option.value ? 'server' : 'server-off'}
+                      size={16}
+                      color={option.cloud ? 'var(--brand)' : 'var(--text-tertiary)'}
+                    />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-2 font-sans text-[13px] font-semibold leading-normal">
+                      <span className="truncate">{option.label}</span>
+                      {option.cloud && (
+                        <span className="flex-none rounded-full bg-(--brand-soft) px-[7px] py-[2px] font-sans text-[10.5px] font-semibold leading-normal text-(--brand-soft-text)">
+                          Cloud
+                        </span>
+                      )}
+                    </span>
+                    <span className="mt-[3px] block truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                      {option.detail}
+                    </span>
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -48,6 +48,7 @@ import {
 } from '@/lib/api'
 import { GithubMark } from '@/components/marks'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
+import { DaemonSelect, type DaemonSelectOption } from '@/components/console/DaemonSelect'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
 import { randomGlyphIcon, type AgentIcon } from '@/lib/agent-icon'
 import { DEFAULT_AGENT_OUTPUT_MODE, type OutputMode } from '@/lib/output-mode'
@@ -337,8 +338,26 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   // Cloud is one null-valued UI choice; the server still receives one serving pool member.
   const daemonChoice = addAgentDaemonChoice(daemons, daemonId)
   const { cloudAvailable, daemon, localDaemons, placementDaemonId, value: effectiveDaemonId } = daemonChoice
-  const cloudSelected = cloudAvailable && effectiveDaemonId === ''
-  const daemonLabel = cloudSelected ? CLOUD_DAEMON_LABEL : daemon ? daemon.name : 'No daemons connected'
+  const daemonOptions: DaemonSelectOption[] = [
+    ...(cloudAvailable
+      ? [
+          {
+            value: '',
+            label: CLOUD_DAEMON_LABEL,
+            detail: 'Model usage included — no API key needed.',
+            cloud: true
+          }
+        ]
+      : []),
+    ...localDaemons.map((candidate) => ({
+      value: candidate.daemonId,
+      label: candidate.name,
+      detail:
+        candidate.status === 'online'
+          ? 'Uses the credentials on this machine.'
+          : `${candidate.status[0]!.toUpperCase()}${candidate.status.slice(1)} — this machine is not currently serving.`
+    }))
+  ]
   const sandboxRequired = daemon?.caps.features.includes('sandbox-required') ?? false
   const sandboxSupported = sandboxRequired || (daemon?.caps.features.includes('sandbox') ?? false)
   const effectiveRunInSandbox = sandboxRequired || (sandboxSupported && runInSandbox)
@@ -969,26 +988,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
               <div className="desktop:col-span-2 grid grid-cols-1 gap-[14px] desktop:grid-cols-3">
                 <div className="fld">
                   <span className="fldlbl">Daemon</span>
-                  <div className="inp relative">
-                    <span className={`truncate ${daemon ? 'text-(--text-primary)' : 'text-(--text-tertiary)'}`}>
-                      {daemonLabel}
-                    </span>
-                    <Icon name="chevron-down" size={15} color="var(--text-tertiary)" className="flex-none" />
-                    <select
-                      value={effectiveDaemonId}
-                      onChange={(e) => setDaemonId(e.target.value)}
-                      className="absolute inset-0 cursor-pointer opacity-0"
-                      aria-label="Daemon"
-                    >
-                      {cloudAvailable && <option value="">{CLOUD_DAEMON_LABEL}</option>}
-                      {localDaemons.map((d) => (
-                        <option key={d.daemonId} value={d.daemonId}>
-                          {d.name}
-                          {d.status !== 'online' ? ` (${d.status})` : ''}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
+                  <DaemonSelect value={effectiveDaemonId} options={daemonOptions} onChange={setDaemonId} />
                 </div>
                 <div className="fld">
                   <span className="fldlbl">Runtime</span>

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -310,15 +310,27 @@ export default function EditAgentModal({
   const daemonChoices = editAgentDaemonChoices(daemons, daemonId, initialDaemonId.current)
   const cloudServing = daemons.some((candidate) => candidate.cloud && moveReady(candidate))
   const daemonOptions: DaemonSelectOption[] = [
-    ...daemonChoices
-      .filter((candidate) => candidate.cloud)
-      .map((candidate) => ({
-        value: candidate.daemonId,
-        label: CLOUD_DAEMON_LABEL,
-        detail: cloudServing ? 'Model usage included — no API key needed.' : 'Cloud is currently unavailable.',
-        cloud: true,
-        disabled: candidate.daemonId !== initialDaemonId.current && !moveReady(candidate)
-      })),
+    ...(daemonChoices.cloudChoice
+      ? [
+          {
+            value: daemonChoices.cloudChoice.daemonId,
+            label: CLOUD_DAEMON_LABEL,
+            detail: cloudServing ? 'Model usage included — no API key needed.' : 'Cloud is currently unavailable.',
+            cloud: true,
+            disabled:
+              daemonChoices.cloudChoice.daemonId !== initialDaemonId.current && !moveReady(daemonChoices.cloudChoice)
+          }
+        ]
+      : []),
+    ...(daemonChoices.currentCloudChoice
+      ? [
+          {
+            value: daemonChoices.currentCloudChoice.daemonId,
+            label: 'Current placement',
+            detail: 'Currently on an unavailable Cloud node — select Cloud above to recover.'
+          }
+        ]
+      : []),
     ...(!initialDaemonId.current ? [{ value: '', label: 'No daemon', detail: 'Leave this agent inactive.' }] : []),
     ...(daemonId && !daemon
       ? [
@@ -329,23 +341,21 @@ export default function EditAgentModal({
           }
         ]
       : []),
-    ...daemonChoices
-      .filter((candidate) => !candidate.cloud)
-      .map((candidate) => {
-        const eligible = moveReady(candidate)
-        const current = candidate.daemonId === initialDaemonId.current
-        return {
-          value: candidate.daemonId,
-          label: candidate.name,
-          detail:
-            candidate.status !== 'online'
-              ? 'Offline — bring this machine online to use it.'
-              : !candidate.caps.features.includes('agent-move-v1')
-                ? 'Upgrade required before this machine can host the agent.'
-                : 'Uses the credentials on this machine.',
-          disabled: !current && !eligible
-        }
-      })
+    ...daemonChoices.localChoices.map((candidate) => {
+      const eligible = moveReady(candidate)
+      const current = candidate.daemonId === initialDaemonId.current
+      return {
+        value: candidate.daemonId,
+        label: candidate.name,
+        detail:
+          candidate.status !== 'online'
+            ? 'Offline — bring this machine online to use it.'
+            : !candidate.caps.features.includes('agent-move-v1')
+              ? 'Upgrade required before this machine can host the agent.'
+              : 'Uses the credentials on this machine.',
+        disabled: !current && !eligible
+      }
+    })
   ]
   const sourceUnavailable = !!sourceDaemon && !moveReady(sourceDaemon)
   const sourceOffline = sourceDaemon?.status === 'offline'

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -23,6 +23,7 @@ import {
   selectedPermissionPreset,
   supportsModes,
   agentLabel,
+  CLOUD_DAEMON_LABEL,
   type Agent,
   type AgentCallPolicy,
   type ApprovalsReviewer
@@ -34,7 +35,9 @@ import { useOrgs } from '@/lib/org-context'
 import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import { Spinner } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
+import { DaemonSelect, type DaemonSelectOption } from '@/components/console/DaemonSelect'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
+import { editAgentDaemonChoices } from './edit-agent-daemon-choice'
 import { VisibilityField, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
 import { AgentCallVisibility } from '@/components/console/AgentCallVisibility'
 import {
@@ -221,15 +224,12 @@ export default function EditAgentModal({
     )
   }, [agent.id])
 
-  // An unplaced agent (the built-in `agentconnect` preset ships this way) defaults its
-  // daemon to the first placement-eligible one, so opening the editor to place it starts
-  // on that daemon instead of an empty picker when a daemon already exists. `initialDaemonId`
-  // stays '' so this reads as an initial placement (arms Save + requires runtime/model).
-  // One-shot: the user can still switch it back to "No daemon".
+  // An unplaced agent defaults to Cloud, then the first placement-ready local daemon.
   const autofilledDaemon = useRef(false)
   useEffect(() => {
     if (!loaded || autofilledDaemon.current || initialDaemonId.current || daemonId) return
-    const target = daemons.find((d) => d.status === 'online' && d.caps.features.includes('agent-move-v1'))
+    const ready = (d: (typeof daemons)[number]) => d.status === 'online' && d.caps.features.includes('agent-move-v1')
+    const target = daemons.find((d) => d.cloud && ready(d)) ?? daemons.find(ready)
     if (target) {
       autofilledDaemon.current = true
       setDaemonId(target.daemonId)
@@ -289,16 +289,6 @@ export default function EditAgentModal({
     return () => el.removeEventListener('scroll', sync)
   }, [loaded])
 
-  // Placement choices are operational: only a READY daemon that advertises the
-  // acknowledged move protocol can become a new target. The current daemon
-  // stays selectable even when it has gone offline (selecting it is a no-op), and
-  // a hidden/deleted current daemon gets a synthetic option instead of silently
-  // falling back to the first visible machine.
-  const sortedDaemons = [...daemons].sort((a, b) => {
-    const score = (d: (typeof daemons)[number]) =>
-      Number(d.status === 'online') * 2 + Number(d.caps.features.includes('agent-move-v1'))
-    return score(b) - score(a)
-  })
   const daemon = daemons.find((d) => d.daemonId === daemonId)
   const sourceDaemon = daemons.find((d) => d.daemonId === initialDaemonId.current)
   const daemonChanged = daemonId !== initialDaemonId.current
@@ -317,7 +307,46 @@ export default function EditAgentModal({
   const effectiveRunInSandbox = selectedSandboxRequired || (selectedSandboxSupported && runInSandbox)
   const moveReady = (d: (typeof daemons)[number] | undefined) =>
     !!d && d.status === 'online' && d.caps.features.includes('agent-move-v1')
-  const daemonLabel = daemon?.name ?? (daemonId ? `Current daemon (${daemonId.slice(0, 8)})` : 'No daemon')
+  const daemonChoices = editAgentDaemonChoices(daemons, daemonId, initialDaemonId.current)
+  const cloudServing = daemons.some((candidate) => candidate.cloud && moveReady(candidate))
+  const daemonOptions: DaemonSelectOption[] = [
+    ...daemonChoices
+      .filter((candidate) => candidate.cloud)
+      .map((candidate) => ({
+        value: candidate.daemonId,
+        label: CLOUD_DAEMON_LABEL,
+        detail: cloudServing ? 'Model usage included — no API key needed.' : 'Cloud is currently unavailable.',
+        cloud: true,
+        disabled: candidate.daemonId !== initialDaemonId.current && !moveReady(candidate)
+      })),
+    ...(!initialDaemonId.current ? [{ value: '', label: 'No daemon', detail: 'Leave this agent inactive.' }] : []),
+    ...(daemonId && !daemon
+      ? [
+          {
+            value: daemonId,
+            label: `Current daemon (${daemonId.slice(0, 8)})`,
+            detail: 'This daemon is no longer visible.'
+          }
+        ]
+      : []),
+    ...daemonChoices
+      .filter((candidate) => !candidate.cloud)
+      .map((candidate) => {
+        const eligible = moveReady(candidate)
+        const current = candidate.daemonId === initialDaemonId.current
+        return {
+          value: candidate.daemonId,
+          label: candidate.name,
+          detail:
+            candidate.status !== 'online'
+              ? 'Offline — bring this machine online to use it.'
+              : !candidate.caps.features.includes('agent-move-v1')
+                ? 'Upgrade required before this machine can host the agent.'
+                : 'Uses the credentials on this machine.',
+          disabled: !current && !eligible
+        }
+      })
+  ]
   const sourceUnavailable = !!sourceDaemon && !moveReady(sourceDaemon)
   const sourceOffline = sourceDaemon?.status === 'offline'
   const forceEligible = daemonChanged && !initialPlacement && sourceOffline && moveReady(daemon)
@@ -625,48 +654,18 @@ export default function EditAgentModal({
                       </button>
                     )}
                   </div>
-                  <div className="inp relative">
-                    <span className={daemon ? 'inline-flex items-center gap-[7px]' : 'text-(--text-tertiary)'}>
-                      {daemon && <Icon name="server" size={14} color="var(--text-tertiary)" />}
-                      {daemonLabel}
-                    </span>
-                    <Icon name="chevron-down" size={15} color="var(--text-tertiary)" />
-                    <select
-                      value={daemonId}
-                      onChange={(e) => {
-                        setDaemonId(e.target.value)
-                        setRepairPlacement(false)
-                        setForceReassign(false)
-                        setForceConfirmed(false)
-                        setErr(null)
-                      }}
-                      className="absolute inset-0 cursor-pointer opacity-0"
-                      aria-label="Daemon"
-                    >
-                      {/* An agent that opened unplaced keeps "No daemon" selectable
-                          so a chosen target can be taken back — picking one is what
-                          turns the dialog into a placement. Never offered to a placed
-                          agent: unplacing is not a move. */}
-                      {!initialDaemonId.current && <option value="">No daemon</option>}
-                      {daemonId && !daemon && <option value={daemonId}>Current daemon ({daemonId.slice(0, 8)})</option>}
-                      {sortedDaemons.map((d) => {
-                        const current = d.daemonId === initialDaemonId.current
-                        const eligible = moveReady(d)
-                        const suffix =
-                          d.status !== 'online'
-                            ? ` (${d.status})`
-                            : !d.caps.features.includes('agent-move-v1')
-                              ? ' (upgrade required)'
-                              : ''
-                        return (
-                          <option key={d.daemonId} value={d.daemonId} disabled={!current && !eligible}>
-                            {d.name}
-                            {suffix}
-                          </option>
-                        )
-                      })}
-                    </select>
-                  </div>
+                  <DaemonSelect
+                    value={daemonId}
+                    options={daemonOptions}
+                    placeholder="No daemon"
+                    onChange={(nextDaemonId) => {
+                      setDaemonId(nextDaemonId)
+                      setRepairPlacement(false)
+                      setForceReassign(false)
+                      setForceConfirmed(false)
+                      setErr(null)
+                    }}
+                  />
                   {sourceDaemon && sourceUnavailable && (
                     <div className="mt-2 flex items-start gap-[9px] rounded-md border border-(--amber-500) bg-(--status-paused-soft) px-3 py-[10px]">
                       <Icon name="triangle-alert" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { editAgentDaemonChoices } from './edit-agent-daemon-choice'
+
+type Row = {
+  caps: { features: string[] }
+  cloud: boolean
+  daemonId: string
+  status: 'online' | 'offline'
+}
+
+const row = (daemonId: string, cloud = false, status: Row['status'] = 'online', movable = true): Row => ({
+  caps: { features: movable ? ['agent-move-v1'] : [] },
+  cloud,
+  daemonId,
+  status
+})
+
+describe('editAgentDaemonChoices', () => {
+  it('collapses every Cloud member into one first choice', () => {
+    const choices = editAgentDaemonChoices(
+      [row('local-1'), row('cloud-1', true), row('cloud-2', true), row('cloud-3', true), row('local-2')],
+      'local-1',
+      'local-1'
+    )
+
+    expect(choices.map((choice) => choice.daemonId)).toEqual(['cloud-1', 'local-1', 'local-2'])
+    expect(choices.filter((choice) => choice.cloud)).toHaveLength(1)
+  })
+
+  it('keeps the selected Cloud member as the concrete placement target', () => {
+    const choices = editAgentDaemonChoices(
+      [row('cloud-offline', true, 'offline'), row('cloud-serving', true), row('local-1')],
+      'cloud-serving',
+      'local-1'
+    )
+
+    expect(choices[0]?.daemonId).toBe('cloud-serving')
+  })
+
+  it('keeps the source Cloud member available so a pending move can be cancelled', () => {
+    const choices = editAgentDaemonChoices(
+      [row('cloud-source', true, 'offline'), row('cloud-serving', true), row('local-1')],
+      'local-1',
+      'cloud-source'
+    )
+
+    expect(choices[0]?.daemonId).toBe('cloud-source')
+  })
+
+  it('puts move-ready local daemons before unavailable local daemons', () => {
+    const choices = editAgentDaemonChoices(
+      [row('local-offline', false, 'offline'), row('local-old', false, 'online', false), row('local-ready')],
+      'local-offline',
+      'local-offline'
+    )
+
+    expect(choices.map((choice) => choice.daemonId)).toEqual(['local-ready', 'local-offline', 'local-old'])
+  })
+})

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
@@ -23,8 +23,9 @@ describe('editAgentDaemonChoices', () => {
       'local-1'
     )
 
-    expect(choices.map((choice) => choice.daemonId)).toEqual(['cloud-1', 'local-1', 'local-2'])
-    expect(choices.filter((choice) => choice.cloud)).toHaveLength(1)
+    expect(choices.cloudChoice?.daemonId).toBe('cloud-1')
+    expect(choices.currentCloudChoice).toBeUndefined()
+    expect(choices.localChoices.map((choice) => choice.daemonId)).toEqual(['local-1', 'local-2'])
   })
 
   it('keeps the selected Cloud member as the concrete placement target', () => {
@@ -34,17 +35,30 @@ describe('editAgentDaemonChoices', () => {
       'local-1'
     )
 
-    expect(choices[0]?.daemonId).toBe('cloud-serving')
+    expect(choices.cloudChoice?.daemonId).toBe('cloud-serving')
+    expect(choices.currentCloudChoice).toBeUndefined()
   })
 
-  it('keeps the source Cloud member available so a pending move can be cancelled', () => {
+  it('keeps an unavailable Cloud source as an explicit cancellation choice', () => {
     const choices = editAgentDaemonChoices(
       [row('cloud-source', true, 'offline'), row('cloud-serving', true), row('local-1')],
       'local-1',
       'cloud-source'
     )
 
-    expect(choices[0]?.daemonId).toBe('cloud-source')
+    expect(choices.cloudChoice?.daemonId).toBe('cloud-serving')
+    expect(choices.currentCloudChoice?.daemonId).toBe('cloud-source')
+  })
+
+  it('offers a healthy Cloud sibling when the current Cloud placement is unavailable', () => {
+    const choices = editAgentDaemonChoices(
+      [row('cloud-source', true, 'offline'), row('cloud-serving', true), row('local-1')],
+      'cloud-source',
+      'cloud-source'
+    )
+
+    expect(choices.cloudChoice?.daemonId).toBe('cloud-serving')
+    expect(choices.currentCloudChoice?.daemonId).toBe('cloud-source')
   })
 
   it('puts move-ready local daemons before unavailable local daemons', () => {
@@ -54,6 +68,7 @@ describe('editAgentDaemonChoices', () => {
       'local-offline'
     )
 
-    expect(choices.map((choice) => choice.daemonId)).toEqual(['local-ready', 'local-offline', 'local-old'])
+    expect(choices.cloudChoice).toBeUndefined()
+    expect(choices.localChoices.map((choice) => choice.daemonId)).toEqual(['local-ready', 'local-offline', 'local-old'])
   })
 })

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
@@ -7,20 +7,37 @@ type DaemonChoiceRow = Pick<DaemonRow, 'cloud' | 'daemonId' | 'status'> & {
 const moveReady = (daemon: DaemonChoiceRow): boolean =>
   daemon.status === 'online' && daemon.caps.features.includes('agent-move-v1')
 
+export interface EditAgentDaemonChoices<T extends DaemonChoiceRow> {
+  cloudChoice: T | undefined
+  currentCloudChoice: T | undefined
+  localChoices: T[]
+}
+
 export function editAgentDaemonChoices<T extends DaemonChoiceRow>(
   daemons: T[],
   selectedDaemonId: string,
   initialDaemonId: string
-): T[] {
+): EditAgentDaemonChoices<T> {
   const selected = daemons.find((daemon) => daemon.daemonId === selectedDaemonId)
   const initial = daemons.find((daemon) => daemon.daemonId === initialDaemonId)
   const cloudMembers = daemons.filter((daemon) => daemon.cloud)
+  const recoveryTarget =
+    initial?.cloud && !moveReady(initial)
+      ? cloudMembers.find((daemon) => daemon.daemonId !== initial.daemonId && moveReady(daemon))
+      : undefined
   const cloudChoice =
+    (selected?.cloud && selected.daemonId !== initialDaemonId && moveReady(selected) ? selected : undefined) ??
+    recoveryTarget ??
     (selected?.cloud ? selected : undefined) ??
     (initial?.cloud ? initial : undefined) ??
     cloudMembers.find(moveReady) ??
     cloudMembers[0]
   const localChoices = daemons.filter((daemon) => !daemon.cloud)
   localChoices.sort((a, b) => Number(moveReady(b)) - Number(moveReady(a)))
-  return cloudChoice ? [cloudChoice, ...localChoices] : localChoices
+  return {
+    cloudChoice,
+    currentCloudChoice:
+      initial?.cloud && cloudChoice?.daemonId !== initial.daemonId && recoveryTarget ? initial : undefined,
+    localChoices
+  }
 }

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
@@ -1,0 +1,26 @@
+import type { DaemonRow } from '@/lib/data'
+
+type DaemonChoiceRow = Pick<DaemonRow, 'cloud' | 'daemonId' | 'status'> & {
+  caps: Pick<DaemonRow['caps'], 'features'>
+}
+
+const moveReady = (daemon: DaemonChoiceRow): boolean =>
+  daemon.status === 'online' && daemon.caps.features.includes('agent-move-v1')
+
+export function editAgentDaemonChoices<T extends DaemonChoiceRow>(
+  daemons: T[],
+  selectedDaemonId: string,
+  initialDaemonId: string
+): T[] {
+  const selected = daemons.find((daemon) => daemon.daemonId === selectedDaemonId)
+  const initial = daemons.find((daemon) => daemon.daemonId === initialDaemonId)
+  const cloudMembers = daemons.filter((daemon) => daemon.cloud)
+  const cloudChoice =
+    (selected?.cloud ? selected : undefined) ??
+    (initial?.cloud ? initial : undefined) ??
+    cloudMembers.find(moveReady) ??
+    cloudMembers[0]
+  const localChoices = daemons.filter((daemon) => !daemon.cloud)
+  localChoices.sort((a, b) => Number(moveReady(b)) - Number(moveReady(a)))
+  return cloudChoice ? [cloudChoice, ...localChoices] : localChoices
+}


### PR DESCRIPTION
## What changed

- Replace the native daemon selector in Add/Edit Agent with a shared, accessible listbox.
- Present AgentConnect Cloud as one branded option with managed-runtime guidance, always before local daemon choices.
- Collapse every Cloud pool member to one Edit Agent choice while retaining a concrete serving member for the existing placement contract.
- Preserve current-daemon cancellation, unavailable-target states, and keyboard navigation.

## Why

PR #959 collapsed Cloud only in Add Agent. Edit Agent still rendered every underlying Cloud Pod, so a three-member pool appeared as three identical `AgentConnect Cloud` options and exposed replaceable infrastructure identities.

## Impact

Users now see one stable Cloud choice in both agent forms. Local daemons retain readiness and credential guidance, and agent placement behavior remains unchanged server-side.

## Validation

- `pnpm --filter @agentconnect.md/web test` (146 files, 1544 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- ESLint on all changed files
- Prettier check on all changed files
- `git diff --check`