### PR TITLE
fix(daemon): key the memory-capture gate by agent, not the ACP id alone

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -551,10 +551,14 @@ from `isDm`/webchat/launch-correlation alone. The gate therefore has two layers:
    - The daemon **acknowledges** the frame and persists the gate state (with
      its rev) in its local store alongside the session; the CP retries
      unacked frames, per the WS channel's existing command semantics.
+   - The frame names the **owning agent** as well as the session, and the
+     stored gate is keyed by that pair. ACP session ids are runtime-local, so
+     on a pool's install-wide shared store the id alone would let one
+     organization's push answer for another organization's gate.
    - On daemon **register/reconnect**, the CP replays the current
-     `(sessionId, private?, visibilityRev)` set for the daemon's active
-     sessions (a snapshot, not a diff), closing the window where a change
-     happened while the daemon was offline.
+     `(agentId, sessionId, private?, visibilityRev)` set for the daemon's
+     active sessions (a snapshot, not a diff), closing the window where a
+     change happened while the daemon was offline.
    - **Fail closed on known-unknown state:** a session whose _locally stored_
      gate state is missing or pre-snapshot (e.g. right after a daemon
      restart) is treated as private for capture until the snapshot confirms

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -101,8 +101,10 @@ describe('notifySessions', () => {
     const { push, sessionVisibility, recordVisibilityAck } = deps()
     await push.notifySessions([session()])
 
+    // The agent rides along: the daemon keys its gate by (agent, ACP session id).
     expect(sessionVisibility).toHaveBeenCalledWith(DAEMON, ORG, {
       sessionId: 'acp-1',
+      agentId: AGENT,
       visibility: 'private',
       sharedMemoryExcluded: true,
       visibilityRev: 2

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -59,6 +59,9 @@ export interface VisibilityPushDeps {
 function toPush(s: SessionMetaRecord): SessionVisibilityPush {
   return {
     sessionId: s.id,
+    // The gate is keyed by (agent, ACP session id) on the daemon: ACP ids are
+    // runtime-local, so the id alone would answer for a colliding neighbour.
+    agentId: s.agentId,
     visibility: s.visibility,
     // An external-source session (Slack/Feishu channel) is no longer memory-
     // excluded just for being external — `external` visibility now captures like

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1094,6 +1094,7 @@ export interface SessionVisibilityChange {
 /** One entry of the §5.1 register-time gate snapshot. */
 export interface SessionVisibilityState {
   orgId: OrgId
+  agentId: AgentId
   sessionId: SessionId
   visibility: SessionVisibility
   sharedMemoryExcluded: boolean

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -1610,9 +1610,16 @@ export class PgSessionRepo implements SessionRepo {
     // matter how old it is — a plain newest-first window would drop it past the
     // cap and leave the daemon capturing with a stale `org` gate forever.
     const rows = await this.db.$queryRaw<
-      Array<{ id: string; orgId: string; visibility: string; externalProvider: string | null; visibilityRev: number }>
+      Array<{
+        id: string
+        orgId: string
+        agentId: string
+        visibility: string
+        externalProvider: string | null
+        visibilityRev: number
+      }>
     >(Prisma.sql`
-      SELECT "id", "orgId", "visibility", "externalProvider", "visibilityRev"
+      SELECT "id", "orgId", "agentId", "visibility", "externalProvider", "visibilityRev"
       FROM "session_meta"
       WHERE "daemonId" = ${daemonId}::uuid
         AND (${includeExternal} OR "externalProvider" IS NULL)
@@ -1622,6 +1629,7 @@ export class PgSessionRepo implements SessionRepo {
     `)
     return rows.map((r) => ({
       orgId: OrgId(r.orgId),
+      agentId: AgentId(r.agentId),
       sessionId: SessionId(r.id),
       visibility: r.visibility as SessionVisibility,
       // External-source sessions are no longer memory-excluded just for being

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -1170,7 +1170,14 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
     expect(await repo.countUnackedVisibility(daemonId)).toBe(1)
     const capped = await repo.visibilitySnapshotForDaemon(daemonId, 1)
     expect(capped).toEqual([
-      { sessionId: stale, orgId: DEFAULT_ORG_ID, visibility: 'private', sharedMemoryExcluded: true, visibilityRev: 1 }
+      {
+        sessionId: stale,
+        orgId: DEFAULT_ORG_ID,
+        agentId,
+        visibility: 'private',
+        sharedMemoryExcluded: true,
+        visibilityRev: 1
+      }
     ])
   })
 
@@ -1216,6 +1223,7 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
       {
         sessionId: newer,
         orgId: DEFAULT_ORG_ID,
+        agentId,
         visibility: 'private',
         sharedMemoryExcluded: true,
         visibilityRev: 0
@@ -1223,6 +1231,7 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
       {
         sessionId: older,
         orgId: DEFAULT_ORG_ID,
+        agentId,
         visibility: 'org',
         sharedMemoryExcluded: false,
         visibilityRev: 0

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3456,7 +3456,7 @@ export class Daemon {
       // like post-turn distillation). Resolved from trusted session coords at call
       // time so a policy change takes effect for an already-running ACP session.
       memoryAccessAllowed: (ctx, mode) =>
-        mode === 'read' || !this.store.isCaptureExcluded(this.acpSessionIdForToolCall(ctx)),
+        mode === 'read' || !this.store.isCaptureExcluded(ctx.agentId, this.acpSessionIdForToolCall(ctx)),
       memoryScope: (ctx) => this.memoryScope(ctx.agentId, ctx.channel, ctx.transportScope),
       recordOutbound: (ctx, channel, thread, text, ts, integrationId) =>
         this.store.appendTranscript({
@@ -5726,7 +5726,7 @@ export class Daemon {
     // launch-correlated one) must never be distilled into it. The gate is checked
     // HERE — before both the managed distillation and the external capture outbox
     // — and fails closed on unknown state.
-    if (this.store.isCaptureExcluded(sessionId)) return
+    if (this.store.isCaptureExcluded(agentId, sessionId)) return
     const provider = binding?.provider ?? 'managed'
     const observableCapture = provider === 'managed' || provider === 'external'
     const record = async () => {
@@ -9302,7 +9302,9 @@ export class Daemon {
       ...(req.needsReply === true && originSessionId !== undefined ? { needsReply: true } : {}),
       // §5.1: seal the child's capture gate when the waking session is private.
       // Tighten-only — see CallMeta.parentPrivate.
-      ...(originSessionId !== undefined && this.store.isCaptureExcluded(originSessionId) ? { parentPrivate: true } : {})
+      ...(originSessionId !== undefined && this.store.isCaptureExcluded(req.callerAgentId, originSessionId)
+        ? { parentPrivate: true }
+        : {})
     }
 
     const normalized: NormalizedMessage = {
@@ -9485,7 +9487,7 @@ export class Daemon {
       ...(externalOrigin ? { externalOrigin } : {}),
       // §5.1: seal the child's capture gate when the waking session is private.
       // Tighten-only — see CallMeta.parentPrivate.
-      ...(replierSessionId !== undefined && this.store.isCaptureExcluded(replierSessionId)
+      ...(replierSessionId !== undefined && this.store.isCaptureExcluded(req.callerAgentId, replierSessionId)
         ? { parentPrivate: true }
         : {})
     }
@@ -10030,7 +10032,7 @@ export class Daemon {
       },
       // §5.1: seal the child's capture gate when the waking session is private.
       // Tighten-only — see CallMeta.parentPrivate.
-      ...(originSessionId && this.store.isCaptureExcluded(originSessionId) ? { parentPrivate: true } : {})
+      ...(originSessionId && this.store.isCaptureExcluded(req.agentId, originSessionId) ? { parentPrivate: true } : {})
     }
     const transportScope = this.transportScopeForIntegrationIds(
       req.integrationId !== undefined ? [req.integrationId] : undefined
@@ -10107,7 +10109,7 @@ export class Daemon {
       const ack = await this.relays.sendAgentMsg({
         claimedFromAgentId: req.callerAgentId,
         // Tighten-only privacy hint for the remote child's capture gate (§5.1).
-        ...(ctx.originSessionId !== undefined && this.store.isCaptureExcluded(ctx.originSessionId)
+        ...(ctx.originSessionId !== undefined && this.store.isCaptureExcluded(req.callerAgentId, ctx.originSessionId)
           ? { parentPrivate: true }
           : {}),
         toAgentId: req.toAgentId,
@@ -18346,7 +18348,7 @@ export class Daemon {
       // Never let classification break a turn — but fail CLOSED: an unclassified
       // session keeps memory capture excluded until the CP confirms otherwise.
       this.log.warn(`session visibility: classification failed for ${acpSessionId} (${formatErr(err)})`)
-      this.store.setLocalCaptureGate(acpSessionId, true)
+      this.store.setLocalCaptureGate(agentId, acpSessionId, true)
     }
   }
 
@@ -18569,7 +18571,7 @@ export class Daemon {
     // stay private.
     const locallyPrivate =
       !isEvaluation && (isA2aChild || msg.isDm || msg.platform === 'webchat' || launchCorrelationId !== undefined)
-    this.store.setLocalCaptureGate(acpSessionId, locallyPrivate)
+    this.store.setLocalCaptureGate(agentId, acpSessionId, locallyPrivate)
   }
 
   /** The ACP session id behind an MCP tool call, from the caller's trusted
@@ -21514,12 +21516,18 @@ export class Daemon {
       // settlements and cascades); the daemon only enforces the resulting
       // capture gate. Ordering is by the CP's durable revision, so retransmits
       // and out-of-order delivery are safe.
-      applySessionVisibility: (p: SessionVisibilityPush): 'applied' | 'superseded' =>
-        this.store.applyCpCaptureGate(
+      applySessionVisibility: (p: SessionVisibilityPush): 'applied' | 'superseded' => {
+        // A CP too old to name the agent leaves only the runtime-local ACP id: use the
+        // sole local holder, and where there is none leave the gate closed (still ACKed).
+        const agentId = p.agentId ?? this.store.soleAgentForAcpSession(p.sessionId)
+        if (!agentId) return 'superseded'
+        return this.store.applyCpCaptureGate(
+          agentId,
           p.sessionId,
           p.sharedMemoryExcluded ?? p.visibility === 'private',
           p.visibilityRev
         )
+      }
     }
   }
 

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -621,7 +621,7 @@ function restrictPath(path: string, mode: number): void {
  * change that edits a `CREATE TABLE` below, and append the matching step to
  * {@link SCHEMA_MIGRATIONS}.
  */
-const SCHEMA_VERSION = 5
+const SCHEMA_VERSION = 6
 
 /**
  * Ordered in-place upgrades for a store created by an EARLIER daemon.
@@ -660,6 +660,35 @@ const SCHEMA_MIGRATIONS: ((db: StoreDatabase) => void)[] = [
     db.exec(`
       ALTER TABLE inbox ADD COLUMN reportOwnerId TEXT;
       ALTER TABLE inbox ADD COLUMN reportClaimedAt INTEGER;
+    `),
+  // session_gates gains the owning agent in its key. Existing rows are attributed
+  // through the sessions row that holds the ACP id; a row no session claims is
+  // dropped, and an id several agents claim is rewritten to the fail-closed state
+  // because its stored verdict was never attributable to one of them.
+  (db) =>
+    db.exec(`
+      CREATE TABLE session_gates_keyed (
+        agentId TEXT NOT NULL,
+        acpSessionId TEXT NOT NULL,
+        localExcluded INTEGER NOT NULL DEFAULT 1,
+        cpPrivate INTEGER,
+        cpRev INTEGER NOT NULL DEFAULT 0,
+        updatedAt INTEGER,
+        PRIMARY KEY (agentId, acpSessionId)
+      );
+      INSERT INTO session_gates_keyed (agentId, acpSessionId, localExcluded, cpPrivate, cpRev, updatedAt)
+      SELECT o.agentId, g.acpSessionId, g.localExcluded, g.cpPrivate, g.cpRev, g.updatedAt
+      FROM session_gates g
+      JOIN (
+        SELECT DISTINCT agentId, acpSessionId FROM sessions
+        WHERE agentId IS NOT NULL AND acpSessionId IS NOT NULL
+      ) o ON o.acpSessionId = g.acpSessionId;
+      UPDATE session_gates_keyed SET localExcluded = 1, cpPrivate = NULL, cpRev = 0
+      WHERE acpSessionId IN (
+        SELECT acpSessionId FROM session_gates_keyed GROUP BY acpSessionId HAVING COUNT(*) > 1
+      );
+      DROP TABLE session_gates;
+      ALTER TABLE session_gates_keyed RENAME TO session_gates;
     `)
 ]
 
@@ -724,20 +753,25 @@ export class LocalStore {
       CREATE TABLE IF NOT EXISTS session_mutes (
         key TEXT PRIMARY KEY
       );
-      -- Per-session memory-capture gate (session-visibility.md §5.1). Keyed by ACP
-      -- session id, NOT the logical session key: the CP addresses sessions by the
-      -- id it knows, and its push can arrive before (or after a resume recreates)
-      -- the sessions row — so this table stands alone, like session_mutes.
+      -- Per-session memory-capture gate (session-visibility.md §5.1). Keyed by
+      -- (agentId, acpSessionId), NOT the logical session key: the CP addresses
+      -- sessions by the id it knows, and its push can arrive before (or after a
+      -- resume recreates) the sessions row — so this table stands alone, like
+      -- session_mutes. The agent is part of the key because ACP session ids are
+      -- runtime-local: on a pool's shared store every agent of every org can hold
+      -- an acp-1, and one org's push must never answer for another org's gate.
       --   localExcluded: the daemon-local initial verdict (DM/webchat/launch/A2A).
       --   cpPrivate    : the CP-confirmed bit; authoritative once it is set.
       --   cpRev        : the CP's durable visibilityRev — the dedup/order key.
       -- (localExcluded, not "excluded": SQLite's upsert pseudo-table owns that name.)
       CREATE TABLE IF NOT EXISTS session_gates (
-        acpSessionId TEXT PRIMARY KEY,
+        agentId TEXT NOT NULL,
+        acpSessionId TEXT NOT NULL,
         localExcluded INTEGER NOT NULL DEFAULT 1,
         cpPrivate INTEGER,
         cpRev INTEGER NOT NULL DEFAULT 0,
-        updatedAt INTEGER
+        updatedAt INTEGER,
+        PRIMARY KEY (agentId, acpSessionId)
       );
       -- Latest-wins session metadata awaiting a correlated CP persistence ACK.
       -- This is deliberately separate from sessions: an upgrade starts with an
@@ -1716,15 +1750,15 @@ export class LocalStore {
 
   /** Seed the local verdict for a session the daemon just created. Never lowers
    *  `cpRev`: a CP push that arrived first stays authoritative. */
-  setLocalCaptureGate(acpSessionId: string, localExcluded: boolean): void {
+  setLocalCaptureGate(agentId: string, acpSessionId: string, localExcluded: boolean): void {
     this.db
       .prepare(
-        `INSERT INTO session_gates (acpSessionId, localExcluded, cpRev, updatedAt)
-         VALUES (?, ?, 0, ?)
-         ON CONFLICT(acpSessionId) DO UPDATE SET
+        `INSERT INTO session_gates (agentId, acpSessionId, localExcluded, cpRev, updatedAt)
+         VALUES (?, ?, ?, 0, ?)
+         ON CONFLICT(agentId, acpSessionId) DO UPDATE SET
            localExcluded = excluded.localExcluded, updatedAt = excluded.updatedAt`
       )
-      .run(acpSessionId, localExcluded ? 1 : 0, Date.now())
+      .run(agentId, acpSessionId, localExcluded ? 1 : 0, Date.now())
   }
 
   /**
@@ -1732,22 +1766,33 @@ export class LocalStore {
    * rev is at or below what we hold is NOT reapplied but IS still acknowledged
    * (`superseded`) — "ignore" must never mean "don't ACK", or a lost ack leaves
    * the CP retrying forever.
+   *
+   * The revision test is the upsert's own `WHERE`, not a prior `SELECT`: two members
+   * on the shared store otherwise interleave read and write and land the older rev last.
    */
-  applyCpCaptureGate(acpSessionId: string, isPrivate: boolean, rev: number): 'applied' | 'superseded' {
-    const row = this.db.prepare('SELECT cpRev FROM session_gates WHERE acpSessionId = ?').get(acpSessionId) as
-      { cpRev: number } | undefined
+  applyCpCaptureGate(agentId: string, acpSessionId: string, isPrivate: boolean, rev: number): 'applied' | 'superseded' {
     // rev 0 is a legitimate first revision (a session ingested and never
     // changed), so it applies once — but only while we hold nothing newer.
-    if (row && (rev > 0 ? row.cpRev >= rev : row.cpRev > 0)) return 'superseded'
-    this.db
+    const changes = this.db
       .prepare(
-        `INSERT INTO session_gates (acpSessionId, localExcluded, cpPrivate, cpRev, updatedAt)
-         VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(acpSessionId) DO UPDATE SET
-           cpPrivate = excluded.cpPrivate, cpRev = excluded.cpRev, updatedAt = excluded.updatedAt`
+        `INSERT INTO session_gates (agentId, acpSessionId, localExcluded, cpPrivate, cpRev, updatedAt)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(agentId, acpSessionId) DO UPDATE SET
+           cpPrivate = excluded.cpPrivate, cpRev = excluded.cpRev, updatedAt = excluded.updatedAt
+         WHERE session_gates.cpRev < excluded.cpRev
+            OR (excluded.cpRev = 0 AND session_gates.cpRev = 0)`
       )
-      .run(acpSessionId, isPrivate ? 1 : 0, isPrivate ? 1 : 0, rev, Date.now())
-    return 'applied'
+      .run(agentId, acpSessionId, isPrivate ? 1 : 0, isPrivate ? 1 : 0, rev, Date.now()).changes
+    return Number(changes) > 0 ? 'applied' : 'superseded'
+  }
+
+  /** The one agent holding this ACP id locally, or undefined when none or several
+   *  do — how a push from a CP too old to name the agent is attributed. */
+  soleAgentForAcpSession(acpSessionId: string): string | undefined {
+    const rows = this.db
+      .prepare('SELECT DISTINCT agentId FROM sessions WHERE acpSessionId = ? AND agentId IS NOT NULL LIMIT 2')
+      .all(acpSessionId) as { agentId: string }[]
+    return rows.length === 1 ? rows[0]!.agentId : undefined
   }
 
   /**
@@ -1755,7 +1800,7 @@ export class LocalStore {
    * we have one; otherwise the local verdict; otherwise excluded. An A2A child
    * therefore starts closed and only a CP-confirmed `org` state opens it.
    */
-  isCaptureExcluded(acpSessionId: string | undefined): boolean {
+  isCaptureExcluded(agentId: string, acpSessionId: string | undefined): boolean {
     if (!acpSessionId) return true
     // External-source binding (a Slack/Feishu channel = external identity domain)
     // no longer forces memory exclusion: such channels behave like any other
@@ -1764,8 +1809,8 @@ export class LocalStore {
     // §5.1). DM / webchat / A2A / launch-correlated sessions stay private through
     // those same layers.
     const row = this.db
-      .prepare('SELECT localExcluded, cpPrivate FROM session_gates WHERE acpSessionId = ?')
-      .get(acpSessionId) as { localExcluded: number; cpPrivate: number | null } | undefined
+      .prepare('SELECT localExcluded, cpPrivate FROM session_gates WHERE agentId = ? AND acpSessionId = ?')
+      .get(agentId, acpSessionId) as { localExcluded: number; cpPrivate: number | null } | undefined
     if (!row) return true
     if (row.cpPrivate !== null) return row.cpPrivate === 1
     return row.localExcluded === 1
@@ -2200,9 +2245,8 @@ export class LocalStore {
    *  - unacknowledged terminal hook reports (`terminalReport IS NOT NULL`) — an
    *    outbox the CP has not converged yet, preserved exactly like
    *    removeInboxByAgentId does.
-   *  permission_requests is scoped by agentId, and the capture gate is dropped
-   *  only when no surviving session still references the ACP id: ACP session ids
-   *  are runtime-local, so two agents can both hold an `acp-1`.
+   *  permission_requests and the capture gate are both scoped by agentId, so a
+   *  neighbour holding the same runtime-local `acp-1` keeps its own rows.
    *  Returns false when the row is already gone (idempotent). */
   deleteSession(key: string, purge?: { reason: string; at: number }): boolean {
     const rec = this.getSession(key)
@@ -2231,16 +2275,9 @@ export class LocalStore {
         this.db
           .prepare('DELETE FROM session_metadata_outbox WHERE agentId = ? AND sessionId = ?')
           .run(rec.agentId, rec.acpSessionId)
-        // session_gates is keyed by the ACP id ALONE, and ACP ids are runtime-local
-        // — another agent's still-live `acp-1` may share the key. Drop the gate only
-        // once no surviving session references it (the sessions row above is already
-        // deleted inside this transaction, so a self-reference cannot pin it).
-        const stillReferenced = this.db
-          .prepare('SELECT 1 AS present FROM sessions WHERE acpSessionId = ? LIMIT 1')
-          .get(rec.acpSessionId)
-        if (!stillReferenced) {
-          this.db.prepare('DELETE FROM session_gates WHERE acpSessionId = ?').run(rec.acpSessionId)
-        }
+        this.db
+          .prepare('DELETE FROM session_gates WHERE agentId = ? AND acpSessionId = ?')
+          .run(rec.agentId, rec.acpSessionId)
         this.db
           .prepare('DELETE FROM permission_requests WHERE agentId = ? AND sessionId = ?')
           .run(rec.agentId, rec.acpSessionId)

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -227,7 +227,7 @@ describe('Daemon interrupt safety gates', () => {
       await vi.waitFor(() => expect(hasPending(daemon, 'acp-2')).toBe(true), WAIT)
       // DMs start private. Model the CP publishing this unrelated session so
       // the memory assertion below tests cancellation isolation, not privacy.
-      expect((daemon as any).store.applyCpCaptureGate('acp-2', false, 1)).toBe('applied')
+      expect((daemon as any).store.applyCpCaptureGate(AGENT_ID, 'acp-2', false, 1)).toBe('applied')
       t2Queued = (daemon as any).dispatch(AGENT_ID, t2QueuedMsg)
       const t2Key = sessionKey('slack', 'C2', 'T2', AGENT_ID)
       expect((daemon as any).serialQueue.get(t2Key)).toHaveLength(1)
@@ -342,7 +342,7 @@ describe('Daemon interrupt safety gates', () => {
       lastDeliveredTs: null,
       updatedAt: Date.now()
     })
-    expect((daemon as any).store.applyCpCaptureGate('acp-memory', false, 1)).toBe('applied')
+    expect((daemon as any).store.applyCpCaptureGate(AGENT_ID, 'acp-memory', false, 1)).toBe('applied')
 
     const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold memory', 'alice', stream.sink)
     await vi.waitFor(() => expect(standingContext).toHaveBeenCalled(), WAIT)

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -742,7 +742,7 @@ describe('Daemon session lifecycle (#118)', () => {
     const rec = (daemon as any).store.getSession(key)
     expect(rec?.conversationKind).toBe('dm')
     // The private-capture gate follows the same bit.
-    expect((daemon as any).store.isCaptureExcluded(rec?.acpSessionId)).toBe(true)
+    expect((daemon as any).store.isCaptureExcluded('bot-a', rec?.acpSessionId)).toBe(true)
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -181,7 +181,7 @@ describe('Daemon transcript records the agent reply', () => {
     await daemon.start()
     const conn = makeRoutable(daemon)
     await (daemon as any).dispatch('bot-a', dm('100', 'private question'), 'int-a')
-    expect((daemon as any).store.applyCpCaptureGate('acp-1', false, 1)).toBe('applied')
+    expect((daemon as any).store.applyCpCaptureGate('bot-a', 'acp-1', false, 1)).toBe('applied')
 
     let releaseDelivery!: () => void
     const deliveryBlocked = new Promise<void>((resolve) => (releaseDelivery = resolve))
@@ -228,7 +228,7 @@ describe('Daemon transcript records the agent reply', () => {
 
     await (daemon as any).dispatch('bot-a', channelMsg('100', 'question?'), 'int-a')
 
-    expect((daemon as any).store.isCaptureExcluded('acp-1')).toBe(false)
+    expect((daemon as any).store.isCaptureExcluded('bot-a', 'acp-1')).toBe(false)
     await vi.waitFor(() => expect(recordTurn).toHaveBeenCalledOnce(), WAIT)
     await daemon.stop()
   }, 15_000)
@@ -296,7 +296,7 @@ describe('Daemon transcript records the agent reply', () => {
 
     await (daemon as any).dispatch('bot-a', dm('100', 'question?'), 'int-a')
 
-    expect((daemon as any).store.isCaptureExcluded('acp-1')).toBe(true)
+    expect((daemon as any).store.isCaptureExcluded('bot-a', 'acp-1')).toBe(true)
     expect(recordTurn).not.toHaveBeenCalled()
     await daemon.stop()
   }, 15_000)

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -70,7 +70,38 @@ describe('LocalStore schema versioning', () => {
     expect(dreamColumns).toContain('ownerId')
     expect(grantColumns).toContain('ownerId')
     expect(inboxColumns).toEqual(expect.arrayContaining(['reportOwnerId', 'reportClaimedAt']))
-    expect(userVersion(path)).toBe(5)
+    expect(userVersion(path)).toBe(6)
+  })
+
+  it('re-keys the capture gate by agent when upgrading a v5 store', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-schema-v5-')), 'local.sqlite')
+    new LocalStore(path).close()
+    const old = new DatabaseSync(path)
+    old.exec('DROP TABLE session_gates')
+    old.exec(`CREATE TABLE session_gates (
+      acpSessionId TEXT PRIMARY KEY, localExcluded INTEGER NOT NULL DEFAULT 1,
+      cpPrivate INTEGER, cpRev INTEGER NOT NULL DEFAULT 0, updatedAt INTEGER
+    )`)
+    old.exec(`INSERT INTO sessions (key, agentId, acpSessionId) VALUES
+      ('a', 'bot-a', 'acp-1'), ('b', 'bot-b', 'acp-2'), ('c', 'bot-c', 'acp-2')`)
+    old.exec(`INSERT INTO session_gates (acpSessionId, localExcluded, cpPrivate, cpRev) VALUES
+      ('acp-1', 1, 0, 4), ('acp-2', 0, 0, 7), ('acp-orphan', 0, 0, 1)`)
+    old.exec('PRAGMA user_version = 5')
+    old.close()
+
+    const upgraded = new LocalStore(path)
+    // Attributable: the CP verdict follows the one agent that held the id.
+    expect(upgraded.isCaptureExcluded('bot-a', 'acp-1')).toBe(false)
+    // Held by two agents: the stored verdict was never attributable to either, so
+    // both start from the fail-closed state and wait for their own CP push.
+    expect(upgraded.isCaptureExcluded('bot-b', 'acp-2')).toBe(true)
+    expect(upgraded.isCaptureExcluded('bot-c', 'acp-2')).toBe(true)
+    expect(upgraded.applyCpCaptureGate('bot-b', 'acp-2', false, 1)).toBe('applied')
+    expect(upgraded.isCaptureExcluded('bot-b', 'acp-2')).toBe(false)
+    expect(upgraded.isCaptureExcluded('bot-c', 'acp-2')).toBe(true)
+    upgraded.close()
+
+    expect(userVersion(path)).toBe(6)
   })
 
   it('refuses a store written by a newer daemon WITHOUT touching it first', () => {
@@ -1008,7 +1039,7 @@ describe('LocalStore session retention GC (#485)', () => {
     const s = store()
     seed(s, 'gone', 'closed', 100)
     s.setSessionMuted('gone', true)
-    s.setLocalCaptureGate('acp-gone', true)
+    s.setLocalCaptureGate('bot-a', 'acp-gone', true)
     s.appendInbox({ id: 'm1', sessionKey: 'gone', agentId: 'bot-a', msg: '{}', enqueuedAt: '0000000001' })
     // An unacknowledged terminal hook report is an outbox toward the CP and must
     // survive the session delete (same rule as removeInboxByAgentId).
@@ -1064,7 +1095,7 @@ describe('LocalStore session retention GC (#485)', () => {
     s.close()
   })
 
-  it('deleteSession keeps a capture gate another agent still references through the same ACP id', () => {
+  it('deleteSession drops only the deleted agent gate for a shared ACP id', () => {
     const s = store()
     // ACP session ids are runtime-local: bot-a and bot-b can both hold `acp-shared`.
     const put = (key: string, agentId: string) =>
@@ -1081,16 +1112,16 @@ describe('LocalStore session retention GC (#485)', () => {
       })
     put('a', 'bot-a')
     put('b', 'bot-b')
-    s.setLocalCaptureGate('acp-shared', false) // capture open (not excluded)
-    expect(s.isCaptureExcluded('acp-shared')).toBe(false)
+    s.setLocalCaptureGate('bot-a', 'acp-shared', false) // capture open (not excluded)
+    s.setLocalCaptureGate('bot-b', 'acp-shared', false)
 
-    // bot-a's session expires first: bot-b still references the id — gate survives.
+    // bot-a's session expires: its own gate goes, bot-b's is untouched.
     expect(s.deleteSession('a')).toBe(true)
-    expect(s.isCaptureExcluded('acp-shared')).toBe(false)
+    expect(s.isCaptureExcluded('bot-a', 'acp-shared')).toBe(true) // no row ⇒ excluded-by-default
+    expect(s.isCaptureExcluded('bot-b', 'acp-shared')).toBe(false)
 
-    // The last referencing session goes: the gate is finally collected too.
     expect(s.deleteSession('b')).toBe(true)
-    expect(s.isCaptureExcluded('acp-shared')).toBe(true) // no row ⇒ excluded-by-default
+    expect(s.isCaptureExcluded('bot-b', 'acp-shared')).toBe(true)
     s.close()
   })
 

--- a/packages/daemon/test/session-capture-gate.test.ts
+++ b/packages/daemon/test/session-capture-gate.test.ts
@@ -16,37 +16,37 @@ function newStore(): LocalStore {
 describe('capture gate — local state', () => {
   it('fails closed for a session it has never heard of', () => {
     const store = newStore()
-    expect(store.isCaptureExcluded('unknown-session')).toBe(true)
-    expect(store.isCaptureExcluded(undefined)).toBe(true)
+    expect(store.isCaptureExcluded('bot-a', 'unknown-session')).toBe(true)
+    expect(store.isCaptureExcluded('bot-a', undefined)).toBe(true)
   })
 
   it('honors the daemon-local verdict until the CP confirms otherwise', () => {
     const store = newStore()
-    store.setLocalCaptureGate('acp-dm', true)
-    store.setLocalCaptureGate('acp-channel', false)
-    expect(store.isCaptureExcluded('acp-dm')).toBe(true)
-    expect(store.isCaptureExcluded('acp-channel')).toBe(false)
+    store.setLocalCaptureGate('bot-a', 'acp-dm', true)
+    store.setLocalCaptureGate('bot-a', 'acp-channel', false)
+    expect(store.isCaptureExcluded('bot-a', 'acp-dm')).toBe(true)
+    expect(store.isCaptureExcluded('bot-a', 'acp-channel')).toBe(false)
   })
 
   it('lets the CP-confirmed state win over the local verdict, in both directions', () => {
     const store = newStore()
     // A channel session the CP later pulls private (§4.3 tightening).
-    store.setLocalCaptureGate('acp-1', false)
-    expect(store.applyCpCaptureGate('acp-1', true, 1)).toBe('applied')
-    expect(store.isCaptureExcluded('acp-1')).toBe(true)
+    store.setLocalCaptureGate('bot-a', 'acp-1', false)
+    expect(store.applyCpCaptureGate('bot-a', 'acp-1', true, 1)).toBe('applied')
+    expect(store.isCaptureExcluded('bot-a', 'acp-1')).toBe(true)
     // An A2A child that starts excluded and is confirmed org-visible.
-    store.setLocalCaptureGate('acp-2', true)
-    expect(store.applyCpCaptureGate('acp-2', false, 1)).toBe('applied')
-    expect(store.isCaptureExcluded('acp-2')).toBe(false)
+    store.setLocalCaptureGate('bot-a', 'acp-2', true)
+    expect(store.applyCpCaptureGate('bot-a', 'acp-2', false, 1)).toBe('applied')
+    expect(store.isCaptureExcluded('bot-a', 'acp-2')).toBe(false)
   })
 
   it('applies a gate that arrives before the session exists locally', () => {
     const store = newStore()
-    expect(store.applyCpCaptureGate('acp-early', false, 3)).toBe('applied')
-    expect(store.isCaptureExcluded('acp-early')).toBe(false)
+    expect(store.applyCpCaptureGate('bot-a', 'acp-early', false, 3)).toBe('applied')
+    expect(store.isCaptureExcluded('bot-a', 'acp-early')).toBe(false)
     // A later local verdict must not clobber the CP's authoritative state.
-    store.setLocalCaptureGate('acp-early', true)
-    expect(store.isCaptureExcluded('acp-early')).toBe(false)
+    store.setLocalCaptureGate('bot-a', 'acp-early', true)
+    expect(store.isCaptureExcluded('bot-a', 'acp-early')).toBe(false)
   })
 
   it('lets an external (Slack/Feishu channel) session capture, following the gate not a hard deny', () => {
@@ -62,8 +62,8 @@ describe('capture gate — local state', () => {
       lastDeliveredTs: null,
       updatedAt: 1
     })
-    store.setLocalCaptureGate('acp-external', false)
-    expect(store.applyCpCaptureGate('acp-external', false, 1)).toBe('applied')
+    store.setLocalCaptureGate('bot-a', 'acp-external', false)
+    expect(store.applyCpCaptureGate('bot-a', 'acp-external', false, 1)).toBe('applied')
     store.setSessionClassification('slack:C1:T1:bot-a', {
       externalProvider: 'slack',
       externalRealmKey: 'W1',
@@ -82,10 +82,10 @@ describe('capture gate — local state', () => {
     })
 
     // External is no longer a hard deny: an org-confirmed external session captures.
-    expect(store.isCaptureExcluded('acp-external')).toBe(false)
+    expect(store.isCaptureExcluded('bot-a', 'acp-external')).toBe(false)
     // A private push still excludes it, proving it follows the gate.
-    expect(store.applyCpCaptureGate('acp-external', true, 2)).toBe('applied')
-    expect(store.isCaptureExcluded('acp-external')).toBe(true)
+    expect(store.applyCpCaptureGate('bot-a', 'acp-external', true, 2)).toBe('applied')
+    expect(store.isCaptureExcluded('bot-a', 'acp-external')).toBe(true)
     // Source-binding integrity is unchanged: the first-bound realm/resource wins;
     // only the optional integration id is backfilled.
     expect(store.getSessionClassification('bot-a', 'acp-external')).toMatchObject({
@@ -100,32 +100,80 @@ describe('capture gate — local state', () => {
 describe('capture gate — revision rule (§5.1 at-least-once)', () => {
   it('applies the initial revision, so fail-closed state is not mistaken for a duplicate', () => {
     const store = newStore()
-    expect(store.applyCpCaptureGate('acp-1', false, 0)).toBe('applied')
-    expect(store.isCaptureExcluded('acp-1')).toBe(false)
+    expect(store.applyCpCaptureGate('bot-a', 'acp-1', false, 0)).toBe('applied')
+    expect(store.isCaptureExcluded('bot-a', 'acp-1')).toBe(false)
   })
 
   it('reports a duplicate delivery as superseded WITHOUT reapplying it', () => {
     const store = newStore()
-    expect(store.applyCpCaptureGate('acp-1', true, 4)).toBe('applied')
+    expect(store.applyCpCaptureGate('bot-a', 'acp-1', true, 4)).toBe('applied')
     // The CP lost the first ack and retransmits the identical frame: still an
     // answer (never an error), just not a second application.
-    expect(store.applyCpCaptureGate('acp-1', true, 4)).toBe('superseded')
-    expect(store.isCaptureExcluded('acp-1')).toBe(true)
+    expect(store.applyCpCaptureGate('bot-a', 'acp-1', true, 4)).toBe('superseded')
+    expect(store.isCaptureExcluded('bot-a', 'acp-1')).toBe(true)
   })
 
   it('ignores an out-of-order older revision but keeps the newer state', () => {
     const store = newStore()
-    expect(store.applyCpCaptureGate('acp-1', true, 7)).toBe('applied')
-    expect(store.applyCpCaptureGate('acp-1', false, 6)).toBe('superseded')
-    expect(store.isCaptureExcluded('acp-1')).toBe(true)
-    expect(store.applyCpCaptureGate('acp-1', false, 8)).toBe('applied')
-    expect(store.isCaptureExcluded('acp-1')).toBe(false)
+    expect(store.applyCpCaptureGate('bot-a', 'acp-1', true, 7)).toBe('applied')
+    expect(store.applyCpCaptureGate('bot-a', 'acp-1', false, 6)).toBe('superseded')
+    expect(store.isCaptureExcluded('bot-a', 'acp-1')).toBe(true)
+    expect(store.applyCpCaptureGate('bot-a', 'acp-1', false, 8)).toBe('applied')
+    expect(store.isCaptureExcluded('bot-a', 'acp-1')).toBe(false)
   })
 
   it('treats a rev-0 push as superseded once a real revision is stored', () => {
     const store = newStore()
-    expect(store.applyCpCaptureGate('acp-1', true, 2)).toBe('applied')
-    expect(store.applyCpCaptureGate('acp-1', false, 0)).toBe('superseded')
-    expect(store.isCaptureExcluded('acp-1')).toBe(true)
+    expect(store.applyCpCaptureGate('bot-a', 'acp-1', true, 2)).toBe('applied')
+    expect(store.applyCpCaptureGate('bot-a', 'acp-1', false, 0)).toBe('superseded')
+    expect(store.isCaptureExcluded('bot-a', 'acp-1')).toBe(true)
+  })
+})
+
+describe('capture gate — key (#1037: ACP session ids are runtime-local)', () => {
+  it('keeps the gates of two organizations independent for the same ACP session id', () => {
+    const store = newStore()
+    // On the install-wide shared store both agents legitimately hold `acp-1`.
+    store.setLocalCaptureGate('org-x-agent', 'acp-1', true) // a private DM
+    store.setLocalCaptureGate('org-y-agent', 'acp-1', false) // an ordinary channel
+
+    // The CP publishes ONLY the other organization's session.
+    expect(store.applyCpCaptureGate('org-y-agent', 'acp-1', false, 1)).toBe('applied')
+
+    expect(store.isCaptureExcluded('org-x-agent', 'acp-1')).toBe(true)
+    expect(store.isCaptureExcluded('org-y-agent', 'acp-1')).toBe(false)
+
+    // And the reverse: pulling one private leaves the neighbour capturing.
+    expect(store.applyCpCaptureGate('org-x-agent', 'acp-1', true, 1)).toBe('applied')
+    expect(store.isCaptureExcluded('org-y-agent', 'acp-1')).toBe(false)
+  })
+
+  it('orders revisions per agent, so a higher rev next door cannot supersede a push', () => {
+    const store = newStore()
+    expect(store.applyCpCaptureGate('org-x-agent', 'acp-1', true, 9)).toBe('applied')
+    expect(store.applyCpCaptureGate('org-y-agent', 'acp-1', false, 1)).toBe('applied')
+    expect(store.isCaptureExcluded('org-x-agent', 'acp-1')).toBe(true)
+    expect(store.isCaptureExcluded('org-y-agent', 'acp-1')).toBe(false)
+  })
+
+  it('attributes a push from a CP too old to name the agent only when one agent holds the id', () => {
+    const store = newStore()
+    const put = (key: string, agentId: string) =>
+      store.upsertSession({
+        key,
+        agentId,
+        platform: 'slack',
+        channel: 'C1',
+        thread: key,
+        acpSessionId: 'acp-1',
+        state: 'idle',
+        lastDeliveredTs: null,
+        updatedAt: 1
+      })
+    put('x', 'org-x-agent')
+    expect(store.soleAgentForAcpSession('acp-1')).toBe('org-x-agent')
+    put('y', 'org-y-agent')
+    expect(store.soleAgentForAcpSession('acp-1')).toBeUndefined()
+    expect(store.soleAgentForAcpSession('acp-unknown')).toBeUndefined()
   })
 })

--- a/packages/protocol/src/frames/session-visibility.test.ts
+++ b/packages/protocol/src/frames/session-visibility.test.ts
@@ -35,6 +35,14 @@ describe('session/visibility frames (session-visibility.md §5.1)', () => {
     expect(SessionVisibilityPush.safeParse({ ...push, sessionId: '' }).success).toBe(false)
   })
 
+  it('carries the owning agent, optional so an older CP still decodes (#1037)', () => {
+    // ACP session ids are runtime-local, so the daemon keys its capture gate by
+    // (agent, session id) — the id alone would answer for a colliding neighbour.
+    expect(SessionVisibilityPush.parse(push).agentId).toBeUndefined()
+    expect(SessionVisibilityPush.parse({ ...push, agentId: AGENT_ID }).agentId).toBe(AGENT_ID)
+    expect(SessionVisibilityPush.safeParse({ ...push, agentId: '' }).success).toBe(false)
+  })
+
   it('SessionVisibilityOk carries both settlement statuses — superseded is an ACK, not an error', () => {
     const ok = { sessionId: 'acp-sess-01H9', visibilityRev: 3, status: 'applied' }
     expect(SessionVisibilityOk.parse(ok).status).toBe('applied')

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -265,6 +265,11 @@ export type ChildSessionStatusProbe = z.infer<typeof ChildSessionStatusProbe>
  */
 export const SessionVisibilityPush = z.object({
   sessionId: z.string().min(1), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+  // The session's owning agent. ACP session ids are runtime-local, so on a pool's
+  // shared store the id alone names a gate every org could claim. Optional for
+  // rolling upgrades: an older CP omits it and the daemon attributes the push to
+  // the sole local holder, or leaves the gate closed when there is no single one.
+  agentId: z.string().min(1).optional(),
   visibility: z.enum(['private', 'org', 'external']),
   // New daemons use this explicit capture/recall verdict. It is optional for
   // wire compatibility with older CPs and decouples the runtime safety gate


### PR DESCRIPTION
## Summary

`session_gates` — the daemon's memory-capture privacy gate — was keyed by the ACP
session id alone. ACP session ids are runtime-local (the store says so about itself
twice, and every adjacent table is keyed `(agentId, sessionId)` for exactly that
reason), so on the install-wide shared store the collision domain was every agent of
every organization in the install. This keys the gate by the owning agent as well,
threads the agent through the frame and the four call sites, and turns the revision
check into a CAS in the upsert.

Fixes #1037.

## Failure scenario

Two agents in different organizations open their first session; both runtimes mint
`acp-1`. Agent X's session is a DM, so it is locally excluded from memory capture;
agent Y's is an ordinary channel. The control plane pushes Y's `org` visibility and
`applyCpCaptureGate` upserts `cpPrivate = 0` on the row keyed `acp-1` — X's row.
`cpPrivate` is authoritative over `localExcluded`, so X's private DM becomes
capture-eligible and its content can be distilled into shared agent memory. The
reverse direction is equally available: Y's ordinary session inherits X's private
verdict and silently stops contributing memory.

`applyCpCaptureGate` compounded it by being a read-modify-write — it `SELECT`ed
`cpRev`, compared in JS, then upserted with no revision predicate on the update — so
two members applying pushes for two colliding ids could also invert the revision
ordering.

## Fix

- `session_gates` is keyed `(agentId, acpSessionId)`; `setLocalCaptureGate`,
  `applyCpCaptureGate`, `isCaptureExcluded` and the `deleteSession` cleanup all take
  the agent. `deleteSession` no longer needs its "still referenced by another agent"
  guard — the row it deletes is already the agent's own.
- The revision test moved into the upsert's `ON CONFLICT … WHERE`, so the compare and
  the write are one statement. Semantics are unchanged: a rev at or below the stored
  one is not reapplied but is still acknowledged as `superseded`, and rev 0 still
  applies once while nothing newer is held.
- `session/visibility` (and its register-time snapshot) now carries `agentId`. It is
  optional on the wire for rolling upgrades: a control plane too old to send it leaves
  only the runtime-local id, which the daemon attributes to the sole local holder of
  that id, and where there is no single holder the gate stays closed — the frame is
  still acknowledged, never errored.
- Migration (`SCHEMA_MIGRATIONS` step, `SCHEMA_VERSION` 5 → 6) rebuilds the table with
  the wider key and attributes each existing row through the sessions row that holds
  the ACP id. A row no session claims is dropped; an id several agents claim is
  rewritten to the fail-closed state, because its stored verdict was never attributable
  to one of them. SQLite single-daemon behavior is unchanged — there the id has one
  holder, so every row keeps its verdict.

## Test plan

- `packages/daemon/test/session-capture-gate.test.ts`: two organizations' sessions with
  the same ACP id keep independent gates in both directions; a higher revision next door
  cannot supersede a push; the older-CP attribution resolves only when one agent holds
  the id. All existing gate tests pass unchanged apart from the new agent argument.
- `packages/daemon/test/local-store.test.ts`: upgrading a v5 store re-keys the gate,
  carries an attributable verdict through, and fail-closes an ambiguous one; the
  `deleteSession` cascade now asserts that a neighbour's gate on the same ACP id survives.
- `packages/protocol/src/frames/session-visibility.test.ts`: `agentId` rides when present
  and stays optional so an older CP still decodes.
- `pnpm --filter @agentconnect.md/daemon typecheck`, `pnpm lint`, `pnpm format:check`.
- Suites run: daemon `local-store`, `session-capture-gate`, `daemon-transcript`,
  `daemon-interrupt-safety`, `daemon-lifecycle`, `memory-write-gate`,
  `external-memory-provider`, `daemon-message-agent`; full protocol suite; control-plane
  `test:unit` plus the `session-visibility.route` integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
