### PR TITLE
fix(control-plane): settle in-flight duty recomputes instead of leaking them across tests

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1747,6 +1747,7 @@ export function buildContainer(
         ...relayRegistrationTasks,
         visibilityPush.settle(),
         sessionAccessWarmer.settle(),
+        dutyRecompute.settle(),
         ...(installationDoorbell ? [installationDoorbell.settle()] : [])
       ])
       await rootPrisma.$disconnect()

--- a/packages/control-plane/src/orchestrator/dutyRecompute.ts
+++ b/packages/control-plane/src/orchestrator/dutyRecompute.ts
@@ -32,6 +32,8 @@ export class DutyRecomputeSweep {
   private cursor: string | null = null
   private readonly kicked = new Set<string>()
   private kickTimer: TimerHandle | undefined
+  // Recomputes already fired — awaited by settle(), since stop() cancels timers, not running work.
+  private readonly inFlight = new Set<Promise<unknown>>()
 
   constructor(
     private readonly repo: Pick<
@@ -64,6 +66,17 @@ export class DutyRecomputeSweep {
     this.kicked.clear()
   }
 
+  /** Await recomputes already fired — the shutdown counterpart to stop(), so Prisma is not disconnected mid-write. */
+  async settle(): Promise<void> {
+    await Promise.allSettled([...this.inFlight])
+  }
+
+  // Fire-and-forget, but never unobserved: shutdown and tests settle on these.
+  private track(work: Promise<unknown>): void {
+    this.inFlight.add(work)
+    void work.finally(() => this.inFlight.delete(work))
+  }
+
   /**
    * Recompute one org promptly instead of waiting for its rotation slice — the
    * ledger's inputs just changed (an integration, a cron's enabled flag, a bot
@@ -81,18 +94,22 @@ export class DutyRecomputeSweep {
       const orgs = [...this.kicked]
       this.kicked.clear()
       for (const org of orgs) {
-        void this.recomputeOrg(org).catch((err) => this.log?.error({ err, orgId: org }, 'duty recompute kick failed'))
+        this.track(
+          this.recomputeOrg(org).catch((err) => this.log?.error({ err, orgId: org }, 'duty recompute kick failed'))
+        )
       }
     }, this.cfg.kickDelayMs)
   }
 
   private arm(): void {
     this.timer = this.clock.setTimeout(() => {
-      void this.tick()
-        .catch((err) => this.log?.error({ err }, 'duty recompute sweep failed'))
-        .finally(() => {
-          if (!this.stopped) this.arm()
-        })
+      this.track(
+        this.tick()
+          .catch((err) => this.log?.error({ err }, 'duty recompute sweep failed'))
+          .finally(() => {
+            if (!this.stopped) this.arm()
+          })
+      )
     }, this.cfg.intervalMs)
   }
 

--- a/packages/control-plane/test/repo/duty-recompute.test.ts
+++ b/packages/control-plane/test/repo/duty-recompute.test.ts
@@ -496,6 +496,8 @@ describe('duty recompute kick (real Postgres)', () => {
       const groups = await repo.listForOrg(ORG)
       expect(groups).toHaveLength(1)
     })
+    // The recompute's tail outlives the assertion; settle it here, not into the next test's database.
+    await s.settle()
   })
 
   it('a burst against one org collapses into a single recompute', async () => {
@@ -526,6 +528,8 @@ describe('duty recompute kick (real Postgres)', () => {
     s.kick(DEFAULT_ORG_ID)
     clock.advance(10)
     await vi.waitFor(() => expect(recomputes).toEqual([DEFAULT_ORG_ID]))
+    // `recomputes` is pushed on ENTRY: settle the still-pending writes here, not into the next test.
+    await s.settle()
   })
 
   it('stop() cancels a pending kick', async () => {
@@ -537,8 +541,11 @@ describe('duty recompute kick (real Postgres)', () => {
 
     s.kick(DEFAULT_ORG_ID)
     s.stop()
+    // The cancellation itself, asserted directly: the pending kick is the only timer this sweep armed.
+    expect(clock.pendingTimers()).toBe(0)
     clock.advance(1_000)
-    await new Promise((r) => setTimeout(r, 20))
+    // Settles nothing when stop() held — and awaits the recompute it missed when it did not.
+    await s.settle()
     expect(await repo.listForOrg(ORG)).toEqual([])
   })
 })


### PR DESCRIPTION
Fixes the intermittent CI failure in `duty recompute kick (real Postgres) > stop() cancels a pending kick` (`AssertionError: expected [ { …(6) } ] to deeply equal []`, run 31930016893 / job 95123293326).

## Diagnosis

Two candidate causes were on the table. **Neither is what is happening**, so the fix is in a third place.

**`stop()` is correct — it does cancel a pending kick.** `FakeClock.clearTimeout` deletes the timer from its map outright, so `advance(1_000)` has nothing left to fire. I verified this against the real `FakeClock` with a throwaway probe: after `kick()` → `stop()`, `pendingTimers()` is 0 and *no* recompute is ever entered, even given a 200ms real-time window — ten times the one the test used.

**The 20ms window was not racing the test's own work either.** After `stop()` the failing test starts no async work at all, so widening the sleep would have changed nothing. It only widened the window in which someone *else's* write could be observed.

**The row is written by the previous test in the same describe block.** `a burst against one org collapses into a single recompute` spies on `computeInputs` by pushing the org id *on entry*, then awaits only that:

```ts
computeInputs: async (orgId) => { recomputes.push(orgId); return repo.computeInputs(orgId) }
...
await vi.waitFor(() => expect(recomputes).toEqual([DEFAULT_ORG_ID]))
```

So `vi.waitFor` resolves at the instant the recompute *begins*, while `applyReconcile` — the INSERT that actually writes the duty row — is still pending. `kick()` is fire-and-forget and nothing awaits it, so that write outlives the test body and races `setup.db.ts`'s `beforeEach` sweep. The sweep re-seeds the same `DEFAULT_ORG_ID`, so a late INSERT still satisfies its FK, commits, and becomes visible to the next test — which is `stop() cancels a pending kick`, asserting the org has no duty groups. On a loaded runner the round trip crosses the cleanup boundary and the row survives; locally it lands first and the test passes. The harness already carries deadlock retries for exactly this class of leftover in-flight writer (`setup.db.ts`: *"A leftover in-flight writer and this sweep can want each other's row locks"*).

Probe results, all passing:

| Assertion | Result |
| --- | --- |
| `stop()` before the timer fires ⇒ no recompute entered (200ms window) | ✅ candidate 1 refuted |
| `vi.waitFor` on the entry-recorded spy returns while `applyReconcile` is still pending | ✅ leak confirmed |
| `settle()` ⇒ the write has landed before the test ends | ✅ fix confirmed |

## Changes

`DutyRecomputeSweep` was the only fire-and-forget background writer in the control plane without the `settle()` seam that `visibilityPush`, `sessionAccessWarmer`, and the installation doorbell all have, so nothing could await its work.

- **`orchestrator/dutyRecompute.ts`** — track both un-awaited paths (the `kick` callback and the re-arming `tick`) in an `inFlight` set and add `settle()`, mirroring the existing idiom.
- **`container.ts`** — shutdown awaits `dutyRecompute.settle()` alongside the others. `stop()` cancelled the timers but left an already-running recompute to be cut off mid-write by `rootPrisma.$disconnect()`; this is a real (small) production gap the same seam closes.
- **`test/repo/duty-recompute.test.ts`** — both kick tests settle their sweep inside the test instead of leaking it into the next one. The failing test drops the 20ms sleep for a deterministic `await s.settle()` and now asserts the cancellation *directly* via `expect(clock.pendingTimers()).toBe(0)`, which is what its name actually claims.

The settle is strictly stronger than the sleep it replaces: if a kick ever did survive `stop()`, `settle()` would await its write and the assertion would fail deterministically rather than by coin flip.

## Testing

- `pnpm --filter @agentconnect.md/control-plane test:unit` — 1724 passed / 159 files
- `pnpm --filter @agentconnect.md/control-plane typecheck` — clean
- `eslint` + `prettier --check` on all three changed files — clean

⚠️ **The integration project (`test:int`) could not be run here** — this environment has no Docker, so Testcontainers cannot start the `postgres:16-alpine` the suite needs, and no local Postgres server is installed. The diagnosis above was established against the real `FakeClock` and a fake repo in the unit project; the integration test itself needs CI to confirm. Since the failure is a timing race, a single green run is weak evidence — re-running this job a few times is worth doing before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpJCVkshbL2NgPEnvknT7g)_