### PR TITLE
fix(control-plane): session content follows the serving daemon

### DIFF
--- a/packages/control-plane/prisma/migrations/20260824000000_session_content_set/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260824000000_session_content_set/migration.sql
@@ -1,0 +1,33 @@
+-- Session-scoped content provenance: WHICH store this session's transcript was written to.
+-- `daemonId` names the daemon that first reported the session, but a member set's daemons share
+-- one data-plane store, so a retired member's rows stay readable through a peer. That failover is
+-- only sound when the session itself was written to that set's store — the agent's CURRENT
+-- placement proves nothing, because an agent can be moved into (or between) sets long after a
+-- session ran on a local daemon. Null ⇒ the recorded daemon's own local store; nobody else has it.
+ALTER TABLE "session_meta" ADD COLUMN "contentSetId" UUID;
+
+ALTER TABLE "session_meta" ADD CONSTRAINT "session_meta_contentSetId_fkey"
+  FOREIGN KEY ("contentSetId") REFERENCES "member_set"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Backfill (a): the recorded daemon is currently a member of a set, so the content it holds lives
+-- in that set's shared store.
+UPDATE "session_meta" s
+SET "contentSetId" = m."setId"
+FROM "member_set_member" m
+WHERE s."daemonId" = m."daemonId" AND s."contentSetId" IS NULL;
+
+-- Backfill (b): `daemonId IS NULL` on a `set`-placed agent ⇒ that agent's set. The only writer of
+-- that null is the FK when a daemon row is deleted, and the only daemons deleted out from under
+-- live sessions are org-less pool members retired by the pool-member reaper — which are by
+-- definition members of the set the agent is placed on. A machine-placed agent keeps its recorded
+-- daemon, so it is untouched here and stays null.
+UPDATE "session_meta" s
+SET "contentSetId" = a."setId"
+FROM "agent" a
+WHERE s."agentId" = a.id
+  AND s."daemonId" IS NULL
+  AND s."contentSetId" IS NULL
+  AND a."placementKind" = 'set'
+  AND a."setId" IS NOT NULL;
+
+-- Everything else stays null: no evidence the content was ever written to a shared store.

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -685,8 +685,9 @@ model MemberSet {
   createdAt DateTime @default(now()) @db.Timestamptz(6)
 
   org     Org?              @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  members MemberSetMember[]
-  agents  Agent[]
+  members  MemberSetMember[]
+  agents   Agent[]
+  sessions SessionMeta[]
 
   @@index([orgId])
   @@map("member_set")
@@ -1039,6 +1040,11 @@ model SessionMeta {
   permissionMode      String? // runtime permission/approval mode
   outputMode          String? // daemon-side output verbosity (low/medium/high)
   daemonId            String?             @db.Uuid // first daemon that reported the session; immutable content owner, stamped by the CP from the authenticated WS conn, never daemon-echoed
+  // The member set whose SHARED data-plane store this session's content was written to, stamped
+  // from `daemonId`'s membership when that daemon is pinned. Null ⇒ the recorded daemon's own
+  // local store, which no other daemon can read. Session-scoped on purpose: the agent's CURRENT
+  // placement says nothing about where a past session's transcript landed.
+  contentSetId        String?             @db.Uuid
   // Session-pinned checkout choice. Null is a legacy row whose daemon never
   // reported it; `session` identifies a daemon-local worktree eligible for the
   // authorized Workspace viewer.
@@ -1085,6 +1091,7 @@ model SessionMeta {
   agent         Agent          @relation(fields: [agentId], references: [id], onDelete: Cascade)
   launch        AgentLaunch?   @relation(fields: [launchId], references: [id], onDelete: SetNull)
   daemon        Daemon?        @relation(fields: [daemonId], references: [id], onDelete: SetNull)
+  contentSet    MemberSet?     @relation(fields: [contentSetId], references: [id], onDelete: SetNull)
   externalScope ExternalScope? @relation(fields: [externalScopeId, orgId, externalProvider], references: [id, orgId, provider], onDelete: Restrict, onUpdate: Restrict)
 
   webchatCurrentFor      WebchatConversation[]      @relation("WebchatCurrentSession")

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -8,8 +8,8 @@
  * - `GET /sessions` lists CP-stored session metadata synced by daemon
  *   `event/session` snapshots. Transcript bodies still stay daemon-local.
  * - `GET /sessions/:id/messages` pulls one transcript page from the daemon that
- *   can serve it — the recorded one, else the serving daemon of a shared-store
- *   placement — and proxies it through. Bodies transit the CP live for display
+ *   can serve it — the recorded one, else a live member of the shared store the
+ *   session was written to — and proxies it through. Bodies transit the CP live for display
  *   only, never persisted (body-locality §1/§12).
  */
 import type { FastifyInstance, FastifyRequest } from 'fastify'
@@ -421,12 +421,13 @@ export function sessionRoutes(deps: HttpDeps) {
     // Daemon-local session content, read through the daemon that can still serve it. The recorded
     // daemon owns it, but a pool member is replaceable: retiring one deletes its row and nulls the
     // session's `daemonId`, while its set peers read the same shared store. So: recorded daemon
-    // first, then whatever `contentFailoverDaemon` names — null unless the store is shared, which
-    // is how a machine-placed agent's move keeps answering 503 instead of a false empty page.
+    // first, then whatever `contentFailoverDaemon` names for THIS session's recorded store — null
+    // unless that store is shared and still the agent's, which is how a move keeps answering 503
+    // instead of a false empty page.
     type ContentRead<T> = { ok: true; value: T } | { ok: false; reason: 'unplaced' | 'offline' }
     const readSessionContent = async <T>(
       req: FastifyRequest,
-      session: { agentId: string; daemonId: string | null },
+      session: { agentId: string; daemonId: string | null; contentSetId: string | null },
       read: (daemonId: string) => Promise<T>
     ): Promise<ContentRead<T>> => {
       if (session.daemonId) {
@@ -437,7 +438,7 @@ export function sessionRoutes(deps: HttpDeps) {
         }
       }
       const agent = await deps.repos.agent.get(orgOf(req), AgentId(session.agentId))
-      const failover = agent ? await deps.placementResolver.contentFailoverDaemon(agent) : null
+      const failover = agent ? await deps.placementResolver.contentFailoverDaemon(agent, session) : null
       if (!failover) return { ok: false, reason: session.daemonId ? 'offline' : 'unplaced' }
       if (failover === session.daemonId) return { ok: false, reason: 'offline' }
       try {
@@ -905,7 +906,7 @@ export function sessionRoutes(deps: HttpDeps) {
 
     // Replay view: proxy a page of the session's chat history live from the daemon that can serve
     // it. CP stores list/detail metadata only, not transcript bodies. The recorded daemon is tried
-    // first; only a shared-store placement has a second daemon holding the same content.
+    // first; only a session written to a shared store has a second daemon holding the same rows.
     r.get(
       '/sessions/:id/messages',
       {
@@ -913,7 +914,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get session messages',
           description:
-            "Proxies a page of the session's chat history live from the daemon recorded on the session, falling back to the agent's current serving daemon when its placement shares one content store; 503 if neither is known or reachable.",
+            "Proxies a page of the session's chat history live from the daemon recorded on the session, falling back to the agent's current serving daemon when the session was written to a member set's shared content store the agent is still placed on; 503 if neither is known or reachable.",
           operationId: 'getSessionMessages',
           params: IdParam,
           querystring: SessionHistoryQueryDto,
@@ -970,7 +971,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get a tool-call body',
           description:
-            "Proxies one byte slice of a tool call's untruncated ToolBody JSON live from the daemon recorded on the session, falling back to the agent's current serving daemon when its placement shares one content store; the console pages by offset until nextOffset is null. 503 if neither is known or reachable.",
+            "Proxies one byte slice of a tool call's untruncated ToolBody JSON live from the daemon recorded on the session, falling back to the agent's current serving daemon when the session was written to a member set's shared content store the agent is still placed on; the console pages by offset until nextOffset is null. 503 if neither is known or reachable.",
           operationId: 'getSessionToolBody',
           params: IdParam,
           querystring: SessionToolBodyQueryDto,

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -7,9 +7,10 @@
  *
  * - `GET /sessions` lists CP-stored session metadata synced by daemon
  *   `event/session` snapshots. Transcript bodies still stay daemon-local.
- * - `GET /sessions/:id/messages` pulls one transcript page from the owning
- *   daemon (resolved via the row's `agentId`) and proxies it through. Bodies
- *   transit the CP live for display only, never persisted (body-locality §1/§12).
+ * - `GET /sessions/:id/messages` pulls one transcript page from the daemon that
+ *   can serve it — the recorded one, else the agent's current serving daemon —
+ *   and proxies it through. Bodies transit the CP live for display only, never
+ *   persisted (body-locality §1/§12).
  */
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { z } from 'zod'
@@ -416,6 +417,43 @@ export function sessionRoutes(deps: HttpDeps) {
       if (!canViewSession(session, ctxOf(req), access.identitySet, access.externalAccess)) return null
       return { session, access }
     }
+
+    // Daemon-local session content, read through the daemon that can still serve it. The recorded
+    // daemon owns it, but a pool member is replaceable: retiring one deletes its row and nulls the
+    // session's `daemonId`, while whichever daemon serves the agent now reads the same store. So:
+    // recorded daemon first, then the agent's current serving daemon. No placement kind is read
+    // here — the resolver is the abstraction.
+    type ContentRead<T> = { ok: true; value: T } | { ok: false; reason: 'unplaced' | 'offline' }
+    const readSessionContent = async <T>(
+      req: FastifyRequest,
+      session: { agentId: string; daemonId: string | null },
+      read: (daemonId: string) => Promise<T>
+    ): Promise<ContentRead<T>> => {
+      if (session.daemonId) {
+        try {
+          return { ok: true, value: await read(session.daemonId) }
+        } catch (err) {
+          if (!(err instanceof NoConnection)) throw err
+        }
+      }
+      const agent = await deps.repos.agent.get(orgOf(req), AgentId(session.agentId))
+      const serving = agent ? await deps.placementResolver.servingDaemon(agent) : null
+      if (!serving) return { ok: false, reason: session.daemonId ? 'offline' : 'unplaced' }
+      if (serving === session.daemonId) return { ok: false, reason: 'offline' }
+      try {
+        return { ok: true, value: await read(serving) }
+      } catch (err) {
+        if (err instanceof NoConnection) return { ok: false, reason: 'offline' }
+        throw err
+      }
+    }
+
+    // The two 503s the content proxies answer with when nothing served the read.
+    const contentUnavailable = (reason: 'unplaced' | 'offline') => ({
+      error: 'Service Unavailable',
+      statusCode: 503 as const,
+      message: reason === 'unplaced' ? 'session has no recorded daemon' : 'owning daemon is offline'
+    })
 
     type ExternalAccessProvider = 'slack' | 'github' | 'feishu'
     const externalAccessAvailable = (provider: ExternalAccessProvider) =>
@@ -865,10 +903,9 @@ export function sessionRoutes(deps: HttpDeps) {
       }
     )
 
-    // Replay view: proxy a page of the session's chat history live from the
-    // session-recorded daemon. CP stores list/detail metadata only, not transcript
-    // bodies. Agent placement may have changed since this session ran; content
-    // stays on its original daemon and does not follow that move.
+    // Replay view: proxy a page of the session's chat history live from the daemon that can serve
+    // it. CP stores list/detail metadata only, not transcript bodies. The recorded daemon is tried
+    // first; when it is gone or unreachable the read follows the agent's current serving daemon.
     r.get(
       '/sessions/:id/messages',
       {
@@ -876,7 +913,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get session messages',
           description:
-            "Proxies a page of the session's chat history live from the daemon recorded on the session; 503 if that daemon is unknown or offline.",
+            "Proxies a page of the session's chat history live from the daemon recorded on the session, falling back to the agent's current serving daemon; 503 if neither is known or reachable.",
           operationId: 'getSessionMessages',
           params: IdParam,
           querystring: SessionHistoryQueryDto,
@@ -898,46 +935,34 @@ export function sessionRoutes(deps: HttpDeps) {
         if (session.contentPurgedAt) {
           return { sessionId: session.id, messages: [], nextCursor: null, liveCursor: null, liveMore: false }
         }
-        if (!session.daemonId) {
-          return reply
-            .code(503)
-            .send({ error: 'Service Unavailable', statusCode: 503, message: 'session has no recorded daemon' })
-        }
-
-        try {
-          const page = await deps.control.sessionHistory(session.daemonId, {
+        const read = await readSessionContent(req, session, (daemonId) =>
+          deps.control.sessionHistory(daemonId, {
             agentId: session.agentId,
             sessionId: session.id,
             ...(req.query.cursor !== undefined ? { cursor: req.query.cursor } : {}),
             ...(req.query.after !== undefined ? { after: req.query.after } : {}),
             limit: req.query.limit ?? 50
           })
-          // Provider membership and identity can be revoked while the daemon is
-          // answering. Re-run the complete predicate before any body leaves CP.
-          if (!(await getOrgViewableSession(req, req.params.id))) {
-            return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
-          }
-          return {
-            sessionId: page.sessionId,
-            messages: page.messages,
-            nextCursor: page.nextCursor ?? null,
-            liveCursor: page.liveCursor ?? null,
-            liveMore: page.liveMore ?? false
-          }
-        } catch (err) {
-          if (err instanceof NoConnection) {
-            return reply
-              .code(503)
-              .send({ error: 'Service Unavailable', statusCode: 503, message: 'owning daemon is offline' })
-          }
-          throw err
+        )
+        if (!read.ok) return reply.code(503).send(contentUnavailable(read.reason))
+        // Provider membership and identity can be revoked while the daemon is
+        // answering. Re-run the complete predicate before any body leaves CP.
+        if (!(await getOrgViewableSession(req, req.params.id))) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
+        }
+        const page = read.value
+        return {
+          sessionId: page.sessionId,
+          messages: page.messages,
+          nextCursor: page.nextCursor ?? null,
+          liveCursor: page.liveCursor ?? null,
+          liveMore: page.liveMore ?? false
         }
       }
     )
 
-    // Full-body view follows the same immutable session-content owner as history.
-    // The console pages by offset until nextOffset is null. 503 if the recorded
-    // daemon is unknown or offline.
+    // Full-body view resolves its daemon exactly like history does. The console pages by offset
+    // until nextOffset is null. 503 when neither daemon can serve the read.
     r.get(
       '/sessions/:id/tool-body',
       {
@@ -945,7 +970,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get a tool-call body',
           description:
-            "Proxies one byte slice of a tool call's untruncated ToolBody JSON live from the daemon recorded on the session; the console pages by offset until nextOffset is null. 503 if that daemon is unknown or offline.",
+            "Proxies one byte slice of a tool call's untruncated ToolBody JSON live from the daemon recorded on the session, falling back to the agent's current serving daemon; the console pages by offset until nextOffset is null. 503 if neither is known or reachable.",
           operationId: 'getSessionToolBody',
           params: IdParam,
           querystring: SessionToolBodyQueryDto,
@@ -958,36 +983,25 @@ export function sessionRoutes(deps: HttpDeps) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
         }
         const { session } = owned
-        if (!session.daemonId) {
-          return reply
-            .code(503)
-            .send({ error: 'Service Unavailable', statusCode: 503, message: 'session has no recorded daemon' })
-        }
-
-        try {
-          const chunk = await deps.control.sessionToolBody(session.daemonId, {
+        const read = await readSessionContent(req, session, (daemonId) =>
+          deps.control.sessionToolBody(daemonId, {
             agentId: session.agentId,
             sessionId: session.id,
             toolCallId: req.query.toolCallId,
             offset: req.query.offset ?? 0
           })
-          if (!(await getOrgViewableSession(req, req.params.id))) {
-            return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
-          }
-          return {
-            sessionId: chunk.sessionId,
-            toolCallId: chunk.toolCallId,
-            data: chunk.data,
-            totalBytes: chunk.totalBytes,
-            nextOffset: chunk.nextOffset ?? null
-          }
-        } catch (err) {
-          if (err instanceof NoConnection) {
-            return reply
-              .code(503)
-              .send({ error: 'Service Unavailable', statusCode: 503, message: 'owning daemon is offline' })
-          }
-          throw err
+        )
+        if (!read.ok) return reply.code(503).send(contentUnavailable(read.reason))
+        if (!(await getOrgViewableSession(req, req.params.id))) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
+        }
+        const chunk = read.value
+        return {
+          sessionId: chunk.sessionId,
+          toolCallId: chunk.toolCallId,
+          data: chunk.data,
+          totalBytes: chunk.totalBytes,
+          nextOffset: chunk.nextOffset ?? null
         }
       }
     )

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -8,9 +8,9 @@
  * - `GET /sessions` lists CP-stored session metadata synced by daemon
  *   `event/session` snapshots. Transcript bodies still stay daemon-local.
  * - `GET /sessions/:id/messages` pulls one transcript page from the daemon that
- *   can serve it — the recorded one, else the agent's current serving daemon —
- *   and proxies it through. Bodies transit the CP live for display only, never
- *   persisted (body-locality §1/§12).
+ *   can serve it — the recorded one, else the serving daemon of a shared-store
+ *   placement — and proxies it through. Bodies transit the CP live for display
+ *   only, never persisted (body-locality §1/§12).
  */
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { z } from 'zod'
@@ -420,9 +420,9 @@ export function sessionRoutes(deps: HttpDeps) {
 
     // Daemon-local session content, read through the daemon that can still serve it. The recorded
     // daemon owns it, but a pool member is replaceable: retiring one deletes its row and nulls the
-    // session's `daemonId`, while whichever daemon serves the agent now reads the same store. So:
-    // recorded daemon first, then the agent's current serving daemon. No placement kind is read
-    // here — the resolver is the abstraction.
+    // session's `daemonId`, while its set peers read the same shared store. So: recorded daemon
+    // first, then whatever `contentFailoverDaemon` names — null unless the store is shared, which
+    // is how a machine-placed agent's move keeps answering 503 instead of a false empty page.
     type ContentRead<T> = { ok: true; value: T } | { ok: false; reason: 'unplaced' | 'offline' }
     const readSessionContent = async <T>(
       req: FastifyRequest,
@@ -437,11 +437,11 @@ export function sessionRoutes(deps: HttpDeps) {
         }
       }
       const agent = await deps.repos.agent.get(orgOf(req), AgentId(session.agentId))
-      const serving = agent ? await deps.placementResolver.servingDaemon(agent) : null
-      if (!serving) return { ok: false, reason: session.daemonId ? 'offline' : 'unplaced' }
-      if (serving === session.daemonId) return { ok: false, reason: 'offline' }
+      const failover = agent ? await deps.placementResolver.contentFailoverDaemon(agent) : null
+      if (!failover) return { ok: false, reason: session.daemonId ? 'offline' : 'unplaced' }
+      if (failover === session.daemonId) return { ok: false, reason: 'offline' }
       try {
-        return { ok: true, value: await read(serving) }
+        return { ok: true, value: await read(failover) }
       } catch (err) {
         if (err instanceof NoConnection) return { ok: false, reason: 'offline' }
         throw err
@@ -905,7 +905,7 @@ export function sessionRoutes(deps: HttpDeps) {
 
     // Replay view: proxy a page of the session's chat history live from the daemon that can serve
     // it. CP stores list/detail metadata only, not transcript bodies. The recorded daemon is tried
-    // first; when it is gone or unreachable the read follows the agent's current serving daemon.
+    // first; only a shared-store placement has a second daemon holding the same content.
     r.get(
       '/sessions/:id/messages',
       {
@@ -913,7 +913,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get session messages',
           description:
-            "Proxies a page of the session's chat history live from the daemon recorded on the session, falling back to the agent's current serving daemon; 503 if neither is known or reachable.",
+            "Proxies a page of the session's chat history live from the daemon recorded on the session, falling back to the agent's current serving daemon when its placement shares one content store; 503 if neither is known or reachable.",
           operationId: 'getSessionMessages',
           params: IdParam,
           querystring: SessionHistoryQueryDto,
@@ -970,7 +970,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get a tool-call body',
           description:
-            "Proxies one byte slice of a tool call's untruncated ToolBody JSON live from the daemon recorded on the session, falling back to the agent's current serving daemon; the console pages by offset until nextOffset is null. 503 if neither is known or reachable.",
+            "Proxies one byte slice of a tool call's untruncated ToolBody JSON live from the daemon recorded on the session, falling back to the agent's current serving daemon when its placement shares one content store; the console pages by offset until nextOffset is null. 503 if neither is known or reachable.",
           operationId: 'getSessionToolBody',
           params: IdParam,
           querystring: SessionToolBodyQueryDto,

--- a/packages/control-plane/src/orchestrator/placementResolver.test.ts
+++ b/packages/control-plane/src/orchestrator/placementResolver.test.ts
@@ -2,10 +2,10 @@
  * `PlacementResolver.contentFailoverDaemon` — the one question whose answer is NOT "who serves
  * this agent" (unit, no I/O).
  *
- * Session transcripts and tool bodies are written where the turn ran. A member set shares one
- * data-plane store, so a peer can still read a retired member's rows; a machine's store is its
- * own, and a move carries none of it. The resolver is where that difference is decided, so the
- * routes that proxy content never read a placement kind.
+ * Session transcripts and tool bodies are written where the turn ran, so failover is sound only
+ * where the store is shared AND this session was written to it. Two facts, one on the session
+ * (`contentSetId`) and one on the agent (its current set), and they must be the same set. The
+ * resolver is where that is decided, so the routes proxying content never read a placement kind.
  */
 import { describe, it, expect } from 'vitest'
 import { PlacementResolver, type ResolvableAgent } from './placementResolver.js'
@@ -14,8 +14,10 @@ import { systemClock } from '../domain/clock.js'
 
 const HOLDER = 'ddddddd1-dddd-4ddd-8ddd-dddddddddddd' as DaemonId
 const MACHINE = 'ddddddd2-dddd-4ddd-8ddd-dddddddddddd' as DaemonId
+const SET = 'set-1'
+const OTHER_SET = 'set-2'
 
-const setAgent: ResolvableAgent = { id: AgentId('a1'), placementKind: 'set', daemonId: null, setId: 'set-1' }
+const setAgent: ResolvableAgent = { id: AgentId('a1'), placementKind: 'set', daemonId: null, setId: SET }
 const machineAgent: ResolvableAgent = { id: AgentId('a2'), placementKind: 'daemon', daemonId: MACHINE, setId: null }
 const unplaced: ResolvableAgent = { id: AgentId('a3'), placementKind: 'daemon', daemonId: null, setId: null }
 
@@ -26,26 +28,36 @@ const held = new PlacementResolver({
 })
 
 describe('PlacementResolver.contentFailoverDaemon', () => {
-  it('names the duty holder for a set placement — its members read one shared store', async () => {
-    expect(await held.contentFailoverDaemon(setAgent)).toBe(HOLDER)
+  it('names the duty holder when the session was written to the set the agent is still on', async () => {
+    expect(await held.contentFailoverDaemon(setAgent, { contentSetId: SET })).toBe(HOLDER)
+  })
+
+  it('names nobody when the session carries no shared-store provenance, set agent or not', async () => {
+    // The bug this pins: the agent ran this session on a local daemon and was moved into the pool
+    // afterwards. Its placement is a set, but nothing in that set ever held these rows.
+    expect(await held.contentFailoverDaemon(setAgent, { contentSetId: null })).toBeNull()
+  })
+
+  it('names nobody when the session was written to a DIFFERENT set', async () => {
+    expect(await held.contentFailoverDaemon(setAgent, { contentSetId: OTHER_SET })).toBeNull()
   })
 
   it('names nobody for a machine placement, even while a holder serves the agent', async () => {
-    // `servingDaemon` would answer here; content must not, or a move would turn a lost
-    // transcript into a valid-looking empty page instead of the honest 503.
+    // `servingDaemon` answers here; content must not, or a move would turn a lost transcript into
+    // a valid-looking empty page instead of the honest 503.
     expect(await held.servingDaemon(machineAgent)).toBe(MACHINE)
-    expect(await held.contentFailoverDaemon(machineAgent)).toBeNull()
+    expect(await held.contentFailoverDaemon(machineAgent, { contentSetId: SET })).toBeNull()
   })
 
   it('names nobody for an unplaced agent', async () => {
-    expect(await held.contentFailoverDaemon(unplaced)).toBeNull()
+    expect(await held.contentFailoverDaemon(unplaced, { contentSetId: SET })).toBeNull()
   })
 
-  it('names nobody for a set placement no member currently holds', async () => {
+  it('names nobody when no member of the recorded store currently holds the agent', async () => {
     const vacant = new PlacementResolver({
       duties: { holdersOf: async () => [], confirmedHoldersOf: async () => [] },
       clock: systemClock
     })
-    expect(await vacant.contentFailoverDaemon(setAgent)).toBeNull()
+    expect(await vacant.contentFailoverDaemon(setAgent, { contentSetId: SET })).toBeNull()
   })
 })

--- a/packages/control-plane/src/orchestrator/placementResolver.test.ts
+++ b/packages/control-plane/src/orchestrator/placementResolver.test.ts
@@ -1,0 +1,51 @@
+/**
+ * `PlacementResolver.contentFailoverDaemon` — the one question whose answer is NOT "who serves
+ * this agent" (unit, no I/O).
+ *
+ * Session transcripts and tool bodies are written where the turn ran. A member set shares one
+ * data-plane store, so a peer can still read a retired member's rows; a machine's store is its
+ * own, and a move carries none of it. The resolver is where that difference is decided, so the
+ * routes that proxy content never read a placement kind.
+ */
+import { describe, it, expect } from 'vitest'
+import { PlacementResolver, type ResolvableAgent } from './placementResolver.js'
+import { AgentId, type DaemonId } from '../domain/ids.js'
+import { systemClock } from '../domain/clock.js'
+
+const HOLDER = 'ddddddd1-dddd-4ddd-8ddd-dddddddddddd' as DaemonId
+const MACHINE = 'ddddddd2-dddd-4ddd-8ddd-dddddddddddd' as DaemonId
+
+const setAgent: ResolvableAgent = { id: AgentId('a1'), placementKind: 'set', daemonId: null, setId: 'set-1' }
+const machineAgent: ResolvableAgent = { id: AgentId('a2'), placementKind: 'daemon', daemonId: MACHINE, setId: null }
+const unplaced: ResolvableAgent = { id: AgentId('a3'), placementKind: 'daemon', daemonId: null, setId: null }
+
+/** A ledger where HOLDER holds every agent's duty — the shape after a pool member claims one. */
+const held = new PlacementResolver({
+  duties: { holdersOf: async () => [HOLDER], confirmedHoldersOf: async () => [HOLDER] },
+  clock: systemClock
+})
+
+describe('PlacementResolver.contentFailoverDaemon', () => {
+  it('names the duty holder for a set placement — its members read one shared store', async () => {
+    expect(await held.contentFailoverDaemon(setAgent)).toBe(HOLDER)
+  })
+
+  it('names nobody for a machine placement, even while a holder serves the agent', async () => {
+    // `servingDaemon` would answer here; content must not, or a move would turn a lost
+    // transcript into a valid-looking empty page instead of the honest 503.
+    expect(await held.servingDaemon(machineAgent)).toBe(MACHINE)
+    expect(await held.contentFailoverDaemon(machineAgent)).toBeNull()
+  })
+
+  it('names nobody for an unplaced agent', async () => {
+    expect(await held.contentFailoverDaemon(unplaced)).toBeNull()
+  })
+
+  it('names nobody for a set placement no member currently holds', async () => {
+    const vacant = new PlacementResolver({
+      duties: { holdersOf: async () => [], confirmedHoldersOf: async () => [] },
+      clock: systemClock
+    })
+    expect(await vacant.contentFailoverDaemon(setAgent)).toBeNull()
+  })
+})

--- a/packages/control-plane/src/orchestrator/placementResolver.ts
+++ b/packages/control-plane/src/orchestrator/placementResolver.ts
@@ -94,14 +94,23 @@ export class PlacementResolver {
   }
 
   /**
-   * The daemon that may serve this agent's HISTORICAL session content once the daemon recorded on
-   * the session cannot. Only a member set answers: its members share one data-plane store, so any
-   * of them reads what another wrote. A machine's transcripts and tool bodies are local to that
-   * machine and a move never carries them, so failing over there would turn a gone transcript into
-   * a valid-looking empty page. Kind is read HERE, which is why no route has to read it.
+   * The daemon that may serve this SESSION's content once the daemon recorded on it cannot.
+   *
+   * Two facts have to agree, and the second is why the session is a parameter. The content must
+   * have been written to a SHARED store — `contentSetId`, stamped when the session ran — because a
+   * machine's transcripts are local and a daemon that never wrote them answers "no rows" as a
+   * valid empty page rather than an error. And the agent must still be placed on THAT set, or the
+   * resolver has no live member of that store to name. An agent moved out of a set, into one after
+   * the session ran, or between two sets satisfies neither, and gets the honest 503.
+   *
+   * Placement kind is read HERE, which is why no route has to read it.
    */
-  async contentFailoverDaemon(agent: ResolvableAgent): Promise<DaemonId | null> {
-    if (dutyEligibility(agent).scope !== 'set') return null
+  async contentFailoverDaemon(
+    agent: ResolvableAgent,
+    session: { contentSetId: string | null }
+  ): Promise<DaemonId | null> {
+    const eligibility = dutyEligibility(agent)
+    if (!session.contentSetId || eligibility.scope !== 'set' || eligibility.setId !== session.contentSetId) return null
     return this.servingDaemon(agent)
   }
 

--- a/packages/control-plane/src/orchestrator/placementResolver.ts
+++ b/packages/control-plane/src/orchestrator/placementResolver.ts
@@ -93,6 +93,18 @@ export class PlacementResolver {
     return ((await this.servingDaemons(agent))[0] as DaemonId | undefined) ?? null
   }
 
+  /**
+   * The daemon that may serve this agent's HISTORICAL session content once the daemon recorded on
+   * the session cannot. Only a member set answers: its members share one data-plane store, so any
+   * of them reads what another wrote. A machine's transcripts and tool bodies are local to that
+   * machine and a move never carries them, so failing over there would turn a gone transcript into
+   * a valid-looking empty page. Kind is read HERE, which is why no route has to read it.
+   */
+  async contentFailoverDaemon(agent: ResolvableAgent): Promise<DaemonId | null> {
+    if (dutyEligibility(agent).scope !== 'set') return null
+    return this.servingDaemon(agent)
+  }
+
   /** May this daemon act on the agent's behalf — report its sessions, mint its credentials, ask on
    *  its behalf? True where it is the placement, and true where it holds the agent's duty. */
   async mayAct(agent: ResolvableAgent, daemonId: string): Promise<boolean> {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1153,6 +1153,9 @@ export interface SessionMetaRecord {
   permissionMode: string | null
   outputMode: string | null
   daemonId: DaemonId | null
+  /** The member set whose shared store holds this session's content; null ⇒ the recorded daemon's
+   *  own local store. Session-scoped provenance — never the agent's current placement. */
+  contentSetId: string | null
   workspaceIsolation: 'shared' | 'session' | null
   activityState: ActivityState
   // ── session visibility (session-visibility.md §3) ──

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -74,6 +74,7 @@ function toRecord(s: SessionMeta): SessionMetaRecord {
     permissionMode: s.permissionMode,
     outputMode: s.outputMode,
     daemonId: s.daemonId ? DaemonId(s.daemonId) : null,
+    contentSetId: s.contentSetId,
     workspaceIsolation: s.workspaceIsolation as 'shared' | 'session' | null,
     activityState: s.activityState as ActivityState,
     orgId: OrgId(s.orgId),
@@ -782,7 +783,7 @@ export class PgSessionRepo implements SessionRepo {
         "thread", "tenantScope", "phase", "link", "summary", "title", "status",
         "lastActivityAt", "triggeredBy", "channelName", "triggeredByName",
         "threadUrl", "runtime", "model", "effort", "fastMode",
-        "permissionMode", "outputMode", "daemonId", "workspaceIsolation", "orgId", "visibility",
+        "permissionMode", "outputMode", "daemonId", "contentSetId", "workspaceIsolation", "orgId", "visibility",
         "ownerIdentity", "visibilitySource", "externalProvider",
         "externalScopeId", "externalResolution", "legacyUnresolved",
         "classifiedPolicyRev", "startedAt", "endedAt", "updatedAt"
@@ -796,6 +797,9 @@ export class PgSessionRepo implements SessionRepo {
         ${ev.runtime ?? null}, ${ev.model ?? null}, ${ev.effort ?? null},
         ${ev.fastMode ?? null}, ${ev.permissionMode ?? null},
         ${ev.outputMode ?? null}, ${ev.daemonId ?? null},
+        -- Content provenance, read from the reporting daemon's membership in this same statement
+        -- so it can never drift from the daemon it describes. No set ⇒ null ⇒ a local store.
+        (SELECT "setId" FROM "member_set_member" WHERE "daemonId" = ${ev.daemonId ?? null}::uuid),
         ${ev.workspaceIsolation ?? null}::"WorkspaceIsolation",
         ${orgId},
         ${cls.visibility}::"SessionVisibility", ${cls.ownerIdentity},
@@ -851,6 +855,14 @@ export class PgSessionRepo implements SessionRepo {
         -- reports the session. A later milestone must not move daemon-local
         -- transcript/worktree provenance when the agent itself is reassigned.
         "daemonId" = COALESCE("session_meta"."daemonId", EXCLUDED."daemonId"),
+        -- Provenance follows that pin: fill it only while the reporter IS the recorded content
+        -- owner, so a milestone from a daemon that merely serves the agent now cannot claim this
+        -- session's content for its store. Same reporter, same set ⇒ rewrites the same value.
+        "contentSetId" = CASE
+          WHEN "session_meta"."daemonId" IS DISTINCT FROM EXCLUDED."daemonId"
+            THEN "session_meta"."contentSetId"
+          ELSE COALESCE("session_meta"."contentSetId", EXCLUDED."contentSetId")
+        END,
         "workspaceIsolation" = COALESCE(
           EXCLUDED."workspaceIsolation",
           "session_meta"."workspaceIsolation"

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -15,7 +15,7 @@ import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
-import { ControlSender } from '../../src/orchestrator/outbound.js'
+import { ControlSender, NoConnection } from '../../src/orchestrator/outbound.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import type { DaemonLiveness } from '../../src/ports.js'
 import type { SessionListReq, SessionListPage, SessionHistoryReq, SessionHistoryPage } from '@agentconnect.md/protocol'
@@ -41,13 +41,15 @@ const LIVE: DaemonLiveness = {
   get: (id) => (id === DAEMON ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined)
 }
 
-/** A ControlSender spy answering sessionList + sessionHistory with canned data. */
+/** A ControlSender spy answering sessionList + sessionHistory with canned data. Daemons in
+ *  `unreachable` record the call and then throw `NoConnection`, as an absent socket would. */
 class SpyControl {
   listCalls: Array<{ daemonId: string; req: SessionListReq }> = []
   histCalls: Array<{ daemonId: string; req: SessionHistoryReq }> = []
   constructor(
     private readonly list: SessionListPage,
-    private readonly hist: SessionHistoryPage
+    private readonly hist: SessionHistoryPage,
+    private readonly unreachable: readonly string[] = []
   ) {}
   async sessionList(daemonId: string, req: SessionListReq): Promise<SessionListPage> {
     this.listCalls.push({ daemonId, req })
@@ -55,6 +57,7 @@ class SpyControl {
   }
   async sessionHistory(daemonId: string, req: SessionHistoryReq): Promise<SessionHistoryPage> {
     this.histCalls.push({ daemonId, req })
+    if (this.unreachable.includes(daemonId)) throw new NoConnection(daemonId)
     return this.hist
   }
 }
@@ -672,6 +675,48 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
     expect(res.statusCode).toBe(503)
     expect(res.json()).toMatchObject({ message: 'session has no recorded daemon' })
+  })
+
+  it('falls back to the serving daemon when the recorded one is unreachable', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, OTHER_DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: OTHER_DAEMON })
+    await seedSession(AGENT, DAEMON)
+    const spy = new SpyControl({ sessions: [] }, emptyHist, [DAEMON])
+    running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(200)
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([DAEMON, OTHER_DAEMON])
+  })
+
+  it('reads from the serving daemon when the session has no recorded daemon', async () => {
+    await seedDaemon(prisma, OTHER_DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: OTHER_DAEMON })
+    await seedSession(AGENT)
+    const spy = new SpyControl({ sessions: [] }, emptyHist)
+    running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(200)
+    expect(spy.histCalls).toEqual([{ daemonId: OTHER_DAEMON, req: { agentId: AGENT, sessionId: SESSION, limit: 50 } }])
+  })
+
+  it('503s when neither the recorded nor the serving daemon is reachable', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, OTHER_DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: OTHER_DAEMON })
+    await seedSession(AGENT, DAEMON)
+    const spy = new SpyControl({ sessions: [] }, emptyHist, [DAEMON, OTHER_DAEMON])
+    running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(503)
+    expect(res.json()).toMatchObject({ message: 'owning daemon is offline' })
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([DAEMON, OTHER_DAEMON])
   })
 
   it('503s when the owning daemon is offline (NoConnection → 503)', async () => {

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
-import { joinPool, poolSetId } from '../fakes/member-set.js'
+import { joinPool } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender, NoConnection } from '../../src/orchestrator/outbound.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
@@ -65,12 +65,13 @@ class SpyControl {
 
 const emptyHist: SessionHistoryPage = { sessionId: SESSION, messages: [] }
 
-async function seedSession(agentId = AGENT, daemonId?: string): Promise<void> {
+async function seedSession(agentId = AGENT, daemonId?: string, contentSetId?: string): Promise<void> {
   await prisma.sessionMeta.create({
     data: {
       id: SESSION,
       agentId,
       ...(daemonId ? { daemonId } : {}),
+      ...(contentSetId ? { contentSetId } : {}),
       orgId: DEFAULT_ORG_ID,
       platform: 'slack',
       channel: '#deploys',
@@ -82,17 +83,15 @@ async function seedSession(agentId = AGENT, daemonId?: string): Promise<void> {
 
 /**
  * The shared-store placement: AGENT sits on the install-wide member set and `holder` is the member
- * currently holding its duty. Content failover exists only for this shape — set members read one
- * data-plane store, so a retired member's transcripts are still readable through its peer.
+ * currently holding its duty. Returns the set id, which a session written by one of its members
+ * carries as `contentSetId` — the provenance that makes failover to a peer sound.
  */
-async function seedPooledAgentHeldBy(holder: string): Promise<void> {
+async function seedPooledAgentHeldBy(holder: string): Promise<string> {
   await prisma.daemon.create({ data: { id: holder, orgId: null, status: 'ready', maxAgents: 4 } })
-  await joinPool(prisma, holder)
-  await prisma.agent.update({
-    where: { id: AGENT },
-    data: { placementKind: 'set', setId: await poolSetId(prisma), daemonId: null }
-  })
+  const setId = await joinPool(prisma, holder)
+  await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'set', setId, daemonId: null } })
   await seedDutyGroup(prisma, randomUUID(), holder, [AGENT])
+  return setId
 }
 
 describe('GET /sessions (metadata list from CP DB)', () => {
@@ -696,8 +695,8 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
   it('a pooled agent falls back to its duty holder when the recorded member is unreachable', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT)
-    await seedPooledAgentHeldBy(OTHER_DAEMON)
-    await seedSession(AGENT, DAEMON)
+    const setId = await seedPooledAgentHeldBy(OTHER_DAEMON)
+    await seedSession(AGENT, DAEMON, setId)
     const spy = new SpyControl({ sessions: [] }, emptyHist, [DAEMON])
     running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
 
@@ -709,8 +708,8 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
 
   it('a pooled agent reads from its duty holder when the retired member left no recorded daemon', async () => {
     await seedAgent(prisma, AGENT)
-    await seedPooledAgentHeldBy(OTHER_DAEMON)
-    await seedSession(AGENT)
+    const setId = await seedPooledAgentHeldBy(OTHER_DAEMON)
+    await seedSession(AGENT, undefined, setId)
     const spy = new SpyControl({ sessions: [] }, emptyHist)
     running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
 
@@ -737,11 +736,28 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
     expect(spy.histCalls.map((c) => c.daemonId)).toEqual([DAEMON])
   })
 
+  it('a session written on a local daemon never fails over to the pool the agent moved into', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    // The session ran on DAEMON's own store, so it carries no set provenance. Moving the agent
+    // into the pool afterwards gives it a serving member, but not one that has these rows.
+    await seedSession(AGENT, DAEMON)
+    await seedPooledAgentHeldBy(OTHER_DAEMON)
+    const spy = new SpyControl({ sessions: [] }, emptyHist, [DAEMON])
+    running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(503)
+    expect(res.json()).toMatchObject({ message: 'owning daemon is offline' })
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([DAEMON])
+  })
+
   it('503s when neither the recorded member nor the duty holder is reachable', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT)
-    await seedPooledAgentHeldBy(OTHER_DAEMON)
-    await seedSession(AGENT, DAEMON)
+    const setId = await seedPooledAgentHeldBy(OTHER_DAEMON)
+    await seedSession(AGENT, DAEMON, setId)
     const spy = new SpyControl({ sessions: [] }, emptyHist, [DAEMON, OTHER_DAEMON])
     running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
 

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -13,7 +13,8 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
+import { joinPool, poolSetId } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender, NoConnection } from '../../src/orchestrator/outbound.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
@@ -77,6 +78,21 @@ async function seedSession(agentId = AGENT, daemonId?: string): Promise<void> {
       lastActivityAt: new Date('2026-07-05T08:00:00.000Z')
     }
   })
+}
+
+/**
+ * The shared-store placement: AGENT sits on the install-wide member set and `holder` is the member
+ * currently holding its duty. Content failover exists only for this shape — set members read one
+ * data-plane store, so a retired member's transcripts are still readable through its peer.
+ */
+async function seedPooledAgentHeldBy(holder: string): Promise<void> {
+  await prisma.daemon.create({ data: { id: holder, orgId: null, status: 'ready', maxAgents: 4 } })
+  await joinPool(prisma, holder)
+  await prisma.agent.update({
+    where: { id: AGENT },
+    data: { placementKind: 'set', setId: await poolSetId(prisma), daemonId: null }
+  })
+  await seedDutyGroup(prisma, randomUUID(), holder, [AGENT])
 }
 
 describe('GET /sessions (metadata list from CP DB)', () => {
@@ -677,10 +693,10 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
     expect(res.json()).toMatchObject({ message: 'session has no recorded daemon' })
   })
 
-  it('falls back to the serving daemon when the recorded one is unreachable', async () => {
+  it('a pooled agent falls back to its duty holder when the recorded member is unreachable', async () => {
     await seedDaemon(prisma, DAEMON)
-    await seedDaemon(prisma, OTHER_DAEMON)
-    await seedAgent(prisma, AGENT, { daemonId: OTHER_DAEMON })
+    await seedAgent(prisma, AGENT)
+    await seedPooledAgentHeldBy(OTHER_DAEMON)
     await seedSession(AGENT, DAEMON)
     const spy = new SpyControl({ sessions: [] }, emptyHist, [DAEMON])
     running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
@@ -691,9 +707,9 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
     expect(spy.histCalls.map((c) => c.daemonId)).toEqual([DAEMON, OTHER_DAEMON])
   })
 
-  it('reads from the serving daemon when the session has no recorded daemon', async () => {
-    await seedDaemon(prisma, OTHER_DAEMON)
-    await seedAgent(prisma, AGENT, { daemonId: OTHER_DAEMON })
+  it('a pooled agent reads from its duty holder when the retired member left no recorded daemon', async () => {
+    await seedAgent(prisma, AGENT)
+    await seedPooledAgentHeldBy(OTHER_DAEMON)
     await seedSession(AGENT)
     const spy = new SpyControl({ sessions: [] }, emptyHist)
     running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
@@ -704,10 +720,27 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
     expect(spy.histCalls).toEqual([{ daemonId: OTHER_DAEMON, req: { agentId: AGENT, sessionId: SESSION, limit: 50 } }])
   })
 
-  it('503s when neither the recorded nor the serving daemon is reachable', async () => {
+  it('a machine-placed agent moved off an offline daemon still 503s — content never follows the move', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedDaemon(prisma, OTHER_DAEMON)
     await seedAgent(prisma, AGENT, { daemonId: OTHER_DAEMON })
+    await seedSession(AGENT, DAEMON)
+    const spy = new SpyControl({ sessions: [] }, emptyHist, [DAEMON])
+    running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    // The new daemon holds none of this session's transcript, and it would answer an empty page
+    // rather than say so — asking it at all would dress a lost transcript up as an empty one.
+    expect(res.statusCode).toBe(503)
+    expect(res.json()).toMatchObject({ message: 'owning daemon is offline' })
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([DAEMON])
+  })
+
+  it('503s when neither the recorded member nor the duty holder is reachable', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT)
+    await seedPooledAgentHeldBy(OTHER_DAEMON)
     await seedSession(AGENT, DAEMON)
     const spy = new SpyControl({ sessions: [] }, emptyHist, [DAEMON, OTHER_DAEMON])
     running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)

--- a/packages/control-plane/test/integration/visibility.route.test.ts
+++ b/packages/control-plane/test/integration/visibility.route.test.ts
@@ -728,9 +728,11 @@ describe('derived visibility — session bodies, usage', () => {
     const app = appAs(other).app
     expect((await app.inject({ method: 'GET', url: `${ORG}/agents/${R}` })).statusCode).toBe(404)
     for (const path of [`/sessions/${session}/messages`, `/sessions/${session}/tool-body?toolCallId=t1`]) {
+      // Past the audience gate: the row records no daemon, so the read follows the agent's
+      // serving daemon, which is offline here — a body-plane 503, never the gate's 404.
       const response = await app.inject({ method: 'GET', url: `${ORG}${path}` })
       expect(response.statusCode).toBe(503)
-      expect(response.json()).toMatchObject({ message: 'session has no recorded daemon' })
+      expect(response.json()).toMatchObject({ message: 'owning daemon is offline' })
     }
   })
 

--- a/packages/control-plane/test/integration/visibility.route.test.ts
+++ b/packages/control-plane/test/integration/visibility.route.test.ts
@@ -728,11 +728,9 @@ describe('derived visibility — session bodies, usage', () => {
     const app = appAs(other).app
     expect((await app.inject({ method: 'GET', url: `${ORG}/agents/${R}` })).statusCode).toBe(404)
     for (const path of [`/sessions/${session}/messages`, `/sessions/${session}/tool-body?toolCallId=t1`]) {
-      // Past the audience gate: the row records no daemon, so the read follows the agent's
-      // serving daemon, which is offline here — a body-plane 503, never the gate's 404.
       const response = await app.inject({ method: 'GET', url: `${ORG}${path}` })
       expect(response.statusCode).toBe(503)
-      expect(response.json()).toMatchObject({ message: 'owning daemon is offline' })
+      expect(response.json()).toMatchObject({ message: 'session has no recorded daemon' })
     }
   })
 

--- a/packages/control-plane/test/repo/session.repo.test.ts
+++ b/packages/control-plane/test/repo/session.repo.test.ts
@@ -13,6 +13,7 @@ import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.j
 import { DEF_ORG, seedAgent, seedDaemon, seedLaunch } from '../fixtures/seed.js'
 import { DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import { AgentId, BotId, DaemonId, LaunchId, SessionId } from '../../src/domain/ids.js'
+import { joinPool } from '../fakes/member-set.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const OTHER_AGENT = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
@@ -20,6 +21,13 @@ const DAEMON = 'd1111111-1111-4111-8111-111111111111'
 const OTHER_DAEMON = 'd2222222-2222-4222-8222-222222222222'
 const LAUNCH = '11111111-1111-4111-8111-111111111111'
 const SESSION = '55555555-5555-4555-8555-555555555555'
+const POOL_MEMBER = 'd3333333-3333-4333-8333-333333333333'
+
+/** An org-less pool member, the way `upsertOnAuth` writes one: daemon row plus its membership. */
+async function seedPoolMember(id = POOL_MEMBER): Promise<string> {
+  await prisma.daemon.create({ data: { id, orgId: null, status: 'ready', maxAgents: 4 } })
+  return joinPool(prisma, id)
+}
 
 async function fixtures(): Promise<void> {
   await seedDaemon(prisma, DAEMON)
@@ -186,6 +194,33 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
 
     const row = await prisma.sessionMeta.findUnique({ where: { id: SESSION } })
     expect(row?.daemonId).toBe(DAEMON)
+  })
+
+  it("stamps the reporting daemon's member set as the session's content store", async () => {
+    await fixtures()
+    const setId = await seedPoolMember()
+    const repo = new PgSessionRepo(prisma)
+
+    await repo.recordMilestone(ev('start', { daemonId: DaemonId(POOL_MEMBER) }))
+
+    // Provenance is a fact about where the content landed, so it is read from the reporter's
+    // membership at write time — not inferred later from wherever the agent happens to sit.
+    expect((await prisma.sessionMeta.findUnique({ where: { id: SESSION } }))?.contentSetId).toBe(setId)
+  })
+
+  it('leaves content provenance null when the content owner belongs to no set', async () => {
+    await fixtures()
+    await seedPoolMember()
+    const repo = new PgSessionRepo(prisma)
+
+    await repo.recordMilestone(ev('start', { daemonId: DaemonId(DAEMON) }))
+    // A later milestone from a pooled daemon reports on a session whose rows live on DAEMON. It
+    // may not claim them for the pool's store — the content owner never moved.
+    await repo.recordMilestone(ev('end', { daemonId: DaemonId(POOL_MEMBER) }))
+
+    const row = await prisma.sessionMeta.findUnique({ where: { id: SESSION } })
+    expect(row?.daemonId).toBe(DAEMON)
+    expect(row?.contentSetId).toBeNull()
   })
 
   it('keeps the recorded execution config when a later milestone omits it', async () => {


### PR DESCRIPTION
## Summary

`GET /sessions/:id/messages` and `GET /sessions/:id/tool-body` proxied session content
strictly from the daemon recorded on the session row. Content now follows the agent's
current serving daemon when that recorded daemon can no longer answer.

## Failure scenario

An agent held by a multi-member deployment is served by whichever member currently holds
its duty lease. That member is replaceable: a rollout retires it, the pool-member reaper
deletes its `daemon` row, and the FK nulls `session_meta.daemonId`. Both routes then answer
`503 session has no recorded daemon` — or `503 owning daemon is offline` while the retired
member is still recorded — permanently, for every session that ran before the rollout, even
though the member serving the agent now can read the same content.

## Fix

One helper shared by both routes resolves the read target as: the recorded daemon first (a
machine-placed agent's daemon-local store lives there), and on `NoConnection` or a null
`daemonId`, the agent's current serving daemon via `deps.placementResolver.servingDaemon`,
tried once when it differs. When neither answers, the existing 503s are unchanged. No route
branches on the placement kind — the resolver stays the abstraction. The `contentPurgedAt`
early return is untouched, and both OpenAPI descriptions now state the fallback.

## Test plan

- `packages/control-plane/test/integration/sessions.history.route.test.ts`: recorded daemon
  throws `NoConnection` → the page comes from the serving daemon (call order asserted); a
  null `daemonId` → served from the serving daemon; neither reachable → 503. The existing
  "reads from the recorded daemon after the agent moves elsewhere", legacy-unplaced, and
  offline cases still pass.
- `visibility.route.test.ts`: the body-plane 503 for an unrecorded session on an offline
  agent is now the offline message; it still proves the audience gate answered 503, not 404.
- `pnpm --filter @agentconnect.md/control-plane test:int`, `typecheck`, `pnpm lint`,
  `pnpm format:check`.
