### PR TITLE
fix: the per-member assumptions collected in #1041

### DIFF
--- a/packages/control-plane/src/http/routes/organization-environment.ts
+++ b/packages/control-plane/src/http/routes/organization-environment.ts
@@ -37,9 +37,10 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import { ctxOf, denyNonOwner, orgOf } from '../rbac.js'
-import { AgentId, type DaemonId, type OrgId } from '../../domain/ids.js'
+import { AgentId, DaemonId, type OrgId } from '../../domain/ids.js'
 import { canEdit, canView, type ViewCtx } from '../../authorization/policy.js'
 import type {
+  AgentRecord,
   OrganizationEnvironmentEntryRecord,
   OrganizationEnvironmentWriteResult,
   OrganizationEnvironmentWriteFailure
@@ -131,14 +132,19 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
       )
     }
 
-    /** Does this placed agent's daemon persist and enforce `configRevision`? An
-     *  unplaced agent is always fine (placement re-checks the feature), and an
-     *  unknown/never-registered daemon cannot be proven compatible — the gate
-     *  never relies on lenient behavior from an unverified daemon. */
-    const onCompatibleDaemon = async (orgId: OrgId, daemonId: DaemonId | null): Promise<boolean> => {
-      if (daemonId === null) return true
-      const daemon = await deps.registry.getAvailable(orgId, daemonId)
-      return !!daemon?.capabilities.features.includes(AGENT_CONFIG_REVISION_FEATURE)
+    /** Does every daemon serving this agent persist and enforce `configRevision`? Asked through
+     *  the resolver, never off `agent.daemonId`: a pool agent is placed but names no machine, so
+     *  the column reads as unplaced and skipped the precondition entirely. An agent nothing serves
+     *  is still fine (placement re-checks the feature), and an unknown/never-registered daemon
+     *  cannot be proven compatible — the gate never relies on lenient behavior from an
+     *  unverified daemon. */
+    const onCompatibleDaemon = async (orgId: OrgId, agent: AgentRecord): Promise<boolean> => {
+      const daemonIds = await deps.placementResolver.servingDaemons(agent)
+      for (const daemonId of daemonIds) {
+        const daemon = await deps.registry.getAvailable(orgId, DaemonId(daemonId))
+        if (!daemon?.capabilities.features.includes(AGENT_CONFIG_REVISION_FEATURE)) return false
+      }
+      return true
     }
 
     /**
@@ -155,7 +161,7 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
       const placed = (await deps.repos.agent.list(orgId)).filter((agent) => wanted.has(agent.id))
       const out: string[] = []
       for (const agent of placed) {
-        if (!(await onCompatibleDaemon(orgId, agent.daemonId))) out.push(agent.id)
+        if (!(await onCompatibleDaemon(orgId, agent))) out.push(agent.id)
       }
       return out
     }
@@ -197,7 +203,7 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
       // what keeps the refusal indistinguishable from a missing agent.
       const inScope = mode === 'requested' ? agents.filter((agent) => canEdit(agent, ctx)) : agents
       for (const agent of inScope) {
-        if (!(await onCompatibleDaemon(orgId, agent.daemonId))) {
+        if (!(await onCompatibleDaemon(orgId, agent))) {
           // Naming is safe only for an agent the caller can already see.
           return canView(agent, ctx)
             ? `agent ${agent.name} runs on a daemon that does not yet support organization environment entries; upgrade it first`

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { HttpBotOrchestrator } from './httpBot.js'
 import { AgentDelivery } from './agentDelivery.js'
+import type { PlacementResolver } from './placementResolver.js'
 import { systemClock } from '../domain/clock.js'
 import { RelayRegistry, type RelayChannel } from '../ws/relay-registry.js'
 import type { RcBotAssign, RelayCpFrameType } from '@agentconnect.md/protocol'
-import { AgentId, BotId, IntegrationId, OrgId } from '../domain/ids.js'
+import { AgentId, BotId, DaemonId, IntegrationId, OrgId } from '../domain/ids.js'
 import type {
   BotRepo,
   BotRecord,
@@ -130,7 +131,8 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
   }[]
   let secretMaterial: BotSecretMaterial
   // Drives the SessionRepo.findThreadOwner fallback in lookupThread (null = no daemon session).
-  let threadOwner: { agentId: string; daemonId: string } | null
+  // The AGENT alone: which member serves it is resolved live, so a pool agent resolves too.
+  let threadOwner: { agentId: string } | null
   let threadOwnerLookup: { botId: BotId; channel: string; thread: string } | null
   // §14: agents whose AgentRepo.get returns visibility 'restricted' (⇒ gated).
   let gatedAgents: Set<string>
@@ -152,7 +154,9 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
   // "why is my bot not receiving anything".
   let warns: { bindings: Record<string, unknown>; message: string }[]
 
-  function makeOrch(platforms = PLATFORMS): HttpBotOrchestrator {
+  /** `placement` stands in for the duty ledger: absent ⇒ placement alone, which is what every
+   *  expectation predating the pool was written against. */
+  function makeOrch(platforms = PLATFORMS, placement?: Pick<PlacementResolver, 'routableDaemon'>): HttpBotOrchestrator {
     const agents: Record<string, AgentRecord> = {
       [ALICE]: agent(ALICE, 'alice', unplacedAgents.has(ALICE) ? null : D1),
       [BOB]: agent(BOB, 'bob', unplacedAgents.has(BOB) ? null : D2)
@@ -323,7 +327,8 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       platforms,
       // No duty ledger wired ⇒ the delivery set is the placement alone, which is
       // exactly what every expectation in this file was written against.
-      new AgentDelivery({ control: control as never, specs: undefined as never, clock: systemClock })
+      new AgentDelivery({ control: control as never, specs: undefined as never, clock: systemClock }),
+      ...(placement ? [placement] : [])
     )
   }
 
@@ -357,7 +362,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     // the relay's REPORT leg is still resolved from the daemon-reported SessionMeta.
     it('falls back to the daemon-reported SessionMeta owner (channel/thread parsed from sessionKey)', async () => {
       const orch = makeOrch()
-      threadOwner = { agentId: ALICE, daemonId: D1 }
+      threadOwner = { agentId: ALICE }
       const res = await orch.lookupThread({ botId: BOT, sessionKey: SK })
       expect(res).toEqual({
         botId: BOT,
@@ -366,6 +371,29 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         participants: [{ agentId: ALICE, daemonId: D1 }]
       })
       expect(threadOwnerLookup).toEqual({ botId: BOT, channel: 'C1', thread: '1784297789.871789' })
+    })
+
+    it('resolves a POOL owner through the placement resolver, which the agent row cannot name', async () => {
+      // The blind spot: the lookup used to require a non-null `agent.daemonId`, so a pool agent —
+      // placed on a set, naming no machine — never resolved and its own thread's un-mentioned
+      // follow-ups were dropped.
+      unplacedAgents = new Set([ALICE])
+      const orch = makeOrch(PLATFORMS, {
+        routableDaemon: async (a) => (a.id === ALICE ? DaemonId(D1) : null)
+      })
+      threadOwner = { agentId: ALICE }
+      const res = await orch.lookupThread({ botId: BOT, sessionKey: SK })
+      expect(res.target).toEqual({ agentId: ALICE, daemonId: D1 })
+    })
+
+    it('still names nobody while no member is routable for the owning agent', async () => {
+      // Fail closed, not stale: between a lapsed lease and the next grant the honest answer is
+      // "no target", which the relay retries — never a member that has stopped serving it.
+      unplacedAgents = new Set([ALICE])
+      const orch = makeOrch(PLATFORMS, { routableDaemon: async () => null })
+      threadOwner = { agentId: ALICE }
+      const res = await orch.lookupThread({ botId: BOT, sessionKey: SK })
+      expect(res.target).toBeNull()
     })
 
     it('returns null when neither affinity nor a SessionMeta owner exists', async () => {

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -436,18 +436,36 @@ export class HttpBotOrchestrator {
       const channel = m.sessionKey.slice(0, slash)
       const thread = m.sessionKey.slice(slash + 1)
       const owner = await this.sessions.findThreadOwner(BotId(m.botId), channel, thread)
-      if (owner && (await this.threadTargetAllowed(m.botId, channel, owner.agentId))) {
+      // The session names the agent; the member serving it is resolved live, so this fallback
+      // covers a pool agent — whose row names no machine — as well as a machine-placed one.
+      const target = owner ? await this.threadOwnerTarget(m.botId, channel, owner.agentId) : null
+      if (target) {
         return {
           botId: m.botId,
           sessionKey: m.sessionKey,
-          target: owner,
-          participants: participants.some((participant) => participant.agentId === owner.agentId)
+          target,
+          participants: participants.some((participant) => participant.agentId === target.agentId)
             ? participants
-            : [...participants, owner]
+            : [...participants, target]
         }
       }
     }
     return { botId: m.botId, sessionKey: m.sessionKey, target: null, participants }
+  }
+
+  /** The addressable target for a thread owner, or null when the gate refuses it or nothing is
+   *  routable. `routableDaemon` and not `servingDaemon`: this seeds relay ingress affinity, so a
+   *  member that holds the agent but has not yet reported it must not be named. */
+  private async threadOwnerTarget(
+    botId: string,
+    channel: string,
+    agentId: string
+  ): Promise<{ agentId: string; daemonId: string } | null> {
+    if (!(await this.threadTargetAllowed(botId, channel, agentId))) return null
+    const agent = await this.agents.getUnscoped(AgentId(agentId))
+    if (!agent) return null
+    const daemonId = await this.placement.routableDaemon({ ...agent, id: agent.id })
+    return daemonId ? { agentId, daemonId } : null
   }
 
   /** §14 conversation-gating check for the thread-lookup backstop: a non-gated

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1422,12 +1422,13 @@ export interface SessionRepo {
    *  System-tier: driven by the visibility-push orchestrator from a row it holds. */
   visibilitySubtree(sessionId: SessionId, limit: number): Promise<SessionMetaRecord[]>
   /** Resolve the agent that owns a bot's `(channel, thread)` — the most-recently-active session
-   *  keyed there whose agent still has an active integration for that bot and a current daemon
-   *  placement. Backstop for shared-bot thread-affinity lookup: a daemon-created session (e.g.
-   *  an agent's own channel-root post, session-concept §7.2 case 2a) never goes through the
-   *  relay's mention/switch REPORT leg, so no `thread-assign` seeds the affinity store — this
-   *  lets `lookupThread` still find the owner. Null when none. */
-  findThreadOwner(botId: BotId, channel: string, thread: string): Promise<{ agentId: string; daemonId: string } | null>
+   *  keyed there whose agent still has an active integration for that bot. Backstop for
+   *  shared-bot thread-affinity lookup: a daemon-created session (e.g. an agent's own channel-root
+   *  post, session-concept §7.2 case 2a) never goes through the relay's mention/switch REPORT leg,
+   *  so no `thread-assign` seeds the affinity store — this lets `lookupThread` still find the
+   *  owner. Null when none. Placement is deliberately NOT a predicate here: which daemon serves
+   *  the agent is {@link PlacementResolver}'s answer, and a pool agent names no machine. */
+  findThreadOwner(botId: BotId, channel: string, thread: string): Promise<{ agentId: string } | null>
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -1683,31 +1683,23 @@ export class PgSessionRepo implements SessionRepo {
     return rows.map(toRecord)
   }
 
-  async findThreadOwner(
-    botId: BotId,
-    channel: string,
-    thread: string
-  ): Promise<{ agentId: string; daemonId: string } | null> {
-    // Most-recently-active session on this bot's (channel, thread) whose agent is currently
-    // placed. The session's daemonId is provenance only and may be null after its reporting
-    // daemon is deleted; routing follows current agent placement.
+  async findThreadOwner(botId: BotId, channel: string, thread: string): Promise<{ agentId: string } | null> {
+    // Most-recently-active session on this bot's (channel, thread). The AGENT is the answer; who
+    // serves it right now is the placement resolver's, so this asks nothing about placement at
+    // all. Requiring a non-null `agent.daemonId` here excluded every pool agent — placed, but
+    // naming no machine — so the pull-on-miss fallback below never fired for one.
+    // The session's own daemonId is provenance only and may be null after its reporting daemon is
+    // deleted; routing follows current agent placement.
     // NOTE: do NOT filter on `endedAt` — a session emits `phase:'end'` (→ `endedAt`) at the end
     // of EVERY turn, so an idle-between-turns session (the normal state of a thread's owner
     // between messages) has `endedAt` set yet is still the valid target; the daemon resumes it on
     // delivery. Filtering `endedAt: null` here made the affinity fallback miss essentially every
     // real thread (incl. a case-2a spawned session after its one headless turn).
     const row = await this.db.sessionMeta.findFirst({
-      where: {
-        channel,
-        thread,
-        agent: {
-          daemonId: { not: null },
-          integrations: { some: { botId, status: 'active' } }
-        }
-      },
+      where: { channel, thread, agent: { integrations: { some: { botId, status: 'active' } } } },
       orderBy: [{ lastActivityAt: 'desc' }, { startedAt: 'desc' }],
-      select: { agentId: true, agent: { select: { daemonId: true } } }
+      select: { agentId: true }
     })
-    return row?.agent.daemonId ? { agentId: row.agentId, daemonId: row.agent.daemonId } : null
+    return row ? { agentId: row.agentId } : null
   }
 }

--- a/packages/control-plane/src/ws/handlers/channel-agents.test.ts
+++ b/packages/control-plane/src/ws/handlers/channel-agents.test.ts
@@ -13,7 +13,9 @@ import type { AnyFrame } from '@agentconnect.md/protocol'
 import type { ChannelAgentRecord, OrgAgentRecord } from '../../persistence/ports.js'
 import type { DaemonConnection } from '../connection.js'
 import type { DaemonWsDeps } from '../deps.js'
-import { AgentId } from '../../domain/ids.js'
+import { AgentId, type DaemonId } from '../../domain/ids.js'
+import { PlacementResolver } from '../../orchestrator/placementResolver.js'
+import { systemClock } from '../../domain/clock.js'
 
 const CALLER = AgentId('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
 const PEER = AgentId('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')
@@ -21,6 +23,7 @@ const OTHER = AgentId('cccccccc-cccc-4ccc-8ccc-cccccccccccc')
 const ASKING_DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const OTHER_DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
 const ORG = 'org-a'
+const SET = 'set-pool'
 
 function rec(over: Partial<ChannelAgentRecord> & { agentId: ChannelAgentRecord['agentId'] }): ChannelAgentRecord {
   return {
@@ -155,6 +158,34 @@ function fakeDeps(placedOn: string | null, channelExtra?: ChannelAgentRecord) {
   }
 }
 
+/**
+ * The pool shape: CALLER is placed on a SET (so its row names no machine) and its duty is held by
+ * `holders`; only `confirmed` may be addressed for ingress. PEER stays machine-placed on the asking
+ * daemon, so the reply has something routable in it either way.
+ */
+function fakePoolDeps(duty: { holders: string[]; confirmed: string[] }) {
+  const orgRoster: OrgAgentRecord[] = [
+    { ...rec({ agentId: CALLER }), placementKind: 'set', daemonId: null, setId: SET },
+    { ...rec({ agentId: PEER }), placementKind: 'daemon', daemonId: ASKING_DAEMON, setId: null }
+  ]
+  const forCaller = (agentId: string, ids: string[]) => (agentId === CALLER ? ids : [])
+  const placementResolver = new PlacementResolver({
+    clock: systemClock,
+    duties: {
+      holdersOf: async (agentId) => forCaller(agentId, duty.holders) as DaemonId[],
+      confirmedHoldersOf: async (agentId) => forCaller(agentId, duty.confirmed) as DaemonId[]
+    }
+  })
+  return {
+    deps: {
+      registry: { getUnscoped: async () => ({ id: ASKING_DAEMON, orgId: ORG }) },
+      agent: { orgDirectory: async () => orgRoster },
+      integration: { agentsInChannel: async () => [] },
+      placementResolver
+    } as unknown as DaemonWsDeps
+  }
+}
+
 const rosterNames = (conn: ReturnType<typeof fakeConn>): string[] =>
   ((conn.replyTo.mock.calls[0]![2] as { agents: Array<{ agentId: string }> }).agents ?? []).map((a) => a.agentId)
 
@@ -221,5 +252,27 @@ describe('handleChannelAgents — daemon-ownership bind on requesterAgentId', ()
     const conn = fakeConn()
     await handleChannelAgents(frame({ channel: 'C1' }), conn, deps)
     expect(rosterNames(conn).sort()).toEqual([CALLER, PEER].sort())
+  })
+
+  // The pool window this bind used to close over the wrong predicate. A grant makes a member a
+  // HOLDER at once; it becomes a CONFIRMED holder only from its first reporting digest, and
+  // `resolveDirectory` deliberately names confirmed holders because it addresses ingress. Binding
+  // the ownership question on that projection refused a member that genuinely held the agent.
+  it('serves a member that HOLDS the requester but has not yet confirmed the grant', async () => {
+    const { deps } = fakePoolDeps({ holders: [ASKING_DAEMON], confirmed: [] })
+    const conn = fakeConn()
+    await handleChannelAgents(frame({}), conn, deps)
+    expect(conn.replyTo.mock.calls[0]![1]).toBe('channel/agents/ok')
+    // PEER is confirmed elsewhere, so it is routable and listed; the requester always sees itself.
+    expect(rosterNames(conn).sort()).toEqual([CALLER, PEER].sort())
+  })
+
+  it('still refuses a member that holds NOTHING for the requester', async () => {
+    // The integrity control is unchanged: may-act widens the bind from confirmed holders to
+    // holders, never to "any member of the set".
+    const { deps } = fakePoolDeps({ holders: [OTHER_DAEMON], confirmed: [OTHER_DAEMON] })
+    const conn = fakeConn()
+    await handleChannelAgents(frame({}), conn, deps)
+    expect(rosterNames(conn)).toEqual([])
   })
 })

--- a/packages/control-plane/src/ws/handlers/channel-agents.ts
+++ b/packages/control-plane/src/ws/handlers/channel-agents.ts
@@ -43,7 +43,7 @@
  */
 import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import { isFrame } from '@agentconnect.md/protocol'
-import { DaemonId, OrgId } from '../../domain/ids.js'
+import { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import { isSessionIdentityPlatform } from '../../persistence/platform.js'
 import type { ChannelAgentRecord } from '../../persistence/ports.js'
 import type { Handler } from './index.js'
@@ -97,11 +97,11 @@ export const handleChannelAgents: Handler = async (frame, conn, deps) => {
     // ONE org-scoped read, feeding both scopes and the bind (see the header). It is also
     // literally the read `buildCollabSnapshot` builds `agents[]` from, which is what keeps
     // "discoverable" and "callable" from disagreeing.
+    const resolver = deps.placementResolver ?? PLACEMENT_ONLY
+    const directory = await deps.agent.orgDirectory(orgId)
     // Resolved through the placement resolver, so a pool agent is listed against the member that
     // currently serves it rather than dropped for naming no machine.
-    const orgRoster = await (deps.placementResolver ?? PLACEMENT_ONLY).resolveDirectory(
-      await deps.agent.orgDirectory(orgId)
-    )
+    const orgRoster = await resolver.resolveDirectory(directory)
 
     // THE DAEMON-OWNERSHIP BIND (§2.2/§6.1) — the read-side twin of the relay's
     // `claimedFromAgentId` / `caller.daemonId !== fromDaemonId` check. `requesterAgentId`
@@ -127,14 +127,29 @@ export const handleChannelAgents: Handler = async (frame, conn, deps) => {
     // practice near-unreachable — `AgentMoveService` takes the move only when the source is
     // idle and detaches it before the placement CAS — so treat this as fail-closed
     // belt-and-braces, not a window anything depends on.
-    const requester = orgRoster.find((a) => a.agentId === requesterAgentId)
-    if (requester?.daemonId !== conn.daemonId) return [] // null/undefined never equals a daemonId
+    //
+    // Bound off `mayAct` (holders) and the UNRESOLVED directory, never off `orgRoster`, which is
+    // the ingress projection (confirmed holders only). A member is a holder from the grant but a
+    // confirmed one only from its first reporting digest, so binding on the projection refused a
+    // member that genuinely held the agent and answered it "you have no peers".
+    const requester = directory.find((a) => a.agentId === requesterAgentId)
+    if (!requester || !(await resolver.mayAct({ ...requester, id: requester.agentId }, conn.daemonId))) return []
 
-    if (channel === undefined) return orgRoster
+    // The requester's OWN row rides along even while nothing routes to it — the other half of the
+    // same window. `visibleToRequester` fails closed on a requester missing from the roster, so a
+    // member still holding an unconfirmed grant would pass the bind and then be told it has no
+    // peers anyway. Its peers stay filtered by routability; an agent never wakes itself.
+    const withRequester = (roster: ChannelAgentRecord[], eligible: boolean): ChannelAgentRecord[] =>
+      eligible && !roster.some((a) => a.agentId === requesterAgentId) ? [...roster, requester] : roster
+
+    if (channel === undefined) return withRequester(orgRoster, true)
     // The channel scope is a literal INTERSECTION: `agentsInChannel` supplies the membership
     // id set, the org roster supplies the records (and the placement filter).
     const inChannel = new Set((await deps.integration.agentsInChannel(orgId, platform, channel)).map((a) => a.agentId))
-    return orgRoster.filter((a) => inChannel.has(a.agentId))
+    return withRequester(
+      orgRoster.filter((a) => inChannel.has(a.agentId)),
+      inChannel.has(AgentId(requesterAgentId))
+    )
   })()
 
   const visible = visibleToRequester(roster, requesterAgentId)

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -65,6 +65,8 @@ export async function seedAgent(
     gitAccess?: 'read' | 'write'
     /** `runtimeOverrides` JSON — where the MCP enable-list and memory binding live. */
     runtimeOverrides?: Record<string, unknown>
+    /** A `set` placement: placed, but naming no machine — which member serves it is the ledger's. */
+    setId?: string
   } = {}
 ): Promise<AgentId> {
   await prisma.agent.create({
@@ -74,6 +76,7 @@ export async function seedAgent(
       name: opts.name ?? `agent-${id.slice(0, 4)}`,
       runtime: opts.runtime ?? 'claude',
       daemonId: opts.daemonId,
+      ...(opts.setId ? { placementKind: 'set' as const, setId: opts.setId } : {}),
       ...(opts.visibility ? { visibility: opts.visibility } : {}),
       ...(opts.sharedWith ? { sharedWith: opts.sharedWith } : {}),
       ...(opts.createdByUserId ? { createdByUserId: opts.createdByUserId } : {}),

--- a/packages/control-plane/test/integration/organization-environment.route.test.ts
+++ b/packages/control-plane/test/integration/organization-environment.route.test.ts
@@ -18,7 +18,8 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { AgentUpsert } from '@agentconnect.md/protocol'
 import { AGENT_CONFIG_REVISION_FEATURE } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
-import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { seedAgent, seedDaemon, seedDutyGroup } from '../fixtures/seed.js'
+import { poolSetId } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { NoConnection, type ControlSender } from '../../src/orchestrator/outbound.js'
@@ -669,6 +670,37 @@ describe('organization environment — daemon feature gate', () => {
     expect(bind.statusCode).toBe(409)
     expect(bind.body).toContain('does not yet support')
     expect(await prisma.organizationEnvironmentAssignment.count({ where: { entryId: entry.id } })).toBe(0)
+  })
+
+  it('gates a SET-placed agent on the member holding it, not on the column it never fills', async () => {
+    // The inverse of the refusal above, and the one this gate used to get wrong: a pool agent is
+    // placed but names no machine, so `agent.daemonId === null` read as "unplaced, always fine"
+    // and skipped the configRevision precondition entirely — a silent pass where every other
+    // finding of this class is a silent refusal.
+    await seedDaemon(prisma, LEGACY_DAEMON, { capabilities: LEGACY })
+    const poolAgent = randomUUID()
+    await seedAgent(prisma, poolAgent, { setId: await poolSetId(prisma), name: 'pool-bot' })
+    await seedDutyGroup(prisma, randomUUID(), LEGACY_DAEMON, [poolAgent])
+    const http = app({ control: new RecordingControl() })
+
+    const entry = (await createEntry(http, { key: 'POOLED', kind: 'variable', value: 'v', audience: 'selected' })).entry
+    const bind = await http.app.inject({ method: 'PUT', url: `${ENV}/${entry.id}/agents/${poolAgent}` })
+    expect(bind.statusCode).toBe(409)
+    expect(bind.body).toContain('does not yet support')
+    expect(await prisma.organizationEnvironmentAssignment.count({ where: { entryId: entry.id } })).toBe(0)
+  })
+
+  it('lets a SET-placed agent through once the member holding it carries the fence', async () => {
+    await seedDaemon(prisma, DAEMON, { capabilities: CAPABLE })
+    const poolAgent = randomUUID()
+    await seedAgent(prisma, poolAgent, { setId: await poolSetId(prisma), name: 'pool-ok-bot' })
+    await seedDutyGroup(prisma, randomUUID(), DAEMON, [poolAgent])
+    const http = app({ control: new RecordingControl() })
+
+    const entry = (await createEntry(http, { key: 'POOLED_OK', kind: 'variable', value: 'v', audience: 'selected' }))
+      .entry
+    const bind = await http.app.inject({ method: 'PUT', url: `${ENV}/${entry.id}/agents/${poolAgent}` })
+    expect(bind.statusCode).toBe(200)
   })
 
   it('SKIPS an agent on an incompatible daemon from `all` enrollment instead of refusing', async () => {

--- a/packages/control-plane/test/repo/session.repo.test.ts
+++ b/packages/control-plane/test/repo/session.repo.test.ts
@@ -13,6 +13,7 @@ import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.j
 import { DEF_ORG, seedAgent, seedDaemon, seedLaunch } from '../fixtures/seed.js'
 import { DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import { AgentId, BotId, DaemonId, LaunchId, SessionId } from '../../src/domain/ids.js'
+import { poolSetId } from '../fakes/member-set.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const OTHER_AGENT = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
@@ -369,7 +370,7 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     expect(await repo.list({ platform: 'telegram' })).toHaveLength(0)
   })
 
-  it("scopes shared-bot thread fallback to the bot's active, currently placed agent", async () => {
+  it("scopes shared-bot thread fallback to the bot's active agent, whatever places it", async () => {
     await fixtures()
     await seedDaemon(prisma, OTHER_DAEMON)
     await seedAgent(prisma, OTHER_AGENT, { daemonId: OTHER_DAEMON })
@@ -414,33 +415,36 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
       })
     )
 
-    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({
-      agentId: AGENT,
-      daemonId: DAEMON
-    })
-    expect(await repo.findThreadOwner(BotId(otherBotId), 'C1', 'T1')).toEqual({
-      agentId: OTHER_AGENT,
-      daemonId: OTHER_DAEMON
-    })
+    // The AGENT is the answer; which member serves it is the placement resolver's, so the
+    // reply carries no daemon and asks nothing about placement.
+    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({ agentId: AGENT })
+    expect(await repo.findThreadOwner(BotId(otherBotId), 'C1', 'T1')).toEqual({ agentId: OTHER_AGENT })
 
     await prisma.integration.update({ where: { id: integrationId }, data: { status: 'revoked' } })
     expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toBeNull()
 
     await prisma.integration.update({ where: { id: integrationId }, data: { status: 'active' } })
     await prisma.agent.update({ where: { id: AGENT }, data: { daemonId: OTHER_DAEMON } })
-    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({
-      agentId: AGENT,
-      daemonId: OTHER_DAEMON
-    })
+    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({ agentId: AGENT })
 
     await prisma.daemon.delete({ where: { id: DAEMON } })
-    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({
-      agentId: AGENT,
-      daemonId: OTHER_DAEMON
-    })
+    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({ agentId: AGENT })
 
-    await prisma.agent.update({ where: { id: AGENT }, data: { daemonId: null, status: 'inactive' } })
-    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toBeNull()
+    // A SET placement — placed, naming no machine. The old predicate required a non-null
+    // `agent.daemonId`, so every pool agent fell out of this fallback entirely.
+    await prisma.agent.update({
+      where: { id: AGENT },
+      data: { daemonId: null, placementKind: 'set', setId: await poolSetId(prisma) }
+    })
+    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({ agentId: AGENT })
+
+    // Unplaced entirely is still an answer here: only the integration gates this read now, and
+    // `lookupThread` refuses the target when nothing is routable for the agent.
+    await prisma.agent.update({
+      where: { id: AGENT },
+      data: { placementKind: 'daemon', setId: null, status: 'inactive' }
+    })
+    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({ agentId: AGENT })
   })
 
   it('joins usage into list() and sorts by latest activity', async () => {

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -215,6 +215,20 @@ export type TokenCounts = Pick<
 /** Context-window + cost snapshot (from a `usage_update`), latest-wins. */
 export type UsageSnapshot = Pick<StoredUsage, 'contextUsed' | 'contextSize' | 'costAmount' | 'costCurrency'>
 
+/** `{}` for an unrecorded or unreadable blob — an unparseable one is not worth failing a turn over. */
+function parseUsage(raw: string | null): StoredUsage {
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw) as StoredUsage
+  } catch {
+    return {}
+  }
+}
+
+/** CAS attempts before the usage merge writes blind. One session has one writer plus, at most, a
+ *  handover peer, so losing four in a row means something other than contention is going on. */
+const USAGE_MERGE_ATTEMPTS = 5
+
 /** A session row as read back for `session/list`, carrying the raw usage JSON. */
 export interface SessionListRow extends SessionRecord {
   usage: string | null
@@ -903,6 +917,8 @@ export class LocalStore {
       -- Stable-row updates need a cursor independent of insertion-order seq.
       CREATE INDEX IF NOT EXISTS transcript_thread_revision
         ON transcript (channel, thread, revision);
+      -- Written ONLY by an exclusively owned store: a shared store's members would each
+      -- serialize their own map over this one row, so they do not persist here at all.
       CREATE TABLE IF NOT EXISTS cp_routing (
         id INTEGER PRIMARY KEY CHECK (id = 1),
         routingEpoch INTEGER, assignments TEXT, globalRules TEXT
@@ -2113,16 +2129,41 @@ export class LocalStore {
   getUsage(key: string): StoredUsage {
     const row = this.db.prepare('SELECT usage FROM sessions WHERE key = ?').get(key) as
       { usage: string | null } | undefined
-    if (!row?.usage) return {}
-    try {
-      return JSON.parse(row.usage) as StoredUsage
-    } catch {
-      return {}
-    }
+    return parseUsage(row?.usage ?? null)
   }
 
-  private writeUsage(key: string, u: StoredUsage): void {
-    this.db.prepare('UPDATE sessions SET usage = ? WHERE key = ?').run(JSON.stringify(u), key)
+  /**
+   * Read-merge-write `sessions.usage` under a compare-and-set on the value read, retried when a
+   * concurrent writer wins. `addTokenUsage` and `addCost` are genuinely additive, so a plain
+   * read-then-write drops the loser's increment; on a shared store two members touch one session
+   * across a handover. A relative UPDATE would be simpler but the column is one JSON blob and the
+   * two backends spell JSON mutation differently, whereas a CAS is plain SQL in both.
+   *
+   * `merge` runs again on every attempt, so it must be safe to repeat; returning undefined aborts.
+   */
+  private mergeUsage(key: string, merge: (u: StoredUsage) => StoredUsage | undefined): void {
+    for (let attempt = 1; attempt <= USAGE_MERGE_ATTEMPTS; attempt++) {
+      const row = this.db.prepare('SELECT usage FROM sessions WHERE key = ?').get(key) as
+        { usage: string | null } | undefined
+      if (!row) return // unknown key: the row is created first (unchanged from the plain write)
+      const merged = merge(parseUsage(row.usage))
+      if (!merged) return
+      const next = JSON.stringify(merged)
+      // The last attempt writes unconditionally. Losing an increment is exactly the behavior this
+      // replaces, so it is the floor to degrade to rather than dropping the write entirely.
+      if (attempt === USAGE_MERGE_ATTEMPTS) {
+        this.db.prepare('UPDATE sessions SET usage = ? WHERE key = ?').run(next, key)
+        return
+      }
+      // Two statements, not one NULL-safe comparison: `IS` / `IS NOT DISTINCT FROM` are spelled
+      // differently by the two backends, and which case applies is already known here.
+      const changes =
+        row.usage === null
+          ? this.db.prepare('UPDATE sessions SET usage = ? WHERE key = ? AND usage IS NULL').run(next, key).changes
+          : this.db.prepare('UPDATE sessions SET usage = ? WHERE key = ? AND usage = ?').run(next, key, row.usage)
+              .changes
+      if (changes > 0) return
+    }
   }
 
   /** Record the latest token counts for a session when an adapter reports a
@@ -2130,54 +2171,63 @@ export class LocalStore {
    *  additive. Only provided fields are updated; the context/cost snapshot is
    *  left intact. No-op on an unknown key (the row is created first). */
   setTokenUsage(key: string, counts: TokenCounts): void {
-    const u = this.getUsage(key)
-    if (counts.totalTokens !== undefined) u.totalTokens = counts.totalTokens
-    if (counts.inputTokens !== undefined) u.inputTokens = counts.inputTokens
-    if (counts.outputTokens !== undefined) u.outputTokens = counts.outputTokens
-    if (counts.thoughtTokens !== undefined) u.thoughtTokens = counts.thoughtTokens
-    if (counts.cachedReadTokens !== undefined) u.cachedReadTokens = counts.cachedReadTokens
-    if (counts.cachedWriteTokens !== undefined) u.cachedWriteTokens = counts.cachedWriteTokens
-    this.writeUsage(key, u)
+    this.mergeUsage(key, (u) => {
+      if (counts.totalTokens !== undefined) u.totalTokens = counts.totalTokens
+      if (counts.inputTokens !== undefined) u.inputTokens = counts.inputTokens
+      if (counts.outputTokens !== undefined) u.outputTokens = counts.outputTokens
+      if (counts.thoughtTokens !== undefined) u.thoughtTokens = counts.thoughtTokens
+      if (counts.cachedReadTokens !== undefined) u.cachedReadTokens = counts.cachedReadTokens
+      if (counts.cachedWriteTokens !== undefined) u.cachedWriteTokens = counts.cachedWriteTokens
+      return u
+    })
   }
 
   /** Add one turn's token counts to the session total. codex-acp currently maps
    *  Codex's `last_token_usage` into PromptResponse.usage, so its values are a
    *  per-turn delta even though other ACP adapters return a session snapshot. */
   addTokenUsage(key: string, counts: TokenCounts): void {
-    const u = this.getUsage(key)
-    const add = (field: keyof TokenCounts, value: number | undefined) => {
-      if (value !== undefined) u[field] = (u[field] ?? 0) + value
-    }
-    add('totalTokens', counts.totalTokens)
-    add('inputTokens', counts.inputTokens)
-    add('outputTokens', counts.outputTokens)
-    add('thoughtTokens', counts.thoughtTokens)
-    add('cachedReadTokens', counts.cachedReadTokens)
-    add('cachedWriteTokens', counts.cachedWriteTokens)
-    this.writeUsage(key, u)
+    this.mergeUsage(key, (u) => {
+      const add = (field: keyof TokenCounts, value: number | undefined) => {
+        if (value !== undefined) u[field] = (u[field] ?? 0) + value
+      }
+      add('totalTokens', counts.totalTokens)
+      add('inputTokens', counts.inputTokens)
+      add('outputTokens', counts.outputTokens)
+      add('thoughtTokens', counts.thoughtTokens)
+      add('cachedReadTokens', counts.cachedReadTokens)
+      add('cachedWriteTokens', counts.cachedWriteTokens)
+      return u
+    })
   }
 
   /** Overwrite the session's context-window + cost snapshot (latest `usage_update`
    *  wins). Only provided fields are updated. No-op on an unknown key. */
   setUsageSnapshot(key: string, snap: UsageSnapshot): void {
-    const u = this.getUsage(key)
-    if (snap.contextUsed !== undefined) u.contextUsed = snap.contextUsed
-    if (snap.contextSize !== undefined) u.contextSize = snap.contextSize
-    if (snap.costAmount !== undefined) u.costAmount = snap.costAmount
-    if (snap.costCurrency !== undefined) u.costCurrency = snap.costCurrency
-    this.writeUsage(key, u)
+    this.mergeUsage(key, (u) => {
+      if (snap.contextUsed !== undefined) u.contextUsed = snap.contextUsed
+      if (snap.contextSize !== undefined) u.contextSize = snap.contextSize
+      if (snap.costAmount !== undefined) u.costAmount = snap.costAmount
+      if (snap.costCurrency !== undefined) u.costCurrency = snap.costCurrency
+      return u
+    })
   }
 
   /** Add one turn's fallback cost to the session running total. Refuse to mix
    *  currencies; a later ACP usage_update can still replace the total snapshot. */
   addCost(key: string, amount: number, currency: string): boolean {
     if (!Number.isFinite(amount) || amount <= 0 || !currency) return false
-    const u = this.getUsage(key)
-    if (u.costCurrency !== undefined && u.costCurrency !== currency) return false
-    u.costAmount = (u.costAmount ?? 0) + amount
-    u.costCurrency = currency
-    this.writeUsage(key, u)
-    return true
+    // Set at most once and only by the refusal branch, so repeating the merge cannot change it.
+    let mixedCurrency = false
+    this.mergeUsage(key, (u) => {
+      if (u.costCurrency !== undefined && u.costCurrency !== currency) {
+        mixedCurrency = true
+        return undefined
+      }
+      u.costAmount = (u.costAmount ?? 0) + amount
+      u.costCurrency = currency
+      return u
+    })
+    return !mixedCurrency
   }
 
   /** Most-recent activity across an agent's non-closed sessions (epoch ms), or null
@@ -3234,12 +3284,28 @@ export class LocalStore {
     return out
   }
 
+  /**
+   * The persisted CP routing map — one row, and therefore EXCLUSIVELY OWNED STORES ONLY.
+   *
+   * `CpRoutingLayer` serializes its whole in-memory map on every mutation, so on a shared store
+   * each member's write erased every other member's and each boot hydrated a foreign map — a
+   * foreign `routingEpoch` with it, which then made `applyUpdate`'s stale guard discard legitimate
+   * global-rule updates until the real epoch caught up. Partitioning the row per member does not
+   * fix it either: `ownerId` is a process incarnation, so the key would change on every restart,
+   * leaking a row each time and still hydrating nothing.
+   *
+   * A shared member therefore starts from an empty map at epoch 0, which is the safe direction: it
+   * accepts the first `route/update` it is pushed, and `converge()` restates assignments from the
+   * CP snapshot on register/ok. An exclusively owned store keeps persisting exactly as before.
+   */
   getCpRouting(): { routingEpoch: number; assignments: string; globalRules: string } | undefined {
+    if (this.shared) return undefined
     return this.db.prepare('SELECT routingEpoch, assignments, globalRules FROM cp_routing WHERE id = 1').get() as
       { routingEpoch: number; assignments: string; globalRules: string } | undefined
   }
 
   setCpRouting(routingEpoch: number, assignments: string, globalRules: string): void {
+    if (this.shared) return
     this.db
       .prepare(
         `INSERT INTO cp_routing (id, routingEpoch, assignments, globalRules) VALUES (1, @routingEpoch, @assignments, @globalRules)

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -47,7 +47,7 @@ describe('LocalStore schema versioning', () => {
     expect(userVersion(path)).toBe(stamped)
   })
 
-  it('adds permission ownership when upgrading a v1 store', () => {
+  it('adds permission ownership, recovery ownership and per-owner routing when upgrading a v1 store', () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-schema-v1-')), 'local.sqlite')
     new LocalStore(path).close()
     const old = new DatabaseSync(path)
@@ -84,6 +84,30 @@ describe('LocalStore schema versioning', () => {
     // A stamp is only comparable to a fire of the same schedule definition (#1031).
     expect(cronColumns).toContain('definition')
     expect(userVersion(path)).toBe(8)
+  })
+
+  it('never persists the CP routing map on a shared store, and still does on an owned one', () => {
+    // One row and many members: each member's save used to erase every other member's, and each
+    // boot hydrated whichever map was written last — a foreign `routingEpoch` with it. A shared
+    // member now writes nothing and reads nothing, so it starts from an empty map at epoch 0.
+    const database = new DatabaseSync(join(mkdtempSync(join(tmpdir(), 'ac-schema-shared-')), 'local.sqlite'))
+    const first = new LocalStore({ database, shared: true, ownerId: 'member-1' })
+    const second = new LocalStore({ database, shared: true, ownerId: 'member-2' })
+
+    first.setCpRouting(1, '{"a":[]}', '[]')
+    second.setCpRouting(9, '{"b":[]}', '[{"kind":"global"}]')
+    expect(first.getCpRouting()).toBeUndefined()
+    expect(second.getCpRouting()).toBeUndefined()
+    // Not even a row to leak: `ownerId` is a process incarnation, so any partition key a member
+    // could write here would be abandoned on its next restart.
+    expect(database.prepare('SELECT COUNT(*) AS n FROM cp_routing').get()).toMatchObject({ n: 0 })
+    database.close()
+
+    // An exclusively owned store is untouched: it is the one store where the row survives a restart.
+    const solo = store()
+    solo.setCpRouting(4, '{"solo":[]}', '[{"kind":"global"}]')
+    expect(solo.getCpRouting()).toMatchObject({ routingEpoch: 4, assignments: '{"solo":[]}' })
+    solo.close()
   })
 
   it('re-keys the capture gate by agent when upgrading a v5 store', () => {
@@ -528,6 +552,57 @@ describe('LocalStore', () => {
     s.setUsageSnapshot(key, { costAmount: 0.25, costCurrency: 'USD' })
     expect(s.getUsage(key)).toMatchObject({ costAmount: 0.25, costCurrency: 'USD' })
     s.close()
+  })
+
+  it('keeps an increment a concurrent writer would otherwise have erased', () => {
+    // The pool shape: two members touch one session across a handover. `usage` is one JSON blob, so
+    // a plain read-merge-write silently drops whichever writer commits first. The compare-and-set
+    // notices and re-merges instead.
+    const database = new DatabaseSync(join(mkdtempSync(join(tmpdir(), 'ac-usage-race-')), 'local.sqlite'))
+    const peer = new LocalStore({ database, shared: true, ownerId: 'member-2' })
+    const key = sessionKey('slack', 'C1', 'T1', 'bot-a')
+
+    // Slip the peer's whole write in between our read and our compare-and-set, exactly once.
+    let raced = false
+    const racing: StoreDatabase = {
+      exec: (sql) => database.exec(sql),
+      close: () => database.close(),
+      prepare: (sql) => {
+        const statement = database.prepare(sql)
+        if (!sql.startsWith('SELECT usage FROM sessions')) return statement
+        return {
+          run: (...params) => statement.run(...params),
+          all: (...params) => statement.all(...params),
+          get: (...params) => {
+            const row = statement.get(...params)
+            if (!raced) {
+              raced = true
+              peer.addTokenUsage(key, { totalTokens: 5 })
+            }
+            return row
+          }
+        }
+      }
+    }
+    const member = new LocalStore({ database: racing, shared: true, ownerId: 'member-1' })
+    member.upsertSession({
+      key,
+      agentId: 'bot-a',
+      platform: 'slack',
+      channel: 'C1',
+      thread: 'T1',
+      acpSessionId: 'acp-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: 1
+    })
+
+    member.addTokenUsage(key, { totalTokens: 10 })
+
+    expect(raced).toBe(true)
+    // 15, not 10: the peer's 5 survived our write instead of being overwritten by it.
+    expect(peer.getUsage(key)).toMatchObject({ totalTokens: 15 })
+    database.close()
   })
 })
 


### PR DESCRIPTION
Works through the low-severity items in #1041 one at a time. Five of the seven are fixed here, one turned out to be already fixed on `main`, and one is left alone because closing it is a tenancy decision rather than a mechanical fix. Two commits, split by package.

Every item below is the same underlying mistake in a different place: **"one daemon owns this agent for its lifetime"**, encoded either as `agent.daemonId` or as one install-wide row. Neither holds on the pool.

## What is fixed

### 1 — `cp_routing` is one install-wide row rewritten from each member's memory ✅

`CHECK (id = 1)`, and `CpRoutingLayer` serializes the process's whole `assignments` map on every mutation. On a shared store each member's write erased every other member's, and each boot hydrated whichever map was written last — including a foreign `routingEpoch`, which then made `applyUpdate`'s stale guard drop legitimate global-rule updates until the real epoch caught up.

**A shared store no longer reads or writes the row at all**, which is the second of the two fixes the issue offered.

I tried the first one — partitioning the row per member — and it does not work, which is worth recording because it looks like the better answer. `ownerId` is a **process incarnation**: `PostgresDataPlane` mints `randomUUID()` on every open, and `local-store.ts` describes the column as "daemon incarnation holding the grant". That is exactly right for the other things keyed on it, which are all claims and caches, but a per-owner `cp_routing` key would change on every restart — abandoning a row each time and still hydrating nothing. No stable member identity exists at store-open time either: the CP assigns `daemonId` later, at auth/ok, and minting one is a placement decision rather than a bug fix. So the partitioned version bought nothing over not persisting, and cost a schema migration and a row leak. (Caught in review by @agentconnect-md-test — the earlier revision of this PR had the per-owner key.)

Not persisting is safe in the direction that matters. A shared member starts from an empty map at epoch 0, so it **accepts** the first `route/update` it is pushed instead of discarding pushes against a foreign epoch, and `converge()` restates assignments from the CP snapshot on register/ok. An exclusively owned store is untouched — it is the one store where the row genuinely survives a restart, and it still does. No schema change, so no version bump and nothing to migrate.

### 2 — `findThreadOwner` excludes every pool agent ✅

The `daemonId: { not: null }` predicate meant the pull-on-miss fallback for un-mentioned thread follow-ups never fired for a pool agent. The repo now answers with the **agent** and says nothing about placement; `lookupThread` resolves the member through `routableDaemon`.

Routable, not serving, deliberately: this seeds relay ingress affinity, so a member that holds the agent but has not yet reported it must not be named. With nothing routable the target stays `null` — which the relay retries — rather than a stale member it would cache against the deliveryId.

`lookupThread`'s other leg still returns `SharedThreadAgent.daemonId` verbatim. `agentRouting.ts:15` defers thread affinity to a later milestone, so as the issue says, that half stays known-deferred.

### 3 — `channel/agents` binds ownership on the ingress projection ✅

Bound on `mayAct` (holders) against the unresolved directory, while the returned roster stays `resolveDirectory` (confirmed holders) for the wake targets — exactly as the issue prescribes.

**One thing beyond the literal fix, because without it the fix does nothing.** `visibleToRequester` fails closed on a requester missing from the roster it is asking about. A member holding an unconfirmed grant would therefore pass the new bind and still be told it has no peers — the reported symptom, unchanged. So the requester's own row now rides along when nothing routes to it yet. Its peers stay filtered by routability and an agent never wakes itself, so this does not reintroduce a discoverable-but-uncallable peer (the invariant the channel-scope intersection exists to protect). Flagging it explicitly as the one place I widened an item.

### 4 — the organization-environment gate fails *open* for pool agents ✅

The inverse of the others: `daemonId === null` read as "unplaced, always fine", so a placed pool agent skipped the `AGENT_CONFIG_REVISION_FEATURE` precondition entirely. The gate now asks the resolver which daemons serve the agent and checks each. Byte-identical for a machine placement (`placementTargets` returns the one id), correct at last for a set one, and an agent nothing serves is still fine because placement re-checks the feature.

### 5 — `sessions.usage` accumulation is a read-modify-write ✅

`addTokenUsage` and `addCost` are genuinely additive and dropped the loser's increment when two members touched one session across a handover.

The issue suggests a single relative `UPDATE`. That is not available here — `usage` is one JSON blob and the two backends spell JSON mutation differently (`json_set` vs `jsonb_set`), so no single statement works on both. A compare-and-set is plain SQL in both, and closes the same gap: all four writers now go through one merge that re-merges on a lost race and, on its last attempt, degrades to exactly the blind write it replaces — so this can never be worse than the behaviour it removes.

## Not in this PR

### 6 — boot inbox replay logs one warn per foreign row — **already fixed on `main`**

`daemon.ts` now computes `const level = this.dataPlane ? 'debug' : 'warn'` and skips on `!this.servesAgent(row.agentId)`. Landed while this batch was in progress; nothing to do. Worth closing that item on the issue.

### 7 — the org-fenced data-plane transcript table is off the write path — **skipped, needs a design decision**

The issue's own framing is "either wiring up or deleting". Those are opposite tenancy decisions, not two spellings of one fix: wiring it up makes transcripts org-fenced at the data plane and touches the read path plus the `LocalStore` mirror schema, which has no `org_id` at all; deleting it concedes that the fence does not apply to this data. Which one is right is a call about the tenancy model, so it wants an owner's decision rather than a drive-by patch.

## Verification

Each fix is pinned by a test that **fails against the previous predicate** — checked by reverting the fix and watching the new test go red, then restoring:

| Item | Test | Fails on the old code with |
| --- | --- | --- |
| 1 | `never persists the CP routing map on a shared store, and still does on an owned one` | each member reading back a peer's map |
| 2 | `resolves a POOL owner through the placement resolver` | no target at all |
| 3 | `serves a member that HOLDS the requester but has not yet confirmed the grant` | `expected [] to deeply equal [ …(2) ]` |
| 4 | `gates a SET-placed agent on the member holding it` | `expected 200 to be 409` |
| 5 | `keeps an increment a concurrent writer would otherwise have erased` | `{ totalTokens: 10 }` vs `15` |

The item-5 test interleaves a peer's entire write between the read and the CAS through a wrapping `StoreDatabase`, so the race is deterministic rather than timing-dependent.

Suites, on this branch rebased onto current `main`:

- control-plane — 155 files / 1693 unit, 88 files / 1341 integration, all green
- daemon — 3667 passed. 14 failures, all reproduced on unmodified `main` before touching anything (`daemon-agent-mention-routing`, `daemon-duty-fence`, `daemon-duty-replacement`, `cp-agent-registry`, `gh-shim`, and `acp-matrix`, which needs live ACP runtimes). Identical set before and after.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean

The item-5 CAS statements were also exercised against a real PostgreSQL server rather than SQLite alone, via `postgres-pool-store.int.test.ts` and `postgres-transcript-store.int.test.ts`, since both store backends execute them.