### PR TITLE
fix(daemon): compensate the cron and dream fires a duty handover swallows

### DIFF
--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -465,8 +465,16 @@ definition never covered, and a disable/re-enable would owe every moment inside
 the disabled window. A catch-up is eligible only when the stored fingerprint
 equals the active one, and the reconcile that arms the schedules retires a stamp
 whose definition has moved — re-stamping NOW, so the new definition starts clean.
-A row written before the fingerprint existed carries NULL and is simply
-ineligible until its next real fire.
+A schedule that is GONE has its row dropped instead: ids are re-mintable, so a
+recreated one must start from no evidence rather than inherit the deleted
+schedule's last run. A row written before the fingerprint existed carries NULL
+and is simply ineligible until its next real fire.
+
+Only the holder writes those rows. They are shared by the whole pool, so a
+member that arms nothing for an agent reconciles nothing for it either — a stale
+non-holder re-stamping under its own view of the definitions would erase the very
+gap the holder is there to compensate. The check is at the write, not only at its
+caller.
 
 **The lease is what fixes the offline-cron hole, not a new trigger path.** A
 cron whose owning daemon is offline simply does not fire today, and nothing

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -447,6 +447,16 @@ the holder is already the agent's home, so the wake is §8 with no routing step
 at all. `CronDef.lastRunAt` keeps its advisory, daemon-authoritative
 semantics; the dream scheduler is scoped identically.
 
+**The handover window is compensated, not ignored.** A schedule is armed only
+while its holder holds the duty, and a freshly constructed `croner` job knows
+nothing of a moment that has already passed — so a fire landing between the old
+holder unregistering and the new one arming used to run nowhere, silently, on
+every rollout. On GAINING an agent, a member now replays the one occurrence its
+stamp says ran nowhere: the newest missed moment only (never a backlog), inside
+a grace window of one interval capped at an hour, and taken by a CAS on the
+stamp row so two members racing the same handoff fire it once. `cron_runs` is
+what that stamp was declared for; `dream_runs` is its dream twin.
+
 **The lease is what fixes the offline-cron hole, not a new trigger path.** A
 cron whose owning daemon is offline simply does not fire today, and nothing
 notices; under the ledger, a dead holder's group goes vacant at T_reassign, a

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -457,6 +457,17 @@ a grace window of one interval capped at an hour, and taken by a CAS on the
 stamp row so two members racing the same handoff fire it once. `cron_runs` is
 what that stamp was declared for; `dream_runs` is its dream twin.
 
+A stamp is only evidence about the definition it was written under, so both rows
+carry a `definition` fingerprint (expression + timezone + enabled) alongside the
+timestamp. Schedules are edited in place: "daily, last fired 03:00" then
+"switched to hourly at 12:30" would otherwise owe a 12:00 fire the hourly
+definition never covered, and a disable/re-enable would owe every moment inside
+the disabled window. A catch-up is eligible only when the stored fingerprint
+equals the active one, and the reconcile that arms the schedules retires a stamp
+whose definition has moved — re-stamping NOW, so the new definition starts clean.
+A row written before the fingerprint existed carries NULL and is simply
+ineligible until its next real fire.
+
 **The lease is what fixes the offline-cron hole, not a new trigger path.** A
 cron whose owning daemon is offline simply does not fire today, and nothing
 notices; under the ledger, a dead holder's group goes vacant at T_reassign, a

--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -478,6 +478,12 @@ to run once dreaming has usage data.
   tick landing while a dream is in flight is skipped, never queued. Each fire
   also obeys the agent lifecycle gates (pause, safety-drain, per-agent drain,
   daemon drain) — as skips, so the schedule resumes by itself on unpause.
+  Every tick stamps its occurrence in the shared store's `dream_runs` (the dream
+  twin of `cron_runs`) BEFORE those gates, so the stamp records that the moment
+  was serviced here rather than that a dream ran. On gaining an agent's duty a
+  member compensates the one occurrence a handover swallowed — the newest missed
+  moment only, inside a grace window of one interval capped at an hour, claimed
+  by a CAS on the stamp so two members racing a handoff dream once.
 - **Idle-triggered (later)** — "N hours since the last consolidation and the
   agent has been active since" fits the daemon (it already tracks per-agent
   activity), as a follow-up once scheduled dreams are proven.

--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -483,7 +483,11 @@ to run once dreaming has usage data.
   was serviced here rather than that a dream ran. On gaining an agent's duty a
   member compensates the one occurrence a handover swallowed — the newest missed
   moment only, inside a grace window of one interval capped at an hour, claimed
-  by a CAS on the stamp so two members racing a handoff dream once.
+  by a CAS on the stamp so two members racing a handoff dream once. The row also
+  fingerprints the policy fields that define the schedule (enabled + expression +
+  timezone), because a mutable policy makes a bare stamp meaningless: a catch-up
+  is eligible only under the same definition, and a reconcile that sees a moved
+  one retires the stamp so the new policy starts clean.
 - **Idle-triggered (later)** — "N hours since the last consolidation and the
   agent has been active since" fits the daemon (it already tracks per-agent
   activity), as a follow-up once scheduled dreams are proven.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -254,7 +254,7 @@ import {
   type DiscordComponents
 } from './discord/render.js'
 import { FeishuConverger, type FeishuAction } from './feishu/render.js'
-import { Scheduler, buildSyntheticMessage } from './scheduler/scheduler.js'
+import { Scheduler, buildSyntheticMessage, missedOccurrence } from './scheduler/scheduler.js'
 import { DreamScheduler } from './scheduler/dream-scheduler.js'
 import { planChannelIntros, buildIntroMessage } from './agents/channel-intro.js'
 import { buildHookMessage, githubOpensReviewGeneration, hookAnchorText } from './messages/hook-message.js'
@@ -12972,6 +12972,8 @@ export class Daemon {
     // heartbeat. Outside the duty gate below on purpose: the CP acts on the digest either way.
     this.cpClient?.reportDutiesNow()
     this.onDutyChanged()
+    // After the arm, so a catch-up runs against the schedules this member now actually holds.
+    this.catchUpMissedSchedules(result.agentsGained)
   }
 
   /**
@@ -13296,6 +13298,42 @@ export class Daemon {
     const serve = this.servesAgent(a.id)
     this.scheduler.sync(a.id, serve ? a.crons : [])
     this.dreamScheduler.sync(a.id, serve ? this.dreamSchedulePolicyFor(a) : undefined)
+  }
+
+  /**
+   * Compensate the fires a duty handover swallowed (#1031). The old holder unregisters an agent's
+   * schedules before the moment and the new holder arms a `Cron` that knows nothing of a moment
+   * already passed, so a cron or dream inside the window runs NOWHERE — no error, no late run, no
+   * log line. On gaining an agent this replays at most ONE occurrence per schedule (the newest
+   * missed moment, inside its grace window — never a backlog), and every fire is a CAS claim on the
+   * shared stamp, so two members racing the same handoff compensate it exactly once.
+   */
+  private catchUpMissedSchedules(agentIds: string[]): void {
+    const now = this.clock.now()
+    for (const agentId of agentIds) {
+      // Gained, then withdrawn again inside the same settle: the fire belongs to whoever holds it.
+      if (!this.servesAgent(agentId)) continue
+      const agent = this.agents.get(agentId)
+      if (!agent) continue
+      for (const cron of agent.crons) {
+        if (cron.enabled === false) continue
+        const key = `${agentId}:${cron.id}`
+        const due = missedOccurrence(cron.schedule, cron.timezone, this.store.getCronLastRun(key), now)
+        if (due === undefined || !this.store.claimCronCatchUp(key, due, now)) continue
+        this.log.info(`cron "${cron.id}" of agent "${agentId}": firing the occurrence a duty handover missed`)
+        const { msg } = buildSyntheticMessage(agentId, cron, randomUUID())
+        void this.onCronFire(agentId, msg, cron).catch((err) =>
+          this.log.error(`cron catch-up dispatch failed for agent "${agentId}": ${formatErr(err)}`)
+        )
+      }
+      const dreaming = this.dreamSchedulePolicyFor(agent)
+      if (!dreaming?.enabled || !dreaming.schedule) continue
+      const stamp = this.store.getDreamLastRun(agentId)
+      const dueDream = missedOccurrence(dreaming.schedule, dreaming.timezone, stamp, now)
+      if (dueDream === undefined || !this.store.claimDreamCatchUp(agentId, dueDream, now)) continue
+      this.log.info(`dream schedule of agent "${agentId}": firing the occurrence a duty handover missed`)
+      this.onDreamScheduleFire(agentId)
+    }
   }
 
   /** Stop serving one agent because its duty moved — the light teardown: no
@@ -21746,6 +21784,8 @@ export class Daemon {
    * between the reconcile and the tick simply does nothing.
    */
   private onDreamScheduleFire(agentId: string): void {
+    // Stamped before the gates, as a cron fire stamps cron_runs: this moment was SERVICED here (#1031).
+    this.store.setDreamLastRun(agentId, this.clock.now())
     // Lifecycle gates first — a scheduled dream is background work that spawns a
     // runtime host and burns model tokens, so it obeys the same operator stops as
     // any other scheduled trigger. The cron stays REGISTERED throughout: these are

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13304,7 +13304,8 @@ export class Daemon {
     const serve = this.servesAgent(a.id)
     this.scheduler.sync(a.id, serve ? a.crons : [])
     this.dreamScheduler.sync(a.id, serve ? this.dreamSchedulePolicyFor(a) : undefined)
-    this.reconcileScheduleStamps(a)
+    // An unserved replica only disarms its own jobs — the stamps are the holder's to write.
+    if (serve) this.reconcileScheduleStamps(a)
   }
 
   /** The definition a cron entry fires under — an entry with no explicit `enabled` is enabled. */
@@ -13320,19 +13321,31 @@ export class Daemon {
     return { schedule, timezone: policy?.timezone, enabled: policy?.enabled === true && schedule !== '' }
   }
 
-  /** Retire a stamp whose definition has moved on (#1031). A stamp proves a fire of the definition
-   *  it was written under, so an edited expression, a changed timezone, or a disable/re-enable makes
-   *  the recorded moment meaningless — re-stamp NOW under the new definition, and the new definition
-   *  starts clean instead of inheriting a catch-up for a moment it never covered. Only an existing
-   *  row is reset: writing one would fabricate a fire that never happened. */
+  /**
+   * Retire a stamp whose definition has moved on (#1031). A stamp proves a fire of the definition it
+   * was written under, so an edited expression, a changed timezone, or a disable/re-enable makes the
+   * recorded moment meaningless — re-stamp NOW under the new definition, and the new definition
+   * starts clean instead of inheriting a catch-up for a moment it never covered. A cron that is GONE
+   * gets its row dropped rather than re-stamped: ids are re-mintable, and a recreated one must start
+   * from no evidence at all. Only an existing row is ever rewritten — writing one would fabricate a
+   * fire that never happened.
+   *
+   * Ownership is re-checked here rather than trusted from the caller: these rows are shared by the
+   * whole pool, so a member that does not serve the agent must never overwrite the holder's evidence
+   * with its own, possibly stale, view of the definitions.
+   */
   private reconcileScheduleStamps(a: { id: string; crons: CronDef[]; memory?: Agent['memory'] }): void {
+    if (!this.servesAgent(a.id)) return
     const now = this.clock.now()
+    const active = new Set(a.crons.map((cron) => `${a.id}:${cron.id}`))
+    for (const key of this.store.cronRunKeys(a.id)) if (!active.has(key)) this.store.deleteCronRun(key)
     for (const cron of a.crons) {
       const key = `${a.id}:${cron.id}`
       const fingerprint = scheduleFingerprint(this.cronDefinition(cron))
       const run = this.store.cronRun(key)
       if (run && run.definition !== fingerprint) this.store.setCronLastRun(key, now, fingerprint)
     }
+    // A removed dreaming policy is "unscheduled", a fingerprint no live policy ever matches.
     const dream = scheduleFingerprint(this.dreamDefinition(a))
     const dreamRun = this.store.dreamRun(a.id)
     if (dreamRun && dreamRun.definition !== dream) this.store.setDreamLastRun(a.id, now, dream)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -254,7 +254,13 @@ import {
   type DiscordComponents
 } from './discord/render.js'
 import { FeishuConverger, type FeishuAction } from './feishu/render.js'
-import { Scheduler, buildSyntheticMessage, missedOccurrence } from './scheduler/scheduler.js'
+import {
+  Scheduler,
+  buildSyntheticMessage,
+  missedOccurrence,
+  scheduleFingerprint,
+  type ScheduleDefinition
+} from './scheduler/scheduler.js'
 import { DreamScheduler } from './scheduler/dream-scheduler.js'
 import { planChannelIntros, buildIntroMessage } from './agents/channel-intro.js'
 import { buildHookMessage, githubOpensReviewGeneration, hookAnchorText } from './messages/hook-message.js'
@@ -13298,6 +13304,38 @@ export class Daemon {
     const serve = this.servesAgent(a.id)
     this.scheduler.sync(a.id, serve ? a.crons : [])
     this.dreamScheduler.sync(a.id, serve ? this.dreamSchedulePolicyFor(a) : undefined)
+    this.reconcileScheduleStamps(a)
+  }
+
+  /** The definition a cron entry fires under — an entry with no explicit `enabled` is enabled. */
+  private cronDefinition(cron: CronDef): ScheduleDefinition {
+    return { schedule: cron.schedule, timezone: cron.timezone, enabled: cron.enabled !== false }
+  }
+
+  /** The definition an agent's dream schedule fires under; an absent or scheduleless policy is
+   *  "unscheduled", which is itself a definition a later re-enable must differ from. */
+  private dreamDefinition(a: { memory?: Agent['memory'] }): ScheduleDefinition {
+    const policy = this.dreamSchedulePolicyFor(a)
+    const schedule = policy?.schedule ?? ''
+    return { schedule, timezone: policy?.timezone, enabled: policy?.enabled === true && schedule !== '' }
+  }
+
+  /** Retire a stamp whose definition has moved on (#1031). A stamp proves a fire of the definition
+   *  it was written under, so an edited expression, a changed timezone, or a disable/re-enable makes
+   *  the recorded moment meaningless — re-stamp NOW under the new definition, and the new definition
+   *  starts clean instead of inheriting a catch-up for a moment it never covered. Only an existing
+   *  row is reset: writing one would fabricate a fire that never happened. */
+  private reconcileScheduleStamps(a: { id: string; crons: CronDef[]; memory?: Agent['memory'] }): void {
+    const now = this.clock.now()
+    for (const cron of a.crons) {
+      const key = `${a.id}:${cron.id}`
+      const fingerprint = scheduleFingerprint(this.cronDefinition(cron))
+      const run = this.store.cronRun(key)
+      if (run && run.definition !== fingerprint) this.store.setCronLastRun(key, now, fingerprint)
+    }
+    const dream = scheduleFingerprint(this.dreamDefinition(a))
+    const dreamRun = this.store.dreamRun(a.id)
+    if (dreamRun && dreamRun.definition !== dream) this.store.setDreamLastRun(a.id, now, dream)
   }
 
   /**
@@ -13316,21 +13354,21 @@ export class Daemon {
       const agent = this.agents.get(agentId)
       if (!agent) continue
       for (const cron of agent.crons) {
-        if (cron.enabled === false) continue
         const key = `${agentId}:${cron.id}`
-        const due = missedOccurrence(cron.schedule, cron.timezone, this.store.getCronLastRun(key), now)
-        if (due === undefined || !this.store.claimCronCatchUp(key, due, now)) continue
+        const definition = this.cronDefinition(cron)
+        const fingerprint = scheduleFingerprint(definition)
+        const due = missedOccurrence(definition, this.store.cronRun(key), now)
+        if (due === undefined || !this.store.claimCronCatchUp(key, due, now, fingerprint)) continue
         this.log.info(`cron "${cron.id}" of agent "${agentId}": firing the occurrence a duty handover missed`)
         const { msg } = buildSyntheticMessage(agentId, cron, randomUUID())
         void this.onCronFire(agentId, msg, cron).catch((err) =>
           this.log.error(`cron catch-up dispatch failed for agent "${agentId}": ${formatErr(err)}`)
         )
       }
-      const dreaming = this.dreamSchedulePolicyFor(agent)
-      if (!dreaming?.enabled || !dreaming.schedule) continue
-      const stamp = this.store.getDreamLastRun(agentId)
-      const dueDream = missedOccurrence(dreaming.schedule, dreaming.timezone, stamp, now)
-      if (dueDream === undefined || !this.store.claimDreamCatchUp(agentId, dueDream, now)) continue
+      const dream = this.dreamDefinition(agent)
+      const dueDream = missedOccurrence(dream, this.store.dreamRun(agentId), now)
+      if (dueDream === undefined || !this.store.claimDreamCatchUp(agentId, dueDream, now, scheduleFingerprint(dream)))
+        continue
       this.log.info(`dream schedule of agent "${agentId}": firing the occurrence a duty handover missed`)
       this.onDreamScheduleFire(agentId)
     }
@@ -21785,7 +21823,11 @@ export class Daemon {
    */
   private onDreamScheduleFire(agentId: string): void {
     // Stamped before the gates, as a cron fire stamps cron_runs: this moment was SERVICED here (#1031).
-    this.store.setDreamLastRun(agentId, this.clock.now())
+    this.store.setDreamLastRun(
+      agentId,
+      this.clock.now(),
+      scheduleFingerprint(this.dreamDefinition(this.agents.get(agentId) ?? {}))
+    )
     // Lifecycle gates first — a scheduled dream is background work that spawns a
     // runtime host and burns model tokens, so it obeys the same operator stops as
     // any other scheduled trigger. The cron stays REGISTERED throughout: these are
@@ -21841,7 +21883,7 @@ export class Daemon {
       if (cron.origin === 'cp')
         this.cpClient?.emitCronReport({ cronId: cron.id, agentId, firedAt: firedAtIso, ...update })
     }
-    this.store.setCronLastRun(`${agentId}:${cron.id}`, firedAt)
+    this.store.setCronLastRun(`${agentId}:${cron.id}`, firedAt, scheduleFingerprint(this.cronDefinition(cron)))
     // CP-owned crons report the fire, attach the session as soon as it exists,
     // then close the run when the turn ends. Hand-authored crons stay local.
     report()
@@ -22137,7 +22179,7 @@ export class Daemon {
         for (const a of this.effectiveAgents())
           for (const c of a.crons) {
             if (c.origin !== 'cp') continue
-            const at = this.store.getCronLastRun(`${a.id}:${c.id}`)
+            const at = this.store.cronRun(`${a.id}:${c.id}`)?.lastRunAt
             if (at !== undefined)
               this.cpClient?.emitCronReport({ cronId: c.id, agentId: a.id, firedAt: new Date(at).toISOString() })
           }

--- a/packages/daemon/src/scheduler/scheduler.ts
+++ b/packages/daemon/src/scheduler/scheduler.ts
@@ -32,32 +32,60 @@ export function buildSyntheticMessage(
 /** Staleness cap on a catch-up: past this, a swallowed moment is history rather than a late fire. */
 const CATCH_UP_GRACE_CAP_MS = 60 * 60 * 1_000
 
+/** The fields that DEFINE when a schedule fires — a cron entry or an agent's dreaming policy. */
+export interface ScheduleDefinition {
+  schedule: string
+  timezone?: string
+  enabled: boolean
+}
+
+/** Durable record of the last fire: when it happened, and under which definition. */
+export interface ScheduleRun {
+  lastRunAt: number
+  definition: string | null
+}
+
+/**
+ * Identity of a schedule DEFINITION, stored next to its stamp.
+ *
+ * A stamp on its own proves nothing about the CURRENT schedule: cron ids are edited in place and
+ * dreaming policies are mutable, so "daily, last fired 03:00" then "switched to hourly at 12:30"
+ * would otherwise look like an hourly fire owed at 12:00 that the hourly definition never covered.
+ * Comparing this fingerprint answers "is that stamp a fire of THIS definition".
+ */
+export function scheduleFingerprint(definition: ScheduleDefinition): string {
+  return JSON.stringify([definition.enabled, definition.schedule, definition.timezone ?? null])
+}
+
 /**
  * The one occurrence a duty handover swallowed, or undefined when nothing is owed (#1031).
  *
  * A freshly constructed `Cron` knows nothing of a moment that has already passed, so a schedule
  * whose moment lands between the old holder unregistering and the new one arming runs nowhere.
- * This answers "was a fire due since `lastRunAt`" from the schedule alone: the previous occurrence,
- * when it is newer than the stamp and still within one interval (capped). Only the NEWEST missed
- * moment is returned — a catch-up compensates a gap, it never replays a backlog. An absent stamp
- * is not a missed fire: nothing durable says this schedule has ever been due.
+ * This answers "was a fire of THIS definition due since its stamp": the previous occurrence, when
+ * it is newer than the stamp and still within one interval (capped). Only the NEWEST missed moment
+ * is returned — a catch-up compensates a gap, it never replays a backlog. Nothing is owed without a
+ * stamp (nothing durable says this schedule has ever been due) or when the stamp was written under
+ * a different definition (the moment it recorded belongs to a schedule that no longer exists).
  */
 export function missedOccurrence(
-  schedule: string,
-  timezone: string | undefined,
-  lastRunAt: number | undefined,
+  definition: ScheduleDefinition,
+  run: ScheduleRun | undefined,
   now: number
 ): number | undefined {
-  if (lastRunAt === undefined) return undefined
+  if (!definition.enabled || !run || run.definition !== scheduleFingerprint(definition)) return undefined
   let runs: Date[]
   try {
     // Pattern-only: croner schedules nothing without a handler, so this is a pure query.
-    runs = new Cron(schedule, timezone ? { timezone } : {}).previousRuns(2, new Date(now))
+    runs = new Cron(definition.schedule, definition.timezone ? { timezone: definition.timezone } : {}).previousRuns(
+      2,
+      new Date(now)
+    )
   } catch {
     return undefined // malformed patterns are warned about where they are armed
   }
   const [previous, before] = runs
-  if (!previous || previous.getTime() <= lastRunAt) return undefined
+  if (!previous || previous.getTime() <= run.lastRunAt) return undefined
   const interval = before ? previous.getTime() - before.getTime() : CATCH_UP_GRACE_CAP_MS
   const grace = Math.min(interval, CATCH_UP_GRACE_CAP_MS)
   return now - previous.getTime() <= grace ? previous.getTime() : undefined

--- a/packages/daemon/src/scheduler/scheduler.ts
+++ b/packages/daemon/src/scheduler/scheduler.ts
@@ -29,6 +29,40 @@ export function buildSyntheticMessage(
   return { agentId, msg }
 }
 
+/** Staleness cap on a catch-up: past this, a swallowed moment is history rather than a late fire. */
+const CATCH_UP_GRACE_CAP_MS = 60 * 60 * 1_000
+
+/**
+ * The one occurrence a duty handover swallowed, or undefined when nothing is owed (#1031).
+ *
+ * A freshly constructed `Cron` knows nothing of a moment that has already passed, so a schedule
+ * whose moment lands between the old holder unregistering and the new one arming runs nowhere.
+ * This answers "was a fire due since `lastRunAt`" from the schedule alone: the previous occurrence,
+ * when it is newer than the stamp and still within one interval (capped). Only the NEWEST missed
+ * moment is returned — a catch-up compensates a gap, it never replays a backlog. An absent stamp
+ * is not a missed fire: nothing durable says this schedule has ever been due.
+ */
+export function missedOccurrence(
+  schedule: string,
+  timezone: string | undefined,
+  lastRunAt: number | undefined,
+  now: number
+): number | undefined {
+  if (lastRunAt === undefined) return undefined
+  let runs: Date[]
+  try {
+    // Pattern-only: croner schedules nothing without a handler, so this is a pure query.
+    runs = new Cron(schedule, timezone ? { timezone } : {}).previousRuns(2, new Date(now))
+  } catch {
+    return undefined // malformed patterns are warned about where they are armed
+  }
+  const [previous, before] = runs
+  if (!previous || previous.getTime() <= lastRunAt) return undefined
+  const interval = before ? previous.getTime() - before.getTime() : CATCH_UP_GRACE_CAP_MS
+  const grace = Math.min(interval, CATCH_UP_GRACE_CAP_MS)
+  return now - previous.getTime() <= grace ? previous.getTime() : undefined
+}
+
 /**
  * Local scheduler for `agent.json.crons[]` (D5). Jobs are keyed per agent so the
  * reconciler can converge them on any agent change (design §5.2: crons change →

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -900,6 +900,11 @@ export class LocalStore {
       CREATE TABLE IF NOT EXISTS cron_runs (
         key TEXT PRIMARY KEY, lastRunAt INTEGER NOT NULL
       );
+      -- The dream half of cron_runs (#1031): a dream schedule's only durable last-fired, so a
+      -- handover can tell a swallowed occurrence from one that already ran. One row per agent.
+      CREATE TABLE IF NOT EXISTS dream_runs (
+        agentId TEXT PRIMARY KEY, lastRunAt INTEGER NOT NULL
+      );
       -- §6.9 #353 durable inbox: an ADMITTED-but-QUEUED message persisted BEFORE the
       -- admission ACK, so a hard kill / agent move can't lose a message the caller was
       -- already told delivered:true. Replayed FIFO-by-sessionKey on startup and removed
@@ -3237,6 +3242,42 @@ export class LocalStore {
     const row = this.db.prepare('SELECT lastRunAt FROM cron_runs WHERE key = ?').get(key) as
       { lastRunAt: number } | undefined
     return row?.lastRunAt
+  }
+
+  /** Stamp a dream-schedule fire (one row per agent). */
+  setDreamLastRun(agentId: string, lastRunAt: number): void {
+    this.db
+      .prepare(
+        `INSERT INTO dream_runs (agentId, lastRunAt) VALUES (@agentId, @lastRunAt)
+         ON CONFLICT(agentId) DO UPDATE SET lastRunAt=excluded.lastRunAt`
+      )
+      .run({ agentId, lastRunAt })
+  }
+
+  getDreamLastRun(agentId: string): number | undefined {
+    const row = this.db.prepare('SELECT lastRunAt FROM dream_runs WHERE agentId = ?').get(agentId) as
+      { lastRunAt: number } | undefined
+    return row?.lastRunAt
+  }
+
+  /** CAS claim on a cron occurrence a handover missed (#1031): take it iff the stamp is still older
+   *  than the occurrence, so two members racing one handoff compensate it exactly once. A schedule
+   *  with no stamp has nothing to compensate and is never claimed. */
+  claimCronCatchUp(key: string, occurrence: number, claimedAt: number): boolean {
+    return (
+      this.db
+        .prepare('UPDATE cron_runs SET lastRunAt = ? WHERE key = ? AND lastRunAt < ?')
+        .run(claimedAt, key, occurrence).changes === 1
+    )
+  }
+
+  /** The dream twin of {@link claimCronCatchUp}, over the per-agent dream stamp. */
+  claimDreamCatchUp(agentId: string, occurrence: number, claimedAt: number): boolean {
+    return (
+      this.db
+        .prepare('UPDATE dream_runs SET lastRunAt = ? WHERE agentId = ? AND lastRunAt < ?')
+        .run(claimedAt, agentId, occurrence).changes === 1
+    )
   }
 
   /** Self-introduce-on-join (issue #536). The set of channels this agent has already

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -3248,6 +3248,24 @@ export class LocalStore {
       ScheduleRun | undefined
   }
 
+  /** Every stamp key this agent still carries — the substring match is exact, so an agent id with
+   *  LIKE metacharacters cannot widen it. */
+  cronRunKeys(agentId: string): string[] {
+    const prefix = `${agentId}:`
+    return (
+      this.db.prepare('SELECT key FROM cron_runs WHERE substr(key, 1, @len) = @prefix').all({
+        len: prefix.length,
+        prefix
+      }) as { key: string }[]
+    ).map((row) => row.key)
+  }
+
+  /** Drop a cron's stamp: the definition it fingerprints is gone, and a re-minted id of the same
+   *  name must start from no evidence rather than inherit the deleted schedule's last run. */
+  deleteCronRun(key: string): void {
+    this.db.prepare('DELETE FROM cron_runs WHERE key = ?').run(key)
+  }
+
   /** Stamp a dream-schedule fire (one row per agent), under the definition that fired. */
   setDreamLastRun(agentId: string, lastRunAt: number, definition: string): void {
     this.db

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -9,6 +9,7 @@ import {
   type SessionImageAttachment
 } from '@agentconnect.md/protocol'
 import { SESSION_TITLE_TOOL_TITLES } from '../mcp/session-title-tool.js'
+import type { ScheduleRun } from '../scheduler/scheduler.js'
 
 /** Per-tool-row rawInput budget in the mining prompt — enough for a command
  *  line or path, short enough that N tool rows can't crowd out the store. */
@@ -621,7 +622,7 @@ function restrictPath(path: string, mode: number): void {
  * change that edits a `CREATE TABLE` below, and append the matching step to
  * {@link SCHEMA_MIGRATIONS}.
  */
-const SCHEMA_VERSION = 6
+const SCHEMA_VERSION = 7
 
 /**
  * Ordered in-place upgrades for a store created by an EARLIER daemon.
@@ -689,7 +690,8 @@ const SCHEMA_MIGRATIONS: ((db: StoreDatabase) => void)[] = [
       );
       DROP TABLE session_gates;
       ALTER TABLE session_gates_keyed RENAME TO session_gates;
-    `)
+    `),
+  (db) => db.exec('ALTER TABLE cron_runs ADD COLUMN definition TEXT')
 ]
 
 export class LocalStore {
@@ -897,13 +899,16 @@ export class LocalStore {
       );
       -- Authoritative last-run per cron (protocol §5.4 — missed-fire compensation).
       -- key = "<agentId>:<cronId>" (cron defs themselves live in agent.json).
+      -- The definition column fingerprints the entry the stamp was written under (#1031): schedules are
+      -- edited in place, so a stamp is only comparable to a fire of the SAME definition. NULL on
+      -- rows written before it existed, which simply makes them ineligible for a catch-up.
       CREATE TABLE IF NOT EXISTS cron_runs (
-        key TEXT PRIMARY KEY, lastRunAt INTEGER NOT NULL
+        key TEXT PRIMARY KEY, lastRunAt INTEGER NOT NULL, definition TEXT
       );
       -- The dream half of cron_runs (#1031): a dream schedule's only durable last-fired, so a
       -- handover can tell a swallowed occurrence from one that already ran. One row per agent.
       CREATE TABLE IF NOT EXISTS dream_runs (
-        agentId TEXT PRIMARY KEY, lastRunAt INTEGER NOT NULL
+        agentId TEXT PRIMARY KEY, lastRunAt INTEGER NOT NULL, definition TEXT
       );
       -- §6.9 #353 durable inbox: an ADMITTED-but-QUEUED message persisted BEFORE the
       -- admission ACK, so a hard kill / agent move can't lose a message the caller was
@@ -3229,54 +3234,53 @@ export class LocalStore {
   }
 
   /** Stamp a cron fire (key = `<agentId>:<cronId>`). */
-  setCronLastRun(key: string, lastRunAt: number): void {
+  setCronLastRun(key: string, lastRunAt: number, definition: string): void {
     this.db
       .prepare(
-        `INSERT INTO cron_runs (key, lastRunAt) VALUES (@key, @lastRunAt)
-         ON CONFLICT(key) DO UPDATE SET lastRunAt=excluded.lastRunAt`
+        `INSERT INTO cron_runs (key, lastRunAt, definition) VALUES (@key, @lastRunAt, @definition)
+         ON CONFLICT(key) DO UPDATE SET lastRunAt=excluded.lastRunAt, definition=excluded.definition`
       )
-      .run({ key, lastRunAt })
+      .run({ key, lastRunAt, definition })
   }
 
-  getCronLastRun(key: string): number | undefined {
-    const row = this.db.prepare('SELECT lastRunAt FROM cron_runs WHERE key = ?').get(key) as
-      { lastRunAt: number } | undefined
-    return row?.lastRunAt
+  cronRun(key: string): ScheduleRun | undefined {
+    return this.db.prepare('SELECT lastRunAt, definition FROM cron_runs WHERE key = ?').get(key) as
+      ScheduleRun | undefined
   }
 
-  /** Stamp a dream-schedule fire (one row per agent). */
-  setDreamLastRun(agentId: string, lastRunAt: number): void {
+  /** Stamp a dream-schedule fire (one row per agent), under the definition that fired. */
+  setDreamLastRun(agentId: string, lastRunAt: number, definition: string): void {
     this.db
       .prepare(
-        `INSERT INTO dream_runs (agentId, lastRunAt) VALUES (@agentId, @lastRunAt)
-         ON CONFLICT(agentId) DO UPDATE SET lastRunAt=excluded.lastRunAt`
+        `INSERT INTO dream_runs (agentId, lastRunAt, definition) VALUES (@agentId, @lastRunAt, @definition)
+         ON CONFLICT(agentId) DO UPDATE SET lastRunAt=excluded.lastRunAt, definition=excluded.definition`
       )
-      .run({ agentId, lastRunAt })
+      .run({ agentId, lastRunAt, definition })
   }
 
-  getDreamLastRun(agentId: string): number | undefined {
-    const row = this.db.prepare('SELECT lastRunAt FROM dream_runs WHERE agentId = ?').get(agentId) as
-      { lastRunAt: number } | undefined
-    return row?.lastRunAt
+  dreamRun(agentId: string): ScheduleRun | undefined {
+    return this.db.prepare('SELECT lastRunAt, definition FROM dream_runs WHERE agentId = ?').get(agentId) as
+      ScheduleRun | undefined
   }
 
   /** CAS claim on a cron occurrence a handover missed (#1031): take it iff the stamp is still older
-   *  than the occurrence, so two members racing one handoff compensate it exactly once. A schedule
-   *  with no stamp has nothing to compensate and is never claimed. */
-  claimCronCatchUp(key: string, occurrence: number, claimedAt: number): boolean {
+   *  than the occurrence AND was written under the definition asking for it, so two members racing
+   *  one handoff compensate it exactly once and an edited schedule replays nothing. A row with no
+   *  stamp, or one fingerprinted differently, is never claimed. */
+  claimCronCatchUp(key: string, occurrence: number, claimedAt: number, definition: string): boolean {
     return (
       this.db
-        .prepare('UPDATE cron_runs SET lastRunAt = ? WHERE key = ? AND lastRunAt < ?')
-        .run(claimedAt, key, occurrence).changes === 1
+        .prepare('UPDATE cron_runs SET lastRunAt = ? WHERE key = ? AND lastRunAt < ? AND definition = ?')
+        .run(claimedAt, key, occurrence, definition).changes === 1
     )
   }
 
   /** The dream twin of {@link claimCronCatchUp}, over the per-agent dream stamp. */
-  claimDreamCatchUp(agentId: string, occurrence: number, claimedAt: number): boolean {
+  claimDreamCatchUp(agentId: string, occurrence: number, claimedAt: number, definition: string): boolean {
     return (
       this.db
-        .prepare('UPDATE dream_runs SET lastRunAt = ? WHERE agentId = ? AND lastRunAt < ?')
-        .run(claimedAt, agentId, occurrence).changes === 1
+        .prepare('UPDATE dream_runs SET lastRunAt = ? WHERE agentId = ? AND lastRunAt < ? AND definition = ?')
+        .run(claimedAt, agentId, occurrence, definition).changes === 1
     )
   }
 

--- a/packages/daemon/test/dream-scheduler.test.ts
+++ b/packages/daemon/test/dream-scheduler.test.ts
@@ -125,11 +125,14 @@ describe('scheduled dream lifecycle gates (daemon)', () => {
     let started = false
     const inner = daemon as unknown as {
       onDreamScheduleFire(id: string): void
+      store?: { setDreamLastRun(id: string, at: number): void }
       dreamRunner(): {
         start(id: string, opts: unknown): Promise<unknown>
         hasNewSessionsSinceLastDream(id: string): boolean
       }
     }
+    // The tick stamps its occurrence (#1031) ahead of the gates, and these daemons never start.
+    inner.store ??= { setDreamLastRun: () => {} }
     inner.dreamRunner = () => ({
       start: async () => {
         started = true

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -50,6 +50,7 @@ describe('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE webchat_mcp_grant_ledger DROP COLUMN ownerId')
     old.exec('ALTER TABLE inbox DROP COLUMN reportOwnerId')
     old.exec('ALTER TABLE inbox DROP COLUMN reportClaimedAt')
+    old.exec('ALTER TABLE cron_runs DROP COLUMN definition')
     old.exec('PRAGMA user_version = 1')
     old.close()
 
@@ -63,6 +64,7 @@ describe('LocalStore schema versioning', () => {
     const dreamColumns = columnsOf('dreams')
     const grantColumns = columnsOf('webchat_mcp_grant_ledger')
     const inboxColumns = columnsOf('inbox')
+    const cronColumns = columnsOf('cron_runs')
     upgraded.close()
     expect(columns).toContain('ownerId')
     expect(outboxColumns).toEqual(expect.arrayContaining(['failedAttempts', 'nextAttemptAt']))
@@ -70,7 +72,9 @@ describe('LocalStore schema versioning', () => {
     expect(dreamColumns).toContain('ownerId')
     expect(grantColumns).toContain('ownerId')
     expect(inboxColumns).toEqual(expect.arrayContaining(['reportOwnerId', 'reportClaimedAt']))
-    expect(userVersion(path)).toBe(6)
+    // A stamp is only comparable to a fire of the same schedule definition (#1031).
+    expect(cronColumns).toContain('definition')
+    expect(userVersion(path)).toBe(7)
   })
 
   it('re-keys the capture gate by agent when upgrading a v5 store', () => {
@@ -101,7 +105,7 @@ describe('LocalStore schema versioning', () => {
     expect(upgraded.isCaptureExcluded('bot-c', 'acp-2')).toBe(true)
     upgraded.close()
 
-    expect(userVersion(path)).toBe(6)
+    expect(userVersion(path)).toBe(7)
   })
 
   it('refuses a store written by a newer daemon WITHOUT touching it first', () => {
@@ -310,14 +314,32 @@ describe('LocalStore', () => {
     s.close()
   })
 
-  it('round-trips per-cron last-run stamps (latest-wins)', () => {
+  it('round-trips per-cron last-run stamps with their definition (latest-wins)', () => {
     const s = store()
-    expect(s.getCronLastRun('bot-a:daily')).toBeUndefined()
-    s.setCronLastRun('bot-a:daily', 1000)
-    s.setCronLastRun('bot-a:daily', 2000)
-    s.setCronLastRun('bot-b:weekly', 1500)
-    expect(s.getCronLastRun('bot-a:daily')).toBe(2000)
-    expect(s.getCronLastRun('bot-b:weekly')).toBe(1500)
+    expect(s.cronRun('bot-a:daily')).toBeUndefined()
+    s.setCronLastRun('bot-a:daily', 1000, 'def-1')
+    s.setCronLastRun('bot-a:daily', 2000, 'def-2')
+    s.setCronLastRun('bot-b:weekly', 1500, 'def-1')
+    expect(s.cronRun('bot-a:daily')).toEqual({ lastRunAt: 2000, definition: 'def-2' })
+    expect(s.cronRun('bot-b:weekly')).toEqual({ lastRunAt: 1500, definition: 'def-1' })
+    s.close()
+  })
+
+  it('claims a catch-up only for the definition the stamp was written under', () => {
+    const s = store()
+    s.setCronLastRun('bot-a:daily', 1000, 'def-1')
+    s.setDreamLastRun('bot-a', 1000, 'def-1')
+    // A definition that has moved on cannot claim the moment the old one left behind.
+    expect(s.claimCronCatchUp('bot-a:daily', 2000, 3000, 'def-2')).toBe(false)
+    expect(s.claimDreamCatchUp('bot-a', 2000, 3000, 'def-2')).toBe(false)
+    expect(s.cronRun('bot-a:daily')).toEqual({ lastRunAt: 1000, definition: 'def-1' })
+    // The same definition claims once; the loser of the race sees a stamp past the occurrence.
+    expect(s.claimCronCatchUp('bot-a:daily', 2000, 3000, 'def-1')).toBe(true)
+    expect(s.claimCronCatchUp('bot-a:daily', 2000, 3000, 'def-1')).toBe(false)
+    expect(s.claimDreamCatchUp('bot-a', 2000, 3000, 'def-1')).toBe(true)
+    expect(s.claimDreamCatchUp('bot-a', 2000, 3000, 'def-1')).toBe(false)
+    // Never claimed for a schedule that has never stamped a run.
+    expect(s.claimCronCatchUp('bot-b:weekly', 2000, 3000, 'def-1')).toBe(false)
     s.close()
   })
 

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -90,6 +90,7 @@ describe('LocalStore schema versioning', () => {
       ('a', 'bot-a', 'acp-1'), ('b', 'bot-b', 'acp-2'), ('c', 'bot-c', 'acp-2')`)
     old.exec(`INSERT INTO session_gates (acpSessionId, localExcluded, cpPrivate, cpRev) VALUES
       ('acp-1', 1, 0, 4), ('acp-2', 0, 0, 7), ('acp-orphan', 0, 0, 1)`)
+    old.exec('ALTER TABLE cron_runs DROP COLUMN definition')
     old.exec('PRAGMA user_version = 5')
     old.close()
 
@@ -340,6 +341,21 @@ describe('LocalStore', () => {
     expect(s.claimDreamCatchUp('bot-a', 2000, 3000, 'def-1')).toBe(false)
     // Never claimed for a schedule that has never stamped a run.
     expect(s.claimCronCatchUp('bot-b:weekly', 2000, 3000, 'def-1')).toBe(false)
+    s.close()
+  })
+
+  it("enumerates and drops one agent's stamp keys without matching a neighbour", () => {
+    const s = store()
+    s.setCronLastRun('bot-a:daily', 1000, 'def-1')
+    s.setCronLastRun('bot-a:weekly', 1000, 'def-1')
+    // A prefix match must be exact: an agent id is not a LIKE pattern, and a longer id that merely
+    // starts with this one is a different agent.
+    s.setCronLastRun('bot-ab:daily', 1000, 'def-1')
+    s.setCronLastRun('bot%:daily', 1000, 'def-1')
+    expect(s.cronRunKeys('bot-a').sort()).toEqual(['bot-a:daily', 'bot-a:weekly'])
+    expect(s.cronRunKeys('bot%')).toEqual(['bot%:daily'])
+    s.deleteCronRun('bot-a:weekly')
+    expect(s.cronRunKeys('bot-a')).toEqual(['bot-a:daily'])
     s.close()
   })
 

--- a/packages/daemon/test/schedule-catchup.test.ts
+++ b/packages/daemon/test/schedule-catchup.test.ts
@@ -19,6 +19,8 @@ const HOURLY = '0 * * * *'
 const AGENT = 'bot-a'
 const GROUP = '11111111-1111-4111-8111-111111111111'
 const HOUR_MS = 60 * 60_000
+const CRON = { id: 'report', schedule: HOURLY, trigger: 'run the report' }
+const DREAMING = { enabled: true, schedule: HOURLY }
 
 function scaffold(): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-catchup-'))
@@ -43,8 +45,8 @@ function scaffold(): string {
       integrations: [],
       output: { mode: 'low' },
       // Target-less ⇒ a headless fire, so the catch-up needs no live platform connection.
-      crons: [{ id: 'report', schedule: HOURLY, trigger: 'run the report' }],
-      memory: { provider: 'managed', dreaming: { enabled: true, schedule: HOURLY } }
+      crons: [CRON],
+      memory: { provider: 'managed', dreaming: DREAMING }
     })
   )
   return root
@@ -112,19 +114,21 @@ function stampsBefore(inner: any, msAgo: number): void {
   inner.store.setDreamLastRun(AGENT, at, scheduleFingerprint(inner.dreamDefinition(agent)))
 }
 
-/** Edit the cron entry and the dreaming policy on disk, then reconcile every member — the path a
- *  real definition change takes, and where a moved definition retires its stamp. */
-async function editSchedules(
-  root: string,
-  members: { inner: any }[],
-  over: { schedule?: string; enabled?: boolean }
-): Promise<void> {
+/** Rewrite agent.json, then reconcile every listed member — the path a real definition change
+ *  takes, and where a moved definition retires its stamp. */
+async function editAgent(root: string, members: { inner: any }[], mutate: (agent: any) => void): Promise<void> {
   const path = join(root, 'agents', AGENT, 'agent.json')
   const agent = JSON.parse(readFileSync(path, 'utf8'))
-  for (const target of [agent.crons[0], agent.memory.dreaming]) Object.assign(target, over)
+  mutate(agent)
   writeFileSync(path, JSON.stringify(agent))
   for (const member of members) await member.inner.reconcile()
 }
+
+/** Move both schedules the same way, as a console edit of the agent would. */
+const editSchedules = (root: string, members: { inner: any }[], over: { schedule?: string; enabled?: boolean }) =>
+  editAgent(root, members, (agent) => {
+    for (const target of [agent.crons[0], agent.memory.dreaming]) Object.assign(target, over)
+  })
 
 /** croner fires are async under the hood; let the stubbed dispatch settle. */
 const settle = () => new Promise((r) => setTimeout(r, 30))
@@ -217,6 +221,43 @@ describe('missed-fire compensation across a duty handover', () => {
     // Same cadence, different moments: :30 past the hour is due on its own, but the stamp is
     // evidence about the :00 schedule that no longer exists.
     await editSchedules(root, [a, b], { schedule: '30 * * * *' })
+    hold(b.inner)
+    await settle()
+    expect(b.crons).toEqual([])
+    expect(b.dreams).toEqual([])
+    await stop()
+  })
+
+  it('a member that does not serve the agent never rewrites the shared stamps', async () => {
+    const { a, b, root, stop } = await bootPool()
+    hold(a.inner)
+    stampsBefore(a.inner, 2 * HOUR_MS)
+    const cron = a.inner.store.cronRun(`${AGENT}:report`)
+    const dream = a.inner.store.dreamRun(AGENT)
+    // b holds nothing. Its reconcile disarms its own jobs; the shared evidence is the holder's,
+    // and a stale non-holder rewriting it would erase the very gap the holder must compensate.
+    await editSchedules(root, [b], { schedule: '30 * * * *' })
+    expect(b.inner.store.cronRun(`${AGENT}:report`)).toEqual(cron)
+    expect(b.inner.store.dreamRun(AGENT)).toEqual(dream)
+    await stop()
+  })
+
+  it('a cron id deleted and recreated starts from no evidence', async () => {
+    const { a, b, root, stop } = await bootPool()
+    hold(a.inner)
+    stampsBefore(a.inner, 2 * HOUR_MS)
+    // Deleting drops the row outright — ids are re-mintable, so leaving one would let a later
+    // schedule of the same name inherit a run it never had.
+    await editAgent(root, [a], (agent) => {
+      agent.crons = []
+      delete agent.memory.dreaming
+    })
+    expect(a.inner.store.cronRun(`${AGENT}:report`)).toBeUndefined()
+    await editAgent(root, [a, b], (agent) => {
+      agent.crons = [CRON]
+      agent.memory.dreaming = DREAMING
+    })
+    drop(a.inner)
     hold(b.inner)
     await settle()
     expect(b.crons).toEqual([])

--- a/packages/daemon/test/schedule-catchup.test.ts
+++ b/packages/daemon/test/schedule-catchup.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
+import { scheduleFingerprint } from '../src/scheduler/scheduler.js'
 
 /**
  * #1031 — a cron or dream whose moment lands inside a duty handover (old holder released, new
  * holder not yet armed) used to run nowhere: a fresh `Cron` knows nothing of a moment already
  * passed. Gaining an agent's duty now replays the one occurrence that was swallowed, claimed
- * through the shared store so a pair of members racing the same handoff fires it once.
+ * through the shared store so a pair of members racing the same handoff fires it once. A stamp is
+ * only evidence about the definition it was written under, so an edited schedule replays nothing.
  */
 
 /** Hourly: the previous occurrence is always inside the schedule's own grace window, and a real
@@ -88,7 +90,7 @@ async function bootPool() {
   const root = scaffold()
   const a = await boot(root)
   const b = await boot(root)
-  return { a, b, stop: () => Promise.all([a.daemon.stop(), b.daemon.stop()]) }
+  return { a, b, root, stop: () => Promise.all([a.daemon.stop(), b.daemon.stop()]) }
 }
 
 const grant = () => ({
@@ -100,11 +102,28 @@ const grant = () => ({
 const hold = (inner: any) => inner.settleDutyChange(inner.duties.applyGrant([grant()]))
 const drop = (inner: any) => inner.applyDutyRevoke([{ groupId: GROUP, reason: 'reassigned' }])
 
-/** Backdate both stamps so the schedules' previous occurrence reads as swallowed. */
+const agentOf = (inner: any) => inner.agents.get(AGENT)
+
+/** Backdate both stamps, fingerprinted under the definitions currently in force. */
 function stampsBefore(inner: any, msAgo: number): void {
   const at = inner.clock.now() - msAgo
-  inner.store.setCronLastRun(`${AGENT}:report`, at)
-  inner.store.setDreamLastRun(AGENT, at)
+  const agent = agentOf(inner)
+  inner.store.setCronLastRun(`${AGENT}:report`, at, scheduleFingerprint(inner.cronDefinition(agent.crons[0])))
+  inner.store.setDreamLastRun(AGENT, at, scheduleFingerprint(inner.dreamDefinition(agent)))
+}
+
+/** Edit the cron entry and the dreaming policy on disk, then reconcile every member — the path a
+ *  real definition change takes, and where a moved definition retires its stamp. */
+async function editSchedules(
+  root: string,
+  members: { inner: any }[],
+  over: { schedule?: string; enabled?: boolean }
+): Promise<void> {
+  const path = join(root, 'agents', AGENT, 'agent.json')
+  const agent = JSON.parse(readFileSync(path, 'utf8'))
+  for (const target of [agent.crons[0], agent.memory.dreaming]) Object.assign(target, over)
+  writeFileSync(path, JSON.stringify(agent))
+  for (const member of members) await member.inner.reconcile()
 }
 
 /** croner fires are async under the hood; let the stubbed dispatch settle. */
@@ -181,10 +200,41 @@ describe('missed-fire compensation across a duty handover', () => {
 
   it('a real fire stamps the dream schedule, so the next handover sees the moment as served', async () => {
     const { a, stop } = await bootPool()
-    expect(a.inner.store.getDreamLastRun(AGENT)).toBeUndefined()
+    expect(a.inner.store.dreamRun(AGENT)).toBeUndefined()
     a.inner.onDreamScheduleFire(AGENT)
     await settle()
-    expect(a.inner.store.getDreamLastRun(AGENT)).toBeGreaterThan(0)
+    const run = a.inner.store.dreamRun(AGENT)
+    expect(run.lastRunAt).toBeGreaterThan(0)
+    expect(run.definition).toBe(scheduleFingerprint(a.inner.dreamDefinition(agentOf(a.inner))))
+    await stop()
+  })
+
+  it('replays nothing when the definition was edited since the stamp', async () => {
+    const { a, b, root, stop } = await bootPool()
+    hold(a.inner)
+    stampsBefore(a.inner, 2 * HOUR_MS)
+    drop(a.inner)
+    // Same cadence, different moments: :30 past the hour is due on its own, but the stamp is
+    // evidence about the :00 schedule that no longer exists.
+    await editSchedules(root, [a, b], { schedule: '30 * * * *' })
+    hold(b.inner)
+    await settle()
+    expect(b.crons).toEqual([])
+    expect(b.dreams).toEqual([])
+    await stop()
+  })
+
+  it('replays nothing across a disable and re-enable', async () => {
+    const { a, b, root, stop } = await bootPool()
+    hold(a.inner)
+    stampsBefore(a.inner, 2 * HOUR_MS)
+    await editSchedules(root, [a, b], { enabled: false })
+    await editSchedules(root, [a, b], { enabled: true })
+    drop(a.inner)
+    hold(b.inner)
+    await settle()
+    expect(b.crons).toEqual([])
+    expect(b.dreams).toEqual([])
     await stop()
   })
 })

--- a/packages/daemon/test/schedule-catchup.test.ts
+++ b/packages/daemon/test/schedule-catchup.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Daemon } from '../src/daemon.js'
+
+/**
+ * #1031 — a cron or dream whose moment lands inside a duty handover (old holder released, new
+ * holder not yet armed) used to run nowhere: a fresh `Cron` knows nothing of a moment already
+ * passed. Gaining an agent's duty now replays the one occurrence that was swallowed, claimed
+ * through the shared store so a pair of members racing the same handoff fires it once.
+ */
+
+/** Hourly: the previous occurrence is always inside the schedule's own grace window, and a real
+ *  tick is an hour away, so nothing but the catch-up can fire inside a test. */
+const HOURLY = '0 * * * *'
+const AGENT = 'bot-a'
+const GROUP = '11111111-1111-4111-8111-111111111111'
+const HOUR_MS = 60 * 60_000
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-catchup-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  const adir = join(root, 'agents', AGENT)
+  mkdirSync(adir, { recursive: true })
+  writeFileSync(
+    join(adir, 'agent.json'),
+    JSON.stringify({
+      id: AGENT,
+      name: AGENT,
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+      integrations: [],
+      output: { mode: 'low' },
+      // Target-less ⇒ a headless fire, so the catch-up needs no live platform connection.
+      crons: [{ id: 'report', schedule: HOURLY, trigger: 'run the report' }],
+      memory: { provider: 'managed', dreaming: { enabled: true, schedule: HOURLY } }
+    })
+  )
+  return root
+}
+
+/** One member: dispatch and the dream runner stubbed, so a fire is observable without a real turn. */
+async function boot(root: string) {
+  const daemon = new Daemon({
+    root,
+    hostFactory: () => ({}) as any,
+    dreamOperationPolicy: 'test-only',
+    probeRuntimes: async () => []
+  })
+  await daemon.start()
+  const inner = daemon as any
+  const crons: string[] = []
+  const dreams: string[] = []
+  inner.dispatch = vi.fn(async (agentId: string) => {
+    crons.push(agentId)
+    return 'acp-1'
+  })
+  inner.dreamRunner = () => ({
+    start: async (agentId: string) => {
+      dreams.push(agentId)
+      return { dreamId: 'drm-test' }
+    },
+    hasNewSessionsSinceLastDream: () => true,
+    reclaimDreams: () => {}
+  })
+  // Duty leases gate service, exactly like an install-wide pool member.
+  inner.cpClient = {
+    organizationScope: () => 'frame',
+    stop: async () => {},
+    releaseDuties: vi.fn(async () => {}),
+    reportDutiesNow: vi.fn(() => {}),
+    fetchDutyAgent: vi.fn()
+  }
+  return { daemon, inner, crons, dreams }
+}
+
+/** Two members over ONE store: the same root, so both LocalStores open the same database. */
+async function bootPool() {
+  const root = scaffold()
+  const a = await boot(root)
+  const b = await boot(root)
+  return { a, b, stop: () => Promise.all([a.daemon.stop(), b.daemon.stop()]) }
+}
+
+const grant = () => ({
+  groupId: GROUP,
+  orgId: 'org-1',
+  term: '1',
+  members: [{ kind: 'agent' as const, refId: AGENT }]
+})
+const hold = (inner: any) => inner.settleDutyChange(inner.duties.applyGrant([grant()]))
+const drop = (inner: any) => inner.applyDutyRevoke([{ groupId: GROUP, reason: 'reassigned' }])
+
+/** Backdate both stamps so the schedules' previous occurrence reads as swallowed. */
+function stampsBefore(inner: any, msAgo: number): void {
+  const at = inner.clock.now() - msAgo
+  inner.store.setCronLastRun(`${AGENT}:report`, at)
+  inner.store.setDreamLastRun(AGENT, at)
+}
+
+/** croner fires are async under the hood; let the stubbed dispatch settle. */
+const settle = () => new Promise((r) => setTimeout(r, 30))
+
+describe('missed-fire compensation across a duty handover', () => {
+  it('replays a cron and a dream that fell inside the handover, on the member that gained the duty', async () => {
+    const { a, b, stop } = await bootPool()
+    hold(a.inner)
+    // The window: the old holder releases before the moment, the successor arms after it.
+    stampsBefore(a.inner, 2 * HOUR_MS)
+    drop(a.inner)
+    a.crons.length = 0
+    a.dreams.length = 0
+    hold(b.inner)
+    await settle()
+    expect(b.crons).toEqual([AGENT])
+    expect(b.dreams).toEqual([AGENT])
+    // The released member neither fires nor holds anything to fire.
+    expect(a.crons).toEqual([])
+    expect(a.dreams).toEqual([])
+    await stop()
+  })
+
+  it('fires nothing when the schedules already ran — the stamp is newer than the missed moment', async () => {
+    const { a, b, stop } = await bootPool()
+    hold(a.inner)
+    stampsBefore(a.inner, 0)
+    drop(a.inner)
+    hold(b.inner)
+    await settle()
+    expect(b.crons).toEqual([])
+    expect(b.dreams).toEqual([])
+    await stop()
+  })
+
+  it('fires nothing when a schedule has no stamp at all — nothing durable says a fire was due', async () => {
+    const { a, b, stop } = await bootPool()
+    hold(a.inner)
+    drop(a.inner)
+    hold(b.inner)
+    await settle()
+    expect(b.crons).toEqual([])
+    expect(b.dreams).toEqual([])
+    await stop()
+  })
+
+  it('two members racing the same handoff compensate the occurrence exactly once', async () => {
+    const { a, b, stop } = await bootPool()
+    stampsBefore(a.inner, 2 * HOUR_MS)
+    // Both claim the group — the overlap a handover leaves behind.
+    hold(a.inner)
+    hold(b.inner)
+    await settle()
+    expect(a.crons.length + b.crons.length).toBe(1)
+    expect(a.dreams.length + b.dreams.length).toBe(1)
+    await stop()
+  })
+
+  it('a second grant of an agent already held replays nothing — a catch-up is per handover', async () => {
+    const { a, stop } = await bootPool()
+    stampsBefore(a.inner, 2 * HOUR_MS)
+    hold(a.inner)
+    await settle()
+    expect(a.crons).toEqual([AGENT])
+    a.crons.length = 0
+    a.dreams.length = 0
+    hold(a.inner)
+    await settle()
+    expect(a.crons).toEqual([])
+    expect(a.dreams).toEqual([])
+    await stop()
+  })
+
+  it('a real fire stamps the dream schedule, so the next handover sees the moment as served', async () => {
+    const { a, stop } = await bootPool()
+    expect(a.inner.store.getDreamLastRun(AGENT)).toBeUndefined()
+    a.inner.onDreamScheduleFire(AGENT)
+    await settle()
+    expect(a.inner.store.getDreamLastRun(AGENT)).toBeGreaterThan(0)
+    await stop()
+  })
+})

--- a/packages/daemon/test/scheduler.test.ts
+++ b/packages/daemon/test/scheduler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildSyntheticMessage, Scheduler } from '../src/scheduler/scheduler.js'
+import { buildSyntheticMessage, missedOccurrence, Scheduler } from '../src/scheduler/scheduler.js'
 import type { CronDef } from '../src/agents/agent-schema.js'
 
 const cron = (id: string, over: Partial<CronDef> = {}): CronDef => ({
@@ -104,5 +104,47 @@ describe('Scheduler (per-agent converge — §5.2 crons change → upsert/remove
       s.stop()
       vi.useRealTimers()
     }
+  })
+})
+
+// #1031 — the arm-time question a duty handover creates: was a fire due while nobody held this
+// schedule? A fresh `Cron` cannot answer it, so the answer comes from the pattern plus the stamp.
+describe('missedOccurrence (handover catch-up)', () => {
+  const DAILY = '0 3 * * *'
+  const at = (iso: string) => new Date(iso).getTime()
+
+  it('returns the previous occurrence when it is newer than the stamp', () => {
+    const now = at('2026-03-07T03:00:40.000Z')
+    expect(missedOccurrence(DAILY, 'Etc/UTC', at('2026-03-06T03:00:00.000Z'), now)).toBe(at('2026-03-07T03:00:00.000Z'))
+  })
+
+  it('returns nothing when the stamp already covers the previous occurrence', () => {
+    const now = at('2026-03-07T03:00:40.000Z')
+    expect(missedOccurrence(DAILY, 'Etc/UTC', at('2026-03-07T03:00:00.500Z'), now)).toBeUndefined()
+  })
+
+  it('returns nothing without a stamp — nothing durable says this schedule has ever been due', () => {
+    expect(missedOccurrence(DAILY, 'Etc/UTC', undefined, at('2026-03-07T03:00:40.000Z'))).toBeUndefined()
+  })
+
+  it('refuses a stale moment: past the grace window a missed fire is history, not a late fire', () => {
+    // Every minute ⇒ a one-minute grace, so the moment inside it is owed and an older one is not.
+    expect(
+      missedOccurrence('* * * * *', 'Etc/UTC', at('2026-03-07T03:00:00.000Z'), at('2026-03-07T03:02:30.000Z'))
+    ).toBe(at('2026-03-07T03:02:00.000Z'))
+    expect(
+      missedOccurrence(DAILY, 'Etc/UTC', at('2026-03-01T03:00:00.000Z'), at('2026-03-07T09:00:00.000Z'))
+    ).toBeUndefined()
+  })
+
+  it('never returns a backlog — a stamp days behind still yields only the newest missed moment', () => {
+    const now = at('2026-03-07T03:00:40.000Z')
+    expect(missedOccurrence(DAILY, 'Etc/UTC', at('2026-03-01T03:00:00.000Z'), now)).toBe(at('2026-03-07T03:00:00.000Z'))
+  })
+
+  it('returns nothing for a malformed pattern or an unknown zone instead of throwing', () => {
+    const now = at('2026-03-07T03:00:40.000Z')
+    expect(missedOccurrence('not-a-cron', undefined, at('2026-03-01T00:00:00.000Z'), now)).toBeUndefined()
+    expect(missedOccurrence(DAILY, 'Mars/Olympus_Mons', at('2026-03-01T00:00:00.000Z'), now)).toBeUndefined()
   })
 })

--- a/packages/daemon/test/scheduler.test.ts
+++ b/packages/daemon/test/scheduler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildSyntheticMessage, missedOccurrence, Scheduler } from '../src/scheduler/scheduler.js'
+import { buildSyntheticMessage, missedOccurrence, scheduleFingerprint, Scheduler } from '../src/scheduler/scheduler.js'
 import type { CronDef } from '../src/agents/agent-schema.js'
 
 const cron = (id: string, over: Partial<CronDef> = {}): CronDef => ({
@@ -108,43 +108,76 @@ describe('Scheduler (per-agent converge — §5.2 crons change → upsert/remove
 })
 
 // #1031 — the arm-time question a duty handover creates: was a fire due while nobody held this
-// schedule? A fresh `Cron` cannot answer it, so the answer comes from the pattern plus the stamp.
+// schedule? A fresh `Cron` cannot answer it, so the answer comes from the pattern, the stamp, and
+// the definition the stamp was written under.
 describe('missedOccurrence (handover catch-up)', () => {
-  const DAILY = '0 3 * * *'
+  const DAILY = { schedule: '0 3 * * *', timezone: 'Etc/UTC', enabled: true }
   const at = (iso: string) => new Date(iso).getTime()
+  const ranAt = (iso: string, definition = DAILY) => ({
+    lastRunAt: at(iso),
+    definition: scheduleFingerprint(definition)
+  })
 
   it('returns the previous occurrence when it is newer than the stamp', () => {
-    const now = at('2026-03-07T03:00:40.000Z')
-    expect(missedOccurrence(DAILY, 'Etc/UTC', at('2026-03-06T03:00:00.000Z'), now)).toBe(at('2026-03-07T03:00:00.000Z'))
+    expect(missedOccurrence(DAILY, ranAt('2026-03-06T03:00:00.000Z'), at('2026-03-07T03:00:40.000Z'))).toBe(
+      at('2026-03-07T03:00:00.000Z')
+    )
   })
 
   it('returns nothing when the stamp already covers the previous occurrence', () => {
-    const now = at('2026-03-07T03:00:40.000Z')
-    expect(missedOccurrence(DAILY, 'Etc/UTC', at('2026-03-07T03:00:00.500Z'), now)).toBeUndefined()
+    expect(missedOccurrence(DAILY, ranAt('2026-03-07T03:00:00.500Z'), at('2026-03-07T03:00:40.000Z'))).toBeUndefined()
   })
 
   it('returns nothing without a stamp — nothing durable says this schedule has ever been due', () => {
-    expect(missedOccurrence(DAILY, 'Etc/UTC', undefined, at('2026-03-07T03:00:40.000Z'))).toBeUndefined()
+    expect(missedOccurrence(DAILY, undefined, at('2026-03-07T03:00:40.000Z'))).toBeUndefined()
+  })
+
+  it('returns nothing when the stamp was written under a DIFFERENT definition', () => {
+    const now = at('2026-03-07T12:40:00.000Z')
+    const hourly = { schedule: '0 * * * *', timezone: 'Etc/UTC', enabled: true }
+    // Daily last stamped at 03:00, switched to hourly at 12:30: 12:00 is a moment the hourly
+    // definition never covered, and the stamp is no evidence about it either way.
+    expect(missedOccurrence(hourly, ranAt('2026-03-07T03:00:00.000Z'), now)).toBeUndefined()
+    // A moved timezone and a moved enabled flag are the same kind of change.
+    expect(
+      missedOccurrence(DAILY, ranAt('2026-03-06T03:00:00.000Z', { ...DAILY, timezone: 'Asia/Singapore' }), now)
+    ).toBeUndefined()
+    expect(
+      missedOccurrence(DAILY, ranAt('2026-03-06T03:00:00.000Z', { ...DAILY, enabled: false }), now)
+    ).toBeUndefined()
+    // A legacy row that predates the fingerprint is ineligible rather than assumed to match.
+    expect(
+      missedOccurrence(DAILY, { lastRunAt: at('2026-03-06T03:00:00.000Z'), definition: null }, now)
+    ).toBeUndefined()
+  })
+
+  it('returns nothing for a disabled definition — it is not armed, so nothing is owed', () => {
+    const off = { ...DAILY, enabled: false }
+    expect(
+      missedOccurrence(off, ranAt('2026-03-06T03:00:00.000Z', off), at('2026-03-07T03:00:40.000Z'))
+    ).toBeUndefined()
   })
 
   it('refuses a stale moment: past the grace window a missed fire is history, not a late fire', () => {
     // Every minute ⇒ a one-minute grace, so the moment inside it is owed and an older one is not.
+    const minutely = { schedule: '* * * * *', timezone: 'Etc/UTC', enabled: true }
     expect(
-      missedOccurrence('* * * * *', 'Etc/UTC', at('2026-03-07T03:00:00.000Z'), at('2026-03-07T03:02:30.000Z'))
+      missedOccurrence(minutely, ranAt('2026-03-07T03:00:00.000Z', minutely), at('2026-03-07T03:02:30.000Z'))
     ).toBe(at('2026-03-07T03:02:00.000Z'))
-    expect(
-      missedOccurrence(DAILY, 'Etc/UTC', at('2026-03-01T03:00:00.000Z'), at('2026-03-07T09:00:00.000Z'))
-    ).toBeUndefined()
+    expect(missedOccurrence(DAILY, ranAt('2026-03-01T03:00:00.000Z'), at('2026-03-07T09:00:00.000Z'))).toBeUndefined()
   })
 
   it('never returns a backlog — a stamp days behind still yields only the newest missed moment', () => {
-    const now = at('2026-03-07T03:00:40.000Z')
-    expect(missedOccurrence(DAILY, 'Etc/UTC', at('2026-03-01T03:00:00.000Z'), now)).toBe(at('2026-03-07T03:00:00.000Z'))
+    expect(missedOccurrence(DAILY, ranAt('2026-03-01T03:00:00.000Z'), at('2026-03-07T03:00:40.000Z'))).toBe(
+      at('2026-03-07T03:00:00.000Z')
+    )
   })
 
   it('returns nothing for a malformed pattern or an unknown zone instead of throwing', () => {
     const now = at('2026-03-07T03:00:40.000Z')
-    expect(missedOccurrence('not-a-cron', undefined, at('2026-03-01T00:00:00.000Z'), now)).toBeUndefined()
-    expect(missedOccurrence(DAILY, 'Mars/Olympus_Mons', at('2026-03-01T00:00:00.000Z'), now)).toBeUndefined()
+    const bad = { schedule: 'not-a-cron', enabled: true }
+    const zone = { ...DAILY, timezone: 'Mars/Olympus_Mons' }
+    expect(missedOccurrence(bad, ranAt('2026-03-01T00:00:00.000Z', bad), now)).toBeUndefined()
+    expect(missedOccurrence(zone, ranAt('2026-03-01T00:00:00.000Z', zone), now)).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Cron and dream fires that land inside a duty handover ran nowhere. Both schedulers are
process-local `croner` jobs armed only while this member holds the agent's duty, and a freshly
constructed `Cron` knows nothing of a moment that has already passed — so arming at 03:00:40 does
not fire a 03:00 schedule. `cron_runs` was declared for missed-fire compensation but read in
exactly one place (re-reporting the stamp to the control plane after a reconnect), and dreams had
no durable last-fired at all.

Gaining an agent's duty now replays the one occurrence that was swallowed.

## Failure scenario

Agent X has a cron at 03:00 and a nightly dream. A rollout (or any rebalance) starts at 02:59: the
holder drains, releases the group and unregisters both jobs; the successor claims the group and
arms its own jobs at 03:00:40. Nothing fires at 03:00 and nothing notices — the run does not appear
late, it does not appear at all, no error, no drop counter, no log line. Under a pool this is a
routine outcome of every rollout, for every schedule that lands in the handover window.

## Fix

- `missedOccurrence(schedule, timezone, lastRunAt, now)` (`packages/daemon/src/scheduler/scheduler.ts`)
  answers "was a fire due since the stamp" from the pattern alone — the previous occurrence, when
  it is newer than the stamp and still inside a grace window of one interval capped at an hour.
  Only the newest missed moment is ever returned: a catch-up compensates a gap, it never replays a
  backlog. An absent stamp is not a missed fire, so a schedule that has never run is never
  back-fired.
- `Daemon.catchUpMissedSchedules` runs on the `agentsGained` path of `settleDutyChange`, after the
  arm, gated on `servesAgent` — the same hook the orchestration-deadline re-derive uses. At most one
  catch-up per schedule per handover.
- Every replay is a CAS on the stamp row (`claimCronCatchUp` / `claimDreamCatchUp`: `UPDATE … WHERE
  lastRunAt < occurrence`), so two members racing the same handoff compensate it exactly once, and
  a member whose stamp is already current claims nothing.
- Dreams get `dream_runs`, the per-agent twin of `cron_runs`, stamped by every tick ahead of the
  lifecycle gates — the stamp records that the moment was serviced here, not that a dream ran, which
  mirrors how `onCronFire` stamps `cron_runs` before its own gates. It is a new table only, so it
  needs no `SCHEMA_MIGRATIONS` step or `SCHEMA_VERSION` bump: per the store header, plain
  `CREATE TABLE IF NOT EXISTS` in the `CREATE` block already covers fresh and upgraded stores.
- A local single daemon never settles a duty change, so it is unchanged. Orchestration deadlines,
  the k8s driver and the outboxes are untouched.
- Design notes recorded in `docs/designs/k8s-daemon-pool.md` §9 and `docs/designs/memory-dreaming.md` §9.

## Test plan

New `packages/daemon/test/schedule-catchup.test.ts` — two members over one shared store:

- a cron and a dream due inside the handover fire exactly once, on the member that gained the duty,
  and not on the released one;
- nothing fires when the stamp is newer than the missed moment;
- nothing fires when a schedule has no stamp at all;
- two members racing the same handoff fire the occurrence once (cron and dream);
- a second grant of an agent already held replays nothing;
- a real dream tick stamps `dream_runs`.

New `missedOccurrence` unit cases in `packages/daemon/test/scheduler.test.ts` cover the stamp
comparison, the absent stamp, the stale-moment refusal, the no-backlog guarantee, and malformed
pattern / unknown zone.

Verified the pool tests fail without the `settleDutyChange` hook. Run:
`pnpm --filter @agentconnect.md/daemon typecheck`, the scheduler / dream-scheduler / catch-up /
duty / orchestration / local-store suites (189 passing), `pnpm lint`, `pnpm format:check`.

Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)
