### PR TITLE
docs(designs): daemon groups — the tenancy axis for org-scoped member sets

### DIFF
--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -1,0 +1,177 @@
+# Daemon groups
+
+**Status:** design. Not built. Sequenced after the k8s pool runs enforced end to end,
+which it now does ([k8s-daemon-pool.md](k8s-daemon-pool.md) §14 records the pool as the
+degenerate case of what this document generalizes).
+
+A _daemon group_ is a named set of daemons within which an agent's duty may be claimed.
+The k8s pool is one such group — implicit, install-wide, its members every frame-mode Pod
+of the install. This document makes the concept explicit and org-scoped so that
+self-hosted installs can form groups out of ordinary local daemons: point an agent at a
+group instead of a machine, and the same ledger, lease exchange, install-on-grant,
+self-fence, and holder-following delivery distribute it within the group. For local
+daemons this is the cross-machine generalization of the singleton pid lock — today two
+local daemons configured with the same bot token fight over the platform API; a group
+makes multi-machine failover safe for the first time.
+
+Almost everything here is "reuse X". The one genuinely new thing is the **tenancy axis**
+(§3), and it is the reason this is a design document rather than a PR description.
+
+## 1. What is already in place
+
+Every mechanism a group needs landed for the pool and is holder-shaped, not
+member-shaped — none of it knows or cares whether the holder is a Pod or a laptop.
+
+| Need                                                                               | Landed as                                                                                                                                                            |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A duty moving between machines needs the agent's durable state reachable on both   | Shared Postgres data plane (#958). For local groups this is the one operational prerequisite: the members must share a Postgres, and workspaces must be re-cloneable |
+| No two members serve one agent across a partition                                  | Daemon self-fence with per-group deadlines anchored on CP-confirmed renewal, plus the general withdrawal guard (#976)                                                |
+| A member that wins a duty for an agent it never had can serve it                   | Install-on-grant: `duty/fetch` pulls the bundle, authorized by holding the duty; the grant is applied only after the install (#972, #989)                            |
+| Every later update reaches whoever holds the agent, not whoever it was placed on   | `AgentDelivery` + `servedAgents` (#978); MCP/memory definitions ride the bundle and the roster (#989)                                                                |
+| Every agent has a group to be claimed under                                        | Components derived per agent, crons subsumed (#983)                                                                                                                  |
+| Placement is a target, not a member; eligibility is one predicate                  | `placementKind ∈ {daemon, pool}` and `domain/placement.ts#dutyEligibility` / `mayHold`, mirrored row-wise in the ledger's SQL (#991)                                 |
+| Ingress routes to a member only once it has admitted the grant                     | Routing-projection confirmation on `(holder, term)` (#991, #992)                                                                                                     |
+| Healing is proactive: the sweep re-grants a lapsed holder's groups with no trigger | `incumbent` deleted (#991); verified on a real rollout                                                                                                               |
+
+`domain/placement.ts` was written with this document in mind. Its contract: _nothing
+outside this module may branch on the placement kind; a later `group` kind adds one arm
+here and one join in the ledger's predicate, and the callers do not learn about it._ §4
+holds it to that.
+
+## 2. Model
+
+- **`daemon_group`** — `(id, orgId, name)`. Org-scoped: a group belongs to exactly one
+  organization and can only contain that organization's daemons. There is no cross-org
+  group; the install-wide pool is _not_ a row in this table (§3 explains why).
+- **`daemon_group_member`** — `(groupId, daemonId)`, one daemon in at most one group.
+  A daemon joins by an operator action in the console (or the CLI); membership is
+  control-plane metadata, never negotiated on the wire.
+- **`Agent.placementKind`** gains `group`, with `placementRef` naming the group id.
+  `daemon` and `pool` are unchanged. A `group` agent has no `daemonId`, exactly like a
+  `pool` agent.
+
+That is the whole schema. The duty ledger (`duty_group`, `duty_group_member`) is
+untouched: a duty group is the _thing claimed_, a daemon group is the _set that may claim
+it_ — the two share a word and nothing else, and the ledger's rows already exist for
+every agent regardless of how it is placed.
+
+## 3. The tenancy axis — the only new thing
+
+Today the ledger admits exactly one kind of claimant: an **install-wide** (frame-mode,
+org-less) connection. Every org-scoped connection has its `duties` dropped at the
+heartbeat handler, and the three duty request handlers (`duty/claim`, `duty/fetch`,
+`duty/release`) answer `SCOPE_DENIED` to it. That door is a deliberate tenancy fence: an
+org-scoped connection must never be able to claim, fetch, or release another
+organization's work.
+
+A local group's members are org-scoped connections. So the door has to open — but it
+opens **narrower**, never wider. The rule from the pool design stands verbatim: _the
+tenancy gate widens, never disappears._ Concretely:
+
+- An install-wide claimant may hold a `pool` agent's duty. Unchanged.
+- A `daemon`-placed agent's duty may be held by exactly that daemon. Unchanged.
+- A `group`-placed agent's duty may be held by a claimant that is **(a) an org-scoped
+  connection of the agent's own organization and (b) a member of that group**. Both
+  conditions, always. An install-wide member is _not_ eligible for a group agent — the
+  pool does not absorb groups — and an org-scoped daemon is never eligible for a `pool`
+  agent.
+
+So `claimScopeOf(daemon)` stops being a two-valued predicate:
+
+```
+install-wide            — orgId IS NULL                       (the pool)
+group(orgId, groupId)   — orgId = X, member of group G in X   (a local group)
+none                    — orgId = X, in no group              (today's single-org daemon)
+```
+
+and `mayHold(agent, claimant)` gains one arm: `agent.placementKind = 'group'` requires
+`claimant.scope = group` with the same `orgId` and the same `groupId`. The SQL mirror
+(`eligibleAgent` / `noIneligibleAgent` in the ledger repo) gains the matching join to
+`daemon_group_member`. Nothing else in the claim path changes: `claimVacant`,
+`claimAgentHome`, `holdsAgent`, `vacateIneligible` all already read the predicate rather
+than the connection kind.
+
+**Why the pool is not a group row.** The install-wide pool has no `orgId`; its members
+are org-less by construction and serve every organization. A row for it would either
+need a nullable `orgId` (and then every group query has to special-case null) or a
+synthetic install org (a fiction). Keeping `pool` as its own placement kind, and letting
+`group` mean "org-scoped set", is the honest encoding — and it is what keeps the tenancy
+rule statable in one sentence.
+
+**What the three handlers do.** The `conn.orgId !== null ⇒ SCOPE_DENIED` line in
+`duty-claim.ts`, `duty-fetch.ts` and `duty-release.ts` becomes "resolve this
+connection's claim scope; `none` ⇒ `SCOPE_DENIED`". The heartbeat handler forwards
+`duties` for any connection whose scope is not `none`. The predicate then does the
+narrowing per agent, inside the transaction, exactly as it does today for the pool. An
+org-scoped connection that is in a group and sends a `duty/claim` for an agent in another
+org, or in another group, or placed on a specific machine, gets `granted: false` from the
+same code path a pool member gets it for a `daemon`-placed agent.
+
+**What the daemon does.** `dutyEnforced()` today reduces to `organizationScope() ===
+'frame'` (after #982). It becomes "this connection has a claim scope other than `none`",
+learned from `auth/ok` — the CP tells the daemon at handshake whether it is a pool member
+or a group member, alongside the lease horizon it already announces (#976). A daemon in
+no group behaves exactly as today: no `duties` on the heartbeat, no enforcement, serves
+what it is placed with. This is also the last step of #982's argument: the enforcement
+predicate becomes "participates in a member set", which is what the design always
+said membership should be.
+
+## 4. What does not change
+
+Stated so nobody rebuilds it: install-on-grant, the self-fence, the withdrawal guard,
+holder-following delivery, MCP/memory bundle projection, routing-projection
+confirmation, proactive re-grant, the drain release, the placement fence — every one of
+these is keyed on _the holder_ and already runs for pool members. A group member is a
+holder. The two things that read placement kind (`dutyEligibility` and the SQL mirror)
+each gain one arm; the readers of those two do not change.
+
+The console's placement selector already lists targets, not machines (#959, #961,
+#991). A group is one more entry per group the viewer's org has.
+
+## 5. Operational prerequisites for a local group
+
+These are the operator's, not the code's:
+
+- **Shared Postgres.** Group members must point at one data-plane Postgres, the same
+  way pool members do. A duty that moves to a member whose store does not have the
+  agent's history is not a move, it is a loss.
+- **Re-cloneable workspaces.** A GitHub-mode workspace re-materializes on the new holder
+  from its repo; a scratch workspace does not follow. This is already true for the pool
+  and is documented there; a group inherits the same constraint and the same guidance
+  (commit or discard before relying on failover).
+- **A member's platform credentials.** Bots are org-scoped and ride the bundle, so a
+  group member gets them on install; nothing per-machine is needed.
+
+## 6. Sequencing and size
+
+One PR, small, after #982 lands (it and this both edit `dutyEnforced()`):
+
+1. Schema: `daemon_group`, `daemon_group_member`, `placementKind` gains `group`.
+2. `domain/placement.ts`: the third claim scope and the one new `mayHold` arm; the SQL
+   mirror gains its join.
+3. The three duty handlers and the heartbeat handler: `SCOPE_DENIED` becomes "scope is
+   `none`".
+4. `auth/ok` announces the connection's claim scope; the daemon's enforcement predicate
+   reads it.
+5. Console: group CRUD (org settings), membership on the daemon detail, one more
+   placement entry.
+
+Load-bearing tests, all mutation-checked: an org-scoped member of group G in org X
+claims a `group`-placed agent of X in G; the same member is refused a `group` agent of X
+in another group, any agent of another org, any `pool` agent, and any `daemon`-placed
+agent; an install-wide member is refused any `group` agent; and the pool's existing
+"never claims a local-daemon agent" test still holds. Then the same rollout test the
+pool passed: stop one member of a local group, and its agents re-grant to another
+member with no message sent.
+
+## 7. Rejected
+
+- **A group row for the pool** (§3) — forces a nullable or fictional org onto every
+  group query.
+- **A daemon in several groups.** Nothing needs it, and it turns "which group's
+  eligibility applies" into a policy question. Add if a real case appears.
+- **Cross-org groups.** They would be a second tenancy model. The pool already covers
+  "one member set serving many orgs", with the org-less identity that makes it safe.
+- **Negotiating membership on the wire** (a daemon announcing which group it is in).
+  Membership is an operator decision recorded in the control plane; the daemon is told,
+  it does not tell.

--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -167,7 +167,12 @@ member with no message sent.
 ## 7. Rejected
 
 - **A group row for the pool** (§3) — forces a nullable or fictional org onto every
-  group query.
+  group query. The pool _is_ a member set conceptually, and the two kinds already share
+  the claim predicate, the enforcement predicate, and every holder-keyed mechanism —
+  what is unified is the reading, not the row. If several install-wide pools ever exist
+  (say, per runtime tier), that is its own org-less table beside `daemon_group`, still
+  not a row in it; with one pool today, that table would be an interface guessed from a
+  single implementer.
 - **A daemon in several groups.** Nothing needs it, and it turns "which group's
   eligibility applies" into a policy question. Add if a real case appears.
 - **Cross-org groups.** They would be a second tenancy model. The pool already covers

--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -187,10 +187,15 @@ its next beat it claims those groups back and re-activates them (it is a member 
 still has the replicas installed, so install-on-grant is a refresh, not a fetch). The
 operator sees one action; underneath it is the move convention applied N times inside
 one fence. If the machine is unreachable, the same rule as the move applies:
-enrollment uses the move's existing force-reassign semantics — the operator confirms
-the source is permanently stopped, and the agents become set-placed without the
-detach — and successors claim them after the source's lease/self-fence horizon, not
-before. The converse is enforced statically: a `daemon` placement may not name a
+enrollment uses the move's existing force-reassign contract — the operator explicitly
+confirms the source is permanently stopped, and on that confirmation the agents become
+set-placed without the detach and are claimable immediately. There is nothing else to
+wait for: a directly placed machine is outside the ledger, so it holds no lease and
+runs no self-fence — the operator's assertion _is_ the safety boundary, exactly as it
+is for a forced machine-to-machine move today. (The lease/self-fence horizon governs
+the _removal_ path above, where the leaver was a set member and does hold leases; the
+two paths have different boundaries because the source is in the ledger in one and not
+in the other.) The converse is enforced statically: a `daemon` placement may not name a
 machine that is in a set (the console does not offer it; the route refuses it).
 
 Leaving a set does not move agents by itself: they stay `set`-placed and re-grant to

--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -147,41 +147,57 @@ gets `granted: false` from the same code path a pool member gets it for a
 lease horizon it already announces (#976).
 
 **Membership changes on a live daemon.** Org-set membership is operator-mutable while
-the daemon is connected, so `auth/ok` cannot be the only time it learns its set. Two
-rules:
+the daemon is connected, so `auth/ok` cannot be the only time it learns its set. The
+order of operations is the one the pool drain and the product's agent move already
+follow, and for the same reason: **stop the old runtime authority and confirm it stopped,
+then commit the new placement — never the reverse.** A transition that publishes a
+claimable lease before the old holder has acknowledged it stopped serving lets a
+successor win the duty while the old platform connections and turns are still live,
+which is the split the ledger exists to prevent. So every membership change is a
+two-phase, generation-fenced transition, and while a daemon is entering or leaving a
+set nothing may claim what it is giving up or taking on.
 
-- _Removal from a set_ is a withdrawal, exactly like a revoke or a drain release: the
-  control plane vacates every lease that daemon holds (the general withdrawal guard from
-  #976 makes an in-flight admission refuse to commit), the sweep re-grants those groups
-  to remaining members, and the daemon is told its scope is now `none` on a versioned
-  scope update over the existing connection — not by tearing the socket down. The daemon
-  fences what it held (the same local `duty/revoke` effect, never removal) and stops
-  sending `duties`. If the scope update cannot be delivered, the next heartbeat's digest
-  reports groups the ledger no longer leases to it and the exchange supersedes them —
-  the lease horizon bounds the window either way.
-- _Addition to a set_ is the reverse: the daemon is told its new scope, starts reporting
-  `duties`, and claims on its next beat. Nothing it currently holds is affected, because
-  a daemon in no set holds nothing.
+- _Removal from a set._ (1) Mark the daemon **leaving**: the ledger stops granting to it
+  and stops re-granting its groups to anyone else — the leaving mark is a claim fence on
+  exactly those groups. (2) Send a correlated withdrawal request over the existing
+  connection carrying the new scope (`none`) and a transition generation; the daemon
+  fences every group it holds (the local `duty/revoke` effect — connections and
+  schedules stop, workspace and sessions survive) and acknowledges. (3) On the ack,
+  commit: delete the membership row, vacate the leases, lift the fence; the sweep
+  re-grants to remaining members. If the daemon is unreachable or does not ack, the
+  operation does **not** proceed to (3) on a timeout — it waits out the daemon's own
+  self-fence horizon (§1, #976), after which the daemon has provably stopped serving
+  and the leases have lapsed on their own; then it commits. Successors never receive an
+  immediately vacated lease from an unconfirmed leaver.
+- _Addition to a set_ of a daemon with no directly placed agents. There is nothing to
+  stop, so the transition is one phase: write the row, send the scope update, the daemon
+  starts reporting `duties` and claims on its next beat.
 
 **Enrolling a daemon that has directly placed agents.** A `daemon`-placed agent is
-outside the ledger; the moment its machine joins a set, that machine enforces duties and
-would serve only what it holds a lease for — so every agent still pinned to it becomes
-unservable. That state is not allowed to exist. Enrollment **re-places those agents onto
-the set atomically**, in the same transaction that writes the membership row: their
-`placementKind` becomes `set` with that set's id, and the sweep grants them back to the
-same machine on its next beat (it is a member and it already has them installed, so
-install-on-grant is a no-op refresh). This is what an operator enrolling a machine means
-— "let its agents fail over" — and it is why enrollment is a control-plane action rather
-than a daemon-side flag. The converse is also enforced: a `daemon` placement may not
-name a machine that is in a set (the console does not offer it; the route refuses it).
-Leaving a set is the same story reversed only if the operator asks for it: by default the
-agents stay `set`-placed and re-grant to remaining members; an operator who wants them
-pinned back to the leaving machine moves them explicitly, which the existing move
-machinery already does. A daemon in
-no group behaves exactly as today: no `duties` on the heartbeat, no enforcement, serves
-what it is placed with. This is also the last step of #982's argument: the enforcement
-predicate becomes "participates in a member set", which is what the design always
-said membership should be.
+outside the ledger; the moment its machine enforces duties it serves only what it holds
+a lease for, so every agent still pinned to it would become unservable. That state is
+not allowed to exist, and the transition that avoids it is **the existing agent move**,
+run once per pinned agent with the set as the target — not a new mechanism: (1) mark
+the daemon **entering** (a claim fence on those agents' groups, so no member can win them
+mid-transition); (2) for each pinned agent, the move's detach step stops runtime
+authority on the machine and confirms it, exactly as a machine-to-machine move does;
+(3) commit in one transaction — the agents become `set`-placed on that set, the
+membership row is written, the fence lifts — and the daemon receives its new scope; on
+its next beat it claims those groups back and re-activates them (it is a member and it
+still has the replicas installed, so install-on-grant is a refresh, not a fetch). The
+operator sees one action; underneath it is the move convention applied N times inside
+one fence. If the machine is unreachable, the same rule as the move applies:
+enrollment uses the move's existing force-reassign semantics — the operator confirms
+the source is permanently stopped, and the agents become set-placed without the
+detach — and successors claim them after the source's lease/self-fence horizon, not
+before. The converse is enforced statically: a `daemon` placement may not name a
+machine that is in a set (the console does not offer it; the route refuses it).
+
+Leaving a set does not move agents by itself: they stay `set`-placed and re-grant to
+the remaining members. An operator who wants them pinned back to the leaving machine
+moves them explicitly afterwards, which the existing move machinery already does. Both
+transitions carry a generation so a stale ack (from a previous attempt, or from a
+daemon that reconnected mid-transition) cannot commit the wrong step.
 
 ## 4. What does not change
 

--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -64,7 +64,11 @@ tenancy, not by kind:
 - **`Agent.placementKind ∈ {daemon, set}`** with `setId` as the ref for `set`. `daemon`
   is unchanged — pinned to one machine, outside the ledger. The `pool` kind #991
   introduced **goes away** as a stored value (§8): a pool agent is a `set` agent whose
-  set is the org-less one.
+  set is the org-less one. **Third write-time invariant, on the agent:** a `set`-placed
+  agent may reference only the org-less set or a set whose `orgId` equals the agent's
+  own. Enforced in the same transaction that writes the placement (create, move) — the
+  read path never re-checks it. Without this, `mayHold`'s single rule would let org X's
+  members claim an org Y agent that had been pointed at X's set.
 
 That is the whole schema. The duty ledger (`duty_group`, `duty_group_member`) is
 untouched: a duty group is the _thing claimed_, a member set is the _set that may claim
@@ -116,8 +120,9 @@ agent.placementKind = 'set'  ⇒  claimant.setId = agent.setId
 agent.placementKind = 'daemon' ⇒ claimant.daemonId = agent.daemonId
 ```
 
-The tenancy narrowing is not a branch in `mayHold` at all — it lives in the two
-write-time invariants on `member_set_member` (§2). An org-less set can only ever contain
+The tenancy narrowing is not a branch in `mayHold` at all — it lives in the three
+write-time invariants (§2): two on `member_set_member` (which daemons a set may
+contain) and one on the agent's placement (which set an agent may reference). An org-less set can only ever contain
 org-less daemons, so "claimant is in the pool's set" already implies "claimant is
 install-wide"; an org set can only contain that org's daemons, so "claimant is in group
 G of org X" already implies "claimant is an org-scoped connection of X". The read path
@@ -139,7 +144,40 @@ gets `granted: false` from the same code path a pool member gets it for a
 **What the daemon does.** `dutyEnforced()` today reduces to `organizationScope() ===
 'frame'` (after #982). It becomes "this connection is in a set", learned from `auth/ok`
 — the CP tells the daemon at handshake which set it belongs to, if any, alongside the
-lease horizon it already announces (#976). A daemon in
+lease horizon it already announces (#976).
+
+**Membership changes on a live daemon.** Org-set membership is operator-mutable while
+the daemon is connected, so `auth/ok` cannot be the only time it learns its set. Two
+rules:
+
+- _Removal from a set_ is a withdrawal, exactly like a revoke or a drain release: the
+  control plane vacates every lease that daemon holds (the general withdrawal guard from
+  #976 makes an in-flight admission refuse to commit), the sweep re-grants those groups
+  to remaining members, and the daemon is told its scope is now `none` on a versioned
+  scope update over the existing connection — not by tearing the socket down. The daemon
+  fences what it held (the same local `duty/revoke` effect, never removal) and stops
+  sending `duties`. If the scope update cannot be delivered, the next heartbeat's digest
+  reports groups the ledger no longer leases to it and the exchange supersedes them —
+  the lease horizon bounds the window either way.
+- _Addition to a set_ is the reverse: the daemon is told its new scope, starts reporting
+  `duties`, and claims on its next beat. Nothing it currently holds is affected, because
+  a daemon in no set holds nothing.
+
+**Enrolling a daemon that has directly placed agents.** A `daemon`-placed agent is
+outside the ledger; the moment its machine joins a set, that machine enforces duties and
+would serve only what it holds a lease for — so every agent still pinned to it becomes
+unservable. That state is not allowed to exist. Enrollment **re-places those agents onto
+the set atomically**, in the same transaction that writes the membership row: their
+`placementKind` becomes `set` with that set's id, and the sweep grants them back to the
+same machine on its next beat (it is a member and it already has them installed, so
+install-on-grant is a no-op refresh). This is what an operator enrolling a machine means
+— "let its agents fail over" — and it is why enrollment is a control-plane action rather
+than a daemon-side flag. The converse is also enforced: a `daemon` placement may not
+name a machine that is in a set (the console does not offer it; the route refuses it).
+Leaving a set is the same story reversed only if the operator asks for it: by default the
+agents stay `set`-placed and re-grant to remaining members; an operator who wants them
+pinned back to the leaving machine moves them explicitly, which the existing move
+machinery already does. A daemon in
 no group behaves exactly as today: no `duties` on the heartbeat, no enforcement, serves
 what it is placed with. This is also the last step of #982's argument: the enforcement
 predicate becomes "participates in a member set", which is what the design always
@@ -247,3 +285,13 @@ agent, claimant in the org-less set" — the same answer.
 
 The daemon needs nothing for PR 1: it still learns "you are install-wide" from
 `auth/ok` as today; PR 2 turns that into "you are in set S".
+
+**Rollout ordering.** Old control-plane code does not understand a stored `set`
+placement, and new code cannot resolve eligibility before `member_set` exists, so the
+migration and the code that reads it must not straddle a rolling deploy of the control
+plane. Two acceptable answers: run the migration as a coordinated cutover with the
+control plane briefly down (this is a pre-release project with a single control-plane
+replica per environment, so that is the honest, cheap one), or ship the schema first
+with dual-read code that treats `pool` and `set`-of-the-org-less-row as the same
+eligibility, migrate, then drop the `pool` arm in a following release. The design does
+not require the second; the deployment picks.

--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -40,6 +40,16 @@ holds it to that.
 
 ## 2. Model
 
+**Two kinds of member set, distinguished by tenancy, not by size.** The install-wide
+pool is **one per install**, shared by every organization: its members are org-less
+daemon rows (`Daemon.orgId IS NULL`, frame-mode connections, every frame carrying its
+own `orgId`), and one member serves many organizations' agents at once. There is no
+per-org pool; an organization that must not share a member gets a _dedicated daemon_ —
+a `daemon`-placed machine pinned to it — not a pool of its own. A daemon group, by
+contrast, is **one organization's** set of ordinary org-scoped daemons. So "org-less"
+on a member set never means "unassigned"; it means "serves every org". That is the
+whole reason the two kinds are not one table (§7).
+
 - **`daemon_group`** — `(id, orgId, name)`. Org-scoped: a group belongs to exactly one
   organization and can only contain that organization's daemons. There is no cross-org
   group; the install-wide pool is _not_ a row in this table (§3 explains why).

--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -34,36 +34,49 @@ member-shaped — none of it knows or cares whether the holder is a Pod or a lap
 | Healing is proactive: the sweep re-grants a lapsed holder's groups with no trigger | `incumbent` deleted (#991); verified on a real rollout                                                                                                               |
 
 `domain/placement.ts` was written with this document in mind. Its contract: _nothing
-outside this module may branch on the placement kind; a later `group` kind adds one arm
-here and one join in the ledger's predicate, and the callers do not learn about it._ §4
-holds it to that.
+outside this module may branch on the placement kind; a later kind adds one arm here
+and one join in the ledger's predicate, and the callers do not learn about it._ This
+design holds it to that — and goes one step further than the module anticipated: the
+`pool` arm it has today is not joined by a `group` arm but **replaced** by a single
+`set` arm that is a membership lookup (§3), so the module ends with fewer branches
+than it started with, not more.
 
 ## 2. Model
 
-**Two kinds of member set, distinguished by tenancy, not by size.** The install-wide
-pool is **one per install**, shared by every organization: its members are org-less
-daemon rows (`Daemon.orgId IS NULL`, frame-mode connections, every frame carrying its
-own `orgId`), and one member serves many organizations' agents at once. There is no
-per-org pool; an organization that must not share a member gets a _dedicated daemon_ —
-a `daemon`-placed machine pinned to it — not a pool of its own. A daemon group, by
-contrast, is **one organization's** set of ordinary org-scoped daemons. So "org-less"
-on a member set never means "unassigned"; it means "serves every org". That is the
-whole reason the two kinds are not one table (§7).
+One concept: a **member set** — a named set of daemons within which an agent's duty may
+be claimed. The pool and a local group are two rows of the same table, distinguished by
+tenancy, not by kind:
 
-- **`daemon_group`** — `(id, orgId, name)`. Org-scoped: a group belongs to exactly one
-  organization and can only contain that organization's daemons. There is no cross-org
-  group; the install-wide pool is _not_ a row in this table (§3 explains why).
-- **`daemon_group_member`** — `(groupId, daemonId)`, one daemon in at most one group.
-  A daemon joins by an operator action in the console (or the CLI); membership is
-  control-plane metadata, never negotiated on the wire.
-- **`Agent.placementKind`** gains `group`, with `placementRef` naming the group id.
-  `daemon` and `pool` are unchanged. A `group` agent has no `daemonId`, exactly like a
-  `pool` agent.
+- **`member_set`** — `(id, orgId, name)`. `orgId` is **nullable, and null means
+  cross-org**, never "unassigned": an org-less set is served by org-less daemons and
+  holds every organization's agents. The install-wide pool is one such row — **one per
+  install**, shared by every organization; there is no per-org pool, and an
+  organization that must not share a member gets a `daemon`-placed machine pinned to
+  it, not a pool of its own. A local group is a row with an `orgId`: one organization's
+  set of its own org-scoped daemons.
+- **`member_set_member`** — `(setId, daemonId)`, one daemon in at most one set. Two
+  write-time invariants, enforced where the row is written and nowhere else: an
+  org-less set accepts only org-less daemons; an org set accepts only that org's
+  daemons. Membership is control-plane metadata: an operator records it for org sets
+  (console or CLI), and the control plane enrolls an org-less daemon in the org-less
+  set itself when it authenticates (§6). It is never negotiated on the wire — the
+  daemon is told which set it is in, it does not tell.
+- **`Agent.placementKind ∈ {daemon, set}`** with `setId` as the ref for `set`. `daemon`
+  is unchanged — pinned to one machine, outside the ledger. The `pool` kind #991
+  introduced **goes away** as a stored value (§8): a pool agent is a `set` agent whose
+  set is the org-less one.
 
 That is the whole schema. The duty ledger (`duty_group`, `duty_group_member`) is
-untouched: a duty group is the _thing claimed_, a daemon group is the _set that may claim
+untouched: a duty group is the _thing claimed_, a member set is the _set that may claim
 it_ — the two share a word and nothing else, and the ledger's rows already exist for
 every agent regardless of how it is placed.
+
+**Why `daemon` stays its own kind rather than an N=1 set.** A set's meaning is
+replaceability — a member dies, the duty moves. A pinned machine has nowhere for a duty
+to move; it needs no lease, no fence, no install-on-grant onto itself, and the reaper's
+cascade unplaces it rather than re-granting it. Modeling it as a set would add every one
+of those rituals for no benefit. A local daemon that wants failover does not become a
+set — it **joins** one, and its agents are re-placed onto the set.
 
 ## 3. The tenancy axis — the only new thing
 
@@ -78,49 +91,55 @@ A local group's members are org-scoped connections. So the door has to open — 
 opens **narrower**, never wider. The rule from the pool design stands verbatim: _the
 tenancy gate widens, never disappears._ Concretely:
 
-- An install-wide claimant may hold a `pool` agent's duty. Unchanged.
 - A `daemon`-placed agent's duty may be held by exactly that daemon. Unchanged.
-- A `group`-placed agent's duty may be held by a claimant that is **(a) an org-scoped
-  connection of the agent's own organization and (b) a member of that group**. Both
-  conditions, always. An install-wide member is _not_ eligible for a group agent — the
-  pool does not absorb groups — and an org-scoped daemon is never eligible for a `pool`
-  agent.
+- A `set`-placed agent's duty may be held by exactly the members of that set. For the
+  org-less set (the pool) those are the install-wide members — unchanged from today.
+  For an org set those are org-scoped connections of that org that an operator enrolled.
+- Because of the write-time invariants (§2), those two sentences already imply the
+  narrowing: an install-wide member is _not_ eligible for an org set's agent (it can
+  never be enrolled in an org set), and an org-scoped daemon is never eligible for a
+  pool agent (it can never be enrolled in the org-less set). The pool does not absorb
+  groups; groups do not reach the pool.
 
-So `claimScopeOf(daemon)` stops being a two-valued predicate:
+So `claimScopeOf(daemon)` stops being a two-valued predicate. It becomes "which set is
+this daemon a member of, if any":
 
 ```
-install-wide            — orgId IS NULL                       (the pool)
-group(orgId, groupId)   — orgId = X, member of group G in X   (a local group)
-none                    — orgId = X, in no group              (today's single-org daemon)
+member(setId)   — the daemon is in member_set_member for setId
+none            — in no set (today's single-org daemon)
 ```
 
-and `mayHold(agent, claimant)` gains one arm: `agent.placementKind = 'group'` requires
-`claimant.scope = group` with the same `orgId` and the same `groupId`. The SQL mirror
-(`eligibleAgent` / `noIneligibleAgent` in the ledger repo) gains the matching join to
-`daemon_group_member`. Nothing else in the claim path changes: `claimVacant`,
-`claimAgentHome`, `holdsAgent`, `vacateIneligible` all already read the predicate rather
-than the connection kind.
+and `mayHold(agent, claimant)` collapses to **one rule** for every set agent:
 
-**Why the pool is not a group row.** The install-wide pool has no `orgId`; its members
-are org-less by construction and serve every organization. A row for it would either
-need a nullable `orgId` (and then every group query has to special-case null) or a
-synthetic install org (a fiction). Keeping `pool` as its own placement kind, and letting
-`group` mean "org-scoped set", is the honest encoding — and it is what keeps the tenancy
-rule statable in one sentence.
+```
+agent.placementKind = 'set'  ⇒  claimant.setId = agent.setId
+agent.placementKind = 'daemon' ⇒ claimant.daemonId = agent.daemonId
+```
+
+The tenancy narrowing is not a branch in `mayHold` at all — it lives in the two
+write-time invariants on `member_set_member` (§2). An org-less set can only ever contain
+org-less daemons, so "claimant is in the pool's set" already implies "claimant is
+install-wide"; an org set can only contain that org's daemons, so "claimant is in group
+G of org X" already implies "claimant is an org-scoped connection of X". The read path
+checks membership; the write path guarantees what membership means. That is what makes
+one arm sufficient, and it is the argument for this shape over a per-kind branch. The
+SQL mirror in the ledger repo (`eligibleAgent` / `noIneligibleAgent`) is a join to
+`member_set_member` on `(agent.setId, holder)` — one join, no `CASE` on kind beyond
+`daemon` vs `set`.
 
 **What the three handlers do.** The `conn.orgId !== null ⇒ SCOPE_DENIED` line in
 `duty-claim.ts`, `duty-fetch.ts` and `duty-release.ts` becomes "resolve this
-connection's claim scope; `none` ⇒ `SCOPE_DENIED`". The heartbeat handler forwards
-`duties` for any connection whose scope is not `none`. The predicate then does the
-narrowing per agent, inside the transaction, exactly as it does today for the pool. An
-org-scoped connection that is in a group and sends a `duty/claim` for an agent in another
-org, or in another group, or placed on a specific machine, gets `granted: false` from the
-same code path a pool member gets it for a `daemon`-placed agent.
+connection's set; `none` ⇒ `SCOPE_DENIED`". The heartbeat handler forwards `duties`
+for any connection in a set. The predicate then does the narrowing per agent, inside
+the transaction, exactly as it does today for the pool. An org-scoped member of group G
+that sends a `duty/claim` for an agent in another set, or placed on a specific machine,
+gets `granted: false` from the same code path a pool member gets it for a
+`daemon`-placed agent.
 
 **What the daemon does.** `dutyEnforced()` today reduces to `organizationScope() ===
-'frame'` (after #982). It becomes "this connection has a claim scope other than `none`",
-learned from `auth/ok` — the CP tells the daemon at handshake whether it is a pool member
-or a group member, alongside the lease horizon it already announces (#976). A daemon in
+'frame'` (after #982). It becomes "this connection is in a set", learned from `auth/ok`
+— the CP tells the daemon at handshake which set it belongs to, if any, alongside the
+lease horizon it already announces (#976). A daemon in
 no group behaves exactly as today: no `duties` on the heartbeat, no enforcement, serves
 what it is placed with. This is also the last step of #982's argument: the enforcement
 predicate becomes "participates in a member set", which is what the design always
@@ -133,10 +152,16 @@ holder-following delivery, MCP/memory bundle projection, routing-projection
 confirmation, proactive re-grant, the drain release, the placement fence — every one of
 these is keyed on _the holder_ and already runs for pool members. A group member is a
 holder. The two things that read placement kind (`dutyEligibility` and the SQL mirror)
-each gain one arm; the readers of those two do not change.
+lose the `pool` arm and gain a `set` arm that is one membership lookup; the readers of
+those two do not change.
 
 The console's placement selector already lists targets, not machines (#959, #961,
-#991). A group is one more entry per group the viewer's org has.
+#991). A group is one more entry per set the viewer's org has. On the wire,
+`{ kind: 'pool' }` stays accepted as **API sugar** for "the org-less set": the control
+plane resolves it at the edge and stores `set`, so the console's existing "Cloud" entry
+needs no change and storage has one representation. The sugar becomes ambiguous the
+day a second org-less set exists, which is exactly when the console should start naming
+the set explicitly.
 
 ## 5. Operational prerequisites for a local group
 
@@ -154,39 +179,71 @@ These are the operator's, not the code's:
 
 ## 6. Sequencing and size
 
-One PR, small, after #982 lands (it and this both edit `dutyEnforced()`):
+Two PRs, after #982 lands (it and this both edit `dutyEnforced()`). The first is a
+refactor with no behavior change; the second is the feature. Splitting them keeps the
+pool's just-verified behavior separable from the new one if anything regresses.
 
-1. Schema: `daemon_group`, `daemon_group_member`, `placementKind` gains `group`.
-2. `domain/placement.ts`: the third claim scope and the one new `mayHold` arm; the SQL
-   mirror gains its join.
-3. The three duty handlers and the heartbeat handler: `SCOPE_DENIED` becomes "scope is
-   `none`".
-4. `auth/ok` announces the connection's claim scope; the daemon's enforcement predicate
-   reads it.
-5. Console: group CRUD (org settings), membership on the daemon detail, one more
-   placement entry.
+**PR 1 — fold the pool into a member set (§8).** Schema: `member_set`,
+`member_set_member`, `placementKind` gains `set` and loses `pool`; a migration creates
+the one org-less row, rewrites every `pool` agent to `set` + that row's id, and enrolls
+every org-less daemon row as its member. `domain/placement.ts` and the SQL mirror
+replace the `pool` arm with the membership lookup. `{ kind: 'pool' }` stays as API sugar
+at the edge. Every #991 test must pass unchanged — this PR is the proof that the pool
+was a set all along. Also: a new org-less daemon row (a Pod that just authenticated)
+must be enrolled in the org-less set as part of `upsertOnAuth`, so pool membership stays
+automatic; a `daemon`-kind daemon row is never enrolled anywhere by itself.
 
-Load-bearing tests, all mutation-checked: an org-scoped member of group G in org X
-claims a `group`-placed agent of X in G; the same member is refused a `group` agent of X
-in another group, any agent of another org, any `pool` agent, and any `daemon`-placed
-agent; an install-wide member is refused any `group` agent; and the pool's existing
-"never claims a local-daemon agent" test still holds. Then the same rollout test the
-pool passed: stop one member of a local group, and its agents re-grant to another
-member with no message sent.
+**PR 2 — org sets.** Console: set CRUD in org settings, membership on the daemon detail,
+one more placement entry per set. The three duty handlers and the heartbeat handler:
+`SCOPE_DENIED` becomes "in no set". `auth/ok` announces the daemon's set; the daemon's
+enforcement predicate reads it. Nothing in the ledger changes — PR 1 already made it
+set-shaped.
+
+Load-bearing tests, all mutation-checked: an org-scoped member of set G in org X claims
+a `set`-placed agent of X in G; the same member is refused a `set` agent of X in another
+set, any agent of another org, any pool agent, and any `daemon`-placed agent; a pool
+member is refused any org-set agent; the write-time invariants reject an org-less
+daemon joining an org set and vice versa; and the pool's existing "never claims a
+local-daemon agent" test still holds. Then the same rollout test the pool passed: stop
+one member of a local set, and its agents re-grant to another member with no message
+sent.
 
 ## 7. Rejected
 
-- **A group row for the pool** (§3) — forces a nullable or fictional org onto every
-  group query. The pool _is_ a member set conceptually, and the two kinds already share
-  the claim predicate, the enforcement predicate, and every holder-keyed mechanism —
-  what is unified is the reading, not the row. If several install-wide pools ever exist
-  (say, per runtime tier), that is its own org-less table beside `daemon_group`, still
-  not a row in it; with one pool today, that table would be an interface guessed from a
-  single implementer.
-- **A daemon in several groups.** Nothing needs it, and it turns "which group's
-  eligibility applies" into a policy question. Add if a real case appears.
-- **Cross-org groups.** They would be a second tenancy model. The pool already covers
-  "one member set serving many orgs", with the org-less identity that makes it safe.
-- **Negotiating membership on the wire** (a daemon announcing which group it is in).
+- **`group` as a third placement kind beside `pool`** (the shape an earlier draft of
+  this document had). It costs the same as this one — the tenancy distinction moves
+  from a write-time invariant to a read-path branch — and buys nothing but avoiding
+  §8's migration; it makes a second install-wide pool a schema change instead of a row,
+  and it leaves "why is the pool not a row" as a permanent question. The migration is
+  small and has #991's tests as its net, so the two-shape version is not worth carrying.
+- **`daemon` as an N=1 set** (§2). A pinned machine has no replaceability, so every
+  set ritual (lease, fence, install-onto-self) would be pure cost.
+- **A daemon in several sets.** Nothing needs it, and it turns "which set's eligibility
+  applies" into a policy question. Add if a real case appears.
+- **Cross-org sets with an org id** — a set with `orgId = X` that admits another org's
+  daemons. That would be a second tenancy model; the org-less set already is the
+  cross-org shape, with the org-less identity that makes it safe.
+- **Negotiating membership on the wire** (a daemon announcing which set it is in).
   Membership is an operator decision recorded in the control plane; the daemon is told,
-  it does not tell.
+  it does not tell. The one exception is automatic pool enrollment on auth (§6 PR 1),
+  which is the CP deciding, not the daemon.
+
+## 8. Folding the pool: the migration
+
+The pool exists today as `placementKind = 'pool'` on agents and as "org-less daemon
+row" on daemons, with no set row anywhere. PR 1 makes it a set:
+
+1. Create `member_set` and `member_set_member`; insert one org-less row (the pool).
+2. `UPDATE agent SET placementKind = 'set', setId = <pool> WHERE placementKind = 'pool'`.
+3. `INSERT INTO member_set_member SELECT <pool>, id FROM daemon WHERE "orgId" IS NULL`.
+4. Drop `pool` from the `AgentPlacementKind` enum. `setId` is nullable (null for
+   `daemon`-kind agents), like `daemonId` is nullable for `set`-kind agents.
+
+Behavior must be identical before and after: the same members hold the same groups at
+the same terms. The migration touches no ledger row. It is safe to run under load
+because eligibility is re-read on every claim from current placement, and a claim in
+flight across the migration sees either "pool agent, install-wide claimant" or "set
+agent, claimant in the org-less set" — the same answer.
+
+The daemon needs nothing for PR 1: it still learns "you are install-wide" from
+`auth/ok` as today; PR 2 turns that into "you are in set S".

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -607,33 +607,20 @@ byte-identical heartbeats to before and never observes any of this.
 The k8s pool is the **degenerate case of a more general concept**: a _daemon
 group_ — a named set of members within which an agent's duty may be claimed.
 Today the member set is implicit (every frame-mode Pod of the install); the
-generalization makes it explicit and parameterizable, so that self-hosted
-installs can form groups too: point `Agent.daemonId` (or a successor placement
-field) at a group instead of a machine, and the same ledger, lease exchange,
-rendezvous, and drain semantics distribute the agent within it. For local
-daemons this is the cross-machine generalization of the singleton pid lock —
-today two local daemons configured with the same bot token fight over the
-platform API (R13); a group makes multi-machine failover safe for the first
-time.
+generalization makes it explicit and org-scoped, so that self-hosted installs
+can form groups out of ordinary local daemons. For local daemons this is the
+cross-machine generalization of the singleton pid lock — two local daemons
+configured with the same bot token fight over the platform API (R13); a group
+makes multi-machine failover safe for the first time.
 
-Deliberately **not built yet** — it layers a second untested generalization on
-a mechanism that has not run enforced end to end, and its hard prerequisites
-are exactly the pool's own: the shared data plane (a duty moving to another
-machine needs the agent's state to be reachable there — for local groups that
-means a shared Postgres and re-cloneable workspaces) and the daemon-side
-self-fence. Sequencing: prove the N=1 group (this pool) end to end first, then
-generalize.
-
-Two constraints on intervening work, so the door stays open:
-
-- **Membership must stay a predicate, not a hardcoded connection kind.** The
-  claim gate ("who may claim this agent's duty") is one SQL predicate today;
-  nothing new should assume frame-mode is the only shape of membership.
-- **The tenancy gate widens, never disappears.** Org-scoped connections
-  currently have their `duties` dropped (a deliberate tenancy fence). A local
-  group re-opens that door only as "this org's agents, in a group containing
-  the claimant" — org-scoped connection plus org-and-group-scoped claims is
-  still leak-free; install-wide claims remain frame-mode-only.
+Its prerequisites — the shared data plane, the daemon self-fence, placement as a
+target rather than a member id — have all landed for the pool, and the pool has
+run enforced end to end. The design is now its own document,
+[daemon-groups.md](daemon-groups.md); the one genuinely new piece is the tenancy
+axis (org-scoped connections claiming only "this org's agents, in a group
+containing the claimant"), and that document exists to state it precisely. The
+two constraints this section used to carry — membership stays a predicate, the
+tenancy gate widens and never disappears — are now that document's §3 and §4.
 
 ## 15. Rejected alternatives
 


### PR DESCRIPTION
The k8s pool is the degenerate case of a daemon group: a named set of members
within which an agent's duty may be claimed. Every prerequisite the pool design
listed for generalizing it has landed — shared data plane, self-fence,
placement as a target — and the pool has run enforced end to end, so the
"future direction" stub in k8s-daemon-pool.md §14 becomes its own document.

Almost all of it is "reuse X": install-on-grant, the fence, holder-following
delivery, proactive re-grant are keyed on the holder and do not care whether
it is a Pod or a laptop. The one new thing, and the reason this is a design
rather than a PR, is the tenancy axis. Today only install-wide connections may
touch the ledger; a local group's members are org-scoped connections, so that
door must open — narrower, never wider: a group agent may be held only by an
org-scoped connection of the agent's own org that is a member of that group,
install-wide members are never eligible for group agents, and org-scoped
daemons are never eligible for pool agents. `claimScopeOf` becomes three-valued,
`mayHold` gains one arm, the SQL mirror one join; the three duty handlers turn
`SCOPE_DENIED` into "scope is none".

Also records why the pool is not a group row (no org to put on it), what the
operator owes a local group (shared Postgres, re-cloneable workspaces), and the
load-bearing tests, including the same rollout test the pool passed.

Design only — no code. Sequenced after #982 (both touch the daemon's enforcement predicate). Tracked under #955.