### PR TITLE
feat(duty): self-fence held duties when the CP link outlives the lease horizon

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -406,6 +406,9 @@ export function buildContainer(
     clock,
     {
       HEARTBEAT_SEC: config.HEARTBEAT_SEC,
+      // Single-sourced from the lease service's own horizon: the daemon derives its duty
+      // self-fence from this, so the two halves of `T_reassign > T_fence` cannot drift.
+      DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs,
       // Web console origin for daemon-built session deep links: explicit PUBLIC_WEB_URL, else
       // a concrete CORS_ORIGIN (the browser console origin a two-origin deploy already lists),
       // else PUBLIC_CP_URL for single-origin deploys. All unset ⇒ no webAppUrl sent (daemon

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -45,7 +45,7 @@ export const DUTY_LEASE_DEFAULTS: DutyLeaseConfig = {
   grantPolicy: 'incumbent'
 }
 
-type Send = (type: 'duty/grant' | 'duty/revoke', payload: unknown) => void
+type Send = (type: 'duty/grant' | 'duty/revoke' | 'duty/renewed', payload: unknown) => void
 
 function toGrantEntry(g: Pick<DutyGrantRecord, 'groupId' | 'orgId' | 'term' | 'members'>): DutyGrantEntry {
   return { groupId: g.groupId, orgId: g.orgId, term: String(g.term), members: g.members }
@@ -127,6 +127,12 @@ export class DutyLeaseService {
   private async exchange(daemonId: DaemonId, duties: HeartbeatDuties, send: Send): Promise<void> {
     const now = new Date(this.clock.now())
     await this.repo.renewHeld(daemonId, now, this.config.leaseMs)
+    // Confirm the renewal that just happened, before anything else on this connection.
+    // The member's self-fence anchors on RECEIPT of this frame: sending a heartbeat is not
+    // renewing a lease (a half-open socket swallows it, and a beat arriving while this
+    // daemon's lane is busy is dropped without ever reaching `renewHeld`), so only the CP
+    // can tell it the countdown restarted. Relative, never a timestamp — no shared clock.
+    send('duty/renewed', { leaseMs: this.config.leaseMs })
     const held = await this.repo.listHeldBy(daemonId)
     const heldById = new Map(held.map((g) => [g.groupId, g]))
     const digestIds = new Set(duties.held.map((d) => d.groupId))

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -127,12 +127,6 @@ export class DutyLeaseService {
   private async exchange(daemonId: DaemonId, duties: HeartbeatDuties, send: Send): Promise<void> {
     const now = new Date(this.clock.now())
     await this.repo.renewHeld(daemonId, now, this.config.leaseMs)
-    // Confirm the renewal that just happened, before anything else on this connection.
-    // The member's self-fence anchors on RECEIPT of this frame: sending a heartbeat is not
-    // renewing a lease (a half-open socket swallows it, and a beat arriving while this
-    // daemon's lane is busy is dropped without ever reaching `renewHeld`), so only the CP
-    // can tell it the countdown restarted. Relative, never a timestamp — no shared clock.
-    send('duty/renewed', { leaseMs: this.config.leaseMs })
     const held = await this.repo.listHeldBy(daemonId)
     const heldById = new Map(held.map((g) => [g.groupId, g]))
     const digestIds = new Set(duties.held.map((d) => d.groupId))
@@ -223,6 +217,15 @@ export class DutyLeaseService {
     for (let i = 0; i < revocations.length; i += this.config.revocationsPerFrame) {
       send('duty/revoke', { revocations: revocations.slice(i, i + this.config.revocationsPerFrame) })
     }
+    // LAST, and the ordering is load-bearing. The member's self-fence anchors on receipt of this
+    // frame, and the fence is global while renewal is per-group — so a delivered PREFIX of this
+    // exchange must never extend the countdown without also carrying what invalidated the
+    // member's holdings. Every digest entry `renewHeld` did not renew is answered above, in this
+    // same exchange, by a revocation (or by a grant that re-took it), and one socket delivers in
+    // order: "the confirmation arrived" therefore implies "everything that supersedes what I hold
+    // arrived first". A truncated exchange simply leaves the fence running, which is the safe
+    // direction, as does any throw before this line. Relative, never a timestamp — no shared clock.
+    send('duty/renewed', { leaseMs: this.config.leaseMs })
   }
 
   /**

--- a/packages/control-plane/src/registry/authService.test.ts
+++ b/packages/control-plane/src/registry/authService.test.ts
@@ -3,6 +3,7 @@ import { DaemonAuthService } from './authService.js'
 import { ApiKeyCodec } from './apiKey.js'
 import type { ApiKeyRepo, ApiKeyRecord } from '../persistence/ports.js'
 import type { EpochService } from '../orchestrator/epoch.js'
+import { DUTY_LEASE_DEFAULTS } from '../orchestrator/dutyLease.js'
 import type { Clock } from '../domain/clock.js'
 import type { ClientCtx, ClusterDaemonIdentity } from '../ports.js'
 import { OrgId, DaemonId } from '../domain/ids.js'
@@ -52,7 +53,14 @@ function svc(
   webAppUrl?: string,
   orgs: { slugById: (orgId: string) => Promise<string | null> } = { slugById: async () => null }
 ): DaemonAuthService {
-  return new DaemonAuthService(codec, repo, epoch, clock, { HEARTBEAT_SEC: 15, WEB_APP_URL: webAppUrl }, orgs)
+  return new DaemonAuthService(
+    codec,
+    repo,
+    epoch,
+    clock,
+    { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs, WEB_APP_URL: webAppUrl },
+    orgs
+  )
 }
 
 const okEpoch = makeEpoch(async () => ({ sessionEpoch: 7n }))
@@ -66,6 +74,8 @@ describe('DaemonAuthService.authenticate — close-code contract', () => {
     if (!r.ok) throw new Error('expected ok')
     expect(r.okFrame.sessionEpoch).toBe(7)
     expect(r.okFrame.heartbeatSec).toBe(15)
+    // The daemon's self-fence is derived from this, so it must be THIS CP's horizon.
+    expect(r.okFrame.dutyLeaseMs).toBe(DUTY_LEASE_DEFAULTS.leaseMs)
     expect(r.okFrame.webAppUrl).toBeUndefined() // omitted when WEB_APP_URL is unset
     expect(repo.touchLastUsed).toHaveBeenCalledOnce()
   })
@@ -186,7 +196,15 @@ describe('DaemonAuthService.authenticate — the in-cluster token path', () => {
   const orgs = { slugById: async () => 'cluster-org' }
 
   function withIdentity(verify: ClusterDaemonIdentity['verify'], repo = makeRepo()): DaemonAuthService {
-    return new DaemonAuthService(codec, repo, okEpoch, clock, { HEARTBEAT_SEC: 15 }, orgs, { verify })
+    return new DaemonAuthService(
+      codec,
+      repo,
+      okEpoch,
+      clock,
+      { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs },
+      orgs,
+      { verify }
+    )
   }
 
   it('a verified token authenticates without any API key', async () => {
@@ -226,9 +244,17 @@ describe('DaemonAuthService.authenticate — the in-cluster token path', () => {
     const epoch = makeEpoch(async () => {
       throw new Error('must not be reached')
     })
-    const service = new DaemonAuthService(codec, makeRepo(), epoch, clock, { HEARTBEAT_SEC: 15 }, orgs, {
-      verify: async () => null
-    })
+    const service = new DaemonAuthService(
+      codec,
+      makeRepo(),
+      epoch,
+      clock,
+      { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs },
+      orgs,
+      {
+        verify: async () => null
+      }
+    )
     const r = await service.authenticate({ serviceAccountToken: 'projected', agentVersion: '1' }, ctx)
     expect(r).toMatchObject({ ok: false, closeCode: 4401 })
   })

--- a/packages/control-plane/src/registry/authService.ts
+++ b/packages/control-plane/src/registry/authService.ts
@@ -33,6 +33,9 @@ import { ApiKeyCodec } from './apiKey.js'
 /** Config slice the auth service needs. */
 export interface AuthServiceConfig {
   HEARTBEAT_SEC: number
+  /** Duty lease horizon handed to the daemon so its self-fence tracks THIS CP's
+   *  `DUTY_LEASE_DEFAULTS.leaseMs` instead of a duplicated constant. */
+  DUTY_LEASE_MS: number
   /** Web App console origin sent to daemons on `auth/ok` for session deep links.
    *  Undefined ⇒ no `webAppUrl` in the reply (daemon falls back to its own config). */
   WEB_APP_URL?: string
@@ -145,6 +148,9 @@ export class DaemonAuthService implements DaemonAuth {
       daemonId, // authoritative id (what the credential resolves to) — the daemon adopts this
       sessionEpoch: Number(sessionEpoch), // wire is a JS number; DB stores bigint
       heartbeatSec: this.config.HEARTBEAT_SEC,
+      // The daemon's duty self-fence deadline is derived from this, so it can never
+      // outlive the vacancy window this same CP reassigns on.
+      dutyLeaseMs: this.config.DUTY_LEASE_MS,
       serverTime: new Date(nowMs).toISOString(),
       organizationMode: orgId ? 'connection' : 'frame',
       ...(this.config.WEB_APP_URL ? { webAppUrl: this.config.WEB_APP_URL } : {}),

--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -40,6 +40,7 @@ const INSTALL_WIDE_FRAME_TYPES = new Set([
   'config/push',
   // Duty lease exchange: groups span orgs on one member; grants carry per-entry orgId.
   'duty/grant',
+  'duty/renewed',
   'duty/revoke',
   'duty/release',
   'duty/claim',

--- a/packages/control-plane/test/fakes/build-app.ts
+++ b/packages/control-plane/test/fakes/build-app.ts
@@ -31,6 +31,7 @@ import {
 } from '../../src/persistence/index.js'
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import { EpochService } from '../../src/orchestrator/epoch.js'
+import { DUTY_LEASE_DEFAULTS } from '../../src/orchestrator/dutyLease.js'
 import { Placement } from '../../src/orchestrator/placement.js'
 import { AgentSpecAssembler } from '../../src/orchestrator/agentSpecAssembler.js'
 import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
@@ -100,7 +101,14 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
 
   const codec = new ApiKeyCodec({ API_KEY_PEPPER: TEST_API_KEY_PEPPER })
   const epoch = new EpochService(repos.daemon, clock)
-  const auth = new DaemonAuthService(codec, repos.apiKey, epoch, clock, { HEARTBEAT_SEC: 15 }, new PgOrgRepo(prisma))
+  const auth = new DaemonAuthService(
+    codec,
+    repos.apiKey,
+    epoch,
+    clock,
+    { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs },
+    new PgOrgRepo(prisma)
+  )
   const registry = new DaemonRegistryService(repos.daemon, repos.runtimeProfile, repos.daemonLifecycleOp, clock)
   const orchestrator = new Placement(
     repos.daemon,

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -76,6 +76,7 @@ import { OrgInviteLinkCodec } from '../../src/registry/orgInviteLink.js'
 import { OrgInviteLinkService } from '../../src/registry/orgInviteLinkService.js'
 import { WaitlistService } from '../../src/registry/waitlistService.js'
 import { EpochService } from '../../src/orchestrator/epoch.js'
+import { DUTY_LEASE_DEFAULTS } from '../../src/orchestrator/dutyLease.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import { RelayControlSender } from '../../src/orchestrator/relayControl.js'
 import { HttpBotOrchestrator } from '../../src/orchestrator/httpBot.js'
@@ -425,7 +426,14 @@ export function buildHttpApp(
       githubInstallationRepo,
       'agentconnect-test'
     ),
-    auth: new DaemonAuthService(codec, apiKeyRepo, epoch, clock, { HEARTBEAT_SEC: 15 }, new PgOrgRepo(prisma)),
+    auth: new DaemonAuthService(
+      codec,
+      apiKeyRepo,
+      epoch,
+      clock,
+      { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs },
+      new PgOrgRepo(prisma)
+    ),
     apiKeys: apiKeyService,
     oauth: new OAuthService(oauthRepo, apiKeyService, codec, clock),
     webchatTokens: new WebchatTokenService(TEST_API_KEY_PEPPER),

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -132,6 +132,9 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
 
   const codec = new ApiKeyCodec({ API_KEY_PEPPER: TEST_API_KEY_PEPPER })
 
+  // One horizon for both halves: auth/ok tells the daemon exactly what the lease service uses.
+  const dutyLeaseMs = opts.dutyLease?.leaseMs ?? 120_000
+
   const epoch = new EpochService(repos.daemon, clock)
   // Fake in-cluster identity: token → install-wide daemon, no TokenReview.
   const cloudTokens = new Map<string, string>()
@@ -140,7 +143,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     repos.apiKey,
     epoch,
     clock,
-    { HEARTBEAT_SEC: opts.heartbeatSec ?? 15 },
+    { HEARTBEAT_SEC: opts.heartbeatSec ?? 15, DUTY_LEASE_MS: dutyLeaseMs },
     new PgOrgRepo(prisma),
     {
       verify: async (token: string) => {
@@ -192,7 +195,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
   )
 
   const dutyLease = new DutyLeaseService(new PgDutyGroupRepo(prisma), clock, {
-    leaseMs: opts.dutyLease?.leaseMs ?? 120_000,
+    leaseMs: dutyLeaseMs,
     recoveryGraceMs: opts.dutyLease?.recoveryGraceMs ?? 0,
     grantMaxPerTick: opts.dutyLease?.grantMaxPerTick ?? 32,
     grantsPerFrame: opts.dutyLease?.grantsPerFrame ?? 50,

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -136,7 +136,24 @@ describe('duty lease exchange (protocol level, real Postgres)', () => {
     const row = await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })
     expect(row.term).toBe(1n)
     expect(row.expiresAt).toEqual(new Date(h.clock.now() + LEASE_MS))
-    expect(stub.sent.filter((f) => f.type.startsWith('duty/'))).toEqual([])
+    // Nothing to grant and nothing to revoke — only the confirmation that the renewal happened,
+    // which is what the member anchors its self-fence on.
+    expect(stub.sent.filter((f) => f.type.startsWith('duty/')).map((f) => f.type)).toEqual(['duty/renewed'])
+  })
+
+  it('every processed duty beat is answered with the renewal horizon it just wrote', async () => {
+    const h = buildWsHarness(prisma, { dutyLease: { leaseMs: 90_000 } })
+    const start = new Date(h.clock.now())
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(start.getTime() + 5_000) })
+    const { stub } = await ready(h)
+
+    stub.inject('heartbeat', heartbeat({ held: [{ groupId: GROUP, term: '1' }], headroom: 0 }))
+    const renewed = await stub.expectFrame('duty/renewed')
+    if (!isFrame('duty/renewed')(renewed)) throw new Error('expected duty/renewed')
+    // Relative, never a timestamp: the member measures from receipt on its own clock.
+    expect(renewed.payload).toEqual({ leaseMs: 90_000 })
+    const row = await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })
+    expect(row.expiresAt).toEqual(new Date(h.clock.now() + 90_000))
   })
 
   it('a digest entry the ledger granted elsewhere is revoked as superseded', async () => {

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -156,6 +156,25 @@ describe('duty lease exchange (protocol level, real Postgres)', () => {
     expect(row.expiresAt).toEqual(new Date(h.clock.now() + 90_000))
   })
 
+  it('the renewal confirmation comes LAST, after the revocation it must never outrun', async () => {
+    // The member's fence is global while renewal is per-group, so a delivered PREFIX of this
+    // exchange must not extend the countdown without the revocation that makes it safe. Here
+    // `renewHeld` renews nothing the member reported — the group belongs to OTHER now — and one
+    // socket delivers in order, so a confirmation implies the supersession arrived first.
+    const h = buildWsHarness(prisma)
+    const start = new Date(h.clock.now())
+    await seedGroup({ holder: OTHER, term: 2n, expiresAt: new Date(start.getTime() + LEASE_MS) })
+    const { stub } = await ready(h)
+
+    stub.inject('heartbeat', heartbeat({ held: [{ groupId: GROUP, term: '1' }], headroom: 0 }))
+    await stub.expectFrame('duty/renewed')
+
+    expect(stub.sent.filter((f) => f.type.startsWith('duty/')).map((f) => f.type)).toEqual([
+      'duty/revoke',
+      'duty/renewed'
+    ])
+  })
+
   it('a digest entry the ledger granted elsewhere is revoked as superseded', async () => {
     const h = buildWsHarness(prisma)
     const start = new Date(h.clock.now())

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -160,6 +160,13 @@ const INSTALL_WIDE_FRAME_TYPES = new Set([
 const ACK_TIMEOUT_MS = 5000
 const BACKOFF_BASE_MS = 1000
 const BACKOFF_CAP_MS = 30000
+// No-split invariant `T_reassign > T_fence`: the CP frees a lease at `lastRenew + dutyLeaseMs`, so a member that
+// stopped renewing must be quiet strictly earlier — it fences this fraction of the horizon past its last duty beat.
+// The remaining quarter absorbs clock skew, the beat's in-flight delivery, and a beat the CP dropped.
+const DUTY_FENCE_HORIZON_FRACTION = 0.75
+// Horizon assumed when `auth/ok` carries none (a CP older than the field); mirrors the CP's shipped default.
+// Deliberately a copy: it is a guess about a peer that cannot answer, and guessing beats silently never fencing.
+const DUTY_LEASE_FALLBACK_MS = 120_000
 const REGISTERING_CONTROL_QUEUE_LIMIT = 1024
 const utf8Bytes = (value: string) => new TextEncoder().encode(value).length
 
@@ -211,6 +218,9 @@ export interface CpClientDeps {
    *  an install-wide (frame-mode) connection; absent ⇒ this daemon does not
    *  participate in the ledger and the CP-side exchange stays dormant. */
   duties?: () => HeartbeatDuties | undefined
+  /** Duty self-fence: the link has been down long enough that the ledger is about to hand this member's leases
+   *  to a successor, so stop serving them first. Armed off the last duty beat, never off the disconnect. */
+  onDutyFence?: () => void
   configApply: ConfigApply
   /** Read-only session list/history seam over the local store (§1/§12). */
   sessionRead: SessionReader
@@ -272,6 +282,14 @@ export class CpClient {
   private lastAuthedEpoch = 0 // for resume on reconnect (per-agent seq tail is out of scope)
   private heartbeatTimer?: TimerHandle
   private heartbeatMs = 0
+  /** Lease horizon from `auth/ok`; undefined until a CP that sends one answers. */
+  private dutyLeaseMs?: number
+  /** When the last heartbeat CARRYING DUTIES went out on a live socket — the event the CP renews from, and
+   *  therefore the only sound anchor for the fence deadline. */
+  private lastDutyBeatAt = 0
+  private dutyFenceTimer?: TimerHandle
+  /** Set once the fence fires and cleared by the next duty beat, so a flapping link fences once, not per drop. */
+  private dutyFenced = false
   private connectRun?: Promise<void>
   /** `stop()` must join snapshot convergence after a transport has connected,
    *  but it cannot wait forever for a connector whose dial is not cancellable.
@@ -315,6 +333,9 @@ export class CpClient {
       this.reconnectTimer = undefined
     }
     this.stopHeartbeat()
+    // A local shutdown tears down every agent anyway — a fence timer outliving it would
+    // only fire into a daemon that has already stopped serving.
+    this.clearDutyFence()
     this.correlator.rejectAll(new Error('stopping'))
     this.registerControlBarrier = undefined
     this.transport?.close(1000, 'shutdown')
@@ -422,6 +443,7 @@ export class CpClient {
       daemonId: string
       sessionEpoch: number
       heartbeatSec: number
+      dutyLeaseMs?: number
       webAppUrl?: string
       orgSlug?: string
       organizationMode?: 'connection' | 'frame'
@@ -429,6 +451,13 @@ export class CpClient {
     }
     this.sessionEpoch = ok.sessionEpoch
     this.organizationMode = ok.organizationMode ?? 'connection'
+    this.dutyLeaseMs = ok.dutyLeaseMs
+    // Once per connection, and only where a lease can exist: a member fencing on a guess should say so.
+    if (ok.dutyLeaseMs === undefined && this.organizationMode === 'frame' && this.deps.duties) {
+      this.deps.log.warn(
+        `cp: no duty lease horizon in auth/ok — self-fencing on the built-in ${DUTY_LEASE_FALLBACK_MS}ms default`
+      )
+    }
     this.lastAuthedEpoch = ok.sessionEpoch
     // Adopt the authoritative daemonId the CP assigned (no-op if we already had one).
     if (ok.daemonId && ok.daemonId !== this.deps.daemonId) {
@@ -511,6 +540,9 @@ export class CpClient {
     this.updateCapabilities()
     this.heartbeatMs = ok.heartbeatSec > 0 ? ok.heartbeatSec * 1000 : this.deps.heartbeatDefaultMs
     this.armHeartbeat()
+    // Reconnected with a fence pending: renew the leases now instead of a cadence from now.
+    // The fence lifts on a lease exchange, and a healthy link must not be fenced waiting for one.
+    if (this.state === 'READY' && this.dutyFenceTimer !== undefined) this.sendHeartbeat()
     this.deps.log.info(`cp: READY (epoch=${this.sessionEpoch}, routingEpoch=${this.routingEpoch})`)
 
     // Report the observed runtime snapshot (D→C `facts/daemon-runtimes`,
@@ -1131,6 +1163,9 @@ export class CpClient {
     this.transport = undefined
     if (this.registerControlBarrier?.transport === source) this.registerControlBarrier = undefined
     this.correlator.rejectAll(new WireError('INTERNAL', 'connection closed', true))
+    // Before the fatal/stopped branches: a member whose credential died can never renew
+    // either, and its leases go vacant on exactly the same schedule.
+    if (!this.stopped) this.armDutyFence()
     if (code === 4401) {
       this.fatal = true
       this.state = 'CLOSED'
@@ -1149,30 +1184,67 @@ export class CpClient {
     this.heartbeatTimer = this.deps.clock.setTimeout(() => {
       // Skip the send mid-drain (we report `degraded` differently), but keep the
       // loop alive so heartbeats resume once we transition DRAINING → READY.
-      if (this.state === 'READY') {
-        // The duty lease exchange rides this beat (frames/duty.ts). Absent on a
-        // single-org daemon, which keeps the whole CP-side path dormant.
-        const duties = this.organizationMode === 'frame' ? this.deps.duties?.() : undefined
-        this.transport?.send(
-          encode(
-            buildEnvelope('heartbeat', {
-              load: this.deps.loadSnapshot(),
-              health: 'ok',
-              activeSessions: this.deps.activeSessions(),
-              degradedScopes: this.deps.degradedScopes?.() ?? [],
-              ...(duties ? { duties } : {})
-            })
-          )
-        )
-      }
+      if (this.state === 'READY') this.sendHeartbeat()
       if (this.state === 'READY' || this.state === 'DRAINING') this.armHeartbeat()
     }, this.heartbeatMs)
+  }
+
+  private sendHeartbeat(): void {
+    // The duty lease exchange rides this beat (frames/duty.ts). Absent on a
+    // single-org daemon, which keeps the whole CP-side path dormant.
+    const duties = this.organizationMode === 'frame' ? this.deps.duties?.() : undefined
+    const live = this.transport
+    live?.send(
+      encode(
+        buildEnvelope('heartbeat', {
+          load: this.deps.loadSnapshot(),
+          health: 'ok',
+          activeSessions: this.deps.activeSessions(),
+          degradedScopes: this.deps.degradedScopes?.() ?? [],
+          ...(duties ? { duties } : {})
+        })
+      )
+    )
+    // This beat is what the CP renews from, so it re-anchors the deadline and cancels a fence armed by an
+    // earlier outage — the link is healthy AND the lease exchange ran, which socket-open alone never proves.
+    if (duties && live) {
+      this.lastDutyBeatAt = this.deps.clock.now()
+      this.dutyFenced = false
+      this.clearDutyFence()
+    }
   }
 
   private stopHeartbeat(): void {
     if (this.heartbeatTimer !== undefined) {
       this.deps.clock.clearTimeout(this.heartbeatTimer)
       this.heartbeatTimer = undefined
+    }
+  }
+
+  /** Arm the duty self-fence for a link that just went down. The deadline is absolute (`lastDutyBeat + fraction ×
+   *  horizon`), so disconnecting just before a due beat cannot push it past the CP's expiry and a re-arm across
+   *  several failed reconnects keeps the original deadline instead of restarting the countdown. */
+  private armDutyFence(): void {
+    if (this.lastDutyBeatAt === 0) return // never renewed a lease: nothing the CP could reassign
+    if (this.dutyFenceTimer !== undefined || this.dutyFenced || !this.deps.onDutyFence) return
+    const horizon = this.dutyLeaseMs ?? DUTY_LEASE_FALLBACK_MS
+    const deadline = this.lastDutyBeatAt + Math.floor(horizon * DUTY_FENCE_HORIZON_FRACTION)
+    const delay = Math.max(0, deadline - this.deps.clock.now())
+    this.dutyFenceTimer = this.deps.clock.setTimeout(() => {
+      this.dutyFenceTimer = undefined
+      this.dutyFenced = true
+      this.deps.log.warn(
+        `cp: duty self-fence — no lease renewal for ${this.deps.clock.now() - this.lastDutyBeatAt}ms; ` +
+          'releasing held duties before the CP can reassign them'
+      )
+      this.deps.onDutyFence?.()
+    }, delay)
+  }
+
+  private clearDutyFence(): void {
+    if (this.dutyFenceTimer !== undefined) {
+      this.deps.clock.clearTimeout(this.dutyFenceTimer)
+      this.dutyFenceTimer = undefined
     }
   }
 

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -223,6 +223,9 @@ export interface CpClientDeps {
    *  an install-wide (frame-mode) connection; absent ⇒ this daemon does not
    *  participate in the ledger and the CP-side exchange stays dormant. */
   duties?: () => HeartbeatDuties | undefined
+  /** Groups whose admission is in flight — intended to be held, not yet in the digest. Their deadlines must
+   *  survive a renewal's prune: dropping one is exactly what would leave an admitted group with no fence. */
+  dutyPending?: () => string[]
   /** Duty self-fence: these groups' leases are about to go vacant at the CP, so stop serving them first. Called
    *  with the groups whose OWN deadline elapsed — never the whole held set — so a member sheds exactly what it
    *  can no longer prove it holds and keeps serving the rest. */
@@ -878,6 +881,9 @@ export class CpClient {
     }
     const rep = await this.request('duty/release', { groupIds })
     if (rep.type !== 'ack') throw new WireError('INTERNAL', `expected ack, got ${rep.type}`, false)
+    // Handed back, so their deadlines are not ours to run any more — and a released group must not
+    // sit in the map holding the timer earlier than a group this member still serves.
+    this.forgetLeaseDeadlines(groupIds)
   }
 
   /**
@@ -1241,11 +1247,16 @@ export class CpClient {
    *  filter, so one confirmation genuinely does refresh them all, and the per-group map collapses back to a single
    *  value after each one. It is also where the map is pruned: the daemon's digest is the authoritative held set. */
   private noteLeasesRenewed(): void {
-    const held = this.deps.duties?.()?.held ?? []
-    const stillHeld = new Set(held.map((entry) => entry.groupId))
-    for (const groupId of this.dutyDeadlines.keys()) if (!stillHeld.has(groupId)) this.dutyDeadlines.delete(groupId)
+    // "What we intend to hold" = the digest PLUS the admissions still in flight. A pending group is
+    // absent from the digest by design (it is not servable yet), and pruning its deadline here is what
+    // would leave it serving with no fence the moment its admission completes.
+    const ours = new Set([
+      ...(this.deps.duties?.()?.held ?? []).map((entry) => entry.groupId),
+      ...(this.deps.dutyPending?.() ?? [])
+    ])
+    for (const groupId of this.dutyDeadlines.keys()) if (!ours.has(groupId)) this.dutyDeadlines.delete(groupId)
     const now = this.deps.clock.now()
-    for (const entry of held) this.dutyDeadlines.set(entry.groupId, this.deadlineFrom(now))
+    for (const groupId of ours) this.dutyDeadlines.set(groupId, this.deadlineFrom(now))
     this.armDutyFence()
   }
 

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -292,9 +292,10 @@ export class CpClient {
   /** True when this CP confirms renewals (`auth/ok` carried a horizon ⇒ it also sends `duty/renewed`), so the
    *  anchor is evidence the CP renewed rather than evidence we queued a frame. */
   private dutyRenewalsConfirmed = false
-  /** When the lease countdown last provably restarted: receipt of `duty/renewed`, or — only against a CP that
-   *  confirms nothing — the weaker "we sent a duty beat". Zero ⇒ no lease this member could lose. */
-  private lastLeaseRenewalAt = 0
+  /** When the lease countdown last provably restarted: receipt of `duty/renewed` or of a won `duty/claim/ok`,
+   *  or — only against a CP that confirms nothing — the weaker "we sent a duty beat". Undefined, never 0, so a
+   *  renewal at clock time zero is not read as "no lease this member could lose". */
+  private lastLeaseRenewalAt?: number
   private dutyFenceTimer?: TimerHandle
   private connectRun?: Promise<void>
   /** `stop()` must join snapshot convergence after a transport has connected,
@@ -552,7 +553,7 @@ export class CpClient {
     // A member with a running fence beats immediately instead of a cadence from now: only a CONFIRMED
     // renewal lifts the fence, and a reconnect that waits for the next scheduled beat can be fenced with
     // the link already healthy. The confirmation this elicits is what actually cancels it.
-    if (this.state === 'READY' && this.lastLeaseRenewalAt > 0) this.sendHeartbeat()
+    if (this.state === 'READY' && this.lastLeaseRenewalAt !== undefined) this.sendHeartbeat()
     this.deps.log.info(`cp: READY (epoch=${this.sessionEpoch}, routingEpoch=${this.routingEpoch})`)
 
     // Report the observed runtime snapshot (D→C `facts/daemon-runtimes`,
@@ -890,7 +891,14 @@ export class CpClient {
     if (rep.type !== 'duty/claim/ok') {
       throw new WireError('INTERNAL', `expected duty/claim/ok, got ${rep.type}`, false)
     }
-    return rep.payload as DutyClaimOk
+    const claim = rep.payload as DutyClaimOk
+    // A won claim CREATES this member's lease (`claimAgentHome` writes `expiresAt = now + leaseMs`)
+    // and it starts serving at once — so it is a renewal in every sense the fence cares about, and
+    // often the FIRST one, on a member no heartbeat has confirmed anything for yet. Without this the
+    // rendezvous serves a lease with no countdown running at all. Receipt-anchored like a renewal,
+    // and conservative for the same reason: the CP wrote `expiresAt` strictly before this reply.
+    if (claim.granted) this.noteLeaseRenewed()
+    return claim
   }
 
   /**
@@ -1243,18 +1251,18 @@ export class CpClient {
    *  a half-open socket produces no close event and no renewal either, and only a running deadline fences it.
    *  A healthy member simply re-arms every renewal, long before the deadline it set the time before. */
   private armDutyFence(): void {
-    if (this.lastLeaseRenewalAt === 0) return // no lease was ever renewed here: nothing the CP could reassign
+    const renewedAt = this.lastLeaseRenewalAt
+    if (renewedAt === undefined) return // no lease was ever renewed here: nothing the CP could reassign
     if (!this.deps.onDutyFence) return
     this.clearDutyFence()
     const horizon = this.dutyLeaseMs ?? DUTY_LEASE_FALLBACK_MS
-    const deadline = this.lastLeaseRenewalAt + Math.floor(horizon * DUTY_FENCE_HORIZON_FRACTION)
-    const delay = Math.max(0, deadline - this.deps.clock.now())
+    const delay = Math.max(0, renewedAt + Math.floor(horizon * DUTY_FENCE_HORIZON_FRACTION) - this.deps.clock.now())
     // Fires at most once per renewal: nothing re-arms it but the next confirmed renewal, so a
     // link that flaps for an hour fences (and warns) once, not once per drop.
     this.dutyFenceTimer = this.deps.clock.setTimeout(() => {
       this.dutyFenceTimer = undefined
       this.deps.log.warn(
-        `cp: duty self-fence — no confirmed lease renewal for ${this.deps.clock.now() - this.lastLeaseRenewalAt}ms; ` +
+        `cp: duty self-fence — no confirmed lease renewal for ${this.deps.clock.now() - renewedAt}ms; ` +
           'releasing held duties before the CP can reassign them'
       )
       this.deps.onDutyFence?.()

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -223,9 +223,10 @@ export interface CpClientDeps {
    *  an install-wide (frame-mode) connection; absent ⇒ this daemon does not
    *  participate in the ledger and the CP-side exchange stays dormant. */
   duties?: () => HeartbeatDuties | undefined
-  /** Duty self-fence: the link has been down long enough that the ledger is about to hand this member's leases
-   *  to a successor, so stop serving them first. Armed off the last duty beat, never off the disconnect. */
-  onDutyFence?: () => void
+  /** Duty self-fence: these groups' leases are about to go vacant at the CP, so stop serving them first. Called
+   *  with the groups whose OWN deadline elapsed — never the whole held set — so a member sheds exactly what it
+   *  can no longer prove it holds and keeps serving the rest. */
+  onDutyFence?: (groupIds: string[]) => void
   configApply: ConfigApply
   /** Read-only session list/history seam over the local store (§1/§12). */
   sessionRead: SessionReader
@@ -292,10 +293,12 @@ export class CpClient {
   /** True when this CP confirms renewals (`auth/ok` carried a horizon ⇒ it also sends `duty/renewed`), so the
    *  anchor is evidence the CP renewed rather than evidence we queued a frame. */
   private dutyRenewalsConfirmed = false
-  /** When the lease countdown last provably restarted: receipt of `duty/renewed` or of a won `duty/claim/ok`,
-   *  or — only against a CP that confirms nothing — the weaker "we sent a duty beat". Undefined, never 0, so a
-   *  renewal at clock time zero is not read as "no lease this member could lose". */
-  private lastLeaseRenewalAt?: number
+  /** One fence deadline PER HELD GROUP, keyed by groupId, each anchored on the receipt that restarted it:
+   *  `duty/renewed` (all of them), a `duty/grant`, or a won `duty/claim/ok` (just that one). The CP expires each
+   *  lease independently, so a single global deadline would let a fresh grant or claim postpone an older group
+   *  past its own unchanged expiry — and would leave a group granted without a following confirmation with no
+   *  deadline at all. Empty ⇒ no lease this member could lose. */
+  private readonly dutyDeadlines = new Map<string, { anchoredAt: number; deadline: number }>()
   private dutyFenceTimer?: TimerHandle
   private connectRun?: Promise<void>
   /** `stop()` must join snapshot convergence after a transport has connected,
@@ -553,7 +556,7 @@ export class CpClient {
     // A member with a running fence beats immediately instead of a cadence from now: only a CONFIRMED
     // renewal lifts the fence, and a reconnect that waits for the next scheduled beat can be fenced with
     // the link already healthy. The confirmation this elicits is what actually cancels it.
-    if (this.state === 'READY' && this.lastLeaseRenewalAt !== undefined) this.sendHeartbeat()
+    if (this.state === 'READY' && this.dutyDeadlines.size > 0) this.sendHeartbeat()
     this.deps.log.info(`cp: READY (epoch=${this.sessionEpoch}, routingEpoch=${this.routingEpoch})`)
 
     // Report the observed runtime snapshot (D→C `facts/daemon-runtimes`,
@@ -892,12 +895,11 @@ export class CpClient {
       throw new WireError('INTERNAL', `expected duty/claim/ok, got ${rep.type}`, false)
     }
     const claim = rep.payload as DutyClaimOk
-    // A won claim CREATES this member's lease (`claimAgentHome` writes `expiresAt = now + leaseMs`)
-    // and it starts serving at once — so it is a renewal in every sense the fence cares about, and
-    // often the FIRST one, on a member no heartbeat has confirmed anything for yet. Without this the
-    // rendezvous serves a lease with no countdown running at all. Receipt-anchored like a renewal,
-    // and conservative for the same reason: the CP wrote `expiresAt` strictly before this reply.
-    if (claim.granted) this.noteLeaseRenewed()
+    // A won claim CREATES this member's lease (`claimAgentHome` writes `expiresAt = now + leaseMs`) and it starts
+    // serving at once — often the member's FIRST lease, with no heartbeat confirmed for it yet, so without this
+    // the rendezvous would serve with no countdown running. Only THIS group's deadline moves: the claim renewed
+    // nothing else, and postponing an older group here is exactly the hole per-group deadlines close.
+    if (claim.granted && claim.grant) this.noteLeasesGranted([claim.grant.groupId])
     return claim
   }
 
@@ -1225,19 +1227,50 @@ export class CpClient {
     // Sending is not renewing: on a half-open socket this `send` succeeds locally and the CP never runs
     // `renewHeld`, so against a confirming CP the anchor moves only in `onDutyRenewed`. Against one that
     // confirms nothing this is the best evidence available, and it is weaker on exactly that failure.
-    if (duties && live && !this.dutyRenewalsConfirmed) this.noteLeaseRenewed()
+    if (duties && live && !this.dutyRenewalsConfirmed) this.noteLeasesRenewed()
   }
 
   /** `duty/renewed` EVT — the CP renewed this member's leases for `leaseMs` more, as of a moment strictly before
    *  this frame arrived. The only thing that restarts the fence countdown against a confirming CP. */
   private onDutyRenewed(leaseMs: number): void {
     this.dutyLeaseMs = leaseMs
-    this.noteLeaseRenewed()
+    this.noteLeasesRenewed()
   }
 
-  private noteLeaseRenewed(): void {
-    this.lastLeaseRenewalAt = this.deps.clock.now()
+  /** A renewal restarts the countdown of EVERY group this member holds — `renewHeld` renews by holder with no id
+   *  filter, so one confirmation genuinely does refresh them all, and the per-group map collapses back to a single
+   *  value after each one. It is also where the map is pruned: the daemon's digest is the authoritative held set. */
+  private noteLeasesRenewed(): void {
+    const held = this.deps.duties?.()?.held ?? []
+    const stillHeld = new Set(held.map((entry) => entry.groupId))
+    for (const groupId of this.dutyDeadlines.keys()) if (!stillHeld.has(groupId)) this.dutyDeadlines.delete(groupId)
+    const now = this.deps.clock.now()
+    for (const entry of held) this.dutyDeadlines.set(entry.groupId, this.deadlineFrom(now))
     this.armDutyFence()
+  }
+
+  /** A grant or a won claim CREATES (or re-terms) exactly one lease, so only that group's countdown restarts —
+   *  postponing an older group's deadline because a new one arrived is precisely the split this prevents.
+   *  Receipt-anchored: the CP wrote `expiresAt` strictly before the frame reached us. This is also what arms a
+   *  first grant whose renewal confirmation never lands, and what re-arms a group granted back after a fence. */
+  private noteLeasesGranted(groupIds: string[]): void {
+    if (groupIds.length === 0) return
+    const now = this.deps.clock.now()
+    for (const groupId of groupIds) this.dutyDeadlines.set(groupId, this.deadlineFrom(now))
+    this.armDutyFence()
+  }
+
+  /** A revoked group is no longer ours to fence — drop its deadline so it cannot fire, and so it cannot hold the
+   *  timer at an earlier point than any group still held. */
+  private forgetLeaseDeadlines(groupIds: string[]): void {
+    let dropped = false
+    for (const groupId of groupIds) dropped = this.dutyDeadlines.delete(groupId) || dropped
+    if (dropped) this.armDutyFence()
+  }
+
+  private deadlineFrom(now: number): { anchoredAt: number; deadline: number } {
+    const horizon = this.dutyLeaseMs ?? DUTY_LEASE_FALLBACK_MS
+    return { anchoredAt: now, deadline: now + Math.floor(horizon * DUTY_FENCE_HORIZON_FRACTION) }
   }
 
   private stopHeartbeat(): void {
@@ -1247,26 +1280,42 @@ export class CpClient {
     }
   }
 
-  /** (Re)arm the self-fence off the latest renewal. Deliberately armed while the link is UP, not on disconnect:
+  /** Arm on the EARLIEST deadline any held group has. Deliberately armed while the link is UP, not on disconnect:
    *  a half-open socket produces no close event and no renewal either, and only a running deadline fences it.
    *  A healthy member simply re-arms every renewal, long before the deadline it set the time before. */
   private armDutyFence(): void {
-    const renewedAt = this.lastLeaseRenewalAt
-    if (renewedAt === undefined) return // no lease was ever renewed here: nothing the CP could reassign
-    if (!this.deps.onDutyFence) return
     this.clearDutyFence()
-    const horizon = this.dutyLeaseMs ?? DUTY_LEASE_FALLBACK_MS
-    const delay = Math.max(0, renewedAt + Math.floor(horizon * DUTY_FENCE_HORIZON_FRACTION) - this.deps.clock.now())
-    // Fires at most once per renewal: nothing re-arms it but the next confirmed renewal, so a
-    // link that flaps for an hour fences (and warns) once, not once per drop.
+    if (!this.deps.onDutyFence || this.dutyDeadlines.size === 0) return // no lease the CP could reassign
+    let earliest = Infinity
+    for (const { deadline } of this.dutyDeadlines.values()) earliest = Math.min(earliest, deadline)
+    const delay = Math.max(0, earliest - this.deps.clock.now())
     this.dutyFenceTimer = this.deps.clock.setTimeout(() => {
       this.dutyFenceTimer = undefined
-      this.deps.log.warn(
-        `cp: duty self-fence — no confirmed lease renewal for ${this.deps.clock.now() - renewedAt}ms; ` +
-          'releasing held duties before the CP can reassign them'
-      )
-      this.deps.onDutyFence?.()
+      this.fireDutyFence()
     }, delay)
+  }
+
+  /** Fence the groups whose own deadline has passed and re-arm at the next earliest — a group whose lease the CP
+   *  still honours keeps serving. Each fenced group's deadline is dropped, so nothing re-arms it but a fresh grant
+   *  or renewal: a link that flaps for an hour fences a given group once, not once per drop. */
+  private fireDutyFence(): void {
+    const now = this.deps.clock.now()
+    const expired: string[] = []
+    let oldest = now
+    for (const [groupId, entry] of this.dutyDeadlines) {
+      if (entry.deadline > now) continue
+      expired.push(groupId)
+      oldest = Math.min(oldest, entry.anchoredAt)
+      this.dutyDeadlines.delete(groupId)
+    }
+    if (expired.length > 0) {
+      this.deps.log.warn(
+        `cp: duty self-fence — ${expired.length} group(s) with no confirmed lease renewal for ${now - oldest}ms; ` +
+          `releasing them before the CP can reassign them (${this.dutyDeadlines.size} still leased)`
+      )
+      this.deps.onDutyFence?.(expired)
+    }
+    this.armDutyFence()
   }
 
   private clearDutyFence(): void {
@@ -1282,15 +1331,25 @@ export class CpClient {
       case 'config/push':
         this.deps.configApply.applyConfigPush((frame.payload as { keys: Record<string, unknown> }).keys)
         return // EVT — no reply
-      case 'duty/grant':
-        this.deps.configApply.applyDutyGrant((frame.payload as DutyGrant).grants)
+      case 'duty/grant': {
+        const { grants } = frame.payload as DutyGrant
+        // BEFORE admission, which is async: the CP's lease on these groups is already running, and a grant whose
+        // renewal confirmation never arrives must still fence — the receipt of the grant is what arms it.
+        this.noteLeasesGranted(grants.map((entry) => entry.groupId))
+        this.deps.configApply.applyDutyGrant(grants)
         return // EVT — no reply
+      }
       case 'duty/renewed':
         this.onDutyRenewed((frame.payload as DutyRenewed).leaseMs)
         return // EVT — no reply
-      case 'duty/revoke':
-        this.deps.configApply.applyDutyRevoke((frame.payload as DutyRevoke).revocations)
+      case 'duty/revoke': {
+        const { revocations } = frame.payload as DutyRevoke
+        this.deps.configApply.applyDutyRevoke(revocations)
+        // Not ours any more: a revoked group must not keep a deadline that could fence it a second time, nor
+        // hold the timer earlier than any group still held.
+        this.forgetLeaseDeadlines(revocations.map((revocation) => revocation.groupId))
         return // EVT — no reply
+      }
       case 'cron/upsert':
         try {
           this.deps.configApply.upsertCron(frame.payload as Parameters<ConfigApply['upsertCron']>[0])

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -10,6 +10,7 @@ import type {
   Heartbeat,
   HeartbeatDuties,
   DutyGrant,
+  DutyRenewed,
   DutyRevoke,
   DutyClaimOk,
   DutyFetchOk,
@@ -151,6 +152,7 @@ const INSTALL_WIDE_FRAME_TYPES = new Set([
   'daemon/upgrade',
   'config/push',
   'duty/grant',
+  'duty/renewed',
   'duty/revoke',
   'duty/release',
   'duty/claim',
@@ -160,9 +162,12 @@ const INSTALL_WIDE_FRAME_TYPES = new Set([
 const ACK_TIMEOUT_MS = 5000
 const BACKOFF_BASE_MS = 1000
 const BACKOFF_CAP_MS = 30000
-// No-split invariant `T_reassign > T_fence`: the CP frees a lease at `lastRenew + dutyLeaseMs`, so a member that
-// stopped renewing must be quiet strictly earlier — it fences this fraction of the horizon past its last duty beat.
-// The remaining quarter absorbs clock skew, the beat's in-flight delivery, and a beat the CP dropped.
+// No-split invariant `T_reassign > T_fence`. The CP frees a lease at `renewedAt + leaseMs` and tells the member
+// that horizon on each renewal it performed (`duty/renewed`), so the member fences this fraction of it measured
+// from RECEIPT — receipt is strictly after the CP's renew, and both ends of the subtraction are the daemon's own
+// clock, so no skew enters. The remaining quarter is pure slop: the confirmation's one-way delivery, the daemon's
+// scheduling delay, and the teardown itself. Breaking the invariant would take a confirmation delivered more than
+// a quarter of the horizon late (30s at the shipped 120s) — a link that dead delivers nothing at all.
 const DUTY_FENCE_HORIZON_FRACTION = 0.75
 // Horizon assumed when `auth/ok` carries none (a CP older than the field); mirrors the CP's shipped default.
 // Deliberately a copy: it is a guess about a peer that cannot answer, and guessing beats silently never fencing.
@@ -282,14 +287,15 @@ export class CpClient {
   private lastAuthedEpoch = 0 // for resume on reconnect (per-agent seq tail is out of scope)
   private heartbeatTimer?: TimerHandle
   private heartbeatMs = 0
-  /** Lease horizon from `auth/ok`; undefined until a CP that sends one answers. */
+  /** Lease horizon: the CP's `auth/ok` value, replaced by each renewal's own. */
   private dutyLeaseMs?: number
-  /** When the last heartbeat CARRYING DUTIES went out on a live socket — the event the CP renews from, and
-   *  therefore the only sound anchor for the fence deadline. */
-  private lastDutyBeatAt = 0
+  /** True when this CP confirms renewals (`auth/ok` carried a horizon ⇒ it also sends `duty/renewed`), so the
+   *  anchor is evidence the CP renewed rather than evidence we queued a frame. */
+  private dutyRenewalsConfirmed = false
+  /** When the lease countdown last provably restarted: receipt of `duty/renewed`, or — only against a CP that
+   *  confirms nothing — the weaker "we sent a duty beat". Zero ⇒ no lease this member could lose. */
+  private lastLeaseRenewalAt = 0
   private dutyFenceTimer?: TimerHandle
-  /** Set once the fence fires and cleared by the next duty beat, so a flapping link fences once, not per drop. */
-  private dutyFenced = false
   private connectRun?: Promise<void>
   /** `stop()` must join snapshot convergence after a transport has connected,
    *  but it cannot wait forever for a connector whose dial is not cancellable.
@@ -452,10 +458,13 @@ export class CpClient {
     this.sessionEpoch = ok.sessionEpoch
     this.organizationMode = ok.organizationMode ?? 'connection'
     this.dutyLeaseMs = ok.dutyLeaseMs
+    // A CP that announces its horizon is a CP that confirms renewals — both landed together.
+    this.dutyRenewalsConfirmed = ok.dutyLeaseMs !== undefined
     // Once per connection, and only where a lease can exist: a member fencing on a guess should say so.
-    if (ok.dutyLeaseMs === undefined && this.organizationMode === 'frame' && this.deps.duties) {
+    if (!this.dutyRenewalsConfirmed && this.organizationMode === 'frame' && this.deps.duties) {
       this.deps.log.warn(
-        `cp: no duty lease horizon in auth/ok — self-fencing on the built-in ${DUTY_LEASE_FALLBACK_MS}ms default`
+        `cp: no duty lease horizon in auth/ok — self-fencing on the built-in ${DUTY_LEASE_FALLBACK_MS}ms default, ` +
+          'anchored on the heartbeats sent rather than on renewals confirmed'
       )
     }
     this.lastAuthedEpoch = ok.sessionEpoch
@@ -540,9 +549,10 @@ export class CpClient {
     this.updateCapabilities()
     this.heartbeatMs = ok.heartbeatSec > 0 ? ok.heartbeatSec * 1000 : this.deps.heartbeatDefaultMs
     this.armHeartbeat()
-    // Reconnected with a fence pending: renew the leases now instead of a cadence from now.
-    // The fence lifts on a lease exchange, and a healthy link must not be fenced waiting for one.
-    if (this.state === 'READY' && this.dutyFenceTimer !== undefined) this.sendHeartbeat()
+    // A member with a running fence beats immediately instead of a cadence from now: only a CONFIRMED
+    // renewal lifts the fence, and a reconnect that waits for the next scheduled beat can be fenced with
+    // the link already healthy. The confirmation this elicits is what actually cancels it.
+    if (this.state === 'READY' && this.lastLeaseRenewalAt > 0) this.sendHeartbeat()
     this.deps.log.info(`cp: READY (epoch=${this.sessionEpoch}, routingEpoch=${this.routingEpoch})`)
 
     // Report the observed runtime snapshot (D→C `facts/daemon-runtimes`,
@@ -1163,9 +1173,8 @@ export class CpClient {
     this.transport = undefined
     if (this.registerControlBarrier?.transport === source) this.registerControlBarrier = undefined
     this.correlator.rejectAll(new WireError('INTERNAL', 'connection closed', true))
-    // Before the fatal/stopped branches: a member whose credential died can never renew
-    // either, and its leases go vacant on exactly the same schedule.
-    if (!this.stopped) this.armDutyFence()
+    // The fence needs nothing here: it has been running off the last confirmed renewal since that
+    // renewal arrived, and a closed socket is simply one more way for the next one not to.
     if (code === 4401) {
       this.fatal = true
       this.state = 'CLOSED'
@@ -1205,13 +1214,22 @@ export class CpClient {
         })
       )
     )
-    // This beat is what the CP renews from, so it re-anchors the deadline and cancels a fence armed by an
-    // earlier outage — the link is healthy AND the lease exchange ran, which socket-open alone never proves.
-    if (duties && live) {
-      this.lastDutyBeatAt = this.deps.clock.now()
-      this.dutyFenced = false
-      this.clearDutyFence()
-    }
+    // Sending is not renewing: on a half-open socket this `send` succeeds locally and the CP never runs
+    // `renewHeld`, so against a confirming CP the anchor moves only in `onDutyRenewed`. Against one that
+    // confirms nothing this is the best evidence available, and it is weaker on exactly that failure.
+    if (duties && live && !this.dutyRenewalsConfirmed) this.noteLeaseRenewed()
+  }
+
+  /** `duty/renewed` EVT — the CP renewed this member's leases for `leaseMs` more, as of a moment strictly before
+   *  this frame arrived. The only thing that restarts the fence countdown against a confirming CP. */
+  private onDutyRenewed(leaseMs: number): void {
+    this.dutyLeaseMs = leaseMs
+    this.noteLeaseRenewed()
+  }
+
+  private noteLeaseRenewed(): void {
+    this.lastLeaseRenewalAt = this.deps.clock.now()
+    this.armDutyFence()
   }
 
   private stopHeartbeat(): void {
@@ -1221,20 +1239,22 @@ export class CpClient {
     }
   }
 
-  /** Arm the duty self-fence for a link that just went down. The deadline is absolute (`lastDutyBeat + fraction ×
-   *  horizon`), so disconnecting just before a due beat cannot push it past the CP's expiry and a re-arm across
-   *  several failed reconnects keeps the original deadline instead of restarting the countdown. */
+  /** (Re)arm the self-fence off the latest renewal. Deliberately armed while the link is UP, not on disconnect:
+   *  a half-open socket produces no close event and no renewal either, and only a running deadline fences it.
+   *  A healthy member simply re-arms every renewal, long before the deadline it set the time before. */
   private armDutyFence(): void {
-    if (this.lastDutyBeatAt === 0) return // never renewed a lease: nothing the CP could reassign
-    if (this.dutyFenceTimer !== undefined || this.dutyFenced || !this.deps.onDutyFence) return
+    if (this.lastLeaseRenewalAt === 0) return // no lease was ever renewed here: nothing the CP could reassign
+    if (!this.deps.onDutyFence) return
+    this.clearDutyFence()
     const horizon = this.dutyLeaseMs ?? DUTY_LEASE_FALLBACK_MS
-    const deadline = this.lastDutyBeatAt + Math.floor(horizon * DUTY_FENCE_HORIZON_FRACTION)
+    const deadline = this.lastLeaseRenewalAt + Math.floor(horizon * DUTY_FENCE_HORIZON_FRACTION)
     const delay = Math.max(0, deadline - this.deps.clock.now())
+    // Fires at most once per renewal: nothing re-arms it but the next confirmed renewal, so a
+    // link that flaps for an hour fences (and warns) once, not once per drop.
     this.dutyFenceTimer = this.deps.clock.setTimeout(() => {
       this.dutyFenceTimer = undefined
-      this.dutyFenced = true
       this.deps.log.warn(
-        `cp: duty self-fence — no lease renewal for ${this.deps.clock.now() - this.lastDutyBeatAt}ms; ` +
+        `cp: duty self-fence — no confirmed lease renewal for ${this.deps.clock.now() - this.lastLeaseRenewalAt}ms; ` +
           'releasing held duties before the CP can reassign them'
       )
       this.deps.onDutyFence?.()
@@ -1256,6 +1276,9 @@ export class CpClient {
         return // EVT — no reply
       case 'duty/grant':
         this.deps.configApply.applyDutyGrant((frame.payload as DutyGrant).grants)
+        return // EVT — no reply
+      case 'duty/renewed':
+        this.onDutyRenewed((frame.payload as DutyRenewed).leaseMs)
         return // EVT — no reply
       case 'duty/revoke':
         this.deps.configApply.applyDutyRevoke((frame.payload as DutyRevoke).revocations)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12866,20 +12866,22 @@ export class Daemon {
     this.onDutyChanged()
   }
 
-  // The duty self-fence (`T_reassign > T_fence`): stop serving before the CP can hand these leases to a successor.
-  // A local `duty/revoke`, never a removal — workspace, sessions, and the registry entry all survive it.
-  // Clearing the held groups IS the recovery: on reconnect the CP's missing-regrant reissues and re-installs them.
-  private fenceDuties(): void {
+  // The duty self-fence (`T_reassign > T_fence`): stop serving these groups before the CP can hand them to a
+  // successor. Per group, because the CP expires each lease on its own schedule — a group whose lease is still
+  // honoured keeps serving. Literally a local `duty/revoke`: same registry path, same teardown, so workspace,
+  // sessions, and the registry entry all survive it (#948), and the omitted groups are what the CP's
+  // missing-regrant path reissues on reconnect.
+  private fenceDuties(groupIds: string[]): void {
     // Enforcement off ⇒ duties gate nothing, so a teardown would drop live traffic for no reason.
     if (!this.dutyEnforced()) return
-    const served = this.duties.agents()
-    const groups = this.duties.releaseAll()
-    if (groups.length === 0) return
+    const held = groupIds.filter((groupId) => this.duties.get(groupId) !== undefined)
+    if (held.length === 0) return
+    const result = this.duties.applyRevoke(held.map((groupId) => ({ groupId, reason: 'superseded' as const })))
     this.log.warn(
-      `duty: self-fenced ${groups.length} group(s) covering ${served.size} agent(s) — ` +
-        'the CP lease horizon elapsed with the link down'
+      `duty: self-fenced ${held.length} group(s); ${result.agentsLost.length} agent(s) left service, ` +
+        `${this.duties.size()} group(s) still held — no confirmed lease renewal before the CP's horizon`
     )
-    for (const agentId of served) this.stopServingAgent(agentId)
+    for (const agentId of result.agentsLost) this.stopServingAgent(agentId)
     this.onDutyChanged()
   }
 
@@ -21446,7 +21448,7 @@ export class Daemon {
       },
       degradedScopes: () => this.cpDegradedScopes(),
       duties: () => this.dutyDigest(),
-      onDutyFence: () => this.fenceDuties(),
+      onDutyFence: (groupIds) => this.fenceDuties(groupIds),
       configApply: this.cpConfigApply(),
       sessionRead: createSessionReader(this.store, (session) => this.sessionThreadUrl(session)),
       // §5.4: serve a CP-forwarded status probe for a child session we own. Authorization is

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2153,6 +2153,12 @@ export class Daemon {
   // rendezvous claim awaits one for the SAME grant, so both must join a single
   // fetch+apply rather than race two of them.
   private readonly dutyInstalls = new Map<string, Promise<void>>()
+  // Admissions in flight: groupId → the admission that owns it. Deadline tracking and every
+  // withdrawal are synchronous while admission is deliberately not, so this mark is what lets a
+  // withdrawal landing mid-admission win — and what tells the fence that a group absent from the
+  // digest is still intended to be held.
+  private readonly dutyAdmissions = new Map<string, number>()
+  private dutyAdmissionSeq = 0
   // When each agent's install last failed. A dropped group is regranted on the
   // next beat, so without this a permanently failing agent would be re-fetched
   // once per regrant AND once per inbound trigger that claims its group.
@@ -12744,19 +12750,62 @@ export class Daemon {
    * retry, paced by the heartbeat rather than a private loop. Nothing needs the
    * group present in the meantime: `renewHeld` renews by holder alone.
    *
-   * Returns the groupIds it refused.
+   * Returns the groupIds it refused — a failed install, or a withdrawal that landed while the
+   * install was in flight.
    */
   private async admitDutyGrants(entries: DutyGrantEntry[]): Promise<Set<string>> {
-    const failed = await this.installGrantedAgents(entries)
-    const servable = entries.filter((entry) => !failed.has(entry.groupId))
-    if (servable.length === 0) return failed
-    const result = this.duties.applyGrant(servable)
-    this.log.info(
-      `duty: granted ${result.added.length} + re-granted ${result.updated.length} group(s); ` +
-        `holding ${this.duties.size()} covering ${this.duties.agents().size} agent(s)`
-    )
-    if (result.agentsGained.length > 0 || result.added.length > 0) this.onDutyChanged()
-    return failed
+    const admission = ++this.dutyAdmissionSeq
+    for (const entry of entries) this.dutyAdmissions.set(entry.groupId, admission)
+    try {
+      const failed = await this.installGrantedAgents(entries)
+      // The withdrawal fence, checked with NO await between it and `applyGrant`. Admission is
+      // deliberately async, so a fence, a revoke, or a drain release can land inside this window —
+      // and each of them means "this member must not serve that group". A withdrawal drops the
+      // group's admission mark, so the identity check below fails and the grant is never applied.
+      // A newer admission for the same group replaces the mark for the same reason.
+      const refused = new Set(
+        entries.filter((entry) => this.dutyAdmissions.get(entry.groupId) !== admission).map((e) => e.groupId)
+      )
+      for (const groupId of failed) refused.add(groupId)
+      const servable = entries.filter((entry) => !refused.has(entry.groupId))
+      if (servable.length > 0) {
+        const result = this.duties.applyGrant(servable)
+        this.log.info(
+          `duty: granted ${result.added.length} + re-granted ${result.updated.length} group(s); ` +
+            `holding ${this.duties.size()} covering ${this.duties.agents().size} agent(s)`
+        )
+        if (result.agentsGained.length > 0 || result.added.length > 0) this.onDutyChanged()
+      }
+      const withdrawn = refused.size - failed.size
+      if (withdrawn > 0) this.log.info(`duty: ${withdrawn} group(s) were withdrawn while being admitted — not held`)
+      return refused
+    } finally {
+      // Only ours to clear: a withdrawal already dropped it, and a newer admission owns it now.
+      for (const entry of entries) {
+        if (this.dutyAdmissions.get(entry.groupId) === admission) this.dutyAdmissions.delete(entry.groupId)
+      }
+    }
+  }
+
+  /**
+   * Withdraw these groups from service — a fence, a `duty/revoke`, or a drain release. Every one of
+   * them means the same thing, so they share one guard: a withdrawal that lands while an admission
+   * is in flight WINS, and that admission refuses to apply when it completes. Without this the group
+   * sits in a gap between grant receipt and `applyGrant` — not yet held, so nothing to withdraw —
+   * and then starts serving after the withdrawal that was meant to stop it.
+   *
+   * Returns the groups that were pending, for the caller's log; the retry story is unchanged, since
+   * the CP still leases them, does not see them in our digest, and reissues through missing-regrant.
+   */
+  private withdrawDutyGroups(groupIds: Iterable<string>): string[] {
+    const pending: string[] = []
+    for (const groupId of groupIds) if (this.dutyAdmissions.delete(groupId)) pending.push(groupId)
+    return pending
+  }
+
+  /** Groups whose admission is in flight: intended to be held, absent from the digest until applied. */
+  private pendingDutyAdmissions(): string[] {
+    return [...this.dutyAdmissions.keys()]
   }
 
   /**
@@ -12857,6 +12906,10 @@ export class Daemon {
    *  workspace, sessions, and registry entry all survive — only the platform
    *  connections and schedules this daemon was running for it stop. */
   private applyDutyRevoke(revocations: DutyRevoke['revocations']): void {
+    // Same guard as the fence: a revoke landing while the group is still being admitted must stop
+    // that admission, or the member starts serving a group the CP has already taken away.
+    const pending = this.withdrawDutyGroups(revocations.map((revocation) => revocation.groupId))
+    if (pending.length > 0) this.log.info(`duty: revoked ${pending.length} group(s) mid-admission`)
     const result = this.duties.applyRevoke(revocations)
     this.log.info(
       `duty: revoked ${revocations.length} group(s) (${revocations.map((r) => r.reason).join(',')}); ` +
@@ -12874,6 +12927,10 @@ export class Daemon {
   private fenceDuties(groupIds: string[]): void {
     // Enforcement off ⇒ duties gate nothing, so a teardown would drop live traffic for no reason.
     if (!this.dutyEnforced()) return
+    // BEFORE the held filter: a group still being admitted is not held yet, so there would be
+    // nothing to shed — and it would start serving the moment its admission completed.
+    const pending = this.withdrawDutyGroups(groupIds)
+    if (pending.length > 0) this.log.warn(`duty: self-fenced ${pending.length} group(s) mid-admission`)
     const held = groupIds.filter((groupId) => this.duties.get(groupId) !== undefined)
     if (held.length === 0) return
     const result = this.duties.applyRevoke(held.map((groupId) => ({ groupId, reason: 'superseded' as const })))
@@ -19569,6 +19626,10 @@ export class Daemon {
     // Join first: a claim still awaiting the CP would otherwise land after the
     // snapshot below and outlive the drain.
     await this.joinInFlightDutyClaims()
+    // A grant EVT can still be mid-admission here — the claim join covers the rendezvous path only.
+    // Withdraw those too, so nothing installs itself back into service after `drain/done`.
+    const pending = this.withdrawDutyGroups(this.pendingDutyAdmissions())
+    if (pending.length > 0) this.log.info(`duty: dropped ${pending.length} group(s) still being admitted on drain`)
     const groupIds = this.duties.releaseAll()
     if (groupIds.length === 0) return
     try {
@@ -21448,6 +21509,7 @@ export class Daemon {
       },
       degradedScopes: () => this.cpDegradedScopes(),
       duties: () => this.dutyDigest(),
+      dutyPending: () => this.pendingDutyAdmissions(),
       onDutyFence: (groupIds) => this.fenceDuties(groupIds),
       configApply: this.cpConfigApply(),
       sessionRead: createSessionReader(this.store, (session) => this.sessionThreadUrl(session)),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2160,6 +2160,11 @@ export class Daemon {
   // Retry window for a failed duty install: the default heartbeat cadence, which
   // is how fast the CP's missing-regrant path can offer the group back.
   private static readonly DUTY_INSTALL_RETRY_MS = 15_000
+  // Backoff for retrying the platform convergence a duty change needs, when the reconcile that
+  // carries it throws. It doubles to a slow poll and never gives up: the state it exists to leave
+  // is a fenced agent whose sockets are still open.
+  private static readonly DUTY_CONVERGE_RETRY_BASE_MS = 1_000
+  private static readonly DUTY_CONVERGE_RETRY_CAP_MS = 30_000
   // Latched for the WHOLE drain handoff, including the window after `draining`
   // reopens and before the leases are surrendered — a claim landing there would
   // install a grant the release snapshot has already passed by.
@@ -3802,11 +3807,13 @@ export class Daemon {
    */
   private reconcileRun?: Promise<void>
   private reconcilePending = false
-  // A duty change moves no agent FILE, so the agent diff is empty and platform convergence
-  // would be skipped — while the serving gate it feeds (`transportAgents`) has just changed.
-  // Set by `onDutyChanged`, consumed by the next pass, so a revoke or a fence actually closes
-  // the sockets it stopped serving.
-  private dutyConnectionsDirty = false
+  // A duty change moves no agent FILE, so the agent diff is empty and platform convergence would
+  // be skipped — while the serving gate it feeds (`transportAgents`) has just changed. Counters,
+  // not a flag: a pass claims the requested value and publishes it only once the sockets are
+  // actually converged, so neither a failed pass nor a duty change landing mid-pass is lost.
+  private dutyConnectionsRequested = 0
+  private dutyConnectionsConverged = 0
+  private dutyConvergeRetryTimer?: TimerHandle
   // Register snapshots publish agents before integrations. Carry newly-owned
   // inbox rows across coalesced passes and retry only after convergence is idle.
   private readonly pendingInboxReplayAgents = new Set<string>()
@@ -3833,10 +3840,11 @@ export class Daemon {
   }
 
   private async runReconcile(): Promise<void> {
-    // Claimed for THIS pass. A duty change landing after this read leaves the flag set, and
-    // the coalesced trailing re-run honours it.
-    const dutyDirty = this.dutyConnectionsDirty
-    this.dutyConnectionsDirty = false
+    // CLAIMED, not consumed: the request is marked satisfied only where the sockets actually
+    // converge. This pass can throw at a dozen places before it reaches the platform layer, and a
+    // fence whose sockets are still open must not be forgotten because one reconcile failed.
+    const dutyClaimed = this.dutyConnectionsRequested
+    const dutyDirty = dutyClaimed !== this.dutyConnectionsConverged
     const snapshot = this.loadAgentList(true)
     const files = snapshot.agents
     const nextFileAgents = new Map(files.map((a) => [a.id, a]))
@@ -4010,6 +4018,10 @@ export class Daemon {
       await this.reconcileTelegramConnections()
       await this.reconcileDiscordConnections()
       await this.reconcileFeishuConnections()
+      // Converged for real: the sockets a duty change invalidated are closed. Publishing the
+      // CLAIMED value (not the current one) leaves a duty change that landed mid-pass outstanding,
+      // so the trailing re-run still converges it.
+      if (dutyDirty) this.dutyConnectionsConverged = dutyClaimed
     }
     // The live roster just changed shape — re-announce any agent-derived register
     // capabilities. No-op when nothing changed. Optional call: tests inject
@@ -12959,8 +12971,27 @@ export class Daemon {
   private onDutyChanged(): void {
     if (!this.dutyEnforced()) return
     for (const agent of this.agents.values()) this.syncAgentSchedules(agent)
-    this.dutyConnectionsDirty = true
-    void this.reconcile().catch((err) => this.log.warn(`duty: reconcile after a duty change failed: ${err}`))
+    this.dutyConnectionsRequested++
+    this.convergeDutyConnections()
+  }
+
+  /** Reconcile until the duty-driven convergence has actually run. A pass that throws (a workspace
+   *  authority conflict, a host teardown, a platform close) leaves the request outstanding, and a
+   *  fence still holding its sockets open is the one state this must never settle in — so it
+   *  retries, backing off to a slow poll rather than giving up. Any other reconcile trigger
+   *  satisfies the same outstanding request and stops the loop. */
+  private convergeDutyConnections(delayMs = Daemon.DUTY_CONVERGE_RETRY_BASE_MS): void {
+    void this.reconcile().catch((err) => {
+      this.log.warn(`duty: reconcile after a duty change failed: ${formatErr(err)}`)
+      if (this.draining || this.dutyConnectionsRequested === this.dutyConnectionsConverged) return
+      this.log.warn(`duty: retrying platform convergence in ${delayMs}ms — a fenced agent may still be served`)
+      if (this.dutyConvergeRetryTimer !== undefined) this.clock.clearTimeout(this.dutyConvergeRetryTimer)
+      this.dutyConvergeRetryTimer = this.clock.setTimeout(() => {
+        this.dutyConvergeRetryTimer = undefined
+        if (this.dutyConnectionsRequested === this.dutyConnectionsConverged) return
+        this.convergeDutyConnections(Math.min(delayMs * 2, Daemon.DUTY_CONVERGE_RETRY_CAP_MS))
+      }, delayMs)
+    })
   }
 
   /** Arm this agent's cron + dream schedules, or disarm them when its duty lives
@@ -22046,6 +22077,10 @@ export class Daemon {
     if (this.runtimeProbeTimer !== undefined) {
       this.clock.clearTimeout(this.runtimeProbeTimer)
       this.runtimeProbeTimer = undefined
+    }
+    if (this.dutyConvergeRetryTimer !== undefined) {
+      this.clock.clearTimeout(this.dutyConvergeRetryTimer)
+      this.dutyConvergeRetryTimer = undefined
     }
     for (const t of this.bgWakeTimers) this.clock.clearTimeout(t)
     this.bgWakeTimers.clear()

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12845,6 +12845,23 @@ export class Daemon {
     this.onDutyChanged()
   }
 
+  // The duty self-fence (`T_reassign > T_fence`): stop serving before the CP can hand these leases to a successor.
+  // A local `duty/revoke`, never a removal — workspace, sessions, and the registry entry all survive it.
+  // Clearing the held groups IS the recovery: on reconnect the CP's missing-regrant reissues and re-installs them.
+  private fenceDuties(): void {
+    // Enforcement off ⇒ duties gate nothing, so a teardown would drop live traffic for no reason.
+    if (!this.dutyEnforced()) return
+    const served = this.duties.agents()
+    const groups = this.duties.releaseAll()
+    if (groups.length === 0) return
+    this.log.warn(
+      `duty: self-fenced ${groups.length} group(s) covering ${served.size} agent(s) — ` +
+        'the CP lease horizon elapsed with the link down'
+    )
+    for (const agentId of served) this.stopServingAgent(agentId)
+    this.onDutyChanged()
+  }
+
   /** Claim one agent's duty because a trigger for it arrived here. A win is
    *  installed exactly like a `duty/grant`, so the same converge path runs.
    *  Refuses without asking the CP when this member must not take new work:
@@ -21385,6 +21402,7 @@ export class Daemon {
       },
       degradedScopes: () => this.cpDegradedScopes(),
       duties: () => this.dutyDigest(),
+      onDutyFence: () => this.fenceDuties(),
       configApply: this.cpConfigApply(),
       sessionRead: createSessionReader(this.store, (session) => this.sessionThreadUrl(session)),
       // §5.4: serve a CP-forwarded status probe for a child session we own. Authorization is

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3802,6 +3802,11 @@ export class Daemon {
    */
   private reconcileRun?: Promise<void>
   private reconcilePending = false
+  // A duty change moves no agent FILE, so the agent diff is empty and platform convergence
+  // would be skipped — while the serving gate it feeds (`transportAgents`) has just changed.
+  // Set by `onDutyChanged`, consumed by the next pass, so a revoke or a fence actually closes
+  // the sockets it stopped serving.
+  private dutyConnectionsDirty = false
   // Register snapshots publish agents before integrations. Carry newly-owned
   // inbox rows across coalesced passes and retry only after convergence is idle.
   private readonly pendingInboxReplayAgents = new Set<string>()
@@ -3828,6 +3833,10 @@ export class Daemon {
   }
 
   private async runReconcile(): Promise<void> {
+    // Claimed for THIS pass. A duty change landing after this read leaves the flag set, and
+    // the coalesced trailing re-run honours it.
+    const dutyDirty = this.dutyConnectionsDirty
+    this.dutyConnectionsDirty = false
     const snapshot = this.loadAgentList(true)
     const files = snapshot.agents
     const nextFileAgents = new Map(files.map((a) => [a.id, a]))
@@ -3900,7 +3909,7 @@ export class Daemon {
         this.drainingAgents.delete(id)
       }
     }
-    let connectionsDirty = toStart.length > 0 || toStop.length > 0
+    let connectionsDirty = dutyDirty || toStart.length > 0 || toStop.length > 0
     for (const change of toChange) {
       const a = change.agent
       const previous = this.agents.get(a.id)
@@ -12943,10 +12952,14 @@ export class Daemon {
     }
   }
 
-  /** Re-derive platform connections and schedules from the new duty set. */
+  /** Re-derive platform connections and schedules from the new duty set. The physical
+   *  half is not optional: `transportAgents` gates which agents get sockets, and direct
+   *  ingress has no per-message duty check, so a group this member stopped serving keeps
+   *  receiving platform traffic until its connection is actually closed. */
   private onDutyChanged(): void {
     if (!this.dutyEnforced()) return
     for (const agent of this.agents.values()) this.syncAgentSchedules(agent)
+    this.dutyConnectionsDirty = true
     void this.reconcile().catch((err) => this.log.warn(`duty: reconcile after a duty change failed: ${err}`))
   }
 

--- a/packages/daemon/test/cp/client-duty-fence.test.ts
+++ b/packages/daemon/test/cp/client-duty-fence.test.ts
@@ -1,0 +1,279 @@
+// The timing half of the duty self-fence (`T_reassign > T_fence`): when the daemon arms it,
+// what it anchors the deadline on, and — just as load-bearing — when it must NOT fire.
+import { describe, it, expect, vi } from 'vitest'
+import { buildEnvelope } from '@agentconnect.md/protocol'
+import { CpClient, type CpClientDeps } from '../../src/cp/client.js'
+import { FakeTransport } from './fake-transport.js'
+import { FakeClock } from './fake-clock.js'
+
+const DAEMON_ID = '22222222-2222-4222-8222-222222222222'
+const GROUP = '11111111-1111-4111-8111-111111111111'
+const LEASE_MS = 120_000
+// The shipped fence: 3/4 of the horizon past the last heartbeat that carried duties.
+const FENCE_MS = 90_000
+const BEAT_MS = 15_000
+
+const tick = () => new Promise((r) => setImmediate(r))
+
+/** A CP that can be taken away: `up = false` makes every dial fail, like a partition. */
+class Link {
+  readonly transports: FakeTransport[] = []
+  up = true
+  connect = async (): Promise<FakeTransport> => {
+    if (!this.up) throw new Error('control plane unreachable')
+    const t = new FakeTransport()
+    this.transports.push(t)
+    return t
+  }
+  get current(): FakeTransport {
+    return this.transports[this.transports.length - 1]!
+  }
+}
+
+async function handshake(t: FakeTransport, epoch: number, dutyLeaseMs?: number): Promise<void> {
+  const auth = t.lastSent()
+  t.pushInbound(
+    JSON.stringify(
+      buildEnvelope(
+        'auth/ok',
+        {
+          daemonId: DAEMON_ID,
+          sessionEpoch: epoch,
+          heartbeatSec: BEAT_MS / 1000,
+          ...(dutyLeaseMs !== undefined ? { dutyLeaseMs } : {}),
+          serverTime: '2026-08-14T00:00:00.000Z',
+          organizationMode: 'frame'
+        },
+        { corr: auth.id }
+      )
+    )
+  )
+  await tick()
+  const reg = t.lastSent()
+  t.pushInbound(
+    JSON.stringify(
+      buildEnvelope(
+        'register/ok',
+        {
+          routingEpoch: 1,
+          serverFeatures: [],
+          assignments: [],
+          crons: [],
+          leases: [],
+          drop: { assignments: [], crons: [] }
+        },
+        { corr: reg.id }
+      )
+    )
+  )
+  await tick()
+}
+
+interface Options {
+  /** Answer `auth/ok` without the horizon field, the way a CP older than it does. */
+  noHorizon?: boolean
+  /** Omit the duty getter (or scope the connection to one org) — then no lease can exist. */
+  duties?: boolean
+  organizationMode?: 'connection' | 'frame'
+}
+
+async function ready(opts: Options = {}) {
+  const link = new Link()
+  const clock = new FakeClock()
+  const onDutyFence = vi.fn()
+  const warn = vi.fn()
+  const deps = {
+    url: 'wss://cp.example.test/daemon/ws',
+    token: 't',
+    daemonId: DAEMON_ID,
+    agentVersion: '0.0.0',
+    host: 'h',
+    heartbeatDefaultMs: BEAT_MS,
+    maxAgents: 4,
+    capabilities: () => ({ platforms: [], runtimes: [], acp: true, features: [] }),
+    runtimeProfiles: () => [],
+    localState: () => ({ assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }),
+    loadSnapshot: () => ({ cpu: 0, mem: 0, agents: 0 }),
+    activeSessions: () => 0,
+    ...(opts.duties === false ? {} : { duties: () => ({ held: [{ groupId: GROUP, term: '7' }], headroom: 3 }) }),
+    onDutyFence,
+    configApply: {
+      applyConfigPush() {},
+      applyReconcileSnapshot() {},
+      upsertCron() {},
+      removeCron() {},
+      applyRouteAssign() {},
+      applyRouteUpdate() {}
+    },
+    clock,
+    connect: link.connect,
+    log: { trace() {}, debug() {}, info() {}, warn, error() {} },
+    jitter: () => 0
+  } as unknown as CpClientDeps
+  const client = new CpClient(deps)
+  client.start()
+  await tick()
+  await handshake(link.current, 1, opts.noHorizon ? undefined : LEASE_MS)
+  if (opts.organizationMode === 'connection') {
+    // Re-run the handshake as an org-scoped connection: the same client, no duty exchange.
+    link.current.simulateClose(1012, 'rescope')
+    clock.advance(1000)
+    await tick()
+    const t = link.current
+    const auth = t.lastSent()
+    t.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'auth/ok',
+          {
+            daemonId: DAEMON_ID,
+            sessionEpoch: 2,
+            heartbeatSec: BEAT_MS / 1000,
+            dutyLeaseMs: LEASE_MS,
+            serverTime: '2026-08-14T00:00:00.000Z',
+            organizationMode: 'connection'
+          },
+          { corr: auth.id }
+        )
+      )
+    )
+    await tick()
+    const reg = t.lastSent()
+    t.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'register/ok',
+          {
+            routingEpoch: 1,
+            serverFeatures: [],
+            assignments: [],
+            crons: [],
+            leases: [],
+            drop: { assignments: [], crons: [] }
+          },
+          { corr: reg.id }
+        )
+      )
+    )
+    await tick()
+  }
+  return { client, link, clock, onDutyFence, warn }
+}
+
+/** Advance the clock, letting each step's async work settle. */
+async function advance(clock: FakeClock, ms: number): Promise<void> {
+  clock.advance(ms)
+  await tick()
+}
+
+const beats = (t: FakeTransport) => t.sent.map((raw) => JSON.parse(raw)).filter((f) => f.type === 'heartbeat')
+
+describe('the duty self-fence deadline', () => {
+  it('a control-plane restart moves no duty: the epoch bumps and nothing is fenced', async () => {
+    // The #955 acceptance run. A restart reconnects well inside the horizon, so the fence
+    // must stay quiet — a fence here would drop live platform connections for a blip.
+    const { client, link, clock, onDutyFence } = await ready()
+    await advance(clock, BEAT_MS)
+    const before = beats(link.current).at(-1)
+    expect(before.payload.duties.held).toEqual([{ groupId: GROUP, term: '7' }])
+
+    link.current.simulateClose(1012, 'restarting')
+    expect(client.state).toBe('DEGRADED')
+    await advance(clock, 1000)
+    await handshake(link.current, 2, LEASE_MS)
+
+    expect(client.state).toBe('READY')
+    expect(client.sessionEpoch).toBe(2) // a fresh fencing token, as the restart mints
+    // The reconnect renews the leases immediately, reporting the SAME terms it held before.
+    expect(beats(link.current).at(-1).payload.duties.held).toEqual([{ groupId: GROUP, term: '7' }])
+
+    // Far past the deadline the outage had armed.
+    await advance(clock, 4 * LEASE_MS)
+    expect(onDutyFence).not.toHaveBeenCalled()
+  })
+
+  it('fires once the horizon elapses with the link down', async () => {
+    const { link, clock, onDutyFence } = await ready()
+    await advance(clock, BEAT_MS)
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+
+    await advance(clock, FENCE_MS - 1)
+    expect(onDutyFence).not.toHaveBeenCalled()
+
+    await advance(clock, 1)
+    expect(onDutyFence).toHaveBeenCalledTimes(1)
+
+    // Reconnect attempts keep failing; the fence stays fired exactly once.
+    await advance(clock, 10 * LEASE_MS)
+    expect(onDutyFence).toHaveBeenCalledTimes(1)
+  })
+
+  it('anchors the deadline on the last heartbeat, not on the disconnect', async () => {
+    const { link, clock, onDutyFence } = await ready()
+    await advance(clock, BEAT_MS) // the beat the CP renews from, at t = 15s
+    await advance(clock, BEAT_MS - 1) // …and the socket dies just before the next one is due
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+
+    // Measured from the disconnect the fence would still be 15s away.
+    await advance(clock, FENCE_MS - (BEAT_MS - 1))
+    expect(onDutyFence).toHaveBeenCalledTimes(1)
+  })
+
+  it('never arms for a daemon that renews no lease', async () => {
+    const { link, clock, onDutyFence } = await ready({ duties: false })
+    await advance(clock, BEAT_MS)
+    expect(beats(link.current).at(-1).payload).not.toHaveProperty('duties')
+
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+    await advance(clock, 10 * LEASE_MS)
+    expect(onDutyFence).not.toHaveBeenCalled()
+  })
+
+  it('never arms on an org-scoped connection, where the ledger stays dormant', async () => {
+    const { link, clock, onDutyFence } = await ready({ organizationMode: 'connection' })
+    await advance(clock, BEAT_MS)
+    expect(beats(link.current).at(-1).payload).not.toHaveProperty('duties')
+
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+    await advance(clock, 10 * LEASE_MS)
+    expect(onDutyFence).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the built-in horizon, loudly, when the CP sends none', async () => {
+    const { link, clock, onDutyFence, warn } = await ready({ noHorizon: true })
+    // An older CP omits the field; fencing on a guess beats silently not fencing at all.
+    expect(warn.mock.calls.flat().join(' ')).toContain('no duty lease horizon')
+
+    await advance(clock, BEAT_MS)
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+
+    await advance(clock, FENCE_MS - 1)
+    expect(onDutyFence).not.toHaveBeenCalled()
+    await advance(clock, 1)
+    expect(onDutyFence).toHaveBeenCalledTimes(1)
+  })
+
+  it('fences a daemon whose credential died, which can never renew either', async () => {
+    const { link, clock, onDutyFence } = await ready()
+    await advance(clock, BEAT_MS)
+    link.current.simulateClose(4401, 'AUTH_FAILED')
+
+    await advance(clock, FENCE_MS)
+    expect(onDutyFence).toHaveBeenCalledTimes(1)
+  })
+
+  it('a local shutdown does not fence — the daemon is leaving, not being replaced', async () => {
+    const { client, link, clock, onDutyFence } = await ready()
+    await advance(clock, BEAT_MS)
+
+    await client.stop()
+    link.up = false
+    await advance(clock, 10 * LEASE_MS)
+    expect(onDutyFence).not.toHaveBeenCalled()
+  })
+})

--- a/packages/daemon/test/cp/client-duty-fence.test.ts
+++ b/packages/daemon/test/cp/client-duty-fence.test.ts
@@ -88,6 +88,8 @@ async function ready(opts: Options = {}) {
   const warn = vi.fn()
   // The daemon's authoritative held set, which the digest projects and a renewal refreshes.
   const held: string[] = [...(opts.held ?? [GROUP])]
+  // Admissions in flight: intended to be held, deliberately absent from the digest until applied.
+  const pending: string[] = []
   const deps = {
     url: 'wss://cp.example.test/daemon/ws',
     token: 't',
@@ -103,7 +105,10 @@ async function ready(opts: Options = {}) {
     activeSessions: () => 0,
     ...(opts.duties === false
       ? {}
-      : { duties: () => ({ held: held.map((groupId) => ({ groupId, term: '7' })), headroom: 3 }) }),
+      : {
+          duties: () => ({ held: held.map((groupId) => ({ groupId, term: '7' })), headroom: 3 }),
+          dutyPending: () => [...pending]
+        }),
     onDutyFence,
     configApply: {
       applyConfigPush() {},
@@ -167,7 +172,7 @@ async function ready(opts: Options = {}) {
     )
     await tick()
   }
-  return { client, link, clock, onDutyFence, warn, held }
+  return { client, link, clock, onDutyFence, warn, held, pending }
 }
 
 /** A `duty/grant` EVT for one group, as the CP emits it when it claims or re-terms a lease. */
@@ -455,6 +460,50 @@ describe('the duty self-fence deadline', () => {
     // The revoked group's earlier deadline is gone with it; only B is left to fence, at its own time.
     await advance(clock, FENCE_MS)
     expect(fenced(onDutyFence)).toEqual([[GROUP_B]])
+  })
+
+  it('a confirmation arriving mid-admission keeps the pending group’s deadline', async () => {
+    // A group being admitted is absent from the digest by design — it is not servable yet. Pruning
+    // its deadline against the digest is what would leave it serving with no fence at all once the
+    // admission commits, so "what we intend to hold" includes the admissions in flight.
+    const { link, clock, onDutyFence, held, pending } = await ready({ held: [] })
+    grant(link.current, GROUP)
+    pending.push(GROUP) // admission in flight: marked by the daemon, not yet in the digest
+    await tick()
+
+    await advance(clock, BEAT_MS)
+    confirmRenewal(link.current)
+    await tick()
+
+    // The admission commits: now it is held, and no longer pending.
+    const renewedAt = clock.now()
+    held.push(GROUP)
+    pending.length = 0
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+
+    // Its deadline survived the prune and moved with the renewal, so it still fences — on schedule.
+    await advance(clock, FENCE_MS - 1)
+    expect(onDutyFence).not.toHaveBeenCalled()
+    await advance(clock, 1)
+    expect(clock.now()).toBe(renewedAt + FENCE_MS)
+    expect(fenced(onDutyFence)).toEqual([[GROUP]])
+  })
+
+  it('a confirmation still prunes a group that is neither held nor being admitted', async () => {
+    const { link, clock, onDutyFence, held } = await ready({ held: [GROUP] })
+    grant(link.current, GROUP_B) // never admitted, never held — a refused group
+    await tick()
+
+    await advance(clock, BEAT_MS)
+    confirmRenewal(link.current)
+    await tick()
+
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+    await advance(clock, FENCE_MS)
+    expect(fenced(onDutyFence)).toEqual([[GROUP]]) // B's stale deadline is gone
+    expect(held).toEqual([GROUP])
   })
 
   it('never arms for a daemon that renews no lease', async () => {

--- a/packages/daemon/test/cp/client-duty-fence.test.ts
+++ b/packages/daemon/test/cp/client-duty-fence.test.ts
@@ -168,14 +168,25 @@ async function advance(clock: FakeClock, ms: number): Promise<void> {
 
 const beats = (t: FakeTransport) => t.sent.map((raw) => JSON.parse(raw)).filter((f) => f.type === 'heartbeat')
 
+/** The CP's answer to a beat it processed. Anchoring happens HERE, not on the send. */
+function confirmRenewal(t: FakeTransport, leaseMs = LEASE_MS): void {
+  t.pushInbound(JSON.stringify(buildEnvelope('duty/renewed', { leaseMs })))
+}
+
+/** One healthy round trip: the daemon beats, the CP renews and says so. */
+async function renewedBeat(clock: FakeClock, t: FakeTransport, leaseMs = LEASE_MS): Promise<void> {
+  await advance(clock, BEAT_MS)
+  confirmRenewal(t, leaseMs)
+  await tick()
+}
+
 describe('the duty self-fence deadline', () => {
   it('a control-plane restart moves no duty: the epoch bumps and nothing is fenced', async () => {
     // The #955 acceptance run. A restart reconnects well inside the horizon, so the fence
     // must stay quiet — a fence here would drop live platform connections for a blip.
     const { client, link, clock, onDutyFence } = await ready()
-    await advance(clock, BEAT_MS)
-    const before = beats(link.current).at(-1)
-    expect(before.payload.duties.held).toEqual([{ groupId: GROUP, term: '7' }])
+    await renewedBeat(clock, link.current)
+    expect(beats(link.current).at(-1).payload.duties.held).toEqual([{ groupId: GROUP, term: '7' }])
 
     link.current.simulateClose(1012, 'restarting')
     expect(client.state).toBe('DEGRADED')
@@ -184,17 +195,21 @@ describe('the duty self-fence deadline', () => {
 
     expect(client.state).toBe('READY')
     expect(client.sessionEpoch).toBe(2) // a fresh fencing token, as the restart mints
-    // The reconnect renews the leases immediately, reporting the SAME terms it held before.
+    // The reconnect beats at once, reporting the SAME terms it held before, and the CP confirms.
     expect(beats(link.current).at(-1).payload.duties.held).toEqual([{ groupId: GROUP, term: '7' }])
+    confirmRenewal(link.current)
+    await tick()
 
-    // Far past the deadline the outage had armed.
-    await advance(clock, 4 * LEASE_MS)
+    // Keep the restarted CP running well past the deadline the outage had armed: a renewed
+    // beat every cadence, so the countdown restarts long before it can expire.
+    for (let i = 0; i < 10; i++) await renewedBeat(clock, link.current)
+    expect(clock.now()).toBeGreaterThan(FENCE_MS)
     expect(onDutyFence).not.toHaveBeenCalled()
   })
 
   it('fires once the horizon elapses with the link down', async () => {
     const { link, clock, onDutyFence } = await ready()
-    await advance(clock, BEAT_MS)
+    await renewedBeat(clock, link.current)
     link.up = false
     link.current.simulateClose(1006, 'gone')
 
@@ -209,16 +224,47 @@ describe('the duty self-fence deadline', () => {
     expect(onDutyFence).toHaveBeenCalledTimes(1)
   })
 
-  it('anchors the deadline on the last heartbeat, not on the disconnect', async () => {
+  it('fires on schedule on a HALF-OPEN socket, where every beat is sent and none arrives', async () => {
+    // The failure the anchor exists for: `send()` succeeds locally, the CP never runs
+    // `renewHeld`, and no close event ever fires. Sending is not renewing — the deadline set
+    // by the last CONFIRMED renewal must not move a millisecond for the beats that follow.
     const { link, clock, onDutyFence } = await ready()
-    await advance(clock, BEAT_MS) // the beat the CP renews from, at t = 15s
-    await advance(clock, BEAT_MS - 1) // …and the socket dies just before the next one is due
+    await renewedBeat(clock, link.current) // last confirmed renewal, at t = 15s
+    const sentByThen = beats(link.current).length
+
+    // The socket stays "open" and the daemon keeps beating into it — unanswered.
+    for (let i = 0; i < 5; i++) await advance(clock, BEAT_MS)
+    expect(beats(link.current).length).toBeGreaterThan(sentByThen) // the sends really happened
+    expect(onDutyFence).not.toHaveBeenCalled() // …and moved nothing: t = 90s, deadline 105s
+
+    await advance(clock, FENCE_MS - 5 * BEAT_MS - 1)
+    expect(onDutyFence).not.toHaveBeenCalled()
+    await advance(clock, 1)
+    expect(onDutyFence).toHaveBeenCalledTimes(1)
+  })
+
+  it('anchors on the confirmation, not on the disconnect', async () => {
+    const { link, clock, onDutyFence } = await ready()
+    await renewedBeat(clock, link.current) // renewal confirmed at t = 15s
+    await advance(clock, BEAT_MS - 1) // …and the socket dies just before the next beat is due
     link.up = false
     link.current.simulateClose(1006, 'gone')
 
-    // Measured from the disconnect the fence would still be 15s away.
+    // Measured from the disconnect the fence would still be a cadence away.
     await advance(clock, FENCE_MS - (BEAT_MS - 1))
     expect(onDutyFence).toHaveBeenCalledTimes(1)
+  })
+
+  it('never arms before a renewal this member can lose', async () => {
+    // Beats go out from the first cadence, but nothing is confirmed, so no lease was ever
+    // renewed here — there is no countdown to run and nothing for a successor to take.
+    const { link, clock, onDutyFence } = await ready()
+    await advance(clock, BEAT_MS)
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+
+    await advance(clock, 10 * LEASE_MS)
+    expect(onDutyFence).not.toHaveBeenCalled()
   })
 
   it('never arms for a daemon that renews no lease', async () => {
@@ -243,9 +289,22 @@ describe('the duty self-fence deadline', () => {
     expect(onDutyFence).not.toHaveBeenCalled()
   })
 
-  it('falls back to the built-in horizon, loudly, when the CP sends none', async () => {
+  it('adopts each renewal horizon the CP announces', async () => {
+    const { link, clock, onDutyFence } = await ready()
+    await renewedBeat(clock, link.current, 40_000) // this CP now leases for 40s
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+
+    await advance(clock, 30_000 - 1) // 3/4 of 40s
+    expect(onDutyFence).not.toHaveBeenCalled()
+    await advance(clock, 1)
+    expect(onDutyFence).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the built-in horizon and the weaker send anchor when the CP confirms nothing', async () => {
     const { link, clock, onDutyFence, warn } = await ready({ noHorizon: true })
-    // An older CP omits the field; fencing on a guess beats silently not fencing at all.
+    // A CP too old to announce a horizon is too old to confirm renewals. Anchoring on sends is
+    // strictly weaker, and saying so is the point — silently not fencing would be worse.
     expect(warn.mock.calls.flat().join(' ')).toContain('no duty lease horizon')
 
     await advance(clock, BEAT_MS)
@@ -260,7 +319,7 @@ describe('the duty self-fence deadline', () => {
 
   it('fences a daemon whose credential died, which can never renew either', async () => {
     const { link, clock, onDutyFence } = await ready()
-    await advance(clock, BEAT_MS)
+    await renewedBeat(clock, link.current)
     link.current.simulateClose(4401, 'AUTH_FAILED')
 
     await advance(clock, FENCE_MS)
@@ -269,7 +328,7 @@ describe('the duty self-fence deadline', () => {
 
   it('a local shutdown does not fence — the daemon is leaving, not being replaced', async () => {
     const { client, link, clock, onDutyFence } = await ready()
-    await advance(clock, BEAT_MS)
+    await renewedBeat(clock, link.current)
 
     await client.stop()
     link.up = false

--- a/packages/daemon/test/cp/client-duty-fence.test.ts
+++ b/packages/daemon/test/cp/client-duty-fence.test.ts
@@ -8,6 +8,7 @@ import { FakeClock } from './fake-clock.js'
 
 const DAEMON_ID = '22222222-2222-4222-8222-222222222222'
 const GROUP = '11111111-1111-4111-8111-111111111111'
+const GROUP_B = '11111111-1111-4111-8111-111111111112'
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const LEASE_MS = 120_000
 // The shipped fence: 3/4 of the horizon past the last heartbeat that carried duties.
@@ -76,6 +77,8 @@ interface Options {
   /** Omit the duty getter (or scope the connection to one org) — then no lease can exist. */
   duties?: boolean
   organizationMode?: 'connection' | 'frame'
+  /** The groups the daemon holds; the digest projects these and a renewal refreshes exactly them. */
+  held?: string[]
 }
 
 async function ready(opts: Options = {}) {
@@ -83,6 +86,8 @@ async function ready(opts: Options = {}) {
   const clock = new FakeClock()
   const onDutyFence = vi.fn()
   const warn = vi.fn()
+  // The daemon's authoritative held set, which the digest projects and a renewal refreshes.
+  const held: string[] = [...(opts.held ?? [GROUP])]
   const deps = {
     url: 'wss://cp.example.test/daemon/ws',
     token: 't',
@@ -96,11 +101,15 @@ async function ready(opts: Options = {}) {
     localState: () => ({ assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }),
     loadSnapshot: () => ({ cpu: 0, mem: 0, agents: 0 }),
     activeSessions: () => 0,
-    ...(opts.duties === false ? {} : { duties: () => ({ held: [{ groupId: GROUP, term: '7' }], headroom: 3 }) }),
+    ...(opts.duties === false
+      ? {}
+      : { duties: () => ({ held: held.map((groupId) => ({ groupId, term: '7' })), headroom: 3 }) }),
     onDutyFence,
     configApply: {
       applyConfigPush() {},
       applyReconcileSnapshot() {},
+      applyDutyGrant() {},
+      applyDutyRevoke() {},
       upsertCron() {},
       removeCron() {},
       applyRouteAssign() {},
@@ -158,8 +167,22 @@ async function ready(opts: Options = {}) {
     )
     await tick()
   }
-  return { client, link, clock, onDutyFence, warn }
+  return { client, link, clock, onDutyFence, warn, held }
 }
+
+/** A `duty/grant` EVT for one group, as the CP emits it when it claims or re-terms a lease. */
+function grant(t: FakeTransport, groupId: string): void {
+  t.pushInbound(
+    JSON.stringify(
+      buildEnvelope('duty/grant', {
+        grants: [{ groupId, orgId: 'org-1', term: '7', members: [{ kind: 'agent', refId: AGENT }] }]
+      })
+    )
+  )
+}
+
+/** The groups each fence call shed, in call order. */
+const fenced = (spy: { mock: { calls: unknown[][] } }): unknown[] => spy.mock.calls.map((call) => call[0])
 
 /** Advance the clock, letting each step's async work settle. */
 async function advance(clock: FakeClock, ms: number): Promise<void> {
@@ -309,6 +332,129 @@ describe('the duty self-fence deadline', () => {
     link.current.simulateClose(1006, 'gone')
     await advance(clock, 10 * LEASE_MS)
     expect(onDutyFence).not.toHaveBeenCalled()
+  })
+
+  it('a grant whose renewal confirmation never arrives still fences on time', async () => {
+    // The grant's own receipt arms it. Nothing else can: this is the member's FIRST lease, so no
+    // confirmation has ever been seen, and the one that would follow this grant is lost.
+    const { link, clock, onDutyFence } = await ready()
+    grant(link.current, GROUP)
+    await tick()
+
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+    await advance(clock, FENCE_MS - 1)
+    expect(onDutyFence).not.toHaveBeenCalled()
+    await advance(clock, 1)
+    expect(fenced(onDutyFence)).toEqual([[GROUP]])
+  })
+
+  it('a grant after a fence re-arms that group, rather than serving it undeadlined', async () => {
+    const { link, clock, onDutyFence } = await ready()
+    grant(link.current, GROUP)
+    await tick()
+    await advance(clock, FENCE_MS)
+    expect(fenced(onDutyFence)).toEqual([[GROUP]])
+
+    // The CP hands it back (its missing-regrant, or a fresh claim) — a new lease, a new deadline.
+    grant(link.current, GROUP)
+    await tick()
+    await advance(clock, FENCE_MS - 1)
+    expect(onDutyFence).toHaveBeenCalledTimes(1)
+    await advance(clock, 1)
+    expect(fenced(onDutyFence)).toEqual([[GROUP], [GROUP]])
+  })
+
+  it('a claim for another group does not postpone an older group’s deadline', async () => {
+    // The one global deadline used to be reset by any lease event; group A's CP expiry never moved,
+    // so a claim for B could carry A past it. Per-group deadlines make that unrepresentable.
+    const { client, link, clock, onDutyFence } = await ready()
+    grant(link.current, GROUP) // A, deadline at t = FENCE_MS
+    await tick()
+    await advance(clock, BEAT_MS * 2)
+
+    const claim = client.claimDuty(AGENT)
+    await tick()
+    const req = link.current.sent.map((raw) => JSON.parse(raw)).find((f) => f.type === 'duty/claim')
+    link.current.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'duty/claim/ok',
+          { granted: true, grant: { groupId: GROUP_B, orgId: 'org-1', term: '1', members: [] } },
+          { corr: req.id }
+        )
+      )
+    )
+    await expect(claim).resolves.toMatchObject({ granted: true })
+
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+    // A fences at its own deadline, untouched by B's arrival…
+    await advance(clock, FENCE_MS - BEAT_MS * 2)
+    expect(fenced(onDutyFence)).toEqual([[GROUP]])
+    // …and B, leased later, fences later — a partial fence, not a teardown of everything.
+    await advance(clock, BEAT_MS * 2)
+    expect(fenced(onDutyFence)).toEqual([[GROUP], [GROUP_B]])
+  })
+
+  it('fences only the expired group and re-arms at the next earliest', async () => {
+    const { link, clock, onDutyFence } = await ready({ held: [GROUP, GROUP_B] })
+    grant(link.current, GROUP) // deadline FENCE_MS
+    await tick()
+    await advance(clock, BEAT_MS)
+    grant(link.current, GROUP_B) // deadline FENCE_MS + BEAT_MS
+    await tick()
+
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+    await advance(clock, FENCE_MS - BEAT_MS)
+    expect(fenced(onDutyFence)).toEqual([[GROUP]]) // B's lease is still honoured by the CP
+
+    await advance(clock, BEAT_MS)
+    expect(fenced(onDutyFence)).toEqual([[GROUP], [GROUP_B]])
+  })
+
+  it('one renewal refreshes every held group at once', async () => {
+    const { link, clock, onDutyFence } = await ready({ held: [GROUP, GROUP_B] })
+    grant(link.current, GROUP)
+    await tick()
+    await advance(clock, BEAT_MS)
+    grant(link.current, GROUP_B)
+    await tick()
+
+    // `renewHeld` renews by holder with no id filter, so ONE confirmation restarts both countdowns.
+    await advance(clock, BEAT_MS)
+    confirmRenewal(link.current)
+    await tick()
+    const renewedAt = clock.now()
+
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+    await advance(clock, FENCE_MS - 1)
+    expect(onDutyFence).not.toHaveBeenCalled() // neither group kept its older, earlier deadline
+    await advance(clock, 1)
+    expect(clock.now()).toBe(renewedAt + FENCE_MS)
+    expect(fenced(onDutyFence)).toEqual([[GROUP, GROUP_B]]) // both, in one call, at one deadline
+  })
+
+  it('a revoked group stops holding a deadline of its own', async () => {
+    const { link, clock, onDutyFence } = await ready({ held: [GROUP, GROUP_B] })
+    grant(link.current, GROUP)
+    await tick()
+    await advance(clock, BEAT_MS)
+    grant(link.current, GROUP_B)
+    await tick()
+
+    link.current.pushInbound(
+      JSON.stringify(buildEnvelope('duty/revoke', { revocations: [{ groupId: GROUP, reason: 'superseded' }] }))
+    )
+    await tick()
+
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+    // The revoked group's earlier deadline is gone with it; only B is left to fence, at its own time.
+    await advance(clock, FENCE_MS)
+    expect(fenced(onDutyFence)).toEqual([[GROUP_B]])
   })
 
   it('never arms for a daemon that renews no lease', async () => {

--- a/packages/daemon/test/cp/client-duty-fence.test.ts
+++ b/packages/daemon/test/cp/client-duty-fence.test.ts
@@ -8,6 +8,7 @@ import { FakeClock } from './fake-clock.js'
 
 const DAEMON_ID = '22222222-2222-4222-8222-222222222222'
 const GROUP = '11111111-1111-4111-8111-111111111111'
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const LEASE_MS = 120_000
 // The shipped fence: 3/4 of the horizon past the last heartbeat that carried duties.
 const FENCE_MS = 90_000
@@ -263,6 +264,49 @@ describe('the duty self-fence deadline', () => {
     link.up = false
     link.current.simulateClose(1006, 'gone')
 
+    await advance(clock, 10 * LEASE_MS)
+    expect(onDutyFence).not.toHaveBeenCalled()
+  })
+
+  it('arms on a won rendezvous claim, which is this member’s first lease', async () => {
+    // The claim CREATES a lease (`claimAgentHome` writes `expiresAt = now + leaseMs`) and the
+    // member serves it immediately — often before any heartbeat has been confirmed, so without
+    // this the rendezvous serves a lease with no countdown running at all.
+    const { client, link, clock, onDutyFence } = await ready()
+    const claim = client.claimDuty(AGENT)
+    await tick()
+    const req = link.current.sent.map((raw) => JSON.parse(raw)).find((f) => f.type === 'duty/claim')
+    link.current.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'duty/claim/ok',
+          { granted: true, grant: { groupId: GROUP, orgId: 'org-1', term: '1', members: [] } },
+          { corr: req.id }
+        )
+      )
+    )
+    await expect(claim).resolves.toMatchObject({ granted: true })
+
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
+    await advance(clock, FENCE_MS - 1)
+    expect(onDutyFence).not.toHaveBeenCalled()
+    await advance(clock, 1)
+    expect(onDutyFence).toHaveBeenCalledTimes(1)
+  })
+
+  it('a LOST rendezvous claim arms nothing — no lease was created here', async () => {
+    const { client, link, clock, onDutyFence } = await ready()
+    const claim = client.claimDuty(AGENT)
+    await tick()
+    const req = link.current.sent.map((raw) => JSON.parse(raw)).find((f) => f.type === 'duty/claim')
+    link.current.pushInbound(
+      JSON.stringify(buildEnvelope('duty/claim/ok', { granted: false, holder: DAEMON_ID }, { corr: req.id }))
+    )
+    await expect(claim).resolves.toMatchObject({ granted: false })
+
+    link.up = false
+    link.current.simulateClose(1006, 'gone')
     await advance(clock, 10 * LEASE_MS)
     expect(onDutyFence).not.toHaveBeenCalled()
   })

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -10,8 +10,11 @@ import { Daemon } from '../src/daemon.js'
 import type { DutyRegistry } from '../src/cp/duty-registry.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const AGENT_B = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
 const GROUP = '11111111-1111-4111-8111-111111111111'
+const GROUP_B = '11111111-1111-4111-8111-111111111112'
 const INTEGRATION = '22222222-2222-4222-8222-222222222222'
+const INTEGRATION_B = '22222222-2222-4222-8222-222222222223'
 const CRON = '33333333-3333-4333-8333-333333333333'
 const ORG = 'org-1'
 
@@ -29,35 +32,40 @@ function scaffold(dutyEnforcement: boolean): string {
   return root
 }
 
-const grant = (): DutyGrantEntry => ({
-  groupId: GROUP,
+const grant = (groupId = GROUP, agentId = AGENT): DutyGrantEntry => ({
+  groupId,
   orgId: ORG,
   term: '1',
-  members: [{ kind: 'agent', refId: AGENT }]
+  members: [{ kind: 'agent', refId: agentId }]
 })
 
-const bundle = () => ({
-  agentId: AGENT,
+const bundle = (
+  agentId = AGENT,
+  name = 'scout',
+  integrationId = INTEGRATION,
+  creds = { botToken: 'xoxb-test', appToken: 'xapp-test' }
+) => ({
+  agentId,
   spec: {
     orgId: ORG,
-    name: 'scout',
+    name,
     runtime: 'claude',
     workspace: { mode: 'scratch' as const, isolation: 'shared' as const }
   },
   integrations: [
     {
-      integrationId: INTEGRATION,
-      agentId: AGENT,
+      integrationId,
+      agentId,
       orgId: ORG,
       platform: 'slack',
       core: { mode: 'direct' as const, bindRules: [], mutedChannels: [], gated: false },
-      config: { botToken: 'xoxb-test', appToken: 'xapp-test' }
+      config: { ...creds }
     }
   ],
   crons: [
     {
-      cronId: CRON,
-      agentId: AGENT,
+      cronId: agentId === AGENT ? CRON : `${CRON.slice(0, -1)}4`,
+      agentId,
       orgId: ORG,
       schedule: '0 9 * * *',
       timezone: 'UTC',
@@ -85,21 +93,21 @@ async function boot(dutyEnforcement = true) {
 
 const duties = (d: Daemon) => (d as any).duties as DutyRegistry
 const served = (d: Daemon): string[] => (d as any).transportAgents().map((a: { id: string }) => a.id)
-const fence = (d: Daemon) => (d as any).fenceDuties()
+/** Fence the given groups, as the client's per-group deadline does when one elapses. */
+const fence = (d: Daemon, groupIds: string[] = [GROUP]) => (d as any).fenceDuties(groupIds)
 
 /** Put a live Slack socket in the pool under the granted agent's own credentials, exactly as a
  *  successful `reconcileSlackConnections` would. Its key is what consolidation asks for while the
  *  duty is held — and what it must stop asking for once the fence closes the serving gate. */
-function liveSlackSocket(d: Daemon) {
-  const conn = {
-    appToken: 'xapp-test',
-    botToken: 'xoxb-test',
-    botUserId: 'U-bot',
-    stop: vi.fn(async () => {})
-  }
+function liveSlackSocket(
+  d: Daemon,
+  integrationId = INTEGRATION,
+  creds = { botToken: 'xoxb-test', appToken: 'xapp-test' }
+) {
+  const conn = { ...creds, botUserId: `U-${integrationId.slice(-1)}`, stop: vi.fn(async () => {}) }
   ;(d as any).slackPool.add(conn)
-  ;(d as any).connByIntegration.set(INTEGRATION, conn)
-  ;(d as any).botUserIds[INTEGRATION] = conn.botUserId
+  ;(d as any).connByIntegration.set(integrationId, conn)
+  ;(d as any).botUserIds[integrationId] = conn.botUserId
   return conn
 }
 
@@ -192,6 +200,54 @@ describe('the duty self-fence', () => {
     await vi.waitFor(() => expect(conn.stop).toHaveBeenCalled(), { timeout: 10_000 })
     expect(failures).toBeGreaterThan(1) // the first pass really did throw
     expect(pooled(daemon)).not.toContain(conn)
+    await daemon.stop()
+  })
+
+  it('fences one group and leaves the other serving, then fences that one at its own deadline', async () => {
+    // The CP expires each lease on its own schedule, so a member sheds exactly what it can no
+    // longer prove it holds. Tearing down the rest would drop live traffic the ledger still ours.
+    const { daemon } = await boot()
+    ;(daemon as any).cpClient.fetchDutyAgent = vi.fn(async () => ({
+      bundle: bundle(AGENT_B, 'ranger', INTEGRATION_B, { botToken: 'xoxb-b', appToken: 'xapp-b' })
+    }))
+    await (daemon as any).admitDutyGrants([grant(GROUP_B, AGENT_B)])
+    expect(served(daemon).sort()).toEqual([AGENT, AGENT_B].sort())
+    const socketA = liveSlackSocket(daemon)
+    const socketB = liveSlackSocket(daemon, INTEGRATION_B, { botToken: 'xoxb-b', appToken: 'xapp-b' })
+
+    fence(daemon, [GROUP])
+
+    // A is shed…
+    expect(duties(daemon).get(GROUP)).toBeUndefined()
+    expect(served(daemon)).not.toContain(AGENT)
+    await vi.waitFor(() => expect(socketA.stop).toHaveBeenCalled())
+    // …and B keeps serving, socket and schedules intact.
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP_B, term: '1' }])
+    expect(served(daemon)).toContain(AGENT_B)
+    expect((daemon as any).scheduler.count(AGENT_B)).toBe(1)
+    expect(socketB.stop).not.toHaveBeenCalled()
+    expect(pooled(daemon)).toContain(socketB)
+
+    fence(daemon, [GROUP_B])
+
+    expect(duties(daemon).digest()).toEqual([])
+    expect(served(daemon)).not.toContain(AGENT_B)
+    await vi.waitFor(() => expect(socketB.stop).toHaveBeenCalled())
+    await daemon.stop()
+  })
+
+  it('fencing a group leaves an agent that another held group also covers in service', async () => {
+    // `applyRevoke` reports an agent as lost only when it is in NO held group any more, and the
+    // teardown follows that, not the group membership — so a shared agent keeps serving.
+    const { daemon } = await boot()
+    await (daemon as any).admitDutyGrants([grant(GROUP_B, AGENT)])
+    expect(duties(daemon).digest()).toHaveLength(2)
+
+    fence(daemon, [GROUP])
+
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP_B, term: '1' }])
+    expect(served(daemon)).toContain(AGENT) // still covered by the group that did not expire
+    expect((daemon as any).scheduler.count(AGENT)).toBe(1)
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -1,0 +1,182 @@
+// The daemon half of `T_reassign > T_fence`: a member must stop serving its duties before
+// the CP can hand them to a successor. These pin what the fence tears down, what it must
+// leave alone, and that it does nothing at all while enforcement is off.
+import { describe, it, expect, vi } from 'vitest'
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { DutyGrantEntry } from '@agentconnect.md/protocol'
+import { Daemon } from '../src/daemon.js'
+import type { DutyRegistry } from '../src/cp/duty-registry.js'
+
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const GROUP = '11111111-1111-4111-8111-111111111111'
+const INTEGRATION = '22222222-2222-4222-8222-222222222222'
+const CRON = '33333333-3333-4333-8333-333333333333'
+const ORG = 'org-1'
+
+function scaffold(dutyEnforcement: boolean): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-duty-fence-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      features: { dutyEnforcement },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  return root
+}
+
+const grant = (): DutyGrantEntry => ({
+  groupId: GROUP,
+  orgId: ORG,
+  term: '1',
+  members: [{ kind: 'agent', refId: AGENT }]
+})
+
+const bundle = () => ({
+  agentId: AGENT,
+  spec: {
+    orgId: ORG,
+    name: 'scout',
+    runtime: 'claude',
+    workspace: { mode: 'scratch' as const, isolation: 'shared' as const }
+  },
+  integrations: [
+    {
+      integrationId: INTEGRATION,
+      agentId: AGENT,
+      orgId: ORG,
+      platform: 'slack',
+      core: { mode: 'direct' as const, bindRules: [], mutedChannels: [], gated: false },
+      config: { botToken: 'xoxb-test', appToken: 'xapp-test' }
+    }
+  ],
+  crons: [
+    {
+      cronId: CRON,
+      agentId: AGENT,
+      orgId: ORG,
+      schedule: '0 9 * * *',
+      timezone: 'UTC',
+      trigger: 'standup',
+      enabled: true
+    }
+  ]
+})
+
+/** A daemon holding one granted duty, with a stub CP client — only the duty surface runs. */
+async function boot(dutyEnforcement = true) {
+  const root = scaffold(dutyEnforcement)
+  const daemon = new Daemon({ root })
+  await daemon.start()
+  const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
+  ;(daemon as any).cpClient = {
+    organizationScope: () => 'frame',
+    stop: async () => {},
+    releaseDuties: vi.fn(async () => {}),
+    fetchDutyAgent
+  }
+  await (daemon as any).admitDutyGrants([grant()])
+  return { daemon, root, fetchDutyAgent }
+}
+
+const duties = (d: Daemon) => (d as any).duties as DutyRegistry
+const served = (d: Daemon): string[] => (d as any).transportAgents().map((a: { id: string }) => a.id)
+const fence = (d: Daemon) => (d as any).fenceDuties()
+
+describe('the duty self-fence', () => {
+  it('releases every held group and stops serving its agents', async () => {
+    const { daemon } = await boot()
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '1' }])
+    expect(served(daemon)).toContain(AGENT)
+    expect((daemon as any).scheduler.count(AGENT)).toBe(1)
+    // A live runtime for the fenced agent must go too — the successor is about to start one.
+    const stop = vi.fn(async () => {})
+    ;(daemon as any).hosts.set(AGENT, { stop })
+
+    fence(daemon)
+    await vi.waitFor(() => expect(stop).toHaveBeenCalled())
+
+    // Nothing held ⇒ the next digest reports nothing, which is what makes the CP's
+    // missing-regrant path the recovery path.
+    expect(duties(daemon).digest()).toEqual([])
+    expect(duties(daemon).agents().size).toBe(0)
+    // The serving gate every platform consolidator derives from is closed.
+    expect(served(daemon)).not.toContain(AGENT)
+    // And the agent's schedules are disarmed — a cron is an ingress edge, so it fires
+    // only at the holder.
+    expect((daemon as any).scheduler.count(AGENT)).toBe(0)
+    await daemon.stop()
+  })
+
+  it('is a revoke, not a removal — workspace, agent registry, and sessions survive', async () => {
+    const { daemon, root } = await boot()
+    const store = (daemon as any).store
+    store.upsertSession({
+      key: `slack:C1:T1:${AGENT}`,
+      agentId: AGENT,
+      platform: 'slack',
+      channel: 'C1',
+      thread: 'T1',
+      acpSessionId: 'acp-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    expect(existsSync(join(root, 'agents', 'scout'))).toBe(true)
+
+    fence(daemon)
+
+    expect((daemon as any).cpAgents.has(AGENT)).toBe(true)
+    expect((daemon as any).agentRemovalPending(AGENT)).toBe(false)
+    expect(existsSync(join(root, 'agents', 'scout'))).toBe(true)
+    // No session purge rides a fence: the duty moved, the history did not.
+    expect(store.listSessions(AGENT)).toHaveLength(1)
+    expect(store.getSession(`slack:C1:T1:${AGENT}`)).toBeDefined()
+    await daemon.stop()
+  })
+
+  it('does nothing while enforcement is off — duties gate no service, so there is nothing to fence', async () => {
+    const { daemon } = await boot(false)
+    expect(served(daemon)).toContain(AGENT)
+
+    fence(daemon)
+
+    // Still held, still served: tearing anything down here would drop live traffic.
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '1' }])
+    expect(served(daemon)).toContain(AGENT)
+    await daemon.stop()
+  })
+
+  it('a re-grant after a fence restores service without re-fetching the surviving agent', async () => {
+    const { daemon, fetchDutyAgent } = await boot()
+    expect(fetchDutyAgent).toHaveBeenCalledTimes(1)
+
+    fence(daemon)
+    expect(served(daemon)).not.toContain(AGENT)
+
+    // What a reconnect looks like: the CP still leases the group to this member, sees a
+    // digest that omits it, and reissues the grant.
+    await (daemon as any).admitDutyGrants([grant()])
+
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '1' }])
+    expect(served(daemon)).toContain(AGENT)
+    // The registry survived the fence, so the regrant installs nothing a second time.
+    expect(fetchDutyAgent).toHaveBeenCalledTimes(1)
+    await daemon.stop()
+  })
+
+  it('holding nothing makes the fence a no-op', async () => {
+    const { daemon } = await boot()
+    fence(daemon)
+    const warn = vi.spyOn((daemon as any).log, 'warn')
+
+    fence(daemon)
+
+    expect(warn).not.toHaveBeenCalled()
+    await daemon.stop()
+  })
+})

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -173,6 +173,28 @@ describe('the duty self-fence', () => {
     await daemon.stop()
   })
 
+  it('closes it on a retry when the reconcile pass carrying the fence throws', async () => {
+    // A reconcile has a dozen ways to throw before it reaches the platform layer (workspace
+    // authority, host teardown, a platform close). If the request were consumed by that pass, the
+    // fenced agent would keep its socket — and its direct ingress — indefinitely.
+    const { daemon } = await boot()
+    const conn = liveSlackSocket(daemon)
+    const realLoad = (daemon as any).loadAgentList.bind(daemon)
+    let failures = 0
+    ;(daemon as any).loadAgentList = (...args: unknown[]) => {
+      if (failures++ < 1) throw new Error('reconcile blew up before the platform layer')
+      return realLoad(...args)
+    }
+
+    fence(daemon)
+
+    // The pass that carried the fence threw; the retry converges it anyway.
+    await vi.waitFor(() => expect(conn.stop).toHaveBeenCalled(), { timeout: 10_000 })
+    expect(failures).toBeGreaterThan(1) // the first pass really did throw
+    expect(pooled(daemon)).not.toContain(conn)
+    await daemon.stop()
+  })
+
   it('does nothing while enforcement is off — duties gate no service, so there is nothing to fence', async () => {
     const { daemon } = await boot(false)
     expect(served(daemon)).toContain(AGENT)

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -91,7 +91,32 @@ async function boot(dutyEnforcement = true) {
   return { daemon, root, fetchDutyAgent }
 }
 
+/** A daemon with an admission held open at the `duty/fetch` round trip, so a withdrawal can land
+ *  inside the window between grant receipt and `applyGrant` — the gap this guard exists for. */
+async function bootMidAdmission() {
+  const daemon = new Daemon({ root: scaffold(true) })
+  await daemon.start()
+  let release!: () => void
+  const fetched = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const fetchDutyAgent = vi.fn(async () => {
+    await fetched
+    return { bundle: bundle() }
+  })
+  ;(daemon as any).cpClient = {
+    organizationScope: () => 'frame',
+    stop: async () => {},
+    releaseDuties: vi.fn(async () => {}),
+    fetchDutyAgent
+  }
+  const admitted = (daemon as any).admitDutyGrants([grant()]) as Promise<Set<string>>
+  await vi.waitFor(() => expect(fetchDutyAgent).toHaveBeenCalled())
+  return { daemon, admitted, release }
+}
+
 const duties = (d: Daemon) => (d as any).duties as DutyRegistry
+const pending = (d: Daemon): string[] => (d as any).pendingDutyAdmissions()
 const served = (d: Daemon): string[] => (d as any).transportAgents().map((a: { id: string }) => a.id)
 /** Fence the given groups, as the client's per-group deadline does when one elapses. */
 const fence = (d: Daemon, groupIds: string[] = [GROUP]) => (d as any).fenceDuties(groupIds)
@@ -248,6 +273,60 @@ describe('the duty self-fence', () => {
     expect(duties(daemon).digest()).toEqual([{ groupId: GROUP_B, term: '1' }])
     expect(served(daemon)).toContain(AGENT) // still covered by the group that did not expire
     expect((daemon as any).scheduler.count(AGENT)).toBe(1)
+    await daemon.stop()
+  })
+
+  it('a fence landing mid-admission stops that admission from ever starting service', async () => {
+    // Deadline tracking is synchronous, admission deliberately is not. Between grant receipt and
+    // `applyGrant` the group is not held, so there is nothing for the fence to shed — and without
+    // the withdrawal guard it would start serving the moment the admission completed.
+    const { daemon, admitted, release } = await bootMidAdmission()
+    expect(pending(daemon)).toEqual([GROUP])
+    expect(duties(daemon).digest()).toEqual([]) // not held yet: the gap
+
+    fence(daemon, [GROUP])
+    release()
+
+    expect([...(await admitted)]).toEqual([GROUP]) // refused
+    expect(duties(daemon).digest()).toEqual([])
+    expect(served(daemon)).not.toContain(AGENT)
+    expect(pending(daemon)).toEqual([]) // and nothing left marked either
+    await daemon.stop()
+  })
+
+  it('a revoke landing mid-admission refuses it the same way', async () => {
+    const { daemon, admitted, release } = await bootMidAdmission()
+
+    ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
+    release()
+
+    expect([...(await admitted)]).toEqual([GROUP])
+    expect(duties(daemon).digest()).toEqual([])
+    expect(served(daemon)).not.toContain(AGENT)
+    await daemon.stop()
+  })
+
+  it('a drain release mid-admission refuses it, so nothing installs itself back after drain/done', async () => {
+    const { daemon, admitted, release } = await bootMidAdmission()
+
+    await (daemon as any).releaseAllDuties()
+    release()
+
+    expect([...(await admitted)]).toEqual([GROUP])
+    expect(duties(daemon).digest()).toEqual([])
+    expect(served(daemon)).not.toContain(AGENT)
+    await daemon.stop()
+  })
+
+  it('an admission no withdrawal touched still applies — the guard refuses nothing on its own', async () => {
+    const { daemon, admitted, release } = await bootMidAdmission()
+
+    release()
+
+    expect([...(await admitted)]).toEqual([])
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '1' }])
+    expect(served(daemon)).toContain(AGENT)
+    expect(pending(daemon)).toEqual([])
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -87,6 +87,24 @@ const duties = (d: Daemon) => (d as any).duties as DutyRegistry
 const served = (d: Daemon): string[] => (d as any).transportAgents().map((a: { id: string }) => a.id)
 const fence = (d: Daemon) => (d as any).fenceDuties()
 
+/** Put a live Slack socket in the pool under the granted agent's own credentials, exactly as a
+ *  successful `reconcileSlackConnections` would. Its key is what consolidation asks for while the
+ *  duty is held — and what it must stop asking for once the fence closes the serving gate. */
+function liveSlackSocket(d: Daemon) {
+  const conn = {
+    appToken: 'xapp-test',
+    botToken: 'xoxb-test',
+    botUserId: 'U-bot',
+    stop: vi.fn(async () => {})
+  }
+  ;(d as any).slackPool.add(conn)
+  ;(d as any).connByIntegration.set(INTEGRATION, conn)
+  ;(d as any).botUserIds[INTEGRATION] = conn.botUserId
+  return conn
+}
+
+const pooled = (d: Daemon): unknown[] => (d as any).slackPool.all()
+
 describe('the duty self-fence', () => {
   it('releases every held group and stops serving its agents', async () => {
     const { daemon } = await boot()
@@ -136,6 +154,22 @@ describe('the duty self-fence', () => {
     // No session purge rides a fence: the duty moved, the history did not.
     expect(store.listSessions(AGENT)).toHaveLength(1)
     expect(store.getSession(`slack:C1:T1:${AGENT}`)).toBeDefined()
+    await daemon.stop()
+  })
+
+  it('closes the platform connection the fenced agents were served over', async () => {
+    // The physical half. `transportAgents` is the only ingress gate for a daemon-owned socket —
+    // direct platform traffic is never re-checked per message — so a fence that empties a set but
+    // leaves the socket up keeps delivering work a successor is already serving.
+    const { daemon } = await boot()
+    const conn = liveSlackSocket(daemon)
+    expect(pooled(daemon)).toContain(conn)
+
+    fence(daemon)
+
+    await vi.waitFor(() => expect(conn.stop).toHaveBeenCalled())
+    expect(pooled(daemon)).not.toContain(conn)
+    expect((daemon as any).connByIntegration.has(INTEGRATION)).toBe(false)
     await daemon.stop()
   })
 

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -19,7 +19,16 @@ import {
   AgentPermissionDecision
 } from './frames/agent.js'
 import { CronUpsert, CronRemove, CronReport, CronRunNow } from './frames/cron.js'
-import { DutyGrant, DutyRevoke, DutyRelease, DutyClaim, DutyClaimOk, DutyFetch, DutyFetchOk } from './frames/duty.js'
+import {
+  DutyGrant,
+  DutyRenewed,
+  DutyRevoke,
+  DutyRelease,
+  DutyClaim,
+  DutyClaimOk,
+  DutyFetch,
+  DutyFetchOk
+} from './frames/duty.js'
 import {
   GithubReviewAuthorize,
   GithubReviewAuthorized,
@@ -197,6 +206,7 @@ export const FRAME_SCHEMAS = {
   // ── telemetry ──
   heartbeat: Heartbeat,
   'duty/grant': DutyGrant,
+  'duty/renewed': DutyRenewed,
   'duty/revoke': DutyRevoke,
   'duty/release': DutyRelease,
   'duty/claim': DutyClaim,
@@ -456,6 +466,7 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('collaboration/routes', FRAME_SCHEMAS['collaboration/routes']),
   frame('heartbeat', FRAME_SCHEMAS['heartbeat']),
   frame('duty/grant', FRAME_SCHEMAS['duty/grant']),
+  frame('duty/renewed', FRAME_SCHEMAS['duty/renewed']),
   frame('duty/revoke', FRAME_SCHEMAS['duty/revoke']),
   frame('duty/release', FRAME_SCHEMAS['duty/release']),
   frame('duty/claim', FRAME_SCHEMAS['duty/claim']),

--- a/packages/protocol/src/frames/auth.ts
+++ b/packages/protocol/src/frames/auth.ts
@@ -44,6 +44,10 @@ export const AuthOk = z.object({
   daemonId: z.string().uuid(),
   sessionEpoch: z.number().int(), // monotonic; bumped each successful (re)auth — fencing token
   heartbeatSec: z.number().int(), // cadence the daemon must emit heartbeat at
+  // How long the CP keeps a duty lease alive past the last heartbeat it renewed from
+  // (T_reassign). The member self-fences strictly earlier, so it must be told the CP's
+  // own value rather than duplicate it. Optional: an older CP omits it.
+  dutyLeaseMs: z.number().int().positive().optional(),
   serverTime: z.string().datetime(),
   // Single-org daemons inherit tenant context from auth; install-wide cloud daemons require
   // every org-scoped post-auth frame to carry `Envelope.orgId`.

--- a/packages/protocol/src/frames/duty.test.ts
+++ b/packages/protocol/src/frames/duty.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   HeartbeatDuties,
   DutyGrant,
+  DutyRenewed,
   DutyRevoke,
   DutyRelease,
   DutyClaim,
@@ -61,6 +62,17 @@ describe('duty frames', () => {
     expect(DutyRevoke.safeParse({ revocations: [{ groupId: GROUP, reason: 'superseded' }] }).success).toBe(true)
     expect(DutyRevoke.safeParse({ revocations: [{ groupId: GROUP, reason: 'evicted' }] }).success).toBe(false)
     expect(DutyRevoke.safeParse({ revocations: [] }).success).toBe(false)
+  })
+
+  it('duty/renewed carries a RELATIVE horizon and round-trips through the codec', () => {
+    const decoded = decodeEnvelope(encode(buildEnvelope('duty/renewed', { leaseMs: 120_000 })))
+    if (!decoded.ok) throw new Error(`decode failed: ${decoded.msg}`)
+    expect(decoded.frame.payload).toEqual({ leaseMs: 120_000 })
+    // A duration, so the member measures from receipt on its own clock — never a shared wall clock,
+    // and never zero or negative, which would make a fence deadline meaningless.
+    expect(DutyRenewed.safeParse({ leaseMs: 0 }).success).toBe(false)
+    expect(DutyRenewed.safeParse({ leaseMs: -1 }).success).toBe(false)
+    expect(DutyRenewed.safeParse({ renewedAt: '2026-08-14T00:00:00.000Z' }).success).toBe(false)
   })
 
   it('duty/release requires at least one group', () => {

--- a/packages/protocol/src/frames/duty.ts
+++ b/packages/protocol/src/frames/duty.ts
@@ -50,6 +50,21 @@ export const DutyGrant = z.object({
 })
 export type DutyGrant = z.infer<typeof DutyGrant>
 
+/**
+ * C→D EVT: the renewal the CP just performed for this member, emitted on every
+ * duty-carrying heartbeat it actually processed. `leaseMs` is RELATIVE — "the
+ * leases I hold for you live this much longer, measured from when I renewed
+ * them" — so the daemon anchors its self-fence on RECEIPT and the two sides
+ * never compare wall clocks. Receipt is strictly after the CP's renew, which is
+ * what makes the daemon's deadline conservative and `T_reassign > T_fence`
+ * sound. A beat the CP dropped produces no confirmation, so a member's fence
+ * countdown keeps running — sending a beat is not renewing a lease.
+ */
+export const DutyRenewed = z.object({
+  leaseMs: z.number().int().positive()
+})
+export type DutyRenewed = z.infer<typeof DutyRenewed>
+
 /** Why a held group is being taken away: `superseded` = another member holds it
  *  now (term reassigned), `gone` = the group no longer exists (edges removed). */
 export const DutyRevokeReason = z.enum(['superseded', 'gone'])


### PR DESCRIPTION
## The invariant

The duty ledger's no-split rule is `T_reassign > T_fence`: a member must stop serving its duties **before** the CP can hand them to a successor. Only the CP half existed. A lease dies at `lastRenew + leaseMs` (`DUTY_LEASE_DEFAULTS.leaseMs`, 120s) and `claimVacant` may then reassign it, but on losing the link `CpClient.onClose` only stopped heartbeats and entered `DEGRADED` while `DutyRegistry` kept every grant. A partitioned ex-holder went on serving the exact agents a successor had already claimed.

This adds the daemon half.

## The shape: one deadline per held group

Leases are per-group and the CP expires each on its own schedule, so the fence is per-group too. `CpClient` keeps `dutyDeadlines: Map<groupId, {anchoredAt, deadline}>`, the timer targets the **minimum**, and when it fires only the groups whose own deadline passed are shed — the rest keep serving, and the timer re-arms at the next earliest. A single global deadline would let a fresh grant or a won claim postpone an older group past its own unchanged expiry, and would leave a group granted without a following confirmation with no deadline at all; both are unrepresentable in this shape rather than patched out of it.

What sets a deadline:

| Event | Scope | Why |
|---|---|---|
| `duty/grant` receipt | just those groups | the grant's own receipt arms it, before the async admission — a lost confirmation, a first grant, or a group granted back after a fence are all covered |
| won `duty/claim/ok` | just the claimed group | the claim renewed nothing else |
| `duty/renewed` | every held group | `renewHeld` renews by holder with no id filter, so one confirmation genuinely refreshes them all; this is also where the map is pruned against the daemon's digest, so it collapses back to one value after each confirmation |
| `duty/revoke` | drops those groups | not ours to fence, and must not hold the timer earlier than a group still held |

`Daemon.fenceDuties(groupIds)` sheds a subset through `DutyRegistry.applyRevoke` — literally the local `duty/revoke` path, so the teardown is identical and #948 holds. Using its `agentsLost` also means an agent covered by two held groups keeps serving when only one is fenced.

## The withdrawal guard (also closes #975's first finding)

Deadline tracking and every withdrawal are synchronous; grant admission is deliberately async (`duty/fetch` + install *before* the serving gate opens). Between grant receipt and `duties.applyGrant` a group therefore sits in a gap — it has a deadline but is not in the digest, so nothing can withdraw it because nothing holds it yet — and it starts serving when the admission commits.

That gap is not fence-specific: a `duty/revoke` or a drain release landing in the same window has the same outcome, which is finding 1 of #975. One guard covers all three:

- `dutyAdmissions: Map<groupId, admissionSeq>` marks the groups an admission owns, set synchronously before the install and cleared in its `finally`.
- Every withdrawal — `fenceDuties`, `applyDutyRevoke`, `releaseAllDuties` — calls `withdrawDutyGroups` **before** its own held-set filter, because a pending group is not held and would otherwise be filtered out of the very withdrawal meant to stop it.
- `admitDutyGrants` re-checks the mark immediately before `applyGrant`, with no await in between, and refuses any group whose mark is gone or belongs to a newer admission — one more term in #972's existing `servable` filter.
- `CpClientDeps.dutyPending` exposes the marks so a renewal's prune keeps *digest ∪ pending*; pruning a pending group's deadline is exactly what left an admitted group unfenced.
- `releaseDuties` forgets released groups' deadlines, so a drain leaves no stale deadline pinning the timer.

A refused admission leaves nothing held, nothing serving, and no deadline, and the retry is unchanged: the CP still leases the group, does not see it in our digest, and reissues through missing-regrant.

## The anchor: confirmed renewal, never a send

The member's deadline may only advance on **evidence the CP renewed the lease**. Sending a heartbeat is not renewing one — on a half-open socket `send()` succeeds locally, the frame never arrives, and `renewHeld` never runs; the CP's per-daemon lane likewise drops a beat that overlaps a running exchange. Anchoring on the send would push the deadline forward for beats the CP never processed, and on a half-open socket the two anchors diverge without bound.

So the CP answers every duty-carrying beat it actually processed with a new `duty/renewed { leaseMs }` EVT, emitted immediately after `renewHeld` — a sibling of the `duty/grant` / `duty/revoke` the exchange already replies with conditionally. The daemon anchors on **receipt**:

- **Relative, never a timestamp.** "Your leases live this much longer, from when I renewed them." Receipt is strictly after the CP's renew, so the daemon's deadline can only be conservative; and both ends of its subtraction are the daemon's own clock, so cross-host skew cannot enter the calculation at all.
- **A dropped or undelivered beat produces no confirmation**, and the countdown keeps running — which is the whole point.
- **The horizon is told to the member on every renewal**, so it can never be stale, and the CP's `DUTY_LEASE_DEFAULTS.leaseMs` stays the single source. `auth/ok.dutyLeaseMs` remains as the first-window value and as the capability signal (see compatibility).

That retires the fraction as a *guess about the peer*. `DUTY_FENCE_HORIZON_FRACTION = 0.75` (in `packages/daemon/src/cp/client.ts`, where the inequality is documented) is now pure slop: the confirmation's one-way delivery, the daemon's scheduling delay, and the teardown itself. Breaking the invariant would take a confirmation delivered more than a quarter of the horizon late — 30s at the shipped 120s, on a link that by then delivers nothing at all.

The confirmation is emitted **last** in the exchange, after that exchange's grants and revocations. The fence is global while renewal is per-group, so a delivered *prefix* must never extend the countdown without also carrying what invalidated the member's holdings: `renewHeld` and `listHeldBy` use the identical `holder =` predicate back to back, so a digest entry is renewed iff it comes back in `held` and everything else is answered by a revocation (or a grant that re-took it) in the same exchange. One socket delivers in order, so "the confirmation arrived" implies "everything that supersedes what I hold arrived first"; a truncated exchange, or any throw before the last line, just leaves the fence running.

A won rendezvous claim (`duty/claim/ok { granted: true }`) anchors too: it CREATES this member's lease (`claimAgentHome` writes `expiresAt = now + leaseMs`) and it serves that agent at once, often before any heartbeat has been confirmed. Receipt-anchored and conservative for the same reason. The reply carries no horizon of its own — `claimAgentHome` leases for the same `DutyLeaseConfig.leaseMs` the exchange uses and `auth/ok` announced, in the same process on the same connection — and it arms through the same `armDutyFence`, so the old-CP fallback is inherited rather than special-cased. A lost claim anchors nothing.

Because a half-open socket produces no close event, deadlines run **while the link is up**, refreshed by each renewal, rather than being armed on disconnect. A healthy member re-arms every cadence, long before the deadline it set the time before; a member that stops hearing renewals — for any reason, close event or not — fences on schedule. The reconnect cancel is likewise a *confirmed* renewal: a reconnect beats immediately instead of waiting a cadence, and the confirmation that elicits is what lifts the fence.

## The teardown: physical, not just logical

Verified in the code, as asked. `runReconcile` runs the five platform consolidators only when `connectionsDirty`, and that flag was derived purely from the agent-file diff (`toStart` / `toStop` / `change.integrations`). A duty change moves no agent file, so the diff is empty — **a fence, and `duty/revoke` before it, cleared the registry and closed no socket.** Direct platform ingress has no per-message duty check (`transportAgents` IS the gate; the only other one, in `handleRelayMsg`, covers relay traffic only), so a partitioned ex-holder kept receiving and processing platform traffic for agents a successor already served.

`onDutyChanged` now records a convergence request and the next reconcile pass converges the connections — fixing the fence and the pre-existing revoke path together, through the one seam both already used.

The request is a requested/converged **counter pair**, not a flag: a pass CLAIMS the requested value and publishes it only after the platform layer has actually converged. A pass that throws — and it can, at a dozen places before it reaches that layer — leaves the request outstanding instead of dropping it, a duty change landing mid-pass stays outstanding (the claimed value is published, not the current one), and `convergeDutyConnections` retries with a doubling backoff to a 30s poll rather than giving up. Any other reconcile trigger satisfies the same request and ends the loop; the retry timer is cleared on shutdown. A fence whose convergence failed must never quietly go on serving.

One more consequence of the new frame: `duty/renewed` had to be added to the CP's install-wide frame allowlist in `ws/connection.ts`. Without it `organizationFor` raised `SCOPE_DENIED` on a pooled connection and aborted the entire exchange — the existing handler tests caught it.

## Why the fence is enforcement-gated

`transportAgents` computes `serve = !dutyEnforced() || duties.holdsAgent(id)`. With `features.dutyEnforcement` off — the production default — duties gate no service at all, so a fence that tore down platform connections would be dropping live traffic today for no reason whatsoever. With enforcement off there is nothing to fence, and `fenceDuties()` returns before touching anything. There is a test for exactly that.

## Teardown semantics and recovery

Teardown is a local `duty/revoke`, never a removal (#948): held groups are cleared, `stopServingAgent` stops in-flight turns, the cron/dream schedules, and the running host, and the reconcile pass closes the platform connections — while the workspace, the sessions, and the registry entry all survive.

No private recovery path is built, because clearing the held groups **is** the recovery: on reconnect the CP sees leases it holds for a member that reports none, and its existing missing-regrant path reissues them — which since #972 also re-installs the agents through `admitDutyGrants`.

## The no-horizon decision

**A conservative built-in fallback (120s) plus a warn, not silence.** A CP too old to announce a horizon in `auth/ok` is a CP too old to confirm renewals, so that one field is the capability signal. Against such a CP the daemon falls back to the built-in 120s horizon *and* to the weaker send anchor — strictly worse on exactly the half-open failure, and still far better than silently never fencing, which would disable a safety mechanism without saying so. The warn names both degradations. Every CP that ever shipped uses the same 120s value, so the fallback deadline lands where the real one would.

## Tests

- **`packages/daemon/test/cp/client-duty-fence.test.ts`** (timing, fake clock + fake transport)
  - **half-open socket**: sends succeed, nothing arrives, no close event — the deadline set by the last confirmed renewal does not move for the beats that follow, and the fence fires on schedule;
  - the #955 acceptance run: a control-plane restart bumps `sessionEpoch`, the reconnect reports the same held terms, is confirmed, and keeps running past the old deadline with nothing fenced;
  - the fence fires exactly at the horizon with the link down, and exactly once while reconnects keep failing;
  - anchored on the confirmation, not the disconnect; never armed before a renewal this member could lose; never armed for a daemon that renews no lease or on an org-scoped connection;
  - each announced horizon is adopted (a 40s lease fences at 30s);
  - a won rendezvous claim arms the fence with no prior renewal; a lost one arms nothing;
  - **mid-admission**: a confirmation arriving while a group is being admitted keeps its deadline, and still prunes one that is neither held nor pending;
  - **per-group**: a grant whose confirmation never arrives still fences on time; a grant after a fence re-arms that group; a claim for B does not postpone A's deadline; only the expired group is shed and the timer re-arms at the next earliest; one renewal refreshes every held group; a revoked group stops holding a deadline;
  - the older-CP fallback warns and still fences; a dead credential fences; a local shutdown does not.
- **`packages/daemon/test/daemon-duty-fence.test.ts`** (semantics, real daemon)
  - **a real Slack socket in the pool is stopped and evicted**, and its integration binding dropped, after the fence;
  - and it is still closed **on a retry after a reconcile pass that throws** — the assertion is on the connection, not on a counter;
  - the fence closes the serving gate for the named groups, disarms their schedules, and stops the running host;
  - **a partial fence** tears down one group's socket, schedules and host while the other group keeps serving, then fences it at its own deadline — and an agent covered by two held groups stays in service when only one is fenced;
  - **the withdrawal handoff**, with the admission held open at its `duty/fetch` round trip: a fence, a revoke, and a drain release each refuse it — leaving it neither held nor serving nor marked — while an admission no withdrawal touched still applies;
  - workspace, agent registry, and sessions survive it;
  - enforcement off ⇒ nothing released, nothing stopped;
  - a re-grant after a fence restores service without re-fetching the surviving agent.
- **`test/protocol/duty-lease.handler.test.ts`**: every processed duty beat is answered with the horizon just written; a beat with nothing to grant or revoke still carries the confirmation; and the confirmation is the **last** duty frame of an exchange that also revokes.
- **`packages/protocol/src/frames/duty.test.ts`**: `duty/renewed` round-trips and rejects a non-positive or absolute-timestamp payload.
- **`authService.test.ts`**: `auth/ok` carries this CP's own horizon.

Mutation-checked, each failing exactly the test that exists to catch it: a grant receipt arming nothing, a claim refreshing every deadline instead of its own, the fence shedding everything rather than what expired, a renewal refreshing only one group, the daemon ignoring which groups it was handed, restoring the send anchor (half-open test), removing the duty-driven connection convergence (Slack socket test), emitting the confirmation first again, consuming the convergence request up front, the CP not emitting the confirmation at all, anchoring on the disconnect, dropping the margin, not cancelling on renewal, dropping the enforcement gate, and skipping `stopServingAgent`.

## Gates

`typecheck`, `lint`, `format:check`, `protocol test` (329), `control-plane test:unit` (1607), `control-plane test:int` (1194) all green. The daemon suite is green apart from the pre-existing environmental failures (`shim-*`, `workspace-git-runner-seam`, live `acp-matrix`), verified identical on `origin/main` with the change stashed.

## Scope

`features.dutyEnforcement` stays off, the grant policy stays `incumbent`, placement and the reaper are untouched. This is one of three gates on the enforcement flip, with #973 (updates must follow the holder) and #975 (admission ordering).
