### PR TITLE
fix(knowledge): authorize organization reads through the serving member

### DIFF
--- a/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
@@ -611,6 +611,141 @@ describe('handleManagedSkillRead', () => {
   })
 })
 
+// #999: the four organization READS on an install-wide member. A pool agent names no machine, so
+// `agent.daemonId` refuses every read from the very member that runs it.
+describe('organization reads follow the serving member', () => {
+  const knowledgeRow = {
+    id: '11111111-1111-4111-8111-111111111111',
+    title: 'Runbook',
+    summary: null,
+    tags: ['runbook'],
+    currentRevision: 1,
+    updatedAt: new Date('2026-08-01T00:00:00.000Z'),
+    content: 'body'
+  }
+
+  /** A pool row with one managed skill enabled — the shape every read below asks about. */
+  const poolRequester = (orgId = ORG_A) => ({ ...poolAgent(AGENT), orgId, managedSkills: [SKILL] })
+  const machineRequester = () => ({
+    id: AGENT,
+    placementKind: 'daemon' as const,
+    daemonId: DAEMON,
+    orgId: ORG_A,
+    managedSkills: [SKILL]
+  })
+
+  function knowledgeRepo() {
+    return {
+      searchKnowledge: vi.fn(async () => [knowledgeRow]),
+      listKnowledge: vi.fn(async () => [knowledgeRow]),
+      listManagedSkills: vi.fn(async () => [
+        {
+          id: SKILL,
+          orgId: ORG_A,
+          name: 'release-service',
+          description: 'Release with rollback',
+          currentRevision: 1,
+          updatedAt: new Date('2026-08-01T00:00:00.000Z')
+        }
+      ]),
+      getManagedSkill: vi.fn(async () => ({ id: SKILL, orgId: ORG_A, archivedAt: null })),
+      getManagedSkillRevision: vi.fn(async () => ({
+        managedSkillId: SKILL,
+        revision: 1,
+        archive: new Uint8Array([1, 2, 3, 4]),
+        digest: `sha256:${'b'.repeat(64)}`
+      }))
+    }
+  }
+
+  const reads = [
+    {
+      type: 'knowledge/search' as const,
+      ok: 'knowledge/search/ok',
+      payload: { query: 'runbook', limit: 5, maxBytes: 1024 },
+      probe: 'searchKnowledge' as const,
+      handler: handleKnowledgeSearch
+    },
+    {
+      type: 'knowledge/list' as const,
+      ok: 'knowledge/list/ok',
+      payload: { limit: 5, maxBytes: 1024 },
+      probe: 'listKnowledge' as const,
+      handler: handleKnowledgeList
+    },
+    {
+      type: 'skills/org' as const,
+      ok: 'skills/org/ok',
+      payload: { limit: 5 },
+      probe: 'listManagedSkills' as const,
+      handler: handleOrgSkills
+    },
+    {
+      type: 'managed-skill/read' as const,
+      ok: 'managed-skill/chunk',
+      payload: { managedSkillId: SKILL, revision: 1, offset: 0, limit: 1024 },
+      probe: 'getManagedSkillRevision' as const,
+      handler: handleManagedSkillRead
+    }
+  ]
+
+  async function read(
+    spec: (typeof reads)[number],
+    requester: Record<string, unknown>,
+    holds: Record<string, string[]>
+  ) {
+    const organizationKnowledge = knowledgeRepo()
+    const deps = {
+      // An install-wide member: org-less, so the frame is the only thing that names an org.
+      registry: { getUnscoped: async () => ({ id: DAEMON, orgId: null, capabilities: installWideCapabilities }) },
+      agent: { getUnscoped: async () => requester },
+      placementResolver: holderOf(holds),
+      organizationKnowledge
+    } as unknown as DaemonWsDeps
+    const connection = conn()
+    await spec.handler(
+      { ...frame(spec.type, { requesterAgentId: AGENT, ...spec.payload }), orgId: ORG_A },
+      connection,
+      deps
+    )
+    return { connection, organizationKnowledge }
+  }
+
+  for (const spec of reads) {
+    it(`serves ${spec.type} for a pool agent whose duty this member holds`, async () => {
+      const { connection, organizationKnowledge } = await read(spec, poolRequester(), { [AGENT]: [DAEMON] })
+
+      expect(connection.sendError).not.toHaveBeenCalled()
+      expect(connection.replyTo.mock.calls[0]![1]).toBe(spec.ok)
+      expect(organizationKnowledge[spec.probe]).toHaveBeenCalled()
+    })
+
+    it(`refuses ${spec.type} for a pool agent another member holds`, async () => {
+      const { connection, organizationKnowledge } = await read(spec, poolRequester(), { [AGENT]: ['another-member'] })
+
+      expect(connection.replyTo).not.toHaveBeenCalled()
+      expect(connection.sendError.mock.calls[0]![1]).toBe('SCOPE_DENIED')
+      expect(organizationKnowledge[spec.probe]).not.toHaveBeenCalled()
+    })
+
+    it(`still serves ${spec.type} for an agent placed on this daemon`, async () => {
+      const { connection, organizationKnowledge } = await read(spec, machineRequester(), {})
+
+      expect(connection.sendError).not.toHaveBeenCalled()
+      expect(connection.replyTo.mock.calls[0]![1]).toBe(spec.ok)
+      expect(organizationKnowledge[spec.probe]).toHaveBeenCalled()
+    })
+  }
+
+  it('refuses a read whose requester belongs to another organization', async () => {
+    // Serving an agent is not standing in its org: the frame names ORG_A, the requester is in ORG_B.
+    const { connection, organizationKnowledge } = await read(reads[0]!, poolRequester(ORG_B), { [AGENT]: [DAEMON] })
+
+    expect(connection.sendError.mock.calls[0]![1]).toBe('SCOPE_DENIED')
+    expect(organizationKnowledge.searchKnowledge).not.toHaveBeenCalled()
+  })
+})
+
 function randomUuid(): string {
   return crypto.randomUUID()
 }

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.ts
@@ -31,19 +31,38 @@ function clampUtf8(text: string, maxBytes: number): { content: string; truncated
   return { content, truncated: true, bytes: Buffer.byteLength(content) }
 }
 
-/** On-demand search. Organization membership is derived from the placed
+/** The requester an organization read may be served for: in the frame's org, and served by this
+ *  connection right now. Authority is the live seam — placement PLUS the duty leases this member
+ *  holds — because a pool agent names no machine and `agent.daemonId` would refuse every read from
+ *  the very member running it. */
+async function servingRequester(
+  requesterAgentId: string,
+  frameOrgId: string | undefined,
+  daemon: DaemonView,
+  conn: Parameters<Handler>[1],
+  deps: Parameters<Handler>[2]
+) {
+  const requester = await deps.agent.getUnscoped(AgentId(requesterAgentId))
+  const orgId = frameOrgId ? OrgId(frameOrgId) : daemon.orgId
+  if (!requester || !orgId || requester.orgId !== orgId) return null
+  const resolver = deps.placementResolver ?? PLACEMENT_ONLY
+  return (await resolver.mayAct(requester, conn.daemonId)) ? requester : null
+}
+
+/** On-demand search. Organization membership is derived from the served
  * requester, never from daemon-supplied org input. */
 export const handleKnowledgeSearch: Handler = async (frame, conn, deps) => {
   if (!isFrame('knowledge/search')(frame)) return
-  if (!(await featureDaemon(frame.id, conn, deps))) return
+  const daemon = await featureDaemon(frame.id, conn, deps)
+  if (!daemon) return
   const repo = deps.organizationKnowledge
   if (!repo) {
     conn.sendError(frame.id, 'INTERNAL', 'organization knowledge is unavailable', true)
     return
   }
-  const requester = await deps.agent.getUnscoped(AgentId(frame.payload.requesterAgentId))
-  if (!requester || requester.daemonId !== DaemonId(conn.daemonId)) {
-    conn.sendError(frame.id, 'SCOPE_DENIED', 'requesting agent is not placed on this daemon', false)
+  const requester = await servingRequester(frame.payload.requesterAgentId, frame.orgId, daemon, conn, deps)
+  if (!requester) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'requesting agent is not served by this daemon', false)
     return
   }
 
@@ -74,18 +93,19 @@ export const handleKnowledgeSearch: Handler = async (frame, conn, deps) => {
 
 /** List recent org knowledge (query-less) the requester's org can see — the
  * browse companion to search, so a dreamer can enumerate what already exists
- * before proposing new. Org scope comes from the placed requester. */
+ * before proposing new. Org scope comes from the served requester. */
 export const handleKnowledgeList: Handler = async (frame, conn, deps) => {
   if (!isFrame('knowledge/list')(frame)) return
-  if (!(await featureDaemon(frame.id, conn, deps))) return
+  const daemon = await featureDaemon(frame.id, conn, deps)
+  if (!daemon) return
   const repo = deps.organizationKnowledge
   if (!repo) {
     conn.sendError(frame.id, 'INTERNAL', 'organization knowledge is unavailable', true)
     return
   }
-  const requester = await deps.agent.getUnscoped(AgentId(frame.payload.requesterAgentId))
-  if (!requester || requester.daemonId !== DaemonId(conn.daemonId)) {
-    conn.sendError(frame.id, 'SCOPE_DENIED', 'requesting agent is not placed on this daemon', false)
+  const requester = await servingRequester(frame.payload.requesterAgentId, frame.orgId, daemon, conn, deps)
+  if (!requester) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'requesting agent is not served by this daemon', false)
     return
   }
   const tags = frame.payload.tags
@@ -117,15 +137,16 @@ export const handleKnowledgeList: Handler = async (frame, conn, deps) => {
  * update-vs-create. `query` filters by name/description; absent ⇒ list. */
 export const handleOrgSkills: Handler = async (frame, conn, deps) => {
   if (!isFrame('skills/org')(frame)) return
-  if (!(await featureDaemon(frame.id, conn, deps))) return
+  const daemon = await featureDaemon(frame.id, conn, deps)
+  if (!daemon) return
   const repo = deps.organizationKnowledge
   if (!repo) {
     conn.sendError(frame.id, 'INTERNAL', 'organization skills are unavailable', true)
     return
   }
-  const requester = await deps.agent.getUnscoped(AgentId(frame.payload.requesterAgentId))
-  if (!requester || requester.daemonId !== DaemonId(conn.daemonId)) {
-    conn.sendError(frame.id, 'SCOPE_DENIED', 'requesting agent is not placed on this daemon', false)
+  const requester = await servingRequester(frame.payload.requesterAgentId, frame.orgId, daemon, conn, deps)
+  if (!requester) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'requesting agent is not served by this daemon', false)
     return
   }
   const q = frame.payload.query?.toLowerCase()
@@ -194,24 +215,21 @@ export const handleOrganizationSuggestionsSync: Handler = async (frame, conn, de
  * the managed skill enabled. */
 export const handleManagedSkillRead: Handler = async (frame, conn, deps) => {
   if (!isFrame('managed-skill/read')(frame)) return
-  if (!(await featureDaemon(frame.id, conn, deps))) return
+  const daemon = await featureDaemon(frame.id, conn, deps)
+  if (!daemon) return
   const repo = deps.organizationKnowledge
   if (!repo) {
     conn.sendError(frame.id, 'INTERNAL', 'managed skills are unavailable', true)
     return
   }
-  const requester = await deps.agent.getUnscoped(AgentId(frame.payload.requesterAgentId))
-  if (
-    !requester ||
-    requester.daemonId !== DaemonId(conn.daemonId) ||
-    !requester.managedSkills.includes(frame.payload.managedSkillId)
-  ) {
+  const requester = await servingRequester(frame.payload.requesterAgentId, frame.orgId, daemon, conn, deps)
+  if (!requester || !requester.managedSkills.includes(frame.payload.managedSkillId)) {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'managed skill is not enabled for this agent', false)
     return
   }
-  // The managed-skill id comes from the daemon's frame, so it is fenced on the
-  // REQUESTER's org — the one thing this handler has already proved (the agent is
-  // placed on this connection). The revision fences through that parent (§3.6).
+  // The managed-skill id comes from the daemon's frame, so it is fenced on the REQUESTER's org —
+  // the one thing this handler has already proved (this connection serves the agent). The revision
+  // fences through that parent (§3.6).
   const skill = await repo.getManagedSkill(requester.orgId, frame.payload.managedSkillId)
   const revision = await repo.getManagedSkillRevision(frame.payload.managedSkillId, frame.payload.revision)
   if (!skill || skill.archivedAt !== null || !revision) {

--- a/packages/control-plane/test/protocol/organization-knowledge-reads.handler.test.ts
+++ b/packages/control-plane/test/protocol/organization-knowledge-reads.handler.test.ts
@@ -1,0 +1,206 @@
+// The four organization READS a dreaming agent issues (#999). Authority is the LIVE seam —
+// placement plus the duty leases this member holds — never `agent.daemonId`, which a pool agent
+// leaves null, so an install-wide member was refused every read for the agents it actually runs.
+import { randomUUID } from 'node:crypto'
+import { describe, it, expect } from 'vitest'
+import {
+  isFrame,
+  ORGANIZATION_KNOWLEDGE_FEATURE,
+  ORGANIZATION_SUGGESTION_REVIEW_FEATURE
+} from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { buildWsHarness } from '../fakes/build-ws.js'
+import type { InMemoryDaemonStub } from '../fakes/daemon-stub.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const DAEMON = 'd3333333-3333-4333-8333-333333333333'
+const OTHER = 'd4444444-4444-4444-8444-444444444444'
+const AUTH_ID = '99999999-9999-4999-8999-999999999999'
+const REG_ID = '88888888-8888-4888-8888-888888888888'
+
+/** A pool agent: placed, but naming no machine. Only the ledger can say who serves it. */
+async function seedPoolAgent(managedSkills: string[]): Promise<string> {
+  const id = randomUUID()
+  await prisma.agent.create({
+    data: {
+      id,
+      orgId: DEFAULT_ORG_ID,
+      name: `dreamer-${id.slice(0, 8)}`,
+      runtime: 'claude',
+      placementKind: 'pool',
+      managedSkills
+    }
+  })
+  return id
+}
+
+async function seedLease(holder: string, agentId: string, expiresAt: Date): Promise<void> {
+  const groupId = randomUUID()
+  await prisma.dutyGroup.create({ data: { id: groupId, orgId: DEFAULT_ORG_ID, holder, term: 1n, expiresAt } })
+  await prisma.dutyGroupMember.create({ data: { kind: 'agent', refId: agentId, groupId, orgId: DEFAULT_ORG_ID } })
+}
+
+async function seedKnowledge(): Promise<string> {
+  const id = randomUUID()
+  await prisma.organizationKnowledge.create({
+    data: {
+      id,
+      orgId: DEFAULT_ORG_ID,
+      title: 'Pool runbook',
+      revisions: {
+        create: {
+          revision: 1,
+          content: 'drain the member before the upgrade',
+          tags: ['runbook'],
+          digest: `sha256:${'c'.repeat(64)}`,
+          source: 'manual'
+        }
+      }
+    }
+  })
+  return id
+}
+
+async function seedManagedSkill(): Promise<string> {
+  const id = randomUUID()
+  await prisma.managedSkill.create({
+    data: {
+      id,
+      orgId: DEFAULT_ORG_ID,
+      name: `release-${id.slice(0, 8)}`,
+      description: 'Release with rollback',
+      revisions: {
+        create: {
+          revision: 1,
+          archive: Buffer.from([1, 2, 3, 4]),
+          digest: `sha256:${'d'.repeat(64)}`,
+          compressedBytes: 4,
+          expandedBytes: 4,
+          fileCount: 1,
+          manifest: {},
+          source: 'manual'
+        }
+      }
+    }
+  })
+  return id
+}
+
+/** An install-wide (frame-mode) member advertising the organization-knowledge surface. */
+async function readyMember(h: ReturnType<typeof buildWsHarness>) {
+  const { stub } = h.connect()
+  const saToken = await h.mintCloudDaemon(DAEMON)
+  stub.inject('auth', { serviceAccountToken: saToken, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
+  await stub.expectFrame('auth/ok')
+  stub.inject(
+    'register',
+    {
+      host: 'member-1',
+      capabilities: {
+        platforms: [],
+        runtimes: ['claude'],
+        acp: true,
+        features: [ORGANIZATION_KNOWLEDGE_FEATURE, ORGANIZATION_SUGGESTION_REVIEW_FEATURE]
+      },
+      maxAgents: 8,
+      localState: { assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }
+    },
+    { id: REG_ID }
+  )
+  await stub.expectFrame('register/ok')
+  return stub
+}
+
+/** The reply correlated to one request — `expectFrame` cannot tell four refusals apart. */
+async function settle(stub: InMemoryDaemonStub, id: string) {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const reply = stub.sent.find((f) => f.corr === id)
+    if (reply) return reply
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  throw new Error(`no reply correlated to ${id}`)
+}
+
+/** Every read a dreaming agent makes, with the reply each must produce. */
+function reads(requesterAgentId: string, managedSkillId: string) {
+  return [
+    {
+      type: 'knowledge/search' as const,
+      ok: 'knowledge/search/ok',
+      payload: { requesterAgentId, query: 'runbook', limit: 5, maxBytes: 4096 }
+    },
+    {
+      type: 'knowledge/list' as const,
+      ok: 'knowledge/list/ok',
+      payload: { requesterAgentId, limit: 5, maxBytes: 4096 }
+    },
+    { type: 'skills/org' as const, ok: 'skills/org/ok', payload: { requesterAgentId, limit: 5 } },
+    {
+      type: 'managed-skill/read' as const,
+      ok: 'managed-skill/chunk',
+      payload: { requesterAgentId, managedSkillId, revision: 1, offset: 0, limit: 1024 }
+    }
+  ]
+}
+
+describe('organization reads from an install-wide member', () => {
+  it('serves every read for a pool agent whose duty this member holds', async () => {
+    const h = buildWsHarness(prisma)
+    await seedKnowledge()
+    const skillId = await seedManagedSkill()
+    const agentId = await seedPoolAgent([skillId])
+    await seedLease(DAEMON, agentId, new Date(h.clock.now() + 120_000))
+    const stub = await readyMember(h)
+
+    for (const read of reads(agentId, skillId)) {
+      const reply = await settle(stub, stub.inject(read.type, read.payload, { orgId: DEFAULT_ORG_ID }))
+      expect({ read: read.type, reply: reply.type }).toEqual({ read: read.type, reply: read.ok })
+    }
+
+    expect(stub.sent.find((f) => isFrame('error')(f))).toBeUndefined()
+    // Not an empty success: the org's own rows came back through the requester's tenancy.
+    const search = stub.lastSent('knowledge/search/ok')!.payload as { items: { title: string }[] }
+    expect(search.items.map((item) => item.title)).toEqual(['Pool runbook'])
+    const skills = stub.lastSent('skills/org/ok')!.payload as { items: { id: string }[] }
+    expect(skills.items.map((item) => item.id)).toEqual([skillId])
+  })
+
+  it('refuses every read for a pool agent whose duty another member holds', async () => {
+    const h = buildWsHarness(prisma)
+    await seedKnowledge()
+    const skillId = await seedManagedSkill()
+    const agentId = await seedPoolAgent([skillId])
+    await prisma.daemon.create({ data: { id: OTHER, orgId: null, maxAgents: 8, status: 'ready' } })
+    await seedLease(OTHER, agentId, new Date(h.clock.now() + 120_000))
+    const stub = await readyMember(h)
+
+    for (const read of reads(agentId, skillId)) {
+      const reply = await settle(stub, stub.inject(read.type, read.payload, { orgId: DEFAULT_ORG_ID }))
+      if (!isFrame('error')(reply)) throw new Error(`expected an error frame for ${read.type}`)
+      expect({ read: read.type, code: reply.payload.code }).toEqual({ read: read.type, code: 'SCOPE_DENIED' })
+    }
+  })
+
+  it('still serves every read for a machine-placed agent this member is the placement of', async () => {
+    const h = buildWsHarness(prisma)
+    await seedKnowledge()
+    const skillId = await seedManagedSkill()
+    const stub = await readyMember(h)
+    const agentId = randomUUID()
+    await prisma.agent.create({
+      data: {
+        id: agentId,
+        orgId: DEFAULT_ORG_ID,
+        name: 'pinned-dreamer',
+        runtime: 'claude',
+        daemonId: DAEMON,
+        managedSkills: [skillId]
+      }
+    })
+
+    for (const read of reads(agentId, skillId)) {
+      const reply = await settle(stub, stub.inject(read.type, read.payload, { orgId: DEFAULT_ORG_ID }))
+      expect({ read: read.type, reply: reply.type }).toEqual({ read: read.type, reply: read.ok })
+    }
+  })
+})


### PR DESCRIPTION
The four organization read handlers — `knowledge/search`, `knowledge/list`, `skills/org`, `managed-skill/read` — authorized the requesting agent with `agent.daemonId === conn.daemonId`. A pool agent names no machine, so on an install-wide member that comparison never holds and every read was refused: an agent the pool actually runs could not search or list organization knowledge, nor download the managed skills it has enabled. A dreaming agent on the pool was blind to its own org.

## The fix

Authority is now the seam #996 gave the sync handler and the review path: placement plus the duty leases this member currently holds, read through `PlacementResolver.mayAct` (`deps.placementResolver ?? PLACEMENT_ONLY`). One helper answers "may this connection be served for that requester", and all four handlers go through it, so `git grep daemonId` over the file finds only `conn.daemonId` — no handler compares an agent's placement column to the connection any more. That is also what makes the change immune to the pending `pool` → `set` + `setId` rename: nothing here reads the placement kind.

The org fence the old comparison implied is now explicit rather than incidental. A machine placement guaranteed same-org by construction; a duty holder does not, so the requester must be in the org the frame names (or the connection's own org) before it is served. That keeps an org-scoped connection from reading a second org's knowledge through a lease.

## Tests

- **Unit** (`src/ws/handlers/organization-knowledge.test.ts`, +13): for each of the four reads — a pool-placed agent (`placementKind: 'pool'`, `daemonId: null`) whose duty this member holds is served; the same agent when another member holds the lease is refused `SCOPE_DENIED` before the repo is touched; a `daemon`-placed agent on this connection is still served (regression). Plus one org-fence case: a requester in another org is refused even when this member holds its duty.
- **WS protocol** (`test/protocol/organization-knowledge-reads.handler.test.ts`, new): the same three shapes driven end to end over the real duty ledger — a real pool row, a real `DutyGroup` lease, seeded org knowledge and a seeded managed skill — asserting the replies carry the org's own rows rather than an empty success.

### Mutation

| Mutation | Result |
| --- | --- |
| `servingRequester` back to `requester.daemonId === DaemonId(conn.daemonId)` | unit: 4 failed / 25 passed — exactly the four "pool agent whose duty this member holds" cases; protocol: 1 failed / 2 passed — "serves every read for a pool agent whose duty this member holds" |
| drop `requester.orgId !== orgId` from the org fence | unit: 1 failed / 28 passed — "refuses a read whose requester belongs to another organization" |

Both mutations were reverted; every negative and every machine-placement regression stayed green under both, so the new tests fail for the defect and not for the shape of the code.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm --filter @agentconnect.md/control-plane test:unit` (1657 passed) all green. `test:int`: 1275 passed, 1 failure in `test/protocol/duty-lease.handler.test.ts` — unrelated to this diff and green on its own (`49 passed`), the same parallel-load flake family as `rewrap.test.ts`.

Closes #999
