### PR TITLE
fix(daemon): key the runtime model catalog cache by its owning member

### DIFF
--- a/docs/designs/runtime-model-catalog.md
+++ b/docs/designs/runtime-model-catalog.md
@@ -328,25 +328,39 @@ accessors, and tests:
 ```sql
 -- Runtime-level metadata: fingerprint, source, and model-independent capabilities
 CREATE TABLE IF NOT EXISTS runtime_catalog_meta (
-  runtimeId       TEXT PRIMARY KEY,
+  ownerId         TEXT NOT NULL DEFAULT '',   -- Owning member; '' is the single-daemon store
+  runtimeId       TEXT NOT NULL,
   fingerprint     TEXT NOT NULL,
   source          TEXT NOT NULL,              -- 'native' (driver) | 'acp' (enumeration/phase 1)
   defaultModel    TEXT,                       -- Resolved concrete model ID, or NULL
   permissionModes TEXT,                       -- JSON [{value, name?, description?}]
   complete        INTEGER NOT NULL DEFAULT 0, -- 1 only after full discovery succeeds
-  observedAt      INTEGER NOT NULL
+  observedAt      INTEGER NOT NULL,
+  PRIMARY KEY (ownerId, runtimeId)
 );
 
 -- Model-level capabilities, one row per model
 CREATE TABLE IF NOT EXISTS runtime_model_catalog (
+  ownerId     TEXT NOT NULL DEFAULT '',
   runtimeId   TEXT NOT NULL,
   modelId     TEXT NOT NULL,
   fingerprint TEXT NOT NULL,
   capsJson    TEXT NOT NULL,               -- {name?, efforts?, defaultEffort?, fastMode?}
   observedAt  INTEGER NOT NULL,
-  PRIMARY KEY (runtimeId, modelId)
+  PRIMARY KEY (ownerId, runtimeId, modelId)
 );
 ```
+
+**`ownerId` leads both keys because this cache describes an image, not an
+install.** A pool member's store is one Postgres schema shared by every member,
+and a rolling update runs two image generations at once with two different
+fingerprints. Unkeyed, each member reads the other's row as "the fingerprint
+changed", re-runs discovery, resets `complete`, and prunes the other
+generation's model rows — probe sessions ping-ponging for the length of the
+rollout, a console model list that flaps, and a member that boots (§4 rule 1)
+advertising models its own image cannot run. Every read and write is scoped to
+the store's own member, so the single-daemon SQLite store — which owns the one
+`''` partition forever — behaves exactly as before.
 
 Lifecycle rules:
 
@@ -399,7 +413,11 @@ Lifecycle rules:
    current catalog resolved from registry/user/curated sources. Do not advertise
    or report them, but retain the rows because resolution may have failed
    temporarily. At startup, delete rows with `observedAt` older than 30 days to
-   prevent unbounded growth.
+   prevent unbounded growth. On a shared store, another member's rows go at a
+   shorter window (7 days): an `ownerId` dies with the process that minted it, so
+   a rollout leaves caches nobody can read again. The window stays conservative
+   because a live member that has not re-probed inside it pays one re-discovery
+   for the reclaim.
 
 ## 5. Protocol and CP Persistence
 

--- a/docs/designs/runtime-model-catalog.md
+++ b/docs/designs/runtime-model-catalog.md
@@ -412,12 +412,21 @@ Lifecycle rules:
 6. **Garbage collection**: during hydration, ignore runtime IDs absent from the
    current catalog resolved from registry/user/curated sources. Do not advertise
    or report them, but retain the rows because resolution may have failed
-   temporarily. At startup, delete rows with `observedAt` older than 30 days to
-   prevent unbounded growth. On a shared store, another member's rows go at a
-   shorter window (7 days): an `ownerId` dies with the process that minted it, so
-   a rollout leaves caches nobody can read again. The window stays conservative
-   because a live member that has not re-probed inside it pays one re-discovery
-   for the reclaim.
+   temporarily. At startup, delete catalogs unseen for 30 days to prevent
+   unbounded growth. On a shared store, another member's go at a shorter window
+   (7 days): an `ownerId` dies with the process that minted it, so a rollout
+   leaves caches nobody can read again. The window stays conservative because a
+   live member that has not re-probed inside it pays one re-discovery for the
+   reclaim.
+
+   **Staleness is a property of one whole `(ownerId, runtimeId)` catalog — its
+   meta row and its model rows together — never of a single row.** A phase-1
+   refresh (rule 1 of §3.3) re-stamps the meta row and the seed model only, so
+   the models a full discovery found keep their older `observedAt`. A row-by-row
+   sweep would delete exactly those while leaving `complete` and `modelsHash`
+   standing, and the discovery gate — same fingerprint, complete, matching model
+   hash — would never reopen: the matrix stays permanently short of those models.
+   A catalog is therefore kept whole or dropped whole.
 
 ## 5. Protocol and CP Persistence
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -22505,7 +22505,7 @@ export class Daemon {
    *  never boot advertising models a peer's image runs and its own does not. */
   private hydrateRuntimeCatalogCache(): void {
     try {
-      // A member's own last-good rows keep the 30-day window; a departed member's are
+      // A member's own last-good catalogs keep the 30-day window; a departed member's are
       // reclaimed after 7 days, long enough that a quiet live peer keeps its cache.
       this.store.gcRuntimeCatalog(this.clock.now() - 30 * 24 * 3600_000, this.clock.now() - 7 * 24 * 3600_000)
       for (const meta of this.store.listRuntimeCatalogMetas()) {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -22501,10 +22501,13 @@ export class Daemon {
    *  that would wipe the CP's learned state until the sweep completes. Rows for
    *  runtimes not in the installed catalog are ignored (kept on disk — the
    *  runtime may only be temporarily unresolved); rows older than 30 days are
-   *  garbage-collected. */
+   *  garbage-collected. The store reads only this member's rows, so a member can
+   *  never boot advertising models a peer's image runs and its own does not. */
   private hydrateRuntimeCatalogCache(): void {
     try {
-      this.store.gcRuntimeCatalog(this.clock.now() - 30 * 24 * 3600_000)
+      // A member's own last-good rows keep the 30-day window; a departed member's are
+      // reclaimed after 7 days, long enough that a quiet live peer keeps its cache.
+      this.store.gcRuntimeCatalog(this.clock.now() - 30 * 24 * 3600_000, this.clock.now() - 7 * 24 * 3600_000)
       for (const meta of this.store.listRuntimeCatalogMetas()) {
         if (!this.runtimeCatalog.entries[meta.runtimeId]) continue
         this.rebuildRuntimeCatalog(meta.runtimeId)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -622,7 +622,7 @@ function restrictPath(path: string, mode: number): void {
  * change that edits a `CREATE TABLE` below, and append the matching step to
  * {@link SCHEMA_MIGRATIONS}.
  */
-const SCHEMA_VERSION = 7
+const SCHEMA_VERSION = 8
 
 /**
  * Ordered in-place upgrades for a store created by an EARLIER daemon.
@@ -691,13 +691,22 @@ const SCHEMA_MIGRATIONS: ((db: StoreDatabase) => void)[] = [
       DROP TABLE session_gates;
       ALTER TABLE session_gates_keyed RENAME TO session_gates;
     `),
-  (db) => db.exec('ALTER TABLE cron_runs ADD COLUMN definition TEXT')
+  (db) => db.exec('ALTER TABLE cron_runs ADD COLUMN definition TEXT'),
+  // The catalog cache is re-keyed on its owning member (#1039): pre-owner rows name none, so
+  // they are dropped rather than misattributed and the CREATE block rebuilds both tables.
+  (db) =>
+    db.exec(`
+      DROP TABLE IF EXISTS runtime_catalog_meta;
+      DROP TABLE IF EXISTS runtime_model_catalog;
+    `)
 ]
 
 export class LocalStore {
   private db: StoreDatabase
   private readonly shared: boolean
   private readonly ownerId?: string
+  /** Partition key for per-member cache rows; a single-daemon store owns one partition forever. */
+  private readonly cacheOwnerId: string
   private transcriptRevision = 0
   private transcriptMutationListener?: (mutation: TranscriptMutation) => void
 
@@ -728,6 +737,7 @@ export class LocalStore {
       this.ownerId = source.ownerId
       if (this.shared && !this.ownerId) throw new Error('shared LocalStore requires an ownerId')
     }
+    this.cacheOwnerId = this.ownerId ?? ''
     // Decided BEFORE the CREATE block, which is what makes an empty file
     // indistinguishable from an old one a moment later.
     const freshDatabase =
@@ -1080,8 +1090,11 @@ export class LocalStore {
       -- Failures never clear rows; models are pruned only after a COMPLETE successful
       -- discovery. complete stays 0 on phase-1 probe writes so the discovery gate
       -- can tell "never fully discovered" from "last-good on file".
+      -- ownerId leads both keys (#1039): the cache describes an image, so on a store every
+      -- pool member shares, two rollout generations would re-probe and prune each other.
       CREATE TABLE IF NOT EXISTS runtime_catalog_meta (
-        runtimeId TEXT PRIMARY KEY,
+        ownerId TEXT NOT NULL DEFAULT '', -- the owning member; '' is the single-daemon store
+        runtimeId TEXT NOT NULL,
         fingerprint TEXT NOT NULL,
         source TEXT NOT NULL,             -- 'native' | 'acp'
         defaultModel TEXT,
@@ -1089,15 +1102,17 @@ export class LocalStore {
         defaultPermissionMode TEXT,       -- mode select currentValue on a fresh probe session
         complete INTEGER NOT NULL DEFAULT 0,
         modelsHash TEXT,                  -- hash of probed models[] at last complete discovery
-        observedAt INTEGER NOT NULL
+        observedAt INTEGER NOT NULL,
+        PRIMARY KEY (ownerId, runtimeId)
       );
       CREATE TABLE IF NOT EXISTS runtime_model_catalog (
+        ownerId TEXT NOT NULL DEFAULT '',
         runtimeId TEXT NOT NULL,
         modelId TEXT NOT NULL,
         fingerprint TEXT NOT NULL,
         capsJson TEXT NOT NULL,           -- JSON {name?, efforts?: [{value,name?,description?}], defaultEffort?, fastMode?}
         observedAt INTEGER NOT NULL,
-        PRIMARY KEY (runtimeId, modelId)
+        PRIMARY KEY (ownerId, runtimeId, modelId)
       );
       -- Memory dream jobs (docs/designs/memory-dreaming.md §4). METADATA ONLY —
       -- staged store bodies live on disk under <agent-root>/memory-dreams/ and
@@ -4520,21 +4535,25 @@ export class LocalStore {
     this.db.exec('BEGIN')
     try {
       const existing = this.db
-        .prepare('SELECT fingerprint, complete, modelsHash FROM runtime_catalog_meta WHERE runtimeId = ?')
-        .get(meta.runtimeId) as { fingerprint: string; complete: number; modelsHash: string | null } | undefined
+        .prepare(
+          'SELECT fingerprint, complete, modelsHash FROM runtime_catalog_meta WHERE ownerId = ? AND runtimeId = ?'
+        )
+        .get(this.cacheOwnerId, meta.runtimeId) as
+        { fingerprint: string; complete: number; modelsHash: string | null } | undefined
       const sameGeneration = existing && existing.fingerprint === meta.fingerprint ? existing : undefined
       this.db
         .prepare(
           `INSERT INTO runtime_catalog_meta
-             (runtimeId, fingerprint, source, defaultModel, permissionModes, defaultPermissionMode, complete, modelsHash, observedAt)
-           VALUES (@runtimeId, @fingerprint, @source, @defaultModel, @permissionModes, @defaultPermissionMode, @complete, @modelsHash, @observedAt)
-           ON CONFLICT(runtimeId) DO UPDATE SET
+             (ownerId, runtimeId, fingerprint, source, defaultModel, permissionModes, defaultPermissionMode, complete, modelsHash, observedAt)
+           VALUES (@ownerId, @runtimeId, @fingerprint, @source, @defaultModel, @permissionModes, @defaultPermissionMode, @complete, @modelsHash, @observedAt)
+           ON CONFLICT(ownerId, runtimeId) DO UPDATE SET
              fingerprint=excluded.fingerprint, source=excluded.source, defaultModel=excluded.defaultModel,
              permissionModes=excluded.permissionModes, defaultPermissionMode=excluded.defaultPermissionMode,
              complete=excluded.complete,
              modelsHash=excluded.modelsHash, observedAt=excluded.observedAt`
         )
         .run({
+          ownerId: this.cacheOwnerId,
           runtimeId: meta.runtimeId,
           fingerprint: meta.fingerprint,
           source: meta.source,
@@ -4560,9 +4579,9 @@ export class LocalStore {
       .prepare(
         `UPDATE runtime_catalog_meta
          SET complete = 1, modelsHash = @modelsHash, observedAt = @observedAt
-         WHERE runtimeId = @runtimeId AND fingerprint = @fingerprint`
+         WHERE ownerId = @ownerId AND runtimeId = @runtimeId AND fingerprint = @fingerprint`
       )
-      .run({ runtimeId, fingerprint, modelsHash, observedAt })
+      .run({ ownerId: this.cacheOwnerId, runtimeId, fingerprint, modelsHash, observedAt })
   }
 
   /** Upsert one model's capability row (latest-wins). Written incrementally as each
@@ -4570,12 +4589,13 @@ export class LocalStore {
   upsertRuntimeModelCap(rec: RuntimeModelCapRecord): void {
     this.db
       .prepare(
-        `INSERT INTO runtime_model_catalog (runtimeId, modelId, fingerprint, capsJson, observedAt)
-         VALUES (@runtimeId, @modelId, @fingerprint, @capsJson, @observedAt)
-         ON CONFLICT(runtimeId, modelId) DO UPDATE SET
+        `INSERT INTO runtime_model_catalog (ownerId, runtimeId, modelId, fingerprint, capsJson, observedAt)
+         VALUES (@ownerId, @runtimeId, @modelId, @fingerprint, @capsJson, @observedAt)
+         ON CONFLICT(ownerId, runtimeId, modelId) DO UPDATE SET
            fingerprint=excluded.fingerprint, capsJson=excluded.capsJson, observedAt=excluded.observedAt`
       )
       .run({
+        ownerId: this.cacheOwnerId,
         runtimeId: rec.runtimeId,
         modelId: rec.modelId,
         fingerprint: rec.fingerprint,
@@ -4591,29 +4611,35 @@ export class LocalStore {
     // the runtime's rows — correct for a runtime whose catalog came back empty.
     const placeholders = keepModelIds.map(() => '?').join(', ')
     this.db
-      .prepare(`DELETE FROM runtime_model_catalog WHERE runtimeId = ? AND modelId NOT IN (${placeholders})`)
-      .run(runtimeId, ...keepModelIds)
+      .prepare(
+        `DELETE FROM runtime_model_catalog
+         WHERE ownerId = ? AND runtimeId = ? AND modelId NOT IN (${placeholders})`
+      )
+      .run(this.cacheOwnerId, runtimeId, ...keepModelIds)
   }
 
   getRuntimeCatalogMeta(runtimeId: string): RuntimeCatalogMetaRecord | undefined {
-    const row = this.db.prepare('SELECT * FROM runtime_catalog_meta WHERE runtimeId = ?').get(runtimeId) as
-      RuntimeCatalogMetaRow | undefined
+    const row = this.db
+      .prepare('SELECT * FROM runtime_catalog_meta WHERE ownerId = ? AND runtimeId = ?')
+      .get(this.cacheOwnerId, runtimeId) as RuntimeCatalogMetaRow | undefined
     return row ? runtimeCatalogMetaFromRow(row) : undefined
   }
 
   listRuntimeCatalogMetas(): RuntimeCatalogMetaRecord[] {
     const rows = this.db
-      .prepare('SELECT * FROM runtime_catalog_meta ORDER BY runtimeId ASC')
-      .all() as unknown as RuntimeCatalogMetaRow[]
+      .prepare('SELECT * FROM runtime_catalog_meta WHERE ownerId = ? ORDER BY runtimeId ASC')
+      .all(this.cacheOwnerId) as unknown as RuntimeCatalogMetaRow[]
     return rows.map(runtimeCatalogMetaFromRow)
   }
 
   listRuntimeModelCaps(runtimeId?: string): RuntimeModelCapRecord[] {
     const rows = (runtimeId !== undefined
-      ? this.db.prepare('SELECT * FROM runtime_model_catalog WHERE runtimeId = ? ORDER BY modelId ASC').all(runtimeId)
+      ? this.db
+          .prepare('SELECT * FROM runtime_model_catalog WHERE ownerId = ? AND runtimeId = ? ORDER BY modelId ASC')
+          .all(this.cacheOwnerId, runtimeId)
       : this.db
-          .prepare('SELECT * FROM runtime_model_catalog ORDER BY runtimeId ASC, modelId ASC')
-          .all()) as unknown as RuntimeModelCapRow[]
+          .prepare('SELECT * FROM runtime_model_catalog WHERE ownerId = ? ORDER BY runtimeId ASC, modelId ASC')
+          .all(this.cacheOwnerId)) as unknown as RuntimeModelCapRow[]
     return rows.map((row) => ({
       runtimeId: row.runtimeId,
       modelId: row.modelId,
@@ -4623,11 +4649,22 @@ export class LocalStore {
     }))
   }
 
-  /** Startup GC (§4 rule 6): drop rows unseen for the caller-computed retention window
-   *  (30 days) from both tables, so uninstalled runtimes cannot accumulate forever. */
-  gcRuntimeCatalog(cutoffEpochMs: number): void {
-    this.db.prepare('DELETE FROM runtime_catalog_meta WHERE observedAt < ?').run(cutoffEpochMs)
-    this.db.prepare('DELETE FROM runtime_model_catalog WHERE observedAt < ?').run(cutoffEpochMs)
+  /** Startup GC (§4 rule 6): drop rows unseen for the caller-computed retention window (30 days),
+   *  and another member's at the shorter `departedOwnerCutoffEpochMs` — an ownerId dies with the
+   *  process that minted it, so a rollout leaves caches nobody can read again. That window stays
+   *  conservative: a live member that has not re-probed inside it pays one re-discovery. A
+   *  single-daemon store owns every row, so only the first window ever reaches it. */
+  gcRuntimeCatalog(cutoffEpochMs: number, departedOwnerCutoffEpochMs = cutoffEpochMs): void {
+    const params = { ownerId: this.cacheOwnerId, cutoff: cutoffEpochMs, departed: departedOwnerCutoffEpochMs }
+    for (const table of ['runtime_catalog_meta', 'runtime_model_catalog']) {
+      this.db
+        .prepare(
+          `DELETE FROM ${table}
+           WHERE (ownerId = @ownerId AND observedAt < @cutoff)
+              OR (ownerId <> @ownerId AND observedAt < @departed)`
+        )
+        .run(params)
+    }
   }
 
   /** Next shim-binding generation for an agent's sandbox: one atomic upsert, so two members cannot tie. */

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -4649,21 +4649,34 @@ export class LocalStore {
     }))
   }
 
-  /** Startup GC (§4 rule 6): drop rows unseen for the caller-computed retention window (30 days),
-   *  and another member's at the shorter `departedOwnerCutoffEpochMs` — an ownerId dies with the
-   *  process that minted it, so a rollout leaves caches nobody can read again. That window stays
+  /** Startup GC (§4 rule 6): drop catalogs unseen for the caller-computed retention window (30
+   *  days), and another member's at the shorter `departedOwnerCutoffEpochMs` — an ownerId dies with
+   *  the process that minted it, so a rollout leaves caches nobody can read again. That window stays
    *  conservative: a live member that has not re-probed inside it pays one re-discovery. A
-   *  single-daemon store owns every row, so only the first window ever reaches it. */
+   *  single-daemon store owns every row, so only the first window ever reaches it.
+   *
+   *  Staleness is a property of a whole `(ownerId, runtimeId)` catalog, never of one row. A phase-1
+   *  refresh re-stamps the meta row and the seed model only, so a row-by-row sweep would delete the
+   *  models discovery found while leaving `complete`/`modelsHash` standing — a gate that never
+   *  reopens over a matrix permanently missing those models. */
   gcRuntimeCatalog(cutoffEpochMs: number, departedOwnerCutoffEpochMs = cutoffEpochMs): void {
-    const params = { ownerId: this.cacheOwnerId, cutoff: cutoffEpochMs, departed: departedOwnerCutoffEpochMs }
     for (const table of ['runtime_catalog_meta', 'runtime_model_catalog']) {
-      this.db
-        .prepare(
-          `DELETE FROM ${table}
-           WHERE (ownerId = @ownerId AND observedAt < @cutoff)
-              OR (ownerId <> @ownerId AND observedAt < @departed)`
-        )
-        .run(params)
+      const unseen = (source: string): string =>
+        `NOT EXISTS (SELECT 1 FROM ${source} fresh
+                      WHERE fresh.ownerId = ${table}.ownerId AND fresh.runtimeId = ${table}.runtimeId
+                        AND fresh.observedAt >= @cutoff)`
+      const sweep = (ownerTest: string, cutoff: number): void => {
+        this.db
+          .prepare(
+            `DELETE FROM ${table}
+             WHERE ownerId ${ownerTest} @ownerId
+               AND ${unseen('runtime_catalog_meta')}
+               AND ${unseen('runtime_model_catalog')}`
+          )
+          .run({ ownerId: this.cacheOwnerId, cutoff })
+      }
+      sweep('=', cutoffEpochMs)
+      sweep('<>', departedOwnerCutoffEpochMs)
     }
   }
 

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -3,10 +3,19 @@ import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
-import { LocalStore, sessionKey } from '../src/store/local-store.js'
+import { LocalStore, sessionKey, type StoreDatabase } from '../src/store/local-store.js'
 
 function store(): LocalStore {
   return new LocalStore(join(mkdtempSync(join(tmpdir(), 'ac-db-')), 'local.sqlite'))
+}
+
+/** Two pool members over ONE database — what the shared Postgres schema is during a rollout. */
+function sharedMembers(first: string, second: string): [LocalStore, LocalStore] {
+  const database = new DatabaseSync(':memory:') as unknown as StoreDatabase
+  return [
+    new LocalStore({ database, shared: true, ownerId: first }),
+    new LocalStore({ database, shared: true, ownerId: second })
+  ]
 }
 
 describe('LocalStore schema versioning', () => {
@@ -74,7 +83,7 @@ describe('LocalStore schema versioning', () => {
     expect(inboxColumns).toEqual(expect.arrayContaining(['reportOwnerId', 'reportClaimedAt']))
     // A stamp is only comparable to a fire of the same schedule definition (#1031).
     expect(cronColumns).toContain('definition')
-    expect(userVersion(path)).toBe(7)
+    expect(userVersion(path)).toBe(8)
   })
 
   it('re-keys the capture gate by agent when upgrading a v5 store', () => {
@@ -106,7 +115,52 @@ describe('LocalStore schema versioning', () => {
     expect(upgraded.isCaptureExcluded('bot-c', 'acp-2')).toBe(true)
     upgraded.close()
 
-    expect(userVersion(path)).toBe(7)
+    expect(userVersion(path)).toBe(8)
+  })
+
+  it('re-keys the runtime catalog cache on its owning member when upgrading a v7 store', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-schema-v7-')), 'local.sqlite')
+    new LocalStore(path).close()
+    const old = new DatabaseSync(path)
+    old.exec(`
+      DROP TABLE runtime_catalog_meta;
+      DROP TABLE runtime_model_catalog;
+      CREATE TABLE runtime_catalog_meta (
+        runtimeId TEXT PRIMARY KEY, fingerprint TEXT NOT NULL, source TEXT NOT NULL, defaultModel TEXT,
+        permissionModes TEXT, defaultPermissionMode TEXT, complete INTEGER NOT NULL DEFAULT 0,
+        modelsHash TEXT, observedAt INTEGER NOT NULL
+      );
+      CREATE TABLE runtime_model_catalog (
+        runtimeId TEXT NOT NULL, modelId TEXT NOT NULL, fingerprint TEXT NOT NULL,
+        capsJson TEXT NOT NULL, observedAt INTEGER NOT NULL, PRIMARY KEY (runtimeId, modelId)
+      );
+      INSERT INTO runtime_catalog_meta (runtimeId, fingerprint, source, complete, observedAt)
+        VALUES ('claude', 'fp-1', 'acp', 1, 100);
+      INSERT INTO runtime_model_catalog (runtimeId, modelId, fingerprint, capsJson, observedAt)
+        VALUES ('claude', 'opus', 'fp-1', '{}', 100);
+    `)
+    old.exec('PRAGMA user_version = 7')
+    old.close()
+
+    const upgraded = new LocalStore(path)
+    // Pre-upgrade rows name no member, so no member can honestly claim them; the next
+    // probe refills the cache this one owns.
+    expect(upgraded.getRuntimeCatalogMeta('claude')).toBeUndefined()
+    expect(upgraded.listRuntimeModelCaps()).toEqual([])
+    upgraded.close()
+
+    const after = new DatabaseSync(path)
+    const metaColumns = after.prepare('PRAGMA table_info(runtime_catalog_meta)').all() as { name: string; pk: number }[]
+    const capColumns = after.prepare('PRAGMA table_info(runtime_model_catalog)').all() as { name: string; pk: number }[]
+    after.close()
+    const primaryKey = (columns: { name: string; pk: number }[]): string[] =>
+      columns
+        .filter((column) => column.pk > 0)
+        .sort((a, b) => a.pk - b.pk)
+        .map((column) => column.name)
+    expect(primaryKey(metaColumns)).toEqual(['ownerId', 'runtimeId'])
+    expect(primaryKey(capColumns)).toEqual(['ownerId', 'runtimeId', 'modelId'])
+    expect(userVersion(path)).toBe(8)
   })
 
   it('refuses a store written by a newer daemon WITHOUT touching it first', () => {
@@ -1365,7 +1419,58 @@ describe('LocalStore runtime model-catalog cache (runtime-model-catalog.md §4)'
     expect(s.getRuntimeCatalogMeta('old-rt')).toBeUndefined()
     expect(s.getRuntimeCatalogMeta('fresh-rt')).toBeDefined()
     expect(s.listRuntimeModelCaps().map((c) => c.runtimeId)).toEqual(['fresh-rt'])
+    // A single daemon owns every row, so the departed-member window never reaches them.
+    s.gcRuntimeCatalog(500, 5000)
+    expect(s.getRuntimeCatalogMeta('fresh-rt')).toBeDefined()
+    expect(s.listRuntimeModelCaps().map((c) => c.runtimeId)).toEqual(['fresh-rt'])
     s.close()
+  })
+
+  it('keeps two members of one shared store on independent catalogs', () => {
+    // The rollout case: two image generations, one Postgres schema. Each member reads and
+    // writes only its own rows, so neither sees the other's fingerprint as a change.
+    const [a, b] = sharedMembers('member-a', 'member-b')
+    a.recordRuntimeCatalogMeta(meta('claude', 'fp-a'))
+    a.upsertRuntimeModelCap(cap('claude', 'opus'))
+    a.markRuntimeCatalogComplete('claude', 'fp-a', 'hash-a', 200)
+
+    b.recordRuntimeCatalogMeta(meta('claude', 'fp-b'))
+    b.upsertRuntimeModelCap(cap('claude', 'haiku'))
+    b.upsertRuntimeModelCap(cap('claude', 'sonnet'))
+    b.pruneRuntimeModelCaps('claude', ['haiku'])
+
+    // a's gate stays closed on its own generation; the prune-on-success stayed inside b.
+    expect(a.getRuntimeCatalogMeta('claude')).toMatchObject({
+      fingerprint: 'fp-a',
+      complete: true,
+      modelsHash: 'hash-a',
+      observedAt: 200
+    })
+    expect(b.getRuntimeCatalogMeta('claude')).toMatchObject({ fingerprint: 'fp-b', complete: false })
+    expect(a.listRuntimeModelCaps('claude').map((c) => c.modelId)).toEqual(['opus'])
+    expect(b.listRuntimeModelCaps('claude').map((c) => c.modelId)).toEqual(['haiku'])
+    // Hydration too: a member boots on its own catalog, never a peer image's.
+    expect(a.listRuntimeCatalogMetas().map((m) => m.fingerprint)).toEqual(['fp-a'])
+    expect(b.listRuntimeModelCaps().map((c) => c.modelId)).toEqual(['haiku'])
+    // And a completion from the other member cannot close a's gate on a's fingerprint.
+    b.markRuntimeCatalogComplete('claude', 'fp-a', 'hash-a', 300)
+    expect(b.getRuntimeCatalogMeta('claude')?.complete).toBe(false)
+    a.close()
+  })
+
+  it('gcRuntimeCatalog reclaims a departed member at the shorter cutoff', () => {
+    const [live, gone] = sharedMembers('member-live', 'member-gone')
+    live.recordRuntimeCatalogMeta(meta('claude', 'fp-live', 100))
+    live.upsertRuntimeModelCap(cap('claude', 'opus', 100))
+    gone.recordRuntimeCatalogMeta(meta('claude', 'fp-gone', 100))
+    gone.upsertRuntimeModelCap(cap('claude', 'sonnet', 100))
+
+    live.gcRuntimeCatalog(50, 500)
+    expect(live.getRuntimeCatalogMeta('claude')).toMatchObject({ fingerprint: 'fp-live' })
+    expect(live.listRuntimeModelCaps('claude').map((c) => c.modelId)).toEqual(['opus'])
+    expect(gone.getRuntimeCatalogMeta('claude')).toBeUndefined()
+    expect(gone.listRuntimeModelCaps()).toEqual([])
+    live.close()
   })
 
   it('finds a pending skill proposal behind many skill-bearing dreams', () => {

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -1426,6 +1426,24 @@ describe('LocalStore runtime model-catalog cache (runtime-model-catalog.md §4)'
     s.close()
   })
 
+  it('gcRuntimeCatalog keeps a refreshed catalog whole, models discovery found included', () => {
+    // Staleness is per catalog, not per row: a phase-1 refresh re-stamps the meta row and the
+    // seed model only, so sweeping row by row would strip the older model rows while leaving
+    // complete/modelsHash standing — a closed gate over a permanently partial matrix.
+    const s = store()
+    s.recordRuntimeCatalogMeta(meta('claude', 'fp-1', 100))
+    s.upsertRuntimeModelCap(cap('claude', 'opus', 100))
+    s.upsertRuntimeModelCap(cap('claude', 'sonnet', 100))
+    s.markRuntimeCatalogComplete('claude', 'fp-1', 'hash-1', 100)
+    s.recordRuntimeCatalogMeta(meta('claude', 'fp-1', 900))
+    s.upsertRuntimeModelCap(cap('claude', 'opus', 900))
+
+    s.gcRuntimeCatalog(500)
+    expect(s.getRuntimeCatalogMeta('claude')).toMatchObject({ complete: true, modelsHash: 'hash-1' })
+    expect(s.listRuntimeModelCaps('claude').map((c) => c.modelId)).toEqual(['opus', 'sonnet'])
+    s.close()
+  })
+
   it('keeps two members of one shared store on independent catalogs', () => {
     // The rollout case: two image generations, one Postgres schema. Each member reads and
     // writes only its own rows, so neither sees the other's fingerprint as a change.
@@ -1470,6 +1488,24 @@ describe('LocalStore runtime model-catalog cache (runtime-model-catalog.md §4)'
     expect(live.listRuntimeModelCaps('claude').map((c) => c.modelId)).toEqual(['opus'])
     expect(gone.getRuntimeCatalogMeta('claude')).toBeUndefined()
     expect(gone.listRuntimeModelCaps()).toEqual([])
+    live.close()
+  })
+
+  it('a peer sweep cannot strip a live member catalog down the middle', () => {
+    // The live member last ran a full discovery long ago and has only been refreshing phase-1
+    // since. Its meta row is fresh, its older model rows are not — and its gate stays closed on
+    // an unchanged fingerprint, so anything a peer deletes here is never rediscovered.
+    const [live, peer] = sharedMembers('member-live', 'member-peer')
+    live.recordRuntimeCatalogMeta(meta('claude', 'fp-live', 100))
+    live.upsertRuntimeModelCap(cap('claude', 'opus', 100))
+    live.upsertRuntimeModelCap(cap('claude', 'sonnet', 100))
+    live.markRuntimeCatalogComplete('claude', 'fp-live', 'hash-live', 100)
+    live.recordRuntimeCatalogMeta(meta('claude', 'fp-live', 900))
+    live.upsertRuntimeModelCap(cap('claude', 'opus', 900))
+
+    peer.gcRuntimeCatalog(50, 500)
+    expect(live.getRuntimeCatalogMeta('claude')).toMatchObject({ complete: true, modelsHash: 'hash-live' })
+    expect(live.listRuntimeModelCaps('claude').map((c) => c.modelId)).toEqual(['opus', 'sonnet'])
     live.close()
   })
 

--- a/packages/daemon/test/postgres-pool-store.int.test.ts
+++ b/packages/daemon/test/postgres-pool-store.int.test.ts
@@ -256,4 +256,40 @@ describe.skipIf(!databaseUrl)('PostgreSQL pool member store', () => {
       await first.close()
     }
   })
+
+  it('keeps each member on its own runtime model catalog', async () => {
+    // The rollout case against the real schema: two members, two fingerprints, one table.
+    const suffix = randomUUID()
+    const runtimeId = `runtime-${suffix}`
+    const config = { version: 1 as const, databaseUrl: databaseUrl!, maxConnections: 2 }
+    const first = await PostgresDataPlane.open(config, () => undefined)
+    const second = await PostgresDataPlane.open(config, () => undefined)
+    try {
+      first.store.recordRuntimeCatalogMeta({ runtimeId, fingerprint: 'fp-1', source: 'acp', observedAt: 100 })
+      first.store.upsertRuntimeModelCap({ runtimeId, modelId: 'a', fingerprint: 'fp-1', caps: {}, observedAt: 100 })
+      first.store.markRuntimeCatalogComplete(runtimeId, 'fp-1', 'hash-1', 100)
+
+      second.store.recordRuntimeCatalogMeta({ runtimeId, fingerprint: 'fp-2', source: 'acp', observedAt: 200 })
+      second.store.upsertRuntimeModelCap({ runtimeId, modelId: 'b', fingerprint: 'fp-2', caps: {}, observedAt: 200 })
+      second.store.pruneRuntimeModelCaps(runtimeId, ['b'])
+
+      expect(first.store.getRuntimeCatalogMeta(runtimeId)).toMatchObject({
+        fingerprint: 'fp-1',
+        complete: true,
+        modelsHash: 'hash-1'
+      })
+      expect(second.store.getRuntimeCatalogMeta(runtimeId)).toMatchObject({ fingerprint: 'fp-2', complete: false })
+      expect(first.store.listRuntimeModelCaps(runtimeId).map((row) => row.modelId)).toEqual(['a'])
+      expect(second.store.listRuntimeModelCaps(runtimeId).map((row) => row.modelId)).toEqual(['b'])
+
+      // A departed member's cache is unreadable by anyone, so the shorter window takes it.
+      second.store.gcRuntimeCatalog(1, 150)
+      expect(first.store.getRuntimeCatalogMeta(runtimeId)).toBeUndefined()
+      expect(second.store.getRuntimeCatalogMeta(runtimeId)).toMatchObject({ fingerprint: 'fp-2' })
+    } finally {
+      second.store.gcRuntimeCatalog(Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+      await second.close()
+      await first.close()
+    }
+  })
 })


### PR DESCRIPTION
## What was wrong

`runtime_catalog_meta` and `runtime_model_catalog` are a **per-member cache** with no member
column, and a pool member's store is one Postgres schema every member shares. Two members
running the same image share a fingerprint, so the §3.3 discovery gate accidentally held and
nobody noticed the table was shared.

A rolling update breaks that accident. The two image generations have different fingerprints,
so each member reads the other's row as "the fingerprint changed", re-runs discovery, resets
`complete`, overwrites the meta row, and `pruneRuntimeModelCaps` deletes the other generation's
model rows. Both members ping-pong probe sessions — real runtime work — for the length of the
rollout, and the console's model list flaps between the two catalogs. It does not end cleanly
either: `hydrateRuntimeCatalogCache` boots a member from whatever is in the table, so a member
can come up advertising models its own image cannot run, and the control plane assigns turns
on that basis.

## What changed

- **`ownerId` leads both primary keys** — `(ownerId, runtimeId)` and
  `(ownerId, runtimeId, modelId)` — and every catalog read and write is scoped to the store's
  own member: `recordRuntimeCatalogMeta`, `markRuntimeCatalogComplete`, `upsertRuntimeModelCap`,
  `pruneRuntimeModelCaps`, `getRuntimeCatalogMeta`, `listRuntimeCatalogMetas`,
  `listRuntimeModelCaps`. Boot hydration therefore reads only this member's catalog.
- **A single-daemon SQLite store owns the one `''` partition forever**, so its behaviour is
  unchanged — including cross-restart hydration of the last-good catalog, and the prune,
  fingerprint-fencing and gate semantics the existing tests pin.
- **`gcRuntimeCatalog` prunes catalogs whose owner is gone.** It keeps the 30-day retention
  window for the caller's own catalogs and takes another member's at a shorter one (7 days): an
  `ownerId` dies with the process that minted it, so a rollout leaves caches nobody can read
  again. The second window stays conservative because a live member that has not re-probed
  inside it pays one re-discovery for the reclaim. It never reaches a single-daemon store,
  which owns every row.
- **Staleness is a property of one whole `(ownerId, runtimeId)` catalog** — meta row and model
  rows together — never of a single row. A phase-1 refresh re-stamps the meta row and the seed
  model only, so a row-by-row sweep would delete the models a full discovery found while
  leaving `complete`/`modelsHash` standing, and the gate — same fingerprint, complete, matching
  model hash — would never reopen over the now permanently partial matrix. A catalog is kept
  whole or dropped whole. (Found in review; the pre-existing 30-day window had the same shape
  for a single daemon whose fingerprint had not changed in a month, and is covered by the same
  change.)
- **A `SCHEMA_MIGRATIONS` step**, per the header rules in `local-store.ts`. Pre-owner rows name
  no member and cannot be attributed to one, so the step drops both tables and the `CREATE`
  block (which runs afterwards, `IF NOT EXISTS`) rebuilds them owner-keyed; the next probe
  refills the cache. That is a one-time cache loss on upgrade — the tables are last-good
  discovery results by design, and a backfill would either misattribute a shared store's rows or
  preserve column drift on a store whose catalog tables never had a migration. The step is last
  in the list, so the store lands at **v7**, behind the three migrations `main` added while this
  was open.
- `docs/designs/runtime-model-catalog.md` §4 carries the new keys and the GC rules.

The alternative the issue offers — partitioning by fingerprint — fixes the thrash but not the
hydration half: a member cannot know its own fingerprint before it has probed, so at boot it
would still have to guess which generation's rows are its own.

## Tests

- `local-store.test.ts`: two members over one shared database keep independent catalogs
  (fingerprints, `complete`/`modelsHash`, model rows, prune-on-success, and the hydration read
  all stay inside their owner); `gcRuntimeCatalog` reclaims a departed member at the shorter
  cutoff while keeping the caller's catalogs; a peer sweep cannot strip a live member's catalog
  down the middle, and neither can a single daemon's own 30-day window; a single-daemon store is
  untouched by the departed-member window; and a v6 store upgrades to v7 with `ownerId` leading
  both primary keys.
- `postgres-pool-store.int.test.ts`: the same isolation and reclaim against a real Postgres
  schema (skipped without `DATA_PLANE_TEST_DATABASE_URL`).

Verified locally, after merging `main`: daemon `typecheck`, `pnpm lint`, `pnpm format:check`,
`local-store.test.ts` (81 passed), `model-catalog.test.ts` + `model-catalog-daemon.test.ts`
(33 passed), and `postgres-pool-store.int.test.ts` against a local PostgreSQL 16 (3 passed) —
including a run where the pool schema was first rolled back to the pre-owner table shape at v6,
which exercised the migration end to end (`PRIMARY KEY (ownerid, runtimeid)` after the upgrade).

The full daemon suite cannot pass in this container: it runs Node 22 while the repo requires
Node ≥ 24.12, and `node:sqlite`'s `enableDefensive` does not exist before Node 24. The suite
was run on this branch and on `origin/main` for comparison — the same 36 files fail in both,
and the only test-level difference is one 5s timeout in a suite that already fails on `main`.

Closes #1039