### PR TITLE
fix(daemon): allocate shim binding generations from the shared store

### DIFF
--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -294,6 +294,17 @@ After loss is reported, the driver revokes the outbound dial and forgets the lau
 socket therefore cannot reattach to the terminal session; the next turn creates a fresh
 generation and dials the pod through the ordinary wake path.
 
+**The generation belongs to the agent, not to the daemon process.** A sandbox pod's shim
+records the highest generation it has ever bound and refuses anything below it for the rest of
+that pod's life, so the number has to be allocated from state every daemon that may hold the
+agent shares — `LocalStore.nextSandboxGeneration`, one atomic upsert, on the pool's shared
+Postgres store for a pool member and on SQLite for a local daemon. A per-process counter was
+correct only under the original assumption of one daemon per sandbox for the sandbox's life:
+in the pool an agent moves to another member on every rollout, and a successor restarting at 1
+would be closed with `stale generation` on every dial — every turn ending in a launch timeout
+until the pod happened to be recycled. Because the number fences a pod rather than a claim,
+the row deliberately outlives the claim it was allocated for.
+
 **Removed ⇒ delete the claim, and the volume with it.** Where the local path deletes the
 agent's checkout, the cluster path deletes its SandboxClaim; the volume is not reachable from
 the daemon's filesystem, so nothing else can. This is removal only. A **detached or moved**

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2899,6 +2899,9 @@ export class Daemon {
       const startPlane = this.opts.startK8sPlane ?? startK8sRuntimePlane
       try {
         this.k8sPlane = await startPlane({
+          // The data plane opened above, so launch generations are counted in state every pool
+          // member shares — a per-process counter restarts at 1 and the agent's pod refuses it.
+          generations: this.dataPlane!.store,
           orgForAgent: (agentId) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
           // Which sockets this agent's pod needs, and where this daemon serves them. A GitHub-App
           // workspace is the one case today: its git reaches the credential helper over a unix

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -56,12 +56,21 @@ export const RUNTIME_GRANTS: ShimCapability[] = ['acp', 'materialize', 'exec', '
  *  authority it never exercises — which the direct-connect grant test exists to catch. */
 export const PROBE_GRANTS: ShimCapability[] = ['probe']
 
+/** Allocator for the per-agent shim-binding generation; the daemon store is the durable one. */
+export interface LaunchGenerations {
+  nextSandboxGeneration(agentId: string): number
+}
+
 export interface K8sDriverDeps {
   api: SandboxApi
   /** Resolves tenant ownership at claim time; pool members serve more than one org. */
   orgForAgent: (agentId: string) => string | undefined
   /** Pool the claim references; v1beta1 requires one, and a cold pool is `replicas: 0`. */
   warmPoolName: string
+  /** Where a launch's generation comes from. Never a process-local counter: agents move between
+   *  pool members while their sandbox pod stays, and that pod refuses any generation below the
+   *  highest it has bound — so a successor must continue the sequence, not restart it. */
+  generations: LaunchGenerations
   /** Optional claim metadata for host-owned synthetic agents such as runtime probes. */
   claimMetadataForAgent?: (
     agentId: string
@@ -124,7 +133,6 @@ interface Launch {
 export class K8sDriver implements SpawnDriver {
   private readonly metrics: ClusterMetrics
   private readonly launches = new Map<string, Launch>()
-  private readonly generations = new Map<string, number>()
   /** Live work per Sandbox: binds, workspace preparation, and runtimes that have not exited. */
   private readonly busy = new Map<string, number>()
   /** Per-SANDBOX transition queue. A guarded write protects competing writes, but it cannot
@@ -198,8 +206,9 @@ export class K8sDriver implements SpawnDriver {
     )
     const sandboxUid = sandbox.metadata?.uid
     if (!sandboxUid) throw new Error(`sandbox ${sandboxName} has no metadata.uid to bind against`)
-    const generation = (this.generations.get(agentId) ?? 0) + 1
-    this.generations.set(agentId, generation)
+    // Allocated from durable install-wide state, not from this process: the pod this launch is
+    // about to dial may have been bound by a member that has since been rolled away.
+    const generation = this.deps.generations.nextSandboxGeneration(agentId)
     const launch: Launch = { agentId, sandboxName, sandboxUid, generation }
     this.launches.set(agentId, launch)
     return launch

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { K8sHttp, loadInClusterConfig } from '@agentconnect.md/k8s-client'
-import { K8sDriver, PROBE_GRANTS } from './driver.js'
+import { K8sDriver, PROBE_GRANTS, type LaunchGenerations } from './driver.js'
 import { SandboxApi } from './sandbox-api.js'
 import { clusterMetrics } from './cluster-metrics.js'
 import { ShimDialer } from '../shim/dialer.js'
@@ -84,6 +84,9 @@ interface LossWatch {
  * daemon's own host and no Sandbox was ever created.
  */
 export interface K8sRuntimePlaneOptions {
+  /** Durable, install-shared allocator for launch generations — in production the daemon store,
+   *  which every pool member shares, so an agent that moves between members keeps counting up. */
+  generations: LaunchGenerations
   /** Connection-scoped org for an envelope daemon; absent for an install-wide pool member. */
   orgId?: string
   /** Per-agent tenant lookup used by an install-wide pool member. */
@@ -138,7 +141,7 @@ export const K8S_SHIM_PORT_ENV = 'AC_K8S_SHIM_PORT'
 export const DEFAULT_SHIM_PORT = DEFAULT_SHIM_LISTEN_PORT
 
 /** Explicit options win per FIELD, so a caller may name one and leave the rest to the env. */
-export function resolveK8sPlaneSettings(options: K8sRuntimePlaneOptions = {}): K8sPlaneSettings {
+export function resolveK8sPlaneSettings(options: Partial<K8sRuntimePlaneOptions> = {}): K8sPlaneSettings {
   const env = options.env ?? process.env
   const orgId = options.orgId ?? env[K8S_ORG_ID_ENV]?.trim()
   const warmPoolName = options.warmPoolName ?? env[K8S_WARM_POOL_ENV]?.trim()
@@ -278,6 +281,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
         ? (settings.orgId ?? 'install')
         : (options.orgForAgent?.(agentId) ?? settings.orgId),
     warmPoolName: settings.warmPoolName,
+    generations: options.generations,
     claimMetadataForAgent: (agentId) =>
       agentId === runtimeProbeAgentId
         ? {

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1049,6 +1049,13 @@ export class LocalStore {
         endedAt TEXT
       );
       CREATE INDEX IF NOT EXISTS dreams_agent_created ON dreams (agentId, createdAt DESC);
+      -- Monotonic shim-binding generation per agent. Durable and install-shared because a sandbox
+      -- pod outlives the daemon holding it: a member that restarted the count would dial below the
+      -- generation that pod already bound, which its shim refuses for the rest of the pod's life.
+      CREATE TABLE IF NOT EXISTS sandbox_generations (
+        agentId TEXT PRIMARY KEY,
+        generation INTEGER NOT NULL
+      );
     `)
     // Stamped only once the CREATE block above has actually emitted that schema, so
     // a store that failed halfway through creation is not left claiming to be current.
@@ -4354,6 +4361,20 @@ export class LocalStore {
   gcRuntimeCatalog(cutoffEpochMs: number): void {
     this.db.prepare('DELETE FROM runtime_catalog_meta WHERE observedAt < ?').run(cutoffEpochMs)
     this.db.prepare('DELETE FROM runtime_model_catalog WHERE observedAt < ?').run(cutoffEpochMs)
+  }
+
+  /** Next shim-binding generation for an agent's sandbox: one atomic upsert, so two members cannot tie. */
+  // The row outlives the claim on purpose — nothing here may hand out a number a pod has seen before.
+  nextSandboxGeneration(agentId: string): number {
+    const row = this.db
+      .prepare(
+        `INSERT INTO sandbox_generations (agentId, generation) VALUES (?, 1)
+         ON CONFLICT(agentId) DO UPDATE SET generation = sandbox_generations.generation + 1
+         RETURNING generation`
+      )
+      .get(agentId) as { generation: number } | undefined
+    if (row === undefined) throw new Error(`could not allocate a sandbox generation for agent ${agentId}`)
+    return Number(row.generation)
   }
 
   close(): void {

--- a/packages/daemon/test/cluster-acp-e2e.test.ts
+++ b/packages/daemon/test/cluster-acp-e2e.test.ts
@@ -11,6 +11,7 @@ import { ShimServer } from '../src/shim/server.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import { GuardedResumeRejectedError, type Sandbox, type SandboxClaim } from '../src/k8s/sandbox-api.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
+import { fakeGenerations } from './fake-generations.js'
 
 /**
  * A complete ACP turn through the cluster path: driver → listener → shim → runtime → back.
@@ -159,6 +160,7 @@ async function clusterUnderTest(options: { credentialTtlMs?: number } = {}): Pro
     api: api.api as never,
     orgForAgent: () => 'org-1',
     warmPoolName: 'pool',
+    generations: fakeGenerations(),
     connectChannel: (record: SpawnRecord, _podIp, timeoutMs) =>
       dialer.connect(`ws://127.0.0.1:${port}`, record, timeoutMs),
     revokeChannel: (agentId) => dialer.revokeAgent(agentId),

--- a/packages/daemon/test/cluster-cold-start.test.ts
+++ b/packages/daemon/test/cluster-cold-start.test.ts
@@ -12,6 +12,7 @@ import { SandboxApi } from '../src/k8s/sandbox-api.js'
 import { startK8sRuntimePlane, type K8sRuntimePlane } from '../src/k8s/runtime-plane.js'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import { ShimServer } from '../src/shim/server.js'
+import { fakeGenerations } from './fake-generations.js'
 
 /**
  * The sandbox cold-start race (#1010).
@@ -133,6 +134,7 @@ async function clusterUnderTest(options: {
   const plane = await startK8sRuntimePlane({
     orgId: 'org-1',
     warmPoolName: 'pool',
+    generations: fakeGenerations(),
     sandboxNamespace: 'agent-sandboxes',
     memberId: 'member-a',
     shimPort: port,

--- a/packages/daemon/test/cluster-metrics.test.ts
+++ b/packages/daemon/test/cluster-metrics.test.ts
@@ -5,6 +5,7 @@ import { K8sDriver, type ClusterDriverDeps } from '../src/k8s/driver.js'
 import { LaunchTimer, type ClusterMetrics, type LaunchPath, type LaunchStage } from '../src/k8s/cluster-metrics.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import { GuardedResumeRejectedError, type Sandbox, type SandboxClaim } from '../src/k8s/sandbox-api.js'
+import { fakeGenerations } from './fake-generations.js'
 
 // The acceptance criterion for D9 is a dashboard that settles "resume p95 ≤ 15s, cold start
 // p95 ≤ 60s" without log archaeology. That is only true if the cold/resume tag is right and the
@@ -153,6 +154,7 @@ function driverFor(
     api: api.api as never,
     orgForAgent: () => 'org-1',
     warmPoolName: 'pool',
+    generations: fakeGenerations(),
     connectChannel: awaitChannel
       ? async (record, _podIp, timeoutMs) => await awaitChannel(record.agentId, record.generation, timeoutMs)
       : async () => respondingConnection(open) as never,

--- a/packages/daemon/test/direct-connect-credentials.test.ts
+++ b/packages/daemon/test/direct-connect-credentials.test.ts
@@ -4,6 +4,7 @@ import { turnFailureCode } from '../src/acp/acp-host.js'
 import { K8sDriver, RUNTIME_GRANTS } from '../src/k8s/driver.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
+import { fakeGenerations } from './fake-generations.js'
 import type { ShimConnection } from '../src/shim/listener.js'
 
 /**
@@ -54,6 +55,7 @@ describe('provider credentials in the direct-connect stage', () => {
       api: api as never,
       orgForAgent: () => 'org-1',
       warmPoolName: 'pool',
+      generations: fakeGenerations(),
       connectChannel: async () => ({}) as ShimConnection,
       log: { info: () => {}, warn: () => {}, debug: () => {} }
     })

--- a/packages/daemon/test/fake-generations.ts
+++ b/packages/daemon/test/fake-generations.ts
@@ -1,0 +1,13 @@
+import type { LaunchGenerations } from '../src/k8s/driver.js'
+
+/** Process-local stand-in for the shared store, for tests that only need generations to increase. */
+export function fakeGenerations(): LaunchGenerations {
+  const counters = new Map<string, number>()
+  return {
+    nextSandboxGeneration(agentId: string): number {
+      const next = (counters.get(agentId) ?? 0) + 1
+      counters.set(agentId, next)
+      return next
+    }
+  }
+}

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -1,6 +1,11 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { FakeClock } from '@agentconnect.md/connection'
 import { K8sDriver, AC_LABEL_AGENT, AC_LABEL_ORG } from '../src/k8s/driver.js'
+import { LocalStore } from '../src/store/local-store.js'
+import { fakeGenerations } from './fake-generations.js'
 import { GuardedResumeRejectedError, OperatingModeRejectedError } from '../src/k8s/sandbox-api.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
@@ -136,6 +141,7 @@ function driver(api: ReturnType<typeof fakeApi>['api'], overrides: Record<string
     api: api as never,
     orgForAgent: () => 'org-1',
     warmPoolName: 'ac-runtime-standard-pool',
+    generations: fakeGenerations(),
     clock,
     log: { info: (message: string) => infos.push(message), warn: () => {}, debug: () => {} },
     ...overrides,
@@ -664,5 +670,67 @@ describe('cluster spawn driver', () => {
     const { api } = fakeApi()
     const { instance } = driver(api)
     await expect(instance.launch({ command: 'claude-code-acp', args: [], env: {} })).rejects.toThrow(/AC_AGENT_ID/)
+  })
+})
+
+/**
+ * The pool moves an agent between members on every rollout while its sandbox pod stays up, and
+ * that pod's shim refuses any generation below the highest it has ever bound. A per-process
+ * counter therefore breaks the successor permanently: it dials 1 against a pod already bound at
+ * 2, is closed with `stale generation`, and every turn ends in a launch timeout until the pod is
+ * recycled. The sequence has to come from state the members share.
+ */
+describe('cluster launch generations', () => {
+  function storeFile(): string {
+    return join(mkdtempSync(join(tmpdir(), 'ac-generations-')), 'state.db')
+  }
+
+  it('continues the sequence when a successor member takes an agent over', async () => {
+    const store = new LocalStore(storeFile())
+    const { api } = fakeApi()
+    const memberA = driver(api, { generations: store })
+    expect((await memberA.instance.ensureSandbox('agent-a')).generation).toBe(1)
+    // A dial that timed out forgets the launch, so the same member re-claims at a fresh generation.
+    memberA.instance.forgetLaunch('agent-a')
+    expect((await memberA.instance.ensureSandbox('agent-a')).generation).toBe(2)
+    // The rollout: a different member process, the same sandbox pod, the same shared store.
+    const memberB = driver(api, { generations: store })
+    expect((await memberB.instance.ensureSandbox('agent-a')).generation).toBe(3)
+    store.close()
+  })
+
+  it('resumes the sequence from the store after the member process restarts', async () => {
+    const path = storeFile()
+    const first = new LocalStore(path)
+    const before = driver(fakeApi().api, { generations: first })
+    expect((await before.instance.ensureSandbox('agent-a')).generation).toBe(1)
+    first.close()
+    const reopened = new LocalStore(path)
+    const after = driver(fakeApi().api, { generations: reopened })
+    expect((await after.instance.ensureSandbox('agent-a')).generation).toBe(2)
+    reopened.close()
+  })
+
+  it('counts each agent independently, so churn on one pod does not skip generations on another', async () => {
+    const store = new LocalStore(storeFile())
+    const { api } = fakeApi()
+    const { instance } = driver(api, { generations: store })
+    expect((await instance.ensureSandbox('agent-a')).generation).toBe(1)
+    instance.forgetLaunch('agent-a')
+    expect((await instance.ensureSandbox('agent-a')).generation).toBe(2)
+    expect((await instance.ensureSandbox('agent-b')).generation).toBe(1)
+    store.close()
+  })
+
+  it('does not consume a generation when the cached launch answers', async () => {
+    const store = new LocalStore(storeFile())
+    const { api } = fakeApi()
+    const { instance } = driver(api, { generations: store })
+    await instance.ensureSandbox('agent-a')
+    // Re-attach, not re-launch: the shim binding registry treats an equal generation from the
+    // same pod as a reconnect, and burning a number here would fence out the live channel.
+    expect((await instance.ensureSandbox('agent-a')).generation).toBe(1)
+    expect(store.nextSandboxGeneration('agent-a')).toBe(2)
+    store.close()
   })
 })

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -13,6 +13,7 @@ import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import { ShimServer } from '../src/shim/server.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
+import { fakeGenerations } from './fake-generations.js'
 
 /**
  * The assembly itself, which is the thing that did not exist: every part of the k8s path was
@@ -91,6 +92,7 @@ async function planeUnderTest(api: ReturnType<typeof fakeApi>): Promise<K8sRunti
   const plane = await startK8sRuntimePlane({
     orgId: 'org-1',
     warmPoolName: 'pool',
+    generations: fakeGenerations(),
     sandboxNamespace: 'agent-sandboxes',
     memberId: 'member-a',
     shimPort: port,

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -1603,3 +1603,24 @@ describe('LocalStore activation rendezvous (send-message-routing-rework.md §3.2
     s.close()
   })
 })
+
+describe('sandbox generations', () => {
+  it('never hands the same number out twice for an agent, and starts each agent at 1', () => {
+    const s = store()
+    expect(s.nextSandboxGeneration('agent-a')).toBe(1)
+    expect(s.nextSandboxGeneration('agent-a')).toBe(2)
+    expect(s.nextSandboxGeneration('agent-b')).toBe(1)
+    expect(s.nextSandboxGeneration('agent-a')).toBe(3)
+    s.close()
+  })
+
+  it('survives a reopen, because the sandbox pod the number fences does', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-generations-')), 'local.sqlite')
+    const first = new LocalStore(path)
+    expect(first.nextSandboxGeneration('agent-a')).toBe(1)
+    first.close()
+    const reopened = new LocalStore(path)
+    expect(reopened.nextSandboxGeneration('agent-a')).toBe(2)
+    reopened.close()
+  })
+})

--- a/packages/daemon/test/shim-tunnel.test.ts
+++ b/packages/daemon/test/shim-tunnel.test.ts
@@ -12,6 +12,7 @@ import { TunnelHost } from '../src/shim/tunnel-host.js'
 import { TunnelProxy } from '../src/shim/tunnel-proxy.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
+import { fakeGenerations } from './fake-generations.js'
 import type { ShimEvent } from '../src/shim/protocol.js'
 import type { TunnelName } from '../src/shim/tunnel.js'
 
@@ -128,6 +129,7 @@ async function clusterWithTunnel(
   const plane = await startK8sRuntimePlane({
     orgId: 'org-1',
     warmPoolName: 'pool',
+    generations: fakeGenerations(),
     sandboxNamespace: 'agent-sandboxes',
     memberId: 'member-a',
     shimPort,


### PR DESCRIPTION
## Summary

The k8s spawn driver counted shim-binding generations in a per-process `Map`, so every daemon
process started an agent's sequence at 1. That was correct only under the original assumption
of **one daemon per sandbox for the sandbox's life**. The pool breaks it: agents are held via
duty leases and move to another member on every rollout, while their Sandbox keeps running.

Generations now come from the daemon store — `LocalStore.nextSandboxGeneration`, one atomic
upsert against a new `sandbox_generations` row. Pool members already share that store on
Postgres (#958), a local daemon keeps it in SQLite, so a successor member continues the
sequence instead of restarting it.

## Failure scenario (observed on a test cluster)

1. Member A launches `agent-x` against its Running sandbox pod, binds generation 1.
2. Something makes A re-launch — a dial timeout, an ACP host restart — so it forgets the launch
   and re-claims at generation 2. The pod's shim client records 2 as the highest it has bound.
3. A rollout replaces A with member B. B's `Map` is empty, so its first dial says generation 1.
4. `ShimClient` closes it with `4403 stale generation` (it refuses any hello below the highest
   generation it has ever bound, for the rest of that pod's life).
5. Every turn then ends in `LaunchTimeoutError: no shim channel bound for agent … in time`,
   until the pod happens to be recycled by a suspend/resume.

## Fix

- `LocalStore.nextSandboxGeneration(agentId)` — `INSERT … ON CONFLICT DO UPDATE SET generation
  = generation + 1 RETURNING generation`. One statement, so two members allocating for the same
  agent at the same time cannot tie.
- `K8sDriverDeps.generations` / `K8sRuntimePlaneOptions.generations` are **required**, with no
  in-memory default — a silent fallback is exactly the bug being fixed. `daemon.ts` passes the
  data-plane store, which in `--k8s` mode is opened immediately before the execution plane.
- The row deliberately outlives the claim it was allocated for: the number fences a *pod*, and
  a warm-pool pod can be reused, so a reset counter is never safe. Cost is one small row per
  agent (and per member-scoped runtime probe identity).
- Wall-clock time is not used, as required — the sequence stays a dense monotonic counter.

Fence semantics are unchanged. `ensureSandbox` still returns a cached launch without
allocating, so an equal-generation re-bind is still the reconnect `ShimBindingRegistry.bind`
expects (same pod, same generation = renewal, not duplicate); `onChannelLost` still drops the
session and the launch so the next turn claims a fresh generation; `suspendIfIdle` and
`forgetLaunch` are untouched.

`docs/designs/cluster-spawn-and-shim.md` gains a paragraph stating that the generation belongs
to the agent, not to the daemon process.

## Test plan

- `packages/daemon/test/k8s-driver.test.ts` — new `cluster launch generations` suite: a
  successor member sharing one store continues at 3 after the predecessor reached 2; the
  sequence resumes from the database after the process restarts; agents count independently;
  a cached launch consumes no generation.
- `packages/daemon/test/local-store.test.ts` — the primitive itself: never the same number
  twice per agent, each agent starts at 1, survives a reopen.
- `pnpm --filter @agentconnect.md/daemon test` — 10 affected suites pass (190 tests). The 5
  files failing in the full run (`shim-workspace-files`, `shim-cancellation`,
  `shim-exec-handler`, `workspace-git-runner-seam`, `acp-matrix`) fail identically on
  `origin/main` in this environment; verified by re-running them on a clean tree.
- `pnpm --filter @agentconnect.md/daemon typecheck` and `pnpm lint` clean.
