### PR TITLE
fix(daemon): sync sandbox image on resume

### DIFF
--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -228,11 +228,18 @@ CLI helper and differs only in which socket it dials.
 
 ## 7. Runtime-image rollout ownership
 
-The retired per-org operator was the sole producer of `agentconnect.md/drain-requested`.
-Consequently the daemon no longer watches every Sandbox for that orphaned annotation. Pool-member
-rollout is owned by the daemon Deployment and duty-release flow; agent compute migrates through the
-ordinary idle suspension path described below. Work holds its Sandbox only to prevent that idle
-sweep from suspending the pod during a bind, workspace preparation, runtime, or runtime probe.
+The daemon does not force a running agent onto a new runtime image. Agent compute migrates through
+the ordinary idle suspension path described below: when a later launch finds its Sandbox Suspended,
+the daemon resolves its configured SandboxWarmPool and SandboxTemplate, then atomically patches the
+persisted Sandbox's `runtime` container image and `operatingMode: Running`. The name and observed
+image are JSON Patch preconditions, so a concurrent container reorder or image edit rejects the
+whole wake instead of changing a sidecar or starting an unverified image.
+
+This is a resume-time update, not a proactive rollout. A Sandbox already Running keeps serving its
+current image until it naturally becomes idle, and a template edit racing the daemon's fresh read is
+picked up by a later resume. The SandboxClaim, Sandbox UID, immutable volumeClaimTemplates, and
+workspace PVC all survive; only the pod incarnation changes. The daemon Role therefore reads the
+configured `sandboxwarmpools` and `sandboxtemplates` but still never reads or writes Pods directly.
 
 ## 8. The lifecycle of an idle agent: suspend, resume, discard
 

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -7,6 +7,7 @@ import { ShimRequestTimeoutError } from '../shim/channels.js'
 import { ShimSession } from '../shim/session.js'
 import type { SpawnRecord } from '../shim/binding.js'
 import {
+  GuardedResumeRejectedError,
   OperatingModeRejectedError,
   isSandboxReady,
   type OperatingMode,
@@ -314,25 +315,81 @@ export class K8sDriver implements SpawnDriver {
     // The mode observed on the FIRST read, before this call changed anything. A later attempt
     // sees the state we produced, which would say nothing about where the launch started.
     let first: OperatingMode | undefined
+    let lastRejection: GuardedResumeRejectedError | OperatingModeRejectedError | undefined
     for (let attempt = 1; attempt <= MAX_MODE_ATTEMPTS; attempt += 1) {
       const sandbox = await this.deps.api.getSandbox(sandboxName)
       const observed = sandbox.spec?.operatingMode ?? 'Running'
       if (observed === desired) return first ?? observed
       first ??= observed
       try {
-        await this.deps.api.setOperatingMode(sandboxName, desired, observed)
-        this.deps.log.info(`cluster: sandbox ${sandboxName} → ${desired}`)
+        if (desired === 'Running' && observed === 'Suspended') {
+          const image = await this.resolveResumeImage(sandboxName, sandbox)
+          await this.deps.api.resumeWithRuntimeImage(sandboxName, image)
+          if (image.observedImage === image.targetImage) {
+            this.deps.log.info(`cluster: sandbox ${sandboxName} → Running`)
+          } else {
+            this.deps.log.info(
+              `cluster: sandbox ${sandboxName} runtime image ${image.observedImage} → ${image.targetImage}; resumed`
+            )
+          }
+        } else {
+          await this.deps.api.setOperatingMode(sandboxName, desired, observed)
+          this.deps.log.info(`cluster: sandbox ${sandboxName} → ${desired}`)
+        }
         return first
       } catch (err) {
-        if (!(err instanceof OperatingModeRejectedError)) throw err
+        if (!(err instanceof OperatingModeRejectedError) && !(err instanceof GuardedResumeRejectedError)) throw err
+        lastRejection = err
         this.metrics.writeRetry('rejected_precondition')
         this.deps.log.debug?.(`cluster: ${desired} write for ${sandboxName} rejected (attempt ${attempt}) — re-reading`)
       }
     }
+    if (lastRejection instanceof GuardedResumeRejectedError) {
+      throw new Error(
+        `sandbox ${sandboxName} guarded mode/image resume was rejected after ${MAX_MODE_ATTEMPTS} attempts`,
+        { cause: lastRejection.cause }
+      )
+    }
     throw new Error(
       `sandbox ${sandboxName} would not accept ${desired} after ${MAX_MODE_ATTEMPTS} attempts — ` +
-        `something else is changing its mode`
+        `the guarded mode write was repeatedly rejected`,
+      { cause: lastRejection?.cause }
     )
+  }
+
+  private async resolveResumeImage(
+    sandboxName: string,
+    sandbox: Sandbox
+  ): Promise<{ containerIndex: number; observedName: string; observedImage: string; targetImage: string }> {
+    const pool = await this.deps.api.getWarmPool(this.deps.warmPoolName)
+    const templateName = pool.spec?.sandboxTemplateRef?.name
+    if (!templateName?.trim()) {
+      throw new Error(`sandbox warm pool ${this.deps.warmPoolName} has no sandboxTemplateRef.name`)
+    }
+    if (templateName.trim() !== templateName) {
+      throw new Error(`sandbox warm pool ${this.deps.warmPoolName} has invalid sandboxTemplateRef.name`)
+    }
+    const template = await this.deps.api.getSandboxTemplate(templateName)
+    const targetContainers = (template.spec?.podTemplate?.spec?.containers ?? []).filter(
+      (container) => container.name === 'runtime'
+    )
+    if (targetContainers.length > 1) throw new Error(`sandbox template ${templateName} has multiple runtime containers`)
+    const targetImage = targetContainers[0]?.image
+    if (!targetImage?.trim()) throw new Error(`sandbox template ${templateName} runtime container has no image`)
+    if (targetImage.trim() !== targetImage) {
+      throw new Error(`sandbox template ${templateName} runtime container has invalid image`)
+    }
+    const containers = sandbox.spec?.podTemplate?.spec?.containers ?? []
+    const containerIndexes = containers.flatMap((container, index) => (container.name === 'runtime' ? [index] : []))
+    if (containerIndexes.length === 0) throw new Error(`sandbox ${sandboxName} has no runtime container`)
+    if (containerIndexes.length > 1) throw new Error(`sandbox ${sandboxName} has multiple runtime containers`)
+    const containerIndex = containerIndexes[0]!
+    const observedImage = containers[containerIndex]?.image
+    if (!observedImage?.trim()) throw new Error(`sandbox ${sandboxName} runtime container has no image`)
+    if (observedImage.trim() !== observedImage) {
+      throw new Error(`sandbox ${sandboxName} runtime container has invalid image`)
+    }
+    return { containerIndex, observedName: 'runtime', observedImage, targetImage }
   }
 
   private forgetSandbox(name: string): void {

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -6,8 +6,17 @@ export const SANDBOX_EXTENSIONS_GROUP = 'extensions.agents.x-k8s.io/v1beta1'
 
 export type OperatingMode = 'Running' | 'Suspended'
 
+interface SandboxContainer {
+  name?: string
+  image?: string
+}
+
+interface SandboxPodTemplate {
+  spec?: { containers?: SandboxContainer[] }
+}
+
 export interface Sandbox extends K8sObject {
-  spec?: { operatingMode?: OperatingMode; podTemplate?: unknown }
+  spec?: { operatingMode?: OperatingMode; podTemplate?: SandboxPodTemplate }
   status?: {
     conditions?: Array<{ type?: string; status?: string }>
     podIPs?: Array<string | { ip?: string }>
@@ -21,6 +30,14 @@ export interface SandboxClaim extends K8sObject {
   }
   spec?: { warmPoolRef?: { name?: string }; additionalPodMetadata?: { labels?: Record<string, string> } }
   status?: { sandbox?: { name?: string } }
+}
+
+export interface SandboxWarmPool extends K8sObject {
+  spec?: { sandboxTemplateRef?: { name?: string } }
+}
+
+export interface SandboxTemplate extends K8sObject {
+  spec?: { podTemplate?: SandboxPodTemplate }
 }
 
 export interface TokenReviewResult {
@@ -62,6 +79,16 @@ export class OperatingModeRejectedError extends Error {
   }
 }
 
+export class GuardedResumeRejectedError extends Error {
+  constructor(
+    readonly sandbox: string,
+    readonly cause: K8sApiError
+  ) {
+    super(`sandbox ${sandbox}: guarded mode/image resume patch was rejected`)
+    this.name = 'GuardedResumeRejectedError'
+  }
+}
+
 function collectionPath(group: string, namespace: string, plural: string): string {
   return `/apis/${group}/namespaces/${namespace}/${plural}`
 }
@@ -81,6 +108,14 @@ export class SandboxApi {
 
   private sandboxes(): string {
     return collectionPath(SANDBOX_GROUP, this.namespace, 'sandboxes')
+  }
+
+  private warmPools(): string {
+    return collectionPath(SANDBOX_EXTENSIONS_GROUP, this.namespace, 'sandboxwarmpools')
+  }
+
+  private sandboxTemplates(): string {
+    return collectionPath(SANDBOX_EXTENSIONS_GROUP, this.namespace, 'sandboxtemplates')
   }
 
   /** Create a claim, treating an existing one as success: names are derived from the
@@ -152,6 +187,41 @@ export class SandboxApi {
 
   getSandbox(name: string): Promise<Sandbox> {
     return this.http.json<Sandbox>({ method: 'GET', path: `${this.sandboxes()}/${name}` })
+  }
+
+  getWarmPool(name: string): Promise<SandboxWarmPool> {
+    return this.http.json<SandboxWarmPool>({ method: 'GET', path: `${this.warmPools()}/${name}` })
+  }
+
+  getSandboxTemplate(name: string): Promise<SandboxTemplate> {
+    return this.http.json<SandboxTemplate>({ method: 'GET', path: `${this.sandboxTemplates()}/${name}` })
+  }
+
+  async resumeWithRuntimeImage(
+    name: string,
+    image: { containerIndex: number; observedName: string; observedImage: string; targetImage: string }
+  ): Promise<Sandbox> {
+    const containerPath = `/spec/podTemplate/spec/containers/${image.containerIndex}`
+    const body: Array<{ op: 'test' | 'replace'; path: string; value: string }> = [
+      { op: 'test', path: '/spec/operatingMode', value: 'Suspended' },
+      { op: 'test', path: `${containerPath}/name`, value: image.observedName },
+      { op: 'test', path: `${containerPath}/image`, value: image.observedImage }
+    ]
+    if (image.observedImage !== image.targetImage) {
+      body.push({ op: 'replace', path: `${containerPath}/image`, value: image.targetImage })
+    }
+    body.push({ op: 'replace', path: '/spec/operatingMode', value: 'Running' })
+    try {
+      return await this.http.json<Sandbox>({
+        method: 'PATCH',
+        path: `${this.sandboxes()}/${name}`,
+        contentType: 'application/json-patch+json',
+        body
+      })
+    } catch (err) {
+      if (err instanceof K8sApiError && err.isUnprocessable) throw new GuardedResumeRejectedError(name, err)
+      throw err
+    }
   }
 
   /** Set a bound Sandbox's operating mode — the sleep/wake path.

--- a/packages/daemon/test/cluster-acp-e2e.test.ts
+++ b/packages/daemon/test/cluster-acp-e2e.test.ts
@@ -9,7 +9,7 @@ import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import { ShimDialer } from '../src/shim/dialer.js'
 import { ShimServer } from '../src/shim/server.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
-import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
+import { GuardedResumeRejectedError, type Sandbox, type SandboxClaim } from '../src/k8s/sandbox-api.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
 
 /**
@@ -45,7 +45,10 @@ function fakeApi() {
         uid: 'sandbox-uid-1',
         annotations: { 'agents.x-k8s.io/pod-name': 'runtime-1' }
       },
-      spec: { operatingMode: 'Suspended' as 'Running' | 'Suspended' },
+      spec: {
+        operatingMode: 'Suspended' as 'Running' | 'Suspended',
+        podTemplate: { spec: { containers: [{ name: 'runtime', image: 'runtime:1' }] } }
+      },
       status: { conditions: [{ type: 'Ready', status: 'True' }], podIPs: ['127.0.0.1'] }
     } as Sandbox,
     claim: undefined as SandboxClaim | undefined
@@ -65,9 +68,43 @@ function fakeApi() {
         state.claim = undefined
       },
       getSandbox: async () => state.sandbox,
+      getWarmPool: async () => ({ spec: { sandboxTemplateRef: { name: 'runtime-template' } } }),
+      getSandboxTemplate: async () => ({
+        spec: { podTemplate: { spec: { containers: [{ name: 'runtime', image: 'runtime:1' }] } } }
+      }),
+      resumeWithRuntimeImage: async (
+        _name: string,
+        image: { containerIndex: number; observedName: string; observedImage: string; targetImage: string }
+      ) => {
+        const current = state.sandbox.spec?.podTemplate?.spec?.containers?.[image.containerIndex]
+        if (
+          state.mode !== 'Suspended' ||
+          current?.name !== image.observedName ||
+          current.image !== image.observedImage
+        ) {
+          throw new GuardedResumeRejectedError('sb-1', new K8sApiError(422, 'Invalid', 'guard rejected'))
+        }
+        state.mode = 'Running'
+        state.sandbox = {
+          ...state.sandbox,
+          spec: {
+            ...state.sandbox.spec,
+            operatingMode: 'Running',
+            podTemplate: {
+              ...state.sandbox.spec?.podTemplate,
+              spec: {
+                containers: (state.sandbox.spec?.podTemplate?.spec?.containers ?? []).map((container, index) =>
+                  index === image.containerIndex ? { ...container, image: image.targetImage } : container
+                )
+              }
+            }
+          }
+        }
+        return state.sandbox
+      },
       setOperatingMode: async (_name: string, desired: 'Running' | 'Suspended') => {
         state.mode = desired
-        state.sandbox = { ...state.sandbox, spec: { operatingMode: desired } }
+        state.sandbox = { ...state.sandbox, spec: { ...state.sandbox.spec, operatingMode: desired } }
         return state.sandbox
       },
       watchClaims: vi.fn(),

--- a/packages/daemon/test/cluster-metrics.test.ts
+++ b/packages/daemon/test/cluster-metrics.test.ts
@@ -4,7 +4,7 @@ import { FakeClock } from '@agentconnect.md/connection'
 import { K8sDriver, type ClusterDriverDeps } from '../src/k8s/driver.js'
 import { LaunchTimer, type ClusterMetrics, type LaunchPath, type LaunchStage } from '../src/k8s/cluster-metrics.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
-import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
+import { GuardedResumeRejectedError, type Sandbox, type SandboxClaim } from '../src/k8s/sandbox-api.js'
 
 // The acceptance criterion for D9 is a dashboard that settles "resume p95 ≤ 15s, cold start
 // p95 ≤ 60s" without log archaeology. That is only true if the cold/resume tag is right and the
@@ -68,9 +68,31 @@ function fakeApi(options: { claimExists: boolean; mode: 'Running' | 'Suspended' 
       getSandbox: async () =>
         ({
           metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
-          spec: { operatingMode: state.mode },
+          spec: {
+            operatingMode: state.mode,
+            podTemplate: { spec: { containers: [{ name: 'runtime', image: 'runtime:1' }] } }
+          },
           status: { conditions: [{ type: 'Ready', status: 'True' }], podIPs: ['10.0.0.8'] }
         }) as Sandbox,
+      getWarmPool: async () => ({ spec: { sandboxTemplateRef: { name: 'runtime-template' } } }),
+      getSandboxTemplate: async () => ({
+        spec: { podTemplate: { spec: { containers: [{ name: 'runtime', image: 'runtime:1' }] } } }
+      }),
+      resumeWithRuntimeImage: async (
+        _name: string,
+        image: { containerIndex: number; observedName: string; observedImage: string; targetImage: string }
+      ) => {
+        if (
+          state.mode !== 'Suspended' ||
+          image.containerIndex !== 0 ||
+          image.observedName !== 'runtime' ||
+          image.observedImage !== 'runtime:1'
+        ) {
+          throw new GuardedResumeRejectedError('sb-1', new K8sApiError(422, 'Invalid', 'guard rejected'))
+        }
+        state.mode = 'Running'
+        return {} as Sandbox
+      },
       setOperatingMode: async (_name: string, desired: 'Running' | 'Suspended') => {
         state.mode = desired
         return {} as Sandbox
@@ -287,7 +309,10 @@ describe('cluster launch metrics', () => {
     notReady.api.getSandbox = async () =>
       ({
         metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
-        spec: { operatingMode: notReady.state.mode },
+        spec: {
+          operatingMode: notReady.state.mode,
+          podTemplate: { spec: { containers: [{ name: 'runtime', image: 'runtime:1' }] } }
+        },
         status: { conditions: [{ type: 'Ready', status: 'False' }] }
       }) as Sandbox
     const podClock = new FakeClock()
@@ -349,13 +374,12 @@ describe('cluster launch metrics', () => {
     const retried = recorder()
     const api = fakeApi({ claimExists: true, mode: 'Suspended' })
     let attempts = 0
-    api.api.setOperatingMode = async (_name: string, desired: 'Running' | 'Suspended') => {
+    api.api.resumeWithRuntimeImage = async () => {
       attempts += 1
       if (attempts === 1) {
-        const { OperatingModeRejectedError } = await import('../src/k8s/sandbox-api.js')
-        throw new OperatingModeRejectedError('sb-1', 'Suspended', desired, new K8sApiError(422, 'Invalid', 'no'))
+        throw new GuardedResumeRejectedError('sb-1', new K8sApiError(422, 'Invalid', 'no'))
       }
-      api.state.mode = desired
+      api.state.mode = 'Running'
       return {} as Sandbox
     }
     await driverFor(retried.metrics, api).launch(launchRequest)

--- a/packages/daemon/test/k8s-client.test.ts
+++ b/packages/daemon/test/k8s-client.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { K8sApiError, K8sHttp } from '@agentconnect.md/k8s-client'
 import { closeFakeApiServers, fakeApiServer } from '@agentconnect.md/k8s-client/testing'
-import { OperatingModeRejectedError, SandboxApi, isSandboxReady } from '../src/k8s/sandbox-api.js'
+import {
+  GuardedResumeRejectedError,
+  OperatingModeRejectedError,
+  SandboxApi,
+  isSandboxReady
+} from '../src/k8s/sandbox-api.js'
 
 // Generic config/http/watch coverage lives in packages/k8s-client; this file
 // covers the daemon-owned agent-sandbox verb surface only.
@@ -13,9 +18,13 @@ describe('SandboxApi', () => {
     const api = new SandboxApi(new K8sHttp(config), 'org-test')
     await api.getClaim('agent-a')
     await api.getSandbox('sb-1')
+    await api.getWarmPool('runtime-pool')
+    await api.getSandboxTemplate('runtime-template')
     expect(requests.map((url) => url.pathname)).toEqual([
       '/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/org-test/sandboxclaims/agent-a',
-      '/apis/agents.x-k8s.io/v1beta1/namespaces/org-test/sandboxes/sb-1'
+      '/apis/agents.x-k8s.io/v1beta1/namespaces/org-test/sandboxes/sb-1',
+      '/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/org-test/sandboxwarmpools/runtime-pool',
+      '/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/org-test/sandboxtemplates/runtime-template'
     ])
   })
 
@@ -131,6 +140,70 @@ describe('SandboxApi', () => {
       { op: 'test', path: '/spec/operatingMode', value: 'Suspended' },
       { op: 'replace', path: '/spec/operatingMode', value: 'Running' }
     ])
+  })
+
+  it('guards a resume with the observed runtime name and image before replacing either state', async () => {
+    let patch: any
+    let contentType: string | undefined
+    const { config } = await fakeApiServer(({ body, headers }) => {
+      if (body) patch = JSON.parse(body)
+      contentType = headers['content-type'] as string | undefined
+      return { json: { spec: { operatingMode: 'Running' } } }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await api.resumeWithRuntimeImage('sb-1', {
+      containerIndex: 1,
+      observedName: 'runtime',
+      observedImage: 'runtime:old',
+      targetImage: 'runtime:new'
+    })
+    expect(contentType).toBe('application/json-patch+json')
+    expect(patch).toEqual([
+      { op: 'test', path: '/spec/operatingMode', value: 'Suspended' },
+      { op: 'test', path: '/spec/podTemplate/spec/containers/1/name', value: 'runtime' },
+      { op: 'test', path: '/spec/podTemplate/spec/containers/1/image', value: 'runtime:old' },
+      { op: 'replace', path: '/spec/podTemplate/spec/containers/1/image', value: 'runtime:new' },
+      { op: 'replace', path: '/spec/operatingMode', value: 'Running' }
+    ])
+  })
+
+  it('keeps the runtime guards when a resume image already matches', async () => {
+    let patch: any
+    const { config } = await fakeApiServer(({ body }) => {
+      if (body) patch = JSON.parse(body)
+      return { json: { spec: { operatingMode: 'Running' } } }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await api.resumeWithRuntimeImage('sb-1', {
+      containerIndex: 1,
+      observedName: 'runtime',
+      observedImage: 'runtime:new',
+      targetImage: 'runtime:new'
+    })
+    expect(patch).toEqual([
+      { op: 'test', path: '/spec/operatingMode', value: 'Suspended' },
+      { op: 'test', path: '/spec/podTemplate/spec/containers/1/name', value: 'runtime' },
+      { op: 'test', path: '/spec/podTemplate/spec/containers/1/image', value: 'runtime:new' },
+      { op: 'replace', path: '/spec/operatingMode', value: 'Running' }
+    ])
+  })
+
+  it('reports a guarded resume rejection without guessing which precondition failed', async () => {
+    const { config } = await fakeApiServer(() => ({
+      status: 422,
+      json: { kind: 'Status', code: 422, reason: 'Invalid', message: 'test failed' }
+    }))
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const error = await api
+      .resumeWithRuntimeImage('sb-1', {
+        containerIndex: 1,
+        observedName: 'runtime',
+        observedImage: 'runtime:old',
+        targetImage: 'runtime:new'
+      })
+      .catch((err: unknown) => err)
+    expect(error).toBeInstanceOf(GuardedResumeRejectedError)
+    expect((error as GuardedResumeRejectedError).cause.isUnprocessable).toBe(true)
   })
 
   it('carries the guard on the suspend direction too — there is no unguarded path', async () => {

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -1,26 +1,44 @@
 import { describe, expect, it, vi } from 'vitest'
 import { FakeClock } from '@agentconnect.md/connection'
 import { K8sDriver, AC_LABEL_AGENT, AC_LABEL_ORG } from '../src/k8s/driver.js'
-import { OperatingModeRejectedError } from '../src/k8s/sandbox-api.js'
+import { GuardedResumeRejectedError, OperatingModeRejectedError } from '../src/k8s/sandbox-api.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
 import type { ShimConnection } from '../src/shim/listener.js'
 
 /** A SandboxApi stand-in whose object state a test drives directly. */
-function fakeApi(options: { ready?: boolean; mode?: 'Running' | 'Suspended' } = {}) {
+function fakeApi(options: { ready?: boolean; mode?: 'Running' | 'Suspended'; templateImage?: string } = {}) {
   const state = {
     claims: new Map<string, SandboxClaim>(),
     sandbox: {
       metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
-      spec: { operatingMode: options.mode ?? 'Running' },
+      spec: {
+        operatingMode: options.mode ?? 'Running',
+        podTemplate: {
+          spec: {
+            containers: [
+              { name: 'sidecar', image: 'sidecar:1' },
+              { name: 'runtime', image: 'runtime:old' }
+            ]
+          }
+        }
+      },
       status: {
         conditions: [{ type: 'Ready', status: options.ready === false ? 'False' : 'True' }],
         podIPs: ['10.0.0.8']
       }
     } as Sandbox,
     modeWrites: [] as Array<{ desired: string; observed: string }>,
+    resumeWrites: [] as Array<{
+      containerIndex: number
+      observedName: string
+      observedImage: string
+      targetImage: string
+    }>,
     rejectNextModeWrites: 0,
+    beforeResume: undefined as (() => void) | undefined,
+    templateImage: options.templateImage ?? 'runtime:new',
     created: [] as SandboxClaim[],
     deleted: [] as string[]
   }
@@ -40,6 +58,42 @@ function fakeApi(options: { ready?: boolean; mode?: 'Running' | 'Suspended' } = 
       state.claims.delete(name)
     }),
     getSandbox: vi.fn(async () => state.sandbox),
+    getWarmPool: vi.fn(async () => ({ spec: { sandboxTemplateRef: { name: 'runtime-template' } } })),
+    getSandboxTemplate: vi.fn(async () => ({
+      spec: {
+        podTemplate: { spec: { containers: [{ name: 'runtime', image: state.templateImage }] } }
+      }
+    })),
+    resumeWithRuntimeImage: vi.fn(
+      async (
+        _name: string,
+        image: { containerIndex: number; observedName: string; observedImage: string; targetImage: string }
+      ) => {
+        state.resumeWrites.push(image)
+        state.beforeResume?.()
+        const containers = state.sandbox.spec?.podTemplate?.spec?.containers ?? []
+        const current = containers[image.containerIndex]
+        if (
+          state.sandbox.spec?.operatingMode !== 'Suspended' ||
+          current?.name !== image.observedName ||
+          current.image !== image.observedImage
+        ) {
+          throw new GuardedResumeRejectedError('sb-1', new K8sApiError(422, 'Invalid', 'guard rejected'))
+        }
+        const nextContainers = containers.map((container, index) =>
+          index === image.containerIndex ? { ...container, image: image.targetImage } : container
+        )
+        state.sandbox = {
+          ...state.sandbox,
+          spec: {
+            ...state.sandbox.spec,
+            operatingMode: 'Running',
+            podTemplate: { ...state.sandbox.spec?.podTemplate, spec: { containers: nextContainers } }
+          }
+        }
+        return state.sandbox
+      }
+    ),
     setOperatingMode: vi.fn(
       async (_name: string, desired: 'Running' | 'Suspended', observed: 'Running' | 'Suspended') => {
         state.modeWrites.push({ desired, observed })
@@ -73,6 +127,7 @@ const launchRequest = { command: 'x', args: [], env: { AC_AGENT_ID: 'agent-a' },
 
 function driver(api: ReturnType<typeof fakeApi>['api'], overrides: Record<string, unknown> = {}) {
   const records: SpawnRecord[] = []
+  const infos: string[] = []
   const clock = new FakeClock()
   let generation = 0
   const customConnect = overrides.connectChannel as
@@ -82,14 +137,14 @@ function driver(api: ReturnType<typeof fakeApi>['api'], overrides: Record<string
     orgForAgent: () => 'org-1',
     warmPoolName: 'ac-runtime-standard-pool',
     clock,
-    log: { info: () => {}, warn: () => {}, debug: () => {} },
+    log: { info: (message: string) => infos.push(message), warn: () => {}, debug: () => {} },
     ...overrides,
     connectChannel: async (record: SpawnRecord, podIp: string, timeoutMs: number) => {
       records.push(record)
       return customConnect ? await customConnect(record, podIp, timeoutMs) : stubConnection(++generation)
     }
   })
-  return { instance, records, clock }
+  return { instance, records, clock, infos }
 }
 
 describe('cluster spawn driver', () => {
@@ -180,6 +235,231 @@ describe('cluster spawn driver', () => {
     await instance.ensureSandbox('agent-a')
     await instance.wake('agent-a')
     expect(state.modeWrites).toEqual([])
+    expect(api.getWarmPool).not.toHaveBeenCalled()
+    expect(api.getSandboxTemplate).not.toHaveBeenCalled()
+  })
+
+  it('resumes a suspended sandbox with the current template image', async () => {
+    const { api, state } = fakeApi({ mode: 'Suspended' })
+    const sandboxUid = state.sandbox.metadata?.uid
+    const { instance, infos } = driver(api)
+    await instance.ensureSandbox('agent-a')
+
+    await instance.wake('agent-a')
+
+    expect(api.getWarmPool).toHaveBeenCalledWith('ac-runtime-standard-pool')
+    expect(api.getSandboxTemplate).toHaveBeenCalledWith('runtime-template')
+    expect(state.resumeWrites).toEqual([
+      {
+        containerIndex: 1,
+        observedName: 'runtime',
+        observedImage: 'runtime:old',
+        targetImage: 'runtime:new'
+      }
+    ])
+    expect(state.sandbox.spec?.podTemplate?.spec?.containers?.[1]?.image).toBe('runtime:new')
+    expect(state.sandbox.spec?.operatingMode).toBe('Running')
+    expect(state.sandbox.metadata?.uid).toBe(sandboxUid)
+    expect(state.deleted).toEqual([])
+    expect(infos.filter((message) => message.includes('runtime:old') && message.includes('runtime:new'))).toHaveLength(
+      1
+    )
+    expect(infos).not.toContain('cluster: sandbox sb-1 → Running')
+  })
+
+  it('uses the guarded resume when the suspended sandbox already has the template image', async () => {
+    const { api, state } = fakeApi({ mode: 'Suspended', templateImage: 'runtime:old' })
+    const { instance, infos } = driver(api)
+    await instance.ensureSandbox('agent-a')
+
+    await instance.wake('agent-a')
+
+    expect(state.resumeWrites).toEqual([
+      {
+        containerIndex: 1,
+        observedName: 'runtime',
+        observedImage: 'runtime:old',
+        targetImage: 'runtime:old'
+      }
+    ])
+    expect(infos).toContain('cluster: sandbox sb-1 → Running')
+    expect(infos.filter((message) => message.includes('runtime:old → runtime:old'))).toEqual([])
+  })
+
+  it('re-reads the sandbox and template when the observed image changes before resume', async () => {
+    const { api, state } = fakeApi({ mode: 'Suspended' })
+    state.beforeResume = () => {
+      state.beforeResume = undefined
+      const containers = state.sandbox.spec?.podTemplate?.spec?.containers ?? []
+      state.sandbox = {
+        ...state.sandbox,
+        spec: {
+          ...state.sandbox.spec,
+          podTemplate: {
+            ...state.sandbox.spec?.podTemplate,
+            spec: {
+              containers: containers.map((container) =>
+                container.name === 'runtime' ? { ...container, image: 'runtime:raced' } : container
+              )
+            }
+          }
+        }
+      }
+    }
+    const { instance, infos } = driver(api)
+    await instance.ensureSandbox('agent-a')
+
+    await instance.wake('agent-a')
+
+    expect(state.resumeWrites.map((write) => write.observedImage)).toEqual(['runtime:old', 'runtime:raced'])
+    expect(api.getWarmPool).toHaveBeenCalledTimes(2)
+    expect(api.getSandboxTemplate).toHaveBeenCalledTimes(2)
+    expect(
+      state.sandbox.spec?.podTemplate?.spec?.containers?.find((container) => container.name === 'runtime')?.image
+    ).toBe('runtime:new')
+    expect(infos.filter((message) => message.includes('runtime image'))).toHaveLength(1)
+  })
+
+  it('re-resolves the runtime index after a concurrent container reorder without changing the sidecar', async () => {
+    const { api, state } = fakeApi({ mode: 'Suspended' })
+    state.beforeResume = () => {
+      state.beforeResume = undefined
+      const containers = state.sandbox.spec?.podTemplate?.spec?.containers ?? []
+      state.sandbox = {
+        ...state.sandbox,
+        spec: {
+          ...state.sandbox.spec,
+          podTemplate: { ...state.sandbox.spec?.podTemplate, spec: { containers: [...containers].reverse() } }
+        }
+      }
+    }
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+
+    await instance.wake('agent-a')
+
+    expect(state.resumeWrites.map((write) => write.containerIndex)).toEqual([1, 0])
+    expect(
+      state.sandbox.spec?.podTemplate?.spec?.containers?.find((container) => container.name === 'sidecar')?.image
+    ).toBe('sidecar:1')
+  })
+
+  it('uses a newly read template target after a guarded resume rejection', async () => {
+    const { api, state } = fakeApi({ mode: 'Suspended' })
+    state.beforeResume = () => {
+      state.beforeResume = undefined
+      state.templateImage = 'runtime:newer'
+      const runtime = state.sandbox.spec?.podTemplate?.spec?.containers?.[1]
+      if (runtime) runtime.image = 'runtime:raced'
+    }
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+
+    await instance.wake('agent-a')
+
+    expect(state.resumeWrites.map((write) => write.targetImage)).toEqual(['runtime:new', 'runtime:newer'])
+    expect(state.sandbox.spec?.podTemplate?.spec?.containers?.[1]?.image).toBe('runtime:newer')
+  })
+
+  it.each([
+    ['missing pool template reference', () => ({ spec: {} }), /has no sandboxTemplateRef\.name/],
+    [
+      'empty pool template reference',
+      () => ({ spec: { sandboxTemplateRef: { name: ' ' } } }),
+      /has no sandboxTemplateRef\.name/
+    ],
+    [
+      'non-canonical pool template reference',
+      () => ({ spec: { sandboxTemplateRef: { name: ' runtime-template ' } } }),
+      /has invalid sandboxTemplateRef\.name/
+    ]
+  ])('blocks resume for %s', async (_label, pool, expected) => {
+    const { api } = fakeApi({ mode: 'Suspended' })
+    api.getWarmPool.mockImplementation(pool)
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    await expect(instance.wake('agent-a')).rejects.toThrow(expected)
+  })
+
+  it('blocks resume when the sandbox has no runtime container', async () => {
+    const { api, state } = fakeApi({ mode: 'Suspended' })
+    state.sandbox.spec!.podTemplate!.spec!.containers = [{ name: 'sidecar', image: 'sidecar:1' }]
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    await expect(instance.wake('agent-a')).rejects.toThrow(/sandbox sb-1 has no runtime container/)
+  })
+
+  it('blocks resume when the sandbox has duplicate runtime containers', async () => {
+    const { api, state } = fakeApi({ mode: 'Suspended' })
+    state.sandbox.spec!.podTemplate!.spec!.containers!.push({ name: 'runtime', image: 'runtime:duplicate' })
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    await expect(instance.wake('agent-a')).rejects.toThrow(/sandbox sb-1 has multiple runtime containers/)
+  })
+
+  it.each([
+    [[], /runtime container has no image/],
+    [[{ name: 'runtime', image: ' ' }], /runtime container has no image/],
+    [[{ name: 'runtime', image: ' runtime:new ' }], /runtime container has invalid image/],
+    [
+      [
+        { name: 'runtime', image: 'runtime:new' },
+        { name: 'runtime', image: 'runtime:duplicate' }
+      ],
+      /multiple runtime containers/
+    ]
+  ])('blocks resume for an invalid template runtime container %#', async (containers, expected) => {
+    const { api } = fakeApi({ mode: 'Suspended' })
+    api.getSandboxTemplate.mockResolvedValue({ spec: { podTemplate: { spec: { containers } } } })
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    await expect(instance.wake('agent-a')).rejects.toThrow(expected)
+  })
+
+  it('blocks resume when the sandbox runtime image is non-canonical', async () => {
+    const { api, state } = fakeApi({ mode: 'Suspended' })
+    state.sandbox.spec!.podTemplate!.spec!.containers![1]!.image = ' runtime:old '
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    await expect(instance.wake('agent-a')).rejects.toThrow(/sandbox sb-1 runtime container has invalid image/)
+  })
+
+  it.each([
+    ['warm pool', 'getWarmPool', 404, 'NotFound'],
+    ['warm pool', 'getWarmPool', 403, 'Forbidden'],
+    ['template', 'getSandboxTemplate', 404, 'NotFound'],
+    ['template', 'getSandboxTemplate', 403, 'Forbidden']
+  ] as const)('fails closed when the %s read returns %s', async (_resource, method, status, reason) => {
+    const { api, state } = fakeApi({ mode: 'Suspended' })
+    api[method].mockRejectedValue(new K8sApiError(status, reason, `${reason} read`))
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    const error = await instance.wake('agent-a').catch((err: unknown) => err)
+    expect(error).toBeInstanceOf(K8sApiError)
+    expect((error as K8sApiError).status).toBe(status)
+    expect(state.resumeWrites).toEqual([])
+  })
+
+  it('stops after five guarded resume rejections and retains the Kubernetes cause', async () => {
+    const { api, state } = fakeApi({ mode: 'Suspended' })
+    let revision = 0
+    state.beforeResume = () => {
+      revision += 1
+      const runtime = state.sandbox.spec?.podTemplate?.spec?.containers?.find(
+        (container) => container.name === 'runtime'
+      )
+      if (runtime) runtime.image = `runtime:raced-${revision}`
+    }
+    const { instance, infos } = driver(api)
+    await instance.ensureSandbox('agent-a')
+
+    const error = await instance.wake('agent-a').catch((err: unknown) => err)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toMatch(/guarded mode\/image resume was rejected after 5 attempts/)
+    expect((error as Error & { cause?: unknown }).cause).toBeInstanceOf(K8sApiError)
+    expect(state.resumeWrites).toHaveLength(5)
+    expect(infos.filter((message) => message.includes('runtime image'))).toEqual([])
   })
 
   it('re-reads and retries when the guarded write is rejected', async () => {
@@ -237,7 +517,8 @@ describe('cluster spawn driver', () => {
     expect(state.deleted).toEqual([])
 
     await instance.ensureBoundChannel('agent-a')
-    expect(state.modeWrites.at(-1)).toEqual({ desired: 'Running', observed: 'Suspended' })
+    expect(state.resumeWrites).toHaveLength(1)
+    expect(state.sandbox.spec?.operatingMode).toBe('Running')
     expect(records.map((record) => record.generation)).toEqual([1, 2])
     expect(instance.sessionFor('agent-a')?.isAttached()).toBe(true)
   })
@@ -286,7 +567,8 @@ describe('cluster spawn driver', () => {
     await binding
     // It resumed the instance it waited for, at a fresh generation — the pod that comes back is a
     // new one, and binding it against the old generation is what this ordering prevents.
-    expect(state.modeWrites.map((write) => write.desired)).toEqual(['Suspended', 'Running'])
+    expect(state.modeWrites.map((write) => write.desired)).toEqual(['Suspended'])
+    expect(state.resumeWrites).toHaveLength(1)
     expect(records.map((record) => record.generation)).toEqual([1, 2])
     expect(instance.sessionFor('agent-a')?.isAttached()).toBe(true)
   })
@@ -315,7 +597,8 @@ describe('cluster spawn driver', () => {
 
     // The wake was decided second, so it must be the state that survives.
     expect(state.sandbox.spec?.operatingMode).toBe('Running')
-    expect(state.modeWrites.map((write) => write.desired)).toEqual(['Suspended', 'Running'])
+    expect(state.modeWrites.map((write) => write.desired)).toEqual(['Suspended'])
+    expect(state.resumeWrites).toHaveLength(1)
   })
 
   it('resolves a suspended claim without waiting for readiness first', async () => {


### PR DESCRIPTION
## Summary

- refresh the persisted Sandbox `runtime` image from the configured SandboxWarmPool and SandboxTemplate whenever AgentConnect resumes a suspended sandbox
- apply the image and `operatingMode: Running` changes as one guarded JSON Patch, with mode, container-name, and observed-image preconditions plus bounded retry on races
- fail closed for missing, forbidden, malformed, ambiguous, or non-canonical pool/template/container data while leaving already-running sandboxes untouched
- preserve the SandboxClaim, Sandbox, and workspace PVC; only the pod incarnation changes

## Root cause

The Sandbox copies its pod template when it is created. Editing the SandboxTemplate later does not update that persisted copy, while the daemon's wake path previously changed only `spec.operatingMode`. A suspended sandbox therefore restarted with its old image indefinitely.

## Deployment prerequisite

Deployment change: [workflows#109](https://github.com/agentconnect-md/workflows/pull/109)

The daemon's namespaced Role must have read-only `get` access in `extensions.agents.x-k8s.io` to:

- `sandboxwarmpools`
- `sandboxtemplates`

No Pod permission or extension-resource write permission is required.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/k8s-client.test.ts test/k8s-driver.test.ts test/cluster-acp-e2e.test.ts test/cluster-metrics.test.ts` — 77 passed
- `pnpm --filter @agentconnect.md/daemon typecheck`
- focused Prettier and ESLint checks for all changed TypeScript/Markdown files
- repository pre-push `eslint .`

The complete daemon suite was also attempted locally. The changed K8s tests passed, but the run exposed eight independently reproducible failures in untouched workspace-file/worktree tests and then stalled in the machine-dependent live ACP runtime matrix, so that broad run was interrupted.
