### PR TITLE
fix(daemon): start the shim loss window when the sandbox pod is up

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5472,6 +5472,9 @@ export class Daemon {
       }
       throw new Error(`agent "${agentId}" runtime launch preparation failed: ${formatErr(err)}`, { cause: err })
     }
+    // Filled right after construction, so the terminal reap can prove the host that exited is
+    // still the memoized one before evicting anything.
+    const constructed: { host?: AcpHost } = {}
     const host = new AcpHost(launchRuntime, {
       // In --k8s the runtime runs in the agent's own Sandbox pod; everywhere else AcpHost falls
       // back to its LocalDriver, which is what a self-hosted daemon wants.
@@ -5483,6 +5486,8 @@ export class Daemon {
         : {}),
       onElicit: (sid, params) => this.onAcpElicit(agentId, sid, params),
       onSdkLifecycle: (sid, message) => this.onSdkLifecycle(agentId, sid, message),
+      // Pairs the runtime's terminal exit with the ordinary rebuild — see reapTerminalHost.
+      onTerminal: () => this.reapTerminalHost(agentId, constructed.host),
       env: launch.env,
       inheritProcessEnv: launch.inheritProcessEnv,
       runtimeId: agent.runtime,
@@ -5497,7 +5502,30 @@ export class Daemon {
       },
       log: this.log
     })
+    constructed.host = host
     return { host, configFileState }
+  }
+
+  /**
+   * Reclaim a host whose runtime reached terminal exit, so the next message rebuilds it.
+   *
+   * A dead runtime leaves a host that can never serve again — its ACP connection is closed —
+   * yet it stays memoized, so every later turn is dispatched into it and fails with "ACP
+   * connection closed" until the daemon is replaced. A lost sandbox channel is exactly this
+   * shape: the pod goes and the runtime with it. The teardown is therefore paired here with the
+   * ordinary rebuild — `stopHost` returns the agent to provisioned and the next message starts
+   * a fresh host through `ensureHostAsync`, the same path a grant or an activation uses.
+   *
+   * A host that never became ready is deliberately left alone: `startHostWithRetry` reaps its
+   * own failed child, and evicting the start generation here would cancel its remaining attempts.
+   */
+  private reapTerminalHost(agentId: string, host?: AcpHost): void {
+    if (!host || this.hosts.get(agentId) !== host) return
+    if (!this.readyHosts.has(agentId)) return
+    this.log.warn(`acp: agent "${agentId}" runtime exited — reclaiming its host so the next message re-spawns it`)
+    void this.stopHost(agentId).catch((err) =>
+      this.log.warn(`acp: reclaiming the exited host for agent "${agentId}" failed: ${formatErr(err)}`)
+    )
   }
 
   /**

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -217,11 +217,14 @@ export class K8sDriver implements SpawnDriver {
    * The driver has just watched that pod, so it can tell an unbound channel apart from a lost
    * one: while the Sandbox is not Ready its shim cannot dial at all, and a dial that times out
    * against it is "not ready yet", not a channel that went away.
+   *
+   * The read takes the caller's `signal` because the answer is only useful before the caller's
+   * deadline: a stalled API server must abort this read, not extend the decision it feeds.
    */
-  async sandboxReadiness(agentId: string): Promise<SandboxReadiness> {
+  async sandboxReadiness(agentId: string, opts: { signal?: AbortSignal } = {}): Promise<SandboxReadiness> {
     const launch = this.launches.get(agentId)
     if (!launch) return 'absent'
-    const sandbox = await this.deps.api.getSandbox(launch.sandboxName).catch((err: unknown) => {
+    const sandbox = await this.deps.api.getSandbox(launch.sandboxName, opts).catch((err: unknown) => {
       if (err instanceof K8sApiError && err.isNotFound) return undefined
       throw err
     })

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -99,6 +99,13 @@ export class LaunchTimeoutError extends Error {
 const DEFAULT_READY_TIMEOUT_MS = 90_000
 const MAX_MODE_ATTEMPTS = 5
 
+/**
+ * How to read a channel that has not arrived: `starting` means the pod is not up yet, so
+ * nothing has been lost — a cold start pays PVC provisioning and an image pull before any
+ * shim can dial. `absent` means there is no pod coming at all.
+ */
+export type SandboxReadiness = 'ready' | 'starting' | 'absent'
+
 /** Per-agent launch state the driver keeps: the Sandbox it bound and which launch it is. */
 interface Launch {
   agentId: string
@@ -196,6 +203,32 @@ export class K8sDriver implements SpawnDriver {
     const launch: Launch = { agentId, sandboxName, sandboxUid, generation }
     this.launches.set(agentId, launch)
     return launch
+  }
+
+  /** How long a pod may take to come up, as this driver itself waits for it. One definition, so
+   *  the loss window and the launch path cannot disagree about what a cold start may cost. */
+  get podUpTimeoutMs(): number {
+    return this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
+  }
+
+  /**
+   * Whether the pod that should hold this agent's channel is up right now.
+   *
+   * The driver has just watched that pod, so it can tell an unbound channel apart from a lost
+   * one: while the Sandbox is not Ready its shim cannot dial at all, and a dial that times out
+   * against it is "not ready yet", not a channel that went away.
+   */
+  async sandboxReadiness(agentId: string): Promise<SandboxReadiness> {
+    const launch = this.launches.get(agentId)
+    if (!launch) return 'absent'
+    const sandbox = await this.deps.api.getSandbox(launch.sandboxName).catch((err: unknown) => {
+      if (err instanceof K8sApiError && err.isNotFound) return undefined
+      throw err
+    })
+    if (!sandbox) return 'absent'
+    // Suspended is a decision this daemon made: the pod is gone and none is coming up for it.
+    if ((sandbox.spec?.operatingMode ?? 'Running') !== 'Running') return 'absent'
+    return isSandboxReady(sandbox) && resolvePodIp(sandbox) ? 'ready' : 'starting'
   }
 
   /** Wait for the Sandbox to report Ready, after something has asked it to run. */

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -359,12 +359,20 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
 
   async function runLossCheck(agentId: string, watch: LossWatch): Promise<void> {
     if (!lossWatchStillOpen(agentId, watch)) return
-    const readiness = await driver.sandboxReadiness(agentId).catch((err: unknown) => {
-      // An unreadable Sandbox proves nothing about the pod, so it counts as still coming up —
-      // bounded by the ceiling, which is what keeps an API outage from pinning a dead launch.
-      options.log?.warn(`k8s: could not read the sandbox for agent ${agentId} — ${(err as Error).message}`)
-      return 'starting' as const
-    })
+    // The read itself is bounded by what is LEFT of the ceiling, and by nothing else. The API
+    // server has no request deadline of its own, so a read that is accepted and never answered
+    // would hold this decision open forever — the launch stuck, its host dead, and nothing to
+    // rebuild it: the outcome this whole window exists to remove.
+    const remainingMs = watch.ceiling - Date.now()
+    const readiness =
+      remainingMs <= 0
+        ? ('absent' as const)
+        : await driver.sandboxReadiness(agentId, { signal: AbortSignal.timeout(remainingMs) }).catch((err: unknown) => {
+            // An unreadable Sandbox proves nothing about the pod, so it counts as still coming
+            // up — and the ceiling below, which the abort cannot outlive, decides in the end.
+            options.log?.warn(`k8s: could not read the sandbox for agent ${agentId} — ${(err as Error).message}`)
+            return 'starting' as const
+          })
     // Re-checked after the round trip: a replacement may have bound, or the agent gone away.
     if (!lossWatchStillOpen(agentId, watch)) return
     if (Date.now() < watch.ceiling) {

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -61,6 +61,19 @@ export async function reapExpiredProbeClaims(
   )
 }
 
+/** How long a pod that is UP may go without a shim channel before the launch counts as lost. */
+const DEFAULT_REBIND_GRACE_MS = 20_000
+
+/** One agent's pending loss decision: why the channel dropped, and how long the pod may take. */
+interface LossWatch {
+  reason: string
+  timer?: NodeJS.Timeout
+  /** Set once the pod has been observed coming up, so its arrival restarts the grace window. */
+  podWasStarting: boolean
+  /** When an unbound channel becomes a loss whatever the pod is doing. */
+  ceiling: number
+}
+
 /**
  * Assembles the k8s execution plane: the shim dialer, the driver, and the seams that make an
  * agent's git run where its workspace actually is.
@@ -101,6 +114,9 @@ export interface K8sRuntimePlaneOptions {
   /** Lifetime of an issued session credential. The shim renews at half of it, so a test that has
    *  to cross a renewal shortens it rather than waiting out the default. */
   credentialTtlMs?: number
+  /** How long a pod that is up may go without a shim channel before the launch counts as lost.
+   *  Injected so a test can cross the window in milliseconds rather than waiting out the default. */
+  rebindGraceMs?: number
   log?: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
 }
 
@@ -207,8 +223,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     metrics: clusterMetrics,
     onConnection: (connection) => {
       // A rebind cancels any pending loss check: this IS the replacement it was waiting for.
-      clearTimeout(lossTimers.get(connection.binding.agentId))
-      lossTimers.delete(connection.binding.agentId)
+      cancelLossCheck(connection.binding.agentId)
       driver.onChannelBound(connection)
     },
     // A closed socket is not a lost launch; renewals reconnect underneath the logical session.
@@ -283,8 +298,11 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
 
   // A renewal reconnects immediately, so a
   // replacement that has not arrived well inside the request deadline is a pod that is gone.
-  const REBIND_GRACE_MS = 20_000
-  const lossTimers = new Map<string, NodeJS.Timeout>()
+  const REBIND_GRACE_MS = options.rebindGraceMs ?? DEFAULT_REBIND_GRACE_MS
+  // How often to re-read a pod that is still coming up. Deliberately well under the grace: this
+  // is a wait for an event, not a window being spent, and the pod's arrival restarts the window.
+  const POD_UP_POLL_MS = Math.max(1, Math.min(2_000, Math.floor(REBIND_GRACE_MS / 4)))
+  const lossWatches = new Map<string, LossWatch>()
   let stopped = false
   let probeGcTimer: NodeJS.Timeout | undefined
   let probeInFlight: Promise<K8sRuntimeTable> | undefined
@@ -300,17 +318,75 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
 
   void runProbeClaimGc()
 
+  /**
+   * Start the grace window for a channel that dropped, measured from the right event.
+   *
+   * The window is for a pod that IS up and whose shim has not come back. While the pod is still
+   * coming up nothing can dial it at all — a cold start pays PVC provisioning and an image pull —
+   * so that time is waited out rather than counted, and the window restarts once the pod is
+   * Ready. `driver.podUpTimeoutMs` is the ceiling: a pod that never arrives still reports loss.
+   */
   function scheduleLossCheck(agentId: string, reason: string): void {
-    clearTimeout(lossTimers.get(agentId))
-    lossTimers.set(
-      agentId,
-      setTimeout(() => {
-        lossTimers.delete(agentId)
-        if (dialer.connectionsFor(agentId).length > 0) return
-        options.log?.warn(`k8s: no shim channel for agent ${agentId} after ${REBIND_GRACE_MS}ms — reporting loss`)
-        driver.onChannelLost(agentId, reason)
-      }, REBIND_GRACE_MS).unref?.() as NodeJS.Timeout
+    cancelLossCheck(agentId)
+    const watch: LossWatch = {
+      reason,
+      podWasStarting: false,
+      ceiling: Date.now() + driver.podUpTimeoutMs + REBIND_GRACE_MS
+    }
+    lossWatches.set(agentId, watch)
+    armLossCheck(agentId, watch, REBIND_GRACE_MS)
+  }
+
+  function armLossCheck(agentId: string, watch: LossWatch, delayMs: number): void {
+    watch.timer = setTimeout(() => void runLossCheck(agentId, watch), delayMs)
+    watch.timer.unref?.()
+  }
+
+  function cancelLossCheck(agentId: string): void {
+    const watch = lossWatches.get(agentId)
+    if (!watch) return
+    clearTimeout(watch.timer)
+    lossWatches.delete(agentId)
+  }
+
+  /** True while this watch is still the current one and nothing has rebound underneath it. */
+  function lossWatchStillOpen(agentId: string, watch: LossWatch): boolean {
+    if (lossWatches.get(agentId) !== watch) return false
+    if (dialer.connectionsFor(agentId).length === 0) return true
+    cancelLossCheck(agentId)
+    return false
+  }
+
+  async function runLossCheck(agentId: string, watch: LossWatch): Promise<void> {
+    if (!lossWatchStillOpen(agentId, watch)) return
+    const readiness = await driver.sandboxReadiness(agentId).catch((err: unknown) => {
+      // An unreadable Sandbox proves nothing about the pod, so it counts as still coming up —
+      // bounded by the ceiling, which is what keeps an API outage from pinning a dead launch.
+      options.log?.warn(`k8s: could not read the sandbox for agent ${agentId} — ${(err as Error).message}`)
+      return 'starting' as const
+    })
+    // Re-checked after the round trip: a replacement may have bound, or the agent gone away.
+    if (!lossWatchStillOpen(agentId, watch)) return
+    if (Date.now() < watch.ceiling) {
+      if (readiness === 'starting') {
+        watch.podWasStarting = true
+        options.log?.debug?.(`k8s: agent ${agentId} has no shim channel yet — its sandbox pod is still coming up`)
+        armLossCheck(agentId, watch, POD_UP_POLL_MS)
+        return
+      }
+      // The pod has just come up, so its shim gets the whole grace window to dial in — the clock
+      // starts here rather than at a socket that dropped while there was no pod to dial at all.
+      if (readiness === 'ready' && watch.podWasStarting) {
+        watch.podWasStarting = false
+        armLossCheck(agentId, watch, REBIND_GRACE_MS)
+        return
+      }
+    }
+    lossWatches.delete(agentId)
+    options.log?.warn(
+      `k8s: no shim channel for agent ${agentId} after ${REBIND_GRACE_MS}ms with its pod ${readiness} — reporting loss`
     )
+    driver.onChannelLost(agentId, watch.reason)
   }
 
   function probeRuntimes(): Promise<K8sRuntimeTable> {
@@ -372,8 +448,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       dialer.revokeAgent(agentId)
       // Ordered after the revoke, whose close schedules one: a loss check for an agent that no
       // longer exists would report a lost launch nobody is waiting for.
-      clearTimeout(lossTimers.get(agentId))
-      lossTimers.delete(agentId)
+      cancelLossCheck(agentId)
       proxies.get(agentId)?.proxy.stop('agent removed')
       proxies.delete(agentId)
       await driver.removeAgent(agentId)
@@ -382,8 +457,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       stopped = true
       if (probeGcTimer) clearTimeout(probeGcTimer)
       probeGcTimer = undefined
-      for (const timer of lossTimers.values()) clearTimeout(timer)
-      lossTimers.clear()
+      for (const agentId of [...lossWatches.keys()]) cancelLossCheck(agentId)
       for (const { proxy } of proxies.values()) proxy.stop('daemon is shutting down')
       proxies.clear()
       dialer.stop()

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -185,8 +185,14 @@ export class SandboxApi {
     }
   }
 
-  getSandbox(name: string): Promise<Sandbox> {
-    return this.http.json<Sandbox>({ method: 'GET', path: `${this.sandboxes()}/${name}` })
+  /** `signal` bounds the read: a caller on a deadline must not be pinned by an API server that
+   *  accepted the connection and never answered. Same seam a watch aborts through. */
+  getSandbox(name: string, opts: { signal?: AbortSignal } = {}): Promise<Sandbox> {
+    return this.http.json<Sandbox>({
+      method: 'GET',
+      path: `${this.sandboxes()}/${name}`,
+      ...(opts.signal ? { signal: opts.signal } : {})
+    })
   }
 
   getWarmPool(name: string): Promise<SandboxWarmPool> {

--- a/packages/daemon/src/shim/dialer.ts
+++ b/packages/daemon/src/shim/dialer.ts
@@ -78,20 +78,12 @@ export class ShimDialer {
       return existing.current ? Promise.resolve(existing.current) : this.awaitReady(existing, timeoutMs)
     }
     if (existing) this.stopDial(existing, 'superseded by a newer launch')
-    let resolveReady: (connection: ShimConnection) => void = () => {}
-    let rejectReady: (error: Error) => void = () => {}
-    const ready = new Promise<ShimConnection>((resolve, reject) => {
-      resolveReady = resolve
-      rejectReady = reject
-    })
     const dial: SupervisedDial = {
       endpoint,
       record,
       stopped: false,
       readySettled: false,
-      ready,
-      resolveReady,
-      rejectReady
+      ...this.freshReady()
     }
     this.dials.set(record.agentId, dial)
     void this.supervise(dial, timeoutMs)
@@ -244,15 +236,26 @@ export class ShimDialer {
   }
 
   private resetReady(dial: SupervisedDial): void {
+    Object.assign(dial, this.freshReady(), { readySettled: false })
+  }
+
+  /**
+   * A fresh "next connection" promise for a dial.
+   *
+   * Its rejection is pre-observed, deliberately: a revoke or a supersede stops the dial whether
+   * or not anything is waiting for its next connection, and that teardown is expected — the
+   * caller that IS waiting still receives it through {@link awaitReady}, which attaches its own
+   * handlers. Without this, an ordinary `revokeAgent` surfaced as an unhandled rejection.
+   */
+  private freshReady(): Pick<SupervisedDial, 'ready' | 'resolveReady' | 'rejectReady'> {
     let resolveReady: (connection: ShimConnection) => void = () => {}
     let rejectReady: (error: Error) => void = () => {}
-    dial.ready = new Promise<ShimConnection>((resolve, reject) => {
+    const ready = new Promise<ShimConnection>((resolve, reject) => {
       resolveReady = resolve
       rejectReady = reject
     })
-    dial.resolveReady = resolveReady
-    dial.rejectReady = rejectReady
-    dial.readySettled = false
+    void ready.catch(() => undefined)
+    return { ready, resolveReady, rejectReady }
   }
 
   private bind(

--- a/packages/daemon/test/cluster-cold-start.test.ts
+++ b/packages/daemon/test/cluster-cold-start.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Backoff } from '@agentconnect.md/connection'
+import { K8sHttp } from '@agentconnect.md/k8s-client'
+import { closeFakeApiServers, fakeApiServer } from '@agentconnect.md/k8s-client/testing'
+import { AcpHost } from '../src/acp/acp-host.js'
+import { Daemon } from '../src/daemon.js'
+import { SandboxApi } from '../src/k8s/sandbox-api.js'
+import { startK8sRuntimePlane, type K8sRuntimePlane } from '../src/k8s/runtime-plane.js'
+import { ShimClient, type ShimTransport } from '../src/shim/client.js'
+import { ShimServer } from '../src/shim/server.js'
+
+/**
+ * The sandbox cold-start race (#1010).
+ *
+ * A pod that is still coming up — PVC bind plus image pull — cannot answer a dial at all, and
+ * the daemon used to read that as a lost channel: after a fixed 20s window it revoked the
+ * binding, tore the ACP host down, and left it torn down, so every later turn failed with "ACP
+ * connection closed" until the member was replaced. Both halves are checked here: the loss
+ * window starts from the pod being up, and a runtime that DID reach terminal exit leaves no
+ * dead host memoized behind it.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fakeAgent = join(here, 'fixtures', 'fake-acp-agent.mjs')
+const SILENT = { info: () => {}, warn: () => {}, debug: () => {} }
+const POD_NAME = 'pool-pod-9'
+const AGENT = 'agent-a'
+const WAIT = { timeout: 15_000 }
+
+const planes: K8sRuntimePlane[] = []
+const clients: ShimClient[] = []
+const servers: ShimServer[] = []
+const hosts: AcpHost[] = []
+
+afterEach(async () => {
+  for (const host of hosts.splice(0)) await host.stop(2_000).catch(() => undefined)
+  for (const client of clients.splice(0)) client.stop()
+  for (const plane of planes.splice(0)) await plane.stop()
+  for (const server of servers.splice(0)) await server.stop()
+  closeFakeApiServers()
+})
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** A gate the test opens when the pod starts answering dials. */
+function gate(): { closed: () => void; open: () => void; wait: () => Promise<void> } {
+  let waiting: Promise<void> = Promise.resolve()
+  let release: () => void = () => {}
+  return {
+    closed: () => {
+      waiting = new Promise<void>((resolve) => (release = resolve))
+    },
+    open: () => release(),
+    wait: () => waiting
+  }
+}
+
+/** The Sandbox as the API server reports it; `ready` is the pod being up. */
+function sandboxObject(ready: boolean): unknown {
+  return {
+    metadata: { name: 'sb-1', uid: 'sandbox-uid-1', annotations: { 'agents.x-k8s.io/pod-name': POD_NAME } },
+    spec: { operatingMode: 'Running' },
+    status: { conditions: [{ type: 'Ready', status: ready ? 'True' : 'False' }], podIPs: ['127.0.0.1'] }
+  }
+}
+
+/**
+ * A cluster the test drives: a real SandboxApi over the in-process fake API server, a real
+ * dialer reaching a real sandbox listener over a real socket, and one flag per thing the test
+ * changes — whether the pod reports Ready, and whether its shim answers the daemon's dial.
+ */
+async function clusterUnderTest(options: {
+  rebindGraceMs: number
+  readyTimeoutMs: number
+  log?: { info: (m: string) => void; warn: (m: string) => void; debug: (m: string) => void }
+}): Promise<{
+  plane: K8sRuntimePlane
+  server: ShimServer
+  state: { ready: boolean }
+  reachable: ReturnType<typeof gate>
+  shim: () => ShimClient
+}> {
+  const server = new ShimServer()
+  const port = await server.start(0, '127.0.0.1')
+  servers.push(server)
+  const state = { ready: true }
+  let claim: unknown
+  const { config } = await fakeApiServer(({ method, url }) => {
+    const path = url.pathname
+    if (path.endsWith('/tokenreviews')) {
+      return {
+        json: {
+          status: {
+            authenticated: true,
+            user: {
+              username: 'system:serviceaccount:agent-sandboxes:sandbox',
+              extra: {
+                'authentication.kubernetes.io/pod-name': [POD_NAME],
+                'authentication.kubernetes.io/pod-uid': ['pod-uid-1']
+              }
+            }
+          }
+        }
+      }
+    }
+    if (path.endsWith('/sandboxes/sb-1')) return { json: sandboxObject(state.ready) }
+    if (path.endsWith('/sandboxclaims')) {
+      if (method !== 'POST') return { json: { items: [] } }
+      claim = { metadata: { name: `agent-${AGENT}`, uid: 'claim-uid-1' }, status: { sandbox: { name: 'sb-1' } } }
+      return { json: claim }
+    }
+    if (path.endsWith(`/sandboxclaims/agent-${AGENT}`)) {
+      if (method === 'DELETE') {
+        claim = undefined
+        return { json: {} }
+      }
+      if (!claim) return { status: 404, json: { kind: 'Status', reason: 'NotFound', message: 'no claim' } }
+      return { json: claim }
+    }
+    return { status: 404, json: { kind: 'Status', reason: 'NotFound', message: path } }
+  })
+  const plane = await startK8sRuntimePlane({
+    orgId: 'org-1',
+    warmPoolName: 'pool',
+    sandboxNamespace: 'agent-sandboxes',
+    memberId: 'member-a',
+    shimPort: port,
+    readyTimeoutMs: options.readyTimeoutMs,
+    rebindGraceMs: options.rebindGraceMs,
+    api: new SandboxApi(new K8sHttp(config), 'agent-sandboxes') as never,
+    log: options.log ?? SILENT
+  })
+  planes.push(plane)
+  const reachable = gate()
+  const shim = (): ShimClient => {
+    const client = new ShimClient({
+      endpoint: 'accepted-daemon-channel',
+      acceptDialIn: true,
+      // The pod answers a dial only while the gate is open; a closed gate is a pod that is
+      // still coming up, which is what the daemon must not read as a lost channel.
+      dial: async () => {
+        await reachable.wait()
+        return (await server.nextTransport()) as ShimTransport
+      },
+      readToken: () => 'projected-token',
+      backoff: new Backoff({ baseMs: 25, capMs: 100, jitter: () => 0 }),
+      log: { info: () => {}, warn: () => {} }
+    })
+    clients.push(client)
+    void client.start()
+    return client
+  }
+  return { plane, server, state, reachable, shim }
+}
+
+/** A host whose runtime runs in the sandbox, over the plane's driver. */
+function hostUnderTest(plane: K8sRuntimePlane, onTerminal?: () => void): AcpHost {
+  const host = new AcpHost(
+    { command: process.execPath, args: [fakeAgent], env: [] },
+    {
+      driver: plane.driver,
+      onUpdate: () => {},
+      ...(onTerminal ? { onTerminal } : {}),
+      env: { AC_AGENT_ID: AGENT }
+    }
+  )
+  hosts.push(host)
+  return host
+}
+
+/** Collect unhandled rejections raised while `work` runs — `binding revoked` was one. */
+async function unhandledRejectionsDuring(work: () => Promise<void>): Promise<unknown[]> {
+  const seen: unknown[] = []
+  const listener = (reason: unknown): void => void seen.push(reason)
+  process.on('unhandledRejection', listener)
+  try {
+    await work()
+    // Node reports an unobserved rejection a tick after it is created, so give it one.
+    await delay(250)
+  } finally {
+    process.off('unhandledRejection', listener)
+  }
+  return seen
+}
+
+describe('a shim channel that drops while its sandbox pod is coming up', () => {
+  it('keeps dialing the cold pod and serves a turn once it binds', async () => {
+    // The defect: a dial that could not complete while the pod was being created counted
+    // against a fixed grace window, so the launch was revoked and the runtime killed — even
+    // though the pod was on its way up and its shim would have bound moments later.
+    const { plane, state, reachable, shim } = await clusterUnderTest({ rebindGraceMs: 400, readyTimeoutMs: 8_000 })
+    shim()
+    const host = hostUnderTest(plane)
+    await host.start()
+    const sessionId = await host.newSession('/tmp')
+    expect(await host.prompt(sessionId, [{ type: 'text', text: 'before' }])).toMatchObject({ stopReason: 'end_turn' })
+
+    // The pod goes down for a cold restart: the Sandbox stops reporting Ready and nothing
+    // answers a dial until its image is pulled and the shim is listening again.
+    state.ready = false
+    reachable.closed()
+    plane.dialer.connectionsFor(AGENT)[0]?.close('pod restarting')
+    await vi.waitFor(() => expect(plane.dialer.connectionsFor(AGENT)).toHaveLength(0), WAIT)
+
+    // Five grace windows of cold start. None of it is a loss: the launch stands, and so does
+    // the session the runtime speaks ACP over.
+    await delay(2_000)
+    expect(plane.driver.currentLaunch(AGENT)).toBeDefined()
+    expect(plane.driver.sessionFor(AGENT)).toBeDefined()
+
+    // The pod comes up and its shim binds again.
+    state.ready = true
+    reachable.open()
+    await vi.waitFor(() => expect(plane.dialer.connectionsFor(AGENT).length).toBeGreaterThan(0), WAIT)
+    await vi.waitFor(() => expect(plane.runsInSandbox(AGENT)).toBe(true), WAIT)
+
+    // The agent is serving, which is the whole point: same host, same ACP session, a turn
+    // dispatched after the bind.
+    expect(await host.prompt(sessionId, [{ type: 'text', text: 'after' }])).toMatchObject({ stopReason: 'end_turn' })
+  }, 60_000)
+
+  it('still reports loss when the pod is up and no shim comes back, without an unhandled rejection', async () => {
+    // The other half of the same window: waiting for a pod that IS up would be waiting forever,
+    // and the revoke that follows a real loss must not surface as an unhandled rejection —
+    // `stopDial` rejects a dial nobody is awaiting, which is expected and is swallowed there.
+    const { plane, reachable, shim } = await clusterUnderTest({ rebindGraceMs: 400, readyTimeoutMs: 4_000 })
+    const client = shim()
+    let terminal = 0
+    const host = hostUnderTest(plane, () => (terminal += 1))
+    await host.start()
+
+    const rejections = await unhandledRejectionsDuring(async () => {
+      // The pod is Ready throughout; its shim simply never comes back.
+      reachable.closed()
+      client.stop()
+      await vi.waitFor(() => expect(plane.driver.currentLaunch(AGENT)).toBeUndefined(), WAIT)
+      await vi.waitFor(() => expect(terminal).toBe(1), WAIT)
+    })
+    expect(rejections).toEqual([])
+  }, 60_000)
+
+  it('gives the shim the whole grace window measured from the pod coming up', async () => {
+    // The window is for a pod that is up: a pod that arrives late must still get the full grace
+    // to dial in, or a cold start that finishes just as the window elapses is killed on arrival.
+    const grace = 400
+    let lostAt = 0
+    const log = {
+      info: () => {},
+      debug: () => {},
+      warn: (message: string) => {
+        if (message.includes('reporting loss') && lostAt === 0) lostAt = Date.now()
+      }
+    }
+    const { plane, state, reachable, shim } = await clusterUnderTest({
+      rebindGraceMs: grace,
+      readyTimeoutMs: 8_000,
+      log
+    })
+    const client = shim()
+    const host = hostUnderTest(plane)
+    await host.start()
+
+    // The pod goes cold and its shim never comes back, so the only question is WHEN the window
+    // that ends the launch starts.
+    state.ready = false
+    reachable.closed()
+    client.stop()
+    await delay(1_500)
+    expect(lostAt).toBe(0)
+    const readyAt = Date.now()
+    state.ready = true
+
+    await vi.waitFor(() => expect(lostAt).toBeGreaterThan(0), WAIT)
+    // Measured from the pod being observed up, not from the socket that dropped while there was
+    // no pod to dial at all — the readiness poll is a quarter of the window, so a report that
+    // started its clock at the drop would land far inside it.
+    expect(lostAt - readyAt).toBeGreaterThanOrEqual(grace - 50)
+  }, 60_000)
+
+  it('reports loss for a pod that never comes up, bounded by the pod-up timeout', async () => {
+    // The ceiling: a sandbox stuck pulling an image forever must not pin a dead launch, or the
+    // agent would never be re-claimed onto a pod that works.
+    const { plane, state, reachable, shim } = await clusterUnderTest({ rebindGraceMs: 400, readyTimeoutMs: 2_000 })
+    const client = shim()
+    const host = hostUnderTest(plane)
+    await host.start()
+
+    state.ready = false
+    reachable.closed()
+    client.stop()
+    await vi.waitFor(() => expect(plane.driver.currentLaunch(AGENT)).toBeUndefined(), WAIT)
+  }, 60_000)
+})
+
+/** A daemon root with one agent whose runtime is the fake ACP adapter — a real host, not a stub. */
+function daemonRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-cold-start-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { claude: { command: process.execPath, args: [fakeAgent] } }
+    })
+  )
+  const agentDir = join(root, 'agents', 'bot-a')
+  mkdirSync(agentDir, { recursive: true })
+  writeFileSync(
+    join(agentDir, 'agent.json'),
+    JSON.stringify({
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: join(agentDir, 'workspace') },
+      integrations: [],
+      output: { mode: 'medium' }
+    })
+  )
+  return root
+}
+
+describe('a runtime that reached terminal exit', () => {
+  it('leaves no dead host memoized, so the next message starts a fresh one', async () => {
+    // What kept #1010 broken after the re-bind: the host torn down with the lost channel stayed
+    // in the daemon's map, so every later turn was dispatched into a closed ACP connection. The
+    // teardown is paired with the ordinary start path — the exit reclaims the host, and the next
+    // caller builds and starts a new one exactly as a fresh activation would.
+    const daemon = new Daemon({ root: daemonRoot() })
+    try {
+      await daemon.start()
+      const first = (await (daemon as any).ensureHostAsync('bot-a')) as AcpHost
+      expect((daemon as any).hosts.get('bot-a')).toBe(first)
+
+      // The runtime goes terminal. A lost sandbox channel produces exactly this signal —
+      // cluster-acp-e2e covers that half — and a local adapter that crashes produces it too.
+      await first.stop(2_000)
+      await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false), WAIT)
+      expect((daemon as any).readyHosts.has('bot-a')).toBe(false)
+
+      const second = (await (daemon as any).ensureHostAsync('bot-a')) as AcpHost
+      expect(second).not.toBe(first)
+      expect((daemon as any).readyHosts.has('bot-a')).toBe(true)
+      // Serving, not merely constructed: the rebuilt host answers a session on its own child.
+      expect(await second.newSession(join(daemonRoot(), 'workspace'))).toBeTruthy()
+    } finally {
+      await daemon.stop()
+    }
+  }, 60_000)
+})

--- a/packages/daemon/test/cluster-cold-start.test.ts
+++ b/packages/daemon/test/cluster-cold-start.test.ts
@@ -41,7 +41,7 @@ afterEach(async () => {
   for (const client of clients.splice(0)) client.stop()
   for (const plane of planes.splice(0)) await plane.stop()
   for (const server of servers.splice(0)) await server.stop()
-  closeFakeApiServers()
+  await closeFakeApiServers()
 })
 
 function delay(ms: number): Promise<void> {
@@ -82,14 +82,14 @@ async function clusterUnderTest(options: {
 }): Promise<{
   plane: K8sRuntimePlane
   server: ShimServer
-  state: { ready: boolean }
+  state: { ready: boolean; hang: boolean }
   reachable: ReturnType<typeof gate>
   shim: () => ShimClient
 }> {
   const server = new ShimServer()
   const port = await server.start(0, '127.0.0.1')
   servers.push(server)
-  const state = { ready: true }
+  const state = { ready: true, hang: false }
   let claim: unknown
   const { config } = await fakeApiServer(({ method, url }) => {
     const path = url.pathname
@@ -109,7 +109,12 @@ async function clusterUnderTest(options: {
         }
       }
     }
-    if (path.endsWith('/sandboxes/sb-1')) return { json: sandboxObject(state.ready) }
+    if (path.endsWith('/sandboxes/sb-1')) {
+      // `hang` is an API server that accepts the read and never answers it — headers withheld,
+      // response never ended — which is what a request with no deadline waits on forever.
+      if (state.hang) return { lines: [], hold: true }
+      return { json: sandboxObject(state.ready) }
+    }
     if (path.endsWith('/sandboxclaims')) {
       if (method !== 'POST') return { json: { items: [] } }
       claim = { metadata: { name: `agent-${AGENT}`, uid: 'claim-uid-1' }, status: { sandbox: { name: 'sb-1' } } }
@@ -281,6 +286,26 @@ describe('a shim channel that drops while its sandbox pod is coming up', () => {
     // no pod to dial at all — the readiness poll is a quarter of the window, so a report that
     // started its clock at the drop would land far inside it.
     expect(lostAt - readyAt).toBeGreaterThanOrEqual(grace - 50)
+  }, 60_000)
+
+  it('reports loss at the ceiling when the readiness read itself never answers', async () => {
+    // The readiness read is the new dependency this window has, and the Kubernetes client has no
+    // request deadline of its own: one accepted-but-unanswered GET would otherwise pin the watch,
+    // and with it the lost session and the dead host — exactly the stuck-forever outcome the
+    // window exists to remove. Each read is bounded by what is LEFT of the ceiling instead.
+    const { plane, state, reachable, shim } = await clusterUnderTest({ rebindGraceMs: 400, readyTimeoutMs: 2_000 })
+    const client = shim()
+    let terminal = 0
+    const host = hostUnderTest(plane, () => (terminal += 1))
+    await host.start()
+
+    state.hang = true
+    reachable.closed()
+    client.stop()
+    // The launch is released and the runtime learns its channel is gone, so the next message
+    // re-claims a pod and rebuilds the host rather than waiting on a read that never returns.
+    await vi.waitFor(() => expect(plane.driver.currentLaunch(AGENT)).toBeUndefined(), WAIT)
+    await vi.waitFor(() => expect(terminal).toBe(1), WAIT)
   }, 60_000)
 
   it('reports loss for a pod that never comes up, bounded by the pod-up timeout', async () => {


### PR DESCRIPTION
Closes #1010.

## The defect

On a genuine sandbox cold start (PVC bind plus image pull), a shim that drops
its socket cannot dial back until the pod is Running again. The plane counted
that time against a fixed 20s rebind window, so it revoked the binding and
reported the launch lost. Two things then went wrong at once:

- the revoke rejected a dial promise nothing was awaiting, which surfaced as
  `unhandled rejection: Error: binding revoked` from `ShimDialer.stopDial`;
- the ACP host torn down with the loss stayed memoized in the daemon, so the
  retry re-bound at a new generation, brought the gitcred tunnel back, and every
  later turn still failed with `ACP connection closed` until the member was
  replaced.

## The fix

**The loss window starts from the pod being up, not from the socket that
dropped.** `K8sDriver.sandboxReadiness` reads the Sandbox the driver already
watches and answers `ready | starting | absent`. A loss check that finds the pod
still coming up logs and re-reads instead of reporting, the pod's arrival
restarts the whole grace window, and `K8sDriver.podUpTimeoutMs` — the same bound
the launch path waits on — is the ceiling, so a pod that never arrives is still
reported lost. The 20s constant is unchanged; only the event it is measured from
moved.

**A terminal runtime is paired with the ordinary rebuild.** `AcpHost` already
reports terminal exit through `onTerminal`, and a lost sandbox channel produces
exactly that. The daemon now reclaims the host there via `stopHost`, returning
the agent to provisioned, so the next message starts a fresh host through
`ensureHostAsync` — the same path a grant or an activation takes. No second
start-the-host routine, and a host that never became ready is left to
`startHostWithRetry`, which reaps its own failed children.

**Each readiness read is bounded by what is left of the ceiling.** The Kubernetes
client has no request deadline, so a Sandbox GET the API server accepts and never
answers would hold the loss check open forever — the launch pinned, its host dead,
`onChannelLost` never reached. The read carries `AbortSignal.timeout(remaining)`
(the same abort seam a watch uses, threaded through `SandboxApi.getSandbox`), no
new constant: an aborted or failed read counts as "still coming up" for that tick
and the ceiling check that follows decides, so a read that stalls to the ceiling
reports loss the moment it unblocks, and a watch already past its ceiling reads
nothing at all.

**The expected rejection is swallowed where it is expected.** A dial's "next
connection" promise is created pre-observed: a revoke or a supersede rejects it
whether or not anything awaits it, and a caller that *is* waiting still receives
the rejection through `awaitReady`.

## Tests

`packages/daemon/test/cluster-cold-start.test.ts` — a real `SandboxApi` over the
in-process fake API server, a real dialer reaching a real sandbox listener over a
real socket, a real ACP runtime in the "pod", plus a daemon with a real host.

| Test | Mutation that kills it |
| --- | --- |
| keeps dialing the cold pod and serves a turn once it binds | loss check ignores pod readiness (the old fixed window) |
| gives the shim the whole grace window measured from the pod coming up | same, and separately: pod arrival does not restart the window |
| reports loss for a pod that never comes up, bounded by the pod-up timeout | the cold-start ceiling is dropped |
| reports loss at the ceiling when the readiness read itself never answers | the remaining-ceiling bound on the read is dropped (test hangs; the fake API server never answers the GET) |
| still reports loss when the pod is up and no shim comes back, without an unhandled rejection | the dial's ready promise is no longer pre-observed |
| leaves no dead host memoized, so the next message starts a fresh one | the `onTerminal` reap is removed |

Gates: `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, and
`pnpm --filter @agentconnect.md/daemon test` all pass; the only failures are the
pre-existing environmental ones (`shim-cancellation`, `shim-exec-handler`,
`shim-workspace-files`, `workspace-git-runner-seam`, live `acp-matrix`), checked
test-for-test against a clean `main` run on the same machine.
