### PR TITLE
fix(daemon): keep the agent-removal obligation off the ephemeral state root

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2981,7 +2981,16 @@ export class Daemon {
     )
     this.agentsDir = cfg.agentsDir!
     this.removalObligationsDir = agentRemovalObligationsDir(root)
-    this.removedAgentTombstones = agentRemovalTombstones(this.agentsDir, this.removalObligationsDir)
+    // Opened here rather than further down: the removal obligations below are the first
+    // durable read of the boot, and in cloud mode the store is the only place they live.
+    this.store = this.dataPlane?.store ?? new LocalStore(statePath(root))
+    // Both filesystem mirrors share the state root, which is ephemeral for a cloud daemon.
+    // The store outlives it, and `agent/remove` is a fire-and-forget EVT the CP never
+    // retries, so the store row is what keeps an interrupted removal reissuable.
+    this.removedAgentTombstones = new Set([
+      ...agentRemovalTombstones(this.agentsDir, this.removalObligationsDir),
+      ...this.store.agentRemovalObligations()
+    ])
     for (const agentId of this.removedAgentTombstones) {
       this.drainingAgents.add(agentId)
       this.cpDroppedAgents.add(agentId)
@@ -3099,7 +3108,6 @@ export class Daemon {
       onDefinitionChange: (connectionId) => this.onMemoryConnectionDefinitionChange(connectionId)
     })
 
-    this.store = this.dataPlane?.store ?? new LocalStore(statePath(root))
     this.store.setTranscriptMutationListener((mutation) => this.scheduleSessionActivity(mutation))
     this.memoryOutbox = new MemoryCaptureOutbox(this.store, this.memoryConnections, {
       log: { warn: (message) => this.log.warn(message) }
@@ -19470,20 +19478,35 @@ export class Daemon {
     // already-queued re-add observes this newer removal and the queued cleanup
     // below installs a typed failure latch after stopping live authority.
     this.pendingAgentRemovals.set(agentId, (this.pendingAgentRemovals.get(agentId) ?? 0) + 1)
-    // The filesystem marker is the crash boundary: once this method returns,
-    // restart cannot rediscover and serve an old root even if asynchronous
-    // quiesce/removal never reaches its disk-delete step.
+    // The durable marker is the crash boundary: once this method returns, restart cannot
+    // rediscover and serve an old root, nor forget that the cluster still owes this agent's
+    // sandbox teardown. The store mirror leads because it is the only one a cloud daemon
+    // keeps across a pod replacement; only a total failure leaves the removal unfenced.
     let markerError: Error | undefined
+    const degraded: Error[] = []
+    let published = false
+    try {
+      this.store.recordAgentRemovalObligation(agentId, this.clock.now())
+      published = true
+    } catch (error) {
+      degraded.push(error instanceof Error ? error : new Error('agent removal obligation store write failed'))
+    }
     try {
       const marker = markAgentRemoval(this.agentsDir, agentId, this.removalObligationsDir)
+      published = true
+      degraded.push(...marker.degraded)
+    } catch (error) {
+      degraded.push(error instanceof Error ? error : new Error('agent removal tombstone publication failed'))
+    }
+    if (published) {
       this.removedAgentTombstones.add(agentId)
-      if (marker.degraded.length > 0) {
+      if (degraded.length > 0) {
         this.log.warn(
-          `cp: agent "${agentId}" removal marker is running on one durable mirror; retry will repair the other (${marker.degraded.map(formatErr).join('; ')})`
+          `cp: agent "${agentId}" removal marker is running on a reduced set of durable mirrors; retry will repair the rest (${degraded.map(formatErr).join('; ')})`
         )
       }
-    } catch (error) {
-      markerError = error instanceof Error ? error : new Error('agent removal tombstone publication failed')
+    } else {
+      markerError = new AggregateError(degraded, 'agent removal marker publication failed')
     }
     let released = false
     const release = () => {
@@ -19506,9 +19529,17 @@ export class Daemon {
    * tombstone and let a later CP retry repair it without failing the removal. */
   private clearRemovalAfterDestruction(agentId: string): void {
     const cleared = clearAgentRemoval(this.agentsDir, agentId, this.removalObligationsDir)
-    if (cleared.degraded.length > 0) {
+    const degraded = [...cleared.degraded]
+    // Best-effort like the mirrors above: the destruction already happened, so a failed
+    // discharge costs only an idempotent reissue the next time this daemon registers.
+    try {
+      this.store.clearAgentRemovalObligation(agentId)
+    } catch (error) {
+      degraded.push(error instanceof Error ? error : new Error('agent removal obligation store clear failed'))
+    }
+    if (degraded.length > 0) {
       this.log.warn(
-        `cp: agent "${agentId}" was durably removed but a tombstone mirror could not clear; retry will repair it (${cleared.degraded.map(formatErr).join('; ')})`
+        `cp: agent "${agentId}" was durably removed but a tombstone mirror could not clear; retry will repair it (${degraded.map(formatErr).join('; ')})`
       )
       return
     }
@@ -19519,8 +19550,18 @@ export class Daemon {
    * the gate can reopen, otherwise memory and restart authority would diverge. */
   private clearRemovalForReadd(agentId: string): void {
     const cleared = clearAgentRemovalForReadd(this.agentsDir, agentId, this.removalObligationsDir)
-    if (cleared.degraded.length > 0) {
-      throw new AggregateError(cleared.degraded, `cannot clear agent "${agentId}" removal tombstone for re-add`)
+    const degraded = [...cleared.degraded]
+    // The store row is the anchor: cleared last so a failure here leaves the gate closed
+    // in memory AND across restart, rather than reopening one of the two authorities.
+    if (degraded.length === 0) {
+      try {
+        this.store.clearAgentRemovalObligation(agentId)
+      } catch (error) {
+        degraded.push(error instanceof Error ? error : new Error('agent removal obligation store clear failed'))
+      }
+    }
+    if (degraded.length > 0) {
+      throw new AggregateError(degraded, `cannot clear agent "${agentId}" removal tombstone for re-add`)
     }
     this.removedAgentTombstones.delete(agentId)
   }

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -755,6 +755,15 @@ export class LocalStore {
         integrationId TEXT NOT NULL, channelId TEXT NOT NULL, retractedAt INTEGER NOT NULL,
         PRIMARY KEY (integrationId, channelId)
       );
+      -- Agents whose CP-ordered removal was admitted but not proven complete. The store
+      -- mirror of the filesystem removal markers, and the ONLY one a cloud daemon keeps:
+      -- its state root is ephemeral, while agent/remove is a fire-and-forget EVT the CP
+      -- never retries and never reaps. Losing the obligation strands the agent's sandbox
+      -- claim and workspace volume in the cluster forever, because the daemon reporting
+      -- the replica at register is the sole trigger for the CP to reissue the removal.
+      CREATE TABLE IF NOT EXISTS agent_removal_obligation (
+        agentId TEXT PRIMARY KEY, createdAt INTEGER NOT NULL
+      );
       CREATE TABLE IF NOT EXISTS permission_requests (
         id TEXT PRIMARY KEY,
         agentId TEXT NOT NULL,
@@ -1221,6 +1230,27 @@ export class LocalStore {
     this.db
       .prepare('DELETE FROM retracted_conversations WHERE integrationId = ? AND channelId = ?')
       .run(integrationId, channelId)
+  }
+
+  /** Admit a removal obligation before the destruction it fences. Idempotent: a
+   *  retried removal keeps the first admission time rather than sliding it forward. */
+  recordAgentRemovalObligation(agentId: string, now: number): void {
+    this.db
+      .prepare('INSERT OR IGNORE INTO agent_removal_obligation (agentId, createdAt) VALUES (?, ?)')
+      .run(agentId, now)
+  }
+
+  /** Agents whose removal this store still owes. Unioned into the filesystem markers at
+   *  boot, so a cloud daemon that lost its state root still reports the pending drop. */
+  agentRemovalObligations(): string[] {
+    const rows = this.db.prepare('SELECT agentId FROM agent_removal_obligation').all() as { agentId: string }[]
+    return rows.map((row) => row.agentId)
+  }
+
+  /** Discharge the obligation once the removal is durably complete, or once an
+   *  authoritative re-add has replaced the authority the obligation was fencing. */
+  clearAgentRemovalObligation(agentId: string): void {
+    this.db.prepare('DELETE FROM agent_removal_obligation WHERE agentId = ?').run(agentId)
   }
 
   /** Distinct conversation targets this agent has been triggered in through one

--- a/packages/daemon/test/daemon-k8s-ephemeral-state.test.ts
+++ b/packages/daemon/test/daemon-k8s-ephemeral-state.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Daemon } from '../src/daemon.js'
+import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
+import { LocalStore } from '../src/store/local-store.js'
+
+/** A cloud daemon's state root is an emptyDir, so a pod replacement wipes every file it
+ *  wrote. What a `--k8s` daemon reads back at boot has to survive in the cloud store
+ *  instead — these are the durable semantics that must cross a wipe, and the control
+ *  cases that prove the store is what carries them. */
+
+const REMOVED_AGENT = 'agent-doomed'
+
+function seedStateRoot(path: string): void {
+  writeFileSync(join(path, 'config.json'), JSON.stringify({ version: 1, controlPlane: { enabled: false } }))
+}
+
+function stateRoot(): string {
+  const path = mkdtempSync(join(tmpdir(), 'ac-ephemeral-state-'))
+  seedStateRoot(path)
+  return path
+}
+
+/** Replace the pod: the volume is discarded and remounted with only what the deployment
+ *  supplies, which is the config file and nothing the previous daemon wrote. */
+function replacePod(root: string): void {
+  rmSync(root, { recursive: true, force: true })
+  mkdirSync(root, { recursive: true })
+  seedStateRoot(root)
+  expect(readdirSync(root)).toEqual(['config.json'])
+}
+
+function cloudStore(): { file: string; open: () => LocalStore } {
+  const file = join(mkdtempSync(join(tmpdir(), 'ac-cloud-store-')), 'cloud-store.sqlite')
+  return { file, open: () => new LocalStore(file) }
+}
+
+function catalog(): ResolvedRuntimeCatalog {
+  const absent = { command: 'ac-k8s-absent-runtime', args: [], env: [] }
+  return {
+    entries: {
+      claude: { runtime: absent, source: 'registry', name: 'Claude Code', version: '1.0.0', skillsAgentId: 'claude' }
+    },
+    runtimes: { claude: absent }
+  }
+}
+
+/** One pod lifetime: a fresh daemon over the given state root and cloud store. */
+function daemon(root: string, store: LocalStore): Daemon {
+  return new Daemon({
+    root,
+    k8s: true,
+    openDataPlane: (async () => ({
+      store,
+      transcripts: {
+        appendTranscript: () => {},
+        insertToolCall: () => {},
+        updateToolCall: () => {},
+        transcriptTailForAgent: async () => ({ rows: [], hasMore: false, cursor: 0 }),
+        transcriptPageForAgentByEventTime: async () => ({ rows: [], hasMore: false }),
+        transcriptPageForAgent: async () => ({ rows: [], hasMore: false }),
+        currentTranscriptRevision: async () => 0,
+        getToolBodyForAgent: async () => undefined
+      },
+      close: async () => {}
+    })) as never,
+    startK8sPlane: (async () => ({
+      driver: { claimName: (id: string) => `agent-${id}` } as never,
+      listener: { listeningPort: () => 0 } as never,
+      gitRunnerFor: () => undefined,
+      launchedAgents: () => [],
+      suspendIdle: async () => 'absent',
+      discardAgent: async () => {},
+      stop: async () => {}
+    })) as never,
+    startControlPlane: vi.fn(() => Promise.resolve()) as never,
+    resolveCatalog: async () => catalog(),
+    hostFactory: () => ({}) as never
+  })
+}
+
+/** Run one pod lifetime, hand the caller the live daemon, then shut both it and the
+ *  store handle down the way a terminating pod does. */
+async function inPod(root: string, store: LocalStore, body: (d: Daemon) => void | Promise<void>): Promise<void> {
+  const instance = daemon(root, store)
+  try {
+    await instance.start()
+    await body(instance)
+  } finally {
+    await instance.stop()
+    store.close()
+  }
+}
+
+describe('--k8s durable semantics across an ephemeral state root', () => {
+  it('keeps a removed agent fenced after the state root is wiped', async () => {
+    const root = stateRoot()
+    const store = cloudStore()
+
+    await inPod(root, store.open(), (before) => {
+      // Admission of a CP removal, through the real reservation path that publishes
+      // both the filesystem markers and the store row.
+      const reservation = (
+        before as never as { reserveAgentRemoval(id: string): { markerError?: Error } }
+      ).reserveAgentRemoval(REMOVED_AGENT)
+      expect(reservation.markerError).toBeUndefined()
+    })
+
+    // The removal never reached its delete step: the pod died mid-flight and came back
+    // on a volume that has neither filesystem mirror on it.
+    replacePod(root)
+
+    await inPod(root, store.open(), (after) => {
+      const probe = after as never as {
+        removedAgentTombstones: Set<string>
+        effectiveAgents(): { id: string }[]
+        cpLocalState(): { agents: { agentId: string; origin: string }[] }
+      }
+      expect(probe.removedAgentTombstones.has(REMOVED_AGENT)).toBe(true)
+      expect(probe.effectiveAgents().map((agent) => agent.id)).not.toContain(REMOVED_AGENT)
+      // agent/remove is a fire-and-forget EVT that the CP never retries and no reaper
+      // replays, so reporting the replica here is the only thing that ever gets the
+      // agent's sandbox claim and workspace volume reclaimed.
+      expect(probe.cpLocalState().agents).toContainEqual({ agentId: REMOVED_AGENT, origin: 'cp' })
+    })
+  })
+
+  it('loses the fence when the cloud store is discarded too, isolating what carries it', async () => {
+    const root = stateRoot()
+    const store = cloudStore()
+
+    await inPod(root, store.open(), (before) => {
+      ;(before as never as { reserveAgentRemoval(id: string): unknown }).reserveAgentRemoval(REMOVED_AGENT)
+    })
+    replacePod(root)
+
+    // The control for the case above: a different database, so nothing but the wiped
+    // volume could have carried the obligation.
+    await inPod(root, cloudStore().open(), (after) => {
+      expect((after as never as { removedAgentTombstones: Set<string> }).removedAgentTombstones.size).toBe(0)
+    })
+  })
+
+  it('discharges the obligation once the removal completes, so the fence does not outlive it', async () => {
+    const root = stateRoot()
+    const store = cloudStore()
+
+    await inPod(root, store.open(), (before) => {
+      const probe = before as never as {
+        reserveAgentRemoval(id: string): unknown
+        clearRemovalAfterDestruction(id: string): void
+        removedAgentTombstones: Set<string>
+      }
+      probe.reserveAgentRemoval(REMOVED_AGENT)
+      probe.clearRemovalAfterDestruction(REMOVED_AGENT)
+      expect(probe.removedAgentTombstones.has(REMOVED_AGENT)).toBe(false)
+    })
+    replacePod(root)
+
+    await inPod(root, store.open(), (after) => {
+      expect((after as never as { removedAgentTombstones: Set<string> }).removedAgentTombstones.size).toBe(0)
+    })
+  })
+
+  it('reopens the gate across a wipe once an authoritative re-add clears the obligation', async () => {
+    const root = stateRoot()
+    const store = cloudStore()
+
+    await inPod(root, store.open(), (before) => {
+      const probe = before as never as {
+        reserveAgentRemoval(id: string): unknown
+        clearRemovalForReadd(id: string): void
+      }
+      probe.reserveAgentRemoval(REMOVED_AGENT)
+      // A complete authority replacement: the durable latch has to go with it, or the
+      // re-added agent would stay dark on every later pod.
+      probe.clearRemovalForReadd(REMOVED_AGENT)
+    })
+    replacePod(root)
+
+    await inPod(root, store.open(), (after) => {
+      expect((after as never as { removedAgentTombstones: Set<string> }).removedAgentTombstones.size).toBe(0)
+    })
+  })
+})
+
+describe('LocalStore agent removal obligations', () => {
+  it('admits, lists, and discharges obligations idempotently', () => {
+    const store = new LocalStore(':memory:')
+    try {
+      store.recordAgentRemovalObligation('a', 1)
+      store.recordAgentRemovalObligation('b', 2)
+      // A retried removal must not multiply the row or slide its admission time.
+      store.recordAgentRemovalObligation('a', 9)
+      expect(store.agentRemovalObligations().sort()).toEqual(['a', 'b'])
+
+      store.clearAgentRemovalObligation('a')
+      expect(store.agentRemovalObligations()).toEqual(['b'])
+      // Discharging an obligation that was never admitted is a no-op, not an error.
+      store.clearAgentRemovalObligation('a')
+      expect(store.agentRemovalObligations()).toEqual(['b'])
+    } finally {
+      store.close()
+    }
+  })
+})


### PR DESCRIPTION
Since #958 a `--k8s` daemon writes every durable row to PostgreSQL and never opens SQLite. But
the shared pool's members already run on an **ephemeral state root** (`emptyDir`), so anything
still durable on that filesystem is lost on pod replacement **today** — this is a live gap, not
preparation for a future change. (The per-org envelope's state PVC needs no code work of its
own: it disappears with the envelope model itself, per the k8s-daemon-pool design's D17.) This
PR inventories what is left on the state root and moves the one item that cannot survive.

## Why the removal marker is not redundant in cloud mode

The obvious reading is that the marker only fences a stale agent root, and that a wipe removes
the root and the marker together — leaving nothing to fence. That reading is wrong, and the
control plane is where it breaks:

- `agent/remove` is a fire-and-forget EVT (`orchestrator/outbound.ts`); the caller swallows a
  missing connection and the DELETE route returns 204 either way.
- The CP keeps no pending-removal row, outbox or tombstone for agents, and no reaper re-issues
  one. The only replay path is `Placement.reconcile` diffing `localState.agents` against
  `listForDaemon`: a replica the daemon reports with `origin:'cp'` and no matching row comes
  back as `drop.agents{action:'remove'}`.
- The daemon populates that report from the on-disk marker (`cpLocalState`).
- In `--k8s` the reissued removal is what calls `discardClusterSandbox` → `deleteClaim`, and the
  claim takes the agent's workspace volume with it. Nothing else does: the driver's launch map
  is empty at boot, the sandbox watch only reconciles the drain set, and there is no startup GC
  that compares live sandboxes against the roster.

So a pod killed between removal admission and the delete step, on an ephemeral root, loses the
only record that the cluster still owes that teardown. A deleted agent's checkout then sits in
the cluster permanently, and no amount of later convergence finds it.

## The fix

`agent_removal_obligation` in the cloud store, unioned with the two filesystem mirrors at boot.
Deliberately not k8s-gated: one boot path, and a self-hosted daemon gets a third mirror for
free. No schema-version bump — a brand-new table belongs in the `CREATE` block, which is
`IF NOT EXISTS` and runs on every open, so it covers fresh and upgraded stores on both drivers.

Ordering is the load-bearing part. The store row leads on publication because it is the only
mirror a cloud daemon keeps, and `markerError` now means *no* durable mirror was published
rather than *the filesystem* one was not. Both clear paths discharge the row last, so a partial
failure leaves the gate closed on every authority instead of reopening one of them.

The table is install-wide rather than keyed by daemon, and that is deliberate: a pool successor
boots with a new daemon id, so a daemon-keyed row would be stranded by exactly the pod
replacement it exists to survive. Install-wide means whichever member notices converges the
predecessor's obligation, and the CP's own reply decides what happens — no record answers
`remove` and the sandbox is reclaimed. The trade-off worth a reviewer's eye: if a lingering
obligation's agent id somehow *did* have a live CP record placed on another member, the reply
would be `detach` and the reporting member would arm a stale staged-move gate. That needs an id
to be reused after a failed removal, which CP-generated ids are not, so it is bounded and
recoverable — against a failure mode that is currently permanent and silent.

## Inventory

### (a) Durable semantic — fixed here

| Item | Where | Boot read | Action |
| --- | --- | --- | --- |
| Agent-removal obligation | `<agentsDir>/.removed/<sha>/` + `<root>/state/agent-removals/<sha>/` | yes | moved into the cloud store; filesystem mirrors retained |

### (a) Durable semantic — right home genuinely ambiguous, left as open questions

| Item | Where | Why not guessed |
| --- | --- | --- |
| Staged-move fence | `<agentsDir>/.staged/<id>/metadata.json` | Same shape as the removal marker but it does **not** self-heal: register/ok filters staged agents out of `desiredAgents`, so a stale row dark-holds an agent forever instead of being cleared by the next roster. Install-wide is therefore unsafe, and daemon-scoped does not survive a pod replacement for pool members — cloud pool identity binds per pod uid, while envelope daemons are stable per namespace. Needs a decision on the scope key first. |
| Workspace conversion + materialization markers | `.<workspace>.workspace-conversion.json`, `.<workspace>.workspace-materialization.json` | Written on the **cluster** path but landing on the daemon's own disk, while describing what a sandbox pod's volume holds. Fails open: an acknowledged repo/branch conversion is silently skipped and the agent keeps the old checkout. Arguably belongs on the pod volume next to the checkout rather than in the store. |
| CP data-root marker replica inventory | `<agentsDir>/<agent>/.cp-agent-id` | Makes an offline deletion converge. Cannot go install-wide: a pool successor boots with a **new** daemon id, so reporting install-wide replicas would make the CP answer `detach` for every agent placed on other members. |
| Managed agent memory | `<agent-root>/memory/`, `<agent-root>/channels/<key>/channel.json` | Durable user content with no cloud home today. Already broken by the pool model independently of this change — an agent that migrates between members loses it — so it wants its own design, not a table appended here. |

### (b) Rebuildable cache — safe on an ephemeral disk

`<root>/run/**` (gitcred socket, git-credential and gh shims, MCP socket) are regenerated every
boot; `<root>/acp_registry.json` and its cache are superseded in k8s by the declared table and
the sandbox probe, costing one extra fetch per pod; `<root>/managed-skills/**` is
content-addressed and refetched (and not wired on the k8s path at all); `<root>/daemon.lock`
protects a singleton the pod boundary already guarantees; `<agent-root>/run/config-files/**` and
the OS-temp probe roots are both already swept at boot; `<root>/logs/**`.

### (c) Not applicable under `--k8s`

`<root>/state/local.sqlite` is never opened (#958). The daemon id is re-derived from the
projected token on every connect and deliberately not persisted. The relay roster's offline
re-dial is `!k8s`-gated, and cloud startup awaits the CP registry before ingress anyway.
`<root>/cli-entry` and `<root>/current/**` back the self-installing upgrade, which k8s refuses
by mode. `<root>/skill-installs/**`, local workspace/worktree trees, sandbox settings files and
the runtime private HOME all sit on the non-k8s preparation branch or need an SRT mechanism a
k8s daemon never has. `.cp-config-revision.json` has test-only readers and writers — the live
fence is already in-memory. The `.detached/` cold-move archive is production-unreachable.

**One deployment note, not a code change:** `<root>/k8s-runtimes.json` is read at boot and
written by nobody. With an `emptyDir` root it must arrive via `AGENTCONNECT_K8S_RUNTIMES` or its
own mount; if it is merely dropped onto the volume today, the daemon will advertise no runtimes
until the sandbox probe returns.

## Tests

`packages/daemon/test/daemon-k8s-ephemeral-state.test.ts` runs two `--k8s` daemon lifetimes over
one cloud store, discarding and remounting the state root between them, and asserts a tombstoned
agent stays out of the effective roster and is still reported to the CP as an `origin:'cp'`
replica. Three controls keep the assertion honest: the fence disappears when the store is
discarded too (isolating what carries it), and a completed removal or an authoritative re-add
discharges the obligation so the fence does not outlive it. Reverting the boot union fails the
load-bearing case and leaves the controls green.

Verified: `tsc --noEmit`, the full `packages/daemon` vitest suite, `eslint` and `prettier` on the
changed files.

## Scope

Does not touch the operator or charts — no operator-side change follows: the per-org envelope
(and with it the daemon state PVC) retires wholesale with the pool migration rather than
piecemeal. This PR is the daemon-side fix that makes the pool's already-ephemeral state root
safe for agent removal. The four open questions above are the remaining durable items to
resolve before pool members carry production agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

