### PR TITLE
fix(control-plane): resolve the serving member on every pool-agent write, report and replay

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -676,7 +676,8 @@ export function buildContainer(
     undefined,
     { warn: (o, m) => http.log.warn(o, m) },
     repos.agent,
-    agentRouting
+    agentRouting,
+    visibilityPush
   )
   // Duty-group projection: derived from Integration/CronDef rows on a rotation;
   // deltas reach daemons via the heartbeat lease exchange, never from the sweep.

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -628,6 +628,9 @@ export function buildContainer(
     control: sender,
     connReg,
     placement: placementResolver,
+    // The replay's inverse half: a reconnecting member's served set, not the recorded column.
+    duties: repos.dutyGroup,
+    clock,
     // Lazy over `http.log` (assigned below; only ever called at push time).
     log: { warn: (o, m) => http.log.warn(o, m) }
   })

--- a/packages/control-plane/src/domain/placement.ts
+++ b/packages/control-plane/src/domain/placement.ts
@@ -101,6 +101,12 @@ export function samePlacement(a: PlacementTarget, b: PlacementTarget): boolean {
   return a.kind !== 'set' || a.setId === (b as { setId: string }).setId
 }
 
+/** Do two reads of one agent name the same placement? The identity a mutation fences on —
+ *  `daemonId` alone misses a set change and reads every set placement as unplaced. */
+export function samePlacementRef(a: PlacementRef, b: PlacementRef): boolean {
+  return samePlacement(placementTargetOf(a), placementTargetOf(b))
+}
+
 /** A stable label for logs and conflict messages — never a raw member id for a set placement. */
 export function placementLabel(target: PlacementTarget): string {
   return target.kind === 'daemon' ? target.daemonId : target.kind

--- a/packages/control-plane/src/http/routes/crons.ts
+++ b/packages/control-plane/src/http/routes/crons.ts
@@ -22,6 +22,7 @@ import { canView, canEdit, canManageSharing, type ViewCtx } from '../../authoriz
 import { resolveShareSet } from '../sharing.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { cronToUpsert } from '../../orchestrator/placement.js'
+import { samePlacementRef } from '../../domain/placement.js'
 import { toDbPlatform } from '../../persistence/platform.js'
 import { Tag } from '../plugins/openapi.js'
 import {
@@ -67,11 +68,13 @@ function toDto(c: CronRecord, ctx: ViewCtx): CronDtoT {
 export function cronRoutes(deps: HttpDeps) {
   return async function cronRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
+    // Placement IDENTITY, not the `daemonId` column: a set placement names no machine, so column
+    // equality both misses a re-placement onto another set and reads every set agent as unplaced.
     const refreshMutationAgent = async (observed: AgentRecord): Promise<AgentRecord | null> => {
       const current = await deps.repos.agent.get(observed.orgId, observed.id)
       if (
         !current ||
-        current.daemonId !== observed.daemonId ||
+        !samePlacementRef(current, observed) ||
         current.lastModifiedAt.getTime() !== observed.lastModifiedAt.getTime()
       ) {
         return null
@@ -335,16 +338,14 @@ export function cronRoutes(deps: HttpDeps) {
         if (!canEdit(cron, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot run this cron' })
         }
-        let agent = cron.agentId ? await deps.repos.agent.get(orgOf(req), cron.agentId) : null
+        const agent = cron.agentId ? await deps.repos.agent.get(orgOf(req), cron.agentId) : null
         // A manual run goes to whoever serves the agent right now — its placement, or the member
         // holding its duty. Nothing serving it is a 503, exactly as an unplaced agent was.
-        const runDaemonId = agent ? await deps.placementResolver.servingDaemon(agent) : null
-        if (!agent || !runDaemonId) {
+        if (!agent || !(await deps.placementResolver.servingDaemon(agent))) {
           return reply
             .code(503)
             .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent is not placed on a daemon' })
         }
-        agent = { ...agent, daemonId: runDaemonId }
         const release = deps.agentMutations.tryBeginMutation(agent.id)
         if (!release) {
           return reply
@@ -360,8 +361,9 @@ export function cronRoutes(deps: HttpDeps) {
               message: 'agent placement changed; refresh and retry the cron run'
             })
           }
-          agent = current
-          const daemonId = current.daemonId
+          // Re-resolved under the lease rather than read off the row, so the fire reaches the
+          // member serving a pool agent instead of refusing on a column that names no machine.
+          const daemonId = await deps.placementResolver.servingDaemon(current)
           if (!daemonId) {
             return reply
               .code(409)

--- a/packages/control-plane/src/http/routes/feishu-registration.ts
+++ b/packages/control-plane/src/http/routes/feishu-registration.ts
@@ -212,11 +212,15 @@ export function feishuRegistrationRoutes(deps: HttpDeps, feishu: FeishuRouteSeam
           let httpAppConfig: ConfigureFeishuHttpAppInput | undefined
           try {
             const current = await deps.repos.agent.get(orgOf(req), registration.agentId)
-            if (!current || !current.daemonId || !canView(current, ctxOf(req)) || !canEdit(current, ctxOf(req))) {
+            if (!current || !canView(current, ctxOf(req)) || !canEdit(current, ctxOf(req))) {
               throw new FeishuRegistrationSetupError('agent_unavailable')
             }
+            // Resolved under the lease, exactly as the start leg resolved it: the column is null
+            // for a pool agent, so re-reading it would refuse every registration one finishes.
+            const finalizeDaemonId = await deps.placementResolver.servingDaemon(current)
+            if (!finalizeDaemonId) throw new FeishuRegistrationSetupError('agent_unavailable')
             const availability = await integrationPlatformAvailability(deps, {
-              daemonId: current.daemonId,
+              daemonId: finalizeDaemonId,
               orgId: registration.orgId,
               viewer: ctxOf(req),
               platform: 'feishu'

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -28,6 +28,7 @@ import type { ResolvableAgent } from '../../orchestrator/placementResolver.js'
 import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
+import { samePlacementRef } from '../../domain/placement.js'
 import { conversationOwnerRow, pickConversationOwner } from '../../orchestrator/httpBot.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewBot } from '../install-bot.js'
@@ -86,11 +87,13 @@ export function integrationRoutes(deps: HttpDeps) {
     const CreateIntegrationBody = buildCreateIntegrationBody(deps.platforms)
     // The caller's active org — every read/write below is scoped to it.
     const orgIdOf = (req: { orgCtx?: { orgId: OrgId } }) => req.orgCtx!.orgId
+    // Placement IDENTITY, not the `daemonId` column: a set placement names no machine, so column
+    // equality both misses a re-placement onto another set and reads every set agent as unplaced.
     const refreshMutationAgent = async (observed: AgentRecord): Promise<AgentRecord | null> => {
       const current = await deps.repos.agent.get(observed.orgId, observed.id)
       if (
         !current ||
-        current.daemonId !== observed.daemonId ||
+        !samePlacementRef(current, observed) ||
         current.lastModifiedAt.getTime() !== observed.lastModifiedAt.getTime()
       ) {
         return null
@@ -259,8 +262,9 @@ export function integrationRoutes(deps: HttpDeps) {
             })
           }
           agent = current
-          const daemonId = current.daemonId
-          if (!daemonId) {
+          // Re-taken under the lease, and RESOLVED: the column is null for a pool agent, which is
+          // served without naming a machine. Nothing serving it is what "no longer placed" means.
+          if (!(await deps.placementResolver.servingDaemon(current))) {
             return reply.code(409).send({
               error: 'Conflict',
               statusCode: 409,
@@ -672,9 +676,12 @@ export function integrationRoutes(deps: HttpDeps) {
           message: 'the daemon is offline, so this conversation would be listed again — retry once it reconnects'
         }
       }
-      if (!agent.daemonId) return undeliverable
+      // The suppression goes to whoever serves the agent right now — its placement, or the member
+      // holding its duty. A pool agent names no machine, so the column would refuse every one.
+      const target = await deps.placementResolver.servingDaemon(agent)
+      if (!target) return undeliverable
       try {
-        const ack = await deps.control.integrationForget(agent.daemonId, { integrationId: integration.id, channels })
+        const ack = await deps.control.integrationForget(target, { integrationId: integration.id, channels })
         if (ack.ok) return { ok: true }
         return {
           ok: false,
@@ -1074,8 +1081,9 @@ export function integrationRoutes(deps: HttpDeps) {
           }
           // The daemon holding this integration owns provider egress for it in BOTH
           // transports — a relay-managed bot still keeps send credentials — so the
-          // platform call belongs to the agent's own daemon either way.
-          if (!placed.daemonId) {
+          // platform call belongs to whichever member serves the agent, resolved not read.
+          const egressDaemonId = await deps.placementResolver.servingDaemon(placed)
+          if (!egressDaemonId) {
             return reply.code(409).send({
               error: 'Conflict',
               statusCode: 409,
@@ -1084,7 +1092,7 @@ export function integrationRoutes(deps: HttpDeps) {
           }
           let verdict
           try {
-            verdict = await deps.control.integrationLeave(placed.daemonId, { integrationId: integration.id, target })
+            verdict = await deps.control.integrationLeave(egressDaemonId, { integrationId: integration.id, target })
           } catch (err) {
             return reply.code(502).send({
               error: 'Bad Gateway',

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -24,6 +24,7 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import { AgentId, OrgId } from '../../domain/ids.js'
+import { samePlacementRef } from '../../domain/placement.js'
 import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { resolveWebAppUrl } from '../../config/env.js'
@@ -103,13 +104,16 @@ export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
         }
-        if (!agent.daemonId) {
+        // Delivery is daemon-scoped; refuse until the agent is placed. A pool agent IS placed and
+        // names no machine, so the capability probe asks whichever member serves it.
+        const installDaemonId = await deps.placementResolver.servingDaemon(agent)
+        if (!installDaemonId) {
           return reply
             .code(409)
             .send({ error: 'Conflict', statusCode: 409, message: 'agent must be placed on a daemon first' })
         }
         const platformAvailability = await integrationPlatformAvailability(deps, {
-          daemonId: agent.daemonId,
+          daemonId: installDaemonId,
           orgId,
           viewer: ctxOf(req),
           platform: 'slack'
@@ -343,13 +347,15 @@ export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
         }
-        if (!agent.daemonId) {
+        // A pool agent IS placed and names no machine; the probe asks whichever member serves it.
+        const installDaemonId = await deps.placementResolver.servingDaemon(agent)
+        if (!installDaemonId) {
           return reply
             .code(409)
             .send({ error: 'Conflict', statusCode: 409, message: 'agent must be placed on a daemon first' })
         }
         const platformAvailability = await integrationPlatformAvailability(deps, {
-          daemonId: agent.daemonId,
+          daemonId: installDaemonId,
           orgId,
           viewer: ctxOf(req),
           platform: 'slack'
@@ -406,10 +412,11 @@ export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
           // Token verification and capability checks above can take long enough
           // for placement to change. Re-read after taking the mutation side of
           // the move gate so the bot cannot be installed onto a stale daemon.
+          // Placement IDENTITY, not the column: a set placement names no machine.
           const current = await deps.repos.agent.get(orgOf(req), agent.id)
           if (
             !current ||
-            current.daemonId !== agent.daemonId ||
+            !samePlacementRef(current, agent) ||
             current.lastModifiedAt.getTime() !== agent.lastModifiedAt.getTime()
           ) {
             return reply.code(409).send({

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -136,7 +136,12 @@ export class DutyLeaseService {
      *  moves who serves the agent, so the hook rules, HTTP-bot assignment and collaboration
      *  snapshot have to follow — otherwise the ledger heals and ingress keeps arriving at the
      *  member that lost it. Absent (tests / no pool) ⇒ no convergence, the pre-duty behavior. */
-    private readonly routing?: { kick(agentIds: Iterable<string>): void }
+    private readonly routing?: { kick(agentIds: Iterable<string>): void },
+    /** Converges the per-session capture gates of what this member now serves. A member registers
+     *  BEFORE it holds anything, so register-time replay alone leaves a duty acquired later with
+     *  no gate state at all (the duty bundle carries none). Absent ⇒ no replay, the pre-duty
+     *  behavior. */
+    private readonly visibility?: { replayTo(daemonId: DaemonId): Promise<void> }
   ) {
     this.bootedAtMs = clock.now()
   }
@@ -351,6 +356,13 @@ export class DutyLeaseService {
     if (confirmed.length > 0) {
       const groups = held.filter((g) => confirmed.includes(g.groupId))
       this.routing?.kick(agentIdsOf(groups))
+      // Same moment, same reason: what this member now serves includes sessions whose capture gate
+      // was tightened while someone else held them. Register-time replay cannot have carried them
+      // — the member held nothing then. Best-effort; `confirmHeld` fires once per grant, not per
+      // beat, and the daemon fails closed on an unknown gate until this lands.
+      void this.visibility
+        ?.replayTo(daemonId)
+        .catch((err) => this.log?.warn({ daemonId, err }, 'visibility replay on duty admission failed'))
     }
 
     // Re-issue held groups the member does not know it holds (restart / lost

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -48,6 +48,19 @@ function connReg(opts: { connected?: boolean; feature?: boolean; externalFeature
   } as never
 }
 
+/**
+ * The agent repo as the service reads it from BOTH sides: the live push resolves one agent's
+ * serving member, the replay asks which agents the connecting member serves.
+ */
+function agentRepo(daemonId: string | null | undefined = DAEMON) {
+  const agent = daemonId ? { id: AGENT, daemonId } : { id: AGENT }
+  return {
+    getUnscoped: vi.fn(async () => agent),
+    listForDaemon: vi.fn(async () => (daemonId ? [agent] : [])),
+    listByIds: vi.fn(async () => [])
+  } as never
+}
+
 function deps(
   over: {
     connReg?: never
@@ -71,23 +84,23 @@ function deps(
   const daemonId = over.daemonId === undefined ? DAEMON : over.daemonId
   const pages = [...(over.snapshotPages ?? [[]])]
   const unacked = [...(over.unackedAfter ?? [0])]
-  const visibilitySnapshotForDaemon = vi.fn(async () => pages.shift() ?? [])
-  const countUnackedVisibility = vi.fn(async () => unacked.shift() ?? 0)
+  const visibilitySnapshotForAgents = vi.fn(async () => pages.shift() ?? [])
+  const countUnackedVisibilityForAgents = vi.fn(async () => unacked.shift() ?? 0)
   const sessionVisibilitySnapshot = vi.fn(async () => ({ ok: true }))
   return {
     recordVisibilityAck,
     sessionVisibility,
-    visibilitySnapshotForDaemon,
+    visibilitySnapshotForAgents,
     sessionVisibilitySnapshot,
     push: new SessionVisibilityPushService({
       repos: {
         session: {
           recordVisibilityAck,
-          visibilitySnapshotForDaemon,
-          countUnackedVisibility,
+          visibilitySnapshotForAgents,
+          countUnackedVisibilityForAgents,
           get: vi.fn(async () => null)
         } as never,
-        agent: { getUnscoped: vi.fn(async () => (daemonId ? { id: AGENT, daemonId } : { id: AGENT })) } as never
+        agent: agentRepo(daemonId)
       },
       control: { sessionVisibility, sessionVisibilitySnapshot } as never,
       connReg: over.connReg ?? connReg(),
@@ -193,7 +206,7 @@ describe('replayTo — register-time convergence', () => {
     const d = deps({ snapshotPages: [page(3)] })
     await d.push.replayTo(DAEMON as never)
     expect(d.sessionVisibilitySnapshot).toHaveBeenCalledTimes(1)
-    expect(d.visibilitySnapshotForDaemon).toHaveBeenCalledTimes(1)
+    expect(d.visibilitySnapshotForAgents).toHaveBeenCalledTimes(1)
   })
 
   it('splits a shared daemon snapshot into one organization-scoped request per org', async () => {
@@ -224,18 +237,18 @@ describe('replayTo — register-time convergence', () => {
       // as fast as we ack. A round cap would walk away from gates we KNOW are
       // stale; the loop must yield and come back instead.
       const warn = vi.fn()
-      const visibilitySnapshotForDaemon = vi.fn(async () => page(500))
-      const countUnackedVisibility = vi.fn(async () => 5_000)
+      const visibilitySnapshotForAgents = vi.fn(async () => page(500))
+      const countUnackedVisibilityForAgents = vi.fn(async () => 5_000)
       const sessionVisibilitySnapshot = vi.fn(async () => ({ ok: true }))
       const push = new SessionVisibilityPushService({
         repos: {
           session: {
             recordVisibilityAck: vi.fn(async () => {}),
-            visibilitySnapshotForDaemon,
-            countUnackedVisibility,
+            visibilitySnapshotForAgents,
+            countUnackedVisibilityForAgents,
             get: vi.fn(async () => null)
           } as never,
-          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: agentRepo(DAEMON)
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
         connReg: connReg(),
@@ -267,17 +280,17 @@ describe('replayTo — register-time convergence', () => {
       // A repo read rejects OUTSIDE sendSnapshotChunk's catch. Left unhandled it
       // would both surface as an unhandled rejection and strand the gates we
       // already know are stale.
-      const visibilitySnapshotForDaemon = vi.fn().mockRejectedValueOnce(new Error('db down')).mockResolvedValue(page(2))
+      const visibilitySnapshotForAgents = vi.fn().mockRejectedValueOnce(new Error('db down')).mockResolvedValue(page(2))
       const sessionVisibilitySnapshot = vi.fn(async () => ({ ok: true }))
       const push = new SessionVisibilityPushService({
         repos: {
           session: {
             recordVisibilityAck: vi.fn(async () => {}),
-            visibilitySnapshotForDaemon,
-            countUnackedVisibility: vi.fn(async () => 0),
+            visibilitySnapshotForAgents,
+            countUnackedVisibilityForAgents: vi.fn(async () => 0),
             get: vi.fn(async () => null)
           } as never,
-          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: agentRepo(DAEMON)
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
         connReg: connReg(),
@@ -299,16 +312,16 @@ describe('replayTo — register-time convergence', () => {
   it('stops scheduling once shut down, and settles a resume that already fired', async () => {
     vi.useFakeTimers()
     try {
-      const visibilitySnapshotForDaemon = vi.fn(async () => page(500))
+      const visibilitySnapshotForAgents = vi.fn(async () => page(500))
       const push = new SessionVisibilityPushService({
         repos: {
           session: {
             recordVisibilityAck: vi.fn(async () => {}),
-            visibilitySnapshotForDaemon,
-            countUnackedVisibility: vi.fn(async () => 5_000),
+            visibilitySnapshotForAgents,
+            countUnackedVisibilityForAgents: vi.fn(async () => 5_000),
             get: vi.fn(async () => null)
           } as never,
-          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: agentRepo(DAEMON)
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot: vi.fn(async () => ({ ok: true })) } as never,
         connReg: connReg(),
@@ -317,13 +330,13 @@ describe('replayTo — register-time convergence', () => {
 
       await push.replayTo(DAEMON as never) // stalls, arms a resume
       push.stop()
-      const callsAtShutdown = visibilitySnapshotForDaemon.mock.calls.length
+      const callsAtShutdown = visibilitySnapshotForAgents.mock.calls.length
       await vi.advanceTimersByTimeAsync(60_000)
       await push.settle()
       // Nothing re-armed and nothing touched the database after shutdown.
-      expect(visibilitySnapshotForDaemon.mock.calls.length).toBe(callsAtShutdown)
+      expect(visibilitySnapshotForAgents.mock.calls.length).toBe(callsAtShutdown)
       await expect(push.replayTo(DAEMON as never)).resolves.toBeUndefined()
-      expect(visibilitySnapshotForDaemon.mock.calls.length).toBe(callsAtShutdown)
+      expect(visibilitySnapshotForAgents.mock.calls.length).toBe(callsAtShutdown)
     } finally {
       vi.useRealTimers()
     }
@@ -342,11 +355,11 @@ describe('replayTo — register-time convergence', () => {
         repos: {
           session: {
             recordVisibilityAck: vi.fn(async () => {}),
-            visibilitySnapshotForDaemon: vi.fn(async () => page(2)),
-            countUnackedVisibility: vi.fn(async () => 0),
+            visibilitySnapshotForAgents: vi.fn(async () => page(2)),
+            countUnackedVisibilityForAgents: vi.fn(async () => 0),
             get: vi.fn(async () => null)
           } as never,
-          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: agentRepo(DAEMON)
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
         connReg: connReg(),
@@ -372,11 +385,11 @@ describe('replayTo — register-time convergence', () => {
         repos: {
           session: {
             recordVisibilityAck,
-            visibilitySnapshotForDaemon: vi.fn(async () => page(2)),
-            countUnackedVisibility: vi.fn(async () => 0),
+            visibilitySnapshotForAgents: vi.fn(async () => page(2)),
+            countUnackedVisibilityForAgents: vi.fn(async () => 0),
             get: vi.fn(async () => null)
           } as never,
-          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: agentRepo(DAEMON)
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
         connReg: connReg(),
@@ -400,16 +413,16 @@ describe('replayTo — register-time convergence', () => {
       const sessionVisibilitySnapshot = vi.fn(async () => {
         throw new NoConnection(DAEMON)
       })
-      const visibilitySnapshotForDaemon = vi.fn(async () => page(500))
+      const visibilitySnapshotForAgents = vi.fn(async () => page(500))
       const push = new SessionVisibilityPushService({
         repos: {
           session: {
             recordVisibilityAck: vi.fn(async () => {}),
-            visibilitySnapshotForDaemon,
-            countUnackedVisibility: vi.fn(async () => 10),
+            visibilitySnapshotForAgents,
+            countUnackedVisibilityForAgents: vi.fn(async () => 10),
             get: vi.fn(async () => null)
           } as never,
-          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: agentRepo(DAEMON)
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
         connReg: connReg(),
@@ -419,7 +432,7 @@ describe('replayTo — register-time convergence', () => {
       await push.replayTo(DAEMON as never)
       await vi.advanceTimersByTimeAsync(60_000)
       await push.settle()
-      expect(visibilitySnapshotForDaemon).toHaveBeenCalledTimes(1)
+      expect(visibilitySnapshotForAgents).toHaveBeenCalledTimes(1)
       push.stop()
     } finally {
       vi.useRealTimers()
@@ -429,7 +442,7 @@ describe('replayTo — register-time convergence', () => {
   it('sends nothing to a daemon that does not advertise the feature', async () => {
     const d = deps({ snapshotPages: [page(3)], connReg: connReg({ feature: false }) as never })
     await d.push.replayTo(DAEMON as never)
-    expect(d.visibilitySnapshotForDaemon).not.toHaveBeenCalled()
+    expect(d.visibilitySnapshotForAgents).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -71,6 +71,8 @@ function deps(
       Array<{ orgId: string; sessionId: string; visibility: 'private' | 'org' | 'external'; visibilityRev: number }>
     >
     unackedAfter?: number[]
+    /** Successive PRIVATE pages (phase 2), newest call first. */
+    privatePages?: Array<Array<{ orgId: string; sessionId: string; visibility: 'private'; visibilityRev: number }>>
   } = {}
 ) {
   const recordVisibilityAck = vi.fn(async () => {})
@@ -84,13 +86,16 @@ function deps(
   const daemonId = over.daemonId === undefined ? DAEMON : over.daemonId
   const pages = [...(over.snapshotPages ?? [[]])]
   const unacked = [...(over.unackedAfter ?? [0])]
+  const privatePages = [...(over.privatePages ?? [[]])]
   const visibilitySnapshotForAgents = vi.fn(async () => pages.shift() ?? [])
   const countUnackedVisibilityForAgents = vi.fn(async () => unacked.shift() ?? 0)
+  const privateVisibilityPage = vi.fn(async () => privatePages.shift() ?? [])
   const sessionVisibilitySnapshot = vi.fn(async () => ({ ok: true }))
   return {
     recordVisibilityAck,
     sessionVisibility,
     visibilitySnapshotForAgents,
+    privateVisibilityPage,
     sessionVisibilitySnapshot,
     push: new SessionVisibilityPushService({
       repos: {
@@ -98,6 +103,7 @@ function deps(
           recordVisibilityAck,
           visibilitySnapshotForAgents,
           countUnackedVisibilityForAgents,
+          privateVisibilityPage,
           get: vi.fn(async () => null)
         } as never,
         agent: agentRepo(daemonId)
@@ -246,6 +252,7 @@ describe('replayTo — register-time convergence', () => {
             recordVisibilityAck: vi.fn(async () => {}),
             visibilitySnapshotForAgents,
             countUnackedVisibilityForAgents,
+            privateVisibilityPage: vi.fn(async () => []),
             get: vi.fn(async () => null)
           } as never,
           agent: agentRepo(DAEMON)
@@ -288,6 +295,7 @@ describe('replayTo — register-time convergence', () => {
             recordVisibilityAck: vi.fn(async () => {}),
             visibilitySnapshotForAgents,
             countUnackedVisibilityForAgents: vi.fn(async () => 0),
+            privateVisibilityPage: vi.fn(async () => []),
             get: vi.fn(async () => null)
           } as never,
           agent: agentRepo(DAEMON)
@@ -319,6 +327,7 @@ describe('replayTo — register-time convergence', () => {
             recordVisibilityAck: vi.fn(async () => {}),
             visibilitySnapshotForAgents,
             countUnackedVisibilityForAgents: vi.fn(async () => 5_000),
+            privateVisibilityPage: vi.fn(async () => []),
             get: vi.fn(async () => null)
           } as never,
           agent: agentRepo(DAEMON)
@@ -357,6 +366,7 @@ describe('replayTo — register-time convergence', () => {
             recordVisibilityAck: vi.fn(async () => {}),
             visibilitySnapshotForAgents: vi.fn(async () => page(2)),
             countUnackedVisibilityForAgents: vi.fn(async () => 0),
+            privateVisibilityPage: vi.fn(async () => []),
             get: vi.fn(async () => null)
           } as never,
           agent: agentRepo(DAEMON)
@@ -387,6 +397,7 @@ describe('replayTo — register-time convergence', () => {
             recordVisibilityAck,
             visibilitySnapshotForAgents: vi.fn(async () => page(2)),
             countUnackedVisibilityForAgents: vi.fn(async () => 0),
+            privateVisibilityPage: vi.fn(async () => []),
             get: vi.fn(async () => null)
           } as never,
           agent: agentRepo(DAEMON)
@@ -420,6 +431,7 @@ describe('replayTo — register-time convergence', () => {
             recordVisibilityAck: vi.fn(async () => {}),
             visibilitySnapshotForAgents,
             countUnackedVisibilityForAgents: vi.fn(async () => 10),
+            privateVisibilityPage: vi.fn(async () => []),
             get: vi.fn(async () => null)
           } as never,
           agent: agentRepo(DAEMON)
@@ -437,6 +449,47 @@ describe('replayTo — register-time convergence', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  // The ACK watermark is per SESSION, not per daemon: once duty can move a session's server, a
+  // previous holder's ack marks a gate "delivered" to a member that never saw it. Phase 1 then
+  // stops on `unacked === 0` and the older private gates are never sent. Phase 2 is what covers
+  // them, so it must run even when phase 1 reports full convergence.
+  it('re-sends the private gates after the unacked phase reports nothing outstanding', async () => {
+    const priv = [{ orgId: ORG, sessionId: 'acp-old-private', visibility: 'private' as const, visibilityRev: 3 }]
+    const d = deps({ snapshotPages: [page(500)], unackedAfter: [0], privatePages: [priv] })
+    await d.push.replayTo(DAEMON as never)
+
+    expect(d.privateVisibilityPage).toHaveBeenCalledTimes(1)
+    const sent = d.sessionVisibilitySnapshot.mock.calls.at(-1)!
+    expect((sent[2] as Array<{ sessionId: string }>).map((e) => e.sessionId)).toEqual(['acp-old-private'])
+  })
+
+  it('cursors the private phase on the last id of a full page', async () => {
+    const full = Array.from({ length: 500 }, (_, i) => ({
+      orgId: ORG,
+      sessionId: `acp-p-${String(i).padStart(3, '0')}`,
+      visibility: 'private' as const,
+      visibilityRev: 1
+    }))
+    const tail = [{ orgId: ORG, sessionId: 'acp-p-500', visibility: 'private' as const, visibilityRev: 1 }]
+    const d = deps({ privatePages: [full, tail] })
+    await d.push.replayTo(DAEMON as never)
+
+    expect(d.privateVisibilityPage).toHaveBeenCalledTimes(2)
+    // Blind to the watermark, so the cursor is the ONLY thing that ends the walk.
+    expect(d.privateVisibilityPage.mock.calls[1]![3]).toBe('acp-p-499')
+  })
+
+  it('does not start the private phase when the unacked phase aborted', async () => {
+    const d = deps({ snapshotPages: [page(500), page(500, 500)], unackedAfter: [500, 0] })
+    d.sessionVisibilitySnapshot.mockImplementationOnce(async () => {
+      throw new NoConnection(DAEMON)
+    })
+    await d.push.replayTo(DAEMON as never)
+
+    // The daemon is gone; its next register redoes both phases from scratch.
+    expect(d.privateVisibilityPage).not.toHaveBeenCalled()
   })
 
   it('sends nothing to a daemon that does not advertise the feature', async () => {

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -41,7 +41,7 @@ import { NoConnection, type ControlSender } from './outbound.js'
 
 /** Entries per snapshot frame. The schema caps at 1000; stay well under the
  *  256 KiB frame ceiling. */
-const SNAPSHOT_CHUNK = 500
+export const SNAPSHOT_CHUNK = 500
 /** How long to wait before resuming a replay that stalled — i.e. one where the
  *  unacknowledged set stopped shrinking because new changes are landing as fast
  *  as we ack them. A pause, never an abandonment: the remaining gates are known
@@ -184,6 +184,23 @@ export class SessionVisibilityPushService {
   }
 
   /**
+   * TWO phases, because one watermark cannot answer both questions.
+   *
+   * The unacked phase converges what the CP knows is outstanding; the private phase converges what
+   * it cannot know, because `visibilityAckedRev` is per SESSION and not per daemon — once duty can
+   * move a session's server, an ack from the previous holder marks a gate "delivered" to a member
+   * that never saw it. The second phase runs only if the first drained normally; an abort already
+   * armed a resume that redoes both.
+   */
+  private async replayPages(daemonId: DaemonId): Promise<void> {
+    const includeExternal = this.supportsExternal(daemonId)
+    // What phase 1 already put on the wire, so phase 2 re-sends only what it did not cover.
+    const sent = new Set<string>()
+    if (!(await this.replayUnackedPages(daemonId, includeExternal, sent))) return
+    await this.replayPrivatePages(daemonId, includeExternal, sent)
+  }
+
+  /**
    * Page until nothing is left unacknowledged. Ordering alone is not enough:
    * with more unacked rows than one page holds, a single pass would ack the
    * first page and leave the rest carrying a stale gate until some LATER
@@ -193,34 +210,75 @@ export class SessionVisibilityPushService {
    * the unacknowledged set strictly shrinks and the loop ends. A fixed cap would
    * instead walk away from gates we KNOW are stale, which is the privacy gap
    * this replay exists to close.
+   *
+   * Returns whether it drained rather than aborted — false means a resume is armed, or the daemon
+   * is gone and its next register starts over.
    */
-  private async replayPages(daemonId: DaemonId): Promise<void> {
+  private async replayUnackedPages(daemonId: DaemonId, includeExternal: boolean, sent: Set<string>): Promise<boolean> {
     let previousUnacked = Number.POSITIVE_INFINITY
-    const includeExternal = this.supportsExternal(daemonId)
     for (;;) {
-      if (this.stopped) return // shutdown: the next process converges on register
+      if (this.stopped) return false // shutdown: the next process converges on register
       // Re-resolved each round: a duty granted mid-replay widens the set the very next page.
       const agentIds = await this.servedAgentIds(daemonId)
       const page = await this.deps.repos.session.visibilitySnapshotForAgents(agentIds, SNAPSHOT_CHUNK, includeExternal)
-      if (page.length === 0) return
+      if (page.length === 0) return true
       const outcome = await this.sendSnapshotChunk(daemonId, page)
-      if (outcome === 'gone') return // disconnected: its next register replays
+      if (outcome === 'sent') for (const entry of page) sent.add(entry.sessionId)
+      if (outcome === 'gone') return false // disconnected: its next register replays
       if (outcome === 'retry') {
         // Still connected, but this page did not land. Nothing else is coming
         // back for the tail on its own, so resume it ourselves.
         this.scheduleRetry(daemonId, 'failed')
-        return
+        return false
       }
-      if (page.length < SNAPSHOT_CHUNK) return // the page was not full: nothing behind it
+      if (page.length < SNAPSHOT_CHUNK) return true // the page was not full: nothing behind it
       const unacked = await this.deps.repos.session.countUnackedVisibilityForAgents(agentIds, includeExternal)
-      if (unacked === 0) return
+      if (unacked === 0) return true
       if (unacked >= previousUnacked) {
         // Not converging — new changes are arriving at least as fast as we ack.
         // Yield and resume rather than spin, and rather than leave it to chance.
         this.scheduleRetry(daemonId, unacked)
-        return
+        return false
       }
       previousUnacked = unacked
+    }
+  }
+
+  /**
+   * Re-send every currently-private gate of the served agents, cursored and blind to the ack
+   * watermark.
+   *
+   * A member that never heard of a session already fails closed, so the only way capture reopens is
+   * a stale NON-private gate left over from an earlier hold — and duty revocation deliberately
+   * preserves that local state. So the set that has to land is exactly the private one, which is
+   * the explicitly-reclassified minority rather than every session ever recorded. Idempotent by
+   * revision on the daemon: a member that already holds the gate answers `superseded`.
+   */
+  private async replayPrivatePages(daemonId: DaemonId, includeExternal: boolean, sent: Set<string>): Promise<void> {
+    let afterId: string | undefined
+    for (;;) {
+      if (this.stopped) return
+      const agentIds = await this.servedAgentIds(daemonId)
+      const page = await this.deps.repos.session.privateVisibilityPage(
+        agentIds,
+        SNAPSHOT_CHUNK,
+        includeExternal,
+        afterId
+      )
+      if (page.length === 0) return
+      // Filter AFTER the page is in hand: the cursor walks raw rows, so a page covered entirely by
+      // phase 1 still advances it instead of stalling the walk.
+      const fresh = page.filter((entry) => !sent.has(entry.sessionId))
+      if (fresh.length > 0) {
+        const outcome = await this.sendSnapshotChunk(daemonId, fresh)
+        if (outcome === 'gone') return
+        if (outcome === 'retry') {
+          this.scheduleRetry(daemonId, 'failed')
+          return
+        }
+      }
+      if (page.length < SNAPSHOT_CHUNK) return
+      afterId = page.at(-1)!.sessionId // keyset on the id this page ordered by
     }
   }
 

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -27,6 +27,7 @@
  * closed (unknown gate state ⇒ capture excluded).
  */
 import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
+import { servedAgents, type DutyHeldAgentReader } from './servedAgents.js'
 import {
   SESSION_VISIBILITY_FEATURE,
   SLACK_SESSION_AUDIENCE_FEATURE,
@@ -34,6 +35,7 @@ import {
 } from '@agentconnect.md/protocol'
 import type { AgentRepo, SessionMetaRecord, SessionRepo, SessionVisibilityState } from '../persistence/ports.js'
 import { SessionId, type DaemonId } from '../domain/ids.js'
+import { systemClock, type Clock } from '../domain/clock.js'
 import { ConnectionClosed, type ConnectionRegistry } from '../ws/registry.js'
 import { NoConnection, type ControlSender } from './outbound.js'
 
@@ -53,6 +55,10 @@ export interface VisibilityPushDeps {
   connReg: ConnectionRegistry
   /** Resolves the member that serves each session's agent. Absent ⇒ placement alone. */
   placement?: Pick<PlacementResolver, 'servingDaemon'>
+  /** The inverse read the replay pages by — which agents a member serves. Absent ⇒ placement
+   *  alone, which is the pre-duty behavior. */
+  duties?: DutyHeldAgentReader
+  clock?: Clock
   log?: { warn(obj: unknown, msg?: string): void }
 }
 
@@ -102,6 +108,17 @@ export class SessionVisibilityPushService {
   /** Absent (tests / no pool) ⇒ placement alone, which is the pre-duty behavior. */
   private placement(): Pick<PlacementResolver, 'servingDaemon'> {
     return this.deps.placement ?? PLACEMENT_ONLY
+  }
+
+  /** The agents this member serves — `pinned-to-me ∪ duties I hold`, the inverse of the resolver
+   *  the live push uses, so a replay covers exactly the sessions that member can capture from. */
+  private async servedAgentIds(daemonId: DaemonId): Promise<string[]> {
+    const { agents } = await servedAgents(daemonId, {
+      agents: this.deps.repos.agent,
+      ...(this.deps.duties ? { duties: this.deps.duties } : {}),
+      now: new Date((this.deps.clock ?? systemClock).now())
+    })
+    return agents.map((agent) => agent.id as string)
   }
 
   private supports(daemonId: string): boolean {
@@ -182,7 +199,9 @@ export class SessionVisibilityPushService {
     const includeExternal = this.supportsExternal(daemonId)
     for (;;) {
       if (this.stopped) return // shutdown: the next process converges on register
-      const page = await this.deps.repos.session.visibilitySnapshotForDaemon(daemonId, SNAPSHOT_CHUNK, includeExternal)
+      // Re-resolved each round: a duty granted mid-replay widens the set the very next page.
+      const agentIds = await this.servedAgentIds(daemonId)
+      const page = await this.deps.repos.session.visibilitySnapshotForAgents(agentIds, SNAPSHOT_CHUNK, includeExternal)
       if (page.length === 0) return
       const outcome = await this.sendSnapshotChunk(daemonId, page)
       if (outcome === 'gone') return // disconnected: its next register replays
@@ -193,7 +212,7 @@ export class SessionVisibilityPushService {
         return
       }
       if (page.length < SNAPSHOT_CHUNK) return // the page was not full: nothing behind it
-      const unacked = await this.deps.repos.session.countUnackedVisibility(daemonId, includeExternal)
+      const unacked = await this.deps.repos.session.countUnackedVisibilityForAgents(agentIds, includeExternal)
       if (unacked === 0) return
       if (unacked >= previousUnacked) {
         // Not converging — new changes are arriving at least as fast as we ack.

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1413,6 +1413,15 @@ export interface SessionRepo {
   /** How many of those agents' sessions still owe an ack — used to report when a
    *  bounded snapshot could not carry them all (never a silent truncation). */
   countUnackedVisibilityForAgents(agentIds: readonly string[], includeExternal?: boolean): Promise<number>
+  /** Every currently-PRIVATE session of those agents, ordered by id and cursored on `afterId`.
+   *  Deliberately blind to `visibilityAckedRev`: that watermark is per session, not per daemon, so
+   *  a previous holder's ack cannot prove this member ever received the gate. */
+  privateVisibilityPage(
+    agentIds: readonly string[],
+    limit: number,
+    includeExternal?: boolean,
+    afterId?: string
+  ): Promise<SessionVisibilityState[]>
   /** A session plus every descendant — the set a tightening cascade rewrote, so
    *  the detail view's cutover state covers the whole subtree, not just the root.
    *  System-tier: driven by the visibility-push orchestrator from a row it holds. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1402,17 +1402,17 @@ export interface SessionRepo {
   /** Raise the daemon-ack watermark (§5.1). Monotonic: a late ack for an older
    *  revision never lowers it, so the tighten stays `applied`. */
   recordVisibilityAck(sessionId: SessionId, visibilityRev: number): Promise<void>
-  /** The §5.1 register-time gate snapshot for one daemon: the current
-   *  `(sessionId, visibility, visibilityRev)` set for the sessions it reported,
-   *  newest first and bounded. A snapshot, not a diff. */
-  visibilitySnapshotForDaemon(
-    daemonId: DaemonId,
+  /** The §5.1 register-time gate snapshot for a daemon, keyed on the AGENTS it serves (the
+   *  caller resolves that set): the current `(sessionId, visibility, visibilityRev)` set,
+   *  unacked first then newest-active, and bounded. A snapshot, not a diff. */
+  visibilitySnapshotForAgents(
+    agentIds: readonly string[],
     limit: number,
     includeExternal?: boolean
   ): Promise<SessionVisibilityState[]>
-  /** How many of a daemon's sessions still owe an ack — used to report when a
+  /** How many of those agents' sessions still owe an ack — used to report when a
    *  bounded snapshot could not carry them all (never a silent truncation). */
-  countUnackedVisibility(daemonId: DaemonId, includeExternal?: boolean): Promise<number>
+  countUnackedVisibilityForAgents(agentIds: readonly string[], includeExternal?: boolean): Promise<number>
   /** A session plus every descendant — the set a tightening cascade rewrote, so
    *  the detail view's cutover state covers the whole subtree, not just the root.
    *  System-tier: driven by the visibility-push orchestrator from a row it holds. */
@@ -1976,14 +1976,14 @@ export interface CronRepo {
   /** Every cron definition owned by one agent (cold placement-move snapshot).
    *  System-tier (§3.4): agent-fenced, orchestration-only. */
   listForAgent(agentId: AgentId): Promise<CronRecord[]>
-  /** Apply a daemon `cron/report`. Scoped: the cron's owning agent must be
-   *  placed on the REPORTING daemon (a daemon can never write another daemon's
-   *  cron). `lastRunAt` is latest-wins (re-asserts / out-of-order reports never
+  /** Apply a daemon `cron/report`. The reporting daemon's authority is settled by the caller
+   *  against the placement resolver (placement ∪ live duty holders), never by a join here.
+   *  `lastRunAt` is latest-wins (re-asserts / out-of-order reports never
    *  regress it); the run row upserts on (cronId, firedAt) — the fire report
    *  opens it `running`, a progress report can attach its session, and the
    *  completion report closes it. Returns whether the report was accepted
-   *  (false ⇒ unknown/foreign cron, dropped). */
-  recordReport(cronId: CronId, reportingDaemonId: DaemonId, report: CronReportInput): Promise<boolean>
+   *  (false ⇒ unknown cron, dropped). */
+  recordReport(cronId: CronId, report: CronReportInput): Promise<boolean>
   /** Run history for the console detail page, newest first. Run rows carry
    *  their own `orgId`, so the fence rides this query directly rather than only
    *  through the parent cron (§3.6). */
@@ -2003,10 +2003,11 @@ export interface CronRepo {
    *  agents are named by the ledger, not by placement. */
   listForAgents(agentIds: readonly string[]): Promise<CronRecord[]>
   /** Org-fenced point read (§3): a cross-org id reads as absent, exactly like a
-   *  missing row. Crons have no internal-trust-domain reader — the daemon-facing
-   *  paths are `listForDaemon` and `recordReport`, both fenced by the daemon
-   *  axis — so this port deliberately grows no `getUnscoped`. */
+   *  missing row. */
   get(orgId: OrgId, cronId: CronId): Promise<CronRecord | null>
+  /** Internal-trust-domain point read: the `cron/report` fence needs the cron's OWNING AGENT
+   *  before it can ask the resolver who serves it, and the reporting daemon carries no org. */
+  getUnscoped(cronId: CronId): Promise<CronRecord | null>
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/cron.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/cron.repo.ts
@@ -218,13 +218,15 @@ export class PgCronRepo implements CronRepo {
     return c ? toRecord(c) : null
   }
 
-  async recordReport(cronId: CronId, reportingDaemonId: DaemonId, r: CronReportInput): Promise<boolean> {
-    // Scope gate first (owning agent placed on the reporting daemon) — a
-    // foreign daemon's report is a silent no-op, never an error.
-    const cron = await this.db.cronDef.findFirst({
-      where: { id: cronId, agent: { daemonId: reportingDaemonId } },
-      select: { id: true, orgId: true }
-    })
+  async getUnscoped(cronId: CronId): Promise<CronRecord | null> {
+    const c = await this.db.cronDef.findUnique({ where: { id: cronId }, include: withUsers })
+    return c ? toRecord(c) : null
+  }
+
+  async recordReport(cronId: CronId, r: CronReportInput): Promise<boolean> {
+    // The reporting daemon's authority is settled by the caller against the resolver (placement ∪
+    // live duty holders); a join on `agent.daemonId` here dropped every pool member's report.
+    const cron = await this.db.cronDef.findUnique({ where: { id: cronId }, select: { id: true, orgId: true } })
     if (!cron) return false
     // lastRunAt is latest-wins: an older firedAt (reconnect re-assert,
     // out-of-order delivery) never regresses the stamp.

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -1600,11 +1600,16 @@ export class PgSessionRepo implements SessionRepo {
     `)
   }
 
-  async visibilitySnapshotForDaemon(
-    daemonId: DaemonId,
+  async visibilitySnapshotForAgents(
+    agentIds: readonly string[],
     limit: number,
     includeExternal = true
   ): Promise<SessionVisibilityState[]> {
+    if (agentIds.length === 0) return []
+    // Keyed on the AGENTS the daemon serves, not on `session_meta.daemonId` — that column names
+    // the member that first reported the session and is null once that member is reaped, so a new
+    // duty holder would page zero rows and keep the gates it was never sent (#1029).
+    //
     // Unacknowledged revisions FIRST, newest-active after. A session tightened
     // while this daemon was offline is by definition unacked, so it replays no
     // matter how old it is — a plain newest-first window would drop it past the
@@ -1614,7 +1619,7 @@ export class PgSessionRepo implements SessionRepo {
     >(Prisma.sql`
       SELECT "id", "orgId", "visibility", "externalProvider", "visibilityRev"
       FROM "session_meta"
-      WHERE "daemonId" = ${daemonId}::uuid
+      WHERE "agentId" = ANY(${[...agentIds]}::uuid[])
         AND (${includeExternal} OR "externalProvider" IS NULL)
       ORDER BY ("visibilityAckedRev" < "visibilityRev") DESC,
                "lastActivityAt" DESC, "startedAt" DESC, "id" DESC
@@ -1632,10 +1637,13 @@ export class PgSessionRepo implements SessionRepo {
     }))
   }
 
-  async countUnackedVisibility(daemonId: DaemonId, includeExternal = true): Promise<number> {
+  async countUnackedVisibilityForAgents(agentIds: readonly string[], includeExternal = true): Promise<number> {
+    if (agentIds.length === 0) return 0
+    // Same predicate as the snapshot above, or the counter reports a convergence that never
+    // happened for a member whose served set the recorded column does not describe.
     const rows = await this.db.$queryRaw<Array<{ n: bigint }>>(Prisma.sql`
       SELECT COUNT(*)::bigint AS n FROM "session_meta"
-      WHERE "daemonId" = ${daemonId}::uuid
+      WHERE "agentId" = ANY(${[...agentIds]}::uuid[])
         AND (${includeExternal} OR "externalProvider" IS NULL)
         AND "visibilityAckedRev" < "visibilityRev"
     `)

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -1637,6 +1637,39 @@ export class PgSessionRepo implements SessionRepo {
     }))
   }
 
+  async privateVisibilityPage(
+    agentIds: readonly string[],
+    limit: number,
+    includeExternal = true,
+    afterId?: string
+  ): Promise<SessionVisibilityState[]> {
+    if (agentIds.length === 0) return []
+    // The rows a member must not be wrong about: `sharedMemoryExcluded` is `visibility ===
+    // 'private'`, and a member that never heard of a session already fails closed. So the ONLY way
+    // to leak is a stale non-private gate left from an earlier hold — which is what this page
+    // overwrites. Cursored on `id` and blind to `visibilityAckedRev` on purpose: that watermark is
+    // per SESSION, not per daemon, so an ack from the previous holder says nothing about this one.
+    const rows = await this.db.$queryRaw<
+      Array<{ id: string; orgId: string; visibility: string; externalProvider: string | null; visibilityRev: number }>
+    >(Prisma.sql`
+      SELECT "id", "orgId", "visibility", "externalProvider", "visibilityRev"
+      FROM "session_meta"
+      WHERE "agentId" = ANY(${[...agentIds]}::uuid[])
+        AND "visibility" = 'private'::"SessionVisibility"
+        AND (${includeExternal} OR "externalProvider" IS NULL)
+        ${afterId ? Prisma.sql`AND "id" > ${afterId}` : Prisma.empty}
+      ORDER BY "id"
+      LIMIT ${limit}
+    `)
+    return rows.map((r) => ({
+      orgId: OrgId(r.orgId),
+      sessionId: SessionId(r.id),
+      visibility: r.visibility as SessionVisibility,
+      sharedMemoryExcluded: true,
+      visibilityRev: r.visibilityRev
+    }))
+  }
+
   async countUnackedVisibilityForAgents(agentIds: readonly string[], includeExternal = true): Promise<number> {
     if (agentIds.length === 0) return 0
     // Same predicate as the snapshot above, or the counter reports a convergence that never

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -1675,9 +1675,16 @@ export class PgSessionRepo implements SessionRepo {
     // overwrites. Cursored on `id` and blind to `visibilityAckedRev` on purpose: that watermark is
     // per SESSION, not per daemon, so an ack from the previous holder says nothing about this one.
     const rows = await this.db.$queryRaw<
-      Array<{ id: string; orgId: string; visibility: string; externalProvider: string | null; visibilityRev: number }>
+      Array<{
+        id: string
+        orgId: string
+        agentId: string
+        visibility: string
+        externalProvider: string | null
+        visibilityRev: number
+      }>
     >(Prisma.sql`
-      SELECT "id", "orgId", "visibility", "externalProvider", "visibilityRev"
+      SELECT "id", "orgId", "agentId", "visibility", "externalProvider", "visibilityRev"
       FROM "session_meta"
       WHERE "agentId" = ANY(${[...agentIds]}::uuid[])
         AND "visibility" = 'private'::"SessionVisibility"
@@ -1688,6 +1695,7 @@ export class PgSessionRepo implements SessionRepo {
     `)
     return rows.map((r) => ({
       orgId: OrgId(r.orgId),
+      agentId: AgentId(r.agentId),
       sessionId: SessionId(r.id),
       visibility: r.visibility as SessionVisibility,
       sharedMemoryExcluded: true,

--- a/packages/control-plane/src/ws/handlers/child-session-status.test.ts
+++ b/packages/control-plane/src/ws/handlers/child-session-status.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it, vi } from 'vitest'
 import type { AnyFrame, ChildSessionStatus } from '@agentconnect.md/protocol'
 import type { DaemonConnection } from '../connection.js'
 import type { DaemonWsDeps } from '../deps.js'
+import { PlacementResolver } from '../../orchestrator/placementResolver.js'
+import { systemClock } from '../../domain/clock.js'
 import { handleChildSessionStatus } from './child-session-status.js'
 
 const ASKING_DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const OWNING_DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
+const PARENT_AGENT = 'a1a1a1a1-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const CHILD_AGENT = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const ORG = 'org-a'
 
@@ -43,12 +46,21 @@ function fakeConn() {
   } as unknown as DaemonConnection & { replyTo: ReturnType<typeof vi.fn>; sendError: ReturnType<typeof vi.fn> }
 }
 
-/** Deps with every check passing; each test overrides exactly the one it exercises. */
+/**
+ * Deps with every check passing; each test overrides exactly the one it exercises.
+ *
+ * Both legs are LIVE reads now: the parent is admitted by "does the asking daemon serve this
+ * session's agent", and the child is addressed at whoever serves it — so the fake carries two
+ * agents (parent on the asker, child elsewhere) and, where a test needs one, a duty ledger.
+ */
 function fakeDeps(
   over: {
     parent?: unknown
+    parentAgent?: unknown
     childAgent?: unknown
     ownerConn?: unknown
+    /** agentId → the members holding its duty right now. */
+    holders?: Record<string, string[]>
     request?: ReturnType<typeof vi.fn>
   } = {}
 ) {
@@ -57,6 +69,12 @@ function fakeDeps(
     'ownerConn' in over
       ? over.ownerConn
       : { daemonId: OWNING_DAEMON, reachable: true, sessionEpoch: 7, conn: { request } }
+  const agents: Record<string, unknown> = {
+    [PARENT_AGENT]:
+      'parentAgent' in over ? over.parentAgent : { id: PARENT_AGENT, orgId: ORG, daemonId: ASKING_DAEMON },
+    [CHILD_AGENT]: 'childAgent' in over ? over.childAgent : { id: CHILD_AGENT, orgId: ORG, daemonId: OWNING_DAEMON }
+  }
+  const holdersOf = async (agentId: string) => over.holders?.[agentId] ?? []
   return {
     deps: {
       registry: { getUnscoped: async () => ({ id: ASKING_DAEMON, orgId: ORG }) },
@@ -64,12 +82,13 @@ function fakeDeps(
         getUnscoped: async () =>
           'parent' in over
             ? over.parent
-            : { id: PARENT_SESSION, orgId: ORG, daemonId: ASKING_DAEMON, agentId: CHILD_AGENT }
+            : { id: PARENT_SESSION, orgId: ORG, daemonId: ASKING_DAEMON, agentId: PARENT_AGENT }
       },
-      agent: {
-        getUnscoped: async () =>
-          'childAgent' in over ? over.childAgent : { id: CHILD_AGENT, orgId: ORG, daemonId: OWNING_DAEMON }
-      },
+      agent: { getUnscoped: async (id: string) => agents[id] ?? null },
+      placementResolver: new PlacementResolver({
+        duties: { holdersOf, confirmedHoldersOf: holdersOf } as never,
+        clock: systemClock
+      }),
       connReg: { get: () => owner }
     } as unknown as DaemonWsDeps,
     request
@@ -99,8 +118,8 @@ describe('handleChildSessionStatus — cross-daemon child status (session-concep
 
   // (a) The parent-session claim is untrusted: without this check any daemon could name someone
   // else's parent session and read its children.
-  it('refuses when the claimed parent session was reported by a DIFFERENT daemon', async () => {
-    const { deps, request } = fakeDeps({ parent: { id: PARENT_SESSION, daemonId: OWNING_DAEMON } })
+  it('refuses when the asking daemon does not serve the claimed parent session’s agent', async () => {
+    const { deps, request } = fakeDeps({ parentAgent: { id: PARENT_AGENT, orgId: ORG, daemonId: OWNING_DAEMON } })
     const conn = fakeConn()
     await handleChildSessionStatus(frame(), conn, deps)
 
@@ -117,6 +136,34 @@ describe('handleChildSessionStatus — cross-daemon child status (session-concep
     expect(request).not.toHaveBeenCalled()
   })
 
+  // A rollout moves the duty; the recorded `session_meta.daemonId` still names the retired member
+  // (or nothing at all), so the column would refuse the holder its own parent.
+  it('admits a parent whose agent this daemon holds by duty, not by placement', async () => {
+    const { deps, request } = fakeDeps({
+      parent: { id: PARENT_SESSION, orgId: ORG, daemonId: null, agentId: PARENT_AGENT },
+      parentAgent: { id: PARENT_AGENT, orgId: ORG, placementKind: 'set', daemonId: null, setId: 'pool' },
+      holders: { [PARENT_AGENT]: [ASKING_DAEMON] }
+    })
+    const conn = fakeConn()
+    await handleChildSessionStatus(frame(), conn, deps)
+
+    expect(replied(conn)).toEqual(ANSWER)
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  // A pool child names no machine, so the column refused every one of them outright.
+  it('addresses a pool child at the member currently holding its duty', async () => {
+    const { deps, request } = fakeDeps({
+      childAgent: { id: CHILD_AGENT, orgId: ORG, placementKind: 'set', daemonId: null, setId: 'pool' },
+      holders: { [CHILD_AGENT]: [OWNING_DAEMON] }
+    })
+    const conn = fakeConn()
+    await handleChildSessionStatus(frame(), conn, deps)
+
+    expect(replied(conn)).toEqual(ANSWER)
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
   it('refuses a child agent in another org even when both daemons are reachable', async () => {
     const { deps, request } = fakeDeps({ childAgent: { id: CHILD_AGENT, orgId: 'org-b', daemonId: OWNING_DAEMON } })
     const conn = fakeConn()
@@ -126,7 +173,7 @@ describe('handleChildSessionStatus — cross-daemon child status (session-concep
     expect(request).not.toHaveBeenCalled()
   })
 
-  it('refuses an unknown or unplaced child agent', async () => {
+  it('refuses an unknown child agent, or one nothing is serving', async () => {
     for (const childAgent of [null, { id: CHILD_AGENT, orgId: ORG, daemonId: null }]) {
       const { deps, request } = fakeDeps({ childAgent })
       const conn = fakeConn()

--- a/packages/control-plane/src/ws/handlers/child-session-status.ts
+++ b/packages/control-plane/src/ws/handlers/child-session-status.ts
@@ -12,8 +12,8 @@
  *
  * AUTHORIZATION IS TWO-SIDED, and neither half is sufficient alone:
  *   • HERE: `parentSessionId` is an untrusted claim from the asking daemon, so the CP verifies that
- *     session was actually reported by THIS daemon (and belongs to its org). Without this any
- *     daemon could name someone else's parent session and read its children.
+ *     this daemon SERVES the session's agent (and that the session belongs to its org). Without
+ *     this any daemon could name someone else's parent session and read its children.
  *   • ON THE OWNING DAEMON: it re-checks that the child's durable origin link really is that parent
  *     session. That is the real lineage rule and it is enforced where the session lives — the CP
  *     never asserts "this is your child", only "you own the session you claim to be asking as".
@@ -25,6 +25,7 @@
 import { isFrame } from '@agentconnect.md/protocol'
 import type { ChildSessionStatus } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, SessionId } from '../../domain/ids.js'
+import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import type { Handler } from './index.js'
 
 const NOT_FOUND: ChildSessionStatus = { found: false }
@@ -32,26 +33,38 @@ const NOT_FOUND: ChildSessionStatus = { found: false }
 export const handleChildSessionStatus: Handler = async (frame, conn, deps) => {
   if (!isFrame('session/child-status')(frame)) return
   const { parentSessionId, childSessionId, childAgentId } = frame.payload
+  const resolver = deps.placementResolver ?? PLACEMENT_ONLY
 
   // Daemon trust domain: the connection's own daemon (org-scoped-data-layer.md §4).
   const daemon = await deps.registry.getUnscoped(DaemonId(conn.daemonId))
   if (!daemon) return // unknown daemon (should not happen post-auth) — drop silently
 
-  // (a) Prove the asking daemon owns the parent session it is asking AS. `daemonId` on the session
-  // row is stamped by the CP from the authenticated socket and is never daemon-echoed, so it is
-  // trustworthy here. Fail closed when the session is unknown to the CP.
-  // Daemon trust domain: the parent session the asking daemon claims to own —
-  // the ownership check below is what admits it (org-scoped-data-layer.md §4).
+  // (a) Prove the asking daemon serves the parent session it is asking AS. The LIVE seam, not
+  // `SessionMeta.daemonId`: that column is the daemon that first reported the session and goes
+  // null when its member is reaped, so after a rollout the new holder would be refused its own
+  // parent. Fail closed when the session or its agent is unknown to the CP.
   const parent = await deps.session.getUnscoped(SessionId(parentSessionId))
-  if (!parent || parent.daemonId !== conn.daemonId || (frame.orgId && frame.orgId !== parent.orgId)) {
+  const parentAgent = parent ? await deps.agent.getUnscoped(AgentId(parent.agentId)) : null
+  if (
+    !parent ||
+    !parentAgent ||
+    !(await resolver.mayAct(parentAgent, conn.daemonId)) ||
+    (frame.orgId && frame.orgId !== parent.orgId)
+  ) {
     conn.replyTo(frame, 'session/child-status/ok', NOT_FOUND)
     return
   }
 
-  // (b) Resolve the child agent's placement. Cross-org is refused outright: a status read must
+  // (b) Resolve the child agent's serving daemon. Cross-org is refused outright: a status read must
   // never cross an org boundary even when both daemons are reachable.
   const childAgent = await deps.agent.getUnscoped(AgentId(childAgentId))
-  if (!childAgent || childAgent.orgId !== parent.orgId || !childAgent.daemonId) {
+  if (!childAgent || childAgent.orgId !== parent.orgId) {
+    conn.replyTo(frame, 'session/child-status/ok', NOT_FOUND)
+    return
+  }
+  // Resolved, never read: a pool agent names no machine, so the column refused every one of them.
+  const childDaemonId = await resolver.servingDaemon(childAgent)
+  if (!childDaemonId) {
     conn.replyTo(frame, 'session/child-status/ok', NOT_FOUND)
     return
   }
@@ -59,12 +72,12 @@ export const handleChildSessionStatus: Handler = async (frame, conn, deps) => {
   // A child that turns out to live on the ASKING daemon needs no round trip — and forwarding it
   // back would deadlock the caller's own request. It should have been answered locally, so the only
   // way here is a stale placement view; answer the same way an unknown child is answered.
-  if (childAgent.daemonId === conn.daemonId) {
+  if (childDaemonId === conn.daemonId) {
     conn.replyTo(frame, 'session/child-status/ok', NOT_FOUND)
     return
   }
 
-  const owner = deps.connReg.get(childAgent.daemonId)
+  const owner = deps.connReg.get(childDaemonId)
   if (!owner || !owner.reachable) {
     // Transport-level, NOT an authorization verdict: the asking agent is told to retry rather than
     // that its child does not exist.

--- a/packages/control-plane/src/ws/handlers/cron-report.ts
+++ b/packages/control-plane/src/ws/handlers/cron-report.ts
@@ -6,14 +6,15 @@
  * here so the console's `lastRunAt` and run history converge: the FIRE report
  * (no `status`) stamps lastRunAt and opens the run row, an optional SESSION
  * report attaches the deep-link while it is running, and the COMPLETION report
- * closes it with the outcome/duration. The repo write is scoped (the
- * cron's owning agent must be placed on the REPORTING daemon) and latest-wins
- * (the daemon re-asserts stored stamps on reconnect; an older `firedAt` never
- * regresses the value) — so unknown, foreign, and stale reports all drop
- * silently, never error.
+ * closes it with the outcome/duration. The write is fenced on the LIVE seam
+ * (the reporting daemon must serve the cron's agent — its placement, or a duty
+ * it holds) and latest-wins (the daemon re-asserts stored stamps on reconnect;
+ * an older `firedAt` never regresses the value) — so unknown, foreign, and
+ * stale reports all drop silently, never error.
  */
 import { isFrame } from '@agentconnect.md/protocol'
 import { CronId, DaemonId } from '../../domain/ids.js'
+import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import type { Handler } from './index.js'
 
 export const handleCronReport: Handler = async (frame, conn, deps) => {
@@ -21,7 +22,14 @@ export const handleCronReport: Handler = async (frame, conn, deps) => {
   const p = frame.payload
   const firedAt = new Date(p.firedAt)
   if (Number.isNaN(firedAt.getTime())) return
-  await deps.cron.recordReport(CronId(p.cronId), DaemonId(conn.daemonId), {
+  // The cron's OWN agent, never the frame's claim: `agentId` rides an untrusted daemon payload.
+  const cron = await deps.cron.getUnscoped(CronId(p.cronId))
+  if (!cron?.agentId) return // unknown / orphaned cron — inert by design
+  const agent = await deps.agent.getUnscoped(cron.agentId)
+  if (!agent) return
+  const resolver = deps.placementResolver ?? PLACEMENT_ONLY
+  if (!(await resolver.mayAct(agent, DaemonId(conn.daemonId)))) return
+  await deps.cron.recordReport(cron.id, {
     firedAt,
     ...(p.status ? { status: p.status } : {}),
     ...(p.durationMs !== undefined ? { durationMs: p.durationMs } : {}),

--- a/packages/control-plane/src/ws/handlers/integration-channels.test.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.test.ts
@@ -22,10 +22,16 @@ function fakeDeps(platform = 'slack', known = true) {
   const dropPublicAudiences = vi.fn()
   const integration = known ? [{ id: INTEGRATION, agentId: AGENT, botId: BOT, orgId: 'org-1', platform }] : []
   const deps = {
-    integration: { activeForDaemon: vi.fn(async () => integration) },
+    // The handler admits by SERVED agents now, so the repo read is the agent-keyed one.
+    integration: { activeForAgents: vi.fn(async () => integration) },
     slackSessionAccess: { dropPublicAudiences },
     agentMutations: { tryBeginMutation: vi.fn(() => vi.fn()) },
-    agent: { getUnscoped: vi.fn(async () => null) },
+    agent: {
+      getUnscoped: vi.fn(async () => null),
+      listForDaemon: vi.fn(async () => [{ id: AGENT }]),
+      listByIds: vi.fn(async () => [])
+    },
+    clock: { now: () => Date.now() },
     integrationChannel: { replaceSnapshot: vi.fn(async () => {}) },
     collabRoutes: { broadcast: vi.fn(async () => {}) }
   } as unknown as DaemonWsDeps

--- a/packages/control-plane/src/ws/handlers/integration-channels.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.ts
@@ -13,19 +13,34 @@
  * applies alongside the upsert, so one report can both refresh what remains and
  * retire what is gone.
  *
- * Scope check: the integration's owning agent must be placed on the REPORTING
- * daemon (the same daemon-scoped join as `register/ok.integrations[]`) — a daemon
- * can never write channel rows for another daemon's integration.
+ * Scope check: the integration's owning agent must be SERVED by the reporting
+ * daemon — the same `pinned-to-me ∪ duties I hold` union `register/ok.integrations[]`
+ * ships under, so a duty holder may write for what it was given and nothing else.
+ * A daemon can never write channel rows for another daemon's integration.
  */
 import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId } from '../../domain/ids.js'
 import { isGatedAgent } from '../../orchestrator/placement.js'
+import { servedAgents } from '../../orchestrator/servedAgents.js'
+import type { DaemonWsDeps } from '../deps.js'
+import type { IntegrationRecord } from '../../persistence/ports.js'
 import type { Handler } from './index.js'
+
+/** Active integrations of the agents this daemon serves — a pool member is the placement of
+ *  none of them, so `activeForDaemon` alone discarded every one of its reports. */
+async function activeForServedAgents(daemonId: DaemonId, deps: DaemonWsDeps): Promise<IntegrationRecord[]> {
+  const { agents } = await servedAgents(daemonId, {
+    agents: deps.agent,
+    ...(deps.dutyLease ? { duties: deps.dutyLease } : {}),
+    now: new Date(deps.clock.now())
+  })
+  return deps.integration.activeForAgents(agents.map((agent) => agent.id))
+}
 
 export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
   if (!isFrame('integration/channels')(frame)) return
   const p = frame.payload
-  const owned = await deps.integration.activeForDaemon(DaemonId(conn.daemonId))
+  const owned = await activeForServedAgents(DaemonId(conn.daemonId), deps)
   const integration = owned.find((i) => i.id === p.integrationId)
   if (!integration) return // unknown / just deleted / not this daemon's — drop silently
   // §4.2(4) session-access cross-check (session-access-cold-visit.md): a channel observed
@@ -43,7 +58,7 @@ export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
     // Re-check under the shared mutation lease before accepting this daemon's
     // latest-wins snapshot, otherwise a late source event can overwrite target
     // channel metadata after a cold move.
-    const current = await deps.integration.activeForDaemon(DaemonId(conn.daemonId))
+    const current = await activeForServedAgents(DaemonId(conn.daemonId), deps)
     if (!current.some((candidate) => candidate.id === integration.id && candidate.agentId === integration.agentId)) {
       return
     }

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -92,6 +92,8 @@ export interface WsHarness {
    *  addresses a daemon, so "ingress follows the holder" is assertable on it directly. */
   hookAssigns: CapturedHookRule[]
   hookRemovals: string[]
+  /** Daemons the duty exchange asked for a session-visibility replay, in order. */
+  visibilityReplays: string[]
   /** The resolver the projections read through — lets a test ask what the peer directory would
    *  publish right now without reaching through the orchestrator. */
   placement: PlacementResolver
@@ -261,6 +263,10 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     delayMs: 0
   })
 
+  // Members the exchange asked for a capture-gate replay, in order. The snapshot's CONTENT is
+  // pinned in `session-visibility.route.test.ts`; what belongs here is that a confirmed grant
+  // triggers one at all — a member registers before it holds anything.
+  const visibilityReplays: string[] = []
   const dutyLease = new DutyLeaseService(
     dutyGroupRepo,
     clock,
@@ -277,7 +283,8 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     },
     undefined,
     repos.agent,
-    agentRouting
+    agentRouting,
+    { replayTo: async (daemonId) => void visibilityReplays.push(daemonId) }
   )
 
   const deps: DaemonWsDeps = {
@@ -318,6 +325,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     clock,
     hookAssigns,
     hookRemovals,
+    visibilityReplays,
     placement: placementResolver,
     codec,
     mintPoolMember: async (daemonId: string) => {

--- a/packages/control-plane/test/fakes/member-set.ts
+++ b/packages/control-plane/test/fakes/member-set.ts
@@ -20,3 +20,25 @@ export async function joinPool(prisma: PrismaClient, ...daemonIds: string[]): Pr
   await prisma.memberSetMember.createMany({ data: daemonIds.map((daemonId) => ({ setId, daemonId })) })
   return setId
 }
+
+/** An org-less daemon ROW plus its pool membership — one install-wide member, ready to hold duty.
+ *  Capabilities mirror `fixtures/seed.ts`'s stock member so install probes can pass. */
+export async function seedPoolMember(prisma: PrismaClient, daemonId: string): Promise<string> {
+  await prisma.daemon.create({
+    data: {
+      id: daemonId,
+      orgId: null,
+      maxAgents: 8,
+      status: 'ready',
+      // What makes an org-less row an install-wide MEMBER rather than an orphan (`getAvailable`).
+      clusterIdentity: `cluster/${daemonId}`,
+      capabilities: {
+        platforms: ['slack', 'telegram', 'discord', 'feishu'],
+        runtimes: ['claude'],
+        acp: true,
+        features: []
+      }
+    }
+  })
+  return joinPool(prisma, daemonId)
+}

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -54,6 +54,8 @@ export async function seedAgent(
   opts: {
     runtime?: string
     daemonId?: string
+    /** A MEMBER-SET placement: placed, naming no machine. Only the duty ledger says who serves it. */
+    setId?: string
     name?: string
     visibility?: 'org' | 'restricted'
     sharedWith?: string[]
@@ -74,6 +76,7 @@ export async function seedAgent(
       name: opts.name ?? `agent-${id.slice(0, 4)}`,
       runtime: opts.runtime ?? 'claude',
       daemonId: opts.daemonId,
+      ...(opts.setId ? { placementKind: 'set' as const, setId: opts.setId } : {}),
       ...(opts.visibility ? { visibility: opts.visibility } : {}),
       ...(opts.sharedWith ? { sharedWith: opts.sharedWith } : {}),
       ...(opts.createdByUserId ? { createdByUserId: opts.createdByUserId } : {}),

--- a/packages/control-plane/test/integration/channel-agents.route.test.ts
+++ b/packages/control-plane/test/integration/channel-agents.route.test.ts
@@ -112,6 +112,7 @@ async function reportChannels(daemonId: string, integrationId: string, channels:
     integration: new PgIntegrationRepo(prisma),
     integrationChannel: new PgIntegrationChannelRepo(prisma),
     agent: new PgAgentRepo(prisma),
+    clock: systemClock,
     agentMutations: new AgentMutationGate()
   } as unknown as DaemonWsDeps
   await handleIntegrationChannels(frame, { daemonId } as DaemonConnection, deps)

--- a/packages/control-plane/test/integration/child-session-status.test.ts
+++ b/packages/control-plane/test/integration/child-session-status.test.ts
@@ -1,0 +1,152 @@
+/**
+ * `session/child-status` (D→C REQ) against real rows — the cross-daemon leg of a parent session
+ * following a child it started (session-concept §5.4).
+ *
+ * Both halves are LIVE reads (#1027): the asking daemon is admitted because it SERVES the parent
+ * session's agent, and the child is addressed at whoever serves it. `SessionMeta.daemonId` is the
+ * daemon that first reported the session and is `onDelete: SetNull`, so after a rollout it names a
+ * retired member or nothing — and a pool agent names no machine at all.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import type { AnyFrame, ChildSessionStatus } from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { seedAgent, seedDaemon, seedDutyGroup, seedSessionMeta } from '../fixtures/seed.js'
+import { poolSetId, seedPoolMember } from '../fakes/member-set.js'
+import { PgAgentRepo, PgDaemonRepo, PgDutyGroupRepo, PgRuntimeProfileRepo } from '../../src/persistence/index.js'
+import { PgDaemonLifecycleOpRepo } from '../../src/persistence/repositories/daemon-lifecycle-op.repo.js'
+import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.js'
+import { DaemonRegistryService } from '../../src/registry/registryService.js'
+import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
+import { systemClock } from '../../src/domain/clock.js'
+import { handleChildSessionStatus } from '../../src/ws/handlers/index.js'
+import type { DaemonConnection } from '../../src/ws/connection.js'
+import type { DaemonWsDeps } from '../../src/ws/deps.js'
+
+const ASKER = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
+const OWNER = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
+
+const ANSWER: ChildSessionStatus = { found: true, status: 'in-progress', state: 'prompting', updatedAt: 42 }
+
+/** Dispatch a hand-built `session/child-status` REQ through the real handler, over real repos and
+ *  the production resolver. Returns the reply payload and which daemon (if any) was probed. */
+async function ask(input: {
+  from: string
+  parentSessionId: string
+  childSessionId: string
+  childAgentId: string
+}): Promise<{ reply: ChildSessionStatus; probed: string[] }> {
+  const frame = {
+    v: 1,
+    id: randomUUID(),
+    ts: new Date().toISOString(),
+    type: 'session/child-status',
+    payload: {
+      parentSessionId: input.parentSessionId,
+      childSessionId: input.childSessionId,
+      childAgentId: input.childAgentId
+    }
+  } as AnyFrame
+  const probed: string[] = []
+  const replyTo = vi.fn()
+  const deps = {
+    registry: new DaemonRegistryService(
+      new PgDaemonRepo(prisma),
+      new PgRuntimeProfileRepo(prisma),
+      new PgDaemonLifecycleOpRepo(prisma),
+      systemClock
+    ),
+    session: new PgSessionRepo(prisma),
+    agent: new PgAgentRepo(prisma),
+    placementResolver: new PlacementResolver({ duties: new PgDutyGroupRepo(prisma), clock: systemClock }),
+    connReg: {
+      get: (daemonId: string) => ({
+        daemonId,
+        reachable: true,
+        sessionEpoch: 7,
+        conn: {
+          request: async () => {
+            probed.push(daemonId)
+            return ANSWER
+          }
+        }
+      })
+    }
+  } as unknown as DaemonWsDeps
+  await handleChildSessionStatus(frame, { daemonId: input.from, replyTo } as unknown as DaemonConnection, deps)
+  return { reply: replyTo.mock.calls[0]![2] as ChildSessionStatus, probed }
+}
+
+describe('session/child-status — authority is the serving member, not the recorded column', () => {
+  it('answers for a pool parent and a pool child, each through its current duty holder', async () => {
+    const setId = await seedPoolMember(prisma, ASKER)
+    await seedPoolMember(prisma, OWNER)
+    const parentAgent = await seedAgent(prisma, randomUUID(), { setId })
+    const childAgent = await seedAgent(prisma, randomUUID(), { setId })
+    await seedDutyGroup(prisma, randomUUID(), ASKER, [parentAgent])
+    await seedDutyGroup(prisma, randomUUID(), OWNER, [childAgent])
+    // Reported before a rollout: the column names nobody the ledger still knows about.
+    const parentSession = await seedSessionMeta(prisma, `s-parent-${randomUUID()}`, parentAgent, {})
+
+    const { reply, probed } = await ask({
+      from: ASKER,
+      parentSessionId: parentSession,
+      childSessionId: `s-child-${randomUUID()}`,
+      childAgentId: childAgent
+    })
+
+    expect({ reply, probed }).toEqual({ reply: ANSWER, probed: [OWNER] })
+  })
+
+  it('refuses a parent session whose agent the asking daemon does not serve', async () => {
+    const setId = await poolSetId(prisma)
+    await seedPoolMember(prisma, ASKER)
+    await seedPoolMember(prisma, OWNER)
+    const parentAgent = await seedAgent(prisma, randomUUID(), { setId })
+    const childAgent = await seedAgent(prisma, randomUUID(), { setId })
+    await seedDutyGroup(prisma, randomUUID(), OWNER, [parentAgent, childAgent])
+    const parentSession = await seedSessionMeta(prisma, `s-parent-${randomUUID()}`, parentAgent, {})
+
+    const { reply, probed } = await ask({
+      from: ASKER,
+      parentSessionId: parentSession,
+      childSessionId: `s-child-${randomUUID()}`,
+      childAgentId: childAgent
+    })
+
+    expect({ reply, probed }).toEqual({ reply: { found: false }, probed: [] })
+  })
+
+  it('still answers for two machine-placed agents on different daemons', async () => {
+    await seedDaemon(prisma, ASKER)
+    await seedDaemon(prisma, OWNER)
+    const parentAgent = await seedAgent(prisma, randomUUID(), { daemonId: ASKER })
+    const childAgent = await seedAgent(prisma, randomUUID(), { daemonId: OWNER })
+    const parentSession = await seedSessionMeta(prisma, `s-parent-${randomUUID()}`, parentAgent, { daemonId: ASKER })
+
+    const { reply, probed } = await ask({
+      from: ASKER,
+      parentSessionId: parentSession,
+      childSessionId: `s-child-${randomUUID()}`,
+      childAgentId: childAgent
+    })
+
+    expect({ reply, probed }).toEqual({ reply: ANSWER, probed: [OWNER] })
+  })
+
+  it('never forwards back to the asking daemon when it serves the child too', async () => {
+    await seedDaemon(prisma, ASKER)
+    const parentAgent = await seedAgent(prisma, randomUUID(), { daemonId: ASKER })
+    const childAgent = await seedAgent(prisma, randomUUID(), { daemonId: ASKER })
+    const parentSession = await seedSessionMeta(prisma, `s-parent-${randomUUID()}`, parentAgent, { daemonId: ASKER })
+
+    const { reply, probed } = await ask({
+      from: ASKER,
+      parentSessionId: parentSession,
+      childSessionId: `s-child-${randomUUID()}`,
+      childAgentId: childAgent
+    })
+
+    expect({ reply, probed }).toEqual({ reply: { found: false }, probed: [] })
+  })
+})

--- a/packages/control-plane/test/integration/cron-report.test.ts
+++ b/packages/control-plane/test/integration/cron-report.test.ts
@@ -1,17 +1,23 @@
 /**
  * `cron/report` (D→C EVT) → `lastRunAt` convergence, end to end on the CP side:
  *
- *  - A report from the daemon OWNING the cron's agent stamps `lastRunAt`.
- *  - Daemon-scoped: a report from a daemon the agent is not placed on drops
- *    silently (a daemon can never stamp another daemon's cron).
+ *  - A report from a daemon that SERVES the cron's agent stamps `lastRunAt` — its
+ *    placement, or a duty it currently holds (a pool agent names no machine).
+ *  - Fenced: a report from a daemon that serves neither drops silently (a daemon
+ *    can never stamp another daemon's cron).
  *  - Latest-wins: an older `firedAt` (reconnect re-assert, out-of-order
  *    delivery) never regresses the stored stamp; a newer one advances it.
  */
 import { describe, it, expect } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
+import { poolSetId, seedPoolMember } from '../fakes/member-set.js'
 import { PgCronRepo } from '../../src/persistence/repositories/cron.repo.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
+import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
+import { systemClock } from '../../src/domain/clock.js'
 import { handleCronReport } from '../../src/ws/handlers/index.js'
 import { AgentId, CronId, OrgId } from '../../src/domain/ids.js'
 import type { DaemonConnection } from '../../src/ws/connection.js'
@@ -21,6 +27,7 @@ import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
 const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const OTHER_DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
+const POOL_MEMBER = 'd3d3d3d3-dddd-4ddd-8ddd-dddddddddddd'
 
 /** Dispatch a hand-built `cron/report` EVT through the real handler. */
 async function report(
@@ -37,7 +44,12 @@ async function report(
     type: 'cron/report',
     payload: { cronId, agentId, firedAt, ...outcome }
   } as AnyFrame
-  const deps = { cron: new PgCronRepo(prisma) } as unknown as DaemonWsDeps
+  // The same graph production wires: the fence is the resolver's, over a real duty ledger.
+  const deps = {
+    cron: new PgCronRepo(prisma),
+    agent: new PgAgentRepo(prisma),
+    placementResolver: new PlacementResolver({ duties: new PgDutyGroupRepo(prisma), clock: systemClock })
+  } as unknown as DaemonWsDeps
   await handleCronReport(frame, { daemonId } as DaemonConnection, deps)
 }
 
@@ -70,6 +82,29 @@ describe('cron/report EVT → lastRunAt convergence', () => {
     expect((await new PgCronRepo(prisma).get(OrgId(DEFAULT_ORG_ID), CronId(cronId)))!.lastRunAt).toEqual(
       new Date(firedAt)
     )
+  })
+
+  it('stamps lastRunAt from the pool member holding the agent’s duty (#1027)', async () => {
+    await seedPoolMember(prisma, POOL_MEMBER)
+    await seedDaemon(prisma, OTHER_DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { setId: await poolSetId(prisma) })
+    const cronId = await seedCron(agentId)
+    const firedAt = '2026-07-03T09:00:00.000Z'
+    const repo = new PgCronRepo(prisma)
+
+    // Nothing holds the duty yet: the member serves the agent no more than any other daemon does.
+    await report(POOL_MEMBER, cronId, agentId, firedAt)
+    expect((await repo.get(OrgId(DEFAULT_ORG_ID), CronId(cronId)))!.lastRunAt).toBeNull()
+
+    await seedDutyGroup(prisma, randomUUID(), POOL_MEMBER, [agentId])
+    // A member that holds no duty for it still cannot stamp it.
+    await report(OTHER_DAEMON, cronId, agentId, firedAt)
+    expect((await repo.get(OrgId(DEFAULT_ORG_ID), CronId(cronId)))!.lastRunAt).toBeNull()
+
+    await report(POOL_MEMBER, cronId, agentId, firedAt)
+    expect((await repo.get(OrgId(DEFAULT_ORG_ID), CronId(cronId)))!.lastRunAt).toEqual(new Date(firedAt))
+    expect(await repo.listRuns(OrgId(DEFAULT_ORG_ID), CronId(cronId))).toHaveLength(1)
   })
 
   it('latest-wins: an older firedAt never regresses the stamp; a newer one advances it', async () => {

--- a/packages/control-plane/test/integration/crons.route.test.ts
+++ b/packages/control-plane/test/integration/crons.route.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
+import { seedPoolMember } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import type { ControlSender } from '../../src/orchestrator/outbound.js'
 import type { CronUpsert, CronRemove } from '@agentconnect.md/protocol'
@@ -467,6 +468,38 @@ describe('cron updates follow the duty holder', () => {
     await app.app.inject({ method: 'PUT', url: `${ORG}/crons/${randomUUID()}`, payload: body(agentId) })
 
     expect(spy.upserts.map((u) => u.daemonId)).toEqual([DAEMON, HOLDER])
+  })
+
+  // #1026: "Run now" resolved the serving member and then wrote it onto the observed record, so
+  // the mutation refresh compared a synthetic value against a NULL column and 409'd every time.
+  it('fires a POOL agent’s cron on the member holding its duty (#1026)', async () => {
+    const setId = await seedPoolMember(prisma, HOLDER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { setId })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+    const cronId = randomUUID()
+    const { app, spy } = withSpy()
+
+    expect(
+      (await app.app.inject({ method: 'PUT', url: `${ORG}/crons/${cronId}`, payload: body(agentId) })).statusCode
+    ).toBe(200)
+    const run = await app.app.inject({ method: 'POST', url: `${ORG}/crons/${cronId}/run` })
+    expect({ status: run.statusCode, runs: spy.runs }).toEqual({
+      status: 202,
+      runs: [{ daemonId: HOLDER, cronId }]
+    })
+  })
+
+  it('a POOL agent nothing is serving still refuses the run with 503', async () => {
+    const setId = await seedPoolMember(prisma, HOLDER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { setId })
+    const cronId = randomUUID()
+    const { app, spy } = withSpy()
+
+    await app.app.inject({ method: 'PUT', url: `${ORG}/crons/${cronId}`, payload: body(agentId) })
+    const run = await app.app.inject({ method: 'POST', url: `${ORG}/crons/${cronId}/run` })
+    expect({ status: run.statusCode, runs: spy.runs }).toEqual({ status: 503, runs: [] })
   })
 
   it('an EXPIRED lease is not a holding — the cron goes nowhere', async () => {

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -3,7 +3,8 @@ import { gunzipSync } from 'node:zlib'
 import { randomUUID } from 'node:crypto'
 import type { IntegrationUpsert } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
-import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { seedAgent, seedDaemon, seedDutyGroup } from '../fixtures/seed.js'
+import { seedPoolMember } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import {
@@ -29,6 +30,8 @@ import type { RelayChannel } from '../../src/ws/relay-registry.js'
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const UNSUPPORTED_DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
+const MEMBER = 'd9999999-9999-4999-8999-999999999999'
+const GROUP = '00000000-0000-4000-8000-0000000009f1'
 
 let running: HttpApp | undefined
 
@@ -229,6 +232,58 @@ describe('Feishu/Lark one-click app registration', () => {
         // §6.4 emission flip: credentials ride the opaque config envelope.
         config: { appId: 'cli_oneclick', appSecret: 'one-click-secret', region: 'lark' }
       }
+    })
+  }, 15_000)
+
+  // #1026: `start` resolved the serving member, then the finalize step re-read `agent.daemonId` —
+  // NULL for a pool agent — and failed the whole registration as `agent_unavailable`.
+  it('finalizes a POOL agent’s registration through the member holding its duty (#1026)', async () => {
+    const setId = await seedPoolMember(prisma, MEMBER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { setId, name: 'pool-agent' })
+    await seedDutyGroup(prisma, GROUP, MEMBER, [agentId])
+    const fetcher = vi.fn<typeof fetch>(async (_input, init) => {
+      const form = new URLSearchParams(String(init?.body))
+      if (form.get('action') === 'begin') {
+        return new Response(
+          JSON.stringify({
+            verification_uri_complete: 'https://accounts.feishu.cn/device?user_code=POOL-CODE',
+            device_code: 'pool-device-code',
+            expires_in: 600,
+            interval: 1
+          })
+        )
+      }
+      return new Response(
+        JSON.stringify({
+          client_id: 'cli_pool',
+          client_secret: 'pool-secret',
+          user_info: { tenant_brand: 'lark' }
+        })
+      )
+    })
+    const spy = new SpyControl()
+    const app = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender, {
+      feishuAppRegistration: service(fetcher),
+      verifyFeishuBot: async () => ({ status: 'ok', name: 'Pool Bot', openId: 'ou_pool_bot' })
+    })
+    running = app
+
+    const started = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/feishu/app`,
+      payload: { agentId, name: 'AgentConnect Pool', region: 'lark' }
+    })
+    expect({ status: started.statusCode, body: started.json() }).toMatchObject({ status: 201 })
+    const { id } = started.json() as { id: string }
+
+    await vi.waitFor(async () => {
+      const polled = await app.app.inject({ method: 'GET', url: `${ORG}/integrations/feishu/app/${id}` })
+      expect(polled.json()).toMatchObject({ status: 'completed', failureReason: null })
+    })
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([MEMBER])
+    expect(await prisma.bot.findFirst({ where: { externalAppId: 'cli_pool' } })).toMatchObject({
+      name: 'AgentConnect Pool'
     })
   }, 15_000)
 

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -14,10 +14,13 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
+import { seedPoolMember } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgAgentRepo, PgDaemonRepo, PgIntegrationRepo, PgIntegrationChannelRepo } from '../../src/persistence/index.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
+import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
+import { systemClock } from '../../src/domain/clock.js'
 import { handleIntegrationChannels } from '../../src/ws/handlers/index.js'
 import { IntegrationId } from '../../src/domain/ids.js'
 import type { DaemonConnection } from '../../src/ws/connection.js'
@@ -149,6 +152,9 @@ async function report(
     integration: new PgIntegrationRepo(prisma),
     integrationChannel: new PgIntegrationChannelRepo(prisma),
     agent: new PgAgentRepo(prisma),
+    // Admission is the served set now — placement ∪ the duties this member holds.
+    dutyLease: new PgDutyGroupRepo(prisma),
+    clock: systemClock,
     agentMutations,
     collabRoutes
   } as unknown as DaemonWsDeps
@@ -727,7 +733,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
     const id = await install(running)
     const stored = await prisma.integration.findUniqueOrThrow({ where: { id } })
-    const scoped = new PgIntegrationRepo(prisma)
+    const agents = new PgAgentRepo(prisma)
     let firstRead = true
     const frame = {
       v: 1,
@@ -736,17 +742,22 @@ describe('integration/channels EVT → integration_channel convergence', () => {
       type: 'integration/channels',
       payload: { integrationId: id, channels: [{ id: 'C1', name: 'late-source' }] }
     } as AnyFrame
+    // The served set is what admission reads, so the move lands between its two evaluations.
     const deps = {
-      integration: {
-        activeForDaemon: async (daemonId: Parameters<typeof scoped.activeForDaemon>[0]) => {
-          const rows = await scoped.activeForDaemon(daemonId)
+      integration: new PgIntegrationRepo(prisma),
+      agent: {
+        listForDaemon: async (daemonId: Parameters<typeof agents.listForDaemon>[0]) => {
+          const rows = await agents.listForDaemon(daemonId)
           if (firstRead) {
             firstRead = false
             await prisma.agent.update({ where: { id: stored.agentId }, data: { daemonId: OTHER_DAEMON } })
           }
           return rows
-        }
+        },
+        listByIds: (ids: Parameters<typeof agents.listByIds>[0]) => agents.listByIds(ids),
+        getUnscoped: (agentId: Parameters<typeof agents.getUnscoped>[0]) => agents.getUnscoped(agentId)
       },
+      clock: systemClock,
       integrationChannel: new PgIntegrationChannelRepo(prisma),
       agentMutations: new AgentMutationGate()
     } as unknown as DaemonWsDeps
@@ -1361,6 +1372,81 @@ describe('DELETE …/channels/:channelId (forget) and POST …/leave (platform)'
     expect(res.statusCode).toBe(204)
     expect(spy.leaves).toEqual([
       { daemonId: DAEMON, l: { integrationId: id, target: { kind: 'space', spaceId: 'G1' } } }
+    ])
+  })
+})
+
+/**
+ * The pool half of every conversation path (#1026, #1027): a POOL agent is placed and names no
+ * machine, so a snapshot admitted by `agent.daemonId` was dropped in silence, and Forget / Leave
+ * refused on a column that could never be filled.
+ */
+describe('conversation paths for a POOL agent', () => {
+  const MEMBER = 'd9999999-9999-4999-8999-999999999999'
+  const GROUP = '00000000-0000-4000-8000-0000000009d1'
+
+  /** A pool agent whose duty MEMBER holds, with a Telegram install (the session-derived
+   *  platform, so Forget must reach a daemon) — plus the id of that install. */
+  async function heldInstall(app: HttpApp, platform: 'slack' | 'telegram'): Promise<string> {
+    const setId = await seedPoolMember(prisma, MEMBER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { setId, createdByUserId: DEFAULT_OWNER_ID })
+    await seedDutyGroup(prisma, GROUP, MEMBER, [agentId])
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload:
+        platform === 'slack'
+          ? { name: 'pool-bot', platform, agentId, slack: SLACK }
+          : { name: 'pool-tg', platform, agentId, telegram: { botToken: '123456:AAE-xyz' } }
+    })
+    expect(res.statusCode).toBe(201)
+    return (res.json() as { id: string }).id
+  }
+
+  it('accepts a channel snapshot from the member holding the duty, and no one else (#1027)', async () => {
+    await seedDaemon(prisma, OTHER_DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await heldInstall(running, 'slack')
+    const channels = new PgIntegrationChannelRepo(prisma)
+
+    // A daemon that holds no duty for the agent writes nothing — silently, as before.
+    await report(OTHER_DAEMON, id, [{ id: 'C1', name: 'deploys' }])
+    expect(await channels.listForIntegration(IntegrationId(id))).toEqual([])
+
+    await report(MEMBER, id, [{ id: 'C1', name: 'deploys' }])
+    expect((await channels.listForIntegration(IntegrationId(id))).map((c) => c.channelId)).toEqual(['C1'])
+  })
+
+  it('pushes Forget to the duty holder instead of refusing as undeliverable (#1026)', async () => {
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await heldInstall(running, 'telegram')
+    await report(MEMBER, id, [{ id: '-100123', name: 'Team' }], undefined, undefined, false)
+
+    const res = await running.app.inject({ method: 'DELETE', url: `${ORG}/integrations/${id}/channels/-100123` })
+
+    expect(res.statusCode).toBe(204)
+    expect(spy.forgets).toEqual([{ daemonId: MEMBER, f: { integrationId: id, channels: ['-100123'] } }])
+    expect(await new PgIntegrationChannelRepo(prisma).listForIntegration(IntegrationId(id))).toEqual([])
+  })
+
+  it('dispatches Leave to the duty holder (#1026)', async () => {
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await heldInstall(running, 'telegram')
+    await report(MEMBER, id, [{ id: 'C1', name: 'deploys' }], undefined, undefined, false)
+
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/${id}/leave`,
+      payload: { target: { kind: 'conversation', channel: 'C1' } }
+    })
+
+    expect(res.statusCode).toBe(204)
+    expect(spy.leaves).toEqual([
+      { daemonId: MEMBER, l: { integrationId: id, target: { kind: 'conversation', channel: 'C1' } } }
     ])
   })
 })

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
+import { seedPoolMember } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import type { IntegrationUpsert, IntegrationRemove } from '@agentconnect.md/protocol'
@@ -1799,6 +1800,44 @@ describe('integration updates follow the duty holder', () => {
     // A holder still admitting on the ungated defaults would serve conversations
     // the agent's new visibility forbids.
     expect(held!.u.core.gated).toBe(true)
+  })
+
+  // #1026: the create probed with the resolver and then finalized on `agent.daemonId`, which is
+  // NULL for a pool agent — so the whole install refused after its capability check had passed.
+  it('installs on a POOL agent through the member holding its duty (#1026)', async () => {
+    const setId = await seedPoolMember(prisma, HOLDER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { setId })
+    await seedDutyGroup(prisma, GROUP, HOLDER, [agentId])
+    const { app, spy } = withSpy()
+
+    const created = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { name: 'pool-bot', platform: 'slack', agentId, slack: SLACK }
+    })
+    expect({ status: created.statusCode, message: created.json() }).toMatchObject({ status: 201 })
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([HOLDER])
+    expect(await prisma.integration.count()).toBe(1)
+  })
+
+  it('a POOL agent nothing is serving is still refused with 409, and stores nothing', async () => {
+    const setId = await seedPoolMember(prisma, HOLDER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { setId })
+    const { app, spy } = withSpy()
+
+    const created = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { name: 'pool-bot', platform: 'slack', agentId, slack: SLACK }
+    })
+    expect(created.statusCode).toBe(409)
+    expect({
+      integrations: await prisma.integration.count(),
+      bots: await prisma.bot.count(),
+      pushes: spy.upserts
+    }).toEqual({ integrations: 0, bots: 0, pushes: [] })
   })
 
   it('an EXPIRED lease is not a holding — the dependent goes to the placement alone', async () => {

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -17,7 +17,7 @@ import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.j
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
 import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
-import { SessionVisibilityPushService } from '../../src/orchestrator/visibilityPush.js'
+import { SessionVisibilityPushService, SNAPSHOT_CHUNK } from '../../src/orchestrator/visibilityPush.js'
 import { systemClock } from '../../src/domain/clock.js'
 import { SESSION_VISIBILITY_FEATURE, SLACK_SESSION_AUDIENCE_FEATURE } from '@agentconnect.md/protocol'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
@@ -1306,6 +1306,79 @@ describe('session visibility — §5.1 replay follows the serving member', () =>
     await push.replayTo(NEW_HOLDER as never)
 
     expect(snapshots).toEqual([])
+  })
+
+  // The exact leak the ACK watermark allows, end to end. `visibilityAckedRev` is per SESSION, so
+  // the PREVIOUS holder's ack makes every row look delivered; ordering then puts the old private
+  // session past the 500-row page, and phase 1 stops on `unacked === 0`. Without the private phase
+  // the new holder never receives it and — because losing a duty preserves its local gate state —
+  // can go on capturing from a session the user marked private.
+  //
+  // Mutation check: drop `replayPrivatePages` and this test fails on exactly that session.
+  it('sends an old private gate the previous holder acked, past the page cap', async () => {
+    const setId = await seedPoolMember(prisma, NEW_HOLDER)
+    await seedDaemon(prisma, RETIRED)
+    const agentId = await seedAgent(prisma, randomUUID(), { setId })
+    const repo = new PgSessionRepo(prisma)
+
+    // One OLD session, tightened and acked while RETIRED held the agent.
+    const old = `s-old-private-${randomUUID()}`
+    await seedSessionMeta(prisma, old, agentId, {
+      daemonId: RETIRED,
+      lastActivityAt: new Date(Date.now() - 365 * 86_400_000)
+    })
+    await repo.setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(old), 'private')
+    await repo.recordVisibilityAck(SessionId(old), 1)
+
+    // …behind a full page of newer, already-acked sessions.
+    await prisma.sessionMeta.createMany({
+      data: Array.from({ length: SNAPSHOT_CHUNK }, (_, i) => ({
+        id: `s-bulk-${i}-${randomUUID()}`,
+        agentId,
+        orgId: DEFAULT_ORG_ID,
+        platform: 'slack',
+        channel: '#bulk',
+        phase: 'start' as const,
+        // Acked at their initial revision — the state a previous holder's replay leaves behind.
+        visibilityAckedRev: 0,
+        lastActivityAt: new Date(Date.now() - i * 1000)
+      }))
+    })
+    // Nothing is outstanding as far as the watermark is concerned.
+    expect(await repo.countUnackedVisibilityForAgents([agentId])).toBe(0)
+
+    await seedDutyGroup(prisma, GROUP, NEW_HOLDER, [agentId])
+    const { push, snapshots } = pushService()
+    await push.replayTo(NEW_HOLDER as never)
+
+    const delivered = snapshots.flatMap((s) => s.entries.map((e) => e.sessionId))
+    expect(delivered).toContain(old)
+  })
+
+  it('the private page is cursored, agent-scoped and blind to the ack watermark', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const mine = await seedAgent(prisma, randomUUID(), { daemonId })
+    const theirs = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const ids: string[] = []
+    for (const owner of [mine, mine, theirs]) {
+      const id = `s-priv-${randomUUID()}`
+      await seedSessionMeta(prisma, id, owner)
+      await repo.setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(id), 'private')
+      await repo.recordVisibilityAck(SessionId(id), 1) // fully acked — phase 1 would skip these
+      if (owner === mine) ids.push(id)
+    }
+    // An org session of the same agent is not a gate anyone can be wrong about the safe way.
+    await seedSessionMeta(prisma, `s-org-${randomUUID()}`, mine)
+    const ordered = [...ids].sort()
+
+    const first = await repo.privateVisibilityPage([mine], 1)
+    expect(first.map((r) => r.sessionId)).toEqual([ordered[0]])
+    expect(first[0]).toMatchObject({ visibility: 'private', sharedMemoryExcluded: true })
+
+    const next = await repo.privateVisibilityPage([mine], 10, true, ordered[0])
+    expect(next.map((r) => r.sessionId)).toEqual([ordered[1]]) // the other agent's row never appears
+    expect(await repo.privateVisibilityPage([mine], 10, true, ordered[1])).toEqual([])
   })
 
   it('a machine-placed agent still replays to its placement', async () => {

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -9,10 +9,17 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedAgent, seedDaemon, seedSessionMeta } from '../fixtures/seed.js'
+import { seedAgent, seedDaemon, seedDutyGroup, seedSessionMeta } from '../fixtures/seed.js'
+import { seedPoolMember } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
+import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
+import { SessionVisibilityPushService } from '../../src/orchestrator/visibilityPush.js'
+import { systemClock } from '../../src/domain/clock.js'
+import { SESSION_VISIBILITY_FEATURE, SLACK_SESSION_AUDIENCE_FEATURE } from '@agentconnect.md/protocol'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { AgentId, OrgId, SessionId } from '../../src/domain/ids.js'
 import type { OrgMemberRole } from '../../src/persistence/ports.js'
@@ -1167,8 +1174,8 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
     })
     await repo.recordVisibilityAck(SessionId(fresh), 0)
 
-    expect(await repo.countUnackedVisibility(daemonId)).toBe(1)
-    const capped = await repo.visibilitySnapshotForDaemon(daemonId, 1)
+    expect(await repo.countUnackedVisibilityForAgents([agentId])).toBe(1)
+    const capped = await repo.visibilitySnapshotForAgents([agentId], 1)
     expect(capped).toEqual([
       { sessionId: stale, orgId: DEFAULT_ORG_ID, visibility: 'private', sharedMemoryExcluded: true, visibilityRev: 1 }
     ])
@@ -1196,10 +1203,11 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
     expect(subtree.find((r) => r.id === child)).toMatchObject({ visibilityAckedRev: -1, visibilityRev: 1 })
   })
 
-  it('snapshots the gate state for one daemon, newest first', async () => {
+  it('snapshots the gate state for the agents a daemon serves, newest first', async () => {
     const daemonId = await seedDaemon(prisma, randomUUID())
     const otherDaemonId = await seedDaemon(prisma, randomUUID())
     const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const otherAgentId = await seedAgent(prisma, randomUUID(), { daemonId: otherDaemonId })
     const older = await seedSessionMeta(prisma, `s-snap-old-${randomUUID()}`, agentId, {
       daemonId,
       lastActivityAt: new Date(Date.now() - 60_000)
@@ -1209,9 +1217,10 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
       visibility: 'private',
       lastActivityAt: new Date()
     })
-    await seedSessionMeta(prisma, `s-snap-elsewhere-${randomUUID()}`, agentId, { daemonId: otherDaemonId })
+    // Another agent's session never rides this page, whichever daemon first reported it.
+    await seedSessionMeta(prisma, `s-snap-elsewhere-${randomUUID()}`, otherAgentId, { daemonId: otherDaemonId })
 
-    const snapshot = await new PgSessionRepo(prisma).visibilitySnapshotForDaemon(daemonId, 10)
+    const snapshot = await new PgSessionRepo(prisma).visibilitySnapshotForAgents([agentId], 10)
     expect(snapshot).toEqual([
       {
         sessionId: newer,
@@ -1227,6 +1236,89 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
         sharedMemoryExcluded: false,
         visibilityRev: 0
       }
+    ])
+  })
+})
+
+/**
+ * #1029 — the reconnect replay is what "ultimately closes the bypass" for a gate a member missed.
+ * It paged by `session_meta.daemonId`, the daemon that FIRST reported the session (nulled once
+ * that member is reaped), so a duty that moved after a rollout left the new holder replaying
+ * nothing and capturing from a session the user had marked private.
+ */
+describe('session visibility — §5.1 replay follows the serving member', () => {
+  const RETIRED = 'd5555555-5555-4555-8555-555555555555'
+  const NEW_HOLDER = 'd6666666-6666-4666-8666-666666666666'
+  const GROUP = '00000000-0000-4000-8000-0000000009a2'
+
+  /** The push service as the container builds it, over a capturing sender and a registry that
+   *  says every daemon is connected and speaks the visibility features. */
+  function pushService() {
+    const snapshots: Array<{ daemonId: string; orgId: string; entries: Array<{ sessionId: string }> }> = []
+    const push = new SessionVisibilityPushService({
+      repos: { session: new PgSessionRepo(prisma), agent: new PgAgentRepo(prisma) },
+      control: {
+        sessionVisibilitySnapshot: async (daemonId: string, orgId: string, entries: Array<{ sessionId: string }>) => {
+          snapshots.push({ daemonId, orgId, entries })
+          return { ok: true }
+        }
+      } as never,
+      connReg: {
+        get: () => ({
+          capabilities: { features: [SESSION_VISIBILITY_FEATURE, SLACK_SESSION_AUDIENCE_FEATURE] }
+        })
+      } as never,
+      placement: new PlacementResolver({ duties: new PgDutyGroupRepo(prisma), clock: systemClock }),
+      duties: new PgDutyGroupRepo(prisma),
+      clock: systemClock
+    })
+    return { push, snapshots }
+  }
+
+  it('replays a pool agent’s tightened gate to the member holding its duty now', async () => {
+    const setId = await seedPoolMember(prisma, NEW_HOLDER)
+    await seedDaemon(prisma, RETIRED)
+    const agentId = await seedAgent(prisma, randomUUID(), { setId })
+    const repo = new PgSessionRepo(prisma)
+    // Reported by the member that has since been rolled away — the column still names it.
+    const sessionId = await seedSessionMeta(prisma, `s-pool-${randomUUID()}`, agentId, { daemonId: RETIRED })
+    await repo.setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(sessionId), 'private')
+    await seedDutyGroup(prisma, GROUP, NEW_HOLDER, [agentId])
+
+    const { push, snapshots } = pushService()
+    await push.replayTo(NEW_HOLDER as never)
+
+    expect(snapshots.map((s) => ({ daemonId: s.daemonId, sessions: s.entries.map((e) => e.sessionId) }))).toEqual([
+      { daemonId: NEW_HOLDER, sessions: [sessionId] }
+    ])
+    // …and the unacked counter agrees, so nothing reports a convergence that did not happen.
+    expect(await repo.countUnackedVisibilityForAgents([agentId])).toBe(0)
+  })
+
+  it('a member holding no duty for the agent still replays nothing', async () => {
+    const setId = await seedPoolMember(prisma, NEW_HOLDER)
+    await seedDaemon(prisma, RETIRED)
+    const agentId = await seedAgent(prisma, randomUUID(), { setId })
+    const sessionId = await seedSessionMeta(prisma, `s-unheld-${randomUUID()}`, agentId, { daemonId: RETIRED })
+    await new PgSessionRepo(prisma).setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(sessionId), 'private')
+
+    const { push, snapshots } = pushService()
+    await push.replayTo(NEW_HOLDER as never)
+
+    expect(snapshots).toEqual([])
+  })
+
+  it('a machine-placed agent still replays to its placement', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const sessionId = await seedSessionMeta(prisma, `s-pinned-${randomUUID()}`, agentId, { daemonId })
+    await new PgSessionRepo(prisma).setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(sessionId), 'private')
+
+    const { push, snapshots } = pushService()
+    await push.replayTo(daemonId as never)
+
+    expect(snapshots.map((s) => ({ daemonId: s.daemonId, sessions: s.entries.map((e) => e.sessionId) }))).toEqual([
+      { daemonId, sessions: [sessionId] }
     ])
   })
 })

--- a/packages/control-plane/test/integration/slack-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-install.route.test.ts
@@ -13,7 +13,8 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
+import { seedPoolMember } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import type { RelayChannel } from '../../src/ws/relay-registry.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
@@ -32,6 +33,8 @@ import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
+const MEMBER = 'd9999999-9999-4999-8999-999999999999'
+const GROUP = '00000000-0000-4000-8000-0000000009e1'
 // The PUBLIC form (`/v1` alias mount) — what Slack actually redirects the browser
 // to on a direct-hit deploy; the gateway-rewritten arrival at the internal
 // `/api/v1/…` mount gets its own test below.
@@ -375,6 +378,51 @@ describe('slack auto-install funnel', () => {
   // later, as a scoped call answering `missing_scope` and the session-access
   // check failing closed. Finalize is the last point where the operator is still
   // in the flow and one reinstall away, so it refuses there.
+  // #1026: both funnel legs still gated on `agent.daemonId`, which a POOL agent leaves NULL — so
+  // the whole wizard was unreachable for one while its siblings had already been converted.
+  it('start and finalize both work for a POOL agent, through the member holding its duty (#1026)', async () => {
+    const setId = await seedPoolMember(prisma, MEMBER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { setId })
+    await seedDutyGroup(prisma, GROUP, MEMBER, [agentId])
+    await seedUserConfig()
+    const { app, spy } = withFunnel()
+
+    const started = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app`,
+      payload: { agentId, name: 'pool-bot' }
+    })
+    expect({ status: started.statusCode, body: started.json() }).toMatchObject({ status: 201 })
+    const { installId } = started.json() as { installId: string }
+    await app.app.inject({ method: 'GET', url: `${CALLBACK}?code=the-code&state=${installId}` })
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app/${installId}/finalize`,
+      payload: { appToken: 'xapp-1-A1TEST-9-abcdef' }
+    })
+    expect({ status: res.statusCode, body: res.json() }).toMatchObject({ status: 201 })
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([MEMBER])
+    expect(await prisma.slackInstall.findUnique({ where: { id: installId } })).toBeNull()
+  })
+
+  it('start refuses a POOL agent nothing is serving with 409, minting no pending row', async () => {
+    const setId = await seedPoolMember(prisma, MEMBER)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { setId })
+    await seedUserConfig()
+    const { app, stub } = withFunnel()
+
+    const started = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app`,
+      payload: { agentId }
+    })
+    expect(started.statusCode).toBe(409)
+    expect({ created: stub.createCalls, rows: await prisma.slackInstall.count() }).toEqual({ created: [], rows: 0 })
+  })
+
   it('finalize refuses a workspace authorization that granted fewer bot scopes, minting nothing', async () => {
     const { app, spy } = withFunnel()
     const withheld = ['channels:history', 'users:read']

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -1141,6 +1141,34 @@ describe('routing follows the holder (protocol level, real Postgres)', () => {
     expect(h.hookAssigns.every((rule) => rule.daemonId !== OTHER)).toBe(true)
   })
 
+  // The privacy half of the same moment (#1029). A member REGISTERS before it holds anything, so
+  // the register-time replay resolves an empty served set and returns; the duty then arrives on a
+  // beat, and `duty/fetch` carries no gate state. Without a replay here the member serves the
+  // agent with whatever gate it last had — for a re-acquired agent, a stale `org` on a session the
+  // user has since marked private.
+  //
+  // Mutation check: drop the `visibility?.replayTo(...)` from the confirmation branch and a member
+  // that acquires its first duty never converges its capture gates until it reconnects.
+  it('asks for a capture-gate replay at the moment the member confirms the grant', async () => {
+    const start = 1_700_000_000_000
+    const h = buildWsHarness(prisma)
+    await seedPooledAgentWithHook()
+    await seedGroup({ holder: OTHER, term: 4n, expiresAt: new Date(start - 1) })
+    const { stub } = await ready(h)
+    // Register replayed for a member that held nothing — that is exactly the empty one.
+    h.visibilityReplays.length = 0
+
+    await beat(stub, { held: [], headroom: 4 }) // claims; not serving yet
+    expect(h.visibilityReplays).toEqual([])
+
+    await beat(stub, { held: [{ groupId: GROUP, term: '5' }], headroom: 4 }) // confirms
+    await vi.waitFor(() => expect(h.visibilityReplays).toEqual([DAEMON]))
+
+    // Confirmation is stamped once per grant, so a repeat digest is not a replay storm.
+    await beat(stub, { held: [{ groupId: GROUP, term: '5' }], headroom: 4 })
+    expect(h.visibilityReplays).toEqual([DAEMON])
+  })
+
   it('withdraws the rule when the lease is handed back and nothing serves the agent', async () => {
     // The other half of the same property: a holder change AWAY from a member has to stop the
     // ingress it was receiving, or a dead member keeps being addressed.

--- a/packages/control-plane/test/repo/cron.repo.test.ts
+++ b/packages/control-plane/test/repo/cron.repo.test.ts
@@ -160,9 +160,9 @@ describe('CronRepo — cron definitions (real Postgres)', () => {
     })
     expect(await repo.reapStaleRuns(new Date('2026-01-01T00:30:00Z'))).toBe(1)
 
-    // The daemon's completion finally arrives (owning daemon → accepted) and
+    // The daemon's completion finally arrives (the handler already fenced it) and
     // re-closes the reaped row with the real outcome — the reaper is non-destructive.
-    const ok = await repo.recordReport(CronId(CRON), DaemonId(DAEMON), {
+    const ok = await repo.recordReport(CronId(CRON), {
       firedAt,
       status: 'success',
       durationMs: 999,


### PR DESCRIPTION
Closes #1026, closes #1027, closes #1029.

## Summary

Placement stopped being a member id, but a dozen control-plane sites still authorized on — or targeted — `agent.daemonId`, which is NULL for a `set` placement. Every one of them now goes through `deps.placementResolver` (`mayAct` / `servingDaemon` / `routableDaemon`), and the repositories that joined on `agent: { daemonId }` take the resolved set from the service instead. No caller branches on the placement kind; that stays inside `domain/placement.ts` and the resolver.

One new domain predicate: `samePlacementRef` — "do two reads of this agent name the same placement?" — so a mutation fences on placement identity rather than on one column.

## Failure scenario

Three shapes of the same bug, all of them reachable today by moving an agent onto the pool:

**#1026 — write routes refuse a placement that is real.** An operator adds a Slack integration, creates any integration, runs a cron on demand, finishes a Feishu registration, or tells an agent to stop listing a conversation. Each flow shows its capability check passing and then refuses with a placement error that is not true: the agent *is* placed, on a set rather than a machine. `POST /crons/:id/run` had an extra twist — it resolved the serving member, wrote it onto the observed record, and then compared that synthetic value against the row's NULL column, so it 409'd "agent placement changed" every single time. The Slack install wizard was never converted at all, so it was unreachable for a pool agent end to end.

**#1027 — daemon reports dropped in silence.** Three handlers admitted a frame only if the reporting daemon was the agent's *recorded* daemon, and each treats "not mine" as "ignore":
- every cron fire/progress/completion report from a pool member was discarded, so `lastRunAt` never advanced and the console's run history stayed empty forever;
- Slack channel-membership snapshots were discarded, so conversation lists — and the gating defaults and collab-route refresh derived from them — never updated;
- `viewSessionStatus` on a cross-daemon child returned "not found" for every pool agent, and the parent proof compared `session_meta.daemonId` (the daemon that *first* reported the session, `onDelete: SetNull`) against the asker, so after a rollout the member now serving the parent was refused its own session.

**#1029 — a privacy gate that silently does not converge.** A user marks a session private; the CP pushes to whichever member serves it (correct today). That member is rolled away and the duty moves. The new holder connects, the CP replays the visibility snapshot to converge it — and `visibilitySnapshotForDaemon` returns zero rows, because no `session_meta` row names the new member. It keeps the session's `org` memory-capture gate and can distill a session the user marked private into agent-scoped shared memory. `countUnackedVisibility` shared the predicate, so the counter reported 0 and the tightening looked delivered.

Review surfaced two more edges on that same replay, both fixed here:

- **A member registers before it holds anything.** Vacancy duties are claimed later by the heartbeat exchange and installed through `duty/fetch`, which carries no gate state — so the register-time replay resolved an empty served set and returned, and a member re-acquiring an agent kept whatever gate it last had.
- **`visibilityAckedRev` is per session, not per daemon.** Coherent while one daemon owned a session; once duty moves the serving member, the *previous* holder's ack marks a gate "delivered" to a member that never saw it. With more than one page of such rows the replay stops on `countUnacked… === 0` and an older private gate is never sent — and since `duty/revoke` deliberately preserves local state, the member still holds a stale `org` gate for it, so failing closed does not apply.

## Fix

**#1026 — `http/routes/`**
- `slack-install.ts`: both legs (`POST /integrations/slack/app`, `…/finalize`) resolve the serving member and probe capability against it. The finalize re-read under the mutation lease now compares placement identity.
- `integrations.ts`: create finalizes on the resolved member rather than re-reading the column; `pushForget` and `integrationLeave` dispatch at `servingDaemon(agent)`.
- `crons.ts`: "Run now" no longer writes a resolver-derived `daemonId` onto the observed record — it refreshes the row, then re-resolves the target under the lease.
- `feishu-registration.ts`: the finalize step resolves the member the way its own `start` leg already did.
- `refreshMutationAgent` in crons / integrations, and the equivalent inline check in slack-install, fence on `samePlacementRef` — column equality both missed a re-placement onto another set and read every set placement as unplaced.

**#1027 — `ws/handlers/` + repos**
- `cron-report.ts` reads the cron's own agent (never the frame's untrusted `agentId` claim) and fences on `mayAct`; `CronRepo.recordReport` drops its `reportingDaemonId` join, and `CronRepo` grows the `getUnscoped` the fence needs.
- `integration-channels.ts` admits by served agents — `servedAgents(daemon)` → `activeForAgents(...)`, the same `placement ∪ held duties` union the reconcile roster builds — on the first read *and* on the re-check under the mutation lease.
- `child-session-status.ts` admits the parent through `mayAct` on the session's agent and addresses the child through `servingDaemon`.

**#1029 — `persistence/` + `orchestrator/`**
- `visibilitySnapshotForDaemon` / `countUnackedVisibility` become `visibilitySnapshotForAgents` / `countUnackedVisibilityForAgents`, keyed on the agent set and keeping the existing "unacked first, then newest-active" ordering.
- `SessionVisibilityPushService` resolves the connecting member's served set each round (a duty granted mid-replay widens the next page) and pages by it; `container.ts` wires the duty ledger and clock it needs.
- **Replay also fires on duty admission** — from the exchange's confirmation branch, the same moment the routing projections converge and the first proof the member is actually serving the group. `confirmHeld` stamps once per grant, so this is not per-beat churn.
- **Replay is two phases.** Phase 1 is the unacked walk, unchanged. Phase 2 cursor-pages `privateVisibilityPage` — every currently-private gate of the served agents, ordered by `id`, blind to `visibilityAckedRev`. Private-only is sufficient because `isCaptureExcluded` returns `true` when the member has no row at all, so the only way capture reopens is a stale non-private gate; that set is exactly the private one, which is the explicitly-reclassified minority rather than every session ever recorded. Rows phase 1 already put on the wire are filtered out, so one pass never sends a gate twice.

## Test plan

`test/fixtures/seed.ts` gains a `setId` option and `test/fakes/member-set.ts` a `seedPoolMember`, so a suite can seed the org-less member + pool membership + duty group the way `#1004`/`#1022` do.

New coverage — a pool agent (org-less member set + duty holder) on each fixed path, plus the machine-placed agent still working:

| Path | Suite |
| --- | --- |
| Slack install start + finalize; and 409 when nothing serves it | `slack-install.route.test.ts` |
| integration create; and 409 + nothing stored when nothing serves it | `integrations.route.test.ts` |
| cron "Run now"; and 503 when nothing serves it | `crons.route.test.ts` |
| Feishu registration finalize | `feishu-registration.route.test.ts` |
| `cron/report` from the duty holder, dropped from a non-holder | `cron-report.test.ts` |
| `integration/channels` snapshot, Forget, Leave | `integration-channels.test.ts` |
| `session/child-status` pool parent + pool child, cross-org refusal, machine-placed pair, no self-forward | `child-session-status.test.ts` (new) |
| visibility replay to the new holder, nothing for a non-holder, machine placement unchanged | `session-visibility.route.test.ts` |
| replay fires on duty confirmation, not on the claim, and once per grant | `duty-lease.handler.test.ts` |
| an old private gate the previous holder acked, past the page cap | `session-visibility.route.test.ts` |
| the private page is cursored, agent-scoped and blind to the ack watermark | `session-visibility.route.test.ts` |

The last three are mutation-checked: disabling the confirmation hook, or phase 2, makes exactly those tests fail.

Existing tests updated where they encoded the old column semantics: the child-status unit test now models two agents and a duty ledger; the `integration/channels` ownership re-check intercepts the served-set read; the visibility snapshot repo test seeds a second *agent* rather than a second daemon.

Commands run on `4532089` (main merged in at `85b418e`):

- `pnpm --filter @agentconnect.md/control-plane typecheck` — clean
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 155 files, 1694 tests, all passing
- `pnpm --filter @agentconnect.md/control-plane test:int` — 89 files, 1360 tests, all passing (this sandbox blocks the Testcontainers image pull at the egress proxy, so the suite ran against a local PostgreSQL 16 cluster through a scratch global-setup with the identical migrate/seed/clone-per-pool contract; that scratch file is not part of the diff)
- `pnpm typecheck` (repo-wide), `pnpm lint`, `pnpm format:check` — clean

## Not in scope

- A `private → org` widen whose stale `private` survives on a member over-restricts (memory not captured when it could be). That is the safe direction rather than a leak, unchanged from before this PR, and closing it needs per-holder delivery state — a `(sessionId, daemonId)` table plus changes to `recordVisibilityAck` and the §4.3 applied/pending semantics.
- `agents.ts` still refuses on `agent.daemonId` in its own daemon-directed routes (permission requests, workspace and dream reads, and friends). Same class, tracked by #955's siblings, and large enough to want its own change.

`HookRepo.recordReport`'s join is no longer outstanding — #1061 landed it upstream and is merged in here.

Happy to take either remaining item as a follow-up.

---
_Generated by [Claude Code](
