### PR TITLE
feat(duty): make the pool heal itself by making placement a target

### DIFF
--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -305,8 +305,9 @@ pass reaped the singleton the activation rendezvous had just minted, and the
 next trigger minted it again — a grant/revoke loop that interrupted the agent's
 in-flight turn on every sweep. The cost is one `duty_group` row per agent per
 org, most of them permanently vacant in a deployment whose agents live on
-org-scoped daemons; vacancy is cheap by construction (§5) and the `incumbent`
-grant policy filters those rows out inside `claimVacant`, so they consume no
+org-scoped daemons; vacancy is cheap by construction (§5) and the eligibility
+gate filters those rows out inside `claimVacant` — a machine-placed agent has
+exactly one eligible holder and it is never a pool member — so they consume no
 grant budget.
 
 ### The activation rendezvous
@@ -578,14 +579,28 @@ and cannot carry the flag; the operator sets `AGENTCONNECT_DUTY_ENFORCEMENT`
 (`1`/`true`/`yes`/`on`, anything unrecognized refused at startup) on the Pod
 instead, which outranks the file for this one key. The daemon reports which
 state it got — enforcing, or configured-but-inactive on a non-frame
-connection — once the control-plane connection is up. During the soak the grant policy is
-**incumbent-only** — a vacancy is granted only to the member the group's
-agents are already placed on, and the recompute vacates a lease whose holder
-no longer hosts any of the group's agents (partial occupancy keeps it, so a
-split group never flaps). Duties pin where agent state already lives; the
-policy widens to any-member once the shared data plane makes state portable.
-A single-org daemon sends byte-identical heartbeats to before and never
-observes any of this.
+connection — once the control-plane connection is up.
+
+**There is no grant policy any more.** The soak ran on an incumbent-only one —
+a vacancy went only to the member the group's agents were already placed on —
+and it could not survive its own premise: after a rollout the incumbent names a
+Pod that no longer exists, so a vacated group was claimable in principle and
+claimed by nobody in practice. What replaced it is not a wider policy but a
+different question. Placement is a **target**: `daemon` names one machine
+through `Agent.daemonId`, `pool` names the install-wide member set and carries
+no ref at all. A member may claim a group iff it may hold **every** agent in it —
+that machine for a `daemon` placement, any install-wide member for a `pool`
+one. One predicate, applied identically by the heartbeat claim, the activation
+rendezvous, and the sweep's placement fence, which now vacates a lease whose
+holder is no longer eligible rather than one that lost its last incumbency.
+
+Two consequences worth stating. A group mixing a `pool` agent with a
+machine-placed one is claimable by **neither** — serving it as a unit would mean
+one side running what the other already runs — so the gate is FORALL, not
+EXISTS. And an agent placed on a machine has exactly one eligible holder, which
+an install-wide member never is: dropping the incumbent gate cannot reach the
+agents a local daemon is already serving. A single-org daemon sends
+byte-identical heartbeats to before and never observes any of this.
 
 ### Future direction: daemon groups
 

--- a/packages/control-plane/prisma/migrations/20260820000000_agent_placement_kind/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260820000000_agent_placement_kind/migration.sql
@@ -1,0 +1,6 @@
+-- Placement becomes a target, not only a member id: `daemon` resolves through `Agent.daemonId`,
+-- `pool` resolves to the install-wide member set. Additive and defaulted, so every existing row
+-- stays a `daemon` placement naming the machine it already names.
+CREATE TYPE "AgentPlacementKind" AS ENUM ('daemon', 'pool');
+
+ALTER TABLE "agent" ADD COLUMN "placementKind" "AgentPlacementKind" NOT NULL DEFAULT 'daemon';

--- a/packages/control-plane/prisma/migrations/20260821000000_duty_group_confirmed_at/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260821000000_duty_group_confirmed_at/migration.sql
@@ -1,0 +1,13 @@
+-- Ingress addressing must name a holder that is provably SERVING, not merely granted: a grant is
+-- applied on the daemon only after its install succeeds (#972), so "the holder reported this group
+-- in its digest" is the confirmation, and it is the same signal the self-fence and CP renewal
+-- already ride. Null while a grant is outstanding.
+ALTER TABLE "duty_group" ADD COLUMN "confirmedAt" TIMESTAMPTZ(6);
+
+-- Every currently-held group IS being served right now, so assert it rather than manufacturing a
+-- heartbeat-long gap in A2A routing at deploy time. `updatedAt` is the last time the lease moved,
+-- which is the closest true statement available for rows that predate the column.
+UPDATE "duty_group" SET "confirmedAt" = "updatedAt" WHERE "holder" IS NOT NULL;
+
+-- The ingress read is "confirmed holders of this agent", so it scans by holder among confirmed rows.
+CREATE INDEX "duty_group_confirmedAt_idx" ON "duty_group"("confirmedAt");

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2888,6 +2888,12 @@ model DutyGroup {
   holder    String?   @db.Uuid // member (daemon) the group is granted to; null ⇒ never claimed or released
   term      BigInt    @default(0) // monotonic per group; bumped on EVERY grant/re-grant — the fencing token
   expiresAt DateTime? @db.Timestamptz(6) // renewal horizon written by the granter; past ⇒ vacant and grantable
+  // When the CURRENT holder first reported this group in its heartbeat digest — the earliest
+  // moment it is provably serving, because #972 applies a grant only after the install succeeded.
+  // Null while a grant is outstanding; reset whenever `holder` changes. Ingress addressing waits
+  // for it; delivery and `duty/fetch` deliberately do not (a member must receive its bundle to
+  // become confirmed at all).
+  confirmedAt DateTime? @db.Timestamptz(6)
   createdAt DateTime  @default(now()) @db.Timestamptz(6)
   updatedAt DateTime  @updatedAt @db.Timestamptz(6)
 
@@ -2897,6 +2903,7 @@ model DutyGroup {
   @@index([orgId])
   @@index([holder])
   @@index([expiresAt])
+  @@index([confirmedAt])
   @@map("duty_group")
 }
 

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -665,6 +665,14 @@ enum AgentStatus {
   paused
 }
 
+// Where an agent's duty may be held (docs/designs/k8s-daemon-pool.md §14). `daemon` names one
+// machine through `Agent.daemonId`; `pool` names the install-wide member set and carries no ref.
+// A later `group` value names an explicit daemon group — read it through domain/placement.ts.
+enum AgentPlacementKind {
+  daemon
+  pool
+}
+
 model Agent {
   id                    String             @id @db.Uuid // wire UUID across route/*, agent/*, event/session
   orgId                 String
@@ -680,7 +688,11 @@ model Agent {
   // requires one. When set it must be in Daemon.capabilities.runtimes.
   runtime               String?
   status                AgentStatus        @default(inactive)
-  daemonId              String?            @db.Uuid // 1 agent : 1 machine (null until placed)
+  // Placement is a TARGET, not only a member id. `daemon` (the default, so every pre-existing row
+  // keeps meaning what it meant) resolves through `daemonId`; `pool` resolves to the install-wide
+  // member set and requires `daemonId` to be null. Only domain/placement.ts reads the pair.
+  placementKind         AgentPlacementKind @default(daemon)
+  daemonId              String?            @db.Uuid // the `daemon`-kind ref: 1 agent : 1 machine (null until placed)
   // ── workspace (inline; §3.5) — daemon-generated path ──
   workspaceMode         WorkspaceMode      @default(scratch)
   workspaceIsolation    WorkspaceIsolation @default(shared)

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -153,6 +153,7 @@ import { relayHttpOrigin } from './orchestrator/mcpProvider.js'
 import { CollabRoutesService } from './orchestrator/collabRoutes.service.js'
 import { DutyLeaseService, DUTY_LEASE_DEFAULTS } from './orchestrator/dutyLease.js'
 import { AgentDelivery } from './orchestrator/agentDelivery.js'
+import { AgentRoutingConverger } from './orchestrator/agentRouting.js'
 import { PlacementResolver } from './orchestrator/placementResolver.js'
 import { DutyRecomputeSweep } from './orchestrator/dutyRecompute.js'
 import { AgentMutationGate } from './orchestrator/agentMutationGate.js'
@@ -626,6 +627,7 @@ export function buildContainer(
     repos: { session: repos.session, agent: repos.agent },
     control: sender,
     connReg,
+    placement: placementResolver,
     // Lazy over `http.log` (assigned below; only ever called at push time).
     log: { warn: (o, m) => http.log.warn(o, m) }
   })
@@ -638,11 +640,29 @@ export function buildContainer(
     repos.agent,
     relayControl,
     sender,
-    placementResolver
+    placementResolver,
+    repos.dutyGroup
   )
 
   // The fan-out that rides the resolver (orchestrator/agentDelivery.ts).
   const agentDelivery = new AgentDelivery({ control: sender, specs: agentSpecs, placement: placementResolver })
+
+  // The projections that BAKE IN the serving daemon — hook rules, HTTP-bot assignment, the
+  // collaboration snapshot. A duty grant or release moves who serves an agent exactly as a
+  // placement move does, so both go through this one fan-out rather than two copies of the list.
+  const agentRouting = new AgentRoutingConverger({
+    hooks: hookService,
+    collabRoutes,
+    // Lazy over `httpBot` (assigned below; only ever called at convergence time), the same
+    // late-binding the logger wrappers use.
+    httpBot: { syncBot: (botId: string) => httpBot.syncBot(botId) },
+    agents: repos.agent,
+    integrations: repos.integration,
+    bots: repos.bot,
+    clock,
+    delayMs: 250,
+    log: { warn: (o, m) => http.log.warn(o, m) }
+  })
 
   // Duty lease exchange riding the heartbeat (k8s daemons; orchestrator/dutyLease.ts).
   // The revision reader stamps each granted agent member with the CP's current
@@ -652,7 +672,8 @@ export function buildContainer(
     clock,
     undefined,
     { warn: (o, m) => http.log.warn(o, m) },
-    repos.agent
+    repos.agent,
+    agentRouting
   )
   // Duty-group projection: derived from Integration/CronDef rows on a rotation;
   // deltas reach daemons via the heartbeat lease exchange, never from the sweep.
@@ -665,7 +686,8 @@ export function buildContainer(
       leaseMs: DUTY_LEASE_DEFAULTS.leaseMs,
       kickDelayMs: 250
     },
-    { warn: (o, m) => http.log.warn(o, m), error: (o, m) => http.log.error(o, m) }
+    { warn: (o, m) => http.log.warn(o, m), error: (o, m) => http.log.error(o, m) },
+    agentRouting
   )
   const agentMutations = new AgentMutationGate()
 
@@ -724,6 +746,7 @@ export function buildContainer(
     mutations: agentMutations,
     sessionOwners: connReg,
     placement: placementResolver,
+    daemons: repos.daemon,
     recomputeDuties: (orgId: string) => dutyRecompute.kick(orgId),
     log: { warn: (o, m) => http.log.warn(o, m) }
   })
@@ -1032,6 +1055,7 @@ export function buildContainer(
     control: sender,
     agentDelivery,
     placementResolver,
+    daemonRows: repos.daemon,
     visibilityPush,
     relayControl,
     httpBot,

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -153,6 +153,7 @@ import { relayHttpOrigin } from './orchestrator/mcpProvider.js'
 import { CollabRoutesService } from './orchestrator/collabRoutes.service.js'
 import { DutyLeaseService, DUTY_LEASE_DEFAULTS } from './orchestrator/dutyLease.js'
 import { AgentDelivery } from './orchestrator/agentDelivery.js'
+import { PlacementResolver } from './orchestrator/placementResolver.js'
 import { DutyRecomputeSweep } from './orchestrator/dutyRecompute.js'
 import { AgentMutationGate } from './orchestrator/agentMutationGate.js'
 import { AgentMoveService } from './orchestrator/agentMove.js'
@@ -589,6 +590,20 @@ export function buildContainer(
   // deployment tenant anchor used to admit Bot Apps from the same organization.
   const feishuPlatformApps = resolveFeishuPlatformApps(config)
 
+  // The ONE answer to "which daemons serve this agent" — what its placement names, plus every
+  // current duty holder (orchestrator/placementResolver.ts).
+  const placementResolver = new PlacementResolver({
+    duties: repos.dutyGroup,
+    // Install-wide members ready to take a trigger. Only the rendezvous fallback reads this: a
+    // pool agent whose lease lapsed has no holder, and any member can claim it on receipt.
+    liveMembers: () =>
+      connReg
+        .reachableDaemons()
+        .filter((d) => d.orgId === null && d.state === 'READY')
+        .map((d) => d.daemonId),
+    clock
+  })
+
   // Hook compiler/converger (webhook-triggers-and-github-events.md): CRUD routes
   // broadcast through it, and a (re)registering relay gets the full-set replay.
   // The installation repo feeds the github-kind compile (installationIds gate).
@@ -597,6 +612,7 @@ export function buildContainer(
     repos.hookSecret,
     repos.agent,
     relayControl,
+    placementResolver,
     githubAppCfg ? repos.githubInstallation : undefined,
     githubAppCfg?.slug
   )
@@ -616,16 +632,17 @@ export function buildContainer(
 
   // Bot-agnostic collaboration routing snapshot fan-out (agent-collaboration
   // §2.3/§6.2): relays get the all-org table; daemons get their org-scoped copy.
-  const collabRoutes = new CollabRoutesService(repos.daemon, repos.integration, repos.agent, relayControl, sender)
+  const collabRoutes = new CollabRoutesService(
+    repos.daemon,
+    repos.integration,
+    repos.agent,
+    relayControl,
+    sender,
+    placementResolver
+  )
 
-  // The ONE resolver of an agent's delivery set — placement ∪ current duty
-  // holders — and the fan-out that rides it (orchestrator/agentDelivery.ts).
-  const agentDelivery = new AgentDelivery({
-    control: sender,
-    specs: agentSpecs,
-    duties: repos.dutyGroup,
-    clock
-  })
+  // The fan-out that rides the resolver (orchestrator/agentDelivery.ts).
+  const agentDelivery = new AgentDelivery({ control: sender, specs: agentSpecs, placement: placementResolver })
 
   // Duty lease exchange riding the heartbeat (k8s daemons; orchestrator/dutyLease.ts).
   // The revision reader stamps each granted agent member with the CP's current
@@ -646,7 +663,6 @@ export function buildContainer(
       intervalMs: 30_000,
       orgsPerTick: 25,
       leaseMs: DUTY_LEASE_DEFAULTS.leaseMs,
-      incumbentFence: DUTY_LEASE_DEFAULTS.grantPolicy === 'incumbent',
       kickDelayMs: 250
     },
     { warn: (o, m) => http.log.warn(o, m), error: (o, m) => http.log.error(o, m) }
@@ -678,7 +694,8 @@ export function buildContainer(
       debug: (o, m) => http.log.debug(o, m)
     },
     platforms,
-    agentDelivery
+    agentDelivery,
+    placementResolver
   )
   const stagedAgentMoves = new AgentMoveService({
     agents: repos.agent,
@@ -706,6 +723,7 @@ export function buildContainer(
     collabRoutes,
     mutations: agentMutations,
     sessionOwners: connReg,
+    placement: placementResolver,
     recomputeDuties: (orgId: string) => dutyRecompute.kick(orgId),
     log: { warn: (o, m) => http.log.warn(o, m) }
   })
@@ -744,6 +762,7 @@ export function buildContainer(
       },
       // The duty half of the reconcile roster: pinned-to-me ∪ held-by-me.
       duties: repos.dutyGroup,
+      placement: placementResolver,
       log: { warn: (o, m) => http.log.warn(o, m) } // lazy over http.log (assigned below; called at reconcile time)
     }
   )
@@ -1012,6 +1031,7 @@ export function buildContainer(
     daemonConns: connReg,
     control: sender,
     agentDelivery,
+    placementResolver,
     visibilityPush,
     relayControl,
     httpBot,
@@ -1309,6 +1329,7 @@ export function buildContainer(
   // ── daemon WS edge (mounted on the live http.Server after listen) ──────────
   const wsDeps: DaemonWsServerDeps = {
     auth,
+    placementResolver,
     lifecycleOps: repos.daemonLifecycleOp,
     registry,
     orchestrator,
@@ -1387,7 +1408,8 @@ export function buildContainer(
       conversations: repos.webchatConversation,
       sessions: repos.session,
       orgs: repos.org,
-      remoteMcp: webchatRemoteMcp
+      remoteMcp: webchatRemoteMcp,
+      placement: placementResolver
     }),
     // Current-permission fallback for GitHub comment webhooks whose
     // author_association snapshot is stale or inconsistent across event types.

--- a/packages/control-plane/src/domain/placement.ts
+++ b/packages/control-plane/src/domain/placement.ts
@@ -1,0 +1,93 @@
+/**
+ * The ONE answer to "which daemons may hold this agent's duty, and what connection scope must
+ * they have" (docs/designs/k8s-daemon-pool.md §14). Placement used to be a member id read inline
+ * as `agent.daemonId`; it is now a TARGET — `daemon` names one machine, `pool` names the
+ * install-wide member set — and every reader of eligibility comes through here.
+ *
+ * Nothing outside this module may branch on the string `pool`. A later `group` kind adds one arm
+ * here and one join in the ledger's predicate; the callers do not learn about it.
+ */
+import type { DaemonId } from './ids.js'
+
+/** Mirrors the Prisma `AgentPlacementKind` enum without importing the generated client. */
+export type PlacementKind = 'daemon' | 'pool'
+
+/** The placement columns, as every caller already has them on an agent record. */
+export interface PlacementRef {
+  placementKind: PlacementKind
+  daemonId: string | null
+}
+
+/** What a connection is allowed to claim. Install-wide = frame-mode (org-less) member. */
+export type DutyClaimScope = 'install-wide' | 'org-scoped'
+
+/**
+ * Who may hold this agent's duty.
+ * - `daemon` — exactly that machine. An install-wide member is never it, so a local daemon's
+ *   vacancies stay vacant, which is what keeps the pool off agents it must not serve.
+ * - `install-wide` — any live frame-mode member.
+ * - `none` — the agent is unplaced; nobody may hold it.
+ */
+export type DutyEligibility = { scope: 'daemon'; daemonId: DaemonId } | { scope: 'install-wide' } | { scope: 'none' }
+
+export function dutyEligibility(agent: PlacementRef): DutyEligibility {
+  if (agent.placementKind === 'pool') return { scope: 'install-wide' }
+  return agent.daemonId ? { scope: 'daemon', daemonId: agent.daemonId as DaemonId } : { scope: 'none' }
+}
+
+/** The claim scope of a connected daemon: org-less rows are the install-wide pool members. */
+export function claimScopeOf(daemon: { orgId: string | null }): DutyClaimScope {
+  return daemon.orgId === null ? 'install-wide' : 'org-scoped'
+}
+
+/** May this claimant hold this agent's duty? The predicate the ledger's SQL mirrors row-wise. */
+export function mayHold(agent: PlacementRef, claimant: { daemonId: DaemonId; scope: DutyClaimScope }): boolean {
+  const eligibility = dutyEligibility(agent)
+  if (eligibility.scope === 'none') return false
+  if (eligibility.scope === 'install-wide') return claimant.scope === 'install-wide'
+  return eligibility.daemonId === claimant.daemonId
+}
+
+/**
+ * The delivery targets placement alone names — the placement half of `AgentDelivery.daemonsFor`.
+ * A pool agent names none: its members are whoever holds the duty, which is the ledger's answer,
+ * not placement's. That is the whole reason this returns a list rather than an id.
+ */
+export function placementTargets(agent: PlacementRef): string[] {
+  const eligibility = dutyEligibility(agent)
+  return eligibility.scope === 'daemon' ? [eligibility.daemonId] : []
+}
+
+/** Is this agent placed at all? `pool` is placed without naming a machine. */
+export function isPlaced(agent: PlacementRef): boolean {
+  return dutyEligibility(agent).scope !== 'none'
+}
+
+/** Where a placement write points. `unplaced` is the absence of a target, not a third kind. */
+export type PlacementTarget = { kind: 'daemon'; daemonId: DaemonId } | { kind: 'pool' } | { kind: 'unplaced' }
+
+export const UNPLACED: PlacementTarget = { kind: 'unplaced' }
+export const ON_POOL: PlacementTarget = { kind: 'pool' }
+export const onDaemon = (daemonId: DaemonId): PlacementTarget => ({ kind: 'daemon', daemonId })
+
+export function placementTargetOf(agent: PlacementRef): PlacementTarget {
+  if (agent.placementKind === 'pool') return { kind: 'pool' }
+  return agent.daemonId ? { kind: 'daemon', daemonId: agent.daemonId as DaemonId } : UNPLACED
+}
+
+/** The two columns a target writes. `pool` clears `daemonId`: a pool agent names no machine, and
+ *  leaving a stale member id there is exactly the dead-Pod pointer this representation removes. */
+export function placementColumns(target: PlacementTarget): { placementKind: PlacementKind; daemonId: string | null } {
+  if (target.kind === 'pool') return { placementKind: 'pool', daemonId: null }
+  return { placementKind: 'daemon', daemonId: target.kind === 'daemon' ? target.daemonId : null }
+}
+
+export function samePlacement(a: PlacementTarget, b: PlacementTarget): boolean {
+  if (a.kind !== b.kind) return false
+  return a.kind !== 'daemon' || a.daemonId === (b as { daemonId: DaemonId }).daemonId
+}
+
+/** A stable label for logs and conflict messages — never a raw member id for a pool placement. */
+export function placementLabel(target: PlacementTarget): string {
+  return target.kind === 'daemon' ? target.daemonId : target.kind
+}

--- a/packages/control-plane/src/hooks/hook.service.test.ts
+++ b/packages/control-plane/src/hooks/hook.service.test.ts
@@ -93,7 +93,11 @@ function make(
     hookRemove: (id: string) => removes.push(id)
   } as unknown as RelayControlSender
   const installations = opts.installations ? { listForOrg: vi.fn(async () => opts.installations!) } : undefined
-  return { svc: new HookService(hooks, secrets, agents, relayControl, installations, opts.appSlug), assigns, removes }
+  return {
+    svc: new HookService(hooks, secrets, agents, relayControl, undefined, installations, opts.appSlug),
+    assigns,
+    removes
+  }
 }
 
 describe('HookService.compile', () => {
@@ -241,7 +245,7 @@ describe('HookService.replayTo', () => {
         throw new Error('db blip')
       })
     }
-    const svc = new HookService(hooks, secrets, agents, {} as RelayControlSender, installations, undefined, {
+    const svc = new HookService(hooks, secrets, agents, {} as RelayControlSender, undefined, installations, undefined, {
       warn: vi.fn()
     })
     const sent: string[] = []

--- a/packages/control-plane/src/hooks/hook.service.ts
+++ b/packages/control-plane/src/hooks/hook.service.ts
@@ -26,6 +26,7 @@ import type {
   HookSecretStore
 } from '../persistence/ports.js'
 import type { RelayControlSender } from '../orchestrator/relayControl.js'
+import { PLACEMENT_ONLY, type PlacementResolver } from '../orchestrator/placementResolver.js'
 import type { RelayChannel } from '../ws/relay-registry.js'
 import { toDbPlatform } from '../persistence/platform.js'
 
@@ -44,6 +45,8 @@ export class HookService {
     private readonly secrets: HookSecretStore,
     private readonly agents: HookAgentReads,
     private readonly relayControl: RelayControlSender,
+    /** Names the member a compiled rule dispatches to (placement, or the current duty holder). */
+    private readonly placement: Pick<PlacementResolver, 'servingDaemon'> = PLACEMENT_ONLY,
     /** github-kind compile source: the org's live installation set (the relay's
      *  runtime attribution gate, decision 6). Absent ⇒ github hooks never compile
      *  (deployment without the GitHub App). */
@@ -63,7 +66,11 @@ export class HookService {
   async compile(hook: HookRecord): Promise<RcHookAssign | null> {
     if (!hook.enabled || !hook.agentId) return null
     const agent = await this.agents.getUnscoped(hook.agentId)
-    if (!agent?.daemonId) return null
+    // The relay needs one member to address; for a pool agent that is the current duty holder,
+    // since placement names none. Nothing serving it ⇒ the rule leaves the relay pool, exactly as
+    // an unplaced agent's does.
+    const agentDaemonId = agent ? await this.placement.servingDaemon(agent) : null
+    if (!agent || !agentDaemonId) return null
     const snapshot =
       typeof hook.configRevision === 'bigint' &&
       typeof hook.dispatchRevision === 'bigint' &&
@@ -73,7 +80,7 @@ export class HookService {
         ? {
             configRevision: hook.configRevision.toString(),
             dispatchRevision: hook.dispatchRevision.toString(),
-            dispatchDaemonId: agent.daemonId,
+            dispatchDaemonId: agentDaemonId,
             reviewPolicy: hook.kind === 'github' ? hook.reviewPolicy : ('off' as const),
             reportingMode: hook.kind === 'github' ? hook.reportingMode : ('off' as const),
             gateMode: hook.kind === 'github' ? hook.gateMode : ('informational' as const)
@@ -82,7 +89,7 @@ export class HookService {
     const base = {
       hookId: hook.id,
       agentId: hook.agentId,
-      daemonId: agent.daemonId,
+      daemonId: agentDaemonId,
       ...snapshot,
       sessionMode: hook.sessionMode,
       // Anchoring target only when a channel is set (null channel ⇒ headless);

--- a/packages/control-plane/src/hooks/hook.service.ts
+++ b/packages/control-plane/src/hooks/hook.service.ts
@@ -46,7 +46,7 @@ export class HookService {
     private readonly agents: HookAgentReads,
     private readonly relayControl: RelayControlSender,
     /** Names the member a compiled rule dispatches to (placement, or the current duty holder). */
-    private readonly placement: Pick<PlacementResolver, 'servingDaemon'> = PLACEMENT_ONLY,
+    private readonly placement: Pick<PlacementResolver, 'routableDaemon'> = PLACEMENT_ONLY,
     /** github-kind compile source: the org's live installation set (the relay's
      *  runtime attribution gate, decision 6). Absent ⇒ github hooks never compile
      *  (deployment without the GitHub App). */
@@ -69,7 +69,7 @@ export class HookService {
     // The relay needs one member to address; for a pool agent that is the current duty holder,
     // since placement names none. Nothing serving it ⇒ the rule leaves the relay pool, exactly as
     // an unplaced agent's does.
-    const agentDaemonId = agent ? await this.placement.servingDaemon(agent) : null
+    const agentDaemonId = agent ? await this.placement.routableDaemon(agent) : null
     if (!agent || !agentDaemonId) return null
     const snapshot =
       typeof hook.configRevision === 'bigint' &&

--- a/packages/control-plane/src/http/daemon-removal.ts
+++ b/packages/control-plane/src/http/daemon-removal.ts
@@ -21,6 +21,7 @@
  */
 import type { FastifyBaseLogger } from 'fastify'
 import type { AgentId, DaemonId, OrgId } from '../domain/ids.js'
+import { UNPLACED } from '../domain/placement.js'
 import type { HttpDeps } from './deps.js'
 
 /** Just enough of an agent to re-converge what pointed at it. */
@@ -47,7 +48,7 @@ export async function detachDaemon(
   // `daemonId` with `status` — and going through the repo is also what revokes
   // the agents' webchat MCP delegations and bumps their hook dispatchRevision,
   // exactly as an operator-initiated unplacement would.
-  for (const agent of placedAgents) await deps.repos.agent.setPlacement(agent.id, null)
+  for (const agent of placedAgents) await deps.repos.agent.setPlacement(agent.id, UNPLACED)
   await deps.registry.remove(orgId, daemonId)
   await settleAfterRemoval(deps, daemonId, placedAgents, log)
 }

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -46,6 +46,7 @@ import type {
   GithubInstallationRepo,
   AgentRepoAuthorizationRepo,
   DaemonLifecycleOpRepo,
+  DaemonRepo,
   OAuthRepo,
   WebchatMcpOperationRepo
 } from '../persistence/ports.js'
@@ -275,6 +276,9 @@ export interface HttpDeps {
    *  instead of reading `agent.daemonId`, which stopped naming a machine when `pool` became a
    *  placement target. */
   placementResolver: PlacementResolver
+  /** Daemon rows, unscoped — a move needs the SOURCE's own scope to decide whether it is still an
+   *  eligible holder of the new placement, which is a property of the row, not of its liveness. */
+  daemonRows?: Pick<DaemonRepo, 'getUnscoped'>
   /** Pushes the per-session memory-capture gate to the owning daemons after a
    *  §4.3 visibility change, and answers the pending/applied cutover state
    *  (session-visibility.md §5.1). Absent ⇒ changes converge on register. */

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -64,6 +64,7 @@ import type { OrgInviteLinkService } from '../registry/orgInviteLinkService.js'
 import type { WaitlistService } from '../registry/waitlistService.js'
 import type { ControlSender } from '../orchestrator/outbound.js'
 import type { AgentDelivery } from '../orchestrator/agentDelivery.js'
+import type { PlacementResolver } from '../orchestrator/placementResolver.js'
 import type { SessionVisibilityPushService } from '../orchestrator/visibilityPush.js'
 import type { AgentSpecAssembler } from '../orchestrator/agentSpecAssembler.js'
 import type { RelayControlSender } from '../orchestrator/relayControl.js'
@@ -270,6 +271,10 @@ export interface HttpDeps {
    *  fans `agent/upsert`/`agent/remove` out over it. EVERY replicate site routes
    *  through this; none of them reads `agent.daemonId` to decide delivery. */
   agentDelivery: AgentDelivery
+  /** The ONE answer to "which daemons serve this agent" (placement ∪ duty holders). Routes ask it
+   *  instead of reading `agent.daemonId`, which stopped naming a machine when `pool` became a
+   *  placement target. */
+  placementResolver: PlacementResolver
   /** Pushes the per-session memory-capture gate to the owning daemons after a
    *  §4.3 visibility change, and answers the pending/applied cutover state
    *  (session-visibility.md §5.1). Absent ⇒ changes converge on register. */

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -557,6 +557,8 @@ export const CreateAgentBody = z.object({
   skills: SkillEnableBody.optional(),
   managedSkills: ManagedSkillEnableBody.optional(),
   memory: MemoryConfigBody.optional(), // memory backend; absent ⇒ managed default
+  // Placement at create. `pool` needs no id; `daemon` (the default) uses `daemonId`.
+  placementKind: z.enum(['daemon', 'pool']).optional(),
   daemonId: z.string().optional(), // the owning daemon, if chosen at create
   workspace: AgentWorkspaceInputBody.optional(), // absent ⇒ scratch; the cold editor can replace either mode later
   capabilities: z.array(z.string()).default([]),
@@ -618,7 +620,20 @@ export const UpdateAgentBody = z
  * drains one daemon, reprovisions another, and does not migrate local state.
  * `force` is the explicit disaster-recovery path for a source that cannot ACK
  * its detach; every target-side admission check still applies. */
-export const SetAgentDaemonBody = z.object({ daemonId: z.string().uuid(), force: z.boolean().optional() }).strict()
+export const SetAgentDaemonBody = z
+  .object({
+    // The placement TARGET. `daemon` names one machine through `daemonId`; `pool` names the
+    // install-wide member set and carries no id at all — whichever member holds the agent's duty
+    // serves it, so pinning one here is exactly the dead-Pod pointer this replaced. Omitted ⇒
+    // `daemon`, so an existing client that sends only `daemonId` still means what it meant.
+    placementKind: z.enum(['daemon', 'pool']).optional(),
+    daemonId: z.string().uuid().optional(),
+    force: z.boolean().optional()
+  })
+  .strict()
+  .refine((b) => (b.placementKind === 'pool' ? b.daemonId === undefined : b.daemonId !== undefined), {
+    message: 'daemonId is required for a daemon placement and must be omitted for a pool placement'
+  })
 
 /** Full desired workspace definition for the acknowledged cold edit path. */
 export const SetAgentWorkspaceBody = z.discriminatedUnion('mode', [
@@ -681,7 +696,14 @@ export const AgentDto = z.object({
   managedSkills: z.array(z.string().uuid()), // explicitly enabled accepted managed-skill ids
   memory: MemoryConfigBody.nullable(), // memory backend (null ⇒ managed default)
   status: z.string(),
+  // What the placement NAMES. `pool` carries a null `daemonId` on purpose: no member id is
+  // durable, so the console must read readiness from `placementReady` rather than from a machine.
+  placementKind: z.enum(['daemon', 'pool']),
   daemonId: z.string().nullable(),
+  /** Can a session start right now? For a `daemon` placement that is its daemon's liveness; for a
+   *  `pool` placement it is "some live member could serve this", which is the question the console
+   *  was answering with a dead Pod's id (#987). */
+  placementReady: z.boolean(),
   workspace: AgentWorkspaceBody,
   /** Rename-proof numeric identity of the GitHub workspace repository. Null
    * for scratch/anonymous or legacy rows that have not been repaired yet. */

--- a/packages/control-plane/src/http/install-bot.ts
+++ b/packages/control-plane/src/http/install-bot.ts
@@ -123,7 +123,6 @@ export async function installNewBot(
   // because a freshly pasted credential that reaches only the placement leaves the
   // holder authenticating with the old one. Best-effort — an offline daemon picks
   // it up from the register/ok reconcile roster. Never log the token-bearing spec.
-  const daemonId = agent.daemonId! // caller guarantees placement for socket transport
   // The bot row joins the reads: it is a required input of the §9 projector that
   // assembles the spec payload (`orchestrator/placement.ts`). `bot` was created
   // above, so this is the same row, not a second fetch.
@@ -133,7 +132,7 @@ export async function installNewBot(
   ])
   if (secret) {
     const spec = await integrationToSpec(deps.platforms, integration, bot, secret, channels, isGatedAgent(agent))
-    await deps.agentDelivery.integrationUpsert(agent.id, daemonId, spec, (err, target) => {
+    await deps.agentDelivery.integrationUpsert(agent, spec, (err, target) => {
       if (!(err instanceof NoConnection)) throw err
       log.debug({ integrationId: id, daemonId: target }, 'integration/upsert skipped: daemon offline')
     })

--- a/packages/control-plane/src/http/install-feishu.ts
+++ b/packages/control-plane/src/http/install-feishu.ts
@@ -112,7 +112,7 @@ export async function installNewFeishuBot(
   ])
   if (secret && botRow) {
     const spec = await integrationToSpec(deps.platforms, integration, botRow, secret, channels, isGatedAgent(agent))
-    await deps.agentDelivery.integrationUpsert(agent.id, agent.daemonId, spec, (err, target) => {
+    await deps.agentDelivery.integrationUpsert(agent, spec, (err, target) => {
       if (!(err instanceof NoConnection)) throw err
       log.debug({ integrationId: id, daemonId: target }, 'integration/upsert skipped: daemon offline')
     })

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1007,7 +1007,7 @@ export function agentRoutes(deps: HttpDeps) {
       if (added.length === 0 && removed.length === 0) return
       // Every daemon serving this agent, not just its placement: a duty holder
       // installed the same enable-list and needs the same defs.
-      const targets = await deps.agentDelivery.daemonsFor(agent.id, agent.daemonId)
+      const targets = await deps.agentDelivery.daemonsFor(agent)
       if (targets.length === 0) return
       try {
         const byName = new Map((await deps.repos.mcpProvider.listForOrg(orgId)).map((p) => [p.name, p]))
@@ -1256,7 +1256,7 @@ export function agentRoutes(deps: HttpDeps) {
     /** Every daemon serving this agent gets the connection before the spec that
      *  names it — a duty holder included, or its memory admission stays closed. */
     const pushExternalMemoryBeforeAgent = async (agent: AgentRecord): Promise<void> => {
-      for (const daemonId of await deps.agentDelivery.daemonsFor(agent.id, agent.daemonId)) {
+      for (const daemonId of await deps.agentDelivery.daemonsFor(agent)) {
         await pushExternalMemoryToDaemon(agent, daemonId)
       }
     }
@@ -1290,7 +1290,7 @@ export function agentRoutes(deps: HttpDeps) {
       ) {
         return
       }
-      for (const daemonId of await deps.agentDelivery.daemonsFor(before.id, before.daemonId)) {
+      for (const daemonId of await deps.agentDelivery.daemonsFor(before)) {
         await removeExternalMemoryFromDaemonIfUnused(before.orgId, daemonId, connectionId)
       }
     }
@@ -1312,6 +1312,7 @@ export function agentRoutes(deps: HttpDeps) {
       mutations: deps.agentMutations,
       sessionOwners: deps.sessionOwners,
       placement: deps.placementResolver,
+      ...(deps.daemonRows ? { daemons: deps.daemonRows } : {}),
       ...(deps.recomputeDuties ? { recomputeDuties: deps.recomputeDuties } : {}),
       log: app.log
     })
@@ -1353,12 +1354,18 @@ export function agentRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
         const conflict = (message: string) => reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
-        // Placement accepts visible org-owned daemons and install-wide cloud members, never another org's daemon.
-        const placedDaemon =
-          req.body.daemonId !== undefined
+        // Placement accepts visible org-owned daemons and install-wide cloud members, never another
+        // org's daemon — or the POOL, which names no member and is validated against the live
+        // member set instead, exactly like the move route's pool target.
+        const wantsPool = req.body.placementKind === 'pool'
+        const poolMembers = wantsPool ? await readyPoolMembers(deps, orgOf(req)) : []
+        if (wantsPool && poolMembers.length === 0) return conflict('no cloud daemon member is ready')
+        const placedDaemon = wantsPool
+          ? (poolMembers[0] ?? null)
+          : req.body.daemonId !== undefined
             ? await deps.registry.getAvailable(orgOf(req), DaemonId(req.body.daemonId))
             : null
-        if (req.body.daemonId !== undefined) {
+        if (!wantsPool && req.body.daemonId !== undefined) {
           if (!placedDaemon || !canView(placedDaemon, ctxOf(req))) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
           }
@@ -1554,7 +1561,11 @@ export function agentRoutes(deps: HttpDeps) {
                   ...(req.body.skills !== undefined ? { skills: req.body.skills } : {}),
                   ...(req.body.managedSkills !== undefined ? { managedSkills: req.body.managedSkills } : {}),
                   ...(req.body.memory !== undefined ? { memory: req.body.memory } : {}),
-                  ...(req.body.daemonId !== undefined ? { daemonId: DaemonId(req.body.daemonId) } : {}),
+                  ...(wantsPool
+                    ? { placementKind: 'pool' as const }
+                    : req.body.daemonId !== undefined
+                      ? { daemonId: DaemonId(req.body.daemonId) }
+                      : {}),
                   ...(workspace !== undefined ? { workspace } : {}),
                   ...(workspaceRepoId !== undefined ? { workspaceRepoId } : {}),
                   ...(req.principal ? { createdByUserId: req.principal.userId } : {}),

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -58,7 +58,15 @@ import {
   isSyntheticEmail
 } from '../../persistence/ports.js'
 import type { DaemonView } from '../../ports.js'
-import { AgentId, DaemonId, SessionId, type OrgId } from '../../domain/ids.js'
+import { AgentId, DaemonId, OrgId, SessionId } from '../../domain/ids.js'
+import {
+  dutyEligibility,
+  ON_POOL,
+  placementLabel,
+  placementTargetOf,
+  type PlacementTarget
+} from '../../domain/placement.js'
+import type { ResolvableAgent } from '../../orchestrator/placementResolver.js'
 import { currentMcpGrant, mcpProxyDef, relayHttpOrigin } from '../../orchestrator/mcpProvider.js'
 import { serializeByProviderNames } from './mcp-providers.js'
 
@@ -256,7 +264,7 @@ function toDto(
   secretKeys: string[],
   hookKinds: AgentDtoT['hookKinds'],
   iconBases: IconUrlBases,
-  sandboxPolicy: SandboxPolicy,
+  placementView: PlacementView,
   // Organization entries assigned to THIS agent. Metadata only: variable values
   // plus secret KEY names, resolved without decrypting anything (design §6).
   organizationEnvironment: AssignedOrganizationMetadata = NO_ORGANIZATION_ENVIRONMENT
@@ -297,7 +305,9 @@ function toDto(
     managedSkills: a.managedSkills,
     memory: a.memory,
     status: a.status,
+    placementKind: a.placementKind,
     daemonId: a.daemonId,
+    placementReady: placementView.ready,
     workspace: workspaceToDto(a.workspace),
     workspaceRepoId: a.workspaceRepoId?.toString() ?? null,
     capabilities: a.capabilities,
@@ -319,17 +329,45 @@ function toDto(
     allowedTargetAgentIds: a.allowedTargetAgentIds,
     introduceOnJoin: a.introduceOnJoin,
     runInSandbox: a.runInSandbox,
-    sandboxSupported: sandboxPolicy.supported,
-    sandboxRequired: sandboxPolicy.required,
+    sandboxSupported: placementView.sandbox.supported,
+    sandboxRequired: placementView.sandbox.required,
     hookKinds
   }
 }
 
-/** #642: sandbox capability and policy for an org-owned or install-wide placement. */
-async function sandboxPolicyFor(deps: HttpDeps, a: AgentRecord): Promise<SandboxPolicy> {
-  if (!a.daemonId) return UNAVAILABLE_SANDBOX
-  // The org-fenced agent read supplies the availability scope for its daemon.
-  return sandboxPolicyOf(await deps.registry.getAvailable(a.orgId, a.daemonId))
+/**
+ * What placement says the console needs to know: the sandbox policy (#642) and whether a session
+ * can start right now. Both come from ONE resolution of "who may serve this agent", so they can
+ * never disagree — and for a pool placement that resolution is "is any member live", not "is the
+ * member this row names live", which is the question a rollout made unanswerable (#987).
+ */
+interface PlacementView {
+  sandbox: SandboxPolicy
+  ready: boolean
+}
+
+const NO_PLACEMENT: PlacementView = { sandbox: UNAVAILABLE_SANDBOX, ready: false }
+
+function placementViewOf(deps: HttpDeps, daemon: DaemonView | null): PlacementView {
+  const live = daemon ? deps.liveness.get(daemon.daemonId) : undefined
+  return { sandbox: sandboxPolicyOf(daemon), ready: live?.reachable === true && live.state === 'READY' }
+}
+
+/** The install-wide members that could serve an agent right now. One read; reuse it for a page. */
+async function readyPoolMembers(deps: HttpDeps, orgId: OrgId): Promise<DaemonView[]> {
+  const daemons = await deps.registry.listAvailable(orgId)
+  return daemons.filter((d) => d.orgId === null && placementViewOf(deps, d).ready)
+}
+
+async function placementViewFor(deps: HttpDeps, a: AgentRecord, poolMembers?: DaemonView[]): Promise<PlacementView> {
+  const eligibility = dutyEligibility(a)
+  if (eligibility.scope === 'none') return NO_PLACEMENT
+  if (eligibility.scope === 'daemon') {
+    // The org-fenced agent read supplies the availability scope for its daemon.
+    return placementViewOf(deps, await deps.registry.getAvailable(a.orgId, eligibility.daemonId))
+  }
+  const members = poolMembers ?? (await readyPoolMembers(deps, OrgId(a.orgId)))
+  return placementViewOf(deps, members[0] ?? null)
 }
 
 /** The dto's hook-kind marks for ONE agent (single-agent reads/writes). */
@@ -752,6 +790,22 @@ export function agentRoutes(deps: HttpDeps) {
       return canView(agent, ctxOf(req)) ? agent : null
     }
 
+    /**
+     * The same read, with `daemonId` resolved to the member that SERVES the agent right now
+     * instead of the one its placement names. Every daemon-edge proxy below (workspace, git,
+     * memory, dreams, tasks, skills, permissions) loads through this, because for a `pool`
+     * placement the row names no machine at all and the live answer is the ledger's.
+     *
+     * Deliberately NOT used by the placement-authoritative routes — create, PATCH, move, delete —
+     * which compare and write the placement itself and must see what the row says.
+     */
+    const getServingAgent = async (req: FastifyRequest, id: string): Promise<AgentRecord | null> => {
+      const agent = await getOrgAgent(req, id)
+      if (!agent) return null
+      const daemonId = await deps.placementResolver.servingDaemon(agent)
+      return { ...agent, daemonId }
+    }
+
     // A session worktree is part of that session's protected body surface. The
     // caller must pass both the owning-agent gate above and the session's own
     // private/external visibility rule before its daemon-local files are read.
@@ -919,10 +973,10 @@ export function agentRoutes(deps: HttpDeps) {
         }
       })
 
-    const replicateRemove = (agentId: string, daemonId: string | null, orgId: string): Promise<void> =>
-      deps.agentDelivery.remove(agentId, daemonId, orgId, (err, target) => {
+    const replicateRemove = (agent: ResolvableAgent, orgId: string): Promise<void> =>
+      deps.agentDelivery.remove(agent, orgId, (err, target) => {
         if (!(err instanceof NoConnection)) throw err
-        app.log.debug({ agentId, daemonId: target }, 'agent/remove skipped: daemon offline')
+        app.log.debug({ agentId: agent.id, daemonId: target }, 'agent/remove skipped: daemon offline')
       })
 
     // The alive relay's HTTP origin for MCP proxy defs (ws→http/wss→https), or null
@@ -1257,6 +1311,8 @@ export function agentRoutes(deps: HttpDeps) {
       collabRoutes: deps.collabRoutes,
       mutations: deps.agentMutations,
       sessionOwners: deps.sessionOwners,
+      placement: deps.placementResolver,
+      ...(deps.recomputeDuties ? { recomputeDuties: deps.recomputeDuties } : {}),
       log: app.log
     })
     const refreshMutationAgent = async (observed: AgentRecord): Promise<AgentRecord | null> => {
@@ -1569,7 +1625,7 @@ export function agentRoutes(deps: HttpDeps) {
               await secretKeysOf(agent.orgId, agent.id),
               await hookKindsOf(deps, agent.id),
               iconBasesOf(deps),
-              sandboxPolicy,
+              await placementViewFor(deps, agent),
               // Create already enrolled the agent into the org's `all` entries in
               // its own transaction, so the response shows what will actually apply.
               await organizationEnvironmentOf(agent)
@@ -1619,15 +1675,23 @@ export function agentRoutes(deps: HttpDeps) {
         )
         // ONE batched resolve for the whole page (design §6) — never a query per agent.
         const organizationEnvironment = await organizationEnvironmentOfAll(orgOf(req), rows)
+        // Two batched resolves for the whole page: the named daemons, and the pool once.
         const daemonIds = [...new Set(rows.flatMap((a) => (a.daemonId ? [a.daemonId] : [])))]
-        const policies = new Map(
+        const views = new Map(
           await Promise.all(
             daemonIds.map(
               async (daemonId) =>
-                [daemonId, sandboxPolicyOf(await deps.registry.getAvailable(orgOf(req), daemonId))] as const
+                [daemonId, placementViewOf(deps, await deps.registry.getAvailable(orgOf(req), daemonId))] as const
             )
           )
         )
+        const poolMembers = await readyPoolMembers(deps, orgOf(req))
+        const poolView = placementViewOf(deps, poolMembers[0] ?? null)
+        const viewFor = (a: AgentRecord): PlacementView => {
+          const eligibility = dutyEligibility(a)
+          if (eligibility.scope === 'none') return NO_PLACEMENT
+          return eligibility.scope === 'daemon' ? (views.get(eligibility.daemonId) ?? NO_PLACEMENT) : poolView
+        }
         return rows.map((a) =>
           toDto(
             a,
@@ -1635,7 +1699,7 @@ export function agentRoutes(deps: HttpDeps) {
             secretKeys.get(a.id) ?? [],
             hookKinds.get(a.id) ?? [],
             iconBasesOf(deps),
-            a.daemonId ? (policies.get(a.daemonId) ?? UNAVAILABLE_SANDBOX) : UNAVAILABLE_SANDBOX,
+            viewFor(a),
             organizationEnvironment.get(a.id) ?? NO_ORGANIZATION_ENVIRONMENT
           )
         )
@@ -1663,7 +1727,7 @@ export function agentRoutes(deps: HttpDeps) {
           await secretKeysOf(agent.orgId, agent.id),
           await hookKindsOf(deps, agent.id),
           iconBasesOf(deps),
-          await sandboxPolicyFor(deps, agent),
+          await placementViewFor(deps, agent),
           await organizationEnvironmentOf(agent)
         )
       }
@@ -1722,7 +1786,7 @@ export function agentRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
@@ -1770,7 +1834,7 @@ export function agentRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
@@ -1866,15 +1930,15 @@ export function agentRoutes(deps: HttpDeps) {
               .code(409)
               .send({ error: 'Conflict', statusCode: 409, message: 'agent changed; refresh and retry the edit' })
           }
-          const sandboxPolicy = await sandboxPolicyFor(deps, existing)
-          if (sandboxPolicy.required && req.body.runInSandbox === false) {
+          const placementView = await placementViewFor(deps, existing)
+          if (placementView.sandbox.required && req.body.runInSandbox === false) {
             return reply.code(409).send({
               error: 'Conflict',
               statusCode: 409,
               message: 'Run in sandbox is required by this daemon'
             })
           }
-          if (!sandboxPolicy.supported && req.body.runInSandbox === true) {
+          if (!placementView.sandbox.supported && req.body.runInSandbox === true) {
             return reply.code(409).send({
               error: 'Conflict',
               statusCode: 409,
@@ -2022,7 +2086,7 @@ export function agentRoutes(deps: HttpDeps) {
             await secretKeysOf(agent.orgId, agent.id),
             await hookKindsOf(deps, agent.id),
             iconBasesOf(deps),
-            sandboxPolicy,
+            placementView,
             // A PATCH may also have enrolled the agent into `all` entries added
             // since its last edit, so re-resolve rather than echoing the request.
             await organizationEnvironmentOf(agent)
@@ -2167,7 +2231,7 @@ export function agentRoutes(deps: HttpDeps) {
             await secretKeysOf(converted.orgId, converted.id),
             await hookKindsOf(deps, converted.id),
             iconBasesOf(deps),
-            await sandboxPolicyFor(deps, converted),
+            await placementViewFor(deps, converted),
             await organizationEnvironmentOf(converted)
           )
         } catch (err) {
@@ -2224,99 +2288,139 @@ export function agentRoutes(deps: HttpDeps) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
         }
 
-        const target = await deps.registry.getAvailable(orgOf(req), DaemonId(req.body.daemonId))
-        if (!target || !canView(target, ctxOf(req))) {
-          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
-        }
-
         const conflict = (message: string) => reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
         const force = req.body.force === true
-        // Deferred exec config (preset-agents.md §3.2): placement is where a
-        // runtime becomes mandatory — an unplaced preset carries none until the
-        // user (or M1 auto-placement) chooses one.
-        if (!existing.runtime) {
-          return conflict('agent has no runtime yet — set a runtime before placing it on a daemon')
-        }
+        const wantsPool = req.body.placementKind === 'pool'
         const moveReady = (daemonId: string) => {
           const live = deps.liveness.get(daemonId)
           return live?.reachable === true && live.state === 'READY'
         }
         const MOVE_FEATURE = 'agent-move-v1'
 
-        if (!moveReady(target.daemonId)) return conflict('target daemon is not ready')
-        if (!target.capabilities.features.includes(MOVE_FEATURE)) {
-          return conflict('target daemon does not support agent moves')
-        }
-        if (existing.managedSkills.length > 0 && !organizationKnowledgeSupportedOn(target)) {
-          return conflict('target daemon does not support organization knowledge managed skills')
-        }
-        // Rollout gate (organization-secrets-and-variables.md §10 step 3): an agent
-        // bound to an organization entry receives FULL resolved env/secret maps, and
-        // that is only safe on a daemon that persists `configRevision` and refuses an
-        // older snapshot. An unplaced bound agent may be saved; placing it requires
-        // the feature. Deliberately not "old daemons ignore the optional field" — a
-        // late-completing older snapshot there would reinstate a rotated value.
-        if ((await organizationEnvironmentBindingCount(existing)) > 0 && !configRevisionSupportedOn(target)) {
-          return conflict(
-            'target daemon does not yet support organization variables and secrets, which this agent is assigned; upgrade it first'
-          )
-        }
-        const targetRuntime = target.runtimeProfiles.find((p) => p.runtime === existing.runtime)
-        if (target.runtimeProfiles.length > 0 && !targetRuntime) {
-          return conflict(`target daemon does not support runtime ${existing.runtime}`)
-        }
-        // A 'cached' model list (hydrated from the daemon's last-good cache, not
-        // confirmed by a live probe this process) is permissive exactly like an
-        // empty one — only a probed list enforces membership, so a daemon that
-        // restarted mid-upgrade never strands a move on a stale hydrated list
-        // (runtime-model-catalog.md §5).
-        if (
-          existing.model &&
-          targetRuntime &&
-          targetRuntime.modelsSource !== 'cached' &&
-          targetRuntime.models.length > 0 &&
-          !targetRuntime.models.includes(existing.model)
-        ) {
-          return conflict(`target daemon does not support model ${existing.model} for runtime ${existing.runtime}`)
-        }
-        for (const name of existing.mcpServers) {
-          const server = target.mcpServers.find((candidate) => candidate.name === name)
-          if (!server) return conflict(`target daemon cannot attach MCP server ${name}`)
-          const caps = targetRuntime?.mcpCapabilities
-          const transportSupported =
-            server.transport === 'stdio' || !caps || (server.transport === 'http' ? caps.http : caps.sse)
-          if (!transportSupported) {
-            return conflict(
-              `target runtime ${existing.runtime} does not support MCP ${server.transport} transport for ${name}`
+        // The daemons the target admits. A `daemon` target is one machine and every check below
+        // is about that machine. A `pool` target names the install-wide member set, and the CP
+        // does not get to choose which member serves the agent — so the checks are evaluated
+        // against the UNION of live members: the target is admissible when SOME live member could
+        // serve this agent today. Members are one Deployment of one image, so union and
+        // intersection differ only mid-rollout, and there the ledger's install-on-grant refusal
+        // is the backstop that keeps a member from holding what it cannot install.
+        const candidates = wantsPool
+          ? (await deps.registry.listAvailable(orgOf(req))).filter(
+              (d) => d.orgId === null && moveReady(d.daemonId) && canView(d, ctxOf(req))
             )
+          : await (async () => {
+              const one = await deps.registry.getAvailable(orgOf(req), DaemonId(req.body.daemonId!))
+              return one && canView(one, ctxOf(req)) ? [one] : []
+            })()
+        if (candidates.length === 0) {
+          if (!wantsPool) {
+            return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
           }
+          return conflict('no cloud daemon member is ready')
         }
-        if (
-          existing.daemonId !== target.daemonId &&
-          target.load &&
-          target.maxAgents > 0 &&
-          target.load.agents >= target.maxAgents
-        ) {
-          return conflict('target daemon is at agent capacity')
+
+        // Deferred exec config (preset-agents.md §3.2): placement is where a
+        // runtime becomes mandatory — an unplaced preset carries none until the
+        // user (or M1 auto-placement) chooses one.
+        if (!existing.runtime) {
+          return conflict('agent has no runtime yet — set a runtime before placing it on a daemon')
         }
+
+        const placement = placementTargetOf(existing)
+        const samePlacementTarget = wantsPool
+          ? placement.kind === 'pool'
+          : placement.kind === 'daemon' && placement.daemonId === req.body.daemonId
+
+        /** Why this daemon cannot take the agent, or null when it can. */
+        const admits = async (daemon: DaemonView): Promise<string | null> => {
+          if (!moveReady(daemon.daemonId)) return 'target daemon is not ready'
+          if (!daemon.capabilities.features.includes(MOVE_FEATURE)) return 'target daemon does not support agent moves'
+          if (existing.managedSkills.length > 0 && !organizationKnowledgeSupportedOn(daemon)) {
+            return 'target daemon does not support organization knowledge managed skills'
+          }
+          // Rollout gate (organization-secrets-and-variables.md §10 step 3): an agent
+          // bound to an organization entry receives FULL resolved env/secret maps, and
+          // that is only safe on a daemon that persists `configRevision` and refuses an
+          // older snapshot. An unplaced bound agent may be saved; placing it requires
+          // the feature. Deliberately not "old daemons ignore the optional field" — a
+          // late-completing older snapshot there would reinstate a rotated value.
+          if ((await organizationEnvironmentBindingCount(existing)) > 0 && !configRevisionSupportedOn(daemon)) {
+            return 'target daemon does not yet support organization variables and secrets, which this agent is assigned; upgrade it first'
+          }
+          const targetRuntime = daemon.runtimeProfiles.find((p) => p.runtime === existing.runtime)
+          if (daemon.runtimeProfiles.length > 0 && !targetRuntime) {
+            return `target daemon does not support runtime ${existing.runtime}`
+          }
+          // A 'cached' model list (hydrated from the daemon's last-good cache, not
+          // confirmed by a live probe this process) is permissive exactly like an
+          // empty one — only a probed list enforces membership, so a daemon that
+          // restarted mid-upgrade never strands a move on a stale hydrated list
+          // (runtime-model-catalog.md §5).
+          if (
+            existing.model &&
+            targetRuntime &&
+            targetRuntime.modelsSource !== 'cached' &&
+            targetRuntime.models.length > 0 &&
+            !targetRuntime.models.includes(existing.model)
+          ) {
+            return `target daemon does not support model ${existing.model} for runtime ${existing.runtime}`
+          }
+          for (const name of existing.mcpServers) {
+            const server = daemon.mcpServers.find((candidate) => candidate.name === name)
+            if (!server) return `target daemon cannot attach MCP server ${name}`
+            const caps = targetRuntime?.mcpCapabilities
+            const transportSupported =
+              server.transport === 'stdio' || !caps || (server.transport === 'http' ? caps.http : caps.sse)
+            if (!transportSupported) {
+              return `target runtime ${existing.runtime} does not support MCP ${server.transport} transport for ${name}`
+            }
+          }
+          // Capacity is a per-member fact even on the pool: "some member has headroom" is exactly
+          // the condition the ledger's own headroom gate applies when it hands out the duty.
+          if (!samePlacementTarget && daemon.load && daemon.maxAgents > 0 && daemon.load.agents >= daemon.maxAgents) {
+            return 'target daemon is at agent capacity'
+          }
+          return null
+        }
+
+        // First admitting candidate wins; a pool target refuses only when EVERY live member
+        // refuses, and then it reports the first member's reason rather than inventing one.
+        let target: DaemonView | undefined
+        let refusal: string | null = null
+        for (const candidate of candidates) {
+          const why = await admits(candidate)
+          if (why === null) {
+            target = candidate
+            break
+          }
+          refusal ??= why
+        }
+        if (!target) return conflict(refusal ?? 'no daemon can take this agent')
+
+        const moveTarget: PlacementTarget = wantsPool ? ON_POOL : { kind: 'daemon', daemonId: target.daemonId }
 
         // A same-target retry is an idempotent repair after placement already
         // committed, not a second handoff. Target admission above still applies,
         // but there is no separate source to gate before ensureActive below.
-        if (existing.daemonId !== target.daemonId) {
-          if (existing.daemonId) {
-            const source = await deps.registry.getAvailable(orgOf(req), existing.daemonId)
-            const sourceLive = source ? deps.liveness.get(source.daemonId) : undefined
-            const sourceReady = sourceLive?.reachable === true && sourceLive.state === 'READY'
-            if (force) {
-              if (sourceReady) return conflict('source daemon is ready; use a safe move')
-              if (sourceLive?.reachable === true) {
-                return conflict('source daemon is reconnecting; wait until it is ready')
-              }
-            } else {
-              if (!source || !moveReady(source.daemonId)) return conflict('source daemon is not ready')
-              if (!source.capabilities.features.includes(MOVE_FEATURE)) {
-                return conflict('source daemon does not support agent moves')
+        if (!samePlacementTarget) {
+          // Every member serving the agent today has to quiesce — for a pool source that is the
+          // duty holder, not a placement, and there may be none at all.
+          const sourceDaemonIds = await deps.placementResolver.servingDaemons(existing)
+          if (sourceDaemonIds.length > 0) {
+            for (const sourceDaemonId of sourceDaemonIds) {
+              const source = await deps.registry.getAvailable(orgOf(req), DaemonId(sourceDaemonId))
+              const sourceLive = source ? deps.liveness.get(source.daemonId) : undefined
+              const sourceReady = sourceLive?.reachable === true && sourceLive.state === 'READY'
+              if (force) {
+                if (sourceReady) return conflict('source daemon is ready; use a safe move')
+                if (sourceLive?.reachable === true) {
+                  return conflict('source daemon is reconnecting; wait until it is ready')
+                }
+              } else {
+                if (!source || !moveReady(source.daemonId)) return conflict('source daemon is not ready')
+                if (!source.capabilities.features.includes(MOVE_FEATURE)) {
+                  return conflict('source daemon does not support agent moves')
+                }
               }
             }
           } else if (force) {
@@ -2360,7 +2464,7 @@ export function agentRoutes(deps: HttpDeps) {
           // Retry/repair: the prior response may have been lost, or a failed move
           // may have left DB placement on a partially bootstrapped target. Reapply
           // the full bundle + activate; all operations are idempotent.
-          if (existing.daemonId === target.daemonId) {
+          if (samePlacementTarget) {
             try {
               const repaired = await agentMoves.ensureActive(existing)
               return toDto(
@@ -2369,7 +2473,7 @@ export function agentRoutes(deps: HttpDeps) {
                 await secretKeysOf(repaired.orgId, repaired.id),
                 await hookKindsOf(deps, repaired.id),
                 iconBasesOf(deps),
-                sandboxPolicyOf(target),
+                placementViewOf(deps, target),
                 await organizationEnvironmentOf(repaired)
               )
             } catch (err) {
@@ -2386,16 +2490,16 @@ export function agentRoutes(deps: HttpDeps) {
             req.log.warn(
               {
                 agentId: existing.id,
-                sourceDaemonId: existing.daemonId,
-                targetDaemonId: target.daemonId,
+                sourcePlacement: placementLabel(placement),
+                targetPlacement: placementLabel(moveTarget),
                 userId: req.principal?.userId
               },
               'agent force reassign requested while source daemon is unavailable'
             )
           }
           const moved = force
-            ? await agentMoves.forceReassign(existing, target.daemonId, req.principal?.userId)
-            : await agentMoves.move(existing, target.daemonId, req.principal?.userId)
+            ? await agentMoves.forceReassign(existing, moveTarget, req.principal?.userId)
+            : await agentMoves.move(existing, moveTarget, req.principal?.userId)
           // The pre-activation probe fact can arrive before the placement CAS and
           // is correctly rejected by the daemon-ownership check. Re-send the
           // idempotent definition after commit so the daemon re-emits its current
@@ -2414,7 +2518,7 @@ export function agentRoutes(deps: HttpDeps) {
             await secretKeysOf(moved.orgId, moved.id),
             await hookKindsOf(deps, moved.id),
             iconBasesOf(deps),
-            sandboxPolicyOf(target),
+            placementViewOf(deps, target),
             await organizationEnvironmentOf(moved)
           )
         } catch (err) {
@@ -2504,7 +2608,7 @@ export function agentRoutes(deps: HttpDeps) {
               )
             }
           }
-          await replicateRemove(current.id, current.daemonId, current.orgId)
+          await replicateRemove(current, current.orgId)
           // AFTER the fan-out: `remove` resolves holders from the membership rows
           // the reap deletes, and the agent row this reads by is already gone.
           deps.recomputeDuties?.(current.orgId)
@@ -2584,7 +2688,7 @@ export function agentRoutes(deps: HttpDeps) {
             await secretKeysOf(agent.orgId, agent.id),
             await hookKindsOf(deps, agent.id),
             iconBasesOf(deps),
-            await sandboxPolicyFor(deps, agent),
+            await placementViewFor(deps, agent),
             await organizationEnvironmentOf(agent)
           )
         } finally {
@@ -2665,7 +2769,7 @@ export function agentRoutes(deps: HttpDeps) {
             await secretKeysOf(agent.orgId, agent.id),
             await hookKindsOf(deps, agent.id),
             iconBasesOf(deps),
-            await sandboxPolicyFor(deps, agent),
+            await placementViewFor(deps, agent),
             await organizationEnvironmentOf(agent)
           )
         } finally {
@@ -2692,7 +2796,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!(await canReadWorkspaceScope(req, agent.id, req.query.sessionId))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'workspace not found' })
@@ -2738,7 +2842,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!agent.daemonId) {
           return reply
@@ -2775,7 +2879,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!(await canReadWorkspaceScope(req, agent.id, req.query.sessionId))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'workspace not found' })
@@ -2829,7 +2933,7 @@ export function agentRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
@@ -2904,7 +3008,7 @@ export function agentRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
@@ -2964,7 +3068,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (agent.memory?.provider === 'none') {
           return toAgentMemoryDto({ agentId: agent.id, path: req.query.path ?? 'MEMORY.md', exists: false })
@@ -3014,7 +3118,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (agent.memory?.provider === 'none') {
           return toMemoryFilesDto({ agentId: agent.id, exists: false, entries: [] })
@@ -3060,7 +3164,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (agent.memory?.provider !== undefined && agent.memory.provider !== 'managed') {
           return { channels: [] }
@@ -3105,7 +3209,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (agent.memory?.provider === 'none') {
           return toAgentMemoryDto({ agentId: agent.id, path: req.query.path ?? 'MEMORY.md', exists: false })
@@ -3164,7 +3268,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
@@ -3234,7 +3338,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if ((agent.memory?.provider ?? 'managed') !== 'managed') {
           return reply.code(400).send({
@@ -3285,7 +3389,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         const provider = agent.memory?.provider ?? 'managed'
         if (provider === 'none') return { shape: 'none' as const, capabilities: [] }
@@ -3321,7 +3425,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (agent.memory?.provider !== 'external') {
           return reply
@@ -3366,7 +3470,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (agent.memory?.provider !== 'external') {
           return reply
@@ -3417,7 +3521,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
@@ -3464,7 +3568,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (agent.memory?.provider !== 'external') {
           return reply
@@ -3511,7 +3615,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
@@ -3568,7 +3672,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
@@ -3622,7 +3726,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (agent.memory?.provider !== 'external') {
           return reply
@@ -3672,7 +3776,7 @@ export function agentRoutes(deps: HttpDeps) {
       id: string,
       edit = false
     ): Promise<(AgentRecord & { daemonId: string }) | null> => {
-      const agent = await getOrgAgent(req, id)
+      const agent = await getServingAgent(req, id)
       if (!agent) {
         await reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         return null
@@ -4097,7 +4201,7 @@ export function agentRoutes(deps: HttpDeps) {
       async (req, reply) => {
         // Route through getOrgAgent (org boundary + canView) — a bare repo.get here
         // would leak a restricted / cross-org agent's checkout state.
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!(await canReadWorkspaceScope(req, agent.id, req.query.sessionId))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'workspace not found' })
@@ -4141,7 +4245,7 @@ export function agentRoutes(deps: HttpDeps) {
       async (req, reply) => {
         // Route through getOrgAgent (org boundary + canView) — a bare repo.get here
         // would leak a restricted / cross-org agent's uncommitted work.
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!(await canReadWorkspaceScope(req, agent.id, req.query.sessionId))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'workspace not found' })
@@ -4188,7 +4292,7 @@ export function agentRoutes(deps: HttpDeps) {
       async (req, reply) => {
         // Route through getOrgAgent (org boundary + canView) — a bare repo.get here
         // would leak a restricted / cross-org agent's commit history.
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!(await canReadWorkspaceScope(req, agent.id, req.query.sessionId))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'workspace not found' })
@@ -4234,7 +4338,7 @@ export function agentRoutes(deps: HttpDeps) {
       async (req, reply) => {
         // Route through getOrgAgent (org boundary + canView) — a bare repo.get here
         // would let a non-viewer trigger a pull on a restricted / cross-org agent.
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!agent.daemonId) {
           return reply
@@ -4267,7 +4371,7 @@ export function agentRoutes(deps: HttpDeps) {
       requireFeature: (reply: FastifyReply, orgId: OrgId, daemonId: DaemonId) => Promise<boolean>
     ): Promise<{ agent: AgentRecord; daemonId: DaemonId } | null> => {
       if (denyViewerWrite(req, reply)) return null
-      const agent = await getOrgAgent(req, agentId)
+      const agent = await getServingAgent(req, agentId)
       if (!agent) {
         void reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         return null
@@ -4519,7 +4623,7 @@ export function agentRoutes(deps: HttpDeps) {
       async (req, reply) => {
         // Route through getOrgAgent (org boundary + canView) — a bare repo.get here would leak
         // a restricted / cross-org agent's work, and task descriptions are model-authored text.
-        const agent = await getOrgAgent(req, req.params.id)
+        const agent = await getServingAgent(req, req.params.id)
         if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         if (!(await visibleAgentSession(req, agent.id, req.query.sessionId))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })

--- a/packages/control-plane/src/http/routes/crons.ts
+++ b/packages/control-plane/src/http/routes/crons.ts
@@ -228,7 +228,7 @@ export function cronRoutes(deps: HttpDeps) {
             .catch(() => {})
           const wire = cronToUpsert(cron)
           if (wire) {
-            await deps.agentDelivery.cronUpsert(agent.id, agent.daemonId, wire, cronPushFailed('cron/upsert'))
+            await deps.agentDelivery.cronUpsert(agent, wire, cronPushFailed('cron/upsert'))
           }
           return toDto(cron, ctxOf(req))
         } finally {
@@ -336,11 +336,15 @@ export function cronRoutes(deps: HttpDeps) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot run this cron' })
         }
         let agent = cron.agentId ? await deps.repos.agent.get(orgOf(req), cron.agentId) : null
-        if (!agent?.daemonId) {
+        // A manual run goes to whoever serves the agent right now — its placement, or the member
+        // holding its duty. Nothing serving it is a 503, exactly as an unplaced agent was.
+        const runDaemonId = agent ? await deps.placementResolver.servingDaemon(agent) : null
+        if (!agent || !runDaemonId) {
           return reply
             .code(503)
             .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent is not placed on a daemon' })
         }
+        agent = { ...agent, daemonId: runDaemonId }
         const release = deps.agentMutations.tryBeginMutation(agent.id)
         if (!release) {
           return reply
@@ -446,13 +450,7 @@ export function cronRoutes(deps: HttpDeps) {
             .catch(() => {})
           // The row's own org rides the send: `cron/remove` carries only a cronId,
           // so a holder that never registered this cron has nothing to resolve.
-          await deps.agentDelivery.cronRemove(
-            agent.id,
-            agent.daemonId,
-            existing.id,
-            existing.orgId,
-            cronPushFailed('cron/remove')
-          )
+          await deps.agentDelivery.cronRemove(agent, existing.id, existing.orgId, cronPushFailed('cron/remove'))
           return reply.code(204).send(null)
         } finally {
           release()

--- a/packages/control-plane/src/http/routes/feishu-registration.ts
+++ b/packages/control-plane/src/http/routes/feishu-registration.ts
@@ -71,13 +71,15 @@ export function feishuRegistrationRoutes(deps: HttpDeps, feishu: FeishuRouteSeam
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
         }
-        if (!agent.daemonId) {
+        // A pool agent is placed and names no machine; the capability probe asks its server.
+        const installDaemonId = await deps.placementResolver.servingDaemon(agent)
+        if (!installDaemonId) {
           return reply
             .code(409)
             .send({ error: 'Conflict', statusCode: 409, message: 'agent must be placed on a daemon first' })
         }
         const availability = await integrationPlatformAvailability(deps, {
-          daemonId: agent.daemonId,
+          daemonId: installDaemonId,
           orgId,
           viewer: ctxOf(req),
           platform: 'feishu'

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -24,6 +24,7 @@ import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import type { AgentRecord, BotRecord, IntegrationRecord, IntegrationChannelRecord } from '../../persistence/ports.js'
 import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
+import type { ResolvableAgent } from '../../orchestrator/placementResolver.js'
 import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
@@ -103,7 +104,7 @@ export function integrationRoutes(deps: HttpDeps) {
     // or stale bind rules is the frozen-bundle failure one level down). Best-effort:
     // an offline daemon picks it up from the reconcile roster on the next connect.
     // Token-bearing — never log the spec.
-    const replicateUpsert = async (i: IntegrationRecord, daemonId: string | null): Promise<void> => {
+    const replicateUpsert = async (i: IntegrationRecord, owningAgent: ResolvableAgent): Promise<void> => {
       // The bot row joins the reads: it is a required input of the §9 projector
       // that now assembles the spec payload (`orchestrator/placement.ts`). Every
       // caller here is already on the socket-transport arm, so the projector
@@ -123,7 +124,7 @@ export function integrationRoutes(deps: HttpDeps) {
         channels,
         owner ? isGatedAgent(owner) : false
       )
-      await deps.agentDelivery.integrationUpsert(i.agentId, daemonId, spec, (err, target) => {
+      await deps.agentDelivery.integrationUpsert(owningAgent, spec, (err, target) => {
         if (!(err instanceof NoConnection)) throw err
         app.log.debug({ integrationId: i.id, daemonId: target }, 'integration/upsert skipped: daemon offline')
       })
@@ -167,12 +168,12 @@ export function integrationRoutes(deps: HttpDeps) {
 
     const replicateRemove = async (
       i: Pick<IntegrationRecord, 'id' | 'agentId' | 'orgId'>,
-      daemonId: string | null
+      owningAgent: ResolvableAgent
     ): Promise<void> => {
       const { id: integrationId } = i
       // The row's own org rides the send: `integration/remove` carries only an id,
       // so a holder that never registered this integration has nothing to resolve.
-      await deps.agentDelivery.integrationRemove(i.agentId, daemonId, i.id, i.orgId, (err, target) => {
+      await deps.agentDelivery.integrationRemove(owningAgent, i.id, i.orgId, (err, target) => {
         if (!(err instanceof NoConnection)) throw err
         app.log.debug({ integrationId, daemonId: target }, 'integration/remove skipped: daemon offline')
       })
@@ -207,14 +208,17 @@ export function integrationRoutes(deps: HttpDeps) {
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
         }
-        // Delivery is daemon-scoped; refuse until the agent is placed (no backfill hook).
-        if (!agent.daemonId) {
+        // Delivery is daemon-scoped; refuse until the agent is placed (no backfill hook). A pool
+        // agent IS placed and names no machine, so the capability probe below asks whichever
+        // member serves it.
+        const installDaemonId = await deps.placementResolver.servingDaemon(agent)
+        if (!installDaemonId) {
           return reply
             .code(409)
             .send({ error: 'Conflict', statusCode: 409, message: 'agent must be placed on a daemon first' })
         }
         const platformAvailability = await integrationPlatformAvailability(deps, {
-          daemonId: agent.daemonId,
+          daemonId: installDaemonId,
           orgId,
           viewer: ctxOf(req),
           platform: req.body.platform
@@ -383,7 +387,7 @@ export function integrationRoutes(deps: HttpDeps) {
             })
             // A socket-transport install is a new duty edge (design §4.4).
             deps.recomputeDuties?.(orgId)
-            await replicateUpsert(integration, daemonId)
+            await replicateUpsert(integration, agent)
             return reply.code(201).send(toDto(integration))
           }
 
@@ -621,7 +625,7 @@ export function integrationRoutes(deps: HttpDeps) {
       agent: AgentRecord
     ): Promise<void> => {
       if (bot.transport === 'http') await deps.httpBot.syncRoutes(bot.id)
-      else await replicateUpsert(integration, agent.daemonId)
+      else await replicateUpsert(integration, agent)
     }
 
     /**
@@ -887,7 +891,7 @@ export function integrationRoutes(deps: HttpDeps) {
           if (bot.transport === 'http') {
             if (!routesSynced) await deps.httpBot.syncRoutes(bot.id)
           } else {
-            await replicateUpsert(integration, agent.daemonId)
+            await replicateUpsert(integration, agent)
           }
           return toChannelDto(updated!)
         } finally {
@@ -1175,7 +1179,7 @@ export function integrationRoutes(deps: HttpDeps) {
             await deps.repos.bot.markFreed(orgIdOf(req), existing.botId, new Date(), agent.name ?? null)
           }
           // Tell the removed agent's daemon to drop the spec either way.
-          await replicateRemove(existing, agent.daemonId ?? null)
+          await replicateRemove(existing, agent)
           // HTTP bot: recompute the relay's routes + members (or release it if this
           // was the last install).
           if (botBefore?.transport === 'http') await deps.httpBot.syncBot(existing.botId)

--- a/packages/control-plane/src/orchestrator/agentDelivery.ts
+++ b/packages/control-plane/src/orchestrator/agentDelivery.ts
@@ -10,8 +10,9 @@
  * the placement if the agent has one, plus every member currently holding an
  * unexpired duty lease covering it.
  *
- * It is a seam, not a special case: a later change makes placement a delivery
- * TARGET rather than a member id, and this is the one place that has to learn it.
+ * It is a seam, not a special case, and that is now load-bearing: placement is a TARGET rather
+ * than a member id, so a `pool` agent names no machine at all and the ledger is its entire
+ * delivery set. `PlacementResolver` owns that translation; this file never reads a placement kind.
  * The lifecycle sends keep taking an explicit `orgId`, because an install-wide
  * (frame-mode) member's connection carries no org and a duty holder is exactly
  * the connection that cannot resolve one from its own maps.
@@ -19,14 +20,10 @@
 import type { CronUpsert, IntegrationSpec } from '@agentconnect.md/protocol'
 import type { AgentSpecAssembler } from './agentSpecAssembler.js'
 import type { ControlSender } from './outbound.js'
+import { PLACEMENT_ONLY, type PlacementResolver, type ResolvableAgent } from './placementResolver.js'
 import type { AgentRecord } from '../persistence/ports.js'
-import { AgentId, type DaemonId } from '../domain/ids.js'
-import type { Clock } from '../domain/clock.js'
 
-/** The duty ledger read this seam needs — the delivery half of `holdsAgent`. */
-export interface DutyHolderReader {
-  holdersOf(agentId: AgentId, now: Date): Promise<DaemonId[]>
-}
+export type { DutyHolderReader } from './placementResolver.js'
 
 /** Per-target failure hook: every site logs it its own way, and none of them
  *  fails the HTTP write over it (the reconnect roster is the backstop). */
@@ -40,21 +37,19 @@ export class AgentDelivery {
         'agentUpsert' | 'agentRemove' | 'integrationUpsert' | 'integrationRemove' | 'cronUpsert' | 'cronRemove'
       >
       specs: AgentSpecAssembler
-      duties?: DutyHolderReader
-      clock: Clock
+      /** Absent (tests / no pool) ⇒ placement alone, which is the pre-duty behavior. */
+      placement?: PlacementResolver
     }
   ) {}
 
   /**
-   * Every daemon that must receive this agent's updates, placement first and
-   * deduped. No duty ledger wired (tests, or a deployment with no pool) ⇒ the
-   * placement alone, which is exactly the pre-duty behavior.
+   * Every daemon that must receive this agent's updates, placement first and deduped. The
+   * placement half is what the resolver makes of the agent's placement fields — one machine for a
+   * `daemon` placement, nothing for a `pool` one — so a caller passes the placement REF rather
+   * than a daemon id, and gains a kind it never has to read.
    */
-  async daemonsFor(agentId: string, placement: string | null): Promise<string[]> {
-    const holders = this.deps.duties
-      ? await this.deps.duties.holdersOf(AgentId(agentId), new Date(this.deps.clock.now()))
-      : []
-    return [...new Set([...(placement ? [placement] : []), ...holders])]
+  daemonsFor(agent: ResolvableAgent): Promise<string[]> {
+    return (this.deps.placement ?? PLACEMENT_ONLY).servingDaemons(agent)
   }
 
   /**
@@ -74,7 +69,7 @@ export class AgentDelivery {
   /** Push an edited spec to every delivery target. The spec is assembled ONCE:
    *  the targets replicate the same agent, and two assemblies could disagree. */
   async upsert(agent: AgentRecord, onError: DeliveryErrorHandler): Promise<void> {
-    const targets = await this.daemonsFor(agent.id, agent.daemonId)
+    const targets = await this.daemonsFor(agent)
     if (targets.length === 0) return
     const spec = await this.deps.specs.assemble(agent)
     await this.fanOut(targets, onError, (daemonId) =>
@@ -86,29 +81,26 @@ export class AgentDelivery {
    *  deleted by now; duty membership has no FK to it, so a holder is still
    *  resolvable — which is the whole point (a deleted agent must stop being
    *  served, not just stop being placed). */
-  async remove(agentId: string, placement: string | null, orgId: string, onError: DeliveryErrorHandler): Promise<void> {
-    const targets = await this.daemonsFor(agentId, placement)
-    await this.fanOut(targets, onError, (daemonId) => this.deps.control.agentRemove(daemonId, { agentId }, orgId))
+  async remove(agent: ResolvableAgent, orgId: string, onError: DeliveryErrorHandler): Promise<void> {
+    const targets = await this.daemonsFor(agent)
+    await this.fanOut(targets, onError, (daemonId) =>
+      this.deps.control.agentRemove(daemonId, { agentId: agent.id }, orgId)
+    )
   }
 
   // A dependent goes exactly where its agent's own updates go. An integration
   // spec is token-bearing and a cron definition drives execution, so a holder
   // that receives neither keeps stale credentials, stale bind rules, or a stale
   // schedule until it happens to reconnect — the same frozen-bundle failure as a
-  // stale spec, one level down. These take the agent's id and placement rather
-  // than the record, because a removal path may only have those.
+  // stale spec, one level down. These take the placement REF rather than the whole record,
+  // because a removal path may only have that.
 
   /** Push one integration's spec (token-bearing — NEVER log it) to every target.
    *  No explicit orgId: `IntegrationSpec.orgId` is a required wire field, so the
    *  payload IS the explicit org — and sending it also teaches the connection's
    *  id→org map, which is why upserts never had this problem. */
-  async integrationUpsert(
-    agentId: string,
-    placement: string | null,
-    spec: IntegrationSpec,
-    onError: DeliveryErrorHandler
-  ): Promise<void> {
-    const targets = await this.daemonsFor(agentId, placement)
+  async integrationUpsert(agent: ResolvableAgent, spec: IntegrationSpec, onError: DeliveryErrorHandler): Promise<void> {
+    const targets = await this.daemonsFor(agent)
     await this.fanOut(targets, onError, (daemonId) => this.deps.control.integrationUpsert(daemonId, spec))
   }
 
@@ -118,38 +110,31 @@ export class AgentDelivery {
    *  `duty/fetch` never registered it, so the send would raise SCOPE_DENIED
    *  before the frame left the process. The record in hand always has the org. */
   async integrationRemove(
-    agentId: string,
-    placement: string | null,
+    agent: ResolvableAgent,
     integrationId: string,
     orgId: string,
     onError: DeliveryErrorHandler
   ): Promise<void> {
-    const targets = await this.daemonsFor(agentId, placement)
+    const targets = await this.daemonsFor(agent)
     await this.fanOut(targets, onError, (daemonId) =>
       this.deps.control.integrationRemove(daemonId, { integrationId }, orgId)
     )
   }
 
   /** Same as the integration upsert: `CronUpsert.orgId` is a required wire field. */
-  async cronUpsert(
-    agentId: string,
-    placement: string | null,
-    wire: CronUpsert,
-    onError: DeliveryErrorHandler
-  ): Promise<void> {
-    const targets = await this.daemonsFor(agentId, placement)
+  async cronUpsert(agent: ResolvableAgent, wire: CronUpsert, onError: DeliveryErrorHandler): Promise<void> {
+    const targets = await this.daemonsFor(agent)
     await this.fanOut(targets, onError, async (daemonId) => void (await this.deps.control.cronUpsert(daemonId, wire)))
   }
 
   /** `orgId` is REQUIRED for the same reason as {@link AgentDelivery.integrationRemove}. */
   async cronRemove(
-    agentId: string,
-    placement: string | null,
+    agent: ResolvableAgent,
     cronId: string,
     orgId: string,
     onError: DeliveryErrorHandler
   ): Promise<void> {
-    const targets = await this.daemonsFor(agentId, placement)
+    const targets = await this.daemonsFor(agent)
     await this.fanOut(
       targets,
       onError,

--- a/packages/control-plane/src/orchestrator/agentDelivery.ts
+++ b/packages/control-plane/src/orchestrator/agentDelivery.ts
@@ -58,10 +58,10 @@ export class AgentDelivery {
    * defs are not addressed to an agent, so their fan-out sites resolve "who uses
    * this" first and hand the result here rather than reading `daemonId` inline.
    */
-  async daemonsForAgents(agents: readonly { id: string; daemonId: string | null }[]): Promise<string[]> {
+  async daemonsForAgents(agents: readonly ResolvableAgent[]): Promise<string[]> {
     const targets = new Set<string>()
     for (const agent of agents) {
-      for (const daemonId of await this.daemonsFor(agent.id, agent.daemonId)) targets.add(daemonId)
+      for (const daemonId of await this.daemonsFor(agent)) targets.add(daemonId)
     }
     return [...targets]
   }

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -1,3 +1,4 @@
+import { onDaemon, placementTargetOf, samePlacement, type PlacementTarget } from '../domain/placement.js'
 import { describe, expect, it } from 'vitest'
 import type { Ack, AgentActivate, AgentDetach } from '@agentconnect.md/protocol'
 import { AgentId, BotId, CronId, DaemonId, IntegrationId, OrgId } from '../domain/ids.js'
@@ -211,9 +212,9 @@ function make(
       return current
     },
     setWorkspaceRepoId: async () => true,
-    movePlacement: async (_id: string, expected: string | null, target: string | null) => {
-      if (opts.casMiss || current.daemonId !== expected) return null
-      current = agent(target)
+    movePlacement: async (_id: string, expected: PlacementTarget, target: PlacementTarget) => {
+      if (opts.casMiss || !samePlacement(placementTargetOf(current), expected)) return null
+      current = agent(target.kind === 'daemon' ? target.daemonId : null)
       return current
     }
   } as unknown as AgentRepo
@@ -314,14 +315,14 @@ describe('AgentMoveService', () => {
     // nor an agent it has never installed can supply one, so an unscoped frame is
     // refused with SCOPE_DENIED before it leaves the CP.
     const t = make()
-    await t.service.move(t.current(), TARGET)
+    await t.service.move(t.current(), onDaemon(TARGET))
     expect(t.frameOrgs.length).toBeGreaterThan(0)
     expect(t.frameOrgs.every((orgId) => orgId === ORG)).toBe(true)
   })
 
   it('hard-cuts the source, bootstraps the complete target bundle, and activates last', async () => {
     const t = make()
-    const moved = await t.service.move(t.current(), TARGET)
+    const moved = await t.service.move(t.current(), onDaemon(TARGET))
     expect(moved.daemonId).toBe(TARGET)
     expect(t.calls).toEqual([
       `detach:${SOURCE}`,
@@ -466,7 +467,7 @@ describe('AgentMoveService', () => {
 
   it('on target activation failure, confirms target detach then restores the full source bundle before activate', async () => {
     const t = make({ failTargetActivate: true })
-    await expect(t.service.move(t.current(), TARGET)).rejects.toBeInstanceOf(AgentMoveFailed)
+    await expect(t.service.move(t.current(), onDaemon(TARGET))).rejects.toBeInstanceOf(AgentMoveFailed)
     expect(t.current().daemonId).toBe(SOURCE)
     expect(t.calls).toEqual([
       `detach:${SOURCE}`,
@@ -481,20 +482,20 @@ describe('AgentMoveService', () => {
 
   it('fails closed when target detach is not acknowledged: DB stays on target and source is not restored', async () => {
     const t = make({ failTargetActivate: true, failRollbackTargetDetach: true })
-    await expect(t.service.move(t.current(), TARGET)).rejects.toThrow('placement remains on target')
+    await expect(t.service.move(t.current(), onDaemon(TARGET))).rejects.toThrow('placement remains on target')
     expect(t.current().daemonId).toBe(TARGET)
     expect(t.calls).not.toContain(`activate:${SOURCE}`)
   })
 
   it('restores the full source bundle after a CAS miss', async () => {
     const t = make({ casMiss: true })
-    await expect(t.service.move(t.current(), TARGET)).rejects.toThrow('changed concurrently')
+    await expect(t.service.move(t.current(), onDaemon(TARGET))).rejects.toThrow('changed concurrently')
     expect(t.calls).toEqual([`detach:${SOURCE}`, `release:${SOURCE}`, `detach:${SOURCE}`, `activate:${SOURCE}`])
   })
 
   it('re-stages with a fresh token when the bundle changes across activate ACK', async () => {
     const t = make({ changeBundleAfterFirstActivate: true })
-    await expect(t.service.move(t.current(), TARGET)).resolves.toMatchObject({ daemonId: TARGET })
+    await expect(t.service.move(t.current(), onDaemon(TARGET))).resolves.toMatchObject({ daemonId: TARGET })
 
     const targetActivations = t.activations.filter((_value, index) => index < 2)
     expect(targetActivations.map((value) => value.crons[0]?.schedule)).toEqual(['0 0 * * *', '5 * * * *'])
@@ -545,9 +546,9 @@ describe('AgentMoveService', () => {
     const sourceDetachStarted = new Promise<void>((resolve) => (markStarted = resolve))
     const t = make({ waitSourceDetach, sourceDetachStarted: markStarted })
 
-    const first = t.service.move(t.current(), TARGET)
+    const first = t.service.move(t.current(), onDaemon(TARGET))
     await sourceDetachStarted
-    await expect(t.service.move(t.current(), TARGET)).rejects.toBeInstanceOf(AgentMoveConflict)
+    await expect(t.service.move(t.current(), onDaemon(TARGET))).rejects.toBeInstanceOf(AgentMoveConflict)
     expect(t.mutations.tryBeginMutation(AGENT)).toBeNull()
     releaseSource()
     await expect(first).resolves.toMatchObject({ daemonId: TARGET })
@@ -555,7 +556,7 @@ describe('AgentMoveService', () => {
 
   it('detaches target and fails closed when DB ownership changes after activation', async () => {
     const t = make({ moveOwnershipAfterFirstActivate: true })
-    await expect(t.service.move(t.current(), TARGET)).rejects.toThrow('placement changed during move')
+    await expect(t.service.move(t.current(), onDaemon(TARGET))).rejects.toThrow('placement changed during move')
     expect(t.calls.at(-1)).toBe(`detach:${TARGET}`)
     expect(t.calls).not.toContain(`activate:${SOURCE}`)
   })

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -39,6 +39,14 @@ import type {
 } from '../persistence/ports.js'
 import { AgentWorkspaceIntegrationConflict } from '../persistence/errors.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
+import {
+  isPlaced,
+  placementLabel,
+  placementTargetOf,
+  samePlacement,
+  type PlacementTarget
+} from '../domain/placement.js'
+import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
 import { cronToUpsert, integrationToSpec, isGatedAgent, httpIntegrationToSpec } from './placement.js'
 import {
   mcpDefsForAgents,
@@ -104,6 +112,9 @@ export interface AgentMoveDeps {
   collabRoutes: CollabRoutesService
   mutations: AgentMutationGate
   sessionOwners: { releaseSession(key: SessionKey): void }
+  /** Resolves the members currently serving an agent — the sources a move must quiesce when
+   *  placement names no machine of its own. Absent ⇒ placement alone (the pre-duty behavior). */
+  placement?: PlacementResolver
   log?: AgentMoveLog
   /** Placement decides duty incumbency (design §4.4 soak policy), so a completed
    *  move re-derives the org's groups. Fire-and-forget; the sweep is the backstop. */
@@ -170,7 +181,7 @@ function isUnchangedWorkspace(agent: AgentRecord | null, original: AgentRecord):
     agent !== null &&
     sameWorkspaceDefinition(agent.workspace, original.workspace) &&
     agent.workspaceRepoId === original.workspaceRepoId &&
-    agent.daemonId === original.daemonId &&
+    samePlacement(placementTargetOf(agent), placementTargetOf(original)) &&
     agent.lastModifiedAt.getTime() === original.lastModifiedAt.getTime()
   )
 }
@@ -194,18 +205,18 @@ export class AgentMoveService {
     }
   }
 
-  async move(agent: AgentRecord, targetDaemonId: DaemonId, editor?: string): Promise<AgentRecord> {
+  async move(agent: AgentRecord, target: PlacementTarget, editor?: string): Promise<AgentRecord> {
     return this.withMoveGate(agent.id, async () =>
-      this.moveLocked(await this.reloadAfterGate(agent), targetDaemonId, editor, 'required')
+      this.moveLocked(await this.reloadAfterGate(agent), target, editor, 'required')
     )
   }
 
   /** Disaster recovery for a source daemon that cannot confirm detach. Target
    * admission and activation remain fully acknowledged; only the source handoff
    * becomes best-effort. */
-  async forceReassign(agent: AgentRecord, targetDaemonId: DaemonId, editor?: string): Promise<AgentRecord> {
+  async forceReassign(agent: AgentRecord, target: PlacementTarget, editor?: string): Promise<AgentRecord> {
     return this.withMoveGate(agent.id, async () =>
-      this.moveLocked(await this.reloadAfterGate(agent), targetDaemonId, editor, 'best-effort')
+      this.moveLocked(await this.reloadAfterGate(agent), target, editor, 'best-effort')
     )
   }
 
@@ -227,7 +238,7 @@ export class AgentMoveService {
     const current = await this.deps.agents.getUnscoped(observed.id)
     if (!current) throw new AgentMoveConflict('agent was deleted while preparing the move; refresh and retry')
     if (
-      current.daemonId !== observed.daemonId ||
+      !samePlacement(placementTargetOf(current), placementTargetOf(observed)) ||
       current.lastModifiedAt.getTime() !== observed.lastModifiedAt.getTime()
     ) {
       throw new AgentMoveConflict('agent changed while preparing the move; refresh and retry')
@@ -249,7 +260,7 @@ export class AgentMoveService {
     const release = await this.deps.mutations.beginMoveWhenIdle(agentId)
     try {
       const current = await this.deps.agents.getUnscoped(agentId)
-      if (!current || current.daemonId !== daemonId) return
+      if (!current || !(await (this.deps.placement ?? PLACEMENT_ONLY).mayAct(current, daemonId))) return
 
       const candidate = await this.snapshotOwned(agentId, daemonId, current.orgId)
       const resumed = await this.deps.control.agentActivate(
@@ -267,7 +278,7 @@ export class AgentMoveService {
         const observed = await this.snapshotOwned(agentId, daemonId, current.orgId)
         if (candidate.fingerprint === observed.fingerprint) {
           const confirmed = await this.deps.agents.getUnscoped(agentId)
-          if (!confirmed || confirmed.daemonId !== daemonId) {
+          if (!confirmed || !(await (this.deps.placement ?? PLACEMENT_ONLY).mayAct(confirmed, daemonId))) {
             return this.failClosedOwnership(agentId, daemonId, current.orgId)
           }
           stable = { ...observed, agent: confirmed }
@@ -291,10 +302,20 @@ export class AgentMoveService {
   }
 
   private async ensureActiveLocked(agent: AgentRecord): Promise<AgentRecord> {
-    if (!agent.daemonId) throw new AgentMoveConflict('agent is not placed')
+    const placement = placementTargetOf(agent)
+    if (placement.kind === 'unplaced') throw new AgentMoveConflict('agent is not placed')
+    // Repairing a pool placement is the ledger's job, not a synchronous activation: the CP does
+    // not choose which member serves it, so the honest repair is to re-derive its duty group and
+    // let the next lease exchange grant and install it.
+    if (placement.kind !== 'daemon') {
+      this.deps.recomputeDuties?.(agent.orgId)
+      await this.convergeDerived(agent, (await this.snapshot(agent)).httpBotIds)
+      return agent
+    }
+    const daemonId = placement.daemonId
     let stable: ActivationSnapshot
     try {
-      stable = await this.activateUntilStable(agent.id, agent.daemonId, 'target repair', agent.orgId, {
+      stable = await this.activateUntilStable(agent.id, daemonId, 'target repair', agent.orgId, {
         reconcileWorkspace: true
       })
     } catch (err) {
@@ -314,21 +335,24 @@ export class AgentMoveService {
     if (workspace.mode === 'github' && workspaceRepoId === undefined) {
       throw new AgentMoveConflict('a GitHub workspace requires a resolved repository')
     }
+    // The member to fence and re-activate: placement when it names a machine, otherwise whichever
+    // pool member currently holds the agent. Nothing serving it ⇒ this is a cold edit.
+    const servingDaemonId = await (this.deps.placement ?? PLACEMENT_ONLY).servingDaemon(agent)
     if (sameWorkspace(agent, workspace, workspaceRepoId)) {
-      if (!agent.daemonId) {
+      if (!servingDaemonId) {
         await this.finalizeWorkspaceChange(agent, workspaceRepoId, [])
         return agent
       }
       // Lost-response repair: the daemon's durable materialization marker makes
       // this replay idempotent even when the prior edit changed repo/branch/mode.
-      const stable = await this.activateUntilStable(agent.id, agent.daemonId, 'workspace edit repair', agent.orgId, {
+      const stable = await this.activateUntilStable(agent.id, servingDaemonId, 'workspace edit repair', agent.orgId, {
         reconcileWorkspace: true
       })
       await this.finalizeWorkspaceChange(stable.agent, workspaceRepoId, stable.bundle.httpBotIds)
       return stable.agent
     }
 
-    if (!agent.daemonId) {
+    if (!servingDaemonId) {
       let converted: AgentRecord | null = null
       try {
         converted = await this.deps.agents.setWorkspace(
@@ -342,7 +366,7 @@ export class AgentMoveService {
         )
       } catch (err) {
         const observed = await this.deps.agents.getUnscoped(agent.id).catch(() => null)
-        if (observed?.daemonId === null && sameWorkspace(observed, workspace, workspaceRepoId)) {
+        if (observed && !isPlaced(observed) && sameWorkspace(observed, workspace, workspaceRepoId)) {
           converted = observed
         } else if (err instanceof AgentWorkspaceIntegrationConflict) {
           throw new AgentMoveConflict(err.message)
@@ -355,7 +379,7 @@ export class AgentMoveService {
       return converted
     }
 
-    const daemonId = agent.daemonId
+    const daemonId = servingDaemonId
     const bundle = await this.snapshot(agent)
     const moveId = randomUUID()
     let detached: Ack
@@ -396,7 +420,7 @@ export class AgentMoveService {
         })
       }
 
-      if (observed?.daemonId === daemonId && sameWorkspace(observed, workspace, workspaceRepoId)) {
+      if (observed && isPlaced(observed) && sameWorkspace(observed, workspace, workspaceRepoId)) {
         // The CAS committed and only its response was lost. Continue from the
         // durable GitHub definition instead of reviving stale scratch authority.
         converted = observed
@@ -449,17 +473,21 @@ export class AgentMoveService {
 
   private async moveLocked(
     agent: AgentRecord,
-    targetDaemonId: DaemonId,
+    target: PlacementTarget,
     editor: string | undefined,
     sourceDetachMode: SourceDetachMode
   ): Promise<AgentRecord> {
-    const sourceDaemonId = agent.daemonId
+    const source = placementTargetOf(agent)
+    // Every member serving the agent today, not only the one placement names: a `pool` agent is
+    // served by whoever holds its duty, so moving it onto a machine has to quiesce that member or
+    // the machine it lands on and the member it left both run it.
+    const sourceDaemonIds = (await (this.deps.placement ?? PLACEMENT_ONLY).servingDaemons(agent)) as DaemonId[]
     // Retained only as compensation input if the source is detached but the
     // placement CAS never commits. The target always receives a fresh post-CAS
     // snapshot, never this pre-detach copy.
     const sourceBundle = await this.snapshot(agent)
 
-    if (sourceDaemonId) {
+    for (const sourceDaemonId of sourceDaemonIds) {
       try {
         requireAck(
           'source cutover',
@@ -471,7 +499,7 @@ export class AgentMoveService {
           throw new AgentMoveFailed('source daemon cutover failed', err)
         }
         this.deps.log?.warn(
-          { err, agentId: agent.id, sourceDaemonId, targetDaemonId },
+          { err, agentId: agent.id, sourceDaemonId, target: placementLabel(target) },
           'agent force reassign: source detach unconfirmed; continuing by operator request'
         )
       }
@@ -491,17 +519,27 @@ export class AgentMoveService {
 
     let moved: AgentRecord | null
     try {
-      moved = await this.deps.agents.movePlacement(agent.id, sourceDaemonId, targetDaemonId, editor)
+      moved = await this.deps.agents.movePlacement(agent.id, source, target, editor)
       if (moved) this.deps.recomputeDuties?.(moved.orgId)
     } catch (err) {
-      await this.restoreSourceIfStillOwner(agent, sourceDaemonId, sourceBundle)
+      await this.restoreSourceIfStillOwner(agent, source, sourceBundle)
       throw new AgentMoveFailed('failed to persist agent placement', err)
     }
     if (!moved) {
-      await this.restoreSourceIfStillOwner(agent, sourceDaemonId, sourceBundle)
+      await this.restoreSourceIfStillOwner(agent, source, sourceBundle)
       throw new AgentMoveConflict('agent placement changed concurrently; refresh and retry')
     }
 
+    // A pool target has no daemon to bootstrap, and that is the design rather than a gap: the
+    // ledger grants the agent's group to a live member, which installs exactly this bundle
+    // through `duty/fetch` and starts serving. Committing the placement IS the move — a
+    // synchronous activation would only name one member the ledger is free to replace next beat.
+    if (target.kind !== 'daemon') {
+      await this.convergeDerived(moved, sourceBundle.httpBotIds)
+      return moved
+    }
+
+    const targetDaemonId = target.daemonId
     let stable: ActivationSnapshot
     try {
       // Re-read the full wire definition only AFTER the placement CAS. The
@@ -510,7 +548,7 @@ export class AgentMoveService {
       stable = await this.activateUntilStable(moved.id, targetDaemonId, 'target', moved.orgId)
     } catch (err) {
       if (err instanceof AgentMoveFailClosed) throw err
-      const rolledBack = await this.rollback(agent, moved, sourceDaemonId, targetDaemonId, editor, sourceBundle)
+      const rolledBack = await this.rollback(agent, moved, source, targetDaemonId, editor, sourceBundle)
       if (!rolledBack) {
         throw new AgentMoveFailed(
           'target bootstrap failed and target detach was not confirmed; placement remains on target for manual recovery',
@@ -587,7 +625,7 @@ export class AgentMoveService {
     // applied. Replaying `original` therefore could not restore anything the target had accepted —
     // every rejected edit ended fail-closed with the agent staged and offline.
     await this.restoreDetachedWorkspace(
-      converted.daemonId!,
+      (await (this.deps.placement ?? PLACEMENT_ONLY).servingDaemon(converted))!,
       restored,
       bundle,
       moveId,
@@ -715,7 +753,9 @@ export class AgentMoveService {
 
   private async snapshotOwned(agentId: AgentId, targetDaemonId: DaemonId, orgId: string): Promise<ActivationSnapshot> {
     const agent = await this.deps.agents.getUnscoped(agentId)
-    if (!agent || agent.daemonId !== targetDaemonId) {
+    // "Still ours" is the resolver's answer, not placement equality: a pool member legitimately
+    // acts for an agent whose placement names no machine, and only the ledger can say so.
+    if (!agent || !(await (this.deps.placement ?? PLACEMENT_ONLY).mayAct(agent, targetDaemonId))) {
       return this.failClosedOwnership(agentId, targetDaemonId, orgId)
     }
     const bundle = await this.snapshot(agent)
@@ -749,7 +789,7 @@ export class AgentMoveService {
         // Explicit final ownership read: an agent deleted or re-placed after the
         // ACK must never leave this target serving an orphaned copy.
         const confirmed = await this.deps.agents.getUnscoped(agentId)
-        if (!confirmed || confirmed.daemonId !== targetDaemonId) {
+        if (!confirmed || !(await (this.deps.placement ?? PLACEMENT_ONLY).mayAct(confirmed, targetDaemonId))) {
           return this.failClosedOwnership(agentId, targetDaemonId, orgId)
         }
         return { ...observed, agent: confirmed }
@@ -793,7 +833,7 @@ export class AgentMoveService {
   private async rollback(
     sourceAgent: AgentRecord,
     moved: AgentRecord,
-    sourceDaemonId: DaemonId | null,
+    source: PlacementTarget,
     targetDaemonId: DaemonId,
     editor: string | undefined,
     bundle: MoveBundle
@@ -812,26 +852,33 @@ export class AgentMoveService {
     }
     let restored: AgentRecord | null = null
     try {
-      restored = await this.deps.agents.movePlacement(moved.id, targetDaemonId, sourceDaemonId, editor)
+      restored = await this.deps.agents.movePlacement(
+        moved.id,
+        { kind: 'daemon', daemonId: targetDaemonId },
+        source,
+        editor
+      )
       if (restored) this.deps.recomputeDuties?.(restored.orgId)
     } catch (err) {
       this.deps.log?.warn({ err, agentId: moved.id }, 'agent move: placement rollback failed')
     }
-    if (restored && sourceDaemonId) {
-      await this.bestEffortBootstrap('source bootstrap rollback', sourceDaemonId, sourceAgent, bundle)
+    // Only a machine source has a bootstrap to restore. A pool source is restored by the ledger:
+    // the placement is back, so the next sweep re-grants the group and install-on-grant replays.
+    if (restored && source.kind === 'daemon') {
+      await this.bestEffortBootstrap('source bootstrap rollback', source.daemonId, sourceAgent, bundle)
     }
     return restored !== null
   }
 
   private async restoreSourceIfStillOwner(
     agent: AgentRecord,
-    sourceDaemonId: DaemonId | null,
+    source: PlacementTarget,
     bundle: MoveBundle
   ): Promise<void> {
-    if (!sourceDaemonId) return
+    if (source.kind !== 'daemon') return
     const current = await this.deps.agents.getUnscoped(agent.id).catch(() => null)
-    if (current?.daemonId !== sourceDaemonId) return
-    await this.bestEffortBootstrap('source bootstrap after CAS failure', sourceDaemonId, agent, bundle)
+    if (!current || !samePlacement(placementTargetOf(current), source)) return
+    await this.bestEffortBootstrap('source bootstrap after CAS failure', source.daemonId, agent, bundle)
   }
 
   /** Stage first, then install one authoritative bundle under the daemon gate. */

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -33,6 +33,7 @@ import type {
   BotRepo,
   BotSecretStore,
   CronRepo,
+  DaemonRepo,
   AgentWorkspace,
   IntegrationChannelRepo,
   IntegrationRepo
@@ -40,13 +41,17 @@ import type {
 import { AgentWorkspaceIntegrationConflict } from '../persistence/errors.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
 import {
+  claimScopeOf,
   isPlaced,
+  mayHold,
+  placementColumns,
   placementLabel,
   placementTargetOf,
   samePlacement,
   type PlacementTarget
 } from '../domain/placement.js'
 import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
+import { convergeAgentRouting } from './agentRouting.js'
 import { cronToUpsert, integrationToSpec, isGatedAgent, httpIntegrationToSpec } from './placement.js'
 import {
   mcpDefsForAgents,
@@ -112,6 +117,9 @@ export interface AgentMoveDeps {
   collabRoutes: CollabRoutesService
   mutations: AgentMutationGate
   sessionOwners: { releaseSession(key: SessionKey): void }
+  /** Daemon rows, for deciding whether a detached source is still an eligible holder of the new
+   *  placement. Absent ⇒ no source is ever unstaged, the pre-pool behavior. */
+  daemons?: Pick<DaemonRepo, 'getUnscoped'>
   /** Resolves the members currently serving an agent — the sources a move must quiesce when
    *  placement names no machine of its own. Absent ⇒ placement alone (the pre-duty behavior). */
   placement?: PlacementResolver
@@ -487,11 +495,14 @@ export class AgentMoveService {
     // snapshot, never this pre-detach copy.
     const sourceBundle = await this.snapshot(agent)
 
+    const stagedSources = new Map<DaemonId, string>()
     for (const sourceDaemonId of sourceDaemonIds) {
+      const moveId = randomUUID()
+      stagedSources.set(sourceDaemonId, moveId)
       try {
         requireAck(
           'source cutover',
-          await this.detach(sourceDaemonId, agent.id, agent.orgId, { discardActiveTurns: true })
+          await this.detach(sourceDaemonId, agent.id, agent.orgId, { moveId, discardActiveTurns: true })
         )
       } catch (err) {
         if (sourceDetachMode === 'required') {
@@ -535,6 +546,7 @@ export class AgentMoveService {
     // through `duty/fetch` and starts serving. Committing the placement IS the move — a
     // synchronous activation would only name one member the ledger is free to replace next beat.
     if (target.kind !== 'daemon') {
+      await this.unstageEligibleSources(moved, stagedSources, target)
       await this.convergeDerived(moved, sourceBundle.httpBotIds)
       return moved
     }
@@ -561,6 +573,53 @@ export class AgentMoveService {
 
     await this.convergeDerived(stable.agent, stable.bundle.httpBotIds)
     return stable.agent
+  }
+
+  /**
+   * Clear the staging fence on a source that is STILL an eligible holder of the new placement.
+   *
+   * A detached source is normally meant to stay fenced — that is the whole point of a hard
+   * cutover, and it is right for every move onto a machine and for a LOCAL daemon losing an agent
+   * to the pool: neither may serve it again. `daemon(member) → pool` is the one transition where
+   * it is wrong. The member remains install-wide, so the ledger may hand it the very group it was
+   * just fenced out of — and `installGrantedAgents` skips a move-staged agent, so it would take
+   * the lease, install nothing, and serve nothing, with no other member able to claim it. The
+   * agent would be servable by nobody, which is worse than where it started.
+   *
+   * So the fence is released with the same move token that armed it, which is also what leaves
+   * the member's replica current: if the ledger grants it back, install-on-grant sees the agent
+   * present at the granted revision and skips the fetch entirely. Eligibility is the resolver's
+   * answer, not a kind test — a local daemon is never eligible for a pool placement and stays
+   * fenced. Best-effort: the fence is the member's own state and a member that cannot be reached
+   * re-registers into a reconcile that has the authoritative placement.
+   */
+  private async unstageEligibleSources(
+    agent: AgentRecord,
+    stagedSources: ReadonlyMap<DaemonId, string>,
+    target: PlacementTarget
+  ): Promise<void> {
+    if (stagedSources.size === 0) return
+    const columns = placementColumns(target)
+    const bundle = await this.snapshot(agent)
+    for (const [daemonId, moveId] of stagedSources) {
+      const daemon = await this.deps.daemons?.getUnscoped(daemonId)
+      if (!daemon || !mayHold(columns, { daemonId, scope: claimScopeOf(daemon) })) continue
+      try {
+        requireAck(
+          'source unstage',
+          await this.deps.control.agentActivate(
+            daemonId,
+            { ...this.activationDefinition(agent, bundle), moveId },
+            agent.orgId
+          )
+        )
+      } catch (err) {
+        this.deps.log?.warn(
+          { err, agentId: agent.id, daemonId },
+          'agent move: could not clear the source staging fence; its reconnect reconcile is the backstop'
+        )
+      }
+    }
   }
 
   private async restoreDetachedWorkspace(
@@ -922,21 +981,16 @@ export class AgentMoveService {
     }
   }
 
+  /** The placement and daemon activation are already committed, and every one of these projections
+   *  has a reconnect/replay backstop, so a transient fan-out error is logged rather than turning a
+   *  committed move into a 500. Shared with the duty path (`orchestrator/agentRouting.ts`): a
+   *  holder change moves who serves the agent exactly as a placement move does, and two copies of
+   *  this list would be two chances to forget one. */
   private async convergeDerived(agent: AgentRecord, httpBotIds: string[]): Promise<void> {
-    const jobs: Array<{ label: string; run: () => Promise<void> }> = [
-      { label: 'hook routes', run: () => this.deps.hooks.rebroadcastForAgent(agent.id) },
-      { label: 'collaboration routes', run: () => this.deps.collabRoutes.broadcast(agent.orgId) },
-      ...httpBotIds.map((botId) => ({ label: `HTTP bot ${botId}`, run: () => this.deps.httpBot.syncBot(botId) }))
-    ]
-    for (const job of jobs) {
-      try {
-        await job.run()
-      } catch (err) {
-        // The placement and daemon activation are already committed. Each of
-        // these derived tables has a reconnect/replay convergence backstop, so a
-        // transient fan-out error is logged rather than turning success into 500.
-        this.deps.log?.warn({ err, agentId: agent.id, job: job.label }, 'agent move: derived convergence deferred')
-      }
-    }
+    await convergeAgentRouting(
+      this.deps,
+      { agentId: agent.id, orgId: agent.orgId, httpBotIds },
+      { warn: (obj, msg) => this.deps.log?.warn(obj, msg) }
+    )
   }
 }

--- a/packages/control-plane/src/orchestrator/agentRouting.ts
+++ b/packages/control-plane/src/orchestrator/agentRouting.ts
@@ -1,0 +1,132 @@
+/**
+ * `convergeAgentRouting` — re-derive every projection that BAKES IN which daemon serves an agent.
+ *
+ * Most of the CP resolves that per use, through `PlacementResolver`. Three things cannot: the
+ * compiled hook rules the relay dispatches on, the HTTP bot's `rc/bot-assign` table, and the
+ * collaboration snapshot peers are woken through. Each is computed once and pushed, so each holds
+ * a member id that was true only at compile time.
+ *
+ * A placement move has always re-converged them (`AgentMoveService.convergeDerived`, which now
+ * calls this). A DUTY change never did — and that is the gap that made "the sweep re-granted it"
+ * stop short of "it heals": the agent is installed on the new member while ingress keeps arriving
+ * at the old one. A holder change moves who serves the agent exactly as a placement move does, so
+ * it converges through the same code rather than a second, drifting copy of it.
+ *
+ * Deliberately NOT here: thread affinity and `SessionMeta.daemonId`. Those are per-conversation
+ * provenance that a placement move does not invalidate either; they are a separate, pre-existing
+ * question (`docs/designs/k8s-daemon-pool.md` §8) and inventing an answer for the duty path alone
+ * would make the two disagree.
+ */
+import type { AgentId } from '../domain/ids.js'
+import type { AgentRepo, IntegrationRepo } from '../persistence/ports.js'
+import type { Clock, TimerHandle } from '../domain/clock.js'
+
+/** The three pushed projections, as the narrow surface each one is used through. */
+export interface RoutingProjections {
+  hooks: { rebroadcastForAgent(agentId: string): Promise<void> }
+  collabRoutes: { broadcast(orgId?: string): Promise<void> }
+  httpBot: { syncBot(botId: string): Promise<void> }
+}
+
+export interface RoutingConvergeLog {
+  warn(obj: unknown, msg?: string): void
+}
+
+/** One agent's convergence inputs: the projections are keyed by agent, org and bot respectively. */
+export interface RoutingTarget {
+  agentId: string
+  orgId: string
+  /** The agent's HTTP-transport bots — an `rc/bot-assign` names its members by daemon. */
+  httpBotIds: readonly string[]
+}
+
+/**
+ * Push all three projections for one agent. Each job is independently caught: they are pushes
+ * over a live wire, every one of them has a reconnect/replay backstop, and a transient failure in
+ * one must not stop the other two — the same posture `convergeDerived` has always had.
+ */
+export async function convergeAgentRouting(
+  deps: RoutingProjections,
+  target: RoutingTarget,
+  log?: RoutingConvergeLog
+): Promise<void> {
+  const jobs: Array<{ label: string; run: () => Promise<void> }> = [
+    { label: 'hook routes', run: () => deps.hooks.rebroadcastForAgent(target.agentId) },
+    { label: 'collaboration routes', run: () => deps.collabRoutes.broadcast(target.orgId) },
+    ...target.httpBotIds.map((botId) => ({ label: `HTTP bot ${botId}`, run: () => deps.httpBot.syncBot(botId) }))
+  ]
+  for (const job of jobs) {
+    try {
+      await job.run()
+    } catch (err) {
+      log?.warn({ err, agentId: target.agentId, job: job.label }, 'agent routing convergence deferred')
+    }
+  }
+}
+
+/**
+ * The duty side's entry point: "these agents changed hands, re-converge what routes to them."
+ *
+ * Coalescing and fire-and-forget for the same reasons `DutyRecomputeSweep.kick` is: the callers
+ * are a heartbeat exchange and a sweep tick, neither of which may block on a relay push, and one
+ * beat routinely moves several groups covering the same agent. The reconnect/replay path remains
+ * the backstop, so a dropped kick costs latency, never correctness.
+ */
+export class AgentRoutingConverger {
+  private readonly pending = new Set<string>()
+  private timer: TimerHandle | undefined
+  private stopped = false
+
+  constructor(
+    private readonly deps: RoutingProjections & {
+      agents: Pick<AgentRepo, 'listByIds'>
+      integrations: Pick<IntegrationRepo, 'listForAgent'>
+      bots: { getUnscoped(botId: string): Promise<{ transport: string } | null> }
+      clock: Clock
+      /** Coalescing window; a burst covering one agent costs one convergence. */
+      delayMs: number
+      log?: RoutingConvergeLog
+    }
+  ) {}
+
+  stop(): void {
+    this.stopped = true
+    if (this.timer !== undefined) {
+      this.deps.clock.clearTimeout(this.timer)
+      this.timer = undefined
+    }
+    this.pending.clear()
+  }
+
+  kick(agentIds: Iterable<string>): void {
+    if (this.stopped) return
+    for (const agentId of agentIds) this.pending.add(agentId)
+    if (this.pending.size === 0 || this.timer !== undefined) return
+    this.timer = this.deps.clock.setTimeout(() => {
+      this.timer = undefined
+      const agentIds = [...this.pending]
+      this.pending.clear()
+      void this.converge(agentIds).catch((err) =>
+        this.deps.log?.warn({ err, agentIds }, 'agent routing convergence kick failed')
+      )
+    }, this.deps.delayMs)
+  }
+
+  /** Exported for tests; the timer path calls exactly this. */
+  async converge(agentIds: readonly string[]): Promise<void> {
+    const agents = await this.deps.agents.listByIds(agentIds as AgentId[])
+    for (const agent of agents) {
+      const integrations = await this.deps.integrations.listForAgent(agent.id)
+      const httpBotIds = new Set<string>()
+      for (const integration of integrations) {
+        const bot = await this.deps.bots.getUnscoped(integration.botId)
+        if (bot?.transport === 'http') httpBotIds.add(integration.botId)
+      }
+      await convergeAgentRouting(
+        this.deps,
+        { agentId: agent.id, orgId: agent.orgId, httpBotIds: [...httpBotIds] },
+        this.deps.log
+      )
+    }
+  }
+}

--- a/packages/control-plane/src/orchestrator/collabRoutes.service.ts
+++ b/packages/control-plane/src/orchestrator/collabRoutes.service.ts
@@ -18,6 +18,7 @@ import { buildCollabSnapshot } from './collabSnapshot.js'
 import type { CollabChannelRoute, CollabOrgAgent, CollabRoutesSnapshot } from '@agentconnect.md/protocol'
 import type { OrgId } from '../domain/ids.js'
 import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
+import { servedAgents, type DutyHeldAgentReader } from './servedAgents.js'
 
 export class CollabRoutesService {
   private tail: Promise<void> = Promise.resolve()
@@ -30,7 +31,10 @@ export class CollabRoutesService {
     private readonly control?: ControlSender,
     /** Names the member each peer is routable at (placement, or the current duty holder).
      *  Absent (tests / no pool) ⇒ the directory's own placement, which is the pre-duty behavior. */
-    private readonly placement: Pick<PlacementResolver, 'resolveDirectory'> = PLACEMENT_ONLY
+    private readonly placement: Pick<PlacementResolver, 'resolveDirectory'> = PLACEMENT_ONLY,
+    /** The duty half of "which orgs does this install-wide member serve".
+     *  Absent (tests / no pool) ⇒ placement alone, which is the pre-duty behavior. */
+    private readonly duties?: DutyHeldAgentReader
   ) {}
 
   private serialize<T>(run: () => Promise<T>): Promise<T> {
@@ -52,7 +56,15 @@ export class CollabRoutesService {
         orgIds.add(daemon.orgId)
         continue
       }
-      for (const agent of await this.agents.listForDaemon(daemon.id)) orgIds.add(agent.orgId)
+      // An install-wide member's orgs are the orgs of the agents it SERVES. Placement alone would
+      // miss every pool agent — they name no machine — and drop that org from the relay's
+      // full-replace table, so its peers would stop being callable.
+      const served = await servedAgents(daemon.id, {
+        agents: this.agents,
+        ...(this.duties ? { duties: this.duties } : {}),
+        now: new Date()
+      })
+      for (const agent of served.agents) orgIds.add(agent.orgId)
     }
     const channels: CollabChannelRoute[] = []
     const agents: CollabOrgAgent[] = []

--- a/packages/control-plane/src/orchestrator/collabRoutes.service.ts
+++ b/packages/control-plane/src/orchestrator/collabRoutes.service.ts
@@ -17,6 +17,7 @@ import type { AgentRepo, DaemonRecord, DaemonRepo, IntegrationRepo } from '../pe
 import { buildCollabSnapshot } from './collabSnapshot.js'
 import type { CollabChannelRoute, CollabOrgAgent, CollabRoutesSnapshot } from '@agentconnect.md/protocol'
 import type { OrgId } from '../domain/ids.js'
+import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
 
 export class CollabRoutesService {
   private tail: Promise<void> = Promise.resolve()
@@ -26,7 +27,10 @@ export class CollabRoutesService {
     private readonly integrations: IntegrationRepo,
     private readonly agents: AgentRepo,
     private readonly relayControl: RelayControlSender,
-    private readonly control?: ControlSender
+    private readonly control?: ControlSender,
+    /** Names the member each peer is routable at (placement, or the current duty holder).
+     *  Absent (tests / no pool) ⇒ the directory's own placement, which is the pre-duty behavior. */
+    private readonly placement: Pick<PlacementResolver, 'resolveDirectory'> = PLACEMENT_ONLY
   ) {}
 
   private serialize<T>(run: () => Promise<T>): Promise<T> {
@@ -55,7 +59,9 @@ export class CollabRoutesService {
     let platformKinds: CollabRoutesSnapshot['platformKinds'] = []
     for (const orgId of orgIds) {
       const placements = await this.integrations.channelPlacements(orgId)
-      const orgAgents = await this.agents.orgDirectory(orgId)
+      // The directory carries placement, not a live daemon: the resolver fills in who serves each
+      // agent right now, and drops the ones nothing does.
+      const orgAgents = await this.placement.resolveDirectory(await this.agents.orgDirectory(orgId))
       const snapshot = buildCollabSnapshot(orgId, placements, generation, orgAgents)
       channels.push(...snapshot.channels)
       agents.push(...snapshot.agents)

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -11,6 +11,7 @@ import {
 } from '@agentconnect.md/protocol'
 import type { DutyGroupRepo, DutyGroupRecord, DutyGrantRecord } from '../persistence/ports.js'
 import type { AgentId, DaemonId, OrgId } from '../domain/ids.js'
+import type { DutyClaimScope } from '../domain/placement.js'
 import type { Clock } from '../domain/clock.js'
 
 export interface DutyLeaseConfig {
@@ -28,11 +29,13 @@ export interface DutyLeaseConfig {
   grantMembersPerFrame: number
   /** Revocations per duty/revoke frame (schema caps at 1000). */
   revocationsPerFrame: number
-  /** Vacancy grant policy. `incumbent` (the soak default until the shared data
-   *  plane lands) pins grants to groups whose agents already live on the
-   *  claimant, so the machinery runs without moving anyone; `any` is the target
-   *  pool behavior. */
-  grantPolicy: 'incumbent' | 'any'
+  /** Consecutive beats a member may leave a group it holds out of its digest before the lease is
+   *  handed back. An install can straddle one beat, so this must be >1 to be a refusal rather than
+   *  a race; a member that keeps refusing is one that cannot serve the group. */
+  refusalsBeforeRelease: number
+  /** How long a group stays unclaimable by the member that just gave it back, so the rotation
+   *  reaches a member that can install it instead of returning to the one that could not. */
+  refusalBackoffMs: number
 }
 
 export const DUTY_LEASE_DEFAULTS: DutyLeaseConfig = {
@@ -42,7 +45,8 @@ export const DUTY_LEASE_DEFAULTS: DutyLeaseConfig = {
   grantsPerFrame: 50,
   grantMembersPerFrame: 2000,
   revocationsPerFrame: 500,
-  grantPolicy: 'incumbent'
+  refusalsBeforeRelease: 3,
+  refusalBackoffMs: 300_000
 }
 
 type Send = (type: 'duty/grant' | 'duty/revoke' | 'duty/renewed', payload: unknown) => void
@@ -84,6 +88,13 @@ interface DaemonLane {
   tail: Promise<void>
 }
 
+/** One member's refusal state for one group: how many beats it has left the group out of its
+ *  digest, and — once it gave the lease back — until when it must not re-take it. */
+interface RefusalState {
+  misses: number
+  backoffUntilMs?: number
+}
+
 export class DutyLeaseService {
   private readonly bootedAtMs: number
   /** Per-daemon serialization lane: WS handlers dispatch without awaiting, so
@@ -92,6 +103,9 @@ export class DutyLeaseService {
    *  interleave with a running exchange (its ack has to mean "every grant sent
    *  before it is already on the wire, and nothing else was granted since"). */
   private readonly lanes = new Map<string, DaemonLane>()
+  /** daemonId → groupId → refusal state. Per CP instance, which is exact rather than approximate:
+   *  a member has one socket, so every beat and every grant for it lands on this process. */
+  private readonly refusals = new Map<string, Map<string, RefusalState>>()
 
   constructor(
     private readonly repo: DutyGroupRepo,
@@ -126,6 +140,82 @@ export class DutyLeaseService {
         return revision === undefined ? member : { ...member, configRevision: revision.toString() }
       })
     }))
+  }
+
+  /**
+   * Bound the cost of a group one member cannot install.
+   *
+   * A refused grant is invisible on the wire: the member simply never reports the group, so the
+   * CP's missing-regrant path offers it back on the next beat — and `renewHeld` renews by holder
+   * alone, so the lease never lapses either. Left alone, one member that cannot install an agent
+   * holds its group for as long as it keeps beating, and no member that CAN install it is ever
+   * offered the vacancy. The daemon's own per-agent failure stamp (#976) does not help: it paces
+   * one member's fetches, it does not move the group.
+   *
+   * So the CP counts consecutive beats in which a held group is absent from the digest. An install
+   * legitimately straddles one beat, which is why the threshold is above one rather than a single
+   * miss. Past it the lease is handed back and the group enters a per-member backoff, so the next
+   * claim reaches a different member and the rotation is bounded by member count rather than
+   * unbounded in time. Reporting the group at any point clears the count — that is convergence.
+   *
+   * Deliberately only the MISSING case. A member that refused a replacement shrank the group and
+   * still reports it at the old term (#977), so it is serving the shared part; taking that away
+   * over a failing addition would cost service rather than move it. Its retry is the stale-term
+   * re-issue, which costs nothing against headroom.
+   *
+   * Returns the missing groups still worth re-issuing to this member.
+   */
+  private async settleRefusals(
+    daemonId: DaemonId,
+    digestIds: ReadonlySet<string>,
+    missing: DutyGroupRecord[]
+  ): Promise<DutyGroupRecord[]> {
+    const nowMs = this.clock.now()
+    const states = this.refusals.get(daemonId) ?? new Map<string, RefusalState>()
+    for (const [groupId, state] of states) {
+      if (digestIds.has(groupId)) states.delete(groupId)
+      else if (state.backoffUntilMs !== undefined && state.backoffUntilMs <= nowMs) states.delete(groupId)
+    }
+
+    const regrant: DutyGroupRecord[] = []
+    const surrendered: string[] = []
+    for (const group of missing) {
+      const state = states.get(group.groupId) ?? { misses: 0 }
+      // A group already in backoff cannot be missing-and-held at the same time (the release
+      // vacated it), so reaching here means it was re-claimed elsewhere and lost again.
+      state.misses += 1
+      if (state.misses < this.config.refusalsBeforeRelease) {
+        states.set(group.groupId, state)
+        regrant.push(group)
+        continue
+      }
+      states.set(group.groupId, { misses: 0, backoffUntilMs: nowMs + this.config.refusalBackoffMs })
+      surrendered.push(group.groupId)
+    }
+    if (states.size > 0) this.refusals.set(daemonId, states)
+    else this.refusals.delete(daemonId)
+
+    if (surrendered.length > 0) {
+      await this.repo.release(daemonId, surrendered)
+      this.log?.warn(
+        { daemonId, groupIds: surrendered, beats: this.config.refusalsBeforeRelease },
+        'duty groups were granted but never reported as held; lease handed back so another member can take them'
+      )
+    }
+    return regrant
+  }
+
+  /** Groups this member gave back too recently to be offered again. */
+  private backedOff(daemonId: DaemonId): string[] {
+    const nowMs = this.clock.now()
+    const states = this.refusals.get(daemonId)
+    if (!states) return []
+    return [...states].filter(([, s]) => s.backoffUntilMs !== undefined && s.backoffUntilMs > nowMs).map(([id]) => id)
+  }
+
+  /** Forget a departed member's refusal state — its lane is gone and so is its socket. */
+  forget(daemonId: DaemonId): void {
+    this.refusals.delete(daemonId)
   }
 
   /** Chain `fn` on the daemon's lane so operations never interleave. */
@@ -188,19 +278,24 @@ export class DutyLeaseService {
       )
     }
 
+    const regrant = await this.settleRefusals(daemonId, digestIds, deliverable(missing))
+
     let granted: DutyGrantRecord[] = []
-    const budget = Math.max(0, duties.headroom - deliverable(missing).length)
+    const budget = Math.max(0, duties.headroom - regrant.length)
     if (budget > 0 && this.clock.now() >= this.bootedAtMs + this.config.recoveryGraceMs) {
       // Oversized groups are excluded at the claim boundary (the size gate), so
       // a claim never lands on a group it would immediately have to release.
+      // `scope` is install-wide because the heartbeat handler only reaches this service on an
+      // org-less connection; it is passed rather than assumed so the gate stays a predicate.
       granted = await this.repo.claimVacant(
         daemonId,
         Math.min(budget, this.config.grantMaxPerTick),
         now,
         this.config.leaseMs,
         {
+          scope: 'install-wide',
           maxMembers: DUTY_GRANT_MEMBERS_MAX,
-          incumbentOnly: this.config.grantPolicy === 'incumbent'
+          excludeGroupIds: this.backedOff(daemonId)
         }
       )
     }
@@ -238,7 +333,7 @@ export class DutyLeaseService {
       )
     }
     const grants = await this.stamp([
-      ...deliverable(missing).map(toGrantEntry),
+      ...regrant.map(toGrantEntry),
       ...deliverable(stale).map(toGrantEntry),
       ...granted.map(toGrantEntry)
     ])
@@ -264,17 +359,21 @@ export class DutyLeaseService {
    * that was handed a trigger it does not serve. Serialized on the member's lane
    * like every other ledger touch, so a claim cannot interleave with its own
    * heartbeat exchange. Returns a grant the member can install verbatim, or the
-   * incumbent it lost to.
+   * incumbent it lost to. `scope` carries the claimant's connection scope into the same
+   * eligibility gate the heartbeat claim uses: a trigger reaching the wrong member is not
+   * authority to serve an agent that member may not hold.
    */
   async claimAgentHome(
     orgId: OrgId,
     agentId: AgentId,
-    holder: DaemonId
+    holder: DaemonId,
+    scope: DutyClaimScope
   ): Promise<{ granted: boolean; grant?: DutyGrantEntry; holder?: string }> {
     return this.serialize(holder, async () => {
       const now = new Date(this.clock.now())
-      const claim = await this.repo.claimAgentHome(orgId, agentId, holder, now, this.config.leaseMs)
-      if (!claim.granted) return claim.holder ? { granted: false, holder: claim.holder } : { granted: false }
+      const claim = await this.repo.claimAgentHome(orgId, agentId, holder, now, this.config.leaseMs, scope)
+      if (!claim.granted || claim.groupId === undefined)
+        return claim.holder ? { granted: false, holder: claim.holder } : { granted: false }
       const [group] = await this.repo.getByIds([claim.groupId])
       // An oversized group is undeliverable on this wire (§ member cap), so the
       // claim is handed straight back rather than wedged held-but-unserved.

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -264,6 +264,21 @@ export class DutyLeaseService {
     const heldById = new Map(held.map((g) => [g.groupId, g]))
     const digestIds = new Set(duties.held.map((d) => d.groupId))
 
+    // The ADD side of routing convergence, and it belongs HERE rather than at the grant: a grant is
+    // applied daemon-side only after its install succeeds (#972), so a group appearing in the
+    // digest is the proof that the member is actually serving it. Publishing at grant time is the
+    // same error #976 fixed for the fence — the gate opening before the fact — and on a pushed
+    // projection it costs a message: relay ingress recovers through the rendezvous, but a
+    // cross-daemon peer wake forwards ONCE and takes a terminal miss.
+    //
+    // `confirmHeld` only stamps unconfirmed rows, so this fires on the first beat that reports a
+    // group and never again — no per-beat churn.
+    const confirmed = await this.repo.confirmHeld(daemonId, [...digestIds], now)
+    if (confirmed.length > 0) {
+      const groups = held.filter((g) => confirmed.includes(g.groupId))
+      this.routing?.kick(agentIdsOf(groups))
+    }
+
     // Re-issue held groups the member does not know it holds (restart / lost
     // grant EVT) or knows only at a stale term — the reconnect crossing point:
     // confirm the terms or supersede, never both. A missing group will occupy a
@@ -344,9 +359,6 @@ export class DutyLeaseService {
         'held duty groups grew past the grant member cap; superseded and vacated — move them to a dedicated tier'
       )
     }
-    // Fresh grants moved the agent to THIS member; the surrendered ones moved it away. Both are
-    // holder changes, and the projections that address a daemon have to be re-derived for them.
-    if (granted.length > 0) this.routing?.kick(agentIdsOf(granted))
     const grants = await this.stamp([
       ...regrant.map(toGrantEntry),
       ...deliverable(stale).map(toGrantEntry),
@@ -397,7 +409,9 @@ export class DutyLeaseService {
         return { granted: false }
       }
       const [grant] = await this.stamp([toGrantEntry(group)])
-      this.routing?.kick(agentIdsOf([group]))
+      // No routing kick here: like every other grant this is not yet a fact — the claimant
+      // installs before it answers, but the ledger has not seen the group in a digest. The
+      // member's next beat confirms it and converges then.
       return { granted: true, grant }
     })
   }

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -10,6 +10,7 @@ import {
   type DutyRevoke
 } from '@agentconnect.md/protocol'
 import type { DutyGroupRepo, DutyGroupRecord, DutyGrantRecord } from '../persistence/ports.js'
+import type { DutyMemberKey } from '../domain/duty.js'
 import type { AgentId, DaemonId, OrgId } from '../domain/ids.js'
 import type { DutyClaimScope } from '../domain/placement.js'
 import type { Clock } from '../domain/clock.js'
@@ -50,6 +51,11 @@ export const DUTY_LEASE_DEFAULTS: DutyLeaseConfig = {
 }
 
 type Send = (type: 'duty/grant' | 'duty/revoke' | 'duty/renewed', payload: unknown) => void
+
+/** The agent members of a set of groups — the unit a routing convergence is keyed on. */
+function agentIdsOf(groups: readonly { members: DutyMemberKey[] }[]): string[] {
+  return [...new Set(groups.flatMap((g) => g.members.filter((m) => m.kind === 'agent').map((m) => m.refId)))]
+}
 
 /** The freshness signal's source: the CP's current spec revision per agent. */
 export interface AgentRevisionReader {
@@ -113,7 +119,12 @@ export class DutyLeaseService {
     private readonly config: DutyLeaseConfig = DUTY_LEASE_DEFAULTS,
     private readonly log?: { warn(obj: unknown, msg?: string): void },
     /** Absent ⇒ unstamped entries, and a member falls back to presence alone. */
-    private readonly agentRevisions?: AgentRevisionReader
+    private readonly agentRevisions?: AgentRevisionReader,
+    /** Re-converges the routing projections that bake in the serving daemon. A grant or a release
+     *  moves who serves the agent, so the hook rules, HTTP-bot assignment and collaboration
+     *  snapshot have to follow — otherwise the ledger heals and ingress keeps arriving at the
+     *  member that lost it. Absent (tests / no pool) ⇒ no convergence, the pre-duty behavior. */
+    private readonly routing?: { kick(agentIds: Iterable<string>): void }
   ) {
     this.bootedAtMs = clock.now()
   }
@@ -197,6 +208,7 @@ export class DutyLeaseService {
 
     if (surrendered.length > 0) {
       await this.repo.release(daemonId, surrendered)
+      this.routing?.kick(agentIdsOf(missing.filter((g) => surrendered.includes(g.groupId))))
       this.log?.warn(
         { daemonId, groupIds: surrendered, beats: this.config.refusalsBeforeRelease },
         'duty groups were granted but never reported as held; lease handed back so another member can take them'
@@ -332,6 +344,9 @@ export class DutyLeaseService {
         'held duty groups grew past the grant member cap; superseded and vacated — move them to a dedicated tier'
       )
     }
+    // Fresh grants moved the agent to THIS member; the surrendered ones moved it away. Both are
+    // holder changes, and the projections that address a daemon have to be re-derived for them.
+    if (granted.length > 0) this.routing?.kick(agentIdsOf(granted))
     const grants = await this.stamp([
       ...regrant.map(toGrantEntry),
       ...deliverable(stale).map(toGrantEntry),
@@ -382,6 +397,7 @@ export class DutyLeaseService {
         return { granted: false }
       }
       const [grant] = await this.stamp([toGrantEntry(group)])
+      this.routing?.kick(agentIdsOf([group]))
       return { granted: true, grant }
     })
   }
@@ -406,6 +422,12 @@ export class DutyLeaseService {
    *  every grant that exchange emitted reaches the daemon BEFORE this ack, and
    *  no grant can slip in between the vacate and the ack. */
   release(daemonId: DaemonId, groupIds: string[]): Promise<void> {
-    return this.serialize(daemonId, () => this.repo.release(daemonId, groupIds))
+    return this.serialize(daemonId, async () => {
+      // Read the membership BEFORE the vacate: `release` keeps the rows, but reading after would
+      // race a successor's claim and converge for the wrong holder.
+      const groups = await this.repo.getByIds(groupIds)
+      await this.repo.release(daemonId, groupIds)
+      this.routing?.kick(agentIdsOf(groups))
+    })
   }
 }

--- a/packages/control-plane/src/orchestrator/dutyRecompute.ts
+++ b/packages/control-plane/src/orchestrator/dutyRecompute.ts
@@ -16,10 +16,6 @@ export interface DutyRecomputeConfig {
   orgsPerTick: number
   /** Renewal horizon for re-grants applied inside the reconcile. */
   leaseMs: number
-  /** Mirrors the lease exchange's grant policy: under `incumbent`, a placement
-   *  move must also move the duty, so each tick vacates leases whose holder no
-   *  longer hosts any of the group's agents. Flip together with the policy. */
-  incumbentFence: boolean
   /** Coalescing window for {@link DutyRecomputeSweep.kick}: a burst of writes to
    *  one org (an install touching several rows) costs one recompute. */
   kickDelayMs: number
@@ -40,7 +36,7 @@ export class DutyRecomputeSweep {
   constructor(
     private readonly repo: Pick<
       DutyGroupRepo,
-      'listDutyOrgs' | 'computeInputs' | 'applyReconcile' | 'vacateNonIncumbent'
+      'listDutyOrgs' | 'computeInputs' | 'applyReconcile' | 'vacateIneligible'
     >,
     private readonly clock: Clock,
     private readonly cfg: DutyRecomputeConfig,
@@ -121,10 +117,11 @@ export class DutyRecomputeSweep {
       (existing) => planDutyReconcile(toExistingDutyGroups(existing, now), components),
       { now, leaseMs: this.cfg.leaseMs }
     )
-    if (this.cfg.incumbentFence) {
-      const vacated = await this.repo.vacateNonIncumbent(OrgId(orgId))
-      if (vacated.length > 0)
-        this.log?.warn({ orgId, groupIds: vacated }, 'duty leases vacated after a placement move-away')
-    }
+    // Unconditional: this is the placement fence, not a soak-phase switch. A lease whose holder
+    // may no longer hold the group is wrong under every grant policy, and the sweep is the only
+    // place that notices — `renewHeld` renews by holder alone and would keep it alive forever.
+    const vacated = await this.repo.vacateIneligible(OrgId(orgId))
+    if (vacated.length > 0)
+      this.log?.warn({ orgId, groupIds: vacated }, 'duty leases vacated: the holder is no longer eligible')
   }
 }

--- a/packages/control-plane/src/orchestrator/dutyRecompute.ts
+++ b/packages/control-plane/src/orchestrator/dutyRecompute.ts
@@ -36,11 +36,14 @@ export class DutyRecomputeSweep {
   constructor(
     private readonly repo: Pick<
       DutyGroupRepo,
-      'listDutyOrgs' | 'computeInputs' | 'applyReconcile' | 'vacateIneligible'
+      'listDutyOrgs' | 'computeInputs' | 'applyReconcile' | 'vacateIneligible' | 'getByIds'
     >,
     private readonly clock: Clock,
     private readonly cfg: DutyRecomputeConfig,
-    private readonly log?: DutyRecomputeLog
+    private readonly log?: DutyRecomputeLog,
+    /** Re-converges the routing projections when the fence moves a group's holder. Absent
+     *  (tests / no pool) ⇒ no convergence, the pre-duty behavior. */
+    private readonly routing?: { kick(agentIds: Iterable<string>): void }
   ) {}
 
   start(): void {
@@ -121,7 +124,12 @@ export class DutyRecomputeSweep {
     // may no longer hold the group is wrong under every grant policy, and the sweep is the only
     // place that notices — `renewHeld` renews by holder alone and would keep it alive forever.
     const vacated = await this.repo.vacateIneligible(OrgId(orgId))
-    if (vacated.length > 0)
+    if (vacated.length > 0) {
       this.log?.warn({ orgId, groupIds: vacated }, 'duty leases vacated: the holder is no longer eligible')
+      // A vacated lease is a holder change like any other: whatever addressed the old holder has
+      // to stop, or ingress keeps arriving at a member that no longer serves the agent.
+      const groups = await this.repo.getByIds(vacated)
+      this.routing?.kick(groups.flatMap((g) => g.members.filter((m) => m.kind === 'agent').map((m) => m.refId)))
+    }
   }
 }

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -139,7 +139,7 @@ export class HttpBotOrchestrator {
     private readonly agentDelivery: AgentDelivery,
     /** Names the one member the relay addresses ingress to. Placement when it names a machine;
      *  for a pool agent, the member currently holding its duty — placement names none. */
-    private readonly placement: Pick<PlacementResolver, 'servingDaemon'> = PLACEMENT_ONLY
+    private readonly placement: Pick<PlacementResolver, 'routableDaemon'> = PLACEMENT_ONLY
   ) {}
 
   /**
@@ -753,7 +753,7 @@ export class HttpBotOrchestrator {
     for (const integration of integrations) {
       const agent = agentById.get(integration.agentId)
       if (!agent) continue
-      const daemonId = await this.placement.servingDaemon(agent)
+      const daemonId = await this.placement.routableDaemon(agent)
       if (!daemonId) continue
       placed.push({ integration, agent, daemonId, gated: isGatedAgent(agent) })
     }

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -46,6 +46,7 @@ import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 import { ControlSender, NoConnection } from './outbound.js'
 import { isGatedAgent, httpIntegrationToSpec } from './placement.js'
 import type { AgentDelivery } from './agentDelivery.js'
+import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
 import type { CpPlatformRegistry } from '../platforms/provider.js'
 import { AgentId, BotId, DaemonId } from '../domain/ids.js'
 
@@ -83,7 +84,7 @@ interface Compiled {
    *  without delivery must not latch). */
   noticedDmConversations: string[]
   /** Placed member integrations (spec push targets: daemonId + integration). */
-  placed: { integration: IntegrationRecord; daemonId: string; gated: boolean }[]
+  placed: { integration: IntegrationRecord; agent: AgentRecord; daemonId: string; gated: boolean }[]
 }
 
 /** Resolve a persisted owner marker to its active integration, falling back to
@@ -134,8 +135,11 @@ export class HttpBotOrchestrator {
     private readonly platforms: CpPlatformRegistry,
     /** Resolves where a dependent of an agent goes (placement ∪ duty holders).
      *  Used ONLY for the send-only spec and its removal — the relay's own
-     *  `rc/assign` target stays the placement, which is routing, not replication. */
-    private readonly agentDelivery: AgentDelivery
+     *  `rc/assign` target is one member, resolved below. */
+    private readonly agentDelivery: AgentDelivery,
+    /** Names the one member the relay addresses ingress to. Placement when it names a machine;
+     *  for a pool agent, the member currently holding its duty — placement names none. */
+    private readonly placement: Pick<PlacementResolver, 'servingDaemon'> = PLACEMENT_ONLY
   ) {}
 
   /**
@@ -308,7 +312,7 @@ export class HttpBotOrchestrator {
     for (const integration of installs) {
       const agent = await this.agents.getUnscoped(integration.agentId)
       if (!agent) continue
-      await this.agentDelivery.integrationRemove(agent.id, agent.daemonId, integration.id, integration.orgId, (err) => {
+      await this.agentDelivery.integrationRemove(agent, integration.id, integration.orgId, (err) => {
         if (!(err instanceof NoConnection)) throw err
         this.log.debug?.({ integrationId: integration.id }, 'http-bot: revoke spec removal skipped — daemon offline')
       })
@@ -742,16 +746,17 @@ export class HttpBotOrchestrator {
       const a = await this.agents.getUnscoped(i.agentId)
       if (a) agentById.set(i.agentId, a)
     }
-    // Only agents currently PLACED on a daemon can receive traffic.
-    const placed = integrations
-      .map((integration) => ({ integration, agent: agentById.get(integration.agentId) }))
-      .filter((x): x is { integration: IntegrationRecord; agent: AgentRecord } => !!x.agent?.daemonId)
-      .map((x) => ({
-        integration: x.integration,
-        agent: x.agent,
-        daemonId: x.agent.daemonId!,
-        gated: isGatedAgent(x.agent)
-      }))
+    // Only agents a daemon is currently SERVING can receive traffic. The relay addresses ingress
+    // to one member, so a pool agent resolves to whichever member holds its duty — placement
+    // names no machine and would strand the whole install.
+    const placed: { integration: IntegrationRecord; agent: AgentRecord; daemonId: string; gated: boolean }[] = []
+    for (const integration of integrations) {
+      const agent = agentById.get(integration.agentId)
+      if (!agent) continue
+      const daemonId = await this.placement.servingDaemon(agent)
+      if (!daemonId) continue
+      placed.push({ integration, agent, daemonId, gated: isGatedAgent(agent) })
+    }
     if (placed.length === 0) return null
 
     // members: daemonId → agentIds (the daemon connections the relay expects).
@@ -859,7 +864,12 @@ export class HttpBotOrchestrator {
       gatedOffChannels,
       noticedDmConversations,
       botChannels: chans,
-      placed: placed.map((p) => ({ integration: p.integration, daemonId: p.daemonId, gated: p.gated }))
+      placed: placed.map((p) => ({
+        integration: p.integration,
+        agent: p.agent,
+        daemonId: p.daemonId,
+        gated: p.gated
+      }))
     }
   }
 
@@ -870,13 +880,13 @@ export class HttpBotOrchestrator {
     // last-hop admission backstop (§14.3), and EVERY install carries its Off channels
     // for the same backstop. The compile already read the bot's rows; they are keyed
     // per install, so filter by integrationId.
-    for (const { integration, daemonId, gated } of compiled.placed) {
+    for (const { integration, agent, gated } of compiled.placed) {
       const channels = compiled.botChannels.filter((c) => c.integrationId === integration.id)
       const spec = await httpIntegrationToSpec(this.platforms, integration, bot, secret, channels, gated)
       // The relay still addresses ingress to `daemonId`; the send-only credential
       // bundle goes to every daemon serving the agent, so a duty holder is not
       // left signing egress with a credential the workspace has since rotated.
-      await this.agentDelivery.integrationUpsert(integration.agentId, daemonId, spec, (err, target) => {
+      await this.agentDelivery.integrationUpsert(agent, spec, (err, target) => {
         if (!(err instanceof NoConnection)) throw err
         this.log.debug?.(
           { integrationId: integration.id, daemonId: target },

--- a/packages/control-plane/src/orchestrator/integrationPush.ts
+++ b/packages/control-plane/src/orchestrator/integrationPush.ts
@@ -66,7 +66,7 @@ export async function convergeIntegrationGating(
       // reaches only the placement leaves a holder admitting conversations the
       // agent's new visibility forbids.
       const spec = await integrationToSpec(deps.platforms, i, bot, secret, channels, gated)
-      await deps.agentDelivery.integrationUpsert(agent.id, agent.daemonId, spec, (err) => {
+      await deps.agentDelivery.integrationUpsert(agent, spec, (err) => {
         if (err instanceof NoConnection) return // offline daemon → reconcile roster carries it
         throw err
       })

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -72,6 +72,7 @@ import type { AgentSpecAssembler } from './agentSpecAssembler.js'
 import { buildCollabSnapshot } from './collabSnapshot.js'
 import type { ConnectionRegistry, DaemonConnState } from '../ws/registry.js'
 import type { ControlSender } from './outbound.js'
+import type { PlacementResolver } from './placementResolver.js'
 import type { EpochService } from './epoch.js'
 import type { Clock } from '../domain/clock.js'
 
@@ -96,6 +97,8 @@ export interface PlacementOrchDeps {
   /** The duty ledger read that makes the reconcile roster `pinned-to-me ∪ agents
    *  in the duties I hold`. Absent (tests / no pool) ⇒ placement alone. */
   duties?: { heldAgentIds(holder: DaemonId, now: Date): Promise<AgentId[]> }
+  /** Resolves the peer directory's routing targets. Absent ⇒ placement alone. */
+  placement?: Pick<PlacementResolver, 'resolveDirectory'>
   /** Optional structured logger for reconcile-time skips (no live relay). */
   log?: { warn(obj: object, msg: string): void }
   // NOTE: icon URL bases moved into the AgentSpecAssembler (it owns spec assembly).
@@ -490,7 +493,15 @@ export class Placement implements ReconcileService {
         this.integrations.channelPlacements(orgId),
         this.agents.orgDirectory(orgId)
       ])
-      const snapshot = buildCollabSnapshot(orgId, placements, Number(daemon.routingEpoch), orgDirectory)
+      const snapshot = buildCollabSnapshot(
+        orgId,
+        placements,
+        Number(daemon.routingEpoch),
+        // Placement names the target for a machine-placed peer; the ledger names it for a pool
+        // one. `buildCollabSnapshot` drops rows with no daemon, so resolving here is what keeps a
+        // pool agent discoverable AND callable.
+        this.orch?.placement ? await this.orch.placement.resolveDirectory(orgDirectory) : orgDirectory
+      )
       collabRoutes.channels.push(...snapshot.channels)
       collabRoutes.agents.push(...snapshot.agents)
       collabRoutes.platformKinds = snapshot.platformKinds

--- a/packages/control-plane/src/orchestrator/placementResolver.ts
+++ b/packages/control-plane/src/orchestrator/placementResolver.ts
@@ -18,9 +18,19 @@ import { dutyEligibility, placementTargets, type PlacementRef } from '../domain/
 import { AgentId, type DaemonId } from '../domain/ids.js'
 import { systemClock, type Clock } from '../domain/clock.js'
 
-/** The duty-ledger read the resolver needs — the delivery half of `holdsAgent`. */
+/**
+ * The duty-ledger reads the resolver needs. TWO of them, and the difference is the point:
+ *
+ * - `holdersOf` — every live lease. Who must RECEIVE the agent's updates, and who may act for it.
+ *   A member that is still installing is included, because it has to receive its bundle to finish.
+ * - `confirmedHoldersOf` — only holds the member has reported in its digest. Who INGRESS may be
+ *   addressed at. Publishing a member here before it has admitted the grant is the same error
+ *   #976 fixed for the fence — the gate opens before the fact — and on a projection there is no
+ *   second chance: a cross-daemon peer wake forwards once and gets a terminal miss.
+ */
 export interface DutyHolderReader {
   holdersOf(agentId: AgentId, now: Date): Promise<DaemonId[]>
+  confirmedHoldersOf(agentId: AgentId, now: Date): Promise<DaemonId[]>
 }
 
 /** An agent as the resolver reads it: its identity plus the placement columns. */
@@ -41,6 +51,36 @@ export class PlacementResolver {
   private holders(agentId: string): Promise<DaemonId[]> {
     if (!this.deps.duties) return Promise.resolve([])
     return this.deps.duties.holdersOf(AgentId(agentId), new Date(this.deps.clock.now()))
+  }
+
+  private confirmedHolders(agentId: string): Promise<DaemonId[]> {
+    if (!this.deps.duties) return Promise.resolve([])
+    return this.deps.duties.confirmedHoldersOf(AgentId(agentId), new Date(this.deps.clock.now()))
+  }
+
+  /**
+   * Every daemon INGRESS may be addressed at. `servingDaemons` minus the holds the member has not
+   * confirmed yet — a grant it has not installed is a lease, not a route.
+   *
+   * Between a grant and its first digest this names NOBODY for a pool agent. For platform ingress
+   * that is fully covered — the trigger reaches a member and claims through the activation
+   * rendezvous. For a cross-daemon peer wake it is NOT covered, and the honest reason to prefer it
+   * anyway is narrower than "absence is retryable", because absence is terminal too
+   * (`admits()` fails closed on an agent missing from the directory, so the wake is refused
+   * locally as `not_allowed`): naming the installing member instead makes the relay AND the target
+   * cache a terminal `not_found` against that `deliveryId`, so even a retransmit stays dead after
+   * the member is ready. Absence refuses the attempt without poisoning the next one.
+   *
+   * Closing it properly needs a retryable verdict on `rd/agentmsg`, which that wire does not have
+   * — see the PR body; it is its own change.
+   */
+  async routableDaemons(agent: ResolvableAgent): Promise<string[]> {
+    return [...new Set([...placementTargets(agent), ...(await this.confirmedHolders(agent.id))])]
+  }
+
+  /** The one daemon an ingress projection should name, or null when nothing may be addressed. */
+  async routableDaemon(agent: ResolvableAgent): Promise<DaemonId | null> {
+    return ((await this.routableDaemons(agent))[0] as DaemonId | undefined) ?? null
   }
 
   /** Every daemon that serves this agent: what placement names, then every live duty holder. */
@@ -70,7 +110,9 @@ export class PlacementResolver {
   ): Promise<(T & { daemonId: string })[]> {
     const resolved: (T & { daemonId: string })[] = []
     for (const row of rows) {
-      const daemonId = await this.servingDaemon({ ...row, id: row.agentId })
+      // ROUTABLE, not serving: this directory is what a cross-daemon peer wake is addressed
+      // through, and it forwards once.
+      const daemonId = await this.routableDaemon({ ...row, id: row.agentId })
       if (daemonId) resolved.push({ ...row, daemonId })
     }
     return resolved
@@ -85,8 +127,8 @@ export class PlacementResolver {
    * there is exactly one daemon that may serve it.
    */
   async dispatchDaemon(agent: ResolvableAgent): Promise<DaemonId | null> {
-    const serving = await this.servingDaemon(agent)
-    if (serving) return serving
+    const routable = await this.routableDaemon(agent)
+    if (routable) return routable
     if (dutyEligibility(agent).scope !== 'install-wide') return null
     return ((this.deps.liveMembers?.() ?? [])[0] as DaemonId | undefined) ?? null
   }

--- a/packages/control-plane/src/orchestrator/placementResolver.ts
+++ b/packages/control-plane/src/orchestrator/placementResolver.ts
@@ -9,6 +9,10 @@
  *
  * No caller branches on the placement kind; a later `group` kind changes only this file and the
  * ledger predicate it mirrors.
+ *
+ * The inverse query — member→agents — is `servedAgents.ts`, which reads the same two relations
+ * from the other side; its header states the biconditional the pair has to satisfy and names the
+ * test that pins it.
  */
 import { dutyEligibility, placementTargets, type PlacementRef } from '../domain/placement.js'
 import { AgentId, type DaemonId } from '../domain/ids.js'

--- a/packages/control-plane/src/orchestrator/placementResolver.ts
+++ b/packages/control-plane/src/orchestrator/placementResolver.ts
@@ -1,0 +1,93 @@
+/**
+ * `PlacementResolver` — the ledger-aware half of `domain/placement.ts`, and the ONLY place that
+ * answers "which daemons serve this agent right now" once placement stopped being a member id.
+ *
+ * `domain/placement.ts` answers eligibility from the row alone; this adds the live duty leases, so
+ * a `pool` agent — which names no machine — still resolves to the member currently holding it. Two
+ * questions, one resolver: delivery/edge targets (`servingDaemons`, `servingDaemon`) and authority
+ * (`mayAct`, the "is this agent yours" fence every daemon-originated write applies).
+ *
+ * No caller branches on the placement kind; a later `group` kind changes only this file and the
+ * ledger predicate it mirrors.
+ */
+import { dutyEligibility, placementTargets, type PlacementRef } from '../domain/placement.js'
+import { AgentId, type DaemonId } from '../domain/ids.js'
+import { systemClock, type Clock } from '../domain/clock.js'
+
+/** The duty-ledger read the resolver needs — the delivery half of `holdsAgent`. */
+export interface DutyHolderReader {
+  holdersOf(agentId: AgentId, now: Date): Promise<DaemonId[]>
+}
+
+/** An agent as the resolver reads it: its identity plus the placement columns. */
+export type ResolvableAgent = PlacementRef & { id: string }
+
+export class PlacementResolver {
+  constructor(
+    private readonly deps: {
+      /** Absent (tests, or a deployment with no pool) ⇒ placement alone, which is the pre-duty behavior. */
+      duties?: DutyHolderReader
+      /** The install-wide members that are live right now. Only {@link PlacementResolver.dispatchDaemon}
+       *  uses it, and only as the rendezvous target — never as a claim of who serves what. */
+      liveMembers?: () => string[]
+      clock: Clock
+    }
+  ) {}
+
+  private holders(agentId: string): Promise<DaemonId[]> {
+    if (!this.deps.duties) return Promise.resolve([])
+    return this.deps.duties.holdersOf(AgentId(agentId), new Date(this.deps.clock.now()))
+  }
+
+  /** Every daemon that serves this agent: what placement names, then every live duty holder. */
+  async servingDaemons(agent: ResolvableAgent): Promise<string[]> {
+    return [...new Set([...placementTargets(agent), ...(await this.holders(agent.id))])]
+  }
+
+  /** The one daemon a live edge read should go to, or null when nothing serves the agent. */
+  async servingDaemon(agent: ResolvableAgent): Promise<DaemonId | null> {
+    return ((await this.servingDaemons(agent))[0] as DaemonId | undefined) ?? null
+  }
+
+  /** May this daemon act on the agent's behalf — report its sessions, mint its credentials, ask on
+   *  its behalf? True where it is the placement, and true where it holds the agent's duty. */
+  async mayAct(agent: ResolvableAgent, daemonId: string): Promise<boolean> {
+    return (await this.servingDaemons(agent)).includes(daemonId)
+  }
+
+  /**
+   * Fill the serving daemon into a directory projection, dropping every row nothing serves right
+   * now. The peer directory and the collaboration snapshot both need "who do I wake", which is a
+   * live question for a pool agent and a column read for a machine-placed one — so it is answered
+   * here once rather than at each surface, where the two could disagree.
+   */
+  async resolveDirectory<T extends PlacementRef & { agentId: string }>(
+    rows: readonly T[]
+  ): Promise<(T & { daemonId: string })[]> {
+    const resolved: (T & { daemonId: string })[] = []
+    for (const row of rows) {
+      const daemonId = await this.servingDaemon({ ...row, id: row.agentId })
+      if (daemonId) resolved.push({ ...row, daemonId })
+    }
+    return resolved
+  }
+
+  /**
+   * Where to send a TRIGGER for this agent. Distinct from {@link PlacementResolver.servingDaemon}
+   * on purpose: a pool agent whose lease has lapsed is served by nobody for one lease horizon, and
+   * refusing the trigger for that window is what left webchat permanently offline after a rollout
+   * (#987). Any live member is a correct target — it claims the agent's group on receipt (the
+   * activation rendezvous) and then serves the turn. A machine placement has no such fallback:
+   * there is exactly one daemon that may serve it.
+   */
+  async dispatchDaemon(agent: ResolvableAgent): Promise<DaemonId | null> {
+    const serving = await this.servingDaemon(agent)
+    if (serving) return serving
+    if (dutyEligibility(agent).scope !== 'install-wide') return null
+    return ((this.deps.liveMembers?.() ?? [])[0] as DaemonId | undefined) ?? null
+  }
+}
+
+/** The resolver a graph with no duty ledger gets: placement alone, which is exactly the pre-duty
+ *  behavior. Consumers default to it so a pool-less composition needs no wiring at all. */
+export const PLACEMENT_ONLY = new PlacementResolver({ clock: systemClock })

--- a/packages/control-plane/src/orchestrator/servedAgents.ts
+++ b/packages/control-plane/src/orchestrator/servedAgents.ts
@@ -1,13 +1,33 @@
 /**
  * `servedAgents` — the ONE answer to "which agents does this daemon serve".
  *
- * The daemon-side twin of `AgentDelivery.daemonsFor`: `pinned-to-me ∪ agents in
+ * The daemon-side twin of `PlacementResolver.servingDaemons`: `pinned-to-me ∪ agents in
  * the duties I hold`. #978 introduced that union inside `Placement.reconcile` for
  * the roster; anything else keyed on "what this daemon serves" — the MCP and
  * external-memory definitions the roster ships, and the inbound ownership gate on
  * daemon-reported memory facts — has to use the same one or a duty holder is
  * served an agent whose definitions, or whose probe reports, silently do not
  * belong to it. Recomputing it per caller is exactly the drift to avoid.
+ *
+ * ## Why this is not expressible over the resolver, and what keeps them honest
+ *
+ * The two are inverse queries over the same two relations, not one function and a wrapper:
+ * this one is member→agents, the resolver is agent→members. Neither can be written as the
+ * other without scanning the opposite side, so both exist — and the invariant that matters is
+ * that they never disagree:
+ *
+ *   `D ∈ servingDaemons(A)` ⟺ `A ∈ servedAgents(D).agents`
+ *
+ * It holds because each half reads ONE predicate from its own side:
+ *
+ * | Half      | member→agents (here)                    | agent→members (resolver)          |
+ * | --------- | --------------------------------------- | --------------------------------- |
+ * | placement | `listForDaemon` (`placementKind:'daemon'`, `daemonId`) | `placementTargets` (`domain/placement.ts`) |
+ * | duty      | `heldAgentIds(holder, now)`             | `holdersOf(agentId, now)`         |
+ *
+ * Both duty reads are the same live-lease join in `duty-group.repo.ts`, and both placement
+ * reads are now the same `(kind, ref)` pair rather than `daemonId` alone. `servedAgents.test.ts`
+ * pins the biconditional over a fixture that mixes machine, pool and unplaced agents.
  */
 import type { AgentRecord, AgentRepo } from '../persistence/ports.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -26,6 +26,7 @@
  * reports the tighten as `pending` until it does, and the daemon meanwhile fails
  * closed (unknown gate state ⇒ capture excluded).
  */
+import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
 import {
   SESSION_VISIBILITY_FEATURE,
   SLACK_SESSION_AUDIENCE_FEATURE,
@@ -50,6 +51,8 @@ export interface VisibilityPushDeps {
   repos: { session: SessionRepo; agent: AgentRepo }
   control: ControlSender
   connReg: ConnectionRegistry
+  /** Resolves the member that serves each session's agent. Absent ⇒ placement alone. */
+  placement?: Pick<PlacementResolver, 'servingDaemon'>
   log?: { warn(obj: unknown, msg?: string): void }
 }
 
@@ -96,6 +99,11 @@ export class SessionVisibilityPushService {
    * `UNKNOWN_FRAME`, which the correlator surfaces as a rejection — feature
    * gating keeps that off the §4.3 endpoint's pending/applied bookkeeping.
    */
+  /** Absent (tests / no pool) ⇒ placement alone, which is the pre-duty behavior. */
+  private placement(): Pick<PlacementResolver, 'servingDaemon'> {
+    return this.deps.placement ?? PLACEMENT_ONLY
+  }
+
   private supports(daemonId: string): boolean {
     const c = this.deps.connReg.get(daemonId)
     return c?.capabilities?.features?.includes(SESSION_VISIBILITY_FEATURE) ?? false
@@ -114,11 +122,13 @@ export class SessionVisibilityPushService {
    * move.
    */
   async notifySessions(sessions: SessionMetaRecord[]): Promise<void> {
+    // Resolved, not read: a pool agent's gate belongs on whichever member holds it, and
+    // `agent.daemonId` names no machine for one — the whole session set would silently skip.
     const byAgent = new Map<string, string | null>()
     for (const s of sessions) {
       if (!byAgent.has(s.agentId)) {
         const agent = await this.deps.repos.agent.getUnscoped(s.agentId)
-        byAgent.set(s.agentId, agent?.daemonId ?? null)
+        byAgent.set(s.agentId, agent ? await this.placement().servingDaemon(agent) : null)
       }
       const daemonId = byAgent.get(s.agentId)
       if (!daemonId || !this.supports(daemonId) || (s.externalProvider != null && !this.supportsExternal(daemonId))) {
@@ -291,7 +301,9 @@ export class SessionVisibilityPushService {
       if (s.visibilitySource === 'default' && s.visibilityRev === 0) continue // initial classification — nothing staged
       if (s.visibilityAckedRev >= s.visibilityRev) continue
       const agent = await this.deps.repos.agent.getUnscoped(s.agentId)
-      if (!agent?.daemonId) continue // unplaced: no daemon runs it, nothing to stop
+      // Nothing SERVING it ⇒ nothing to stop. Placement alone would read a held pool agent as
+      // unplaced and call a pending cutover vacuously applied.
+      if (!agent || !(await this.placement().servingDaemon(agent))) continue
       return false
     }
     return true

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -41,6 +41,7 @@ import type {
 } from '../domain/ids.js'
 import type { SessionKey } from '../domain/sessionKey.js'
 import type { DutyMemberKey, DutyReconcilePlan, DutyEdge, AgentSeed } from '../domain/duty.js'
+import type { DutyClaimScope, PlacementKind, PlacementTarget } from '../domain/placement.js'
 import type {
   OrganizationEnvironmentAudience,
   OrganizationEnvironmentKind,
@@ -639,6 +640,8 @@ export interface CreateAgentInput {
   managedSkills?: string[] // accepted managed_skill ids, explicitly enabled
   memory?: AgentMemoryBinding // memory backend
   icon?: AgentIcon // console avatar; absent ⇒ the repo assigns a random glyph+color combo
+  /** Placement at create time: `pool` needs no ref, `daemon` needs `daemonId`. Absent ⇒ unplaced. */
+  placementKind?: PlacementKind
   daemonId?: DaemonId // the owning machine, if chosen at create time
   workspace?: AgentWorkspace // absent ⇒ scratch
   /** Rename-proof numeric identity of the github workspace repository. This is
@@ -735,6 +738,11 @@ export interface AgentRecord {
   managedSkills: string[] // accepted managed_skill ids ([] ⇒ none)
   memory: AgentMemoryBinding | null // runtimeOverrides.memory
   status: 'active' | 'inactive' | 'paused'
+  /** What placement NAMES (domain/placement.ts): `daemon` resolves through `daemonId`, `pool`
+   *  resolves to the install-wide member set and carries no ref. Never branch on it directly. */
+  placementKind: PlacementKind
+  /** The `daemon`-kind ref, and null for every other kind — placement, never "who serves it now".
+   *  Ask {@link PlacementResolver} for that. */
   daemonId: DaemonId | null
   workspace: AgentWorkspace
   /** Nullable on scratch/anonymous and pre-R2a rows; action-time authorization
@@ -884,18 +892,18 @@ export interface AgentRepo {
   ): Promise<AgentRecord>
   /** Serialize on the Agent row. A real placement change atomically revokes all
    *  active webchat MCP delegations; a same-placement write does not. */
-  setPlacement(agentId: AgentId, daemonId: DaemonId | null): Promise<void>
+  setPlacement(agentId: AgentId, target: PlacementTarget): Promise<void>
   /**
-   * Atomically move an agent only when its current owner still matches
-   * `expectedDaemonId`. Returns the updated row, or null when another move won
-   * the compare-and-set race. A real move revokes active webchat MCP authority
-   * in the same transaction. This is the persistence fence for the explicit
-   * cold daemon-switch action.
+   * Atomically move an agent only when its current placement still matches `expected` — BOTH
+   * columns, so moving between `pool` and a machine is fenced exactly like moving between two
+   * machines. Returns the updated row, or null when another move won the compare-and-set race. A
+   * real move revokes active webchat MCP authority in the same transaction. This is the
+   * persistence fence for the explicit cold placement-switch action.
    */
   movePlacement(
     agentId: AgentId,
-    expectedDaemonId: DaemonId | null,
-    daemonId: DaemonId | null,
+    expected: PlacementTarget,
+    target: PlacementTarget,
     byUserId?: string
   ): Promise<AgentRecord | null>
   /** Atomically enumerate the agent's HookDefs, tombstone their durable review
@@ -935,6 +943,8 @@ export interface AgentRepo {
  *  scopes) plus the owning daemon, which the flat `CollabRoutesSnapshot.agents[]`
  *  entry routes on. `daemonId` is null for an unplaced agent (not routable). */
 export interface OrgAgentRecord extends ChannelAgentRecord {
+  /** The placement columns, so a consumer can resolve the serving daemon (domain/placement.ts). */
+  placementKind: PlacementKind
   daemonId: string | null
 }
 
@@ -5005,8 +5015,10 @@ export interface DutyGrantRecord {
 
 export interface AgentHomeClaim {
   granted: boolean
-  groupId: string
-  term: bigint
+  /** Absent only when the claim was refused before any group was read or minted — an ineligible
+   *  claimant, which has no group to name and must not learn of one. */
+  groupId?: string
+  term?: bigint
   /** The live holder — the caller when granted, the incumbent for a `not_holder` answer otherwise. */
   holder: DaemonId | null
 }
@@ -5034,15 +5046,17 @@ export interface DutyGroupRepo {
    *  each grant bumps the term. Install-wide — capacity gating is the caller's.
    *  `maxMembers` excludes undeliverable (oversized) groups at the claim
    *  boundary, so they never churn or starve the vacancies behind them.
-   *  `incumbentOnly` restricts vacancies to groups with an agent already placed
-   *  on the claimant (`agent.daemonId`) — the soak-phase grant policy that pins
-   *  duties where state already lives until the shared data plane arrives. */
+   *  `scope` is the claimant's connection scope, and the ONLY input to the
+   *  eligibility gate (domain/placement.ts): a group is claimable only when the
+   *  claimant may hold EVERY agent in it, which is what keeps an install-wide
+   *  member off the agents a local daemon is already serving.
+   *  `excludeGroupIds` carries the caller's refusal backoff. */
   claimVacant(
     holder: DaemonId,
     max: number,
     now: Date,
     leaseMs: number,
-    opts?: { maxMembers?: number; incumbentOnly?: boolean }
+    opts: { scope: DutyClaimScope; maxMembers?: number; excludeGroupIds?: readonly string[] }
   ): Promise<DutyGrantRecord[]>
   /** The group-computation inputs for one org: every agent as a node, plus
    *  active integrations on daemon-held (socket, unrevoked) bots as edges. */
@@ -5050,12 +5064,11 @@ export interface DutyGroupRepo {
   /** Keyset rotation over orgs that can need a recompute — any org owning an
    *  agent or an existing duty group. */
   listDutyOrgs(afterOrgId: string | null, limit: number): Promise<string[]>
-  /** Soak-phase placement fence: vacate every held group whose holder no longer
-   *  hosts ANY of its agents (a full placement move-away), so the new incumbent
-   *  can claim. Partial occupancy keeps the lease — split groups never flap —
-   *  and so does a group whose agents are all unplaced: nothing moved away.
-   *  Returns the vacated groupIds. */
-  vacateNonIncumbent(orgId: OrgId): Promise<string[]>
+  /** The placement fence, re-derived from the eligibility predicate: vacate every held group its
+   *  holder may no longer hold — an agent moved off the pool onto a machine, or off one machine
+   *  onto another. Same rule as {@link DutyGroupRepo.claimVacant}, read from the holder's side, so
+   *  a lease can never outlive the placement that justified it. Returns the vacated groupIds. */
+  vacateIneligible(orgId: OrgId): Promise<string[]>
   /** Batched renewal — one write per heartbeat covering every held group.
    *  Term-preserving; a reassigned group simply stops matching. Returns the
    *  renewed groupIds for digest comparison. */
@@ -5064,8 +5077,18 @@ export interface DutyGroupRepo {
   release(holder: DaemonId, groupIds: string[]): Promise<void>
   /** First-trigger claim for a botless agent: creates the singleton home if none
    *  exists ("claiming creates the lease"), grants if vacant, otherwise names
-   *  the incumbent. Idempotent for the current holder (no term churn). */
-  claimAgentHome(orgId: OrgId, agentId: AgentId, holder: DaemonId, now: Date, leaseMs: number): Promise<AgentHomeClaim>
+   *  the incumbent. Idempotent for the current holder (no term churn). Gated by
+   *  the SAME eligibility predicate as {@link DutyGroupRepo.claimVacant}, read
+   *  inside the transaction — the rendezvous is a claim path too, and a member
+   *  must not reach through it for an agent it may not hold. */
+  claimAgentHome(
+    orgId: OrgId,
+    agentId: AgentId,
+    holder: DaemonId,
+    now: Date,
+    leaseMs: number,
+    scope: DutyClaimScope
+  ): Promise<AgentHomeClaim>
   /** Does `holder` currently hold an unexpired lease on a group covering this
    *  agent? The authorization for `duty/fetch`: a member may pull exactly the
    *  agent definitions it has won, and nothing else. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5093,6 +5093,14 @@ export interface DutyGroupRepo {
    *  agent? The authorization for `duty/fetch`: a member may pull exactly the
    *  agent definitions it has won, and nothing else. */
   holdsAgent(holder: DaemonId, agentId: AgentId, now: Date): Promise<boolean>
+  /** Stamp `confirmedAt` on the groups this holder reports in its heartbeat digest, returning the
+   *  ones that became confirmed on THIS beat. A grant is applied daemon-side only after its
+   *  install succeeds (#972), so the digest IS the proof that the member is serving — the same
+   *  signal the self-fence and CP renewal already ride, not a new one. */
+  confirmHeld(holder: DaemonId, groupIds: readonly string[], now: Date): Promise<string[]>
+  /** {@link DutyGroupRepo.holdersOf} restricted to CONFIRMED holds — who INGRESS may be addressed
+   *  at. A holder that is still installing is a live lease and not yet a route. */
+  confirmedHoldersOf(agentId: AgentId, now: Date): Promise<DaemonId[]>
   /** Every member currently holding an unexpired lease on a group covering this
    *  agent — the delivery half of {@link DutyGroupRepo.holdsAgent}, so a live
    *  update reaches whoever serves the agent rather than only where it is placed

--- a/packages/control-plane/src/persistence/repositories/agent-placement.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-placement.ts
@@ -11,13 +11,16 @@
  * agent deletion cannot form an inverse cycle.
  */
 import { Prisma } from '../../generated/prisma/client.js'
+import type { PlacementKind } from '../../domain/placement.js'
 
+/** Both placement columns under the row lock: `daemonId` alone stopped being the placement when
+ *  `pool` became a target that names no machine. */
 export async function lockAgentPlacement(
   tx: Prisma.TransactionClient,
   agentId: string
-): Promise<{ daemonId: string | null } | null> {
-  const [row] = await tx.$queryRaw<{ daemonId: string | null }[]>(
-    Prisma.sql`SELECT "daemonId" FROM "agent" WHERE "id" = ${agentId} FOR UPDATE`
+): Promise<{ placementKind: PlacementKind; daemonId: string | null } | null> {
+  const [row] = await tx.$queryRaw<{ placementKind: PlacementKind; daemonId: string | null }[]>(
+    Prisma.sql`SELECT "placementKind", "daemonId" FROM "agent" WHERE "id" = ${agentId} FOR UPDATE`
   )
   return row ?? null
 }
@@ -44,10 +47,13 @@ export async function revokeActiveWebchatMcpDelegations(
  */
 export async function settleCascadedUnplacement(tx: Prisma.TransactionClient, agentId: string): Promise<boolean> {
   const current = await lockAgentPlacement(tx, agentId)
-  if (!current || current.daemonId !== null) return false
+  // A `pool` agent has no daemonId for the FK to have nulled, so it is not this removal's to
+  // settle: it was never placed on the departing member, only served by it, and the ledger
+  // hands its duty to another member on the next beat.
+  if (!current || current.placementKind !== 'daemon' || current.daemonId !== null) return false
   await tx.agent.update({
     // No daemonId write — the cascade already did that; what is missing is everything
-    // `setPlacement(null)` pairs with it, including the revision the next owner compares.
+    // `setPlacement(unplaced)` pairs with it, including the revision the next owner compares.
     where: { id: agentId },
     data: { status: 'inactive', configRevision: { increment: 1 } }
   })

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -21,6 +21,13 @@ import type {
 } from '../ports.js'
 import { visibilityWhere } from '../../authorization/policy.js'
 import { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
+import {
+  placementColumns,
+  placementTargetOf,
+  samePlacement,
+  type PlacementKind,
+  type PlacementTarget
+} from '../../domain/placement.js'
 import { parseAgentIcon, randomGlyphIcon } from '../../agents/agent-icon.js'
 import {
   lockHookReviewAgentLifecycleScope,
@@ -32,6 +39,17 @@ import { lockSkillSourceNameScopes } from '../skill-source-lock.js'
 import { tryLockMemoryConnectionScopes } from '../memory-connection-lock.js'
 import { PgHookRepo } from './hook.repo.js'
 import { lockAgentPlacement, revokeActiveWebchatMcpDelegations } from './agent-placement.js'
+
+/** An agent may be created already placed. `pool` needs no ref, so the create input carries a kind
+ *  and the columns follow from it rather than from the presence of a daemon id. */
+function placementCreateColumns(input: { placementKind?: PlacementKind; daemonId?: string }): {
+  placementKind?: 'daemon' | 'pool'
+  daemonId?: string
+  status?: 'active'
+} {
+  if (input.placementKind === 'pool') return { placementKind: 'pool', status: 'active' }
+  return input.daemonId ? { daemonId: input.daemonId, status: 'active' } : {}
+}
 import { fenceAgentLocalConfigWrite, lockOrgForConfigWrite, orgIdOfAgent } from './organization-environment-fence.js'
 import {
   AgentMissing,
@@ -215,6 +233,7 @@ function toRecord(a: AgentWithUsers): AgentRecord {
     managedSkills: a.managedSkills,
     memory: ov.memory ?? null,
     status: a.status as AgentRecord['status'],
+    placementKind: a.placementKind,
     daemonId: a.daemonId ? DaemonId(a.daemonId) : null,
     workspace: workspaceOf(a),
     ...(a.workspaceRepoId !== null ? { workspaceRepoId: a.workspaceRepoId } : {}),
@@ -301,7 +320,7 @@ export class PgAgentRepo implements AgentRepo {
           icon: (input.icon ?? randomGlyphIcon()) as Prisma.InputJsonValue,
           description: input.description ?? null,
           runtime: input.runtime,
-          ...(input.daemonId ? { daemonId: input.daemonId, status: 'active' } : {}),
+          ...placementCreateColumns(input),
           ...(input.managedSkills ? { managedSkills: input.managedSkills } : {}),
           ...(input.model ||
           input.reasoningEffort ||
@@ -799,19 +818,24 @@ export class PgAgentRepo implements AgentRepo {
     return toRecord(a)
   }
 
-  async setPlacement(agentId: AgentId, daemonId: DaemonId | null): Promise<void> {
+  async setPlacement(agentId: AgentId, target: PlacementTarget): Promise<void> {
     await this.transaction(async (tx) => {
       const current = await lockAgentPlacement(tx, agentId)
       if (!current) return
+      const columns = placementColumns(target)
       await tx.agent.update({
         where: { id: agentId },
         // A placement change makes a different daemon the spec's recipient. Bumping
         // here means the new owner's first snapshot is never mistaken for an older
         // revision it already applied during a previous residency.
-        data: { daemonId, status: daemonId ? 'active' : 'inactive', configRevision: { increment: 1 } }
+        data: {
+          ...columns,
+          status: target.kind === 'unplaced' ? 'inactive' : 'active',
+          configRevision: { increment: 1 }
+        }
       })
-      if (daemonId) await settlePresetPlacement(tx, agentId)
-      if (current.daemonId !== daemonId) {
+      if (target.kind !== 'unplaced') await settlePresetPlacement(tx, agentId)
+      if (!samePlacement(placementTargetOf(current), target)) {
         await revokeActiveWebchatMcpDelegations(tx, agentId, new Date())
         await tx.hookDef.updateMany({
           where: { agentId },
@@ -823,22 +847,24 @@ export class PgAgentRepo implements AgentRepo {
 
   async movePlacement(
     agentId: AgentId,
-    expectedDaemonId: DaemonId | null,
-    daemonId: DaemonId | null,
+    expected: PlacementTarget,
+    target: PlacementTarget,
     byUserId?: string
   ): Promise<AgentRecord | null> {
     // The explicit Agent lock serializes the compare-and-set read with all
-    // placement writers. Keep daemonId on the update as a defensive guard; a
+    // placement writers. Keep the expected columns on the update as a defensive guard; a
     // missing/deleted row still resolves to null rather than overwriting state.
+    const expectedColumns = placementColumns(expected)
+    const columns = placementColumns(target)
     try {
       return await this.transaction(async (tx) => {
         const current = await lockAgentPlacement(tx, agentId)
-        if (!current || current.daemonId !== expectedDaemonId) return null
+        if (!current || !samePlacement(placementTargetOf(current), expected)) return null
         const a = await tx.agent.update({
-          where: { id: agentId, daemonId: expectedDaemonId },
+          where: { id: agentId, daemonId: expectedColumns.daemonId, placementKind: expectedColumns.placementKind },
           data: {
-            daemonId,
-            status: daemonId ? 'active' : 'inactive',
+            ...columns,
+            status: target.kind === 'unplaced' ? 'inactive' : 'active',
             lastModifiedAt: new Date(),
             ...(byUserId ? { lastModifiedByUserId: byUserId } : {}),
             // See setPlacement: a move re-targets who receives the spec, so the
@@ -847,8 +873,8 @@ export class PgAgentRepo implements AgentRepo {
           },
           include: withUsers
         })
-        if (daemonId) await settlePresetPlacement(tx, agentId)
-        if (expectedDaemonId !== daemonId) {
+        if (target.kind !== 'unplaced') await settlePresetPlacement(tx, agentId)
+        if (!samePlacement(expected, target)) {
           await revokeActiveWebchatMcpDelegations(tx, agentId, new Date())
           await tx.hookDef.updateMany({
             where: { agentId },
@@ -951,16 +977,20 @@ export class PgAgentRepo implements AgentRepo {
   // integration join, so an agent with no IM integration is included — that is the
   // whole point of the flat directory.
   //
-  // `daemonId: { not: null }` is NOT an optimization: this one query feeds BOTH the
+  // Excluding the UNPLACED is not an optimization: this one query feeds BOTH the
   // `channel/agents` roster a model discovers peers from AND the flat
   // `CollabRoutesSnapshot.agents[]` wakes are authorized against, and
   // `buildCollabSnapshot` drops daemonId-less rows there (no owning daemon ⇒ nothing to
   // route a wake to). Listing an unplaced agent would therefore advertise a peer that is
   // discoverable but not callable — the model gets a bare 'not_allowed' and retries — so
   // the exclusion belongs in the shared read, where the two surfaces cannot disagree.
+  //
+  // A `pool` agent IS placed and carries no daemonId, so the filter is on the placement, not on
+  // the column: each consumer fills the serving daemon in through the resolver, which is the only
+  // thing that knows which member holds it right now.
   async orgDirectory(orgId: OrgId): Promise<OrgAgentRecord[]> {
     const rows = await this.db.agent.findMany({
-      where: { orgId, daemonId: { not: null } },
+      where: { orgId, OR: [{ daemonId: { not: null } }, { placementKind: 'pool' }] },
       orderBy: { createdAt: 'asc' },
       select: {
         id: true,
@@ -968,6 +998,7 @@ export class PgAgentRepo implements AgentRepo {
         displayName: true,
         description: true,
         status: true,
+        placementKind: true,
         daemonId: true,
         callPolicy: true,
         allowedCallerAgentIds: true,
@@ -981,6 +1012,7 @@ export class PgAgentRepo implements AgentRepo {
       displayName: row.displayName,
       description: row.description,
       status: row.status as OrgAgentRecord['status'],
+      placementKind: row.placementKind,
       daemonId: row.daemonId,
       callPolicy: row.callPolicy as AgentCallPolicy,
       allowedCallerAgentIds: row.allowedCallerAgentIds,

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -960,9 +960,14 @@ export class PgAgentRepo implements AgentRepo {
     return new Map(rows.map((r) => [r.id, r.configRevision]))
   }
 
+  // The placement relation read from the MEMBER's side, and deliberately the row-wise mirror of
+  // `domain/placement.ts#placementTargets` read from the agent's side: `placementKind: 'daemon'`
+  // is what makes "this daemon is the placement" mean the same thing in both directions. Without
+  // it the two agree only by accident — because `pool` happens to store a null ref — and a later
+  // kind that stores one would be placed here and unplaced there.
   async listForDaemon(daemonId: DaemonId): Promise<AgentRecord[]> {
     const rows = await this.db.agent.findMany({
-      where: { daemonId },
+      where: { daemonId, placementKind: 'daemon' },
       orderBy: { createdAt: 'asc' },
       include: withUsers
     })

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -138,7 +138,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     // nothing may serve an unplaced agent, and leaving the lease standing would keep one member
     // serving what the operator detached.
     const rows = await this.prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
-      UPDATE "duty_group" g SET "holder" = NULL, "expiresAt" = NULL
+      UPDATE "duty_group" g SET "holder" = NULL, "expiresAt" = NULL, "confirmedAt" = NULL
       FROM "daemon" d
       WHERE g."orgId" = ${orgId} AND g."holder" IS NOT NULL AND d.id = g."holder"
         AND NOT ${noIneligibleAgent(Prisma.sql`g.id`, Prisma.sql`g."holder"`, Prisma.sql`d."orgId" IS NULL`)}
@@ -226,6 +226,9 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
         if (w.regrantTo !== null)
           await tx.dutyGroup.update({
             where: { id: w.groupId },
+            // `regrantTo` is the group's existing holder (the planner only re-grants in place), so
+            // its confirmation stands: it is still serving every member both compositions share,
+            // and dropping it would blank a working route over an ADDED member.
             data: { holder: w.regrantTo, term: { increment: 1 }, expiresAt }
           })
       }
@@ -237,7 +240,10 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
             orgId,
             holder: c.grantTo,
             term: c.grantTo !== null ? 1n : 0n,
-            expiresAt: c.grantTo !== null ? expiresAt : null
+            expiresAt: c.grantTo !== null ? expiresAt : null,
+            // A created row with a holder is a SPLIT inheriting its sole contributor's holder —
+            // the same member, already serving these members under the row this one came from.
+            confirmedAt: c.grantTo !== null ? opts.now : null
           }
         })
         await tx.dutyGroupMember.createMany({
@@ -293,7 +299,10 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
           FOR UPDATE SKIP LOCKED
         )
         UPDATE "duty_group" g
-        SET "holder" = ${holder}::uuid, "term" = g."term" + 1, "expiresAt" = ${expiresAt}, "updatedAt" = ${now}
+        SET "holder" = ${holder}::uuid, "term" = g."term" + 1, "expiresAt" = ${expiresAt}, "updatedAt" = ${now},
+            -- The grant is not yet a fact: the member has not installed it. Preserved when the
+            -- claimant is the same member re-taking its own lapsed lease — its replica is intact.
+            "confirmedAt" = CASE WHEN g."holder" IS DISTINCT FROM ${holder}::uuid THEN NULL ELSE g."confirmedAt" END
         FROM picked WHERE g.id = picked.id
         RETURNING g.id, g."orgId", g."holder", g."term", g."expiresAt"
       `)
@@ -328,7 +337,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     // Vacate immediately but keep `term` — monotonicity is the whole token.
     await this.prisma.dutyGroup.updateMany({
       where: { holder, id: { in: groupIds } },
-      data: { holder: null, expiresAt: null }
+      data: { holder: null, expiresAt: null, confirmedAt: null }
     })
   }
 
@@ -343,6 +352,35 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       LIMIT 1
     `)
     return rows.length > 0
+  }
+
+  async confirmHeld(holder: DaemonId, groupIds: readonly string[], now: Date): Promise<string[]> {
+    if (groupIds.length === 0) return []
+    // Idempotent and first-write-wins: only an unconfirmed row is stamped, so the returned set is
+    // exactly the groups whose hold became a fact on THIS beat — which is what the routing
+    // convergence is keyed on. Holder-conditional, so a digest naming a group the ledger has since
+    // moved confirms nothing.
+    const rows = await this.prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
+      UPDATE "duty_group" SET "confirmedAt" = ${now}
+      WHERE "holder" = ${holder}::uuid AND "confirmedAt" IS NULL
+        AND id = ANY(${groupIds as string[]}::uuid[])
+      RETURNING id
+    `)
+    return rows.map((r) => r.id).sort()
+  }
+
+  async confirmedHoldersOf(agentId: AgentId, now: Date): Promise<DaemonId[]> {
+    // `holdersOf` with the confirmation term: the same live-lease join, restricted to holders that
+    // have reported the group. INGRESS addressing uses this one — naming a member that is still
+    // installing turns a routable message into a terminal miss.
+    const rows = await this.prisma.$queryRaw<{ holder: string }[]>(Prisma.sql`
+      SELECT DISTINCT g."holder" AS holder FROM "duty_group_member" m
+      JOIN "duty_group" g ON g.id = m."groupId"
+      WHERE m."kind" = 'agent' AND m."refId" = ${agentId}
+        AND g."holder" IS NOT NULL AND g."expiresAt" IS NOT NULL AND g."expiresAt" > ${now}
+        AND g."confirmedAt" IS NOT NULL
+    `)
+    return rows.map((r) => r.holder as DaemonId).sort()
   }
 
   async holdersOf(agentId: AgentId, now: Date): Promise<DaemonId[]> {
@@ -419,7 +457,13 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
             id: row.id,
             OR: [{ holder: null }, { expiresAt: null }, { expiresAt: { lt: now } }]
           },
-          data: { holder, term: { increment: 1 }, expiresAt }
+          // Same rule as `claimVacant`: a new holder has not proved it serves the group yet.
+          data: {
+            holder,
+            term: { increment: 1 },
+            expiresAt,
+            ...(row.holder === holder ? {} : { confirmedAt: null })
+          }
         })
         if (won.count === 1) {
           const granted = await tx.dutyGroup.findUniqueOrThrow({ where: { id: row.id } })

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -6,6 +6,7 @@ import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
 import type { DutyMemberKey, DutyReconcilePlan, DutyEdge, AgentSeed } from '../../domain/duty.js'
 import type { AgentHomeClaim, DutyGrantRecord, DutyGroupRecord, DutyGroupRepo, DutyReconcilePlanner } from '../ports.js'
 import type { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
+import type { DutyClaimScope } from '../../domain/placement.js'
 import { withTx } from '../prisma.js'
 
 // Serializes the writers that CREATE or REWRITE rows for an org (applyReconcile
@@ -16,6 +17,42 @@ async function lockOrgDutyScope(tx: Prisma.TransactionClient, orgId: string): Pr
 }
 
 type Row = { id: string; orgId: string; holder: string | null; term: bigint; expiresAt: Date | null }
+
+/**
+ * The eligibility predicate, once, as SQL — the row-wise mirror of `domain/placement.ts#mayHold`.
+ * May `holder` (whose connection scope is install-wide when `installWide` holds) hold the duty of
+ * the agent row `agent`? `pool` placement is the install-wide member set; `daemon` placement is
+ * that one machine; an unplaced agent has no eligible holder.
+ *
+ * Both claim paths and the placement fence share it, so a lease can never be taken under one rule
+ * and kept under another. A later `group` kind adds one arm here.
+ */
+function eligibleAgent(agent: Prisma.Sql, holder: Prisma.Sql, installWide: Prisma.Sql): Prisma.Sql {
+  return Prisma.sql`(
+    CASE ${agent}."placementKind"
+      WHEN 'pool' THEN (${installWide})
+      ELSE ${agent}."daemonId" IS NOT NULL AND ${agent}."daemonId" = ${holder}
+    END
+  )`
+}
+
+/**
+ * A group is claimable by `holder` only when EVERY agent in it is one the holder may hold. Stated
+ * as "no ineligible agent" rather than "some eligible agent": a group that merges a pool agent
+ * with a machine-placed one must be claimable by neither, or the winner serves an agent the other
+ * side is already serving — the duplicate service the ledger exists to prevent.
+ *
+ * A member ref whose agent row is gone cannot be adjudicated and does not block: the group is
+ * reaped by the next recompute, and install-on-grant refuses an empty bundle in the meantime.
+ */
+function noIneligibleAgent(group: Prisma.Sql, holder: Prisma.Sql, installWide: Prisma.Sql): Prisma.Sql {
+  return Prisma.sql`NOT EXISTS (
+    SELECT 1 FROM "duty_group_member" m
+    JOIN "agent" a ON a.id = m."refId"
+    WHERE m."groupId" = ${group} AND m."kind" = 'agent'
+      AND NOT ${eligibleAgent(Prisma.sql`a`, holder, installWide)}
+  )`
+}
 
 // Row-locked snapshot: FOR UPDATE fences the lease writers the advisory scope
 // does not cover (claimVacant/renewHeld/release), so a plan can never be applied
@@ -88,28 +125,23 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     return rows.map((r) => toRecord(r, members.get(r.id) ?? []))
   }
 
-  async vacateNonIncumbent(orgId: OrgId): Promise<string[]> {
-    // Soak-phase placement fence: a holder keeps a group while it still hosts
-    // AT LEAST ONE of its agents — so a split group cannot flap between two
-    // partial incumbents — but a full move-away vacates the lease, letting the
-    // new incumbent claim on its next beat (the old holder learns via digest
-    // diff as a superseded revocation). A move-away needs somewhere to have
-    // moved TO: a group whose agents are all unplaced has no rival incumbent,
-    // and vacating it every sweep would just churn the rendezvous claim that
-    // put a holder there.
+  async vacateIneligible(orgId: OrgId): Promise<string[]> {
+    // The placement fence, stated as the eligibility predicate read from the holder's side: a
+    // lease survives exactly as long as its holder may still hold every agent in the group. An
+    // agent moved off the pool onto a machine, or off one machine onto another, therefore vacates
+    // the lease on the next sweep and the eligible member claims it on its next beat (the old
+    // holder learns through the digest diff, as a superseded revocation).
+    //
+    // The holder's own scope comes from its row — an org-less daemon is an install-wide pool
+    // member — so this is the same rule `claimVacant` applies, not a second one that can disagree.
+    // A group whose agents are ALL unplaced has no eligible holder at all and is vacated too:
+    // nothing may serve an unplaced agent, and leaving the lease standing would keep one member
+    // serving what the operator detached.
     const rows = await this.prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
       UPDATE "duty_group" g SET "holder" = NULL, "expiresAt" = NULL
-      WHERE g."orgId" = ${orgId} AND g."holder" IS NOT NULL
-        AND EXISTS (
-          SELECT 1 FROM "duty_group_member" m
-          JOIN "agent" a ON a.id = m."refId"
-          WHERE m."groupId" = g.id AND m."kind" = 'agent' AND a."daemonId" IS NOT NULL
-        )
-        AND NOT EXISTS (
-          SELECT 1 FROM "duty_group_member" m
-          JOIN "agent" a ON a.id = m."refId"
-          WHERE m."groupId" = g.id AND m."kind" = 'agent' AND a."daemonId" = g."holder"
-        )
+      FROM "daemon" d
+      WHERE g."orgId" = ${orgId} AND g."holder" IS NOT NULL AND d.id = g."holder"
+        AND NOT ${noIneligibleAgent(Prisma.sql`g.id`, Prisma.sql`g."holder"`, Prisma.sql`d."orgId" IS NULL`)}
       RETURNING g.id
     `)
     return rows.map((r) => r.id).sort()
@@ -221,7 +253,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     max: number,
     now: Date,
     leaseMs: number,
-    opts: { maxMembers?: number; incumbentOnly?: boolean } = {}
+    opts: { scope: DutyClaimScope; maxMembers?: number; excludeGroupIds?: readonly string[] }
   ): Promise<DutyGrantRecord[]> {
     if (max <= 0) return []
     const expiresAt = new Date(now.getTime() + leaseMs)
@@ -232,14 +264,20 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       opts.maxMembers === undefined
         ? Prisma.empty
         : Prisma.sql`AND (SELECT count(*) FROM "duty_group_member" m WHERE m."groupId" = "duty_group".id) <= ${opts.maxMembers}`
-    // Soak-phase policy: only groups whose agents already live on the claimant.
-    const incumbentGate = !opts.incumbentOnly
-      ? Prisma.empty
-      : Prisma.sql`AND EXISTS (
-          SELECT 1 FROM "duty_group_member" m
-          JOIN "agent" a ON a.id = m."refId"
-          WHERE m."groupId" = "duty_group".id AND m."kind" = 'agent' AND a."daemonId" = ${holder}::uuid
-        )`
+    // The eligibility gate — the whole grant policy, and the only one. There is no incumbency test
+    // left: what a member may claim follows from the agents' placement, not from where their state
+    // happens to already be.
+    const eligibilityGate = Prisma.sql`AND ${noIneligibleAgent(
+      Prisma.sql`"duty_group".id`,
+      Prisma.sql`${holder}::uuid`,
+      opts.scope === 'install-wide' ? Prisma.sql`TRUE` : Prisma.sql`FALSE`
+    )}`
+    // The caller's refusal backoff: a group this member has just failed to install is skipped so
+    // it can reach one that can serve it, instead of being re-taken on the very next beat.
+    const backoffGate =
+      opts.excludeGroupIds && opts.excludeGroupIds.length > 0
+        ? Prisma.sql`AND "duty_group".id <> ALL(${opts.excludeGroupIds as string[]}::uuid[])`
+        : Prisma.empty
     // One transaction, so the grant's row locks hold until the returned
     // (term, members) snapshot is assembled — a reconcile cannot interleave and
     // pair the old term with rewritten membership. First valid claim wins;
@@ -249,7 +287,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       const granted = await tx.$queryRaw<Row[]>(Prisma.sql`
         WITH picked AS (
           SELECT id FROM "duty_group"
-          WHERE ("holder" IS NULL OR "expiresAt" IS NULL OR "expiresAt" < ${now}) ${sizeGate} ${incumbentGate}
+          WHERE ("holder" IS NULL OR "expiresAt" IS NULL OR "expiresAt" < ${now}) ${sizeGate} ${eligibilityGate} ${backoffGate}
           ORDER BY "orgId", id
           LIMIT ${max}
           FOR UPDATE SKIP LOCKED
@@ -335,13 +373,22 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     agentId: AgentId,
     holder: DaemonId,
     now: Date,
-    leaseMs: number
+    leaseMs: number,
+    scope: DutyClaimScope
   ): Promise<AgentHomeClaim> {
     const expiresAt = new Date(now.getTime() + leaseMs)
     return withTx(this.prisma, async (tx) => {
       // Org scope fences row creation against applyReconcile; the FOR UPDATE row
       // lock below fences the lease against claimVacant/renewHeld/release.
       await lockOrgDutyScope(tx, orgId)
+      // The rendezvous is a claim path, so it takes the same eligibility gate — inside the
+      // transaction, against the live row, because this path can MINT a group and a check made
+      // before the lock would let a member reach through it for an agent it may not hold.
+      const [eligible] = await tx.$queryRaw<{ ok: boolean }[]>(Prisma.sql`
+        SELECT ${eligibleAgent(Prisma.sql`a`, Prisma.sql`${holder}::uuid`, scope === 'install-wide' ? Prisma.sql`TRUE` : Prisma.sql`FALSE`)} AS ok
+        FROM "agent" a WHERE a.id = ${agentId}::uuid
+      `)
+      if (eligible?.ok !== true) return { granted: false, holder: null }
       const member = await tx.dutyGroupMember.findUnique({ where: { kind_refId: { kind: 'agent', refId: agentId } } })
       if (!member) {
         // Claiming creates the lease: the first trigger for a botless agent.

--- a/packages/control-plane/src/registry/webchatVerification.ts
+++ b/packages/control-plane/src/registry/webchatVerification.ts
@@ -7,6 +7,7 @@ import {
   type RegisterReq
 } from '@agentconnect.md/protocol'
 import { AgentId, OrgId, SessionId } from '../domain/ids.js'
+import type { PlacementResolver, ResolvableAgent } from '../orchestrator/placementResolver.js'
 import type { WebchatRemoteMcpService } from './webchatRemoteMcpService.js'
 import type { WebchatTokenService } from './webchatToken.js'
 
@@ -17,7 +18,7 @@ interface VerificationDaemon {
 
 export interface WebchatVerificationDeps {
   tokens: Pick<WebchatTokenService, 'verify'>
-  agents: { getUnscoped(agentId: AgentId): Promise<{ orgId: string; daemonId: string | null } | null> }
+  agents: { getUnscoped(agentId: AgentId): Promise<(ResolvableAgent & { orgId: string }) | null> }
   daemons: { get(daemonId: string): VerificationDaemon | undefined }
   /** Roster reads for multi-agent conversations (webchat-multi-agents.md §6.2). */
   conversations: {
@@ -38,6 +39,9 @@ export interface WebchatVerificationDeps {
   }
   orgs: { roleOf(orgId: string, userId: string): Promise<string | null> }
   remoteMcp: Pick<WebchatRemoteMcpService, 'establish'>
+  /** Resolves the daemon a webchat turn should reach — the holder, or any live member that can
+   *  claim the agent's duty on receipt. */
+  placement: Pick<PlacementResolver, 'dispatchDaemon'>
 }
 
 /**
@@ -65,8 +69,13 @@ export function createWebchatTokenVerifier(deps: WebchatVerificationDeps): (toke
     if (!claims) return { ok: false, reason: 'invalid token' }
     const agent = await deps.agents.getUnscoped(AgentId(claims.agentId))
     if (!agent || agent.orgId !== claims.orgId) return { ok: false, reason: 'invalid token' }
-    if (!agent.daemonId) return { ok: false, reason: 'agent unplaced' }
-    const daemon = deps.daemons.get(agent.daemonId)
+    // Readiness is the resolver's answer, not a member id the row happens to carry: a pool agent
+    // is dialable while ANY member is live, and after a rollout the member its row used to name is
+    // gone by construction — which is what made webchat permanently offline (#987). A lapsed lease
+    // resolves to a live member anyway; it claims the group on receipt.
+    const agentDaemonId = await deps.placement.dispatchDaemon(agent)
+    if (!agentDaemonId) return { ok: false, reason: 'agent unplaced' }
+    const daemon = deps.daemons.get(agentDaemonId)
     if (daemon?.state !== 'READY') return { ok: false, reason: 'daemon offline' }
 
     // The durable conversation row is required for every dial; a targeted row
@@ -82,7 +91,7 @@ export function createWebchatTokenVerifier(deps: WebchatVerificationDeps): (toke
       userId: claims.userId,
       user: claims.user,
       agentId: claims.agentId,
-      daemonId: agent.daemonId,
+      daemonId: agentDaemonId,
       orgId: claims.orgId,
       conversationId: claims.conversationId
     }
@@ -105,7 +114,7 @@ export function createWebchatTokenVerifier(deps: WebchatVerificationDeps): (toke
       }
       // Content ownership is daemon-local: the agent must still be on the
       // session's recorded daemon, and that daemon continuation-capable.
-      if (session.daemonId === null || session.daemonId !== agent.daemonId) {
+      if (session.daemonId === null || session.daemonId !== agentDaemonId) {
         return { ok: false, reason: 'continuation unavailable' }
       }
       if (!daemon.capabilities?.features.includes(WEBCHAT_SESSION_CONTINUATION_FEATURE)) {
@@ -114,7 +123,7 @@ export function createWebchatTokenVerifier(deps: WebchatVerificationDeps): (toke
       // Single fixed participant; no roster growth, no remote MCP entitlement.
       return {
         ...verifiedBase,
-        participants: [{ agentId: claims.agentId, daemonId: agent.daemonId, primary: true }],
+        participants: [{ agentId: claims.agentId, daemonId: agentDaemonId, primary: true }],
         targetSessionId
       }
     }
@@ -127,20 +136,21 @@ export function createWebchatTokenVerifier(deps: WebchatVerificationDeps): (toke
     const participants: RcWebchatParticipant[] = []
     for (const p of roster) {
       if (p.agentId === claims.agentId) {
-        participants.push({ agentId: p.agentId, daemonId: agent.daemonId, primary: true })
+        participants.push({ agentId: p.agentId, daemonId: agentDaemonId, primary: true })
         continue
       }
       const member = await deps.agents.getUnscoped(p.agentId)
-      const memberDaemon =
-        member && member.orgId === claims.orgId && member.daemonId ? deps.daemons.get(member.daemonId) : undefined
+      const memberDaemonId =
+        member && member.orgId === claims.orgId ? await deps.placement.dispatchDaemon(member) : null
+      const memberDaemon = memberDaemonId ? deps.daemons.get(memberDaemonId) : undefined
       participants.push({
         agentId: p.agentId,
-        ...(memberDaemon?.state === 'READY' ? { daemonId: member!.daemonId! } : {}),
+        ...(memberDaemon?.state === 'READY' && memberDaemonId ? { daemonId: memberDaemonId } : {}),
         ...(p.role === 'primary' ? { primary: true } : {})
       })
     }
     if (participants.length === 0) {
-      participants.push({ agentId: claims.agentId, daemonId: agent.daemonId, primary: true })
+      participants.push({ agentId: claims.agentId, daemonId: agentDaemonId, primary: true })
     }
 
     const verified: RcVerifyResult = { ...verifiedBase, participants }
@@ -156,7 +166,7 @@ export function createWebchatTokenVerifier(deps: WebchatVerificationDeps): (toke
       verifiedUserId: claims.userId,
       orgId: claims.orgId,
       agentId: claims.agentId,
-      daemonId: agent.daemonId
+      daemonId: agentDaemonId
     })
     return entitlement ? { ...verified, remoteMcp: entitlement } : verified
   }

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -37,6 +37,7 @@ import type { ConnectionRegistry } from './registry.js'
 import type { Clock } from '../domain/clock.js'
 import type { SessionEventSink } from '../events/sink.js'
 import type { AgentMutationGate } from '../orchestrator/agentMutationGate.js'
+import type { PlacementResolver } from '../orchestrator/placementResolver.js'
 import type { CollabRoutesService } from '../orchestrator/collabRoutes.service.js'
 import type { DutyLeaseService } from '../orchestrator/dutyLease.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
@@ -112,6 +113,10 @@ export interface DaemonWsDeps {
   /** Viewer-free agent reads for the `gitcred/request` placement check — a DATA-PLANE
    *  path (resource-visibility §9): restricted-but-active agents must keep minting. */
   agent: AgentRepo
+  /** "May this connection act for that agent?" — placement OR a held duty. A pool member serves
+   *  agents its row does not name, so placement equality is no longer the fence. Absent ⇒
+   *  placement alone, which is the pre-duty behavior. */
+  placementResolver?: PlacementResolver
   /** Accepted Knowledge/skills and retained suggestion metadata. */
   organizationKnowledge?: OrganizationKnowledgeRepo
   /** Revision-fenced sink for daemon external-memory conformance facts. */

--- a/packages/control-plane/src/ws/handlers/channel-agents.ts
+++ b/packages/control-plane/src/ws/handlers/channel-agents.ts
@@ -41,6 +41,7 @@
  * channel-filtered ask on a session-identity platform short-circuits to an empty roster
  * before any repo read (see below) — nothing to leak, so nothing to bind.
  */
+import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import { isFrame } from '@agentconnect.md/protocol'
 import { DaemonId, OrgId } from '../../domain/ids.js'
 import { isSessionIdentityPlatform } from '../../persistence/platform.js'
@@ -96,7 +97,11 @@ export const handleChannelAgents: Handler = async (frame, conn, deps) => {
     // ONE org-scoped read, feeding both scopes and the bind (see the header). It is also
     // literally the read `buildCollabSnapshot` builds `agents[]` from, which is what keeps
     // "discoverable" and "callable" from disagreeing.
-    const orgRoster = await deps.agent.orgDirectory(orgId)
+    // Resolved through the placement resolver, so a pool agent is listed against the member that
+    // currently serves it rather than dropped for naming no machine.
+    const orgRoster = await (deps.placementResolver ?? PLACEMENT_ONLY).resolveDirectory(
+      await deps.agent.orgDirectory(orgId)
+    )
 
     // THE DAEMON-OWNERSHIP BIND (§2.2/§6.1) — the read-side twin of the relay's
     // `claimedFromAgentId` / `caller.daemonId !== fromDaemonId` check. `requesterAgentId`

--- a/packages/control-plane/src/ws/handlers/duty-claim.ts
+++ b/packages/control-plane/src/ws/handlers/duty-claim.ts
@@ -20,6 +20,8 @@ export const handleDutyClaim: Handler = async (frame, conn, deps) => {
     conn.replyTo(frame, 'duty/claim/ok', { granted: false })
     return
   }
-  const claim = await deps.dutyLease.claimAgentHome(agent.orgId, agentId, DaemonId(conn.daemonId))
+  // The connection reached here org-less, so its claim scope is install-wide; the ledger applies
+  // the placement predicate to it rather than trusting the trigger that got the member here.
+  const claim = await deps.dutyLease.claimAgentHome(agent.orgId, agentId, DaemonId(conn.daemonId), 'install-wide')
   conn.replyTo(frame, 'duty/claim/ok', claim)
 }

--- a/packages/control-plane/src/ws/handlers/event-session-purged.ts
+++ b/packages/control-plane/src/ws/handlers/event-session-purged.ts
@@ -24,6 +24,7 @@
  *     dropping it. This is also what garbage-collects receipts for a deleted
  *     agent, whose `SessionMeta` rows cascaded away with it.
  */
+import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, SessionId } from '../../domain/ids.js'
 import type { Handler } from './index.js'
@@ -39,7 +40,7 @@ export const handleSessionPurged: Handler = async (frame, conn, deps) => {
   }
   try {
     const agent = await deps.agent.getUnscoped(agentId)
-    if (agent?.daemonId === DaemonId(conn.daemonId)) {
+    if (agent && (await (deps.placementResolver ?? PLACEMENT_ONLY).mayAct(agent, DaemonId(conn.daemonId)))) {
       await deps.session.markContentPurged(
         agentId,
         p.sessionIds.map((id) => SessionId(id)),

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -14,6 +14,7 @@
  * Trust boundary: the reported agent must still be placed on the authenticated
  * daemon, and an existing sessionId remains bound to its first agent.
  */
+import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import { isFrame, type EventSession } from '@agentconnect.md/protocol'
 import { AgentId, BotId, DaemonId, HookId, IntegrationId, LaunchId, SessionId } from '../../domain/ids.js'
 import { classifySession } from '../../domain/session-visibility.js'
@@ -257,7 +258,8 @@ export const handleEventSessionSync: Handler = async (frame, conn, deps) => {
   }
   try {
     const agent = await deps.agent.getUnscoped(agentId)
-    if (agent?.daemonId === daemonId) await recordEventSession(p, agentId, daemonId, deps)
+    if (agent && (await (deps.placementResolver ?? PLACEMENT_ONLY).mayAct(agent, daemonId)))
+      await recordEventSession(p, agentId, daemonId, deps)
     // ACK only after recordEventSession's transaction has committed. An agent
     // placed elsewhere (or deleted) can never accept this daemon's stale row, so
     // retaining it forever would be worse than collecting it.

--- a/packages/control-plane/src/ws/handlers/gitcred.ts
+++ b/packages/control-plane/src/ws/handlers/gitcred.ts
@@ -16,6 +16,7 @@
  *
  * The grant payload carries the token MATERIAL — never log it.
  */
+import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, HookId } from '../../domain/ids.js'
 import { GitCredDeniedError } from '../../github/service.js'
@@ -30,12 +31,12 @@ export const handleGitCredRequest: Handler = async (frame, conn, deps) => {
     return
   }
 
-  // Placement scope: the agent must currently live on the REQUESTING daemon.
-  // A daemon that lost the agent (re-placement while offline) gets a terminal
-  // SCOPE_DENIED — its cache layer clears the entry and stops asking.
+  // Service scope: the requesting daemon must currently serve the agent — its placement, or a
+  // duty it holds. A daemon that lost it (re-placement or a lapsed lease while offline) gets a
+  // terminal SCOPE_DENIED — its cache layer clears the entry and stops asking.
   const agent = await deps.agent.getUnscoped(AgentId(agentId))
-  if (!agent || agent.daemonId !== conn.daemonId) {
-    conn.sendError(frame.id, 'SCOPE_DENIED', 'agent is not placed on this daemon', false)
+  if (!agent || !(await (deps.placementResolver ?? PLACEMENT_ONLY).mayAct(agent, conn.daemonId))) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'this daemon does not serve that agent', false)
     return
   }
 

--- a/packages/control-plane/src/ws/handlers/reporting-agent.ts
+++ b/packages/control-plane/src/ws/handlers/reporting-agent.ts
@@ -1,22 +1,23 @@
+import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import type { AgentId, DaemonId } from '../../domain/ids.js'
 import type { DaemonWsDeps } from '../deps.js'
 
 /**
- * Run one daemon-originated agent write only while that agent is placed on the
- * authenticated reporting daemon. The shared mutation lease prevents a cold
- * move from racing the placement check and the write.
+ * Run one daemon-originated agent write only while the authenticated reporting daemon actually
+ * serves that agent — its placement, or a duty it currently holds. The shared mutation lease
+ * prevents a cold move from racing the check and the write.
  */
 export async function runForReportingAgent(
   agentId: AgentId,
   daemonId: DaemonId,
-  deps: Pick<DaemonWsDeps, 'agent' | 'agentMutations'>,
+  deps: Pick<DaemonWsDeps, 'agent' | 'agentMutations' | 'placementResolver'>,
   write: () => Promise<void>
 ): Promise<boolean> {
   const release = deps.agentMutations.tryBeginMutation(agentId)
   if (!release) return false
   try {
     const agent = await deps.agent.getUnscoped(agentId)
-    if (agent?.daemonId !== daemonId) return false
+    if (!agent || !(await (deps.placementResolver ?? PLACEMENT_ONLY).mayAct(agent, daemonId))) return false
     await write()
     return true
   } finally {

--- a/packages/control-plane/src/ws/relay-connection.test.ts
+++ b/packages/control-plane/src/ws/relay-connection.test.ts
@@ -1,3 +1,4 @@
+import { PLACEMENT_ONLY } from '../orchestrator/placementResolver.js'
 import { describe, it, expect, vi } from 'vitest'
 import {
   buildRelayCpFrame,
@@ -254,6 +255,7 @@ function buildWebchatVerifier(
       },
       sessions: { getUnscoped: async (id) => over.sessionById?.[id] ?? null },
       orgs: { roleOf: async () => (over.role === undefined ? 'collaborator' : over.role) },
+      placement: PLACEMENT_ONLY,
       remoteMcp: { establish }
     })
   }

--- a/packages/control-plane/test/fakes/build-app.ts
+++ b/packages/control-plane/test/fakes/build-app.ts
@@ -16,6 +16,7 @@ import {
   PgApiKeyRepo,
   PgOrgRepo,
   PgAgentRepo,
+  PgDutyGroupRepo,
   PgAgentSecretStore,
   PgAssignmentRepo,
   PgCronRepo,
@@ -49,6 +50,7 @@ import { createDaemonWsServer } from '../../src/ws/gateway.js'
 import type { DaemonWsDeps } from '../../src/ws/deps.js'
 import { InMemorySessionEventSink } from '../../src/events/sink.js'
 import { systemClock } from '../../src/domain/clock.js'
+import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
 import { DaemonId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
@@ -124,6 +126,15 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
     PLATFORMS
   )
   const connReg = new ConnectionRegistry()
+  const placementResolver = new PlacementResolver({
+    duties: new PgDutyGroupRepo(prisma),
+    liveMembers: () =>
+      connReg
+        .reachableDaemons()
+        .filter((d) => d.orgId === null && d.state === 'READY')
+        .map((d) => d.daemonId),
+    clock
+  })
 
   // Mount the daemon WS gateway once the HTTP server exists (after `listen`).
   let listening = false
@@ -137,6 +148,7 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
       orchestrator,
       connReg,
       agent: repos.agent,
+      placementResolver,
       session: repos.session,
       events: new InMemorySessionEventSink(),
       sessionUsage: repos.sessionUsage,

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -80,6 +80,7 @@ import { EpochService } from '../../src/orchestrator/epoch.js'
 import { DUTY_LEASE_DEFAULTS } from '../../src/orchestrator/dutyLease.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import { AgentDelivery } from '../../src/orchestrator/agentDelivery.js'
+import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
 import { RelayControlSender } from '../../src/orchestrator/relayControl.js'
 import { HttpBotOrchestrator } from '../../src/orchestrator/httpBot.js'
 import { CollabRoutesService } from '../../src/orchestrator/collabRoutes.service.js'
@@ -304,7 +305,16 @@ export function buildHttpApp(
   )
   // Same graph as prod: every replicate site resolves its targets here, so the
   // duty ledger is a real repo and a holder actually receives the pushes.
-  const agentDelivery = new AgentDelivery({ control: sender, specs: agentSpecs, duties: dutyGroupRepo, clock })
+  const placementResolver = new PlacementResolver({
+    duties: dutyGroupRepo,
+    liveMembers: () =>
+      connReg
+        .reachableDaemons()
+        .filter((d) => d.orgId === null && d.state === 'READY')
+        .map((d) => d.daemonId),
+    clock
+  })
+  const agentDelivery = new AgentDelivery({ control: sender, specs: agentSpecs, placement: placementResolver })
 
   // LATE-BOUND exactly as `buildContainer` binds it (§9): the providers below are
   // constructed WITH this dep bundle, because their funnel plugins are route
@@ -409,6 +419,7 @@ export function buildHttpApp(
     daemonConns: liveness as HttpDeps['daemonConns'],
     control: sender,
     agentDelivery,
+    placementResolver,
     relayControl,
     httpBot: new HttpBotOrchestrator(
       botRepo,
@@ -423,9 +434,17 @@ export function buildHttpApp(
       new PgSessionRepo(prisma),
       { info() {}, warn() {}, debug() {} },
       platforms,
-      agentDelivery
+      agentDelivery,
+      placementResolver
     ),
-    collabRoutes: new CollabRoutesService(daemonRepo, integrationRepo, agentRepo, relayControl, sender),
+    collabRoutes: new CollabRoutesService(
+      daemonRepo,
+      integrationRepo,
+      agentRepo,
+      relayControl,
+      sender,
+      placementResolver
+    ),
     agentMutations: new AgentMutationGate(),
     sessionOwners: connReg,
     // The installations repo feeds the github-kind compile — same graph as prod.
@@ -434,6 +453,7 @@ export function buildHttpApp(
       hookSecretStore,
       agentRepo,
       relayControl,
+      placementResolver,
       githubInstallationRepo,
       'agentconnect-test'
     ),

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -420,6 +420,7 @@ export function buildHttpApp(
     control: sender,
     agentDelivery,
     placementResolver,
+    daemonRows: daemonRepo,
     relayControl,
     httpBot: new HttpBotOrchestrator(
       botRepo,
@@ -443,7 +444,8 @@ export function buildHttpApp(
       agentRepo,
       relayControl,
       sender,
-      placementResolver
+      placementResolver,
+      dutyGroupRepo
     ),
     agentMutations: new AgentMutationGate(),
     sessionOwners: connReg,

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -36,7 +36,8 @@ import {
   PgExternalMemoryGrantRepo,
   PgMcpProviderRepo,
   PgMcpGrantRepo,
-  PgDutyGroupRepo
+  PgDutyGroupRepo,
+  PgHookSecretStore
 } from '../../src/persistence/index.js'
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import { EpochService } from '../../src/orchestrator/epoch.js'
@@ -52,6 +53,8 @@ import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
 import { CollabRoutesService } from '../../src/orchestrator/collabRoutes.service.js'
 import { DutyLeaseService, type DutyLeaseConfig } from '../../src/orchestrator/dutyLease.js'
 import { RelayControlSender } from '../../src/orchestrator/relayControl.js'
+import { HookService } from '../../src/hooks/hook.service.js'
+import { AgentRoutingConverger } from '../../src/orchestrator/agentRouting.js'
 import { FrameRouter } from '../../src/ws/handlers/index.js'
 import { DaemonConnection } from '../../src/ws/connection.js'
 import { RelayRegistry } from '../../src/ws/relay-registry.js'
@@ -83,6 +86,10 @@ export const TEST_API_KEY_PEPPER = 'test-api-key-pepper-0123456789abcdef'
 export interface WsHarness {
   deps: DaemonWsDeps
   clock: FakeClock
+  /** Compiled hook rules the relay would have received, in order — the routing projection that
+   *  addresses a daemon, so "ingress follows the holder" is assertable on it directly. */
+  hookAssigns: CapturedHookRule[]
+  hookRemovals: string[]
   codec: ApiKeyCodec
   /** Provision a daemon row + mint an API key for `daemonId`; returns the plaintext `apiKey`. */
   mintToken(daemonId: string): Promise<string>
@@ -103,6 +110,13 @@ export interface HarnessOpts {
   relays?: RelayRosterEntry[]
   /** Duty lease knobs (defaults suit tests; recoveryGraceMs 0 so grants flow immediately). */
   dutyLease?: Partial<DutyLeaseConfig>
+}
+
+/** One compiled hook rule as the relay would receive it — the routing projection under test. */
+export interface CapturedHookRule {
+  hookId: string
+  agentId: string
+  daemonId: string
 }
 
 export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): WsHarness {
@@ -212,6 +226,32 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     }
   )
 
+  // A REAL HookService over a capturing relay sender: `hookAssigns` is literally what a relay
+  // would dispatch on, so a test can assert that ingress follows a holder change rather than
+  // asserting that some internal seam was called.
+  const hookAssigns: CapturedHookRule[] = []
+  const hookRemovals: string[] = []
+  const hookService = new HookService(
+    repos.hook,
+    new PgHookSecretStore(prisma, cipher),
+    repos.agent,
+    {
+      hookAssign: (rule: { hookId: string; agentId: string; daemonId: string }) => void hookAssigns.push(rule),
+      hookRemove: (hookId: string) => void hookRemovals.push(hookId)
+    } as unknown as RelayControlSender,
+    placementResolver
+  )
+  const agentRouting = new AgentRoutingConverger({
+    hooks: hookService,
+    collabRoutes,
+    httpBot: { syncBot: async () => {} },
+    agents: repos.agent,
+    integrations: repos.integration,
+    bots: repos.bot,
+    clock,
+    delayMs: 0
+  })
+
   const dutyLease = new DutyLeaseService(
     dutyGroupRepo,
     clock,
@@ -226,7 +266,8 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
       refusalBackoffMs: opts.dutyLease?.refusalBackoffMs ?? 300_000
     },
     undefined,
-    repos.agent
+    repos.agent,
+    agentRouting
   )
 
   const deps: DaemonWsDeps = {
@@ -263,6 +304,8 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
   return {
     deps,
     clock,
+    hookAssigns,
+    hookRemovals,
     codec,
     mintCloudDaemon: async (daemonId: string) => {
       await prisma.daemon.create({ data: { id: daemonId, orgId: null, maxAgents: 8, status: 'ready' } })

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -90,6 +90,9 @@ export interface WsHarness {
    *  addresses a daemon, so "ingress follows the holder" is assertable on it directly. */
   hookAssigns: CapturedHookRule[]
   hookRemovals: string[]
+  /** The resolver the projections read through — lets a test ask what the peer directory would
+   *  publish right now without reaching through the orchestrator. */
+  placement: PlacementResolver
   codec: ApiKeyCodec
   /** Provision a daemon row + mint an API key for `daemonId`; returns the plaintext `apiKey`. */
   mintToken(daemonId: string): Promise<string>
@@ -306,6 +309,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     clock,
     hookAssigns,
     hookRemovals,
+    placement: placementResolver,
     codec,
     mintCloudDaemon: async (daemonId: string) => {
       await prisma.daemon.create({ data: { id: daemonId, orgId: null, maxAgents: 8, status: 'ready' } })

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -41,6 +41,7 @@ import {
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import { EpochService } from '../../src/orchestrator/epoch.js'
 import { Placement } from '../../src/orchestrator/placement.js'
+import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import { AgentSpecAssembler } from '../../src/orchestrator/agentSpecAssembler.js'
 import { ApiKeyCodec } from '../../src/registry/apiKey.js'
@@ -168,6 +169,15 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
   )
   const relays = opts.relays ?? []
   const dutyGroupRepo = new PgDutyGroupRepo(prisma)
+  const placementResolver = new PlacementResolver({
+    duties: dutyGroupRepo,
+    liveMembers: () =>
+      connReg
+        .reachableDaemons()
+        .filter((d) => d.orgId === null && d.state === 'READY')
+        .map((d) => d.daemonId),
+    clock
+  })
   const orchestrator = new Placement(
     repos.daemon,
     repos.agent,
@@ -197,7 +207,8 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
         grants: repos.externalMemoryGrant,
         relayRoster: { entries: async () => relays }
       },
-      duties: dutyGroupRepo
+      duties: dutyGroupRepo,
+      placement: placementResolver
     }
   )
 
@@ -211,9 +222,8 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
       grantsPerFrame: opts.dutyLease?.grantsPerFrame ?? 50,
       grantMembersPerFrame: opts.dutyLease?.grantMembersPerFrame ?? 2000,
       revocationsPerFrame: opts.dutyLease?.revocationsPerFrame ?? 500,
-      // Wire tests use synthetic member refs with no agent rows; the incumbent
-      // policy is exercised by its own repo tests against real placements.
-      grantPolicy: opts.dutyLease?.grantPolicy ?? 'any'
+      refusalsBeforeRelease: opts.dutyLease?.refusalsBeforeRelease ?? 3,
+      refusalBackoffMs: opts.dutyLease?.refusalBackoffMs ?? 300_000
     },
     undefined,
     repos.agent
@@ -226,6 +236,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     orchestrator,
     connReg,
     agent: repos.agent,
+    placementResolver,
     session: repos.session,
     events: new InMemorySessionEventSink(),
     sessionUsage: repos.sessionUsage,

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -59,6 +59,26 @@ const live: DaemonLiveness = {
   get: (id) => ([SOURCE, TARGET].includes(id) ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined)
 }
 
+/** One install-wide pool member, live alongside the two machines. Org-less AND Pod-bound: that
+ *  shape is what makes a row visible to every org's placement list. */
+const MEMBER = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const seedPoolMember = () =>
+  prisma.daemon.create({
+    data: {
+      id: MEMBER,
+      orgId: null,
+      clusterIdentity: 'system:serviceaccount:ac-example:ac-cloud-daemon',
+      clusterPodUid: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      maxAgents: 8,
+      status: 'ready',
+      capabilities: MOVE_CAPS
+    }
+  })
+const poolLive: DaemonLiveness = {
+  get: (id) =>
+    [SOURCE, TARGET, MEMBER].includes(id) ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined
+}
+
 async function seedMoveDaemons(): Promise<void> {
   await seedDaemon(prisma, SOURCE, { capabilities: MOVE_CAPS })
   await seedDaemon(prisma, TARGET, { capabilities: MOVE_CAPS })
@@ -574,5 +594,110 @@ describe('PUT /agents/:id/daemon', () => {
     })
     expect(cron.statusCode).toBe(409)
     expect(await prisma.cronDef.count({ where: { id: cronId } })).toBe(0)
+  })
+})
+
+describe('PUT /agents/:id/daemon — the pool as a placement target', () => {
+  // The pool is not a member id. Moving onto it commits kind `pool` and CLEARS `daemonId`; the
+  // ledger then grants the agent's group to whichever member is live, which is what makes the
+  // placement survive a rollout instead of naming a Pod that no longer exists.
+  it('moves onto the pool: kind pool, no member id, and no synchronous activation', async () => {
+    await seedMoveDaemons()
+    await seedPoolMember()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: SOURCE })
+    const control = new MoveControlSpy()
+    running = buildHttpApp(prisma, undefined, poolLive, control as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { placementKind: 'pool' }
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ placementKind: 'pool', daemonId: null })
+    expect(await prisma.agent.findUnique({ where: { id: agentId } })).toMatchObject({
+      placementKind: 'pool',
+      daemonId: null,
+      status: 'active'
+    })
+    // The source is quiesced; the pool member is NOT activated — install-on-grant does that when
+    // the ledger picks a member, and naming one here would only pre-empt a choice that is not the
+    // control plane's to make.
+    expect(control.calls.filter((c) => c.startsWith('detach:'))).toContain(`detach:${SOURCE}`)
+    expect(control.calls.some((c) => c.startsWith('activate:'))).toBe(false)
+  })
+
+  it('moves back off the pool onto a machine, quiescing the member that holds it', async () => {
+    await seedMoveDaemons()
+    await seedPoolMember()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    await prisma.agent.update({ where: { id: agentId }, data: { placementKind: 'pool', daemonId: null } })
+    // The member currently holding its duty is the source to quiesce — placement names none.
+    const groupId = randomUUID()
+    await prisma.dutyGroup.create({
+      data: {
+        id: groupId,
+        orgId: DEFAULT_ORG_ID,
+        holder: MEMBER,
+        term: 1n,
+        expiresAt: new Date(Date.now() + 120_000)
+      }
+    })
+    await prisma.dutyGroupMember.create({
+      data: { kind: 'agent', refId: agentId, groupId, orgId: DEFAULT_ORG_ID }
+    })
+    const control = new MoveControlSpy()
+    running = buildHttpApp(prisma, undefined, poolLive, control as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { daemonId: TARGET }
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ placementKind: 'daemon', daemonId: TARGET })
+    expect(control.calls).toContain(`detach:${MEMBER}`)
+    expect(control.calls).toContain(`activate:${TARGET}`)
+  })
+
+  it('refuses a pool target when no member is ready', async () => {
+    await seedMoveDaemons()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: SOURCE })
+    const control = new MoveControlSpy()
+    // `live` knows only SOURCE and TARGET — there is no install-wide member at all.
+    running = buildHttpApp(prisma, undefined, live, control as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { placementKind: 'pool' }
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.json().message).toContain('no cloud daemon member is ready')
+    expect(await prisma.agent.findUnique({ where: { id: agentId } })).toMatchObject({
+      placementKind: 'daemon',
+      daemonId: SOURCE
+    })
+  })
+
+  it('rejects a body that names both a pool placement and a member id', async () => {
+    await seedMoveDaemons()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: SOURCE })
+    running = buildHttpApp(prisma, undefined, live, new MoveControlSpy() as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { placementKind: 'pool', daemonId: TARGET }
+    })
+
+    expect(res.statusCode).toBe(400)
   })
 })

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { randomUUID } from 'node:crypto'
-import type { Ack, AgentActivate, MemoryConnectionSpec } from '@agentconnect.md/protocol'
+import type { Ack, AgentActivate, AgentDetach, MemoryConnectionSpec } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
@@ -35,15 +35,21 @@ class MoveControlSpy {
   failSourceDetach = false
   readonly calls: string[] = []
   readonly activations: AgentActivate[] = []
+  /** Per-target detach/activate records — the staging fence is a (daemon, moveId) pair, so a test
+   *  that asserts it was RELEASED has to compare the tokens, not just the call order. */
+  readonly detaches: { daemonId: string; value: AgentDetach }[] = []
+  readonly activateCalls: { daemonId: string; value: AgentActivate }[] = []
 
-  async agentDetach(daemonId: string): Promise<Ack> {
+  async agentDetach(daemonId: string, value: AgentDetach): Promise<Ack> {
     this.calls.push(`detach:${daemonId}`)
+    this.detaches.push({ daemonId, value })
     if (daemonId === SOURCE && this.failSourceDetach) throw new Error('source is unavailable')
     return { ok: true }
   }
   async agentActivate(daemonId: string, value: AgentActivate): Promise<Ack> {
     this.calls.push(`activate:${daemonId}`)
     this.activations.push(value)
+    this.activateCalls.push({ daemonId, value })
     return { ok: true }
   }
   async memoryConnectionUpsert(daemonId: string, spec: MemoryConnectionSpec): Promise<void> {
@@ -699,5 +705,96 @@ describe('PUT /agents/:id/daemon — the pool as a placement target', () => {
     })
 
     expect(res.statusCode).toBe(400)
+  })
+})
+
+describe('POST /agents — the pool as a create-time placement', () => {
+  it('creates ON the pool: kind pool, no member id, active', async () => {
+    // The console submits `placementKind: 'pool'`. Dropping it on the floor lands the agent as an
+    // inactive daemon placement with no ref — unplaced — which reads to the user as "create
+    // silently did nothing".
+    await seedMoveDaemons()
+    await seedPoolMember()
+    running = buildHttpApp(prisma, undefined, poolLive, new MoveControlSpy() as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'pooled-create', runtime: 'Claude Code', placementKind: 'pool' }
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(res.json()).toMatchObject({ placementKind: 'pool', daemonId: null, status: 'active' })
+    const row = await prisma.agent.findFirstOrThrow({ where: { name: 'pooled-create' } })
+    expect(row).toMatchObject({ placementKind: 'pool', daemonId: null, status: 'active' })
+  })
+
+  it('refuses a pool create when no member is ready, instead of landing it unplaced', async () => {
+    await seedMoveDaemons()
+    running = buildHttpApp(prisma, undefined, live, new MoveControlSpy() as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'pooled-create', runtime: 'Claude Code', placementKind: 'pool' }
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(await prisma.agent.findFirst({ where: { name: 'pooled-create' } })).toBeNull()
+  })
+})
+
+describe('PUT /agents/:id/daemon — converting a member-pinned agent to the pool', () => {
+  // The transition that differs from every other move: the source is itself an eligible holder of
+  // the NEW placement. Leaving it fenced would let the ledger grant it back the group it was
+  // staged out of — and `installGrantedAgents` skips a move-staged agent, so it would hold the
+  // lease, install nothing, and serve nothing, with no other member able to claim it.
+  it('clears the source member’s staging fence so it is a usable holder again', async () => {
+    await seedMoveDaemons()
+    await seedPoolMember()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    // Pinned to the MEMBER, which is the shape today's pool agents actually have.
+    await prisma.agent.update({ where: { id: agentId }, data: { daemonId: MEMBER } })
+    const control = new MoveControlSpy()
+    running = buildHttpApp(prisma, undefined, poolLive, control as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { placementKind: 'pool' }
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ placementKind: 'pool', daemonId: null })
+    // Detached to stop it serving as a PLACEMENT, then activated with the SAME token so the fence
+    // it armed is released and its replica is current for a re-grant.
+    const detach = control.detaches.find((d) => d.daemonId === MEMBER)
+    const activate = control.activateCalls.find((a) => a.daemonId === MEMBER)
+    expect(detach).toBeDefined()
+    expect(activate).toBeDefined()
+    expect(activate!.value.moveId).toBe(detach!.value.moveId)
+    expect(control.calls.indexOf(`detach:${MEMBER}`)).toBeLessThan(control.calls.indexOf(`activate:${MEMBER}`))
+  })
+
+  it('leaves a LOCAL daemon fenced on the same conversion — it may not serve a pool agent', async () => {
+    // The asymmetry, stated as a test: a local daemon is not an eligible holder, so the fence is
+    // exactly right there and clearing it would invite the split brain a hard cutover prevents.
+    await seedMoveDaemons()
+    await seedPoolMember()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: SOURCE })
+    const control = new MoveControlSpy()
+    running = buildHttpApp(prisma, undefined, poolLive, control as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { placementKind: 'pool' }
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(control.calls).toContain(`detach:${SOURCE}`)
+    expect(control.calls).not.toContain(`activate:${SOURCE}`)
   })
 })

--- a/packages/control-plane/test/integration/preset-agents.test.ts
+++ b/packages/control-plane/test/integration/preset-agents.test.ts
@@ -3,6 +3,7 @@
  * the one-time backfill, the reserved slugs, and the deferred-runtime tolerance
  * of the existing routes.
  */
+import { onDaemon } from '../../src/domain/placement.js'
 import { describe, it, expect, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
@@ -420,7 +421,7 @@ describe('deferred-runtime tolerance of existing routes', () => {
       // First placement of any kind stamps placementSettledAt (repo anchor).
       const daemonId = randomUUID()
       await seedDaemon(prisma, daemonId)
-      await new PgAgentRepo(prisma).setPlacement(AgentId(preset!.id), DaemonId(daemonId))
+      await new PgAgentRepo(prisma).setPlacement(AgentId(preset!.id), onDaemon(DaemonId(daemonId)))
       const row = await prisma.presetAgent.findUnique({
         where: { orgId_preset: { orgId: DEFAULT_ORG_ID, preset: 'general' } }
       })

--- a/packages/control-plane/test/protocol/drain.test.ts
+++ b/packages/control-plane/test/protocol/drain.test.ts
@@ -130,6 +130,13 @@ function build(): Built {
     lifecycleOps: {} as DaemonWsDeps['lifecycleOps'],
     registry: {} as DaemonWsDeps['registry'],
     orchestrator: {} as DaemonWsDeps['orchestrator'],
+    placementResolver: {
+      mayAct: async () => true,
+      servingDaemon: async () => null,
+      servingDaemons: async () => [],
+      dispatchDaemon: async () => null,
+      resolveDirectory: async (rows: unknown[]) => rows
+    } as unknown as DaemonWsDeps['placementResolver'],
     connReg,
     agent: {} as DaemonWsDeps['agent'],
     session: {} as DaemonWsDeps['session'],

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -973,3 +973,66 @@ describe('proactive healing after a rollout (protocol level, real Postgres)', ()
     expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).holder).toBe(DAEMON)
   })
 })
+
+describe('routing follows the holder (protocol level, real Postgres)', () => {
+  const HOOK = '77777777-7777-4777-8777-77777777770a'
+
+  async function seedPooledAgentWithHook(): Promise<void> {
+    await prisma.agent.create({
+      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'hooked', runtime: 'claude', placementKind: 'pool' }
+    })
+    await prisma.hookDef.create({
+      data: {
+        id: HOOK,
+        orgId: DEFAULT_ORG_ID,
+        agentId: AGENT,
+        kind: 'webhook',
+        name: 'inbound',
+        enabled: true,
+        urlToken: 'wh-pool-heal-token',
+        sessionMode: 'perDelivery'
+      }
+    })
+  }
+
+  // THE test this whole change exists for. "The sweep re-granted it" is not "it heals" unless the
+  // thing that ADDRESSES a daemon moves too: the relay dispatches an inbound webhook on the
+  // compiled hook rule, and that rule bakes in a member id. So: A holds, A lapses, B is granted —
+  // and the rule the relay would dispatch on now names B, with no reconnect and no trigger.
+  //
+  // Mutation check: drop the `routing?.kick(...)` from the lease exchange's grant branch and the
+  // rule stays pinned to A, so the message keeps arriving at the member that lost the agent.
+  it('re-addresses the compiled hook rule at the new holder after a grant, with no reconnect', async () => {
+    const start = 1_700_000_000_000
+    const h = buildWsHarness(prisma)
+    await seedPooledAgentWithHook()
+    // OTHER held it and its lease ran out 1ms ago — the rollout, as the ledger sees it.
+    await seedGroup({ holder: OTHER, term: 4n, expiresAt: new Date(start - 1) })
+    const { stub } = await ready(h)
+
+    stub.inject('heartbeat', heartbeat({ held: [], headroom: 4 }))
+    await stub.expectFrame('duty/grant')
+    // The converger is debounced on the same clock the exchange runs on.
+    h.clock.advance(1)
+    await vi.waitFor(() => expect(h.hookAssigns.length).toBeGreaterThan(0))
+
+    const latest = h.hookAssigns.at(-1)!
+    expect(latest).toMatchObject({ hookId: HOOK, agentId: AGENT, daemonId: DAEMON })
+    expect(h.hookAssigns.every((rule) => rule.daemonId !== OTHER)).toBe(true)
+  })
+
+  it('withdraws the rule when the lease is handed back and nothing serves the agent', async () => {
+    // The other half of the same property: a holder change AWAY from a member has to stop the
+    // ingress it was receiving, or a dead member keeps being addressed.
+    const h = buildWsHarness(prisma, { dutyLease: { refusalsBeforeRelease: 1 } })
+    const startAt = new Date(h.clock.now())
+    await seedPooledAgentWithHook()
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(startAt.getTime() + LEASE_MS) })
+    const { stub } = await ready(h)
+
+    // One absence is the threshold here, so this beat hands the lease back.
+    await beat(stub, { held: [], headroom: 0 })
+    h.clock.advance(1)
+    await vi.waitFor(() => expect(h.hookRemovals).toContain(HOOK))
+  })
+})

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { isFrame } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { buildWsHarness } from '../fakes/build-ws.js'
+import type { InMemoryDaemonStub } from '../fakes/daemon-stub.js'
 import { PgDutyGroupRepo, PgLaunchRepo } from '../../src/persistence/index.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
@@ -62,6 +63,18 @@ async function ready(h: ReturnType<typeof buildWsHarness>, opts: { orgScoped?: b
   return { conn, stub }
 }
 
+/** Inject one beat and wait for ITS renewal confirmation. `expectFrame` resolves from a frame
+ *  already sent, so a multi-beat test has to count instead — otherwise the next inject races the
+ *  running exchange and the lane drops it. */
+async function beat(
+  stub: InMemoryDaemonStub,
+  duties: { held: { groupId: string; term: string }[]; headroom: number }
+): Promise<void> {
+  const before = stub.sent.filter((f) => f.type === 'duty/renewed').length
+  stub.inject('heartbeat', heartbeat(duties))
+  await vi.waitFor(() => expect(stub.sent.filter((f) => f.type === 'duty/renewed').length).toBe(before + 1))
+}
+
 function heartbeat(duties?: { held: { groupId: string; term: string }[]; headroom: number }) {
   return {
     load: { cpu: 0.1, mem: 0.1, agents: 0 },
@@ -105,7 +118,14 @@ describe('duty lease exchange (protocol level, real Postgres)', () => {
     // alone and keeps serving a bundle the CP has edited since (#973).
     await seedGroup()
     await prisma.agent.create({
-      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'stamped', runtime: 'claude', configRevision: 9n }
+      data: {
+        id: AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'stamped',
+        runtime: 'claude',
+        placementKind: 'pool',
+        configRevision: 9n
+      }
     })
     const h = buildWsHarness(prisma)
     const { stub } = await ready(h)
@@ -276,7 +296,9 @@ describe('duty lease exchange (protocol level, real Postgres)', () => {
 
     // Immediately grantable by a survivor at a bumped term.
     const repo = new PgDutyGroupRepo(prisma)
-    const grants = await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS)
+    const grants = await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS, {
+      scope: 'install-wide'
+    })
     expect(grants[0]).toMatchObject({ groupId: GROUP, orgId: OrgId(DEFAULT_ORG_ID), term: 3n })
   })
 })
@@ -763,9 +785,11 @@ describe('duty lease exchange — drain barrier', () => {
 describe('duty/claim — the activation rendezvous (real Postgres)', () => {
   const CLAIM_ID = '66666666-6666-4666-8666-666666666666'
 
+  // Placed on the POOL: the rendezvous applies the same eligibility gate as the heartbeat claim,
+  // so an install-wide member may only claim an agent whose placement is the pool.
   async function seedAgentRow(): Promise<void> {
     await prisma.agent.create({
-      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'agent-1', runtime: 'claude' }
+      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'agent-1', runtime: 'claude', placementKind: 'pool' }
     })
   }
 
@@ -850,5 +874,102 @@ describe('duty/claim — the activation rendezvous (real Postgres)', () => {
     if (!isFrame('error')(err)) throw new Error('expected error')
     expect(err.payload.code).toBe('SCOPE_DENIED')
     expect(await prisma.dutyGroup.count()).toBe(0)
+  })
+})
+
+describe('proactive healing after a rollout (protocol level, real Postgres)', () => {
+  // The live failure this whole change exists to end: a member is replaced by a rollout, its lease
+  // lapses, the group becomes a claimable vacancy — and under the incumbent policy NOTHING claimed
+  // it, because the vacancy's agents named a Pod that no longer exists. Healing waited for a
+  // trigger, and for webchat the trigger could not even be sent (#987).
+  //
+  // Mutation check: restoring the incumbent gate (only groups with an agent whose `daemonId` is
+  // the claimant) makes this fail — a pool agent has no `daemonId` at all, so no member qualifies.
+  it('re-grants a lapsed holder’s group to a live member with no trigger involved', async () => {
+    const start = 1_700_000_000_000
+    const h = buildWsHarness(prisma)
+    // The replaced Pod: it held the group, and its lease ran out 1ms ago.
+    await seedGroup({ holder: OTHER, term: 4n, expiresAt: new Date(start - 1) })
+    await prisma.agent.create({
+      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'webchat-only', runtime: 'claude', placementKind: 'pool' }
+    })
+    const { stub } = await ready(h)
+
+    // A plain heartbeat. No rd/msg, no duty/claim, no console send — nothing but the beat.
+    stub.inject('heartbeat', heartbeat({ held: [], headroom: 4 }))
+    const grant = await stub.expectFrame('duty/grant')
+    if (!isFrame('duty/grant')(grant)) throw new Error('expected duty/grant')
+    expect(grant.payload.grants[0]).toMatchObject({ groupId: GROUP, term: '5' })
+
+    const row = await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })
+    expect(row.holder).toBe(DAEMON)
+  })
+
+  it('a member at capacity does not claim, however healable the vacancy is', async () => {
+    const start = 1_700_000_000_000
+    const h = buildWsHarness(prisma)
+    await seedGroup({ holder: OTHER, term: 4n, expiresAt: new Date(start - 1) })
+    await prisma.agent.create({
+      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'webchat-only', runtime: 'claude', placementKind: 'pool' }
+    })
+    const { stub } = await ready(h)
+
+    stub.inject('heartbeat', heartbeat({ held: [], headroom: 0 }))
+    await stub.expectFrame('duty/renewed')
+    expect(stub.sent.filter((f) => f.type === 'duty/grant')).toEqual([])
+    const row = await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })
+    expect(row.holder).toBe(OTHER)
+  })
+
+  it('bounds a group one member cannot install: the lease is handed back and not re-offered to it', async () => {
+    // A refused grant is invisible on the wire — the member simply never reports the group — and
+    // `renewHeld` renews by holder alone, so without this the group would sit on the one member
+    // that cannot serve it for as long as it keeps beating. Counting consecutive absences is what
+    // turns "wedged forever" into "rotated to a member that can".
+    const h = buildWsHarness(prisma, { dutyLease: { refusalsBeforeRelease: 3, refusalBackoffMs: 300_000 } })
+    const start = new Date(h.clock.now())
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(start.getTime() + LEASE_MS) })
+    await prisma.agent.create({
+      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'uninstallable', runtime: 'claude', placementKind: 'pool' }
+    })
+    const { stub } = await ready(h)
+
+    // Two beats: an install may legitimately straddle one, so these are re-offers, not refusals.
+    for (let n = 0; n < 2; n += 1) {
+      await beat(stub, { held: [], headroom: 4 })
+      expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).holder).toBe(DAEMON)
+    }
+    expect(stub.sent.filter((f) => f.type === 'duty/grant')).toHaveLength(2)
+
+    // The third consecutive absence is a refusal: the lease goes back.
+    await beat(stub, { held: [], headroom: 4 })
+    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).holder).toBeNull()
+
+    // And it is NOT handed straight back to the member that just refused it — that rotation is
+    // exactly what would spin every beat.
+    await beat(stub, { held: [], headroom: 4 })
+    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).holder).toBeNull()
+    expect(stub.sent.filter((f) => f.type === 'duty/grant')).toHaveLength(2)
+
+    // A different member takes it immediately — the point of handing it back.
+    const repo = new PgDutyGroupRepo(prisma)
+    const grants = await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS, {
+      scope: 'install-wide'
+    })
+    expect(grants.map((g) => g.groupId)).toEqual([GROUP])
+  })
+
+  it('reporting the group at any point clears the count — that is convergence, not refusal', async () => {
+    const h = buildWsHarness(prisma, { dutyLease: { refusalsBeforeRelease: 2 } })
+    const start = new Date(h.clock.now())
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(start.getTime() + LEASE_MS) })
+    const { stub } = await ready(h)
+
+    await beat(stub, { held: [], headroom: 0 })
+    await beat(stub, { held: [{ groupId: GROUP, term: '1' }], headroom: 0 })
+    // The count restarts, so this absence is the FIRST, not the threshold-crossing second.
+    await beat(stub, { held: [], headroom: 0 })
+
+    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).holder).toBe(DAEMON)
   })
 })

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -997,12 +997,13 @@ describe('routing follows the holder (protocol level, real Postgres)', () => {
 
   // THE test this whole change exists for. "The sweep re-granted it" is not "it heals" unless the
   // thing that ADDRESSES a daemon moves too: the relay dispatches an inbound webhook on the
-  // compiled hook rule, and that rule bakes in a member id. So: A holds, A lapses, B is granted —
-  // and the rule the relay would dispatch on now names B, with no reconnect and no trigger.
+  // compiled hook rule, and that rule bakes in a member id. So: A holds, A lapses, B is granted and
+  // reports the group — and the rule the relay would dispatch on now names B, with no reconnect and
+  // no trigger anywhere in the sequence.
   //
-  // Mutation check: drop the `routing?.kick(...)` from the lease exchange's grant branch and the
-  // rule stays pinned to A, so the message keeps arriving at the member that lost the agent.
-  it('re-addresses the compiled hook rule at the new holder after a grant, with no reconnect', async () => {
+  // Mutation check: drop the `routing?.kick(...)` from the confirmation branch of the exchange and
+  // the rule stays pinned to A, so the webhook keeps arriving at the member that lost the agent.
+  it('re-addresses the compiled hook rule at the new holder, with no reconnect', async () => {
     const start = 1_700_000_000_000
     const h = buildWsHarness(prisma)
     await seedPooledAgentWithHook()
@@ -1010,8 +1011,11 @@ describe('routing follows the holder (protocol level, real Postgres)', () => {
     await seedGroup({ holder: OTHER, term: 4n, expiresAt: new Date(start - 1) })
     const { stub } = await ready(h)
 
-    stub.inject('heartbeat', heartbeat({ held: [], headroom: 4 }))
-    await stub.expectFrame('duty/grant')
+    // Beat 1 claims. Beat 2 reports the group, which is the first moment the member is provably
+    // serving it — publishing at beat 1 would address a member still running `duty/fetch`.
+    await beat(stub, { held: [], headroom: 4 })
+    expect(stub.sent.some((f) => f.type === 'duty/grant')).toBe(true)
+    await beat(stub, { held: [{ groupId: GROUP, term: '5' }], headroom: 4 })
     // The converger is debounced on the same clock the exchange runs on.
     h.clock.advance(1)
     await vi.waitFor(() => expect(h.hookAssigns.length).toBeGreaterThan(0))
@@ -1034,5 +1038,119 @@ describe('routing follows the holder (protocol level, real Postgres)', () => {
     await beat(stub, { held: [], headroom: 0 })
     h.clock.advance(1)
     await vi.waitFor(() => expect(h.hookRemovals).toContain(HOOK))
+  })
+})
+
+describe('a grant is not a route until the digest confirms it (protocol level, real Postgres)', () => {
+  const HOOK2 = '77777777-7777-4777-8777-77777777770b'
+
+  async function seedPooledAgent(): Promise<void> {
+    await prisma.agent.create({
+      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'peer', runtime: 'claude', placementKind: 'pool' }
+    })
+  }
+
+  /** The flat peer directory as the relay and every daemon receive it — what an A2A wake resolves
+   *  through, and what `admits()` fails closed against. */
+  async function directoryDaemonFor(h: ReturnType<typeof buildWsHarness>, agentId: string): Promise<string | null> {
+    const rows = await h.placement.resolveDirectory(await h.deps.agent.orgDirectory(OrgId(DEFAULT_ORG_ID)))
+    return rows.find((r) => r.agentId === agentId)?.daemonId ?? null
+  }
+
+  // The #976 shape, on a projection: the gate must not open before the fact. A grant commits the
+  // lease; the member has NOT installed yet (`duty/fetch` is still in flight), and #972 applies the
+  // grant only once that install succeeds — so "reported in the digest" is the first moment the
+  // member is provably serving. Publishing at grant time makes the relay and the target both cache
+  // a terminal `not_found` against that deliveryId, which stays dead even after the member is ready.
+  it('does not name the new holder in the peer directory until it reports the group', async () => {
+    const start = 1_700_000_000_000
+    const h = buildWsHarness(prisma)
+    await seedPooledAgent()
+    await seedGroup({ holder: OTHER, term: 4n, expiresAt: new Date(start - 1) })
+    const { stub } = await ready(h)
+
+    // Beat 1 claims the vacancy. The lease is DAEMON's from this moment. Awaited to completion:
+    // the lane drops a beat injected while one is still running.
+    await beat(stub, { held: [], headroom: 4 })
+    const grant = await stub.expectFrame('duty/grant')
+    if (!isFrame('duty/grant')(grant)) throw new Error('expected duty/grant')
+    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).holder).toBe(DAEMON)
+
+    // ...and the directory still names nobody: a lease is not yet a route.
+    expect(await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).toMatchObject({ confirmedAt: null })
+    expect(await directoryDaemonFor(h, AGENT)).toBeNull()
+
+    // Beat 2 carries the group in the digest — the member installed and opened its gate.
+    await beat(stub, { held: [{ groupId: GROUP, term: '5' }], headroom: 4 })
+    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).confirmedAt).not.toBeNull()
+    expect(await directoryDaemonFor(h, AGENT)).toBe(DAEMON)
+  })
+
+  it('publishes the hook rule on confirmation, not on the grant', async () => {
+    // Same property on the other pushed projection, and the one with a spy on the wire.
+    const start = 1_700_000_000_000
+    const h = buildWsHarness(prisma)
+    await seedPooledAgent()
+    await prisma.hookDef.create({
+      data: {
+        id: HOOK2,
+        orgId: DEFAULT_ORG_ID,
+        agentId: AGENT,
+        kind: 'webhook',
+        name: 'inbound',
+        enabled: true,
+        urlToken: 'wh-confirm-gate-token',
+        sessionMode: 'perDelivery'
+      }
+    })
+    await seedGroup({ holder: OTHER, term: 4n, expiresAt: new Date(start - 1) })
+    const { stub } = await ready(h)
+
+    await beat(stub, { held: [], headroom: 4 })
+    expect(stub.sent.some((f) => f.type === 'duty/grant')).toBe(true)
+    h.clock.advance(1)
+    await new Promise((r) => setTimeout(r, 30))
+    expect(h.hookAssigns.filter((rule) => rule.daemonId === DAEMON)).toEqual([])
+
+    await beat(stub, { held: [{ groupId: GROUP, term: '5' }], headroom: 4 })
+    h.clock.advance(1)
+    await vi.waitFor(() => expect(h.hookAssigns.some((rule) => rule.daemonId === DAEMON)).toBe(true))
+  })
+
+  it('confirms once, not on every beat — the stamp is first-write-wins', async () => {
+    const h = buildWsHarness(prisma)
+    const startAt = new Date(h.clock.now())
+    await seedPooledAgent()
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(startAt.getTime() + LEASE_MS) })
+    const { stub } = await ready(h)
+
+    await beat(stub, { held: [{ groupId: GROUP, term: '1' }], headroom: 0 })
+    const first = (await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).confirmedAt
+    expect(first).not.toBeNull()
+
+    h.clock.advance(5_000)
+    await beat(stub, { held: [{ groupId: GROUP, term: '1' }], headroom: 0 })
+    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).confirmedAt).toEqual(first)
+  })
+
+  it('a re-grant to a DIFFERENT member drops the confirmation; renewal keeps it', async () => {
+    // The reset rule, both ways. A composition change re-grants IN PLACE and must not blank a
+    // working route; a claim by another member must.
+    const h = buildWsHarness(prisma)
+    const startAt = new Date(h.clock.now())
+    await seedPooledAgent()
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(startAt.getTime() + LEASE_MS) })
+    const { stub } = await ready(h)
+    await beat(stub, { held: [{ groupId: GROUP, term: '1' }], headroom: 0 })
+    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).confirmedAt).not.toBeNull()
+
+    // Lapse it, then let a different member take it.
+    await prisma.dutyGroup.update({ where: { id: GROUP }, data: { expiresAt: new Date(h.clock.now() - 1) } })
+    const repo = new PgDutyGroupRepo(prisma)
+    await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS, { scope: 'install-wide' })
+
+    const row = await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })
+    expect(row.holder).toBe(OTHER)
+    expect(row.confirmedAt).toBeNull()
   })
 })

--- a/packages/control-plane/test/protocol/fencing.test.ts
+++ b/packages/control-plane/test/protocol/fencing.test.ts
@@ -37,6 +37,13 @@ function fencingDeps(clock: FakeClock): DaemonWsDeps {
     lifecycleOps: {} as DaemonWsDeps['lifecycleOps'],
     registry: {} as DaemonWsDeps['registry'],
     orchestrator: {} as DaemonWsDeps['orchestrator'],
+    placementResolver: {
+      mayAct: async () => true,
+      servingDaemon: async () => null,
+      servingDaemons: async () => [],
+      dispatchDaemon: async () => null,
+      resolveDirectory: async (rows: unknown[]) => rows
+    } as unknown as DaemonWsDeps['placementResolver'],
     connReg,
     agent: {} as DaemonWsDeps['agent'],
     session: {} as DaemonWsDeps['session'],

--- a/packages/control-plane/test/repo/agent-placement-delegation.test.ts
+++ b/packages/control-plane/test/repo/agent-placement-delegation.test.ts
@@ -1,3 +1,4 @@
+import { onDaemon } from '../../src/domain/placement.js'
 import { describe, expect, it } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
@@ -157,7 +158,7 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
     const releasePlacement = barrier()
     const placement = prisma.$transaction(
       async (tx) => {
-        await new PgAgentRepo(tx).setPlacement(AGENT, OTHER_DAEMON)
+        await new PgAgentRepo(tx).setPlacement(AGENT, onDaemon(OTHER_DAEMON))
         placed.release()
         await releasePlacement.promise
       },
@@ -190,7 +191,7 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
     )
     await established.promise
 
-    const movement = new PgAgentRepo(prisma).movePlacement(AGENT, DAEMON, OTHER_DAEMON)
+    const movement = new PgAgentRepo(prisma).movePlacement(AGENT, onDaemon(DAEMON), onDaemon(OTHER_DAEMON))
     await expectPending(movement)
     releaseEstablishment.release()
 
@@ -208,12 +209,12 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
     const agents = new PgAgentRepo(prisma)
     const delegation = (await delegations.establish(input))!
 
-    await agents.setPlacement(AGENT, DAEMON)
+    await agents.setPlacement(AGENT, onDaemon(DAEMON))
     expect((await delegations.get(delegation.id))?.revokedAt).toBeNull()
-    expect(await agents.movePlacement(AGENT, DAEMON, DAEMON)).not.toBeNull()
+    expect(await agents.movePlacement(AGENT, onDaemon(DAEMON), onDaemon(DAEMON))).not.toBeNull()
     expect((await delegations.get(delegation.id))?.revokedAt).toBeNull()
 
-    await agents.setPlacement(AGENT, OTHER_DAEMON)
+    await agents.setPlacement(AGENT, onDaemon(OTHER_DAEMON))
     expect(await delegations.get(delegation.id)).toMatchObject({
       revokedReason: 'agent_placement_changed',
       revokedAt: expect.any(Date)
@@ -237,7 +238,7 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
       conversationId: OTHER_CONVERSATION
     }))!
 
-    expect(await new PgAgentRepo(prisma).movePlacement(AGENT, DAEMON, OTHER_DAEMON)).not.toBeNull()
+    expect(await new PgAgentRepo(prisma).movePlacement(AGENT, onDaemon(DAEMON), onDaemon(OTHER_DAEMON))).not.toBeNull()
 
     for (const id of [first.id, second.id]) {
       expect(await delegations.get(id)).toMatchObject({
@@ -255,7 +256,7 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
     const agents = new PgAgentRepo(prisma)
     // Genuinely placed and serving — the seed leaves the row inactive, and `active` is the
     // half of the state the cascade cannot touch and this helper exists to correct.
-    await agents.setPlacement(AGENT, DAEMON)
+    await agents.setPlacement(AGENT, onDaemon(DAEMON))
     const before = (await prisma.agent.findUnique({ where: { id: AGENT } }))!
 
     await prisma.daemon.delete({ where: { id: DAEMON } })
@@ -272,7 +273,7 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
     })
 
     // Placed again (a peer control plane, an operator) before the sweep got here.
-    await agents.setPlacement(AGENT, OTHER_DAEMON)
+    await agents.setPlacement(AGENT, onDaemon(OTHER_DAEMON))
     expect(await prisma.$transaction((tx) => settleCascadedUnplacement(tx, AGENT))).toBe(false)
     expect(await prisma.agent.findUnique({ where: { id: AGENT } })).toMatchObject({
       daemonId: OTHER_DAEMON,
@@ -287,7 +288,7 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
 
     await expect(
       prisma.$transaction(async (tx) => {
-        await new PgAgentRepo(tx).setPlacement(AGENT, OTHER_DAEMON)
+        await new PgAgentRepo(tx).setPlacement(AGENT, onDaemon(OTHER_DAEMON))
         throw new Error('forced placement rollback')
       })
     ).rejects.toThrow('forced placement rollback')

--- a/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
+++ b/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
@@ -1,4 +1,5 @@
 /** Real-Postgres coverage for Kubernetes identity-to-daemon bindings. */
+import { onDaemon } from '../../src/domain/placement.js'
 import { describe, it, expect } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
@@ -192,7 +193,7 @@ describe('DaemonRepo cloud-member retirement', () => {
     // cloud member has, and the reason the settlement cannot be org-scoped.
     const hosted = AgentId('a9999999-9999-4999-8999-999999999999')
     await seedAgent(prisma, hosted, { daemonId: pod.id })
-    await new PgAgentRepo(prisma).setPlacement(hosted, pod.id)
+    await new PgAgentRepo(prisma).setPlacement(hosted, onDaemon(pod.id))
     const envelope = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
     const laptop = DaemonId('88888888-8888-4888-8888-888888888888')
     await repo.provision(laptop, DEF_ORG)
@@ -217,6 +218,32 @@ describe('DaemonRepo cloud-member retirement', () => {
     expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).toBeNull()
     expect(await prisma.daemon.findUnique({ where: { id: envelope!.id } })).not.toBeNull()
     expect(await prisma.daemon.findUnique({ where: { id: laptop } })).not.toBeNull()
+  })
+
+  it('does not unplace a POOL agent when the member serving it is retired', async () => {
+    // A pool agent is not placed ON the member — the member only holds its duty — so retiring the
+    // Pod must leave the placement alone. Unplacing it would set `status: 'inactive'` and strand
+    // it exactly the way the reaper stranded agents before placement became a target: nothing
+    // re-places an unplaced agent, so it would be permanently offline.
+    const repo = new PgDaemonRepo(prisma)
+    const pod = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    await prisma.daemon.update({ where: { id: pod.id }, data: { lastSeenAt: HOUR_AGO } })
+    const pooled = AgentId('a8888888-8888-4888-8888-888888888888')
+    await seedAgent(prisma, pooled)
+    await prisma.agent.update({
+      where: { id: pooled },
+      data: { placementKind: 'pool', daemonId: null, status: 'active' }
+    })
+
+    expect(await repo.retireCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: pod.sessionEpoch })).toEqual({
+      deleted: true,
+      settled: []
+    })
+    expect(await prisma.agent.findUnique({ where: { id: pooled } })).toMatchObject({
+      placementKind: 'pool',
+      daemonId: null,
+      status: 'active'
+    })
   })
 
   it('refuses a member that came back between the worklist read and the delete', async () => {

--- a/packages/control-plane/test/repo/duty-group.repo.test.ts
+++ b/packages/control-plane/test/repo/duty-group.repo.test.ts
@@ -2,7 +2,7 @@
 // Claims are CAS grants (first valid claim wins), renewal is holder-conditional
 // and term-preserving, and applyReconcile applies the pure planner's output
 // under a per-org advisory scope.
-import { describe, it, expect } from 'vitest'
+import { beforeEach, describe, it, expect } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
 import { planDutyReconcile, computeDutyComponents } from '../../src/orchestrator/dutyGroup.js'
@@ -56,7 +56,7 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
     expect(rows).toHaveLength(2)
     expect(rows.every((r) => r.holder === null && r.term === 0n && r.expiresAt === null)).toBe(true)
 
-    const grants = await repo.claimVacant(M1, 10, T0, LEASE_MS)
+    const grants = await repo.claimVacant(M1, 10, T0, LEASE_MS, { scope: 'install-wide' })
     expect(grants).toHaveLength(2)
     expect(grants.every((g) => g.term === 1n)).toBe(true)
     expect(grants.map((g) => g.members)).toContainEqual([
@@ -69,15 +69,18 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
 
-    expect(await repo.claimVacant(M1, 1, T0, LEASE_MS)).toHaveLength(1)
-    expect(await repo.claimVacant(M2, 10, T0, LEASE_MS)).toHaveLength(1)
+    expect(await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })).toHaveLength(1)
+    expect(await repo.claimVacant(M2, 10, T0, LEASE_MS, { scope: 'install-wide' })).toHaveLength(1)
   })
 
   it('racing claimants never receive the same group', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
 
-    const [g1, g2] = await Promise.all([repo.claimVacant(M1, 2, T0, LEASE_MS), repo.claimVacant(M2, 2, T0, LEASE_MS)])
+    const [g1, g2] = await Promise.all([
+      repo.claimVacant(M1, 2, T0, LEASE_MS, { scope: 'install-wide' }),
+      repo.claimVacant(M2, 2, T0, LEASE_MS, { scope: 'install-wide' })
+    ])
     const ids = [...g1, ...g2].map((g) => g.groupId)
     expect(new Set(ids).size).toBe(ids.length)
     expect(ids).toHaveLength(2)
@@ -86,10 +89,10 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('an expired lease is grantable again at a higher term', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [], [A1], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
 
     const late = after(LEASE_MS + 1)
-    const regrants = await repo.claimVacant(M2, 1, late, LEASE_MS)
+    const regrants = await repo.claimVacant(M2, 1, late, LEASE_MS, { scope: 'install-wide' })
     expect(regrants).toHaveLength(1)
     expect(regrants[0]!.term).toBe(2n)
     const [row] = await repo.listHeldBy(M2)
@@ -99,7 +102,7 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('renewHeld refreshes the horizon term-free; a reassigned group stops matching', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [], [A1], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
 
     const renewed = await repo.renewHeld(M1, after(10_000), LEASE_MS)
     expect(renewed).toHaveLength(1)
@@ -109,14 +112,14 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
 
     // Lapse, reassign to M2, then the old holder's renewal matches nothing.
     const late = after(LEASE_MS * 2)
-    await repo.claimVacant(M2, 1, late, LEASE_MS)
+    await repo.claimVacant(M2, 1, late, LEASE_MS, { scope: 'install-wide' })
     expect(await repo.renewHeld(M1, after(LEASE_MS * 2 + 1000), LEASE_MS)).toEqual([])
   })
 
   it('a lapsed-but-unclaimed lease still renews at the same term (CP outage recovery)', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [], [A1], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
 
     const renewed = await repo.renewHeld(M1, after(LEASE_MS * 3), LEASE_MS)
     expect(renewed).toHaveLength(1)
@@ -127,21 +130,21 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('release vacates immediately, keeps the term, and is holder-conditional', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [], [A1], T0)
-    const [grant] = await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    const [grant] = await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
 
     await repo.release(M2, [grant!.groupId]) // not the holder — no-op
     expect(await repo.listHeldBy(M1)).toHaveLength(1)
 
     await repo.release(M1, [grant!.groupId])
     expect(await repo.listHeldBy(M1)).toHaveLength(0)
-    const regrant = await repo.claimVacant(M2, 1, after(1), LEASE_MS)
+    const regrant = await repo.claimVacant(M2, 1, after(1), LEASE_MS, { scope: 'install-wide' })
     expect(regrant[0]!.term).toBe(2n)
   })
 
   it('reconcile re-grants the incumbent at a bumped term when a held group gains a bot', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
 
     const plan = await reconcile(
       repo,
@@ -161,8 +164,8 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('reconcile merge keeps the larger held group and reports the loser superseded', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
-    const grants1 = await repo.claimVacant(M1, 1, T0, LEASE_MS)
-    const grants2 = await repo.claimVacant(M2, 1, T0, LEASE_MS)
+    const grants1 = await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
+    const grants2 = await repo.claimVacant(M2, 1, T0, LEASE_MS, { scope: 'install-wide' })
     const bigHolder = grants1[0]!.members.length > grants2[0]!.members.length ? M1 : M2
 
     // A2 gains an integration on B1: the {A1,B1} pair and the {A2} singleton merge.
@@ -185,7 +188,7 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('reconcile deletes groups whose edges vanished', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
 
     const plan = await reconcile(repo, [], [], after(1000))
     expect(plan.deletes).toHaveLength(1)
@@ -201,7 +204,10 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
 
-    const [grants, plan] = await Promise.all([repo.claimVacant(M1, 1, T0, LEASE_MS), reconcile(repo, [], [], after(1))])
+    const [grants, plan] = await Promise.all([
+      repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' }),
+      reconcile(repo, [], [], after(1))
+    ])
     expect(plan.deletes).toHaveLength(1)
     if (grants.length === 1) expect(plan.superseded).toEqual([{ groupId: grants[0]!.groupId, holder: M1 }])
     else expect(plan.superseded).toEqual([])
@@ -211,7 +217,7 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('reconcile leaves an unchanged held group untouched (no term churn)', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
 
     const plan = await reconcile(repo, [{ agentId: A1, botId: B1 }], [], after(1000))
     expect(plan.unchanged).toHaveLength(1)
@@ -221,9 +227,17 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
 })
 
 describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
+  // The rendezvous is a claim path, so it takes the eligibility gate too — which means the agent
+  // has to exist and be placed on the pool for an install-wide member to claim it.
+  beforeEach(async () => {
+    await prisma.agent.create({
+      data: { id: A1, orgId: DEFAULT_ORG_ID, name: 'pooled', runtime: 'claude', placementKind: 'pool' }
+    })
+  })
+
   it('claiming creates the lease for an unmapped agent', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    const claim = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    const claim = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
     expect(claim).toMatchObject({ granted: true, term: 1n, holder: M1 })
     const rows = await repo.listForOrg(ORG)
     expect(rows[0]!.members).toEqual([{ kind: 'agent', refId: A1 }])
@@ -231,8 +245,8 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
 
   it('is idempotent for the current holder — horizon refreshed, term kept', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
-    const again = await repo.claimAgentHome(ORG, AgentId(A1), M1, after(10_000), LEASE_MS)
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
+    const again = await repo.claimAgentHome(ORG, AgentId(A1), M1, after(10_000), LEASE_MS, 'install-wide')
     expect(again).toMatchObject({ granted: true, term: 1n, holder: M1 })
     const [row] = await repo.listHeldBy(M1)
     expect(row!.expiresAt).toEqual(after(10_000 + LEASE_MS))
@@ -240,21 +254,21 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
 
   it('names the incumbent instead of granting while the home is live', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    const won = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
-    const lost = await repo.claimAgentHome(ORG, AgentId(A1), M2, after(1000), LEASE_MS)
+    const won = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
+    const lost = await repo.claimAgentHome(ORG, AgentId(A1), M2, after(1000), LEASE_MS, 'install-wide')
     expect(lost).toEqual({ granted: false, groupId: won.groupId, term: 1n, holder: M1 })
   })
 
   it('grants an expired home to the new claimant at a bumped term', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
-    const claim = await repo.claimAgentHome(ORG, AgentId(A1), M2, after(LEASE_MS + 1), LEASE_MS)
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
+    const claim = await repo.claimAgentHome(ORG, AgentId(A1), M2, after(LEASE_MS + 1), LEASE_MS, 'install-wide')
     expect(claim).toMatchObject({ granted: true, term: 2n, holder: M2 })
   })
 
   it('holdsAgent answers only for the live holder — the duty/fetch authorization', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
 
     expect(await repo.holdsAgent(M1, AgentId(A1), T0)).toBe(true)
     // Another member holds nothing here, and neither does the holder for an agent
@@ -276,7 +290,7 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
       [],
       T0
     )
-    await repo.claimVacant(M1, 10, T0, LEASE_MS)
+    await repo.claimVacant(M1, 10, T0, LEASE_MS, { scope: 'install-wide' })
 
     expect(await repo.holdsAgent(M1, AgentId(A1), T0)).toBe(true)
     expect(await repo.holdsAgent(M1, AgentId(A2), T0)).toBe(true)
@@ -294,7 +308,7 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
       T0
     )
     const [first] = await repo.listForOrg(ORG)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
     const heldAgent = first!.members.find((m) => m.kind === 'agent')!.refId
 
     expect(await repo.holdersOf(AgentId(heldAgent), T0)).toEqual([M1])
@@ -306,7 +320,7 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
 
   it('holdersOf survives the agent row it names — a delete must still reach the holder', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
     // No FK from membership to `agent`: the projection owns that lifecycle, so a
     // cascade cannot strand `agent/remove` with nowhere to send it.
     expect(await repo.holdersOf(AgentId(A1), T0)).toEqual([M1])
@@ -315,8 +329,8 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
   it('racing first claims resolve to exactly one home and one winner', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     const [c1, c2] = await Promise.all([
-      repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS),
-      repo.claimAgentHome(ORG, AgentId(A1), M2, T0, LEASE_MS)
+      repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide'),
+      repo.claimAgentHome(ORG, AgentId(A1), M2, T0, LEASE_MS, 'install-wide')
     ])
     expect([c1.granted, c2.granted].filter(Boolean)).toHaveLength(1)
     expect(c1.groupId).toBe(c2.groupId)

--- a/packages/control-plane/test/repo/duty-recompute.test.ts
+++ b/packages/control-plane/test/repo/duty-recompute.test.ts
@@ -1,6 +1,6 @@
-// DutyRecomputeSweep + the soak-phase incumbent grant policy (real Postgres):
-// the sweep derives one duty group per agent (merged by shared socket bots), and
-// claimVacant's incumbent gate pins grants to the member its agents live on.
+// DutyRecomputeSweep + the placement eligibility gate (real Postgres): the sweep derives one
+// duty group per agent (merged by shared socket bots), and claimVacant grants only what the
+// claimant may hold — every agent in the group placed on it, or placed on the pool it belongs to.
 import { describe, it, expect, vi } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { PgDutyGroupRepo } from '../../src/persistence/index.js'
@@ -12,6 +12,8 @@ import { FakeClock } from '../fakes/fake-clock.js'
 
 const M1 = DaemonId('d1111111-1111-4111-8111-111111111111')
 const M2 = DaemonId('d2222222-2222-4222-8222-222222222222')
+const POOL_A = DaemonId('d3333333-3333-4333-8333-333333333333')
+const POOL_B = DaemonId('d4444444-4444-4444-8444-444444444444')
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const AGENT2 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
 const BOT = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'
@@ -38,7 +40,7 @@ function sweep(clock = new FakeClock(1_700_000_000_000)) {
       plans.push(plan)
       return plan
     },
-    vacateNonIncumbent: repo.vacateNonIncumbent.bind(repo)
+    vacateIneligible: repo.vacateIneligible.bind(repo)
   }
   return {
     repo,
@@ -52,7 +54,6 @@ function sweep(clock = new FakeClock(1_700_000_000_000)) {
         intervalMs: 30_000,
         orgsPerTick: 25,
         leaseMs: LEASE_MS,
-        incumbentFence: true,
         kickDelayMs: 0
       },
       { warn: (o) => void warns.push(o), error: () => undefined }
@@ -72,6 +73,23 @@ async function seedDaemons(): Promise<void> {
 async function seedAgent(id: string, name: string, daemonId?: string): Promise<void> {
   await prisma.agent.create({
     data: { id, orgId: DEFAULT_ORG_ID, name, runtime: 'claude', ...(daemonId ? { daemonId } : {}) }
+  })
+}
+
+/** An agent placed on the POOL: kind `pool`, no member id at all. */
+async function seedPoolAgent(id: string, name: string): Promise<void> {
+  await prisma.agent.create({
+    data: { id, orgId: DEFAULT_ORG_ID, name, runtime: 'claude', placementKind: 'pool' }
+  })
+}
+
+/** Install-wide pool members: org-less rows, which is what makes them install-wide. */
+async function seedMembers(): Promise<void> {
+  await prisma.daemon.createMany({
+    data: [
+      { id: POOL_A, orgId: null, maxAgents: 8, status: 'ready' },
+      { id: POOL_B, orgId: null, maxAgents: 8, status: 'ready' }
+    ]
   })
 }
 
@@ -143,7 +161,7 @@ describe('duty recompute sweep (real Postgres)', () => {
     await s.tick()
     const [created] = await repo.listForOrg(ORG)
     expect(created!.members).toEqual([{ kind: 'agent', refId: AGENT }])
-    const [grant] = await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { incumbentOnly: true })
+    const [grant] = await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
     expect(grant).toBeDefined()
 
     // The flap this test exists for: sweep 2 and 3 must plan no delete and no
@@ -171,7 +189,7 @@ describe('duty recompute sweep (real Postgres)', () => {
     const { repo, clock, warns, sweep: s } = sweep()
 
     // The design's fallback path: the trigger arrives before the sweep ran.
-    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), M1, new Date(clock.now()), LEASE_MS)
+    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), M1, new Date(clock.now()), LEASE_MS, 'install-wide')
     expect(claim.granted).toBe(true)
 
     await s.tick()
@@ -182,17 +200,19 @@ describe('duty recompute sweep (real Postgres)', () => {
     expect(warns).toEqual([])
   })
 
-  it('an unplaced agent’s rendezvous claim is not vacated — nothing moved away', async () => {
+  it('an unplaced agent’s home cannot be claimed at all, so there is no lease to fence', async () => {
+    // The old fence had to make an exception for this case — the rendezvous minted a lease for an
+    // unplaced agent and vacating it every sweep would churn. Eligibility removes the exception at
+    // the source: nothing may serve an unplaced agent, so nothing claims one.
     await seedDaemons()
-    await seedAgent(AGENT, 'agent-1') // no placement: the fence has no rival incumbent
+    await seedAgent(AGENT, 'agent-1') // no placement
     const { repo, clock, warns, sweep: s } = sweep()
 
-    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), M1, new Date(clock.now()), LEASE_MS)
+    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), M1, new Date(clock.now()), LEASE_MS, 'install-wide')
+    expect(claim.granted).toBe(false)
     await s.tick()
 
-    const [held] = await repo.listHeldBy(M1)
-    expect(held!.groupId).toBe(claim.groupId)
-    expect(held!.term).toBe(claim.term)
+    expect(await repo.listHeldBy(M1)).toEqual([])
     expect(warns).toEqual([])
   })
 
@@ -218,7 +238,7 @@ describe('duty recompute sweep (real Postgres)', () => {
 
     await s.tick()
     const [singleton] = await repo.listForOrg(ORG)
-    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { incumbentOnly: true })
+    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
 
     await seedBot(BOT, 'socket')
     await seedIntegration(INTEG, AGENT, BOT)
@@ -271,7 +291,7 @@ describe('duty recompute sweep (real Postgres)', () => {
     const { repo, clock, sweep: s } = sweep()
 
     await s.tick()
-    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS)
+    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
 
     // A second agent joins the same daemon-held bot: the group widens.
     await seedAgent(AGENT2, 'agent-2', M1)
@@ -293,20 +313,25 @@ describe('incumbent placement fence (real Postgres)', () => {
     await seedIntegration(INTEG, AGENT, BOT)
     const { repo, clock, sweep: s } = sweep()
     await s.tick()
-    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { incumbentOnly: true })
+    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
 
     // The agent moves to M2: the next tick vacates M1's lease, and only M2 can claim.
     await prisma.agent.update({ where: { id: AGENT }, data: { daemonId: M2 } })
     await s.tick()
     expect(await repo.listHeldBy(M1)).toEqual([])
     const now = new Date(clock.now())
-    expect(await repo.claimVacant(M1, 5, now, LEASE_MS, { incumbentOnly: true })).toEqual([])
-    const grants = await repo.claimVacant(M2, 5, now, LEASE_MS, { incumbentOnly: true })
+    expect(await repo.claimVacant(M1, 5, now, LEASE_MS, { scope: 'install-wide' })).toEqual([])
+    const grants = await repo.claimVacant(M2, 5, now, LEASE_MS, { scope: 'install-wide' })
     expect(grants).toHaveLength(1)
     expect(grants[0]!.term).toBe(2n)
   })
 
-  it('partial occupancy keeps the lease — a split group never flaps', async () => {
+  it('a PARTIAL move-away now vacates the lease, because the holder is no longer eligible for all of it', async () => {
+    // The old fence kept the lease while the holder still hosted ANY of the group's agents, to
+    // stop a split group flapping between two partial incumbents. Eligibility is FORALL, so it
+    // vacates instead — and that is the point: under the old rule M1 kept SERVING an agent that
+    // had moved to M2, which is the duplicate service the ledger exists to prevent. The group is
+    // unclaimable until the next recompute splits it, which is the safe direction.
     await seedDaemons()
     await seedAgent(AGENT, 'agent-1', M1)
     await seedAgent(AGENT2, 'agent-2', M1)
@@ -315,19 +340,17 @@ describe('incumbent placement fence (real Postgres)', () => {
     await seedIntegration(INTEG2, AGENT2, BOT)
     const { repo, clock, sweep: s } = sweep()
     await s.tick()
-    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { incumbentOnly: true })
+    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { scope: 'org-scoped' })
+    expect(await repo.listHeldBy(M1)).toHaveLength(1)
 
-    // Only one of the two agents moves: M1 still hosts AGENT, so the lease stays.
     await prisma.agent.update({ where: { id: AGENT2 }, data: { daemonId: M2 } })
     await s.tick()
-    const [held] = await repo.listHeldBy(M1)
-    expect(held!.holder).toBe(M1)
-    expect(held!.term).toBe(1n)
+    expect(await repo.listHeldBy(M1)).toEqual([])
   })
 })
 
-describe('incumbent grant policy (real Postgres)', () => {
-  it('incumbentOnly pins a vacancy to the member its agent is placed on', async () => {
+describe('placement eligibility gate (real Postgres)', () => {
+  it('a machine-placed agent’s group is claimable only by that machine', async () => {
     await seedDaemons()
     await seedAgent(AGENT, 'agent-1', M1)
     await seedBot(BOT, 'socket')
@@ -336,35 +359,124 @@ describe('incumbent grant policy (real Postgres)', () => {
     await s.tick()
     const now = new Date(clock.now())
 
-    // M2 is not the incumbent: nothing to claim under the policy.
-    expect(await repo.claimVacant(M2, 5, now, LEASE_MS, { incumbentOnly: true })).toEqual([])
-    // M1 is: the grant flows.
-    const grants = await repo.claimVacant(M1, 5, now, LEASE_MS, { incumbentOnly: true })
+    // Another machine may not take it, and neither may an install-wide member.
+    expect(await repo.claimVacant(M2, 5, now, LEASE_MS, { scope: 'org-scoped' })).toEqual([])
+    const grants = await repo.claimVacant(M1, 5, now, LEASE_MS, { scope: 'org-scoped' })
     expect(grants).toHaveLength(1)
     expect(grants[0]!.members).toContainEqual({ kind: 'agent', refId: AGENT })
   })
 
-  it('an unplaced agent’s group is claimable by nobody under the policy, anybody without it', async () => {
+  // THE load-bearing tenancy invariant of the whole change: dropping the incumbent gate must not
+  // let the pool reach the agents a local daemon is already serving.
+  it('NO pool member ever claims an agent placed on a local daemon', async () => {
     await seedDaemons()
-    await seedAgent(AGENT, 'agent-1') // no placement
-    await prisma.cronDef.create({
-      data: {
-        id: CRON,
-        orgId: DEFAULT_ORG_ID,
-        agentId: AGENT,
-        schedule: '0 9 * * *',
-        timezone: 'UTC',
-        targetPlatform: 'telegram',
-        trigger: 'daily',
-        enabled: true
-      }
-    })
+    await seedMembers()
+    await seedAgent(AGENT, 'agent-1', M1)
     const { repo, clock, sweep: s } = sweep()
     await s.tick()
     const now = new Date(clock.now())
 
-    expect(await repo.claimVacant(M1, 5, now, LEASE_MS, { incumbentOnly: true })).toEqual([])
-    expect(await repo.claimVacant(M1, 5, now, LEASE_MS)).toHaveLength(1)
+    expect(await repo.claimVacant(POOL_A, 5, now, LEASE_MS, { scope: 'install-wide' })).toEqual([])
+    expect(await repo.claimVacant(POOL_B, 5, now, LEASE_MS, { scope: 'install-wide' })).toEqual([])
+    // And the rendezvous is the same gate, not a second one: a trigger reaching the wrong member
+    // is not authority to serve an agent that member may not hold.
+    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), POOL_A, now, LEASE_MS, 'install-wide')
+    expect(claim.granted).toBe(false)
+    expect(await repo.listHeldBy(POOL_A)).toEqual([])
+  })
+
+  it('a pool agent’s group is claimable by ANY live member, and by no machine', async () => {
+    await seedDaemons()
+    await seedMembers()
+    await seedPoolAgent(AGENT, 'pool-agent')
+    const { repo, clock, sweep: s } = sweep()
+    await s.tick()
+    const now = new Date(clock.now())
+
+    // A machine-scoped claimant is never install-wide, so the pool's work stays out of reach.
+    expect(await repo.claimVacant(M1, 5, now, LEASE_MS, { scope: 'org-scoped' })).toEqual([])
+    const grants = await repo.claimVacant(POOL_B, 5, now, LEASE_MS, { scope: 'install-wide' })
+    expect(grants).toHaveLength(1)
+    expect(grants[0]!.members).toContainEqual({ kind: 'agent', refId: AGENT })
+  })
+
+  it('a group mixing a pool agent with a machine-placed one is claimable by neither', async () => {
+    // Two agents sharing one socket bot merge into one component. Serving it as a unit would mean
+    // one member running an agent the other side already runs, so the gate is FORALL, not EXISTS.
+    await seedDaemons()
+    await seedMembers()
+    await seedAgent(AGENT, 'agent-1', M1)
+    await seedPoolAgent(AGENT2, 'pool-agent')
+    await seedBot(BOT, 'socket')
+    await seedIntegration(INTEG, AGENT, BOT)
+    await seedIntegration(INTEG2, AGENT2, BOT)
+    const { repo, clock, sweep: s } = sweep()
+    await s.tick()
+    expect(await repo.listForOrg(ORG)).toHaveLength(1)
+    const now = new Date(clock.now())
+
+    expect(await repo.claimVacant(M1, 5, now, LEASE_MS, { scope: 'org-scoped' })).toEqual([])
+    expect(await repo.claimVacant(POOL_A, 5, now, LEASE_MS, { scope: 'install-wide' })).toEqual([])
+  })
+
+  it('an unplaced agent’s group is claimable by nobody, and its rendezvous claim is refused', async () => {
+    await seedDaemons()
+    await seedMembers()
+    await seedAgent(AGENT, 'agent-1') // no placement
+    const { repo, clock, sweep: s } = sweep()
+    await s.tick()
+    const now = new Date(clock.now())
+
+    expect(await repo.claimVacant(POOL_A, 5, now, LEASE_MS, { scope: 'install-wide' })).toEqual([])
+    expect(await repo.claimVacant(M1, 5, now, LEASE_MS, { scope: 'org-scoped' })).toEqual([])
+    expect((await repo.claimAgentHome(ORG, AgentId(AGENT), POOL_A, now, LEASE_MS, 'install-wide')).granted).toBe(false)
+  })
+
+  it('the backoff list excludes named groups from a claim without disturbing the rest', async () => {
+    await seedDaemons()
+    await seedMembers()
+    await seedPoolAgent(AGENT, 'pool-agent')
+    await seedPoolAgent(AGENT2, 'pool-agent-2')
+    const { repo, clock, sweep: s } = sweep()
+    await s.tick()
+    const now = new Date(clock.now())
+    const [first, second] = (await repo.listForOrg(ORG)).map((g) => g.groupId)
+
+    const grants = await repo.claimVacant(POOL_A, 5, now, LEASE_MS, {
+      scope: 'install-wide',
+      excludeGroupIds: [first!]
+    })
+    expect(grants.map((g) => g.groupId)).toEqual([second])
+  })
+})
+
+describe('the placement fence (real Postgres)', () => {
+  it('vacates a lease whose holder may no longer hold it — a pool agent moved onto a machine', async () => {
+    await seedDaemons()
+    await seedMembers()
+    await seedPoolAgent(AGENT, 'pool-agent')
+    const { repo, clock, sweep: s, warns } = sweep()
+    await s.tick()
+    const [granted] = await repo.claimVacant(POOL_A, 5, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
+    expect(granted).toBeDefined()
+
+    // Moved off the pool onto a machine: the member holding it is no longer eligible.
+    await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'daemon', daemonId: M1 } })
+    await s.tick()
+
+    expect(await repo.listHeldBy(POOL_A)).toEqual([])
+    expect(warns).not.toEqual([])
+  })
+
+  it('keeps a lease whose holder is still eligible', async () => {
+    await seedDaemons()
+    await seedMembers()
+    await seedPoolAgent(AGENT, 'pool-agent')
+    const { repo, clock, sweep: s } = sweep()
+    await s.tick()
+    await repo.claimVacant(POOL_A, 5, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
+    await s.tick()
+    expect(await repo.listHeldBy(POOL_A)).toHaveLength(1)
   })
 })
 
@@ -397,13 +509,12 @@ describe('duty recompute kick (real Postgres)', () => {
         return repo.computeInputs(orgId)
       },
       applyReconcile: repo.applyReconcile.bind(repo),
-      vacateNonIncumbent: repo.vacateNonIncumbent.bind(repo)
+      vacateIneligible: repo.vacateIneligible.bind(repo)
     }
     const s = new DutyRecomputeSweep(spy, clock, {
       intervalMs: 30_000,
       orgsPerTick: 25,
       leaseMs: LEASE_MS,
-      incumbentFence: true,
       kickDelayMs: 10
     })
 

--- a/packages/control-plane/test/repo/duty-recompute.test.ts
+++ b/packages/control-plane/test/repo/duty-recompute.test.ts
@@ -40,7 +40,8 @@ function sweep(clock = new FakeClock(1_700_000_000_000)) {
       plans.push(plan)
       return plan
     },
-    vacateIneligible: repo.vacateIneligible.bind(repo)
+    vacateIneligible: repo.vacateIneligible.bind(repo),
+    getByIds: repo.getByIds.bind(repo)
   }
   return {
     repo,
@@ -509,7 +510,8 @@ describe('duty recompute kick (real Postgres)', () => {
         return repo.computeInputs(orgId)
       },
       applyReconcile: repo.applyReconcile.bind(repo),
-      vacateIneligible: repo.vacateIneligible.bind(repo)
+      vacateIneligible: repo.vacateIneligible.bind(repo),
+      getByIds: repo.getByIds.bind(repo)
     }
     const s = new DutyRecomputeSweep(spy, clock, {
       intervalMs: 30_000,

--- a/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
+++ b/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
@@ -1,3 +1,4 @@
+import { onDaemon, UNPLACED } from '../../src/domain/placement.js'
 import { randomUUID } from 'node:crypto'
 import {
   HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
@@ -1546,9 +1547,9 @@ describe('R1/R2a persistence foundation', () => {
     })
     expect((await hooks.getUnscoped(hookId))?.dispatchRevision).toBe(1n)
 
-    expect(await agents.movePlacement(agentId, D1, D2)).not.toBeNull()
+    expect(await agents.movePlacement(agentId, onDaemon(D1), onDaemon(D2))).not.toBeNull()
     expect((await hooks.getUnscoped(hookId))?.dispatchRevision).toBe(2n)
-    await agents.setPlacement(agentId, null)
+    await agents.setPlacement(agentId, UNPLACED)
     expect((await hooks.getUnscoped(hookId))?.dispatchRevision).toBe(3n)
   })
 

--- a/packages/control-plane/test/repo/served-agents.repo.test.ts
+++ b/packages/control-plane/test/repo/served-agents.repo.test.ts
@@ -1,0 +1,121 @@
+// The two placement axes must never disagree (real Postgres).
+//
+// `servedAgents(daemon)` is member→agents; `PlacementResolver.servingDaemons(agent)` is
+// agent→members. Neither is expressible as the other without scanning the opposite side, so both
+// exist — and #989 and this change introduced them independently. What keeps them honest is that
+// each half reads ONE predicate from its own side: the placement half is `listForDaemon`
+// (`placementKind:'daemon'` + `daemonId`) against `domain/placement.ts#placementTargets`, and the
+// duty half is the same live-lease join read from either end.
+//
+// This pins the biconditional over a fixture that mixes every placement kind. It is the test that
+// fails if someone widens one side's SQL without the other — the drift the pair exists to prevent.
+import { describe, it, expect } from 'vitest'
+import { prisma } from '../setup.db.js'
+import { PgAgentRepo, PgDutyGroupRepo } from '../../src/persistence/index.js'
+import { servedAgents } from '../../src/orchestrator/servedAgents.js'
+import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { DaemonId } from '../../src/domain/ids.js'
+import { FakeClock } from '../fakes/fake-clock.js'
+
+const LOCAL = DaemonId('d1111111-1111-4111-8111-111111111111')
+const MEMBER_A = DaemonId('d2222222-2222-4222-8222-222222222222')
+const MEMBER_B = DaemonId('d3333333-3333-4333-8333-333333333333')
+
+const ON_LOCAL = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const ON_POOL_HELD = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
+const ON_POOL_VACANT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3'
+const UNPLACED_AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4'
+const GROUP = '00000000-0000-4000-8000-000000000001'
+
+const LEASE_MS = 120_000
+
+async function seedFixture(now: Date): Promise<void> {
+  await prisma.daemon.createMany({
+    data: [
+      { id: LOCAL, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' },
+      { id: MEMBER_A, orgId: null, maxAgents: 8, status: 'ready' },
+      { id: MEMBER_B, orgId: null, maxAgents: 8, status: 'ready' }
+    ]
+  })
+  await prisma.agent.createMany({
+    data: [
+      { id: ON_LOCAL, orgId: DEFAULT_ORG_ID, name: 'on-local', runtime: 'claude', daemonId: LOCAL },
+      { id: ON_POOL_HELD, orgId: DEFAULT_ORG_ID, name: 'pool-held', runtime: 'claude', placementKind: 'pool' },
+      { id: ON_POOL_VACANT, orgId: DEFAULT_ORG_ID, name: 'pool-vacant', runtime: 'claude', placementKind: 'pool' },
+      { id: UNPLACED_AGENT, orgId: DEFAULT_ORG_ID, name: 'unplaced', runtime: 'claude' }
+    ]
+  })
+  // MEMBER_A holds the one pool agent that is actually served.
+  await prisma.dutyGroup.create({
+    data: {
+      id: GROUP,
+      orgId: DEFAULT_ORG_ID,
+      holder: MEMBER_A,
+      term: 1n,
+      expiresAt: new Date(now.getTime() + LEASE_MS)
+    }
+  })
+  await prisma.dutyGroupMember.create({
+    data: { kind: 'agent', refId: ON_POOL_HELD, groupId: GROUP, orgId: DEFAULT_ORG_ID }
+  })
+}
+
+describe('the two placement axes agree (real Postgres)', () => {
+  it('D ∈ servingDaemons(A) ⟺ A ∈ servedAgents(D) for every agent and every daemon', async () => {
+    const clock = new FakeClock(1_700_000_000_000)
+    const now = new Date(clock.now())
+    await seedFixture(now)
+    const agents = new PgAgentRepo(prisma)
+    const duties = new PgDutyGroupRepo(prisma)
+    const resolver = new PlacementResolver({ duties, clock })
+
+    const daemons = [LOCAL, MEMBER_A, MEMBER_B]
+    const agentIds = [ON_LOCAL, ON_POOL_HELD, ON_POOL_VACANT, UNPLACED_AGENT]
+
+    const memberSide = new Map<string, Set<string>>()
+    for (const daemonId of daemons) {
+      const served = await servedAgents(daemonId, { agents, duties, now })
+      memberSide.set(daemonId, new Set(served.agents.map((a) => a.id)))
+    }
+
+    for (const agentId of agentIds) {
+      const agent = (await agents.getUnscoped(agentId as never))!
+      const serving = new Set(await resolver.servingDaemons(agent))
+      for (const daemonId of daemons) {
+        expect(
+          { agentId, daemonId, agentSide: serving.has(daemonId) },
+          `agent→member and member→agent disagree for ${agentId} / ${daemonId}`
+        ).toEqual({ agentId, daemonId, agentSide: memberSide.get(daemonId)!.has(agentId) })
+      }
+    }
+
+    // And the fixture actually exercises each arm, so the biconditional above is not vacuous.
+    expect(memberSide.get(LOCAL)).toEqual(new Set([ON_LOCAL]))
+    expect(memberSide.get(MEMBER_A)).toEqual(new Set([ON_POOL_HELD]))
+    expect(memberSide.get(MEMBER_B)).toEqual(new Set())
+  })
+
+  it('the placement half is keyed on the KIND, not on the ref being non-null', async () => {
+    // Today a pool row carries `daemonId = null`, so `where: { daemonId }` alone would already
+    // exclude it — the two sides agree by accident of the encoding, not by rule. This seeds the
+    // state that accident does not cover and the next placement kind WILL produce: a ref stored
+    // under a non-`daemon` kind. `placementColumns` never writes it, so it goes in through raw
+    // SQL, which is the point — the test is about what the query promises, not about what today's
+    // writer happens to produce.
+    const clock = new FakeClock(1_700_000_000_000)
+    await seedFixture(new Date(clock.now()))
+    await prisma.$executeRaw`UPDATE "agent" SET "daemonId" = ${MEMBER_A}::uuid WHERE id = ${ON_POOL_HELD}::uuid`
+    const agents = new PgAgentRepo(prisma)
+
+    // The member side must still not call it placed — its duty is the only way it reaches a
+    // member, and counting it twice is exactly the double-service the ledger exists to prevent.
+    for (const daemonId of [LOCAL, MEMBER_A, MEMBER_B]) {
+      expect((await agents.listForDaemon(daemonId)).map((a) => a.id)).not.toContain(ON_POOL_HELD)
+    }
+    // And the agent side agrees: placement names no machine for it, whatever the column says.
+    const resolver = new PlacementResolver({ duties: new PgDutyGroupRepo(prisma), clock })
+    const agent = (await agents.getUnscoped(ON_POOL_HELD as never))!
+    expect(await resolver.servingDaemons(agent)).toEqual([MEMBER_A])
+  })
+})

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -290,6 +290,8 @@ export class CpClient {
   private reconnectTimer?: TimerHandle
   private lastAuthedEpoch = 0 // for resume on reconnect (per-agent seq tail is out of scope)
   private heartbeatTimer?: TimerHandle
+  /** Debounce for {@link CpClient.reportDutiesNow} — one extra beat per admission, not per group. */
+  private dutyReportTimer?: TimerHandle
   private heartbeatMs = 0
   /** Lease horizon: the CP's `auth/ok` value, replaced by each renewal's own. */
   private dutyLeaseMs?: number
@@ -1212,6 +1214,26 @@ export class CpClient {
       if (this.state === 'READY') this.sendHeartbeat()
       if (this.state === 'READY' || this.state === 'DRAINING') this.armHeartbeat()
     }, this.heartbeatMs)
+  }
+
+  /**
+   * Report the duty digest NOW instead of waiting out the interval.
+   *
+   * The digest is the CP's proof that a grant is installed — a grant is applied here only after
+   * its install succeeds, so "in the digest" is the first moment this member is provably serving,
+   * and the CP holds every projection that ADDRESSES this member until it sees one. Letting an
+   * admission sit until the next tick therefore costs up to a full heartbeat of unroutable time
+   * for an agent that is already running, which is the gap a peer wake falls into.
+   *
+   * Coalesced onto one extra beat: an admission routinely settles several groups, and each one
+   * calls this. Dormant off a frame-mode connection, where there is no digest at all.
+   */
+  reportDutiesNow(): void {
+    if (this.organizationMode !== 'frame' || this.state !== 'READY' || this.dutyReportTimer !== undefined) return
+    this.dutyReportTimer = this.deps.clock.setTimeout(() => {
+      this.dutyReportTimer = undefined
+      if (this.state === 'READY') this.sendHeartbeat()
+    }, 0)
   }
 
   private sendHeartbeat(): void {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12835,7 +12835,14 @@ export class Daemon {
   private settleDutyChange(result: DutyApplyResult): void {
     for (const agentId of result.agentsLost) this.stopServingAgent(agentId)
     const changed = result.added.length + result.updated.length + result.agentsGained.length + result.agentsLost.length
-    if (changed > 0) this.onDutyChanged()
+    if (changed === 0) return
+    // Report the new digest immediately. The CP publishes the projections that address this member
+    // only once it has SEEN the group held (the grant alone is not proof of an install), so waiting
+    // for the next tick leaves an agent this member is already serving unroutable for up to a
+    // heartbeat. Outside the enforcement gate below on purpose: the digest is sent, and the CP
+    // acts on it, whether or not this member is enforcing.
+    this.cpClient?.reportDutiesNow()
+    this.onDutyChanged()
   }
 
   /**

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -85,6 +85,10 @@ async function boot(dutyEnforcement = true) {
     organizationScope: () => 'frame',
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
+    // An admission reports its new digest immediately: the CP holds every projection that
+    // ADDRESSES this member until it sees the group held, so waiting for the next tick would
+    // leave an agent this member is already serving unroutable.
+    reportDutiesNow: vi.fn(() => {}),
     fetchDutyAgent
   }
   await (daemon as any).admitDutyGrants([grant()])
@@ -108,6 +112,10 @@ async function bootMidAdmission() {
     organizationScope: () => 'frame',
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
+    // An admission reports its new digest immediately: the CP holds every projection that
+    // ADDRESSES this member until it sees the group held, so waiting for the next tick would
+    // leave an agent this member is already serving unroutable.
+    reportDutiesNow: vi.fn(() => {}),
     fetchDutyAgent
   }
   const admitted = (daemon as any).admitDutyGrants([grant()]) as Promise<Set<string>>

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -120,6 +120,10 @@ async function boot(client: Record<string, unknown>) {
     organizationScope: () => 'frame',
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
+    // An admission reports its new digest immediately: the CP holds every projection that
+    // ADDRESSES this member until it sees the group held, so waiting for the next tick would
+    // leave an agent this member is already serving unroutable.
+    reportDutiesNow: vi.fn(() => {}),
     // The memory registry reports body-free probe facts as soon as a definition lands.
     emitMemoryConnectionFacts: vi.fn(() => {}),
     ...client

--- a/packages/daemon/test/daemon-duty-replacement.test.ts
+++ b/packages/daemon/test/daemon-duty-replacement.test.ts
@@ -94,6 +94,10 @@ async function boot(broken = new Set<string>()) {
     organizationScope: () => 'frame',
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
+    // An admission reports its new digest immediately: the CP holds every projection that
+    // ADDRESSES this member until it sees the group held, so waiting for the next tick would
+    // leave an agent this member is already serving unroutable.
+    reportDutiesNow: vi.fn(() => {}),
     fetchDutyAgent
   }
   await (daemon as any).admitDutyGrants([grant(GROUP, '1', [AGENT_A, AGENT_C])])

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -335,9 +335,9 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     return () => el.removeEventListener('scroll', sync)
   }, [])
 
-  // Cloud is one null-valued UI choice; the server still receives one serving pool member.
+  // Cloud is one UI choice AND one server-side placement: the pool, named as itself.
   const daemonChoice = addAgentDaemonChoice(daemons, daemonId)
-  const { cloudAvailable, daemon, localDaemons, placementDaemonId, value: effectiveDaemonId } = daemonChoice
+  const { cloudAvailable, daemon, localDaemons, placement, value: effectiveDaemonId } = daemonChoice
   const daemonOptions: DaemonSelectOption[] = [
     ...(cloudAvailable
       ? [
@@ -822,7 +822,11 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
         runtime: effectiveRuntime,
         ...(selectedModel ? { model: selectedModel } : {}),
         ...(description.trim() ? { description: description.trim() } : {}),
-        ...(placementDaemonId !== null ? { daemonId: placementDaemonId } : {}),
+        ...(placement?.kind === 'pool'
+          ? { placementKind: 'pool' as const }
+          : placement
+            ? { daemonId: placement.daemonId }
+            : {}),
         outputMode,
         showFooter,
         showStatusBar,

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -24,6 +24,7 @@ import {
   supportsModes,
   agentLabel,
   CLOUD_DAEMON_LABEL,
+  CLOUD_PLACEMENT,
   type Agent,
   type AgentCallPolicy,
   type ApprovalsReviewer
@@ -310,15 +311,16 @@ export default function EditAgentModal({
   const daemonChoices = editAgentDaemonChoices(daemons, daemonId, initialDaemonId.current)
   const cloudServing = daemons.some((candidate) => candidate.cloud && moveReady(candidate))
   const daemonOptions: DaemonSelectOption[] = [
-    ...(daemonChoices.cloudChoice
+    ...(daemonChoices.cloudChoice || agent.placementKind === 'pool'
       ? [
           {
-            value: daemonChoices.cloudChoice.daemonId,
+            // The POOL, named as itself. The server picks the member — and re-picks it after every
+            // rollout, which is the whole reason this stopped being a member id.
+            value: CLOUD_PLACEMENT,
             label: CLOUD_DAEMON_LABEL,
             detail: cloudServing ? 'Model usage included — no API key needed.' : 'Cloud is currently unavailable.',
             cloud: true,
-            disabled:
-              daemonChoices.cloudChoice.daemonId !== initialDaemonId.current && !moveReady(daemonChoices.cloudChoice)
+            disabled: initialDaemonId.current !== CLOUD_PLACEMENT && !cloudServing
           }
         ]
       : []),
@@ -569,7 +571,10 @@ export default function EditAgentModal({
         }
         await saveAgentCallPolicy(agent.id, body)
       }
-      if (placementRequested) await moveAgent(agent.id, daemonId, forceMove ? { force: true } : undefined)
+      if (placementRequested) {
+        const target = daemonId === CLOUD_PLACEMENT ? { kind: 'pool' as const } : { kind: 'daemon' as const, daemonId }
+        await moveAgent(agent.id, target, forceMove ? { force: true } : undefined)
+      }
       // Sharing uses canManageSharing and may intentionally remove this editor's
       // own visibility. Apply it only after every operation that still needs the
       // editor's authorization, including placement.

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -25,6 +25,7 @@ import {
   agentLabel,
   CLOUD_DAEMON_LABEL,
   CLOUD_PLACEMENT,
+  placementValueOf,
   type Agent,
   type AgentCallPolicy,
   type ApprovalsReviewer
@@ -185,8 +186,11 @@ export default function EditAgentModal({
         initialDisplayName.current = dto.displayName ?? ''
         setRuntime(dto.runtime ?? '')
         initialRuntime.current = dto.runtime ?? ''
-        setDaemonId(dto.daemonId ?? '')
-        initialDaemonId.current = dto.daemonId ?? ''
+        // Through the SAME mapping the list projection uses, so a pool agent reloads as the pool
+        // rather than as unplaced — `daemonId` is null for it by design.
+        const placement = placementValueOf(dto) ?? ''
+        setDaemonId(placement)
+        initialDaemonId.current = placement
         setModel(dto.model ?? '')
         initialModel.current = dto.model ?? ''
         setEffort(dto.reasoningEffort ?? '')

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.test.ts
@@ -14,7 +14,7 @@ const row = (daemonId: string, cloud = false, status: Row['status'] = 'online'):
 })
 
 describe('addAgentDaemonChoice', () => {
-  it('collapses frame-scoped members into one null-valued Cloud choice', () => {
+  it('collapses frame-scoped members into one Cloud choice that places on the POOL', () => {
     const choice = addAgentDaemonChoice(
       [row('cloud-stale', true, 'offline'), row('local-1'), row('cloud-serving', true)],
       ''
@@ -24,7 +24,8 @@ describe('addAgentDaemonChoice', () => {
     expect(choice.value).toBe('')
     expect(choice.daemonId).toBeNull()
     expect(choice.daemon?.daemonId).toBe('cloud-serving')
-    expect(choice.placementDaemonId).toBe('cloud-serving')
+    // The pool, not one of its members: a member id here is what a rollout invalidates.
+    expect(choice.placement).toEqual({ kind: 'pool' })
     expect(choice.localDaemons.map((daemon) => daemon.daemonId)).toEqual(['local-1'])
   })
 
@@ -34,7 +35,7 @@ describe('addAgentDaemonChoice', () => {
     expect(choice.value).toBe('local-1')
     expect(choice.daemonId).toBe('local-1')
     expect(choice.daemon?.daemonId).toBe('local-1')
-    expect(choice.placementDaemonId).toBe('local-1')
+    expect(choice.placement).toEqual({ kind: 'daemon', daemonId: 'local-1' })
   })
 
   it('requires and defaults to a local daemon when Cloud is unavailable', () => {
@@ -44,7 +45,7 @@ describe('addAgentDaemonChoice', () => {
     expect(choice.value).toBe('local-online')
     expect(choice.daemonId).toBe('local-online')
     expect(choice.daemon?.daemonId).toBe('local-online')
-    expect(choice.placementDaemonId).toBe('local-online')
+    expect(choice.placement).toEqual({ kind: 'daemon', daemonId: 'local-online' })
   })
 
   it('falls back to a local daemon when no Cloud member is serving', () => {
@@ -52,7 +53,7 @@ describe('addAgentDaemonChoice', () => {
 
     expect(choice.cloudAvailable).toBe(false)
     expect(choice.value).toBe('local-online')
-    expect(choice.placementDaemonId).toBe('local-online')
+    expect(choice.placement).toEqual({ kind: 'daemon', daemonId: 'local-online' })
   })
 
   it('has no valid choice when neither Cloud nor a local daemon exists', () => {
@@ -61,7 +62,7 @@ describe('addAgentDaemonChoice', () => {
       daemon: undefined,
       daemonId: null,
       localDaemons: [],
-      placementDaemonId: null,
+      placement: null,
       value: ''
     })
   })

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
@@ -7,7 +7,9 @@ export interface AddAgentDaemonChoice<T extends DaemonChoiceRow> {
   daemon: T | undefined
   daemonId: string | null
   localDaemons: T[]
-  placementDaemonId: string | null
+  /** What create submits. Cloud is the POOL, not one of its members: pinning a member id here is
+   *  what left an agent stranded on a Pod the next rollout replaced. */
+  placement: { kind: 'pool' } | { kind: 'daemon'; daemonId: string } | null
   value: string
 }
 
@@ -29,7 +31,13 @@ export function addAgentDaemonChoice<T extends DaemonChoiceRow>(
     daemon,
     daemonId: value || null,
     localDaemons,
-    placementDaemonId: daemon?.daemonId ?? null,
+    placement: value
+      ? daemon
+        ? { kind: 'daemon', daemonId: daemon.daemonId }
+        : null
+      : cloudDaemons.length > 0
+        ? { kind: 'pool' }
+        : null,
     value
   }
 }

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -258,7 +258,7 @@ describe('onboarding — configure the built-in agent', () => {
     await render()
     await click('Save and continue')
     expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude', model: 'claude-sonnet-4-5' })
-    expect(mocks.moveAgent).toHaveBeenCalledWith('ag_ac', 'dmn_new')
+    expect(mocks.moveAgent).toHaveBeenCalledWith('ag_ac', { kind: 'daemon', daemonId: 'dmn_new' })
     // Order matters: the CP rejects a move on a runtime-less agent.
     const updateOrder = mocks.updateAgent.mock.invocationCallOrder[0] ?? 0
     const moveOrder = mocks.moveAgent.mock.invocationCallOrder[0] ?? Infinity

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -106,7 +106,8 @@ export default function OnboardingView() {
     setSaveErr(null)
     try {
       await updateAgent(builtinAgent.id, { runtime, ...(model ? { model } : {}) })
-      await moveAgent(builtinAgent.id, placementDaemon.daemonId)
+      // Onboarding places onto a concrete machine; the cloud pool is chosen from the agent editor.
+      await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: placementDaemon.daemonId })
       await refresh()
     } catch (e) {
       setSaveErr(e instanceof Error ? e.message : String(e))

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -15,7 +15,7 @@ import type {
   SessionImage,
   Workspace
 } from '@/lib/data'
-import { CLOUD_DAEMON_LABEL, CLOUD_PLACEMENT, isSelfSender, lifecycleStatus, MOCK_MODE } from '@/lib/data'
+import { CLOUD_DAEMON_LABEL, isSelfSender, lifecycleStatus, MOCK_MODE, placementValueOf } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
 import {
@@ -1810,7 +1810,7 @@ export function agentFromDto(d: AgentDto): Agent {
     // that a rollout invalidates.
     placementKind: d.placementKind ?? 'daemon',
     placementReady: d.placementReady ?? false,
-    daemon: d.placementKind === 'pool' ? CLOUD_PLACEMENT : (d.daemonId ?? PLACEHOLDER),
+    daemon: placementValueOf(d) ?? PLACEHOLDER,
     region: PLACEHOLDER,
     repo: ws.mode === 'github' ? ws.repo : PLACEHOLDER,
     workdir: ws.mode === 'github' ? ws.agentDir : PLACEHOLDER,

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -15,7 +15,7 @@ import type {
   SessionImage,
   Workspace
 } from '@/lib/data'
-import { CLOUD_DAEMON_LABEL, isSelfSender, lifecycleStatus, MOCK_MODE } from '@/lib/data'
+import { CLOUD_DAEMON_LABEL, CLOUD_PLACEMENT, isSelfSender, lifecycleStatus, MOCK_MODE } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
 import {
@@ -313,6 +313,9 @@ export interface AgentDto {
   organizationVariables?: Array<{ key: string; value: string }>
   organizationSecretKeys?: string[]
   status: string
+  // Placement is a TARGET: `pool` names the install-wide member set and carries no id.
+  placementKind?: 'daemon' | 'pool'
+  placementReady?: boolean
   daemonId: string | null
   workspace: AgentWorkspaceDto
   workspaceRepoId?: string | null
@@ -1080,6 +1083,8 @@ export interface DaemonLifecycleOpDto {
 }
 
 export interface CreateAgentInput {
+  /** `pool` places the agent on the cloud member set and carries no member id. */
+  placementKind?: 'pool'
   name: string // slug — the CP rejects anything but ^[a-z0-9]+(-[a-z0-9]+)*$
   displayName?: string
   icon?: AgentIcon // absent ⇒ the CP assigns a random glyph+color
@@ -1800,7 +1805,12 @@ export function agentFromDto(d: AgentDto): Agent {
     // the pre-feature console did.
     organizationVariables: (d.organizationVariables ?? []).map((e) => ({ k: e.key, v: e.value })),
     organizationSecretKeys: d.organizationSecretKeys ?? [],
-    daemon: d.daemonId ?? PLACEHOLDER,
+    // A `pool` placement names no member, on purpose: whichever member holds the agent's duty
+    // serves it, so the row carries the KIND and a server-computed readiness instead of a Pod id
+    // that a rollout invalidates.
+    placementKind: d.placementKind ?? 'daemon',
+    placementReady: d.placementReady ?? false,
+    daemon: d.placementKind === 'pool' ? CLOUD_PLACEMENT : (d.daemonId ?? PLACEHOLDER),
     region: PLACEHOLDER,
     repo: ws.mode === 'github' ? ws.repo : PLACEHOLDER,
     workdir: ws.mode === 'github' ? ws.agentDir : PLACEHOLDER,
@@ -3414,17 +3424,24 @@ export async function setAgentWorkspace(agentId: string, input: SetAgentWorkspac
 // acknowledged source fence/cancel and destination activation; `force` is the
 // explicit recovery path when the source cannot ACK. This stays separate from
 // the ordinary spec PATCH because placement changes have runtime side effects.
-export async function moveAgent(agentId: string, daemonId: string, options: { force?: boolean } = {}): Promise<Agent> {
+/** A move target: one machine, or the cloud pool as a whole. */
+export type AgentPlacementTarget = { kind: 'daemon'; daemonId: string } | { kind: 'pool' }
+
+export async function moveAgent(
+  agentId: string,
+  target: AgentPlacementTarget,
+  options: { force?: boolean } = {}
+): Promise<Agent> {
   const moved = agentFromDto(
     await apiPut<AgentDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/daemon`, {
-      daemonId,
+      ...(target.kind === 'pool' ? { placementKind: 'pool' } : { daemonId: target.daemonId }),
       ...(options.force ? { force: true } : {})
     })
   )
   track('agent_moved', {
     org_id: apiOrgId,
     agent_id: moved.id,
-    to_daemon_id: daemonId,
+    to_daemon_id: target.kind === 'pool' ? 'pool' : target.daemonId,
     force: options.force === true
   })
   return moved

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -31,6 +31,7 @@ import {
   deleteAgent as apiDeleteAgent,
   updateAgent as apiUpdateAgent,
   moveAgent as apiMoveAgent,
+  type AgentPlacementTarget,
   createIntegration as apiCreateIntegration,
   finalizeSlackInstall as apiFinalizeSlackInstall,
   deleteIntegration as apiDeleteIntegration,
@@ -193,7 +194,7 @@ interface ConsoleData {
   /** Edit an agent's spec (PATCH), then re-pull. */
   updateAgent: (agentId: string, patch: UpdateAgentInput) => Promise<void>
   /** Hard-cut over or explicitly recover an agent, then refresh placement-derived views. */
-  moveAgent: (agentId: string, daemonId: string, options?: { force?: boolean }) => Promise<void>
+  moveAgent: (agentId: string, target: AgentPlacementTarget, options?: { force?: boolean }) => Promise<void>
   /** Install a Slack integration (POST /integrations), then re-pull. */
   createIntegration: (input: CreateIntegrationInput) => Promise<void>
   /** Finalize the config-token auto-install (§Tier B), then re-pull. Socket passes the
@@ -1069,8 +1070,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   // A placement move changes the agent row, both daemons' hosted-agent counts,
   // and where live session bodies resolve. Refresh all three projections.
   const moveAgent = useCallback(
-    async (agentId: string, daemonId: string, options?: { force?: boolean }) => {
-      await apiMoveAgent(agentId, daemonId, options)
+    async (agentId: string, target: AgentPlacementTarget, options?: { force?: boolean }) => {
+      await apiMoveAgent(agentId, target, options)
       settleInBackground(mutateAgents(), mutateDaemons(), revalidateSessionLists())
     },
     [mutateAgents, mutateDaemons, revalidateSessionLists]

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -59,6 +59,9 @@ export function presentedDaemonStatus(daemon: Pick<DaemonRow, 'status' | 'lifecy
  *  Pod they run in, which is churn nobody outside the cluster should read: the pool is one
  *  managed thing, so `daemonFromDto` labels each member with this instead. */
 export const CLOUD_DAEMON_LABEL = 'AgentConnect Cloud'
+/** `Agent.daemon` for a pool placement. It names the POOL, never a member: no member id survives
+ *  a rollout, which is precisely why the placement stopped carrying one. */
+export const CLOUD_PLACEMENT = 'cloud'
 
 /** The Cloud entry stands in for the whole pool: online while any member is serving. */
 export function cloudFleetStatus(members: Pick<DaemonRow, 'status'>[]): ConnectionStatusKey {
@@ -77,10 +80,14 @@ export function cloudFleetStatus(members: Pick<DaemonRow, 'status'>[]): Connecti
 // without writing the status (a bare FK SetNull, say) would otherwise paint a green
 // dot on an agent that cannot run.
 export function effectiveAgentStatus(
-  agent: Pick<Agent, 'status' | 'daemon'>,
+  agent: Pick<Agent, 'status' | 'daemon' | 'placementKind' | 'placementReady'>,
   owningDaemon: Pick<DaemonRow, 'status' | 'lifecycleStatus'> | undefined
 ): StatusKey {
   if (agent.status === 'online') {
+    // A pool placement names no member, so there is no owning daemon to consult: the CP already
+    // answered "could anything serve this now" and that answer is the whole story (#987 — asking
+    // a placed member's liveness is what kept a rolled-over agent permanently offline).
+    if (agent.placementKind === 'pool') return agent.placementReady ? agent.status : 'offline'
     if (agent.daemon === '—') return 'offline'
     if (owningDaemon !== undefined) {
       if (owningDaemon.lifecycleStatus) return owningDaemon.lifecycleStatus
@@ -94,8 +101,8 @@ export function effectiveAgentStatus(
 // ships the built-in `agentconnect` preset UNPLACED (daemon '—', deferred runtime '');
 // configuring it (onboarding's agent step) or creating a user agent flips this true. It
 // is the signal for "the org is set up" — used by the onboarding gate + getting-started.
-export function agentIsPlaced(agent: Pick<Agent, 'daemon' | 'runtime'>): boolean {
-  return agent.daemon !== '—' && agent.runtime !== ''
+export function agentIsPlaced(agent: Pick<Agent, 'daemon' | 'runtime' | 'placementKind'>): boolean {
+  return (agent.placementKind === 'pool' || agent.daemon !== '—') && agent.runtime !== ''
 }
 
 export type LaneKind = 'msg' | 'plan' | 'tool' | 'edit' | 'done'
@@ -311,6 +318,12 @@ export interface Agent {
   /** Names of organization-owned secrets assigned to this agent. Values are never
    *  returned for these either. */
   organizationSecretKeys: string[]
+  /** What the placement NAMES. `pool` carries `daemon: CLOUD_PLACEMENT` and no member id.
+   *  Absent (a mock row, an older CP) reads as `daemon`, which is the pre-pool behavior. */
+  placementKind?: 'daemon' | 'pool'
+  /** Server-computed: can a session start right now? For a pool placement that is "some member is
+   *  live", which is the question the console used to answer with a dead member's liveness. */
+  placementReady?: boolean
   daemon: string
   region: string
   /** Convenience mirror of the workspace for list views: github repo, else '—'. */

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -63,6 +63,17 @@ export const CLOUD_DAEMON_LABEL = 'AgentConnect Cloud'
  *  a rollout, which is precisely why the placement stopped carrying one. */
 export const CLOUD_PLACEMENT = 'cloud'
 
+/**
+ * The ONE mapping from a DTO's placement pair to the value the console selects on: the pool
+ * sentinel, a member id, or null when the agent is unplaced. Every reader of the raw DTO uses it —
+ * the list projection AND the editor's own reload — so a reload cannot disagree with the row it
+ * reloaded. Deriving "is this the pool?" from `daemonId` being null is what made a reloaded pool
+ * agent read as unplaced; `placementKind` is the only thing that says it.
+ */
+export function placementValueOf(dto: { placementKind?: 'daemon' | 'pool'; daemonId: string | null }): string | null {
+  return dto.placementKind === 'pool' ? CLOUD_PLACEMENT : (dto.daemonId ?? null)
+}
+
 /** The Cloud entry stands in for the whole pool: online while any member is serving. */
 export function cloudFleetStatus(members: Pick<DaemonRow, 'status'>[]): ConnectionStatusKey {
   return members.some((m) => m.status === 'online') ? 'online' : 'offline'

--- a/packages/web/src/lib/placement-value.test.ts
+++ b/packages/web/src/lib/placement-value.test.ts
@@ -1,0 +1,59 @@
+// The console's ONE mapping from a DTO's placement pair to the value it selects on.
+//
+// A pool placement carries `daemonId: null` by design — no member id survives a rollout — so
+// anything that derives "is this the pool?" from `daemonId` being non-null reads a pool agent as
+// unplaced. That is what made a reloaded agent lose its Cloud selection: the list projection went
+// through the mapping and the editor's own re-fetch did not.
+import { describe, it, expect } from 'vitest'
+import { CLOUD_PLACEMENT, effectiveAgentStatus, agentIsPlaced, placementValueOf } from '@/lib/data'
+import type { Agent, DaemonRow } from '@/lib/data'
+
+describe('placementValueOf', () => {
+  it('maps a pool placement to the pool sentinel, never to its null member id', () => {
+    expect(placementValueOf({ placementKind: 'pool', daemonId: null })).toBe(CLOUD_PLACEMENT)
+  })
+
+  it('ignores a stray member id under a pool kind — the KIND is what says pool', () => {
+    expect(placementValueOf({ placementKind: 'pool', daemonId: 'dmn_1' })).toBe(CLOUD_PLACEMENT)
+  })
+
+  it('maps a machine placement to its member id, and an unplaced agent to null', () => {
+    expect(placementValueOf({ placementKind: 'daemon', daemonId: 'dmn_1' })).toBe('dmn_1')
+    expect(placementValueOf({ placementKind: 'daemon', daemonId: null })).toBeNull()
+    // An older CP omits the field entirely; that has to keep meaning `daemon`.
+    expect(placementValueOf({ daemonId: 'dmn_1' })).toBe('dmn_1')
+  })
+})
+
+const poolAgent = (over: Partial<Agent> = {}): Pick<Agent, 'status' | 'daemon' | 'placementKind' | 'placementReady'> =>
+  ({
+    status: 'online',
+    daemon: CLOUD_PLACEMENT,
+    placementKind: 'pool',
+    placementReady: true,
+    ...over
+  }) as Pick<Agent, 'status' | 'daemon' | 'placementKind' | 'placementReady'>
+
+describe('a pool agent’s readiness is the server’s answer, not a member’s liveness', () => {
+  it('stays online while the pool is ready, with no owning daemon to consult', () => {
+    // #987: asking a placed member's liveness is what kept a rolled-over agent permanently
+    // offline — the member it named was gone by construction.
+    expect(effectiveAgentStatus(poolAgent(), undefined)).toBe('online')
+  })
+
+  it('reads offline when no member can serve it', () => {
+    expect(effectiveAgentStatus(poolAgent({ placementReady: false }), undefined)).toBe('offline')
+  })
+
+  it('does not consult an unrelated daemon row’s liveness', () => {
+    const dead = { status: 'offline', lifecycleStatus: undefined } as unknown as Pick<
+      DaemonRow,
+      'status' | 'lifecycleStatus'
+    >
+    expect(effectiveAgentStatus(poolAgent(), dead)).toBe('online')
+  })
+
+  it('counts as placed even though it names no machine', () => {
+    expect(agentIsPlaced({ daemon: CLOUD_PLACEMENT, runtime: 'claude', placementKind: 'pool' })).toBe(true)
+  })
+})


### PR DESCRIPTION
## What was observed

Enforcement is on in one environment. A pooled agent's member was replaced by a rollout, its lease lapsed 120s later, and its duty group became a claimable vacancy in the ledger — **the exact state the mechanism exists for. Nothing claimed it.** Three live members, zero grants, indefinitely.

The grant policy was `incumbent`: `claimVacant` only claimed a vacancy whose agents' `agent.daemonId` equalled the claimant. After a rollout that id names a Pod that no longer exists, so no live member qualified. Healing therefore waited for a *trigger* to arrive (the activation rendezvous) — and for webchat the trigger could not even be sent, because the console decides "offline" from that same dead member id (#987). The reaper eventually unplaced the agent, which under `incumbent` made it permanently offline, since nothing re-places an unplaced agent.

## Why `incumbent` was scaffolding, and why it could not just be deleted

It came from #942, built when a grant to a member that had not installed the agent would have meant nothing. Every reason for it is gone: a granted member installs what it lacks (#972), updates and the reconnect roster follow the holder (#978), a refused replacement shrinks rather than keeps departed members (#977), the self-fence bounds a partitioned ex-holder (#976), and every agent has a group (#983).

But it was also, accidentally, the **only** thing keeping pool members off the agents local daemons serve. After #983 every agent has a duty group; in a real org most of those groups are vacancies for agents on org-scoped daemons. Delete the gate and the members claim all of them, `duty/fetch` them, and serve agents a local daemon is already serving — duplicate service, the precise failure the ledger exists to prevent.

So the ledger needed a real notion of *which agents belong to the pool*. It had none: `agent.daemonId` named either a member Pod or a local machine, and nothing distinguished "placed on a machine" from "belongs to the pool, and whichever member holds it serves it".

## Placement becomes a target

`Agent.placementKind ∈ {daemon, pool}`, additive and defaulted to `daemon`, plus the existing `daemonId` as the **ref for `daemon` only**. A `pool` placement carries `daemonId = null`: no member id is durable, and leaving a stale one there is the dead-Pod pointer this replaces.

The migration is behaviour-preserving by construction. Every existing row — including today's pool agents, which are pinned to a member — stays `daemon`-kind, and for a `daemon`-kind agent the new predicate reduces to *exactly* the old incumbent rule. The `any`-style behaviour applies only to agents actually moved onto the pool.

**One resolver, two halves.** `domain/placement.ts` answers eligibility from the row alone; `orchestrator/placementResolver.ts` adds the live leases and answers "which daemons serve this agent right now". Every reader goes through them — `claimVacant`'s gate, `claimAgentHome`'s gate, the sweep's placement fence, `AgentDelivery.daemonsFor`, the reconnect roster, the peer directory, hook compilation, relay ingress routing, webchat readiness and dispatch, and the daemon-originated authority fences. Nothing outside those two modules branches on the string `pool`, so adding a `group` kind later is one arm here and one join in the ledger's predicate.

**Eligibility is one SQL predicate, shared.** A member may claim a group iff it may hold **every** agent in it. Stated as "no ineligible agent" rather than "some eligible agent" on purpose: a group merging a pool agent with a machine-placed one must be claimable by *neither*, or the winner serves what the other side already serves. `claimVacant`, `claimAgentHome` and the fence all build from the same fragment, so a lease can never be taken under one rule and kept under another.

## What happened to the pieces

**`grantPolicy` / `incumbentOnly` are deleted**, not widened to `any` — a policy enum with one member is a lie about there being a choice. `DUTY_LEASE_DEFAULTS` loses the field; `DutyRecomputeConfig.incumbentFence` goes with it.

**`vacateNonIncumbent` is re-derived, not removed** — it is `vacateIneligible` now, and it runs unconditionally rather than behind a soak flag. It is not meaningless: `renewHeld` renews by holder alone, so a lease whose holder stopped being eligible (an agent moved off the pool onto a machine, or between machines) would otherwise be renewed forever and keep that member serving. It is the only place that notices. It also drops two special cases the old fence needed — an unplaced agent's group is now unclaimable at the source, so there is no minted lease to churn; and a *partial* move-away now vacates, because under the old EXISTS rule the holder kept serving an agent that had moved elsewhere.

**The move validators.** `PUT /agents/:id/daemon` takes `{ placementKind: 'pool' }` or `{ daemonId }` (omitted kind ⇒ `daemon`, so an existing client is unchanged). For a pool target the checks — move feature, organization knowledge, `configRevision`, runtime, model catalog, MCP transport, capacity — are evaluated against the **union of live install-wide members**: the target is admissible when *some* live member could serve this agent, and that member's sandbox policy is what the response reports. Members are one Deployment of one image, so union and intersection differ only mid-rollout, and there the ledger's install-on-grant refusal is the backstop that stops a member holding what it cannot install. Capacity stays per-member, which is the same condition the ledger's own headroom gate applies. No live member ⇒ 409.

Moving *onto* the pool commits the placement and stops: there is no daemon to activate, and naming one would pre-empt a choice that is not the control plane's to make — the ledger grants the group and install-on-grant does the rest. Moving *off* the pool quiesces every member currently **holding** the agent, not the one placement names, because placement names none.

**The reaper.** `retireCloudMember` selects `agent.daemonId = <member>`, so a pool agent is never in its worklist and `settleCascadedUnplacement` additionally refuses anything that is not `daemon`-kind. Unplacing a pool agent would set it `inactive` and strand it exactly the way the reaper stranded agents before — nothing re-places an unplaced agent. Covered by a test.

**Contention and churn.** `FOR UPDATE SKIP LOCKED` already prevents double-claims and distribution is first-come; that is accepted. Two things are now tested. A member at capacity does not claim (headroom gate unchanged). And a group one member cannot install is bounded: #976's failure stamp is *per-agent, per-member* — it paces one member's fetches, it does not move the group, and because a refused grant is invisible on the wire (the member simply never reports it) while `renewHeld` renews by holder alone, the group sat on the one member that could not serve it for as long as it kept beating. The CP now counts consecutive beats in which a held group is absent from the digest — above one, because an install legitimately straddles a beat — then hands the lease back and puts that group in a per-member backoff so the next claim reaches a different member. Reporting the group at any point clears the count; that is convergence, not refusal.

**#987.** The readiness half fell out of the resolver and is included: `AgentDto` gains `placementKind` + a server-computed `placementReady`, and webchat verification asks the resolver instead of a placed member's liveness. The delivery half is largely moot now — the sweep re-grants proactively, so the vacancy window is one lease horizon rather than forever — but the dispatch path also falls back to any live member for a pool agent whose lease has momentarily lapsed, which the member claims on receipt through the rendezvous that already exists.

## Tests

| Test | File | Mutation that breaks it |
|---|---|---|
| re-grants a lapsed holder's group to a live member with **no trigger** | `test/protocol/duty-lease.handler.test.ts` | restore the incumbent gate — a pool agent has no `daemonId`, so no member qualifies |
| **no pool member ever claims an agent placed on a local daemon** (claim *and* rendezvous) | `test/repo/duty-recompute.test.ts` | drop the `install-wide`/`pool` arm, or make the gate EXISTS |
| a mixed pool + machine group is claimable by neither | `test/repo/duty-recompute.test.ts` | change `noIneligibleAgent` from FORALL to EXISTS |
| a machine-placed agent's group is claimable only by that machine | `test/repo/duty-recompute.test.ts` | make the `daemon` arm ignore `daemonId` |
| a full member does not claim, however healable the vacancy | `test/protocol/duty-lease.handler.test.ts` | drop the headroom budget |
| refused-install rotation is bounded; the lease is handed back and not re-offered | `test/protocol/duty-lease.handler.test.ts` | remove `settleRefusals`, or the `excludeGroupIds` backoff |
| reporting the group clears the refusal count | `test/protocol/duty-lease.handler.test.ts` | count total absences instead of consecutive ones |
| the fence vacates a lease whose holder stopped being eligible | `test/repo/duty-recompute.test.ts` | delete `vacateIneligible` from the sweep |
| an unplaced agent is claimable by nobody, rendezvous included | `test/repo/duty-recompute.test.ts` | treat `daemonId IS NULL` as permissive |
| move onto the pool: kind `pool`, no member id, **no** synchronous activation | `test/integration/agents.move.route.test.ts` | keep activating a chosen member |
| move off the pool quiesces the **holder**, not the placement | `test/integration/agents.move.route.test.ts` | resolve sources from `agent.daemonId` |
| a pool target with no ready member is refused | `test/integration/agents.move.route.test.ts` | drop the empty-candidate check |
| the reaper does **not** unplace a pool agent | `test/repo/daemon-cluster-identity.repo.test.ts` | remove the kind check in `settleCascadedUnplacement` |
| the backoff list excludes named groups without disturbing the rest | `test/repo/duty-recompute.test.ts` | ignore `excludeGroupIds` |

Everything #948/#972/#976/#977/#978/#983 established still holds and their suites are unchanged, except two whose premise the new rule deliberately supersedes — both rewritten with the reasoning inline: an unplaced agent's minted lease (now unclaimable at the source, so there is nothing to fence) and partial-occupancy retention (now vacates, because keeping it meant serving an agent that had moved away).

## Deliberately not in this change

Named so they are not mistaken for oversights. These read `agent.daemonId` directly and therefore treat a `pool`-placed agent as unplaced; no existing agent is affected, because no existing row is `pool`-kind:

- `#979`'s territory, untouched by agreement: external-memory and MCP proxy definitions (`pushExternalMemoryToDaemon`, `mcp-push.ts#daemonsEnabling`, `memory-connections.ts`).
- `github/review-broker.service.ts`, `webchatMcpAuthority.ts`, `child-session-status.ts`, `organization-knowledge.ts` and `visibilityPush.ts` — the same `mayAct` substitution as the fences that *are* converted here, in files that would have doubled this diff.
- `features.dutyEnforcement` stays (that is #982). Daemon groups are not built.

Refs #955, #987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Rebased onto #989 + #990, and four review findings folded in

### Reconciliation with #989: two axes, one predicate

#989 landed `orchestrator/servedAgents.ts` (member→agents) while this branch added `orchestrator/placementResolver.ts` (agent→members). They are **inverse queries over the same two relations**, and neither is expressible as the other without scanning the opposite side — so both stay, and what keeps them from drifting is that each half now reads one predicate from its own side:

| Half | member→agents (`servedAgents`) | agent→members (`PlacementResolver`) |
|---|---|---|
| placement | `listForDaemon` — `placementKind:'daemon'` **+** `daemonId` | `placementTargets` (`domain/placement.ts`) |
| duty | `heldAgentIds(holder, now)` | `holdersOf(agentId, now)` |

`AgentRepo.listForDaemon` gained the `placementKind: 'daemon'` term. Before it, the two agreed only **by accident of the encoding** — a pool row happens to store a null ref, so `where: { daemonId }` excluded it without ever consulting the kind. The next placement kind that stores a ref would have been placed on one side and unplaced on the other. `test/repo/served-agents.repo.test.ts` pins the biconditional `D ∈ servingDaemons(A) ⟺ A ∈ servedAgents(D)` over a fixture mixing machine / pool-held / pool-vacant / unplaced, and its second case seeds (via raw SQL) the row the accident does not cover — a ref under a non-`daemon` kind — so removing the kind term now fails.

One real bug fell out of the same read: `CollabRoutesService.build` derived an **org-less member's orgs** from `listForDaemon`, which for a pool member is empty. Its orgs are the orgs of the agents it *serves*, so it goes through `servedAgents` now — otherwise a pool agent's whole org drops out of the relay's full-replace collaboration table.

`daemonsForAgents` (#989) and `getServingAgent` (this branch) agree by construction: both bottom out in `PlacementResolver.servingDaemons`, and `servingDaemon` is literally its first element.

### Finding 1 — holder changes now invalidate the routing projections

**This was the important one: "the sweep re-granted it" was not yet "it heals."** Three projections bake in the serving daemon rather than resolving it per use — compiled hook rules, the HTTP bot's `rc/bot-assign` table, and the collaboration snapshot. A *placement* move has always re-converged them; a *duty* change never did. So healing installed the agent on the new member while ingress kept arriving at the dead one.

**Kick site: `orchestrator/agentRouting.ts`.** `convergeAgentRouting` is now the single definition of that fan-out — `AgentMoveService.convergeDerived` calls it instead of owning its own copy, so a placement move and a holder change converge through the same list. `AgentRoutingConverger` is the duty side's coalescing, fire-and-forget entry point, invoked from the two services that actually mutate holdership (a holder changes on the heartbeat exchange *and* in the sweep, so it cannot honestly be one call site): `DutyLeaseService` on a fresh grant, a rendezvous grant, a refusal surrender and a drain release; `DutyRecomputeSweep` when the fence vacates.

The load-bearing test asserts the projection, not the seam: A holds a pooled agent with a webhook hook, A's lease lapses, B beats and is granted — and **the compiled rule the relay would dispatch on now names B**, with no reconnect and no trigger. Its mirror asserts the rule is *withdrawn* when the lease goes back and nothing serves the agent.

`visibilityPush` was on the deferred list and is fixed too — it resolved targets per call but read raw `agent.daemonId`, so a held pool agent read as unplaced and a pending cutover was reported vacuously applied.

Deliberately still out: thread affinity and `SessionMeta.daemonId`. A placement move does not invalidate those either — it is a real, pre-existing question, and answering it for the duty path alone would make the two disagree.

### Finding 2 — create with `placementKind: 'pool'`

The POST handler never forwarded it, so the console's Cloud choice landed as an inactive unplaced `daemon` placement. It now validates against the live member set exactly like the move route's pool target (409 when no member is ready, rather than silently landing unplaced) and forwards the kind to the repo. Round-tripped through the route.

### Finding 3 — `daemon(member) → pool`

The sequence, stated: **detach, CAS, then re-activate the source with the same move token.**

This is the one transition where a detached source must *not* stay fenced. The member remains install-wide, so the ledger may hand it back the very group it was staged out of — and `installGrantedAgents` skips a move-staged agent, so it would take the lease, install nothing and serve nothing, with no other member able to claim it: servable by nobody, worse than where it started. Releasing the fence with the token that armed it also leaves its replica current, so if the ledger grants it back, install-on-grant sees the agent at the granted revision and skips the fetch entirely.

The asymmetry is precise and tested both ways: eligibility is the resolver's answer, not a kind test, so a **local** daemon losing an agent to the pool stays fenced — it is never an eligible holder, and clearing its fence would invite the split brain a hard cutover exists to prevent.

### Finding 4 — editor reload

`placementValueOf(dto)` in `lib/data.ts` is now the one mapping from `(placementKind, daemonId)` to the value the console selects on; the list projection and the editor's own re-fetch both go through it. The editor is not special-cased — it was the *second* reader that had derived "pool" from `daemonId` being non-null, which is exactly the derivation a pool placement breaks.

### Mutation table delta

| Test | File | Mutation that breaks it |
|---|---|---|
| the compiled hook rule re-addresses at the new holder, no reconnect | `test/protocol/duty-lease.handler.test.ts` | drop `routing?.kick(...)` from the exchange's grant branch |
| the rule is withdrawn when the lease is handed back | `test/protocol/duty-lease.handler.test.ts` | drop the kick from the refusal-surrender branch |
| `D ∈ servingDaemons(A) ⟺ A ∈ servedAgents(D)` | `test/repo/served-agents.repo.test.ts` | widen either half's predicate |
| the placement half is keyed on the KIND, not on the ref being non-null | `test/repo/served-agents.repo.test.ts` | drop `placementKind:'daemon'` from `listForDaemon` |
| create ON the pool round-trips through the route | `test/integration/agents.move.route.test.ts` | stop forwarding `placementKind` to the repo |
| a pool create with no ready member is refused, not landed unplaced | `test/integration/agents.move.route.test.ts` | drop the empty-member check |
| `daemon(member) → pool` clears the source's staging fence | `test/integration/agents.move.route.test.ts` | remove `unstageEligibleSources` |
| a LOCAL source stays fenced on the same conversion | `test/integration/agents.move.route.test.ts` | unstage every source instead of the eligible ones |
| the pool sentinel survives a DTO reload | `packages/web/src/lib/placement-value.test.ts` | derive pool from `daemonId` instead of `placementKind` |

Each was run against its mutation and observed to fail.


---

## Round 3 — a grant is not a route until the digest confirms it

Accepted: the fresh holder was published at **grant** time, before the member had received and admitted it. Same shape as #976 — the gate opening before the fact — now on a pushed projection, where relay ingress recovers through the rendezvous and a cross-daemon peer wake does not.

### What `rd/agentmsg` does today on "no holder"

Checked before changing anything, because the suggested fix depended on it. **There is no retryable outcome to reuse — every "no holder" path is terminal**, and the caller usually never even reaches the wire:

- The wake is refused **locally** first: `localWakeDecision` → `cpCollab.admits()` fails closed for an agent missing from the flat directory → **`not_allowed`**, terminal, no frame sent.
- If it does reach the relay, an agent absent from the collab snapshot gets **`not_found`** — terminal, *and* cached by `deliveryId` at three layers (relay `seen`, target daemon `relayAgentMsgAcks`, caller-side map).
- `offline` exists as the semantically-retryable slot but nothing acts on it.

So the reviewer's "reuse what an unplaced peer does" does not hold: **an unplaced peer is terminal too.** I have corrected the comment I had written claiming otherwise.

That changes the justification for the gate rather than the gate itself. During the install window both behaviours lose the message, but they lose it differently:

| | publish at grant (before) | gate on digest (now) |
|---|---|---|
| caller | sends; B answers `not_found` | refused locally, `not_allowed` |
| dedup | **poisoned** — that `deliveryId` replays `not_found` forever, even after B is ready | untouched |
| next attempt | dead | succeeds as soon as B confirms |

That is the concrete content of "publishing a stale holder is worse than publishing none": **absence refuses the attempt; a wrong holder poisons the retry.**

### Was the digest gate alone enough?

**No — it needed the daemon-side beat.** The daemon only beats on its timer (15s default); there was no beat after a duty admission. So the gate on its own turned "misrouted for the install duration" into "unroutable for the install duration **plus up to a full heartbeat**", which is worse for an agent that is already running.

`CpClient.reportDutiesNow()` reports the new digest immediately once an admission settles — debounced to one extra beat per admission (an admission routinely settles several groups), dormant off a frame-mode connection, and called from `settleDutyChange` **outside** the enforcement gate, because the CP acts on the digest whether or not the member is enforcing. The window is now the install duration plus one RTT.

### Why gating the trigger was not sufficient

The snapshot is rebuilt from live ledger state on **any** convergence, so an unrelated kick — an integration edit, another agent's holder change, a relay reconnect replay — would have published the installing member regardless of when I fired the routing kick. The **content** had to be gated, not the kick. Hence `duty_group.confirmedAt` rather than a scheduling change.

### The representation

`confirmedAt` = when the **current** holder first reported the group in its heartbeat digest. Not a new signal: #972 applies a grant only after its install succeeds, so the digest is already the proof the fence and CP renewal ride. Reset exactly when `holder` changes; preserved on renewal and on an in-place re-grant, because blanking a working route over an *added* member loses messages in the other direction. The migration backfills `confirmedAt = updatedAt` for currently-held rows so the deploy does not manufacture a heartbeat-long outage.

The resolver now answers two questions:

- `servingDaemons` — unchanged: who receives this agent's updates and may act for it. A member must receive its bundle to become confirmed at all, so delivery and `duty/fetch` deliberately do **not** wait.
- `routableDaemons` — the confirmed subset, read by everything that **addresses** ingress: the peer directory, compiled hook rules, the relay bot table, webchat dispatch.

### Residual, stated plainly

A peer wake during the install window is still refused (`not_allowed`) rather than retried. Closing that needs a retryable verdict on `rd/agentmsg` — either the documented `not_holder` rendezvous or an optional-`daemonId` directory entry with a retryable outcome. The latter is a **wire-compat hazard**: `CollabOrgAgent.daemonId` is required today, the snapshot is full-replace, and an older relay that rejects the frame wipes its routing table. That is its own change, as the reviewer suspected. What this PR does remove is the misroute and the poisoned dedup — and relative to `incumbent`, where the agent was never re-granted at all, A2A goes from permanently dead to unavailable for the install duration.

### Mutation delta

| Test | Mutation | Result |
|---|---|---|
| the peer directory does not name the new holder until it reports the group | `resolveDirectory` uses `servingDaemon` instead of `routableDaemon` | fails |
| the hook rule is published on confirmation, not on the grant | kick from the grant branch instead of the confirmation branch | fails |
| confirmation is first-write-wins (stamp does not move on later beats) | — | pinned |
| a re-grant to a **different** member drops confirmation; renewal keeps it | — | pinned |

The round-2 test that asserted publication *at grant time* had its premise superseded and now asserts publication after the digest.

Gates on the rebased tree: `pnpm build`, `typecheck`, `lint`, `format:check` clean; CP unit 1636, **CP int 1263/1263** (`rewrap` passed this run), protocol 331, web 1540, daemon only the known `shim-*` / `workspace-git-runner-seam` baselines.

**Migration ordering** — checked, not a typo. The folder ordinals in this repo are hand-sequenced and deliberately run ahead of wall clock: `20260819000000_duty_group_ledger` was authored 2026-08-14 and `20260815000000_daemon_cluster_identity` on 2026-08-12. Main's max is `20260819000000`; this PR's two follow it. Renaming to today's date would sort this `ALTER TABLE "duty_group"` *before* the migration that creates that table, which is the ordering bug the question was about.
