### PR TITLE
refactor(control-plane): fold the pool into the unified member-set model

### DIFF
--- a/packages/control-plane/prisma/migrations/20260823000000_member_set/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260823000000_member_set/migration.sql
@@ -1,0 +1,55 @@
+-- Fold the install-wide pool into the unified member-set model (docs/designs/daemon-groups.md §8).
+-- A member set is a named set of daemons within which an agent's duty may be claimed; the pool is
+-- one row of it, org-less, and `placementKind = 'pool'` stops being a stored value.
+CREATE TABLE "member_set" (
+    "id" UUID NOT NULL,
+    "orgId" TEXT,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "member_set_pkey" PRIMARY KEY ("id")
+);
+
+-- One daemon in at most one set: the daemon IS the primary key.
+CREATE TABLE "member_set_member" (
+    "setId" UUID NOT NULL,
+    "daemonId" UUID NOT NULL,
+    "joinedAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "member_set_member_pkey" PRIMARY KEY ("daemonId")
+);
+
+CREATE INDEX "member_set_orgId_idx" ON "member_set"("orgId");
+CREATE INDEX "member_set_member_setId_idx" ON "member_set_member"("setId");
+
+-- One cross-org set per install: `orgId IS NULL` means the pool, and there is exactly one pool.
+CREATE UNIQUE INDEX "member_set_cross_org_key" ON "member_set" (("orgId" IS NULL)) WHERE "orgId" IS NULL;
+
+ALTER TABLE "member_set" ADD CONSTRAINT "member_set_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "member_set_member" ADD CONSTRAINT "member_set_member_setId_fkey" FOREIGN KEY ("setId") REFERENCES "member_set"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- Retiring a member's daemon row removes its membership with it, so a dead Pod is never eligible.
+ALTER TABLE "member_set_member" ADD CONSTRAINT "member_set_member_daemonId_fkey" FOREIGN KEY ("daemonId") REFERENCES "daemon"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- The `set`-kind ref, nullable exactly as `daemonId` is nullable for a `set`-kind agent.
+ALTER TABLE "agent" ADD COLUMN "setId" UUID;
+CREATE INDEX "agent_setId_idx" ON "agent"("setId");
+ALTER TABLE "agent" ADD CONSTRAINT "agent_setId_fkey" FOREIGN KEY ("setId") REFERENCES "member_set"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- The install-wide pool, as a row.
+INSERT INTO "member_set" ("id", "orgId", "name") VALUES (gen_random_uuid(), NULL, 'AgentConnect Cloud');
+
+-- Every pool agent points at it, and every org-less daemon row is one of its members.
+UPDATE "agent" SET "setId" = (SELECT "id" FROM "member_set" WHERE "orgId" IS NULL) WHERE "placementKind" = 'pool';
+INSERT INTO "member_set_member" ("setId", "daemonId")
+SELECT (SELECT "id" FROM "member_set" WHERE "orgId" IS NULL), "id" FROM "daemon" WHERE "orgId" IS NULL;
+
+-- Contract the enum. `ALTER TYPE … ADD VALUE` cannot be used in the transaction that adds it, so
+-- the rewrite goes through a replacement type, which is also what drops `pool` in the same step.
+CREATE TYPE "AgentPlacementKind_new" AS ENUM ('daemon', 'set');
+ALTER TABLE "agent" ALTER COLUMN "placementKind" DROP DEFAULT;
+ALTER TABLE "agent" ALTER COLUMN "placementKind" TYPE "AgentPlacementKind_new"
+  USING (CASE "placementKind"::text WHEN 'pool' THEN 'set' ELSE "placementKind"::text END)::"AgentPlacementKind_new";
+ALTER TYPE "AgentPlacementKind" RENAME TO "AgentPlacementKind_old";
+ALTER TYPE "AgentPlacementKind_new" RENAME TO "AgentPlacementKind";
+DROP TYPE "AgentPlacementKind_old";
+ALTER TABLE "agent" ALTER COLUMN "placementKind" SET DEFAULT 'daemon';

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -86,6 +86,7 @@ model Org {
   members                   Membership[]
   daemons                   Daemon[]
   agents                    Agent[]
+  memberSets                MemberSet[]
   crons                     CronDef[]
   hooks                     HookDef[]
   apiKeys                   ApiKey[]
@@ -435,6 +436,7 @@ model Daemon {
   sessions              SessionMeta[]
   lifecycleOps          DaemonLifecycleOp[]
   webchatMcpDelegations WebchatMcpDelegation[]
+  setMembership         MemberSetMember?
 
   @@unique([clusterIdentity, clusterPodUid], map: "daemon_cluster_identity_pod_key")
   @@index([orgId])
@@ -665,12 +667,53 @@ enum AgentStatus {
   paused
 }
 
-// Where an agent's duty may be held (docs/designs/k8s-daemon-pool.md §14). `daemon` names one
-// machine through `Agent.daemonId`; `pool` names the install-wide member set and carries no ref.
-// A later `group` value names an explicit daemon group — read it through domain/placement.ts.
+// ───────────────────────────────────────────────────────────────────────────
+// MemberSet / MemberSetMember — a named set of daemons within which an agent's
+//   duty may be claimed (docs/designs/daemon-groups.md §2). The install-wide
+//   pool is one ROW of it, not a kind of its own.
+// ───────────────────────────────────────────────────────────────────────────
+
+/// A named set of daemons within which an agent's duty may be claimed. `orgId` is nullable and
+/// NULL MEANS CROSS-ORG, never "unassigned": an org-less set is served by org-less daemons and
+/// holds every organization's agents. The install-wide pool is that row — one per install, which
+/// the partial unique index `member_set_cross_org_key` (migration-only; Prisma cannot express it)
+/// enforces.
+model MemberSet {
+  id        String   @id @db.Uuid
+  orgId     String? // NULL = cross-org (the install-wide pool), never "unassigned"
+  name      String
+  createdAt DateTime @default(now()) @db.Timestamptz(6)
+
+  org     Org?              @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  members MemberSetMember[]
+  agents  Agent[]
+
+  @@index([orgId])
+  @@map("member_set")
+}
+
+/// One daemon in at most one set — the daemon IS the primary key. Two write-time invariants,
+/// enforced where the row is written (`member-set.repo.ts#enrollDaemonInSet`) and nowhere else:
+/// an org-less set accepts only org-less daemons, an org set only that org's daemons. They are
+/// what lets eligibility be a single membership lookup with no tenancy branch.
+model MemberSetMember {
+  setId    String   @db.Uuid
+  daemonId String   @id @db.Uuid
+  joinedAt DateTime @default(now()) @db.Timestamptz(6)
+
+  set    MemberSet @relation(fields: [setId], references: [id], onDelete: Cascade)
+  daemon Daemon    @relation(fields: [daemonId], references: [id], onDelete: Cascade)
+
+  @@index([setId])
+  @@map("member_set_member")
+}
+
+// Where an agent's duty may be held (docs/designs/daemon-groups.md §2). `daemon` names one
+// machine through `Agent.daemonId`; `set` names a member set through `Agent.setId` — the
+// install-wide pool is the org-less set. Read the pair through domain/placement.ts.
 enum AgentPlacementKind {
   daemon
-  pool
+  set
 }
 
 model Agent {
@@ -689,10 +732,11 @@ model Agent {
   runtime               String?
   status                AgentStatus        @default(inactive)
   // Placement is a TARGET, not only a member id. `daemon` (the default, so every pre-existing row
-  // keeps meaning what it meant) resolves through `daemonId`; `pool` resolves to the install-wide
-  // member set and requires `daemonId` to be null. Only domain/placement.ts reads the pair.
+  // keeps meaning what it meant) resolves through `daemonId`; `set` resolves through `setId`, the
+  // install-wide pool being the org-less set. Only domain/placement.ts reads the triple.
   placementKind         AgentPlacementKind @default(daemon)
   daemonId              String?            @db.Uuid // the `daemon`-kind ref: 1 agent : 1 machine (null until placed)
+  setId                 String?            @db.Uuid // the `set`-kind ref, null for a `daemon` placement as daemonId is for a `set` one
   // ── workspace (inline; §3.5) — daemon-generated path ──
   workspaceMode         WorkspaceMode      @default(scratch)
   workspaceIsolation    WorkspaceIsolation @default(shared)
@@ -742,6 +786,7 @@ model Agent {
 
   org                   Org                        @relation(fields: [orgId], references: [id], onDelete: Cascade)
   daemon                Daemon?                    @relation(fields: [daemonId], references: [id], onDelete: SetNull)
+  set                   MemberSet?                 @relation(fields: [setId], references: [id], onDelete: SetNull)
   createdBy             User?                      @relation("AgentCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
   lastModifiedBy        User?                      @relation("AgentModifiedBy", fields: [lastModifiedByUserId], references: [id], onDelete: SetNull)
   assignments           Assignment[]
@@ -767,6 +812,7 @@ model Agent {
   @@unique([id, orgId])
   @@index([orgId])
   @@index([daemonId])
+  @@index([setId])
   @@map("agent")
 }
 

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -86,6 +86,7 @@ import {
   PgSocialIdentityMutationGate,
   PgCronRepo,
   PgDutyGroupRepo,
+  PgMemberSetRepo,
   PgHookRepo,
   PgHookSecretStore,
   PgRuntimeProfileRepo,
@@ -361,6 +362,7 @@ export function buildContainer(
     presetAgent: new PgPresetAgentStore(prisma),
     cron: new PgCronRepo(prisma),
     dutyGroup: new PgDutyGroupRepo(prisma),
+    memberSet: new PgMemberSetRepo(prisma),
     hook: new PgHookRepo(prisma),
     hookSecret: new PgHookSecretStore(prisma, secretCipher),
     runtimeProfile: new PgRuntimeProfileRepo(prisma),
@@ -595,13 +597,15 @@ export function buildContainer(
   // current duty holder (orchestrator/placementResolver.ts).
   const placementResolver = new PlacementResolver({
     duties: repos.dutyGroup,
-    // Install-wide members ready to take a trigger. Only the rendezvous fallback reads this: a
-    // pool agent whose lease lapsed has no holder, and any member can claim it on receipt.
-    liveMembers: () =>
-      connReg
+    // The set's members ready to take a trigger. Only the rendezvous fallback reads this: a set
+    // agent whose lease lapsed has no holder, and any member can claim it on receipt.
+    liveMembers: async (setId) => {
+      const members = new Set(await repos.memberSet.memberIdsOf(setId))
+      return connReg
         .reachableDaemons()
-        .filter((d) => d.orgId === null && d.state === 'READY')
-        .map((d) => d.daemonId),
+        .filter((d) => d.state === 'READY' && members.has(d.daemonId))
+        .map((d) => d.daemonId)
+    },
     clock
   })
 
@@ -746,7 +750,7 @@ export function buildContainer(
     mutations: agentMutations,
     sessionOwners: connReg,
     placement: placementResolver,
-    daemons: repos.daemon,
+    memberSets: repos.memberSet,
     recomputeDuties: (orgId: string) => dutyRecompute.kick(orgId),
     log: { warn: (o, m) => http.log.warn(o, m) }
   })
@@ -1003,6 +1007,7 @@ export function buildContainer(
     repos: {
       agent: repos.agent,
       assignment: repos.assignment,
+      memberSet: repos.memberSet,
       daemonLifecycleOp: repos.daemonLifecycleOp,
       cron: repos.cron,
       hook: repos.hook,
@@ -1055,7 +1060,6 @@ export function buildContainer(
     control: sender,
     agentDelivery,
     placementResolver,
-    daemonRows: repos.daemon,
     visibilityPush,
     relayControl,
     httpBot,

--- a/packages/control-plane/src/domain/placement.ts
+++ b/packages/control-plane/src/domain/placement.ts
@@ -1,56 +1,59 @@
 /**
- * The ONE answer to "which daemons may hold this agent's duty, and what connection scope must
- * they have" (docs/designs/k8s-daemon-pool.md §14). Placement used to be a member id read inline
- * as `agent.daemonId`; it is now a TARGET — `daemon` names one machine, `pool` names the
- * install-wide member set — and every reader of eligibility comes through here.
+ * The ONE answer to "which daemons may hold this agent's duty"
+ * (docs/designs/daemon-groups.md §2/§3). Placement is a TARGET — `daemon` names one machine,
+ * `set` names a member set (the install-wide pool is the org-less one) — and every reader of
+ * eligibility comes through here.
  *
- * Nothing outside this module may branch on the string `pool`. A later `group` kind adds one arm
- * here and one join in the ledger's predicate; the callers do not learn about it.
+ * Nothing outside this module may branch on the placement kind. Tenancy is deliberately NOT a
+ * branch here: it is the write-time invariant on membership, so eligibility for a set is one
+ * membership lookup and the module has fewer arms than when the pool was a kind.
  */
 import type { DaemonId } from './ids.js'
 
 /** Mirrors the Prisma `AgentPlacementKind` enum without importing the generated client. */
-export type PlacementKind = 'daemon' | 'pool'
+export type PlacementKind = 'daemon' | 'set'
 
 /** The placement columns, as every caller already has them on an agent record. */
 export interface PlacementRef {
   placementKind: PlacementKind
   daemonId: string | null
+  setId: string | null
 }
 
-/** What a connection is allowed to claim. Install-wide = frame-mode (org-less) member. */
-export type DutyClaimScope = 'install-wide' | 'org-scoped'
+/** What a connected daemon may claim: the set it is a member of, or nothing at all. */
+export type DutyClaimScope = { setId: string } | 'none'
 
 /**
  * Who may hold this agent's duty.
- * - `daemon` — exactly that machine. An install-wide member is never it, so a local daemon's
- *   vacancies stay vacant, which is what keeps the pool off agents it must not serve.
- * - `install-wide` — any live frame-mode member.
+ * - `daemon` — exactly that machine. A set member is never it, so a local daemon's vacancies stay
+ *   vacant, which is what keeps the pool off agents it must not serve.
+ * - `set` — exactly the members of that set.
  * - `none` — the agent is unplaced; nobody may hold it.
  */
-export type DutyEligibility = { scope: 'daemon'; daemonId: DaemonId } | { scope: 'install-wide' } | { scope: 'none' }
+export type DutyEligibility =
+  { scope: 'daemon'; daemonId: DaemonId } | { scope: 'set'; setId: string } | { scope: 'none' }
 
 export function dutyEligibility(agent: PlacementRef): DutyEligibility {
-  if (agent.placementKind === 'pool') return { scope: 'install-wide' }
+  if (agent.placementKind === 'set') return agent.setId ? { scope: 'set', setId: agent.setId } : { scope: 'none' }
   return agent.daemonId ? { scope: 'daemon', daemonId: agent.daemonId as DaemonId } : { scope: 'none' }
 }
 
-/** The claim scope of a connected daemon: org-less rows are the install-wide pool members. */
-export function claimScopeOf(daemon: { orgId: string | null }): DutyClaimScope {
-  return daemon.orgId === null ? 'install-wide' : 'org-scoped'
+/** The claim scope of a connected daemon: the set it belongs to, read from membership. */
+export function claimScopeOf(daemon: { setId: string | null }): DutyClaimScope {
+  return daemon.setId === null ? 'none' : { setId: daemon.setId }
 }
 
 /** May this claimant hold this agent's duty? The predicate the ledger's SQL mirrors row-wise. */
 export function mayHold(agent: PlacementRef, claimant: { daemonId: DaemonId; scope: DutyClaimScope }): boolean {
   const eligibility = dutyEligibility(agent)
   if (eligibility.scope === 'none') return false
-  if (eligibility.scope === 'install-wide') return claimant.scope === 'install-wide'
+  if (eligibility.scope === 'set') return claimant.scope !== 'none' && claimant.scope.setId === eligibility.setId
   return eligibility.daemonId === claimant.daemonId
 }
 
 /**
  * The delivery targets placement alone names — the placement half of `AgentDelivery.daemonsFor`.
- * A pool agent names none: its members are whoever holds the duty, which is the ledger's answer,
+ * A set agent names none: its members are whoever holds the duty, which is the ledger's answer,
  * not placement's. That is the whole reason this returns a list rather than an id.
  */
 export function placementTargets(agent: PlacementRef): string[] {
@@ -58,36 +61,47 @@ export function placementTargets(agent: PlacementRef): string[] {
   return eligibility.scope === 'daemon' ? [eligibility.daemonId] : []
 }
 
-/** Is this agent placed at all? `pool` is placed without naming a machine. */
+/** Is this agent placed at all? A `set` placement is placed without naming a machine. */
 export function isPlaced(agent: PlacementRef): boolean {
   return dutyEligibility(agent).scope !== 'none'
 }
 
 /** Where a placement write points. `unplaced` is the absence of a target, not a third kind. */
-export type PlacementTarget = { kind: 'daemon'; daemonId: DaemonId } | { kind: 'pool' } | { kind: 'unplaced' }
+export type PlacementTarget =
+  { kind: 'daemon'; daemonId: DaemonId } | { kind: 'set'; setId: string } | { kind: 'unplaced' }
 
 export const UNPLACED: PlacementTarget = { kind: 'unplaced' }
-export const ON_POOL: PlacementTarget = { kind: 'pool' }
+export const onSet = (setId: string): PlacementTarget => ({ kind: 'set', setId })
 export const onDaemon = (daemonId: DaemonId): PlacementTarget => ({ kind: 'daemon', daemonId })
 
 export function placementTargetOf(agent: PlacementRef): PlacementTarget {
-  if (agent.placementKind === 'pool') return { kind: 'pool' }
-  return agent.daemonId ? { kind: 'daemon', daemonId: agent.daemonId as DaemonId } : UNPLACED
+  const eligibility = dutyEligibility(agent)
+  if (eligibility.scope === 'set') return { kind: 'set', setId: eligibility.setId }
+  return eligibility.scope === 'daemon' ? { kind: 'daemon', daemonId: eligibility.daemonId } : UNPLACED
 }
 
-/** The two columns a target writes. `pool` clears `daemonId`: a pool agent names no machine, and
- *  leaving a stale member id there is exactly the dead-Pod pointer this representation removes. */
-export function placementColumns(target: PlacementTarget): { placementKind: PlacementKind; daemonId: string | null } {
-  if (target.kind === 'pool') return { placementKind: 'pool', daemonId: null }
-  return { placementKind: 'daemon', daemonId: target.kind === 'daemon' ? target.daemonId : null }
+/** The columns a target writes. Each kind clears the other's ref: a set agent names no machine,
+ *  and leaving a stale member id there is exactly the dead-Pod pointer this representation removes. */
+export function placementColumns(target: PlacementTarget): {
+  placementKind: PlacementKind
+  daemonId: string | null
+  setId: string | null
+} {
+  if (target.kind === 'set') return { placementKind: 'set', daemonId: null, setId: target.setId }
+  return {
+    placementKind: 'daemon',
+    daemonId: target.kind === 'daemon' ? target.daemonId : null,
+    setId: null
+  }
 }
 
 export function samePlacement(a: PlacementTarget, b: PlacementTarget): boolean {
   if (a.kind !== b.kind) return false
-  return a.kind !== 'daemon' || a.daemonId === (b as { daemonId: DaemonId }).daemonId
+  if (a.kind === 'daemon') return a.daemonId === (b as { daemonId: DaemonId }).daemonId
+  return a.kind !== 'set' || a.setId === (b as { setId: string }).setId
 }
 
-/** A stable label for logs and conflict messages — never a raw member id for a pool placement. */
+/** A stable label for logs and conflict messages — never a raw member id for a set placement. */
 export function placementLabel(target: PlacementTarget): string {
   return target.kind === 'daemon' ? target.daemonId : target.kind
 }

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -26,6 +26,7 @@ import type {
   AgentSecretStore,
   AgentConfigWriter,
   McpProviderRepo,
+  MemberSetRepo,
   McpProviderSecretStore,
   McpGrantRepo,
   SkillSourceRepo,
@@ -46,7 +47,6 @@ import type {
   GithubInstallationRepo,
   AgentRepoAuthorizationRepo,
   DaemonLifecycleOpRepo,
-  DaemonRepo,
   OAuthRepo,
   WebchatMcpOperationRepo
 } from '../persistence/ports.js'
@@ -172,6 +172,8 @@ export interface HttpDeps {
     /** Transactional agent-row + secret-row writer — REST create/PATCH go through
      *  this so a failure between the two writes can't leave a partial definition. */
     agentConfig: AgentConfigWriter
+    /** The sets a duty may be claimed within — the console resolves a placement target to one. */
+    memberSet: MemberSetRepo
     /** Org-level MCP provider metadata (never upstream header values / grant keys). */
     mcpProvider: McpProviderRepo
     /** The ONLY read/write path for upstream MCP auth headers (store-only, never DTO'd). */
@@ -273,12 +275,9 @@ export interface HttpDeps {
    *  through this; none of them reads `agent.daemonId` to decide delivery. */
   agentDelivery: AgentDelivery
   /** The ONE answer to "which daemons serve this agent" (placement ∪ duty holders). Routes ask it
-   *  instead of reading `agent.daemonId`, which stopped naming a machine when `pool` became a
-   *  placement target. */
+   *  instead of reading `agent.daemonId`, which stopped naming a machine when a member set became
+   *  a placement target. */
   placementResolver: PlacementResolver
-  /** Daemon rows, unscoped — a move needs the SOURCE's own scope to decide whether it is still an
-   *  eligible holder of the new placement, which is a property of the row, not of its liveness. */
-  daemonRows?: Pick<DaemonRepo, 'getUnscoped'>
   /** Pushes the per-session memory-capture gate to the owning daemons after a
    *  §4.3 visibility change, and answers the pending/applied cutover state
    *  (session-visibility.md §5.1). Absent ⇒ changes converge on register. */

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -557,9 +557,11 @@ export const CreateAgentBody = z.object({
   skills: SkillEnableBody.optional(),
   managedSkills: ManagedSkillEnableBody.optional(),
   memory: MemoryConfigBody.optional(), // memory backend; absent ⇒ managed default
-  // Placement at create. `pool` needs no id; `daemon` (the default) uses `daemonId`.
-  placementKind: z.enum(['daemon', 'pool']).optional(),
+  // Placement at create. `set` uses `setId`; `daemon` (the default) uses `daemonId`. `pool` is
+  // accepted API sugar for "the org-less set" and is resolved to it at the edge.
+  placementKind: z.enum(['daemon', 'pool', 'set']).optional(),
   daemonId: z.string().optional(), // the owning daemon, if chosen at create
+  setId: z.string().uuid().optional(), // the owning member set, for a `set` placement
   workspace: AgentWorkspaceInputBody.optional(), // absent ⇒ scratch; the cold editor can replace either mode later
   capabilities: z.array(z.string()).default([]),
   // Initial visibility (absent ⇒ 'org', visible to all members); `sharedWith` is
@@ -622,18 +624,27 @@ export const UpdateAgentBody = z
  * its detach; every target-side admission check still applies. */
 export const SetAgentDaemonBody = z
   .object({
-    // The placement TARGET. `daemon` names one machine through `daemonId`; `pool` names the
-    // install-wide member set and carries no id at all — whichever member holds the agent's duty
-    // serves it, so pinning one here is exactly the dead-Pod pointer this replaced. Omitted ⇒
-    // `daemon`, so an existing client that sends only `daemonId` still means what it meant.
-    placementKind: z.enum(['daemon', 'pool']).optional(),
+    // The placement TARGET. `daemon` names one machine through `daemonId`; `set` names a member
+    // set through `setId` — whichever member holds the agent's duty serves it, so pinning one here
+    // is exactly the dead-Pod pointer this replaced. `pool` stays accepted API sugar for "the
+    // org-less set" (daemon-groups.md §4) and is resolved at the edge. Omitted ⇒ `daemon`, so an
+    // existing client that sends only `daemonId` still means what it meant.
+    placementKind: z.enum(['daemon', 'pool', 'set']).optional(),
     daemonId: z.string().uuid().optional(),
+    setId: z.string().uuid().optional(),
     force: z.boolean().optional()
   })
   .strict()
-  .refine((b) => (b.placementKind === 'pool' ? b.daemonId === undefined : b.daemonId !== undefined), {
-    message: 'daemonId is required for a daemon placement and must be omitted for a pool placement'
+  .refine((b) => (b.placementKind === 'set' ? b.setId !== undefined : b.setId === undefined), {
+    message: 'setId is required for a set placement and must be omitted otherwise'
   })
+  .refine(
+    (b) =>
+      b.placementKind === 'pool' || b.placementKind === 'set' ? b.daemonId === undefined : b.daemonId !== undefined,
+    {
+      message: 'daemonId is required for a daemon placement and must be omitted for a set placement'
+    }
+  )
 
 /** Full desired workspace definition for the acknowledged cold edit path. */
 export const SetAgentWorkspaceBody = z.discriminatedUnion('mode', [
@@ -696,12 +707,13 @@ export const AgentDto = z.object({
   managedSkills: z.array(z.string().uuid()), // explicitly enabled accepted managed-skill ids
   memory: MemoryConfigBody.nullable(), // memory backend (null ⇒ managed default)
   status: z.string(),
-  // What the placement NAMES. `pool` carries a null `daemonId` on purpose: no member id is
+  // What the placement NAMES. `set` carries a null `daemonId` on purpose: no member id is
   // durable, so the console must read readiness from `placementReady` rather than from a machine.
-  placementKind: z.enum(['daemon', 'pool']),
+  placementKind: z.enum(['daemon', 'set']),
   daemonId: z.string().nullable(),
+  setId: z.string().nullable(), // the `set`-kind ref; null for a `daemon` placement
   /** Can a session start right now? For a `daemon` placement that is its daemon's liveness; for a
-   *  `pool` placement it is "some live member could serve this", which is the question the console
+   *  `set` placement it is "some live member could serve this", which is the question the console
    *  was answering with a dead Pod's id (#987). */
   placementReady: z.boolean(),
   workspace: AgentWorkspaceBody,

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -61,7 +61,7 @@ import type { DaemonView } from '../../ports.js'
 import { AgentId, DaemonId, OrgId, SessionId } from '../../domain/ids.js'
 import {
   dutyEligibility,
-  ON_POOL,
+  onSet,
   placementLabel,
   placementTargetOf,
   type PlacementTarget
@@ -307,6 +307,7 @@ function toDto(
     status: a.status,
     placementKind: a.placementKind,
     daemonId: a.daemonId,
+    setId: a.setId,
     placementReady: placementView.ready,
     workspace: workspaceToDto(a.workspace),
     workspaceRepoId: a.workspaceRepoId?.toString() ?? null,
@@ -338,7 +339,7 @@ function toDto(
 /**
  * What placement says the console needs to know: the sandbox policy (#642) and whether a session
  * can start right now. Both come from ONE resolution of "who may serve this agent", so they can
- * never disagree — and for a pool placement that resolution is "is any member live", not "is the
+ * never disagree — and for a set placement that resolution is "is any member live", not "is the
  * member this row names live", which is the question a rollout made unanswerable (#987).
  */
 interface PlacementView {
@@ -353,20 +354,43 @@ function placementViewOf(deps: HttpDeps, daemon: DaemonView | null): PlacementVi
   return { sandbox: sandboxPolicyOf(daemon), ready: live?.reachable === true && live.state === 'READY' }
 }
 
-/** The install-wide members that could serve an agent right now. One read; reuse it for a page. */
-async function readyPoolMembers(deps: HttpDeps, orgId: OrgId): Promise<DaemonView[]> {
-  const daemons = await deps.registry.listAvailable(orgId)
-  return daemons.filter((d) => d.orgId === null && placementViewOf(deps, d).ready)
+/**
+ * The API-sugar edge (daemon-groups.md §4): `{ placementKind: 'pool' }` names THE org-less set, so
+ * the console's existing "Cloud" entry needs no change and storage keeps one representation.
+ * `{ placementKind: 'set', setId }` names one explicitly; a set belonging to another org is not
+ * resolvable here, exactly as another org's daemon is not.
+ */
+async function resolveTargetSetId(
+  deps: HttpDeps,
+  orgId: OrgId,
+  body: { placementKind?: 'daemon' | 'pool' | 'set'; setId?: string }
+): Promise<string | null> {
+  if (body.placementKind === 'pool') return deps.repos.memberSet.crossOrgSetId()
+  if (body.placementKind !== 'set' || body.setId === undefined) return null
+  const set = await deps.repos.memberSet.get(body.setId)
+  return set && (set.orgId === null || set.orgId === orgId) ? set.id : null
 }
 
-async function placementViewFor(deps: HttpDeps, a: AgentRecord, poolMembers?: DaemonView[]): Promise<PlacementView> {
+/** The members of a set that could serve an agent right now. One read; reuse it for a page.
+ *  Membership is the read — not "org-less daemon", which is only what the pool's membership MEANS
+ *  by the write-time invariant (daemon-groups.md §2). */
+async function readySetMembers(deps: HttpDeps, orgId: OrgId, setId: string): Promise<DaemonView[]> {
+  const [daemons, memberIds] = await Promise.all([
+    deps.registry.listAvailable(orgId),
+    deps.repos.memberSet.memberIdsOf(setId)
+  ])
+  const members = new Set(memberIds)
+  return daemons.filter((d) => members.has(d.daemonId) && placementViewOf(deps, d).ready)
+}
+
+async function placementViewFor(deps: HttpDeps, a: AgentRecord, setMembers?: DaemonView[]): Promise<PlacementView> {
   const eligibility = dutyEligibility(a)
   if (eligibility.scope === 'none') return NO_PLACEMENT
   if (eligibility.scope === 'daemon') {
     // The org-fenced agent read supplies the availability scope for its daemon.
     return placementViewOf(deps, await deps.registry.getAvailable(a.orgId, eligibility.daemonId))
   }
-  const members = poolMembers ?? (await readyPoolMembers(deps, OrgId(a.orgId)))
+  const members = setMembers ?? (await readySetMembers(deps, OrgId(a.orgId), eligibility.setId))
   return placementViewOf(deps, members[0] ?? null)
 }
 
@@ -793,7 +817,7 @@ export function agentRoutes(deps: HttpDeps) {
     /**
      * The same read, with `daemonId` resolved to the member that SERVES the agent right now
      * instead of the one its placement names. Every daemon-edge proxy below (workspace, git,
-     * memory, dreams, tasks, skills, permissions) loads through this, because for a `pool`
+     * memory, dreams, tasks, skills, permissions) loads through this, because for a `set`
      * placement the row names no machine at all and the live answer is the ledger's.
      *
      * Deliberately NOT used by the placement-authoritative routes — create, PATCH, move, delete —
@@ -1312,7 +1336,7 @@ export function agentRoutes(deps: HttpDeps) {
       mutations: deps.agentMutations,
       sessionOwners: deps.sessionOwners,
       placement: deps.placementResolver,
-      ...(deps.daemonRows ? { daemons: deps.daemonRows } : {}),
+      memberSets: deps.repos.memberSet,
       ...(deps.recomputeDuties ? { recomputeDuties: deps.recomputeDuties } : {}),
       log: app.log
     })
@@ -1354,18 +1378,22 @@ export function agentRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
         const conflict = (message: string) => reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
-        // Placement accepts visible org-owned daemons and install-wide cloud members, never another
-        // org's daemon — or the POOL, which names no member and is validated against the live
-        // member set instead, exactly like the move route's pool target.
-        const wantsPool = req.body.placementKind === 'pool'
-        const poolMembers = wantsPool ? await readyPoolMembers(deps, orgOf(req)) : []
-        if (wantsPool && poolMembers.length === 0) return conflict('no cloud daemon member is ready')
-        const placedDaemon = wantsPool
-          ? (poolMembers[0] ?? null)
+        // Placement accepts visible org-owned daemons and this org's member sets, never another
+        // org's daemon — or a SET, which names no member and is validated against its live members
+        // instead, exactly like the move route's set target.
+        const wantsSet = req.body.placementKind === 'pool' || req.body.placementKind === 'set'
+        const targetSetId = wantsSet ? await resolveTargetSetId(deps, orgOf(req), req.body) : null
+        if (wantsSet && targetSetId === null) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'member set not found' })
+        }
+        const setMembers = targetSetId ? await readySetMembers(deps, orgOf(req), targetSetId) : []
+        if (wantsSet && setMembers.length === 0) return conflict('no cloud daemon member is ready')
+        const placedDaemon = wantsSet
+          ? (setMembers[0] ?? null)
           : req.body.daemonId !== undefined
             ? await deps.registry.getAvailable(orgOf(req), DaemonId(req.body.daemonId))
             : null
-        if (!wantsPool && req.body.daemonId !== undefined) {
+        if (!wantsSet && req.body.daemonId !== undefined) {
           if (!placedDaemon || !canView(placedDaemon, ctxOf(req))) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
           }
@@ -1561,8 +1589,8 @@ export function agentRoutes(deps: HttpDeps) {
                   ...(req.body.skills !== undefined ? { skills: req.body.skills } : {}),
                   ...(req.body.managedSkills !== undefined ? { managedSkills: req.body.managedSkills } : {}),
                   ...(req.body.memory !== undefined ? { memory: req.body.memory } : {}),
-                  ...(wantsPool
-                    ? { placementKind: 'pool' as const }
+                  ...(targetSetId !== null
+                    ? { placementKind: 'set' as const, setId: targetSetId }
                     : req.body.daemonId !== undefined
                       ? { daemonId: DaemonId(req.body.daemonId) }
                       : {}),
@@ -1686,7 +1714,7 @@ export function agentRoutes(deps: HttpDeps) {
         )
         // ONE batched resolve for the whole page (design §6) — never a query per agent.
         const organizationEnvironment = await organizationEnvironmentOfAll(orgOf(req), rows)
-        // Two batched resolves for the whole page: the named daemons, and the pool once.
+        // Two batched resolves for the whole page: the named daemons, and each named set once.
         const daemonIds = [...new Set(rows.flatMap((a) => (a.daemonId ? [a.daemonId] : [])))]
         const views = new Map(
           await Promise.all(
@@ -1696,12 +1724,20 @@ export function agentRoutes(deps: HttpDeps) {
             )
           )
         )
-        const poolMembers = await readyPoolMembers(deps, orgOf(req))
-        const poolView = placementViewOf(deps, poolMembers[0] ?? null)
+        const setIds = [...new Set(rows.flatMap((a) => (a.setId ? [a.setId] : [])))]
+        const setViews = new Map(
+          await Promise.all(
+            setIds.map(
+              async (setId) =>
+                [setId, placementViewOf(deps, (await readySetMembers(deps, orgOf(req), setId))[0] ?? null)] as const
+            )
+          )
+        )
         const viewFor = (a: AgentRecord): PlacementView => {
           const eligibility = dutyEligibility(a)
           if (eligibility.scope === 'none') return NO_PLACEMENT
-          return eligibility.scope === 'daemon' ? (views.get(eligibility.daemonId) ?? NO_PLACEMENT) : poolView
+          if (eligibility.scope === 'set') return setViews.get(eligibility.setId) ?? NO_PLACEMENT
+          return views.get(eligibility.daemonId) ?? NO_PLACEMENT
         }
         return rows.map((a) =>
           toDto(
@@ -2301,7 +2337,11 @@ export function agentRoutes(deps: HttpDeps) {
 
         const conflict = (message: string) => reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
         const force = req.body.force === true
-        const wantsPool = req.body.placementKind === 'pool'
+        const wantsSet = req.body.placementKind === 'pool' || req.body.placementKind === 'set'
+        const targetSetId = wantsSet ? await resolveTargetSetId(deps, orgOf(req), req.body) : null
+        if (wantsSet && targetSetId === null) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'member set not found' })
+        }
         const moveReady = (daemonId: string) => {
           const live = deps.liveness.get(daemonId)
           return live?.reachable === true && live.state === 'READY'
@@ -2309,22 +2349,25 @@ export function agentRoutes(deps: HttpDeps) {
         const MOVE_FEATURE = 'agent-move-v1'
 
         // The daemons the target admits. A `daemon` target is one machine and every check below
-        // is about that machine. A `pool` target names the install-wide member set, and the CP
-        // does not get to choose which member serves the agent — so the checks are evaluated
-        // against the UNION of live members: the target is admissible when SOME live member could
-        // serve this agent today. Members are one Deployment of one image, so union and
-        // intersection differ only mid-rollout, and there the ledger's install-on-grant refusal
-        // is the backstop that keeps a member from holding what it cannot install.
-        const candidates = wantsPool
-          ? (await deps.registry.listAvailable(orgOf(req))).filter(
-              (d) => d.orgId === null && moveReady(d.daemonId) && canView(d, ctxOf(req))
-            )
+        // is about that machine. A `set` target names a member set, and the CP does not get to
+        // choose which member serves the agent — so the checks are evaluated against the UNION of
+        // its live members: the target is admissible when SOME live member could serve this agent
+        // today. Pool members are one Deployment of one image, so union and intersection differ
+        // only mid-rollout, and there the ledger's install-on-grant refusal is the backstop that
+        // keeps a member from holding what it cannot install.
+        const candidates = targetSetId
+          ? await (async () => {
+              const memberIds = new Set(await deps.repos.memberSet.memberIdsOf(targetSetId))
+              return (await deps.registry.listAvailable(orgOf(req))).filter(
+                (d) => memberIds.has(d.daemonId) && moveReady(d.daemonId) && canView(d, ctxOf(req))
+              )
+            })()
           : await (async () => {
               const one = await deps.registry.getAvailable(orgOf(req), DaemonId(req.body.daemonId!))
               return one && canView(one, ctxOf(req)) ? [one] : []
             })()
         if (candidates.length === 0) {
-          if (!wantsPool) {
+          if (!wantsSet) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
           }
           return conflict('no cloud daemon member is ready')
@@ -2338,8 +2381,8 @@ export function agentRoutes(deps: HttpDeps) {
         }
 
         const placement = placementTargetOf(existing)
-        const samePlacementTarget = wantsPool
-          ? placement.kind === 'pool'
+        const samePlacementTarget = targetSetId
+          ? placement.kind === 'set' && placement.setId === targetSetId
           : placement.kind === 'daemon' && placement.daemonId === req.body.daemonId
 
         /** Why this daemon cannot take the agent, or null when it can. */
@@ -2386,7 +2429,7 @@ export function agentRoutes(deps: HttpDeps) {
               return `target runtime ${existing.runtime} does not support MCP ${server.transport} transport for ${name}`
             }
           }
-          // Capacity is a per-member fact even on the pool: "some member has headroom" is exactly
+          // Capacity is a per-member fact even on a set: "some member has headroom" is exactly
           // the condition the ledger's own headroom gate applies when it hands out the duty.
           if (!samePlacementTarget && daemon.load && daemon.maxAgents > 0 && daemon.load.agents >= daemon.maxAgents) {
             return 'target daemon is at agent capacity'
@@ -2394,7 +2437,7 @@ export function agentRoutes(deps: HttpDeps) {
           return null
         }
 
-        // First admitting candidate wins; a pool target refuses only when EVERY live member
+        // First admitting candidate wins; a set target refuses only when EVERY live member
         // refuses, and then it reports the first member's reason rather than inventing one.
         let target: DaemonView | undefined
         let refusal: string | null = null
@@ -2408,13 +2451,15 @@ export function agentRoutes(deps: HttpDeps) {
         }
         if (!target) return conflict(refusal ?? 'no daemon can take this agent')
 
-        const moveTarget: PlacementTarget = wantsPool ? ON_POOL : { kind: 'daemon', daemonId: target.daemonId }
+        const moveTarget: PlacementTarget = targetSetId
+          ? onSet(targetSetId)
+          : { kind: 'daemon', daemonId: target.daemonId }
 
         // A same-target retry is an idempotent repair after placement already
         // committed, not a second handoff. Target admission above still applies,
         // but there is no separate source to gate before ensureActive below.
         if (!samePlacementTarget) {
-          // Every member serving the agent today has to quiesce — for a pool source that is the
+          // Every member serving the agent today has to quiesce — for a set source that is the
           // duty holder, not a placement, and there may be none at all.
           const sourceDaemonIds = await deps.placementResolver.servingDaemons(existing)
           if (sourceDaemonIds.length > 0) {

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -33,7 +33,7 @@ import type {
   BotRepo,
   BotSecretStore,
   CronRepo,
-  DaemonRepo,
+  MemberSetRepo,
   AgentWorkspace,
   IntegrationChannelRepo,
   IntegrationRepo
@@ -117,9 +117,9 @@ export interface AgentMoveDeps {
   collabRoutes: CollabRoutesService
   mutations: AgentMutationGate
   sessionOwners: { releaseSession(key: SessionKey): void }
-  /** Daemon rows, for deciding whether a detached source is still an eligible holder of the new
-   *  placement. Absent ⇒ no source is ever unstaged, the pre-pool behavior. */
-  daemons?: Pick<DaemonRepo, 'getUnscoped'>
+  /** Set membership, for deciding whether a detached source is still an eligible holder of the
+   *  new placement. Absent ⇒ no source is ever unstaged, the pre-pool behavior. */
+  memberSets?: Pick<MemberSetRepo, 'setIdOf'>
   /** Resolves the members currently serving an agent — the sources a move must quiesce when
    *  placement names no machine of its own. Absent ⇒ placement alone (the pre-duty behavior). */
   placement?: PlacementResolver
@@ -580,16 +580,16 @@ export class AgentMoveService {
    *
    * A detached source is normally meant to stay fenced — that is the whole point of a hard
    * cutover, and it is right for every move onto a machine and for a LOCAL daemon losing an agent
-   * to the pool: neither may serve it again. `daemon(member) → pool` is the one transition where
-   * it is wrong. The member remains install-wide, so the ledger may hand it the very group it was
-   * just fenced out of — and `installGrantedAgents` skips a move-staged agent, so it would take
-   * the lease, install nothing, and serve nothing, with no other member able to claim it. The
+   * to a set: neither may serve it again. `daemon(member) → its own set` is the one transition
+   * where it is wrong. The member is still in that set, so the ledger may hand it the very group
+   * it was just fenced out of — and `installGrantedAgents` skips a move-staged agent, so it would
+   * take the lease, install nothing, and serve nothing, with no other member able to claim it. The
    * agent would be servable by nobody, which is worse than where it started.
    *
    * So the fence is released with the same move token that armed it, which is also what leaves
    * the member's replica current: if the ledger grants it back, install-on-grant sees the agent
    * present at the granted revision and skips the fetch entirely. Eligibility is the resolver's
-   * answer, not a kind test — a local daemon is never eligible for a pool placement and stays
+   * answer, not a kind test — a daemon in no set is never eligible for a set placement and stays
    * fenced. Best-effort: the fence is the member's own state and a member that cannot be reached
    * re-registers into a reconcile that has the authoritative placement.
    */
@@ -598,12 +598,13 @@ export class AgentMoveService {
     stagedSources: ReadonlyMap<DaemonId, string>,
     target: PlacementTarget
   ): Promise<void> {
-    if (stagedSources.size === 0) return
+    if (stagedSources.size === 0 || !this.deps.memberSets) return
+    const memberSets = this.deps.memberSets
     const columns = placementColumns(target)
     const bundle = await this.snapshot(agent)
     for (const [daemonId, moveId] of stagedSources) {
-      const daemon = await this.deps.daemons?.getUnscoped(daemonId)
-      if (!daemon || !mayHold(columns, { daemonId, scope: claimScopeOf(daemon) })) continue
+      const setId = await memberSets.setIdOf(daemonId)
+      if (!mayHold(columns, { daemonId, scope: claimScopeOf({ setId }) })) continue
       try {
         requireAck(
           'source unstage',

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -12,7 +12,6 @@ import {
 import type { DutyGroupRepo, DutyGroupRecord, DutyGrantRecord } from '../persistence/ports.js'
 import type { DutyMemberKey } from '../domain/duty.js'
 import type { AgentId, DaemonId, OrgId } from '../domain/ids.js'
-import type { DutyClaimScope } from '../domain/placement.js'
 import type { Clock } from '../domain/clock.js'
 
 export interface DutyLeaseConfig {
@@ -319,18 +318,12 @@ export class DutyLeaseService {
     if (budget > 0 && this.clock.now() >= this.bootedAtMs + this.config.recoveryGraceMs) {
       // Oversized groups are excluded at the claim boundary (the size gate), so
       // a claim never lands on a group it would immediately have to release.
-      // `scope` is install-wide because the heartbeat handler only reaches this service on an
-      // org-less connection; it is passed rather than assumed so the gate stays a predicate.
       granted = await this.repo.claimVacant(
         daemonId,
         Math.min(budget, this.config.grantMaxPerTick),
         now,
         this.config.leaseMs,
-        {
-          scope: 'install-wide',
-          maxMembers: DUTY_GRANT_MEMBERS_MAX,
-          excludeGroupIds: this.backedOff(daemonId)
-        }
+        { maxMembers: DUTY_GRANT_MEMBERS_MAX, excludeGroupIds: this.backedOff(daemonId) }
       )
     }
 
@@ -393,19 +386,18 @@ export class DutyLeaseService {
    * that was handed a trigger it does not serve. Serialized on the member's lane
    * like every other ledger touch, so a claim cannot interleave with its own
    * heartbeat exchange. Returns a grant the member can install verbatim, or the
-   * incumbent it lost to. `scope` carries the claimant's connection scope into the same
-   * eligibility gate the heartbeat claim uses: a trigger reaching the wrong member is not
-   * authority to serve an agent that member may not hold.
+   * incumbent it lost to. It runs the same eligibility gate the heartbeat claim uses, read from
+   * the claimant's own membership: a trigger reaching the wrong member is not authority to serve
+   * an agent that member may not hold.
    */
   async claimAgentHome(
     orgId: OrgId,
     agentId: AgentId,
-    holder: DaemonId,
-    scope: DutyClaimScope
+    holder: DaemonId
   ): Promise<{ granted: boolean; grant?: DutyGrantEntry; holder?: string }> {
     return this.serialize(holder, async () => {
       const now = new Date(this.clock.now())
-      const claim = await this.repo.claimAgentHome(orgId, agentId, holder, now, this.config.leaseMs, scope)
+      const claim = await this.repo.claimAgentHome(orgId, agentId, holder, now, this.config.leaseMs)
       if (!claim.granted || claim.groupId === undefined)
         return claim.holder ? { granted: false, holder: claim.holder } : { granted: false }
       const [group] = await this.repo.getByIds([claim.groupId])

--- a/packages/control-plane/src/orchestrator/placementResolver.ts
+++ b/packages/control-plane/src/orchestrator/placementResolver.ts
@@ -3,12 +3,12 @@
  * answers "which daemons serve this agent right now" once placement stopped being a member id.
  *
  * `domain/placement.ts` answers eligibility from the row alone; this adds the live duty leases, so
- * a `pool` agent — which names no machine — still resolves to the member currently holding it. Two
+ * a `set` agent — which names no machine — still resolves to the member currently holding it. Two
  * questions, one resolver: delivery/edge targets (`servingDaemons`, `servingDaemon`) and authority
  * (`mayAct`, the "is this agent yours" fence every daemon-originated write applies).
  *
- * No caller branches on the placement kind; a later `group` kind changes only this file and the
- * ledger predicate it mirrors.
+ * No caller branches on the placement kind; this file and the ledger predicate it mirrors are the
+ * two readers of it.
  *
  * The inverse query — member→agents — is `servedAgents.ts`, which reads the same two relations
  * from the other side; its header states the biconditional the pair has to satisfy and names the
@@ -41,9 +41,9 @@ export class PlacementResolver {
     private readonly deps: {
       /** Absent (tests, or a deployment with no pool) ⇒ placement alone, which is the pre-duty behavior. */
       duties?: DutyHolderReader
-      /** The install-wide members that are live right now. Only {@link PlacementResolver.dispatchDaemon}
+      /** A member set's members that are live right now. Only {@link PlacementResolver.dispatchDaemon}
        *  uses it, and only as the rendezvous target — never as a claim of who serves what. */
-      liveMembers?: () => string[]
+      liveMembers?: (setId: string) => Promise<string[]>
       clock: Clock
     }
   ) {}
@@ -62,7 +62,7 @@ export class PlacementResolver {
    * Every daemon INGRESS may be addressed at. `servingDaemons` minus the holds the member has not
    * confirmed yet — a grant it has not installed is a lease, not a route.
    *
-   * Between a grant and its first digest this names NOBODY for a pool agent. For platform ingress
+   * Between a grant and its first digest this names NOBODY for a set agent. For platform ingress
    * that is fully covered — the trigger reaches a member and claims through the activation
    * rendezvous. For a cross-daemon peer wake it is NOT covered, and the honest reason to prefer it
    * anyway is narrower than "absence is retryable", because absence is terminal too
@@ -102,7 +102,7 @@ export class PlacementResolver {
   /**
    * Fill the serving daemon into a directory projection, dropping every row nothing serves right
    * now. The peer directory and the collaboration snapshot both need "who do I wake", which is a
-   * live question for a pool agent and a column read for a machine-placed one — so it is answered
+   * live question for a set agent and a column read for a machine-placed one — so it is answered
    * here once rather than at each surface, where the two could disagree.
    */
   async resolveDirectory<T extends PlacementRef & { agentId: string }>(
@@ -120,7 +120,7 @@ export class PlacementResolver {
 
   /**
    * Where to send a TRIGGER for this agent. Distinct from {@link PlacementResolver.servingDaemon}
-   * on purpose: a pool agent whose lease has lapsed is served by nobody for one lease horizon, and
+   * on purpose: a set agent whose lease has lapsed is served by nobody for one lease horizon, and
    * refusing the trigger for that window is what left webchat permanently offline after a rollout
    * (#987). Any live member is a correct target — it claims the agent's group on receipt (the
    * activation rendezvous) and then serves the turn. A machine placement has no such fallback:
@@ -129,11 +129,12 @@ export class PlacementResolver {
   async dispatchDaemon(agent: ResolvableAgent): Promise<DaemonId | null> {
     const routable = await this.routableDaemon(agent)
     if (routable) return routable
-    if (dutyEligibility(agent).scope !== 'install-wide') return null
-    return ((this.deps.liveMembers?.() ?? [])[0] as DaemonId | undefined) ?? null
+    const eligibility = dutyEligibility(agent)
+    if (eligibility.scope !== 'set' || !this.deps.liveMembers) return null
+    return ((await this.deps.liveMembers(eligibility.setId))[0] as DaemonId | undefined) ?? null
   }
 }
 
 /** The resolver a graph with no duty ledger gets: placement alone, which is exactly the pre-duty
- *  behavior. Consumers default to it so a pool-less composition needs no wiring at all. */
+ *  behavior. Consumers default to it so a set-less composition needs no wiring at all. */
 export const PLACEMENT_ONLY = new PlacementResolver({ clock: systemClock })

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -27,6 +27,40 @@ export class OwnerConflict extends Error {
 export const PG_UNIQUE_VIOLATION = '23505'
 
 /**
+ * Thrown by `enrollDaemonInSet` when the membership row would break the set's tenancy invariant
+ * (docs/designs/daemon-groups.md §2): an org-less set accepts only org-less daemons, an org set
+ * only that org's daemons. Enforced where the row is written, because it is what lets the read
+ * path be one membership lookup with no tenancy branch.
+ */
+export class MemberSetTenancyMismatch extends Error {
+  readonly code = 'MEMBER_SET_TENANCY_MISMATCH' as const
+  constructor(
+    readonly setId: string,
+    readonly daemonId: string
+  ) {
+    super(`daemon ${daemonId} does not belong to the tenancy of member set ${setId}`)
+    this.name = 'MemberSetTenancyMismatch'
+  }
+}
+
+/**
+ * Thrown by the placement writers when a `set` placement names a set the agent may not reference
+ * (docs/designs/daemon-groups.md §2, third write-time invariant): only the org-less set or a set
+ * of the agent's own org. Without it, `mayHold`'s single rule would let org X's members claim an
+ * org Y agent that had been pointed at X's set.
+ */
+export class AgentSetPlacementDenied extends Error {
+  readonly code = 'AGENT_SET_PLACEMENT_DENIED' as const
+  constructor(
+    readonly agentId: string,
+    readonly setId: string
+  ) {
+    super(`agent ${agentId} may not be placed on member set ${setId}`)
+    this.name = 'AgentSetPlacementDenied'
+  }
+}
+
+/**
  * Thrown by org-fenced agent mutations (docs/designs/org-scoped-data-layer.md
  * §3) when the addressed row does not exist in the caller's organization — a
  * cross-org id is deliberately indistinguishable from a missing row. Routes

--- a/packages/control-plane/src/persistence/index.ts
+++ b/packages/control-plane/src/persistence/index.ts
@@ -68,6 +68,7 @@ export {
 export { PresetAgentBackfill } from './preset-agent-backfill.js'
 export { PgCronRepo } from './repositories/cron.repo.js'
 export { PgDutyGroupRepo } from './repositories/duty-group.repo.js'
+export { PgMemberSetRepo } from './repositories/member-set.repo.js'
 export { PgHookRepo, PgHookSecretStore } from './repositories/hook.repo.js'
 export { PgRuntimeProfileRepo } from './repositories/runtime-profile.repo.js'
 export { PgAuditRepo } from './repositories/audit.repo.js'

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -41,7 +41,7 @@ import type {
 } from '../domain/ids.js'
 import type { SessionKey } from '../domain/sessionKey.js'
 import type { DutyMemberKey, DutyReconcilePlan, DutyEdge, AgentSeed } from '../domain/duty.js'
-import type { DutyClaimScope, PlacementKind, PlacementTarget } from '../domain/placement.js'
+import type { PlacementKind, PlacementTarget } from '../domain/placement.js'
 import type {
   OrganizationEnvironmentAudience,
   OrganizationEnvironmentKind,
@@ -640,9 +640,10 @@ export interface CreateAgentInput {
   managedSkills?: string[] // accepted managed_skill ids, explicitly enabled
   memory?: AgentMemoryBinding // memory backend
   icon?: AgentIcon // console avatar; absent ⇒ the repo assigns a random glyph+color combo
-  /** Placement at create time: `pool` needs no ref, `daemon` needs `daemonId`. Absent ⇒ unplaced. */
+  /** Placement at create time: `set` needs `setId`, `daemon` needs `daemonId`. Absent ⇒ unplaced. */
   placementKind?: PlacementKind
   daemonId?: DaemonId // the owning machine, if chosen at create time
+  setId?: string // the owning member set, if placed on one at create time
   workspace?: AgentWorkspace // absent ⇒ scratch
   /** Rename-proof numeric identity of the github workspace repository. This is
    *  control-plane metadata only and never rides AgentWorkspace on the wire. */
@@ -738,12 +739,14 @@ export interface AgentRecord {
   managedSkills: string[] // accepted managed_skill ids ([] ⇒ none)
   memory: AgentMemoryBinding | null // runtimeOverrides.memory
   status: 'active' | 'inactive' | 'paused'
-  /** What placement NAMES (domain/placement.ts): `daemon` resolves through `daemonId`, `pool`
-   *  resolves to the install-wide member set and carries no ref. Never branch on it directly. */
+  /** What placement NAMES (domain/placement.ts): `daemon` resolves through `daemonId`, `set`
+   *  resolves through `setId`. Never branch on it directly. */
   placementKind: PlacementKind
   /** The `daemon`-kind ref, and null for every other kind — placement, never "who serves it now".
    *  Ask {@link PlacementResolver} for that. */
   daemonId: DaemonId | null
+  /** The `set`-kind ref, null for a `daemon` placement. Which MEMBER serves it is the ledger's. */
+  setId: string | null
   workspace: AgentWorkspace
   /** Nullable on scratch/anonymous and pre-R2a rows; action-time authorization
    *  fails closed until a legacy github workspace is lazily repaired. */
@@ -894,8 +897,8 @@ export interface AgentRepo {
    *  active webchat MCP delegations; a same-placement write does not. */
   setPlacement(agentId: AgentId, target: PlacementTarget): Promise<void>
   /**
-   * Atomically move an agent only when its current placement still matches `expected` — BOTH
-   * columns, so moving between `pool` and a machine is fenced exactly like moving between two
+   * Atomically move an agent only when its current placement still matches `expected` — the whole
+   * target, so moving between a set and a machine is fenced exactly like moving between two
    * machines. Returns the updated row, or null when another move won the compare-and-set race. A
    * real move revokes active webchat MCP authority in the same transaction. This is the
    * persistence fence for the explicit cold placement-switch action.
@@ -946,6 +949,7 @@ export interface OrgAgentRecord extends ChannelAgentRecord {
   /** The placement columns, so a consumer can resolve the serving daemon (domain/placement.ts). */
   placementKind: PlacementKind
   daemonId: string | null
+  setId: string | null
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -4991,6 +4995,29 @@ export interface OrgInviteLinkRepo {
   accept(tokenHash: string, userId: string, now: Date): Promise<OrgInviteAcceptResult>
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// MemberSetRepo — the sets a duty may be claimed within (daemon-groups.md §2)
+// ───────────────────────────────────────────────────────────────────────────
+
+/** A member set. `orgId` null means CROSS-ORG (the install-wide pool), never "unassigned". */
+export interface MemberSetRecord {
+  id: string
+  orgId: string | null
+  name: string
+}
+
+export interface MemberSetRepo {
+  /** The install-wide pool: the one org-less row. Null only before the migration that mints it. */
+  crossOrgSetId(): Promise<string | null>
+  get(setId: string): Promise<MemberSetRecord | null>
+  /** Which set this daemon is a member of — the claim scope of its connection (§3). */
+  setIdOf(daemonId: DaemonId): Promise<string | null>
+  /** The set's members, sorted. The read path for "who could serve a `set`-placed agent". */
+  memberIdsOf(setId: string): Promise<string[]>
+  /** Record a membership under the set's tenancy invariant; throws MemberSetTenancyMismatch. */
+  enroll(setId: string, daemonId: DaemonId): Promise<void>
+}
+
 // DutyGroupRepo (k8s daemons) — the CP-hosted duty ledger
 
 /** One entry of a member's heartbeat duty digest: the group, at the term it believes it holds. */
@@ -5049,20 +5076,19 @@ export interface DutyGroupRepo {
     opts: { now: Date; leaseMs: number }
   ): Promise<DutyReconcilePlan>
   /** "Grant me up to `max` vacant groups": first valid claim wins (SKIP LOCKED),
-   *  each grant bumps the term. Install-wide — capacity gating is the caller's.
+   *  each grant bumps the term. Capacity gating is the caller's.
    *  `maxMembers` excludes undeliverable (oversized) groups at the claim
    *  boundary, so they never churn or starve the vacancies behind them.
-   *  `scope` is the claimant's connection scope, and the ONLY input to the
-   *  eligibility gate (domain/placement.ts): a group is claimable only when the
-   *  claimant may hold EVERY agent in it, which is what keeps an install-wide
-   *  member off the agents a local daemon is already serving.
+   *  Eligibility is read from the HOLDER's own set membership (domain/placement.ts), never
+   *  asserted by the caller: a group is claimable only when the claimant may hold EVERY agent in
+   *  it, which is what keeps a pool member off the agents a local daemon is already serving.
    *  `excludeGroupIds` carries the caller's refusal backoff. */
   claimVacant(
     holder: DaemonId,
     max: number,
     now: Date,
     leaseMs: number,
-    opts: { scope: DutyClaimScope; maxMembers?: number; excludeGroupIds?: readonly string[] }
+    opts?: { maxMembers?: number; excludeGroupIds?: readonly string[] }
   ): Promise<DutyGrantRecord[]>
   /** The group-computation inputs for one org: every agent as a node, plus
    *  active integrations on daemon-held (socket, unrevoked) bots as edges. */
@@ -5071,7 +5097,7 @@ export interface DutyGroupRepo {
    *  agent or an existing duty group. */
   listDutyOrgs(afterOrgId: string | null, limit: number): Promise<string[]>
   /** The placement fence, re-derived from the eligibility predicate: vacate every held group its
-   *  holder may no longer hold — an agent moved off the pool onto a machine, or off one machine
+   *  holder may no longer hold — an agent moved off a set onto a machine, or off one machine
    *  onto another. Same rule as {@link DutyGroupRepo.claimVacant}, read from the holder's side, so
    *  a lease can never outlive the placement that justified it. Returns the vacated groupIds. */
   vacateIneligible(orgId: OrgId): Promise<string[]>
@@ -5087,14 +5113,7 @@ export interface DutyGroupRepo {
    *  the SAME eligibility predicate as {@link DutyGroupRepo.claimVacant}, read
    *  inside the transaction — the rendezvous is a claim path too, and a member
    *  must not reach through it for an agent it may not hold. */
-  claimAgentHome(
-    orgId: OrgId,
-    agentId: AgentId,
-    holder: DaemonId,
-    now: Date,
-    leaseMs: number,
-    scope: DutyClaimScope
-  ): Promise<AgentHomeClaim>
+  claimAgentHome(orgId: OrgId, agentId: AgentId, holder: DaemonId, now: Date, leaseMs: number): Promise<AgentHomeClaim>
   /** Does `holder` currently hold an unexpired lease on a group covering this
    *  agent? The authorization for `duty/fetch`: a member may pull exactly the
    *  agent definitions it has won, and nothing else. */

--- a/packages/control-plane/src/persistence/repositories/agent-placement.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-placement.ts
@@ -13,16 +13,24 @@
 import { Prisma } from '../../generated/prisma/client.js'
 import type { PlacementKind } from '../../domain/placement.js'
 
-/** Both placement columns under the row lock: `daemonId` alone stopped being the placement when
- *  `pool` became a target that names no machine. */
+/** Every placement column under the row lock, plus the agent's org — `daemonId` alone stopped
+ *  being the placement when a set became a target that names no machine, and the org is what the
+ *  set placement invariant is judged against. */
 export async function lockAgentPlacement(
   tx: Prisma.TransactionClient,
   agentId: string
-): Promise<{ placementKind: PlacementKind; daemonId: string | null } | null> {
-  const [row] = await tx.$queryRaw<{ placementKind: PlacementKind; daemonId: string | null }[]>(
-    Prisma.sql`SELECT "placementKind", "daemonId" FROM "agent" WHERE "id" = ${agentId} FOR UPDATE`
+): Promise<LockedPlacement | null> {
+  const [row] = await tx.$queryRaw<LockedPlacement[]>(
+    Prisma.sql`SELECT "orgId", "placementKind", "daemonId", "setId" FROM "agent" WHERE "id" = ${agentId} FOR UPDATE`
   )
   return row ?? null
+}
+
+export interface LockedPlacement {
+  orgId: string
+  placementKind: PlacementKind
+  daemonId: string | null
+  setId: string | null
 }
 
 export async function revokeActiveWebchatMcpDelegations(
@@ -47,7 +55,7 @@ export async function revokeActiveWebchatMcpDelegations(
  */
 export async function settleCascadedUnplacement(tx: Prisma.TransactionClient, agentId: string): Promise<boolean> {
   const current = await lockAgentPlacement(tx, agentId)
-  // A `pool` agent has no daemonId for the FK to have nulled, so it is not this removal's to
+  // A `set` agent has no daemonId for the FK to have nulled, so it is not this removal's to
   // settle: it was never placed on the departing member, only served by it, and the ledger
   // hands its duty to another member on the next beat.
   if (!current || current.placementKind !== 'daemon' || current.daemonId !== null) return false

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -39,15 +39,18 @@ import { lockSkillSourceNameScopes } from '../skill-source-lock.js'
 import { tryLockMemoryConnectionScopes } from '../memory-connection-lock.js'
 import { PgHookRepo } from './hook.repo.js'
 import { lockAgentPlacement, revokeActiveWebchatMcpDelegations } from './agent-placement.js'
+import { assertAgentMayUseSet } from './member-set.repo.js'
 
-/** An agent may be created already placed. `pool` needs no ref, so the create input carries a kind
- *  and the columns follow from it rather than from the presence of a daemon id. */
-function placementCreateColumns(input: { placementKind?: PlacementKind; daemonId?: string }): {
-  placementKind?: 'daemon' | 'pool'
+/** An agent may be created already placed. A `set` placement names a set rather than a machine, so
+ *  the create input carries a kind and the columns follow from it rather than from a daemon id. */
+function placementCreateColumns(input: { placementKind?: PlacementKind; daemonId?: string; setId?: string }): {
+  placementKind?: PlacementKind
   daemonId?: string
+  setId?: string
   status?: 'active'
 } {
-  if (input.placementKind === 'pool') return { placementKind: 'pool', status: 'active' }
+  if (input.placementKind === 'set' && input.setId)
+    return { placementKind: 'set', setId: input.setId, status: 'active' }
   return input.daemonId ? { daemonId: input.daemonId, status: 'active' } : {}
 }
 import { fenceAgentLocalConfigWrite, lockOrgForConfigWrite, orgIdOfAgent } from './organization-environment-fence.js'
@@ -235,6 +238,7 @@ function toRecord(a: AgentWithUsers): AgentRecord {
     status: a.status as AgentRecord['status'],
     placementKind: a.placementKind,
     daemonId: a.daemonId ? DaemonId(a.daemonId) : null,
+    setId: a.setId,
     workspace: workspaceOf(a),
     ...(a.workspaceRepoId !== null ? { workspaceRepoId: a.workspaceRepoId } : {}),
     capabilities: a.capabilities,
@@ -309,6 +313,9 @@ export class PgAgentRepo implements AgentRepo {
         actorUserId: input.createdByUserId,
         sharedWith: input.sharedWith
       })
+      // Third write-time invariant (daemon-groups.md §2): a create places too, so it takes it.
+      if (input.placementKind === 'set' && input.setId)
+        await assertAgentMayUseSet(tx, { id: input.id, orgId: input.orgId }, input.setId)
       const a = await tx.agent.create({
         data: {
           id: input.id,
@@ -822,6 +829,8 @@ export class PgAgentRepo implements AgentRepo {
     await this.transaction(async (tx) => {
       const current = await lockAgentPlacement(tx, agentId)
       if (!current) return
+      // Third write-time invariant (daemon-groups.md §2), inside the transaction that writes it.
+      if (target.kind === 'set') await assertAgentMayUseSet(tx, { id: agentId, orgId: current.orgId }, target.setId)
       const columns = placementColumns(target)
       await tx.agent.update({
         where: { id: agentId },
@@ -860,8 +869,14 @@ export class PgAgentRepo implements AgentRepo {
       return await this.transaction(async (tx) => {
         const current = await lockAgentPlacement(tx, agentId)
         if (!current || !samePlacement(placementTargetOf(current), expected)) return null
+        if (target.kind === 'set') await assertAgentMayUseSet(tx, { id: agentId, orgId: current.orgId }, target.setId)
         const a = await tx.agent.update({
-          where: { id: agentId, daemonId: expectedColumns.daemonId, placementKind: expectedColumns.placementKind },
+          where: {
+            id: agentId,
+            daemonId: expectedColumns.daemonId,
+            setId: expectedColumns.setId,
+            placementKind: expectedColumns.placementKind
+          },
           data: {
             ...columns,
             status: target.kind === 'unplaced' ? 'inactive' : 'active',
@@ -963,8 +978,8 @@ export class PgAgentRepo implements AgentRepo {
   // The placement relation read from the MEMBER's side, and deliberately the row-wise mirror of
   // `domain/placement.ts#placementTargets` read from the agent's side: `placementKind: 'daemon'`
   // is what makes "this daemon is the placement" mean the same thing in both directions. Without
-  // it the two agree only by accident — because `pool` happens to store a null ref — and a later
-  // kind that stores one would be placed here and unplaced there.
+  // it the two agree only by accident — because a `set` placement happens to store a null daemon
+  // ref — and a later kind that stores one would be placed here and unplaced there.
   async listForDaemon(daemonId: DaemonId): Promise<AgentRecord[]> {
     const rows = await this.db.agent.findMany({
       where: { daemonId, placementKind: 'daemon' },
@@ -990,12 +1005,12 @@ export class PgAgentRepo implements AgentRepo {
   // discoverable but not callable — the model gets a bare 'not_allowed' and retries — so
   // the exclusion belongs in the shared read, where the two surfaces cannot disagree.
   //
-  // A `pool` agent IS placed and carries no daemonId, so the filter is on the placement, not on
-  // the column: each consumer fills the serving daemon in through the resolver, which is the only
+  // A `set` agent IS placed and carries no daemonId, so the filter is on the placement, not on
+  // one column: each consumer fills the serving daemon in through the resolver, which is the only
   // thing that knows which member holds it right now.
   async orgDirectory(orgId: OrgId): Promise<OrgAgentRecord[]> {
     const rows = await this.db.agent.findMany({
-      where: { orgId, OR: [{ daemonId: { not: null } }, { placementKind: 'pool' }] },
+      where: { orgId, OR: [{ daemonId: { not: null } }, { setId: { not: null } }] },
       orderBy: { createdAt: 'asc' },
       select: {
         id: true,
@@ -1005,6 +1020,7 @@ export class PgAgentRepo implements AgentRepo {
         status: true,
         placementKind: true,
         daemonId: true,
+        setId: true,
         callPolicy: true,
         allowedCallerAgentIds: true,
         outboundPolicy: true,
@@ -1019,6 +1035,7 @@ export class PgAgentRepo implements AgentRepo {
       status: row.status as OrgAgentRecord['status'],
       placementKind: row.placementKind,
       daemonId: row.daemonId,
+      setId: row.setId,
       callPolicy: row.callPolicy as AgentCallPolicy,
       allowedCallerAgentIds: row.allowedCallerAgentIds,
       outboundPolicy: row.outboundPolicy as AgentCallPolicy,

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -22,6 +22,7 @@ import type {
 import { visibilityWhere } from '../../authorization/policy.js'
 import { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import { lockAgentPlacement, settleCascadedUnplacement } from './agent-placement.js'
+import { enrollDaemonInSet } from './member-set.repo.js'
 import type { Heartbeat, FactsMcpServer } from '@agentconnect.md/protocol'
 import { lockResourceWriteMemberships } from '../resource-membership-lock.js'
 
@@ -197,27 +198,36 @@ export class PgDaemonRepo implements DaemonRepo {
   }
 
   async upsertOnAuth(input: AuthReqInput): Promise<{ daemon: DaemonRecord; sessionEpoch: bigint }> {
-    const daemon = await this.db.daemon.upsert({
-      where: { id: input.daemonId },
-      create: {
-        id: input.daemonId,
-        orgId: input.orgId,
-        agentVersion: input.agentVersion,
-        machineId: input.machineId,
-        tokenFp: input.tokenFp,
-        sessionEpoch: 1n, // first successful auth mints epoch 1
-        status: 'authenticating'
-      },
-      update: {
-        agentVersion: input.agentVersion,
-        machineId: input.machineId,
-        tokenFp: input.tokenFp,
-        sessionEpoch: { increment: 1n }, // atomic monotonic bump (§3.13)
-        status: 'authenticating'
-      },
-      include: withUsers
+    return withAmbientTx(this.db, async (tx) => {
+      const daemon = await tx.daemon.upsert({
+        where: { id: input.daemonId },
+        create: {
+          id: input.daemonId,
+          orgId: input.orgId,
+          agentVersion: input.agentVersion,
+          machineId: input.machineId,
+          tokenFp: input.tokenFp,
+          sessionEpoch: 1n, // first successful auth mints epoch 1
+          status: 'authenticating'
+        },
+        update: {
+          agentVersion: input.agentVersion,
+          machineId: input.machineId,
+          tokenFp: input.tokenFp,
+          sessionEpoch: { increment: 1n }, // atomic monotonic bump (§3.13)
+          status: 'authenticating'
+        },
+        include: withUsers
+      })
+      // Pool membership stays AUTOMATIC (daemon-groups.md §6): an org-less row is a member of the
+      // org-less set, enrolled in the same transaction that mints it. An org-scoped row is never
+      // auto-enrolled anywhere — its set is an operator decision.
+      if (daemon.orgId === null) {
+        const pool = await tx.memberSet.findFirst({ where: { orgId: null }, select: { id: true } })
+        if (pool) await enrollDaemonInSet(tx, pool.id, daemon.id)
+      }
+      return { daemon: toRecord(daemon), sessionEpoch: daemon.sessionEpoch }
     })
-    return { daemon: toRecord(daemon), sessionEpoch: daemon.sessionEpoch }
   }
 
   async applyRegister(daemonId: DaemonId, reg: RegisterReqInput): Promise<DaemonRecord> {

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -13,7 +13,6 @@ import type {
   DutyReconcilePlanner
 } from '../ports.js'
 import type { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
-import type { DutyClaimScope } from '../../domain/placement.js'
 import { withTx } from '../prisma.js'
 
 // Serializes the writers that CREATE or REWRITE rows for an org (applyReconcile
@@ -27,17 +26,25 @@ type Row = { id: string; orgId: string; holder: string | null; term: bigint; exp
 
 /**
  * The eligibility predicate, once, as SQL — the row-wise mirror of `domain/placement.ts#mayHold`.
- * May `holder` (whose connection scope is install-wide when `installWide` holds) hold the duty of
- * the agent row `agent`? `pool` placement is the install-wide member set; `daemon` placement is
- * that one machine; an unplaced agent has no eligible holder.
+ * May `holder` hold the duty of the agent row `agent`? A `set` placement is claimable by the
+ * members of that set, which is ONE join to `member_set_member` on `(agent.setId, holder)`; a
+ * `daemon` placement is that one machine; an unplaced agent has no eligible holder.
+ *
+ * Tenancy is not a branch here. The write-time invariants (daemon-groups.md §2) guarantee what
+ * membership MEANS — an org-less set holds only org-less daemons, an org set only that org's — so
+ * "the holder is in the agent's set" already implies the tenancy narrowing. The claimant's scope
+ * is therefore read from the ledger's own tables, never asserted by the caller.
  *
  * Both claim paths and the placement fence share it, so a lease can never be taken under one rule
- * and kept under another. A later `group` kind adds one arm here.
+ * and kept under another.
  */
-function eligibleAgent(agent: Prisma.Sql, holder: Prisma.Sql, installWide: Prisma.Sql): Prisma.Sql {
+function eligibleAgent(agent: Prisma.Sql, holder: Prisma.Sql): Prisma.Sql {
   return Prisma.sql`(
     CASE ${agent}."placementKind"
-      WHEN 'pool' THEN (${installWide})
+      WHEN 'set' THEN EXISTS (
+        SELECT 1 FROM "member_set_member" ms
+        WHERE ms."setId" = ${agent}."setId" AND ms."daemonId" = ${holder}
+      )
       ELSE ${agent}."daemonId" IS NOT NULL AND ${agent}."daemonId" = ${holder}
     END
   )`
@@ -45,19 +52,19 @@ function eligibleAgent(agent: Prisma.Sql, holder: Prisma.Sql, installWide: Prism
 
 /**
  * A group is claimable by `holder` only when EVERY agent in it is one the holder may hold. Stated
- * as "no ineligible agent" rather than "some eligible agent": a group that merges a pool agent
+ * as "no ineligible agent" rather than "some eligible agent": a group that merges a set agent
  * with a machine-placed one must be claimable by neither, or the winner serves an agent the other
  * side is already serving — the duplicate service the ledger exists to prevent.
  *
  * A member ref whose agent row is gone cannot be adjudicated and does not block: the group is
  * reaped by the next recompute, and install-on-grant refuses an empty bundle in the meantime.
  */
-function noIneligibleAgent(group: Prisma.Sql, holder: Prisma.Sql, installWide: Prisma.Sql): Prisma.Sql {
+function noIneligibleAgent(group: Prisma.Sql, holder: Prisma.Sql): Prisma.Sql {
   return Prisma.sql`NOT EXISTS (
     SELECT 1 FROM "duty_group_member" m
     JOIN "agent" a ON a.id = m."refId"
     WHERE m."groupId" = ${group} AND m."kind" = 'agent'
-      AND NOT ${eligibleAgent(Prisma.sql`a`, holder, installWide)}
+      AND NOT ${eligibleAgent(Prisma.sql`a`, holder)}
   )`
 }
 
@@ -139,8 +146,8 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     // the lease on the next sweep and the eligible member claims it on its next beat (the old
     // holder learns through the digest diff, as a superseded revocation).
     //
-    // The holder's own scope comes from its row — an org-less daemon is an install-wide pool
-    // member — so this is the same rule `claimVacant` applies, not a second one that can disagree.
+    // The holder's own scope comes from its membership row, so this is the same rule
+    // `claimVacant` applies, not a second one that can disagree.
     // A group whose agents are ALL unplaced has no eligible holder at all and is vacated too:
     // nothing may serve an unplaced agent, and leaving the lease standing would keep one member
     // serving what the operator detached.
@@ -149,7 +156,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
         "confirmedTerm" = NULL, "confirmedHolder" = NULL
       FROM "daemon" d
       WHERE g."orgId" = ${orgId} AND g."holder" IS NOT NULL AND d.id = g."holder"
-        AND NOT ${noIneligibleAgent(Prisma.sql`g.id`, Prisma.sql`g."holder"`, Prisma.sql`d."orgId" IS NULL`)}
+        AND NOT ${noIneligibleAgent(Prisma.sql`g.id`, Prisma.sql`g."holder"`)}
       RETURNING g.id
     `)
     return rows.map((r) => r.id).sort()
@@ -265,7 +272,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     max: number,
     now: Date,
     leaseMs: number,
-    opts: { scope: DutyClaimScope; maxMembers?: number; excludeGroupIds?: readonly string[] }
+    opts: { maxMembers?: number; excludeGroupIds?: readonly string[] } = {}
   ): Promise<DutyGrantRecord[]> {
     if (max <= 0) return []
     const expiresAt = new Date(now.getTime() + leaseMs)
@@ -279,11 +286,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     // The eligibility gate — the whole grant policy, and the only one. There is no incumbency test
     // left: what a member may claim follows from the agents' placement, not from where their state
     // happens to already be.
-    const eligibilityGate = Prisma.sql`AND ${noIneligibleAgent(
-      Prisma.sql`"duty_group".id`,
-      Prisma.sql`${holder}::uuid`,
-      opts.scope === 'install-wide' ? Prisma.sql`TRUE` : Prisma.sql`FALSE`
-    )}`
+    const eligibilityGate = Prisma.sql`AND ${noIneligibleAgent(Prisma.sql`"duty_group".id`, Prisma.sql`${holder}::uuid`)}`
     // The caller's refusal backoff: a group this member has just failed to install is skipped so
     // it can reach one that can serve it, instead of being re-taken on the very next beat.
     const backoffGate =
@@ -432,8 +435,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     agentId: AgentId,
     holder: DaemonId,
     now: Date,
-    leaseMs: number,
-    scope: DutyClaimScope
+    leaseMs: number
   ): Promise<AgentHomeClaim> {
     const expiresAt = new Date(now.getTime() + leaseMs)
     return withTx(this.prisma, async (tx) => {
@@ -444,7 +446,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       // transaction, against the live row, because this path can MINT a group and a check made
       // before the lock would let a member reach through it for an agent it may not hold.
       const [eligible] = await tx.$queryRaw<{ ok: boolean }[]>(Prisma.sql`
-        SELECT ${eligibleAgent(Prisma.sql`a`, Prisma.sql`${holder}::uuid`, scope === 'install-wide' ? Prisma.sql`TRUE` : Prisma.sql`FALSE`)} AS ok
+        SELECT ${eligibleAgent(Prisma.sql`a`, Prisma.sql`${holder}::uuid`)} AS ok
         FROM "agent" a WHERE a.id = ${agentId}::uuid
       `)
       if (eligible?.ok !== true) return { granted: false, holder: null }

--- a/packages/control-plane/src/persistence/repositories/member-set.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/member-set.repo.ts
@@ -1,0 +1,75 @@
+/**
+ * Member sets — the named sets of daemons within which an agent's duty may be claimed
+ * (docs/designs/daemon-groups.md §2). The install-wide pool is the ONE org-less row; org sets
+ * arrive with the console CRUD in PR 2.
+ *
+ * Everything tenancy-shaped lives on the WRITE side here. `enrollDaemonInSet` is the only writer
+ * of `member_set_member`, and it is where "an org-less set accepts only org-less daemons, an org
+ * set only that org's daemons" is enforced — which is precisely what lets the ledger's read path
+ * be one membership lookup with no tenancy branch.
+ */
+import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
+import type { DaemonId } from '../../domain/ids.js'
+import type { MemberSetRecord, MemberSetRepo } from '../ports.js'
+import { AgentSetPlacementDenied, MemberSetTenancyMismatch } from '../errors.js'
+
+/** The ONLY writer of `member_set_member`: the set's org and the daemon's org must be the same
+ *  value, null (cross-org) included, or the row is refused. */
+export async function enrollDaemonInSet(tx: Prisma.TransactionClient, setId: string, daemonId: string): Promise<void> {
+  const [pair] = await tx.$queryRaw<{ setOrgId: string | null; daemonOrgId: string | null }[]>(Prisma.sql`
+    SELECT s."orgId" AS "setOrgId", d."orgId" AS "daemonOrgId"
+    FROM "member_set" s, "daemon" d
+    WHERE s.id = ${setId}::uuid AND d.id = ${daemonId}::uuid
+  `)
+  if (!pair || pair.setOrgId !== pair.daemonOrgId) throw new MemberSetTenancyMismatch(setId, daemonId)
+  // Idempotent: re-auth re-enrolls the same member. Moving a daemon BETWEEN sets is a two-phase
+  // generation-fenced transition (§3), never this path, so a conflicting row is left alone.
+  await tx.$executeRaw(Prisma.sql`
+    INSERT INTO "member_set_member" ("setId", "daemonId") VALUES (${setId}::uuid, ${daemonId}::uuid)
+    ON CONFLICT ("daemonId") DO NOTHING
+  `)
+}
+
+/**
+ * The third write-time invariant, taken inside the transaction that writes the placement: a
+ * `set`-placed agent may reference only the org-less set or a set of its own org. The read path
+ * never re-checks it.
+ */
+export async function assertAgentMayUseSet(
+  tx: Prisma.TransactionClient,
+  agent: { id: string; orgId: string },
+  setId: string
+): Promise<void> {
+  const [row] = await tx.$queryRaw<{ orgId: string | null }[]>(
+    Prisma.sql`SELECT "orgId" FROM "member_set" WHERE id = ${setId}::uuid`
+  )
+  if (!row || (row.orgId !== null && row.orgId !== agent.orgId)) throw new AgentSetPlacementDenied(agent.id, setId)
+}
+
+export class PgMemberSetRepo implements MemberSetRepo {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async crossOrgSetId(): Promise<string | null> {
+    const row = await this.prisma.memberSet.findFirst({ where: { orgId: null }, select: { id: true } })
+    return row?.id ?? null
+  }
+
+  async get(setId: string): Promise<MemberSetRecord | null> {
+    const row = await this.prisma.memberSet.findUnique({ where: { id: setId } })
+    return row ? { id: row.id, orgId: row.orgId, name: row.name } : null
+  }
+
+  async setIdOf(daemonId: DaemonId): Promise<string | null> {
+    const row = await this.prisma.memberSetMember.findUnique({ where: { daemonId }, select: { setId: true } })
+    return row?.setId ?? null
+  }
+
+  async memberIdsOf(setId: string): Promise<string[]> {
+    const rows = await this.prisma.memberSetMember.findMany({ where: { setId }, select: { daemonId: true } })
+    return rows.map((r) => r.daemonId).sort()
+  }
+
+  async enroll(setId: string, daemonId: DaemonId): Promise<void> {
+    await this.prisma.$transaction((tx) => enrollDaemonInSet(tx, setId, daemonId))
+  }
+}

--- a/packages/control-plane/src/ws/handlers/duty-claim.ts
+++ b/packages/control-plane/src/ws/handlers/duty-claim.ts
@@ -20,8 +20,8 @@ export const handleDutyClaim: Handler = async (frame, conn, deps) => {
     conn.replyTo(frame, 'duty/claim/ok', { granted: false })
     return
   }
-  // The connection reached here org-less, so its claim scope is install-wide; the ledger applies
-  // the placement predicate to it rather than trusting the trigger that got the member here.
-  const claim = await deps.dutyLease.claimAgentHome(agent.orgId, agentId, DaemonId(conn.daemonId), 'install-wide')
+  // The ledger applies the placement predicate to this member's own set membership rather than
+  // trusting the trigger that got it here.
+  const claim = await deps.dutyLease.claimAgentHome(agent.orgId, agentId, DaemonId(conn.daemonId))
   conn.replyTo(frame, 'duty/claim/ok', claim)
 }

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
@@ -25,13 +25,16 @@ const SKILL = '51515151-5151-4515-8515-515151515151'
 const ORG_A = 'org-a'
 const ORG_B = 'org-b'
 
+const POOL_SET = '5e700000-0000-4000-8000-000000000001'
+
 const installWideCapabilities = {
   features: [ORGANIZATION_KNOWLEDGE_FEATURE, ORGANIZATION_SUGGESTION_REVIEW_FEATURE]
 }
 
-/** A pool row: placed, naming no machine. `agent.daemonId` can never authorize one. */
+/** A pool row: placed on the org-less set, naming no machine. `agent.daemonId` can never
+ *  authorize one. */
 function poolAgent(id: string) {
-  return { id, placementKind: 'pool' as const, daemonId: null }
+  return { id, placementKind: 'set' as const, daemonId: null, setId: POOL_SET }
 }
 
 /** The live seam, keyed by who holds each agent's duty right now. */

--- a/packages/control-plane/test/fakes/build-app.ts
+++ b/packages/control-plane/test/fakes/build-app.ts
@@ -30,6 +30,7 @@ import {
   PgSessionRepo,
   PgSessionUsageRepo
 } from '../../src/persistence/index.js'
+import { PgMemberSetRepo } from '../../src/persistence/repositories/member-set.repo.js'
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import { EpochService } from '../../src/orchestrator/epoch.js'
 import { DUTY_LEASE_DEFAULTS } from '../../src/orchestrator/dutyLease.js'
@@ -126,13 +127,16 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
     PLATFORMS
   )
   const connReg = new ConnectionRegistry()
+  const memberSets = new PgMemberSetRepo(prisma)
   const placementResolver = new PlacementResolver({
     duties: new PgDutyGroupRepo(prisma),
-    liveMembers: () =>
-      connReg
+    liveMembers: async (setId) => {
+      const members = new Set(await memberSets.memberIdsOf(setId))
+      return connReg
         .reachableDaemons()
-        .filter((d) => d.orgId === null && d.state === 'READY')
-        .map((d) => d.daemonId),
+        .filter((d) => d.state === 'READY' && members.has(d.daemonId))
+        .map((d) => d.daemonId)
+    },
     clock
   })
 

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -63,6 +63,7 @@ import {
   PgIntegrationChannelRepo,
   PgDutyGroupRepo
 } from '../../src/persistence/index.js'
+import { PgMemberSetRepo } from '../../src/persistence/repositories/member-set.repo.js'
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import { runWithSharedTx, withSharedTxRouting } from '../../src/persistence/ambient-tx.js'
 import { AgentSpecAssembler } from '../../src/orchestrator/agentSpecAssembler.js'
@@ -240,6 +241,7 @@ export function buildHttpApp(
   const sender = control ?? new ControlSender(connReg, new PgLaunchRepo(prisma))
 
   const dutyGroupRepo = new PgDutyGroupRepo(prisma)
+  const memberSets = new PgMemberSetRepo(prisma)
 
   const cipher = new PlaintextSecretCipher()
   const agentSecretStore = new PgAgentSecretStore(prisma, cipher)
@@ -307,11 +309,13 @@ export function buildHttpApp(
   // duty ledger is a real repo and a holder actually receives the pushes.
   const placementResolver = new PlacementResolver({
     duties: dutyGroupRepo,
-    liveMembers: () =>
-      connReg
+    liveMembers: async (setId) => {
+      const members = new Set(await memberSets.memberIdsOf(setId))
+      return connReg
         .reachableDaemons()
-        .filter((d) => d.orgId === null && d.state === 'READY')
-        .map((d) => d.daemonId),
+        .filter((d) => d.state === 'READY' && members.has(d.daemonId))
+        .map((d) => d.daemonId)
+    },
     clock
   })
   const agentDelivery = new AgentDelivery({ control: sender, specs: agentSpecs, placement: placementResolver })
@@ -368,6 +372,7 @@ export function buildHttpApp(
     repos: {
       agent: agentRepo,
       assignment: new PgAssignmentRepo(prisma),
+      memberSet: memberSets,
       daemonLifecycleOp: daemonLifecycleOpRepo,
       cron: new PgCronRepo(prisma),
       hook: hookRepo,
@@ -420,7 +425,6 @@ export function buildHttpApp(
     control: sender,
     agentDelivery,
     placementResolver,
-    daemonRows: daemonRepo,
     relayControl,
     httpBot: new HttpBotOrchestrator(
       botRepo,

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -40,6 +40,7 @@ import {
   PgDutyGroupRepo,
   PgHookSecretStore
 } from '../../src/persistence/index.js'
+import { PgMemberSetRepo } from '../../src/persistence/repositories/member-set.repo.js'
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import { EpochService } from '../../src/orchestrator/epoch.js'
 import { Placement } from '../../src/orchestrator/placement.js'
@@ -188,13 +189,16 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
   )
   const relays = opts.relays ?? []
   const dutyGroupRepo = new PgDutyGroupRepo(prisma)
+  const memberSets = new PgMemberSetRepo(prisma)
   const placementResolver = new PlacementResolver({
     duties: dutyGroupRepo,
-    liveMembers: () =>
-      connReg
+    liveMembers: async (setId) => {
+      const members = new Set(await memberSets.memberIdsOf(setId))
+      return connReg
         .reachableDaemons()
-        .filter((d) => d.orgId === null && d.state === 'READY')
-        .map((d) => d.daemonId),
+        .filter((d) => d.state === 'READY' && members.has(d.daemonId))
+        .map((d) => d.daemonId)
+    },
     clock
   })
   const orchestrator = new Placement(

--- a/packages/control-plane/test/fakes/member-set.ts
+++ b/packages/control-plane/test/fakes/member-set.ts
@@ -1,0 +1,22 @@
+/**
+ * Pool-membership helpers for tests that mint org-less daemon rows directly.
+ *
+ * Eligibility is a MEMBERSHIP lookup now (docs/designs/daemon-groups.md §3), not a scope string
+ * the caller asserts — so a test whose claimant is a pool member has to be one: the daemon row
+ * plus its `member_set_member` row, exactly what `upsertOnAuth` writes in production. The pool set
+ * itself is created by the migration, so it survives the per-test truncate.
+ */
+import type { PrismaClient } from '../../src/generated/prisma/client.js'
+
+/** The install-wide pool: the one org-less `member_set` row the migration mints. */
+export async function poolSetId(prisma: PrismaClient): Promise<string> {
+  const row = await prisma.memberSet.findFirstOrThrow({ where: { orgId: null }, select: { id: true } })
+  return row.id
+}
+
+/** Enroll org-less daemon rows in the pool, the way `upsertOnAuth` does on a real connection. */
+export async function joinPool(prisma: PrismaClient, ...daemonIds: string[]): Promise<string> {
+  const setId = await poolSetId(prisma)
+  await prisma.memberSetMember.createMany({ data: daemonIds.map((daemonId) => ({ setId, daemonId })) })
+  return setId
+}

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -12,6 +12,7 @@ import type { CollabRoutesService } from '../../src/orchestrator/collabRoutes.se
 import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
 import { OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
+import { joinPool, poolSetId } from '../fakes/member-set.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 const SOURCE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -68,8 +69,8 @@ const live: DaemonLiveness = {
 /** One install-wide pool member, live alongside the two machines. Org-less AND Pod-bound: that
  *  shape is what makes a row visible to every org's placement list. */
 const MEMBER = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
-const seedPoolMember = () =>
-  prisma.daemon.create({
+const seedPoolMember = async () => {
+  const daemon = await prisma.daemon.create({
     data: {
       id: MEMBER,
       orgId: null,
@@ -80,6 +81,10 @@ const seedPoolMember = () =>
       capabilities: MOVE_CAPS
     }
   })
+  // What `upsertOnAuth` writes for a real Pod: the org-less row is a member of the org-less set.
+  await joinPool(prisma, MEMBER)
+  return daemon
+}
 const poolLive: DaemonLiveness = {
   get: (id) =>
     [SOURCE, TARGET, MEMBER].includes(id) ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined
@@ -622,9 +627,9 @@ describe('PUT /agents/:id/daemon — the pool as a placement target', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toMatchObject({ placementKind: 'pool', daemonId: null })
+    expect(res.json()).toMatchObject({ placementKind: 'set', setId: await poolSetId(prisma), daemonId: null })
     expect(await prisma.agent.findUnique({ where: { id: agentId } })).toMatchObject({
-      placementKind: 'pool',
+      placementKind: 'set',
       daemonId: null,
       status: 'active'
     })
@@ -640,7 +645,10 @@ describe('PUT /agents/:id/daemon — the pool as a placement target', () => {
     await seedPoolMember()
     const agentId = randomUUID()
     await seedAgent(prisma, agentId)
-    await prisma.agent.update({ where: { id: agentId }, data: { placementKind: 'pool', daemonId: null } })
+    await prisma.agent.update({
+      where: { id: agentId },
+      data: { placementKind: 'set', setId: await poolSetId(prisma), daemonId: null }
+    })
     // The member currently holding its duty is the source to quiesce — placement names none.
     const groupId = randomUUID()
     await prisma.dutyGroup.create({
@@ -724,9 +732,14 @@ describe('POST /agents — the pool as a create-time placement', () => {
     })
 
     expect(res.statusCode).toBe(201)
-    expect(res.json()).toMatchObject({ placementKind: 'pool', daemonId: null, status: 'active' })
+    expect(res.json()).toMatchObject({ placementKind: 'set', daemonId: null, status: 'active' })
     const row = await prisma.agent.findFirstOrThrow({ where: { name: 'pooled-create' } })
-    expect(row).toMatchObject({ placementKind: 'pool', daemonId: null, status: 'active' })
+    expect(row).toMatchObject({
+      placementKind: 'set',
+      setId: await poolSetId(prisma),
+      daemonId: null,
+      status: 'active'
+    })
   })
 
   it('refuses a pool create when no member is ready, instead of landing it unplaced', async () => {
@@ -766,7 +779,7 @@ describe('PUT /agents/:id/daemon — converting a member-pinned agent to the poo
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toMatchObject({ placementKind: 'pool', daemonId: null })
+    expect(res.json()).toMatchObject({ placementKind: 'set', daemonId: null })
     // Detached to stop it serving as a PLACEMENT, then activated with the SAME token so the fence
     // it armed is released and its replica is current for a re-grant.
     const detach = control.detaches.find((d) => d.daemonId === MEMBER)

--- a/packages/control-plane/test/integration/organization-knowledge.route.test.ts
+++ b/packages/control-plane/test/integration/organization-knowledge.route.test.ts
@@ -18,6 +18,7 @@ import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { NoConnection, type ControlSender } from '../../src/orchestrator/outbound.js'
 import { AgentId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { poolSetId } from '../fakes/member-set.js'
 import type { DaemonLiveness } from '../../src/ports.js'
 import type { OrgMemberRole } from '../../src/persistence/ports.js'
 import { organizationSuggestionSnapshotToken } from '../../src/organization-knowledge/suggestion-snapshot.js'
@@ -995,7 +996,7 @@ describe('Dream organization suggestion review on a pool member', () => {
     await seedAgent(prisma, sourceAgentId, { name: 'pool-dreamer' })
     await prisma.agent.update({
       where: { id: sourceAgentId },
-      data: { placementKind: 'pool', daemonId: null }
+      data: { placementKind: 'set', setId: await poolSetId(prisma), daemonId: null }
     })
     await seedDutyGroup(prisma, randomUUID(), DAEMON, [sourceAgentId])
 
@@ -1044,7 +1045,7 @@ describe('Dream organization suggestion review on a pool member', () => {
     await seedAgent(prisma, sourceAgentId, { name: 'pool-dreamer-expired' })
     await prisma.agent.update({
       where: { id: sourceAgentId },
-      data: { placementKind: 'pool', daemonId: null }
+      data: { placementKind: 'set', setId: await poolSetId(prisma), daemonId: null }
     })
     // An expired lease is how the ledger says "this member stopped serving it".
     await seedDutyGroup(prisma, randomUUID(), DAEMON, [sourceAgentId], { expiresAt: new Date(Date.now() - 60_000) })

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -10,10 +10,18 @@ import type { InMemoryDaemonStub } from '../fakes/daemon-stub.js'
 import { PgDutyGroupRepo, PgLaunchRepo } from '../../src/persistence/index.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { joinPool, poolSetId } from '../fakes/member-set.js'
 import { DaemonId, OrgId } from '../../src/domain/ids.js'
 
 const DAEMON = 'd1111111-1111-4111-8111-111111111111'
 const OTHER = 'd2222222-2222-4222-8222-222222222222'
+
+/** A second POOL member: the org-less row plus its membership, exactly what `upsertOnAuth` writes
+ *  when a Pod authenticates. Eligibility is a membership lookup, so a survivor has to be one. */
+async function seedPoolPeer(daemonId: string): Promise<void> {
+  await prisma.daemon.create({ data: { id: daemonId, orgId: null, maxAgents: 8, status: 'ready' } })
+  await joinPool(prisma, daemonId)
+}
 const GROUP = '00000000-0000-4000-8000-000000000001'
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const AGENT2 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
@@ -123,7 +131,8 @@ describe('duty lease exchange (protocol level, real Postgres)', () => {
         orgId: DEFAULT_ORG_ID,
         name: 'stamped',
         runtime: 'claude',
-        placementKind: 'pool',
+        placementKind: 'set',
+        setId: await poolSetId(prisma),
         configRevision: 9n
       }
     })
@@ -295,10 +304,9 @@ describe('duty lease exchange (protocol level, real Postgres)', () => {
     expect(row.term).toBe(2n)
 
     // Immediately grantable by a survivor at a bumped term.
+    await seedPoolPeer(OTHER)
     const repo = new PgDutyGroupRepo(prisma)
-    const grants = await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS, {
-      scope: 'install-wide'
-    })
+    const grants = await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS)
     expect(grants[0]).toMatchObject({ groupId: GROUP, orgId: OrgId(DEFAULT_ORG_ID), term: 3n })
   })
 })
@@ -786,10 +794,17 @@ describe('duty/claim — the activation rendezvous (real Postgres)', () => {
   const CLAIM_ID = '66666666-6666-4666-8666-666666666666'
 
   // Placed on the POOL: the rendezvous applies the same eligibility gate as the heartbeat claim,
-  // so an install-wide member may only claim an agent whose placement is the pool.
+  // so a pool member may only claim an agent whose placement is the pool's set.
   async function seedAgentRow(): Promise<void> {
     await prisma.agent.create({
-      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'agent-1', runtime: 'claude', placementKind: 'pool' }
+      data: {
+        id: AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'agent-1',
+        runtime: 'claude',
+        placementKind: 'set',
+        setId: await poolSetId(prisma)
+      }
     })
   }
 
@@ -891,7 +906,14 @@ describe('proactive healing after a rollout (protocol level, real Postgres)', ()
     // The replaced Pod: it held the group, and its lease ran out 1ms ago.
     await seedGroup({ holder: OTHER, term: 4n, expiresAt: new Date(start - 1) })
     await prisma.agent.create({
-      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'webchat-only', runtime: 'claude', placementKind: 'pool' }
+      data: {
+        id: AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'webchat-only',
+        runtime: 'claude',
+        placementKind: 'set',
+        setId: await poolSetId(prisma)
+      }
     })
     const { stub } = await ready(h)
 
@@ -910,7 +932,14 @@ describe('proactive healing after a rollout (protocol level, real Postgres)', ()
     const h = buildWsHarness(prisma)
     await seedGroup({ holder: OTHER, term: 4n, expiresAt: new Date(start - 1) })
     await prisma.agent.create({
-      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'webchat-only', runtime: 'claude', placementKind: 'pool' }
+      data: {
+        id: AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'webchat-only',
+        runtime: 'claude',
+        placementKind: 'set',
+        setId: await poolSetId(prisma)
+      }
     })
     const { stub } = await ready(h)
 
@@ -930,7 +959,14 @@ describe('proactive healing after a rollout (protocol level, real Postgres)', ()
     const start = new Date(h.clock.now())
     await seedGroup({ holder: DAEMON, term: 1n, expiresAt: new Date(start.getTime() + LEASE_MS) })
     await prisma.agent.create({
-      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'uninstallable', runtime: 'claude', placementKind: 'pool' }
+      data: {
+        id: AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'uninstallable',
+        runtime: 'claude',
+        placementKind: 'set',
+        setId: await poolSetId(prisma)
+      }
     })
     const { stub } = await ready(h)
 
@@ -952,10 +988,9 @@ describe('proactive healing after a rollout (protocol level, real Postgres)', ()
     expect(stub.sent.filter((f) => f.type === 'duty/grant')).toHaveLength(2)
 
     // A different member takes it immediately — the point of handing it back.
+    await seedPoolPeer(OTHER)
     const repo = new PgDutyGroupRepo(prisma)
-    const grants = await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS, {
-      scope: 'install-wide'
-    })
+    const grants = await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS)
     expect(grants.map((g) => g.groupId)).toEqual([GROUP])
   })
 
@@ -979,7 +1014,14 @@ describe('routing follows the holder (protocol level, real Postgres)', () => {
 
   async function seedPooledAgentWithHook(): Promise<void> {
     await prisma.agent.create({
-      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'hooked', runtime: 'claude', placementKind: 'pool' }
+      data: {
+        id: AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'hooked',
+        runtime: 'claude',
+        placementKind: 'set',
+        setId: await poolSetId(prisma)
+      }
     })
     await prisma.hookDef.create({
       data: {
@@ -1046,7 +1088,14 @@ describe('a grant is not a route until the digest confirms it (protocol level, r
 
   async function seedPooledAgent(): Promise<void> {
     await prisma.agent.create({
-      data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'peer', runtime: 'claude', placementKind: 'pool' }
+      data: {
+        id: AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'peer',
+        runtime: 'claude',
+        placementKind: 'set',
+        setId: await poolSetId(prisma)
+      }
     })
   }
 
@@ -1158,8 +1207,9 @@ describe('a grant is not a route until the digest confirms it (protocol level, r
 
     // Lapse it, then let a different member take it.
     await prisma.dutyGroup.update({ where: { id: GROUP }, data: { expiresAt: new Date(h.clock.now() - 1) } })
+    await seedPoolPeer(OTHER)
     const repo = new PgDutyGroupRepo(prisma)
-    await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(DaemonId(OTHER), 1, new Date(h.clock.now()), LEASE_MS)
 
     expect(await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).toMatchObject({ holder: OTHER })
     expect(await isConfirmed(GROUP)).toBe(false)
@@ -1183,9 +1233,7 @@ describe('a grant is not a route until the digest confirms it (protocol level, r
     // Lapse, then the SAME member re-takes it.
     await prisma.dutyGroup.update({ where: { id: GROUP }, data: { expiresAt: new Date(h.clock.now() - 1) } })
     const repo = new PgDutyGroupRepo(prisma)
-    const [regrant] = await repo.claimVacant(DaemonId(DAEMON), 1, new Date(h.clock.now()), LEASE_MS, {
-      scope: 'install-wide'
-    })
+    const [regrant] = await repo.claimVacant(DaemonId(DAEMON), 1, new Date(h.clock.now()), LEASE_MS)
     expect(regrant?.term).toBe(2n)
     expect(await isConfirmed(GROUP)).toBe(false)
     expect(await directoryDaemonFor(h, AGENT)).toBeNull()

--- a/packages/control-plane/test/protocol/organization-knowledge-reads.handler.test.ts
+++ b/packages/control-plane/test/protocol/organization-knowledge-reads.handler.test.ts
@@ -12,6 +12,7 @@ import { prisma } from '../setup.db.js'
 import { buildWsHarness } from '../fakes/build-ws.js'
 import type { InMemoryDaemonStub } from '../fakes/daemon-stub.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { poolSetId } from '../fakes/member-set.js'
 
 const DAEMON = 'd3333333-3333-4333-8333-333333333333'
 const OTHER = 'd4444444-4444-4444-8444-444444444444'
@@ -27,7 +28,8 @@ async function seedPoolAgent(managedSkills: string[]): Promise<string> {
       orgId: DEFAULT_ORG_ID,
       name: `dreamer-${id.slice(0, 8)}`,
       runtime: 'claude',
-      placementKind: 'pool',
+      placementKind: 'set',
+      setId: await poolSetId(prisma),
       managedSkills
     }
   })

--- a/packages/control-plane/test/protocol/organization-suggestion-sync.handler.test.ts
+++ b/packages/control-plane/test/protocol/organization-suggestion-sync.handler.test.ts
@@ -11,6 +11,7 @@ import {
 import { prisma } from '../setup.db.js'
 import { buildWsHarness } from '../fakes/build-ws.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { poolSetId } from '../fakes/member-set.js'
 
 const DAEMON = 'd1111111-1111-4111-8111-111111111111'
 const OTHER = 'd2222222-2222-4222-8222-222222222222'
@@ -21,7 +22,14 @@ const REG_ID = '88888888-8888-4888-8888-888888888888'
 async function seedPoolAgent(): Promise<string> {
   const id = randomUUID()
   await prisma.agent.create({
-    data: { id, orgId: DEFAULT_ORG_ID, name: `dreamer-${id.slice(0, 8)}`, runtime: 'claude', placementKind: 'pool' }
+    data: {
+      id,
+      orgId: DEFAULT_ORG_ID,
+      name: `dreamer-${id.slice(0, 8)}`,
+      runtime: 'claude',
+      placementKind: 'set',
+      setId: await poolSetId(prisma)
+    }
   })
   return id
 }

--- a/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
+++ b/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
@@ -2,6 +2,7 @@
 import { onDaemon } from '../../src/domain/placement.js'
 import { describe, it, expect } from 'vitest'
 import { prisma } from '../setup.db.js'
+import { poolSetId } from '../fakes/member-set.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { seedAgent } from '../fixtures/seed.js'
 import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
@@ -232,7 +233,7 @@ describe('DaemonRepo cloud-member retirement', () => {
     await seedAgent(prisma, pooled)
     await prisma.agent.update({
       where: { id: pooled },
-      data: { placementKind: 'pool', daemonId: null, status: 'active' }
+      data: { placementKind: 'set', setId: await poolSetId(prisma), daemonId: null, status: 'active' }
     })
 
     expect(await repo.retireCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: pod.sessionEpoch })).toEqual({
@@ -240,7 +241,7 @@ describe('DaemonRepo cloud-member retirement', () => {
       settled: []
     })
     expect(await prisma.agent.findUnique({ where: { id: pooled } })).toMatchObject({
-      placementKind: 'pool',
+      placementKind: 'set',
       daemonId: null,
       status: 'active'
     })

--- a/packages/control-plane/test/repo/duty-group.repo.test.ts
+++ b/packages/control-plane/test/repo/duty-group.repo.test.ts
@@ -9,6 +9,7 @@ import { planDutyReconcile, computeDutyComponents } from '../../src/orchestrator
 import type { DutyGroupRecord } from '../../src/persistence/ports.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
+import { joinPool } from '../fakes/member-set.js'
 
 const ORG = OrgId(DEFAULT_ORG_ID)
 const M1 = DaemonId('d1111111-1111-4111-8111-111111111111')
@@ -56,7 +57,7 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
     expect(rows).toHaveLength(2)
     expect(rows.every((r) => r.holder === null && r.term === 0n && r.expiresAt === null)).toBe(true)
 
-    const grants = await repo.claimVacant(M1, 10, T0, LEASE_MS, { scope: 'install-wide' })
+    const grants = await repo.claimVacant(M1, 10, T0, LEASE_MS)
     expect(grants).toHaveLength(2)
     expect(grants.every((g) => g.term === 1n)).toBe(true)
     expect(grants.map((g) => g.members)).toContainEqual([
@@ -69,18 +70,15 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
 
-    expect(await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })).toHaveLength(1)
-    expect(await repo.claimVacant(M2, 10, T0, LEASE_MS, { scope: 'install-wide' })).toHaveLength(1)
+    expect(await repo.claimVacant(M1, 1, T0, LEASE_MS)).toHaveLength(1)
+    expect(await repo.claimVacant(M2, 10, T0, LEASE_MS)).toHaveLength(1)
   })
 
   it('racing claimants never receive the same group', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
 
-    const [g1, g2] = await Promise.all([
-      repo.claimVacant(M1, 2, T0, LEASE_MS, { scope: 'install-wide' }),
-      repo.claimVacant(M2, 2, T0, LEASE_MS, { scope: 'install-wide' })
-    ])
+    const [g1, g2] = await Promise.all([repo.claimVacant(M1, 2, T0, LEASE_MS), repo.claimVacant(M2, 2, T0, LEASE_MS)])
     const ids = [...g1, ...g2].map((g) => g.groupId)
     expect(new Set(ids).size).toBe(ids.length)
     expect(ids).toHaveLength(2)
@@ -89,10 +87,10 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('an expired lease is grantable again at a higher term', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [], [A1], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
 
     const late = after(LEASE_MS + 1)
-    const regrants = await repo.claimVacant(M2, 1, late, LEASE_MS, { scope: 'install-wide' })
+    const regrants = await repo.claimVacant(M2, 1, late, LEASE_MS)
     expect(regrants).toHaveLength(1)
     expect(regrants[0]!.term).toBe(2n)
     const [row] = await repo.listHeldBy(M2)
@@ -102,7 +100,7 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('renewHeld refreshes the horizon term-free; a reassigned group stops matching', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [], [A1], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
 
     const renewed = await repo.renewHeld(M1, after(10_000), LEASE_MS)
     expect(renewed).toHaveLength(1)
@@ -112,14 +110,14 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
 
     // Lapse, reassign to M2, then the old holder's renewal matches nothing.
     const late = after(LEASE_MS * 2)
-    await repo.claimVacant(M2, 1, late, LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M2, 1, late, LEASE_MS)
     expect(await repo.renewHeld(M1, after(LEASE_MS * 2 + 1000), LEASE_MS)).toEqual([])
   })
 
   it('a lapsed-but-unclaimed lease still renews at the same term (CP outage recovery)', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [], [A1], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
 
     const renewed = await repo.renewHeld(M1, after(LEASE_MS * 3), LEASE_MS)
     expect(renewed).toHaveLength(1)
@@ -130,21 +128,21 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('release vacates immediately, keeps the term, and is holder-conditional', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [], [A1], T0)
-    const [grant] = await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
+    const [grant] = await repo.claimVacant(M1, 1, T0, LEASE_MS)
 
     await repo.release(M2, [grant!.groupId]) // not the holder — no-op
     expect(await repo.listHeldBy(M1)).toHaveLength(1)
 
     await repo.release(M1, [grant!.groupId])
     expect(await repo.listHeldBy(M1)).toHaveLength(0)
-    const regrant = await repo.claimVacant(M2, 1, after(1), LEASE_MS, { scope: 'install-wide' })
+    const regrant = await repo.claimVacant(M2, 1, after(1), LEASE_MS)
     expect(regrant[0]!.term).toBe(2n)
   })
 
   it('reconcile re-grants the incumbent at a bumped term when a held group gains a bot', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
 
     const plan = await reconcile(
       repo,
@@ -164,8 +162,8 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('reconcile merge keeps the larger held group and reports the loser superseded', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
-    const grants1 = await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
-    const grants2 = await repo.claimVacant(M2, 1, T0, LEASE_MS, { scope: 'install-wide' })
+    const grants1 = await repo.claimVacant(M1, 1, T0, LEASE_MS)
+    const grants2 = await repo.claimVacant(M2, 1, T0, LEASE_MS)
     const bigHolder = grants1[0]!.members.length > grants2[0]!.members.length ? M1 : M2
 
     // A2 gains an integration on B1: the {A1,B1} pair and the {A2} singleton merge.
@@ -188,7 +186,7 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('reconcile deletes groups whose edges vanished', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
 
     const plan = await reconcile(repo, [], [], after(1000))
     expect(plan.deletes).toHaveLength(1)
@@ -204,10 +202,7 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
 
-    const [grants, plan] = await Promise.all([
-      repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' }),
-      reconcile(repo, [], [], after(1))
-    ])
+    const [grants, plan] = await Promise.all([repo.claimVacant(M1, 1, T0, LEASE_MS), reconcile(repo, [], [], after(1))])
     expect(plan.deletes).toHaveLength(1)
     if (grants.length === 1) expect(plan.superseded).toEqual([{ groupId: grants[0]!.groupId, holder: M1 }])
     else expect(plan.superseded).toEqual([])
@@ -217,7 +212,7 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
   it('reconcile leaves an unchanged held group untouched (no term churn)', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
 
     const plan = await reconcile(repo, [{ agentId: A1, botId: B1 }], [], after(1000))
     expect(plan.unchanged).toHaveLength(1)
@@ -228,16 +223,24 @@ describe('DutyGroupRepo — ledger writes (real Postgres)', () => {
 
 describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
   // The rendezvous is a claim path, so it takes the eligibility gate too — which means the agent
-  // has to exist and be placed on the pool for an install-wide member to claim it.
+  // has to be placed on the pool AND the claimant has to be one of its members. Eligibility reads
+  // membership from the ledger's own tables, so a claimant now has to be a real enrolled daemon.
   beforeEach(async () => {
+    await prisma.daemon.createMany({
+      data: [
+        { id: M1, orgId: null, maxAgents: 8, status: 'ready' },
+        { id: M2, orgId: null, maxAgents: 8, status: 'ready' }
+      ]
+    })
+    const setId = await joinPool(prisma, M1, M2)
     await prisma.agent.create({
-      data: { id: A1, orgId: DEFAULT_ORG_ID, name: 'pooled', runtime: 'claude', placementKind: 'pool' }
+      data: { id: A1, orgId: DEFAULT_ORG_ID, name: 'pooled', runtime: 'claude', placementKind: 'set', setId }
     })
   })
 
   it('claiming creates the lease for an unmapped agent', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    const claim = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
+    const claim = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
     expect(claim).toMatchObject({ granted: true, term: 1n, holder: M1 })
     const rows = await repo.listForOrg(ORG)
     expect(rows[0]!.members).toEqual([{ kind: 'agent', refId: A1 }])
@@ -245,8 +248,8 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
 
   it('is idempotent for the current holder — horizon refreshed, term kept', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
-    const again = await repo.claimAgentHome(ORG, AgentId(A1), M1, after(10_000), LEASE_MS, 'install-wide')
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    const again = await repo.claimAgentHome(ORG, AgentId(A1), M1, after(10_000), LEASE_MS)
     expect(again).toMatchObject({ granted: true, term: 1n, holder: M1 })
     const [row] = await repo.listHeldBy(M1)
     expect(row!.expiresAt).toEqual(after(10_000 + LEASE_MS))
@@ -254,21 +257,21 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
 
   it('names the incumbent instead of granting while the home is live', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    const won = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
-    const lost = await repo.claimAgentHome(ORG, AgentId(A1), M2, after(1000), LEASE_MS, 'install-wide')
+    const won = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    const lost = await repo.claimAgentHome(ORG, AgentId(A1), M2, after(1000), LEASE_MS)
     expect(lost).toEqual({ granted: false, groupId: won.groupId, term: 1n, holder: M1 })
   })
 
   it('grants an expired home to the new claimant at a bumped term', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
-    const claim = await repo.claimAgentHome(ORG, AgentId(A1), M2, after(LEASE_MS + 1), LEASE_MS, 'install-wide')
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    const claim = await repo.claimAgentHome(ORG, AgentId(A1), M2, after(LEASE_MS + 1), LEASE_MS)
     expect(claim).toMatchObject({ granted: true, term: 2n, holder: M2 })
   })
 
   it('holdsAgent answers only for the live holder — the duty/fetch authorization', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
 
     expect(await repo.holdsAgent(M1, AgentId(A1), T0)).toBe(true)
     // Another member holds nothing here, and neither does the holder for an agent
@@ -290,7 +293,7 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
       [],
       T0
     )
-    await repo.claimVacant(M1, 10, T0, LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 10, T0, LEASE_MS)
 
     expect(await repo.holdsAgent(M1, AgentId(A1), T0)).toBe(true)
     expect(await repo.holdsAgent(M1, AgentId(A2), T0)).toBe(true)
@@ -308,7 +311,7 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
       T0
     )
     const [first] = await repo.listForOrg(ORG)
-    await repo.claimVacant(M1, 1, T0, LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 1, T0, LEASE_MS)
     const heldAgent = first!.members.find((m) => m.kind === 'agent')!.refId
 
     expect(await repo.holdersOf(AgentId(heldAgent), T0)).toEqual([M1])
@@ -320,7 +323,7 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
 
   it('holdersOf survives the agent row it names — a delete must still reach the holder', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
-    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide')
+    await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
     // No FK from membership to `agent`: the projection owns that lifecycle, so a
     // cascade cannot strand `agent/remove` with nowhere to send it.
     expect(await repo.holdersOf(AgentId(A1), T0)).toEqual([M1])
@@ -329,8 +332,8 @@ describe('DutyGroupRepo — agent-home claims (real Postgres)', () => {
   it('racing first claims resolve to exactly one home and one winner', async () => {
     const repo = new PgDutyGroupRepo(prisma, minter())
     const [c1, c2] = await Promise.all([
-      repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS, 'install-wide'),
-      repo.claimAgentHome(ORG, AgentId(A1), M2, T0, LEASE_MS, 'install-wide')
+      repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS),
+      repo.claimAgentHome(ORG, AgentId(A1), M2, T0, LEASE_MS)
     ])
     expect([c1.granted, c2.granted].filter(Boolean)).toHaveLength(1)
     expect(c1.groupId).toBe(c2.groupId)

--- a/packages/control-plane/test/repo/duty-recompute.test.ts
+++ b/packages/control-plane/test/repo/duty-recompute.test.ts
@@ -7,6 +7,7 @@ import { PgDutyGroupRepo } from '../../src/persistence/index.js'
 import { DutyRecomputeSweep } from '../../src/orchestrator/dutyRecompute.js'
 import type { DutyReconcilePlan } from '../../src/domain/duty.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { joinPool, poolSetId } from '../fakes/member-set.js'
 import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
 import { FakeClock } from '../fakes/fake-clock.js'
 
@@ -77,14 +78,14 @@ async function seedAgent(id: string, name: string, daemonId?: string): Promise<v
   })
 }
 
-/** An agent placed on the POOL: kind `pool`, no member id at all. */
+/** An agent placed on the POOL: kind `set` pointing at the org-less set, no member id at all. */
 async function seedPoolAgent(id: string, name: string): Promise<void> {
   await prisma.agent.create({
-    data: { id, orgId: DEFAULT_ORG_ID, name, runtime: 'claude', placementKind: 'pool' }
+    data: { id, orgId: DEFAULT_ORG_ID, name, runtime: 'claude', placementKind: 'set', setId: await poolSetId(prisma) }
   })
 }
 
-/** Install-wide pool members: org-less rows, which is what makes them install-wide. */
+/** Install-wide pool members: org-less rows enrolled in the org-less set, as `upsertOnAuth` does. */
 async function seedMembers(): Promise<void> {
   await prisma.daemon.createMany({
     data: [
@@ -92,6 +93,7 @@ async function seedMembers(): Promise<void> {
       { id: POOL_B, orgId: null, maxAgents: 8, status: 'ready' }
     ]
   })
+  await joinPool(prisma, POOL_A, POOL_B)
 }
 
 async function seedBot(id: string, transport: 'socket' | 'http'): Promise<void> {
@@ -162,7 +164,7 @@ describe('duty recompute sweep (real Postgres)', () => {
     await s.tick()
     const [created] = await repo.listForOrg(ORG)
     expect(created!.members).toEqual([{ kind: 'agent', refId: AGENT }])
-    const [grant] = await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
+    const [grant] = await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS)
     expect(grant).toBeDefined()
 
     // The flap this test exists for: sweep 2 and 3 must plan no delete and no
@@ -190,7 +192,7 @@ describe('duty recompute sweep (real Postgres)', () => {
     const { repo, clock, warns, sweep: s } = sweep()
 
     // The design's fallback path: the trigger arrives before the sweep ran.
-    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), M1, new Date(clock.now()), LEASE_MS, 'install-wide')
+    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), M1, new Date(clock.now()), LEASE_MS)
     expect(claim.granted).toBe(true)
 
     await s.tick()
@@ -209,7 +211,7 @@ describe('duty recompute sweep (real Postgres)', () => {
     await seedAgent(AGENT, 'agent-1') // no placement
     const { repo, clock, warns, sweep: s } = sweep()
 
-    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), M1, new Date(clock.now()), LEASE_MS, 'install-wide')
+    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), M1, new Date(clock.now()), LEASE_MS)
     expect(claim.granted).toBe(false)
     await s.tick()
 
@@ -239,7 +241,7 @@ describe('duty recompute sweep (real Postgres)', () => {
 
     await s.tick()
     const [singleton] = await repo.listForOrg(ORG)
-    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS)
 
     await seedBot(BOT, 'socket')
     await seedIntegration(INTEG, AGENT, BOT)
@@ -292,7 +294,7 @@ describe('duty recompute sweep (real Postgres)', () => {
     const { repo, clock, sweep: s } = sweep()
 
     await s.tick()
-    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS)
 
     // A second agent joins the same daemon-held bot: the group widens.
     await seedAgent(AGENT2, 'agent-2', M1)
@@ -314,15 +316,15 @@ describe('incumbent placement fence (real Postgres)', () => {
     await seedIntegration(INTEG, AGENT, BOT)
     const { repo, clock, sweep: s } = sweep()
     await s.tick()
-    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS)
 
     // The agent moves to M2: the next tick vacates M1's lease, and only M2 can claim.
     await prisma.agent.update({ where: { id: AGENT }, data: { daemonId: M2 } })
     await s.tick()
     expect(await repo.listHeldBy(M1)).toEqual([])
     const now = new Date(clock.now())
-    expect(await repo.claimVacant(M1, 5, now, LEASE_MS, { scope: 'install-wide' })).toEqual([])
-    const grants = await repo.claimVacant(M2, 5, now, LEASE_MS, { scope: 'install-wide' })
+    expect(await repo.claimVacant(M1, 5, now, LEASE_MS)).toEqual([])
+    const grants = await repo.claimVacant(M2, 5, now, LEASE_MS)
     expect(grants).toHaveLength(1)
     expect(grants[0]!.term).toBe(2n)
   })
@@ -341,7 +343,7 @@ describe('incumbent placement fence (real Postgres)', () => {
     await seedIntegration(INTEG2, AGENT2, BOT)
     const { repo, clock, sweep: s } = sweep()
     await s.tick()
-    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS, { scope: 'org-scoped' })
+    await repo.claimVacant(M1, 1, new Date(clock.now()), LEASE_MS)
     expect(await repo.listHeldBy(M1)).toHaveLength(1)
 
     await prisma.agent.update({ where: { id: AGENT2 }, data: { daemonId: M2 } })
@@ -361,8 +363,8 @@ describe('placement eligibility gate (real Postgres)', () => {
     const now = new Date(clock.now())
 
     // Another machine may not take it, and neither may an install-wide member.
-    expect(await repo.claimVacant(M2, 5, now, LEASE_MS, { scope: 'org-scoped' })).toEqual([])
-    const grants = await repo.claimVacant(M1, 5, now, LEASE_MS, { scope: 'org-scoped' })
+    expect(await repo.claimVacant(M2, 5, now, LEASE_MS)).toEqual([])
+    const grants = await repo.claimVacant(M1, 5, now, LEASE_MS)
     expect(grants).toHaveLength(1)
     expect(grants[0]!.members).toContainEqual({ kind: 'agent', refId: AGENT })
   })
@@ -377,11 +379,11 @@ describe('placement eligibility gate (real Postgres)', () => {
     await s.tick()
     const now = new Date(clock.now())
 
-    expect(await repo.claimVacant(POOL_A, 5, now, LEASE_MS, { scope: 'install-wide' })).toEqual([])
-    expect(await repo.claimVacant(POOL_B, 5, now, LEASE_MS, { scope: 'install-wide' })).toEqual([])
+    expect(await repo.claimVacant(POOL_A, 5, now, LEASE_MS)).toEqual([])
+    expect(await repo.claimVacant(POOL_B, 5, now, LEASE_MS)).toEqual([])
     // And the rendezvous is the same gate, not a second one: a trigger reaching the wrong member
     // is not authority to serve an agent that member may not hold.
-    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), POOL_A, now, LEASE_MS, 'install-wide')
+    const claim = await repo.claimAgentHome(ORG, AgentId(AGENT), POOL_A, now, LEASE_MS)
     expect(claim.granted).toBe(false)
     expect(await repo.listHeldBy(POOL_A)).toEqual([])
   })
@@ -395,8 +397,8 @@ describe('placement eligibility gate (real Postgres)', () => {
     const now = new Date(clock.now())
 
     // A machine-scoped claimant is never install-wide, so the pool's work stays out of reach.
-    expect(await repo.claimVacant(M1, 5, now, LEASE_MS, { scope: 'org-scoped' })).toEqual([])
-    const grants = await repo.claimVacant(POOL_B, 5, now, LEASE_MS, { scope: 'install-wide' })
+    expect(await repo.claimVacant(M1, 5, now, LEASE_MS)).toEqual([])
+    const grants = await repo.claimVacant(POOL_B, 5, now, LEASE_MS)
     expect(grants).toHaveLength(1)
     expect(grants[0]!.members).toContainEqual({ kind: 'agent', refId: AGENT })
   })
@@ -416,8 +418,8 @@ describe('placement eligibility gate (real Postgres)', () => {
     expect(await repo.listForOrg(ORG)).toHaveLength(1)
     const now = new Date(clock.now())
 
-    expect(await repo.claimVacant(M1, 5, now, LEASE_MS, { scope: 'org-scoped' })).toEqual([])
-    expect(await repo.claimVacant(POOL_A, 5, now, LEASE_MS, { scope: 'install-wide' })).toEqual([])
+    expect(await repo.claimVacant(M1, 5, now, LEASE_MS)).toEqual([])
+    expect(await repo.claimVacant(POOL_A, 5, now, LEASE_MS)).toEqual([])
   })
 
   it('an unplaced agent’s group is claimable by nobody, and its rendezvous claim is refused', async () => {
@@ -428,9 +430,9 @@ describe('placement eligibility gate (real Postgres)', () => {
     await s.tick()
     const now = new Date(clock.now())
 
-    expect(await repo.claimVacant(POOL_A, 5, now, LEASE_MS, { scope: 'install-wide' })).toEqual([])
-    expect(await repo.claimVacant(M1, 5, now, LEASE_MS, { scope: 'org-scoped' })).toEqual([])
-    expect((await repo.claimAgentHome(ORG, AgentId(AGENT), POOL_A, now, LEASE_MS, 'install-wide')).granted).toBe(false)
+    expect(await repo.claimVacant(POOL_A, 5, now, LEASE_MS)).toEqual([])
+    expect(await repo.claimVacant(M1, 5, now, LEASE_MS)).toEqual([])
+    expect((await repo.claimAgentHome(ORG, AgentId(AGENT), POOL_A, now, LEASE_MS)).granted).toBe(false)
   })
 
   it('the backoff list excludes named groups from a claim without disturbing the rest', async () => {
@@ -444,7 +446,6 @@ describe('placement eligibility gate (real Postgres)', () => {
     const [first, second] = (await repo.listForOrg(ORG)).map((g) => g.groupId)
 
     const grants = await repo.claimVacant(POOL_A, 5, now, LEASE_MS, {
-      scope: 'install-wide',
       excludeGroupIds: [first!]
     })
     expect(grants.map((g) => g.groupId)).toEqual([second])
@@ -458,7 +459,7 @@ describe('the placement fence (real Postgres)', () => {
     await seedPoolAgent(AGENT, 'pool-agent')
     const { repo, clock, sweep: s, warns } = sweep()
     await s.tick()
-    const [granted] = await repo.claimVacant(POOL_A, 5, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
+    const [granted] = await repo.claimVacant(POOL_A, 5, new Date(clock.now()), LEASE_MS)
     expect(granted).toBeDefined()
 
     // Moved off the pool onto a machine: the member holding it is no longer eligible.
@@ -475,7 +476,7 @@ describe('the placement fence (real Postgres)', () => {
     await seedPoolAgent(AGENT, 'pool-agent')
     const { repo, clock, sweep: s } = sweep()
     await s.tick()
-    await repo.claimVacant(POOL_A, 5, new Date(clock.now()), LEASE_MS, { scope: 'install-wide' })
+    await repo.claimVacant(POOL_A, 5, new Date(clock.now()), LEASE_MS)
     await s.tick()
     expect(await repo.listHeldBy(POOL_A)).toHaveLength(1)
   })

--- a/packages/control-plane/test/repo/member-set.repo.test.ts
+++ b/packages/control-plane/test/repo/member-set.repo.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Member sets — the write-time invariants that let the read path be one membership lookup
+ * (docs/designs/daemon-groups.md §2/§3), plus the eligibility parity the fold rests on.
+ *
+ * Everything tenancy-shaped is enforced HERE, where the row is written. If any of these three
+ * rejections stops working, `mayHold`'s single rule silently widens: an org-scoped daemon could
+ * be enrolled in the pool and reach every organization's agents, or an agent could be pointed at
+ * another org's set and be claimed by that org's members.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
+import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
+import { PgMemberSetRepo } from '../../src/persistence/repositories/member-set.repo.js'
+import { AgentSetPlacementDenied, MemberSetTenancyMismatch } from '../../src/persistence/errors.js'
+import { onSet, onDaemon } from '../../src/domain/placement.js'
+import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { joinPool, poolSetId } from '../fakes/member-set.js'
+
+const ORG = OrgId(DEFAULT_ORG_ID)
+const POOL_MEMBER = 'd1111111-1111-4111-8111-111111111111'
+const LOCAL_DAEMON = 'd2222222-2222-4222-8222-222222222222'
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const T0 = new Date('2026-01-01T00:00:00Z')
+const LEASE_MS = 120_000
+
+/** A second org with a set of its own — the shape PR 2 creates and PR 1 must already refuse to mix. */
+async function otherOrgSet(): Promise<{ orgId: string; setId: string }> {
+  const org = await prisma.org.create({ data: { slug: `member-set-other-${randomUUID().slice(0, 8)}` } })
+  const set = await prisma.memberSet.create({ data: { id: randomUUID(), orgId: org.id, name: 'other-group' } })
+  return { orgId: org.id, setId: set.id }
+}
+
+describe('member_set_member — the tenancy invariant on membership (real Postgres)', () => {
+  beforeEach(async () => {
+    await prisma.daemon.createMany({
+      data: [
+        { id: POOL_MEMBER, orgId: null, maxAgents: 8, status: 'ready' },
+        { id: LOCAL_DAEMON, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' }
+      ]
+    })
+  })
+
+  it('refuses an org-scoped daemon in the org-less set — the pool never absorbs a local machine', async () => {
+    const repo = new PgMemberSetRepo(prisma)
+    await expect(repo.enroll(await poolSetId(prisma), DaemonId(LOCAL_DAEMON))).rejects.toBeInstanceOf(
+      MemberSetTenancyMismatch
+    )
+    expect(await prisma.memberSetMember.count()).toBe(0)
+  })
+
+  it('refuses an org-less daemon in an org set — a group never reaches the pool', async () => {
+    const repo = new PgMemberSetRepo(prisma)
+    const { setId } = await otherOrgSet()
+    await expect(repo.enroll(setId, DaemonId(POOL_MEMBER))).rejects.toBeInstanceOf(MemberSetTenancyMismatch)
+    expect(await prisma.memberSetMember.count()).toBe(0)
+  })
+
+  it('accepts matching tenancy and is idempotent, because re-auth re-enrolls the same member', async () => {
+    const repo = new PgMemberSetRepo(prisma)
+    const setId = await poolSetId(prisma)
+    await repo.enroll(setId, DaemonId(POOL_MEMBER))
+    await repo.enroll(setId, DaemonId(POOL_MEMBER))
+    expect(await repo.memberIdsOf(setId)).toEqual([POOL_MEMBER])
+    expect(await repo.setIdOf(DaemonId(POOL_MEMBER))).toBe(setId)
+    expect(await repo.setIdOf(DaemonId(LOCAL_DAEMON))).toBeNull()
+  })
+
+  it('enrolls an org-less row in the pool on auth, and never an org-scoped one', async () => {
+    const daemons = new PgDaemonRepo(prisma)
+    const sets = new PgMemberSetRepo(prisma)
+    await daemons.upsertOnAuth({ daemonId: DaemonId(POOL_MEMBER), orgId: null, agentVersion: '1.0.0' })
+    await daemons.upsertOnAuth({ daemonId: DaemonId(LOCAL_DAEMON), orgId: ORG, agentVersion: '1.0.0' })
+
+    expect(await sets.setIdOf(DaemonId(POOL_MEMBER))).toBe(await poolSetId(prisma))
+    expect(await sets.setIdOf(DaemonId(LOCAL_DAEMON))).toBeNull()
+  })
+
+  it('drops the membership with the daemon row a reaper retires', async () => {
+    const setId = await joinPool(prisma, POOL_MEMBER)
+    await prisma.daemon.delete({ where: { id: POOL_MEMBER } })
+    expect(await new PgMemberSetRepo(prisma).memberIdsOf(setId)).toEqual([])
+  })
+})
+
+describe('agent placement — the set an agent may reference (real Postgres)', () => {
+  it('refuses a create pointed at another org’s set', async () => {
+    const { setId } = await otherOrgSet()
+    await expect(
+      new PgAgentRepo(prisma).create({
+        id: AgentId(AGENT),
+        orgId: ORG,
+        name: 'cross-org',
+        runtime: 'claude',
+        placementKind: 'set',
+        setId
+      })
+    ).rejects.toBeInstanceOf(AgentSetPlacementDenied)
+    expect(await prisma.agent.count()).toBe(0)
+  })
+
+  it('refuses a move onto another org’s set, and takes the org-less one', async () => {
+    const repo = new PgAgentRepo(prisma)
+    const { setId } = await otherOrgSet()
+    await prisma.daemon.create({ data: { id: LOCAL_DAEMON, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    await repo.create({
+      id: AgentId(AGENT),
+      orgId: ORG,
+      name: 'movable',
+      runtime: 'claude',
+      daemonId: DaemonId(LOCAL_DAEMON)
+    })
+
+    await expect(repo.setPlacement(AgentId(AGENT), onSet(setId))).rejects.toBeInstanceOf(AgentSetPlacementDenied)
+    expect(await prisma.agent.findUniqueOrThrow({ where: { id: AGENT } })).toMatchObject({
+      placementKind: 'daemon',
+      daemonId: LOCAL_DAEMON
+    })
+
+    // The org-less set is the one every org may reference — that is what "cross-org" means.
+    const pool = await poolSetId(prisma)
+    await repo.setPlacement(AgentId(AGENT), onSet(pool))
+    expect(await prisma.agent.findUniqueOrThrow({ where: { id: AGENT } })).toMatchObject({
+      placementKind: 'set',
+      setId: pool,
+      daemonId: null
+    })
+  })
+
+  it('fences the compare-and-set move onto another org’s set too', async () => {
+    const repo = new PgAgentRepo(prisma)
+    const { setId } = await otherOrgSet()
+    const pool = await poolSetId(prisma)
+    await repo.create({
+      id: AgentId(AGENT),
+      orgId: ORG,
+      name: 'cas',
+      runtime: 'claude',
+      placementKind: 'set',
+      setId: pool
+    })
+    await expect(repo.movePlacement(AgentId(AGENT), onSet(pool), onSet(setId))).rejects.toBeInstanceOf(
+      AgentSetPlacementDenied
+    )
+  })
+})
+
+describe('the fold is behaviour-preserving: a pool agent’s claimants (real Postgres)', () => {
+  it('is claimable by the pool’s members and by nobody else', async () => {
+    await prisma.daemon.createMany({
+      data: [
+        { id: POOL_MEMBER, orgId: null, maxAgents: 8, status: 'ready' },
+        { id: LOCAL_DAEMON, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' }
+      ]
+    })
+    const setId = await joinPool(prisma, POOL_MEMBER)
+    const agents = new PgAgentRepo(prisma)
+    await agents.create({
+      id: AgentId(AGENT),
+      orgId: ORG,
+      name: 'pooled',
+      runtime: 'claude',
+      placementKind: 'set',
+      setId
+    })
+
+    const ledger = new PgDutyGroupRepo(prisma)
+    // A local daemon is not in the pool's set, so it may not claim what the pool serves…
+    expect(await ledger.claimAgentHome(ORG, AgentId(AGENT), DaemonId(LOCAL_DAEMON), T0, LEASE_MS)).toMatchObject({
+      granted: false
+    })
+    // …and a member of it may, which is the same pair of answers `placementKind = 'pool'` gave.
+    expect(await ledger.claimAgentHome(ORG, AgentId(AGENT), DaemonId(POOL_MEMBER), T0, LEASE_MS)).toMatchObject({
+      granted: true,
+      holder: POOL_MEMBER
+    })
+
+    // Moving it onto the machine flips both answers, through the same one predicate.
+    await agents.setPlacement(AgentId(AGENT), onDaemon(DaemonId(LOCAL_DAEMON)))
+    expect(await ledger.vacateIneligible(ORG)).toHaveLength(1)
+    expect(await ledger.claimVacant(DaemonId(POOL_MEMBER), 5, new Date(T0.getTime() + LEASE_MS + 1), LEASE_MS)).toEqual(
+      []
+    )
+    expect(
+      await ledger.claimVacant(DaemonId(LOCAL_DAEMON), 5, new Date(T0.getTime() + LEASE_MS + 1), LEASE_MS)
+    ).toHaveLength(1)
+  })
+})

--- a/packages/control-plane/test/repo/served-agents.repo.test.ts
+++ b/packages/control-plane/test/repo/served-agents.repo.test.ts
@@ -15,6 +15,7 @@ import { PgAgentRepo, PgDutyGroupRepo } from '../../src/persistence/index.js'
 import { servedAgents } from '../../src/orchestrator/servedAgents.js'
 import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { joinPool } from '../fakes/member-set.js'
 import { DaemonId } from '../../src/domain/ids.js'
 import { FakeClock } from '../fakes/fake-clock.js'
 
@@ -38,11 +39,19 @@ async function seedFixture(now: Date): Promise<void> {
       { id: MEMBER_B, orgId: null, maxAgents: 8, status: 'ready' }
     ]
   })
+  const setId = await joinPool(prisma, MEMBER_A, MEMBER_B)
   await prisma.agent.createMany({
     data: [
       { id: ON_LOCAL, orgId: DEFAULT_ORG_ID, name: 'on-local', runtime: 'claude', daemonId: LOCAL },
-      { id: ON_POOL_HELD, orgId: DEFAULT_ORG_ID, name: 'pool-held', runtime: 'claude', placementKind: 'pool' },
-      { id: ON_POOL_VACANT, orgId: DEFAULT_ORG_ID, name: 'pool-vacant', runtime: 'claude', placementKind: 'pool' },
+      { id: ON_POOL_HELD, orgId: DEFAULT_ORG_ID, name: 'pool-held', runtime: 'claude', placementKind: 'set', setId },
+      {
+        id: ON_POOL_VACANT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'pool-vacant',
+        runtime: 'claude',
+        placementKind: 'set',
+        setId
+      },
       { id: UNPLACED_AGENT, orgId: DEFAULT_ORG_ID, name: 'unplaced', runtime: 'claude' }
     ]
   })

--- a/packages/control-plane/test/setup.db.ts
+++ b/packages/control-plane/test/setup.db.ts
@@ -10,6 +10,7 @@
  * Imported as a `setupFiles` entry (NOT a global), so the hooks register per
  * test file while every concurrently active pool stays on its own database.
  */
+import { randomUUID } from 'node:crypto'
 import { afterAll, beforeEach, inject } from 'vitest'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { PrismaClient } from '../src/generated/prisma/client.js'
@@ -113,10 +114,21 @@ async function truncateAll(): Promise<void> {
   }
 }
 
+/**
+ * The install-wide pool set is created by the MIGRATION, not by the seed — and `TRUNCATE … CASCADE`
+ * reaches `member_set` through its `org` FK even though the pool row is org-less. Restoring it here
+ * is what leaves every test on the migrated shape, where the pool is a row and eligibility is a
+ * membership lookup (docs/designs/daemon-groups.md §8).
+ */
+async function restorePoolSet(): Promise<void> {
+  await prisma.memberSet.create({ data: { id: randomUUID(), orgId: null, name: 'AgentConnect Cloud' } })
+}
+
 beforeEach(async () => {
   // Clean slate, then re-seed the tenancy anchor.
   await truncateAll()
   await seed(prisma)
+  await restorePoolSet()
 })
 
 afterAll(async () => {

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -25,6 +25,7 @@ import {
   agentLabel,
   CLOUD_DAEMON_LABEL,
   CLOUD_PLACEMENT,
+  isCloudPlacementKind,
   placementValueOf,
   type Agent,
   type AgentCallPolicy,
@@ -315,7 +316,7 @@ export default function EditAgentModal({
   const daemonChoices = editAgentDaemonChoices(daemons, daemonId, initialDaemonId.current)
   const cloudServing = daemons.some((candidate) => candidate.cloud && moveReady(candidate))
   const daemonOptions: DaemonSelectOption[] = [
-    ...(daemonChoices.cloudChoice || agent.placementKind === 'pool'
+    ...(daemonChoices.cloudChoice || isCloudPlacementKind(agent.placementKind)
       ? [
           {
             // The POOL, named as itself. The server picks the member — and re-picks it after every

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -13,7 +13,8 @@ import type {
   ResourceVisibility,
   Session,
   SessionImage,
-  Workspace
+  Workspace,
+  PlacementKindValue
 } from '@/lib/data'
 import { CLOUD_DAEMON_LABEL, isSelfSender, lifecycleStatus, MOCK_MODE, placementValueOf } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
@@ -313,10 +314,11 @@ export interface AgentDto {
   organizationVariables?: Array<{ key: string; value: string }>
   organizationSecretKeys?: string[]
   status: string
-  // Placement is a TARGET: `pool` names the install-wide member set and carries no id.
-  placementKind?: 'daemon' | 'pool'
+  // Placement is a TARGET: `set` names a member set through `setId` and carries no member id.
+  placementKind?: PlacementKindValue
   placementReady?: boolean
   daemonId: string | null
+  setId?: string | null
   workspace: AgentWorkspaceDto
   workspaceRepoId?: string | null
   capabilities: string[]
@@ -1083,7 +1085,7 @@ export interface DaemonLifecycleOpDto {
 }
 
 export interface CreateAgentInput {
-  /** `pool` places the agent on the cloud member set and carries no member id. */
+  /** `pool` is the API sugar for the cloud member set; the CP resolves it and stores `set`. */
   placementKind?: 'pool'
   name: string // slug — the CP rejects anything but ^[a-z0-9]+(-[a-z0-9]+)*$
   displayName?: string
@@ -3424,7 +3426,7 @@ export async function setAgentWorkspace(agentId: string, input: SetAgentWorkspac
 // acknowledged source fence/cancel and destination activation; `force` is the
 // explicit recovery path when the source cannot ACK. This stays separate from
 // the ordinary spec PATCH because placement changes have runtime side effects.
-/** A move target: one machine, or the cloud pool as a whole. */
+/** A move target: one machine, or the cloud member set as a whole (submitted as the `pool` sugar). */
 export type AgentPlacementTarget = { kind: 'daemon'; daemonId: string } | { kind: 'pool' }
 
 export async function moveAgent(

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -63,6 +63,15 @@ export const CLOUD_DAEMON_LABEL = 'AgentConnect Cloud'
  *  a rollout, which is precisely why the placement stopped carrying one. */
 export const CLOUD_PLACEMENT = 'cloud'
 
+/** What a placement NAMES. The CP stores and emits `set` (daemon-groups.md §2); `pool` stays
+ *  accepted API sugar on the way IN, so the console keeps submitting it and tolerates both. */
+export type PlacementKindValue = 'daemon' | 'set' | 'pool'
+
+/** Is this placement the Cloud entry — a member set rather than one machine? */
+export function isCloudPlacementKind(kind?: PlacementKindValue): boolean {
+  return kind === 'set' || kind === 'pool'
+}
+
 /**
  * The ONE mapping from a DTO's placement pair to the value the console selects on: the pool
  * sentinel, a member id, or null when the agent is unplaced. Every reader of the raw DTO uses it —
@@ -70,8 +79,8 @@ export const CLOUD_PLACEMENT = 'cloud'
  * reloaded. Deriving "is this the pool?" from `daemonId` being null is what made a reloaded pool
  * agent read as unplaced; `placementKind` is the only thing that says it.
  */
-export function placementValueOf(dto: { placementKind?: 'daemon' | 'pool'; daemonId: string | null }): string | null {
-  return dto.placementKind === 'pool' ? CLOUD_PLACEMENT : (dto.daemonId ?? null)
+export function placementValueOf(dto: { placementKind?: PlacementKindValue; daemonId: string | null }): string | null {
+  return isCloudPlacementKind(dto.placementKind) ? CLOUD_PLACEMENT : (dto.daemonId ?? null)
 }
 
 /** The Cloud entry stands in for the whole pool: online while any member is serving. */
@@ -98,7 +107,7 @@ export function effectiveAgentStatus(
     // A pool placement names no member, so there is no owning daemon to consult: the CP already
     // answered "could anything serve this now" and that answer is the whole story (#987 — asking
     // a placed member's liveness is what kept a rolled-over agent permanently offline).
-    if (agent.placementKind === 'pool') return agent.placementReady ? agent.status : 'offline'
+    if (isCloudPlacementKind(agent.placementKind)) return agent.placementReady ? agent.status : 'offline'
     if (agent.daemon === '—') return 'offline'
     if (owningDaemon !== undefined) {
       if (owningDaemon.lifecycleStatus) return owningDaemon.lifecycleStatus
@@ -113,7 +122,7 @@ export function effectiveAgentStatus(
 // configuring it (onboarding's agent step) or creating a user agent flips this true. It
 // is the signal for "the org is set up" — used by the onboarding gate + getting-started.
 export function agentIsPlaced(agent: Pick<Agent, 'daemon' | 'runtime' | 'placementKind'>): boolean {
-  return (agent.placementKind === 'pool' || agent.daemon !== '—') && agent.runtime !== ''
+  return (isCloudPlacementKind(agent.placementKind) || agent.daemon !== '—') && agent.runtime !== ''
 }
 
 export type LaneKind = 'msg' | 'plan' | 'tool' | 'edit' | 'done'
@@ -329,10 +338,10 @@ export interface Agent {
   /** Names of organization-owned secrets assigned to this agent. Values are never
    *  returned for these either. */
   organizationSecretKeys: string[]
-  /** What the placement NAMES. `pool` carries `daemon: CLOUD_PLACEMENT` and no member id.
+  /** What the placement NAMES. A `set` carries `daemon: CLOUD_PLACEMENT` and no member id.
    *  Absent (a mock row, an older CP) reads as `daemon`, which is the pre-pool behavior. */
-  placementKind?: 'daemon' | 'pool'
-  /** Server-computed: can a session start right now? For a pool placement that is "some member is
+  placementKind?: PlacementKindValue
+  /** Server-computed: can a session start right now? For a set placement that is "some member is
    *  live", which is the question the console used to answer with a dead member's liveness. */
   placementReady?: boolean
   daemon: string

--- a/packages/web/src/lib/placement-value.test.ts
+++ b/packages/web/src/lib/placement-value.test.ts
@@ -8,6 +8,15 @@ import { describe, it, expect } from 'vitest'
 import { CLOUD_PLACEMENT, effectiveAgentStatus, agentIsPlaced, placementValueOf } from '@/lib/data'
 import type { Agent, DaemonRow } from '@/lib/data'
 
+const poolAgent = (over: Partial<Agent> = {}): Pick<Agent, 'status' | 'daemon' | 'placementKind' | 'placementReady'> =>
+  ({
+    status: 'online',
+    daemon: CLOUD_PLACEMENT,
+    placementKind: 'pool',
+    placementReady: true,
+    ...over
+  }) as Pick<Agent, 'status' | 'daemon' | 'placementKind' | 'placementReady'>
+
 describe('placementValueOf', () => {
   it('maps a pool placement to the pool sentinel, never to its null member id', () => {
     expect(placementValueOf({ placementKind: 'pool', daemonId: null })).toBe(CLOUD_PLACEMENT)
@@ -17,6 +26,15 @@ describe('placementValueOf', () => {
     expect(placementValueOf({ placementKind: 'pool', daemonId: 'dmn_1' })).toBe(CLOUD_PLACEMENT)
   })
 
+  // What the CP actually STORES and emits now: the pool is one member set (daemon-groups.md §2).
+  // `pool` stays accepted on the way in as API sugar, so both spellings have to read as Cloud.
+  it('maps a set placement to the same Cloud sentinel — that is the console round-trip', () => {
+    expect(placementValueOf({ placementKind: 'set', daemonId: null })).toBe(CLOUD_PLACEMENT)
+    expect(agentIsPlaced({ daemon: CLOUD_PLACEMENT, runtime: 'claude', placementKind: 'set' })).toBe(true)
+    expect(effectiveAgentStatus(poolAgent({ placementKind: 'set' }), undefined)).toBe('online')
+    expect(effectiveAgentStatus(poolAgent({ placementKind: 'set', placementReady: false }), undefined)).toBe('offline')
+  })
+
   it('maps a machine placement to its member id, and an unplaced agent to null', () => {
     expect(placementValueOf({ placementKind: 'daemon', daemonId: 'dmn_1' })).toBe('dmn_1')
     expect(placementValueOf({ placementKind: 'daemon', daemonId: null })).toBeNull()
@@ -24,15 +42,6 @@ describe('placementValueOf', () => {
     expect(placementValueOf({ daemonId: 'dmn_1' })).toBe('dmn_1')
   })
 })
-
-const poolAgent = (over: Partial<Agent> = {}): Pick<Agent, 'status' | 'daemon' | 'placementKind' | 'placementReady'> =>
-  ({
-    status: 'online',
-    daemon: CLOUD_PLACEMENT,
-    placementKind: 'pool',
-    placementReady: true,
-    ...over
-  }) as Pick<Agent, 'status' | 'daemon' | 'placementKind' | 'placementReady'>
 
 describe('a pool agent’s readiness is the server’s answer, not a member’s liveness', () => {
   it('stays online while the pool is ready, with no owning daemon to consult', () => {


### PR DESCRIPTION
**Zero behaviour change; every #991 test passes with its assertions unchanged.** PR 1 of
[`docs/designs/daemon-groups.md`](https://github.com/agentconnect-md/agentconnect/blob/main/docs/designs/daemon-groups.md)
(§2 model, §3 predicate, §6 "PR 1", §8 migration). The install-wide pool stops being a
`placementKind` value and becomes one row of a new `member_set` table — which is the proof
that the pool was a set all along. Refs #955.

## The model

- **`member_set(id, orgId, name)`** — `orgId` is nullable and **NULL means cross-org**, never
  "unassigned": an org-less set is served by org-less daemons and holds every organization's
  agents. The pool is that row, and a partial unique index keeps it to one per install.
- **`member_set_member(setId, daemonId)`** — the daemon is the primary key, so a daemon is in
  at most one set. `ON DELETE CASCADE` from `daemon`, so retiring a member's row removes its
  membership with it and a dead Pod is never eligible.
- **`Agent.placementKind ∈ {daemon, set}`** with `Agent.setId` as the `set` ref, nullable
  exactly as `daemonId` is nullable for a `set` placement. `pool` is gone as a stored value.

**Three write-time invariants**, each enforced in the transaction that writes the row and
never re-checked on read — this is what lets eligibility be one membership lookup with no
tenancy branch:

1. an org-less set accepts only org-less daemons (`enrollDaemonInSet`);
2. an org set accepts only that org's daemons (same writer);
3. a `set`-placed agent may reference only the org-less set or a set of its own org
   (`assertAgentMayUseSet`, taken by create, `setPlacement`, and the placement CAS).

Only the org-less set exists after this PR, but (2) and (3) land now because they are the
argument for §3's single-arm predicate being sound.

**The resolver.** `dutyEligibility` returns `{scope:'daemon'|'set'|'none'}`; `mayHold` for a
set is `claimant.setId === agent.setId`; `claimScopeOf` reads the daemon's membership. The
SQL mirror in the ledger is one join to `member_set_member` on `(agent.setId, holder)` — no
`CASE` beyond `daemon` vs `set`. Nothing outside `domain/placement.ts` branches on the kind.

**Automatic pool enrolment.** `upsertOnAuth` enrols an org-less row in the org-less set in
the same transaction that mints or refreshes it, and never enrols an org-scoped row — the
set of an org-scoped daemon is an operator decision (PR 2).

**API sugar.** `{ placementKind: 'pool' }` stays accepted on create and move; the route
resolves it to the org-less set at the edge and stores `set`. `{ placementKind: 'set', setId }`
is accepted too. Responses now carry `set` + `setId`, and the console maps both spellings to
its Cloud entry, so Cloud still submits, still stores, and still reads back as Cloud (#993's
readiness guard for the Cloud sentinel is untouched).

## Rollout — this is a coordinated cutover, not a rolling deploy

Old control-plane code does not understand a stored `set` placement, and new code cannot
resolve eligibility before `member_set` exists. **The migration and the code that reads it
must not straddle a rolling deploy**, which is exactly why the migration ships in the same PR
as the code rather than split across two. Deploy it as a coordinated cutover with the control
plane briefly down — this is a pre-release project with a single control-plane replica per
environment, so that is the honest, cheap answer (daemon-groups.md §8 "Rollout ordering").
The migration itself is safe under load: eligibility is re-read from current placement on
every claim, and a claim in flight across it sees either "pool agent, install-wide claimant"
or "set agent, claimant in the org-less set" — the same answer. It touches no ledger row.

The daemon needs nothing here: it still learns "you are install-wide" from `auth/ok`. PR 2
turns that into "you are in set S", opens the three duty handlers' `SCOPE_DENIED` door, and
adds console CRUD for org sets.

## Tests

New, all mutation-checked:

| # | Mutation | Caught by |
|---|---|---|
| M1 | drop the membership tenancy check entirely | refuses an org-scoped daemon in the org-less set; refuses an org-less daemon in an org set |
| M2 | let the org-less set accept any daemon | refuses an org-scoped daemon in the org-less set |
| M3 | auto-enrol every daemon on auth, not only org-less ones | enrols an org-less row in the pool on auth, and never an org-scoped one |
| M4 | drop the agent→set invariant on create | refuses a create pointed at another org's set |
| M5 | drop the agent→set invariant on `setPlacement` | refuses a move onto another org's set |
| M6 | drop the agent→set invariant on the placement CAS | fences the compare-and-set move onto another org's set |
| M7 | make every holder eligible for a `set` placement | is claimable by the pool's members and by nobody else |
| M8 | membership FK `RESTRICT` instead of `CASCADE` | drops the membership with the daemon row a reaper retires |

Plus: a migrated pool row resolves to `set` + the org-less id and is eligible for exactly the
same claimants as before (and flipping it onto a machine flips both answers through the same
one predicate); `{kind:'pool'}` sugar stores `set` on both create and move; the console
round-trip (`placementValueOf({placementKind:'set'})` → Cloud).

### What changed in existing tests, and why

No assertion about behaviour changed. Two mechanical classes of edit were unavoidable, and
both follow from the same deliberate improvement — **the ledger now READS the claimant's
scope from its own tables instead of trusting a `scope: 'install-wide'` string the caller
asserts**:

1. `claimVacant` / `claimAgentHome` no longer take a claim-scope argument, so the argument is
   dropped at ~40 call sites. Nothing else about those calls or their expectations moved.
2. A test whose claimant is a pool member now has to *be* one: an org-less `daemon` row plus
   its `member_set_member` row, which is what `upsertOnAuth` writes in production. That is a
   seeding change in five fixtures/helpers, not an assertion change. (The WS harness's cloud
   daemons are deliberately **not** seeded with a membership row — they get theirs by
   authenticating, which exercises the auto-enrolment path end to end.)

Rebasing onto #996 and #1004 brought four more `placementKind: 'pool'` seeds (the
organization-knowledge, suggestion-sync, and knowledge-reads tests) plus one unit-level
`poolAgent` helper; they became `set` + the org-less set id, with no assertion touched.

Three DTO assertions in the move-route suite now read `placementKind: 'set'` (+ `setId`)
where they read `'pool'`: the request payloads still submit the `pool` sugar, and the
responses are what changed representation. `test/setup.db.ts` restores the pool row after
each truncate, because `TRUNCATE … CASCADE` reaches `member_set` through its `org` FK even
though the pool row is org-less.

## Gates

`prisma:generate`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, protocol tests
(331), CP `test:unit` (1644), CP `test:int` (87 files / 1285), web tests (1540) — all green.
Daemon tests are byte-identical to `main` (zero files changed in that package) and fail only
the known baseline: `shim-*`, `workspace-git-runner-seam`, and the live `acp-matrix`.
