### PR TITLE
fix(duty): derive a duty group for every agent, not only for edge-bearing ones

### DIFF
--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -81,12 +81,12 @@ pool membership.
 | D2  | Sleep                   | Agents sleep (existing sandbox suspension); wake = existing `SandboxClaim` flow; no new machinery                                                                                                     |
 | D3  | Connection direction    | The duty holder dials the sandbox; the shim is a hardened listener; one NetworkPolicy ingress-rule amendment                                                                                          |
 | D4  | Member anatomy          | Singleton machinery + per-agent rooms + thin refcounted org contexts; the session stays the atomic unit                                                                                               |
-| D5  | Duty group              | The claim unit is the connected component of the agent↔daemon-held-bot graph, claimed atomically under one term                                                                                       |
+| D5  | Duty group              | The claim unit is the connected component of the agent↔daemon-held-bot graph — every agent is a node, so an edgeless one is its own singleton — claimed atomically under one term                     |
 | D6  | Lease service           | CP-hosted `duty_group` ledger over the fleet WS, with a derived membership projection; vacancy grant = the claim call                                                                                 |
 | D7  | Lease timing            | Batched renewals; T_fence self-fence < T_reassign; startup recovery grace                                                                                                                             |
 | D8  | Cross-member paths      | `rd/agentmsg` stays A2A-only; the rendezvous adds a `not_holder` NAK on the inbound `rd/msg` path; no redirects, no presence streams; the ledger is the directory                                     |
 | D9  | Org context on the wire | Install-wide connection with per-frame `orgId`; reconnect state is a combined multi-org snapshot / revision-fenced stream — no per-org subscription, room, or socket                                  |
-| D10 | Crons                   | A time-based ingress edge: an enabled cron joins the duty-group computation, making the group proactively claimable; the holder fires the schedule locally with today's daemon machinery              |
+| D10 | Crons                   | A time-based trigger against a group that is already proactively claimable (D5), so a schedule always has a home; the holder fires it locally with today's daemon machinery                           |
 | D11 | State                   | Separate data-plane PG, shared tables with an `org` column (org injected by the store handle, never by call sites); daemon-owned async store interfaces, SQLite + PG drivers                          |
 | D12 | Upgrades                | maxSurge ≥ 1, maxUnavailable = 0; drain = duty release + sleep-as-migration                                                                                                                           |
 | D13 | Failure model           | Explicit matrix; two accepted loss windows                                                                                                                                                            |
@@ -163,8 +163,8 @@ agent's work.
 A sleeping agent still belongs to a duty group (§6), and if that group
 contains a daemon-held bot the group stays claimed while the agent sleeps —
 that held duty is precisely what lets the wake message arrive. A singleton
-group with no daemon-held bot has no reason to be held at all, and is claimed
-on the first trigger.
+group with no daemon-held bot carries no connection to keep alive, so it may
+sit vacant until a trigger arrives — but the group itself exists either way.
 
 Wake is the existing spawn flow: whichever member needs the agent creates the
 `SandboxClaim` idempotently (`SandboxApi.ensureClaim`, deterministic name
@@ -183,7 +183,7 @@ the `Bot` and `Integration` rows it already owns.
 
 **The ledger is a `duty_group` table, not columns on existing rows.** Per-row
 leases cannot express the claim unit of §6: they are exactly the independent
-claims that would give one agent two homes, a botless cron agent has no
+claims that would give one agent two homes, a botless agent has no
 `Integration` row to carry a lease at all, and two already-held groups merging
 have no row on which to record the single surviving holder. The shape
 (`packages/control-plane/prisma/schema.prisma`, repo in
@@ -192,9 +192,9 @@ have no row on which to record the single surviving holder. The shape
 - `duty_group` — `(orgId, holder, term, expiresAt)`, one row per connected
   component, the only thing ever claimed.
 - `duty_group_member` — the derived `(agentId|botId → group)` projection,
-  recomputed from `Integration`/`CronDef` rows whenever an edge changes; its
-  composite primary key makes "one home per agent / per bot" a database
-  invariant.
+  recomputed from the org's `Agent` and `Integration` rows whenever an agent or
+  an edge changes; its composite primary key makes "one home per agent / per
+  bot" a database invariant.
 
 **`term` is the fencing token**: monotonic per group, bumped on _every_ grant
 and never on renewal. **Vacancy is temporal**, not referential: a group is
@@ -220,9 +220,9 @@ former members — which makes "the holder of the larger group keeps the merged
 group, ties broken by the lower groupId" a corollary, lets splits follow the
 largest fragment without eviction, and names every superseded holder in the
 plan. The sweep walks orgs on a keyset rotation; a coalescing `kick(orgId)`
-runs the same recompute promptly from the mutation seams (integration
-create/delete, cron upsert/remove, placement moves), with the rotation as the
-backstop.
+runs the same recompute promptly from the mutation seams (agent create/delete,
+integration create/delete, cron upsert/remove, placement moves), with the
+rotation as the backstop.
 
 **The lease protocol rides the existing heartbeat.** Not a new connection,
 timer, or tick (`orchestrator/dutyLease.ts`):
@@ -287,20 +287,36 @@ mechanism count is forever.
 | ----------------------------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | Agent with agent-bound bots (Telegram, Discord)       | `{agent, bot…}`                 | Ingress and execution co-located by construction                                                               |
 | Shared daemon-held bot (Slack Socket Mode, Feishu WS) | `{bot, …every agent it serves}` | One socket per bot token — its agents cluster at the socket's owner                                            |
-| Agent with an enabled cron                            | `{agent, cron edges…}`          | A cron is a time-based ingress edge (§9): the group is proactively claimable so the schedule always has a home |
-| Relay-ingress-only / webchat / A2A agent              | `{agent}`                       | A singleton, created on the first trigger's claim ("claiming creates the lease")                               |
+| Agent with an enabled cron                            | `{agent}`                       | A cron needs a home like any other trigger; the singleton below already is one, so the schedule always has one |
+| Relay-ingress-only / webchat / A2A agent              | `{agent}`                       | A singleton, derived by the recompute — every agent is ownable, so it is proactively claimable                 |
 
-Edges come from active `Integration` rows whose bot has `transport: 'socket'`
-plus enabled `CronDef` rows; relay-ingress (`http`) integrations create no
-edge because the relay, not the daemon, owns that socket. An oversized group
-is the mechanical signal for a dedicated daemon (D16).
+**Every agent is a node.** The component set is seeded from the org's `agent`
+rows and then merged by edges; an edge only forces **co-location**, it is not
+what makes an agent ownable. Edges come from active `Integration` rows whose
+bot has `transport: 'socket'`; relay-ingress (`http`) integrations create no
+edge because the relay, not the daemon, owns that socket. Crons need no input
+of their own — a cron's agent is an agent. An oversized group is the mechanical
+signal for a dedicated daemon (D16).
+
+Deriving the singleton rather than minting it on first contact is what keeps
+the ledger self-consistent: an edgeless agent used to appear in **no** computed
+component, so the recompute's final "delete every group no component claimed"
+pass reaped the singleton the activation rendezvous had just minted, and the
+next trigger minted it again — a grant/revoke loop that interrupted the agent's
+in-flight turn on every sweep. The cost is one `duty_group` row per agent per
+org, most of them permanently vacant in a deployment whose agents live on
+org-scoped daemons; vacancy is cheap by construction (§5) and the `incumbent`
+grant policy filters those rows out inside `claimVacant`, so they consume no
+grant budget.
 
 ### The activation rendezvous
 
 A trigger for an _unheld_ group has nowhere to go — the ledger names no holder
 for a group nobody has claimed. The resolution keeps members volunteering and
 adds no component: the relay routes the trigger to **any connected member**,
-and that member claims the group on receipt.
+and that member claims the group on receipt. The claim normally lands on a
+group the recompute already derived; minting one is the fallback for the window
+between an agent's creation and its first sweep.
 
 - The daemon's `rd/msg` handler checks its duty registry (one gate covers all
   four message sources). On a miss it sends `duty/claim`; a win returns a
@@ -407,13 +423,13 @@ Nothing here is new mechanism: the polling connection is today's
 `K8sDriver.ensureSandbox`/`bindChannel` with the dial direction flipped, and
 the session machinery is untouched.
 
-## 9. Crons are a time-based ingress edge (D10)
+## 9. Crons are a time-based trigger, not an input (D10)
 
 An enabled `CronDef` is a standing reason for its agent's duty group to be
-held — exactly as a bot connection is — so the group computation takes
-`CronDef` rows as input alongside `Integration` rows, and a cron-bearing group
-is **proactively claimable**: it appears in the vacancy pool even while its
-agent sleeps. The holder loads the schedule with the ordinary daemon-side
+held — exactly as a bot connection is. It needs no input of its own: every
+agent already seeds a component (§6), so a cron-bearing group is **proactively
+claimable** like any other, appearing in the vacancy pool even while its agent
+sleeps. The holder loads the schedule with the ordinary daemon-side
 machinery (`croner` in `packages/daemon/src/scheduler/scheduler.ts`, its
 roster filter following group holdership) and fires it locally; at fire time
 the holder is already the agent's home, so the wake is §8 with no routing step

--- a/packages/control-plane/src/domain/duty.ts
+++ b/packages/control-plane/src/domain/duty.ts
@@ -4,14 +4,15 @@
 
 export type DutyMemberKind = 'agent' | 'bot'
 
-/** An active Integration row whose bot the daemon itself connects (socket transport). */
+/** An active Integration row whose bot the daemon itself connects (socket transport).
+ *  An edge only forces CO-LOCATION; it is not what makes an agent ownable. */
 export interface DutyEdge {
   agentId: string
   botId: string
 }
 
-/** An enabled cron: the agent must belong to a claimable group even with no bots. */
-export interface CronSeed {
+/** Every agent is ownable: it seeds at least a singleton, with or without edges. */
+export interface AgentSeed {
   agentId: string
 }
 

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1517,6 +1517,9 @@ export function agentRoutes(deps: HttpDeps) {
           // closed until the registry validates it.
           await pushExternalMemoryBeforeAgent(agent)
           await replicateUpsert(agent) // no-op until placed; reconcile carries it otherwise
+          // Mint the agent's duty group now, so a pool member can claim it on its
+          // next beat instead of waiting for the first trigger's rendezvous.
+          deps.recomputeDuties?.(agent.orgId)
           // A create that arrives already PLACED (`daemonId` in the body) must also enter
           // the peer directory now. `replicateUpsert` only ships the AgentSpec (same-daemon
           // authorization); a peer WAKE is authorized against the collaboration snapshot,
@@ -2483,6 +2486,9 @@ export function agentRoutes(deps: HttpDeps) {
             }
           }
           await replicateRemove(current.id, current.daemonId, current.orgId)
+          // AFTER the fan-out: `remove` resolves holders from the membership rows
+          // the reap deletes, and the agent row this reads by is already gone.
+          deps.recomputeDuties?.(current.orgId)
           if (current.daemonId && current.memory?.provider === 'external') {
             await removeExternalMemoryFromDaemonIfUnused(current.orgId, current.daemonId, current.memory.connectionId)
           }

--- a/packages/control-plane/src/orchestrator/dutyGroup.test.ts
+++ b/packages/control-plane/src/orchestrator/dutyGroup.test.ts
@@ -47,9 +47,20 @@ describe('computeDutyComponents', () => {
     expect(out).toEqual([comp(agent('a1'), agent('a2'), bot('shared'), bot('tg'))])
   })
 
-  it('an enabled cron seeds a singleton component for a botless agent', () => {
+  it('every agent seeds a component; a botless one gets a singleton', () => {
     const out = computeDutyComponents([{ agentId: 'a1', botId: 'b1' }], [{ agentId: 'lone' }, { agentId: 'a1' }])
     expect(out).toEqual([comp(agent('a1'), bot('b1')), comp(agent('lone'))])
+  })
+
+  it('an agent listed after its edge keeps the merged component, not a duplicate singleton', () => {
+    const out = computeDutyComponents(
+      [
+        { agentId: 'a1', botId: 'shared' },
+        { agentId: 'a2', botId: 'shared' }
+      ],
+      [{ agentId: 'a1' }, { agentId: 'a2' }, { agentId: 'a3' }]
+    )
+    expect(out).toEqual([comp(agent('a1'), agent('a2'), bot('shared')), comp(agent('a3'))])
   })
 
   it('is deterministic regardless of input order', () => {

--- a/packages/control-plane/src/orchestrator/dutyGroup.ts
+++ b/packages/control-plane/src/orchestrator/dutyGroup.ts
@@ -1,10 +1,10 @@
-// Pure duty-group math for k8s daemons: connected components of the
-// agent↔daemon-held-bot graph (an enabled cron is an edge too), plus the
-// deterministic reconcile plan that maps freshly computed components onto the
-// persisted `duty_group` rows. No I/O — the repo applies the plan it returns.
-import type { DutyMemberKind, DutyMemberKey, DutyReconcilePlan, DutyEdge, CronSeed } from '../domain/duty.js'
+// Pure duty-group math for k8s daemons: EVERY agent is a node, and connected
+// components of the agent↔daemon-held-bot graph merge the ones that share a bot,
+// plus the deterministic reconcile plan that maps freshly computed components
+// onto the persisted `duty_group` rows. No I/O — the repo applies the plan.
+import type { DutyMemberKind, DutyMemberKey, DutyReconcilePlan, DutyEdge, AgentSeed } from '../domain/duty.js'
 
-export type { DutyMemberKind, DutyMemberKey, DutyReconcilePlan, DutyEdge, CronSeed }
+export type { DutyMemberKind, DutyMemberKey, DutyReconcilePlan, DutyEdge, AgentSeed }
 
 export interface ComputedComponent {
   /** Canonically sorted, deduplicated membership. */
@@ -43,8 +43,8 @@ function canonical(members: Iterable<DutyMemberKey>): DutyMemberKey[] {
   return [...seen.values()].sort(compareMembers)
 }
 
-/** Union-find over agent/bot nodes; every edge joins, every seed guarantees a node. */
-export function computeDutyComponents(edges: DutyEdge[], seeds: CronSeed[]): ComputedComponent[] {
+/** Union-find over agent/bot nodes; every agent is a node, every edge joins. */
+export function computeDutyComponents(edges: DutyEdge[], agents: AgentSeed[]): ComputedComponent[] {
   const parent = new Map<string, string>()
   const find = (x: string): string => {
     let r = x
@@ -74,7 +74,8 @@ export function computeDutyComponents(edges: DutyEdge[], seeds: CronSeed[]): Com
     add(b)
     union(a, b)
   }
-  for (const s of seeds) add(keyOf({ kind: 'agent', refId: s.agentId }))
+  // After the edges: an agent that already joined a bot keeps that component.
+  for (const a of agents) add(keyOf({ kind: 'agent', refId: a.agentId }))
 
   const byRoot = new Map<string, DutyMemberKey[]>()
   for (const k of parent.keys()) {

--- a/packages/control-plane/src/orchestrator/dutyRecompute.ts
+++ b/packages/control-plane/src/orchestrator/dutyRecompute.ts
@@ -1,6 +1,6 @@
 // DutyRecomputeSweep — keeps the duty ledger's membership projection derived
 // from reality: every tick it walks a slice of orgs (keyset rotation), recomputes
-// connected components from Integration/CronDef rows, and applies the plan.
+// connected components from the org's agents and Integration rows, applies the plan.
 // The sweep only WRITES THE LEDGER — grants, re-grants after a merge, and
 // supersessions all reach daemons through the next heartbeat's lease exchange,
 // so no delivery mechanism exists here to duplicate or race it.
@@ -113,8 +113,8 @@ export class DutyRecomputeSweep {
   }
 
   async recomputeOrg(orgId: string): Promise<void> {
-    const { edges, seeds } = await this.repo.computeInputs(OrgId(orgId))
-    const components = computeDutyComponents(edges, seeds)
+    const { edges, agents } = await this.repo.computeInputs(OrgId(orgId))
+    const components = computeDutyComponents(edges, agents)
     const now = new Date(this.clock.now())
     await this.repo.applyReconcile(
       OrgId(orgId),

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -40,7 +40,7 @@ import type {
   OrgId
 } from '../domain/ids.js'
 import type { SessionKey } from '../domain/sessionKey.js'
-import type { DutyMemberKey, DutyReconcilePlan, DutyEdge, CronSeed } from '../domain/duty.js'
+import type { DutyMemberKey, DutyReconcilePlan, DutyEdge, AgentSeed } from '../domain/duty.js'
 import type {
   OrganizationEnvironmentAudience,
   OrganizationEnvironmentKind,
@@ -5054,15 +5054,16 @@ export interface DutyGroupRepo {
     leaseMs: number,
     opts?: { maxMembers?: number; incumbentOnly?: boolean }
   ): Promise<DutyGrantRecord[]>
-  /** The group-computation inputs for one org: active integrations on
-   *  daemon-held (socket, unrevoked) bots as edges; enabled crons as seeds. */
-  computeInputs(orgId: OrgId): Promise<{ edges: DutyEdge[]; seeds: CronSeed[] }>
+  /** The group-computation inputs for one org: every agent as a node, plus
+   *  active integrations on daemon-held (socket, unrevoked) bots as edges. */
+  computeInputs(orgId: OrgId): Promise<{ edges: DutyEdge[]; agents: AgentSeed[] }>
   /** Keyset rotation over orgs that can need a recompute — any org owning an
-   *  integration, an enabled cron, or an existing duty group. */
+   *  agent or an existing duty group. */
   listDutyOrgs(afterOrgId: string | null, limit: number): Promise<string[]>
   /** Soak-phase placement fence: vacate every held group whose holder no longer
    *  hosts ANY of its agents (a full placement move-away), so the new incumbent
-   *  can claim. Partial occupancy keeps the lease — split groups never flap.
+   *  can claim. Partial occupancy keeps the lease — split groups never flap —
+   *  and so does a group whose agents are all unplaced: nothing moved away.
    *  Returns the vacated groupIds. */
   vacateNonIncumbent(orgId: OrgId): Promise<string[]>
   /** Batched renewal — one write per heartbeat covering every held group.

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -3,7 +3,7 @@
 // the lease. Every grant path bumps `term` (the fencing token); renewal never
 // does. Vacancy is temporal: `holder IS NULL` or a lapsed `expiresAt`.
 import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
-import type { DutyMemberKey, DutyReconcilePlan, DutyEdge, CronSeed } from '../../domain/duty.js'
+import type { DutyMemberKey, DutyReconcilePlan, DutyEdge, AgentSeed } from '../../domain/duty.js'
 import type { AgentHomeClaim, DutyGrantRecord, DutyGroupRecord, DutyGroupRepo, DutyReconcilePlanner } from '../ports.js'
 import type { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import { withTx } from '../prisma.js'
@@ -93,12 +93,17 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     // AT LEAST ONE of its agents — so a split group cannot flap between two
     // partial incumbents — but a full move-away vacates the lease, letting the
     // new incumbent claim on its next beat (the old holder learns via digest
-    // diff as a superseded revocation).
+    // diff as a superseded revocation). A move-away needs somewhere to have
+    // moved TO: a group whose agents are all unplaced has no rival incumbent,
+    // and vacating it every sweep would just churn the rendezvous claim that
+    // put a holder there.
     const rows = await this.prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
       UPDATE "duty_group" g SET "holder" = NULL, "expiresAt" = NULL
       WHERE g."orgId" = ${orgId} AND g."holder" IS NOT NULL
         AND EXISTS (
-          SELECT 1 FROM "duty_group_member" m WHERE m."groupId" = g.id AND m."kind" = 'agent'
+          SELECT 1 FROM "duty_group_member" m
+          JOIN "agent" a ON a.id = m."refId"
+          WHERE m."groupId" = g.id AND m."kind" = 'agent' AND a."daemonId" IS NOT NULL
         )
         AND NOT EXISTS (
           SELECT 1 FROM "duty_group_member" m
@@ -110,29 +115,33 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     return rows.map((r) => r.id).sort()
   }
 
-  async computeInputs(orgId: OrgId): Promise<{ edges: DutyEdge[]; seeds: CronSeed[] }> {
-    const [integrations, crons] = await Promise.all([
+  // EVERY agent seeds a component. The ledger's whole job is to name one owner
+  // per agent, and ownability is a property of the agent, not of its ingress —
+  // an agent with no socket bot and no cron (webchat, A2A, relay-ingress only)
+  // is exactly the case the edge-derived set used to miss, leaving the sweep to
+  // delete the singleton the activation rendezvous had just minted. Crons need
+  // no query of their own any more: a cron's agent is an agent.
+  async computeInputs(orgId: OrgId): Promise<{ edges: DutyEdge[]; agents: AgentSeed[] }> {
+    const [integrations, agents] = await Promise.all([
       this.prisma.integration.findMany({
         where: { orgId, status: 'active', bot: { transport: 'socket', revokedAt: null } },
         select: { agentId: true, botId: true }
       }),
-      this.prisma.cronDef.findMany({
-        where: { orgId, enabled: true, agentId: { not: null } },
-        select: { agentId: true }
-      })
+      this.prisma.agent.findMany({ where: { orgId }, select: { id: true } })
     ])
     return {
       edges: integrations.map((i) => ({ agentId: i.agentId, botId: i.botId })),
-      seeds: crons.flatMap((c) => (c.agentId ? [{ agentId: c.agentId }] : []))
+      agents: agents.map((a) => ({ agentId: a.id }))
     }
   }
 
+  // Any org with an agent has components to derive; `duty_group` keeps orgs
+  // whose last agent is gone in the rotation until their rows are reaped.
   async listDutyOrgs(afterOrgId: string | null, limit: number): Promise<string[]> {
     const after = afterOrgId ?? ''
     const rows = await this.prisma.$queryRaw<{ orgId: string }[]>(Prisma.sql`
       SELECT DISTINCT "orgId" FROM (
-        SELECT "orgId" FROM "integration"
-        UNION SELECT "orgId" FROM "cron_def" WHERE "enabled"
+        SELECT "orgId" FROM "agent"
         UNION SELECT "orgId" FROM "duty_group"
       ) orgs
       WHERE "orgId" > ${after}

--- a/packages/control-plane/test/repo/duty-recompute.test.ts
+++ b/packages/control-plane/test/repo/duty-recompute.test.ts
@@ -1,12 +1,13 @@
 // DutyRecomputeSweep + the soak-phase incumbent grant policy (real Postgres):
-// the sweep derives duty groups from Integration/CronDef rows, and claimVacant's
-// incumbent gate pins grants to the member the group's agents already live on.
+// the sweep derives one duty group per agent (merged by shared socket bots), and
+// claimVacant's incumbent gate pins grants to the member its agents live on.
 import { describe, it, expect, vi } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { PgDutyGroupRepo } from '../../src/persistence/index.js'
 import { DutyRecomputeSweep } from '../../src/orchestrator/dutyRecompute.js'
+import type { DutyReconcilePlan } from '../../src/domain/duty.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
-import { DaemonId } from '../../src/domain/ids.js'
+import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
 import { FakeClock } from '../fakes/fake-clock.js'
 
 const M1 = DaemonId('d1111111-1111-4111-8111-111111111111')
@@ -21,18 +22,41 @@ const INTEG2 = '11111111-1111-4111-8111-11111111111b'
 
 const LEASE_MS = 120_000
 
+const ORG = OrgId(DEFAULT_ORG_ID)
+
+// Records every applied plan and every warning, so a test can assert what the
+// sweep DID — "no revoke was planned" is not observable from the rows alone.
 function sweep(clock = new FakeClock(1_700_000_000_000)) {
   const repo = new PgDutyGroupRepo(prisma)
+  const plans: DutyReconcilePlan[] = []
+  const warns: unknown[] = []
+  const recording = {
+    listDutyOrgs: repo.listDutyOrgs.bind(repo),
+    computeInputs: repo.computeInputs.bind(repo),
+    applyReconcile: async (...args: Parameters<typeof repo.applyReconcile>) => {
+      const plan = await repo.applyReconcile(...args)
+      plans.push(plan)
+      return plan
+    },
+    vacateNonIncumbent: repo.vacateNonIncumbent.bind(repo)
+  }
   return {
     repo,
     clock,
-    sweep: new DutyRecomputeSweep(repo, clock, {
-      intervalMs: 30_000,
-      orgsPerTick: 25,
-      leaseMs: LEASE_MS,
-      incumbentFence: true,
-      kickDelayMs: 0
-    })
+    plans,
+    warns,
+    sweep: new DutyRecomputeSweep(
+      recording,
+      clock,
+      {
+        intervalMs: 30_000,
+        orgsPerTick: 25,
+        leaseMs: LEASE_MS,
+        incumbentFence: true,
+        kickDelayMs: 0
+      },
+      { warn: (o) => void warns.push(o), error: () => undefined }
+    )
   }
 }
 
@@ -62,27 +86,30 @@ async function seedIntegration(id: string, agentId: string, botId: string): Prom
 }
 
 describe('duty recompute sweep (real Postgres)', () => {
-  it('derives groups from socket integrations and enabled crons; http-only agents get none', async () => {
+  it('joins an agent to its socket bot and leaves a relay-ingress agent its own singleton', async () => {
     await seedDaemons()
     await seedAgent(AGENT, 'agent-1', M1)
     await seedAgent(AGENT2, 'agent-2', M1)
     await seedBot(BOT, 'socket')
     await seedBot(HTTP_BOT, 'http')
     await seedIntegration(INTEG, AGENT, BOT)
-    await seedIntegration(INTEG2, AGENT2, HTTP_BOT) // relay-ingress: no edge
+    await seedIntegration(INTEG2, AGENT2, HTTP_BOT) // relay-ingress: no edge, but still ownable
     const { repo, sweep: s } = sweep()
 
     expect(await s.tick()).toBe(1)
-    const groups = await repo.listForOrg(DEFAULT_ORG_ID as Parameters<typeof repo.listForOrg>[0])
-    expect(groups).toHaveLength(1)
-    expect(groups[0]!.members).toEqual([
-      { kind: 'agent', refId: AGENT },
-      { kind: 'bot', refId: BOT }
+    // listForOrg orders by the minted (random) groupId, so compare as a set.
+    const groups = await repo.listForOrg(ORG)
+    expect(groups.map((g) => g.members).sort((a, b) => a[0]!.refId.localeCompare(b[0]!.refId))).toEqual([
+      [
+        { kind: 'agent', refId: AGENT },
+        { kind: 'bot', refId: BOT }
+      ],
+      [{ kind: 'agent', refId: AGENT2 }]
     ])
-    expect(groups[0]!.holder).toBeNull()
+    expect(groups.every((g) => g.holder === null)).toBe(true)
   })
 
-  it('an enabled cron seeds a claimable singleton; disabling it removes the group', async () => {
+  it('a cron adds nothing of its own — the agent already owns a singleton, enabled or not', async () => {
     await seedDaemons()
     await seedAgent(AGENT, 'agent-1', M1)
     await prisma.cronDef.create({
@@ -100,14 +127,126 @@ describe('duty recompute sweep (real Postgres)', () => {
     const { repo, sweep: s } = sweep()
 
     await s.tick()
-    let groups = await repo.listForOrg(DEFAULT_ORG_ID as Parameters<typeof repo.listForOrg>[0])
-    expect(groups).toHaveLength(1)
-    expect(groups[0]!.members).toEqual([{ kind: 'agent', refId: AGENT }])
+    const [group] = await repo.listForOrg(ORG)
+    expect(group!.members).toEqual([{ kind: 'agent', refId: AGENT }])
 
     await prisma.cronDef.update({ where: { id: CRON }, data: { enabled: false } })
     await s.tick()
-    groups = await repo.listForOrg(DEFAULT_ORG_ID as Parameters<typeof repo.listForOrg>[0])
-    expect(groups).toEqual([])
+    expect(await repo.listForOrg(ORG)).toEqual([group])
+  })
+
+  it('an agent with no integration and no cron converges to a stable held group', async () => {
+    await seedDaemons()
+    await seedAgent(AGENT, 'agent-1', M1) // webchat / A2A only: no edge, no seed
+    const { repo, clock, plans, warns, sweep: s } = sweep()
+
+    await s.tick()
+    const [created] = await repo.listForOrg(ORG)
+    expect(created!.members).toEqual([{ kind: 'agent', refId: AGENT }])
+    const [grant] = await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { incumbentOnly: true })
+    expect(grant).toBeDefined()
+
+    // The flap this test exists for: sweep 2 and 3 must plan no delete and no
+    // supersession, and must leave the term exactly where the grant put it.
+    plans.length = 0
+    await s.tick()
+    await s.tick()
+    expect(plans).toHaveLength(2)
+    for (const plan of plans) {
+      expect(plan.deletes).toEqual([])
+      expect(plan.superseded).toEqual([])
+      expect(plan.creates).toEqual([])
+      expect(plan.writes).toEqual([])
+      expect(plan.unchanged).toEqual([created!.groupId])
+    }
+    const [held] = await repo.listHeldBy(M1)
+    expect(held!.groupId).toBe(created!.groupId)
+    expect(held!.term).toBe(grant!.term)
+    expect(warns).toEqual([])
+  })
+
+  it('a rendezvous claim survives the next sweep with the same holder and term', async () => {
+    await seedDaemons()
+    await seedAgent(AGENT, 'agent-1', M1)
+    const { repo, clock, warns, sweep: s } = sweep()
+
+    // The design's fallback path: the trigger arrives before the sweep ran.
+    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), M1, new Date(clock.now()), LEASE_MS)
+    expect(claim.granted).toBe(true)
+
+    await s.tick()
+    const [held] = await repo.listHeldBy(M1)
+    expect(held!.groupId).toBe(claim.groupId)
+    expect(held!.term).toBe(claim.term)
+    expect(held!.members).toEqual([{ kind: 'agent', refId: AGENT }])
+    expect(warns).toEqual([])
+  })
+
+  it('an unplaced agent’s rendezvous claim is not vacated — nothing moved away', async () => {
+    await seedDaemons()
+    await seedAgent(AGENT, 'agent-1') // no placement: the fence has no rival incumbent
+    const { repo, clock, warns, sweep: s } = sweep()
+
+    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), M1, new Date(clock.now()), LEASE_MS)
+    await s.tick()
+
+    const [held] = await repo.listHeldBy(M1)
+    expect(held!.groupId).toBe(claim.groupId)
+    expect(held!.term).toBe(claim.term)
+    expect(warns).toEqual([])
+  })
+
+  it('reaps the group of an agent whose row is gone', async () => {
+    await seedDaemons()
+    await seedAgent(AGENT, 'agent-1', M1)
+    const { repo, plans, sweep: s } = sweep()
+
+    await s.tick()
+    const [created] = await repo.listForOrg(ORG)
+    await prisma.agent.delete({ where: { id: AGENT } })
+
+    plans.length = 0
+    await s.tick()
+    expect(plans[0]!.deletes).toEqual([created!.groupId])
+    expect(await repo.listForOrg(ORG)).toEqual([])
+  })
+
+  it('an agent gaining its first integration merges into its singleton instead of duplicating', async () => {
+    await seedDaemons()
+    await seedAgent(AGENT, 'agent-1', M1)
+    const { repo, clock, sweep: s } = sweep()
+
+    await s.tick()
+    const [singleton] = await repo.listForOrg(ORG)
+    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { incumbentOnly: true })
+
+    await seedBot(BOT, 'socket')
+    await seedIntegration(INTEG, AGENT, BOT)
+    await s.tick()
+
+    const groups = await repo.listForOrg(ORG)
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.groupId).toBe(singleton!.groupId)
+    expect(groups[0]!.holder).toBe(M1)
+    expect(groups[0]!.members).toEqual([
+      { kind: 'agent', refId: AGENT },
+      { kind: 'bot', refId: BOT }
+    ])
+  })
+
+  it('two agents sharing a socket bot land in one group, not one each', async () => {
+    await seedDaemons()
+    await seedAgent(AGENT, 'agent-1', M1)
+    await seedAgent(AGENT2, 'agent-2', M1)
+    await seedBot(BOT, 'socket')
+    await seedIntegration(INTEG, AGENT, BOT)
+    await seedIntegration(INTEG2, AGENT2, BOT)
+    const { repo, sweep: s } = sweep()
+
+    await s.tick()
+    const groups = await repo.listForOrg(ORG)
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.members).toHaveLength(3)
   })
 
   it('a repeated tick over unchanged rows writes nothing (idempotent rotation)', async () => {
@@ -118,9 +257,9 @@ describe('duty recompute sweep (real Postgres)', () => {
     const { repo, sweep: s } = sweep()
 
     await s.tick()
-    const before = await repo.listForOrg(DEFAULT_ORG_ID as Parameters<typeof repo.listForOrg>[0])
+    const before = await repo.listForOrg(ORG)
     await s.tick()
-    const after = await repo.listForOrg(DEFAULT_ORG_ID as Parameters<typeof repo.listForOrg>[0])
+    const after = await repo.listForOrg(ORG)
     expect(after).toEqual(before)
   })
 
@@ -240,7 +379,7 @@ describe('duty recompute kick (real Postgres)', () => {
     s.kick(DEFAULT_ORG_ID)
     clock.advance(1)
     await vi.waitFor(async () => {
-      const groups = await repo.listForOrg(DEFAULT_ORG_ID as Parameters<typeof repo.listForOrg>[0])
+      const groups = await repo.listForOrg(ORG)
       expect(groups).toHaveLength(1)
     })
   })
@@ -286,6 +425,6 @@ describe('duty recompute kick (real Postgres)', () => {
     s.stop()
     clock.advance(1_000)
     await new Promise((r) => setTimeout(r, 20))
-    expect(await repo.listForOrg(DEFAULT_ORG_ID as Parameters<typeof repo.listForOrg>[0])).toEqual([])
+    expect(await repo.listForOrg(ORG)).toEqual([])
   })
 })


### PR DESCRIPTION
## The failure

With `features.dutyEnforcement` on, a pooled agent that has **no socket-transport
integration and no enabled cron** flaps forever:

```
duty: granted 1 + re-granted 0 group(s); holding 1 covering 1 agent(s)
duty: revoked 1 group(s) (gone); 1 agent(s) left service
stop: interrupting 1 active session(s) for agent "<id>"
duty: granted 1 + re-granted 0 group(s); holding 1 covering 1 agent(s)
webchat: agent "<id>" is stopping an interrupted turn — rejecting turn
duty: revoked 1 group(s) (gone); 1 agent(s) left service
```

Every revoke runs `stopServingAgent`, so each cycle interrupts the agent's
in-flight turn. In practice **every webchat-only, A2A-only or otherwise botless
agent is unusable on the pool** the moment enforcement is on.

## Root cause

Ownability was being read off the edges, and the two halves of the ledger
disagreed about what that meant:

- `DutyGroupRepo.computeInputs` derived components from exactly two sources —
  `integration` rows whose bot has `transport: 'socket'`, and enabled `cron_def`
  rows. An agent with neither appeared in **no** computed component.
- `planDutyReconcile`'s final loop deletes every existing group that was not
  assigned to a computed component, so a group covering only such an agent is
  planned as a delete. That is the `gone` revoke.
- The activation rendezvous (`claimAgentHome`) *mints* exactly such a singleton
  on the first trigger — the design's stated behavior for a relay-ingress-only /
  webchat / A2A agent ("claiming creates the lease"). The next sweep deletes it,
  the next trigger mints it again.

The design intends these singletons to exist; the recompute planner had no
notion of them.

## The fix

Seed the component set from the org's `agent` rows and let the existing
union-find merge them wherever agents share a bot. **A bot edge only forces
co-location; it is not what makes an agent ownable** — the ledger's whole job is
to give every agent exactly one owner. Recompute now derives what the rendezvous
used to mint, so:

- the planner sees no orphan and plans no delete;
- a group is claimable **proactively**, so a pool rollout heals without waiting
  for a message;
- `claimAgentHome` claims the group that already exists, and "claiming creates
  the lease" becomes the fallback for the window between an agent's creation and
  its first sweep.

Crons need no input of their own any more — a cron's agent is an agent — so the
`cron_def` query is gone from `computeInputs` and from the `listDutyOrgs`
rotation, which now keys off `agent ∪ duty_group`. Agent create/delete join the
existing kick seams (integration CRUD, cron upsert/remove, placement moves); the
delete kick is placed **after** the `agent/remove` fan-out, which resolves
holders from the very membership rows the reap deletes.

One adjacent tightening, needed so the fix does not simply trade one flap for
another: `vacateNonIncumbent` now requires that some agent of the group is
actually placed somewhere before it vacates. A move-away needs somewhere to have
moved *to*; a group whose agents are all unplaced has no rival incumbent, and
vacating it every sweep would turn the `gone` loop into a `superseded` one.

## What was verified

- **Row volume** — one `duty_group` + one `duty_group_member` row per agent per
  org. Nothing queries the ledger assuming sparsity: `listHeldBy`/`getByIds` are
  keyed lookups, and `claimVacant` filters and orders inside SQL before `LIMIT`,
  so it returns only matching rows.
- **Grant budget** — under the shipped `incumbent` policy (`DUTY_LEASE_DEFAULTS`,
  no env override), `claimVacant`'s incumbent gate requires a group agent whose
  `agent.daemonId` is the claimant. Agents placed on org-scoped daemons never
  match, so the large vacant population they create consumes no budget, produces
  no writes, and raises no warnings — asserted directly in the new tests.
  `vacateNonIncumbent` is a no-op on a vacant row, so the sweep does not churn
  them either. Note for later: under the target `any` policy those vacancies
  *would* become claimable pool-wide, which is a widening worth revisiting when
  that policy is switched on.
- **`claimAgentHome`** — the existing-member branch already claims the row in
  place rather than minting a duplicate; the mint branch is now the fallback.
  Covered by a test that claims first and sweeps after.
- **Reaping** — agents are hard-deleted, so a removed agent stops producing a
  component and the planner's delete path still reaps its group.

## Design doc

`docs/designs/k8s-daemon-pool.md` **did** describe the old shape and is corrected
here: D5 and D10 in the decision table, the §6 group-shape table and its
"edges come from…" paragraph (now "every agent is a node", with the flap recorded
as the reason and the vacant-row cost stated), the §4.4 rendezvous paragraph
(minting is the fallback), the §5 projection bullet and kick-seam list, and §9,
which no longer claims `CronDef` rows are an input to the computation.

## Tests

`packages/control-plane/test/repo/duty-recompute.test.ts` (real Postgres) and
`src/orchestrator/dutyGroup.test.ts` (pure). The load-bearing one — an agent with
no integration and no cron converging to a stable held group over three sweeps,
asserting the term does not move and that sweeps 2 and 3 plan no delete, no
supersession, and no write — fails against current main.

Mutation-checked, each reverted after:

| Mutation | Tests that failed |
| --- | --- |
| `computeInputs`: seed from `cron_def` again instead of `agent` | 7 — the stable-group, both rendezvous, relay-ingress singleton, cron-redundancy, reap, and first-integration-merge tests |
| `listDutyOrgs`: restore the `integration ∪ cron_def ∪ duty_group` union | 3 — every test whose org reaches the rotation only through its agent rows |
| `computeDutyComponents`: drop the agent-seeding loop | 2 — both `computeDutyComponents` seeding tests, and nothing else |
| `vacateNonIncumbent`: drop the "some agent is placed" guard | 1 — the unplaced-agent rendezvous test, exactly |

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm format:check`, control-plane `test:unit`
(1610) and `test:int` (1223) all green. The daemon suite fails 15 tests across 5
files (`shim-cancellation`, `shim-exec-handler`, `shim-workspace-files`,
`workspace-git-runner-seam`, live `acp-matrix`) — the documented baseline,
reproduced file-for-file and count-for-count; this diff touches no daemon code
and the daemon package does not depend on the control plane.
