### PR TITLE
test(daemon): stop the unit suite from reaching slack.com

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -147,6 +147,7 @@ import {
   slackSharedKey,
   SlackConnection,
   type InteractionActor,
+  type SlackAppFactory,
   type SlackPostOptions,
   type SlackStatusOptions
 } from './slack/connection.js'
@@ -2500,6 +2501,9 @@ export class Daemon {
       overrides?: FlatOverrides
       agentName?: string
       hostFactory?: (agent: Agent, onUpdate: (sid: string, u: any) => void) => AcpHost
+      /** Builds the Slack app each connection drives. Injected by tests ONLY — unset, connections
+       * build the real client and reach slack.com, which is not something a unit suite should need. */
+      slackAppFactory?: SlackAppFactory
       /** Explicit test/evaluation-only Dream bypass. It is honored only with an
        * injected hostFactory, never by the production CLI/config surface. */
       dreamOperationPolicy?: DreamOperationPolicy
@@ -3672,22 +3676,25 @@ export class Daemon {
     if (groups.size === 0) this.log.info('slack: no slack integrations configured')
     else this.log.info(`slack: opening ${groups.size} socket connection(s)`)
     for (const group of groups.values()) {
-      const conn: SlackConnection = new SlackConnection({
-        group,
-        newTraceId: () => randomUUID(),
-        onMessage: (msg) => {
-          this.nameResolver?.noteMessage(conn, msg)
-          this.onInbound(msg, this.srcIntegrationIds(conn))
+      const conn: SlackConnection = new SlackConnection(
+        {
+          group,
+          newTraceId: () => randomUUID(),
+          onMessage: (msg) => {
+            this.nameResolver?.noteMessage(conn, msg)
+            this.onInbound(msg, this.srcIntegrationIds(conn))
+          },
+          onChannelsChanged: () => void this.refreshChannels(conn),
+          onMessageShortcut: (shortcut) => this.slackShortcutSession(shortcut, this.srcIntegrationIds(conn)),
+          onStatusAction: (a) => this.handleStatusAction(a),
+          onStatusInfo: (key) => this.statusInfoForKey(key),
+          onPermissionChoice: (a) => this.handlePermissionChoice(a),
+          onElicitChoice: (a) => this.handleElicitChoice(a),
+          log: this.log,
+          boltDebug: cfg.logging.level === 'debug' || cfg.logging.level === 'trace'
         },
-        onChannelsChanged: () => void this.refreshChannels(conn),
-        onMessageShortcut: (shortcut) => this.slackShortcutSession(shortcut, this.srcIntegrationIds(conn)),
-        onStatusAction: (a) => this.handleStatusAction(a),
-        onStatusInfo: (key) => this.statusInfoForKey(key),
-        onPermissionChoice: (a) => this.handlePermissionChoice(a),
-        onElicitChoice: (a) => this.handleElicitChoice(a),
-        log: this.log,
-        boltDebug: cfg.logging.level === 'debug' || cfg.logging.level === 'trace'
-      })
+        this.opts.slackAppFactory
+      )
       this.log.info(
         `slack: connecting (${group.integrations.length} integration(s): ${group.integrations.map((i) => i.agentId).join(', ')})…`
       )
@@ -4316,22 +4323,25 @@ export class Daemon {
       // New appToken: open an isolated socket (tier 2). Guard so a bad token logs
       // and leaves existing sockets intact instead of throwing out of reconcile.
       try {
-        const conn: SlackConnection = new SlackConnection({
-          group,
-          newTraceId: () => randomUUID(),
-          onMessage: (msg) => {
-            this.nameResolver?.noteMessage(conn, msg)
-            this.onInbound(msg, this.srcIntegrationIds(conn))
+        const conn: SlackConnection = new SlackConnection(
+          {
+            group,
+            newTraceId: () => randomUUID(),
+            onMessage: (msg) => {
+              this.nameResolver?.noteMessage(conn, msg)
+              this.onInbound(msg, this.srcIntegrationIds(conn))
+            },
+            onChannelsChanged: () => void this.refreshChannels(conn),
+            onMessageShortcut: (shortcut) => this.slackShortcutSession(shortcut, this.srcIntegrationIds(conn)),
+            onStatusAction: (a) => this.handleStatusAction(a),
+            onStatusInfo: (key) => this.statusInfoForKey(key),
+            onPermissionChoice: (a) => this.handlePermissionChoice(a),
+            onElicitChoice: (a) => this.handleElicitChoice(a),
+            log: this.log,
+            boltDebug: this.cfg.logging.level === 'debug' || this.cfg.logging.level === 'trace'
           },
-          onChannelsChanged: () => void this.refreshChannels(conn),
-          onMessageShortcut: (shortcut) => this.slackShortcutSession(shortcut, this.srcIntegrationIds(conn)),
-          onStatusAction: (a) => this.handleStatusAction(a),
-          onStatusInfo: (key) => this.statusInfoForKey(key),
-          onPermissionChoice: (a) => this.handlePermissionChoice(a),
-          onElicitChoice: (a) => this.handleElicitChoice(a),
-          log: this.log,
-          boltDebug: this.cfg.logging.level === 'debug' || this.cfg.logging.level === 'trace'
-        })
+          this.opts.slackAppFactory
+        )
         this.log.info(
           `slack: opening new socket at runtime (${group.integrations.length} integration(s): ${group.integrations
             .map((i) => i.agentId)
@@ -4378,17 +4388,20 @@ export class Daemon {
       let conn = this.slackSharedPool.find(slackSharedKey(group))
       let bound = false
       if (!conn) {
-        conn = new SlackConnection({
-          group,
-          sendOnly: true,
-          newTraceId: () => randomUUID(),
-          onMessage: () => {}, // never called (relay owns inbound)
-          onStatusAction: (a) => this.handleStatusAction(a),
-          onStatusInfo: (key) => this.statusInfoForKey(key),
-          onPermissionChoice: (a) => this.handlePermissionChoice(a),
-          onElicitChoice: (a) => this.handleElicitChoice(a),
-          log: this.log
-        })
+        conn = new SlackConnection(
+          {
+            group,
+            sendOnly: true,
+            newTraceId: () => randomUUID(),
+            onMessage: () => {}, // never called (relay owns inbound)
+            onStatusAction: (a) => this.handleStatusAction(a),
+            onStatusInfo: (key) => this.statusInfoForKey(key),
+            onPermissionChoice: (a) => this.handlePermissionChoice(a),
+            onElicitChoice: (a) => this.handleElicitChoice(a),
+            log: this.log
+          },
+          this.opts.slackAppFactory
+        )
         try {
           await conn.start()
           this.slackSharedPool.add(conn)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5094,24 +5094,27 @@ export class Daemon {
     this.log.info(
       `slack: background retry for appToken (${group.integrations.length} integration(s): ${group.integrations.map((i) => i.agentId).join(', ')})…`
     )
-    const conn: SlackConnection = new SlackConnection({
-      group,
-      newTraceId: () => randomUUID(),
-      onMessage: (msg) => {
-        // The arrow captures the NEW `conn` ref so nameResolver/onInbound use the
-        // successfully-retried connection, not a stale one from an earlier attempt.
-        this.nameResolver?.noteMessage(conn, msg)
-        this.onInbound(msg, this.srcIntegrationIds(conn))
+    const conn: SlackConnection = new SlackConnection(
+      {
+        group,
+        newTraceId: () => randomUUID(),
+        onMessage: (msg) => {
+          // The arrow captures the NEW `conn` ref so nameResolver/onInbound use the
+          // successfully-retried connection, not a stale one from an earlier attempt.
+          this.nameResolver?.noteMessage(conn, msg)
+          this.onInbound(msg, this.srcIntegrationIds(conn))
+        },
+        onChannelsChanged: () => void this.refreshChannels(conn),
+        onMessageShortcut: (shortcut) => this.slackShortcutSession(shortcut, this.srcIntegrationIds(conn)),
+        onStatusAction: (a) => this.handleStatusAction(a),
+        onStatusInfo: (key) => this.statusInfoForKey(key),
+        onPermissionChoice: (a) => this.handlePermissionChoice(a),
+        onElicitChoice: (a) => this.handleElicitChoice(a),
+        log: this.log,
+        boltDebug: this.cfg.logging.level === 'debug' || this.cfg.logging.level === 'trace'
       },
-      onChannelsChanged: () => void this.refreshChannels(conn),
-      onMessageShortcut: (shortcut) => this.slackShortcutSession(shortcut, this.srcIntegrationIds(conn)),
-      onStatusAction: (a) => this.handleStatusAction(a),
-      onStatusInfo: (key) => this.statusInfoForKey(key),
-      onPermissionChoice: (a) => this.handlePermissionChoice(a),
-      onElicitChoice: (a) => this.handleElicitChoice(a),
-      log: this.log,
-      boltDebug: this.cfg.logging.level === 'debug' || this.cfg.logging.level === 'trace'
-    })
+      this.opts.slackAppFactory
+    )
     try {
       await conn.start()
       // The roster may have changed while start() was in flight. Never publish a

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -535,6 +535,39 @@ function sendOnlyApp(botToken: string): AppLike {
  *  inert one so a unit suite never depends on Slack being reachable. */
 export type SlackAppFactory = (opts: { token: string; appToken: string }) => AppLike
 
+/** The production socket-mode app: a real Bolt/`WebClient` pair that reaches slack.com. */
+function realSocketModeApp(o: { token: string; appToken: string }, boltDebug?: boolean): AppLike {
+  // If HTTPS_PROXY or HTTP_PROXY is set, route all Slack API calls and
+  // WebSocket connections through that proxy.
+  const dispatcher = proxyDispatcher()
+  const clientOptions: WebClientOptions = {
+    ...(dispatcher ? { fetch: fetchWithDispatcher(dispatcher) } : {}),
+    // Bound the Web API per-request time + retries. The @slack/web-api default
+    // "10 retries over ~30 minutes" would, combined with our serial send-queue,
+    // let one transient failure block all delivery for a whole turn. 30s is a
+    // compromise: long enough for auth.test and sends to survive a slow/VPN link,
+    // yet still bounded so a stuck call cannot wedge the queue indefinitely.
+    timeout: 30_000,
+    retryConfig: { retries: 2 }
+  }
+  const logLevel = boltDebug ? LogLevel.DEBUG : undefined
+  const receiver = new SocketModeReceiver({
+    appToken: o.appToken,
+    ...(dispatcher ? { dispatcher } : {}),
+    installerOptions: { clientOptions },
+    ...(logLevel ? { logLevel } : {})
+  })
+  return new App({
+    token: o.token,
+    receiver,
+    clientOptions,
+    // Bolt v5 otherwise starts token verification from its constructor without
+    // an awaitable lifecycle. start() calls init() before opening the socket.
+    deferInitialization: true,
+    ...(logLevel ? { logLevel } : {})
+  }) as unknown as AppLike
+}
+
 export class SlackConnection implements PlatformConnection {
   private app: AppLike
   // §9.1: all outbound writes (post/update/setStatus/setTitle) funnel through one queue so
@@ -567,37 +600,7 @@ export class SlackConnection implements PlatformConnection {
 
   constructor(
     private deps: SlackDeps,
-    factory: SlackAppFactory = (o) => {
-      // If HTTPS_PROXY or HTTP_PROXY is set, route all Slack API calls and
-      // WebSocket connections through that proxy.
-      const dispatcher = proxyDispatcher()
-      const clientOptions: WebClientOptions = {
-        ...(dispatcher ? { fetch: fetchWithDispatcher(dispatcher) } : {}),
-        // Bound the Web API per-request time + retries. The @slack/web-api default
-        // "10 retries over ~30 minutes" would, combined with our serial send-queue,
-        // let one transient failure block all delivery for a whole turn. 30s is a
-        // compromise: long enough for auth.test and sends to survive a slow/VPN link,
-        // yet still bounded so a stuck call cannot wedge the queue indefinitely.
-        timeout: 30_000,
-        retryConfig: { retries: 2 }
-      }
-      const logLevel = deps.boltDebug ? LogLevel.DEBUG : undefined
-      const receiver = new SocketModeReceiver({
-        appToken: o.appToken,
-        ...(dispatcher ? { dispatcher } : {}),
-        installerOptions: { clientOptions },
-        ...(logLevel ? { logLevel } : {})
-      })
-      return new App({
-        token: o.token,
-        receiver,
-        clientOptions,
-        // Bolt v5 otherwise starts token verification from its constructor without
-        // an awaitable lifecycle. start() calls init() before opening the socket.
-        deferInitialization: true,
-        ...(logLevel ? { logLevel } : {})
-      }) as unknown as AppLike
-    }
+    factory?: SlackAppFactory
   ) {
     this.appToken = deps.group.appToken
     this.botToken = deps.group.botToken
@@ -605,9 +608,13 @@ export class SlackConnection implements PlatformConnection {
     // Send-only: a bare Web-API client (no Socket Mode, no appToken) wrapped in the
     // AppLike send surface. The event/action/start/stop members are inert — nothing
     // ever registers a handler or opens a socket in this mode.
-    this.app = deps.sendOnly
-      ? sendOnlyApp(deps.group.botToken)
-      : factory({ token: deps.group.botToken, appToken: deps.group.appToken })
+    // An injected factory wins in BOTH modes: send-only otherwise hard-coded `sendOnlyApp`, whose
+    // `auth.test()` reaches Slack, which left injected tests network-dependent on that path.
+    this.app = factory
+      ? factory({ token: deps.group.botToken, appToken: deps.group.appToken })
+      : deps.sendOnly
+        ? sendOnlyApp(deps.group.botToken)
+        : realSocketModeApp({ token: deps.group.botToken, appToken: deps.group.appToken }, deps.boltDebug)
     this.queue = new SlackSendQueue(deps.sendIntervalMs ?? 350)
   }
 

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -333,7 +333,9 @@ function actorOf(body: BlockActionArgs['body']): InteractionActor | undefined {
   return body?.user?.id ? { userId: body.user.id } : undefined
 }
 
-type AppLike = {
+/** The Slack surface `SlackConnection` drives. Exported so a caller can supply its own — see
+ *  {@link SlackAppFactory}. */
+export type AppLike = {
   message: (handler: (args: { message: unknown }) => Promise<void> | void) => void
   event: (type: string, handler: (args: { event: unknown }) => Promise<void> | void) => void
   action: (actionId: string | RegExp, handler: (args: BlockActionArgs) => Promise<void> | void) => void
@@ -529,6 +531,10 @@ function sendOnlyApp(botToken: string): AppLike {
   }
 }
 
+/** Builds the Slack app a connection drives. The default reaches slack.com; daemon tests inject an
+ *  inert one so a unit suite never depends on Slack being reachable. */
+export type SlackAppFactory = (opts: { token: string; appToken: string }) => AppLike
+
 export class SlackConnection implements PlatformConnection {
   private app: AppLike
   // §9.1: all outbound writes (post/update/setStatus/setTitle) funnel through one queue so
@@ -561,7 +567,7 @@ export class SlackConnection implements PlatformConnection {
 
   constructor(
     private deps: SlackDeps,
-    factory: (opts: { token: string; appToken: string }) => AppLike = (o) => {
+    factory: SlackAppFactory = (o) => {
       // If HTTPS_PROXY or HTTP_PROXY is set, route all Slack API calls and
       // WebSocket connections through that proxy.
       const dispatcher = proxyDispatcher()

--- a/packages/daemon/test/channel-intro.test.ts
+++ b/packages/daemon/test/channel-intro.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { planChannelIntros, buildIntroMessage, introPrompt, INTRO_MAX_BURST } from '../src/agents/channel-intro.js'
 import { Daemon } from '../src/daemon.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 const state = (seeded: boolean, introduced: string[] = []) => ({ seeded, introduced: new Set(introduced) })
 
@@ -140,7 +141,11 @@ describe('Daemon.maybeIntroduceOnJoin: the intro turn carries its own discovery 
   }
 
   it('stamps the joined channel on the dispatched turn’s CallMeta', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => ({}) as never })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => ({}) as never
+    })
     await daemon.start()
     const agent = (daemon as never as { agents: Map<string, Record<string, unknown>> }).agents.get('bot-a')!
     agent.integrations = [{ id: 'int-1', platform: 'slack' }]

--- a/packages/daemon/test/cp/cp-agent-directory.test.ts
+++ b/packages/daemon/test/cp/cp-agent-directory.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { CpCollabRoutes } from '../../src/cp/cp-collab-routes.js'
 import { Daemon } from '../../src/daemon.js'
 import { sessionKey } from '../../src/store/local-store.js'
+import { fakeSlackAppFactory } from '../fakes/slack-app.js'
 
 /**
  * Org-scoped peer directory: `CpCollabRoutes.admits()` is THE agent-call authorization
@@ -349,7 +350,11 @@ function scaffold(): string {
 
 describe("daemon channelAgents dep: 'agent-directory-org-scope-v1' negotiation", () => {
   async function bootWithCp(supports: boolean) {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => ({}) as never })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => ({}) as never
+    })
     await daemon.start()
     const sent: unknown[] = []
     ;(daemon as never as { cpClient: unknown }).cpClient = {

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../src/agents/write-agent.js'
 import { RegisterReq, type AgentSpec } from '@agentconnect.md/protocol'
 import { agentRemovalObligationsDir } from '../../src/paths.js'
+import { fakeSlackAppFactory } from '../fakes/slack-app.js'
 
 const MOVE_ID = '77777777-7777-4777-8777-777777777777'
 const MOVE_ID_2 = '88888888-8888-4888-8888-888888888888'
@@ -54,6 +55,7 @@ function writeAgent(root: string, id: string) {
 function makeDaemon(root: string) {
   const hosts: Array<{ id: string; stop: ReturnType<typeof vi.fn> }> = []
   const daemon = new Daemon({
+    slackAppFactory: fakeSlackAppFactory(),
     root,
     hostFactory: (agent) => {
       const h = {

--- a/packages/daemon/test/cp/cp-integration.test.ts
+++ b/packages/daemon/test/cp/cp-integration.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../src/slack/connection.js', async (importActual) => {
 
 import { Daemon } from '../../src/daemon.js'
 import type { IntegrationSpec } from '@agentconnect.md/protocol'
+import { fakeSlackAppFactory } from '../fakes/slack-app.js'
 
 function root1(): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-cpint-'))
@@ -57,6 +58,7 @@ function writeAgent(root: string, id: string) {
 
 function makeDaemon(root: string) {
   const daemon = new Daemon({
+    slackAppFactory: fakeSlackAppFactory(),
     root,
     hostFactory: (agent) =>
       ({

--- a/packages/daemon/test/cp/daemon-integration.test.ts
+++ b/packages/daemon/test/cp/daemon-integration.test.ts
@@ -9,6 +9,7 @@ import { CpRoutingLayer } from '../../src/router/cp-routing-layer.js'
 import { resolveCpRule } from '../../src/router/routing-rule.js'
 import { routeRules } from '../../src/router/routing-table.js'
 import type { NormalizedMessage } from '../../src/messages/normalized.js'
+import { fakeSlackAppFactory } from '../fakes/slack-app.js'
 
 const roots: string[] = []
 function freshRoot(): string {
@@ -32,7 +33,7 @@ describe('Daemon ↔ CP integration', () => {
       }) + '\n'
     )
     // Must not throw or hang even though the CP refuses the connection.
-    const daemon = new Daemon({ root })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root })
     await daemon.start()
     expect(true).toBe(true)
     await daemon.stop()
@@ -40,7 +41,7 @@ describe('Daemon ↔ CP integration', () => {
 
   it('mints and persists a daemonId when none is configured', async () => {
     const root = freshRoot()
-    const daemon = new Daemon({ root })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root })
     await daemon.start()
     await daemon.stop()
     const cfg = JSON.parse(readFileSync(join(root, 'config.json'), 'utf8'))

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import { sessionKey } from '../src/store/local-store.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 /**
  * send-message-routing-rework.md §4 / §4.1 / §6 — the DIRECT-daemon ladder for a
@@ -98,7 +99,8 @@ async function boot(
 ) {
   const daemon = new Daemon({
     root: scaffold(agents, over.distinctTokens),
-    hostFactory: () => fakeHost() as any
+    hostFactory: () => fakeHost() as any,
+    slackAppFactory: fakeSlackAppFactory()
   })
   await daemon.start()
   const placements = agents.map((a) => ({

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -13,6 +13,7 @@ import {
 import { Daemon } from '../src/daemon.js'
 import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -134,7 +135,11 @@ const dm = (ts: string, text: string) => ({
 describe('Daemon in-conversation commands', () => {
   it('!resume explicitly resets a durable loop guard; anonymous events cannot reset it', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     const scope = LOOP_SCOPE
@@ -153,7 +158,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('lets an authorized human recover a top-level loop latch from its ownerless warning thread', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     const integration = (daemon as any).agents.get('bot-a').integrations[0]
@@ -187,7 +196,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('shared-bot rd/msg(im) only lets a human reset the loop guard', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     const scope = LOOP_SCOPE
@@ -405,7 +418,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('shared-bot rd/msg(im) honors a !stop thread mute: implicit traffic drops, an @mention un-mutes', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     // The session the HTTP bot's inbound keys to (sessionKey(platform, channel, thread, agent)).
@@ -444,7 +461,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('!queue buffers a message and dispatches it once the turn goes idle', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -471,7 +492,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('!queue runs immediately when the agent is idle', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -487,7 +512,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('!queue rejects once the per-session cap (10) is reached', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -507,7 +536,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('!stop cancels the in-flight turn', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -538,7 +571,7 @@ describe('Daemon in-conversation commands', () => {
       stop: vi.fn(async () => {})
     }
     const root = scaffold()
-    const daemon = new Daemon({ root, hostFactory: () => host as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => host as any })
     await daemon.start()
     makeRoutable(daemon)
     const key = SESSION_KEY
@@ -578,7 +611,11 @@ describe('Daemon in-conversation commands', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const oldKey = SESSION_KEY
@@ -614,7 +651,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('!cancel interrupts the in-flight turn WITHOUT muting the thread', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -635,7 +676,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('!cancel with no in-flight turn just reports (no mute)', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -647,7 +692,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('!stop drops queued messages so they do not run after cancellation', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -671,7 +720,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('!stop mutes the thread: follow-ups are dropped (but transcribed) until an explicit @mention', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const store = (daemon as any).store
@@ -714,7 +767,11 @@ describe('Daemon in-conversation commands', () => {
     // latest session — otherwise every idle agent in the channel replies "Nothing is
     // running" to a command meant for whoever owns that thread.
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     const store = (daemon as any).store
@@ -745,7 +802,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('!stop with no in-flight turn still mutes an open thread; without a session it just reports', async () => {
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     const store = (daemon as any).store
@@ -771,7 +832,11 @@ describe('Daemon in-conversation commands', () => {
   }, 15_000)
 
   it('!status replies with the session status line; reports when no session exists', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -793,7 +858,11 @@ describe('Daemon in-conversation commands', () => {
   }, 15_000)
 
   it('!fast on|off records the sticky override; bare /fast prints usage', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
@@ -817,7 +886,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('/models · /effort · /permission list the choices and apply a selection', async () => {
     const host = selectHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
@@ -873,7 +946,11 @@ describe('Daemon in-conversation commands', () => {
       })),
       setSessionApprovalsReviewer: vi.fn(async () => true)
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     const store = (daemon as any).store
@@ -939,7 +1016,11 @@ describe('Daemon in-conversation commands', () => {
 
   it('a command from a non-routable thread is ignored (no dispatch, no crash)', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     // no integration attached → routeRules resolves nothing
     ;(daemon as any).onInbound(dm('100', '!stop'))
@@ -980,7 +1061,11 @@ function selectHost() {
 describe('Daemon managed-agent bot ingress', () => {
   it('ignores managed agent bot messages in mention and every-message paths but admits an external bot mention', async () => {
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     // This test mutates the in-memory fixture directly; it does not need the agent
     // directory watcher that start() opens for production hot reload.
@@ -1051,7 +1136,11 @@ describe('Daemon managed-agent bot ingress', () => {
 
 describe('Daemon transcript recording (§8.5 unrouted)', () => {
   it('records an unrouted mention into a live thread', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const store = (daemon as any).store
@@ -1081,7 +1170,11 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
   }, 15_000)
 
   it('backfill relabels the agent’s own bot frames to agentId and folds in attachment mentions', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon) as any
     conn.botUserId = 'UBOT'
@@ -1114,7 +1207,11 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
     // Slack hands out an auth-gated file URL, so the row can only carry the image if the
     // daemon fetches it — without that the console showed just `[attached: …]`. The fetch
     // is independent of the agent's image capability (quietHost advertises none).
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon) as any
     const bytes = Buffer.from('PNGBYTES')
@@ -1141,7 +1238,11 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
   }, 15_000)
 
   it('backfill preserves a remote agent author carried by an HTTP Slack bot', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon) as any
     conn.botUserId = 'USHARED'
@@ -1170,7 +1271,11 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
   }, 15_000)
 
   it('backfill ignores AgentConnect metadata from an unrelated Slack app', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon) as any
     conn.botUserId = 'UOWN'
@@ -1207,7 +1312,11 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
 
   it('records an unrouted message while a long turn is in flight even if the session looks idle-stale', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const store = (daemon as any).store
@@ -1247,7 +1356,11 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
   }, 15_000)
 
   it('does not record an unrouted message when no session is open in its thread', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const store = (daemon as any).store
@@ -1318,7 +1431,11 @@ describe('Slack interactive status bar', () => {
 
   it('posts one session status line and updates it on later turns', async () => {
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(AGENT_IDENTITY), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(AGENT_IDENTITY),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
 
@@ -1363,7 +1480,7 @@ describe('Slack interactive status bar', () => {
     // Exercise the hidden branch without starting the daemon's unrelated file watchers.
     // Config/default replication is covered separately; this proves the Slack cleanup
     // action deletes the remembered row and dedupes later usage/turn-end refreshes.
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     const conn = {
       deleteMessage: vi.fn(async () => true),
       getThreadReplies: vi.fn(async () => [{ ts: 'legacy', text: ':bar_chart: legacy', isBot: true }])
@@ -1402,7 +1519,11 @@ describe('Slack interactive status bar', () => {
 
   it('keeps the session status bar pinned above cards that need human input', async () => {
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(AGENT_IDENTITY), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(AGENT_IDENTITY),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
 
@@ -1443,7 +1564,11 @@ describe('Slack interactive status bar', () => {
 
   it('posts shareable channel status with agent identity and one compact overflow', async () => {
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(AGENT_IDENTITY), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(AGENT_IDENTITY),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
     const integration = (daemon as any).agents.get('bot-a').integrations[0]
@@ -1496,7 +1621,11 @@ describe('Slack interactive status bar', () => {
 
   it('drops Switch agent for a non-shareable HTTP bot while keeping agent identity + relay routing', async () => {
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(AGENT_IDENTITY), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(AGENT_IDENTITY),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
     const integration = (daemon as any).agents.get('bot-a').integrations[0]
@@ -1538,7 +1667,11 @@ describe('Slack interactive status bar', () => {
   }, 15_000)
 
   it('§6.6: a platform_action envelope decodes per-platform and NAKs unsupported items', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blockingHost().host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blockingHost().host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const integration = (daemon as any).agents.get('bot-a').integrations[0]
@@ -1586,7 +1719,11 @@ describe('Slack interactive status bar', () => {
   })
 
   it('handles shared session interactions only for the exact local integration and session owner', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blockingHost().host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blockingHost().host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const integration = (daemon as any).agents.get('bot-a').integrations[0]
@@ -1758,7 +1895,11 @@ describe('Slack interactive status bar', () => {
   })
 
   it('handles shared Feishu card actions only through the exact local integration', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blockingHost().host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blockingHost().host as any
+    })
     await daemon.start()
     const agent = (daemon as any).agents.get('bot-a')
     agent.integrations = [
@@ -1804,7 +1945,11 @@ describe('Slack interactive status bar', () => {
 
   it('adopts the first existing status line in a Slack thread', async () => {
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
     ;(conn as any).botId = 'B1'
@@ -1857,7 +2002,11 @@ describe('Slack interactive status bar', () => {
     // lets a bot chat.update its own messages. Adopting the sibling's bar would fail
     // with cant_update_message on every usage tick (and show the wrong session's data).
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
     ;(conn as any).botId = 'B-MINE'
@@ -1886,7 +2035,11 @@ describe('Slack interactive status bar', () => {
 
   it('never adopts a sibling Agent status line when both share one Slack app', async () => {
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
     ;(conn as any).botId = 'B-SHARED'
@@ -1921,7 +2074,11 @@ describe('Slack interactive status bar', () => {
     // on the session keeps failing chat.update forever — after an explicit false the
     // ts must be discarded so a later status emit posts a fresh, editable bar.
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
 
@@ -1962,7 +2119,11 @@ describe('Slack interactive status bar', () => {
 
   it('fetchThreadHistory skips daemon chrome (metadata-marked + status-bar text) but keeps conversation', async () => {
     const { host } = modelHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
     ;(conn as any).botId = 'B-X'
@@ -1994,7 +2155,11 @@ describe('Slack interactive status bar', () => {
     // The bar must still appear as soon as the turn begins (overflow + View), filling in
     // the model later via chat.update — regression for "no status bar until first message".
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
 
@@ -2011,7 +2176,11 @@ describe('Slack interactive status bar', () => {
 
   it('the Configure modal (statusInfoForKey) carries the CP-provided View-session link', async () => {
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(AGENT_IDENTITY), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(AGENT_IDENTITY),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     routableWithBlocks(daemon)
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
@@ -2040,7 +2209,7 @@ describe('Slack interactive status bar', () => {
   }, 15_000)
 
   it('uses the local Web App default when neither local nor CP configuration provides an origin', () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     ;(daemon as any).cfg = {}
     expect((daemon as any).sessionLink('acp-1')).toBe('http://localhost:3000/sessions/acp-1')
     expect((daemon as any).sessionLink('acp-1', 'slack')).toBe('http://localhost:3000/sessions/acp-1?source=slack')
@@ -2071,7 +2240,11 @@ describe('Slack interactive status bar', () => {
 
   it('falls back to the probed runtime models when the persisted session is cold', async () => {
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
     routableWithBlocks(daemon)
@@ -2101,7 +2274,11 @@ describe('Slack interactive status bar', () => {
 
   it('handleStatusAction routes set-model / cancel by session key', async () => {
     const { host, release } = modelHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
     const conn = routableWithBlocks(daemon)

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path'
 import type { DutyGrantEntry } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import type { DutyRegistry } from '../src/cp/duty-registry.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const AGENT_B = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
@@ -79,7 +80,7 @@ const bundle = (
 /** A daemon holding one granted duty, with a stub CP client — only the duty surface runs. */
 async function boot(scope: 'frame' | 'connection' = 'frame') {
   const root = scaffold()
-  const daemon = new Daemon({ root })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root })
   await daemon.start()
   const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
   ;(daemon as any).cpClient = {
@@ -99,7 +100,7 @@ async function boot(scope: 'frame' | 'connection' = 'frame') {
 /** A daemon with an admission held open at the `duty/fetch` round trip, so a withdrawal can land
  *  inside the window between grant receipt and `applyGrant` — the gap this guard exists for. */
 async function bootMidAdmission() {
-  const daemon = new Daemon({ root: scaffold() })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
   await daemon.start()
   let release!: () => void
   const fetched = new Promise<void>((resolve) => {

--- a/packages/daemon/test/daemon-duty-inbox-replay.test.ts
+++ b/packages/daemon/test/daemon-duty-inbox-replay.test.ts
@@ -12,6 +12,7 @@ import type { DutyGrantEntry } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import { LocalStore, sessionKey, type InboxRow } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 const WAIT = { timeout: 10_000 }
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
@@ -96,7 +97,7 @@ const msg = (ts: string, text: string) => ({
 /** A frame-scope member with a stub CP client that serves the one agent's bundle. */
 async function boot(root: string) {
   const g = gatedHost()
-  const daemon = new Daemon({ root, hostFactory: () => g.host as any })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => g.host as any })
   await daemon.start()
   const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
   ;(daemon as any).cpClient = {

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path'
 import type { DutyGrantEntry } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import type { DutyRegistry } from '../src/cp/duty-registry.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const GROUP = '11111111-1111-4111-8111-111111111111'
@@ -114,7 +115,7 @@ const bundleWithDefinitions = (grantKey?: string, issuedAt?: number) => ({
 
 /** A daemon started with a stub CP client — only the duty surface is exercised. */
 async function boot(client: Record<string, unknown>) {
-  const daemon = new Daemon({ root: scaffold() })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
   await daemon.start()
   ;(daemon as any).cpClient = {
     organizationScope: () => 'frame',

--- a/packages/daemon/test/daemon-duty-replacement.test.ts
+++ b/packages/daemon/test/daemon-duty-replacement.test.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path'
 import type { DutyGrantEntry } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import type { DutyRegistry } from '../src/cp/duty-registry.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 const AGENT_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const AGENT_B = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
@@ -84,7 +85,7 @@ const bundle = (agentId: string) => ({
  *  fails — the uninstallable addition a replacement carries. */
 async function boot(broken = new Set<string>()) {
   const root = scaffold()
-  const daemon = new Daemon({ root })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root })
   await daemon.start()
   const fetchDutyAgent = vi.fn(async (agentId: string) => {
     if (broken.has(agentId)) throw new Error('control plane unreachable')

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -30,6 +30,7 @@ import { transcriptCoords } from '../src/session/session-manager.js'
 import { sessionKey } from '../src/store/local-store.js'
 import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
 import { FakeClock } from '@agentconnect.md/connection'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // One plane per test file — the isolation Vitest's per-file module registry used to give.
 const workspaces = new WorkspaceManager()
@@ -128,6 +129,7 @@ describe('Daemon rd/msg hook fires', () => {
     const { factory, host } = streamingHost()
     host.modelOptions.mockReturnValue({ current: 'claude-sonnet-4-5' } as never)
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold({ name: 'review-bot', displayName: 'Review Bot', runtimeOverrides: { model: 'fallback-model' } }),
       hostFactory: factory
     })
@@ -147,7 +149,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('accepts, runs headless through the turn engine, and reports success + sessionId', async () => {
     const { factory, host } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
@@ -174,7 +176,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('persists a structured initial title for a GitHub pull-request session', async () => {
     const { factory } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
@@ -257,7 +259,7 @@ describe('Daemon rd/msg hook fires', () => {
     async ({ error, reason }) => {
       const { factory, host } = streamingHost()
       host.prompt.mockRejectedValue(error)
-      const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
       await daemon.start()
       const cp = fakeCpClient()
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
@@ -316,6 +318,7 @@ describe('Daemon rd/msg hook fires', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold(),
       hostFactory: (_agent, cb) => {
         onUpdate = cb
@@ -456,6 +459,7 @@ describe('Daemon rd/msg hook fires', () => {
         stop: vi.fn(async () => {})
       }
       const daemon = new Daemon({
+        slackAppFactory: fakeSlackAppFactory(),
         root: scaffold(),
         clock,
         hostFactory: (_agent, cb) => {
@@ -557,7 +561,11 @@ describe('Daemon rd/msg hook fires', () => {
   )
 
   it('grants formal-review authority only when an issue_comment explicitly requests review', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: streamingHost().factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: streamingHost().factory
+    })
     await daemon.start()
     const dispatchDaemonId = (daemon as any).cfg.daemonId as string
     const startHook = vi.fn(async () => ({ accepted: true }))
@@ -620,7 +628,7 @@ describe('Daemon rd/msg hook fires', () => {
         pullOnNewSession: true
       }
     })
-    const daemon = new Daemon({ root, hostFactory: streamingHost().factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
     await daemon.start()
     const dispatchDaemonId = (daemon as any).cfg.daemonId as string
     const prepare = vi.spyOn(daemon as any, 'prepareAgentWorkspace').mockResolvedValue('/agent/worktrees/review')
@@ -687,7 +695,7 @@ describe('Daemon rd/msg hook fires', () => {
         pullOnNewSession: true
       }
     })
-    const daemon = new Daemon({ root, hostFactory: streamingHost().factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
     await daemon.start()
     const dispatchDaemonId = (daemon as any).cfg.daemonId as string
     const prepare = vi
@@ -761,7 +769,7 @@ describe('Daemon rd/msg hook fires', () => {
         pullOnNewSession: true
       }
     })
-    const daemon = new Daemon({ root, hostFactory: streamingHost().factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
     await daemon.start()
     const dispatchDaemonId = (daemon as any).cfg.daemonId as string
     const prepare = vi.spyOn(daemon as any, 'prepareAgentWorkspace')
@@ -803,7 +811,11 @@ describe('Daemon rd/msg hook fires', () => {
   })
 
   it('disables formal-review authority by event family when a rolling relay omits inline ids', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: streamingHost().factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: streamingHost().factory
+    })
     await daemon.start()
     const dispatchDaemonId = (daemon as any).cfg.daemonId as string
     const startHook = vi.fn(async () => ({ accepted: true }))
@@ -917,7 +929,7 @@ describe('Daemon rd/msg hook fires', () => {
         return host as never
       }
 
-      const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
       await daemon.start()
       const cp = fakeCpClient()
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
@@ -1071,7 +1083,7 @@ describe('Daemon rd/msg hook fires', () => {
         return host as never
       }
 
-      const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
       await daemon.start()
       const cp = fakeCpClient()
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
@@ -1114,7 +1126,11 @@ describe('Daemon rd/msg hook fires', () => {
   )
 
   it('durably clears an old not_submitted result before authorizing a fresh retry', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: streamingHost().factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: streamingHost().factory
+    })
     await daemon.start()
 
     const oldAttemptId = '11111111-1111-4111-8111-111111111111'
@@ -1196,7 +1212,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('fails closed after restart when a current attempt is unresolved but an older report was not_submitted', async () => {
     const root = scaffold()
-    const seed = new Daemon({ root, hostFactory: streamingHost().factory })
+    const seed = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
     await seed.start()
 
     const dispatchDaemonId = (seed as any).cfg.daemonId as string
@@ -1294,6 +1310,7 @@ describe('Daemon rd/msg hook fires', () => {
       stop: vi.fn(async () => {})
     }
     const restarted = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, cb) => {
         onUpdate = cb
@@ -1351,7 +1368,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('preserves the inline review-thread target through durable inbox replay', async () => {
     const root = scaffold()
-    const seed = new Daemon({ root, hostFactory: streamingHost().factory })
+    const seed = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
     await seed.start()
     const replayFire = fire({
       sessionKey: 'acme/infra#42',
@@ -1409,7 +1426,7 @@ describe('Daemon rd/msg hook fires', () => {
     await seed.stop()
 
     const { factory } = streamingHost()
-    const restarted = new Daemon({ root, hostFactory: factory })
+    const restarted = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: factory })
     const cp = fakeCpClient()
     ;(restarted as never as { cpClient: unknown }).cpClient = cp
     const poster = { publish: vi.fn(async () => {}) }
@@ -1493,7 +1510,7 @@ describe('Daemon rd/msg hook fires', () => {
       execFileSync('git', ['update-ref', 'refs/remotes/origin/main', 'HEAD'], { cwd: workspace })
 
       const { factory, host } = streamingHost()
-      const daemon = new Daemon({ root, hostFactory: factory })
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: factory })
       await daemon.start()
       ;(daemon as any).hosts.set(AGENT_ID, host)
       const cp = fakeCpClient()
@@ -1580,7 +1597,7 @@ describe('Daemon rd/msg hook fires', () => {
   it('replays a retained GitHub deleted event as a maintenance no-op after restart', async () => {
     const root = scaffold()
     const seedHost = streamingHost()
-    const daemon = new Daemon({ root, hostFactory: seedHost.factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: seedHost.factory })
     await daemon.start()
     vi.spyOn(daemon as any, 'emitHookCompletion').mockImplementationOnce(() => {})
 
@@ -1591,7 +1608,7 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.stop()
 
     const restartedHost = streamingHost()
-    const restarted = new Daemon({ root, hostFactory: restartedHost.factory })
+    const restarted = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: restartedHost.factory })
     const cp = fakeCpClient()
     ;(restarted as never as { cpClient: unknown }).cpClient = cp
     await restarted.start()
@@ -1606,7 +1623,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('keeps a deleted GitHub comment silent when the thread already has a session', async () => {
     const { factory, host } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
@@ -1632,7 +1649,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('rejects a fire for an agent not on this daemon (no_agent)', async () => {
     const { factory } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
 
     const ack = await (daemon as any).handleRelayMsg(fire({ agentId: 'ghost' }), () => {})
@@ -1642,7 +1659,11 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('rejects a fire for a paused agent (paused)', async () => {
     const { factory } = streamingHost()
-    const daemon = new Daemon({ root: scaffold({ pause: true }), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold({ pause: true }),
+      hostFactory: factory
+    })
     await daemon.start()
 
     const ack = await (daemon as any).handleRelayMsg(fire(), () => {})
@@ -1652,7 +1673,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('rejects a fresh hook before durable admission when its conversation loop circuit is already open', async () => {
     const { factory, host } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
@@ -1673,7 +1694,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('rejects before the model turn when durable hook admission fails', async () => {
     const { factory, host } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     vi.spyOn((daemon as any).store, 'appendInbox').mockImplementation(() => {
       throw new Error('disk full')
@@ -1687,7 +1708,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('an anchored fire posts the trigger to the target channel and threads under it (P1.5)', async () => {
     const { factory } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
@@ -1717,7 +1738,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('uses only a bounded preparation pull credential when spawning a github-app workspace', async () => {
     const { factory, host } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const getCredential = vi.spyOn((daemon as any).gitCreds, 'get')
     const agent = (daemon as any).agents.get(AGENT_ID)
@@ -1744,7 +1765,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('replays the original ack on a redelivered (sessionKey, msgId) without re-running', async () => {
     const { factory, host } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
@@ -1776,6 +1797,7 @@ describe('Daemon rd/msg hook fires', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold(),
       hostFactory: (_agent, cb) => {
         onUpdate = cb
@@ -1826,6 +1848,7 @@ describe('Daemon rd/msg hook fires', () => {
     }
     const root = scaffold()
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, cb) => {
         onUpdate = cb
@@ -1941,7 +1964,7 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.stop()
 
     const restartedHost = streamingHost()
-    const restarted = new Daemon({ root, hostFactory: restartedHost.factory })
+    const restarted = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: restartedHost.factory })
     const restartedCp = fakeCpClient()
     ;(restarted as never as { cpClient: unknown }).cpClient = restartedCp
     ;(restarted as any).makeGithubReply = vi.fn(() => ({
@@ -1992,6 +2015,7 @@ describe('Daemon rd/msg hook fires', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold(),
       hostFactory: (_agent, cb) => {
         onUpdate = cb
@@ -2111,7 +2135,7 @@ describe('Daemon rd/msg hook fires', () => {
         stop: vi.fn(async () => {})
       }
       const root = scaffold()
-      const daemon = new Daemon({ root, hostFactory: () => host as never })
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => host as never })
       await daemon.start()
       // An unreachable CP keeps the report in the durable outbox (retryable
       // failure), without leaving an unresolved request alive during teardown.
@@ -2166,7 +2190,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('caps retained hook/report replay at 100 globally until requests settle', async () => {
     const { factory } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const emitHookReport = vi.fn(() => new Promise<'acknowledged'>(() => {}))
     ;(daemon as never as { cpClient: unknown }).cpClient = {
@@ -2196,7 +2220,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('retries the durable report drain after local read or ACK-cleanup failures', async () => {
     const { factory } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     ;(daemon as never as { cpClient: unknown }).cpClient = fakeCpClient()
     const retry = vi.spyOn(daemon as any, 'scheduleHookReportRetry').mockImplementation(() => {})
@@ -2221,7 +2245,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('keeps the first terminal owner as the only durable report writer', async () => {
     const { factory } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const cp = {
       hookReports: [] as HookReport[],
@@ -2269,7 +2293,7 @@ describe('Daemon rd/msg hook fires', () => {
     // row is told CONFLICT because it is the wrong reporter — not because the
     // completion is invalid — so nulling the body would lose a finished turn forever.
     const { factory } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const rejection = Object.assign(new Error('hook completion does not match the accepted dispatch'), {
       retryable: false
@@ -2326,7 +2350,7 @@ describe('Daemon rd/msg hook fires', () => {
 
   it('does not ACK-clean a live hook row when terminal redaction fails', async () => {
     const { factory } = streamingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
@@ -2370,7 +2394,7 @@ describe('Daemon rd/msg hook fires', () => {
   it('retains a terminal receipt so redelivery after restart does not rerun the model', async () => {
     const root = scaffold()
     const firstHost = streamingHost()
-    const first = new Daemon({ root, hostFactory: firstHost.factory })
+    const first = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: firstHost.factory })
     await first.start()
     const firstCp = fakeCpClient()
     ;(first as never as { cpClient: unknown }).cpClient = firstCp
@@ -2389,7 +2413,7 @@ describe('Daemon rd/msg hook fires', () => {
     await first.stop()
 
     const secondHost = streamingHost()
-    const second = new Daemon({ root, hostFactory: secondHost.factory })
+    const second = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: secondHost.factory })
     await second.start()
     ;(second as never as { cpClient: unknown }).cpClient = fakeCpClient()
     const secondAnchor = {

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -6,6 +6,7 @@ import { Daemon } from '../src/daemon.js'
 import { executeTool, type SessionContext } from '../src/mcp/ops.js'
 import { sessionKey } from '../src/store/local-store.js'
 import { FakeClock } from './cp/fake-clock.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -101,7 +102,11 @@ describe('Daemon interrupt safety gates', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     const stream = webchatSink()
     await daemon.start()
     ;(daemon as any).agents.get(AGENT_ID).allowRuntimeChangesInChat = true
@@ -154,7 +159,11 @@ describe('Daemon interrupt safety gates', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     const stream = webchatSink()
     await daemon.start()
 
@@ -211,7 +220,11 @@ describe('Daemon interrupt safety gates', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
 
     const t1Msg = dm('C1', 'T1', '100', 'T1 active')
@@ -287,7 +300,12 @@ describe('Daemon interrupt safety gates', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => settleSession())
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any,
+      clock
+    })
     const stream = webchatSink()
     await daemon.start()
 
@@ -325,7 +343,12 @@ describe('Daemon interrupt safety gates', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any,
+      clock
+    })
     const stream = webchatSink()
     await daemon.start()
     const standingContext = vi.fn(() => memoryBlocked)
@@ -376,7 +399,12 @@ describe('Daemon interrupt safety gates', () => {
         throw new Error('cannot stop child')
       })
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any,
+      clock
+    })
     const stream = webchatSink()
     await daemon.start()
 
@@ -425,7 +453,7 @@ describe('Daemon interrupt safety gates', () => {
     const hosts = [host1, host2]
     const factory = vi.fn(() => hosts.shift()!)
     const root = scaffold()
-    const daemon = new Daemon({ root, hostFactory: () => factory() as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => factory() as any })
     await daemon.start()
     await (daemon as any).watcher.close()
     ;(daemon as any).watcher = undefined
@@ -484,7 +512,7 @@ describe('Daemon interrupt safety gates', () => {
     }
     const factory = vi.fn(() => host)
     const root = scaffold()
-    const daemon = new Daemon({ root, hostFactory: () => factory() as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => factory() as any })
     await daemon.start()
     await (daemon as any).watcher.close()
     ;(daemon as any).watcher = undefined
@@ -541,7 +569,7 @@ describe('Daemon interrupt safety gates', () => {
     const hosts = [host1, host2]
     const factory = vi.fn(() => hosts.shift()!)
     const root = scaffold()
-    const daemon = new Daemon({ root, hostFactory: () => factory() as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => factory() as any })
     await daemon.start()
     await (daemon as any).watcher.close()
     ;(daemon as any).watcher = undefined
@@ -600,7 +628,7 @@ describe('Daemon interrupt safety gates', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root, hostFactory: () => host as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => host as any })
     await daemon.start()
     // Per-turn config rematerialization touches agents/**; on a slow runner the
     // debounced file-watch reconcile can then land mid-loop and revert the
@@ -728,7 +756,12 @@ describe('Daemon interrupt safety gates', () => {
       idleSweepMs: 30_000,
       shutdownDrainMs: 1_000
     })
-    const daemon = new Daemon({ root, hostFactory: () => factory() as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      hostFactory: () => factory() as any,
+      clock
+    })
     await daemon.start()
     const store = (daemon as any).store
     const closeStore = store.close.bind(store)
@@ -765,7 +798,11 @@ describe('Daemon interrupt safety gates', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     const stream = webchatSink()
     await daemon.start()
 

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -10,6 +10,7 @@ import { configFilesDir } from '../src/agents/config-file-env.js'
 import { readSkillLedger, skillLedgerLocation } from '../src/skills/skill-install-ledger.js'
 import { sessionKey } from '../src/store/local-store.js'
 import { FakeClock } from './cp/fake-clock.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -180,7 +181,7 @@ describe('Daemon session lifecycle (#118)', () => {
       expect(existsSync(workspace)).toBe(true)
       return host as any
     })
-    const daemon = new Daemon({ root, hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: factory })
     await daemon.start()
     expect(existsSync(workspace)).toBe(false)
 
@@ -196,7 +197,7 @@ describe('Daemon session lifecycle (#118)', () => {
     const workspace = join(root, 'agents', 'bot-a', 'workspace')
     writeFileSync(workspace, 'not a directory')
     const factory = vi.fn(() => quietHost() as any)
-    const daemon = new Daemon({ root, hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: factory })
     await daemon.start()
 
     await expect((daemon as any).ensureHostAsync('bot-a')).rejects.toThrow()
@@ -207,7 +208,11 @@ describe('Daemon session lifecycle (#118)', () => {
   }, 15_000)
 
   it('shares one cold preparation between host start and session creation', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const prepare = vi.spyOn(daemon as any, 'prepareAgentWorkspace')
@@ -233,7 +238,7 @@ describe('Daemon session lifecycle (#118)', () => {
     })
     const second = quietHost()
     const factory = vi.fn().mockReturnValueOnce(first).mockReturnValueOnce(second)
-    const daemon = new Daemon({ root, hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: factory })
     await daemon.start()
     const realPrepare = (daemon as any).prepareAgentWorkspace.bind(daemon)
     let preparations = 0
@@ -256,7 +261,7 @@ describe('Daemon session lifecycle (#118)', () => {
     const root = scaffold()
     const host = quietHost()
     const factory = vi.fn(() => host as any)
-    const daemon = new Daemon({ root, hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: factory })
     await daemon.start()
 
     const realPrepare = (daemon as any).prepareAgentWorkspace.bind(daemon)
@@ -319,7 +324,7 @@ describe('Daemon session lifecycle (#118)', () => {
     const secondHost = quietHost()
     const factory = vi.fn().mockReturnValueOnce(firstHost).mockReturnValueOnce(secondHost)
     const clock = new FakeClock()
-    const daemon = new Daemon({ root, hostFactory: factory, clock })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: factory, clock })
     await daemon.start()
     makeRoutable(daemon)
     await (daemon as any).ensureHostAsync('bot-a')
@@ -376,7 +381,7 @@ describe('Daemon session lifecycle (#118)', () => {
     const firstHost = quietHost()
     const secondHost = quietHost()
     const factory = vi.fn().mockReturnValueOnce(firstHost).mockReturnValueOnce(secondHost)
-    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
     await daemon.start()
     await (daemon as any).ensureHostAsync('bot-a')
     const capturedAgent = (daemon as any).agents.get('bot-a')
@@ -394,7 +399,11 @@ describe('Daemon session lifecycle (#118)', () => {
   }, 20_000)
 
   it('keeps stopAgent fenced until an aborted warm preparation quiesces', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     await (daemon as any).ensureHostAsync('bot-a')
@@ -429,7 +438,11 @@ describe('Daemon session lifecycle (#118)', () => {
   }, 20_000)
 
   it('coordinates a console git write like a file write, minus the host stop', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     const agent = (daemon as any).agents.get('bot-a')
     const stopHost = vi.spyOn(daemon as any, 'stopHost')
@@ -488,7 +501,11 @@ describe('Daemon session lifecycle (#118)', () => {
   }, 20_000)
 
   it('serializes workspace preparation and file publication in both admission orders', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     const agent = (daemon as any).agents.get('bot-a')
 
@@ -542,7 +559,11 @@ describe('Daemon session lifecycle (#118)', () => {
   }, 20_000)
 
   it('writes the session back to idle once a turn finishes (no longer stuck prompting)', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
@@ -552,7 +573,11 @@ describe('Daemon session lifecycle (#118)', () => {
 
   it('does not post a cron anchor while the target agent is paused', async () => {
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     ;(daemon as any).agents.get('bot-a').pause = true
@@ -573,7 +598,11 @@ describe('Daemon session lifecycle (#118)', () => {
 
   it('attributes a cron anchor to its agent and uses its Slack timestamp for follow-ups', async () => {
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     Object.assign((daemon as any).agents.get('bot-a'), {
       displayName: 'Review Bot',
@@ -625,7 +654,11 @@ describe('Daemon session lifecycle (#118)', () => {
 
   it('§6.8: a telegram anchored fire keys the session by that platform conversation model', async () => {
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const postMessage = vi.fn(async () => '777')
@@ -665,7 +698,11 @@ describe('Daemon session lifecycle (#118)', () => {
 
   it('§6.8: a telegram DM anchored fire keys `dm` and classifies as a DM session', async () => {
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const postMessage = vi.fn(async () => '888')
@@ -707,7 +744,11 @@ describe('Daemon session lifecycle (#118)', () => {
     // A Discord DM is one continuous conversation keyed by its channel. The same
     // classification also drives `conversationKind` and the private-capture gate.
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const postMessage = vi.fn(async () => 'msg-1')
@@ -748,7 +789,11 @@ describe('Daemon session lifecycle (#118)', () => {
 
   it('§6.8: a discord guild anchored fire materializes its native thread before dispatch', async () => {
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const postMessage = vi.fn(async () => 'msg-1')
@@ -788,7 +833,11 @@ describe('Daemon session lifecycle (#118)', () => {
 
   it('§6.8: a discord guild anchored fire starts no session when thread creation fails', async () => {
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
     const createThread = vi.fn(async () => undefined)
@@ -828,7 +877,11 @@ describe('Daemon session lifecycle (#118)', () => {
 
   it('reports a cron session before its turn finishes', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     Object.assign(conn, {
@@ -872,7 +925,12 @@ describe('Daemon session lifecycle (#118)', () => {
   it('!stop sets cancelling, and the backstop force-stops the host if the agent ignores cancel', async () => {
     const clock = new FakeClock()
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any,
+      clock
+    })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -897,7 +955,7 @@ describe('Daemon session lifecycle (#118)', () => {
   it('pausing interrupts every active session, drops queued turns, and keeps the host warm', async () => {
     const root = scaffold()
     const blocked = multiBlockingHost()
-    const daemon = new Daemon({ root, hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => blocked.host as any })
     await daemon.start()
 
     const first = (daemon as any).dispatch('bot-a', dm('100', 'first', 'T1'))
@@ -936,7 +994,7 @@ describe('Daemon session lifecycle (#118)', () => {
   it('pausing suppresses renderer actions already queued by the old turn', async () => {
     const root = scaffold()
     const blocked = blockingHost()
-    const daemon = new Daemon({ root, hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => blocked.host as any })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -970,7 +1028,7 @@ describe('Daemon session lifecycle (#118)', () => {
   it('does not revive a cold pre-pause turn after a quick unpause', async () => {
     const root = scaffold()
     const cold = coldBlockingHost()
-    const daemon = new Daemon({ root, hostFactory: () => cold.host as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => cold.host as any })
     await daemon.start()
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'cold', 'T1'))
@@ -1010,6 +1068,7 @@ describe('Daemon idle sweep (#111/#118)', () => {
       onUpdate('acp-1', { sessionUpdate: 'session_info_update', title: 'Final stopped title' })
     })
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold({ agentIdleTimeoutMs: 1000, idleSweepMs: 1000 }),
       hostFactory: (_agent, update) => {
         onUpdate = update
@@ -1039,7 +1098,7 @@ describe('Daemon idle sweep (#111/#118)', () => {
     const clock = new FakeClock()
     const host = quietHost()
     const root = scaffold({ agentIdleTimeoutMs: 1000, idleSweepMs: 1000 })
-    const daemon = new Daemon({ root, hostFactory: () => host as any, clock })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => host as any, clock })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -1072,7 +1131,7 @@ describe('Daemon idle sweep (#111/#118)', () => {
       sawFileAtPrompt.push(existsSync(kubeFile))
       return 'end_turn'
     })
-    const daemon = new Daemon({ root, hostFactory: () => host as any, clock })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => host as any, clock })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -1109,7 +1168,12 @@ describe('Daemon idle sweep (#111/#118)', () => {
     const root = scaffold({ agentIdleTimeoutMs: 1_000_000, idleSweepMs: 10_000_000, configFilesIdleMs: 1000 })
     const adir = join(root, 'agents', 'bot-a')
     const kubeFile = join(configFilesDir(adir), 'kubeconfig')
-    const daemon = new Daemon({ root, hostFactory: () => blocked.host as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      hostFactory: () => blocked.host as any,
+      clock
+    })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -1137,7 +1201,7 @@ describe('Daemon idle sweep (#111/#118)', () => {
     mkdirSync(secretsDir, { recursive: true })
     writeFileSync(join(secretsDir, 'kubeconfig'), 'stale')
 
-    const daemon = new Daemon({ root, hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => quietHost() as any })
     await daemon.start()
     expect(existsSync(secretsDir)).toBe(false)
     await daemon.stop()
@@ -1153,6 +1217,7 @@ describe('Daemon idle sweep (#111/#118)', () => {
     clock.advance(1_700_000_000_000) // a realistic epoch, so `now - 0` ≫ TTL (the bug's trigger)
     const host = quietHost()
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold({ agentIdleTimeoutMs: 1000, idleSweepMs: 10_000_000 }),
       hostFactory: () => host as any,
       clock
@@ -1183,7 +1248,12 @@ describe('Daemon idle sweep — background-task lease', () => {
 
   async function bootWithTurn(clock: FakeClock, limits: Record<string, number>) {
     const host = quietHost()
-    const daemon = new Daemon({ root: scaffold(limits), hostFactory: () => host as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(limits),
+      hostFactory: () => host as any,
+      clock
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
@@ -1535,6 +1605,7 @@ describe('Daemon idle sweep — background-task lease', () => {
         stop: vi.fn(async () => {})
       }
       const daemon = new Daemon({
+        slackAppFactory: fakeSlackAppFactory(),
         root: scaffold({ agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 }),
         hostFactory: () => host as any,
         clock
@@ -1817,7 +1888,11 @@ describe('Daemon idle sweep — background-task lease', () => {
 describe('Daemon graceful shutdown drain (#109)', () => {
   it('awaits an in-flight turn before tearing the host down (no mid-turn kill)', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -1839,7 +1914,11 @@ describe('Daemon graceful shutdown drain (#109)', () => {
   }, 15_000)
 
   it('keeps the store alive until an admitted workspace file write settles', async () => {
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any
+    })
     await daemon.start()
     const store = (daemon as any).store
     const close = vi.spyOn(store, 'close')
@@ -1876,7 +1955,11 @@ describe('Daemon CP drain (#109)', () => {
 
   it('scope:daemon drains in-flight turns, releases them, stops hosts, re-opens the gate', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -1896,7 +1979,11 @@ describe('Daemon CP drain (#109)', () => {
 
   it('omits the thread for a channel-root session in released[] (matches the CP key)', async () => {
     const blocked = blockingHost()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -1943,7 +2030,12 @@ describe('Daemon session retention GC (#485)', () => {
 
   it('the idle sweep deletes expired sessions but spares live turns and gate-owned keys', async () => {
     const clock = new FakeClock()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any,
+      clock
+    })
     await daemon.start()
 
     seedSession(daemon, 'expired-closed', 'closed', 0)
@@ -1966,7 +2058,12 @@ describe('Daemon session retention GC (#485)', () => {
 
   it('retention "never" disables the sweep entirely', async () => {
     const clock = new FakeClock()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any,
+      clock
+    })
     await daemon.start()
     ;(daemon as any).cfg.sessions.retention = 'never'
     seedSession(daemon, 'expired-closed', 'closed', 0)
@@ -1980,7 +2077,12 @@ describe('Daemon session retention GC (#485)', () => {
 
   it('reports each purged session to the CP and clears the receipt only on the ACK', async () => {
     const clock = new FakeClock()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any,
+      clock
+    })
     await daemon.start()
     const emitSessionPurged = vi.fn(async () => 'acknowledged' as const)
     ;(daemon as any).cpClient = { emitSessionPurged, state: 'READY', stop: vi.fn(async () => {}) }
@@ -2006,7 +2108,12 @@ describe('Daemon session retention GC (#485)', () => {
 
   it('never reports a session under another purge time or agent', async () => {
     const clock = new FakeClock()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any,
+      clock
+    })
     await daemon.start()
     const emitSessionPurged = vi.fn(async () => 'acknowledged' as const)
     ;(daemon as any).cpClient = { emitSessionPurged, state: 'READY', stop: vi.fn(async () => {}) }
@@ -2040,7 +2147,12 @@ describe('Daemon session retention GC (#485)', () => {
 
   it('leaves the receipts alone while the CP socket is down', async () => {
     const clock = new FakeClock()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any,
+      clock
+    })
     await daemon.start()
     const emitSessionPurged = vi.fn()
     ;(daemon as any).cpClient = { emitSessionPurged, state: 'DEGRADED', stop: vi.fn(async () => {}) }
@@ -2059,7 +2171,12 @@ describe('Daemon session retention GC (#485)', () => {
 
   it('keeps the purge receipts when the CP cannot accept them yet', async () => {
     const clock = new FakeClock()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any,
+      clock
+    })
     await daemon.start()
     // A CP that does not advertise the feature would reject the unknown frame, so
     // the receipt must survive for a post-upgrade reconnect.
@@ -2094,7 +2211,12 @@ describe('Daemon session retention GC (#485)', () => {
 
   it('a session with pending durable inbox work is treated as active and kept', async () => {
     const clock = new FakeClock()
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any, clock })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any,
+      clock
+    })
     await daemon.start()
     seedSession(daemon, 'expired-queued', 'closed', 0)
     ;(daemon as any).store.appendInbox({

--- a/packages/daemon/test/daemon-loop-guard-pool.test.ts
+++ b/packages/daemon/test/daemon-loop-guard-pool.test.ts
@@ -7,6 +7,7 @@ import { Daemon } from '../src/daemon.js'
 import { LocalStore } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
 import { FakeClock } from './cp/fake-clock.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 /**
  * #1038 — the loop guard's durable backlog is one inbox table for the whole install, but a
@@ -51,7 +52,12 @@ function scaffold(): string {
 }
 
 async function boot(root: string, daemonId: string, scope: 'frame' | 'legacy') {
-  const daemon = new Daemon({ root, hostFactory: () => ({}) as any, clock: new FakeClock() })
+  const daemon = new Daemon({
+    slackAppFactory: fakeSlackAppFactory(),
+    root,
+    hostFactory: () => ({}) as any,
+    clock: new FakeClock()
+  })
   await daemon.start()
   const inner = daemon as any
   inner.cfg.daemonId = daemonId

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -9,6 +9,7 @@ import { AGENTMSG_NOT_READY_RETRY } from '../src/cp/agentmsg-retry.js'
 import { executeTool, type MessageAgentReq } from '../src/mcp/ops.js'
 import { sessionKey } from '../src/store/local-store.js'
 import * as monotonic from '../src/store/monotonic-ts.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -79,7 +80,7 @@ const fakeHost = () => ({
 
 /** Boot a daemon and replace `dispatch` with a spy that records its args. */
 async function bootWithDispatchSpy(root: string) {
-  const daemon = new Daemon({ root, hostFactory: () => fakeHost() as any })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost() as any })
   await daemon.start()
   // Same-daemon authorization consumes the same CP collaboration snapshot as
   // relay terminal verification. Seed the default test channel with every local
@@ -2171,7 +2172,7 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
   it('creates an idle session without prompting the model', async () => {
     const root = scaffold([{ id: 'bot-a' }])
     const host = fakeHost()
-    const daemon = new Daemon({ root, hostFactory: () => host as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => host as any })
     await daemon.start()
     const targetKey = sessionKey('slack', 'C1', '1784297789.871789', 'bot-a')
 

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import type { CreateElicitationRequest, RequestPermissionRequest } from '@agentclientprotocol/sdk'
 import { Daemon, noneSuppressedApprovalSurface, isBuiltinSystemTool, isBuiltinSystemToolCall } from '../src/daemon.js'
 import { ALL_TOOL_NAMES } from '../src/mcp/tools.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 /**
  * Auto-approve policy for the daemon's OWN built-in MCP tools (UX fix): a human should
@@ -141,7 +142,7 @@ describe('built-in MCP approvals use one policy on both ACP paths', () => {
   })
 
   it.each(ALL_TOOL_NAMES)('bypasses both approval paths for %s after a trusted tool event', async (name) => {
-    const daemon = new Daemon({ sandboxMechanism: null })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending = installPending(daemon)
     const toolCallId = `opaque-${name}`
 
@@ -166,7 +167,7 @@ describe('built-in MCP approvals use one policy on both ACP paths', () => {
   })
 
   it('queues non-system requests for an Agent editor even when `none` hides the chat surface', async () => {
-    const daemon = new Daemon({ sandboxMechanism: null })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending = installPending(daemon) as Record<string, unknown>
     pending.approvalSurfaceSuppressed = true
 
@@ -227,7 +228,7 @@ describe('built-in MCP approvals use one policy on both ACP paths', () => {
 
   it('routes non-Slack and webchat requests to Agent editors instead of auto-allowing them', async () => {
     for (const platform of ['telegram', 'discord', 'feishu', 'webchat']) {
-      const daemon = new Daemon({ sandboxMechanism: null })
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
       const pending = installPending(daemon) as Record<string, unknown>
       pending.platform = platform
       pending.approvalSurfaceSuppressed = false
@@ -247,7 +248,7 @@ describe('built-in MCP approvals use one policy on both ACP paths', () => {
   })
 
   it('fails closed when the editor queue cannot be persisted', async () => {
-    const daemon = new Daemon({ sandboxMechanism: null })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     installPending(daemon)
     ;(daemon as any).store.createPermissionRequest = vi.fn(() => {
       throw new Error('disk unavailable')
@@ -261,7 +262,7 @@ describe('built-in MCP approvals use one policy on both ACP paths', () => {
   })
 
   it('does not trust another server, an uncorrelated id, or malformed approval metadata', async () => {
-    const daemon = new Daemon({ sandboxMechanism: null })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending = installPending(daemon)
 
     ;(daemon as any).onAcpUpdate('agent-1', 's1', {

--- a/packages/daemon/test/daemon-platform-authorship.test.ts
+++ b/packages/daemon/test/daemon-platform-authorship.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { manifestFor } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 /**
  * Behavioral pins for the bot-authorship cluster — the seven core branches that were
@@ -89,7 +90,11 @@ const fakeHost = () => ({
  * verify. The gates are what keep it out, not a missing snapshot row.
  */
 async function boot(agentIds: string[], over: { botShared?: boolean; platforms?: string[] } = {}) {
-  const daemon = new Daemon({ root: scaffold(agentIds), hostFactory: () => fakeHost() as any })
+  const daemon = new Daemon({
+    root: scaffold(agentIds),
+    hostFactory: () => fakeHost() as any,
+    slackAppFactory: fakeSlackAppFactory()
+  })
   await daemon.start()
   const placements = agentIds.map((id) => ({
     agentId: id,

--- a/packages/daemon/test/daemon-runtime-auth.test.ts
+++ b/packages/daemon/test/daemon-runtime-auth.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 /**
  * Live-turn auth signal (issue: claude-agent-acp initializes, opens sessions,
@@ -105,7 +106,7 @@ describe('live-turn runtime auth signal', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     makeRoutable(daemon)
     const emitted: Array<Array<{ runtime: string; authRequired?: boolean }>> = []
@@ -164,7 +165,7 @@ describe('live-turn runtime auth signal', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     makeRoutable(daemon)
     ;(daemon as any).cpClient = {

--- a/packages/daemon/test/daemon-serial-gate.test.ts
+++ b/packages/daemon/test/daemon-serial-gate.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
 import type { WebchatOutput, WebchatDone } from '@agentconnect.md/protocol'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -101,7 +102,11 @@ const msg = (ts: string, text: string, thread = 'T1') => ({
 })
 
 async function boot(host: any) {
-  const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+  const daemon = new Daemon({
+    slackAppFactory: fakeSlackAppFactory(),
+    root: scaffold(),
+    hostFactory: () => host as any
+  })
   await daemon.start()
   return daemon
 }
@@ -170,7 +175,7 @@ describe('P4 serial gate', () => {
     )
 
     const g = gatedHost()
-    const daemon = new Daemon({ root, hostFactory: () => g.host as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => g.host as any })
     await daemon.start()
     const key = 'slack:C1:T1:bot-a'
     const active = (daemon as any).dispatch('bot-a', msg('100', 'active'), 'int-a')
@@ -234,7 +239,7 @@ describe('P4 serial gate', () => {
     )
 
     const g = gatedHost()
-    const daemon = new Daemon({ root, hostFactory: () => g.host as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => g.host as any })
     await daemon.start()
     await (daemon as any).ensureHostAsync('bot-a')
     expect((daemon as any).hosts.has('bot-a')).toBe(true)

--- a/packages/daemon/test/daemon-session-metadata-outbox-pool.test.ts
+++ b/packages/daemon/test/daemon-session-metadata-outbox-pool.test.ts
@@ -7,6 +7,7 @@ import { Daemon } from '../src/daemon.js'
 import { LocalStore } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
 import { FakeClock } from './cp/fake-clock.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 /**
  * #1023 — on a daemon pool the session-metadata outbox is one shared table, but the
@@ -59,7 +60,7 @@ type Member = Awaited<ReturnType<typeof boot>>
  *  from the agent registry, which on a pool carries only the agents this member serves. */
 async function boot(root: string, daemonId: string, scope: 'frame' | 'install' = 'frame') {
   const clock = new FakeClock()
-  const daemon = new Daemon({ root, hostFactory: () => ({}) as any, clock })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => ({}) as any, clock })
   await daemon.start()
   const inner = daemon as any
   inner.cfg.daemonId = daemonId

--- a/packages/daemon/test/daemon-session-sweeps-pool.test.ts
+++ b/packages/daemon/test/daemon-session-sweeps-pool.test.ts
@@ -7,6 +7,7 @@ import { Daemon } from '../src/daemon.js'
 import { LocalStore } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
 import { FakeClock } from './cp/fake-clock.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 /**
  * #1032 — on a daemon pool the session table is one table for every member, but the
@@ -56,7 +57,7 @@ function scaffold(): string {
 /** One pool member: duty leases gate service, exactly like an install-wide member. */
 async function boot(root: string, daemonId: string) {
   const clock = new FakeClock()
-  const daemon = new Daemon({ root, hostFactory: () => ({}) as any, clock })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => ({}) as any, clock })
   await daemon.start()
   const inner = daemon as any
   inner.cfg.daemonId = daemonId

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { Daemon } from '../src/daemon.js'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../src/cp/gitcred-server.js'
 import { FakeClock } from './cp/fake-clock.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -49,6 +50,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
   it('sandboxes a host only when the agent opts in — skills are not force-sandboxed (#36)', async () => {
     const root = scaffold()
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       sandboxMechanism: 'bwrap',
       probeRuntimes: async () => []
@@ -82,14 +84,14 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       JSON.stringify({ version: 1, controlPlane: { enabled: false }, security: { requireSandbox: true } })
     )
 
-    await expect(new Daemon({ root, sandboxMechanism: null }).start()).rejects.toThrow(
-      /daemon startup refused.*requireSandbox.*no supported Linux SRT\/bwrap/
-    )
+    await expect(
+      new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: null }).start()
+    ).rejects.toThrow(/daemon startup refused.*requireSandbox.*no supported Linux SRT\/bwrap/)
   })
 
   it('does not force the skill sandbox or fail closed when the host has no sandbox mechanism (#36)', async () => {
     const root = scaffold()
-    const daemon = new Daemon({ root, sandboxMechanism: null })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: null })
     try {
       // Sandbox-optional principle: skills are NOT force-sandboxed fleet-wide, so
       // boot/reconcile must not throw on a host with no OS sandbox (the exact
@@ -107,7 +109,12 @@ describe('Daemon (no Slack, injected ACP host)', () => {
 
   it('enables production Dream operations (security hold lifted) without a host factory (#36 Phase C)', async () => {
     const root = scaffold()
-    const daemon = new Daemon({ root, sandboxMechanism: null, probeRuntimes: async () => [] })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      sandboxMechanism: null,
+      probeRuntimes: async () => []
+    })
     try {
       await daemon.start()
       // The production security hold is lifted: a real (no host-factory) daemon
@@ -123,7 +130,12 @@ describe('Daemon (no Slack, injected ACP host)', () => {
 
   it('lets a dream session run its org-context tools off the chat-turn queue (#36 canRun carve-out)', async () => {
     const root = scaffold()
-    const daemon = new Daemon({ root, sandboxMechanism: null, probeRuntimes: async () => [] })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      sandboxMechanism: null,
+      probeRuntimes: async () => []
+    })
     try {
       await daemon.start()
       // A dream never populates activeGateEntries (it runs off the chat-turn
@@ -144,7 +156,12 @@ describe('Daemon (no Slack, injected ACP host)', () => {
 
   it('keeps agent tool credentials out of the dream host without re-enabling repository hooks', async () => {
     const root = scaffold()
-    const daemon = new Daemon({ root, sandboxMechanism: 'bwrap', probeRuntimes: async () => [] })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      sandboxMechanism: 'bwrap',
+      probeRuntimes: async () => []
+    })
     try {
       await daemon.start()
       const agent = (daemon as any).agents.get('bot-a')
@@ -205,7 +222,12 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       })
     )
 
-    const daemon = new Daemon({ root, agentName: 'bot-a', sandboxMechanism: 'bwrap' })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      agentName: 'bot-a',
+      sandboxMechanism: 'bwrap'
+    })
     try {
       await expect(daemon.start()).rejects.toThrow(/workspace cwd.*not inside the agent dir/)
     } finally {
@@ -231,7 +253,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       })
     )
 
-    const daemon = new Daemon({ root, sandboxMechanism: 'bwrap' })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: 'bwrap' })
     try {
       await expect(daemon.start()).rejects.toThrow(/duplicate active agent id "bot-a"/)
     } finally {
@@ -254,7 +276,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     // directly exercise dispatch via the scheduler path
     await (daemon as any).dispatch('bot-a', {
@@ -284,7 +306,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     await (daemon as any).dispatch('bot-a', {
       msgId: 'slack:C1:1',
@@ -315,7 +337,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     await (daemon as any).dispatch('bot-a', {
       msgId: 'slack:C1:1',
@@ -361,7 +383,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     // Inject a fake CP client so the fire-and-forget emit is observable (no real WS).
     const emitEventSession = vi.fn()
@@ -459,7 +481,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     writeFileSync(configPath, JSON.stringify(config))
     const agentId = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
     const sessionId = 'acp-durable-1'
-    const first = new Daemon({ root, probeRuntimes: async () => [] })
+    const first = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, probeRuntimes: async () => [] })
     let firstStopped = false
     let restored: Daemon | undefined
     try {
@@ -496,7 +518,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       await first.stop()
       firstStopped = true
 
-      restored = new Daemon({ root, probeRuntimes: async () => [] })
+      restored = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, probeRuntimes: async () => [] })
       ;(restored as any).startCpClient = vi.fn()
       await restored.start()
       const replayed = vi.fn().mockResolvedValue('acknowledged')
@@ -529,7 +551,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
   it('preempts a deferred session metadata retry when work is ready sooner', async () => {
     const root = scaffold()
     const clock = new FakeClock()
-    const daemon = new Daemon({ root, clock, probeRuntimes: async () => [] })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, clock, probeRuntimes: async () => [] })
     await daemon.start()
     const drain = vi.spyOn(daemon as any, 'drainSessionMetadataSnapshots').mockResolvedValue(undefined)
 
@@ -549,7 +571,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
   it('defers a poisoned session metadata snapshot and drains unrelated sessions', async () => {
     const root = scaffold()
     const clock = new FakeClock()
-    const daemon = new Daemon({ root, clock, probeRuntimes: async () => [] })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, clock, probeRuntimes: async () => [] })
     await daemon.start()
     const agentId = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
     const poison = {
@@ -617,6 +639,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       stop: vi.fn()
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, update) => {
         onUpdate = update
@@ -686,6 +709,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       stop: vi.fn()
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, update) => {
         onUpdate = update
@@ -760,6 +784,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       stop: vi.fn()
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, update) => {
         onUpdate = update
@@ -829,6 +854,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       })
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, update) => {
         onUpdate = update
@@ -910,6 +936,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     const releases = new Map<string, () => void>()
     const updates = new Map<string, (sessionId: string, update: unknown) => void>()
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (agent, onUpdate) => {
         updates.set(agent.id, onUpdate)
@@ -982,6 +1009,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
         stop: vi.fn()
       }
       const daemon = new Daemon({
+        slackAppFactory: fakeSlackAppFactory(),
         root,
         hostFactory: (_agent, update) => {
           onUpdate = update
@@ -1047,6 +1075,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
         stop: vi.fn()
       }
       const daemon = new Daemon({
+        slackAppFactory: fakeSlackAppFactory(),
         root,
         hostFactory: (_agent, update) => {
           onUpdate = update
@@ -1120,7 +1149,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
         cancel: vi.fn(),
         stop: vi.fn()
       }
-      const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
       await daemon.start()
       const postMessage = vi.fn(async () => 'failure-ts')
       vi.spyOn(daemon as any, 'replyConnFor').mockReturnValue({
@@ -1163,7 +1192,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     const emitEventSession = vi.fn()
     ;(daemon as any).cpClient = { emitEventSession, emitUsageReport: vi.fn(), stop: vi.fn() }
@@ -1210,7 +1239,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     const msg = {
       msgId: 'cron:x:2',
@@ -1261,6 +1290,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       stop: vi.fn()
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, update) => {
         onUpdate = update
@@ -1325,6 +1355,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       stop: vi.fn()
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, update) => {
         onUpdate = update
@@ -1379,7 +1410,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     const posts: string[] = []
     vi.spyOn(daemon as any, 'replyConnFor').mockReturnValue({
@@ -1425,7 +1456,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     const dispatchSpy = vi.spyOn(daemon as any, 'dispatch')
     const msg = {
@@ -1458,7 +1489,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     vi.spyOn(daemon as any, 'mergedRules').mockReturnValue([
       {
@@ -1507,7 +1538,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: stopSpy
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
     // trigger host creation so it ends up in hosts map
     await (daemon as any).dispatch('bot-a', {
@@ -1560,7 +1591,13 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, agentName: 'solo', overrides: { agentsDir }, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      agentName: 'solo',
+      overrides: { agentsDir },
+      hostFactory: () => fakeHost as any
+    })
     await daemon.start()
     expect((daemon as any).agents.size).toBe(1)
     expect((daemon as any).agents.has('solo')).toBe(true)
@@ -1591,7 +1628,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
     await daemon.start()
 
     const statuses: string[] = []
@@ -1648,6 +1685,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       })
     )
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       agentName: 'paused-bot',
       overrides: { agentsDir },

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -7,6 +7,7 @@ import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import { transcriptChannelKey, type TranscriptEntry } from '../src/store/local-store.js'
 import { stableTurnId } from '../src/messages/normalized.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -160,7 +161,11 @@ function streamingResponse(hopCount = 0) {
 describe('Daemon transcript records the agent reply', () => {
   it('medium mode: the buffered reply (flushed at onFinal) lands as a bot-a row', async () => {
     const { factory } = replyingHost('here is my answer')
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -177,7 +182,11 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('records post-turn memory for a CP-published session only after the reply is delivered', async () => {
     const { factory } = replyingHost('here is my answer')
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     await (daemon as any).dispatch('bot-a', dm('100', 'private question'), 'int-a')
@@ -220,7 +229,11 @@ describe('Daemon transcript records the agent reply', () => {
   // (see the DM test below).
   it('captures post-turn memory from a Slack channel input', async () => {
     const { factory } = replyingHost('here is my answer')
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     makeRoutable(daemon)
     const recordTurn = vi.fn(async () => {})
@@ -235,7 +248,11 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('rejects a Slack audience change on a session created from another source', async () => {
     const { factory, host } = replyingHost('here is my answer')
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
 
     // A headless Slack-shaped automation has no trusted external destination,
@@ -255,7 +272,11 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('reuses an external runtime only for the same inherited Slack source', async () => {
     const { factory, host } = replyingHost('here is my answer')
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
     const callMeta = (resourceKey: string) => ({
@@ -288,7 +309,11 @@ describe('Daemon transcript records the agent reply', () => {
   // private from its first turn, with no CP round-trip.
   it('never captures post-turn memory from a private DM session', async () => {
     const { factory } = replyingHost('here is my answer')
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     makeRoutable(daemon)
     const recordTurn = vi.fn(async () => {})
@@ -306,7 +331,11 @@ describe('Daemon transcript records the agent reply', () => {
   // gated for isolated sessions.
   it('runs automatic recall for a private DM (reads are always allowed, #653)', async () => {
     const { factory } = replyingHost('here is my answer')
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     makeRoutable(daemon)
     const recallForTurn = vi.spyOn((daemon as any).memory, 'recallForTurn').mockResolvedValue([])
@@ -319,7 +348,11 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('runs automatic recall for an A2A child (reads are always allowed, #653)', async () => {
     const { factory } = replyingHost('here is my answer')
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     makeRoutable(daemon)
     const recallForTurn = vi.spyOn((daemon as any).memory, 'recallForTurn').mockResolvedValue([])
@@ -334,7 +367,11 @@ describe('Daemon transcript records the agent reply', () => {
   it('uses the stable bot name in linked attribution instead of the display name', async () => {
     const { factory, host } = replyingHost('the answer')
     ;(host as any).modelOptions = vi.fn(() => ({ current: 'claude-sonnet-4-5' }))
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     ;(daemon as any).runtimeNames.claude = 'Claude Code'
     ;(daemon as any).agents.get('bot-a').displayName = 'Repo Bot'
@@ -357,7 +394,11 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('marks the last admitted agent turn in the attached Slack footer', async () => {
     const { factory } = replyingHost('the final autonomous answer')
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -401,7 +442,11 @@ describe('Daemon transcript records the agent reply', () => {
       model = 'model-after-prompt'
       return result
     })
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -437,6 +482,7 @@ describe('Daemon transcript records the agent reply', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold('low'),
       hostFactory: (_agent, callback) => {
         onUpdate = callback
@@ -463,7 +509,11 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('minimal mode: includes the footer in the initial live-reply post', async () => {
     const { factory } = replyingHost('here is my answer')
-    const daemon = new Daemon({ root: scaffold('minimal'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('minimal'),
+      hostFactory: factory
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -485,7 +535,11 @@ describe('Daemon transcript records the agent reply', () => {
   it('minimal mode: delivers an over-limit final reply across messages and attaches the footer last', async () => {
     const reply = `${'a'.repeat(12_000)}\nsecond section`
     const { factory } = replyingHost(reply)
-    const daemon = new Daemon({ root: scaffold('minimal'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('minimal'),
+      hostFactory: factory
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -559,6 +613,7 @@ describe('Daemon transcript records the agent reply', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold('minimal'),
       hostFactory: (_agent, callback) => {
         onUpdate = callback
@@ -597,7 +652,11 @@ describe('Daemon transcript records the agent reply', () => {
     // in call order, so a reply/status message whose applyChain step hasn't run yet would be
     // sent AFTER — and land BELOW — the card. Serializing the post on the chain keeps it above.
     const { factory } = replyingHost('x')
-    const daemon = new Daemon({ root: scaffold('minimal'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('minimal'),
+      hostFactory: factory
+    })
     await daemon.start()
 
     const order: string[] = []
@@ -627,7 +686,7 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('moves the attached footer to the latest body section across a flush boundary', async () => {
     const { factory } = streamingHost([text('first section'), tool('t1', 'Read file.ts'), text('last section')])
-    const daemon = new Daemon({ root: scaffold('low'), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold('low'), hostFactory: factory })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -652,7 +711,7 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('retries a failed stale-footer cleanup at finalization', async () => {
     const { factory } = streamingHost([text('first section'), tool('t1', 'Read file.ts'), text('last section')])
-    const daemon = new Daemon({ root: scaffold('low'), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold('low'), hostFactory: factory })
     await daemon.start()
     const conn = makeRoutable(daemon)
     ;(conn.updateBlocks as any).mockRejectedValueOnce(new Error('queue timeout')).mockResolvedValueOnce(true)
@@ -668,7 +727,7 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('keeps the prior footer when a later body post returns no timestamp', async () => {
     const { factory } = streamingHost([text('first section'), tool('t1', 'Read file.ts'), text('last section')])
-    const daemon = new Daemon({ root: scaffold('low'), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold('low'), hostFactory: factory })
     await daemon.start()
     const conn = makeRoutable(daemon)
     ;(conn.postMessage as any).mockResolvedValueOnce('reply-1').mockResolvedValueOnce(undefined)
@@ -682,7 +741,7 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('does not create an orphan attribution message when the turn has no reply body', async () => {
     const { factory } = streamingHost([tool('t1', 'Read file.ts')])
-    const daemon = new Daemon({ root: scaffold('high'), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold('high'), hostFactory: factory })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -702,7 +761,11 @@ describe('Daemon transcript records the agent reply', () => {
     host.prompt = vi.fn(async () => {
       throw new Error('runtime exploded')
     })
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     const conn = makeRoutable(daemon)
 
@@ -737,6 +800,7 @@ describe('Daemon transcript records the agent reply', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold('low'),
       hostFactory: (_agent, callback) => {
         onUpdate = callback
@@ -758,7 +822,11 @@ describe('Daemon transcript records the agent reply', () => {
 
   it('a replayed reply is filtered out of its own author’s catch-up context', async () => {
     const { factory } = replyingHost('my first reply')
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -789,7 +857,7 @@ describe('Daemon transcript captures the full activity log (mode-independent)', 
   for (const mode of ['low', 'medium', 'high'] as const) {
     it(`${mode} mode: tool + reasoning + text are all recorded with their kind`, async () => {
       const { factory } = streamingHost(turn)
-      const daemon = new Daemon({ root: scaffold(mode), hostFactory: factory })
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(mode), hostFactory: factory })
       await daemon.start()
       makeRoutable(daemon)
 
@@ -807,7 +875,7 @@ describe('Daemon transcript captures the full activity log (mode-independent)', 
 
   it('tool/reasoning rows are excluded from §8.5 catch-up replay', async () => {
     const { factory } = streamingHost(turn)
-    const daemon = new Daemon({ root: scaffold('low'), hostFactory: factory })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold('low'), hostFactory: factory })
     await daemon.start()
     makeRoutable(daemon)
 
@@ -842,6 +910,7 @@ describe('Daemon transcript captures the full activity log (mode-independent)', 
       text('yes, TestSA is set to s3cret-value')
     ])
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold('medium', {
         runtimeOverrides: { secrets: [{ name: 'TestSA', value: 's3cret-value' }] }
       }),
@@ -876,7 +945,11 @@ describe('Daemon transcript captures the full activity log (mode-independent)', 
       { sessionUpdate: 'tool_call_update', toolCallId: 't1', status: 'completed' },
       text('done')
     ])
-    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
     await daemon.start()
     makeRoutable(daemon)
 

--- a/packages/daemon/test/daemon-webchat-session-continuation.test.ts
+++ b/packages/daemon/test/daemon-webchat-session-continuation.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { Daemon } from '../src/daemon.js'
 import type { RdAck, RdChatEvent, RdMsgWebchat } from '@agentconnect.md/protocol'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // Session-targeted webchat continuation (webchat-cross-integration-continuation.md
 // §5.2/§6.4): a browser turn carrying `targetSessionId` dispatches onto the target
@@ -67,7 +68,7 @@ function scriptedHost(reply: (prompt: string) => string) {
 
 async function boot(reply: (prompt: string) => string = () => 'done') {
   const { factory, prompts } = scriptedHost(reply)
-  const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
   await daemon.start()
   ;(daemon as never as { cpClient: unknown }).cpClient = {
     emitUsageReport: vi.fn(),

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -8,6 +8,7 @@ import { statePath } from '../src/paths.js'
 import { Daemon } from '../src/daemon.js'
 import { stableMessageId } from '../src/messages/normalized.js'
 import type { WebchatOutput, WebchatDone } from '@agentconnect.md/protocol'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -431,7 +432,7 @@ function retainedHook(deliveryKey: string) {
 }
 
 async function boot(root: string, host: any) {
-  const daemon = new Daemon({ root, hostFactory: () => host as any })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => host as any })
   await daemon.start()
   return daemon
 }
@@ -1013,6 +1014,7 @@ describe('daemon durable inbox', () => {
     const a = gatedHost('acp-a')
     const b = gatedHost('acp-b')
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (agent) => (agent.id === 'bot-a' ? a.host : b.host) as any
     })
@@ -1389,6 +1391,7 @@ describe('daemon durable inbox', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, update) => {
         onUpdate = update

--- a/packages/daemon/test/evaluation-game-ingress.test.ts
+++ b/packages/daemon/test/evaluation-game-ingress.test.ts
@@ -11,6 +11,7 @@ import {
   type OutboundEffectResult,
   type VirtualConnectionWorldPort
 } from '../src/evaluation/index.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 const AGENT_ID = 'game-agent'
 const OTHER_AGENT_ID = 'other-agent'
@@ -142,6 +143,7 @@ afterEach(async () => {
 
 async function startDaemon(world: RecordingWorld): Promise<Daemon> {
   daemon = new Daemon({
+    slackAppFactory: fakeSlackAppFactory(),
     root: scaffold([AGENT_ID, OTHER_AGENT_ID]),
     hostFactory: echoHostFactory(),
     evaluation: {

--- a/packages/daemon/test/evaluation-game-tools.test.ts
+++ b/packages/daemon/test/evaluation-game-tools.test.ts
@@ -13,6 +13,7 @@ import {
   type OutboundEffectResult,
   type VirtualConnectionWorldPort
 } from '../src/evaluation/index.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 const PLAYER_A = 'player-a'
 const PLAYER_B = 'player-b'
@@ -189,6 +190,7 @@ describe('evaluation tool registry (§6)', () => {
     const bindings = new Map<string, CapturedBinding>()
     const inTurnResults = new Map<string, Record<string, unknown>>()
     daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold([PLAYER_A, PLAYER_B]),
       hostFactory: bindingCapturingHostFactory(bindings, async (agentId, binding) => {
         // Dispatch binds the TRUSTED session identity, never tool input.
@@ -264,6 +266,7 @@ describe('evaluation tool registry (§6)', () => {
       }
     ]
     daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold([PLAYER_A, PLAYER_B]),
       hostFactory: bindingCapturingHostFactory(new Map()),
       evaluation: {
@@ -288,6 +291,7 @@ describe('evaluation tool registry (§6)', () => {
       handler: async () => ({})
     }
     daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold([PLAYER_A, PLAYER_B]),
       hostFactory: bindingCapturingHostFactory(new Map()),
       evaluation: {

--- a/packages/daemon/test/fakes/slack-app.ts
+++ b/packages/daemon/test/fakes/slack-app.ts
@@ -1,0 +1,63 @@
+// An inert Slack app for daemon tests.
+//
+// Without it, `Daemon.start()` builds the real `@slack/web-api` client for every configured Slack
+// integration and reaches slack.com. That made a unit suite depend on Slack being reachable: on CI
+// the API answers `invalid_auth` fast, but a slow answer is a flake, and the one test that boots two
+// distinct apps has twice the exposure — it timed out at the 5s budget for exactly that reason.
+// Behind a proxy the failure is transport-level instead, so `p-retry` spends its 1s + 2s ladder and
+// `daemon.start()` takes ~4s instead of ~40ms.
+//
+// Every method resolves empty rather than throwing: these suites assert routing and authorship
+// decisions, and a rejection here would fail them for a reason that has nothing to do with Slack.
+import type { SlackAppFactory } from '../../src/slack/connection.js'
+
+/** `auth.test`'s answer. Suites that assert on the bot identity pass their own ids. */
+export interface FakeSlackIdentity {
+  userId?: string
+  botId?: string
+  teamId?: string
+  url?: string
+}
+
+export function fakeSlackAppFactory(identity: FakeSlackIdentity = {}): SlackAppFactory {
+  const ok = async (): Promise<Record<string, never>> => ({})
+  return () =>
+    ({
+      message: () => {},
+      event: () => {},
+      action: () => {},
+      shortcut: () => {},
+      client: {
+        views: { open: ok, update: ok },
+        auth: {
+          test: async () => ({
+            user_id: identity.userId ?? 'U_FAKE_BOT',
+            bot_id: identity.botId ?? 'B_FAKE_BOT',
+            team_id: identity.teamId ?? 'T_FAKE_TEAM',
+            url: identity.url ?? 'https://fake.slack.com/'
+          })
+        },
+        chat: {
+          postMessage: async () => ({ ts: '1700000000.000100' }),
+          getPermalink: async () => ({ permalink: 'https://fake.slack.com/archives/C1/p1700000000000100' }),
+          update: async () => ({ ts: '1700000000.000100' }),
+          delete: ok
+        },
+        conversations: {
+          open: async () => ({ channel: { id: 'D_FAKE' } }),
+          info: async () => ({ channel: { id: 'C1', name: 'fake' } }),
+          members: async () => ({ members: [] }),
+          leave: ok,
+          list: async () => ({ channels: [] }),
+          replies: async () => ({ messages: [] })
+        },
+        users: {
+          info: async () => ({}),
+          conversations: async () => ({ channels: [] })
+        },
+        assistant: { threads: { setStatus: ok, setTitle: ok } }
+      },
+      start: async () => {},
+      stop: async () => {}
+    }) as ReturnType<SlackAppFactory>
+}

--- a/packages/daemon/test/orchestration.test.ts
+++ b/packages/daemon/test/orchestration.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
 import { sessionKey } from '../src/store/local-store.js'
 import type { StartOrchestrationReq, OrchestrationOwnerReq } from '../src/mcp/ops.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 /**
  * §3.4/§6.8 main-agent orchestration. These drive the daemon's private orchestration
@@ -53,7 +54,7 @@ const fakeHost = () => ({
 
 /** Boot a daemon with `dispatch` replaced by a spy so no real ACP turn runs; capture calls. */
 async function boot(root: string) {
-  const daemon = new Daemon({ root, hostFactory: () => fakeHost() as any })
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost() as any })
   await daemon.start()
   const localAgents = [...(daemon as any).agents.values()].map((agent: any) => ({
     agentId: agent.id,
@@ -390,7 +391,7 @@ describe('startup re-arm', () => {
     await daemon.stop()
 
     // Fresh daemon over the SAME root/store → re-arm should re-schedule the deadline.
-    const daemon2 = new Daemon({ root, hostFactory: () => fakeHost() as any })
+    const daemon2 = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost() as any })
     ;(daemon2 as any).__noop = true
     await daemon2.start()
     expect((daemon2 as any).orchestrationDeadlines.has(res.orchestrationId)).toBe(true)

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -6,6 +6,7 @@ import { Daemon } from '../src/daemon.js'
 import { SlackConnection } from '../src/slack/connection.js'
 import { TelegramConnection } from '../src/telegram/connection.js'
 import { DiscordConnection } from '../src/discord/connection.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -65,6 +66,7 @@ describe('Daemon debounce timer cleared on stop()', () => {
     writeAgent(root, 'bot-a')
     const daemon = new Daemon({
       root,
+      slackAppFactory: fakeSlackAppFactory(),
       hostFactory: () =>
         ({
           __started: true,
@@ -129,6 +131,7 @@ describe('Daemon.reconcile', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const daemon = new Daemon({
       root,
+      slackAppFactory: fakeSlackAppFactory(),
       hostFactory: () =>
         ({
           __started: true,
@@ -155,6 +158,7 @@ describe('Daemon.reconcile', () => {
     writeAgent(root, 'bot-a')
     const daemon = new Daemon({
       root,
+      slackAppFactory: fakeSlackAppFactory(),
       hostFactory: () =>
         ({
           __started: true,
@@ -321,6 +325,7 @@ describe('Daemon watcher resilience: corrupt agent.json', () => {
     writeAgent(root, 'bot-b')
     const daemon = new Daemon({
       root,
+      slackAppFactory: fakeSlackAppFactory(),
       hostFactory: () =>
         ({
           __started: true,

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -6,6 +6,7 @@ import { Daemon } from '../src/daemon.js'
 import { routeRules } from '../src/router/routing-table.js'
 import { sessionKey } from '../src/store/local-store.js'
 import type { NormalizedMessage } from '../src/messages/normalized.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 function scaffold(): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-tg-thread-'))
@@ -103,7 +104,7 @@ const owner = (daemon: Daemon) => (c: string, t: string) => (daemon as any).sess
 
 describe('Telegram conversation discovery', () => {
   it('reports a public DM as a configurable direct row', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     makeTelegramRoutable(daemon)
     vi.spyOn(daemon as any, 'dispatch').mockResolvedValue('acp')
@@ -121,7 +122,7 @@ describe('Telegram conversation discovery', () => {
   })
 
   it('reports an explicitly mentioned Off group before routing drops the message', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const conn = makeTelegramGated(daemon)
     const emitIntegrationChannels = vi.fn()
@@ -141,7 +142,7 @@ describe('Telegram conversation discovery', () => {
   })
 
   it('reports a newly joined group without routing its membership service message', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     makeTelegramGated(daemon)
     const emitIntegrationChannels = vi.fn()
@@ -162,7 +163,7 @@ describe('Telegram conversation discovery', () => {
 
 describe('Telegram ingress attribution', () => {
   it('routes and deduplicates DMs within the bot connection that received them', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const wrong = (daemon as any).agents.get('bot-a')
     wrong.integrations = [
@@ -210,7 +211,11 @@ describe('Telegram ingress attribution', () => {
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
     await daemon.start()
     const agent = (daemon as any).agents.get('bot-a')
     agent.integrations = [
@@ -252,7 +257,7 @@ describe('Telegram ingress attribution', () => {
 
 describe('canonicalizeTelegramThread', () => {
   it('roots a fresh group @mention at its own message (tg:<id>)', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const m = tg(100, { mentionedBots: ['mybot'] })
     ;(daemon as any).canonicalizeTelegramThread(m)
@@ -260,7 +265,7 @@ describe('canonicalizeTelegramThread', () => {
   })
 
   it('uses the forum-topic id as the thread', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const m = tg(101, { topicId: '555', mentionedBots: ['mybot'] })
     ;(daemon as any).canonicalizeTelegramThread(m)
@@ -268,7 +273,7 @@ describe('canonicalizeTelegramThread', () => {
   })
 
   it('§6.5: keys off the GENERIC coordinates alone (post-window emission)', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const topic = tg(103, { topicId: '555', mentionedBots: ['mybot'] })
     ;(daemon as any).canonicalizeTelegramThread(topic)
@@ -283,7 +288,7 @@ describe('canonicalizeTelegramThread', () => {
   })
 
   it('collapses a DM to one continuous session (dm)', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const m = tg(102, { channel: '42', isDm: true })
     ;(daemon as any).canonicalizeTelegramThread(m)
@@ -291,7 +296,7 @@ describe('canonicalizeTelegramThread', () => {
   })
 
   it('keys a plain-supergroup reply thread by its native root — matching the opening @mention', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     // The opening @mention (message 6) is top-level: no topic, no root, no reply.
     const mention = tg(6, { mentionedBots: ['mybot'] })
@@ -306,7 +311,7 @@ describe('canonicalizeTelegramThread', () => {
   })
 
   it('does not treat a plain-supergroup reply-thread root as a forum topic', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     // Only a real forum topic yields the bare numeric thread (postable as
     // message_thread_id); a reply-thread root is prefixed so it never is.
@@ -319,7 +324,7 @@ describe('canonicalizeTelegramThread', () => {
   })
 
   it('continues the session a replied-to message belongs to', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     // A prior bot reply (message 500) recorded under the session thread tg:100.
     ;(daemon as any).store.appendTranscript({
@@ -336,7 +341,7 @@ describe('canonicalizeTelegramThread', () => {
   })
 
   it('roots a basic-group reply on the replied-to message when the transcript has no record', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     // No message_thread_id (basic group) and message 999 was never recorded (cold /
     // restarted): fall back to rooting the thread on the replied-to message.
@@ -346,7 +351,7 @@ describe('canonicalizeTelegramThread', () => {
   })
 
   it('leaves non-telegram messages untouched', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const m = { ...tg(1), platform: 'slack' as const, thread: undefined }
     ;(daemon as any).canonicalizeTelegramThread(m)
@@ -356,7 +361,7 @@ describe('canonicalizeTelegramThread', () => {
 
 describe('reply-based session continuity (routing)', () => {
   it('routes a reply-to-bot to the session owner via thread affinity — no @mention needed', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     makeTelegramRoutable(daemon)
     // Simulate an established session for thread tg:100 + its bot reply (message 500).
@@ -389,7 +394,7 @@ describe('reply-based session continuity (routing)', () => {
   })
 
   it('resolves identical thread coordinates independently on each receiving bot', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     makeScopedTelegramPair(daemon)
     seedSession(daemon, '-100', 'tg:77', { agentId: 'bot-a', integrationId: 'i-a' })
@@ -407,7 +412,7 @@ describe('reply-based session continuity (routing)', () => {
   })
 
   it('a fresh @mention with no reply starts a new, distinct session thread', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     makeTelegramRoutable(daemon)
     const m = tg(800, { mentionedBots: ['mybot'] })
@@ -420,7 +425,7 @@ describe('reply-based session continuity (routing)', () => {
 
 describe('reply targeting', () => {
   it('a command reply threads under the triggering Telegram message', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const conn = makeTelegramRoutable(daemon)
     // A DM `/status` with no live session → the "no session" note, replied to message 900.
@@ -431,7 +436,7 @@ describe('reply targeting', () => {
   })
 
   it('an agent-call turn falls back to the session thread root as its reply anchor', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const replyTarget = (m: NormalizedMessage) => (daemon as any).telegramReplyTarget(m)
     // A synthesized agent-call delivery (replyToSession / peer wake) — its msgId carries
@@ -535,7 +540,7 @@ function makeScopedTelegramPair(daemon: Daemon) {
 
 describe('group command routing (no mention entity)', () => {
   it('routes a bare group /status@bot to the channel latest session — replies under the command', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const conn = makeTelegramRoutable(daemon)
     seedSession(daemon, '-100', 'tg:100')
@@ -549,7 +554,7 @@ describe('group command routing (no mention entity)', () => {
   })
 
   it('finds the latest eligible session on the bot that received the command', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const { connA, connB } = makeScopedTelegramPair(daemon)
     const now = Date.now()
@@ -590,7 +595,7 @@ function injectHost(daemon: Daemon) {
 
 describe('session-control cards (/models tappable buttons)', () => {
   it('renders a tappable card for a bare /models with the current model flagged', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
     const conn = makeTelegramRoutable(daemon)
@@ -605,7 +610,7 @@ describe('session-control cards (/models tappable buttons)', () => {
   })
 
   it('applies the tapped button, acks it, and re-renders the card', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
     const conn = makeTelegramRoutable(daemon)
@@ -622,7 +627,7 @@ describe('session-control cards (/models tappable buttons)', () => {
   })
 
   it('attributes an applied tap to the tapping user, and records nothing when refused', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
     const conn = makeTelegramRoutable(daemon)
@@ -650,7 +655,7 @@ describe('session-control cards (/models tappable buttons)', () => {
   })
 
   it('applies a callback only to a session owned by the bot that delivered the tap', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const { agentA, agentB, connB } = makeScopedTelegramPair(daemon)
     agentA.allowRuntimeChangesInChat = true
@@ -717,7 +722,7 @@ describe('continue-the-topic hint delivery', () => {
   }
 
   it('sends the hint with the reply but keeps it out of the transcript', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const { conn, p, apply } = pending(daemon)
 
@@ -734,7 +739,7 @@ describe('continue-the-topic hint delivery', () => {
   })
 
   it('edits the hint onto the body already sent when the turn ends empty', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const { conn, apply } = pending(daemon)
 
@@ -749,7 +754,7 @@ describe('continue-the-topic hint delivery', () => {
   })
 
   it('skips the edit when no body was sent, or when the suffix would breach the cap', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
     await daemon.start()
     const { conn, apply } = pending(daemon)
 

--- a/packages/daemon/test/turn-output-workflow.test.ts
+++ b/packages/daemon/test/turn-output-workflow.test.ts
@@ -6,6 +6,7 @@ import { Daemon } from '../src/daemon.js'
 import { sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import type { NormalizedMessage } from '../src/messages/normalized.js'
 import { FakeClock } from './cp/fake-clock.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -84,6 +85,7 @@ describe('TurnOutputWorkflow', () => {
     // cast that only looks like one. A connection without the port contributes
     // no provider snapshot and the fence falls back to daemon-observed rows.
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold(),
       hostFactory: () =>
         ({
@@ -153,6 +155,7 @@ describe('TurnOutputWorkflow', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold(),
       hostFactory: (_agent, update) => {
         onUpdate = update
@@ -225,6 +228,7 @@ describe('TurnOutputWorkflow', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold(),
       hostFactory: (_agent, update) => {
         onUpdate = update
@@ -319,6 +323,7 @@ describe('TurnOutputWorkflow', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold(),
       clock,
       hostFactory: (_agent, update) => {
@@ -359,6 +364,7 @@ describe('TurnOutputWorkflow', () => {
       stop: vi.fn(async () => {})
     }
     const firstDaemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, update) => {
         onFirstUpdate = update
@@ -406,6 +412,7 @@ describe('TurnOutputWorkflow', () => {
       stop: vi.fn(async () => {})
     }
     const restarted = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root,
       hostFactory: (_agent, update) => {
         onRestartedUpdate = update
@@ -456,6 +463,7 @@ describe('TurnOutputWorkflow', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold(),
       hostFactory: (_agent, update) => {
         onUpdate = update
@@ -503,6 +511,7 @@ describe('TurnOutputWorkflow', () => {
       stop: vi.fn(async () => {})
     }
     const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
       root: scaffold(),
       hostFactory: (_agent, update) => {
         onUpdate = update


### PR DESCRIPTION
Follow-up to #1076. `Daemon.start()` builds a real `@slack/web-api` client for every configured Slack integration, so booting a daemon in a unit test dialled out to slack.com. Instrumenting the default factory across a full run found **82 real Slack apps constructed**.

## Why this matters — it is a flake source, not latency

On CI the API answers `invalid_auth` fast, so the time saved is small: roughly **5–20s** across the job. That is not the reason to do this.

- A slow answer is a **failure**, not a slow test. The case that boots two distinct apps (`distinctTokens: true`) has twice the exposure and **timed out at the 5s budget on this branch's own CI** during #1076.
- Behind a proxy the request fails at the transport layer instead, so `p-retry` spends its 1s + 2s ladder and `start()` takes ~4s against ~40ms.

**Full-suite failures drop from 15 to 3.** Twelve failures I had been attributing all along to "sandbox environment flakes" were this bug: `daemon-agent-mention-routing` (4), `daemon-platform-authorship` (1), `daemon-duty-replacement` (6), `daemon-duty-fence` (1). Only `acp-matrix`, `cp-agent-registry` and `cp/gh-shim` are genuinely environmental.

## The change

`SlackConnection` already accepted a `factory` — the daemon never passed one. Exposed as `slackAppFactory` on `Daemon` opts, injected by tests only, mirroring the existing `hostFactory` seam ("*injected hostFactory, never by the production CLI/config surface*").

Review on the first revision caught two gaps, both real:

- `retrySlackConnection()` rebuilt with the real Bolt client, so a failed injected startup came back over the network.
- `SlackConnection` ignored an injected factory outright when `deps.sendOnly` was set, hard-coding `sendOnlyApp` whose `auth.test()` reaches Slack.

Fixed by lifting the constructor's default into `realSocketModeApp` and making `factory` a plain optional, so an injected factory wins in **both** modes while production — which passes none — keeps today's branch exactly.

## Attribution note

My first pass used stack traces and found only 4 test files. That was wrong: most of these construct on async continuations that lose the test frame. Grepping by content (`platform: 'slack'` + `new Daemon(`) found **29 more**.

## Results

| | before | after |
|---|---|---|
| real Slack apps across the suite | 82 | **4** |
| full-suite failures | 15 | **3** |
| `daemon-agent-mention-routing` + `daemon-platform-authorship` | ~195s, 5 failing | **10.4s, 46 passing** |
| full daemon suite (local wall) | 2m47s | **1m24s** |

The local wall-clock drop is mostly the proxy retry ladder, which CI does not have — expect the smaller number there. CPU is essentially unchanged (~1m52s user), which is the point: what disappeared was *idle waiting*, not work.

Of the 4 remaining, 3 are `connection.test.ts` deliberately exercising default construction (construction alone makes no call) and 1 is a `reconcile-watch` path I have not traced. So this is not a hard no-network guarantee — an earlier draft of this description claimed one, which was wrong.

## Test plan

- Full daemon suite: 3801 tests, 3 failures, all pre-existing and environmental
- Re-instrumented the default factory to confirm 82 → 30 → 4 across the two revisions
- `tsc -p tsconfig.typecheck.json` 0 errors; `eslint`, `prettier --check` clean
- CI green on `ba9ae6d3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtPhRcPGtRX8RZqApUZRGu