### PR TITLE
fix(daemon): fire an orchestration deadline only where the main's duty is held

### DIFF
--- a/docs/designs/agent-collaboration-implementation.md
+++ b/docs/designs/agent-collaboration-implementation.md
@@ -876,7 +876,10 @@ Timeout, retransmission, and deduplication at each hop use the stable
 - **Deadline durability:** Store the deadline in the durable orchestration
   record, re-arm it at startup, and make cancellation idempotent. The wake
   dispatches directly to `mainSessionKey` and does not reuse cron
-  `fireTrigger`, which would create a new platform anchor.
+  `fireTrigger`, which would create a new platform anchor. On a pool the store
+  is shared, so a deadline is armed only where the main's duty is held, re-armed
+  on every duty change, and the fire is a CAS claim on the stored deadline —
+  one wake per deadline however many members hold a timer for it.
 - **Atomic start boundary:** A database write and cross-daemon send cannot be
   one atomic operation. Record the orchestration and stable per-subtask
   delivery/correlation ids before delivery, use monotonic state transitions,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3721,7 +3721,7 @@ export class Daemon {
       .on('unlink', debounced)
     this.log.info(`watching ${this.agentsDir} for agent changes`)
     this.replayInbox()
-    this.rearmOrchestrationDeadlines()
+    this.syncOrchestrationDeadlines()
     // #485 startup retention pass: reconcile what accumulated (or was orphaned by a
     // crash) while the daemon was down. Best-effort — never blocks readiness. Runs
     // AFTER replayInbox so replayed durable work is visible to its active-turn guard.
@@ -10271,12 +10271,28 @@ export class Daemon {
     this.orchestrationDeadlines.set(orchestrationId, handle)
   }
 
+  /** Whether this member serves the agent's ingress edges (crons, deadlines): the duty holder, or any local daemon. */
+  private servesAgent(agentId: string): boolean {
+    return !this.dutyEnforced() || this.duties.holdsAgent(agentId)
+  }
+
   /** Deadline fired (§3.5): mark every still-open subtask timed_out, then WAKE the main's
    *  session so it re-reads getOrchestration and summarizes the partial result. The wake is
-   *  a direct dispatch to the stored session coords — no platform post, no new thread. */
+   *  a direct dispatch to the stored session coords — no platform post, no new thread.
+   *  Every pool member sharing the store may have a timer for this id, so the fire is gated
+   *  twice: the duty check (a dispatch binds the agent's sandbox, so only its holder may wake
+   *  it) and a CAS claim on the stored deadline, which makes a handoff race fire once. */
   private fireOrchestrationDeadline(orchestrationId: string): void {
     const orch = this.store.getOrchestration(orchestrationId)
-    if (!orch || orch.status !== 'active') return // cancelled / completed → nothing to do
+    if (!orch || orch.status !== 'active' || orch.deadline == null) return // cancelled / completed / already fired
+    if (!this.servesAgent(orch.mainAgentId)) {
+      this.log.debug(`orchestration ${orchestrationId}: deadline reached but ${orch.mainAgentId} is served elsewhere`)
+      return
+    }
+    if (!this.store.claimOrchestrationDeadline(orchestrationId, orch.deadline, this.clock.now())) {
+      this.log.debug(`orchestration ${orchestrationId}: deadline already claimed by another member`)
+      return
+    }
     // Mark unreported (delivered but not yet reported, or still sending/pending) as timed_out.
     for (const s of this.store.getSubtasks(orchestrationId)) {
       this.store.setSubtaskStatus(
@@ -10287,7 +10303,6 @@ export class Daemon {
         monotonicTs()
       )
     }
-    this.store.setOrchestrationDeadline(orchestrationId, null, this.clock.now())
     this.emitEvaluation({
       type: 'orchestration.state',
       agentId: orch.mainAgentId,
@@ -10435,10 +10450,12 @@ export class Daemon {
     return orch
   }
 
-  /** Startup re-arm (§3.5): re-arm the one-shot deadline for every still-active orchestration
-   *  from the durable `deadline` epoch. A deadline already in the past fires ~immediately.
-   *  Mirrors replayInbox's read-active-rows/re-schedule pattern; idempotent. */
-  private rearmOrchestrationDeadlines(): void {
+  /** Re-derive which deadlines this member arms from the durable `deadline` epochs (§3.5): arm
+   *  the held agents' still-active orchestrations, disarm what moved to another member. Runs at
+   *  startup and after every duty change; idempotent, and a stale timer is harmless because the
+   *  fire re-checks the duty and claims the deadline through the store. A deadline already in
+   *  the past fires ~immediately. */
+  private syncOrchestrationDeadlines(): void {
     let active: OrchestrationRow[]
     try {
       active = this.store.listActiveOrchestrations()
@@ -10447,12 +10464,20 @@ export class Daemon {
       return
     }
     let armed = 0
+    let disarmed = 0
     for (const orch of active) {
-      if (orch.deadline == null) continue
-      this.armOrchestrationDeadline(orch.orchestrationId, orch.deadline)
-      armed++
+      const held = this.servesAgent(orch.mainAgentId)
+      const handle = this.orchestrationDeadlines.get(orch.orchestrationId)
+      if (held && orch.deadline != null && handle === undefined) {
+        this.armOrchestrationDeadline(orch.orchestrationId, orch.deadline)
+        armed++
+      } else if (!held && handle !== undefined) {
+        this.clock.clearTimeout(handle)
+        this.orchestrationDeadlines.delete(orch.orchestrationId)
+        disarmed++
+      }
     }
-    if (armed) this.log.info(`orchestration: re-armed ${armed} deadline(s) on startup`)
+    if (armed || disarmed) this.log.info(`orchestration: armed ${armed} and disarmed ${disarmed} deadline(s)`)
   }
 
   /**
@@ -13205,6 +13230,7 @@ export class Daemon {
   private onDutyChanged(): void {
     if (!this.dutyEnforced()) return
     for (const agent of this.agents.values()) this.syncAgentSchedules(agent)
+    this.syncOrchestrationDeadlines()
     this.dutyConnectionsRequested++
     this.convergeDutyConnections()
   }
@@ -13231,7 +13257,7 @@ export class Daemon {
   /** Arm this agent's cron + dream schedules, or disarm them when its duty lives
    *  elsewhere — a cron is an ingress edge, so it fires only at the holder. */
   private syncAgentSchedules(a: { id: string; crons: CronDef[]; memory?: Agent['memory'] }): void {
-    const serve = !this.dutyEnforced() || this.duties.holdsAgent(a.id)
+    const serve = this.servesAgent(a.id)
     this.scheduler.sync(a.id, serve ? a.crons : [])
     this.dreamScheduler.sync(a.id, serve ? this.dreamSchedulePolicyFor(a) : undefined)
   }
@@ -21698,6 +21724,8 @@ export class Daemon {
     for (const a of this.effectiveAgents()) {
       const cron = a.crons.find((c) => c.id === cronId && c.origin === 'cp')
       if (!cron) continue
+      // A cron is an ingress edge: it fires only where the agent's duty is held.
+      if (!this.servesAgent(a.id)) return { ok: false, reason: 'agent is served by another member' }
       const { msg } = buildSyntheticMessage(a.id, cron, randomUUID())
       void this.onCronFire(a.id, msg, cron).catch((err) =>
         this.log.error(`cron/run dispatch failed for agent "${a.id}": ${formatErr(err)}`)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -4243,6 +4243,18 @@ export class LocalStore {
       .run(deadline, updatedAt, orchestrationId)
   }
 
+  /** CAS fire claim: clear the deadline iff it is still the armed one — every member sharing the
+   *  store may hold a timer for it, and exactly one of them gets `true`. */
+  claimOrchestrationDeadline(orchestrationId: string, deadline: number, updatedAt: number): boolean {
+    return (
+      this.db
+        .prepare(
+          "UPDATE orchestration SET deadline=NULL, updatedAt=? WHERE orchestrationId=? AND status='active' AND deadline=?"
+        )
+        .run(updatedAt, orchestrationId, deadline).changes === 1
+    )
+  }
+
   // ── runtime model-catalog cache (runtime-model-catalog.md §4) ──
 
   /** Upsert a runtime's catalog metadata (phase-1 probe fold or a discovery run).

--- a/packages/daemon/test/orchestration.test.ts
+++ b/packages/daemon/test/orchestration.test.ts
@@ -397,3 +397,111 @@ describe('startup re-arm', () => {
     await daemon2.stop()
   })
 })
+
+// #1036 — on a daemon pool every member shares one store, so every member could arm and fire the
+// same deadline. Only the member holding the main agent's duty may wake it (a dispatch binds the
+// agent's sandbox), and the fire itself is claimed through the store so a handoff fires once.
+describe('pool duty gate on deadlines', () => {
+  const GROUP = '11111111-1111-4111-8111-111111111111'
+  const grant = (groupId = GROUP) => ({
+    groupId,
+    orgId: 'org-1',
+    term: '1',
+    members: [{ kind: 'agent' as const, refId: 'main' }]
+  })
+  const armed = (d: Daemon, id: string) => (d as any).orchestrationDeadlines.has(id)
+
+  /** Frame-scoped member: duty leases gate service, exactly like an install-wide pool member. */
+  function frameScope(daemon: Daemon) {
+    ;(daemon as any).cpClient = {
+      organizationScope: () => 'frame',
+      stop: async () => {},
+      releaseDuties: vi.fn(async () => {}),
+      reportDutiesNow: vi.fn(() => {}),
+      fetchDutyAgent: vi.fn()
+    }
+  }
+  const hold = (d: Daemon) => (d as any).settleDutyChange((d as any).duties.applyGrant([grant()]))
+  const drop = (d: Daemon) => (d as any).applyDutyRevoke([{ groupId: GROUP, reason: 'reassigned' }])
+
+  /** Two members over ONE store: the same root, so both LocalStores open the same database. */
+  async function bootPool() {
+    const root = scaffold(['main', 'wA', 'wB'])
+    const a = await boot(root)
+    const b = await boot(root)
+    frameScope(a.daemon)
+    frameScope(b.daemon)
+    return { a, b, stop: () => Promise.all([a.daemon.stop(), b.daemon.stop()]) }
+  }
+
+  it('only the duty holder arms and fires; a stale timer on a non-holder is refused', async () => {
+    const { a, b, stop } = await bootPool()
+    hold(a.daemon)
+    const res = await (a.daemon as any).startOrchestration(startReq({ deadlineMs: 30_000 }))
+    ;(b.daemon as any).syncOrchestrationDeadlines()
+    expect(armed(a.daemon, res.orchestrationId)).toBe(true)
+    expect(armed(b.daemon, res.orchestrationId)).toBe(false)
+    a.calls.length = 0
+    b.calls.length = 0
+    // The non-holder's timer fires first (the pool has no ordering) — the duty gate drops it.
+    ;(b.daemon as any).fireOrchestrationDeadline(res.orchestrationId)
+    expect(b.calls).toHaveLength(0)
+    expect(store(b.daemon).getOrchestration(res.orchestrationId).deadline).not.toBeNull()
+    ;(a.daemon as any).fireOrchestrationDeadline(res.orchestrationId)
+    expect(a.calls.map((c) => c.agentId)).toEqual(['main'])
+    expect(store(a.daemon).getOrchestration(res.orchestrationId).deadline).toBeNull()
+    expect(
+      store(a.daemon)
+        .getSubtasks(res.orchestrationId)
+        .every((s: any) => s.status === 'timed_out')
+    ).toBe(true)
+    await stop()
+  })
+
+  it('a deadline armed by one member fires on the member the duty moved to', async () => {
+    const { a, b, stop } = await bootPool()
+    hold(a.daemon)
+    const res = await (a.daemon as any).startOrchestration(startReq({ deadlineMs: 30_000 }))
+    expect(armed(a.daemon, res.orchestrationId)).toBe(true)
+    drop(a.daemon)
+    hold(b.daemon)
+    expect(armed(a.daemon, res.orchestrationId)).toBe(false)
+    expect(armed(b.daemon, res.orchestrationId)).toBe(true)
+    a.calls.length = 0
+    b.calls.length = 0
+    ;(a.daemon as any).fireOrchestrationDeadline(res.orchestrationId)
+    ;(b.daemon as any).fireOrchestrationDeadline(res.orchestrationId)
+    expect(a.calls).toHaveLength(0)
+    expect(b.calls.map((c) => c.agentId)).toEqual(['main'])
+    await stop()
+  })
+
+  it('a fire during a handoff, when both members still hold the duty, wakes the main once', async () => {
+    const { a, b, stop } = await bootPool()
+    hold(a.daemon)
+    hold(b.daemon)
+    const res = await (a.daemon as any).startOrchestration(startReq({ deadlineMs: 30_000 }))
+    ;(b.daemon as any).syncOrchestrationDeadlines()
+    expect(armed(b.daemon, res.orchestrationId)).toBe(true)
+    a.calls.length = 0
+    b.calls.length = 0
+    ;(a.daemon as any).fireOrchestrationDeadline(res.orchestrationId)
+    ;(b.daemon as any).fireOrchestrationDeadline(res.orchestrationId)
+    expect(a.calls.length + b.calls.length).toBe(1)
+    const orch = store(a.daemon).getOrchestration(res.orchestrationId)
+    expect(orch.status).toBe('active')
+    expect(orch.deadline).toBeNull()
+    await stop()
+  })
+
+  it('a machine-placed daemon holds no duties and still fires its own deadlines', async () => {
+    const root = scaffold(['main', 'wA', 'wB'])
+    const { daemon, calls } = await boot(root)
+    ;(daemon as any).cpClient = { organizationScope: () => 'connection', stop: async () => {} }
+    const res = await (daemon as any).startOrchestration(startReq({ deadlineMs: 30_000 }))
+    calls.length = 0
+    ;(daemon as any).fireOrchestrationDeadline(res.orchestrationId)
+    expect(calls.map((c) => c.agentId)).toEqual(['main'])
+    await daemon.stop()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1036. On a daemon pool the orchestration table lives in the shared store, so every member armed every active deadline in the install, and the deadline wake dispatched with no duty gate. This scopes both ends to the member that holds the main agent's duty and makes the fire idempotent across members through the store.

## Failure scenario

N pool members each re-armed the same deadline at startup. At the deadline all N read `status === 'active'`, all N flipped the subtasks to `timed_out`, and all N dispatched a "summarize what you have" wake into the main's session — N duplicate turns in one conversation. N−1 of those ran on a member that does not hold the agent, and a dispatch is what binds the agent's sandbox, so a non-holder claimed a fresh shim generation and took the channel away from the member legitimately serving it. Steady state for any pool with more than one member and one active orchestration, not a rollout window.

## Design

- `servesAgent(agentId)` = `!dutyEnforced() || duties.holdsAgent(agentId)` — the same predicate that already gates cron arming; `syncAgentSchedules` now uses it too.
- `syncOrchestrationDeadlines()` replaces the startup-only re-arm: arm the held agents' active deadlines that are not armed here, disarm what this member no longer holds. Runs at startup and from `onDutyChanged`, so a grant, revoke, fence, or drain re-derives the timer set; the new holder arms from the durable `deadline` epoch, the old holder disarms.
- `fireOrchestrationDeadline` re-checks the duty at fire time (a duty can move between arming and firing, and a stale timer is then harmless) and then claims the fire with `LocalStore.claimOrchestrationDeadline` — a CAS `UPDATE … SET deadline = NULL WHERE status = 'active' AND deadline = <armed>` that exactly one member wins, so even two members that both hold the duty during a handoff wake the main once. The store also runs on the shared Postgres data plane, so the CAS holds across processes.
- `runCronNow` (`cron/run`) refuses on a member that does not hold the agent — the smaller rider from the issue.
- Local and machine-placed daemons hold no duties: `servesAgent` is always true there, so behavior is unchanged apart from the harmless CAS.

Out of scope, tracked separately: shim generation (#1017) and per-member `launches` (#1030).

## Test plan

- [x] `test/orchestration.test.ts` — new `pool duty gate on deadlines` block with two daemons over one shared store: only the holder arms and fires and a stale non-holder timer is refused; a deadline armed by member A fires on member B after the duty moves; a fire while both members hold the duty wakes the main once (CAS); a machine-placed daemon still fires. Existing deadline / startup re-arm tests unchanged.
- [x] `pnpm --filter @agentconnect.md/daemon typecheck`
- [x] daemon duty install / fence / drain / replacement, lifecycle, local-store suites
- [x] `pnpm lint`, `pnpm format:check`
