### PR TITLE
fix(relay): hold GitHub authorization and run reports across a CP reconnect

### DIFF
--- a/packages/relay/src/relay-cp-client.test.ts
+++ b/packages/relay/src/relay-cp-client.test.ts
@@ -21,6 +21,14 @@ const COMMENT_AUTHZ = {
   configRevision: '3',
   dispatchRevision: '5'
 } as const
+const RUN_REPORT = {
+  hookId: COMMENT_AUTHZ.hookId,
+  deliveryKey: 'delivery-1',
+  firedAt: '2026-07-07T00:00:00.000Z',
+  agentId: '33333333-3333-4333-8333-333333333333',
+  status: 'failed',
+  reason: 'review_request_required'
+} as const
 const REREQUEST = {
   checkRunId: '86617583005',
   repoId: '987654321',
@@ -67,15 +75,12 @@ class FakeTransport implements Transport {
   }
 }
 
-/** Drive a client from start() through to READY against `transport`. */
-async function handshakeToReady(
-  client: RelayCpClient,
+/** Answer the auth + register REQs already sitting on `transport`. */
+async function completeHandshake(
   transport: FakeTransport,
   heartbeatSec = 15,
   deploymentConfig?: { revision: number; githubWebhookSecret?: string }
 ): Promise<void> {
-  client.start()
-  await flush()
   const auth = transport.lastReq('rc/auth')!
   transport.inject(
     buildRelayCpFrame(
@@ -92,6 +97,49 @@ async function handshakeToReady(
   const reg = transport.lastReq('rc/register')!
   transport.inject(buildRelayCpFrame('rc/registered', { relayId: RELAY_ID }, { corr: reg.id }))
   await flush()
+}
+
+/** Drive a client from start() through to READY against `transport`. */
+async function handshakeToReady(
+  client: RelayCpClient,
+  transport: FakeTransport,
+  heartbeatSec = 15,
+  deploymentConfig?: { revision: number; githubWebhookSecret?: string }
+): Promise<void> {
+  client.start()
+  await flush()
+  await completeHandshake(transport, heartbeatSec, deploymentConfig)
+}
+
+/** A client whose every dial hands out a FRESH transport, so a close can be
+ *  followed through the reconnect the way a CP restart is. */
+function makeReconnectingClient(over: Partial<RelayCpClientDeps> = {}) {
+  const clock = new FakeClock()
+  const transports: FakeTransport[] = []
+  const client = new RelayCpClient({
+    auth: { method: 'token', credential: TOKEN },
+    name: 'relay-0',
+    daemonUrl: 'wss://relay-0.example',
+    heartbeatDefaultMs: 15_000,
+    clock,
+    connect: async () => {
+      const transport = new FakeTransport()
+      transports.push(transport)
+      return transport
+    },
+    log: silentLog,
+    jitter: () => 0,
+    ...over
+  })
+  /** Close the live transport and complete the handshake on the replacement. */
+  const reconnect = async (): Promise<FakeTransport> => {
+    clock.advance(1_000)
+    await flush()
+    const next = transports.at(-1)!
+    await completeHandshake(next)
+    return next
+  }
+  return { client, clock, transports, reconnect }
 }
 
 function makeClient(over: Partial<RelayCpClientDeps> = {}) {
@@ -452,5 +500,99 @@ describe('RelayCpClient', () => {
 
     await expect(pending).resolves.toEqual(result)
     expect(client.state).toBe('READY')
+  })
+
+  it('authorizeGithubComment() rides out a CP restart instead of failing closed', async () => {
+    const { client, transports, reconnect } = makeReconnectingClient()
+    client.start()
+    await flush()
+    await completeHandshake(transports[0]!)
+    transports[0]!.simulateClose(1012)
+
+    // The delivery is already answered 202: waiting for the link is the difference
+    // between a review and a silently skipped one.
+    const pending = client.authorizeGithubComment(COMMENT_AUTHZ)
+    await flush()
+    expect(transports[0]!.sent.filter((f) => f.type === 'rc/github-comment-authz')).toHaveLength(0)
+
+    const next = await reconnect()
+    await flush()
+    const req = next.lastReq('rc/github-comment-authz')!
+    expect(req.payload).toEqual(COMMENT_AUTHZ)
+    next.inject(buildRelayCpFrame('rc/github-comment-authz/ok', { allowed: true }, { corr: req.id }))
+    await expect(pending).resolves.toBe(true)
+  })
+
+  it('authorizeGithubComment() re-issues a request the dying link swallowed, exactly once', async () => {
+    const { client, transports, reconnect } = makeReconnectingClient()
+    client.start()
+    await flush()
+    await completeHandshake(transports[0]!)
+
+    const pending = client.authorizeGithubComment(COMMENT_AUTHZ)
+    await flush()
+    expect(transports[0]!.lastReq('rc/github-comment-authz')).toBeDefined()
+    transports[0]!.simulateClose(1012) // in-flight REQ rejects as retryable
+
+    const next = await reconnect()
+    await flush()
+    const req = next.lastReq('rc/github-comment-authz')!
+    next.inject(buildRelayCpFrame('rc/github-comment-authz/ok', { allowed: false }, { corr: req.id }))
+
+    await expect(pending).resolves.toBe(false)
+    expect(next.sent.filter((f) => f.type === 'rc/github-comment-authz')).toHaveLength(1)
+  })
+
+  it('authorizeGithubComment() still fails closed when the link stays down', async () => {
+    const { client, clock, transports } = makeReconnectingClient()
+    client.start()
+    await flush()
+    await completeHandshake(transports[0]!)
+    transports[0]!.simulateClose(1012)
+
+    const settled = expect(client.authorizeGithubComment(COMMENT_AUTHZ)).rejects.toMatchObject({ retryable: true })
+    clock.advance(30_000) // the wait window, with no CP answering the reconnect
+    await flush()
+
+    await settled
+    for (const transport of transports) {
+      expect(transport.sent.filter((f) => f.type === 'rc/github-comment-authz')).toHaveLength(0)
+    }
+  })
+
+  it('replays run reports queued while the link was down, oldest first', async () => {
+    const { client, transports, reconnect } = makeReconnectingClient()
+    client.start()
+    await flush()
+    await completeHandshake(transports[0]!)
+    transports[0]!.simulateClose(1012)
+
+    // A delivery refused pre-dispatch never reaches a daemon, so this row is the
+    // only trace it ever gets — dropping it shows the console nothing at all.
+    client.emitRunReport({ ...RUN_REPORT, deliveryKey: 'delivery-1' })
+    client.emitRunReport({ ...RUN_REPORT, deliveryKey: 'delivery-2' })
+
+    const next = await reconnect()
+    const replayed = next.sent.filter((f) => f.type === 'rc/run-report')
+    expect(replayed.map((f) => (f.payload as { deliveryKey: string }).deliveryKey)).toEqual([
+      'delivery-1',
+      'delivery-2'
+    ])
+    expect((replayed[0]!.payload as { firedAt: string }).firedAt).toBe(RUN_REPORT.firedAt)
+  })
+
+  it('bounds the queued run reports, dropping the oldest', async () => {
+    const { client, transports, reconnect } = makeReconnectingClient()
+    client.start()
+    await flush()
+    await completeHandshake(transports[0]!)
+    transports[0]!.simulateClose(1012)
+
+    for (let i = 0; i < 205; i++) client.emitRunReport({ ...RUN_REPORT, deliveryKey: `delivery-${i}` })
+
+    const next = await reconnect()
+    const replayed = next.sent.filter((f) => f.type === 'rc/run-report')
+    expect(replayed).toHaveLength(200)
+    expect((replayed[0]!.payload as { deliveryKey: string }).deliveryKey).toBe('delivery-5')
   })
 })

--- a/packages/relay/src/relay-cp-client.test.ts
+++ b/packages/relay/src/relay-cp-client.test.ts
@@ -543,6 +543,38 @@ describe('RelayCpClient', () => {
     expect(next.sent.filter((f) => f.type === 'rc/github-comment-authz')).toHaveLength(1)
   })
 
+  it('authorizeGithubComment() does not re-ask over a link that never died', async () => {
+    // A retryable answer is not proof the connection dropped: the CP replies
+    // retryable for its own GitHub/DB blips, and an ack timeout is retryable
+    // too. Re-issuing on that same link would duplicate the upstream lookup.
+    const { client, transport } = makeClient()
+    await handshakeToReady(client, transport)
+
+    const pending = client.authorizeGithubComment(COMMENT_AUTHZ)
+    await flush()
+    const req = transport.lastReq('rc/github-comment-authz')!
+    transport.inject(
+      buildRelayCpFrame('error', { code: 'INTERNAL', message: 'github blip', retryable: true }, { corr: req.id })
+    )
+
+    await expect(pending).rejects.toMatchObject({ retryable: true })
+    expect(transport.sent.filter((f) => f.type === 'rc/github-comment-authz')).toHaveLength(1)
+    expect(client.state).toBe('READY')
+  })
+
+  it('authorizeGithubComment() gives up when the ack never comes and the link stays up', async () => {
+    const { client, clock, transport } = makeClient()
+    await handshakeToReady(client, transport)
+
+    const settled = expect(client.authorizeGithubComment(COMMENT_AUTHZ)).rejects.toMatchObject({ retryable: true })
+    await flush()
+    clock.advance(5_000) // the single-shot ack budget — retryable, but the link never dropped
+    await flush()
+
+    await settled
+    expect(transport.sent.filter((f) => f.type === 'rc/github-comment-authz')).toHaveLength(1)
+  })
+
   it('authorizeGithubComment() still fails closed when the link stays down', async () => {
     const { client, clock, transports } = makeReconnectingClient()
     client.start()

--- a/packages/relay/src/relay-cp-client.ts
+++ b/packages/relay/src/relay-cp-client.ts
@@ -147,6 +147,8 @@ export class RelayCpClient {
   private reconnectTimer?: TimerHandle
   private heartbeatTimer?: TimerHandle
   private heartbeatMs = 0
+  /** Bumped on every registration — identifies WHICH connection a request rode. */
+  private linkGeneration = 0
   /** Callers parked in {@link waitReady} until the link registers again. */
   private readonly readyWaiters = new Set<ReadyWaiter>()
   /** FIFO of `rc/run-report` EVTs the link wasn't up for, replayed on READY. */
@@ -239,18 +241,25 @@ export class RelayCpClient {
    * One authorization RPC, single-shot PER LINK but held across ONE reconnect:
    * the caller is off GitHub's HTTP request already, and failing closed on a
    * link that is merely restarting turns a CP rollout into silently skipped
-   * reviews. A settled `error` REP (an old CP, a refusal) is terminal — only a
-   * retryable wire failure, i.e. the link itself, buys the second attempt.
+   * reviews. The second attempt is bought by a REPLACED CONNECTION, never by a
+   * retryable flag: an ack timeout and the CP's own retryable `error` REPs both
+   * arrive on a link that is still READY, and re-issuing there would duplicate
+   * an expensive upstream permission lookup.
    */
   private async authorizationRequest(build: () => RelayCpFrame, label: string): Promise<RelayCpFrame> {
     for (let attempt = 0; attempt < 2; attempt++) {
       if (!(await this.waitReady(LINK_READY_WAIT_MS)) || !this.transport) {
         throw new WireError('INTERNAL', `relay↔CP link not ready (${this.state})`, true)
       }
+      const generation = this.linkGeneration
       try {
         return await this.sendRequest(build(), { maxTries: 1, ackTimeoutMs: ACK_TIMEOUT_MS })
       } catch (err) {
         if (attempt > 0 || !(err instanceof WireError) || !err.retryable) throw err
+        // Only a connection this request never reached the CP over is retryable
+        // here: wait for the replacement, and give up on the original error if
+        // the link that failed is still the live one.
+        if (!(await this.waitReady(LINK_READY_WAIT_MS)) || this.linkGeneration === generation) throw err
         this.deps.log.warn(`relay: ${label} lost its link (${err.message}) — retrying across the reconnect`)
       }
     }
@@ -504,6 +513,7 @@ export class RelayCpClient {
     this.deps.onRegistered?.(this.relayId)
 
     this.state = 'READY'
+    this.linkGeneration += 1
     this.heartbeatMs = ok.heartbeatSec > 0 ? ok.heartbeatSec * 1000 : this.deps.heartbeatDefaultMs
     this.armHeartbeat()
     this.deps.log.info(`relay: READY (relayId=${this.relayId})`)

--- a/packages/relay/src/relay-cp-client.ts
+++ b/packages/relay/src/relay-cp-client.ts
@@ -65,8 +65,23 @@ import type { RelayAuthCredential } from './config.js'
 
 const ACK_TIMEOUT_MS = 5000
 
+/** How long an out-of-band GitHub authorization waits for a reconnecting link before
+ *  failing closed. A CP restart drops the link for seconds; the delivery is already
+ *  answered 202, so waiting costs nothing and is the difference between a review and
+ *  a silently skipped one. */
+const LINK_READY_WAIT_MS = 30_000
+
+/** Run reports held while the link is down. Bounded — the OLDEST is dropped first
+ *  (a stale delivery-stage row is the least useful one to replay). */
+const MAX_PENDING_RUN_REPORTS = 200
+
 /** CP close code for a rejected credential — fatal, never auto-retry (mirrors the daemon's 4401). */
 const AUTH_FAILED_CLOSE = 4401
+
+interface ReadyWaiter {
+  resolve: (ready: boolean) => void
+  timer?: TimerHandle
+}
 
 export type RelayCpState = 'CONNECTING' | 'AUTHENTICATING' | 'REGISTERING' | 'READY' | 'CLOSED' | 'DEGRADED'
 
@@ -132,6 +147,10 @@ export class RelayCpClient {
   private reconnectTimer?: TimerHandle
   private heartbeatTimer?: TimerHandle
   private heartbeatMs = 0
+  /** Callers parked in {@link waitReady} until the link registers again. */
+  private readonly readyWaiters = new Set<ReadyWaiter>()
+  /** FIFO of `rc/run-report` EVTs the link wasn't up for, replayed on READY. */
+  private readonly pendingRunReports: RcRunReport[] = []
 
   constructor(private readonly deps: RelayCpClientDeps) {
     this.correlator = new ReqRep<RelayCpFrame>(deps.clock, ACK_TIMEOUT_MS)
@@ -153,6 +172,7 @@ export class RelayCpClient {
     }
     this.stopHeartbeat()
     this.correlator.rejectAll(new Error('stopping'))
+    this.releaseReadyWaiters(false)
     this.transport?.close(1000, 'shutdown')
     this.state = 'CLOSED'
   }
@@ -160,6 +180,34 @@ export class RelayCpClient {
   /** True once the relay↔CP link has completed registration and is heartbeating. */
   isReady(): boolean {
     return this.state === 'READY'
+  }
+
+  /**
+   * Resolve as soon as the link is READY, or `false` when `timeoutMs` elapses
+   * first (or this client is stopped / fatally closed). The GitHub
+   * authorization path rides a reconnect on this instead of failing closed on a
+   * seconds-long CP restart, which would silently skip the review the delivery
+   * was going to trigger.
+   */
+  waitReady(timeoutMs: number): Promise<boolean> {
+    if (this.state === 'READY' && this.transport) return Promise.resolve(true)
+    if (this.stopped || this.fatal || timeoutMs <= 0) return Promise.resolve(false)
+    return new Promise<boolean>((resolve) => {
+      const waiter: ReadyWaiter = { resolve }
+      waiter.timer = this.deps.clock.setTimeout(() => {
+        this.readyWaiters.delete(waiter)
+        resolve(false)
+      }, timeoutMs)
+      this.readyWaiters.add(waiter)
+    })
+  }
+
+  private releaseReadyWaiters(ready: boolean): void {
+    for (const waiter of [...this.readyWaiters]) {
+      this.readyWaiters.delete(waiter)
+      if (waiter.timer !== undefined) this.deps.clock.clearTimeout(waiter.timer)
+      waiter.resolve(ready)
+    }
   }
 
   /**
@@ -188,19 +236,38 @@ export class RelayCpClient {
   }
 
   /**
+   * One authorization RPC, single-shot PER LINK but held across ONE reconnect:
+   * the caller is off GitHub's HTTP request already, and failing closed on a
+   * link that is merely restarting turns a CP rollout into silently skipped
+   * reviews. A settled `error` REP (an old CP, a refusal) is terminal — only a
+   * retryable wire failure, i.e. the link itself, buys the second attempt.
+   */
+  private async authorizationRequest(build: () => RelayCpFrame, label: string): Promise<RelayCpFrame> {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      if (!(await this.waitReady(LINK_READY_WAIT_MS)) || !this.transport) {
+        throw new WireError('INTERNAL', `relay↔CP link not ready (${this.state})`, true)
+      }
+      try {
+        return await this.sendRequest(build(), { maxTries: 1, ackTimeoutMs: ACK_TIMEOUT_MS })
+      } catch (err) {
+        if (attempt > 0 || !(err instanceof WireError) || !err.retryable) throw err
+        this.deps.log.warn(`relay: ${label} lost its link (${err.message}) — retrying across the reconnect`)
+      }
+    }
+    throw new WireError('INTERNAL', `relay↔CP link not ready (${this.state})`, true)
+  }
+
+  /**
    * Resolve an untrusted/stale GitHub comment association against the App's
-   * current repository permission. This request is deliberately single-shot:
-   * GitHub deliveries are already deduplicated by delivery id, and retrying the
-   * control RPC could duplicate an expensive upstream permission lookup.
+   * current repository permission. One upstream permission lookup per link: the
+   * request is never retransmitted on the same connection (GitHub deliveries are
+   * already deduplicated by delivery id), only re-issued once after a reconnect.
    */
   async authorizeGithubComment(request: RcGithubCommentAuthz): Promise<boolean> {
-    if (this.state !== 'READY' || !this.transport) {
-      throw new WireError('INTERNAL', `relay↔CP link not ready (${this.state})`, true)
-    }
-    const rep = await this.sendRequest(buildRelayCpFrame('rc/github-comment-authz', request), {
-      maxTries: 1,
-      ackTimeoutMs: ACK_TIMEOUT_MS
-    })
+    const rep = await this.authorizationRequest(
+      () => buildRelayCpFrame('rc/github-comment-authz', request),
+      'rc/github-comment-authz'
+    )
     if (rep.type !== 'rc/github-comment-authz/ok') {
       throw new WireError('INTERNAL', `expected rc/github-comment-authz/ok, got ${rep.type}`, false)
     }
@@ -208,16 +275,14 @@ export class RelayCpClient {
   }
 
   /** Resolve a signature-verified Check run or suite rerequest to current
-   * informational projection targets. Single-shot: GitHub redelivery keeps the
-   * same delivery key and the daemon/hook stores provide the retry fence. */
+   * informational projection targets. Same one-attempt-per-link rule: GitHub
+   * redelivery keeps the same delivery key and the daemon/hook stores provide
+   * the retry fence. */
   async authorizeGithubRerequest(request: RcGithubRerequest): Promise<RcGithubRerequestResult> {
-    if (this.state !== 'READY' || !this.transport) {
-      throw new WireError('INTERNAL', `relay↔CP link not ready (${this.state})`, true)
-    }
-    const rep = await this.sendRequest(buildRelayCpFrame('rc/github-rerequest', request), {
-      maxTries: 1,
-      ackTimeoutMs: ACK_TIMEOUT_MS
-    })
+    const rep = await this.authorizationRequest(
+      () => buildRelayCpFrame('rc/github-rerequest', request),
+      'rc/github-rerequest'
+    )
     if (rep.type !== 'rc/github-rerequest/ok') {
       throw new WireError('INTERNAL', `expected rc/github-rerequest/ok, got ${rep.type}`, false)
     }
@@ -226,16 +291,32 @@ export class RelayCpClient {
 
   /**
    * Emit one delivery-stage bookkeeping EVT (`rc/run-report`, fire-and-forget).
-   * A CP outage drops the report — by design the TRIGGER survives (the daemon
-   * already has the fire) and only the console record suffers; the reaper and a
-   * late `hook/report` converge the row when the CP returns.
+   * A report the link wasn't up for is QUEUED and replayed on READY, in order:
+   * the row it opens is the only trace some deliveries ever get (a delivery
+   * refused pre-dispatch never reaches a daemon, so no late `hook/report`
+   * converges it), and dropping it leaves the console showing nothing at all.
+   * `firedAt` travels with the report, so a replayed row keeps its real time.
    */
   emitRunReport(report: RcRunReport): void {
     if (this.state !== 'READY' || !this.transport) {
-      this.deps.log.warn(`relay: dropping rc/run-report ${report.hookId}:${report.deliveryKey} (link ${this.state})`)
+      if (this.pendingRunReports.length >= MAX_PENDING_RUN_REPORTS) {
+        const dropped = this.pendingRunReports.shift()!
+        this.deps.log.warn(`relay: dropping rc/run-report ${dropped.hookId}:${dropped.deliveryKey} (queue full)`)
+      }
+      this.pendingRunReports.push(report)
+      this.deps.log.warn(`relay: deferring rc/run-report ${report.hookId}:${report.deliveryKey} (link ${this.state})`)
       return
     }
     this.transport.send(JSON.stringify(buildRelayCpFrame('rc/run-report', report)))
+  }
+
+  /** Replay the reports queued while the link was down (oldest first), stopping
+   *  at the first one the link still can't take. */
+  private flushPendingRunReports(): void {
+    while (this.pendingRunReports.length > 0) {
+      if (this.state !== 'READY' || !this.transport) return
+      this.transport.send(JSON.stringify(buildRelayCpFrame('rc/run-report', this.pendingRunReports.shift()!)))
+    }
   }
 
   /**
@@ -426,6 +507,8 @@ export class RelayCpClient {
     this.heartbeatMs = ok.heartbeatSec > 0 ? ok.heartbeatSec * 1000 : this.deps.heartbeatDefaultMs
     this.armHeartbeat()
     this.deps.log.info(`relay: READY (relayId=${this.relayId})`)
+    this.flushPendingRunReports()
+    this.releaseReadyWaiters(true)
     this.deps.onReady?.()
   }
 
@@ -536,11 +619,13 @@ export class RelayCpClient {
     if (code === AUTH_FAILED_CLOSE) {
       this.fatal = true
       this.state = 'CLOSED'
+      this.releaseReadyWaiters(false) // nothing to wait for — this link never comes back
       this.deps.log.error('relay: AUTH_FAILED (4401) — not reconnecting; check RELAY_TOKEN / RELAY_API_KEY')
       return
     }
     if (this.stopped) {
       this.state = 'CLOSED'
+      this.releaseReadyWaiters(false)
       return
     }
     this.state = 'DEGRADED'


### PR DESCRIPTION
## Summary

A GitHub PR-lifecycle delivery that lands while the relay's CP link is down disappears **without a trace**: no `HookRun` row, no Check, nothing on the PR — and GitHub never retries a delivery it considers served.

Two independent paths fail on the same dead link:

- `pull_request:opened` / `synchronize` are gated on a live maintainer-permission lookup (`author_association` is deliberately not trusted, #319), and `authorizeGithubComment` throws the moment the link is not `READY`. The ingress fails closed → `pullRequestNeedsMaintainer` → the review is skipped, for the repository owner's own PR as much as anyone's.
- The compensating "review request required" informational Check is reported through `emitRunReport` on that same link, which dropped it.

Observed in practice: a rolling restart terminated the CP a few seconds before a PR was opened, and that PR simply never got a review — while the deliveries ~20s either side of it were processed normally.

## Fix

- **`authorizationRequest()`** — one seam for both GitHub authorization RPCs (`rc/github-comment-authz`, `rc/github-rerequest`). It waits up to 30s for the link to register, and re-issues the request **exactly once** when the wire failure was retryable (i.e. the link itself died mid-flight). A settled `error` REP stays terminal, so a refusal or an old CP still fails closed on the first answer, and no request is ever retransmitted on the same connection. Both call sites are already off GitHub's HTTP request (`void dispatch…`), so the wait costs nothing but a pending promise. The post-await `currentAuthorizedRule` re-read already fences a rule that changed during the wait.
- **`emitRunReport`** queues instead of dropping, and the queue replays in order on `READY` (bounded at 200, oldest dropped first). A delivery refused pre-dispatch never reaches a daemon, so no late `hook/report` converges its row — that report is the only trace it will ever get. `firedAt` travels with the report, so a replayed row keeps its real ingest time.

## Test plan

- [x] `relay-cp-client.test.ts` (new): authorization rides out a restart instead of failing closed; a request the dying link swallowed is re-issued exactly once on the new link; it still fails closed when the link stays down for the whole window; run reports replay oldest-first with `firedAt` intact; the queue bound drops the oldest.
- [x] Existing single-shot semantics preserved — the "old CP error" case still rejects on the first answer with one frame sent.
- [x] `pnpm --filter @agentconnect.md/relay test` (494 passed), `typecheck`, `eslint`, `prettier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
