### PR TITLE
test(k8s-client): sync the watch backoff test on the parked timer

### DIFF
--- a/packages/connection/src/clock.ts
+++ b/packages/connection/src/clock.ts
@@ -46,6 +46,12 @@ export class FakeClock implements Clock {
     return this.t
   }
 
+  /** Armed-timer count — how a test waits for the code under test to park on a delay
+   *  instead of guessing from a side effect that lands earlier. */
+  get pending(): number {
+    return this.timers.size
+  }
+
   setTimeout(fn: () => void, ms: number): TimerHandle {
     const id = ++this.seq
     this.timers.set(id, { at: this.t + Math.max(0, ms), fn })

--- a/packages/k8s-client/src/watch.test.ts
+++ b/packages/k8s-client/src/watch.test.ts
@@ -158,14 +158,18 @@ describe('watchCollection', () => {
     })()
     // Each failed list parks on a clock-driven delay; advancing releases it. A retry
     // whose timer wins must unregister its listener, or a long outage grows them
-    // without bound on this one long-lived signal.
+    // without bound on this one long-lived signal. Wait for the armed timer rather than
+    // for the server's hit count: that lands while the request is still in flight, still
+    // holding the listener node:http registers for its own lifetime.
     for (let attempt = 0; attempt < 3; attempt += 1) {
-      await waitUntil(() => lists === attempt + 1)
+      await waitUntil(() => clock.pending === 1)
+      expect(getEventListeners(controller.signal, 'abort')).toHaveLength(1)
       clock.advance(60_000)
       expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
     }
     await drain
     expect(collected).toEqual(['synced'])
+    expect(lists).toBe(4)
     expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
     controller.abort()
   })


### PR DESCRIPTION
Fixes #1009.

### What was flaky

`watchCollection > backs off a failed connection without accumulating abort listeners` waited for the fake API server's hit count before advancing the clock:

```ts
await waitUntil(() => lists === attempt + 1)
clock.advance(60_000)
expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
```

`lists` is incremented by the *server* handler, which runs before the client has read the response. When the poll wins that race, two things go wrong at once: `clock.advance` fires with no backoff timer armed yet, and the assertion runs while the request is still in flight — still holding the abort listener `node:http` registers for a `ClientRequest`'s lifetime. That listener is the anonymous `[ [Function] ]` in the reported failure; the watch loop's own listener is named `onAbort`.

Reproduced deterministically by delaying the client's read past the poll interval (a 25 ms spin in the fake server handler), which yields the exact reported error at the exact reported line. Under that same forcing, the new version passes 75/75 runs alongside 12 CPU hogs.

### The fix

Wait for the armed backoff timer instead. That state is reachable only after the failed request settled and released its own listener, so the measurement is unambiguous: exactly one listener while parked (this retry's), zero once the timer fires. `FakeClock.pending` exposes the armed-timer count for the wait.

Nothing in `watch.ts` was leaking — this is test synchronization only. Verified the assertion still catches the regression it guards: dropping `cleanup()` from `sleep`'s timer path fails the test with `[ [Function onAbort] ]`.