### PR TITLE
refactor: rename the cloud-daemon identifiers to the pool vocabulary

### DIFF
--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -368,14 +368,14 @@ enum HealthState {
 
 model Daemon {
   id            String  @id @db.Uuid // AuthReq.daemonId (wire UUID)
-  orgId         String? // null only for an install-wide cloud-daemon member shared by every org
+  orgId         String? // null only for an install-wide pool member shared by every org
   host          String? // RegisterReq.host (display)
   name          String? // human-assigned display name (set via the console, never by the daemon)
   agentVersion  String?
   machineId     String? @db.Uuid // 🅼 AuthReq.machineId (stored, stub-enforced)
   tokenFp       String? // `id` of the authenticating ApiKey (audit; written by upsertOnAuth)
   /// The Kubernetes ServiceAccount subject TokenReview reports. Envelope rows are unique by
-  /// subject; cloud members share the subject and are unique by the bound token's Pod UID.
+  /// subject; pool members share the subject and are unique by the bound token's Pod UID.
   clusterIdentity String?
   clusterPodUid   String?
   attestationFp String? // 🅼 last accepted attestation digest

--- a/packages/control-plane/src/cluster/daemon-identity.test.ts
+++ b/packages/control-plane/src/cluster/daemon-identity.test.ts
@@ -1,4 +1,4 @@
-/** Projected-token checks for install-wide cloud members. */
+/** Projected-token checks for install-wide pool members. */
 import { afterEach, describe, expect, it } from 'vitest'
 import { CLOUD_DAEMON_SA_NAME, CP_TOKEN_AUDIENCE } from '@agentconnect.md/protocol'
 import { K8sHttp } from '@agentconnect.md/k8s-client'
@@ -9,8 +9,8 @@ import { DaemonId } from '../domain/ids.js'
 
 const DAEMON_ID = '11111111-1111-4111-8111-111111111111'
 const POD_UID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
-/** Where this install runs its cloud daemons — the control namespace, as in production. */
-const CLOUD_NAMESPACE = 'agentconnect'
+/** Where this install runs its pool members — the control namespace, as in production. */
+const POOL_NAMESPACE = 'agentconnect'
 
 /** A TokenReview response as the API server writes it; `undefined` fields are omitted. */
 function reviewed(opts: {
@@ -37,7 +37,7 @@ function daemons(record: Partial<DaemonRecord> = { id: DaemonId(DAEMON_ID) }) {
   return {
     seen,
     seenPodUids,
-    resolveCloudClusterIdentity: async (identity: string, podUid: string) => {
+    resolvePoolClusterIdentity: async (identity: string, podUid: string) => {
       seen.push(identity)
       seenPodUids.push(podUid)
       return record as DaemonRecord
@@ -48,7 +48,7 @@ function daemons(record: Partial<DaemonRecord> = { id: DaemonId(DAEMON_ID) }) {
 async function service(opts: { review: unknown; daemonStore?: ReturnType<typeof daemons> }) {
   const server = await fakeApiServer(() => ({ json: opts.review }))
   const store = opts.daemonStore ?? daemons()
-  return { store, svc: new ClusterDaemonIdentityService(new K8sHttp(server.config), store, CLOUD_NAMESPACE) }
+  return { store, svc: new ClusterDaemonIdentityService(new K8sHttp(server.config), store, POOL_NAMESPACE) }
 }
 
 afterEach(async () => {
@@ -72,7 +72,7 @@ describe('parseServiceAccountSubject', () => {
 })
 
 describe('ClusterDaemonIdentityService', () => {
-  const cloudReview = (namespace = CLOUD_NAMESPACE) =>
+  const poolReview = (namespace = POOL_NAMESPACE) =>
     reviewed({
       audiences: [CP_TOKEN_AUDIENCE],
       username: clusterIdentityOf(namespace, CLOUD_DAEMON_SA_NAME),
@@ -83,9 +83,9 @@ describe('ClusterDaemonIdentityService', () => {
     const seen: string[] = []
     const server = await fakeApiServer((req) => {
       seen.push(req.body)
-      return { json: cloudReview() }
+      return { json: poolReview() }
     })
-    const svc = new ClusterDaemonIdentityService(new K8sHttp(server.config), daemons(), CLOUD_NAMESPACE)
+    const svc = new ClusterDaemonIdentityService(new K8sHttp(server.config), daemons(), POOL_NAMESPACE)
     await svc.verify('presented')
     expect(JSON.parse(seen[0]!).spec).toEqual({ token: 'presented', audiences: [CP_TOKEN_AUDIENCE] })
   })
@@ -99,39 +99,39 @@ describe('ClusterDaemonIdentityService', () => {
     const { svc } = await service({
       review: reviewed({
         audiences: ['ac-daemon-callback'],
-        username: clusterIdentityOf(CLOUD_NAMESPACE, CLOUD_DAEMON_SA_NAME),
+        username: clusterIdentityOf(POOL_NAMESPACE, CLOUD_DAEMON_SA_NAME),
         extra: { 'authentication.kubernetes.io/pod-uid': [POD_UID] }
       })
     })
     expect(await svc.verify('token')).toBeNull()
   })
 
-  it('refuses another ServiceAccount in the cloud namespace', async () => {
+  it('refuses another ServiceAccount in the pool namespace', async () => {
     const { svc } = await service({
       review: reviewed({
         audiences: [CP_TOKEN_AUDIENCE],
-        username: clusterIdentityOf(CLOUD_NAMESPACE, 'ac-runtime')
+        username: clusterIdentityOf(POOL_NAMESPACE, 'ac-runtime')
       })
     })
     expect(await svc.verify('token')).toBeNull()
   })
 
-  it('binds a reviewed cloud Pod to its org-less member record', async () => {
-    const { svc, store } = await service({ review: cloudReview() })
+  it('binds a reviewed pool member Pod to its org-less member record', async () => {
+    const { svc, store } = await service({ review: poolReview() })
     expect(await svc.verify('token')).toEqual({ daemonId: DAEMON_ID, scope: 'install' })
     expect(await svc.verify('token')).toEqual({ daemonId: DAEMON_ID, scope: 'install' })
     expect(store.seen).toEqual([
-      clusterIdentityOf(CLOUD_NAMESPACE, CLOUD_DAEMON_SA_NAME),
-      clusterIdentityOf(CLOUD_NAMESPACE, CLOUD_DAEMON_SA_NAME)
+      clusterIdentityOf(POOL_NAMESPACE, CLOUD_DAEMON_SA_NAME),
+      clusterIdentityOf(POOL_NAMESPACE, CLOUD_DAEMON_SA_NAME)
     ])
     expect(store.seenPodUids).toEqual([POD_UID, POD_UID])
   })
 
-  it('refuses a cloud ServiceAccount token that is not Pod-bound', async () => {
+  it('refuses a pool ServiceAccount token that is not Pod-bound', async () => {
     const { svc } = await service({
       review: reviewed({
         audiences: [CP_TOKEN_AUDIENCE],
-        username: clusterIdentityOf(CLOUD_NAMESPACE, CLOUD_DAEMON_SA_NAME)
+        username: clusterIdentityOf(POOL_NAMESPACE, CLOUD_DAEMON_SA_NAME)
       })
     })
     expect(await svc.verify('token')).toBeNull()
@@ -141,25 +141,25 @@ describe('ClusterDaemonIdentityService', () => {
     const { svc } = await service({
       review: reviewed({
         audiences: [CP_TOKEN_AUDIENCE],
-        username: clusterIdentityOf(CLOUD_NAMESPACE, CLOUD_DAEMON_SA_NAME),
+        username: clusterIdentityOf(POOL_NAMESPACE, CLOUD_DAEMON_SA_NAME),
         extra: { 'authentication.kubernetes.io/pod-uid': [POD_UID, 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'] }
       })
     })
     expect(await svc.verify('token')).toBeNull()
   })
 
-  it('refuses a cloud identity from any other namespace', async () => {
-    const { svc } = await service({ review: cloudReview('kube-system') })
+  it('refuses a pool identity from any other namespace', async () => {
+    const { svc } = await service({ review: poolReview('kube-system') })
     expect(await svc.verify('token')).toBeNull()
   })
 
   it('accepts the member daemon id echoed by the relay hop', async () => {
-    const { svc } = await service({ review: cloudReview(), daemonStore: daemons({ id: DaemonId(DAEMON_ID) }) })
+    const { svc } = await service({ review: poolReview(), daemonStore: daemons({ id: DaemonId(DAEMON_ID) }) })
     expect(await svc.verify('token', { daemonId: DAEMON_ID })).toEqual({ daemonId: DAEMON_ID, scope: 'install' })
   })
 
   it('refuses a claimed daemon id different from the reviewed Pod member', async () => {
-    const { svc } = await service({ review: cloudReview(), daemonStore: daemons({ id: DaemonId(DAEMON_ID) }) })
+    const { svc } = await service({ review: poolReview(), daemonStore: daemons({ id: DaemonId(DAEMON_ID) }) })
     expect(await svc.verify('token', { daemonId: '22222222-2222-4222-8222-222222222222' })).toBeNull()
   })
 })

--- a/packages/control-plane/src/cluster/daemon-identity.ts
+++ b/packages/control-plane/src/cluster/daemon-identity.ts
@@ -1,4 +1,4 @@
-/** Verifies a Pod's projected Kubernetes identity as an install-wide cloud daemon. */
+/** Verifies a Pod's projected Kubernetes identity as an install-wide pool member. */
 import { CLOUD_DAEMON_SA_NAME, CP_TOKEN_AUDIENCE } from '@agentconnect.md/protocol'
 import type { K8sHttp } from '@agentconnect.md/k8s-client'
 import { DaemonId } from '../domain/ids.js'
@@ -44,10 +44,10 @@ export function reviewedPodUid(extra: Record<string, string[]> | undefined): str
 export class ClusterDaemonIdentityService implements ClusterDaemonIdentity {
   constructor(
     private readonly http: K8sHttp,
-    private readonly daemons: Pick<DaemonRepo, 'resolveCloudClusterIdentity'>,
-    /** Namespace the install runs its cloud daemons in. A cloud identity from anywhere else
+    private readonly daemons: Pick<DaemonRepo, 'resolvePoolClusterIdentity'>,
+    /** Namespace the install runs its pool members in. A pool identity from anywhere else
      *  is refused, so the claim-your-own-org rule stays confined to pods the install placed. */
-    private readonly cloudNamespace: string
+    private readonly poolNamespace: string
   ) {}
 
   async verify(token: string, claim?: { daemonId?: string }): Promise<VerifiedClusterDaemon | null> {
@@ -67,21 +67,21 @@ export class ClusterDaemonIdentityService implements ClusterDaemonIdentity {
     if (!status.audiences?.includes(CP_TOKEN_AUDIENCE)) return null
     const subject = parseServiceAccountSubject(status.user?.username)
     if (!subject) return null
-    if (subject.serviceAccount !== CLOUD_DAEMON_SA_NAME || subject.namespace !== this.cloudNamespace) return null
+    if (subject.serviceAccount !== CLOUD_DAEMON_SA_NAME || subject.namespace !== this.poolNamespace) return null
     const podUid = reviewedPodUid(status.user?.extra)
     if (!podUid) return null
-    return this.bindCloud(subject.namespace, subject.serviceAccount, podUid, claim?.daemonId)
+    return this.bindPoolMember(subject.namespace, subject.serviceAccount, podUid, claim?.daemonId)
   }
 
-  /** Resolve one cloud Pod to its org-less member row. */
-  private async bindCloud(
+  /** Resolve one pool member Pod to its org-less member row. */
+  private async bindPoolMember(
     namespace: string,
     serviceAccount: string,
     podUid: string,
     claimedDaemonId?: string
   ): Promise<VerifiedClusterDaemon | null> {
     const identity = clusterIdentityOf(namespace, serviceAccount)
-    const daemon = await this.daemons.resolveCloudClusterIdentity(identity, podUid)
+    const daemon = await this.daemons.resolvePoolClusterIdentity(identity, podUid)
     if (claimedDaemonId && claimedDaemonId !== daemon.id) return null
     return { daemonId: DaemonId(daemon.id), scope: 'install' }
   }

--- a/packages/control-plane/src/config/env.ts
+++ b/packages/control-plane/src/config/env.ts
@@ -235,9 +235,9 @@ const CoreConfigShape = {
     .enum(['true', 'false'])
     .default('false')
     .transform((v) => v === 'true'),
-  // Namespace the install runs its CLOUD daemons in — the pods that serve every org rather
+  // Namespace the install runs its pool members in — the pods that serve every org rather
   // than one, and whose identity therefore names no org. Unset ⇒ the control plane's own
-  // namespace, which is where a single-namespace install puts them. A cloud identity from
+  // namespace, which is where a single-namespace install puts them. A pool identity from
   // any other namespace is refused, so this is the fence around "may name its own org".
   CLUSTER_CLOUD_DAEMON_NAMESPACE: z
     .string()

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -105,10 +105,10 @@ import { Placement } from './orchestrator/placement.js'
 import { Watchdog } from './orchestrator/watchdog.js'
 import { CronRunReaper } from './orchestrator/cronRunReaper.js'
 import {
-  CloudDaemonReaper,
-  CLOUD_DAEMON_REAP_AFTER_MS,
-  CLOUD_DAEMON_REAP_INTERVAL_MS
-} from './orchestrator/cloudDaemonReaper.js'
+  PoolMemberReaper,
+  POOL_MEMBER_REAP_AFTER_MS,
+  POOL_MEMBER_REAP_INTERVAL_MS
+} from './orchestrator/poolMemberReaper.js'
 import { RelaySweeper } from './orchestrator/relaySweeper.js'
 import { RelayRoster } from './orchestrator/relayRoster.js'
 import { WebchatMcpOperationReaper } from './orchestrator/webchatMcpOperationReaper.js'
@@ -167,7 +167,7 @@ import type { RelayWsServerDeps } from './ws/relay-gateway.js'
 import { buildHttpServer } from './http/server.js'
 import type { HttpDeps } from './http/deps.js'
 import { createReadiness, type Readiness } from './http/readiness.js'
-import { retireCloudDaemonMember } from './http/daemon-removal.js'
+import { retirePoolMember } from './http/daemon-removal.js'
 import { McpRateLimiter } from './http/mcp/rate-limit.js'
 import { RemoteGrantAuthenticator } from './http/mcp/remote-grant-authenticator.js'
 import { InternalInvocationAuth } from './http/mcp/internal-invocation-auth.js'
@@ -401,7 +401,7 @@ export function buildContainer(
       ? new ClusterDaemonIdentityService(
           clusterHttp,
           repos.daemon,
-          // Where this install's cloud daemons live; its own namespace unless told otherwise.
+          // Where this install's pool members live; its own namespace unless told otherwise.
           config.CLUSTER_CLOUD_DAEMON_NAMESPACE ?? clusterAccess.namespace
         )
       : undefined
@@ -1135,17 +1135,17 @@ export function buildContainer(
     defaultWebchatMcpMetrics
   )
 
-  // Retires the daemon rows replaced cloud Pods leave behind (a cloud member is bound to
+  // Retires the daemon rows replaced pool member Pods leave behind (a pool member is bound to
   // its Pod UID, so a new Pod means a new record). Org-less rows no `DELETE /daemons/:id`
   // can reach, which is why they accumulate in every org's fleet. Only where cluster tokens
-  // are accepted at all: nowhere else can a cloud member exist.
-  const cloudDaemonReaper = clusterIdentity
-    ? new CloudDaemonReaper(
+  // are accepted at all: nowhere else can a pool member exist.
+  const poolMemberReaper = clusterIdentity
+    ? new PoolMemberReaper(
         repos.daemon,
-        (member, retiredBefore) => retireCloudDaemonMember(httpDeps, member, retiredBefore, http.log),
+        (member, retiredBefore) => retirePoolMember(httpDeps, member, retiredBefore, http.log),
         connReg,
         clock,
-        { retireAfterMs: CLOUD_DAEMON_REAP_AFTER_MS, intervalMs: CLOUD_DAEMON_REAP_INTERVAL_MS },
+        { retireAfterMs: POOL_MEMBER_REAP_AFTER_MS, intervalMs: POOL_MEMBER_REAP_INTERVAL_MS },
         http.log
       )
     : undefined
@@ -1700,7 +1700,7 @@ export function buildContainer(
     startBackground() {
       cronRunReaper.start()
       hookRunReaper.start()
-      cloudDaemonReaper?.start()
+      poolMemberReaper?.start()
       webchatMcpOperationReaper.start()
       githubRunReporter?.start()
       hookRedeliveryReconciler?.start()
@@ -1716,7 +1716,7 @@ export function buildContainer(
     async shutdown() {
       cronRunReaper.stop()
       hookRunReaper.stop()
-      cloudDaemonReaper?.stop()
+      poolMemberReaper?.stop()
       const webchatMcpOperationSettled = webchatMcpOperationReaper.stopAndSettle()
       githubRunReporter?.stop()
       hookRedeliveryReconciler?.stop()

--- a/packages/control-plane/src/http/daemon-platform-capability.ts
+++ b/packages/control-plane/src/http/daemon-platform-capability.ts
@@ -29,7 +29,7 @@ export async function integrationPlatformAvailability(
   deps: HttpDeps,
   input: { daemonId: string; orgId: OrgId; viewer: ViewCtx; platform: string }
 ): Promise<DaemonPlatformAvailability> {
-  // Availability admits this org's visible daemons and install-wide cloud members, never another org's daemon.
+  // Availability admits this org's visible daemons and install-wide pool members, never another org's daemon.
   const daemon = await deps.registry.getAvailable(input.orgId, DaemonId(input.daemonId))
   if (!daemon || !canView(daemon, input.viewer)) return 'not_found'
   return daemon.capabilities.platforms.includes(input.platform) ? 'available' : 'unsupported'

--- a/packages/control-plane/src/http/daemon-removal.ts
+++ b/packages/control-plane/src/http/daemon-removal.ts
@@ -8,7 +8,7 @@
  * `daemon_offline` until a re-register replays them.
  *
  * Three callers need the whole sequence — `DELETE /daemons/:id`, organization deletion
- * (which retires the cluster envelope's own daemon), and the cloud-member reaper — and a
+ * (which retires the cluster envelope's own daemon), and the pool-member reaper — and a
  * partial copy in any of them is a bug that only shows up in the console days later. So it
  * lives here rather than in whichever route wrote it first.
  *
@@ -16,7 +16,7 @@
  * already decided, so it unplaces first and then deletes — and a crash between the two leaves
  * a live daemon with unplaced agents, which converges. The reaper's decision is a guess about
  * a row it read moments ago, so its delete comes FIRST as a fenced claim, which puts the
- * cascade before the settlement and makes the pair a transaction (`retireCloudMember`) rather
+ * cascade before the settlement and makes the pair a transaction (`retirePoolMember`) rather
  * than an ordering.
  */
 import type { FastifyBaseLogger } from 'fastify'
@@ -54,8 +54,8 @@ export async function detachDaemon(
 }
 
 /**
- * Retire one install-wide cloud member whose Pod is gone
- * (`orchestrator/cloudDaemonReaper.ts`). No org owns the row, so the org-fenced delete
+ * Retire one install-wide pool member whose Pod is gone
+ * (`orchestrator/poolMemberReaper.ts`). No org owns the row, so the org-fenced delete
  * cannot reach it — and its placements may span every organization, which is the whole
  * reason it goes through this sequence instead of a bare delete.
  *
@@ -68,7 +68,7 @@ export async function detachDaemon(
  * What follows the transaction is only the out-of-database convergence, which is best-effort
  * by nature and backstopped by `register/ok` on the next reconnect.
  */
-export async function retireCloudDaemonMember(
+export async function retirePoolMember(
   deps: DaemonRemovalDeps,
   member: { daemonId: DaemonId; sessionEpoch: bigint },
   retiredBefore: Date,
@@ -77,7 +77,7 @@ export async function retireCloudDaemonMember(
   const { daemonId, sessionEpoch } = member
   // One transaction for both database halves — the delete and the unplacement it cascades —
   // so nothing here can be interrupted into leaving an agent active with nowhere to run.
-  const { deleted, settled } = await deps.registry.retireCloudMember(daemonId, { retiredBefore, sessionEpoch })
+  const { deleted, settled } = await deps.registry.retirePoolMember(daemonId, { retiredBefore, sessionEpoch })
   if (!deleted) return false
   await settleAfterRemoval(deps, daemonId, settled, log)
   return true
@@ -99,7 +99,7 @@ async function settleAfterRemoval(
   // relay can only answer 'offline' to. Best-effort, after the row is already
   // gone; `register/ok` carries the corrected directory as the reconnect backstop.
   // Which organizations need one is derived from the placements the row held, because a
-  // cloud member's agents are not one org's.
+  // pool member's agents are not one org's.
   for (const orgId of new Set(unplacedAgents.map((agent) => agent.orgId))) {
     try {
       await deps.collabRoutes.broadcast(orgId)

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -196,7 +196,7 @@ export const DaemonViewDto = z.object({
   lifecycleOp: DaemonLifecycleOpDto.nullable(),
   /** Live connection status overlaid from the in-memory index (not the stale durable field). */
   status: z.string(),
-  /** An install-wide cloud member (`Daemon.orgId === null`, one row per cloud-daemon Pod):
+  /** An install-wide pool member (`Daemon.orgId === null`, one row per pool member Pod):
    *  managed infrastructure every org shares, not a machine this org connected. The console
    *  collapses the whole pool into its single "AgentConnect Cloud" entry. */
   cloud: z.boolean(),

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -147,7 +147,7 @@ function toDto(
         }
       : null,
     status: liveStatus(view, liveness, graceMs, nowMs),
-    // Org-less ⇒ an install-wide cloud member; the console groups the pool under one entry.
+    // Org-less ⇒ an install-wide pool member; the console groups the pool under one entry.
     cloud: !orgOwned,
     health: view.health,
     capabilities: view.capabilities,
@@ -212,7 +212,7 @@ export function daemonRoutes(deps: HttpDeps) {
           tags: [Tag.Daemons],
           summary: 'List daemons',
           description:
-            'The org’s available daemon fleet, including install-wide cloud members, overlaid with live connection status.',
+            'The org’s available daemon fleet, including install-wide pool members, overlaid with live connection status.',
           operationId: 'listDaemons',
           response: { 200: DaemonListDto }
         }

--- a/packages/control-plane/src/http/routes/stream.ts
+++ b/packages/control-plane/src/http/routes/stream.ts
@@ -79,7 +79,7 @@ export function streamRoutes(deps: HttpDeps) {
 
         const orgId = req.orgCtx!.orgId
         const connectedCtx = ctxOf(req)
-        // daemonId → available to this org, memoized per connection; shared cloud members qualify.
+        // daemonId → available to this org, memoized per connection; shared pool members qualify.
         const daemonOrg = new Map<string, boolean>()
         const inOrg = async (daemonId: string): Promise<boolean> => {
           const cached = daemonOrg.get(daemonId)

--- a/packages/control-plane/src/orchestrator/poolMemberReaper.test.ts
+++ b/packages/control-plane/src/orchestrator/poolMemberReaper.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { CloudDaemonReaper } from './cloudDaemonReaper.js'
+import { PoolMemberReaper } from './poolMemberReaper.js'
 import { DaemonId } from '../domain/ids.js'
 import type { DaemonRecord } from '../persistence/ports.js'
 import type { DaemonLiveness } from '../ports.js'
@@ -15,19 +15,19 @@ const member = (id: string, sessionEpoch = 7n): DaemonRecord =>
 const liveness = (...connected: string[]): DaemonLiveness =>
   ({ get: (id: string) => (connected.includes(id) ? { reachable: true } : undefined) }) as unknown as DaemonLiveness
 
-describe('CloudDaemonReaper', () => {
+describe('PoolMemberReaper', () => {
   it('retires every member unheard-from since now − retireAfterMs', async () => {
     const clock = new FakeClock(1_700_000_000_000)
-    const findRetiredCloudMembers = vi.fn(async () => [member('a'), member('b')])
+    const findRetiredPoolMembers = vi.fn(async () => [member('a'), member('b')])
     const retire = vi.fn(async () => true)
-    const reaper = new CloudDaemonReaper({ findRetiredCloudMembers }, retire, liveness(), clock, {
+    const reaper = new PoolMemberReaper({ findRetiredPoolMembers }, retire, liveness(), clock, {
       retireAfterMs: RETIRE_AFTER_MS,
       intervalMs: INTERVAL_MS
     })
 
     await reaper.tick()
 
-    expect(findRetiredCloudMembers).toHaveBeenCalledWith(new Date(clock.now() - RETIRE_AFTER_MS))
+    expect(findRetiredPoolMembers).toHaveBeenCalledWith(new Date(clock.now() - RETIRE_AFTER_MS))
     expect(retire.mock.calls.map(([m]) => m.daemonId)).toEqual(['a', 'b'])
     reaper.stop()
   })
@@ -37,8 +37,8 @@ describe('CloudDaemonReaper', () => {
     // still the one that was read, or a member that reconnected mid-sweep loses its agents.
     const clock = new FakeClock(1_700_000_000_000)
     const retire = vi.fn(async () => true)
-    const reaper = new CloudDaemonReaper(
-      { findRetiredCloudMembers: async () => [member('a', 12n)] },
+    const reaper = new PoolMemberReaper(
+      { findRetiredPoolMembers: async () => [member('a', 12n)] },
       retire,
       liveness(),
       clock,
@@ -54,8 +54,8 @@ describe('CloudDaemonReaper', () => {
   it('does not count a member the claim refused — it came back', async () => {
     const clock = new FakeClock()
     const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
-    const reaper = new CloudDaemonReaper(
-      { findRetiredCloudMembers: async () => [member('back')] },
+    const reaper = new PoolMemberReaper(
+      { findRetiredPoolMembers: async () => [member('back')] },
       async () => false,
       liveness(),
       clock,
@@ -72,8 +72,8 @@ describe('CloudDaemonReaper', () => {
   it('leaves a member that is connected here, however stale its last heartbeat looks', async () => {
     const clock = new FakeClock()
     const retire = vi.fn(async () => true)
-    const reaper = new CloudDaemonReaper(
-      { findRetiredCloudMembers: async () => [member('live'), member('gone')] },
+    const reaper = new PoolMemberReaper(
+      { findRetiredPoolMembers: async () => [member('live'), member('gone')] },
       retire,
       liveness('live'),
       clock,
@@ -92,8 +92,8 @@ describe('CloudDaemonReaper', () => {
       if (m.daemonId === 'boom') throw new Error('cascade failed')
       return true
     })
-    const reaper = new CloudDaemonReaper(
-      { findRetiredCloudMembers: async () => [member('boom'), member('next')] },
+    const reaper = new PoolMemberReaper(
+      { findRetiredPoolMembers: async () => [member('boom'), member('next')] },
       retire,
       liveness(),
       clock,
@@ -107,9 +107,9 @@ describe('CloudDaemonReaper', () => {
 
   it('swallows a failed worklist read and keeps the loop alive', async () => {
     const clock = new FakeClock()
-    const reaper = new CloudDaemonReaper(
+    const reaper = new PoolMemberReaper(
       {
-        findRetiredCloudMembers: async () => {
+        findRetiredPoolMembers: async () => {
           throw new Error('db down')
         }
       },
@@ -125,17 +125,17 @@ describe('CloudDaemonReaper', () => {
 
   it('start() arms a periodic sweep driven by the clock', async () => {
     const clock = new FakeClock()
-    const findRetiredCloudMembers = vi.fn(async () => [])
-    const reaper = new CloudDaemonReaper({ findRetiredCloudMembers }, async () => true, liveness(), clock, {
+    const findRetiredPoolMembers = vi.fn(async () => [])
+    const reaper = new PoolMemberReaper({ findRetiredPoolMembers }, async () => true, liveness(), clock, {
       retireAfterMs: RETIRE_AFTER_MS,
       intervalMs: INTERVAL_MS
     })
 
     reaper.start()
-    expect(findRetiredCloudMembers).not.toHaveBeenCalled()
+    expect(findRetiredPoolMembers).not.toHaveBeenCalled()
     clock.advance(INTERVAL_MS)
     await Promise.resolve() // let the async tick settle
-    expect(findRetiredCloudMembers).toHaveBeenCalledTimes(1)
+    expect(findRetiredPoolMembers).toHaveBeenCalledTimes(1)
     reaper.stop()
   })
 })

--- a/packages/control-plane/src/orchestrator/poolMemberReaper.ts
+++ b/packages/control-plane/src/orchestrator/poolMemberReaper.ts
@@ -1,8 +1,8 @@
 /**
- * `CloudDaemonReaper` (agentconnect-org-operator.md §"The cloud daemon, which serves every
- * org") — retires the daemon rows replaced cloud Pods leave behind.
+ * `PoolMemberReaper` (agentconnect-org-operator.md §"The cloud daemon, which serves every
+ * org") — retires the daemon rows replaced pool member Pods leave behind.
  *
- * A cloud member is bound to its reviewed Pod UID, so a replacement Pod gets a NEW daemon
+ * A pool member is bound to its reviewed Pod UID, so a replacement Pod gets a NEW daemon
  * record and the old one lingers: org-less, never reachable again, and visible in every
  * organization's fleet because install-wide infrastructure is shared. Nothing else can clear
  * them — no org owns the row, so `DELETE /daemons/:id` cannot name it.
@@ -14,12 +14,12 @@
  *
  * The sweep only nominates. Retiring re-checks the same cutoff and the epoch this read saw
  * INSIDE the delete statement, so a member that comes back between the two loses nothing:
- * see `http/daemon-removal.ts#retireCloudDaemonMember`.
+ * see `http/daemon-removal.ts#retirePoolMember`.
  *
  * Clock-driven via a self-rescheduling `setTimeout` (like {@link RelaySweeper}) so tests
  * advance a `FakeClock`; armed by the container's `startBackground()`, never in tests.
  * Every replica running it is fine — the delete is idempotent and fenced to the org-less
- * cloud shape, so a row another replica just retired reads as "no longer retired".
+ * pool shape, so a row another replica just retired reads as "no longer retired".
  */
 import type { Clock, TimerHandle } from '../domain/clock.js'
 import type { DaemonId } from '../domain/ids.js'
@@ -27,36 +27,36 @@ import type { DaemonLiveness } from '../ports.js'
 import type { DaemonRepo } from '../persistence/ports.js'
 
 /** How often the sweep runs. */
-export const CLOUD_DAEMON_REAP_INTERVAL_MS = 5 * 60_000
+export const POOL_MEMBER_REAP_INTERVAL_MS = 5 * 60_000
 
 /**
- * How long a cloud member must go unheard-from before its row is retired. Two orders of
+ * How long a pool member must go unheard-from before its row is retired. Two orders of
  * magnitude past the watchdog's freeze threshold (missed beats × heartbeat): by then its
  * sessions have long been rebalanced, and the window is what keeps a network partition from
  * deleting the record of a Pod that is still running.
  */
-export const CLOUD_DAEMON_REAP_AFTER_MS = 15 * 60_000
+export const POOL_MEMBER_REAP_AFTER_MS = 15 * 60_000
 
 /** Optional structured log sink (the Fastify logger in prod; omitted in tests). */
-export interface CloudDaemonReaperLog {
+export interface PoolMemberReaperLog {
   info(obj: unknown, msg?: string): void
   warn(obj: unknown, msg?: string): void
   error(obj: unknown, msg?: string): void
 }
 
-export interface CloudDaemonReaperConfig {
+export interface PoolMemberReaperConfig {
   /** Silence after which a member's row is retired. */
   retireAfterMs: number
   /** How often the sweep runs. */
   intervalMs: number
 }
 
-export class CloudDaemonReaper {
+export class PoolMemberReaper {
   private timer: TimerHandle | undefined
   private stopped = false
 
   constructor(
-    private readonly daemons: Pick<DaemonRepo, 'findRetiredCloudMembers'>,
+    private readonly daemons: Pick<DaemonRepo, 'findRetiredPoolMembers'>,
     /** The full detach sequence for one member (`http/daemon-removal.ts`), re-fenced on the
      *  cutoff and epoch this sweep read; false ⇒ not retired after all (a reconnect, or a
      *  peer replica got there first) and nothing was written. */
@@ -66,8 +66,8 @@ export class CloudDaemonReaper {
     ) => Promise<boolean>,
     private readonly liveness: DaemonLiveness,
     private readonly clock: Clock,
-    private readonly cfg: CloudDaemonReaperConfig,
-    private readonly log?: CloudDaemonReaperLog
+    private readonly cfg: PoolMemberReaperConfig,
+    private readonly log?: PoolMemberReaperLog
   ) {}
 
   /** Arm the periodic sweep. Idempotent — a second call re-arms from now. */
@@ -101,7 +101,7 @@ export class CloudDaemonReaper {
     this.timer = undefined
     try {
       const cutoff = new Date(this.clock.now() - this.cfg.retireAfterMs)
-      const retired = await this.daemons.findRetiredCloudMembers(cutoff)
+      const retired = await this.daemons.findRetiredPoolMembers(cutoff)
       let removed = 0
       for (const member of retired) {
         if (this.stopped) break
@@ -112,17 +112,17 @@ export class CloudDaemonReaper {
         try {
           if (await this.retire({ daemonId: member.id, sessionEpoch: member.sessionEpoch }, cutoff)) removed++
         } catch (err) {
-          this.log?.warn({ err, daemonId: member.id }, 'cloud-daemon-reaper: retiring one member failed')
+          this.log?.warn({ err, daemonId: member.id }, 'pool-member-reaper: retiring one member failed')
         }
       }
       if (removed > 0) {
         this.log?.info(
           { removed, considered: retired.length, cutoff: cutoff.toISOString() },
-          'cloud-daemon-reaper: retired cloud members whose Pods are gone'
+          'pool-member-reaper: retired pool members whose Pods are gone'
         )
       }
     } catch (err) {
-      this.log?.error({ err }, 'cloud-daemon-reaper: sweep failed')
+      this.log?.error({ err }, 'pool-member-reaper: sweep failed')
     } finally {
       this.arm()
     }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -147,7 +147,7 @@ export interface RegisterReqInput {
 
 export interface DaemonRecord {
   id: DaemonId
-  /** Null only for an install-wide cloud-daemon member. */
+  /** Null only for an install-wide pool member. */
   orgId: OrgId | null
   host: string | null
   /** Human-assigned display name (console-set); null until a user names it. */
@@ -209,8 +209,8 @@ export interface DaemonRepo {
     clusterIdentity: string,
     opts?: { adoptDaemonId?: string }
   ): Promise<DaemonRecord | null>
-  /** Resolve one install-wide cloud member by its reviewed ServiceAccount subject and Pod UID. */
-  resolveCloudClusterIdentity(clusterIdentity: string, clusterPodUid: string): Promise<DaemonRecord>
+  /** Resolve one install-wide pool member by its reviewed ServiceAccount subject and Pod UID. */
+  resolvePoolClusterIdentity(clusterIdentity: string, clusterPodUid: string): Promise<DaemonRecord>
   /** The Kubernetes identity a daemon record is bound to, or null for an unknown/key daemon. */
   findClusterIdentity(daemonId: DaemonId): Promise<{ orgId: string | null; clusterIdentity: string } | null>
   /** Ids of the org's daemons bound to a Kubernetes identity — the ones the control
@@ -259,27 +259,27 @@ export interface DaemonRepo {
    */
   delete(orgId: OrgId, daemonId: DaemonId): Promise<void>
   /**
-   * Install-wide cloud members nothing has been heard from since `cutoff` — the rows left
+   * Install-wide pool members nothing has been heard from since `cutoff` — the rows left
    * behind by replaced Pods, which no org's DELETE can reach because no org owns them
    * (agentconnect-org-operator.md §"The cloud daemon, which serves every org": a replacement
    * Pod gets a new daemon ID). System-tier and deliberately fleet-wide, like
    * {@link DaemonRepo.findReassignable}. Never-connected rows are judged by `createdAt`.
    */
-  findRetiredCloudMembers(cutoff: Date): Promise<DaemonRecord[]>
+  findRetiredPoolMembers(cutoff: Date): Promise<DaemonRecord[]>
   /**
-   * Retire ONE install-wide cloud member: the fenced delete (cascading exactly like
+   * Retire ONE install-wide pool member: the fenced delete (cascading exactly like
    * {@link DaemonRepo.delete}) plus the database-side settlement of every agent it hosted, in
    * one transaction — so no crash can leave an agent unplaced but still `active`.
    *
    * A compare-and-delete, not a delete: the whole fence rides one statement — the org-less
-   * cloud shape (so it cannot touch an org's own daemon), the same `retiredBefore` cutoff the
+   * pool shape (so it cannot touch an org's own daemon), the same `retiredBefore` cutoff the
    * worklist selected on, and the `sessionEpoch` observed there, which a (re)auth bumps before
    * the first heartbeat moves `lastSeenAt`. A row that stopped matching yields
    * `deleted: false`, having written nothing, so nothing downstream runs for a member that
    * came back. `settled` is the agents this call actually unplaced — the audience for the
    * out-of-database pushes that follow, excluding any a concurrent writer had already moved.
    */
-  retireCloudMember(
+  retirePoolMember(
     daemonId: DaemonId,
     fence: { retiredBefore: Date; sessionEpoch: bigint }
   ): Promise<{ deleted: boolean; settled: { id: AgentId; orgId: OrgId }[] }>
@@ -290,9 +290,9 @@ export interface DaemonRepo {
   /** Daemons unreachable for longer than `graceSec` — reassignment candidates (§4.9).
    *  System-tier: the watchdog's worklist is deliberately fleet-wide. */
   findReassignable(graceSec: number, now: Date): Promise<DaemonRecord[]>
-  /** Org-owned point read; shared cloud members are deliberately absent. */
+  /** Org-owned point read; shared pool members are deliberately absent. */
   get(orgId: OrgId, daemonId: DaemonId): Promise<DaemonRecord | null>
-  /** Placement/display read admitting both org-owned daemons and install-wide cloud members. */
+  /** Placement/display read admitting both org-owned daemons and install-wide pool members. */
   getAvailable(orgId: OrgId, daemonId: DaemonId): Promise<DaemonRecord | null>
   /** Tenancy-UNSCOPED read for internal trust domains — WS handlers resolving
    *  their own connection's daemon, orchestration/placement resolving a daemon
@@ -301,7 +301,7 @@ export interface DaemonRepo {
   getUnscoped(daemonId: DaemonId): Promise<DaemonRecord | null>
   /** Owned fleet, optionally filtered to one org; undefined is the internal fleet-wide read. */
   list(orgId?: OrgId, viewer?: ViewCtx): Promise<DaemonRecord[]>
-  /** Display/placement fleet including install-wide cloud members. */
+  /** Display/placement fleet including install-wide pool members. */
   listAvailable(orgId: OrgId, viewer?: ViewCtx): Promise<DaemonRecord[]>
 }
 

--- a/packages/control-plane/src/persistence/repositories/agent-placement.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-placement.ts
@@ -1,8 +1,8 @@
 /**
  * Placement primitives shared by the agent repository and the one writer that has to settle
- * placements from OUTSIDE it: retiring an install-wide cloud member, where the daemon delete
+ * placements from OUTSIDE it: retiring an install-wide pool member, where the daemon delete
  * and the settlement of every agent it hosted must land in one transaction
- * (`daemon.repo.ts#retireCloudMember`).
+ * (`daemon.repo.ts#retirePoolMember`).
  *
  * Placement/delegation lock order:
  *   Agent FOR UPDATE → active WebchatMcpDelegation rows.

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -65,17 +65,17 @@ function toRecord(d: DaemonWithUsers): DaemonRecord {
   }
 }
 
-// What an install-wide cloud member is, as a where-clause: org-less, cluster-reviewed, and
+// What an install-wide pool member is, as a where-clause: org-less, cluster-reviewed, and
 // bound to one Pod UID. An envelope daemon carries an identity but no Pod, so it never matches.
-const CLOUD_MEMBER_WHERE = { orgId: null, clusterIdentity: { not: null }, clusterPodUid: { not: null } } as const
+const POOL_MEMBER_WHERE = { orgId: null, clusterIdentity: { not: null }, clusterPodUid: { not: null } } as const
 
 /** ONE definition of "retired", shared by the worklist read and the delete that acts on it: a
  *  claim fenced on a different predicate than the one that selected the row is not a claim.
  *  A row that never heartbeated is judged by its own age — `lastSeenAt` stays null for a Pod
  *  that authenticated and died before its first beat. */
-function retiredCloudMemberWhere(cutoff: Date) {
+function retiredPoolMemberWhere(cutoff: Date) {
   return {
-    ...CLOUD_MEMBER_WHERE,
+    ...POOL_MEMBER_WHERE,
     OR: [{ lastSeenAt: { lt: cutoff } }, { lastSeenAt: null, createdAt: { lt: cutoff } }]
   }
 }
@@ -138,7 +138,7 @@ export class PgDaemonRepo implements DaemonRepo {
     }
   }
 
-  async resolveCloudClusterIdentity(clusterIdentity: string, clusterPodUid: string): Promise<DaemonRecord> {
+  async resolvePoolClusterIdentity(clusterIdentity: string, clusterPodUid: string): Promise<DaemonRecord> {
     const where = { clusterIdentity_clusterPodUid: { clusterIdentity, clusterPodUid } }
     const existing = await this.db.daemon.findUnique({ where, include: withUsers })
     if (existing) return toRecord(existing)
@@ -364,12 +364,12 @@ export class PgDaemonRepo implements DaemonRepo {
     await this.db.daemon.delete({ where: { id: daemonId, orgId } })
   }
 
-  /** The org-less-cloud shape rides every clause, so neither the worklist nor the delete can
+  /** The org-less pool shape rides every clause, so neither the worklist nor the delete can
    *  name an org's own daemon. A member still inside the window is left alone even if its Pod
    *  is long gone: only silence past `cutoff` retires a row. */
-  async findRetiredCloudMembers(cutoff: Date): Promise<DaemonRecord[]> {
+  async findRetiredPoolMembers(cutoff: Date): Promise<DaemonRecord[]> {
     const rows = await this.db.daemon.findMany({
-      where: retiredCloudMemberWhere(cutoff),
+      where: retiredPoolMemberWhere(cutoff),
       orderBy: { createdAt: 'asc' },
       include: withUsers
     })
@@ -377,13 +377,13 @@ export class PgDaemonRepo implements DaemonRepo {
   }
 
   /**
-   * Retire one cloud member: the fenced delete AND the settlement of every agent it hosted,
+   * Retire one pool member: the fenced delete AND the settlement of every agent it hosted,
    * in ONE transaction. Split across two commits, a process exit or a transient failure in
    * between would strand agents at `daemonId = null` with `status = 'active'` — nowhere to
    * run, live delegations, stale hook revisions — with no durable work item to retry from.
    *
    * The whole fence rides the DELETE statement, so this is a compare-and-delete and not a
-   * delete that trusts an earlier read: still an org-less cloud member, still silent past the
+   * delete that trusts an earlier read: still an org-less pool member, still silent past the
    * same cutoff the worklist selected on, still at the `sessionEpoch` it saw there. The epoch
    * is what makes it airtight — `upsertOnAuth` bumps it atomically on every (re)auth, while
    * `lastSeenAt` only moves on the first heartbeat AFTER one, so a member that just came back
@@ -392,7 +392,7 @@ export class PgDaemonRepo implements DaemonRepo {
    * The agents are locked BEFORE the daemon row, matching the placement path's Agent → Daemon
    * order (`agent-placement.ts`), so a concurrent move cannot deadlock against this.
    */
-  async retireCloudMember(
+  async retirePoolMember(
     daemonId: DaemonId,
     fence: { retiredBefore: Date; sessionEpoch: bigint }
   ): Promise<{ deleted: boolean; settled: { id: AgentId; orgId: OrgId }[] }> {
@@ -408,7 +408,7 @@ export class PgDaemonRepo implements DaemonRepo {
         })
         for (const agent of placed) await lockAgentPlacement(tx, agent.id)
         const { count } = await tx.daemon.deleteMany({
-          where: { id: daemonId, sessionEpoch: fence.sessionEpoch, ...retiredCloudMemberWhere(fence.retiredBefore) }
+          where: { id: daemonId, sessionEpoch: fence.sessionEpoch, ...retiredPoolMemberWhere(fence.retiredBefore) }
         })
         if (count !== 1) return { deleted: false, settled: [] }
         const settled: { id: AgentId; orgId: OrgId }[] = []

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -42,7 +42,7 @@ export interface DaemonAuth {
   authenticate(req: AuthReq, ctx: ClientCtx): Promise<AuthResult>
 }
 
-/** The daemon record a verified Kubernetes identity, including a cloud Pod UID, resolves to. */
+/** The daemon record a verified Kubernetes identity, including a pool member Pod UID, resolves to. */
 export type VerifiedClusterDaemon =
   { daemonId: DaemonId; scope: 'org'; orgId: OrgId } | { daemonId: DaemonId; scope: 'install' }
 
@@ -308,20 +308,20 @@ export interface DaemonRegistry {
   /** Hard-delete a daemon from the fleet (DELETE /daemons/:id). Org-fenced:
    *  throws for an absent row and for a cross-org id alike. */
   remove(orgId: OrgId, daemonId: DaemonId): Promise<void>
-  /** Retire one install-wide cloud member — the row a replaced cloud Pod left behind
-   *  (`orchestrator/cloudDaemonReaper.ts`). No org owns it, so {@link DaemonRegistry.remove}
-   *  cannot reach it. The fence is the claim: org-less cloud shape, still silent past the same
+  /** Retire one install-wide pool member — the row a replaced pool member Pod left behind
+   *  (`orchestrator/poolMemberReaper.ts`). No org owns it, so {@link DaemonRegistry.remove}
+   *  cannot reach it. The fence is the claim: org-less pool shape, still silent past the same
    *  cutoff the worklist used, still at the epoch observed there. `deleted: false` means the
    *  row no longer matched — a member that came back — and nothing was written. The delete and
    *  the agent settlement share one transaction; `settled` names the agents it unplaced, whose
    *  relay, collaboration and hook state the caller re-converges after the commit. */
-  retireCloudMember(
+  retirePoolMember(
     daemonId: DaemonId,
     fence: { retiredBefore: Date; sessionEpoch: bigint }
   ): Promise<{ deleted: boolean; settled: { id: AgentId; orgId: OrgId }[] }>
-  /** The org-owned fleet; shared cloud members are deliberately absent. */
+  /** The org-owned fleet; shared pool members are deliberately absent. */
   list(orgId: OrgId, viewer?: ViewCtx): Promise<DaemonView[]>
-  /** The display/placement fleet, including install-wide cloud members. */
+  /** The display/placement fleet, including install-wide pool members. */
   listAvailable(orgId: OrgId, viewer?: ViewCtx): Promise<DaemonView[]>
   /** One org-owned daemon; shared and foreign ids are indistinguishable from missing. */
   get(orgId: OrgId, daemonId: DaemonId): Promise<DaemonView | null>

--- a/packages/control-plane/src/registry/authService.test.ts
+++ b/packages/control-plane/src/registry/authService.test.ts
@@ -276,9 +276,9 @@ describe('DaemonAuthService.authenticate — the in-cluster token path', () => {
     expect(claims).toEqual([{ daemonId: verified.daemonId }])
   })
 
-  it('authenticates an install-wide cloud daemon in frame-scoped organization mode', async () => {
-    const cloud = { daemonId: verified.daemonId, scope: 'install' as const }
-    const r = await withIdentity(async () => cloud).authenticate(
+  it('authenticates an install-wide pool member in frame-scoped organization mode', async () => {
+    const poolMember = { daemonId: verified.daemonId, scope: 'install' as const }
+    const r = await withIdentity(async () => poolMember).authenticate(
       { serviceAccountToken: 'projected', agentVersion: '1' },
       ctx
     )

--- a/packages/control-plane/src/registry/authService.ts
+++ b/packages/control-plane/src/registry/authService.ts
@@ -15,7 +15,7 @@
  *   3. on success → mint the next monotonic `sessionEpoch` via `EpochService`
  *      (persisted in C6) and return the `auth/ok` frame.
  *
- * TokenReview resolves an envelope to one org or a cloud Pod to one install-wide member.
+ * TokenReview resolves an envelope to one org or a pool member Pod to one install-wide member.
  *
  * A DB error during lookup or the epoch bump closes `1011` (SERVER_INTERNAL) so the
  * daemon backs off and retries rather than treating a transient blip as a dead

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -206,11 +206,11 @@ export class DaemonRegistryService implements DaemonRegistry {
     await this.daemons.delete(orgId, daemonId)
   }
 
-  async retireCloudMember(
+  async retirePoolMember(
     daemonId: DaemonId,
     fence: { retiredBefore: Date; sessionEpoch: bigint }
   ): Promise<{ deleted: boolean; settled: { id: AgentId; orgId: OrgId }[] }> {
-    return this.daemons.retireCloudMember(daemonId, fence)
+    return this.daemons.retirePoolMember(daemonId, fence)
   }
 
   /** Org-fenced (org-scoped-data-layer.md §3): the repo read is filtered, so a

--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -50,7 +50,7 @@ const INSTALL_WIDE_FRAME_TYPES = new Set([
 export class DaemonConnection implements ConnChannel {
   state: LifecycleState = 'CONNECTING'
   daemonId = '' // set on auth/ok; "" until then (ConnChannel requires a string)
-  /** Auth-scoped org; null for an install-wide cloud daemon. */
+  /** Auth-scoped org; null for an install-wide pool member. */
   orgId: string | null = null
   /** Current fencing epoch for this daemon (set on auth/ok). */
   sessionEpoch = 0
@@ -129,7 +129,7 @@ export class DaemonConnection implements ConnChannel {
     }
   }
 
-  /** Enforce connection-scoped tenancy for ordinary daemons and frame-scoped tenancy for cloud. */
+  /** Enforce connection-scoped tenancy for ordinary daemons and frame-scoped tenancy for a pool member. */
   private gateOrganization(frame: AnyFrame): boolean {
     if (this.state === 'AUTHENTICATING' || this.state === 'REGISTERING') return true
     if (this.orgId) {

--- a/packages/control-plane/src/ws/relay-connection.test.ts
+++ b/packages/control-plane/src/ws/relay-connection.test.ts
@@ -628,7 +628,7 @@ describe('RelayConnection FSM', () => {
       }
     })
     await toReady(transport)
-    // The claimed id travels with the token: a cloud daemon's identity names no org, so it
+    // The claimed id travels with the token: a pool member's identity names no org, so it
     // is checked against the install-wide daemon record.
     const claimedId = '99999999-9999-4999-8999-999999999999'
     transport.feed('rc/verify', { kind: 'daemon-token', credential: 'projected', daemonId: claimedId })

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -100,7 +100,7 @@ export interface WsHarness {
   mintToken(daemonId: string): Promise<string>
   /** Provision an org-less (install-wide, frame-mode) daemon row + a fake cluster
    *  ServiceAccount token for it; auth with `{ serviceAccountToken }`. */
-  mintCloudDaemon(daemonId: string): Promise<string>
+  mintPoolMember(daemonId: string): Promise<string>
   /** Open a fresh connection (started) over a new stub. */
   connect(stub?: InMemoryDaemonStub): { conn: DaemonConnection; stub: InMemoryDaemonStub }
 }
@@ -162,7 +162,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
 
   const epoch = new EpochService(repos.daemon, clock)
   // Fake in-cluster identity: token → install-wide daemon, no TokenReview.
-  const cloudTokens = new Map<string, string>()
+  const poolTokens = new Map<string, string>()
   const auth = new DaemonAuthService(
     codec,
     repos.apiKey,
@@ -172,7 +172,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     new PgOrgRepo(prisma),
     {
       verify: async (token: string) => {
-        const daemonId = cloudTokens.get(token)
+        const daemonId = poolTokens.get(token)
         return daemonId ? { daemonId: DaemonId(daemonId), scope: 'install' as const } : null
       }
     }
@@ -318,10 +318,10 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     hookRemovals,
     placement: placementResolver,
     codec,
-    mintCloudDaemon: async (daemonId: string) => {
+    mintPoolMember: async (daemonId: string) => {
       await prisma.daemon.create({ data: { id: daemonId, orgId: null, maxAgents: 8, status: 'ready' } })
       const token = `fake-sa-token-${daemonId}`
-      cloudTokens.set(token, daemonId)
+      poolTokens.set(token, daemonId)
       return token
     },
     mintToken: async (daemonId: string) => {

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -116,29 +116,29 @@ describe('GET /daemons — live-status overlay', () => {
     expect(d!.status).toBe('offline') // durable status is still `ready`, but it is not connected
   })
 
-  it('lists an install-wide cloud daemon without granting org-owned mutation access', async () => {
-    const cloud = await new PgDaemonRepo(prisma).resolveCloudClusterIdentity(
+  it('lists an install-wide pool member without granting org-owned mutation access', async () => {
+    const poolMember = await new PgDaemonRepo(prisma).resolvePoolClusterIdentity(
       'system:serviceaccount:agentconnect:ac-cloud-daemon',
       'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
     )
     running = buildHttpApp(prisma)
 
     const rows = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })).json() as DaemonDto[]
-    expect(rows.find((row) => row.daemonId === cloud.id)).toMatchObject({
+    expect(rows.find((row) => row.daemonId === poolMember.id)).toMatchObject({
       canEdit: false,
       canManageSharing: false,
       canManageLifecycle: false
     })
 
-    const issueKey = await running.app.inject({ method: 'POST', url: `${ORG}/daemons/${cloud.id}/keys` })
+    const issueKey = await running.app.inject({ method: 'POST', url: `${ORG}/daemons/${poolMember.id}/keys` })
     expect(issueKey.statusCode).toBe(404)
-    expect(await prisma.apiKey.count({ where: { daemonId: cloud.id } })).toBe(0)
+    expect(await prisma.apiKey.count({ where: { daemonId: poolMember.id } })).toBe(0)
 
-    expect((await running.app.inject({ method: 'POST', url: `${ORG}/daemons/${cloud.id}/restart` })).statusCode).toBe(
-      404
-    )
     expect(
-      (await running.app.inject({ method: 'PATCH', url: `${ORG}/daemons/${cloud.id}`, payload: { name: 'mine' } }))
+      (await running.app.inject({ method: 'POST', url: `${ORG}/daemons/${poolMember.id}/restart` })).statusCode
+    ).toBe(404)
+    expect(
+      (await running.app.inject({ method: 'PATCH', url: `${ORG}/daemons/${poolMember.id}`, payload: { name: 'mine' } }))
         .statusCode
     ).toBe(404)
   })

--- a/packages/control-plane/test/integration/orgs.route.test.ts
+++ b/packages/control-plane/test/integration/orgs.route.test.ts
@@ -347,8 +347,8 @@ describe('DELETE /orgs/:orgId', () => {
     }
   })
 
-  it('does not treat install-wide cloud daemons as org deletion blockers', async () => {
-    const cloud = await new PgDaemonRepo(prisma).resolveCloudClusterIdentity(
+  it('does not treat install-wide pool members as org deletion blockers', async () => {
+    const poolMember = await new PgDaemonRepo(prisma).resolvePoolClusterIdentity(
       'system:serviceaccount:agentconnect:ac-cloud-daemon',
       'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
     )
@@ -360,7 +360,7 @@ describe('DELETE /orgs/:orgId', () => {
 
       expect((await app.inject({ method: 'DELETE', url: `/api/v1/orgs/${created.id}` })).statusCode).toBe(204)
       expect(await prisma.org.findUnique({ where: { id: created.id } })).toBeNull()
-      expect(await prisma.daemon.findUnique({ where: { id: cloud.id } })).not.toBeNull()
+      expect(await prisma.daemon.findUnique({ where: { id: poolMember.id } })).not.toBeNull()
     } finally {
       await close()
     }

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -53,7 +53,7 @@ async function ready(h: ReturnType<typeof buildWsHarness>, opts: { orgScoped?: b
     const token = await h.mintToken(DAEMON)
     stub.inject('auth', { apiKey: token, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
   } else {
-    const saToken = await h.mintCloudDaemon(DAEMON)
+    const saToken = await h.mintPoolMember(DAEMON)
     stub.inject('auth', { serviceAccountToken: saToken, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
   }
   await stub.expectFrame('auth/ok')
@@ -321,7 +321,7 @@ describe('the reconnect roster follows the duty holder', () => {
   /** Register while claiming a local replica of `AGENT`, and read the snapshot back. */
   async function reconnectHolding(h: ReturnType<typeof buildWsHarness>) {
     const { stub } = h.connect()
-    const saToken = await h.mintCloudDaemon(DAEMON)
+    const saToken = await h.mintPoolMember(DAEMON)
     stub.inject('auth', { serviceAccountToken: saToken, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
     await stub.expectFrame('auth/ok')
     stub.inject(

--- a/packages/control-plane/test/protocol/fencing.test.ts
+++ b/packages/control-plane/test/protocol/fencing.test.ts
@@ -167,7 +167,7 @@ describe('fencing gate — epoch → launchId, typed error REPs', () => {
 })
 
 describe('organization gate', () => {
-  it('stamps an explicit organization on cloud-daemon downlink frames', () => {
+  it('stamps an explicit organization on pool-member downlink frames', () => {
     const { conn, stub } = readyConn({ sessionEpoch: 5 })
     conn.orgId = null
     conn.send('mcpserver/remove', { orgId: 'org-a', name: 'shared-name' }, { epoch: 5 })

--- a/packages/control-plane/test/protocol/organization-knowledge-reads.handler.test.ts
+++ b/packages/control-plane/test/protocol/organization-knowledge-reads.handler.test.ts
@@ -91,7 +91,7 @@ async function seedManagedSkill(): Promise<string> {
 /** An install-wide (frame-mode) member advertising the organization-knowledge surface. */
 async function readyMember(h: ReturnType<typeof buildWsHarness>) {
   const { stub } = h.connect()
-  const saToken = await h.mintCloudDaemon(DAEMON)
+  const saToken = await h.mintPoolMember(DAEMON)
   stub.inject('auth', { serviceAccountToken: saToken, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
   await stub.expectFrame('auth/ok')
   stub.inject(

--- a/packages/control-plane/test/protocol/organization-suggestion-sync.handler.test.ts
+++ b/packages/control-plane/test/protocol/organization-suggestion-sync.handler.test.ts
@@ -43,7 +43,7 @@ async function seedLease(holder: string, agentId: string, expiresAt: Date): Prom
 /** An install-wide (frame-mode) member advertising the organization-knowledge surface. */
 async function readyMember(h: ReturnType<typeof buildWsHarness>) {
   const { stub } = h.connect()
-  const saToken = await h.mintCloudDaemon(DAEMON)
+  const saToken = await h.mintPoolMember(DAEMON)
   stub.inject('auth', { serviceAccountToken: saToken, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
   await stub.expectFrame('auth/ok')
   stub.inject(

--- a/packages/control-plane/test/repo/agent-placement-delegation.test.ts
+++ b/packages/control-plane/test/repo/agent-placement-delegation.test.ts
@@ -249,7 +249,7 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
   })
 
   it('finishes what a daemon delete cascaded, and leaves an agent placed elsewhere alone', async () => {
-    // Retiring a cloud member has to delete FIRST to claim the row atomically, so the FK gets
+    // Retiring a pool member has to delete FIRST to claim the row atomically, so the FK gets
     // there before any repo write: `daemonId` null, `status` untouched. Settling that is
     // conditional, because a placement that landed elsewhere is not the removal's to undo.
     await fixtures()

--- a/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
+++ b/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
@@ -117,13 +117,13 @@ describe('DaemonRepo.resolveClusterIdentity', () => {
     expect(await prisma.daemon.findUnique({ where: { id: laptop } })).toMatchObject({ clusterIdentity: null })
   })
 
-  it('keeps cloud Pods out of owned reads while exposing them to availability reads', async () => {
+  it('keeps pool member Pods out of owned reads while exposing them to availability reads', async () => {
     const repo = new PgDaemonRepo(prisma)
     const other = await prisma.org.create({ data: { slug: 'install-daemon-other-org' } })
 
-    const first = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
-    const samePod = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
-    const secondPod = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_B)
+    const first = await repo.resolvePoolClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    const samePod = await repo.resolvePoolClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    const secondPod = await repo.resolvePoolClusterIdentity(INSTALL_IDENTITY, POD_UID_B)
 
     expect(samePod.id).toBe(first.id)
     expect(secondPod.id).not.toBe(first.id)
@@ -150,17 +150,17 @@ describe('DaemonRepo.resolveClusterIdentity', () => {
   })
 })
 
-describe('DaemonRepo cloud-member retirement', () => {
+describe('DaemonRepo pool-member retirement', () => {
   const HOUR_AGO = new Date(Date.now() - 60 * 60_000)
   const CUTOFF = new Date(Date.now() - 15 * 60_000)
 
-  it('finds only the org-less cloud rows silent past the cutoff', async () => {
+  it('finds only the org-less pool member rows silent past the cutoff', async () => {
     const repo = new PgDaemonRepo(prisma)
-    const gone = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
-    const serving = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_B)
+    const gone = await repo.resolvePoolClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    const serving = await repo.resolvePoolClusterIdentity(INSTALL_IDENTITY, POD_UID_B)
     await prisma.daemon.update({ where: { id: gone.id }, data: { lastSeenAt: HOUR_AGO } })
     await prisma.daemon.update({ where: { id: serving.id }, data: { lastSeenAt: new Date() } })
-    // Neither of these is a cloud member: an envelope daemon is bound to a namespace rather
+    // Neither of these is a pool member: an envelope daemon is bound to a namespace rather
     // than a Pod, and a laptop has no identity at all. Both are long silent regardless.
     const envelope = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
     const laptop = DaemonId('77777777-7777-4777-8777-777777777777')
@@ -169,29 +169,29 @@ describe('DaemonRepo cloud-member retirement', () => {
       await prisma.daemon.update({ where: { id }, data: { lastSeenAt: HOUR_AGO } })
     }
 
-    const retired = await repo.findRetiredCloudMembers(CUTOFF)
+    const retired = await repo.findRetiredPoolMembers(CUTOFF)
 
     expect(retired.map((daemon) => daemon.id)).toEqual([gone.id])
   })
 
   it('judges a member that never heartbeated by its own age', async () => {
     const repo = new PgDaemonRepo(prisma)
-    const fresh = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    const fresh = await repo.resolvePoolClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
 
     // Authenticated and died before its first beat: `lastSeenAt` stays null forever, so a
     // brand-new row must survive the sweep and an old one must not.
-    expect(await repo.findRetiredCloudMembers(CUTOFF)).toEqual([])
+    expect(await repo.findRetiredPoolMembers(CUTOFF)).toEqual([])
     await prisma.daemon.update({ where: { id: fresh.id }, data: { createdAt: HOUR_AGO } })
 
-    expect((await repo.findRetiredCloudMembers(CUTOFF)).map((daemon) => daemon.id)).toEqual([fresh.id])
+    expect((await repo.findRetiredPoolMembers(CUTOFF)).map((daemon) => daemon.id)).toEqual([fresh.id])
   })
 
   it('retires a member and settles its agents in one transaction, refusing anything else', async () => {
     const repo = new PgDaemonRepo(prisma)
-    const pod = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    const pod = await repo.resolvePoolClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
     await prisma.daemon.update({ where: { id: pod.id }, data: { lastSeenAt: HOUR_AGO } })
     // An agent from an ordinary org, hosted on install-wide infrastructure — the shape only a
-    // cloud member has, and the reason the settlement cannot be org-scoped.
+    // pool member has, and the reason the settlement cannot be org-scoped.
     const hosted = AgentId('a9999999-9999-4999-8999-999999999999')
     await seedAgent(prisma, hosted, { daemonId: pod.id })
     await new PgAgentRepo(prisma).setPlacement(hosted, onDaemon(pod.id))
@@ -203,7 +203,7 @@ describe('DaemonRepo cloud-member retirement', () => {
     }
     const fence = { retiredBefore: CUTOFF, sessionEpoch: pod.sessionEpoch }
 
-    expect(await repo.retireCloudMember(pod.id, fence)).toEqual({
+    expect(await repo.retirePoolMember(pod.id, fence)).toEqual({
       deleted: true,
       settled: [{ id: hosted, orgId: DEFAULT_ORG_ID }]
     })
@@ -213,9 +213,9 @@ describe('DaemonRepo cloud-member retirement', () => {
       status: 'inactive'
     })
     // Gone, so a repeat (a peer replica sweeping the same row) is a no-op, not an error.
-    expect(await repo.retireCloudMember(pod.id, fence)).toMatchObject({ deleted: false })
-    expect(await repo.retireCloudMember(envelope!.id, fence)).toMatchObject({ deleted: false })
-    expect(await repo.retireCloudMember(laptop, fence)).toMatchObject({ deleted: false })
+    expect(await repo.retirePoolMember(pod.id, fence)).toMatchObject({ deleted: false })
+    expect(await repo.retirePoolMember(envelope!.id, fence)).toMatchObject({ deleted: false })
+    expect(await repo.retirePoolMember(laptop, fence)).toMatchObject({ deleted: false })
     expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).toBeNull()
     expect(await prisma.daemon.findUnique({ where: { id: envelope!.id } })).not.toBeNull()
     expect(await prisma.daemon.findUnique({ where: { id: laptop } })).not.toBeNull()
@@ -227,7 +227,7 @@ describe('DaemonRepo cloud-member retirement', () => {
     // it exactly the way the reaper stranded agents before placement became a target: nothing
     // re-places an unplaced agent, so it would be permanently offline.
     const repo = new PgDaemonRepo(prisma)
-    const pod = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    const pod = await repo.resolvePoolClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
     await prisma.daemon.update({ where: { id: pod.id }, data: { lastSeenAt: HOUR_AGO } })
     const pooled = AgentId('a8888888-8888-4888-8888-888888888888')
     await seedAgent(prisma, pooled)
@@ -236,7 +236,7 @@ describe('DaemonRepo cloud-member retirement', () => {
       data: { placementKind: 'set', setId: await poolSetId(prisma), daemonId: null, status: 'active' }
     })
 
-    expect(await repo.retireCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: pod.sessionEpoch })).toEqual({
+    expect(await repo.retirePoolMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: pod.sessionEpoch })).toEqual({
       deleted: true,
       settled: []
     })
@@ -249,16 +249,16 @@ describe('DaemonRepo cloud-member retirement', () => {
 
   it('refuses a member that came back between the worklist read and the delete', async () => {
     const repo = new PgDaemonRepo(prisma)
-    const pod = await repo.resolveCloudClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
+    const pod = await repo.resolvePoolClusterIdentity(INSTALL_IDENTITY, POD_UID_A)
     await prisma.daemon.update({ where: { id: pod.id }, data: { lastSeenAt: HOUR_AGO } })
-    const observed = (await repo.findRetiredCloudMembers(CUTOFF))[0]!
+    const observed = (await repo.findRetiredPoolMembers(CUTOFF))[0]!
 
     // Re-auth is the case `lastSeenAt` alone cannot catch: it bumps the epoch atomically,
     // while the clock only moves on the first heartbeat AFTER it.
     await repo.upsertOnAuth({ daemonId: pod.id, orgId: null, agentVersion: '1.0.0' })
 
     expect(
-      await repo.retireCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: observed.sessionEpoch })
+      await repo.retirePoolMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: observed.sessionEpoch })
     ).toMatchObject({ deleted: false })
     expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).not.toBeNull()
 
@@ -266,7 +266,7 @@ describe('DaemonRepo cloud-member retirement', () => {
     await prisma.daemon.update({ where: { id: pod.id }, data: { lastSeenAt: new Date() } })
     const current = await repo.getUnscoped(pod.id)
     expect(
-      await repo.retireCloudMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: current!.sessionEpoch })
+      await repo.retirePoolMember(pod.id, { retiredBefore: CUTOFF, sessionEpoch: current!.sessionEpoch })
     ).toMatchObject({ deleted: false })
     expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).not.toBeNull()
   })

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2471,7 +2471,7 @@ export class Daemon {
       startK8sPlane?: typeof startK8sRuntimePlane
       /** Test seam only; production `--k8s` always reads the fixed Secret mount. */
       openDataPlane?: typeof openMountedPostgresDataPlane
-      /** Test seam for the cloud startup barrier; production waits for CP register/ok. */
+      /** Test seam for the pool member startup barrier; production waits for CP register/ok. */
       startControlPlane?: (root: string) => Promise<void> | undefined
       /** Test seams for local catalog resolution and executable/state filtering. */
       resolveCatalog?: typeof resolveRuntimeCatalog
@@ -3089,7 +3089,7 @@ export class Daemon {
           }
         })()
       : this.k8s
-        ? this.declaredCloudCatalog(root, resolvedCatalog)
+        ? this.declaredPoolCatalog(root, resolvedCatalog)
         : installedRuntimeCatalog(resolvedCatalog)
     const { runtimes: installed, entries: installedEntries } = installedCatalog
     this.runtimeCatalog = installedCatalog
@@ -3589,11 +3589,11 @@ export class Daemon {
     // Install synthetic evaluation integrations before routing observes them; they never open sockets.
     this.installEvaluationEnvironment()
     const startControlPlane = this.opts.startControlPlane ?? ((cpRoot: string) => this.startCpClient(cpRoot))
-    const cloudCpReady = this.k8s ? startControlPlane(root) : undefined
-    if (this.k8s && !cloudCpReady)
+    const poolCpReady = this.k8s ? startControlPlane(root) : undefined
+    if (this.k8s && !poolCpReady)
       throw new Error('daemon startup refused: --k8s requires an authoritative CP organization registry')
-    if (cloudCpReady) this.log.info('data-plane: waiting for the initial CP organization registry before ingress')
-    await cloudCpReady
+    if (poolCpReady) this.log.info('data-plane: waiting for the initial CP organization registry before ingress')
+    await poolCpReady
     if (this.k8s) {
       this.store.recoverPermissionRequests(
         (this.cpAgents?.agents() ?? []).map((agent) => agent.id),
@@ -21397,10 +21397,10 @@ export class Daemon {
       }
       return undefined
     }
-    // A managed cloud daemon's credential is its Kubernetes identity, full stop.
+    // A pool member's credential is its Kubernetes identity, full stop.
     if (this.k8s && !process.env[K8S_ORG_ID_ENV]?.trim() && !this.clusterIdentityToken) {
       this.log.error(
-        `cp: not connecting — a cloud daemon authenticates with its projected identity token, expected at ${CP_IDENTITY_TOKEN_PATH}`
+        `cp: not connecting — a pool member authenticates with its projected identity token, expected at ${CP_IDENTITY_TOKEN_PATH}`
       )
       return
     }
@@ -21443,7 +21443,7 @@ export class Daemon {
       // A forwarded cross-daemon agent-call — terminal-verify + dispatch (P2).
       onRelayAgentMsg: (msg) => this.handleRelayAgentMsg(msg)
     })
-    // Self-hosted daemons boot-dial persisted relays; cloud ingress waits for fresh org authority.
+    // Self-hosted daemons boot-dial persisted relays; pool ingress waits for fresh org authority.
     if (this.cfg.relays.length && !this.k8s) this.relays.converge(this.cfg.relays)
 
     let resolveInitialRegistry!: () => void
@@ -21762,7 +21762,7 @@ export class Daemon {
     }
   }
 
-  private declaredCloudCatalog(root: string, resolved: ResolvedRuntimeCatalog): ResolvedRuntimeCatalog {
+  private declaredPoolCatalog(root: string, resolved: ResolvedRuntimeCatalog): ResolvedRuntimeCatalog {
     // Kept for a file-supplied table (an override, or a daemon started before its first probe
     // returns). The authoritative answer comes from the sandbox itself — see probeK8sRuntimes.
     this.k8sResolvedCatalog = resolved

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -58,7 +58,7 @@ export const PROBE_GRANTS: ShimCapability[] = ['probe']
 
 export interface K8sDriverDeps {
   api: SandboxApi
-  /** Resolves tenant ownership at claim time; cloud daemons serve more than one org. */
+  /** Resolves tenant ownership at claim time; pool members serve more than one org. */
   orgForAgent: (agentId: string) => string | undefined
   /** Pool the claim references; v1beta1 requires one, and a cold pool is `replicas: 0`. */
   warmPoolName: string

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -71,9 +71,9 @@ export async function reapExpiredProbeClaims(
  * daemon's own host and no Sandbox was ever created.
  */
 export interface K8sRuntimePlaneOptions {
-  /** Connection-scoped org for an envelope daemon; absent for an install-wide cloud daemon. */
+  /** Connection-scoped org for an envelope daemon; absent for an install-wide pool member. */
   orgId?: string
-  /** Per-agent tenant lookup used by an install-wide cloud daemon. */
+  /** Per-agent tenant lookup used by an install-wide pool member. */
   orgForAgent?: (agentId: string) => string | undefined
   /** Warm pool the claims reference. v1beta1 requires one; a cold pool is `replicas: 0`. */
   warmPoolName?: string

--- a/packages/daemon/src/store/postgres-sync-database.ts
+++ b/packages/daemon/src/store/postgres-sync-database.ts
@@ -2,7 +2,8 @@ import { MessageChannel, receiveMessageOnPort, Worker } from 'node:worker_thread
 import type { DataPlaneConfig } from './postgres-config.js'
 import type { StoreDatabase, StoreRunResult, StoreStatement } from './local-store.js'
 
-const CLOUD_STORE_SCHEMA = 'agentconnect_cloud_store'
+// Stored schema name — the pool's data lives here, so the literal outlives the vocabulary rename.
+const POOL_STORE_SCHEMA = 'agentconnect_cloud_store'
 
 type WorkerReply = { id: number; ok: true; value?: unknown } | { id: number; ok: false; error: string }
 
@@ -177,7 +178,7 @@ export class PostgresSyncDatabase implements StoreDatabase {
     this.worker = new Worker(new URL('./postgres-store-worker.js', import.meta.url), {
       workerData: {
         databaseUrl: config.databaseUrl,
-        schema: CLOUD_STORE_SCHEMA,
+        schema: POOL_STORE_SCHEMA,
         columnNames,
         replyPort: channel.port2,
         readySignal
@@ -186,10 +187,10 @@ export class PostgresSyncDatabase implements StoreDatabase {
     })
     if (Atomics.wait(readySignal, 0, 0, 30_000) === 'timed-out') {
       void this.worker.terminate()
-      throw new Error('PostgreSQL cloud store startup timed out after 30 seconds')
+      throw new Error('PostgreSQL pool store startup timed out after 30 seconds')
     }
     const ready = this.waitForReply(0)
-    if (!ready.ok) throw new Error(`PostgreSQL cloud store failed to open: ${ready.error}`)
+    if (!ready.ok) throw new Error(`PostgreSQL pool store failed to open: ${ready.error}`)
   }
 
   exec(sql: string): void {
@@ -218,12 +219,12 @@ export class PostgresSyncDatabase implements StoreDatabase {
   }
 
   private request(kind: string, sql: string, params: unknown[]): unknown {
-    if (this.closed) throw new Error('PostgreSQL cloud store is closed')
+    if (this.closed) throw new Error('PostgreSQL pool store is closed')
     const id = this.nextId++
     const signal = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT))
     this.worker.postMessage({ id, kind, sql, params, signal })
     if (Atomics.wait(signal, 0, 0, 30_000) === 'timed-out') {
-      const error = new Error('PostgreSQL cloud store operation timed out after 30 seconds')
+      const error = new Error('PostgreSQL pool store operation timed out after 30 seconds')
       this.onFailure(error)
       throw error
     }

--- a/packages/daemon/src/store/postgres-transcript-store.ts
+++ b/packages/daemon/src/store/postgres-transcript-store.ts
@@ -434,7 +434,7 @@ export class PostgresTranscriptStore {
 export class PostgresDataPlane {
   readonly transcripts: PostgresTranscriptStore
   readonly store: LocalStore
-  /** The org this daemon runs for, as the mount named it — what a cloud daemon's control
+  /** The org this daemon runs for, as the mount named it — what a pool member's control
    *  socket declares, since its Kubernetes identity names no org. */
   readonly orgId?: string
 

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -126,7 +126,7 @@ describe('daemon --k8s mode', () => {
     await expect(k8sDaemon.start()).rejects.toThrow(/data-plane configuration is not readable/)
   })
 
-  it('uses the mounted PostgreSQL store without creating a cloud SQLite database', async () => {
+  it('uses the mounted PostgreSQL store without creating a pool member SQLite database', async () => {
     const rootDir = root()
     const instance = daemon({ root: rootDir, k8s: true })
     try {
@@ -150,7 +150,7 @@ describe('daemon --k8s mode', () => {
     }
   })
 
-  it('waits for the initial CP organization registry before completing cloud startup', async () => {
+  it('waits for the initial CP organization registry before completing pool member startup', async () => {
     let release!: () => void
     const registryReady = new Promise<void>((resolve) => {
       release = resolve
@@ -177,7 +177,7 @@ describe('daemon --k8s mode', () => {
     }
   })
 
-  it('refuses cloud startup when no authoritative CP organization registry is available', async () => {
+  it('refuses pool member startup when no authoritative CP organization registry is available', async () => {
     const instance = daemon({ root: root(), k8s: true, startControlPlane: vi.fn(() => undefined) })
     await expect(instance.start()).rejects.toThrow(/requires an authoritative CP organization registry/)
     await instance.stop()

--- a/packages/daemon/test/postgres-pool-store.int.test.ts
+++ b/packages/daemon/test/postgres-pool-store.int.test.ts
@@ -4,7 +4,7 @@ import { PostgresDataPlane } from '../src/store/postgres-transcript-store.js'
 
 const databaseUrl = process.env.DATA_PLANE_TEST_DATABASE_URL
 
-describe.skipIf(!databaseUrl)('PostgreSQL cloud daemon store', () => {
+describe.skipIf(!databaseUrl)('PostgreSQL pool member store', () => {
   it('persists sessions, transcripts, inbox, outboxes, and caches without SQLite', async () => {
     const suffix = randomUUID()
     const agentId = `agent-${suffix}`

--- a/packages/protocol/src/consts.ts
+++ b/packages/protocol/src/consts.ts
@@ -191,7 +191,7 @@ export const MAX_ENVIRONMENT_VALUE_LENGTH = 64 * 1024
 export const RESERVED_RESTART_CODE = 75
 
 /**
- * `AGENTCONNECT_SUPERVISOR` value a cloud daemon runs under: Kubernetes, where the
+ * `AGENTCONNECT_SUPERVISOR` value a pool member runs under: Kubernetes, where the
  * kubelet takes the place of launchd/systemd AND of the CLI's version store.
  *
  * It supervises restart — `restartPolicy: Always` brings the container back after
@@ -223,7 +223,7 @@ export const CP_TOKEN_AUDIENCE = 'ac-control-plane'
 export const ENVELOPE_DAEMON_SA_NAME = 'ac-daemon'
 
 /**
- * ServiceAccount a cloud daemon runs as. A cloud daemon serves EVERY org, so it lives in the
+ * ServiceAccount a pool member runs as. A pool member serves EVERY org, so it lives in the
  * install's control namespace rather than in an org namespace, and no namespace⇒org mapping
  * can name its org — the org is a per-connection selector it declares in `auth`, which is
  * safe precisely because this ServiceAccount is an install-level principal. The

--- a/packages/protocol/src/frames/auth.ts
+++ b/packages/protocol/src/frames/auth.ts
@@ -49,7 +49,7 @@ export const AuthOk = z.object({
   // own value rather than duplicate it. Optional: an older CP omits it.
   dutyLeaseMs: z.number().int().positive().optional(),
   serverTime: z.string().datetime(),
-  // Single-org daemons inherit tenant context from auth; install-wide cloud daemons require
+  // Single-org daemons inherit tenant context from auth; install-wide pool members require
   // every org-scoped post-auth frame to carry `Envelope.orgId`.
   organizationMode: z.enum(['connection', 'frame']).default('connection'),
   // Base URL of the Web App console (the CP's own public origin), so the daemon can build

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -103,7 +103,7 @@ export const RcVerify = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('daemon-token'),
     credential: z.string().min(1),
-    // The daemonId claimed on `rd/hello`, forwarded unverified. CP binds a cloud token's
+    // The daemonId claimed on `rd/hello`, forwarded unverified. CP binds a pool member token's
     // reviewed Pod UID to one member record and refuses any different claim.
     daemonId: z.string().uuid().optional()
   }),

--- a/packages/relay/src/relay-daemon-connection.ts
+++ b/packages/relay/src/relay-daemon-connection.ts
@@ -220,7 +220,7 @@ export class RelayDaemonConnection {
     }
     let result: RcVerifyResult
     try {
-      // CP verifies the untrusted echoed id against the reviewed cloud Pod UID.
+      // CP verifies the untrusted echoed id against the reviewed pool member Pod UID.
       result = await this.deps.verify(presented.kind, presented.credential, hello.daemonId)
     } catch {
       // Link not READY / CP error → transient; the daemon backs off and retries.

--- a/packages/web/src/components/console/DaemonSelect.test.tsx
+++ b/packages/web/src/components/console/DaemonSelect.test.tsx
@@ -12,17 +12,17 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
 const options: DaemonSelectOption[] = [
   {
-    value: 'cloud-1',
+    value: 'pool-1',
     label: 'AgentConnect Cloud',
     detail: 'Model usage included — no API key needed.',
-    cloud: true
+    pool: true
   },
   { value: 'edge-1', label: 'edge-1', detail: 'Uses the credentials on this machine.' },
   { value: 'edge-2', label: 'edge-2', detail: 'Offline — bring this machine online to use it.', disabled: true }
 ]
 
 function Harness() {
-  const [value, setValue] = useState('cloud-1')
+  const [value, setValue] = useState('pool-1')
   return <DaemonSelect value={value} options={options} onChange={setValue} />
 }
 
@@ -47,7 +47,7 @@ describe('DaemonSelect', () => {
     await act(async () => trigger.click())
     const rows = [...container!.querySelectorAll<HTMLButtonElement>('[role="option"]')]
 
-    expect(rows[0]?.dataset.cloud).toBe('true')
+    expect(rows[0]?.dataset.pool).toBe('true')
     expect(rows[0]?.textContent).toContain('AgentConnect Cloud')
     expect(rows[0]?.textContent).toContain('Model usage included — no API key needed.')
     expect(rows).toHaveLength(3)

--- a/packages/web/src/components/console/DaemonSelect.tsx
+++ b/packages/web/src/components/console/DaemonSelect.tsx
@@ -5,7 +5,7 @@ export interface DaemonSelectOption {
   value: string
   label: string
   detail: string
-  cloud?: boolean
+  pool?: boolean
   disabled?: boolean
 }
 
@@ -127,18 +127,18 @@ export function DaemonSelect({
           {selected && (
             <span
               className={`flex h-6 w-6 flex-none items-center justify-center rounded-md ${
-                selected.cloud ? 'bg-(--brand-soft)' : 'bg-(--surface-sunken)'
+                selected.pool ? 'bg-(--brand-soft)' : 'bg-(--surface-sunken)'
               }`}
             >
               <Icon
-                name={selected.cloud ? 'cloud' : selected.value ? 'server' : 'server-off'}
+                name={selected.pool ? 'cloud' : selected.value ? 'server' : 'server-off'}
                 size={14}
-                color={selected.cloud ? 'var(--brand)' : 'var(--text-tertiary)'}
+                color={selected.pool ? 'var(--brand)' : 'var(--text-tertiary)'}
               />
             </span>
           )}
           <span className="truncate">{selected?.label ?? placeholder}</span>
-          {selected?.cloud && (
+          {selected?.pool && (
             <span className="flex-none rounded-full bg-(--brand-soft) px-[7px] py-[2px] font-sans text-[10.5px] font-semibold leading-normal text-(--brand-soft-text)">
               Cloud
             </span>
@@ -169,7 +169,7 @@ export function DaemonSelect({
               const isActive = index === activeIndex
               return (
                 <button
-                  key={`${option.cloud ? 'cloud' : 'daemon'}:${option.value}`}
+                  key={`${option.pool ? 'cloud' : 'daemon'}:${option.value}`}
                   id={`${listboxId}-option-${index}`}
                   type="button"
                   role="option"
@@ -177,7 +177,7 @@ export function DaemonSelect({
                   aria-selected={isSelected}
                   aria-disabled={option.disabled || undefined}
                   disabled={option.disabled}
-                  data-cloud={option.cloud || undefined}
+                  data-pool={option.pool || undefined}
                   className={`fopt min-h-[58px] gap-[10px] rounded-md px-2 py-[7px] text-[13px] ${
                     option.disabled
                       ? 'cursor-not-allowed text-(--text-disabled) opacity-65'
@@ -195,19 +195,19 @@ export function DaemonSelect({
                   </span>
                   <span
                     className={`flex h-8 w-8 flex-none items-center justify-center rounded-md ${
-                      option.cloud ? 'bg-(--brand-soft)' : 'bg-(--surface-sunken)'
+                      option.pool ? 'bg-(--brand-soft)' : 'bg-(--surface-sunken)'
                     }`}
                   >
                     <Icon
-                      name={option.cloud ? 'cloud' : option.value ? 'server' : 'server-off'}
+                      name={option.pool ? 'cloud' : option.value ? 'server' : 'server-off'}
                       size={16}
-                      color={option.cloud ? 'var(--brand)' : 'var(--text-tertiary)'}
+                      color={option.pool ? 'var(--brand)' : 'var(--text-tertiary)'}
                     />
                   </span>
                   <span className="min-w-0 flex-1">
                     <span className="flex items-center gap-2 font-sans text-[13px] font-semibold leading-normal">
                       <span className="truncate">{option.label}</span>
-                      {option.cloud && (
+                      {option.pool && (
                         <span className="flex-none rounded-full bg-(--brand-soft) px-[7px] py-[2px] font-sans text-[10.5px] font-semibold leading-normal text-(--brand-soft-text)">
                           Cloud
                         </span>

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -8,7 +8,7 @@ import { useProfile } from '@/lib/profile'
 import { useOrgs } from '@/lib/org-context'
 import {
   FALLBACK_RUNTIME_IDS,
-  CLOUD_DAEMON_LABEL,
+  POOL_LABEL,
   approvalsReviewerDefault,
   loginRequiredRuntimeIds,
   agentSlugFinalize,
@@ -337,15 +337,15 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
 
   // Cloud is one UI choice AND one server-side placement: the pool, named as itself.
   const daemonChoice = addAgentDaemonChoice(daemons, daemonId)
-  const { cloudAvailable, daemon, localDaemons, placement, value: effectiveDaemonId } = daemonChoice
+  const { poolAvailable, daemon, localDaemons, placement, value: effectiveDaemonId } = daemonChoice
   const daemonOptions: DaemonSelectOption[] = [
-    ...(cloudAvailable
+    ...(poolAvailable
       ? [
           {
             value: '',
-            label: CLOUD_DAEMON_LABEL,
+            label: POOL_LABEL,
             detail: 'Model usage included — no API key needed.',
-            cloud: true
+            pool: true
           }
         ]
       : []),

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -23,9 +23,9 @@ import {
   selectedPermissionPreset,
   supportsModes,
   agentLabel,
-  CLOUD_DAEMON_LABEL,
-  CLOUD_PLACEMENT,
-  isCloudPlacementKind,
+  POOL_LABEL,
+  POOL_PLACEMENT,
+  isPoolPlacementKind,
   placementValueOf,
   type Agent,
   type AgentCallPolicy,
@@ -235,7 +235,7 @@ export default function EditAgentModal({
   useEffect(() => {
     if (!loaded || autofilledDaemon.current || initialDaemonId.current || daemonId) return
     const ready = (d: (typeof daemons)[number]) => d.status === 'online' && d.caps.features.includes('agent-move-v1')
-    const target = daemons.find((d) => d.cloud && ready(d)) ?? daemons.find(ready)
+    const target = daemons.find((d) => d.pool && ready(d)) ?? daemons.find(ready)
     if (target) {
       autofilledDaemon.current = true
       setDaemonId(target.daemonId)
@@ -314,25 +314,25 @@ export default function EditAgentModal({
   const moveReady = (d: (typeof daemons)[number] | undefined) =>
     !!d && d.status === 'online' && d.caps.features.includes('agent-move-v1')
   const daemonChoices = editAgentDaemonChoices(daemons, daemonId, initialDaemonId.current)
-  const cloudServing = daemons.some((candidate) => candidate.cloud && moveReady(candidate))
+  const poolServing = daemons.some((candidate) => candidate.pool && moveReady(candidate))
   const daemonOptions: DaemonSelectOption[] = [
-    ...(daemonChoices.cloudChoice || isCloudPlacementKind(agent.placementKind)
+    ...(daemonChoices.poolChoice || isPoolPlacementKind(agent.placementKind)
       ? [
           {
             // The POOL, named as itself. The server picks the member — and re-picks it after every
             // rollout, which is the whole reason this stopped being a member id.
-            value: CLOUD_PLACEMENT,
-            label: CLOUD_DAEMON_LABEL,
-            detail: cloudServing ? 'Model usage included — no API key needed.' : 'Cloud is currently unavailable.',
-            cloud: true,
-            disabled: initialDaemonId.current !== CLOUD_PLACEMENT && !cloudServing
+            value: POOL_PLACEMENT,
+            label: POOL_LABEL,
+            detail: poolServing ? 'Model usage included — no API key needed.' : 'Cloud is currently unavailable.',
+            pool: true,
+            disabled: initialDaemonId.current !== POOL_PLACEMENT && !poolServing
           }
         ]
       : []),
-    ...(daemonChoices.currentCloudChoice
+    ...(daemonChoices.currentPoolChoice
       ? [
           {
-            value: daemonChoices.currentCloudChoice.daemonId,
+            value: daemonChoices.currentPoolChoice.daemonId,
             label: 'Current placement',
             detail: 'Currently on an unavailable Cloud node — select Cloud above to recover.'
           }
@@ -524,10 +524,10 @@ export default function EditAgentModal({
         return
       }
       // The pool is a target, not a member: ready when any live member could serve.
-      const targetReady = daemonId === CLOUD_PLACEMENT ? cloudServing : moveReady(daemon)
+      const targetReady = daemonId === POOL_PLACEMENT ? poolServing : moveReady(daemon)
       if (!targetReady) {
         setErr(
-          daemonId === CLOUD_PLACEMENT
+          daemonId === POOL_PLACEMENT
             ? 'Cloud has no online member right now; try again shortly.'
             : 'Choose an online daemon that supports agent moves.'
         )
@@ -543,7 +543,7 @@ export default function EditAgentModal({
       }
       if (runtimeUnavailable) {
         setErr(
-          `${daemon?.name ?? CLOUD_DAEMON_LABEL} does not advertise the ${runtimeLabel(runtime, runtimeMeta?.name)} runtime.`
+          `${daemon?.name ?? POOL_LABEL} does not advertise the ${runtimeLabel(runtime, runtimeMeta?.name)} runtime.`
         )
         return
       }
@@ -551,9 +551,7 @@ export default function EditAgentModal({
         // Reachable only when the target DOES advertise models (see
         // `modelUnavailable`), so the picker always has a real id to point at —
         // never a synthesized "Default" the runtime does not offer.
-        setErr(
-          `${daemon?.name ?? CLOUD_DAEMON_LABEL} does not advertise model “${selectedModel}”. Choose one of its models.`
-        )
+        setErr(`${daemon?.name ?? POOL_LABEL} does not advertise model “${selectedModel}”. Choose one of its models.`)
         return
       }
     }
@@ -587,7 +585,7 @@ export default function EditAgentModal({
         await saveAgentCallPolicy(agent.id, body)
       }
       if (placementRequested) {
-        const target = daemonId === CLOUD_PLACEMENT ? { kind: 'pool' as const } : { kind: 'daemon' as const, daemonId }
+        const target = daemonId === POOL_PLACEMENT ? { kind: 'pool' as const } : { kind: 'daemon' as const, daemonId }
         await moveAgent(agent.id, target, forceMove ? { force: true } : undefined)
       }
       // Sharing uses canManageSharing and may intentionally remove this editor's

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { addAgentDaemonChoice } from './add-agent-daemon-choice'
 
 type Row = {
-  cloud: boolean
+  pool: boolean
   daemonId: string
   status: 'online' | 'offline'
 }
 
-const row = (daemonId: string, cloud = false, status: Row['status'] = 'online'): Row => ({
-  cloud,
+const row = (daemonId: string, pool = false, status: Row['status'] = 'online'): Row => ({
+  pool,
   daemonId,
   status
 })
@@ -16,21 +16,21 @@ const row = (daemonId: string, cloud = false, status: Row['status'] = 'online'):
 describe('addAgentDaemonChoice', () => {
   it('collapses frame-scoped members into one Cloud choice that places on the POOL', () => {
     const choice = addAgentDaemonChoice(
-      [row('cloud-stale', true, 'offline'), row('local-1'), row('cloud-serving', true)],
+      [row('pool-stale', true, 'offline'), row('local-1'), row('pool-serving', true)],
       ''
     )
 
-    expect(choice.cloudAvailable).toBe(true)
+    expect(choice.poolAvailable).toBe(true)
     expect(choice.value).toBe('')
     expect(choice.daemonId).toBeNull()
-    expect(choice.daemon?.daemonId).toBe('cloud-serving')
+    expect(choice.daemon?.daemonId).toBe('pool-serving')
     // The pool, not one of its members: a member id here is what a rollout invalidates.
     expect(choice.placement).toEqual({ kind: 'pool' })
     expect(choice.localDaemons.map((daemon) => daemon.daemonId)).toEqual(['local-1'])
   })
 
   it('keeps an explicitly selected local daemon when Cloud is available', () => {
-    const choice = addAgentDaemonChoice([row('cloud-1', true), row('local-1')], 'local-1')
+    const choice = addAgentDaemonChoice([row('pool-1', true), row('local-1')], 'local-1')
 
     expect(choice.value).toBe('local-1')
     expect(choice.daemonId).toBe('local-1')
@@ -41,7 +41,7 @@ describe('addAgentDaemonChoice', () => {
   it('requires and defaults to a local daemon when Cloud is unavailable', () => {
     const choice = addAgentDaemonChoice([row('local-offline', false, 'offline'), row('local-online')], '')
 
-    expect(choice.cloudAvailable).toBe(false)
+    expect(choice.poolAvailable).toBe(false)
     expect(choice.value).toBe('local-online')
     expect(choice.daemonId).toBe('local-online')
     expect(choice.daemon?.daemonId).toBe('local-online')
@@ -49,16 +49,16 @@ describe('addAgentDaemonChoice', () => {
   })
 
   it('falls back to a local daemon when no Cloud member is serving', () => {
-    const choice = addAgentDaemonChoice([row('cloud-offline', true, 'offline'), row('local-online')], '')
+    const choice = addAgentDaemonChoice([row('pool-offline', true, 'offline'), row('local-online')], '')
 
-    expect(choice.cloudAvailable).toBe(false)
+    expect(choice.poolAvailable).toBe(false)
     expect(choice.value).toBe('local-online')
     expect(choice.placement).toEqual({ kind: 'daemon', daemonId: 'local-online' })
   })
 
   it('has no valid choice when neither Cloud nor a local daemon exists', () => {
     expect(addAgentDaemonChoice([], '')).toMatchObject({
-      cloudAvailable: false,
+      poolAvailable: false,
       daemon: undefined,
       daemonId: null,
       localDaemons: [],

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
@@ -1,9 +1,9 @@
 import type { DaemonRow } from '@/lib/data'
 
-type DaemonChoiceRow = Pick<DaemonRow, 'cloud' | 'daemonId' | 'status'>
+type DaemonChoiceRow = Pick<DaemonRow, 'pool' | 'daemonId' | 'status'>
 
 export interface AddAgentDaemonChoice<T extends DaemonChoiceRow> {
-  cloudAvailable: boolean
+  poolAvailable: boolean
   daemon: T | undefined
   daemonId: string | null
   localDaemons: T[]
@@ -20,14 +20,14 @@ export function addAgentDaemonChoice<T extends DaemonChoiceRow>(
   daemons: T[],
   selectedDaemonId: string
 ): AddAgentDaemonChoice<T> {
-  const cloudDaemons = daemons.filter((daemon) => daemon.cloud && daemon.status === 'online')
-  const localDaemons = onlineFirst(daemons.filter((daemon) => !daemon.cloud))
+  const poolDaemons = daemons.filter((daemon) => daemon.pool && daemon.status === 'online')
+  const localDaemons = onlineFirst(daemons.filter((daemon) => !daemon.pool))
   const selectedLocal = localDaemons.find((daemon) => daemon.daemonId === selectedDaemonId)
-  const value = selectedLocal?.daemonId ?? (cloudDaemons.length > 0 ? '' : (localDaemons[0]?.daemonId ?? ''))
-  const daemon = value ? localDaemons.find((candidate) => candidate.daemonId === value) : cloudDaemons[0]
+  const value = selectedLocal?.daemonId ?? (poolDaemons.length > 0 ? '' : (localDaemons[0]?.daemonId ?? ''))
+  const daemon = value ? localDaemons.find((candidate) => candidate.daemonId === value) : poolDaemons[0]
 
   return {
-    cloudAvailable: cloudDaemons.length > 0,
+    poolAvailable: poolDaemons.length > 0,
     daemon,
     daemonId: value || null,
     localDaemons,
@@ -35,7 +35,7 @@ export function addAgentDaemonChoice<T extends DaemonChoiceRow>(
       ? daemon
         ? { kind: 'daemon', daemonId: daemon.daemonId }
         : null
-      : cloudDaemons.length > 0
+      : poolDaemons.length > 0
         ? { kind: 'pool' }
         : null,
     value

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
@@ -3,14 +3,14 @@ import { editAgentDaemonChoices } from './edit-agent-daemon-choice'
 
 type Row = {
   caps: { features: string[] }
-  cloud: boolean
+  pool: boolean
   daemonId: string
   status: 'online' | 'offline'
 }
 
-const row = (daemonId: string, cloud = false, status: Row['status'] = 'online', movable = true): Row => ({
+const row = (daemonId: string, pool = false, status: Row['status'] = 'online', movable = true): Row => ({
   caps: { features: movable ? ['agent-move-v1'] : [] },
-  cloud,
+  pool,
   daemonId,
   status
 })
@@ -18,47 +18,47 @@ const row = (daemonId: string, cloud = false, status: Row['status'] = 'online', 
 describe('editAgentDaemonChoices', () => {
   it('collapses every Cloud member into one first choice', () => {
     const choices = editAgentDaemonChoices(
-      [row('local-1'), row('cloud-1', true), row('cloud-2', true), row('cloud-3', true), row('local-2')],
+      [row('local-1'), row('pool-1', true), row('pool-2', true), row('pool-3', true), row('local-2')],
       'local-1',
       'local-1'
     )
 
-    expect(choices.cloudChoice?.daemonId).toBe('cloud-1')
-    expect(choices.currentCloudChoice).toBeUndefined()
+    expect(choices.poolChoice?.daemonId).toBe('pool-1')
+    expect(choices.currentPoolChoice).toBeUndefined()
     expect(choices.localChoices.map((choice) => choice.daemonId)).toEqual(['local-1', 'local-2'])
   })
 
   it('keeps the selected Cloud member as the concrete placement target', () => {
     const choices = editAgentDaemonChoices(
-      [row('cloud-offline', true, 'offline'), row('cloud-serving', true), row('local-1')],
-      'cloud-serving',
+      [row('pool-offline', true, 'offline'), row('pool-serving', true), row('local-1')],
+      'pool-serving',
       'local-1'
     )
 
-    expect(choices.cloudChoice?.daemonId).toBe('cloud-serving')
-    expect(choices.currentCloudChoice).toBeUndefined()
+    expect(choices.poolChoice?.daemonId).toBe('pool-serving')
+    expect(choices.currentPoolChoice).toBeUndefined()
   })
 
   it('keeps an unavailable Cloud source as an explicit cancellation choice', () => {
     const choices = editAgentDaemonChoices(
-      [row('cloud-source', true, 'offline'), row('cloud-serving', true), row('local-1')],
+      [row('pool-source', true, 'offline'), row('pool-serving', true), row('local-1')],
       'local-1',
-      'cloud-source'
+      'pool-source'
     )
 
-    expect(choices.cloudChoice?.daemonId).toBe('cloud-serving')
-    expect(choices.currentCloudChoice?.daemonId).toBe('cloud-source')
+    expect(choices.poolChoice?.daemonId).toBe('pool-serving')
+    expect(choices.currentPoolChoice?.daemonId).toBe('pool-source')
   })
 
   it('offers a healthy Cloud sibling when the current Cloud placement is unavailable', () => {
     const choices = editAgentDaemonChoices(
-      [row('cloud-source', true, 'offline'), row('cloud-serving', true), row('local-1')],
-      'cloud-source',
-      'cloud-source'
+      [row('pool-source', true, 'offline'), row('pool-serving', true), row('local-1')],
+      'pool-source',
+      'pool-source'
     )
 
-    expect(choices.cloudChoice?.daemonId).toBe('cloud-serving')
-    expect(choices.currentCloudChoice?.daemonId).toBe('cloud-source')
+    expect(choices.poolChoice?.daemonId).toBe('pool-serving')
+    expect(choices.currentPoolChoice?.daemonId).toBe('pool-source')
   })
 
   it('puts move-ready local daemons before unavailable local daemons', () => {
@@ -68,7 +68,7 @@ describe('editAgentDaemonChoices', () => {
       'local-offline'
     )
 
-    expect(choices.cloudChoice).toBeUndefined()
+    expect(choices.poolChoice).toBeUndefined()
     expect(choices.localChoices.map((choice) => choice.daemonId)).toEqual(['local-ready', 'local-offline', 'local-old'])
   })
 })

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
@@ -1,6 +1,6 @@
 import type { DaemonRow } from '@/lib/data'
 
-type DaemonChoiceRow = Pick<DaemonRow, 'cloud' | 'daemonId' | 'status'> & {
+type DaemonChoiceRow = Pick<DaemonRow, 'pool' | 'daemonId' | 'status'> & {
   caps: Pick<DaemonRow['caps'], 'features'>
 }
 
@@ -8,8 +8,8 @@ const moveReady = (daemon: DaemonChoiceRow): boolean =>
   daemon.status === 'online' && daemon.caps.features.includes('agent-move-v1')
 
 export interface EditAgentDaemonChoices<T extends DaemonChoiceRow> {
-  cloudChoice: T | undefined
-  currentCloudChoice: T | undefined
+  poolChoice: T | undefined
+  currentPoolChoice: T | undefined
   localChoices: T[]
 }
 
@@ -20,24 +20,24 @@ export function editAgentDaemonChoices<T extends DaemonChoiceRow>(
 ): EditAgentDaemonChoices<T> {
   const selected = daemons.find((daemon) => daemon.daemonId === selectedDaemonId)
   const initial = daemons.find((daemon) => daemon.daemonId === initialDaemonId)
-  const cloudMembers = daemons.filter((daemon) => daemon.cloud)
+  const poolMembers = daemons.filter((daemon) => daemon.pool)
   const recoveryTarget =
-    initial?.cloud && !moveReady(initial)
-      ? cloudMembers.find((daemon) => daemon.daemonId !== initial.daemonId && moveReady(daemon))
+    initial?.pool && !moveReady(initial)
+      ? poolMembers.find((daemon) => daemon.daemonId !== initial.daemonId && moveReady(daemon))
       : undefined
-  const cloudChoice =
-    (selected?.cloud && selected.daemonId !== initialDaemonId && moveReady(selected) ? selected : undefined) ??
+  const poolChoice =
+    (selected?.pool && selected.daemonId !== initialDaemonId && moveReady(selected) ? selected : undefined) ??
     recoveryTarget ??
-    (selected?.cloud ? selected : undefined) ??
-    (initial?.cloud ? initial : undefined) ??
-    cloudMembers.find(moveReady) ??
-    cloudMembers[0]
-  const localChoices = daemons.filter((daemon) => !daemon.cloud)
+    (selected?.pool ? selected : undefined) ??
+    (initial?.pool ? initial : undefined) ??
+    poolMembers.find(moveReady) ??
+    poolMembers[0]
+  const localChoices = daemons.filter((daemon) => !daemon.pool)
   localChoices.sort((a, b) => Number(moveReady(b)) - Number(moveReady(a)))
   return {
-    cloudChoice,
-    currentCloudChoice:
-      initial?.cloud && cloudChoice?.daemonId !== initial.daemonId && recoveryTarget ? initial : undefined,
+    poolChoice,
+    currentPoolChoice:
+      initial?.pool && poolChoice?.daemonId !== initial.daemonId && recoveryTarget ? initial : undefined,
     localChoices
   }
 }

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -533,7 +533,7 @@ export default function DaemonDetailView() {
             </span>
           </div>
         </div>
-        {/* No menu at all when the caller may do none of it (a cloud member is nobody's to
+        {/* No menu at all when the caller may do none of it (a pool member is nobody's to
             edit, restart or detach) — an empty popover is worse than a missing button. */}
         <div className={daemon.canEdit || canRestart ? 'relative flex-none' : 'hidden'}>
           <button className="iconbtn" onClick={() => setMenuOpen((v) => !v)} title="Daemon actions">

--- a/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 /**
- * A cloud member is a Pod: the pool rolls, every replacement mints another daemon row, and
+ * A pool member is a Pod: the pool rolls, every replacement mints another daemon row, and
  * all of them are visible to every org. Listed one card each, a healthy 3-replica deployment
  * read as a dozen look-alike "daemons" nobody could rename, restart or delete. The page
  * therefore shows the pool as ONE entry — and the machines someone actually connected as
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mocks.push }) }))
 vi.mock('@/lib/org-context', () => ({
-  useOrgs: () => ({ activeOrg: { id: 'org-cloud' }, myRole: 'viewer', orgPath: (p: string) => `/acme${p}` })
+  useOrgs: () => ({ activeOrg: { id: 'org-pool' }, myRole: 'viewer', orgPath: (p: string) => `/acme${p}` })
 }))
 vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({
@@ -37,7 +37,7 @@ const DaemonsView = (await import('./DaemonsView')).default
 function daemon(over: Partial<DaemonRow>): DaemonRow {
   return {
     daemonId: 'd',
-    cloud: false,
+    pool: false,
     name: 'edge-1',
     version: '1.41.0',
     latestVersion: '1.41.0',
@@ -70,12 +70,12 @@ function daemon(over: Partial<DaemonRow>): DaemonRow {
   } as DaemonRow
 }
 
-/** A cloud member as the CP reports it: org-less, named after its Pod. `daemonFromDto`
+/** A pool member as the CP reports it: org-less, named after its Pod. `daemonFromDto`
  *  relabels it, which is why the pod name lives in `host` alone. */
 const member = (id: string, over: Partial<DaemonRow> = {}): DaemonRow =>
-  daemon({ daemonId: id, cloud: true, name: 'AgentConnect Cloud', host: `cloud-daemon-${id}`, ...over })
+  daemon({ daemonId: id, pool: true, name: 'AgentConnect Cloud', host: `pool-member-${id}`, ...over })
 
-const onCloud = (id: string, daemonId: string): Agent => ({ id, daemon: daemonId }) as Agent
+const onPool = (id: string, daemonId: string): Agent => ({ id, daemon: daemonId }) as Agent
 
 function render(): string {
   const host = document.createElement('div')
@@ -96,7 +96,7 @@ beforeEach(() => {
   mocks.push.mockClear()
 })
 
-describe('DaemonsView cloud pool', () => {
+describe('DaemonsView pool', () => {
   it('shows one Cloud entry for the whole pool, however many Pods are in it', () => {
     mocks.daemons = [member('p1'), member('p2'), member('p3', { status: 'offline' })]
 
@@ -106,12 +106,12 @@ describe('DaemonsView cloud pool', () => {
     // Serving nodes only: a row left behind by a replaced Pod must not inflate the count.
     expect(html).toContain('2 nodes')
     // Pod identity is cluster churn — never a name this page puts in front of anyone.
-    expect(html).not.toContain('cloud-daemon-p1')
+    expect(html).not.toContain('pool-member-p1')
   })
 
   it('counts the agents across every member, not just the one it links to', () => {
     mocks.daemons = [member('p1'), member('p2')]
-    mocks.agents = [onCloud('a1', 'p1'), onCloud('a2', 'p2'), onCloud('a3', 'p2')]
+    mocks.agents = [onPool('a1', 'p1'), onPool('a2', 'p2'), onPool('a3', 'p2')]
 
     const html = render()
 

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { CLOUD_DAEMON_LABEL, cloudFleetStatus, presentedDaemonStatus, status, type DaemonRow } from '@/lib/data'
+import { POOL_LABEL, poolFleetStatus, presentedDaemonStatus, status, type DaemonRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useModal } from '@/components/console/ModalProvider'
 import { RestrictedLock } from '@/components/console/VisibilityField'
@@ -23,20 +23,20 @@ export default function DaemonsView() {
     return map
   }, [agents])
 
-  // The cloud pool is ONE entry, not one card per Pod: its members are install-wide
+  // The pool is ONE entry, not one card per Pod: its members are install-wide
   // infrastructure every org sees, replaced without notice, and nothing here is the
   // org's to rename or detach. Everything else is a machine someone connected.
-  const cloudMembers = useMemo(() => daemons.filter((d) => d.cloud), [daemons])
-  const ownDaemons = useMemo(() => daemons.filter((d) => !d.cloud), [daemons])
-  const cloudAgents = useMemo(() => {
-    const memberIds = new Set(cloudMembers.map((m) => m.daemonId))
+  const poolMembers = useMemo(() => daemons.filter((d) => d.pool), [daemons])
+  const ownDaemons = useMemo(() => daemons.filter((d) => !d.pool), [daemons])
+  const poolAgents = useMemo(() => {
+    const memberIds = new Set(poolMembers.map((m) => m.daemonId))
     return agents.filter((a) => memberIds.has(a.daemon)).length
-  }, [agents, cloudMembers])
+  }, [agents, poolMembers])
 
   // Fleet summary for the mobile-only strip below — counted over what the page SHOWS,
   // so the pool contributes one entry rather than one per member.
   const shownStatuses = [
-    ...(cloudMembers.length > 0 ? [cloudFleetStatus(cloudMembers)] : []),
+    ...(poolMembers.length > 0 ? [poolFleetStatus(poolMembers)] : []),
     ...ownDaemons.map((d) => d.status)
   ]
   const online = shownStatuses.filter((s) => s === 'online').length
@@ -86,12 +86,12 @@ export default function DaemonsView() {
               {paused} paused
             </span>
           </div>
-          {cloudMembers.length > 0 && <CloudFleetCard members={cloudMembers} hosted={cloudAgents} />}
+          {poolMembers.length > 0 && <PoolFleetCard members={poolMembers} hosted={poolAgents} />}
           {ownDaemons.length > 0 && (
             <>
               {/* The section label earns its place only next to the Cloud entry — without
                   one there is nothing to tell these cards apart from. */}
-              {cloudMembers.length > 0 && (
+              {poolMembers.length > 0 && (
                 <div className="mt-6 mb-[9px] flex min-h-[26px] items-center gap-[9px]">
                   <span className="font-sans text-[13px] font-semibold leading-normal">Daemons</span>
                   <span className="mono text-[11.5px] text-(--text-tertiary)">{ownDaemons.length}</span>
@@ -111,7 +111,7 @@ export default function DaemonsView() {
 }
 
 /**
- * The whole cloud pool as one entry (design: the Infra screen's `cloudSlot`).
+ * The whole pool as one entry (design: the Infra screen's `cloudSlot`).
  *
  * Deliberately nothing per-member: a member is a Pod, so its name, host, CPU and memory
  * are cluster churn no reader outside the cluster can act on, and a card each turned a
@@ -121,10 +121,10 @@ export default function DaemonsView() {
  * No utilization bar and no "Manage": the design's are a billing plan's included-usage and
  * upgrade path, and inventing either from load telemetry would read as a real quota.
  */
-function CloudFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: number }) {
+function PoolFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: number }) {
   const { orgPath } = useOrgs()
   const router = useRouter()
-  const s = status(cloudFleetStatus(members))
+  const s = status(poolFleetStatus(members))
   const serving = members.filter((m) => m.status === 'online')
   const online = serving.length > 0
   // The serving members share a release (they roll together); an idle pool has no version
@@ -152,7 +152,7 @@ function CloudFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: num
       <div className="flex min-w-0 flex-1 flex-col gap-[2px] desktop:gap-0">
         <div className="flex min-w-0 items-center gap-[6px] desktop:gap-2">
           <span className="truncate font-sans text-[14px] font-semibold leading-normal desktop:text-[13.5px]">
-            {CLOUD_DAEMON_LABEL}
+            {POOL_LABEL}
           </span>
           <span className="dot hidden flex-none desktop:inline-block" style={{ background: s.dot }} />
         </div>

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -106,7 +106,7 @@ export default function OnboardingView() {
     setSaveErr(null)
     try {
       await updateAgent(builtinAgent.id, { runtime, ...(model ? { model } : {}) })
-      // Onboarding places onto a concrete machine; the cloud pool is chosen from the agent editor.
+      // Onboarding places onto a concrete machine; the pool is chosen from the agent editor.
       await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: placementDaemon.daemonId })
       await refresh()
     } catch (e) {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -16,7 +16,7 @@ import type {
   Workspace,
   PlacementKindValue
 } from '@/lib/data'
-import { CLOUD_DAEMON_LABEL, isSelfSender, lifecycleStatus, MOCK_MODE, placementValueOf } from '@/lib/data'
+import { POOL_LABEL, isSelfSender, lifecycleStatus, MOCK_MODE, placementValueOf } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
 import {
@@ -1043,8 +1043,8 @@ export interface DaemonViewDto {
    *  `status` is expiry-projected server-side. The console tracks its OWN command by `id`. */
   lifecycleOp: DaemonLifecycleOpDto | null
   status: string
-  /** An install-wide cloud member — managed infrastructure shared by every org, one row
-   *  per cloud-daemon Pod. Absent from an older CP ⇒ treat as a plain daemon. */
+  /** An install-wide pool member — managed infrastructure shared by every org, one row
+   *  per pool member Pod. Absent from an older CP ⇒ treat as a plain daemon. */
   cloud?: boolean
   health: string
   capabilities: DaemonCapabilitiesDto
@@ -1085,7 +1085,7 @@ export interface DaemonLifecycleOpDto {
 }
 
 export interface CreateAgentInput {
-  /** `pool` is the API sugar for the cloud member set; the CP resolves it and stores `set`. */
+  /** `pool` is the API sugar for the pool member set; the CP resolves it and stores `set`. */
   placementKind?: 'pool'
   name: string // slug — the CP rejects anything but ^[a-z0-9]+(-[a-z0-9]+)*$
   displayName?: string
@@ -2043,16 +2043,17 @@ export function mergeSessionDetailUsage(local: Session, detail: Session | null):
 }
 
 export function daemonFromDto(d: DaemonViewDto): DaemonRow {
-  const cloud = d.cloud ?? false
+  // `cloud` is the CP DTO's field name (a REST contract); the console's own word is `pool`.
+  const pool = d.cloud ?? false
   return {
     daemonId: d.daemonId,
-    cloud,
+    pool,
     // Display label: the daemon name (the CP seeds it from the hostname on first
     // register, so a connected daemon always has one), else a short id for a
-    // provisioned-but-never-connected row. Never the raw hostname. A cloud member's
+    // provisioned-but-never-connected row. Never the raw hostname. A pool member's
     // name is its Pod, which is meaningless outside the cluster and changes on every
     // roll — the pool is one managed thing everywhere it is named, so use that label.
-    name: cloud ? CLOUD_DAEMON_LABEL : d.name || d.daemonId.slice(0, 8),
+    name: pool ? POOL_LABEL : d.name || d.daemonId.slice(0, 8),
     version: d.agentVersion || PLACEHOLDER,
     latestVersion: d.latestVersion,
     releaseChannel: d.releaseChannel,
@@ -3426,7 +3427,7 @@ export async function setAgentWorkspace(agentId: string, input: SetAgentWorkspac
 // acknowledged source fence/cancel and destination activation; `force` is the
 // explicit recovery path when the source cannot ACK. This stays separate from
 // the ordinary spec PATCH because placement changes have runtime side effects.
-/** A move target: one machine, or the cloud member set as a whole (submitted as the `pool` sugar). */
+/** A move target: one machine, or the pool member set as a whole (submitted as the `pool` sugar). */
 export type AgentPlacementTarget = { kind: 'daemon'; daemonId: string } | { kind: 'pool' }
 
 export async function moveAgent(

--- a/packages/web/src/lib/daemon-notifications.test.tsx
+++ b/packages/web/src/lib/daemon-notifications.test.tsx
@@ -37,7 +37,7 @@ const mockDaemon = (id: string, name: string, op?: DaemonRow['lifecycleOp']): Da
   lifecycleOp: op ?? null,
   canManageLifecycle: true,
   status: 'online',
-  cloud: false,
+  pool: false,
   lifecycleStatus: null,
   host: 'localhost',
   cpu: 10,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -55,20 +55,20 @@ export function presentedDaemonStatus(daemon: Pick<DaemonRow, 'status' | 'lifecy
   return daemon.lifecycleStatus ?? daemon.status
 }
 
-/** What every surface calls an install-wide cloud member. The CP names those rows after the
+/** What every surface calls an install-wide pool member. The CP names those rows after the
  *  Pod they run in, which is churn nobody outside the cluster should read: the pool is one
  *  managed thing, so `daemonFromDto` labels each member with this instead. */
-export const CLOUD_DAEMON_LABEL = 'AgentConnect Cloud'
+export const POOL_LABEL = 'AgentConnect Cloud'
 /** `Agent.daemon` for a pool placement. It names the POOL, never a member: no member id survives
  *  a rollout, which is precisely why the placement stopped carrying one. */
-export const CLOUD_PLACEMENT = 'cloud'
+export const POOL_PLACEMENT = 'pool'
 
 /** What a placement NAMES. The CP stores and emits `set` (daemon-groups.md §2); `pool` stays
  *  accepted API sugar on the way IN, so the console keeps submitting it and tolerates both. */
 export type PlacementKindValue = 'daemon' | 'set' | 'pool'
 
-/** Is this placement the Cloud entry — a member set rather than one machine? */
-export function isCloudPlacementKind(kind?: PlacementKindValue): boolean {
+/** Is this placement the pool — a member set rather than one machine? */
+export function isPoolPlacementKind(kind?: PlacementKindValue): boolean {
   return kind === 'set' || kind === 'pool'
 }
 
@@ -80,11 +80,11 @@ export function isCloudPlacementKind(kind?: PlacementKindValue): boolean {
  * agent read as unplaced; `placementKind` is the only thing that says it.
  */
 export function placementValueOf(dto: { placementKind?: PlacementKindValue; daemonId: string | null }): string | null {
-  return isCloudPlacementKind(dto.placementKind) ? CLOUD_PLACEMENT : (dto.daemonId ?? null)
+  return isPoolPlacementKind(dto.placementKind) ? POOL_PLACEMENT : (dto.daemonId ?? null)
 }
 
-/** The Cloud entry stands in for the whole pool: online while any member is serving. */
-export function cloudFleetStatus(members: Pick<DaemonRow, 'status'>[]): ConnectionStatusKey {
+/** One status for the whole pool: online while any member is serving. */
+export function poolFleetStatus(members: Pick<DaemonRow, 'status'>[]): ConnectionStatusKey {
   return members.some((m) => m.status === 'online') ? 'online' : 'offline'
 }
 
@@ -107,7 +107,7 @@ export function effectiveAgentStatus(
     // A pool placement names no member, so there is no owning daemon to consult: the CP already
     // answered "could anything serve this now" and that answer is the whole story (#987 — asking
     // a placed member's liveness is what kept a rolled-over agent permanently offline).
-    if (isCloudPlacementKind(agent.placementKind)) return agent.placementReady ? agent.status : 'offline'
+    if (isPoolPlacementKind(agent.placementKind)) return agent.placementReady ? agent.status : 'offline'
     if (agent.daemon === '—') return 'offline'
     if (owningDaemon !== undefined) {
       if (owningDaemon.lifecycleStatus) return owningDaemon.lifecycleStatus
@@ -122,7 +122,7 @@ export function effectiveAgentStatus(
 // configuring it (onboarding's agent step) or creating a user agent flips this true. It
 // is the signal for "the org is set up" — used by the onboarding gate + getting-started.
 export function agentIsPlaced(agent: Pick<Agent, 'daemon' | 'runtime' | 'placementKind'>): boolean {
-  return (isCloudPlacementKind(agent.placementKind) || agent.daemon !== '—') && agent.runtime !== ''
+  return (isPoolPlacementKind(agent.placementKind) || agent.daemon !== '—') && agent.runtime !== ''
 }
 
 export type LaneKind = 'msg' | 'plan' | 'tool' | 'edit' | 'done'
@@ -338,7 +338,7 @@ export interface Agent {
   /** Names of organization-owned secrets assigned to this agent. Values are never
    *  returned for these either. */
   organizationSecretKeys: string[]
-  /** What the placement NAMES. A `set` carries `daemon: CLOUD_PLACEMENT` and no member id.
+  /** What the placement NAMES. A `set` carries `daemon: POOL_PLACEMENT` and no member id.
    *  Absent (a mock row, an older CP) reads as `daemon`, which is the pre-pool behavior. */
   placementKind?: PlacementKindValue
   /** Server-computed: can a session start right now? For a set placement that is "some member is
@@ -1890,10 +1890,10 @@ export interface DaemonRow {
   canManageLifecycle: boolean
   /** Actual daemon connection/readiness. Never replaced by a presentation-only lifecycle state. */
   status: ConnectionStatusKey
-  /** An install-wide cloud member: managed infrastructure every org shares, one row per
-   *  cloud-daemon Pod. The daemons page collapses the whole pool into one Cloud entry, and
+  /** An install-wide pool member: managed infrastructure every org shares, one row per
+   *  pool member Pod. The daemons page collapses the whole pool into one Cloud entry, and
    *  nothing here is the org's to rename, restart, or detach (`canEdit` is false). */
-  cloud: boolean
+  pool: boolean
   /** Planned lifecycle presentation while the durable operation is pending. */
   lifecycleStatus: LifecycleStatusKey | null
   host: string

--- a/packages/web/src/lib/placement-value.test.ts
+++ b/packages/web/src/lib/placement-value.test.ts
@@ -5,13 +5,13 @@
 // unplaced. That is what made a reloaded agent lose its Cloud selection: the list projection went
 // through the mapping and the editor's own re-fetch did not.
 import { describe, it, expect } from 'vitest'
-import { CLOUD_PLACEMENT, effectiveAgentStatus, agentIsPlaced, placementValueOf } from '@/lib/data'
+import { POOL_PLACEMENT, effectiveAgentStatus, agentIsPlaced, placementValueOf } from '@/lib/data'
 import type { Agent, DaemonRow } from '@/lib/data'
 
 const poolAgent = (over: Partial<Agent> = {}): Pick<Agent, 'status' | 'daemon' | 'placementKind' | 'placementReady'> =>
   ({
     status: 'online',
-    daemon: CLOUD_PLACEMENT,
+    daemon: POOL_PLACEMENT,
     placementKind: 'pool',
     placementReady: true,
     ...over
@@ -19,18 +19,18 @@ const poolAgent = (over: Partial<Agent> = {}): Pick<Agent, 'status' | 'daemon' |
 
 describe('placementValueOf', () => {
   it('maps a pool placement to the pool sentinel, never to its null member id', () => {
-    expect(placementValueOf({ placementKind: 'pool', daemonId: null })).toBe(CLOUD_PLACEMENT)
+    expect(placementValueOf({ placementKind: 'pool', daemonId: null })).toBe(POOL_PLACEMENT)
   })
 
   it('ignores a stray member id under a pool kind — the KIND is what says pool', () => {
-    expect(placementValueOf({ placementKind: 'pool', daemonId: 'dmn_1' })).toBe(CLOUD_PLACEMENT)
+    expect(placementValueOf({ placementKind: 'pool', daemonId: 'dmn_1' })).toBe(POOL_PLACEMENT)
   })
 
   // What the CP actually STORES and emits now: the pool is one member set (daemon-groups.md §2).
   // `pool` stays accepted on the way in as API sugar, so both spellings have to read as Cloud.
   it('maps a set placement to the same Cloud sentinel — that is the console round-trip', () => {
-    expect(placementValueOf({ placementKind: 'set', daemonId: null })).toBe(CLOUD_PLACEMENT)
-    expect(agentIsPlaced({ daemon: CLOUD_PLACEMENT, runtime: 'claude', placementKind: 'set' })).toBe(true)
+    expect(placementValueOf({ placementKind: 'set', daemonId: null })).toBe(POOL_PLACEMENT)
+    expect(agentIsPlaced({ daemon: POOL_PLACEMENT, runtime: 'claude', placementKind: 'set' })).toBe(true)
     expect(effectiveAgentStatus(poolAgent({ placementKind: 'set' }), undefined)).toBe('online')
     expect(effectiveAgentStatus(poolAgent({ placementKind: 'set', placementReady: false }), undefined)).toBe('offline')
   })
@@ -63,6 +63,6 @@ describe('a pool agent’s readiness is the server’s answer, not a member’s 
   })
 
   it('counts as placed even though it names no machine', () => {
-    expect(agentIsPlaced({ daemon: CLOUD_PLACEMENT, runtime: 'claude', placementKind: 'pool' })).toBe(true)
+    expect(agentIsPlaced({ daemon: POOL_PLACEMENT, runtime: 'claude', placementKind: 'pool' })).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #1001. Follows #1003, which folded the pool into the unified `member_set` model.

## The vocabulary

`docs/designs/daemon-groups.md` §2 fixed the words. A **member set** is a named set of
daemons within which an agent's duty may be claimed. **The pool** is the org-less one —
`member_set` with a null `orgId`, one per install, shared by every organization, its
members every frame-mode Pod. A **pool member** is one daemon in it.

"Cloud" is none of those. It is a hosting model, and the code has no way to know whether
an install is hosted. This renames the identifiers that said it to what the thing is.

## What changed

A mechanical rename: **41 distinct identifiers** across control-plane, web, protocol,
relay and daemon, plus **4 files** whose name carried the word. Zero behavior change —
57 files, +367/-367 lines, and the test-block count is identical on both sides of the
diff (16 added, 16 removed; all renames).

Files:

| Before | After |
| --- | --- |
| `control-plane/src/orchestrator/cloudDaemonReaper.ts` | `poolMemberReaper.ts` |
| `control-plane/src/orchestrator/cloudDaemonReaper.test.ts` | `poolMemberReaper.test.ts` |
| `daemon/test/postgres-cloud-store.int.test.ts` | `postgres-pool-store.int.test.ts` |
| `web/.../views/DaemonsView.cloud.test.tsx` | `DaemonsView.pool.test.tsx` |

Representative identifiers:

- **control-plane** — `CloudDaemonReaper` → `PoolMemberReaper` (plus its `Log`/`Config`
  types and both `CLOUD_DAEMON_REAP_*` constants); `findRetiredCloudMembers` →
  `findRetiredPoolMembers`; `retireCloudMember` → `retirePoolMember` on the repo, the
  port and the registry; `retireCloudDaemonMember` → `retirePoolMember` in
  `http/daemon-removal.ts`; `CLOUD_MEMBER_WHERE` → `POOL_MEMBER_WHERE` and
  `retiredCloudMemberWhere` → `retiredPoolMemberWhere`; `resolveCloudClusterIdentity` →
  `resolvePoolClusterIdentity`; `bindCloud` → `bindPoolMember`; `cloudNamespace` →
  `poolNamespace`; the reaper's three log lines `cloud-daemon-reaper:` →
  `pool-member-reaper:`; and in tests `mintCloudDaemon` → `mintPoolMember`,
  `cloudTokens` → `poolTokens`, `CLOUD_NAMESPACE` → `POOL_NAMESPACE`.
- **web** — `CLOUD_DAEMON_LABEL` → `POOL_LABEL` (constant only; the string is unchanged,
  see below); `CLOUD_PLACEMENT` → `POOL_PLACEMENT`; `isCloudPlacementKind` →
  `isPoolPlacementKind`; `cloudFleetStatus` → `poolFleetStatus`; `CloudFleetCard` →
  `PoolFleetCard`; `DaemonRow.cloud` → `DaemonRow.pool` and `DaemonSelectOption.cloud` →
  `.pool` (with `data-cloud` → `data-pool`); `cloudServing` → `poolServing`;
  `cloudAvailable` → `poolAvailable`; `cloudChoice` / `currentCloudChoice` →
  `poolChoice` / `currentPoolChoice`; `cloudMembers`, `cloudDaemons`, `cloudAgents` →
  their `pool*` spellings.
- **daemon** — `CLOUD_STORE_SCHEMA` → `POOL_STORE_SCHEMA` (the constant only — its value
  is a stored schema name); `cloudCpReady` → `poolCpReady`; `declaredCloudCatalog` →
  `declaredPoolCatalog`.
- **comments** across all five packages, wherever they said "cloud daemon" / "cloud
  member" / "cloud Pod" for the pool. Test names were renamed with their subjects; every
  test's intent is unchanged.

`POOL_PLACEMENT`'s value moved from `'cloud'` to `'pool'`. It is a console-only sentinel
for `Agent.daemon` — it is never persisted, never put in a URL, and never submitted: the
editor maps it to `{ kind: 'pool' }` before the request. Every reader goes through the
constant.

## Deliberately not renamed

Each of these is a contract where a rename is a migration, not a refactor:

- **`CLOUD_DAEMON_SA_NAME` and its value `ac-cloud-daemon`** (`protocol/src/consts.ts`) —
  the ServiceAccount name TokenReview binds pool identity to. Renaming it changes the
  authentication contract and needs a control-plane dual-read plus a coordinated
  deployment-side rename. Constant, value and every test literal left alone; only the
  surrounding comments now say "pool member".
- **`agentconnect_cloud_store`** (`daemon/src/store/postgres-sync-database.ts`) — the
  pool's Postgres schema name. Stored data; renaming it orphans it. The constant holding
  it was renamed and now carries a one-line comment saying why the literal stays. The
  advisory-lock keys in `postgres-store-worker.js` are cross-process coordination values
  and are untouched for the same reason.
- **`CLUSTER_CLOUD_DAEMON_NAMESPACE`** — an env key a deployment sets. Changing it breaks
  a running deployment. The key stays; the TypeScript that reads it is now `poolNamespace`.
- **`DaemonDto.cloud`** (`control-plane/src/http/dto/index.ts`, read as `d.cloud` in
  `web/src/lib/api.ts`) — a published REST response field that appears in the generated
  OpenAPI document. Renaming it is an API change, not a refactor. The console's own
  projection is `DaemonRow.pool`; the one line that crosses the seam carries a comment
  saying so.
- **Prisma columns** (`clusterIdentity`, `clusterPodUid`, …) and the applied migration
  `20260818000000_install_wide_cloud_daemon` — schema and applied history.
- **`CLOUD_DAEMON_LABEL`'s value `'AgentConnect Cloud'`** and the console's user-visible
  "Cloud" strings (the pool card, the select badge, `agents on Cloud`, the move-failure
  copy). The product word is decided elsewhere; only the identifier moved.
- **`conflict('no cloud daemon member is ready')`** in `http/routes/agents.ts` (two call
  sites, asserted by `agents.move.route.test.ts`) — this string reaches the user as an
  error, so it is the same product-wording decision as the label. Flagging it rather than
  changing it; happy to fold it into whichever PR settles the user-facing word.
- **`docs/designs/*.md`** — historical wording left as written, per the issue. Two code
  comments quote a section title from `agentconnect-org-operator.md` verbatim; the
  quotation is preserved even though the surrounding prose was updated.

## Gates

`typecheck`, `lint`, `format:check`, `protocol test` (331), `control-plane test:unit`
(1660), `control-plane test:int` (1304 passed, only the known `rewrap.test.ts` load
flake), `daemon test` (3556 passed; only the known `shim-*`, `workspace-git-runner-seam`
and live `acp-matrix` baseline failures, none in a touched file), `web test` (1541). No
test count moved.
