### PR TITLE
refactor(control-plane): delete CLUSTER_EXECUTION_ENABLED, POOL_NAMESPACE is the switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,15 +156,12 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # OTEL_WEB_DEPLOYMENT_ENVIRONMENT=development
 # OTEL_WEB_PROPAGATE_TRACE_HEADER_URLS=http://localhost:8080
 
-# In-cluster Kubernetes access (docs/designs/k8s-daemon-pool.md) — opt-in. It is
-# what lets the control plane TokenReview a cloud daemon's projected
-# ServiceAccount token. Unset ⇒ off, and only API-key daemon auth is accepted.
-# Switching it on asserts this control plane runs INSIDE the cluster: the
-# credential is the pod's ServiceAccount and the control namespace is the pod's
-# own, so there is nothing else to configure here. A process outside a pod fails
-# at boot rather than at the first call.
-# CLUSTER_EXECUTION_ENABLED=true
-# Namespace this install runs its POOL members in — the pods that serve every org
-# rather than one. Unset ⇒ the control plane's own namespace. A pool member's
-# identity from any other namespace is refused.
+# In-cluster Kubernetes access (docs/designs/k8s-daemon-pool.md) — opt-in. Naming
+# the namespace this install runs its POOL members in (the pods that serve every
+# org rather than one) is the switch: it lets the control plane TokenReview a
+# pool member's projected ServiceAccount token, and asserts this control plane
+# runs INSIDE the cluster — the credential is the pod's ServiceAccount, so there
+# is nothing else to configure and a process outside a pod fails at boot. Unset
+# ⇒ off, only API-key daemon auth is accepted. A pool member's identity from any
+# other namespace is refused.
 # POOL_NAMESPACE=agentconnect

--- a/packages/control-plane/src/cluster/access.test.ts
+++ b/packages/control-plane/src/cluster/access.test.ts
@@ -2,19 +2,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { loadClusterAccess } from './access.js'
 
 // The pod-discovery loader itself is covered in @agentconnect.md/k8s-client;
-// what matters here is the switch and that being outside a pod fails at boot
-// rather than later, at the first write.
+// what matters here is that naming the pool namespace is the switch, and that
+// being outside a pod then fails at boot rather than later, at the first call.
 afterEach(() => vi.unstubAllEnvs())
 
 describe('loadClusterAccess', () => {
-  it('is off by default, so an existing deployment is untouched', () => {
-    expect(loadClusterAccess({ CLUSTER_EXECUTION_ENABLED: false })).toBeUndefined()
+  it('is off when no pool namespace is named, so an existing deployment is untouched', () => {
+    expect(loadClusterAccess({})).toBeUndefined()
   })
 
-  it('refuses to boot when the feature is on outside a pod', () => {
+  it('refuses to boot when a pool namespace is named outside a pod', () => {
     // Stubbed rather than assumed: a runner that IS in Kubernetes would
     // otherwise get past this and read a real ServiceAccount.
     vi.stubEnv('KUBERNETES_SERVICE_HOST', '')
-    expect(() => loadClusterAccess({ CLUSTER_EXECUTION_ENABLED: true })).toThrow(/KUBERNETES_SERVICE_HOST/)
+    expect(() => loadClusterAccess({ POOL_NAMESPACE: 'agentconnect' })).toThrow(/KUBERNETES_SERVICE_HOST/)
   })
 })

--- a/packages/control-plane/src/cluster/access.ts
+++ b/packages/control-plane/src/cluster/access.ts
@@ -1,13 +1,12 @@
 /**
- * Kubernetes API access for the control plane's cluster surface — today the
- * TokenReview call that authenticates an in-cluster daemon.
+ * Kubernetes API access for the control plane's cluster surface (pool member
+ * identity via TokenReview).
  *
- * One switch and no credentials to configure: enabling cluster execution
- * asserts that this control plane runs INSIDE the cluster, so the pod's
- * projected ServiceAccount is the credential and the pod's own namespace is the
- * control namespace. The switch stays explicit — a control plane that merely
- * happens to run on Kubernetes must not start claiming cluster access — but
- * nothing beyond it is a knob.
+ * Naming the pool namespace is the switch, and there are no credentials to
+ * configure: it asserts that this control plane runs INSIDE the cluster, so
+ * the pod's projected ServiceAccount is the credential. A control plane that
+ * merely happens to run on Kubernetes must not start claiming cluster access,
+ * which is why this is an explicit key and not sniffed from the environment.
  *
  * There is deliberately no out-of-cluster mode. An API server plus a token, or
  * a kubeconfig, would each be a second deployment shape to keep correct; a
@@ -17,16 +16,22 @@
 import { loadInClusterConfig, type InClusterConfig } from '@agentconnect.md/k8s-client'
 
 export interface ClusterAccessConfig {
-  /** The whole feature's switch; there is nothing else to set. */
-  CLUSTER_EXECUTION_ENABLED: boolean
+  /** Namespace of this install's pool members; set ⇒ the cluster surface is on. */
+  POOL_NAMESPACE?: string
+}
+
+export interface ClusterAccess {
+  cluster: InClusterConfig
+  poolNamespace: string
 }
 
 /**
- * The in-cluster client config, or undefined when the feature is off. Throws
- * when it is on and this process is not in a pod: the surface is opt-in, so a
- * deployment that asked for it should fail loudly at boot rather than mount a
- * cluster surface whose every call fails at the API server.
+ * The in-cluster client config plus the pool namespace, or undefined when no
+ * pool namespace is named. Throws when one is named and this process is not in
+ * a pod: a deployment that asked for cluster access should fail loudly at boot
+ * rather than mount a surface whose every call fails at the API server.
  */
-export function loadClusterAccess(config: ClusterAccessConfig): InClusterConfig | undefined {
-  return config.CLUSTER_EXECUTION_ENABLED ? loadInClusterConfig() : undefined
+export function loadClusterAccess(config: ClusterAccessConfig): ClusterAccess | undefined {
+  if (!config.POOL_NAMESPACE) return undefined
+  return { cluster: loadInClusterConfig(), poolNamespace: config.POOL_NAMESPACE }
 }

--- a/packages/control-plane/src/config/env.ts
+++ b/packages/control-plane/src/config/env.ts
@@ -223,19 +223,12 @@ const CoreConfigShape = {
   OPEN_CONNECTOR_PROVIDER_BLOCKLIST: z
     .string()
     .default('github,slack,telegram,discord,discordbot,feishu,feishu_app_bot,feishu_custom_bot'),
-  // ── in-cluster Kubernetes access — opt-in ──
-  // The switch for the cluster surface, and the ONLY access knob: turning it on
-  // asserts that this control plane runs inside the cluster, so the pod's
-  // ServiceAccount is the credential and the pod's own namespace is the control
-  // namespace. 'false' (default) ⇒ no cluster module and no behavior change for
-  // an existing deployment. Explicit rather than sniffed: a control plane that
-  // merely happens to run on Kubernetes must not start claiming cluster access.
-  // EXPLICIT enum, not z.coerce.boolean().
-  CLUSTER_EXECUTION_ENABLED: z
-    .enum(['true', 'false'])
-    .default('false')
-    .transform((v) => v === 'true'),
-  // Namespace the install runs its pool members in; unset ⇒ the control plane's own namespace.
+  // ── in-cluster Kubernetes access — opt-in by naming the pool namespace ──
+  // Namespace the install runs its pool members in. Setting it is THE switch for the
+  // cluster surface: it asserts this control plane runs inside the cluster, so the pod's
+  // ServiceAccount is the credential and a process outside a pod fails at boot. Unset ⇒
+  // no cluster module, only API-key daemon auth. Explicit rather than sniffed: a control
+  // plane that merely happens to run on Kubernetes must not start claiming cluster access.
   // A pool identity from any other namespace is refused — the fence around "may name its own org".
   POOL_NAMESPACE: z
     .string()

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -389,21 +389,16 @@ export function buildContainer(
 
   const codec = new ApiKeyCodec({ API_KEY_PEPPER: config.API_KEY_PEPPER })
   const webAppUrl = resolveWebAppUrl(config)
-  // In-cluster Kubernetes access: assembled ONLY when the switch is on. Hoisted above the
-  // auth service because an in-cluster daemon authenticates against this same cluster client.
+  // In-cluster Kubernetes access: assembled ONLY when a pool namespace is named. Hoisted
+  // above the auth service because an in-cluster daemon authenticates against this client.
   const clusterAccess = loadClusterAccess(config)
-  const clusterHttp = clusterAccess ? new K8sHttp(clusterAccess) : undefined
+  const clusterHttp = clusterAccess ? new K8sHttp(clusterAccess.cluster) : undefined
   // The in-cluster daemon's token path; undefined ⇒ this deployment only accepts API keys.
   // Shared by both doors a daemon can knock on — the CP socket and, through `rc/verify`,
   // the relay — so the relay hop can never be the weaker one.
   const clusterIdentity =
     clusterAccess && clusterHttp
-      ? new ClusterDaemonIdentityService(
-          clusterHttp,
-          repos.daemon,
-          // Where this install's pool members live; its own namespace unless told otherwise.
-          config.POOL_NAMESPACE ?? clusterAccess.namespace
-        )
+      ? new ClusterDaemonIdentityService(clusterHttp, repos.daemon, clusterAccess.poolNamespace)
       : undefined
   const auth = new DaemonAuthService(
     codec,

--- a/packages/control-plane/src/platforms/env.test.ts
+++ b/packages/control-plane/src/platforms/env.test.ts
@@ -26,7 +26,6 @@ import { createFeishuCpProvider } from './feishu/provider.js'
 const EXPECTED_KEYS = [
   'ACK_TIMEOUT_MS',
   'API_KEY_PEPPER',
-  'CLUSTER_EXECUTION_ENABLED',
   'CORS_ORIGIN',
   'CRON_RUN_REAP_INTERVAL_SEC',
   'CRON_RUN_TTL_SEC',


### PR DESCRIPTION
## Summary

Deletes `CLUSTER_EXECUTION_ENABLED`. Since the per-org envelope model was retired the flag meant exactly "this control plane may TokenReview an in-cluster daemon" — how a pool member registers — and `POOL_NAMESPACE` already asserted the same fact whenever it was set. #955 records the decision: not renamed (#971 rejected — a rename carries a deprecated alias), deleted once the namespace key can carry the signal on its own.

- **`POOL_NAMESPACE` set ⇒ cluster access on**: `loadClusterAccess` builds the in-cluster client from the pod's ServiceAccount (still fail-loud outside a pod) and returns it together with the pool namespace; the container no longer falls back to the pod's own namespace.
- **Unset ⇒ off**: no cluster module, API-key daemon auth only. Same default as before.
- `.env.example` and the schema comments describe the one key; the deployment-key list test drops the flag.

## Compatibility

Deployments that still set `CLUSTER_EXECUTION_ENABLED` keep working — the key is ignored. The only shape that changes is "flag on, no `POOL_NAMESPACE`", which meant "pool members live in the CP's own namespace" and now needs that namespace named explicitly. Deployment side follows separately (the transitional `clusterExecution.enabled` block).

## Test plan

- `pnpm --filter @agentconnect.md/control-plane typecheck` / unit tests for `cluster/`, `config/`, `platforms/env.test.ts` pass; `pnpm lint` clean.
- Test cluster: the chart already renders `POOL_NAMESPACE`, so pool members should register unchanged on the release carrying this.

Refs #955.
