### PR TITLE
feat(daemon): publish a real pool-member readiness signal

### DIFF
--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -567,7 +567,10 @@ most one move per agent (#1016):
   probe has returned, and false again the instant the SIGTERM latch closes, so
   the endpoints controller stops routing while the pod keeps running for the
   drain. That makes the rollout barrier the fact rather than a timed
-  `minReadySeconds` (#1043).
+  `minReadySeconds` (#1043). The gate is the FIRST thing `start()` does — a
+  marker file on a mounted path outlives the container that wrote it, so it is
+  cleared before startup blocks on the CP registry, and readiness reads
+  `starting` until `start()` returns.
 - **Drain is real, slow-safe, and acknowledged.** Per member
   (`Daemon.stop()` → `releaseDutiesForShutdown`): in-flight turns are never
   cut to speed the rollout up; each held group is withdrawn locally (the same

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -559,6 +559,15 @@ most one move per agent (#1016):
   missing-regrant re-issue all skip a draining member until it registers
   afresh, so a vacated group can only land on a member that is staying —
   even if the scale-down is not simultaneous. Renewal continues meanwhile.
+- **Ready means servable, not merely up.** A member under `--k8s` publishes one
+  predicate (`packages/daemon/src/readiness.ts`, `readinessState`) on the two
+  sinks a pod probe can read — HTTP `/readyz` on `AC_READINESS_PORT` and a file
+  at `AC_READINESS_FILE` (default `/var/run/agentconnect/ready`) — true only once
+  the CP registration is acknowledged **and** the install-wide sandbox runtime
+  probe has returned, and false again the instant the SIGTERM latch closes, so
+  the endpoints controller stops routing while the pod keeps running for the
+  drain. That makes the rollout barrier the fact rather than a timed
+  `minReadySeconds` (#1043).
 - **Drain is real, slow-safe, and acknowledged.** Per member
   (`Daemon.stop()` → `releaseDutiesForShutdown`): in-flight turns are never
   cut to speed the rollout up; each held group is withdrawn locally (the same
@@ -796,3 +805,4 @@ shrinking every actor's permissions.
 | Relay re-route                                                         | `packages/relay/src/relay-ingress-manager.ts` (`sendWithRendezvous`), `relay-browser-connection.ts`   |
 | Shim dial-in                                                           | `packages/daemon/src/shim/{dialer,server}.ts`                                                         |
 | Pod-bound member identity                                              | `packages/control-plane/src/cluster/daemon-identity.ts`                                               |
+| Member readiness (probe sinks)                                         | `packages/daemon/src/readiness.ts`, `src/daemon.ts` (`readinessState`)                                |

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6,6 +6,7 @@ import { mkdtemp } from 'node:fs/promises'
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
 import { loadConfig, persistDaemonId, persistRelays, type FlatOverrides } from './config/load-config.js'
 import { readCliEntry, runCliUpgrade } from './lifecycle/cli-upgrade.js'
+import { ReadinessGate, readinessSinksFromEnv, readinessState, type ReadinessState } from './readiness.js'
 import { sessionRetentionMs, type Config, type RuntimeDef } from './config/config-schema.js'
 import { discoverAgentsTolerant, type LoadedAgent } from './agents/load-agents.js'
 import { agentChildEnv } from './agents/agent-env.js'
@@ -2196,6 +2197,10 @@ export class Daemon {
   // `draining` so the CP stops granting to this member (sticky for the registration), and turns the
   // shutdown into a duty drain: hold and serve until each group's turns settle, then release it.
   private shutdownDraining = false
+  // Kubernetes readiness (#1043): the two sinks a pod probe reads, and the one fact only this
+  // member knows — that the install-wide sandbox runtime probe came back.
+  private readiness?: ReadinessGate
+  private k8sRuntimeProbed = false
   // The shutdown duty drain in progress: its deadline, its counters, and the release of every grant
   // that landed after the latch, so the summary and `stop()` can wait for all of them.
   private shutdownDutyDrain?: ShutdownDutyDrain
@@ -3734,6 +3739,9 @@ export class Daemon {
     void this.probeRuntimesAndEmit(false).finally(() => this.armRuntimeProbeRefresh())
     if (!this.k8s) startControlPlane(root)
     this.armIdleSweep()
+    // Under Kubernetes only: elsewhere the process being up IS the signal, and nothing reads a
+    // readiness sink. Last, so the endpoint exists exactly when the rest of the daemon does.
+    if (this.k8s || this.opts.supervisor === K8S_SUPERVISOR) await this.startReadinessGate()
     this.log.info('daemon ready')
   }
 
@@ -21994,6 +22002,7 @@ export class Daemon {
       // may have missed emits while we were disconnected; latest-wins upsert).
       onReady: () => {
         resolveInitialRegistry()
+        this.readiness?.refresh()
         void this.probeRuntimesAndEmit()
         void this.syncOrganizationSuggestions().catch((err) =>
           this.log.warn(`cp: organization suggestion replay failed (${err instanceof Error ? err.name : 'unknown'})`)
@@ -22236,6 +22245,10 @@ export class Daemon {
         this.runtimeProbedVersions.set(id, entry.version || (this.runtimeProbedVersions.get(id) ?? ''))
       }
       this.applyK8sDeclaredFacts()
+      // The half of readiness only this call can settle: before it the member advertises nothing
+      // and the CP would assign it nothing, so it is not servable however healthy it looks.
+      this.k8sRuntimeProbed = true
+      this.readiness?.refresh()
       this.log.info(
         `runtimes ready (probed): ${table.runtimes.map((entry) => `${entry.id}@${entry.version}`).join(', ') || '(none)'}`
       )
@@ -22257,6 +22270,37 @@ export class Daemon {
           : `runtimes: sandbox probe failed — advertising none (${message})`
       )
     }
+  }
+
+  /**
+   * What a Kubernetes readiness probe reads (#1043) — one predicate, so the HTTP endpoint, the
+   * readiness file, and the tests can never answer differently.
+   */
+  readinessState(): ReadinessState {
+    return readinessState({
+      cpRegistered: this.cpClient?.state === 'READY',
+      // No execution plane means no image to interrogate, so a k8s-supervised daemon that runs its
+      // runtimes locally is not held behind a probe it never makes.
+      runtimeProbed: !this.k8sPlane || this.k8sRuntimeProbed,
+      // Both gates: the shutdown latch, and the drain a failed data plane requests an exit behind.
+      draining: this.draining || this.shutdownDraining
+    })
+  }
+
+  /** Start the readiness sinks. Their configuration is environment, not daemon config: the pod
+   *  spec that declares the probe is the same thing that sets the port and path it reads. */
+  private async startReadinessGate(): Promise<void> {
+    const gate = new ReadinessGate({
+      ...readinessSinksFromEnv(process.env, (message) => this.log.warn(message)),
+      state: () => this.readinessState(),
+      log: { info: (message) => this.log.info(message), warn: (message) => this.log.warn(message) }
+    })
+    try {
+      await gate.start()
+    } catch (error) {
+      throw new Error(`daemon startup refused: the readiness endpoint could not listen — ${formatErr(error)}`)
+    }
+    this.readiness = gate
   }
 
   private projectDeclaredRuntimes(
@@ -22665,6 +22709,9 @@ export class Daemon {
     // digest says `draining` with zero headroom — sent now rather than at the next tick, so the CP
     // stops granting to this member within one round trip of the SIGTERM.
     this.shutdownDraining = true
+    // Flip readiness with the latch, not on the next sync tick: the endpoints controller has to
+    // stop routing here while the pod keeps running for the whole drain.
+    this.readiness?.refresh()
     this.dutyClaimsSuspended = true
     const drainDeadlineAt = this.clock.now() + this.shutdownDrainBudgetMs()
     const shutdownDrain: ShutdownDutyDrain = {
@@ -22783,6 +22830,8 @@ export class Daemon {
     // would cut in-flight turns and closing it before host teardown would leave `AcpHost.stop()`
     // unable to send its ACP close — a sandbox process still running, and reconnecting.
     await this.k8sPlane?.stop().catch(() => undefined)
+    await this.readiness?.stop().catch(() => undefined)
+    this.readiness = undefined
     setWorkspaceGitRunnerResolver(undefined)
     setWorkspacePathClearer(undefined)
     setSandboxWorkspaceMode(false)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2201,6 +2201,7 @@ export class Daemon {
   // member knows — that the install-wide sandbox runtime probe came back.
   private readiness?: ReadinessGate
   private k8sRuntimeProbed = false
+  private startupComplete = false
   // The shutdown duty drain in progress: its deadline, its counters, and the release of every grant
   // that landed after the latch, so the summary and `stop()` can wait for all of them.
   private shutdownDutyDrain?: ShutdownDutyDrain
@@ -2877,6 +2878,10 @@ export class Daemon {
   }
 
   async start(): Promise<void> {
+    // FIRST, before any await that can block for as long as the control plane is down: the file
+    // sink clears its marker here, and a marker on a mounted path outlives the container that
+    // wrote it — left in place, `test -f` would call an unregistered replacement ready.
+    if (this.k8s || this.opts.supervisor === K8S_SUPERVISOR) await this.startReadinessGate()
     // A service-installed daemon normally arrives through the CLI run shell's
     // login-shell launch with a full user env (cli service-spawn.ts). This is
     // the backstop for legacy direct-ExecStart units and bare docker runs:
@@ -3739,9 +3744,8 @@ export class Daemon {
     void this.probeRuntimesAndEmit(false).finally(() => this.armRuntimeProbeRefresh())
     if (!this.k8s) startControlPlane(root)
     this.armIdleSweep()
-    // Under Kubernetes only: elsewhere the process being up IS the signal, and nothing reads a
-    // readiness sink. Last, so the endpoint exists exactly when the rest of the daemon does.
-    if (this.k8s || this.opts.supervisor === K8S_SUPERVISOR) await this.startReadinessGate()
+    this.startupComplete = true
+    this.readiness?.refresh()
     this.log.info('daemon ready')
   }
 
@@ -22278,6 +22282,7 @@ export class Daemon {
    */
   readinessState(): ReadinessState {
     return readinessState({
+      startupComplete: this.startupComplete,
       cpRegistered: this.cpClient?.state === 'READY',
       // No execution plane means no image to interrogate, so a k8s-supervised daemon that runs its
       // runtimes locally is not held behind a probe it never makes.
@@ -22287,8 +22292,9 @@ export class Daemon {
     })
   }
 
-  /** Start the readiness sinks. Their configuration is environment, not daemon config: the pod
-   *  spec that declares the probe is the same thing that sets the port and path it reads. */
+  /** Start the readiness sinks — under Kubernetes only, since elsewhere the process being up IS
+   *  the signal. Their configuration is environment, not daemon config: the pod spec that declares
+   *  the probe is the same thing that sets the port and path it reads. */
   private async startReadinessGate(): Promise<void> {
     const gate = new ReadinessGate({
       ...readinessSinksFromEnv(process.env, (message) => this.log.warn(message)),

--- a/packages/daemon/src/readiness.ts
+++ b/packages/daemon/src/readiness.ts
@@ -7,9 +7,11 @@ import { dirname } from 'node:path'
 // deployment side can only guess at the gap with a fixed minReadySeconds.
 
 /** Why a member is not servable; `ready` is the only servable value. */
-export type ReadinessReason = 'ready' | 'draining' | 'control-plane-unregistered' | 'runtime-probe-pending'
+export type ReadinessReason = 'ready' | 'draining' | 'starting' | 'control-plane-unregistered' | 'runtime-probe-pending'
 
 export interface ReadinessInputs {
+  /** `start()` returned. False from the first instruction of the process, before anything is dialled. */
+  startupComplete: boolean
   /** The CP connection is authenticated AND this daemon's registration was acknowledged. */
   cpRegistered: boolean
   /** The install-wide sandbox runtime probe returned, so the member advertises what it can launch. */
@@ -28,6 +30,9 @@ export function readinessState(inputs: ReadinessInputs): ReadinessState {
   // Draining wins over everything: a draining member is still registered and still probed, and the
   // point of the signal at SIGTERM is that neither makes it servable any more.
   if (inputs.draining) return { ready: false, reason: 'draining' }
+  // Answered before the daemon has done anything at all: startup blocks on the CP registry, and a
+  // marker left on a mounted path by the previous container must not read as ready meanwhile.
+  if (!inputs.startupComplete) return { ready: false, reason: 'starting' }
   if (!inputs.cpRegistered) return { ready: false, reason: 'control-plane-unregistered' }
   if (!inputs.runtimeProbed) return { ready: false, reason: 'runtime-probe-pending' }
   return { ready: true, reason: 'ready' }

--- a/packages/daemon/src/readiness.ts
+++ b/packages/daemon/src/readiness.ts
@@ -1,0 +1,178 @@
+import { createServer, type Server } from 'node:http'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+// Pool-member readiness (#1043): a member's process is up long before it has registered with the
+// CP and learned from a sandbox what the runtime image provides, so without a signal the
+// deployment side can only guess at the gap with a fixed minReadySeconds.
+
+/** Why a member is not servable; `ready` is the only servable value. */
+export type ReadinessReason = 'ready' | 'draining' | 'control-plane-unregistered' | 'runtime-probe-pending'
+
+export interface ReadinessInputs {
+  /** The CP connection is authenticated AND this daemon's registration was acknowledged. */
+  cpRegistered: boolean
+  /** The install-wide sandbox runtime probe returned, so the member advertises what it can launch. */
+  runtimeProbed: boolean
+  /** SIGTERM drain has started: in-flight turns keep running, but no new traffic may arrive. */
+  draining: boolean
+}
+
+export interface ReadinessState {
+  ready: boolean
+  reason: ReadinessReason
+}
+
+/** The single readiness predicate both sinks are derived from. */
+export function readinessState(inputs: ReadinessInputs): ReadinessState {
+  // Draining wins over everything: a draining member is still registered and still probed, and the
+  // point of the signal at SIGTERM is that neither makes it servable any more.
+  if (inputs.draining) return { ready: false, reason: 'draining' }
+  if (!inputs.cpRegistered) return { ready: false, reason: 'control-plane-unregistered' }
+  if (!inputs.runtimeProbed) return { ready: false, reason: 'runtime-probe-pending' }
+  return { ready: true, reason: 'ready' }
+}
+
+/** The one path the HTTP sink answers on; anything else is a 404, not a health surface. */
+export const READINESS_HTTP_PATH = '/readyz'
+
+/** Where the file sink lands unless `AC_READINESS_FILE` names somewhere else. */
+export const DEFAULT_READINESS_FILE = '/var/run/agentconnect/ready'
+
+/** How often the file sink is reconciled with the predicate, between explicit refreshes. */
+const DEFAULT_SYNC_INTERVAL_MS = 1000
+
+export interface ReadinessSinks {
+  /** HTTP port; undefined leaves the endpoint off, which is the default. */
+  port?: number
+  /** Readiness file path; empty disables the file sink. */
+  filePath?: string
+}
+
+/** Read the two sink knobs off the environment. An unusable port is reported, not guessed at. */
+export function readinessSinksFromEnv(
+  env: NodeJS.ProcessEnv,
+  warn: (message: string) => void = () => {}
+): ReadinessSinks {
+  const raw = env.AC_READINESS_PORT?.trim()
+  let port: number | undefined
+  if (raw) {
+    const parsed = Number(raw)
+    if (Number.isInteger(parsed) && parsed >= 0 && parsed <= 65535) port = parsed
+    else warn('readiness: AC_READINESS_PORT is not a port number — HTTP readiness stays off')
+  }
+  const configured = env.AC_READINESS_FILE
+  const filePath = configured === undefined ? DEFAULT_READINESS_FILE : configured.trim()
+  return { ...(port !== undefined ? { port } : {}), ...(filePath ? { filePath } : {}) }
+}
+
+export interface ReadinessGateOptions extends ReadinessSinks {
+  /** The live predicate; evaluated per HTTP request and per file sync, never cached. */
+  state: () => ReadinessState
+  host?: string
+  syncIntervalMs?: number
+  log: { info: (message: string) => void; warn: (message: string) => void }
+}
+
+/**
+ * Publishes {@link readinessState} on the two sinks a Kubernetes probe can read: a tiny HTTP
+ * endpoint (`httpGet`) and a file (`exec test -f`). Both re-evaluate the same closure, so a pod
+ * configured either way gets one answer with two spellings.
+ */
+export class ReadinessGate {
+  private server?: Server
+  private timer?: NodeJS.Timeout
+  private filePresent = false
+  private fileFailed = false
+  private port?: number
+
+  constructor(private readonly opts: ReadinessGateOptions) {}
+
+  async start(): Promise<void> {
+    // A file left by a previous container in this pod would read as ready before this process has
+    // proved anything, so the sink starts from a known-absent state.
+    this.clearFile()
+    if (this.opts.port !== undefined) await this.startHttp(this.opts.port)
+    this.timer = setInterval(() => this.syncFile(), this.opts.syncIntervalMs ?? DEFAULT_SYNC_INTERVAL_MS)
+    this.timer.unref()
+    this.syncFile()
+  }
+
+  /** Reconcile the file sink now — called at transitions so SIGTERM does not wait for a tick. */
+  refresh(): void {
+    this.syncFile()
+  }
+
+  /** The bound HTTP port, or undefined when the endpoint is off. */
+  listeningPort(): number | undefined {
+    return this.port
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) clearInterval(this.timer)
+    this.timer = undefined
+    this.clearFile()
+    const server = this.server
+    this.server = undefined
+    this.port = undefined
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+
+  private async startHttp(port: number): Promise<void> {
+    const server = createServer((req, res) => {
+      if ((req.url ?? '').split('?', 1)[0] !== READINESS_HTTP_PATH) {
+        res.statusCode = 404
+        res.end()
+        return
+      }
+      const state = this.opts.state()
+      res.statusCode = state.ready ? 200 : 503
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('cache-control', 'no-store')
+      res.end(req.method === 'HEAD' ? undefined : JSON.stringify(state))
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(port, this.opts.host ?? '0.0.0.0', () => {
+        server.removeListener('error', reject)
+        resolve()
+      })
+    })
+    this.server = server
+    this.port = (server.address() as { port: number }).port
+    this.opts.log.info(`readiness: listening on ${this.opts.host ?? '0.0.0.0'}:${this.port}${READINESS_HTTP_PATH}`)
+  }
+
+  private syncFile(): void {
+    const path = this.opts.filePath
+    if (!path || this.fileFailed) return
+    const state = this.opts.state()
+    if (state.ready === this.filePresent) return
+    if (!state.ready) {
+      this.clearFile()
+      return
+    }
+    try {
+      mkdirSync(dirname(path), { recursive: true })
+      writeFileSync(path, `${state.reason}\n`)
+      this.filePresent = true
+      this.opts.log.info(`readiness: ready — wrote ${path}`)
+    } catch (error) {
+      // One warning, then the sink is off: an unwritable path is a deployment that probes over
+      // HTTP, not a reason to log once a second forever.
+      this.fileFailed = true
+      this.opts.log.warn(`readiness: cannot write ${path} — file readiness is off (${(error as Error).message})`)
+    }
+  }
+
+  private clearFile(): void {
+    const path = this.opts.filePath
+    if (!path || this.fileFailed) return
+    try {
+      rmSync(path, { force: true })
+    } catch (error) {
+      this.opts.log.warn(`readiness: cannot remove ${path} (${(error as Error).message})`)
+    }
+    this.filePresent = false
+  }
+}

--- a/packages/daemon/test/daemon-duty-drain.test.ts
+++ b/packages/daemon/test/daemon-duty-drain.test.ts
@@ -97,6 +97,19 @@ describe('shutdown drain of a duty-holding member', () => {
     expect(duties(daemon).size()).toBe(0)
   })
 
+  it('turns readiness false at the latch, so the endpoints controller stops routing before the drain runs', async () => {
+    const { daemon } = await boot()
+    ;(daemon as any).cpClient.state = 'READY'
+    expect(daemon.readinessState()).toEqual({ ready: true, reason: 'ready' })
+
+    const stopping = daemon.stop()
+    // Synchronous with the latch, not a sync tick later: the drain that follows can take minutes,
+    // and every second of it routing new traffic here is traffic the member is retiring from.
+    expect(daemon.readinessState()).toEqual({ ready: false, reason: 'draining' })
+    await stopping
+    expect(daemon.readinessState()).toEqual({ ready: false, reason: 'draining' })
+  })
+
   it('a late grant with everything clean is never installed and is acknowledged only after the loop is done', async () => {
     const LATE = '11111111-1111-4111-8111-111111111113'
     const { daemon, calls } = await boot()

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -434,6 +434,33 @@ describe('daemon --k8s mode', () => {
     }
   })
 
+  it('clears a readiness marker left on a mounted path before it waits on the control plane (#1043)', async () => {
+    const rootDir = root()
+    const marker = join(rootDir, 'ready')
+    writeFileSync(marker, 'ready\n')
+    vi.stubEnv('AC_READINESS_FILE', marker)
+    let release!: () => void
+    const startControlPlane = vi.fn(() => new Promise<void>((resolve) => (release = resolve)))
+    const instance = daemon({ root: rootDir, k8s: true, startControlPlane })
+    const starting = instance.start()
+    try {
+      // The marker outlives the container that wrote it, and startup blocks here for as long as the
+      // CP is down — so it has to be gone before the wait, not after it.
+      await vi.waitFor(() => expect(startControlPlane).toHaveBeenCalledOnce())
+      expect(existsSync(marker)).toBe(false)
+      expect(instance.readinessState()).toEqual({ ready: false, reason: 'starting' })
+      release()
+      await starting
+      // Startup is done; what is left is the member's own registration.
+      expect(instance.readinessState()).toEqual({ ready: false, reason: 'control-plane-unregistered' })
+      expect(existsSync(marker)).toBe(false)
+    } finally {
+      await starting.catch(() => undefined)
+      await instance.stop()
+      vi.unstubAllEnvs()
+    }
+  })
+
   it('is not ready until the install-wide sandbox runtime probe returns (#1043)', async () => {
     let settle!: (table: unknown) => void
     const k8sDaemon = daemon({

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -434,6 +434,27 @@ describe('daemon --k8s mode', () => {
     }
   })
 
+  it('is not ready until the install-wide sandbox runtime probe returns (#1043)', async () => {
+    let settle!: (table: unknown) => void
+    const k8sDaemon = daemon({
+      root: root(),
+      k8s: true,
+      plane: { probeRuntimes: () => new Promise((resolve) => (settle = resolve)) }
+    })
+    try {
+      await k8sDaemon.start()
+      // Registered, but the member still advertises nothing: the CP would assign it no agent, so
+      // process health is not servability and the probe is the half only this member can settle.
+      ;(k8sDaemon as any).cpClient = { state: 'READY' }
+      expect(k8sDaemon.readinessState()).toEqual({ ready: false, reason: 'runtime-probe-pending' })
+      settle({ runtimes: [{ id: 'claude', version: '1.2.3' }] })
+      await vi.waitFor(() => expect(k8sDaemon.readinessState()).toEqual({ ready: true, reason: 'ready' }))
+    } finally {
+      ;(k8sDaemon as any).cpClient = undefined
+      await k8sDaemon.stop()
+    }
+  })
+
   it('deletes a removed agent’s sandbox, which is what takes its workspace volume with it', async () => {
     const discarded: string[] = []
     const k8sDaemon = daemon({

--- a/packages/daemon/test/daemon-readiness.test.ts
+++ b/packages/daemon/test/daemon-readiness.test.ts
@@ -26,32 +26,29 @@ async function get(port: number, path = READINESS_HTTP_PATH): Promise<{ status: 
 }
 
 describe('readinessState', () => {
+  const up = { startupComplete: true, cpRegistered: true, runtimeProbed: true, draining: false }
+
   it('is ready once the member is registered and the runtime probe has returned', () => {
-    expect(readinessState({ cpRegistered: true, runtimeProbed: true, draining: false })).toEqual({
-      ready: true,
-      reason: 'ready'
-    })
+    expect(readinessState(up)).toEqual({ ready: true, reason: 'ready' })
+  })
+
+  it('is not ready while startup has not finished, whatever else already holds', () => {
+    expect(readinessState({ ...up, startupComplete: false })).toEqual({ ready: false, reason: 'starting' })
   })
 
   it('is not ready while the control-plane registration is unacknowledged', () => {
-    expect(readinessState({ cpRegistered: false, runtimeProbed: true, draining: false })).toEqual({
+    expect(readinessState({ ...up, cpRegistered: false })).toEqual({
       ready: false,
       reason: 'control-plane-unregistered'
     })
   })
 
   it('is not ready while the install-wide runtime probe is outstanding', () => {
-    expect(readinessState({ cpRegistered: true, runtimeProbed: false, draining: false })).toEqual({
-      ready: false,
-      reason: 'runtime-probe-pending'
-    })
+    expect(readinessState({ ...up, runtimeProbed: false })).toEqual({ ready: false, reason: 'runtime-probe-pending' })
   })
 
   it('is not ready while draining, however registered and probed the member is', () => {
-    expect(readinessState({ cpRegistered: true, runtimeProbed: true, draining: true })).toEqual({
-      ready: false,
-      reason: 'draining'
-    })
+    expect(readinessState({ ...up, draining: true })).toEqual({ ready: false, reason: 'draining' })
   })
 })
 

--- a/packages/daemon/test/daemon-readiness.test.ts
+++ b/packages/daemon/test/daemon-readiness.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  DEFAULT_READINESS_FILE,
+  READINESS_HTTP_PATH,
+  ReadinessGate,
+  readinessSinksFromEnv,
+  readinessState,
+  type ReadinessState
+} from '../src/readiness.js'
+
+// Pool-member readiness (#1043): what the deployment side's probe is allowed to conclude from the
+// two sinks, and the transitions it has to observe for a rollout barrier to be exact.
+
+const silent = { info: () => {}, warn: () => {} }
+
+function file(): string {
+  return join(mkdtempSync(join(tmpdir(), 'ac-readiness-')), 'ready')
+}
+
+async function get(port: number, path = READINESS_HTTP_PATH): Promise<{ status: number; body: string }> {
+  const response = await fetch(`http://127.0.0.1:${port}${path}`)
+  return { status: response.status, body: await response.text() }
+}
+
+describe('readinessState', () => {
+  it('is ready once the member is registered and the runtime probe has returned', () => {
+    expect(readinessState({ cpRegistered: true, runtimeProbed: true, draining: false })).toEqual({
+      ready: true,
+      reason: 'ready'
+    })
+  })
+
+  it('is not ready while the control-plane registration is unacknowledged', () => {
+    expect(readinessState({ cpRegistered: false, runtimeProbed: true, draining: false })).toEqual({
+      ready: false,
+      reason: 'control-plane-unregistered'
+    })
+  })
+
+  it('is not ready while the install-wide runtime probe is outstanding', () => {
+    expect(readinessState({ cpRegistered: true, runtimeProbed: false, draining: false })).toEqual({
+      ready: false,
+      reason: 'runtime-probe-pending'
+    })
+  })
+
+  it('is not ready while draining, however registered and probed the member is', () => {
+    expect(readinessState({ cpRegistered: true, runtimeProbed: true, draining: true })).toEqual({
+      ready: false,
+      reason: 'draining'
+    })
+  })
+})
+
+describe('readinessSinksFromEnv', () => {
+  it('leaves the endpoint off and the file on its default path when nothing is configured', () => {
+    expect(readinessSinksFromEnv({})).toEqual({ filePath: DEFAULT_READINESS_FILE })
+  })
+
+  it('takes the configured port and path', () => {
+    expect(readinessSinksFromEnv({ AC_READINESS_PORT: '9099', AC_READINESS_FILE: '/run/ac/ready' })).toEqual({
+      port: 9099,
+      filePath: '/run/ac/ready'
+    })
+  })
+
+  it('reports an unusable port instead of guessing at one, and an empty path disables the file', () => {
+    const warnings: string[] = []
+    expect(
+      readinessSinksFromEnv({ AC_READINESS_PORT: 'http', AC_READINESS_FILE: '' }, (m) => warnings.push(m))
+    ).toEqual({})
+    expect(warnings).toHaveLength(1)
+  })
+})
+
+describe('ReadinessGate', () => {
+  it('answers 503 until the member is servable and 200 after, on its own path only', async () => {
+    let state: ReadinessState = { ready: false, reason: 'control-plane-unregistered' }
+    const gate = new ReadinessGate({ port: 0, state: () => state, host: '127.0.0.1', log: silent })
+    await gate.start()
+    const port = gate.listeningPort()!
+    try {
+      const pending = await get(port)
+      expect(pending.status).toBe(503)
+      expect(JSON.parse(pending.body)).toEqual({ ready: false, reason: 'control-plane-unregistered' })
+      state = { ready: true, reason: 'ready' }
+      expect((await get(port)).status).toBe(200)
+      // The port serves readiness, not a general health surface.
+      expect((await get(port, '/')).status).toBe(404)
+    } finally {
+      await gate.stop()
+    }
+  })
+
+  it('writes the readiness file only while ready, and removes it when the member drains', async () => {
+    const path = file()
+    let state: ReadinessState = { ready: false, reason: 'runtime-probe-pending' }
+    const gate = new ReadinessGate({ filePath: path, state: () => state, log: silent })
+    await gate.start()
+    try {
+      expect(existsSync(path)).toBe(false)
+      state = { ready: true, reason: 'ready' }
+      gate.refresh()
+      expect(existsSync(path)).toBe(true)
+      state = { ready: false, reason: 'draining' }
+      gate.refresh()
+      expect(existsSync(path)).toBe(false)
+    } finally {
+      await gate.stop()
+    }
+  })
+
+  it('clears a file left behind by an earlier container before it proves anything', async () => {
+    const path = file()
+    writeFileSync(path, 'ready\n')
+    const gate = new ReadinessGate({
+      filePath: path,
+      state: () => ({ ready: false, reason: 'control-plane-unregistered' }),
+      log: silent
+    })
+    await gate.start()
+    try {
+      expect(existsSync(path)).toBe(false)
+    } finally {
+      await gate.stop()
+    }
+  })
+
+  it('removes the file on stop so an exited process never reads as servable', async () => {
+    const path = file()
+    const gate = new ReadinessGate({ filePath: path, state: () => ({ ready: true, reason: 'ready' }), log: silent })
+    await gate.start()
+    expect(existsSync(path)).toBe(true)
+    await gate.stop()
+    expect(existsSync(path)).toBe(false)
+  })
+
+  it('reconciles the file on its own tick, without an explicit refresh', async () => {
+    const path = file()
+    let state: ReadinessState = { ready: false, reason: 'runtime-probe-pending' }
+    const gate = new ReadinessGate({ filePath: path, state: () => state, syncIntervalMs: 5, log: silent })
+    await gate.start()
+    try {
+      state = { ready: true, reason: 'ready' }
+      await expect.poll(() => existsSync(path)).toBe(true)
+    } finally {
+      await gate.stop()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Closes #1043 (follow-up to #1016).

A daemon-pool member's process is ready long before it can serve anything: it still
has to register with the control plane and learn from a sandbox what the runtime
image provides. With no signal for that gap, the deployment side can only stand in
for it with a fixed `minReadySeconds` — either too short (the rollout scales old
members down before their replacements can take the duties) or wastefully long, and
timed either way rather than exact.

This adds the signal. Under Kubernetes the daemon publishes one predicate on the two
sinks a pod probe can read, so the rollout barrier becomes a fact the member states
about itself.

## Design

- **One predicate, two sinks.** `packages/daemon/src/readiness.ts` exports
  `readinessState({ cpRegistered, runtimeProbed, draining })`, and both sinks
  re-evaluate the same closure per request/tick — a pod configured either way gets
  one answer with two spellings. `Daemon.readinessState()` supplies the inputs.
- **Ready means servable.** True only when the CP connection is `READY` (authenticated
  **and** registration acknowledged, so the member is duty-eligible) *and* the
  install-wide sandbox runtime probe (`probeK8sRuntimes` → `plane.probeRuntimes()`)
  has returned. Before that probe the member advertises no runtime, the CP would
  assign it no agent, and it is not servable however healthy the process looks.
- **False at the latch.** `Daemon.stop()` sets `shutdownDraining` (#1021/#1016) and
  refreshes readiness in the same synchronous step, so the endpoints controller stops
  routing new traffic while the pod keeps running for the whole drain (minutes, by
  design — in-flight turns are never cut).
- **HTTP sink:** `GET /readyz` on `AC_READINESS_PORT` — 200 with `{"ready":true,"reason":"ready"}`,
  503 with the blocking reason otherwise, 404 on any other path. Off unless the port is
  set. No new listener was reusable: the daemon dials the sandbox shim out, it does not
  accept (`shim/server.ts` runs in the pod), so nothing daemon-side was already serving HTTP.
- **File sink:** `AC_READINESS_FILE`, default `/var/run/agentconnect/ready`, for a plain
  `exec` probe. Written only while ready, removed on the flip and on stop. An unwritable
  path warns once and turns the file sink off rather than logging every second.
- **The gate is the first statement of `start()`**, before any await that can block for as
  long as the CP is down. A marker on a mounted path outlives the container that wrote it,
  so it is cleared before startup waits on the CP registry; until `start()` returns the
  predicate carries `startupComplete: false` and reports `starting` (HTTP 503).
- Enabled only under Kubernetes (`--k8s` runtime plane or `AGENTCONNECT_SUPERVISOR=k8s`);
  elsewhere the process being up is the signal and nothing reads a sink.

No chart or deployment file is touched — that side follows separately.

## Deployment-side probe settings

Set `AC_READINESS_PORT` (e.g. `8081`) on the pool container, or mount a writable
`/var/run/agentconnect` for the file sink, then configure the readiness probe:

| Setting               | HTTP                    | Exec                                        |
| --------------------- | ----------------------- | ------------------------------------------- |
| probe                 | `httpGet /readyz` on `AC_READINESS_PORT` | `test -f /var/run/agentconnect/ready` |
| `initialDelaySeconds` | `5`                     | `5`                                         |
| `periodSeconds`       | `5`                     | `5`                                         |
| `timeoutSeconds`      | `2`                     | `2`                                         |
| `successThreshold`    | `1`                     | `1`                                         |
| `failureThreshold`    | `3`                     | `3`                                         |

The readiness port must not be exposed through any Service that routes traffic; it is
a probe surface only. Once the probe is configured, `minReadySeconds` can drop to a
small settle margin (a few seconds) or `0` — the barrier is now "registered + probed"
rather than a fixed 60 s. Keep `maxSurge: 100%` / `maxUnavailable: 0` and
`terminationGracePeriodSeconds` ≥ `limits.poolShutdownDrainMs` plus margin; readiness
going false at SIGTERM is what stops traffic during that grace period.

## Test plan

- `packages/daemon/test/daemon-readiness.test.ts` (new, 13 cases): `readinessState`
  transitions (registered + probed ⇒ ready; still starting ⇒ not ready; unregistered ⇒ not
  ready; probe pending ⇒ not ready; draining ⇒ not ready even when registered and probed), env parsing
  (default off/default path, configured values, unusable port reported), and the gate
  itself (503 → 200, 404 off-path, file written only while ready, removed on drain and
  on stop, stale file cleared at start, reconciled on its own tick).
- `daemon-k8s-mode.test.ts`: a pool member reports `runtime-probe-pending` until the
  sandbox probe returns, then `ready`; and a pre-existing marker file is removed before
  startup waits on the CP registry, with readiness reading `starting` throughout that wait.
- `daemon-duty-drain.test.ts`: readiness turns false synchronously with the SIGTERM latch
  and stays false through the drain.
- `pnpm --filter @agentconnect.md/daemon typecheck`, the three suites above plus
  `daemon-supervisor-k8s` / `k8s-runtime-plane` / `daemon-duty-fence`, `pnpm lint`,
  `pnpm format:check` — all green.
- `docs/designs/k8s-daemon-pool.md` §12 records the signal; §17 maps the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

