### PR TITLE
fix(control-plane): bind a skill source's repo identity server-side

### DIFF
--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -209,6 +209,14 @@ enabled in the console and installs nothing. A `PATCH` re-binds when the source
 changes or the row never had an identity, which is how a historical unbound row
 is repaired; clearing the identity is refused.
 
+**The stored slug is canonicalized with the ID.** GitHub follows rename and
+transfer redirects, so the resolved `full_name` may not be the slug that was
+typed (`docker/docker` resolves as `moby/moby`). The daemon's numeric-identity
+check requires `full_name` to equal the configured source, so the route persists
+the canonical owner/repository -- rewriting only that half and preserving any
+`.git` suffix or `/tree/<ref>/<subdir>` the source carries. The two fields are
+written together or the write is refused; they may never disagree.
+
 ### Per-agent binding: inline source definitions in `AgentSpec` and `agent.json`
 
 The key decision is that **all information the daemon needs to acquire and

--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -198,6 +198,17 @@ public-only. `githubRepoId` remains nullable in the database only so rolling
 upgrades can read historical rows; a current row is installable only after it is
 bound to GitHub's numeric repository identity.
 
+**Binding is the Control Plane's job, not the client's.** No console entry point
+can know the numeric ID -- it appears in no read the browser makes -- so the
+create/patch routes resolve it from `source` themselves: the org installation
+first when it covers the owner, then an anonymous public read, which is the only
+path available for a skills.sh hit whose repository belongs to no installation.
+A write that cannot bind is refused (400 when GitHub says the repository does not
+exist, 503 while GitHub is unreachable) rather than persisted as a row that looks
+enabled in the console and installs nothing. A `PATCH` re-binds when the source
+changes or the row never had an identity, which is how a historical unbound row
+is repaired; clearing the identity is refused.
+
 ### Per-agent binding: inline source definitions in `AgentSpec` and `agent.json`
 
 The key decision is that **all information the daemon needs to acquire and
@@ -273,8 +284,8 @@ Every route follows `openapi.ts` requirements for tags, summary, and
 | `GET /skill-sources`                 | List sources.                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `GET /skill-sources/registry/search` | Search the public skills.sh index by skill name for the "Install from skills.sh" modal. Read-only proxy of the index `npx skills find` uses (skills.sh sends no CORS headers); each hit is normalized to `{id, name, source, installs}` and validated against the same `source` / `-s` grammars the create body enforces. Nothing is persisted, and `reachable:false` distinguishes "index down" from "no match". |
 | `POST /skill-sources/preview`        | Best-effort UI scan. Given `{installationId, owner, repo, ref?}`, use the selected GitHub App installation to return branch/tag choices and candidate `{name,dirPath}` skills. Preview is not persisted or authoritative; an empty list still permits “install all.”                                                                                                                                              |
-| `POST /skill-sources`                | Persist a public GitHub source and numeric repository ID. A migration-compatible unbound row remains visible but is omitted from `AgentSpec` until bound.                                                                                                                                                                                                                                                         |
-| `PATCH /skill-sources/:id`           | Change source, numeric repository ID, ref, subdirectory, or skills (name is immutable), then **repush every agent that references it**.                                                                                                                                                                                                                                                                           |
+| `POST /skill-sources`                | Persist a public GitHub source, resolving its numeric repository ID server-side (installation read, then anonymous public read). A source that cannot be bound is refused rather than stored non-installable; a body-supplied ID overrides the lookup.                                                                                                                                                            |
+| `PATCH /skill-sources/:id`           | Change source, numeric repository ID, ref, subdirectory, or skills (name is immutable), then **repush every agent that references it**. Re-binds the numeric ID when the source changes or the row is unbound (the repair path for historical rows); clearing it is refused.                                                                                                                                      |
 | `PUT /skill-sources/:id/sharing`     | Set `ResourceVisibility`, matching MCP providers.                                                                                                                                                                                                                                                                                                                                                                 |
 | `DELETE /skill-sources/:id`          | Delete a source only when no agent references it; otherwise return 409 and require explicit unselection first.                                                                                                                                                                                                                                                                                                    |
 

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -177,6 +177,7 @@ import { runWithSharedTx, withSharedTxRouting } from './persistence/ambient-tx.j
 import { verifySlackBot, verifySlackAppToken } from './http/slack-identity.js'
 import { verifyTelegramBot } from './http/telegram-identity.js'
 import { searchSkillRegistry } from './http/skills-registry.js'
+import { createPublicRepoResolver } from './github/public-repo.js'
 import { createTelegramBotIconSyncer } from './http/telegram-bot-profile.js'
 import { ensureDiscordMessageContentIntent, verifyDiscordBot } from './http/discord-identity.js'
 import { createDiscordBotProfileSyncer } from './http/discord-bot-profile.js'
@@ -1082,6 +1083,7 @@ export function buildContainer(
     webchatMcpMetrics: defaultWebchatMcpMetrics,
     readiness,
     searchSkillRegistry,
+    resolvePublicRepo: createPublicRepoResolver(),
     ...(github ? { github } : {}),
     ...(pullRequestView ? { pullRequestView } : {}),
     ...(githubUserAuthz ? { githubUserAuthz } : {}),

--- a/packages/control-plane/src/github/public-repo.test.ts
+++ b/packages/control-plane/src/github/public-repo.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The anonymous repo read that binds a skill source's identity (issue #935).
+ * What matters here is the verdict split: `not-found` is definitive and fails the
+ * write, everything else is `unreachable` and stays retryable — a rate-limited
+ * GitHub must never be reported as "no such repository".
+ */
+import { describe, it, expect } from 'vitest'
+import { createPublicRepoResolver } from './public-repo.js'
+
+function respond(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return async () =>
+    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json', ...headers } })
+}
+
+describe('createPublicRepoResolver', () => {
+  it('reads identity, privacy, and default branch without any credential', async () => {
+    const calls: string[] = []
+    let sentAuth: string | null = 'unset'
+    const resolve = createPublicRepoResolver({
+      fetchImpl: async (url, init) => {
+        calls.push(url)
+        sentAuth = new Headers(init?.headers).get('authorization')
+        return new Response(
+          JSON.stringify({ id: 8484, full_name: 'anthropics/skills', private: false, default_branch: 'trunk' }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+    })
+
+    expect(await resolve('anthropics', 'skills')).toEqual({
+      repoId: 8484n,
+      fullName: 'anthropics/skills',
+      private: false,
+      defaultBranch: 'trunk'
+    })
+    expect(calls[0]).toBe('https://api.github.com/repos/anthropics/skills')
+    expect(sentAuth).toBeNull()
+  })
+
+  it('reports a missing (or private-to-anonymous) repo as the definitive not-found', async () => {
+    const resolve = createPublicRepoResolver({ fetchImpl: respond(404, { message: 'Not Found' }) })
+    expect(await resolve('nobody', 'nothing')).toBe('not-found')
+  })
+
+  it('keeps a rate limit and a server error retryable rather than calling them not-found', async () => {
+    const limited = createPublicRepoResolver({
+      fetchImpl: respond(403, { message: 'rate limit exceeded' }, { 'x-ratelimit-remaining': '0' })
+    })
+    expect(await limited('anthropics', 'skills')).toBe('unreachable')
+
+    const down = createPublicRepoResolver({ fetchImpl: respond(500, { message: 'boom' }) })
+    expect(await down('anthropics', 'skills')).toBe('unreachable')
+
+    const offline = createPublicRepoResolver({
+      fetchImpl: async () => {
+        throw new Error('ENOTFOUND')
+      }
+    })
+    expect(await offline('anthropics', 'skills')).toBe('unreachable')
+  })
+})

--- a/packages/control-plane/src/github/public-repo.ts
+++ b/packages/control-plane/src/github/public-repo.ts
@@ -1,0 +1,58 @@
+/**
+ * Unauthenticated GitHub repository lookup — the binding fallback for skill
+ * sources (docs/designs/shared-skills.md §4).
+ *
+ * A skill source needs its NUMERIC repo id to project onto an AgentSpec, but the
+ * installation-token path (`GithubService.repoRefFor`) only covers repos an org
+ * GitHub App installation can see. Skill sources are public by contract, and the
+ * commonest source of all — a skills.sh registry hit like `anthropics/skills` —
+ * belongs to no installation. This read closes that gap with the same anonymous
+ * endpoint the daemon already uses to verify identity before acquisition.
+ *
+ * No credential is involved and nothing is persisted: `/repos/{owner}/{repo}` on
+ * a public repo is exactly what an unauthenticated `git clone` could learn.
+ */
+import { githubRequest, GithubApiError } from './api.js'
+import type { FetchLike } from './api.js'
+
+/** What binding needs: rename-proof identity, the public-only guard, and the
+ *  default branch a `subDir` source must pin its ref to. */
+export interface PublicRepoRef {
+  repoId: bigint
+  fullName: string
+  private: boolean
+  defaultBranch: string
+}
+
+/** `not-found` is a definitive answer (no such public repo) and must fail the
+ *  write; `unreachable` (rate limit, outage, timeout) is NOT — the caller
+ *  reports it as retryable rather than persisting a row it could not bind. */
+export type PublicRepoLookup = PublicRepoRef | 'not-found' | 'unreachable'
+
+export type PublicRepoResolver = (owner: string, repo: string) => Promise<PublicRepoLookup>
+
+export function createPublicRepoResolver(opts: { fetchImpl?: FetchLike; baseUrl?: string } = {}): PublicRepoResolver {
+  return async (owner, repo) => {
+    try {
+      const meta = await githubRequest<{ id: number; full_name: string; private: boolean; default_branch: string }>(
+        `/repos/${owner}/${repo}`,
+        {
+          auth: null,
+          ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+          ...(opts.baseUrl ? { baseUrl: opts.baseUrl } : {})
+        }
+      )
+      return {
+        repoId: BigInt(meta.id),
+        fullName: meta.full_name,
+        private: meta.private,
+        defaultBranch: meta.default_branch
+      }
+    } catch (e) {
+      // Anonymous reads see 404 for both "gone" and "private" — either way the repo
+      // is not a public source this release can install, so both are definitive.
+      if (e instanceof GithubApiError && e.status === 404) return 'not-found'
+      return 'unreachable'
+    }
+  }
+}

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -75,6 +75,7 @@ import type { AgentMutationGate } from '../orchestrator/agentMutationGate.js'
 import type { SessionEventSink } from '../events/sink.js'
 import type { HumanAuthConfig } from './plugins/auth.js'
 import type { SkillRegistrySearcher } from './skills-registry.js'
+import type { PublicRepoResolver } from '../github/public-repo.js'
 import type { Readiness } from './readiness.js'
 import type { McpRateLimiter } from './mcp/rate-limit.js'
 import type { RemoteGrantAuthenticator } from './mcp/remote-grant-authenticator.js'
@@ -339,6 +340,10 @@ export interface HttpDeps {
    *  search route reports the index unreachable and the console offers the GitHub
    *  import path instead). */
   searchSkillRegistry?: SkillRegistrySearcher
+  /** Anonymous GitHub repo lookup that binds a skill source's numeric identity when
+   *  no org installation covers the owner (the skills.sh case). Optional/injectable
+   *  so tests stay offline; absent ⇒ only the installation path can bind. */
+  resolvePublicRepo?: PublicRepoResolver
   /** github-app workspaces façade; absent ⇒ feature disabled (GITHUB_APP_* unset) and
    *  every github route 404s. */
   github?: GithubService

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -908,8 +908,8 @@ export const CreateSkillSourceBody = z
   .object({
     name: SkillSourceName,
     source: SkillSourceArg,
-    // Exact decimal identity (BigInt on the wire). Optional only so historical
-    // unbound rows can be repaired; projection omits them until bound.
+    // Exact decimal identity (BigInt on the wire). Optional because the route
+    // resolves it from `source`; supplying it only overrides that lookup.
     githubRepoId: GithubRepoId.optional(),
     ref: SkillSourceRef.optional(),
     subDir: SkillSourceSubDir.optional(),
@@ -929,6 +929,8 @@ export const CreateSkillSourceBody = z
 export const UpdateSkillSourceBody = z
   .object({
     source: SkillSourceArg.optional(),
+    // `null` parses so the route can answer it with a 400 rather than a schema
+    // error: clearing the identity is exactly the non-installable state.
     githubRepoId: GithubRepoId.nullable().optional(),
     ref: SkillSourceRef.nullable().optional(),
     subDir: SkillSourceSubDir.nullable().optional(),

--- a/packages/control-plane/src/http/routes/skill-sources.ts
+++ b/packages/control-plane/src/http/routes/skill-sources.ts
@@ -21,6 +21,7 @@
  */
 import type { FastifyInstance, FastifyReply } from 'fastify'
 import { z } from 'zod'
+import { normalizeGitHubSkillSource } from '@agentconnect.md/protocol'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
@@ -59,23 +60,68 @@ import {
  * where the per-process promise chain this replaced could not reach.
  */
 
-/** Extract `{owner, repo, ref?}` from a source string (shorthand, https, or ssh
- *  GitHub form). Returns null for a non-GitHub / unparseable source. */
+/** Extract `{owner, repo, ref?, subDir?}` from a source string. Decomposes the
+ *  value the SHARED grammar already accepted (`normalizeGitHubSkillSource` — the
+ *  same refinement `SkillSourceArg` enforces) rather than re-deriving the accepted
+ *  set here: binding is mandatory, so any form this missed would be a source the
+ *  DTO admits and the route then rejects. Null ⇒ not a GitHub source at all. */
 function parseGithubRepo(source: string): { owner: string; repo: string; ref?: string; subDir?: string } | null {
-  const s = source.trim().replace(/\.git$/, '')
-  let m = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)(?:\/tree\/([^/]+)(?:\/(.+))?)?/i.exec(s)
-  if (m) return { owner: m[1]!, repo: m[2]!, ...(m[3] ? { ref: m[3] } : {}), ...(m[4] ? { subDir: m[4] } : {}) }
-  m = /^(?:git@github\.com:|ssh:\/\/git@github\.com\/)([^/]+)\/([^/]+)$/i.exec(s)
-  if (m) return { owner: m[1]!, repo: m[2]! }
-  m = /^([^/\s:]+)\/([^/\s]+)$/.exec(s)
-  if (m) return { owner: m[1]!, repo: m[2]! }
-  return null
+  let normalized: string
+  try {
+    normalized = normalizeGitHubSkillSource(source)
+  } catch {
+    return null
+  }
+  // scp form (`git@github.com:owner/repo`) carries its path after the colon and is
+  // not a parseable URL; every other accepted form is absolute by now.
+  const scp = /^[\w.-]+@[\w.-]+:(.+)$/.exec(normalized)
+  let parts: string[]
+  try {
+    parts = (scp ? scp[1]! : new URL(normalized).pathname.slice(1)).split('/').map(decodeURIComponent)
+  } catch {
+    return null
+  }
+  const owner = parts[0]
+  const repo = parts[1]?.replace(/\.git$/i, '')
+  if (!owner || !repo) return null
+  // The grammar admits owner/repo or owner/repo/tree/<ref>[/<subdir>] (https only).
+  const ref = parts[2] === 'tree' ? parts[3] : undefined
+  const subDir = ref && parts.length > 4 ? parts.slice(4).join('/') : undefined
+  return { owner, repo, ...(ref ? { ref } : {}), ...(subDir ? { subDir } : {}) }
+}
+
+/**
+ * Rewrite the owner/repo half of a source to GitHub's canonical `full_name`,
+ * preserving whatever else the string carries (`.git`, `/tree/<ref>/<subdir>`).
+ *
+ * GitHub follows rename and transfer REDIRECTS: `GET /repos/docker/docker` answers
+ * 200 with `full_name: moby/moby`. Persisting the typed slug next to the resolved
+ * numeric id would then fail on the daemon, whose identity check requires
+ * `full_name` to equal the configured source — the same visible-but-uninstallable
+ * state this binding exists to remove, just louder. Null ⇒ the slug is not a
+ * substring we can rewrite (percent-encoded owner/repo); the caller refuses the
+ * write rather than store a mismatch.
+ */
+function canonicalizeSource(source: string, parsed: { owner: string; repo: string }, fullName: string): string | null {
+  const slug = `${parsed.owner}/${parsed.repo}`
+  if (slug.toLowerCase() === fullName.toLowerCase()) return source
+  const at = source.toLowerCase().indexOf(slug.toLowerCase())
+  return at < 0 ? null : source.slice(0, at) + fullName + source.slice(at + slug.length)
 }
 
 /** What one repo lookup can conclude. `unreachable` (GitHub down, rate limited) is
  *  retryable and must not be confused with `not-found`, which is a verdict. */
 type RepoBinding =
-  | { status: 'ok'; repoId: bigint; private: boolean; defaultBranch: string }
+  | {
+      status: 'ok'
+      repoId: bigint
+      fullName: string
+      /** The stored source rewritten to `fullName`; null ⇒ it names a repo that has
+       *  since been renamed and the slug cannot be rewritten in place. */
+      canonicalSource: string | null
+      private: boolean
+      defaultBranch: string
+    }
   | { status: 'not-found' | 'unreachable' | 'unparseable' }
 
 function toDto(s: SkillSourceRecord, ctx: ViewCtx): SkillSourceDtoT {
@@ -120,18 +166,25 @@ export function skillSourceRoutes(deps: HttpDeps) {
     const resolveRepoBinding = async (orgId: OrgId, source: string): Promise<RepoBinding> => {
       const parsed = parseGithubRepo(source)
       if (!parsed) return { status: 'unparseable' }
-      const gh = deps.github
-      if (gh) {
-        const ins = await deps.repos.githubInstallation.liveByOrgAndAccount(orgId, parsed.owner)
-        // An installation failure is not a verdict on a PUBLIC repo — fall through
-        // to the anonymous read rather than treat the source as unbindable.
-        const ref = ins ? await gh.repoRefFor(ins, parsed.owner, parsed.repo).catch(() => null) : null
-        if (ref) return { status: 'ok', ...ref }
+      const found = async (): Promise<
+        { repoId: bigint; fullName: string; private: boolean; defaultBranch: string } | 'not-found' | 'unreachable'
+      > => {
+        const gh = deps.github
+        if (gh) {
+          const ins = await deps.repos.githubInstallation.liveByOrgAndAccount(orgId, parsed.owner)
+          // An installation failure is not a verdict on a PUBLIC repo — fall through
+          // to the anonymous read rather than treat the source as unbindable.
+          const ref = ins ? await gh.repoRefFor(ins, parsed.owner, parsed.repo).catch(() => null) : null
+          if (ref) return ref
+        }
+        const resolve = deps.resolvePublicRepo
+        return resolve ? await resolve(parsed.owner, parsed.repo) : 'unreachable'
       }
-      const resolve = deps.resolvePublicRepo
-      if (!resolve) return { status: 'unreachable' }
-      const pub = await resolve(parsed.owner, parsed.repo)
-      return typeof pub === 'string' ? { status: pub } : { status: 'ok', ...pub }
+      const hit = await found()
+      if (typeof hit === 'string') return { status: hit }
+      // Carry the CANONICAL source alongside the id: the two must agree, or the
+      // daemon refuses the entry (see canonicalizeSource).
+      return { status: 'ok', ...hit, canonicalSource: canonicalizeSource(source, parsed, hit.fullName) }
     }
 
     // Reject rather than persist a source whose identity we could not establish: an
@@ -339,6 +392,10 @@ export function skillSourceRoutes(deps: HttpDeps) {
         // non-installable (#935).
         const repoId = parseRepoId(req.body.githubRepoId) ?? (binding.status === 'ok' ? binding.repoId : undefined)
         if (repoId === undefined) return rejectUnbound(reply, binding)
+        // Store the slug GitHub redirected us to, not the one that was typed: the
+        // daemon requires the two to agree before it will acquire anything.
+        const source = binding.status === 'ok' && repoId === binding.repoId ? binding.canonicalSource : req.body.source
+        if (source === null) return reply.code(400).send(renamedRepo)
         const ref = req.body.ref ?? (req.body.subDir && binding.status === 'ok' ? binding.defaultBranch : undefined)
         // A subdir source needs a ref; if we couldn't resolve one reject rather than
         // let the daemon assume `main`.
@@ -352,7 +409,7 @@ export function skillSourceRoutes(deps: HttpDeps) {
         const created = await deps.repos.skillSource.create({
           orgId: orgOf(req),
           name: req.body.name,
-          source: req.body.source,
+          source,
           githubRepoId: repoId,
           ...(ref !== undefined ? { ref } : {}),
           ...(req.body.subDir !== undefined ? { subDir: req.body.subDir } : {}),
@@ -411,6 +468,11 @@ export function skillSourceRoutes(deps: HttpDeps) {
               : undefined
             : existing.githubRepoId)
         if (repoId === undefined) return rejectUnbound(reply, binding)
+        // Persist the canonical slug whenever this write bound the id — including a
+        // back-fill, where the stored source may name a repo that has since moved.
+        const bound = binding.status === 'ok' && repoId === binding.repoId
+        const canonicalSource = bound ? binding.canonicalSource : effSource
+        if (canonicalSource === null) return reply.code(400).send(renamedRepo)
         // Preserve an explicit ref across an unrelated PATCH: only resolve a default
         // branch when the EFFECTIVE ref is absent (untouched-and-existing counts as
         // present), so a `skills`-only edit can't silently rewrite the pinned ref.
@@ -423,7 +485,7 @@ export function skillSourceRoutes(deps: HttpDeps) {
         // let the daemon assume `main`.
         if (effSubDir && !resolvedRef) return reply.code(400).send(subdirNeedsRef)
         const source = await deps.repos.skillSource.update(orgOf(req), existing.id, {
-          ...(req.body.source !== undefined ? { source: req.body.source } : {}),
+          ...(canonicalSource !== existing.source ? { source: canonicalSource } : {}),
           githubRepoId: repoId,
           ...(resolvedRef !== undefined
             ? { ref: resolvedRef }
@@ -551,6 +613,12 @@ const bindingUnavailable = {
   error: 'Service Unavailable',
   statusCode: 503,
   message: 'could not reach GitHub to identify the repository — retry shortly'
+}
+
+const renamedRepo = {
+  error: 'Bad Request',
+  statusCode: 400,
+  message: 'the repository has been renamed or transferred; register it under its current owner/repository name'
 }
 
 /** An explicit `githubRepoId: null` asks for exactly the state #935 is about. */

--- a/packages/control-plane/src/http/routes/skill-sources.ts
+++ b/packages/control-plane/src/http/routes/skill-sources.ts
@@ -4,7 +4,10 @@
  * CRUD for org-level shared-skills sources. A source records only WHERE skills
  * come from (a bounded public GitHub repository/tree path) plus its numeric
  * repository identity, optional ref, and skill filter — skill CONTENT never
- * touches the CP. The daemon acquires a commit-bound snapshot and installs it
+ * touches the CP. The numeric identity is the CP's to resolve, not the client's:
+ * projection drops a source without one, so a write that cannot bind it is
+ * refused here instead of producing a row that looks enabled and installs
+ * nothing (issue #935). The daemon acquires a commit-bound snapshot and installs it
  * with its bundled exact CLI before the ACP host spawns.
  *
  * There is NO secret side-table and NO grant (unlike MCP providers): skills carry
@@ -62,12 +65,18 @@ function parseGithubRepo(source: string): { owner: string; repo: string; ref?: s
   const s = source.trim().replace(/\.git$/, '')
   let m = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)(?:\/tree\/([^/]+)(?:\/(.+))?)?/i.exec(s)
   if (m) return { owner: m[1]!, repo: m[2]!, ...(m[3] ? { ref: m[3] } : {}), ...(m[4] ? { subDir: m[4] } : {}) }
-  m = /^git@github\.com:([^/]+)\/([^/]+)$/i.exec(s)
+  m = /^(?:git@github\.com:|ssh:\/\/git@github\.com\/)([^/]+)\/([^/]+)$/i.exec(s)
   if (m) return { owner: m[1]!, repo: m[2]! }
   m = /^([^/\s:]+)\/([^/\s]+)$/.exec(s)
   if (m) return { owner: m[1]!, repo: m[2]! }
   return null
 }
+
+/** What one repo lookup can conclude. `unreachable` (GitHub down, rate limited) is
+ *  retryable and must not be confused with `not-found`, which is a verdict. */
+type RepoBinding =
+  | { status: 'ok'; repoId: bigint; private: boolean; defaultBranch: string }
+  | { status: 'not-found' | 'unreachable' | 'unparseable' }
 
 function toDto(s: SkillSourceRecord, ctx: ViewCtx): SkillSourceDtoT {
   return {
@@ -102,38 +111,36 @@ export function skillSourceRoutes(deps: HttpDeps) {
   return async function skillSourceRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
 
-    // A `subDir` source needs a ref (the CLI's tree/<ref>/<subdir> form requires one),
-    // and the daemon must not assume `main`. When a subdir is given without a ref,
-    // resolve the repo's ACTUAL default branch here and persist it as the ref. Returns
-    // the ref unchanged when there's nothing to resolve (no subdir, ref already set,
-    // non-GitHub source, or no installation).
-    const resolveRefForSubdir = async (
-      orgId: OrgId,
-      source: string,
-      ref: string | undefined,
-      subDir: string | undefined
-    ): Promise<string | undefined> => {
-      if (ref || !subDir) return ref
-      const gh = deps.github
+    // ONE lookup per write, answering everything a source write needs about the repo:
+    // its rename-proof NUMERIC id (without which the row never projects onto an
+    // AgentSpec — issue #935), whether it is private (rejected this release), and its
+    // default branch (a subdir source must pin a ref; the daemon must not assume
+    // `main`). The org installation answers first when it covers the owner; otherwise
+    // the anonymous public read does, which is the only path for a skills.sh source.
+    const resolveRepoBinding = async (orgId: OrgId, source: string): Promise<RepoBinding> => {
       const parsed = parseGithubRepo(source)
-      if (!gh || !parsed) return ref
-      const ins = await deps.repos.githubInstallation.liveByOrgAndAccount(orgId, parsed.owner)
-      if (!ins) return ref
-      const meta = await gh.getRepoMeta(ins, parsed.owner, parsed.repo).catch(() => null)
-      return meta?.defaultBranch ?? ref
+      if (!parsed) return { status: 'unparseable' }
+      const gh = deps.github
+      if (gh) {
+        const ins = await deps.repos.githubInstallation.liveByOrgAndAccount(orgId, parsed.owner)
+        // An installation failure is not a verdict on a PUBLIC repo — fall through
+        // to the anonymous read rather than treat the source as unbindable.
+        const ref = ins ? await gh.repoRefFor(ins, parsed.owner, parsed.repo).catch(() => null) : null
+        if (ref) return { status: 'ok', ...ref }
+      }
+      const resolve = deps.resolvePublicRepo
+      if (!resolve) return { status: 'unreachable' }
+      const pub = await resolve(parsed.owner, parsed.repo)
+      return typeof pub === 'string' ? { status: pub } : { status: 'ok', ...pub }
     }
 
-    // True only when we can CONFIRM the source repo is private (GitHub source + org
-    // installation + a readable meta saying private). Unknown ⇒ false (treated public).
-    const isPrivateRepo = async (orgId: OrgId, source: string): Promise<boolean> => {
-      const gh = deps.github
-      const parsed = parseGithubRepo(source)
-      if (!gh || !parsed) return false
-      const ins = await deps.repos.githubInstallation.liveByOrgAndAccount(orgId, parsed.owner)
-      if (!ins) return false
-      const meta = await gh.getRepoMeta(ins, parsed.owner, parsed.repo).catch(() => null)
-      return meta?.private === true
-    }
+    // Reject rather than persist a source whose identity we could not establish: an
+    // unbound row looks enabled in the console but is silently dropped from every
+    // projection, so it can never install anything (#935).
+    const rejectUnbound = (reply: FastifyReply, binding: RepoBinding) =>
+      binding.status === 'unreachable'
+        ? reply.code(503).send(bindingUnavailable)
+        : reply.code(400).send(binding.status === 'not-found' ? repoNotFound : notAGithubRepo)
 
     // Re-inline a source's definition onto every agent that enables it and push
     // the refreshed spec. Best-effort per agent (the register/ok roster is the
@@ -303,10 +310,17 @@ export function skillSourceRoutes(deps: HttpDeps) {
           tags: [Tag.Skills],
           summary: 'Register a skill source',
           description:
-            'Register an org-level public GitHub skill source and numeric repository identity. An omitted migration-compatible identity leaves the row visible but non-installable until bound: projection omits it from AgentSpec. The daemon acquires a bounded local snapshot; the remote source is never passed to the CLI. `skills` empty ⇒ install every skill the snapshot exposes. Rejected with 409 while any agent already enables skills under the requested source name — agents bind by name, so a new source must not silently capture existing selections.',
+            'Register an org-level public GitHub skill source. The numeric repository identity is resolved server-side (org installation first, then a public read), so no client needs to know it; `githubRepoId` in the body only overrides that lookup. A repository that cannot be identified is rejected — 400 when GitHub says it does not exist, 503 while GitHub is unreachable — rather than persisted as a row the projection would silently drop. The daemon acquires a bounded local snapshot; the remote source is never passed to the CLI. `skills` empty ⇒ install every skill the snapshot exposes. Rejected with 409 while any agent already enables skills under the requested source name — agents bind by name, so a new source must not silently capture existing selections.',
           operationId: 'createSkillSource',
           body: CreateSkillSourceBody,
-          response: { 201: SkillSourceDto, 400: ErrorDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
+          response: {
+            201: SkillSourceDto,
+            400: ErrorDto,
+            403: ErrorDto,
+            404: ErrorDto,
+            409: ErrorDto,
+            503: ErrorDto
+          }
         }
       },
       async (req, reply) => {
@@ -315,16 +329,19 @@ export function skillSourceRoutes(deps: HttpDeps) {
           req.body.visibility === 'restricted' && req.body.sharedWith
             ? await resolveShareSet(deps.repos.user, orgOf(req), req.body.sharedWith)
             : undefined
-        const repoId = parseRepoId(req.body.githubRepoId)
+        const binding = await resolveRepoBinding(orgOf(req), req.body.source)
         // Scope this release to PUBLIC sources: the daemon has no authorization path to
         // clone a private skill repo yet (a dedicated read-only grant is a follow-up).
-        // Reject a source we can confirm is private rather than silently accept one that
-        // can never install. Undeterminable privacy (no installation) is allowed through
-        // as public — a private repo with no installation can't be scanned/cloned anyway.
-        if (await isPrivateRepo(orgOf(req), req.body.source)) return reply.code(400).send(privateNotSupported)
-        const ref = await resolveRefForSubdir(orgOf(req), req.body.source, req.body.ref, req.body.subDir)
-        // A subdir source needs a ref; if we couldn't resolve one (owner has no org
-        // installation, non-GitHub source) reject rather than let the daemon assume `main`.
+        if (binding.status === 'ok' && binding.private) return reply.code(400).send(privateNotSupported)
+        // Bind the numeric identity server-side. A client-supplied id still wins (it is
+        // the same fact, already verified by the daemon before acquisition), but no
+        // client has to know it — which is what made every console-created source
+        // non-installable (#935).
+        const repoId = parseRepoId(req.body.githubRepoId) ?? (binding.status === 'ok' ? binding.repoId : undefined)
+        if (repoId === undefined) return rejectUnbound(reply, binding)
+        const ref = req.body.ref ?? (req.body.subDir && binding.status === 'ok' ? binding.defaultBranch : undefined)
+        // A subdir source needs a ref; if we couldn't resolve one reject rather than
+        // let the daemon assume `main`.
         if (req.body.subDir && !ref) return reply.code(400).send(subdirNeedsRef)
         // Name-capture guard — the mirror image of the delete guard: agents bind
         // by NAME, so registering a source under a name agents already enable
@@ -336,7 +353,7 @@ export function skillSourceRoutes(deps: HttpDeps) {
           orgId: orgOf(req),
           name: req.body.name,
           source: req.body.source,
-          ...(repoId !== undefined ? { githubRepoId: repoId } : {}),
+          githubRepoId: repoId,
           ...(ref !== undefined ? { ref } : {}),
           ...(req.body.subDir !== undefined ? { subDir: req.body.subDir } : {}),
           skills: req.body.skills,
@@ -363,23 +380,37 @@ export function skillSourceRoutes(deps: HttpDeps) {
           tags: [Tag.Skills],
           summary: 'Update a skill source',
           description:
-            'Edit a source’s source string, ref, subdir, or skill filter. `skills` replaces the stored filter wholesale. Name is immutable (agents bind by name; recreate to rename). Changes re-push every agent that enables this source.',
+            'Edit a source’s source string, ref, subdir, or skill filter. `skills` replaces the stored filter wholesale. Name is immutable (agents bind by name; recreate to rename). Changes re-push every agent that enables this source. The numeric repository identity is re-resolved when the source changes or the row never had one — which is how a historical unbound row is repaired — and clearing it is refused, since an unbound source can never install.',
           operationId: 'updateSkillSource',
           params: IdParam,
           body: UpdateSkillSourceBody,
-          response: { 200: SkillSourceDto, 400: ErrorDto, 403: ErrorDto, 404: ErrorDto }
+          response: { 200: SkillSourceDto, 400: ErrorDto, 403: ErrorDto, 404: ErrorDto, 503: ErrorDto }
         }
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
         const existing = await deps.repos.skillSource.get(orgOf(req), req.params.id)
         if (!existing || !canView(existing, ctxOf(req))) return notFound(reply)
+        if (req.body.githubRepoId === null) return reply.code(400).send(unbindNotAllowed)
+        const effSource = req.body.source ?? existing.source
+        const binding = await resolveRepoBinding(orgOf(req), effSource)
         // Same public-only guard as create, on the EFFECTIVE source — a PATCH that
         // points an existing source at a (now-confirmed) private repo is rejected too.
-        if (await isPrivateRepo(orgOf(req), req.body.source ?? existing.source)) {
-          return reply.code(400).send(privateNotSupported)
-        }
-        const repoId = parseRepoId(req.body.githubRepoId)
+        if (binding.status === 'ok' && binding.private) return reply.code(400).send(privateNotSupported)
+        // Re-bind when the identity would otherwise be wrong or missing: a changed
+        // source, or a historical row that never got one. This is what repairs the
+        // NULL rows already in the wild — PATCH had no way to fix them (#935). An
+        // unchanged, already-bound row is left alone, so an unrelated `skills` edit
+        // still succeeds while GitHub is unreachable.
+        const rebind = req.body.source !== undefined && req.body.source !== existing.source
+        const repoId =
+          parseRepoId(req.body.githubRepoId) ??
+          (rebind || existing.githubRepoId === null
+            ? binding.status === 'ok'
+              ? binding.repoId
+              : undefined
+            : existing.githubRepoId)
+        if (repoId === undefined) return rejectUnbound(reply, binding)
         // Preserve an explicit ref across an unrelated PATCH: only resolve a default
         // branch when the EFFECTIVE ref is absent (untouched-and-existing counts as
         // present), so a `skills`-only edit can't silently rewrite the pinned ref.
@@ -387,18 +418,13 @@ export function skillSourceRoutes(deps: HttpDeps) {
         const currentRef = refTouched ? (req.body.ref ?? undefined) : (existing.ref ?? undefined)
         const effSubDir =
           req.body.subDir === undefined ? (existing.subDir ?? undefined) : (req.body.subDir ?? undefined)
-        const resolvedRef = await resolveRefForSubdir(
-          orgOf(req),
-          req.body.source ?? existing.source,
-          currentRef,
-          effSubDir
-        )
+        const resolvedRef = currentRef ?? (effSubDir && binding.status === 'ok' ? binding.defaultBranch : undefined)
         // A subdir source needs a ref; reject if we couldn't resolve one rather than
         // let the daemon assume `main`.
         if (effSubDir && !resolvedRef) return reply.code(400).send(subdirNeedsRef)
         const source = await deps.repos.skillSource.update(orgOf(req), existing.id, {
           ...(req.body.source !== undefined ? { source: req.body.source } : {}),
-          ...(repoId !== undefined ? { githubRepoId: repoId } : {}),
+          githubRepoId: repoId,
           ...(resolvedRef !== undefined
             ? { ref: resolvedRef }
             : refTouched && req.body.ref === null
@@ -507,4 +533,29 @@ const privateNotSupported = {
   error: 'Bad Request',
   statusCode: 400,
   message: 'private skill sources are not supported yet — use a public repository'
+}
+
+const repoNotFound = {
+  error: 'Bad Request',
+  statusCode: 400,
+  message: 'no such public GitHub repository — a source that cannot be identified can never install'
+}
+
+const notAGithubRepo = {
+  error: 'Bad Request',
+  statusCode: 400,
+  message: 'source must name a GitHub repository so its numeric identity can be bound'
+}
+
+const bindingUnavailable = {
+  error: 'Service Unavailable',
+  statusCode: 503,
+  message: 'could not reach GitHub to identify the repository — retry shortly'
+}
+
+/** An explicit `githubRepoId: null` asks for exactly the state #935 is about. */
+const unbindNotAllowed = {
+  error: 'Bad Request',
+  statusCode: 400,
+  message: 'githubRepoId cannot be cleared — an unbound source is never installable'
 }

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -194,6 +194,14 @@ export interface HttpApp {
 /** Empty liveness: no daemon is "connected right now" unless a test overrides it. */
 const NO_LIVENESS: DaemonLiveness = { get: () => undefined }
 
+/** Stable per-name repo id for the offline GitHub stand-in — distinct names get
+ *  distinct ids, and one name keeps its id across calls and across apps. */
+function fakeRepoId(fullName: string): bigint {
+  let h = 2166136261n
+  for (const ch of fullName) h = ((h ^ BigInt(ch.codePointAt(0)!)) * 16777619n) & 0xffffffffn
+  return h + 1n
+}
+
 export function buildHttpApp(
   prisma: PrismaClient,
   configOverrides?: Partial<HttpDeps['config']>,
@@ -476,6 +484,15 @@ export function buildHttpApp(
     mcpRateLimit: new McpRateLimiter(clock),
     sharedTx: <T>(fn: () => Promise<T>) => rootPrisma.$transaction((tx) => runWithSharedTx(tx, fn)),
     readiness: createReadiness(() => pingDb(prisma)),
+    // Offline stand-in for the anonymous GitHub read that binds a skill source's
+    // numeric identity: every repo resolves, to a deterministic id per owner/repo.
+    // Suites that care about the unbindable paths override this dep.
+    resolvePublicRepo: async (owner: string, repo: string) => ({
+      repoId: fakeRepoId(`${owner}/${repo}`),
+      fullName: `${owner}/${repo}`,
+      private: false,
+      defaultBranch: 'main'
+    }),
     config: { DEFAULT_OWNER_ID, ...configOverrides },
     sessionAccessPlugins: [
       { provider: 'slack', available: false, resolve: async () => ({ allowedScopes: [], degraded: false }) },

--- a/packages/control-plane/test/integration/skill-sources.route.test.ts
+++ b/packages/control-plane/test/integration/skill-sources.route.test.ts
@@ -27,6 +27,7 @@ import { Prisma } from '../../src/generated/prisma/client.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { lockSkillSourceNameScope } from '../../src/persistence/skill-source-lock.js'
 import type { OrgMemberRole } from '../../src/persistence/ports.js'
+import type { HttpDeps } from '../../src/http/deps.js'
 import { AgentId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 
@@ -664,5 +665,157 @@ describe('GET /skill-sources/registry/search', () => {
     expect(
       (await viewer.app.inject({ method: 'GET', url: `${ORG}/skill-sources/registry/search?q=pdf` })).statusCode
     ).toBe(403)
+  })
+})
+
+/**
+ * Numeric repository identity binding (issue #935). `AgentSkillEntry` REQUIRES
+ * `githubRepoId`, so a row without one is dropped by the projection: the console
+ * shows the source enabled and the daemon never hears about it. No console entry
+ * point can send that id — it isn't in any read the web client has — so the CP
+ * must resolve it from `source` itself, and must refuse a write it cannot bind
+ * rather than persist a row that installs nothing.
+ */
+describe('POST/PATCH /skill-sources — githubRepoId binding', () => {
+  function appResolving(resolve: HttpDeps['resolvePublicRepo']): HttpApp {
+    const app = buildHttpApp(prisma, undefined, undefined, undefined, { resolvePublicRepo: resolve })
+    opened.push(app)
+    return app
+  }
+
+  const publicRepo = async (owner: string, repo: string) => ({
+    repoId: 7654321n,
+    fullName: `${owner}/${repo}`,
+    private: false,
+    defaultBranch: 'trunk'
+  })
+
+  it('binds the id a console create cannot send, and the source then projects onto the AgentSpec', async () => {
+    const app = appResolving(publicRepo)
+    // Exactly the body SkillSourcesCard/InstallRegistrySkillModal send: no id.
+    const created = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'anthropics/skills' }
+    })
+    expect(created.statusCode).toBe(201)
+    expect(created.json().githubRepoId).toBe('7654321')
+
+    const agentId = await createAgent(app, 'enabler', ['kit/*'])
+    const agent = await app.deps.repos.agent.get(OrgId(DEFAULT_ORG_ID), AgentId(agentId))
+    const spec = await app.deps.agentSpecs.assemble(agent!)
+    expect(spec.skills).toEqual([{ name: 'kit', source: 'anthropics/skills', githubRepoId: '7654321', skills: [] }])
+  })
+
+  it('pins a subdir source to the resolved default branch, not an assumed `main`', async () => {
+    const app = appResolving(publicRepo)
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'sub', source: 'anthropics/skills', subDir: 'packs' }
+    })
+    expect(res.statusCode).toBe(201)
+    expect(res.json()).toMatchObject({ ref: 'trunk', githubRepoId: '7654321' })
+  })
+
+  it('an explicitly supplied id still wins over the lookup', async () => {
+    const app = appResolving(publicRepo)
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'anthropics/skills', githubRepoId: '42' }
+    })
+    expect(res.statusCode).toBe(201)
+    expect(res.json().githubRepoId).toBe('42')
+  })
+
+  it('refuses a repo GitHub says does not exist instead of storing a non-installable row', async () => {
+    const app = appResolving(async () => 'not-found')
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'anthropics/skills' }
+    })
+    expect(res.statusCode).toBe(400)
+    expect((await app.app.inject({ method: 'GET', url: `${ORG}/skill-sources` })).json()).toEqual([])
+  })
+
+  it('reports an unreachable GitHub as retryable rather than as a bad request', async () => {
+    const app = appResolving(async () => 'unreachable')
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'anthropics/skills' }
+    })
+    expect(res.statusCode).toBe(503)
+  })
+
+  it('rejects a confirmed-private repo before binding it', async () => {
+    const app = appResolving(async (owner, repo) => ({
+      repoId: 9n,
+      fullName: `${owner}/${repo}`,
+      private: true,
+      defaultBranch: 'main'
+    }))
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'anthropics/skills' }
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().message).toContain('private skill sources are not supported')
+  })
+
+  it('back-fills a historical unbound row on the next edit — the repair PATCH could not do', async () => {
+    const app = appResolving(publicRepo)
+    const id = await createSource(app, 'legacy')
+    // Simulate a row created before the binding existed (SQL bypasses the route).
+    await prisma.skillSource.update({ where: { id }, data: { githubRepoId: null } })
+
+    const patched = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/skill-sources/${id}`,
+      payload: { skills: ['helper'] }
+    })
+    expect(patched.statusCode).toBe(200)
+    expect(patched.json().githubRepoId).toBe('7654321')
+  })
+
+  it('re-binds when the source is repointed, and leaves a bound row alone otherwise', async () => {
+    let calls = 0
+    const app = appResolving(async (owner, repo) => {
+      calls += 1
+      return { repoId: BigInt(1000 + calls), fullName: `${owner}/${repo}`, private: false, defaultBranch: 'main' }
+    })
+    const id = await createSource(app, 'kit') // calls = 1 → 1001
+    const repointed = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/skill-sources/${id}`,
+      payload: { source: 'anthropics/skills' }
+    })
+    expect(repointed.json().githubRepoId).toBe('1002')
+
+    // An unrelated edit keeps the bound id — a `skills`-only PATCH must not depend
+    // on GitHub being reachable.
+    const unrelated = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/skill-sources/${id}`,
+      payload: { skills: ['helper'] }
+    })
+    expect(unrelated.json().githubRepoId).toBe('1002')
+  })
+
+  it('refuses to clear the id — that is precisely the non-installable state', async () => {
+    const app = appResolving(publicRepo)
+    const id = await createSource(app, 'kit')
+    const res = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/skill-sources/${id}`,
+      payload: { githubRepoId: null }
+    })
+    expect(res.statusCode).toBe(400)
+    expect((await app.app.inject({ method: 'GET', url: `${ORG}/skill-sources/${id}` })).json().githubRepoId).toBe(
+      '7654321'
+    )
   })
 })

--- a/packages/control-plane/test/integration/skill-sources.route.test.ts
+++ b/packages/control-plane/test/integration/skill-sources.route.test.ts
@@ -819,3 +819,106 @@ describe('POST/PATCH /skill-sources — githubRepoId binding', () => {
     )
   })
 })
+
+/**
+ * Rename/transfer redirects and the accepted-source grammar — the two findings
+ * from the review of the binding change.
+ *
+ * GitHub answers `GET /repos/docker/docker` with `full_name: moby/moby`. Storing
+ * the typed slug next to the resolved id would fail on the daemon, whose identity
+ * check requires `full_name` to equal the configured source. And because binding
+ * is now mandatory, every form `SkillSourceArg` admits must decompose here, or the
+ * DTO accepts a source the route then rejects.
+ */
+describe('POST/PATCH /skill-sources — canonical slug and accepted forms', () => {
+  /** Resolves any name to one repo that has since moved to `moby/moby`. */
+  const redirected: HttpDeps['resolvePublicRepo'] = async () => ({
+    repoId: 111n,
+    fullName: 'moby/moby',
+    private: false,
+    defaultBranch: 'main'
+  })
+
+  function appResolving(resolve: HttpDeps['resolvePublicRepo']): HttpApp {
+    const app = buildHttpApp(prisma, undefined, undefined, undefined, { resolvePublicRepo: resolve })
+    opened.push(app)
+    return app
+  }
+
+  it('stores the slug GitHub redirected to, so the daemon identity check can pass', async () => {
+    const app = appResolving(redirected)
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'docker/docker' }
+    })
+    expect(res.statusCode).toBe(201)
+    expect(res.json()).toMatchObject({ source: 'moby/moby', githubRepoId: '111' })
+  })
+
+  it('rewrites only the owner/repo half, preserving the rest of the source string', async () => {
+    const app = appResolving(redirected)
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'https://github.com/docker/docker.git/tree/v2/packs' }
+    })
+    expect(res.statusCode).toBe(201)
+    expect(res.json().source).toBe('https://github.com/moby/moby.git/tree/v2/packs')
+  })
+
+  it('canonicalizes on the back-fill too — a stale stored slug is repaired with the id', async () => {
+    const app = appResolving(redirected)
+    const id = await createSource(app, 'legacy', { source: 'docker/docker' })
+    await prisma.skillSource.update({ where: { id }, data: { githubRepoId: null, source: 'docker/docker' } })
+
+    const patched = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/skill-sources/${id}`,
+      payload: { skills: ['helper'] }
+    })
+    expect(patched.statusCode).toBe(200)
+    expect(patched.json()).toMatchObject({ source: 'moby/moby', githubRepoId: '111' })
+  })
+
+  it('leaves the source alone when the resolved name already matches', async () => {
+    const app = appResolving(async (owner, repo) => ({
+      repoId: 5n,
+      fullName: `${owner}/${repo}`,
+      private: false,
+      defaultBranch: 'main'
+    }))
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'https://github.com/anthropics/skills' }
+    })
+    expect(res.json().source).toBe('https://github.com/anthropics/skills')
+  })
+
+  // Every form SkillSourceArg admits must bind; before this, the host-prefixed
+  // shorthand and a mid-path `.git` were newly rejected by mandatory binding.
+  it.each([
+    ['bare shorthand', 'anthropics/skills'],
+    ['host-prefixed shorthand', 'github.com/anthropics/skills'],
+    ['https', 'https://github.com/anthropics/skills'],
+    ['https with .git', 'https://github.com/anthropics/skills.git'],
+    ['https tree with .git', 'https://github.com/anthropics/skills.git/tree/main/packs'],
+    ['scp ssh', 'git@github.com:anthropics/skills'],
+    ['ssh url', 'ssh://git@github.com/anthropics/skills']
+  ])('binds a source given in %s form', async (_label, source) => {
+    const seen: string[] = []
+    const app = appResolving(async (owner, repo) => {
+      seen.push(`${owner}/${repo}`)
+      return { repoId: 314n, fullName: `${owner}/${repo}`, private: false, defaultBranch: 'main' }
+    })
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source }
+    })
+    expect(res.statusCode).toBe(201)
+    expect(res.json().githubRepoId).toBe('314')
+    expect(seen).toEqual(['anthropics/skills'])
+  })
+})


### PR DESCRIPTION
Fixes #935.

## The bug

`AgentSkillEntry` requires `githubRepoId`, so a skill source without one is dropped by the projection — the console shows the source enabled, the daemon never hears about it, nothing is installed, and the only trace is a CP `warn` line.

The value could only come from the request body, and no console entry point sends it: **Import from GitHub**, **Edit skill source**, and **Install from skills.sh** all omit it, and the web client has no read that would surface it (`POST /skill-sources/preview` returns `{branches, tags, skills}` only). So every source created through the supported UI was permanently non-installable. `PATCH` had the same gap, so an existing `NULL` row could not be repaired through the UI either.

## The fix

Resolve the id in the route. The lookup was already happening on both paths for the private-repo guard and was throwing the id away — `getRepoMeta` wraps `repoRefFor`, which returns exactly `{repoId, private, defaultBranch}`. One `resolveRepoBinding` now answers all three questions per write, replacing two duplicate round trips.

**The installation token is not enough.** It only covers repos an org GitHub App installation can see, and the commonest source of all — a skills.sh hit like `anthropics/skills` — belongs to no installation. So binding falls back to an anonymous `GET /repos/{owner}/{repo}` (new `github/public-repo.ts`): the same public endpoint the daemon already uses to verify identity before acquisition, no credential involved.

**A write that cannot bind is refused** rather than persisted as a row that looks enabled and installs nothing:

| Situation | Result |
| --- | --- |
| Bound (installation or public read) | persisted with the id |
| `githubRepoId` supplied in the body | wins over the lookup |
| GitHub says the repo does not exist | `400` |
| GitHub unreachable / rate limited | `503` — retryable, never reported as "no such repo" |
| Confirmed private | `400` (unchanged) |

`PATCH` re-binds when the source changes or the row never had an identity — **this is the repair path for the `NULL` rows already in the wild**. An unchanged, already-bound row is left alone, so a `skills`-only edit still succeeds while GitHub is down. Clearing the id is refused: that is precisely the broken state.

Also parses the `ssh://git@github.com/owner/repo` form, which `parseGithubRepo` missed — now that an unparseable source is rejected, a form that used to be accepted must still parse.

## Why the CP and not the web modals

Fixing this in the three console modals would leave the API able to create silently-broken rows. The CP covers the API and all three entry points at once, and is the only layer that can back-fill an existing unbound row.

## Verification

- New end-to-end assertion: a console-shaped `POST` (no id) → agent enables it → `agentSpecs.assemble()` returns the source in `spec.skills`. That is the link that was broken.
- 9 new integration cases (bind, subdir default-branch pin, explicit-id override, not-found, unreachable, private, back-fill, re-bind vs leave-alone, refuse-clear) + 3 unit cases on the anonymous resolver's verdict split.
- `test:unit` 1639 passed · `test:int` 83 files / 1275 passed · typecheck + lint + format clean.

## Note for reviewers

`POST` now returns `503` when GitHub is unreachable instead of accepting the source. That is a deliberate behavior change — the alternative is keeping the path that produces unbindable rows. Edits to existing bound sources are unaffected.

Two follow-ups the issue raises are **not** in scope here: surfacing "registered but not installable" / last install outcome on the tile, and the broader question of how quiet `onInvalidSkillSource` is. This PR removes the way those rows get created; it does not make a pre-existing one visible in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)