### PR TITLE
fix(daemon): scope the session TTL/GC sweeps to the duty holder and lease purge receipts per member

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2462,6 +2462,7 @@ export class Daemon {
   // Single-flight for the purge-receipt drain (#485): the sweep and a CP reconnect
   // can both trigger it, and each batch awaits a correlated ACK.
   private sessionPurgeDrainInFlight = false
+  private sessionPurgeDrainRerun = false
   // One-at-a-time durable session metadata sync. Sequential ACKs provide natural
   // CP/DB backpressure after an outage; the promise is joined during shutdown.
   private sessionMetadataDrain?: Promise<void>
@@ -12980,6 +12981,8 @@ export class Daemon {
     this.onDutyChanged()
     // After the arm, so a catch-up runs against the schedules this member now actually holds.
     this.catchUpMissedSchedules(result.agentsGained)
+    // The purge-receipt drain is holder-scoped, so a receipt a prior holder left is owed by this member now.
+    if (result.agentsGained.length) void this.drainSessionPurges()
   }
 
   /**
@@ -19692,8 +19695,13 @@ export class Daemon {
     // reconnect drains them, so attempting the request here would only log a
     // failure every sweep for a daemon that is deliberately running local.
     if (!cp || (cp.state !== 'READY' && cp.state !== 'DRAINING')) return
-    if (this.sessionPurgeDrainInFlight) return
+    // Coalesced, not dropped: a trigger that lands mid-drain (a duty gained) runs one more pass after it.
+    if (this.sessionPurgeDrainInFlight) {
+      this.sessionPurgeDrainRerun = true
+      return
+    }
     this.sessionPurgeDrainInFlight = true
+    this.sessionPurgeDrainRerun = false
     try {
       const stale = this.store.pruneSessionPurges(this.clock.now() - SESSION_PURGE_RECEIPT_TTL_MS)
       if (stale)
@@ -19787,6 +19795,7 @@ export class Daemon {
     } finally {
       this.sessionPurgeDrainInFlight = false
     }
+    if (this.sessionPurgeDrainRerun) await this.drainSessionPurges()
   }
 
   private sweepIdle(): void {
@@ -19821,6 +19830,8 @@ export class Daemon {
       void this.sweepSessionRetention().catch((err) =>
         this.log.warn(`retention: session GC sweep failed (${formatErr(err)})`)
       )
+      // Backstop for receipts this member came to own without a sweep of its own (a lapsed peer's).
+      void this.drainSessionPurges()
     }
     const ttl = this.cfg.limits.agentIdleTimeoutMs
     const maxLifetime = this.cfg.limits.agentMaxLifetimeMs

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10306,7 +10306,7 @@ export class Daemon {
     this.orchestrationDeadlines.set(orchestrationId, handle)
   }
 
-  /** Whether this member serves the agent's ingress edges (crons, deadlines): the duty holder, or any local daemon. */
+  /** Whether this member serves the agent's ingress edges and sweeps: the duty holder, or any local daemon. */
   private servesAgent(agentId: string): boolean {
     return !this.dutyEnforced() || this.duties.holdsAgent(agentId)
   }
@@ -19559,9 +19559,11 @@ export class Daemon {
    *  state stays reachable through the same logical session. */
   /** The retention sweep's active-turn exclusion, beyond the durable-state filter:
    *  a claimed serial gate (owns cold dispatch + queued arrivals), a live Pending
-   *  turn, pending durable inbox work, or unsettled SDK background tasks. */
+   *  turn, pending durable inbox work, or unsettled SDK background tasks. All are
+   *  member-local, so an agent this member does not serve counts as active (#1032). */
   private sessionRetentionActive(rec: { key: string; agentId: string; acpSessionId: string | null }): boolean {
     return (
+      !this.servesAgent(rec.agentId) ||
       this.drainingAgents.has(rec.agentId) ||
       this.inflight.has(rec.key) ||
       [...this.pending.values()].some((p) => p.sessionKey === rec.key) ||
@@ -19607,7 +19609,10 @@ export class Daemon {
     if (this.sessionRetentionSweepInFlight) return
     this.sessionRetentionSweepInFlight = true
     try {
-      const expired = this.store.listExpiredSessions(this.clock.now() - windowMs)
+      // Holder-only on a pool: the active-turn exclusions are member-local, so only the holder can judge a row.
+      const expired = this.store
+        .listExpiredSessions(this.clock.now() - windowMs)
+        .filter((rec) => this.servesAgent(rec.agentId))
       if (!expired.length) return
       // ONE stamp for the whole pass, not one per session: it is the sweep that
       // deleted them, and a shared value lets the drain report a pass as a single
@@ -19651,7 +19656,7 @@ export class Daemon {
         // The purge receipt is written in deleteSession's transaction: the CP holds
         // the only surviving record of this session, and it must be told that the
         // content behind it is gone (drained below, durably, on ACK).
-        if (this.store.deleteSession(rec.key, { reason: 'retention', at: purgedAt })) {
+        if (this.store.deleteSession(rec.key, { reason: 'retention', at: purgedAt, ownerId: this.cfg.daemonId })) {
           removed += 1
           if (rec.acpSessionId) this.sdkLease.delete(sdkLeaseKey(rec.agentId, rec.acpSessionId))
         }
@@ -19699,7 +19704,14 @@ export class Daemon {
         )
       // Bounded per pass: whatever is left is picked up by the next sweep or
       // reconnect, so a large backlog drains steadily instead of in one burst.
-      const owed = this.store.listSessionPurges(MAX_SESSION_PURGE_BATCH * 10)
+      // Shared on a pool: offered its own rows, unowned ones, and a lapsed peer's for agents it serves.
+      const served = [...this.agents.keys()].filter((agentId) => this.servesAgent(agentId))
+      const owed = this.store.listSessionPurges(
+        MAX_SESSION_PURGE_BATCH * 10,
+        this.clock.now(),
+        this.cfg.daemonId,
+        served
+      )
       if (!owed.length) return
       // One group per (agent, reason, purge time): the frame states all three for
       // every session it carries, so rows that disagree on any of them must not
@@ -19718,8 +19730,15 @@ export class Daemon {
       }
       let reported = 0
       let skippedReasons = 0
+      let leftForHolder = 0
       for (const rows of groups.values()) {
         const { agentId, reason, purgedAt } = rows[0]!
+        // The CP ACKs a non-holder without marking, so a foreign agent's rows are left for the holder
+        // (the claim lapses) — and skipped, never returned on, so they cannot block the groups behind them.
+        if (!this.servesAgent(agentId)) {
+          leftForHolder += rows.length
+          continue
+        }
         // A reason this build cannot express on the wire would be silently
         // mislabeled as something else, so report the gap and keep the receipts.
         const parsed = SessionPurgeReason.safeParse(reason)
@@ -19729,10 +19748,18 @@ export class Daemon {
         }
         for (let i = 0; i < rows.length; i += MAX_SESSION_PURGE_BATCH) {
           const batch = rows.slice(i, i + MAX_SESSION_PURGE_BATCH)
+          // Emit only under a live claim: a row a peer took over since the read stays with it.
+          const sessionIds = this.store.claimSessionPurges(
+            agentId,
+            batch.map((row) => row.sessionId),
+            this.cfg.daemonId,
+            this.clock.now()
+          )
+          if (!sessionIds.length) continue
           try {
             const result = await cp.emitSessionPurged({
               agentId,
-              sessionIds: batch.map((row) => row.sessionId),
+              sessionIds,
               reason: parsed.data,
               ts: new Date(purgedAt).toISOString()
             })
@@ -19740,19 +19767,18 @@ export class Daemon {
               this.log.debug('retention: control plane does not accept purge receipts yet — keeping them')
               return
             }
-            this.store.acknowledgeSessionPurges(
-              agentId,
-              batch.map((row) => row.sessionId)
-            )
-            reported += batch.length
+            this.store.acknowledgeSessionPurges(agentId, sessionIds, this.cfg.daemonId)
+            reported += sessionIds.length
           } catch (err) {
             // Keep the receipts. The report is idempotent on the CP, so re-sending
             // an already-applied batch after a lost ACK is safe.
             this.log.warn(`retention: purge receipt report failed for agent ${agentId} (${formatErr(err)})`)
-            return
+            break
           }
         }
       }
+      if (leftForHolder)
+        this.log.debug(`retention: ${leftForHolder} purge receipt(s) belong to agents another member serves — kept`)
       if (skippedReasons)
         this.log.warn(`retention: ${skippedReasons} purge receipt(s) carry a reason this build cannot report — kept`)
       if (reported) this.log.info(`retention: reported ${reported} purged session(s) to the control plane`)
@@ -19799,11 +19825,12 @@ export class Daemon {
     const ttl = this.cfg.limits.agentIdleTimeoutMs
     const maxLifetime = this.cfg.limits.agentMaxLifetimeMs
     // §7.3 idle→closed: a thread untouched past the TTL stops catching up — UNLESS it
-    // still has in-flight background work (the SDK lease), which keeps it open.
+    // still has in-flight background work (the SDK lease), which keeps it open. The
+    // lease is member-local, so on a pool only the agent's holder decides its rows.
     const closed = this.store.closeIdleSessions(
       now,
       ttl,
-      (agentId, acpSessionId) => !this.sessionSdkQuiescent(agentId, acpSessionId)
+      (agentId, acpSessionId) => !this.servesAgent(agentId) || !this.sessionSdkQuiescent(agentId, acpSessionId)
     )
     if (closed.length) this.log.info(`idle: TTL-closed ${closed.length} session(s) (>${Math.round(ttl / 1000)}s)`)
     // A failed remote revoke is queued durably by the grant ledger; the periodic

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -622,7 +622,7 @@ function restrictPath(path: string, mode: number): void {
  * change that edits a `CREATE TABLE` below, and append the matching step to
  * {@link SCHEMA_MIGRATIONS}.
  */
-const SCHEMA_VERSION = 8
+const SCHEMA_VERSION = 9
 
 /**
  * Ordered in-place upgrades for a store created by an EARLIER daemon.
@@ -698,6 +698,11 @@ const SCHEMA_MIGRATIONS: ((db: StoreDatabase) => void)[] = [
     db.exec(`
       DROP TABLE IF EXISTS runtime_catalog_meta;
       DROP TABLE IF EXISTS runtime_model_catalog;
+    `),
+  (db) =>
+    db.exec(`
+      ALTER TABLE session_purges ADD COLUMN ownerId TEXT;
+      ALTER TABLE session_purges ADD COLUMN claimedAt INTEGER;
     `)
 ]
 
@@ -809,12 +814,15 @@ export class LocalStore {
       -- losing it would leave the console rendering a permanently empty transcript
       -- with no explanation. Rows are dropped only on the CP's ACK.
       -- Keyed by (agentId, sessionId): ACP session ids are runtime-local, so two
-      -- agents can both have purged an acp-1.
+      -- agents can both have purged an acp-1. On a shared pool store ownerId /
+      -- claimedAt lease each receipt to one member the way inbox.reportOwnerId does.
       CREATE TABLE IF NOT EXISTS session_purges (
         agentId TEXT NOT NULL,
         sessionId TEXT NOT NULL,
         reason TEXT NOT NULL,
         purgedAt INTEGER NOT NULL,
+        ownerId TEXT,
+        claimedAt INTEGER,
         PRIMARY KEY (agentId, sessionId)
       );
       CREATE INDEX IF NOT EXISTS session_purges_fifo ON session_purges (purgedAt);
@@ -2273,7 +2281,7 @@ export class LocalStore {
    *  permission_requests and the capture gate are both scoped by agentId, so a
    *  neighbour holding the same runtime-local `acp-1` keeps its own rows.
    *  Returns false when the row is already gone (idempotent). */
-  deleteSession(key: string, purge?: { reason: string; at: number }): boolean {
+  deleteSession(key: string, purge?: { reason: string; at: number; ownerId?: string }): boolean {
     const rec = this.getSession(key)
     if (!rec) return false
     this.db.exec('BEGIN')
@@ -2286,9 +2294,13 @@ export class LocalStore {
       // re-created for the same id — the console should show when the content
       // actually went away, not when the daemon last retried.
       if (purge && rec.acpSessionId) {
+        // Stamped to the deleting member on a shared store: its drain owns the receipt.
         this.db
-          .prepare('INSERT OR IGNORE INTO session_purges (agentId, sessionId, reason, purgedAt) VALUES (?, ?, ?, ?)')
-          .run(rec.agentId, rec.acpSessionId, purge.reason, purge.at)
+          .prepare(
+            `INSERT OR IGNORE INTO session_purges (agentId, sessionId, reason, purgedAt, ownerId, claimedAt)
+             VALUES (?, ?, ?, ?, ?, ?)`
+          )
+          .run(rec.agentId, rec.acpSessionId, purge.reason, purge.at, purge.ownerId ?? null, purge.at)
       }
       this.db.prepare('DELETE FROM sessions WHERE key = ?').run(key)
       this.db.prepare('DELETE FROM session_mutes WHERE key = ?').run(key)
@@ -2412,21 +2424,76 @@ export class LocalStore {
 
   /** Retention-GC receipts still owed to the CP, oldest purge first, bounded.
    *  Grouped per agent by the caller: one `event/session-purged` frame reports one
-   *  agent, because the CP authorizes the report against that agent's placement. */
-  listSessionPurges(limit: number): SessionPurgeRow[] {
+   *  agent, because the CP authorizes the report against that agent's placement.
+   *  A local store owns every receipt outright. On a shared pool store a row is
+   *  offered only when this member owns it, when it is unowned (pre-pool), or when
+   *  its owner's claim lapsed AND this member serves the agent — the same lease
+   *  the hook-completion outbox uses, so a live peer's receipt stays with its owner. */
+  listSessionPurges(limit: number, now: number, ownerId?: string, agentIds?: readonly string[]): SessionPurgeRow[] {
+    const columns = 'SELECT agentId, sessionId, reason, purgedAt FROM session_purges'
+    const order = ' ORDER BY purgedAt ASC LIMIT @limit'
+    if (!this.shared) return this.db.prepare(`${columns}${order}`).all({ limit }) as unknown as SessionPurgeRow[]
+    const scope = idScope('agentId', agentIds)
     return this.db
-      .prepare('SELECT agentId, sessionId, reason, purgedAt FROM session_purges ORDER BY purgedAt ASC LIMIT ?')
-      .all(limit) as unknown as SessionPurgeRow[]
+      .prepare(
+        `${columns}
+         WHERE (ownerId IS NULL OR ownerId = @ownerId
+                OR (COALESCE(claimedAt, 0) <= @staleBefore${scope.sql}))${order}`
+      )
+      .all({
+        limit,
+        ownerId: ownerId ?? null,
+        staleBefore: now - SHARED_OUTBOX_LEASE_MS,
+        ...scope.params
+      }) as unknown as SessionPurgeRow[]
+  }
+
+  /** Take or renew this member's claim on the receipts of one frame before emitting
+   *  it, returning the session ids actually claimed — a row a peer took over between
+   *  the list and this CAS is left out. Local stores never lease: everything is claimed. */
+  claimSessionPurges(
+    agentId: string,
+    sessionIds: readonly string[],
+    ownerId: string | undefined,
+    now: number
+  ): string[] {
+    if (!this.shared) return [...sessionIds]
+    const claim = this.db.prepare(
+      `UPDATE session_purges
+       SET ownerId = @ownerId, claimedAt = @now
+       WHERE agentId = @agentId AND sessionId = @sessionId
+         AND (ownerId IS NULL OR ownerId = @ownerId OR COALESCE(claimedAt, 0) <= @staleBefore)`
+    )
+    const staleBefore = now - SHARED_OUTBOX_LEASE_MS
+    const claimed: string[] = []
+    this.db.exec('BEGIN')
+    try {
+      for (const sessionId of sessionIds) {
+        if (claim.run({ agentId, sessionId, ownerId: ownerId ?? null, now, staleBefore }).changes === 1)
+          claimed.push(sessionId)
+      }
+      this.db.exec('COMMIT')
+    } catch (err) {
+      this.db.exec('ROLLBACK')
+      throw err
+    }
+    return claimed
   }
 
   /** Settle receipts the CP has ACKed. Scoped by agent: the same ACP id may still
-   *  be owed for a different agent (ids are runtime-local). */
-  acknowledgeSessionPurges(agentId: string, sessionIds: string[]): void {
+   *  be owed for a different agent (ids are runtime-local). On a shared store only
+   *  the claim holder (or nobody) may release a row — never a peer. */
+  acknowledgeSessionPurges(agentId: string, sessionIds: string[], ownerId?: string): void {
     if (sessionIds.length === 0) return
-    const stmt = this.db.prepare('DELETE FROM session_purges WHERE agentId = ? AND sessionId = ?')
+    const fence = this.shared ? ' AND (ownerId IS NULL OR ownerId = @ownerId)' : ''
+    const stmt = this.db.prepare(
+      `DELETE FROM session_purges WHERE agentId = @agentId AND sessionId = @sessionId${fence}`
+    )
     this.db.exec('BEGIN')
     try {
-      for (const sessionId of sessionIds) stmt.run(agentId, sessionId)
+      for (const sessionId of sessionIds) {
+        stmt.run({ agentId, sessionId, ...(fence ? { ownerId: ownerId ?? null } : {}) })
+      }
       this.db.exec('COMMIT')
     } catch (err) {
       this.db.exec('ROLLBACK')

--- a/packages/daemon/src/store/postgres-sync-database.ts
+++ b/packages/daemon/src/store/postgres-sync-database.ts
@@ -27,6 +27,7 @@ const canonicalColumns = [
   'capsJson',
   'channelId',
   'childSessionId',
+  'claimedAt',
   'completedAt',
   'connectionId',
   'connectionRevision',

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -1999,7 +1999,7 @@ describe('Daemon session retention GC (#485)', () => {
     })
     expect(emitSessionPurged.mock.calls[0]![0].sessionIds.sort()).toEqual(['acp-expired-a', 'acp-expired-b'])
     // ACKed ⇒ the durable receipts are released.
-    expect((daemon as any).store.listSessionPurges(10)).toEqual([])
+    expect((daemon as any).store.listSessionPurges(10, 0)).toEqual([])
 
     await daemon.stop()
   }, 15_000)
@@ -2033,7 +2033,7 @@ describe('Daemon session retention GC (#485)', () => {
     expect(frames[0]!.ts).toBe(new Date(1_000).toISOString())
     expect(frames[1]!.sessionIds).toEqual(['acp-sweep-2'])
     expect(frames[1]!.ts).toBe(new Date(2_000).toISOString())
-    expect(store.listSessionPurges(10)).toEqual([])
+    expect(store.listSessionPurges(10, 0)).toEqual([])
 
     await daemon.stop()
   }, 15_000)
@@ -2052,7 +2052,7 @@ describe('Daemon session retention GC (#485)', () => {
     // Not even attempted: the receipt is durable and the reconnect drains it, so a
     // request here would only log a failure on every sweep of a local-only daemon.
     expect(emitSessionPurged).not.toHaveBeenCalled()
-    expect((daemon as any).store.listSessionPurges(10)).toHaveLength(1)
+    expect((daemon as any).store.listSessionPurges(10, 0)).toHaveLength(1)
 
     await daemon.stop()
   }, 15_000)
@@ -2074,7 +2074,7 @@ describe('Daemon session retention GC (#485)', () => {
     await (daemon as any).sweepSessionRetention()
     await (daemon as any).drainSessionPurges()
 
-    expect((daemon as any).store.listSessionPurges(10)).toMatchObject([
+    expect((daemon as any).store.listSessionPurges(10, 0)).toMatchObject([
       { agentId: 'bot-a', sessionId: 'acp-expired-a', reason: 'retention' }
     ])
 
@@ -2087,7 +2087,7 @@ describe('Daemon session retention GC (#485)', () => {
       stop: vi.fn()
     }
     await (daemon as any).drainSessionPurges()
-    expect((daemon as any).store.listSessionPurges(10)).toHaveLength(1)
+    expect((daemon as any).store.listSessionPurges(10, 0)).toHaveLength(1)
 
     await daemon.stop()
   }, 15_000)

--- a/packages/daemon/test/daemon-session-sweeps-pool.test.ts
+++ b/packages/daemon/test/daemon-session-sweeps-pool.test.ts
@@ -241,4 +241,30 @@ describe('session sweeps on a daemon pool are holder-only (#1032)', () => {
     await stop()
     for (const local of locals) local.close()
   }, 15_000)
+
+  it('gaining a duty after the socket came up replays the receipt a prior holder left, once', async () => {
+    const { a, b, root, stop } = await bootPool()
+    const path = statePath(root)
+    const locals: LocalStore[] = [a.inner.store, b.inner.store]
+    a.inner.store = new LocalStore({ database: new DatabaseSync(path), shared: true, ownerId: 'daemon-a' })
+    b.inner.store = new LocalStore({ database: new DatabaseSync(path), shared: true, ownerId: 'daemon-b' })
+    const shared: LocalStore = b.inner.store
+    // The prior holder purged this session and died before its receipt was ACKed.
+    seedSession(shared, 'left', AGENT_A, 'closed', 0)
+    shared.deleteSession('left', { reason: 'retention', at: 1_000, ownerId: 'daemon-a' })
+    await advance(b, 1_000 + 2 * 60_000 + 1)
+
+    // A fresh member's READY replay runs before its post-register grant is admitted: nothing is served yet.
+    await b.inner.drainSessionPurges()
+    expect(b.emitSessionPurged).not.toHaveBeenCalled()
+    // The grant lands: the receipt is this member's to report now, and it is reported exactly once.
+    b.inner.settleDutyChange(b.inner.duties.applyGrant([grant(GROUP_A, AGENT_A)]))
+    await vi.waitFor(() => expect(b.emitSessionPurged).toHaveBeenCalledOnce())
+    expect(b.emitSessionPurged.mock.calls[0]![0]).toMatchObject({ agentId: AGENT_A, sessionIds: ['acp-left'] })
+    await b.inner.drainSessionPurges()
+    expect(b.emitSessionPurged).toHaveBeenCalledOnce()
+    expect(shared.listSessionPurges(10, b.clock.now(), 'daemon-b', [AGENT_A])).toEqual([])
+    await stop()
+    for (const local of locals) local.close()
+  }, 15_000)
 })

--- a/packages/daemon/test/daemon-session-sweeps-pool.test.ts
+++ b/packages/daemon/test/daemon-session-sweeps-pool.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { Daemon } from '../src/daemon.js'
+import { LocalStore } from '../src/store/local-store.js'
+import { statePath } from '../src/paths.js'
+import { FakeClock } from './cp/fake-clock.js'
+
+/**
+ * #1032 — on a daemon pool the session table is one table for every member, but the
+ * TTL-close and retention-GC exemptions (the SDK background lease, the serial gate, the
+ * pending map) live in the memory of the member that serves the agent. Both sweeps are
+ * therefore holder-only, and the purge-receipt drain owns its rows per member exactly
+ * like the hook-completion outbox: a peer's row is skipped, never destroyed, and never
+ * head-of-line blocks the rows behind it.
+ */
+
+const AGENT_A = 'bot-a'
+const AGENT_B = 'bot-b'
+const GROUP_A = '11111111-1111-4111-8111-111111111111'
+const GROUP_B = '22222222-2222-4222-8222-222222222222'
+const TTL_MS = 900_000
+const DAY_MS = 24 * 3_600_000
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-sweeps-pool-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  for (const id of [AGENT_A, AGENT_B]) {
+    const adir = join(root, 'agents', id)
+    mkdirSync(adir, { recursive: true })
+    writeFileSync(
+      join(adir, 'agent.json'),
+      JSON.stringify({
+        id,
+        name: id,
+        status: 'active',
+        runtime: 'claude',
+        workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+        integrations: [],
+        output: { mode: 'low' }
+      })
+    )
+  }
+  return root
+}
+
+/** One pool member: duty leases gate service, exactly like an install-wide member. */
+async function boot(root: string, daemonId: string) {
+  const clock = new FakeClock()
+  const daemon = new Daemon({ root, hostFactory: () => ({}) as any, clock })
+  await daemon.start()
+  const inner = daemon as any
+  inner.cfg.daemonId = daemonId
+  const emitSessionPurged = vi.fn(async () => 'acknowledged' as const)
+  inner.cpClient = {
+    organizationScope: () => 'frame',
+    state: 'READY',
+    emitSessionPurged,
+    stop: async () => {},
+    releaseDuties: vi.fn(async () => {}),
+    reportDutiesNow: vi.fn(() => {}),
+    fetchDutyAgent: vi.fn()
+  }
+  return { daemon, inner, clock, emitSessionPurged }
+}
+
+/** Two members over ONE store: the same root, so both open the same database. Each member keeps
+ *  its own clock, so advancing one fires only that member's timers. */
+async function bootPool() {
+  const root = scaffold()
+  const a = await boot(root, 'daemon-a')
+  const b = await boot(root, 'daemon-b')
+  return { a, b, root, stop: () => Promise.all([a.daemon.stop(), b.daemon.stop()]) }
+}
+
+/** Advance a member past `ms`, letting the sweep its own timer fired settle first. */
+async function advance(member: { inner: any; clock: FakeClock }, ms: number): Promise<void> {
+  member.clock.advance(ms)
+  await vi.waitFor(() => expect(member.inner.sessionRetentionSweepInFlight).toBe(false))
+}
+
+const grant = (groupId: string, agentId: string) => ({
+  groupId,
+  orgId: 'org-1',
+  term: '1',
+  members: [{ kind: 'agent' as const, refId: agentId }]
+})
+const hold = (inner: any, groupId: string, agentId: string) => inner.duties.applyGrant([grant(groupId, agentId)])
+
+const seedSession = (store: LocalStore, key: string, agentId: string, state: 'idle' | 'closed', updatedAt: number) =>
+  store.upsertSession({
+    key,
+    agentId,
+    platform: 'slack',
+    channel: 'C1',
+    thread: key,
+    acpSessionId: `acp-${key}`,
+    state,
+    lastDeliveredTs: null,
+    updatedAt
+  })
+
+/** A's in-memory background-task lease for one of its sessions: live work the TTL sweep must respect. */
+function leaseLiveTask(inner: any, agentId: string, acpSessionId: string): void {
+  inner.sdkLease.set(JSON.stringify([agentId, acpSessionId]), {
+    agentId,
+    tasks: new Map([['task-1', { isSubagent: false, startedAt: 0 }]]),
+    settled: [],
+    sdkState: 'idle',
+    bgWakes: 0,
+    armedWakes: 0,
+    deliveringWakes: 0
+  })
+}
+
+describe('session sweeps on a daemon pool are holder-only (#1032)', () => {
+  it("a member's TTL sweep never closes a session of an agent it does not serve", async () => {
+    const { a, b, stop } = await bootPool()
+    hold(a.inner, GROUP_A, AGENT_A)
+    hold(b.inner, GROUP_B, AGENT_B)
+    const store: LocalStore = a.inner.store
+    // A's turn returned end_turn, the row is idle, and only A's lease knows the task is live.
+    seedSession(store, 'a-busy', AGENT_A, 'idle', 0)
+    leaseLiveTask(a.inner, AGENT_A, 'acp-a-busy')
+    seedSession(store, 'a-quiet', AGENT_A, 'idle', 0)
+    seedSession(store, 'b-quiet', AGENT_B, 'idle', 0)
+
+    // B holds no lease for A's session — before the fix that read as quiescent and closed it.
+    await advance(b, TTL_MS + 1)
+    b.inner.sweepIdle()
+    expect(store.getSession('a-busy')?.state).toBe('idle')
+    expect(store.getSession('a-quiet')?.state).toBe('idle')
+    expect(store.getSession('b-quiet')?.state).toBe('closed')
+
+    // The holder decides its own rows: the lease keeps one open, plain TTL closes the other.
+    await advance(a, TTL_MS + 1)
+    a.inner.sweepIdle()
+    expect(store.getSession('a-busy')?.state).toBe('idle')
+    expect(store.getSession('a-quiet')?.state).toBe('closed')
+    await stop()
+  }, 15_000)
+
+  it("a member's retention GC never deletes a session of an agent another member is mid-turn on", async () => {
+    const { a, b, stop } = await bootPool()
+    hold(a.inner, GROUP_A, AGENT_A)
+    hold(b.inner, GROUP_B, AGENT_B)
+    const store: LocalStore = a.inner.store
+    seedSession(store, 'a-turn', AGENT_A, 'idle', 0)
+    seedSession(store, 'b-old', AGENT_B, 'closed', 0)
+    // A owns the serial gate for its session — state B cannot see.
+    a.inner.inflight.add('a-turn')
+    await advance(a, 8 * DAY_MS)
+    await advance(b, 8 * DAY_MS)
+
+    await b.inner.sweepSessionRetention()
+    expect(store.getSession('a-turn')).toBeDefined()
+    expect(store.getSession('b-old')).toBeUndefined()
+
+    // A skips its own live turn, and deletes it once the turn is over.
+    await a.inner.sweepSessionRetention()
+    expect(store.getSession('a-turn')).toBeDefined()
+    a.inner.inflight.delete('a-turn')
+    await a.inner.sweepSessionRetention()
+    expect(store.getSession('a-turn')).toBeUndefined()
+    await stop()
+  }, 15_000)
+
+  it("the purge-receipt drain skips a peer's rows and still reports its own", async () => {
+    const { a, b, root, stop } = await bootPool()
+    hold(a.inner, GROUP_A, AGENT_A)
+    hold(b.inner, GROUP_B, AGENT_B)
+    // The pool's shared store: one receipt table, leased per member.
+    const path = statePath(root)
+    const locals: LocalStore[] = [a.inner.store, b.inner.store]
+    a.inner.store = new LocalStore({ database: new DatabaseSync(path), shared: true, ownerId: 'daemon-a' })
+    b.inner.store = new LocalStore({ database: new DatabaseSync(path), shared: true, ownerId: 'daemon-b' })
+    const shared: LocalStore = a.inner.store
+    const owed = () => shared.listSessionPurges(10, 0, 'daemon-a', [AGENT_A, AGENT_B]).map((row) => row.sessionId)
+
+    // A's sweep purged two of A's sessions and one legacy, unowned receipt sits alongside;
+    // B's own receipt is the youngest, so a drain that returned on the foreign group would never reach it.
+    seedSession(shared, 'a-1', AGENT_A, 'closed', 0)
+    seedSession(shared, 'a-2', AGENT_A, 'closed', 0)
+    seedSession(shared, 'a-legacy', AGENT_A, 'closed', 0)
+    seedSession(shared, 'b-1', AGENT_B, 'closed', 0)
+    shared.deleteSession('a-1', { reason: 'retention', at: 1_000, ownerId: 'daemon-a' })
+    shared.deleteSession('a-2', { reason: 'retention', at: 1_000, ownerId: 'daemon-a' })
+    shared.deleteSession('a-legacy', { reason: 'retention', at: 1_500 })
+    shared.deleteSession('b-1', { reason: 'retention', at: 2_000, ownerId: 'daemon-b' })
+    await advance(a, 10_000)
+    await advance(b, 10_000)
+
+    await b.inner.drainSessionPurges()
+    expect(b.emitSessionPurged).toHaveBeenCalledOnce()
+    expect(b.emitSessionPurged.mock.calls[0]![0]).toMatchObject({ agentId: AGENT_B, sessionIds: ['acp-b-1'] })
+    // A's live rows and the unowned row for A's agent are left for A: nothing was destroyed.
+    expect(owed().sort()).toEqual(['acp-a-1', 'acp-a-2', 'acp-a-legacy'])
+
+    await a.inner.drainSessionPurges()
+    const frames = a.emitSessionPurged.mock.calls.map((call: any[]) => call[0])
+    expect(frames.map((frame: any) => frame.agentId)).toEqual([AGENT_A, AGENT_A])
+    expect(frames.flatMap((frame: any) => frame.sessionIds).sort()).toEqual(['acp-a-1', 'acp-a-2', 'acp-a-legacy'])
+    expect(owed()).toEqual([])
+    await stop()
+    for (const local of locals) local.close()
+  }, 15_000)
+
+  it("a member's own receipt for an agent it no longer serves is left for the holder, not reported", async () => {
+    const { a, b, root, stop } = await bootPool()
+    hold(a.inner, GROUP_A, AGENT_A)
+    const path = statePath(root)
+    const locals: LocalStore[] = [a.inner.store, b.inner.store]
+    a.inner.store = new LocalStore({ database: new DatabaseSync(path), shared: true, ownerId: 'daemon-a' })
+    b.inner.store = new LocalStore({ database: new DatabaseSync(path), shared: true, ownerId: 'daemon-b' })
+    const shared: LocalStore = a.inner.store
+    // B purged this session while it held the agent; the duty then moved to A.
+    seedSession(shared, 'moved', AGENT_A, 'closed', 0)
+    shared.deleteSession('moved', { reason: 'retention', at: 1_000, ownerId: 'daemon-b' })
+    await advance(a, 10_000)
+    await advance(b, 10_000)
+
+    // The CP would ACK B without marking anything, so B must not report it...
+    await b.inner.drainSessionPurges()
+    expect(b.emitSessionPurged).not.toHaveBeenCalled()
+    // ...and A may not take a live claim either, until it lapses.
+    await a.inner.drainSessionPurges()
+    expect(a.emitSessionPurged).not.toHaveBeenCalled()
+    await advance(a, 2 * 60_000 + 1)
+    await a.inner.drainSessionPurges()
+    expect(a.emitSessionPurged).toHaveBeenCalledOnce()
+    expect(shared.listSessionPurges(10, a.clock.now(), 'daemon-b', [AGENT_A])).toEqual([])
+    await stop()
+    for (const local of locals) local.close()
+  }, 15_000)
+})

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -60,6 +60,8 @@ describe('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE inbox DROP COLUMN reportOwnerId')
     old.exec('ALTER TABLE inbox DROP COLUMN reportClaimedAt')
     old.exec('ALTER TABLE cron_runs DROP COLUMN definition')
+    old.exec('ALTER TABLE session_purges DROP COLUMN ownerId')
+    old.exec('ALTER TABLE session_purges DROP COLUMN claimedAt')
     old.exec('PRAGMA user_version = 1')
     old.close()
 
@@ -74,6 +76,7 @@ describe('LocalStore schema versioning', () => {
     const grantColumns = columnsOf('webchat_mcp_grant_ledger')
     const inboxColumns = columnsOf('inbox')
     const cronColumns = columnsOf('cron_runs')
+    const purgeColumns = columnsOf('session_purges')
     upgraded.close()
     expect(columns).toContain('ownerId')
     expect(outboxColumns).toEqual(expect.arrayContaining(['failedAttempts', 'nextAttemptAt']))
@@ -83,7 +86,9 @@ describe('LocalStore schema versioning', () => {
     expect(inboxColumns).toEqual(expect.arrayContaining(['reportOwnerId', 'reportClaimedAt']))
     // A stamp is only comparable to a fire of the same schedule definition (#1031).
     expect(cronColumns).toContain('definition')
-    expect(userVersion(path)).toBe(8)
+    // Purge receipts are leased per pool member (#1032).
+    expect(purgeColumns).toEqual(expect.arrayContaining(['ownerId', 'claimedAt']))
+    expect(userVersion(path)).toBe(9)
   })
 
   it('re-keys the capture gate by agent when upgrading a v5 store', () => {
@@ -100,6 +105,8 @@ describe('LocalStore schema versioning', () => {
     old.exec(`INSERT INTO session_gates (acpSessionId, localExcluded, cpPrivate, cpRev) VALUES
       ('acp-1', 1, 0, 4), ('acp-2', 0, 0, 7), ('acp-orphan', 0, 0, 1)`)
     old.exec('ALTER TABLE cron_runs DROP COLUMN definition')
+    old.exec('ALTER TABLE session_purges DROP COLUMN ownerId')
+    old.exec('ALTER TABLE session_purges DROP COLUMN claimedAt')
     old.exec('PRAGMA user_version = 5')
     old.close()
 
@@ -115,7 +122,7 @@ describe('LocalStore schema versioning', () => {
     expect(upgraded.isCaptureExcluded('bot-c', 'acp-2')).toBe(true)
     upgraded.close()
 
-    expect(userVersion(path)).toBe(8)
+    expect(userVersion(path)).toBe(9)
   })
 
   it('re-keys the runtime catalog cache on its owning member when upgrading a v7 store', () => {
@@ -139,6 +146,8 @@ describe('LocalStore schema versioning', () => {
       INSERT INTO runtime_model_catalog (runtimeId, modelId, fingerprint, capsJson, observedAt)
         VALUES ('claude', 'opus', 'fp-1', '{}', 100);
     `)
+    old.exec('ALTER TABLE session_purges DROP COLUMN ownerId')
+    old.exec('ALTER TABLE session_purges DROP COLUMN claimedAt')
     old.exec('PRAGMA user_version = 7')
     old.close()
 
@@ -160,7 +169,7 @@ describe('LocalStore schema versioning', () => {
         .map((column) => column.name)
     expect(primaryKey(metaColumns)).toEqual(['ownerId', 'runtimeId'])
     expect(primaryKey(capColumns)).toEqual(['ownerId', 'runtimeId', 'modelId'])
-    expect(userVersion(path)).toBe(8)
+    expect(userVersion(path)).toBe(9)
   })
 
   it('refuses a store written by a newer daemon WITHOUT touching it first', () => {
@@ -1240,7 +1249,7 @@ describe('LocalStore session retention GC (#485)', () => {
     s.deleteSession('gone', { reason: 'retention', at: 1_700 })
     s.deleteSession('unbound', { reason: 'retention', at: 1_800 })
 
-    expect(s.listSessionPurges(10)).toEqual([
+    expect(s.listSessionPurges(10, 0)).toEqual([
       { agentId: 'bot-a', sessionId: 'acp-gone', reason: 'retention', purgedAt: 1_700 }
     ])
     s.close()
@@ -1263,10 +1272,10 @@ describe('LocalStore session retention GC (#485)', () => {
     })
     s.deleteSession('a', { reason: 'retention', at: 100 })
     s.deleteSession('b', { reason: 'retention', at: 200 })
-    expect(s.listSessionPurges(10)).toHaveLength(2)
+    expect(s.listSessionPurges(10, 0)).toHaveLength(2)
 
     s.acknowledgeSessionPurges('bot-a', ['acp-a'])
-    expect(s.listSessionPurges(10)).toEqual([
+    expect(s.listSessionPurges(10, 0)).toEqual([
       { agentId: 'bot-b', sessionId: 'acp-a', reason: 'retention', purgedAt: 200 }
     ])
     s.close()
@@ -1280,7 +1289,7 @@ describe('LocalStore session retention GC (#485)', () => {
     s.deleteSession('recent', { reason: 'retention', at: 900 })
 
     expect(s.pruneSessionPurges(500)).toBe(1)
-    expect(s.listSessionPurges(10).map((row) => row.sessionId)).toEqual(['acp-recent'])
+    expect(s.listSessionPurges(10, 0).map((row) => row.sessionId)).toEqual(['acp-recent'])
     expect(s.pruneSessionPurges(500)).toBe(0)
     s.close()
   })
@@ -1737,6 +1746,87 @@ describe('LocalStore recovery scope on a shared store (daemon pool)', () => {
     // There is no duty axis on a single-daemon store — boot already covered it.
     expect(s.strandedDreams(['agent-1'])).toEqual([])
     expect(s.reclaimWebchatMcpGrants(['agent-1'], 'session_closed', 60)).toBe(0)
+    s.close()
+  })
+
+  // Purge receipts (#1032): one session_purges table for the whole pool, leased per
+  // member exactly like the hook-completion outbox — a peer's live row is never
+  // offered, claimed, or released by anyone but its owner.
+  const LEASE_MS = 2 * 60 * 1_000
+  const purged = (s: LocalStore, key: string, agentId: string, ownerId: string, at: number) => {
+    s.upsertSession({
+      key,
+      agentId,
+      platform: 'slack',
+      channel: 'C1',
+      thread: key,
+      acpSessionId: `acp-${key}`,
+      state: 'closed',
+      lastDeliveredTs: null,
+      updatedAt: 0
+    })
+    expect(s.deleteSession(key, { reason: 'retention', at, ownerId })).toBe(true)
+  }
+  const ids = (rows: { sessionId: string }[]) => rows.map((row) => row.sessionId)
+
+  it("offers a pool member its own purge receipts, never a live peer's", () => {
+    const path = sharedPath()
+    const a = member(path, 'store-a')
+    const b = member(path, 'store-b')
+    purged(a, 'from-a', 'agent-a', 'daemon-a', 1_000)
+    purged(b, 'from-b', 'agent-b', 'daemon-b', 1_000)
+
+    expect(ids(a.listSessionPurges(10, 1_500, 'daemon-a', ['agent-a']))).toEqual(['acp-from-a'])
+    // B serves both agents and still may not touch A's row: A's claim is live.
+    expect(ids(b.listSessionPurges(10, 1_500, 'daemon-b', ['agent-a', 'agent-b']))).toEqual(['acp-from-b'])
+    expect(b.claimSessionPurges('agent-a', ['acp-from-a'], 'daemon-b', 1_500)).toEqual([])
+    // Nor release it: the ACK fence is the claim holder.
+    b.acknowledgeSessionPurges('agent-a', ['acp-from-a'], 'daemon-b')
+    expect(ids(a.listSessionPurges(10, 1_500, 'daemon-a', []))).toEqual(['acp-from-a'])
+    // The owner renews and settles its own row.
+    expect(a.claimSessionPurges('agent-a', ['acp-from-a'], 'daemon-a', 1_500)).toEqual(['acp-from-a'])
+    a.acknowledgeSessionPurges('agent-a', ['acp-from-a'], 'daemon-a')
+    expect(a.listSessionPurges(10, 1_500, 'daemon-a', [])).toEqual([])
+    a.close()
+    b.close()
+  })
+
+  it('lets the member that serves the agent take over a purge receipt after the owner claim lapses', () => {
+    const path = sharedPath()
+    const a = member(path, 'store-a')
+    const b = member(path, 'store-b')
+    purged(a, 'from-a', 'agent-a', 'daemon-a', 1_000)
+    const lapsed = 1_000 + LEASE_MS + 1
+
+    // Still not B's to take while B does not serve the agent.
+    expect(b.listSessionPurges(10, lapsed, 'daemon-b', ['agent-b'])).toEqual([])
+    expect(ids(b.listSessionPurges(10, lapsed, 'daemon-b', ['agent-a']))).toEqual(['acp-from-a'])
+    expect(b.claimSessionPurges('agent-a', ['acp-from-a'], 'daemon-b', lapsed)).toEqual(['acp-from-a'])
+    // The takeover is exclusive: the dead owner's id no longer holds the row.
+    expect(a.listSessionPurges(10, lapsed, 'daemon-a', [])).toEqual([])
+    expect(a.claimSessionPurges('agent-a', ['acp-from-a'], 'daemon-a', lapsed)).toEqual([])
+    a.close()
+    b.close()
+  })
+
+  it('a single-daemon store drains and settles every receipt unfenced', () => {
+    const s = store()
+    s.upsertSession({
+      key: 'k',
+      agentId: 'agent-1',
+      platform: 'slack',
+      channel: 'C1',
+      thread: 'k',
+      acpSessionId: 'acp-k',
+      state: 'closed',
+      lastDeliveredTs: null,
+      updatedAt: 0
+    })
+    s.deleteSession('k', { reason: 'retention', at: 1_000 })
+    expect(ids(s.listSessionPurges(10, 1_500, 'daemon-a', []))).toEqual(['acp-k'])
+    expect(s.claimSessionPurges('agent-1', ['acp-k'], undefined, 1_500)).toEqual(['acp-k'])
+    s.acknowledgeSessionPurges('agent-1', ['acp-k'])
+    expect(s.listSessionPurges(10, 1_500)).toEqual([])
     s.close()
   })
 })


### PR DESCRIPTION
## Summary

Fixes #1032. On a daemon pool the session table is shared, but the session TTL-close sweep and the retention-GC sweep ran on every member with **member-local** exemptions, and the purge-receipt drain behind the GC repeated the #1023 head-of-line block on a second table.

- Both sweeps are now **holder-only** through the existing `servesAgent` gate (the same predicate that scopes crons, orchestration deadlines and the sandbox sweep): `closeIdleSessions` exempts every row of an agent this member does not serve, and `sessionRetentionActive` treats an unserved agent's session as active, so the retention pass and worktree lifecycle cleanup never touch it — including on the re-check after the git awaits.
- `session_purges` gets the **same ownership model as the hook-completion outbox** (#1044): schema v9 adds `ownerId` / `claimedAt`, the deleting member stamps its receipt, `listSessionPurges` offers a member its own rows, unowned rows, and a lapsed peer's for agents it serves (`SHARED_OUTBOX_LEASE_MS`), `claimSessionPurges` is the CAS before every emit, and the ACK release is fenced to the claim holder. A group for an agent this member does not serve is skipped, and a failed group `break`s to the next one instead of `return`ing.
- Local single-daemon (SQLite, `shared === false`) behavior is unchanged: the drain lists and settles unfenced, the claim is a no-op.

## Failure scenario

Agent X is held by member B and runs a long background task: the turn returned `end_turn`, the row is `idle`, and only B's in-memory SDK lease says the work is live. Member A's idle sweep sees the row past the TTL, finds no lease of its own, TTL-closes it, and emits a `phase: 'end'` snapshot for a session it does not own — B's background job loses the session it was going to report into. The retention pass has the same shape with a longer fuse: A can decide a session is inactive while B is mid-turn on it (`inflight` / `pending` are B's), delete the row and write a purge receipt. The drain then reported every member's receipts from every member and `return`ed on the first group that failed, so one foreign group blocked every group behind it on every sweep.

## Fix

- `packages/daemon/src/daemon.ts` — `sweepIdle` TTL exemption and `sessionRetentionActive` gate on `servesAgent`; `sweepSessionRetention` filters candidates to served agents and stamps the receipt owner; `drainSessionPurges` lists with owner/served scope, skips foreign groups, claims before emit, ACKs under the owner fence, `break`s instead of `return`s on a failed group.
- `packages/daemon/src/store/local-store.ts` — `session_purges.ownerId` / `claimedAt` (schema v9, migration step), `deleteSession` stamps the owner, `listSessionPurges` / `claimSessionPurges` / `acknowledgeSessionPurges` carry the shared-store lease; local stores unchanged.
- `packages/daemon/src/store/postgres-sync-database.ts` — `claimedAt` in the canonical column list.

## Test plan

- [x] `test/daemon-session-sweeps-pool.test.ts` (new): two members over one store — B's TTL sweep does not close A's live-lease session (and A's own sweep still does the plain-TTL close for its quiet row); B's retention GC does not delete a session A is mid-turn on; B's purge drain skips A's rows and the unowned row for A's agent and still reports its own; a member's own receipt for an agent it no longer serves is left for the holder and taken over after the lease lapses. All four fail on `main` and pass here.
- [x] `test/local-store.test.ts`: shared-store lease semantics for purge receipts (own vs. live peer, takeover after lapse, single-daemon unfenced), migration steps and `user_version` 9.
- [x] `pnpm --filter @agentconnect.md/daemon typecheck`
- [x] `daemon-lifecycle`, `durable-inbox`, `daemon-hook`, `postgres-migrations`, `schedule-catchup`, `daemon-duty-*`, `orchestration`, `daemon-k8s-mode` suites
- [x] `pnpm lint`, `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

