### PR TITLE
fix(control-plane): scope agent lifecycle frames to the agent org

### DIFF
--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -903,7 +903,7 @@ export function agentRoutes(deps: HttpDeps) {
       if (!agent.daemonId) return
       const spec = await deps.agentSpecs.assemble(agent)
       try {
-        await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec })
+        await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec }, agent.orgId)
       } catch (err) {
         // Best-effort (see the register/ok reconcile backstop above): the agent update is
         // ALREADY persisted, so a daemon-side hiccup must not fail the HTTP write — not just
@@ -922,10 +922,10 @@ export function agentRoutes(deps: HttpDeps) {
       }
     }
 
-    const replicateRemove = async (agentId: string, daemonId: string | null): Promise<void> => {
+    const replicateRemove = async (agentId: string, daemonId: string | null, orgId: string): Promise<void> => {
       if (!daemonId) return
       try {
-        await deps.control.agentRemove(daemonId, { agentId })
+        await deps.control.agentRemove(daemonId, { agentId }, orgId)
       } catch (err) {
         if (!(err instanceof NoConnection)) throw err
         app.log.debug({ agentId, daemonId }, 'agent/remove skipped: daemon offline')
@@ -2489,7 +2489,7 @@ export function agentRoutes(deps: HttpDeps) {
               )
             }
           }
-          await replicateRemove(current.id, current.daemonId)
+          await replicateRemove(current.id, current.daemonId, current.orgId)
           if (current.daemonId && current.memory?.provider === 'external') {
             await removeExternalMemoryFromDaemonIfUnused(current.orgId, current.daemonId, current.memory.connectionId)
           }

--- a/packages/control-plane/src/http/routes/icon-upload.ts
+++ b/packages/control-plane/src/http/routes/icon-upload.ts
@@ -62,11 +62,15 @@ export function iconUploadRoutes(deps: HttpDeps) {
       const agent = await deps.repos.agent.get(orgId, AgentId(agentId))
       if (!agent?.daemonId) return
       try {
-        await deps.control.agentUpsert(agent.daemonId, {
-          agentId: agent.id,
-          // The assembler owns secret loading + icon bases — full spec per upsert.
-          spec: await deps.agentSpecs.assemble(agent)
-        })
+        await deps.control.agentUpsert(
+          agent.daemonId,
+          {
+            agentId: agent.id,
+            // The assembler owns secret loading + icon bases — full spec per upsert.
+            spec: await deps.agentSpecs.assemble(agent)
+          },
+          agent.orgId
+        )
       } catch (err) {
         app.log.warn({ err, agentId }, 'icon replicate agent/upsert failed (backstop: reconnect roster)')
       }

--- a/packages/control-plane/src/http/routes/organization-environment.ts
+++ b/packages/control-plane/src/http/routes/organization-environment.ts
@@ -124,7 +124,7 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
           if (!agent.daemonId) return
           try {
             const spec = await deps.agentSpecs.assemble(agent)
-            await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec })
+            await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec }, agent.orgId)
           } catch (err) {
             app.log.warn(
               { err, orgId, agentId: agent.id, reason },

--- a/packages/control-plane/src/http/routes/organization-knowledge.ts
+++ b/packages/control-plane/src/http/routes/organization-knowledge.ts
@@ -218,7 +218,7 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
           if (!agent.daemonId) return
           try {
             const spec = await deps.agentSpecs.assemble(agent)
-            await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec })
+            await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec }, agent.orgId)
           } catch (err) {
             app.log.warn({ err, agentId: agent.id }, 'managed-skill fan-out deferred to reconnect roster')
           }

--- a/packages/control-plane/src/http/routes/skill-sources.ts
+++ b/packages/control-plane/src/http/routes/skill-sources.ts
@@ -150,7 +150,7 @@ export function skillSourceRoutes(deps: HttpDeps) {
       if (!agent.daemonId) return
       const spec = await deps.agentSpecs.assemble(agent)
       try {
-        await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec })
+        await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec }, agent.orgId)
       } catch (err) {
         if (err instanceof NoConnection) {
           app.log.debug({ agentId: agent.id, daemonId: agent.daemonId }, 'skill fan-out: daemon offline')

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -33,6 +33,7 @@ const PLATFORMS = buildCpPlatformRegistry([
 ])
 
 const AGENT = AgentId('11111111-1111-4111-8111-111111111111')
+const ORG = OrgId('55555555-5555-4555-8555-555555555555')
 const SOURCE = DaemonId('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
 const TARGET = DaemonId('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')
 const INTEGRATION = IntegrationId('22222222-2222-4222-8222-222222222222')
@@ -53,7 +54,7 @@ const GITHUB_WORKSPACE = {
 function agent(daemonId: string | null): AgentRecord {
   return {
     id: AGENT,
-    orgId: OrgId('55555555-5555-4555-8555-555555555555'),
+    orgId: ORG,
     name: 'mover',
     displayName: null,
     builtin: false,
@@ -87,7 +88,7 @@ function agent(daemonId: string | null): AgentRecord {
 
 const integration = {
   id: INTEGRATION,
-  orgId: OrgId('55555555-5555-4555-8555-555555555555'),
+  orgId: ORG,
   agentId: AGENT,
   botId: BOT,
   platform: 'slack',
@@ -98,7 +99,7 @@ const integration = {
 
 const bot = {
   id: BOT,
-  orgId: OrgId('55555555-5555-4555-8555-555555555555'),
+  orgId: ORG,
   platform: 'slack',
   name: 'Slack',
   prebuilt: false,
@@ -116,7 +117,7 @@ const bot = {
 
 const cron = {
   id: CRON,
-  orgId: OrgId('55555555-5555-4555-8555-555555555555'),
+  orgId: ORG,
   agentId: AGENT,
   name: 'daily',
   schedule: '0 0 * * *',
@@ -163,6 +164,9 @@ function make(
   const calls: string[] = []
   const activations: AgentActivate[] = []
   const detaches: AgentDetach[] = []
+  // The org each control frame was scoped to — undefined is what an install-wide
+  // member's connection rejects, so it is the interesting value here.
+  const frameOrgs: Array<string | undefined> = []
   const releasedLive: (typeof SESSION_KEY)[] = []
   const mutations = new AgentMutationGate()
   const repo = {
@@ -217,9 +221,10 @@ function make(
   const appliedRevisions = new Map<string, bigint>()
   let targetDetachCount = 0
   const control = {
-    agentDetach: async (daemonId: string, value: AgentDetach) => {
+    agentDetach: async (daemonId: string, value: AgentDetach, orgId?: string) => {
       calls.push(`detach:${daemonId}`)
       detaches.push(value)
+      frameOrgs.push(orgId)
       if (daemonId === SOURCE && targetDetachCount === 0 && opts.waitSourceDetach) {
         opts.sourceDetachStarted?.()
         await opts.waitSourceDetach
@@ -230,9 +235,10 @@ function make(
       }
       return ack()
     },
-    agentActivate: async (daemonId: string, value: AgentActivate) => {
+    agentActivate: async (daemonId: string, value: AgentActivate, orgId?: string) => {
       calls.push(`activate:${daemonId}`)
       activations.push(value)
+      frameOrgs.push(orgId)
       // The target's own revision fence, which the CP cannot see and must not violate: a bundle
       // older than the one this daemon already applied activates stale credentials and is refused.
       // A rejected activation still leaves its spec applied, so a rollback has to be newer.
@@ -291,7 +297,7 @@ function make(
     mutations,
     sessionOwners: { releaseSession: (key) => void releasedLive.push(key as typeof SESSION_KEY) }
   })
-  return { service, calls, activations, detaches, mutations, releasedLive, current: () => current }
+  return { service, calls, activations, detaches, frameOrgs, mutations, releasedLive, current: () => current }
 }
 
 describe('AgentMoveService', () => {
@@ -301,6 +307,16 @@ describe('AgentMoveService', () => {
     await expect(t.service.ensureActive(t.current())).resolves.toMatchObject({ daemonId: SOURCE })
     expect(t.activations).toHaveLength(1)
     expect(t.activations[0]?.reconcileWorkspace).toBe(true)
+  })
+
+  it('scopes every move frame to the agent org, so an install-wide member accepts it', async () => {
+    // A pool member's connection carries no org and neither `{agentId, moveId}`
+    // nor an agent it has never installed can supply one, so an unscoped frame is
+    // refused with SCOPE_DENIED before it leaves the CP.
+    const t = make()
+    await t.service.move(t.current(), TARGET)
+    expect(t.frameOrgs.length).toBeGreaterThan(0)
+    expect(t.frameOrgs.every((orgId) => orgId === ORG)).toBe(true)
   })
 
   it('hard-cuts the source, bootstraps the complete target bundle, and activates last', async () => {

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -239,22 +239,28 @@ export class AgentMoveService {
       const current = await this.deps.agents.getUnscoped(agentId)
       if (!current || current.daemonId !== daemonId) return
 
-      const candidate = await this.snapshotOwned(agentId, daemonId)
-      const resumed = await this.deps.control.agentActivate(daemonId, {
-        ...this.activationDefinition(candidate.agent, candidate.bundle),
-        moveId,
-        reconcileWorkspace: true
-      })
+      const candidate = await this.snapshotOwned(agentId, daemonId, current.orgId)
+      const resumed = await this.deps.control.agentActivate(
+        daemonId,
+        {
+          ...this.activationDefinition(candidate.agent, candidate.bundle),
+          moveId,
+          reconcileWorkspace: true
+        },
+        candidate.agent.orgId
+      )
 
       let stable: ActivationSnapshot
       if (resumed.ok) {
-        const observed = await this.snapshotOwned(agentId, daemonId)
+        const observed = await this.snapshotOwned(agentId, daemonId, current.orgId)
         if (candidate.fingerprint === observed.fingerprint) {
           const confirmed = await this.deps.agents.getUnscoped(agentId)
-          if (!confirmed || confirmed.daemonId !== daemonId) return this.failClosedOwnership(agentId, daemonId)
+          if (!confirmed || confirmed.daemonId !== daemonId) {
+            return this.failClosedOwnership(agentId, daemonId, current.orgId)
+          }
           stable = { ...observed, agent: confirmed }
         } else {
-          stable = await this.activateUntilStable(agentId, daemonId, 'staged reconnect recovery', {
+          stable = await this.activateUntilStable(agentId, daemonId, 'staged reconnect recovery', current.orgId, {
             reconcileWorkspace: true
           })
         }
@@ -262,7 +268,7 @@ export class AgentMoveService {
         // A conversion may have crashed after swapping its checkout, where the
         // old token retains a one-shot empty-workspace guard. A fresh generic
         // token safely supersedes that fence and completes from current CP state.
-        stable = await this.activateUntilStable(agentId, daemonId, 'staged reconnect recovery', {
+        stable = await this.activateUntilStable(agentId, daemonId, 'staged reconnect recovery', current.orgId, {
           reconcileWorkspace: true
         })
       }
@@ -276,7 +282,7 @@ export class AgentMoveService {
     if (!agent.daemonId) throw new AgentMoveConflict('agent is not placed')
     let stable: ActivationSnapshot
     try {
-      stable = await this.activateUntilStable(agent.id, agent.daemonId, 'target repair', {
+      stable = await this.activateUntilStable(agent.id, agent.daemonId, 'target repair', agent.orgId, {
         reconcileWorkspace: true
       })
     } catch (err) {
@@ -303,7 +309,7 @@ export class AgentMoveService {
       }
       // Lost-response repair: the daemon's durable materialization marker makes
       // this replay idempotent even when the prior edit changed repo/branch/mode.
-      const stable = await this.activateUntilStable(agent.id, agent.daemonId, 'workspace edit repair', {
+      const stable = await this.activateUntilStable(agent.id, agent.daemonId, 'workspace edit repair', agent.orgId, {
         reconcileWorkspace: true
       })
       await this.finalizeWorkspaceChange(stable.agent, workspaceRepoId, stable.bundle.httpBotIds)
@@ -342,10 +348,7 @@ export class AgentMoveService {
     const moveId = randomUUID()
     let detached: Ack
     try {
-      detached = await this.deps.control.agentDetach(daemonId, {
-        agentId: agent.id,
-        moveId
-      })
+      detached = await this.deps.control.agentDetach(daemonId, { agentId: agent.id, moveId }, agent.orgId)
     } catch (err) {
       throw new AgentMoveFailed('workspace edit could not drain the agent', err)
     }
@@ -410,11 +413,15 @@ export class AgentMoveService {
 
     let activated: Ack
     try {
-      activated = await this.deps.control.agentActivate(daemonId, {
-        ...this.activationDefinition(converted, bundle),
-        moveId,
-        reconcileWorkspace: true
-      })
+      activated = await this.deps.control.agentActivate(
+        daemonId,
+        {
+          ...this.activationDefinition(converted, bundle),
+          moveId,
+          reconcileWorkspace: true
+        },
+        converted.orgId
+      )
     } catch (err) {
       // The daemon may have committed and only lost the response. Never roll DB
       // authority back on an unknown outcome; the same request repairs safely.
@@ -442,7 +449,10 @@ export class AgentMoveService {
 
     if (sourceDaemonId) {
       try {
-        requireAck('source cutover', await this.detach(sourceDaemonId, agent.id, { discardActiveTurns: true }))
+        requireAck(
+          'source cutover',
+          await this.detach(sourceDaemonId, agent.id, agent.orgId, { discardActiveTurns: true })
+        )
       } catch (err) {
         if (sourceDetachMode === 'required') {
           if (err instanceof AgentMoveFailed) throw err
@@ -485,7 +495,7 @@ export class AgentMoveService {
       // Re-read the full wire definition only AFTER the placement CAS. The
       // stability loop re-reads after each ACK and re-stages/re-activates if an
       // out-of-band writer changed any spec, integration, secret, or cron.
-      stable = await this.activateUntilStable(moved.id, targetDaemonId, 'target')
+      stable = await this.activateUntilStable(moved.id, targetDaemonId, 'target', moved.orgId)
     } catch (err) {
       if (err instanceof AgentMoveFailClosed) throw err
       const rolledBack = await this.rollback(agent, moved, sourceDaemonId, targetDaemonId, editor, sourceBundle)
@@ -514,11 +524,15 @@ export class AgentMoveService {
     try {
       requireAck(
         `workspace restore after ${after}`,
-        await this.deps.control.agentActivate(daemonId, {
-          ...this.activationDefinition(agent, bundle),
-          moveId,
-          reconcileWorkspace: true
-        })
+        await this.deps.control.agentActivate(
+          daemonId,
+          {
+            ...this.activationDefinition(agent, bundle),
+            moveId,
+            reconcileWorkspace: true
+          },
+          agent.orgId
+        )
       )
     } catch (err) {
       // The rejection that started this is what an operator has to act on; the restoration failure
@@ -664,10 +678,10 @@ export class AgentMoveService {
     }
   }
 
-  private async snapshotOwned(agentId: AgentId, targetDaemonId: DaemonId): Promise<ActivationSnapshot> {
+  private async snapshotOwned(agentId: AgentId, targetDaemonId: DaemonId, orgId: string): Promise<ActivationSnapshot> {
     const agent = await this.deps.agents.getUnscoped(agentId)
     if (!agent || agent.daemonId !== targetDaemonId) {
-      return this.failClosedOwnership(agentId, targetDaemonId)
+      return this.failClosedOwnership(agentId, targetDaemonId, orgId)
     }
     const bundle = await this.snapshot(agent)
     return {
@@ -686,21 +700,22 @@ export class AgentMoveService {
     agentId: AgentId,
     targetDaemonId: DaemonId,
     label: string,
+    orgId: string,
     workspace: Pick<AgentActivate, 'prepareWorkspace' | 'reconcileWorkspace'> = {}
   ): Promise<ActivationSnapshot> {
-    let candidate = await this.snapshotOwned(agentId, targetDaemonId)
+    let candidate = await this.snapshotOwned(agentId, targetDaemonId, orgId)
     for (let attempt = 1; attempt <= MAX_STABILITY_ATTEMPTS; attempt += 1) {
       // A committed token is idempotent by design, so every replay needs a new
       // detach/activate token pair. The newer detach also fences a delayed
       // activate from any prior attempt.
       await this.bootstrap(targetDaemonId, candidate.agent, candidate.bundle, `${label} attempt ${attempt}`, workspace)
-      const observed = await this.snapshotOwned(agentId, targetDaemonId)
+      const observed = await this.snapshotOwned(agentId, targetDaemonId, orgId)
       if (candidate.fingerprint === observed.fingerprint) {
         // Explicit final ownership read: an agent deleted or re-placed after the
         // ACK must never leave this target serving an orphaned copy.
         const confirmed = await this.deps.agents.getUnscoped(agentId)
         if (!confirmed || confirmed.daemonId !== targetDaemonId) {
-          return this.failClosedOwnership(agentId, targetDaemonId)
+          return this.failClosedOwnership(agentId, targetDaemonId, orgId)
         }
         return { ...observed, agent: confirmed }
       }
@@ -711,9 +726,9 @@ export class AgentMoveService {
     )
   }
 
-  private async failClosedOwnership(agentId: AgentId, targetDaemonId: DaemonId): Promise<never> {
+  private async failClosedOwnership(agentId: AgentId, targetDaemonId: DaemonId, orgId: string): Promise<never> {
     try {
-      requireAck('target detach after ownership change', await this.detach(targetDaemonId, agentId))
+      requireAck('target detach after ownership change', await this.detach(targetDaemonId, agentId, orgId))
     } catch (err) {
       throw new AgentMoveFailClosed(
         'agent placement changed during move and target detach was not confirmed; manual recovery is required',
@@ -726,13 +741,18 @@ export class AgentMoveService {
   private detach(
     daemonId: DaemonId,
     agentId: AgentId,
+    orgId: string,
     options: { moveId?: string; discardActiveTurns?: boolean } = {}
   ): Promise<Ack> {
-    return this.deps.control.agentDetach(daemonId, {
-      agentId,
-      moveId: options.moveId ?? randomUUID(),
-      ...(options.discardActiveTurns ? { discardActiveTurns: true } : {})
-    })
+    return this.deps.control.agentDetach(
+      daemonId,
+      {
+        agentId,
+        moveId: options.moveId ?? randomUUID(),
+        ...(options.discardActiveTurns ? { discardActiveTurns: true } : {})
+      },
+      orgId
+    )
   }
 
   private async rollback(
@@ -747,7 +767,7 @@ export class AgentMoveService {
     // an unavailable target may still be running the partial copy, and restoring
     // source in that state would create split brain.
     try {
-      requireAck('target detach rollback', await this.detach(targetDaemonId, moved.id))
+      requireAck('target detach rollback', await this.detach(targetDaemonId, moved.id, moved.orgId))
     } catch (err) {
       this.deps.log?.warn(
         { err, agentId: moved.id, targetDaemonId },
@@ -792,14 +812,18 @@ export class AgentMoveService {
     // definition. Activate persists, exact-prunes, reconciles, and warms this
     // complete snapshot synchronously while the staging tombstone remains armed.
     const moveId = randomUUID()
-    requireAck(`${label} staging detach`, await this.detach(daemonId, agent.id, { moveId }))
+    requireAck(`${label} staging detach`, await this.detach(daemonId, agent.id, agent.orgId, { moveId }))
     requireAck(
       `${label} activate`,
-      await this.deps.control.agentActivate(daemonId, {
-        ...this.activationDefinition(agent, bundle),
-        moveId,
-        ...workspace
-      })
+      await this.deps.control.agentActivate(
+        daemonId,
+        {
+          ...this.activationDefinition(agent, bundle),
+          moveId,
+          ...workspace
+        },
+        agent.orgId
+      )
     )
   }
 

--- a/packages/control-plane/src/orchestrator/outbound.agent-move.test.ts
+++ b/packages/control-plane/src/orchestrator/outbound.agent-move.test.ts
@@ -7,6 +7,7 @@ import { ControlSender } from './outbound.js'
 const DAEMON = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const AGENT = '11111111-1111-4111-8111-111111111111'
 const MOVE = '22222222-2222-4222-8222-222222222222'
+const ORG = 'org-1'
 
 function state(conn: ConnChannel, sessionEpoch = 7): DaemonConnState {
   return {
@@ -32,29 +33,38 @@ describe('ControlSender agent move controls', () => {
     registry.add(state(conn))
     const sender = new ControlSender(registry, {} as LaunchRepo)
 
-    await expect(sender.agentDetach(DAEMON, { agentId: AGENT, moveId: MOVE })).resolves.toEqual({ ok: true })
+    await expect(sender.agentDetach(DAEMON, { agentId: AGENT, moveId: MOVE }, ORG)).resolves.toEqual({ ok: true })
     await expect(
-      sender.agentActivate(DAEMON, {
-        agentId: AGENT,
-        moveId: MOVE,
-        spec: { name: 'mover' },
-        integrations: [],
-        crons: []
-      })
+      sender.agentActivate(
+        DAEMON,
+        {
+          agentId: AGENT,
+          moveId: MOVE,
+          spec: { name: 'mover' },
+          integrations: [],
+          crons: []
+        },
+        ORG
+      )
     ).resolves.toEqual({ ok: true })
 
+    // The org rides as the explicit last argument: an install-wide member's
+    // connection carries none, and neither payload names one.
     expect(request).toHaveBeenNthCalledWith(
       1,
       'agent/detach',
       { agentId: AGENT, moveId: MOVE },
-      { epoch: 7, agentId: AGENT }
+      { epoch: 7, agentId: AGENT },
+      undefined,
+      ORG
     )
     expect(request).toHaveBeenNthCalledWith(
       2,
       'agent/activate',
       { agentId: AGENT, moveId: MOVE, spec: { name: 'mover' }, integrations: [], crons: [] },
       { epoch: 7, agentId: AGENT },
-      { ackTimeoutMs: 60_000, maxTries: 5 }
+      { ackTimeoutMs: 60_000, maxTries: 5 },
+      ORG
     )
   })
 
@@ -72,13 +82,17 @@ describe('ControlSender agent move controls', () => {
     registry.add(state(first))
     const sender = new ControlSender(registry, {} as LaunchRepo)
 
-    const activation = sender.agentActivate(DAEMON, {
-      agentId: AGENT,
-      moveId: MOVE,
-      spec: { name: 'mover' },
-      integrations: [],
-      crons: []
-    })
+    const activation = sender.agentActivate(
+      DAEMON,
+      {
+        agentId: AGENT,
+        moveId: MOVE,
+        spec: { name: 'mover' },
+        integrations: [],
+        crons: []
+      },
+      ORG
+    )
     await vi.waitFor(() => expect(firstRequest).toHaveBeenCalledOnce())
 
     const nextRequest = vi.fn(async () => ({ ok: true }) as Ack)
@@ -91,11 +105,13 @@ describe('ControlSender agent move controls', () => {
     registry.add(state(next, 8))
 
     await expect(activation).resolves.toEqual({ ok: true })
+    // The retry on the replacement connection carries the same org.
     expect(nextRequest).toHaveBeenCalledWith(
       'agent/activate',
       { agentId: AGENT, moveId: MOVE, spec: { name: 'mover' }, integrations: [], crons: [] },
       { epoch: 8, agentId: AGENT },
-      { ackTimeoutMs: 60_000, maxTries: 5 }
+      { ackTimeoutMs: 60_000, maxTries: 5 },
+      ORG
     )
   })
 

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -294,27 +294,39 @@ export class ControlSender {
     }
   }
 
+  // The agent-lifecycle frames below take an explicit orgId: on an install-wide
+  // (frame-mode) member the connection carries no org, and a payload like
+  // `{agentId, moveId}` for an agent the member has never installed cannot be
+  // resolved from the connection's org maps either — the send would throw
+  // SCOPE_DENIED before the frame ever left the process.
+
   /** Push an edited agent spec and wait until the daemon's live reconcile applies it. */
-  async agentUpsert(daemonId: string, u: AgentUpsert): Promise<void> {
+  async agentUpsert(daemonId: string, u: AgentUpsert, orgId?: string): Promise<void> {
     const c = this.must(daemonId)
-    const ack = await c.conn.request<Ack>('agent/upsert', u, { epoch: c.sessionEpoch, agentId: u.agentId })
+    const ack = await c.conn.request<Ack>(
+      'agent/upsert',
+      u,
+      { epoch: c.sessionEpoch, agentId: u.agentId },
+      undefined,
+      orgId
+    )
     if (!ack.ok) throw new Error(`agent upsert rejected${ack.reason ? `: ${ack.reason}` : ''}`)
   }
 
   /** Tell a running daemon an agent was deleted (live CRUD, epoch-fenced EVT). */
-  async agentRemove(daemonId: string, r: AgentRemove): Promise<void> {
+  async agentRemove(daemonId: string, r: AgentRemove, orgId?: string): Promise<void> {
     const c = this.must(daemonId)
-    c.conn.send('agent/remove', r, { epoch: c.sessionEpoch, agentId: r.agentId })
+    c.conn.send('agent/remove', r, { epoch: c.sessionEpoch, agentId: r.agentId }, orgId)
   }
 
   /** Fence and archive an agent before a daemon move or workspace edit (REQ → ack). */
-  async agentDetach(daemonId: string, d: AgentDetach): Promise<Ack> {
+  async agentDetach(daemonId: string, d: AgentDetach, orgId?: string): Promise<Ack> {
     const c = this.must(daemonId)
-    return c.conn.request<Ack>('agent/detach', d, { epoch: c.sessionEpoch, agentId: d.agentId })
+    return c.conn.request<Ack>('agent/detach', d, { epoch: c.sessionEpoch, agentId: d.agentId }, undefined, orgId)
   }
 
   /** Activate a fully bootstrapped/restored agent after a daemon move (REQ → ack). */
-  async agentActivate(daemonId: string, a: AgentActivate): Promise<Ack> {
+  async agentActivate(daemonId: string, a: AgentActivate, orgId?: string): Promise<Ack> {
     let c = await this.activationConnection(daemonId)
     for (let connectionTry = 1; ; connectionTry += 1) {
       try {
@@ -322,7 +334,8 @@ export class ControlSender {
           'agent/activate',
           a,
           { epoch: c.sessionEpoch, agentId: a.agentId },
-          { ackTimeoutMs: COLD_ACTIVATE_ACK_TIMEOUT_MS, maxTries: COLD_ACTIVATE_MAX_TRIES }
+          { ackTimeoutMs: COLD_ACTIVATE_ACK_TIMEOUT_MS, maxTries: COLD_ACTIVATE_MAX_TRIES },
+          orgId
         )
       } catch (err) {
         if (!(err instanceof ConnectionClosed) || connectionTry >= COLD_ACTIVATE_MAX_CONNECTIONS) throw err


### PR DESCRIPTION
An agent placed on an install-wide (frame-mode) pool member could not be moved,
activated, detached, or re-synced. Every one of those frames was built with no
`orgId`, and the connection refused it with `SCOPE_DENIED` before it left the
process.

## Why it only breaks on a pool member

`DaemonConnection.organizationFor` resolves a frame's org in three steps: the
connection's own auth-scoped org, then an explicit `orgId` on the payload, then
the per-connection `id → org` maps built at `register`. An install-wide member
fails all three:

- it has no connection org by construction (one member serves every org);
- `agent/detach` is `{agentId, moveId}` and `agent/activate` carries a spec with
  no org field;
- the maps only cover agents the member has already installed — and the agent
  being moved *to* it is, by definition, not one of them.

So the first frame of a move to a pool member throws. The placement CAS commits,
the member never learns about the agent, and the console reports the agent as
having no live daemon while the member logs
`no agent "<id>" on this daemon — rejecting turn`.

Org-scoped daemons were never affected: their connection org short-circuits the
resolution before any of this matters.

## The fix

The org is known at every call site — the agent record carries it — so the four
agent-lifecycle senders (`agentUpsert`, `agentRemove`, `agentDetach`,
`agentActivate`) take it explicitly and pass it to `request`/`send`, which
already accept an org override for exactly this case. `AgentMoveService` threads
it through its private helpers rather than re-reading the agent, so the org
always comes from the same record the frame's contents came from.

Behavior for org-scoped daemons is unchanged: the connection's own org still
wins over the argument.

## Tests

- `agentMove.test.ts` records the org of every emitted control frame and asserts
  a full move scopes all of them. It is load-bearing: reverting any single call
  site fails it, and it fails against the pre-fix code.
- `outbound.agent-move.test.ts` pins the wire shape, including that the retry on
  a replacement connection carries the same org.

Verified: `typecheck`, `lint`, control-plane unit (1674) and integration (1218).

## Scope

Placement itself is untouched. Assigning a cloud agent a concrete member id is
the current transitional model — the duty ledger derives grants from
`agent.daemonId` under the `incumbent` policy — and this PR only makes that path
work on a member whose connection is org-less. Moving cloud placement to
"leave `daemonId` empty, let the lease decide" needs spec-follow-grant plus the
daemon self-fence and the enforcement flip, all tracked in #955.
