### PR TITLE
feat(daemon): make duty enforcement reachable from the environment

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -140,6 +140,8 @@ The daemon does not implement these, but interacts with them through the section
 
 All environment equivalents use the `AGENTCONNECT_` prefix, such as `AGENTCONNECT_CP_URL`, `AGENTCONNECT_CP_KEY`, and `AGENTCONNECT_ROOT`, for containers and system services.
 
+One feature switch is reachable the same way: `AGENTCONNECT_DUTY_ENFORCEMENT` sets `features.dutyEnforcement`, so a daemon whose config.json is machine-generated on every start can still state it. It accepts `1`/`true`/`yes`/`on` or `0`/`false`/`no`/`off` (case-insensitive; blank or unset means "not stated"), rejects anything else at startup rather than reading as off, and — unlike the table above — **outranks the config file**, because in that deployment the file is regenerated from defaults and could never carry the decision. It only changes behavior on an install-wide (frame-scope) daemon; an org-scoped daemon is unaffected whatever it says.
+
 ### 2.4 Mapping In-Process Responsibilities to CLI
 
 `run`, including the same `run` managed by a service after `up`, starts every module in the section 1.2 diagram corresponding to upstream D1-D12: Supervisor, CP-Client, ConnectionManager and Platform Adapters, Local Router, Scheduler, ACP Host, MCP Tool Server, Workspace Manager, Local Store, and Telemetry. Secrets Agent remains future work. Sections 6-10 expand the parts directly related to the eight requirements.

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -556,7 +556,13 @@ ledger needs the digest to converge — but _enforcement_ (the
 `transportAgents()` filter, schedule scoping, refusal of unheld triggers) is
 behind `features.dutyEnforcement`, default off: a grant or revoke only moves
 bookkeeping until the flag flips, so convergence is observable in production
-before it gates a single connection. During the soak the grant policy is
+before it gates a single connection. A pool member's state root is an
+`emptyDir`, so its config.json is regenerated from defaults on every Pod start
+and cannot carry the flag; the operator sets `AGENTCONNECT_DUTY_ENFORCEMENT`
+(`1`/`true`/`yes`/`on`, anything unrecognized refused at startup) on the Pod
+instead, which outranks the file for this one key. The daemon reports which
+state it got — enforcing, or configured-but-inactive on a non-frame
+connection — once the control-plane connection is up. During the soak the grant policy is
 **incumbent-only** — a vacancy is granted only to the member the group's
 agents are already placed on, and the recompute vacates a lease whose holder
 no longer hosts any of the group's agents (partial occupancy keeps it, so a

--- a/packages/daemon/src/config/load-config.ts
+++ b/packages/daemon/src/config/load-config.ts
@@ -15,6 +15,25 @@ export interface FlatOverrides {
   requireSandbox?: boolean
 }
 
+/** Env override for `features.dutyEnforcement` — the only channel a pool member has, its config.json being regenerated each start. */
+export const DUTY_ENFORCEMENT_ENV = 'AGENTCONNECT_DUTY_ENFORCEMENT'
+
+const DUTY_ENFORCEMENT_ON = ['1', 'true', 'yes', 'on']
+const DUTY_ENFORCEMENT_OFF = ['0', 'false', 'no', 'off']
+
+/** Unset or blank ⇒ no override; an unrecognized value throws, because a switch that silently reads as off is the failure mode. */
+export function dutyEnforcementFromEnv(env: NodeJS.ProcessEnv = process.env): boolean | undefined {
+  const raw = env[DUTY_ENFORCEMENT_ENV]
+  if (raw === undefined) return undefined
+  const value = raw.trim().toLowerCase()
+  if (value === '') return undefined
+  if (DUTY_ENFORCEMENT_ON.includes(value)) return true
+  if (DUTY_ENFORCEMENT_OFF.includes(value)) return false
+  throw new Error(
+    `${DUTY_ENFORCEMENT_ENV} must be one of ${[...DUTY_ENFORCEMENT_ON, ...DUTY_ENFORCEMENT_OFF].join('/')} (got ${JSON.stringify(raw)})`
+  )
+}
+
 function protectConfigFile(file: string, writable = false): void {
   if (!existsSync(file)) return
   try {
@@ -83,6 +102,10 @@ export function loadConfig(
     cfg.controlPlane.url = envUrl
     if (!o.noCp) cfg.controlPlane.enabled = true
   }
+
+  // Env wins over the file for this key alone, on every branch above: a pool member's emptyDir root regenerates config.json each start.
+  const dutyEnforcement = dutyEnforcementFromEnv()
+  if (dutyEnforcement !== undefined) cfg.features.dutyEnforcement = dutyEnforcement
 
   cfg.agentsDir = o.agentsDir ?? cfg.agentsDir ?? defaultAgentsDir(root)
   return cfg

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2141,6 +2141,8 @@ export class Daemon {
   // only on an install-wide connection — empty on a single-org daemon, which is
   // what keeps the whole path dormant there.
   private readonly duties = new DutyRegistry()
+  // Last enforcement state logged, so a reconnect only speaks when the answer changed.
+  private dutyEnforcementReported?: boolean
   // What an unbounded member reports as heartbeat headroom: the CP's own
   // per-tick grant cap, so the wire carries a finite number without implying a
   // ceiling. Never used for a local capacity decision.
@@ -3001,6 +3003,9 @@ export class Daemon {
     this.log.info(
       `control plane: ${cfg.controlPlane?.enabled ? `enabled (${cfg.controlPlane.url ?? 'no url'})` : 'disabled — running local'}`
     )
+    // The default is off and silent; when it is on, say so before any lease can gate a connection.
+    if (cfg.features.dutyEnforcement)
+      this.log.info('duty: enforcement configured on — awaiting an install-wide (frame-scope) control-plane connection')
     this.agentsDir = cfg.agentsDir!
     this.removalObligationsDir = agentRemovalObligationsDir(root)
     this.removedAgentTombstones = agentRemovalTombstones(this.agentsDir, this.removalObligationsDir)
@@ -12731,6 +12736,19 @@ export class Daemon {
     return this.cfg?.features?.dutyEnforcement === true && this.cpClient?.organizationScope() === 'frame'
   }
 
+  /** Which of the two configured-on states this connection resolved to; a reconnect that changes nothing stays quiet. */
+  private logDutyEnforcementScope(): void {
+    if (this.cfg?.features?.dutyEnforcement !== true) return
+    const enforcing = this.dutyEnforced()
+    if (this.dutyEnforcementReported === enforcing) return
+    this.dutyEnforcementReported = enforcing
+    if (enforcing) this.log.info('duty: enforcement ACTIVE — this daemon serves only the agents it holds a lease for')
+    else
+      this.log.warn(
+        `duty: enforcement INACTIVE — it applies only to an install-wide (frame-scope) connection, and this one is ${this.cpClient?.organizationScope() ?? 'not established'}`
+      )
+  }
+
   /** `duty/grant` EVT: admit the grants off the frame-dispatch path, so a slow
    *  CP cannot stall the socket. */
   private applyDutyGrant(grants: DutyGrantEntry[]): void {
@@ -21496,6 +21514,8 @@ export class Daemon {
       // may have missed emits while we were disconnected; latest-wins upsert).
       onReady: () => {
         resolveInitialRegistry()
+        // The organization scope is only known once the connection is up, and it is half the answer.
+        this.logDutyEnforcementScope()
         void this.probeRuntimesAndEmit()
         void this.syncOrganizationSuggestions().catch((err) =>
           this.log.warn(`cp: organization suggestion replay failed (${err instanceof Error ? err.name : 'unknown'})`)

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { chmodSync, mkdtempSync, writeFileSync, mkdirSync, existsSync, readFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { loadConfig } from '../src/config/load-config.js'
+import { loadConfig, DUTY_ENFORCEMENT_ENV } from '../src/config/load-config.js'
 import { McpServerDefSchema, RuntimeDefSchema, sessionRetentionMs } from '../src/config/config-schema.js'
 import { CP_URL_ENV } from '@agentconnect.md/protocol'
 
@@ -70,6 +70,72 @@ describe('loadConfig', () => {
       const cfg = withEnv('   ', () => loadConfig({ root: tmpRoot({ version: 1 }) }))
       expect(cfg.controlPlane.url).toBeUndefined()
       expect(cfg.controlPlane.enabled).toBe(false)
+    })
+  })
+
+  // A pool member's state root is an emptyDir, so its config.json is regenerated from defaults each start.
+  describe(`${DUTY_ENFORCEMENT_ENV} (the pool member's rollout switch)`, () => {
+    const withEnv = <T>(value: string | undefined, run: () => T): T => {
+      const previous = process.env[DUTY_ENFORCEMENT_ENV]
+      if (value === undefined) delete process.env[DUTY_ENFORCEMENT_ENV]
+      else process.env[DUTY_ENFORCEMENT_ENV] = value
+      try {
+        return run()
+      } finally {
+        if (previous === undefined) delete process.env[DUTY_ENFORCEMENT_ENV]
+        else process.env[DUTY_ENFORCEMENT_ENV] = previous
+      }
+    }
+
+    it('is off when the variable is absent, keeping the shipped default', () => {
+      const cfg = withEnv(undefined, () => loadConfig({ root: tmpRoot({ version: 1 }) }))
+      expect(cfg.features.dutyEnforcement).toBe(false)
+    })
+
+    it('turns enforcement on for every accepted spelling of on', () => {
+      for (const value of ['1', 'true', 'TRUE', 'yes', 'on', ' true ']) {
+        const cfg = withEnv(value, () => loadConfig({ root: tmpRoot({ version: 1 }) }))
+        expect(cfg.features.dutyEnforcement, value).toBe(true)
+      }
+    })
+
+    it('turns enforcement off for every accepted spelling of off', () => {
+      for (const value of ['0', 'false', 'FALSE', 'no', 'off']) {
+        const cfg = withEnv(value, () => loadConfig({ root: tmpRoot({ version: 1 }) }))
+        expect(cfg.features.dutyEnforcement, value).toBe(false)
+      }
+    })
+
+    it('refuses an unparseable value rather than silently staying off', () => {
+      expect(() => withEnv('maybe', () => loadConfig({ root: tmpRoot({ version: 1 }) }))).toThrow(
+        new RegExp(DUTY_ENFORCEMENT_ENV)
+      )
+      expect(() => withEnv('2', () => loadConfig({ root: tmpRoot({ version: 1 }) }))).toThrow(/must be one of/)
+    })
+
+    it('is ignored when blank, so a chart templating an empty value decides nothing', () => {
+      const root = tmpRoot({ version: 1, features: { dutyEnforcement: true } })
+      expect(withEnv('   ', () => loadConfig({ root })).features.dutyEnforcement).toBe(true)
+    })
+
+    it('outranks a config file that says the opposite, in both directions', () => {
+      const off = tmpRoot({ version: 1, features: { dutyEnforcement: false } })
+      expect(withEnv('true', () => loadConfig({ root: off })).features.dutyEnforcement).toBe(true)
+      const on = tmpRoot({ version: 1, features: { dutyEnforcement: true } })
+      expect(withEnv('false', () => loadConfig({ root: on })).features.dutyEnforcement).toBe(false)
+    })
+
+    it('survives the auto-create path, so a fresh ephemeral root still comes up enforcing', () => {
+      const root = mkdtempSync(join(tmpdir(), 'ac-cfg-')) // no config.json written
+      const cfg = withEnv('1', () => loadConfig({ root, autoCreate: true }))
+      expect(cfg.features.dutyEnforcement).toBe(true)
+      // The generated file stays default-shaped — the env, not the disposable file, is the source.
+      expect(JSON.parse(readFileSync(join(root, 'config.json'), 'utf8'))).toEqual({ version: 1 })
+    })
+
+    it('applies on the optional (no file) path too', () => {
+      const root = mkdtempSync(join(tmpdir(), 'ac-cfg-'))
+      expect(withEnv('on', () => loadConfig({ root, optional: true })).features.dutyEnforcement).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Why

`features.dutyEnforcement` is a daemon-local, operator-owned rollout switch that defaults to `false`, and its comment is explicit that it is never negotiated through the control plane. That design is right and unchanged here. The problem is that it was **unreachable in exactly the deployment it was written for**:

- a `--k8s` pool daemon's state root is an `emptyDir`, so `config.json` is auto-created from schema defaults on every Pod start and any hand edit dies with the Pod;
- nothing under `features` had an environment override;
- the only file mounted into those Pods is the data-plane secret, a different `config.json` entirely.

So the flag could be read, but never set on a pool member.

## What this adds

One environment override, for this one flag, following the existing precedent for daemon settings that must arrive from outside the config file (`AGENTCONNECT_ROOT`, `AGENTCONNECT_SUPERVISOR`, `AGENTCONNECT_K8S_RUNTIMES`). The variable name is exported as a named constant, `DUTY_ENFORCEMENT_ENV` in `packages/daemon/src/config/load-config.ts`, the way `K8S_RUNTIMES_ENV` is, rather than scattered as a literal.

```
AGENTCONNECT_DUTY_ENFORCEMENT=1
```

### Precedence: the environment wins over the config file

Deliberately the opposite of the daemon's usual `CLI flag > env > config.json > default` ordering, and the doc note says so. In the deployment this exists for the file is machine-generated from defaults on every start, so an env value that lost to the file could never be stated at all — the override would be decorative. It is scoped to this one key; the general ordering is untouched.

The override is applied **after** the schema parse and on every branch of `loadConfig`, so it survives the auto-create path (`run`), the optional/no-file path (`chat`), and an existing file alike. A fresh ephemeral root therefore comes up enforcing. The auto-created file itself is left default-shaped (`{ "version": 1 }`) — the environment, not the disposable file, stays the source of truth.

### Parsing: strict, and loud when it cannot tell

| Input | Result |
| --- | --- |
| `1` `true` `yes` `on` (any case, surrounding whitespace trimmed) | enforcement on |
| `0` `false` `no` `off` (same) | enforcement off |
| unset, or blank/whitespace-only | no override — the config file's value stands |
| anything else | **throws at startup**, naming the variable and the accepted values |

Blank is treated as "not stated" rather than as an error so a chart templating an empty value does not decide the switch. Everything else refuses to boot: a rollout switch that silently stays off is the failure mode that wastes an afternoon, so an unparseable value is a startup failure, not a default.

### Observability

`dutyEnforced()` requires both the flag **and** `organizationScope() === 'frame'`, so an org-scoped daemon is unaffected no matter what the environment says. Someone flipping this in a cluster has to be able to tell those two apart from the logs:

- at startup, when the flag is on: `duty: enforcement configured on — awaiting an install-wide (frame-scope) control-plane connection`
- once the CP connection is up and the scope is known, one of:
  - `duty: enforcement ACTIVE — this daemon serves only the agents it holds a lease for`
  - `duty: enforcement INACTIVE — it applies only to an install-wide (frame-scope) connection, and this one is connection` (warn)

The resolved line is deduped, so a reconnect that changes nothing stays quiet and a scope that changes is reported.

Nothing is logged when the flag is off — that is the default and the silent case.

## Scope

- The default is **unchanged** (`false`). Nothing is turned on.
- The duty mechanism, grant policy, placement, and reaper are untouched.
- No general "any config key from the environment" mechanism — that is a much larger blast radius and a different change.

Throwing the switch remains a separate, deployment-side act.

## Tests

`packages/daemon/test/config.test.ts` — env on (every accepted spelling, plus case and whitespace) / env off / env absent / env unparseable / env vs. a config file that says the opposite in both directions / blank ignored / auto-create path preserves it / optional path preserves it.

Mutation-checked — each mutation applied, the suite run, the failure set recorded, then restored:

| # | Mutation | Test that failed | Others |
| --- | --- | --- | --- |
| M1 | unparseable value returns `false` instead of throwing | `refuses an unparseable value rather than silently staying off` | none |
| M2 | drop the blank-is-absent guard | `is ignored when blank, so a chart templating an empty value decides nothing` | none |
| M3 | drop `.trim()` | `turns enforcement on for every accepted spelling of on`, `is ignored when blank…` | both intended |
| M4 | drop `.toLowerCase()` | `turns enforcement on for every accepted spelling of on`, `turns enforcement off for every accepted spelling of off` | both intended |
| M5 | apply the env only when the file left the key at its default (file outranks env) | `outranks a config file that says the opposite, in both directions` | none |
| M6 | skip the override on the auto-create path | `survives the auto-create path, so a fresh ephemeral root still comes up enforcing` | none |
| M7 | skip the override on the optional (no file) path | `applies on the optional (no file) path too` | none |

## Docs

There is no daemon env-var table in the repo, only prose. Both mentions were extended rather than a new page invented:

- `docs/designs/daemon-detailed-design.md` §2.3, right after the existing "all environment equivalents use the `AGENTCONNECT_` prefix" sentence — what it sets, the accepted values, that it outranks the file and why, and that it only changes behavior on an install-wide (frame-mode) daemon.
- `docs/designs/k8s-daemon-pool.md`, in the **Rollout** paragraph that already owns this flag — how an operator actually turns it on for a pool member, which the doc previously never said.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean. `pnpm --filter @agentconnect.md/daemon test`: 15 failures, all pre-existing — `shim-workspace-files`, `shim-exec-handler`, `shim-cancellation`, `workspace-git-runner-seam` (14 failures, reproduced identically on a clean checkout of `main`) and the live `acp-matrix` suite (1, real upstream provider errors). No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
