### PR TITLE
fix(control-plane): refuse http-transport installs a platform can never reach

### DIFF
--- a/packages/control-plane/src/http/relay-ingress.test.ts
+++ b/packages/control-plane/src/http/relay-ingress.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { relayHttpBase, unreachableIngressOrigin, publicRelayIngress } from './relay-ingress.js'
+
+describe('relayHttpBase', () => {
+  it('normalizes ws(s) to http(s) and trims a trailing slash', () => {
+    expect(relayHttpBase('wss://relay.example.test/')).toBe('https://relay.example.test')
+    expect(relayHttpBase('ws://relay.example.test')).toBe('http://relay.example.test')
+    expect(relayHttpBase('https://relay.example.test/')).toBe('https://relay.example.test')
+  })
+
+  it('is null when PUBLIC_RELAY_URL is unset', () => {
+    expect(relayHttpBase(undefined)).toBeNull()
+    expect(relayHttpBase('')).toBeNull()
+  })
+})
+
+describe('unreachableIngressOrigin', () => {
+  it('accepts an origin a platform could dial', () => {
+    expect(unreachableIngressOrigin('https://relay.example.test')).toBe(false)
+    expect(unreachableIngressOrigin('https://relay.example.test:8443/relay')).toBe(false)
+    expect(unreachableIngressOrigin('https://203.0.113.10')).toBe(false)
+    expect(unreachableIngressOrigin('https://[2606:4700:4700::1111]')).toBe(false)
+  })
+
+  it('rejects loopback and special-use names', () => {
+    expect(unreachableIngressOrigin('http://localhost:8090')).toBe(true)
+    expect(unreachableIngressOrigin('http://LOCALHOST:8090')).toBe(true)
+    expect(unreachableIngressOrigin('http://relay.localhost:8090')).toBe(true)
+    expect(unreachableIngressOrigin('http://relay.local')).toBe(true)
+    expect(unreachableIngressOrigin('https://relay.internal')).toBe(true)
+    expect(unreachableIngressOrigin('https://relay.home.arpa')).toBe(true)
+  })
+
+  it('rejects literal private, loopback and link-local addresses', () => {
+    for (const origin of [
+      'http://127.0.0.1:8090',
+      'http://10.1.2.3:8090',
+      'http://172.16.0.9',
+      'http://192.168.1.4:8090',
+      'http://169.254.169.254',
+      'http://100.64.0.1',
+      'http://[::1]:8090',
+      'http://[fd00::1]',
+      'http://[fe80::1]'
+    ]) {
+      expect(unreachableIngressOrigin(origin), origin).toBe(true)
+    }
+  })
+
+  it('does not mistake a public name that merely contains a private suffix', () => {
+    expect(unreachableIngressOrigin('https://relay.localhost.example.test')).toBe(false)
+    expect(unreachableIngressOrigin('https://internal.example.test')).toBe(false)
+  })
+})
+
+describe('publicRelayIngress', () => {
+  it('hands back the request_url base when a public relay is connected', () => {
+    expect(publicRelayIngress('wss://relay.example.test/', true)).toEqual({
+      ok: true,
+      base: 'https://relay.example.test'
+    })
+  })
+
+  it('names which half of the deployment is missing', () => {
+    const noUrl = publicRelayIngress(undefined, true)
+    const noRelay = publicRelayIngress('https://relay.example.test', false)
+    expect(noUrl).toEqual({
+      ok: false,
+      message:
+        'HTTP callback delivery is unavailable on this deployment — the relay pool has no public origin (set PUBLIC_RELAY_URL).'
+    })
+    expect(noRelay).toEqual({
+      ok: false,
+      message: 'HTTP callback delivery is unavailable on this deployment — no relay is connected.'
+    })
+  })
+
+  it('refuses a connected relay no platform can reach, naming the origin', () => {
+    // The issue's default Compose stack: a healthy, registered, loopback-only relay.
+    const result = publicRelayIngress('http://localhost:8090', true)
+    expect(result.ok).toBe(false)
+    expect(result.ok === false && result.message).toContain('http://localhost:8090')
+    expect(result.ok === false && result.message).toContain('socket')
+  })
+})

--- a/packages/control-plane/src/http/relay-ingress.ts
+++ b/packages/control-plane/src/http/relay-ingress.ts
@@ -1,0 +1,75 @@
+/**
+ * The ONE precondition every http-transport install shares: this deployment can
+ * terminate public platform callbacks. Core knowledge, not a provider's
+ * (integration-plugin-architecture.md §9 — core knows the relay pool), so the
+ * Slack funnel, the platform-app install, the generic `POST /integrations` tail
+ * and the Feishu registration all answer it the same way.
+ *
+ * Availability is NOT reachability. A relay can be registered, connected and
+ * healthy while sitting on `http://localhost:8090` behind a firewall — the
+ * platform's servers still cannot POST to it, and because the transport is
+ * immutable the resulting bot is a silent black hole that can only be recovered
+ * by deleting the integration and the bot. So the gate also refuses a public
+ * origin that could never be dialled from the internet.
+ */
+import net from 'node:net'
+import type { HttpDeps } from './deps.js'
+import { privateV4, privateV6 } from '../net/private-address.js'
+
+/** The relay pool's public HTTPS base from PUBLIC_RELAY_URL, normalizing a
+ *  `ws(s)://` origin to `http(s)://` (the Events API request_url is HTTP) and
+ *  trimming a trailing slash. Null/undefined ⇒ null. */
+export function relayHttpBase(publicRelayUrl: string | undefined): string | null {
+  if (!publicRelayUrl) return null
+  return publicRelayUrl.replace(/^ws(s?):\/\//i, 'http$1://').replace(/\/$/, '')
+}
+
+/** Special-use names that never resolve to a public address (RFC 6761 `.localhost`,
+ *  RFC 6762 `.local`, RFC 8375 `.home.arpa`, and ICANN's private-use `.internal`). */
+const PRIVATE_SUFFIXES = ['.localhost', '.local', '.internal', '.home.arpa']
+
+/**
+ * Could a platform's servers never deliver an event to this origin? True only for
+ * the unmistakable cases — `localhost`, a special-use name, or a literal
+ * loopback/private/link-local IP. A name we cannot classify counts as reachable:
+ * an operator's split-horizon or tunnelled hostname is theirs to know, and this
+ * check exists to close the one-way door, not to police DNS.
+ */
+export function unreachableIngressOrigin(base: string): boolean {
+  let host: string
+  try {
+    host = new URL(base).hostname.toLowerCase()
+  } catch {
+    return true // PUBLIC_RELAY_URL is url-validated at boot, so this is not a working origin
+  }
+  if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1) // IPv6 literal
+  if (host === 'localhost' || PRIVATE_SUFFIXES.some((s) => host.endsWith(s))) return true
+  const fam = net.isIP(host)
+  return (fam === 4 && privateV4(host)) || (fam === 6 && privateV6(host))
+}
+
+/** The gate's answer: the request_url base to bake into a platform app, or the
+ *  refusal to send back as a 409. */
+export type RelayIngress = { ok: true; base: string } | { ok: false; message: string }
+
+const UNAVAILABLE = 'HTTP callback delivery is unavailable on this deployment'
+
+/** Pure form of {@link relayIngress}, so the predicate is testable without deps. */
+export function publicRelayIngress(publicRelayUrl: string | undefined, relayConnected: boolean): RelayIngress {
+  const base = relayHttpBase(publicRelayUrl)
+  if (!base)
+    return { ok: false, message: `${UNAVAILABLE} — the relay pool has no public origin (set PUBLIC_RELAY_URL).` }
+  if (!relayConnected) return { ok: false, message: `${UNAVAILABLE} — no relay is connected.` }
+  if (unreachableIngressOrigin(base)) {
+    return {
+      ok: false,
+      message: `HTTP callback delivery cannot work on this deployment: PUBLIC_RELAY_URL (${base}) is a loopback or private address, so a chat platform can never deliver events to it. Use socket delivery, or point PUBLIC_RELAY_URL at a publicly reachable relay origin.`
+    }
+  }
+  return { ok: true, base }
+}
+
+/** Can this deployment accept an http-transport install right now? */
+export function relayIngress(deps: Pick<HttpDeps, 'config' | 'httpBot'>): RelayIngress {
+  return publicRelayIngress(deps.config.PUBLIC_RELAY_URL, deps.httpBot.hasConnectedRelay())
+}

--- a/packages/control-plane/src/http/routes/feishu-registration.ts
+++ b/packages/control-plane/src/http/routes/feishu-registration.ts
@@ -22,7 +22,7 @@ import {
 } from '../feishu-registration.js'
 import { installNewFeishuBot } from '../install-feishu.js'
 import { feishuEventsRequestUrl, type ConfigureFeishuHttpAppInput } from '../feishu-app-config.js'
-import { relayHttpBase } from './slack-install.js'
+import { relayIngress } from '../relay-ingress.js'
 import type { FeishuRouteSeams } from '../platform-route-seams.js'
 import {
   ErrorDto,
@@ -107,13 +107,9 @@ export function feishuRegistrationRoutes(deps: HttpDeps, feishu: FeishuRouteSeam
         const createdByUserId = req.principal.userId
         const targetAgentId = agent.id
         const transport = req.body.transport
-        const relayBase = transport === 'http' ? relayHttpBase(deps.config.PUBLIC_RELAY_URL) : null
-        if (transport === 'http' && (!relayBase || !deps.httpBot.hasConnectedRelay())) {
-          return reply.code(409).send({
-            error: 'Conflict',
-            statusCode: 409,
-            message: 'HTTP callback delivery is unavailable on this deployment'
-          })
+        const ingress = transport === 'http' ? relayIngress(deps) : null
+        if (ingress && !ingress.ok) {
+          return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: ingress.message })
         }
         const tenant = await feishu.tenantGuard.loginAppStatus(req.body.region).catch(() => 'unavailable' as const)
         if (tenant === 'not_configured') {
@@ -227,9 +223,11 @@ export function feishuRegistrationRoutes(deps: HttpDeps, feishu: FeishuRouteSeam
               throw new FeishuRegistrationSetupError('agent_unavailable')
             }
             const name = registration.requestedName || (check?.status === 'ok' ? check.name : null) || current.name
-            const relayBase = registration.transport === 'http' ? relayHttpBase(deps.config.PUBLIC_RELAY_URL) : null
-            if (registration.transport === 'http' && (!relayBase || !deps.httpBot.hasConnectedRelay())) {
-              throw new FeishuRegistrationRetryError()
+            let relayBase: string | null = null
+            if (registration.transport === 'http') {
+              const ingress = relayIngress(deps)
+              if (!ingress.ok) throw new FeishuRegistrationRetryError()
+              relayBase = ingress.base
             }
             const existingSecret =
               registration.transport === 'http'

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -32,6 +32,7 @@ import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewBot } from '../install-bot.js'
 import { BotExternalIdentityTaken } from '../../persistence/errors.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
+import { relayIngress } from '../relay-ingress.js'
 import { buildCreateIntegrationBody, credentialBlockOf } from '../dto/create-integration-body.js'
 import type { CpConfigRefusal } from '../../platforms/provider.js'
 import { MULTI_AGENT_UNSUPPORTED_MESSAGE, supportsMultiAgentBots } from '../../platforms/sharing.js'
@@ -142,15 +143,9 @@ export function integrationRoutes(deps: HttpDeps) {
           body: { error: 'Bad Request', statusCode: 400, message: MULTI_AGENT_UNSUPPORTED_MESSAGE }
         }
       }
-      if (!deps.httpBot.hasConnectedRelay()) {
-        return {
-          code: 409,
-          body: {
-            error: 'Conflict',
-            statusCode: 409,
-            message: 'HTTP callback delivery is unavailable on this deployment'
-          }
-        }
+      const ingress = relayIngress(deps)
+      if (!ingress.ok) {
+        return { code: 409, body: { error: 'Conflict', statusCode: 409, message: ingress.message } }
       }
       if (bot.agentIds.includes(agentId)) {
         return { code: 409, body: { error: 'Conflict', statusCode: 409, message: 'this agent already uses this bot' } }
@@ -322,12 +317,11 @@ export function integrationRoutes(deps: HttpDeps) {
                 const shareableErr = await validateShareableInstall(bot, agent.id, req.body.platform)
                 if (shareableErr) return reply.code(shareableErr.code).send(shareableErr.body)
                 if (!bot.shareable) await deps.repos.bot.setShareable(orgId, bot.id, true)
-              } else if (!deps.httpBot.hasConnectedRelay()) {
-                return reply.code(409).send({
-                  error: 'Conflict',
-                  statusCode: 409,
-                  message: 'HTTP callback delivery is unavailable on this deployment'
-                })
+              } else {
+                const ingress = relayIngress(deps)
+                if (!ingress.ok) {
+                  return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: ingress.message })
+                }
               }
               // Membership admission is ATOMIC with the bot row — the same
               // primitive as the platform callback. The checks above are the
@@ -413,18 +407,17 @@ export function integrationRoutes(deps: HttpDeps) {
               message: 'HTTP callback delivery currently supports Slack and Feishu only'
             })
           }
-          // Relay availability is CORE's 409 (§9 — core, not the provider, knows
+          // Public relay ingress is CORE's 409 (§9 — core, not the provider, knows
           // the relay pool), and it now precedes the provider round-trip on every
           // platform: a deployment that cannot serve http ingress at all is a
           // deployment-level blocker, so there is no point spending a provider API
           // call first. (Feishu already checked in this order; Slack checked after.
           // The two refusals can only race when the credential is ALSO bad.)
-          if (transport === 'http' && !deps.httpBot.hasConnectedRelay()) {
-            return reply.code(409).send({
-              error: 'Conflict',
-              statusCode: 409,
-              message: 'HTTP callback delivery is unavailable on this deployment'
-            })
+          if (transport === 'http') {
+            const ingress = relayIngress(deps)
+            if (!ingress.ok) {
+              return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: ingress.message })
+            }
           }
 
           // The chosen platform's credential block: validated by the provider's OWN

--- a/packages/control-plane/src/http/routes/slack-bot-refresh.ts
+++ b/packages/control-plane/src/http/routes/slack-bot-refresh.ts
@@ -28,7 +28,7 @@ import { denyViewerWrite, orgOf } from '../rbac.js'
 import { SlackBotRefreshDto, ErrorDto, IdParam, type SlackBotRefreshDtoT } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
 import { checkSlackBotScopes, mergeManagedSlackManifest, slackOAuthRedirectUri } from '../slack-manifest.js'
-import { relayHttpBase } from './slack-install.js'
+import { relayHttpBase } from '../relay-ingress.js'
 
 /** Slack errors from the manifest export/update that mean "this app is not
  *  managed by the caller's config token" — a graceful `manual_update_required`,

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -33,6 +33,7 @@ import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
 import { CONFIG_ACCESS_TTL_MS, configUsable } from '../slack-user-config.js'
 import type { SlackRouteSeams } from '../platform-route-seams.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
+import { relayHttpBase, relayIngress } from '../relay-ingress.js'
 import {
   SlackAppStartBody,
   SlackAppStartDto,
@@ -45,14 +46,6 @@ import {
   SlackInstallErrorDto,
   IdParam
 } from '../dto/index.js'
-
-/** The relay pool's public HTTPS base from PUBLIC_RELAY_URL, normalizing a
- *  `ws(s)://` origin to `http(s)://` (the Events API request_url is HTTP) and
- *  trimming a trailing slash. Null/undefined ⇒ null. */
-export function relayHttpBase(publicRelayUrl: string | undefined): string | null {
-  if (!publicRelayUrl) return null
-  return publicRelayUrl.replace(/^ws(s?):\/\//i, 'http$1://').replace(/\/$/, '')
-}
 
 /** Slack error strings from `apps.manifest.create` that mean the config token itself is
  *  invalid/expired (as opposed to a transient error or a rate limit). An ACCESS-ONLY stored
@@ -157,16 +150,13 @@ export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
 
         // Transport (slack-http-mode): http ⇒ the CP builds an Events-API manifest and
         // captures the signing secret from apps.manifest.create, so finalize needs no
-        // manual paste. http requires a connected relay to receive the POSTs.
+        // manual paste. http requires a relay Slack itself can POST to.
         const transport = req.body.transport ?? 'socket'
-        const httpBase = transport === 'http' ? (relayHttpBase(deps.config.PUBLIC_RELAY_URL) ?? undefined) : undefined
-        if (transport === 'http' && (!httpBase || !deps.httpBot.hasConnectedRelay())) {
-          return reply.code(409).send({
-            error: 'Conflict',
-            statusCode: 409,
-            message: 'HTTP-mode install needs a connected relay — set PUBLIC_RELAY_URL and run a relay.'
-          })
+        const ingress = transport === 'http' ? relayIngress(deps) : null
+        if (ingress && !ingress.ok) {
+          return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: ingress.message })
         }
+        const httpBase = ingress?.ok ? ingress.base : undefined
 
         // The CP owns the manifest (chiefly `redirect_urls`): a client-supplied
         // redirect would be an open-redirect / token-theft hole.
@@ -508,9 +498,9 @@ export function slackConfigRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
       // The deployment half — a configured public callback origin — stays here,
       // which is what knows it.
       const credentialUsable = configUsable(row, now)
-      // HTTP mode is offerable here: a public relay origin is configured AND ≥1 relay
-      // is connected to receive the Events API POSTs.
-      const relayAvailable = !!relayPublicUrl && deps.httpBot.hasConnectedRelay()
+      // HTTP mode is offerable here: the SAME gate the http install paths refuse
+      // on, so the console never offers a transport the create call would reject.
+      const relayAvailable = relayIngress(deps).ok
       return {
         configured: !!row,
         durable,

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -39,7 +39,8 @@ import { resolveWebAppUrl } from '../../config/env.js'
 import { checkSlackBotScopes, SLACK_BOT_SCOPES, slackPlatformOAuthRedirectUri } from '../slack-manifest.js'
 import { installNewSlackBot } from '../install-slack.js'
 import { BotWorkspaceClaimed } from '../../persistence/errors.js'
-import { closePageHtml, relayHttpBase } from './slack-install.js'
+import { closePageHtml } from './slack-install.js'
+import { relayIngress } from '../relay-ingress.js'
 import type { SlackRouteSeams } from '../platform-route-seams.js'
 import {
   SlackPlatformInstallStartBody,
@@ -78,12 +79,9 @@ export function slackPlatformInstallRoutes(deps: HttpDeps, slack: SlackRouteSeam
         }
         const orgId = req.orgCtx!.orgId
         // Events-API-only: same relay precondition as an http quick-install.
-        if (!relayHttpBase(deps.config.PUBLIC_RELAY_URL) || !deps.httpBot.hasConnectedRelay()) {
-          return reply.code(409).send({
-            error: 'Conflict',
-            statusCode: 409,
-            message: 'HTTP-mode Slack requires a connected relay (PUBLIC_RELAY_URL + a running relay)'
-          })
+        const ingress = relayIngress(deps)
+        if (!ingress.ok) {
+          return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: ingress.message })
         }
         let agentId: AgentId | undefined
         let expectedBotId: BotId | undefined

--- a/packages/control-plane/src/net/private-address.ts
+++ b/packages/control-plane/src/net/private-address.ts
@@ -1,0 +1,38 @@
+/**
+ * One definition of "this literal address can never be reached from the public
+ * internet", shared by the SSRF fast-fail on user-supplied upstream URLs
+ * (`orchestrator/mcpProvider.ts`) and the public-ingress gate on http-transport
+ * bots (`http/relay-ingress.ts`). Pure — literals only, no DNS.
+ */
+
+/** RFC 1918 / loopback / link-local / CGNAT IPv4, plus the cloud metadata address. */
+export function privateV4(ip: string): boolean {
+  const o = ip.split('.').map(Number)
+  const a = o[0] ?? -1
+  const b = o[1] ?? -1
+  if (a === 0 || a === 127) return true // this-host / loopback
+  if (a === 10) return true // 10/8
+  if (a === 172 && b >= 16 && b <= 31) return true // 172.16/12
+  if (a === 192 && b === 168) return true // 192.168/16
+  if (a === 169 && b === 254) return true // link-local incl. 169.254.169.254 (cloud metadata)
+  if (a === 100 && b >= 64 && b <= 127) return true // 100.64/10 CGNAT
+  return false
+}
+
+/** Loopback / unspecified / ULA / link-local IPv6, and IPv4-mapped forms of the above. */
+export function privateV6(ip: string): boolean {
+  const l = ip.toLowerCase()
+  if (l === '::1' || l === '::') return true // loopback / unspecified
+  const mapped = l.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/) // IPv4-mapped (dotted)
+  if (mapped?.[1]) return privateV4(mapped[1])
+  const hex = l.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/) // IPv4-mapped (URL-normalized hex)
+  if (hex?.[1] && hex[2]) {
+    const hi = parseInt(hex[1], 16)
+    const lo = parseInt(hex[2], 16)
+    return privateV4(`${hi >> 8}.${hi & 255}.${lo >> 8}.${lo & 255}`)
+  }
+  const head = l.split(':')[0] ?? ''
+  if (/^f[cd]/.test(head)) return true // fc00::/7 ULA
+  if (/^fe[89ab]/.test(head)) return true // fe80::/10 link-local
+  return false
+}

--- a/packages/control-plane/src/orchestrator/mcpProvider.ts
+++ b/packages/control-plane/src/orchestrator/mcpProvider.ts
@@ -15,6 +15,7 @@
 import { createHash, randomBytes } from 'node:crypto'
 import net from 'node:net'
 import type { McpServerSpec, RcMcpAssign } from '@agentconnect.md/protocol'
+import { privateV4, privateV6 } from '../net/private-address.js'
 
 /** The provider fields the mappers read (structural subset of the McpProvider row). */
 interface ProviderView {
@@ -22,36 +23,6 @@ interface ProviderView {
   orgId: string
   name: string
   url: string
-}
-
-function privateV4(ip: string): boolean {
-  const o = ip.split('.').map(Number)
-  const a = o[0] ?? -1
-  const b = o[1] ?? -1
-  if (a === 0 || a === 127) return true // this-host / loopback
-  if (a === 10) return true // 10/8
-  if (a === 172 && b >= 16 && b <= 31) return true // 172.16/12
-  if (a === 192 && b === 168) return true // 192.168/16
-  if (a === 169 && b === 254) return true // link-local incl. 169.254.169.254 (cloud metadata)
-  if (a === 100 && b >= 64 && b <= 127) return true // 100.64/10 CGNAT
-  return false
-}
-
-function privateV6(ip: string): boolean {
-  const l = ip.toLowerCase()
-  if (l === '::1' || l === '::') return true // loopback / unspecified
-  const mapped = l.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/) // IPv4-mapped (dotted)
-  if (mapped?.[1]) return privateV4(mapped[1])
-  const hex = l.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/) // IPv4-mapped (URL-normalized hex)
-  if (hex?.[1] && hex[2]) {
-    const hi = parseInt(hex[1], 16)
-    const lo = parseInt(hex[2], 16)
-    return privateV4(`${hi >> 8}.${hi & 255}.${lo >> 8}.${lo & 255}`)
-  }
-  const head = l.split(':')[0] ?? ''
-  if (/^f[cd]/.test(head)) return true // fc00::/7 ULA
-  if (/^fe[89ab]/.test(head)) return true // fe80::/10 link-local
-  return false
 }
 
 /**

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -60,7 +60,11 @@ function daemonCapabilities(platforms: string[]) {
 
 function withSpy(): { app: HttpApp; spy: SpyControl } {
   const spy = new SpyControl()
-  const app = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+  // A publicly reachable relay origin — the http-transport gate refuses a
+  // deployment whose PUBLIC_RELAY_URL is unset or loopback-only, so the tests
+  // that exercise http installs need the same config a real one would have.
+  const config = { PUBLIC_RELAY_URL: 'https://relay.example.test' }
+  const app = buildHttpApp(prisma, config, undefined, spy as unknown as ControlSender)
   running = app
   return { app, spy }
 }
@@ -211,13 +215,70 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
 
       expect(res.statusCode).toBe(409)
       expect((res.json() as { message: string }).message).toBe(
-        'HTTP callback delivery is unavailable on this deployment'
+        'HTTP callback delivery is unavailable on this deployment — no relay is connected.'
       )
       expect(verified).toBe(false)
       expect(await prisma.bot.count({ where: { orgId: DEFAULT_ORG_ID } })).toBe(0)
       await app.close()
       running = undefined
     }
+  })
+
+  it('POST refuses an http install when the connected relay is loopback-only', async () => {
+    // The default self-hosted Compose stack: a healthy, registered relay whose
+    // PUBLIC_RELAY_URL no platform can POST to. Availability is not reachability —
+    // and because transport is immutable, accepting one mints a bot that silently
+    // black-holes every inbound message.
+    const agentId = await placedAgent()
+    const spy = new SpyControl()
+    const app = buildHttpApp(
+      prisma,
+      { PUBLIC_RELAY_URL: 'http://localhost:8090' },
+      undefined,
+      spy as unknown as ControlSender
+    )
+    running = app
+    app.relayReg.add({ relayId: 'r1', send() {}, close() {} } as RelayChannel)
+    let verified = false
+    app.platformStubs.verifySlackBot = async () => {
+      verified = true
+      return {
+        status: 'ok',
+        name: 'http-bot',
+        appId: 'AHTTPBOT',
+        botUserId: 'U1',
+        teamId: 'T1',
+        teamName: 'Acme',
+        scopes: [...SLACK_BOT_SCOPES]
+      }
+    }
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: {
+        platform: 'slack',
+        agentId,
+        transport: 'http',
+        slack: { botToken: SLACK.botToken, signingSecret: 'signing-secret' }
+      }
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect((res.json() as { message: string }).message).toContain('http://localhost:8090')
+    expect(verified).toBe(false)
+    expect(await prisma.bot.count({ where: { orgId: DEFAULT_ORG_ID } })).toBe(0)
+    // Socket transport is the escape hatch the refusal points at, and it still works.
+    const socket = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: {
+        platform: 'slack',
+        agentId,
+        slack: { botToken: SLACK.botToken, appToken: SLACK.appToken }
+      }
+    })
+    expect(socket.statusCode).toBe(201)
   })
 
   it('POST telegram check reports Group Privacy Mode without storing the token', async () => {


### PR DESCRIPTION
Closes #957.

## The bug

An http bot's Events API `request_url` is the deployment's `PUBLIC_RELAY_URL`, baked into the platform app at create time and never repointed. The precondition on that path only asked whether a relay was **registered and connected** — which the default self-hosted Compose stack satisfies, because `PUBLIC_RELAY_URL` defaults to `http://localhost:8090` and the daemon dials it happily.

So the install succeeded, the bot reported active, the daemon logged a healthy send-only connection, and every inbound message was silently lost: Slack has no route to a relay on loopback behind a firewall. No error in the console, the daemon log, or the relay log. And because transport is immutable, recovery meant deleting the integration, then the bot, then recreating both.

Availability is not reachability — a relay can be healthy and registered while being unreachable from the platform's network.

## The change

One gate, `relayIngress(deps)` in `http/relay-ingress.ts`, replaces the five hand-rolled `hasConnectedRelay()` checks. It answers three ways:

| state | 409 message |
| --- | --- |
| `PUBLIC_RELAY_URL` unset | `… — the relay pool has no public origin (set PUBLIC_RELAY_URL).` |
| set, no relay connected | `… — no relay is connected.` |
| set to loopback/private, relay connected | names the origin: ``PUBLIC_RELAY_URL (http://localhost:8090) is a loopback or private address, so a chat platform can never deliver events to it. Use socket delivery, or point PUBLIC_RELAY_URL at a publicly reachable relay origin.`` |

It fronts every path that can mint an immutable `http` bot: `POST /integrations` (new bot, bot reuse, shareable install), the Slack config-token funnel, the platform-app install, and the Feishu registration (both start and the post-authorization finalize).

`relayAvailable` in `GET /slack/config` now reads the **same** gate, so the console cannot offer a transport the create call would reject — the wizard defaults to Socket Mode and drops the "Switch to HTTP" affordance on a loopback deployment. That closes the issue's aggravating factor 2, where the default install path steered self-hosters into a mode that cannot work for them.

## Refuse, not warn

The three refused states are not risky, they are impossible: there is no network path from a platform's servers to `127.0.0.1` or `10.0.0.0/8`, and the value is frozen into the app manifest at create time. A warning in front of a wall would only add a click before the same dead bot, priced against a delete-and-recreate recovery.

The predicate is deliberately narrow for the same reason — it refuses only `localhost`, the special-use suffixes (`.localhost`, `.local`, `.internal`, `.home.arpa`), and literal loopback/private/link-local/CGNAT IPs. A hostname it cannot classify passes untouched: a tunnel or a split-horizon name is the operator's to know, and this exists to close the one-way door, not to police DNS.

## Reviewer notes

- **`POST /integrations` now also requires `PUBLIC_RELAY_URL`,** which it did not check before. The console already gated the http option on it, so this aligns the API with the UI rather than setting new policy — but a raw API caller creating http bots without it will now get a 409.
- **`privateV4`/`privateV6` moved** out of `orchestrator/mcpProvider.ts` into `net/private-address.ts` so the MCP SSRF gate and this one share one definition. `blockedUpstreamUrl`'s behavior and messages are unchanged.
- **Existing bots are untouched** — the gate runs at create/registration time only, so no live http integration changes behavior.
- `withSpy()` in the integrations route tests now supplies a public `PUBLIC_RELAY_URL`, which is the config a deployment offering http would actually have.

## Not in this PR

When the gate refuses, the console *silently* hides the HTTP option rather than explaining why. For the operator falling into the trap that is a strict improvement — they never open the one-way door — but an operator who deliberately wants HTTP mode sees the option vanish with no reason given. Surfacing the refusal reason means carrying it in `SlackConfigDto` through to the delivery picker, across control-plane and web. Happy to file that separately.

## Verification

- `pnpm --filter @agentconnect.md/control-plane typecheck` — clean
- `eslint` on every touched file — clean
- Full control-plane suite: **1618 unit + 1218 integration, all passing**
- New coverage: 9 unit cases on the predicate, plus an integration test reproducing the issue's exact setup — a registered, connected, loopback-only relay — asserting the 409, that no bot row is written, that the credential round-trip is skipped, and that socket transport still installs on the same deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
