### PR TITLE
fix(knowledge): scope the organization-suggestion replay to the org that owns it

### DIFF
--- a/packages/control-plane/src/http/routes/organization-knowledge.ts
+++ b/packages/control-plane/src/http/routes/organization-knowledge.ts
@@ -176,8 +176,12 @@ async function suggestionReviewAvailable(
     deps.registry.getAvailable(orgId, DaemonId(sourceDaemonId)),
     deps.repos.agent.get(orgId, AgentId(sourceAgentId))
   ])
+  if (!agent) return false
+  // The staged bytes sit on the member that dreamt them, so ask the delivery seam whether it still
+  // serves the agent — `agent.daemonId` alone misses a duty holder, and a pool agent names nobody.
+  const serving = await deps.agentDelivery.daemonsFor(agent)
   return (
-    agent?.daemonId === sourceDaemonId &&
+    serving.includes(sourceDaemonId) &&
     daemon?.capabilities.features.includes(ORGANIZATION_KNOWLEDGE_FEATURE) === true &&
     daemon.capabilities.features.includes(ORGANIZATION_SUGGESTION_REVIEW_FEATURE)
   )
@@ -531,12 +535,16 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
           return unavailable(reply)
         }
         try {
-          const content = await deps.control.organizationSuggestionRead(suggestion.sourceDaemonId, {
-            sourceAgentId: suggestion.sourceAgentId,
-            dreamId: suggestion.dreamId,
-            candidateId: suggestion.candidateId,
-            kind: suggestion.kind
-          })
+          const content = await deps.control.organizationSuggestionRead(
+            suggestion.sourceDaemonId,
+            {
+              sourceAgentId: suggestion.sourceAgentId,
+              dreamId: suggestion.dreamId,
+              candidateId: suggestion.candidateId,
+              kind: suggestion.kind
+            },
+            orgOf(req)
+          )
           if (!content.exists || !content.body || !suggestionContentMatches(suggestion, content.digest, content.body)) {
             return reply.code(409).send({
               error: 'Conflict',
@@ -614,12 +622,16 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
             })
           }
           void deps.control
-            .organizationSuggestionReview(suggestion.sourceDaemonId, {
-              sourceAgentId: suggestion.sourceAgentId,
-              dreamId: suggestion.dreamId,
-              candidateId: suggestion.candidateId,
-              state: 'rejected'
-            })
+            .organizationSuggestionReview(
+              suggestion.sourceDaemonId,
+              {
+                sourceAgentId: suggestion.sourceAgentId,
+                dreamId: suggestion.dreamId,
+                candidateId: suggestion.candidateId,
+                state: 'rejected'
+              },
+              orgOf(req)
+            )
             .catch((err) =>
               app.log.warn(
                 { err, suggestionId: suggestion.id, decision: 'rejected' },
@@ -644,12 +656,16 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
         }
         let content
         try {
-          content = await deps.control.organizationSuggestionRead(suggestion.sourceDaemonId, {
-            sourceAgentId: suggestion.sourceAgentId,
-            dreamId: suggestion.dreamId,
-            candidateId: suggestion.candidateId,
-            kind: suggestion.kind
-          })
+          content = await deps.control.organizationSuggestionRead(
+            suggestion.sourceDaemonId,
+            {
+              sourceAgentId: suggestion.sourceAgentId,
+              dreamId: suggestion.dreamId,
+              candidateId: suggestion.candidateId,
+              kind: suggestion.kind
+            },
+            orgOf(req)
+          )
         } catch (err) {
           if (suggestionReadUnavailable(err)) {
             app.log.warn({ err, suggestionId: suggestion.id }, 'organization suggestion acceptance read unavailable')
@@ -718,12 +734,16 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
         }
 
         void deps.control
-          .organizationSuggestionReview(suggestion.sourceDaemonId, {
-            sourceAgentId: suggestion.sourceAgentId,
-            dreamId: suggestion.dreamId,
-            candidateId: suggestion.candidateId,
-            state: 'accepted'
-          })
+          .organizationSuggestionReview(
+            suggestion.sourceDaemonId,
+            {
+              sourceAgentId: suggestion.sourceAgentId,
+              dreamId: suggestion.dreamId,
+              candidateId: suggestion.candidateId,
+              state: 'accepted'
+            },
+            orgOf(req)
+          )
           .catch((err) =>
             app.log.warn(
               { err, suggestionId: suggestion.id, decision: 'accepted' },

--- a/packages/control-plane/src/orchestrator/outbound.organization-knowledge.test.ts
+++ b/packages/control-plane/src/orchestrator/outbound.organization-knowledge.test.ts
@@ -77,13 +77,17 @@ describe('ControlSender organization suggestion content', () => {
       1,
       'knowledge/suggestion/read',
       expect.objectContaining({ offset: 0, limit: ORGANIZATION_SUGGESTION_CHUNK_BYTES }),
-      { epoch: 7 }
+      { epoch: 7 },
+      undefined,
+      undefined
     )
     expect(request).toHaveBeenNthCalledWith(
       2,
       'knowledge/suggestion/read',
       expect.objectContaining({ offset: ORGANIZATION_SUGGESTION_CHUNK_BYTES }),
-      { epoch: 7 }
+      { epoch: 7 },
+      undefined,
+      undefined
     )
   })
 
@@ -153,5 +157,42 @@ describe('ControlSender organization suggestion content', () => {
         kind: 'knowledge'
       })
     ).rejects.toThrow('mismatched digest')
+  })
+
+  // #968: a duty holder never registered the agent, so the connection's id→org map cannot name the
+  // org for it. Both downlink sends therefore state it, exactly as the lifecycle sends do.
+  it('states the organization explicitly on the review and content sends', async () => {
+    const body = Buffer.from(JSON.stringify({ kind: 'knowledge', content: 'runbook' }))
+    const seen: (string | undefined)[] = []
+    const request = vi.fn(async (type: string, _payload, _ext, _opts, orgId?: string) => {
+      seen.push(orgId)
+      if (type === 'knowledge/suggestion/review') return {}
+      return {
+        sourceAgentId: AGENT,
+        dreamId: 'dream-1',
+        candidateId: CANDIDATE,
+        digest: digest('runbook'),
+        exists: true,
+        size: body.byteLength,
+        offset: 0,
+        nextOffset: body.byteLength,
+        data: body.toString('base64'),
+        truncated: false
+      }
+    })
+    const sender = senderWith(request as unknown as ConnChannel['request'])
+
+    await sender.organizationSuggestionRead(
+      DAEMON,
+      { sourceAgentId: AGENT, dreamId: 'dream-1', candidateId: CANDIDATE, kind: 'knowledge' },
+      'org-b'
+    )
+    await sender.organizationSuggestionReview(
+      DAEMON,
+      { sourceAgentId: AGENT, dreamId: 'dream-1', candidateId: CANDIDATE, state: 'accepted' },
+      'org-b'
+    )
+
+    expect(seen).toEqual(['org-b', 'org-b'])
   })
 })

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -714,7 +714,8 @@ export class ControlSender {
 
   async organizationSuggestionRead(
     daemonId: string,
-    req: Omit<OrganizationSuggestionReadReq, 'offset' | 'limit'>
+    req: Omit<OrganizationSuggestionReadReq, 'offset' | 'limit'>,
+    orgId?: string
   ): Promise<OrganizationSuggestionContent> {
     const c = this.must(daemonId)
     const chunks: Buffer[] = []
@@ -725,7 +726,9 @@ export class ControlSender {
       const chunk = await c.conn.request<OrganizationSuggestionChunk>(
         'knowledge/suggestion/read',
         { ...req, offset, limit: ORGANIZATION_SUGGESTION_CHUNK_BYTES },
-        { epoch: c.sessionEpoch }
+        { epoch: c.sessionEpoch },
+        undefined,
+        orgId
       )
       if (
         chunk.sourceAgentId !== req.sourceAgentId ||
@@ -795,9 +798,14 @@ export class ControlSender {
     }
   }
 
-  async organizationSuggestionReview(daemonId: string, req: OrganizationSuggestionReviewReq): Promise<Ack> {
+  /** `orgId` is explicit: an install-wide holder resolves no org from a bare source-agent id. */
+  async organizationSuggestionReview(
+    daemonId: string,
+    req: OrganizationSuggestionReviewReq,
+    orgId?: string
+  ): Promise<Ack> {
     const c = this.must(daemonId)
-    return c.conn.request<Ack>('knowledge/suggestion/review', req, { epoch: c.sessionEpoch })
+    return c.conn.request<Ack>('knowledge/suggestion/review', req, { epoch: c.sessionEpoch }, undefined, orgId)
   }
 
   /**

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
@@ -6,6 +6,9 @@ import {
 } from '@agentconnect.md/protocol'
 import type { DaemonConnection } from '../connection.js'
 import type { DaemonWsDeps } from '../deps.js'
+import { PlacementResolver } from '../../orchestrator/placementResolver.js'
+import { systemClock } from '../../domain/clock.js'
+import type { DaemonId } from '../../domain/ids.js'
 import {
   handleKnowledgeSearch,
   handleKnowledgeList,
@@ -24,6 +27,17 @@ const ORG_B = 'org-b'
 
 const installWideCapabilities = {
   features: [ORGANIZATION_KNOWLEDGE_FEATURE, ORGANIZATION_SUGGESTION_REVIEW_FEATURE]
+}
+
+/** A pool row: placed, naming no machine. `agent.daemonId` can never authorize one. */
+function poolAgent(id: string) {
+  return { id, placementKind: 'pool' as const, daemonId: null }
+}
+
+/** The live seam, keyed by who holds each agent's duty right now. */
+function holderOf(holds: Record<string, string[]>): PlacementResolver {
+  const of = async (agentId: string) => (holds[String(agentId)] ?? []) as DaemonId[]
+  return new PlacementResolver({ duties: { holdersOf: of, confirmedHoldersOf: of }, clock: systemClock })
 }
 
 function proposed(sourceAgentId: string) {
@@ -410,18 +424,20 @@ describe('handleOrganizationSuggestionsSync', () => {
     expect(connection.replyTo.mock.calls[0]![2]).toEqual({ decisions: [] })
   })
 
-  // #968: a pool member is an org-less per-Pod record, so the connection has no org to derive.
+  // #968: a pool member is an org-less per-Pod record, so the connection has no org to derive —
+  // and the agents it dreams for are pool rows naming no machine at all.
   it('records each org-scoped frame from one install-wide member under the org it names', async () => {
     const syncSuggestions = vi.fn(async (_orgId, _daemonId, suggestions) =>
       suggestions.map((s: { sourceAgentId: string }) => ({ ...s, id: 'suggestion-id', state: 'pending' }))
     )
-    const byOrg: Record<string, { id: string; daemonId: string }[]> = {
-      [ORG_A]: [{ id: AGENT, daemonId: DAEMON }],
-      [ORG_B]: [{ id: FOREIGN_AGENT, daemonId: DAEMON }]
+    const byOrg: Record<string, ReturnType<typeof poolAgent>[]> = {
+      [ORG_A]: [poolAgent(AGENT)],
+      [ORG_B]: [poolAgent(FOREIGN_AGENT)]
     }
     const deps = {
       registry: { getUnscoped: async () => ({ id: DAEMON, orgId: null, capabilities: installWideCapabilities }) },
       agent: { list: async (orgId: string) => byOrg[orgId] ?? [] },
+      placementResolver: holderOf({ [AGENT]: [DAEMON], [FOREIGN_AGENT]: [DAEMON] }),
       organizationKnowledge: { syncSuggestions }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -447,6 +463,7 @@ describe('handleOrganizationSuggestionsSync', () => {
     const deps = {
       registry: { getUnscoped: async () => ({ id: DAEMON, orgId: null, capabilities: installWideCapabilities }) },
       agent: { list: async () => [] },
+      placementResolver: holderOf({ [AGENT]: [DAEMON] }),
       organizationKnowledge: { syncSuggestions }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -461,11 +478,35 @@ describe('handleOrganizationSuggestionsSync', () => {
     expect(syncSuggestions).toHaveBeenCalledWith(ORG_B, DAEMON, [])
   })
 
+  it('refuses a pool agent this member holds no duty for', async () => {
+    const syncSuggestions = vi.fn(async () => [])
+    const deps = {
+      registry: { getUnscoped: async () => ({ id: DAEMON, orgId: null, capabilities: installWideCapabilities }) },
+      agent: { list: async () => [poolAgent(AGENT), poolAgent(FOREIGN_AGENT)] },
+      // The foreign agent's duty is held by another member, so this connection may not report it.
+      placementResolver: holderOf({ [AGENT]: [DAEMON], [FOREIGN_AGENT]: ['another-member'] }),
+      organizationKnowledge: { syncSuggestions }
+    } as unknown as DaemonWsDeps
+    const connection = conn()
+
+    await handleOrganizationSuggestionsSync(
+      {
+        ...frame('knowledge/suggestions/sync', { suggestions: [proposed(AGENT), proposed(FOREIGN_AGENT)] }),
+        orgId: ORG_A
+      },
+      connection,
+      deps
+    )
+
+    expect(syncSuggestions).toHaveBeenCalledWith(ORG_A, DAEMON, [proposed(AGENT)])
+  })
+
   it('refuses an unscoped frame from an install-wide member', async () => {
     const syncSuggestions = vi.fn(async () => [])
     const deps = {
       registry: { getUnscoped: async () => ({ id: DAEMON, orgId: null, capabilities: installWideCapabilities }) },
-      agent: { list: async () => [{ id: AGENT, daemonId: DAEMON }] },
+      agent: { list: async () => [poolAgent(AGENT)] },
+      placementResolver: holderOf({ [AGENT]: [DAEMON] }),
       organizationKnowledge: { syncSuggestions }
     } as unknown as DaemonWsDeps
     const connection = conn()

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
@@ -19,6 +19,28 @@ const AGENT = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const FOREIGN_AGENT = 'a1a1a1a1-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const ORG = 'org-default'
 const SKILL = '51515151-5151-4515-8515-515151515151'
+const ORG_A = 'org-a'
+const ORG_B = 'org-b'
+
+const installWideCapabilities = {
+  features: [ORGANIZATION_KNOWLEDGE_FEATURE, ORGANIZATION_SUGGESTION_REVIEW_FEATURE]
+}
+
+function proposed(sourceAgentId: string) {
+  return {
+    sourceAgentId,
+    dreamId: `dream-${sourceAgentId.slice(0, 4)}`,
+    candidateId: '33333333-3333-4333-8333-333333333333',
+    kind: 'knowledge',
+    operation: 'create',
+    title: 'Candidate',
+    digest: `sha256:${'a'.repeat(64)}`,
+    contentBytes: 10,
+    state: 'proposed',
+    sessionIds: ['session-1'],
+    createdAt: '2026-08-01T00:00:00.000Z'
+  }
+}
 
 function frame(type: AnyFrame['type'], payload: Record<string, unknown>): AnyFrame {
   return {
@@ -386,6 +408,76 @@ describe('handleOrganizationSuggestionsSync', () => {
 
     expect(syncSuggestions).toHaveBeenCalledWith(ORG, DAEMON, [suggestion])
     expect(connection.replyTo.mock.calls[0]![2]).toEqual({ decisions: [] })
+  })
+
+  // #968: a pool member is an org-less per-Pod record, so the connection has no org to derive.
+  it('records each org-scoped frame from one install-wide member under the org it names', async () => {
+    const syncSuggestions = vi.fn(async (_orgId, _daemonId, suggestions) =>
+      suggestions.map((s: { sourceAgentId: string }) => ({ ...s, id: 'suggestion-id', state: 'pending' }))
+    )
+    const byOrg: Record<string, { id: string; daemonId: string }[]> = {
+      [ORG_A]: [{ id: AGENT, daemonId: DAEMON }],
+      [ORG_B]: [{ id: FOREIGN_AGENT, daemonId: DAEMON }]
+    }
+    const deps = {
+      registry: { getUnscoped: async () => ({ id: DAEMON, orgId: null, capabilities: installWideCapabilities }) },
+      agent: { list: async (orgId: string) => byOrg[orgId] ?? [] },
+      organizationKnowledge: { syncSuggestions }
+    } as unknown as DaemonWsDeps
+    const connection = conn()
+
+    await handleOrganizationSuggestionsSync(
+      { ...frame('knowledge/suggestions/sync', { suggestions: [proposed(AGENT)] }), orgId: ORG_A },
+      connection,
+      deps
+    )
+    await handleOrganizationSuggestionsSync(
+      { ...frame('knowledge/suggestions/sync', { suggestions: [proposed(FOREIGN_AGENT)] }), orgId: ORG_B },
+      connection,
+      deps
+    )
+
+    expect(connection.sendError).not.toHaveBeenCalled()
+    expect(syncSuggestions).toHaveBeenNthCalledWith(1, ORG_A, DAEMON, [proposed(AGENT)])
+    expect(syncSuggestions).toHaveBeenNthCalledWith(2, ORG_B, DAEMON, [proposed(FOREIGN_AGENT)])
+  })
+
+  it('refuses an org-scoped frame that names an org the sending agent is not in', async () => {
+    const syncSuggestions = vi.fn(async () => [])
+    const deps = {
+      registry: { getUnscoped: async () => ({ id: DAEMON, orgId: null, capabilities: installWideCapabilities }) },
+      agent: { list: async () => [] },
+      organizationKnowledge: { syncSuggestions }
+    } as unknown as DaemonWsDeps
+    const connection = conn()
+
+    await handleOrganizationSuggestionsSync(
+      { ...frame('knowledge/suggestions/sync', { suggestions: [proposed(AGENT)] }), orgId: ORG_B },
+      connection,
+      deps
+    )
+
+    // The allowed set is still the fence: an org that holds none of this member's agents records nothing.
+    expect(syncSuggestions).toHaveBeenCalledWith(ORG_B, DAEMON, [])
+  })
+
+  it('refuses an unscoped frame from an install-wide member', async () => {
+    const syncSuggestions = vi.fn(async () => [])
+    const deps = {
+      registry: { getUnscoped: async () => ({ id: DAEMON, orgId: null, capabilities: installWideCapabilities }) },
+      agent: { list: async () => [{ id: AGENT, daemonId: DAEMON }] },
+      organizationKnowledge: { syncSuggestions }
+    } as unknown as DaemonWsDeps
+    const connection = conn()
+
+    await handleOrganizationSuggestionsSync(
+      frame('knowledge/suggestions/sync', { suggestions: [proposed(AGENT)] }),
+      connection,
+      deps
+    )
+
+    expect(syncSuggestions).not.toHaveBeenCalled()
+    expect(connection.sendError.mock.calls[0]![1]).toBe('SCOPE_DENIED')
   })
 })
 

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.ts
@@ -4,6 +4,7 @@ import {
   ORGANIZATION_SUGGESTION_REVIEW_FEATURE
 } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
+import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import type { DaemonView } from '../../ports.js'
 import type { Handler } from './index.js'
 
@@ -142,7 +143,7 @@ export const handleOrgSkills: Handler = async (frame, conn, deps) => {
   })
 }
 
-/** Reconnect/completion inventory upsert. Only currently placed agents may
+/** Reconnect/completion inventory upsert. Only agents this member currently SERVES may
  * publish metadata; CP review state stays authoritative. */
 export const handleOrganizationSuggestionsSync: Handler = async (frame, conn, deps) => {
   if (!isFrame('knowledge/suggestions/sync')(frame)) return
@@ -158,10 +159,19 @@ export const handleOrganizationSuggestionsSync: Handler = async (frame, conn, de
     conn.sendError(frame.id, 'INTERNAL', 'organization knowledge is unavailable', true)
     return
   }
-  const agents = await deps.agent.list(orgId)
-  const allowed = new Set(
-    agents.filter((agent) => agent.daemonId === DaemonId(conn.daemonId)).map((agent) => String(agent.id))
+  // Authority is the live seam, never `agent.daemonId`: a pool agent names no machine, so
+  // placement equality would silently empty the inventory of the very members that dream.
+  const resolver = deps.placementResolver ?? PLACEMENT_ONLY
+  const claimed = new Set(
+    frame.payload.suggestions
+      .filter((suggestion) => suggestion.state === 'proposed')
+      .map((suggestion) => suggestion.sourceAgentId)
   )
+  const allowed = new Set<string>()
+  for (const agent of await deps.agent.list(orgId)) {
+    if (!claimed.has(String(agent.id))) continue
+    if (await resolver.mayAct(agent, conn.daemonId)) allowed.add(String(agent.id))
+  }
   const proposed = frame.payload.suggestions.filter(
     (suggestion) => suggestion.state === 'proposed' && allowed.has(suggestion.sourceAgentId)
   )

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -32,6 +32,7 @@ import {
   PgLaunchRepo,
   PgMemoryPluginInstallationRepo,
   PgExternalMemoryConnectionRepo,
+  PgOrganizationKnowledgeRepo,
   PgExternalMemoryConnectionSecretStore,
   PgExternalMemoryGrantRepo,
   PgMcpProviderRepo,
@@ -146,6 +147,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     launch: new PgLaunchRepo(prisma),
     memoryPluginInstallation: new PgMemoryPluginInstallationRepo(prisma),
     externalMemoryConnection: new PgExternalMemoryConnectionRepo(prisma),
+    organizationKnowledge: new PgOrganizationKnowledgeRepo(prisma),
     externalMemoryConnectionSecret: new PgExternalMemoryConnectionSecretStore(prisma, cipher),
     externalMemoryGrant: new PgExternalMemoryGrantRepo(prisma, cipher),
     mcpProvider: new PgMcpProviderRepo(prisma),
@@ -293,6 +295,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     cron: repos.cron,
     hook: repos.hook,
     externalMemoryConnection: repos.externalMemoryConnection,
+    organizationKnowledge: repos.organizationKnowledge,
     relayRoster: async () => relays,
     clock,
     config: {

--- a/packages/control-plane/test/integration/organization-knowledge.route.test.ts
+++ b/packages/control-plane/test/integration/organization-knowledge.route.test.ts
@@ -12,7 +12,7 @@ import {
   organizationSuggestionCanonical
 } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
-import { DEF_ORG, seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { DEF_ORG, seedAgent, seedDaemon, seedDutyGroup } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { NoConnection, type ControlSender } from '../../src/orchestrator/outbound.js'
@@ -976,5 +976,105 @@ describe('managed organization skills', () => {
     expect(
       (await owner.app.inject({ method: 'GET', url: `${ORG}/managed-skills?includeArchived=true` })).json()
     ).toHaveLength(1)
+  })
+})
+
+describe('Dream organization suggestion review on a pool member', () => {
+  // #968: a pool agent names no machine, so `agent.daemonId` can never equal the member that
+  // staged the bytes. Review has to resolve the target the way every other update now does.
+  it('reaches the duty holder that dreamt it, not the agent placement', async () => {
+    const sourceAgentId = randomUUID()
+    await seedDaemon(prisma, DAEMON, {
+      capabilities: {
+        platforms: [],
+        runtimes: ['claude'],
+        acp: true,
+        features: [ORGANIZATION_KNOWLEDGE_FEATURE, ORGANIZATION_SUGGESTION_REVIEW_FEATURE]
+      }
+    })
+    await seedAgent(prisma, sourceAgentId, { name: 'pool-dreamer' })
+    await prisma.agent.update({
+      where: { id: sourceAgentId },
+      data: { placementKind: 'pool', daemonId: null }
+    })
+    await seedDutyGroup(prisma, randomUUID(), DAEMON, [sourceAgentId])
+
+    const control = new KnowledgeControl()
+    const owner = app({ control, connected: true })
+    const repo = owner.deps.repos.organizationKnowledge!
+    const [pending] = await repo.syncSuggestions(DEF_ORG, DAEMON, [
+      {
+        sourceAgentId,
+        dreamId: 'dream-pool-1',
+        candidateId: randomUUID(),
+        kind: 'knowledge',
+        operation: 'create',
+        title: 'Staged on the holder',
+        digest: digest('unused'),
+        contentBytes: 16,
+        state: 'proposed',
+        sessionIds: ['session-1'],
+        createdAt: '2026-08-01T00:00:00.000Z'
+      }
+    ])
+
+    const listed = await owner.app.inject({ method: 'GET', url: `${ORG}/knowledge-suggestions?state=pending` })
+    expect(listed.json()).toMatchObject([{ id: pending!.id, contentAvailable: true }])
+
+    const rejected = await owner.app.inject({
+      method: 'POST',
+      url: `${ORG}/knowledge-suggestions/${pending!.id}/review`,
+      payload: { decision: 'reject', reason: 'not useful' }
+    })
+
+    expect(rejected.statusCode).toBe(200)
+    expect(control.reviews).toMatchObject([{ daemonId: DAEMON, request: { sourceAgentId, state: 'rejected' } }])
+  })
+
+  it('reports the suggestion unavailable once the holder no longer serves the agent', async () => {
+    const sourceAgentId = randomUUID()
+    await seedDaemon(prisma, DAEMON, {
+      capabilities: {
+        platforms: [],
+        runtimes: ['claude'],
+        acp: true,
+        features: [ORGANIZATION_KNOWLEDGE_FEATURE, ORGANIZATION_SUGGESTION_REVIEW_FEATURE]
+      }
+    })
+    await seedAgent(prisma, sourceAgentId, { name: 'pool-dreamer-expired' })
+    await prisma.agent.update({
+      where: { id: sourceAgentId },
+      data: { placementKind: 'pool', daemonId: null }
+    })
+    // An expired lease is how the ledger says "this member stopped serving it".
+    await seedDutyGroup(prisma, randomUUID(), DAEMON, [sourceAgentId], { expiresAt: new Date(Date.now() - 60_000) })
+
+    const control = new KnowledgeControl()
+    const owner = app({ control, connected: true })
+    const repo = owner.deps.repos.organizationKnowledge!
+    const [pending] = await repo.syncSuggestions(DEF_ORG, DAEMON, [
+      {
+        sourceAgentId,
+        dreamId: 'dream-pool-2',
+        candidateId: randomUUID(),
+        kind: 'knowledge',
+        operation: 'create',
+        title: 'Staged on a member that left',
+        digest: digest('unused'),
+        contentBytes: 16,
+        state: 'proposed',
+        sessionIds: ['session-1'],
+        createdAt: '2026-08-01T00:00:00.000Z'
+      }
+    ])
+
+    const rejected = await owner.app.inject({
+      method: 'POST',
+      url: `${ORG}/knowledge-suggestions/${pending!.id}/review`,
+      payload: { decision: 'reject', reason: 'not useful' }
+    })
+
+    expect(rejected.statusCode).toBe(503)
+    expect(control.reviews).toEqual([])
   })
 })

--- a/packages/control-plane/test/protocol/fencing.test.ts
+++ b/packages/control-plane/test/protocol/fencing.test.ts
@@ -28,6 +28,7 @@ const DAEMON = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
 const AGENT = 'a1a1a1a1-a1a1-4a1a-8a1a-a1a1a1a1a1a1'
 const LAUNCH = '11111111-1111-4111-8111-111111111111'
 const OLD_LAUNCH = '99999999-9999-4999-8999-999999999999'
+const FOREIGN_AGENT = 'a2a2a2a2-a2a2-4a2a-8a2a-a2a2a2a2a2a2'
 
 /** Minimal deps — fencing is pure FSM logic, no DB/auth/registry needed. */
 function fencingDeps(clock: FakeClock): DaemonWsDeps {
@@ -227,5 +228,33 @@ describe('organization gate', () => {
     const err = stub.lastSent('error')
     if (!err || !isFrame('error')(err)) throw new Error('expected error frame')
     expect(err.payload.code).toBe('SCOPE_DENIED')
+  })
+
+  // #968: the replay a pool member sends after READY. Unscoped it never reaches the handler.
+  it('rejects an unscoped organization-suggestion sync from an install-wide daemon', () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    const id = stub.inject('knowledge/suggestions/sync', { suggestions: [] })
+    const err = stub.lastSent('error')
+    if (!err || !isFrame('error')(err)) throw new Error('expected error frame')
+    expect(err.corr).toBe(id)
+    expect(err.payload.code).toBe('SCOPE_DENIED')
+  })
+
+  it('accepts an org-scoped organization-suggestion sync from an install-wide daemon', () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    stub.inject('knowledge/suggestions/sync', { suggestions: [] }, { orgId: 'org-a' })
+    expect(stub.lastSent('error')).toBeUndefined()
+  })
+
+  // A duty holder never registered the agent, so the id→org map cannot answer for it.
+  it('stamps the caller-supplied organization on a suggestion review the map cannot resolve', () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    const review = { sourceAgentId: FOREIGN_AGENT, dreamId: 'dream-1', candidateId: LAUNCH, state: 'accepted' }
+    expect(() => conn.send('knowledge/suggestion/review', review, { epoch: 5 })).toThrow(/organization is required/)
+    conn.send('knowledge/suggestion/review', review, { epoch: 5 }, 'org-b')
+    expect(stub.lastSent('knowledge/suggestion/review')?.orgId).toBe('org-b')
   })
 })

--- a/packages/control-plane/test/protocol/organization-suggestion-sync.handler.test.ts
+++ b/packages/control-plane/test/protocol/organization-suggestion-sync.handler.test.ts
@@ -1,0 +1,134 @@
+// The organization-suggestion replay a pool member sends after READY (#968). The frame is
+// org-scoped by nature, and the authority for each source agent is the LIVE seam — placement plus
+// the duty leases this member holds — never `agent.daemonId`, which a pool agent leaves null.
+import { randomUUID } from 'node:crypto'
+import { describe, it, expect } from 'vitest'
+import {
+  isFrame,
+  ORGANIZATION_KNOWLEDGE_FEATURE,
+  ORGANIZATION_SUGGESTION_REVIEW_FEATURE
+} from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { buildWsHarness } from '../fakes/build-ws.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const DAEMON = 'd1111111-1111-4111-8111-111111111111'
+const OTHER = 'd2222222-2222-4222-8222-222222222222'
+const AUTH_ID = '99999999-9999-4999-8999-999999999999'
+const REG_ID = '88888888-8888-4888-8888-888888888888'
+
+/** A pool agent: placed, but naming no machine. Only the ledger can say who serves it. */
+async function seedPoolAgent(): Promise<string> {
+  const id = randomUUID()
+  await prisma.agent.create({
+    data: { id, orgId: DEFAULT_ORG_ID, name: `dreamer-${id.slice(0, 8)}`, runtime: 'claude', placementKind: 'pool' }
+  })
+  return id
+}
+
+async function seedLease(holder: string, agentId: string, expiresAt: Date): Promise<void> {
+  const groupId = randomUUID()
+  await prisma.dutyGroup.create({ data: { id: groupId, orgId: DEFAULT_ORG_ID, holder, term: 1n, expiresAt } })
+  await prisma.dutyGroupMember.create({ data: { kind: 'agent', refId: agentId, groupId, orgId: DEFAULT_ORG_ID } })
+}
+
+/** An install-wide (frame-mode) member advertising the organization-knowledge surface. */
+async function readyMember(h: ReturnType<typeof buildWsHarness>) {
+  const { stub } = h.connect()
+  const saToken = await h.mintCloudDaemon(DAEMON)
+  stub.inject('auth', { serviceAccountToken: saToken, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
+  await stub.expectFrame('auth/ok')
+  stub.inject(
+    'register',
+    {
+      host: 'member-1',
+      capabilities: {
+        platforms: [],
+        runtimes: ['claude'],
+        acp: true,
+        features: [ORGANIZATION_KNOWLEDGE_FEATURE, ORGANIZATION_SUGGESTION_REVIEW_FEATURE]
+      },
+      maxAgents: 8,
+      localState: { assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }
+    },
+    { id: REG_ID }
+  )
+  await stub.expectFrame('register/ok')
+  return stub
+}
+
+function suggestion(sourceAgentId: string) {
+  return {
+    sourceAgentId,
+    dreamId: `dream-${sourceAgentId.slice(0, 8)}`,
+    candidateId: randomUUID(),
+    kind: 'knowledge',
+    operation: 'create',
+    title: 'Staged on the member that dreamt it',
+    digest: `sha256:${'a'.repeat(64)}`,
+    contentBytes: 24,
+    state: 'proposed',
+    sessionIds: ['session-1'],
+    createdAt: '2026-08-01T00:00:00.000Z'
+  }
+}
+
+describe('knowledge/suggestions/sync from an install-wide member', () => {
+  it('records suggestions for a pool agent whose duty this member holds', async () => {
+    const h = buildWsHarness(prisma)
+    const agentId = await seedPoolAgent()
+    await seedLease(DAEMON, agentId, new Date(h.clock.now() + 120_000))
+    const stub = await readyMember(h)
+
+    const id = stub.inject(
+      'knowledge/suggestions/sync',
+      { suggestions: [suggestion(agentId)] },
+      { orgId: DEFAULT_ORG_ID }
+    )
+    const ok = await stub.expectFrame('knowledge/suggestions/sync/ok')
+
+    expect(ok.corr).toBe(id)
+    expect(stub.sent.find((f) => isFrame('error')(f))).toBeUndefined()
+    // The whole point: the reply is not an empty success. The row is really there.
+    expect(await prisma.organizationSuggestion.findMany({ where: { sourceAgentId: agentId } })).toMatchObject([
+      { orgId: DEFAULT_ORG_ID, sourceDaemonId: DAEMON, state: 'pending' }
+    ])
+  })
+
+  it('records nothing for an agent no live duty of this member covers', async () => {
+    const h = buildWsHarness(prisma)
+    const held = await seedPoolAgent()
+    const foreign = await seedPoolAgent()
+    const lapsed = await seedPoolAgent()
+    await seedLease(DAEMON, held, new Date(h.clock.now() + 120_000))
+    // Held by a different member, and held by this one but expired: neither is authority.
+    await prisma.daemon.create({ data: { id: OTHER, orgId: null, maxAgents: 8, status: 'ready' } })
+    await seedLease(OTHER, foreign, new Date(h.clock.now() + 120_000))
+    await seedLease(DAEMON, lapsed, new Date(h.clock.now() - 60_000))
+    const stub = await readyMember(h)
+
+    stub.inject(
+      'knowledge/suggestions/sync',
+      { suggestions: [suggestion(held), suggestion(foreign), suggestion(lapsed)] },
+      { orgId: DEFAULT_ORG_ID }
+    )
+    await stub.expectFrame('knowledge/suggestions/sync/ok')
+
+    const rows = await prisma.organizationSuggestion.findMany({ where: { sourceDaemonId: DAEMON } })
+    expect(rows.map((row) => row.sourceAgentId)).toEqual([held])
+  })
+
+  it('still records for a machine-placed agent this member is the placement of', async () => {
+    const h = buildWsHarness(prisma)
+    const stub = await readyMember(h)
+    const agentId = randomUUID()
+    await prisma.agent.create({
+      data: { id: agentId, orgId: DEFAULT_ORG_ID, name: 'pinned-dreamer', runtime: 'claude', daemonId: DAEMON }
+    })
+
+    stub.inject('knowledge/suggestions/sync', { suggestions: [suggestion(agentId)] }, { orgId: DEFAULT_ORG_ID })
+    await stub.expectFrame('knowledge/suggestions/sync/ok')
+
+    expect(await prisma.organizationSuggestion.count({ where: { sourceAgentId: agentId } })).toBe(1)
+  })
+})

--- a/packages/control-plane/test/repo/organization-suggestion-scope.repo.test.ts
+++ b/packages/control-plane/test/repo/organization-suggestion-scope.repo.test.ts
@@ -1,0 +1,67 @@
+/** Real-Postgres coverage for an install-wide member syncing suggestions for several orgs (#968). */
+import { randomUUID } from 'node:crypto'
+import { describe, it, expect } from 'vitest'
+import { prisma } from '../setup.db.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { PgOrganizationKnowledgeRepo } from '../../src/persistence/repositories/organization-knowledge.repo.js'
+import { OrgId } from '../../src/domain/ids.js'
+
+const DEF_ORG = OrgId(DEFAULT_ORG_ID)
+const DAEMON = 'd0d0d0d0-dddd-4ddd-8ddd-dddddddddddd'
+
+function suggestion(sourceAgentId: string, title: string) {
+  return {
+    sourceAgentId,
+    dreamId: `dream-${sourceAgentId.slice(0, 8)}`,
+    candidateId: randomUUID(),
+    kind: 'knowledge' as const,
+    operation: 'create' as const,
+    title,
+    digest: `sha256:${'a'.repeat(64)}`,
+    contentBytes: 32,
+    state: 'proposed' as const,
+    sessionIds: ['session-1'],
+    createdAt: '2026-08-01T00:00:00.000Z'
+  }
+}
+
+describe('PgOrganizationKnowledgeRepo.syncSuggestions across organizations', () => {
+  it('keeps one member’s per-org frames independent instead of replacing by daemon', async () => {
+    const repo = new PgOrganizationKnowledgeRepo(prisma)
+    const other = await prisma.org.create({ data: { slug: `suggestion-scope-${randomUUID().slice(0, 8)}` } })
+    const otherOrg = OrgId(other.id)
+    await seedDaemon(prisma, DAEMON)
+    const agentA = await seedAgent(prisma, randomUUID(), { daemonId: DAEMON })
+    const agentB = randomUUID()
+    await prisma.agent.create({ data: { id: agentB, orgId: other.id, name: 'dreamer-b', runtime: 'claude' } })
+
+    const first = suggestion(agentA, 'From org A')
+    const second = suggestion(agentB, 'From org B')
+    // The same member, one frame per org — the second must not sweep the first away.
+    await repo.syncSuggestions(DEF_ORG, DAEMON, [first])
+    await repo.syncSuggestions(otherOrg, DAEMON, [second])
+
+    expect((await repo.listSuggestions(DEF_ORG)).map((row) => row.title)).toEqual(['From org A'])
+    expect((await repo.listSuggestions(otherOrg)).map((row) => row.title)).toEqual(['From org B'])
+    expect(await prisma.organizationSuggestion.count({ where: { sourceDaemonId: DAEMON } })).toBe(2)
+  })
+
+  it('re-syncs an org without disturbing the other org it shares a member with', async () => {
+    const repo = new PgOrganizationKnowledgeRepo(prisma)
+    const other = await prisma.org.create({ data: { slug: `suggestion-scope-${randomUUID().slice(0, 8)}` } })
+    const otherOrg = OrgId(other.id)
+    await seedDaemon(prisma, DAEMON)
+    const agentA = await seedAgent(prisma, randomUUID(), { daemonId: DAEMON })
+    const agentB = randomUUID()
+    await prisma.agent.create({ data: { id: agentB, orgId: other.id, name: 'dreamer-b', runtime: 'claude' } })
+    await repo.syncSuggestions(DEF_ORG, DAEMON, [suggestion(agentA, 'From org A')])
+    await repo.syncSuggestions(otherOrg, DAEMON, [suggestion(agentB, 'From org B')])
+
+    // An empty replay for one org is a no-op there and invisible to the other.
+    await repo.syncSuggestions(otherOrg, DAEMON, [])
+
+    expect((await repo.listSuggestions(DEF_ORG)).map((row) => row.title)).toEqual(['From org A'])
+    expect((await repo.listSuggestions(otherOrg)).map((row) => row.title)).toEqual(['From org B'])
+  })
+})

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6418,32 +6418,37 @@ export class Daemon {
     const client = this.cpClient
     if (!client || !client.supportsServerFeature?.(ORGANIZATION_KNOWLEDGE_FEATURE)) return
     const runner = this.dreamRunner()
+    // Install-wide connection: this frame is org-scoped by nature and there is no connection org behind it.
+    const frameScoped = client.organizationScope?.() === 'frame'
     const byOrg = new Map<string | undefined, ReturnType<DreamRunner['organizationSuggestionInventory']>>()
     const inventory = runner.organizationSuggestionInventory()
     for (const suggestion of inventory) {
       const orgId = this.cpAgents?.orgForAgent(suggestion.sourceAgentId)
+      // An org we cannot name has no frame to ride; holding it back beats failing every other org's replay.
+      if (frameScoped && !orgId) continue
       const suggestions = byOrg.get(orgId) ?? []
       suggestions.push(suggestion)
       byOrg.set(orgId, suggestions)
     }
-    if (inventory.length === 0) {
+    if (byOrg.size === 0) {
       const orgIds = this.cpAgents?.organizationIds() ?? []
-      if (orgIds.length > 0) {
-        for (const orgId of orgIds) byOrg.set(orgId, [])
-      } else {
-        byOrg.set(undefined, [])
-      }
+      if (orgIds.length > 0) for (const orgId of orgIds) byOrg.set(orgId, [])
+      else if (!frameScoped) byOrg.set(undefined, [])
     }
-    const decisions = (
-      await Promise.all(
-        [...byOrg].map(([orgId, suggestions]) => {
-          const sync = orgId
-            ? client.syncOrganizationSuggestions({ suggestions }, orgId)
-            : client.syncOrganizationSuggestions({ suggestions })
-          return sync.then((reply) => reply.decisions)
-        })
+    // One org's refusal must not cost the others their decisions: the replay is per-org, not per-connection.
+    const replies = await Promise.allSettled(
+      [...byOrg].map(([orgId, suggestions]) =>
+        orgId
+          ? client.syncOrganizationSuggestions({ suggestions }, orgId)
+          : client.syncOrganizationSuggestions({ suggestions })
       )
-    ).flat()
+    )
+    for (const reply of replies)
+      if (reply.status === 'rejected')
+        this.log.warn(
+          `cp: organization suggestion sync refused for one organization (${reply.reason instanceof Error ? reply.reason.name : 'unknown'})`
+        )
+    const decisions = replies.flatMap((reply) => (reply.status === 'fulfilled' ? reply.value.decisions : []))
     // During the production hold, publish inventory but do not apply destructive review decisions.
     if (!this.dreamOperationsAllowed()) return
     for (const decision of decisions) await runner.organizationSuggestionReview(decision)

--- a/packages/daemon/test/organization-suggestion-sync-scope.test.ts
+++ b/packages/daemon/test/organization-suggestion-sync-scope.test.ts
@@ -1,0 +1,196 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { Daemon } from '../src/daemon.js'
+
+// An install-wide (frame-mode) member serves several orgs, so the suggestion replay is org-scoped by
+// nature: one frame per org, each naming it. A connection-mode daemon must keep sending what it did.
+const AGENT_A = 'suggestion-agent-a'
+const AGENT_B = 'suggestion-agent-b'
+const ORG_A = '00000000-0000-4000-8000-00000000000a'
+const ORG_B = '00000000-0000-4000-8000-00000000000b'
+
+function agentJson(root: string, id: string): void {
+  const dir = join(root, 'agents', id)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'agent.json'),
+    JSON.stringify({
+      id,
+      name: id,
+      status: 'active',
+      runtime: 'test',
+      workspace: { mode: 'from-scratch', path: join(dir, 'workspace') },
+      integrations: [],
+      output: { mode: 'medium' }
+    })
+  )
+}
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-suggestion-scope-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { test: { command: 'node', args: ['unused'] } }
+    })
+  )
+  agentJson(root, AGENT_A)
+  agentJson(root, AGENT_B)
+  return root
+}
+
+function hostFactory() {
+  return () => ({
+    start: vi.fn(async () => {}),
+    newSession: vi.fn(async () => 'session-1'),
+    hasSession: vi.fn(() => true),
+    modelOptions: vi.fn(() => ({ current: 'test-model', models: ['test-model'] })),
+    prompt: vi.fn(async () => ({ stopReason: 'end_turn' })),
+    cancel: vi.fn(async () => {}),
+    stop: vi.fn(async () => {})
+  })
+}
+
+function seedSuggestion(daemon: Daemon, agentId: string, candidateId: string): void {
+  const dreamId = `drm-${agentId}`
+  const body = `{"kind":"knowledge","content":"body for ${agentId}"}`
+  ;(daemon as any).store.insertDream({
+    dreamId,
+    agentId,
+    status: 'superseded',
+    trigger: 'manual',
+    sessionIds: ['session-1'],
+    snapshotDigest: `sha256:${'b'.repeat(64)}`,
+    organizationSuggestions: [
+      {
+        candidateId,
+        kind: 'knowledge',
+        operation: 'create',
+        title: `Suggestion from ${agentId}`,
+        digest: `sha256:${'a'.repeat(64)}`,
+        contentBytes: Buffer.byteLength(body),
+        state: 'proposed',
+        sessionIds: ['session-1'],
+        createdAt: '2026-08-01T00:00:00.000Z'
+      }
+    ],
+    createdAt: '2026-08-01T00:00:00.000Z',
+    endedAt: '2026-08-01T00:01:00.000Z'
+  })
+}
+
+function fakeClient(scope?: 'connection' | 'frame') {
+  const sync = vi.fn(async () => ({ decisions: [] }))
+  return {
+    sync,
+    client: {
+      supportsServerFeature: vi.fn(() => true),
+      ...(scope ? { organizationScope: vi.fn(() => scope) } : {}),
+      syncOrganizationSuggestions: sync,
+      stop: vi.fn(async () => {})
+    }
+  }
+}
+
+describe('organization suggestion sync scope', () => {
+  it('sends one org-scoped frame per org on an install-wide connection', async () => {
+    const daemon = new Daemon({ root: scaffold(), hostFactory: hostFactory() as never })
+    await daemon.start()
+    seedSuggestion(daemon, AGENT_A, '11111111-1111-4111-8111-111111111111')
+    seedSuggestion(daemon, AGENT_B, '22222222-2222-4222-8222-222222222222')
+    const orgs = new Map([
+      [AGENT_A, ORG_A],
+      [AGENT_B, ORG_B]
+    ])
+    ;(daemon as any).cpAgents = {
+      orgForAgent: (id: string) => orgs.get(id),
+      organizationIds: () => [...new Set(orgs.values())]
+    }
+    const { sync, client } = fakeClient('frame')
+    ;(daemon as any).cpClient = client
+
+    await (daemon as any).syncOrganizationSuggestions()
+
+    expect(sync).toHaveBeenCalledTimes(2)
+    const byOrg = new Map(
+      sync.mock.calls.map((call) => [
+        (call as unknown as [{ suggestions: { sourceAgentId: string }[] }, string])[1],
+        (call as unknown as [{ suggestions: { sourceAgentId: string }[] }, string])[0].suggestions.map(
+          (s) => s.sourceAgentId
+        )
+      ])
+    )
+    // Two orgs, two frames — and neither frame carries the other org's suggestion.
+    expect(byOrg.get(ORG_A)).toEqual([AGENT_A])
+    expect(byOrg.get(ORG_B)).toEqual([AGENT_B])
+    await daemon.stop()
+  }, 20_000)
+
+  it('sends nothing unscoped on an install-wide connection with no resolvable org', async () => {
+    const daemon = new Daemon({ root: scaffold(), hostFactory: hostFactory() as never })
+    await daemon.start()
+    seedSuggestion(daemon, AGENT_A, '11111111-1111-4111-8111-111111111111')
+    ;(daemon as any).cpAgents = { orgForAgent: () => undefined, organizationIds: () => [] }
+    const { sync, client } = fakeClient('frame')
+    ;(daemon as any).cpClient = client
+
+    await expect((daemon as any).syncOrganizationSuggestions()).resolves.toBeUndefined()
+
+    // The CP would answer SCOPE_DENIED to an unscoped frame here, which is the whole failure (#968).
+    expect(sync).not.toHaveBeenCalled()
+    await daemon.stop()
+  }, 20_000)
+
+  it('keeps a single unscoped frame on a connection-scoped daemon', async () => {
+    const daemon = new Daemon({ root: scaffold(), hostFactory: hostFactory() as never })
+    await daemon.start()
+    seedSuggestion(daemon, AGENT_A, '11111111-1111-4111-8111-111111111111')
+    seedSuggestion(daemon, AGENT_B, '22222222-2222-4222-8222-222222222222')
+    ;(daemon as any).cpAgents = { orgForAgent: () => undefined, organizationIds: () => [] }
+    const { sync, client } = fakeClient('connection')
+    ;(daemon as any).cpClient = client
+
+    await (daemon as any).syncOrganizationSuggestions()
+
+    expect(sync).toHaveBeenCalledOnce()
+    expect(sync.mock.calls[0]).toHaveLength(1)
+    const sent = (sync.mock.calls[0] as unknown as [{ suggestions: { sourceAgentId: string }[] }])[0]
+    expect(sent.suggestions.map((s) => s.sourceAgentId).sort()).toEqual([AGENT_A, AGENT_B])
+    await daemon.stop()
+  }, 20_000)
+
+  it('keeps every other org replaying when one org is refused', async () => {
+    const daemon = new Daemon({ root: scaffold(), hostFactory: hostFactory() as never })
+    await daemon.start()
+    seedSuggestion(daemon, AGENT_A, '11111111-1111-4111-8111-111111111111')
+    seedSuggestion(daemon, AGENT_B, '22222222-2222-4222-8222-222222222222')
+    const orgs = new Map([
+      [AGENT_A, ORG_A],
+      [AGENT_B, ORG_B]
+    ])
+    ;(daemon as any).cpAgents = {
+      orgForAgent: (id: string) => orgs.get(id),
+      organizationIds: () => [...new Set(orgs.values())]
+    }
+    const sync = vi.fn(async (_payload: unknown, orgId?: string) => {
+      if (orgId === ORG_A) throw new Error('SCOPE_DENIED')
+      return { decisions: [] }
+    })
+    ;(daemon as any).cpClient = {
+      supportsServerFeature: vi.fn(() => true),
+      organizationScope: vi.fn(() => 'frame'),
+      syncOrganizationSuggestions: sync,
+      stop: vi.fn(async () => {})
+    }
+
+    await expect((daemon as any).syncOrganizationSuggestions()).resolves.toBeUndefined()
+
+    expect(sync).toHaveBeenCalledTimes(2)
+    expect(sync.mock.calls.map((call) => call[1]).sort()).toEqual([ORG_A, ORG_B])
+    await daemon.stop()
+  }, 20_000)
+})


### PR DESCRIPTION
A pool member logged `cp: organization suggestion replay failed (WireError)` once per
connect. `knowledge/suggestions/sync` is org-scoped by nature and an install-wide
connection carries no org, so the daemon has to state one on the frame — but it still
fell back to an unscoped frame whenever it could not name an org, and an unscoped frame
is refused at the connection gate before the handler ever sees it. The frame is
deliberately NOT in `INSTALL_WIDE_FRAME_TYPES`; the fix is to always name the org, not
to exempt the frame.

## Daemon

- A suggestion whose org the daemon cannot name is held back instead of riding an
  unscoped frame, and a member that knows no org at all sends nothing rather than one
  frame the control plane must refuse.
- A connection-scoped daemon is unchanged: one unscoped frame carrying the whole
  inventory, which the connection org answers for. Pinned by the existing evaluation
  test plus a new one.
- The per-org sends are settled independently. One org's refusal used to reject the
  whole replay through `Promise.all` and cost every other org its review decisions —
  the same failure the issue describes, one level up.

## Control plane

- `handleOrganizationSuggestionsSync` authorizes each source agent through
  `PlacementResolver.mayAct` (placement ∪ live duty holders) instead of
  `agent.daemonId === conn.daemonId`. A pool agent names no machine, so that comparison
  emptied the inventory of exactly the members that dream and the CP answered success
  while recording nothing — worse than the refusal it replaced, because it masked the
  signal. Only the source agents the frame actually claims are resolved, so the ledger
  reads are bounded by the payload rather than by the org's roster.
- `suggestionReviewAvailable` resolves the source member through `AgentDelivery`
  (placement ∪ live duty holders) instead of comparing it to `agent.daemonId`. A pool
  agent names no machine, so that comparison was permanently false: the staged body
  could never be read back and no decision could be applied. An expired lease still
  makes it unavailable, which is the honest answer once the member stopped serving the
  agent.
- Both downlink sends (`knowledge/suggestion/read`, `knowledge/suggestion/review`) now
  state the org explicitly. A duty holder never registered the agent, so the
  connection's id→org map cannot resolve one from a bare `sourceAgentId` — the same
  reason the lifecycle sends carry an explicit org.

## What did not need changing

`syncSuggestions` is an upsert keyed by `(sourceAgentId, dreamId, candidateId)`, not a
replace scoped to the sending daemon. One member's frames for two orgs therefore cannot
collide, and an empty replay for one org is invisible to the other. A repo test pins
both, and a mutation that turns it into a per-daemon replace fails them.

## Tests

Every assertion below was mutation-checked — each mutation of the changed line fails at
least one test.

| Mutation | Detected by |
| --- | --- |
| daemon: drop the frame-mode skip, send unscoped | `organization-suggestion-sync-scope`: sends nothing unscoped |
| daemon: fall back to an unscoped frame with no known org | same |
| daemon: `Promise.allSettled` → `Promise.all` | `organization-suggestion-sync-scope`: keeps every other org replaying |
| daemon: treat every connection as connection-scoped | sends nothing unscoped |
| daemon: never put `orgId` on the frame | one org-scoped frame per org |
| CP handler: ignore `frame.orgId`, use the connection daemon's org | handler unit tests (both org-scoped frames) |
| CP handler: authority back to `agent.daemonId` | handler unit tests (2) **and** WS protocol int tests (2) |
| CP handler: no authority fence at all | handler unit tests (2) **and** WS protocol int test (negative) |
| CP route: resolve review by `agent.daemonId` | route int test: reaches the duty holder |
| CP route: skip the serving fence entirely | route int test: unavailable once the holder left |
| CP outbound: drop the explicit org | outbound unit test |
| CP connection: make the sync frame install-wide | fencing test: rejects an unscoped sync |
| CP repo: make `syncSuggestions` replace per daemon | both repo tests |

The handler fixtures are real pool rows (`placementKind: 'pool'`, `daemonId: null`), and
`test/protocol/organization-suggestion-sync.handler.test.ts` drives the frame end to end
over the real duty ledger: a live lease records, a lease held by another member or an
expired one records nothing, and a machine-placed agent still records through placement.

Gates: `typecheck`, `lint`, `format:check`, CP `test:unit` (1644 passed), CP `test:int`
(1273 passed), daemon `test`. Daemon failures are the known baseline (`shim-*`,
`workspace-git-runner-seam`, live `acp-matrix`).

Not in scope, worth its own issue: the read handlers on this frame family
(`knowledge/search`, `knowledge/list`, `skills/org`, `managed-skill/read`) still fence on
`requester.daemonId !== conn.daemonId` and have the same blind spot for a pool member.

Closes #968
