### PR TITLE
feat(duty): route agent updates and the reconnect roster to the duty holder

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -152,6 +152,7 @@ import { replayMemoryConnectionsTo, syncMemoryConnectionsToDaemons } from './orc
 import { relayHttpOrigin } from './orchestrator/mcpProvider.js'
 import { CollabRoutesService } from './orchestrator/collabRoutes.service.js'
 import { DutyLeaseService, DUTY_LEASE_DEFAULTS } from './orchestrator/dutyLease.js'
+import { AgentDelivery } from './orchestrator/agentDelivery.js'
 import { DutyRecomputeSweep } from './orchestrator/dutyRecompute.js'
 import { AgentMutationGate } from './orchestrator/agentMutationGate.js'
 import { AgentMoveService } from './orchestrator/agentMove.js'
@@ -617,10 +618,25 @@ export function buildContainer(
   // §2.3/§6.2): relays get the all-org table; daemons get their org-scoped copy.
   const collabRoutes = new CollabRoutesService(repos.daemon, repos.integration, repos.agent, relayControl, sender)
 
-  // Duty lease exchange riding the heartbeat (k8s daemons; orchestrator/dutyLease.ts).
-  const dutyLease = new DutyLeaseService(repos.dutyGroup, clock, undefined, {
-    warn: (o, m) => http.log.warn(o, m)
+  // The ONE resolver of an agent's delivery set — placement ∪ current duty
+  // holders — and the fan-out that rides it (orchestrator/agentDelivery.ts).
+  const agentDelivery = new AgentDelivery({
+    control: sender,
+    specs: agentSpecs,
+    duties: repos.dutyGroup,
+    clock
   })
+
+  // Duty lease exchange riding the heartbeat (k8s daemons; orchestrator/dutyLease.ts).
+  // The revision reader stamps each granted agent member with the CP's current
+  // spec revision, so a member that already has the agent can tell frozen from current.
+  const dutyLease = new DutyLeaseService(
+    repos.dutyGroup,
+    clock,
+    undefined,
+    { warn: (o, m) => http.log.warn(o, m) },
+    repos.agent
+  )
   // Duty-group projection: derived from Integration/CronDef rows on a rotation;
   // deltas reach daemons via the heartbeat lease exchange, never from the sweep.
   const dutyRecompute = new DutyRecomputeSweep(
@@ -715,6 +731,8 @@ export function buildContainer(
         grants: repos.externalMemoryGrant,
         relayRoster
       },
+      // The duty half of the reconcile roster: pinned-to-me ∪ held-by-me.
+      duties: repos.dutyGroup,
       log: { warn: (o, m) => http.log.warn(o, m) } // lazy over http.log (assigned below; called at reconcile time)
     }
   )
@@ -982,6 +1000,7 @@ export function buildContainer(
     liveness: connReg,
     daemonConns: connReg,
     control: sender,
+    agentDelivery,
     visibilityPush,
     relayControl,
     httpBot,
@@ -1478,25 +1497,20 @@ export function buildContainer(
                 ...hooks.map((hook) => hookService.broadcast(hook)),
                 ...agentIds.map(async (agentId) => {
                   const agent = await repos.agent.getUnscoped(agentId)
-                  if (!agent?.daemonId) return
-                  try {
-                    await sender.agentUpsert(agent.daemonId, {
-                      agentId: agent.id,
-                      spec: await agentSpecs.assemble(agent)
-                    })
-                  } catch (err) {
+                  if (!agent) return
+                  await agentDelivery.upsert(agent, (err, daemonId) => {
                     if (err instanceof NoConnection) {
                       http.log.debug(
-                        { agentId, daemonId: agent.daemonId },
+                        { agentId, daemonId },
                         'github rename: workspace agent/upsert skipped — daemon offline'
                       )
                     } else {
                       http.log.warn(
-                        { err, agentId, daemonId: agent.daemonId },
+                        { err, agentId, daemonId },
                         'github rename: workspace agent/upsert failed (backstop: reconnect roster)'
                       )
                     }
-                  }
+                  })
                 })
               ])
             )

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -677,7 +677,8 @@ export function buildContainer(
       warn: (o, m) => http.log.warn(o, m),
       debug: (o, m) => http.log.debug(o, m)
     },
-    platforms
+    platforms,
+    agentDelivery
   )
   const stagedAgentMoves = new AgentMoveService({
     agents: repos.agent,

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -63,6 +63,7 @@ import type { WebchatTokenService } from '../registry/webchatToken.js'
 import type { OrgInviteLinkService } from '../registry/orgInviteLinkService.js'
 import type { WaitlistService } from '../registry/waitlistService.js'
 import type { ControlSender } from '../orchestrator/outbound.js'
+import type { AgentDelivery } from '../orchestrator/agentDelivery.js'
 import type { SessionVisibilityPushService } from '../orchestrator/visibilityPush.js'
 import type { AgentSpecAssembler } from '../orchestrator/agentSpecAssembler.js'
 import type { RelayControlSender } from '../orchestrator/relayControl.js'
@@ -265,6 +266,10 @@ export interface HttpDeps {
   /** The fencing site for C→D control. REST agent CRUD pushes `agent/upsert`/
    *  `agent/remove` through it to replicate config to the owning daemon. */
   control: ControlSender
+  /** Resolves an agent's delivery set — placement ∪ current duty holders — and
+   *  fans `agent/upsert`/`agent/remove` out over it. EVERY replicate site routes
+   *  through this; none of them reads `agent.daemonId` to decide delivery. */
+  agentDelivery: AgentDelivery
   /** Pushes the per-session memory-capture gate to the owning daemons after a
    *  §4.3 visibility change, and answers the pending/applied cutover state
    *  (session-visibility.md §5.1). Absent ⇒ changes converge on register. */

--- a/packages/control-plane/src/http/install-bot.ts
+++ b/packages/control-plane/src/http/install-bot.ts
@@ -118,9 +118,11 @@ export async function installNewBot(
     return { integration, bot }
   }
 
-  // Classic: push the full spec (metadata + credentials) to the owning daemon so
-  // it opens its connection. Best-effort — an offline daemon picks it up from the
-  // register/ok reconcile roster. Never log the token-bearing spec.
+  // Classic: push the full spec (metadata + credentials) to every daemon serving
+  // this agent so it opens its connection — the placement and any duty holder,
+  // because a freshly pasted credential that reaches only the placement leaves the
+  // holder authenticating with the old one. Best-effort — an offline daemon picks
+  // it up from the register/ok reconcile roster. Never log the token-bearing spec.
   const daemonId = agent.daemonId! // caller guarantees placement for socket transport
   // The bot row joins the reads: it is a required input of the §9 projector that
   // assembles the spec payload (`orchestrator/placement.ts`). `bot` was created
@@ -130,15 +132,11 @@ export async function installNewBot(
     deps.repos.integrationChannel.listForIntegration(id)
   ])
   if (secret) {
-    try {
-      await deps.control.integrationUpsert(
-        daemonId,
-        await integrationToSpec(deps.platforms, integration, bot, secret, channels, isGatedAgent(agent))
-      )
-    } catch (err) {
+    const spec = await integrationToSpec(deps.platforms, integration, bot, secret, channels, isGatedAgent(agent))
+    await deps.agentDelivery.integrationUpsert(agent.id, daemonId, spec, (err, target) => {
       if (!(err instanceof NoConnection)) throw err
-      log.debug({ integrationId: id, daemonId }, 'integration/upsert skipped: daemon offline')
-    }
+      log.debug({ integrationId: id, daemonId: target }, 'integration/upsert skipped: daemon offline')
+    })
   }
   return { integration, bot }
 }

--- a/packages/control-plane/src/http/install-feishu.ts
+++ b/packages/control-plane/src/http/install-feishu.ts
@@ -111,15 +111,11 @@ export async function installNewFeishuBot(
     deps.repos.bot.get(orgId, botId)
   ])
   if (secret && botRow) {
-    try {
-      await deps.control.integrationUpsert(
-        agent.daemonId!,
-        await integrationToSpec(deps.platforms, integration, botRow, secret, channels, isGatedAgent(agent))
-      )
-    } catch (err) {
+    const spec = await integrationToSpec(deps.platforms, integration, botRow, secret, channels, isGatedAgent(agent))
+    await deps.agentDelivery.integrationUpsert(agent.id, agent.daemonId, spec, (err, target) => {
       if (!(err instanceof NoConnection)) throw err
-      log.debug({ integrationId: id, daemonId: agent.daemonId }, 'integration/upsert skipped: daemon offline')
-    }
+      log.debug({ integrationId: id, daemonId: target }, 'integration/upsert skipped: daemon offline')
+    })
   }
   return integration
 }

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -895,16 +895,14 @@ export function agentRoutes(deps: HttpDeps) {
         agents.map((agent) => agent.id)
       )) ?? new Map()
 
-    // Replicate a spec change to the agent's owning daemon so its local config
-    // replica stays current (direct Slack→daemon launch reads the replica, not
-    // the CP). Best-effort: if the agent isn't placed or the daemon is offline,
-    // the `register/ok` reconcile roster is the backstop on its next connect.
-    const replicateUpsert = async (agent: AgentRecord): Promise<void> => {
-      if (!agent.daemonId) return
-      const spec = await deps.agentSpecs.assemble(agent)
-      try {
-        await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec }, agent.orgId)
-      } catch (err) {
+    // Replicate a spec change to every daemon that serves this agent — its
+    // placement AND any member currently holding its duty (deps.agentDelivery is
+    // the one resolver). The daemon's local config replica must stay current
+    // because a direct Slack→daemon launch reads the replica, not the CP.
+    // Best-effort: if the agent reaches no daemon or a daemon is offline, the
+    // `register/ok` reconcile roster is the backstop on its next connect.
+    const replicateUpsert = (agent: AgentRecord): Promise<void> =>
+      deps.agentDelivery.upsert(agent, (err, daemonId) => {
         // Best-effort (see the register/ok reconcile backstop above): the agent update is
         // ALREADY persisted, so a daemon-side hiccup must not fail the HTTP write — not just
         // an offline daemon (NoConnection) but also a rejected/failed live reconcile or a
@@ -912,25 +910,20 @@ export function agentRoutes(deps: HttpDeps) {
         // reconcile hiccup was silent). The daemon re-syncs from the register/ok roster on its
         // next (re)connect. Matches the icon route's replicate handler.
         if (err instanceof NoConnection) {
-          app.log.debug({ agentId: agent.id, daemonId: agent.daemonId }, 'agent/upsert skipped: daemon offline')
+          app.log.debug({ agentId: agent.id, daemonId }, 'agent/upsert skipped: daemon offline')
         } else {
           app.log.warn(
-            { err, agentId: agent.id, daemonId: agent.daemonId },
+            { err, agentId: agent.id, daemonId },
             'agent/upsert live reconcile failed (backstop: reconnect roster)'
           )
         }
-      }
-    }
+      })
 
-    const replicateRemove = async (agentId: string, daemonId: string | null, orgId: string): Promise<void> => {
-      if (!daemonId) return
-      try {
-        await deps.control.agentRemove(daemonId, { agentId }, orgId)
-      } catch (err) {
+    const replicateRemove = (agentId: string, daemonId: string | null, orgId: string): Promise<void> =>
+      deps.agentDelivery.remove(agentId, daemonId, orgId, (err, target) => {
         if (!(err instanceof NoConnection)) throw err
-        app.log.debug({ agentId, daemonId }, 'agent/remove skipped: daemon offline')
-      }
-    }
+        app.log.debug({ agentId, daemonId: target }, 'agent/remove skipped: daemon offline')
+      })
 
     // The alive relay's HTTP origin for MCP proxy defs (ws→http/wss→https), or null
     // when no relay is live. Mirrors the mcp-providers route's relayBaseUrl.

--- a/packages/control-plane/src/http/routes/crons.ts
+++ b/packages/control-plane/src/http/routes/crons.ts
@@ -88,24 +88,19 @@ export function cronRoutes(deps: HttpDeps) {
       return canView(cron, ctxOf(req)) ? cron : null
     }
 
-    // Live-sink a cron change to the owning agent's daemon. Best-effort: offline
-    // daemon ⇒ the register/ok reconcile snapshot carries it on the next connect.
-    async function pushLive(
-      daemonId: string | null,
-      what: string,
-      push: (daemonId: string) => Promise<unknown>
-    ): Promise<void> {
-      if (!daemonId) return // unplaced agent — reconcile is the backstop
-      try {
-        await push(daemonId) // non-null past the guard — no assertion at the call site
-      } catch (err) {
+    // Best-effort per-target log for a cron push. The delivery set itself is
+    // `deps.agentDelivery`'s call (placement ∪ duty holders): a cron drives the
+    // agent, so it belongs wherever the agent is served. Offline daemon ⇒ the
+    // register/ok reconcile snapshot carries it on the next connect.
+    const cronPushFailed =
+      (what: string) =>
+      (err: unknown, daemonId: string): void => {
         if (err instanceof NoConnection) {
           app.log.debug({ daemonId }, `${what} skipped: daemon offline`)
           return
         }
         app.log.warn({ daemonId, err }, `${what} live push failed — daemon converges on next register`)
       }
-    }
 
     r.put(
       '/crons/:id',
@@ -233,7 +228,7 @@ export function cronRoutes(deps: HttpDeps) {
             .catch(() => {})
           const wire = cronToUpsert(cron)
           if (wire) {
-            await pushLive(agent.daemonId, 'cron/upsert', (daemonId) => deps.control.cronUpsert(daemonId, wire))
+            await deps.agentDelivery.cronUpsert(agent.id, agent.daemonId, wire, cronPushFailed('cron/upsert'))
           }
           return toDto(cron, ctxOf(req))
         } finally {
@@ -449,9 +444,7 @@ export function cronRoutes(deps: HttpDeps) {
               details: { cronId: existing.id }
             })
             .catch(() => {})
-          await pushLive(agent.daemonId, 'cron/remove', (daemonId) =>
-            deps.control.cronRemove(daemonId, { cronId: existing.id })
-          )
+          await deps.agentDelivery.cronRemove(agent.id, agent.daemonId, existing.id, cronPushFailed('cron/remove'))
           return reply.code(204).send(null)
         } finally {
           release()

--- a/packages/control-plane/src/http/routes/crons.ts
+++ b/packages/control-plane/src/http/routes/crons.ts
@@ -444,7 +444,15 @@ export function cronRoutes(deps: HttpDeps) {
               details: { cronId: existing.id }
             })
             .catch(() => {})
-          await deps.agentDelivery.cronRemove(agent.id, agent.daemonId, existing.id, cronPushFailed('cron/remove'))
+          // The row's own org rides the send: `cron/remove` carries only a cronId,
+          // so a holder that never registered this cron has nothing to resolve.
+          await deps.agentDelivery.cronRemove(
+            agent.id,
+            agent.daemonId,
+            existing.id,
+            existing.orgId,
+            cronPushFailed('cron/remove')
+          )
           return reply.code(204).send(null)
         } finally {
           release()

--- a/packages/control-plane/src/http/routes/icon-upload.ts
+++ b/packages/control-plane/src/http/routes/icon-upload.ts
@@ -56,24 +56,14 @@ export function iconUploadRoutes(deps: HttpDeps) {
       (_req, body, done) => done(null, body)
     )
 
-    // Best-effort: replicate the agent's new icon to its owning daemon so the Slack
-    // per-message avatar refreshes now (the reconnect roster is the backstop).
+    // Best-effort: replicate the agent's new icon to every daemon serving it so the
+    // Slack per-message avatar refreshes now (the reconnect roster is the backstop).
     const replicateAgent = async (orgId: OrgId, agentId: string): Promise<void> => {
       const agent = await deps.repos.agent.get(orgId, AgentId(agentId))
-      if (!agent?.daemonId) return
-      try {
-        await deps.control.agentUpsert(
-          agent.daemonId,
-          {
-            agentId: agent.id,
-            // The assembler owns secret loading + icon bases — full spec per upsert.
-            spec: await deps.agentSpecs.assemble(agent)
-          },
-          agent.orgId
-        )
-      } catch (err) {
-        app.log.warn({ err, agentId }, 'icon replicate agent/upsert failed (backstop: reconnect roster)')
-      }
+      if (!agent) return
+      await deps.agentDelivery.upsert(agent, (err, daemonId) => {
+        app.log.warn({ err, agentId, daemonId }, 'icon replicate agent/upsert failed (backstop: reconnect roster)')
+      })
     }
 
     // ── Agent icon ────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -170,8 +170,14 @@ export function integrationRoutes(deps: HttpDeps) {
         message: refusal.message
       })
 
-    const replicateRemove = async (agentId: string, integrationId: string, daemonId: string | null): Promise<void> => {
-      await deps.agentDelivery.integrationRemove(agentId, daemonId, integrationId, (err, target) => {
+    const replicateRemove = async (
+      i: Pick<IntegrationRecord, 'id' | 'agentId' | 'orgId'>,
+      daemonId: string | null
+    ): Promise<void> => {
+      const { id: integrationId } = i
+      // The row's own org rides the send: `integration/remove` carries only an id,
+      // so a holder that never registered this integration has nothing to resolve.
+      await deps.agentDelivery.integrationRemove(i.agentId, daemonId, i.id, i.orgId, (err, target) => {
         if (!(err instanceof NoConnection)) throw err
         app.log.debug({ integrationId, daemonId: target }, 'integration/remove skipped: daemon offline')
       })
@@ -1176,7 +1182,7 @@ export function integrationRoutes(deps: HttpDeps) {
             await deps.repos.bot.markFreed(orgIdOf(req), existing.botId, new Date(), agent.name ?? null)
           }
           // Tell the removed agent's daemon to drop the spec either way.
-          await replicateRemove(existing.agentId, existing.id, agent.daemonId ?? null)
+          await replicateRemove(existing, agent.daemonId ?? null)
           // HTTP bot: recompute the relay's routes + members (or release it if this
           // was the last install).
           if (botBefore?.transport === 'http') await deps.httpBot.syncBot(existing.botId)

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -96,10 +96,13 @@ export function integrationRoutes(deps: HttpDeps) {
       return current
     }
 
-    // Push the full spec (metadata + tokens + per-conversation bindRules) to the owning
-    // daemon. Best-effort: if the daemon is offline the reconcile roster carries it
-    // on the next connect. Token-bearing — never log the spec.
-    const replicateUpsert = async (i: IntegrationRecord, daemonId: string): Promise<void> => {
+    // Push the full spec (metadata + tokens + per-conversation bindRules) to every
+    // daemon that serves the owning agent — its placement AND any duty holder
+    // (`deps.agentDelivery` is the one resolver; a holder left on stale credentials
+    // or stale bind rules is the frozen-bundle failure one level down). Best-effort:
+    // an offline daemon picks it up from the reconcile roster on the next connect.
+    // Token-bearing — never log the spec.
+    const replicateUpsert = async (i: IntegrationRecord, daemonId: string | null): Promise<void> => {
       // The bot row joins the reads: it is a required input of the §9 projector
       // that now assembles the spec payload (`orchestrator/placement.ts`). Every
       // caller here is already on the socket-transport arm, so the projector
@@ -111,15 +114,18 @@ export function integrationRoutes(deps: HttpDeps) {
         deps.repos.bot.get(i.orgId, i.botId)
       ])
       if (!secret || !bot) return
-      try {
-        await deps.control.integrationUpsert(
-          daemonId,
-          await integrationToSpec(deps.platforms, i, bot, secret, channels, owner ? isGatedAgent(owner) : false)
-        )
-      } catch (err) {
+      const spec = await integrationToSpec(
+        deps.platforms,
+        i,
+        bot,
+        secret,
+        channels,
+        owner ? isGatedAgent(owner) : false
+      )
+      await deps.agentDelivery.integrationUpsert(i.agentId, daemonId, spec, (err, target) => {
         if (!(err instanceof NoConnection)) throw err
-        app.log.debug({ integrationId: i.id, daemonId }, 'integration/upsert skipped: daemon offline')
-      }
+        app.log.debug({ integrationId: i.id, daemonId: target }, 'integration/upsert skipped: daemon offline')
+      })
     }
 
     // Shareable-install preconditions (shared-bot-relay.md §6): Slack-only for now, a
@@ -164,14 +170,11 @@ export function integrationRoutes(deps: HttpDeps) {
         message: refusal.message
       })
 
-    const replicateRemove = async (integrationId: string, daemonId: string | null): Promise<void> => {
-      if (!daemonId) return
-      try {
-        await deps.control.integrationRemove(daemonId, { integrationId })
-      } catch (err) {
+    const replicateRemove = async (agentId: string, integrationId: string, daemonId: string | null): Promise<void> => {
+      await deps.agentDelivery.integrationRemove(agentId, daemonId, integrationId, (err, target) => {
         if (!(err instanceof NoConnection)) throw err
-        app.log.debug({ integrationId, daemonId }, 'integration/remove skipped: daemon offline')
-      }
+        app.log.debug({ integrationId, daemonId: target }, 'integration/remove skipped: daemon offline')
+      })
     }
 
     r.post(
@@ -619,7 +622,7 @@ export function integrationRoutes(deps: HttpDeps) {
       agent: AgentRecord
     ): Promise<void> => {
       if (bot.transport === 'http') await deps.httpBot.syncRoutes(bot.id)
-      else if (agent.daemonId) await replicateUpsert(integration, agent.daemonId)
+      else await replicateUpsert(integration, agent.daemonId)
     }
 
     /**
@@ -884,7 +887,7 @@ export function integrationRoutes(deps: HttpDeps) {
           // bot re-pushes its recomputed bindRules to the owning daemon.
           if (bot.transport === 'http') {
             if (!routesSynced) await deps.httpBot.syncRoutes(bot.id)
-          } else if (agent.daemonId) {
+          } else {
             await replicateUpsert(integration, agent.daemonId)
           }
           return toChannelDto(updated!)
@@ -1173,7 +1176,7 @@ export function integrationRoutes(deps: HttpDeps) {
             await deps.repos.bot.markFreed(orgIdOf(req), existing.botId, new Date(), agent.name ?? null)
           }
           // Tell the removed agent's daemon to drop the spec either way.
-          await replicateRemove(existing.id, agent.daemonId ?? null)
+          await replicateRemove(existing.agentId, existing.id, agent.daemonId ?? null)
           // HTTP bot: recompute the relay's routes + members (or release it if this
           // was the last install).
           if (botBefore?.transport === 'http') await deps.httpBot.syncBot(existing.botId)

--- a/packages/control-plane/src/http/routes/organization-environment.ts
+++ b/packages/control-plane/src/http/routes/organization-environment.ts
@@ -119,19 +119,15 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
       const agents = await deps.repos.agent.list(orgId)
       const affected = agents.filter((agent) => agentIds.includes(agent.id))
       await Promise.all(
-        affected.map(async (agent) => {
-          // An unplaced agent needs no event; it will be assembled at placement.
-          if (!agent.daemonId) return
-          try {
-            const spec = await deps.agentSpecs.assemble(agent)
-            await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec }, agent.orgId)
-          } catch (err) {
+        affected.map((agent) =>
+          // An agent that reaches no daemon needs no event; it will be assembled at placement.
+          deps.agentDelivery.upsert(agent, (err, daemonId) => {
             app.log.warn(
-              { err, orgId, agentId: agent.id, reason },
+              { err, orgId, agentId: agent.id, daemonId, reason },
               'organization environment fan-out deferred to reconnect roster'
             )
-          }
-        })
+          })
+        )
       )
     }
 

--- a/packages/control-plane/src/http/routes/organization-knowledge.ts
+++ b/packages/control-plane/src/http/routes/organization-knowledge.ts
@@ -214,15 +214,11 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
         agent.managedSkills.includes(managedSkillId)
       )
       await Promise.all(
-        agents.map(async (agent) => {
-          if (!agent.daemonId) return
-          try {
-            const spec = await deps.agentSpecs.assemble(agent)
-            await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec }, agent.orgId)
-          } catch (err) {
-            app.log.warn({ err, agentId: agent.id }, 'managed-skill fan-out deferred to reconnect roster')
-          }
-        })
+        agents.map((agent) =>
+          deps.agentDelivery.upsert(agent, (err, daemonId) => {
+            app.log.warn({ err, agentId: agent.id, daemonId }, 'managed-skill fan-out deferred to reconnect roster')
+          })
+        )
       )
     }
 

--- a/packages/control-plane/src/http/routes/skill-sources.ts
+++ b/packages/control-plane/src/http/routes/skill-sources.ts
@@ -140,25 +140,21 @@ export function skillSourceRoutes(deps: HttpDeps) {
     // reconnect backstop), mirroring the agents route's replicateUpsert.
     const fanOutToReferrers = async (orgId: OrgId, sourceName: string): Promise<void> => {
       const agents = await deps.repos.agent.list(orgId)
-      const referrers = agents.filter(
-        (a) => a.daemonId && a.skills.some((ref) => parseSkillRef(ref).source === sourceName)
-      )
+      const referrers = agents.filter((a) => a.skills.some((ref) => parseSkillRef(ref).source === sourceName))
       for (const a of referrers) await replicate(a)
     }
 
-    const replicate = async (agent: AgentRecord): Promise<void> => {
-      if (!agent.daemonId) return
-      const spec = await deps.agentSpecs.assemble(agent)
-      try {
-        await deps.control.agentUpsert(agent.daemonId, { agentId: agent.id, spec }, agent.orgId)
-      } catch (err) {
+    const replicate = (agent: AgentRecord): Promise<void> =>
+      deps.agentDelivery.upsert(agent, (err, daemonId) => {
         if (err instanceof NoConnection) {
-          app.log.debug({ agentId: agent.id, daemonId: agent.daemonId }, 'skill fan-out: daemon offline')
+          app.log.debug({ agentId: agent.id, daemonId }, 'skill fan-out: daemon offline')
         } else {
-          app.log.warn({ err, agentId: agent.id }, 'skill fan-out agent/upsert failed (backstop: reconnect roster)')
+          app.log.warn(
+            { err, agentId: agent.id, daemonId },
+            'skill fan-out agent/upsert failed (backstop: reconnect roster)'
+          )
         }
-      }
-    }
+      })
 
     r.get(
       '/skill-sources',

--- a/packages/control-plane/src/orchestrator/agentDelivery.ts
+++ b/packages/control-plane/src/orchestrator/agentDelivery.ts
@@ -84,7 +84,10 @@ export class AgentDelivery {
   // stale spec, one level down. These take the agent's id and placement rather
   // than the record, because a removal path may only have those.
 
-  /** Push one integration's spec (token-bearing — NEVER log it) to every target. */
+  /** Push one integration's spec (token-bearing — NEVER log it) to every target.
+   *  No explicit orgId: `IntegrationSpec.orgId` is a required wire field, so the
+   *  payload IS the explicit org — and sending it also teaches the connection's
+   *  id→org map, which is why upserts never had this problem. */
   async integrationUpsert(
     agentId: string,
     placement: string | null,
@@ -95,16 +98,25 @@ export class AgentDelivery {
     await this.fanOut(targets, onError, (daemonId) => this.deps.control.integrationUpsert(daemonId, spec))
   }
 
+  /** `orgId` is REQUIRED, not derived. A removal payload is a bare id, so an
+   *  install-wide connection can only resolve the org from the id→org map it
+   *  built at `register` — and a holder that acquired the integration through
+   *  `duty/fetch` never registered it, so the send would raise SCOPE_DENIED
+   *  before the frame left the process. The record in hand always has the org. */
   async integrationRemove(
     agentId: string,
     placement: string | null,
     integrationId: string,
+    orgId: string,
     onError: DeliveryErrorHandler
   ): Promise<void> {
     const targets = await this.daemonsFor(agentId, placement)
-    await this.fanOut(targets, onError, (daemonId) => this.deps.control.integrationRemove(daemonId, { integrationId }))
+    await this.fanOut(targets, onError, (daemonId) =>
+      this.deps.control.integrationRemove(daemonId, { integrationId }, orgId)
+    )
   }
 
+  /** Same as the integration upsert: `CronUpsert.orgId` is a required wire field. */
   async cronUpsert(
     agentId: string,
     placement: string | null,
@@ -115,17 +127,19 @@ export class AgentDelivery {
     await this.fanOut(targets, onError, async (daemonId) => void (await this.deps.control.cronUpsert(daemonId, wire)))
   }
 
+  /** `orgId` is REQUIRED for the same reason as {@link AgentDelivery.integrationRemove}. */
   async cronRemove(
     agentId: string,
     placement: string | null,
     cronId: string,
+    orgId: string,
     onError: DeliveryErrorHandler
   ): Promise<void> {
     const targets = await this.daemonsFor(agentId, placement)
     await this.fanOut(
       targets,
       onError,
-      async (daemonId) => void (await this.deps.control.cronRemove(daemonId, { cronId }))
+      async (daemonId) => void (await this.deps.control.cronRemove(daemonId, { cronId }, orgId))
     )
   }
 

--- a/packages/control-plane/src/orchestrator/agentDelivery.ts
+++ b/packages/control-plane/src/orchestrator/agentDelivery.ts
@@ -1,0 +1,102 @@
+/**
+ * `AgentDelivery` — the ONE answer to "which daemons must receive this agent's
+ * updates", and the fan-out that rides it.
+ *
+ * Placement used to be that answer, read inline as `agent.daemonId` at every
+ * replicate site. A duty grant broke it: a pool member that wins a duty for an
+ * agent it is not the placement of installs one bundle (`duty/fetch`) and then
+ * serves it frozen, because every spec edit, rotated credential and organization
+ * secret rides a placement-keyed push. The delivery set is therefore the union —
+ * the placement if the agent has one, plus every member currently holding an
+ * unexpired duty lease covering it.
+ *
+ * It is a seam, not a special case: a later change makes placement a delivery
+ * TARGET rather than a member id, and this is the one place that has to learn it.
+ * The lifecycle sends keep taking an explicit `orgId`, because an install-wide
+ * (frame-mode) member's connection carries no org and a duty holder is exactly
+ * the connection that cannot resolve one from its own maps.
+ */
+import type { AgentSpecAssembler } from './agentSpecAssembler.js'
+import type { ControlSender } from './outbound.js'
+import type { AgentRecord } from '../persistence/ports.js'
+import { AgentId, type DaemonId } from '../domain/ids.js'
+import type { Clock } from '../domain/clock.js'
+
+/** The duty ledger read this seam needs — the delivery half of `holdsAgent`. */
+export interface DutyHolderReader {
+  holdersOf(agentId: AgentId, now: Date): Promise<DaemonId[]>
+}
+
+/** Per-target failure hook: every site logs it its own way, and none of them
+ *  fails the HTTP write over it (the reconnect roster is the backstop). */
+export type DeliveryErrorHandler = (err: unknown, daemonId: string) => void
+
+export class AgentDelivery {
+  constructor(
+    private readonly deps: {
+      control: Pick<ControlSender, 'agentUpsert' | 'agentRemove'>
+      specs: AgentSpecAssembler
+      duties?: DutyHolderReader
+      clock: Clock
+    }
+  ) {}
+
+  /**
+   * Every daemon that must receive this agent's updates, placement first and
+   * deduped. No duty ledger wired (tests, or a deployment with no pool) ⇒ the
+   * placement alone, which is exactly the pre-duty behavior.
+   */
+  async daemonsFor(agentId: string, placement: string | null): Promise<string[]> {
+    const holders = this.deps.duties
+      ? await this.deps.duties.holdersOf(AgentId(agentId), new Date(this.deps.clock.now()))
+      : []
+    return [...new Set([...(placement ? [placement] : []), ...holders])]
+  }
+
+  /** Push an edited spec to every delivery target. The spec is assembled ONCE:
+   *  the targets replicate the same agent, and two assemblies could disagree. */
+  async upsert(agent: AgentRecord, onError: DeliveryErrorHandler): Promise<void> {
+    const targets = await this.daemonsFor(agent.id, agent.daemonId)
+    if (targets.length === 0) return
+    const spec = await this.deps.specs.assemble(agent)
+    await this.fanOut(targets, onError, (daemonId) =>
+      this.deps.control.agentUpsert(daemonId, { agentId: agent.id, spec }, agent.orgId)
+    )
+  }
+
+  /** Tell every delivery target the agent is gone. The agent row is already
+   *  deleted by now; duty membership has no FK to it, so a holder is still
+   *  resolvable — which is the whole point (a deleted agent must stop being
+   *  served, not just stop being placed). */
+  async remove(agentId: string, placement: string | null, orgId: string, onError: DeliveryErrorHandler): Promise<void> {
+    const targets = await this.daemonsFor(agentId, placement)
+    await this.fanOut(targets, onError, (daemonId) => this.deps.control.agentRemove(daemonId, { agentId }, orgId))
+  }
+
+  /** Sequential so the placement keeps going first. A handler that rethrows (the
+   *  delete route escalates anything that is not an offline daemon) still lets
+   *  every remaining target hear the news before the error surfaces. */
+  private async fanOut(
+    targets: string[],
+    onError: DeliveryErrorHandler,
+    send: (daemonId: string) => Promise<void>
+  ): Promise<void> {
+    let escalated: unknown
+    let failed = false
+    for (const daemonId of targets) {
+      try {
+        await send(daemonId)
+      } catch (err) {
+        try {
+          onError(err, daemonId)
+        } catch (rethrown) {
+          if (!failed) {
+            escalated = rethrown
+            failed = true
+          }
+        }
+      }
+    }
+    if (failed) throw escalated
+  }
+}

--- a/packages/control-plane/src/orchestrator/agentDelivery.ts
+++ b/packages/control-plane/src/orchestrator/agentDelivery.ts
@@ -16,6 +16,7 @@
  * (frame-mode) member's connection carries no org and a duty holder is exactly
  * the connection that cannot resolve one from its own maps.
  */
+import type { CronUpsert, IntegrationSpec } from '@agentconnect.md/protocol'
 import type { AgentSpecAssembler } from './agentSpecAssembler.js'
 import type { ControlSender } from './outbound.js'
 import type { AgentRecord } from '../persistence/ports.js'
@@ -34,7 +35,10 @@ export type DeliveryErrorHandler = (err: unknown, daemonId: string) => void
 export class AgentDelivery {
   constructor(
     private readonly deps: {
-      control: Pick<ControlSender, 'agentUpsert' | 'agentRemove'>
+      control: Pick<
+        ControlSender,
+        'agentUpsert' | 'agentRemove' | 'integrationUpsert' | 'integrationRemove' | 'cronUpsert' | 'cronRemove'
+      >
       specs: AgentSpecAssembler
       duties?: DutyHolderReader
       clock: Clock
@@ -71,6 +75,58 @@ export class AgentDelivery {
   async remove(agentId: string, placement: string | null, orgId: string, onError: DeliveryErrorHandler): Promise<void> {
     const targets = await this.daemonsFor(agentId, placement)
     await this.fanOut(targets, onError, (daemonId) => this.deps.control.agentRemove(daemonId, { agentId }, orgId))
+  }
+
+  // A dependent goes exactly where its agent's own updates go. An integration
+  // spec is token-bearing and a cron definition drives execution, so a holder
+  // that receives neither keeps stale credentials, stale bind rules, or a stale
+  // schedule until it happens to reconnect — the same frozen-bundle failure as a
+  // stale spec, one level down. These take the agent's id and placement rather
+  // than the record, because a removal path may only have those.
+
+  /** Push one integration's spec (token-bearing — NEVER log it) to every target. */
+  async integrationUpsert(
+    agentId: string,
+    placement: string | null,
+    spec: IntegrationSpec,
+    onError: DeliveryErrorHandler
+  ): Promise<void> {
+    const targets = await this.daemonsFor(agentId, placement)
+    await this.fanOut(targets, onError, (daemonId) => this.deps.control.integrationUpsert(daemonId, spec))
+  }
+
+  async integrationRemove(
+    agentId: string,
+    placement: string | null,
+    integrationId: string,
+    onError: DeliveryErrorHandler
+  ): Promise<void> {
+    const targets = await this.daemonsFor(agentId, placement)
+    await this.fanOut(targets, onError, (daemonId) => this.deps.control.integrationRemove(daemonId, { integrationId }))
+  }
+
+  async cronUpsert(
+    agentId: string,
+    placement: string | null,
+    wire: CronUpsert,
+    onError: DeliveryErrorHandler
+  ): Promise<void> {
+    const targets = await this.daemonsFor(agentId, placement)
+    await this.fanOut(targets, onError, async (daemonId) => void (await this.deps.control.cronUpsert(daemonId, wire)))
+  }
+
+  async cronRemove(
+    agentId: string,
+    placement: string | null,
+    cronId: string,
+    onError: DeliveryErrorHandler
+  ): Promise<void> {
+    const targets = await this.daemonsFor(agentId, placement)
+    await this.fanOut(
+      targets,
+      onError,
+      async (daemonId) => void (await this.deps.control.cronRemove(daemonId, { cronId }))
+    )
   }
 
   /** Sequential so the placement keeps going first. A handler that rethrows (the

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -47,6 +47,11 @@ export const DUTY_LEASE_DEFAULTS: DutyLeaseConfig = {
 
 type Send = (type: 'duty/grant' | 'duty/revoke' | 'duty/renewed', payload: unknown) => void
 
+/** The freshness signal's source: the CP's current spec revision per agent. */
+export interface AgentRevisionReader {
+  configRevisions(agentIds: readonly AgentId[]): Promise<Map<string, bigint>>
+}
+
 function toGrantEntry(g: Pick<DutyGrantRecord, 'groupId' | 'orgId' | 'term' | 'members'>): DutyGrantEntry {
   return { groupId: g.groupId, orgId: g.orgId, term: String(g.term), members: g.members }
 }
@@ -92,9 +97,35 @@ export class DutyLeaseService {
     private readonly repo: DutyGroupRepo,
     private readonly clock: Clock,
     private readonly config: DutyLeaseConfig = DUTY_LEASE_DEFAULTS,
-    private readonly log?: { warn(obj: unknown, msg?: string): void }
+    private readonly log?: { warn(obj: unknown, msg?: string): void },
+    /** Absent ⇒ unstamped entries, and a member falls back to presence alone. */
+    private readonly agentRevisions?: AgentRevisionReader
   ) {
     this.bootedAtMs = clock.now()
+  }
+
+  /**
+   * Stamp every agent member with the CP's current spec revision. Presence is not
+   * freshness: a member that already holds an agent — installed under an earlier
+   * duty it has since lost, then edited while it was not a delivery target — must
+   * be able to tell a frozen replica from a current one and refetch only the
+   * frozen ones. An agent with no row (deleted under the projection, or a
+   * synthetic ref) is simply left unstamped.
+   */
+  private async stamp(entries: DutyGrantEntry[]): Promise<DutyGrantEntry[]> {
+    if (!this.agentRevisions || entries.length === 0) return entries
+    const agentIds = [
+      ...new Set(entries.flatMap((e) => e.members.filter((m) => m.kind === 'agent').map((m) => m.refId)))
+    ] as AgentId[]
+    if (agentIds.length === 0) return entries
+    const revisions = await this.agentRevisions.configRevisions(agentIds)
+    return entries.map((entry) => ({
+      ...entry,
+      members: entry.members.map((member) => {
+        const revision = member.kind === 'agent' ? revisions.get(member.refId) : undefined
+        return revision === undefined ? member : { ...member, configRevision: revision.toString() }
+      })
+    }))
   }
 
   /** Chain `fn` on the daemon's lane so operations never interleave. */
@@ -206,11 +237,11 @@ export class DutyLeaseService {
         'held duty groups grew past the grant member cap; superseded and vacated — move them to a dedicated tier'
       )
     }
-    const grants = [
+    const grants = await this.stamp([
       ...deliverable(missing).map(toGrantEntry),
       ...deliverable(stale).map(toGrantEntry),
       ...granted.map(toGrantEntry)
-    ]
+    ])
     for (const chunk of chunkGrants(grants, this.config.grantsPerFrame, this.config.grantMembersPerFrame)) {
       send('duty/grant', { grants: chunk })
     }
@@ -251,7 +282,8 @@ export class DutyLeaseService {
         await this.repo.release(holder, [claim.groupId])
         return { granted: false }
       }
-      return { granted: true, grant: toGrantEntry(group) }
+      const [grant] = await this.stamp([toGrantEntry(group)])
+      return { granted: true, grant }
     })
   }
 

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { HttpBotOrchestrator } from './httpBot.js'
+import { AgentDelivery } from './agentDelivery.js'
+import { systemClock } from '../domain/clock.js'
 import { RelayRegistry, type RelayChannel } from '../ws/relay-registry.js'
 import type { RcBotAssign, RelayCpFrameType } from '@agentconnect.md/protocol'
 import { AgentId, BotId, IntegrationId, OrgId } from '../domain/ids.js'
@@ -318,7 +320,10 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         },
         debug() {}
       },
-      platforms
+      platforms,
+      // No duty ledger wired ⇒ the delivery set is the placement alone, which is
+      // exactly what every expectation in this file was written against.
+      new AgentDelivery({ control: control as never, specs: undefined as never, clock: systemClock })
     )
   }
 

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -45,6 +45,7 @@ import type {
 import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 import { ControlSender, NoConnection } from './outbound.js'
 import { isGatedAgent, httpIntegrationToSpec } from './placement.js'
+import type { AgentDelivery } from './agentDelivery.js'
 import type { CpPlatformRegistry } from '../platforms/provider.js'
 import { AgentId, BotId, DaemonId } from '../domain/ids.js'
 
@@ -130,7 +131,11 @@ export class HttpBotOrchestrator {
      *  and demux bags, and (through `httpIntegrationToSpec`) of a send-only
      *  spec's payload. Late-bound in the composition root; every read happens at
      *  sync/replay time. */
-    private readonly platforms: CpPlatformRegistry
+    private readonly platforms: CpPlatformRegistry,
+    /** Resolves where a dependent of an agent goes (placement ∪ duty holders).
+     *  Used ONLY for the send-only spec and its removal — the relay's own
+     *  `rc/assign` target stays the placement, which is routing, not replication. */
+    private readonly agentDelivery: AgentDelivery
   ) {}
 
   /**
@@ -302,13 +307,11 @@ export class HttpBotOrchestrator {
     await this.unassign(bot, { credentialRevision: bot.credentialRevision })
     for (const integration of installs) {
       const agent = await this.agents.getUnscoped(integration.agentId)
-      if (!agent?.daemonId) continue
-      try {
-        await this.control.integrationRemove(agent.daemonId, { integrationId: integration.id })
-      } catch (err) {
+      if (!agent) continue
+      await this.agentDelivery.integrationRemove(agent.id, agent.daemonId, integration.id, (err) => {
         if (!(err instanceof NoConnection)) throw err
         this.log.debug?.({ integrationId: integration.id }, 'http-bot: revoke spec removal skipped — daemon offline')
-      }
+      })
     }
     this.log.info({ botId: bot.id, reason, installs: installs.length }, 'http-bot: bot revoked by workspace')
     return { applied: true }
@@ -868,16 +871,18 @@ export class HttpBotOrchestrator {
     // for the same backstop. The compile already read the bot's rows; they are keyed
     // per install, so filter by integrationId.
     for (const { integration, daemonId, gated } of compiled.placed) {
-      try {
-        const channels = compiled.botChannels.filter((c) => c.integrationId === integration.id)
-        await this.control.integrationUpsert(
-          daemonId,
-          await httpIntegrationToSpec(this.platforms, integration, bot, secret, channels, gated)
-        )
-      } catch (err) {
+      const channels = compiled.botChannels.filter((c) => c.integrationId === integration.id)
+      const spec = await httpIntegrationToSpec(this.platforms, integration, bot, secret, channels, gated)
+      // The relay still addresses ingress to `daemonId`; the send-only credential
+      // bundle goes to every daemon serving the agent, so a duty holder is not
+      // left signing egress with a credential the workspace has since rotated.
+      await this.agentDelivery.integrationUpsert(integration.agentId, daemonId, spec, (err, target) => {
         if (!(err instanceof NoConnection)) throw err
-        this.log.debug?.({ integrationId: integration.id, daemonId }, 'http-bot: spec push skipped — daemon offline')
-      }
+        this.log.debug?.(
+          { integrationId: integration.id, daemonId: target },
+          'http-bot: spec push skipped — daemon offline'
+        )
+      })
     }
   }
 

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -308,7 +308,7 @@ export class HttpBotOrchestrator {
     for (const integration of installs) {
       const agent = await this.agents.getUnscoped(integration.agentId)
       if (!agent) continue
-      await this.agentDelivery.integrationRemove(agent.id, agent.daemonId, integration.id, (err) => {
+      await this.agentDelivery.integrationRemove(agent.id, agent.daemonId, integration.id, integration.orgId, (err) => {
         if (!(err instanceof NoConnection)) throw err
         this.log.debug?.({ integrationId: integration.id }, 'http-bot: revoke spec removal skipped — daemon offline')
       })

--- a/packages/control-plane/src/orchestrator/integrationPush.ts
+++ b/packages/control-plane/src/orchestrator/integrationPush.ts
@@ -13,7 +13,8 @@ import type {
   IntegrationChannelRepo,
   IntegrationRepo
 } from '../persistence/ports.js'
-import { NoConnection, type ControlSender } from './outbound.js'
+import { NoConnection } from './outbound.js'
+import type { AgentDelivery } from './agentDelivery.js'
 import { integrationToSpec, isGatedAgent } from './placement.js'
 import type { CpPlatformRegistry } from '../platforms/provider.js'
 import { AgentId } from '../domain/ids.js'
@@ -25,7 +26,7 @@ export interface GatingPushDeps {
     botSecret: BotSecretStore
     integrationChannel: IntegrationChannelRepo
   }
-  control: ControlSender
+  agentDelivery: AgentDelivery
   httpBot: { syncBot(botId: string): Promise<void> }
   /** §9 platform providers — the projector behind the re-pushed spec's payload.
    *  `HttpDeps` already carries this field, so the caller passes its bundle
@@ -56,16 +57,19 @@ export async function convergeIntegrationGating(
       // integration→bot FK is non-null and `onDelete: Restrict` — but a spec
       // without it would be a fabricated identity, so skip like a missing secret.
       if (!bot) continue
-      if (!agent.daemonId) continue
       const [secret, channels] = await Promise.all([
         deps.repos.botSecret.get(i.orgId, i.botId),
         deps.repos.integrationChannel.listForIntegration(i.id)
       ])
       if (!secret) continue
-      await deps.control.integrationUpsert(
-        agent.daemonId,
-        await integrationToSpec(deps.platforms, i, bot, secret, channels, gated)
-      )
+      // Every daemon serving the agent, not just its placement: a gating flip that
+      // reaches only the placement leaves a holder admitting conversations the
+      // agent's new visibility forbids.
+      const spec = await integrationToSpec(deps.platforms, i, bot, secret, channels, gated)
+      await deps.agentDelivery.integrationUpsert(agent.id, agent.daemonId, spec, (err) => {
+        if (err instanceof NoConnection) return // offline daemon → reconcile roster carries it
+        throw err
+      })
     } catch (err) {
       if (err instanceof NoConnection) continue // offline daemon → reconcile roster carries it
       log?.warn({ integrationId: i.id, err: (err as Error).message }, 'gating converge: integration push failed')

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -394,10 +394,14 @@ export class ControlSender {
     c.conn.send('integration/upsert', u, { epoch: c.sessionEpoch, agentId: u.agentId })
   }
 
-  /** Tell a running daemon an integration was removed (live, epoch-fenced EVT). */
-  async integrationRemove(daemonId: string, r: IntegrationRemove): Promise<void> {
+  /** Tell a running daemon an integration was removed (live, epoch-fenced EVT).
+   *  Takes an explicit orgId for the same reason the agent frames do: the payload
+   *  is an id alone, so an install-wide connection has nothing to resolve the org
+   *  from — and a duty holder that acquired the integration through `duty/fetch`
+   *  never registered it, so the connection's id→org map has nothing either. */
+  async integrationRemove(daemonId: string, r: IntegrationRemove, orgId?: string): Promise<void> {
     const c = this.must(daemonId)
-    c.conn.send('integration/remove', r, { epoch: c.sessionEpoch })
+    c.conn.send('integration/remove', r, { epoch: c.sessionEpoch }, orgId)
   }
 
   /** Tell a daemon to stop REPORTING conversations an operator forgot (REQ → ack).
@@ -475,10 +479,12 @@ export class ControlSender {
     return c.conn.request<Ack>('cron/upsert', u, { epoch: c.sessionEpoch })
   }
 
-  /** Remove a cron from a running daemon (live CRUD, epoch-fenced REQ → ack, §5.4). */
-  async cronRemove(daemonId: string, r: CronRemove): Promise<Ack> {
+  /** Remove a cron from a running daemon (live CRUD, epoch-fenced REQ → ack, §5.4).
+   *  Explicit orgId for the same reason as `integrationRemove`: the payload is a
+   *  bare cronId, and a duty holder never registered the cron. */
+  async cronRemove(daemonId: string, r: CronRemove, orgId?: string): Promise<Ack> {
     const c = this.must(daemonId)
-    return c.conn.request<Ack>('cron/remove', r, { epoch: c.sessionEpoch })
+    return c.conn.request<Ack>('cron/remove', r, { epoch: c.sessionEpoch }, undefined, orgId)
   }
 
   /** Fire a cron immediately on its daemon (console "Run now"; REQ → ack — the

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -66,7 +66,7 @@ import type {
 import type { CpPlatformRegistry } from '../platforms/provider.js'
 import { mcpProxyDef, relayHttpOrigin } from './mcpProvider.js'
 import { memoryConnectionSpec, stdioMemoryConnectionSpec } from './memoryConnection.js'
-import type { DaemonId } from '../domain/ids.js'
+import type { AgentId, DaemonId } from '../domain/ids.js'
 import { AgentId as toAgentId, DaemonId as toDaemonId, IntegrationId as toIntegrationId } from '../domain/ids.js'
 import { sessionKeyStr, type SessionKey } from '../domain/sessionKey.js'
 import { toDbPlatform } from '../persistence/platform.js'
@@ -106,6 +106,9 @@ export interface PlacementOrchDeps {
     grants: ExternalMemoryGrantRepo
     relayRoster: RelayRosterView
   }
+  /** The duty ledger read that makes the reconcile roster `pinned-to-me ∪ agents
+   *  in the duties I hold`. Absent (tests / no pool) ⇒ placement alone. */
+  duties?: { heldAgentIds(holder: DaemonId, now: Date): Promise<AgentId[]> }
   /** Optional structured logger for reconcile-time skips (no live relay). */
   log?: { warn(obj: object, msg: string): void }
   // NOTE: icon URL bases moved into the AgentSpecAssembler (it owns spec assembly).
@@ -330,6 +333,14 @@ async function projectSpec(
   return { orgId: i.orgId, integrationId: i.id, agentId: i.agentId, platform: i.platform, core, config }
 }
 
+/** Union two roster halves by row id, keeping the first occurrence — the placement
+ *  half and the duty half legitimately overlap when a member holds what it hosts. */
+function dedupeById<T extends { id: string }>(first: readonly T[], second: readonly T[]): T[] {
+  const byId = new Map<string, T>()
+  for (const row of [...first, ...second]) if (!byId.has(row.id)) byId.set(row.id, row)
+  return [...byId.values()]
+}
+
 /** A session to re-home: its key + the agent/workspace that should own it. */
 function recordToSessionKey(a: AssignmentRecord): SessionKey {
   return {
@@ -368,6 +379,14 @@ export class Placement implements ReconcileService {
     return this.orch
   }
 
+  /** The agents this member currently holds a duty for. No ledger wired ⇒ none,
+   *  which is exactly the pre-duty roster. */
+  private async dutyHeldAgentIds(daemonId: DaemonId): Promise<AgentId[]> {
+    const duties = this.orch?.duties
+    if (!duties || !this.orch) return []
+    return duties.heldAgentIds(daemonId, new Date(this.orch.clock.now()))
+  }
+
   async reconcile(daemonId: DaemonId, req: RegisterReq): Promise<RegisterOk> {
     // Daemon trust domain: reconcile runs for the registering connection's own
     // daemon (org-scoped-data-layer.md §4).
@@ -377,13 +396,35 @@ export class Placement implements ReconcileService {
       throw new Error(`reconcile: unknown daemon ${daemonId}`)
     }
 
-    const [activeAssignments, ownedAgents, daemonCrons, activeLeases, activeIntegrations] = await Promise.all([
+    // The roster is `pinned-to-me ∪ agents in the duties I hold`. A duty grant is
+    // how a pool member comes to serve an agent it is not the placement of, and
+    // its install (`duty/fetch`) has to survive a reconnect: an agent absent from
+    // the desired set is a stale-replica candidate below and would be PRUNED,
+    // undoing the install. Its integrations and crons ride along for the same
+    // reason — a served group whose sockets the reconcile dropped serves nothing.
+    const heldAgentIds = await this.dutyHeldAgentIds(daemonId)
+    const [
+      activeAssignments,
+      placedAgents,
+      heldAgents,
+      daemonCrons,
+      heldCrons,
+      activeLeases,
+      daemonIntegrations,
+      heldIntegrations
+    ] = await Promise.all([
       this.assignments.activeForDaemon(daemonId),
       this.agents.listForDaemon(daemonId),
+      this.agents.listByIds(heldAgentIds),
       this.crons.listForDaemon(daemonId),
+      this.crons.listForAgents(heldAgentIds),
       this.leases.activeForDaemon(daemonId),
-      this.integrations.activeForDaemon(daemonId)
+      this.integrations.activeForDaemon(daemonId),
+      this.integrations.activeForAgents(heldAgentIds)
     ])
+    const ownedAgents = dedupeById(placedAgents, heldAgents)
+    const activeIntegrations = dedupeById(daemonIntegrations, heldIntegrations)
+    const ownedCrons = dedupeById(daemonCrons, heldCrons)
 
     const quarantinedAgentIds = new Set<string>()
     // Conversation gating (§14): derived per-agent from restricted visibility. This
@@ -421,8 +462,10 @@ export class Placement implements ReconcileService {
       )
     ])
 
-    // Integrations FILTERED to this daemon (via agent.daemonId) — each carries
-    // plaintext tokens, so this must never be the org-wide set. Tokens are pulled
+    // Integrations FILTERED to the agents this daemon serves (placed on it or held
+    // by it) — each carries plaintext tokens, so this must never be the org-wide
+    // set, and the duty half is exactly what the ledger says this member won.
+    // Tokens are pulled
     // from the secret store (the only decrypt/read seam); NEVER log this array.
     // ALL platforms belong in the roster (Slack + Telegram): the roster is the
     // backstop when the live integration/upsert was skipped (daemon offline) or
@@ -436,18 +479,17 @@ export class Placement implements ReconcileService {
     const desiredAssignments = activeAssignments
       .filter((assignment) => !quarantinedAgentIds.has(assignment.agentId))
       .map(assignmentToRoute)
-    // The agent-config replica for THIS daemon: only the agents placed on it
-    // (1 agent : 1 machine). A daemon never receives specs for agents owned by
-    // other machines. Unplaced agents (daemonId null) go to no daemon. The daemon
-    // converges its replica to this set (CP wins); live edits ride
-    // `agent/upsert`/`agent/remove`; this snapshot is the reconnect backstop.
+    // The agent-config replica for THIS daemon: the agents placed on it, plus the
+    // agents whose duty it holds. A daemon never receives specs for agents that
+    // are neither. Unplaced, unheld agents go to no daemon. The daemon converges
+    // its replica to this set (CP wins); live edits ride `agent/upsert`/
+    // `agent/remove` over the same union; this snapshot is the reconnect backstop.
     // The assembler owns secret loading + icon bases — same spec shape as the
     // live agent/upsert emit, structurally. Historical unsafe repository rows
     // are quarantined above without stranding the rest of this daemon's roster.
-    // Crons FILTERED to this daemon (via agent.daemonId) — a cron drives one
-    // agent, so its def lands only on that agent's daemon (same rule as
-    // integrations above). Orphaned rows map to null and are never pushed.
-    const desiredCrons = daemonCrons
+    // Crons scoped the same way — a cron drives one agent, so its def lands on the
+    // daemons that serve that agent. Orphaned rows map to null and are never pushed.
+    const desiredCrons = ownedCrons
       .map(cronToUpsert)
       .filter((cron): cron is CronUpsert => cron !== null && !quarantinedAgentIds.has(cron.agentId))
     const desiredLeases = activeLeases.map(leaseToGrant)
@@ -482,6 +524,12 @@ export class Placement implements ReconcileService {
     // belongs elsewhere (the backstop for moves missed while this daemon was
     // disconnected). New replicas carry origin=cp and can also converge a missed
     // delete after the durable row is gone.
+    // The desired sets are the UNION computed above, so a duty-held replica is
+    // never a candidate here at all — its CP row names another daemon, which is
+    // exactly the `record.daemonId !== daemonId` detach below. That is the whole
+    // pruning bug: subtracting from the placement-only set undid the install.
+    // An agent the ledger still names but whose row is gone stays a candidate and
+    // is removed on its own merits — a deleted agent must not keep being served.
     const desiredKeySet = new Set(desiredAssignments.map((a) => sessionKeyStr(a.sessionKey)))
     const desiredCronSet = new Set(desiredCrons.map((c) => c.cronId))
     const desiredAgentSet = new Set(desiredAgents.map((a) => a.agentId))

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -910,6 +910,12 @@ export interface AgentRepo {
   /** Agents placed on a specific daemon — the reconcile roster (`register/ok.agents`).
    *  A daemon only ever receives the specs of the agents it owns (1 agent : 1 machine). */
   listForDaemon(daemonId: DaemonId): Promise<AgentRecord[]>
+  /** Unscoped batch read by id — the duty half of the reconcile roster, whose
+   *  agents are named by the ledger rather than by placement. */
+  listByIds(agentIds: readonly AgentId[]): Promise<AgentRecord[]>
+  /** The current `configRevision` of each agent — the freshness signal stamped
+   *  onto a duty grant's agent members (orchestrator/dutyLease.ts). */
+  configRevisions(agentIds: readonly AgentId[]): Promise<Map<string, bigint>>
   /**
    * The org's PEER directory: every agent, with only the fields the collaboration
    * roster filter needs. This is the channel-free discovery/authorization input —
@@ -1976,6 +1982,9 @@ export interface CronRepo {
    *  (`register/ok.crons[]`, same scope rule as integrations §3.11).
    *  System-tier: daemon-fenced. */
   listForDaemon(daemonId: DaemonId): Promise<CronRecord[]>
+  /** The crons of these agents — the duty half of the reconcile roster, whose
+   *  agents are named by the ledger, not by placement. */
+  listForAgents(agentIds: readonly string[]): Promise<CronRecord[]>
   /** Org-fenced point read (§3): a cross-org id reads as absent, exactly like a
    *  missing row. Crons have no internal-trust-domain reader — the daemon-facing
    *  paths are `listForDaemon` and `recordReport`, both fenced by the daemon
@@ -3438,6 +3447,10 @@ export interface IntegrationRepo {
    * org-wide) since the delivered spec carries plaintext tokens.
    */
   activeForDaemon(daemonId: DaemonId): Promise<IntegrationRecord[]>
+  /** Active integrations of these agents — the duty half of the reconcile roster,
+   *  whose agents are named by the ledger, not by placement. Token-bearing once
+   *  projected, so callers pass only the agents that daemon is entitled to. */
+  activeForAgents(agentIds: readonly string[]): Promise<IntegrationRecord[]>
   /**
    * The agents present in a channel (agent-collaboration directory, §channel).
    * Joins the channel's active integrations to their agents, ACROSS all daemons
@@ -5066,4 +5079,13 @@ export interface DutyGroupRepo {
    *  agent? The authorization for `duty/fetch`: a member may pull exactly the
    *  agent definitions it has won, and nothing else. */
   holdsAgent(holder: DaemonId, agentId: AgentId, now: Date): Promise<boolean>
+  /** Every member currently holding an unexpired lease on a group covering this
+   *  agent — the delivery half of {@link DutyGroupRepo.holdsAgent}, so a live
+   *  update reaches whoever serves the agent rather than only where it is placed
+   *  (orchestrator/agentDelivery.ts). Deliberately membership-only: the agent row
+   *  may already be gone (a delete replicates AFTER the cascade). */
+  holdersOf(agentId: AgentId, now: Date): Promise<DaemonId[]>
+  /** Every agent covered by the unexpired leases `holder` holds — the duty half
+   *  of the `register/ok` reconcile roster, which is `pinned-to-me ∪ held-by-me`. */
+  heldAgentIds(holder: DaemonId, now: Date): Promise<AgentId[]>
 }

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -915,6 +915,25 @@ export class PgAgentRepo implements AgentRepo {
     return rows.map(toRecord)
   }
 
+  async listByIds(agentIds: readonly AgentId[]): Promise<AgentRecord[]> {
+    if (agentIds.length === 0) return []
+    const rows = await this.db.agent.findMany({
+      where: { id: { in: [...agentIds] } },
+      orderBy: { createdAt: 'asc' },
+      include: withUsers
+    })
+    return rows.map(toRecord)
+  }
+
+  async configRevisions(agentIds: readonly AgentId[]): Promise<Map<string, bigint>> {
+    if (agentIds.length === 0) return new Map()
+    const rows = await this.db.agent.findMany({
+      where: { id: { in: [...agentIds] } },
+      select: { id: true, configRevision: true }
+    })
+    return new Map(rows.map((r) => [r.id, r.configRevision]))
+  }
+
   async listForDaemon(daemonId: DaemonId): Promise<AgentRecord[]> {
     const rows = await this.db.agent.findMany({
       where: { daemonId },

--- a/packages/control-plane/src/persistence/repositories/cron.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/cron.repo.ts
@@ -190,6 +190,16 @@ export class PgCronRepo implements CronRepo {
     return rows.map(toRecord)
   }
 
+  async listForAgents(agentIds: readonly string[]): Promise<CronRecord[]> {
+    if (agentIds.length === 0) return []
+    const rows = await this.db.cronDef.findMany({
+      where: { agentId: { in: [...agentIds] } },
+      include: withUsers,
+      orderBy: { createdAt: 'asc' }
+    })
+    return rows.map(toRecord)
+  }
+
   async listForDaemon(daemonId: DaemonId): Promise<CronRecord[]> {
     // Via the agent relation: only crons whose owning agent is placed on this
     // daemon. Orphaned rows (agentId null) match no daemon — inert by design.

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -298,6 +298,29 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     return rows.length > 0
   }
 
+  async holdersOf(agentId: AgentId, now: Date): Promise<DaemonId[]> {
+    // Same unexpired-lease join as holdsAgent, read from the agent's side: an
+    // update must reach every member actually serving it. Membership survives an
+    // agent delete (no FK), so `agent/remove` still finds the holder.
+    const rows = await this.prisma.$queryRaw<{ holder: string }[]>(Prisma.sql`
+      SELECT DISTINCT g."holder" AS holder FROM "duty_group_member" m
+      JOIN "duty_group" g ON g.id = m."groupId"
+      WHERE m."kind" = 'agent' AND m."refId" = ${agentId}
+        AND g."holder" IS NOT NULL AND g."expiresAt" IS NOT NULL AND g."expiresAt" > ${now}
+    `)
+    return rows.map((r) => r.holder as DaemonId).sort()
+  }
+
+  async heldAgentIds(holder: DaemonId, now: Date): Promise<AgentId[]> {
+    const rows = await this.prisma.$queryRaw<{ refId: string }[]>(Prisma.sql`
+      SELECT DISTINCT m."refId" FROM "duty_group_member" m
+      JOIN "duty_group" g ON g.id = m."groupId"
+      WHERE m."kind" = 'agent'
+        AND g."holder" = ${holder}::uuid AND g."expiresAt" IS NOT NULL AND g."expiresAt" > ${now}
+    `)
+    return rows.map((r) => r.refId as AgentId).sort()
+  }
+
   async claimAgentHome(
     orgId: OrgId,
     agentId: AgentId,

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -538,6 +538,16 @@ export class PgIntegrationRepo implements IntegrationRepo {
     return rows.map(toRecord)
   }
 
+  // The duty half of that roster: the ledger names the agents, not the placement.
+  async activeForAgents(agentIds: readonly string[]): Promise<IntegrationRecord[]> {
+    if (agentIds.length === 0) return []
+    const rows = await this.db.integration.findMany({
+      where: { status: 'active', agentId: { in: [...agentIds] } },
+      orderBy: { createdAt: 'asc' }
+    })
+    return rows.map(toRecord)
+  }
+
   // Agent-collaboration directory: agents present in a channel, ACROSS all daemons
   // (the CP is the only authority for the full roster). Join the channel's active
   // integrations to their agents; dedupe by agent (an agent may reach a channel via

--- a/packages/control-plane/src/platforms/feishu/provider.test.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.test.ts
@@ -26,6 +26,8 @@ import {
 } from './provider.js'
 import { integrationToSpec, httpIntegrationToSpec } from '../../orchestrator/placement.js'
 import { HttpBotOrchestrator } from '../../orchestrator/httpBot.js'
+import { AgentDelivery } from '../../orchestrator/agentDelivery.js'
+import { systemClock as clock } from '../../domain/clock.js'
 import { RelayRegistry, type RelayChannel } from '../../ws/relay-registry.js'
 import { buildCreateIntegrationBody } from '../../http/dto/create-integration-body.js'
 import { buildCpPlatformRegistry } from '../registry.js'
@@ -550,7 +552,9 @@ async function liveAssignFrame(botRow: BotRecord, secret: BotSecretMaterial): Pr
     { upsert: async () => {}, get: async () => null, listForBot: async () => [] } as unknown as ThreadAffinityStore,
     { findThreadOwner: async () => null } as unknown as SessionRepo,
     { info() {}, warn() {}, debug() {} },
-    PLATFORMS
+    PLATFORMS,
+    // No duty ledger ⇒ the spec goes to the placement alone, as this fixture expects.
+    new AgentDelivery({ control: { integrationUpsert: async () => {} } as never, specs: undefined as never, clock })
   )
   await orch.syncBot(botRow.id)
   const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign | undefined

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -28,6 +28,8 @@ import {
 import { integrationToSpec, httpIntegrationToSpec } from '../../orchestrator/placement.js'
 import { SLACK_BOT_SCOPES } from '../../http/slack-manifest.js'
 import { HttpBotOrchestrator } from '../../orchestrator/httpBot.js'
+import { AgentDelivery } from '../../orchestrator/agentDelivery.js'
+import { systemClock as clock } from '../../domain/clock.js'
 import { RelayRegistry, type RelayChannel } from '../../ws/relay-registry.js'
 import { buildCreateIntegrationBody } from '../../http/dto/create-integration-body.js'
 import { buildCpPlatformRegistry } from '../registry.js'
@@ -643,7 +645,9 @@ async function liveAssignFrame(botRow: BotRecord, secret: BotSecretMaterial): Pr
     { upsert: async () => {}, get: async () => null, listForBot: async () => [] } as unknown as ThreadAffinityStore,
     { findThreadOwner: async () => null } as unknown as SessionRepo,
     { info() {}, warn() {}, debug() {} },
-    PLATFORMS
+    PLATFORMS,
+    // No duty ledger ⇒ the spec goes to the placement alone, as this fixture expects.
+    new AgentDelivery({ control: { integrationUpsert: async () => {} } as never, specs: undefined as never, clock })
   )
   await orch.syncBot(botRow.id)
   const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign | undefined

--- a/packages/control-plane/src/ws/handlers/duty-fetch.test.ts
+++ b/packages/control-plane/src/ws/handlers/duty-fetch.test.ts
@@ -20,6 +20,7 @@ const BUNDLE = {
   spec: { orgId: ORG, name: 'scout', runtime: 'claude' },
   integrations: [
     {
+      orgId: ORG,
       integrationId: INTEGRATION,
       agentId: AGENT,
       platform: 'slack',
@@ -27,7 +28,17 @@ const BUNDLE = {
       config: { botToken: 'xoxb-test' }
     }
   ],
-  crons: [{ cronId: CRON, agentId: AGENT, schedule: '0 9 * * *', timezone: 'UTC', trigger: 'standup', enabled: true }]
+  crons: [
+    {
+      orgId: ORG,
+      cronId: CRON,
+      agentId: AGENT,
+      schedule: '0 9 * * *',
+      timezone: 'UTC',
+      trigger: 'standup',
+      enabled: true
+    }
+  ]
 }
 
 function fetchFrame(agentId = AGENT): AnyFrame {
@@ -50,14 +61,24 @@ function fakeConn(orgId: string | null = null) {
   } as unknown as DaemonConnection & { replyTo: ReturnType<typeof vi.fn>; sendError: ReturnType<typeof vi.fn> }
 }
 
-function fakeDeps(over: {
-  agent?: unknown
-  holdsAgent?: boolean
-  agentBundle?: ReturnType<typeof vi.fn>
-}): DaemonWsDeps {
+/** The per-connection id→org maps `register` normally builds. A duty holder that
+ *  installed mid-session never registered these resources, so they start empty. */
+function fakeScopes() {
+  return { orgByAgent: new Map<string, string>(), orgByIntegration: new Map(), orgByCron: new Map() }
+}
+
+function fakeDeps(
+  over: {
+    agent?: unknown
+    holdsAgent?: boolean
+    agentBundle?: ReturnType<typeof vi.fn>
+  },
+  scopes = fakeScopes()
+): DaemonWsDeps {
   return {
     agent: { getUnscoped: async () => over.agent ?? null },
     dutyLease: { holdsAgent: async () => over.holdsAgent ?? false },
+    connReg: { get: () => scopes },
     agentBundle: over.agentBundle ?? vi.fn(async () => BUNDLE)
   } as unknown as DaemonWsDeps
 }
@@ -113,6 +134,33 @@ describe('handleDutyFetch', () => {
     expect(agentBundle).toHaveBeenCalledWith(AGENT_RECORD)
     expect(conn.replyTo).toHaveBeenCalledWith(frame, 'duty/fetch/ok', { bundle: BUNDLE })
     expect(conn.sendError).not.toHaveBeenCalled()
+  })
+
+  it('teaches the connection which org the fetched resources belong to', async () => {
+    // The id→org maps are otherwise built ONLY from the register snapshot, so a
+    // resource installed mid-session through this path is absent from them — and
+    // any later C→D frame carrying a bare id has no org to resolve on an
+    // install-wide connection. A hint, never an authorization: holding the duty
+    // is what authorizes, and the removals carry their org explicitly anyway.
+    const scopes = fakeScopes()
+    const conn = fakeConn()
+
+    await handleDutyFetch(fetchFrame(), conn, fakeDeps({ agent: AGENT_RECORD, holdsAgent: true }, scopes))
+
+    expect(scopes.orgByAgent.get(AGENT)).toBe(ORG)
+    expect(scopes.orgByIntegration.get(INTEGRATION)).toBe(ORG)
+    expect(scopes.orgByCron.get(CRON)).toBe(ORG)
+  })
+
+  it('a refused fetch teaches the connection nothing', async () => {
+    const scopes = fakeScopes()
+    const conn = fakeConn()
+
+    await handleDutyFetch(fetchFrame(), conn, fakeDeps({ agent: AGENT_RECORD, holdsAgent: false }, scopes))
+
+    expect(scopes.orgByAgent.size).toBe(0)
+    expect(scopes.orgByIntegration.size).toBe(0)
+    expect(scopes.orgByCron.size).toBe(0)
   })
 
   it('answers empty when no bundle assembler is wired', async () => {

--- a/packages/control-plane/src/ws/handlers/duty-fetch.ts
+++ b/packages/control-plane/src/ws/handlers/duty-fetch.ts
@@ -3,8 +3,9 @@
 // agent's complete definition here, so grants stay thin and a member asks only
 // for what it lacks. Holding the duty IS the authorization: the CP answers only
 // for an agent this daemon currently holds an unexpired lease on.
-import { isFrame } from '@agentconnect.md/protocol'
+import { isFrame, type DutyAgentBundle } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId } from '../../domain/ids.js'
+import type { DaemonWsDeps } from '../deps.js'
 import type { Handler } from './index.js'
 
 export const handleDutyFetch: Handler = async (frame, conn, deps) => {
@@ -27,5 +28,34 @@ export const handleDutyFetch: Handler = async (frame, conn, deps) => {
     conn.replyTo(frame, 'duty/fetch/ok', {})
     return
   }
-  conn.replyTo(frame, 'duty/fetch/ok', { bundle: await deps.agentBundle(agent) })
+  const bundle = await deps.agentBundle(agent)
+  rememberScopes(conn.daemonId, deps, bundle)
+  conn.replyTo(frame, 'duty/fetch/ok', { bundle })
+}
+
+/**
+ * Teach this connection which org the fetched resources belong to.
+ *
+ * The id→org maps are otherwise built ONLY from the `register` reconcile
+ * snapshot, so a resource a member acquires mid-session through `duty/fetch` is
+ * absent from them until its next reconnect. Any later C→D frame whose payload
+ * carries a bare id — a session/workspace/memory read keyed on `agentId`,
+ * `cron/run`, `integration/forget` — then has no org to resolve on an
+ * install-wide connection and raises SCOPE_DENIED before it is sent.
+ *
+ * This is a scoping HINT, never an authorization: holding the duty is what
+ * authorizes, and a frame for a resource the member declined to install still
+ * fails on the member. Recording it optimistically is therefore safe, and it
+ * also lets the inbound gate cross-check the org the member claims.
+ *
+ * The removal frames do NOT rely on this — they carry an explicit org, which is
+ * authoritative and local to the send. This only covers the frames that cannot.
+ */
+function rememberScopes(daemonId: string, deps: DaemonWsDeps, bundle: DutyAgentBundle): void {
+  const state = deps.connReg.get(daemonId)
+  if (!state) return
+  const orgId = bundle.spec.orgId
+  if (orgId) state.orgByAgent?.set(bundle.agentId, orgId)
+  for (const i of bundle.integrations) if (i.orgId) state.orgByIntegration?.set(i.integrationId, i.orgId)
+  for (const c of bundle.crons) if (c.orgId) state.orgByCron?.set(c.cronId, c.orgId)
 }

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -60,7 +60,8 @@ import {
   PgThreadAffinityStore,
   PgSlackUserConfigStore,
   PgPresetAgentStore,
-  PgIntegrationChannelRepo
+  PgIntegrationChannelRepo,
+  PgDutyGroupRepo
 } from '../../src/persistence/index.js'
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import { runWithSharedTx, withSharedTxRouting } from '../../src/persistence/ambient-tx.js'
@@ -78,6 +79,7 @@ import { WaitlistService } from '../../src/registry/waitlistService.js'
 import { EpochService } from '../../src/orchestrator/epoch.js'
 import { DUTY_LEASE_DEFAULTS } from '../../src/orchestrator/dutyLease.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
+import { AgentDelivery } from '../../src/orchestrator/agentDelivery.js'
 import { RelayControlSender } from '../../src/orchestrator/relayControl.js'
 import { HttpBotOrchestrator } from '../../src/orchestrator/httpBot.js'
 import { CollabRoutesService } from '../../src/orchestrator/collabRoutes.service.js'
@@ -236,6 +238,8 @@ export function buildHttpApp(
   const connReg = new ConnectionRegistry()
   const sender = control ?? new ControlSender(connReg, new PgLaunchRepo(prisma))
 
+  const dutyGroupRepo = new PgDutyGroupRepo(prisma)
+
   const cipher = new PlaintextSecretCipher()
   const agentSecretStore = new PgAgentSecretStore(prisma, cipher)
   const integrationRepo = new PgIntegrationRepo(prisma)
@@ -289,6 +293,18 @@ export function buildHttpApp(
       isCuratedTool: (toolName) => findTool(toolName) !== undefined
     })
   const internalInvocationAuth = depsOverrides?.internalInvocationAuth ?? new InternalInvocationAuth()
+
+  const agentSpecs = new AgentSpecAssembler(
+    agentSecretStore,
+    {},
+    skillSourceRepo,
+    organizationKnowledgeRepo,
+    undefined,
+    organizationEnvironmentResolver
+  )
+  // Same graph as prod: every replicate site resolves its targets here, so the
+  // duty ledger is a real repo and a holder actually receives the pushes.
+  const agentDelivery = new AgentDelivery({ control: sender, specs: agentSpecs, duties: dutyGroupRepo, clock })
 
   // LATE-BOUND exactly as `buildContainer` binds it (§9): the providers below are
   // constructed WITH this dep bundle, because their funnel plugins are route
@@ -386,19 +402,13 @@ export function buildHttpApp(
     },
     registry: new DaemonRegistryService(daemonRepo, new PgRuntimeProfileRepo(prisma), daemonLifecycleOpRepo, clock),
     platforms,
-    agentSpecs: new AgentSpecAssembler(
-      agentSecretStore,
-      {},
-      skillSourceRepo,
-      organizationKnowledgeRepo,
-      undefined,
-      organizationEnvironmentResolver
-    ),
+    agentSpecs,
     liveness,
     // Capability reads share the liveness fake: a test that needs a capable
     // daemon overrides `liveness` with one whose entries carry `capabilities`.
     daemonConns: liveness as HttpDeps['daemonConns'],
     control: sender,
+    agentDelivery,
     relayControl,
     httpBot: new HttpBotOrchestrator(
       botRepo,

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -422,7 +422,8 @@ export function buildHttpApp(
       new PgThreadAffinityStore(prisma),
       new PgSessionRepo(prisma),
       { info() {}, warn() {}, debug() {} },
-      platforms
+      platforms,
+      agentDelivery
     ),
     collabRoutes: new CollabRoutesService(daemonRepo, integrationRepo, agentRepo, relayControl, sender),
     agentMutations: new AgentMutationGate(),

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -163,6 +163,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     sender
   )
   const relays = opts.relays ?? []
+  const dutyGroupRepo = new PgDutyGroupRepo(prisma)
   const orchestrator = new Placement(
     repos.daemon,
     repos.agent,
@@ -190,21 +191,28 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
         secrets: repos.externalMemoryConnectionSecret,
         grants: repos.externalMemoryGrant,
         relayRoster: { entries: async () => relays }
-      }
+      },
+      duties: dutyGroupRepo
     }
   )
 
-  const dutyLease = new DutyLeaseService(new PgDutyGroupRepo(prisma), clock, {
-    leaseMs: dutyLeaseMs,
-    recoveryGraceMs: opts.dutyLease?.recoveryGraceMs ?? 0,
-    grantMaxPerTick: opts.dutyLease?.grantMaxPerTick ?? 32,
-    grantsPerFrame: opts.dutyLease?.grantsPerFrame ?? 50,
-    grantMembersPerFrame: opts.dutyLease?.grantMembersPerFrame ?? 2000,
-    revocationsPerFrame: opts.dutyLease?.revocationsPerFrame ?? 500,
-    // Wire tests use synthetic member refs with no agent rows; the incumbent
-    // policy is exercised by its own repo tests against real placements.
-    grantPolicy: opts.dutyLease?.grantPolicy ?? 'any'
-  })
+  const dutyLease = new DutyLeaseService(
+    dutyGroupRepo,
+    clock,
+    {
+      leaseMs: dutyLeaseMs,
+      recoveryGraceMs: opts.dutyLease?.recoveryGraceMs ?? 0,
+      grantMaxPerTick: opts.dutyLease?.grantMaxPerTick ?? 32,
+      grantsPerFrame: opts.dutyLease?.grantsPerFrame ?? 50,
+      grantMembersPerFrame: opts.dutyLease?.grantMembersPerFrame ?? 2000,
+      revocationsPerFrame: opts.dutyLease?.revocationsPerFrame ?? 500,
+      // Wire tests use synthetic member refs with no agent rows; the incumbent
+      // policy is exercised by its own repo tests against real placements.
+      grantPolicy: opts.dutyLease?.grantPolicy ?? 'any'
+    },
+    undefined,
+    repos.agent
+  )
 
   const deps: DaemonWsDeps = {
     auth,

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -83,6 +83,29 @@ export async function seedAgent(
   return AgentId(id)
 }
 
+/** A held duty group covering `agentIds`. The lease is live by default — an
+ *  expired one is how a test states "this member no longer serves it". */
+export async function seedDutyGroup(
+  prisma: PrismaClient,
+  groupId: string,
+  holder: string,
+  agentIds: string[],
+  opts: { expiresAt?: Date; term?: bigint } = {}
+): Promise<void> {
+  await prisma.dutyGroup.create({
+    data: {
+      id: groupId,
+      orgId: DEFAULT_ORG_ID,
+      holder,
+      term: opts.term ?? 1n,
+      expiresAt: opts.expiresAt ?? new Date(Date.now() + 120_000)
+    }
+  })
+  await prisma.dutyGroupMember.createMany({
+    data: agentIds.map((refId) => ({ kind: 'agent' as const, refId, groupId, orgId: DEFAULT_ORG_ID }))
+  })
+}
+
 /** A converged session milestone row. `visibility`/`ownerIdentity` default to
  *  what ingest records for a channel session (session-visibility.md §4.2). */
 export async function seedSessionMeta(

--- a/packages/control-plane/test/integration/agents.replication.route.test.ts
+++ b/packages/control-plane/test/integration/agents.replication.route.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender, NoConnection } from '../../src/orchestrator/outbound.js'
 import type { AgentUpsert, AgentRemove, CollabRoutesSnapshot } from '@agentconnect.md/protocol'
@@ -470,5 +470,105 @@ describe('agent MCP enable-list → daemon proxy-def push (REST → mcpserver/up
     expect(disable.statusCode).toBe(200)
     expect(spy.mcpRemoves).toEqual([{ daemonId: DAEMON, orgId: DEFAULT_ORG_ID, name: 'fakemcp' }])
     expect(spy.mcpUpserts).toHaveLength(1) // no further upsert on disable
+  })
+})
+
+/**
+ * Delivery follows the DUTY HOLDER, not just the placement (#973). A pool member
+ * that wins a duty for an agent it is not the placement of installs one bundle
+ * (`duty/fetch`) and — before this — served it frozen, because every replicate
+ * site resolved its target from `agent.daemonId`. The delivery set is now
+ * `placement ∪ current holders`, resolved in ONE seam (orchestrator/agentDelivery.ts).
+ */
+describe('agent updates follow the duty holder', () => {
+  const HOLDER = 'd1111111-1111-4111-8111-111111111111'
+  const GROUP = '00000000-0000-4000-8000-0000000009a1'
+
+  it('a spec edit reaches a holder that is NOT the placement', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, HOLDER)
+    const agentId = randomUUID()
+    // Placed nowhere: the ONLY reason this agent reaches a daemon is the duty.
+    await seedAgent(prisma, agentId)
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+    const { app, spy } = withSpy()
+
+    const patch = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { description: 'You triage alerts.' }
+    })
+    expect(patch.statusCode).toBe(200)
+
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([HOLDER])
+    expect(spy.upserts[0]!.u.spec).toMatchObject({ description: 'You triage alerts.' })
+  })
+
+  it('an EXPIRED lease is not a holding — the update goes nowhere', async () => {
+    await seedDaemon(prisma, HOLDER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId], { expiresAt: new Date(Date.now() - 1000) })
+    const { app, spy } = withSpy()
+
+    const patch = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { description: 'stale' }
+    })
+    expect(patch.statusCode).toBe(200)
+    expect(spy.upserts).toHaveLength(0)
+  })
+
+  it('agent/remove reaches the holder, so a deleted agent stops being served', async () => {
+    await seedDaemon(prisma, HOLDER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+    const { app, spy } = withSpy()
+
+    const del = await app.app.inject({ method: 'DELETE', url: `${ORG}/agents/${agentId}` })
+    expect(del.statusCode).toBe(204)
+
+    // Duty membership has no FK to the agent row, so the holder is still
+    // resolvable AFTER the cascade — which is what makes this reachable at all.
+    expect(spy.removes).toEqual([{ daemonId: HOLDER, r: { agentId } }])
+  })
+
+  it('a placement AND a different holder each get the update exactly once', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, HOLDER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+    const { app, spy } = withSpy()
+
+    const patch = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { description: 'both' }
+    })
+    expect(patch.statusCode).toBe(200)
+
+    // Placement first, holder second, no duplicate — and ONE assembled spec, so
+    // the two replicas cannot disagree about what revision they applied.
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([DAEMON, HOLDER])
+    expect(spy.upserts[0]!.u.spec).toEqual(spy.upserts[1]!.u.spec)
+  })
+
+  it('the placement holding its own agent is one target, not two', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    await seedDutyGroup(prisma, GROUP, DAEMON, [agentId])
+    const { app, spy } = withSpy()
+
+    const patch = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { description: 'incumbent' }
+    })
+    expect(patch.statusCode).toBe(200)
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([DAEMON])
   })
 })

--- a/packages/control-plane/test/integration/crons.route.test.ts
+++ b/packages/control-plane/test/integration/crons.route.test.ts
@@ -15,7 +15,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import type { ControlSender } from '../../src/orchestrator/outbound.js'
 import type { CronUpsert, CronRemove } from '@agentconnect.md/protocol'
@@ -395,5 +395,77 @@ describe('cron replication CP→daemon (REST → cron/upsert·remove)', () => {
       expect((rows[0]!.details as { cronId: string }).cronId).toBe(cronId)
       expect(rows[0]!.agentId).toBe(agentId)
     })
+  })
+})
+
+/**
+ * A cron follows the DUTY HOLDER too (#973): it drives the agent, so it belongs
+ * wherever the agent is served. A holder left on a stale schedule (or still
+ * holding one the operator deleted) fires the wrong work, and a cron mutation
+ * does not advance `Agent.configRevision`, so nothing makes it refetch either.
+ */
+describe('cron updates follow the duty holder', () => {
+  const HOLDER = 'd8888888-8888-4888-8888-888888888888'
+  const GROUP = '00000000-0000-4000-8000-0000000009c1'
+
+  it('a cron upsert reaches a holder that is NOT the placement, carrying the new schedule', async () => {
+    await seedDaemon(prisma, HOLDER)
+    const agentId = randomUUID()
+    // Placed nowhere: the duty is the only reason this cron reaches a daemon.
+    await seedAgent(prisma, agentId)
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+    const cronId = randomUUID()
+    const { app, spy } = withSpy()
+
+    const put = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/crons/${cronId}`,
+      payload: body(agentId, { schedule: '30 6 * * *' })
+    })
+    expect(put.statusCode).toBe(200)
+
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([HOLDER])
+    // Current without a reconnect: the definition that arrived is the edited one.
+    expect(spy.upserts[0]!.u).toMatchObject({ cronId, agentId, schedule: '30 6 * * *' })
+  })
+
+  it('a cron removal reaches the holder', async () => {
+    await seedDaemon(prisma, HOLDER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+    const cronId = randomUUID()
+    const { app, spy } = withSpy()
+
+    await app.app.inject({ method: 'PUT', url: `${ORG}/crons/${cronId}`, payload: body(agentId) })
+    const del = await app.app.inject({ method: 'DELETE', url: `${ORG}/crons/${cronId}` })
+    expect(del.statusCode).toBe(204)
+
+    expect(spy.removes).toEqual([{ daemonId: HOLDER, r: { cronId } }])
+  })
+
+  it('a placement AND a holder each get the cron exactly once', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, HOLDER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+    const { app, spy } = withSpy()
+
+    await app.app.inject({ method: 'PUT', url: `${ORG}/crons/${randomUUID()}`, payload: body(agentId) })
+
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([DAEMON, HOLDER])
+  })
+
+  it('an EXPIRED lease is not a holding — the cron goes nowhere', async () => {
+    await seedDaemon(prisma, HOLDER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId], { expiresAt: new Date(Date.now() - 1000) })
+    const { app, spy } = withSpy()
+
+    await app.app.inject({ method: 'PUT', url: `${ORG}/crons/${randomUUID()}`, payload: body(agentId) })
+
+    expect(spy.upserts).toHaveLength(0)
   })
 })

--- a/packages/control-plane/test/integration/crons.route.test.ts
+++ b/packages/control-plane/test/integration/crons.route.test.ts
@@ -34,13 +34,15 @@ afterEach(async () => {
 /** A ControlSender spy recording the cron pushes the route makes. */
 class SpyControl {
   readonly upserts: Array<{ daemonId: string; u: CronUpsert }> = []
-  readonly removes: Array<{ daemonId: string; r: CronRemove }> = []
+  readonly removes: Array<{ daemonId: string; r: CronRemove; orgId?: string }> = []
   async cronUpsert(daemonId: string, u: CronUpsert): Promise<{ ok: boolean }> {
     this.upserts.push({ daemonId, u })
     return { ok: true }
   }
-  async cronRemove(daemonId: string, r: CronRemove): Promise<{ ok: boolean }> {
-    this.removes.push({ daemonId, r })
+  // `orgId` is recorded because a removal payload is a bare cronId: the send
+  // cannot derive an org on an install-wide connection, so dropping it is the bug.
+  async cronRemove(daemonId: string, r: CronRemove, orgId?: string): Promise<{ ok: boolean }> {
+    this.removes.push({ daemonId, r, orgId })
     return { ok: true }
   }
   // POST /integrations (used to seed a target integration) pushes these too.
@@ -272,7 +274,9 @@ describe('cron replication CP→daemon (REST → cron/upsert·remove)', () => {
     await app.app.inject({ method: 'PUT', url: `${ORG}/crons/${cronId}`, payload: body(agentId) })
     const del = await app.app.inject({ method: 'DELETE', url: `${ORG}/crons/${cronId}` })
     expect(del.statusCode).toBe(204)
-    expect(spy.removes).toEqual([{ daemonId: DAEMON, r: { cronId } }])
+    // The org rides every removal now: the payload is a bare cronId, so the send
+    // has nothing else to scope on when the connection is install-wide.
+    expect(spy.removes).toEqual([{ daemonId: DAEMON, r: { cronId }, orgId: DEFAULT_ORG_ID }])
 
     expect((await app.app.inject({ method: 'DELETE', url: `${ORG}/crons/${cronId}` })).statusCode).toBe(404)
   })
@@ -427,6 +431,10 @@ describe('cron updates follow the duty holder', () => {
     expect(spy.upserts.map((u) => u.daemonId)).toEqual([HOLDER])
     // Current without a reconnect: the definition that arrived is the edited one.
     expect(spy.upserts[0]!.u).toMatchObject({ cronId, agentId, schedule: '30 6 * * *' })
+    // `CronUpsert.orgId` is OPTIONAL on the wire, so the guarantee is that
+    // `cronToUpsert` always stamps the row's org. Pin it: a producer that omits
+    // it hands the upsert path exactly the removal bug.
+    expect(spy.upserts[0]!.u.orgId).toBe(DEFAULT_ORG_ID)
   })
 
   it('a cron removal reaches the holder', async () => {
@@ -441,7 +449,11 @@ describe('cron updates follow the duty holder', () => {
     const del = await app.app.inject({ method: 'DELETE', url: `${ORG}/crons/${cronId}` })
     expect(del.statusCode).toBe(204)
 
-    expect(spy.removes).toEqual([{ daemonId: HOLDER, r: { cronId } }])
+    // The org is the assertion, not an incidental: `cron/remove` carries only a
+    // cronId, and this holder never registered the cron (it would have arrived
+    // through `duty/fetch`), so a send without the org is SCOPE_DENIED before it
+    // leaves the process — the daemon would keep firing a deleted schedule.
+    expect(spy.removes).toEqual([{ daemonId: HOLDER, r: { cronId }, orgId: DEFAULT_ORG_ID }])
   })
 
   it('a placement AND a holder each get the cron exactly once', async () => {

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -14,7 +14,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import type { IntegrationUpsert, IntegrationRemove } from '@agentconnect.md/protocol'
@@ -1616,5 +1616,122 @@ describe('bot sharing capability (PATCH /bots/:id)', () => {
 
     expect(res.statusCode).toBe(400)
     expect(res.json()).toMatchObject({ message: 'multi-agent bots currently support Slack only' })
+  })
+})
+
+/**
+ * A dependent follows the DUTY HOLDER too (#973). `AgentDelivery` owns the agent
+ * frames; an integration spec is token-bearing and its bindRules are what the
+ * daemon admits on, so a holder that never receives the push keeps stale
+ * credentials and stale routing until it happens to reconnect — the same
+ * frozen-bundle failure one level down. These mutations do not advance
+ * `Agent.configRevision` either, so the grant-time freshness stamp gives the
+ * holder no reason to refetch: the live push IS the only in-session repair.
+ */
+describe('integration updates follow the duty holder', () => {
+  const HOLDER = 'd7777777-7777-4777-8777-777777777777'
+  const GROUP = '00000000-0000-4000-8000-0000000009b1'
+
+  /** A placed agent with a Slack install, plus a live duty held by HOLDER. */
+  async function installedWithHolder(): Promise<{ agentId: string; integrationId: string; app: HttpApp }> {
+    const agentId = await placedAgent()
+    await seedDaemon(prisma, HOLDER, { capabilities: daemonCapabilities(ALL_BOT_PLATFORMS) })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+    const { app } = withSpy()
+    const created = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { name: 'held-bot', platform: 'slack', agentId, slack: SLACK }
+    })
+    expect(created.statusCode).toBe(201)
+    return { agentId, integrationId: (created.json() as { id: string }).id, app }
+  }
+
+  it('the install push reaches the holder as well as the placement — with the credential', async () => {
+    const agentId = await placedAgent()
+    await seedDaemon(prisma, HOLDER, { capabilities: daemonCapabilities(ALL_BOT_PLATFORMS) })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+    const { app, spy } = withSpy()
+
+    const created = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { name: 'held-bot', platform: 'slack', agentId, slack: SLACK }
+    })
+    expect(created.statusCode).toBe(201)
+
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([DAEMON, HOLDER])
+    // A credential that reaches only the placement is the worst of the three:
+    // the holder would go on authenticating with whatever it last saw.
+    expect(JSON.stringify(spy.upserts.at(-1)!.u)).toContain(SLACK.botToken)
+  })
+
+  it('a bindRules change reaches the holder, and the holder is current WITHOUT a reconnect', async () => {
+    const { integrationId, app } = await installedWithHolder()
+    const spy = app.deps.control as unknown as SpyControl
+    await prisma.integrationChannel.create({
+      data: { integrationId, channelId: 'C900', kind: 'channel', trigger: 'mention' }
+    })
+    spy.upserts.length = 0
+
+    const patched = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${integrationId}/channels/C900`,
+      payload: { trigger: 'any' }
+    })
+    expect(patched.statusCode).toBe(200)
+
+    // Arrival is not enough — the pinning assertion is that what ARRIVED is the
+    // new routing. No register/reconcile ran anywhere in this test.
+    const held = spy.upserts.find((u) => u.daemonId === HOLDER)
+    expect(held).toBeDefined()
+    expect(held!.u.core.bindRules).toContainEqual({ channel: 'C900', match: { kind: 'auto' } })
+  })
+
+  it('an integration removal reaches the holder', async () => {
+    const { integrationId, app } = await installedWithHolder()
+    const spy = app.deps.control as unknown as SpyControl
+
+    const deleted = await app.app.inject({ method: 'DELETE', url: `${ORG}/integrations/${integrationId}` })
+    expect(deleted.statusCode).toBe(204)
+
+    expect(spy.removes.map((r) => r.daemonId)).toEqual([DAEMON, HOLDER])
+    expect(spy.removes.every((r) => r.r.integrationId === integrationId)).toBe(true)
+  })
+
+  it('a gating flip re-pushes the derived spec to the holder', async () => {
+    const { agentId, app } = await installedWithHolder()
+    const spy = app.deps.control as unknown as SpyControl
+    spy.upserts.length = 0
+
+    // Visibility drives the derived conversation-gating flag; the converge path
+    // (orchestrator/integrationPush.ts) re-pushes every integration of the agent.
+    const shared = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/sharing`,
+      payload: { visibility: 'restricted', sharedWith: [DEFAULT_OWNER_ID] }
+    })
+    expect(shared.statusCode).toBe(200)
+
+    const held = spy.upserts.find((u) => u.daemonId === HOLDER)
+    expect(held).toBeDefined()
+    // A holder still admitting on the ungated defaults would serve conversations
+    // the agent's new visibility forbids.
+    expect(held!.u.core.gated).toBe(true)
+  })
+
+  it('an EXPIRED lease is not a holding — the dependent goes to the placement alone', async () => {
+    const agentId = await placedAgent()
+    await seedDaemon(prisma, HOLDER, { capabilities: daemonCapabilities(ALL_BOT_PLATFORMS) })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId], { expiresAt: new Date(Date.now() - 1000) })
+    const { app, spy } = withSpy()
+
+    const created = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { name: 'lapsed-bot', platform: 'slack', agentId, slack: SLACK }
+    })
+    expect(created.statusCode).toBe(201)
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([DAEMON])
   })
 })

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -39,12 +39,14 @@ afterEach(async () => {
 /** A ControlSender spy recording the integration pushes the route makes. */
 class SpyControl {
   readonly upserts: Array<{ daemonId: string; u: IntegrationUpsert }> = []
-  readonly removes: Array<{ daemonId: string; r: IntegrationRemove }> = []
+  readonly removes: Array<{ daemonId: string; r: IntegrationRemove; orgId?: string }> = []
   async integrationUpsert(daemonId: string, u: IntegrationUpsert): Promise<void> {
     this.upserts.push({ daemonId, u })
   }
-  async integrationRemove(daemonId: string, r: IntegrationRemove): Promise<void> {
-    this.removes.push({ daemonId, r })
+  // `orgId` is recorded because a removal payload is a bare id: the send cannot
+  // derive an org on an install-wide connection, so dropping it here is the bug.
+  async integrationRemove(daemonId: string, r: IntegrationRemove, orgId?: string): Promise<void> {
+    this.removes.push({ daemonId, r, orgId })
   }
 }
 
@@ -1066,7 +1068,9 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect(bot?.lastUsedAt).not.toBeNull()
     expect(bot?.lastAgentName).toBe(`agent-${agentId.slice(0, 4)}`)
     expect(await prisma.botSecret.findUnique({ where: { botId: created.botId } })).not.toBeNull()
-    expect(spy.removes).toEqual([{ daemonId: DAEMON, r: { integrationId: created.id } }])
+    // The org rides every removal now: the payload is a bare id, so the send has
+    // nothing else to scope on when the connection is install-wide.
+    expect(spy.removes).toEqual([{ daemonId: DAEMON, r: { integrationId: created.id }, orgId: DEFAULT_ORG_ID }])
   })
 
   it('a freed bot can be reinstalled by botId — tokens reused, no new bot row', async () => {
@@ -1697,6 +1701,22 @@ describe('integration updates follow the duty holder', () => {
 
     expect(spy.removes.map((r) => r.daemonId)).toEqual([DAEMON, HOLDER])
     expect(spy.removes.every((r) => r.r.integrationId === integrationId)).toBe(true)
+    // The org is the assertion, not an incidental: `integration/remove` carries
+    // only an id, and this holder never registered the integration (it would have
+    // arrived through `duty/fetch`), so a send without the org is SCOPE_DENIED
+    // before it leaves the process — the delete 500s and the holder keeps serving.
+    expect(spy.removes.every((r) => r.orgId === DEFAULT_ORG_ID)).toBe(true)
+  })
+
+  it('the upsert path carries the org on the payload — verified, not assumed', async () => {
+    // `IntegrationSpec.orgId` is OPTIONAL on the wire (decode tolerance), so the
+    // guarantee is that the projector always stamps the row's org. Pin it: if a
+    // future producer omits it, upserts inherit exactly the removal bug.
+    const { app } = await installedWithHolder()
+    const spy = app.deps.control as unknown as SpyControl
+
+    expect(spy.upserts).not.toHaveLength(0)
+    expect(spy.upserts.every((u) => u.u.orgId === DEFAULT_ORG_ID)).toBe(true)
   })
 
   it('a gating flip re-pushes the derived spec to the holder', async () => {

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -99,6 +99,22 @@ describe('duty lease exchange (protocol level, real Postgres)', () => {
     expect(row.term).toBe(1n)
   })
 
+  it("a granted agent member carries the CP's current configRevision — presence is not freshness", async () => {
+    // Without it a member that already has the agent skips the fetch on `has()`
+    // alone and keeps serving a bundle the CP has edited since (#973).
+    await seedGroup()
+    await prisma.agent.create({
+      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'stamped', runtime: 'claude', configRevision: 9n }
+    })
+    const h = buildWsHarness(prisma)
+    const { stub } = await ready(h)
+
+    stub.inject('heartbeat', heartbeat({ held: [], headroom: 4 }))
+    const grant = await stub.expectFrame('duty/grant')
+    if (!isFrame('duty/grant')(grant)) throw new Error('expected duty/grant')
+    expect(grant.payload.grants[0]?.members).toEqual([{ kind: 'agent', refId: AGENT, configRevision: '9' }])
+  })
+
   it('zero headroom claims nothing', async () => {
     await seedGroup()
     const h = buildWsHarness(prisma)
@@ -261,6 +277,72 @@ describe('duty lease exchange (protocol level, real Postgres)', () => {
     const repo = new PgDutyGroupRepo(prisma)
     const grants = await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS)
     expect(grants[0]).toMatchObject({ groupId: GROUP, orgId: OrgId(DEFAULT_ORG_ID), term: 3n })
+  })
+})
+
+/**
+ * The reconnect roster is `pinned-to-me ∪ agents in the duties I hold` (#973).
+ * Before this it was `listForDaemon(daemonId)` alone, so a duty-installed agent
+ * was absent from the desired set on reconnect — a stale-replica candidate whose
+ * CP row names another daemon, i.e. a `detach` that undid the install entirely.
+ */
+describe('the reconnect roster follows the duty holder', () => {
+  /** Register while claiming a local replica of `AGENT`, and read the snapshot back. */
+  async function reconnectHolding(h: ReturnType<typeof buildWsHarness>) {
+    const { stub } = h.connect()
+    const saToken = await h.mintCloudDaemon(DAEMON)
+    stub.inject('auth', { serviceAccountToken: saToken, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
+    await stub.expectFrame('auth/ok')
+    stub.inject(
+      'register',
+      {
+        host: 'member-1',
+        capabilities: { platforms: ['slack'], runtimes: ['claude'], acp: true },
+        maxAgents: 8,
+        localState: {
+          assignments: [],
+          crons: [],
+          leases: [],
+          agents: [{ agentId: AGENT, origin: 'cp' }],
+          integrations: [],
+          stagedAgents: []
+        }
+      },
+      { id: REG_ID }
+    )
+    const ok = await stub.expectFrame('register/ok')
+    if (!isFrame('register/ok')(ok)) throw new Error('expected register/ok')
+    return ok.payload
+  }
+
+  it('a duty-held agent is IN the roster and is never a prune candidate', async () => {
+    const h = buildWsHarness(prisma)
+    // Placed on ANOTHER daemon — exactly the row that used to read as "moved away".
+    await prisma.daemon.create({ data: { id: OTHER, orgId: DEFAULT_ORG_ID, maxAgents: 4, status: 'ready' } })
+    await prisma.agent.create({
+      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'held', runtime: 'claude', daemonId: OTHER }
+    })
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(h.clock.now() + LEASE_MS) })
+
+    const ok = await reconnectHolding(h)
+
+    expect(ok.agents.map((a) => a.agentId)).toContain(AGENT)
+    expect(ok.drop.agents).toEqual([])
+  })
+
+  it('an EXPIRED lease is not a holding — the replica goes back to being a prune candidate', async () => {
+    const h = buildWsHarness(prisma)
+    await prisma.daemon.create({ data: { id: OTHER, orgId: DEFAULT_ORG_ID, maxAgents: 4, status: 'ready' } })
+    await prisma.agent.create({
+      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'lapsed', runtime: 'claude', daemonId: OTHER }
+    })
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(h.clock.now() - 1_000) })
+
+    const ok = await reconnectHolding(h)
+
+    expect(ok.agents.map((a) => a.agentId)).not.toContain(AGENT)
+    // Detach, never remove: the CP row still proves the agent lives elsewhere.
+    expect(ok.drop.agents).toEqual([{ agentId: AGENT, action: 'detach' }])
   })
 })
 

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -6,7 +6,8 @@ import { describe, it, expect, vi } from 'vitest'
 import { isFrame } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { buildWsHarness } from '../fakes/build-ws.js'
-import { PgDutyGroupRepo } from '../../src/persistence/index.js'
+import { PgDutyGroupRepo, PgLaunchRepo } from '../../src/persistence/index.js'
+import { ControlSender } from '../../src/orchestrator/outbound.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { DaemonId, OrgId } from '../../src/domain/ids.js'
 
@@ -343,6 +344,58 @@ describe('the reconnect roster follows the duty holder', () => {
     expect(ok.agents.map((a) => a.agentId)).not.toContain(AGENT)
     // Detach, never remove: the CP row still proves the agent lives elsewhere.
     expect(ok.drop.agents).toEqual([{ agentId: AGENT, action: 'detach' }])
+  })
+})
+
+/**
+ * A dependent REMOVAL carries a bare resource id, so on an install-wide
+ * connection the org can only come from the explicit argument or from the id→org
+ * map `register` built. A holder that acquired the resource through `duty/fetch`
+ * never registered it, so the map has nothing — and the send raises SCOPE_DENIED
+ * before the frame leaves the process (integration delete 500s after the row is
+ * already gone; cron delete logs and returns success; either way the holder goes
+ * on serving a deleted resource). Same class as #965, so the same fix: the org is
+ * explicit and local to the send.
+ */
+describe('a dependent removal to a holder that never registered the resource', () => {
+  const INTEGRATION = 'ffffffff-ffff-4fff-8fff-fffffffffff1'
+  const CRON = 'ffffffff-ffff-4fff-8fff-fffffffffff2'
+
+  /** An install-wide connection registered with EMPTY local state — exactly the
+   *  member that installed through `duty/fetch` and has no id→org map entries. */
+  async function readyWithNoRegisteredResources(h: ReturnType<typeof buildWsHarness>) {
+    const { stub } = await ready(h)
+    const state = h.deps.connReg.get(DaemonId(DAEMON))
+    expect(state?.orgByIntegration?.size).toBe(0)
+    expect(state?.orgByCron?.size).toBe(0)
+    return { stub, sender: new ControlSender(h.deps.connReg, new PgLaunchRepo(prisma)) }
+  }
+
+  it('integration/remove rides the explicit org, and is refused without it', async () => {
+    const h = buildWsHarness(prisma)
+    const { stub, sender } = await readyWithNoRegisteredResources(h)
+
+    await sender.integrationRemove(DAEMON, { integrationId: INTEGRATION }, DEFAULT_ORG_ID)
+    const sent = stub.sent.find((f) => f.type === 'integration/remove')
+    expect(sent?.orgId).toBe(DEFAULT_ORG_ID)
+
+    // The regression pin: without it the frame never leaves. This is what made
+    // the delete fail after the row was already gone.
+    await expect(sender.integrationRemove(DAEMON, { integrationId: INTEGRATION })).rejects.toThrow(/organization/i)
+    expect(stub.sent.filter((f) => f.type === 'integration/remove')).toHaveLength(1)
+  })
+
+  it('cron/remove rides the explicit org, and is refused without it', async () => {
+    const h = buildWsHarness(prisma)
+    const { stub, sender } = await readyWithNoRegisteredResources(h)
+
+    // REQ→ack: the stub never answers, so assert on what was SENT, not the reply.
+    void sender.cronRemove(DAEMON, { cronId: CRON }, DEFAULT_ORG_ID)
+    await vi.waitFor(() => expect(stub.sent.some((f) => f.type === 'cron/remove')).toBe(true))
+    expect(stub.sent.find((f) => f.type === 'cron/remove')?.orgId).toBe(DEFAULT_ORG_ID)
+
+    await expect(sender.cronRemove(DAEMON, { cronId: CRON })).rejects.toThrow(/organization/i)
+    expect(stub.sent.filter((f) => f.type === 'cron/remove')).toHaveLength(1)
   })
 })
 

--- a/packages/control-plane/test/repo/duty-group.repo.test.ts
+++ b/packages/control-plane/test/repo/duty-group.repo.test.ts
@@ -282,6 +282,36 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
     expect(await repo.holdsAgent(M1, AgentId(A2), T0)).toBe(true)
   })
 
+  it('holdersOf and heldAgentIds are the delivery/roster halves of holdsAgent', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(
+      repo,
+      [
+        { agentId: A1, botId: B1 },
+        { agentId: A2, botId: B2 }
+      ],
+      [],
+      T0
+    )
+    const [first] = await repo.listForOrg(ORG)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    const heldAgent = first!.members.find((m) => m.kind === 'agent')!.refId
+
+    expect(await repo.holdersOf(AgentId(heldAgent), T0)).toEqual([M1])
+    expect(await repo.heldAgentIds(M1, T0)).toEqual([heldAgent])
+    // A lapsed lease is not a holding on either side — the same fence as holdsAgent.
+    expect(await repo.holdersOf(AgentId(heldAgent), after(LEASE_MS + 1))).toEqual([])
+    expect(await repo.heldAgentIds(M1, after(LEASE_MS + 1))).toEqual([])
+  })
+
+  it('holdersOf survives the agent row it names — a delete must still reach the holder', async () => {
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    // No FK from membership to `agent`: the projection owns that lifecycle, so a
+    // cascade cannot strand `agent/remove` with nowhere to send it.
+    expect(await repo.holdersOf(AgentId(A1), T0)).toEqual([M1])
+  })
+
   it('racing first claims resolve to exactly one home and one winner', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     const [c1, c2] = await Promise.all([

--- a/packages/daemon/src/cp/cp-agent-registry.ts
+++ b/packages/daemon/src/cp/cp-agent-registry.ts
@@ -159,6 +159,13 @@ export class CpAgentRegistry {
     return this.active.has(agentId)
   }
 
+  /** The greatest spec revision applied for this agent — undefined when it was
+   *  never applied, or applied from an unfenced spec. The freshness half of
+   *  `has`: presence says the replica exists, this says how current it is. */
+  appliedRevision(agentId: string): bigint | undefined {
+    return this.revisions.get(agentId)?.revision
+  }
+
   agents(): LoadedAgent[] {
     return [...this.active.values()]
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -498,6 +498,7 @@ import type {
   TaskList,
   TaskListReq,
   DutyGrantEntry,
+  DutyMemberRef,
   DutyRevoke,
   HeartbeatDuties
 } from '@agentconnect.md/protocol'
@@ -12840,10 +12841,11 @@ export class Daemon {
   }
 
   /**
-   * Install every agent these grants cover that this daemon does not already
-   * have. Grants are thin by design, so the member pulls exactly what it lacks
-   * (`duty/fetch`) and applies the bundle the way an activation would — minus
-   * the move token, the staging fence, and workspace preparation.
+   * Install every agent these grants cover that this daemon does not already have
+   * AT THE GRANTED REVISION. Grants are thin by design, so the member pulls
+   * exactly what it lacks or what has moved on (`duty/fetch`) and applies the
+   * bundle the way an activation would — minus the move token, the staging fence,
+   * and workspace preparation.
    *
    * Returns the granted groups it could NOT install. A group is served as a
    * unit, so its bots wait on its agents too — that is the point, not a cost.
@@ -12852,7 +12854,7 @@ export class Daemon {
     const wanted = new Map<string, { orgId: string; groupId: string }>()
     for (const entry of entries) {
       for (const member of entry.members) {
-        if (member.kind !== 'agent' || this.cpAgents?.has(member.refId)) continue
+        if (member.kind !== 'agent' || !this.dutyBundleIsStale(member)) continue
         // A duty grant must never resurrect an agent a move or removal is tearing down.
         if (this.moveStagedAgents.has(member.refId) || this.agentRemovalPending(member.refId)) continue
         wanted.set(member.refId, { orgId: entry.orgId, groupId: entry.groupId })
@@ -12873,6 +12875,23 @@ export class Daemon {
     })
     await Promise.all(installs)
     return failed
+  }
+
+  /**
+   * Does this granted agent need a (re)fetch? Presence is not freshness: an agent
+   * this member installed under a duty it later lost keeps its replica (#948 — a
+   * release is never a removal) while the CP goes on editing a spec this member is
+   * no longer a delivery target for. A regrant that skipped on presence alone
+   * would serve that frozen bundle forever. So the grant carries the CP's current
+   * `configRevision` and it is compared against the applied one — the same fence
+   * the install itself re-applies, never a second notion of freshness. Unstamped
+   * (an older CP, a bot member's group) falls back to presence.
+   */
+  private dutyBundleIsStale(member: DutyMemberRef): boolean {
+    if (!this.cpAgents?.has(member.refId)) return true
+    if (member.configRevision === undefined) return false
+    const applied = this.cpAgents.appliedRevision(member.refId)
+    return applied === undefined || BigInt(member.configRevision) > applied
   }
 
   /** Join the in-flight install for this agent, or start one. A failure is

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -36,12 +36,19 @@ const grant = (agents: string[] = [AGENT]): DutyGrantEntry => ({
   members: agents.map((refId) => ({ kind: 'agent' as const, refId }))
 })
 
-const bundle = () => ({
+/** A grant that states what the CP currently holds for the agent — the freshness signal. */
+const grantAt = (configRevision: string): DutyGrantEntry => ({
+  ...grant(),
+  members: [{ kind: 'agent', refId: AGENT, configRevision }]
+})
+
+const bundle = (configRevision?: string) => ({
   agentId: AGENT,
   spec: {
     orgId: ORG,
     name: 'scout',
     runtime: 'claude',
+    ...(configRevision !== undefined ? { configRevision } : {}),
     workspace: { mode: 'scratch' as const, isolation: 'shared' as const }
   },
   integrations: [
@@ -127,6 +134,77 @@ describe('installing an agent a duty grant covers', () => {
     await (daemon as any).installGrantedAgents([grant()])
 
     expect(fetchDutyAgent).toHaveBeenCalledTimes(1)
+    await daemon.stop()
+  })
+
+  it('REFETCHES an agent it already has when the grant names a newer revision', async () => {
+    // The stale-bundle case: this member installed the agent under a duty, lost
+    // that duty (which is not a removal — #948 — so the replica survived), the CP
+    // went on editing a spec this member was no longer a delivery target for, and
+    // now the duty comes back. Presence alone would serve the frozen bundle forever.
+    const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle('7') }))
+    const daemon = await boot({ fetchDutyAgent })
+    const cp = registries(daemon)
+
+    cp.agents.upsert(AGENT, { ...bundle('3').spec })
+    expect(cp.agents.appliedRevision(AGENT)).toBe(3n)
+
+    await (daemon as any).installGrantedAgents([grantAt('7')])
+
+    expect(fetchDutyAgent).toHaveBeenCalledWith(AGENT, ORG)
+    expect(cp.agents.appliedRevision(AGENT)).toBe(7n)
+    await daemon.stop()
+  })
+
+  it('does NOT refetch when the grant names the revision it already applied', async () => {
+    const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle('7') }))
+    const daemon = await boot({ fetchDutyAgent })
+    const cp = registries(daemon)
+
+    cp.agents.upsert(AGENT, { ...bundle('7').spec })
+
+    await (daemon as any).installGrantedAgents([grantAt('7')])
+
+    // The common path stays free: a regrant of a current replica costs no round trip.
+    expect(fetchDutyAgent).not.toHaveBeenCalled()
+    await daemon.stop()
+  })
+
+  it('a grant naming an OLDER revision than the applied one costs no round trip', async () => {
+    // Directional, like the fence itself: only "the CP has moved on" is a reason to
+    // pull. A lagging grant would be refused by the revision fence anyway, so
+    // fetching it would only burn a round trip on a bundle we must not apply.
+    const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle('3') }))
+    const daemon = await boot({ fetchDutyAgent })
+    registries(daemon).agents.upsert(AGENT, { ...bundle('7').spec })
+
+    await (daemon as any).installGrantedAgents([grantAt('3')])
+
+    expect(fetchDutyAgent).not.toHaveBeenCalled()
+    await daemon.stop()
+  })
+
+  it('a refetched bundle goes through the same withdrawal guard as any other admission', async () => {
+    // Load-bearing: a refetch is an admission like any other, so a revoke landing
+    // mid-flight must stop it — otherwise the refresh path is a hole in the guard.
+    let releaseFetch!: () => void
+    const fetched = new Promise<void>((resolve) => {
+      releaseFetch = resolve
+    })
+    const fetchDutyAgent = vi.fn(async () => {
+      await fetched
+      return { bundle: bundle('7') }
+    })
+    const daemon = await boot({ fetchDutyAgent })
+    registries(daemon).agents.upsert(AGENT, { ...bundle('3').spec })
+
+    const admission = (daemon as any).admitDutyGrants([grantAt('7')])
+    await vi.waitFor(() => expect(fetchDutyAgent).toHaveBeenCalled())
+    ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'gone' }])
+    releaseFetch()
+
+    await expect(admission).resolves.toEqual(new Set([GROUP]))
+    expect(duties(daemon).digest()).toEqual([])
     await daemon.stop()
   })
 

--- a/packages/protocol/src/frames/duty.test.ts
+++ b/packages/protocol/src/frames/duty.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   HeartbeatDuties,
   DutyGrant,
+  DutyGrantEntry,
   DutyRenewed,
   DutyRevoke,
   DutyRelease,
@@ -56,6 +57,36 @@ describe('duty frames', () => {
     if (!decoded.ok) throw new Error(`decode failed: ${decoded.msg}`)
     expect(decoded.frame.type).toBe('duty/grant')
     expect(decoded.frame.payload).toEqual(payload)
+  })
+
+  it("an agent member may carry the CP's current configRevision — the freshness signal", () => {
+    const stamped: DutyGrant = {
+      grants: [
+        {
+          groupId: GROUP,
+          orgId: 'org-1',
+          term: '4',
+          members: [
+            { kind: 'agent', refId: AGENT, configRevision: '12' },
+            { kind: 'bot', refId: BOT }
+          ]
+        }
+      ]
+    }
+    const decoded = decodeEnvelope(encode(buildEnvelope('duty/grant', stamped)))
+    if (!decoded.ok) throw new Error(`decode failed: ${decoded.msg}`)
+    expect(decoded.frame.payload).toEqual(stamped)
+    // Optional (an older CP omits it) but never a free-form string: it is compared
+    // as a bigint against the applied revision.
+    expect(DutyGrantEntry.safeParse({ ...stamped.grants[0], members: [{ kind: 'agent', refId: AGENT }] }).success).toBe(
+      true
+    )
+    expect(
+      DutyGrantEntry.safeParse({
+        ...stamped.grants[0],
+        members: [{ kind: 'agent', refId: AGENT, configRevision: 'v12' }]
+      }).success
+    ).toBe(false)
   })
 
   it('duty/revoke carries only the closed reason vocabulary', () => {

--- a/packages/protocol/src/frames/duty.ts
+++ b/packages/protocol/src/frames/duty.ts
@@ -13,10 +13,15 @@ import { CronUpsert } from './cron.js'
 export const DutyTerm = z.string().regex(/^\d+$/)
 export type DutyTerm = z.infer<typeof DutyTerm>
 
-/** One member of a duty group: an agent to serve or a daemon-held bot to connect. */
+/** One member of a duty group: an agent to serve or a daemon-held bot to connect.
+ *  `configRevision` is the freshness signal for AGENT members — the CP's current
+ *  `AgentSpec.configRevision` — so a member that already has the agent can tell a
+ *  current replica from a frozen one and refetch only the frozen ones. Optional:
+ *  an older CP omits it and the member falls back to presence alone. */
 export const DutyMemberRef = z.object({
   kind: z.enum(['agent', 'bot']),
-  refId: z.string().uuid()
+  refId: z.string().uuid(),
+  configRevision: z.string().regex(/^\d+$/).optional()
 })
 export type DutyMemberRef = z.infer<typeof DutyMemberRef>
 


### PR DESCRIPTION
Closes #973.

`duty/fetch` (#972) lets a member install an agent it won a duty for, but every
*subsequent* update was still routed by placement. A holder that is not the
agent's `daemonId` installed one bundle and then served it frozen — spec edits,
rotated credentials, organization secrets/variables, integrations and crons all
ride placement-keyed pushes. Worse, on reconnect that install was absent from the
desired set, so it was a stale-replica candidate and could be pruned outright.

This is the **last gate before the `features.dutyEnforcement` flip**. Nothing here
flips it: the flag also needs an env override that does not exist yet, and the
grant policy stays `incumbent`.

## The seam

`orchestrator/agentDelivery.ts` — `AgentDelivery` — is the one answer to "which
daemons must receive this agent's updates":

```
daemonsFor(agentId, placement) = { placement } ∪ { members holding an unexpired
                                                  duty lease covering the agent }
```

backed by a new `DutyGroupRepo.holdersOf(agentId, now)` — the delivery half of the
`holdsAgent` read `duty/fetch` already authorizes with, same unexpired-lease join,
read from the agent's side.

Every replicate site routes through it — the agent frames **and their
dependents**. `agentUpsert`, `agentRemove`, `integrationUpsert`,
`integrationRemove`, `cronUpsert` and `cronRemove` now have **exactly one
`ControlSender` call site each in the whole CP**, all six inside
`AgentDelivery`, so nothing outside it reads `agent.daemonId` to decide where
anything goes:

| Site | Sends |
|---|---|
| agent routes `replicateUpsert` / `replicateRemove` | agent/upsert, agent/remove |
| icon-upload replicate | agent/upsert |
| skill-source fan-out | agent/upsert |
| organization-environment fan-out | agent/upsert |
| organization-knowledge managed-skill fan-out | agent/upsert |
| container GitHub repository-rename convergence | agent/upsert |
| cron routes (PUT, DELETE) | cron/upsert, cron/remove |
| integration routes (create, republish, channel trigger, delete) | integration/upsert, integration/remove |
| `install-bot` / `install-feishu` | integration/upsert |
| `convergeIntegrationGating` | integration/upsert |
| `HttpBotOrchestrator` (send-only spec, revoke removal) | integration/upsert, integration/remove |

**Why the dependents had to follow too** (review-bot on this PR): an integration
spec is token-bearing and its bindRules are what the daemon admits on, and a cron
definition is what it fires. A holder that never receives those keeps stale
credentials, stale routing, or a stale schedule. And these mutations do **not**
advance `Agent.configRevision`, so the grant-time freshness stamp gives the
holder no reason to refetch either — it is only consulted when a grant is
delivered. Neither delivery nor refresh: that is exactly the frozen-bundle
failure #973 exists to fix, one level down. No dependent needed the
`configRevision`-bump fallback; every one of them fit the seam.

### The removals carry an explicit org

`integration/remove` and `cron/remove` carry only their resource id. On an
install-wide connection `organizationFor` resolves the org from the connection
(absent by construction), then the payload (an id alone), then the id→org map
`register` built — and a holder that acquired the resource through `duty/fetch`
never registered it, so the map has nothing. `SCOPE_DENIED` was raised before
either frame left the process: the integration delete returned 500 *after* the
row was gone, the cron delete logged and returned success, and either way the
holder kept serving a deleted resource.

Both removals now take the record's own `orgId`, through `AgentDelivery` and
through `ControlSender` — exactly the pattern #965 established for
`agentUpsert` / `agentRemove` / `agentDetach` / `agentActivate`. The org is on the
record in hand at every call site.

**The upserts were verified, not assumed**, and the reviewer's read was *almost*
right: `IntegrationSpec.orgId` and `CronUpsert.orgId` are `optional()` on the
wire (decode tolerance), so the schema does **not** force them. What actually
holds is that both producers always stamp the row's org — `projectSpec`
(`orgId: i.orgId`) and `cronToUpsert` (`orgId: c.orgId`) are the only producers
of either payload. `organizationFor` then reads `p.orgId` as the explicit org
*and* remembers it in the map, which is why the upserts never had this bug. That
guarantee now has tests of its own, so a future producer that omits the field
cannot silently hand the upserts the same failure.

### The id→org maps are populated on duty install too — and yes, they should be

The coordinator asked whether the maps themselves need filling on `duty/fetch`.
They do, and the hole is wider than the removals: the maps are built **only**
from the `register` reconcile snapshot, so *every* C→D frame whose payload
carries a bare id has nothing to resolve for a resource installed mid-session —
the whole BFF read/write surface keyed on `agentId` (session list/history,
workspace read/write, memory, dream, permission decisions) plus `cron/run`,
`integration/forget` and `integration/leave`. None of those can take the #965
route as cheaply, because their call sites are not holding the record.

`duty/fetch` now records the bundle's agent, integrations and crons into the
connection's maps. It is ~8 lines in the one handler that already knows all
three, so I did it here rather than filing it — but the explicit org stays the
primary mechanism, and the removals do **not** depend on the map. Two properties
worth stating:

- it is a scoping **hint, never an authorization** — holding the duty is what
  authorizes, and a frame for a resource the member declined to install still
  fails on the member, so recording optimistically is safe;
- it also strengthens the *inbound* gate, which cross-checks the org a member
  claims for a resource against the same maps.

A reconnect was already covered before this: the roster union above puts
duty-held agents, integrations and crons into the register snapshot, so the maps
have been correct across reconnects since the first commit. This closes the
mid-session window.

**Verifiable as a grep**, which is the point of the shape:

```
$ grep -rn 'integrationUpsert|integrationRemove|cronUpsert|cronRemove|agentUpsert|agentRemove' \
    packages/control-plane/src | grep -v outbound.ts | grep -v agentDelivery.ts
# → only `deps.agentDelivery.*` / `this.agentDelivery.*` call sites
```

Choices worth stating:

- **A service, not a bare function.** The issue asks for a resolution helper; the
  five upsert sites also duplicated *assemble → send → log*, so the seam owns the
  fan-out too and each site keeps only its own error log through a callback. That
  is what makes "no site reads `daemonId` for delivery" enforceable rather than a
  convention.
- **One spec per fan-out, not one per target.** Two assemblies of the same agent
  could disagree; the replicas must apply the same revision.
- **Sequential, placement first.** The fan-out is 1–2 targets in practice, and
  sequencing preserves the delete route's existing escalation semantics — a
  handler that rethrows (anything that is not an offline daemon) still lets every
  remaining target hear the removal before the error surfaces.
- **`orgId` stays explicit** on every lifecycle send (the earlier frame-scope fix);
  a duty holder is precisely the install-wide connection that cannot derive an org
  from its own maps. The GitHub-rename site actually *gains* an explicit `orgId` —
  it was the one caller passing none.
- The seam is where "placement is a delivery target, not a member id" lands later:
  `daemonsFor` is the only thing that would have to change.
- **One boundary deliberately NOT moved.** `HttpBotOrchestrator` hands the relay a
  single owning `daemonId` in `rc/assign` / `members`; that is ingress *routing*,
  not replication, and it stays the placement (placement semantics are out of
  scope). Only the send-only credential bundle and its removal fan out — so a
  duty holder is not left signing egress with a credential the workspace has
  since rotated, while the relay keeps addressing ingress exactly as before.
- `cron/run` ("Run now") is likewise left alone: an imperative one-shot fire is
  routing, not a definition to replicate.

## The roster union

`Placement.reconcile`'s desired set becomes `pinned-to-me ∪ agents in the duties I
hold`, via a new `DutyGroupRepo.heldAgentIds(holder, now)`. Because
`staleAgentCandidates = localState.agents − desiredAgentSet`, a duty-held replica
is **never a prune candidate** — that is where the pruning decision is made, and
the union is applied upstream of it rather than as a second exception inside the
loop (which would have been dead code and a second place to keep in sync).

**Integrations and crons ride along.** They are not in the issue's roster bullet,
but `dropIntegrations` prunes CP-owned integrations missing from the roster, so
leaving them placement-keyed would have converged the agent while dropping the
sockets it is held to serve — the group would survive and serve nothing. Both get
`activeForAgents` / `listForAgents` companions.

An agent the ledger still names but whose row is gone stays a candidate and is
removed on its own merits: a deleted agent must not keep being served.

## The freshness signal

`configRevision` on `DutyMemberRef` (optional; an older CP omits it). The CP stamps
each granted agent member with `agent.configRevision`; the daemon's install filter
asks `dutyBundleIsStale(member)` instead of `cpAgents.has(agentId)`:

- absent locally → fetch;
- present, unstamped → skip (exactly today's behavior);
- present, granted revision **greater** than the applied one → refetch.

Chosen over the two alternatives:

- *Always refetch* would cost one full bundle round trip per held agent on every
  reconnect regrant (a member holding 100 agents pays 100 spec assemblies with
  secret decryption) — and with the roster union in place every one of them is
  redundant, because `register/ok` just delivered the current spec.
- *A second freshness notion* was unnecessary: `configRevision` is already the
  revision fence on the spec, and the daemon already enforces it
  (`stale`/`conflict`/`apply`). The comparison and the application now agree by
  construction; a refetch that races a newer local apply is refused by the same
  fence.

The refetch is an ordinary admission — same `queueAgentLifecycle`, same revision
fence, same `dutyAdmissions` withdrawal guard, same refuse-the-group-on-failure
and `shrinkToGrant` behavior from #977. A revoke landing mid-refetch stops it.

The comparison is deliberately directional (`>`, not `!=`): a *lagging* grant
would be refused by the fence anyway, so pulling it only burns a round trip.

## Invariants

- A duty release is still never a removal — nothing here touches teardown.
- The withdrawal guard covers refetches; there is a test for exactly that.
- An expired lease is not a holding on either new read, so an agent stops being a
  delivery target and its replica goes back to being a prune candidate.
- `features.dutyEnforcement` untouched, grant policy untouched, placement
  semantics / reaper / operator untouched.

## Known gap, deliberately out of scope

MCP proxy defs and external-memory connection defs are still placement-keyed in
both the live push and the reconcile roster — tracked separately as #979. A
duty-installed agent never receives them today either (the `duty/fetch` bundle
carries only `{spec, integrations, crons}`), so this is an install-completeness
gap rather than a delivery regression, and it does not gate the flip.

## Tests

New, all mutation-checked (break the mechanism, confirm exactly the intended test
fails, restore). The dependent set adds nine: an integration install reaching the
holder **with the credential**, a bindRules change reaching it, an integration
removal, a gating flip, a cron upsert **carrying the edited schedule**, a cron
removal, placement-and-holder-exactly-once, and two expired-lease negatives. The
"current without a reconnect" property is pinned by asserting the *content* that
arrived (`bindRules` contains the new `auto` rule; the cron carries the new
`schedule`) in tests where no register/reconcile runs at all — arrival alone
would not have distinguished a live push from a roster repair.

The org round adds tests at **two levels**, because the bug lives in two places.
Route-level (real Postgres, spy sender) asserts `AgentDelivery` propagates the
record's org onto each removal — a send whose org is wrong is the bug, so the
org is asserted, not just the arrival. Protocol-level (real WS harness, real
`ControlSender`, real `DaemonConnection`) registers an install-wide daemon with
**empty** local state — the map is asserted empty first, which is precisely the
duty-installed member — then shows the removal riding the explicit org, and, as
the regression pin, that the same send without it never leaves the process. Two
more unit tests cover the `duty/fetch` scope recording and that a refused fetch
records nothing.

| # | Mutation | Expected failure | Result |
|---|---|---|---|
| M1 | `AgentDelivery.upsert` targets the placement only | the two upsert-holder tests | ✅ 2 failed, remove unaffected |
| M2 | `AgentDelivery.remove` targets the placement only | `agent/remove reaches the holder` | ✅ exactly 1 |
| M3 | drop the target-set dedupe | `the placement holding its own agent is one target` | ✅ exactly 1 |
| M4 | `holdersOf` ignores lease expiry | the two expired-lease tests | ✅ exactly 2 |
| M5 | roster union drops its duty half | `a duty-held agent is IN the roster and is never a prune candidate` | ✅ exactly 1 |
| M6 | CP emits unstamped grants | `a granted agent member carries the CP's current configRevision` | ✅ exactly 1 |
| M7 | install filter back to presence-only | `REFETCHES … newer revision` + the withdrawal-guard test | ✅ 2; "does NOT refetch" still green |
| M8 | unstamped members always refetch | #972's `never re-fetches an agent it already has` + `a re-grant … no fetch at all` | ✅ exactly 2 |
| M9 | revision comparison `!=` instead of `>` | `a grant naming an OLDER revision … costs no round trip` | ✅ exactly 1 |
| M10 | `AgentDelivery.integrationUpsert` targets the placement only | the 3 integration-upsert holder tests | ✅ 3; removal unaffected |
| M11 | `AgentDelivery.integrationRemove` targets the placement only | `an integration removal reaches the holder` | ✅ exactly 1 |
| M12 | `AgentDelivery.cronUpsert` targets the placement only | the 2 cron-upsert holder tests | ✅ 2; removal unaffected |
| M13 | `AgentDelivery.cronRemove` targets the placement only | `a cron removal reaches the holder` | ✅ exactly 1 |
| M14 | gating converge loses the agent's delivery set | `a gating flip re-pushes the derived spec to the holder` | ✅ exactly 1 |
| M15 | `AgentDelivery.integrationRemove` drops the org | the 2 integration-removal org assertions | ✅ exactly 2 |
| M16 | `AgentDelivery.cronRemove` drops the org | the 2 cron-removal org assertions | ✅ exactly 2 |
| M17 | `ControlSender.integrationRemove` ignores its org argument | `integration/remove rides the explicit org…` | ✅ exactly 1 |
| M18 | `ControlSender.cronRemove` ignores its org argument | `cron/remove rides the explicit org…` | ✅ exactly 1 |
| M19 | `duty/fetch` stops recording scopes | `teaches the connection which org the fetched resources belong to` | ✅ exactly 1 |

## Gates

`typecheck`, `lint`, `format:check`, `protocol test` (330), `control-plane
test:unit` (1607), `control-plane test:int` (1214), `daemon test` — all green.
One `test/repo/rewrap.test.ts` failure appeared in a loaded integration run and
passes in isolation — the documented flake, and unrelated (secret re-sealing).
The daemon suite's failures
are the known clean-main baseline, verified against a stashed clean main in this
same worktree: `shim-cancellation`, `shim-exec-handler`, `shim-workspace-files`,
`workspace-git-runner-seam` (identical 4 files / 14 tests before and after), plus
the live `acp-matrix` run, which needs real runtimes and network.

