### PR TITLE
fix(duty): scope the routing confirmation to the grant it proves

### DIFF
--- a/packages/control-plane/prisma/migrations/20260822000000_duty_confirmation_term_scoped/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260822000000_duty_confirmation_term_scoped/migration.sql
@@ -1,0 +1,21 @@
+-- Scope the duty confirmation to the grant it actually proves.
+--
+-- `confirmedAt` was a bare timestamp: it recorded THAT a holder had reported the group, never
+-- WHICH hold it reported. Any later state that merely looked the same inherited it — a lapsed
+-- lease re-taken by the same member, an in-place composition rewrite that added agents, or a
+-- digest still carrying the previous term. `term` is already the fencing token: every grant path
+-- bumps it and renewal never does, so (holder, term) names the exact grant.
+ALTER TABLE "duty_group" ADD COLUMN "confirmedTerm" BIGINT;
+ALTER TABLE "duty_group" ADD COLUMN "confirmedHolder" UUID;
+
+-- Carry the currently-true confirmations across rather than manufacturing a heartbeat-long gap in
+-- ingress routing at deploy time: a row that is held AND was confirmed is being served right now,
+-- and its current (holder, term) is what that confirmation was about.
+UPDATE "duty_group"
+SET "confirmedTerm" = "term", "confirmedHolder" = "holder"
+WHERE "holder" IS NOT NULL AND "confirmedAt" IS NOT NULL;
+
+-- The predicate is now a same-row comparison, which no index can serve; the read is driven by
+-- `duty_group_member`'s primary key into `duty_group`'s.
+DROP INDEX "duty_group_confirmedAt_idx";
+ALTER TABLE "duty_group" DROP COLUMN "confirmedAt";

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2888,12 +2888,16 @@ model DutyGroup {
   holder    String?   @db.Uuid // member (daemon) the group is granted to; null ⇒ never claimed or released
   term      BigInt    @default(0) // monotonic per group; bumped on EVERY grant/re-grant — the fencing token
   expiresAt DateTime? @db.Timestamptz(6) // renewal horizon written by the granter; past ⇒ vacant and grantable
-  // When the CURRENT holder first reported this group in its heartbeat digest — the earliest
-  // moment it is provably serving, because #972 applies a grant only after the install succeeded.
-  // Null while a grant is outstanding; reset whenever `holder` changes. Ingress addressing waits
-  // for it; delivery and `duty/fetch` deliberately do not (a member must receive its bundle to
-  // become confirmed at all).
-  confirmedAt DateTime? @db.Timestamptz(6)
+  // WHICH hold the member has reported in its heartbeat digest — a grant is applied daemon-side
+  // only after its install succeeded (#972), so the digest is the proof it is serving. Scoped to
+  // the exact grant it proves: confirmed ⟺ `confirmedTerm = term AND confirmedHolder = holder`.
+  // A bare timestamp could not say WHAT it confirmed, so a re-take, a composition rewrite, or a
+  // stale-term digest inherited a confirmation none of them earned. Every grant path bumps `term`
+  // and renewal never does (#939), which is exactly the identity this needs. Ingress addressing
+  // waits for it; delivery and `duty/fetch` deliberately do not (a member must receive its bundle
+  // to become confirmed at all).
+  confirmedTerm   BigInt?
+  confirmedHolder String? @db.Uuid
   createdAt DateTime  @default(now()) @db.Timestamptz(6)
   updatedAt DateTime  @updatedAt @db.Timestamptz(6)
 
@@ -2903,7 +2907,6 @@ model DutyGroup {
   @@index([orgId])
   @@index([holder])
   @@index([expiresAt])
-  @@index([confirmedAt])
   @@map("duty_group")
 }
 

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -271,9 +271,16 @@ export class DutyLeaseService {
     // projection it costs a message: relay ingress recovers through the rendezvous, but a
     // cross-daemon peer wake forwards ONCE and takes a terminal miss.
     //
-    // `confirmHeld` only stamps unconfirmed rows, so this fires on the first beat that reports a
-    // group and never again — no per-beat churn.
-    const confirmed = await this.repo.confirmHeld(daemonId, [...digestIds], now)
+    // The digest's TERMS ride along, not just its ids: a member mid-admission of a re-grant still
+    // reports the previous term, and that confirms the previous grant, never the current one. Same
+    // rule the stale-term branch below applies — confirm the terms or supersede, never both.
+    //
+    // `confirmHeld` only stamps rows whose (holder, term) is not already recorded, so this fires on
+    // the first beat that reports a given grant and never again — no per-beat churn.
+    const confirmed = await this.repo.confirmHeld(
+      daemonId,
+      duties.held.map((d) => ({ groupId: d.groupId, term: BigInt(d.term) }))
+    )
     if (confirmed.length > 0) {
       const groups = held.filter((g) => confirmed.includes(g.groupId))
       this.routing?.kick(agentIdsOf(groups))

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4993,6 +4993,12 @@ export interface OrgInviteLinkRepo {
 
 // DutyGroupRepo (k8s daemons) — the CP-hosted duty ledger
 
+/** One entry of a member's heartbeat duty digest: the group, at the term it believes it holds. */
+export interface DutyDigestEntry {
+  groupId: string
+  term: bigint
+}
+
 /** A ledger row plus its derived membership projection. */
 export interface DutyGroupRecord {
   groupId: string
@@ -5093,11 +5099,14 @@ export interface DutyGroupRepo {
    *  agent? The authorization for `duty/fetch`: a member may pull exactly the
    *  agent definitions it has won, and nothing else. */
   holdsAgent(holder: DaemonId, agentId: AgentId, now: Date): Promise<boolean>
-  /** Stamp `confirmedAt` on the groups this holder reports in its heartbeat digest, returning the
-   *  ones that became confirmed on THIS beat. A grant is applied daemon-side only after its
-   *  install succeeds (#972), so the digest IS the proof that the member is serving — the same
-   *  signal the self-fence and CP renewal already ride, not a new one. */
-  confirmHeld(holder: DaemonId, groupIds: readonly string[], now: Date): Promise<string[]>
+  /** Record the holds this member reports in its heartbeat digest, returning the ones that became
+   *  confirmed on THIS beat. A grant is applied daemon-side only after its install succeeds
+   *  (#972), so the digest IS the proof that the member is serving — the same signal the
+   *  self-fence and CP renewal already ride, not a new one.
+   *
+   *  Scoped to the exact grant: an entry only confirms while its `term` still matches the row's,
+   *  so a beat that crossed a re-grant confirms nothing. */
+  confirmHeld(holder: DaemonId, reported: readonly DutyDigestEntry[]): Promise<string[]>
   /** {@link DutyGroupRepo.holdersOf} restricted to CONFIRMED holds — who INGRESS may be addressed
    *  at. A holder that is still installing is a live lease and not yet a route. */
   confirmedHoldersOf(agentId: AgentId, now: Date): Promise<DaemonId[]>

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -4,7 +4,14 @@
 // does. Vacancy is temporal: `holder IS NULL` or a lapsed `expiresAt`.
 import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
 import type { DutyMemberKey, DutyReconcilePlan, DutyEdge, AgentSeed } from '../../domain/duty.js'
-import type { AgentHomeClaim, DutyGrantRecord, DutyGroupRecord, DutyGroupRepo, DutyReconcilePlanner } from '../ports.js'
+import type {
+  AgentHomeClaim,
+  DutyDigestEntry,
+  DutyGrantRecord,
+  DutyGroupRecord,
+  DutyGroupRepo,
+  DutyReconcilePlanner
+} from '../ports.js'
 import type { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import type { DutyClaimScope } from '../../domain/placement.js'
 import { withTx } from '../prisma.js'
@@ -138,7 +145,8 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     // nothing may serve an unplaced agent, and leaving the lease standing would keep one member
     // serving what the operator detached.
     const rows = await this.prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
-      UPDATE "duty_group" g SET "holder" = NULL, "expiresAt" = NULL, "confirmedAt" = NULL
+      UPDATE "duty_group" g SET "holder" = NULL, "expiresAt" = NULL,
+        "confirmedTerm" = NULL, "confirmedHolder" = NULL
       FROM "daemon" d
       WHERE g."orgId" = ${orgId} AND g."holder" IS NOT NULL AND d.id = g."holder"
         AND NOT ${noIneligibleAgent(Prisma.sql`g.id`, Prisma.sql`g."holder"`, Prisma.sql`d."orgId" IS NULL`)}
@@ -226,9 +234,10 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
         if (w.regrantTo !== null)
           await tx.dutyGroup.update({
             where: { id: w.groupId },
-            // `regrantTo` is the group's existing holder (the planner only re-grants in place), so
-            // its confirmation stands: it is still serving every member both compositions share,
-            // and dropping it would blank a working route over an ADDED member.
+            // A composition rewrite re-grants IN PLACE at a bumped term, and that bump IS the
+            // invalidation: the member has admitted the old composition, not this one, so it must
+            // re-report before ingress is addressed at it again. No separate clear — introducing a
+            // second reason for the confirmation to move would be a second thing to keep in sync.
             data: { holder: w.regrantTo, term: { increment: 1 }, expiresAt }
           })
       }
@@ -240,10 +249,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
             orgId,
             holder: c.grantTo,
             term: c.grantTo !== null ? 1n : 0n,
-            expiresAt: c.grantTo !== null ? expiresAt : null,
-            // A created row with a holder is a SPLIT inheriting its sole contributor's holder —
-            // the same member, already serving these members under the row this one came from.
-            confirmedAt: c.grantTo !== null ? opts.now : null
+            expiresAt: c.grantTo !== null ? expiresAt : null
           }
         })
         await tx.dutyGroupMember.createMany({
@@ -298,11 +304,12 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
           LIMIT ${max}
           FOR UPDATE SKIP LOCKED
         )
+        -- The confirmation columns are deliberately untouched: this bumps the term, and a
+        -- confirmation only counts while it matches (holder, term), so the grant is unconfirmed by
+        -- construction. That includes the SAME member re-taking its own lapsed lease — it may have
+        -- fenced and dropped the group in between and be re-installing right now.
         UPDATE "duty_group" g
-        SET "holder" = ${holder}::uuid, "term" = g."term" + 1, "expiresAt" = ${expiresAt}, "updatedAt" = ${now},
-            -- The grant is not yet a fact: the member has not installed it. Preserved when the
-            -- claimant is the same member re-taking its own lapsed lease — its replica is intact.
-            "confirmedAt" = CASE WHEN g."holder" IS DISTINCT FROM ${holder}::uuid THEN NULL ELSE g."confirmedAt" END
+        SET "holder" = ${holder}::uuid, "term" = g."term" + 1, "expiresAt" = ${expiresAt}, "updatedAt" = ${now}
         FROM picked WHERE g.id = picked.id
         RETURNING g.id, g."orgId", g."holder", g."term", g."expiresAt"
       `)
@@ -337,7 +344,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     // Vacate immediately but keep `term` — monotonicity is the whole token.
     await this.prisma.dutyGroup.updateMany({
       where: { holder, id: { in: groupIds } },
-      data: { holder: null, expiresAt: null, confirmedAt: null }
+      data: { holder: null, expiresAt: null, confirmedTerm: null, confirmedHolder: null }
     })
   }
 
@@ -354,31 +361,45 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     return rows.length > 0
   }
 
-  async confirmHeld(holder: DaemonId, groupIds: readonly string[], now: Date): Promise<string[]> {
-    if (groupIds.length === 0) return []
-    // Idempotent and first-write-wins: only an unconfirmed row is stamped, so the returned set is
-    // exactly the groups whose hold became a fact on THIS beat — which is what the routing
-    // convergence is keyed on. Holder-conditional, so a digest naming a group the ledger has since
-    // moved confirms nothing.
+  async confirmHeld(holder: DaemonId, reported: readonly DutyDigestEntry[]): Promise<string[]> {
+    if (reported.length === 0) return []
+    // The digest confirms THIS grant, not the group in general: the reported term has to match the
+    // row's current one. That is the same rule the lease exchange already applies to renewal —
+    // confirm the terms or supersede, never both — so a member still reporting the previous term
+    // (mid-admission of a re-grant, or a beat that crossed one) confirms nothing.
+    //
+    // Idempotent and first-write-wins: an already-matching row is excluded, so the returned set is
+    // exactly the grants that became facts on THIS beat, which is what the routing convergence is
+    // keyed on. Holder-conditional too, so a digest naming a group the ledger has since moved
+    // confirms nothing either.
+    const values = Prisma.join(
+      reported.map((entry) => Prisma.sql`(${entry.groupId}::uuid, ${entry.term}::bigint)`),
+      ','
+    )
     const rows = await this.prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
-      UPDATE "duty_group" SET "confirmedAt" = ${now}
-      WHERE "holder" = ${holder}::uuid AND "confirmedAt" IS NULL
-        AND id = ANY(${groupIds as string[]}::uuid[])
-      RETURNING id
+      UPDATE "duty_group" g
+      SET "confirmedTerm" = g."term", "confirmedHolder" = g."holder"
+      FROM (VALUES ${values}) AS reported(id, term)
+      WHERE g.id = reported.id AND g."term" = reported.term
+        AND g."holder" = ${holder}::uuid
+        AND (g."confirmedTerm" IS DISTINCT FROM g."term" OR g."confirmedHolder" IS DISTINCT FROM g."holder")
+      RETURNING g.id
     `)
     return rows.map((r) => r.id).sort()
   }
 
   async confirmedHoldersOf(agentId: AgentId, now: Date): Promise<DaemonId[]> {
-    // `holdersOf` with the confirmation term: the same live-lease join, restricted to holders that
-    // have reported the group. INGRESS addressing uses this one — naming a member that is still
-    // installing turns a routable message into a terminal miss.
+    // `holdersOf` with the confirmation term: the same live-lease join, restricted to holders whose
+    // reported hold is the one the row currently describes. INGRESS addressing uses this — naming a
+    // member that is still installing turns a routable message into a terminal miss, and matching
+    // on (holder, term) rather than on "a confirmation exists" is what stops a re-take, a
+    // composition rewrite or a stale-term digest from inheriting one it never earned.
     const rows = await this.prisma.$queryRaw<{ holder: string }[]>(Prisma.sql`
       SELECT DISTINCT g."holder" AS holder FROM "duty_group_member" m
       JOIN "duty_group" g ON g.id = m."groupId"
       WHERE m."kind" = 'agent' AND m."refId" = ${agentId}
         AND g."holder" IS NOT NULL AND g."expiresAt" IS NOT NULL AND g."expiresAt" > ${now}
-        AND g."confirmedAt" IS NOT NULL
+        AND g."confirmedTerm" = g."term" AND g."confirmedHolder" = g."holder"
     `)
     return rows.map((r) => r.holder as DaemonId).sort()
   }
@@ -457,13 +478,9 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
             id: row.id,
             OR: [{ holder: null }, { expiresAt: null }, { expiresAt: { lt: now } }]
           },
-          // Same rule as `claimVacant`: a new holder has not proved it serves the group yet.
-          data: {
-            holder,
-            term: { increment: 1 },
-            expiresAt,
-            ...(row.holder === holder ? {} : { confirmedAt: null })
-          }
+          // Same rule as `claimVacant`: the term bump leaves the grant unconfirmed by construction,
+          // including when the claimant is the member that just lost this lease.
+          data: { holder, term: { increment: 1 }, expiresAt }
         })
         if (won.count === 1) {
           const granted = await tx.dutyGroup.findUniqueOrThrow({ where: { id: row.id } })

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -1050,6 +1050,14 @@ describe('a grant is not a route until the digest confirms it (protocol level, r
     })
   }
 
+  /** The confirmation rule itself: a hold counts only while it is the hold the row describes.
+   *  Asserting on `(confirmedTerm, confirmedHolder)` rather than on "a confirmation exists" is the
+   *  whole point — a bare marker could not tell a re-take or a rewrite from the grant it proved. */
+  async function isConfirmed(groupId: string): Promise<boolean> {
+    const row = await prisma.dutyGroup.findUniqueOrThrow({ where: { id: groupId } })
+    return row.confirmedTerm === row.term && row.confirmedHolder === row.holder
+  }
+
   /** The flat peer directory as the relay and every daemon receive it — what an A2A wake resolves
    *  through, and what `admits()` fails closed against. */
   async function directoryDaemonFor(h: ReturnType<typeof buildWsHarness>, agentId: string): Promise<string | null> {
@@ -1077,12 +1085,12 @@ describe('a grant is not a route until the digest confirms it (protocol level, r
     expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).holder).toBe(DAEMON)
 
     // ...and the directory still names nobody: a lease is not yet a route.
-    expect(await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).toMatchObject({ confirmedAt: null })
+    expect(await isConfirmed(GROUP)).toBe(false)
     expect(await directoryDaemonFor(h, AGENT)).toBeNull()
 
     // Beat 2 carries the group in the digest — the member installed and opened its gate.
     await beat(stub, { held: [{ groupId: GROUP, term: '5' }], headroom: 4 })
-    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).confirmedAt).not.toBeNull()
+    expect(await isConfirmed(GROUP)).toBe(true)
     expect(await directoryDaemonFor(h, AGENT)).toBe(DAEMON)
   })
 
@@ -1117,7 +1125,7 @@ describe('a grant is not a route until the digest confirms it (protocol level, r
     await vi.waitFor(() => expect(h.hookAssigns.some((rule) => rule.daemonId === DAEMON)).toBe(true))
   })
 
-  it('confirms once, not on every beat — the stamp is first-write-wins', async () => {
+  it('confirms one grant once — a repeat beat re-converges nothing', async () => {
     const h = buildWsHarness(prisma)
     const startAt = new Date(h.clock.now())
     await seedPooledAgent()
@@ -1125,32 +1133,130 @@ describe('a grant is not a route until the digest confirms it (protocol level, r
     const { stub } = await ready(h)
 
     await beat(stub, { held: [{ groupId: GROUP, term: '1' }], headroom: 0 })
-    const first = (await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).confirmedAt
-    expect(first).not.toBeNull()
+    expect(await isConfirmed(GROUP)).toBe(true)
+    const row = await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })
+    expect(row.confirmedTerm).toBe(1n)
 
+    // A steady-state member reports the same hold on every beat forever; re-stamping it would
+    // re-push every projection that names it, once per heartbeat, for the life of the lease.
     h.clock.advance(5_000)
     await beat(stub, { held: [{ groupId: GROUP, term: '1' }], headroom: 0 })
-    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).confirmedAt).toEqual(first)
+    expect(await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).toMatchObject({
+      confirmedTerm: 1n,
+      confirmedHolder: DAEMON
+    })
   })
 
-  it('a re-grant to a DIFFERENT member drops the confirmation; renewal keeps it', async () => {
-    // The reset rule, both ways. A composition change re-grants IN PLACE and must not blank a
-    // working route; a claim by another member must.
+  it('a claim by a DIFFERENT member drops the confirmation', async () => {
     const h = buildWsHarness(prisma)
     const startAt = new Date(h.clock.now())
     await seedPooledAgent()
     await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(startAt.getTime() + LEASE_MS) })
     const { stub } = await ready(h)
     await beat(stub, { held: [{ groupId: GROUP, term: '1' }], headroom: 0 })
-    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).confirmedAt).not.toBeNull()
+    expect(await isConfirmed(GROUP)).toBe(true)
 
     // Lapse it, then let a different member take it.
     await prisma.dutyGroup.update({ where: { id: GROUP }, data: { expiresAt: new Date(h.clock.now() - 1) } })
     const repo = new PgDutyGroupRepo(prisma)
     await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS, { scope: 'install-wide' })
 
-    const row = await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })
-    expect(row.holder).toBe(OTHER)
-    expect(row.confirmedAt).toBeNull()
+    expect(await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).toMatchObject({ holder: OTHER })
+    expect(await isConfirmed(GROUP)).toBe(false)
+  })
+
+  // ── the three ways a bare marker was inherited by state that never earned it ──
+
+  it('a lapsed lease re-taken by the SAME member is unconfirmed until the new term is reported', async () => {
+    // The member is the one that held it, so a holder-keyed marker survived — but a lapse is
+    // exactly what the daemon self-fence acts on (#976): it may have dropped the group and be
+    // re-installing right now. The term bump is what makes that visible.
+    const h = buildWsHarness(prisma)
+    const startAt = new Date(h.clock.now())
+    await seedPooledAgent()
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(startAt.getTime() + LEASE_MS) })
+    const { stub } = await ready(h)
+    await beat(stub, { held: [{ groupId: GROUP, term: '1' }], headroom: 0 })
+    expect(await isConfirmed(GROUP)).toBe(true)
+    expect(await directoryDaemonFor(h, AGENT)).toBe(DAEMON)
+
+    // Lapse, then the SAME member re-takes it.
+    await prisma.dutyGroup.update({ where: { id: GROUP }, data: { expiresAt: new Date(h.clock.now() - 1) } })
+    const repo = new PgDutyGroupRepo(prisma)
+    const [regrant] = await repo.claimVacant(DaemonId(DAEMON), 1, new Date(h.clock.now()), LEASE_MS, {
+      scope: 'install-wide'
+    })
+    expect(regrant?.term).toBe(2n)
+    expect(await isConfirmed(GROUP)).toBe(false)
+    expect(await directoryDaemonFor(h, AGENT)).toBeNull()
+
+    // Reporting the NEW term re-arms it, which is what the daemon does after re-admitting.
+    await beat(stub, { held: [{ groupId: GROUP, term: '2' }], headroom: 0 })
+    expect(await isConfirmed(GROUP)).toBe(true)
+    expect(await directoryDaemonFor(h, AGENT)).toBe(DAEMON)
+  })
+
+  it('an in-place composition rewrite drops the confirmation until the member re-admits it', async () => {
+    // The rewrite re-grants IN PLACE at a bumped term (#977/#983 already do this), so the bump IS
+    // the invalidation — no second rule. The member has admitted the OLD composition; the agents
+    // this rewrite ADDS are ones it has never installed, and addressing ingress at it for them is
+    // the same terminal miss.
+    const h = buildWsHarness(prisma)
+    const startAt = new Date(h.clock.now())
+    await seedPooledAgent()
+    await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(startAt.getTime() + LEASE_MS) })
+    const { stub } = await ready(h)
+    await beat(stub, { held: [{ groupId: GROUP, term: '1' }], headroom: 0 })
+    expect(await isConfirmed(GROUP)).toBe(true)
+
+    // Rewrite the group in place, adding a member — the shape a new shared bot produces.
+    const repo = new PgDutyGroupRepo(prisma)
+    await repo.applyReconcile(
+      OrgId(DEFAULT_ORG_ID),
+      () => ({
+        unchanged: [],
+        writes: [
+          {
+            groupId: GROUP,
+            members: [
+              { kind: 'agent' as const, refId: AGENT },
+              { kind: 'agent' as const, refId: AGENT2 }
+            ],
+            regrantTo: DAEMON
+          }
+        ],
+        creates: [],
+        deletes: [],
+        superseded: []
+      }),
+      { now: new Date(h.clock.now()), leaseMs: LEASE_MS }
+    )
+
+    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).term).toBe(2n)
+    expect(await isConfirmed(GROUP)).toBe(false)
+    expect(await directoryDaemonFor(h, AGENT)).toBeNull()
+
+    await beat(stub, { held: [{ groupId: GROUP, term: '2' }], headroom: 0 })
+    expect(await isConfirmed(GROUP)).toBe(true)
+  })
+
+  it('a digest still carrying the OLD term does not confirm the current one', async () => {
+    // A beat that crossed a re-grant reports what the member believed a moment ago. The exchange
+    // already refuses to treat that as a renewal ("confirm the terms or supersede, never both");
+    // confirmation has to apply the same rule or the crossing beat confirms an install that has
+    // not happened.
+    const h = buildWsHarness(prisma)
+    const startAt = new Date(h.clock.now())
+    await seedPooledAgent()
+    await seedGroup({ holder: DAEMON, term: 5n, expiresAt: new Date(startAt.getTime() + LEASE_MS) })
+    const { stub } = await ready(h)
+
+    await beat(stub, { held: [{ groupId: GROUP, term: '4' }], headroom: 0 })
+    expect(await isConfirmed(GROUP)).toBe(false)
+    expect(await directoryDaemonFor(h, AGENT)).toBeNull()
+
+    await beat(stub, { held: [{ groupId: GROUP, term: '5' }], headroom: 0 })
+    expect(await isConfirmed(GROUP)).toBe(true)
+    expect(await directoryDaemonFor(h, AGENT)).toBe(DAEMON)
   })
 })


### PR DESCRIPTION
Follow-up to #991, closing the three findings from its round-3 review. They were one defect: **`confirmedAt` was a bare timestamp that did not know what it confirmed.**

#991 made ingress addressing wait for the holder to report the group in its heartbeat digest — the earliest moment the member is provably serving, since a grant is applied daemon-side only after its install succeeds (#972). But it recorded that as a timestamp, so any later state that *looked* the same inherited a confirmation it never earned. Each case reopens the terminal A2A miss the gate exists to close:

| | what happened | why the marker survived |
|---|---|---|
| 1 | a lapsed lease re-taken by the **same** member | holder unchanged, so a holder-keyed reset did not fire — even though a lapse is exactly what the daemon self-fence acts on (#976): it may have dropped the group and be re-installing |
| 2 | an in-place composition rewrite (#977's shrink, or a replacement adding agents) | the group kept its marker, so **newly added** agents inherited a confirmation the member never gave for them |
| 3 | a digest still carrying the **old** term | `confirmHeld` matched on group id alone |

## The key

`(confirmedHolder, confirmedTerm)`, and **confirmed** means `confirmedTerm = term AND confirmedHolder = holder`.

`term` is already the fencing token — every grant path bumps it and renewal never does (#939) — so it is exactly the identity this needed. Two of the three fall out with no new rule:

- **(1)** a re-take bumps the term, so the old confirmation no longer matches. The same-member case is now indistinguishable from the different-member one, which is the point.
- **(3)** `confirmHeld` carries the digest's terms and matches them against the row's current one. That is the rule the exchange already applies to renewal — *confirm the terms or supersede, never both* — so a beat that crossed a re-grant confirms the grant it actually saw, which is no longer current.

I kept `confirmedHolder` alongside the term even though the term alone is sufficient today (terms are per-group monotonic, so a `(groupId, term)` pair belongs to exactly one grant). It costs one column and makes the predicate a direct statement of the rule rather than something that depends on a monotonicity argument holding forever.

## Composition rewrites: invalidated, not cleared

**Invalidated by the existing term bump.** `applyReconcile`'s in-place re-grant already does `term: { increment: 1 }` (#977/#983), so the composition change is *already* a new grant and the confirmation stops matching on its own. No separate clear — per the review, introducing a second reason for the confirmation to move would be a second thing to keep in sync.

Two related corrections in the same file:

- **A split's created row is no longer pre-confirmed.** #991 stamped `confirmedAt` on `plan.creates` with a `grantTo`, reasoning that the inheriting member was already serving those agents under the old row. It is — but it has never reported *this* group id, and the CP revokes the old id as `gone` and re-grants the new one, so the member has an admission to do. Pre-confirming it was the same defect in miniature. It re-confirms on the beat after it admits, accelerated by `reportDutiesNow()`.
- **`claimVacant` and `claimAgentHome` no longer hand-clear anything.** Both bump the term, so the grant is unconfirmed by construction; the explicit `CASE`/conditional they carried existed only to express the holder-change rule the term now expresses better.

`reportDutiesNow()` (from #991's round 3) still lines up: after admitting a re-grant the member's digest carries the **new** term, so confirmation re-arms on the immediate beat rather than waiting out the interval.

## Migration

`20260822000000_duty_confirmation_term_scoped` adds the two columns, backfills `confirmedTerm = term, confirmedHolder = holder` for rows that are **held and were confirmed**, then drops `confirmedAt` and its index. The backfill is the same reasoning #991's was: those rows are being served right now, so carrying the confirmation across avoids manufacturing a heartbeat-long gap in ingress routing at deploy time. The index goes because the predicate is now a same-row comparison no index can serve; the read is driven by `duty_group_member`'s primary key into `duty_group`'s.

## Tests — one per finding, each mutation-checked

| Test | Mutation | Result |
|---|---|---|
| a lapsed lease re-taken by the **same** member is unconfirmed until the new term is reported | confirmed ⟺ `confirmedTerm IS NOT NULL` (back to a bare marker) | **fails** |
| an in-place composition rewrite drops confirmation until the member re-admits | same bare-marker mutation | **fails** |
| a digest carrying the **old** term does not confirm the current one | drop `AND g."term" = reported.term` from `confirmHeld` | **fails** |

Each asserts the *observable* as well as the row: `directoryDaemonFor()` — the flat peer directory an A2A wake resolves through — names nobody while unconfirmed and the member once it re-confirms.

The existing #991 tests still pass, including "not before the digest". Two were updated rather than replaced: they asserted on `confirmedAt` and now assert the rule through a shared `isConfirmed()` helper, and "confirms once" now states its real purpose — a steady-state member reports the same hold on every beat, and re-stamping would re-push every projection naming it once per heartbeat for the life of the lease.

## Gates

`typecheck`, `lint`, `format:check` clean. CP unit 1636, **CP int 1265/1266** — the one failure is `rewrap.test.ts`, the known load flake, which passes on its own. Protocol 331, web 1540, daemon only the known `shim-*` / `workspace-git-runner-seam` baselines.

## Scope

Ledger and its tests only. The residual #991 documents is unchanged and still open: a peer wake landing inside the install window is refused rather than retried, because `rd/agentmsg` has no retryable verdict — closing that needs the `not_holder` rendezvous or an optional-`daemonId` directory entry, and the latter is a wire-compat hazard on a required field of a full-replace snapshot. This PR narrows *which* states fall into that window; it does not change the window's behaviour.

Refs #991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
