### PR TITLE
perf(daemon): run the unit suite with a shared module registry

### DIFF
--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -7,7 +7,7 @@ import { selectAgent } from '../agents/load-agents.js'
 import { agentChildEnv } from '../agents/agent-env.js'
 import { cleanupConfigFiles, materializeConfigFiles } from '../agents/config-file-env.js'
 import { memoryKindOf, memoryProviderFor } from '../agents/memory-provider.js'
-import { additionalWorkspaceDirectories, prepareWorkspace } from '../workspace/workspace-manager.js'
+import { WorkspaceManager } from '../workspace/workspace-manager.js'
 import { configureWorkspaceGitOrigins } from '../workspace/git-origin-policy.js'
 import { AcpHost } from '../acp/acp-host.js'
 import { effectiveRunInSandbox } from '../acp/runtime-launch.js'
@@ -168,14 +168,23 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   }
   process.once('SIGINT', onSigint)
   try {
-    const cwd = await prepareWorkspace(agent, {
+    // The standalone chat CLI runs one agent locally, so it owns a plane with nothing registered
+    // on it: git runs here and no path lives in a sandbox.
+    const workspaces = new WorkspaceManager()
+    const cwd = await workspaces.prepareWorkspace(agent, {
       skillsStateDir: join(root, 'skill-installs'),
       skillsAgentId: entry?.skillsAgentId ?? null
     })
     // Runtime adapters may discover skills only during initialization. Finish the
     // complete clone/pull + unified-skill reconciliation before the child starts.
     await host.start()
-    const sessionId = await host.newSession(cwd, [], undefined, undefined, additionalWorkspaceDirectories(agent, cwd))
+    const sessionId = await host.newSession(
+      cwd,
+      [],
+      undefined,
+      undefined,
+      workspaces.additionalWorkspaceDirectories(agent, cwd)
+    )
 
     const send = async (text: string) => {
       const blocks: ContentBlock[] = [{ type: 'text', text }]

--- a/packages/daemon/src/cp/local-skills-reader.ts
+++ b/packages/daemon/src/cp/local-skills-reader.ts
@@ -12,13 +12,14 @@ import { existsSync } from 'node:fs'
 import type { LocalSkillsList, LocalSkillsReq } from '@agentconnect.md/protocol'
 import { listLocalSkills, listSandboxSkills } from '../skills/local-skill-inventory.js'
 import type { WorkspaceFiles } from '../workspace/workspace-files.js'
-import { sandboxWorkspaceMode } from '../workspace/workspace-manager.js'
+import { WorkspaceManager } from '../workspace/workspace-manager.js'
 
 export interface LocalSkillsReader {
   list(req: LocalSkillsReq): Promise<LocalSkillsList>
 }
 
 export function createLocalSkillsReader(
+  workspaces: WorkspaceManager,
   workspacePathFor: (agentId: string) => string | undefined,
   stateDir: string,
   /** The filesystem that agent's workspace lives on; undefined ⇒ this daemon's. */
@@ -37,7 +38,7 @@ export function createLocalSkillsReader(
         // sits at that path on this daemon's filesystem. Unreachable is reported as unmaterialized —
         // the wire has no third answer here, and the two other seams refuse with `sandbox-unavailable`
         // because theirs does.
-        if (sandboxWorkspaceMode()) return { materialized: false, skills: [] }
+        if (workspaces.sandboxMode) return { materialized: false, skills: [] }
         if (!existsSync(cwd)) return { materialized: false, skills: [] }
         return { materialized: true, skills: await listLocalSkills(cwd, stateDir) }
       }

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -63,7 +63,7 @@ import {
   workspaceGitPullTarget,
   workspaceGitPushTarget
 } from '../workspace/git-injection.js'
-import { consoleWorkspaceGitRunner, sandboxWorkspaceMode } from '../workspace/workspace-manager.js'
+import { WorkspaceManager } from '../workspace/workspace-manager.js'
 import { GitTransportError, type GitRunner } from '../workspace/git-runner.js'
 import { authorizeWorkspaceGitUrl } from '../workspace/git-origin-policy.js'
 import { canonicalWorkspacePath, containedWorkspacePath, WorkspaceViolationError } from './workspace-reader.js'
@@ -116,8 +116,8 @@ const STAGE_PATHSPEC_CHUNK = 50
  *  resolves exactly once and derives every other runner from that one, so this is also the whole of
  *  how an unreachable sandbox is detected: there is no window in which a check said "reachable" and a
  *  later resolution answered with this daemon's filesystem. */
-function runnerFor(agentId: string, cwd: string, abort?: AbortSignal): GitRunner {
-  const runner = consoleWorkspaceGitRunner(agentId, cwd, abort)
+function runnerFor(workspaces: WorkspaceManager, agentId: string, cwd: string, abort?: AbortSignal): GitRunner {
+  const runner = workspaces.consoleWorkspaceGitRunner(agentId, cwd, abort)
   if (!runner) {
     throw new WorkspaceViolationError(
       `agent "${agentId}" has no running sandbox, so its workspace cannot be reached`,
@@ -209,6 +209,7 @@ export interface WorkspaceGitTarget {
 }
 
 export function createWorkspaceGit(
+  workspaces: WorkspaceManager,
   workspaceRootByAgent: (agentId: string, sessionId?: string) => string | undefined,
   credentialEnvByAgent: (agentId: string) => Record<string, string> = () => ({}),
   workspaceTargetByAgent: (agentId: string) => WorkspaceGitTarget | undefined = () => undefined,
@@ -304,7 +305,7 @@ export function createWorkspaceGit(
     // Resolved ONCE per request, and `runnerFor` refuses rather than falling back in sandbox mode:
     // re-resolving would let a channel that drops in between prove the sandbox checkout and then
     // mutate this daemon's own disk. Every runner below derives from this one.
-    const base = bound?.base ?? runnerFor(agentId, root)
+    const base = bound?.base ?? runnerFor(workspaces, agentId, root)
     if (!(await isRepo(base))) return { agentId, isRepo: false, clean: true }
 
     // Status is read-only and the daemon policy already disables hooks and
@@ -328,7 +329,7 @@ export function createWorkspaceGit(
         ...(n?.deletions !== undefined ? { deletions: n.deletions } : {})
       }
     })
-    const [lastCommit, lastFetchAt] = await Promise.all([headCommit(git), fetchHeadMtime(root)])
+    const [lastCommit, lastFetchAt] = await Promise.all([headCommit(git), fetchHeadMtime(workspaces, root)])
     return {
       agentId,
       isRepo: true,
@@ -361,7 +362,7 @@ export function createWorkspaceGit(
     // Resolved ONCE per request, and `runnerFor` refuses rather than falling back in sandbox mode:
     // re-resolving would let a channel that drops in between prove the sandbox checkout and then
     // mutate this daemon's own disk. Every runner below derives from this one.
-    const base = runnerFor(req.agentId, root)
+    const base = runnerFor(workspaces, req.agentId, root)
     if (!(await isRepo(base))) return { agentId: req.agentId, isRepo: false, clean: true }
     const wanted = new Set(req.paths.map((requested) => relativeWorkspacePath(root, requested)))
     if (wanted.size > 0) {
@@ -420,7 +421,7 @@ export function createWorkspaceGit(
       // Resolved ONCE per request, and `runnerFor` refuses rather than falling back in sandbox mode:
       // re-resolving would let a channel that drops in between prove the sandbox checkout and then
       // mutate this daemon's own disk. Every runner below derives from this one.
-      const base = runnerFor(req.agentId, root)
+      const base = runnerFor(workspaces, req.agentId, root)
       if (!(await isRepo(base))) return { agentId: req.agentId, path: req.path, isRepo: false, exists: false }
       // Through the runner, so a cluster-backed workspace answers by running git in its own sandbox rather than on a disk this daemon cannot see.
       const git = base.withEnv({ ...workspaceGitLocalEnv(), GIT_OPTIONAL_LOCKS: '0' })
@@ -443,7 +444,7 @@ export function createWorkspaceGit(
         // `git diff` never shows an untracked file) or it does not. Both are DATA.
         // `canonical` is null for EVERY path in a sandbox workspace, so git answers there instead —
         // the difference between "no changes" and "no such file".
-        const exists = sandboxWorkspaceMode() ? await pathExists(git, rel) : canonical !== null
+        const exists = workspaces.sandboxMode ? await pathExists(git, rel) : canonical !== null
         return { agentId: req.agentId, path: req.path, isRepo: true, exists }
       }
       // git itself reported `-` `-` for every row ⇒ nothing textual to render. A
@@ -474,7 +475,7 @@ export function createWorkspaceGit(
       // Resolved ONCE per request, and `runnerFor` refuses rather than falling back in sandbox mode:
       // re-resolving would let a channel that drops in between prove the sandbox checkout and then
       // mutate this daemon's own disk. Every runner below derives from this one.
-      const base = runnerFor(req.agentId, root)
+      const base = runnerFor(workspaces, req.agentId, root)
       if (!(await isRepo(base))) return { agentId: req.agentId, isRepo: false, commits: [], truncated: false }
       // Through the runner, so a cluster-backed workspace answers by running git in its own sandbox rather than on a disk this daemon cannot see.
       const git = base.withEnv({ ...workspaceGitLocalEnv(), GIT_OPTIONAL_LOCKS: '0' })
@@ -533,7 +534,7 @@ export function createWorkspaceGit(
       // Resolved ONCE per request, and `runnerFor` refuses rather than falling back in sandbox mode:
       // re-resolving would let a channel that drops in between prove the sandbox checkout and then
       // mutate this daemon's own disk.
-      const base = runnerFor(agentId, root, abort.signal)
+      const base = runnerFor(workspaces, agentId, root, abort.signal)
       if (!(await isRepo(base))) return { agentId, isRepo: false, ok: false, detail: 'workspace is not a git checkout' }
 
       try {
@@ -580,7 +581,7 @@ export function createWorkspaceGit(
       // Resolved ONCE per request, and `runnerFor` refuses rather than falling back in sandbox mode:
       // re-resolving would let a channel that drops in between prove the sandbox checkout and then
       // mutate this daemon's own disk. Every runner below derives from this one.
-      const base = runnerFor(agentId, root)
+      const base = runnerFor(workspaces, agentId, root)
       if (!(await isRepo(base))) return commitRefusal(agentId, false, 'not-a-repo', 'workspace is not a git checkout')
       const message = req.message.trim()
       if (!message) return commitRefusal(agentId, true, 'empty-message', 'The commit message is empty.')
@@ -642,7 +643,7 @@ export function createWorkspaceGit(
       // Resolved ONCE per request, with the signal already attached, and `runnerFor` refuses rather
       // than falling back in sandbox mode: re-resolving would let a channel that drops in between
       // prove the sandbox checkout and then mutate this daemon's own disk.
-      const base = runnerFor(agentId, root, abort.signal)
+      const base = runnerFor(workspaces, agentId, root, abort.signal)
       if (!(await isRepo(base))) return pushRefusal(agentId, false, 'not-a-repo', 'workspace is not a git checkout')
       try {
         const git = base.withEnv(workspaceGitLocalEnv())
@@ -750,7 +751,7 @@ export function createWorkspaceGit(
       // Resolved ONCE per request, and `runnerFor` refuses rather than falling back in sandbox mode:
       // re-resolving would let a channel that drops in between prove the sandbox checkout and then
       // mutate this daemon's own disk. Every runner below derives from this one.
-      const base = runnerFor(agentId, root)
+      const base = runnerFor(workspaces, agentId, root)
       if (!(await isRepo(base))) {
         return { agentId, ok: false, detail: 'This workspace is not a git checkout, so there is no staged diff.' }
       }
@@ -1020,8 +1021,8 @@ async function headCommit(git: GitRunner): Promise<WorkspaceGitCommit | null> {
  *  rewrites it on every fetch/pull). Null if it has never fetched — and null for a
  *  sandbox workspace, whose mtime no git subcommand reports and whose path names a
  *  filesystem this process cannot see. Restoring it needs a shim stat, not an argv. */
-async function fetchHeadMtime(root: string): Promise<string | null> {
-  if (sandboxWorkspaceMode()) return null
+async function fetchHeadMtime(workspaces: WorkspaceManager, root: string): Promise<string | null> {
+  if (workspaces.sandboxMode) return null
   try {
     const st = await fs.stat(join(root, '.git', 'FETCH_HEAD'))
     return st.mtime.toISOString()

--- a/packages/daemon/src/cp/workspace-reader.ts
+++ b/packages/daemon/src/cp/workspace-reader.ts
@@ -27,7 +27,7 @@ import {
   type WorkspaceFiles,
   type WorkspaceLocation
 } from '../workspace/workspace-files.js'
-import { sandboxWorkspaceMode } from '../workspace/workspace-manager.js'
+import { WorkspaceManager } from '../workspace/workspace-manager.js'
 
 // Re-exported rather than moved-and-chased: the error classes are what the CP dispatcher maps onto
 // wire frames, and the two path helpers are what the git seam contains its pathspecs with. Neither
@@ -58,6 +58,7 @@ export type WorkspaceWriteCoordinator = <T>(agentId: string, write: () => Promis
 export type WorkspaceFilesResolver = (agentId: string) => WorkspaceFiles | undefined
 
 export function createWorkspaceReader(
+  workspaces: WorkspaceManager,
   workspaceByAgent: (agentId: string, sessionId?: string) => WorkspaceLocation | undefined,
   coordinateWrite: WorkspaceWriteCoordinator,
   filesFor: WorkspaceFilesResolver = () => undefined
@@ -82,7 +83,7 @@ export function createWorkspaceReader(
   function filesOf(agentId: string): WorkspaceFiles {
     const remote = filesFor(agentId)
     if (remote) return remote
-    if (sandboxWorkspaceMode()) {
+    if (workspaces.sandboxMode) {
       throw new WorkspaceViolationError(
         `agent "${agentId}" has no running sandbox, so its workspace cannot be reached`,
         'sandbox-unavailable'

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3498,6 +3498,10 @@ export class Daemon {
     )
 
     this.sessions = new SessionManager({
+      // THIS daemon's plane. Omitting it hands the manager a local-mode one, and
+      // `additionalWorkspaceDirectories` would then `realpathSync` a `--k8s` workspace's pod-side
+      // cwd against this filesystem — failing session create/load before the runtime call.
+      workspaces: this.workspaces,
       memoryScopeFor: (agentId, msg, integrationId) =>
         this.memoryScope(
           agentId,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -212,21 +212,7 @@ import {
 } from './platforms/slack/turn-output.js'
 import { ChannelNameResolver } from './messages/channel-name-resolver.js'
 import {
-  cleanupStaleWorkspaceClones,
-  clusterWorkspaceCwd,
-  consoleWorkspaceRoot,
-  convergeGithubAppWorkspaceRename,
-  ensureWorkspaceMaterialization,
-  isWorkspaceEmpty,
-  prepareClusterWorkspace,
-  prepareWorkspace,
-  prepareSessionWorkspace,
-  prepareWorkspaceForActivation,
-  resolvePreparedWorkspaceCwd,
-  prefetchWorkspace,
-  removeSessionWorktree,
-  sessionWorktreePath,
-  sessionWorktreeRoot,
+  WorkspaceManager,
   type PrepareSessionWorkspaceRequest,
   type SessionWorktreeRemoval
 } from './workspace/workspace-manager.js'
@@ -281,11 +267,6 @@ import {
 import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from './runtimes/registry.js'
 import { installedRuntimeCatalog, installedRuntimes, resolveCommandPath } from './runtimes/probe.js'
 import { K8S_ORG_ID_ENV, startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.js'
-import {
-  setSandboxWorkspaceMode,
-  setWorkspaceGitRunnerResolver,
-  setWorkspacePathClearer
-} from './workspace/workspace-manager.js'
 import { initiatorLabel } from './workspace/session-branch.js'
 import { declaredRuntimeCatalog, loadK8sRuntimeTable, type K8sRuntimeAcpSnapshot } from './runtimes/k8s-runtimes.js'
 import { ensureNodeBinOnPath } from './runtimes/exec-path.js'
@@ -1941,6 +1922,10 @@ interface ShutdownDutyDrain {
 }
 
 export class Daemon {
+  // This daemon's workspace execution plane. Owned per instance, so two daemons in one process
+  // (the test suite, and a k8s daemon beside a local one) cannot inherit each other's git runner,
+  // path clearer or sandbox mode — which is what a module-level plane silently did.
+  readonly workspaces = new WorkspaceManager()
   private readonly evaluation: EvaluationEventEmitter
   private readonly evaluationProfile: EvaluationCapabilityProfile
   private store!: LocalStore
@@ -2998,13 +2983,13 @@ export class Daemon {
       // Workspace git then runs where the workspace actually is. Registered for ALL agents; the
       // resolver answers undefined for any without a bound channel, so an agent this daemon has
       // not launched into a sandbox keeps its local behaviour.
-      setWorkspaceGitRunnerResolver((agentId, cwd, abort) => this.k8sPlane?.gitRunnerFor(agentId, cwd, abort))
+      this.workspaces.setGitRunnerResolver((agentId, cwd, abort) => this.k8sPlane?.gitRunnerFor(agentId, cwd, abort))
       // And the one destructive operation a cluster workspace needs, for the same reason: a
       // partial clone sits on a volume no `rmSync` here can reach.
-      setWorkspacePathClearer((agentId, root) => this.k8sPlane!.clearPath(agentId, root))
+      this.workspaces.setPathClearer((agentId, root) => this.k8sPlane!.clearPath(agentId, root))
       // And the mode itself, which decides what workspace operations are available at all: an
       // in-place conversion has no pod-side implementation of its rollback contract.
-      setSandboxWorkspaceMode(true)
+      this.workspaces.setSandboxMode(true)
       this.log.info('k8s: execution plane ready — daemon-to-sandbox shim dialing enabled')
     }
     // Sandbox-optional principle (#36): skills are NOT force-sandboxed fleet-wide.
@@ -3116,7 +3101,7 @@ export class Daemon {
     for (const agent of discoveredAgents) {
       if (!this.removedAgentTombstones.has(agent.id)) {
         try {
-          const removed = cleanupStaleWorkspaceClones(agent)
+          const removed = this.workspaces.cleanupStaleWorkspaceClones(agent)
           if (removed > 0) {
             this.log.info(`workspace: removed ${removed} stale conversion clone(s) for agent "${agent.id}"`)
           }
@@ -3535,8 +3520,8 @@ export class Daemon {
       // the channel (and with it the pod's reported mount) has already bound.
       resolvePreparedWorkspace: (agent) =>
         this.k8sPlane
-          ? clusterWorkspaceCwd(agent, this.k8sPlane.workspaceRootFor(agent.id))
-          : resolvePreparedWorkspaceCwd(agent),
+          ? this.workspaces.clusterWorkspaceCwd(agent, this.k8sPlane.workspaceRootFor(agent.id))
+          : this.workspaces.resolvePreparedWorkspaceCwd(agent),
       memory: this.memory,
       onMemoryRecallError: (agentId, error) =>
         this.log.warn(
@@ -4031,7 +4016,7 @@ export class Daemon {
       if (change.workspaceRepoRename) {
         try {
           await this.enqueueAgentWorkspacePreparation(a as LoadedAgent, () =>
-            convergeGithubAppWorkspaceRename(a as LoadedAgent)
+            this.workspaces.convergeGithubAppWorkspaceRename(a as LoadedAgent)
           )
         } catch (err) {
           workspaceNeedsColdRecovery = true
@@ -5207,7 +5192,7 @@ export class Daemon {
         // The pod's own preparation: clone and pull happen on its volume through the runner, and
         // none of the local work below runs — its mkdir, `existsSync(.git)` and skills installation
         // all land on this daemon's disk, describing a filesystem the runtime never reads.
-        return await prepareClusterWorkspace(agent, plane.workspaceRootFor(agent.id), request)
+        return await this.workspaces.prepareClusterWorkspace(agent, plane.workspaceRootFor(agent.id), request)
       })
     }
     if (!this.opts.hostFactory) assertExclusiveAgentWorkspaces([agent as LoadedAgent])
@@ -5216,14 +5201,16 @@ export class Daemon {
       skillsStateDir: join(this.root, 'skill-installs'),
       skillsAgentId: this.runtimeCatalog.entries[agent.runtime]?.skillsAgentId ?? null
     }
-    return request ? prepareSessionWorkspace(agent, request, opts) : prepareWorkspace(agent, opts)
+    return request
+      ? this.workspaces.prepareSessionWorkspace(agent, request, opts)
+      : this.workspaces.prepareWorkspace(agent, opts)
   }
 
   private runAgentWorkspacePrefetch(agent: Agent): Promise<void> {
     // A cluster workspace materializes on the pod's volume at session time; a local prefetch
     // would clone the repository onto this daemon's own disk instead.
     if (this.k8sPlane) return Promise.resolve()
-    return prefetchWorkspace(agent)
+    return this.workspaces.prefetchWorkspace(agent)
   }
 
   private workspacePreparationAuthority(agent: Agent): string {
@@ -5530,7 +5517,9 @@ export class Daemon {
           ? this.sandboxRuntimeReadRoots(agent, runtime, { ...runtimeEnv, ...env }, githubAppCredentials)
           : undefined,
         trustedWorkspaceWriteRoots:
-          runInSandbox && agent.workspace.mode === 'git-repo' ? [sessionWorktreeRoot(agent)] : undefined,
+          runInSandbox && agent.workspace.mode === 'git-repo'
+            ? [this.workspaces.sessionWorktreeRoot(agent)]
+            : undefined,
         explicitEnv: { ...runtimeEnv, ...env },
         sandboxMechanism: this.sandboxMechanism,
         mcpSocketPath: mcpSocketPath(this.root),
@@ -19756,7 +19745,7 @@ export class Daemon {
 
   /** The one safe per-session worktree deletion path shared by age retention
    * and GitHub thread lifecycle cleanup. It deliberately preserves the current
-   * dirty/untracked and unique-commit protections in removeSessionWorktree(). */
+   * dirty/untracked and unique-commit protections in this.workspaces.removeSessionWorktree(). */
   private async cleanupSessionWorktree(rec: SessionRecord): Promise<SessionWorktreeCleanupResult> {
     if (this.sessionRetentionActive(rec)) return { outcome: 'active' }
     const agent = this.agents.get(rec.agentId)
@@ -19771,7 +19760,7 @@ export class Daemon {
       if (!currentAgent || currentAgent.workspace.mode !== 'git-repo' || rec.workspaceIsolation === 'shared') {
         return { outcome: 'not_applicable' }
       }
-      const result = await removeSessionWorktree(currentAgent, rec.key)
+      const result = await this.workspaces.removeSessionWorktree(currentAgent, rec.key)
       if ((result.outcome === 'removed' || result.outcome === 'absent') && rec.acpSessionId) {
         // The session row intentionally survives lifecycle cleanup. Evict only
         // this stale warm binding so the next reopened/comment turn recreates
@@ -21472,7 +21461,7 @@ export class Daemon {
           // permission/subdirectory edit from a destructive mode/repo/branch
           // replacement, including after an ACK-loss retry.
           const currentWorkspace = this.agents.get(agentId)
-          if (currentWorkspace) ensureWorkspaceMaterialization(currentWorkspace)
+          if (currentWorkspace) this.workspaces.ensureWorkspaceMaterialization(currentWorkspace)
 
           // This is also the destination staging gate. An absent agent is expected:
           // ACK after arming the gate so the atomic activate bundle cannot serve early.
@@ -21505,7 +21494,7 @@ export class Daemon {
               ? `agent ${agentId} is not active on this daemon`
               : current.workspace.mode !== 'from-scratch'
                 ? 'workspace is no longer scratch'
-                : !isWorkspaceEmpty(current)
+                : !this.workspaces.isWorkspaceEmpty(current)
                   ? 'scratch workspace is not empty; remove or move its files before converting'
                   : undefined
             if (reason) {
@@ -21642,7 +21631,7 @@ export class Daemon {
                 rollbackPreparedWorkspace = await this.enqueueAgentWorkspacePreparation(
                   agent,
                   () =>
-                    prepareWorkspaceForActivation(agent, {
+                    this.workspaces.prepareWorkspaceForActivation(agent, {
                       allowExistingCheckout: stage.requireEmptyWorkspace !== true,
                       reconcileMaterialization: activate.reconcileWorkspace === true
                     }),
@@ -22281,7 +22270,7 @@ export class Daemon {
       }
       const session = this.store.getSessionByAcpIdForAgent(id, sessionId)
       if (agent.workspace.mode !== 'git-repo' || session?.workspaceIsolation !== 'session') return undefined
-      return { root: sessionWorktreePath(agent, session.key), scratch: false }
+      return { root: this.workspaces.sessionWorktreePath(agent, session.key), scratch: false }
     }
 
     // Where that workspace actually is, which under --k8s is the sandbox pod's volume. ONE resolver
@@ -22293,7 +22282,7 @@ export class Daemon {
       const agent = this.agents.get(id)
       const local = daemonWorkspaceLocation(id, sessionId)
       if (!agent || !local) return undefined
-      const root = consoleWorkspaceRoot(
+      const root = this.workspaces.consoleWorkspaceRoot(
         agent,
         local.root,
         this.k8sPlane?.workspaceRootFor(id),
@@ -22306,6 +22295,7 @@ export class Daemon {
       workspaceLocation(id, sessionId)?.root
 
     const workspaceGit = createWorkspaceGit(
+      this.workspaces,
       workspaceGitRoot,
       (id) => {
         const workspace = this.agents.get(id)?.workspace
@@ -22440,6 +22430,7 @@ export class Daemon {
       // The third argument is what makes a cluster agent's files reachable at all: the operations
       // run inside its pod, on the volume the root above names.
       workspaceRead: createWorkspaceReader(
+        this.workspaces,
         workspaceLocation,
         (id, write) => this.withWorkspaceFileWrite(id, write),
         (id) => this.k8sPlane?.workspaceFilesFor(id)
@@ -22482,6 +22473,7 @@ export class Daemon {
       memoryReader: createMemoryReader((id) => this.agents.get(id)?.dir, this.memory),
       dreamReader: createDreamReader(this.dreamRunner()),
       localSkillsReader: createLocalSkillsReader(
+        this.workspaces,
         // The workspace root in EXECUTION coordinates, like the file reader's: the skill roots the
         // console lists are the ones the agent's harness loads, and those are in the pod.
         (id) => workspaceLocation(id)?.root,
@@ -23237,9 +23229,9 @@ export class Daemon {
     await this.k8sPlane?.stop().catch(() => undefined)
     await this.readiness?.stop().catch(() => undefined)
     this.readiness = undefined
-    setWorkspaceGitRunnerResolver(undefined)
-    setWorkspacePathClearer(undefined)
-    setSandboxWorkspaceMode(false)
+    this.workspaces.setGitRunnerResolver(undefined)
+    this.workspaces.setPathClearer(undefined)
+    this.workspaces.setSandboxMode(false)
     await Promise.allSettled(hostStarts)
     // Shutdown backstop: dream extractions reclaim their own tombstone when the
     // dedicated host stops, and stopHost sweeps per-agent for warm hosts, but drop

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -3,7 +3,7 @@ import { LocalStore, sessionKey, transcriptChannelKey, type TranscriptEntry } fr
 import { isSyntheticA2aChannel } from '../cp/cp-collab-routes.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
 import { SLACK_RESPONSE_FINAL_EVENT_TAG } from '@agentconnect.md/message'
-import { additionalWorkspaceDirectories, prepareWorkspace } from '../workspace/workspace-manager.js'
+import { WorkspaceManager } from '../workspace/workspace-manager.js'
 import { initiatorLabel } from '../workspace/session-branch.js'
 import { memoryKindOf, type MemoryProvider, type MemoryScope } from '../agents/memory-provider.js'
 import { MAX_INDEX_INJECT_BYTES } from '../agents/memory.js'
@@ -235,6 +235,13 @@ function abortable<T>(start: () => PromiseLike<T> | T, signal?: AbortSignal): Pr
 }
 
 export class SessionManager {
+  /** The owning daemon's plane when it supplied one; otherwise a private plane, so two harnesses
+   *  in one process still cannot see each other's registrations. */
+  private get workspaces(): WorkspaceManager {
+    return (this.ownWorkspaces ??= this.deps.workspaces ?? new WorkspaceManager())
+  }
+  private ownWorkspaces?: WorkspaceManager
+
   constructor(
     private deps: {
       store: LocalStore
@@ -243,6 +250,9 @@ export class SessionManager {
        * own preparation itself when resolvePreparedWorkspace is also supplied. */
       isHostRunning?: (agentId: string) => boolean
       agentById: (id: string) => LoadedAgent | undefined
+      /** The owning daemon's workspace plane. Absent only in lightweight harnesses, which get
+       *  their own so nothing is shared between them. */
+      workspaces?: WorkspaceManager
       /** Daemon seam for the unified Git/managed/accepted-local skill
        * reconciliation. Tests and the standalone chat CLI use the ordinary
        * workspace preparer. Production also passes the ordinary warm host so
@@ -609,7 +619,9 @@ export class SessionManager {
     let preparedCwd =
       hostCold && !this.deps.resolvePreparedWorkspace
         ? await abortable(
-            () => this.deps.prepareWorkspace?.(agent, undefined, workspaceRequest) ?? prepareWorkspace(agent),
+            () =>
+              this.deps.prepareWorkspace?.(agent, undefined, workspaceRequest) ??
+              this.workspaces.prepareWorkspace(agent),
             signal
           )
         : undefined
@@ -632,7 +644,7 @@ export class SessionManager {
       return { value, chatSelected: value !== undefined }
     }
     const runtimeWorkspaceDirectories = (cwd: string): string[] =>
-      additionalWorkspaceDirectories(agent, cwd, {
+      this.workspaces.additionalWorkspaceDirectories(agent, cwd, {
         sessionKey: key,
         isolation: workspaceIsolation
       })
@@ -910,7 +922,9 @@ export class SessionManager {
         options.preparedWorkspaceCwd ??
         (workspaceIsolation === 'shared' ? preparedCwd : undefined) ??
         (await abortable(
-          () => this.deps.prepareWorkspace?.(agent, expectedWarmHost, workspaceRequest) ?? prepareWorkspace(agent),
+          () =>
+            this.deps.prepareWorkspace?.(agent, expectedWarmHost, workspaceRequest) ??
+            this.workspaces.prepareWorkspace(agent),
           signal
         ))
       const ordinaryMcpServers =
@@ -971,7 +985,9 @@ export class SessionManager {
         options.preparedWorkspaceCwd ??
         (workspaceIsolation === 'shared' ? preparedCwd : undefined) ??
         (await abortable(
-          () => this.deps.prepareWorkspace?.(agent, expectedWarmHost, workspaceRequest) ?? prepareWorkspace(agent),
+          () =>
+            this.deps.prepareWorkspace?.(agent, expectedWarmHost, workspaceRequest) ??
+            this.workspaces.prepareWorkspace(agent),
           signal
         ))
       // Resolved once, shared by both paths: session/load must re-attach the same

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -79,6 +79,8 @@ export class ShimClient {
   private transport?: ShimTransport
   private bound?: ShimBound
   private stopped = false
+  /** Settles an in-flight `connectOnce` handshake, so `stop()` leaves no timer behind. */
+  private abortHandshake?: () => void
   /** The channel in service. Every transport callback compares against this before
    *  mutating shared state: a delayed close from a transport being replaced must not tear
    *  down the healthy replacement that already bound. */
@@ -152,6 +154,7 @@ export class ShimClient {
 
   stop(): void {
     this.stopped = true
+    this.abortHandshake?.()
     if (this.transport) this.abortTransportWork(this.transport, 'shim stopping')
     this.bound = undefined
     this.channel?.end?.('lost')
@@ -214,8 +217,15 @@ export class ShimClient {
         if (settled) return
         settled = true
         clearHandshakeTimer()
+        this.abortHandshake = undefined
         reject(new Error(message))
       }
+      // `stop()` cancels this timer. It must NOT settle the promise: the transport close `stop()`
+      // performs already does that through onClose, and rejecting here too lands on a promise the
+      // supervision loop may have stopped awaiting. Left armed, the timer outlives the stopped
+      // client and rejects into nobody — which under a shared test registry surfaces as an
+      // unhandled rejection long after the test that built the client finished.
+      this.abortHandshake = clearHandshakeTimer
       handshakeTimer = this.clock.setTimeout(() => {
         transport.close(4408, 'binding timeout')
         fail('binding timed out')

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -78,34 +78,6 @@ export interface PrepareSessionWorkspaceRequest {
   githubReviewRevisionOnly?: true
 }
 
-async function withSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOptions): Promise<string> {
-  // Resolving local sources (managed cache + accepted Dream) is best-effort: a
-  // failure to read/validate them means we install none of THOSE sources, not
-  // that the workspace fails to come up (git + messaging still have to work).
-  let managedSkills: LocalSkillSource[] = []
-  let acceptedSkills: LocalSkillSource[] = []
-  const agentRoot = (agent as { dir?: string }).dir
-  try {
-    managedSkills = (await opts.managedSkills?.(agent)) ?? []
-    acceptedSkills = agentRoot ? await acceptedDreamSkillSources({ dir: agentRoot }) : []
-  } catch (err) {
-    skillsLog.warn(`skills: local source resolution failed for "${agent.id}": ${(err as Error).message}`)
-  }
-  // installSkills fails closed: it degrades acquisition/CLI failures into
-  // result.errors but THROWS a safety error when stale executable content cannot
-  // be removed or the ledger cannot be proven coherent. Those must block host
-  // startup rather than launch ACP with stale/incoherent executable skills, so
-  // let them propagate (design: docs/designs/shared-skills.md §2).
-  await installSkills(agent, acpCwd, {
-    ...(opts.skillsStateDir ? { stateDir: opts.skillsStateDir } : {}),
-    ...(opts.skillsAgentId === undefined ? {} : { skillsAgentId: opts.skillsAgentId }),
-    localSkills: [...managedSkills, ...acceptedSkills],
-    useGitCredential: usesGithubApp(agent),
-    warn: (msg) => skillsLog.warn(msg)
-  })
-  return acpCwd
-}
-
 const PULL_TIMEOUT_MS = 4500
 const REVIEW_FETCH_TIMEOUT_MS = 15_000
 const MATERIALIZATION_FILE = 'workspace-materialization.json'
@@ -161,29 +133,1120 @@ export class WorkspaceManager {
   cloneKey(agentId: string, cwd: string): string {
     return this.gitRunnerResolver?.(agentId, cwd) ? `${agentId}\u0000${cwd}` : cwd
   }
-}
 
-// The plane the module-level entry points below still resolve through. Step 2 threads an explicit
-// instance down from the owning `Daemon`, and this — with the `set*` shims — goes away.
-const defaultWorkspaces = new WorkspaceManager()
-
-const cloneInFlight = defaultWorkspaces.cloneInFlight
-
-function cloneKey(agentId: string, cwd: string): string {
-  return defaultWorkspaces.cloneKey(agentId, cwd)
-}
-
-function usesGithubApp(agent: Agent): boolean {
-  return agent.workspace.mode === 'git-repo' && agent.workspace.gitCredential === 'github-app'
-}
-
-function gitRepoOf(agent: Agent): string {
-  if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) {
-    throw new Error(`workspace clone: agent "${agent.id}" has git-repo mode but no gitRepo configured`)
+  async withSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOptions): Promise<string> {
+    // Resolving local sources (managed cache + accepted Dream) is best-effort: a
+    // failure to read/validate them means we install none of THOSE sources, not
+    // that the workspace fails to come up (git + messaging still have to work).
+    let managedSkills: LocalSkillSource[] = []
+    let acceptedSkills: LocalSkillSource[] = []
+    const agentRoot = (agent as { dir?: string }).dir
+    try {
+      managedSkills = (await opts.managedSkills?.(agent)) ?? []
+      acceptedSkills = agentRoot ? await acceptedDreamSkillSources({ dir: agentRoot }) : []
+    } catch (err) {
+      skillsLog.warn(`skills: local source resolution failed for "${agent.id}": ${(err as Error).message}`)
+    }
+    // installSkills fails closed: it degrades acquisition/CLI failures into
+    // result.errors but THROWS a safety error when stale executable content cannot
+    // be removed or the ledger cannot be proven coherent. Those must block host
+    // startup rather than launch ACP with stale/incoherent executable skills, so
+    // let them propagate (design: docs/designs/shared-skills.md §2).
+    await installSkills(agent, acpCwd, {
+      ...(opts.skillsStateDir ? { stateDir: opts.skillsStateDir } : {}),
+      ...(opts.skillsAgentId === undefined ? {} : { skillsAgentId: opts.skillsAgentId }),
+      localSkills: [...managedSkills, ...acceptedSkills],
+      useGitCredential: this.usesGithubApp(agent),
+      warn: (msg) => skillsLog.warn(msg)
+    })
+    return acpCwd
   }
-  return authorizeWorkspaceGitUrl(
-    usesGithubApp(agent) ? normalizeGithubRepoUrl(agent.workspace.gitRepo) : agent.workspace.gitRepo
-  )
+
+  usesGithubApp(agent: Agent): boolean {
+    return agent.workspace.mode === 'git-repo' && agent.workspace.gitCredential === 'github-app'
+  }
+
+  gitRepoOf(agent: Agent): string {
+    if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) {
+      throw new Error(`workspace clone: agent "${agent.id}" has git-repo mode but no gitRepo configured`)
+    }
+    return authorizeWorkspaceGitUrl(
+      this.usesGithubApp(agent) ? normalizeGithubRepoUrl(agent.workspace.gitRepo) : agent.workspace.gitRepo
+    )
+  }
+
+  isTrustedGithubOrigin(input: string): boolean {
+    const raw = input.trim()
+    if (raw.includes('\\')) return false
+    const scp = /^[\w.-]+@([\w.-]+):/.exec(raw)
+    if (scp) return scp[1]!.toLowerCase() === 'github.com'
+    if (!/^(?:https|ssh):\/\//i.test(raw)) return false
+    try {
+      return new URL(normalizeGitCloneUrl(redactGitUrlSecrets(raw))).hostname.toLowerCase() === 'github.com'
+    } catch {
+      return false
+    }
+  }
+
+  runnerFor(agentId: string, cwd?: string, abort?: AbortSignal): GitRunner {
+    return (
+      this.resolveGitRunner(agentId, cwd, abort) ??
+      new LocalGitRunner(gitFor(cwd, abort), cwd, (env) => gitFor(cwd, abort).env(env))
+    )
+  }
+
+  async clearSandboxPath(agentId: string, root: string): Promise<void> {
+    const error = await this.clearPath(agentId, root)
+    if (error) {
+      workspaceLog.warn(`workspace: could not empty ${root} for agent "${agentId}" after a failed clone (${error})`)
+    }
+  }
+
+  async requireEmptiedSandboxPath(agentId: string, root: string): Promise<void> {
+    const error = await this.clearPath(agentId, root)
+    if (error) throw new Error(`workspace: could not replace ${root} for agent "${agentId}" (${error})`)
+  }
+
+  consoleWorkspaceGitRunner(agentId: string, cwd?: string, abort?: AbortSignal): GitRunner | undefined {
+    const remote = this.resolveGitRunner(agentId, cwd, abort)
+    if (remote) return remote
+    if (this.sandboxMode) return undefined
+    return new LocalGitRunner(gitFor(cwd, abort), cwd, (env) => gitFor(cwd, abort).env(env))
+  }
+
+  async convergeWorkspaceOrigin(agent: Agent, cwd = agent.workspace.path): Promise<void> {
+    const clone = this.cloneInFlight.get(this.cloneKey(agent.id, cwd))
+    if (clone) await clone
+    if (!existsSync(join(cwd, '.git'))) return
+    await this.convergeOriginInPlace(agent, cwd)
+  }
+
+  markerAttestsRepository(previous: string | undefined, target: string): boolean {
+    if (previous === undefined) return false
+    const repoOf = (raw: string): string | undefined => {
+      try {
+        const parsed = JSON.parse(raw) as { repo?: unknown }
+        return typeof parsed.repo === 'string' ? parsed.repo.replace(/\.git$/i, '').toLowerCase() : undefined
+      } catch {
+        return undefined
+      }
+    }
+    const left = repoOf(previous)
+    const right = repoOf(target)
+    return left !== undefined && right !== undefined && left === right
+  }
+
+  async clusterCheckoutBranch(agentId: string, checkout: string): Promise<string> {
+    try {
+      const head = await this.runnerFor(agentId, checkout)
+        .withEnv(workspaceGitLocalEnv())
+        .raw(['rev-parse', '--abbrev-ref', 'HEAD'])
+      return head.trim()
+    } catch {
+      return ''
+    }
+  }
+
+  async convergeOriginInPlace(agent: Agent, cwd: string): Promise<void> {
+    const expected = this.gitRepoOf(agent)
+    const git = this.runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
+    let current: string
+    try {
+      current = (await git.raw(['remote', 'get-url', 'origin'])).trim()
+    } catch (cause) {
+      if (this.usesGithubApp(agent)) throw new UntrustedGithubWorkspaceOriginError({ cause })
+      return
+    }
+    if (this.usesGithubApp(agent) && !this.isTrustedGithubOrigin(current)) {
+      throw new UntrustedGithubWorkspaceOriginError()
+    }
+    const normalizedCurrent = normalizeGitUrl(current)
+    let unsafeCurrent = redactGitUrlSecrets(current) !== normalizedCurrent
+    try {
+      authorizeWorkspaceGitUrl(current)
+      if (!/^(?:https|ssh):\/\//i.test(current) && !/^[\w.-]+@[\w.-]+:/.test(current)) unsafeCurrent = true
+    } catch {
+      unsafeCurrent = true
+    }
+    const mismatched = normalizedCurrent.toLowerCase() !== expected.toLowerCase()
+    if ((!mismatched && !unsafeCurrent) || (!unsafeCurrent && !this.usesGithubApp(agent))) return
+    // App-backed mismatches and unsafe anonymous origins must converge before
+    // daemon-managed Git can proceed. A failed rewrite is fail-closed.
+    await git.raw(['remote', 'set-url', 'origin', expected])
+  }
+
+  materializationKey(agent: Agent): string {
+    if (agent.workspace.mode === 'from-scratch') return JSON.stringify({ mode: 'scratch' })
+    const repo = this.gitRepoOf(agent)
+    return JSON.stringify({
+      mode: 'github',
+      // GitHub treats the conventional `.git` suffix as the same repository.
+      // Ignoring it here prevents a harmless CP canonicalization from replacing
+      // an existing checkout during an access/agentDir-only edit.
+      repo: (this.usesGithubApp(agent) ? repo.replace(/\.git$/i, '') : repo).toLowerCase(),
+      branch: agent.workspace.gitBranch
+    })
+  }
+
+  materializationFile(agent: Agent): string {
+    const cwd = agent.workspace.path
+    return join(dirname(cwd), `.${basename(cwd)}.${MATERIALIZATION_FILE}`)
+  }
+
+  readMaterialization(agent: Agent): string | undefined {
+    try {
+      const value = JSON.parse(readFileSync(this.materializationFile(agent), 'utf8')) as { key?: unknown }
+      return typeof value.key === 'string' ? value.key : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  conversionFile(agent: Agent): string {
+    const cwd = agent.workspace.path
+    return join(dirname(cwd), `.${basename(cwd)}.${CONVERSION_FILE}`)
+  }
+
+  readPendingConversion(agent: Agent): string | undefined {
+    try {
+      const value = JSON.parse(readFileSync(this.conversionFile(agent), 'utf8')) as { key?: unknown }
+      return typeof value.key === 'string' ? value.key : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  writePendingConversion(agent: Agent, key: string | undefined): void {
+    const file = this.conversionFile(agent)
+    if (key === undefined) {
+      rmSync(file, { force: true })
+      return
+    }
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, JSON.stringify({ version: 1, key }, null, 2) + '\n')
+  }
+
+  clusterConversionDue(agent: Agent, stored: string | undefined, target: string): boolean {
+    if (this.sameMaterialization(agent, stored, target)) return false
+    return this.readPendingConversion(agent) !== undefined
+  }
+
+  sameMaterialization(agent: Agent, previous: string | undefined, target: string): boolean {
+    if (previous === target) return true
+    if (!this.usesGithubApp(agent) || previous === undefined) return false
+    try {
+      const left = JSON.parse(previous) as { mode?: unknown; repo?: unknown; branch?: unknown }
+      const right = JSON.parse(target) as { mode?: unknown; repo?: unknown; branch?: unknown }
+      if (
+        left.mode !== 'github' ||
+        right.mode !== 'github' ||
+        typeof left.repo !== 'string' ||
+        typeof right.repo !== 'string'
+      ) {
+        return false
+      }
+      return (
+        left.repo.replace(/\.git$/i, '').toLowerCase() === right.repo.replace(/\.git$/i, '').toLowerCase() &&
+        left.branch === right.branch
+      )
+    } catch {
+      return false
+    }
+  }
+
+  recordWorkspaceMaterialization(agent: Agent): void {
+    const file = this.materializationFile(agent)
+    const temp = `${file}.tmp`
+    mkdirSync(dirname(file), { recursive: true })
+    try {
+      writeFileSync(temp, JSON.stringify({ version: 1, key: this.materializationKey(agent) }, null, 2) + '\n')
+      renameSync(temp, file)
+    } catch (err) {
+      rmSync(temp, { force: true })
+      throw err
+    }
+  }
+
+  async convergeGithubAppWorkspaceRename(agent: Agent): Promise<void> {
+    if (!this.usesGithubApp(agent)) return
+    this.recordWorkspaceMaterialization(agent)
+    await this.convergeWorkspaceOrigin(agent)
+  }
+
+  ensureWorkspaceMaterialization(agent: Agent): void {
+    if (!existsSync(this.materializationFile(agent))) this.recordWorkspaceMaterialization(agent)
+  }
+
+  forgetWorkspaceMaterialization(agent: Agent): void {
+    rmSync(this.materializationFile(agent), { force: true })
+  }
+
+  restoreWorkspaceMaterialization(agent: Agent, key: string | undefined): void {
+    if (key === undefined) {
+      rmSync(this.materializationFile(agent), { force: true })
+      return
+    }
+    const file = this.materializationFile(agent)
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, JSON.stringify({ version: 1, key }, null, 2) + '\n')
+  }
+
+  async prepareWorkspace(agent: Agent, opts: PrepareWorkspaceOptions = {}): Promise<string> {
+    const cwd = agent.workspace.path
+    // Fail unsafe config before using either a fresh or existing checkout.
+    const agentDir = agent.workspace.mode === 'git-repo' ? normalizeRepoSubdir(agent.workspace.agentDir) : undefined
+    if (agent.workspace.mode === 'git-repo') this.gitRepoOf(agent)
+    mkdirSync(cwd, { recursive: true })
+
+    if (agent.workspace.mode === 'from-scratch') {
+      // The agent's memory file lives at the agent ROOT (outside the workspace) and
+      // is seeded separately (see agents/memory.ts `ensureMemory`), so from-scratch
+      // just needs the (empty) workspace dir to exist.
+      return this.withSkills(agent, cwd, opts)
+    }
+
+    // git-repo, first session: no checkout yet → clone. Unlike pull, a clone has no
+    // on-disk fallback, so on failure we THROW (the session creation fails + the error
+    // surfaces) rather than silently proceeding with an empty dir (design §4.3).
+    if (!existsSync(join(cwd, '.git'))) {
+      await this.cloneRepo(agent)
+      return this.withSkills(agent, this.resolveAcpCwd(cwd, agentDir), opts)
+    }
+
+    // git-repo, existing checkout: the repo-local helper pin may carry a previous
+    // agent generation's id (agent deleted + recreated under the same name adopts
+    // the surviving checkout) — re-pin so agent-run git presents a live identity
+    // even where the env channel doesn't reach. Best-effort: a locked .git/config
+    // must not block the session; the session-env channel still covers this run.
+    if (this.usesGithubApp(agent)) {
+      // The CP follows repository renames by numeric repo id. Repoint the existing
+      // checkout instead of treating that canonical URL refresh as a new workspace.
+      await this.convergeWorkspaceOrigin(agent, cwd)
+      await writeRepoHelperConfig(this.runnerFor(agent.id, cwd), agent.id).catch(() => undefined)
+    } else {
+      // Historical anonymous checkouts may still have credential-bearing or
+      // disallowed origins even after their CP row has been sanitized.
+      await this.convergeWorkspaceOrigin(agent, cwd)
+    }
+
+    // Best-effort ff-only pull; never block/throw on offline (design §4.3) —
+    // proceed with the on-disk checkout.
+    if (agent.workspace.pullOnNewSession) {
+      // github-app: warm the credential cache OUTSIDE the pull budget — a cold
+      // cache means a CP round trip that would otherwise eat the whole 4.5s.
+      if (this.usesGithubApp(agent)) await preWarmGitCred(agent.id, 'pull').catch(() => undefined)
+      // Abort-driven budget: the signal makes simple-git KILL the git child at
+      // the deadline. A bare Promise.race would abandon it still running — a
+      // wedged pull (network black hole) then holds .git/index.lock into the
+      // next session's pull.
+      const abort = new AbortController()
+      const timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
+      try {
+        const repository = this.gitRepoOf(agent)
+        await assertSafeWorkspaceGitConfig(this.runnerFor(agent.id, cwd))
+        const pullTarget = workspaceGitPullTarget(repository)
+        const git = this.runnerFor(agent.id, cwd, abort.signal).withEnv({
+          ...workspaceGitLocalEnv(),
+          ...pullTarget.env,
+          ...(this.usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
+          GIT_TERMINAL_PROMPT: '0'
+        })
+        await pullWorkspaceRef(git, pullTarget.remote, agent.workspace.gitBranch)
+      } catch {
+        // offline / timed out / non-fast-forward: proceed with the on-disk checkout
+      } finally {
+        clearTimeout(timer)
+      }
+    }
+    return this.withSkills(agent, this.resolveAcpCwd(cwd, agentDir), opts)
+  }
+
+  sessionWorktreeRoot(agent: Agent): string {
+    const agentRoot = (agent as { dir?: string }).dir ?? dirname(agent.workspace.path)
+    return join(agentRoot, 'worktrees')
+  }
+
+  validateSessionWorktreeRoot(agent: Agent, root: string): string {
+    if (lstatSync(root).isSymbolicLink()) {
+      throw new Error('session worktree root must not be a symlink')
+    }
+    const agentRoot = realpathSync((agent as { dir?: string }).dir ?? dirname(agent.workspace.path))
+    const canonicalRoot = realpathSync(root)
+    const rel = relative(agentRoot, canonicalRoot)
+    if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+      throw new Error('session worktree root resolves outside the agent directory')
+    }
+    return canonicalRoot
+  }
+
+  prepareSessionWorktreeRoot(agent: Agent): string {
+    const root = this.sessionWorktreeRoot(agent)
+    if (existsSync(root) && lstatSync(root).isSymbolicLink()) {
+      throw new Error('session worktree root must not be a symlink')
+    }
+    mkdirSync(root, { recursive: true, mode: 0o700 })
+    return this.validateSessionWorktreeRoot(agent, root)
+  }
+
+  clearSessionWorktrees(agent: Agent): void {
+    rmSync(this.sessionWorktreeRoot(agent), { recursive: true, force: true })
+  }
+
+  sessionWorktreeId(sessionKey: string): string {
+    return createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)
+  }
+
+  sessionWorktreePath(agent: Agent, sessionKey: string): string {
+    return join(this.sessionWorktreeRoot(agent), this.sessionWorktreeId(sessionKey))
+  }
+
+  async removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
+    const id = this.sessionWorktreeId(sessionKey)
+    const primaryGit = () => this.runnerFor(agent.id, agent.workspace.path).withEnv(workspaceGitLocalEnv())
+    // Drop the stale Git registration and this worktree's daemon-owned review refs.
+    // Ref deletion is best-effort: most worktrees never had review refs.
+    const cleanupRegistrations = async () => {
+      await primaryGit().raw(['worktree', 'prune'])
+      for (const name of ['base', 'head', 'merge']) {
+        await primaryGit()
+          .raw(['update-ref', '-d', `refs/agentconnect/reviews/${id}/${name}`])
+          .catch(() => undefined)
+      }
+    }
+    try {
+      if (agent.workspace.mode !== 'git-repo') throw new Error('agent workspace is not a Git repository')
+      const rootPath = this.sessionWorktreeRoot(agent)
+      if (!existsSync(rootPath)) {
+        // No root ⇒ no worktree directory can exist; Git may still hold a stale
+        // registration/review refs for it.
+        await cleanupRegistrations()
+        return { outcome: 'absent' }
+      }
+      // Re-derive cwd from the CANONICAL root: a symlinked root (or symlinked
+      // ancestor) must never redirect the destructive branches below outside the
+      // agent directory.
+      const cwd = join(this.validateSessionWorktreeRoot(agent, rootPath), id)
+      if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) throw new Error('session worktree path is a symlink')
+      if (!existsSync(cwd)) {
+        await cleanupRegistrations()
+        return { outcome: 'absent' }
+      }
+      if (!existsSync(join(cwd, '.git'))) {
+        // The `.git` marker is gone, so Git no longer considers this a worktree —
+        // but a NONEMPTY directory may hold exactly the untracked work this GC
+        // promises never to auto-delete (`status` can't run without the marker).
+        // Reclaim only a provably empty leftover; report anything else.
+        if (readdirSync(cwd).length > 0) return { outcome: 'retained', reason: 'dirty' }
+        rmSync(cwd, { recursive: true, force: true })
+        await cleanupRegistrations()
+        return { outcome: 'removed' }
+      }
+      const worktreeGit = this.runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
+      if ((await worktreeGit.raw(['status', '--porcelain'])).trim() !== '') {
+        return { outcome: 'retained', reason: 'dirty' }
+      }
+      // The generated branch this worktree checks out, read BEFORE the removal that
+      // unregisters it. Empty for a worktree created before session branches existed.
+      const branch = (await worktreeGit.raw(['symbolic-ref', '--quiet', '--short', 'HEAD']).catch(() => '')).trim()
+      // A session branch tracks nothing, so there is no upstream to compare against:
+      // a commit is "unique" when no remote ref (and no fetched review ref of this
+      // worktree) can reach it.
+      const unique = (
+        await worktreeGit.raw([
+          'rev-list',
+          '--count',
+          'HEAD',
+          '--not',
+          '--remotes',
+          `--glob=refs/agentconnect/reviews/${id}`
+        ])
+      ).trim()
+      if (unique !== '0') return { outcome: 'retained', reason: 'unique-commits' }
+      // No --force: if the tree went dirty between the check and here, Git refuses
+      // and the failure keeps the session.
+      await primaryGit().raw(['worktree', 'remove', cwd])
+      await cleanupRegistrations()
+      // Only a branch this daemon generated for a session worktree, and only after
+      // the check above proved every commit on it is reachable from a remote — so
+      // the forced delete can drop no work. Best-effort: a surviving ref is clutter,
+      // not a reason to report a removed worktree as retained.
+      if (isSessionBranch(branch)) {
+        await primaryGit()
+          .raw(['branch', '-D', branch])
+          .catch(() => undefined)
+      }
+      return { outcome: 'removed' }
+    } catch (err) {
+      return { outcome: 'failed', error: (err as Error).message }
+    }
+  }
+
+  exactObjectId(value: string, label: string): string {
+    if (!GIT_OBJECT_ID.test(value)) throw new Error(`github review ${label} is not a Git object id`)
+    return value.toLowerCase()
+  }
+
+  async revParse(agentId: string, cwd: string, ref: string): Promise<string> {
+    return (
+      await this.runnerFor(agentId, cwd)
+        .withEnv(workspaceGitLocalEnv())
+        .raw(['rev-parse', '--verify', `${ref}^{commit}`])
+    ).trim()
+  }
+
+  async fetchReviewRevision(
+    agent: Agent,
+    worktreeId: string,
+    review: GithubReviewWorkspaceRevision
+  ): Promise<{ base: string; head: string; checkout: string }> {
+    const base = this.exactObjectId(review.baseSha, 'base SHA')
+    const head = this.exactObjectId(review.headSha, 'head SHA')
+    if (!Number.isSafeInteger(review.pullNumber) || review.pullNumber <= 0) {
+      throw new Error('github review pull number is invalid')
+    }
+    const root = `refs/agentconnect/reviews/${worktreeId}`
+    const baseRef = `${root}/base`
+    const headRef = `${root}/head`
+    const mergeRef = `${root}/merge`
+    const repository = this.gitRepoOf(agent)
+    await assertSafeWorkspaceGitConfig(this.runnerFor(agent.id, agent.workspace.path))
+    if (this.usesGithubApp(agent)) await preWarmGitCred(agent.id, 'pull')
+    const pullTarget = workspaceGitPullTarget(repository)
+    const abort = new AbortController()
+    const timer = setTimeout(() => abort.abort(), REVIEW_FETCH_TIMEOUT_MS)
+    try {
+      const git = this.runnerFor(agent.id, agent.workspace.path, abort.signal).withEnv({
+        ...pullTarget.env,
+        ...(this.usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
+        GIT_TERMINAL_PROMPT: '0'
+      })
+      await git.raw([
+        'fetch',
+        '--force',
+        '--no-tags',
+        '--no-recurse-submodules',
+        pullTarget.remote,
+        `+${base}:${baseRef}`,
+        `+refs/pull/${review.pullNumber}/head:${headRef}`
+      ])
+      if ((await this.revParse(agent.id, agent.workspace.path, baseRef)).toLowerCase() !== base) {
+        throw new Error('github review base ref did not resolve to the requested SHA')
+      }
+      if ((await this.revParse(agent.id, agent.workspace.path, headRef)).toLowerCase() !== head) {
+        throw new Error('github review head ref did not resolve to the requested SHA')
+      }
+
+      // A conflicted PR has no merge ref. Head remains an exact, reviewable
+      // checkout; when GitHub does provide a merge ref, trust it only after proving
+      // both parents are the exact base/head pair carried by the hook.
+      await git.raw(['update-ref', '-d', mergeRef]).catch(() => undefined)
+      try {
+        await git.raw([
+          'fetch',
+          '--force',
+          '--no-tags',
+          '--no-recurse-submodules',
+          pullTarget.remote,
+          `+refs/pull/${review.pullNumber}/merge:${mergeRef}`
+        ])
+        const merge = (await this.revParse(agent.id, agent.workspace.path, mergeRef)).toLowerCase()
+        const expectedMerge = review.mergeCommitSha ? this.exactObjectId(review.mergeCommitSha, 'merge SHA') : undefined
+        const parents = (
+          await this.runnerFor(agent.id, agent.workspace.path)
+            .withEnv(workspaceGitLocalEnv())
+            .raw(['rev-list', '--parents', '-n', '1', mergeRef])
+        )
+          .trim()
+          .toLowerCase()
+          .split(/\s+/)
+        if (
+          (!expectedMerge || merge === expectedMerge) &&
+          parents.length === 3 &&
+          parents[1] === base &&
+          parents[2] === head
+        ) {
+          return { base, head, checkout: merge }
+        }
+      } catch {
+        // Exact head/base refs above are authoritative; merge is optional.
+      }
+      return { base, head, checkout: head }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  prepareGithubRevisionOnlyWorkspace(agent: Agent, id: string): string {
+    const root = this.prepareSessionWorktreeRoot(agent)
+    const cwd = join(root, id)
+    if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) {
+      throw new Error('github review workspace path must not be a symlink')
+    }
+    const staged = `${cwd}.review-${randomUUID()}`
+    mkdirSync(staged, { recursive: true, mode: 0o700 })
+    try {
+      rmSync(cwd, { recursive: true, force: true })
+      renameSync(staged, cwd)
+    } catch (err) {
+      rmSync(staged, { recursive: true, force: true })
+      throw err
+    }
+    return realpathSync(cwd)
+  }
+
+  async addSessionWorktree(agent: Agent, cwd: string, target: string, initiatedBy?: string): Promise<void> {
+    const git = () => this.runnerFor(agent.id, agent.workspace.path).withEnv(workspaceGitLocalEnv())
+    let branch = ''
+    for (let attempt = 0; ; attempt++) {
+      branch = sessionBranchName(initiatedBy, attempt >= SESSION_BRANCH_DRAWS)
+      if (attempt >= SESSION_BRANCH_DRAWS) break
+      const taken = await git()
+        .raw(['show-ref', '--verify', '--quiet', `refs/heads/${branch}`])
+        .then(() => true)
+        .catch(() => false)
+      if (!taken) break
+    }
+    // --no-track: the start point is a remote-tracking ref, so git's own `branch.autoSetupMerge`
+    // would otherwise make `origin/<base>` this branch's upstream. That upstream is what the console's
+    // push authorizes against — it would turn the push button into a remote-branch creator — and it
+    // leaves a plain `git push` failing under push.default=simple on the name mismatch.
+    await git().raw(['worktree', 'add', '-b', branch, '--no-track', cwd, target])
+  }
+
+  async prepareSessionWorkspace(
+    agent: Agent,
+    request: PrepareSessionWorkspaceRequest,
+    opts: PrepareWorkspaceOptions = {}
+  ): Promise<string> {
+    if (request.githubReviewRevisionOnly) {
+      if (agent.workspace.mode !== 'git-repo' || request.isolation !== 'session' || request.review) {
+        throw new Error('github revision-only workspace requires an isolated git-repo review session')
+      }
+      return this.prepareGithubRevisionOnlyWorkspace(agent, this.sessionWorktreeId(request.sessionKey))
+    }
+    const primary = await this.prepareWorkspace(agent, opts)
+    if (agent.workspace.mode !== 'git-repo' || request.isolation === 'shared') return primary
+
+    const id = this.sessionWorktreeId(request.sessionKey)
+    const root = this.prepareSessionWorktreeRoot(agent)
+    const cwd = join(root, id)
+    if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) {
+      throw new Error('session worktree path must not be a symlink')
+    }
+    const review = request.review ? await this.fetchReviewRevision(agent, id, request.review) : undefined
+    const target = review?.checkout ?? `refs/remotes/origin/${agent.workspace.gitBranch}`
+    let attached = existsSync(join(cwd, '.git'))
+    if (attached) {
+      try {
+        await this.revParse(agent.id, cwd, 'HEAD')
+      } catch {
+        attached = false
+        rmSync(cwd, { recursive: true, force: true })
+      }
+    }
+    if (!attached) {
+      rmSync(cwd, { recursive: true, force: true })
+      await this.runnerFor(agent.id, agent.workspace.path).withEnv(workspaceGitLocalEnv()).raw(['worktree', 'prune'])
+      // prepareWorkspace's pull is best-effort (and may be disabled), but this
+      // checkout runs in the daemon process. Unsafe executable config must gate
+      // the worktree operation itself instead of being swallowed as a pull error.
+      await assertSafeWorkspaceGitConfig(this.runnerFor(agent.id, agent.workspace.path))
+      await this.addSessionWorktree(agent, cwd, target, request.initiatedBy)
+    } else if (review) {
+      // Re-audit at the checkout boundary rather than relying on the earlier
+      // network fetch audit; repository config may have changed while fetching.
+      await assertSafeWorkspaceGitConfig(this.runnerFor(agent.id, agent.workspace.path))
+      const worktreeGit = this.runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
+      await worktreeGit.raw(['reset', '--hard', target])
+      await worktreeGit.raw(['clean', '-ffdx'])
+    }
+    if (review && (await this.revParse(agent.id, cwd, 'HEAD')).toLowerCase() !== review.checkout) {
+      throw new Error('github review worktree HEAD does not match the verified revision')
+    }
+    const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
+    return this.withSkills(agent, this.resolveAcpCwd(cwd, agentDir), opts)
+  }
+
+  clusterWorkspaceCwd(
+    agent: Agent,
+    runtimeRoot: string | undefined,
+    request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
+  ): string {
+    this.refuseSessionIsolationInCluster(agent, request)
+    const checkout = this.clusterWorkspaceCheckout(agent, runtimeRoot)
+    if (agent.workspace.mode === 'from-scratch') return checkout
+    // The configured working subdirectory is applied LEXICALLY here: validating it means resolving
+    // symlinks and stat-ing, which only means something in the filesystem that holds it — so the shim
+    // does that when it refuses a cwd outside its own root.
+    const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
+    return agentDir === undefined ? checkout : join(checkout, ...agentDir.split('/'))
+  }
+
+  refuseSessionIsolationInCluster(agent: Agent, request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>): void {
+    if (request?.isolation === 'session') {
+      throw new Error(`session-isolated workspaces are not supported with --k8s yet (agent "${agent.id}")`)
+    }
+  }
+
+  clusterWorkspaceCheckout(agent: Agent, runtimeRoot: string | undefined): string {
+    const root = runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
+    return agent.workspace.mode === 'from-scratch' ? root : join(root, SANDBOX_CHECKOUT_DIR)
+  }
+
+  consoleWorkspaceRoot(
+    agent: Agent,
+    local: string | undefined,
+    runtimeRoot: string | undefined,
+    request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
+  ): string | undefined {
+    if (local === undefined || !this.sandboxMode) return local
+    this.refuseSessionIsolationInCluster(agent, request)
+    return this.clusterWorkspaceCheckout(agent, runtimeRoot)
+  }
+
+  async prepareClusterWorkspace(
+    agent: Agent,
+    runtimeRoot: string | undefined,
+    request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
+  ): Promise<string> {
+    const acpCwd = this.clusterWorkspaceCwd(agent, runtimeRoot, request)
+    const root = runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
+    const checkout = join(root, SANDBOX_CHECKOUT_DIR)
+    const targetMarker = this.materializationKey(agent)
+    const stored = this.readMaterialization(agent)
+    // The acknowledged edit's replacement, executed here because this is the only code that reaches
+    // the volume. Emptying the checkout IS the replacement: a git-repo target then clones below, and a
+    // from-scratch one is simply the absence of it. Fail-closed — a clear that did not happen would
+    // otherwise leave the previous repository's tree serving as the new workspace.
+    //
+    // The marker is dropped FIRST, and that order is the whole safety property. Everything from the
+    // clear to the proof can fail — the clone, its helper pin, the marker write itself — and a marker
+    // left describing the emptied workspace would tell the CP's rollback that nothing changed, so it
+    // would repoint the rejected tree and ACK an agent running the wrong repository. Unproven instead:
+    // whichever definition arrives next re-materializes the volume before anything runs on it.
+    const conversionDue = this.clusterConversionDue(agent, stored, targetMarker)
+    if (conversionDue) {
+      this.forgetWorkspaceMaterialization(agent)
+      await this.requireEmptiedSandboxPath(agent.id, checkout)
+    }
+
+    if (agent.workspace.mode === 'from-scratch') {
+      // Provable by construction: the checkout is gone, so the volume holds exactly the scratch
+      // workspace the configuration asks for. Recording it is what ends the conversion.
+      if (conversionDue) this.recordMaterializationBestEffort(agent)
+      return acpCwd
+    }
+    // Validated at the execution boundary, exactly as the local path does: a hand-edited agent.json
+    // must not turn daemon-managed git into a local-path or remote-helper launcher.
+    const repository = this.gitRepoOf(agent)
+    const githubApp = this.usesGithubApp(agent)
+
+    // Whether the volume can be PROVEN to hold what the marker would claim. A fresh clone can, by
+    // construction (`--branch` at clone time). An existing one has to be interrogated.
+    let volumeMatchesConfig = false
+    // A conversion just emptied the checkout, so nothing the old marker attested survives it.
+    const repositoryAttested = !conversionDue && this.markerAttestsRepository(stored, targetMarker)
+    if (!(await this.clusterCheckoutExists(agent.id, checkout))) {
+      await this.cloneRepoInSandbox(agent, root, repository)
+      volumeMatchesConfig = true
+    } else {
+      // A resumed volume carries the PREVIOUS launch's checkout, so the same two things the local
+      // path does to one: follow a repository rename onto the canonical URL (and refuse an origin
+      // that is not a trusted GitHub remote, which is fail-closed), and re-pin the helper line in
+      // `.git/config`, whose agent id goes stale when an agent is recreated over a surviving volume.
+      await this.convergeOriginInPlace(agent, checkout)
+      if (githubApp) {
+        await writeRepoHelperConfig(this.runnerFor(agent.id, checkout), agent.id).catch(() => undefined)
+      }
+    }
+
+    let pulled = false
+    if (agent.workspace.pullOnNewSession) {
+      if (githubApp) await preWarmGitCred(agent.id, 'pull').catch(() => undefined)
+      const abort = new AbortController()
+      const timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
+      try {
+        await assertSafeWorkspaceGitConfig(this.runnerFor(agent.id, checkout))
+        const pullTarget = workspaceGitPullTarget(repository)
+        const git = this.runnerFor(agent.id, checkout, abort.signal).withEnv({
+          ...workspaceGitLocalEnv(),
+          ...pullTarget.env,
+          ...(githubApp ? gitCredentialEnv(agent.id) : {}),
+          GIT_TERMINAL_PROMPT: '0'
+        })
+        await pullWorkspaceRef(git, pullTarget.remote, agent.workspace.gitBranch)
+        pulled = true
+      } catch {
+        // offline / timed out / non-fast-forward: proceed with the checkout on the volume, which is
+        // the same degradation the local path accepts.
+      } finally {
+        clearTimeout(timer)
+      }
+    }
+    // The marker records what the VOLUME holds, and this is the only place that knows — but ONLY when
+    // that can be proven, because a marker that overstates is worse than one that lags.
+    //
+    // The case that made this precise: a volume on branch A, a configuration that now says a divergent
+    // branch B. `pullWorkspaceRef` pulls INTO the current branch rather than switching, so its ff-only
+    // pull fails, the failure is swallowed as ordinary offline degradation, and the volume stays on A.
+    // Recording B there tells every later activation that nothing changed, and the agent runs the
+    // wrong branch indefinitely — silently, which is the property that makes it expensive.
+    //
+    // Provable means: a fresh clone (its `--branch` decided HEAD), or an existing checkout whose HEAD
+    // IS the configured branch AND whose tree is attributable to the configured repository — either
+    // because a stored marker already attests it, or because a pull from it just succeeded. A rewritten
+    // origin says nothing about the tree that was already there, and a branch name can match in both
+    // repositories, so without one of those two the volume is simply unproven.
+    //
+    // Anything else leaves the marker alone, so a later activation still sees the change and refuses it
+    // with a message naming what to do.
+    if (!volumeMatchesConfig) {
+      const head = await this.clusterCheckoutBranch(agent.id, checkout)
+      volumeMatchesConfig = head === agent.workspace.gitBranch && (repositoryAttested || pulled)
+    }
+    if (!volumeMatchesConfig) {
+      workspaceLog.warn(
+        `workspace: the volume for agent "${agent.id}" does not provably hold ${repository} @ ` +
+          `${agent.workspace.gitBranch} — leaving its materialization marker unchanged`
+      )
+      return acpCwd
+    }
+    this.recordMaterializationBestEffort(agent)
+    return acpCwd
+  }
+
+  recordMaterializationBestEffort(agent: Agent): void {
+    try {
+      this.recordWorkspaceMaterialization(agent)
+      this.writePendingConversion(agent, undefined)
+    } catch (err) {
+      workspaceLog.warn(
+        `workspace: could not record the materialization marker for agent "${agent.id}" (${(err as Error).message})`
+      )
+    }
+  }
+
+  async clusterCheckoutExists(agentId: string, checkout: string): Promise<boolean> {
+    try {
+      await this.runnerFor(agentId, checkout).withEnv(workspaceGitLocalEnv()).raw(['rev-parse', '--git-dir'])
+      return true
+    } catch {
+      // Missing directory, empty directory, or a partial clone — all "clone it".
+      return false
+    }
+  }
+
+  async cloneRepoInSandbox(agent: Agent, root: string, repository: string): Promise<void> {
+    const checkout = join(root, SANDBOX_CHECKOUT_DIR)
+    // Single-flight like the local clone. Per-agent workspace preparation is already serialized by the
+    // daemon's own queue, so this is the belt to that braces: two clones into one volume would be a
+    // half-written checkout, and the cost of preventing it is a map lookup.
+    //
+    // The key is captured ONCE and reused for get/set/delete. `cloneKey` is deliberately
+    // state-dependent — it includes the agent id only while a sandbox runner is attached — so a clone
+    // that fails BECAUSE the channel dropped would otherwise compute a different key on the way out,
+    // delete nothing, and leave its own rejection cached under the old one. Every retry after
+    // reattachment would then re-await that dead promise until the daemon restarted.
+    const key = this.cloneKey(agent.id, checkout)
+    const inflight = this.cloneInFlight.get(key)
+    if (inflight) return await inflight
+    const started = this.cloneInSandbox(agent, root, repository, checkout).finally(() => {
+      this.cloneInFlight.delete(key)
+    })
+    this.cloneInFlight.set(key, started)
+    return await started
+  }
+
+  async cloneInSandbox(agent: Agent, root: string, repository: string, checkout: string): Promise<void> {
+    const githubApp = this.usesGithubApp(agent)
+    if (githubApp) await preWarmGitCred(agent.id, 'clone')
+    const env = githubApp
+      ? { ...workspaceGitEnvBase(repository), ...cloneGitEnv(agent.id, repository) }
+      : { ...workspaceGitEnvBase(repository), GIT_TERMINAL_PROMPT: '0' }
+    try {
+      await this.runnerFor(agent.id, root)
+        .withEnv(env)
+        .clone(repository, SANDBOX_CHECKOUT_DIR, ['--branch', agent.workspace.gitBranch, '--single-branch'])
+    } catch (err) {
+      // A partial checkout would fail the probe above forever after, since git refuses to clone into
+      // a non-empty directory. Emptying it is the pod's own job — there is no rmSync to reach it.
+      await this.clearSandboxPath(agent.id, checkout)
+      throw err
+    }
+    if (githubApp) await writeRepoHelperConfig(this.runnerFor(agent.id, checkout), agent.id)
+  }
+
+  resolvePreparedWorkspaceCwd(agent: Agent): string {
+    const agentDir = agent.workspace.mode === 'git-repo' ? normalizeRepoSubdir(agent.workspace.agentDir) : undefined
+    return this.resolveAcpCwd(agent.workspace.path, agentDir)
+  }
+
+  additionalWorkspaceDirectories(
+    agent: Agent,
+    cwd: string,
+    request?: Pick<PrepareSessionWorkspaceRequest, 'sessionKey' | 'isolation'>
+  ): string[] {
+    if (agent.workspace.mode !== 'git-repo') return []
+    if (this.sandboxMode) {
+      // `cwd` is in the POD's coordinates, which this daemon cannot `realpathSync` — the path exists
+      // on no filesystem it can see, so the check below throws on the workspace it was handed. Undo
+      // the lexical join `clusterWorkspaceCwd` made instead; the shim re-checks containment itself.
+      const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
+      if (agentDir === undefined) return []
+      return [agentDir.split('/').reduce((path) => dirname(path), cwd)]
+    }
+    const expectedRoot =
+      request?.isolation === 'session' ? this.sessionWorktreePath(agent, request.sessionKey) : agent.workspace.path
+    const root = realpathSync(expectedRoot)
+    const canonicalCwd = realpathSync(cwd)
+    const rel = relative(root, canonicalCwd)
+    if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+      throw new Error(`prepared workspace cwd "${cwd}" resolves outside its checkout root`)
+    }
+    return root === canonicalCwd ? [] : [root]
+  }
+
+  resolveAcpCwd(workspaceRoot: string, agentDir: string | undefined): string {
+    const canonicalRoot = realpathSync(workspaceRoot)
+    if (agentDir === undefined) return canonicalRoot
+
+    let canonicalCandidate: string
+    try {
+      canonicalCandidate = realpathSync(join(workspaceRoot, ...agentDir.split('/')))
+    } catch {
+      throw new Error(`workspace working subdirectory "${agentDir}" does not exist`)
+    }
+    if (!statSync(canonicalCandidate).isDirectory()) {
+      throw new Error(`workspace working subdirectory "${agentDir}" is not a directory`)
+    }
+
+    const rel = relative(canonicalRoot, canonicalCandidate)
+    if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+      throw new Error(`workspace working subdirectory "${agentDir}" resolves outside the repository`)
+    }
+    return canonicalCandidate
+  }
+
+  isWorkspaceEmpty(agent: Agent): boolean {
+    const cwd = agent.workspace.path
+    return !existsSync(cwd) || readdirSync(cwd).length === 0
+  }
+
+  cleanupStaleWorkspaceClones(agent: Agent): number {
+    const cwd = agent.workspace.path
+    const parent = dirname(cwd)
+    if (!existsSync(parent)) return 0
+
+    const prefix = `${basename(cwd)}.clone-`
+    let removed = 0
+    for (const entry of readdirSync(parent, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.startsWith(prefix)) continue
+      if (!STAGED_CLONE_ID.test(entry.name.slice(prefix.length))) continue
+      rmSync(join(parent, entry.name), { recursive: true, force: true })
+      removed += 1
+    }
+    return removed
+  }
+
+  async prepareWorkspaceForActivation(
+    agent: Agent,
+    {
+      allowExistingCheckout = true,
+      reconcileMaterialization = false
+    }: { allowExistingCheckout?: boolean; reconcileMaterialization?: boolean } = {}
+  ): Promise<() => void> {
+    const cwd = agent.workspace.path
+    const previousMaterialization = reconcileMaterialization ? this.readMaterialization(agent) : undefined
+    const targetMaterialization = this.materializationKey(agent)
+    let replace =
+      reconcileMaterialization && !this.sameMaterialization(agent, previousMaterialization, targetMaterialization)
+    const restoreMarker = () => {
+      if (reconcileMaterialization) this.restoreWorkspaceMaterialization(agent, previousMaterialization)
+    }
+
+    // A cluster agent's checkout is on its pod volume, so this function has nothing local to do — and
+    // the one case that would need to do something, replacing an existing checkout, cannot be done
+    // from here at all: it needs a staged clone beside the target, `renameSync` for an atomic swap,
+    // `readdirSync` to prove the destination is still empty, and a rollback that restores the previous
+    // tree. The shim offers none of those, and this runs BEFORE the CP has acknowledged the edit, so
+    // anything destructive here would have to survive a rollback that cannot restore it.
+    //
+    // So activation records the intent and returns. `prepareClusterWorkspace` carries it out on the
+    // volume — after the acknowledgement, inside a bound sandbox, where a failed clone is retried like
+    // any other and an empty checkout is the recovery state, not a lost one.
+    //
+    // The marker is deliberately NOT advanced. For a cluster agent it means "the volume held this",
+    // and writing the TARGET here would say it about a volume nothing has inspected — which cluster
+    // preparation then reads back as proof of the repository, in a circle. Seeding at detach is a
+    // different thing and stays: it names the definition the agent has been RUNNING on.
+    if (this.sandboxMode) {
+      // Set, never taken back — not by the else branch of this condition, and not by the rollback
+      // below, which is why there is nothing to roll back. `ensureHostAsync` runs before the ACK, so
+      // preparation may already be replacing the volume when this activation is rejected, and no
+      // rollback reaches a pod's tree to undo it. Withdrawing the intent (or restoring the marker)
+      // there would tell the CP's restored definition that nothing changed, and it would be ACKed onto
+      // the rejected tree. Left standing, the pair says the volume is unattributable and whichever
+      // definition arrives next re-materializes it — so recovery needs no rollback to run at all.
+      // A stale intent costs nothing: a marker that proves the target ends the conversion.
+      //
+      // No previous marker means no proven volume to replace, so nothing is asked for — the pod either
+      // has no checkout, which preparation clones, or has one that convergence fixes.
+      if (reconcileMaterialization && replace && previousMaterialization !== undefined) {
+        this.writePendingConversion(agent, targetMaterialization)
+      }
+      return () => {}
+    }
+    mkdirSync(cwd, { recursive: true })
+
+    if (agent.workspace.mode === 'from-scratch') {
+      if (replace) {
+        this.clearSessionWorktrees(agent)
+        rmSync(cwd, { recursive: true, force: true })
+        mkdirSync(cwd, { recursive: true })
+      }
+      if (reconcileMaterialization) this.recordWorkspaceMaterialization(agent)
+      return () => {
+        if (replace) {
+          rmSync(cwd, { recursive: true, force: true })
+          mkdirSync(cwd, { recursive: true })
+        }
+        restoreMarker()
+      }
+    }
+    if (existsSync(join(cwd, '.git'))) {
+      if (!replace) {
+        if (!allowExistingCheckout) {
+          throw new Error('workspace changed after its empty check; retry after making it empty')
+        }
+        try {
+          await this.convergeWorkspaceOrigin(agent, cwd)
+        } catch (err) {
+          if (!(reconcileMaterialization && err instanceof UntrustedGithubWorkspaceOriginError)) throw err
+          // A historical App-backed checkout from a non-GitHub origin cannot be
+          // trusted merely by rewriting .git/config: replace its working tree
+          // from the installation-authorized GitHub repository.
+          replace = true
+        }
+        if (!replace) {
+          this.resolveAcpCwd(cwd, normalizeRepoSubdir(agent.workspace.agentDir))
+          if (reconcileMaterialization) this.recordWorkspaceMaterialization(agent)
+          return restoreMarker
+        }
+      }
+      // A different repo/branch is cloned below before the old checkout is
+      // removed, so network/auth failures leave the current workspace intact.
+    }
+    if (!replace && !this.isWorkspaceEmpty(agent)) {
+      throw new Error('workspace is not empty; remove or move its files before converting')
+    }
+
+    const staged = `${cwd}.clone-${randomUUID()}`
+    mkdirSync(staged, { recursive: true })
+    try {
+      await this.cloneRepoAt(agent, staged)
+      this.resolveAcpCwd(staged, normalizeRepoSubdir(agent.workspace.agentDir))
+      if (replace) {
+        this.clearSessionWorktrees(agent)
+        rmSync(cwd, { recursive: true, force: true })
+        renameSync(staged, cwd)
+        try {
+          this.recordWorkspaceMaterialization(agent)
+        } catch (err) {
+          rmSync(cwd, { recursive: true, force: true })
+          mkdirSync(cwd, { recursive: true })
+          restoreMarker()
+          throw err
+        }
+        return () => {
+          rmSync(cwd, { recursive: true, force: true })
+          mkdirSync(cwd, { recursive: true })
+          restoreMarker()
+        }
+      }
+      // The agent is gated, but an operator can still write directly on disk.
+      // Re-check at the swap boundary and fail without touching either tree.
+      if (!this.isWorkspaceEmpty(agent)) {
+        throw new Error('workspace changed while conversion was cloning; retry after making it empty')
+      }
+      try {
+        // POSIX directory replacement is atomic when the destination is still
+        // empty. If an operator writes into cwd after the check above, rename
+        // fails with the original tree untouched instead of deleting that data.
+        renameSync(staged, cwd)
+      } catch (err) {
+        if (!this.isWorkspaceEmpty(agent)) {
+          throw new Error('workspace changed while conversion was cloning; retry after making it empty', {
+            cause: err
+          })
+        }
+        throw err
+      }
+    } catch (err) {
+      rmSync(staged, { recursive: true, force: true })
+      throw err
+    }
+
+    if (reconcileMaterialization) this.recordWorkspaceMaterialization(agent)
+
+    return () => {
+      rmSync(cwd, { recursive: true, force: true })
+      mkdirSync(cwd, { recursive: true })
+      restoreMarker()
+    }
+  }
+
+  async prefetchWorkspace(agent: Agent): Promise<void> {
+    if (agent.workspace.mode !== 'git-repo') return
+    const cwd = agent.workspace.path
+    this.gitRepoOf(agent)
+    if (existsSync(join(cwd, '.git'))) {
+      await this.convergeWorkspaceOrigin(agent, cwd)
+      return
+    }
+    mkdirSync(cwd, { recursive: true })
+    await this.cloneRepo(agent)
+  }
+
+  async cloneRepo(agent: Agent): Promise<void> {
+    return this.cloneRepoAt(agent, agent.workspace.path)
+  }
+
+  async cloneRepoAt(agent: Agent, cwd: string): Promise<void> {
+    const key = this.cloneKey(agent.id, cwd)
+    const inflight = this.cloneInFlight.get(key)
+    if (inflight) return inflight
+
+    // Validate again at the execution boundary: a hand-edited/legacy agent.json
+    // must not turn daemon-managed git into a local-path or remote-helper launcher.
+    const gitRepo = this.gitRepoOf(agent)
+    const branch = agent.workspace.gitBranch
+    const githubApp = this.usesGithubApp(agent)
+
+    const p = (async () => {
+      // github-app: credentials ride the env-injected helper (no repo config exists
+      // yet). SPREAD over process.env — withEnv REPLACES the child env, as .env() did.
+      if (githubApp) await preWarmGitCred(agent.id, 'clone')
+      const git = githubApp
+        ? this.runnerFor(agent.id).withEnv({ ...workspaceGitEnvBase(gitRepo), ...cloneGitEnv(agent.id, gitRepo) })
+        : this.runnerFor(agent.id).withEnv({ ...workspaceGitEnvBase(gitRepo), GIT_TERMINAL_PROMPT: '0' })
+      try {
+        await git.clone(gitRepo, cwd, ['--branch', branch, '--single-branch'])
+      } catch (e) {
+        // A failed clone leaves a half-written dir whose stray `.git` would make
+        // every later attempt think the checkout exists — clean before rethrowing.
+        rmSync(join(cwd, '.git'), { recursive: true, force: true })
+        throw e
+      }
+      // Pin the repo-local helper so AGENT-run git in this checkout authenticates
+      // through the daemon too — the "no credentials on the machine, but the agent
+      // can still push" half of the design.
+      if (githubApp) await writeRepoHelperConfig(this.runnerFor(agent.id, cwd), agent.id)
+    })().finally(() => {
+      this.cloneInFlight.delete(key)
+    })
+    this.cloneInFlight.set(key, p)
+    return p
+  }
 }
 
 class UntrustedGithubWorkspaceOriginError extends Error {
@@ -193,35 +1256,12 @@ class UntrustedGithubWorkspaceOriginError extends Error {
   }
 }
 
-function isTrustedGithubOrigin(input: string): boolean {
-  const raw = input.trim()
-  if (raw.includes('\\')) return false
-  const scp = /^[\w.-]+@([\w.-]+):/.exec(raw)
-  if (scp) return scp[1]!.toLowerCase() === 'github.com'
-  if (!/^(?:https|ssh):\/\//i.test(raw)) return false
-  try {
-    return new URL(normalizeGitCloneUrl(redactGitUrlSecrets(raw))).hostname.toLowerCase() === 'github.com'
-  } catch {
-    return false
-  }
-}
-
 // Resolves where one agent's git runs. Per-agent because a cluster workspace's runner is bound to
 // that agent's own sandbox channel; undefined means local, so self-hosting needs no registration.
 export type WorkspaceGitRunnerResolver = (agentId: string, cwd?: string, abort?: AbortSignal) => GitRunner | undefined
 
-export function setWorkspaceGitRunnerResolver(resolver: WorkspaceGitRunnerResolver | undefined): void {
-  defaultWorkspaces.setGitRunnerResolver(resolver)
-}
-
 // Every git operation here routes through this: a direct gitFor still passes locally and then runs
 // a cluster agent's git on the wrong filesystem.
-function runnerFor(agentId: string, cwd?: string, abort?: AbortSignal): GitRunner {
-  return (
-    defaultWorkspaces.resolveGitRunner(agentId, cwd, abort) ??
-    new LocalGitRunner(gitFor(cwd, abort), cwd, (env) => gitFor(cwd, abort).env(env))
-  )
-}
 
 /**
  * Empties a directory in the filesystem that agent's work happens in; undefined ⇒ this daemon's.
@@ -232,10 +1272,6 @@ function runnerFor(agentId: string, cwd?: string, abort?: AbortSignal): GitRunne
  */
 export type WorkspacePathClearer = (agentId: string, root: string) => Promise<string | undefined>
 
-export function setWorkspacePathClearer(clearer: WorkspacePathClearer | undefined): void {
-  defaultWorkspaces.setPathClearer(clearer)
-}
-
 /**
  * Whether this daemon places workspaces in sandbox pods at all.
  *
@@ -243,31 +1279,15 @@ export function setWorkspacePathClearer(clearer: WorkspacePathClearer | undefine
  * false before a channel binds, so an operation guarded by it would take the local path for a
  * cluster agent that simply has no pod yet — and clone onto the daemon's disk.
  */
-export function setSandboxWorkspaceMode(enabled: boolean): void {
-  defaultWorkspaces.setSandboxMode(enabled)
-}
 
 /** The same answer for callers OUTSIDE this module — a seam that would otherwise `stat` a workspace
  *  path that names a filesystem this process cannot see. */
-export function sandboxWorkspaceMode(): boolean {
-  return defaultWorkspaces.sandboxMode
-}
 
 /** Empty a path belonging to a cluster agent. A daemon with no clearer registered has no sandbox to
  *  reach, so there is nothing to empty — the local path never calls this. */
-async function clearSandboxPath(agentId: string, root: string): Promise<void> {
-  const error = await defaultWorkspaces.clearPath(agentId, root)
-  if (error) {
-    workspaceLog.warn(`workspace: could not empty ${root} for agent "${agentId}" after a failed clone (${error})`)
-  }
-}
 
 /** Empty a cluster path the caller cannot proceed without. A conversion that kept the old checkout
  *  would clone into a non-empty directory, or converge the new origin onto the previous tree. */
-async function requireEmptiedSandboxPath(agentId: string, root: string): Promise<void> {
-  const error = await defaultWorkspaces.clearPath(agentId, root)
-  if (error) throw new Error(`workspace: could not replace ${root} for agent "${agentId}" (${error})`)
-}
 
 /**
  * The console git seam's runner: the agent's own, or — only when workspaces are not in sandboxes at
@@ -281,19 +1301,6 @@ async function requireEmptiedSandboxPath(agentId: string, root: string): Promise
  * this disk. The fallback is therefore not merely unhelpful in sandbox mode, it is refused, so no
  * caller can reintroduce it by ordering its own checks differently.
  */
-export function consoleWorkspaceGitRunner(agentId: string, cwd?: string, abort?: AbortSignal): GitRunner | undefined {
-  const remote = defaultWorkspaces.resolveGitRunner(agentId, cwd, abort)
-  if (remote) return remote
-  if (defaultWorkspaces.sandboxMode) return undefined
-  return new LocalGitRunner(gitFor(cwd, abort), cwd, (env) => gitFor(cwd, abort).env(env))
-}
-
-async function convergeWorkspaceOrigin(agent: Agent, cwd = agent.workspace.path): Promise<void> {
-  const clone = cloneInFlight.get(cloneKey(agent.id, cwd))
-  if (clone) await clone
-  if (!existsSync(join(cwd, '.git'))) return
-  await convergeOriginInPlace(agent, cwd)
-}
 
 /**
  * Whether a stored marker already attests that the volume's tree came from the configured
@@ -307,20 +1314,6 @@ async function convergeWorkspaceOrigin(agent: Agent, cwd = agent.workspace.path)
  * Branch is deliberately not compared here; HEAD answers that directly. Absent or unparseable counts
  * as no attestation, so a pull has to prove it.
  */
-function markerAttestsRepository(previous: string | undefined, target: string): boolean {
-  if (previous === undefined) return false
-  const repoOf = (raw: string): string | undefined => {
-    try {
-      const parsed = JSON.parse(raw) as { repo?: unknown }
-      return typeof parsed.repo === 'string' ? parsed.repo.replace(/\.git$/i, '').toLowerCase() : undefined
-    } catch {
-      return undefined
-    }
-  }
-  const left = repoOf(previous)
-  const right = repoOf(target)
-  return left !== undefined && right !== undefined && left === right
-}
 
 /**
  * Which branch the pod's checkout is actually on.
@@ -329,16 +1322,6 @@ function markerAttestsRepository(previous: string | undefined, target: string): 
  * this is the only thing that can tell a volume holding the requested branch from one that merely
  * fetched it. Empty when it cannot be established, which counts as "cannot prove it".
  */
-async function clusterCheckoutBranch(agentId: string, checkout: string): Promise<string> {
-  try {
-    const head = await runnerFor(agentId, checkout)
-      .withEnv(workspaceGitLocalEnv())
-      .raw(['rev-parse', '--abbrev-ref', 'HEAD'])
-    return head.trim()
-  } catch {
-    return ''
-  }
-}
 
 /**
  * The convergence itself, for a checkout the caller has already established exists.
@@ -347,60 +1330,6 @@ async function clusterCheckoutBranch(agentId: string, checkout: string): Promise
  * test, and for a pod it is a question asked over the channel. What follows is identical, and has to
  * be — this is where a repository rename is followed and where an untrusted origin is refused.
  */
-async function convergeOriginInPlace(agent: Agent, cwd: string): Promise<void> {
-  const expected = gitRepoOf(agent)
-  const git = runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
-  let current: string
-  try {
-    current = (await git.raw(['remote', 'get-url', 'origin'])).trim()
-  } catch (cause) {
-    if (usesGithubApp(agent)) throw new UntrustedGithubWorkspaceOriginError({ cause })
-    return
-  }
-  if (usesGithubApp(agent) && !isTrustedGithubOrigin(current)) {
-    throw new UntrustedGithubWorkspaceOriginError()
-  }
-  const normalizedCurrent = normalizeGitUrl(current)
-  let unsafeCurrent = redactGitUrlSecrets(current) !== normalizedCurrent
-  try {
-    authorizeWorkspaceGitUrl(current)
-    if (!/^(?:https|ssh):\/\//i.test(current) && !/^[\w.-]+@[\w.-]+:/.test(current)) unsafeCurrent = true
-  } catch {
-    unsafeCurrent = true
-  }
-  const mismatched = normalizedCurrent.toLowerCase() !== expected.toLowerCase()
-  if ((!mismatched && !unsafeCurrent) || (!unsafeCurrent && !usesGithubApp(agent))) return
-  // App-backed mismatches and unsafe anonymous origins must converge before
-  // daemon-managed Git can proceed. A failed rewrite is fail-closed.
-  await git.raw(['remote', 'set-url', 'origin', expected])
-}
-
-function materializationKey(agent: Agent): string {
-  if (agent.workspace.mode === 'from-scratch') return JSON.stringify({ mode: 'scratch' })
-  const repo = gitRepoOf(agent)
-  return JSON.stringify({
-    mode: 'github',
-    // GitHub treats the conventional `.git` suffix as the same repository.
-    // Ignoring it here prevents a harmless CP canonicalization from replacing
-    // an existing checkout during an access/agentDir-only edit.
-    repo: (usesGithubApp(agent) ? repo.replace(/\.git$/i, '') : repo).toLowerCase(),
-    branch: agent.workspace.gitBranch
-  })
-}
-
-function materializationFile(agent: Agent): string {
-  const cwd = agent.workspace.path
-  return join(dirname(cwd), `.${basename(cwd)}.${MATERIALIZATION_FILE}`)
-}
-
-function readMaterialization(agent: Agent): string | undefined {
-  try {
-    const value = JSON.parse(readFileSync(materializationFile(agent), 'utf8')) as { key?: unknown }
-    return typeof value.key === 'string' ? value.key : undefined
-  } catch {
-    return undefined
-  }
-}
 
 /**
  * That an edit asked this agent's POD volume to be replaced, and which workspace it asked for.
@@ -419,29 +1348,6 @@ function readMaterialization(agent: Agent): string | undefined {
  * that cannot be attributed to a workspace is still a conversion — the volume is unattributable
  * from the moment its checkout is emptied until preparation proves the new one.
  */
-function conversionFile(agent: Agent): string {
-  const cwd = agent.workspace.path
-  return join(dirname(cwd), `.${basename(cwd)}.${CONVERSION_FILE}`)
-}
-
-function readPendingConversion(agent: Agent): string | undefined {
-  try {
-    const value = JSON.parse(readFileSync(conversionFile(agent), 'utf8')) as { key?: unknown }
-    return typeof value.key === 'string' ? value.key : undefined
-  } catch {
-    return undefined
-  }
-}
-
-function writePendingConversion(agent: Agent, key: string | undefined): void {
-  const file = conversionFile(agent)
-  if (key === undefined) {
-    rmSync(file, { force: true })
-    return
-  }
-  mkdirSync(dirname(file), { recursive: true })
-  writeFileSync(file, JSON.stringify({ version: 1, key }, null, 2) + '\n')
-}
 
 /**
  * Whether the pod still has to replace its checkout: a replacement was asked for, and the marker
@@ -454,198 +1360,32 @@ function writePendingConversion(agent: Agent, key: string | undefined): void {
  * the release: it is written only when preparation proved the volume, which is also when the intent
  * is cleared. That makes a leftover intent inert rather than a repeated wipe.
  */
-function clusterConversionDue(agent: Agent, stored: string | undefined, target: string): boolean {
-  if (sameMaterialization(agent, stored, target)) return false
-  return readPendingConversion(agent) !== undefined
-}
-
-function sameMaterialization(agent: Agent, previous: string | undefined, target: string): boolean {
-  if (previous === target) return true
-  if (!usesGithubApp(agent) || previous === undefined) return false
-  try {
-    const left = JSON.parse(previous) as { mode?: unknown; repo?: unknown; branch?: unknown }
-    const right = JSON.parse(target) as { mode?: unknown; repo?: unknown; branch?: unknown }
-    if (
-      left.mode !== 'github' ||
-      right.mode !== 'github' ||
-      typeof left.repo !== 'string' ||
-      typeof right.repo !== 'string'
-    ) {
-      return false
-    }
-    return (
-      left.repo.replace(/\.git$/i, '').toLowerCase() === right.repo.replace(/\.git$/i, '').toLowerCase() &&
-      left.branch === right.branch
-    )
-  } catch {
-    return false
-  }
-}
 
 /** Snapshot the currently-live workspace definition before a cold detach. */
-export function recordWorkspaceMaterialization(agent: Agent): void {
-  const file = materializationFile(agent)
-  const temp = `${file}.tmp`
-  mkdirSync(dirname(file), { recursive: true })
-  try {
-    writeFileSync(temp, JSON.stringify({ version: 1, key: materializationKey(agent) }, null, 2) + '\n')
-    renameSync(temp, file)
-  } catch (err) {
-    rmSync(temp, { force: true })
-    throw err
-  }
-}
 
 /** Converge the durable identity and remote of an App-backed checkout after a
  * canonical GitHub rename. Advance the marker first within this update so
  * origin convergence is fail-closed and retryable while the target marker holds. */
-export async function convergeGithubAppWorkspaceRename(agent: Agent): Promise<void> {
-  if (!usesGithubApp(agent)) return
-  recordWorkspaceMaterialization(agent)
-  await convergeWorkspaceOrigin(agent)
-}
 
 /** Seed the marker for a pre-v2 workspace without overwriting an earlier
  * materialization. The on-disk spec may already be the target after a crash,
  * while the checkout still belongs to the recorded source. */
-export function ensureWorkspaceMaterialization(agent: Agent): void {
-  if (!existsSync(materializationFile(agent))) recordWorkspaceMaterialization(agent)
-}
 
 /** Say that nothing is known about the volume, for the stretch where nothing IS: a cluster
  *  conversion between emptying the checkout and proving its replacement. Throws rather than
  *  leaving a stale marker behind — the destructive step is ordered after it for that reason. */
-function forgetWorkspaceMaterialization(agent: Agent): void {
-  rmSync(materializationFile(agent), { force: true })
-}
-
-function restoreWorkspaceMaterialization(agent: Agent, key: string | undefined): void {
-  if (key === undefined) {
-    rmSync(materializationFile(agent), { force: true })
-    return
-  }
-  const file = materializationFile(agent)
-  mkdirSync(dirname(file), { recursive: true })
-  writeFileSync(file, JSON.stringify({ version: 1, key }, null, 2) + '\n')
-}
-
-export async function prepareWorkspace(agent: Agent, opts: PrepareWorkspaceOptions = {}): Promise<string> {
-  const cwd = agent.workspace.path
-  // Fail unsafe config before using either a fresh or existing checkout.
-  const agentDir = agent.workspace.mode === 'git-repo' ? normalizeRepoSubdir(agent.workspace.agentDir) : undefined
-  if (agent.workspace.mode === 'git-repo') gitRepoOf(agent)
-  mkdirSync(cwd, { recursive: true })
-
-  if (agent.workspace.mode === 'from-scratch') {
-    // The agent's memory file lives at the agent ROOT (outside the workspace) and
-    // is seeded separately (see agents/memory.ts `ensureMemory`), so from-scratch
-    // just needs the (empty) workspace dir to exist.
-    return withSkills(agent, cwd, opts)
-  }
-
-  // git-repo, first session: no checkout yet → clone. Unlike pull, a clone has no
-  // on-disk fallback, so on failure we THROW (the session creation fails + the error
-  // surfaces) rather than silently proceeding with an empty dir (design §4.3).
-  if (!existsSync(join(cwd, '.git'))) {
-    await cloneRepo(agent)
-    return withSkills(agent, resolveAcpCwd(cwd, agentDir), opts)
-  }
-
-  // git-repo, existing checkout: the repo-local helper pin may carry a previous
-  // agent generation's id (agent deleted + recreated under the same name adopts
-  // the surviving checkout) — re-pin so agent-run git presents a live identity
-  // even where the env channel doesn't reach. Best-effort: a locked .git/config
-  // must not block the session; the session-env channel still covers this run.
-  if (usesGithubApp(agent)) {
-    // The CP follows repository renames by numeric repo id. Repoint the existing
-    // checkout instead of treating that canonical URL refresh as a new workspace.
-    await convergeWorkspaceOrigin(agent, cwd)
-    await writeRepoHelperConfig(runnerFor(agent.id, cwd), agent.id).catch(() => undefined)
-  } else {
-    // Historical anonymous checkouts may still have credential-bearing or
-    // disallowed origins even after their CP row has been sanitized.
-    await convergeWorkspaceOrigin(agent, cwd)
-  }
-
-  // Best-effort ff-only pull; never block/throw on offline (design §4.3) —
-  // proceed with the on-disk checkout.
-  if (agent.workspace.pullOnNewSession) {
-    // github-app: warm the credential cache OUTSIDE the pull budget — a cold
-    // cache means a CP round trip that would otherwise eat the whole 4.5s.
-    if (usesGithubApp(agent)) await preWarmGitCred(agent.id, 'pull').catch(() => undefined)
-    // Abort-driven budget: the signal makes simple-git KILL the git child at
-    // the deadline. A bare Promise.race would abandon it still running — a
-    // wedged pull (network black hole) then holds .git/index.lock into the
-    // next session's pull.
-    const abort = new AbortController()
-    const timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
-    try {
-      const repository = gitRepoOf(agent)
-      await assertSafeWorkspaceGitConfig(runnerFor(agent.id, cwd))
-      const pullTarget = workspaceGitPullTarget(repository)
-      const git = runnerFor(agent.id, cwd, abort.signal).withEnv({
-        ...workspaceGitLocalEnv(),
-        ...pullTarget.env,
-        ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
-        GIT_TERMINAL_PROMPT: '0'
-      })
-      await pullWorkspaceRef(git, pullTarget.remote, agent.workspace.gitBranch)
-    } catch {
-      // offline / timed out / non-fast-forward: proceed with the on-disk checkout
-    } finally {
-      clearTimeout(timer)
-    }
-  }
-  return withSkills(agent, resolveAcpCwd(cwd, agentDir), opts)
-}
 
 /** Daemon-owned parent for logical-session worktrees. It sits beside the main
  * checkout so both stay inside one agent's filesystem/sandbox boundary. */
-export function sessionWorktreeRoot(agent: Agent): string {
-  const agentRoot = (agent as { dir?: string }).dir ?? dirname(agent.workspace.path)
-  return join(agentRoot, 'worktrees')
-}
 
 /** Canonicalize an EXISTING worktree root and prove it (and every ancestor
  * symlink it may hide behind) still resolves inside the agent directory. Every
  * destructive path must go through this — checking only the final entry misses
  * a symlinked `worktrees/` parent redirecting the whole tree elsewhere. */
-function validateSessionWorktreeRoot(agent: Agent, root: string): string {
-  if (lstatSync(root).isSymbolicLink()) {
-    throw new Error('session worktree root must not be a symlink')
-  }
-  const agentRoot = realpathSync((agent as { dir?: string }).dir ?? dirname(agent.workspace.path))
-  const canonicalRoot = realpathSync(root)
-  const rel = relative(agentRoot, canonicalRoot)
-  if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
-    throw new Error('session worktree root resolves outside the agent directory')
-  }
-  return canonicalRoot
-}
-
-function prepareSessionWorktreeRoot(agent: Agent): string {
-  const root = sessionWorktreeRoot(agent)
-  if (existsSync(root) && lstatSync(root).isSymbolicLink()) {
-    throw new Error('session worktree root must not be a symlink')
-  }
-  mkdirSync(root, { recursive: true, mode: 0o700 })
-  return validateSessionWorktreeRoot(agent, root)
-}
-
-function clearSessionWorktrees(agent: Agent): void {
-  rmSync(sessionWorktreeRoot(agent), { recursive: true, force: true })
-}
-
-function sessionWorktreeId(sessionKey: string): string {
-  return createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)
-}
 
 /** The stable daemon-owned worktree directory for one logical session. Derived,
  * never stored — the id is a hex hash, so the path always sits under the agent's
  * worktrees root. */
-export function sessionWorktreePath(agent: Agent, sessionKey: string): string {
-  return join(sessionWorktreeRoot(agent), sessionWorktreeId(sessionKey))
-}
 
 export type SessionWorktreeRemoval =
   | { outcome: 'removed' }
@@ -662,283 +1402,20 @@ export type SessionWorktreeRemoval =
  * anything else is reported as retained/failed so the caller keeps the session.
  * The active-turn exclusion is the caller's job — this function only judges the
  * on-disk state. */
-export async function removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
-  const id = sessionWorktreeId(sessionKey)
-  const primaryGit = () => runnerFor(agent.id, agent.workspace.path).withEnv(workspaceGitLocalEnv())
-  // Drop the stale Git registration and this worktree's daemon-owned review refs.
-  // Ref deletion is best-effort: most worktrees never had review refs.
-  const cleanupRegistrations = async () => {
-    await primaryGit().raw(['worktree', 'prune'])
-    for (const name of ['base', 'head', 'merge']) {
-      await primaryGit()
-        .raw(['update-ref', '-d', `refs/agentconnect/reviews/${id}/${name}`])
-        .catch(() => undefined)
-    }
-  }
-  try {
-    if (agent.workspace.mode !== 'git-repo') throw new Error('agent workspace is not a Git repository')
-    const rootPath = sessionWorktreeRoot(agent)
-    if (!existsSync(rootPath)) {
-      // No root ⇒ no worktree directory can exist; Git may still hold a stale
-      // registration/review refs for it.
-      await cleanupRegistrations()
-      return { outcome: 'absent' }
-    }
-    // Re-derive cwd from the CANONICAL root: a symlinked root (or symlinked
-    // ancestor) must never redirect the destructive branches below outside the
-    // agent directory.
-    const cwd = join(validateSessionWorktreeRoot(agent, rootPath), id)
-    if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) throw new Error('session worktree path is a symlink')
-    if (!existsSync(cwd)) {
-      await cleanupRegistrations()
-      return { outcome: 'absent' }
-    }
-    if (!existsSync(join(cwd, '.git'))) {
-      // The `.git` marker is gone, so Git no longer considers this a worktree —
-      // but a NONEMPTY directory may hold exactly the untracked work this GC
-      // promises never to auto-delete (`status` can't run without the marker).
-      // Reclaim only a provably empty leftover; report anything else.
-      if (readdirSync(cwd).length > 0) return { outcome: 'retained', reason: 'dirty' }
-      rmSync(cwd, { recursive: true, force: true })
-      await cleanupRegistrations()
-      return { outcome: 'removed' }
-    }
-    const worktreeGit = runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
-    if ((await worktreeGit.raw(['status', '--porcelain'])).trim() !== '') {
-      return { outcome: 'retained', reason: 'dirty' }
-    }
-    // The generated branch this worktree checks out, read BEFORE the removal that
-    // unregisters it. Empty for a worktree created before session branches existed.
-    const branch = (await worktreeGit.raw(['symbolic-ref', '--quiet', '--short', 'HEAD']).catch(() => '')).trim()
-    // A session branch tracks nothing, so there is no upstream to compare against:
-    // a commit is "unique" when no remote ref (and no fetched review ref of this
-    // worktree) can reach it.
-    const unique = (
-      await worktreeGit.raw([
-        'rev-list',
-        '--count',
-        'HEAD',
-        '--not',
-        '--remotes',
-        `--glob=refs/agentconnect/reviews/${id}`
-      ])
-    ).trim()
-    if (unique !== '0') return { outcome: 'retained', reason: 'unique-commits' }
-    // No --force: if the tree went dirty between the check and here, Git refuses
-    // and the failure keeps the session.
-    await primaryGit().raw(['worktree', 'remove', cwd])
-    await cleanupRegistrations()
-    // Only a branch this daemon generated for a session worktree, and only after
-    // the check above proved every commit on it is reachable from a remote — so
-    // the forced delete can drop no work. Best-effort: a surviving ref is clutter,
-    // not a reason to report a removed worktree as retained.
-    if (isSessionBranch(branch)) {
-      await primaryGit()
-        .raw(['branch', '-D', branch])
-        .catch(() => undefined)
-    }
-    return { outcome: 'removed' }
-  } catch (err) {
-    return { outcome: 'failed', error: (err as Error).message }
-  }
-}
-
-function exactObjectId(value: string, label: string): string {
-  if (!GIT_OBJECT_ID.test(value)) throw new Error(`github review ${label} is not a Git object id`)
-  return value.toLowerCase()
-}
-
-async function revParse(agentId: string, cwd: string, ref: string): Promise<string> {
-  return (
-    await runnerFor(agentId, cwd)
-      .withEnv(workspaceGitLocalEnv())
-      .raw(['rev-parse', '--verify', `${ref}^{commit}`])
-  ).trim()
-}
-
-async function fetchReviewRevision(
-  agent: Agent,
-  worktreeId: string,
-  review: GithubReviewWorkspaceRevision
-): Promise<{ base: string; head: string; checkout: string }> {
-  const base = exactObjectId(review.baseSha, 'base SHA')
-  const head = exactObjectId(review.headSha, 'head SHA')
-  if (!Number.isSafeInteger(review.pullNumber) || review.pullNumber <= 0) {
-    throw new Error('github review pull number is invalid')
-  }
-  const root = `refs/agentconnect/reviews/${worktreeId}`
-  const baseRef = `${root}/base`
-  const headRef = `${root}/head`
-  const mergeRef = `${root}/merge`
-  const repository = gitRepoOf(agent)
-  await assertSafeWorkspaceGitConfig(runnerFor(agent.id, agent.workspace.path))
-  if (usesGithubApp(agent)) await preWarmGitCred(agent.id, 'pull')
-  const pullTarget = workspaceGitPullTarget(repository)
-  const abort = new AbortController()
-  const timer = setTimeout(() => abort.abort(), REVIEW_FETCH_TIMEOUT_MS)
-  try {
-    const git = runnerFor(agent.id, agent.workspace.path, abort.signal).withEnv({
-      ...pullTarget.env,
-      ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
-      GIT_TERMINAL_PROMPT: '0'
-    })
-    await git.raw([
-      'fetch',
-      '--force',
-      '--no-tags',
-      '--no-recurse-submodules',
-      pullTarget.remote,
-      `+${base}:${baseRef}`,
-      `+refs/pull/${review.pullNumber}/head:${headRef}`
-    ])
-    if ((await revParse(agent.id, agent.workspace.path, baseRef)).toLowerCase() !== base) {
-      throw new Error('github review base ref did not resolve to the requested SHA')
-    }
-    if ((await revParse(agent.id, agent.workspace.path, headRef)).toLowerCase() !== head) {
-      throw new Error('github review head ref did not resolve to the requested SHA')
-    }
-
-    // A conflicted PR has no merge ref. Head remains an exact, reviewable
-    // checkout; when GitHub does provide a merge ref, trust it only after proving
-    // both parents are the exact base/head pair carried by the hook.
-    await git.raw(['update-ref', '-d', mergeRef]).catch(() => undefined)
-    try {
-      await git.raw([
-        'fetch',
-        '--force',
-        '--no-tags',
-        '--no-recurse-submodules',
-        pullTarget.remote,
-        `+refs/pull/${review.pullNumber}/merge:${mergeRef}`
-      ])
-      const merge = (await revParse(agent.id, agent.workspace.path, mergeRef)).toLowerCase()
-      const expectedMerge = review.mergeCommitSha ? exactObjectId(review.mergeCommitSha, 'merge SHA') : undefined
-      const parents = (
-        await runnerFor(agent.id, agent.workspace.path)
-          .withEnv(workspaceGitLocalEnv())
-          .raw(['rev-list', '--parents', '-n', '1', mergeRef])
-      )
-        .trim()
-        .toLowerCase()
-        .split(/\s+/)
-      if (
-        (!expectedMerge || merge === expectedMerge) &&
-        parents.length === 3 &&
-        parents[1] === base &&
-        parents[2] === head
-      ) {
-        return { base, head, checkout: merge }
-      }
-    } catch {
-      // Exact head/base refs above are authoritative; merge is optional.
-    }
-    return { base, head, checkout: head }
-  } finally {
-    clearTimeout(timer)
-  }
-}
 
 /** Replace any earlier checkout with an empty stable cwd. This lets a formal
  * review continue through revision-addressed GitHub tools without exposing a
  * stale or checkout-controlled local repository as evidence. */
-function prepareGithubRevisionOnlyWorkspace(agent: Agent, id: string): string {
-  const root = prepareSessionWorktreeRoot(agent)
-  const cwd = join(root, id)
-  if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) {
-    throw new Error('github review workspace path must not be a symlink')
-  }
-  const staged = `${cwd}.review-${randomUUID()}`
-  mkdirSync(staged, { recursive: true, mode: 0o700 })
-  try {
-    rmSync(cwd, { recursive: true, force: true })
-    renameSync(staged, cwd)
-  } catch (err) {
-    rmSync(staged, { recursive: true, force: true })
-    throw err
-  }
-  return realpathSync(cwd)
-}
 
 /** Check out a session worktree on its OWN generated branch rather than at a
  * detached HEAD, so the work a session produces has a name it can be pushed and
  * reviewed under. A drawn name can already exist in the repository, which
  * `worktree add -b` refuses — so ask git first and draw again, then let random
  * bytes end the search rather than failing the session over a word pair. */
-async function addSessionWorktree(agent: Agent, cwd: string, target: string, initiatedBy?: string): Promise<void> {
-  const git = () => runnerFor(agent.id, agent.workspace.path).withEnv(workspaceGitLocalEnv())
-  let branch = ''
-  for (let attempt = 0; ; attempt++) {
-    branch = sessionBranchName(initiatedBy, attempt >= SESSION_BRANCH_DRAWS)
-    if (attempt >= SESSION_BRANCH_DRAWS) break
-    const taken = await git()
-      .raw(['show-ref', '--verify', '--quiet', `refs/heads/${branch}`])
-      .then(() => true)
-      .catch(() => false)
-    if (!taken) break
-  }
-  // --no-track: the start point is a remote-tracking ref, so git's own `branch.autoSetupMerge`
-  // would otherwise make `origin/<base>` this branch's upstream. That upstream is what the console's
-  // push authorizes against — it would turn the push button into a remote-branch creator — and it
-  // leaves a plain `git push` failing under push.default=simple on the name mismatch.
-  await git().raw(['worktree', 'add', '-b', branch, '--no-track', cwd, target])
-}
 
 /** Prepare the stable cwd for one logical session. Ordinary worktrees preserve
  * their working state between turns. Review worktrees are daemon-owned snapshots
  * and are reset on every delivery after an exact remote fetch. */
-export async function prepareSessionWorkspace(
-  agent: Agent,
-  request: PrepareSessionWorkspaceRequest,
-  opts: PrepareWorkspaceOptions = {}
-): Promise<string> {
-  if (request.githubReviewRevisionOnly) {
-    if (agent.workspace.mode !== 'git-repo' || request.isolation !== 'session' || request.review) {
-      throw new Error('github revision-only workspace requires an isolated git-repo review session')
-    }
-    return prepareGithubRevisionOnlyWorkspace(agent, sessionWorktreeId(request.sessionKey))
-  }
-  const primary = await prepareWorkspace(agent, opts)
-  if (agent.workspace.mode !== 'git-repo' || request.isolation === 'shared') return primary
-
-  const id = sessionWorktreeId(request.sessionKey)
-  const root = prepareSessionWorktreeRoot(agent)
-  const cwd = join(root, id)
-  if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) {
-    throw new Error('session worktree path must not be a symlink')
-  }
-  const review = request.review ? await fetchReviewRevision(agent, id, request.review) : undefined
-  const target = review?.checkout ?? `refs/remotes/origin/${agent.workspace.gitBranch}`
-  let attached = existsSync(join(cwd, '.git'))
-  if (attached) {
-    try {
-      await revParse(agent.id, cwd, 'HEAD')
-    } catch {
-      attached = false
-      rmSync(cwd, { recursive: true, force: true })
-    }
-  }
-  if (!attached) {
-    rmSync(cwd, { recursive: true, force: true })
-    await runnerFor(agent.id, agent.workspace.path).withEnv(workspaceGitLocalEnv()).raw(['worktree', 'prune'])
-    // prepareWorkspace's pull is best-effort (and may be disabled), but this
-    // checkout runs in the daemon process. Unsafe executable config must gate
-    // the worktree operation itself instead of being swallowed as a pull error.
-    await assertSafeWorkspaceGitConfig(runnerFor(agent.id, agent.workspace.path))
-    await addSessionWorktree(agent, cwd, target, request.initiatedBy)
-  } else if (review) {
-    // Re-audit at the checkout boundary rather than relying on the earlier
-    // network fetch audit; repository config may have changed while fetching.
-    await assertSafeWorkspaceGitConfig(runnerFor(agent.id, agent.workspace.path))
-    const worktreeGit = runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
-    await worktreeGit.raw(['reset', '--hard', target])
-    await worktreeGit.raw(['clean', '-ffdx'])
-  }
-  if (review && (await revParse(agent.id, cwd, 'HEAD')).toLowerCase() !== review.checkout) {
-    throw new Error('github review worktree HEAD does not match the verified revision')
-  }
-  const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
-  return withSkills(agent, resolveAcpCwd(cwd, agentDir), opts)
-}
 
 /**
  * The ACP cwd for a CLUSTER agent, in the sandbox pod's own coordinates.
@@ -950,40 +1427,14 @@ export async function prepareSessionWorkspace(
  * can see. The root comes from the bound shim's hello; a legacy shim that reported none
  * gets the one mount layout such images ever had.
  */
-export function clusterWorkspaceCwd(
-  agent: Agent,
-  runtimeRoot: string | undefined,
-  request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
-): string {
-  refuseSessionIsolationInCluster(agent, request)
-  const checkout = clusterWorkspaceCheckout(agent, runtimeRoot)
-  if (agent.workspace.mode === 'from-scratch') return checkout
-  // The configured working subdirectory is applied LEXICALLY here: validating it means resolving
-  // symlinks and stat-ing, which only means something in the filesystem that holds it — so the shim
-  // does that when it refuses a cwd outside its own root.
-  const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
-  return agentDir === undefined ? checkout : join(checkout, ...agentDir.split('/'))
-}
 
 /** A logical-session worktree needs a daemon-owned parent beside the checkout, `worktree add` in the
  *  sandbox, and a retention GC that reads the pod's tree — a separate migration, and a clear error
  *  beats a mystery one from git inside the sandbox. */
-function refuseSessionIsolationInCluster(
-  agent: Agent,
-  request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
-): void {
-  if (request?.isolation === 'session') {
-    throw new Error(`session-isolated workspaces are not supported with --k8s yet (agent "${agent.id}")`)
-  }
-}
 
 /** Where a CLUSTER agent's tree ROOT is in the pod's coordinates: the mounted volume for a
  *  from-scratch workspace, and the checkout one level down (away from the runtime's HOME) for a
  *  git-repo one. The ACP cwd is derived from it; the console addresses it directly. */
-export function clusterWorkspaceCheckout(agent: Agent, runtimeRoot: string | undefined): string {
-  const root = runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
-  return agent.workspace.mode === 'from-scratch' ? root : join(root, SANDBOX_CHECKOUT_DIR)
-}
 
 /**
  * The root the CONSOLE's workspace surfaces work in: the CHECKOUT root, in the coordinates of the
@@ -1003,16 +1454,6 @@ export function clusterWorkspaceCheckout(agent: Agent, runtimeRoot: string | und
  * `local` still decides WHETHER there is a workspace to name — absent stays absent, so a
  * shared-workspace sessionId is refused as before — and only the coordinates change.
  */
-export function consoleWorkspaceRoot(
-  agent: Agent,
-  local: string | undefined,
-  runtimeRoot: string | undefined,
-  request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
-): string | undefined {
-  if (local === undefined || !defaultWorkspaces.sandboxMode) return local
-  refuseSessionIsolationInCluster(agent, request)
-  return clusterWorkspaceCheckout(agent, runtimeRoot)
-}
 
 /**
  * Prepare a CLUSTER agent's workspace on its sandbox pod's volume.
@@ -1027,130 +1468,10 @@ export function consoleWorkspaceRoot(
  * local-filesystem work, and pointing them at a pod path would write them onto this daemon's disk;
  * that migration is its own change, so a cluster agent runs with none.
  */
-export async function prepareClusterWorkspace(
-  agent: Agent,
-  runtimeRoot: string | undefined,
-  request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
-): Promise<string> {
-  const acpCwd = clusterWorkspaceCwd(agent, runtimeRoot, request)
-  const root = runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
-  const checkout = join(root, SANDBOX_CHECKOUT_DIR)
-  const targetMarker = materializationKey(agent)
-  const stored = readMaterialization(agent)
-  // The acknowledged edit's replacement, executed here because this is the only code that reaches
-  // the volume. Emptying the checkout IS the replacement: a git-repo target then clones below, and a
-  // from-scratch one is simply the absence of it. Fail-closed — a clear that did not happen would
-  // otherwise leave the previous repository's tree serving as the new workspace.
-  //
-  // The marker is dropped FIRST, and that order is the whole safety property. Everything from the
-  // clear to the proof can fail — the clone, its helper pin, the marker write itself — and a marker
-  // left describing the emptied workspace would tell the CP's rollback that nothing changed, so it
-  // would repoint the rejected tree and ACK an agent running the wrong repository. Unproven instead:
-  // whichever definition arrives next re-materializes the volume before anything runs on it.
-  const conversionDue = clusterConversionDue(agent, stored, targetMarker)
-  if (conversionDue) {
-    forgetWorkspaceMaterialization(agent)
-    await requireEmptiedSandboxPath(agent.id, checkout)
-  }
-
-  if (agent.workspace.mode === 'from-scratch') {
-    // Provable by construction: the checkout is gone, so the volume holds exactly the scratch
-    // workspace the configuration asks for. Recording it is what ends the conversion.
-    if (conversionDue) recordMaterializationBestEffort(agent)
-    return acpCwd
-  }
-  // Validated at the execution boundary, exactly as the local path does: a hand-edited agent.json
-  // must not turn daemon-managed git into a local-path or remote-helper launcher.
-  const repository = gitRepoOf(agent)
-  const githubApp = usesGithubApp(agent)
-
-  // Whether the volume can be PROVEN to hold what the marker would claim. A fresh clone can, by
-  // construction (`--branch` at clone time). An existing one has to be interrogated.
-  let volumeMatchesConfig = false
-  // A conversion just emptied the checkout, so nothing the old marker attested survives it.
-  const repositoryAttested = !conversionDue && markerAttestsRepository(stored, targetMarker)
-  if (!(await clusterCheckoutExists(agent.id, checkout))) {
-    await cloneRepoInSandbox(agent, root, repository)
-    volumeMatchesConfig = true
-  } else {
-    // A resumed volume carries the PREVIOUS launch's checkout, so the same two things the local
-    // path does to one: follow a repository rename onto the canonical URL (and refuse an origin
-    // that is not a trusted GitHub remote, which is fail-closed), and re-pin the helper line in
-    // `.git/config`, whose agent id goes stale when an agent is recreated over a surviving volume.
-    await convergeOriginInPlace(agent, checkout)
-    if (githubApp) {
-      await writeRepoHelperConfig(runnerFor(agent.id, checkout), agent.id).catch(() => undefined)
-    }
-  }
-
-  let pulled = false
-  if (agent.workspace.pullOnNewSession) {
-    if (githubApp) await preWarmGitCred(agent.id, 'pull').catch(() => undefined)
-    const abort = new AbortController()
-    const timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
-    try {
-      await assertSafeWorkspaceGitConfig(runnerFor(agent.id, checkout))
-      const pullTarget = workspaceGitPullTarget(repository)
-      const git = runnerFor(agent.id, checkout, abort.signal).withEnv({
-        ...workspaceGitLocalEnv(),
-        ...pullTarget.env,
-        ...(githubApp ? gitCredentialEnv(agent.id) : {}),
-        GIT_TERMINAL_PROMPT: '0'
-      })
-      await pullWorkspaceRef(git, pullTarget.remote, agent.workspace.gitBranch)
-      pulled = true
-    } catch {
-      // offline / timed out / non-fast-forward: proceed with the checkout on the volume, which is
-      // the same degradation the local path accepts.
-    } finally {
-      clearTimeout(timer)
-    }
-  }
-  // The marker records what the VOLUME holds, and this is the only place that knows — but ONLY when
-  // that can be proven, because a marker that overstates is worse than one that lags.
-  //
-  // The case that made this precise: a volume on branch A, a configuration that now says a divergent
-  // branch B. `pullWorkspaceRef` pulls INTO the current branch rather than switching, so its ff-only
-  // pull fails, the failure is swallowed as ordinary offline degradation, and the volume stays on A.
-  // Recording B there tells every later activation that nothing changed, and the agent runs the
-  // wrong branch indefinitely — silently, which is the property that makes it expensive.
-  //
-  // Provable means: a fresh clone (its `--branch` decided HEAD), or an existing checkout whose HEAD
-  // IS the configured branch AND whose tree is attributable to the configured repository — either
-  // because a stored marker already attests it, or because a pull from it just succeeded. A rewritten
-  // origin says nothing about the tree that was already there, and a branch name can match in both
-  // repositories, so without one of those two the volume is simply unproven.
-  //
-  // Anything else leaves the marker alone, so a later activation still sees the change and refuses it
-  // with a message naming what to do.
-  if (!volumeMatchesConfig) {
-    const head = await clusterCheckoutBranch(agent.id, checkout)
-    volumeMatchesConfig = head === agent.workspace.gitBranch && (repositoryAttested || pulled)
-  }
-  if (!volumeMatchesConfig) {
-    workspaceLog.warn(
-      `workspace: the volume for agent "${agent.id}" does not provably hold ${repository} @ ` +
-        `${agent.workspace.gitBranch} — leaving its materialization marker unchanged`
-    )
-    return acpCwd
-  }
-  recordMaterializationBestEffort(agent)
-  return acpCwd
-}
 
 /** Cluster preparation's marker write: best-effort, because the volume IS prepared and failing a
  *  session over bookkeeping would trade a stale marker for no session at all. The pending
  *  conversion goes with it — the marker now says the volume holds what the edit asked for. */
-function recordMaterializationBestEffort(agent: Agent): void {
-  try {
-    recordWorkspaceMaterialization(agent)
-    writePendingConversion(agent, undefined)
-  } catch (err) {
-    workspaceLog.warn(
-      `workspace: could not record the materialization marker for agent "${agent.id}" (${(err as Error).message})`
-    )
-  }
-}
 
 /**
  * Whether the pod already holds a checkout — asked of the pod, because that is where it would be.
@@ -1160,15 +1481,6 @@ function recordMaterializationBestEffort(agent: Agent): void {
  * A half-written clone has a `.git` and fails this, which is the case that would otherwise make
  * every later session believe the checkout exists.
  */
-async function clusterCheckoutExists(agentId: string, checkout: string): Promise<boolean> {
-  try {
-    await runnerFor(agentId, checkout).withEnv(workspaceGitLocalEnv()).raw(['rev-parse', '--git-dir'])
-    return true
-  } catch {
-    // Missing directory, empty directory, or a partial clone — all "clone it".
-    return false
-  }
-}
 
 /**
  * Clone into the pod, with the target RELATIVE to the fenced working directory.
@@ -1177,54 +1489,11 @@ async function clusterCheckoutExists(agentId: string, checkout: string): Promise
  * outside its workspace root, so a relative target cannot land anywhere else. An absolute target
  * would be argv the fence never looks at.
  */
-async function cloneRepoInSandbox(agent: Agent, root: string, repository: string): Promise<void> {
-  const checkout = join(root, SANDBOX_CHECKOUT_DIR)
-  // Single-flight like the local clone. Per-agent workspace preparation is already serialized by the
-  // daemon's own queue, so this is the belt to that braces: two clones into one volume would be a
-  // half-written checkout, and the cost of preventing it is a map lookup.
-  //
-  // The key is captured ONCE and reused for get/set/delete. `cloneKey` is deliberately
-  // state-dependent — it includes the agent id only while a sandbox runner is attached — so a clone
-  // that fails BECAUSE the channel dropped would otherwise compute a different key on the way out,
-  // delete nothing, and leave its own rejection cached under the old one. Every retry after
-  // reattachment would then re-await that dead promise until the daemon restarted.
-  const key = cloneKey(agent.id, checkout)
-  const inflight = cloneInFlight.get(key)
-  if (inflight) return await inflight
-  const started = cloneInSandbox(agent, root, repository, checkout).finally(() => {
-    cloneInFlight.delete(key)
-  })
-  cloneInFlight.set(key, started)
-  return await started
-}
-
-async function cloneInSandbox(agent: Agent, root: string, repository: string, checkout: string): Promise<void> {
-  const githubApp = usesGithubApp(agent)
-  if (githubApp) await preWarmGitCred(agent.id, 'clone')
-  const env = githubApp
-    ? { ...workspaceGitEnvBase(repository), ...cloneGitEnv(agent.id, repository) }
-    : { ...workspaceGitEnvBase(repository), GIT_TERMINAL_PROMPT: '0' }
-  try {
-    await runnerFor(agent.id, root)
-      .withEnv(env)
-      .clone(repository, SANDBOX_CHECKOUT_DIR, ['--branch', agent.workspace.gitBranch, '--single-branch'])
-  } catch (err) {
-    // A partial checkout would fail the probe above forever after, since git refuses to clone into
-    // a non-empty directory. Emptying it is the pod's own job — there is no rmSync to reach it.
-    await clearSandboxPath(agent.id, checkout)
-    throw err
-  }
-  if (githubApp) await writeRepoHelperConfig(runnerFor(agent.id, checkout), agent.id)
-}
 
 /** Resolve the already-prepared ACP cwd without pulling, acquiring sources, or
  * reconciling skills. The daemon cold-host gate calls prepareWorkspace before
  * spawn; SessionManager uses this pure follow-up to consume that same result
  * instead of triggering a second preparation after the host starts. */
-export function resolvePreparedWorkspaceCwd(agent: Agent): string {
-  const agentDir = agent.workspace.mode === 'git-repo' ? normalizeRepoSubdir(agent.workspace.agentDir) : undefined
-  return resolveAcpCwd(agent.workspace.path, agentDir)
-}
 
 /** Return the checkout root that encloses an already-prepared ACP cwd.
  *
@@ -1232,81 +1501,18 @@ export function resolvePreparedWorkspaceCwd(agent: Agent): string {
  * project instructions retain their existing meaning. Runtimes that support
  * additional workspace directories receive this enclosing root separately,
  * which lets repository-wide tools reach `.git` and sibling paths. */
-export function additionalWorkspaceDirectories(
-  agent: Agent,
-  cwd: string,
-  request?: Pick<PrepareSessionWorkspaceRequest, 'sessionKey' | 'isolation'>
-): string[] {
-  if (agent.workspace.mode !== 'git-repo') return []
-  if (defaultWorkspaces.sandboxMode) {
-    // `cwd` is in the POD's coordinates, which this daemon cannot `realpathSync` — the path exists
-    // on no filesystem it can see, so the check below throws on the workspace it was handed. Undo
-    // the lexical join `clusterWorkspaceCwd` made instead; the shim re-checks containment itself.
-    const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
-    if (agentDir === undefined) return []
-    return [agentDir.split('/').reduce((path) => dirname(path), cwd)]
-  }
-  const expectedRoot =
-    request?.isolation === 'session' ? sessionWorktreePath(agent, request.sessionKey) : agent.workspace.path
-  const root = realpathSync(expectedRoot)
-  const canonicalCwd = realpathSync(cwd)
-  const rel = relative(root, canonicalCwd)
-  if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
-    throw new Error(`prepared workspace cwd "${cwd}" resolves outside its checkout root`)
-  }
-  return root === canonicalCwd ? [] : [root]
-}
 
 /** Resolve the checked path ACP receives, closing symlink and prefix-containment gaps. */
-function resolveAcpCwd(workspaceRoot: string, agentDir: string | undefined): string {
-  const canonicalRoot = realpathSync(workspaceRoot)
-  if (agentDir === undefined) return canonicalRoot
-
-  let canonicalCandidate: string
-  try {
-    canonicalCandidate = realpathSync(join(workspaceRoot, ...agentDir.split('/')))
-  } catch {
-    throw new Error(`workspace working subdirectory "${agentDir}" does not exist`)
-  }
-  if (!statSync(canonicalCandidate).isDirectory()) {
-    throw new Error(`workspace working subdirectory "${agentDir}" is not a directory`)
-  }
-
-  const rel = relative(canonicalRoot, canonicalCandidate)
-  if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
-    throw new Error(`workspace working subdirectory "${agentDir}" resolves outside the repository`)
-  }
-  return canonicalCandidate
-}
 
 /** True only when the daemon-owned working directory has no entries. Missing
  *  directories count as empty. Callers that need a race-free answer must first
  *  gate/drain the agent (workspace conversion does this through agent/detach). */
-export function isWorkspaceEmpty(agent: Agent): boolean {
-  const cwd = agent.workspace.path
-  return !existsSync(cwd) || readdirSync(cwd).length === 0
-}
 
 const STAGED_CLONE_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 /** Best-effort startup GC for hard-crash leftovers from workspace conversion.
  *  Match only the exact daemon-owned `<workspace>.clone-<uuid>` siblings so a
  *  similarly named operator directory is never treated as disposable. */
-export function cleanupStaleWorkspaceClones(agent: Agent): number {
-  const cwd = agent.workspace.path
-  const parent = dirname(cwd)
-  if (!existsSync(parent)) return 0
-
-  const prefix = `${basename(cwd)}.clone-`
-  let removed = 0
-  for (const entry of readdirSync(parent, { withFileTypes: true })) {
-    if (!entry.isDirectory() || !entry.name.startsWith(prefix)) continue
-    if (!STAGED_CLONE_ID.test(entry.name.slice(prefix.length))) continue
-    rmSync(join(parent, entry.name), { recursive: true, force: true })
-    removed += 1
-  }
-  return removed
-}
 
 /**
  * Materialize a staged cold workspace edit.
@@ -1317,151 +1523,6 @@ export function cleanupStaleWorkspaceClones(agent: Agent): number {
  * Rollback restores a correct empty base for the old definition to re-clone,
  * but deliberately cannot restore files discarded by an acknowledged replace.
  */
-export async function prepareWorkspaceForActivation(
-  agent: Agent,
-  {
-    allowExistingCheckout = true,
-    reconcileMaterialization = false
-  }: { allowExistingCheckout?: boolean; reconcileMaterialization?: boolean } = {}
-): Promise<() => void> {
-  const cwd = agent.workspace.path
-  const previousMaterialization = reconcileMaterialization ? readMaterialization(agent) : undefined
-  const targetMaterialization = materializationKey(agent)
-  let replace = reconcileMaterialization && !sameMaterialization(agent, previousMaterialization, targetMaterialization)
-  const restoreMarker = () => {
-    if (reconcileMaterialization) restoreWorkspaceMaterialization(agent, previousMaterialization)
-  }
-
-  // A cluster agent's checkout is on its pod volume, so this function has nothing local to do — and
-  // the one case that would need to do something, replacing an existing checkout, cannot be done
-  // from here at all: it needs a staged clone beside the target, `renameSync` for an atomic swap,
-  // `readdirSync` to prove the destination is still empty, and a rollback that restores the previous
-  // tree. The shim offers none of those, and this runs BEFORE the CP has acknowledged the edit, so
-  // anything destructive here would have to survive a rollback that cannot restore it.
-  //
-  // So activation records the intent and returns. `prepareClusterWorkspace` carries it out on the
-  // volume — after the acknowledgement, inside a bound sandbox, where a failed clone is retried like
-  // any other and an empty checkout is the recovery state, not a lost one.
-  //
-  // The marker is deliberately NOT advanced. For a cluster agent it means "the volume held this",
-  // and writing the TARGET here would say it about a volume nothing has inspected — which cluster
-  // preparation then reads back as proof of the repository, in a circle. Seeding at detach is a
-  // different thing and stays: it names the definition the agent has been RUNNING on.
-  if (defaultWorkspaces.sandboxMode) {
-    // Set, never taken back — not by the else branch of this condition, and not by the rollback
-    // below, which is why there is nothing to roll back. `ensureHostAsync` runs before the ACK, so
-    // preparation may already be replacing the volume when this activation is rejected, and no
-    // rollback reaches a pod's tree to undo it. Withdrawing the intent (or restoring the marker)
-    // there would tell the CP's restored definition that nothing changed, and it would be ACKed onto
-    // the rejected tree. Left standing, the pair says the volume is unattributable and whichever
-    // definition arrives next re-materializes it — so recovery needs no rollback to run at all.
-    // A stale intent costs nothing: a marker that proves the target ends the conversion.
-    //
-    // No previous marker means no proven volume to replace, so nothing is asked for — the pod either
-    // has no checkout, which preparation clones, or has one that convergence fixes.
-    if (reconcileMaterialization && replace && previousMaterialization !== undefined) {
-      writePendingConversion(agent, targetMaterialization)
-    }
-    return () => {}
-  }
-  mkdirSync(cwd, { recursive: true })
-
-  if (agent.workspace.mode === 'from-scratch') {
-    if (replace) {
-      clearSessionWorktrees(agent)
-      rmSync(cwd, { recursive: true, force: true })
-      mkdirSync(cwd, { recursive: true })
-    }
-    if (reconcileMaterialization) recordWorkspaceMaterialization(agent)
-    return () => {
-      if (replace) {
-        rmSync(cwd, { recursive: true, force: true })
-        mkdirSync(cwd, { recursive: true })
-      }
-      restoreMarker()
-    }
-  }
-  if (existsSync(join(cwd, '.git'))) {
-    if (!replace) {
-      if (!allowExistingCheckout) {
-        throw new Error('workspace changed after its empty check; retry after making it empty')
-      }
-      try {
-        await convergeWorkspaceOrigin(agent, cwd)
-      } catch (err) {
-        if (!(reconcileMaterialization && err instanceof UntrustedGithubWorkspaceOriginError)) throw err
-        // A historical App-backed checkout from a non-GitHub origin cannot be
-        // trusted merely by rewriting .git/config: replace its working tree
-        // from the installation-authorized GitHub repository.
-        replace = true
-      }
-      if (!replace) {
-        resolveAcpCwd(cwd, normalizeRepoSubdir(agent.workspace.agentDir))
-        if (reconcileMaterialization) recordWorkspaceMaterialization(agent)
-        return restoreMarker
-      }
-    }
-    // A different repo/branch is cloned below before the old checkout is
-    // removed, so network/auth failures leave the current workspace intact.
-  }
-  if (!replace && !isWorkspaceEmpty(agent)) {
-    throw new Error('workspace is not empty; remove or move its files before converting')
-  }
-
-  const staged = `${cwd}.clone-${randomUUID()}`
-  mkdirSync(staged, { recursive: true })
-  try {
-    await cloneRepoAt(agent, staged)
-    resolveAcpCwd(staged, normalizeRepoSubdir(agent.workspace.agentDir))
-    if (replace) {
-      clearSessionWorktrees(agent)
-      rmSync(cwd, { recursive: true, force: true })
-      renameSync(staged, cwd)
-      try {
-        recordWorkspaceMaterialization(agent)
-      } catch (err) {
-        rmSync(cwd, { recursive: true, force: true })
-        mkdirSync(cwd, { recursive: true })
-        restoreMarker()
-        throw err
-      }
-      return () => {
-        rmSync(cwd, { recursive: true, force: true })
-        mkdirSync(cwd, { recursive: true })
-        restoreMarker()
-      }
-    }
-    // The agent is gated, but an operator can still write directly on disk.
-    // Re-check at the swap boundary and fail without touching either tree.
-    if (!isWorkspaceEmpty(agent)) {
-      throw new Error('workspace changed while conversion was cloning; retry after making it empty')
-    }
-    try {
-      // POSIX directory replacement is atomic when the destination is still
-      // empty. If an operator writes into cwd after the check above, rename
-      // fails with the original tree untouched instead of deleting that data.
-      renameSync(staged, cwd)
-    } catch (err) {
-      if (!isWorkspaceEmpty(agent)) {
-        throw new Error('workspace changed while conversion was cloning; retry after making it empty', {
-          cause: err
-        })
-      }
-      throw err
-    }
-  } catch (err) {
-    rmSync(staged, { recursive: true, force: true })
-    throw err
-  }
-
-  if (reconcileMaterialization) recordWorkspaceMaterialization(agent)
-
-  return () => {
-    rmSync(cwd, { recursive: true, force: true })
-    mkdirSync(cwd, { recursive: true })
-    restoreMarker()
-  }
-}
 
 /**
  * Eagerly clone a git-repo workspace that has no checkout yet — for reconcile-time
@@ -1473,56 +1534,5 @@ export async function prepareWorkspaceForActivation(
  * failure here is non-fatal because `prepareWorkspace` re-clones (and hard-fails)
  * on the first session as the backstop.
  */
-export async function prefetchWorkspace(agent: Agent): Promise<void> {
-  if (agent.workspace.mode !== 'git-repo') return
-  const cwd = agent.workspace.path
-  gitRepoOf(agent)
-  if (existsSync(join(cwd, '.git'))) {
-    await convergeWorkspaceOrigin(agent, cwd)
-    return
-  }
-  mkdirSync(cwd, { recursive: true })
-  await cloneRepo(agent)
-}
 
 /** Clone agent.workspace.gitRepo @ gitBranch into cwd, single-flight per cwd. */
-async function cloneRepo(agent: Agent): Promise<void> {
-  return cloneRepoAt(agent, agent.workspace.path)
-}
-
-async function cloneRepoAt(agent: Agent, cwd: string): Promise<void> {
-  const key = cloneKey(agent.id, cwd)
-  const inflight = cloneInFlight.get(key)
-  if (inflight) return inflight
-
-  // Validate again at the execution boundary: a hand-edited/legacy agent.json
-  // must not turn daemon-managed git into a local-path or remote-helper launcher.
-  const gitRepo = gitRepoOf(agent)
-  const branch = agent.workspace.gitBranch
-  const githubApp = usesGithubApp(agent)
-
-  const p = (async () => {
-    // github-app: credentials ride the env-injected helper (no repo config exists
-    // yet). SPREAD over process.env — withEnv REPLACES the child env, as .env() did.
-    if (githubApp) await preWarmGitCred(agent.id, 'clone')
-    const git = githubApp
-      ? runnerFor(agent.id).withEnv({ ...workspaceGitEnvBase(gitRepo), ...cloneGitEnv(agent.id, gitRepo) })
-      : runnerFor(agent.id).withEnv({ ...workspaceGitEnvBase(gitRepo), GIT_TERMINAL_PROMPT: '0' })
-    try {
-      await git.clone(gitRepo, cwd, ['--branch', branch, '--single-branch'])
-    } catch (e) {
-      // A failed clone leaves a half-written dir whose stray `.git` would make
-      // every later attempt think the checkout exists — clean before rethrowing.
-      rmSync(join(cwd, '.git'), { recursive: true, force: true })
-      throw e
-    }
-    // Pin the repo-local helper so AGENT-run git in this checkout authenticates
-    // through the daemon too — the "no credentials on the machine, but the agent
-    // can still push" half of the design.
-    if (githubApp) await writeRepoHelperConfig(runnerFor(agent.id, cwd), agent.id)
-  })().finally(() => {
-    cloneInFlight.delete(key)
-  })
-  cloneInFlight.set(key, p)
-  return p
-}

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -114,15 +114,63 @@ const CONVERSION_FILE = 'workspace-conversion.json'
 const SESSION_BRANCH_DRAWS = 5
 const GIT_OBJECT_ID = /^[0-9a-f]{40,64}$/i
 
-// Single-flight clone lock. Two concurrent sessions (especially multiple agents sharing one repo
-// checkout) must not race into the same dir — the second awaits the first's in-flight clone.
-const cloneInFlight = new Map<string, Promise<void>>()
+// The per-daemon execution plane every workspace operation resolves through: where an agent's git
+// runs, how a path this process cannot see gets emptied, whether workspaces live in sandboxes at
+// all, and the clone single-flight that coalesces concurrent sessions.
+//
+// Instance state, not module state, because a process can hold more than one daemon — the test
+// suite routinely does, and a k8s daemon and a local one disagree on every field here. While these
+// were module-level bindings the second daemon in a process silently inherited the first's plane.
+export class WorkspaceManager {
+  // Single-flight clone lock. Two concurrent sessions (especially multiple agents sharing one repo
+  // checkout) must not race into the same dir — the second awaits the first's in-flight clone.
+  readonly cloneInFlight = new Map<string, Promise<void>>()
+  private gitRunnerResolver: WorkspaceGitRunnerResolver | undefined
+  private pathClearer: WorkspacePathClearer | undefined
+  private workspacesLiveInSandboxes = false
 
-// The key is the cwd for a local workspace, where sharing a path means sharing a checkout and
-// coalescing is the intent. For a cluster workspace the same path is a DIFFERENT filesystem per
-// agent, so coalescing there would hand one agent the other's clone; the agent id disambiguates.
+  setGitRunnerResolver(resolver: WorkspaceGitRunnerResolver | undefined): void {
+    this.gitRunnerResolver = resolver
+  }
+
+  setPathClearer(clearer: WorkspacePathClearer | undefined): void {
+    this.pathClearer = clearer
+  }
+
+  setSandboxMode(enabled: boolean): void {
+    this.workspacesLiveInSandboxes = enabled
+  }
+
+  get sandboxMode(): boolean {
+    return this.workspacesLiveInSandboxes
+  }
+
+  /** The agent's own runner; undefined means its workspace is reachable locally. */
+  resolveGitRunner(agentId: string, cwd?: string, abort?: AbortSignal): GitRunner | undefined {
+    return this.gitRunnerResolver?.(agentId, cwd, abort)
+  }
+
+  /** The clearer's error message, or undefined when it succeeded or none is registered. */
+  async clearPath(agentId: string, root: string): Promise<string | undefined> {
+    return await this.pathClearer?.(agentId, root).catch((err: unknown) => (err as Error).message)
+  }
+
+  // The key is the cwd for a local workspace, where sharing a path means sharing a checkout and
+  // coalescing is the intent. For a cluster workspace the same path is a DIFFERENT filesystem per
+  // agent, so coalescing there would hand one agent the other's clone; the agent id disambiguates.
+  cloneKey(agentId: string, cwd: string): string {
+    return this.gitRunnerResolver?.(agentId, cwd) ? `${agentId}\u0000${cwd}` : cwd
+  }
+}
+
+// The plane the module-level entry points below still resolve through. Step 2 threads an explicit
+// instance down from the owning `Daemon`, and this — with the `set*` shims — goes away.
+const defaultWorkspaces = new WorkspaceManager()
+
+const cloneInFlight = defaultWorkspaces.cloneInFlight
+
 function cloneKey(agentId: string, cwd: string): string {
-  return resolveWorkspaceGitRunner?.(agentId, cwd) ? `${agentId}\u0000${cwd}` : cwd
+  return defaultWorkspaces.cloneKey(agentId, cwd)
 }
 
 function usesGithubApp(agent: Agent): boolean {
@@ -162,18 +210,15 @@ function isTrustedGithubOrigin(input: string): boolean {
 // that agent's own sandbox channel; undefined means local, so self-hosting needs no registration.
 export type WorkspaceGitRunnerResolver = (agentId: string, cwd?: string, abort?: AbortSignal) => GitRunner | undefined
 
-/** Module-level init, mirroring cloneInFlight and git-injection's own registration. */
-let resolveWorkspaceGitRunner: WorkspaceGitRunnerResolver | undefined
-
 export function setWorkspaceGitRunnerResolver(resolver: WorkspaceGitRunnerResolver | undefined): void {
-  resolveWorkspaceGitRunner = resolver
+  defaultWorkspaces.setGitRunnerResolver(resolver)
 }
 
 // Every git operation here routes through this: a direct gitFor still passes locally and then runs
 // a cluster agent's git on the wrong filesystem.
 function runnerFor(agentId: string, cwd?: string, abort?: AbortSignal): GitRunner {
   return (
-    resolveWorkspaceGitRunner?.(agentId, cwd, abort) ??
+    defaultWorkspaces.resolveGitRunner(agentId, cwd, abort) ??
     new LocalGitRunner(gitFor(cwd, abort), cwd, (env) => gitFor(cwd, abort).env(env))
   )
 }
@@ -187,35 +232,31 @@ function runnerFor(agentId: string, cwd?: string, abort?: AbortSignal): GitRunne
  */
 export type WorkspacePathClearer = (agentId: string, root: string) => Promise<string | undefined>
 
-let clearWorkspacePathInSandbox: WorkspacePathClearer | undefined
-
 export function setWorkspacePathClearer(clearer: WorkspacePathClearer | undefined): void {
-  clearWorkspacePathInSandbox = clearer
+  defaultWorkspaces.setPathClearer(clearer)
 }
 
 /**
  * Whether this daemon places workspaces in sandbox pods at all.
  *
- * Deliberately NOT `resolveWorkspaceGitRunner?.(id) !== undefined`: that answers per agent and is
+ * Deliberately NOT `resolveGitRunner(id) !== undefined`: that answers per agent and is
  * false before a channel binds, so an operation guarded by it would take the local path for a
  * cluster agent that simply has no pod yet — and clone onto the daemon's disk.
  */
-let workspacesLiveInSandboxes = false
-
 export function setSandboxWorkspaceMode(enabled: boolean): void {
-  workspacesLiveInSandboxes = enabled
+  defaultWorkspaces.setSandboxMode(enabled)
 }
 
 /** The same answer for callers OUTSIDE this module — a seam that would otherwise `stat` a workspace
  *  path that names a filesystem this process cannot see. */
 export function sandboxWorkspaceMode(): boolean {
-  return workspacesLiveInSandboxes
+  return defaultWorkspaces.sandboxMode
 }
 
 /** Empty a path belonging to a cluster agent. A daemon with no clearer registered has no sandbox to
  *  reach, so there is nothing to empty — the local path never calls this. */
 async function clearSandboxPath(agentId: string, root: string): Promise<void> {
-  const error = await clearWorkspacePathInSandbox?.(agentId, root).catch((err: unknown) => (err as Error).message)
+  const error = await defaultWorkspaces.clearPath(agentId, root)
   if (error) {
     workspaceLog.warn(`workspace: could not empty ${root} for agent "${agentId}" after a failed clone (${error})`)
   }
@@ -224,7 +265,7 @@ async function clearSandboxPath(agentId: string, root: string): Promise<void> {
 /** Empty a cluster path the caller cannot proceed without. A conversion that kept the old checkout
  *  would clone into a non-empty directory, or converge the new origin onto the previous tree. */
 async function requireEmptiedSandboxPath(agentId: string, root: string): Promise<void> {
-  const error = await clearWorkspacePathInSandbox?.(agentId, root).catch((err: unknown) => (err as Error).message)
+  const error = await defaultWorkspaces.clearPath(agentId, root)
   if (error) throw new Error(`workspace: could not replace ${root} for agent "${agentId}" (${error})`)
 }
 
@@ -241,9 +282,9 @@ async function requireEmptiedSandboxPath(agentId: string, root: string): Promise
  * caller can reintroduce it by ordering its own checks differently.
  */
 export function consoleWorkspaceGitRunner(agentId: string, cwd?: string, abort?: AbortSignal): GitRunner | undefined {
-  const remote = resolveWorkspaceGitRunner?.(agentId, cwd, abort)
+  const remote = defaultWorkspaces.resolveGitRunner(agentId, cwd, abort)
   if (remote) return remote
-  if (workspacesLiveInSandboxes) return undefined
+  if (defaultWorkspaces.sandboxMode) return undefined
   return new LocalGitRunner(gitFor(cwd, abort), cwd, (env) => gitFor(cwd, abort).env(env))
 }
 
@@ -968,7 +1009,7 @@ export function consoleWorkspaceRoot(
   runtimeRoot: string | undefined,
   request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
 ): string | undefined {
-  if (local === undefined || !workspacesLiveInSandboxes) return local
+  if (local === undefined || !defaultWorkspaces.sandboxMode) return local
   refuseSessionIsolationInCluster(agent, request)
   return clusterWorkspaceCheckout(agent, runtimeRoot)
 }
@@ -1197,7 +1238,7 @@ export function additionalWorkspaceDirectories(
   request?: Pick<PrepareSessionWorkspaceRequest, 'sessionKey' | 'isolation'>
 ): string[] {
   if (agent.workspace.mode !== 'git-repo') return []
-  if (workspacesLiveInSandboxes) {
+  if (defaultWorkspaces.sandboxMode) {
     // `cwd` is in the POD's coordinates, which this daemon cannot `realpathSync` — the path exists
     // on no filesystem it can see, so the check below throws on the workspace it was handed. Undo
     // the lexical join `clusterWorkspaceCwd` made instead; the shim re-checks containment itself.
@@ -1306,7 +1347,7 @@ export async function prepareWorkspaceForActivation(
   // and writing the TARGET here would say it about a volume nothing has inspected — which cluster
   // preparation then reads back as proof of the repository, in a circle. Seeding at detach is a
   // different thing and stays: it names the definition the agent has been RUNNING on.
-  if (workspacesLiveInSandboxes) {
+  if (defaultWorkspaces.sandboxMode) {
     // Set, never taken back — not by the else branch of this condition, and not by the rollback
     // below, which is why there is nothing to roll back. `ensureHostAsync` runs before the ACK, so
     // preparation may already be replacing the volume when this activation is rejected, and no

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -2,15 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import {
-  additionalWorkspaceDirectories,
-  clusterWorkspaceCwd,
-  prepareClusterWorkspace,
-  prepareWorkspaceForActivation,
-  setSandboxWorkspaceMode,
-  setWorkspaceGitRunnerResolver,
-  setWorkspacePathClearer
-} from '../src/workspace/workspace-manager.js'
+import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
+
+// One plane per test file — the isolation Vitest's per-file module registry used to give.
+const workspaces = new WorkspaceManager()
 import {
   daemonGitCredentialTarget,
   initGitInjection,
@@ -128,15 +123,15 @@ beforeEach(() => {
   clearFails = false
   helperWriteFails = false
   // Every agent here runs in a pod, so both seams resolve to the sandbox.
-  setWorkspaceGitRunnerResolver((_agentId, cwd) => recordingRunner(cwd))
-  setWorkspacePathClearer(async (_agentId, root) => {
+  workspaces.setGitRunnerResolver((_agentId, cwd) => recordingRunner(cwd))
+  workspaces.setPathClearer(async (_agentId, root) => {
     cleared.push(root)
     // Emptying the checkout is precisely what makes the pod's probe stop finding one.
     if (root === CHECKOUT) checkoutExists = false
     if (clearFails) return 'permission denied'
     return undefined
   })
-  setSandboxWorkspaceMode(true)
+  workspaces.setSandboxMode(true)
   initGitInjection({
     targetFor: (agentId) =>
       agentId.startsWith('local-')
@@ -148,23 +143,25 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  setWorkspaceGitRunnerResolver(undefined)
-  setWorkspacePathClearer(undefined)
-  setSandboxWorkspaceMode(false)
+  workspaces.setGitRunnerResolver(undefined)
+  workspaces.setPathClearer(undefined)
+  workspaces.setSandboxMode(false)
 })
 
 describe('clusterWorkspaceCwd', () => {
   it('puts a checkout one level below the mount, away from the runtime HOME', () => {
     // The mount is also HOME=/agent: a working tree at the root would sit on top of `.claude` and
     // `.codex`, where git reports them as untracked and `git clean` would delete them.
-    expect(clusterWorkspaceCwd(clusterAgent(), POD_ROOT)).toBe(CHECKOUT)
+    expect(workspaces.clusterWorkspaceCwd(clusterAgent(), POD_ROOT)).toBe(CHECKOUT)
     // A from-scratch workspace keeps the root — it has no tree to confuse with HOME, and moving it
     // would strand every volume already provisioned.
-    expect(clusterWorkspaceCwd(clusterAgent({ mode: 'from-scratch' }), POD_ROOT)).toBe(POD_ROOT)
+    expect(workspaces.clusterWorkspaceCwd(clusterAgent({ mode: 'from-scratch' }), POD_ROOT)).toBe(POD_ROOT)
   })
 
   it('applies the configured working subdirectory inside the pod', () => {
-    expect(clusterWorkspaceCwd(clusterAgent({ agentDir: 'services/api' }), POD_ROOT)).toBe(`${CHECKOUT}/services/api`)
+    expect(workspaces.clusterWorkspaceCwd(clusterAgent({ agentDir: 'services/api' }), POD_ROOT)).toBe(
+      `${CHECKOUT}/services/api`
+    )
   })
 
   it('names the enclosing checkout in the POD coordinates the cwd is in', () => {
@@ -172,15 +169,17 @@ describe('clusterWorkspaceCwd', () => {
     // siblings. Deriving it the local way means `realpathSync` on a path that exists on no
     // filesystem this daemon can see — which throws, and takes every cluster session with it.
     const agent = clusterAgent({ agentDir: 'services/api' })
-    expect(additionalWorkspaceDirectories(agent, clusterWorkspaceCwd(agent, POD_ROOT))).toEqual([CHECKOUT])
+    expect(workspaces.additionalWorkspaceDirectories(agent, workspaces.clusterWorkspaceCwd(agent, POD_ROOT))).toEqual([
+      CHECKOUT
+    ])
     // No subdirectory means the cwd already IS the root, and a second copy of it says nothing.
-    expect(additionalWorkspaceDirectories(clusterAgent(), CHECKOUT)).toEqual([])
+    expect(workspaces.additionalWorkspaceDirectories(clusterAgent(), CHECKOUT)).toEqual([])
   })
 
   it('still refuses session isolation rather than half-supporting it', () => {
     // A logical-session worktree needs a daemon-owned parent, `worktree add` in the sandbox, and a
     // retention GC that reads the pod's tree — none of which this change provides.
-    expect(() => clusterWorkspaceCwd(clusterAgent(), POD_ROOT, { isolation: 'session' })).toThrow(
+    expect(() => workspaces.clusterWorkspaceCwd(clusterAgent(), POD_ROOT, { isolation: 'session' })).toThrow(
       /session-isolated workspaces are not supported/
     )
   })
@@ -188,7 +187,7 @@ describe('clusterWorkspaceCwd', () => {
 
 describe('preparing a cluster git-repo workspace', () => {
   it('asks the POD whether a checkout exists, and clones inside its fence when it does not', async () => {
-    const cwd = await prepareClusterWorkspace(clusterAgent(), POD_ROOT)
+    const cwd = await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT)
     expect(cwd).toBe(CHECKOUT)
 
     // The existence question went to the pod as git, not to this daemon as a file test.
@@ -213,7 +212,7 @@ describe('preparing a cluster git-repo workspace', () => {
   })
 
   it('pins the repo-local helper in the pod after cloning', async () => {
-    await prepareClusterWorkspace(clusterAgent(), POD_ROOT)
+    await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT)
     // `.git/config` outlives the launch, so the helper a later agent-run git finds has to be the
     // image's path — written through the runner, in the checkout.
     const helper = calls.filter((call) => call.args[0] === 'config' && call.args.includes('--add'))
@@ -224,7 +223,7 @@ describe('preparing a cluster git-repo workspace', () => {
 
   it('pulls an existing checkout instead of cloning over it', async () => {
     checkoutExists = true
-    await prepareClusterWorkspace(clusterAgent(), POD_ROOT)
+    await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT)
 
     expect(calls.some((call) => call.args[0] === 'clone')).toBe(false)
     const pull = calls.find((call) => call.args[0] === 'pull')
@@ -241,7 +240,7 @@ describe('preparing a cluster git-repo workspace', () => {
     // treated as a different workspace.
     checkoutExists = true
     originUrl = 'https://github.com/acme/old-name.git'
-    await prepareClusterWorkspace(clusterAgent(), POD_ROOT)
+    await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT)
     const setUrl = calls.find((call) => call.args[0] === 'remote' && call.args[1] === 'set-url')
     expect(setUrl).toMatchObject({
       cwd: CHECKOUT,
@@ -254,7 +253,9 @@ describe('preparing a cluster git-repo workspace', () => {
     // have daemon-managed git run against whatever origin it carries.
     checkoutExists = true
     originUrl = 'https://evil.example/acme/private.git'
-    await expect(prepareClusterWorkspace(clusterAgent(), POD_ROOT)).rejects.toThrow(/not a trusted GitHub remote/)
+    await expect(workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT)).rejects.toThrow(
+      /not a trusted GitHub remote/
+    )
     expect(calls.some((call) => call.args[0] === 'pull')).toBe(false)
   })
 
@@ -262,18 +263,18 @@ describe('preparing a cluster git-repo workspace', () => {
     // Left behind, git would refuse to clone into a non-empty directory forever after, while the
     // probe kept saying there is no usable checkout. There is no `rmSync` that can reach it.
     cloneFails = true
-    await expect(prepareClusterWorkspace(clusterAgent(), POD_ROOT)).rejects.toThrow(/remote hung up/)
+    await expect(workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT)).rejects.toThrow(/remote hung up/)
     expect(cleared).toEqual([CHECKOUT])
   })
 
   it('does no git at all for a from-scratch cluster workspace', async () => {
-    const cwd = await prepareClusterWorkspace(clusterAgent({ mode: 'from-scratch' }), POD_ROOT)
+    const cwd = await workspaces.prepareClusterWorkspace(clusterAgent({ mode: 'from-scratch' }), POD_ROOT)
     expect(cwd).toBe(POD_ROOT)
     expect(calls).toEqual([])
   })
 
   it('falls back to the historical mount when a legacy shim reported none', async () => {
-    const cwd = await prepareClusterWorkspace(clusterAgent(), undefined)
+    const cwd = await workspaces.prepareClusterWorkspace(clusterAgent(), undefined)
     expect(cwd).toBe(CHECKOUT)
   })
 })
@@ -295,7 +296,7 @@ describe('replacing a cluster workspace in place', () => {
   async function withProvenMarker(overrides: Partial<Agent['workspace']> = {}): Promise<Agent> {
     const agent = bookkeepingAgent(overrides)
     checkoutExists = false
-    await prepareClusterWorkspace(agent, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(agent, POD_ROOT)
     calls.length = 0
     return agent
   }
@@ -305,9 +306,9 @@ describe('replacing a cluster workspace in place', () => {
     // clones, or has one that convergence fixes. Refusing here would make a git-repo cluster agent
     // impossible to create at all, since `replace` is true whenever there is no previous marker.
     const agent = bookkeepingAgent()
-    await expect(prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })).resolves.toBeTypeOf(
-      'function'
-    )
+    await expect(
+      workspaces.prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
+    ).resolves.toBeTypeOf('function')
     expect(calls).toEqual([])
   })
 
@@ -316,16 +317,16 @@ describe('replacing a cluster workspace in place', () => {
     // has inspected, and cluster preparation then treats that as attestation of the repository. So an
     // existing unproven volume with a failing pull would be accepted.
     const agent = bookkeepingAgent()
-    await prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
+    await workspaces.prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
 
     checkoutExists = true
     pullFails = true
-    await prepareClusterWorkspace(agent, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(agent, POD_ROOT)
     // Still unproven, so a conversion stays detectable rather than being silently accepted.
     const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
-    await expect(prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })).resolves.toBeTypeOf(
-      'function'
-    )
+    await expect(
+      workspaces.prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    ).resolves.toBeTypeOf('function')
   })
 
   it('lets a rollback and a same-workspace repair through, which a blanket refusal stranded', async () => {
@@ -333,10 +334,10 @@ describe('replacing a cluster workspace in place', () => {
     // it with `reconcileWorkspace`. When that restoration was refused too, the agent stayed staged
     // and offline — the failure the refusal was supposed to prevent, made permanent.
     const agent = await withProvenMarker()
-    await expect(prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })).resolves.toBeTypeOf(
-      'function'
-    )
-    await expect(prepareWorkspaceForActivation(agent)).resolves.toBeTypeOf('function')
+    await expect(
+      workspaces.prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
+    ).resolves.toBeTypeOf('function')
+    await expect(workspaces.prepareWorkspaceForActivation(agent)).resolves.toBeTypeOf('function')
   })
 
   it('refreshes the marker after preparation, so a rename elsewhere does not strand a repair', async () => {
@@ -351,12 +352,12 @@ describe('replacing a cluster workspace in place', () => {
     } as Agent
     checkoutExists = true
     originUrl = 'https://github.com/acme/private.git'
-    await prepareClusterWorkspace(renamed, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(renamed, POD_ROOT)
     expect(calls.some((call) => call.args[0] === 'remote' && call.args[1] === 'set-url')).toBe(true)
 
-    await expect(prepareWorkspaceForActivation(renamed, { reconcileMaterialization: true })).resolves.toBeTypeOf(
-      'function'
-    )
+    await expect(
+      workspaces.prepareWorkspaceForActivation(renamed, { reconcileMaterialization: true })
+    ).resolves.toBeTypeOf('function')
   })
 
   it('leaves the marker alone when a divergent branch keeps the volume on the old one', async () => {
@@ -369,13 +370,13 @@ describe('replacing a cluster workspace in place', () => {
     checkoutExists = true
     headBranch = 'main' // the volume never left `main`
     pullFails = true
-    await prepareClusterWorkspace(moved, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(moved, POD_ROOT)
 
     // Unproven, so the edit's replacement is still due: the next preparation empties the checkout
     // and clones the configured branch rather than serving `main` forever.
-    await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    await workspaces.prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
     calls.length = 0
-    await prepareClusterWorkspace(moved, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(moved, POD_ROOT)
     expect(cleared).toEqual([CHECKOUT])
     expect(calls.find((call) => call.args[0] === 'clone')?.args).toContain('release')
   })
@@ -385,10 +386,10 @@ describe('replacing a cluster workspace in place', () => {
     const moved = { ...agent, workspace: { ...agent.workspace, gitBranch: 'release' } } as Agent
     checkoutExists = true
     headBranch = 'release' // the volume IS on it, and the pull succeeded
-    await prepareClusterWorkspace(moved, POD_ROOT)
-    await expect(prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })).resolves.toBeTypeOf(
-      'function'
-    )
+    await workspaces.prepareClusterWorkspace(moved, POD_ROOT)
+    await expect(
+      workspaces.prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    ).resolves.toBeTypeOf('function')
   })
 
   it('will not trust a rewritten origin that no successful pull backs up, on ANY attempt', async () => {
@@ -404,22 +405,22 @@ describe('replacing a cluster workspace in place', () => {
     checkoutExists = true
     originUrl = 'https://github.com/acme/private.git' // convergence has to rewrite it
     pullFails = true
-    await prepareClusterWorkspace(renamed, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(renamed, POD_ROOT)
 
     // SECOND attempt: `set-url` persisted, so the origin already matches and nothing is rewritten
     // this time. Keyed off that, the proof would evaporate and the marker would advance over a tree
     // no pull has ever reached.
     originUrl = 'https://github.com/acme/renamed.git'
-    await prepareClusterWorkspace(renamed, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(renamed, POD_ROOT)
     // Nothing an EDIT asked for, so the unproven volume is left in place rather than replaced.
     expect(cleared).toEqual([])
 
     // And once a pull from the new origin does succeed, it is proven and recorded.
     pullFails = false
-    await prepareClusterWorkspace(renamed, POD_ROOT)
-    await expect(prepareWorkspaceForActivation(renamed, { reconcileMaterialization: true })).resolves.toBeTypeOf(
-      'function'
-    )
+    await workspaces.prepareClusterWorkspace(renamed, POD_ROOT)
+    await expect(
+      workspaces.prepareWorkspaceForActivation(renamed, { reconcileMaterialization: true })
+    ).resolves.toBeTypeOf('function')
     expect(cleared).toEqual([])
   })
 
@@ -429,14 +430,14 @@ describe('replacing a cluster workspace in place', () => {
     // rollback that cannot restore it. It records the intent; the pod's preparation carries it out.
     const agent = await withProvenMarker()
     const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
-    await expect(prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })).resolves.toBeTypeOf(
-      'function'
-    )
+    await expect(
+      workspaces.prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    ).resolves.toBeTypeOf('function')
     expect(calls).toEqual([])
     expect(cleared).toEqual([])
 
     checkoutExists = true
-    await prepareClusterWorkspace(moved, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(moved, POD_ROOT)
     // Emptied, then re-cloned from the new repository — the replacement the edit asked for.
     expect(cleared).toEqual([CHECKOUT])
     expect(calls.find((call) => call.args[0] === 'clone')?.args).toContain('https://github.com/acme/other.git')
@@ -449,11 +450,11 @@ describe('replacing a cluster workspace in place', () => {
     // file — is what ends the conversion. A leftover intent must not re-wipe a converged volume.
     const agent = await withProvenMarker()
     const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
-    await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    await workspaces.prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
     checkoutExists = true
-    await prepareClusterWorkspace(moved, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(moved, POD_ROOT)
     checkoutExists = true
-    await prepareClusterWorkspace(moved, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(moved, POD_ROOT)
     expect(cleared).toEqual([CHECKOUT])
   })
 
@@ -463,11 +464,11 @@ describe('replacing a cluster workspace in place', () => {
     // the restored definition's marker still proves the volume, so nothing is replaced.
     const agent = await withProvenMarker()
     const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
-    const rollback = await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    const rollback = await workspaces.prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
     rollback()
 
     checkoutExists = true
-    await prepareClusterWorkspace(agent, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(agent, POD_ROOT)
     expect(cleared).toEqual([])
     expect(calls.some((call) => call.args[0] === 'clone')).toBe(false)
   })
@@ -480,17 +481,17 @@ describe('replacing a cluster workspace in place', () => {
     // would send that rollback down the converge-and-pull path over the rejected tree.
     const agent = await withProvenMarker()
     const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
-    await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    await workspaces.prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
     checkoutExists = true
     helperWriteFails = true
-    await expect(prepareClusterWorkspace(moved, POD_ROOT)).rejects.toThrow(/helper pin refused/)
+    await expect(workspaces.prepareClusterWorkspace(moved, POD_ROOT)).rejects.toThrow(/helper pin refused/)
 
     helperWriteFails = false
     cleared.length = 0
     calls.length = 0
-    await prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
+    await workspaces.prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
     checkoutExists = true
-    await prepareClusterWorkspace(agent, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(agent, POD_ROOT)
     expect(cleared).toEqual([CHECKOUT])
     expect(calls.find((call) => call.args[0] === 'clone')?.args).toContain('https://github.com/acme/private.git')
     // Never the alternative: repointing the rejected tree at the original origin and pulling.
@@ -503,9 +504,9 @@ describe('replacing a cluster workspace in place', () => {
   async function rejectedAfterConversion(runRollback: boolean): Promise<Agent> {
     const agent = await withProvenMarker()
     const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
-    const rollback = await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    const rollback = await workspaces.prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
     checkoutExists = true
-    await prepareClusterWorkspace(moved, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(moved, POD_ROOT)
     if (runRollback) rollback()
     cleared.length = 0
     calls.length = 0
@@ -518,9 +519,9 @@ describe('replacing a cluster workspace in place', () => {
     // own rollback would be ACKed onto it, silently, with pull failures degrading as usual.
     const original = await rejectedAfterConversion(true)
 
-    await prepareWorkspaceForActivation(original, { reconcileMaterialization: true })
+    await workspaces.prepareWorkspaceForActivation(original, { reconcileMaterialization: true })
     checkoutExists = true
-    await prepareClusterWorkspace(original, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(original, POD_ROOT)
     expect(cleared).toEqual([CHECKOUT])
     expect(calls.find((call) => call.args[0] === 'clone')?.args).toContain('https://github.com/acme/private.git')
   })
@@ -530,9 +531,9 @@ describe('replacing a cluster workspace in place', () => {
     // depend on a rollback closure that a crash — or a failure path that forgets it — never calls.
     const original = await rejectedAfterConversion(false)
 
-    await prepareWorkspaceForActivation(original, { reconcileMaterialization: true })
+    await workspaces.prepareWorkspaceForActivation(original, { reconcileMaterialization: true })
     checkoutExists = true
-    await prepareClusterWorkspace(original, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(original, POD_ROOT)
     expect(cleared).toEqual([CHECKOUT])
     expect(calls.find((call) => call.args[0] === 'clone')?.args).toContain('https://github.com/acme/private.git')
   })
@@ -542,10 +543,10 @@ describe('replacing a cluster workspace in place', () => {
     // the previous repository's tree and serve it as the new workspace.
     const agent = await withProvenMarker()
     const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
-    await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    await workspaces.prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
     checkoutExists = true
     clearFails = true
-    await expect(prepareClusterWorkspace(moved, POD_ROOT)).rejects.toThrow(/could not replace/)
+    await expect(workspaces.prepareClusterWorkspace(moved, POD_ROOT)).rejects.toThrow(/could not replace/)
     expect(calls.some((call) => call.args[0] === 'clone')).toBe(false)
   })
 
@@ -554,14 +555,14 @@ describe('replacing a cluster workspace in place', () => {
     // left behind would sit in the scratch workspace as the previous repository's working tree.
     const agent = await withProvenMarker()
     const scratch = { ...agent, workspace: { ...agent.workspace, mode: 'from-scratch' } } as Agent
-    await prepareWorkspaceForActivation(scratch, { reconcileMaterialization: true })
+    await workspaces.prepareWorkspaceForActivation(scratch, { reconcileMaterialization: true })
     checkoutExists = true
-    expect(await prepareClusterWorkspace(scratch, POD_ROOT)).toBe(POD_ROOT)
+    expect(await workspaces.prepareClusterWorkspace(scratch, POD_ROOT)).toBe(POD_ROOT)
     expect(cleared).toEqual([CHECKOUT])
     expect(calls).toEqual([])
 
     // And the marker now says scratch, so the next session does not empty it again.
-    await prepareClusterWorkspace(scratch, POD_ROOT)
+    await workspaces.prepareClusterWorkspace(scratch, POD_ROOT)
     expect(cleared).toEqual([CHECKOUT])
   })
 
@@ -570,9 +571,9 @@ describe('replacing a cluster workspace in place', () => {
     // volume is not involved, so refusing here would break the mode that already works. A real path,
     // because this one legitimately does touch this disk.
     const path = join(mkdtempSync(join(tmpdir(), 'ac-cluster-scratch-')), 'workspace')
-    await expect(prepareWorkspaceForActivation(clusterAgent({ mode: 'from-scratch', path }))).resolves.toBeTypeOf(
-      'function'
-    )
+    await expect(
+      workspaces.prepareWorkspaceForActivation(clusterAgent({ mode: 'from-scratch', path }))
+    ).resolves.toBeTypeOf('function')
     rmSync(dirname(path), { recursive: true, force: true })
   })
 })

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -28,8 +28,11 @@ import {
 import { GithubReplyCollector } from '../src/github/poster.js'
 import { transcriptCoords } from '../src/session/session-manager.js'
 import { sessionKey } from '../src/store/local-store.js'
-import { sessionWorktreePath } from '../src/workspace/workspace-manager.js'
+import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
 import { FakeClock } from '@agentconnect.md/connection'
+
+// One plane per test file — the isolation Vitest's per-file module registry used to give.
+const workspaces = new WorkspaceManager()
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -1497,7 +1500,7 @@ describe('Daemon rd/msg hook fires', () => {
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
       const agent = (daemon as any).agents.get(AGENT_ID)
       const key = sessionKey('hook', 'acme/infra', '42', AGENT_ID, 'github:123')
-      const worktree = sessionWorktreePath(agent, key)
+      const worktree = workspaces.sessionWorktreePath(agent, key)
       mkdirSync(join(agentDir, 'worktrees'), { recursive: true })
       execFileSync('git', ['worktree', 'add', '--detach', worktree, 'HEAD'], { cwd: workspace, stdio: 'ignore' })
       ;(daemon as any).store.upsertSession({

--- a/packages/daemon/test/no-stray-vi-mock.test.ts
+++ b/packages/daemon/test/no-stray-vi-mock.test.ts
@@ -1,0 +1,36 @@
+// The `daemon` project runs with `isolate: false`, which shares one module registry per worker. A
+// `vi.mock` call is registered per file but rewires the registry, so a file that mocks while sharing
+// either misses its own mock or leaks it into a later file — and both fail in ways that read as
+// product bugs (`workspace.test.ts` surfaced as "fatal: not a git repository", because real git ran).
+//
+// vitest.config.ts therefore routes the mocking files to a second, isolated project. This test is
+// what keeps that list honest: add `vi.mock` to a file and it fails here, at the seam, instead of
+// somewhere unrelated depending on which worker happened to run the two files together.
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { MOCKING_TESTS } from '../vitest.config.js'
+
+const testRoot = fileURLToPath(new URL('.', import.meta.url))
+
+function testFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) return testFiles(full)
+    return entry.endsWith('.test.ts') ? [full] : []
+  })
+}
+
+describe('vi.mock routing', () => {
+  it('lists exactly the files that call vi.mock', () => {
+    const mocking = testFiles(testRoot)
+      .filter((file) => /(?<![\w.])vi\s*\.\s*mock\s*\(/.test(readFileSync(file, 'utf8')))
+      .map((file) => `test/${relative(testRoot, file)}`.replaceAll('\\', '/'))
+      .sort()
+
+    // Both directions matter: an unlisted mocking file breaks under the shared registry, and a
+    // listed file that no longer mocks pays for isolation it does not need.
+    expect(mocking).toEqual([...MOCKING_TESTS].sort())
+  })
+})

--- a/packages/daemon/test/workspace-files-routing.test.ts
+++ b/packages/daemon/test/workspace-files-routing.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createWorkspaceReader, WorkspaceViolationError } from '../src/cp/workspace-reader.js'
 import { createLocalSkillsReader } from '../src/cp/local-skills-reader.js'
-import { setSandboxWorkspaceMode, setWorkspaceGitRunnerResolver } from '../src/workspace/workspace-manager.js'
+import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
+
+// One plane per test file — the isolation Vitest's per-file module registry used to give.
+const workspaces = new WorkspaceManager()
 import { localWorkspaceFiles, type WorkspaceFiles } from '../src/workspace/workspace-files.js'
 
 /**
@@ -53,6 +56,7 @@ describe('createWorkspaceReader routing', () => {
   it('lists the workspace filesystem, not this daemon disk', async () => {
     const { daemonSide, podSide } = split()
     const reader = createWorkspaceReader(
+      workspaces,
       () => ({ root: daemonSide, scratch: true }),
       pass,
       () => filesAt(podSide)
@@ -64,6 +68,7 @@ describe('createWorkspaceReader routing', () => {
   it('reads and WRITES there too, so an edit is not published to a directory nobody runs in', async () => {
     const { daemonSide, podSide } = split()
     const reader = createWorkspaceReader(
+      workspaces,
       () => ({ root: daemonSide, scratch: true }),
       pass,
       () => filesAt(podSide)
@@ -83,6 +88,7 @@ describe('createWorkspaceReader routing', () => {
     let asked = false
     const files = filesAt(podSide)
     const reader = createWorkspaceReader(
+      workspaces,
       () => ({ root: daemonSide, scratch: false }),
       pass,
       () => ({
@@ -103,7 +109,7 @@ describe('createWorkspaceReader routing', () => {
 
   it('falls back to this filesystem when no seam is registered, so self-hosting needs no wiring', async () => {
     const { daemonSide } = split()
-    const reader = createWorkspaceReader(() => ({ root: daemonSide, scratch: true }), pass)
+    const reader = createWorkspaceReader(workspaces, () => ({ root: daemonSide, scratch: true }), pass)
     const page = await reader.list({ agentId: AGENT, path: '', limit: 50 })
     expect(page.entries.map((entry) => entry.name)).toEqual(['STALE-DAEMON-COPY.txt'])
   })
@@ -111,7 +117,7 @@ describe('createWorkspaceReader routing', () => {
 
 describe('createLocalSkillsReader routing', () => {
   // The mode is module state, so leaving it set makes the NEXT test read as a cluster daemon.
-  afterEach(() => setSandboxWorkspaceMode(false))
+  afterEach(() => workspaces.setSandboxMode(false))
 
   function skill(root: string, dir: string, name: string, description: string): void {
     mkdirSync(join(root, '.claude', 'skills', dir), { recursive: true })
@@ -128,6 +134,7 @@ describe('createLocalSkillsReader routing', () => {
     skill(podSide, 'deploy', 'deploy', 'ship it')
     skill(daemonSide, 'ghost', 'ghost', 'must not appear')
     const reader = createLocalSkillsReader(
+      workspaces,
       () => podSide,
       join(daemonSide, 'skill-installs'),
       () => filesAt(podSide)
@@ -142,6 +149,7 @@ describe('createLocalSkillsReader routing', () => {
     const { daemonSide } = split()
     const missing = join(daemonSide, 'not-created-yet')
     const reader = createLocalSkillsReader(
+      workspaces,
       () => missing,
       daemonSide,
       () => filesAt(missing)
@@ -151,13 +159,14 @@ describe('createLocalSkillsReader routing', () => {
 
   it('does not read this daemon disk for an unbound cluster agent', async () => {
     const { daemonSide, podSide } = split()
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     // The root is already in POD coordinates, so an `existsSync`/`listLocalSkills` fallback inspects
     // whatever sits at that path HERE — the daemon-disk fallback the git and file seams had removed,
     // still open on the skills surface. Unreachable reports unmaterialized; the wire has no third
     // answer, and reporting a listing of this filesystem would be worse than saying "not prepared".
     skill(daemonSide, 'ghost', 'ghost', 'must not appear')
     const reader = createLocalSkillsReader(
+      workspaces,
       () => daemonSide,
       join(podSide, 'skill-installs'),
       () => undefined
@@ -168,7 +177,7 @@ describe('createLocalSkillsReader routing', () => {
   it('still reads this daemon own workspace when no seam is registered', async () => {
     const { daemonSide } = split()
     skill(daemonSide, 'local-one', 'local-one', 'on this disk')
-    const reader = createLocalSkillsReader(() => daemonSide, join(daemonSide, 'skill-installs'))
+    const reader = createLocalSkillsReader(workspaces, () => daemonSide, join(daemonSide, 'skill-installs'))
     const answer = await reader.list({ agentId: AGENT })
     expect(answer.materialized).toBe(true)
     expect(answer.skills.map((entry) => entry.name)).toEqual(['local-one'])
@@ -181,15 +190,15 @@ describe('an unreachable sandbox workspace', () => {
   // that, because the alternatives are the two answers a reader cannot act on: "not a git checkout"
   // and an empty file tree, each about a workspace that is fine.
   afterEach(() => {
-    setSandboxWorkspaceMode(false)
-    setWorkspaceGitRunnerResolver(undefined)
+    workspaces.setSandboxMode(false)
+    workspaces.setGitRunnerResolver(undefined)
   })
 
   it('is a refusal with a machine-readable reason, not an empty listing', async () => {
     const { daemonSide } = split()
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     // No seam registered for this agent — exactly what the plane answers with no bound channel.
-    const reader = createWorkspaceReader(() => ({ root: '/agent', scratch: true }), pass)
+    const reader = createWorkspaceReader(workspaces, () => ({ root: '/agent', scratch: true }), pass)
     for (const read of [
       () => reader.list({ agentId: AGENT, path: '', limit: 50 }),
       () => reader.read({ agentId: AGENT, path: 'app.ts', offset: 0, limit: 65_536 })
@@ -208,8 +217,9 @@ describe('an unreachable sandbox workspace', () => {
 
   it('says nothing of the kind once a channel is bound', async () => {
     const { daemonSide, podSide } = split()
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     const reader = createWorkspaceReader(
+      workspaces,
       () => ({ root: daemonSide, scratch: true }),
       pass,
       () => filesAt(podSide)
@@ -225,8 +235,8 @@ describe('a channel that drops between resolutions', () => {
   // coordinates. Reads would report an empty workspace; a create would `mkdir -p` that pod path here
   // and publish into it. Both seams resolve once and hold what they got.
   afterEach(() => {
-    setSandboxWorkspaceMode(false)
-    setWorkspaceGitRunnerResolver(undefined)
+    workspaces.setSandboxMode(false)
+    workspaces.setGitRunnerResolver(undefined)
   })
 
   /** Answers the first call and nothing after it — a detach timed to land between two resolutions. */
@@ -241,8 +251,9 @@ describe('a channel that drops between resolutions', () => {
 
   it('does not publish a scratch file onto this disk when the channel drops mid-request', async () => {
     const { daemonSide, podSide } = split()
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     const reader = createWorkspaceReader(
+      workspaces,
       // A root in POD coordinates, as the real resolver returns: what a local fallback would create.
       () => ({ root: join(daemonSide, 'agent-repo'), scratch: true }),
       pass,
@@ -256,8 +267,9 @@ describe('a channel that drops between resolutions', () => {
 
   it('does not read this disk when the channel drops mid-request', async () => {
     const { daemonSide, podSide } = split()
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     const reader = createWorkspaceReader(
+      workspaces,
       () => ({ root: daemonSide, scratch: true }),
       pass,
       detachAfterFirst(filesAt(podSide))

--- a/packages/daemon/test/workspace-git-read.test.ts
+++ b/packages/daemon/test/workspace-git-read.test.ts
@@ -7,7 +7,10 @@ import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
 import { createWorkspaceGit } from '../src/cp/workspace-git.js'
 import { WorkspaceViolationError } from '../src/cp/workspace-reader.js'
 import { gitFor, workspaceGitLocalEnv } from '../src/workspace/git-injection.js'
-import { setSandboxWorkspaceMode, setWorkspaceGitRunnerResolver } from '../src/workspace/workspace-manager.js'
+import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
+
+// One plane per test file — the isolation Vitest's per-file module registry used to give.
+const workspaces = new WorkspaceManager()
 import { LocalGitRunner } from '../src/workspace/git-runner.js'
 
 // The seam's git reads against a REAL repository: the mocked-simple-git suite
@@ -66,7 +69,9 @@ beforeAll(() => {
   git(repo, 'add', 'logo.png')
   writeFileSync(join(repo, 'untracked.txt'), 'brand new\n')
 
-  seam = createWorkspaceGit((agentId) => (agentId === AGENT ? repo : agentId === 'scratch-agent' ? scratch : undefined))
+  seam = createWorkspaceGit(workspaces, (agentId) =>
+    agentId === AGENT ? repo : agentId === 'scratch-agent' ? scratch : undefined
+  )
 })
 
 afterAll(() => rmSync(base, { recursive: true, force: true }))
@@ -145,7 +150,11 @@ describe('createWorkspaceGit.diff against a real repo', () => {
     git(doomed, 'add', '-A')
     git(doomed, 'commit', '-m', 'add doomed.txt')
     rmSync(join(doomed, 'doomed.txt'))
-    const d = await createWorkspaceGit(() => doomed).diff({ agentId: AGENT, path: 'doomed.txt', staged: false })
+    const d = await createWorkspaceGit(workspaces, () => doomed).diff({
+      agentId: AGENT,
+      path: 'doomed.txt',
+      staged: false
+    })
     expect(d.exists).toBe(true) // the path is gone from disk, but its CHANGE is what was asked for
     expect(d.diff).toContain('-here for now')
   })
@@ -289,6 +298,7 @@ describe('createWorkspaceGit.log against a real repo', () => {
 
     const seamFor = (root: string) =>
       createWorkspaceGit(
+        workspaces,
         () => root,
         () => ({}),
         () => target
@@ -332,7 +342,7 @@ describe('createWorkspaceGit.log against a real repo', () => {
     writeFileSync(join(orphan, 'a.txt'), 'a\n')
     git(orphan, 'add', '-A')
     git(orphan, 'commit', '-m', 'only commit')
-    const l = await createWorkspaceGit(() => orphan).log({ agentId: AGENT, limit: 20 })
+    const l = await createWorkspaceGit(workspaces, () => orphan).log({ agentId: AGENT, limit: 20 })
     expect(l.tracking).toBeUndefined()
     expect(l.commits).toHaveLength(1)
     expect(l.commits[0]!.pushed).toBe(false) // no upstream ⇒ not known to be on a remote
@@ -346,7 +356,7 @@ describe('createWorkspaceGit.log against a real repo', () => {
     git(fresh, 'init', '-b', 'main')
     writeFileSync(join(fresh, 'a.ts'), 'x\n')
     git(fresh, 'add', 'a.ts')
-    const s = await createWorkspaceGit(() => fresh).status(AGENT)
+    const s = await createWorkspaceGit(workspaces, () => fresh).status(AGENT)
     expect(s.isRepo).toBe(true)
     expect(s.files?.map((f) => f.path)).toEqual(['a.ts'])
     expect(s.files?.[0]).not.toHaveProperty('additions')
@@ -373,13 +383,13 @@ describe('createWorkspaceGit.log against a real repo', () => {
     const nowhere = join(base, 'no-daemon-checkout')
     mkdirSync(nowhere, { recursive: true })
 
-    setWorkspaceGitRunnerResolver(() => answering as never)
+    workspaces.setGitRunnerResolver(() => answering as never)
     try {
-      const status = await createWorkspaceGit(() => nowhere).status(AGENT)
+      const status = await createWorkspaceGit(workspaces, () => nowhere).status(AGENT)
       expect(status.isRepo).toBe(true)
       expect(seen.some((args) => args.includes('--show-prefix'))).toBe(true)
     } finally {
-      setWorkspaceGitRunnerResolver(undefined)
+      workspaces.setGitRunnerResolver(undefined)
     }
   })
 
@@ -398,7 +408,7 @@ describe('createWorkspaceGit.log against a real repo', () => {
     git(broken, 'commit', '-m', 'seed')
     rmSync(join(broken, '.git', 'objects'), { recursive: true, force: true })
 
-    expect(await createWorkspaceGit(() => broken).log({ agentId: AGENT, limit: 20 })).toEqual({
+    expect(await createWorkspaceGit(workspaces, () => broken).log({ agentId: AGENT, limit: 20 })).toEqual({
       agentId: AGENT,
       isRepo: false,
       commits: [],
@@ -410,7 +420,7 @@ describe('createWorkspaceGit.log against a real repo', () => {
     const empty = join(base, 'empty')
     mkdirSync(empty, { recursive: true })
     git(empty, 'init', '-b', 'main')
-    expect(await createWorkspaceGit(() => empty).log({ agentId: AGENT, limit: 20 })).toEqual({
+    expect(await createWorkspaceGit(workspaces, () => empty).log({ agentId: AGENT, limit: 20 })).toEqual({
       agentId: AGENT,
       isRepo: true,
       commits: [],
@@ -431,7 +441,7 @@ describe('createWorkspaceGit.log against a real repo', () => {
     writeFileSync(join(shouty, 'a.txt'), 'a\n')
     git(shouty, 'add', '-A')
     git(shouty, 'commit', '-m', 'x'.repeat(5_000))
-    const l = await createWorkspaceGit(() => shouty).log({ agentId: AGENT, limit: 20 })
+    const l = await createWorkspaceGit(workspaces, () => shouty).log({ agentId: AGENT, limit: 20 })
     expect(l.commits[0]!.subject).toHaveLength(200)
   })
 
@@ -448,16 +458,16 @@ describe('createWorkspaceGit against a workspace this daemon cannot see', () => 
   let clusterSeam: ReturnType<typeof createWorkspaceGit>
 
   beforeAll(() => {
-    setSandboxWorkspaceMode(true)
-    setWorkspaceGitRunnerResolver(
+    workspaces.setSandboxMode(true)
+    workspaces.setGitRunnerResolver(
       (_agentId, _cwd, abort) => new LocalGitRunner(gitFor(repo, abort), repo, (e) => gitFor(repo, abort).env(e))
     )
-    clusterSeam = createWorkspaceGit((agentId) => (agentId === AGENT ? POD_ROOT : undefined))
+    clusterSeam = createWorkspaceGit(workspaces, (agentId) => (agentId === AGENT ? POD_ROOT : undefined))
   })
 
   afterAll(() => {
-    setSandboxWorkspaceMode(false)
-    setWorkspaceGitRunnerResolver(undefined)
+    workspaces.setSandboxMode(false)
+    workspaces.setGitRunnerResolver(undefined)
   })
 
   it('reads the checkout at all — this is what answered isRepo:false over a real repository', async () => {

--- a/packages/daemon/test/workspace-git-runner-seam.test.ts
+++ b/packages/daemon/test/workspace-git-runner-seam.test.ts
@@ -4,16 +4,10 @@ import { createHash } from 'node:crypto'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import {
-  clusterWorkspaceCwd,
-  consoleWorkspaceRoot,
-  prefetchWorkspace,
-  removeSessionWorktree,
-  sessionWorktreeRoot,
-  setSandboxWorkspaceMode,
-  setWorkspaceGitRunnerResolver,
-  type WorkspaceGitRunnerResolver
-} from '../src/workspace/workspace-manager.js'
+import { WorkspaceManager, type WorkspaceGitRunnerResolver } from '../src/workspace/workspace-manager.js'
+
+// One plane per test file — the isolation Vitest's per-file module registry used to give.
+const workspaces = new WorkspaceManager()
 import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
 import { gitFor } from '../src/workspace/git-injection.js'
 import type { Agent } from '../src/agents/agent-schema.js'
@@ -25,8 +19,8 @@ import type { Agent } from '../src/agents/agent-schema.js'
 const roots: string[] = []
 
 afterEach(() => {
-  setWorkspaceGitRunnerResolver(undefined)
-  setSandboxWorkspaceMode(false)
+  workspaces.setGitRunnerResolver(undefined)
+  workspaces.setSandboxMode(false)
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
 
@@ -83,7 +77,7 @@ function agentWithWorktree(sessionKey: string): { agent: Agent; worktree: string
 
   // The real worktree the removal path judges, registered by real git.
   const id = createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)
-  const worktree = join(sessionWorktreeRoot(agent), id)
+  const worktree = join(workspaces.sessionWorktreeRoot(agent), id)
   mkdirSync(dirname(worktree), { recursive: true })
   git(path, ['worktree', 'add', '--detach', worktree, 'HEAD'])
   return { agent, worktree }
@@ -155,9 +149,9 @@ describe('workspace-manager git runner seam', () => {
   it('routes worktree removal through the resolver, with the agent it belongs to', async () => {
     const { agent, worktree } = agentWithWorktree('session-1')
     const { resolver, calls, argv } = recording()
-    setWorkspaceGitRunnerResolver(resolver)
+    workspaces.setGitRunnerResolver(resolver)
 
-    const outcome = await removeSessionWorktree(agent, 'session-1')
+    const outcome = await workspaces.removeSessionWorktree(agent, 'session-1')
 
     // Real removal against a real worktree — the outcome proves the routed argv actually ran.
     expect(outcome).toEqual({ outcome: 'removed' })
@@ -177,20 +171,20 @@ describe('workspace-manager git runner seam', () => {
     const { agent, worktree } = agentWithWorktree('session-2')
     writeFileSync(join(worktree, 'dirty.txt'), 'x\n')
     const { resolver } = recording()
-    setWorkspaceGitRunnerResolver(resolver)
+    workspaces.setGitRunnerResolver(resolver)
 
     // The decision must come from the runner's answer, not from this daemon's own disk.
-    expect(await removeSessionWorktree(agent, 'session-2')).toEqual({ outcome: 'retained', reason: 'dirty' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-2')).toEqual({ outcome: 'retained', reason: 'dirty' })
     expect(existsSync(worktree)).toBe(true)
   })
 
   it('cannot be bypassed: a refusing resolver stops the operation instead of falling back', async () => {
     const { agent, worktree } = agentWithWorktree('session-3')
     // A site still reaching git directly would succeed despite the seam refusing everything.
-    setWorkspaceGitRunnerResolver(() => {
+    workspaces.setGitRunnerResolver(() => {
       throw new Error('seam refused')
     })
-    const outcome = await removeSessionWorktree(agent, 'session-3')
+    const outcome = await workspaces.removeSessionWorktree(agent, 'session-3')
     expect(outcome.outcome).toBe('failed')
     expect(existsSync(worktree)).toBe(true)
   })
@@ -198,7 +192,7 @@ describe('workspace-manager git runner seam', () => {
   it('leaves the local path unregistered, so a self-hosted daemon needs no wiring', async () => {
     const { agent, worktree } = agentWithWorktree('session-4')
     // No resolver installed: undefined means local, and the default must still work.
-    expect(await removeSessionWorktree(agent, 'session-4')).toEqual({ outcome: 'removed' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-4')).toEqual({ outcome: 'removed' })
     expect(existsSync(worktree)).toBe(false)
   })
 
@@ -215,7 +209,7 @@ describe('workspace-manager git runner seam', () => {
       release = resolve
     })
     // Clone is intercepted, so nothing reaches the network; the point is who asks and how often.
-    setWorkspaceGitRunnerResolver((agentId) => {
+    workspaces.setGitRunnerResolver((agentId) => {
       const runner = {
         withEnv: () => runner,
         raw: async () => '',
@@ -230,8 +224,8 @@ describe('workspace-manager git runner seam', () => {
       return runner
     })
 
-    const first = prefetchWorkspace(clusterAgent('bot-one', shared))
-    const second = prefetchWorkspace(clusterAgent('bot-two', shared))
+    const first = workspaces.prefetchWorkspace(clusterAgent('bot-one', shared))
+    const second = workspaces.prefetchWorkspace(clusterAgent('bot-two', shared))
     // Both arrive while the other is in flight, which is the race the lock exists for.
     await new Promise((resolve) => setTimeout(resolve, 20))
     release()
@@ -280,53 +274,61 @@ describe('consoleWorkspaceRoot', () => {
 
   it('is the daemon-local path for a self-hosted daemon', () => {
     expect(
-      consoleWorkspaceRoot(agentAt('/var/lib/ac/agents/bot/workspace'), '/var/lib/ac/agents/bot/workspace', undefined)
+      workspaces.consoleWorkspaceRoot(
+        agentAt('/var/lib/ac/agents/bot/workspace'),
+        '/var/lib/ac/agents/bot/workspace',
+        undefined
+      )
     ).toBe('/var/lib/ac/agents/bot/workspace')
   })
 
   it('is the POD checkout under --k8s, never the daemon path the runtime cannot see', () => {
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     const local = '/var/lib/agentconnect/agents/bot/workspace'
-    expect(consoleWorkspaceRoot(agentAt(local), local, '/agent')).toBe('/agent/repo')
+    expect(workspaces.consoleWorkspaceRoot(agentAt(local), local, '/agent')).toBe('/agent/repo')
   })
 
   it('falls back to the legacy mount when the bound shim reported no root', () => {
-    setSandboxWorkspaceMode(true)
-    expect(consoleWorkspaceRoot(agentAt('/local/ws'), '/local/ws', undefined)).toBe('/agent/repo')
+    workspaces.setSandboxMode(true)
+    expect(workspaces.consoleWorkspaceRoot(agentAt('/local/ws'), '/local/ws', undefined)).toBe('/agent/repo')
   })
 
   it('is the mounted volume itself for a from-scratch workspace', () => {
-    setSandboxWorkspaceMode(true)
-    expect(consoleWorkspaceRoot(agentAt('/local/ws', { mode: 'from-scratch' }), '/local/ws', '/agent')).toBe('/agent')
+    workspaces.setSandboxMode(true)
+    expect(workspaces.consoleWorkspaceRoot(agentAt('/local/ws', { mode: 'from-scratch' }), '/local/ws', '/agent')).toBe(
+      '/agent'
+    )
   })
 
   it('stops at the CHECKOUT root, not the runtime cwd, when a working subdirectory is configured', () => {
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     // The distinction is the local path's: it has always addressed `workspace.path` (the clone root)
     // while the ACP cwd went one level in. Routing the console through `clusterWorkspaceCwd` instead
     // put every agentDir-configured cluster agent on "not a git checkout" — `isRepo` accepts only an
     // empty `--show-prefix`, so a descendant cwd is rejected before any operation runs, and no status
     // ever reaches the panel to be corrected downstream.
-    expect(consoleWorkspaceRoot(agentAt('/local/ws', { agentDir: 'services/api' }), '/local/ws', '/agent')).toBe(
-      '/agent/repo'
-    )
+    expect(
+      workspaces.consoleWorkspaceRoot(agentAt('/local/ws', { agentDir: 'services/api' }), '/local/ws', '/agent')
+    ).toBe('/agent/repo')
     // The RUNTIME still gets the subdirectory — the two answers differ on purpose.
-    expect(clusterWorkspaceCwd(agentAt('/local/ws', { agentDir: 'services/api' }), '/agent')).toBe(
+    expect(workspaces.clusterWorkspaceCwd(agentAt('/local/ws', { agentDir: 'services/api' }), '/agent')).toBe(
       '/agent/repo/services/api'
     )
   })
 
   it('keeps an absent workspace absent, so a shared-workspace sessionId stays refused', () => {
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     // The local resolver answers undefined for a sessionId naming a session that is NOT isolated.
     // Turning that into the shared checkout would answer a question about a worktree that has none.
-    expect(consoleWorkspaceRoot(agentAt('/local/ws'), undefined, '/agent')).toBeUndefined()
+    expect(workspaces.consoleWorkspaceRoot(agentAt('/local/ws'), undefined, '/agent')).toBeUndefined()
   })
 
   it('refuses a session-isolated worktree loudly rather than naming the shared checkout', () => {
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     expect(() =>
-      consoleWorkspaceRoot(agentAt('/local/ws'), '/local/ws/.sessions/abc', '/agent', { isolation: 'session' })
+      workspaces.consoleWorkspaceRoot(agentAt('/local/ws'), '/local/ws/.sessions/abc', '/agent', {
+        isolation: 'session'
+      })
     ).toThrow(/session-isolated/)
   })
 })

--- a/packages/daemon/test/workspace-git-sandbox.test.ts
+++ b/packages/daemon/test/workspace-git-sandbox.test.ts
@@ -5,7 +5,10 @@ import { join } from 'node:path'
 import { createWorkspaceGit } from '../src/cp/workspace-git.js'
 import { ShimChannelLostError } from '../src/shim/channels.js'
 import { ShimGitRunner } from '../src/shim/git-exec.js'
-import { setSandboxWorkspaceMode, setWorkspaceGitRunnerResolver } from '../src/workspace/workspace-manager.js'
+import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
+
+// One plane per test file — the isolation Vitest's per-file module registry used to give.
+const workspaces = new WorkspaceManager()
 
 /**
  * What the console's git seam answers for a cluster agent whose sandbox is not reachable.
@@ -19,8 +22,8 @@ import { setSandboxWorkspaceMode, setWorkspaceGitRunnerResolver } from '../src/w
 const AGENT = 'bot-cluster'
 
 afterEach(() => {
-  setSandboxWorkspaceMode(false)
-  setWorkspaceGitRunnerResolver(undefined)
+  workspaces.setSandboxMode(false)
+  workspaces.setGitRunnerResolver(undefined)
 })
 
 /** Answers the first call and nothing after it — a detach timed to land between two resolutions. */
@@ -53,9 +56,9 @@ function answeringRunner(seen: string[][]) {
 
 describe('the console git seam without a bound sandbox', () => {
   it('refuses with a machine-readable reason instead of reporting "not a git checkout"', async () => {
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     // No resolver registered for this agent — what the plane answers with no bound channel.
-    const git = createWorkspaceGit(() => '/agent/repo')
+    const git = createWorkspaceGit(workspaces, () => '/agent/repo')
     for (const read of [
       () => git.status(AGENT),
       () => git.log({ agentId: AGENT, limit: 20 }),
@@ -80,7 +83,7 @@ describe('the console git seam without a bound sandbox', () => {
     // answer comes from git on this filesystem — a real directory that simply is not a checkout.
     const plain = mkdtempSync(join(tmpdir(), 'ac-git-sandbox-'))
     try {
-      const status = await createWorkspaceGit(() => plain).status(AGENT)
+      const status = await createWorkspaceGit(workspaces, () => plain).status(AGENT)
       expect(status.isRepo).toBe(false)
     } finally {
       rmSync(plain, { recursive: true, force: true })
@@ -88,21 +91,21 @@ describe('the console git seam without a bound sandbox', () => {
   })
 
   it('holds the runner it resolved when the channel drops mid-request', async () => {
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     // The shim re-dials at half its credential TTL, so "the resolver answered once" is not a promise
     // that it answers the same way again. A fence that probes and then resolves is check-then-use: the
     // second answer would be a daemon-local runner against a pod path, so a read reports no checkout
     // and a write mutates this disk. The refusal rides on the resolution, which happens once.
     const seen: string[][] = []
-    setWorkspaceGitRunnerResolver(detachAfterFirst(answeringRunner(seen) as never))
-    const status = await createWorkspaceGit(() => '/agent/repo').status(AGENT)
+    workspaces.setGitRunnerResolver(detachAfterFirst(answeringRunner(seen) as never))
+    const status = await createWorkspaceGit(workspaces, () => '/agent/repo').status(AGENT)
     expect(status.isRepo).toBe(true)
     expect(seen.some((args) => args.includes('--show-prefix'))).toBe(true)
   })
 
   it('still refuses an unknown agent as an unknown agent, ahead of reachability', async () => {
-    setSandboxWorkspaceMode(true)
-    await expect(createWorkspaceGit(() => undefined).status('nope')).rejects.toMatchObject({
+    workspaces.setSandboxMode(true)
+    await expect(createWorkspaceGit(workspaces, () => undefined).status('nope')).rejects.toMatchObject({
       reason: 'unknown-agent'
     })
   })
@@ -114,8 +117,8 @@ describe('a shim channel that goes away mid-request', () => {
   // ordinary renewal settled as "not a git checkout" — the same misleading answer this seam was built
   // to remove, arriving from the transport instead of from a wrong path.
   afterEach(() => {
-    setSandboxWorkspaceMode(false)
-    setWorkspaceGitRunnerResolver(undefined)
+    workspaces.setSandboxMode(false)
+    workspaces.setGitRunnerResolver(undefined)
   })
 
   /** A remote runner whose channel is lost on the Nth request, as a renewal loses it. */
@@ -132,27 +135,27 @@ describe('a shim channel that goes away mid-request', () => {
   }
 
   it('retries a read once across the renewal rather than reporting no checkout', async () => {
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     // The first `rev-parse` loses its channel; the second lands. The panel must never see the blip.
     const { runner, state } = losingRunner((n) => n === 1)
-    setWorkspaceGitRunnerResolver(() => runner)
-    const status = await createWorkspaceGit(() => '/agent/repo').status(AGENT)
+    workspaces.setGitRunnerResolver(() => runner)
+    const status = await createWorkspaceGit(workspaces, () => '/agent/repo').status(AGENT)
     expect(status.isRepo).toBe(true)
     expect(state.calls).toBeGreaterThan(1)
   })
 
   it('reports a channel that stays gone as transient, NOT as "not a git checkout"', async () => {
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     const { runner } = losingRunner(() => true)
-    setWorkspaceGitRunnerResolver(() => runner)
-    await expect(createWorkspaceGit(() => '/agent/repo').status(AGENT)).rejects.toMatchObject({
+    workspaces.setGitRunnerResolver(() => runner)
+    await expect(createWorkspaceGit(workspaces, () => '/agent/repo').status(AGENT)).rejects.toMatchObject({
       name: 'WorkspaceViolationError',
       reason: 'sandbox-unavailable'
     })
   })
 
   it('never repeats a write, whose first attempt may already have landed', async () => {
-    setSandboxWorkspaceMode(true)
+    workspaces.setSandboxMode(true)
     // The abort says a REPLY was lost, not whether the request arrived — so a repeated `commit` risks
     // a second commit. Reads are the only invocations this may resend.
     const seen: string[][] = []
@@ -164,12 +167,12 @@ describe('a shim channel that goes away mid-request', () => {
         throw new ShimChannelLostError('shim channel renewed')
       }
     }
-    setWorkspaceGitRunnerResolver(() => new ShimGitRunner(session))
+    workspaces.setGitRunnerResolver(() => new ShimGitRunner(session))
     // Refused as transient rather than retried. `config` — the executable-config audit a stage runs
     // first — is left out of the repeatable set for the same reason: it CAN write, and the cheapest
     // way never to get that wrong is to repeat nothing that can.
     await expect(
-      createWorkspaceGit(() => '/agent/repo').stage({ agentId: AGENT, paths: ['a.ts'] })
+      createWorkspaceGit(workspaces, () => '/agent/repo').stage({ agentId: AGENT, paths: ['a.ts'] })
     ).rejects.toMatchObject({ reason: 'sandbox-unavailable' })
     // Nothing that mutates was sent twice — nor, here, even once.
     const sent = seen.map((args) => args.join(' '))

--- a/packages/daemon/test/workspace-git-write.test.ts
+++ b/packages/daemon/test/workspace-git-write.test.ts
@@ -13,7 +13,10 @@ import {
 } from '../src/workspace/git-injection.js'
 import type { GitRunner } from '../src/workspace/git-runner.js'
 import { parsePorcelainV2 } from '../src/shim/git-exec.js'
-import { setWorkspaceGitRunnerResolver } from '../src/workspace/workspace-manager.js'
+import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
+
+// One plane per test file — the isolation Vitest's per-file module registry used to give.
+const workspaces = new WorkspaceManager()
 import { LocalGitRunner } from '../src/workspace/git-runner.js'
 
 // Real git against real checkouts, no simple-git mock: the write half is a set of claims about what
@@ -182,7 +185,7 @@ const githubTarget = (branch = 'main') => ({
 })
 
 afterEach(() => {
-  setWorkspaceGitRunnerResolver(undefined)
+  workspaces.setGitRunnerResolver(undefined)
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
 
@@ -191,7 +194,7 @@ describe('workspace git stage / unstage (real repo, real index)', () => {
     const dir = repo()
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
     writeFileSync(join(dir, 'new.txt'), 'new\n')
-    const seam = createWorkspaceGit(() => dir)
+    const seam = createWorkspaceGit(workspaces, () => dir)
 
     const before = await seam.status('a')
     expect(byPath(before.files)).toEqual([
@@ -213,7 +216,7 @@ describe('workspace git stage / unstage (real repo, real index)', () => {
     const dir = repo()
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
     writeFileSync(join(dir, 'new.txt'), 'new\n')
-    const seam = createWorkspaceGit(() => dir)
+    const seam = createWorkspaceGit(workspaces, () => dir)
     await seam.stage({ agentId: 'a', paths: ['tracked.txt', 'new.txt'] })
 
     const after = await seam.unstage({ agentId: 'a', paths: ['tracked.txt', 'new.txt'] })
@@ -231,7 +234,7 @@ describe('workspace git stage / unstage (real repo, real index)', () => {
     git(dir, ['init', '-q', '-b', 'main', '.'])
     writeFileSync(join(dir, 'first.txt'), 'first\n')
     git(dir, ['add', 'first.txt'])
-    const seam = createWorkspaceGit(() => dir)
+    const seam = createWorkspaceGit(workspaces, () => dir)
 
     const after = await seam.unstage({ agentId: 'a', paths: ['first.txt'] })
     expect(after.files).toEqual([{ path: 'first.txt', index: '?', workingDir: '?' }])
@@ -241,7 +244,7 @@ describe('workspace git stage / unstage (real repo, real index)', () => {
   it('treats every no-op as data: an empty list, an unchanged path, and a path git does not report', async () => {
     const dir = repo()
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
-    const seam = createWorkspaceGit(() => dir)
+    const seam = createWorkspaceGit(workspaces, () => dir)
 
     // Empty selection: the fresh status, and nothing staged behind the caller's back.
     const untouched = await seam.stage({ agentId: 'a', paths: [] })
@@ -261,14 +264,14 @@ describe('workspace git stage / unstage (real repo, real index)', () => {
   it('reports a from-scratch workspace as isRepo:false instead of failing', async () => {
     const dir = join(tempRoot(), 'scratch')
     mkdirSync(dir, { recursive: true })
-    const seam = createWorkspaceGit(() => dir)
+    const seam = createWorkspaceGit(workspaces, () => dir)
     expect(await seam.stage({ agentId: 'a', paths: ['x.txt'] })).toEqual({ agentId: 'a', isRepo: false, clean: true })
     expect(await seam.unstage({ agentId: 'a', paths: ['x.txt'] })).toEqual({ agentId: 'a', isRepo: false, clean: true })
   })
 
   it('refuses a pathspec that escapes the workspace or reaches into .git', async () => {
     const dir = repo()
-    const seam = createWorkspaceGit(() => dir)
+    const seam = createWorkspaceGit(workspaces, () => dir)
     await expect(seam.stage({ agentId: 'a', paths: ['../agent.json'] })).rejects.toBeInstanceOf(WorkspaceViolationError)
     await expect(seam.stage({ agentId: 'a', paths: ['/etc/passwd'] })).rejects.toMatchObject({
       reason: 'path-escape'
@@ -284,7 +287,7 @@ describe('workspace git stage / unstage (real repo, real index)', () => {
     const dir = repo()
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
     git(dir, ['config', 'filter.evil.process', 'sh -c "touch /tmp/pwned"'])
-    const seam = createWorkspaceGit(() => dir)
+    const seam = createWorkspaceGit(workspaces, () => dir)
     await expect(seam.stage({ agentId: 'a', paths: ['tracked.txt'] })).rejects.toThrow(/disallowed/)
     expect(git(dir, ['diff', '--cached', '--name-only'])).toBe('')
   })
@@ -295,6 +298,7 @@ describe('workspace git commit (real repo, real commit)', () => {
     const dir = repo()
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
     const seam = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       () => githubTarget(),
@@ -322,6 +326,7 @@ describe('workspace git commit (real repo, real commit)', () => {
     const dir = repo()
     writeFileSync(join(dir, 'tracked.txt'), 'three\n')
     const seam = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       () => githubTarget(),
@@ -345,7 +350,7 @@ describe('workspace git commit (real repo, real commit)', () => {
   it('REFUSES as data when no commit identity was registered, and creates no commit', async () => {
     const dir = repo()
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
-    const seam = createWorkspaceGit(() => dir)
+    const seam = createWorkspaceGit(workspaces, () => dir)
     await seam.stage({ agentId: 'a', paths: ['tracked.txt'] })
     const head = git(dir, ['rev-parse', 'HEAD']).trim()
 
@@ -361,6 +366,7 @@ describe('workspace git commit (real repo, real commit)', () => {
   it('reports nothing staged, an empty message and a from-scratch workspace as data', async () => {
     const dir = repo()
     const seam = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       () => githubTarget(),
@@ -380,6 +386,7 @@ describe('workspace git commit (real repo, real commit)', () => {
     const scratch = join(tempRoot(), 'scratch')
     mkdirSync(scratch, { recursive: true })
     const scratchSeam = createWorkspaceGit(
+      workspaces,
       () => scratch,
       () => ({}),
       () => undefined,
@@ -396,6 +403,7 @@ describe('workspace git commit (real repo, real commit)', () => {
     const dir = repo()
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
     const seam = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       () => githubTarget(),
@@ -420,6 +428,7 @@ describe('workspace git commit (real repo, real commit)', () => {
     writeFileSync(join(hooks, 'pre-commit'), `#!/bin/sh\ntouch '${marker}'\nexit 1\n`, { mode: 0o755 })
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
     const seam = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       () => githubTarget(),
@@ -436,9 +445,10 @@ describe('workspace git push (real repo; local bare remote through the runner se
   it('pushes the branch, then advances origin/<branch> so the commits stop reading as unpushed', async () => {
     const { dir, bare, origin } = repoWithRemote()
     const calls: Call[] = []
-    setWorkspaceGitRunnerResolver((_agentId, cwd) => new SeamRunner(cwd ?? dir, calls, origin, bare))
+    workspaces.setGitRunnerResolver((_agentId, cwd) => new SeamRunner(cwd ?? dir, calls, origin, bare))
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
     const seam = createWorkspaceGit(
+      workspaces,
       () => dir,
       gitcredEnv,
       () => githubTarget(),
@@ -497,9 +507,10 @@ describe('workspace git push (real repo; local bare remote through the runner se
     git(other, ['push', '-q', 'origin', 'main'])
     const remoteHead = git(bare, ['rev-parse', 'refs/heads/main']).trim()
 
-    setWorkspaceGitRunnerResolver((_agentId, cwd) => new SeamRunner(cwd ?? dir, [], origin, bare))
+    workspaces.setGitRunnerResolver((_agentId, cwd) => new SeamRunner(cwd ?? dir, [], origin, bare))
     writeFileSync(join(dir, 'tracked.txt'), 'mine\n')
     const seam = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       () => githubTarget(),
@@ -521,10 +532,10 @@ describe('workspace git push (real repo; local bare remote through the runner se
   it('chunks the pathspecs so one invocation stays inside the sandbox argv cap', async () => {
     const dir = repo()
     const calls: Call[] = []
-    setWorkspaceGitRunnerResolver((_agentId, cwd) => new SeamRunner(cwd ?? dir, calls))
+    workspaces.setGitRunnerResolver((_agentId, cwd) => new SeamRunner(cwd ?? dir, calls))
     const paths = Array.from({ length: 120 }, (_, index) => `f${index}.txt`)
     for (const path of paths) writeFileSync(join(dir, path), `${path}\n`)
-    const seam = createWorkspaceGit(() => dir)
+    const seam = createWorkspaceGit(workspaces, () => dir)
 
     const after = await seam.stage({ agentId: 'a', paths })
     expect(after.files?.filter((file) => file.index === 'A')).toHaveLength(120)
@@ -538,6 +549,7 @@ describe('workspace git push (real repo; local bare remote through the runner se
 describe('workspace git push preconditions (data, not errors)', () => {
   const seamFor = (dir: string) =>
     createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       () => githubTarget(),
@@ -605,7 +617,7 @@ describe('workspace git push preconditions (data, not errors)', () => {
     // never sent. Verified against real git.
     const { dir, bare, origin } = repoWithRemote()
     const calls: Call[] = []
-    setWorkspaceGitRunnerResolver((_agentId, cwd) => new SeamRunner(cwd ?? dir, calls, origin, bare))
+    workspaces.setGitRunnerResolver((_agentId, cwd) => new SeamRunner(cwd ?? dir, calls, origin, bare))
     // `feature` branches off main at the SAME commit and adds nothing, so `ahead(origin/main)` is
     // zero — while `origin/feature` does not exist, which means there is very much something to
     // send. A URL-only check reports "Everything is already pushed" here and creates nothing.
@@ -614,6 +626,7 @@ describe('workspace git push preconditions (data, not errors)', () => {
     expect(git(dir, ['rev-list', '--count', 'origin/main..HEAD']).trim()).toBe('0')
     expect(git(dir, ['ls-remote', '--heads', bare, 'feature']).trim()).toBe('')
     const seam = createWorkspaceGit(
+      workspaces,
       () => dir,
       gitcredEnv,
       () => githubTarget(),
@@ -657,7 +670,7 @@ describe('workspace git push preconditions (data, not errors)', () => {
     const { dir } = repoWithRemote()
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
     let resolutions = 0
-    setWorkspaceGitRunnerResolver((_agentId, cwd) => {
+    workspaces.setGitRunnerResolver((_agentId, cwd) => {
       resolutions += 1
       if (resolutions > 1) return undefined
       return new LocalGitRunner(gitFor(cwd ?? dir), cwd ?? dir, (env) => gitFor(cwd ?? dir).env(env))
@@ -668,7 +681,7 @@ describe('workspace git push preconditions (data, not errors)', () => {
       expect(status.isRepo).toBe(true)
       expect(status.files?.map((f) => f.path)).toEqual(['tracked.txt'])
     } finally {
-      setWorkspaceGitRunnerResolver(undefined)
+      workspaces.setGitRunnerResolver(undefined)
     }
   })
 
@@ -706,7 +719,7 @@ describe('workspace git push preconditions (data, not errors)', () => {
   })
 
   it('refuses an unknown agent as a BAD_PAYLOAD violation, not as data', async () => {
-    const seam = createWorkspaceGit(() => undefined)
+    const seam = createWorkspaceGit(workspaces, () => undefined)
     await expect(seam.push({ agentId: 'ghost' })).rejects.toMatchObject({ reason: 'unknown-agent' })
     await expect(seam.commit({ agentId: 'ghost', message: 'x' })).rejects.toBeInstanceOf(WorkspaceViolationError)
     await expect(seam.stage({ agentId: 'ghost', paths: [] })).rejects.toBeInstanceOf(WorkspaceViolationError)
@@ -722,6 +735,7 @@ describe('workspace git message — the AI commit-message pass (real staged diff
   function seamWith(dir: string, answer: () => Promise<{ output: string; stopReason: string }>) {
     const pass: Pass = { calls: [] }
     const seam = createWorkspaceGit(
+      workspaces,
       () => dir,
       undefined,
       undefined,
@@ -851,10 +865,11 @@ describe('workspace git message — the AI commit-message pass (real staged diff
     const dir = repo()
     // Every git call synchronous through the seam runner, so the only thing this test has to wait for
     // is the fake clock — a real simple-git read would still be in flight when the clock advanced.
-    setWorkspaceGitRunnerResolver((_agentId, cwd) => new SeamRunner(cwd ?? dir, []))
+    workspaces.setGitRunnerResolver((_agentId, cwd) => new SeamRunner(cwd ?? dir, []))
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
     let aborted = false
     const seam = createWorkspaceGit(
+      workspaces,
       () => dir,
       undefined,
       undefined,
@@ -886,7 +901,7 @@ describe('workspace git message — the AI commit-message pass (real staged diff
   it('answers as data when the daemon wired no model pass at all, and for a from-scratch workspace', async () => {
     const dir = repo()
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')
-    const bare = createWorkspaceGit(() => dir)
+    const bare = createWorkspaceGit(workspaces, () => dir)
     await bare.stage({ agentId: 'a', paths: ['tracked.txt'] })
     expect(await bare.message({ agentId: 'a' })).toEqual({
       agentId: 'a',

--- a/packages/daemon/test/workspace-git.test.ts
+++ b/packages/daemon/test/workspace-git.test.ts
@@ -29,6 +29,10 @@ vi.mock('simple-git', () => ({
 }))
 
 const { createWorkspaceGit } = await import('../src/cp/workspace-git.js')
+
+const { WorkspaceManager } = await import('../src/workspace/workspace-manager.js')
+// One plane per test file — the isolation Vitest's per-file module registry used to give.
+const workspaces = new WorkspaceManager()
 const { WorkspaceViolationError } = await import('../src/cp/workspace-reader.js')
 
 /** A temp dir; `repo:true` seeds a `.git/` so it reads as a git-repo checkout. */
@@ -61,7 +65,7 @@ beforeEach(() => {
 describe('createWorkspaceGit.status', () => {
   it('reports isRepo:false / clean:true for a from-scratch (no .git) workspace', async () => {
     const dir = ws(false)
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(workspaces, () => dir)
     expect(await git.status('a')).toEqual({ agentId: 'a', isRepo: false, clean: true })
     expect(statusImpl).not.toHaveBeenCalled() // short-circuits before touching git
   })
@@ -76,7 +80,7 @@ describe('createWorkspaceGit.status', () => {
       files: [],
       isClean: () => true
     })
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(workspaces, () => dir)
     const s = await git.status('a')
     expect(s).toMatchObject({ agentId: 'a', isRepo: true, clean: true, branch: 'main', tracking: 'origin/main' })
     expect(s.files).toBeUndefined()
@@ -96,7 +100,7 @@ describe('createWorkspaceGit.status', () => {
       ],
       isClean: () => false
     })
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(workspaces, () => dir)
     const s = await git.status('a')
     expect(s.clean).toBe(false)
     expect(s.ahead).toBe(1)
@@ -112,7 +116,7 @@ describe('createWorkspaceGit.status', () => {
     const dir = ws(true)
     const files = Array.from({ length: 501 }, (_, i) => ({ path: `f${i}.ts`, index: 'M', working_dir: ' ' }))
     statusImpl = vi.fn().mockResolvedValue({ current: 'main', ahead: 0, behind: 0, files, isClean: () => false })
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(workspaces, () => dir)
     const s = await git.status('a')
     expect(s.files).toHaveLength(500)
     expect(s.truncated).toBe(true)
@@ -133,7 +137,7 @@ describe('createWorkspaceGit.status', () => {
       subject: 'Pin deploy image'
     }
     logImpl = vi.fn().mockResolvedValue({ all: [commit], latest: commit })
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(workspaces, () => dir)
     const s = await git.status('a')
     expect(s.lastCommit).toEqual({
       sha: 'a3f9c21deadbeef0000000000000000000000000',
@@ -148,7 +152,7 @@ describe('createWorkspaceGit.status', () => {
     const dir = ws(true)
     statusImpl = vi.fn().mockResolvedValue({ current: 'main', ahead: 0, behind: 0, files: [], isClean: () => true })
     // logImpl rejects by default (beforeEach)
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(workspaces, () => dir)
     const s = await git.status('a')
     expect(s.lastCommit).toBeUndefined()
   })
@@ -159,7 +163,7 @@ describe('createWorkspaceGit.status', () => {
   // read, and a case that cannot construct its own state is worse than no case.
 
   it('throws WorkspaceViolationError for an unknown agent', async () => {
-    const git = createWorkspaceGit(() => undefined)
+    const git = createWorkspaceGit(workspaces, () => undefined)
     await expect(git.status('nope')).rejects.toBeInstanceOf(WorkspaceViolationError)
     await expect(git.diff({ agentId: 'nope', path: 'a.ts', staged: false })).rejects.toBeInstanceOf(
       WorkspaceViolationError
@@ -169,7 +173,7 @@ describe('createWorkspaceGit.status', () => {
 
   it('short-circuits diff and log for a from-scratch workspace without touching git', async () => {
     const dir = ws(false)
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(workspaces, () => dir)
     expect(await git.diff({ agentId: 'a', path: 'a.ts', staged: false })).toEqual({
       agentId: 'a',
       path: 'a.ts',
@@ -189,7 +193,7 @@ describe('createWorkspaceGit.status', () => {
 describe('createWorkspaceGit.pull', () => {
   it('reports isRepo:false / ok:false for a from-scratch workspace (nothing to pull)', async () => {
     const dir = ws(false)
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(workspaces, () => dir)
     expect(await git.pull('a')).toEqual({
       agentId: 'a',
       isRepo: false,
@@ -203,6 +207,7 @@ describe('createWorkspaceGit.pull', () => {
     const dir = ws(true)
     pullImpl = vi.fn().mockResolvedValue({ files: ['a.ts', 'b.ts'], summary: { insertions: 10, deletions: 3 } })
     const git = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({ AC_GITCRED_CAPABILITY: 'cap-a' }),
       githubTarget
@@ -239,6 +244,7 @@ describe('createWorkspaceGit.pull', () => {
     try {
       await expect(
         createWorkspaceGit(
+          workspaces,
           () => dir,
           () => ({}),
           githubTarget
@@ -256,6 +262,7 @@ describe('createWorkspaceGit.pull', () => {
     const dir = ws(true)
     pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
     const git = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       githubTarget
@@ -269,6 +276,7 @@ describe('createWorkspaceGit.pull', () => {
     const dir = ws(true)
     rawImpl = vi.fn().mockResolvedValue('https://legacy-user:super-secret@invalid.invalid/repo?token=query-secret\n')
     const git = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       githubTarget
@@ -291,6 +299,7 @@ describe('createWorkspaceGit.pull', () => {
     const dir = ws(true)
     rawImpl = vi.fn().mockResolvedValue('git@github.com:acme/repo.git\n')
     const git = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       () => ({ repo: 'https://github.com/acme/repo.git', branch: 'main', githubApp: true })
@@ -306,7 +315,7 @@ describe('createWorkspaceGit.pull', () => {
 
   it('refuses to pull without the configured workspace target', async () => {
     const dir = ws(true)
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(workspaces, () => dir)
 
     expect(await git.pull('a')).toMatchObject({
       isRepo: true,
@@ -326,6 +335,7 @@ describe('createWorkspaceGit.pull', () => {
           : 'url.https://127.0.0.1.invalid/redirected/.insteadof\0'
       )
     const git = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       githubTarget
@@ -348,6 +358,7 @@ describe('createWorkspaceGit.pull', () => {
       )
     pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
     const git = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       githubTarget
@@ -364,6 +375,7 @@ describe('createWorkspaceGit.pull', () => {
       .mockImplementation(async (args: string[]) => (args[0] === 'remote' ? 'https://github.com/acme/repo.git\n' : ''))
     pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
     const git = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       () => ({ repo: 'https://github.com/acme/repo.git', branch: 'release/v2', githubApp: true })
@@ -387,6 +399,7 @@ describe('createWorkspaceGit.pull', () => {
     const dir = ws(true)
     pullImpl = vi.fn().mockRejectedValue(new Error(`cannot fast-forward in ${dir}/x`))
     const git = createWorkspaceGit(
+      workspaces,
       () => dir,
       () => ({}),
       githubTarget

--- a/packages/daemon/test/workspace-reader.test.ts
+++ b/packages/daemon/test/workspace-reader.test.ts
@@ -11,6 +11,10 @@ import {
   type WorkspaceReader,
   type WorkspaceWriteCoordinator
 } from '../src/cp/workspace-reader.js'
+import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
+
+// One plane per test file — the isolation Vitest's per-file module registry used to give.
+const workspaces = new WorkspaceManager()
 
 const AGENT = 'bot-a'
 
@@ -62,7 +66,11 @@ beforeEach(() => {
   outside = join(base, 'outside')
   mkdirSync(ws)
   mkdirSync(outside)
-  reader = createWorkspaceReader((id) => (id === AGENT ? { root: ws, scratch: true } : undefined), directWrite)
+  reader = createWorkspaceReader(
+    workspaces,
+    (id) => (id === AGENT ? { root: ws, scratch: true } : undefined),
+    directWrite
+  )
 })
 
 afterEach(() => {
@@ -76,6 +84,7 @@ describe('workspace list', () => {
     writeFileSync(join(ws, 'primary.txt'), 'primary')
     writeFileSync(join(worktree, 'session.txt'), 'session')
     const scoped = createWorkspaceReader(
+      workspaces,
       (id, sessionId) =>
         id === AGENT
           ? { root: sessionId === 'session-a' ? worktree : ws, scratch: sessionId === undefined }
@@ -349,6 +358,7 @@ describe('workspace write', () => {
     )
 
     const repoReader = createWorkspaceReader(
+      workspaces,
       (id) => (id === AGENT ? { root: ws, scratch: false } : undefined),
       directWrite
     )
@@ -377,6 +387,7 @@ describe('workspace delete', () => {
     const target = join(ws, 'notes.md')
     writeFileSync(target, 'current')
     const repoReader = createWorkspaceReader(
+      workspaces,
       (id) => (id === AGENT ? { root: ws, scratch: false } : undefined),
       directWrite
     )

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -39,20 +39,10 @@ vi.mock('simple-git', () => ({
 }))
 
 // Imported after vi.mock so the mock is in effect.
-const {
-  additionalWorkspaceDirectories,
-  clusterWorkspaceCwd,
-  convergeGithubAppWorkspaceRename,
-  ensureWorkspaceMaterialization,
-  prepareSessionWorkspace,
-  prepareWorkspace,
-  prepareWorkspaceForActivation,
-  prefetchWorkspace,
-  recordWorkspaceMaterialization,
-  removeSessionWorktree,
-  sessionWorktreePath,
-  sessionWorktreeRoot
-} = await import('../src/workspace/workspace-manager.js')
+const { WorkspaceManager } = await import('../src/workspace/workspace-manager.js')
+
+// One plane per test file — the isolation Vitest's per-file module registry used to give.
+const workspaces = new WorkspaceManager()
 const { daemonGitCredentialTarget, initGitInjection } = await import('../src/workspace/git-injection.js')
 
 // Made once and reused: `targetFor` is called on every pointer build, so minting a directory
@@ -122,7 +112,7 @@ beforeEach(() => {
 describe('prepareWorkspace', () => {
   it('creates the workspace dir for from-scratch mode (memory lives at the agent root, not here)', async () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'workspace')
-    const cwd = await prepareWorkspace(fromScratchAgent(path))
+    const cwd = await workspaces.prepareWorkspace(fromScratchAgent(path))
     expect(cwd).toBe(path)
     expect(existsSync(path)).toBe(true)
     // memory.md is NOT created in the workspace anymore — it moved to <agent-root>/memory.md
@@ -132,7 +122,7 @@ describe('prepareWorkspace', () => {
 
   it('clones git-repo when the checkout has no .git, with branch + single-branch args', async () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
-    const cwd = await prepareWorkspace(gitRepoAgent(path))
+    const cwd = await workspaces.prepareWorkspace(gitRepoAgent(path))
     expect(cwd).toBe(realpathSync(path))
     expect(cloneImpl).toHaveBeenCalledTimes(1)
     expect(cloneImpl).toHaveBeenCalledWith('https://github.com/acme/repo.git', path, [
@@ -149,7 +139,7 @@ describe('prepareWorkspace', () => {
     const agent = gitRepoAgent(path)
     agent.workspace.gitRepo = 'ssh://git@github.com/acme/repo.git'
 
-    await prepareWorkspace(agent)
+    await workspaces.prepareWorkspace(agent)
 
     expect(cloneImpl).toHaveBeenCalledWith('ssh://git@github.com/acme/repo.git', path, [
       '--branch',
@@ -166,7 +156,7 @@ describe('prepareWorkspace', () => {
       for (const path of [fresh, existing]) {
         const agent = gitRepoAgent(path)
         agent.workspace.gitRepo = gitRepo
-        await expect(prepareWorkspace(agent)).rejects.toThrow()
+        await expect(workspaces.prepareWorkspace(agent)).rejects.toThrow()
       }
     }
 
@@ -184,8 +174,8 @@ describe('prepareWorkspace', () => {
         })
     )
     const agent = gitRepoAgent(path)
-    const p1 = prepareWorkspace(agent)
-    const p2 = prepareWorkspace(agent) // arrives while p1's clone is in flight
+    const p1 = workspaces.prepareWorkspace(agent)
+    const p2 = workspaces.prepareWorkspace(agent) // arrives while p1's clone is in flight
     resolveClone()
     await Promise.all([p1, p2])
     expect(cloneImpl).toHaveBeenCalledTimes(1)
@@ -194,13 +184,13 @@ describe('prepareWorkspace', () => {
   it('THROWS on clone failure (no on-disk fallback)', async () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
     cloneImpl = vi.fn().mockRejectedValue(new Error('boom'))
-    await expect(prepareWorkspace(gitRepoAgent(path))).rejects.toThrow('boom')
+    await expect(workspaces.prepareWorkspace(gitRepoAgent(path))).rejects.toThrow('boom')
   })
 
   it('pulls (not clones) when an existing .git checkout is present', async () => {
     const dir = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
     mkdirSync(join(dir, '.git'), { recursive: true })
-    await prepareWorkspace(gitRepoAgent(dir))
+    await workspaces.prepareWorkspace(gitRepoAgent(dir))
     expect(cloneImpl).not.toHaveBeenCalled()
     expect(pullMock).toHaveBeenCalledWith(
       expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
@@ -219,7 +209,7 @@ describe('prepareWorkspace', () => {
       args[0] === 'remote' && args[1] === 'get-url' ? 'https://attacker.example/other.git\n' : ''
     )
 
-    await prepareWorkspace(agent)
+    await workspaces.prepareWorkspace(agent)
 
     expect(pullMock).toHaveBeenCalledWith(
       expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
@@ -234,7 +224,7 @@ describe('prepareWorkspace', () => {
     mkdirSync(join(dir, '.git'), { recursive: true })
     mkdirSync(join(dir, 'services', 'api'), { recursive: true })
 
-    await expect(prepareWorkspace(gitRepoAgent(dir, './services/api'))).resolves.toBe(
+    await expect(workspaces.prepareWorkspace(gitRepoAgent(dir, './services/api'))).resolves.toBe(
       realpathSync(join(dir, 'services', 'api'))
     )
   })
@@ -242,7 +232,7 @@ describe('prepareWorkspace', () => {
   it('rejects lexical traversal before cloning', async () => {
     const dir = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
 
-    await expect(prepareWorkspace(gitRepoAgent(dir, '../outside'))).rejects.toThrow('working subdirectory')
+    await expect(workspaces.prepareWorkspace(gitRepoAgent(dir, '../outside'))).rejects.toThrow('working subdirectory')
     expect(cloneImpl).not.toHaveBeenCalled()
   })
 
@@ -251,8 +241,8 @@ describe('prepareWorkspace', () => {
     mkdirSync(join(dir, '.git'), { recursive: true })
     writeFileSync(join(dir, 'README.md'), 'not a directory')
 
-    await expect(prepareWorkspace(gitRepoAgent(dir, 'missing'))).rejects.toThrow('missing')
-    await expect(prepareWorkspace(gitRepoAgent(dir, 'README.md'))).rejects.toThrow('not a directory')
+    await expect(workspaces.prepareWorkspace(gitRepoAgent(dir, 'missing'))).rejects.toThrow('missing')
+    await expect(workspaces.prepareWorkspace(gitRepoAgent(dir, 'README.md'))).rejects.toThrow('not a directory')
   })
 
   it('returns the canonical target of an in-repository symlink', async () => {
@@ -261,7 +251,7 @@ describe('prepareWorkspace', () => {
     mkdirSync(join(dir, 'packages', 'api'), { recursive: true })
     symlinkSync(join(dir, 'packages', 'api'), join(dir, 'api-link'))
 
-    await expect(prepareWorkspace(gitRepoAgent(dir, 'api-link'))).resolves.toBe(
+    await expect(workspaces.prepareWorkspace(gitRepoAgent(dir, 'api-link'))).resolves.toBe(
       realpathSync(join(dir, 'packages', 'api'))
     )
   })
@@ -274,7 +264,9 @@ describe('prepareWorkspace', () => {
     mkdirSync(outside)
     symlinkSync(outside, join(dir, 'outside-link'))
 
-    await expect(prepareWorkspace(gitRepoAgent(dir, 'outside-link'))).rejects.toThrow('outside the repository')
+    await expect(workspaces.prepareWorkspace(gitRepoAgent(dir, 'outside-link'))).rejects.toThrow(
+      'outside the repository'
+    )
   })
 })
 
@@ -311,10 +303,10 @@ describe('prepareSessionWorkspace', () => {
       isolation: 'session' as const,
       review: { pullNumber: 461, baseSha: base, headSha: head }
     }
-    const cwd = await prepareSessionWorkspace(agent, request)
-    await prepareSessionWorkspace(agent, request)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, request)
+    await workspaces.prepareSessionWorkspace(agent, request)
 
-    expect(dirname(cwd)).toBe(realpathSync(sessionWorktreeRoot(agent)))
+    expect(dirname(cwd)).toBe(realpathSync(workspaces.sessionWorktreeRoot(agent)))
     const addCall = rawMock.mock.calls
       .map((call) => call[0] as string[])
       .find((args) => args[0] === 'worktree' && args[1] === 'add')
@@ -347,11 +339,11 @@ describe('prepareSessionWorkspace', () => {
       githubReviewRevisionOnly: true as const
     }
 
-    const cwd = await prepareSessionWorkspace(agent, request)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, request)
     mkdirSync(join(cwd, '.git'))
     writeFileSync(join(cwd, 'stale-review.txt'), 'must not be trusted')
 
-    await expect(prepareSessionWorkspace(agent, request)).resolves.toBe(cwd)
+    await expect(workspaces.prepareSessionWorkspace(agent, request)).resolves.toBe(cwd)
     expect(readdirSync(cwd)).toEqual([])
   })
 
@@ -368,9 +360,9 @@ describe('prepareSessionWorkspace', () => {
       return ''
     })
 
-    await expect(prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })).rejects.toThrow(
-      'workspace Git configuration contains a disallowed network override or executable setting'
-    )
+    await expect(
+      workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
+    ).rejects.toThrow('workspace Git configuration contains a disallowed network override or executable setting')
     expect(rawMock.mock.calls.some(([args]) => args[0] === 'worktree' && args[1] === 'add')).toBe(false)
   })
 
@@ -391,18 +383,18 @@ describe('prepareSessionWorkspace', () => {
       return args[0] === 'rev-parse' ? `${'c'.repeat(40)}\n` : ''
     })
 
-    const first = await prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
-    const again = await prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
-    const second = await prepareSessionWorkspace(agent, { sessionKey: 'session-b', isolation: 'session' })
+    const first = await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
+    const again = await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
+    const second = await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-b', isolation: 'session' })
 
     expect(again).toBe(first)
     expect(second).not.toBe(first)
-    expect(additionalWorkspaceDirectories(agent, first, { sessionKey: 'session-a', isolation: 'session' })).toEqual([
-      realpathSync(sessionWorktreePath(agent, 'session-a'))
-    ])
-    expect(additionalWorkspaceDirectories(agent, second, { sessionKey: 'session-b', isolation: 'session' })).toEqual([
-      realpathSync(sessionWorktreePath(agent, 'session-b'))
-    ])
+    expect(
+      workspaces.additionalWorkspaceDirectories(agent, first, { sessionKey: 'session-a', isolation: 'session' })
+    ).toEqual([realpathSync(workspaces.sessionWorktreePath(agent, 'session-a'))])
+    expect(
+      workspaces.additionalWorkspaceDirectories(agent, second, { sessionKey: 'session-b', isolation: 'session' })
+    ).toEqual([realpathSync(workspaces.sessionWorktreePath(agent, 'session-b'))])
   })
 
   /** A session worktree on `dev/<user>/<words>`, with control over which branch
@@ -431,7 +423,11 @@ describe('prepareSessionWorkspace', () => {
   it('checks the worktree out on its own branch, named for the user who opened the session', async () => {
     const { agent, addCall } = branchFixture()
 
-    await prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session', initiatedBy: 'Yu Long' })
+    await workspaces.prepareSessionWorkspace(agent, {
+      sessionKey: 'session-a',
+      isolation: 'session',
+      initiatedBy: 'Yu Long'
+    })
 
     expect(addCall()?.[2]).toBe('-b')
     expect(addCall()?.[3]).toMatch(/^dev\/yu-long\/[a-zA-Z]+-[a-zA-Z]+$/)
@@ -446,14 +442,18 @@ describe('prepareSessionWorkspace', () => {
       return args[0] === 'rev-parse' ? `${'c'.repeat(40)}\n` : ''
     })
 
-    await prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session', initiatedBy: 'yulong' })
+    await workspaces.prepareSessionWorkspace(agent, {
+      sessionKey: 'session-a',
+      isolation: 'session',
+      initiatedBy: 'yulong'
+    })
 
     expect(rawMock.mock.calls.filter(([args]) => (args as string[])[0] === 'show-ref')).toHaveLength(5)
     expect(addCall()?.[3]).toMatch(/^dev\/yulong\/[a-zA-Z]+-[a-zA-Z]+-[0-9a-f]{6}$/)
   })
 })
 
-describe('removeSessionWorktree (#485 retention GC)', () => {
+describe('workspaces.removeSessionWorktree(#485 retention GC)', () => {
   /** A git-repo agent plus one on-disk session worktree (a dir with a `.git` file,
    *  exactly what `worktree add` leaves behind). */
   function fixture() {
@@ -461,7 +461,7 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
     const path = join(root, 'workspace')
     mkdirSync(join(path, '.git'), { recursive: true })
     const agent = gitRepoAgent(path)
-    const requestedCwd = sessionWorktreePath(agent, 'session-a')
+    const requestedCwd = workspaces.sessionWorktreePath(agent, 'session-a')
     mkdirSync(requestedCwd, { recursive: true })
     const cwd = realpathSync(requestedCwd)
     writeFileSync(join(cwd, '.git'), 'gitdir: elsewhere')
@@ -480,7 +480,7 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
       return ''
     })
 
-    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
 
     const calls = gitCalls()
     const removeAt = calls.findIndex((args) => args[0] === 'worktree' && args[1] === 'remove' && args[2] === cwd)
@@ -509,7 +509,7 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
       return ''
     })
 
-    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
 
     const calls = gitCalls()
     const readAt = calls.findIndex((args) => args[0] === 'symbolic-ref')
@@ -529,7 +529,7 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
       if (args[0] === 'symbolic-ref') return 'main\n'
       return ''
     })
-    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
     expect(gitCalls().some((args) => args[0] === 'branch')).toBe(false)
 
     // Unique commits keep the worktree, so its branch must survive with them.
@@ -539,7 +539,10 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
       if (args[0] === 'symbolic-ref') return 'dev/yulong/brave-otter\n'
       return ''
     })
-    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'retained', reason: 'unique-commits' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({
+      outcome: 'retained',
+      reason: 'unique-commits'
+    })
     expect(gitCalls().some((args) => args[0] === 'branch')).toBe(false)
   })
 
@@ -551,7 +554,7 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
       return ''
     })
 
-    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
     expect(gitCalls().some((args) => args[0] === 'branch')).toBe(false)
   })
 
@@ -562,7 +565,7 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
       return '0\n'
     })
 
-    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'retained', reason: 'dirty' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'retained', reason: 'dirty' })
     expect(gitCalls().some((args) => args[0] === 'worktree')).toBe(false)
   })
 
@@ -570,7 +573,7 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
     const { agent } = fixture()
     rawMock.mockImplementation(async (args: string[]) => (args[0] === 'rev-list' ? '2\n' : ''))
 
-    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({
       outcome: 'retained',
       reason: 'unique-commits'
     })
@@ -585,22 +588,25 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
       return ''
     })
 
-    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'failed', error: 'worktree is locked' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({
+      outcome: 'failed',
+      error: 'worktree is locked'
+    })
   })
 
   it('an absent worktree still prunes stale registrations and review refs', async () => {
     const { agent, id } = fixture()
-    const other = sessionWorktreePath(agent, 'session-b')
-    expect(other).not.toBe(sessionWorktreePath(agent, 'session-a'))
+    const other = workspaces.sessionWorktreePath(agent, 'session-b')
+    expect(other).not.toBe(workspaces.sessionWorktreePath(agent, 'session-a'))
 
-    expect(await removeSessionWorktree(agent, 'session-b')).toEqual({ outcome: 'absent' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-b')).toEqual({ outcome: 'absent' })
 
     const calls = gitCalls()
     expect(calls).toContainEqual(['worktree', 'prune'])
     expect(calls).toContainEqual(['update-ref', '-d', `refs/agentconnect/reviews/${basename(other)}/base`])
     expect(calls.some((args) => args[0] === 'status' || args[0] === 'rev-list')).toBe(false)
     // fixture()'s own worktree for session-a is untouched
-    expect(existsSync(sessionWorktreePath(agent, 'session-a'))).toBe(true)
+    expect(existsSync(workspaces.sessionWorktreePath(agent, 'session-a'))).toBe(true)
     void id
   })
 
@@ -608,7 +614,7 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
     const { agent, cwd } = fixture()
     rmSync(join(cwd, '.git'))
 
-    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
     expect(existsSync(cwd)).toBe(false)
     expect(gitCalls()).toContainEqual(['worktree', 'prune'])
   })
@@ -618,7 +624,7 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
     rmSync(join(cwd, '.git'))
     writeFileSync(join(cwd, 'notes.md'), 'work in progress')
 
-    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'retained', reason: 'dirty' })
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'retained', reason: 'dirty' })
     expect(readFileSync(join(cwd, 'notes.md'), 'utf8')).toBe('work in progress')
   })
 
@@ -630,12 +636,12 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
     // An attacker-replaced root: `worktrees` is a symlink to a directory outside
     // the agent dir, holding a victim tree at the derived worktree id.
     const outside = mkdtempSync(join(tmpdir(), 'ac-wt-victim-'))
-    const victim = join(outside, basename(sessionWorktreePath(agent, 'session-a')))
+    const victim = join(outside, basename(workspaces.sessionWorktreePath(agent, 'session-a')))
     mkdirSync(victim, { recursive: true })
     writeFileSync(join(victim, 'precious.txt'), 'do not delete')
-    symlinkSync(outside, sessionWorktreeRoot(agent))
+    symlinkSync(outside, workspaces.sessionWorktreeRoot(agent))
 
-    const res = await removeSessionWorktree(agent, 'session-a')
+    const res = await workspaces.removeSessionWorktree(agent, 'session-a')
     expect(res.outcome).toBe('failed')
     expect(readFileSync(join(victim, 'precious.txt'), 'utf8')).toBe('do not delete')
   })
@@ -646,16 +652,16 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
     const outside = mkdtempSync(join(tmpdir(), 'ac-wt-outside-'))
     symlinkSync(outside, cwd)
 
-    const res = await removeSessionWorktree(agent, 'session-a')
+    const res = await workspaces.removeSessionWorktree(agent, 'session-a')
     expect(res.outcome).toBe('failed')
     expect(existsSync(outside)).toBe(true) // the link target was never touched
   })
 })
 
-describe('prefetchWorkspace (reconcile-time eager clone)', () => {
+describe('workspaces.prefetchWorkspace(reconcile-time eager clone)', () => {
   it('clones a git-repo with no checkout yet (warms it ahead of the first session)', async () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
-    await prefetchWorkspace(gitRepoAgent(path))
+    await workspaces.prefetchWorkspace(gitRepoAgent(path))
     expect(cloneImpl).toHaveBeenCalledTimes(1)
     expect(cloneImpl).toHaveBeenCalledWith('https://github.com/acme/repo.git', path, [
       '--branch',
@@ -666,14 +672,14 @@ describe('prefetchWorkspace (reconcile-time eager clone)', () => {
 
   it('is a no-op for from-scratch mode', async () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'workspace')
-    await prefetchWorkspace(fromScratchAgent(path))
+    await workspaces.prefetchWorkspace(fromScratchAgent(path))
     expect(cloneImpl).not.toHaveBeenCalled()
   })
 
   it('is a no-op (no re-clone, no pull) when a .git checkout already exists', async () => {
     const dir = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
     mkdirSync(join(dir, '.git'), { recursive: true })
-    await prefetchWorkspace(gitRepoAgent(dir))
+    await workspaces.prefetchWorkspace(gitRepoAgent(dir))
     expect(cloneImpl).not.toHaveBeenCalled()
     expect(pullMock).not.toHaveBeenCalled()
   })
@@ -687,7 +693,7 @@ describe('prepareWorkspaceForActivation', () => {
       writeFileSync(join(target, 'README.md'), 'converted')
     })
 
-    const rollback = await prepareWorkspaceForActivation(gitRepoAgent(path))
+    const rollback = await workspaces.prepareWorkspaceForActivation(gitRepoAgent(path))
     const cloneTarget = (cloneImpl as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string
     expect(cloneTarget).not.toBe(path)
     expect(existsSync(join(path, '.git'))).toBe(true)
@@ -703,7 +709,7 @@ describe('prepareWorkspaceForActivation', () => {
     mkdirSync(path, { recursive: true })
     writeFileSync(join(path, 'keep.txt'), 'do not overwrite')
 
-    await expect(prepareWorkspaceForActivation(gitRepoAgent(path))).rejects.toThrow('workspace is not empty')
+    await expect(workspaces.prepareWorkspaceForActivation(gitRepoAgent(path))).rejects.toThrow('workspace is not empty')
     expect(cloneImpl).not.toHaveBeenCalled()
     expect(existsSync(join(path, 'keep.txt'))).toBe(true)
   })
@@ -712,7 +718,7 @@ describe('prepareWorkspaceForActivation', () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-convert-')), 'workspace')
     cloneImpl = vi.fn().mockRejectedValue(new Error('clone failed'))
 
-    await expect(prepareWorkspaceForActivation(gitRepoAgent(path))).rejects.toThrow('clone failed')
+    await expect(workspaces.prepareWorkspaceForActivation(gitRepoAgent(path))).rejects.toThrow('clone failed')
     expect(existsSync(path)).toBe(true)
     expect(readdirSync(path)).toEqual([])
   })
@@ -724,7 +730,7 @@ describe('prepareWorkspaceForActivation', () => {
       writeFileSync(join(path, 'keep.txt'), 'do not overwrite')
     })
 
-    await expect(prepareWorkspaceForActivation(gitRepoAgent(path))).rejects.toThrow(
+    await expect(workspaces.prepareWorkspaceForActivation(gitRepoAgent(path))).rejects.toThrow(
       'workspace changed while conversion was cloning'
     )
     expect(existsSync(join(path, 'keep.txt'))).toBe(true)
@@ -735,9 +741,9 @@ describe('prepareWorkspaceForActivation', () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-convert-')), 'workspace')
     mkdirSync(join(path, '.git'), { recursive: true })
 
-    await expect(prepareWorkspaceForActivation(gitRepoAgent(path), { allowExistingCheckout: false })).rejects.toThrow(
-      'workspace changed after its empty check'
-    )
+    await expect(
+      workspaces.prepareWorkspaceForActivation(gitRepoAgent(path), { allowExistingCheckout: false })
+    ).rejects.toThrow('workspace changed after its empty check')
     expect(cloneImpl).not.toHaveBeenCalled()
   })
 
@@ -751,7 +757,7 @@ describe('prepareWorkspaceForActivation', () => {
     })
     mkdirSync(join(path, '.git'), { recursive: true })
     writeFileSync(join(path, 'local.txt'), 'keep me')
-    recordWorkspaceMaterialization(current)
+    workspaces.recordWorkspaceMaterialization(current)
     // Older daemons recorded the conventional `.git` suffix in this marker.
     writeFileSync(
       join(dirname(path), `.${basename(path)}.workspace-materialization.json`),
@@ -768,7 +774,7 @@ describe('prepareWorkspaceForActivation', () => {
       args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/repo.git\n' : ''
     )
 
-    const rollback = await prepareWorkspaceForActivation(
+    const rollback = await workspaces.prepareWorkspaceForActivation(
       { ...current, workspace: { ...current.workspace, gitRepo: 'https://github.com/acme/repo' } } as Agent,
       { reconcileMaterialization: true }
     )
@@ -789,7 +795,7 @@ describe('prepareWorkspaceForActivation', () => {
     })
     mkdirSync(join(path, '.git'), { recursive: true })
     writeFileSync(join(path, 'untrusted.txt'), 'wrong-host content')
-    recordWorkspaceMaterialization(agent)
+    workspaces.recordWorkspaceMaterialization(agent)
     rawMock.mockImplementation(async (args: string[]) =>
       args[0] === 'remote' && args[1] === 'get-url' ? 'https://other-host.example/acme/repo.git\n' : ''
     )
@@ -798,7 +804,7 @@ describe('prepareWorkspaceForActivation', () => {
       writeFileSync(join(target, 'README.md'), 'authorized GitHub content')
     })
 
-    const rollback = await prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
+    const rollback = await workspaces.prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
 
     expect(cloneImpl).toHaveBeenCalledWith('https://github.com/acme/repo.git', expect.any(String), [
       '--branch',
@@ -817,7 +823,7 @@ describe('prepareWorkspaceForActivation', () => {
     mkdirSync(join(path, '.git'), { recursive: true })
     mkdirSync(join(path, 'packages', 'service'), { recursive: true })
     writeFileSync(join(path, 'local.txt'), 'keep me')
-    recordWorkspaceMaterialization(current)
+    workspaces.recordWorkspaceMaterialization(current)
     let failSetUrl = true
     rawMock.mockImplementation(async (args: string[]) => {
       if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/old-name\n'
@@ -829,10 +835,10 @@ describe('prepareWorkspaceForActivation', () => {
       ...current,
       workspace: { ...current.workspace, gitRepo: 'https://github.com/acme/new-name' }
     } as Agent
-    await expect(convergeGithubAppWorkspaceRename(renamed)).rejects.toThrow('config locked')
+    await expect(workspaces.convergeGithubAppWorkspaceRename(renamed)).rejects.toThrow('config locked')
     failSetUrl = false
 
-    const rollback = await prepareWorkspaceForActivation(
+    const rollback = await workspaces.prepareWorkspaceForActivation(
       { ...renamed, workspace: { ...renamed.workspace, agentDir: 'packages/service' } } as Agent,
       { reconcileMaterialization: true }
     )
@@ -855,7 +861,7 @@ describe('prepareWorkspaceForActivation', () => {
     const current = gitRepoAgent(path)
     mkdirSync(join(path, '.git'), { recursive: true })
     writeFileSync(join(path, 'local.txt'), 'discard me')
-    recordWorkspaceMaterialization(current)
+    workspaces.recordWorkspaceMaterialization(current)
     cloneImpl = vi.fn().mockImplementation(async (_repo: string, target: string) => {
       mkdirSync(join(target, '.git'), { recursive: true })
       writeFileSync(join(target, 'README.md'), 'replacement')
@@ -866,9 +872,9 @@ describe('prepareWorkspaceForActivation', () => {
     } as Agent
     // A crash can leave the target spec on disk before materialization. The next
     // detach must not overwrite the source marker merely because it sees that spec.
-    ensureWorkspaceMaterialization(target)
+    workspaces.ensureWorkspaceMaterialization(target)
 
-    const rollback = await prepareWorkspaceForActivation(target, { reconcileMaterialization: true })
+    const rollback = await workspaces.prepareWorkspaceForActivation(target, { reconcileMaterialization: true })
 
     expect(existsSync(join(path, 'local.txt'))).toBe(false)
     expect(readFileSync(join(path, 'README.md'), 'utf8')).toBe('replacement')
@@ -893,7 +899,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-ws-repin-'))
     mkdirSync(join(dir, '.git'))
 
-    await prepareWorkspace(githubAppAgent(dir))
+    await workspaces.prepareWorkspace(githubAppAgent(dir))
 
     const configCalls = rawMock.mock.calls.map((c) => c[0] as string[])
     expect(configCalls).toContainEqual(['config', '--replace-all', 'credential.https://github.com.helper', ''])
@@ -913,7 +919,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/old-name\n' : ''
     )
 
-    await prepareWorkspace(agent)
+    await workspaces.prepareWorkspace(agent)
 
     expect(rawMock.mock.calls.map((call) => call[0])).toContainEqual(['remote', 'get-url', 'origin'])
     expect(rawMock.mock.calls.map((call) => call[0])).toContainEqual([
@@ -939,7 +945,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
     })
 
     try {
-      await prepareWorkspace(agent)
+      await workspaces.prepareWorkspace(agent)
     } finally {
       if (previousGitDir === undefined) delete process.env.GIT_DIR
       else process.env.GIT_DIR = previousGitDir
@@ -960,7 +966,9 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       args[0] === 'remote' && args[1] === 'get-url' ? 'https://other-host.example/acme/repo.git\n' : ''
     )
 
-    await expect(prepareWorkspace(githubAppAgent(dir))).rejects.toThrow('origin is not a trusted GitHub remote')
+    await expect(workspaces.prepareWorkspace(githubAppAgent(dir))).rejects.toThrow(
+      'origin is not a trusted GitHub remote'
+    )
     expect(pullMock).not.toHaveBeenCalled()
   })
 
@@ -975,7 +983,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       return ''
     })
 
-    await expect(prepareWorkspace(agent)).rejects.toThrow('config locked')
+    await expect(workspaces.prepareWorkspace(agent)).rejects.toThrow('config locked')
     expect(pullMock).not.toHaveBeenCalled()
   })
 
@@ -986,7 +994,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/repo.git\n' : ''
     )
 
-    await prepareWorkspace(gitRepoAgent(dir))
+    await workspaces.prepareWorkspace(gitRepoAgent(dir))
 
     expect(rawMock.mock.calls.map((call) => call[0])).toContainEqual(['remote', 'get-url', 'origin'])
     expect(rawMock.mock.calls.map((call) => call[0])).not.toContainEqual([
@@ -1006,7 +1014,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
         : ''
     )
 
-    await prepareWorkspace(gitRepoAgent(dir))
+    await workspaces.prepareWorkspace(gitRepoAgent(dir))
 
     expect(rawMock.mock.calls.map((call) => call[0])).toContainEqual([
       'remote',
@@ -1026,7 +1034,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       args[0] === 'remote' && args[1] === 'get-url' ? 'acme/repo\n' : ''
     )
 
-    await prepareWorkspace(agent)
+    await workspaces.prepareWorkspace(agent)
 
     expect(rawMock.mock.calls.map((call) => call[0])).toContainEqual([
       'remote',
@@ -1038,27 +1046,27 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
   })
 })
 
-describe('clusterWorkspaceCwd (--k8s pod coordinates)', () => {
+describe('workspaces.clusterWorkspaceCwd(--k8s pod coordinates)', () => {
   it('hands a from-scratch agent the pod root, never the daemon-disk workspace path', () => {
     const agent = fromScratchAgent('/var/lib/agentconnect/agents/bot-a/workspace')
-    expect(clusterWorkspaceCwd(agent, '/agent')).toBe('/agent')
+    expect(workspaces.clusterWorkspaceCwd(agent, '/agent')).toBe('/agent')
   })
 
   it('falls back to the historical mount for a legacy shim that reported none', () => {
     const agent = fromScratchAgent('/var/lib/agentconnect/agents/bot-a/workspace')
-    expect(clusterWorkspaceCwd(agent, undefined)).toBe('/agent')
+    expect(workspaces.clusterWorkspaceCwd(agent, undefined)).toBe('/agent')
   })
 
   it('checks a git-repo workspace out below the mount, never at the daemon-disk path', () => {
     // The mount is also the runtime's HOME, so a working tree at the root would sit on top of its
     // `.claude`/`.codex` state. What must never appear is the daemon's own workspace path.
     const agent = gitRepoAgent('/var/lib/agentconnect/agents/bot-git/workspace')
-    expect(clusterWorkspaceCwd(agent, '/agent')).toBe('/agent/repo')
-    expect(clusterWorkspaceCwd(agent, '/agent')).not.toContain('/var/lib/agentconnect')
+    expect(workspaces.clusterWorkspaceCwd(agent, '/agent')).toBe('/agent/repo')
+    expect(workspaces.clusterWorkspaceCwd(agent, '/agent')).not.toContain('/var/lib/agentconnect')
   })
 
   it('refuses session isolation, whose worktrees still assume the daemon filesystem', () => {
     const agent = fromScratchAgent('/var/lib/agentconnect/agents/bot-a/workspace')
-    expect(() => clusterWorkspaceCwd(agent, '/agent', { isolation: 'session' })).toThrow(/session-isolated/)
+    expect(() => workspaces.clusterWorkspaceCwd(agent, '/agent', { isolation: 'session' })).toThrow(/session-isolated/)
   })
 })

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -1,13 +1,49 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, configDefaults } from 'vitest/config'
 import { githubActionsReporters } from '../../scripts/vitest-github-reporters.js'
+
+// The files that call `vi.mock`. A mock is registered per FILE but rewires a module in the registry,
+// so under a shared registry it either misses (the real module was already imported by an earlier
+// file) or leaks into a later one — `workspace.test.ts` mocking `simple-git` came out as "fatal: not
+// a git repository" because real git ran. Nothing else in this suite is registry-sensitive, so these
+// keep per-file isolation and everything else stops paying for it.
+//
+// `test/no-stray-vi-mock.test.ts` fails if this list drifts from what the suite actually mocks.
+export const MOCKING_TESTS = [
+  'test/cp/cp-integration.test.ts',
+  'test/daemon-cp-onboarding.test.ts',
+  'test/telegram-connection.test.ts',
+  'test/workspace-git.test.ts',
+  'test/workspace.test.ts'
+]
 
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['test/**/*.test.ts'],
     // Keep process-heavy, integration-shaped unit files from oversubscribing
     // available test-worker resources.
     maxWorkers: 4,
-    reporters: githubActionsReporters('daemon.md')
+    reporters: githubActionsReporters('daemon.md'),
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'daemon',
+          include: ['test/**/*.test.ts'],
+          exclude: [...configDefaults.exclude, ...MOCKING_TESTS],
+          // Execute each module once per worker instead of once per FILE. Module-level state is
+          // shared as a result, which is why the workspace execution plane had to become per-daemon
+          // instance state first — see `WorkspaceManager`.
+          isolate: false
+        }
+      },
+      {
+        extends: true,
+        test: {
+          name: 'daemon-mocked',
+          include: MOCKING_TESTS,
+          isolate: true
+        }
+      }
+    ]
   }
 })


### PR DESCRIPTION
Cuts the daemon unit suite's CPU by ~69% by executing each module once per worker instead of once per test file. Replaces the CI-sharding approach that was previously on this branch (that diff is still reachable at `7243db15` if we want it later).

## The measurement

`packages/daemon` was ~88% of the Unit Test job's 3m31s step (248 files, 3699 tests, 186.52s against the step's 211s), and `import` was 327.50s of its ~700s of worker time — module re-execution, not tests.

On one machine, full suite:

| | wall | user+sys CPU |
|---|---|---|
| before | 3m28s | **8m55s** |
| after | 2m47s | **2m48s** |

Wall moves less than CPU locally because much of this suite is *idle*, not busy — see the last section. CI is CPU-bound, so it should track the CPU number.

## What had to change first

`isolate: false` shares module-level state between files in a worker, so anything the daemon kept at module scope becomes cross-file state. Two commits precede the flip:

**1. `WorkspaceManager` (`1414b269`, `05619dec`).** Where an agent's git runs, how a path this process cannot see gets emptied, whether workspaces live in sandboxes, and the clone single-flight were four module-level bindings that `Daemon.start()` wrote. They are now instance state owned by the daemon, threaded to the three CP factories, `SessionManager`, and the standalone `chat` CLI.

This is a real production bug independent of tests: a process holding two daemons had **one** plane between them, so the second inherited the first's git runner and sandbox mode — its git could run through the other's sandbox channel, or a cluster clone could land on this disk. A k8s daemon beside a local one is exactly that shape.

Honest note: I predicted this refactor would unblock `workspace.test.ts` and `workspace-git.test.ts` under `isolate: false`. It did not — they were failing for the reason below. The refactor stands on the production bug, not on the test win I expected from it.

**2. `vi.mock` is the one genuinely registry-sensitive construct.** A mock is registered per file but rewires a module in the shared registry, so it either misses (the real module was already imported by an earlier file) or leaks into a later one. `workspace.test.ts` mocking `simple-git` surfaced as `fatal: not a git repository` — real git ran.

Measured directly rather than guessed: excluding the five files that call `vi.mock` leaves **zero** isolation failures across the other 246, and those five are the entire remaining set. So they get a second Vitest project that keeps `isolate: true`, and the other 246 stop paying for isolation they never used.

`test/no-stray-vi-mock.test.ts` fails if that list drifts in either direction, so a new `vi.mock` breaks at the seam instead of somewhere unrelated depending on which worker paired the two files.

## Test plan

- Full daemon suite: 3789 tests, 13 failures in 6 files — all pre-existing sandbox-network flakes present on the base commit too, **zero new**
- Same comparison after each of the three commits, against a baseline captured on the same machine
- `tsc -p tsconfig.typecheck.json` — 0 errors; `eslint`, `prettier --check` clean

## Two things this does not fix

**Sharding.** Still available at `7243db15` (2 shards, cost-balanced sequencer, reviewed and green). Worth re-deciding once CI shows what this change alone buys.

**The daemon unit suite reaches slack.com.** `Daemon.start()` makes a `@slack/web-api` call on every boot, and 54 test files construct a `Daemon`. On CI it is fast because Slack answers `invalid_auth` over HTTP and `p-retry` does not retry a successful response — but where the request fails at the transport layer the retry ladder costs ~4s per boot, which is why local wall clock here is mostly idle. It also already caused a real CI failure on this branch: the one test using `boot(..., { distinctTokens: true })` makes **two** such calls and timed out at 5s. Worth stubbing at the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtPhRcPGtRX8RZqApUZRGu