### PR TITLE
fix(web): let the edit modal place an agent on the pool

### DIFF
--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -522,8 +522,14 @@ export default function EditAgentModal({
         setErr(`Confirm that ${sourceDaemon?.name ?? 'the source daemon'} is permanently stopped.`)
         return
       }
-      if (!daemon || !moveReady(daemon)) {
-        setErr('Choose an online daemon that supports agent moves.')
+      // The pool is a target, not a member: ready when any live member could serve.
+      const targetReady = daemonId === CLOUD_PLACEMENT ? cloudServing : moveReady(daemon)
+      if (!targetReady) {
+        setErr(
+          daemonId === CLOUD_PLACEMENT
+            ? 'Cloud has no online member right now; try again shortly.'
+            : 'Choose an online daemon that supports agent moves.'
+        )
         return
       }
       // Placement is where a deferred runtime becomes mandatory (§3.2). Ahead of
@@ -535,14 +541,18 @@ export default function EditAgentModal({
         return
       }
       if (runtimeUnavailable) {
-        setErr(`${daemon.name} does not advertise the ${runtimeLabel(runtime, runtimeMeta?.name)} runtime.`)
+        setErr(
+          `${daemon?.name ?? CLOUD_DAEMON_LABEL} does not advertise the ${runtimeLabel(runtime, runtimeMeta?.name)} runtime.`
+        )
         return
       }
       if (modelUnavailable) {
         // Reachable only when the target DOES advertise models (see
         // `modelUnavailable`), so the picker always has a real id to point at —
         // never a synthesized "Default" the runtime does not offer.
-        setErr(`${daemon.name} does not advertise model “${selectedModel}”. Choose one of its models.`)
+        setErr(
+          `${daemon?.name ?? CLOUD_DAEMON_LABEL} does not advertise model “${selectedModel}”. Choose one of its models.`
+        )
         return
       }
     }


### PR DESCRIPTION
Choosing "Cloud" as the placement in the edit modal failed every time with
"Choose an online daemon that supports agent moves." The submit path already
maps the pool sentinel to `{ kind: 'pool' }`, but the readiness guard that runs
before it resolves the target with `daemons.find(d => d.daemonId === daemonId)`
— and the sentinel is not a daemon, so the lookup is always empty and the guard
always fires. The pool became unreachable from the one place a user would pick
it.

The pool is a target, not a member: it is ready when any live member could
serve, which is exactly what `cloudServing` (already computed for the option's
own enabled state) says. The guard now asks that for the sentinel and keeps the
per-daemon check for a concrete target. The two later messages that named
`daemon.name` fall back to the pool label; a pool target never reaches them
(their conditions derive from the selected daemon's advertised runtimes and
models, empty for the sentinel), and the control plane validates a pool target
against the union of live members.

Follow-up to #991, which made placement a target on the server and in the submit mapping but left this guard member-keyed. Found by trying to move an agent onto the pool from the console.