### PR TITLE
chore(duty): retire the dutyEnforcement soak flag

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -140,8 +140,6 @@ The daemon does not implement these, but interacts with them through the section
 
 All environment equivalents use the `AGENTCONNECT_` prefix, such as `AGENTCONNECT_CP_URL`, `AGENTCONNECT_CP_KEY`, and `AGENTCONNECT_ROOT`, for containers and system services.
 
-One feature switch is reachable the same way: `AGENTCONNECT_DUTY_ENFORCEMENT` sets `features.dutyEnforcement`, so a daemon whose config.json is machine-generated on every start can still state it. It accepts `1`/`true`/`yes`/`on` or `0`/`false`/`no`/`off` (case-insensitive; blank or unset means "not stated"), rejects anything else at startup rather than reading as off, and — unlike the table above — **outranks the config file**, because in that deployment the file is regenerated from defaults and could never carry the decision. It only changes behavior on an install-wide (frame-scope) daemon; an org-scoped daemon is unaffected whatever it says.
-
 ### 2.4 Mapping In-Process Responsibilities to CLI
 
 `run`, including the same `run` managed by a service after `up`, starts every module in the section 1.2 diagram corresponding to upstream D1-D12: Supervisor, CP-Client, ConnectionManager and Platform Adapters, Local Router, Scheduler, ACP Host, MCP Tool Server, Workspace Manager, Local Store, and Telemetry. Secrets Agent remains future work. Sections 6-10 expand the parts directly related to the eight requirements.

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -1,8 +1,9 @@
 # The K8s Daemon Pool: Multi-Org Daemons and the Duty Ledger
 
 **Status:** The ownership mechanism is implemented (control plane, daemon,
-relay, protocol) with enforcement opt-in behind `features.dutyEnforcement`,
-off by default. The remaining build order is the tracking issue
+relay, protocol) and enforcement is unconditional: an install-wide (frame-scope)
+member is duty-governed, an org-scoped daemon is not, and there is no switch
+between them. The remaining build order is the tracking issue
 "K8s daemon pool — implementation plan and tracking". This document states the
 design and marks what is not yet built; file references are given so every
 claim can be checked against the code.
@@ -253,11 +254,9 @@ timer, or tick (`orchestrator/dutyLease.ts`):
 
 - **T_fence** — a holder that cannot renew for T_fence **self-fences**: it
   tears down the affected duties, including their platform connections. Sized
-  to cover a routine CP deploy. **Not yet implemented daemon-side** — on
-  losing the CP link the client today only stops heartbeats while the registry
-  retains its grants; landing this self-fence is a precondition for turning
-  enforcement on (tracking issue), because without it a partitioned ex-holder
-  could still serve a group a successor has claimed.
+  to cover a routine CP deploy. Implemented daemon-side: the client tracks a
+  per-group deadline and calls `Daemon.fenceDuties`, without which a partitioned
+  ex-holder could still serve a group a successor has claimed.
 - **T_reassign > T_fence** — the CP treats a duty as vacant only after
   T_reassign without renewal, guaranteeing the old holder has self-fenced
   before a successor can claim.
@@ -543,7 +542,7 @@ dials, and sandboxes never dial anyone.
 | Failure                              | Behavior                                                                                                                                                                                                                                                                                                                        | Bound                                                                                                                                |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | **Member death**                     | Its duties stop renewing; successors claim after T_reassign and dial. Sleeping agents untouched. In-memory pending turns die. For relay-ingress agents the relay re-routes the bot within seconds, but that member waits out T_reassign before it can claim the dead member's agent homes — no connection-death fast path (R7). | Platform retry/buffering bounds message loss (accepted window 1); takeover gap ≈ T_reassign + platform reconnect (accepted window 2) |
-| **Member ↔ CP partition**            | The member self-fences its duties at T_fence, including tearing down platform connections. _(The daemon-side self-fence is not yet implemented — see §5 and the tracking issue; enforcement stays off until it lands.)_                                                                                                         | Accepted false-positive teardown when the CP is up but unreachable from this member                                                  |
+| **Member ↔ CP partition**            | The member self-fences its duties at T_fence, including tearing down platform connections.                                                                                                                                                                                                                                      | Accepted false-positive teardown when the CP is up but unreachable from this member                                                  |
 | **Member ↔ data-plane PG partition** | The member cannot serve state: fail turns after a bounded retry window, release duties, stop accepting work.                                                                                                                                                                                                                    | Data-plane PG availability is pool availability                                                                                      |
 | **Member ↔ sandbox path break**      | Dial-retry with backoff; after N failures, release the agent's duty so another member claims and dials from its own network position.                                                                                                                                                                                           | N × backoff before relocation                                                                                                        |
 | **Shim side**                        | On connection drop the shim just listens — it never dials. A half-dead old holder is fenced by term at the shim and at every data-plane write.                                                                                                                                                                                  | Fencing is absolute, not probabilistic                                                                                               |
@@ -568,18 +567,22 @@ its runtimes — it spawns child processes and owns their stdio. Dial-in makes
 pool and local symmetric: in both, the daemon reaches out to establish the
 execution channel.
 
-**Rollout.** The exchange runs unconditionally on frame-mode daemons — the
-ledger needs the digest to converge — but _enforcement_ (the
-`transportAgents()` filter, schedule scoping, refusal of unheld triggers) is
-behind `features.dutyEnforcement`, default off: a grant or revoke only moves
-bookkeeping until the flag flips, so convergence is observable in production
-before it gates a single connection. A pool member's state root is an
-`emptyDir`, so its config.json is regenerated from defaults on every Pod start
-and cannot carry the flag; the operator sets `AGENTCONNECT_DUTY_ENFORCEMENT`
-(`1`/`true`/`yes`/`on`, anything unrecognized refused at startup) on the Pod
-instead, which outranks the file for this one key. The daemon reports which
-state it got — enforcing, or configured-but-inactive on a non-frame
-connection — once the control-plane connection is up.
+**Enforcement is not configurable.** Both the exchange and _enforcement_ (the
+`transportAgents()` filter, schedule scoping, refusal of unheld triggers) follow
+one predicate: `organizationScope() === 'frame'`. An install-wide member is
+duty-governed and needs no configuration to be; an org-scoped daemon owns its
+agents outright and is untouched. A pool member's state root is an `emptyDir`,
+so its config.json is regenerated from defaults on every Pod start — which is
+now simply irrelevant, since the file carries no part of the decision.
+
+There was a `features.dutyEnforcement` soak flag, with an
+`AGENTCONNECT_DUTY_ENFORCEMENT` override, and it is gone. It let a grant or
+revoke move only bookkeeping so convergence could be watched before it gated a
+connection, and it made sense only while placement pinned each agent to exactly
+one member: "serve everything I was placed with" was then a well-defined
+fallback. Once placement became a target, a `pool` agent is placed on no member,
+so off meant those agents were served by nobody — a lever that breaks the
+system rather than a safety valve.
 
 **There is no grant policy any more.** The soak ran on an incumbent-only one —
 a vacancy went only to the member the group's agents were already placed on —

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -171,15 +171,9 @@ export const ConfigSchema = z.object({
    * never negotiated through the control plane or placed on the message hot path. */
   features: z
     .object({
-      turnFinalContextRefresh: z.boolean().default(true),
-      // Duty leases decide which agents this daemon serves (k8s pools). The
-      // exchange itself always runs on an install-wide connection — the ledger
-      // needs the digest to converge — but ENFORCEMENT is opt-in: until this is
-      // on, a duty grant/revoke only moves bookkeeping, so the ledger can be
-      // observed converging before it gates a single platform connection.
-      dutyEnforcement: z.boolean().default(false)
+      turnFinalContextRefresh: z.boolean().default(true)
     })
-    .default({ turnFinalContextRefresh: true, dutyEnforcement: false }),
+    .default({ turnFinalContextRefresh: true }),
   sessions: z
     .object({
       // Local-DB retention for FINISHED sessions (issue #485): a session untouched

--- a/packages/daemon/src/config/load-config.ts
+++ b/packages/daemon/src/config/load-config.ts
@@ -15,25 +15,6 @@ export interface FlatOverrides {
   requireSandbox?: boolean
 }
 
-/** Env override for `features.dutyEnforcement` — the only channel a pool member has, its config.json being regenerated each start. */
-export const DUTY_ENFORCEMENT_ENV = 'AGENTCONNECT_DUTY_ENFORCEMENT'
-
-const DUTY_ENFORCEMENT_ON = ['1', 'true', 'yes', 'on']
-const DUTY_ENFORCEMENT_OFF = ['0', 'false', 'no', 'off']
-
-/** Unset or blank ⇒ no override; an unrecognized value throws, because a switch that silently reads as off is the failure mode. */
-export function dutyEnforcementFromEnv(env: NodeJS.ProcessEnv = process.env): boolean | undefined {
-  const raw = env[DUTY_ENFORCEMENT_ENV]
-  if (raw === undefined) return undefined
-  const value = raw.trim().toLowerCase()
-  if (value === '') return undefined
-  if (DUTY_ENFORCEMENT_ON.includes(value)) return true
-  if (DUTY_ENFORCEMENT_OFF.includes(value)) return false
-  throw new Error(
-    `${DUTY_ENFORCEMENT_ENV} must be one of ${[...DUTY_ENFORCEMENT_ON, ...DUTY_ENFORCEMENT_OFF].join('/')} (got ${JSON.stringify(raw)})`
-  )
-}
-
 function protectConfigFile(file: string, writable = false): void {
   if (!existsSync(file)) return
   try {
@@ -102,10 +83,6 @@ export function loadConfig(
     cfg.controlPlane.url = envUrl
     if (!o.noCp) cfg.controlPlane.enabled = true
   }
-
-  // Env wins over the file for this key alone, on every branch above: a pool member's emptyDir root regenerates config.json each start.
-  const dutyEnforcement = dutyEnforcementFromEnv()
-  if (dutyEnforcement !== undefined) cfg.features.dutyEnforcement = dutyEnforcement
 
   cfg.agentsDir = o.agentsDir ?? cfg.agentsDir ?? defaultAgentsDir(root)
   return cfg

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2143,8 +2143,6 @@ export class Daemon {
   // only on an install-wide connection — empty on a single-org daemon, which is
   // what keeps the whole path dormant there.
   private readonly duties = new DutyRegistry()
-  // Last enforcement state logged, so a reconnect only speaks when the answer changed.
-  private dutyEnforcementReported?: boolean
   // What an unbounded member reports as heartbeat headroom: the CP's own
   // per-tick grant cap, so the wire carries a finite number without implying a
   // ceiling. Never used for a local capacity decision.
@@ -3005,9 +3003,6 @@ export class Daemon {
     this.log.info(
       `control plane: ${cfg.controlPlane?.enabled ? `enabled (${cfg.controlPlane.url ?? 'no url'})` : 'disabled — running local'}`
     )
-    // The default is off and silent; when it is on, say so before any lease can gate a connection.
-    if (cfg.features.dutyEnforcement)
-      this.log.info('duty: enforcement configured on — awaiting an install-wide (frame-scope) control-plane connection')
     this.agentsDir = cfg.agentsDir!
     this.removalObligationsDir = agentRemovalObligationsDir(root)
     this.removedAgentTombstones = agentRemovalTombstones(this.agentsDir, this.removalObligationsDir)
@@ -12731,24 +12726,12 @@ export class Daemon {
     return max - this.duties.agents().size - Math.max(0, this.inFlightDutyClaims.size - 1)
   }
 
-  /** True when duty leases actually gate service. Off (the default) the exchange
-   *  still runs and the registry still tracks — only enforcement is withheld. */
+  /** True when duty leases gate service: a tenancy question, not an option. An install-wide
+   *  (frame-scope) member serves only what it holds a lease for; an org-scoped daemon owns its
+   *  agents outright and never participates in the ledger. */
   private dutyEnforced(): boolean {
-    // `cfg` lands in start(); transportAgents can run before that in tests.
-    return this.cfg?.features?.dutyEnforcement === true && this.cpClient?.organizationScope() === 'frame'
-  }
-
-  /** Which of the two configured-on states this connection resolved to; a reconnect that changes nothing stays quiet. */
-  private logDutyEnforcementScope(): void {
-    if (this.cfg?.features?.dutyEnforcement !== true) return
-    const enforcing = this.dutyEnforced()
-    if (this.dutyEnforcementReported === enforcing) return
-    this.dutyEnforcementReported = enforcing
-    if (enforcing) this.log.info('duty: enforcement ACTIVE — this daemon serves only the agents it holds a lease for')
-    else
-      this.log.warn(
-        `duty: enforcement INACTIVE — it applies only to an install-wide (frame-scope) connection, and this one is ${this.cpClient?.organizationScope() ?? 'not established'}`
-      )
+    // `cpClient` lands in start(); transportAgents can run before that in tests.
+    return this.cpClient?.organizationScope() === 'frame'
   }
 
   /** `duty/grant` EVT: admit the grants off the frame-dispatch path, so a slow
@@ -12839,8 +12822,7 @@ export class Daemon {
     // Report the new digest immediately. The CP publishes the projections that address this member
     // only once it has SEEN the group held (the grant alone is not proof of an install), so waiting
     // for the next tick leaves an agent this member is already serving unroutable for up to a
-    // heartbeat. Outside the enforcement gate below on purpose: the digest is sent, and the CP
-    // acts on it, whether or not this member is enforcing.
+    // heartbeat. Outside the duty gate below on purpose: the CP acts on the digest either way.
     this.cpClient?.reportDutiesNow()
     this.onDutyChanged()
   }
@@ -13032,7 +13014,7 @@ export class Daemon {
   // sessions, and the registry entry all survive it (#948), and the omitted groups are what the CP's
   // missing-regrant path reissues on reconnect.
   private fenceDuties(groupIds: string[]): void {
-    // Enforcement off ⇒ duties gate nothing, so a teardown would drop live traffic for no reason.
+    // Not duty-governed (an org-scoped daemon) ⇒ a teardown would drop live traffic for no reason.
     if (!this.dutyEnforced()) return
     // BEFORE the held filter: a group still being admitted is not held yet, so there would be
     // nothing to shed — and it would start serving the moment its admission completed.
@@ -21574,8 +21556,6 @@ export class Daemon {
       // may have missed emits while we were disconnected; latest-wins upsert).
       onReady: () => {
         resolveInitialRegistry()
-        // The organization scope is only known once the connection is up, and it is half the answer.
-        this.logDutyEnforcementScope()
         void this.probeRuntimesAndEmit()
         void this.syncOrganizationSuggestions().catch((err) =>
           this.log.warn(`cp: organization suggestion replay failed (${err instanceof Error ? err.name : 'unknown'})`)

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { chmodSync, mkdtempSync, writeFileSync, mkdirSync, existsSync, readFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { loadConfig, DUTY_ENFORCEMENT_ENV } from '../src/config/load-config.js'
+import { loadConfig } from '../src/config/load-config.js'
 import { McpServerDefSchema, RuntimeDefSchema, sessionRetentionMs } from '../src/config/config-schema.js'
 import { CP_URL_ENV } from '@agentconnect.md/protocol'
 
@@ -70,72 +70,6 @@ describe('loadConfig', () => {
       const cfg = withEnv('   ', () => loadConfig({ root: tmpRoot({ version: 1 }) }))
       expect(cfg.controlPlane.url).toBeUndefined()
       expect(cfg.controlPlane.enabled).toBe(false)
-    })
-  })
-
-  // A pool member's state root is an emptyDir, so its config.json is regenerated from defaults each start.
-  describe(`${DUTY_ENFORCEMENT_ENV} (the pool member's rollout switch)`, () => {
-    const withEnv = <T>(value: string | undefined, run: () => T): T => {
-      const previous = process.env[DUTY_ENFORCEMENT_ENV]
-      if (value === undefined) delete process.env[DUTY_ENFORCEMENT_ENV]
-      else process.env[DUTY_ENFORCEMENT_ENV] = value
-      try {
-        return run()
-      } finally {
-        if (previous === undefined) delete process.env[DUTY_ENFORCEMENT_ENV]
-        else process.env[DUTY_ENFORCEMENT_ENV] = previous
-      }
-    }
-
-    it('is off when the variable is absent, keeping the shipped default', () => {
-      const cfg = withEnv(undefined, () => loadConfig({ root: tmpRoot({ version: 1 }) }))
-      expect(cfg.features.dutyEnforcement).toBe(false)
-    })
-
-    it('turns enforcement on for every accepted spelling of on', () => {
-      for (const value of ['1', 'true', 'TRUE', 'yes', 'on', ' true ']) {
-        const cfg = withEnv(value, () => loadConfig({ root: tmpRoot({ version: 1 }) }))
-        expect(cfg.features.dutyEnforcement, value).toBe(true)
-      }
-    })
-
-    it('turns enforcement off for every accepted spelling of off', () => {
-      for (const value of ['0', 'false', 'FALSE', 'no', 'off']) {
-        const cfg = withEnv(value, () => loadConfig({ root: tmpRoot({ version: 1 }) }))
-        expect(cfg.features.dutyEnforcement, value).toBe(false)
-      }
-    })
-
-    it('refuses an unparseable value rather than silently staying off', () => {
-      expect(() => withEnv('maybe', () => loadConfig({ root: tmpRoot({ version: 1 }) }))).toThrow(
-        new RegExp(DUTY_ENFORCEMENT_ENV)
-      )
-      expect(() => withEnv('2', () => loadConfig({ root: tmpRoot({ version: 1 }) }))).toThrow(/must be one of/)
-    })
-
-    it('is ignored when blank, so a chart templating an empty value decides nothing', () => {
-      const root = tmpRoot({ version: 1, features: { dutyEnforcement: true } })
-      expect(withEnv('   ', () => loadConfig({ root })).features.dutyEnforcement).toBe(true)
-    })
-
-    it('outranks a config file that says the opposite, in both directions', () => {
-      const off = tmpRoot({ version: 1, features: { dutyEnforcement: false } })
-      expect(withEnv('true', () => loadConfig({ root: off })).features.dutyEnforcement).toBe(true)
-      const on = tmpRoot({ version: 1, features: { dutyEnforcement: true } })
-      expect(withEnv('false', () => loadConfig({ root: on })).features.dutyEnforcement).toBe(false)
-    })
-
-    it('survives the auto-create path, so a fresh ephemeral root still comes up enforcing', () => {
-      const root = mkdtempSync(join(tmpdir(), 'ac-cfg-')) // no config.json written
-      const cfg = withEnv('1', () => loadConfig({ root, autoCreate: true }))
-      expect(cfg.features.dutyEnforcement).toBe(true)
-      // The generated file stays default-shaped — the env, not the disposable file, is the source.
-      expect(JSON.parse(readFileSync(join(root, 'config.json'), 'utf8'))).toEqual({ version: 1 })
-    })
-
-    it('applies on the optional (no file) path too', () => {
-      const root = mkdtempSync(join(tmpdir(), 'ac-cfg-'))
-      expect(withEnv('on', () => loadConfig({ root, optional: true })).features.dutyEnforcement).toBe(true)
     })
   })
 

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -1,6 +1,6 @@
 // The daemon half of `T_reassign > T_fence`: a member must stop serving its duties before
 // the CP can hand them to a successor. These pin what the fence tears down, what it must
-// leave alone, and that it does nothing at all while enforcement is off.
+// leave alone, and that an org-scoped daemon — which is not duty-governed — is untouched.
 import { describe, it, expect, vi } from 'vitest'
 import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -18,14 +18,15 @@ const INTEGRATION_B = '22222222-2222-4222-8222-222222222223'
 const CRON = '33333333-3333-4333-8333-333333333333'
 const ORG = 'org-1'
 
-function scaffold(dutyEnforcement: boolean): string {
+// No `features` block anywhere in here on purpose: duty enforcement follows the connection's
+// tenancy, so an install-wide member enforces with no configuration at all.
+function scaffold(): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-duty-fence-'))
   writeFileSync(
     join(root, 'config.json'),
     JSON.stringify({
       version: 1,
       controlPlane: { enabled: false },
-      features: { dutyEnforcement },
       runtimes: { claude: { command: 'node', args: ['unused'] } }
     })
   )
@@ -76,13 +77,13 @@ const bundle = (
 })
 
 /** A daemon holding one granted duty, with a stub CP client — only the duty surface runs. */
-async function boot(dutyEnforcement = true) {
-  const root = scaffold(dutyEnforcement)
+async function boot(scope: 'frame' | 'connection' = 'frame') {
+  const root = scaffold()
   const daemon = new Daemon({ root })
   await daemon.start()
   const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
   ;(daemon as any).cpClient = {
-    organizationScope: () => 'frame',
+    organizationScope: () => scope,
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
     // An admission reports its new digest immediately: the CP holds every projection that
@@ -98,7 +99,7 @@ async function boot(dutyEnforcement = true) {
 /** A daemon with an admission held open at the `duty/fetch` round trip, so a withdrawal can land
  *  inside the window between grant receipt and `applyGrant` — the gap this guard exists for. */
 async function bootMidAdmission() {
-  const daemon = new Daemon({ root: scaffold(true) })
+  const daemon = new Daemon({ root: scaffold() })
   await daemon.start()
   let release!: () => void
   const fetched = new Promise<void>((resolve) => {
@@ -147,7 +148,9 @@ function liveSlackSocket(
 const pooled = (d: Daemon): unknown[] => (d as any).slackPool.all()
 
 describe('the duty self-fence', () => {
-  it('releases every held group and stops serving its agents', async () => {
+  it('releases every held group and stops serving its agents, with no configuration asking for it', async () => {
+    // The scaffold writes no `features` block: an install-wide (frame-scope) connection is the
+    // whole condition, so a fresh pool member enforces the moment it registers.
     const { daemon } = await boot()
     expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '1' }])
     expect(served(daemon)).toContain(AGENT)
@@ -338,13 +341,14 @@ describe('the duty self-fence', () => {
     await daemon.stop()
   })
 
-  it('does nothing while enforcement is off — duties gate no service, so there is nothing to fence', async () => {
-    const { daemon } = await boot(false)
+  it('does nothing on an org-scoped connection — that daemon owns its agents outright', async () => {
+    // Duty is a tenancy question: an org-scoped daemon is not in the ledger, so its agents are
+    // served whatever the registry happens to hold, and a fence there would drop live traffic.
+    const { daemon } = await boot('connection')
     expect(served(daemon)).toContain(AGENT)
 
     fence(daemon)
 
-    // Still held, still served: tearing anything down here would drop live traffic.
     expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '1' }])
     expect(served(daemon)).toContain(AGENT)
     await daemon.stop()

--- a/packages/daemon/test/daemon-duty-replacement.test.ts
+++ b/packages/daemon/test/daemon-duty-replacement.test.ts
@@ -28,6 +28,7 @@ const CRON: Record<string, string> = {
   [AGENT_C]: '33333333-3333-4333-8333-333333333333'
 }
 
+// No `features` block: the frame-scope stub connection below is the whole enforcement condition.
 function scaffold(): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-duty-replacement-'))
   writeFileSync(
@@ -35,7 +36,6 @@ function scaffold(): string {
     JSON.stringify({
       version: 1,
       controlPlane: { enabled: false },
-      features: { dutyEnforcement: true },
       runtimes: { claude: { command: 'node', args: ['unused'] } }
     })
   )

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -97,6 +97,8 @@ function fakeCpClient() {
   return {
     hookReports,
     sessionEvents,
+    // An ordinary org-scoped daemon: it owns its agents outright and is not duty-governed.
+    organizationScope: () => 'connection' as const,
     stop: vi.fn(async () => {}),
     emitEventSession: (event: EventSession) => sessionEvents.push(event),
     emitHookReport: async (r: HookReport) => {
@@ -1298,6 +1300,7 @@ describe('Daemon rd/msg hook fires', () => {
     const hookReports: HookReport[] = []
     const cp = {
       stop: vi.fn(async () => {}),
+      organizationScope: () => 'connection' as const,
       startHook: vi.fn(async () => ({ accepted: true })),
       authorizeGithubReview: vi.fn(async () => ({
         attemptId: currentAttemptId,
@@ -2112,7 +2115,11 @@ describe('Daemon rd/msg hook fires', () => {
       const emitHookReport = vi.fn(async () => {
         throw new Error('cp unreachable')
       })
-      ;(daemon as never as { cpClient: unknown }).cpClient = { stop: vi.fn(async () => {}), emitHookReport }
+      ;(daemon as never as { cpClient: unknown }).cpClient = {
+        stop: vi.fn(async () => {}),
+        organizationScope: () => 'connection' as const,
+        emitHookReport
+      }
 
       const first = fire({ sessionKey: HOOK_ID })
       const second = fire({ sessionKey: HOOK_ID, msgId: `${HOOK_ID}:d-2`, deliveryKey: 'd-2' })
@@ -2159,7 +2166,11 @@ describe('Daemon rd/msg hook fires', () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
     await daemon.start()
     const emitHookReport = vi.fn(() => new Promise<'acknowledged'>(() => {}))
-    ;(daemon as never as { cpClient: unknown }).cpClient = { stop: vi.fn(async () => {}), emitHookReport }
+    ;(daemon as never as { cpClient: unknown }).cpClient = {
+      stop: vi.fn(async () => {}),
+      organizationScope: () => 'connection' as const,
+      emitHookReport
+    }
 
     const rows = Array.from({ length: 150 }, (_, i) => ({
       id: `${HOOK_ID}:backlog-${i}`,

--- a/packages/daemon/test/daemon-webchat-session-continuation.test.ts
+++ b/packages/daemon/test/daemon-webchat-session-continuation.test.ts
@@ -72,6 +72,8 @@ async function boot(reply: (prompt: string) => string = () => 'done') {
   ;(daemon as never as { cpClient: unknown }).cpClient = {
     emitUsageReport: vi.fn(),
     emitSessionActivity: vi.fn(),
+    // Org-scoped: this daemon owns its agents outright and is not duty-governed.
+    organizationScope: () => 'connection' as const,
     stop: vi.fn(async () => {})
   }
   const d = daemon as never as {

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -110,6 +110,8 @@ function fakeCpClient() {
     usageReports,
     emitUsageReport: vi.fn((report: unknown) => usageReports.push(report)),
     emitSessionActivity: vi.fn(),
+    // An ordinary org-scoped daemon: it owns its agents outright and is not duty-governed.
+    organizationScope: () => 'connection' as const,
     stop: vi.fn(async () => {}),
     // The transport-neutral reply sink a dispatch()/handleRelayMsg call threads in (the
     // turn engine writes here instead of a hardcoded client; captures the same arrays).

--- a/packages/daemon/test/webchat-continuation-fixture.ts
+++ b/packages/daemon/test/webchat-continuation-fixture.ts
@@ -79,7 +79,13 @@ export function scriptedHosts(replies: Record<string, (prompt: string) => string
 }
 
 export function fakeCpClient() {
-  return { emitUsageReport: vi.fn(), emitSessionActivity: vi.fn(), stop: vi.fn(async () => {}) }
+  // Org-scoped: this daemon owns its agents outright and is not duty-governed.
+  return {
+    emitUsageReport: vi.fn(),
+    emitSessionActivity: vi.fn(),
+    organizationScope: () => 'connection' as const,
+    stop: vi.fn(async () => {})
+  }
 }
 
 /** Frame factory bound to one conversation id — mirrors the relay's

--- a/packages/daemon/test/webchat-turn-refresh.test.ts
+++ b/packages/daemon/test/webchat-turn-refresh.test.ts
@@ -45,7 +45,13 @@ function scaffold(): string {
 }
 
 function fakeCpClient() {
-  return { emitUsageReport: vi.fn(), emitSessionActivity: vi.fn(), stop: vi.fn(async () => {}) }
+  // Org-scoped: this daemon owns its agents outright and is not duty-governed.
+  return {
+    emitUsageReport: vi.fn(),
+    emitSessionActivity: vi.fn(),
+    organizationScope: () => 'connection' as const,
+    stop: vi.fn(async () => {})
+  }
 }
 
 const rd = (payload: RdMsgWebchat['payload'], over: Partial<RdMsgWebchat> = {}): RdMsgWebchat => ({


### PR DESCRIPTION
Closes #982.

## Both retirement conditions are met

**1. Placement no longer names a member.** #991 made placement a *target*:
`placementKind ∈ {daemon, pool}`, and a `pool` agent carries `daemonId = null`.

**2. Soak is complete everywhere there is anything to soak.** Only one
environment runs a Cloud Daemon pool; enforcement has been on there and
proactive healing across a real rollout has been verified. Every other
environment has only org-scoped daemons, for which `dutyEnforced()` was false
regardless of the flag — there was never a soak to run.

## And "off" had stopped being a safe position

Turning the flag off was coherent only while placement pinned each agent to
exactly one member: "serve everything I was placed with" was then a well-defined
fallback. A pool agent is placed on **no** member, so with the flag off nothing
gates and nothing owns — **pool agents are served by nobody**. The switch was no
longer a safety valve; it was a way to break the system. That is the difference
between deleting dead weight and deleting a hazard, and it is why this is not
"leave it, it costs nothing".

## What `dutyEnforced()` became

```ts
/** True when duty leases gate service: a tenancy question, not an option. An install-wide
 *  (frame-scope) member serves only what it holds a lease for; an org-scoped daemon owns its
 *  agents outright and never participates in the ledger. */
private dutyEnforced(): boolean {
  return this.cpClient?.organizationScope() === 'frame'
}
```

The function stays. The predicate is the half that always did the work, and it
keeps a name that says it is a tenancy check — not inlined into its six call
sites, not renamed to something that hides what it asks. If daemon groups
arrive, this widens from "install-wide" to "participates in a group", which is
the design's standing constraint that membership stays a predicate.

## Removed

- `features.dutyEnforcement` from the daemon config schema.
- `AGENTCONNECT_DUTY_ENFORCEMENT` / `DUTY_ENFORCEMENT_ENV` and its parser in
  `load-config.ts` (the whole of #980).
- The startup line (`enforcement configured on — awaiting …`), the resolved
  ACTIVE/INACTIVE ready line, and the `dutyEnforcementReported` dedupe field
  they needed. With no flag there are no two states to disambiguate.

Nothing in the ledger, admission, fence, or placement machinery is touched.

## Nothing keyed on the flag as a proxy for "is a pool member"

Checked both directions — every occurrence of the flag name, and every caller of
`dutyEnforced()`. The six callers are `transportAgents`, the `rd/msg` activation
rendezvous, `fenceDuties`, `onDutyChanged`, `syncAgentSchedules`, and
`stopServingAgent`: all of them are duty-service gates asking the same question,
none was using the boolean to mean something else. So no call site had to be
rewritten to read `organizationScope()` directly — they already did, through
this function.

One consequence worth naming: with the conjunct gone, `dutyEnforced()` no longer
short-circuits before touching `cpClient`, so a few test fakes that stood in for
a CP client without an `organizationScope` method now have one. They model an
org-scoped daemon and say so.

## Tests

`daemon-duty-fence.test.ts` and `daemon-duty-replacement.test.ts` wrote
`features: { dutyEnforcement: true }` into their scaffolds; both now write **no
`features` block at all**, which is the assertion — a frame-mode daemon enforces
with zero configuration. The fence file's boot helper is parameterized on the
connection scope instead of the flag, the axis it was really exercising.

The one test that existed to prove "off does nothing" is not kept as a dead
assertion; it is rewritten as its real subject, an org-scoped daemon, which
still must not be fenced. `config.test.ts` loses the entire env-override block.

### Mutation check

Applied to `dutyEnforced()`, suite run, failures recorded, restored. Files run:
`daemon-duty-fence`, `daemon-duty-replacement`, `daemon-duty-install`.

| # | Mutation | frame-mode enforces with no config | org-scoped is unaffected | Others |
| --- | --- | --- | --- | --- |
| M1 | `return false` (never enforce) | **fails** | passes | 11, all duty-service tests that require the gate to be closed |
| M2 | `return true` (always enforce) | passes | **fails** | none — 45/46 pass |
| M3 | `=== 'connection'` (invert the tenancy) | **fails** | **fails** | 8, same set as M1 |

M2 is the load-bearing one: exactly one test in the tree distinguishes "enforce
when frame-scope" from "enforce always", and it is the org-scoped case.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean.
`pnpm --filter @agentconnect.md/control-plane test:unit` — 1636 passed.
`pnpm --filter @agentconnect.md/daemon test` — 15 failures, all the known
baseline reproduced on clean `main`: `shim-workspace-files` (7),
`shim-cancellation` (5), `shim-exec-handler` (1), `workspace-git-runner-seam`
(1), and the live `acp-matrix` suite (1, real upstream provider errors). No new
failures.

## Follow-up

The deployment side still templates a `cloudDaemon.dutyEnforcement` value into
the pool members' Pod environment. It is inert the moment this ships — the
daemon no longer reads the variable — and is removed separately in the private
deployment repository.
