### PR TITLE
fix(collab): retry a cross-daemon peer wake through the pool install window

### DIFF
--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -357,6 +357,18 @@ relay-owned durable retry, which is deliberately future work rather than an
 implied property. Crons never reach this rendezvous: a cron-bearing group is
 proactively claimable, so it always has a holder by the time a fire is due.
 
+**A cross-daemon peer wake (`rd/agentmsg`) does not take the rendezvous; it
+waits it out.** Its sender is a daemon, not a provider callback, so it can be
+told "not yet". The peer directory carries a pool agent nobody may be addressed
+at yet — a grant its member has not confirmed in a digest, a lapsed lease a live
+member is about to claim — as a **pending** entry (policy intact, no daemon), the
+relay answers the retryable **`not_ready`** for it (as does a target daemon
+handed an agent it does not run), no hop caches that verdict against the
+`deliveryId`, and the source daemon re-sends the same `deliveryId` with backoff
+for a few lease horizons before recording it as terminal. Exactly-once holds
+because the id never changes: an attempt that landed is replayed from the
+target's dedup on every later attempt.
+
 ## 7. Ownership and dial-in binding (D3)
 
 Historically the shim dialed out to its org's daemon (`AC_SHIM_ENDPOINT` — the

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -649,7 +649,8 @@ export function buildContainer(
     relayControl,
     sender,
     placementResolver,
-    repos.dutyGroup
+    repos.dutyGroup,
+    clock
   )
 
   // The fan-out that rides the resolver (orchestrator/agentDelivery.ts).

--- a/packages/control-plane/src/orchestrator/collabRoutes.service.ts
+++ b/packages/control-plane/src/orchestrator/collabRoutes.service.ts
@@ -17,6 +17,7 @@ import type { AgentRepo, DaemonRecord, DaemonRepo, IntegrationRepo } from '../pe
 import { buildCollabSnapshot } from './collabSnapshot.js'
 import type { CollabChannelRoute, CollabOrgAgent, CollabRoutesSnapshot } from '@agentconnect.md/protocol'
 import type { OrgId } from '../domain/ids.js'
+import { systemClock, type Clock } from '../domain/clock.js'
 import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
 import { servedAgents, type DutyHeldAgentReader } from './servedAgents.js'
 
@@ -34,7 +35,8 @@ export class CollabRoutesService {
     private readonly placement: Pick<PlacementResolver, 'resolveDirectory'> = PLACEMENT_ONLY,
     /** The duty half of "which orgs does this install-wide member serve".
      *  Absent (tests / no pool) ⇒ placement alone, which is the pre-duty behavior. */
-    private readonly duties?: DutyHeldAgentReader
+    private readonly duties?: DutyHeldAgentReader,
+    private readonly clock: Clock = systemClock
   ) {}
 
   private serialize<T>(run: () => Promise<T>): Promise<T> {
@@ -62,7 +64,7 @@ export class CollabRoutesService {
       const served = await servedAgents(daemon.id, {
         agents: this.agents,
         ...(this.duties ? { duties: this.duties } : {}),
-        now: new Date()
+        now: new Date(this.clock.now())
       })
       for (const agent of served.agents) orgIds.add(agent.orgId)
     }

--- a/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
@@ -173,8 +173,12 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
     expect(snap.agents.find((a) => a.agentId === AGENT_1)?.displayName).toBe('Deploy Bot')
   })
 
-  it('drops an unplaced agent from the flat directory — nothing to route a wake to', () => {
+  // The resolver already dropped what nothing serves; a null daemon here is a PENDING pool
+  // agent, carried without a daemon so a wake gets the retryable `not_ready` (#987).
+  it('carries a pending (daemon-less) directory row without a daemonId', () => {
     const snap = buildCollabSnapshot(DEFAULT_ORG_ID, [], 1, [orgAgent({ agentId: AGENT_3, daemonId: null })])
-    expect(snap.agents).toEqual([])
+    expect(snap.agents).toHaveLength(1)
+    expect(snap.agents[0]).toMatchObject({ agentId: AGENT_3, orgId: DEFAULT_ORG_ID })
+    expect(snap.agents[0]).not.toHaveProperty('daemonId')
   })
 })

--- a/packages/control-plane/src/orchestrator/collabSnapshot.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.ts
@@ -3,8 +3,10 @@
  * (agent-collaboration §2.3/§6.2) from an org's channel placements. Groups the flat
  * placement records into per-channel `CollabChannelRoute`s, dropping unplaced agents
  * (no daemonId ⇒ not routable), plus the FLAT org-scoped `agents[]` directory built
- * from `orgAgents` — the only carrier for an agent that has no IM integration and so
- * appears in no channel at all. Bodiless routing/policy metadata only.
+ * from the RESOLVED `orgAgents` (`PlacementResolver.resolveDirectory`) — the only
+ * carrier for an agent that has no IM integration and so appears in no channel at all,
+ * and the only list that may carry a PENDING (daemon-less) entry. Bodiless
+ * routing/policy metadata only.
  *
  * The SAME snapshot is shipped to the relay (`rc/collab-routes`, full org) and to a
  * daemon (`register/ok.collabRoutes` / `collaboration/routes` EVT). The daemon copy is
@@ -78,23 +80,23 @@ export function buildCollabSnapshot(
   // The FLAT org directory, alongside the channel-keyed routes. An agent with no IM
   // integration appears in NO `channels[]` entry, so this list is the only place a
   // holder of the snapshot can learn it exists — and channel-free A2A authorization
-  // needs exactly that. Unplaced agents (daemonId null) are dropped for the same
-  // reason as in `channels[]`: with no owning daemon there is nothing to route to.
-  // No `integrationId`/`botAppId`: both are per-channel reply coordinates, not
-  // identity, and this entry is deliberately channel-free.
-  const agents: CollabOrgAgent[] = orgAgents
-    .filter((a): a is OrgAgentRecord & { daemonId: string } => a.daemonId !== null)
-    .map((a) => ({
-      orgId,
-      agentId: a.agentId,
-      daemonId: a.daemonId,
-      callPolicy: a.callPolicy,
-      allowedCallerAgentIds: a.allowedCallerAgentIds,
-      outboundPolicy: a.outboundPolicy,
-      allowedTargetAgentIds: a.allowedTargetAgentIds,
-      name: a.name,
-      ...(a.displayName !== null ? { displayName: a.displayName } : {})
-    }))
+  // needs exactly that. `orgAgents` is the RESOLVED directory (`PlacementResolver.
+  // resolveDirectory`): rows nothing serves are already gone, and a `daemonId: null`
+  // row is PENDING — carried without a daemon so a wake gets the retryable `not_ready`
+  // rather than failing closed as unknown. No `integrationId`/`botAppId`: both are
+  // per-channel reply coordinates, not identity, and this entry is deliberately
+  // channel-free.
+  const agents: CollabOrgAgent[] = orgAgents.map((a) => ({
+    orgId,
+    agentId: a.agentId,
+    ...(a.daemonId !== null ? { daemonId: a.daemonId } : {}),
+    callPolicy: a.callPolicy,
+    allowedCallerAgentIds: a.allowedCallerAgentIds,
+    outboundPolicy: a.outboundPolicy,
+    allowedTargetAgentIds: a.allowedTargetAgentIds,
+    name: a.name,
+    ...(a.displayName !== null ? { displayName: a.displayName } : {})
+  }))
 
   return { generation, channels: [...byChannel.values()], agents, platformKinds: PLATFORM_KINDS }
 }

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -335,8 +335,9 @@ export class DutyLeaseService {
     // applied daemon-side only after its install succeeds (#972), so a group appearing in the
     // digest is the proof that the member is actually serving it. Publishing at grant time is the
     // same error #976 fixed for the fence — the gate opening before the fact — and on a pushed
-    // projection it costs a message: relay ingress recovers through the rendezvous, but a
-    // cross-daemon peer wake forwards ONCE and takes a terminal miss.
+    // projection it costs a message: relay ingress recovers through the rendezvous, and a
+    // cross-daemon peer wake rides the directory's PENDING entry (retryable `not_ready`) until
+    // this confirmation names the member.
     //
     // The digest's TERMS ride along, not just its ids: a member mid-admission of a re-grant still
     // reports the previous term, and that confirms the previous grant, never the current one. Same

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -407,6 +407,10 @@ export class DutyLeaseService {
         { maxMembers: DUTY_GRANT_MEMBERS_MAX, excludeGroupIds: this.backedOff(daemonId) }
       )
       this.noteGranted(granted, daemonId)
+      // Not a route yet (routable reads confirmations), but a state change: the directory must stop
+      // naming the expired holder and carry the agents as PENDING now, or a peer wake in the
+      // grant→digest window sees a terminal `offline` instead of the retryable `not_ready` (#987).
+      if (granted.length > 0) this.routing?.kick(agentIdsOf(granted))
     }
 
     // Classified AFTER the claim so the grant and revoke sets are disjoint by
@@ -497,9 +501,9 @@ export class DutyLeaseService {
       if (claim.granted && claim.term !== undefined)
         this.noteGranted([{ groupId: claim.groupId, term: claim.term }], holder)
       const [grant] = await this.stamp([toGrantEntry(group)])
-      // No routing kick here: like every other grant this is not yet a fact — the claimant
-      // installs before it answers, but the ledger has not seen the group in a digest. The
-      // member's next beat confirms it and converges then.
+      // Kicked for the same reason as the vacancy grant: the routable member still waits for the
+      // digest, but the directory turns the agents PENDING right away.
+      this.routing?.kick(agentIdsOf([group]))
       return { granted: true, grant }
     })
   }

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -72,7 +72,7 @@ import type { AgentSpecAssembler } from './agentSpecAssembler.js'
 import { buildCollabSnapshot } from './collabSnapshot.js'
 import type { ConnectionRegistry, DaemonConnState } from '../ws/registry.js'
 import type { ControlSender } from './outbound.js'
-import type { PlacementResolver } from './placementResolver.js'
+import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
 import type { EpochService } from './epoch.js'
 import type { Clock } from '../domain/clock.js'
 
@@ -498,9 +498,9 @@ export class Placement implements ReconcileService {
         placements,
         Number(daemon.routingEpoch),
         // Placement names the target for a machine-placed peer; the ledger names it for a pool
-        // one. `buildCollabSnapshot` drops rows with no daemon, so resolving here is what keeps a
-        // pool agent discoverable AND callable.
-        this.orch?.placement ? await this.orch.placement.resolveDirectory(orgDirectory) : orgDirectory
+        // one, and marks a pool agent nobody may be addressed at yet as pending. The resolver is
+        // the only producer of that shape, so a graph without one still goes through it.
+        await (this.orch?.placement ?? PLACEMENT_ONLY).resolveDirectory(orgDirectory)
       )
       collabRoutes.channels.push(...snapshot.channels)
       collabRoutes.agents.push(...snapshot.agents)

--- a/packages/control-plane/src/orchestrator/placementResolver.test.ts
+++ b/packages/control-plane/src/orchestrator/placementResolver.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { PlacementResolver, type DutyHolderReader } from './placementResolver.js'
+import { DaemonId } from '../domain/ids.js'
+import { systemClock } from '../domain/clock.js'
+
+const AGENT = '00000000-0000-0000-0000-00000000000a'
+const MACHINE = DaemonId('00000000-0000-0000-0000-0000000000d0')
+const MEMBER = DaemonId('00000000-0000-0000-0000-0000000000d1')
+const SET = 'set-pool'
+
+function duties(over: { holders?: DaemonId[]; confirmed?: DaemonId[] } = {}): DutyHolderReader {
+  return {
+    holdersOf: async () => over.holders ?? [],
+    confirmedHoldersOf: async () => over.confirmed ?? []
+  }
+}
+
+const setAgent = { agentId: AGENT, placementKind: 'set' as const, daemonId: null, setId: SET }
+const machineAgent = { agentId: AGENT, placementKind: 'daemon' as const, daemonId: MACHINE, setId: null }
+const unplaced = { agentId: AGENT, placementKind: 'daemon' as const, daemonId: null, setId: null }
+
+// The three directory outcomes (#987): routable names the confirmed member; pending is a set agent
+// nobody may be addressed at yet but a live member holds or will claim; dropped is the rest.
+describe('PlacementResolver.resolveDirectory', () => {
+  it('names the confirmed holder for a set agent, never an unconfirmed one', async () => {
+    const resolver = new PlacementResolver({
+      duties: duties({ holders: [MEMBER], confirmed: [MEMBER] }),
+      clock: systemClock
+    })
+    expect(await resolver.resolveDirectory([setAgent])).toEqual([{ ...setAgent, daemonId: MEMBER }])
+  })
+
+  it('carries a set agent as PENDING while its grant is held but not yet confirmed', async () => {
+    const resolver = new PlacementResolver({ duties: duties({ holders: [MEMBER] }), clock: systemClock })
+    expect(await resolver.resolveDirectory([setAgent])).toEqual([{ ...setAgent, daemonId: null }])
+  })
+
+  it('carries a lapsed set agent as PENDING while a live member could claim it', async () => {
+    const resolver = new PlacementResolver({
+      duties: duties(),
+      liveMembers: async (setId) => (setId === SET ? [MEMBER] : []),
+      clock: systemClock
+    })
+    expect(await resolver.resolveDirectory([setAgent])).toEqual([{ ...setAgent, daemonId: null }])
+  })
+
+  it('drops a set agent with no holder and no live member — nothing can serve it', async () => {
+    const resolver = new PlacementResolver({ duties: duties(), liveMembers: async () => [], clock: systemClock })
+    expect(await resolver.resolveDirectory([setAgent])).toEqual([])
+  })
+
+  it('reads liveness once per set, not once per row', async () => {
+    let calls = 0
+    const resolver = new PlacementResolver({
+      duties: duties(),
+      liveMembers: async () => {
+        calls += 1
+        return [MEMBER]
+      },
+      clock: systemClock
+    })
+    const rows = [setAgent, { ...setAgent, agentId: '00000000-0000-0000-0000-00000000000b' }]
+    expect(await resolver.resolveDirectory(rows)).toHaveLength(2)
+    expect(calls).toBe(1)
+  })
+
+  it('a machine placement is routable from the column alone, and an unplaced row is dropped', async () => {
+    const resolver = new PlacementResolver({ duties: duties(), liveMembers: async () => [MEMBER], clock: systemClock })
+    expect(await resolver.resolveDirectory([machineAgent, unplaced])).toEqual([machineAgent])
+  })
+})

--- a/packages/control-plane/src/orchestrator/placementResolver.ts
+++ b/packages/control-plane/src/orchestrator/placementResolver.ts
@@ -25,8 +25,9 @@ import { systemClock, type Clock } from '../domain/clock.js'
  *   A member that is still installing is included, because it has to receive its bundle to finish.
  * - `confirmedHoldersOf` — only holds the member has reported in its digest. Who INGRESS may be
  *   addressed at. Publishing a member here before it has admitted the grant is the same error
- *   #976 fixed for the fence — the gate opens before the fact — and on a projection there is no
- *   second chance: a cross-daemon peer wake forwards once and gets a terminal miss.
+ *   #976 fixed for the fence — the gate opens before the fact; a peer wake addressed at an
+ *   installing member would be refused by it, and the window between the two is exactly what the
+ *   directory's PENDING entry (`resolveDirectory`) exists to name.
  */
 export interface DutyHolderReader {
   holdersOf(agentId: AgentId, now: Date): Promise<DaemonId[]>
@@ -63,16 +64,11 @@ export class PlacementResolver {
    * confirmed yet — a grant it has not installed is a lease, not a route.
    *
    * Between a grant and its first digest this names NOBODY for a set agent. For platform ingress
-   * that is fully covered — the trigger reaches a member and claims through the activation
-   * rendezvous. For a cross-daemon peer wake it is NOT covered, and the honest reason to prefer it
-   * anyway is narrower than "absence is retryable", because absence is terminal too
-   * (`admits()` fails closed on an agent missing from the directory, so the wake is refused
-   * locally as `not_allowed`): naming the installing member instead makes the relay AND the target
-   * cache a terminal `not_found` against that `deliveryId`, so even a retransmit stays dead after
-   * the member is ready. Absence refuses the attempt without poisoning the next one.
-   *
-   * Closing it properly needs a retryable verdict on `rd/agentmsg`, which that wire does not have
-   * — see the PR body; it is its own change.
+   * that is covered by the activation rendezvous (the trigger reaches a member and claims). For a
+   * cross-daemon peer wake the directory carries the agent as PENDING instead
+   * ({@link PlacementResolver.resolveDirectory}), so the relay answers the retryable `not_ready`
+   * rather than a terminal `not_found`, and the source retries the same delivery until this
+   * names the confirmed member.
    */
   async routableDaemons(agent: ResolvableAgent): Promise<string[]> {
     return [...new Set([...placementTargets(agent), ...(await this.confirmedHolders(agent.id))])]
@@ -100,20 +96,42 @@ export class PlacementResolver {
   }
 
   /**
-   * Fill the serving daemon into a directory projection, dropping every row nothing serves right
-   * now. The peer directory and the collaboration snapshot both need "who do I wake", which is a
-   * live question for a set agent and a column read for a machine-placed one — so it is answered
-   * here once rather than at each surface, where the two could disagree.
+   * Fill the serving daemon into a directory projection. The peer directory and the collaboration
+   * snapshot both need "who do I wake", which is a live question for a set agent and a column read
+   * for a machine-placed one — so it is answered here once rather than at each surface, where the
+   * two could disagree.
+   *
+   * Three outcomes per row: a ROUTABLE member (`daemonId` set); PENDING (`daemonId: null`) — a set
+   * agent nobody may be addressed at yet, but which a live member holds unconfirmed or is about to
+   * claim, so a wake gets the retryable `not_ready` instead of a terminal miss; or dropped, when
+   * nothing serves the agent and nothing can. Naming the installing member instead would send the
+   * wake to a daemon that refuses it, which is why pending is a state of its own.
    */
   async resolveDirectory<T extends PlacementRef & { agentId: string }>(
     rows: readonly T[]
-  ): Promise<(T & { daemonId: string })[]> {
-    const resolved: (T & { daemonId: string })[] = []
+  ): Promise<(T & { daemonId: string | null })[]> {
+    const resolved: (T & { daemonId: string | null })[] = []
+    const liveBySet = new Map<string, Promise<boolean>>()
+    const setHasLiveMember = (setId: string): Promise<boolean> => {
+      let cached = liveBySet.get(setId)
+      if (!cached) {
+        cached = this.deps.liveMembers ? this.deps.liveMembers(setId).then((m) => m.length > 0) : Promise.resolve(false)
+        liveBySet.set(setId, cached)
+      }
+      return cached
+    }
     for (const row of rows) {
-      // ROUTABLE, not serving: this directory is what a cross-daemon peer wake is addressed
-      // through, and it forwards once.
-      const daemonId = await this.routableDaemon({ ...row, id: row.agentId })
-      if (daemonId) resolved.push({ ...row, daemonId })
+      const agent = { ...row, id: row.agentId }
+      // ROUTABLE, not serving: this directory is what a cross-daemon peer wake is addressed through.
+      const daemonId = await this.routableDaemon(agent)
+      if (daemonId) {
+        resolved.push({ ...row, daemonId })
+        continue
+      }
+      const eligibility = dutyEligibility(row)
+      if (eligibility.scope !== 'set') continue
+      const pending = (await this.holders(row.agentId)).length > 0 || (await setHasLiveMember(eligibility.setId))
+      if (pending) resolved.push({ ...row, daemonId: null })
     }
     return resolved
   }

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -434,7 +434,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
   async confirmedHoldersOf(agentId: AgentId, now: Date): Promise<DaemonId[]> {
     // `holdersOf` with the confirmation term: the same live-lease join, restricted to holders whose
     // reported hold is the one the row currently describes. INGRESS addressing uses this — naming a
-    // member that is still installing turns a routable message into a terminal miss, and matching
+    // member that is still installing sends a routable message to a daemon that refuses it, and matching
     // on (holder, term) rather than on "a confirmation exists" is what stops a re-take, a
     // composition rewrite or a stale-term digest from inheriting one it never earned.
     const rows = await this.prisma.$queryRaw<{ holder: string }[]>(Prisma.sql`

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -10,7 +10,7 @@
  * real socket.
  */
 import type { PrismaClient } from '../../src/generated/prisma/client.js'
-import type { RelayRosterEntry } from '@agentconnect.md/protocol'
+import type { CollabRoutesSnapshot, RelayRosterEntry } from '@agentconnect.md/protocol'
 import {
   PgDaemonRepo,
   PgDaemonLifecycleOpRepo,
@@ -59,7 +59,6 @@ import { HookService } from '../../src/hooks/hook.service.js'
 import { AgentRoutingConverger } from '../../src/orchestrator/agentRouting.js'
 import { FrameRouter } from '../../src/ws/handlers/index.js'
 import { DaemonConnection } from '../../src/ws/connection.js'
-import { RelayRegistry } from '../../src/ws/relay-registry.js'
 import type { DaemonWsDeps } from '../../src/ws/deps.js'
 import { InMemorySessionEventSink } from '../../src/events/sink.js'
 import { DaemonId, OrgId } from '../../src/domain/ids.js'
@@ -92,6 +91,8 @@ export interface WsHarness {
    *  addresses a daemon, so "ingress follows the holder" is assertable on it directly. */
   hookAssigns: CapturedHookRule[]
   hookRemovals: string[]
+  /** Every relay-facing collab-routes push, in order — the peer directory as a relay would hold it. */
+  collabSnapshots: CollabRoutesSnapshot[]
   /** The resolver the projections read through — lets a test ask what the peer directory would
    *  publish right now without reaching through the orchestrator. */
   placement: PlacementResolver
@@ -180,13 +181,6 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
   const registry = new DaemonRegistryService(repos.daemon, repos.runtimeProfile, repos.daemonLifecycleOp, clock)
   const connReg = new ConnectionRegistry()
   const sender = new ControlSender(connReg, repos.launch)
-  const collabRoutes = new CollabRoutesService(
-    repos.daemon,
-    repos.integration,
-    repos.agent,
-    new RelayControlSender(new RelayRegistry()),
-    sender
-  )
   const relays = opts.relays ?? []
   const dutyGroupRepo = new PgDutyGroupRepo(prisma)
   const memberSets = new PgMemberSetRepo(prisma)
@@ -201,6 +195,23 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     },
     clock
   })
+  // The relay-facing collab pushes are captured, not sent: `collabSnapshots` is literally the
+  // directory a relay would route a peer wake through, latest last. Wired like prod — resolver +
+  // duty ledger — so a pool member's held agents put their org into the snapshot.
+  const collabSnapshots: CollabRoutesSnapshot[] = []
+  const collabRoutes = new CollabRoutesService(
+    repos.daemon,
+    repos.integration,
+    repos.agent,
+    {
+      collabRoutes: (snapshot: CollabRoutesSnapshot) => void collabSnapshots.push(snapshot),
+      collabRoutesTo: (_ch: unknown, snapshot: CollabRoutesSnapshot) => void collabSnapshots.push(snapshot)
+    } as unknown as RelayControlSender,
+    sender,
+    placementResolver,
+    dutyGroupRepo,
+    clock
+  )
   const orchestrator = new Placement(
     repos.daemon,
     repos.agent,
@@ -318,6 +329,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     clock,
     hookAssigns,
     hookRemovals,
+    collabSnapshots,
     placement: placementResolver,
     codec,
     mintPoolMember: async (daemonId: string) => {

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -1184,17 +1184,24 @@ describe('a grant is not a route until the digest confirms it (protocol level, r
 
   /** The flat peer directory as the relay and every daemon receive it — what an A2A wake resolves
    *  through, and what `admits()` fails closed against. */
-  async function directoryDaemonFor(h: ReturnType<typeof buildWsHarness>, agentId: string): Promise<string | null> {
+  async function directoryRowFor(
+    h: ReturnType<typeof buildWsHarness>,
+    agentId: string
+  ): Promise<{ daemonId: string | null } | undefined> {
     const rows = await h.placement.resolveDirectory(await h.deps.agent.orgDirectory(OrgId(DEFAULT_ORG_ID)))
-    return rows.find((r) => r.agentId === agentId)?.daemonId ?? null
+    return rows.find((r) => r.agentId === agentId)
+  }
+  async function directoryDaemonFor(h: ReturnType<typeof buildWsHarness>, agentId: string): Promise<string | null> {
+    return (await directoryRowFor(h, agentId))?.daemonId ?? null
   }
 
   // The #976 shape, on a projection: the gate must not open before the fact. A grant commits the
   // lease; the member has NOT installed yet (`duty/fetch` is still in flight), and #972 applies the
   // grant only once that install succeeds — so "reported in the digest" is the first moment the
-  // member is provably serving. Publishing at grant time makes the relay and the target both cache
-  // a terminal `not_found` against that deliveryId, which stays dead even after the member is ready.
-  it('does not name the new holder in the peer directory until it reports the group', async () => {
+  // member is provably serving. Inside that window the row is PENDING (present, no daemon): a peer
+  // wake then gets the retryable `not_ready` instead of a terminal `not_found` cached against its
+  // deliveryId (#987).
+  it('carries the agent as pending, not routable, until the new holder reports the group', async () => {
     const start = 1_700_000_000_000
     const h = buildWsHarness(prisma)
     await seedPooledAgent()
@@ -1208,14 +1215,15 @@ describe('a grant is not a route until the digest confirms it (protocol level, r
     if (!isFrame('duty/grant')(grant)) throw new Error('expected duty/grant')
     expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).holder).toBe(DAEMON)
 
-    // ...and the directory still names nobody: a lease is not yet a route.
+    // ...and the directory still names nobody — a lease is not yet a route — but it carries the
+    // agent as pending rather than dropping it.
     expect(await isConfirmed(GROUP)).toBe(false)
-    expect(await directoryDaemonFor(h, AGENT)).toBeNull()
+    expect(await directoryRowFor(h, AGENT)).toMatchObject({ agentId: AGENT, daemonId: null })
 
     // Beat 2 carries the group in the digest — the member installed and opened its gate.
     await beat(stub, { held: [{ groupId: GROUP, term: '5' }], headroom: 4 })
     expect(await isConfirmed(GROUP)).toBe(true)
-    expect(await directoryDaemonFor(h, AGENT)).toBe(DAEMON)
+    expect(await directoryRowFor(h, AGENT)).toMatchObject({ daemonId: DAEMON })
   })
 
   it('publishes the hook rule on confirmation, not on the grant', async () => {

--- a/packages/control-plane/test/protocol/duty-lease.handler.test.ts
+++ b/packages/control-plane/test/protocol/duty-lease.handler.test.ts
@@ -1226,6 +1226,36 @@ describe('a grant is not a route until the digest confirms it (protocol level, r
     expect(await directoryRowFor(h, AGENT)).toMatchObject({ daemonId: DAEMON })
   })
 
+  // The relay holds the LAST push, and after an ungraceful holder death that push still names the
+  // expired holder. The grant is not a route, but it is a state change: it must re-push at once so the
+  // relay's copy turns the agent PENDING (retryable `not_ready`) instead of answering a terminal
+  // `offline` for the dead holder throughout the grant→digest window — while the claimant is
+  // still withheld until its digest confirms.
+  it('re-publishes the directory on the grant: pending at once, the claimant only on confirmation', async () => {
+    const start = 1_700_000_000_000
+    const h = buildWsHarness(prisma)
+    await seedPooledAgent()
+    await seedGroup({ holder: OTHER, term: 4n, expiresAt: new Date(start - 1) })
+    const { stub } = await ready(h)
+    const pushesBefore = h.collabSnapshots.length
+
+    await beat(stub, { held: [], headroom: 4 })
+    await stub.expectFrame('duty/grant')
+    h.clock.advance(1)
+    await vi.waitFor(() => expect(h.collabSnapshots.length).toBeGreaterThan(pushesBefore), SETTLE)
+    const pending = h.collabSnapshots.at(-1)!.agents.find((a) => a.agentId === AGENT)
+    expect(pending).toBeDefined()
+    expect(pending!.daemonId).toBeUndefined()
+    expect(h.collabSnapshots.at(-1)!.agents.some((a) => a.daemonId === OTHER)).toBe(false)
+
+    await beat(stub, { held: [{ groupId: GROUP, term: '5' }], headroom: 4 })
+    h.clock.advance(1)
+    await vi.waitFor(
+      () => expect(h.collabSnapshots.at(-1)!.agents.find((a) => a.agentId === AGENT)?.daemonId).toBe(DAEMON),
+      SETTLE
+    )
+  })
+
   it('publishes the hook rule on confirmation, not on the grant', async () => {
     // Same property on the other pushed projection, and the one with a spy on the wire.
     const start = 1_700_000_000_000

--- a/packages/daemon/src/cp/agentmsg-retry.ts
+++ b/packages/daemon/src/cp/agentmsg-retry.ts
@@ -1,0 +1,48 @@
+// The SOURCE side of the retryable `rd/agentmsg` verdict (#987): a pool target is briefly addressable by
+// nobody (grant → confirming digest; lapsed lease → claim), the relay/target answer `not_ready` and cache
+// nothing, so ONE deliveryId is re-sent with backoff for a few lease horizons, then the last `not_ready`
+// is terminal. Exactly-once holds because the id never changes: a landed attempt replays from the target's dedup.
+import { isRetryableAgentMsgAck, type RdAgentMsg, type RdAgentMsgAck } from '@agentconnect.md/protocol'
+import { Backoff, type Clock } from '@agentconnect.md/connection'
+
+/** Bounded retry policy: total window plus the backoff bounds of the delays inside it. */
+export interface AgentMsgRetryPolicy {
+  windowMs: number
+  baseMs: number
+  capMs: number
+}
+
+/** Three lease horizons (`DUTY_LEASE_DEFAULTS.leaseMs` = 120s) — covers lapse + claim + install + digest. */
+export const AGENTMSG_NOT_READY_RETRY: AgentMsgRetryPolicy = { windowMs: 360_000, baseMs: 1_000, capMs: 15_000 }
+
+export interface SendAgentMsgUntilReadyDeps {
+  send: (payload: RdAgentMsg) => Promise<RdAgentMsgAck>
+  clock: Clock
+  policy?: AgentMsgRetryPolicy
+  /** Backoff jitter in [0,1); tests inject `() => 0`. */
+  jitter?: () => number
+  onRetry?: (attempt: number, delayMs: number) => void
+}
+
+/** Send `payload` and re-send the SAME deliveryId while the verdict is `not_ready`, bounded by the policy window. */
+export async function sendAgentMsgUntilReady(
+  payload: RdAgentMsg,
+  deps: SendAgentMsgUntilReadyDeps
+): Promise<RdAgentMsgAck> {
+  const policy = deps.policy ?? AGENTMSG_NOT_READY_RETRY
+  const backoff = new Backoff({
+    baseMs: policy.baseMs,
+    capMs: policy.capMs,
+    ...(deps.jitter ? { jitter: deps.jitter } : {})
+  })
+  const deadline = deps.clock.now() + policy.windowMs
+  for (let attempt = 1; ; attempt += 1) {
+    const ack = await deps.send(payload)
+    if (!isRetryableAgentMsgAck(ack)) return ack
+    const delay = backoff.next()
+    // The next attempt would land past the window: the verdict is terminal now.
+    if (deps.clock.now() + delay > deadline) return ack
+    deps.onRetry?.(attempt, delay)
+    await new Promise<void>((resolve) => deps.clock.setTimeout(resolve, delay))
+  }
+}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -308,6 +308,7 @@ import { nodeExecArgvModuleEntries } from './runtimes/node-exec-argv.js'
 import { makeLogger, type Logger } from './log.js'
 import { CpClient, CP_SUBPROTOCOL, CP_WS_PATH, type BootstrapUpgradeOutcome } from './cp/client.js'
 import { RelayManager } from './cp/relay-manager.js'
+import { sendAgentMsgUntilReady } from './cp/agentmsg-retry.js'
 import { CP_IDENTITY_TOKEN_PATH, readClusterIdentityToken } from './cp/cluster-identity.js'
 import { CpCollabRoutes, isSyntheticA2aChannel } from './cp/cp-collab-routes.js'
 import { ClientTransport, systemClock, type Clock, type TimerHandle } from '@agentconnect.md/connection'
@@ -347,6 +348,7 @@ import {
   WireFeishuCardActionEvent,
   gitRepoLabel,
   hasReachedAgentCallHopLimit,
+  RD_AGENTMSG_NOT_READY,
   normalizeGitCloneUrl,
   normalizeGithubRepoUrl,
   MAX_AGENT_CALL_HOPS,
@@ -8731,9 +8733,10 @@ export class Daemon {
 
     const { platform, channel, thread } = msg.coords
 
-    // The target must actually be a local agent (the relay resolved it to us, but we
-    // don't trust that blindly — this is the placement authority for OUR agents).
-    if (!this.agents.get(msg.toAgentId)) return record(nak('not_found'))
+    // Local placement authority: an agent the directory knows but we do not run is a stale route → retryable, uncached; unknown everywhere → terminal.
+    if (!this.agents.get(msg.toAgentId)) {
+      return this.cpCollab.agent(msg.toAgentId) ? nak(RD_AGENTMSG_NOT_READY) : record(nak('not_found'))
+    }
 
     // TERMINAL-VERIFY against the local collaboration snapshot (§2.5 #4), now ORG-scoped
     // rather than (org, channel)-scoped: the relay's asserted org must be the org this
@@ -8741,8 +8744,14 @@ export class Daemon {
     // caller→target. Channel is only the session coordinate here (A2A is postless, #854), so
     // a caller and target that share no channel — or a target with no IM integration at all —
     // is legitimate. Missing snapshot / unknown agent ⇒ fail closed, as before.
-    if (this.cpCollab.orgForAgent(msg.toAgentId) !== msg.orgId) {
-      this.log.warn(`relay: rd/agentmsg/fwd terminal-verify failed (no placement) for ${msg.toAgentId} — fail closed`)
+    const targetOrg = this.cpCollab.orgForAgent(msg.toAgentId)
+    // Our directory copy may still be catching up with the grant: refuse retryably, uncached.
+    if (targetOrg === undefined) {
+      this.log.info(`relay: rd/agentmsg/fwd not_ready — ${msg.toAgentId} is not in this daemon's directory yet`)
+      return nak(RD_AGENTMSG_NOT_READY)
+    }
+    if (targetOrg !== msg.orgId) {
+      this.log.warn(`relay: rd/agentmsg/fwd terminal-verify failed (org mismatch) for ${msg.toAgentId} — fail closed`)
       return record(nak('not_allowed'))
     }
     if (!this.cpCollab.admits(msg.trustedFromAgentId, msg.toAgentId)) {
@@ -10131,37 +10140,49 @@ export class Daemon {
     if (!this.relays) {
       return { delivered: false, targetSession: ctx.targetSession, reason: 'not_local' }
     }
+    const relays = this.relays
     try {
-      const ack = await this.relays.sendAgentMsg({
-        claimedFromAgentId: req.callerAgentId,
-        // Tighten-only privacy hint for the remote child's capture gate (§5.1).
-        ...(ctx.originSessionId !== undefined && this.store.isCaptureExcluded(req.callerAgentId, ctx.originSessionId)
-          ? { parentPrivate: true }
-          : {}),
-        toAgentId: req.toAgentId,
-        text: req.text,
-        coords: {
-          platform: ctx.platform,
-          channel: ctx.channel,
-          ...(ctx.thread !== undefined ? { thread: ctx.thread } : {})
+      // #987: `not_ready` re-sends the SAME deliveryId for a bounded window; only a terminal verdict is recorded below.
+      const ack = await sendAgentMsgUntilReady(
+        {
+          claimedFromAgentId: req.callerAgentId,
+          // Tighten-only privacy hint for the remote child's capture gate (§5.1).
+          ...(ctx.originSessionId !== undefined && this.store.isCaptureExcluded(req.callerAgentId, ctx.originSessionId)
+            ? { parentPrivate: true }
+            : {}),
+          toAgentId: req.toAgentId,
+          text: req.text,
+          coords: {
+            platform: ctx.platform,
+            channel: ctx.channel,
+            ...(ctx.thread !== undefined ? { thread: ctx.thread } : {})
+          },
+          ...(ctx.correlationId !== undefined ? { correlationId: ctx.correlationId } : {}),
+          hopCount: ctx.sourceHopCount,
+          deliveryId: ctx.deliveryId,
+          // Visible-post ts (if this wake was a `toAgent`+`channel` send) so the remote target
+          // dedups the wake against the post it fetches from the shared thread and keeps a
+          // canonical read cursor — same guarantee as the same-daemon path.
+          ...(req.transcriptTs !== undefined ? { transcriptTs: req.transcriptTs } : {}),
+          ...(ctx.originSessionId !== undefined ? { originSessionId: ctx.originSessionId } : {}),
+          ...(ctx.originCoords !== undefined ? { originCoords: ctx.originCoords } : {}),
+          ...(ctx.externalOrigin !== undefined ? { externalOrigin: ctx.externalOrigin } : {}),
+          ...(ctx.lineageReplyTo !== undefined ? { lineageReplyTo: ctx.lineageReplyTo } : {}),
+          // §5.4: ask the remote child to report its outcome back into our origin session. Gated on
+          // having an origin for exactly the reason the local path is — there is nothing to report to
+          // without one, and the target ignores it in that case anyway.
+          ...(req.needsReply === true && ctx.originSessionId !== undefined ? { needsReply: true } : {}),
+          ...(ctx.deliveryKind !== undefined ? { deliveryKind: ctx.deliveryKind } : {})
         },
-        ...(ctx.correlationId !== undefined ? { correlationId: ctx.correlationId } : {}),
-        hopCount: ctx.sourceHopCount,
-        deliveryId: ctx.deliveryId,
-        // Visible-post ts (if this wake was a `toAgent`+`channel` send) so the remote target
-        // dedups the wake against the post it fetches from the shared thread and keeps a
-        // canonical read cursor — same guarantee as the same-daemon path.
-        ...(req.transcriptTs !== undefined ? { transcriptTs: req.transcriptTs } : {}),
-        ...(ctx.originSessionId !== undefined ? { originSessionId: ctx.originSessionId } : {}),
-        ...(ctx.originCoords !== undefined ? { originCoords: ctx.originCoords } : {}),
-        ...(ctx.externalOrigin !== undefined ? { externalOrigin: ctx.externalOrigin } : {}),
-        ...(ctx.lineageReplyTo !== undefined ? { lineageReplyTo: ctx.lineageReplyTo } : {}),
-        // §5.4: ask the remote child to report its outcome back into our origin session. Gated on
-        // having an origin for exactly the reason the local path is — there is nothing to report to
-        // without one, and the target ignores it in that case anyway.
-        ...(req.needsReply === true && ctx.originSessionId !== undefined ? { needsReply: true } : {}),
-        ...(ctx.deliveryKind !== undefined ? { deliveryKind: ctx.deliveryKind } : {})
-      })
+        {
+          send: (payload) => relays.sendAgentMsg(payload),
+          clock: this.clock,
+          onRetry: (attempt, delayMs) =>
+            this.log.info(
+              `messageAgent: ${req.toAgentId} not routable yet (attempt ${attempt}) — retrying delivery ${ctx.deliveryId} in ${delayMs}ms`
+            )
+        }
+      )
       // §5.4: prefer the CANONICAL key the target computed — its transport scope depends on the
       // reply integration the relay chose, which we cannot derive. Fall back to our own guess only
       // for an older target daemon that returns none (it then simply won't be followable).

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -208,8 +208,9 @@ export interface MessageAgentReq {
 }
 
 /** The result of an agent→agent delivery. `delivered:false` carries a typed `reason`
- *  (`self` / `invalid_target` / `not_allowed` / `not_local` / `no_agent`). `targetSession` is the local
- *  session key the message was (or would be) delivered into. */
+ *  (`self` / `invalid_target` / `not_allowed` / `not_local` / `no_agent`, or a cross-daemon
+ *  verdict such as `not_ready` — a target nobody could be addressed at within the retry
+ *  window). `targetSession` is the local session key the message was (or would be) delivered into. */
 export interface MessageAgentResult {
   delivered: boolean
   targetSession: string
@@ -305,6 +306,7 @@ export interface ReplyToSessionResult {
     | 'queue_full'
     | 'not_allowed'
     | 'unsupported'
+    | 'not_ready'
 }
 
 /** One subtask of a {@link StartOrchestrationReq}: an instruction for one worker. */

--- a/packages/daemon/test/agentmsg-retry.test.ts
+++ b/packages/daemon/test/agentmsg-retry.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest'
+import { FakeClock } from '@agentconnect.md/connection'
+import type { RdAgentMsg, RdAgentMsgAck } from '@agentconnect.md/protocol'
+import { sendAgentMsgUntilReady, AGENTMSG_NOT_READY_RETRY } from '../src/cp/agentmsg-retry.js'
+
+const payload: RdAgentMsg = {
+  claimedFromAgentId: '00000000-0000-0000-0000-00000000000a',
+  toAgentId: '00000000-0000-0000-0000-00000000000b',
+  text: 'hi',
+  coords: { platform: 'slack', channel: 'C1' },
+  hopCount: 0,
+  deliveryId: 'd-1'
+}
+const notReady: RdAgentMsgAck = { deliveryId: 'd-1', delivered: false, reason: 'not_ready' }
+const delivered: RdAgentMsgAck = { deliveryId: 'd-1', delivered: true, childSessionId: 'k' }
+
+/** Drive the loop against a scripted sequence of verdicts; time only moves through the fake clock. */
+function run(verdicts: RdAgentMsgAck[], policy = { windowMs: 60_000, baseMs: 1_000, capMs: 8_000 }) {
+  const clock = new FakeClock(1_000_000)
+  const send = vi.fn(async () => verdicts[Math.min(send.mock.calls.length - 1, verdicts.length - 1)]!)
+  const retries: number[] = []
+  const done = sendAgentMsgUntilReady(payload, {
+    send,
+    clock,
+    policy,
+    jitter: () => 0,
+    onRetry: (_attempt, delayMs) => retries.push(delayMs)
+  })
+  return { clock, send, retries, done }
+}
+
+/** Advance the fake clock a second at a time (every delay here is whole seconds) until the loop settles. */
+async function settle(clock: FakeClock, done: Promise<unknown>, maxSteps = 200): Promise<void> {
+  let settled = false
+  void done.then(
+    () => (settled = true),
+    () => (settled = true)
+  )
+  const flush = () => new Promise<void>((resolve) => setImmediate(resolve))
+  for (let i = 0; i < maxSteps && !settled; i += 1) {
+    await flush()
+    if (settled) break
+    if (clock.pending > 0) clock.advance(1_000)
+    await flush()
+  }
+}
+
+describe('sendAgentMsgUntilReady (rd/agentmsg install-window retry, #987)', () => {
+  it('returns a terminal verdict at once — nothing is retried, no timer armed', async () => {
+    const { clock, send, done } = run([{ deliveryId: 'd-1', delivered: false, reason: 'not_found' }])
+    await expect(done).resolves.toMatchObject({ reason: 'not_found' })
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(clock.pending).toBe(0)
+  })
+
+  it('re-sends the SAME deliveryId with exponential backoff while not_ready, and returns the admission', async () => {
+    const { clock, send, retries, done } = run([notReady, notReady, notReady, delivered])
+    await settle(clock, done)
+    await expect(done).resolves.toEqual(delivered)
+    expect(send).toHaveBeenCalledTimes(4)
+    for (const call of send.mock.calls) expect((call as unknown[])[0]).toBe(payload)
+    expect(retries).toEqual([1_000, 2_000, 4_000])
+  })
+
+  it('caps the delay and gives up at the window: the last not_ready becomes the terminal verdict', async () => {
+    const { clock, send, retries, done } = run([notReady], { windowMs: 30_000, baseMs: 1_000, capMs: 8_000 })
+    await settle(clock, done)
+    await expect(done).resolves.toEqual(notReady)
+    // 1+2+4+8+8 = 23s of waiting fits inside 30s; the next 8s step would cross the window.
+    expect(retries).toEqual([1_000, 2_000, 4_000, 8_000, 8_000])
+    expect(send).toHaveBeenCalledTimes(6)
+    expect(clock.now() - 1_000_000).toBe(23_000)
+  })
+
+  it('a verdict that lands mid-window ends the loop even after several misses', async () => {
+    const { clock, send, done } = run([
+      notReady,
+      notReady,
+      { deliveryId: 'd-1', delivered: false, reason: 'not_allowed' }
+    ])
+    await settle(clock, done)
+    await expect(done).resolves.toMatchObject({ reason: 'not_allowed' })
+    expect(send).toHaveBeenCalledTimes(3)
+  })
+
+  it('the default window spans a few lease horizons', () => {
+    expect(AGENTMSG_NOT_READY_RETRY.windowMs).toBeGreaterThanOrEqual(3 * 120_000)
+    expect(AGENTMSG_NOT_READY_RETRY.capMs).toBeLessThan(AGENTMSG_NOT_READY_RETRY.windowMs)
+  })
+})

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -3,7 +3,9 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
+import { FakeClock } from '@agentconnect.md/connection'
 import { Daemon } from '../src/daemon.js'
+import { AGENTMSG_NOT_READY_RETRY } from '../src/cp/agentmsg-retry.js'
 import { executeTool, type MessageAgentReq } from '../src/mcp/ops.js'
 import { sessionKey } from '../src/store/local-store.js'
 import * as monotonic from '../src/store/monotonic-ts.js'
@@ -907,6 +909,54 @@ describe('messageAgent: cross-daemon routing (P2, source side)', () => {
     await daemon.stop()
   })
 
+  it('re-sends the SAME deliveryId while the relay answers not_ready, then returns the admission (#987)', async () => {
+    const root = scaffold([{ id: 'bot-a' }])
+    const { daemon, call } = await bootWithDispatchSpy(root)
+    const clock = new FakeClock(1_000_000)
+    ;(daemon as any).clock = clock
+    const sent: any[] = []
+    ;(daemon as any).relays = {
+      stop: vi.fn(async () => {}),
+      sendAgentMsg: vi.fn(async (p: any) => {
+        sent.push(p)
+        return sent.length < 3
+          ? { deliveryId: p.deliveryId, delivered: false, reason: 'not_ready' }
+          : { deliveryId: p.deliveryId, delivered: true, childSessionId: 'remote-key' }
+      })
+    }
+    const pending = call(baseReq({ toAgentId: 'bot-b' }))
+    // Each miss parks the loop on a backoff timer; fire them one at a time.
+    for (let i = 0; i < 2; i += 1) {
+      await vi.waitFor(() => expect(clock.pending).toBe(1), WAIT)
+      clock.advance(60_000)
+    }
+    const res = await pending
+    expect(res).toMatchObject({ delivered: true, targetSession: 'remote-key' })
+    expect(sent).toHaveLength(3)
+    expect(new Set(sent.map((p) => p.deliveryId)).size).toBe(1)
+    await daemon.stop()
+  })
+
+  it('a not_ready that outlasts the retry window is recorded as the terminal verdict', async () => {
+    const root = scaffold([{ id: 'bot-a' }])
+    const { daemon, call } = await bootWithDispatchSpy(root)
+    const clock = new FakeClock(1_000_000)
+    ;(daemon as any).clock = clock
+    const sendAgentMsg = vi.fn(async (p: any) => ({ deliveryId: p.deliveryId, delivered: false, reason: 'not_ready' }))
+    ;(daemon as any).relays = { stop: vi.fn(async () => {}), sendAgentMsg }
+    const pending = call(baseReq({ toAgentId: 'bot-b' }))
+    // Jumping past the whole window makes the next backoff step cross the deadline: terminal.
+    await vi.waitFor(() => expect(clock.pending).toBe(1), WAIT)
+    clock.advance(AGENTMSG_NOT_READY_RETRY.windowMs)
+    const res = await pending
+    expect(res).toMatchObject({ delivered: false, reason: 'not_ready' })
+    expect(sendAgentMsg).toHaveBeenCalledTimes(2)
+    // Recorded like every other terminal verdict: the same deliveryId replays it, no re-send.
+    const deliveryId = sendAgentMsg.mock.calls[0]![0].deliveryId
+    expect((daemon as any).agentCallDeliveries.get(deliveryId)).toMatchObject({ reason: 'not_ready' })
+    await daemon.stop()
+  })
+
   it('no READY relay (send throws) → delivered:false reason offline', async () => {
     const root = scaffold([{ id: 'bot-a' }])
     const { daemon, call } = await bootWithDispatchSpy(root)
@@ -1284,14 +1334,23 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     await daemon.stop()
   })
 
-  it('fails closed when the local snapshot has no placement (defense in depth)', async () => {
+  it('refuses retryably (not_ready) when the local snapshot does not know the target yet, and terminally on an org mismatch', async () => {
     const root = scaffold([{ id: 'bot-b' }])
     const { daemon, calls } = await bootWithDispatchSpy(root)
-    // Empty snapshot → terminal-verify cannot confirm the caller/target directory entries.
-    ;(daemon as any).cpCollab.replace({ generation: 2, channels: [], agents: [] })
+    // Empty snapshot → terminal-verify cannot confirm the target's org: our copy of the
+    // directory may simply be behind the grant, so this is the retryable miss, not a refusal.
+    ;(daemon as any).cpCollab.replace({ generation: 0, channels: [], agents: [] })
     const ack = await (daemon as any).handleRelayAgentMsg(fwd())
-    expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(ack).toMatchObject({ delivered: false, reason: 'not_ready' })
     expect(calls).toHaveLength(0)
+    // ...and it is NOT cached: once the snapshot lands, the SAME deliveryId dispatches.
+    withSnapshot(daemon)
+    expect(await (daemon as any).handleRelayAgentMsg(fwd())).toMatchObject({ delivered: true })
+    expect(calls).toHaveLength(1)
+    // A directory that names a DIFFERENT org for the target is the terminal, cached refusal.
+    const mismatch = await (daemon as any).handleRelayAgentMsg(fwd({ deliveryId: 'd-2', orgId: 'org-other' }))
+    expect(mismatch).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(calls).toHaveLength(1)
     await daemon.stop()
   })
 
@@ -1484,12 +1543,24 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     await daemon.stop()
   })
 
-  it('target not a local agent → NAK not_found', async () => {
+  it('target known to the directory but not local → NAK not_ready (a stale route, re-routed by the retry)', async () => {
     const root = scaffold([{ id: 'bot-x' }]) // bot-b not local
     const { daemon } = await bootWithDispatchSpy(root)
     withSnapshot(daemon)
     const ack = await (daemon as any).handleRelayAgentMsg(fwd())
+    expect(ack).toMatchObject({ delivered: false, reason: 'not_ready' })
+    // Not cached: the same deliveryId is re-evaluated (still not local here, so still not_ready).
+    expect((daemon as any).relayAgentMsgAcks.has(`bot-a:${fwd().deliveryId}`)).toBe(false)
+    await daemon.stop()
+  })
+
+  it('target unknown to the directory AND not local → NAK not_found (terminal, cached)', async () => {
+    const root = scaffold([{ id: 'bot-x' }])
+    const { daemon } = await bootWithDispatchSpy(root)
+    withSnapshot(daemon)
+    const ack = await (daemon as any).handleRelayAgentMsg(fwd({ toAgentId: 'bot-nowhere' }))
     expect(ack).toMatchObject({ delivered: false, reason: 'not_found' })
+    expect((daemon as any).relayAgentMsgAcks.has(`bot-a:${fwd().deliveryId}`)).toBe(true)
     await daemon.stop()
   })
 

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -2048,6 +2048,27 @@ describe('collaboration/routes snapshot', () => {
     expect(r.frame.payload.agents).toEqual([])
   })
 
+  // A PENDING entry: the agent exists and its policy is authoritative, but no member is
+  // addressable for it yet (an unconfirmed pool grant / a lapsed lease). Only the flat
+  // directory may carry one; a channel row still names its daemon.
+  it('decodes a flat agent entry with no daemonId as pending, and keeps channel rows strict', () => {
+    const r = decodeEnvelope(
+      envelope('collaboration/routes', {
+        agents: [{ agentId: AGENT_ID, orgId: ORG_ID, callPolicy: 'selected', allowedCallerAgentIds: [LAUNCH_ID] }]
+      })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok || !isFrame('collaboration/routes')(r.frame)) throw new Error('expected collaboration/routes')
+    expect(r.frame.payload.agents[0]!.daemonId).toBeUndefined()
+    expect(r.frame.payload.agents[0]!.allowedCallerAgentIds).toEqual([LAUNCH_ID])
+    const channelRow = decodeEnvelope(
+      envelope('collaboration/routes', {
+        channels: [{ orgId: ORG_ID, platform: 'slack', channelId: 'C1', agents: [{ agentId: AGENT_ID }] }]
+      })
+    )
+    expect(channelRow.ok).toBe(false)
+  })
+
   // orgId is required on a flat entry — cross-org authorization has no fallback scope.
   it('rejects a flat agent entry without orgId', () => {
     const r = decodeEnvelope(envelope('collaboration/routes', { agents: [{ agentId: AGENT_ID, daemonId: DAEMON_ID }] }))

--- a/packages/protocol/src/frames/collab.ts
+++ b/packages/protocol/src/frames/collab.ts
@@ -84,7 +84,11 @@ export type CollabAgentPlacement = z.infer<typeof CollabAgentPlacement>
 export const CollabOrgAgent = CollabAgentPlacement.extend({
   // Org ids are opaque strings (see CollabChannelRoute) — carried per entry because
   // the flat list is not nested under an org-keyed parent. Cross-org pairs never resolve.
-  orgId: z.string().min(1)
+  orgId: z.string().min(1),
+  // The member a wake is forwarded to. ABSENT ⇒ PENDING: the agent exists, its policy is authoritative, but
+  // no member is addressable yet (unconfirmed pool grant / lapsed lease) → `not_ready`, not `not_found`.
+  // Only this flat directory carries pending entries; `channels[]` never does.
+  daemonId: z.string().uuid().optional()
 })
 export type CollabOrgAgent = z.infer<typeof CollabOrgAgent>
 

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -9,6 +9,8 @@ import {
   RdAgentMsg,
   RdAgentMsgAck,
   RdAgentMsgFwd,
+  RD_AGENTMSG_NOT_READY,
+  isRetryableAgentMsgAck,
   RdSlackAction,
   MAX_AGENT_CALL_HOPS,
   hasReachedAgentCallHopLimit,
@@ -769,6 +771,17 @@ describe('relay↔daemon wire — union separation (§8 standalone frame union)'
     for (const t of RELAY_DAEMON_FRAME_TYPES) expect(isRelayDaemonFrameType(t)).toBe(true)
     expect(isRelayDaemonFrameType('webchat/output')).toBe(false)
     expect(isRelayDaemonFrameType('rc/verify')).toBe(false)
+  })
+})
+
+describe('RdAgentMsgAck — the retryable not_ready verdict', () => {
+  it('parses not_ready and classifies only it as retryable', () => {
+    const ack = (over: Partial<RdAgentMsgAck>): RdAgentMsgAck =>
+      RdAgentMsgAck.parse({ deliveryId: 'd1', delivered: false, ...over })
+    expect(isRetryableAgentMsgAck(ack({ reason: RD_AGENTMSG_NOT_READY }))).toBe(true)
+    expect(isRetryableAgentMsgAck(ack({ reason: 'not_found' }))).toBe(false)
+    expect(isRetryableAgentMsgAck(ack({ reason: 'offline' }))).toBe(false)
+    expect(isRetryableAgentMsgAck(ack({ delivered: true }))).toBe(false)
   })
 })
 

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -663,6 +663,9 @@ export type RdAgentMsgFwd = z.infer<typeof RdAgentMsgFwd>
 // `offline` — the target IS reachable, it is simply too old to honor this delivery kind,
 // so the caller learns the reply was refused rather than having it land in the wrong
 // session.
+// `not_ready` is the one RETRYABLE verdict: the target is known but nobody is addressable for it YET (an
+// unconfirmed pool grant, a lapsed lease awaiting a claim, a lagging directory copy). No hop caches it
+// against the `deliveryId`; the SOURCE daemon re-sends the same id with backoff for a bounded window.
 export const RdAgentMsgReason = z.enum([
   'busy',
   'offline',
@@ -670,9 +673,13 @@ export const RdAgentMsgReason = z.enum([
   'not_allowed',
   'not_found',
   'hop_limit',
-  'unsupported'
+  'unsupported',
+  'not_ready'
 ])
 export type RdAgentMsgReason = z.infer<typeof RdAgentMsgReason>
+
+/** The retryable `rd/agentmsg/ack` reason — see {@link RdAgentMsgReason}. */
+export const RD_AGENTMSG_NOT_READY = 'not_ready' satisfies RdAgentMsgReason
 
 export const RdAgentMsgAck = z.object({
   deliveryId: z.string().min(1),
@@ -687,6 +694,11 @@ export const RdAgentMsgAck = z.object({
   childSessionId: z.string().min(1).optional()
 })
 export type RdAgentMsgAck = z.infer<typeof RdAgentMsgAck>
+
+/** Is this admission verdict one the sender should retry (same `deliveryId`) rather than record? */
+export function isRetryableAgentMsgAck(ack: Pick<RdAgentMsgAck, 'delivered' | 'reason'>): boolean {
+  return !ack.delivered && ack.reason === RD_AGENTMSG_NOT_READY
+}
 
 // ── webchat output stream (D→R) ──────────────────────────────────────────────
 

--- a/packages/relay/src/agent-msg-router.test.ts
+++ b/packages/relay/src/agent-msg-router.test.ts
@@ -23,7 +23,7 @@ const INT = '00000000-0000-0000-0000-0000000000f1'
 const noopLog = { info() {}, warn() {}, error() {}, debug() {} }
 
 /** An org-scoped directory entry (the flat `agents[]` shape) with policy defaults. */
-function orgAgent(over: Partial<CollabOrgAgent> & { agentId: string; daemonId: string }): CollabOrgAgent {
+function orgAgent(over: Partial<CollabOrgAgent> & { agentId: string }): CollabOrgAgent {
   return {
     orgId: ORG,
     callPolicy: 'all',
@@ -686,6 +686,95 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     const ack = await route(D1, baseMsg())
     expect(ack.delivered).toBe(false)
     expect(ack.reason).toBe('not_found')
+  })
+
+  // The install window (#987): the CP carries a pool agent whose grant is not confirmed (or whose
+  // lapsed lease a live member is about to claim) as a PENDING entry — present, policy intact, no
+  // daemon. The verdict is the retryable `not_ready`, and it is NOT cached: the source re-sends the
+  // same deliveryId, and once the directory names the member the retransmit is forwarded — once.
+  it('PENDING target (directory entry with no daemon) → NAK not_ready, uncached; the retransmit forwards once the member is named', async () => {
+    const pending = snap()
+    pending.agents = pending.agents.map((a) => (a.agentId === B ? orgAgent({ agentId: B }) : a))
+    pending.channels[0].agents = pending.channels[0].agents.filter((a) => a.agentId !== B)
+    const router = new CollaborationRouter()
+    router.replace(pending)
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+    const first = await route(D1, baseMsg())
+    expect(first).toEqual({ deliveryId: 'd-1', delivered: false, reason: 'not_ready' })
+    // Still pending: re-evaluated, still not_ready, still nothing forwarded.
+    expect(await route(D1, baseMsg())).toEqual(first)
+    expect(forwards).toHaveLength(0)
+
+    // The member confirms; the CP re-pushes with B routable at D2. Same deliveryId → forwarded.
+    router.replace({ ...snap(), generation: 2 })
+    const retry = await route(D1, baseMsg())
+    expect(retry.delivered).toBe(true)
+    expect(forwards).toHaveLength(1)
+    // ...and THAT verdict is cached like any other: a further retransmit replays, no double wake.
+    expect(await route(D1, baseMsg())).toEqual(retry)
+    expect(forwards).toHaveLength(1)
+  })
+
+  it('PENDING target still fails policy terminally — a refusal is not deferred behind not_ready', async () => {
+    const pending = snap()
+    pending.agents = pending.agents.map((a) =>
+      a.agentId === B ? orgAgent({ agentId: B, callPolicy: 'selected', allowedCallerAgentIds: [] }) : a
+    )
+    const router = new CollaborationRouter()
+    router.replace(pending)
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, []),
+      log: noopLog
+    })
+    expect((await route(D1, baseMsg())).reason).toBe('not_allowed')
+  })
+
+  it('PENDING caller (no confirmed member to bind the socket to) → NAK not_ready, not forged', async () => {
+    const pending = snap()
+    pending.agents = pending.agents.map((a) => (a.agentId === A ? orgAgent({ agentId: A }) : a))
+    const router = new CollaborationRouter()
+    router.replace(pending)
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+    expect(await route(D1, baseMsg())).toEqual({ deliveryId: 'd-1', delivered: false, reason: 'not_ready' })
+    expect(forwards).toHaveLength(0)
+    router.replace({ ...snap(), generation: 2 })
+    expect((await route(D1, baseMsg())).delivered).toBe(true)
+  })
+
+  it('a target daemon answering not_ready is passed through uncached, so the retransmit is re-forwarded', async () => {
+    const router = new CollaborationRouter()
+    router.replace(snap())
+    const forwards: RdAgentMsgFwd[] = []
+    let verdict: RdAgentMsgAck = { deliveryId: 'd-1', delivered: false, reason: 'not_ready' }
+    const conn = {
+      supports: () => true,
+      forwardAgentMsg: vi.fn(async (fwd: RdAgentMsgFwd) => {
+        forwards.push(fwd)
+        return verdict
+      })
+    }
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => ({ get: (id: string) => (id === D2 ? conn : undefined) }) as unknown as RelayDaemonServer,
+      log: noopLog
+    })
+    expect((await route(D1, baseMsg())).reason).toBe('not_ready')
+    verdict = { deliveryId: 'd-1', delivered: true }
+    expect((await route(D1, baseMsg())).delivered).toBe(true)
+    expect(forwards).toHaveLength(2)
+    expect((await route(D1, baseMsg())).delivered).toBe(true)
+    expect(forwards).toHaveLength(2)
   })
 
   it('target owning daemon offline (no connection) → NAK offline', async () => {

--- a/packages/relay/src/agent-msg-router.ts
+++ b/packages/relay/src/agent-msg-router.ts
@@ -27,14 +27,20 @@
  *     channel assertion) to the owning daemon and relay its admission verdict back.
  *
  * Per-hop dedup on the stable `deliveryId` (§6.4): a retransmit of the same deliveryId
- * replays the prior verdict without a second forward (no double-wake).
+ * replays the prior verdict without a second forward (no double-wake). The one verdict
+ * NEVER cached is the retryable `not_ready` — a PENDING directory entry (a pool member
+ * holding an unconfirmed grant, or a lapsed lease a live member is about to claim), or
+ * the target daemon answering it — so the SOURCE daemon's bounded retry of the same
+ * deliveryId is re-evaluated against the current directory instead of replaying a miss.
  *
- * FOLLOW-UP (P2 scope-down): retransmit/retry is NOT implemented — this is ACK/NAK +
- * per-hop dedup + the 5s correlator timeout (the forward's `rd/agentmsg/fwd` inherits
- * the connection's ACK_TIMEOUT_MS). Documented in the PR description.
+ * Retransmit for the other verdicts is NOT implemented — this is ACK/NAK + per-hop dedup
+ * + the 5s correlator timeout (the forward's `rd/agentmsg/fwd` inherits the connection's
+ * ACK_TIMEOUT_MS).
  */
 import {
   hasReachedAgentCallHopLimit,
+  isRetryableAgentMsgAck,
+  RD_AGENTMSG_NOT_READY,
   RD_HEADLESS_AGENT_DELIVERY_V1,
   type RdAgentMsg,
   type RdAgentMsgAck,
@@ -72,6 +78,7 @@ export function createAgentMsgRouter(deps: AgentMsgRouterDeps) {
     }
 
     const verdict = await route(fromDaemonId, msg)
+    if (isRetryableAgentMsgAck(verdict)) return verdict // not yet, not never — the retry must re-route
     if (seen.size >= 4000) seen.clear() // bound the dedup window
     seen.set(dedupKey, verdict)
     return verdict
@@ -84,6 +91,11 @@ export function createAgentMsgRouter(deps: AgentMsgRouterDeps) {
     // daemon — that daemon-ownership check, not channel membership, is what makes the claim
     // unforgeable. Org is bound from the caller's own entry (the frame carries no org).
     const caller = router.agent(msg.claimedFromAgentId)
+    // A PENDING caller (no confirmed member yet) binds to no socket: refuse retryably, not as forged.
+    if (caller && caller.daemonId === undefined) {
+      deps.log.info(`relay: rd/agentmsg not_ready — caller ${msg.claimedFromAgentId} has no confirmed member yet`)
+      return nak(msg.deliveryId, RD_AGENTMSG_NOT_READY)
+    }
     if (!caller || caller.daemonId !== fromDaemonId) {
       deps.log.warn(
         `relay: rd/agentmsg rejected — forged/unknown caller ${msg.claimedFromAgentId} on daemon ${fromDaemonId}`
@@ -148,6 +160,11 @@ export function createAgentMsgRouter(deps: AgentMsgRouterDeps) {
     if (hasReachedAgentCallHopLimit(hopCount)) return nak(msg.deliveryId, 'hop_limit')
 
     // (f) Resolve the owning daemon connection and forward with a TRUSTED caller claim.
+    // A PENDING target (authorized, no member confirmed yet) is the retryable miss the source re-sends.
+    if (target.daemonId === undefined) {
+      deps.log.info(`relay: rd/agentmsg not_ready — target ${msg.toAgentId} has no confirmed member yet`)
+      return nak(msg.deliveryId, RD_AGENTMSG_NOT_READY)
+    }
     const conn = deps.daemons()?.get(target.daemonId)
     if (!conn) return nak(msg.deliveryId, 'offline')
 


### PR DESCRIPTION
## Summary

Closes the residual of #987: on the daemon pool, a cross-daemon peer wake (`rd/agentmsg`) that arrives while a set agent is not routable *yet* was refused with a **terminal** verdict that every hop cached per `deliveryId`. This PR gives the wire a **retryable** verdict, teaches the directory to name the "not yet" state, and makes the source daemon re-send the same delivery with backoff for a bounded window.

## Failure scenario

1. A pool member retires (rollout) or dies. The agent's group is released or lapses.
2. A successor claims it on its heartbeat. Its `duty/grant` is applied only after the install succeeds, and the CP publishes the member as routable only once the member's digest confirms the grant (#976 shape) — so for one install window `routableDaemons` names **nobody**.
3. Platform ingress copes (the trigger reaches a member and claims through the activation rendezvous). A peer wake does not: the target is absent from the peer directory, so the source daemon's `admits()` fails closed (`not_allowed`), or — had the installing member been named — the relay/target would answer `not_found`. Both were **terminal and cached** against the `deliveryId`, so even a retransmit stayed dead after the member was ready.

## Design

- **protocol** — `rd/agentmsg/ack` gains one retryable reason, `not_ready` (`RD_AGENTMSG_NOT_READY`, `isRetryableAgentMsgAck`). The flat directory entry `CollabOrgAgent.daemonId` becomes optional: an entry with no daemon is **pending** — the agent exists and its policy is authoritative, but no member is addressable yet. `channels[]` rows are unchanged (still require a daemon). Optional-field change; both peers consume `@agentconnect.md/protocol`.
- **control plane** — `PlacementResolver.resolveDirectory` now has three outcomes per row: routable (confirmed member), **pending** (`daemonId: null` — a set agent a member holds unconfirmed, or a lapsed one a live member can claim; liveness read once per set), or dropped (nothing serves it and nothing can). `buildCollabSnapshot` carries pending rows without a daemon; the register baseline always resolves through the resolver (`PLACEMENT_ONLY` when there is no ledger) so it is the only producer of that shape.
- **relay** — a pending target (or a pending caller, which cannot be bound to its socket yet) answers `not_ready` **after** the terminal policy checks, so a genuine refusal is never deferred behind it. `not_ready` is the one verdict the per-hop dedup never caches; a target daemon's `not_ready` is passed through uncached as well.
- **daemon (target)** — an agent the org directory knows but this daemon does not run is a stale route (released, or still installing) → `not_ready`, uncached; a snapshot that does not know the agent yet → `not_ready`, uncached; unknown everywhere stays `not_found`, and an org mismatch stays `not_allowed` (both cached, as before).
- **daemon (source)** — `sendAgentMsgUntilReady` re-sends the **same** `deliveryId` while the verdict is `not_ready`, exponential backoff 1 s → 15 s cap, window 360 s (three lease horizons: lapse + claim + install + confirming digest); when the next step would cross the window the last `not_ready` is returned and recorded as terminal like any other refusal. Exactly-once holds because the id never changes: an attempt that actually landed replays from the target's dedup on every later attempt.
- Left alone on purpose: outboxes, the k8s driver, boot recovery, hook code. A directory that still names a *dead but not yet lapsed* holder keeps answering `offline` at the relay (a machine-placed offline peer must not block a caller for minutes); the drain release kicks the directory to pending immediately in a rollout, so that case is bounded by the un-drained-death lapse.

### Webchat continuation after a rollout (the 2026-08-16 comment on #987)

Not the same seam, and deliberately **not** touched here. Continuing an existing webchat session pinned to a retired member fails in `webchatVerification`'s continuation gate (`session.daemonId !== dispatchDaemon(agent)` → `continuation unavailable`, surfaced as "Connection error"), because session content is daemon-local by contract. That is a content-ownership question for a pool successor (whether the shared data plane lets a successor continue the recorded session), not a delivery verdict cached per `deliveryId`, so it needs its own change.

## Test plan

- [x] protocol: `not_ready` parses and is the only retryable verdict; a flat entry decodes without `daemonId` while a channel row still rejects it
- [x] control-plane unit: `PlacementResolver.resolveDirectory` — routable / pending (unconfirmed hold; lapsed with a live member) / dropped; liveness read once per set; machine placement and unplaced rows unchanged
- [x] control-plane integration (`duty-lease.handler`): grant issued, digest not yet confirmed ⇒ the directory row is present with `daemonId: null`; confirmed ⇒ names the member (Postgres via Testcontainers)
- [x] relay: pending target ⇒ `not_ready`, uncached, the retransmit forwards once the member is named and *that* verdict is cached (no double wake); pending target still fails policy terminally; pending caller ⇒ `not_ready`, not forged; a target daemon's `not_ready` is passed through uncached
- [x] daemon: retry loop unit tests (terminal at once; same deliveryId with 1/2/4 s backoff then admission; cap + window ⇒ last `not_ready` terminal; a mid-window terminal verdict ends the loop; default window ≥ 3 lease horizons); target side (`not_ready` for known-not-local and for a lagging snapshot, uncached and re-evaluated; `not_found` / org-mismatch stay terminal); source side through `messageAgent` with a fake clock (re-sends the same deliveryId, returns the admission; window expiry recorded as terminal)
- [x] `pnpm typecheck` for protocol / daemon / relay / control-plane, the touched suites (protocol, relay full, daemon `daemon-message-agent` + `agentmsg-retry`, CP unit + `duty-lease.handler` / `drain` / `register.handler` / `channel-agents` / `integration-channels` / `agents.move` / `agents.replication` / `hooks-pool-placement` / `served-agents.repo`), `pnpm lint`, `pnpm format:check`
