### PR TITLE
chore(control-plane): fence the daemon WS surface on the frame org

### DIFF
--- a/docs/designs/org-scoped-data-layer.md
+++ b/docs/designs/org-scoped-data-layer.md
@@ -108,13 +108,13 @@ document is the review reference.
 Mirrors [`authorization-policy.md`](authorization-policy.md) §2 — the fence a
 method carries depends on who is allowed to call it:
 
-| Caller domain                                                      | Org source                           | Data-layer surface                                                                                                      |
-| ------------------------------------------------------------------ | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| Console REST / SSE (human)                                         | `req.orgCtx` from path + membership  | scoped methods only                                                                                                     |
-| MCP surface                                                        | the credential's org binding         | scoped methods only                                                                                                     |
-| Daemon WS handlers                                                 | the connection's ApiKey row          | daemon-fenced methods (`listForDaemon`, `agent.daemonId === conn.daemonId` guards) — already stronger than an org check |
-| Orchestrator / reconciliation / platform machinery                 | derived from the row being processed | `*Unscoped` reads, system-tier mutations                                                                                |
-| Public-by-design endpoints (e.g. agent icon PNG, fetched by Slack) | none — intentionally unauthenticated | `*Unscoped` with an inline lint exemption and a justification comment                                                   |
+| Caller domain                                                      | Org source                           | Data-layer surface                                                                    |
+| ------------------------------------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------- |
+| Console REST / SSE (human)                                         | `req.orgCtx` from path + membership  | scoped methods only                                                                   |
+| MCP surface                                                        | the credential's org binding         | scoped methods only                                                                   |
+| Daemon WS handlers                                                 | `frame.orgId`, else `conn.orgId`     | scoped methods, plus the daemon-fenced ones (`listForDaemon`, the placement resolver) |
+| Orchestrator / reconciliation / platform machinery                 | derived from the row being processed | `*Unscoped` reads, system-tier mutations                                              |
+| Public-by-design endpoints (e.g. agent icon PNG, fetched by Slack) | none — intentionally unauthenticated | `*Unscoped` with an inline lint exemption and a justification comment                 |
 
 ## 5. Exemplar migration: Agent (M1, this change)
 
@@ -149,10 +149,12 @@ to `getUnscoped` with the lint exemption and a comment saying exactly that.
 Two structural guards, so the convention cannot silently erode:
 
 1. **ESLint fence.** `no-restricted-syntax` forbids any `*Unscoped` member
-   call in `packages/control-plane/src/http/routes/**` and
-   `packages/control-plane/src/http/mcp/**`. Public-by-design endpoints carry
-   an inline `eslint-disable-next-line` with a justification — the exemption
-   is the documentation.
+   call in `packages/control-plane/src/http/routes/**`,
+   `packages/control-plane/src/http/mcp/**` and
+   `packages/control-plane/src/ws/**`. Public-by-design endpoints and the
+   handful of genuinely install-wide WS reads carry an inline
+   `eslint-disable-next-line` with a justification — the exemption is the
+   documentation.
 2. **Tenant-isolation contract tests.**
    `test/integration/tenant-isolation.route.test.ts` boots the real app
    against Postgres with a two-organization fixture and asserts, per migrated
@@ -209,6 +211,9 @@ Two structural guards, so the convention cannot silently erode:
 - **Postgres RLS** — deliberately separate (M3): it wants the port convention
   in place first, and carries its own Prisma/transaction ergonomics
   trade-offs.
-- **The daemon WS trust domain** — its fences (connection identity, roster
-  scoping, mutation leases) are already stronger than an org parameter and are
-  not reshaped here.
+- **The daemon WS trust domain** — its own fences (connection identity, roster
+  scoping, mutation leases) are not reshaped here. They stopped being stronger
+  than an org parameter once one install-wide member carried many orgs on one
+  socket, so the fence was extended to `src/ws/**` in
+  [`k8s-daemon-pool.md`](k8s-daemon-pool.md) M4: a handler resolves resources
+  with the frame's org, or the connection's when it has one.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,5 +78,23 @@ export default defineConfig([
         }
       ]
     }
+  },
+  {
+    // Same fence on the daemon WS surface (k8s-daemon-pool.md M4): an install-wide
+    // member carries many orgs on one socket, so a handler resolves resources with
+    // the frame's org (`frame.orgId`) or the connection's (`conn.orgId`) — never by
+    // reading a row unscoped and trusting the org it happens to carry. An
+    // install-wide read may disable this inline with a justification.
+    files: ['packages/control-plane/src/ws/**/*.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'CallExpression[callee.property.name=/Unscoped$/]',
+          message:
+            'Tenancy-unscoped reads are forbidden on the daemon WS surface — use the org-fenced method with the frame or connection org (docs/designs/org-scoped-data-layer.md §6).'
+        }
+      ]
+    }
   }
 ])

--- a/packages/control-plane/src/ws/handlers/channel-agents.ts
+++ b/packages/control-plane/src/ws/handlers/channel-agents.ts
@@ -73,8 +73,9 @@ export const handleChannelAgents: Handler = async (frame, conn, deps) => {
   if (!isFrame('channel/agents')(frame)) return
   const { platform, channel, requesterAgentId } = frame.payload
 
-  // Daemon trust domain: the connection's own daemon, resolved without an org
-  // (org-scoped-data-layer.md §4).
+  // Install-wide read: the connection's OWN daemon row, whose org is null on a pool member,
+  // so no org fence exists to apply (org-scoped-data-layer.md §4).
+  // eslint-disable-next-line no-restricted-syntax -- the authenticated connection's own daemon row
   const daemon = await deps.registry.getUnscoped(DaemonId(conn.daemonId))
   if (!daemon) return // unknown daemon (should not happen post-auth) — drop silently
   const orgId = frame.orgId ? OrgId(frame.orgId) : daemon.orgId

--- a/packages/control-plane/src/ws/handlers/child-session-status.test.ts
+++ b/packages/control-plane/src/ws/handlers/child-session-status.test.ts
@@ -38,6 +38,7 @@ function frame(payload: Record<string, unknown> = {}): AnyFrame {
 function fakeConn() {
   return {
     daemonId: ASKING_DAEMON,
+    orgId: ORG,
     replyTo: vi.fn(),
     sendError: vi.fn()
   } as unknown as DaemonConnection & { replyTo: ReturnType<typeof vi.fn>; sendError: ReturnType<typeof vi.fn> }
@@ -61,13 +62,13 @@ function fakeDeps(
     deps: {
       registry: { getUnscoped: async () => ({ id: ASKING_DAEMON, orgId: ORG }) },
       session: {
-        getUnscoped: async () =>
+        get: async () =>
           'parent' in over
             ? over.parent
             : { id: PARENT_SESSION, orgId: ORG, daemonId: ASKING_DAEMON, agentId: CHILD_AGENT }
       },
       agent: {
-        getUnscoped: async () =>
+        get: async () =>
           'childAgent' in over ? over.childAgent : { id: CHILD_AGENT, orgId: ORG, daemonId: OWNING_DAEMON }
       },
       connReg: { get: () => owner }

--- a/packages/control-plane/src/ws/handlers/child-session-status.ts
+++ b/packages/control-plane/src/ws/handlers/child-session-status.ts
@@ -25,6 +25,7 @@
 import { isFrame } from '@agentconnect.md/protocol'
 import type { ChildSessionStatus } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, SessionId } from '../../domain/ids.js'
+import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 
 const NOT_FOUND: ChildSessionStatus = { found: false }
@@ -33,24 +34,31 @@ export const handleChildSessionStatus: Handler = async (frame, conn, deps) => {
   if (!isFrame('session/child-status')(frame)) return
   const { parentSessionId, childSessionId, childAgentId } = frame.payload
 
-  // Daemon trust domain: the connection's own daemon (org-scoped-data-layer.md §4).
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) {
+    conn.replyTo(frame, 'session/child-status/ok', NOT_FOUND)
+    return
+  }
+
+  // Install-wide read: the connection's OWN daemon row, whose org is null on a pool member,
+  // so no org fence exists to apply (org-scoped-data-layer.md §4).
+  // eslint-disable-next-line no-restricted-syntax -- the authenticated connection's own daemon row
   const daemon = await deps.registry.getUnscoped(DaemonId(conn.daemonId))
   if (!daemon) return // unknown daemon (should not happen post-auth) — drop silently
 
   // (a) Prove the asking daemon owns the parent session it is asking AS. `daemonId` on the session
   // row is stamped by the CP from the authenticated socket and is never daemon-echoed, so it is
-  // trustworthy here. Fail closed when the session is unknown to the CP.
-  // Daemon trust domain: the parent session the asking daemon claims to own —
-  // the ownership check below is what admits it (org-scoped-data-layer.md §4).
-  const parent = await deps.session.getUnscoped(SessionId(parentSessionId))
-  if (!parent || parent.daemonId !== conn.daemonId || (frame.orgId && frame.orgId !== parent.orgId)) {
+  // trustworthy here. Fail closed when the session is unknown to the CP. The read is fenced on the
+  // frame's org, so a session outside it is indistinguishable from a missing one.
+  const parent = await deps.session.get(orgId, SessionId(parentSessionId))
+  if (!parent || parent.daemonId !== conn.daemonId) {
     conn.replyTo(frame, 'session/child-status/ok', NOT_FOUND)
     return
   }
 
   // (b) Resolve the child agent's placement. Cross-org is refused outright: a status read must
   // never cross an org boundary even when both daemons are reachable.
-  const childAgent = await deps.agent.getUnscoped(AgentId(childAgentId))
+  const childAgent = await deps.agent.get(orgId, AgentId(childAgentId))
   if (!childAgent || childAgent.orgId !== parent.orgId || !childAgent.daemonId) {
     conn.replyTo(frame, 'session/child-status/ok', NOT_FOUND)
     return

--- a/packages/control-plane/src/ws/handlers/duty-claim.ts
+++ b/packages/control-plane/src/ws/handlers/duty-claim.ts
@@ -15,6 +15,9 @@ export const handleDutyClaim: Handler = async (frame, conn, deps) => {
   }
   const agentId = AgentId(frame.payload.agentId)
   // The CP resolves the org from the agent itself — a claimant never asserts it.
+  // Install-wide read (INSTALL_WIDE_FRAME_TYPES): `duty/claim` carries no org by design,
+  // because the member is asking about an agent it does not yet serve.
+  // eslint-disable-next-line no-restricted-syntax -- install-wide rendezvous frame, no frame org exists
   const agent = await deps.agent.getUnscoped(agentId)
   if (!agent) {
     conn.replyTo(frame, 'duty/claim/ok', { granted: false })

--- a/packages/control-plane/src/ws/handlers/duty-fetch.test.ts
+++ b/packages/control-plane/src/ws/handlers/duty-fetch.test.ts
@@ -41,12 +41,13 @@ const BUNDLE = {
   ]
 }
 
-function fetchFrame(agentId = AGENT): AnyFrame {
+function fetchFrame(agentId = AGENT, orgId: string | null = ORG): AnyFrame {
   return {
     v: 1,
     id: crypto.randomUUID(),
     ts: '2026-08-14T00:00:00.000Z',
     type: 'duty/fetch',
+    ...(orgId ? { orgId } : {}),
     payload: { agentId }
   } as AnyFrame
 }
@@ -76,7 +77,7 @@ function fakeDeps(
   scopes = fakeScopes()
 ): DaemonWsDeps {
   return {
-    agent: { getUnscoped: async () => over.agent ?? null },
+    agent: { get: async () => over.agent ?? null },
     dutyLease: { holdsAgent: async () => over.holdsAgent ?? false },
     connReg: { get: () => scopes },
     agentBundle: over.agentBundle ?? vi.fn(async () => BUNDLE)
@@ -99,6 +100,16 @@ describe('handleDutyFetch', () => {
     )
     expect(conn.replyTo).not.toHaveBeenCalled()
     expect(agentBundle).not.toHaveBeenCalled()
+  })
+
+  it('refuses a fetch that names no organization', async () => {
+    const conn = fakeConn()
+    const frame = fetchFrame(AGENT, null)
+
+    await handleDutyFetch(frame, conn, fakeDeps({ agent: AGENT_RECORD, holdsAgent: true }))
+
+    expect(conn.sendError).toHaveBeenCalledWith(frame.id, 'SCOPE_DENIED', 'organization is required', false)
+    expect(conn.replyTo).not.toHaveBeenCalled()
   })
 
   it('an unknown agent answers empty, never an error frame', async () => {
@@ -166,7 +177,7 @@ describe('handleDutyFetch', () => {
   it('answers empty when no bundle assembler is wired', async () => {
     const conn = fakeConn()
     const deps = {
-      agent: { getUnscoped: async () => AGENT_RECORD },
+      agent: { get: async () => AGENT_RECORD },
       dutyLease: { holdsAgent: async () => true }
     } as unknown as DaemonWsDeps
 

--- a/packages/control-plane/src/ws/handlers/duty-fetch.ts
+++ b/packages/control-plane/src/ws/handlers/duty-fetch.ts
@@ -6,6 +6,7 @@
 import { isFrame, type DutyAgentBundle } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId } from '../../domain/ids.js'
 import type { DaemonWsDeps } from '../deps.js'
+import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 
 export const handleDutyFetch: Handler = async (frame, conn, deps) => {
@@ -15,9 +16,14 @@ export const handleDutyFetch: Handler = async (frame, conn, deps) => {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'duty ledger requires an install-wide connection', false)
     return
   }
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'organization is required', false)
+    return
+  }
   const agentId = AgentId(frame.payload.agentId)
-  // The CP resolves the org from the agent itself — an asker never asserts it.
-  const agent = await deps.agent.getUnscoped(agentId)
+  // Fenced on the frame's org, so an asker can only fetch a bundle inside the org it named.
+  const agent = await deps.agent.get(orgId, agentId)
   // Unknown agent, no duty, or no assembler wired: all answer "install nothing".
   // An empty reply, never an error frame — the member's behavior is the same.
   if (!agent || !deps.agentBundle) {

--- a/packages/control-plane/src/ws/handlers/event-session-activity.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session-activity.test.ts
@@ -6,6 +6,7 @@ import { handleSessionActivity } from './event-session-activity.js'
 
 const DAEMON_ID = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const AGENT_ID = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const ORG_ID = '0e0e0e0e-eeee-4eee-8eee-eeeeeeeeeeee'
 
 function activityFrame(): AnyFrame {
   return {
@@ -27,13 +28,13 @@ describe('handleSessionActivity', () => {
     const publishActivity = vi.fn()
     const release = vi.fn()
     const deps = {
-      agent: { getUnscoped: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
+      agent: { get: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
       agentMutations: { tryBeginMutation: vi.fn(() => release) },
       events: { publishActivity }
     } as unknown as DaemonWsDeps
     const frame = activityFrame()
 
-    await handleSessionActivity(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleSessionActivity(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(publishActivity).toHaveBeenCalledWith(DAEMON_ID, frame.payload)
     expect(release).toHaveBeenCalledOnce()
@@ -42,12 +43,12 @@ describe('handleSessionActivity', () => {
   it('drops activity from a daemon that does not own the agent', async () => {
     const publishActivity = vi.fn()
     const deps = {
-      agent: { getUnscoped: vi.fn().mockResolvedValue({ daemonId: crypto.randomUUID() }) },
+      agent: { get: vi.fn().mockResolvedValue({ daemonId: crypto.randomUUID() }) },
       agentMutations: { tryBeginMutation: vi.fn(() => vi.fn()) },
       events: { publishActivity }
     } as unknown as DaemonWsDeps
 
-    await handleSessionActivity(activityFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleSessionActivity(activityFrame(), { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(publishActivity).not.toHaveBeenCalled()
   })

--- a/packages/control-plane/src/ws/handlers/event-session-activity.ts
+++ b/packages/control-plane/src/ws/handlers/event-session-activity.ts
@@ -4,14 +4,17 @@
  */
 import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId } from '../../domain/ids.js'
+import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 import { runForReportingAgent } from './reporting-agent.js'
 
 export const handleSessionActivity: Handler = async (frame, conn, deps) => {
   if (!isFrame('event/session-activity')(frame)) return
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) return
   const agentId = AgentId(frame.payload.agentId)
   const daemonId = DaemonId(conn.daemonId)
-  await runForReportingAgent(agentId, daemonId, deps, async () => {
+  await runForReportingAgent(orgId, agentId, daemonId, deps, async () => {
     deps.events.publishActivity(daemonId, frame.payload)
   })
 }

--- a/packages/control-plane/src/ws/handlers/event-session-purged.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session-purged.test.ts
@@ -6,6 +6,7 @@ import { handleSessionPurged } from './event-session-purged.js'
 
 const DAEMON_ID = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const AGENT_ID = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const ORG_ID = '0e0e0e0e-eeee-4eee-8eee-eeeeeeeeeeee'
 const PURGED_AT = '2026-08-04T09:00:00.000Z'
 
 function purgedFrame(): AnyFrame {
@@ -30,7 +31,7 @@ function depsWith(
 ): { deps: DaemonWsDeps; release: ReturnType<typeof vi.fn> } {
   const release = vi.fn()
   const deps = {
-    agent: { getUnscoped: vi.fn().mockResolvedValue(placedOn === null ? null : { daemonId: placedOn }) },
+    agent: { get: vi.fn().mockResolvedValue(placedOn === null ? null : { daemonId: placedOn }) },
     agentMutations: { tryBeginMutation: vi.fn(() => (lease === 'free' ? release : null)) },
     session: { markContentPurged }
   } as unknown as DaemonWsDeps
@@ -38,7 +39,7 @@ function depsWith(
 }
 
 function conn() {
-  return { daemonId: DAEMON_ID, replyTo: vi.fn(), sendError: vi.fn() } as unknown as DaemonConnection & {
+  return { daemonId: DAEMON_ID, orgId: ORG_ID, replyTo: vi.fn(), sendError: vi.fn() } as unknown as DaemonConnection & {
     replyTo: ReturnType<typeof vi.fn>
     sendError: ReturnType<typeof vi.fn>
   }

--- a/packages/control-plane/src/ws/handlers/event-session-purged.ts
+++ b/packages/control-plane/src/ws/handlers/event-session-purged.ts
@@ -27,10 +27,16 @@
 import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, SessionId } from '../../domain/ids.js'
+import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 
 export const handleSessionPurged: Handler = async (frame, conn, deps) => {
   if (!isFrame('event/session-purged')(frame)) return
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'organization is required', false)
+    return
+  }
   const p = frame.payload
   const agentId = AgentId(p.agentId)
   const release = deps.agentMutations.tryBeginMutation(agentId)
@@ -39,7 +45,7 @@ export const handleSessionPurged: Handler = async (frame, conn, deps) => {
     return
   }
   try {
-    const agent = await deps.agent.getUnscoped(agentId)
+    const agent = await deps.agent.get(orgId, agentId)
     if (agent && (await (deps.placementResolver ?? PLACEMENT_ONLY).mayAct(agent, DaemonId(conn.daemonId)))) {
       await deps.session.markContentPurged(
         agentId,

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -7,6 +7,7 @@ import { handleEventSession, handleEventSessionSync } from './event-session.js'
 
 const DAEMON_ID = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const AGENT_ID = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const ORG_ID = 'org-1'
 const SESSION_ID = 'session-407'
 const INTEGRATION_ID = '11111111-1111-4111-8111-111111111111'
 const BOT_ID = '22222222-2222-4222-8222-222222222222'
@@ -16,9 +17,9 @@ const GITHUB_INSTALLATION_ROW_ID = '44444444-4444-4444-8444-444444444444'
 function scopedDeps(extra: Record<string, unknown>): DaemonWsDeps {
   return {
     log: { error: vi.fn() },
-    agent: { getUnscoped: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
+    agent: { get: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
     agentMutations: { tryBeginMutation: vi.fn(() => vi.fn()) },
-    hook: { getUnscoped: vi.fn().mockResolvedValue(null) },
+    hook: { get: vi.fn().mockResolvedValue(null) },
     ...extra
   } as unknown as DaemonWsDeps
 }
@@ -71,6 +72,7 @@ describe('handleEventSession', () => {
     const frame = eventSessionFrame('event/session-sync')
     const conn = {
       daemonId: DAEMON_ID,
+      orgId: ORG_ID,
       replyTo,
       sendError: vi.fn()
     } as unknown as DaemonConnection
@@ -100,7 +102,7 @@ describe('handleEventSession', () => {
 
     await handleEventSessionSync(
       frame,
-      { daemonId: DAEMON_ID, replyTo, sendError } as unknown as DaemonConnection,
+      { daemonId: DAEMON_ID, orgId: ORG_ID, replyTo, sendError } as unknown as DaemonConnection,
       deps
     )
 
@@ -131,7 +133,7 @@ describe('handleEventSession', () => {
       session: { recordMilestone },
       events: { publish }
     })
-    const conn = { daemonId: DAEMON_ID } as DaemonConnection
+    const conn = { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection
     const frame = eventSessionFrame()
 
     const handling = handleEventSession(frame, conn, deps)
@@ -164,7 +166,7 @@ describe('handleEventSession', () => {
       outputMode: 'medium'
     })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -200,7 +202,7 @@ describe('handleEventSession', () => {
       parentSessionId: 'parent-session'
     })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(findOwner).not.toHaveBeenCalled()
     expect(recordMilestone).toHaveBeenCalledWith(
@@ -218,7 +220,7 @@ describe('handleEventSession', () => {
     const deps = scopedDeps({
       session: { recordMilestone },
       integration: {
-        getUnscoped: vi.fn().mockResolvedValue({
+        get: vi.fn().mockResolvedValue({
           id: INTEGRATION_ID,
           agentId: AGENT_ID,
           botId: BOT_ID,
@@ -228,7 +230,7 @@ describe('handleEventSession', () => {
         })
       },
       bot: {
-        getUnscoped: vi.fn().mockResolvedValue({
+        get: vi.fn().mockResolvedValue({
           id: BOT_ID,
           orgId: 'org-1',
           platform: 'slack',
@@ -250,7 +252,7 @@ describe('handleEventSession', () => {
       }
     })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -274,7 +276,7 @@ describe('handleEventSession', () => {
     const deps = scopedDeps({
       session: { recordMilestone },
       integration: {
-        getUnscoped: vi.fn().mockResolvedValue({
+        get: vi.fn().mockResolvedValue({
           id: INTEGRATION_ID,
           agentId: AGENT_ID,
           botId: BOT_ID,
@@ -284,7 +286,7 @@ describe('handleEventSession', () => {
         })
       },
       bot: {
-        getUnscoped: vi.fn().mockResolvedValue({
+        get: vi.fn().mockResolvedValue({
           id: BOT_ID,
           orgId: 'org-1',
           platform: 'feishu',
@@ -308,7 +310,7 @@ describe('handleEventSession', () => {
       }
     })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -332,7 +334,7 @@ describe('handleEventSession', () => {
     const deps = scopedDeps({
       session: { recordMilestone },
       integration: {
-        getUnscoped: vi.fn().mockResolvedValue({
+        get: vi.fn().mockResolvedValue({
           id: INTEGRATION_ID,
           agentId: AGENT_ID,
           botId: BOT_ID,
@@ -342,7 +344,7 @@ describe('handleEventSession', () => {
         })
       },
       bot: {
-        getUnscoped: vi.fn().mockResolvedValue({
+        get: vi.fn().mockResolvedValue({
           id: BOT_ID,
           orgId: 'org-1',
           platform: 'feishu',
@@ -366,7 +368,7 @@ describe('handleEventSession', () => {
       }
     })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -392,7 +394,7 @@ describe('handleEventSession', () => {
       events: { publish: vi.fn() }
     })
 
-    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({ externalCandidate: { provider: 'slack', resolution: 'pending' } })
@@ -415,7 +417,7 @@ describe('handleEventSession', () => {
     const frame = eventSessionFrame()
     Object.assign(frame.payload as Record<string, unknown>, { sourceBindingKind: 'local' })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     const milestone = recordMilestone.mock.calls[0]![0]
     expect(milestone).not.toHaveProperty('externalCandidate')
@@ -426,7 +428,7 @@ describe('handleEventSession', () => {
     const deps = scopedDeps({
       session: { recordMilestone },
       integration: {
-        getUnscoped: vi.fn().mockResolvedValue({
+        get: vi.fn().mockResolvedValue({
           id: INTEGRATION_ID,
           agentId: AGENT_ID,
           botId: BOT_ID,
@@ -436,7 +438,7 @@ describe('handleEventSession', () => {
         })
       },
       bot: {
-        getUnscoped: vi.fn().mockResolvedValue({
+        get: vi.fn().mockResolvedValue({
           id: BOT_ID,
           orgId: 'org-1',
           platform: 'slack',
@@ -458,7 +460,7 @@ describe('handleEventSession', () => {
       }
     })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({ externalCandidate: { provider: 'slack', resolution: 'invalid' } })
@@ -500,7 +502,7 @@ describe('handleEventSession', () => {
       }
     })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -550,7 +552,7 @@ describe('handleEventSession', () => {
       }
     })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({ externalCandidate: { provider: 'github', resolution: 'invalid' } })
@@ -563,7 +565,7 @@ describe('handleEventSession', () => {
     const deps = scopedDeps({
       session: { recordMilestone },
       hook: {
-        getUnscoped: vi.fn().mockResolvedValue({ kind: 'github', agentId: AGENT_ID })
+        get: vi.fn().mockResolvedValue({ kind: 'github', agentId: AGENT_ID })
       },
       events: { publish: vi.fn() }
     })
@@ -574,7 +576,7 @@ describe('handleEventSession', () => {
       triggeredBy: `hook:${HOOK_ID}`
     })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({ externalCandidate: { provider: 'github', resolution: 'pending' } })
@@ -583,12 +585,12 @@ describe('handleEventSession', () => {
 
   it('inherits a hook A2A child audience without querying its synthetic channel as a hook id', async () => {
     const recordMilestone = vi.fn().mockResolvedValue(recorded({ parentSessionId: 'parent-session' }))
-    const getUnscoped = vi.fn().mockRejectedValue(new Error('synthetic channel reached HookRepo'))
+    const get = vi.fn().mockRejectedValue(new Error('synthetic channel reached HookRepo'))
     const replyTo = vi.fn()
     const sendError = vi.fn()
     const deps = scopedDeps({
       session: { recordMilestone },
-      hook: { getUnscoped },
+      hook: { get },
       events: { publish: vi.fn() }
     })
     const frame = eventSessionFrame('event/session-sync')
@@ -601,11 +603,11 @@ describe('handleEventSession', () => {
 
     await handleEventSessionSync(
       frame,
-      { daemonId: DAEMON_ID, replyTo, sendError } as unknown as DaemonConnection,
+      { daemonId: DAEMON_ID, orgId: ORG_ID, replyTo, sendError } as unknown as DaemonConnection,
       deps
     )
 
-    expect(getUnscoped).not.toHaveBeenCalled()
+    expect(get).not.toHaveBeenCalled()
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({
         parentSessionId: 'parent-session',
@@ -619,10 +621,10 @@ describe('handleEventSession', () => {
 
   it('treats a non-UUID legacy hook coordinate as a miss', async () => {
     const recordMilestone = vi.fn().mockResolvedValue(recorded())
-    const getUnscoped = vi.fn().mockRejectedValue(new Error('invalid hook id reached Prisma'))
+    const get = vi.fn().mockRejectedValue(new Error('invalid hook id reached Prisma'))
     const deps = scopedDeps({
       session: { recordMilestone },
-      hook: { getUnscoped },
+      hook: { get },
       events: { publish: vi.fn() }
     })
     const frame = eventSessionFrame()
@@ -632,9 +634,9 @@ describe('handleEventSession', () => {
       triggeredBy: undefined
     })
 
-    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(frame, { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
-    expect(getUnscoped).not.toHaveBeenCalled()
+    expect(get).not.toHaveBeenCalled()
     expect(recordMilestone.mock.calls[0]![0].externalCandidate).toBeUndefined()
   })
 
@@ -656,7 +658,7 @@ describe('handleEventSession', () => {
       sessionAccessWarmer: { poke }
     })
 
-    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(order).toEqual(['publish', 'poke'])
     expect(poke).toHaveBeenCalledWith('org-1', 'scope-1')
@@ -672,7 +674,7 @@ describe('handleEventSession', () => {
       sessionAccessWarmer: { poke }
     })
 
-    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(poke).not.toHaveBeenCalled()
   })
@@ -697,7 +699,7 @@ describe('handleEventSession', () => {
 
     await handleEventSessionSync(
       eventSessionFrame('event/session-sync'),
-      { daemonId: DAEMON_ID, replyTo: vi.fn(), sendError: vi.fn() } as unknown as DaemonConnection,
+      { daemonId: DAEMON_ID, orgId: ORG_ID, replyTo: vi.fn(), sendError: vi.fn() } as unknown as DaemonConnection,
       deps
     )
 
@@ -713,7 +715,7 @@ describe('handleEventSession', () => {
     })
 
     await expect(
-      handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+      handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
     ).rejects.toBe(failure)
     expect(publish).not.toHaveBeenCalled()
   })
@@ -725,7 +727,7 @@ describe('handleEventSession', () => {
       events: { publish }
     })
 
-    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(publish).not.toHaveBeenCalled()
   })
@@ -735,13 +737,13 @@ describe('handleEventSession', () => {
     const recordMilestone = vi.fn()
     const publish = vi.fn()
     const deps = scopedDeps({
-      agent: { getUnscoped: vi.fn().mockResolvedValue({ daemonId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee' }) },
+      agent: { get: vi.fn().mockResolvedValue({ daemonId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee' }) },
       agentMutations: { tryBeginMutation: vi.fn(() => release) },
       session: { recordMilestone },
       events: { publish }
     })
 
-    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID, orgId: ORG_ID } as DaemonConnection, deps)
 
     expect(recordMilestone).not.toHaveBeenCalled()
     expect(publish).not.toHaveBeenCalled()

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -16,9 +16,10 @@
  */
 import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import { isFrame, type EventSession } from '@agentconnect.md/protocol'
-import { AgentId, BotId, DaemonId, HookId, IntegrationId, LaunchId, SessionId } from '../../domain/ids.js'
+import { AgentId, BotId, DaemonId, HookId, IntegrationId, LaunchId, OrgId, SessionId } from '../../domain/ids.js'
 import { classifySession } from '../../domain/session-visibility.js'
 import type { DaemonWsDeps } from '../deps.js'
+import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 import { runForReportingAgent } from './reporting-agent.js'
 
@@ -58,7 +59,7 @@ async function classifyMilestone(p: EventSession, agentId: AgentId, deps: Daemon
   })
 }
 
-async function externalCandidate(p: EventSession, agentId: AgentId, deps: DaemonWsDeps) {
+async function externalCandidate(p: EventSession, orgId: OrgId, agentId: AgentId, deps: DaemonWsDeps) {
   const origin = p.externalOrigin
   // An explicit local source binding is authoritative; absent provenance uses the mixed-version fallback below.
   if (p.sourceBindingKind === 'local' && !origin) return undefined
@@ -70,8 +71,9 @@ async function externalCandidate(p: EventSession, agentId: AgentId, deps: Daemon
       : p.platform === 'hook'
         ? p.channel
         : undefined
-    // The reporting daemon names the hook; the agent check below binds that trust (§4).
-    const hook = triggerId && UUID_RE.test(triggerId) ? await deps.hook.getUnscoped(HookId(triggerId)) : null
+    // The reporting daemon names the hook; the frame's org fences it and the agent check below
+    // binds that trust (§4).
+    const hook = triggerId && UUID_RE.test(triggerId) ? await deps.hook.get(orgId, HookId(triggerId)) : null
     const legacyGithub = hook?.kind === 'github' && hook.agentId === agentId
     if (legacyGithub) return { provider: 'github', resolution: 'pending' as const }
 
@@ -119,10 +121,9 @@ async function externalCandidate(p: EventSession, agentId: AgentId, deps: Daemon
     }
   }
   if (!origin.integrationId || !origin.realmKey) return pending
-  // Daemon trust domain: the integration a reporting daemon named as the origin
-  // of a session it already proved it owns (org-scoped-data-layer.md §4). The
-  // ownership checks below still bind it to the reporting agent.
-  const integration = await deps.integration.getUnscoped(IntegrationId(origin.integrationId))
+  // The integration a reporting daemon named as the origin of a session it already proved it
+  // owns, fenced on the frame's org; the ownership checks below still bind it to the agent.
+  const integration = await deps.integration.get(orgId, IntegrationId(origin.integrationId))
   if (
     !integration ||
     integration.agentId !== agentId ||
@@ -131,9 +132,8 @@ async function externalCandidate(p: EventSession, agentId: AgentId, deps: Daemon
   ) {
     return { provider: origin.provider, resolution: 'invalid' as const }
   }
-  // Daemon trust domain: the bot behind an integration row this resolver already
-  // matched against the reporting agent (org-scoped-data-layer.md §4).
-  const bot = await deps.bot?.getUnscoped(BotId(integration.botId))
+  // The bot behind an integration row this resolver already matched against the reporting agent.
+  const bot = await deps.bot?.get(orgId, BotId(integration.botId))
   const feishuRegion = bot?.platform === 'feishu' ? (bot.feishuRegion ?? 'feishu') : undefined
   const feishuAppId = bot?.feishuAppId ?? undefined
   const realmKey =
@@ -166,6 +166,7 @@ async function externalCandidate(p: EventSession, agentId: AgentId, deps: Daemon
 
 async function recordEventSession(
   p: EventSession,
+  orgId: OrgId,
   agentId: AgentId,
   daemonId: DaemonId,
   deps: DaemonWsDeps,
@@ -177,7 +178,7 @@ async function recordEventSession(
 ): Promise<void> {
   const [classification, candidate] = await Promise.all([
     classifyMilestone(p, agentId, deps),
-    externalCandidate(p, agentId, deps)
+    externalCandidate(p, orgId, agentId, deps)
   ])
   const { recorded, session, settled } = await deps.session.recordMilestone({
     sessionId: SessionId(p.sessionId),
@@ -237,11 +238,13 @@ async function recordEventSession(
 
 export const handleEventSession: Handler = async (frame, conn, deps) => {
   if (!isFrame('event/session')(frame)) return
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) return
   const p = frame.payload
   const agentId = AgentId(p.agentId)
   const daemonId = DaemonId(conn.daemonId)
-  await runForReportingAgent(agentId, daemonId, deps, () =>
-    recordEventSession(p, agentId, daemonId, deps, deps.sessionAccessWarmer)
+  await runForReportingAgent(orgId, agentId, daemonId, deps, () =>
+    recordEventSession(p, orgId, agentId, daemonId, deps, deps.sessionAccessWarmer)
   )
 }
 
@@ -249,6 +252,11 @@ export const handleEventSession: Handler = async (frame, conn, deps) => {
  * permanent rejection and is ACKed so the old daemon can collect its outbox. */
 export const handleEventSessionSync: Handler = async (frame, conn, deps) => {
   if (!isFrame('event/session-sync')(frame)) return
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'organization is required', false)
+    return
+  }
   const p = frame.payload
   const agentId = AgentId(p.agentId)
   const daemonId = DaemonId(conn.daemonId)
@@ -258,9 +266,9 @@ export const handleEventSessionSync: Handler = async (frame, conn, deps) => {
     return
   }
   try {
-    const agent = await deps.agent.getUnscoped(agentId)
+    const agent = await deps.agent.get(orgId, agentId)
     if (agent && (await (deps.placementResolver ?? PLACEMENT_ONLY).mayAct(agent, daemonId)))
-      await recordEventSession(p, agentId, daemonId, deps)
+      await recordEventSession(p, orgId, agentId, daemonId, deps)
     // ACK only after recordEventSession's transaction has committed. An agent
     // placed elsewhere (or deleted) can never accept this daemon's stale row, so
     // retaining it forever would be worse than collecting it.

--- a/packages/control-plane/src/ws/handlers/frame-org.ts
+++ b/packages/control-plane/src/ws/handlers/frame-org.ts
@@ -1,0 +1,18 @@
+/**
+ * The organization a dispatched frame acts in (k8s-daemon-pool.md M4).
+ *
+ * An install-wide pool member carries many orgs on one socket, so the org is the
+ * frame's own (`frame.orgId`); an ordinary org-scoped daemon carries it on the
+ * connection. `DaemonConnection.gateOrganization` has already refused a frame whose
+ * org disagrees with the connection or with the resource it targets, so a handler
+ * may fence its repository reads on this value — never on the org a row it read
+ * unscoped happens to carry.
+ */
+import type { AnyFrame } from '@agentconnect.md/protocol'
+import { OrgId } from '../../domain/ids.js'
+import type { DaemonConnection } from '../connection.js'
+
+export function frameOrgId(frame: AnyFrame, conn: DaemonConnection): OrgId | null {
+  const orgId = frame.orgId ?? conn.orgId
+  return orgId ? OrgId(orgId) : null
+}

--- a/packages/control-plane/src/ws/handlers/gitcred.test.ts
+++ b/packages/control-plane/src/ws/handlers/gitcred.test.ts
@@ -8,6 +8,7 @@ import { handleGitCredRequest } from './gitcred.js'
 const DAEMON_ID = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const AGENT_ID = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const HOOK_ID = 'b0b0b0b0-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const ORG_ID = 'org-a'
 
 /** An agent placed on DAEMON_ID — passes the handler's placement scope check. */
 const PLACED_AGENT = { id: AGENT_ID, orgId: 'org-a', daemonId: DAEMON_ID }
@@ -25,6 +26,7 @@ function gitcredFrame(payload: Record<string, unknown> = {}): AnyFrame {
 function fakeConn() {
   return {
     daemonId: DAEMON_ID,
+    orgId: ORG_ID,
     replyTo: vi.fn(),
     sendError: vi.fn()
   } as unknown as DaemonConnection & { replyTo: ReturnType<typeof vi.fn>; sendError: ReturnType<typeof vi.fn> }
@@ -40,7 +42,7 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
       access: 'read' as const
     }))
     const deps = {
-      agent: { getUnscoped: async () => PLACED_AGENT },
+      agent: { get: async () => PLACED_AGENT },
       github: { mintForAgent }
     } as unknown as DaemonWsDeps
     const conn = fakeConn()
@@ -79,9 +81,9 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
       access: 'read' as const
     }))
     const deps = {
-      agent: { getUnscoped: async () => PLACED_AGENT },
+      agent: { get: async () => PLACED_AGENT },
       hook: {
-        getUnscoped: async () => ({
+        get: async () => ({
           agentId: AGENT_ID,
           kind: 'github',
           enabled: true,
@@ -122,8 +124,8 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
   it('denies a GithubPoster mint when no enabled hook watches the requested repo', async () => {
     const mintForHookReply = vi.fn()
     const deps = {
-      agent: { getUnscoped: async () => PLACED_AGENT },
-      hook: { getUnscoped: async () => null },
+      agent: { get: async () => PLACED_AGENT },
+      hook: { get: async () => null },
       github: { mintForHookReply }
     } as unknown as DaemonWsDeps
     const conn = fakeConn()
@@ -147,7 +149,7 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
 
   it('denies a malformed GithubPoster capability request before minting', async () => {
     const deps = {
-      agent: { getUnscoped: async () => PLACED_AGENT },
+      agent: { get: async () => PLACED_AGENT },
       github: { mintForHookReply: vi.fn() }
     } as unknown as DaemonWsDeps
     const conn = fakeConn()
@@ -170,7 +172,7 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
 
   it('maps a GitCredDeniedError onto a correlated error REP (code + retryable preserved)', async () => {
     const deps = {
-      agent: { getUnscoped: async () => PLACED_AGENT },
+      agent: { get: async () => PLACED_AGENT },
       github: {
         mintForAgent: vi.fn(async () => {
           throw new GitCredDeniedError('acme/tools is not authorized for this agent', 'SCOPE_DENIED', false)

--- a/packages/control-plane/src/ws/handlers/gitcred.ts
+++ b/packages/control-plane/src/ws/handlers/gitcred.ts
@@ -20,6 +20,7 @@ import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, HookId } from '../../domain/ids.js'
 import { GitCredDeniedError } from '../../github/service.js'
+import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 
 export const handleGitCredRequest: Handler = async (frame, conn, deps) => {
@@ -31,10 +32,17 @@ export const handleGitCredRequest: Handler = async (frame, conn, deps) => {
     return
   }
 
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'organization is required', false)
+    return
+  }
+
   // Service scope: the requesting daemon must currently serve the agent — its placement, or a
   // duty it holds. A daemon that lost it (re-placement or a lapsed lease while offline) gets a
-  // terminal SCOPE_DENIED — its cache layer clears the entry and stops asking.
-  const agent = await deps.agent.getUnscoped(AgentId(agentId))
+  // terminal SCOPE_DENIED — its cache layer clears the entry and stops asking. The read is
+  // fenced on the frame's org, so a foreign-org agent is indistinguishable from a missing one.
+  const agent = await deps.agent.get(orgId, AgentId(agentId))
   if (!agent || !(await (deps.placementResolver ?? PLACEMENT_ONLY).mayAct(agent, conn.daemonId))) {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'this daemon does not serve that agent', false)
     return
@@ -62,8 +70,8 @@ export const handleGitCredRequest: Handler = async (frame, conn, deps) => {
       // environment. Its authority is the enabled hook itself, not the
       // workspace contents gitAccess (read workspaces must still be able to
       // deliver the reply promised by an always-on GitHub hook).
-      // Daemon trust domain: the hook named by the requesting daemon's own run (§4).
-      const hook = await deps.hook.getUnscoped(HookId(hookId))
+      // The hook named by the requesting daemon's own run, fenced on the frame's org (§4).
+      const hook = await deps.hook.get(orgId, HookId(hookId))
       if (!hook || hook.agentId !== AgentId(agentId) || hook.kind !== 'github' || !hook.enabled) {
         conn.sendError(frame.id, 'SCOPE_DENIED', 'hook is not an enabled github hook of this agent', false)
         return

--- a/packages/control-plane/src/ws/handlers/integration-channels.test.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.test.ts
@@ -25,7 +25,7 @@ function fakeDeps(platform = 'slack', known = true) {
     integration: { activeForDaemon: vi.fn(async () => integration) },
     slackSessionAccess: { dropPublicAudiences },
     agentMutations: { tryBeginMutation: vi.fn(() => vi.fn()) },
-    agent: { getUnscoped: vi.fn(async () => null) },
+    agent: { get: vi.fn(async () => null) },
     integrationChannel: { replaceSnapshot: vi.fn(async () => {}) },
     collabRoutes: { broadcast: vi.fn(async () => {}) }
   } as unknown as DaemonWsDeps

--- a/packages/control-plane/src/ws/handlers/integration-channels.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.ts
@@ -18,7 +18,7 @@
  * can never write channel rows for another daemon's integration.
  */
 import { isFrame } from '@agentconnect.md/protocol'
-import { AgentId, DaemonId } from '../../domain/ids.js'
+import { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import { isGatedAgent } from '../../orchestrator/placement.js'
 import type { Handler } from './index.js'
 
@@ -50,7 +50,8 @@ export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
     // Conversation gating (resource-visibility.md §14): a gated (restricted-agent)
     // integration's fresh conversations start Off — an editor must enable them in
     // the console. Known rows keep their operator-chosen trigger either way.
-    const owner = await deps.agent.getUnscoped(AgentId(integration.agentId))
+    // Fenced on the org of the integration row this daemon just proved it owns.
+    const owner = await deps.agent.get(OrgId(integration.orgId), AgentId(integration.agentId))
     const defaultTrigger = owner && isGatedAgent(owner) ? ('off' as const) : undefined
     await deps.integrationChannel.replaceSnapshot(
       integration.id,

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
@@ -103,7 +103,7 @@ describe('handleKnowledgeSearch', () => {
     ])
     const deps = {
       registry: featureRegistry,
-      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
+      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
       organizationKnowledge: { searchKnowledge }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -137,7 +137,7 @@ describe('handleKnowledgeSearch', () => {
       const searchKnowledge = vi.fn()
       const deps = {
         registry: featureRegistry,
-        agent: { getUnscoped: async () => requester },
+        agent: { get: async () => requester },
         organizationKnowledge: { searchKnowledge }
       } as unknown as DaemonWsDeps
       const connection = conn()
@@ -167,7 +167,7 @@ describe('handleKnowledgeList', () => {
     ])
     const deps = {
       registry: featureRegistry,
-      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
+      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
       organizationKnowledge: { listKnowledge }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -200,7 +200,7 @@ describe('handleKnowledgeList', () => {
     const listKnowledge = vi.fn()
     const deps = {
       registry: featureRegistry,
-      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: 'another-daemon' }) },
+      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: 'another-daemon' }) },
       organizationKnowledge: { listKnowledge }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -236,7 +236,7 @@ describe('handleKnowledgeList', () => {
     ])
     const deps = {
       registry: featureRegistry,
-      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
+      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
       organizationKnowledge: { listKnowledge }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -274,7 +274,7 @@ describe('handleOrgSkills', () => {
     const listManagedSkills = vi.fn(async () => rows)
     const deps = {
       registry: featureRegistry,
-      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
+      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
       organizationKnowledge: { listManagedSkills }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -307,7 +307,7 @@ describe('handleOrgSkills', () => {
     const listManagedSkills = vi.fn(async () => rows)
     const deps = {
       registry: featureRegistry,
-      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
+      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
       organizationKnowledge: { listManagedSkills }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -530,7 +530,7 @@ describe('handleManagedSkillRead', () => {
     const archive = new Uint8Array([0, 1, 2, 3, 4, 5])
     const deps = {
       registry: featureRegistry,
-      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON, managedSkills: [SKILL] }) },
+      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON, managedSkills: [SKILL] }) },
       organizationKnowledge: {
         getManagedSkill: async () => ({ id: SKILL, orgId: ORG, archivedAt: null }),
         getManagedSkillRevision: async () => ({
@@ -572,7 +572,7 @@ describe('handleManagedSkillRead', () => {
     const getManagedSkillRevision = vi.fn()
     const deps = {
       registry: featureRegistry,
-      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON, managedSkills: [] }) },
+      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON, managedSkills: [] }) },
       organizationKnowledge: { getManagedSkillRevision }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -597,7 +597,7 @@ describe('handleManagedSkillRead', () => {
     const searchKnowledge = vi.fn()
     const deps = {
       registry: { getUnscoped: async () => ({ id: DAEMON, orgId: ORG, capabilities: { features: [] } }) },
-      agent: { getUnscoped: vi.fn() },
+      agent: { get: vi.fn() },
       organizationKnowledge: { searchKnowledge }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -610,7 +610,7 @@ describe('handleManagedSkillRead', () => {
 
     expect(connection.sendError).toHaveBeenCalledWith(expect.any(String), 'SCOPE_DENIED', expect.any(String), false)
     expect(searchKnowledge).not.toHaveBeenCalled()
-    expect(deps.agent.getUnscoped).not.toHaveBeenCalled()
+    expect(deps.agent.get).not.toHaveBeenCalled()
   })
 })
 
@@ -701,7 +701,8 @@ describe('organization reads follow the serving member', () => {
     const deps = {
       // An install-wide member: org-less, so the frame is the only thing that names an org.
       registry: { getUnscoped: async () => ({ id: DAEMON, orgId: null, capabilities: installWideCapabilities }) },
-      agent: { getUnscoped: async () => requester },
+      // The org-fenced point read: a requester outside the frame's org reads as absent.
+      agent: { get: async (orgId: string) => (requester.orgId === orgId ? requester : null) },
       placementResolver: holderOf(holds),
       organizationKnowledge
     } as unknown as DaemonWsDeps

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.ts
@@ -13,7 +13,9 @@ async function featureDaemon(
   conn: Parameters<Handler>[1],
   deps: Parameters<Handler>[2]
 ): Promise<DaemonView | null> {
-  // Daemon trust domain: the connection's own daemon (org-scoped-data-layer.md §4).
+  // Install-wide read: the connection's OWN daemon row, whose org is null on a pool member,
+  // so no org fence exists to apply (org-scoped-data-layer.md §4).
+  // eslint-disable-next-line no-restricted-syntax -- the authenticated connection's own daemon row
   const daemon = await deps.registry.getUnscoped(DaemonId(conn.daemonId))
   if (!daemon || !daemon.capabilities.features.includes(ORGANIZATION_KNOWLEDGE_FEATURE)) {
     conn.sendError(frameId, 'SCOPE_DENIED', 'daemon did not advertise organization knowledge support', false)
@@ -42,9 +44,10 @@ async function servingRequester(
   conn: Parameters<Handler>[1],
   deps: Parameters<Handler>[2]
 ) {
-  const requester = await deps.agent.getUnscoped(AgentId(requesterAgentId))
   const orgId = frameOrgId ? OrgId(frameOrgId) : daemon.orgId
-  if (!requester || !orgId || requester.orgId !== orgId) return null
+  if (!orgId) return null
+  const requester = await deps.agent.get(orgId, AgentId(requesterAgentId))
+  if (!requester) return null
   const resolver = deps.placementResolver ?? PLACEMENT_ONLY
   return (await resolver.mayAct(requester, conn.daemonId)) ? requester : null
 }

--- a/packages/control-plane/src/ws/handlers/reporting-agent.ts
+++ b/packages/control-plane/src/ws/handlers/reporting-agent.ts
@@ -1,13 +1,17 @@
 import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
-import type { AgentId, DaemonId } from '../../domain/ids.js'
+import type { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import type { DaemonWsDeps } from '../deps.js'
 
 /**
  * Run one daemon-originated agent write only while the authenticated reporting daemon actually
  * serves that agent — its placement, or a duty it currently holds. The shared mutation lease
  * prevents a cold move from racing the check and the write.
+ *
+ * `orgId` is the reporting frame's org (M4): the agent read is fenced on it, so a member of one
+ * org can never name an agent of another on the same install-wide socket.
  */
 export async function runForReportingAgent(
+  orgId: OrgId,
   agentId: AgentId,
   daemonId: DaemonId,
   deps: Pick<DaemonWsDeps, 'agent' | 'agentMutations' | 'placementResolver'>,
@@ -16,7 +20,7 @@ export async function runForReportingAgent(
   const release = deps.agentMutations.tryBeginMutation(agentId)
   if (!release) return false
   try {
-    const agent = await deps.agent.getUnscoped(agentId)
+    const agent = await deps.agent.get(orgId, agentId)
     if (!agent || !(await (deps.placementResolver ?? PLACEMENT_ONLY).mayAct(agent, daemonId))) return false
     await write()
     return true

--- a/packages/control-plane/src/ws/handlers/usage-report.ts
+++ b/packages/control-plane/src/ws/handlers/usage-report.ts
@@ -11,14 +11,17 @@
  */
 import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId } from '../../domain/ids.js'
+import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 import { runForReportingAgent } from './reporting-agent.js'
 
 export const handleUsageReport: Handler = async (frame, conn, deps) => {
   if (!isFrame('usage/report')(frame)) return
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) return
   const p = frame.payload
   const agentId = AgentId(p.agentId)
-  await runForReportingAgent(agentId, DaemonId(conn.daemonId), deps, async () => {
+  await runForReportingAgent(orgId, agentId, DaemonId(conn.daemonId), deps, async () => {
     await deps.sessionUsage.record({
       sessionId: p.sessionId,
       agentId,

--- a/packages/control-plane/test/integration/session-conversations.route.test.ts
+++ b/packages/control-plane/test/integration/session-conversations.route.test.ts
@@ -50,7 +50,7 @@ async function reportSession(payload: Record<string, unknown>, daemonId = DAEMON
     webchatConversation: new PgWebchatConversationRepo(prisma),
     events: new InMemorySessionEventSink()
   } as unknown as DaemonWsDeps
-  await handleEventSession(frame, { daemonId } as DaemonConnection, deps)
+  await handleEventSession(frame, { daemonId, orgId: DEFAULT_ORG_ID } as DaemonConnection, deps)
 }
 
 /** A Slack thread milestone at a given activity instant. */

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -54,7 +54,7 @@ async function reportSession(payload: Record<string, unknown>, daemonId = DAEMON
     webchatConversation: new PgWebchatConversationRepo(prisma),
     events: new InMemorySessionEventSink()
   } as unknown as DaemonWsDeps
-  await handleEventSession(frame, { daemonId } as DaemonConnection, deps)
+  await handleEventSession(frame, { daemonId, orgId: DEFAULT_ORG_ID } as DaemonConnection, deps)
 }
 
 describe('event/session sync → SessionMeta → GET /sessions/:id', () => {

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -72,10 +72,14 @@ describe('usage/report handler — persists per-session token usage', () => {
       usage: { totalTokens: 4820, inputTokens: 3600, outputTokens: 1220, cachedReadTokens: 512, costAmount: 0.41 }
     })
 
-    // Fire-and-forget EVT — poll for the persisted row.
+    // Fire-and-forget EVT — poll for the persisted rows. The spend sample is a SECOND
+    // upsert, so waiting only on the counters can read the gap between them.
     const key = { agentId_sessionId: { agentId: AGENT_A, sessionId: 'acp-sess-1' } }
     await vi.waitFor(async () => {
       expect(await prisma.sessionUsage.findUnique({ where: key })).not.toBeNull()
+      expect(
+        await prisma.sessionSpend.findFirst({ where: { agentId: AGENT_A, sessionId: 'acp-sess-1' } })
+      ).not.toBeNull()
     })
     let row = await prisma.sessionUsage.findUnique({ where: key })
     expect(row!.totalTokens).toBe(4820)


### PR DESCRIPTION
## Summary

The `*Unscoped` tenancy fence (`docs/designs/org-scoped-data-layer.md` §6) covered the HTTP
and MCP surfaces only; `packages/control-plane/src/ws/**` was exempt. That exemption was
written when a daemon socket meant one organization, so "the connection's ApiKey row" was a
stronger fence than an org parameter. An install-wide pool member breaks that premise — many
organizations share one socket — and the exemption has already produced a live symptom
(#968: an org-less member replaying `knowledge/suggestions/sync`, closed by #996).

This extends the same ESLint rule to `src/ws/**` and gives every handler it flags an explicit
organization argument. The org is the one the frame acts in — `frame.orgId` in frame mode,
`conn.orgId` on an ordinary org-scoped connection — never re-derived from a row the handler
read unscoped. `ws/connection.ts` already refuses a frame whose org disagrees with the
connection or with the resource it targets, so handlers can fence their repository reads on
that value directly.

Mechanical by construction: no frame schema changes, no reconnect-snapshot changes (other M4
bullets), and no change to hook, session-content or duty-lease handler logic beyond the
scoping argument. Part of #955 M4.

## What the fence now covers

`no-restricted-syntax` forbids any `*Unscoped` member call in
`packages/control-plane/src/ws/**/*.ts`, alongside the existing `http/routes/**` and
`http/mcp/**` globs. A genuinely install-wide read carries an inline
`eslint-disable-next-line` with a one-line justification, exactly as a public-by-design
endpoint does — the exemption is the documentation.

New helper `ws/handlers/frame-org.ts` (`frameOrgId(frame, conn)`) is the single place the
org is resolved, so every handler reads the same way.

## Handlers changed

Scoped — the unscoped read became the org-fenced one:

- `duty/fetch` — `agent.get(orgId, …)`; a fetch naming no organization is now `SCOPE_DENIED`.
- `event/session` and `event/session-sync` — `agent.get`, `hook.get`, `integration.get`,
  `bot.get`, all on the frame's org (threaded through `externalCandidate` /
  `recordEventSession`).
- `event/session-activity` and `usage/report` — via the shared `runForReportingAgent`, which
  now takes `orgId` and uses `agent.get`.
- `event/session-purged` — `agent.get`.
- `gitcred/request` — `agent.get`, `hook.get`.
- `session/child-status` — `session.get`, `agent.get`. The now-redundant
  `frame.orgId !== parent.orgId` comparison is dropped: the fenced read is strictly stronger,
  because it also applies when the frame carries no org.
- `integration/channels` — `agent.get` fenced on the org of the integration row this daemon
  proved it owns two lines earlier (and already broadcasts on).
- `knowledge/search`, `knowledge/list`, `skills/org`, `managed-skill/read` — `servingRequester`
  resolves the org first, then reads the requester through `agent.get`. The explicit
  `requester.orgId !== orgId` check becomes the repository's job.

Allow-listed — an install-wide read where no org fence exists to apply:

- `registry.getUnscoped(conn.daemonId)` in `organization-knowledge.ts`, `channel-agents.ts`
  and `child-session-status.ts` — the authenticated connection's OWN daemon row, whose org is
  null on a pool member.
- `agent.getUnscoped(agentId)` in `duty/claim` — the activation rendezvous is an
  `INSTALL_WIDE_FRAME_TYPES` frame by design: the member is asking about an agent it does not
  yet serve, so it asserts no organization and the ledger derives it from the agent.

`docs/designs/org-scoped-data-layer.md` §4/§6/§8 are updated to match — the "daemon WS trust
domain is not reshaped here" note was the reason the exemption existed.

## Test plan

- `pnpm lint` — the fence is the test; a probe file added under `src/ws/` errors as expected.
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane test:unit` — the WS handler suites, updated to
  the scoped ports (fakes model the org-fenced point read, connections carry an org). One new
  case: `duty/fetch` refuses a frame that names no organization.
- `pnpm --filter @agentconnect.md/control-plane test:int` — full integration run (Docker); the two suites that drive `handleEventSession` directly needed an org on their fake connection, and `usage.route` now waits for the spend row it asserts (a second, non-transactional upsert it could read past).
- `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
