### PR TITLE
fix(daemon): recover only the interrupted work this member owns

### DIFF
--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -102,13 +102,17 @@ export type DreamOperationPolicy = 'blocked' | 'test-only' | 'enabled'
 export interface DreamStorePort {
   insertDream(dream: DreamInfo): void
   updateDream(dream: DreamInfo): void
+  /** Crash-recovery write, CAS'd on the open statuses so a peer's terminal outcome survives. */
+  failOpenDream(dream: DreamInfo): boolean
   getDream(agentId: string, dreamId: string): DreamInfo | undefined
   listDreams(agentId: string, limit: number): DreamInfo[]
   /** Dreams still holding an unreviewed skill candidate, independent of the
    *  bounded history page — a proposal outlives the store lifecycle. */
   pendingSkillDreams(agentId: string, limit: number): DreamInfo[]
-  /** Non-terminal dreams (pending|running) for crash recovery at boot. */
+  /** Non-terminal dreams (pending|running) THIS process left behind — crash recovery at boot. */
   openDreams(): DreamInfo[]
+  /** Non-terminal dreams stranded by a former owner of these agents, once this process owns them. */
+  strandedDreams(agentIds: readonly string[]): DreamInfo[]
   /** Every completed store proposal for one agent, without the public list cap. */
   completedDreams(agentId: string): DreamInfo[]
   /** Proposals reconciled as superseded during a store upgrade. */
@@ -264,19 +268,8 @@ export class DreamRunner {
   }
 
   constructor(private readonly deps: DreamRunnerDeps) {
-    // Crash recovery: a dream that was pending|running when the daemon died can
-    // never complete (its extraction session is gone). Fail it, keep the staging
-    // for inspection.
-    for (const dream of this.deps.store.openDreams()) {
-      const failed: DreamInfo = {
-        ...dream,
-        status: 'failed',
-        error: { type: 'daemon_restart', message: 'the daemon restarted while this dream was in flight' },
-        endedAt: this.nowIso()
-      }
-      this.deps.store.updateDream(failed)
-      this.emitLifecycle({ type: 'memory.dream.failed', dream: failed })
-    }
+    // Crash recovery: fail what THIS process left in flight (staging kept); a peer's dream waits for its duty grant.
+    this.failInterrupted(this.deps.store.openDreams())
     // The LocalStore migration marks proposals stranded by adoptions made on an
     // older daemon. Their metadata is already safe; sweep the corresponding
     // store staging now that the runner can resolve agent directories. Proposed
@@ -290,6 +283,25 @@ export class DreamRunner {
           )
         })
       }
+    }
+  }
+
+  /** Reclaim the dreams of agents this process has just been made responsible for: their
+   *  former owner is no longer running them, so they can only be failed. */
+  reclaimDreams(agentIds: readonly string[]): void {
+    this.failInterrupted(this.deps.store.strandedDreams(agentIds))
+  }
+
+  private failInterrupted(dreams: readonly DreamInfo[]): void {
+    for (const dream of dreams) {
+      const failed: DreamInfo = {
+        ...dream,
+        status: 'failed',
+        error: { type: 'daemon_restart', message: 'the daemon restarted while this dream was in flight' },
+        endedAt: this.nowIso()
+      }
+      // The CAS makes reclaim safe: a row that reached its own terminal state keeps it, and announces nothing.
+      if (this.deps.store.failOpenDream(failed)) this.emitLifecycle({ type: 'memory.dream.failed', dream: failed })
     }
   }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12929,6 +12929,7 @@ export class Daemon {
   private settleDutyChange(result: DutyApplyResult): void {
     for (const agentId of result.agentsLost) this.stopServingAgent(agentId)
     for (const agentId of result.agentsGained) this.adoptClusterSandbox(agentId)
+    this.reclaimInterruptedWork(result.agentsGained)
     const changed = result.added.length + result.updated.length + result.agentsGained.length + result.agentsLost.length
     if (changed === 0) return
     // Report the new digest immediately. The CP publishes the projections that address this member
@@ -20223,6 +20224,19 @@ export class Daemon {
     }
   }
 
+  /** Take over the durable work of agents this member has just been made responsible for. On a
+   *  shared store starting proves nothing — peers keep serving through a rollout — so the duty
+   *  grant, not process start, is what makes a stranded row this member's to recover. */
+  private reclaimInterruptedWork(agentIds: readonly string[]): void {
+    if (agentIds.length === 0) return
+    const grants = this.store.reclaimWebchatMcpGrants(agentIds, 'session_closed', this.clock.now())
+    if (grants) {
+      this.log.info(`remote MCP: reclaimed ${grants} grant(s) from a former owner`)
+      void this.drainWebchatMcpRevocations()
+    }
+    this.dreamRunner().reclaimDreams(agentIds)
+  }
+
   /** Await the single-flight reconcile and any coalesced trailing pass. Registry
    *  callbacks fire a background reconcile before lifecycle handlers explicitly
    *  await it, so one plain `await reconcile()` can otherwise observe only the
@@ -22098,9 +22112,8 @@ export class Daemon {
       },
       (agentId) => this.cpAgents?.orgForAgent(agentId)
     )
-    // Grants recorded by a previous process have no surviving descriptor or
-    // plaintext — queue them for remote revocation before the first connect.
-    const orphaned = this.store.markAllWebchatMcpGrantsRevoking('session_closed', this.clock.now())
+    // Grants this process recorded lose their descriptor and plaintext with it; a peer's are not ours to sweep.
+    const orphaned = this.store.markOwnedWebchatMcpGrantsRevoking('session_closed', this.clock.now())
     if (orphaned) this.log.info(`remote MCP: queued ${orphaned} orphaned grant revocation(s) from previous run`)
     this.cpClient.start()
     this.log.info(`cp: connecting to ${url}…`)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -39,6 +39,15 @@ export type LocalStoreSource = string | { database: StoreDatabase; shared?: bool
 
 const SHARED_MEMORY_CAPTURE_LEASE_MS = 2 * 60 * 1_000
 
+/** Every column dreamToRow produces must appear here: node:sqlite rejects a bound parameter the
+ *  statement never references. triggerKind/createdAt are immutable in practice but are still
+ *  assigned, so the row shape and the SQL can't drift apart. */
+const DREAM_UPDATE_SET = `status = @status, triggerKind = @triggerKind, sessionIds = @sessionIds,
+  snapshotDigest = @snapshotDigest, executionSessionId = @executionSessionId, runtime = @runtime,
+  model = @model, stopReason = @stopReason, snapshotWrites = @snapshotWrites, instructions = @instructions,
+  skills = @skills, organizationSuggestions = @organizationSuggestions, usage = @usage, error = @error,
+  createdAt = @createdAt, endedAt = @endedAt, ownerId = @ownerId`
+
 function idScope(column: string, values: readonly string[] | undefined): { sql: string; params: SqlParams } {
   if (values === undefined) return { sql: '', params: {} }
   if (values.length === 0) return { sql: ' AND 0 = 1', params: {} }
@@ -512,6 +521,8 @@ export interface WebchatMcpGrantLedgerRow {
   attempts: number
   nextAttemptAt: number | null
   updatedAt: number
+  /** The daemon incarnation answerable for this row; NULL on an exclusively owned store. */
+  ownerId: string | null
 }
 
 /** §3.4/§6.8 main-agent orchestration record (daemon-local). `status` is the
@@ -602,7 +613,7 @@ function restrictPath(path: string, mode: number): void {
  * change that edits a `CREATE TABLE` below, and append the matching step to
  * {@link SCHEMA_MIGRATIONS}.
  */
-const SCHEMA_VERSION = 3
+const SCHEMA_VERSION = 4
 
 /**
  * Ordered in-place upgrades for a store created by an EARLIER daemon.
@@ -631,6 +642,11 @@ const SCHEMA_MIGRATIONS: ((db: StoreDatabase) => void)[] = [
     db.exec(`
       ALTER TABLE session_metadata_outbox ADD COLUMN failedAttempts INTEGER NOT NULL DEFAULT 0;
       ALTER TABLE session_metadata_outbox ADD COLUMN nextAttemptAt INTEGER;
+    `),
+  (db) =>
+    db.exec(`
+      ALTER TABLE dreams ADD COLUMN ownerId TEXT;
+      ALTER TABLE webchat_mcp_grant_ledger ADD COLUMN ownerId TEXT;
     `)
 ]
 
@@ -905,7 +921,8 @@ export class LocalStore {
         reason TEXT,
         attempts INTEGER NOT NULL DEFAULT 0,
         nextAttemptAt INTEGER,
-        updatedAt INTEGER NOT NULL
+        updatedAt INTEGER NOT NULL,
+        ownerId TEXT                      -- daemon incarnation holding the grant; NULL on an exclusively owned store
       );
       CREATE INDEX IF NOT EXISTS webchat_mcp_grant_ledger_due
         ON webchat_mcp_grant_ledger (state, nextAttemptAt);
@@ -1046,7 +1063,8 @@ export class LocalStore {
         usage TEXT,                       -- JSON DreamUsage (tokens/cost + bounded byte counts)
         error TEXT,                       -- JSON {type, message}
         createdAt TEXT NOT NULL,
-        endedAt TEXT
+        endedAt TEXT,
+        ownerId TEXT                      -- daemon incarnation running it; NULL on an exclusively owned store
       );
       CREATE INDEX IF NOT EXISTS dreams_agent_created ON dreams (agentId, createdAt DESC);
       -- Monotonic shim-binding generation per agent. Durable and install-shared because a sandbox
@@ -2370,7 +2388,8 @@ export class LocalStore {
       usage: dream.usage ? JSON.stringify(dream.usage) : null,
       error: dream.error ? JSON.stringify(dream.error) : null,
       createdAt: dream.createdAt,
-      endedAt: dream.endedAt ?? null
+      endedAt: dream.endedAt ?? null,
+      ownerId: this.ownerId ?? null
     }
   }
 
@@ -2410,29 +2429,35 @@ export class LocalStore {
       .prepare(
         `INSERT INTO dreams (dreamId, agentId, status, triggerKind, sessionIds, snapshotDigest,
            executionSessionId, runtime, model, stopReason, snapshotWrites, instructions, skills, organizationSuggestions,
-           usage, error, createdAt, endedAt)
+           usage, error, createdAt, endedAt, ownerId)
          VALUES (@dreamId, @agentId, @status, @triggerKind, @sessionIds, @snapshotDigest,
            @executionSessionId, @runtime, @model, @stopReason, @snapshotWrites, @instructions, @skills,
-           @organizationSuggestions, @usage, @error, @createdAt, @endedAt)`
+           @organizationSuggestions, @usage, @error, @createdAt, @endedAt, @ownerId)`
       )
       .run(this.dreamToRow(dream))
   }
 
+  /** Whoever writes a dream row is the process running it, so every write re-stamps
+   *  ownership — a reclaimed dream never reads as its former owner's. */
   updateDream(dream: DreamInfo): void {
     this.db
-      .prepare(
-        // Every column dreamToRow produces must appear here: better-sqlite3
-        // rejects a bound parameter the statement never references ("Unknown
-        // named parameter"). triggerKind/createdAt are immutable in practice but
-        // are still assigned, so the row shape and the SQL can't drift apart.
-        `UPDATE dreams SET status = @status, triggerKind = @triggerKind, sessionIds = @sessionIds,
-           snapshotDigest = @snapshotDigest, executionSessionId = @executionSessionId, runtime = @runtime,
-           model = @model, stopReason = @stopReason, snapshotWrites = @snapshotWrites, instructions = @instructions,
-           skills = @skills, organizationSuggestions = @organizationSuggestions, usage = @usage, error = @error,
-           createdAt = @createdAt, endedAt = @endedAt
-         WHERE dreamId = @dreamId AND agentId = @agentId`
-      )
+      .prepare(`UPDATE dreams SET ${DREAM_UPDATE_SET} WHERE dreamId = @dreamId AND agentId = @agentId`)
       .run(this.dreamToRow(dream))
+  }
+
+  /** Crash-recovery write, CAS'd on the open statuses so a losing race can never overwrite
+   *  the terminal outcome the dream's own runner recorded. */
+  failOpenDream(dream: DreamInfo): boolean {
+    return (
+      Number(
+        this.db
+          .prepare(
+            `UPDATE dreams SET ${DREAM_UPDATE_SET}
+             WHERE dreamId = @dreamId AND agentId = @agentId AND status IN ('pending', 'running')`
+          )
+          .run(this.dreamToRow(dream)).changes
+      ) === 1
+    )
   }
 
   getDream(agentId: string, dreamId: string): DreamInfo | undefined {
@@ -2488,10 +2513,29 @@ export class LocalStore {
     )
   }
 
-  /** Non-terminal dreams — the boot-time crash-recovery sweep. */
+  /** Non-terminal dreams this process is answerable for — the boot-time crash-recovery sweep. On a
+   *  shared store that is only what this incarnation started: a peer's in-flight dream is live work. */
   openDreams(): DreamInfo[] {
+    const owned = this.shared ? ' AND ownerId = @ownerId' : ''
     return (
-      this.db.prepare("SELECT * FROM dreams WHERE status IN ('pending', 'running')").all() as Record<string, unknown>[]
+      this.db
+        .prepare(`SELECT * FROM dreams WHERE status IN ('pending', 'running')${owned}`)
+        .all(...(this.shared ? [{ ownerId: this.ownerId! }] : [])) as Record<string, unknown>[]
+    ).map((row) => this.dreamFromRow(row))
+  }
+
+  /** Non-terminal dreams left behind by a FORMER owner of these agents. Only the CP handing
+   *  this process the duty makes them recoverable — mirrors recoverPermissionRequests. */
+  strandedDreams(agentIds: readonly string[]): DreamInfo[] {
+    if (!this.shared || agentIds.length === 0) return []
+    const scope = idScope('agentId', agentIds)
+    return (
+      this.db
+        .prepare(
+          `SELECT * FROM dreams
+           WHERE status IN ('pending', 'running') AND (ownerId IS NULL OR ownerId != @ownerId)${scope.sql}`
+        )
+        .all({ ownerId: this.ownerId!, ...scope.params }) as Record<string, unknown>[]
     ).map((row) => this.dreamFromRow(row))
   }
 
@@ -3675,16 +3719,17 @@ export class LocalStore {
     this.db
       .prepare(
         `INSERT INTO webchat_mcp_grant_ledger
-           (conversationId, agentId, authorityId, authorityGeneration, state, reason, attempts, nextAttemptAt, updatedAt)
-         VALUES (@conversationId, @agentId, @authorityId, @authorityGeneration, 'active', NULL, 0, NULL, @now)
+           (conversationId, agentId, authorityId, authorityGeneration, state, reason, attempts, nextAttemptAt,
+            updatedAt, ownerId)
+         VALUES (@conversationId, @agentId, @authorityId, @authorityGeneration, 'active', NULL, 0, NULL, @now, @ownerId)
          ON CONFLICT (conversationId) DO UPDATE SET
            agentId = excluded.agentId,
            authorityId = excluded.authorityId,
            authorityGeneration = excluded.authorityGeneration,
            state = 'active', reason = NULL, attempts = 0, nextAttemptAt = NULL,
-           updatedAt = excluded.updatedAt`
+           updatedAt = excluded.updatedAt, ownerId = excluded.ownerId`
       )
-      .run(input)
+      .run({ ...input, ownerId: this.ownerId ?? null })
   }
 
   /** Queue a durable revocation for a grant authority whose remote revoke failed
@@ -3701,15 +3746,17 @@ export class LocalStore {
     this.db
       .prepare(
         `INSERT INTO webchat_mcp_grant_ledger
-           (conversationId, agentId, authorityId, authorityGeneration, state, reason, attempts, nextAttemptAt, updatedAt)
-         VALUES (@conversationId, @agentId, @authorityId, @authorityGeneration, 'revoking', @reason, 0, @now, @now)
+           (conversationId, agentId, authorityId, authorityGeneration, state, reason, attempts, nextAttemptAt,
+            updatedAt, ownerId)
+         VALUES (@conversationId, @agentId, @authorityId, @authorityGeneration, 'revoking', @reason, 0, @now, @now,
+            @ownerId)
          ON CONFLICT (conversationId) DO UPDATE SET
            state = 'revoking', reason = excluded.reason, nextAttemptAt = excluded.nextAttemptAt,
-           updatedAt = excluded.updatedAt
+           updatedAt = excluded.updatedAt, ownerId = excluded.ownerId
          WHERE webchat_mcp_grant_ledger.authorityId = excluded.authorityId
            AND webchat_mcp_grant_ledger.authorityGeneration <= excluded.authorityGeneration`
       )
-      .run(input)
+      .run({ ...input, ownerId: this.ownerId ?? null })
   }
 
   /** Drop the ledger row after the CP confirmed revocation — only for the exact
@@ -3723,29 +3770,51 @@ export class LocalStore {
       .run(conversationId, authorityId, authorityGeneration)
   }
 
-  /** Startup orphan sweep: descriptors from a previous process no longer exist,
-   *  so any still-'active' ledger row must be revoked at the CP. */
-  markAllWebchatMcpGrantsRevoking(reason: string, now: number): number {
+  /** Startup orphan sweep over the grants THIS incarnation recorded: its descriptors and
+   *  plaintext died with it. On a shared store an 'active' row may be a peer's live authority
+   *  for a conversation in progress, so ownership — not process start — decides. */
+  markOwnedWebchatMcpGrantsRevoking(reason: string, now: number): number {
+    const owned = this.shared ? ' AND ownerId = @ownerId' : ''
     return Number(
       this.db
         .prepare(
           `UPDATE webchat_mcp_grant_ledger
-           SET state = 'revoking', reason = ?, nextAttemptAt = ?, updatedAt = ?
-           WHERE state = 'active'`
+           SET state = 'revoking', reason = @reason, nextAttemptAt = @now, updatedAt = @now
+           WHERE state = 'active'${owned}`
         )
-        .run(reason, now, now).changes
+        .run({ reason, now, ...(this.shared ? { ownerId: this.ownerId! } : {}) }).changes
     )
   }
 
+  /** Take over the grant rows of a former owner of these agents once the CP makes this process
+   *  responsible for them: the plaintext went with the owner, so the authority must be revoked. */
+  reclaimWebchatMcpGrants(agentIds: readonly string[], reason: string, now: number): number {
+    if (!this.shared || agentIds.length === 0) return 0
+    const scope = idScope('agentId', agentIds)
+    return Number(
+      this.db
+        .prepare(
+          `UPDATE webchat_mcp_grant_ledger
+           SET state = 'revoking', reason = @reason, attempts = 0, nextAttemptAt = @now,
+               updatedAt = @now, ownerId = @ownerId
+           WHERE (ownerId IS NULL OR ownerId != @ownerId)${scope.sql}`
+        )
+        .run({ reason, now, ownerId: this.ownerId!, ...scope.params }).changes
+    )
+  }
+
+  /** The revocations this process must deliver: its own queue, plus rows written before ownership was
+   *  recorded. A peer's queued revoke is the peer's to land — here it would duplicate the CP call. */
   listDueWebchatMcpRevocations(now: number, limit = 50): WebchatMcpGrantLedgerRow[] {
+    const owned = this.shared ? ' AND (ownerId IS NULL OR ownerId = @ownerId)' : ''
     return this.db
       .prepare(
         `SELECT * FROM webchat_mcp_grant_ledger
-         WHERE state = 'revoking' AND (nextAttemptAt IS NULL OR nextAttemptAt <= ?)
+         WHERE state = 'revoking' AND (nextAttemptAt IS NULL OR nextAttemptAt <= @now)${owned}
          ORDER BY nextAttemptAt ASC, conversationId ASC
-         LIMIT ?`
+         LIMIT @limit`
       )
-      .all(now, limit) as unknown as WebchatMcpGrantLedgerRow[]
+      .all({ now, limit, ...(this.shared ? { ownerId: this.ownerId! } : {}) }) as unknown as WebchatMcpGrantLedgerRow[]
   }
 
   /** Reschedule one failed revocation attempt (exact-tuple fenced). */

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -592,4 +592,26 @@ describe('the rendezvous claim ordering', () => {
     expect(registries(daemon).agents.has(AGENT)).toBe(false)
     await daemon.stop()
   })
+
+  it("reclaims a former owner's interrupted work for the agents the grant GAINED (#1033)", async () => {
+    // Boot cannot be the trigger on a pool: peers keep serving through a rollout. The duty
+    // grant is what makes a stranded grant ledger row or dream this member's to recover.
+    const daemon = await boot({ fetchDutyAgent: vi.fn(async () => ({ bundle: bundle() })) })
+    const grants = vi.spyOn((daemon as any).store, 'reclaimWebchatMcpGrants')
+    const dreams = vi.spyOn((daemon as any).dreamRunner(), 'reclaimDreams')
+
+    await (daemon as any).admitDutyGrants([grant()])
+
+    expect(duties(daemon).holdsAgent(AGENT)).toBe(true)
+    expect(grants).toHaveBeenCalledWith([AGENT], 'session_closed', expect.any(Number))
+    expect(dreams).toHaveBeenCalledWith([AGENT])
+
+    // A re-grant of a group already held gains no agent, so it reclaims nothing.
+    grants.mockClear()
+    dreams.mockClear()
+    await (daemon as any).admitDutyGrants([grant()])
+    expect(grants).not.toHaveBeenCalled()
+    expect(dreams).not.toHaveBeenCalled()
+    await daemon.stop()
+  })
 })

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -48,6 +48,12 @@ class FakeStore implements DreamStorePort {
   updateDream(dream: DreamInfo): void {
     this.dreams.set(dream.dreamId, dream)
   }
+  failOpenDream(dream: DreamInfo): boolean {
+    const current = this.dreams.get(dream.dreamId)
+    if (current?.status !== 'pending' && current?.status !== 'running') return false
+    this.dreams.set(dream.dreamId, dream)
+    return true
+  }
   getDream(_agentId: string, dreamId: string): DreamInfo | undefined {
     return this.dreams.get(dreamId)
   }
@@ -64,8 +70,17 @@ class FakeStore implements DreamStorePort {
       .filter((dream) => dream.organizationSuggestions?.some((suggestion) => suggestion.state === 'proposed'))
       .slice(0, limit)
   }
+  /** dreamIds this incarnation started. A shared store hands back nothing else at boot. */
+  owned?: Set<string>
   openDreams(): DreamInfo[] {
-    return [...this.dreams.values()].filter((d) => d.status === 'pending' || d.status === 'running')
+    return [...this.dreams.values()].filter(
+      (d) => (d.status === 'pending' || d.status === 'running') && (!this.owned || this.owned.has(d.dreamId))
+    )
+  }
+  strandedDreams(agentIds: readonly string[]): DreamInfo[] {
+    return [...this.dreams.values()].filter(
+      (d) => agentIds.includes(d.agentId) && (d.status === 'pending' || d.status === 'running')
+    )
   }
   completedDreams(agentId: string): DreamInfo[] {
     return [...this.dreams.values()].filter((d) => d.agentId === agentId && d.status === 'completed')
@@ -961,6 +976,48 @@ describe('DreamRunner crash recovery', () => {
       status: 'failed',
       error: { type: 'daemon_restart' }
     })
+  })
+
+  it("fails a peer's dream on the duty grant, never because this member started", () => {
+    // On a pool the store is shared: boot sees only this incarnation's rows, and a peer's
+    // running dream becomes recoverable only once the CP hands over the agent.
+    const store = new FakeStore()
+    store.owned = new Set()
+    store.insertDream({
+      dreamId: 'drm-peer',
+      agentId: 'a1',
+      status: 'running',
+      trigger: 'manual',
+      sessionIds: [],
+      snapshotDigest: 'sha256:x',
+      createdAt: new Date().toISOString()
+    })
+    const failures: string[] = []
+    const runner = new DreamRunner({
+      agentDirByAgent: () => undefined,
+      dreamingPolicyFor: () => undefined,
+      operationPolicy: 'test-only',
+      store,
+      extract: async () => '',
+      onEvent: (event) => {
+        if (event.type === 'memory.dream.failed') failures.push(event.dream.dreamId)
+      },
+      log: silent
+    })
+    expect(store.dreams.get('drm-peer')?.status).toBe('running')
+
+    runner.reclaimDreams(['a2'])
+    expect(store.dreams.get('drm-peer')?.status).toBe('running')
+
+    runner.reclaimDreams(['a1'])
+    expect(store.dreams.get('drm-peer')).toMatchObject({ status: 'failed', error: { type: 'daemon_restart' } })
+    expect(failures).toEqual(['drm-peer'])
+
+    // The CAS lost: a terminal row is neither rewritten nor re-announced.
+    store.dreams.set('drm-peer', { ...store.dreams.get('drm-peer')!, status: 'completed' })
+    runner.reclaimDreams(['a1'])
+    expect(store.dreams.get('drm-peer')?.status).toBe('completed')
+    expect(failures).toEqual(['drm-peer'])
   })
 
   it('sweeps reconciled superseded staging while preserving proposed skills', async () => {

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -46,20 +46,27 @@ describe('LocalStore schema versioning', () => {
     old.exec('DROP INDEX session_metadata_outbox_attempt')
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN failedAttempts')
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN nextAttemptAt')
+    old.exec('ALTER TABLE dreams DROP COLUMN ownerId')
+    old.exec('ALTER TABLE webchat_mcp_grant_ledger DROP COLUMN ownerId')
     old.exec('PRAGMA user_version = 1')
     old.close()
 
     new LocalStore(path).close()
 
     const upgraded = new DatabaseSync(path)
-    const columns = upgraded.prepare('PRAGMA table_info(permission_requests)').all() as { name: string }[]
-    const outboxColumns = upgraded.prepare('PRAGMA table_info(session_metadata_outbox)').all() as { name: string }[]
+    const columnsOf = (table: string): string[] =>
+      (upgraded.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]).map((column) => column.name)
+    const columns = columnsOf('permission_requests')
+    const outboxColumns = columnsOf('session_metadata_outbox')
+    const dreamColumns = columnsOf('dreams')
+    const grantColumns = columnsOf('webchat_mcp_grant_ledger')
     upgraded.close()
-    expect(columns.map((column) => column.name)).toContain('ownerId')
-    expect(outboxColumns.map((column) => column.name)).toEqual(
-      expect.arrayContaining(['failedAttempts', 'nextAttemptAt'])
-    )
-    expect(userVersion(path)).toBe(3)
+    expect(columns).toContain('ownerId')
+    expect(outboxColumns).toEqual(expect.arrayContaining(['failedAttempts', 'nextAttemptAt']))
+    // Recovery ownership: a pool member must be able to tell its own rows from a peer's.
+    expect(dreamColumns).toContain('ownerId')
+    expect(grantColumns).toContain('ownerId')
+    expect(userVersion(path)).toBe(4)
   })
 
   it('refuses a store written by a newer daemon WITHOUT touching it first', () => {
@@ -1364,11 +1371,11 @@ describe('LocalStore webchat MCP grant ledger', () => {
     s.close()
   })
 
-  it('marks all leftover active grants revoking on the startup orphan sweep', () => {
+  it('marks the leftover active grants of an exclusively owned store revoking on the startup sweep', () => {
     const s = store()
     s.recordWebchatMcpGrant({ ...tuple, now: 10 })
     s.recordWebchatMcpGrant({ ...tuple, conversationId: 'conv-2', now: 10 })
-    expect(s.markAllWebchatMcpGrantsRevoking('session_closed', 50)).toBe(2)
+    expect(s.markOwnedWebchatMcpGrantsRevoking('session_closed', 50)).toBe(2)
     const due = s.listDueWebchatMcpRevocations(50)
     expect(due.map((r) => r.conversationId).sort()).toEqual(['conv-1', 'conv-2'])
     expect(due.every((r) => r.reason === 'session_closed')).toBe(true)
@@ -1418,6 +1425,104 @@ describe('LocalStore webchat MCP grant ledger', () => {
     expect(JSON.parse(row.attachmentsJson ?? 'null')).toEqual([
       { name: 'shot.png', mimeType: 'image/png', data: 'aW1n' }
     ])
+    s.close()
+  })
+})
+
+describe('LocalStore recovery scope on a shared store (daemon pool)', () => {
+  // One store, many members. A member's own id is its PROCESS incarnation, so a starting
+  // member owns nothing yet — which is exactly why boot must recover nothing here.
+  const tuple = {
+    conversationId: 'conv-1',
+    agentId: 'agent-1',
+    authorityId: 'auth-1',
+    authorityGeneration: 3
+  }
+  const openDream = (dreamId: string, agentId = 'agent-1') => ({
+    dreamId,
+    agentId,
+    status: 'running' as const,
+    trigger: 'manual' as const,
+    sessionIds: [],
+    snapshotDigest: 'sha256:x',
+    createdAt: '2026-01-01T00:00:00.000Z'
+  })
+
+  const sharedPath = (): string => join(mkdtempSync(join(tmpdir(), 'ac-pool-')), 'shared.sqlite')
+  const member = (path: string, ownerId: string): LocalStore =>
+    new LocalStore({ database: new DatabaseSync(path), shared: true, ownerId })
+
+  it("a starting member leaves a peer's live grant and running dream untouched", () => {
+    const path = sharedPath()
+    const a = member(path, 'member-a')
+    a.recordWebchatMcpGrant({ ...tuple, now: 10 })
+    a.insertDream(openDream('drm-a'))
+
+    // A rolling update starts a new Pod: a new owner, while A keeps serving.
+    const b = member(path, 'member-b')
+    expect(b.markOwnedWebchatMcpGrantsRevoking('session_closed', 50)).toBe(0)
+    expect(b.openDreams()).toEqual([])
+    expect(b.listDueWebchatMcpRevocations(10_000)).toEqual([])
+    expect(a.listDueWebchatMcpRevocations(10_000)).toEqual([])
+    expect(a.getDream('agent-1', 'drm-a')?.status).toBe('running')
+    a.close()
+    b.close()
+  })
+
+  it("reclaims a former owner's rows only for the agents this member was handed", () => {
+    const path = sharedPath()
+    const a = member(path, 'member-a')
+    a.recordWebchatMcpGrant({ ...tuple, now: 10 })
+    a.insertDream(openDream('drm-a'))
+    const b = member(path, 'member-b')
+
+    expect(b.reclaimWebchatMcpGrants(['other-agent'], 'session_closed', 60)).toBe(0)
+    expect(b.strandedDreams(['other-agent'])).toEqual([])
+
+    expect(b.reclaimWebchatMcpGrants(['agent-1'], 'session_closed', 60)).toBe(1)
+    expect(b.listDueWebchatMcpRevocations(60)[0]).toMatchObject({
+      conversationId: 'conv-1',
+      state: 'revoking',
+      ownerId: 'member-b'
+    })
+    // The queue moved with the duty: its former owner no longer drains it.
+    expect(a.listDueWebchatMcpRevocations(10_000)).toEqual([])
+
+    const stranded = b.strandedDreams(['agent-1'])
+    expect(stranded.map((dream) => dream.dreamId)).toEqual(['drm-a'])
+    const failed = { ...stranded[0]!, status: 'failed' as const, endedAt: '2026-01-01T00:01:00.000Z' }
+    expect(b.failOpenDream(failed)).toBe(true)
+    // Idempotent: the row is terminal now, so a replayed recovery writes nothing.
+    expect(b.failOpenDream(failed)).toBe(false)
+    expect(b.strandedDreams(['agent-1'])).toEqual([])
+    a.close()
+    b.close()
+  })
+
+  it("the recovery CAS keeps the outcome the dream's own runner recorded", () => {
+    const path = sharedPath()
+    const a = member(path, 'member-a')
+    a.insertDream(openDream('drm-a'))
+    const b = member(path, 'member-b')
+    const stranded = b.strandedDreams(['agent-1'])[0]!
+
+    // A finishes between B's read and B's write — the completion must survive.
+    a.updateDream({ ...openDream('drm-a'), status: 'completed', endedAt: '2026-01-01T00:00:30.000Z' })
+    expect(b.failOpenDream({ ...stranded, status: 'failed', endedAt: '2026-01-01T00:01:00.000Z' })).toBe(false)
+    expect(a.getDream('agent-1', 'drm-a')?.status).toBe('completed')
+    a.close()
+    b.close()
+  })
+
+  it('an exclusively owned store still recovers everything it left behind at boot', () => {
+    const s = store()
+    s.recordWebchatMcpGrant({ ...tuple, now: 10 })
+    s.insertDream(openDream('drm-a'))
+    expect(s.markOwnedWebchatMcpGrantsRevoking('session_closed', 50)).toBe(1)
+    expect(s.openDreams().map((dream) => dream.dreamId)).toEqual(['drm-a'])
+    // There is no duty axis on a single-daemon store — boot already covered it.
+    expect(s.strandedDreams(['agent-1'])).toEqual([])
+    expect(s.reclaimWebchatMcpGrants(['agent-1'], 'session_closed', 60)).toBe(0)
     s.close()
   })
 })


### PR DESCRIPTION
## Summary

Boot-time crash recovery still assumed "if I am starting, nothing else is running". Two passes
read the whole store with no owner predicate and rewrote every unfinished row as wreckage from the
process that just died. On a daemon pool that store is shared, and a member starts while every
other member keeps serving — so "unfinished" means "a peer is working on it".

Recovery is now scoped to the work this process actually owned, and a genuinely stranded row is
reclaimed when the CP makes this member responsible for the agent, not when a member boots.

Rebased on `main` after #1042 and #1045. #1042 already closed the orchestration-deadline half of
the issue (deadlines are armed from the duty set and the fire is a CAS claim), so that hunk is
dropped here; the reclaim hook sits beside #1045's sandbox adoption on the same `agentsGained`.

Closes #1033.

## Failure scenario

A rolling update starts a new member while its peers serve live traffic. That member:

1. flipped **every** `active` webchat MCP grant in the install to `revoking`, and the drain then
   revoked them at the control plane — users lost remote MCP authority mid-conversation because
   an unrelated member booted;
2. failed **every** `pending`/`running` dream with `daemon_restart`, including the ones peers were
   running; the running member later wrote `completed` over the same row, so the console and the
   CP saw a spurious failure next to a completion (order depending on the race);
3. drained **every** due revocation row, resolving the org with its own registry — for agents it
   does not host that is a duplicate revoke plus a permanent warn loop.

## Fix

- **Ownership on the rows.** `webchat_mcp_grant_ledger` and `dreams` each gain an `ownerId`,
  stamped by the writes that start the work. The owner id is the member's *process incarnation*
  (`LocalStore.ownerId`), which is exactly right here: a new pod is a new owner, so a fresh member
  owns nothing at boot and its predecessor's rows are handled by the reclaim path below.
- **Boot recovers only its own.** `markOwnedWebchatMcpGrantsRevoking` (renamed from
  `markAllWebchatMcpGrantsRevoking`) revokes only the grants this incarnation recorded — those are
  the ones whose descriptor and plaintext died with it. `openDreams` likewise returns only this
  incarnation's in-flight dreams, so `DreamRunner`'s constructor sweep cannot touch a peer's.
- **Reclaim on the duty grant.** `settleDutyChange`'s `agentsGained` — the CP saying "you serve
  this agent now" — reclaims the former owner's stranded rows: `reclaimWebchatMcpGrants` takes over
  the grant/queue (revoking it, since the plaintext went with the owner) and
  `DreamRunner.reclaimDreams` fails the dreams. This mirrors `recoverPermissionRequests`, which
  already recovers on ownership rather than on process start.
- **CAS on the recovery write.** `failOpenDream` updates only while the row is still
  `pending`/`running`, so a losing race can never overwrite the terminal state the dream's own
  runner recorded, and no phantom `memory.dream.failed` is announced.
- **Drain what is ours.** `listDueWebchatMcpRevocations` returns this member's queue (plus rows
  written before ownership was recorded), so no member drives a revoke for an agent it does not
  host.

Local single-daemon stores are unchanged: with `shared === false` the boot sweeps still recover
everything, because an exclusively owned store is itself the proof that the previous process is
gone, and the duty-scoped reclaims are no-ops there.

Schema goes to v4; one `SCHEMA_MIGRATIONS` step adds both `ownerId` columns to existing stores.

## Test plan

- `packages/daemon/test/local-store.test.ts` — two members over one shared store: a starting
  member leaves a peer's active grant and running dream untouched; a reclaim takes over the former
  owner's rows only for the agents this member was handed, and the queue moves with it; the CAS
  keeps a completion recorded between the reclaim's read and its write; an exclusively owned store
  still recovers everything at boot. Plus the v1→v4 upgrade test now asserts both new columns.
- `packages/daemon/test/dream-runner.test.ts` — a peer's dream survives the constructor sweep and
  is failed only by `reclaimDreams` for its own agent; a row that reached a terminal state is
  neither rewritten nor re-announced.
- `packages/daemon/test/daemon-duty-install.test.ts` — a duty grant reclaims for the agents it
  gained; a re-grant of a group already held reclaims nothing.
- After the rebase: `typecheck`, `pnpm lint`, `pnpm format:check` clean, and
  `local-store` + `dream-runner` + `daemon-duty-install` + `orchestration` (188 passed) and
  `mcp-ops` + `daemon-message-agent` + `daemon-k8s-mode` + `k8s-driver-takeover` (239 passed) green.
  On the full daemon suite the only failures are pre-existing on `main` in this environment
  (`shim-*`, `workspace-git-runner-seam`, `acp-matrix` fail identically without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
