### PR TITLE
fix(control-plane): authorize hook and review reports through the placement resolver

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -155,7 +155,7 @@ import { CollabRoutesService } from './orchestrator/collabRoutes.service.js'
 import { DutyLeaseService, DUTY_LEASE_DEFAULTS } from './orchestrator/dutyLease.js'
 import { AgentDelivery } from './orchestrator/agentDelivery.js'
 import { AgentRoutingConverger } from './orchestrator/agentRouting.js'
-import { PlacementResolver } from './orchestrator/placementResolver.js'
+import { PlacementResolver, type ResolvableAgent } from './orchestrator/placementResolver.js'
 import { DutyRecomputeSweep } from './orchestrator/dutyRecompute.js'
 import { AgentMutationGate } from './orchestrator/agentMutationGate.js'
 import { AgentMoveService } from './orchestrator/agentMove.js'
@@ -364,7 +364,13 @@ export function buildContainer(
     cron: new PgCronRepo(prisma),
     dutyGroup: new PgDutyGroupRepo(prisma),
     memberSet: new PgMemberSetRepo(prisma),
-    hook: new PgHookRepo(prisma),
+    // Fenced hook writes ask "may this daemon act for the hook's agent" — placement ∪ live duty
+    // holders, which a join on `agent.daemonId` cannot express. Lazy over `placementResolver`
+    // (assigned below; only ever called at report time).
+    hook: new PgHookRepo(prisma, {
+      servingDaemons: (agent: ResolvableAgent): Promise<string[]> => placementResolver.servingDaemons(agent),
+      routableDaemon: (agent: ResolvableAgent): Promise<DaemonId | null> => placementResolver.routableDaemon(agent)
+    }),
     hookSecret: new PgHookSecretStore(prisma, secretCipher),
     runtimeProfile: new PgRuntimeProfileRepo(prisma),
     audit: new PgAuditRepo(prisma),
@@ -841,7 +847,13 @@ export function buildContainer(
   // The console PR panel's read projection — long-lived so its short TTL cache actually absorbs mounts.
   const pullRequestView = github ? new PullRequestViewService(github.tokens, clock, opts.githubFetch) : undefined
   const githubReviewBroker = github
-    ? new GithubReviewBrokerService({ hook: repos.hook, agent: repos.agent, github, clock })
+    ? new GithubReviewBrokerService({
+        hook: repos.hook,
+        agent: repos.agent,
+        github,
+        clock,
+        placement: placementResolver
+      })
     : undefined
   const githubCommentAuthz = github
     ? new GithubCommentAuthzService({

--- a/packages/control-plane/src/github/review-broker.service.ts
+++ b/packages/control-plane/src/github/review-broker.service.ts
@@ -27,6 +27,7 @@ import type {
   HookReviewResultInput,
   HookRunRecord
 } from '../persistence/ports.js'
+import { PLACEMENT_ONLY, type PlacementResolver } from '../orchestrator/placementResolver.js'
 import { GitCredDeniedError, type GithubService } from './service.js'
 
 type ReviewBrokerCode = Extract<ErrorCode, 'SCOPE_DENIED' | 'LEASE_DENIED' | 'RATE_LIMITED' | 'CONFLICT' | 'INTERNAL'>
@@ -48,6 +49,8 @@ export interface GithubReviewBrokerDeps {
   agent: Pick<AgentRepo, 'getUnscoped'>
   github: Pick<GithubService, 'mintReviewForAgent' | 'validateReviewForAgent'>
   clock: Pick<Clock, 'now'>
+  /** Absent (tests, or a deployment with no member set) ⇒ placement alone, the pre-duty behavior. */
+  placement?: Pick<PlacementResolver, 'mayAct'>
 }
 
 const POLICY_RANK = {
@@ -165,7 +168,9 @@ function requireCurrentActionAuthority(
   agent: AgentRecord | null,
   run: HookRunRecord,
   daemonId: DaemonId,
-  event: HookReviewEvent
+  event: HookReviewEvent,
+  /** Whether the reporting daemon still serves the agent — placement ∪ live duty holders. */
+  agentIsServed: boolean
 ): { hook: HookRecord; agent: AgentRecord } {
   if (
     !hook ||
@@ -189,7 +194,7 @@ function requireCurrentActionAuthority(
     !agent ||
     agent.id !== run.agentId ||
     agent.status !== 'active' ||
-    agent.daemonId !== daemonId ||
+    !agentIsServed ||
     run.dispatchDaemonId !== daemonId
   ) {
     denied('agent is no longer active on the accepted dispatch daemon')
@@ -234,6 +239,31 @@ function submittedVerdictIsValid(event: HookReviewEvent, verdict: 'pass' | 'fail
 
 export class GithubReviewBrokerService {
   constructor(private readonly deps: GithubReviewBrokerDeps) {}
+
+  /** May the reporting daemon act for this agent — its placement, or a duty it currently holds. */
+  private serves(agent: AgentRecord, daemonId: DaemonId): Promise<boolean> {
+    return (this.deps.placement ?? PLACEMENT_ONLY).mayAct(agent, daemonId)
+  }
+
+  /** Re-read hook + agent and re-apply the current action fence at one authorization checkpoint. */
+  private async requireLiveActionAuthority(
+    hookId: HookId,
+    agentId: AgentId,
+    run: HookRunRecord,
+    reportingDaemonId: DaemonId,
+    event: HookReviewEvent
+  ): Promise<{ hook: HookRecord; agent: AgentRecord }> {
+    const hook = await this.deps.hook.getUnscoped(hookId)
+    const agent = await this.deps.agent.getUnscoped(agentId)
+    return requireCurrentActionAuthority(
+      hook,
+      agent,
+      run,
+      reportingDaemonId,
+      event,
+      agent ? await this.serves(agent, reportingDaemonId) : false
+    )
+  }
 
   /** Re-read the durable attempt at each authorization checkpoint. Keeping
    * this guard named makes the repeated TOCTOU fences visible without
@@ -331,7 +361,7 @@ export class GithubReviewBrokerService {
     )
     requireCurrentHookForStart(await this.deps.hook.getUnscoped(hookId), run, reportingDaemonId)
     const agent = await this.deps.agent.getUnscoped(run.agentId!)
-    if (!agent || agent.status !== 'active' || agent.daemonId !== reportingDaemonId) {
+    if (!agent || agent.status !== 'active' || !(await this.serves(agent, reportingDaemonId))) {
       denied('agent is no longer active on the accepted dispatch daemon')
     }
 
@@ -358,9 +388,9 @@ export class GithubReviewBrokerService {
       denied('requested review event and verdict are incompatible')
     }
     const target = requireTrustedPullTarget(initial)
-    const current = requireCurrentActionAuthority(
-      await this.deps.hook.getUnscoped(hookId),
-      await this.deps.agent.getUnscoped(initial.agentId),
+    const current = await this.requireLiveActionAuthority(
+      hookId,
+      initial.agentId,
       initial,
       reportingDaemonId,
       input.requestedEvent
@@ -411,9 +441,9 @@ export class GithubReviewBrokerService {
       'review attempt reservation changed while authorizing'
     )
     try {
-      const finalAuthority = requireCurrentActionAuthority(
-        await this.deps.hook.getUnscoped(hookId),
-        await this.deps.agent.getUnscoped(initial.agentId),
+      const finalAuthority = await this.requireLiveActionAuthority(
+        hookId,
+        initial.agentId,
         finalRun,
         reportingDaemonId,
         input.requestedEvent
@@ -439,9 +469,9 @@ export class GithubReviewBrokerService {
         reportingDaemonId,
         'review attempt reservation changed while authorizing'
       )
-      requireCurrentActionAuthority(
-        await this.deps.hook.getUnscoped(hookId),
-        await this.deps.agent.getUnscoped(initial.agentId),
+      await this.requireLiveActionAuthority(
+        hookId,
+        initial.agentId,
         exposureRun,
         reportingDaemonId,
         input.requestedEvent

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -51,6 +51,7 @@ import { toDbPlatform } from '../platform.js'
 import type { SecretCipher } from '../../secrets/cipher.js'
 import { orgScope } from '../../secrets/scope.js'
 import { AgentId, HookId, IntegrationId, OrgId, type DaemonId } from '../../domain/ids.js'
+import { PLACEMENT_ONLY, type PlacementResolver, type ResolvableAgent } from '../../orchestrator/placementResolver.js'
 import { ORPHANED_RUN_REASON } from './cron.repo.js'
 import {
   lockHookReviewAgentLifecycleScope,
@@ -371,8 +372,49 @@ async function lockGithubRepoIdentityScope(tx: Prisma.TransactionClient, orgId: 
   `)
 }
 
+/** The placement columns a dispatch fence reads. A `set` agent leaves `daemonId` null, so the
+ *  resolver — not a join — is the only thing that can name who serves it. */
+const PLACEMENT_REF_SELECT = { placementKind: true, daemonId: true, setId: true } as const
+
+/** Who may act for one hook's agent, resolved BEFORE the fenced transaction: asking the duty
+ *  ledger while holding one would trade a pooled connection for a lock. `agentId` is what the hook
+ *  named at resolve time, and every fence re-reads it in the transaction, so this cannot widen. */
+interface HookDispatchAuthority {
+  agentId: string | null
+  /** The resolver's view of the agent, kept for the callers that also need a dispatch target. */
+  ref: ResolvableAgent | null
+  /** Placement ∪ live duty holders. */
+  serving: readonly string[]
+}
+
+const NO_AUTHORITY: HookDispatchAuthority = { agentId: null, ref: null, serving: [] }
+
+/** May `daemonId` act for this hook, given the agent the transaction actually reads? */
+function servedBy(
+  authority: HookDispatchAuthority,
+  agentId: string | null,
+  daemonId: string | null | undefined
+): boolean {
+  return agentId !== null && agentId === authority.agentId && !!daemonId && authority.serving.includes(daemonId)
+}
+
 export class PgHookRepo implements HookRepo {
-  constructor(private readonly db: PrismaLike) {}
+  constructor(
+    private readonly db: PrismaLike,
+    /** Absent (tests, or a deployment with no member set) ⇒ placement alone, the pre-duty behavior. */
+    private readonly placement: Pick<PlacementResolver, 'servingDaemons' | 'routableDaemon'> = PLACEMENT_ONLY
+  ) {}
+
+  /** Resolve one hook's dispatch authority. Called outside the fenced transaction. */
+  private async dispatchAuthority(hookId: HookId): Promise<HookDispatchAuthority> {
+    const hook = await this.db.hookDef.findUnique({
+      where: { id: hookId },
+      select: { agentId: true, agent: { select: PLACEMENT_REF_SELECT } }
+    })
+    if (!hook?.agentId || !hook.agent) return NO_AUTHORITY
+    const ref = { ...hook.agent, id: hook.agentId }
+    return { agentId: hook.agentId, ref, serving: await this.placement.servingDaemons(ref) }
+  }
 
   private transaction<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>, options?: { timeout?: number }): Promise<T> {
     if ('$transaction' in this.db) return (this.db as PrismaClient).$transaction(fn, options)
@@ -696,6 +738,7 @@ export class PgHookRepo implements HookRepo {
   }
 
   async recordDeliveryResult(hookId: HookId, r: HookDeliveryInput): Promise<HookDeliveryRecordResult> {
+    const authority = await this.dispatchAuthority(hookId)
     return this.transaction(async (tx) => {
       // Organization deletion takes this lock before its final HookRun sweep.
       // Serialize both legacy and fenced delivery creation with that sweep so
@@ -727,8 +770,7 @@ export class PgHookRepo implements HookRepo {
                 agentId: true,
                 configRevision: true,
                 dispatchRevision: true,
-                projectionEpoch: true,
-                agent: { select: { daemonId: true } }
+                projectionEpoch: true
               }
             })
           : null
@@ -737,7 +779,7 @@ export class PgHookRepo implements HookRepo {
           current.agentId === r.agentId &&
           current.configRevision === r.configRevision &&
           current.dispatchRevision === r.dispatchRevision &&
-          current.agent?.daemonId === r.dispatchDaemonId
+          servedBy(authority, current.agentId, r.dispatchDaemonId)
         const preservesTriggerAuthority = existing.agentId === r.agentId && existing.configRevision === r.configRevision
         const remainsRetryable =
           hasFence &&
@@ -799,8 +841,7 @@ export class PgHookRepo implements HookRepo {
           projectionEpoch: true,
           reviewPolicy: true,
           reportingMode: true,
-          gateMode: true,
-          agent: { select: { daemonId: true } }
+          gateMode: true
         }
       })
       if (!hook) return { accepted: false, newlyObserved: false }
@@ -826,7 +867,7 @@ export class PgHookRepo implements HookRepo {
         (hook.agentId !== r.agentId ||
           hook.configRevision !== r.configRevision ||
           hook.dispatchRevision !== r.dispatchRevision ||
-          hook.agent?.daemonId !== r.dispatchDaemonId ||
+          !servedBy(authority, hook.agentId, r.dispatchDaemonId) ||
           (r.reviewPolicySnapshot !== undefined && hook.reviewPolicy !== r.reviewPolicySnapshot) ||
           (r.reportingModeSnapshot !== undefined && hook.reportingMode !== r.reportingModeSnapshot) ||
           (r.gateModeSnapshot !== undefined && hook.gateMode !== r.gateModeSnapshot))
@@ -1141,6 +1182,7 @@ export class PgHookRepo implements HookRepo {
   }
 
   async recordStart(hookId: HookId, reportingDaemonId: DaemonId, r: HookStartInput): Promise<boolean> {
+    const authority = await this.dispatchAuthority(hookId)
     return this.transaction(async (tx) => {
       await lockHookReviewLifecycleScope(tx, hookId)
       await lockHookDeliveryRedeliveryScope(tx, r.deliveryKey)
@@ -1170,7 +1212,7 @@ export class PgHookRepo implements HookRepo {
             reviewPolicy: true,
             reportingMode: true,
             gateMode: true,
-            agent: { select: { daemonId: true, status: true } }
+            agent: { select: { status: true } }
           }
         })
         if (
@@ -1180,7 +1222,7 @@ export class PgHookRepo implements HookRepo {
           current.agentId !== r.agentId ||
           current.configRevision !== r.configRevision ||
           current.dispatchRevision !== r.dispatchRevision ||
-          current.agent?.daemonId !== r.dispatchDaemonId ||
+          !servedBy(authority, current.agentId, r.dispatchDaemonId) ||
           current.agent?.status !== 'active' ||
           reportingDaemonId !== r.dispatchDaemonId ||
           run.agentId !== r.agentId ||
@@ -1452,6 +1494,7 @@ export class PgHookRepo implements HookRepo {
   }
 
   async recordReport(hookId: HookId, reportingDaemonId: DaemonId, r: HookReportInput, at: Date): Promise<boolean> {
+    const authority = await this.dispatchAuthority(hookId)
     return this.transaction(async (tx) => {
       // Completion-first recovery can create a FK-less HookRun row. Share the
       // hook lifecycle lock with organization deletion so its final metadata
@@ -1463,10 +1506,10 @@ export class PgHookRepo implements HookRepo {
       })
       let run = found ? await this.lockHookRunById(tx, found.id) : null
       if (!run) {
-        // Completion-first recovery is accepted only from the current placement;
-        // when a full tuple is present it must also match current hook fences.
-        const hook = await tx.hookDef.findFirst({
-          where: { id: hookId, agent: { daemonId: reportingDaemonId } },
+        // Completion-first recovery is accepted only from a daemon that currently serves the
+        // hook's agent; when a full tuple is present it must also match current hook fences.
+        const hookRow = await tx.hookDef.findUnique({
+          where: { id: hookId },
           select: {
             orgId: true,
             agentId: true,
@@ -1481,6 +1524,7 @@ export class PgHookRepo implements HookRepo {
             gateMode: true
           }
         })
+        const hook = hookRow && servedBy(authority, hookRow.agentId, reportingDaemonId) ? hookRow : null
         // A GitHub review token can only have been authorized against an
         // existing HookRun reservation, so completion-first may never invent
         // review metadata.
@@ -1629,7 +1673,7 @@ export class PgHookRepo implements HookRepo {
                 reviewPolicy: true,
                 reportingMode: true,
                 gateMode: true,
-                agent: { select: { daemonId: true, status: true } }
+                agent: { select: { status: true } }
               }
             })
             if (
@@ -1639,7 +1683,7 @@ export class PgHookRepo implements HookRepo {
               current.agentId !== r.agentId ||
               current.configRevision !== r.configRevision ||
               current.dispatchRevision !== r.dispatchRevision ||
-              current.agent?.daemonId !== r.dispatchDaemonId ||
+              !servedBy(authority, current.agentId, r.dispatchDaemonId) ||
               current.agent?.status !== 'active' ||
               current.reviewPolicy !== r.reviewPolicySnapshot ||
               current.reportingMode !== r.reportingModeSnapshot ||
@@ -1744,15 +1788,13 @@ export class PgHookRepo implements HookRepo {
         const acceptedDaemon = run.dispatchDaemonId
         if (acceptedDaemon ? acceptedDaemon !== reportingDaemonId : false) return false
         if (!acceptedDaemon) {
-          const current = await tx.hookDef.findFirst({
-            where: { id: hookId, agent: { daemonId: reportingDaemonId } },
-            select: { agentId: true }
-          })
+          const current = await tx.hookDef.findUnique({ where: { id: hookId }, select: { agentId: true } })
           // Legacy HookRun rows predate the accepted dispatch tuple, but their
-          // daemon report still carries the owning agentId. Fall back to the
-          // hook's current placement without weakening that agent boundary: a
-          // different agent on the same daemon must not be able to close it.
-          if (!current || (r.agentId !== undefined && current.agentId !== r.agentId)) return false
+          // daemon report still carries the owning agentId. Fall back to who serves the hook's
+          // agent now, without weakening that agent boundary: a different agent on the same
+          // daemon must not be able to close it.
+          if (!current || !servedBy(authority, current.agentId, reportingDaemonId)) return false
+          if (r.agentId !== undefined && current.agentId !== r.agentId) return false
         }
         if (
           (r.agentId !== undefined && run.agentId !== null && run.agentId !== r.agentId) ||
@@ -1952,6 +1994,16 @@ export class PgHookRepo implements HookRepo {
     if (backoffMs.length === 0) return false
     const expected = [...new Set(expectedHookIds)].sort()
     if (expected.length === 0) return false
+    const authorities = new Map<string, HookDispatchAuthority>()
+    // Where a redelivered event lands, exactly as the relay rule names it: the placement for a
+    // machine-placed agent, the current duty holder for a set-placed one.
+    const dispatchTargets = new Map<string, string>()
+    for (const hookId of expected) {
+      const authority = await this.dispatchAuthority(hookId)
+      authorities.set(hookId, authority)
+      const routable = authority.ref ? await this.placement.routableDaemon(authority.ref) : null
+      if (routable) dispatchTargets.set(hookId, routable)
+    }
     return this.transaction(async (tx) => {
       // Hook-definition mutation paths take the lifecycle lock. Serialize the
       // expected fanout before the delivery lock; a placement move that commits
@@ -2001,24 +2053,23 @@ export class PgHookRepo implements HookRepo {
           reviewPolicy: true,
           reportingMode: true,
           gateMode: true,
-          agent: { select: { daemonId: true, status: true } }
+          agent: { select: { status: true } }
         }
       })
       const currentById = new Map(currentHooks.map((hook) => [hook.id, hook]))
       const attempt = Math.max(...rows.map((row) => row.redeliveryAttempts))
       const authoritySafe = rows.every((row) => {
         const current = currentById.get(row.hookId)
-        if (!current?.agentId || !current.agent?.daemonId || current.agent.status !== 'active') return false
+        if (!current?.agentId || current.agent?.status !== 'active') return false
+        const target = dispatchTargets.get(row.hookId)
+        if (authorities.get(row.hookId)?.agentId !== current.agentId || !target) return false
         // A definite offline failure may follow a placement-only move, but not
         // an agent/config edit that would reinterpret the old event. Once one
         // external POST has been requested, pin later attempts to its captured
         // dispatch: same-daemon durable inbox dedup is available, cross-daemon
         // dedup is not.
         if (row.agentId !== current.agentId || row.configRevision !== current.configRevision) return false
-        if (
-          attempt > 0 &&
-          (row.dispatchRevision !== current.dispatchRevision || row.dispatchDaemonId !== current.agent.daemonId)
-        )
+        if (attempt > 0 && (row.dispatchRevision !== current.dispatchRevision || row.dispatchDaemonId !== target))
           return false
         return true
       })
@@ -2050,7 +2101,7 @@ export class PgHookRepo implements HookRepo {
           data: {
             dispatchRevision: current.dispatchRevision,
             projectionEpoch: current.projectionEpoch,
-            dispatchDaemonId: current.agent!.daemonId!,
+            dispatchDaemonId: dispatchTargets.get(row.hookId)!,
             reviewPolicySnapshot: current.reviewPolicy,
             reportingModeSnapshot: current.reportingMode,
             gateModeSnapshot: current.gateMode,

--- a/packages/control-plane/test/integration/hooks-pool-placement.test.ts
+++ b/packages/control-plane/test/integration/hooks-pool-placement.test.ts
@@ -1,0 +1,363 @@
+/**
+ * GitHub hooks and PR review for a POOL agent (#1025).
+ *
+ * Dispatch already addressed the duty holder, but every acceptance fence still compared
+ * `agent.daemonId`, which a `set` placement leaves null — so the holder's own report was refused,
+ * `hook/start` came back non-retryable, and the review broker denied every action. Authority is the
+ * same seam as the reads (#1004): placement ∪ live duty holders, read through `PlacementResolver`.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { joinPool, poolSetId } from '../fakes/member-set.js'
+import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
+import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
+import { GithubReviewBrokerService } from '../../src/github/review-broker.service.js'
+import { handleHookReport } from '../../src/ws/handlers/index.js'
+import { AgentId, DaemonId, HookId, OrgId } from '../../src/domain/ids.js'
+import { systemClock } from '../../src/domain/clock.js'
+import type { DaemonConnection } from '../../src/ws/connection.js'
+import type { DaemonWsDeps } from '../../src/ws/deps.js'
+import type { AnyFrame, HookReport } from '@agentconnect.md/protocol'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const HOLDER = 'e1e1e1e1-eeee-4eee-8eee-eeeeeeeeeee1'
+const PEER = 'e2e2e2e2-eeee-4eee-8eee-eeeeeeeeeee2'
+const MACHINE = 'e3e3e3e3-eeee-4eee-8eee-eeeeeeeeeee3'
+const HEAD_SHA = 'a'.repeat(40)
+const BASE_SHA = 'b'.repeat(40)
+
+const placement = () => new PlacementResolver({ duties: new PgDutyGroupRepo(prisma), clock: systemClock })
+const repo = () => new PgHookRepo(prisma, placement())
+
+/** An install-wide pool member: an org-less daemon row enrolled in the org-less set. */
+async function poolMember(daemonId: string): Promise<void> {
+  await seedDaemon(prisma, daemonId)
+  await prisma.daemon.update({ where: { id: daemonId }, data: { orgId: null } })
+  await joinPool(prisma, daemonId)
+}
+
+/** A live, confirmed duty lease over one agent — what makes a member serve it. */
+async function grantDuty(holder: string, agentId: string): Promise<void> {
+  const groupId = randomUUID()
+  await prisma.dutyGroup.create({
+    data: {
+      id: groupId,
+      orgId: DEFAULT_ORG_ID,
+      holder,
+      term: 1n,
+      confirmedTerm: 1n,
+      confirmedHolder: holder,
+      expiresAt: new Date(Date.now() + 600_000)
+    }
+  })
+  await prisma.dutyGroupMember.create({ data: { kind: 'agent', refId: agentId, groupId, orgId: DEFAULT_ORG_ID } })
+}
+
+async function seedGithubHook(agentId: string): Promise<string> {
+  const hookId = randomUUID()
+  await repo().upsert({
+    hookId: HookId(hookId),
+    orgId: OrgId(DEFAULT_ORG_ID),
+    agentId: AgentId(agentId),
+    kind: 'github',
+    name: `review-${hookId.slice(0, 8)}`,
+    sessionMode: 'perThread',
+    repoId: 987654321n,
+    repoFullName: 'acme/infra',
+    events: ['pull_request:*'],
+    reviewPolicy: 'full',
+    reportingMode: 'check',
+    gateMode: 'informational',
+    targetPlatform: 'slack'
+  })
+  return hookId
+}
+
+/** A pool-placed, active agent whose duty `holder` currently holds, plus its github hook. */
+async function pooledGithubHook(holder = HOLDER): Promise<{ agentId: string; hookId: string }> {
+  await poolMember(holder)
+  const agentId = randomUUID()
+  await prisma.agent.create({
+    data: {
+      id: agentId,
+      orgId: DEFAULT_ORG_ID,
+      name: `pooled-${agentId.slice(0, 8)}`,
+      runtime: 'claude',
+      status: 'active',
+      placementKind: 'set',
+      setId: await poolSetId(prisma)
+    }
+  })
+  await grantDuty(holder, agentId)
+  return { agentId, hookId: await seedGithubHook(agentId) }
+}
+
+/** The machine-placed regression twin: same hook, one named daemon, no lease at all. */
+async function machineGithubHook(): Promise<{ agentId: string; hookId: string }> {
+  await seedDaemon(prisma, MACHINE)
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, { daemonId: MACHINE })
+  await prisma.agent.update({ where: { id: agentId }, data: { status: 'active' } })
+  return { agentId, hookId: await seedGithubHook(agentId) }
+}
+
+/** The relay's accepted `rc/run-report` for a pull-request event, addressed at one member. */
+async function acceptDelivery(
+  hookId: string,
+  agentId: string,
+  deliveryKey: string,
+  dispatchDaemonId: string
+): Promise<boolean> {
+  const hook = (await repo().getUnscoped(HookId(hookId)))!
+  return repo().recordDelivery(HookId(hookId), {
+    deliveryKey,
+    firedAt: new Date('2026-08-15T09:00:00.000Z'),
+    event: 'pull_request:synchronize',
+    status: 'accepted',
+    agentId: AgentId(agentId),
+    configRevision: hook.configRevision,
+    dispatchRevision: hook.dispatchRevision,
+    dispatchDaemonId: DaemonId(dispatchDaemonId),
+    reviewPolicySnapshot: hook.reviewPolicy,
+    reportingModeSnapshot: hook.reportingMode,
+    gateModeSnapshot: hook.gateMode,
+    projectionIntent: 'revision_event',
+    repoId: hook.repoId ?? undefined,
+    repoFullName: hook.repoFullName ?? undefined,
+    sourceInstallationId: 44n,
+    subjectKind: 'pull_request',
+    pullNumber: 42,
+    headSha: HEAD_SHA,
+    baseSha: BASE_SHA,
+    reportSha: HEAD_SHA,
+    isDraft: false,
+    baseChanged: false
+  })
+}
+
+/** Dispatch a hand-built `hook/report` completion REQ through the real handler. */
+async function report(
+  daemonId: string,
+  hookId: string,
+  agentId: string,
+  deliveryKey: string,
+  outcome: Omit<HookReport, 'hookId' | 'agentId' | 'deliveryKey'>
+) {
+  const frame = {
+    v: 1,
+    id: randomUUID(),
+    ts: new Date().toISOString(),
+    type: 'hook/report',
+    payload: { hookId, agentId, deliveryKey, ...outcome }
+  } as AnyFrame
+  const deps = { hook: repo(), clock: systemClock } as unknown as DaemonWsDeps
+  const conn = { daemonId, replyTo: vi.fn(), sendError: vi.fn() }
+  await handleHookReport(frame, conn as unknown as DaemonConnection, deps)
+  return { frame, conn }
+}
+
+function broker() {
+  const github = {
+    mintReviewForAgent: vi.fn(async () => ({
+      token: 'broker-secret',
+      ttlSec: 3_540,
+      expiresAt: '2026-08-15T10:00:00.000Z',
+      repoFullName: 'acme/infra',
+      access: 'read' as const,
+      installationId: 44n
+    })),
+    validateReviewForAgent: vi.fn(async () => ({ installation: { installationId: 44n } }) as never)
+  }
+  const service = new GithubReviewBrokerService({
+    hook: repo(),
+    agent: new PgAgentRepo(prisma),
+    github,
+    clock: systemClock,
+    placement: placement()
+  })
+  return { service, github }
+}
+
+function startInput(
+  hookId: string,
+  agentId: string,
+  deliveryKey: string,
+  dispatchDaemonId: string,
+  hook: {
+    configRevision: bigint | null
+    dispatchRevision: bigint | null
+  }
+) {
+  return {
+    hookId,
+    agentId,
+    deliveryKey,
+    sessionId: 'ses_pool',
+    event: 'pull_request:synchronize' as const,
+    configRevision: hook.configRevision!.toString(),
+    dispatchRevision: hook.dispatchRevision!.toString(),
+    dispatchDaemonId,
+    reviewPolicy: 'full' as const,
+    reportingMode: 'check' as const,
+    gateMode: 'informational' as const,
+    github: {
+      repoId: '987654321',
+      repoFullName: 'acme/infra',
+      sourceInstallationId: '44',
+      subjectKind: 'pull_request' as const,
+      pullNumber: 42,
+      headSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+      reportSha: HEAD_SHA,
+      isDraft: false,
+      baseChanged: false
+    }
+  }
+}
+
+describe('hook dispatch authority follows the placement resolver', () => {
+  it('accepts a pool agent delivery + completion from the member holding its duty', async () => {
+    const { agentId, hookId } = await pooledGithubHook()
+
+    expect(await acceptDelivery(hookId, agentId, 'pool-1', HOLDER)).toBe(true)
+    const opened = await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId))
+    expect(opened).toHaveLength(1)
+    expect(opened[0]).toMatchObject({ status: 'running', dispatchDaemonId: HOLDER })
+
+    const completion = await report(HOLDER, hookId, agentId, 'pool-1', {
+      status: 'success',
+      durationMs: 4200,
+      sessionId: 'ses_pool'
+    })
+    expect(completion.conn.sendError).not.toHaveBeenCalled()
+    expect(completion.conn.replyTo).toHaveBeenCalledWith(completion.frame, 'ack', { ok: true })
+    const closed = await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId))
+    expect(closed[0]).toMatchObject({ status: 'success', durationMs: 4200, sessionId: 'ses_pool' })
+  })
+
+  it('refuses a delivery addressed at a member that holds no duty for the pool agent', async () => {
+    const { agentId, hookId } = await pooledGithubHook()
+    await poolMember(PEER)
+
+    expect(await acceptDelivery(hookId, agentId, 'pool-2', PEER)).toBe(false)
+    expect(await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId))).toHaveLength(0)
+  })
+
+  it('refuses a completion from a member that does not serve the pool agent', async () => {
+    const { agentId, hookId } = await pooledGithubHook()
+    await poolMember(PEER)
+    expect(await acceptDelivery(hookId, agentId, 'pool-3', HOLDER)).toBe(true)
+
+    const foreign = await report(PEER, hookId, agentId, 'pool-3', { status: 'success', durationMs: 10 })
+    expect(foreign.conn.sendError).toHaveBeenCalledWith(
+      foreign.frame.id,
+      'CONFLICT',
+      'hook completion does not match the accepted dispatch',
+      false
+    )
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]).toMatchObject({ status: 'running' })
+  })
+
+  it('keeps the machine placement working with no duty lease in play', async () => {
+    const { agentId, hookId } = await machineGithubHook()
+
+    expect(await acceptDelivery(hookId, agentId, 'machine-1', MACHINE)).toBe(true)
+    const completion = await report(MACHINE, hookId, agentId, 'machine-1', { status: 'success', durationMs: 11 })
+    expect(completion.conn.replyTo).toHaveBeenCalledWith(completion.frame, 'ack', { ok: true })
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]).toMatchObject({ status: 'success' })
+  })
+
+  it('captures the duty holder as the redelivery dispatch target for a pool agent', async () => {
+    const { agentId, hookId } = await pooledGithubHook()
+    const hook = (await repo().getUnscoped(HookId(hookId)))!
+    const firedAt = new Date('2026-08-15T09:00:00.000Z')
+    await repo().recordDelivery(HookId(hookId), {
+      deliveryKey: 'pool-offline',
+      firedAt,
+      event: 'pull_request:synchronize',
+      status: 'failed',
+      reason: 'daemon_offline',
+      agentId: AgentId(agentId),
+      configRevision: hook.configRevision,
+      dispatchRevision: hook.dispatchRevision,
+      dispatchDaemonId: DaemonId(HOLDER),
+      reviewPolicySnapshot: hook.reviewPolicy,
+      reportingModeSnapshot: hook.reportingMode,
+      gateModeSnapshot: hook.gateMode,
+      projectionIntent: 'revision_event',
+      repoId: hook.repoId ?? undefined,
+      repoFullName: hook.repoFullName ?? undefined,
+      sourceInstallationId: 44n,
+      subjectKind: 'pull_request',
+      pullNumber: 42,
+      headSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+      reportSha: HEAD_SHA,
+      isDraft: false,
+      baseChanged: false
+    })
+
+    expect(await repo().claimRetryableDeliveryRedelivery('pool-offline', [HookId(hookId)], firedAt, [30_000])).toBe(
+      true
+    )
+    const run = await repo().getRun(HookId(hookId), 'pool-offline')
+    expect(run).toMatchObject({ dispatchDaemonId: HOLDER, redeliveryAttempts: 1 })
+  })
+})
+
+describe('review broker authority follows the placement resolver', () => {
+  it('starts and authorizes a review for the member holding the pool agent duty', async () => {
+    const { agentId, hookId } = await pooledGithubHook()
+    expect(await acceptDelivery(hookId, agentId, 'review-1', HOLDER)).toBe(true)
+    const hook = (await repo().getUnscoped(HookId(hookId)))!
+    const { service, github } = broker()
+
+    await service.start(startInput(hookId, agentId, 'review-1', HOLDER, hook), DaemonId(HOLDER))
+    expect((await repo().getRun(HookId(hookId), 'review-1'))!.turnStartedAt).not.toBeNull()
+
+    const authorized = await service.authorize(
+      {
+        hookId,
+        deliveryKey: 'review-1',
+        attemptId: randomUUID(),
+        requestedEvent: 'APPROVE',
+        requestedVerdict: 'pass',
+        snapshot: {
+          configRevision: hook.configRevision!.toString(),
+          dispatchRevision: hook.dispatchRevision!.toString(),
+          dispatchDaemonId: HOLDER,
+          reviewPolicy: 'full',
+          reportingMode: 'check',
+          gateMode: 'informational'
+        }
+      },
+      DaemonId(HOLDER)
+    )
+    expect(authorized).toMatchObject({ token: 'broker-secret', pullNumber: 42, expectedHeadSha: HEAD_SHA })
+    expect(github.mintReviewForAgent).toHaveBeenCalledOnce()
+  })
+
+  it('denies hook/start from a member that holds no duty for the pool agent', async () => {
+    const { agentId, hookId } = await pooledGithubHook()
+    await poolMember(PEER)
+    expect(await acceptDelivery(hookId, agentId, 'review-2', HOLDER)).toBe(true)
+    const hook = (await repo().getUnscoped(HookId(hookId)))!
+
+    await expect(
+      broker().service.start(startInput(hookId, agentId, 'review-2', PEER, hook), DaemonId(PEER))
+    ).rejects.toThrow()
+  })
+
+  it('keeps the machine placement start path working', async () => {
+    const { agentId, hookId } = await machineGithubHook()
+    expect(await acceptDelivery(hookId, agentId, 'review-3', MACHINE)).toBe(true)
+    const hook = (await repo().getUnscoped(HookId(hookId)))!
+
+    await broker().service.start(startInput(hookId, agentId, 'review-3', MACHINE, hook), DaemonId(MACHINE))
+    expect((await repo().getRun(HookId(hookId), 'review-3'))!.turnStartedAt).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Hook dispatch was converted to `PlacementResolver`, but every acceptance fence behind it still
compared `agent.daemonId`. A `set`-placed agent names no machine, so that column is null and the
comparison could never hold — GitHub hooks and PR review were **permanently** dead for those
agents, not degraded across a rollout.

Authority is now the seam the organization reads already use (#1004): placement plus the duty
leases a member currently holds. Nothing in the hook or review path reads a placement kind.

## Failure scenario

A GitHub webhook fires for a set-placed agent. The relay addresses the current duty holder, the
holder runs the turn and reports back with `dispatchDaemonId = <its own id>`. The control plane
compares that against `agent.daemonId = NULL`:

- the relay's accepted `rc/run-report` is refused, so no run row ever opens;
- `hook/start` comes back `SCOPE_DENIED`, which is non-retryable, so nothing retries;
- the review broker denies `start` and every `authorize` checkpoint;
- a manual GitHub redelivery is never admitted, and its captured dispatch target
  (`current.agent.daemonId`) is null anyway.

## Fix

**`PgHookRepo`** takes the resolver and resolves one dispatch authority per fenced write —
`{ agentId, ref, serving }` — **before** the transaction opens. That ordering is deliberate: the
duty ledger is a second query, and asking it while holding a transaction would trade a pooled
connection for a lock. Each fence then asks `servedBy(authority, <agent the transaction just read>,
candidate)`, so the hook's agent is re-read under the transaction and a pre-read cannot widen
authority. Replaced fences: the failed-delivery reopen and the accepted-delivery tuple in
`recordDeliveryResult`, the claimed-offline recovery in `recordStart`, the completion-first
recovery / claimed-offline recovery / legacy fallback in `recordReport`, and the per-hook authority
check in `claimRetryableDeliveryRedelivery`. Two of those were Prisma joins on
`agent: { daemonId }`; they are now plain `id` lookups with the fence applied in code, because the
predicate is not expressible in SQL.

The redelivery claim also **captures the routable member** as the run's dispatch target instead of
the placement column — the same member the compiled relay rule names — and refuses the claim when
nothing is routable, exactly as an unplaced agent's would be.

**`GithubReviewBrokerService`** asks `PlacementResolver.mayAct` in `start` and at each of the three
`authorize` checkpoints. The three checkpoints collapsed into one `requireLiveActionAuthority`
helper so the hook/agent re-read and the fence stay in one place. Fences on the *persisted* accepted
tuple (`run.dispatchDaemonId`) are untouched: they compare a durable snapshot against the report,
not placement, and they must stay exact.

**`container.ts`** wires the resolver into both. Both consumers default to `PLACEMENT_ONLY`, which
is exactly the pre-duty behavior for a deployment with no member set.

## Test plan

New `test/integration/hooks-pool-placement.test.ts` (8 tests) drives the real repo, the real
`hook/report` handler and the real broker over a real duty ledger — an org-less member enrolled in
the org-less set, a `set`-placed agent, a live confirmed lease:

- accepted delivery + completion from the member holding the duty (the issue's scenario);
- a delivery addressed at a member holding no duty is refused;
- a completion from a non-serving member is refused with `CONFLICT`;
- the redelivery claim captures the duty holder as the dispatch target;
- broker `start` + `authorize` succeed for the holder and `start` is denied for a peer;
- machine-placed regressions for both the report path and the broker start path.

### Mutation

Dropping the resolver from the test's repo/broker construction (i.e. back to placement-only):
**5 failed / 3 passed** — exactly the pool cases. The three survivors are the two machine-placement
regressions plus the negative case that is trivially true without a ledger. Reverted.

### Gates

`pnpm --filter @agentconnect.md/control-plane typecheck`, `test:unit` (1672 passed), `test:int`
(88 files / 1322 passed), `pnpm lint`, `pnpm format:check` — all green.

Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
