### PR TITLE
fix(daemon): clean up Kubernetes runtime plane hygiene

### DIFF
--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -8,7 +8,7 @@ local child process, and how the two halves talk. Companion to
 Staged scope: this describes the mechanism. The hardened security model — an isolating
 runtimeClass, admission policy, egress control, and a managed egress proxy so a provider
 key never enters the sandbox — is a separate, later plan. Until it lands, the pod and the
-per-org namespace are the only isolation boundaries, and a provider key is present inside
+shared Sandbox namespace are the only isolation boundaries, and a provider key is present inside
 the sandbox, so this shape suits internal dogfooding and self-hosted
 bring-your-own-key. As an interim step the runtime image accepts deployment-owned provider
 config from the pod environment — `AC_CLAUDE_BASE_URL`/`AC_CLAUDE_API_KEY` and
@@ -67,6 +67,10 @@ direction also makes a future daemon pool possible: the duty holder can dial the
 sandbox it owns without publishing a callback endpoint for every daemon. What
 "duty holder" means — the pool, the lease ledger, the heartbeat exchange, and
 the activation rendezvous — is [k8s-daemon-pool.md](k8s-daemon-pool.md).
+
+The daemon pool and agent sandboxes are separate namespaces. The runtime plane requires
+`AC_K8S_SANDBOX_NAMESPACE` and uses it for every `SandboxClaim` and `Sandbox` request; it never
+defaults to the namespace mounted into the daemon Pod's ServiceAccount.
 
 ## 3. Binding: proving which pod accepted the connection
 
@@ -217,38 +221,13 @@ unwritable by the runtime — one it could rewrite is one it could replace with 
 asks the daemon for credentials in its name. It shares its implementation with the daemon's
 CLI helper and differs only in which socket it dials.
 
-## 7. Draining for a runtime-image rollout
+## 7. Runtime-image rollout ownership
 
-The daemon owns when an agent's pod runs, so an image rollout cannot simply replace it — a
-forced suspend would kill whatever turn is in flight. Instead the rollout _asks_, by writing
-`agentconnect.md/drain-requested` on the Sandbox, and the daemon answers with
-the one action that is its to take: it stops placing new work on that instance and suspends it
-once the work already there ends — immediately when there is none. The rollout's conditioned
-image patch then applies, because the instance is Suspended.
-
-The consumer is a list-then-watch over the namespace's Sandboxes, started with the runtime
-plane rather than by a launch: the instance a rollout waits on is usually the idle one nobody
-is about to launch, and a request nothing reads would stall the rollout until its deadline.
-Three properties this shape buys:
-
-- **Snapshots converge.** Each re-LIST replaces the whole drain set, so a watch gap that swallowed
-  a request's removal cannot hold an instance down forever.
-- **No launch record required.** Requests are keyed by Sandbox name, not by agent, so an instance
-  this daemon has not bound in this process — after a restart, or for an agent that has been quiet
-  — is still drained. Keying by agent would have made exactly the idle case unreachable.
-- **In-flight work is held, not raced.** Work leases its Sandbox: the bind, the cold workspace
-  preparation that runs in the pod after it (clone, pull, skill materialization — one lease around
-  the whole of it, not around the bind alone), the runtime until it exits, and the runtime probe
-  across its whole request rather than across its bind — a probe can run for minutes with nothing
-  else marking that sandbox as in use, and a daemon whose probe failed advertises no runtimes and
-  does not retry. A request that
-  arrives while a lease is held waits for it instead of pulling the pod out from under it.
-  Taking a lease on an already-draining instance is refused instead, by type
-  (`SandboxDrainingError` → the `draining` launch outcome): nothing has started yet, so the
-  rollout wins that decision and the caller retries once the request clears.
-
-A drain the daemon never completes is the rollout's to give up on, not the daemon's to force:
-the rollout marks the instance `failed` after its own deadline, and the pod keeps serving.
+The retired per-org operator was the sole producer of `agentconnect.md/drain-requested`.
+Consequently the daemon no longer watches every Sandbox for that orphaned annotation. Pool-member
+rollout is owned by the daemon Deployment and duty-release flow; agent compute migrates through the
+ordinary idle suspension path described below. Work holds its Sandbox only to prevent that idle
+sweep from suspending the pod during a bind, workspace preparation, runtime, or runtime probe.
 
 ## 8. The lifecycle of an idle agent: suspend, resume, discard
 

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -74,7 +74,8 @@ defaults to the namespace mounted into the daemon Pod's ServiceAccount.
 
 Runtime probes use a member-hashed claim name plus an expiry annotation. A label-filtered daemon
 sweep deletes expired claims, bounding resources left by a crash or failed teardown without reading
-daemon-local storage or touching ordinary agent claims.
+daemon-local storage or touching ordinary agent claims. UID/resourceVersion delete preconditions
+prevent a stale sweep from deleting a same-name claim recreated by a container restart.
 
 ## 3. Binding: proving which pod accepted the connection
 

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -72,6 +72,10 @@ The daemon pool and agent sandboxes are separate namespaces. The runtime plane r
 `AC_K8S_SANDBOX_NAMESPACE` and uses it for every `SandboxClaim` and `Sandbox` request; it never
 defaults to the namespace mounted into the daemon Pod's ServiceAccount.
 
+Runtime probes use a member-hashed claim name plus an expiry annotation. A label-filtered daemon
+sweep deletes expired claims, bounding resources left by a crash or failed teardown without reading
+daemon-local storage or touching ordinary agent claims.
+
 ## 3. Binding: proving which pod accepted the connection
 
 A shim connection must be bound to the pod it claims to be, before it is given anything.

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -135,7 +135,9 @@ names the shared namespace where the runtime plane reads and writes SandboxClaim
 and Sandboxes. Each member also receives its Pod UID through the Downward API as
 `AC_K8S_MEMBER_ID`; the runtime probe hashes it into
 `agent-ac-runtime-probe-<member-hash>`, so simultaneous member startup never races
-on one probe claim.
+on one probe claim. Probe claims carry a dedicated label and a 15-minute expiry;
+members periodically delete expired claims, so a missed teardown cannot retain a
+Sandbox and volume forever.
 
 **Org-threading is the end state; instantiation is scaffolding.** The wire
 carries the org, the data plane carries the org, and the process interior

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -137,7 +137,8 @@ and Sandboxes. Each member also receives its Pod UID through the Downward API as
 `agent-ac-runtime-probe-<member-hash>`, so simultaneous member startup never races
 on one probe claim. Probe claims carry a dedicated label and a 15-minute expiry;
 members periodically delete expired claims, so a missed teardown cannot retain a
-Sandbox and volume forever.
+Sandbox and volume forever. Each GC delete carries the UID and resourceVersion from
+its LIST snapshot, so a same-name replacement cannot be deleted by a stale sweep.
 
 **Org-threading is the end state; instantiation is scaffolding.** The wire
 carries the org, the data plane carries the org, and the process interior

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -129,6 +129,14 @@ WebSocket is install-wide with `orgId` carried per frame (`organizationMode:
 'frame'`); there is no org room, org-specific connection, or per-org
 subscription (D9).
 
+**The pool and sandboxes occupy two explicit namespaces.** The daemon Pod's
+ServiceAccount namespace identifies the member pool only; `AC_K8S_SANDBOX_NAMESPACE`
+names the shared namespace where the runtime plane reads and writes SandboxClaims
+and Sandboxes. Each member also receives its Pod UID through the Downward API as
+`AC_K8S_MEMBER_ID`; the runtime probe hashes it into
+`agent-ac-runtime-probe-<member-hash>`, so simultaneous member startup never races
+on one probe claim.
+
 **Org-threading is the end state; instantiation is scaffolding.** The wire
 carries the org, the data plane carries the org, and the process interior
 converges on the same axis: subsystems take the org as an explicit parameter,

--- a/packages/daemon/src/k8s/cluster-metrics.ts
+++ b/packages/daemon/src/k8s/cluster-metrics.ts
@@ -15,7 +15,7 @@ export type LaunchStage =
   | 'session_replay' // session/load replay
   | 'first_token' // first token of the first turn
 
-export type LaunchOutcome = 'ok' | 'timeout' | 'draining' | 'error'
+export type LaunchOutcome = 'ok' | 'timeout' | 'error'
 
 // Fixed daemon-authored reasons only. A rejection reason is the one thing a failing handshake
 // tells an operator, and a free-form string here would be both unbounded cardinality and a

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -19,10 +19,6 @@ import { K8sApiError } from '@agentconnect.md/k8s-client'
 export const AC_LABEL_ORG = 'agentconnect.md/org'
 export const AC_LABEL_AGENT = 'agentconnect.md/agent'
 
-/** Annotation an image rollout writes to ask a daemon to quiesce a Sandbox (`<rolloutId>/<image>`).
- *  The rollout is the producer; this is the consumer. */
-export const DRAIN_REQUESTED_ANNOTATION = 'agentconnect.md/drain-requested'
-
 /**
  * Where agent-sandbox records the pod a Sandbox is currently backed by.
  *
@@ -94,21 +90,8 @@ export class LaunchTimeoutError extends Error {
   }
 }
 
-/** Work refused because its Sandbox is draining for an image rollout. Typed for the same reason:
- *  a deliberate hold is not a missed target, and pooling the two makes a rollout look like an outage. */
-export class SandboxDrainingError extends Error {
-  constructor(agentId: string) {
-    super(`agent ${agentId} is draining for an image rollout — retry once it clears`)
-    this.name = 'SandboxDrainingError'
-  }
-}
-
 const DEFAULT_READY_TIMEOUT_MS = 90_000
 const MAX_MODE_ATTEMPTS = 5
-/** Restart delay bounds for the sandbox watch; watchCollection handles its own reconnects, so
- *  this only covers a stream that ended some other way. */
-const WATCH_RESTART_BASE_MS = 500
-const WATCH_RESTART_CAP_MS = 30_000
 
 /** Per-agent launch state the driver keeps: the Sandbox it bound and which launch it is. */
 interface Launch {
@@ -129,12 +112,7 @@ export class K8sDriver implements SpawnDriver {
   private readonly metrics: ClusterMetrics
   private readonly launches = new Map<string, Launch>()
   private readonly generations = new Map<string, number>()
-  /** Sandboxes carrying a drain request, by name → the value that requested it. New work stays
-   *  off them, and each is suspended as soon as the work already on it ends. */
-  private readonly draining = new Map<string, string>()
-  /** Live work per Sandbox: binds in flight, workspace preparation, and runtimes that have not
-   *  exited. A drain waits for this to reach zero — that is what keeps a rollout from pulling a
-   *  pod out mid-turn. */
+  /** Live work per Sandbox: binds, workspace preparation, and runtimes that have not exited. */
   private readonly busy = new Map<string, number>()
   /** Per-SANDBOX transition queue. A guarded write protects competing writes, but it cannot
    *  protect a decision that performs NO write: a later wake could observe Running and
@@ -145,8 +123,6 @@ export class K8sDriver implements SpawnDriver {
    *  dispatch admitted while the suspend was mid-write would otherwise lose its pod. Acquisition
    *  waits this out and then re-claims, which is the ordinary resume path. */
   private readonly suspending = new Map<string, Promise<void>>()
-  /** Term of the sandbox watch, so the plane can stop following on shutdown. */
-  private watch?: AbortController
   /** Logical channels per agent, which survive the shim's credential renewals. */
   private readonly sessions = new Map<string, ShimSession>()
   /** Workspace mount per agent, as the bound pod's shim reported it. */
@@ -243,12 +219,6 @@ export class K8sDriver implements SpawnDriver {
   /** Wake a suspended Sandbox, or confirm it is already running. Reports the mode it found, which
    *  is the only place a CACHED launch can learn whether it is resuming or already warm. */
   async wake(agentId: string): Promise<OperatingMode | undefined> {
-    if (this.isDraining(agentId)) {
-      // A drain request is in flight: new messages queue rather than reviving the instance,
-      // or one message would resurrect the image the rollout is replacing.
-      this.deps.log.info(`cluster: holding agent ${agentId} suspended — a drain request is pending`)
-      return undefined
-    }
     return await this.setMode(agentId, 'Running')
   }
 
@@ -318,8 +288,7 @@ export class K8sDriver implements SpawnDriver {
     return this.queueMode(launch.sandboxName, desired)
   }
 
-  /** Queued per SANDBOX rather than per agent: the drain path writes without an agent in hand,
-   *  and the object being serialized is the one both decisions patch. */
+  /** Queued per Sandbox because it is the object both decisions patch. */
   private queueMode(sandboxName: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
     const previous = this.modeQueue.get(sandboxName) ?? Promise.resolve()
     const next = previous.catch(() => undefined).then(() => this.applyMode(sandboxName, desired))
@@ -359,145 +328,14 @@ export class K8sDriver implements SpawnDriver {
     )
   }
 
-  /**
-   * Follow this namespace's Sandboxes, which is how a drain request is noticed without polling.
-   *
-   * Started by the runtime plane rather than the constructor: a driver a test builds by hand has
-   * no cluster to watch, and the watch is a term with an end (`stopSandboxWatch`) rather than a
-   * side effect of existing.
-   */
-  startSandboxWatch(): void {
-    if (this.watch) return
-    const controller = new AbortController()
-    this.watch = controller
-    void this.runSandboxWatch(controller.signal)
-  }
-
-  stopSandboxWatch(): void {
-    this.watch?.abort()
-    this.watch = undefined
-  }
-
-  // `watchCollection` reconnects and re-LISTs on its own, so this only covers a stream that ended
-  // some other way — and it must be covered, because a daemon that quietly stopped watching would
-  // stall every rollout until the operator's drain deadline failed each instance in turn.
-  private async runSandboxWatch(signal: AbortSignal): Promise<void> {
-    const backoff = new Backoff({ baseMs: WATCH_RESTART_BASE_MS, capMs: WATCH_RESTART_CAP_MS })
-    while (!signal.aborted) {
-      try {
-        const source = this.deps.api.watchSandboxes({
-          signal,
-          clock: this.clock,
-          metrics: this.metrics,
-          log: this.deps.log
-        })
-        for await (const event of source) {
-          backoff.reset()
-          if (event.kind === 'synced') this.onSandboxesSynced(event.items)
-          else if (event.kind === 'deleted') this.onSandboxGone(event.object)
-          else this.onSandboxObserved(event.object)
-        }
-      } catch (err) {
-        if (signal.aborted) return
-        this.deps.log.warn(`cluster: sandbox watch failed (${(err as Error).message})`)
-      }
-      if (signal.aborted) return
-      await this.pause(backoff.next(), signal)
-    }
-  }
-
-  /** A snapshot decides the whole drain set: a watch gap can drop a request or its removal, so
-   *  what the list says wins over the events we happened to see. */
-  private onSandboxesSynced(items: Sandbox[]): void {
-    const seen = new Set<string>()
-    for (const sandbox of items) {
-      const name = sandbox.metadata?.name
-      if (name) seen.add(name)
-      this.onSandboxObserved(sandbox)
-    }
-    for (const name of [...this.draining.keys()]) if (!seen.has(name)) this.clearDrain(name)
-  }
-
-  /**
-   * Observe a Sandbox's drain annotation. While it is present the daemon must not wake the
-   * instance: the rollout is waiting for it to stay down long enough to change its image,
-   * and a single arriving message would otherwise revive the old one. An instance with no work
-   * left on it is suspended right here — that suspension is what lets the rollout proceed.
-   */
-  onSandboxObserved(sandbox: Sandbox): void {
-    const name = sandbox.metadata?.name
-    if (!name) return
-    const requested = sandbox.metadata?.annotations?.[DRAIN_REQUESTED_ANNOTATION]
-    if (!requested) {
-      this.clearDrain(name)
-      return
-    }
-    if (this.draining.get(name) !== requested) {
-      this.draining.set(name, requested)
-      this.deps.log.info(`cluster: drain requested for sandbox ${name} (${requested})`)
-    }
-    // Already down — including the object our own suspend just produced — so nothing to quiesce.
-    if ((sandbox.spec?.operatingMode ?? 'Running') === 'Suspended') return
-    void this.quiesceIfIdle(name)
-  }
-
-  /** A Sandbox that is gone takes its drain request with it; nothing may be written to it again. */
-  private onSandboxGone(sandbox: Sandbox): void {
-    const name = sandbox.metadata?.name
-    if (!name) return
-    this.forgetSandbox(name)
-  }
-
-  /** Whether this agent's bound Sandbox is holding a drain request. */
-  isDraining(agentId: string): boolean {
-    const launch = this.launches.get(agentId)
-    return launch !== undefined && this.draining.has(launch.sandboxName)
-  }
-
-  private clearDrain(name: string): void {
-    if (this.draining.delete(name)) {
-      this.deps.log.info(`cluster: drain request cleared for sandbox ${name} — waking normally again`)
-    }
-  }
-
   private forgetSandbox(name: string): void {
-    this.clearDrain(name)
     this.busy.delete(name)
     this.modeQueue.delete(name)
   }
 
-  /**
-   * Suspend a draining Sandbox once nothing this daemon started is still running on it.
-   *
-   * Suspension is what lets the rollout swap the image, and it is never forced: a live turn keeps
-   * its instance up until the work ends, and an instance that never goes quiet is the rollout's
-   * own deadline to give up on, not ours to kill.
-   */
-  private async quiesceIfIdle(sandboxName: string): Promise<void> {
-    if (!this.draining.has(sandboxName) || (this.busy.get(sandboxName) ?? 0) > 0) return
-    try {
-      await this.queueMode(sandboxName, 'Suspended')
-    } catch (err) {
-      // applyMode already spent its bounded re-read/re-decide budget, so this is a drain that did
-      // not land — say so and let the rollout's deadline report the instance failed.
-      this.metrics.drainTimeout()
-      this.deps.log.warn(
-        `cluster: sandbox ${sandboxName} did not suspend for its drain request — ${(err as Error).message}`
-      )
-    }
-  }
-
-  /**
-   * Hold the agent's Sandbox for the duration of `work` — it is bound first, and a drain request
-   * then waits for the work instead of suspending the pod underneath it.
-   *
-   * The daemon's cold workspace preparation is exactly this case: the clone, pull and skill
-   * materialization all run IN the pod over the shim, between the bind and the launch they are
-   * preparing for, and a bind-scoped hold would leave that whole stretch drainable.
-   */
+  /** Hold the agent's Sandbox for `work`, including workspace preparation before launch. */
   async withSandbox<T>(agentId: string, work: () => Promise<T>): Promise<T> {
     const launch = await this.ensureSandbox(agentId)
-    this.refuseWhenDraining(agentId, launch.sandboxName)
     this.retain(launch.sandboxName)
     try {
       return await work()
@@ -506,7 +344,7 @@ export class K8sDriver implements SpawnDriver {
     }
   }
 
-  /** Count work on a Sandbox, so a drain request waits for it instead of pulling the pod out. */
+  /** Count work on a Sandbox so the idle sweep cannot suspend it. */
   private retain(sandboxName: string): void {
     this.busy.set(sandboxName, (this.busy.get(sandboxName) ?? 0) + 1)
   }
@@ -518,23 +356,6 @@ export class K8sDriver implements SpawnDriver {
       return
     }
     this.busy.delete(sandboxName)
-    // The last work on it just ended, which is when a pending drain gets its suspend.
-    void this.quiesceIfIdle(sandboxName)
-  }
-
-  /** Abortable delay on the driver's clock, so shutdown does not wait out a watch restart. */
-  private pause(ms: number, signal: AbortSignal): Promise<void> {
-    return new Promise<void>((resolve) => {
-      const onAbort = (): void => {
-        this.clock.clearTimeout(handle)
-        resolve()
-      }
-      const handle = this.clock.setTimeout(() => {
-        signal.removeEventListener('abort', onAbort)
-        resolve()
-      }, ms)
-      signal.addEventListener('abort', onAbort, { once: true })
-    })
   }
 
   /** Forget an agent and delete its claim; the volume goes with it, which is the intent. */
@@ -603,10 +424,6 @@ export class K8sDriver implements SpawnDriver {
     grants: ShimCapability[] = RUNTIME_GRANTS
   ): Promise<ShimConnection> {
     const launch = await this.ensureSandbox(agentId, timer)
-    // Checked against the SANDBOX, and only once it is known: an agent this daemon has not bound
-    // yet cannot be matched to a drain request any earlier. Held across the bind so a request
-    // arriving mid-flight waits for it rather than suspending the pod we are waiting on.
-    this.refuseWhenDraining(agentId, launch.sandboxName)
     this.retain(launch.sandboxName)
     try {
       return await this.bindChannel(agentId, launch, timer, grants)
@@ -621,10 +438,7 @@ export class K8sDriver implements SpawnDriver {
     timer: LaunchTimer | undefined,
     grants: ShimCapability[]
   ): Promise<ShimConnection> {
-    // Resume BEFORE waiting: suspension deleted the pod, so readiness cannot arrive until
-    // something asks for Running. Deliberately not `wake()`: this bind already passed the drain
-    // gate and holds the Sandbox, so a request landing mid-flight waits for the work instead of
-    // stranding it against a pod nothing will resume.
+    // Resume before waiting because suspension deleted the pod and readiness cannot arrive first.
     const modeBeforeWake = await this.setMode(agentId, 'Running')
     // A launch this daemon already has cached returns from ensureSandbox before any sandbox
     // read, so this is where the ordinary `launch → suspend → launch` resume learns what it is.
@@ -708,12 +522,10 @@ export class K8sDriver implements SpawnDriver {
     const agentId = request.env.AC_AGENT_ID
     if (!agentId) throw new Error('cluster launch requires AC_AGENT_ID in the runtime environment')
     const timer = new LaunchTimer(this.metrics, () => this.clock.now())
-    // The Sandbox this launch holds, from before the bind until the runtime exits. Released on
-    // every failure path too, or one failed launch would hold a drain open forever.
+    // The Sandbox is held from before bind until runtime exit and released on every failure path.
     let held: string | undefined
     try {
       const bound = await this.ensureSandbox(agentId, timer)
-      this.refuseWhenDraining(agentId, bound.sandboxName)
       this.retain(bound.sandboxName)
       held = bound.sandboxName
       await this.ensureBoundChannel(agentId, timer)
@@ -736,29 +548,16 @@ export class K8sDriver implements SpawnDriver {
           timer.finish(outcome)
         }
       })
-      // The runtime's exit is what makes the Sandbox idle, so it is where a pending drain lands.
+      // Runtime exit releases the hold so the next idle sweep can suspend the Sandbox.
       const sandboxName = held
       held = undefined
       runtime.onExit(() => this.release(sandboxName))
       return runtime
     } catch (err) {
       if (held) this.release(held)
-      // Timeouts are the interesting failure — they are what a missed target looks like — so they
-      // are distinguished from an outright error. By TYPE: all three launch deadlines (claim bind,
-      // pod readiness, channel bind) throw LaunchTimeoutError, and the message regex this replaced
-      // silently stopped covering the channel wait the moment its wording changed. A held-for-
-      // rollout refusal is neither: pooling it with errors would make a rollout look like an outage.
-      timer.finish(
-        err instanceof SandboxDrainingError ? 'draining' : err instanceof LaunchTimeoutError ? 'timeout' : 'error'
-      )
+      timer.finish(err instanceof LaunchTimeoutError ? 'timeout' : 'error')
       throw err
     }
-  }
-
-  private refuseWhenDraining(agentId: string, sandboxName: string): void {
-    // Launching now would wait out the readiness timeout against a sandbox we are deliberately
-    // holding down. Say so instead of timing out.
-    if (this.draining.has(sandboxName)) throw new SandboxDrainingError(agentId)
   }
 
   /** Re-attach a renewed or replacement connection to the launch it belongs to. */

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -11,6 +11,7 @@ import {
   isSandboxReady,
   type OperatingMode,
   type Sandbox,
+  type SandboxClaim,
   type SandboxApi
 } from './sandbox-api.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
@@ -60,6 +61,10 @@ export interface K8sDriverDeps {
   orgForAgent: (agentId: string) => string | undefined
   /** Pool the claim references; v1beta1 requires one, and a cold pool is `replicas: 0`. */
   warmPoolName: string
+  /** Optional claim metadata for host-owned synthetic agents such as runtime probes. */
+  claimMetadataForAgent?: (
+    agentId: string
+  ) => Pick<NonNullable<SandboxClaim['metadata']>, 'annotations' | 'labels'> | undefined
   /** Dials the ready pod and binds the shim channel for this launch. */
   connectChannel: (record: SpawnRecord, podIp: string, timeoutMs: number) => Promise<ShimConnection>
   /** Stops any outbound channel when a launch is forgotten or deliberately suspended. */
@@ -157,11 +162,13 @@ export class K8sDriver implements SpawnDriver {
     const name = this.claimName(agentId)
     const orgId = this.deps.orgForAgent(agentId)
     if (!orgId) throw new Error(`cannot resolve sandbox organization for agent ${agentId}`)
+    const claimMetadata = this.deps.claimMetadataForAgent?.(agentId)
     const ensured = await this.deps.api.ensureClaim({
       metadata: {
         name,
-        annotations: undefined
-      } as { name: string },
+        ...(claimMetadata?.annotations ? { annotations: claimMetadata.annotations } : {}),
+        ...(claimMetadata?.labels ? { labels: claimMetadata.labels } : {})
+      },
       spec: {
         warmPoolRef: { name: this.deps.warmPoolName },
         additionalPodMetadata: { labels: { [AC_LABEL_ORG]: orgId, [AC_LABEL_AGENT]: agentId } }

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { K8sHttp, loadInClusterConfig } from '@agentconnect.md/k8s-client'
 import { K8sDriver, PROBE_GRANTS } from './driver.js'
 import { SandboxApi } from './sandbox-api.js'
@@ -16,11 +17,16 @@ import type { GitRunner } from '../workspace/git-runner.js'
 
 const SILENT = { info: () => {}, warn: () => {} }
 
-/** Reserved agent id for the runtime probe. Not a real agent, and never assigned one: its claim is
- *  `agent-<this>`, so the name must not collide with an id the Control Plane could hand out. */
-export const PROBE_AGENT_ID = 'ac-runtime-probe'
+/** Reserved prefix for member-scoped runtime probes; the Control Plane never assigns it. */
+export const PROBE_AGENT_ID_PREFIX = 'ac-runtime-probe'
 /** A probe drives every runtime through `initialize` plus a session, on a possibly cold pod. */
 const PROBE_TIMEOUT_MS = 180_000
+
+/** A deterministic, DNS-safe probe identity unique to one daemon member. */
+export function probeAgentId(memberId: string): string {
+  const memberHash = createHash('sha256').update(memberId).digest('hex').slice(0, 16)
+  return `${PROBE_AGENT_ID_PREFIX}-${memberHash}`
+}
 
 /**
  * Assembles the k8s execution plane: the shim dialer, the driver, and the seams that make an
@@ -38,6 +44,10 @@ export interface K8sRuntimePlaneOptions {
   orgForAgent?: (agentId: string) => string | undefined
   /** Warm pool the claims reference. v1beta1 requires one; a cold pool is `replicas: 0`. */
   warmPoolName?: string
+  /** Namespace shared by agent sandboxes, separate from the daemon pool namespace. */
+  sandboxNamespace?: string
+  /** Deployment-unique identity for this member, normally the Pod UID from the Downward API. */
+  memberId?: string
   /** Port the sandbox shim listens on; the daemon combines it with the ready pod's IP. */
   shimPort?: number
   /** Environment the deployment settings come from; `process.env` unless a test names another. */
@@ -64,6 +74,8 @@ export interface K8sRuntimePlaneOptions {
 export interface K8sPlaneSettings {
   orgId?: string
   warmPoolName: string
+  sandboxNamespace: string
+  memberId: string
   shimPort: number
 }
 
@@ -71,6 +83,8 @@ export interface K8sPlaneSettings {
  *  in the cluster, which is the deployment's to state and not an operator preference. */
 export const K8S_ORG_ID_ENV = 'AC_K8S_ORG_ID'
 export const K8S_WARM_POOL_ENV = 'AC_K8S_WARM_POOL'
+export const K8S_SANDBOX_NAMESPACE_ENV = 'AC_K8S_SANDBOX_NAMESPACE'
+export const K8S_MEMBER_ID_ENV = 'AC_K8S_MEMBER_ID'
 export const K8S_SHIM_PORT_ENV = 'AC_K8S_SHIM_PORT'
 export const DEFAULT_SHIM_PORT = DEFAULT_SHIM_LISTEN_PORT
 
@@ -80,12 +94,16 @@ export function resolveK8sPlaneSettings(options: K8sRuntimePlaneOptions = {}): K
   const orgId = options.orgId ?? env[K8S_ORG_ID_ENV]?.trim()
   const warmPoolName = options.warmPoolName ?? env[K8S_WARM_POOL_ENV]?.trim()
   if (!warmPoolName) throw new Error(`--k8s requires ${K8S_WARM_POOL_ENV}`)
+  const sandboxNamespace = options.sandboxNamespace ?? env[K8S_SANDBOX_NAMESPACE_ENV]?.trim()
+  if (!sandboxNamespace) throw new Error(`--k8s requires ${K8S_SANDBOX_NAMESPACE_ENV}`)
+  const memberId = options.memberId ?? env[K8S_MEMBER_ID_ENV]?.trim()
+  if (!memberId) throw new Error(`--k8s requires ${K8S_MEMBER_ID_ENV}`)
   const rawPort = options.shimPort ?? env[K8S_SHIM_PORT_ENV] ?? DEFAULT_SHIM_PORT
   const shimPort = Number(rawPort)
   if (!Number.isInteger(shimPort) || shimPort < 1 || shimPort > 65_535) {
     throw new Error(`${K8S_SHIM_PORT_ENV} is not a valid port: ${rawPort}`)
   }
-  return { ...(orgId ? { orgId } : {}), warmPoolName, shimPort }
+  return { ...(orgId ? { orgId } : {}), warmPoolName, sandboxNamespace, memberId, shimPort }
 }
 
 /** The env contract on its own, which is what a deployment has to satisfy. */
@@ -99,8 +117,7 @@ export interface K8sRuntimePlane {
   /** Bring an agent's Sandbox up and bind its channel WITHOUT starting a runtime, so the
    *  workspace can be prepared on the pod's own volume before the runtime looks at it. */
   ensureChannel: (agentId: string) => Promise<void>
-  /** Run `work` holding the agent's Sandbox, so a rollout's drain request waits for it rather
-   *  than suspending the pod while work this daemon already admitted runs inside it. */
+  /** Run `work` while holding the agent's Sandbox against the ordinary idle sweep. */
   withSandbox: <T>(agentId: string, work: () => Promise<T>) => Promise<T>
   /** Ask a sandbox which runtimes the image actually provides, and tear it down again. */
   probeRuntimes: () => Promise<K8sRuntimeTable>
@@ -148,7 +165,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     options.api ??
     (() => {
       const config = loadInClusterConfig()
-      return new SandboxApi(new K8sHttp(config), config.namespace)
+      return new SandboxApi(new K8sHttp(config), settings.sandboxNamespace)
     })()
 
   const dialer = new ShimDialer({
@@ -205,10 +222,13 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     }
   }
 
+  const runtimeProbeAgentId = probeAgentId(settings.memberId)
   const driver = new K8sDriver({
     api,
     orgForAgent: (agentId) =>
-      agentId === PROBE_AGENT_ID ? (settings.orgId ?? 'install') : (options.orgForAgent?.(agentId) ?? settings.orgId),
+      agentId === runtimeProbeAgentId
+        ? (settings.orgId ?? 'install')
+        : (options.orgForAgent?.(agentId) ?? settings.orgId),
     warmPoolName: settings.warmPoolName,
     onChannelReady: ensureTunnels,
     connectChannel: (record, podIp, timeoutMs) =>
@@ -218,11 +238,6 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     ...(options.readyTimeoutMs === undefined ? {} : { readyTimeoutMs: options.readyTimeoutMs }),
     log: options.log ?? SILENT
   })
-
-  // Follows this namespace's Sandboxes for the rollout's drain requests. Part of starting the
-  // plane rather than of the first launch: an instance whose agent is idle is exactly the one a
-  // rollout is waiting on, and nothing else would ever look at it.
-  driver.startSandboxWatch()
 
   // A renewal reconnects immediately, so a
   // replacement that has not arrived well inside the request deadline is a pod that is gone.
@@ -253,20 +268,16 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       // A sandbox of its own, under a reserved id, so a probe never adopts or disturbs an
       // agent's instance — and is torn down afterwards rather than left holding a pod.
       try {
-        // The lease covers the REQUEST, not just the bind: the probe can run for minutes while
-        // nothing else marks that sandbox as in use, and both suspension paths — a rollout's
-        // drain and the idle sweep — read exactly this lease to decide the pod is spare. Losing
-        // the pod mid-probe fails the probe, and a daemon that failed its probe advertises no
-        // runtimes and does not retry.
-        return await driver.withSandbox(PROBE_AGENT_ID, async () => {
-          await driver.ensureBoundChannel(PROBE_AGENT_ID, undefined, PROBE_GRANTS)
-          const session = driver.sessionFor(PROBE_AGENT_ID)
+        // The lease covers the request so the ordinary idle sweep cannot suspend mid-probe.
+        return await driver.withSandbox(runtimeProbeAgentId, async () => {
+          await driver.ensureBoundChannel(runtimeProbeAgentId, undefined, PROBE_GRANTS)
+          const session = driver.sessionFor(runtimeProbeAgentId)
           if (!session) throw new Error('probe sandbox bound no session')
           const raw = await session.request('probe', {}, { timeoutMs: PROBE_TIMEOUT_MS })
           return K8sRuntimeTableSchema.parse(raw)
         })
       } finally {
-        await driver.removeAgent(PROBE_AGENT_ID).catch((err: unknown) => {
+        await driver.removeAgent(runtimeProbeAgentId).catch((err: unknown) => {
           // A leaked probe sandbox costs a pod and a volume, so say so loudly rather than
           // letting it accumulate one per daemon restart.
           options.log?.warn(`k8s: probe sandbox teardown failed: ${(err as Error).message}`)
@@ -306,7 +317,6 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       await driver.removeAgent(agentId)
     },
     stop: async () => {
-      driver.stopSandboxWatch()
       for (const timer of lossTimers.values()) clearTimeout(timer)
       lossTimers.clear()
       for (const { proxy } of proxies.values()) proxy.stop('daemon is shutting down')

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -19,13 +19,39 @@ const SILENT = { info: () => {}, warn: () => {} }
 
 /** Reserved prefix for member-scoped runtime probes; the Control Plane never assigns it. */
 export const PROBE_AGENT_ID_PREFIX = 'ac-runtime-probe'
+export const PROBE_CLAIM_LABEL = 'agentconnect.md/runtime-probe'
+export const PROBE_CLAIM_EXPIRES_ANNOTATION = 'agentconnect.md/runtime-probe-expires-at'
 /** A probe drives every runtime through `initialize` plus a session, on a possibly cold pod. */
 const PROBE_TIMEOUT_MS = 180_000
+/** Bounds an abandoned probe claim while leaving ample room for cold scheduling and the probe. */
+export const PROBE_CLAIM_TTL_MS = 15 * 60_000
+const PROBE_CLAIM_GC_INTERVAL_MS = 5 * 60_000
 
 /** A deterministic, DNS-safe probe identity unique to one daemon member. */
 export function probeAgentId(memberId: string): string {
   const memberHash = createHash('sha256').update(memberId).digest('hex').slice(0, 16)
   return `${PROBE_AGENT_ID_PREFIX}-${memberHash}`
+}
+
+/** Delete only expired probe claims; ordinary agent claims never match. */
+export async function reapExpiredProbeClaims(
+  api: Pick<SandboxApi, 'deleteClaim' | 'listClaims'>,
+  now: number,
+  log: { warn: (message: string) => void } = SILENT
+): Promise<void> {
+  const claims = await api.listClaims(`${PROBE_CLAIM_LABEL}=true`)
+  await Promise.all(
+    claims.map(async (claim) => {
+      const name = claim.metadata?.name
+      if (!name || claim.metadata?.labels?.[PROBE_CLAIM_LABEL] !== 'true') return
+      const rawExpiry = claim.metadata?.annotations?.[PROBE_CLAIM_EXPIRES_ANNOTATION]
+      const expiresAt = rawExpiry ? Date.parse(rawExpiry) : Number.NaN
+      if (!Number.isFinite(expiresAt) || expiresAt > now) return
+      await api.deleteClaim(name).catch((err: unknown) => {
+        log.warn(`k8s: expired probe claim ${name} teardown failed: ${(err as Error).message}`)
+      })
+    })
+  )
 }
 
 /**
@@ -230,6 +256,15 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
         ? (settings.orgId ?? 'install')
         : (options.orgForAgent?.(agentId) ?? settings.orgId),
     warmPoolName: settings.warmPoolName,
+    claimMetadataForAgent: (agentId) =>
+      agentId === runtimeProbeAgentId
+        ? {
+            labels: { [PROBE_CLAIM_LABEL]: 'true' },
+            annotations: {
+              [PROBE_CLAIM_EXPIRES_ANNOTATION]: new Date(Date.now() + PROBE_CLAIM_TTL_MS).toISOString()
+            }
+          }
+        : undefined,
     onChannelReady: ensureTunnels,
     connectChannel: (record, podIp, timeoutMs) =>
       dialer.connect(shimEndpoint(podIp, settings.shimPort), record, timeoutMs),
@@ -243,6 +278,20 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
   // replacement that has not arrived well inside the request deadline is a pod that is gone.
   const REBIND_GRACE_MS = 20_000
   const lossTimers = new Map<string, NodeJS.Timeout>()
+  let stopped = false
+  let probeGcTimer: NodeJS.Timeout | undefined
+  let probeInFlight: Promise<K8sRuntimeTable> | undefined
+
+  async function runProbeClaimGc(): Promise<void> {
+    await reapExpiredProbeClaims(api, Date.now(), options.log ?? SILENT).catch((err: unknown) =>
+      options.log?.warn(`k8s: probe claim sweep failed: ${(err as Error).message}`)
+    )
+    if (stopped) return
+    probeGcTimer = setTimeout(() => void runProbeClaimGc(), PROBE_CLAIM_GC_INTERVAL_MS)
+    probeGcTimer.unref?.()
+  }
+
+  void runProbeClaimGc()
 
   function scheduleLossCheck(agentId: string, reason: string): void {
     clearTimeout(lossTimers.get(agentId))
@@ -257,18 +306,13 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     )
   }
 
-  return {
-    driver,
-    dialer,
-    ensureChannel: async (agentId) => {
-      await driver.ensureBoundChannel(agentId)
-    },
-    withSandbox: (agentId, work) => driver.withSandbox(agentId, work),
-    probeRuntimes: async () => {
-      // A sandbox of its own, under a reserved id, so a probe never adopts or disturbs an
-      // agent's instance — and is torn down afterwards rather than left holding a pod.
+  function probeRuntimes(): Promise<K8sRuntimeTable> {
+    if (probeInFlight) return probeInFlight
+    probeInFlight = (async () => {
+      // Reset this member's deterministic claim so a container restart cannot adopt its leaked probe.
+      await driver.removeAgent(runtimeProbeAgentId)
       try {
-        // The lease covers the request so the ordinary idle sweep cannot suspend mid-probe.
+        // Hold the Sandbox across the request so the ordinary idle sweep cannot suspend it.
         return await driver.withSandbox(runtimeProbeAgentId, async () => {
           await driver.ensureBoundChannel(runtimeProbeAgentId, undefined, PROBE_GRANTS)
           const session = driver.sessionFor(runtimeProbeAgentId)
@@ -278,12 +322,23 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
         })
       } finally {
         await driver.removeAgent(runtimeProbeAgentId).catch((err: unknown) => {
-          // A leaked probe sandbox costs a pod and a volume, so say so loudly rather than
-          // letting it accumulate one per daemon restart.
           options.log?.warn(`k8s: probe sandbox teardown failed: ${(err as Error).message}`)
         })
       }
+    })().finally(() => {
+      probeInFlight = undefined
+    })
+    return probeInFlight
+  }
+
+  return {
+    driver,
+    dialer,
+    ensureChannel: async (agentId) => {
+      await driver.ensureBoundChannel(agentId)
     },
+    withSandbox: (agentId, work) => driver.withSandbox(agentId, work),
+    probeRuntimes,
     gitRunnerFor: (agentId, cwd, abort) => {
       // No channel means this agent has no sandbox to run git in. Returning undefined keeps the
       // caller on its local runner rather than failing the operation — which is what a
@@ -317,6 +372,9 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       await driver.removeAgent(agentId)
     },
     stop: async () => {
+      stopped = true
+      if (probeGcTimer) clearTimeout(probeGcTimer)
+      probeGcTimer = undefined
       for (const timer of lossTimers.values()) clearTimeout(timer)
       lossTimers.clear()
       for (const { proxy } of proxies.values()) proxy.stop('daemon is shutting down')

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -35,7 +35,7 @@ export function probeAgentId(memberId: string): string {
 
 /** Delete only expired probe claims; ordinary agent claims never match. */
 export async function reapExpiredProbeClaims(
-  api: Pick<SandboxApi, 'deleteClaim' | 'listClaims'>,
+  api: Pick<SandboxApi, 'deleteClaimIfCurrent' | 'listClaims'>,
   now: number,
   log: { warn: (message: string) => void } = SILENT
 ): Promise<void> {
@@ -44,12 +44,19 @@ export async function reapExpiredProbeClaims(
     claims.map(async (claim) => {
       const name = claim.metadata?.name
       if (!name || claim.metadata?.labels?.[PROBE_CLAIM_LABEL] !== 'true') return
+      const uid = claim.metadata.uid
+      if (!uid) return
       const rawExpiry = claim.metadata?.annotations?.[PROBE_CLAIM_EXPIRES_ANNOTATION]
       const expiresAt = rawExpiry ? Date.parse(rawExpiry) : Number.NaN
       if (!Number.isFinite(expiresAt) || expiresAt > now) return
-      await api.deleteClaim(name).catch((err: unknown) => {
-        log.warn(`k8s: expired probe claim ${name} teardown failed: ${(err as Error).message}`)
-      })
+      await api
+        .deleteClaimIfCurrent(name, {
+          uid,
+          ...(claim.metadata.resourceVersion ? { resourceVersion: claim.metadata.resourceVersion } : {})
+        })
+        .catch((err: unknown) => {
+          log.warn(`k8s: expired probe claim ${name} teardown failed: ${(err as Error).message}`)
+        })
     })
   )
 }

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -131,10 +131,6 @@ export class SandboxApi {
     return this.http.json<Sandbox>({ method: 'GET', path: `${this.sandboxes()}/${name}` })
   }
 
-  watchSandboxes(options: Omit<WatchOptions, 'path'> = {}): AsyncGenerator<ResourceEvent<Sandbox>> {
-    return watchCollection<Sandbox>(this.http, { ...options, path: this.sandboxes() })
-  }
-
   /** Set a bound Sandbox's operating mode — the sleep/wake path.
    *  `observed` is mandatory: between reading a Sandbox and writing it, a message can
    *  wake an instance we decided to suspend (or the reverse), so every write tests the

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -1,11 +1,4 @@
-import {
-  K8sApiError,
-  watchCollection,
-  type K8sHttp,
-  type K8sObject,
-  type ResourceEvent,
-  type WatchOptions
-} from '@agentconnect.md/k8s-client'
+import { K8sApiError, type K8sHttp, type K8sList, type K8sObject } from '@agentconnect.md/k8s-client'
 
 /** agent-sandbox API groups, pinned to v1beta1 — the compatibility layer is never touched. */
 export const SANDBOX_GROUP = 'agents.x-k8s.io/v1beta1'
@@ -21,9 +14,11 @@ export interface Sandbox extends K8sObject {
   }
 }
 
-/** The claim's status names the bound Sandbox; the Sandbox UID comes from that
- *  object's `metadata.uid`, since the claim carries no uid of its own. */
+/** Claim status names the bound Sandbox; its UID comes from that object's metadata. */
 export interface SandboxClaim extends K8sObject {
+  metadata?: NonNullable<K8sObject['metadata']> & {
+    labels?: Record<string, string>
+  }
   spec?: { warmPoolRef?: { name?: string }; additionalPodMetadata?: { labels?: Record<string, string> } }
   status?: { sandbox?: { name?: string } }
 }
@@ -113,6 +108,15 @@ export class SandboxApi {
     return this.http.json<SandboxClaim>({ method: 'GET', path: `${this.claims()}/${name}` })
   }
 
+  async listClaims(labelSelector?: string): Promise<SandboxClaim[]> {
+    const list = await this.http.json<K8sList<SandboxClaim>>({
+      method: 'GET',
+      path: this.claims(),
+      query: { ...(labelSelector ? { labelSelector } : {}) }
+    })
+    return list.items ?? []
+  }
+
   /** Delete a claim; an already-absent claim is success (agent deletion is idempotent). */
   async deleteClaim(name: string): Promise<void> {
     try {
@@ -121,10 +125,6 @@ export class SandboxApi {
       if (err instanceof K8sApiError && err.isNotFound) return
       throw err
     }
-  }
-
-  watchClaims(options: Omit<WatchOptions, 'path'> = {}): AsyncGenerator<ResourceEvent<SandboxClaim>> {
-    return watchCollection<SandboxClaim>(this.http, { ...options, path: this.claims() })
   }
 
   getSandbox(name: string): Promise<Sandbox> {

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -127,6 +127,29 @@ export class SandboxApi {
     }
   }
 
+  /** Delete only the listed claim incarnation; false means the name now belongs to a replacement. */
+  async deleteClaimIfCurrent(name: string, preconditions: { uid: string; resourceVersion?: string }): Promise<boolean> {
+    try {
+      await this.http.json({
+        method: 'DELETE',
+        path: `${this.claims()}/${name}`,
+        body: {
+          apiVersion: 'v1',
+          kind: 'DeleteOptions',
+          preconditions: {
+            uid: preconditions.uid,
+            ...(preconditions.resourceVersion ? { resourceVersion: preconditions.resourceVersion } : {})
+          }
+        }
+      })
+      return true
+    } catch (err) {
+      if (err instanceof K8sApiError && err.isNotFound) return true
+      if (err instanceof K8sApiError && err.isConflict) return false
+      throw err
+    }
+  }
+
   getSandbox(name: string): Promise<Sandbox> {
     return this.http.json<Sandbox>({ method: 'GET', path: `${this.sandboxes()}/${name}` })
   }

--- a/packages/daemon/test/cluster-acp-e2e.test.ts
+++ b/packages/daemon/test/cluster-acp-e2e.test.ts
@@ -71,7 +71,6 @@ function fakeApi() {
         return state.sandbox
       },
       watchClaims: vi.fn(),
-      watchSandboxes: vi.fn(),
       reviewToken: vi.fn()
     }
   }

--- a/packages/daemon/test/cluster-metrics.test.ts
+++ b/packages/daemon/test/cluster-metrics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { FakeClock } from '@agentconnect.md/connection'
-import { K8sDriver, DRAIN_REQUESTED_ANNOTATION, type ClusterDriverDeps } from '../src/k8s/driver.js'
+import { K8sDriver, type ClusterDriverDeps } from '../src/k8s/driver.js'
 import { LaunchTimer, type ClusterMetrics, type LaunchPath, type LaunchStage } from '../src/k8s/cluster-metrics.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
@@ -76,7 +76,6 @@ function fakeApi(options: { claimExists: boolean; mode: 'Running' | 'Suspended' 
         return {} as Sandbox
       },
       watchClaims: vi.fn(),
-      watchSandboxes: vi.fn(),
       reviewToken: vi.fn()
     }
   }
@@ -344,20 +343,6 @@ describe('cluster launch metrics', () => {
       'runtime_ready'
     ])
     expect(seen.channels).toContain('bound')
-  })
-
-  it('distinguishes a draining refusal from a timeout and from an error', async () => {
-    const drained = recorder()
-    const api = fakeApi({ claimExists: true, mode: 'Suspended' })
-    const driver = driverFor(drained.metrics, api)
-    driver.onSandboxObserved({
-      metadata: { name: 'sb-1', annotations: { [DRAIN_REQUESTED_ANNOTATION]: 'rollout-1/img' } },
-      spec: { operatingMode: 'Suspended' }
-    })
-    await expect(driver.launch(launchRequest)).rejects.toThrow(/draining/)
-    // Held-for-rollout is not a missed target, and pooling it with errors would make a rollout
-    // look like an outage on the dashboard.
-    expect(drained.launches).toEqual([expect.objectContaining({ outcome: 'draining' })])
   })
 
   it('counts a rejected guarded write as a retry rather than losing it in debug logs', async () => {

--- a/packages/daemon/test/direct-connect-credentials.test.ts
+++ b/packages/daemon/test/direct-connect-credentials.test.ts
@@ -42,7 +42,6 @@ function fakeApi() {
         }) as Sandbox,
       setOperatingMode: async () => ({}) as Sandbox,
       watchClaims: vi.fn(),
-      watchSandboxes: vi.fn(),
       reviewToken: vi.fn()
     }
   }

--- a/packages/daemon/test/k8s-client.test.ts
+++ b/packages/daemon/test/k8s-client.test.ts
@@ -83,6 +83,15 @@ describe('SandboxApi', () => {
     await expect(api.deleteClaim('gone')).resolves.toBeUndefined()
   })
 
+  it('lists claims with a server-side label selector', async () => {
+    const { config, requests } = await fakeApiServer(() => ({
+      json: { items: [{ metadata: { name: 'agent-ac-runtime-probe-old' } }] }
+    }))
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await expect(api.listClaims('agentconnect.md/runtime-probe=true')).resolves.toHaveLength(1)
+    expect(requests[0]?.searchParams.get('labelSelector')).toBe('agentconnect.md/runtime-probe=true')
+  })
+
   it('guards an operatingMode patch with a test op on the value it observed', async () => {
     let patch: any
     let contentType: string | undefined

--- a/packages/daemon/test/k8s-client.test.ts
+++ b/packages/daemon/test/k8s-client.test.ts
@@ -83,6 +83,30 @@ describe('SandboxApi', () => {
     await expect(api.deleteClaim('gone')).resolves.toBeUndefined()
   })
 
+  it('fences a GC delete to the listed claim incarnation', async () => {
+    let received: any
+    const { config } = await fakeApiServer(({ body }) => {
+      received = JSON.parse(body)
+      return { json: {} }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await expect(api.deleteClaimIfCurrent('probe-old', { uid: 'uid-old', resourceVersion: '17' })).resolves.toBe(true)
+    expect(received).toEqual({
+      apiVersion: 'v1',
+      kind: 'DeleteOptions',
+      preconditions: { uid: 'uid-old', resourceVersion: '17' }
+    })
+  })
+
+  it('does not delete a replacement claim after the listed UID goes stale', async () => {
+    const { config } = await fakeApiServer(() => ({
+      status: 409,
+      json: { kind: 'Status', reason: 'Conflict', message: 'UID precondition failed' }
+    }))
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await expect(api.deleteClaimIfCurrent('probe-replaced', { uid: 'uid-old' })).resolves.toBe(false)
+  })
+
   it('lists claims with a server-side label selector', async () => {
     const { config, requests } = await fakeApiServer(() => ({
       json: { items: [{ metadata: { name: 'agent-ac-runtime-probe-old' } }] }

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { FakeClock } from '@agentconnect.md/connection'
-import { K8sDriver, DRAIN_REQUESTED_ANNOTATION, AC_LABEL_AGENT, AC_LABEL_ORG } from '../src/k8s/driver.js'
+import { K8sDriver, AC_LABEL_AGENT, AC_LABEL_ORG } from '../src/k8s/driver.js'
 import { OperatingModeRejectedError } from '../src/k8s/sandbox-api.js'
-import { K8sApiError, type ResourceEvent } from '@agentconnect.md/k8s-client'
+import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
 import type { ShimConnection } from '../src/shim/listener.js'
@@ -52,40 +52,9 @@ function fakeApi(options: { ready?: boolean; mode?: 'Running' | 'Suspended' } = 
       }
     ),
     watchClaims: vi.fn(),
-    watchSandboxes: vi.fn(),
     reviewToken: vi.fn()
   }
   return { api, state }
-}
-
-/** The Sandbox as a watch reports it, optionally carrying a rollout's drain request. */
-function observed(mode: 'Running' | 'Suspended', requested?: string): Sandbox {
-  return {
-    metadata: {
-      name: 'sb-1',
-      uid: 'sandbox-uid-1',
-      ...(requested ? { annotations: { [DRAIN_REQUESTED_ANNOTATION]: requested } } : {})
-    },
-    spec: { operatingMode: mode }
-  }
-}
-
-/** A watch a test drives by hand, so events land in a decided order rather than a raced one. */
-function watchSource() {
-  const queue: ResourceEvent<Sandbox>[] = []
-  let wake: (() => void) | undefined
-  return {
-    push(event: ResourceEvent<Sandbox>) {
-      queue.push(event)
-      wake?.()
-    },
-    async *stream(): AsyncGenerator<ResourceEvent<Sandbox>> {
-      for (;;) {
-        while (queue.length > 0) yield queue.shift()!
-        await new Promise<void>((resolve) => (wake = resolve))
-      }
-    }
-  }
 }
 
 /** Enough of a bound channel for `launch()` to attach a session to. */
@@ -322,96 +291,6 @@ describe('cluster spawn driver', () => {
     expect(instance.sessionFor('agent-a')?.isAttached()).toBe(true)
   })
 
-  it('does not wake an instance while a drain request is pending', async () => {
-    const { api, state } = fakeApi({ mode: 'Suspended' })
-    const { instance } = driver(api)
-    await instance.ensureSandbox('agent-a')
-    instance.onSandboxObserved(observed('Suspended', 'rollout-7/image:v2'))
-    expect(instance.isDraining('agent-a')).toBe(true)
-    await instance.wake('agent-a')
-    // One arriving message must not revive the image the rollout is replacing; the message
-    // queues instead.
-    expect(state.modeWrites).toEqual([])
-
-    instance.onSandboxObserved(observed('Suspended'))
-    expect(instance.isDraining('agent-a')).toBe(false)
-    await instance.wake('agent-a')
-    expect(state.modeWrites).toEqual([{ desired: 'Running', observed: 'Suspended' }])
-  })
-
-  it('suspends an idle sandbox as soon as a drain is requested, launch or no launch', async () => {
-    // Nothing bound it in this process — the daemon restarted, or the agent has been quiet — and
-    // that instance is exactly the one a rollout is waiting on. Suspension is what lets it swap
-    // the image, so it comes off the observation itself rather than off the next launch.
-    const { api, state } = fakeApi({ mode: 'Running' })
-    const { instance } = driver(api)
-    instance.onSandboxObserved(observed('Running', 'rollout-7/image:v2'))
-    await vi.waitFor(() => expect(state.modeWrites).toEqual([{ desired: 'Suspended', observed: 'Running' }]))
-  })
-
-  it('waits for the work on a draining sandbox to end before suspending it', async () => {
-    const { api, state } = fakeApi({ mode: 'Running' })
-    const { instance } = driver(api)
-    await instance.launch(launchRequest)
-    instance.onSandboxObserved(observed('Running', 'rollout-7/image:v2'))
-    await Promise.resolve()
-    // A live runtime keeps its pod: the rollout waits for the turn rather than the daemon
-    // killing it, and gives up on its own deadline if it never goes quiet.
-    expect(state.modeWrites).toEqual([])
-
-    // The runtime is gone, so the sandbox is idle — which is when the pending drain lands.
-    instance.onChannelLost('agent-a', 'shim channel gone')
-    await vi.waitFor(() => expect(state.modeWrites).toEqual([{ desired: 'Suspended', observed: 'Running' }]))
-  })
-
-  it('holds the sandbox across workspace preparation, not merely across the bind', async () => {
-    // Cold preparation clones, pulls and materializes IN the pod, over the shim, between the bind
-    // and the launch it is preparing for. A hold that ended with the bind would leave that whole
-    // stretch drainable, and the suspend would pull the pod out from under an admitted turn.
-    const { api, state } = fakeApi({ mode: 'Running' })
-    const { instance } = driver(api)
-    let finishPreparing!: () => void
-    const preparing = new Promise<void>((resolve) => (finishPreparing = resolve))
-    const held = instance.withSandbox('agent-a', async () => {
-      await instance.ensureBoundChannel('agent-a')
-      await preparing
-    })
-    await vi.waitFor(() => expect(instance.currentLaunch('agent-a')).toBeDefined())
-    instance.onSandboxObserved(observed('Running', 'rollout-7/image:v2'))
-    await Promise.resolve()
-    expect(state.modeWrites).toEqual([])
-
-    finishPreparing()
-    await held
-    await vi.waitFor(() => expect(state.modeWrites).toEqual([{ desired: 'Suspended', observed: 'Running' }]))
-  })
-
-  it('refuses to take a lease on a sandbox that is already draining', async () => {
-    // The preparation has not started yet, so the drain wins the decision — fast, and by type.
-    const { api } = fakeApi({ mode: 'Running' })
-    const { instance } = driver(api)
-    await instance.ensureSandbox('agent-a')
-    instance.onSandboxObserved(observed('Suspended', 'rollout-7/image:v2'))
-    await expect(instance.withSandbox('agent-a', async () => 'prepared')).rejects.toThrow(/draining/)
-  })
-
-  it('takes drain requests off the watch and converges on each snapshot', async () => {
-    const { api } = fakeApi({ mode: 'Running' })
-    const source = watchSource()
-    api.watchSandboxes = vi.fn(() => source.stream()) as never
-    const { instance } = driver(api)
-    await instance.ensureSandbox('agent-a')
-    instance.startSandboxWatch()
-    source.push({ kind: 'modified', object: observed('Running', 'rollout-7/image:v2') })
-    await vi.waitFor(() => expect(instance.isDraining('agent-a')).toBe(true))
-
-    // A snapshot is the whole truth: a watch gap can drop a request's removal, so a sandbox the
-    // re-LIST no longer reports must not stay held down forever.
-    source.push({ kind: 'synced', items: [] })
-    await vi.waitFor(() => expect(instance.isDraining('agent-a')).toBe(false))
-    instance.stopSandboxWatch()
-  })
-
   it('orders concurrent wake and suspend decisions so the newer one wins', async () => {
     // A guarded write protects competing WRITES, but it cannot protect a decision that
     // performs no write: a later wake reading Running would return while an earlier suspend
@@ -437,18 +316,6 @@ describe('cluster spawn driver', () => {
     // The wake was decided second, so it must be the state that survives.
     expect(state.sandbox.spec?.operatingMode).toBe('Running')
     expect(state.modeWrites.map((write) => write.desired)).toEqual(['Suspended', 'Running'])
-  })
-
-  it('refuses to launch while a drain request is pending, instead of waiting out a timeout', async () => {
-    const { api } = fakeApi({ mode: 'Suspended' })
-    const { instance } = driver(api)
-    await instance.ensureSandbox('agent-a')
-    instance.onSandboxObserved(observed('Suspended', 'rollout-1/img'))
-    // wake() holds the sandbox down deliberately, so launching would block until the readiness
-    // deadline elapsed. Failing fast says what is actually happening.
-    await expect(instance.launch({ command: 'x', args: [], env: { AC_AGENT_ID: 'agent-a' } })).rejects.toThrow(
-      /draining/
-    )
   })
 
   it('resolves a suspended claim without waiting for readiness first', async () => {

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Backoff, FakeClock } from '@agentconnect.md/connection'
-import { startK8sRuntimePlane, k8sPlaneSettings, type K8sRuntimePlane } from '../src/k8s/runtime-plane.js'
+import { startK8sRuntimePlane, k8sPlaneSettings, probeAgentId, type K8sRuntimePlane } from '../src/k8s/runtime-plane.js'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import { ShimServer } from '../src/shim/server.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
@@ -30,13 +30,10 @@ afterEach(async () => {
   serverByPort.clear()
   delete process.env.AC_K8S_ORG_ID
   delete process.env.AC_K8S_WARM_POOL
+  delete process.env.AC_K8S_SANDBOX_NAMESPACE
+  delete process.env.AC_K8S_MEMBER_ID
   delete process.env.AC_K8S_SHIM_PORT
 })
-
-/** A sandbox watch that reports nothing and ends when the plane aborts it. */
-async function* idleSandboxWatch(signal?: AbortSignal): AsyncGenerator<never> {
-  await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve(), { once: true }))
-}
 
 /** A Sandbox that binds, adopts a pool pod, and reports Ready. */
 function fakeApi(options: { podName?: string; adopt?: boolean } = {}) {
@@ -67,8 +64,6 @@ function fakeApi(options: { podName?: string; adopt?: boolean } = {}) {
       getSandbox: async () => sandbox,
       setOperatingMode: async () => sandbox,
       watchClaims: vi.fn(),
-      // The plane follows Sandboxes for a rollout's drain requests; this one reports none.
-      watchSandboxes: ({ signal }: { signal?: AbortSignal }) => idleSandboxWatch(signal),
       // The dialer verifies through this, so the handshake exercises the real path.
       reviewToken: async (token: string) =>
         token === 'projected-token'
@@ -87,6 +82,8 @@ async function planeUnderTest(api: ReturnType<typeof fakeApi>): Promise<K8sRunti
   const plane = await startK8sRuntimePlane({
     orgId: 'org-1',
     warmPoolName: 'pool',
+    sandboxNamespace: 'agent-sandboxes',
+    memberId: 'member-a',
     shimPort: port,
     readyTimeoutMs: 15_000,
     api: api.api as never,
@@ -143,24 +140,38 @@ async function until(predicate: () => boolean, timeoutMs = 10_000): Promise<bool
 }
 
 describe('k8s plane settings', () => {
-  it('requires a pool but permits an install-wide daemon without an org', () => {
+  it('requires the shared sandbox namespace and member identity but permits no org', () => {
     // The pool is deployment-owned, while an install-wide daemon resolves the tenant per agent.
     expect(() => k8sPlaneSettings({})).toThrow(/AC_K8S_WARM_POOL/)
-    expect(k8sPlaneSettings({ AC_K8S_WARM_POOL: 'pool' })).toEqual({
+    expect(() => k8sPlaneSettings({ AC_K8S_WARM_POOL: 'pool' })).toThrow(/AC_K8S_SANDBOX_NAMESPACE/)
+    expect(() => k8sPlaneSettings({ AC_K8S_WARM_POOL: 'pool', AC_K8S_SANDBOX_NAMESPACE: 'agent-sandboxes' })).toThrow(
+      /AC_K8S_MEMBER_ID/
+    )
+    const base = {
+      AC_K8S_WARM_POOL: 'pool',
+      AC_K8S_SANDBOX_NAMESPACE: 'agent-sandboxes',
+      AC_K8S_MEMBER_ID: 'member-a'
+    }
+    expect(k8sPlaneSettings(base)).toEqual({
       warmPoolName: 'pool',
+      sandboxNamespace: 'agent-sandboxes',
+      memberId: 'member-a',
       shimPort: 8085
     })
-    expect(k8sPlaneSettings({ AC_K8S_ORG_ID: 'org-1', AC_K8S_WARM_POOL: 'pool' })).toEqual({
+    expect(k8sPlaneSettings({ ...base, AC_K8S_ORG_ID: 'org-1' })).toEqual({
       orgId: 'org-1',
       warmPoolName: 'pool',
+      sandboxNamespace: 'agent-sandboxes',
+      memberId: 'member-a',
       shimPort: 8085
     })
-    expect(() =>
-      k8sPlaneSettings({ AC_K8S_ORG_ID: 'org-1', AC_K8S_WARM_POOL: 'pool', AC_K8S_SHIM_PORT: 'http' })
-    ).toThrow(/not a valid port/)
-    expect(() => k8sPlaneSettings({ AC_K8S_ORG_ID: 'org-1', AC_K8S_WARM_POOL: 'pool', AC_K8S_SHIM_PORT: '0' })).toThrow(
-      /not a valid port/
-    )
+    expect(() => k8sPlaneSettings({ ...base, AC_K8S_SHIM_PORT: 'http' })).toThrow(/not a valid port/)
+    expect(() => k8sPlaneSettings({ ...base, AC_K8S_SHIM_PORT: '0' })).toThrow(/not a valid port/)
+  })
+
+  it('derives a distinct DNS-safe probe identity for each member', () => {
+    expect(probeAgentId('member-a')).toMatch(/^ac-runtime-probe-[a-f0-9]{16}$/)
+    expect(probeAgentId('member-a')).not.toBe(probeAgentId('member-b'))
   })
 })
 
@@ -190,13 +201,13 @@ describe('k8s runtime plane assembly', () => {
       }
     })
     await inFlight
-    expect(plane.dialer.connectionsFor('ac-runtime-probe')[0]?.binding.grants ?? []).toEqual(['probe'])
+    expect(plane.dialer.connectionsFor(probeAgentId('member-a'))[0]?.binding.grants ?? []).toEqual(['probe'])
     answer({ runtimes: [{ id: 'claude-acp', version: '0.66.0', acp: { protocolVersion: 1 } }] })
     const table = await probing
     expect(table.runtimes.map((entry) => `${entry.id}@${entry.version}`)).toEqual(['claude-acp@0.66.0'])
     // And the probe sandbox is gone: one leaked pod per daemon restart would be a slow leak that
     // nothing else cleans up.
-    expect(deleted).toContain('agent-ac-runtime-probe')
+    expect(deleted).toContain(`agent-${probeAgentId('member-a')}`)
   })
 
   it('holds the probe sandbox across the request, not just across the bind', async () => {
@@ -223,7 +234,7 @@ describe('k8s runtime plane assembly', () => {
     })
     await inFlight
 
-    expect(await plane.suspendIdle('ac-runtime-probe')).toBe('busy')
+    expect(await plane.suspendIdle(probeAgentId('member-a'))).toBe('busy')
 
     answer({ runtimes: [{ id: 'claude-acp', version: '0.66.0' }] })
     await probing

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Backoff, FakeClock } from '@agentconnect.md/connection'
-import { startK8sRuntimePlane, k8sPlaneSettings, probeAgentId, type K8sRuntimePlane } from '../src/k8s/runtime-plane.js'
+import {
+  PROBE_CLAIM_EXPIRES_ANNOTATION,
+  PROBE_CLAIM_LABEL,
+  k8sPlaneSettings,
+  probeAgentId,
+  reapExpiredProbeClaims,
+  startK8sRuntimePlane,
+  type K8sRuntimePlane
+} from '../src/k8s/runtime-plane.js'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import { ShimServer } from '../src/shim/server.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
@@ -61,6 +69,7 @@ function fakeApi(options: { podName?: string; adopt?: boolean } = {}) {
         return claim
       },
       deleteClaim: async () => undefined,
+      listClaims: async () => [],
       getSandbox: async () => sandbox,
       setOperatingMode: async () => sandbox,
       watchClaims: vi.fn(),
@@ -173,6 +182,37 @@ describe('k8s plane settings', () => {
     expect(probeAgentId('member-a')).toMatch(/^ac-runtime-probe-[a-f0-9]{16}$/)
     expect(probeAgentId('member-a')).not.toBe(probeAgentId('member-b'))
   })
+
+  it('reaps only expired probe claims from previous members', async () => {
+    const deleted: string[] = []
+    const current = `agent-${probeAgentId('member-a')}`
+    const expired = `agent-${probeAgentId('member-old')}`
+    const live = `agent-${probeAgentId('member-b')}`
+    const ordinary = 'agent-customer'
+    const expiry = (name: string, at: string, probe = true): SandboxClaim => ({
+      metadata: {
+        name,
+        labels: probe ? { [PROBE_CLAIM_LABEL]: 'true' } : {},
+        annotations: { [PROBE_CLAIM_EXPIRES_ANNOTATION]: at }
+      }
+    })
+    await reapExpiredProbeClaims(
+      {
+        listClaims: async (selector?: string) => {
+          expect(selector).toBe(`${PROBE_CLAIM_LABEL}=true`)
+          return [
+            expiry(current, '2026-08-14T11:00:00.000Z'),
+            expiry(expired, '2026-08-14T09:00:00.000Z'),
+            expiry(live, '2026-08-14T11:00:00.000Z'),
+            expiry(ordinary, '2026-08-14T09:00:00.000Z', false)
+          ]
+        },
+        deleteClaim: async (name: string) => void deleted.push(name)
+      },
+      Date.parse('2026-08-14T10:00:00.000Z')
+    )
+    expect(deleted).toEqual([expired])
+  })
 })
 
 describe('k8s runtime plane assembly', () => {
@@ -183,8 +223,14 @@ describe('k8s runtime plane assembly', () => {
     // run and looks healthy.
     const api = fakeApi()
     const deleted: string[] = []
+    const ensured: SandboxClaim[] = []
     api.api.deleteClaim = async (name: string) => {
       deleted.push(name)
+    }
+    const ensureClaim = api.api.ensureClaim
+    api.api.ensureClaim = async (claim) => {
+      ensured.push(claim)
+      return ensureClaim(claim)
     }
     const plane = await planeUnderTest(api)
     const port = shimPort(plane)
@@ -205,6 +251,10 @@ describe('k8s runtime plane assembly', () => {
     answer({ runtimes: [{ id: 'claude-acp', version: '0.66.0', acp: { protocolVersion: 1 } }] })
     const table = await probing
     expect(table.runtimes.map((entry) => `${entry.id}@${entry.version}`)).toEqual(['claude-acp@0.66.0'])
+    expect(ensured[0]?.metadata?.labels).toEqual({ [PROBE_CLAIM_LABEL]: 'true' })
+    expect(Date.parse(ensured[0]?.metadata?.annotations?.[PROBE_CLAIM_EXPIRES_ANNOTATION] ?? '')).toBeGreaterThan(
+      Date.now()
+    )
     // And the probe sandbox is gone: one leaked pod per daemon restart would be a slow leak that
     // nothing else cleans up.
     expect(deleted).toContain(`agent-${probeAgentId('member-a')}`)
@@ -219,6 +269,7 @@ describe('k8s runtime plane assembly', () => {
     const port = shimPort(plane)
 
     const probing = plane.probeRuntimes()
+    expect(plane.probeRuntimes()).toBe(probing)
     // A shim that has dialled in and is still generating its table. Waiting for the REQUEST rather
     // than for the connection is the whole point: during the bind the sandbox is held anyway, so
     // an assertion there would hold with or without the lease this test is about.

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -192,6 +192,8 @@ describe('k8s plane settings', () => {
     const expiry = (name: string, at: string, probe = true): SandboxClaim => ({
       metadata: {
         name,
+        uid: `uid-${name}`,
+        resourceVersion: `rv-${name}`,
         labels: probe ? { [PROBE_CLAIM_LABEL]: 'true' } : {},
         annotations: { [PROBE_CLAIM_EXPIRES_ANNOTATION]: at }
       }
@@ -207,7 +209,11 @@ describe('k8s plane settings', () => {
             expiry(ordinary, '2026-08-14T09:00:00.000Z', false)
           ]
         },
-        deleteClaim: async (name: string) => void deleted.push(name)
+        deleteClaimIfCurrent: async (name: string, preconditions) => {
+          expect(preconditions).toEqual({ uid: `uid-${name}`, resourceVersion: `rv-${name}` })
+          deleted.push(name)
+          return true
+        }
       },
       Date.parse('2026-08-14T10:00:00.000Z')
     )

--- a/packages/daemon/test/shim-tunnel.test.ts
+++ b/packages/daemon/test/shim-tunnel.test.ts
@@ -53,11 +53,6 @@ function scratchDir(): string {
   return dir
 }
 
-/** A sandbox watch that reports nothing and ends when the plane aborts it. */
-async function* idleSandboxWatch(signal?: AbortSignal): AsyncGenerator<never> {
-  await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve(), { once: true }))
-}
-
 /** A Sandbox that binds, is Ready, and names its pod. */
 function fakeApi() {
   const sandbox = {
@@ -80,8 +75,6 @@ function fakeApi() {
     getSandbox: async () => sandbox,
     setOperatingMode: async () => sandbox,
     watchClaims: vi.fn(),
-    // The plane follows Sandboxes for a rollout's drain requests; this one reports none.
-    watchSandboxes: ({ signal }: { signal?: AbortSignal }) => idleSandboxWatch(signal),
     reviewToken: async () => ({ authenticated: true, podName: 'pool-pod-9', podUid: 'pod-uid-1' })
   }
 }
@@ -135,6 +128,8 @@ async function clusterWithTunnel(
   const plane = await startK8sRuntimePlane({
     orgId: 'org-1',
     warmPoolName: 'pool',
+    sandboxNamespace: 'agent-sandboxes',
+    memberId: 'member-a',
     shimPort,
     readyTimeoutMs: 15_000,
     api: fakeApi() as never,


### PR DESCRIPTION
Part of #955.

## What changed

- remove the orphaned Sandbox drain-annotation watch and its stale launch outcome/tests
- scope runtime-probe claim names to a daemon member using a hash of `AC_K8S_MEMBER_ID`
- label probe claims with a 15-minute expiry and periodically reap abandoned claims using UID/resourceVersion-fenced deletes
- require `AC_K8S_SANDBOX_NAMESPACE` and use it instead of the daemon Pod namespace
- update the cluster design docs for the two-namespace pool layout and probe lifecycle

## Why

The deleted per-org operator was the only producer of `agentconnect.md/drain-requested`, so the daemon watch had become dead machinery. A fixed probe claim made simultaneous pool members race on one SandboxClaim, while member-scoped claims needed restart-safe garbage collection. Deriving the resource namespace from in-cluster config also targeted the daemon namespace rather than the shared sandbox namespace.

## Impact

`--k8s` now fails fast unless deployments provide `AC_K8S_SANDBOX_NAMESPACE` and a member-unique `AC_K8S_MEMBER_ID` (normally the Pod UID via the Downward API). Abandoned probe claims are bounded without touching ordinary agent claims, and stale sweeps cannot delete a same-name replacement.

## Validation

- 83 related daemon tests passed across the K8s runtime plane, client, driver, metrics, ACP E2E, credentials, and tunnel suites
- `pnpm --filter @agentconnect.md/daemon typecheck`
- targeted ESLint and Prettier checks
- repository pre-push `eslint .`
- full daemon suite on the initial revision: 3510 passed; 3 unrelated environment/live-runtime failures (provider quota/model behavior and host `GIT_ASKPASS` contamination)