### PR TITLE
fix(daemon): own the hook-completion outbox per member

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -811,6 +811,18 @@ const MAX_TOTAL_TURNS_PER_WINDOW = 60
 // would turn a long outage into a memory/socket fan-out spike.
 const MAX_HOOK_REPORT_INFLIGHT = 100
 
+/** The daemon whose dispatch the CP accepts this report from — the outbox row's owner.
+ *  On a pool's shared store that is the only member allowed to release its body. */
+function hookReportOwner(report: HookReport, daemonId?: string): string | undefined {
+  return report.dispatchDaemonId ?? daemonId
+}
+
+/** True when the CP can only be answering about a peer's dispatch. Unproven ownership
+ *  counts as foreign: keeping a report body is always recoverable, nulling it is not. */
+function foreignHookDispatch(report: HookReport, daemonId?: string): boolean {
+  return report.dispatchDaemonId !== undefined && report.dispatchDaemonId !== daemonId
+}
+
 /** Backoff after a session-metadata persistence failure while the socket remains READY. */
 const SESSION_METADATA_RETRY_MS = 5_000
 const SESSION_METADATA_FAILURES_BEFORE_DEFER = 5
@@ -2457,6 +2469,9 @@ export class Daemon {
   private hookReportRetryTimer?: TimerHandle
   private transcriptActivityTimers = new Map<string, { timer: TimerHandle; activity: SessionActivity }>()
   private readonly hookReportInflight = new Set<string>()
+  // Outbox rows this member proved it may not report — a peer owns the dispatch,
+  // or the receipt is unreleasable here. Kept out of the drain for this process.
+  private readonly hookReportForeign = new Set<string>()
   // A timer callback may already be inside conn.start() when an agent detaches.
   // Track those runs so detach can await them and prevent a stale socket from
   // appearing after its strict close pass has ACKed.
@@ -12098,6 +12113,7 @@ export class Daemon {
         leaderHookContext: JSON.stringify(nextHook),
         followerId: follower.inboxId,
         followerTerminalReport: JSON.stringify(report),
+        followerOwnerId: hookReportOwner(report, this.cfg.daemonId),
         completedAt: this.clock.now()
       })
       if (!committed) return false
@@ -13562,7 +13578,12 @@ export class Daemon {
     let reportInboxId: string | undefined
     if (owner?.inboxId) {
       try {
-        const completed = this.store.completeHookInbox(owner.inboxId, JSON.stringify(report), this.clock.now())
+        const completed = this.store.completeHookInbox(
+          owner.inboxId,
+          JSON.stringify(report),
+          this.clock.now(),
+          hookReportOwner(report, this.cfg.daemonId)
+        )
         if (completed === 'already-terminal') {
           owner.hookTerminalReceipt = true
           this.liveInboxIds.delete(owner.inboxId)
@@ -13600,6 +13621,9 @@ export class Daemon {
       this.scheduleHookReportRetry()
       return
     }
+    // On a pool's shared store the outbox is one table for every member. Emit only
+    // under a live claim, so a peer's unacknowledged row stays with its owner.
+    if (inboxId && !this.claimHookReport(inboxId)) return
     if (inboxId) this.hookReportInflight.add(inboxId)
     let refillDrainSlot = false
     void Promise.resolve(this.cpClient.emitHookReport(report))
@@ -13607,7 +13631,7 @@ export class Daemon {
         if (!inboxId) return
         refillDrainSlot = true
         try {
-          this.store.acknowledgeHookInbox(inboxId)
+          this.store.acknowledgeHookInbox(inboxId, { ownerId: this.cfg.daemonId })
         } catch (err) {
           // An ACKed report may be re-sent if the local GC write fails. CP
           // persistence is idempotent, so retaining it is the safe direction.
@@ -13618,11 +13642,25 @@ export class Daemon {
         const permanentlyRejected =
           typeof err === 'object' && err !== null && 'retryable' in err && err.retryable === false
         if (permanentlyRejected && inboxId) {
-          // A dispatch-fence CONFLICT can never become valid. Keep the bounded
+          // A CONFLICT raised against a PEER's dispatch says nothing about this row:
+          // the CP is refusing us as the reporter, not the completion. Hand the claim
+          // back to its owner with the body intact instead of dead-lettering it.
+          if (foreignHookDispatch(report, this.cfg.daemonId)) {
+            this.hookReportForeign.add(inboxId)
+            const owner = report.dispatchDaemonId
+            try {
+              if (owner) this.store.releaseHookTerminalReport(inboxId, owner, this.clock.now())
+            } catch (releaseError) {
+              this.log.warn(`durable inbox: hook report release failed for ${inboxId}: ${formatErr(releaseError)}`)
+            }
+            this.log.warn(`hook report left for its dispatching daemon: ${inboxId}`)
+            return
+          }
+          // Our own dispatch-fence CONFLICT can never become valid. Keep the bounded
           // stable-id receipt for relay dedup, but dead-letter its report body.
           refillDrainSlot = true
           try {
-            this.store.acknowledgeHookInbox(inboxId)
+            this.store.acknowledgeHookInbox(inboxId, { ownerId: this.cfg.daemonId })
           } catch (cleanupError) {
             this.log.warn(`durable inbox: hook report dead-letter failed for ${inboxId}: ${formatErr(cleanupError)}`)
           }
@@ -13638,6 +13676,16 @@ export class Daemon {
         // Transient failures use the 5s backoff instead.
         if (refillDrainSlot) this.scheduleHookReportRetry(250)
       })
+  }
+
+  /** Renew (or take over) this member's claim on one durable report row. */
+  private claimHookReport(inboxId: string): boolean {
+    try {
+      return this.store.claimHookTerminalReport(inboxId, this.cfg.daemonId, this.clock.now())
+    } catch (err) {
+      this.log.warn(`durable inbox: hook report claim failed for ${inboxId}: ${formatErr(err)}`)
+      return false
+    }
   }
 
   private scheduleHookReportRetry(delayMs = 5_000): void {
@@ -20705,13 +20753,15 @@ export class Daemon {
   private replayHookTerminalReports(): void {
     let rows: InboxRow[]
     try {
-      rows = this.store.listInboxBySessionKeyFifo()
+      rows = this.store.listHookTerminalReports(this.clock.now(), this.cfg.daemonId, [...this.agents.keys()])
     } catch (err) {
       this.log.warn(`durable inbox: terminal report read failed: ${formatErr(err)}`)
       this.scheduleHookReportRetry()
       return
     }
-    const pending = rows.filter((row) => row.terminalReport && !this.hookReportInflight.has(row.id))
+    const pending = rows.filter(
+      (row) => row.terminalReport && !this.hookReportInflight.has(row.id) && !this.hookReportForeign.has(row.id)
+    )
     const available = Math.max(0, MAX_HOOK_REPORT_INFLIGHT - this.hookReportInflight.size)
     const batch = pending.slice(0, available)
     let emitted = 0
@@ -20723,7 +20773,10 @@ export class Daemon {
       } catch (err) {
         this.log.warn(`durable inbox: corrupt terminal hook receipt ${row.id}: ${formatErr(err)}`)
         try {
-          this.store.acknowledgeHookInbox(row.id)
+          // Undecodable, so ownership cannot be proven from the body — claim first
+          // and leave a peer's row alone rather than destroying it on their behalf.
+          if (this.claimHookReport(row.id)) this.store.acknowledgeHookInbox(row.id, { ownerId: this.cfg.daemonId })
+          else this.hookReportForeign.add(row.id)
         } catch (cleanupError) {
           this.log.warn(`durable inbox: corrupt receipt cleanup failed for ${row.id}: ${formatErr(cleanupError)}`)
         }

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -37,7 +37,10 @@ export interface StoreDatabase {
 
 export type LocalStoreSource = string | { database: StoreDatabase; shared?: boolean; ownerId?: string }
 
-const SHARED_MEMORY_CAPTURE_LEASE_MS = 2 * 60 * 1_000
+/** How long a shared-store claim survives without renewal. A pool member renews on
+ *  every drain attempt, so a lapsed claim means its owner is gone and a peer may take
+ *  the row over. Local (single-owner) stores never lease. */
+const SHARED_OUTBOX_LEASE_MS = 2 * 60 * 1_000
 
 /** Every column dreamToRow produces must appear here: node:sqlite rejects a bound parameter the
  *  statement never references. triggerKind/createdAt are immutable in practice but are still
@@ -368,6 +371,11 @@ export interface InboxRow {
   /** A redacted, metadata-only HookReport retained as the durable dedup receipt
    * after the model turn finishes. Completed hook rows are never replayed. */
   terminalReport?: string | null
+  /** Daemon entitled to emit the retained report — the dispatch the CP will accept
+   *  it from. NULL on a local store and on rows written before pool ownership. */
+  reportOwnerId?: string | null
+  /** Epoch (ms) the owner last renewed its claim; a lapsed claim is takeable. */
+  reportClaimedAt?: number | null
   completedAt?: number | null
   isQueueCmd?: number | null
   /** 1 once this delivery no longer needs replay accounting (charged when applicable).
@@ -613,7 +621,7 @@ function restrictPath(path: string, mode: number): void {
  * change that edits a `CREATE TABLE` below, and append the matching step to
  * {@link SCHEMA_MIGRATIONS}.
  */
-const SCHEMA_VERSION = 4
+const SCHEMA_VERSION = 5
 
 /**
  * Ordered in-place upgrades for a store created by an EARLIER daemon.
@@ -647,6 +655,11 @@ const SCHEMA_MIGRATIONS: ((db: StoreDatabase) => void)[] = [
     db.exec(`
       ALTER TABLE dreams ADD COLUMN ownerId TEXT;
       ALTER TABLE webchat_mcp_grant_ledger ADD COLUMN ownerId TEXT;
+    `),
+  (db) =>
+    db.exec(`
+      ALTER TABLE inbox ADD COLUMN reportOwnerId TEXT;
+      ALTER TABLE inbox ADD COLUMN reportClaimedAt INTEGER;
     `)
 ]
 
@@ -872,6 +885,8 @@ export class LocalStore {
         hookContext TEXT,
         posterPublishState TEXT,
         terminalReport TEXT,
+        reportOwnerId TEXT,
+        reportClaimedAt INTEGER,
         completedAt INTEGER,
         isQueueCmd INTEGER,
         loopGuardCounted INTEGER NOT NULL DEFAULT 0,
@@ -3300,6 +3315,7 @@ export class LocalStore {
     leaderHookContext: string
     followerId: string
     followerTerminalReport: string
+    followerOwnerId?: string
     completedAt: number
   }): boolean {
     if (input.leaderId === input.followerId) return false
@@ -3321,12 +3337,14 @@ export class LocalStore {
           `UPDATE inbox
            SET msg = '{}', integrationId = NULL, callMeta = NULL, hookContext = NULL,
                posterPublishState = 'settled', terminalReport = @followerTerminalReport,
+               reportOwnerId = @followerOwnerId, reportClaimedAt = @completedAt,
                completedAt = @completedAt, isQueueCmd = NULL
            WHERE id = @followerId AND hookContext IS NOT NULL AND completedAt IS NULL`
         )
         .run({
           followerId: input.followerId,
           followerTerminalReport: input.followerTerminalReport,
+          followerOwnerId: input.followerOwnerId ?? null,
           completedAt: input.completedAt
         })
       if (leader.changes !== 1 || follower.changes !== 1) {
@@ -3349,17 +3367,19 @@ export class LocalStore {
   completeHookInbox(
     id: string,
     terminalReport: string,
-    completedAt: number
+    completedAt: number,
+    ownerId?: string
   ): 'completed' | 'already-terminal' | 'missing' {
     const result = this.db
       .prepare(
         `UPDATE inbox
          SET msg = '{}', integrationId = NULL, callMeta = NULL, hookContext = NULL,
              posterPublishState = 'settled', terminalReport = @terminalReport,
+             reportOwnerId = @ownerId, reportClaimedAt = @completedAt,
              completedAt = @completedAt, isQueueCmd = NULL
          WHERE id = @id AND hookContext IS NOT NULL AND completedAt IS NULL`
       )
-      .run({ id, terminalReport, completedAt })
+      .run({ id, terminalReport, completedAt, ownerId: ownerId ?? null })
     if (result.changes === 1) return 'completed'
 
     const row = this.db.prepare('SELECT completedAt FROM inbox WHERE id = ?').get(id) as
@@ -3369,15 +3389,19 @@ export class LocalStore {
 
   /** A CP-correlated ACK releases only the report payload. Keep a bounded
    * metadata-only stable-id receipt so relay redelivery still cannot rerun the
-   * model; unacknowledged reports are never capacity-evicted. */
-  acknowledgeHookInbox(id: string, maxAcknowledgedReceipts = 10_000): boolean {
+   * model; unacknowledged reports are never capacity-evicted. On a shared pool
+   * store only the claim holder may release a body — a peer's verdict about its
+   * own dispatch says nothing about this row. */
+  acknowledgeHookInbox(id: string, options: { ownerId?: string; maxAcknowledgedReceipts?: number } = {}): boolean {
+    const maxAcknowledgedReceipts = options.maxAcknowledgedReceipts ?? 10_000
+    const fence = this.shared ? ' AND (reportOwnerId IS NULL OR reportOwnerId = @ownerId)' : ''
     const result = this.db
       .prepare(
         `UPDATE inbox
-         SET terminalReport = NULL
-         WHERE id = @id AND completedAt IS NOT NULL AND terminalReport IS NOT NULL`
+         SET terminalReport = NULL, reportOwnerId = NULL, reportClaimedAt = NULL
+         WHERE id = @id AND completedAt IS NOT NULL AND terminalReport IS NOT NULL${fence}`
       )
-      .run({ id })
+      .run({ id, ...(fence ? { ownerId: options.ownerId ?? null } : {}) })
     if (result.changes === 1) {
       this.db
         .prepare(
@@ -3392,6 +3416,68 @@ export class LocalStore {
         .run({ maxAcknowledgedReceipts })
     }
     return result.changes === 1
+  }
+
+  /** Unacknowledged hook terminal reports this member may emit right now.
+   *
+   * A local store owns every row outright, so it drains the whole outbox as
+   * before. On a shared pool store the outbox is one table for every member, so
+   * a row is offered only when this member owns it, when it is unowned (legacy
+   * or pre-pool), or when its owner's claim lapsed AND this member currently
+   * serves the agent — draining a live peer's row would only earn a CONFLICT
+   * for a dispatch that is not ours. */
+  listHookTerminalReports(now: number, ownerId?: string, agentIds?: readonly string[]): InboxRow[] {
+    const order = ' ORDER BY sessionKey ASC, enqueuedAt ASC'
+    if (!this.shared) {
+      return this.db
+        .prepare(`SELECT * FROM inbox WHERE terminalReport IS NOT NULL${order}`)
+        .all() as unknown as InboxRow[]
+    }
+    const scope = idScope('agentId', agentIds)
+    return this.db
+      .prepare(
+        `SELECT * FROM inbox
+         WHERE terminalReport IS NOT NULL
+           AND (reportOwnerId IS NULL OR reportOwnerId = @ownerId
+                OR (COALESCE(reportClaimedAt, 0) <= @staleBefore${scope.sql}))${order}`
+      )
+      .all({
+        ownerId: ownerId ?? null,
+        staleBefore: now - SHARED_OUTBOX_LEASE_MS,
+        ...scope.params
+      }) as unknown as InboxRow[]
+  }
+
+  /** Take or renew this member's claim on one report before emitting it. */
+  claimHookTerminalReport(id: string, ownerId: string | undefined, now: number): boolean {
+    if (!this.shared) return true
+    return (
+      this.db
+        .prepare(
+          `UPDATE inbox
+           SET reportOwnerId = @ownerId, reportClaimedAt = @now
+           WHERE id = @id AND terminalReport IS NOT NULL
+             AND (reportOwnerId IS NULL OR reportOwnerId = @ownerId
+                  OR COALESCE(reportClaimedAt, 0) <= @staleBefore)`
+        )
+        .run({ id, ownerId: ownerId ?? null, now, staleBefore: now - SHARED_OUTBOX_LEASE_MS }).changes === 1
+    )
+  }
+
+  /** Hand a claimed report back to the daemon whose dispatch the CP accepts it
+   * from. The body is never released here: a CONFLICT raised against a peer's
+   * dispatch means "not mine to report", not "this can never be valid". */
+  releaseHookTerminalReport(id: string, ownerId: string, now: number): boolean {
+    if (!this.shared) return false
+    return (
+      this.db
+        .prepare(
+          `UPDATE inbox
+           SET reportOwnerId = @ownerId, reportClaimedAt = @now
+           WHERE id = @id AND terminalReport IS NOT NULL`
+        )
+        .run({ id, ownerId, now }).changes === 1
+    )
   }
 
   /** Remove an ordinary inbox row once its turn reaches a terminal state. Hook
@@ -3540,7 +3626,7 @@ export class LocalStore {
       .get({
         activeAgeMs,
         terminalRetentionMs,
-        recoveryLeaseMs: this.shared ? SHARED_MEMORY_CAPTURE_LEASE_MS : 0,
+        recoveryLeaseMs: this.shared ? SHARED_OUTBOX_LEASE_MS : 0,
         ...scope.params
       }) as { activeAt: number | null; terminalAt: number | null; recoveryAt: number | null } | undefined
     const deadlines = [row?.activeAt, row?.terminalAt, row?.recoveryAt].filter(
@@ -3641,7 +3727,7 @@ export class LocalStore {
     const scope = idScope('connectionId', !this.shared && !staleOnly ? undefined : connectionIds)
     const staleClause = this.shared ? ' AND updatedAt <= @staleBefore' : ''
     const params = this.shared
-      ? { now, staleBefore: now - SHARED_MEMORY_CAPTURE_LEASE_MS, ...scope.params }
+      ? { now, staleBefore: now - SHARED_OUTBOX_LEASE_MS, ...scope.params }
       : { now, ...scope.params }
     const retried = this.db
       .prepare(

--- a/packages/daemon/src/store/postgres-sync-database.ts
+++ b/packages/daemon/src/store/postgres-sync-database.ts
@@ -103,6 +103,8 @@ const canonicalColumns = [
   'quoteJson',
   'reasonCode',
   'replyTarget',
+  'reportClaimedAt',
+  'reportOwnerId',
   'requesterId',
   'requesterName',
   'recoveryAt',

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -2181,7 +2181,7 @@ describe('Daemon rd/msg hook fires', () => {
         status: 'success'
       })
     }))
-    vi.spyOn((daemon as any).store, 'listInboxBySessionKeyFifo').mockReturnValue(rows)
+    vi.spyOn((daemon as any).store, 'listHookTerminalReports').mockReturnValue(rows)
 
     ;(daemon as any).replayHookTerminalReports()
     expect(emitHookReport).toHaveBeenCalledTimes(100)
@@ -2197,7 +2197,7 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.start()
     ;(daemon as never as { cpClient: unknown }).cpClient = fakeCpClient()
     const retry = vi.spyOn(daemon as any, 'scheduleHookReportRetry').mockImplementation(() => {})
-    const list = vi.spyOn((daemon as any).store, 'listInboxBySessionKeyFifo').mockImplementation(() => {
+    const list = vi.spyOn((daemon as any).store, 'listHookTerminalReports').mockImplementation(() => {
       throw new Error('sqlite busy')
     })
 
@@ -2258,6 +2258,66 @@ describe('Daemon rd/msg hook fires', () => {
     expect(cp.hookReports[0]).toMatchObject({ deliveryKey: 'double-terminal', status: 'success' })
     const receipt = (daemon as any).store.listInboxBySessionKeyFifo().find((row: { id: string }) => row.id === id)
     expect(JSON.parse(receipt.terminalReport)).toMatchObject({ status: 'success' })
+    await daemon.stop()
+  }, 15_000)
+
+  it("keeps a peer dispatch's report body when the CP answers a permanent CONFLICT", async () => {
+    // #1035: on a pool the outbox is one shared table. A member that emitted a peer's
+    // row is told CONFLICT because it is the wrong reporter — not because the
+    // completion is invalid — so nulling the body would lose a finished turn forever.
+    const { factory } = streamingHost()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    const rejection = Object.assign(new Error('hook completion does not match the accepted dispatch'), {
+      retryable: false
+    })
+    ;(daemon as never as { cpClient: unknown }).cpClient = {
+      stop: vi.fn(async () => {}),
+      organizationScope: () => 'connection' as const,
+      emitHookReport: vi.fn(async () => {
+        throw rejection
+      })
+    }
+    const store = (daemon as any).store
+    const mine = `${HOOK_ID}:own-dispatch`
+    const peers = `${HOOK_ID}:peer-dispatch`
+    for (const deliveryKey of ['own-dispatch', 'peer-dispatch']) {
+      const id = `${HOOK_ID}:${deliveryKey}`
+      const message = buildHookMessage(fire({ msgId: id, deliveryKey }), `trace-${deliveryKey}`)
+      expect(
+        store.appendInbox({
+          id,
+          sessionKey: `${message.platform}:${message.channel}:${message.thread}:${AGENT_ID}`,
+          agentId: AGENT_ID,
+          msg: JSON.stringify(message),
+          hookContext: '{}',
+          enqueuedAt: '1'
+        })
+      ).toBe(true)
+      expect(store.completeHookInbox(id, JSON.stringify({ deliveryKey }), 1)).toBe('completed')
+    }
+    const report = (dispatchDaemonId?: string): HookReport => ({
+      hookId: HOOK_ID,
+      agentId: AGENT_ID,
+      deliveryKey: 'd-1',
+      status: 'success',
+      ...(dispatchDaemonId ? { dispatchDaemonId } : {})
+    })
+
+    ;(daemon as any).sendHookReport(report((daemon as any).cfg.daemonId), mine)
+    ;(daemon as any).sendHookReport(report('cccccccc-cccc-4ccc-8ccc-cccccccccccc'), peers)
+
+    const rowById = (id: string) =>
+      store.listInboxBySessionKeyFifo().find((row: { id: string }) => row.id === id) as {
+        terminalReport: string | null
+      }
+    // Our own dispatch fence can never become valid: dead-letter it as before.
+    await vi.waitFor(() => expect(rowById(mine).terminalReport).toBeNull(), WAIT)
+    expect(rowById(peers).terminalReport).not.toBeNull()
+    expect((daemon as any).hookReportForeign.has(peers)).toBe(true)
+    // And the drain leaves it alone on the next CP ready.
+    ;(daemon as any).replayHookTerminalReports()
+    expect(rowById(peers).terminalReport).not.toBeNull()
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { DatabaseSync } from 'node:sqlite'
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -167,11 +168,93 @@ describe('LocalStore inbox', () => {
       expect(s.completeHookInbox(id, JSON.stringify({ hookId: 'hook-1', deliveryKey: String(i) }), i)).toBe('completed')
     }
 
-    expect(s.acknowledgeHookInbox('hook-1:delivery-1', 1)).toBe(true)
-    expect(s.acknowledgeHookInbox('hook-1:delivery-2', 1)).toBe(true)
+    expect(s.acknowledgeHookInbox('hook-1:delivery-1', { maxAcknowledgedReceipts: 1 })).toBe(true)
+    expect(s.acknowledgeHookInbox('hook-1:delivery-2', { maxAcknowledgedReceipts: 1 })).toBe(true)
     const remaining = s.listInboxBySessionKeyFifo()
     expect(remaining.map((receipt) => receipt.id).sort()).toEqual(['hook-1:delivery-2', 'hook-1:delivery-3'])
     expect(remaining.find((receipt) => receipt.id.endsWith('-3'))?.terminalReport).not.toBeNull()
+    s.close()
+  })
+
+  // ── shared pool outbox (#1035) ────────────────────────────────────────────
+  // Every member of a daemon pool reads and writes ONE data-plane store, so the
+  // hook terminal-report outbox is install-wide. Ownership, not presence, decides
+  // who may emit a row: the CP accepts a completion only from the daemon its
+  // dispatch named, and answers every other member a permanent CONFLICT.
+  const LEASE_MS = 2 * 60 * 1_000
+
+  function poolMember(database: DatabaseSync, ownerId: string): LocalStore {
+    return new LocalStore({ database: database as never, shared: true, ownerId })
+  }
+
+  function pooledReport(s: LocalStore, id: string, agentId: string, ownerDaemonId: string, at: number): void {
+    const key = sessionKey('hook', 'hook-1', id, agentId)
+    expect(s.appendInbox({ ...row(id, key, String(at), agentId), hookContext: '{}' })).toBe(true)
+    expect(s.completeHookInbox(id, JSON.stringify({ id }), at, ownerDaemonId)).toBe('completed')
+  }
+
+  it("offers a pool member only the reports it owns, never a live peer's", () => {
+    const database = new DatabaseSync(':memory:')
+    const a = poolMember(database, 'store-a')
+    const b = poolMember(database, 'store-b')
+    pooledReport(a, 'from-a', 'agent-a', 'daemon-a', 1_000)
+    pooledReport(b, 'from-b', 'agent-b', 'daemon-b', 1_000)
+
+    const ids = (s: LocalStore, ownerId: string, agentIds: string[]) =>
+      s.listHookTerminalReports(1_500, ownerId, agentIds).map((entry) => entry.id)
+    expect(ids(a, 'daemon-a', ['agent-a'])).toEqual(['from-a'])
+    // B serves both agents and still may not touch A's row: A's claim is live.
+    expect(ids(b, 'daemon-b', ['agent-a', 'agent-b'])).toEqual(['from-b'])
+    expect(b.claimHookTerminalReport('from-a', 'daemon-b', 1_500)).toBe(false)
+    // An owner drains its own row wherever the agent is placed now.
+    expect(ids(a, 'daemon-a', [])).toEqual(['from-a'])
+    a.close()
+  })
+
+  it('lets the member that serves the agent take over after the owner claim lapses', () => {
+    const database = new DatabaseSync(':memory:')
+    const a = poolMember(database, 'store-a')
+    const b = poolMember(database, 'store-b')
+    pooledReport(a, 'from-a', 'agent-a', 'daemon-a', 1_000)
+    const lapsed = 1_000 + LEASE_MS + 1
+
+    // Still not B's to take while B does not serve the agent.
+    expect(b.listHookTerminalReports(lapsed, 'daemon-b', ['agent-b'])).toEqual([])
+    expect(b.listHookTerminalReports(lapsed, 'daemon-b', ['agent-a']).map((entry) => entry.id)).toEqual(['from-a'])
+    expect(b.claimHookTerminalReport('from-a', 'daemon-b', lapsed)).toBe(true)
+    // The takeover is exclusive: the dead owner's id no longer holds the row.
+    expect(a.listHookTerminalReports(lapsed, 'daemon-a', [])).toEqual([])
+    expect(a.claimHookTerminalReport('from-a', 'daemon-a', lapsed)).toBe(false)
+    a.close()
+  })
+
+  it('keeps a peer report body out of reach of every member but its owner', () => {
+    const database = new DatabaseSync(':memory:')
+    const a = poolMember(database, 'store-a')
+    const b = poolMember(database, 'store-b')
+    pooledReport(a, 'from-a', 'agent-a', 'daemon-a', 1_000)
+    const lapsed = 1_000 + LEASE_MS + 1
+    expect(b.claimHookTerminalReport('from-a', 'daemon-b', lapsed)).toBe(true)
+
+    // The CP rejects B as the reporter — B returns the row instead of dead-lettering it.
+    expect(b.releaseHookTerminalReport('from-a', 'daemon-a', lapsed)).toBe(true)
+    expect(b.acknowledgeHookInbox('from-a', { ownerId: 'daemon-b' })).toBe(false)
+    const retained = a.listHookTerminalReports(lapsed, 'daemon-a', [])
+    expect(retained.map((entry) => entry.id)).toEqual(['from-a'])
+    expect(retained[0]!.terminalReport).toBe('{"id":"from-a"}')
+    // Its owner still releases it on a real ACK.
+    expect(a.acknowledgeHookInbox('from-a', { ownerId: 'daemon-a' })).toBe(true)
+    a.close()
+  })
+
+  it('leaves a local store single-owner: every report drains and ACKs unfenced', () => {
+    const s = store()
+    pooledReport(s, 'local-1', 'bot-a', 'daemon-a', 1)
+    pooledReport(s, 'local-2', 'bot-b', 'daemon-b', 2)
+    expect(s.listHookTerminalReports(Number.MAX_SAFE_INTEGER).map((entry) => entry.id)).toEqual(['local-1', 'local-2'])
+    expect(s.claimHookTerminalReport('local-2', undefined, 3)).toBe(true)
+    expect(s.releaseHookTerminalReport('local-2', 'daemon-b', 3)).toBe(false)
+    expect(s.acknowledgeHookInbox('local-2')).toBe(true)
     s.close()
   })
 

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -48,6 +48,8 @@ describe('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN nextAttemptAt')
     old.exec('ALTER TABLE dreams DROP COLUMN ownerId')
     old.exec('ALTER TABLE webchat_mcp_grant_ledger DROP COLUMN ownerId')
+    old.exec('ALTER TABLE inbox DROP COLUMN reportOwnerId')
+    old.exec('ALTER TABLE inbox DROP COLUMN reportClaimedAt')
     old.exec('PRAGMA user_version = 1')
     old.close()
 
@@ -60,13 +62,15 @@ describe('LocalStore schema versioning', () => {
     const outboxColumns = columnsOf('session_metadata_outbox')
     const dreamColumns = columnsOf('dreams')
     const grantColumns = columnsOf('webchat_mcp_grant_ledger')
+    const inboxColumns = columnsOf('inbox')
     upgraded.close()
     expect(columns).toContain('ownerId')
     expect(outboxColumns).toEqual(expect.arrayContaining(['failedAttempts', 'nextAttemptAt']))
     // Recovery ownership: a pool member must be able to tell its own rows from a peer's.
     expect(dreamColumns).toContain('ownerId')
     expect(grantColumns).toContain('ownerId')
-    expect(userVersion(path)).toBe(4)
+    expect(inboxColumns).toEqual(expect.arrayContaining(['reportOwnerId', 'reportClaimedAt']))
+    expect(userVersion(path)).toBe(5)
   })
 
   it('refuses a store written by a newer daemon WITHOUT touching it first', () => {

--- a/packages/daemon/test/postgres-pool-store.int.test.ts
+++ b/packages/daemon/test/postgres-pool-store.int.test.ts
@@ -187,6 +187,37 @@ describe.skipIf(!databaseUrl)('PostgreSQL pool member store', () => {
       expect(second.store.recoverPermissionRequests([agentId], 201)).toBe(1)
       expect(second.store.listPermissionRequests(agentId)[0]).toMatchObject({ status: 'expired', resolvedAt: 201 })
       expect(second.store.recoverMemoryCaptures(101)).toEqual({ retried: 0, ambiguous: 0 })
+      // #1035: the hook terminal-report outbox is install-wide here, so a member
+      // may drain only its own rows and may never release a peer's body.
+      const hookId = `hook-${suffix}`
+      expect(
+        first.store.appendInbox({
+          id: hookId,
+          sessionKey: `hook:${suffix}:d-1:${agentId}`,
+          agentId,
+          msg: '{}',
+          hookContext: '{}',
+          enqueuedAt: '00000000000000000002'
+        })
+      ).toBe(true)
+      expect(first.store.completeHookInbox(hookId, '{"status":"success"}', 1_000, `daemon-a-${suffix}`)).toBe(
+        'completed'
+      )
+      const drained = (ownerId: string, now: number) =>
+        second.store
+          .listHookTerminalReports(now, ownerId, [agentId])
+          .filter((row) => row.id === hookId)
+          .map((row) => row.terminalReport)
+      expect(drained(`daemon-b-${suffix}`, 1_500)).toEqual([])
+      expect(second.store.claimHookTerminalReport(hookId, `daemon-b-${suffix}`, 1_500)).toBe(false)
+      expect(second.store.acknowledgeHookInbox(hookId, { ownerId: `daemon-b-${suffix}` })).toBe(false)
+      const lapsed = 1_000 + 2 * 60 * 1_000 + 1
+      expect(drained(`daemon-b-${suffix}`, lapsed)).toEqual(['{"status":"success"}'])
+      expect(second.store.claimHookTerminalReport(hookId, `daemon-b-${suffix}`, lapsed)).toBe(true)
+      expect(second.store.releaseHookTerminalReport(hookId, `daemon-a-${suffix}`, lapsed)).toBe(true)
+      expect(drained(`daemon-a-${suffix}`, lapsed)).toEqual(['{"status":"success"}'])
+      expect(first.store.acknowledgeHookInbox(hookId, { ownerId: `daemon-a-${suffix}` })).toBe(true)
+      second.store.removeInbox(hookId)
       expect(first.store.attachActivationEnvelope(`activation-${suffix}`, '{}', 10_000).dispatch).toBe(true)
       expect(second.store.attachActivationEnvelope(`activation-${suffix}`, '{}', 10_000).dispatch).toBe(false)
       expect(second.store.recoverMemoryCaptures(120_101, true, [`other-connection-${suffix}`])).toEqual({


### PR DESCRIPTION
## Summary

Fixes #1035. The hook terminal-report outbox lives in the `inbox` table, which on a
daemon pool is one shared data-plane schema rather than a member-private SQLite file.
The drain had no owner filter, so a member happily emitted a peer's row — and the
rejection handler treated the CP's answer as proof that the completion itself was
invalid.

This gives the hook outbox the ownership model `memory_capture_outbox` already uses
(CAS claim + shared-aware lease recovery + scoped reads), so a member drains only what
it owns or may legitimately claim, and a foreign rejection can never destroy a payload.
The same three primitives are the ones the session-metadata outbox (#1023) will need.

## Failure scenario

1. Member A finishes a GitHub hook turn and writes the terminal report into the shared
   inbox. A is SIGTERM'd during a rollout before the CP acknowledges it.
2. Member B starts. `onReady` fires `replayHookTerminalReports`, which read
   `listInboxBySessionKeyFifo()` — install-wide, no owner and no agent filter — and
   emitted A's row. `hookReportInflight` is per-process, so it excluded nothing.
3. The CP compares B's daemon id with the run's recorded `dispatchDaemonId` (A's),
   `hook.repo.recordReport` returns false, and the handler answers `CONFLICT` with
   `retryable: false`.
4. `sendHookReport`'s rejection path read that as a permanent dispatch-fence failure and
   called `acknowledgeHookInbox`, which is `UPDATE inbox SET terminalReport = NULL`.

The true completion is now unrecoverable: the `HookRun` stays open and the check-run is
later reaped as orphaned, for a turn that actually succeeded.

## Fix

**Ownership in the store** (`packages/daemon/src/store/local-store.ts`)

- `inbox` gains `reportOwnerId` and `reportClaimedAt` (schema v4 plus its
  `SCHEMA_MIGRATIONS` step, so an existing store upgrades in place).
  `completeHookInbox` / `coalesceHookInbox` stamp the daemon whose dispatch the CP
  accepts the report from.
- `listHookTerminalReports` offers a member its own rows, unowned rows (legacy /
  pre-pool), and rows whose owner's claim lapsed **while this member currently serves
  the agent**. An owner keeps draining its own rows wherever the agent is placed now,
  because only that daemon can satisfy the CP's fence.
- `claimHookTerminalReport` is the CAS taken before every emit; the lease is renewed on
  each attempt, so a live retrying owner is never displaced.
- `releaseHookTerminalReport` hands a claim back to the rightful owner with the body
  intact, and `acknowledgeHookInbox` releases a body only for the claim holder.

**Never dead-letter a peer's completion** (`packages/daemon/src/daemon.ts`)

- A permanent rejection whose report names a different `dispatchDaemonId` means "not
  mine to report", not "this can never be valid": the claim is returned to its owner and
  the row is kept out of this process's drain instead of being nulled. Unproven
  ownership counts as foreign — retaining a body is recoverable, nulling it is not.
- Our own dispatch-fence CONFLICT still dead-letters exactly as before.
- The corrupt-receipt cleanup claims first, so an undecodable row belonging to a peer is
  left for its owner.

A local SQLite store stays single-owner: it drains and ACKs unfenced and the claim is a
no-op, so a self-hosted daemon behaves exactly as it did.

## Test plan

- `packages/daemon/test/durable-inbox.test.ts` — two pool members over one shared store:
  each is offered only its own rows (B serving both agents still cannot touch A's live
  row), the serving member takes over exclusively after the lease lapses, a released
  peer row stays readable with its body for its owner and refuses a peer's ACK, and a
  local store drains and ACKs everything unfenced.
- `packages/daemon/test/daemon-hook.test.ts` — a permanent CONFLICT for a peer's
  `dispatchDaemonId` leaves `terminalReport` intact and keeps the row out of the next
  drain, while our own dispatch's CONFLICT is still dead-lettered.
- `packages/daemon/test/local-store.test.ts` — the v1 upgrade path now lands on schema
  v4 with both columns present.
- `packages/daemon/test/postgres-pool-store.int.test.ts` — the same ownership, lease
  takeover, release and ACK fence across two replicas on the real shared driver.
- Ran locally: `pnpm --filter @agentconnect.md/daemon typecheck`, the daemon store and
  hook suites, the pool-store integration suite against a throwaway PostgreSQL
  (including a downgrade-to-v3-then-reopen check of the in-place migration), `pnpm lint`,
  `pnpm format:check`. The remaining full-suite failures (shim, git-runner-contract,
  acp-matrix) reproduce unchanged on the base commit — they need a built shim binary and
  installed runtimes.
