### PR TITLE
ci: verify the container images where the release builds them

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -293,7 +293,7 @@ jobs:
       #
       # A target with a verification suite loads into the local daemon instead of pushing, so the
       # checks below run against the exact image this release publishes and a failure never
-      # reaches the registry. Single-platform (`_release`), so there is no manifest list to lose.
+      # reaches the registry. The Push step at the end then publishes it from cache.
       - name: Build
         uses: docker/build-push-action@v7
         with:
@@ -364,12 +364,24 @@ jobs:
           IMAGE: ${{ steps.image.outputs.ref }}
         run: pnpm --filter @agentconnect.md/daemon exec tsx scripts/smoke-runtime-image.mts "$IMAGE"
 
-      # Verified targets publish here rather than from the build, once the checks above have passed.
+      # Publish a verified target once its checks have passed. Same inputs against the same builder,
+      # so this re-exports from cache rather than rebuilding. It goes out through the action's own
+      # push path deliberately: a plain `docker push` of the loaded image would publish these two
+      # without the provenance attestation every directly-pushed target carries.
       - name: Push
         if: matrix.verify != ''
-        env:
-          TAGS: ${{ matrix.tags }}
-        run: printf '%s\n' "$TAGS" | xargs -rn1 docker push
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.build_target }}
+          platforms: ${{ matrix.platforms }}
+          push: true
+          tags: ${{ matrix.tags }}
+          build-args: ${{ matrix.build_args }}
+          build-contexts: ${{ matrix.build_contexts }}
+          labels: ${{ matrix.labels }}
+          cache-from: type=registry,ref=${{ matrix.cache_ref }}
 
   finalize:
     name: Finalize image tags

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,12 @@ name: Build & Push Images
 # effective image (same manifest digest), so `<comp>:<version>` exists for every
 # component at every release regardless.
 #
+# The daemon and the runtime sandbox are confinement boundaries whose failure modes are silent —
+# agent code running somewhere it should not, with every health check still green. Those two are
+# built here, verified against the loaded image, and pushed only once their checks pass. The image
+# a release publishes is therefore the image that was verified. A component skipped as unchanged
+# is not re-verified: it was verified at the release that built it.
+#
 # After pushing, mints a short-lived GitHub App token for the configured
 # workflow repository and fires an `images-pushed` repository_dispatch
 # (payload `{version, sha, components: {controlPlane, web, relay, mem0, runtimeSandbox,
@@ -226,14 +232,17 @@ jobs:
                   cache_ref: (
                     $config.tags[0]
                     | sub(":[^/]+$"; ":buildcache")
-                  )
+                  ),
+                  # The two confinement boundaries carry an image-verification suite; the service
+                  # images have none and push straight from the build.
+                  verify: ({"daemon": "daemon", "runtime-sandbox": "runtime-sandbox"}[$name] // "")
                 }
             ]
           ' "$bake_config")"
 
           if [ "$matrix" = '[]' ]; then
             echo "has_builds=false" >> "$GITHUB_OUTPUT"
-            matrix='[{"target":"none","context":".","dockerfile":"docker/Dockerfile","build_target":"","platforms":"linux/amd64","tags":"","build_args":"","build_contexts":"","labels":"","cache_ref":""}]'
+            matrix='[{"target":"none","context":".","dockerfile":"docker/Dockerfile","build_target":"","platforms":"linux/amd64","tags":"","build_args":"","build_contexts":"","labels":"","cache_ref":"","verify":""}]'
           else
             echo "has_builds=true" >> "$GITHUB_OUTPUT"
           fi
@@ -281,20 +290,86 @@ jobs:
 
       # A target-specific registry cache keeps all intermediate builder layers
       # (`mode=max`) without consuming the GitHub Actions cache quota.
-      - name: Build and push
+      #
+      # A target with a verification suite loads into the local daemon instead of pushing, so the
+      # checks below run against the exact image this release publishes and a failure never
+      # reaches the registry. Single-platform (`_release`), so there is no manifest list to lose.
+      - name: Build
         uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.build_target }}
           platforms: ${{ matrix.platforms }}
-          push: true
+          push: ${{ matrix.verify == '' }}
+          load: ${{ matrix.verify != '' }}
           tags: ${{ matrix.tags }}
           build-args: ${{ matrix.build_args }}
           build-contexts: ${{ matrix.build_contexts }}
           labels: ${{ matrix.labels }}
           cache-from: type=registry,ref=${{ matrix.cache_ref }}
           cache-to: type=registry,ref=${{ matrix.cache_ref }},mode=max
+
+      - name: Resolve the built image reference
+        if: matrix.verify != ''
+        id: image
+        env:
+          TAGS: ${{ matrix.tags }}
+        run: printf 'ref=%s\n' "$(printf '%s\n' "$TAGS" | head -1)" >> "$GITHUB_OUTPUT"
+
+      # Against the BUILT image: non-root, tini as PID 1, git and CA certs present, no ACP runtime
+      # smuggled in, and — the one that matters — `--k8s` refusing to start outside a pod instead
+      # of quietly running agent code on the daemon's own host.
+      - name: Verify the daemon image
+        if: matrix.verify == 'daemon'
+        env:
+          IMAGE: ${{ steps.image.outputs.ref }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: node scripts/verify-daemon-image.mjs "$IMAGE" "$VERSION"
+
+      # Only the runtime sandbox needs a toolchain here: its smoke test's daemon side runs from
+      # source. The other targets skip these steps.
+      - uses: pnpm/action-setup@v6
+        if: matrix.verify == 'runtime-sandbox'
+        with:
+          cache: true
+      - uses: actions/setup-node@v6
+        if: matrix.verify == 'runtime-sandbox'
+        with:
+          node-version-file: .nvmrc
+      - name: Install
+        if: matrix.verify == 'runtime-sandbox'
+        run: pnpm install --frozen-lockfile
+
+      # Against the BUILT image, not the Dockerfile: non-root, tini as PID 1, a root-owned shim the
+      # runtime cannot rewrite, a self-contained shim bundle, no smuggled service-account token,
+      # and the published runtime table agreeing with what the runtimes report.
+      - name: Verify the runtime sandbox image and its runtime table
+        if: matrix.verify == 'runtime-sandbox'
+        env:
+          IMAGE: ${{ steps.image.outputs.ref }}
+        run: node scripts/verify-runtime-image.mjs "$IMAGE"
+
+      # The smoke test's DAEMON side imports the listener from source, which imports the workspace
+      # packages by their built entry points.
+      - name: Build the workspace packages the daemon side imports
+        if: matrix.verify == 'runtime-sandbox'
+        run: pnpm --filter "@agentconnect.md/daemon^..." build
+
+      # The acceptance criterion: a real container, the real shim dialling back, the real ACP
+      # runtime starting inside it, initialize and one session/new.
+      - name: Smoke test through the shim
+        if: matrix.verify == 'runtime-sandbox'
+        env:
+          IMAGE: ${{ steps.image.outputs.ref }}
+        run: pnpm --filter @agentconnect.md/daemon exec tsx scripts/smoke-runtime-image.mts "$IMAGE"
+
+      # Verified targets publish here rather than from the build, once the checks above have passed.
+      - name: Push
+        if: matrix.verify != ''
+        env:
+          TAGS: ${{ matrix.tags }}
+        run: printf '%s\n' "$TAGS" | xargs -rn1 docker push
 
   finalize:
     name: Finalize image tags

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -100,61 +100,6 @@ jobs:
 
   # Keep the fast, Docker-free suites away from the resource-heavy build group
   # so their short per-test timeouts measure code rather than runner contention.
-  daemon-image:
-    name: Daemon Image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      # A local tag only: this job proves the image is sound, publication is build.yaml's job.
-      # Built with a version arg so the release-version path is exercised: without it the image
-      # reports the repo's 1.0.0-dev, which the Control Plane would persist as the fleet version.
-      - name: Build the daemon pod image
-        run: docker build -f docker/Dockerfile --target daemon --build-arg DAEMON_VERSION=v9.9.9-ci -t ac-daemon:ci .
-      # Against the BUILT image: non-root, tini as PID 1, git and CA certs present, no ACP
-      # runtime smuggled in, and — the one that matters — `--k8s` refusing to start outside a
-      # pod instead of quietly running agent code on the daemon's own host.
-      - name: Verify the image properties
-        run: node scripts/verify-daemon-image.mjs ac-daemon:ci v9.9.9-ci
-
-  runtime-sandbox-image:
-    name: Runtime Sandbox Image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@v6
-        with:
-          cache: true
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-      - name: Install
-        run: pnpm install --frozen-lockfile
-      # A local tag only: this job proves the image is sound, it does not publish. Publication is
-      # build.yaml's `runtime-sandbox` bake target at release.
-      - name: Build the runtime sandbox image
-        run: docker build -f docker/runtime-sandbox.Dockerfile -t runtime-sandbox:ci .
-      # Against the BUILT image, not the Dockerfile: non-root, tini as PID 1, a root-owned shim
-      # the runtime cannot rewrite, a self-contained shim bundle, no smuggled service-account
-      # token, and the published runtime table agreeing with what the runtimes report.
-      - name: Verify the image properties and the runtime table
-        run: node scripts/verify-runtime-image.mjs runtime-sandbox:ci
-      # The smoke test's DAEMON side imports the listener from source, which imports the
-      # workspace packages by their built entry points. A tree that happens to have them built
-      # hides this — it passed locally and failed here, which is the same missing-build defect the
-      # image itself had one layer down.
-      - name: Build the workspace packages the daemon side imports
-        run: pnpm --filter "@agentconnect.md/daemon^..." build
-      # The acceptance criterion: a real container, the real shim dialling back, the real ACP
-      # runtime starting inside it, initialize and one session/new.
-      - name: Smoke test through the shim
-        run: pnpm --filter @agentconnect.md/daemon exec tsx scripts/smoke-runtime-image.mts runtime-sandbox:ci
-
   unit:
     name: Unit Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Test built the daemon and runtime-sandbox images under a throwaway tag and checked
those, while the images a release actually publishes were never verified. Two builds
of the same thing, and the verified one was not the one that shipped. It also meant
a workflow named Test was building container images, which is not what a developer
expects to find there.

## What

- `test.yaml` — remove the `Daemon Image` and `Runtime Sandbox Image` jobs. Test runs
  tests; it no longer builds container images.
- `build.yaml` — the bake-derived matrix gains a `verify` field. A target that carries
  a verification suite builds with `load` instead of `push`, runs its checks against
  that image, and pushes only once they pass, so a failure never reaches the registry.
  Every other target pushes straight from the build exactly as before.
- Only the runtime sandbox pulls in a Node toolchain, for its smoke test's daemon side.
  The other targets skip those steps.

The verification scripts and the smoke test are unchanged — they only moved.

## Trade-off

A broken image is now caught at release rather than on the pull request that broke it.
That is the intended trade: the release build fails, we fix it, we re-run. In exchange
the bits that get published are the bits that were checked, and there is one build of
each image instead of two.

A component skipped as unchanged is not re-verified; it was verified at the release
that built it.

## Note before merging

If `Daemon Image` or `Runtime Sandbox Image` is configured as a required status check
on `main`, that entry needs removing or pull requests will wait on a job that no longer
runs. I could not read the branch protection settings from here.
