### PR TITLE
fix(control-plane): resolve webchat multi-agent and delegated MCP placement

### DIFF
--- a/packages/control-plane/prisma/migrations/20260825000000_webchat_mcp_delegation_agent_keyed/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260825000000_webchat_mcp_delegation_agent_keyed/migration.sql
@@ -1,0 +1,6 @@
+-- A webchat MCP delegation belongs to the AGENT, not to the member that happened to serve it when
+-- the browser dialled. Keying it on a daemon row made every delegation cascade away the moment the
+-- pool reaper retired that member, and made a pool agent's entitlement unreachable, since the column
+-- the authority compared is null for a set placement. The serving daemon is resolved at use time.
+ALTER TABLE "webchat_mcp_delegation" DROP CONSTRAINT "webchat_mcp_delegation_daemonId_fkey";
+ALTER TABLE "webchat_mcp_delegation" DROP COLUMN "daemonId";

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -439,7 +439,6 @@ model Daemon {
   apiKeys               ApiKey[]
   sessions              SessionMeta[]
   lifecycleOps          DaemonLifecycleOp[]
-  webchatMcpDelegations WebchatMcpDelegation[]
   setMembership         MemberSetMember?
 
   @@unique([clusterIdentity, clusterPodUid], map: "daemon_cluster_identity_pod_key")
@@ -1228,7 +1227,7 @@ model WebchatConversationAgent {
 }
 
 // Durable, generation-fenced authority for one browser conversation to invoke
-// curated AgentConnect MCP tools through its currently placed daemon.
+// curated AgentConnect MCP tools through whichever daemon serves the agent when it redeems one.
 model WebchatMcpDelegation {
   id             String    @id @default(uuid()) @db.Uuid
   conversationId String    @db.Uuid
@@ -1236,7 +1235,6 @@ model WebchatMcpDelegation {
   userId         String
   orgId          String
   agentId        String    @db.Uuid
-  daemonId       String    @db.Uuid
   createdAt      DateTime  @default(now()) @db.Timestamptz(6)
   expiresAt      DateTime  @db.Timestamptz(6)
   revokedAt      DateTime? @db.Timestamptz(6)
@@ -1246,7 +1244,6 @@ model WebchatMcpDelegation {
   user         User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
   org          Org                     @relation(fields: [orgId], references: [id], onDelete: Cascade)
   agent        Agent                   @relation(fields: [agentId], references: [id], onDelete: Cascade)
-  daemon       Daemon                  @relation(fields: [daemonId], references: [id], onDelete: Cascade)
   grants       WebchatMcpAccessGrant[]
 
   @@unique([conversationId, generation])

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -541,6 +541,22 @@ export function buildContainer(
   // The derived in-memory connection index every hot lookup hits.
   const connReg = new ConnectionRegistry()
 
+  // The ONE answer to "which daemons serve this agent" — what its placement names, plus every
+  // current duty holder (orchestrator/placementResolver.ts).
+  const placementResolver = new PlacementResolver({
+    duties: repos.dutyGroup,
+    // The set's members ready to take a trigger. Only the rendezvous fallback reads this: a set
+    // agent whose lease lapsed has no holder, and any member can claim it on receipt.
+    liveMembers: async (setId) => {
+      const members = new Set(await repos.memberSet.memberIdsOf(setId))
+      return connReg
+        .reachableDaemons()
+        .filter((d) => d.state === 'READY' && members.has(d.daemonId))
+        .map((d) => d.daemonId)
+    },
+    clock
+  })
+
   // Built-in general-preset webchat entitlement and short-lived access grants.
   const webchatMcpGrantToken = new WebchatMcpGrantTokenCodec(config.API_KEY_PEPPER)
   const webchatRemoteMcp = new WebchatRemoteMcpService({
@@ -551,6 +567,7 @@ export function buildContainer(
     agents: repos.agent,
     presets: repos.presetAgent,
     daemons: connReg,
+    placement: placementResolver,
     authorities: repos.webchatMcpDelegation,
     grants: repos.webchatMcpAccessGrant,
     // The daemon installs this verbatim into the adapter's `agentconnect-admin`
@@ -565,6 +582,7 @@ export function buildContainer(
     agents: repos.agent,
     presets: repos.presetAgent,
     daemons: connReg,
+    placement: placementResolver,
     grants: repos.webchatMcpAccessGrant,
     authorities: repos.webchatMcpDelegation,
     sessions: repos.session,
@@ -588,22 +606,6 @@ export function buildContainer(
   // Regional Login Apps mirrored from Logto. Their credentials are the stable
   // deployment tenant anchor used to admit Bot Apps from the same organization.
   const feishuPlatformApps = resolveFeishuPlatformApps(config)
-
-  // The ONE answer to "which daemons serve this agent" — what its placement names, plus every
-  // current duty holder (orchestrator/placementResolver.ts).
-  const placementResolver = new PlacementResolver({
-    duties: repos.dutyGroup,
-    // The set's members ready to take a trigger. Only the rendezvous fallback reads this: a set
-    // agent whose lease lapsed has no holder, and any member can claim it on receipt.
-    liveMembers: async (setId) => {
-      const members = new Set(await repos.memberSet.memberIdsOf(setId))
-      return connReg
-        .reachableDaemons()
-        .filter((d) => d.state === 'READY' && members.has(d.daemonId))
-        .map((d) => d.daemonId)
-    },
-    clock
-  })
 
   // Hook compiler/converger (webhook-triggers-and-github-events.md): CRUD routes
   // broadcast through it, and a (re)registering relay gets the full-set replay.

--- a/packages/control-plane/src/http/mcp/remote-grant-authenticator.ts
+++ b/packages/control-plane/src/http/mcp/remote-grant-authenticator.ts
@@ -12,6 +12,7 @@ export interface InvocationContext {
   grantId: string
   authorityGeneration: number
   agentId: string
+  /** The daemon serving the agent for this invocation, resolved live — never a stored member id. */
   daemonId: string
   orgId: string
   userId: string
@@ -69,12 +70,13 @@ export class RemoteGrantAuthenticator {
     if (!authority || authority.revokedAt || authority.expiresAt <= now) {
       return { kind: 'denied', reason: 'authority_inactive' }
     }
+    // No daemon identity on this seam — the grant arrives over HTTP from the agent's adapter — so
+    // the live check asks the resolver for whichever daemon serves the agent now.
     const live = await resolveLiveWebchatMcpAuthority(this.deps, {
       conversationId: authority.conversationId,
       expectedUserId: authority.userId,
       orgId: authority.orgId,
-      agentId: authority.agentId,
-      daemonId: authority.daemonId
+      agentId: authority.agentId
     })
     if (!live.ok) return { kind: 'denied', reason: live.reason }
 
@@ -119,7 +121,7 @@ export class RemoteGrantAuthenticator {
         grantId: grant.id,
         authorityGeneration: authority.generation,
         agentId: authority.agentId,
-        daemonId: authority.daemonId,
+        daemonId: live.daemonId,
         orgId: authority.orgId,
         userId: authority.userId,
         startedAt: now,

--- a/packages/control-plane/src/http/routes/webchat-mcp-operations.ts
+++ b/packages/control-plane/src/http/routes/webchat-mcp-operations.ts
@@ -81,15 +81,17 @@ export function webchatMcpOperationRoutes(deps: HttpDeps) {
     }) => {
       const agent = await deps.repos.agent.get(req.orgCtx!.orgId, AgentId(req.params.agentId))
       const userId = req.principal!.userId
-      if (!agent || !agent.daemonId || agent.orgId !== req.params.orgId || !canView(agent, ctxOf(req as never)))
-        return null
+      if (!agent || agent.orgId !== req.params.orgId || !canView(agent, ctxOf(req as never))) return null
+      // Who serves the agent is the resolver's answer; a pool agent names no machine of its own.
+      const daemonId = await deps.placementResolver.servingDaemon(agent)
+      if (!daemonId) return null
       const owns = await deps.repos.webchatConversation.owns({
         conversationId: req.params.conversationId,
         orgId: OrgId(req.params.orgId),
         agentId: AgentId(req.params.agentId),
         userId
       })
-      return owns ? { agent, userId } : null
+      return owns ? { agent, daemonId, userId } : null
     }
 
     r.get(
@@ -206,7 +208,7 @@ export function webchatMcpOperationRoutes(deps: HttpDeps) {
           grantId: operation.sourceGrantId,
           authorityGeneration: operation.createdAuthorityGeneration,
           agentId: auth.agent.id,
-          daemonId: auth.agent.daemonId!,
+          daemonId: auth.daemonId,
           orgId: auth.agent.orgId,
           userId: auth.userId,
           startedAt: now,

--- a/packages/control-plane/src/http/routes/webchat-token.ts
+++ b/packages/control-plane/src/http/routes/webchat-token.ts
@@ -22,6 +22,7 @@ import {
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import { AgentId, SessionId, type OrgId } from '../../domain/ids.js'
+import type { ResolvableAgent } from '../../orchestrator/placementResolver.js'
 import { canContinueSession, canView } from '../../authorization/policy.js'
 import { makeSessionAccessResolver } from '../session-access.js'
 import { ctxOf, orgOf } from '../rbac.js'
@@ -68,6 +69,18 @@ export function webchatTokenRoutes(deps: HttpDeps) {
     const authorHandle = async (userId: string, email: string | undefined): Promise<string> => {
       const profile = await deps.repos.user.getProfile(userId)
       return profile?.displayName?.trim() || email || userId
+    }
+
+    /** The first roster agent whose serving daemon does not advertise multi-agent webchat, or
+     *  undefined when every one of them does. The daemon comes from the resolver — the same
+     *  answer `rc/verify` will reach — because a pool agent's row names no machine at all. */
+    const firstWithoutMultiAgent = async (roster: readonly ResolvableAgent[]): Promise<string | undefined> => {
+      for (const agent of roster) {
+        const daemonId = await deps.placementResolver.dispatchDaemon(agent)
+        const daemon = daemonId ? deps.daemonConns.get(daemonId) : undefined
+        if (!daemon?.capabilities?.features?.includes(WEBCHAT_MULTI_AGENT_FEATURE)) return agent.id
+      }
+      return undefined
     }
 
     /** Mint-time fence (webchat-multi-agents.md §10.2): a resume requires the
@@ -285,15 +298,13 @@ export function webchatTokenRoutes(deps: HttpDeps) {
         if (agents.length > 1) {
           // Capability gate at creation (webchat-multi-agents.md §6.3): every
           // selected agent's daemon must advertise multi-agent webchat support.
-          for (const agent of agents) {
-            const daemon = agent.daemonId ? deps.daemonConns.get(agent.daemonId) : undefined
-            if (!daemon?.capabilities?.features?.includes(WEBCHAT_MULTI_AGENT_FEATURE)) {
-              return reply.code(409).send({
-                error: 'Conflict',
-                statusCode: 409,
-                message: `agent ${agent.id} is not on a daemon that supports multi-agent conversations`
-              })
-            }
+          const ungated = await firstWithoutMultiAgent(agents)
+          if (ungated) {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              message: `agent ${ungated} is not on a daemon that supports multi-agent conversations`
+            })
           }
         }
         const conversationId = randomUUID()
@@ -376,15 +387,13 @@ export function webchatTokenRoutes(deps: HttpDeps) {
           const existing = await deps.repos.agent.get(orgOf(req), p.agentId)
           if (existing) rosterAgents.push(existing)
         }
-        for (const member of rosterAgents) {
-          const daemon = member.daemonId ? deps.daemonConns.get(member.daemonId) : undefined
-          if (!daemon?.capabilities?.features?.includes(WEBCHAT_MULTI_AGENT_FEATURE)) {
-            return reply.code(409).send({
-              error: 'Conflict',
-              statusCode: 409,
-              message: `agent ${member.id} is not on a daemon that supports multi-agent conversations`
-            })
-          }
+        const ungated = await firstWithoutMultiAgent(rosterAgents)
+        if (ungated) {
+          return reply.code(409).send({
+            error: 'Conflict',
+            statusCode: 409,
+            message: `agent ${ungated} is not on a daemon that supports multi-agent conversations`
+          })
         }
         await deps.repos.webchatConversation.addParticipant(orgId, conversationId, agent.id, userId)
         return respond()

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -41,7 +41,7 @@ import type {
 } from '../domain/ids.js'
 import type { SessionKey } from '../domain/sessionKey.js'
 import type { DutyMemberKey, DutyReconcilePlan, DutyEdge, AgentSeed } from '../domain/duty.js'
-import type { PlacementKind, PlacementTarget } from '../domain/placement.js'
+import type { PlacementKind, PlacementRef, PlacementTarget } from '../domain/placement.js'
 import type {
   OrganizationEnvironmentAudience,
   OrganizationEnvironmentKind,
@@ -1495,7 +1495,9 @@ export interface EstablishWebchatMcpDelegationInput {
   userId: string
   orgId: OrgId
   agentId: AgentId
-  daemonId: DaemonId
+  /** The placement the caller resolved its live authority against, re-checked under the agent row
+   *  lock so a concurrent move cannot slip a delegation past the revocation that move performs. */
+  expectedPlacement: PlacementRef
   now: Date
   expiresAt: Date
 }
@@ -1507,7 +1509,6 @@ export interface WebchatMcpDelegationRecord {
   userId: string
   orgId: string
   agentId: string
-  daemonId: string
   createdAt: Date
   expiresAt: Date
   revokedAt: Date | null
@@ -1521,7 +1522,6 @@ export interface RevokeWebchatMcpDelegationInput {
   userId: string
   orgId: OrgId
   agentId: AgentId
-  daemonId: DaemonId
   revokedAt: Date
   reason: string
 }
@@ -1536,9 +1536,9 @@ export interface WebchatMcpDelegationRepo {
    * Serialize on the durable conversation owner. Reconnects reuse matching,
    * unexpired authority without extending it. An earlier requested expiry
    * atomically shortens the reused row without rotating its generation.
-   * An already-expired row or a placement change rotates its generation.
-   * A foreign/unknown conversation binding, wrong daemon, or unplaced agent
-   * returns null without mutating the current generation.
+   * An already-expired row rotates its generation, as does a placement change,
+   * which revokes the live row where it lands. A foreign/unknown conversation
+   * binding or a moved placement returns null without mutating the current generation.
    */
   establish(input: EstablishWebchatMcpDelegationInput): Promise<WebchatMcpDelegationRecord | null>
   /** Conditional, generation-fenced revocation. An already-revoked exact match is idempotently true. */
@@ -1576,7 +1576,6 @@ export interface IssueWebchatMcpGrantInput {
   authorityGeneration: number
   conversationId: string
   descriptorInstanceId: string
-  authenticatedDaemonId: string
   tokenHash: string
   now: Date
   pendingExpiresAt: Date
@@ -1590,7 +1589,6 @@ export interface AcceptWebchatMcpGrantInput {
   conversationId: string
   descriptorInstanceId: string
   grantRevision: number
-  authenticatedDaemonId: string
   now: Date
 }
 
@@ -1598,7 +1596,6 @@ export interface RevokeWebchatMcpGrantsInput {
   authorityId: string
   authorityGeneration: number
   conversationId: string
-  authenticatedDaemonId: string
   now: Date
   reason: string
 }

--- a/packages/control-plane/src/persistence/repositories/webchat-mcp-access-grant.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/webchat-mcp-access-grant.repo.ts
@@ -15,10 +15,10 @@ export class PgWebchatMcpAccessGrantRepo implements WebchatMcpAccessGrantRepo {
 
   async issue(input: IssueWebchatMcpGrantInput): Promise<WebchatMcpAccessGrantRecord | null> {
     return this.db.$transaction(async (tx) => {
-      const [authority] = await tx.$queryRaw<
-        { id: string; generation: number; conversationId: string; daemonId: string }[]
-      >(Prisma.sql`
-        SELECT "id", "generation", "conversationId", "daemonId"
+      // No daemon predicate: which member may act for the agent is the placement resolver's
+      // answer, checked live by the caller — this row is keyed on the agent, not on a member.
+      const [authority] = await tx.$queryRaw<{ id: string; generation: number; conversationId: string }[]>(Prisma.sql`
+        SELECT "id", "generation", "conversationId"
         FROM "webchat_mcp_delegation"
         WHERE "id" = ${input.authorityId}
           AND "revokedAt" IS NULL
@@ -28,8 +28,7 @@ export class PgWebchatMcpAccessGrantRepo implements WebchatMcpAccessGrantRepo {
       if (
         !authority ||
         authority.generation !== input.authorityGeneration ||
-        authority.conversationId !== input.conversationId ||
-        authority.daemonId !== input.authenticatedDaemonId
+        authority.conversationId !== input.conversationId
       ) {
         return null
       }
@@ -70,7 +69,6 @@ export class PgWebchatMcpAccessGrantRepo implements WebchatMcpAccessGrantRepo {
           AND g."grantRevision" = ${input.grantRevision}
           AND a."generation" = ${input.authorityGeneration}
           AND a."conversationId" = ${input.conversationId}
-          AND a."daemonId" = ${input.authenticatedDaemonId}
           AND a."revokedAt" IS NULL
           AND a."expiresAt" > ${input.now}
         FOR UPDATE
@@ -104,7 +102,6 @@ export class PgWebchatMcpAccessGrantRepo implements WebchatMcpAccessGrantRepo {
         WHERE "id" = ${input.authorityId}
           AND "generation" = ${input.authorityGeneration}
           AND "conversationId" = ${input.conversationId}
-          AND "daemonId" = ${input.authenticatedDaemonId}
         FOR UPDATE
       `)
       if (!authority) return false

--- a/packages/control-plane/src/persistence/repositories/webchat-mcp-delegation.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/webchat-mcp-delegation.repo.ts
@@ -1,8 +1,10 @@
 /**
- * Durable browser-conversation MCP authority. Establishment serializes on the
- * conversation row so concurrent tabs converge on one generation.
+ * Durable browser-conversation MCP authority, keyed on the AGENT. Establishment serializes on the
+ * conversation row so concurrent tabs converge on one generation, and fences on the agent's
+ * placement — not on a member id, which a pool rollout replaces under a live delegation.
  */
 import { Prisma, type WebchatMcpDelegation } from '../../generated/prisma/client.js'
+import type { PlacementKind, PlacementRef } from '../../domain/placement.js'
 import type { PrismaLike } from '../prisma.js'
 import type {
   EstablishWebchatMcpDelegationInput,
@@ -15,6 +17,10 @@ import type { WebchatMcpMetrics } from '../../observability/webchat-mcp.js'
 
 const toRecord = (row: WebchatMcpDelegation): WebchatMcpDelegationRecord => ({ ...row })
 const WEBCHAT_MCP_DELEGATION_REAP_BATCH_SIZE = 500
+
+/** All three placement columns, compared as one value — never a daemon id on its own. */
+const samePlacement = (left: PlacementRef, right: PlacementRef): boolean =>
+  left.placementKind === right.placementKind && left.daemonId === right.daemonId && left.setId === right.setId
 
 export class PgWebchatMcpDelegationRepo implements WebchatMcpDelegationRepo {
   constructor(
@@ -32,9 +38,9 @@ export class PgWebchatMcpDelegationRepo implements WebchatMcpDelegationRepo {
       // Global lock order is Agent → Conversation → Delegation. FOR SHARE
       // conflicts with placement UPDATE and agent DELETE while allowing two
       // independent conversations on this agent to establish concurrently.
-      const [agent] = await tx.$queryRaw<{ daemonId: string | null }[]>(
-        Prisma.sql`SELECT "daemonId" FROM "agent" WHERE "id" = ${input.agentId} FOR SHARE`
-      )
+      const [agent] = await tx.$queryRaw<
+        { placementKind: PlacementKind; daemonId: string | null; setId: string | null }[]
+      >(Prisma.sql`SELECT "placementKind", "daemonId", "setId" FROM "agent" WHERE "id" = ${input.agentId} FOR SHARE`)
       const [conversation] = await tx.$queryRaw<
         { id: string; userId: string; orgId: string; agentId: string }[]
       >(Prisma.sql`
@@ -49,7 +55,7 @@ export class PgWebchatMcpDelegationRepo implements WebchatMcpDelegationRepo {
         conversation.userId !== input.userId ||
         conversation.orgId !== input.orgId ||
         conversation.agentId !== input.agentId ||
-        agent.daemonId !== input.daemonId
+        !samePlacement(agent, input.expectedPlacement)
       ) {
         return { record: null, events: [] as const }
       }
@@ -66,10 +72,7 @@ export class PgWebchatMcpDelegationRepo implements WebchatMcpDelegationRepo {
         FOR UPDATE
       `)
       const sameAuthority =
-        latest?.userId === input.userId &&
-        latest.orgId === input.orgId &&
-        latest.agentId === input.agentId &&
-        latest.daemonId === input.daemonId
+        latest?.userId === input.userId && latest.orgId === input.orgId && latest.agentId === input.agentId
       if (latest && !latest.revokedAt && latest.expiresAt.getTime() > input.now.getTime() && sameAuthority) {
         if (input.expiresAt.getTime() < latest.expiresAt.getTime()) {
           const shortened = await tx.webchatMcpDelegation.updateMany({
@@ -93,10 +96,7 @@ export class PgWebchatMcpDelegationRepo implements WebchatMcpDelegationRepo {
       if (latest && !latest.revokedAt) {
         await tx.webchatMcpDelegation.updateMany({
           where: { id: latest.id, generation: latest.generation, revokedAt: null },
-          data: {
-            revokedAt: input.now,
-            revokedReason: expired ? 'expired' : sameAuthority ? 'rotated' : 'placement_changed'
-          }
+          data: { revokedAt: input.now, revokedReason: expired ? 'expired' : sameAuthority ? 'rotated' : 'rebound' }
         })
       }
 
@@ -112,7 +112,6 @@ export class PgWebchatMcpDelegationRepo implements WebchatMcpDelegationRepo {
           userId: input.userId,
           orgId: input.orgId,
           agentId: input.agentId,
-          daemonId: input.daemonId,
           createdAt: input.now,
           expiresAt: input.expiresAt
         }
@@ -141,8 +140,7 @@ export class PgWebchatMcpDelegationRepo implements WebchatMcpDelegationRepo {
       generation: input.generation,
       userId: input.userId,
       orgId: input.orgId,
-      agentId: input.agentId,
-      daemonId: input.daemonId
+      agentId: input.agentId
     }
     const changed = await this.db.webchatMcpDelegation.updateMany({
       where: { ...exactAuthority, revokedAt: null },

--- a/packages/control-plane/src/persistence/repositories/webchat-mcp-operation.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/webchat-mcp-operation.repo.ts
@@ -41,7 +41,6 @@ export class PgWebchatMcpOperationRepo implements WebchatMcpOperationRepo {
           JOIN "agent" AS delegated_agent
             ON delegated_agent."id" = authority."agentId"
            AND delegated_agent."orgId" = authority."orgId"
-           AND delegated_agent."daemonId" = authority."daemonId"
            AND (
              delegated_agent."visibility" = 'org'
              OR authority."userId" = ANY(delegated_agent."sharedWith")
@@ -192,7 +191,6 @@ export class PgWebchatMcpOperationRepo implements WebchatMcpOperationRepo {
           JOIN "agent" AS delegated_agent
             ON delegated_agent."id" = authority."agentId"
            AND delegated_agent."orgId" = authority."orgId"
-           AND delegated_agent."daemonId" = authority."daemonId"
            AND (
              delegated_agent."visibility" = 'org'
              OR authority."userId" = ANY(delegated_agent."sharedWith")

--- a/packages/control-plane/src/registry/webchatMcpAuthority.ts
+++ b/packages/control-plane/src/registry/webchatMcpAuthority.ts
@@ -1,6 +1,8 @@
 import { WEBCHAT_REMOTE_MCP_FEATURE } from '@agentconnect.md/protocol'
 import { AgentId, OrgId } from '../domain/ids.js'
 import { canView } from '../authorization/policy.js'
+import type { PlacementRef } from '../domain/placement.js'
+import type { PlacementResolver } from '../orchestrator/placementResolver.js'
 import type { AgentRepo, OrgRepo, PresetAgentStore, WebchatConversationRepo } from '../persistence/ports.js'
 
 export type WebchatMcpAuthorityDenialReason =
@@ -25,10 +27,13 @@ export interface LiveWebchatMcpAuthorityDeps {
   agents: Pick<AgentRepo, 'getUnscoped'>
   presets: Pick<PresetAgentStore, 'get'>
   daemons: { get(daemonId: string): LiveDaemon | undefined }
+  /** The only answer to "which daemons serve this agent" / "may this one act for it". */
+  placement: Pick<PlacementResolver, 'mayAct' | 'servingDaemons'>
 }
 
 export type LiveWebchatMcpAuthorityResult =
-  { ok: true; userId: string } | { ok: false; reason: WebchatMcpAuthorityDenialReason }
+  | { ok: true; userId: string; daemonId: string; placement: PlacementRef }
+  | { ok: false; reason: WebchatMcpAuthorityDenialReason }
 
 /** Shared live-fact policy used both when issuing and when consuming a remote-MCP grant. */
 export async function resolveLiveWebchatMcpAuthority(
@@ -38,7 +43,9 @@ export async function resolveLiveWebchatMcpAuthority(
     expectedUserId: string
     orgId: string
     agentId: string
-    daemonId: string
+    /** The daemon asking to act. Absent where the caller carries no daemon identity (a grant
+     *  redeemed over HTTP), and then any serving daemon satisfies the live check. */
+    actingDaemonId?: string
   }
 ): Promise<LiveWebchatMcpAuthorityResult> {
   const owner = await deps.conversations.findOwner(input.conversationId, AgentId(input.agentId))
@@ -73,16 +80,21 @@ export async function resolveLiveWebchatMcpAuthority(
 
   const preset = await deps.presets.get(OrgId(input.orgId), 'general')
   if (preset?.agentId !== input.agentId) return { ok: false, reason: 'preset_mismatch' }
-  if (!agent.daemonId || agent.daemonId !== input.daemonId) {
-    return { ok: false, reason: 'placement_mismatch' }
-  }
 
-  const daemon = deps.daemons.get(input.daemonId)
-  if (!daemon?.reachable || daemon.state !== 'READY') {
-    return { ok: false, reason: 'daemon_unavailable' }
-  }
-  if (!daemon.capabilities?.features?.includes(WEBCHAT_REMOTE_MCP_FEATURE)) {
-    return { ok: false, reason: 'daemon_feature_missing' }
-  }
-  return { ok: true, userId: owner }
+  // Placement is the resolver's answer, never the column: a pool agent names no machine, and the
+  // member serving it is whoever holds its duty at this moment.
+  const candidates = input.actingDaemonId
+    ? (await deps.placement.mayAct(agent, input.actingDaemonId))
+      ? [input.actingDaemonId]
+      : []
+    : await deps.placement.servingDaemons(agent)
+  if (candidates.length === 0) return { ok: false, reason: 'placement_mismatch' }
+
+  const live = candidates
+    .map((daemonId) => ({ daemonId, daemon: deps.daemons.get(daemonId) }))
+    .filter(({ daemon }) => daemon?.reachable && daemon.state === 'READY')
+  if (live.length === 0) return { ok: false, reason: 'daemon_unavailable' }
+  const featured = live.find(({ daemon }) => daemon!.capabilities?.features?.includes(WEBCHAT_REMOTE_MCP_FEATURE))
+  if (!featured) return { ok: false, reason: 'daemon_feature_missing' }
+  return { ok: true, userId: owner, daemonId: featured.daemonId, placement: agent }
 }

--- a/packages/control-plane/src/registry/webchatRemoteMcpService.ts
+++ b/packages/control-plane/src/registry/webchatRemoteMcpService.ts
@@ -4,7 +4,7 @@ import type {
   WebchatMcpGrantRevoke,
   WebchatRemoteMcpEntitlement
 } from '@agentconnect.md/protocol'
-import { AgentId, DaemonId, OrgId } from '../domain/ids.js'
+import { AgentId, OrgId } from '../domain/ids.js'
 import type { Clock } from '../domain/clock.js'
 import type { WebchatMcpAccessGrantRepo, WebchatMcpDelegationRepo } from '../persistence/ports.js'
 import type { WebchatMcpGrantTokenCodec } from './webchatMcpGrantToken.js'
@@ -45,7 +45,7 @@ export class WebchatRemoteMcpService {
       expectedUserId: input.verifiedUserId,
       orgId: input.orgId,
       agentId: input.agentId,
-      daemonId: input.daemonId
+      actingDaemonId: input.daemonId
     })
     if (!live.ok) return null
     const authority = await this.deps.authorities.establish({
@@ -53,7 +53,7 @@ export class WebchatRemoteMcpService {
       userId: live.userId,
       orgId: OrgId(input.orgId),
       agentId: AgentId(input.agentId),
-      daemonId: DaemonId(input.daemonId),
+      expectedPlacement: live.placement,
       now,
       expiresAt
     })
@@ -73,19 +73,20 @@ export class WebchatRemoteMcpService {
       !authority ||
       authority.generation !== input.authorityGeneration ||
       authority.conversationId !== input.conversationId ||
-      authority.daemonId !== input.authenticatedDaemonId ||
       (input.authenticatedOrgId && authority.orgId !== input.authenticatedOrgId) ||
       authority.revokedAt ||
       authority.expiresAt <= now
     ) {
       return null
     }
+    // The connected daemon must be one that serves the agent right now — the fence the row's
+    // daemon column used to stand in for, and the one it got wrong for a pool agent.
     const live = await resolveLiveWebchatMcpAuthority(this.deps, {
       conversationId: authority.conversationId,
       expectedUserId: authority.userId,
       orgId: authority.orgId,
       agentId: authority.agentId,
-      daemonId: authority.daemonId
+      actingDaemonId: input.authenticatedDaemonId
     })
     if (!live.ok) return null
 
@@ -115,7 +116,8 @@ export class WebchatRemoteMcpService {
 
   async accept(input: WebchatMcpGrantAccept & { authenticatedDaemonId: string; authenticatedOrgId?: string }) {
     const authority = await this.deps.authorities.getCurrent(input.authorityId)
-    if (input.authenticatedOrgId && authority?.orgId !== input.authenticatedOrgId) return null
+    if (!authority || (input.authenticatedOrgId && authority.orgId !== input.authenticatedOrgId)) return null
+    if (!(await this.mayAct(authority.agentId, input.authenticatedDaemonId))) return null
     return this.deps.grants.accept({ ...input, now: new Date(this.deps.clock.now()) })
   }
 
@@ -123,10 +125,17 @@ export class WebchatRemoteMcpService {
     input: WebchatMcpGrantRevoke & { authenticatedDaemonId: string; authenticatedOrgId?: string }
   ): Promise<boolean> {
     const authority = await this.deps.authorities.getCurrent(input.authorityId)
-    if (input.authenticatedOrgId && authority?.orgId !== input.authenticatedOrgId) return false
+    if (!authority || (input.authenticatedOrgId && authority.orgId !== input.authenticatedOrgId)) return false
+    if (!(await this.mayAct(authority.agentId, input.authenticatedDaemonId))) return false
     return this.deps.grants.revokeAuthority({
       ...input,
       now: new Date(this.deps.clock.now())
     })
+  }
+
+  /** The daemon fence the grant SQL no longer carries: authority is a live resolver question. */
+  private async mayAct(agentId: string, daemonId: string): Promise<boolean> {
+    const agent = await this.deps.agents.getUnscoped(AgentId(agentId))
+    return agent ? this.deps.placement.mayAct(agent, daemonId) : false
   }
 }

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -288,6 +288,19 @@ export function buildHttpApp(
   // no-ops — exactly the prod graph with no relay dialed in, unless a test wires one up.
   const relayReg = new RelayRegistry()
   const relayControl = new RelayControlSender(relayReg)
+  // Same graph as prod: every replicate site resolves its targets here, so the
+  // duty ledger is a real repo and a holder actually receives the pushes.
+  const placementResolver = new PlacementResolver({
+    duties: dutyGroupRepo,
+    liveMembers: async (setId) => {
+      const members = new Set(await memberSets.memberIdsOf(setId))
+      return connReg
+        .reachableDaemons()
+        .filter((d) => d.state === 'READY' && members.has(d.daemonId))
+        .map((d) => d.daemonId)
+    },
+    clock
+  })
   const remoteGrantAuth =
     depsOverrides?.remoteGrantAuth ??
     new RemoteGrantAuthenticator({
@@ -298,6 +311,7 @@ export function buildHttpApp(
       agents: agentRepo,
       presets: presetAgentRepo,
       daemons: liveness,
+      placement: placementResolver,
       grants: webchatMcpAccessGrantRepo,
       authorities: webchatMcpDelegationRepo,
       sessions: sessionRepo,
@@ -313,19 +327,6 @@ export function buildHttpApp(
     undefined,
     organizationEnvironmentResolver
   )
-  // Same graph as prod: every replicate site resolves its targets here, so the
-  // duty ledger is a real repo and a holder actually receives the pushes.
-  const placementResolver = new PlacementResolver({
-    duties: dutyGroupRepo,
-    liveMembers: async (setId) => {
-      const members = new Set(await memberSets.memberIdsOf(setId))
-      return connReg
-        .reachableDaemons()
-        .filter((d) => d.state === 'READY' && members.has(d.daemonId))
-        .map((d) => d.daemonId)
-    },
-    clock
-  })
   const agentDelivery = new AgentDelivery({ control: sender, specs: agentSpecs, placement: placementResolver })
 
   // LATE-BOUND exactly as `buildContainer` binds it (§9): the providers below are

--- a/packages/control-plane/test/integration/mcp.route.test.ts
+++ b/packages/control-plane/test/integration/mcp.route.test.ts
@@ -14,7 +14,8 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { seedAgent, seedDaemon, seedDutyGroup } from '../fixtures/seed.js'
+import { joinPool, poolSetId } from '../fakes/member-set.js'
 import { buildHttpApp, TEST_API_KEY_PEPPER, type HttpApp } from '../fakes/build-http.js'
 import { MCP_TOOLS } from '../../src/http/mcp/tools.js'
 import { McpRateLimiter } from '../../src/http/mcp/rate-limit.js'
@@ -169,12 +170,31 @@ describe('POST /api/v1/mcp — auth', () => {
 })
 
 describe('delegated webchat MCP operations', () => {
-  async function delegatedFixture(opts: { registerSession?: boolean } = {}) {
+  /** An org-less pool member holding the agent's duty — the shape whose `agent.daemonId` is null
+   *  and whose row the reaper deletes on every rollout. */
+  async function seedPoolMember(daemonId: string, agentId: string): Promise<void> {
+    await prisma.daemon.create({
+      data: { id: daemonId, orgId: null, maxAgents: 8, status: 'ready', sessionEpoch: 1n }
+    })
+    await joinPool(prisma, daemonId)
+    await seedDutyGroup(prisma, randomUUID(), daemonId, [agentId])
+  }
+
+  async function delegatedFixture(opts: { registerSession?: boolean; pool?: boolean } = {}) {
     const daemonId = randomUUID()
     const hostAgentId = randomUUID()
     const conversationId = randomUUID()
-    await seedDaemon(prisma, daemonId)
-    await seedAgent(prisma, hostAgentId, { daemonId })
+    if (opts.pool) {
+      await seedAgent(prisma, hostAgentId)
+      await prisma.agent.update({
+        where: { id: hostAgentId },
+        data: { placementKind: 'set', setId: await poolSetId(prisma), daemonId: null }
+      })
+      await seedPoolMember(daemonId, hostAgentId)
+    } else {
+      await seedDaemon(prisma, daemonId)
+      await seedAgent(prisma, hostAgentId, { daemonId })
+    }
     await prisma.webchatConversation.create({
       data: {
         id: conversationId,
@@ -191,7 +211,6 @@ describe('delegated webchat MCP operations', () => {
         userId: DEFAULT_OWNER_ID,
         orgId: DEFAULT_ORG_ID,
         agentId: hostAgentId,
-        daemonId,
         expiresAt: new Date(Date.now() + 60_000)
       }
     })
@@ -239,9 +258,11 @@ describe('delegated webchat MCP operations', () => {
       })
     }
 
+    // Mutable so a test can retire the holding member and connect its replacement.
+    const liveDaemons = new Set<string>([daemonId])
     const app = buildHttpApp(prisma, undefined, {
       get: (id) =>
-        id === daemonId
+        liveDaemons.has(id)
           ? {
               reachable: true,
               state: 'READY',
@@ -265,7 +286,18 @@ describe('delegated webchat MCP operations', () => {
     const remoteRpc = (id: number, name: string, args: Record<string, unknown>) =>
       remoteMethod({ id, method: 'tools/call', params: { name, arguments: args } })
     const decisionPath = `/api/v1/orgs/${DEFAULT_ORG_ID}/agents/${hostAgentId}/webchat/${conversationId}/mcp-operations`
-    return { app, daemonId, hostAgentId, conversationId, remoteRpc, remoteMethod, decisionPath, credential }
+    return {
+      app,
+      daemonId,
+      hostAgentId,
+      conversationId,
+      liveDaemons,
+      seedPoolMember,
+      remoteRpc,
+      remoteMethod,
+      decisionPath,
+      credential
+    }
   }
 
   /** Submit a delegated write and return its pending operationId. */
@@ -344,6 +376,37 @@ describe('delegated webchat MCP operations', () => {
     const call = await remoteRpc(3, 'listAgents', {})
     expect(call.statusCode).toBe(401)
     expect(call.headers['www-authenticate']).toBeUndefined()
+  })
+
+  // A pool agent names no machine of its own: `agent.daemonId` is null and the member serving it
+  // is whoever holds its duty. Reading the column here refused every entitlement (#1028).
+  it('entitles a pool agent through its duty holder rather than a placement column', async () => {
+    const { hostAgentId, remoteRpc } = await delegatedFixture({ pool: true })
+
+    const read = await remoteRpc(1, 'listAgents', {})
+    expect(read.statusCode).toBe(200)
+    expect(toolText(mcpMessage(read).result as unknown as ToolCallResult)).toContain(hostAgentId)
+  })
+
+  it('keeps a pool agent delegation across a rollout that retires and replaces the holder', async () => {
+    const fixture = await delegatedFixture({ pool: true })
+    const { daemonId, hostAgentId, liveDaemons, remoteRpc } = fixture
+    expect((await remoteRpc(1, 'listAgents', {})).statusCode).toBe(200)
+
+    // The reaper deletes the retired member's row. The delegation used to cascade away with it.
+    await prisma.dutyGroup.deleteMany({ where: { holder: daemonId } })
+    await prisma.daemon.delete({ where: { id: daemonId } })
+    liveDaemons.delete(daemonId)
+    expect(await prisma.webchatMcpDelegation.count({ where: { agentId: hostAgentId, revokedAt: null } })).toBe(1)
+    // Nothing serves the agent for the handoff window, so the grant is refused rather than honored.
+    expect((await remoteRpc(2, 'listAgents', {})).statusCode).toBe(401)
+
+    const replacement = randomUUID()
+    await fixture.seedPoolMember(replacement, hostAgentId)
+    liveDaemons.add(replacement)
+
+    // Same authority, same grant token: the new holder redeems it without a fresh browser dial.
+    expect((await remoteRpc(3, 'listAgents', {})).statusCode).toBe(200)
   })
 
   it('keeps denying tools/call while the current session is not private', async () => {

--- a/packages/control-plane/test/integration/relay-gateway.test.ts
+++ b/packages/control-plane/test/integration/relay-gateway.test.ts
@@ -25,7 +25,7 @@ import {
   type RcVerifyResult
 } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
-import { seedAgent, seedSessionMeta } from '../fixtures/seed.js'
+import { seedAgent, seedDutyGroup, seedSessionMeta } from '../fixtures/seed.js'
 import { buildApp, type App } from '../../src/app.js'
 import { AppConfigSchema, type AppConfig } from '../../src/config/env.js'
 import { systemClock } from '../../src/domain/clock.js'
@@ -166,6 +166,19 @@ async function connectDaemonReady(base: string, features: string[] = []): Promis
   })
   await nextFrame(ws, 'register/ok')
   return ws
+}
+
+/** Place agents on a MEMBER SET instead of a machine — the shape whose `agent.daemonId` is null,
+ *  exactly like a cloud-pool agent — and hand their duty to one member of that set. */
+async function placeOnSet(agentIds: string[], holder: string): Promise<void> {
+  const setId = randomUUID()
+  await prisma.memberSet.create({ data: { id: setId, orgId: DEFAULT_ORG_ID, name: 'gw-set' } })
+  await prisma.memberSetMember.create({ data: { setId, daemonId: holder } })
+  await prisma.agent.updateMany({
+    where: { id: { in: agentIds } },
+    data: { placementKind: 'set', setId, daemonId: null }
+  })
+  await seedDutyGroup(prisma, randomUUID(), holder, agentIds)
 }
 
 /** POST the webchat-token mint route as the devAuth owner (org-scoped). */
@@ -556,6 +569,54 @@ describe('relay control gateway — rc/* handshake over agentconnect.rc.v1', () 
     expect(result.remoteMcp).toBeUndefined()
     ws.close()
     daemonWs.close()
+  })
+
+  // A pool agent's row names no machine, so the pre-#1028 gate read a null `daemonId`, found no
+  // daemon, and refused every multi-agent conversation with 409.
+  it('POST …/webchat/conversations/token admits pool agents whose duty holder advertises the feature', async () => {
+    const { app, base } = await start({ PUBLIC_RELAY_URL: RELAY_URL })
+    const memberWs = await connectDaemonReady(base, [WEBCHAT_MULTI_AGENT_FEATURE])
+    await seedAgent(prisma, AGENT)
+    await seedAgent(prisma, AGENT_B, { name: 'agent-b' })
+    await placeOnSet([AGENT, AGENT_B], DAEMON)
+
+    const res = await app.http.inject({
+      method: 'POST',
+      url: `/api/v1/orgs/${DEFAULT_ORG_ID}/webchat/conversations/token`,
+      payload: { agentIds: [AGENT, AGENT_B] }
+    })
+    expect(res.statusCode).toBe(200)
+    const minted = res.json() as { token: string; conversationId: string }
+
+    // rc/verify resolves the same member for both participants.
+    const { ws, result } = await verifyWebchat(base, minted.token, 'pod-pool-multi')
+    expect(result.participants).toEqual([
+      { agentId: AGENT, daemonId: DAEMON, primary: true },
+      { agentId: AGENT_B, daemonId: DAEMON }
+    ])
+    ws.close()
+    memberWs.close()
+  })
+
+  it('POST …/webchat/conversations/:id/agents joins a pool agent mid-conversation', async () => {
+    const { app, base } = await start({ PUBLIC_RELAY_URL: RELAY_URL })
+    const memberWs = await connectDaemonReady(base, [WEBCHAT_MULTI_AGENT_FEATURE])
+    await seedAgent(prisma, AGENT)
+    await seedAgent(prisma, AGENT_B, { name: 'agent-b' })
+    await placeOnSet([AGENT, AGENT_B], DAEMON)
+    const fresh = (await mintWebchatToken(app, AGENT).then((r) => r.json())) as { conversationId: string }
+
+    const join = await app.http.inject({
+      method: 'POST',
+      url: `/api/v1/orgs/${DEFAULT_ORG_ID}/webchat/conversations/${fresh.conversationId}/agents`,
+      payload: { agentId: AGENT_B }
+    })
+    expect(join.statusCode).toBe(200)
+    expect((join.json() as { participants: unknown }).participants).toEqual([
+      { agentId: AGENT, primary: true },
+      { agentId: AGENT_B }
+    ])
+    memberWs.close()
   })
 
   it('POST …/webchat/conversations/token → 409 when a selected daemon lacks multi-agent support', async () => {

--- a/packages/control-plane/test/repo/agent-placement-delegation.test.ts
+++ b/packages/control-plane/test/repo/agent-placement-delegation.test.ts
@@ -54,7 +54,7 @@ async function fixtures() {
     userId: DEFAULT_OWNER_ID,
     orgId: OrgId(DEFAULT_ORG_ID),
     agentId: AGENT,
-    daemonId: DAEMON,
+    expectedPlacement: { placementKind: 'daemon' as const, daemonId: DAEMON, setId: null },
     now: NOW,
     expiresAt: new Date(NOW.getTime() + 60_000)
   }
@@ -294,10 +294,6 @@ describe('agent placement and webchat MCP delegation serialization (real Postgre
     ).rejects.toThrow('forced placement rollback')
 
     expect((await prisma.agent.findUnique({ where: { id: AGENT } }))?.daemonId).toBe(DAEMON)
-    expect(await delegations.get(delegation.id)).toMatchObject({
-      daemonId: DAEMON,
-      revokedAt: null,
-      revokedReason: null
-    })
+    expect(await delegations.get(delegation.id)).toMatchObject({ revokedAt: null, revokedReason: null })
   })
 })

--- a/packages/control-plane/test/repo/webchat-mcp-delegation.repo.test.ts
+++ b/packages/control-plane/test/repo/webchat-mcp-delegation.repo.test.ts
@@ -4,12 +4,14 @@ import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { PgWebchatMcpDelegationRepo } from '../../src/persistence/repositories/webchat-mcp-delegation.repo.js'
 import { PgWebchatMcpOperationRepo } from '../../src/persistence/repositories/webchat-mcp-operation.repo.js'
-import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
+import { AgentId, OrgId } from '../../src/domain/ids.js'
+import { revokeActiveWebchatMcpDelegations } from '../../src/persistence/repositories/agent-placement.js'
 import { WebchatMcpOperationReaper } from '../../src/orchestrator/webchatMcpOperationReaper.js'
 import { FakeClock } from '../fakes/fake-clock.js'
 
 const CONVERSATION = 'c1111111-1111-4111-8111-111111111111'
 const AGENT = 'a1111111-1111-4111-8111-111111111111'
+const OTHER_AGENT = 'a2222222-2222-4222-8222-222222222222'
 const DAEMON = 'd1111111-1111-4111-8111-111111111111'
 const OTHER_DAEMON = 'd2222222-2222-4222-8222-222222222222'
 const NOW = new Date('2026-07-30T00:00:00.000Z')
@@ -70,13 +72,16 @@ async function fixtures(): Promise<void> {
   })
 }
 
+/** The placement a caller resolved its live authority against — never a bare daemon id. */
+const machine = (daemonId: string) => ({ placementKind: 'daemon' as const, daemonId, setId: null })
+
 function establishInput(daemonId = DAEMON, expiresAt = at(60_000)) {
   return {
     conversationId: CONVERSATION,
     userId: DEFAULT_OWNER_ID,
     orgId: OrgId(DEFAULT_ORG_ID),
     agentId: AgentId(AGENT),
-    daemonId: DaemonId(daemonId),
+    expectedPlacement: machine(daemonId),
     now: NOW,
     expiresAt
   }
@@ -90,7 +95,6 @@ function revokeInput(delegation: { id: string; generation: number }) {
     userId: DEFAULT_OWNER_ID,
     orgId: OrgId(DEFAULT_ORG_ID),
     agentId: AgentId(AGENT),
-    daemonId: DaemonId(DAEMON),
     revokedAt: at(5_000),
     reason: 'session_closed'
   }
@@ -106,7 +110,7 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
 
     expect(left).not.toBeNull()
     expect(right).not.toBeNull()
-    expect(left).toMatchObject({ generation: 1, daemonId: DAEMON, revokedAt: null })
+    expect(left).toMatchObject({ generation: 1, revokedAt: null })
     expect(right).toMatchObject({ id: left?.id, generation: 1 })
     expect(await prisma.webchatMcpDelegation.count({ where: { conversationId: CONVERSATION } })).toBe(1)
     expect(
@@ -288,24 +292,25 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
     expect(indexes.map(({ indexname }) => indexname)).toContain('webchat_mcp_delegation_agentId_revokedAt_idx')
   })
 
-  it('rotates placement by revoking the active row and incrementing the durable generation', async () => {
+  it('rotates after a placement move revokes the active row, keeping one durable generation ladder', async () => {
     await fixtures()
     const repo = new PgWebchatMcpDelegationRepo(prisma)
     const first = await repo.establish(establishInput())
 
+    // Exactly what a placement write does in its own transaction (agent-placement.ts).
     await prisma.agent.update({ where: { id: AGENT }, data: { daemonId: OTHER_DAEMON } })
+    await prisma.$transaction((tx) => revokeActiveWebchatMcpDelegations(tx, AGENT, NOW))
     const moved = await repo.establish(establishInput(OTHER_DAEMON))
 
-    expect(moved).toMatchObject({ generation: 2, daemonId: OTHER_DAEMON, revokedAt: null })
+    expect(moved).toMatchObject({ generation: 2, revokedAt: null })
     expect(await repo.get(first!.id)).toMatchObject({
       generation: 1,
-      daemonId: DAEMON,
       revokedAt: NOW,
-      revokedReason: 'placement_changed'
+      revokedReason: 'agent_placement_changed'
     })
   })
 
-  it('rejects a caller-supplied daemon that is not the durable agent placement without mutating authority', async () => {
+  it('rejects an expected placement that is no longer the agent row without mutating authority', async () => {
     await fixtures()
     const repo = new PgWebchatMcpDelegationRepo(prisma)
     const first = (await repo.establish(establishInput()))!
@@ -313,7 +318,6 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
     expect(await repo.establish(establishInput(OTHER_DAEMON))).toBeNull()
     expect(await repo.get(first.id)).toMatchObject({
       generation: 1,
-      daemonId: DAEMON,
       revokedAt: null,
       revokedReason: null
     })
@@ -335,7 +339,6 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
     expect(await repo.establish(establishInput())).toBeNull()
     expect(await repo.get(first.id)).toMatchObject({
       generation: 1,
-      daemonId: DAEMON,
       revokedAt: null,
       revokedReason: null
     })
@@ -358,7 +361,7 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
     const first = await repo.establish(establishInput(DAEMON, at(1_000)))
 
     const rotated = await repo.establish({ ...establishInput(DAEMON, at(120_000)), now: at(1_000) })
-    expect(rotated).toMatchObject({ generation: 2, daemonId: DAEMON })
+    expect(rotated).toMatchObject({ generation: 2 })
     expect(await repo.get(first!.id)).toMatchObject({
       revokedAt: at(1_000),
       revokedReason: 'expired'
@@ -395,13 +398,12 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
       userId: DEFAULT_OWNER_ID,
       orgId: OrgId(DEFAULT_ORG_ID),
       agentId: AgentId(AGENT),
-      daemonId: DaemonId(DAEMON),
       revokedAt: at(500),
       reason: 'session_closed'
     }
 
     expect(await repo.revoke({ ...revoke, generation: delegation.generation + 1 })).toBe(false)
-    expect(await repo.revoke({ ...revoke, daemonId: DaemonId(OTHER_DAEMON) })).toBe(false)
+    expect(await repo.revoke({ ...revoke, agentId: AgentId(OTHER_AGENT) })).toBe(false)
     expect((await repo.get(delegation.id))?.revokedAt).toBeNull()
     expect(await repo.revoke(revoke)).toBe(true)
     expect(await repo.revoke(revoke)).toBe(true)
@@ -426,7 +428,6 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
           userId: DEFAULT_OWNER_ID,
           orgId: DEFAULT_ORG_ID,
           agentId: AGENT,
-          daemonId: DAEMON,
           expiresAt: at(1_000),
           revokedAt: at(500),
           revokedReason
@@ -447,7 +448,6 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
       userId: DEFAULT_OWNER_ID,
       orgId: DEFAULT_ORG_ID,
       agentId: AGENT,
-      daemonId: DAEMON,
       createdAt: at(index),
       expiresAt: at(1_000)
     }))
@@ -495,7 +495,6 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
           userId: DEFAULT_OWNER_ID,
           orgId: DEFAULT_ORG_ID,
           agentId: AGENT,
-          daemonId: DAEMON,
           expiresAt: at(1_000)
         },
         {
@@ -505,7 +504,6 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
           userId: DEFAULT_OWNER_ID,
           orgId: DEFAULT_ORG_ID,
           agentId: AGENT,
-          daemonId: DAEMON,
           expiresAt: at(1_000),
           revokedAt: at(500),
           revokedReason: 'session_closed'
@@ -517,7 +515,6 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
           userId: DEFAULT_OWNER_ID,
           orgId: DEFAULT_ORG_ID,
           agentId: AGENT,
-          daemonId: DAEMON,
           expiresAt: at(1_000),
           revokedAt: at(500),
           revokedReason: 'placement_changed'
@@ -529,7 +526,6 @@ describe('PgWebchatMcpDelegationRepo (real Postgres)', () => {
           userId: DEFAULT_OWNER_ID,
           orgId: DEFAULT_ORG_ID,
           agentId: AGENT,
-          daemonId: DAEMON,
           expiresAt: at(1_000),
           revokedAt: at(500),
           revokedReason: 'expired'


### PR DESCRIPTION
## Summary

Fixes #1028. Multi-agent webchat and the delegated webchat MCP entitlement both authorized on
`agent.daemonId`, a column that is `null` for a set-placed (pool) agent. Every such decision now
goes through `PlacementResolver`, and `WebchatMcpDelegation` stops being keyed on a daemon row the
pool reaper deletes.

## Failure scenario

- **Multi-agent webchat.** `webchat-token.ts` read `agent.daemonId ? daemonConns.get(...) : undefined`
  at both roster growth points. For a pool agent the lookup was always `undefined`, so conversation
  creation and mid-conversation join returned `409 … is not on a daemon that supports multi-agent
  conversations`, even though every member advertises the capability.
- **Delegated webchat MCP.** `webchatMcpAuthority.ts` compared `agent.daemonId !== input.daemonId`
  and `webchat-mcp-delegation.repo.ts` repeated the comparison under the agent row lock, so every
  entitlement for a pool agent was denied as `placement_mismatch` — while the daemon id reaching the
  authority was already resolver-derived. `webchat-mcp-operations.ts` also 404'd on a null column and
  then asserted it non-null.
- **Delegation lifetime.** `WebchatMcpDelegation.daemonId` was a `Daemon` FK with `onDelete: Cascade`,
  so a rollout that retires the holding member deleted every live delegation outright, including
  those of machine-placed agents on that daemon.

## Fix

- Every "which daemon serves this agent / may this daemon act for it" read is now
  `deps.placementResolver`. The multi-agent capability gate resolves each roster agent through
  `dispatchDaemon` — the same answer `rc/verify` reaches, so mint and verification cannot disagree —
  and then asks that daemon for the capability. No caller branches on the placement kind.
- `resolveLiveWebchatMcpAuthority` takes an optional `actingDaemonId`: present (a daemon-authenticated
  grant issue / accept / revoke, or the browser dial) it fences on `mayAct`; absent (a grant redeemed
  over HTTP, which carries no daemon identity) it accepts any daemon in `servingDaemons`. It returns
  the live daemon it accepted, so the invocation context and the operations route no longer read a
  column.
- `WebchatMcpDelegation` is keyed on the agent: the `daemonId` column and its cascading FK are dropped
  (`20260825000000_webchat_mcp_delegation_agent_keyed`), and the daemon predicates in the access-grant
  and operation SQL go with it. A duty handoff no longer invalidates a live delegation; the member
  holding the agent at redemption time is the one that may act.
- The transactional fence establishment used to get from the daemon comparison is preserved as
  `expectedPlacement`: the caller passes the placement it resolved its live authority against and the
  repository re-compares all three placement columns under the agent row lock. A real placement move
  still revokes the delegation where it lands (`agent-placement.ts`, unchanged), which is what makes
  the next establishment rotate the generation.
- Grant `issue` / `accept` / `revoke` now apply `mayAct` in the service, replacing the daemon column
  predicate the SQL used to carry.

One consequence worth naming: deleting a daemon no longer cascades its agents' delegations away. The
rows linger un-revoked until the reaper collects them, but they are inert — the agent is unplaced, so
the live check answers `placement_mismatch` on every use. Revoking them eagerly is what
`settleCascadedUnplacement` already does on the pool-retirement path; wiring it into the console
delete is a separate change.

## Test plan

`packages/control-plane`, all against real Postgres:

- `relay-gateway.test.ts` — a two-agent roster placed on a member set (so `agent.daemonId` is null)
  with one duty holder mints a multi-agent token and verifies with that holder as both participants'
  daemon; a set-placed agent joins mid-conversation.
- `mcp.route.test.ts` — `delegatedFixture({ pool: true })` seeds an org-less pool member, enrols it in
  the install-wide set, places the agent on that set and hands it the duty: the delegated read
  succeeds. A second test retires the holder (row deleted, as the reaper does), asserts the delegation
  row survives and the grant is refused while nothing serves the agent, then brings up a replacement
  member and redeems the *same* grant token successfully.
- `webchat-mcp-delegation.repo.test.ts` / `agent-placement-delegation.test.ts` — the establishment
  fence is restated on `expectedPlacement`; the placement-move, unplacement, rotation, revocation,
  lock-ordering and reaper invariants are unchanged and still pass.
- Machine-placed behaviour is unchanged: the pre-existing capability, delegation and continuation
  tests pass untouched.

Ran: `typecheck`, `test:unit` (1672), the full `test:int` project, `lint`, `format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
