### PR TITLE
chore(control-plane): drop the envelope tables

### DIFF
--- a/packages/control-plane/prisma/migrations/20260826000000_drop_envelope_tables/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260826000000_drop_envelope_tables/migration.sql
@@ -1,0 +1,21 @@
+-- The per-org execution envelope is gone: #964 deleted the operator, the
+-- `AgentConnectOrg` CR, the control plane's spec projector, and the
+-- `org_cluster_execution` repository/routes, leaving these tables with no reader
+-- and no writer. The shared pool replaced the model outright
+-- (docs/designs/k8s-daemon-pool.md), so nothing here migrates anywhere: no
+-- production or staging envelope ever existed, and the disposable test
+-- organizations that had one were torn down with their CRs.
+--
+-- FORWARD-ONLY: a binary from before #964 selects these tables. Every control
+-- plane that could has long drained; recovery is a forward deploy, not a rollback.
+
+-- Each row names an `AgentConnectOrg` to delete for an organization that is
+-- already gone. No operator remains to honour one, and the CRD itself was deleted
+-- from the only cluster that ever had it, so a surviving row addresses nothing.
+DROP TABLE IF EXISTS "pending_envelope_teardown";
+
+-- Dropping the table takes its `org` foreign key and `resourceName` unique index.
+DROP TABLE IF EXISTS "org_cluster_execution";
+
+-- Only `org_cluster_execution.egressPolicy` ever used it.
+DROP TYPE IF EXISTS "ClusterEgressPolicy";

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -108,7 +108,6 @@ model Org {
   externalScopes            ExternalScope[]
   sessionExternalAccess     SessionExternalAccessPolicy[]
   environmentEntries        OrganizationEnvironmentEntry[]
-  clusterExecution          OrgClusterExecution?
   dutyGroups                DutyGroup[]
 
   @@index([createdByUserId])
@@ -2833,98 +2832,6 @@ model ExternalMemoryGrant {
 
   @@index([connectionId])
   @@map("external_memory_grant")
-}
-
-// ── managed cluster execution (docs/designs/agentconnect-org-operator.md) ──
-
-/// Sandbox egress tier projected into `AgentConnectOrg.spec.egressPolicy`.
-enum ClusterEgressPolicy {
-  locked
-  curated
-  open
-}
-
-/// The organization's desired managed-execution envelope — the control plane's
-/// half of the `AgentConnectOrg` CR (docs/designs/agentconnect-org-operator.md
-/// §2). One row per org, written only through the cluster-execution routes; the
-/// provisioner projects it into the CR and the operator owns everything from
-/// there. Status is never mirrored here: it is read live from the CR, so a row
-/// can never disagree with the cluster.
-///
-/// `resourceName` — the CR's name in the control namespace — is derived once
-/// from the org id and never rewritten: it is the handle every later call
-/// addresses the envelope by. The envelope NAMESPACE is not stored at all; the
-/// operator derives it as `<install prefix><CR name>` and publishes it on
-/// `status.namespace`, which is the only place a consumer learns it.
-model OrgClusterExecution {
-  orgId String @id
-  /// False ⇒ the org has no CR in the control namespace. Flipping to false
-  /// deletes it, which hands the envelope to the operator's finalizer.
-  enabled              Boolean             @default(false)
-  /// Bumped on every write. The provisioner applies the current row and then
-  /// re-reads this: a changed value means a concurrent writer superseded the
-  /// snapshot it just applied, so it applies again. Without the fence two
-  /// interleaved writes leave the row and the resource apart until the periodic
-  /// re-apply's next rotation — the operator reconciles the CR, not this table.
-  specRevision         Int                 @default(1)
-  resourceName         String              @unique
-  /// Quiesce without tearing down: daemon to zero, sandboxes drained.
-  suspend              Boolean             @default(false)
-  daemonImage          String
-  daemonTier           String              @default("small")
-  /// The daemon record the retired API-key path minted this envelope's key for.
-  /// Nothing writes it any more: an in-cluster daemon authenticates with its
-  /// projected ServiceAccount token, and the binding lives on
-  /// `daemon.clusterIdentity`. It is kept because an envelope provisioned before
-  /// that path has no such binding until its pod reconnects — this is what the
-  /// first token connect adopts, so placements and session history survive, and
-  /// what excepts the envelope's own daemon from the org-delete guard until then.
-  legacyKeyDaemonId    String?             @db.Uuid
-  /// When the in-flight envelope transition was claimed, and by whom. The token
-  /// is the fencing half: every write in a transition is conditional on it, so a
-  /// holder whose lease expired and whose claim was taken over can no longer
-  /// mutate the row or unlock its successor. The timestamp only decides when a
-  /// takeover is allowed, so a process that dies mid-transition cannot wedge the
-  /// envelope. Enable, disable and the teardown drain all take it.
-  envelopeTransitionAt    DateTime?        @db.Timestamptz(6)
-  envelopeTransitionToken String?
-  runtimeImage         String
-  /// `{name, warmReplicas}[]` — the org's sandbox tiers and warm-pool sizes.
-  runtimeTiers         Json                @db.JsonB
-  quotaMaxAgents       Int                 @default(0) // 0 ⇒ unlimited, like the CRD
-  quotaCpu             String              @default("0")
-  quotaMemory          String              @default("0")
-  quotaStorage         String              @default("0")
-  egressPolicy         ClusterEgressPolicy @default(curated)
-  createdAt            DateTime            @default(now()) @db.Timestamptz(6)
-  updatedAt            DateTime            @updatedAt @db.Timestamptz(6)
-
-  org Org @relation(fields: [orgId], references: [id], onDelete: Cascade)
-
-  @@map("org_cluster_execution")
-}
-
-/// One row per deleted organization that still owns an `AgentConnectOrg`.
-/// Deleting the CR is a remote effect that cannot join the delete transaction,
-/// and the cascade above removes the only record of its `resourceName` — so
-/// without this tombstone the operator would keep a namespace, daemon, and
-/// sandboxes alive that nothing left could name.
-///
-/// Written inside the same transaction that deletes the organization, which is
-/// what makes it airtight: an enable that commits first is visible to that read,
-/// and one that has not committed is blocked by the org row's FOR UPDATE lock
-/// and then fails its foreign key. Drained by the cluster provisioner — kicked
-/// right after the deletion and swept periodically, so a deployment that had
-/// cluster execution switched off at delete time still cleans up once it is on.
-///
-/// Deliberately NO foreign key: the row's whole purpose is to outlive the
-/// organization it names.
-model PendingEnvelopeTeardown {
-  orgId        String   @id // the deleted org (identity + idempotency key)
-  resourceName String // the AgentConnectOrg to delete, in the control namespace
-  createdAt    DateTime @default(now()) @db.Timestamptz(6)
-
-  @@map("pending_envelope_teardown")
 }
 
 /// K8s duty ledger: one row per connected component of the


### PR DESCRIPTION
## Summary

The last open item of M5 in #955: drop the per-org execution envelope's tables from
the Prisma schema. #964 deleted the model itself — the operator, the `AgentConnectOrg`
CR and CRD, the control plane's spec projector and maintenance loop, the
`org_cluster_execution` repository/routes/DTOs, and the console card — and stated
explicitly that it was leaving the schema untouched so the data change would not ride
along with the code deletion. This is that follow-up, and it is only a migration.

Nothing is migrated anywhere. No production or staging envelope ever existed; the only
consumers were disposable test organizations, torn down together with their CRs. The
shared multi-org daemon pool replaced the model outright
(`docs/designs/k8s-daemon-pool.md`).

## What was dropped, and why each is dead

- **`org_cluster_execution`** (model `OrgClusterExecution`, plus the `Org.clusterExecution`
  relation field) — the organization's desired envelope: the control plane's half of the
  CR. It was written only through the cluster-execution routes and read only by the
  provisioner; #964 deleted both, along with the repository that was the sole access path.
  Dropping the table takes its `org` foreign key and the `resourceName` unique index with it.
- **`pending_envelope_teardown`** (model `PendingEnvelopeTeardown`) — the tombstone a
  deleted organization left behind so the provisioner could still name the CR to delete.
  Its only writer was the org-delete transaction and its only reader was the provisioner
  drain; both are gone, and no operator remains to honour a row. The CRD was deleted from
  the one cluster that ever had it, so a surviving row addresses nothing.
- **`ClusterEgressPolicy`** (enum type) — projected into `spec.egressPolicy`; its only
  column was `org_cluster_execution.egressPolicy`, so it goes with that table.

Verification: `OrgClusterExecution`, `org_cluster_execution`, `PendingEnvelopeTeardown`,
`pending_envelope_teardown`, `ClusterEgressPolicy`, `clusterExecution`, `egressPolicy`,
`legacyKeyDaemonId`, `envelopeTransition*`, `runtimeTiers`, `daemonTier` and `quotaMaxAgents`
appear nowhere outside `prisma/schema.prisma` and the historical migrations — no reader,
no writer, no fixture, no seed. No other table carries an envelope-only column: the only
envelope-era migration to touch a table other than these two added `daemon.clusterIdentity`,
which is live.

The migration is hand-sequenced as `20260826000000_drop_envelope_tables`, the next ordinal
after the newest directory, and is forward-only: a binary from before #964 selects these
tables, so recovery is a forward deploy rather than a rollback. Every control plane that
could still read them has long drained.

## Left in place on purpose

- **`daemon.clusterIdentity` / `daemon.clusterPodUid`** and the compound unique index —
  this is how a pool member authenticates (Pod-bound TokenReview identity), explicitly
  kept by #964.
- **The partial unique index for the org-scoped in-cluster daemon arm** (`clusterIdentity`
  where the Pod UID is null). `DaemonRepo.resolveClusterIdentity` / `clusterBoundIds` have
  no production caller left, but they still have repository tests that depend on the
  binding. Retiring that arm is a code deletion with its own tests to remove — not this
  change, which is deliberately a migration only.

## Test plan

- `pnpm --filter @agentconnect.md/control-plane prisma:generate` — client regenerates clean.
- `pnpm --filter @agentconnect.md/control-plane typecheck` — passes; nothing referenced the
  dropped models.
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 1724 tests, 159 files, pass.
- `pnpm --filter @agentconnect.md/control-plane test:int` — 1375 tests, 91 files, pass. The
  integration global setup runs `prisma migrate deploy` plus the seed against a real
  Postgres, so the new migration is applied and exercised by the whole suite.
- `pnpm format:check` — clean.
