### PR TITLE
fix(daemon): keep the agent's unrun inbox on a duty handoff

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1132,6 +1132,11 @@ interface CallMeta {
 
 type TurnInterruptReason = 'pause' | 'loop protection' | 'stop' | 'cancel' | 'shutdown' | 'superseded'
 
+/** What an interrupt means for the agent's admitted-but-unrun durable rows. `reason` cannot say
+ *  it: removal and a duty handoff are both `stop`. `terminal` ends that work here (pause, removal,
+ *  host respawn); `handoff` leaves the rows for the successor holder to replay (#1050). */
+type TurnInterruptDisposition = 'terminal' | 'handoff'
+
 /** One durable loop-guard scope shared by every agent on one physical bot.
  *  DMs are keyed at channel level because malformed platform wrappers may lose
  *  thread coordinates; threaded channel conversations retain their canonical
@@ -1536,6 +1541,9 @@ interface QueueEntry {
   /** The live inbox row was redacted into a durable terminal HookReport
    * receipt; removeInbox must retain it for restart-safe redelivery dedup. */
   hookTerminalReceipt?: boolean
+  /** A duty handoff released this row to the successor holder instead of ending it, so the
+   *  entry's later terminal settle must not delete it either (#1050). */
+  inboxHandedOff?: boolean
 }
 
 interface GithubQueueCandidate {
@@ -13407,7 +13415,10 @@ export class Daemon {
    *  longer served here" cannot be claimed. Immediate when no host exists. */
   private stopServingAgentSettled(agentId: string): Promise<void> {
     if (!this.dutyEnforced()) return Promise.resolve()
-    this.interruptAgentTurns(agentId, 'stop')
+    // A handoff, never a removal (#948): the turns stop here, but their admitted-but-unrun rows
+    // stay for whoever holds the duty next. Only a duty-governed member reaches this line, so a
+    // single daemon's terminal-purge semantics are untouched.
+    this.interruptAgentTurns(agentId, 'stop', 'handoff')
     this.scheduler.unregister(agentId)
     this.dreamScheduler.unregister(agentId)
     const prior = this.dutyHostStops.get(agentId) ?? Promise.resolve()
@@ -13806,10 +13817,16 @@ export class Daemon {
   /** Remove an entry's durable inbox row once its turn reaches ANY terminal state (success,
    *  reject/fail-stop, cancel, gate-drop) so it is not replayed on the next startup. No-op
    *  for a non-persisted entry (webchat / never-admitted). NOT called on graceful-shutdown
-   *  settle: those admitted-but-unrun rows are intentionally LEFT for startup replay. */
-  private removeInbox(entry: QueueEntry): void {
+   *  settle: those admitted-but-unrun rows are intentionally LEFT for startup replay.
+   *  `handoff` is the same retention for one agent: drop only this process's live claim so a
+   *  successor holder — or a later re-grant here — replays the row (#1050). */
+  private removeInbox(entry: QueueEntry, handoff = false): void {
     if (!entry.inboxId) return
     this.liveInboxIds.delete(entry.inboxId)
+    // Latched on the entry: the interrupted turn settles through dispatch's own terminal
+    // paths afterwards, and those must not delete the row the handoff just kept.
+    if (handoff) entry.inboxHandedOff = true
+    if (entry.inboxHandedOff) return
     // Hook rows become redacted terminal receipts in emitHookCompletion. If
     // that conversion failed (or shutdown deliberately skipped completion),
     // retaining the live row is the only restart-safe choice.
@@ -15967,6 +15984,8 @@ export class Daemon {
       preserveQueued?: boolean
       allowSameKeyAdmissions?: boolean
       allowGithubLane?: string
+      /** Duty handoff: stop running the work here, but leave its durable rows for the successor. */
+      handoffInbox?: boolean
     } = {}
   ): void {
     // The force-cancel fallback is host-wide. Hold NEW admissions until this exact
@@ -15987,7 +16006,7 @@ export class Daemon {
       if (reason === 'superseded' && activeEntry.hookContext) {
         this.emitHookCompletion(activeEntry.hookContext, 'failed', { reason }, activeEntry)
       } else {
-        this.removeInbox(activeEntry)
+        this.removeInbox(activeEntry, opts.handoffInbox)
       }
     }
     // Drop everything buffered behind this turn first (one unified queue) and settle each
@@ -16001,7 +16020,7 @@ export class Daemon {
         if (e.hookContext) {
           this.emitHookCompletion(e.hookContext, 'failed', { reason: opts.dropQueued ? 'dropped' : 'cancelled' }, e)
         }
-        this.removeInbox(e)
+        this.removeInbox(e, opts.handoffInbox)
         if (opts.dropQueued) e.resolve(null)
         else e.reject(new FailStopError(key))
       }
@@ -16067,11 +16086,17 @@ export class Daemon {
   /** Interrupt every logical session owned by an agent for a lifecycle gate (pause,
    *  removal, or host respawn). Active ACP turns are cancelled; queued turns are
    *  cleanly gate-dropped. A cold head is latched so it cannot resume after teardown. */
-  private interruptAgentTurns(agentId: string, reason: TurnInterruptReason): void {
+  private interruptAgentTurns(
+    agentId: string,
+    reason: TurnInterruptReason,
+    disposition: TurnInterruptDisposition = 'terminal'
+  ): void {
+    const handoffInbox = disposition === 'handoff'
     this.beginSafetyDrain(agentId, reason)
-    // The interruption is terminal for every already-admitted turn. Delete durable
-    // rows first so an immediate daemon stop cannot preserve and replay old work.
-    this.purgeAgentInbox(agentId, reason)
+    // A terminal interrupt ends every already-admitted turn: delete the durable rows first so an
+    // immediate daemon stop cannot preserve and replay old work. A handoff keeps them instead —
+    // on a pool's shared store those rows ARE the unrun work the successor holder must replay.
+    if (!handoffInbox) this.purgeAgentInbox(agentId, reason)
     const targets = new Map<string, string | undefined>()
     for (const [key, entry] of this.activeGateEntries) {
       if (entry.agentId !== agentId) continue
@@ -16089,7 +16114,7 @@ export class Daemon {
     if (targets.size > 0)
       this.log.info(`${reason}: interrupting ${targets.size} active session(s) for agent "${agentId}"`)
     for (const [key, acpSessionId] of targets) {
-      this.interruptTurn(agentId, key, reason, acpSessionId, { dropQueued: true })
+      this.interruptTurn(agentId, key, reason, acpSessionId, { dropQueued: true, handoffInbox })
     }
   }
 

--- a/packages/daemon/test/daemon-duty-inbox-replay.test.ts
+++ b/packages/daemon/test/daemon-duty-inbox-replay.test.ts
@@ -231,3 +231,91 @@ describe('replaying the shared inbox on a duty gain', () => {
     await b.daemon.stop()
   }, 20_000)
 })
+
+// A duty handoff is not an agent removal (#1050). `stopServingAgent` interrupts the turns running
+// here, but on a pool's shared store the agent's admitted-but-unrun rows are the work the successor
+// holder has to replay — purging them makes a GRACEFUL revoke/fence/drain lose messages a crash
+// would have preserved. These pin that the retiring member keeps the rows and that removal, the
+// other caller of the same interrupt, still discards them.
+describe('a duty handoff leaves the agent’s unrun inbox to its successor', () => {
+  const seedRow = (root: string, ts: string, text: string) => {
+    const s = new LocalStore(statePath(root))
+    s.appendInbox({
+      id: `slack:C1:${ts}`,
+      sessionKey: sessionKey('slack', 'C1', 'T1', AGENT),
+      agentId: AGENT,
+      msg: JSON.stringify(msg(ts, text)),
+      integrationId: INTEGRATION,
+      callMeta: null,
+      isQueueCmd: null,
+      enqueuedAt: ts
+    })
+    s.close()
+  }
+
+  it('a graceful fence keeps the admitted row and the successor runs it exactly once', async () => {
+    const rootA = scaffold()
+    const a = await boot(rootA)
+    await admit(a.daemon)
+    await settled(a.daemon)
+    // Admitted before the ACK settled and not yet started — the row a crash would leave behind.
+    seedRow(rootA, '100', 'finish the report')
+
+    fence(a.daemon)
+    await settled(a.daemon)
+    expect(holds(a.daemon)).toBe(false)
+    expect(a.host.prompt).not.toHaveBeenCalled()
+    // On main the fence purged this row, so the successor below had nothing to replay.
+    expect(inbox(rootA).map((r) => r.id)).toEqual(['slack:C1:100'])
+
+    const b = await boot(scaffold(rootA))
+    await admit(b.daemon, '2')
+    await vi.waitFor(() => expect(b.started).toHaveLength(1), WAIT)
+    expect(b.started[0]).toContain('finish the report')
+    await settled(b.daemon)
+    expect(b.host.prompt).toHaveBeenCalledTimes(1)
+
+    b.releaseAll()
+    await vi.waitFor(() => expect(inbox(rootA)).toHaveLength(0), WAIT)
+    await Promise.all([a.daemon.stop(), b.daemon.stop()])
+  }, 20_000)
+
+  it('the interrupted head and everything queued behind it survive the retiring member’s teardown', async () => {
+    const rootA = scaffold()
+    const a = await boot(rootA)
+    await admit(a.daemon)
+    await settled(a.daemon)
+    const head = (a.daemon as any).dispatch(AGENT, msg('100', 'first'), INTEGRATION)
+    void head.catch(() => {})
+    await vi.waitFor(() => expect(a.started).toHaveLength(1), WAIT)
+    const queued = (a.daemon as any).dispatch(AGENT, msg('200', 'second'), INTEGRATION)
+    void queued.catch(() => {})
+    await vi.waitFor(() => expect(inbox(rootA)).toHaveLength(2), WAIT)
+
+    fence(a.daemon)
+    await settled(a.daemon)
+    expect(inbox(rootA).map((r) => r.id)).toEqual(['slack:C1:100', 'slack:C1:200'])
+    // The cancelled head settles through dispatch's own terminal paths afterwards; those must
+    // not delete the row the handoff just kept.
+    a.releaseAll()
+    await head.catch(() => {})
+    await queued.catch(() => {})
+    await new Promise((r) => setTimeout(r, 50))
+    expect(inbox(rootA).map((r) => r.id)).toEqual(['slack:C1:100', 'slack:C1:200'])
+    await a.daemon.stop()
+  }, 20_000)
+
+  it('removing the agent still discards its unrun rows', async () => {
+    const rootA = scaffold()
+    const a = await boot(rootA)
+    await admit(a.daemon)
+    await settled(a.daemon)
+    seedRow(rootA, '100', 'work nobody will do')
+    expect(inbox(rootA)).toHaveLength(1)
+
+    // The destructive authority-release fence every agent removal runs.
+    await (a.daemon as any).quiesceAgentWorkspaceAuthority(AGENT)
+    expect(inbox(rootA)).toHaveLength(0)
+    await a.daemon.stop()
+  }, 20_000)
+})


### PR DESCRIPTION
## Summary

Closes #1050. A duty handoff is not an agent removal (#948), but the two shared one
teardown: `stopServingAgent` → `interruptAgentTurns(…, 'stop')` → `purgeAgentInbox`,
which deletes every ordinary durable inbox row the agent owns. On a pool member that
inbox is the shared data-plane store, so the retiring member was deleting the
admitted-but-unrun work its successor is supposed to pick up. #1049 made the successor
replay that backlog on gaining the duty — this makes sure there is still a backlog to
replay after a graceful handoff.

`reason` cannot express the difference: removal, pause-adjacent host respawn and a duty
handoff all arrive as `stop`. So the intent is now explicit rather than inferred.

## Failure scenario

Member A holds agent X on a pool sharing one data-plane store. A message for X is
admitted and durably recorded; it is queued behind the turn in flight, or its row landed
before the admission settled. The deployment side then moves the duty gracefully — a CP
`duty/revoke`, A's own lease self-fence, a withdrawal mid-admission, or the per-group
release a SIGTERM drain performs. A's `stopServingAgent` purges X's rows on the way out.
B is granted the group, replays X's inbox (#1049) and finds nothing: the user's message
was acknowledged as delivered and never runs anywhere. Only an unclean death of A —
which purges nothing — left the work recoverable, so the graceful path was strictly
worse than a crash. On drain (#1021) in-flight turns are allowed to finish first, but
rows queued behind them were still purged.

## Fix

`interruptAgentTurns` takes an explicit `TurnInterruptDisposition`:

- `terminal` (the default) is today's behaviour and stays on every lifecycle gate —
  pause, reconcile `toStop`, host respawn, and the destructive authority-release fence
  every agent removal runs.
- `handoff` is passed by `stopServingAgentSettled` alone, the single entry point behind
  revoke / fence / withdraw / drain release. It skips `purgeAgentInbox` and threads the
  intent into `interruptTurn`, which otherwise deletes the interrupted head's row and
  every row queued behind it — skipping only the bulk purge would have changed nothing.

Retention is latched on the queue entry (`inboxHandedOff`), because the cancelled head
settles asynchronously afterwards through dispatch's own terminal paths, and those must
not delete the row the handoff just kept. The process-local claim (`liveInboxIds`) is
still dropped, so a later re-grant to this same member replays the row instead of
skipping it as already live.

Local single-daemon semantics are untouched without a second condition:
`stopServingAgentSettled` already returns early unless duties are enforced, so a daemon
that is not a pool member never reaches the handoff disposition.

Deliberately out of scope: hook rows keep their existing completion-owner behaviour
(`purgeAgentInbox` never removed them, and a queued hook entry is still reported failed
on interrupt), and no sweep for rows whose successor never arrives — that is #1032's
seam. K8s driver, outboxes and orchestration are untouched.

## Test plan

- [x] `test/daemon-duty-inbox-replay.test.ts` (#1049's two-members-over-one-shared-store
      fixture) gains three cases: a graceful fence keeps the admitted row and the granted
      successor runs it exactly once; the interrupted head plus everything queued behind
      it survive the retiring member's teardown, including the later settle of the
      cancelled turn; removing the agent still discards its unrun rows. The first two
      fail on `main`.
- [x] `pnpm --filter @agentconnect.md/daemon typecheck`
- [x] daemon duty install / fence / replacement / drain, inbox-replay, lifecycle and
      durable-inbox suites — 164 tests
- [x] `pnpm lint`, `pnpm format:check`
