### PR TITLE
fix(duty): apply a refused replacement's removals instead of keeping the old composition

### DIFF
--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -209,6 +209,27 @@ describe('duty lease exchange (protocol level, real Postgres)', () => {
     expect(grant.payload.grants[0]).toMatchObject({ groupId: GROUP, term: '3' })
   })
 
+  it('the re-issue carries the CURRENT composition — the retry for a member that could not install it', async () => {
+    // A member that refused a replacement keeps the group at its OLD term after applying only the
+    // removals, so this is the branch its digest lands in every beat until the install succeeds:
+    // stale-term, not missing, so it costs nothing against the reported headroom.
+    const h = buildWsHarness(prisma)
+    const start = new Date(h.clock.now())
+    await seedGroup({ holder: DAEMON, term: 2n, expiresAt: new Date(start.getTime() + LEASE_MS) })
+    await prisma.dutyGroupMember.create({
+      data: { kind: 'agent', refId: AGENT2, groupId: GROUP, orgId: DEFAULT_ORG_ID }
+    })
+    const { stub } = await ready(h)
+
+    stub.inject('heartbeat', heartbeat({ held: [{ groupId: GROUP, term: '1' }], headroom: 0 }))
+    const grant = await stub.expectFrame('duty/grant')
+    if (!isFrame('duty/grant')(grant)) throw new Error('expected duty/grant')
+    expect(grant.payload.grants).toHaveLength(1)
+    expect(grant.payload.grants[0]?.term).toBe('2')
+    expect(grant.payload.grants[0]?.members.map((m) => m.refId).sort()).toEqual([AGENT, AGENT2].sort())
+    expect(stub.sent.filter((f) => f.type === 'duty/revoke')).toEqual([])
+  })
+
   it('a held group missing from the digest is re-granted (lost grant EVT recovery)', async () => {
     const h = buildWsHarness(prisma)
     const start = new Date(h.clock.now())

--- a/packages/daemon/src/cp/duty-registry.ts
+++ b/packages/daemon/src/cp/duty-registry.ts
@@ -88,6 +88,28 @@ export class DutyRegistry {
     return this.diff(before, { added, updated })
   }
 
+  /** The removal half of a replacement whose install was refused. Shrink each held group to the
+   *  members its replacement still names, keeping the OLD term: the removals are not what failed,
+   *  so applying them alone only ever reduces what this daemon serves, while the stale term is what
+   *  makes the CP reissue the full replacement. A group this daemon does not hold is skipped — a
+   *  refusal must never resurrect one. */
+  shrinkToGrant(grants: DutyGrantEntry[]): DutyApplyResult {
+    if (grants.length === 0) return EMPTY
+    const before = this.agents()
+    const updated: string[] = []
+    for (const g of grants) {
+      const held = this.held.get(g.groupId)
+      if (!held) continue
+      const kept = new Set(g.members.map((m) => `${m.kind}:${m.refId}`))
+      const agentIds = held.agentIds.filter((id) => kept.has(`agent:${id}`))
+      const botIds = held.botIds.filter((id) => kept.has(`bot:${id}`))
+      if (agentIds.length === held.agentIds.length && botIds.length === held.botIds.length) continue
+      updated.push(g.groupId)
+      this.held.set(g.groupId, { ...held, agentIds, botIds })
+    }
+    return this.diff(before, { added: [], updated })
+  }
+
   applyRevoke(revocations: DutyRevoke['revocations']): DutyApplyResult {
     if (revocations.length === 0) return EMPTY
     const before = this.agents()

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -365,7 +365,7 @@ import { memoryChannelKey } from './agents/memory.js'
 import { createWorkspaceGit } from './cp/workspace-git.js'
 import { DAEMON_VERSION } from './version.js'
 import { CpCronRegistry } from './cp/cp-cron.js'
-import { DutyRegistry } from './cp/duty-registry.js'
+import { DutyRegistry, type DutyApplyResult } from './cp/duty-registry.js'
 import { CpAgentRegistry } from './cp/cp-agent-registry.js'
 import {
   agentRemovalTombstones,
@@ -12750,6 +12750,12 @@ export class Daemon {
    * retry, paced by the heartbeat rather than a private loop. Nothing needs the
    * group present in the meantime: `renewHeld` renews by holder alone.
    *
+   * Refusing a REPLACEMENT of a held group is not enough on its own: an addition is what failed,
+   * yet the entry also carries removals, and keeping the old composition keeps serving agents the
+   * CP has reassigned. So the removals are applied alone — the group shrinks to what both
+   * compositions share, at the OLD term, which is what makes the CP's stale-term branch reissue
+   * the whole replacement every beat until it installs.
+   *
    * Returns the groupIds it refused — a failed install, or a withdrawal that landed while the
    * install was in flight.
    */
@@ -12763,10 +12769,10 @@ export class Daemon {
       // and each of them means "this member must not serve that group". A withdrawal drops the
       // group's admission mark, so the identity check below fails and the grant is never applied.
       // A newer admission for the same group replaces the mark for the same reason.
-      const refused = new Set(
+      const withdrawn = new Set(
         entries.filter((entry) => this.dutyAdmissions.get(entry.groupId) !== admission).map((e) => e.groupId)
       )
-      for (const groupId of failed) refused.add(groupId)
+      const refused = new Set([...withdrawn, ...failed])
       const servable = entries.filter((entry) => !refused.has(entry.groupId))
       if (servable.length > 0) {
         const result = this.duties.applyGrant(servable)
@@ -12774,10 +12780,25 @@ export class Daemon {
           `duty: granted ${result.added.length} + re-granted ${result.updated.length} group(s); ` +
             `holding ${this.duties.size()} covering ${this.duties.agents().size} agent(s)`
         )
-        if (result.agentsGained.length > 0 || result.added.length > 0) this.onDutyChanged()
+        this.settleDutyChange(result)
       }
-      const withdrawn = refused.size - failed.size
-      if (withdrawn > 0) this.log.info(`duty: ${withdrawn} group(s) were withdrawn while being admitted — not held`)
+      // Same fence, same absence of an await: a group a withdrawal took away is not shrunk either,
+      // because it is not ours to write any more — it was revoked outright, or a newer admission
+      // owns it and will apply its own composition.
+      const shrinking = entries.filter((entry) => failed.has(entry.groupId) && !withdrawn.has(entry.groupId))
+      if (shrinking.length > 0) {
+        const result = this.duties.shrinkToGrant(shrinking)
+        if (result.updated.length > 0) {
+          this.log.warn(
+            `duty: refused ${shrinking.length} group(s) but applied their removals; ` +
+              `${result.agentsLost.length} agent(s) left service, ${result.updated.length} group(s) shrunk`
+          )
+        }
+        this.settleDutyChange(result)
+      }
+      if (withdrawn.size > 0) {
+        this.log.info(`duty: ${withdrawn.size} group(s) were withdrawn while being admitted — not held`)
+      }
       return refused
     } finally {
       // Only ours to clear: a withdrawal already dropped it, and a newer admission owns it now.
@@ -12785,6 +12806,16 @@ export class Daemon {
         if (this.dutyAdmissions.get(entry.groupId) === admission) this.dutyAdmissions.delete(entry.groupId)
       }
     }
+  }
+
+  /** Settle what a registry write changed: an agent that left every held group stops being served
+   *  through the revoke teardown (#948 — workspace, sessions and registry entry survive), and any
+   *  change at all re-derives the physical half, since `transportAgents` gates sockets and direct
+   *  ingress is never re-checked per message. */
+  private settleDutyChange(result: DutyApplyResult): void {
+    for (const agentId of result.agentsLost) this.stopServingAgent(agentId)
+    const changed = result.added.length + result.updated.length + result.agentsGained.length + result.agentsLost.length
+    if (changed > 0) this.onDutyChanged()
   }
 
   /**

--- a/packages/daemon/test/cp/duty-registry.test.ts
+++ b/packages/daemon/test/cp/duty-registry.test.ts
@@ -62,6 +62,55 @@ describe('DutyRegistry', () => {
     expect(r.holdsAgent(A2)).toBe(false)
   })
 
+  it('a refused replacement shrinks the held group to the shared members, at the OLD term', () => {
+    // The removals are not what failed, so they apply on their own; the stale term is what makes
+    // the CP reissue the full replacement rather than fall silent on a term the member confirms.
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1, A2], [B1])])
+    const result = r.shrinkToGrant([grant(G1, '2', [A2, 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3'])])
+
+    expect(result.updated).toEqual([G1])
+    expect(result.agentsGained).toEqual([])
+    expect(result.agentsLost).toEqual([A1])
+    expect(r.digest()).toEqual([{ groupId: G1, term: '1' }])
+    expect([...r.agents()]).toEqual([A2])
+    expect([...r.bots()]).toEqual([])
+  })
+
+  it('shrinking never adds a member the install refused', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1])])
+    r.shrinkToGrant([grant(G1, '2', [A1, A2])])
+
+    expect([...r.agents()]).toEqual([A1])
+  })
+
+  it('shrinking reports an agent as lost only when no held group covers it any more', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1]), grant(G2, '1', [A1])])
+    const result = r.shrinkToGrant([grant(G1, '2', [A2])])
+
+    expect(result.agentsLost).toEqual([])
+    expect(r.holdsAgent(A1)).toBe(true)
+  })
+
+  it('shrinking a group this daemon does not hold is a no-op — a refusal never resurrects', () => {
+    const r = new DutyRegistry()
+    const result = r.shrinkToGrant([grant(G1, '1', [A1])])
+
+    expect(result.updated).toEqual([])
+    expect(r.size()).toBe(0)
+  })
+
+  it('a replacement that removes nothing reports no update at all', () => {
+    const r = new DutyRegistry()
+    r.applyGrant([grant(G1, '1', [A1], [B1])])
+    const result = r.shrinkToGrant([grant(G1, '2', [A1, A2], [B1])])
+
+    expect(result.updated).toEqual([])
+    expect(r.digest()).toEqual([{ groupId: G1, term: '1' }])
+  })
+
   it('a revoke drops the group and its agents', () => {
     const r = new DutyRegistry()
     r.applyGrant([grant(G1, '1', [A1]), grant(G2, '1', [A2])])

--- a/packages/daemon/test/daemon-duty-replacement.test.ts
+++ b/packages/daemon/test/daemon-duty-replacement.test.ts
@@ -1,0 +1,293 @@
+// A duty grant REPLACES its group, so it carries removals as well as additions. These pin the half
+// that is not optional when the install refuses the entry: the members the replacement dropped stop
+// being served here anyway, because an addition is what failed and a removal never can.
+import { describe, it, expect, vi } from 'vitest'
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { DutyGrantEntry } from '@agentconnect.md/protocol'
+import { Daemon } from '../src/daemon.js'
+import type { DutyRegistry } from '../src/cp/duty-registry.js'
+
+const AGENT_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const AGENT_B = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
+const AGENT_C = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3'
+const GROUP = '11111111-1111-4111-8111-111111111111'
+const GROUP_B = '11111111-1111-4111-8111-111111111112'
+const ORG = 'org-1'
+
+const NAMES: Record<string, string> = { [AGENT_A]: 'scout', [AGENT_B]: 'ranger', [AGENT_C]: 'pilot' }
+const INTEGRATION: Record<string, string> = {
+  [AGENT_A]: '22222222-2222-4222-8222-222222222221',
+  [AGENT_B]: '22222222-2222-4222-8222-222222222222',
+  [AGENT_C]: '22222222-2222-4222-8222-222222222223'
+}
+const CRON: Record<string, string> = {
+  [AGENT_A]: '33333333-3333-4333-8333-333333333331',
+  [AGENT_B]: '33333333-3333-4333-8333-333333333332',
+  [AGENT_C]: '33333333-3333-4333-8333-333333333333'
+}
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-duty-replacement-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      features: { dutyEnforcement: true },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  return root
+}
+
+const grant = (groupId: string, term: string, agents: string[]): DutyGrantEntry => ({
+  groupId,
+  orgId: ORG,
+  term,
+  members: agents.map((refId) => ({ kind: 'agent' as const, refId }))
+})
+
+const bundle = (agentId: string) => ({
+  agentId,
+  spec: {
+    orgId: ORG,
+    name: NAMES[agentId],
+    runtime: 'claude',
+    workspace: { mode: 'scratch' as const, isolation: 'shared' as const }
+  },
+  integrations: [
+    {
+      integrationId: INTEGRATION[agentId],
+      agentId,
+      orgId: ORG,
+      platform: 'slack',
+      core: { mode: 'direct' as const, bindRules: [], mutedChannels: [], gated: false },
+      config: { botToken: `xoxb-${NAMES[agentId]}`, appToken: `xapp-${NAMES[agentId]}` }
+    }
+  ],
+  crons: [
+    {
+      cronId: CRON[agentId],
+      agentId,
+      orgId: ORG,
+      schedule: '0 9 * * *',
+      timezone: 'UTC',
+      trigger: 'standup',
+      enabled: true
+    }
+  ]
+})
+
+/** A daemon holding GROUP at term 1 over agents A and C. `broken` is the set whose `duty/fetch`
+ *  fails — the uninstallable addition a replacement carries. */
+async function boot(broken = new Set<string>()) {
+  const root = scaffold()
+  const daemon = new Daemon({ root })
+  await daemon.start()
+  const fetchDutyAgent = vi.fn(async (agentId: string) => {
+    if (broken.has(agentId)) throw new Error('control plane unreachable')
+    return { bundle: bundle(agentId) }
+  })
+  ;(daemon as any).cpClient = {
+    organizationScope: () => 'frame',
+    stop: async () => {},
+    releaseDuties: vi.fn(async () => {}),
+    fetchDutyAgent
+  }
+  await (daemon as any).admitDutyGrants([grant(GROUP, '1', [AGENT_A, AGENT_C])])
+  return { daemon, root, broken, fetchDutyAgent }
+}
+
+const duties = (d: Daemon) => (d as any).duties as DutyRegistry
+const served = (d: Daemon): string[] => (d as any).transportAgents().map((a: { id: string }) => a.id)
+const schedules = (d: Daemon, agentId: string): number => (d as any).scheduler.count(agentId)
+const admit = (d: Daemon, entries: DutyGrantEntry[]) => (d as any).admitDutyGrants(entries) as Promise<Set<string>>
+
+/** Put a live Slack socket in the pool under this agent's own credentials, as a successful
+ *  `reconcileSlackConnections` would — what consolidation must stop asking for once it is dropped. */
+function liveSlackSocket(d: Daemon, agentId: string) {
+  const integrationId = INTEGRATION[agentId]
+  const conn = {
+    botToken: `xoxb-${NAMES[agentId]}`,
+    appToken: `xapp-${NAMES[agentId]}`,
+    botUserId: `U-${NAMES[agentId]}`,
+    stop: vi.fn(async () => {})
+  }
+  ;(d as any).slackPool.add(conn)
+  ;(d as any).connByIntegration.set(integrationId, conn)
+  ;(d as any).botUserIds[integrationId] = conn.botUserId
+  return conn
+}
+
+const pooled = (d: Daemon): unknown[] => (d as any).slackPool.all()
+
+describe('a refused replacement still applies its removals', () => {
+  it('drops the departed agent, keeps the group serving the rest, and stays at the old term', async () => {
+    // The split this closes: A has been reassigned elsewhere, and B — the agent the replacement
+    // ADDS — cannot be installed. Refusing the entry whole would leave A serviceable here while its
+    // new holder serves it too.
+    const { daemon } = await boot(new Set([AGENT_B]))
+    expect(served(daemon).sort()).toEqual([AGENT_A, AGENT_C].sort())
+    const socketA = liveSlackSocket(daemon, AGENT_A)
+    const socketC = liveSlackSocket(daemon, AGENT_C)
+    const stopA = vi.fn(async () => {})
+    ;(daemon as any).hosts.set(AGENT_A, { stop: stopA })
+
+    await expect(admit(daemon, [grant(GROUP, '2', [AGENT_C, AGENT_B])])).resolves.toEqual(new Set([GROUP]))
+
+    // A is gone from the group and from service, physically as well as in the ledger.
+    expect(duties(daemon).holdsAgent(AGENT_A)).toBe(false)
+    expect(served(daemon)).not.toContain(AGENT_A)
+    expect(schedules(daemon, AGENT_A)).toBe(0)
+    await vi.waitFor(() => expect(stopA).toHaveBeenCalled())
+    await vi.waitFor(() => expect(socketA.stop).toHaveBeenCalled())
+    expect(pooled(daemon)).not.toContain(socketA)
+    // C keeps serving: the removals are applied, the refusal is not escalated into a surrender.
+    expect(duties(daemon).holdsAgent(AGENT_C)).toBe(true)
+    expect(served(daemon)).toContain(AGENT_C)
+    expect(schedules(daemon, AGENT_C)).toBe(1)
+    expect(socketC.stop).not.toHaveBeenCalled()
+    // B never made it in, so it is not served either.
+    expect(duties(daemon).holdsAgent(AGENT_B)).toBe(false)
+    // The OLD term is what the digest reports, so the CP sees a stale term and its stale-term
+    // branch reissues the whole replacement on the next beat — the retry, at no headroom cost.
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '1' }])
+    await daemon.stop()
+  })
+
+  it('is a revoke, not a removal — the dropped agent keeps workspace, registry entry, and sessions', async () => {
+    const { daemon, root } = await boot(new Set([AGENT_B]))
+    const store = (daemon as any).store
+    store.upsertSession({
+      key: `slack:C1:T1:${AGENT_A}`,
+      agentId: AGENT_A,
+      platform: 'slack',
+      channel: 'C1',
+      thread: 'T1',
+      acpSessionId: 'acp-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+
+    await admit(daemon, [grant(GROUP, '2', [AGENT_C, AGENT_B])])
+
+    expect((daemon as any).cpAgents.has(AGENT_A)).toBe(true)
+    expect((daemon as any).agentRemovalPending(AGENT_A)).toBe(false)
+    expect(existsSync(join(root, 'agents', NAMES[AGENT_A]))).toBe(true)
+    expect(store.listSessions(AGENT_A)).toHaveLength(1)
+    await daemon.stop()
+  })
+
+  it('leaves an agent another held group also covers in service', async () => {
+    // The removal is per group; service is per agent. A second lease over the same agent is a
+    // separate authority, and the refusal here says nothing about it.
+    const { daemon } = await boot(new Set([AGENT_B]))
+    await admit(daemon, [grant(GROUP_B, '1', [AGENT_A])])
+    const stopA = vi.fn(async () => {})
+    ;(daemon as any).hosts.set(AGENT_A, { stop: stopA })
+
+    await admit(daemon, [grant(GROUP, '2', [AGENT_C, AGENT_B])])
+
+    expect(duties(daemon).get(GROUP)?.agentIds).toEqual([AGENT_C])
+    expect(duties(daemon).holdsAgent(AGENT_A)).toBe(true)
+    expect(served(daemon)).toContain(AGENT_A)
+    expect(schedules(daemon, AGENT_A)).toBe(1)
+    // The teardown follows "in no held group any more", not group membership — a running host for
+    // an agent the other lease still covers must not be torn down under it.
+    expect(stopA).not.toHaveBeenCalled()
+    await daemon.stop()
+  })
+
+  it('never resurrects a group this member does not hold', async () => {
+    // Nothing to shrink: the group was never held, and a refusal must not make it appear.
+    const { daemon } = await boot(new Set([AGENT_B]))
+
+    await admit(daemon, [grant(GROUP_B, '1', [AGENT_B])])
+
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '1' }])
+    expect(duties(daemon).get(GROUP_B)).toBeUndefined()
+    await daemon.stop()
+  })
+
+  it('a withdrawal that lands mid-admission still wins — the group is not shrunk back into the ledger', async () => {
+    // The #976 guard: a revoke inside the admission window means "do not serve this group at all",
+    // which outranks the shrink. Applying a composition for it here would re-hold what was revoked.
+    const { daemon } = await boot()
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    ;(daemon as any).cpClient.fetchDutyAgent = vi.fn(async () => {
+      await blocked
+      throw new Error('control plane unreachable')
+    })
+    const admitted = admit(daemon, [grant(GROUP, '2', [AGENT_C, AGENT_B])])
+    await vi.waitFor(() => expect((daemon as any).pendingDutyAdmissions()).toEqual([GROUP]))
+    ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
+    release()
+
+    expect([...(await admitted)]).toEqual([GROUP])
+    expect(duties(daemon).digest()).toEqual([])
+    expect(served(daemon)).not.toContain(AGENT_A)
+    expect(served(daemon)).not.toContain(AGENT_C)
+    await daemon.stop()
+  })
+
+  it('a newer admission owns the group, so an older refusal never writes its stale removals', async () => {
+    // The other half of the same guard, and the one a revoke cannot show: the group IS still held,
+    // but by a later grant. Shrinking to the older entry's composition would drop a member the
+    // newer authority just re-affirmed — an old grant overwriting a new one.
+    const { daemon } = await boot()
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    ;(daemon as any).cpClient.fetchDutyAgent = vi.fn(async () => {
+      await blocked
+      throw new Error('control plane unreachable')
+    })
+    const stale = admit(daemon, [grant(GROUP, '2', [AGENT_C, AGENT_B])])
+    await vi.waitFor(() => expect((daemon as any).pendingDutyAdmissions()).toEqual([GROUP]))
+
+    // The newer grant lands and completes first — both its agents are already installed.
+    await admit(daemon, [grant(GROUP, '3', [AGENT_A, AGENT_C])])
+    release()
+
+    expect([...(await stale)]).toEqual([GROUP])
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '3' }])
+    expect(duties(daemon).get(GROUP)?.agentIds.sort()).toEqual([AGENT_A, AGENT_C].sort())
+    expect(served(daemon)).toContain(AGENT_A)
+    await daemon.stop()
+  })
+})
+
+describe('a replacement that installs cleanly is unaffected', () => {
+  it('takes the new term and the new composition, and stops serving what it dropped', async () => {
+    const { daemon } = await boot()
+    const stopA = vi.fn(async () => {})
+    ;(daemon as any).hosts.set(AGENT_A, { stop: stopA })
+
+    await expect(admit(daemon, [grant(GROUP, '2', [AGENT_C, AGENT_B])])).resolves.toEqual(new Set())
+
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '2' }])
+    expect(served(daemon).sort()).toEqual([AGENT_B, AGENT_C].sort())
+    expect(served(daemon)).not.toContain(AGENT_A)
+    expect(schedules(daemon, AGENT_A)).toBe(0)
+    await vi.waitFor(() => expect(stopA).toHaveBeenCalled())
+    await daemon.stop()
+  })
+
+  it('a re-grant at a new term with the same composition changes nothing it serves', async () => {
+    const { daemon, fetchDutyAgent } = await boot()
+
+    await admit(daemon, [grant(GROUP, '2', [AGENT_A, AGENT_C])])
+
+    expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '2' }])
+    expect(served(daemon).sort()).toEqual([AGENT_A, AGENT_C].sort())
+    expect(fetchDutyAgent).toHaveBeenCalledTimes(2) // the initial pair, and nothing re-fetched
+    await daemon.stop()
+  })
+})


### PR DESCRIPTION
Closes the remaining finding of #975 (finding 2). Finding 1 was closed by #976.

## The defect

A `duty/grant` entry REPLACES its group, so it carries removals as well as
additions. `admitDutyGrants` installs what an entry covers and then applies only
the entries that came back servable. When a **replacement** of an already-held
group cannot be installed — some agent it newly adds fails to fetch or apply —
the whole entry was filtered out and the previously held entry survived at its
old term **and its old composition**.

Keeping the servable agents running is right, and #976 made it so deliberately.
The other half was the bug: the old composition also retained agents the
replacement **removed**, so an agent reassigned elsewhere stayed serviceable on
this member until some later grant succeeded — two members able to serve it at
once, which is the split the duty ledger exists to prevent.

## The invariant

**No agent absent from a replacement's composition remains serviceable on this
member after the refusal.** "Refuse the new members" and "keep the departed
members" are no longer the same code path.

## The shape: shrink, don't surrender

On a refused replacement of a held group the removals are applied on their own.
`DutyRegistry.shrinkToGrant` shrinks the held entry to the members both
compositions name and keeps the **old term**. An *addition* is what failed, so
the removals were never in doubt, and applying them alone can only ever reduce
what this member serves.

Surrendering the group whole also closes the split, but it stops serving agents
this member can still serve, so the shrink is preferred.

## Which exchange branch drives the retry

The **stale-term** branch, not missing-regrant. The digest keeps reporting a term
the ledger has moved past, so `dutyLease.exchange` classifies the group into
`stale` and reissues the whole replacement every beat
(`deliverable(stale).map(toGrantEntry)`). That distinction is load-bearing: a
stale re-issue is already local and is **not** charged against the member's
reported headroom, while a surrendered group would land in `missing` and be
charged — a full member could then starve its own retry. A new integration test
pins that the re-issue carries the *current* composition and rides in with zero
reported headroom.

## Teardown, and what keeps serving

An agent that leaves the composition stops being served through the **revoke**
teardown, never the removal path (#948): `stopServingAgent` runs per agent that is
in no held group any more, so workspace, sessions and the registry entry survive
while schedules, sockets and any running host stop. An agent another held group
still covers is untouched — the loss set is computed across all held groups, which
is the same invariant #976 pinned on the fence path.

That settling is now shared with the servable branch, so a replacement that
installs **cleanly** sheds what it dropped through the same path instead of
leaving schedules, sockets and a running host behind it. Previously only gains
triggered convergence.

The #976 withdrawal guard still wins over the shrink: a group taken away
mid-admission by a revoke, the self-fence, a drain release, or a newer admission is
not shrunk either — it is not that admission's to write any more. The newer-admission
case is the one a revoke cannot demonstrate (a revoke has already deleted the entry),
so it has its own test: an older refusal must not overwrite a newer grant's composition.

## Tests

New `packages/daemon/test/daemon-duty-replacement.test.ts` (8), five registry unit
tests, one CP lease-exchange integration test. Each was mutation-checked — the
mechanism was broken, the intended test confirmed failing, then restored:

| # | Mutation | Test(s) that failed |
| - | -------- | ------------------- |
| M1 | never shrink — refuse the entry whole, as before | `drops the departed agent, keeps the group serving the rest, and stays at the old term`; `leaves an agent another held group also covers in service` |
| M2 | shrink to the NEW term instead of the old | `…and stays at the old term`; `a refused replacement shrinks the held group to the shared members, at the OLD term` |
| M3 | shrink a group this member does not hold (insert it) | `never resurrects a group this member does not hold`; `shrinking a group this daemon does not hold is a no-op` |
| M4 | drop the withdrawal filter on the shrink set | `a newer admission owns the group, so an older refusal never writes its stale removals` |
| M5 | drop `stopServingAgent` from the settle path | `…stays at the old term`; `takes the new term and the new composition, and stops serving what it dropped` |
| M6 | report every dropped member as lost, ignoring other held groups | `shrinking reports an agent as lost only when no held group covers it any more`; `leaves an agent another held group also covers in service` |
| M7 | CP: stop re-issuing stale-term groups | `the re-issue carries the CURRENT composition…`; `a stale digest term is answered by re-issuing the grant at the current term` |

M4 initially failed to break any test — the withdrawal filter is unobservable in
the revoke/fence/drain cases, because those delete the entry before the admission
resumes. That gap produced the newer-admission test above, after which M4 is caught.

## Out of scope, deliberately

`features.dutyEnforcement` is not flipped. #973 (updates and the reconnect roster
following the holder), placement, the reaper, and the grant policy are untouched.

## Gates

`typecheck`, `lint`, `format:check`, protocol tests (329), CP `test:unit` (1607),
CP `test:int` (1195, real Postgres), daemon suite (3513 passed). The daemon suite's
15 failures (`shim-*`, `workspace-git-runner-seam`, live `acp-matrix`) reproduce
identically on clean `origin/main` in this environment.
