### PR TITLE
refactor(daemon): run the orphan reconciler as a one-shot CronJob

### DIFF
--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -192,22 +192,29 @@ Teardown is best-effort and a member can die mid-way — a rollout, an OOM, a
 node loss — leaving a `SandboxClaim`, a `Sandbox`, or a probe claim that no
 process still intends to remove. Rather than one durable obligation per
 failure mode, a single **orphan reconciler**
-(`packages/daemon/src/k8s/orphan-reconciler.ts`) sweeps the sandbox namespace
-on every `--k8s` daemon, by default every 10 minutes with ±25% jitter, and one
-member at a time: a named single-holder lease in the shared store
-(`LocalStore.acquireSweepLease`, table `sweep_leases`) is taken or renewed at
-each sweep and lasts three intervals, so a holder that disappears is replaced
-after at most that.
+(`packages/daemon/src/k8s/orphan-reconciler.ts`) sweeps the sandbox namespace.
+
+**It is a CronJob, not a timer.** The deployment runs
+`agentconnect-daemon reconcile --once` on a schedule (every 10 minutes) with
+`concurrencyPolicy: Forbid`: one shot per run, and the cluster — not the daemon
+— owns the cadence, the mutual exclusion a lease used to provide, and the
+failure reporting a non-zero exit already gives an operator. The Job uses the
+daemon image, the pool members' ServiceAccount, and the same namespace and
+warm-pool environment they read; the members themselves run no sweep and hold
+no scheduler state for one. The job connects to the control plane as an
+**observer** (`register.observer`): the same projected identity a member
+presents, admitted on the same TokenReview path, but enrolled in no member set
+— so the duty ledger can never grant work to a process whose only job is to
+sweep — and marked so the pool-member reaper retires its row promptly.
 
 **What it collects.** It lists the claims and Sandboxes that carry the
 install's agent label (`agentconnect.md/agent` on the pod metadata), asks the
-control plane in **one batched read per sweep** which of those agent ids still
+control plane in **one batched read per run** which of those agent ids still
 exist (`agent/exists` → `agent/exists/ok`, install-wide, advertised as the
 `agent-exists-v1` server feature), and deletes only what is provably orphaned:
 
-- a claim whose agent the control plane no longer knows — and has not known for
-  at least the grace period (default 10 minutes) as observed by the sweeping
-  member across its own sweeps, on an object at least that old;
+- a claim whose agent the control plane no longer knows, on an object at least
+  the grace period old (default 10 minutes);
 - a probe claim past the window the probe stamped on it;
 - a Sandbox no claim binds, whose agent the control plane no longer knows,
   under the same grace.
@@ -215,19 +222,23 @@ exist (`agent/exists` → `agent/exists/ok`, install-wide, advertised as the
 **Safety rules.** An object of a live agent is never touched, a claimless
 Sandbox included — deleting a claim deletes the workspace volume and is
 irreversible, so a stray of a live agent is reported, not collected. An id the
-control plane cannot be asked about, an object without a readable age, and a
-sweep whose control-plane read fails all skip. Every delete carries the UID and
-resourceVersion from the LIST snapshot, so a same-name replacement created
-after the list is never the object deleted. Each sweep logs one summary line
-(candidates, orphaned, deleted, skipped-live, skipped-grace, failed).
+control plane cannot be asked about and an object without a readable age skip;
+a run whose control-plane read fails collects nothing and exits non-zero. The
+grace is the OBJECT'S OWN AGE, which is the clock that matters — no in-flight
+creation can still be racing the control plane's write — and the only one a
+one-shot job has, since it keeps no memory of an earlier run. Every delete
+carries the UID and resourceVersion from the LIST snapshot, so a same-name
+replacement created after the list is never the object deleted. Each run logs
+one summary line (candidates, orphaned, deleted, skipped-live, skipped-grace,
+failed).
 
 **Dry run by default.** The reconciler ships reporting only; deletion is
 enabled per deployment with `AC_K8S_ORPHAN_DELETE=true` after an observation
 window in which the summary lines show it collecting exactly what an operator
-would (`AC_K8S_ORPHAN_SWEEP_INTERVAL_MS` and `AC_K8S_ORPHAN_GRACE_MS` tune the
-cadence and grace). It replaced the dedicated probe-claim GC, and agent
-removal's sandbox teardown is best-effort because of it: `discardAgent` deletes
-the claim once and logs a failure, and the reconciler collects the leftovers.
+would (`AC_K8S_ORPHAN_GRACE_MS` tunes the grace). It replaced the dedicated
+probe-claim GC, and agent removal's sandbox teardown is best-effort because of
+it: `discardAgent` deletes the claim once and logs a failure, and the
+reconciler collects the leftovers.
 
 ## 5. The duty ledger and lease service (D6, D7)
 
@@ -880,17 +891,17 @@ shrinking every actor's permissions.
 
 ## 17. Implementation map
 
-| Piece                                                                  | Where                                                                                                    |
-| ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| Frames + member cap                                                    | `packages/protocol/src/frames/duty.ts`, `relay-daemon.ts` (`RD_ACK_NOT_HOLDER`)                          |
-| Schema + repo (CAS claim, renew, release, reconcile, agent-home claim) | `packages/control-plane/prisma/schema.prisma`, `src/persistence/repositories/duty-group.repo.ts`         |
-| Pure group math + reconcile planner                                    | `packages/control-plane/src/orchestrator/dutyGroup.ts`                                                   |
-| Lease exchange (digest diff, chunking, lanes, grace)                   | `packages/control-plane/src/orchestrator/dutyLease.ts`                                                   |
-| Recompute sweep + mutation kicks + placement fence                     | `packages/control-plane/src/orchestrator/dutyRecompute.ts`                                               |
-| WS handlers                                                            | `packages/control-plane/src/ws/handlers/{heartbeat,duty-release,duty-claim}.ts`                          |
-| Daemon registry + gate + rendezvous claim                              | `packages/daemon/src/cp/duty-registry.ts`, `src/daemon.ts` (`transportAgents`, `claimDutyForTrigger`)    |
-| Relay re-route                                                         | `packages/relay/src/relay-ingress-manager.ts` (`sendWithRendezvous`), `relay-browser-connection.ts`      |
-| Shim dial-in                                                           | `packages/daemon/src/shim/{dialer,server}.ts`                                                            |
-| Pod-bound member identity                                              | `packages/control-plane/src/cluster/daemon-identity.ts`                                                  |
-| Member readiness (probe sinks)                                         | `packages/daemon/src/readiness.ts`, `src/daemon.ts` (`readinessState`)                                   |
-| Orphan reconciler + existence read                                     | `packages/daemon/src/k8s/orphan-reconciler.ts`, `packages/control-plane/src/ws/handlers/agent-exists.ts` |
+| Piece                                                                  | Where                                                                                                                                            |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Frames + member cap                                                    | `packages/protocol/src/frames/duty.ts`, `relay-daemon.ts` (`RD_ACK_NOT_HOLDER`)                                                                  |
+| Schema + repo (CAS claim, renew, release, reconcile, agent-home claim) | `packages/control-plane/prisma/schema.prisma`, `src/persistence/repositories/duty-group.repo.ts`                                                 |
+| Pure group math + reconcile planner                                    | `packages/control-plane/src/orchestrator/dutyGroup.ts`                                                                                           |
+| Lease exchange (digest diff, chunking, lanes, grace)                   | `packages/control-plane/src/orchestrator/dutyLease.ts`                                                                                           |
+| Recompute sweep + mutation kicks + placement fence                     | `packages/control-plane/src/orchestrator/dutyRecompute.ts`                                                                                       |
+| WS handlers                                                            | `packages/control-plane/src/ws/handlers/{heartbeat,duty-release,duty-claim}.ts`                                                                  |
+| Daemon registry + gate + rendezvous claim                              | `packages/daemon/src/cp/duty-registry.ts`, `src/daemon.ts` (`transportAgents`, `claimDutyForTrigger`)                                            |
+| Relay re-route                                                         | `packages/relay/src/relay-ingress-manager.ts` (`sendWithRendezvous`), `relay-browser-connection.ts`                                              |
+| Shim dial-in                                                           | `packages/daemon/src/shim/{dialer,server}.ts`                                                                                                    |
+| Pod-bound member identity                                              | `packages/control-plane/src/cluster/daemon-identity.ts`                                                                                          |
+| Member readiness (probe sinks)                                         | `packages/daemon/src/readiness.ts`, `src/daemon.ts` (`readinessState`)                                                                           |
+| Orphan reconciler + `reconcile --once` job + existence read            | `packages/daemon/src/k8s/orphan-reconciler.ts`, `packages/daemon/src/cli/reconcile.ts`, `packages/control-plane/src/ws/handlers/agent-exists.ts` |

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -224,6 +224,12 @@ export interface DaemonRepo {
    * increasing epoch. First call for a daemon creates the row.
    */
   upsertOnAuth(input: AuthReqInput): Promise<{ daemon: DaemonRecord; sessionEpoch: bigint }>
+  /**
+   * Undo the automatic pool enrollment for a connection that registered as an OBSERVER, and
+   * backdate its liveness so the pool-member reaper retires the row on its next sweep. An
+   * observer holds no membership, so `claimVacant`'s eligibility gate can never reach it.
+   */
+  withdrawObserver(daemonId: DaemonId): Promise<void>
   /** Also records `generation`, stamping `generationSince` only when the value changes. */
   applyRegister(daemonId: DaemonId, reg: RegisterReqInput, now: Date): Promise<DaemonRecord>
   /** Full-replace the stored capabilities from a mid-connection `capabilities/update`. */

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -230,6 +230,15 @@ export class PgDaemonRepo implements DaemonRepo {
     })
   }
 
+  /** The observer's whole cost at the CP: no membership, and a row the reaper takes on its next
+   *  sweep. `new Date(0)` is older than any cutoff, and an observer sends no heartbeat to move it. */
+  async withdrawObserver(daemonId: DaemonId): Promise<void> {
+    await withAmbientTx(this.db, async (tx) => {
+      await tx.memberSetMember.deleteMany({ where: { daemonId } })
+      await tx.daemon.update({ where: { id: daemonId }, data: { lastSeenAt: new Date(0) } })
+    })
+  }
+
   async applyRegister(daemonId: DaemonId, reg: RegisterReqInput, now: Date): Promise<DaemonRecord> {
     // The generation's first-seen stamp moves only when the value does — it orders generations
     // within a member set (duty-group.repo.ts `newerGenerationLive`), so a re-register must not

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -263,6 +263,8 @@ export interface DaemonLiveness {
  */
 export interface DaemonRegistry {
   upsertOnRegister(daemonId: DaemonId, req: RegisterReq): Promise<void>
+  /** Admit an observer connection without making it a pool member (k8s-daemon-pool.md §4). */
+  withdrawObserver(daemonId: DaemonId): Promise<void>
   /** Persist a mid-connection `capabilities/update` full-replace (the durable
    *  sibling of the ConnectionRegistry's live copy). */
   updateCapabilities(daemonId: DaemonId, capabilities: RegisterReq['capabilities']): Promise<void>

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -108,6 +108,13 @@ export class DaemonRegistryService implements DaemonRegistry {
     )
   }
 
+  /** Observer registration (k8s-daemon-pool.md §4): drop the membership `upsertOnAuth` minted for
+   *  this identity and backdate its liveness, so the ledger cannot grant it and the pool-member
+   *  reaper retires the row on its next sweep instead of at the ordinary silence window. */
+  async withdrawObserver(daemonId: DaemonId): Promise<void> {
+    await this.daemons.withdrawObserver(daemonId)
+  }
+
   async updateCapabilities(daemonId: DaemonId, capabilities: RegisterReq['capabilities']): Promise<void> {
     await this.daemons.setCapabilities(daemonId, capabilities)
   }

--- a/packages/control-plane/src/ws/handlers/register.ts
+++ b/packages/control-plane/src/ws/handlers/register.ts
@@ -27,6 +27,17 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
   const req = frame.payload
   const did = DaemonId(conn.daemonId)
 
+  // An observer (`reconcile --once`) is admitted on the identity a member presents but is not one:
+  // it serves nothing, so it must hold no membership the duty ledger could grant against. Refused
+  // on an org-scoped connection — that credential is an operator's daemon key, not a job's identity.
+  if (req.observer === true) {
+    if (conn.orgId !== null) {
+      conn.sendError(frame.id, 'SCOPE_DENIED', 'observer registration requires an install-wide connection', false)
+      return
+    }
+    await deps.registry.withdrawObserver(did)
+  }
+
   await deps.registry.upsertOnRegister(did, req)
   // A fresh registration clears the member's draining declaration (frames/duty.ts).
   deps.dutyLease.onRegister(did)

--- a/packages/control-plane/test/protocol/observer-register.handler.test.ts
+++ b/packages/control-plane/test/protocol/observer-register.handler.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Observer registration (`register.observer`) — the connection the `reconcile --once` CronJob
+ * opens. It authenticates on the same projected pool identity a member does, so the CP admits it
+ * and answers its reads, but it must never become a pool member: no membership row, so the duty
+ * ledger's eligibility gate can never reach it, and a row the pool-member reaper takes at once.
+ */
+import { describe, it, expect } from 'vitest'
+import { prisma } from '../setup.db.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { buildWsHarness } from '../fakes/build-ws.js'
+import { poolSetId } from '../fakes/member-set.js'
+import { PgDaemonRepo } from '../../src/persistence/index.js'
+
+const OBSERVER = 'd0b5e4be-0000-4000-8000-000000000001'
+const MEMBER = 'd0b5e4be-0000-4000-8000-000000000002'
+const AGENT = 'a0b5e4be-0000-4000-8000-000000000003'
+const GROUP = '00000000-0000-4000-8000-0000000000a1'
+const AUTH_ID = '11111111-1111-4111-8111-000000000001'
+const REG_ID = '22222222-2222-4222-8222-000000000002'
+
+function registerPayload(observer?: boolean) {
+  return {
+    host: observer ? 'reconcile' : 'member-1',
+    ...(observer ? { observer: true } : {}),
+    capabilities: { platforms: [], runtimes: [], acp: false, features: [] },
+    maxAgents: observer ? 0 : 8,
+    localState: { assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }
+  }
+}
+
+/** Auth a pool Pod identity, then register — as an observer or as an ordinary member. */
+async function connect(h: ReturnType<typeof buildWsHarness>, daemonId: string, observer?: boolean) {
+  const { stub } = h.connect()
+  const token = await h.mintPoolMember(daemonId)
+  stub.inject('auth', { serviceAccountToken: token, daemonId, agentVersion: '1.4.0' }, { id: AUTH_ID })
+  await stub.expectFrame('auth/ok')
+  stub.inject('register', registerPayload(observer), { id: REG_ID })
+  await stub.settled()
+  return stub
+}
+
+/** A vacant duty group over one set-placed agent — the only thing a pool member could be granted. */
+async function seedVacantDuty(): Promise<void> {
+  await prisma.agent.create({
+    data: {
+      id: AGENT,
+      orgId: DEFAULT_ORG_ID,
+      name: 'agent-1',
+      runtime: 'claude',
+      placementKind: 'set',
+      setId: await poolSetId(prisma)
+    }
+  })
+  await prisma.dutyGroup.create({ data: { id: GROUP, orgId: DEFAULT_ORG_ID, holder: null, term: 0n } })
+  await prisma.dutyGroupMember.create({
+    data: { kind: 'agent', refId: AGENT, groupId: GROUP, orgId: DEFAULT_ORG_ID }
+  })
+}
+
+const heartbeat = { load: { cpu: 0.1, mem: 0.1, agents: 0 }, health: 'ok', activeSessions: 0 }
+
+describe('observer registration (protocol level, real Postgres)', () => {
+  it('admits the identity but enrolls no member, so the ledger never grants it a group', async () => {
+    await seedVacantDuty()
+    const h = buildWsHarness(prisma)
+    const stub = await connect(h, OBSERVER, true)
+    expect(stub.lastSent('register/ok')).toBeDefined()
+
+    // `upsertOnAuth` enrolls every org-less row; the observer's registration takes it back out.
+    expect(await prisma.memberSetMember.findUnique({ where: { daemonId: OBSERVER } })).toBeNull()
+
+    stub.inject('heartbeat', { ...heartbeat, duties: { held: [], headroom: 8 } })
+    await stub.settled()
+    expect(stub.sent.filter((f) => f.type === 'duty/grant')).toEqual([])
+    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).holder).toBeNull()
+  })
+
+  it('leaves an ordinary member of the same pool claiming that group — the difference IS the flag', async () => {
+    await seedVacantDuty()
+    const h = buildWsHarness(prisma)
+    const stub = await connect(h, MEMBER)
+    expect(await prisma.memberSetMember.findUnique({ where: { daemonId: MEMBER } })).not.toBeNull()
+
+    stub.inject('heartbeat', { ...heartbeat, duties: { held: [], headroom: 8 } })
+    await stub.settled()
+    expect((await prisma.dutyGroup.findUniqueOrThrow({ where: { id: GROUP } })).holder).toBe(MEMBER)
+  })
+
+  it('answers an observer connection’s agent/exists read — the one thing the sweep connects for', async () => {
+    await seedVacantDuty()
+    const h = buildWsHarness(prisma)
+    const stub = await connect(h, OBSERVER, true)
+    const gone = 'a0b5e4be-0000-4000-8000-00000000dead'
+
+    stub.inject('agent/exists', { agentIds: [AGENT, gone] })
+    await stub.settled()
+    expect(stub.lastSent('agent/exists/ok')?.payload).toEqual({ existing: [AGENT] })
+  })
+
+  it('backdates the row so the pool-member reaper retires it on its next sweep', async () => {
+    const h = buildWsHarness(prisma)
+    const stub = await connect(h, OBSERVER, true)
+    expect(stub.lastSent('register/ok')).toBeDefined()
+    // What makes the row a POOL member row, which is the only shape the reaper may touch.
+    await prisma.daemon.update({
+      where: { id: OBSERVER },
+      data: { clusterIdentity: 'system:serviceaccount:pool:daemon', clusterPodUid: 'pod-observer' }
+    })
+
+    const retired = await new PgDaemonRepo(prisma).findRetiredPoolMembers(new Date(h.clock.now()))
+    expect(retired.map((row) => row.id)).toEqual([OBSERVER])
+  })
+
+  it('refuses the flag on an org-scoped connection, which is a daemon key and not a job identity', async () => {
+    const h = buildWsHarness(prisma)
+    const { stub } = h.connect()
+    const key = await h.mintToken(MEMBER)
+    stub.inject('auth', { apiKey: key, daemonId: MEMBER, agentVersion: '1.4.0' }, { id: AUTH_ID })
+    await stub.expectFrame('auth/ok')
+
+    stub.inject('register', registerPayload(true), { id: REG_ID })
+    await stub.settled()
+    expect(stub.lastSent('register/ok')).toBeUndefined()
+    expect(stub.lastSent('error')?.payload).toMatchObject({ code: 'SCOPE_DENIED' })
+  })
+})

--- a/packages/daemon/src/cli/reconcile.ts
+++ b/packages/daemon/src/cli/reconcile.ts
@@ -55,7 +55,7 @@ export interface ObserverSeams {
 const dialCp = (url: string): Promise<Transport> =>
   ClientTransport.dial(url, { subprotocol: CP_SUBPROTOCOL, path: CP_WS_PATH, handshakeTimeoutMs: REQUEST_TIMEOUT_MS })
 
-/** Exit code: 0 when the sweep completed, 1 when it could not. */
+/** Exit code: 0 only when the sweep ran AND collected everything it decided to; 1 otherwise. */
 export async function runReconcileOnce(opts: ReconcileOnceOpts = {}): Promise<number> {
   const env = opts.env ?? process.env
   const log = opts.log ?? { info: (m: string) => console.log(m), warn: (m: string) => console.error(m) }
@@ -70,7 +70,10 @@ export async function runReconcileOnce(opts: ReconcileOnceOpts = {}): Promise<nu
     if (!url) throw new Error(`reconcile requires the control plane's address in ${CP_URL_ENV}`)
     cp = await (opts.connectCp ?? connectObserver)(url)
     const reconciler = new OrphanReconciler({ api, liveAgents: cp.liveAgents, settings, log })
-    return (await reconciler.sweep()) ? 0 : 1
+    const summary = await reconciler.sweep()
+    // A delete that failed is counted, not thrown, so the run reports the whole picture — but a run
+    // that left an orphan behind is not a successful Job, or the cluster hides a leak that repeats.
+    return summary && summary.failed === 0 ? 0 : 1
   } catch (err) {
     log.warn(`k8s orphans: sweep failed — ${(err as Error).message}`)
     return 1

--- a/packages/daemon/src/cli/reconcile.ts
+++ b/packages/daemon/src/cli/reconcile.ts
@@ -1,0 +1,144 @@
+/**
+ * `agentconnect-daemon reconcile --once` — one orphan sweep of the sandbox namespace, then exit.
+ *
+ * The reconciler is a Kubernetes CronJob, not a timer inside every pool member: the cluster owns
+ * the schedule, `concurrencyPolicy: Forbid` is the mutual exclusion a lease used to provide, and a
+ * failed run is a failed Job the cluster already reports. So this boots the minimum a sweep needs —
+ * the sandbox API surface and a control-plane connection to ask which agents still exist — and
+ * nothing else: no store, no agents, no platform connections (k8s-daemon-pool.md §4).
+ *
+ * The connection registers as an OBSERVER. It presents the same projected pool identity a member
+ * does, so the control plane admits it on the same TokenReview path, but it is enrolled in no
+ * member set and is granted no duty — a job that sweeps must never be handed work to serve.
+ */
+import type { AnyFrame, AgentExistsOk, FrameType } from '@agentconnect.md/protocol'
+import {
+  AGENT_EXISTS_MAX,
+  buildEnvelope,
+  CP_SUBPROTOCOL,
+  CP_URL_ENV,
+  CP_WS_PATH,
+  decodeEnvelope
+} from '@agentconnect.md/protocol'
+import { ClientTransport, ReqRep, systemClock, type Transport } from '@agentconnect.md/connection'
+import { K8sHttp, loadInClusterConfig } from '@agentconnect.md/k8s-client'
+import { SandboxApi } from '../k8s/sandbox-api.js'
+import { OrphanReconciler, resolveOrphanReconcilerSettings } from '../k8s/orphan-reconciler.js'
+import { K8S_SANDBOX_NAMESPACE_ENV } from '../k8s/runtime-plane.js'
+import { readClusterIdentityToken } from '../cp/cluster-identity.js'
+import { DAEMON_VERSION } from '../version.js'
+
+const REQUEST_TIMEOUT_MS = 15_000
+
+/** What the sweep needs from the control plane, and nothing more. */
+export interface ExistenceReader {
+  liveAgents: (agentIds: string[]) => Promise<Set<string>>
+  close: () => void
+}
+
+export interface ReconcileOnceOpts {
+  env?: NodeJS.ProcessEnv
+  /** Control-plane WS URL; defaults to the pod's `AC_CP_URL`. */
+  apiUrl?: string
+  log?: { info: (m: string) => void; warn: (m: string) => void }
+  /** Seams the tests replace: the cluster surface and the control-plane read. */
+  api?: SandboxApi
+  connectCp?: (url: string) => Promise<ExistenceReader>
+}
+
+/** The socket and the credential, injected so the handshake is testable without a cluster. */
+export interface ObserverSeams {
+  dial?: (url: string) => Promise<Transport>
+  token?: () => string | undefined
+}
+
+const dialCp = (url: string): Promise<Transport> =>
+  ClientTransport.dial(url, { subprotocol: CP_SUBPROTOCOL, path: CP_WS_PATH, handshakeTimeoutMs: REQUEST_TIMEOUT_MS })
+
+/** Exit code: 0 when the sweep completed, 1 when it could not. */
+export async function runReconcileOnce(opts: ReconcileOnceOpts = {}): Promise<number> {
+  const env = opts.env ?? process.env
+  const log = opts.log ?? { info: (m: string) => console.log(m), warn: (m: string) => console.error(m) }
+  let cp: ExistenceReader | undefined
+  try {
+    const settings = resolveOrphanReconcilerSettings(env)
+    // The namespace is resolved BEFORE the in-cluster config: a missing env var must name itself,
+    // not surface as "this process is not in a pod".
+    const namespace = opts.api ? undefined : sandboxNamespace(env)
+    const api = opts.api ?? new SandboxApi(new K8sHttp(loadInClusterConfig()), namespace!)
+    const url = opts.apiUrl ?? env[CP_URL_ENV]?.trim()
+    if (!url) throw new Error(`reconcile requires the control plane's address in ${CP_URL_ENV}`)
+    cp = await (opts.connectCp ?? connectObserver)(url)
+    const reconciler = new OrphanReconciler({ api, liveAgents: cp.liveAgents, settings, log })
+    return (await reconciler.sweep()) ? 0 : 1
+  } catch (err) {
+    log.warn(`k8s orphans: sweep failed — ${(err as Error).message}`)
+    return 1
+  } finally {
+    cp?.close()
+  }
+}
+
+function sandboxNamespace(env: NodeJS.ProcessEnv): string {
+  const namespace = env[K8S_SANDBOX_NAMESPACE_ENV]?.trim()
+  if (!namespace) throw new Error(`reconcile requires ${K8S_SANDBOX_NAMESPACE_ENV}`)
+  return namespace
+}
+
+/**
+ * Dial the control plane, hand it this pod's projected identity, and register as an observer.
+ *
+ * Deliberately not `CpClient`: that client is a member's whole control surface — heartbeats, duty
+ * leases, snapshot convergence, reconnect — and a one-shot job that asks a single question needs
+ * none of it. Sending no heartbeat is also what keeps the observer's row collectable: the control
+ * plane backdates it at register, and nothing here moves it forward again.
+ */
+export async function connectObserver(url: string, seams: ObserverSeams = {}): Promise<ExistenceReader> {
+  const token = (seams.token ?? readClusterIdentityToken)()
+  if (!token) throw new Error("reconcile requires this pod's projected control-plane identity token")
+  const correlator = new ReqRep<AnyFrame>(systemClock, REQUEST_TIMEOUT_MS, 1)
+  const transport: Transport = await (seams.dial ?? dialCp)(url)
+  const request = async (type: FrameType, payload: unknown): Promise<AnyFrame> =>
+    correlator.request(buildEnvelope(type, payload), (encoded) => transport.send(encoded), {
+      maxTries: 1,
+      ackTimeoutMs: REQUEST_TIMEOUT_MS
+    })
+  try {
+    transport.onMessage((text) => {
+      const decoded = decodeEnvelope(text)
+      if (decoded.ok && decoded.frame.corr) correlator.settle(decoded.frame)
+    })
+    transport.onClose(() => correlator.rejectAll(new Error('control-plane connection closed')))
+    const auth = await request('auth', { serviceAccountToken: token, agentVersion: DAEMON_VERSION })
+    if (auth.type !== 'auth/ok') throw new Error(`expected auth/ok, got ${auth.type}`)
+    const registered = await request('register', {
+      host: 'reconcile',
+      observer: true,
+      capabilities: { platforms: [], runtimes: [], acp: false, features: [] },
+      maxAgents: 0,
+      localState: { assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }
+    })
+    if (registered.type !== 'register/ok') throw new Error(`expected register/ok, got ${registered.type}`)
+  } catch (err) {
+    correlator.rejectAll(new Error('observer registration failed'))
+    transport.close(1011, 'observer registration failed')
+    throw err
+  }
+  return {
+    // Chunked at the frame's own cap; an error reply throws, which fails the sweep rather than
+    // letting an unanswerable question read as "these agents are gone".
+    liveAgents: async (agentIds) => {
+      const live = new Set<string>()
+      for (let at = 0; at < agentIds.length; at += AGENT_EXISTS_MAX) {
+        const reply = await request('agent/exists', { agentIds: agentIds.slice(at, at + AGENT_EXISTS_MAX) })
+        if (reply.type !== 'agent/exists/ok') throw new Error(`expected agent/exists/ok, got ${reply.type}`)
+        for (const id of (reply.payload as AgentExistsOk).existing) live.add(id)
+      }
+      return live
+    },
+    close: () => {
+      correlator.rejectAll(new Error('reconcile complete'))
+      transport.close(1000, 'reconcile complete')
+    }
+  }
+}

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -14,7 +14,6 @@ import type {
   DutyRevoke,
   DutyClaimOk,
   DutyFetchOk,
-  AgentExistsOk,
   FactsRuntimeProfile,
   FactsMcpServer,
   UsageReport,
@@ -160,9 +159,7 @@ const INSTALL_WIDE_FRAME_TYPES = new Set([
   'duty/revoke',
   'duty/release',
   'duty/claim',
-  'duty/claim/ok',
-  'agent/exists',
-  'agent/exists/ok'
+  'duty/claim/ok'
 ])
 
 const ACK_TIMEOUT_MS = 5000
@@ -939,23 +936,6 @@ export class CpClient {
       throw new WireError('INTERNAL', `expected duty/fetch/ok, got ${rep.type}`, false)
     }
     return rep.payload as DutyFetchOk
-  }
-
-  /**
-   * `agent/exists` (D→C REQ → `agent/exists/ok`) — which of these agents the CP still knows.
-   * Asked by the cluster orphan reconciler for the ids it read off sandbox objects, in one
-   * round trip; install-wide, since the objects span every org the member serves. Callers
-   * gate on {@link supportsServerFeature}(`AGENT_EXISTS_FEATURE`) — an older CP rejects it.
-   */
-  async agentsExist(agentIds: string[]): Promise<AgentExistsOk> {
-    if ((this.state !== 'READY' && this.state !== 'DRAINING') || !this.transport) {
-      throw new WireError('INTERNAL', `control plane unreachable (client ${this.state})`, true)
-    }
-    const rep = await this.request('agent/exists', { agentIds })
-    if (rep.type !== 'agent/exists/ok') {
-      throw new WireError('INTERNAL', `expected agent/exists/ok, got ${rep.type}`, false)
-    }
-    return rep.payload as AgentExistsOk
   }
 
   /** How this connection is tenanted: `connection` = one org (an API-key daemon),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -281,7 +281,6 @@ import {
 import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from './runtimes/registry.js'
 import { installedRuntimeCatalog, installedRuntimes, resolveCommandPath } from './runtimes/probe.js'
 import { K8S_ORG_ID_ENV, startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.js'
-import { ORPHAN_SWEEP_LEASE } from './k8s/orphan-reconciler.js'
 import {
   setSandboxWorkspaceMode,
   setWorkspaceGitRunnerResolver,
@@ -358,8 +357,6 @@ import {
   originKindOf,
   SessionPurgeReason,
   RD_ACK_NOT_HOLDER,
-  AGENT_EXISTS_FEATURE,
-  AGENT_EXISTS_MAX,
   EventSession as EventSessionSchema
 } from '@agentconnect.md/protocol'
 import { isNoResponseBody, isNoResponsePrefix } from './session/no-response.js'
@@ -2983,12 +2980,6 @@ export class Daemon {
           tunnelsFor: (agentId) =>
             this.agents.get(agentId)?.workspace.gitCredential === 'github-app' ? ['gitcred'] : [],
           tunnelSocketPath: (tunnel) => (tunnel === 'gitcred' ? gitcredSocketPath(root) : undefined),
-          // The orphan reconciler's two install-wide seams: the sweep lease lives in the store every
-          // member shares, and existence is the control plane's to answer — one batched read per sweep.
-          orphans: {
-            acquireLease: (ttlMs, now) => this.dataPlane!.store.acquireSweepLease(ORPHAN_SWEEP_LEASE, ttlMs, now),
-            liveAgents: (agentIds) => this.liveAgentsFor(agentIds)
-          },
           log: {
             info: (message) => this.log.info(message),
             warn: (message) => this.log.warn(message),
@@ -20178,22 +20169,6 @@ export class Daemon {
       .catch((err) =>
         this.log.warn(`cluster: taking over the sandbox for agent "${agentId}" failed: ${formatErr(err)}`)
       )
-  }
-
-  /** Cluster only: which of these agents the control plane still knows — the orphan reconciler's one read. */
-  // Throws rather than guesses when the CP cannot be asked, so the sweep skips instead of collecting.
-  private async liveAgentsFor(agentIds: string[]): Promise<Set<string>> {
-    const client = this.cpClient
-    if (!client) throw new Error('control plane is not connected')
-    if (!client.supportsServerFeature(AGENT_EXISTS_FEATURE)) {
-      throw new Error('control plane does not answer agent existence queries yet')
-    }
-    const live = new Set<string>()
-    for (let at = 0; at < agentIds.length; at += AGENT_EXISTS_MAX) {
-      const reply = await client.agentsExist(agentIds.slice(at, at + AGENT_EXISTS_MAX))
-      for (const id of reply.existing) live.add(id)
-    }
-    return live
   }
 
   /** Cluster only: the sandbox half of "no longer served here"; the claim and volume stay. */

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -141,6 +141,19 @@ program
     }
   })
 
+// The pool's orphan reconciler, as a one-shot job. It runs as a Kubernetes CronJob rather than a
+// timer inside every member, so the cluster owns the schedule and the mutual exclusion
+// (`concurrencyPolicy: Forbid`); a non-zero exit is a failed Job the cluster already reports.
+program
+  .command('reconcile')
+  .description('Sweep the sandbox namespace for orphaned sandbox objects once, then exit')
+  .requiredOption('--once', 'run exactly one sweep (the only mode)')
+  .action(async () => {
+    const opts = program.opts()
+    const { runReconcileOnce } = await import('./cli/reconcile.js')
+    return exit(await runReconcileOnce({ ...(opts.apiUrl ? { apiUrl: opts.apiUrl } : {}) }))
+  })
+
 // Hidden: the stdio MCP server spawned by an agent harness. Not user-facing —
 // it's referenced by `mcpServers[].command/args` at `session/new`. Reads its
 // target socket + session token from AC_MCP_ENDPOINT / AC_MCP_TOKEN.

--- a/packages/daemon/src/k8s/orphan-reconciler.ts
+++ b/packages/daemon/src/k8s/orphan-reconciler.ts
@@ -1,53 +1,48 @@
-import { systemClock, type Clock, type TimerHandle } from '@agentconnect.md/connection'
+import { systemClock, type Clock } from '@agentconnect.md/connection'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import { AC_LABEL_AGENT } from './driver.js'
 import { probeClaimExpiry } from './probe-claim.js'
 import type { Sandbox, SandboxApi, SandboxClaim } from './sandbox-api.js'
 
 /**
- * The pool's orphan reconciler: a periodic sweep that finds sandbox objects nobody will ever
- * clean up and removes them, instead of every teardown path carrying its own durable obligation
- * to survive a member dying mid-way (k8s-daemon-pool.md §4).
+ * The pool's orphan reconciler: ONE sweep that finds sandbox objects nobody will ever clean up and
+ * removes them, instead of every teardown path carrying its own durable obligation to survive a
+ * member dying mid-way (k8s-daemon-pool.md §4).
+ *
+ * It runs as a Kubernetes CronJob (`agentconnect-daemon reconcile --once`), not as a timer inside
+ * every member: the schedule, the mutual exclusion (`concurrencyPolicy: Forbid`) and the failure
+ * reporting are the cluster's, so the daemon keeps no scheduler, no jitter, and no lease.
  *
  * Safety over completeness. Deleting a claim deletes the workspace volume, so a candidate is
- * collected only when it is PROVABLY orphaned: the control plane no longer knows its agent, and
- * has not for at least the grace period as observed by this member across sweeps; a probe claim
- * is past its own window; a Sandbox has no claim and no live agent. An object of a live agent
- * is never touched — not even a claimless Sandbox — and an unreadable answer skips the sweep.
- * Ships dry-run: it logs and counts until the deployment enables deletion.
+ * collected only when it is PROVABLY orphaned: the control plane no longer knows its agent and the
+ * object is older than the grace period; a probe claim is past its own window; a Sandbox has no
+ * claim and no live agent. An object of a live agent is never touched — not even a claimless
+ * Sandbox — and an unreadable answer fails the sweep. Ships dry-run: it logs and counts until the
+ * deployment enables deletion.
  */
 
-/** Deployment-owned settings, env like the rest of the plane's; absent ⇒ the defaults below. */
-export const ORPHAN_SWEEP_INTERVAL_ENV = 'AC_K8S_ORPHAN_SWEEP_INTERVAL_MS'
+/** Deployment-owned settings, env like the rest of the plane's; absent ⇒ the default below. */
 export const ORPHAN_GRACE_ENV = 'AC_K8S_ORPHAN_GRACE_MS'
 /** Deletion is opt-in: `1`/`true` collects, anything else only reports. */
 export const ORPHAN_DELETE_ENV = 'AC_K8S_ORPHAN_DELETE'
-export const DEFAULT_ORPHAN_SWEEP_INTERVAL_MS = 10 * 60_000
 export const DEFAULT_ORPHAN_GRACE_MS = 10 * 60_000
-/** Name of the single-holder lease in the shared store; one member sweeps at a time. */
-export const ORPHAN_SWEEP_LEASE = 'k8s-orphan-sweep'
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export interface OrphanReconcilerSettings {
-  intervalMs: number
   graceMs: number
   deleteEnabled: boolean
 }
 
 export function resolveOrphanReconcilerSettings(env: NodeJS.ProcessEnv = process.env): OrphanReconcilerSettings {
-  const positive = (name: string, fallback: number): number => {
-    const raw = env[name]?.trim()
-    if (!raw) return fallback
+  const raw = env[ORPHAN_GRACE_ENV]?.trim()
+  let graceMs = DEFAULT_ORPHAN_GRACE_MS
+  if (raw) {
     const value = Number(raw)
-    if (!Number.isInteger(value) || value <= 0) throw new Error(`${name} is not a positive integer: ${raw}`)
-    return value
+    if (!Number.isInteger(value) || value <= 0) throw new Error(`${ORPHAN_GRACE_ENV} is not a positive integer: ${raw}`)
+    graceMs = value
   }
   const flag = env[ORPHAN_DELETE_ENV]?.trim().toLowerCase()
-  return {
-    intervalMs: positive(ORPHAN_SWEEP_INTERVAL_ENV, DEFAULT_ORPHAN_SWEEP_INTERVAL_MS),
-    graceMs: positive(ORPHAN_GRACE_ENV, DEFAULT_ORPHAN_GRACE_MS),
-    deleteEnabled: flag === '1' || flag === 'true'
-  }
+  return { graceMs, deleteEnabled: flag === '1' || flag === 'true' }
 }
 
 /** One sweep's counters, also the shape of its summary log line. */
@@ -62,14 +57,10 @@ export interface OrphanSweepSummary {
 
 export interface OrphanReconcilerDeps {
   api: Pick<SandboxApi, 'listClaims' | 'deleteClaimIfCurrent' | 'listSandboxes' | 'deleteSandboxIfCurrent'>
-  /** Take or renew the install-wide sweep lease for `ttlMs`; false ⇒ another member is sweeping. */
-  acquireLease: (ttlMs: number, now: number) => boolean
-  /** Which of these agents the control plane still knows; a throw skips the sweep. */
+  /** Which of these agents the control plane still knows; a throw fails the sweep. */
   liveAgents: (agentIds: string[]) => Promise<Set<string>>
   settings: OrphanReconcilerSettings
   clock?: Clock
-  /** Uniform in [0, 1); spreads the members' timers so a rollout does not line them up. */
-  jitter?: () => number
   log: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
 }
 
@@ -88,65 +79,25 @@ interface Candidate {
 
 export class OrphanReconciler {
   private readonly clock: Clock
-  private readonly jitter: () => number
-  private timer?: TimerHandle
-  private stopped = false
-  private inFlight?: Promise<OrphanSweepSummary | undefined>
-  /** When this member first saw each object's agent missing, by uid; forgotten once seen live. */
-  private readonly missingSince = new Map<string, number>()
   private sandboxListDenied = false
 
   constructor(private readonly deps: OrphanReconcilerDeps) {
     this.clock = deps.clock ?? systemClock
-    this.jitter = deps.jitter ?? Math.random
   }
 
-  /** Arm the periodic sweep; the first one is a jittered interval away, like every later one. */
-  start(): void {
-    this.stopped = false
-    this.arm()
-  }
-
-  stop(): void {
-    this.stopped = true
-    if (this.timer !== undefined) this.clock.clearTimeout(this.timer)
-    this.timer = undefined
-  }
-
-  private arm(): void {
-    if (this.stopped) return
-    // ±25% around the interval: members drift apart, and the lease holder still renews well
-    // inside a lease that lasts three intervals.
-    const delay = Math.round(this.deps.settings.intervalMs * (0.75 + 0.5 * this.jitter()))
-    this.timer = this.clock.setTimeout(() => {
-      this.timer = undefined
-      void this.sweep().finally(() => this.arm())
-    }, delay)
-    // A sweep is housekeeping: it must never be what keeps a stopping process alive.
-    ;(this.timer as { unref?: () => void }).unref?.()
-  }
-
-  /** One sweep. Resolves undefined when this member does not hold the lease or the sweep was skipped. */
-  sweep(): Promise<OrphanSweepSummary | undefined> {
-    if (this.inFlight) return this.inFlight
-    this.inFlight = this.runSweep()
-      .catch((err: unknown) => {
-        this.deps.log.warn(`k8s orphans: sweep failed — ${(err as Error).message}`)
-        return undefined
-      })
-      .finally(() => {
-        this.inFlight = undefined
-      })
-    return this.inFlight
-  }
-
-  private async runSweep(): Promise<OrphanSweepSummary | undefined> {
-    const { settings, log } = this.deps
-    const now = this.clock.now()
-    if (!this.deps.acquireLease(settings.intervalMs * 3, now)) {
-      log.debug?.('k8s orphans: another member holds the sweep lease')
+  /** One sweep. Resolves undefined when it failed — the CronJob turns that into a non-zero exit. */
+  async sweep(): Promise<OrphanSweepSummary | undefined> {
+    try {
+      return await this.runSweep()
+    } catch (err) {
+      this.deps.log.warn(`k8s orphans: sweep failed — ${(err as Error).message}`)
       return undefined
     }
+  }
+
+  private async runSweep(): Promise<OrphanSweepSummary> {
+    const { settings, log } = this.deps
+    const now = this.clock.now()
     const claims = await this.deps.api.listClaims()
     const sandboxes = await this.listSandboxes()
     const bound = new Set(claims.map((claim) => claim.status?.sandbox?.name).filter((name) => name !== undefined))
@@ -174,7 +125,6 @@ export class OrphanReconciler {
       ...new Set(candidates.filter((c) => c.kind !== 'probe-claim' && UUID.test(c.agentId)).map((c) => c.agentId))
     ]
     const live = askable.length > 0 ? await this.deps.liveAgents(askable) : new Set<string>()
-    const seen = new Set<string>()
     const orphans: Candidate[] = []
     for (const candidate of candidates) {
       if (candidate.kind === 'probe-claim') {
@@ -189,19 +139,14 @@ export class OrphanReconciler {
         summary.skippedLive += 1
         continue
       }
-      seen.add(candidate.uid)
-      const firstMissing = this.missingSince.get(candidate.uid) ?? now
-      this.missingSince.set(candidate.uid, firstMissing)
-      // Both clocks must agree: missing across this member's sweeps for the grace, AND old enough
-      // that no in-flight creation could still be racing the control plane's own write.
-      const aged = Number.isFinite(candidate.createdAt) && now - candidate.createdAt >= settings.graceMs
-      if (now - firstMissing < settings.graceMs || !aged) {
+      // The object's own age IS the grace: a one-shot run has no memory of an earlier sweep, and this
+      // is the clock that matters anyway — no in-flight creation can still be racing the CP's write.
+      if (!(Number.isFinite(candidate.createdAt) && now - candidate.createdAt >= settings.graceMs)) {
         summary.skippedGrace += 1
         continue
       }
       orphans.push(candidate)
     }
-    for (const uid of [...this.missingSince.keys()]) if (!seen.has(uid)) this.missingSince.delete(uid)
     summary.orphaned = orphans.length
     for (const orphan of orphans) {
       if (!settings.deleteEnabled) {

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -1,7 +1,6 @@
 import { K8sHttp, loadInClusterConfig } from '@agentconnect.md/k8s-client'
 import { K8sDriver, PROBE_GRANTS, type LaunchGenerations } from './driver.js'
 import { SandboxApi } from './sandbox-api.js'
-import { OrphanReconciler, resolveOrphanReconcilerSettings, type OrphanReconcilerDeps } from './orphan-reconciler.js'
 import { PROBE_CLAIM_EXPIRES_ANNOTATION, PROBE_CLAIM_LABEL, PROBE_CLAIM_TTL_MS, probeAgentId } from './probe-claim.js'
 import { clusterMetrics } from './cluster-metrics.js'
 import { ShimDialer } from '../shim/dialer.js'
@@ -80,8 +79,6 @@ export interface K8sRuntimePlaneOptions {
   /** How long a pod that is up may go without a shim channel before the launch counts as lost.
    *  Injected so a test can cross the window in milliseconds rather than waiting out the default. */
   rebindGraceMs?: number
-  /** The orphan reconciler's install-wide seams (sweep lease, control-plane existence read); absent ⇒ no sweep. */
-  orphans?: Pick<OrphanReconcilerDeps, 'acquireLease' | 'liveAgents'>
   log?: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
 }
 
@@ -275,19 +272,6 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
   const lossWatches = new Map<string, LossWatch>()
   let probeInFlight: Promise<K8sRuntimeTable> | undefined
 
-  // Collects what a member that died mid-teardown left behind — an expired probe claim included
-  // (k8s-daemon-pool.md §4); the seams it needs are the daemon's, so a plane assembled without
-  // them (a test) simply never sweeps.
-  const reconciler = options.orphans
-    ? new OrphanReconciler({
-        api,
-        ...options.orphans,
-        settings: resolveOrphanReconcilerSettings(options.env ?? process.env),
-        log: options.log ?? SILENT
-      })
-    : undefined
-  reconciler?.start()
-
   /**
    * Start the grace window for a channel that dropped, measured from the right event.
    *
@@ -440,7 +424,6 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       await driver.removeAgent(agentId)
     },
     stop: async () => {
-      reconciler?.stop()
       for (const agentId of [...lossWatches.keys()]) cancelLossCheck(agentId)
       for (const { proxy } of proxies.values()) proxy.stop('daemon is shutting down')
       proxies.clear()

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1230,13 +1230,6 @@ export class LocalStore {
         agentId TEXT PRIMARY KEY,
         generation INTEGER NOT NULL
       );
-      -- Single-holder leases for install-wide periodic sweeps (the cluster orphan reconciler): the
-      -- holder renews by re-acquiring, and a lapsed row is any member's to take.
-      CREATE TABLE IF NOT EXISTS sweep_leases (
-        name TEXT PRIMARY KEY,
-        ownerId TEXT NOT NULL,
-        expiresAt INTEGER NOT NULL
-      );
     `)
     // Stamped only once the CREATE block above has actually emitted that schema, so
     // a store that failed halfway through creation is not left claiming to be current.
@@ -5133,20 +5126,6 @@ export class LocalStore {
       .get(agentId) as { generation: number } | undefined
     if (row === undefined) throw new Error(`could not allocate a sandbox generation for agent ${agentId}`)
     return Number(row.generation)
-  }
-
-  /** Take or renew the named single-holder lease; false means another member holds it unexpired. */
-  // One atomic upsert, so two members cannot both win; a store nobody shares always holds.
-  acquireSweepLease(name: string, ttlMs: number, now: number): boolean {
-    if (!this.shared) return true
-    const result = this.db
-      .prepare(
-        `INSERT INTO sweep_leases (name, ownerId, expiresAt) VALUES (@name, @ownerId, @expiresAt)
-         ON CONFLICT(name) DO UPDATE SET ownerId = excluded.ownerId, expiresAt = excluded.expiresAt
-         WHERE sweep_leases.ownerId = excluded.ownerId OR sweep_leases.expiresAt <= @now`
-      )
-      .run({ name, ownerId: this.ownerId ?? '', expiresAt: now + ttlMs, now })
-    return Number(result.changes) === 1
   }
 
   close(): void {

--- a/packages/daemon/test/cli-reconcile.test.ts
+++ b/packages/daemon/test/cli-reconcile.test.ts
@@ -31,11 +31,12 @@ function claim(agentId: string): SandboxClaim {
 }
 
 /** A cluster holding two claims — one of a live agent, one of a forgotten one. */
-async function cluster() {
+async function cluster(opts: { deleteStatus?: number } = {}) {
   const deletes: string[] = []
   const { config } = await fakeApiServer(({ method, url }) => {
     if (method === 'DELETE') {
       deletes.push(url.pathname)
+      if (opts.deleteStatus) return { status: opts.deleteStatus, json: { kind: 'Status', reason: 'Forbidden' } }
       return { json: {} }
     }
     if (url.pathname.endsWith('/sandboxclaims')) return { json: { items: [claim(LIVE), claim(GONE)] } }
@@ -81,6 +82,23 @@ describe('reconcile --once', () => {
     expect(infos.at(-1)).toContain('swept 2 candidates — orphaned=1 deleted=1 skipped-live=1')
     // The connection is one-shot: closed whatever the sweep decided.
     expect(cp.wasClosed()).toBe(true)
+  })
+
+  it('exits 1 when a delete failed, after reporting the whole sweep', async () => {
+    // The failure is counted rather than thrown, so the run still says what it found — but an
+    // orphan it could not collect will be back next run, and a green Job would hide that.
+    const { api, deletes } = await cluster({ deleteStatus: 403 })
+    const logged: string[] = []
+    const code = await runReconcileOnce({
+      api,
+      connectCp: fakeCp().connectCp,
+      apiUrl: 'wss://cp.example.test/daemon/ws',
+      env: { [ORPHAN_DELETE_ENV]: 'true' },
+      log: { info: (m) => logged.push(m), warn: (m) => logged.push(m) }
+    })
+    expect(code).toBe(1)
+    expect(deletes).toHaveLength(1)
+    expect(logged.at(-1)).toContain('orphaned=1 deleted=0 skipped-live=1 skipped-grace=0 failed=1')
   })
 
   it('exits 1 when the control plane cannot be reached, deleting nothing', async () => {

--- a/packages/daemon/test/cli-reconcile.test.ts
+++ b/packages/daemon/test/cli-reconcile.test.ts
@@ -1,0 +1,195 @@
+/**
+ * `agentconnect-daemon reconcile --once` — the CronJob's whole job: connect as an OBSERVER, run
+ * one sweep against the sandbox namespace, print the summary, and exit 0 (non-zero on failure).
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { K8sHttp } from '@agentconnect.md/k8s-client'
+import { closeFakeApiServers, fakeApiServer } from '@agentconnect.md/k8s-client/testing'
+import { buildEnvelope, decodeEnvelope, encode, type AnyFrame } from '@agentconnect.md/protocol'
+import { AC_LABEL_AGENT, AC_LABEL_ORG } from '../src/k8s/driver.js'
+import { SandboxApi, type SandboxClaim } from '../src/k8s/sandbox-api.js'
+import { ORPHAN_DELETE_ENV } from '../src/k8s/orphan-reconciler.js'
+import { K8S_SANDBOX_NAMESPACE_ENV } from '../src/k8s/runtime-plane.js'
+import { connectObserver, runReconcileOnce, type ExistenceReader } from '../src/cli/reconcile.js'
+import { FakeTransport } from './cp/fake-transport.js'
+
+afterEach(closeFakeApiServers)
+
+const LIVE = '11111111-1111-4111-8111-111111111111'
+const GONE = '22222222-2222-4222-8222-222222222222'
+const OLD = new Date(Date.now() - 60 * 60_000).toISOString()
+
+function claim(agentId: string): SandboxClaim {
+  const name = `agent-${agentId}`
+  return {
+    metadata: { name, uid: `uid-${name}`, resourceVersion: `rv-${name}`, creationTimestamp: OLD },
+    spec: {
+      warmPoolRef: { name: 'pool' },
+      additionalPodMetadata: { labels: { [AC_LABEL_ORG]: 'org-1', [AC_LABEL_AGENT]: agentId } }
+    }
+  }
+}
+
+/** A cluster holding two claims — one of a live agent, one of a forgotten one. */
+async function cluster() {
+  const deletes: string[] = []
+  const { config } = await fakeApiServer(({ method, url }) => {
+    if (method === 'DELETE') {
+      deletes.push(url.pathname)
+      return { json: {} }
+    }
+    if (url.pathname.endsWith('/sandboxclaims')) return { json: { items: [claim(LIVE), claim(GONE)] } }
+    if (url.pathname.endsWith('/sandboxes')) return { json: { items: [] } }
+    return { status: 404, json: { kind: 'Status', reason: 'NotFound' } }
+  })
+  return { api: new SandboxApi(new K8sHttp(config), 'agent-sandboxes'), deletes }
+}
+
+/** A control plane that knows only `LIVE`, recording what the sweep asked it. */
+function fakeCp() {
+  const asked: string[][] = []
+  let closed = false
+  const connectCp = async (): Promise<ExistenceReader> => ({
+    liveAgents: async (ids: string[]) => {
+      asked.push(ids)
+      return new Set(ids.filter((id) => id === LIVE))
+    },
+    close: () => {
+      closed = true
+    }
+  })
+  return { connectCp, asked, wasClosed: () => closed }
+}
+
+describe('reconcile --once', () => {
+  it('runs one sweep, prints the summary, and exits 0', async () => {
+    const { api, deletes } = await cluster()
+    const cp = fakeCp()
+    const infos: string[] = []
+    const code = await runReconcileOnce({
+      api,
+      connectCp: cp.connectCp,
+      apiUrl: 'wss://cp.example.test/daemon/ws',
+      env: { [ORPHAN_DELETE_ENV]: 'true' },
+      log: { info: (m) => infos.push(m), warn: (m) => infos.push(m) }
+    })
+    expect(code).toBe(0)
+    expect(cp.asked).toEqual([[LIVE, GONE]])
+    expect(deletes).toEqual([
+      `/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/agent-sandboxes/sandboxclaims/agent-${GONE}`
+    ])
+    expect(infos.at(-1)).toContain('swept 2 candidates — orphaned=1 deleted=1 skipped-live=1')
+    // The connection is one-shot: closed whatever the sweep decided.
+    expect(cp.wasClosed()).toBe(true)
+  })
+
+  it('exits 1 when the control plane cannot be reached, deleting nothing', async () => {
+    const { api, deletes } = await cluster()
+    const warns: string[] = []
+    const code = await runReconcileOnce({
+      api,
+      connectCp: async () => {
+        throw new Error('connection refused')
+      },
+      apiUrl: 'wss://cp.example.test/daemon/ws',
+      env: {},
+      log: { info: () => {}, warn: (m) => warns.push(m) }
+    })
+    expect(code).toBe(1)
+    expect(deletes).toEqual([])
+    expect(warns.at(-1)).toContain('connection refused')
+  })
+
+  it('exits 1 without the sandbox namespace the pool member reads', async () => {
+    const warns: string[] = []
+    const code = await runReconcileOnce({
+      connectCp: fakeCp().connectCp,
+      apiUrl: 'wss://cp.example.test/daemon/ws',
+      env: {},
+      log: { info: () => {}, warn: (m) => warns.push(m) }
+    })
+    expect(code).toBe(1)
+    expect(warns.at(-1)).toContain(K8S_SANDBOX_NAMESPACE_ENV)
+  })
+})
+
+/** Auto-reply to whatever the observer asks, recording the frames it sent. */
+function scriptedCp(over: Partial<Record<string, (frame: AnyFrame) => { type: string; payload: unknown }>> = {}) {
+  const transport = new FakeTransport()
+  const sent: AnyFrame[] = []
+  const answers: Record<string, (frame: AnyFrame) => { type: string; payload: unknown }> = {
+    auth: () => ({
+      type: 'auth/ok',
+      payload: {
+        daemonId: GONE,
+        sessionEpoch: 1,
+        heartbeatSec: 15,
+        serverTime: new Date().toISOString(),
+        organizationMode: 'frame'
+      }
+    }),
+    register: () => ({
+      type: 'register/ok',
+      payload: {
+        routingEpoch: 1,
+        assignments: [],
+        crons: [],
+        leases: [],
+        drop: { assignments: [], crons: [] }
+      }
+    }),
+    'agent/exists': (frame) => ({
+      type: 'agent/exists/ok',
+      payload: { existing: (frame.payload as { agentIds: string[] }).agentIds.filter((id) => id === LIVE) }
+    }),
+    ...over
+  }
+  const originalSend = transport.send.bind(transport)
+  transport.send = (text: string) => {
+    originalSend(text)
+    const decoded = decodeEnvelope(text)
+    if (!decoded.ok) return
+    sent.push(decoded.frame)
+    const answer = answers[decoded.frame.type]
+    if (!answer) return
+    const { type, payload } = answer(decoded.frame)
+    queueMicrotask(() =>
+      transport.pushInbound(encode(buildEnvelope(type as never, payload, { corr: decoded.frame.id })))
+    )
+  }
+  return { transport, sent }
+}
+
+describe('observer connection', () => {
+  it('registers with observer set, then asks only about agent existence', async () => {
+    const { transport, sent } = scriptedCp()
+    const cp = await connectObserver('wss://cp.example.test/daemon/ws', {
+      dial: async () => transport,
+      token: () => 'projected-token'
+    })
+    expect(sent.map((f) => f.type)).toEqual(['auth', 'register'])
+    expect((sent[0]!.payload as { serviceAccountToken: string }).serviceAccountToken).toBe('projected-token')
+    expect(sent[1]!.payload).toMatchObject({ observer: true, maxAgents: 0 })
+
+    expect(await cp.liveAgents([LIVE, GONE])).toEqual(new Set([LIVE]))
+    cp.close()
+    expect(transport.closed?.code).toBe(1000)
+  })
+
+  it('fails the connection when the control plane refuses the observer registration', async () => {
+    const { transport } = scriptedCp({
+      register: () => ({ type: 'error', payload: { code: 'SCOPE_DENIED', message: 'nope', retryable: false } })
+    })
+    await expect(
+      connectObserver('wss://cp.example.test/daemon/ws', { dial: async () => transport, token: () => 'tok' })
+    ).rejects.toThrow()
+    expect(transport.closed?.code).toBe(1011)
+  })
+
+  it('refuses to connect without a projected identity token', async () => {
+    const { transport } = scriptedCp()
+    await expect(
+      connectObserver('wss://cp.example.test/daemon/ws', { dial: async () => transport, token: () => undefined })
+    ).rejects.toThrow('identity token')
+  })
+})

--- a/packages/daemon/test/k8s-orphan-reconciler.test.ts
+++ b/packages/daemon/test/k8s-orphan-reconciler.test.ts
@@ -4,14 +4,11 @@ import { K8sHttp } from '@agentconnect.md/k8s-client'
 import { closeFakeApiServers, fakeApiServer } from '@agentconnect.md/k8s-client/testing'
 import {
   DEFAULT_ORPHAN_GRACE_MS,
-  DEFAULT_ORPHAN_SWEEP_INTERVAL_MS,
   ORPHAN_DELETE_ENV,
   ORPHAN_GRACE_ENV,
-  ORPHAN_SWEEP_INTERVAL_ENV,
   OrphanReconciler,
   resolveOrphanReconcilerSettings,
-  type OrphanReconcilerDeps,
-  type OrphanSweepSummary
+  type OrphanReconcilerDeps
 } from '../src/k8s/orphan-reconciler.js'
 import { AC_LABEL_AGENT, AC_LABEL_ORG } from '../src/k8s/driver.js'
 import { PROBE_CLAIM_EXPIRES_ANNOTATION, PROBE_CLAIM_LABEL, probeAgentId } from '../src/k8s/probe-claim.js'
@@ -19,16 +16,14 @@ import { SandboxApi, type Sandbox, type SandboxClaim } from '../src/k8s/sandbox-
 
 /**
  * The orphan reconciler against a fake API server and a fake control-plane answer. The rules
- * under test are the safety rules: only a provably orphaned object goes, a live agent's never
- * does, grace is measured on this member's own sweeps as well as on the object's age, and the
- * default is to report rather than delete.
+ * under test are the safety rules: one run collects only a provably orphaned object, a live
+ * agent's is never touched, grace is the object's own age, and the default is to report.
  */
 
 afterEach(closeFakeApiServers)
 
 const LIVE = '11111111-1111-4111-8111-111111111111'
 const GONE = '22222222-2222-4222-8222-222222222222'
-const JUST_GONE = '33333333-3333-4333-8333-333333333333'
 const T0 = Date.parse('2026-08-14T10:00:00.000Z')
 const HOUR = 60 * 60_000
 const GRACE = 10 * 60_000
@@ -98,56 +93,39 @@ function reconciler(over: Partial<OrphanReconcilerDeps> & { api: OrphanReconcile
   const infos: string[] = []
   const warns: string[] = []
   const it = new OrphanReconciler({
-    acquireLease: () => true,
     liveAgents: async (ids) => {
       asked.push(ids)
       return new Set(ids.filter((id) => id === LIVE))
     },
-    settings: { intervalMs: DEFAULT_ORPHAN_SWEEP_INTERVAL_MS, graceMs: GRACE, deleteEnabled: true },
+    settings: { graceMs: GRACE, deleteEnabled: true },
     clock,
-    jitter: () => 0.5,
     log: { info: (m) => infos.push(m), warn: (m) => warns.push(m), debug: () => {} },
     ...over
   })
   return { it, clock, asked, infos, warns }
 }
 
-/** Two sweeps a grace apart: the shape every "past grace" case needs. */
-async function twoSweeps(r: ReturnType<typeof reconciler>): Promise<OrphanSweepSummary | undefined> {
-  await r.it.sweep()
-  r.clock.advance(GRACE)
-  return r.it.sweep()
-}
-
 describe('orphan reconciler settings', () => {
-  it('defaults to a ten-minute jittered sweep, a ten-minute grace, and dry run', () => {
+  it('defaults to a ten-minute grace and dry run', () => {
     expect(resolveOrphanReconcilerSettings({})).toEqual({
-      intervalMs: DEFAULT_ORPHAN_SWEEP_INTERVAL_MS,
       graceMs: DEFAULT_ORPHAN_GRACE_MS,
       deleteEnabled: false
     })
-    expect(
-      resolveOrphanReconcilerSettings({
-        [ORPHAN_SWEEP_INTERVAL_ENV]: '60000',
-        [ORPHAN_GRACE_ENV]: '5000',
-        [ORPHAN_DELETE_ENV]: 'true'
-      })
-    ).toEqual({ intervalMs: 60_000, graceMs: 5_000, deleteEnabled: true })
+    expect(resolveOrphanReconcilerSettings({ [ORPHAN_GRACE_ENV]: '5000', [ORPHAN_DELETE_ENV]: 'true' })).toEqual({
+      graceMs: 5_000,
+      deleteEnabled: true
+    })
     expect(() => resolveOrphanReconcilerSettings({ [ORPHAN_GRACE_ENV]: '-1' })).toThrow(ORPHAN_GRACE_ENV)
   })
 })
 
 describe('orphan reconciler', () => {
-  it('deletes a claim whose agent the control plane has forgotten, once past grace on both clocks', async () => {
+  it('deletes a claim whose agent the control plane has forgotten, in one run', async () => {
     const { api, deletes } = await cluster(
       [claim(GONE, { sandbox: 'sb-gone' }), claim(LIVE, { sandbox: 'sb-live' })],
       []
     )
     const r = reconciler({ api })
-    // First sight of the missing agent starts the grace; nothing goes yet.
-    expect(await r.it.sweep()).toMatchObject({ candidates: 2, orphaned: 0, skippedLive: 1, skippedGrace: 1 })
-    expect(deletes).toEqual([])
-    r.clock.advance(GRACE)
     expect(await r.it.sweep()).toMatchObject({ candidates: 2, orphaned: 1, deleted: 1, skippedLive: 1, failed: 0 })
     // Exactly the incarnation that was listed, never a same-name replacement.
     expect(deletes).toEqual([
@@ -156,26 +134,21 @@ describe('orphan reconciler', () => {
         preconditions: { uid: `uid-agent-${GONE}`, resourceVersion: `rv-agent-${GONE}` }
       }
     ])
-    // One existence read per sweep, covering every agent-bearing candidate at once.
-    expect(r.asked).toEqual([
-      [GONE, LIVE],
-      [GONE, LIVE]
-    ])
+    // One existence read per run, covering every agent-bearing candidate at once.
+    expect(r.asked).toEqual([[GONE, LIVE]])
     expect(r.infos.at(-1)).toContain('orphaned=1 deleted=1 skipped-live=1 skipped-grace=0 failed=0')
   })
 
   it('never touches an object of a live agent, claimless Sandbox included', async () => {
     const { api, deletes } = await cluster([claim(LIVE, { sandbox: 'sb-live' })], [sandbox('sb-stray', LIVE)])
     const r = reconciler({ api })
-    expect(await twoSweeps(r)).toMatchObject({ candidates: 2, orphaned: 0, deleted: 0, skippedLive: 2 })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 2, orphaned: 0, deleted: 0, skippedLive: 2 })
     expect(deletes).toEqual([])
   })
 
-  it('waits out the grace for an agent that only just went missing, even on an old object', async () => {
-    const { api, deletes } = await cluster([claim(JUST_GONE)], [])
+  it('leaves an object younger than the grace alone', async () => {
+    const { api, deletes } = await cluster([claim(GONE, { createdAt: T0 - GRACE + 1 })], [])
     const r = reconciler({ api })
-    await r.it.sweep()
-    r.clock.advance(GRACE - 1)
     expect(await r.it.sweep()).toMatchObject({ orphaned: 0, skippedGrace: 1 })
     expect(deletes).toEqual([])
     r.clock.advance(1)
@@ -187,14 +160,14 @@ describe('orphan reconciler', () => {
     delete undated.metadata?.creationTimestamp
     const { api, deletes } = await cluster([undated], [])
     const r = reconciler({ api })
-    expect(await twoSweeps(r)).toMatchObject({ orphaned: 0, skippedGrace: 1 })
+    expect(await r.it.sweep()).toMatchObject({ orphaned: 0, skippedGrace: 1 })
     expect(deletes).toEqual([])
   })
 
   it('only reports in dry run, which is the default', async () => {
     const { api, deletes } = await cluster([claim(GONE)], [sandbox('sb-orphan', GONE)])
-    const r = reconciler({ api, settings: { intervalMs: 60_000, graceMs: GRACE, deleteEnabled: false } })
-    expect(await twoSweeps(r)).toMatchObject({ candidates: 2, orphaned: 2, deleted: 0 })
+    const r = reconciler({ api, settings: { graceMs: GRACE, deleteEnabled: false } })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 2, orphaned: 2, deleted: 0 })
     expect(deletes).toEqual([])
     expect(r.infos.filter((m) => m.includes('would delete'))).toHaveLength(2)
     expect(r.infos.at(-1)).toContain('(dry run)')
@@ -207,7 +180,7 @@ describe('orphan reconciler', () => {
     )
     const r = reconciler({ api })
     // Its claim will go, and the bound Sandbox with it through the claim; only the stray is a Sandbox delete.
-    expect(await twoSweeps(r)).toMatchObject({ candidates: 2, orphaned: 2, deleted: 2 })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 2, orphaned: 2, deleted: 2 })
     expect(deletes.map((d) => d.path)).toEqual([
       `/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/agent-sandboxes/sandboxclaims/agent-${GONE}`,
       '/apis/agents.x-k8s.io/v1beta1/namespaces/agent-sandboxes/sandboxes/sb-orphan'
@@ -229,18 +202,15 @@ describe('orphan reconciler', () => {
     expect(r.asked).toEqual([])
   })
 
-  it('sweeps only while holding the lease, and skips entirely when the control plane cannot answer', async () => {
+  it('fails the whole sweep when the control plane cannot answer', async () => {
     const { api, deletes } = await cluster([claim(GONE)], [])
-    const bystander = reconciler({ api, acquireLease: () => false })
-    expect(await twoSweeps(bystander)).toBeUndefined()
-    expect(bystander.asked).toEqual([])
     const unanswered = reconciler({
       api,
       liveAgents: async () => {
         throw new Error('control plane is not connected')
       }
     })
-    expect(await twoSweeps(unanswered)).toBeUndefined()
+    expect(await unanswered.it.sweep()).toBeUndefined()
     expect(unanswered.warns.at(-1)).toContain('sweep failed')
     expect(deletes).toEqual([])
   })
@@ -248,22 +218,8 @@ describe('orphan reconciler', () => {
   it('narrows to claims when the Role does not allow listing Sandboxes', async () => {
     const { api, deletes } = await cluster([claim(GONE)], [], { sandboxList: 403 })
     const r = reconciler({ api })
-    expect(await twoSweeps(r)).toMatchObject({ candidates: 1, orphaned: 1, deleted: 1 })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 1, orphaned: 1, deleted: 1 })
     expect(deletes).toHaveLength(1)
     expect(r.warns.filter((m) => m.includes('not permitted'))).toHaveLength(1)
-  })
-
-  it('runs on a jittered interval and stops cleanly', async () => {
-    const { api } = await cluster([], [])
-    const r = reconciler({ api })
-    r.it.start()
-    expect(r.clock.pending).toBe(1)
-    r.clock.advance(DEFAULT_ORPHAN_SWEEP_INTERVAL_MS)
-    await new Promise((resolve) => setTimeout(resolve, 20))
-    expect(r.infos.filter((m) => m.includes('swept 0 candidates'))).toHaveLength(1)
-    // Re-armed after the sweep, then disarmed by stop.
-    expect(r.clock.pending).toBe(1)
-    r.it.stop()
-    expect(r.clock.pending).toBe(0)
   })
 })

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -2145,25 +2145,6 @@ describe('sandbox generations', () => {
   })
 })
 
-describe('sweep leases', () => {
-  it('lets one member hold and renew, hands over only once the lease lapses, and always holds locally', () => {
-    const [first, second] = sharedMembers('member-1', 'member-2')
-    expect(first.acquireSweepLease('orphans', 1_000, 10_000)).toBe(true)
-    expect(second.acquireSweepLease('orphans', 1_000, 10_500)).toBe(false)
-    // The holder renews past what the contender saw, so the contender keeps losing.
-    expect(first.acquireSweepLease('orphans', 1_000, 10_900)).toBe(true)
-    expect(second.acquireSweepLease('orphans', 1_000, 11_500)).toBe(false)
-    expect(second.acquireSweepLease('orphans', 1_000, 11_900)).toBe(true)
-    expect(first.acquireSweepLease('orphans', 1_000, 12_000)).toBe(false)
-    // Leases are named: another sweep is unrelated.
-    expect(first.acquireSweepLease('other', 1_000, 12_000)).toBe(true)
-    const local = store()
-    expect(local.acquireSweepLease('orphans', 1_000, 0)).toBe(true)
-    expect(local.acquireSweepLease('orphans', 1_000, 0)).toBe(true)
-    local.close()
-  })
-})
-
 describe('transcript org fence on a shared store', () => {
   const orgs: Record<string, string> = { 'agent-a': 'org-a', 'agent-b': 'org-b' }
   const twoOrgMembers = (): [LocalStore, LocalStore] => {

--- a/packages/daemon/test/postgres-pool-store.int.test.ts
+++ b/packages/daemon/test/postgres-pool-store.int.test.ts
@@ -336,14 +336,6 @@ describe.skipIf(!databaseUrl)('PostgreSQL pool member store', () => {
       second.store.gcRuntimeCatalog(1, 150)
       expect(first.store.getRuntimeCatalogMeta(runtimeId)).toBeUndefined()
       expect(second.store.getRuntimeCatalogMeta(runtimeId)).toMatchObject({ fingerprint: 'fp-2' })
-
-      // The single-holder sweep lease decides through the same upsert on PostgreSQL as on SQLite.
-      const lease = `sweep-${suffix}`
-      expect(first.store.acquireSweepLease(lease, 1_000, 10_000)).toBe(true)
-      expect(second.store.acquireSweepLease(lease, 1_000, 10_500)).toBe(false)
-      expect(first.store.acquireSweepLease(lease, 1_000, 10_900)).toBe(true)
-      expect(second.store.acquireSweepLease(lease, 1_000, 11_950)).toBe(true)
-      expect(first.store.acquireSweepLease(lease, 1_000, 12_000)).toBe(false)
     } finally {
       second.store.gcRuntimeCatalog(Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
       await second.close()

--- a/packages/protocol/src/frames/register.ts
+++ b/packages/protocol/src/frames/register.ts
@@ -23,6 +23,10 @@ export const RegisterReq = z.object({
   // Only the newest live generation of a member set may claim vacated duty groups; absent for
   // local daemons and older pods, which the rule never excludes.
   generation: z.string().min(1).max(128).optional(),
+  // An OBSERVER connection: the `reconcile --once` CronJob, which authenticates with the same
+  // projected pool identity but serves nothing. The CP admits the identity and answers reads, but
+  // enrolls it in no member set, so the duty ledger can never grant it anything (k8s-daemon-pool.md §4).
+  observer: z.boolean().optional(),
   capabilities: z.object({
     platforms: z.array(Platform), // D3 adapters present
     runtimes: z.array(z.string()), // e.g. ["claude","codex"]


### PR DESCRIPTION
## Summary

The pool's orphan reconciler (#1074) moves out of the daemon process and becomes a one-shot
subcommand a Kubernetes CronJob runs: `agentconnect-daemon reconcile --once`. It boots only what a
sweep needs — the sandbox API surface and a control-plane connection for the `agent/exists` read —
runs exactly one sweep, prints the summary line, and exits 0 (non-zero when the sweep could not
complete). The in-process timer, the jitter, the interval knob, and the `sweep_leases` table are
gone.

The connection the job opens registers as an **observer**, a new optional `register.observer` flag,
so a process whose only job is to sweep can never be handed work to serve.

## Why a CronJob

Everything the in-process sweep built by hand is something the cluster already owns:

- **Schedule** — a CronJob schedule instead of a jittered `setTimeout` on every member.
- **Mutual exclusion** — `concurrencyPolicy: Forbid` instead of a single-holder lease in the shared
  store. One run at a time, enforced by the thing that starts the runs.
- **Failure reporting** — a failed Job is visible in the cluster. A sweep that could not read the
  control plane now exits non-zero instead of logging a warning inside a daemon that keeps running.
- **Blast radius** — a sweep is housekeeping; running it in the process that also serves agent
  turns bought nothing and cost a scheduler, a lease table, and a feature gate.

One behavioural consequence, stated deliberately: the grace period is now the **object's own age**
alone. The old code also required the agent to have been missing across the sweeping member's own
sweeps, and a one-shot run has no memory of an earlier run to carry that in. The object-age gate is
the clock that actually guards the race the grace exists for — an in-flight creation still racing
the control plane's write — and it survives; the reconciler also still ships dry-run by default.

## Observer registration

`RegisterReq` gains an optional `observer: true`. On an install-wide (pool identity) connection the
control plane admits it exactly as it admits a member — same TokenReview path, same projected
`ac-control-plane` token, same `auth` → `register` handshake — and then:

- **withdraws the membership** `upsertOnAuth` mints for every org-less row. Duty eligibility is a
  `member_set_member` lookup (`claimVacant`'s `eligibleAgent` gate), so a daemon in no set can never
  be granted a set-placed group, and a machine-placed agent never names it.
- **backdates `lastSeenAt`**, so the existing pool-member reaper retires the row on its next sweep
  rather than after the ordinary 15-minute silence window. Marking the row is the smaller change:
  skipping the row entirely is not available, because the epoch mint, the connection registry, and
  every reply are keyed by a daemon id that has to exist. An observer sends no heartbeat, so nothing
  moves the stamp forward again.

The flag is **refused on an org-scoped (API-key) connection** with `SCOPE_DENIED`: that credential
is an operator's daemon key, not a job identity, and there is no reason to let it opt out of
membership.

`agent/exists` already served install-wide connections and now serves observers unchanged.

## What was removed

- `OrphanReconciler`'s scheduler: `start()`/`stop()`, the ±25% jitter, `AC_K8S_ORPHAN_SWEEP_INTERVAL_MS`,
  and the in-flight single-flight guard. `AC_K8S_ORPHAN_DELETE` (default off = dry-run) and
  `AC_K8S_ORPHAN_GRACE_MS` are unchanged.
- The `sweep_leases` table and `LocalStore.acquireSweepLease`. **No migration step**: the table only
  ever existed in the `CREATE TABLE IF NOT EXISTS` block, was introduced in a single prerelease, and
  is never read again — an existing store simply keeps an unused table until it is recreated.
- The daemon-side feature gate ("skip the sweep if the control plane does not advertise
  `agent-exists-v1`"). It only existed to keep an in-process sweep quiet against an older control
  plane; the job now fails loudly instead, which is what a Job status is for. The control plane
  still advertises the feature.
- `CpClient.agentsExist` and the daemon's `liveAgentsFor`, with the reconciler's wiring in
  `Daemon`/`startK8sRuntimePlane`. Members run no sweep at all now.

## The CronJob the deployment side should add

Image = the daemon image, args `reconcile --once`, every 10 minutes, the pool members'
ServiceAccount, the same namespace/warm-pool/labels environment they read, and
`AC_K8S_ORPHAN_DELETE` left unset so it starts dry-run:

```yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: agentconnect-orphan-reconciler
spec:
  schedule: '*/10 * * * *'
  # This is the mutual exclusion the in-process lease used to provide.
  concurrencyPolicy: Forbid
  startingDeadlineSeconds: 120
  successfulJobsHistoryLimit: 1
  failedJobsHistoryLimit: 3
  jobTemplate:
    spec:
      backoffLimit: 0
      activeDeadlineSeconds: 300
      template:
        spec:
          restartPolicy: Never
          # The pool members' ServiceAccount: same TokenReview identity, same sandbox-namespace RBAC.
          serviceAccountName: ac-cloud-daemon
          containers:
            - name: reconcile
              image: <the same daemon image the pool runs>
              args: ['reconcile', '--once']
              # The same environment source the pool members read, so namespace, warm pool and
              # labels cannot drift: AC_CP_URL and AC_K8S_SANDBOX_NAMESPACE come from it, and the
              # member-only variables it also carries are simply ignored by this command.
              # AC_K8S_ORPHAN_DELETE is deliberately UNSET here — dry run until the summary lines
              # have been observed; set it to "true" to enable collection. AC_K8S_ORPHAN_GRACE_MS
              # defaults to 10 minutes.
              envFrom:
                - configMapRef:
                    name: <the pool members' env ConfigMap>
              volumeMounts:
                - name: cp-identity
                  mountPath: /var/run/ac-cp-identity
                  readOnly: true
          volumes:
            # The projected control-plane audience token, exactly as the pool members mount it.
            - name: cp-identity
              projected:
                sources:
                  - serviceAccountToken:
                      path: token
                      audience: ac-control-plane
                      expirationSeconds: 3600
```

The command needs `AC_CP_URL` and `AC_K8S_SANDBOX_NAMESPACE`, plus the projected identity token at
`/var/run/ac-cp-identity/token`. Its RBAC is the members' existing sandbox-namespace Role (list and
delete `sandboxclaims`, list and delete `sandboxes`); a Role without the Sandbox list verb simply
narrows the sweep to claims, as before.

## Test plan

- `packages/daemon/test/cli-reconcile.test.ts` (new) — the subcommand against the fake API server
  plus a fake control plane: one sweep, one existence read, the summary line, exit 0; exit 1 when
  the control plane cannot be reached (deleting nothing) and when the sandbox namespace is unset.
  Plus the observer handshake itself over a fake transport: `auth` then `register` with
  `observer: true`, the `agent/exists` chunking, and a refused registration failing the connection.
- `packages/control-plane/test/protocol/observer-register.handler.test.ts` (new, real Postgres) —
  an observer register leaves no `member_set_member` row and is granted nothing from a vacant duty
  group over a set-placed agent, while an ordinary member of the same pool claims that same group;
  `agent/exists` is answered on the observer connection; the row is selected by
  `findRetiredPoolMembers` immediately; the flag is refused with `SCOPE_DENIED` on an API-key
  connection.
- `packages/daemon/test/k8s-orphan-reconciler.test.ts` — the #1074 safety rules kept, minus the
  lease and scheduler cases, with the grace now asserted on the object's own age.
- Ran: `pnpm lint`, `pnpm format:check`, typecheck for protocol / daemon / control-plane, the daemon
  `test/cp`, `test/k8s-*`, `test/local-store.test.ts` and `test/cli-reconcile.test.ts` suites, and the
  control-plane unit + integration projects.
