### PR TITLE
fix(control-plane): read a session's transcript from any daemon holding its store

### DIFF
--- a/packages/control-plane/prisma/migrations/20260825000000_session_content_store/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260825000000_session_content_store/migration.sql
@@ -1,0 +1,59 @@
+-- Session-scoped content provenance: WHICH store this session's transcript was written to.
+--
+-- `daemonId` names the daemon that first reported the session, and for a self-hosted daemon that
+-- is also the only machine holding the rows. A cluster pool member is different: its store is the
+-- install-wide data-plane Postgres its peers share. Pool members are bound to a Pod UID and reaped
+-- 15 minutes after they go silent, and the FK SetNulls `daemonId` on every session they recorded —
+-- so routing a content read by that column alone loses transcripts that are still fully present.
+--
+-- The agent's CURRENT placement cannot stand in for this: an agent can be moved into a set, out of
+-- one, or between two long after a session ran, and failing a read over to a store that never held
+-- it returns a valid-looking EMPTY page rather than an error. Null here ⇒ the recorder's own local
+-- store, which nobody else can read.
+--
+-- IF NOT EXISTS / conditional constraint: an earlier attempt at this column (`session_content_set`,
+-- reverted in #1020) may already have been applied to a database. `prisma migrate deploy` does not
+-- replay a migration that is applied-but-missing locally, so this has to converge both states onto
+-- the same shape rather than assume a clean one.
+ALTER TABLE "session_meta" ADD COLUMN IF NOT EXISTS "contentSetId" UUID;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'session_meta_contentSetId_fkey'
+  ) THEN
+    ALTER TABLE "session_meta" ADD CONSTRAINT "session_meta_contentSetId_fkey"
+      FOREIGN KEY ("contentSetId") REFERENCES "member_set"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- Backfill (a), exact: the recorded daemon is still a member of a set, so the content it holds is
+-- in that set's shared store. Nothing is inferred — the recorder itself is the evidence.
+UPDATE "session_meta" s
+SET "contentSetId" = m."setId"
+FROM "member_set_member" m
+JOIN "member_set" ms ON ms."id" = m."setId"
+WHERE s."daemonId" = m."daemonId" AND ms."orgId" IS NULL AND s."contentSetId" IS NULL;
+
+-- Backfill (b), INFERRED, and deliberately confined to this one-time recovery: rows a retired pool
+-- member already SetNulled have no recorder left to ask, so placement is the only signal there is.
+-- A `set`-placed agent on the org-less pool could normally only have recorded into that pool.
+--
+-- The inference is not airtight, and the exact hole is worth naming: a session that ran on a local
+-- daemon, whose agent was then moved onto the pool, and whose original daemon was later removed
+-- with `DELETE /daemons/:id`, reaches this UPDATE and is wrongly attributed to the pool. Its read
+-- then returns an empty page instead of a 503. That costs a row which is already permanently
+-- unreadable today, which is why it is worth the recovery — but it is the reason live routing
+-- never makes this inference, and the reason a store-authoritative reconciliation (asking a member
+-- which sessions it actually holds) is the right way to settle these rows for good.
+UPDATE "session_meta" s
+SET "contentSetId" = a."setId"
+FROM "agent" a
+JOIN "member_set" ms ON ms."id" = a."setId"
+WHERE s."agentId" = a."id"
+  AND s."daemonId" IS NULL
+  AND s."contentSetId" IS NULL
+  AND a."placementKind" = 'set'
+  AND ms."orgId" IS NULL;
+
+-- Everything else stays null: no evidence the content was ever written to a shared store.

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -687,9 +687,10 @@ model MemberSet {
   name      String
   createdAt DateTime @default(now()) @db.Timestamptz(6)
 
-  org     Org?              @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  members MemberSetMember[]
-  agents  Agent[]
+  org      Org?              @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  members  MemberSetMember[]
+  agents   Agent[]
+  sessions SessionMeta[]     @relation("SessionContentStore")
 
   @@index([orgId])
   @@map("member_set")
@@ -1041,7 +1042,15 @@ model SessionMeta {
   fastMode            Boolean?
   permissionMode      String? // runtime permission/approval mode
   outputMode          String? // daemon-side output verbosity (low/medium/high)
-  daemonId            String?             @db.Uuid // first daemon that reported the session; immutable content owner, stamped by the CP from the authenticated WS conn, never daemon-echoed
+  // First daemon that reported the session, stamped by the CP from the authenticated WS conn and
+  // never daemon-echoed. Provenance, NOT the only reader: the FK nulls it when that daemon is
+  // deleted, and a pool member's content outlives it in the store its peers share.
+  daemonId            String?             @db.Uuid
+  /// The member set whose shared data-plane store holds this session's content, stamped from the
+  /// recorder's own membership beside `daemonId`. Null ⇒ the recorder's private local store, which
+  /// nobody else can read. Session-bound on purpose: the agent's CURRENT placement is no evidence
+  /// about where a past session ran (`domain/session-content.ts`).
+  contentSetId        String?             @db.Uuid
   // Session-pinned checkout choice. Null is a legacy row whose daemon never
   // reported it; `session` identifies a daemon-local worktree eligible for the
   // authorized Workspace viewer.
@@ -1088,6 +1097,7 @@ model SessionMeta {
   agent         Agent          @relation(fields: [agentId], references: [id], onDelete: Cascade)
   launch        AgentLaunch?   @relation(fields: [launchId], references: [id], onDelete: SetNull)
   daemon        Daemon?        @relation(fields: [daemonId], references: [id], onDelete: SetNull)
+  contentSet    MemberSet?     @relation("SessionContentStore", fields: [contentSetId], references: [id], onDelete: SetNull)
   externalScope ExternalScope? @relation(fields: [externalScopeId, orgId, externalProvider], references: [id, orgId, provider], onDelete: Restrict, onUpdate: Restrict)
 
   webchatCurrentFor      WebchatConversation[]      @relation("WebchatCurrentSession")

--- a/packages/control-plane/src/domain/session-content.test.ts
+++ b/packages/control-plane/src/domain/session-content.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { sessionContentReaders } from './session-content.js'
+
+describe('sessionContentReaders — who can serve a session transcript', () => {
+  it('reads from the recorder alone when it kept a private store', () => {
+    expect(sessionContentReaders({ recordedDaemonId: 'd-rec', sharedStoreMembers: [] })).toEqual(['d-rec'])
+  })
+
+  it('answers nothing when the recorder is gone and no shared store holds it', () => {
+    expect(sessionContentReaders({ recordedDaemonId: null, sharedStoreMembers: [] })).toEqual([])
+  })
+
+  it('falls back to every member of the store a retired pool recorder wrote to', () => {
+    expect(sessionContentReaders({ recordedDaemonId: null, sharedStoreMembers: ['m-c', 'm-a', 'm-b'] })).toEqual([
+      'm-a',
+      'm-b',
+      'm-c'
+    ])
+  })
+
+  it('keeps the recorder first and never repeats it as a member', () => {
+    expect(sessionContentReaders({ recordedDaemonId: 'm-b', sharedStoreMembers: ['m-a', 'm-b', 'm-c'] })).toEqual([
+      'm-b',
+      'm-a',
+      'm-c'
+    ])
+  })
+})

--- a/packages/control-plane/src/domain/session-content.ts
+++ b/packages/control-plane/src/domain/session-content.ts
@@ -1,0 +1,49 @@
+/**
+ * The ONE answer to "which daemons can serve this session's recorded content"
+ * (transcript pages, tool bodies). Both content-read routes resolve their targets here.
+ *
+ * `SessionMeta.daemonId` names the daemon that FIRST reported the session, and for a
+ * self-hosted daemon that is also the only machine holding the rows — its store is local.
+ * A cluster pool member is different: its store is the install-wide data-plane Postgres
+ * every member shares, so the content outlives the pod that recorded it. Pool members are
+ * bound to a Pod UID and reaped 15 minutes after they go silent, which SetNulls `daemonId`
+ * on every session they recorded — so routing by that column alone loses transcripts that
+ * are still fully there.
+ *
+ * Eligibility is a property of the STORE, and of the SESSION, never of the agent:
+ *
+ * - Not of the agent's placement. It can move into a set, out of one, or between two long
+ *   after a session ran; content does not follow it either way. `SessionMeta.contentSetId`
+ *   is stamped from the recorder's own membership when the session is first reported, so it
+ *   keeps naming the store the bodies went to however the agent is placed later.
+ * - Not of the agent's live duty holder. An idle pooled agent holds no lease at all — the
+ *   ordinary state — yet its transcripts are exactly as readable as ever, by any member of
+ *   the store they were written to.
+ */
+
+/** Where a session's rows were written, and who still holds that store. */
+export interface SessionContentSources {
+  /** `SessionMeta.daemonId` — the recorder, null once a retired pool member SetNulled it. */
+  recordedDaemonId: string | null
+  /** Members of `SessionMeta.contentSetId`, and only where that set shares one content store. */
+  sharedStoreMembers: readonly string[]
+}
+
+/**
+ * Readers to try in order: the recorder first (always right when it is still connected),
+ * then the other members of its store. Empty means the content has no reachable owner at
+ * all — the caller's 503.
+ *
+ * Order matters and no caller may reorder it: a daemon that does not hold the session
+ * answers `history` with an EMPTY page rather than an error, so a wrong pick reads as an
+ * empty transcript, not as a failure to fall through. That is also why membership of the
+ * shared store — not mere reachability — is what earns a daemon a place in this list.
+ */
+export function sessionContentReaders(sources: SessionContentSources): string[] {
+  return [
+    ...new Set([
+      ...(sources.recordedDaemonId ? [sources.recordedDaemonId] : []),
+      ...[...sources.sharedStoreMembers].sort()
+    ])
+  ]
+}

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -7,9 +7,10 @@
  *
  * - `GET /sessions` lists CP-stored session metadata synced by daemon
  *   `event/session` snapshots. Transcript bodies still stay daemon-local.
- * - `GET /sessions/:id/messages` pulls one transcript page from the owning
- *   daemon (resolved via the row's `agentId`) and proxies it through. Bodies
- *   transit the CP live for display only, never persisted (body-locality §1/§12).
+ * - `GET /sessions/:id/messages` pulls one transcript page from a daemon that can
+ *   serve it — the recorded one, else a member of the shared store the session was
+ *   written to — and proxies it through. Bodies transit the CP live for display
+ *   only, never persisted (body-locality §1/§12).
  */
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { z } from 'zod'
@@ -23,6 +24,8 @@ import { originKindOf, WEBCHAT_SESSION_CONTINUATION_FEATURE } from '@agentconnec
 import { makeSessionAccessResolver } from '../session-access.js'
 import { Tag } from '../plugins/openapi.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
+import { ConnectionClosed } from '../../ws/registry.js'
+import { sessionContentReaders } from '../../domain/session-content.js'
 import { visibilityStateOf } from '../../orchestrator/visibilityPush.js'
 import type { PullRequestView } from '../../github/pull-request-view.service.js'
 import { GithubApiError } from '../../github/api.js'
@@ -416,6 +419,43 @@ export function sessionRoutes(deps: HttpDeps) {
       if (!canViewSession(session, ctxOf(req), access.identitySet, access.externalAccess)) return null
       return { session, access }
     }
+
+    // Daemon-local session content, read through a daemon that can still serve it. The recorded
+    // daemon owns it, but a pool member is replaceable: retiring one deletes its row and nulls the
+    // session's `daemonId`, while every peer on the store it wrote to reads the same rows. So:
+    // recorded daemon first, then the members of THIS session's `contentSetId` — nobody at all
+    // when that store was private, which is how a move keeps answering 503 rather than serving a
+    // false empty page from a machine that never held the session.
+    type ContentRead<T> = { ok: true; value: T } | { ok: false; reason: 'unplaced' | 'offline' }
+    const readSessionContent = async <T>(
+      session: { daemonId: string | null; contentSetId: string | null },
+      read: (daemonId: string) => Promise<T>
+    ): Promise<ContentRead<T>> => {
+      const readers = sessionContentReaders({
+        recordedDaemonId: session.daemonId,
+        sharedStoreMembers: session.contentSetId
+          ? await deps.repos.memberSet.sharedStoreMemberIdsOf(session.contentSetId)
+          : []
+      })
+      if (readers.length === 0) return { ok: false, reason: session.daemonId ? 'offline' : 'unplaced' }
+      for (const daemonId of readers) {
+        try {
+          return { ok: true, value: await read(daemonId) }
+        } catch (err) {
+          // Not reachable — try the next holder of the same store. A socket that dies between the
+          // registry lookup and the reply is ordinary during a rollout, and is unavailability too.
+          if (!(err instanceof NoConnection) && !(err instanceof ConnectionClosed)) throw err
+        }
+      }
+      return { ok: false, reason: 'offline' }
+    }
+
+    // The two 503s the content proxies answer with when nothing served the read.
+    const contentUnavailable = (reason: 'unplaced' | 'offline') => ({
+      error: 'Service Unavailable',
+      statusCode: 503 as const,
+      message: reason === 'unplaced' ? 'session has no recorded daemon' : 'owning daemon is offline'
+    })
 
     type ExternalAccessProvider = 'slack' | 'github' | 'feishu'
     const externalAccessAvailable = (provider: ExternalAccessProvider) =>
@@ -865,10 +905,10 @@ export function sessionRoutes(deps: HttpDeps) {
       }
     )
 
-    // Replay view: proxy a page of the session's chat history live from the
-    // session-recorded daemon. CP stores list/detail metadata only, not transcript
-    // bodies. Agent placement may have changed since this session ran; content
-    // stays on its original daemon and does not follow that move.
+    // Replay view: proxy a page of the session's chat history live from a daemon that can
+    // serve it. CP stores list/detail metadata only, not transcript bodies. The recorded daemon
+    // is tried first; only a session written to a shared store has other daemons holding the
+    // same rows, and an agent move never changes which store that was.
     r.get(
       '/sessions/:id/messages',
       {
@@ -876,7 +916,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get session messages',
           description:
-            "Proxies a page of the session's chat history live from the daemon recorded on the session; 503 if that daemon is unknown or offline.",
+            "Proxies a page of the session's chat history live from a daemon holding it — the recording daemon, or a member of the shared store it was written to; 503 when none is reachable.",
           operationId: 'getSessionMessages',
           params: IdParam,
           querystring: SessionHistoryQueryDto,
@@ -898,46 +938,34 @@ export function sessionRoutes(deps: HttpDeps) {
         if (session.contentPurgedAt) {
           return { sessionId: session.id, messages: [], nextCursor: null, liveCursor: null, liveMore: false }
         }
-        if (!session.daemonId) {
-          return reply
-            .code(503)
-            .send({ error: 'Service Unavailable', statusCode: 503, message: 'session has no recorded daemon' })
-        }
-
-        try {
-          const page = await deps.control.sessionHistory(session.daemonId, {
+        const read = await readSessionContent(session, (daemonId) =>
+          deps.control.sessionHistory(daemonId, session.orgId, {
             agentId: session.agentId,
             sessionId: session.id,
             ...(req.query.cursor !== undefined ? { cursor: req.query.cursor } : {}),
             ...(req.query.after !== undefined ? { after: req.query.after } : {}),
             limit: req.query.limit ?? 50
           })
-          // Provider membership and identity can be revoked while the daemon is
-          // answering. Re-run the complete predicate before any body leaves CP.
-          if (!(await getOrgViewableSession(req, req.params.id))) {
-            return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
-          }
-          return {
-            sessionId: page.sessionId,
-            messages: page.messages,
-            nextCursor: page.nextCursor ?? null,
-            liveCursor: page.liveCursor ?? null,
-            liveMore: page.liveMore ?? false
-          }
-        } catch (err) {
-          if (err instanceof NoConnection) {
-            return reply
-              .code(503)
-              .send({ error: 'Service Unavailable', statusCode: 503, message: 'owning daemon is offline' })
-          }
-          throw err
+        )
+        if (!read.ok) return reply.code(503).send(contentUnavailable(read.reason))
+        // Provider membership and identity can be revoked while the daemon is
+        // answering. Re-run the complete predicate before any body leaves CP.
+        if (!(await getOrgViewableSession(req, req.params.id))) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
+        }
+        const page = read.value
+        return {
+          sessionId: page.sessionId,
+          messages: page.messages,
+          nextCursor: page.nextCursor ?? null,
+          liveCursor: page.liveCursor ?? null,
+          liveMore: page.liveMore ?? false
         }
       }
     )
 
-    // Full-body view follows the same immutable session-content owner as history.
-    // The console pages by offset until nextOffset is null. 503 if the recorded
-    // daemon is unknown or offline.
+    // Full-body view resolves the same content readers as history. The console pages by
+    // offset until nextOffset is null. 503 when no reader is reachable.
     r.get(
       '/sessions/:id/tool-body',
       {
@@ -945,7 +973,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get a tool-call body',
           description:
-            "Proxies one byte slice of a tool call's untruncated ToolBody JSON live from the daemon recorded on the session; the console pages by offset until nextOffset is null. 503 if that daemon is unknown or offline.",
+            "Proxies one byte slice of a tool call's untruncated ToolBody JSON live from a daemon holding the session; the console pages by offset until nextOffset is null. 503 when none is reachable.",
           operationId: 'getSessionToolBody',
           params: IdParam,
           querystring: SessionToolBodyQueryDto,
@@ -958,36 +986,25 @@ export function sessionRoutes(deps: HttpDeps) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
         }
         const { session } = owned
-        if (!session.daemonId) {
-          return reply
-            .code(503)
-            .send({ error: 'Service Unavailable', statusCode: 503, message: 'session has no recorded daemon' })
-        }
-
-        try {
-          const chunk = await deps.control.sessionToolBody(session.daemonId, {
+        const read = await readSessionContent(session, (daemonId) =>
+          deps.control.sessionToolBody(daemonId, session.orgId, {
             agentId: session.agentId,
             sessionId: session.id,
             toolCallId: req.query.toolCallId,
             offset: req.query.offset ?? 0
           })
-          if (!(await getOrgViewableSession(req, req.params.id))) {
-            return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
-          }
-          return {
-            sessionId: chunk.sessionId,
-            toolCallId: chunk.toolCallId,
-            data: chunk.data,
-            totalBytes: chunk.totalBytes,
-            nextOffset: chunk.nextOffset ?? null
-          }
-        } catch (err) {
-          if (err instanceof NoConnection) {
-            return reply
-              .code(503)
-              .send({ error: 'Service Unavailable', statusCode: 503, message: 'owning daemon is offline' })
-          }
-          throw err
+        )
+        if (!read.ok) return reply.code(503).send(contentUnavailable(read.reason))
+        if (!(await getOrgViewableSession(req, req.params.id))) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
+        }
+        const chunk = read.value
+        return {
+          sessionId: chunk.sessionId,
+          toolCallId: chunk.toolCallId,
+          data: chunk.data,
+          totalBytes: chunk.totalBytes,
+          nextOffset: chunk.nextOffset ?? null
         }
       }
     )

--- a/packages/control-plane/src/orchestrator/outbound.session-reads.test.ts
+++ b/packages/control-plane/src/orchestrator/outbound.session-reads.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Session content reads must carry an explicit org on the wire.
+ *
+ * A pool member's connection is install-wide (`conn.orgId` undefined), and
+ * `DaemonConnection.organizationFor` resolves one from `orgByAgent` — a map holding only the
+ * agents that connection has been told about. A peer answering for a RETIRED member was told
+ * about none of them, so a frame without an explicit org is SCOPE_DENIED before it leaves the
+ * CP. These pin the argument that prevents that.
+ */
+import { describe, it, expect } from 'vitest'
+import { ControlSender } from './outbound.js'
+import type { ConnectionRegistry } from '../ws/registry.js'
+import type { LaunchRepo } from '../persistence/ports.js'
+
+function senderWithSpyConn() {
+  const calls: Array<{ type: string; orgId: string | undefined }> = []
+  const conn = {
+    request: async (type: string, _payload: unknown, _ext?: unknown, _opts?: unknown, orgId?: string) => {
+      calls.push({ type, orgId })
+      return {}
+    }
+  }
+  const registry = { get: () => ({ conn, sessionEpoch: 7 }) } as unknown as ConnectionRegistry
+  return { calls, sender: new ControlSender(registry, {} as LaunchRepo) }
+}
+
+describe('ControlSender session content reads', () => {
+  it('scopes session/history to the org that authorized the read', async () => {
+    const { calls, sender } = senderWithSpyConn()
+    await sender.sessionHistory('pool-member', 'org-7', { agentId: 'a1', sessionId: 's1', limit: 50 })
+    expect(calls).toEqual([{ type: 'session/history', orgId: 'org-7' }])
+  })
+
+  it('scopes session/tool-body the same way', async () => {
+    const { calls, sender } = senderWithSpyConn()
+    await sender.sessionToolBody('pool-member', 'org-7', {
+      agentId: 'a1',
+      sessionId: 's1',
+      toolCallId: 't1',
+      offset: 0
+    })
+    expect(calls).toEqual([{ type: 'session/tool-body', orgId: 'org-7' }])
+  })
+})

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -503,25 +503,31 @@ export class ControlSender {
   }
 
   /**
-   * Pull one page of a session's history from the owning daemon for the console
+   * Pull one page of a session's history from a daemon holding it for the console
    * (REQ → `session/history/page`). Read-only — the CP proxies the bodies to the
    * UI live and never stores them (body-locality, §1/§12).
+   *
+   * Explicit orgId, for the same reason the agent frames take one: an install-wide pool
+   * member resolves an org from `orgByAgent`, which holds only the agents that connection
+   * was told about, and a shared-store peer answering for a retired member was told about
+   * none of them — so a bare agent id is SCOPE_DENIED before the frame leaves the CP.
    */
-  async sessionHistory(daemonId: string, req: SessionHistoryReq): Promise<SessionHistoryPage> {
+  async sessionHistory(daemonId: string, orgId: string, req: SessionHistoryReq): Promise<SessionHistoryPage> {
     const c = this.must(daemonId)
-    return c.conn.request<SessionHistoryPage>('session/history', req, { epoch: c.sessionEpoch })
+    return c.conn.request<SessionHistoryPage>('session/history', req, { epoch: c.sessionEpoch }, undefined, orgId)
   }
 
   /**
-   * Fetch one frame-budgeted byte slice of a tool call's FULL ToolBody JSON from
-   * the owning daemon for the console (REQ → `session/tool-body/chunk`). Read-only
+   * Fetch one frame-budgeted byte slice of a tool call's FULL ToolBody JSON from a
+   * daemon holding the session (REQ → `session/tool-body/chunk`), with an explicit org for
+   * the same scoping reason as {@link ControlSender.sessionHistory}. Read-only
    * — the CP proxies the bytes to the UI live and never stores them (body-locality,
    * §1/§12). The console pages by `offset` until `nextOffset` is absent, then
    * concatenates and JSON.parses the assembled string.
    */
-  async sessionToolBody(daemonId: string, req: SessionToolBodyReq): Promise<SessionToolBodyChunk> {
+  async sessionToolBody(daemonId: string, orgId: string, req: SessionToolBodyReq): Promise<SessionToolBodyChunk> {
     const c = this.must(daemonId)
-    return c.conn.request<SessionToolBodyChunk>('session/tool-body', req, { epoch: c.sessionEpoch })
+    return c.conn.request<SessionToolBodyChunk>('session/tool-body', req, { epoch: c.sessionEpoch }, undefined, orgId)
   }
 
   /**

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1156,6 +1156,9 @@ export interface SessionMetaRecord {
   permissionMode: string | null
   outputMode: string | null
   daemonId: DaemonId | null
+  /** The member set whose shared store holds this session's content; null ⇒ the recorder kept a
+   *  private one. Session-bound provenance that outlives `daemonId` (domain/session-content.ts). */
+  contentSetId: string | null
   workspaceIsolation: 'shared' | 'session' | null
   activityState: ActivityState
   // ── session visibility (session-visibility.md §3) ──
@@ -5014,6 +5017,10 @@ export interface MemberSetRepo {
   setIdOf(daemonId: DaemonId): Promise<string | null>
   /** The set's members, sorted. The read path for "who could serve a `set`-placed agent". */
   memberIdsOf(setId: string): Promise<string[]>
+  /** The set's members, sorted, but ONLY for a set whose members share one content store — the
+   *  org-less install-wide pool. An org set answers `[]`: its machines may keep private stores, so
+   *  none of them can stand in for another's transcripts (domain/session-content.ts). */
+  sharedStoreMemberIdsOf(setId: string): Promise<string[]>
   /** Record a membership under the set's tenancy invariant; throws MemberSetTenancyMismatch. */
   enroll(setId: string, daemonId: DaemonId): Promise<void>
 }

--- a/packages/control-plane/src/persistence/repositories/member-set.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/member-set.repo.ts
@@ -69,6 +69,17 @@ export class PgMemberSetRepo implements MemberSetRepo {
     return rows.map((r) => r.daemonId).sort()
   }
 
+  async sharedStoreMemberIdsOf(setId: string): Promise<string[]> {
+    // `set: { orgId: null }` IS the shared-store predicate — the install-wide pool is the one set
+    // whose members are cluster daemons on the single data-plane store. An operator-built org set
+    // may be self-hosted machines with private stores, so none of its members answers for another.
+    const rows = await this.prisma.memberSetMember.findMany({
+      where: { setId, set: { orgId: null } },
+      select: { daemonId: true }
+    })
+    return rows.map((r) => r.daemonId).sort()
+  }
+
   async enroll(setId: string, daemonId: DaemonId): Promise<void> {
     await this.prisma.$transaction((tx) => enrollDaemonInSet(tx, setId, daemonId))
   }

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -74,6 +74,7 @@ function toRecord(s: SessionMeta): SessionMetaRecord {
     permissionMode: s.permissionMode,
     outputMode: s.outputMode,
     daemonId: s.daemonId ? DaemonId(s.daemonId) : null,
+    contentSetId: s.contentSetId,
     workspaceIsolation: s.workspaceIsolation as 'shared' | 'session' | null,
     activityState: s.activityState as ActivityState,
     orgId: OrgId(s.orgId),
@@ -782,7 +783,7 @@ export class PgSessionRepo implements SessionRepo {
         "thread", "tenantScope", "phase", "link", "summary", "title", "status",
         "lastActivityAt", "triggeredBy", "channelName", "triggeredByName",
         "threadUrl", "runtime", "model", "effort", "fastMode",
-        "permissionMode", "outputMode", "daemonId", "workspaceIsolation", "orgId", "visibility",
+        "permissionMode", "outputMode", "daemonId", "contentSetId", "workspaceIsolation", "orgId", "visibility",
         "ownerIdentity", "visibilitySource", "externalProvider",
         "externalScopeId", "externalResolution", "legacyUnresolved",
         "classifiedPolicyRev", "startedAt", "endedAt", "updatedAt"
@@ -796,6 +797,14 @@ export class PgSessionRepo implements SessionRepo {
         ${ev.runtime ?? null}, ${ev.model ?? null}, ${ev.effort ?? null},
         ${ev.fastMode ?? null}, ${ev.permissionMode ?? null},
         ${ev.outputMode ?? null}, ${ev.daemonId ?? null},
+        -- Read from the reporting daemon's membership in this same statement, so the store the
+        -- bodies are going to can never drift from the daemon it describes. Restricted to the
+        -- org-less pool: that is the set whose members provably share one data-plane store.
+        (
+          SELECT msm."setId" FROM "member_set_member" msm
+          JOIN "member_set" ms ON ms."id" = msm."setId"
+          WHERE msm."daemonId" = ${ev.daemonId ?? null}::uuid AND ms."orgId" IS NULL
+        ),
         ${ev.workspaceIsolation ?? null}::"WorkspaceIsolation",
         ${orgId},
         ${cls.visibility}::"SessionVisibility", ${cls.ownerIdentity},
@@ -851,6 +860,14 @@ export class PgSessionRepo implements SessionRepo {
         -- reports the session. A later milestone must not move daemon-local
         -- transcript/worktree provenance when the agent itself is reassigned.
         "daemonId" = COALESCE("session_meta"."daemonId", EXCLUDED."daemonId"),
+        -- Filled only while the reporter IS the recorded content owner, so a milestone from a
+        -- daemon that merely serves the agent now cannot claim this session's rows for its store.
+        -- Null is a REAL value here (a private store), which is why this is not a COALESCE.
+        "contentSetId" = CASE
+          WHEN "session_meta"."daemonId" IS DISTINCT FROM EXCLUDED."daemonId"
+            THEN "session_meta"."contentSetId"
+          ELSE COALESCE("session_meta"."contentSetId", EXCLUDED."contentSetId")
+        END,
         "workspaceIsolation" = COALESCE(
           EXCLUDED."workspaceIsolation",
           "session_meta"."workspaceIsolation"

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -14,8 +14,10 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { joinPool } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
-import { ControlSender } from '../../src/orchestrator/outbound.js'
+import { ControlSender, NoConnection } from '../../src/orchestrator/outbound.js'
+import { ConnectionClosed } from '../../src/ws/registry.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import type { DaemonLiveness } from '../../src/ports.js'
 import type { SessionListReq, SessionListPage, SessionHistoryReq, SessionHistoryPage } from '@agentconnect.md/protocol'
@@ -33,6 +35,8 @@ afterEach(async () => {
 
 const DAEMON = 'd0d0d0d0-dddd-4ddd-8ddd-dddddddddddd'
 const OTHER_DAEMON = 'e0e0e0e0-eeee-4eee-8eee-eeeeeeeeeeee'
+const POOL_MEMBER = 'b0b0b0b0-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const OTHER_POOL_MEMBER = 'c0c0c0c0-cccc-4ccc-8ccc-cccccccccccc'
 const AGENT = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const SESSION = '50505050-5555-4555-8555-555555555555'
 
@@ -41,32 +45,42 @@ const LIVE: DaemonLiveness = {
   get: (id) => (id === DAEMON ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined)
 }
 
-/** A ControlSender spy answering sessionList + sessionHistory with canned data. */
+/** Both pool members connected — a store's readers are tried in order. */
+const POOL_LIVE: DaemonLiveness = {
+  get: (id) =>
+    id === POOL_MEMBER || id === OTHER_POOL_MEMBER ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined
+}
+
+/** A ControlSender spy answering sessionList + sessionHistory with canned data. Daemons in
+ *  `unreachable` record the call and then throw `NoConnection`, as an absent socket would. */
 class SpyControl {
   listCalls: Array<{ daemonId: string; req: SessionListReq }> = []
-  histCalls: Array<{ daemonId: string; req: SessionHistoryReq }> = []
+  histCalls: Array<{ daemonId: string; orgId: string; req: SessionHistoryReq }> = []
   constructor(
     private readonly list: SessionListPage,
-    private readonly hist: SessionHistoryPage
+    private readonly hist: SessionHistoryPage,
+    private readonly unreachable: readonly string[] = []
   ) {}
   async sessionList(daemonId: string, req: SessionListReq): Promise<SessionListPage> {
     this.listCalls.push({ daemonId, req })
     return this.list
   }
-  async sessionHistory(daemonId: string, req: SessionHistoryReq): Promise<SessionHistoryPage> {
-    this.histCalls.push({ daemonId, req })
+  async sessionHistory(daemonId: string, orgId: string, req: SessionHistoryReq): Promise<SessionHistoryPage> {
+    this.histCalls.push({ daemonId, orgId, req })
+    if (this.unreachable.includes(daemonId)) throw new NoConnection(daemonId)
     return this.hist
   }
 }
 
 const emptyHist: SessionHistoryPage = { sessionId: SESSION, messages: [] }
 
-async function seedSession(agentId = AGENT, daemonId?: string): Promise<void> {
+async function seedSession(agentId = AGENT, daemonId?: string, contentSetId?: string): Promise<void> {
   await prisma.sessionMeta.create({
     data: {
       id: SESSION,
       agentId,
       ...(daemonId ? { daemonId } : {}),
+      ...(contentSetId ? { contentSetId } : {}),
       orgId: DEFAULT_ORG_ID,
       platform: 'slack',
       channel: '#deploys',
@@ -662,7 +676,9 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
 
     expect(res.statusCode).toBe(200)
-    expect(spy.histCalls).toEqual([{ daemonId: DAEMON, req: { agentId: AGENT, sessionId: SESSION, limit: 50 } }])
+    expect(spy.histCalls).toEqual([
+      { daemonId: DAEMON, orgId: DEFAULT_ORG_ID, req: { agentId: AGENT, sessionId: SESSION, limit: 50 } }
+    ])
   })
 
   it('503s when legacy session metadata has no recorded daemon', async () => {
@@ -685,5 +701,144 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
     running = buildHttpApp(prisma, undefined, undefined, offline)
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
     expect(res.statusCode).toBe(503)
+  })
+
+  // A pool member is bound to its Pod UID and reaped 15 min after it goes silent, which SetNulls
+  // `daemonId` on every session it recorded. The rows survive it — they were written to the store
+  // its peers share — so a live peer still serves them. The agent holds no duty anywhere here:
+  // readability is a property of the store, not of who serves the agent.
+  it('reads a retired pool recorder‘s session from a peer on its store', async () => {
+    await seedAgent(prisma, AGENT)
+    await prisma.daemon.create({ data: { id: POOL_MEMBER, orgId: null, status: 'ready', maxAgents: 4 } })
+    const setId = await joinPool(prisma, POOL_MEMBER)
+    await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'set', setId, daemonId: null } })
+    await seedSession(AGENT, undefined, setId)
+    const spy = new SpyControl({ sessions: [] }, emptyHist)
+    running = buildHttpApp(prisma, undefined, POOL_LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(200)
+    // Explicit org: a peer that never served this agent resolves none from its id, and would
+    // answer SCOPE_DENIED before the frame left the CP.
+    expect(spy.histCalls).toEqual([
+      { daemonId: POOL_MEMBER, orgId: DEFAULT_ORG_ID, req: { agentId: AGENT, sessionId: SESSION, limit: 50 } }
+    ])
+  })
+
+  it('prefers the recording member over its peers while it is still connected', async () => {
+    await seedAgent(prisma, AGENT)
+    await prisma.daemon.createMany({
+      data: [POOL_MEMBER, OTHER_POOL_MEMBER].map((id) => ({ id, orgId: null, status: 'ready' as const, maxAgents: 4 }))
+    })
+    const setId = await joinPool(prisma, POOL_MEMBER, OTHER_POOL_MEMBER)
+    await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'set', setId, daemonId: null } })
+    await seedSession(AGENT, OTHER_POOL_MEMBER, setId)
+    const spy = new SpyControl({ sessions: [] }, emptyHist)
+    running = buildHttpApp(prisma, undefined, POOL_LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(200)
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([OTHER_POOL_MEMBER])
+  })
+
+  it('tries every peer on the store, not just the first', async () => {
+    await seedAgent(prisma, AGENT)
+    await prisma.daemon.createMany({
+      data: [POOL_MEMBER, OTHER_POOL_MEMBER].map((id) => ({ id, orgId: null, status: 'ready' as const, maxAgents: 4 }))
+    })
+    const setId = await joinPool(prisma, POOL_MEMBER, OTHER_POOL_MEMBER)
+    await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'set', setId, daemonId: null } })
+    await seedSession(AGENT, undefined, setId)
+    const spy = new SpyControl({ sessions: [] }, emptyHist, [POOL_MEMBER])
+    running = buildHttpApp(prisma, undefined, POOL_LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(200)
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([POOL_MEMBER, OTHER_POOL_MEMBER])
+  })
+
+  // Ordinary during a rollout: the socket is in the registry at send time and dies before the
+  // reply. That is unavailability, not a failed read — keep going.
+  it('falls through a peer whose socket dies mid-request', async () => {
+    await seedAgent(prisma, AGENT)
+    await prisma.daemon.createMany({
+      data: [POOL_MEMBER, OTHER_POOL_MEMBER].map((id) => ({ id, orgId: null, status: 'ready' as const, maxAgents: 4 }))
+    })
+    const setId = await joinPool(prisma, POOL_MEMBER, OTHER_POOL_MEMBER)
+    await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'set', setId, daemonId: null } })
+    await seedSession(AGENT, undefined, setId)
+    const spy = new SpyControl({ sessions: [] }, emptyHist)
+    const firstDiesInFlight = {
+      ...spy,
+      sessionHistory: async (daemonId: string, orgId: string, req: SessionHistoryReq) => {
+        if (daemonId === POOL_MEMBER) throw new ConnectionClosed()
+        return spy.sessionHistory(daemonId, orgId, req)
+      }
+    }
+    running = buildHttpApp(prisma, undefined, POOL_LIVE, firstDiesInFlight as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(200)
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([OTHER_POOL_MEMBER])
+  })
+
+  // Content does not follow an agent move, so neither does reader eligibility. A session recorded
+  // on a private store gets no pool reader just because its agent has since moved onto the pool —
+  // the pool would answer an EMPTY page, dressing a lost transcript up as an empty one.
+  it('gives a session written on a private store no pool reader after its agent moves onto the pool', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await prisma.daemon.create({ data: { id: POOL_MEMBER, orgId: null, status: 'ready', maxAgents: 4 } })
+    const setId = await joinPool(prisma, POOL_MEMBER)
+    await seedAgent(prisma, AGENT)
+    await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'set', setId, daemonId: null } })
+    await seedSession(AGENT, DAEMON) // recorded on DAEMON's own store ⇒ no contentSetId
+    const spy = new SpyControl({ sessions: [] }, emptyHist, [DAEMON])
+    running = buildHttpApp(prisma, undefined, POOL_LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(503)
+    expect(res.json()).toMatchObject({ message: 'owning daemon is offline' })
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([DAEMON])
+  })
+
+  // The mirror: the agent has moved off the pool, but the session it left behind is still in the
+  // pool's store, so the pool's members are still its readers.
+  it('keeps a pooled session readable after its agent moves off the pool', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await prisma.daemon.create({ data: { id: POOL_MEMBER, orgId: null, status: 'ready', maxAgents: 4 } })
+    const setId = await joinPool(prisma, POOL_MEMBER)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON }) // moved off: machine-placed, setId null
+    await seedSession(AGENT, undefined, setId)
+    const spy = new SpyControl({ sessions: [] }, emptyHist)
+    running = buildHttpApp(prisma, undefined, POOL_LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(200)
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([POOL_MEMBER])
+  })
+
+  // An org set is an operator's grouping of machines that may each keep a private store.
+  it('never stands a peer in across an org set', async () => {
+    const setId = randomUUID()
+    await prisma.memberSet.create({ data: { id: setId, orgId: DEFAULT_ORG_ID, name: 'self-hosted' } })
+    await seedDaemon(prisma, DAEMON)
+    await prisma.memberSetMember.create({ data: { setId, daemonId: DAEMON } })
+    await seedAgent(prisma, AGENT)
+    await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'set', setId, daemonId: null } })
+    await seedSession(AGENT, undefined, setId)
+    const spy = new SpyControl({ sessions: [] }, emptyHist)
+    running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(503)
+    expect(res.json()).toMatchObject({ message: 'session has no recorded daemon' })
+    expect(spy.histCalls).toEqual([])
   })
 })

--- a/packages/control-plane/test/repo/session.repo.test.ts
+++ b/packages/control-plane/test/repo/session.repo.test.ts
@@ -188,6 +188,42 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     expect(row?.daemonId).toBe(DAEMON)
   })
 
+  // The recorder's row is deleted 15 minutes after a pool Pod goes silent and takes `daemonId`
+  // with it, so where the bodies went has to be recorded beside it, at the one moment it is
+  // knowable (domain/session-content.ts).
+  it('stamps the shared content store of a pool recorder, and nothing for a private one', async () => {
+    await fixtures()
+    const setId = (await prisma.memberSet.findFirstOrThrow({ where: { orgId: null } })).id
+    const POOL_MEMBER = 'd3333333-3333-4333-8333-333333333333'
+    await prisma.daemon.create({ data: { id: POOL_MEMBER, orgId: null, sessionEpoch: 1n, status: 'ready' } })
+    await prisma.memberSetMember.create({ data: { setId, daemonId: POOL_MEMBER } })
+    const repo = new PgSessionRepo(prisma)
+
+    await repo.recordMilestone(ev('start', { daemonId: DaemonId(POOL_MEMBER) }))
+    expect((await prisma.sessionMeta.findUnique({ where: { id: SESSION } }))?.contentSetId).toBe(setId)
+
+    // DAEMON is org-scoped and in no set — its store is its own, so no peer may read it.
+    await prisma.sessionMeta.delete({ where: { id: SESSION } })
+    await repo.recordMilestone(ev('start', { daemonId: DaemonId(DAEMON) }))
+    expect((await prisma.sessionMeta.findUnique({ where: { id: SESSION } }))?.contentSetId).toBeNull()
+  })
+
+  it('never lets a later reporter claim the content store of a session it did not record', async () => {
+    await fixtures()
+    const setId = (await prisma.memberSet.findFirstOrThrow({ where: { orgId: null } })).id
+    const POOL_MEMBER = 'd4444444-4444-4444-8444-444444444444'
+    await prisma.daemon.create({ data: { id: POOL_MEMBER, orgId: null, sessionEpoch: 1n, status: 'ready' } })
+    await prisma.memberSetMember.create({ data: { setId, daemonId: POOL_MEMBER } })
+    const repo = new PgSessionRepo(prisma)
+
+    await repo.recordMilestone(ev('start', { daemonId: DaemonId(DAEMON) }))
+    await repo.recordMilestone(ev('end', { daemonId: DaemonId(POOL_MEMBER) }))
+
+    const row = await prisma.sessionMeta.findUnique({ where: { id: SESSION } })
+    expect(row?.daemonId).toBe(DAEMON)
+    expect(row?.contentSetId).toBeNull()
+  })
+
   it('keeps the recorded execution config when a later milestone omits it', async () => {
     await fixtures()
     const repo = new PgSessionRepo(prisma)


### PR DESCRIPTION
Rebased onto current `main` and made self-contained — it no longer depends on #1018, which was reverted in #1020.

## The bug

Opening a pool-run session in the console shows:

> Couldn't load the transcript — the owning daemon may be offline.

No daemon was offline and nothing was lost. In `agentconnect-test`, session `f43b53e9…` still had every row in the shared data-plane Postgres:

```
sessions where acpsessionid = f43b53e9-…   →  1 row  (state closed, "Say hello to draco")
transcript rows for its thread             →  3 rows
```

The CP never asked anyone for them. Both content routes proxy strictly from `session_meta.daemonId`, and short-circuit to `503 session has no recorded daemon` when it is null.

That column is right for a self-hosted daemon, whose store is a private sqlite file. It is not for a cluster pool member: its store is `PostgresSyncDatabase` over the install-wide data-plane Postgres every member shares. Members are bound to a Pod UID and reaped 15 minutes after they go silent (`poolMemberReaper.ts`), and `SessionMeta.daemon` is `onDelete: SetNull` — so every rollout detached the sessions those pods recorded. 49 rows were in that state, 8 of them with content fully intact.

## The fix

Readers are resolved through a new `domain/session-content.ts` as a property of the **store**: the recorder first, then the members of the session's own `contentSetId`.

Nothing about the agent enters the decision, and both halves of that matter:

- **Not its placement.** An agent can move into a set, out of one, or between two long after a session ran. A daemon that does not hold the session answers `history` with an **empty page**, not an error, so a reader picked from current placement dresses a lost transcript up as an empty one.
- **Not its live duty holder.** An idle pooled agent holds no lease at all — the ordinary state — while its transcripts stay exactly as readable. In the test deployment: `1` of `53` duty groups had a live lease, and it was the one agent in active use.

`SessionMeta.contentSetId` is stamped from the recorder's own membership in the same `INSERT … ON CONFLICT` that pins `daemonId`, read from that same daemon id so provenance cannot drift from the daemon it describes, and filled only while the reporter **is** the recorded owner — a milestone from a daemon that merely serves the agent now cannot claim its rows. Null means a private store, and null is a real answer, not "unknown", so it is not a `COALESCE`.

Only the **org-less install-wide pool** counts as shared (`sharedStoreMemberIdsOf` encodes `set.orgId IS NULL`). An operator-built org set may be self-hosted machines with private stores.

Two consequences of reaching a peer that never served the agent:

- **It resolves no org.** `DaemonConnection.organizationFor` (`connection.ts:287`) reads `orgByAgent`, which holds only agents that connection was told about. Both read frames now take the authorized org explicitly, as the agent frames already do — otherwise `SCOPE_DENIED` before the frame leaves the CP. Pinned in `outbound.session-reads.test.ts` against `conn.request` itself, not a route spy.
- **Fall-through needs more than `NoConnection`.** With several candidates, a socket dying between the registry lookup and the reply is ordinary during a rollout; `ConnectionClosed` is unavailability, not a failed read.

## Migration

`20260825000000_session_content_store` uses `ADD COLUMN IF NOT EXISTS` and a conditional constraint: #1018's reverted `session_content_set` migration may already have been applied to a database, and `prisma migrate deploy` does not replay an applied-but-missing migration, so this converges both states instead of assuming a clean one.

Backfill (a) is exact — the recorder is still a pool member, so it is its own evidence. Backfill (b) recovers rows a retired member already orphaned, from placement, and **is an inference**. The sequence that defeats it is named in the SQL: a session on a local daemon, whose agent later moved onto the pool, whose original daemon was then removed with `DELETE /daemons/:id`, is wrongly attributed and answers an empty page instead of a 503. It costs a row that is permanently unreadable today, which is why the recovery is worth it — and it is why live routing never makes this inference, and why a store-authoritative reconciliation (asking a member which sessions it actually holds) is the right way to settle these rows for good. Happy to drop (b) and fail closed instead if reviewers prefer.

## Tests

Route: retired recorder served by a store peer (org asserted); recorder preferred while connected; every peer tried, not just the first; fall-through on a mid-request socket death; private-store session gets **no** pool reader after its agent moves onto the pool; pooled session stays readable after its agent moves off; org set never stands a peer in.

Repo: stamping for a pool recorder vs a private one; a later reporter never claiming a session it did not record.

Unit: resolver ordering/dedup, and org scoping on both frames.

Full control-plane suite green — 1678 unit, 1331 integration — plus typecheck, lint, format.