### PR TITLE
fix(relay): take the activation rendezvous for platform interactions too

### DIFF
--- a/packages/relay/src/platforms/contract.ts
+++ b/packages/relay/src/platforms/contract.ts
@@ -122,7 +122,11 @@ export interface RelayIngressHost {
    *  parsed action semantics); core owns the dedup table on the daemon side.
    *  `route` is the target the plugin resolved through the directory — the
    *  three directory lookups are three distinct trust models, so delivery must
-   *  not re-resolve and silently substitute a different one. */
+   *  not re-resolve and silently substitute a different one. Core still honours
+   *  the activation rendezvous on top of that route: a recorded member that has
+   *  since handed the duty on answers `not_holder`, and the SAME frame is
+   *  re-sent once to the member it names, so the ack returned here is the true
+   *  holder's verdict (including its `response` body). */
   forwardAction(msg: RdMsgPlatformAction, route: RouteTarget): Promise<RdAck>
   /** Report the bot's channel-membership snapshot (queued while the CP link is
    *  down; a newer snapshot supersedes). */

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -2335,4 +2335,52 @@ describe('RelayIngressManager — activation rendezvous', () => {
     expect(ack?.accepted).toBe(true)
     expect(holderSend).not.toHaveBeenCalled()
   })
+
+  it('a button clicked after the duty moved re-routes and answers with the holder’s verdict', async () => {
+    // The recorded member is still connected — it just handed the duty on between the
+    // projection that addressed the button and the click.
+    const staleSend = vi.fn(async (m: RdMsgPlatformAction): Promise<RdAck> => ({
+      msgId: m.msgId,
+      accepted: false,
+      reason: RD_ACK_NOT_HOLDER,
+      holderDaemonId: HOLDER_ID
+    }))
+    const response = { toast: { type: 'info' as const, content: 'Cancellation requested.' } }
+    const holderSend = vi.fn(async (m: RdMsgPlatformAction): Promise<RdAck> => ({
+      msgId: m.msgId,
+      accepted: true,
+      response
+    }))
+    const manager = new RelayIngressManager(
+      deps({
+        getDaemon: (id) =>
+          ({ [DAEMON_ID]: { sendMsg: staleSend }, [HOLDER_ID]: { sendMsg: holderSend } })[id] as unknown as
+            RelayDaemonConnection | undefined
+      })
+    )
+    const rd: RdMsgPlatformAction = {
+      source: 'platform_action',
+      platformId: 'slack',
+      agentId: AGENT_ID,
+      integrationId: INTEGRATION_ID,
+      sessionKey: SESSION_KEY,
+      msgId: 'slack-action:cancel',
+      botId: BOT_ID,
+      payload: { kind: 'cancel' }
+    }
+    const ack = await internalsOf(manager).ingressHost.forwardAction(rd, {
+      agentId: AGENT_ID,
+      daemonId: DAEMON_ID,
+      integrationId: INTEGRATION_ID
+    })
+
+    // The SAME frame, msgId included — the holder's own dedup is what protects a
+    // double-clicked button once the interaction lands twice.
+    expect(holderSend).toHaveBeenCalledTimes(1)
+    expect(holderSend).toHaveBeenCalledWith(rd)
+    // The plugin's synchronous answer (a Feishu toast, a Slack modal) is the true
+    // holder's, not the refusal that used to reach it.
+    expect(ack).toEqual({ msgId: rd.msgId, accepted: true, response })
+    expect(dropCount(manager)).toBe(0)
+  })
 })

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -171,12 +171,19 @@ export class RelayIngressManager {
     return {
       forward: (botId, message) => this.forward(botId, message),
       forwardAction: async (msg, route) => {
+        // An interaction is as pre-addressed as an `rd/msg` and its recorded member is
+        // as likely to have handed the duty on, so it takes the SAME rendezvous path:
+        // one `not_holder` re-route, and a refusal counted as the drop it is.
+        const context = `relay-ingress(${msg.botId}) interaction`
         const daemon = this.deps.getDaemon(route.daemonId)
         if (!daemon) {
-          this.deps.log.warn(`relay-ingress(${msg.botId}): daemon ${route.daemonId} offline — interaction dropped`)
-          return { msgId: msg.msgId, accepted: false, reason: 'offline' }
+          return this.dropUnrouted(msg.botId, `${context}: daemon ${route.daemonId} is not on this relay`, {
+            msgId: msg.msgId,
+            accepted: false,
+            reason: 'offline'
+          })
         }
-        return daemon.sendMsg(msg)
+        return this.sendWithRendezvous(daemon, msg, msg.botId, context)
       },
       reportChannels: (snapshot) => this.reportChannels(snapshot),
       reportRevoked: (botId, reason, eventAtMs, credentialRevision) => {
@@ -631,6 +638,10 @@ export class RelayIngressManager {
    * against a double delivery, and a second refusal terminates rather than
    * chasing a stale ledger.
    *
+   * Messages AND platform interactions ride it: both are addressed from the same
+   * routing projection, so a button click goes stale exactly the way an
+   * un-mentioned follow-up does.
+   *
    * A refusal this cannot resolve — no holder named, the holder not connected
    * to THIS relay, or the redirect target refusing in turn — is a genuinely
    * dropped trigger, counted like any other drop. There is deliberately no
@@ -644,7 +655,7 @@ export class RelayIngressManager {
     rd: RdMsg,
     botId: string,
     context: string
-  ): Promise<RdAck | undefined> {
+  ): Promise<RdAck> {
     const ack = await daemon.sendMsg(rd)
     if (ack.accepted || ack.reason !== RD_ACK_NOT_HOLDER) return ack
     const holderId = ack.holderDaemonId


### PR DESCRIPTION
Fixes #1040.

## What was wrong

`sendWithRendezvous` is what makes a pre-addressed trigger survive a duty move: a member that does not hold the agent answers `not_holder` naming the holder, and the trigger is re-sent there once. Both IM paths use it. `ingressHost.forwardAction` did not — it sent straight to `route.daemonId` and returned whatever came back.

`route.daemonId` is the identity the routing projection last recorded, so a status-modal button or a Feishu card action clicked after a rollout or a ledger rebalance had two ways to fail, both silent:

- the recorded member is gone — `getDaemon` returns undefined and the interaction was dropped behind a warn line that did not even reach the drop counter;
- the recorded member is alive but no longer holds the duty — it answers `not_holder` naming the true holder, and the caller only logged `daemon rejected session action`. The named holder was never tried.

Nothing retries either arm: HTTP ingress acknowledged and deduplicated the provider callback long before the ack came back. So after every rollout there was a window in which interactive controls on existing messages stopped working while ordinary messages to the same agent routed fine.

## The change

`forwardAction` now goes through `sendWithRendezvous`, which is the issue's own smallest correct fix:

- one hop. The same frame — msgId included — is re-sent to the named holder, so the holder's own dedup still covers a double-clicked button, and a second refusal terminates rather than chasing a stale ledger.
- the ack the plugin answers the platform with is the true holder's, `response` body and all. That matters for the two synchronous paths: a Feishu card toast and a Slack modal now carry the holder's verdict instead of the refusal.
- honest drop accounting. A refusal the rendezvous cannot place — no holder named, the holder not on this relay, the redirect target refusing in turn, or the recorded member not connected here at all — lands in the per-bot drop counter like any other unrouted trigger, instead of being logged and forgotten.

`sendWithRendezvous`'s return type drops the `| undefined` it never produced, so `forwardAction` can return it directly.

Nothing changes on the wire: the daemon already answers `not_holder` for `platform_action` (the claim runs before the source switch in `handleRelayMsg`), and `RdAck.holderDaemonId` already carries the redirect target.

`canDeliver` is deliberately unchanged. It cannot pre-flight a rendezvous synchronously, and its one caller — the Slack message shortcut, whose trigger id is one-shot — already does the right thing when the recorded member is gone: it returns false and the plugin opens the local unavailable modal while the trigger is still valid.

## Not changed

The webhook hook dispatch path (`hooks/ingress.ts`) still sends without a rendezvous. It has its own connection-retry loop and reports a rejection upstream as a delivery status, so it is a different shape from this one and out of scope for #1040.

## Tests

Added `a button clicked after the duty moved re-routes and answers with the holder's verdict` to the activation-rendezvous suite: a `platform_action` frame whose recorded member is connected but answers `not_holder`, asserting the identical frame reaches the named holder exactly once, that the caller gets the holder's ack including its `response` body, and that no drop is counted. It fails on `main` (`holderSend` called 0 times) and passes here.

Relay suite green — 485 tests, 26 files. `typecheck`, `pnpm lint`, `pnpm format:check` all clean.

---
_Generated by [Claude Code](
