### PR TITLE
fix(control-plane): accept a hook completion from the member that serves the agent

### DIFF
--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2465,8 +2465,8 @@ export interface HookRepo {
     input: HookReviewAttemptInput
   ): Promise<HookReviewAttemptResult>
   recordReviewResult(hookId: HookId, reportingDaemonId: DaemonId, input: HookReviewResultInput): Promise<boolean>
-  /** Apply a daemon `hook/report` completion. Scoped: the hook's owning agent
-   *  must be placed on the REPORTING daemon. Last-writer-wins; a completion with
+  /** Apply a daemon `hook/report` completion. Scoped: the REPORTING daemon must be the run's
+   *  accepted dispatch target or serve its agent now. Last-writer-wins; a completion with
    *  no prior delivery row (rc/run-report lost) still creates one, with
    *  `startedAt` estimated as `at − durationMs`. Returns acceptance. */
   recordReport(hookId: HookId, reportingDaemonId: DaemonId, input: HookReportInput, at: Date): Promise<boolean>

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -398,6 +398,18 @@ function servedBy(
   return agentId !== null && agentId === authority.agentId && !!daemonId && authority.serving.includes(daemonId)
 }
 
+/** May `reportingDaemonId` close a run of `agentId` that was dispatched to `dispatchDaemonId`?
+ *  The accepted dispatch target is a provenance snapshot, not the fence: a pool member can be
+ *  retired mid-run, and the member that serves the agent afterwards reclaims the completion. */
+function mayReport(
+  authority: HookDispatchAuthority,
+  agentId: string | null,
+  reportingDaemonId: string,
+  dispatchDaemonId: string | null | undefined
+): boolean {
+  return dispatchDaemonId === reportingDaemonId || servedBy(authority, agentId, reportingDaemonId)
+}
+
 export class PgHookRepo implements HookRepo {
   constructor(
     private readonly db: PrismaLike,
@@ -1556,7 +1568,6 @@ export class PgHookRepo implements HookRepo {
           (r.agentId !== undefined && hook.agentId !== r.agentId) ||
           (r.configRevision !== undefined && hook.configRevision !== r.configRevision) ||
           (r.dispatchRevision !== undefined && hook.dispatchRevision !== r.dispatchRevision) ||
-          (r.dispatchDaemonId !== undefined && r.dispatchDaemonId !== reportingDaemonId) ||
           (r.reviewPolicySnapshot !== undefined && hook.reviewPolicy !== r.reviewPolicySnapshot) ||
           (r.reportingModeSnapshot !== undefined && hook.reportingMode !== r.reportingModeSnapshot) ||
           (r.gateModeSnapshot !== undefined && hook.gateMode !== r.gateModeSnapshot)
@@ -1634,7 +1645,7 @@ export class PgHookRepo implements HookRepo {
             r.reviewPolicySnapshot === undefined ||
             r.reportingModeSnapshot === undefined ||
             r.gateModeSnapshot === undefined ||
-            r.dispatchDaemonId !== reportingDaemonId ||
+            !mayReport(authority, run.agentId, reportingDaemonId, r.dispatchDaemonId) ||
             run.agentId !== r.agentId ||
             run.configRevision !== r.configRevision ||
             (run.event !== null && r.event !== undefined && run.event !== r.event) ||
@@ -1781,12 +1792,13 @@ export class PgHookRepo implements HookRepo {
             run.agentId !== r.agentId ||
             run.configRevision !== r.configRevision ||
             run.dispatchRevision !== r.dispatchRevision ||
-            run.dispatchDaemonId !== r.dispatchDaemonId ||
-            r.dispatchDaemonId !== reportingDaemonId)
+            run.dispatchDaemonId !== r.dispatchDaemonId)
         )
           return false
+        // The accepted dispatch target stays a provenance snapshot; who may close the row is the
+        // daemon that dispatched it or the one that serves its agent now.
         const acceptedDaemon = run.dispatchDaemonId
-        if (acceptedDaemon ? acceptedDaemon !== reportingDaemonId : false) return false
+        if (acceptedDaemon && !mayReport(authority, run.agentId, reportingDaemonId, acceptedDaemon)) return false
         if (!acceptedDaemon) {
           const current = await tx.hookDef.findUnique({ where: { id: hookId }, select: { agentId: true } })
           // Legacy HookRun rows predate the accepted dispatch tuple, but their

--- a/packages/control-plane/src/ws/handlers/hook-report.ts
+++ b/packages/control-plane/src/ws/handlers/hook-report.ts
@@ -4,8 +4,8 @@
  * A correlated REQ: the daemon's completion report for a hook
  * fire it received over the relay's rd/* wire — closes the `HookRun` row the
  * relay's `rc/run-report` opened. Same discipline as `cron/report`: the repo
- * write is scoped (the hook's owning agent must be placed on the REPORTING
- * daemon) and last-writer-wins (a late completion overwrites a reaped
+ * write is scoped (the REPORTING daemon must be the run's dispatch target or
+ * serve its agent now) and last-writer-wins (a late completion overwrites a reaped
  * `orphaned`). Unknown or foreign reports receive a permanent CONFLICT so the
  * daemon can dead-letter its durable outbox entry; exact duplicates ACK.
  * A completion whose delivery report was lost (CP down at fire time) still

--- a/packages/control-plane/test/integration/hooks-pool-placement.test.ts
+++ b/packages/control-plane/test/integration/hooks-pool-placement.test.ts
@@ -5,6 +5,9 @@
  * `agent.daemonId`, which a `set` placement leaves null — so the holder's own report was refused,
  * `hook/start` came back non-retryable, and the review broker denied every action. Authority is the
  * same seam as the reads (#1004): placement ∪ live duty holders, read through `PlacementResolver`.
+ *
+ * The completion fence follows the same seam (#1051): the member that dispatched a run can retire
+ * mid-run, so the member that serves the agent afterwards may close it too.
  */
 import { describe, expect, it, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
@@ -27,6 +30,7 @@ import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 const HOLDER = 'e1e1e1e1-eeee-4eee-8eee-eeeeeeeeeee1'
 const PEER = 'e2e2e2e2-eeee-4eee-8eee-eeeeeeeeeee2'
 const MACHINE = 'e3e3e3e3-eeee-4eee-8eee-eeeeeeeeeee3'
+const BYSTANDER = 'e4e4e4e4-eeee-4eee-8eee-eeeeeeeeeee4'
 const HEAD_SHA = 'a'.repeat(40)
 const BASE_SHA = 'b'.repeat(40)
 
@@ -55,6 +59,15 @@ async function grantDuty(holder: string, agentId: string): Promise<void> {
     }
   })
   await prisma.dutyGroupMember.create({ data: { kind: 'agent', refId: agentId, groupId, orgId: DEFAULT_ORG_ID } })
+}
+
+/** Retire the current holder mid-run: the agent's lease is re-taken by another member. */
+async function moveDuty(agentId: string, holder: string): Promise<void> {
+  const member = await prisma.dutyGroupMember.findFirstOrThrow({ where: { kind: 'agent', refId: agentId } })
+  await prisma.dutyGroup.update({
+    where: { id: member.groupId },
+    data: { holder, term: 2n, confirmedTerm: 2n, confirmedHolder: holder, expiresAt: new Date(Date.now() + 600_000) }
+  })
 }
 
 async function seedGithubHook(agentId: string): Promise<string> {
@@ -262,6 +275,56 @@ describe('hook dispatch authority follows the placement resolver', () => {
     expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]).toMatchObject({ status: 'running' })
   })
 
+  it('accepts a completion from the member serving the pool agent after the duty moved (#1051)', async () => {
+    const { agentId, hookId } = await pooledGithubHook()
+    await poolMember(PEER)
+    expect(await acceptDelivery(hookId, agentId, 'pool-move-1', HOLDER)).toBe(true)
+    await moveDuty(agentId, PEER)
+
+    const completion = await report(PEER, hookId, agentId, 'pool-move-1', {
+      status: 'success',
+      durationMs: 900,
+      sessionId: 'ses_moved'
+    })
+    expect(completion.conn.sendError).not.toHaveBeenCalled()
+    expect(completion.conn.replyTo).toHaveBeenCalledWith(completion.frame, 'ack', { ok: true })
+    // The accepted dispatch target stays the provenance snapshot of who the run was addressed at.
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]).toMatchObject({
+      status: 'success',
+      durationMs: 900,
+      sessionId: 'ses_moved',
+      dispatchDaemonId: HOLDER
+    })
+  })
+
+  it('lets the retired dispatch target close its own run after the duty moved', async () => {
+    const { agentId, hookId } = await pooledGithubHook()
+    await poolMember(PEER)
+    expect(await acceptDelivery(hookId, agentId, 'pool-move-2', HOLDER)).toBe(true)
+    await moveDuty(agentId, PEER)
+
+    const completion = await report(HOLDER, hookId, agentId, 'pool-move-2', { status: 'success', durationMs: 12 })
+    expect(completion.conn.sendError).not.toHaveBeenCalled()
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]).toMatchObject({ status: 'success' })
+  })
+
+  it('refuses a completion from a member that serves nothing once the duty moved', async () => {
+    const { agentId, hookId } = await pooledGithubHook()
+    await poolMember(PEER)
+    await poolMember(BYSTANDER)
+    expect(await acceptDelivery(hookId, agentId, 'pool-move-3', HOLDER)).toBe(true)
+    await moveDuty(agentId, PEER)
+
+    const foreign = await report(BYSTANDER, hookId, agentId, 'pool-move-3', { status: 'success', durationMs: 10 })
+    expect(foreign.conn.sendError).toHaveBeenCalledWith(
+      foreign.frame.id,
+      'CONFLICT',
+      'hook completion does not match the accepted dispatch',
+      false
+    )
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]).toMatchObject({ status: 'running' })
+  })
+
   it('keeps the machine placement working with no duty lease in play', async () => {
     const { agentId, hookId } = await machineGithubHook()
 
@@ -269,6 +332,21 @@ describe('hook dispatch authority follows the placement resolver', () => {
     const completion = await report(MACHINE, hookId, agentId, 'machine-1', { status: 'success', durationMs: 11 })
     expect(completion.conn.replyTo).toHaveBeenCalledWith(completion.frame, 'ack', { ok: true })
     expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]).toMatchObject({ status: 'success' })
+  })
+
+  it('refuses a machine-placed completion from a daemon the agent is not placed on', async () => {
+    const { agentId, hookId } = await machineGithubHook()
+    await poolMember(PEER)
+    expect(await acceptDelivery(hookId, agentId, 'machine-2', MACHINE)).toBe(true)
+
+    const foreign = await report(PEER, hookId, agentId, 'machine-2', { status: 'success', durationMs: 5 })
+    expect(foreign.conn.sendError).toHaveBeenCalledWith(
+      foreign.frame.id,
+      'CONFLICT',
+      'hook completion does not match the accepted dispatch',
+      false
+    )
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]).toMatchObject({ status: 'running' })
   })
 
   it('captures the duty holder as the redelivery dispatch target for a pool agent', async () => {


### PR DESCRIPTION
## Summary

`hook.repo.ts` `recordReport` fenced a completion on the run's recorded `dispatchDaemonId`.
On a daemon pool the member that dispatched a run can be retired mid-run, so that column
names a daemon that no longer serves the agent — and the completion had nowhere to land.
#1044 stopped a peer from destroying the report body and let the member that now serves the
agent reclaim the row, but the control plane still answered a permanent `CONFLICT`: the
reclaim path could preserve the completion, never deliver it.

Authority is now the seam every other hook fence has used since #1047 — placement ∪ the
live duty leases, read through `PlacementResolver` — and the accepted dispatch target goes
back to being what it is, a provenance snapshot of who the run was addressed at.

## Failure scenario

1. A GitHub delivery for a pool agent is addressed at member A; the run row records
   `dispatchDaemonId = A`.
2. A is drained during a rollout. Its lease lapses and B takes the agent's duty.
3. B reclaims the terminal report from the shared outbox (#1044) and sends `hook/report`.
4. `recordReport` compares B against the run's `dispatchDaemonId` (A) and returns false, so
   `hook/report` comes back `CONFLICT` with `retryable: false`.

The turn actually succeeded, but the `HookRun` stays open until the reaper marks it
`orphaned` and the check-run reports a failure that never happened. Nothing retries, because
the answer is permanent by design.

## Fix

`recordReport` resolves the hook's dispatch authority before the transaction opens (the
existing `dispatchAuthority` / `HookDispatchAuthority` from #1047 — asking the duty ledger
while holding a transaction would trade a pooled connection for a lock), then asks one new
predicate at each reporter fence:

```
mayReport(authority, agentId, reportingDaemonId, dispatchDaemonId)
  = dispatchDaemonId === reportingDaemonId || servedBy(authority, agentId, reportingDaemonId)
```

`servedBy` is #1047's fence unchanged: the agent must be the one the authority was resolved
for, and the daemon must be in its serving set. The agent it is asked about is the one the
transaction itself read — `run.agentId` under the run lock — so a pre-read cannot widen
authority, and a daemon serving some other agent on the same host cannot close this run.
Three fences move onto it:

- the accepted-run completion (the issue's path), which also drops the now-redundant
  `r.dispatchDaemonId !== reportingDaemonId` clause from the retried-row tuple — that branch
  already pins `run.dispatchDaemonId === r.dispatchDaemonId`, so the reporter question is
  asked once, below, for both branches;
- the claimed-offline recovery, which supplies the missing accepted edge for a delivery whose
  `rc/run-report` was lost;
- completion-first recovery, whose reported dispatch target was compared to the reporter even
  though the branch is already gated on `servedBy(...)` for the reporting daemon — the clause
  is removed rather than restated, and the reported target is written to the new row as
  provenance.

`dispatchDaemonId` is still written and still exact; it is simply no longer the fence. What
did not change: a daemon that neither dispatched the run nor serves its agent is refused with
the same permanent `CONFLICT`; a machine-placed agent behaves exactly as before, because its
placement *is* its serving daemon; and the live-action fences (`recordStart`,
`reserveReviewAttempt`, `recordReviewResult`) keep comparing the persisted accepted tuple —
those authorize work in flight, not a completion arriving after the fact.

## Test plan

`test/integration/hooks-pool-placement.test.ts` (#1047's suite) gains four cases over the real
repo, the real `hook/report` handler and a real duty ledger, with the duty re-seeded onto
another member mid-run:

- a run dispatched to holder A, duty moved to B, B's completion is **accepted** and the row
  keeps `dispatchDaemonId = A`;
- A — retired, no longer serving — can still close its own run;
- a third pool member that serves nothing is still refused with `CONFLICT`, run stays
  `running`;
- machine placement: a completion from a daemon the agent is not placed on is still refused
  (the accept side was already covered).

### Mutation

Reverting `hook.repo.ts` alone: **1 failed / 11 passed** — the acceptance case, which is
exactly the behavior this PR adds. The three negatives are meant to pass both ways; they exist
to pin that the fence was widened to "serves the agent" and not to "any daemon". Reverted.

### Gates

`pnpm --filter @agentconnect.md/control-plane typecheck`, `test:unit` (1672 passed), the hook
suites under `test:int` — `hooks-pool-placement`, `hook-report`, `hooks.route`,
`github-review-persistence.repo` (85 passed) — then the whole integration project
(88 files / 1326 passed), `pnpm lint`, `pnpm format:check` — all green.

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)
