### PR TITLE
fix(daemon): scope sandbox launches to the duty holder and re-derive them on takeover

### DIFF
--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -161,6 +161,17 @@ cluster. Anything that would "recreate" a sandbox must go through
 suspend/resume, never delete-and-claim-again, or it silently deletes the
 agent's work.
 
+**Sleep is the holder's decision, and the holder is the only member that
+knows the launch.** A member's launch record (`K8sDriver.launches`) is scoped
+to the duties it holds: gaining an agent re-derives the launch from the cluster
+(claim → bound Sandbox → mode, recording only a Running pod), losing it — a
+revoke, a self-fence, a drain release — forgets the launch, its shim channel,
+its tunnel proxy and any loss watch without touching the claim. The idle sweep
+suspends only agents this member holds, and floors idleness at the time it
+took the launch when the shared store records no activity. So a Running pod
+has exactly one member that owns its idleness, an ex-holder can never suspend
+a successor's pod, and a rollout leaves no pod without a candidate to suspend it.
+
 A sleeping agent still belongs to a duty group (§6), and if that group
 contains a daemon-held bot the group stays claimed while the agent sleeps —
 that held duty is precisely what lets the wake message arrive. A singleton

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12903,6 +12903,7 @@ export class Daemon {
    *  ingress is never re-checked per message. */
   private settleDutyChange(result: DutyApplyResult): void {
     for (const agentId of result.agentsLost) this.stopServingAgent(agentId)
+    for (const agentId of result.agentsGained) this.adoptClusterSandbox(agentId)
     const changed = result.added.length + result.updated.length + result.agentsGained.length + result.agentsLost.length
     if (changed === 0) return
     // Report the new digest immediately. The CP publishes the projections that address this member
@@ -13263,11 +13264,13 @@ export class Daemon {
     // Behind a FAILED earlier stop the host is still stopped (a later host must not leak), but the
     // failure keeps propagating: that agent stays unconfirmed for the rest of this process.
     const stop: Promise<void> = prior.then(
-      () => this.stopHost(agentId),
+      () => this.stopHost(agentId).finally(() => this.releaseClusterSandbox(agentId)),
       (err: unknown) =>
-        this.stopHost(agentId).then(() => {
-          throw err
-        })
+        this.stopHost(agentId)
+          .finally(() => this.releaseClusterSandbox(agentId))
+          .then(() => {
+            throw err
+          })
     )
     this.dutyHostStops.set(agentId, stop)
     void stop.then(
@@ -19731,15 +19734,16 @@ export class Daemon {
   private sweepIdleSandboxes(now: number, ttl: number): void {
     const plane = this.k8sPlane
     if (!plane) return
-    for (const agentId of plane.launchedAgents()) {
+    for (const { agentId, since } of plane.launchedAgents()) {
+      // Suspend is the holder's decision (k8s-daemon-pool §4); an ex-holder must not touch its successor's pod.
+      if (this.dutyEnforced() && !this.duties.holdsAgent(agentId)) continue
       // A live host owns the decision above; suspending under it would pull the pod out from
       // beneath a runtime that is merely between turns.
       if (this.hosts.has(agentId)) continue
       if ((this.activeDispatchesByAgent.get(agentId)?.size ?? 0) > 0) continue
       if ([...this.pending.values()].some((p) => p.agentId === agentId)) continue
-      // No host means no `hostStartedAt` floor to fall back on, so an agent that has never served
-      // a turn reads as idle-since-epoch — which is correct here: nothing is running in its pod.
-      const last = this.store.agentLastActivityTs(agentId) ?? 0
+      // Shared-store activity, floored at when this member took the launch: a full window, not epoch-idle.
+      const last = Math.max(this.store.agentLastActivityTs(agentId) ?? 0, since)
       if (now - last <= ttl) continue
       void plane
         .suspendIdle(agentId)
@@ -19752,6 +19756,29 @@ export class Daemon {
         })
         .catch((err) => this.log.warn(`idle: suspending the sandbox for agent "${agentId}" failed: ${formatErr(err)}`))
     }
+  }
+
+  /** Cluster only: take over the sandbox of an agent this member just started serving, from the cluster. */
+  // So a Running pod nobody here launched (a rollout, a moved duty) has a holder that can suspend it.
+  // Behind any teardown still settling for the agent, so a lose-then-regain cannot forget the adoption.
+  private adoptClusterSandbox(agentId: string): void {
+    const plane = this.k8sPlane
+    if (!plane) return
+    const prior = this.dutyHostStops.get(agentId) ?? Promise.resolve()
+    void prior
+      .catch(() => undefined)
+      .then(async () => {
+        if (this.dutyEnforced() && !this.duties.holdsAgent(agentId)) return
+        await plane.adoptAgent(agentId)
+      })
+      .catch((err) =>
+        this.log.warn(`cluster: taking over the sandbox for agent "${agentId}" failed: ${formatErr(err)}`)
+      )
+  }
+
+  /** Cluster only: the sandbox half of "no longer served here"; the claim and volume stay. */
+  private releaseClusterSandbox(agentId: string): void {
+    this.k8sPlane?.releaseAgent(agentId)
   }
 
   /**

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -116,11 +116,13 @@ const MAX_MODE_ATTEMPTS = 5
 export type SandboxReadiness = 'ready' | 'starting' | 'absent'
 
 /** Per-agent launch state the driver keeps: the Sandbox it bound and which launch it is. */
-interface Launch {
+export interface Launch {
   agentId: string
   sandboxName: string
   sandboxUid: string
   generation: number
+  /** When this member started holding the launch; the idle floor when no activity is recorded. */
+  since: number
 }
 
 /**
@@ -146,6 +148,10 @@ export class K8sDriver implements SpawnDriver {
   private readonly suspending = new Map<string, Promise<void>>()
   /** Logical channels per agent, which survive the shim's credential renewals. */
   private readonly sessions = new Map<string, ShimSession>()
+  /** Takeover re-derivations in flight, per agent; a concurrent acquisition waits for the answer. */
+  private readonly adopting = new Map<string, Promise<Launch | undefined>>()
+  /** Bumped by `releaseAgent`; an acquisition in flight across a bump records nothing. */
+  private readonly releases = new Map<string, number>()
   /** Workspace mount per agent, as the bound pod's shim reported it. */
   private readonly workspaceRoots = new Map<string, string>()
   private readonly clock: Clock
@@ -173,8 +179,12 @@ export class K8sDriver implements SpawnDriver {
     // a new one — the same resume this call would have done a moment later anyway.
     const suspending = this.suspending.get(agentId)
     if (suspending) await suspending
+    // A takeover re-derivation is the same answer from the cluster; wait for it rather than race it.
+    const adopting = this.adopting.get(agentId)
+    if (adopting) await adopting
     const existing = this.launches.get(agentId)
     if (existing) return existing
+    const releasedAt = this.releases.get(agentId) ?? 0
     const name = this.claimName(agentId)
     const orgId = this.deps.orgForAgent(agentId)
     if (!orgId) throw new Error(`cannot resolve sandbox organization for agent ${agentId}`)
@@ -206,12 +216,59 @@ export class K8sDriver implements SpawnDriver {
     )
     const sandboxUid = sandbox.metadata?.uid
     if (!sandboxUid) throw new Error(`sandbox ${sandboxName} has no metadata.uid to bind against`)
+    this.assertStillServed(agentId, releasedAt)
+    return this.recordLaunch(agentId, sandboxName, sandboxUid)
+  }
+
+  // Allocation and record with no await between them: the last recorder holds the highest generation.
+  private recordLaunch(agentId: string, sandboxName: string, sandboxUid: string): Launch {
     // Allocated from durable install-wide state, not from this process: the pod this launch is
     // about to dial may have been bound by a member that has since been rolled away.
     const generation = this.deps.generations.nextSandboxGeneration(agentId)
-    const launch: Launch = { agentId, sandboxName, sandboxUid, generation }
+    const launch: Launch = { agentId, sandboxName, sandboxUid, generation, since: this.clock.now() }
     this.launches.set(agentId, launch)
     return launch
+  }
+
+  private assertStillServed(agentId: string, releasedAt: number): void {
+    if ((this.releases.get(agentId) ?? 0) !== releasedAt) {
+      throw new Error(`agent ${agentId} left this member while its sandbox was being acquired`)
+    }
+  }
+
+  /** Takeover: re-derive the launch from the cluster (claim → bound Sandbox → mode), creating nothing. */
+  // Only a Running pod is recorded — its idleness is now this member's to own; a suspended or unclaimed
+  // agent needs no launch until its next turn claims one.
+  adoptAgent(agentId: string): Promise<Launch | undefined> {
+    const inFlight = this.adopting.get(agentId)
+    if (inFlight) return inFlight
+    const run = (async (): Promise<Launch | undefined> => {
+      const existing = this.launches.get(agentId)
+      if (existing) return existing
+      const releasedAt = this.releases.get(agentId) ?? 0
+      const claim = await this.deps.api.getClaim(this.claimName(agentId)).catch((err: unknown) => {
+        if (err instanceof K8sApiError && err.isNotFound) return undefined
+        throw err
+      })
+      const sandboxName = claim?.status?.sandbox?.name
+      if (!sandboxName) return undefined
+      const sandbox = await this.deps.api.getSandbox(sandboxName).catch((err: unknown) => {
+        if (err instanceof K8sApiError && err.isNotFound) return undefined
+        throw err
+      })
+      const sandboxUid = sandbox?.metadata?.uid
+      if (!sandbox || !sandboxUid || (sandbox.spec?.operatingMode ?? 'Running') !== 'Running') return undefined
+      // A turn that did not wait acquired it meanwhile, or the agent already left again.
+      const current = this.launches.get(agentId)
+      if (current) return current
+      if ((this.releases.get(agentId) ?? 0) !== releasedAt) return undefined
+      this.deps.log.info(`cluster: agent ${agentId} taken over with sandbox ${sandboxName} running`)
+      return this.recordLaunch(agentId, sandboxName, sandboxUid)
+    })().finally(() => {
+      if (this.adopting.get(agentId) === run) this.adopting.delete(agentId)
+    })
+    this.adopting.set(agentId, run)
+    return run
   }
 
   /** How long a pod may take to come up, as this driver itself waits for it. One definition, so
@@ -323,9 +380,9 @@ export class K8sDriver implements SpawnDriver {
     }
   }
 
-  /** Agents this daemon currently holds a Sandbox for — the candidates an idle sweep considers. */
-  launchedAgents(): string[] {
-    return [...this.launches.keys()]
+  /** Agents this daemon holds a Sandbox for, and since when — the idle sweep's candidates. */
+  launchedAgents(): Array<{ agentId: string; since: number }> {
+    return [...this.launches.values()].map(({ agentId, since }) => ({ agentId, since }))
   }
 
   /**
@@ -469,15 +526,20 @@ export class K8sDriver implements SpawnDriver {
 
   /** Forget an agent and delete its claim; the volume goes with it, which is the intent. */
   async removeAgent(agentId: string): Promise<void> {
+    this.releaseAgent(agentId)
+    await this.deps.api.deleteClaim(this.claimName(agentId))
+  }
+
+  /** "No longer served here", not removal: launch, session, root and holds go; claim and volume stay. */
+  releaseAgent(agentId: string): void {
+    this.releases.set(agentId, (this.releases.get(agentId) ?? 0) + 1)
     const launch = this.launches.get(agentId)
     this.launches.delete(agentId)
     if (launch) this.forgetSandbox(launch.sandboxName)
     this.workspaceRoots.delete(agentId)
-    // The session outlives the claim otherwise, and `runsInSandbox` would keep answering true for
-    // an agent whose pod is being deleted — sending the workspace seam into a sandbox that is gone.
+    // Otherwise `runsInSandbox` keeps answering true for a pod that is not this member's to use.
     this.sessions.delete(agentId)
     this.deps.revokeChannel?.(agentId)
-    await this.deps.api.deleteClaim(this.claimName(agentId))
   }
 
   /**
@@ -547,6 +609,7 @@ export class K8sDriver implements SpawnDriver {
     timer: LaunchTimer | undefined,
     grants: ShimCapability[]
   ): Promise<ShimConnection> {
+    const releasedAt = this.releases.get(agentId) ?? 0
     // Resume before waiting because suspension deleted the pod and readiness cannot arrive first.
     const modeBeforeWake = await this.setMode(agentId, 'Running')
     // A launch this daemon already has cached returns from ensureSandbox before any sandbox
@@ -580,6 +643,11 @@ export class K8sDriver implements SpawnDriver {
         throw err
       })
     timer?.mark('shim_handshake')
+    // Released mid-bind: the pod is another member's to serve now, so the channel is dropped.
+    if ((this.releases.get(agentId) ?? 0) !== releasedAt) {
+      this.deps.revokeChannel?.(agentId)
+      throw new Error(`agent ${agentId} left this member while its sandbox channel was being bound`)
+    }
     this.recordWorkspaceRoot(agentId, connection)
     // The session is created HERE rather than in `launch`, because a channel bound for workspace
     // preparation needs one too — and a second session per agent would mean the runtime and the

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -191,9 +191,13 @@ export interface K8sRuntimePlane {
   /** Where the agent's bound pod mounts its workspace, as its shim reported; undefined before a
    *  bind or from a legacy shim (callers fall back to DEFAULT_SHIM_WORKSPACE_ROOT). */
   workspaceRootFor: (agentId: string) => string | undefined
-  /** Agents this daemon holds a Sandbox for — the candidate set for an idle sweep. Read from the
-   *  driver rather than inferred from live hosts: a launch outlives the host it was made for. */
-  launchedAgents: () => string[]
+  /** Agents this daemon holds a Sandbox for, and since when — the idle sweep's candidates. Read from
+   *  the driver, not inferred from live hosts: a launch outlives the host it was made for. */
+  launchedAgents: () => Array<{ agentId: string; since: number }>
+  /** Take over an agent's sandbox from the cluster (claim → Sandbox → mode) so this member can suspend it. */
+  adoptAgent: (agentId: string) => Promise<void>
+  /** No longer served here: launch, channel, tunnel and loss watch go; claim and volume stay. */
+  releaseAgent: (agentId: string) => void
   /** Suspend a quiet agent's pod, keeping its Sandbox and workspace volume. `busy` means work
    *  still holds it and the caller should try again later; `absent` means there is nothing to
    *  suspend. Waking is not a separate call — the next launch's bind does it. */
@@ -426,6 +430,16 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     return probeInFlight
   }
 
+  function releaseAgent(agentId: string, reason = 'agent no longer served here'): void {
+    // Close the pod's channel first: it may otherwise keep using a binding this member no longer honours.
+    dialer.revokeAgent(agentId)
+    // After the revoke, whose close schedules one: nobody here waits on a loss for an agent not served here.
+    cancelLossCheck(agentId)
+    proxies.get(agentId)?.proxy.stop(reason)
+    proxies.delete(agentId)
+    driver.releaseAgent(agentId)
+  }
+
   return {
     driver,
     dialer,
@@ -454,15 +468,12 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     workspaceRootFor: (agentId) => driver.workspaceRootFor(agentId),
     launchedAgents: () => driver.launchedAgents(),
     suspendIdle: (agentId) => driver.suspendIfIdle(agentId),
+    adoptAgent: async (agentId) => {
+      await driver.adoptAgent(agentId)
+    },
+    releaseAgent,
     discardAgent: async (agentId) => {
-      // Close and forget the pod's channel before the claim goes: the pod has its whole
-      // termination grace to keep using a binding this daemon no longer means to honour.
-      dialer.revokeAgent(agentId)
-      // Ordered after the revoke, whose close schedules one: a loss check for an agent that no
-      // longer exists would report a lost launch nobody is waiting for.
-      cancelLossCheck(agentId)
-      proxies.get(agentId)?.proxy.stop('agent removed')
-      proxies.delete(agentId)
+      releaseAgent(agentId, 'agent removed')
       await driver.removeAgent(agentId)
     },
     stop: async () => {

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -292,7 +292,10 @@ describe('daemon --k8s mode', () => {
       root: root({ declared: { runtimes: [{ id: 'claude' }] } }),
       k8s: true,
       plane: {
-        launchedAgents: () => ['quiet', 'serving'],
+        launchedAgents: () => [
+          { agentId: 'quiet', since: 0 },
+          { agentId: 'serving', since: 0 }
+        ],
         suspendIdle: async (agentId: string) => {
           suspended.push(agentId)
           return 'suspended'
@@ -308,6 +311,125 @@ describe('daemon --k8s mode', () => {
       ;(k8sDaemon as any).sweepIdle()
       await vi.waitFor(() => expect(suspended).toEqual(['quiet']))
     } finally {
+      await k8sDaemon.stop()
+    }
+  })
+
+  it('counts idleness from when the launch was taken over when no activity is recorded', async () => {
+    const suspended: string[] = []
+    const k8sDaemon = daemon({
+      root: root({ declared: { runtimes: [{ id: 'claude' }] } }),
+      k8s: true,
+      plane: {
+        // No session row exists for either agent, so activity alone would read as idle since epoch.
+        launchedAgents: () => [
+          { agentId: 'fresh', since: Date.now() },
+          { agentId: 'stale', since: Date.now() - 24 * 3_600_000 }
+        ],
+        suspendIdle: async (agentId: string) => {
+          suspended.push(agentId)
+          return 'suspended'
+        }
+      }
+    })
+    try {
+      await k8sDaemon.start()
+      ;(k8sDaemon as any).sweepIdle()
+      await vi.waitFor(() => expect(suspended).toEqual(['stale']))
+    } finally {
+      await k8sDaemon.stop()
+    }
+  })
+
+  it('never suspends the sandbox of an agent whose duty is held elsewhere', async () => {
+    const suspended: string[] = []
+    const k8sDaemon = daemon({
+      root: root({ declared: { runtimes: [{ id: 'claude' }] } }),
+      k8s: true,
+      plane: {
+        launchedAgents: () => [
+          { agentId: 'held', since: 0 },
+          { agentId: 'moved', since: 0 }
+        ],
+        suspendIdle: async (agentId: string) => {
+          suspended.push(agentId)
+          return 'suspended'
+        }
+      }
+    })
+    try {
+      await k8sDaemon.start()
+      // An install-wide member: the duty ledger decides which agents it serves.
+      ;(k8sDaemon as any).cpClient = { organizationScope: () => 'frame', stop: async () => {} }
+      ;(k8sDaemon as any).duties.applyGrant([
+        {
+          groupId: '11111111-1111-4111-8111-111111111111',
+          orgId: 'org-1',
+          term: '1',
+          members: [{ kind: 'agent', refId: 'held' }]
+        }
+      ])
+      ;(k8sDaemon as any).sweepIdle()
+      await vi.waitFor(() => expect(suspended).toEqual(['held']))
+      ;(k8sDaemon as any).sweepIdle()
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      expect(suspended).toEqual(['held', 'held'])
+    } finally {
+      ;(k8sDaemon as any).cpClient = undefined
+      await k8sDaemon.stop()
+    }
+  })
+
+  it('takes over the sandbox when a duty arrives and releases it — after the host stop — when the duty leaves', async () => {
+    const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+    const GROUP = '11111111-1111-4111-8111-111111111111'
+    const events: string[] = []
+    const k8sDaemon = daemon({
+      root: root({ declared: { runtimes: [{ id: 'claude' }] } }),
+      k8s: true,
+      plane: {
+        adoptAgent: async (agentId: string) => void events.push(`adopt:${agentId}`),
+        releaseAgent: (agentId: string) => void events.push(`release:${agentId}`)
+      }
+    })
+    try {
+      await k8sDaemon.start()
+      ;(k8sDaemon as any).cpClient = {
+        organizationScope: () => 'frame',
+        stop: async () => {},
+        releaseDuties: vi.fn(async () => {}),
+        reportDutiesNow: vi.fn(() => {}),
+        fetchDutyAgent: vi.fn(async () => ({
+          bundle: {
+            agentId: AGENT,
+            spec: {
+              orgId: 'org-1',
+              name: 'scout',
+              runtime: 'claude',
+              workspace: { mode: 'scratch', isolation: 'shared' }
+            },
+            integrations: [],
+            crons: []
+          }
+        }))
+      }
+      const grant = { groupId: GROUP, orgId: 'org-1', term: '1', members: [{ kind: 'agent', refId: AGENT }] }
+      await (k8sDaemon as any).admitDutyGrants([grant])
+      await vi.waitFor(() => expect(events).toEqual([`adopt:${AGENT}`]))
+      // A stopped host stands in for the ex-holder's runtime; the release must wait for it to be down.
+      let hostDown = false
+      ;(k8sDaemon as any).hosts.set(AGENT, {
+        stop: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 20))
+          hostDown = true
+        }
+      })
+      ;(k8sDaemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
+      expect(events).toEqual([`adopt:${AGENT}`])
+      await vi.waitFor(() => expect(events).toEqual([`adopt:${AGENT}`, `release:${AGENT}`]))
+      expect(hostDown).toBe(true)
+    } finally {
+      ;(k8sDaemon as any).cpClient = undefined
       await k8sDaemon.stop()
     }
   })

--- a/packages/daemon/test/k8s-driver-takeover.test.ts
+++ b/packages/daemon/test/k8s-driver-takeover.test.ts
@@ -1,0 +1,230 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { FakeClock } from '@agentconnect.md/connection'
+import { K8sHttp } from '@agentconnect.md/k8s-client'
+import { closeFakeApiServers, fakeApiServer } from '@agentconnect.md/k8s-client/testing'
+import { K8sDriver } from '../src/k8s/driver.js'
+import { SandboxApi } from '../src/k8s/sandbox-api.js'
+import { LocalStore } from '../src/store/local-store.js'
+import type { SpawnRecord } from '../src/shim/binding.js'
+import type { ShimConnection } from '../src/shim/listener.js'
+
+/**
+ * Two pool members, one shared store, one cluster: what a member may do to an agent's sandbox is
+ * scoped to WHILE it serves that agent. An ex-holder forgets the launch when the duty leaves and
+ * never suspends the pod its successor is using; the successor re-derives the launch from the
+ * cluster on takeover, so a Running pod always has exactly one member that owns its idleness.
+ */
+
+const AGENT = 'agent-a'
+const CLAIM = `agent-${AGENT}`
+
+afterEach(async () => {
+  await closeFakeApiServers()
+})
+
+/** An in-process API server holding one claim and one Sandbox whose mode a JSON Patch moves. */
+async function cluster() {
+  const state = {
+    claim: undefined as Record<string, unknown> | undefined,
+    mode: 'Running' as 'Running' | 'Suspended',
+    modeWrites: [] as string[]
+  }
+  const sandbox = () => ({
+    metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
+    spec: {
+      operatingMode: state.mode,
+      podTemplate: { spec: { containers: [{ name: 'runtime', image: 'runtime:1' }] } }
+    },
+    status: { conditions: [{ type: 'Ready', status: 'True' }], podIPs: ['10.0.0.8'] }
+  })
+  const { config } = await fakeApiServer(({ method, url, body }) => {
+    const path = url.pathname
+    if (path.endsWith('/sandboxclaims') && method === 'POST') {
+      if (state.claim) return { status: 409, json: { kind: 'Status', reason: 'AlreadyExists' } }
+      state.claim = { metadata: { name: CLAIM, uid: 'claim-uid-1' }, status: { sandbox: { name: 'sb-1' } } }
+      return { json: state.claim }
+    }
+    if (path.endsWith(`/sandboxclaims/${CLAIM}`)) {
+      if (method === 'DELETE') {
+        state.claim = undefined
+        return { json: {} }
+      }
+      if (!state.claim) return { status: 404, json: { kind: 'Status', reason: 'NotFound' } }
+      return { json: state.claim }
+    }
+    if (path.endsWith('/sandboxwarmpools/pool')) return { json: { spec: { sandboxTemplateRef: { name: 'tpl' } } } }
+    if (path.endsWith('/sandboxtemplates/tpl')) {
+      return { json: { spec: { podTemplate: { spec: { containers: [{ name: 'runtime', image: 'runtime:1' }] } } } } }
+    }
+    if (path.endsWith('/sandboxes/sb-1')) {
+      if (method === 'PATCH') {
+        // Both the mode write and the guarded resume test the mode first, then replace it.
+        const ops = JSON.parse(body) as Array<{ op: string; path: string; value: unknown }>
+        const test = ops.find((op) => op.op === 'test' && op.path === '/spec/operatingMode')
+        if (test && test.value !== state.mode) return { status: 422, json: { kind: 'Status', reason: 'Invalid' } }
+        const replace = ops.find((op) => op.op === 'replace' && op.path === '/spec/operatingMode')
+        if (replace) {
+          state.mode = replace.value as 'Running' | 'Suspended'
+          state.modeWrites.push(state.mode)
+        }
+      }
+      return { json: sandbox() }
+    }
+    return { status: 404, json: { kind: 'Status', reason: 'NotFound' } }
+  })
+  const api = new SandboxApi(new K8sHttp(config), 'agent-sandboxes')
+  return { api, state }
+}
+
+function stubConnection(record: SpawnRecord): ShimConnection {
+  return {
+    binding: {
+      agentId: record.agentId,
+      generation: record.generation,
+      grants: record.grants,
+      podName: 'p',
+      podUid: 'u'
+    },
+    issuedCredential: 'cred',
+    send: () => {},
+    onFrame: () => {},
+    close: () => {}
+  } as unknown as ShimConnection
+}
+
+function member(api: SandboxApi, store: LocalStore, clock: FakeClock) {
+  const dialed: SpawnRecord[] = []
+  const revoked: string[] = []
+  const driver = new K8sDriver({
+    api,
+    orgForAgent: () => 'org-1',
+    warmPoolName: 'pool',
+    generations: store,
+    clock,
+    connectChannel: async (record) => {
+      dialed.push(record)
+      return stubConnection(record)
+    },
+    revokeChannel: (agentId) => revoked.push(agentId),
+    log: { info: () => {}, warn: () => {}, debug: () => {} }
+  })
+  return { driver, dialed, revoked }
+}
+
+function sharedStore(): LocalStore {
+  return new LocalStore(join(mkdtempSync(join(tmpdir(), 'ac-takeover-')), 'state.db'))
+}
+
+describe('sandbox launches follow the duty', () => {
+  it('an ex-holder forgets its launch and cannot suspend the pod its successor serves', async () => {
+    const { api, state } = await cluster()
+    const store = sharedStore()
+    const clock = new FakeClock()
+    const a = member(api, store, clock)
+    const b = member(api, store, clock)
+    await a.driver.ensureBoundChannel(AGENT)
+    expect(a.driver.launchedAgents().map((l) => l.agentId)).toEqual([AGENT])
+    expect(a.driver.sessionFor(AGENT)?.isAttached()).toBe(true)
+
+    // The duty moves: A stops serving the agent, B takes it over from the cluster.
+    a.driver.releaseAgent(AGENT)
+    expect(a.driver.launchedAgents()).toEqual([])
+    expect(a.driver.sessionFor(AGENT)).toBeUndefined()
+    expect(a.revoked).toEqual([AGENT])
+    expect(await b.driver.adoptAgent(AGENT)).toMatchObject({ sandboxName: 'sb-1', sandboxUid: 'sandbox-uid-1' })
+
+    // A's idle sweep now has nothing to act on, however idle the agent looks from A.
+    expect(await a.driver.suspendIfIdle(AGENT)).toBe('absent')
+    expect(state.mode).toBe('Running')
+    expect(state.modeWrites).toEqual([])
+    store.close()
+  })
+
+  it('the new holder re-derives the launch from the cluster and can suspend it when idle', async () => {
+    const { api, state } = await cluster()
+    const store = sharedStore()
+    const clock = new FakeClock()
+    const a = member(api, store, clock)
+    const b = member(api, store, clock)
+    const bound = await a.driver.ensureSandbox(AGENT)
+    a.driver.releaseAgent(AGENT)
+
+    clock.advance(5_000)
+    const adopted = await b.driver.adoptAgent(AGENT)
+    // Nothing was created: the claim and its Sandbox are the ones A left behind.
+    expect(adopted).toMatchObject({ sandboxName: bound.sandboxName, sandboxUid: bound.sandboxUid })
+    // Idleness is anchored at the takeover, so the pod gets a full window from B's clock.
+    expect(adopted?.since).toBe(clock.now())
+    // The generation continues from the shared store, so B's later dial fences A's out.
+    expect(adopted!.generation).toBeGreaterThan(bound.generation)
+    expect(b.driver.launchedAgents()).toEqual([{ agentId: AGENT, since: clock.now() }])
+
+    expect(await b.driver.suspendIfIdle(AGENT)).toBe('suspended')
+    expect(state.mode).toBe('Suspended')
+    expect(b.driver.launchedAgents()).toEqual([])
+    store.close()
+  })
+
+  it('takes over nothing for a suspended or unclaimed agent — the next turn claims as before', async () => {
+    const { api, state } = await cluster()
+    const store = sharedStore()
+    const clock = new FakeClock()
+    const b = member(api, store, clock)
+    expect(await b.driver.adoptAgent(AGENT)).toBeUndefined()
+    expect(b.driver.launchedAgents()).toEqual([])
+
+    const a = member(api, store, clock)
+    await a.driver.ensureSandbox(AGENT)
+    expect(await a.driver.suspendIfIdle(AGENT)).toBe('suspended')
+    a.driver.releaseAgent(AGENT)
+    expect(state.mode).toBe('Suspended')
+    expect(await b.driver.adoptAgent(AGENT)).toBeUndefined()
+    // The ordinary launch path still resumes it.
+    await b.driver.ensureBoundChannel(AGENT)
+    expect(state.mode).toBe('Running')
+    expect(b.dialed).toHaveLength(1)
+    store.close()
+  })
+
+  it('an acquisition in flight when the agent leaves records nothing', async () => {
+    const { api } = await cluster()
+    const store = sharedStore()
+    const clock = new FakeClock()
+    const a = member(api, store, clock)
+    const acquiring = a.driver.ensureSandbox(AGENT)
+    a.driver.releaseAgent(AGENT)
+    await expect(acquiring).rejects.toThrow(/left this member/)
+    expect(a.driver.launchedAgents()).toEqual([])
+    store.close()
+  })
+
+  it('a concurrent turn waits for the takeover rather than racing it', async () => {
+    const { api } = await cluster()
+    const store = sharedStore()
+    const clock = new FakeClock()
+    const a = member(api, store, clock)
+    await a.driver.ensureSandbox(AGENT)
+    a.driver.releaseAgent(AGENT)
+    const b = member(api, store, clock)
+    const [adopted, acquired] = await Promise.all([b.driver.adoptAgent(AGENT), b.driver.ensureSandbox(AGENT)])
+    expect(acquired).toBe(adopted)
+    expect(b.driver.launchedAgents()).toHaveLength(1)
+    store.close()
+  })
+
+  it('a single member keeps its own launch across the same calls', async () => {
+    const { api, state } = await cluster()
+    const store = sharedStore()
+    const clock = new FakeClock()
+    const a = member(api, store, clock)
+    const launch = await a.driver.ensureSandbox(AGENT)
+    expect(await a.driver.adoptAgent(AGENT)).toBe(launch)
+    expect(a.driver.launchedAgents()).toEqual([{ agentId: AGENT, since: launch.since }])
+    expect(await a.driver.suspendIfIdle(AGENT)).toBe('suspended')
+    expect(state.mode).toBe('Suspended')
+    store.close()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #1030.

`K8sDriver.launches` (and the `busy` counter the idle sweep reads) was per-member in-memory state that outlived the duty. This PR scopes a member's sandbox authority to *while it serves the agent*: the sweep is gated on the duty predicate, losing a duty forgets the launch and everything hanging off it, and gaining a duty re-derives the launch from the cluster so the new holder owns the pod's idleness.

## Failure scenario

Member A holds agent X and has bound its sandbox. A rebalance, revoke or self-fence moves X to member B. A tears down the host but keeps `launches[X]`, the shim session, the tunnel proxy and any loss watch. Once `agentLastActivityTs(X)` is older than the idle window, A's sweep sees `busy == 0` (its own counter), patches the `Sandbox` to `Suspended`, and B loses the pod underneath a live or binding turn.

The other half: after a rollout no member has a launch for any agent and nothing lists claims, so a Running pod whose agent receives no traffic is never suspended. The `?? 0` in the same sweep also produced the epoch-sized "idle" numbers and instant suspends for agents with every session TTL-closed.

## Design

- **Sweep gate.** `sweepIdleSandboxes` skips any agent unless `!dutyEnforced() || duties.holdsAgent(agentId)` — the same gate `transportAgents` uses. Idleness is `max(agentLastActivityTs, launch.since)`, where `since` is when this member took the launch, so an agent with no recorded activity gets a full window from takeover instead of an instant epoch-idle suspend.
- **Release on duty loss.** `stopServingAgentSettled` (revoke / fence / refused replacement / drain release) now runs `plane.releaseAgent` once the host stop settles: the launch, shim session, workspace root, hold counts, dialer binding, tunnel proxy and loss watch all go; the claim, Sandbox and volume stay. `discardAgent` reuses the same release before deleting the claim.
- **In-flight fence.** The driver keeps a per-agent release counter; an `ensureSandbox` or `bindChannel` that was in flight across a release throws instead of recording a launch or session for a pod this member no longer serves.
- **Adopt on duty gain.** `settleDutyChange` calls `plane.adoptAgent` for each gained agent, ordered behind any pending host stop for the same agent. `K8sDriver.adoptAgent` reads the claim and the bound Sandbox (two GETs, creates nothing) and records a launch — with a fresh shared-store generation (#1017) — only when the pod is Running; a suspended or unclaimed agent needs no launch until its next turn claims one. A concurrent `ensureSandbox` waits for an in-flight adoption rather than racing it. No per-tick listing of sandboxes.
- `docs/designs/k8s-daemon-pool.md` §4 records the holder-scoped launch rule.

## Test plan

- New `k8s-driver-takeover.test.ts`: two `K8sDriver` members over one shared `LocalStore` and one fake API server (`@agentconnect.md/k8s-client/testing`) — the ex-holder's `suspendIfIdle` is `absent` after the duty moved and writes no mode; the new holder re-derives the launch (same Sandbox, higher generation, `since` = takeover time) and suspends it when idle; nothing is adopted for a suspended or unclaimed agent and the ordinary launch path still resumes it; an acquisition in flight across a release records nothing; a concurrent turn waits for the adoption; single-member behaviour unchanged.
- `daemon-k8s-mode.test.ts`: idle time anchored at takeover when no activity is known; the sweep never suspends an agent whose duty is held elsewhere; a granted duty adopts the sandbox and a revoke releases it only after the host stop completes.
- `pnpm --filter @agentconnect.md/daemon typecheck`, k8s-driver / k8s-runtime-plane / cluster-cold-start / duty (fence, drain, install, replacement) / lifecycle suites, `pnpm lint`, `pnpm format:check` all pass. The remaining failures in a full daemon run (`shim-*`, `acp-matrix`, `workspace-git-runner-seam`) are pre-existing on `main` in this environment (macOS `sandbox-exec` / live runtimes).
