### PR TITLE
feat(evals): firmer, individually binding referee VOTE wording (webchat Werewolf)

### DIFF
--- a/evals/games/webchat-werewolf.ts
+++ b/evals/games/webchat-werewolf.ts
@@ -195,10 +195,19 @@ export class WebchatWerewolfReferee implements ScriptedBrain {
         if (this.day.order.every((alias) => this.day!.spoke.includes(alias))) {
           this.day.spoke = [...this.day.spoke]
           this.phase = 'day-vote'
+          // Firmer, individually binding wording (measured motivation: real
+          // players completed a perfect 6-speaker discussion and then mostly
+          // never cast a vote — the polite invitation read as optional). The
+          // machine-parsed prefix `VOTE <n>. Discussion is closed.` and the
+          // `Living players:` list are load-bearing for the scripted players
+          // and must not change.
           replies.push(
             `VOTE ${this.round}. Discussion is closed. Living players: ${this.aliveAliases().join(', ')}. ` +
-              `Every living player now says their vote out loud in this conversation, exactly once — for example ` +
-              `"${this.aliveAliases()[0]}: I vote for player-2". Name exactly one living player.`
+              `Every living player MUST now cast exactly one vote by posting a message in this conversation in ` +
+              `the exact form "${this.aliveAliases()[0]}: I vote for player-2" (your own name, then your vote). ` +
+              `This applies to YOU personally, whatever you said during the discussion — having no strong read ` +
+              `does not excuse you: pick the most suspicious living player and vote now, in your next message. ` +
+              `Not voting forfeits your voice in the lynch. Name exactly one living player.`
           )
         }
         continue

--- a/evals/games/webchat-werewolf.ts
+++ b/evals/games/webchat-werewolf.ts
@@ -201,13 +201,17 @@ export class WebchatWerewolfReferee implements ScriptedBrain {
           // machine-parsed prefix `VOTE <n>. Discussion is closed.` and the
           // `Living players:` list are load-bearing for the scripted players
           // and must not change.
+          // The example names LIVING players only (review): a literal-minded
+          // player copies the example's target, and a hardcoded alias can be
+          // dead in a later round.
+          const living = this.aliveAliases()
           replies.push(
-            `VOTE ${this.round}. Discussion is closed. Living players: ${this.aliveAliases().join(', ')}. ` +
+            `VOTE ${this.round}. Discussion is closed. Living players: ${living.join(', ')}. ` +
               `Every living player MUST now cast exactly one vote by posting a message in this conversation in ` +
-              `the exact form "${this.aliveAliases()[0]}: I vote for player-2" (your own name, then your vote). ` +
-              `This applies to YOU personally, whatever you said during the discussion — having no strong read ` +
-              `does not excuse you: pick the most suspicious living player and vote now, in your next message. ` +
-              `Not voting forfeits your voice in the lynch. Name exactly one living player.`
+              `the form "${living[0]}: I vote for ${living[1] ?? living[0]}" — your own name, then ONE living ` +
+              `player from the list above. This applies to YOU personally, whatever you said during the ` +
+              `discussion — having no strong read does not excuse you: pick the most suspicious living player ` +
+              `and vote now, in your next message. Not voting forfeits your voice in the lynch.`
           )
         }
         continue


### PR DESCRIPTION
## What

Stacked on #984/#985 (retargets as they merge). Eval-side only — no product code.

Measured motivation: the 7-player real game completed a **perfect six-speaker sequential discussion** and then stalled at day-vote with one ballot cast — zero hop refusals, zero gated wakes, zero lost replies. The polite "now says their vote out loud" invitation read as optional to players with no strong read.

The referee's vote announcement now binds each player personally: *every living player MUST cast exactly one vote, in your next message; having no strong read does not excuse you; not voting forfeits your voice.* The machine-parsed prefix (`VOTE <n>. Discussion is closed.`) and the `Living players:` list are byte-identical, so the scripted players' parsing is untouched — both CI games pass unmodified. The real effect shows in the 7-player runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)