### PR TITLE
feat(duty): follow the duty holder with MCP and external-memory definitions

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -690,6 +690,16 @@ export function buildContainer(
     platforms,
     specs: agentSpecs,
     crons: repos.cron,
+    // The `duty/fetch` bundle's MCP + external-memory projections (same seams the
+    // reconcile roster below is given, same projector).
+    mcp: { providers: repos.mcpProvider, grants: repos.mcpGrant, relayRoster },
+    memory: {
+      connections: repos.externalMemoryConnection,
+      installations: repos.memoryPluginInstallation,
+      secrets: repos.externalMemoryConnectionSecret,
+      grants: repos.externalMemoryGrant,
+      relayRoster
+    },
     control: sender,
     hooks: hookService,
     httpBot,
@@ -1136,7 +1146,8 @@ export function buildContainer(
           installations: repos.memoryPluginInstallation,
           secrets: repos.externalMemoryConnectionSecret,
           grants: repos.externalMemoryGrant,
-          daemons: repos.daemon,
+          agents: repos.agent,
+          delivery: agentDelivery,
           control: sender,
           log: http.log
         })
@@ -1432,7 +1443,8 @@ export function buildContainer(
           if (!selected) return
           await syncMemoryConnectionsToDaemons(relayHttpOrigin(selected.url), {
             ...memoryDeps,
-            daemons: repos.daemon,
+            agents: repos.agent,
+            delivery: agentDelivery,
             control: sender
           })
         })().catch(() => http.log.error('relay: memory binding/daemon sync on register failed'))

--- a/packages/control-plane/src/http/mcp-push.ts
+++ b/packages/control-plane/src/http/mcp-push.ts
@@ -28,10 +28,13 @@ export function makeMcpPush(deps: HttpDeps): McpPush {
     return url ? relayHttpOrigin(url) : null
   }
 
-  // Daemons with a placed agent that enabled `name` (runtimeOverrides.mcpServers).
+  // Every daemon SERVING an agent that enabled `name` — its placement plus any
+  // duty holder. Resolved through AgentDelivery, never `a.daemonId` inline: a
+  // holder that installed the agent through `duty/fetch` must see the provider's
+  // rotations and its removal, or it keeps calling with a retired grant key.
   const daemonsEnabling = async (orgId: OrgId, name: string): Promise<string[]> => {
-    const agents = await deps.repos.agent.list(orgId)
-    return [...new Set(agents.filter((a) => a.daemonId && a.mcpServers.includes(name)).map((a) => a.daemonId!))]
+    const agents = (await deps.repos.agent.list(orgId)).filter((a) => a.mcpServers.includes(name))
+    return deps.agentDelivery.daemonsForAgents(agents)
   }
 
   return {

--- a/packages/control-plane/src/http/mcp-push.ts
+++ b/packages/control-plane/src/http/mcp-push.ts
@@ -10,10 +10,12 @@
 import type { McpProviderRecord, McpHeader } from '../persistence/ports.js'
 import type { OrgId } from '../domain/ids.js'
 import type { HttpDeps } from './deps.js'
-import { mcpProxyDef, mcpRcAssign, relayHttpOrigin } from '../orchestrator/mcpProvider.js'
+import { mcpProxyDef, mcpRcAssign, relayHttpOrigin, type GrantView } from '../orchestrator/mcpProvider.js'
 
 export interface McpPush {
-  pushAssign(provider: McpProviderRecord, headers: McpHeader[], grantKey: string, orgId: OrgId): Promise<void>
+  /** Takes the grant ROW: the daemon def carries its issuance instant as the
+   *  ordering marker, and that must come from the same grant as the key. */
+  pushAssign(provider: McpProviderRecord, headers: McpHeader[], grant: GrantView, orgId: OrgId): Promise<void>
   pushUnassign(provider: McpProviderRecord, orgId: OrgId): Promise<void>
 }
 
@@ -41,11 +43,11 @@ export function makeMcpPush(deps: HttpDeps): McpPush {
     // Best-effort double-push (like integrations): the relay binding carries the
     // UPSTREAM secret headers; the daemon proxy def carries the grant key + relay URL.
     // NEVER logged. Swallows NoConnection per daemon (reconcile is the backstop).
-    async pushAssign(provider, headers, grantKey, orgId) {
-      deps.relayControl.mcpAssign(mcpRcAssign(provider, headers, [grantKey]))
+    async pushAssign(provider, headers, grant, orgId) {
+      deps.relayControl.mcpAssign(mcpRcAssign(provider, headers, [grant.key]))
       const base = await relayBaseUrl()
       if (!base) return
-      const spec = mcpProxyDef(provider, grantKey, base)
+      const spec = mcpProxyDef(provider, grant, base)
       for (const d of await daemonsEnabling(orgId, provider.name)) {
         try {
           await deps.control.mcpServerUpsert(d, spec)

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -943,14 +943,18 @@ export function agentRoutes(deps: HttpDeps) {
     // daemon-local defs and left alone. Best-effort + never throws: an offline daemon
     // (or transient error) is covered by the reconcile roster on its next register.
     const syncMcpDefsForAgent = async (
-      orgId: OrgId,
-      daemonId: string,
+      agent: AgentRecord,
       before: readonly string[],
       after: readonly string[]
     ): Promise<void> => {
+      const orgId = agent.orgId
       const added = after.filter((n) => !before.includes(n))
       const removed = before.filter((n) => !after.includes(n))
       if (added.length === 0 && removed.length === 0) return
+      // Every daemon serving this agent, not just its placement: a duty holder
+      // installed the same enable-list and needs the same defs.
+      const targets = await deps.agentDelivery.daemonsFor(agent.id, agent.daemonId)
+      if (targets.length === 0) return
       try {
         const byName = new Map((await deps.repos.mcpProvider.listForOrg(orgId)).map((p) => [p.name, p]))
         const send = async (fn: () => Promise<void>) => {
@@ -966,19 +970,27 @@ export function agentRoutes(deps: HttpDeps) {
             const provider = base ? byName.get(name) : undefined
             if (!provider) continue
             const grant = (await deps.repos.mcpGrant.activeForProvider(provider.orgId, provider.id))[0]
-            if (grant) await send(() => deps.control.mcpServerUpsert(daemonId, mcpProxyDef(provider, grant.key, base!)))
+            if (!grant) continue
+            const spec = mcpProxyDef(provider, grant.key, base!)
+            for (const daemonId of targets) await send(() => deps.control.mcpServerUpsert(daemonId, spec))
           }
         }
         if (removed.some((n) => byName.has(n))) {
           const peers = await deps.repos.agent.list(orgId)
           for (const name of removed) {
             if (!byName.has(name)) continue
-            const stillUsed = peers.some((a) => a.daemonId === daemonId && a.mcpServers.includes(name))
-            if (!stillUsed) await send(() => deps.control.mcpServerRemove(daemonId, orgId, name))
+            // "Still used" is delivery-set membership, not placement: a target that
+            // serves any other agent enabling the name keeps the def.
+            const stillOn = new Set(
+              await deps.agentDelivery.daemonsForAgents(peers.filter((a) => a.mcpServers.includes(name)))
+            )
+            for (const daemonId of targets) {
+              if (!stillOn.has(daemonId)) await send(() => deps.control.mcpServerRemove(daemonId, orgId, name))
+            }
           }
         }
       } catch (err) {
-        app.log.warn({ daemonId, err }, 'mcp def sync failed (reconcile will converge)')
+        app.log.warn({ agentId: agent.id, err }, 'mcp def sync failed (reconcile will converge)')
       }
     }
 
@@ -1187,9 +1199,12 @@ export function agentRoutes(deps: HttpDeps) {
       }
     }
 
+    /** Every daemon serving this agent gets the connection before the spec that
+     *  names it — a duty holder included, or its memory admission stays closed. */
     const pushExternalMemoryBeforeAgent = async (agent: AgentRecord): Promise<void> => {
-      if (!agent.daemonId) return
-      await pushExternalMemoryToDaemon(agent, agent.daemonId)
+      for (const daemonId of await deps.agentDelivery.daemonsFor(agent.id, agent.daemonId)) {
+        await pushExternalMemoryToDaemon(agent, daemonId)
+      }
     }
 
     const removeExternalMemoryFromDaemonIfUnused = async (
@@ -1198,13 +1213,13 @@ export function agentRoutes(deps: HttpDeps) {
       connectionId: string
     ): Promise<void> => {
       try {
-        const stillUsed = (await deps.repos.agent.list(orgId)).some(
-          (agent) =>
-            agent.daemonId === daemonId &&
-            agent.memory?.provider === 'external' &&
-            agent.memory.connectionId === connectionId
+        // "Still used on this daemon" is delivery-set membership, not placement:
+        // a duty holder serving another agent bound to the connection keeps it.
+        const users = (await deps.repos.agent.list(orgId)).filter(
+          (agent) => agent.memory?.provider === 'external' && agent.memory.connectionId === connectionId
         )
-        if (!stillUsed) await deps.control.memoryConnectionRemove(daemonId, connectionId)
+        const stillOn = new Set(await deps.agentDelivery.daemonsForAgents(users))
+        if (!stillOn.has(daemonId)) await deps.control.memoryConnectionRemove(daemonId, connectionId)
       } catch (err) {
         // Offline/version-skewed daemon converges the full registry on reconnect.
         app.log.warn({ daemonId, connectionId, err }, 'external memory registry removal deferred')
@@ -1212,7 +1227,7 @@ export function agentRoutes(deps: HttpDeps) {
     }
 
     const removeUnusedExternalMemoryAfterAgent = async (before: AgentRecord, after: AgentRecord): Promise<void> => {
-      if (!before.daemonId || before.memory?.provider !== 'external') return
+      if (before.memory?.provider !== 'external') return
       const connectionId = before.memory.connectionId
       if (
         after.daemonId === before.daemonId &&
@@ -1221,7 +1236,9 @@ export function agentRoutes(deps: HttpDeps) {
       ) {
         return
       }
-      await removeExternalMemoryFromDaemonIfUnused(before.orgId, before.daemonId, connectionId)
+      for (const daemonId of await deps.agentDelivery.daemonsFor(before.id, before.daemonId)) {
+        await removeExternalMemoryFromDaemonIfUnused(before.orgId, daemonId, connectionId)
+      }
     }
 
     const agentMoves = new AgentMoveService({
@@ -1544,7 +1561,7 @@ export function agentRoutes(deps: HttpDeps) {
               )
             }
           }
-          if (agent.daemonId) await syncMcpDefsForAgent(orgOf(req), agent.daemonId, [], agent.mcpServers)
+          await syncMcpDefsForAgent(agent, [], agent.mcpServers)
           return reply.code(201).send({
             ...toDto(
               agent,
@@ -1992,10 +2009,12 @@ export function agentRoutes(deps: HttpDeps) {
           await replicateUpsert(agent)
           if (req.body.icon !== undefined) void syncAgentBotIcons(deps, agent, app.log)
           await removeUnusedExternalMemoryAfterAgent(existing, agent)
-          // Provision/drop MCP proxy defs for an enable-list change on a stably-placed
-          // agent (a daemon move goes through AgentMoveService + reconcile, not here).
-          if (agent.daemonId && agent.daemonId === existing.daemonId) {
-            await syncMcpDefsForAgent(orgOf(req), agent.daemonId, existing.mcpServers, agent.mcpServers)
+          // Provision/drop MCP proxy defs for an enable-list change with the placement
+          // unchanged (a daemon move goes through AgentMoveService + reconcile, not
+          // here). The fan-out itself is delivery-set-wide, so an unplaced agent whose
+          // duty holders serve it is still covered.
+          if (agent.daemonId === existing.daemonId) {
+            await syncMcpDefsForAgent(agent, existing.mcpServers, agent.mcpServers)
           }
           return toDto(
             agent,

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -59,7 +59,7 @@ import {
 } from '../../persistence/ports.js'
 import type { DaemonView } from '../../ports.js'
 import { AgentId, DaemonId, SessionId, type OrgId } from '../../domain/ids.js'
-import { mcpProxyDef, relayHttpOrigin } from '../../orchestrator/mcpProvider.js'
+import { currentMcpGrant, mcpProxyDef, relayHttpOrigin } from '../../orchestrator/mcpProvider.js'
 import { serializeByProviderNames } from './mcp-providers.js'
 
 /** Thrown inside the provider-name fence when the in-fence visibility re-check
@@ -969,9 +969,9 @@ export function agentRoutes(deps: HttpDeps) {
           for (const name of added) {
             const provider = base ? byName.get(name) : undefined
             if (!provider) continue
-            const grant = (await deps.repos.mcpGrant.activeForProvider(provider.orgId, provider.id))[0]
+            const grant = currentMcpGrant(await deps.repos.mcpGrant.activeForProvider(provider.orgId, provider.id))
             if (!grant) continue
-            const spec = mcpProxyDef(provider, grant.key, base!)
+            const spec = mcpProxyDef(provider, grant, base!)
             for (const daemonId of targets) await send(() => deps.control.mcpServerUpsert(daemonId, spec))
           }
         }

--- a/packages/control-plane/src/http/routes/connectors.ts
+++ b/packages/control-plane/src/http/routes/connectors.ts
@@ -163,7 +163,7 @@ export function connectorRoutes(deps: HttpDeps) {
         try {
           await deps.repos.mcpProviderSecret.put(provider.orgId, provider.id, headers)
           const grant = await deps.repos.mcpGrant.mintFor(provider.orgId, provider.id)
-          await pushAssign(provider, headers, grant.key, orgId)
+          await pushAssign(provider, headers, grant, orgId)
 
           const dto = {
             id: provider.id,

--- a/packages/control-plane/src/http/routes/mcp-providers.test.ts
+++ b/packages/control-plane/src/http/routes/mcp-providers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { rotateProviderGrant, serializeByProvider, serializeByProviderNames } from './mcp-providers.js'
-import { grantKeyHash } from '../../orchestrator/mcpProvider.js'
+import { currentMcpGrant, grantKeyHash, type GrantView } from '../../orchestrator/mcpProvider.js'
 import type { McpProviderRecord, McpGrantRecord, McpGrantRepo, McpHeader } from '../../persistence/ports.js'
 import type { OrgId } from '../../domain/ids.js'
 
@@ -56,9 +56,9 @@ describe('rotateProviderGrant', () => {
       [],
       provider.orgId,
       { ...repo, revoke: async (id) => (calls.push('revoke'), revoked.push(id)) },
-      async (_p, _h, grantKey) => {
+      async (_p, _h, grant) => {
         calls.push('assign')
-        pushed.push(grantKey)
+        pushed.push(grant.key)
       },
       (providerId, hash) => {
         calls.push('unassign')
@@ -162,16 +162,16 @@ describe('rotateProviderGrant', () => {
         active.delete(id)
       }
     }
-    const pushAssign = async (_p: McpProviderRecord, _h: McpHeader[], key: string) => {
+    const pushAssign = async (_p: McpProviderRecord, _h: McpHeader[], grant: GrantView) => {
       await yieldTick()
-      published = key
+      published = grant.key
     }
     // rotation + a PATCH-style re-push (read active inside the lock, then push it) race
     await Promise.all([
       rotateProviderGrant(provider, [], provider.orgId, repo, pushAssign, () => {}),
       serializeByProvider(provider.orgId, provider.name, async () => {
-        const grant = (await repo.activeForProvider(provider.id))[0]
-        if (grant) await pushAssign(provider, [], grant.key, provider.orgId)
+        const grant = currentMcpGrant(await repo.activeForProvider(provider.id))
+        if (grant) await pushAssign(provider, [], grant, provider.orgId)
       })
     ])
 

--- a/packages/control-plane/src/http/routes/mcp-providers.ts
+++ b/packages/control-plane/src/http/routes/mcp-providers.ts
@@ -24,7 +24,7 @@ import type { OrgId } from '../../domain/ids.js'
 import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView, canEdit, canManageSharing, type ViewCtx } from '../../authorization/policy.js'
 import { resolveShareSet } from '../sharing.js'
-import { blockedUpstreamUrl, grantKeyHash } from '../../orchestrator/mcpProvider.js'
+import { blockedUpstreamUrl, currentMcpGrant, grantKeyHash, type GrantView } from '../../orchestrator/mcpProvider.js'
 import { makeMcpPush } from '../mcp-push.js'
 import { CONNECTOR_SERVICE_HEADER } from '../../connectors/index.js'
 import {
@@ -55,7 +55,7 @@ export function rotateProviderGrant(
   headers: McpHeader[],
   orgId: OrgId,
   grants: McpGrantRepo,
-  pushAssign: (p: McpProviderRecord, h: McpHeader[], grantKey: string, org: OrgId) => Promise<void>,
+  pushAssign: (p: McpProviderRecord, h: McpHeader[], grant: GrantView, org: OrgId) => Promise<void>,
   unassignHash: (providerId: string, hash: string) => void
 ): Promise<string> {
   return serializeByProvider(orgId, provider.name, () =>
@@ -123,12 +123,12 @@ async function rotateOnce(
   headers: McpHeader[],
   orgId: OrgId,
   grants: McpGrantRepo,
-  pushAssign: (p: McpProviderRecord, h: McpHeader[], grantKey: string, org: OrgId) => Promise<void>,
+  pushAssign: (p: McpProviderRecord, h: McpHeader[], grant: GrantView, org: OrgId) => Promise<void>,
   unassignHash: (providerId: string, hash: string) => void
 ): Promise<string> {
   const prior = await grants.activeForProvider(provider.orgId, provider.id) // before mint — both would read active otherwise
   const fresh = await grants.mintFor(provider.orgId, provider.id)
-  await pushAssign(provider, headers, fresh.key, orgId) // new binding + proxy def in place first
+  await pushAssign(provider, headers, fresh, orgId) // new binding + proxy def in place first
   for (const g of prior) {
     await grants.revoke(g.id)
     unassignHash(provider.id, grantKeyHash(g.key))
@@ -258,7 +258,7 @@ export function mcpProviderRoutes(deps: HttpDeps) {
           await deps.repos.mcpProviderSecret.put(provider.orgId, provider.id, req.body.headers)
           // Exactly one active grant per provider (v1). Plaintext returned once.
           const grant = await deps.repos.mcpGrant.mintFor(provider.orgId, provider.id)
-          await pushAssign(provider, req.body.headers, grant.key, orgOf(req))
+          await pushAssign(provider, req.body.headers, grant, orgOf(req))
           return { provider, grant }
         })
         if (!created) {
@@ -323,8 +323,8 @@ export function mcpProviderRoutes(deps: HttpDeps) {
         // is unchanged (patch never re-mints), so read the active one — but INSIDE the
         // per-provider lock, so a concurrent rotation can't leave us pushing its revoked key.
         await serializeByProvider(orgOf(req), provider.name, async () => {
-          const grant = (await deps.repos.mcpGrant.activeForProvider(provider.orgId, provider.id))[0]
-          if (grant) await pushAssign(provider, headers, grant.key, orgOf(req))
+          const grant = currentMcpGrant(await deps.repos.mcpGrant.activeForProvider(provider.orgId, provider.id))
+          if (grant) await pushAssign(provider, headers, grant, orgOf(req))
         })
         return toDto(provider, ctxOf(req), headers)
       }

--- a/packages/control-plane/src/http/routes/memory-connections.ts
+++ b/packages/control-plane/src/http/routes/memory-connections.ts
@@ -90,10 +90,12 @@ export function memoryConnectionRoutes(deps: HttpDeps) {
         (agent) => agent.memory?.provider === 'external' && agent.memory.connectionId === connectionId
       )
 
-    /** Push the full relay allowlist, then one chosen grant to every using daemon.
-     * Returns true only when every currently placed consumer acknowledged the
+    /** Push the full relay allowlist, then one chosen grant to every daemon SERVING
+     * a using agent — its placement plus any duty holder, resolved through
+     * AgentDelivery. Returns true only when every such consumer acknowledged the
      * chosen definition. Durable CRUD ignores a false result and converges on
-     * reconnect; grant retirement uses it as a hard overlap-before-revoke fence. */
+     * reconnect; grant retirement uses it as a hard overlap-before-revoke fence, so
+     * including holders is what stops a key being retired under a holder still on it. */
     const pushConnection = async (
       connection: ExternalMemoryConnectionRecord,
       installation: MemoryPluginInstallationRecord,
@@ -102,7 +104,7 @@ export function memoryConnectionRoutes(deps: HttpDeps) {
     ): Promise<boolean> => {
       try {
         const daemonIds = new Set(
-          (await agentsUsing(connection.orgId, connection.id)).flatMap((a) => (a.daemonId ? [a.daemonId] : []))
+          await deps.agentDelivery.daemonsForAgents(await agentsUsing(connection.orgId, connection.id))
         )
         let spec: MemoryConnectionSpec
         if (installation.transport === 'stdio') {

--- a/packages/control-plane/src/orchestrator/agentDefinitions.test.ts
+++ b/packages/control-plane/src/orchestrator/agentDefinitions.test.ts
@@ -34,7 +34,14 @@ function provider(orgId: string, name: string, id = `p-${orgId}-${name}`): McpPr
 function mcpDeps(providers: McpProviderRecord[], relay = true): McpDefinitionDeps {
   return {
     providers: { listForOrg: async (orgId: string) => providers.filter((p) => p.orgId === orgId) },
-    grants: { activeForProvider: async (_orgId: string, id: string) => [{ id: `g-${id}`, key: `oct_${id}` }] },
+    grants: {
+      // Ascending by createdAt, exactly as the repo returns it: the retiring grant
+      // FIRST and the fresh one last, which is the rotation overlap window.
+      activeForProvider: async (_orgId: string, id: string) => [
+        { id: `g-${id}-old`, key: `oct_${id}_retiring`, createdAt: new Date(1_000) },
+        { id: `g-${id}`, key: `oct_${id}`, createdAt: new Date(2_000) }
+      ]
+    },
     relayRoster: {
       entries: async () => (relay ? [{ relayId: 'r1', name: 'r1', url: 'wss://relay.example.test' }] : [])
     }
@@ -68,6 +75,17 @@ describe('mcpDefsForAgents — the MCP half of an agent set’s definitions', ()
       [ORG_A, 'docs'],
       [ORG_B, 'payroll']
     ])
+  })
+
+  it('projects the FRESH grant during a rotation overlap, and orders the def by it', async () => {
+    // `activeForProvider` is ascending by createdAt and rotation leaves both active
+    // until the fresh key is distributed, so the head is the key about to be revoked.
+    const specs = await mcpDefsForAgents([agent(ORG_A, { mcpServers: ['docs'] })], mcpDeps([provider(ORG_A, 'docs')]))
+    expect(specs[0]!.headers).toEqual([
+      { name: 'Authorization', value: 'Bearer oct_p-11111111-1111-4111-8111-111111111111-docs' }
+    ])
+    // The marker is the fresh grant's instant — what the daemon compares on apply.
+    expect(specs[0]!.issuedAt).toBe(2_000)
   })
 
   it('skips the reserved name — the daemon injects its own agentconnect server', async () => {
@@ -116,7 +134,13 @@ function memoryDeps(over: Partial<MemoryDefinitionDeps> = {}): MemoryDefinitionD
       })
     },
     secrets: { get: async () => ({ apiKey: 'upstream-secret' }), keys: async () => ['apiKey'] },
-    grants: { activeForConnection: async () => [{ id: 'g1', key: 'omg_key' }] },
+    // Ascending by createdAt, as the repo returns it: retiring first, fresh last.
+    grants: {
+      activeForConnection: async () => [
+        { id: 'g0', key: 'omg_retiring' },
+        { id: 'g1', key: 'omg_key' }
+      ]
+    },
     relayRoster: { entries: async () => [{ relayId: 'r1', name: 'r1', url: 'wss://relay.example.test' }] },
     ...over
   } as unknown as MemoryDefinitionDeps
@@ -139,6 +163,27 @@ describe('memoryDefsForAgents — the external-memory half', () => {
     const get = vi.fn()
     await memoryDefsForAgents([agent(ORG_A)], memoryDeps({ connections: { get } } as unknown as MemoryDefinitionDeps))
     expect(get).not.toHaveBeenCalled()
+  })
+
+  it('projects the FRESH relay grant during a rotation overlap, ordered by the connection revision', async () => {
+    const specs = await memoryDefsForAgents(
+      [bound(CONNECTION)],
+      memoryDeps({
+        installations: {
+          get: async () => ({
+            id: INSTALLATION,
+            pluginId: 'ai.example.memory',
+            transport: 'streamable-http',
+            endpoint: 'https://plugin.example.test/mcp',
+            expectedManifestDigest: `sha256:${'a'.repeat(64)}`,
+            secretHeaders: []
+          })
+        }
+      } as unknown as MemoryDefinitionDeps)
+    )
+    // The memory path was already disciplined: newest active grant, and the
+    // connection's own `revision` is the marker the daemon registry fences on.
+    expect(specs[0]).toMatchObject({ grantKey: 'omg_key', revision: 2 })
   })
 
   it('a remote connection with no live relay is skipped and warned; stdio is unaffected', async () => {

--- a/packages/control-plane/src/orchestrator/agentDefinitions.test.ts
+++ b/packages/control-plane/src/orchestrator/agentDefinitions.test.ts
@@ -1,0 +1,160 @@
+/**
+ * The one projector behind BOTH the reconnect roster's definition arrays and the
+ * `duty/fetch` bundle's (#979). It is keyed on agents, never on a daemon, which
+ * is what lets a duty holder that is not the placement receive the definitions
+ * its installed agent references — and what bounds who can obtain them: an MCP
+ * proxy def carries the relay url plus a plaintext grant key, so "referenced by
+ * an agent in this set" IS the authorization scope.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import {
+  mcpDefsForAgents,
+  memoryDefsForAgents,
+  type AgentDefinitionRef,
+  type McpDefinitionDeps,
+  type MemoryDefinitionDeps
+} from './agentDefinitions.js'
+import { OrgId } from '../domain/ids.js'
+import type { McpProviderRecord } from '../persistence/ports.js'
+
+const ORG_A = '11111111-1111-4111-8111-111111111111'
+const ORG_B = '22222222-2222-4222-8222-222222222222'
+const CONNECTION = '33333333-3333-4333-8333-333333333333'
+const OTHER_CONNECTION = '44444444-4444-4444-8444-444444444444'
+const INSTALLATION = '55555555-5555-4555-8555-555555555555'
+
+function agent(orgId: string, over: Partial<AgentDefinitionRef> = {}): AgentDefinitionRef {
+  return { orgId: OrgId(orgId), mcpServers: [], memory: null, ...over } as AgentDefinitionRef
+}
+
+function provider(orgId: string, name: string, id = `p-${orgId}-${name}`): McpProviderRecord {
+  return { id, orgId: OrgId(orgId), name, url: `https://upstream.example.test/${name}` } as McpProviderRecord
+}
+
+function mcpDeps(providers: McpProviderRecord[], relay = true): McpDefinitionDeps {
+  return {
+    providers: { listForOrg: async (orgId: string) => providers.filter((p) => p.orgId === orgId) },
+    grants: { activeForProvider: async (_orgId: string, id: string) => [{ id: `g-${id}`, key: `oct_${id}` }] },
+    relayRoster: {
+      entries: async () => (relay ? [{ relayId: 'r1', name: 'r1', url: 'wss://relay.example.test' }] : [])
+    }
+  } as unknown as McpDefinitionDeps
+}
+
+describe('mcpDefsForAgents — the MCP half of an agent set’s definitions', () => {
+  it('projects only the providers the agents NAME, never the rest of the org registry', async () => {
+    const specs = await mcpDefsForAgents(
+      [agent(ORG_A, { mcpServers: ['docs'] })],
+      mcpDeps([provider(ORG_A, 'docs'), provider(ORG_A, 'payroll')])
+    )
+    expect(specs.map((s) => s.name)).toEqual(['docs'])
+    // The token-bearing part: the RELAY proxy url + the grant key, never upstream.
+    expect(specs[0]).toMatchObject({
+      transport: 'http',
+      url: 'https://relay.example.test/mcp/p-11111111-1111-4111-8111-111111111111-docs',
+      headers: [{ name: 'Authorization', value: 'Bearer oct_p-11111111-1111-4111-8111-111111111111-docs' }]
+    })
+  })
+
+  it('an agent naming a provider in ITS org never pulls a same-named provider from another', async () => {
+    const specs = await mcpDefsForAgents(
+      [agent(ORG_A, { mcpServers: ['docs'] }), agent(ORG_B)],
+      mcpDeps([provider(ORG_A, 'docs'), provider(ORG_B, 'docs')])
+    )
+    expect(specs.map((s) => s.orgId)).toEqual([ORG_A])
+  })
+
+  it('skips the reserved name — the daemon injects its own agentconnect server', async () => {
+    expect(
+      await mcpDefsForAgents(
+        [agent(ORG_A, { mcpServers: ['agentconnect'] })],
+        mcpDeps([provider(ORG_A, 'agentconnect')])
+      )
+    ).toEqual([])
+  })
+
+  it('ships nothing and warns when no relay is live — the next register is the backstop', async () => {
+    const warn = vi.fn()
+    const specs = await mcpDefsForAgents(
+      [agent(ORG_A, { mcpServers: ['docs'] })],
+      mcpDeps([provider(ORG_A, 'docs')], false),
+      { warn }
+    )
+    expect(specs).toEqual([])
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('an empty agent set reads no registry at all', async () => {
+    const listForOrg = vi.fn()
+    await mcpDefsForAgents([], { ...mcpDeps([]), providers: { listForOrg } } as unknown as McpDefinitionDeps)
+    expect(listForOrg).not.toHaveBeenCalled()
+  })
+})
+
+function memoryDeps(over: Partial<MemoryDefinitionDeps> = {}): MemoryDefinitionDeps {
+  return {
+    connections: {
+      get: async (orgId: string, id: string) =>
+        id === CONNECTION && orgId === ORG_A
+          ? { id: CONNECTION, orgId: OrgId(ORG_A), installationId: INSTALLATION, revision: 2, config: { p: 1 } }
+          : null
+    },
+    installations: {
+      get: async () => ({
+        id: INSTALLATION,
+        pluginId: 'ai.example.memory',
+        transport: 'stdio',
+        commandRef: 'operator-mem0',
+        expectedManifestDigest: `sha256:${'a'.repeat(64)}`,
+        secretHeaders: []
+      })
+    },
+    secrets: { get: async () => ({ apiKey: 'upstream-secret' }), keys: async () => ['apiKey'] },
+    grants: { activeForConnection: async () => [{ id: 'g1', key: 'omg_key' }] },
+    relayRoster: { entries: async () => [{ relayId: 'r1', name: 'r1', url: 'wss://relay.example.test' }] },
+    ...over
+  } as unknown as MemoryDefinitionDeps
+}
+
+const bound = (connectionId: string) =>
+  agent(ORG_A, { memory: { provider: 'external', connectionId } as AgentDefinitionRef['memory'] })
+
+describe('memoryDefsForAgents — the external-memory half', () => {
+  it('projects exactly the connection the agent binds', async () => {
+    const specs = await memoryDefsForAgents([bound(CONNECTION)], memoryDeps())
+    expect(specs.map((s) => s.connectionId)).toEqual([CONNECTION])
+  })
+
+  it('an agent bound to a DIFFERENT connection pulls nothing for this one', async () => {
+    expect(await memoryDefsForAgents([bound(OTHER_CONNECTION)], memoryDeps())).toEqual([])
+  })
+
+  it('an agent with no external binding reads no connection at all', async () => {
+    const get = vi.fn()
+    await memoryDefsForAgents([agent(ORG_A)], memoryDeps({ connections: { get } } as unknown as MemoryDefinitionDeps))
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('a remote connection with no live relay is skipped and warned; stdio is unaffected', async () => {
+    const warn = vi.fn()
+    const specs = await memoryDefsForAgents(
+      [bound(CONNECTION)],
+      memoryDeps({
+        installations: {
+          get: async () => ({
+            id: INSTALLATION,
+            pluginId: 'ai.example.memory',
+            transport: 'streamable-http',
+            endpoint: 'https://plugin.example.test/mcp',
+            expectedManifestDigest: `sha256:${'a'.repeat(64)}`,
+            secretHeaders: []
+          })
+        },
+        relayRoster: { entries: async () => [] }
+      } as unknown as MemoryDefinitionDeps),
+      { warn }
+    )
+    expect(specs).toEqual([])
+    expect(warn).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/control-plane/src/orchestrator/agentDefinitions.test.ts
+++ b/packages/control-plane/src/orchestrator/agentDefinitions.test.ts
@@ -56,12 +56,18 @@ describe('mcpDefsForAgents — the MCP half of an agent set’s definitions', ()
     })
   })
 
-  it('an agent naming a provider in ITS org never pulls a same-named provider from another', async () => {
+  it('resolves each agent’s names in ITS OWN org — a mixed roster is not one flat name set', async () => {
+    // The roster union spans orgs on an install-wide member, so the reference set
+    // is per-org: a name one org enables must never resolve against another's
+    // registry, and each org's own enable must still be found.
     const specs = await mcpDefsForAgents(
-      [agent(ORG_A, { mcpServers: ['docs'] }), agent(ORG_B)],
-      mcpDeps([provider(ORG_A, 'docs'), provider(ORG_B, 'docs')])
+      [agent(ORG_A, { mcpServers: ['docs'] }), agent(ORG_B, { mcpServers: ['payroll'] })],
+      mcpDeps([provider(ORG_A, 'docs'), provider(ORG_A, 'payroll'), provider(ORG_B, 'payroll')])
     )
-    expect(specs.map((s) => s.orgId)).toEqual([ORG_A])
+    expect(specs.map((s) => [s.orgId, s.name])).toEqual([
+      [ORG_A, 'docs'],
+      [ORG_B, 'payroll']
+    ])
   })
 
   it('skips the reserved name — the daemon injects its own agentconnect server', async () => {

--- a/packages/control-plane/src/orchestrator/agentDefinitions.ts
+++ b/packages/control-plane/src/orchestrator/agentDefinitions.ts
@@ -35,7 +35,7 @@ import type {
   MemoryPluginInstallationRepo
 } from '../persistence/ports.js'
 import { OrgId } from '../domain/ids.js'
-import { mcpProxyDef, relayHttpOrigin } from './mcpProvider.js'
+import { currentMcpGrant, mcpProxyDef, relayHttpOrigin } from './mcpProvider.js'
 import { memoryConnectionSpec, stdioMemoryConnectionSpec } from './memoryConnection.js'
 
 /** Minimal relay-roster view both projectors pick a proxy base from. */
@@ -110,8 +110,11 @@ export async function mcpDefsForAgents(
   for (const [orgId, names] of wanted) {
     const providers = (await deps.providers.listForOrg(OrgId(orgId))).filter((provider) => names.has(provider.name))
     for (const provider of providers) {
-      const grant = (await deps.grants.activeForProvider(provider.orgId, provider.id))[0]
-      if (grant) specs.push(mcpProxyDef(provider, grant.key, relayBaseUrl))
+      // The NEWEST active grant, through the one shared selector: a rotation
+      // overlaps old+new until the fresh key is distributed, and a bundle
+      // projected inside that window must never carry the retiring one.
+      const grant = currentMcpGrant(await deps.grants.activeForProvider(provider.orgId, provider.id))
+      if (grant) specs.push(mcpProxyDef(provider, grant, relayBaseUrl))
     }
   }
   return specs

--- a/packages/control-plane/src/orchestrator/agentDefinitions.ts
+++ b/packages/control-plane/src/orchestrator/agentDefinitions.ts
@@ -1,0 +1,174 @@
+/**
+ * `agentDefinitions` — the ONE answer to "which MCP proxy defs and which
+ * external-memory connection defs does this set of agents need".
+ *
+ * An `AgentSpec` only NAMES its MCP servers and its memory connection; the
+ * definitions travel separately. They used to be resolved by placement
+ * (`activeForDaemon(daemonId)` on either repo), so a duty holder that is not the
+ * agent's placement installed an agent referencing tools and a memory backend it
+ * had no definitions for — its tools and its memory silently did not work.
+ *
+ * Both readers are therefore keyed on AGENTS, never on a daemon: the reconnect
+ * snapshot passes the roster union (`pinned-to-me ∪ agents in the duties I hold`)
+ * and `duty/fetch` passes the single agent it just authorized. One projector, so
+ * a member's install bundle and its reconnect snapshot cannot disagree.
+ *
+ * SECURITY: every output is token-bearing (an MCP def carries the relay proxy url
+ * plus the plaintext grant key; a memory def carries the grant and the resolved
+ * secret leases). NEVER log these arrays. Scoping them to the referencing agents
+ * is what keeps "who can obtain a definition" equal to "who serves an agent that
+ * references it".
+ */
+import {
+  RESERVED_MCP_SERVER_NAME,
+  type McpServerSpec,
+  type MemoryConnectionSpec,
+  type RelayRosterEntry
+} from '@agentconnect.md/protocol'
+import type {
+  AgentRecord,
+  ExternalMemoryConnectionRepo,
+  ExternalMemoryConnectionSecretStore,
+  ExternalMemoryGrantRepo,
+  McpGrantRepo,
+  McpProviderRepo,
+  MemoryPluginInstallationRepo
+} from '../persistence/ports.js'
+import { OrgId } from '../domain/ids.js'
+import { mcpProxyDef, relayHttpOrigin } from './mcpProvider.js'
+import { memoryConnectionSpec, stdioMemoryConnectionSpec } from './memoryConnection.js'
+
+/** Minimal relay-roster view both projectors pick a proxy base from. */
+export interface RelayRosterView {
+  entries(): Promise<RelayRosterEntry[]>
+}
+
+/** All a projector reads off an agent — the enable-list and the memory binding. */
+export type AgentDefinitionRef = Pick<AgentRecord, 'orgId' | 'mcpServers' | 'memory'>
+
+/** MCP-proxy projection inputs (centralized-tool-management.md §7). */
+export interface McpDefinitionDeps {
+  providers: McpProviderRepo
+  grants: McpGrantRepo
+  relayRoster: RelayRosterView
+}
+
+/** External-memory projection inputs (agent-memory.md). */
+export interface MemoryDefinitionDeps {
+  connections: ExternalMemoryConnectionRepo
+  installations: MemoryPluginInstallationRepo
+  secrets: ExternalMemoryConnectionSecretStore
+  grants: ExternalMemoryGrantRepo
+  relayRoster: RelayRosterView
+}
+
+export interface DefinitionLog {
+  warn(obj: object, msg: string): void
+}
+
+/** orgId → the referenced names/ids in that org. Grouping by org is what stops a
+ *  provider name shared across two orgs from bleeding between them. */
+function groupByOrg(refs: Iterable<readonly [string, string]>): Map<string, Set<string>> {
+  const byOrg = new Map<string, Set<string>>()
+  for (const [orgId, value] of refs) {
+    const bucket = byOrg.get(orgId) ?? new Set<string>()
+    bucket.add(value)
+    byOrg.set(orgId, bucket)
+  }
+  return byOrg
+}
+
+/**
+ * The relay-proxied `http` MCP defs these agents enable by name: the RELAY proxy
+ * url plus the provider's active plaintext grant key — never the upstream url or
+ * its secret. The reserved name is excluded (the daemon injects its own
+ * `agentconnect` server). No relay live ⇒ none, and the next register once a
+ * relay appears is the backstop.
+ */
+export async function mcpDefsForAgents(
+  agents: readonly AgentDefinitionRef[],
+  deps: McpDefinitionDeps | undefined,
+  log?: DefinitionLog,
+  logCtx: object = {}
+): Promise<McpServerSpec[]> {
+  if (!deps) return []
+  const wanted = groupByOrg(
+    agents.flatMap((agent) =>
+      agent.mcpServers.filter((name) => name !== RESERVED_MCP_SERVER_NAME).map((name) => [agent.orgId, name] as const)
+    )
+  )
+  if (wanted.size === 0) return []
+  const relay = (await deps.relayRoster.entries())[0]
+  if (!relay) {
+    log?.warn(logCtx, 'MCP providers enabled but no live relay — skipping MCP defs')
+    return []
+  }
+  // The roster url is the relay's rd/* WS dial address; the MCP proxy is HTTP on the
+  // same origin — normalize wss→https so the `http` def points at a reachable endpoint.
+  const relayBaseUrl = relayHttpOrigin(relay.url)
+  const specs: McpServerSpec[] = []
+  for (const [orgId, names] of wanted) {
+    const providers = (await deps.providers.listForOrg(OrgId(orgId))).filter((provider) => names.has(provider.name))
+    for (const provider of providers) {
+      const grant = (await deps.grants.activeForProvider(provider.orgId, provider.id))[0]
+      if (grant) specs.push(mcpProxyDef(provider, grant.key, relayBaseUrl))
+    }
+  }
+  return specs
+}
+
+/** The external-memory connection defs these agents bind to. A stdio installation
+ *  needs no relay; a remote one without a live relay is skipped and warned once. */
+export async function memoryDefsForAgents(
+  agents: readonly AgentDefinitionRef[],
+  deps: MemoryDefinitionDeps | undefined,
+  log?: DefinitionLog,
+  logCtx: object = {}
+): Promise<MemoryConnectionSpec[]> {
+  if (!deps) return []
+  const wanted = groupByOrg(
+    agents.flatMap((agent) =>
+      agent.memory?.provider === 'external' && agent.memory.connectionId
+        ? [[agent.orgId, agent.memory.connectionId] as const]
+        : []
+    )
+  )
+  if (wanted.size === 0) return []
+  const relay = (await deps.relayRoster.entries())[0]
+  const relayBaseUrl = relay ? relayHttpOrigin(relay.url) : undefined
+  const specs: MemoryConnectionSpec[] = []
+  let skippedRemote = false
+  for (const [orgId, connectionIds] of wanted) {
+    for (const connectionId of connectionIds) {
+      const connection = await deps.connections.get(OrgId(orgId), connectionId)
+      if (!connection) continue
+      const installation = await deps.installations.get(connection.installationId)
+      if (!installation) continue
+      if (installation.transport === 'stdio') {
+        const secrets = (await deps.secrets.get(connection.orgId, connection.id)) ?? {}
+        specs.push(stdioMemoryConnectionSpec(connection, installation, secrets))
+        continue
+      }
+      if (!relayBaseUrl) {
+        skippedRemote = true
+        continue
+      }
+      const [grant, secretKeys] = await Promise.all([
+        // Rotation overlaps old+new grants until every projection has the fresh
+        // key. Prefer the newest active grant so a reconnect in that window does
+        // not receive the key that is about to be retired.
+        deps.grants.activeForConnection(connection.orgId, connection.id).then((rows) => rows.at(-1)),
+        deps.secrets.keys(connection.orgId, connection.id)
+      ])
+      if (!grant) continue
+      specs.push(memoryConnectionSpec(connection, installation, secretKeys, grant.key, relayBaseUrl))
+    }
+  }
+  if (skippedRemote) {
+    log?.warn(
+      logCtx,
+      'remote external memory connections have no live relay — local stdio definitions remain available'
+    )
+  }
+  return specs
+}

--- a/packages/control-plane/src/orchestrator/agentDelivery.ts
+++ b/packages/control-plane/src/orchestrator/agentDelivery.ts
@@ -57,6 +57,20 @@ export class AgentDelivery {
     return [...new Set([...(placement ? [placement] : []), ...holders])]
   }
 
+  /**
+   * The union delivery set of several agents — the targets of a definition those
+   * agents REFERENCE (an MCP proxy def, an external-memory connection). Those
+   * defs are not addressed to an agent, so their fan-out sites resolve "who uses
+   * this" first and hand the result here rather than reading `daemonId` inline.
+   */
+  async daemonsForAgents(agents: readonly { id: string; daemonId: string | null }[]): Promise<string[]> {
+    const targets = new Set<string>()
+    for (const agent of agents) {
+      for (const daemonId of await this.daemonsFor(agent.id, agent.daemonId)) targets.add(daemonId)
+    }
+    return [...targets]
+  }
+
   /** Push an edited spec to every delivery target. The spec is assembled ONCE:
    *  the targets replicate the same agent, and two assemblies could disagree. */
   async upsert(agent: AgentRecord, onError: DeliveryErrorHandler): Promise<void> {

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -601,7 +601,7 @@ describe('AgentMoveService.bundleFor — the duty/fetch install bundle', () => {
       assignments: {} as unknown as ConstructorParameters<typeof AgentMoveService>[0]['assignments'],
       mcp: {
         providers: { listForOrg: async () => [{ id: PROVIDER, orgId: ORG, name: 'docs' }] },
-        grants: { activeForProvider: async () => [{ id: 'g1', key: 'oct_docs' }] },
+        grants: { activeForProvider: async () => [{ id: 'g1', key: 'oct_docs', createdAt: new Date(2_000) }] },
         relayRoster: { entries: async () => [{ relayId: 'r1', name: 'r1', url: 'wss://relay.example.test' }] }
       } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['mcp'],
       memory: {

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -560,3 +560,105 @@ describe('AgentMoveService', () => {
     expect(t.calls).not.toContain(`activate:${SOURCE}`)
   })
 })
+
+/**
+ * `bundleFor` is the `duty/fetch` reply. An AgentSpec only NAMES its MCP servers
+ * and its memory connection, so a member that installs the bundle on a daemon the
+ * agent is not placed on would come up referencing definitions it never received
+ * (#979). Both now ride the bundle, through the SAME projector the reconnect
+ * roster uses, scoped to this one agent's references.
+ */
+describe('AgentMoveService.bundleFor — the duty/fetch install bundle', () => {
+  const PROVIDER = '88888888-8888-4888-8888-888888888888'
+  const CONNECTION = '99999999-9999-4999-8999-999999999999'
+  const INSTALLATION = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa'
+
+  function bundleService(over: { mcpServers?: string[]; connectionId?: string } = {}) {
+    const record = {
+      ...agent(SOURCE),
+      mcpServers: over.mcpServers ?? [],
+      memory: over.connectionId ? { provider: 'external', connectionId: over.connectionId } : null
+    } as AgentRecord
+    const service = new AgentMoveService({
+      agents: { getUnscoped: async () => record } as unknown as AgentRepo,
+      integrations: { listForAgent: async () => [] } as unknown as ConstructorParameters<
+        typeof AgentMoveService
+      >[0]['integrations'],
+      integrationChannels: { listForIntegration: async () => [] } as unknown as ConstructorParameters<
+        typeof AgentMoveService
+      >[0]['integrationChannels'],
+      bots: { getUnscoped: async () => bot } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['bots'],
+      botSecrets: { get: async () => ({}) } as unknown as ConstructorParameters<
+        typeof AgentMoveService
+      >[0]['botSecrets'],
+      platforms: PLATFORMS,
+      specs: new AgentSpecAssembler({
+        get: async () => ({}),
+        merge: async () => {},
+        keys: async () => new Map()
+      } as unknown as ConstructorParameters<typeof AgentSpecAssembler>[0]),
+      crons: { listForAgent: async () => [] } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['crons'],
+      assignments: {} as unknown as ConstructorParameters<typeof AgentMoveService>[0]['assignments'],
+      mcp: {
+        providers: { listForOrg: async () => [{ id: PROVIDER, orgId: ORG, name: 'docs' }] },
+        grants: { activeForProvider: async () => [{ id: 'g1', key: 'oct_docs' }] },
+        relayRoster: { entries: async () => [{ relayId: 'r1', name: 'r1', url: 'wss://relay.example.test' }] }
+      } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['mcp'],
+      memory: {
+        connections: {
+          get: async (_orgId: string, id: string) =>
+            id === CONNECTION
+              ? { id: CONNECTION, orgId: ORG, installationId: INSTALLATION, revision: 1, config: {} }
+              : null
+        },
+        installations: {
+          get: async () => ({
+            id: INSTALLATION,
+            pluginId: 'ai.example.memory',
+            transport: 'stdio',
+            commandRef: 'operator-mem0',
+            expectedManifestDigest: `sha256:${'a'.repeat(64)}`,
+            secretHeaders: []
+          })
+        },
+        secrets: { get: async () => ({}), keys: async () => [] },
+        grants: { activeForConnection: async () => [] },
+        relayRoster: { entries: async () => [] }
+      } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['memory'],
+      control: {} as unknown as ControlSender,
+      hooks: {} as unknown as HookService,
+      httpBot: {} as unknown as HttpBotOrchestrator,
+      collabRoutes: {} as unknown as CollabRoutesService,
+      mutations: new AgentMutationGate(),
+      sessionOwners: { releaseSession: () => {} }
+    })
+    return { service, record }
+  }
+
+  it('carries the proxy def for every MCP server the spec names', async () => {
+    const { service, record } = bundleService({ mcpServers: ['docs'] })
+    const bundle = await service.bundleFor(record)
+    expect(bundle.spec.mcpServers).toEqual(['docs'])
+    // Not just present — the grant-bearing proxy def, so the holder can actually call it.
+    expect(bundle.mcpServers).toEqual([
+      expect.objectContaining({
+        name: 'docs',
+        url: `https://relay.example.test/mcp/${PROVIDER}`,
+        headers: [{ name: 'Authorization', value: 'Bearer oct_docs' }]
+      })
+    ])
+  })
+
+  it('carries the external-memory connection the spec binds', async () => {
+    const { service, record } = bundleService({ connectionId: CONNECTION })
+    const bundle = await service.bundleFor(record)
+    expect(bundle.memoryConnections.map((c) => c.connectionId)).toEqual([CONNECTION])
+  })
+
+  it('an agent that names neither gets neither — the bundle is scoped to its references', async () => {
+    const { service, record } = bundleService()
+    const bundle = await service.bundleFor(record)
+    expect(bundle.mcpServers).toEqual([])
+    expect(bundle.memoryConnections).toEqual([])
+  })
+})

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -40,6 +40,12 @@ import type {
 import { AgentWorkspaceIntegrationConflict } from '../persistence/errors.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
 import { cronToUpsert, integrationToSpec, isGatedAgent, httpIntegrationToSpec } from './placement.js'
+import {
+  mcpDefsForAgents,
+  memoryDefsForAgents,
+  type McpDefinitionDeps,
+  type MemoryDefinitionDeps
+} from './agentDefinitions.js'
 import type { CpPlatformRegistry } from '../platforms/provider.js'
 import type { AgentSpecAssembler } from './agentSpecAssembler.js'
 import type { OrganizationEnvironmentValues } from './organizationEnvironment.js'
@@ -87,6 +93,11 @@ export interface AgentMoveDeps {
   /** Owns AgentSpec assembly (secret loading + icon bases) for the activation definition. */
   specs: AgentSpecAssembler
   crons: CronRepo
+  /** The `duty/fetch` bundle's MCP and external-memory projections — the same
+   *  optional seams `PlacementOrchDeps` carries, so the bundle and the reconnect
+   *  snapshot are one projector. Absent (tests / no orch) ⇒ neither kind ships. */
+  mcp?: McpDefinitionDeps
+  memory?: MemoryDefinitionDeps
   control: ControlSender
   hooks: HookService
   httpBot: HttpBotOrchestrator
@@ -615,12 +626,25 @@ export class AgentMoveService {
 
   /**
    * The complete installable definition of one agent — secrets, org environment,
-   * skills, integration specs, and crons — with no move token, staging fence, or
-   * placement assertion attached. Shared with `duty/fetch`, so a member that wins
-   * a duty for an agent it lacks installs exactly what an activation would.
+   * skills, integration specs, crons, and the two definition kinds the spec only
+   * NAMES (its proxied MCP servers and its external-memory connection) — with no
+   * move token, staging fence, or placement assertion attached.
+   *
+   * Used only by `duty/fetch`. The MCP and memory defs come from the SAME
+   * projector the reconnect roster uses, scoped to this one agent's references,
+   * so a holder's install and its next snapshot cannot disagree and the reply
+   * carries nothing beyond what the duty it already holds covers. A move keeps
+   * its narrower `activationDefinition` — placement moves converge these two
+   * kinds through their own live pushes and the target's register.
    */
   async bundleFor(agent: AgentRecord): Promise<DutyAgentBundle> {
-    return this.activationDefinition(agent, await this.snapshot(agent))
+    const log = { warn: (obj: object, msg: string) => this.deps.log?.warn(obj, msg) }
+    const [snapshot, mcpServers, memoryConnections] = await Promise.all([
+      this.snapshot(agent),
+      mcpDefsForAgents([agent], this.deps.mcp, log, { agentId: agent.id }),
+      memoryDefsForAgents([agent], this.deps.memory, log, { agentId: agent.id })
+    ])
+    return { ...this.activationDefinition(agent, snapshot), mcpServers, memoryConnections }
   }
 
   /** Read every placement-dependent wire definition. */

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -295,6 +295,13 @@ export class DutyLeaseService {
     return this.repo.holdsAgent(holder, agentId, new Date(this.clock.now()))
   }
 
+  /** The agents this member currently holds a duty for — the holder's-side twin of
+   *  {@link DutyLeaseService.holdsAgent}, and the read behind "which agents does
+   *  this daemon serve" (orchestrator/servedAgents.ts). Same live lease horizon. */
+  heldAgentIds(holder: DaemonId, now: Date = new Date(this.clock.now())): Promise<AgentId[]> {
+    return this.repo.heldAgentIds(holder, now)
+  }
+
   /** Explicit drain release — vacate now instead of waiting out T_reassign.
    *  Queued behind any earlier beat's exchange (lane order = frame order), so
    *  every grant that exchange emitted reaches the daemon BEFORE this ack, and

--- a/packages/control-plane/src/orchestrator/mcpProvider.test.ts
+++ b/packages/control-plane/src/orchestrator/mcpProvider.test.ts
@@ -3,6 +3,7 @@ import { McpServerSpec, RcMcpAssign } from '@agentconnect.md/protocol'
 import {
   mintGrantKey,
   grantKeyHash,
+  currentMcpGrant,
   mcpProxyDef,
   mcpRcAssign,
   blockedUpstreamUrl,
@@ -35,7 +36,11 @@ describe('relayHttpOrigin', () => {
   })
 
   it('produces an http-scheme proxy url when fed a wss relay (the transport bug)', () => {
-    const def = mcpProxyDef(provider, 'oct_k', relayHttpOrigin('wss://relay.example/rd'))
+    const def = mcpProxyDef(
+      provider,
+      { key: 'oct_k', createdAt: new Date(0) },
+      relayHttpOrigin('wss://relay.example/rd')
+    )
     expect(def.url).toBe('https://relay.example/mcp/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d')
     expect(def.transport).toBe('http')
   })
@@ -51,8 +56,30 @@ describe('grantKeyHash', () => {
   })
 })
 
+describe('currentMcpGrant', () => {
+  const at = (ms: number, key: string) => ({ key, createdAt: new Date(ms) })
+
+  it('picks the NEWEST active grant — the retiring one is first during a rotation', () => {
+    // `activeForProvider` orders by createdAt ascending, and rotation deliberately
+    // leaves both active until the fresh key is distributed. Taking the head inside
+    // that window projects the key the CP is about to revoke.
+    expect(currentMcpGrant([at(1_000, 'oct_retiring'), at(2_000, 'oct_fresh')])?.key).toBe('oct_fresh')
+  })
+  it('is undefined when there is no active grant at all', () => {
+    expect(currentMcpGrant([])).toBeUndefined()
+  })
+})
+
 describe('mcpProxyDef', () => {
-  const def = mcpProxyDef(provider, 'oct_secret', 'https://relay.example.com')
+  const def = mcpProxyDef(
+    provider,
+    { key: 'oct_secret', createdAt: new Date(1_700_000_000_000) },
+    'https://relay.example.com'
+  )
+
+  it('orders itself by the instant its grant was issued', () => {
+    expect(def.issuedAt).toBe(1_700_000_000_000)
+  })
 
   it('is a valid McpServerSpec', () => {
     expect(() => McpServerSpec.parse(def)).not.toThrow()

--- a/packages/control-plane/src/orchestrator/mcpProvider.ts
+++ b/packages/control-plane/src/orchestrator/mcpProvider.ts
@@ -104,18 +104,39 @@ export function relayHttpOrigin(relayUrl: string): string {
   return u.origin
 }
 
+/** The grant fields every projection needs: the key it ships and the instant that
+ *  orders it. Taken together off ONE row so the two can never disagree. */
+export interface GrantView {
+  key: string
+  createdAt: Date
+}
+
+/**
+ * The current grant of a provider's active set — the ONE selector, because
+ * rotation deliberately leaves the retiring and the fresh grant both active until
+ * the fresh one is distributed. `activeForProvider` orders by `createdAt` ascending,
+ * so the newest is last; taking `[0]` inside that window projects the key the CP is
+ * about to revoke. The same discipline (and the same reason) as the external-memory
+ * projector's `activeForConnection(...).at(-1)`.
+ */
+export function currentMcpGrant<T extends GrantView>(active: readonly T[]): T | undefined {
+  return active.at(-1)
+}
+
 /**
  * The daemon proxy def for a provider: an `http` MCP server pointing at the relay
  * proxy URL with the PLAINTEXT grant key as its bearer. NEVER carries the upstream
- * url or upstream secret headers.
+ * url or upstream secret headers. Takes the grant ROW, not a bare key, so the
+ * ordering marker and the key it orders always come from the same grant.
  */
-export function mcpProxyDef(provider: ProviderView, grantKey: string, relayBaseUrl: string): McpServerSpec {
+export function mcpProxyDef(provider: ProviderView, grant: GrantView, relayBaseUrl: string): McpServerSpec {
   return {
     orgId: provider.orgId,
     name: provider.name,
+    issuedAt: grant.createdAt.getTime(),
     transport: 'http',
     url: `${relayBaseUrl}/mcp/${provider.id}`,
-    headers: [{ name: 'Authorization', value: `Bearer ${grantKey}` }],
+    headers: [{ name: 'Authorization', value: `Bearer ${grant.key}` }],
     args: [],
     env: []
   }

--- a/packages/control-plane/src/orchestrator/memoryConnectionReplay.ts
+++ b/packages/control-plane/src/orchestrator/memoryConnectionReplay.ts
@@ -1,12 +1,15 @@
 /** Full external-memory binding replay to one freshly registered relay. */
 import type {
+  AgentRepo,
+  ExternalMemoryConnectionRecord,
   ExternalMemoryConnectionRepo,
   ExternalMemoryConnectionSecretStore,
   ExternalMemoryGrantRepo,
-  MemoryPluginInstallationRepo,
-  DaemonRepo
+  MemoryPluginInstallationRepo
 } from '../persistence/ports.js'
+import { OrgId } from '../domain/ids.js'
 import type { RelayChannel } from '../ws/relay-registry.js'
+import type { AgentDelivery } from './agentDelivery.js'
 import type { ControlSender } from './outbound.js'
 import { memoryConnectionSpec, memoryRcAssign, stdioMemoryConnectionSpec } from './memoryConnection.js'
 
@@ -19,7 +22,9 @@ export interface MemoryConnectionReplayDeps {
 }
 
 export interface MemoryConnectionDaemonSyncDeps extends MemoryConnectionReplayDeps {
-  daemons: DaemonRepo
+  agents: AgentRepo
+  /** The one resolver of a definition's delivery set — placement ∪ duty holders. */
+  delivery: Pick<AgentDelivery, 'daemonsForAgents'>
   control: Pick<ControlSender, 'memoryConnectionUpsert'>
 }
 
@@ -51,45 +56,57 @@ export async function replayMemoryConnectionsTo(
 }
 
 /**
- * Re-project every placed connection after the selected relay changes or the
- * first relay appears. Without this hot sync, an agent bound while the relay
- * pool was empty would remain unprobed until its daemon reconnected.
+ * Re-project every bound connection after the selected relay changes or the first
+ * relay appears. Without this hot sync, an agent bound while the relay pool was
+ * empty would remain unprobed until its daemon reconnected.
+ *
+ * Driven from the CONNECTIONS, not from the daemon table: the targets are the
+ * delivery set of the agents bound to each connection — placement ∪ duty holders —
+ * so a member serving the agent through a duty is re-projected too. It also
+ * projects each connection's spec once instead of once per target.
  */
 export async function syncMemoryConnectionsToDaemons(
   relayBaseUrl: string,
   deps: MemoryConnectionDaemonSyncDeps
 ): Promise<void> {
-  await Promise.all(
-    (await deps.daemons.list()).map(async (daemon) => {
-      await Promise.all(
-        (await deps.connections.activeForDaemon(daemon.id)).map(async (connection) => {
-          try {
-            const installation = await deps.installations.get(connection.installationId)
-            if (!installation) return
-            if (installation.transport === 'stdio') {
-              const secrets = (await deps.secrets.get(connection.orgId, connection.id)) ?? {}
-              await deps.control.memoryConnectionUpsert(
-                daemon.id,
-                stdioMemoryConnectionSpec(connection, installation, secrets)
-              )
-              return
-            }
+  const byOrg = new Map<string, ExternalMemoryConnectionRecord[]>()
+  for (const connection of await deps.connections.listAll()) {
+    byOrg.set(connection.orgId, [...(byOrg.get(connection.orgId) ?? []), connection])
+  }
+  for (const [orgId, connections] of byOrg) {
+    const agents = await deps.agents.list(OrgId(orgId))
+    await Promise.all(
+      connections.map(async (connection) => {
+        try {
+          const bound = agents.filter(
+            (agent) => agent.memory?.provider === 'external' && agent.memory.connectionId === connection.id
+          )
+          const targets = await deps.delivery.daemonsForAgents(bound)
+          if (targets.length === 0) return
+          const installation = await deps.installations.get(connection.installationId)
+          if (!installation) return
+          let spec
+          if (installation.transport === 'stdio') {
+            const secrets = (await deps.secrets.get(connection.orgId, connection.id)) ?? {}
+            spec = stdioMemoryConnectionSpec(connection, installation, secrets)
+          } else {
             const [grants, secretKeys] = await Promise.all([
               deps.grants.activeForConnection(connection.orgId, connection.id),
               deps.secrets.keys(connection.orgId, connection.id)
             ])
             const grant = grants.at(-1)
             if (!grant) return
-            await deps.control.memoryConnectionUpsert(
-              daemon.id,
-              memoryConnectionSpec(connection, installation, secretKeys, grant.key, relayBaseUrl)
-            )
-          } catch {
+            spec = memoryConnectionSpec(connection, installation, secretKeys, grant.key, relayBaseUrl)
+          }
+          for (const daemonId of targets) {
             // Offline/version-skewed daemon or store blip. register/ok remains the
             // authoritative backstop; never log secret-bearing details here.
+            await deps.control.memoryConnectionUpsert(daemonId, spec).catch(() => {})
           }
-        })
-      )
-    })
-  )
+        } catch {
+          // Same swallow: a store/projection failure must not starve the rest.
+        }
+      })
+    )
+  }
 }

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -34,10 +34,9 @@ import type {
   IntegrationBindRule,
   IntegrationCoreEnvelope,
   McpServerSpec,
-  MemoryConnectionSpec,
-  RelayRosterEntry
+  MemoryConnectionSpec
 } from '@agentconnect.md/protocol'
-import { RESERVED_MCP_SERVER_NAME, SessionRetentionSetting } from '@agentconnect.md/protocol'
+import { SessionRetentionSetting } from '@agentconnect.md/protocol'
 import type {
   AgentRepo,
   AgentRecord,
@@ -55,17 +54,16 @@ import type {
   BotRecord,
   BotRepo,
   IntegrationChannelRepo,
-  IntegrationChannelRecord,
-  McpProviderRepo,
-  McpGrantRepo,
-  ExternalMemoryConnectionRepo,
-  ExternalMemoryConnectionSecretStore,
-  ExternalMemoryGrantRepo,
-  MemoryPluginInstallationRepo
+  IntegrationChannelRecord
 } from '../persistence/ports.js'
 import type { CpPlatformRegistry } from '../platforms/provider.js'
-import { mcpProxyDef, relayHttpOrigin } from './mcpProvider.js'
-import { memoryConnectionSpec, stdioMemoryConnectionSpec } from './memoryConnection.js'
+import { servedAgents, type ServedAgents } from './servedAgents.js'
+import {
+  mcpDefsForAgents,
+  memoryDefsForAgents,
+  type McpDefinitionDeps,
+  type MemoryDefinitionDeps
+} from './agentDefinitions.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
 import { AgentId as toAgentId, DaemonId as toDaemonId, IntegrationId as toIntegrationId } from '../domain/ids.js'
 import { sessionKeyStr, type SessionKey } from '../domain/sessionKey.js'
@@ -82,11 +80,6 @@ export interface ReconcileService {
   reconcile(daemonId: DaemonId, req: RegisterReq): Promise<RegisterOk>
 }
 
-/** Minimal view of the relay roster the reconcile MCP block picks a proxy base from. */
-export interface RelayRosterView {
-  entries(): Promise<RelayRosterEntry[]>
-}
-
 /** The live-orchestration collaborators Placement needs beyond the C6 repos. */
 export interface PlacementOrchDeps {
   registry: ConnectionRegistry
@@ -95,17 +88,11 @@ export interface PlacementOrchDeps {
   clock: Clock
   config: { REASSIGN_GRACE_SEC: number; ACK_TIMEOUT_MS: number }
   /** MCP-proxy reconcile bundle (centralized-tool-management.md §7): the org providers
-   *  a daemon's agents enabled, their active grant keys, and the relay roster to pick a
-   *  proxy base from. Grouped here (not positional repos) so the whole concern is one
+   *  this daemon's agents enabled, their active grant keys, and the relay roster to pick
+   *  a proxy base from. Grouped here (not positional repos) so the whole concern is one
    *  optional seam — absent (tests / no orch) ⇒ reconcile ships no MCP defs. */
-  mcp?: { providers: McpProviderRepo; grants: McpGrantRepo; relayRoster: RelayRosterView }
-  memory?: {
-    connections: ExternalMemoryConnectionRepo
-    installations: MemoryPluginInstallationRepo
-    secrets: ExternalMemoryConnectionSecretStore
-    grants: ExternalMemoryGrantRepo
-    relayRoster: RelayRosterView
-  }
+  mcp?: McpDefinitionDeps
+  memory?: MemoryDefinitionDeps
   /** The duty ledger read that makes the reconcile roster `pinned-to-me ∪ agents
    *  in the duties I hold`. Absent (tests / no pool) ⇒ placement alone. */
   duties?: { heldAgentIds(holder: DaemonId, now: Date): Promise<AgentId[]> }
@@ -381,10 +368,12 @@ export class Placement implements ReconcileService {
 
   /** The agents this member currently holds a duty for. No ledger wired ⇒ none,
    *  which is exactly the pre-duty roster. */
-  private async dutyHeldAgentIds(daemonId: DaemonId): Promise<AgentId[]> {
-    const duties = this.orch?.duties
-    if (!duties || !this.orch) return []
-    return duties.heldAgentIds(daemonId, new Date(this.orch.clock.now()))
+  private async servedAgents(daemonId: DaemonId): Promise<ServedAgents> {
+    return servedAgents(daemonId, {
+      agents: this.agents,
+      ...(this.orch?.duties ? { duties: this.orch.duties } : {}),
+      now: new Date(this.orch?.clock.now() ?? Date.now())
+    })
   }
 
   async reconcile(daemonId: DaemonId, req: RegisterReq): Promise<RegisterOk> {
@@ -402,27 +391,16 @@ export class Placement implements ReconcileService {
     // the desired set is a stale-replica candidate below and would be PRUNED,
     // undoing the install. Its integrations and crons ride along for the same
     // reason — a served group whose sockets the reconcile dropped serves nothing.
-    const heldAgentIds = await this.dutyHeldAgentIds(daemonId)
-    const [
-      activeAssignments,
-      placedAgents,
-      heldAgents,
-      daemonCrons,
-      heldCrons,
-      activeLeases,
-      daemonIntegrations,
-      heldIntegrations
-    ] = await Promise.all([
-      this.assignments.activeForDaemon(daemonId),
-      this.agents.listForDaemon(daemonId),
-      this.agents.listByIds(heldAgentIds),
-      this.crons.listForDaemon(daemonId),
-      this.crons.listForAgents(heldAgentIds),
-      this.leases.activeForDaemon(daemonId),
-      this.integrations.activeForDaemon(daemonId),
-      this.integrations.activeForAgents(heldAgentIds)
-    ])
-    const ownedAgents = dedupeById(placedAgents, heldAgents)
+    const { heldAgentIds, agents: ownedAgents } = await this.servedAgents(daemonId)
+    const [activeAssignments, daemonCrons, heldCrons, activeLeases, daemonIntegrations, heldIntegrations] =
+      await Promise.all([
+        this.assignments.activeForDaemon(daemonId),
+        this.crons.listForDaemon(daemonId),
+        this.crons.listForAgents(heldAgentIds),
+        this.leases.activeForDaemon(daemonId),
+        this.integrations.activeForDaemon(daemonId),
+        this.integrations.activeForAgents(heldAgentIds)
+      ])
     const activeIntegrations = dedupeById(daemonIntegrations, heldIntegrations)
     const ownedCrons = dedupeById(daemonCrons, heldCrons)
 
@@ -603,8 +581,12 @@ export class Placement implements ReconcileService {
       agents: desiredAgents, // full spec-set the daemon replicates (direct-edge launch needs a local replica)
       crons: desiredCrons,
       integrations: desiredIntegrations, // daemon-scoped platform integrations (token-bearing)
-      mcpServers: await this.desiredMcpServers(daemonId), // proxied MCP defs (relay url + grant key; token-bearing)
-      memoryConnections: await this.desiredMemoryConnections(daemonId),
+      // Both definition kinds are scoped by the SAME roster union as the agents
+      // above — an AgentSpec only names its MCP servers and its memory
+      // connection, so a duty-held replica whose definitions were resolved by
+      // placement would come up with neither. `ownedAgents`, not a second read.
+      mcpServers: await this.desiredMcpServers(daemonId, ownedAgents), // token-bearing (relay url + grant key)
+      memoryConnections: await this.desiredMemoryConnections(daemonId, ownedAgents),
       leases: desiredLeases,
       relays: [], // relay roster — populated once CP relay orchestration lands (shared-bot-relay.md A2)
       collabRoutes, // bot-agnostic collaboration routing snapshot (agent-collaboration P2)
@@ -618,74 +600,20 @@ export class Placement implements ReconcileService {
   }
 
   /**
-   * The proxied MCP defs THIS daemon should hold: for every org provider one of its
-   * placed agents enabled by name (`activeForDaemon`), a relay-proxied `http` def
-   * carrying the RELAY proxy URL + the provider's active plaintext grant key —
-   * NEVER the upstream url or its secret (centralized-tool-management.md §7).
-   * Token-bearing result: NEVER log it. Reserved name excluded (the daemon injects
-   * its own `agentconnect` server). No relay live ⇒ skip (backstop is the next
-   * register once a relay appears).
+   * The proxied MCP defs THIS daemon should hold, keyed on the agents it SERVES
+   * (placed on it or held by duty) rather than on placement — see
+   * `orchestrator/agentDefinitions.ts` for the projector and its security note.
    */
-  private async desiredMcpServers(daemonId: DaemonId): Promise<McpServerSpec[]> {
-    const mcp = this.orch?.mcp
-    if (!mcp) return []
-    const providers = (await mcp.providers.activeForDaemon(daemonId)).filter((p) => p.name !== RESERVED_MCP_SERVER_NAME)
-    if (providers.length === 0) return []
-    const relay = (await mcp.relayRoster.entries())[0]
-    if (!relay) {
-      this.orch?.log?.warn({ daemonId }, 'reconcile: MCP providers enabled but no live relay — skipping MCP defs')
-      return []
-    }
-    // The roster url is the relay's rd/* WS dial address; the MCP proxy is HTTP on the
-    // same origin — normalize wss→https so the `http` def points at a reachable endpoint.
-    const relayBaseUrl = relayHttpOrigin(relay.url)
-    const specs: McpServerSpec[] = []
-    for (const p of providers) {
-      const grant = (await mcp.grants.activeForProvider(p.orgId, p.id))[0]
-      if (grant) specs.push(mcpProxyDef(p, grant.key, relayBaseUrl))
-    }
-    return specs
+  private async desiredMcpServers(daemonId: DaemonId, agents: readonly AgentRecord[]): Promise<McpServerSpec[]> {
+    return mcpDefsForAgents(agents, this.orch?.mcp, this.orch?.log, { daemonId })
   }
 
-  /** Daemon-private connection defs referenced by agents placed on this daemon. */
-  private async desiredMemoryConnections(daemonId: DaemonId): Promise<MemoryConnectionSpec[]> {
-    const memory = this.orch?.memory
-    if (!memory) return []
-    const connections = await memory.connections.activeForDaemon(daemonId)
-    if (connections.length === 0) return []
-    const relay = (await memory.relayRoster.entries())[0]
-    const relayBaseUrl = relay ? relayHttpOrigin(relay.url) : undefined
-    const specs: MemoryConnectionSpec[] = []
-    let skippedRemote = false
-    for (const connection of connections) {
-      const installation = await memory.installations.get(connection.installationId)
-      if (!installation) continue
-      if (installation.transport === 'stdio') {
-        const secrets = (await memory.secrets.get(connection.orgId, connection.id)) ?? {}
-        specs.push(stdioMemoryConnectionSpec(connection, installation, secrets))
-        continue
-      }
-      if (!relayBaseUrl) {
-        skippedRemote = true
-        continue
-      }
-      const [grant, secretKeys] = await Promise.all([
-        // Rotation overlaps old+new grants until every projection has the fresh
-        // key. Prefer the newest active grant so a reconnect in that window does
-        // not receive the key that is about to be retired.
-        memory.grants.activeForConnection(connection.orgId, connection.id).then((rows) => rows.at(-1)),
-        memory.secrets.keys(connection.orgId, connection.id)
-      ])
-      if (!grant) continue
-      specs.push(memoryConnectionSpec(connection, installation, secretKeys, grant.key, relayBaseUrl))
-    }
-    if (skippedRemote) {
-      this.orch?.log?.warn(
-        { daemonId },
-        'reconcile: remote external memory connections have no live relay — local stdio definitions remain available'
-      )
-    }
-    return specs
+  /** Connection defs referenced by the agents this daemon serves — same union. */
+  private async desiredMemoryConnections(
+    daemonId: DaemonId,
+    agents: readonly AgentRecord[]
+  ): Promise<MemoryConnectionSpec[]> {
+    return memoryDefsForAgents(agents, this.orch?.memory, this.orch?.log, { daemonId })
   }
 
   // ── Live placement / rebalance (Phase 3) ──────────────────────────────────

--- a/packages/control-plane/src/orchestrator/servedAgents.ts
+++ b/packages/control-plane/src/orchestrator/servedAgents.ts
@@ -1,0 +1,40 @@
+/**
+ * `servedAgents` — the ONE answer to "which agents does this daemon serve".
+ *
+ * The daemon-side twin of `AgentDelivery.daemonsFor`: `pinned-to-me ∪ agents in
+ * the duties I hold`. #978 introduced that union inside `Placement.reconcile` for
+ * the roster; anything else keyed on "what this daemon serves" — the MCP and
+ * external-memory definitions the roster ships, and the inbound ownership gate on
+ * daemon-reported memory facts — has to use the same one or a duty holder is
+ * served an agent whose definitions, or whose probe reports, silently do not
+ * belong to it. Recomputing it per caller is exactly the drift to avoid.
+ */
+import type { AgentRecord, AgentRepo } from '../persistence/ports.js'
+import type { AgentId, DaemonId } from '../domain/ids.js'
+
+/** The duty ledger read behind the union's second half. */
+export interface DutyHeldAgentReader {
+  heldAgentIds(holder: DaemonId, now: Date): Promise<AgentId[]>
+}
+
+export interface ServedAgentsDeps {
+  agents: Pick<AgentRepo, 'listForDaemon' | 'listByIds'>
+  /** Absent (tests / no pool) ⇒ the placement half alone, the pre-duty behavior. */
+  duties?: DutyHeldAgentReader
+  now: Date
+}
+
+export interface ServedAgents {
+  /** The duty half on its own — dependents keyed by agent id ride it directly. */
+  heldAgentIds: AgentId[]
+  /** The union, deduped, placement first. */
+  agents: AgentRecord[]
+}
+
+export async function servedAgents(daemonId: DaemonId, deps: ServedAgentsDeps): Promise<ServedAgents> {
+  const heldAgentIds = deps.duties ? await deps.duties.heldAgentIds(daemonId, deps.now) : []
+  const [placed, held] = await Promise.all([deps.agents.listForDaemon(daemonId), deps.agents.listByIds(heldAgentIds)])
+  const byId = new Map(placed.map((agent) => [agent.id as string, agent]))
+  for (const agent of held) if (!byId.has(agent.id)) byId.set(agent.id, agent)
+  return { heldAgentIds, agents: [...byId.values()] }
+}

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4145,8 +4145,8 @@ export interface McpProviderRepo {
   /** Org-fenced point read (docs/designs/org-scoped-data-layer.md §3): a
    *  cross-org id reads as absent, exactly like a missing row. This port has no
    *  `getUnscoped` — the daemon and relay reach providers through
-   *  {@link McpProviderRepo.activeForDaemon} and {@link McpProviderRepo.listAll},
-   *  so no internal trust domain needs an id-addressed escape hatch. */
+   *  {@link McpProviderRepo.listForOrg} and {@link McpProviderRepo.listAll}, so no
+   *  internal trust domain needs an id-addressed escape hatch. */
   get(orgId: OrgId, id: string): Promise<McpProviderRecord | null>
   /** The org's providers, filtered to what a supplied human principal may see
    *  (org-visible OR owned-by-them OR shared-with-them). Undefined is reserved
@@ -4164,13 +4164,6 @@ export interface McpProviderRepo {
   update(orgId: OrgId, id: string, patch: UpdateMcpProviderInput): Promise<McpProviderRecord>
   /** Org-fenced: a cross-org id throws the same P2025 as a missing row. */
   delete(orgId: OrgId, id: string): Promise<void>
-  /**
-   * Providers that should be pushed to `daemonId`: an org provider whose `name` is
-   * enabled (in `runtimeOverrides.mcpServers`) by some agent placed on the daemon.
-   * Mirrors {@link IntegrationRepo.activeForDaemon} but org-scoped (v1 visibility='org'):
-   * a daemon receives the proxy def only when one of its agents opted the provider in.
-   */
-  activeForDaemon(daemonId: DaemonId): Promise<McpProviderRecord[]>
   /** EVERY provider across all orgs — the pool-wide set replayed to a relay that just
    *  (re)registered (its in-memory binding table starts empty; bindings are pool-wide,
    *  like bots/hooks). System-tier: deployment-level infrastructure by design. */
@@ -4611,7 +4604,7 @@ export interface ExternalMemoryConnectionRepo {
   }): Promise<ExternalMemoryConnectionRecord>
   /** Org-fenced point read (org-scoped-data-layer.md §3): a cross-org id reads
    *  as absent, exactly like a missing row. No `getUnscoped` — the daemon and
-   *  relay reach connections through `activeForDaemon` / `listAll`, never by id. */
+   *  relay reach connections through `listForOrg` / `listAll`, never by id. */
   get(orgId: OrgId, id: string): Promise<ExternalMemoryConnectionRecord | null>
   listForOrg(orgId: OrgId): Promise<ExternalMemoryConnectionRecord[]>
   /** System-tier: the pool-wide set replayed to a relay that just (re)registered. */
@@ -4620,9 +4613,6 @@ export interface ExternalMemoryConnectionRepo {
   update(orgId: OrgId, id: string, patch: { config?: Record<string, unknown> }): Promise<ExternalMemoryConnectionRecord>
   /** Org-fenced: a cross-org id throws the same P2025 as a missing row. */
   delete(orgId: OrgId, id: string): Promise<void>
-  /** Connections referenced by an external-memory agent placed on this daemon.
-   *  System-tier: daemon-fenced. */
-  activeForDaemon(daemonId: DaemonId): Promise<ExternalMemoryConnectionRecord[]>
   /** Revision-fenced probe fact update; stale daemon facts are ignored.
    *  System-tier: daemon-reported, fenced by the revision CAS. */
   updateProbeFact(

--- a/packages/control-plane/src/persistence/repositories/mcp.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/mcp.repo.ts
@@ -31,7 +31,7 @@ import type {
 import { visibilityWhere } from '../../authorization/policy.js'
 import type { SecretCipher } from '../../secrets/cipher.js'
 import { orgScope } from '../../secrets/scope.js'
-import { DaemonId, OrgId } from '../../domain/ids.js'
+import { OrgId } from '../../domain/ids.js'
 import { lockResourceWriteMemberships } from '../resource-membership-lock.js'
 
 function toProviderRecord(p: McpProvider): McpProviderRecord {
@@ -142,29 +142,6 @@ export class PgMcpProviderRepo implements McpProviderRepo {
   async delete(orgId: OrgId, id: string): Promise<void> {
     // Org-fenced delete: a cross-org id throws the same P2025 as a missing row.
     await this.db.mcpProvider.delete({ where: { id, orgId } }) // FK cascade drops secret + grants
-  }
-
-  // Org providers whose `name` is enabled by some agent placed on this daemon. The
-  // enable-list lives in the agent's `runtimeOverrides.mcpServers` JSON (not a scalar
-  // column), so collect the enabled names in app code, then point-query the providers.
-  async activeForDaemon(daemonId: DaemonId): Promise<McpProviderRecord[]> {
-    const agents = await this.db.agent.findMany({
-      where: { daemonId },
-      select: { orgId: true, runtimeOverrides: true }
-    })
-    const orgIds = new Set<string>()
-    const names = new Set<string>()
-    for (const a of agents) {
-      orgIds.add(a.orgId)
-      const ov = a.runtimeOverrides as { mcpServers?: string[] } | null
-      for (const n of ov?.mcpServers ?? []) names.add(n)
-    }
-    if (names.size === 0) return []
-    const rows = await this.db.mcpProvider.findMany({
-      where: { orgId: { in: [...orgIds] }, name: { in: [...names] } },
-      orderBy: { createdAt: 'asc' }
-    })
-    return rows.map(toProviderRecord)
   }
 }
 

--- a/packages/control-plane/src/persistence/repositories/memory-connection.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/memory-connection.repo.ts
@@ -10,7 +10,7 @@ import type {
   MemoryPluginInstallation
 } from '../../generated/prisma/client.js'
 import { mintGrantKey } from '../../orchestrator/mcpProvider.js'
-import { DaemonId, OrgId } from '../../domain/ids.js'
+import { OrgId } from '../../domain/ids.js'
 import type { SecretCipher } from '../../secrets/cipher.js'
 import { orgScope } from '../../secrets/scope.js'
 import type { PrismaLike } from '../prisma.js'
@@ -167,18 +167,6 @@ export class PgExternalMemoryConnectionRepo implements ExternalMemoryConnectionR
   async delete(orgId: OrgId, id: string): Promise<void> {
     // Org-fenced delete: a cross-org id throws the same P2025 as a missing row.
     await this.db.externalMemoryConnection.delete({ where: { id, orgId } })
-  }
-
-  async activeForDaemon(daemonId: DaemonId): Promise<ExternalMemoryConnectionRecord[]> {
-    const agents = await this.db.agent.findMany({ where: { daemonId }, select: { runtimeOverrides: true } })
-    const ids = new Set<string>()
-    for (const agent of agents) {
-      const memory = (agent.runtimeOverrides as { memory?: { provider?: string; connectionId?: string } } | null)
-        ?.memory
-      if (memory?.provider === 'external' && memory.connectionId) ids.add(memory.connectionId)
-    }
-    if (ids.size === 0) return []
-    return (await this.db.externalMemoryConnection.findMany({ where: { id: { in: [...ids] } } })).map(toConnection)
   }
 
   async updateProbeFact(

--- a/packages/control-plane/src/ws/handlers/memory-connections.ts
+++ b/packages/control-plane/src/ws/handlers/memory-connections.ts
@@ -1,6 +1,7 @@
 /** `facts/memory-connections` — revision-fenced, metadata-only probe facts. */
 import { isFrame } from '@agentconnect.md/protocol'
 import { DaemonId } from '../../domain/ids.js'
+import { servedAgents } from '../../orchestrator/servedAgents.js'
 import type { Handler } from './index.js'
 
 export const handleMemoryConnections: Handler = async (frame, conn, deps) => {
@@ -11,11 +12,19 @@ export const handleMemoryConnections: Handler = async (frame, conn, deps) => {
   // Facts are metadata-only, but they still drive the static admission status
   // shown in the console. A revision fence alone is not an ownership check: a
   // daemon that learned another org's UUID could otherwise poison that
-  // connection's status. Restrict the accepted set to definitions currently
-  // placed on this authenticated daemon, matching every other daemon-originated
-  // fact handler's ownership boundary.
+  // connection's status. The accepted set is therefore the connections bound by
+  // the agents this daemon SERVES — the same `pinned-to-me ∪ duties I hold` union
+  // the roster ships those definitions under, so a duty holder can report on what
+  // it was given and on nothing else.
+  const { agents } = await servedAgents(DaemonId(conn.daemonId), {
+    agents: deps.agent,
+    ...(deps.dutyLease ? { duties: deps.dutyLease } : {}),
+    now: new Date(deps.clock.now())
+  })
   const allowed = new Set(
-    (await connections.activeForDaemon(DaemonId(conn.daemonId))).map((connection) => connection.id)
+    agents.flatMap((agent) =>
+      agent.memory?.provider === 'external' && agent.memory.connectionId ? [agent.memory.connectionId] : []
+    )
   )
   await Promise.all(
     frame.payload.connections.map((fact) => {

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -34,6 +34,8 @@ import {
   PgExternalMemoryConnectionRepo,
   PgExternalMemoryConnectionSecretStore,
   PgExternalMemoryGrantRepo,
+  PgMcpProviderRepo,
+  PgMcpGrantRepo,
   PgDutyGroupRepo
 } from '../../src/persistence/index.js'
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
@@ -127,7 +129,9 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     memoryPluginInstallation: new PgMemoryPluginInstallationRepo(prisma),
     externalMemoryConnection: new PgExternalMemoryConnectionRepo(prisma),
     externalMemoryConnectionSecret: new PgExternalMemoryConnectionSecretStore(prisma, cipher),
-    externalMemoryGrant: new PgExternalMemoryGrantRepo(prisma, cipher)
+    externalMemoryGrant: new PgExternalMemoryGrantRepo(prisma, cipher),
+    mcpProvider: new PgMcpProviderRepo(prisma),
+    mcpGrant: new PgMcpGrantRepo(prisma, cipher)
   }
 
   const codec = new ApiKeyCodec({ API_KEY_PEPPER: TEST_API_KEY_PEPPER })
@@ -185,6 +189,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
         REASSIGN_GRACE_SEC: 60,
         ACK_TIMEOUT_MS: opts.ackTimeoutMs ?? 5000
       },
+      mcp: { providers: repos.mcpProvider, grants: repos.mcpGrant, relayRoster: { entries: async () => relays } },
       memory: {
         connections: repos.externalMemoryConnection,
         installations: repos.memoryPluginInstallation,

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -6,7 +6,7 @@
  * sessions, leases, and crons have valid foreign keys to hang off. All default
  * to the seeded `DEFAULT_ORG_ID`.
  */
-import type { PrismaClient } from '../../src/generated/prisma/client.js'
+import type { Prisma, PrismaClient } from '../../src/generated/prisma/client.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { AgentId, DaemonId, OrgId, type Epoch } from '../../src/domain/ids.js'
 
@@ -80,7 +80,7 @@ export async function seedAgent(
       ...(opts.gitRepo ? { workspaceMode: 'github' as const, gitRepo: opts.gitRepo } : {}),
       ...(opts.installationId ? { installationId: opts.installationId } : {}),
       ...(opts.gitAccess ? { gitAccess: opts.gitAccess } : {}),
-      ...(opts.runtimeOverrides ? { runtimeOverrides: opts.runtimeOverrides } : {})
+      ...(opts.runtimeOverrides ? { runtimeOverrides: opts.runtimeOverrides as Prisma.InputJsonValue } : {})
     }
   })
   return AgentId(id)

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -63,6 +63,8 @@ export async function seedAgent(
     /** GithubInstallation row-id provenance hint ⇒ github-APP credential mode. */
     installationId?: string
     gitAccess?: 'read' | 'write'
+    /** `runtimeOverrides` JSON — where the MCP enable-list and memory binding live. */
+    runtimeOverrides?: Record<string, unknown>
   } = {}
 ): Promise<AgentId> {
   await prisma.agent.create({
@@ -77,7 +79,8 @@ export async function seedAgent(
       ...(opts.createdByUserId ? { createdByUserId: opts.createdByUserId } : {}),
       ...(opts.gitRepo ? { workspaceMode: 'github' as const, gitRepo: opts.gitRepo } : {}),
       ...(opts.installationId ? { installationId: opts.installationId } : {}),
-      ...(opts.gitAccess ? { gitAccess: opts.gitAccess } : {})
+      ...(opts.gitAccess ? { gitAccess: opts.gitAccess } : {}),
+      ...(opts.runtimeOverrides ? { runtimeOverrides: opts.runtimeOverrides } : {})
     }
   })
   return AgentId(id)

--- a/packages/control-plane/test/integration/agents.replication.route.test.ts
+++ b/packages/control-plane/test/integration/agents.replication.route.test.ts
@@ -556,6 +556,97 @@ describe('agent updates follow the duty holder', () => {
     expect(spy.upserts[0]!.u.spec).toEqual(spy.upserts[1]!.u.spec)
   })
 
+  /**
+   * The two definition kinds the AgentSpec only NAMES (#979). They were the last
+   * placement-keyed fan-outs: a holder installed an agent referencing MCP servers
+   * it had no definitions for, and provider rotations never reached it.
+   */
+  it('an MCP provider UPDATE reaches a holder that is not the placement', async () => {
+    await seedDaemon(prisma, HOLDER)
+    const { providerId } = await seedProviderAndRelay()
+    const agentId = randomUUID()
+    // Placed nowhere and enabling `fakemcp`: the duty is the only reason it is served.
+    await seedAgent(prisma, agentId, { runtimeOverrides: { mcpServers: ['fakemcp'] } })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+
+    const spy = new McpSpyControl()
+    running = buildHttpApp(prisma, { RELAY_STALE_MS: 60_000 }, undefined, spy as unknown as ControlSender)
+    const res = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/mcp-providers/${providerId}`,
+      payload: { url: 'https://upstream.example.test/mcp/v2' }
+    })
+    expect(res.statusCode, res.body).toBe(200)
+    // Content, not arrival: the holder must get the callable proxy def, not a bare ping.
+    expect(spy.mcpUpserts).toEqual([
+      {
+        daemonId: HOLDER,
+        spec: expect.objectContaining({
+          name: 'fakemcp',
+          url: `http://relay.example:8443/mcp/${providerId}`,
+          headers: [{ name: 'Authorization', value: 'Bearer oct_testkey' }]
+        })
+      }
+    ])
+  })
+
+  it('a grant ROTATION reaches the holder, so its calls do not start 401ing', async () => {
+    await seedDaemon(prisma, HOLDER)
+    const { providerId } = await seedProviderAndRelay()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { runtimeOverrides: { mcpServers: ['fakemcp'] } })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+
+    const spy = new McpSpyControl()
+    running = buildHttpApp(prisma, { RELAY_STALE_MS: 60_000 }, undefined, spy as unknown as ControlSender)
+    const res = await running.app.inject({ method: 'POST', url: `${ORG}/mcp-providers/${providerId}/grant/rotate` })
+    expect(res.statusCode, res.body).toBe(200)
+    expect(spy.mcpUpserts.map((u) => u.daemonId)).toEqual([HOLDER])
+    // The FRESH key, not the retired one — arrival alone would not prove that.
+    expect(spy.mcpUpserts[0]!.spec.headers).not.toEqual([{ name: 'Authorization', value: 'Bearer oct_testkey' }])
+  })
+
+  it('a member holding NO duty covering the enabling agent receives no def', async () => {
+    await seedDaemon(prisma, HOLDER)
+    await seedDaemon(prisma, DAEMON)
+    const { providerId } = await seedProviderAndRelay()
+    const unrelated = randomUUID()
+    await seedAgent(prisma, randomUUID(), { runtimeOverrides: { mcpServers: ['fakemcp'] } })
+    // HOLDER holds a duty, but for an agent that enables nothing — the boundary.
+    await seedAgent(prisma, unrelated, { daemonId: DAEMON })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [unrelated])
+
+    const spy = new McpSpyControl()
+    running = buildHttpApp(prisma, { RELAY_STALE_MS: 60_000 }, undefined, spy as unknown as ControlSender)
+    const res = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/mcp-providers/${providerId}`,
+      payload: { url: 'https://upstream.example.test/mcp/v2' }
+    })
+    expect(res.statusCode, res.body).toBe(200)
+    // `enabling` reaches no daemon at all, so the grant key leaves the CP nowhere.
+    expect(spy.mcpUpserts).toEqual([])
+  })
+
+  it('enabling a provider ON a duty-held agent pushes the def to its holder', async () => {
+    await seedDaemon(prisma, HOLDER)
+    const { providerId } = await seedProviderAndRelay()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+
+    const spy = new McpSpyControl()
+    running = buildHttpApp(prisma, { RELAY_STALE_MS: 60_000 }, undefined, spy as unknown as ControlSender)
+    const res = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { mcpServers: ['fakemcp'] }
+    })
+    expect(res.statusCode, res.body).toBe(200)
+    expect(spy.mcpUpserts.map((u) => u.daemonId)).toEqual([HOLDER])
+    expect(spy.mcpUpserts[0]!.spec.url).toBe(`http://relay.example:8443/mcp/${providerId}`)
+  })
+
   it('the placement holding its own agent is one target, not two', async () => {
     await seedDaemon(prisma, DAEMON)
     const agentId = randomUUID()

--- a/packages/control-plane/test/integration/agents.replication.route.test.ts
+++ b/packages/control-plane/test/integration/agents.replication.route.test.ts
@@ -21,6 +21,8 @@ import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender, NoConnection } from '../../src/orchestrator/outbound.js'
 import type { AgentUpsert, AgentRemove, CollabRoutesSnapshot } from '@agentconnect.md/protocol'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { mcpDefsForAgents } from '../../src/orchestrator/agentDefinitions.js'
+import { AgentId } from '../../src/domain/ids.js'
 
 // Console routes are org-scoped: /orgs/:orgId/… (devAuth = seeded owner of the default org).
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -604,6 +606,35 @@ describe('agent updates follow the duty holder', () => {
     expect(spy.mcpUpserts.map((u) => u.daemonId)).toEqual([HOLDER])
     // The FRESH key, not the retired one — arrival alone would not prove that.
     expect(spy.mcpUpserts[0]!.spec.headers).not.toEqual([{ name: 'Authorization', value: 'Bearer oct_testkey' }])
+  })
+
+  it('a def projected DURING a rotation overlap carries the fresh key, ordered after the retiring one', async () => {
+    await seedDaemon(prisma, HOLDER)
+    const { providerId } = await seedProviderAndRelay()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { runtimeOverrides: { mcpServers: ['fakemcp'] } })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+
+    const spy = new McpSpyControl()
+    running = buildHttpApp(prisma, { RELAY_STALE_MS: 60_000 }, undefined, spy as unknown as ControlSender)
+    // The overlap window, exactly as `rotateOnce` creates it: mint the fresh grant
+    // while the retiring one is still active, and project BEFORE the revoke lands.
+    const fresh = await prisma.mcpGrant.create({
+      data: { mcpProviderId: providerId, key: 'oct_freshkey', createdAt: new Date(Date.now() + 1_000) }
+    })
+    const agent = await running.deps.repos.agent.getUnscoped(AgentId(agentId))
+    const defs = await mcpDefsForAgents([agent!], {
+      providers: running.deps.repos.mcpProvider,
+      grants: running.deps.repos.mcpGrant,
+      relayRoster: { entries: async () => [{ relayId: randomUUID(), url: 'ws://relay.example:8443' }] }
+    })
+
+    expect(defs).toHaveLength(1)
+    expect(defs[0]!.headers).toEqual([{ name: 'Authorization', value: 'Bearer oct_freshkey' }])
+    // Strictly newer than the retiring grant, which is what makes the daemon fence work.
+    expect(defs[0]!.issuedAt).toBe(fresh.createdAt.getTime())
+    const retiring = await prisma.mcpGrant.findFirstOrThrow({ where: { key: 'oct_testkey' } })
+    expect(defs[0]!.issuedAt!).toBeGreaterThan(retiring.createdAt.getTime())
   })
 
   it('a member holding NO duty covering the enabling agent receives no def', async () => {

--- a/packages/control-plane/test/integration/memory-connections.route.test.ts
+++ b/packages/control-plane/test/integration/memory-connections.route.test.ts
@@ -15,7 +15,7 @@ import type {
 } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
-import { DEF_ORG, seedDaemon } from '../fixtures/seed.js'
+import { DEF_ORG, seedAgent, seedDaemon, seedDutyGroup } from '../fixtures/seed.js'
 import type { Prisma } from '../../src/generated/prisma/client.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import {
@@ -955,5 +955,91 @@ describe('external-memory agent binding — placement and revocation', () => {
     })
     expect(invalid.statusCode).toBe(400)
     expect((invalid.json() as { message: string }).message).toContain('conformance')
+  })
+})
+
+/**
+ * The connection definition is a placement-keyed push no longer (#979). A duty
+ * holder installs the agent through `duty/fetch`, so it must also receive the
+ * connection that agent binds — and every later revision of it, or it keeps a
+ * retired grant and a stale secret set while serving live turns.
+ */
+describe('external-memory definitions follow the duty holder', () => {
+  const HOLDER = 'd7777777-7777-4777-8777-777777777777'
+  const GROUP = '00000000-0000-4000-8000-0000000009b1'
+
+  it('a connection UPDATE reaches a holder that is not the placement', async () => {
+    const control = new SpyControl()
+    const app = build({ control, relay: new SpyRelayControl() })
+    await seedDaemon(prisma, HOLDER)
+    await addLiveRelay(app)
+    const installationId = await createInstallation(app)
+    const connection = await createConnection(app, installationId)
+    // Placed nowhere: the duty is the only reason this agent is served anywhere.
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, {
+      runtimeOverrides: { memory: { provider: 'external', connectionId: connection.id } }
+    })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+
+    const patched = await app.app.inject({
+      method: 'PATCH',
+      url: `${CONNECTIONS}/${connection.id}`,
+      payload: { config: { projectId: 'p2' } }
+    })
+    expect(patched.statusCode, patched.body).toBe(200)
+
+    const pushed = control.events.filter((e) => e.kind === 'memory-upsert')
+    expect(pushed.map((e) => e.daemonId)).toEqual([HOLDER])
+    // Content, not arrival: the holder must hold the NEW revision's definition.
+    expect(pushed[0]).toMatchObject({ spec: { revision: 2, config: { projectId: 'p2' } } })
+  })
+
+  it('a grant ROTATION is fenced on the holder acking, not just the placement', async () => {
+    const control = new SpyControl()
+    const app = build({ control, relay: new SpyRelayControl() })
+    await seedDaemon(prisma, HOLDER)
+    await addLiveRelay(app)
+    const installationId = await createInstallation(app)
+    const connection = await createConnection(app, installationId)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, {
+      runtimeOverrides: { memory: { provider: 'external', connectionId: connection.id } }
+    })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+
+    // The holder refuses the fresh definition: overlap-before-revoke must hold the
+    // old grant alive rather than retire a key the holder is still calling with.
+    control.failMemoryUpsert = true
+    const deferred = await app.app.inject({ method: 'POST', url: `${CONNECTIONS}/${connection.id}/grant/rotate` })
+    expect(deferred.statusCode).toBe(503)
+    expect(
+      await app.deps.repos.externalMemoryGrant.activeForConnection(OrgId(DEFAULT_ORG_ID), connection.id)
+    ).toHaveLength(2)
+  })
+
+  it('a member holding NO duty covering a binding agent receives nothing', async () => {
+    const control = new SpyControl()
+    const app = build({ control, relay: new SpyRelayControl() })
+    await seedDaemon(prisma, HOLDER)
+    await seedDaemon(prisma, DAEMON)
+    await addLiveRelay(app)
+    const installationId = await createInstallation(app)
+    const connection = await createConnection(app, installationId)
+    // Bound but unplaced and unheld; the holder's duty covers an UNBOUND agent.
+    await seedAgent(prisma, randomUUID(), {
+      runtimeOverrides: { memory: { provider: 'external', connectionId: connection.id } }
+    })
+    const unbound = randomUUID()
+    await seedAgent(prisma, unbound, { daemonId: DAEMON })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [unbound])
+
+    const patched = await app.app.inject({
+      method: 'PATCH',
+      url: `${CONNECTIONS}/${connection.id}`,
+      payload: { config: { projectId: 'p2' } }
+    })
+    expect(patched.statusCode, patched.body).toBe(200)
+    expect(control.events.filter((e) => e.kind === 'memory-upsert')).toEqual([])
   })
 })

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -345,6 +345,117 @@ describe('the reconnect roster follows the duty holder', () => {
     // Detach, never remove: the CP row still proves the agent lives elsewhere.
     expect(ok.drop.agents).toEqual([{ agentId: AGENT, action: 'detach' }])
   })
+
+  /**
+   * The definitions the roster's AgentSpecs only NAME (#979). Before this they
+   * were resolved from `activeForDaemon(daemonId)` — placement — so a holder with
+   * no agent PLACED on it received an agent whose MCP servers and memory backend
+   * it had no definitions for, and both silently did not work.
+   */
+  const RELAY = [{ relayId: '00000000-0000-4000-8000-0000000000a1', url: 'wss://relay.example.test' }]
+
+  async function seedProvider(name: string, key: string): Promise<string> {
+    const provider = await prisma.mcpProvider.create({
+      data: { orgId: DEFAULT_ORG_ID, name, url: 'https://upstream.example.test/mcp' }
+    })
+    await prisma.mcpGrant.create({ data: { mcpProviderId: provider.id, key } })
+    return provider.id
+  }
+
+  async function seedStdioConnection(): Promise<string> {
+    const installation = await prisma.memoryPluginInstallation.create({
+      data: {
+        orgId: DEFAULT_ORG_ID,
+        pluginId: 'ai.example.memory',
+        transport: 'stdio',
+        commandRef: 'operator-mem0',
+        expectedManifestDigest: `sha256:${'a'.repeat(64)}`,
+        secretHeaders: []
+      }
+    })
+    const connection = await prisma.externalMemoryConnection.create({
+      data: { orgId: DEFAULT_ORG_ID, installationId: installation.id, config: {} }
+    })
+    return connection.id
+  }
+
+  it('the snapshot carries the MCP defs and memory connection its DUTY-HELD agent references', async () => {
+    const h = buildWsHarness(prisma, { relays: RELAY })
+    await prisma.daemon.create({ data: { id: OTHER, orgId: DEFAULT_ORG_ID, maxAgents: 4, status: 'ready' } })
+    const providerId = await seedProvider('docs', 'oct_docs')
+    const connectionId = await seedStdioConnection()
+    await prisma.agent.create({
+      data: {
+        id: AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'held',
+        runtime: 'claude',
+        daemonId: OTHER,
+        runtimeOverrides: { mcpServers: ['docs'], memory: { provider: 'external', connectionId } }
+      }
+    })
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(h.clock.now() + LEASE_MS) })
+
+    const ok = await reconnectHolding(h)
+
+    // Content, not arrival: the proxy def must carry the grant key the holder calls with.
+    expect(ok.mcpServers).toEqual([
+      expect.objectContaining({
+        name: 'docs',
+        url: `https://relay.example.test/mcp/${providerId}`,
+        headers: [{ name: 'Authorization', value: 'Bearer oct_docs' }]
+      })
+    ])
+    expect(ok.memoryConnections.map((c) => c.connectionId)).toEqual([connectionId])
+  })
+
+  it('a member holding NO duty covering the agent receives neither definition', async () => {
+    const h = buildWsHarness(prisma, { relays: RELAY })
+    await prisma.daemon.create({ data: { id: OTHER, orgId: DEFAULT_ORG_ID, maxAgents: 4, status: 'ready' } })
+    await seedProvider('docs', 'oct_docs')
+    const connectionId = await seedStdioConnection()
+    await prisma.agent.create({
+      data: {
+        id: AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'not-mine',
+        runtime: 'claude',
+        daemonId: OTHER,
+        runtimeOverrides: { mcpServers: ['docs'], memory: { provider: 'external', connectionId } }
+      }
+    })
+    // The group exists but is held by ANOTHER member — same org, same registry.
+    await seedGroup({ holder: OTHER, term: 1n, expiresAt: new Date(h.clock.now() + LEASE_MS) })
+
+    const ok = await reconnectHolding(h)
+
+    expect(ok.agents).toEqual([])
+    expect(ok.mcpServers).toEqual([])
+    expect(ok.memoryConnections).toEqual([])
+  })
+
+  it('an EXPIRED lease takes the definitions away with the agent', async () => {
+    const h = buildWsHarness(prisma, { relays: RELAY })
+    await prisma.daemon.create({ data: { id: OTHER, orgId: DEFAULT_ORG_ID, maxAgents: 4, status: 'ready' } })
+    await seedProvider('docs', 'oct_docs')
+    const connectionId = await seedStdioConnection()
+    await prisma.agent.create({
+      data: {
+        id: AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'lapsed',
+        runtime: 'claude',
+        daemonId: OTHER,
+        runtimeOverrides: { mcpServers: ['docs'], memory: { provider: 'external', connectionId } }
+      }
+    })
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(h.clock.now() - 1_000) })
+
+    const ok = await reconnectHolding(h)
+
+    expect(ok.mcpServers).toEqual([])
+    expect(ok.memoryConnections).toEqual([])
+  })
 })
 
 /**

--- a/packages/control-plane/test/protocol/memory-connections.handler.test.ts
+++ b/packages/control-plane/test/protocol/memory-connections.handler.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { isFrame } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { buildWsHarness } from '../fakes/build-ws.js'
-import { DEF_ORG, seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { DEF_ORG, seedAgent, seedDaemon, seedDutyGroup } from '../fixtures/seed.js'
 import {
   PgExternalMemoryConnectionRepo,
   PgExternalMemoryConnectionSecretStore,
@@ -25,6 +25,7 @@ const DAEMON_2 = 'a2222222-2222-4222-8222-222222222222'
 const AGENT_1 = 'b1111111-1111-4111-8111-111111111111'
 const AGENT_2 = 'b2222222-2222-4222-8222-222222222222'
 const RELAY = 'c1111111-1111-4111-8111-111111111111'
+const GROUP = 'd1111111-1111-4111-8111-111111111111'
 
 function authPayload(token: string) {
   return { apiKey: token, daemonId: DAEMON_1, agentVersion: '1.7.0' }
@@ -236,5 +237,58 @@ describe('facts/memory-connections — daemon-scoped and revision-fenced', () =>
       probedRevision: null
     })
     expect(stub.lastSent('error')).toBeUndefined()
+  })
+
+  /**
+   * The ownership boundary is "the agents this daemon SERVES", not "the agents
+   * placed on it" (#979). It has to be: the roster now ships a duty-held agent's
+   * connection to its holder, so a holder that could not report facts for it
+   * would leave that connection permanently unprobed in the console — and the
+   * definition it was given would be one it may not speak about.
+   */
+  it('a DUTY HOLDER receives its held agent’s connection and may report its facts', async () => {
+    const { connections, connection1, connection2 } = await fixture()
+    // AGENT_2 is placed on DAEMON_2; DAEMON_1 only holds its duty.
+    await seedDutyGroup(prisma, GROUP, DAEMON_1, [AGENT_2])
+    const h = buildWsHarness(prisma, { relays: [{ relayId: RELAY, url: 'wss://relay.example/rd' }] })
+    const token = await h.mintToken(DAEMON_1)
+    const { stub } = h.connect()
+    stub.inject('auth', authPayload(token))
+    await stub.expectFrame('auth/ok')
+    stub.inject('register', registerPayload())
+    const registered = await stub.expectFrame('register/ok')
+    if (!isFrame('register/ok')(registered)) throw new Error('expected register/ok')
+
+    expect(registered.payload.memoryConnections.map((c) => c.connectionId).sort()).toEqual(
+      [connection1.id, connection2.id].sort()
+    )
+
+    stub.inject('facts/memory-connections', {
+      connections: [{ connectionId: connection2.id, revision: 1, pluginId: 'ai.example.memory', status: 'ready' }]
+    })
+    await vi.waitFor(async () => {
+      expect(await connections.get(DEF_ORG, connection2.id)).toMatchObject({ status: 'ready', probedRevision: 1 })
+    })
+  })
+
+  it('an EXPIRED duty is not a holding — neither the definition nor the fact is accepted', async () => {
+    const { connections, connection1, connection2 } = await fixture()
+    const h = buildWsHarness(prisma, { relays: [{ relayId: RELAY, url: 'wss://relay.example/rd' }] })
+    await seedDutyGroup(prisma, GROUP, DAEMON_1, [AGENT_2], { expiresAt: new Date(h.clock.now() - 1_000) })
+    const token = await h.mintToken(DAEMON_1)
+    const { stub } = h.connect()
+    stub.inject('auth', authPayload(token))
+    await stub.expectFrame('auth/ok')
+    stub.inject('register', registerPayload())
+    const registered = await stub.expectFrame('register/ok')
+    if (!isFrame('register/ok')(registered)) throw new Error('expected register/ok')
+
+    expect(registered.payload.memoryConnections.map((c) => c.connectionId)).toEqual([connection1.id])
+
+    stub.inject('facts/memory-connections', {
+      connections: [{ connectionId: connection2.id, revision: 1, pluginId: 'ai.example.memory', status: 'ready' }]
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(await connections.get(DEF_ORG, connection2.id)).toMatchObject({ status: 'probing', probedRevision: null })
   })
 })

--- a/packages/control-plane/test/repo/memory-connection.repo.test.ts
+++ b/packages/control-plane/test/repo/memory-connection.repo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { prisma } from '../setup.db.js'
-import { DEF_ORG, seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { DEF_ORG } from '../fixtures/seed.js'
 import {
   PgExternalMemoryConnectionRepo,
   PgExternalMemoryConnectionSecretStore,
@@ -8,7 +8,7 @@ import {
   PgMemoryPluginInstallationRepo
 } from '../../src/persistence/repositories/memory-connection.repo.js'
 import type { SecretCipher } from '../../src/secrets/cipher.js'
-import { DaemonId, OrgId } from '../../src/domain/ids.js'
+import { OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 
 const DAEMON_ID = '11111111-1111-4111-8111-111111111111'
@@ -106,26 +106,5 @@ describe('external-memory persistence (real Postgres)', () => {
     await connections.delete(DEF_ORG, connection.id)
     expect(await prisma.externalMemoryConnectionSecret.count()).toBe(0)
     expect(await prisma.externalMemoryGrant.count()).toBe(0)
-  })
-
-  it('derives a deduplicated daemon-private registry only from placed external bindings', async () => {
-    const { connections, connection } = await fixture()
-    await seedDaemon(prisma, DAEMON_ID)
-    await seedAgent(prisma, AGENT_ID, { daemonId: DAEMON_ID })
-    await prisma.agent.update({
-      where: { id: AGENT_ID },
-      data: {
-        runtimeOverrides: {
-          memory: {
-            provider: 'external',
-            connectionId: connection.id,
-            recall: { mode: 'auto', topK: 5, maxBytes: 8192, timeoutMs: 1000 },
-            capture: { mode: 'turn' }
-          }
-        }
-      }
-    })
-    await seedAgent(prisma, '33333333-3333-4333-8333-333333333333', { daemonId: DAEMON_ID })
-    expect((await connections.activeForDaemon(DaemonId(DAEMON_ID))).map((row) => row.id)).toEqual([connection.id])
   })
 })

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12993,9 +12993,11 @@ export class Daemon {
   private applyDutyDefinitions(bundle: DutyAgentBundle): void {
     for (const spec of bundle.memoryConnections ?? []) this.memoryConnections?.upsert(spec)
     let mcpChanged = false
-    for (const { orgId, name, ...def } of bundle.mcpServers ?? []) {
+    for (const { orgId, name, issuedAt, ...def } of bundle.mcpServers ?? []) {
       if (!orgId || name === RESERVED_MCP_SERVER_NAME) continue
-      if (this.cpMcpDefs?.upsert(orgId, name, def)) mcpChanged = true
+      // Same monotonic fence as the live push: a bundle projected before a grant
+      // rotation must never overwrite the fresh key it raced.
+      if (this.cpMcpDefs?.upsert(orgId, name, def, issuedAt)) mcpChanged = true
     }
     if (mcpChanged) this.onMcpDefsChanged()
   }
@@ -20554,7 +20556,7 @@ export class Daemon {
         this.cpMcpDefs?.converge(
           (snap.mcpServers ?? [])
             .filter((s) => s.name !== RESERVED_MCP_SERVER_NAME)
-            .flatMap(({ orgId, name, ...def }) => (orgId ? [[orgId, name, def] as const] : []))
+            .flatMap(({ orgId, name, issuedAt, ...def }) => (orgId ? [[orgId, name, def, issuedAt] as const] : []))
         )
         this.cpCollab.replace(snap.collabRoutes) // baseline collaboration routing snapshot (P2 terminal-verify)
         this.convergeRelays(snap.relays) // connect ingress only after its organization authority is installed
@@ -20939,9 +20941,11 @@ export class Daemon {
           this.log.warn(`mcp: ignoring CP push for reserved server name "${spec.name}"`)
           return
         }
-        const { orgId, name, ...def } = spec
+        // `issuedAt` is the ordering marker, not part of the definition the runtime
+        // spawns with — strip it out of `def` at every apply site.
+        const { orgId, name, issuedAt, ...def } = spec
         if (!orgId) return
-        if (this.cpMcpDefs?.upsert(orgId, name, def)) {
+        if (this.cpMcpDefs?.upsert(orgId, name, def, issuedAt)) {
           this.onMcpDefsChanged()
           // NEVER log def values — an http proxy def's headers carry the bearer grant key.
           this.log.info(`mcp: applied CP server def "${name}" for organization ${orgId}`)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -497,6 +497,7 @@ import type {
   ChannelAgentsOk,
   TaskList,
   TaskListReq,
+  DutyAgentBundle,
   DutyGrantEntry,
   DutyMemberRef,
   DutyRevoke,
@@ -12952,6 +12953,13 @@ export class Daemon {
         return
       }
       if (!this.cpAgents) return
+      // Definitions BEFORE the spec that names them, same order as the reconnect
+      // snapshot: an AgentSpec carries MCP server names and a memory connection id,
+      // and static memory admission must never observe the agent before at least a
+      // probing (fail-closed) connection entry exists. Applied unconditionally of
+      // the revision fence below — they are separate registries with their own
+      // fences, and a skipped spec still leaves a replica referencing them.
+      this.applyDutyDefinitions(bundle)
       // The revision fence is the target's own (organization-secrets-and-variables.md
       // §7): a bundle older than what we already applied never overwrites it.
       const applied = this.cpAgents.upsert(agentId, bundle.spec)
@@ -12966,8 +12974,30 @@ export class Daemon {
         cronIds: bundle.crons.map((cron) => cron.cronId)
       })
       await this.flushReconcile()
-      this.log.info(`duty: installed granted agent ${agentId} (${bundle.integrations.length} integration(s))`)
+      this.log.info(
+        `duty: installed granted agent ${agentId} (${bundle.integrations.length} integration(s), ` +
+          `${(bundle.mcpServers ?? []).length} MCP def(s), ${(bundle.memoryConnections ?? []).length} memory connection(s))`
+      )
     })
+  }
+
+  /**
+   * Install the two definition kinds the granted agent's spec only NAMES. Additive
+   * (`upsert`, never `converge`): this member may already serve other agents whose
+   * definitions the bundle does not mention, and a duty install is never a
+   * full-replace of a tenant registry. An older CP omits both arrays.
+   *
+   * NEVER log the defs — an MCP proxy def's headers carry the bearer grant key and
+   * a memory def carries its grant plus secret leases.
+   */
+  private applyDutyDefinitions(bundle: DutyAgentBundle): void {
+    for (const spec of bundle.memoryConnections ?? []) this.memoryConnections?.upsert(spec)
+    let mcpChanged = false
+    for (const { orgId, name, ...def } of bundle.mcpServers ?? []) {
+      if (!orgId || name === RESERVED_MCP_SERVER_NAME) continue
+      if (this.cpMcpDefs?.upsert(orgId, name, def)) mcpChanged = true
+    }
+    if (mcpChanged) this.onMcpDefsChanged()
   }
 
   /** Apply a `duty/revoke` EVT. Losing a duty is NOT a removal: the agent's

--- a/packages/daemon/src/mcp/cp-mcp-defs.ts
+++ b/packages/daemon/src/mcp/cp-mcp-defs.ts
@@ -1,16 +1,40 @@
 import { isDeepStrictEqual } from 'node:util'
 import type { McpServerDef } from '../config/config-schema.js'
 
+/** One CP definition plus the marker that orders it. `issuedAt` is the epoch
+ *  millis of the grant it was projected from; absent means "unordered". */
+interface Entry {
+  def: McpServerDef
+  issuedAt?: number
+}
+
 /** Keeps CP MCP definitions tenant-scoped while layering them over daemon-local definitions. */
 export class CpMcpDefs {
-  private cp = new Map<string, Map<string, McpServerDef>>()
+  private cp = new Map<string, Map<string, Entry>>()
 
   constructor(private readonly local: Record<string, McpServerDef>) {}
 
-  upsert(orgId: string, name: string, def: McpServerDef): boolean {
-    const definitions = this.cp.get(orgId) ?? new Map<string, McpServerDef>()
-    if (isDeepStrictEqual(definitions.get(name), def)) return false
-    definitions.set(name, def)
+  /**
+   * Apply one CP definition, refusing a STRICTLY OLDER one.
+   *
+   * A proxy def is versioned by its grant, and grant rotation deliberately keeps
+   * the retiring and the fresh grant both active until the fresh one is
+   * distributed — so a definition projected inside that window (a `duty/fetch`
+   * bundle, or a slower live push) can arrive after the fresh key and would
+   * otherwise reinstate a key the relay is about to revoke, silently breaking
+   * this agent's tools until the next unrelated update. Same monotonic discipline
+   * as the external-memory registry's revision fence.
+   *
+   * Equal-or-newer applies: a relay-base change carries the same grant instant and
+   * must still converge. An absent marker on either side is "unordered" and
+   * applies, which is exactly the pre-marker behavior for an older CP.
+   */
+  upsert(orgId: string, name: string, def: McpServerDef, issuedAt?: number): boolean {
+    const definitions = this.cp.get(orgId) ?? new Map<string, Entry>()
+    const previous = definitions.get(name)
+    if (previous?.issuedAt !== undefined && issuedAt !== undefined && issuedAt < previous.issuedAt) return false
+    if (previous && isDeepStrictEqual(previous.def, def) && previous.issuedAt === issuedAt) return false
+    definitions.set(name, { def, ...(issuedAt !== undefined ? { issuedAt } : {}) })
     this.cp.set(orgId, definitions)
     return true
   }
@@ -22,11 +46,15 @@ export class CpMcpDefs {
     return true
   }
 
-  converge(entries: Array<[string, string, McpServerDef]>): boolean {
-    const next = new Map<string, Map<string, McpServerDef>>()
-    for (const [orgId, name, def] of entries) {
-      const definitions = next.get(orgId) ?? new Map<string, McpServerDef>()
-      definitions.set(name, def)
+  /** Full-replace from the reconnect snapshot. Deliberately NOT fenced — the CP
+   *  wins on reconcile and this is the backstop that repairs any regression — but
+   *  it RECORDS each marker, so a live push or a bundle that raced the snapshot
+   *  is compared against what the snapshot installed rather than against nothing. */
+  converge(entries: Array<[string, string, McpServerDef, number | undefined]>): boolean {
+    const next = new Map<string, Map<string, Entry>>()
+    for (const [orgId, name, def, issuedAt] of entries) {
+      const definitions = next.get(orgId) ?? new Map<string, Entry>()
+      definitions.set(name, { def, ...(issuedAt !== undefined ? { issuedAt } : {}) })
       next.set(orgId, definitions)
     }
     if (
@@ -35,7 +63,7 @@ export class CpMcpDefs {
         const current = this.cp.get(orgId)
         return (
           current?.size === definitions.size &&
-          [...definitions].every(([name, def]) => isDeepStrictEqual(current.get(name), def))
+          [...definitions].every(([name, entry]) => isDeepStrictEqual(current.get(name), entry))
         )
       })
     ) {
@@ -46,7 +74,8 @@ export class CpMcpDefs {
   }
 
   effective(orgId: string | undefined): Record<string, McpServerDef> {
-    return { ...this.local, ...Object.fromEntries(orgId ? (this.cp.get(orgId) ?? []) : []) }
+    const scoped = orgId ? (this.cp.get(orgId) ?? new Map<string, Entry>()) : new Map<string, Entry>()
+    return { ...this.local, ...Object.fromEntries([...scoped].map(([name, entry]) => [name, entry.def])) }
   }
 
   localDefinitions(): Record<string, McpServerDef> {

--- a/packages/daemon/test/cp-mcp-defs.test.ts
+++ b/packages/daemon/test/cp-mcp-defs.test.ts
@@ -23,8 +23,8 @@ describe('CpMcpDefs — CP-pushed defs layered over local config', () => {
     expect(m.upsert('org-a', 'a', httpDef('https://relay/mcp/a'))).toBe(false)
     expect(m.upsert('org-a', 'a', httpDef('https://relay/mcp/a2'))).toBe(true)
     expect(m.remove('org-a', 'missing')).toBe(false)
-    expect(m.converge([['org-a', 'a', httpDef('https://relay/mcp/a2')]])).toBe(false)
-    expect(m.converge([['org-a', 'b', httpDef('https://relay/mcp/b')]])).toBe(true)
+    expect(m.converge([['org-a', 'a', httpDef('https://relay/mcp/a2'), undefined]])).toBe(false)
+    expect(m.converge([['org-a', 'b', httpDef('https://relay/mcp/b'), undefined]])).toBe(true)
   })
 
   it('local-only and CP-only names both pass through; remove of an absent name is a no-op', () => {
@@ -41,7 +41,7 @@ describe('CpMcpDefs — CP-pushed defs layered over local config', () => {
     m.upsert('org-a', 'a', httpDef('https://relay/mcp/a'))
     m.upsert('org-a', 'b', httpDef('https://relay/mcp/b'))
 
-    m.converge([['org-a', 'c', httpDef('https://relay/mcp/c')]])
+    m.converge([['org-a', 'c', httpDef('https://relay/mcp/c'), undefined]])
     const eff = m.effective('org-a')
     expect(eff.a).toBeUndefined()
     expect(eff.c).toEqual(httpDef('https://relay/mcp/c'))
@@ -55,5 +55,77 @@ describe('CpMcpDefs — CP-pushed defs layered over local config', () => {
 
     expect(m.effective('org-a')['shared-name']).toEqual(httpDef('https://relay/mcp/a'))
     expect(m.effective('org-b')['shared-name']).toEqual(httpDef('https://relay/mcp/b'))
+  })
+
+  /**
+   * A proxy def is versioned by its grant, and rotation keeps the retiring and the
+   * fresh grant BOTH active until the fresh one is distributed. So a definition
+   * projected inside that window — a `duty/fetch` bundle, or simply a slower live
+   * push — can land after the fresh key and would otherwise reinstate one the
+   * relay is about to revoke, breaking the agent's tools until an unrelated update.
+   */
+  describe('the monotonic fence', () => {
+    const bearer = (key: string, issuedAt: number): [McpServerDef, number] => [
+      {
+        transport: 'http',
+        args: [],
+        env: [],
+        url: 'https://relay/mcp/p1',
+        headers: [{ name: 'Authorization', value: `Bearer ${key}` }]
+      },
+      issuedAt
+    ]
+
+    it('refuses a def older than the one already applied, and keeps the fresh key', () => {
+      const m = new CpMcpDefs({})
+      const [fresh, freshAt] = bearer('oct_fresh', 2_000)
+      const [retiring, retiringAt] = bearer('oct_retiring', 1_000)
+
+      expect(m.upsert('org-a', 'p', fresh, freshAt)).toBe(true)
+      expect(m.upsert('org-a', 'p', retiring, retiringAt)).toBe(false)
+      expect(m.effective('org-a').p).toEqual(fresh)
+    })
+
+    it('applies a NEWER def — the rotation itself must still land', () => {
+      const m = new CpMcpDefs({})
+      const [retiring, retiringAt] = bearer('oct_retiring', 1_000)
+      const [fresh, freshAt] = bearer('oct_fresh', 2_000)
+
+      m.upsert('org-a', 'p', retiring, retiringAt)
+      expect(m.upsert('org-a', 'p', fresh, freshAt)).toBe(true)
+      expect(m.effective('org-a').p).toEqual(fresh)
+    })
+
+    it('applies an EQUAL-marker change — a relay-base swap carries the same grant', () => {
+      const m = new CpMcpDefs({})
+      m.upsert('org-a', 'p', httpDef('https://old-relay/mcp/p1'), 2_000)
+      expect(m.upsert('org-a', 'p', httpDef('https://new-relay/mcp/p1'), 2_000)).toBe(true)
+      expect(m.effective('org-a').p).toEqual(httpDef('https://new-relay/mcp/p1'))
+    })
+
+    it('an unmarked def is unordered and applies — an older CP is not fenced out', () => {
+      const m = new CpMcpDefs({})
+      m.upsert('org-a', 'p', httpDef('https://relay/mcp/a'), 2_000)
+      expect(m.upsert('org-a', 'p', httpDef('https://relay/mcp/b'))).toBe(true)
+    })
+
+    it('the marker never reaches the runtime — `effective` returns the bare definition', () => {
+      const m = new CpMcpDefs({})
+      m.upsert('org-a', 'p', httpDef('https://relay/mcp/a'), 2_000)
+      expect(m.effective('org-a').p).toEqual(httpDef('https://relay/mcp/a'))
+      expect(JSON.stringify(m.effective('org-a'))).not.toContain('issuedAt')
+    })
+
+    it('converge RECORDS the markers it installs, so a later stale push is still refused', () => {
+      const m = new CpMcpDefs({})
+      const [fresh, freshAt] = bearer('oct_fresh', 2_000)
+      const [retiring, retiringAt] = bearer('oct_retiring', 1_000)
+
+      // The reconnect snapshot wins unconditionally (CP wins on reconcile)…
+      m.converge([['org-a', 'p', fresh, freshAt]])
+      // …but a bundle that raced it is compared against what it installed.
+      expect(m.upsert('org-a', 'p', retiring, retiringAt)).toBe(false)
+      expect(m.effective('org-a').p).toEqual(fresh)
+    })
   })
 })

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -75,21 +75,28 @@ const bundle = (configRevision?: string) => ({
   ]
 })
 
+/** One proxy def, as the CP projects it: the grant's issuance instant is the
+ *  ordering marker, and the key it orders comes from the same grant. */
+const proxyDef = (key = 'oct_docs', issuedAt = 2_000) => ({
+  orgId: ORG,
+  name: 'docs',
+  issuedAt,
+  transport: 'http' as const,
+  url: 'https://relay.example.test/mcp/p1',
+  args: [],
+  env: [],
+  headers: [{ name: 'Authorization', value: `Bearer ${key}` }]
+})
+
+/** The bearer the daemon would hand a session for `docs`, or undefined. */
+const bearerOf = (d: Daemon): string | undefined =>
+  ((d as any).cpMcpDefs.effective(ORG).docs?.headers as Array<{ name: string; value: string }> | undefined)?.[0]?.value
+
 /** The same bundle plus the two definition kinds the spec only NAMES. */
-const bundleWithDefinitions = () => ({
+const bundleWithDefinitions = (grantKey?: string, issuedAt?: number) => ({
   ...bundle(),
   spec: { ...bundle().spec, mcpServers: ['docs'], memory: { provider: 'external' as const, connectionId: CONNECTION } },
-  mcpServers: [
-    {
-      orgId: ORG,
-      name: 'docs',
-      transport: 'http' as const,
-      url: 'https://relay.example.test/mcp/p1',
-      args: [],
-      env: [],
-      headers: [{ name: 'Authorization', value: 'Bearer oct_docs' }]
-    }
-  ],
+  mcpServers: [proxyDef(grantKey, issuedAt)],
   memoryConnections: [
     {
       connectionId: CONNECTION,
@@ -180,6 +187,56 @@ describe('installing an agent a duty grant covers', () => {
       headers: [{ name: 'Authorization', value: 'Bearer oct_docs' }]
     })
     expect((daemon as any).memoryConnections.connectionIds()).toEqual([CONNECTION])
+    await daemon.stop()
+  })
+
+  /**
+   * MCP grant rotation keeps the retiring and the fresh grant BOTH active until
+   * the fresh one is distributed, so a bundle projected inside that window carries
+   * a key the relay is about to revoke. The bundle apply is fenced by the grant's
+   * issuance instant exactly as the live push is, so the holder ends up on the
+   * fresh key under EITHER interleaving.
+   */
+  it('a bundle projected before a rotation cannot undo the fresh key it raced', async () => {
+    let releaseFetch!: () => void
+    const projected = new Promise<void>((resolve) => (releaseFetch = resolve))
+    const fetchDutyAgent = vi.fn(async () => {
+      await projected
+      return { bundle: bundleWithDefinitions('oct_retiring', 1_000) }
+    })
+    const daemon = await boot({ fetchDutyAgent })
+    const install = (daemon as any).installGrantedAgents([grant()])
+
+    // The rotation's live push lands first, through the real frame handler.
+    ;(daemon as any).cpConfigApply().applyMcpServerUpsert(proxyDef('oct_fresh', 2_000))
+    expect(bearerOf(daemon)).toBe('Bearer oct_fresh')
+
+    releaseFetch()
+    await install
+
+    expect(bearerOf(daemon)).toBe('Bearer oct_fresh')
+    await daemon.stop()
+  })
+
+  it('the other interleaving converges too — the fresh push overtakes an applied bundle', async () => {
+    const fetchDutyAgent = vi.fn(async () => ({ bundle: bundleWithDefinitions('oct_retiring', 1_000) }))
+    const daemon = await boot({ fetchDutyAgent })
+
+    await (daemon as any).installGrantedAgents([grant()])
+    expect(bearerOf(daemon)).toBe('Bearer oct_retiring')
+    ;(daemon as any).cpConfigApply().applyMcpServerUpsert(proxyDef('oct_fresh', 2_000))
+
+    expect(bearerOf(daemon)).toBe('Bearer oct_fresh')
+    await daemon.stop()
+  })
+
+  it('the ordering marker never reaches the runtime definition', async () => {
+    const fetchDutyAgent = vi.fn(async () => ({ bundle: bundleWithDefinitions() }))
+    const daemon = await boot({ fetchDutyAgent })
+
+    await (daemon as any).installGrantedAgents([grant()])
+
+    expect(JSON.stringify((daemon as any).cpMcpDefs.effective(ORG))).not.toContain('issuedAt')
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -14,6 +14,7 @@ const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const GROUP = '11111111-1111-4111-8111-111111111111'
 const INTEGRATION = '22222222-2222-4222-8222-222222222222'
 const CRON = '33333333-3333-4333-8333-333333333333'
+const CONNECTION = '44444444-4444-4444-8444-444444444444'
 const ORG = 'org-1'
 
 function scaffold(): string {
@@ -74,6 +75,36 @@ const bundle = (configRevision?: string) => ({
   ]
 })
 
+/** The same bundle plus the two definition kinds the spec only NAMES. */
+const bundleWithDefinitions = () => ({
+  ...bundle(),
+  spec: { ...bundle().spec, mcpServers: ['docs'], memory: { provider: 'external' as const, connectionId: CONNECTION } },
+  mcpServers: [
+    {
+      orgId: ORG,
+      name: 'docs',
+      transport: 'http' as const,
+      url: 'https://relay.example.test/mcp/p1',
+      args: [],
+      env: [],
+      headers: [{ name: 'Authorization', value: 'Bearer oct_docs' }]
+    }
+  ],
+  memoryConnections: [
+    {
+      connectionId: CONNECTION,
+      orgId: ORG,
+      revision: 1,
+      transport: 'stdio' as const,
+      commandRef: 'operator-mem0',
+      config: {},
+      secretKeys: [],
+      secretLease: { values: {} },
+      pin: { pluginId: 'ai.example.memory', profileMajor: 1 as const, secretHeaders: [] }
+    }
+  ]
+})
+
 /** A daemon started with a stub CP client — only the duty surface is exercised. */
 async function boot(client: Record<string, unknown>) {
   const daemon = new Daemon({ root: scaffold() })
@@ -82,6 +113,8 @@ async function boot(client: Record<string, unknown>) {
     organizationScope: () => 'frame',
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
+    // The memory registry reports body-free probe facts as soon as a definition lands.
+    emitMemoryConnectionFacts: vi.fn(() => {}),
     ...client
   }
   return daemon
@@ -123,6 +156,66 @@ describe('installing an agent a duty grant covers', () => {
     expect(cp.agents.has(AGENT)).toBe(true)
     expect(cp.integrations.forAgent(AGENT).map((i: { id: string }) => i.id)).toEqual([INTEGRATION])
     expect(cp.crons.forAgent(AGENT).map((c: { id: string }) => c.id)).toEqual([CRON])
+    await daemon.stop()
+  })
+
+  /**
+   * An AgentSpec only NAMES its MCP servers and its memory connection; both
+   * definitions arrive separately on placement-keyed paths (#979). A holder that
+   * is not the placement installed neither, so the agent came up with tools it
+   * could not resolve and a memory backend it had no entry for — silently.
+   */
+  it('installs the MCP defs the spec names and the memory connection it binds', async () => {
+    const fetchDutyAgent = vi.fn(async () => ({ bundle: bundleWithDefinitions() }))
+    const daemon = await boot({ fetchDutyAgent })
+
+    await (daemon as any).installGrantedAgents([grant()])
+
+    // The proxy def is keyed (org, name) and must carry the bearer grant key —
+    // presence of the NAME alone is exactly the broken state this fixes.
+    const effective = (daemon as any).cpMcpDefs.effective(ORG)
+    expect(effective.docs).toMatchObject({
+      transport: 'http',
+      url: 'https://relay.example.test/mcp/p1',
+      headers: [{ name: 'Authorization', value: 'Bearer oct_docs' }]
+    })
+    expect((daemon as any).memoryConnections.connectionIds()).toEqual([CONNECTION])
+    await daemon.stop()
+  })
+
+  it('a bundle from an older CP carrying neither definition array still installs', async () => {
+    const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
+    const daemon = await boot({ fetchDutyAgent })
+
+    await (daemon as any).installGrantedAgents([grant()])
+
+    expect(registries(daemon).agents.has(AGENT)).toBe(true)
+    expect((daemon as any).memoryConnections.connectionIds()).toEqual([])
+    await daemon.stop()
+  })
+
+  it('the definitions land BEFORE the spec that references them', async () => {
+    const fetchDutyAgent = vi.fn(async () => ({ bundle: bundleWithDefinitions() }))
+    const daemon = await boot({ fetchDutyAgent })
+    const order: string[] = []
+    const registry = (daemon as any).memoryConnections
+    const realUpsert = registry.upsert.bind(registry)
+    registry.upsert = (spec: unknown) => {
+      order.push('memory')
+      return realUpsert(spec)
+    }
+    const agents = registries(daemon).agents
+    const realAgentUpsert = agents.upsert.bind(agents)
+    agents.upsert = (id: string, spec: unknown) => {
+      order.push('agent')
+      return realAgentUpsert(id, spec)
+    }
+
+    await (daemon as any).installGrantedAgents([grant()])
+
+    // Registry-before-agent: static memory admission must never see the agent
+    // before at least a probing (fail-closed) connection entry exists.
+    expect(order).toEqual(['memory', 'agent'])
     await daemon.stop()
   })
 

--- a/packages/protocol/src/frames/duty.test.ts
+++ b/packages/protocol/src/frames/duty.test.ts
@@ -236,5 +236,21 @@ describe('duty/fetch — installing an agent a duty was won for', () => {
     const decoded = decodeEnvelope(encode(buildEnvelope('duty/fetch/ok', payload)))
     if (!decoded.ok) throw new Error(`decode failed: ${decoded.msg}`)
     expect(decoded.frame.payload).toMatchObject(payload)
+
+    // Both arrays carry their real schemas: these are token-bearing definitions a
+    // member installs verbatim, so a malformed one must be refused at the edge,
+    // never handed to the MCP or memory registry.
+    expect(
+      DutyAgentBundle.safeParse({
+        ...payload.bundle,
+        mcpServers: [{ orgId: 'org-1', name: 'docs', transport: 'http' }]
+      }).success
+    ).toBe(false)
+    expect(
+      DutyAgentBundle.safeParse({
+        ...payload.bundle,
+        memoryConnections: [{ connectionId: CONNECTION, transport: 'streamable-http' }]
+      }).success
+    ).toBe(false)
   })
 })

--- a/packages/protocol/src/frames/duty.test.ts
+++ b/packages/protocol/src/frames/duty.test.ts
@@ -9,7 +9,8 @@ import {
   DutyClaim,
   DutyClaimOk,
   DutyFetch,
-  DutyFetchOk
+  DutyFetchOk,
+  DutyAgentBundle
 } from './duty.js'
 import { Heartbeat } from './telemetry.js'
 import { decodeEnvelope, encode, buildEnvelope } from '../index.js'
@@ -17,6 +18,7 @@ import { decodeEnvelope, encode, buildEnvelope } from '../index.js'
 const GROUP = '11111111-1111-4111-8111-111111111111'
 const AGENT = '22222222-2222-4222-8222-222222222222'
 const BOT = '33333333-3333-4333-8333-333333333333'
+const CONNECTION = '66666666-6666-4666-8666-666666666666'
 
 describe('HeartbeatDuties', () => {
   it('rides the heartbeat as an optional field — absent keeps old daemons parsing clean', () => {
@@ -190,6 +192,49 @@ describe('duty/fetch — installing an agent a duty was won for', () => {
     if (!decoded.ok) throw new Error(`decode failed: ${decoded.msg}`)
     expect(decoded.frame.type).toBe('duty/fetch/ok')
     // toMatchObject, not toEqual: AgentSpec's zod defaults materialize on decode.
+    expect(decoded.frame.payload).toMatchObject(payload)
+    // An older CP omits the two definition arrays entirely; the member reads them
+    // as empty and installs the trio, exactly as before #979.
+    expect(DutyAgentBundle.parse(payload.bundle)).toMatchObject({ mcpServers: [], memoryConnections: [] })
+  })
+
+  it('the bundle also carries the MCP and memory definitions the spec only NAMES', () => {
+    const payload = {
+      bundle: {
+        agentId: AGENT,
+        spec: { orgId: 'org-1', name: 'scout', runtime: 'claude', mcpServers: ['docs'] },
+        integrations: [],
+        crons: [],
+        mcpServers: [
+          {
+            orgId: 'org-1',
+            name: 'docs',
+            transport: 'http',
+            url: 'https://relay.example.test/mcp/p1',
+            headers: [{ name: 'Authorization', value: 'Bearer oct_key' }]
+          }
+        ],
+        memoryConnections: [
+          {
+            connectionId: CONNECTION,
+            orgId: 'org-1',
+            revision: 3,
+            transport: 'streamable-http',
+            config: { projectId: 'p1' },
+            secretKeys: ['apiKey'],
+            pin: {
+              pluginId: 'ai.example.memory',
+              profileMajor: 1,
+              manifestDigest: `sha256:${'a'.repeat(64)}`
+            },
+            relayUrl: 'https://relay.example.test/memory/c1',
+            grantKey: 'omg_key'
+          }
+        ]
+      }
+    }
+    const decoded = decodeEnvelope(encode(buildEnvelope('duty/fetch/ok', payload)))
+    if (!decoded.ok) throw new Error(`decode failed: ${decoded.msg}`)
     expect(decoded.frame.payload).toMatchObject(payload)
   })
 })

--- a/packages/protocol/src/frames/duty.ts
+++ b/packages/protocol/src/frames/duty.ts
@@ -8,6 +8,8 @@ import { z } from 'zod'
 import { AgentSpec } from './agent.js'
 import { IntegrationSpec } from './integration.js'
 import { CronUpsert } from './cron.js'
+import { McpServerSpec } from './mcpserver.js'
+import { MemoryConnectionSpec } from './memory-connection.js'
 
 /** A per-group fencing term — bigint as a decimal string (JSON-safe). */
 export const DutyTerm = z.string().regex(/^\d+$/)
@@ -125,13 +127,26 @@ export const DutyFetch = z.object({
 })
 export type DutyFetch = z.infer<typeof DutyFetch>
 
-/** One agent's complete installable definition — the same trio `agent/activate`
- *  carries, without the move token or the staging fence. */
+/**
+ * One agent's complete installable definition — the trio `agent/activate` carries,
+ * without the move token or the staging fence, plus the two definition kinds the
+ * spec only NAMES: the proxied MCP servers its `mcpServers` list enables and its
+ * external-memory connection. Those arrive separately on the placement-keyed
+ * paths, so a duty holder that is not the placement would otherwise install an
+ * agent referencing tools and a memory backend it has no definitions for.
+ *
+ * Both are token-bearing (relay proxy url + grant key, memory grant + secret
+ * leases) — NEVER log this bundle. They are scoped to what THIS agent references,
+ * so the reply widens nothing beyond the duty the asker already holds. Optional
+ * for decode tolerance: an older CP omits them and the member installs the trio.
+ */
 export const DutyAgentBundle = z.object({
   agentId: z.string().uuid(),
   spec: AgentSpec,
   integrations: z.array(IntegrationSpec),
-  crons: z.array(CronUpsert)
+  crons: z.array(CronUpsert),
+  mcpServers: z.array(McpServerSpec).default([]),
+  memoryConnections: z.array(MemoryConnectionSpec).default([])
 })
 export type DutyAgentBundle = z.infer<typeof DutyAgentBundle>
 

--- a/packages/protocol/src/frames/mcpserver.ts
+++ b/packages/protocol/src/frames/mcpserver.ts
@@ -29,6 +29,20 @@ export const McpServerSpec = z
   .object({
     orgId: z.string().min(1).max(64).optional(),
     name: z.string(),
+    /**
+     * Monotonic ordering marker: epoch millis of the ACTIVE GRANT this definition
+     * was projected from — the only input that versions a proxy def, since the
+     * proxy url is derived from the provider id and the relay base.
+     *
+     * Grant rotation keeps the retiring and the fresh grant both active until the
+     * fresh one is distributed, so a definition projected inside that window can
+     * be applied AFTER the fresh live push and would otherwise silently reinstate
+     * a key the relay is about to retire. The daemon refuses a def strictly older
+     * than the one it already applied; equal-or-newer applies, so a relay-base
+     * change (same grant) still converges. Absent on daemon-local defs and from an
+     * older CP, which reads as "unordered — apply".
+     */
+    issuedAt: z.number().int().nonnegative().optional(),
     transport: z.enum(['stdio', 'http', 'sse']).default('stdio'),
     command: z.string().optional(),
     args: z.array(z.string()).default([]),


### PR DESCRIPTION
Closes #979.

`duty/fetch` (#972) installs a granted agent and #978 made spec, integration and
cron updates plus the reconnect roster follow the holder. Two definition kinds
were deliberately left behind, and both are the ones an `AgentSpec` only **names**
rather than carries: the proxied MCP servers in its enable-list, and its
external-memory connection. Both were still resolved by placement
(`activeForDaemon(daemonId)` on either repo), so a duty-installed agent on a
non-placement holder came up referencing tools it had no definitions for and a
memory backend with no registry entry — silently, on a member that is otherwise
serving live turns.

## The shape: one projector, keyed on agents

`orchestrator/agentDefinitions.ts` is the single answer to *"which MCP defs and
which memory connection defs does this set of agents need"*. It takes agent
records, never a daemon, and it has exactly two callers:

| Caller | Agent set it passes |
|---|---|
| `Placement.reconcile` (the `register/ok` snapshot) | the roster union — `pinned-to-me ∪ agents in the duties I hold` |
| `AgentMoveService.bundleFor` (the `duty/fetch` reply) | the one agent the CP just authorized |

The snapshot does **not** recompute the union: it passes `ownedAgents`, the same
array that produced `register/ok.agents`, so the definitions and the specs that
reference them cannot disagree by construction.

That union itself now has one definition too — `orchestrator/servedAgents.ts`,
extracted from what #978 wrote inline in `reconcile`. It has three callers (see
"the inbound gate" below), and extracting it is what made the third one visible.

Both `activeForDaemon` methods are **deleted** (`McpProviderRepo`,
`ExternalMemoryConnectionRepo`). Nothing resolves either definition kind by
placement anywhere in the CP any more — the same checkable property #978
established for `agent.daemonId`.

## Delivery shape: extend the bundle, not a second convergence

The issue offered two options; this takes the bundle. `DutyAgentBundle` gains
`mcpServers` and `memoryConnections` (both optional on the wire — an older CP
omits them and the member installs the trio exactly as before).

Why the bundle rather than "a successful admission triggers convergence":

- **It keeps one code path with the roster.** The bundle's arrays come from the
  same projector, given `[agent]` instead of the roster union. A convergence
  trigger would have been a *second* answer to "which defs does this member
  need", which is precisely what the issue asks to avoid.
- **It is atomic with the install.** The definitions arrive in the same reply as
  the spec that names them, so the daemon applies them in one lifecycle-queued
  step — registry before agent (below). A separate push would race the install
  and could land after the first turn.
- **It cannot widen who can ask.** The bundle is already gated by
  `holdsAgent(holder, agentId)`; nothing new is authorized. A convergence trigger
  would have needed its own target resolution, i.e. its own way to be wrong.
- **It costs nothing when there is nothing to send.** An agent naming no MCP
  server and binding no connection reads neither registry (asserted).

On the daemon, `applyDutyDefinitions` runs inside the same
`queueAgentLifecycle` block, **before** `cpAgents.upsert`, mirroring the
register path's "registry before agent re-add": static memory admission must
never observe the agent before at least a probing (fail-closed) connection entry
exists. It is `upsert`, never `converge` — a holder may already serve other
agents whose definitions the bundle does not mention, and a duty install is not
a full-replace of a tenant registry.

## Updates: every def fan-out now resolves through `AgentDelivery`

I checked each site rather than assuming. `AgentDelivery` gains
`daemonsForAgents(agents)` — the union delivery set of several agents, which is
what a definition needs because a def is not addressed to an agent; its fan-out
has to answer "who uses this" first.

| Site | Was | Now |
|---|---|---|
| `mcp-push.daemonsEnabling` (provider create / PATCH / rotate / connectors) | daemons with a **placed** agent enabling the name | `daemonsForAgents(agents enabling the name)` |
| `agents.ts syncMcpDefsForAgent` (enable-list change) | the agent's `daemonId` | `daemonsFor(agent)`; the "still used" test for the removal half is delivery-set membership, not placement |
| `agents.ts pushExternalMemoryBeforeAgent` | `agent.daemonId`, skipped when unplaced | every delivery target |
| `agents.ts removeExternalMemoryFromDaemonIfUnused` | `agent.daemonId === daemonId` | delivery-set membership (fixes the predicate for the move path's callers too) |
| `memory-connections.ts pushConnection` (create / PATCH / rotate / delete) | `a.daemonId` of using agents | `daemonsForAgents(using agents)` |
| `memoryConnectionReplay.syncMemoryConnectionsToDaemons` (relay selection change) | `daemons.list() × activeForDaemon` | driven from the connections; targets are the delivery set of the bound agents |

Two consequences worth stating rather than discovering later:

- The memory route's `synced.every(Boolean)` is the **overlap-before-revoke fence**
  for grant rotation. Including holders means a key is no longer retired while a
  holder is still calling with it — the fence gets stronger, not looser. There is
  a test for exactly that (a refusing holder defers the rotation, both grants stay
  active).
- `pushUnassign` on provider delete is unchanged in effect: the delete guard 409s
  while any agent still enables the provider, so by the time it runs the
  referencing set is empty. The rotation path is the one that actually needed
  routing, and it is the one under test.

`syncMemoryConnectionsToDaemons` is the one site that is a relay-topology
convergence rather than a definition update; it is routed anyway, because leaving
it placement-keyed would have been the last place a holder silently missed a
re-projection, and because it is what let `activeForDaemon` go.

## One thing that did not survive contact with the code

Deleting `ExternalMemoryConnectionRepo.activeForDaemon` surfaced a second,
unlisted user: `ws/handlers/memory-connections.ts`, the **inbound** ownership gate
on daemon-reported probe facts. It restricted accepted facts to connections
"placed on this daemon".

That is not a delivery site, but it was wrong in the same way and in the opposite
direction: once the roster ships a duty-held agent's connection to its holder, a
holder that may not report on it leaves the connection permanently unprobed in
the console — the CP hands out a definition it then refuses to hear about. The
gate is now the same `servedAgents` union (`pinned-to-me ∪ duties I hold`), which
is the third caller mentioned above, and it is tested in both directions: a live
duty admits the fact, an expired one admits neither the definition nor the fact.

## The token-bearing boundary

An MCP proxy def carries the relay proxy URL plus the plaintext grant key; a
memory def carries the relay grant and the resolved secret leases. Three
properties keep "who can obtain one" equal to "a member that holds a duty
covering an agent that references it":

1. **The projector is scoped to references, not to orgs or daemons.** It reads
   `agent.mcpServers` / `agent.memory.connectionId` off the agent records it is
   given and point-resolves those; a provider nobody in the set enabled is never
   read, let alone projected. Tested, and mutation-checked by widening the
   fan-outs to every agent in the org (2 negatives fail).
2. **Names resolve per org.** The set is grouped by `orgId` and each group hits
   `listForOrg` for its own org, so a provider name that exists in two orgs cannot
   cross between them on an install-wide member whose roster spans orgs. The old
   `activeForDaemon` did `orgId IN (…) AND name IN (…)` as one cross-product;
   this is strictly narrower.
3. **The two entry points are already authorized.** `duty/fetch` answers only
   after `holdsAgent(holder, agentId)` and the bundle is scoped to that one
   agent's references — the reply widens nothing beyond the duty the asker
   already holds. `register/ok` is scoped by the same union that decides which
   agents the member may serve at all, and an expired lease removes the agent and
   its definitions together (tested).

Nothing here changes who may *hold* a duty, and the grant policy stays
`incumbent`.

## Invariants

- Release is still never removal (#948) — nothing here touches teardown.
- The withdrawal guard, the revision-driven refetch, `shrinkToGrant`, and the
  refuse-the-group-on-failure behavior are untouched; the definition install sits
  inside the existing lifecycle block, after the staged-move / pending-removal
  guards.
- An agent covered by another held group keeps serving.
- No delivery site reads `agent.daemonId` inline — now including the definition
  fan-outs.
- `features.dutyEnforcement`, the grant policy, placement semantics, the reaper,
  and `computeInputs` / `planDutyReconcile` are untouched. Rebased onto #983;
  no overlap with it.
- A move keeps its narrower `activationDefinition` — placement moves converge
  these two kinds through their own live pushes and the target's register, so the
  activation fingerprint is unchanged.

## Tests

New, all mutation-checked (break the mechanism, confirm exactly the intended test
fails, restore).

| # | Mutation | Expected failure | Result |
|---|---|---|---|
| M1 | `servedAgents` drops its duty half | the roster test (#978's), the snapshot-definitions test, the holder-facts test | ✅ exactly 3 |
| M2 | the snapshot's definitions are scoped to placed agents only | the snapshot-definitions test + the holder-facts test | ✅ exactly 2 |
| M3 | the projector flattens all orgs into one name set | `resolves each agent's names in ITS OWN org` | ✅ exactly 1 |
| M4 | `bundleFor` omits `mcpServers` | `carries the proxy def for every MCP server the spec names` | ✅ exactly 1 |
| M5 | `bundleFor` omits `memoryConnections` | `carries the external-memory connection the spec binds` | ✅ exactly 1 |
| M6 | the daemon skips `applyDutyDefinitions` | the install test + the ordering test | ✅ exactly 2 |
| M7 | the daemon applies definitions AFTER the spec | `the definitions land BEFORE the spec that references them` | ✅ exactly 1 |
| M8 | `mcp-push.daemonsEnabling` back to `a.daemonId` | the provider UPDATE and grant ROTATION holder tests | ✅ exactly 2 |
| M9 | the memory route's targets back to `a.daemonId` | the connection UPDATE and rotation-fence holder tests | ✅ exactly 2 |
| M10 | `syncMcpDefsForAgent` targets the placement only | `enabling a provider ON a duty-held agent…` | ✅ exactly 1 |
| M11 | the holder lookup ignores lease expiry | #978's `an EXPIRED lease is not a holding` | ✅ exactly 1 |
| M12 | the fan-outs target every agent's holders, not the referencing ones | both `a member holding NO duty…` negatives | ✅ exactly 2 |
| M13 | the facts gate back to placement-only agents | `a DUTY HOLDER … may report its facts` | ✅ exactly 1 |
| M14 | the bundle's two arrays lose their schemas | `the bundle also carries the MCP and memory definitions…` | ✅ exactly 1 |

The load-bearing assertions are on **content**, not arrival: the reconnect
snapshot and the live pushes assert the proxy def's relay URL and its
`Bearer <grant key>` header, and the rotation test asserts the key is *not* the
retired one — arrival alone would not have distinguished a correct def from an
empty shell.

Coverage by the issue's four requirements:

- *duty-installed agent on a non-placement holder receives the defs* —
  `bundleFor` unit tests (CP) plus the daemon-side install and ordering tests.
- *the reconnect snapshot for such a member includes them* —
  `duty-lease.handler.test.ts`, real WS harness + real Postgres.
- *an MCP provider / memory connection update reaches the holder* —
  `agents.replication.route.test.ts` (provider PATCH, grant rotation, enable-list
  change) and `memory-connections.route.test.ts` (connection PATCH, rotation
  fence).
- *a member holding no covering duty does not receive it* — one negative at each
  of the three levels: the projector (unit), the reconnect snapshot, and each live
  fan-out.

## Review round: ordering an unversioned write against a versioned one

review-bot found the third instance of this workstream's recurring shape. MCP grant
rotation (`rotateOnce`) deliberately keeps the **retiring and the fresh grant both
active** until the fresh one is distributed, and the daemon applied MCP definitions
last-write-wins. A `duty/fetch` projected inside that window could therefore land
*after* the rotation's live push and reinstate a key the relay was about to revoke —
the holder's tools break until some unrelated update or a reconnect repairs it.

Fixed in the two places the finding asks for, because the second is what makes the
first sufficient.

### 1. Projection — one selector, and it prefers the fresh grant

`activeForProvider` orders by `createdAt` **ascending**, so during the overlap the
head of the list is the grant about to be revoked. Every reader took `[0]`:
`mcpDefsForAgents` (this PR), `syncMcpDefsForAgent`, and the provider PATCH re-push.
The rotation itself never selected at all — it holds the freshly minted row and
passes it straight through, which is why the live push was already correct and why
there was no existing selector to reuse.

There *was* an existing **discipline** to reuse, on the sibling path: the
external-memory projector already does `activeForConnection(...).at(-1)` with a
comment naming this exact hazard. That is now one exported selector,
`currentMcpGrant(active)`, and all three readers go through it — so there is one
definition of "the current grant" rather than three copies of `[0]`.

### 2. Application — the marker, and where it came from

**The live MCP push carried no monotonic marker, so this was the gap to close for
both paths together** — a live push racing a live push had the same hole in
principle, and now does not.

The marker is **the active grant's issuance instant** (`McpGrant.createdAt`, epoch
millis), surfaced on the wire as `McpServerSpec.issuedAt`. It is the right marker
rather than an invented one because a proxy def has exactly two variable inputs: the
grant key and the relay base — the proxy url is derived from the provider id, so
provider row edits do not version the def at all. Rather than pass a key and a
marker separately, `mcpProxyDef` now takes the **grant row**, so the key and the
instant that orders it can never come from different grants. `pushAssign` threads
the row for the same reason.

On the daemon, `CpMcpDefs` stores the marker beside each def and `upsert` **refuses a
strictly older** definition — the same monotonic discipline the external-memory
registry already had on `revision`. Three deliberate choices:

- **Equal-or-newer applies.** A relay-base swap carries the same grant instant and
  must still converge; only a *strictly older* def is a regression.
- **An absent marker is "unordered" and applies** — an older CP, and daemon-local
  defs, behave exactly as before.
- **`converge` is not fenced but does record markers.** The reconnect snapshot is the
  CP-wins backstop that repairs any regression, so fencing it could refuse a
  legitimate repair; recording is what stops the first post-reconnect stale bundle
  from applying against an empty marker.

The marker is stripped at all three apply sites (live push, reconnect converge, duty
bundle) so it never reaches the runtime's `mcpServers` config — asserted.

### The external-memory path needed nothing, and here is why

Checked rather than assumed. It was already disciplined end to end: the rotation
route bumps `connection.revision` in **both** halves (`prepareGrantRotation` mint +
`finalizeGrantRotation` revoke), the projector already takes the newest active grant,
`MemoryConnectionSpec.revision` already rides the wire, and
`CpMemoryConnectionRegistry.upsert` already fences on it — and the duty bundle uses
that same projector and that same `upsert`. So a bundle projected pre-rotation and
applied post-push is rejected by the existing fence. Both properties now have tests
of their own rather than resting on inspection.

### The invariant

**After any interleaving of a rotation's live push and a duty fetch, the holder ends
up with the fresh key.** Written as an ordering test in both directions, driving the
*real* frame handler (`cpConfigApply().applyMcpServerUpsert`) against the *real*
install path: the fetch resolves only after the fresh push has landed (refused), and
the reverse order (fresh push overtakes an applied bundle, applied). Plus a
real-Postgres test that a def projected inside a genuine overlap window carries the
fresh key and an `issuedAt` strictly greater than the retiring grant's.

| # | Mutation | Expected failure | Result |
|---|---|---|---|
| M15 | `currentMcpGrant` takes the head instead of the newest | the selector test, the overlap-projection test, and the key assertion in the base projector test | ✅ exactly 3 |
| M16 | `mcpProxyDef` omits `issuedAt` | `orders itself by the instant its grant was issued` + the overlap-projection test | ✅ exactly 2 |
| M17 | `CpMcpDefs.upsert` drops the monotonic fence | the refuses-older test, the converge-records test, and the bundle-vs-rotation ordering test | ✅ exactly 3 |
| M18 | `converge` stops recording markers | `converge RECORDS the markers it installs…` | ✅ exactly 1 |
| M19 | the duty bundle apply passes no marker | `a bundle projected before a rotation cannot undo the fresh key it raced` | ✅ exactly 1 |
| M20 | the marker is not stripped out of the definition | `the ordering marker never reaches the runtime definition` | ✅ exactly 1 |

## Gates

`typecheck`, `lint`, `format:check`, protocol tests (331), control-plane
`test:unit` (1627) and `test:int` (1235) — all green. One `duty-lease.handler`
timing assertion (`renewal is the heartbeat`, an exact `expiresAt` off a
FakeClock) failed once under full parallel load and passes both in isolation and
on a repeat full run — the documented load-flake class. The daemon suite's
failures are the clean-main baseline, verified by checking out `origin/main` in
this worktree and re-running them: `shim-cancellation`, `shim-exec-handler`,
`shim-workspace-files`, `workspace-git-runner-seam`, plus the live `acp-matrix`
run, which needs real runtimes and network. One further `shim-exec-handler` case
(`applies the request env as given`) appears only under full parallel load — that
file's failures are `sandbox-exec … Operation not permitted`, and run in isolation
both `origin/main` and this branch fail exactly the same single test in it.
