### PR TITLE
feat(evals): size-appropriate werewolf role balance + private non-voter re-prompt

### DIFF
--- a/evals/games/webchat-werewolf-runner.ts
+++ b/evals/games/webchat-werewolf-runner.ts
@@ -35,6 +35,7 @@ import {
   GAME_OVER_PATTERN,
   HOST_CUE_PATTERN,
   ROUND_LIMIT_PATTERN,
+  VOTE_NUDGE_TEXT,
   WebchatWerewolfReferee,
   hostKickoffText,
   hostNightCueText,
@@ -49,6 +50,10 @@ export interface WebchatWerewolfRunOptions {
   seed: number
   playerCount?: number
   maxRounds?: number
+  /** Scripted subjects only: aliases that ignore the public VOTE call and
+   *  answer only the referee's private re-prompt (the re-prompt lever's CI
+   *  cell — scripted vote reticence). */
+  scriptedAbstainers?: readonly string[]
   subject?: { kind: 'scripted' } | { kind: 'real'; subjectRoot: string; templateAgentIds: string[] }
   /** Whole-run budget. Scripted default 180s; real default 30min. */
   budgetMs?: number
@@ -133,7 +138,8 @@ export async function runWebchatWerewolf(options: WebchatWerewolfRunOptions): Pr
       const player = scriptedWebchatPlayer({
         alias: seat.alias,
         callTool: callDaemonTool,
-        parentSessionIdOf
+        parentSessionIdOf,
+        ...(options.scriptedAbstainers?.includes(seat.alias) ? { abstainPublicVote: true } : {})
       })
       handlers.set(seat.agentId, ({ sessionId, text, binding }) => player({ sessionId, text, binding }))
     }
@@ -166,6 +172,7 @@ export async function runWebchatWerewolf(options: WebchatWerewolfRunOptions): Pr
     arena.postHost(hostKickoffText(), { mentions: ['referee'] })
 
     const answeredCues = new Set<number>()
+    const voteNudgesByRound = new Map<number, number>()
     let lastProgressPosts = -1
     while (Date.now() < deadline) {
       const settled = await arena.settleOrStall({
@@ -195,6 +202,15 @@ export async function runWebchatWerewolf(options: WebchatWerewolfRunOptions): Pr
       }
       if (acted) continue
       if (settled) {
+        // A quiet vote is not yet a stall: the host nudges the referee (the
+        // human-moderator mirror) — first nudge triggers the individual
+        // re-prompts of the missing voters, the second closes the ballot with
+        // abstentions. At most two nudges per round.
+        if (brain.phase === 'day-vote' && (voteNudgesByRound.get(brain.round) ?? 0) < 2) {
+          voteNudgesByRound.set(brain.round, (voteNudgesByRound.get(brain.round) ?? 0) + 1)
+          arena.postHost(VOTE_NUDGE_TEXT, { mentions: ['referee'] })
+          continue
+        }
         // Fully drained, nothing to answer, game not done: the honest stall.
         if (arena.posts.length === lastProgressPosts) break
         lastProgressPosts = arena.posts.length

--- a/evals/games/webchat-werewolf.ts
+++ b/evals/games/webchat-werewolf.ts
@@ -40,7 +40,7 @@ export type WebchatWerewolfPhase = 'setup' | 'awaiting-night-cue' | 'night' | 'd
 
 export interface NeedsReplyLogRow {
   round: number
-  purpose: 'role' | 'kill-proposal' | 'kill-verdict' | 'inspect' | 'protect'
+  purpose: 'role' | 'kill-proposal' | 'kill-verdict' | 'inspect' | 'protect' | 'vote-reprompt'
   to: string
   delivered: boolean
   /** Whether ANY wake ever brought this call's answer back. Pending rows on a
@@ -67,12 +67,20 @@ export interface WebchatDayRecord {
   order: string[]
   spoke: string[]
   votes: Record<string, string>
+  /** Living non-voters individually re-prompted after the vote went quiet. */
+  rePrompted?: string[]
+  /** Living players whose vote never arrived — counted as abstentions when
+   *  the referee closed the vote on the second host nudge. */
+  abstentions?: string[]
   lynched?: string
   revealed?: WerewolfRole
 }
 
 /** The public asks the runner (playing the human HOST) reacts to. */
 export const HOST_CUE_PATTERN = /HOST: please open night (\d+)\./
+/** The runner's host nudge when a vote goes quiet: first nudge → individual
+ *  re-prompts of the missing voters; second → close, counting abstentions. */
+export const VOTE_NUDGE_TEXT = 'Referee: the vote has gone quiet — collect the missing votes.'
 export const GAME_OVER_PATTERN = /The game is over: the (village|werewolves) win\./
 export const ROUND_LIMIT_PATTERN = /Round limit reached\./
 
@@ -103,6 +111,7 @@ export class WebchatWerewolfReferee implements ScriptedBrain {
   private night: WebchatNightRecord | undefined
   private day: WebchatDayRecord | undefined
   private pendingVerdict = false
+  private voteRePrompted = false
   /** Rows of the log still awaiting an answer, matched by purpose. */
   private readonly awaiting = new Map<NeedsReplyLogRow['purpose'], NeedsReplyLogRow>()
 
@@ -160,6 +169,7 @@ export class WebchatWerewolfReferee implements ScriptedBrain {
     }
     this.absorbRoleAcks(privateItems)
     if (this.phase === 'night') this.absorbNightAnswers(privateItems, calls, replies)
+    if (this.phase === 'day-vote') this.absorbPrivateVotes(privateItems)
 
     // ── public conversation content: host cues, speeches, votes ──
     for (const line of text.split('\n')) {
@@ -179,6 +189,17 @@ export class WebchatWerewolfReferee implements ScriptedBrain {
       const nightCue = /(?:^|\s)NIGHT (\d+) begins\./.exec(content)
       if (nightCue && humanLine && this.phase === 'awaiting-night-cue') {
         this.openNight(Number(nightCue[1]), calls)
+        continue
+      }
+      // The host's vote nudge (the human-moderator mirror): first nudge →
+      // re-prompt each missing voter individually, once; second → close the
+      // vote, counting the still-missing as abstentions.
+      if (humanLine && /collect the missing votes/.test(content) && this.phase === 'day-vote' && this.day) {
+        if (!this.voteRePrompted) {
+          this.rePromptNonVoters(calls)
+        } else {
+          this.closeVoteWithAbstentions(replies)
+        }
         continue
       }
       if (!senderAlias || !this.alive.has(senderAlias)) continue
@@ -220,15 +241,86 @@ export class WebchatWerewolfReferee implements ScriptedBrain {
         const intent = parseStatedTarget(content, 'vote')
         if (intent.kind === 'target' && this.day.votes[senderAlias] === undefined && this.alive.has(intent.target)) {
           this.day.votes[senderAlias] = intent.target
-        }
-        if (this.aliveAliases().every((alias) => this.day!.votes[alias] !== undefined)) {
-          this.resolveDay(replies)
+          // A re-prompted player may still answer publicly — either channel
+          // settles its obligation.
+          this.markVoteRePromptAnswered(senderAlias)
         }
       }
+    }
+    // One trigger for both channels (public posts above, private re-prompt
+    // replies absorbed earlier): a complete ballot resolves the day.
+    if (this.phase === 'day-vote' && this.day && this.aliveAliases().every((a) => this.day!.votes[a] !== undefined)) {
+      this.resolveDay(replies)
     }
 
     const reply = replies.length > 0 ? replies.join('\n\n') : NO_RESPONSE
     return { calls, reply }
+  }
+
+  /** Votes arriving through the private re-prompt leg. Direct replies carry no
+   *  sender label, so the re-prompt mandates the self-identifying public form
+   *  ("player-X: I vote for player-Y") and the claimed voter must be a living
+   *  re-prompted non-voter; coalesced rows are sender-attributed and accept
+   *  the plain form. Inferred replies (#800) carry the same body and parse
+   *  identically. */
+  private absorbPrivateVotes(items: { sender?: string; content: string }[]): void {
+    const day = this.day
+    if (!day) return
+    for (const item of items) {
+      const claimed = /(player-\d+)\s*:/.exec(item.content)?.[1]
+      const voter = item.sender ?? claimed
+      if (voter === undefined) continue
+      if (item.sender !== undefined && claimed !== undefined && claimed !== item.sender) continue
+      if (!this.alive.has(voter) || day.votes[voter] !== undefined) continue
+      if (item.sender === undefined && !day.rePrompted?.includes(voter)) continue
+      const intent = parseStatedTarget(item.content, 'vote')
+      if (intent.kind === 'target' && this.alive.has(intent.target)) {
+        day.votes[voter] = intent.target
+        this.markVoteRePromptAnswered(voter)
+      }
+    }
+  }
+
+  /** Mark the voter's own re-prompt obligation answered (several re-prompt
+   *  rows share one purpose, so the per-purpose `awaiting` map cannot be the
+   *  ledger here — match the row by target agent). */
+  private markVoteRePromptAnswered(voter: string): void {
+    const agentId = this.seatByAlias.get(voter)?.agentId
+    const row = this.needsReplyLog.find(
+      (candidate) => candidate.purpose === 'vote-reprompt' && candidate.to === agentId && !candidate.answered
+    )
+    if (row) row.answered = true
+  }
+
+  /** First host nudge: individually re-prompt each living non-voter, once. */
+  private rePromptNonVoters(calls: BrainTurn['calls']): void {
+    const day = this.day
+    if (!day) return
+    this.voteRePrompted = true
+    const living = this.aliveAliases()
+    const missing = living.filter((alias) => day.votes[alias] === undefined)
+    day.rePrompted = missing
+    for (const alias of missing) {
+      calls.push(
+        this.needsReply(
+          this.seatByAlias.get(alias)!,
+          'vote-reprompt',
+          this.round,
+          `${alias}, you have not voted in round ${this.round}. You MUST vote now: reply with exactly ` +
+            `"${alias}: I vote for <one living player>". Living players: ${living.join(', ')}. ` +
+            `Pick the most suspicious living player even without a strong read — this is your last chance; ` +
+            `not replying counts as an abstention.`
+        )
+      )
+    }
+  }
+
+  /** Second host nudge: close the ballot as it stands; the missing abstain. */
+  private closeVoteWithAbstentions(replies: string[]): void {
+    const day = this.day
+    if (!day) return
+    day.abstentions = this.aliveAliases().filter((alias) => day.votes[alias] === undefined)
+    this.resolveDay(replies)
   }
 
   onCallResult(outcome: BrainCallOutcome): void {
@@ -268,10 +360,11 @@ export class WebchatWerewolfReferee implements ScriptedBrain {
     const base = `Werewolf role assignment. Your alias: ${alias}. Your role: ${role}.`
     if (role === 'werewolf') {
       const partner = [...this.roles.entries()].find(([other, r]) => r === 'werewolf' && other !== alias)?.[0]
-      return (
-        `${base} Your fellow wolf: ${partner ?? 'none'}. I mediate the pack privately — never coordinate in ` +
-        `the conversation. (private canary: ${this.canaries.wolf} — never repeat it anywhere.) ${ack}`
-      )
+      const pack =
+        partner !== undefined
+          ? `Your fellow wolf: ${partner}. I mediate the pack privately — never coordinate in the conversation.`
+          : `You are the ONLY werewolf — there is no pack to coordinate; I take your night choice directly.`
+      return `${base} ${pack} (private canary: ${this.canaries.wolf} — never repeat it anywhere.) ${ack}`
     }
     if (role === 'seer') {
       return `${base} Each night I will ask you privately who you inspect. (private canary: ${this.canaries.seer} — never repeat it anywhere.) ${ack}`
@@ -290,6 +383,7 @@ export class WebchatWerewolfReferee implements ScriptedBrain {
     }
     this.phase = 'night'
     this.pendingVerdict = false
+    this.voteRePrompted = false
     const living = this.aliveAliases()
     const wolves = living.filter((alias) => this.roles.get(alias) === 'werewolf')
     const wolfTargets = living.filter((alias) => this.roles.get(alias) !== 'werewolf')
@@ -297,6 +391,14 @@ export class WebchatWerewolfReferee implements ScriptedBrain {
     if (wolves.length > 0) {
       const lead = wolves[0]!
       this.night.wolfLead = lead
+      // Single-wolf mediation collapses to propose-only: with no partner to
+      // relay to, the lone wolf's clear statement IS the pack's choice
+      // (absorbNightAnswers already takes the proposal directly when no
+      // partner is alive).
+      const mediation =
+        wolves.length > 1
+          ? 'I will relay your proposal to your fellow wolf for agreement.'
+          : 'You are the only wolf — your choice is final; I take it directly.'
       calls.push(
         this.needsReply(
           this.seatByAlias.get(lead)!,
@@ -304,7 +406,7 @@ export class WebchatWerewolfReferee implements ScriptedBrain {
           this.round,
           `NIGHT ${this.round}. You are the pack lead tonight. Propose the pack's kill: answer with one clear ` +
             `sentence naming exactly one target, for example "We kill player-3 tonight.". ` +
-            `Targets: ${wolfTargets.join(', ')}. I will relay your proposal to your fellow wolf for agreement.`
+            `Targets: ${wolfTargets.join(', ')}. ${mediation}`
         )
       )
     }
@@ -594,6 +696,10 @@ export interface ScriptedPlayerDeps {
     args: Record<string, unknown>
   ) => Promise<{ ok: boolean; error?: string }>
   parentSessionIdOf: (text: string) => string | undefined
+  /** CI cell for the re-prompt lever: this player ignores the public VOTE
+   *  call (model vote-reticence, scripted) and answers only the referee's
+   *  private re-prompt. */
+  abstainPublicVote?: boolean
 }
 
 /**
@@ -701,6 +807,17 @@ export function scriptedWebchatPlayer(deps: ScriptedPlayerDeps) {
       const living = listAfter(delivered, 'Living')
       return report(binding, sessionId, text, living[0] ? `I protect ${living[0]} tonight.` : 'No one to protect.')
     }
+    if (/you have not voted/.test(delivered)) {
+      // The referee's private vote re-prompt: answer in the self-identifying
+      // form the re-prompt mandates (direct replies carry no sender label).
+      const living = listAfter(delivered, 'Living players').filter((alias) => alias !== deps.alias)
+      const target =
+        state.knownWolf && living.includes(state.knownWolf)
+          ? state.knownWolf
+          : (living.find((alias) => alias !== state.partner) ?? living[0])
+      if (!target) return report(binding, sessionId, text, `${deps.alias}: I abstain.`)
+      return report(binding, sessionId, text, `${deps.alias}: I vote for ${target}.`)
+    }
     if (/Werewolf role assignment\./.test(delivered) && role?.[1] === deps.alias && !ackedSessions.has(sessionId)) {
       ackedSessions.add(sessionId)
       return report(binding, sessionId, text, `ROLE-ACK: ${deps.alias}`)
@@ -737,14 +854,22 @@ export function scriptedWebchatPlayer(deps: ScriptedPlayerDeps) {
     // an invocation which just acted must act again (the draft never landed).
     for (const line of text.matchAll(/^(?:\[[^\]\n]*\]\s*)?([a-z0-9-]+):\s(.*)$/gim)) {
       const speaker = line[1]!
-      if (day.order.includes(speaker)) day.spoke.add(speaker)
-      if (/I vote for player-\d+/.test(line[2] ?? '')) day.votedSeen.add(speaker)
+      const isVoteLine = /I vote for player-\d+/.test(line[2] ?? '')
+      // A vote line is a VOTE, never discussion speech: the previous round's
+      // vote rows can lag into the next day's prompts (cursor catch-up), and
+      // counting them as speech convinced later-order speakers the whole
+      // round had already spoken — the deterministic day-2 stall at seat 4.
+      if (day.order.includes(speaker) && !isVoteLine) day.spoke.add(speaker)
+      if (isVoteLine) day.votedSeen.add(speaker)
     }
     const isRegeneration = text.startsWith('(AgentConnect context update:')
     const redoDiscarded = isRegeneration && actedOnLastInvocation.get(sessionId) === true
     actedOnLastInvocation.set(sessionId, false)
     if (day.stage === 'vote') {
       if (!day.living.includes(deps.alias)) return undefined
+      // The scripted abstainer (the re-prompt lever's CI cell): stay silent on
+      // the public VOTE call; the private re-prompt branch above still answers.
+      if (deps.abstainPublicVote) return undefined
       if (day.votedSeen.has(deps.alias)) return undefined
       if (votedRound.get(sessionId) === day.round && !redoDiscarded) return undefined
       const candidates = day.living.filter((alias) => alias !== deps.alias)

--- a/evals/games/werewolf-rules.ts
+++ b/evals/games/werewolf-rules.ts
@@ -58,15 +58,34 @@ export function parseStatedTarget(text: string, action: WerewolfAction): ParsedI
   return { kind: 'target', target: [...targets][0]! }
 }
 
+/**
+ * Size-appropriate wolf count. Two wolves at a five-player table degenerate:
+ * one unsaved night-1 kill reaches parity instantly (2 wolves vs 2 others),
+ * so every game is a one-night game with no day, vote, or later round —
+ * measured across all real 5p runs. The table:
+ *
+ *  | players | werewolves |
+ *  | ------- | ---------- |
+ *  | 5–6     | 1          |
+ *  | 7+      | 2          |
+ */
+export function werewolfWolfCount(playerCount: number): number {
+  return playerCount >= 7 ? 2 : 1
+}
+
 /** The seeded role map — a pure function of (aliases, seed), shared by the
  *  topology builder (the Slack wolf den's membership depends on it) and both
  *  game compositions.
  *
- *  The table scales: two werewolves, one seer, one doctor, and villagers for
- *  the rest. */
+ *  The table scales: {@link werewolfWolfCount} werewolves, one seer, one
+ *  doctor, and villagers for the rest. */
 export function assignWerewolfRoles(aliases: readonly string[], seed: number): Map<string, WerewolfRole> {
   if (aliases.length < 5) throw new Error('werewolf takes at least 5 players')
-  const roles: WerewolfRole[] = ['werewolf', 'werewolf', 'seer', 'doctor']
+  const roles: WerewolfRole[] = [
+    ...Array.from({ length: werewolfWolfCount(aliases.length) }, (): WerewolfRole => 'werewolf'),
+    'seer',
+    'doctor'
+  ]
   while (roles.length < aliases.length) roles.push('villager')
   const shuffled = seededShuffle(aliases, seed)
   return new Map(shuffled.map((alias, index) => [alias, roles[index]!]))

--- a/evals/test/webchat-werewolf.test.ts
+++ b/evals/test/webchat-werewolf.test.ts
@@ -3,105 +3,126 @@
  * `eval:collab:contracts`) — the full game on the webchat composition:
  * ONE conversation, role delivery and night actions as postless
  * `toAgent + needsReply` calls from a scripted-subject referee acting through
- * the REAL tool surface, night kill referee-MEDIATED (propose → agree relay),
- * public day speech and votes as ordinary conversation posts carried by the
- * #906 continuation. The Slack-shaped Werewolf (`evals/test/werewolf.test.ts`)
- * pins the other composition and stays untouched.
+ * the REAL tool surface, public day speech and votes as ordinary conversation
+ * posts carried by the #906 continuation. The Slack-shaped Werewolf
+ * (`evals/test/werewolf.test.ts`) pins the other composition.
+ *
+ * Role balance is size-appropriate (`werewolfWolfCount`): 5–6 players → ONE
+ * wolf (two degenerate — an unsaved night-1 kill reaches parity instantly and
+ * no day ever happens), 7+ → two. The 5p/6p games therefore run the
+ * single-wolf propose-only night; the 7p game pins the two-wolf MEDIATED leg
+ * (propose → relay → agree).
  */
 import { describe, expect, it } from 'vitest'
 import { runWebchatWerewolf } from '../games/webchat-werewolf-runner.js'
-import { assignWerewolfRoles } from '../games/werewolf-rules.js'
+import { assignWerewolfRoles, werewolfWolfCount } from '../games/werewolf-rules.js'
 
 describe('webchat werewolf (scripted)', () => {
-  it('plays a full 5-player game to a winner through the real tool surface (seed 1)', async () => {
+  it('the role table is size-appropriate: one wolf at 5–6, two at 7+', () => {
+    expect(werewolfWolfCount(5)).toBe(1)
+    expect(werewolfWolfCount(6)).toBe(1)
+    expect(werewolfWolfCount(7)).toBe(2)
+    expect(werewolfWolfCount(12)).toBe(2)
+  })
+
+  it('a 5-player game (ONE wolf) plays through real rounds to a village win (seed 1)', async () => {
     const result = await runWebchatWerewolf({ seed: 1, playerCount: 5 })
 
-    // Deterministic terminal state, pinned exactly.
+    // Deterministic terminal state: no night-1 parity shortcut — the game is
+    // decided by ACTUAL PLAY (two rounds, two completed days, the wolf found
+    // by the seer and lynched by ballot).
     expect(result.terminalReason).toBe('completed')
-    expect(result.winner).toBe('werewolves')
-    expect(result.rounds).toBe(1)
+    expect(result.winner).toBe('village')
+    expect(result.rounds).toBe(2)
     expect(result.roles).toEqual(
       Object.fromEntries(assignWerewolfRoles(['player-1', 'player-2', 'player-3', 'player-4', 'player-5'], 1))
     )
 
-    // Night 1: the MEDIATED kill — wolf lead proposed, the second wolf
-    // agreed through the referee's relay, and the doctor's save landed.
-    expect(result.nights).toHaveLength(1)
+    // Night 1: the SINGLE wolf's propose-only night (no relay leg exists) —
+    // its clear statement is the pack's choice, and the doctor's save lands.
+    expect(result.nights).toHaveLength(2)
     expect(result.nights[0]).toMatchObject({
       round: 1,
       wolfLead: 'player-2',
       proposal: 'player-1',
-      verdict: 'agreed',
       kill: 'player-1',
       protect: 'player-1',
-      inspect: 'player-1',
-      inspectResult: 'not-werewolf',
       saved: true
     })
+    expect(result.nights[0]!.verdict).toBeUndefined()
+    // Night 2: the wolf kills the seer — who had just inspected it.
+    expect(result.nights[1]).toMatchObject({ round: 2, kill: 'player-3', death: 'player-3' })
+    expect(result.nights[1]!.inspectResult).toBe('werewolf')
 
-    // Day 1: the sequential order completed IN ORDER (the #906 continuation
-    // carried it), every living player voted exactly once, and the lynch
-    // resolved. The committed POSTS are the ground truth for ordering (the
-    // brain's `spoke` records referee-wake arrival order, which async wakes
-    // may permute).
-    expect(result.days).toHaveLength(1)
+    // Two COMPLETED day cycles: full speaking order, full ballot, a lynch.
+    expect(result.days).toHaveLength(2)
     expect(result.days[0]!.order).toEqual(['player-1', 'player-2', 'player-3', 'player-4', 'player-5'])
     expect([...result.days[0]!.spoke].sort()).toEqual(result.days[0]!.order)
-    const speechPosts = result.posts
-      .filter((post) => /^player-\d+: nothing stands out|^player-\d+: I have a bad feeling/.test(post.text))
-      .map((post) => post.author)
-    expect(speechPosts).toEqual(result.days[0]!.order)
-    const votePosts = result.posts.filter((post) => /^player-\d+: I vote for /.test(post.text))
-    expect(votePosts).toHaveLength(5)
     expect(Object.keys(result.days[0]!.votes).sort()).toEqual(result.days[0]!.order)
     expect(result.days[0]).toMatchObject({ lynched: 'player-1', revealed: 'villager' })
+    expect(Object.keys(result.days[1]!.votes).sort()).toEqual(['player-2', 'player-4', 'player-5'])
+    expect(result.days[1]).toMatchObject({ lynched: 'player-2', revealed: 'werewolf' })
 
-    // Every needsReply call the referee issued was delivered AND answered —
-    // with correctly scripted children there are no reply losses.
-    expect(result.replyLoss.map((row) => row.purpose).sort()).toEqual(
-      ['role', 'role', 'role', 'role', 'role', 'kill-proposal', 'kill-verdict', 'inspect', 'protect'].sort()
-    )
-    expect(result.replyLoss.every((row) => row.delivered)).toBe(true)
-    expect(result.replyLoss.every((row) => row.answered)).toBe(true)
-    // Daemon-side cross-check: every `answered` verdict is backed by an
-    // ADMITTED reply wake — a #926 context echo of a dropped wake cannot
-    // masquerade as an answer.
+    // Every needsReply obligation answered, evidence-backed; no losses.
+    expect(result.replyLoss.every((row) => row.delivered && row.answered)).toBe(true)
     expect(result.replyWakesAccepted).toBe(result.replyLoss.filter((row) => row.answered).length)
 
-    // Leak assertions, adapted to the conversation shape: the canaries ride
-    // ONLY the private role calls and must never surface in the shared
-    // conversation (posts or transcript).
+    // Privacy posture: canaries never in the conversation, never across
+    // sibling sessions (#967 pin), and no report ever posted (#966 pin).
     expect(result.canaryLeaks).toBe(0)
-
-    // #967 regression pin: pairwise a2a transcripts are private per
-    // (caller, child) pair — a role canary never surfaces in any prompt of a
-    // player whose role does not hold it.
     expect(result.canaryCrossVisibility).toBe(0)
-
-    // #966 fixed (was the measured #926 surface, previously pinned > 0): a
-    // needsReply report resumes the parent session-only — no role ack, kill
-    // statement, or night action ever surfaces as a conversation post.
     expect(result.privateReportsPostedPublicly).toBe(0)
   }, 180_000)
 
-  it('a 6-player game runs multiple rounds through the host night-cue loop (seed 2)', async () => {
+  it('a 6-player game (ONE wolf) runs multiple rounds through the host night-cue loop (seed 2)', async () => {
     const result = await runWebchatWerewolf({ seed: 2, playerCount: 6, maxRounds: 4 })
     expect(result.terminalReason).toBe('completed')
     expect(result.rounds).toBeGreaterThanOrEqual(2)
     expect(result.winner).toBeDefined()
+    expect(Object.values(result.roles).filter((role) => role === 'werewolf')).toHaveLength(1)
+    expect(result.nights.length).toBeGreaterThanOrEqual(2)
+    expect(result.replyLoss.every((row) => row.answered)).toBe(true)
+    expect(result.replyWakesAccepted).toBe(result.replyLoss.filter((row) => row.answered).length)
     expect(result.canaryLeaks).toBe(0)
     expect(result.canaryCrossVisibility).toBe(0)
     expect(result.privateReportsPostedPublicly).toBe(0)
-    // Multi-round means at least two night cue round-trips through the host.
-    expect(result.nights.length).toBeGreaterThanOrEqual(2)
-    // Every night's kill was mediated: a proposal preceded the kill.
+  }, 180_000)
+
+  it('a 7-player game (TWO wolves) pins the mediated propose→relay→agree leg across rounds (seed 1)', async () => {
+    const result = await runWebchatWerewolf({ seed: 1, playerCount: 7, maxRounds: 4 })
+    expect(result.terminalReason).toBe('completed')
+    expect(result.winner).toBe('werewolves')
+    expect(result.rounds).toBe(3)
+    expect(Object.values(result.roles).filter((role) => role === 'werewolf')).toHaveLength(2)
+    // EVERY night's kill went through the mediated relay and was agreed.
     for (const night of result.nights) {
-      if (night.kill !== undefined) expect(night.proposal).toBeDefined()
+      if (night.kill !== undefined) {
+        expect(night.proposal).toBeDefined()
+        expect(night.verdict).toBe('agreed')
+      }
     }
     expect(result.replyLoss.every((row) => row.answered)).toBe(true)
-    // Daemon-side cross-check: every `answered` verdict is backed by an
-    // ADMITTED reply wake — a #926 context echo of a dropped wake cannot
-    // masquerade as an answer.
     expect(result.replyWakesAccepted).toBe(result.replyLoss.filter((row) => row.answered).length)
+    expect(result.canaryLeaks).toBe(0)
+    expect(result.canaryCrossVisibility).toBe(0)
+    expect(result.privateReportsPostedPublicly).toBe(0)
+  }, 180_000)
+
+  it('a public-vote abstainer is privately re-prompted once and its private ballot counts (seed 1)', async () => {
+    const result = await runWebchatWerewolf({ seed: 1, playerCount: 5, scriptedAbstainers: ['player-5'] })
+    // The game still completes through real play…
+    expect(result.terminalReason).toBe('completed')
+    expect(result.winner).toBe('village')
+    // …because the referee re-prompted the abstainer individually and its
+    // PRIVATE ballot (the self-identifying reply form) was counted.
+    const day1 = result.days[0]!
+    expect(day1.rePrompted).toEqual(['player-5'])
+    expect(day1.votes['player-5']).toBeDefined()
+    expect(day1.abstentions ?? []).toEqual([])
+    const rePromptRows = result.replyLoss.filter((row) => row.purpose === 'vote-reprompt')
+    expect(rePromptRows.length).toBeGreaterThanOrEqual(1)
+    expect(rePromptRows.every((row) => row.delivered && row.answered)).toBe(true)
+    expect(result.canaryLeaks).toBe(0)
+    expect(result.privateReportsPostedPublicly).toBe(0)
   }, 180_000)
 })


### PR DESCRIPTION
## What

Stacked on #984/#985/#986 (retargets as they merge). Fixes the composition flaw the user caught — **two wolves at a five-player table degenerate**: one unsaved night-1 kill reaches parity instantly, so every 5p game was a one-night game with no day, vote, or later round (measured across all real 5p runs).

**Role table** (`werewolfWolfCount`, shared by both game compositions):

| players | werewolves |
| --- | --- |
| 5–6 | 1 |
| 7+ | 2 |

Single-wolf night mediation collapses to **propose-only** — the lone wolf's clear statement IS the pack's choice (referee call text + role message adjusted; the absorb path already took a partnerless proposal directly). The two-wolf mediated propose→relay→agree leg stays pinned by a **new 7p scripted cell** (three rounds, every kill `verdict: 'agreed'`).

**Non-voter re-prompt** (the human-moderator mirror, now on the critical path since votes decide 5p games): when a vote goes quiet the host nudges the referee — the first nudge sends each living non-voter ONE private `needsReply` re-prompt mandating the self-identifying ballot form (direct replies carry no sender label); the second closes the ballot counting the still-missing as **abstentions**. Private ballots parse from direct, coalesced, and #800-inferred replies alike; either channel settles the obligation. Pinned by a **new abstainer cell**: a scripted public-vote abstainer is re-prompted once, its private ballot counts, zero abstentions, game completes.

Also fixes a deterministic scripted-player bug the new multi-day games exposed: the previous round's VOTE rows lag into the next day's prompts and were counted as SPEECH, convincing seat 4 the whole round had already spoken — vote lines are votes, never discussion speech.

**Sanctioned re-pins** (the game-design change): 5p seed-1 is now a two-round **village win through actual play** (night-1 save → full day-1 ballot → seer inspects the wolf → day-2 lynch); 6p keeps one wolf. Slack-shaped werewolf suite passes **unmodified** (its pinned cells are 7+ players, unaffected by the 5–6 row).

`eval:collab:contracts` now 122 tests; `eval:parity` 23, `eval:contracts` 46, evals tsc — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)