### PR TITLE
feat(protocol): require and validate the frame organization on every org-scoped frame and reply (#955 M4)

### DIFF
--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -48,7 +48,7 @@ const Envelope = z.object({
 })
 ```
 
-An API-key or envelope-daemon connection is bound to one organization at auth time, so `orgId` may be omitted for rolling compatibility. Each cloud-daemon Pod has an install-wide connection and must carry `orgId` on every organization-scoped request, event, control frame, and correlated reply. Member-scoped frames such as auth, register, heartbeat, runtime facts, relay roster, collaboration routes, and daemon lifecycle control omit it.
+An API-key or envelope-daemon connection is bound to one organization at auth time, so `orgId` may be omitted for rolling compatibility. Each cloud-daemon Pod has an install-wide connection and must carry `orgId` on every organization-scoped request, event, control frame, and correlated reply. Member-scoped frames such as auth, register, heartbeat, runtime facts, relay roster, collaboration routes, duty lease frames, and daemon lifecycle control omit it — and on the install-wide connection must not carry it. The classification and the checks both peers run live in `packages/protocol/src/frame-scope.ts` (`INSTALL_WIDE_FRAME_TYPES`, `checkInboundFrameOrg`, `checkReplyFrameOrg`); [`org-scoped-data-layer.md`](org-scoped-data-layer.md) §4.1 spells out the contract.
 
 **Reply correlation.** A request-shaped frame (anything expecting an `ack`/result) is answered by a frame whose `corr` == the request's `id`. Fire-and-forget frames (most telemetry) carry no reply. Each frame type below is tagged **REQ** (expects a correlated reply), **REP** (is a reply), or **EVT** (fire-and-forget).
 

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -587,9 +587,15 @@ it is not extended into a platform-message bus (R5). The rendezvous adds a
 hints, no presence streams: **the ledger is the sole directory**.
 
 Org context travels on the frame, not on a subscription. The install-wide
-connection carries `orgId` on every org-scoped frame; auth, register,
-heartbeat, fleet facts, rosters, and daemon lifecycle frames legitimately omit
-it. Reconnect state is a combined multi-org snapshot or revision-fenced stream
+connection carries `orgId` on every org-scoped request, event, control frame
+and correlated reply; auth, register, heartbeat, fleet facts, rosters, duty
+lease frames and daemon lifecycle frames legitimately omit it — and must, on
+that connection. Both peers enforce it with the shared classification in
+`packages/protocol/src/frame-scope.ts`: an org-scoped frame without an org, an
+install-wide frame with one, an org that does not own the targeted resource,
+or a reply that does not carry its request's org is refused with
+`SCOPE_DENIED` and never applied (the contract in detail:
+[`org-scoped-data-layer.md`](org-scoped-data-layer.md) §4.1). Reconnect state is a combined multi-org snapshot or revision-fenced stream
 on the same member connection — deliberately **not** `subscribe(org)`, an org
 room, or an org-specific socket — reusing the watermark machinery that already
 exists in production (`Agent.configRevision` with the daemon-side

--- a/docs/designs/org-scoped-data-layer.md
+++ b/docs/designs/org-scoped-data-layer.md
@@ -116,6 +116,47 @@ method carries depends on who is allowed to call it:
 | Orchestrator / reconciliation / platform machinery                 | derived from the row being processed | `*Unscoped` reads, system-tier mutations                                              |
 | Public-by-design endpoints (e.g. agent icon PNG, fetched by Slack) | none — intentionally unauthenticated | `*Unscoped` with an inline lint exemption and a justification comment                 |
 
+### 4.1 The daemon WS frame contract
+
+How a WS handler comes by `frame.orgId` is a wire contract, not a convention
+(`packages/protocol/src/frame-scope.ts`; the exchange itself is
+[`k8s-daemon-pool.md`](k8s-daemon-pool.md) M4). Every frame type on the
+daemon↔CP wire is one of three things:
+
+- **install-wide** — about the member or the whole install (`auth`,
+  `register`, `heartbeat`, `capabilities/update`, the `facts/*` snapshots, the
+  relay roster and collaboration routes, `daemon/drain` and its progress and
+  done, `daemon/restart` / `daemon/upgrade` and their `daemon/control/ack`,
+  `config/push`, every `duty/*` frame except `duty/fetch`, and `agent/exists`).
+  On an install-wide (frame-mode) connection such a frame **must not** carry
+  `orgId`; on an org-scoped (API-key) connection it may carry the connection's.
+- **org-scoped** — everything else: agent, cron, integration, MCP-server and
+  memory-connection lifecycle, hooks and GitHub review frames, session
+  events, usage, gitcred, secrets, webchat MCP grants, the session / workspace
+  / memory / dream / task read surfaces, organization knowledge, and
+  `duty/fetch` (about one agent in one org). On a frame-mode connection such a
+  frame **must** carry `orgId`, and the receiver checks the org named against
+  the resource the frame targets — the CP through the connection's
+  `id → org` maps and the handler's scoped repository read, the daemon
+  through its own agent / integration / cron registries. A frame that fails
+  either check is refused with `SCOPE_DENIED` and applies nothing.
+- **generic replies** (`ack`, `error`) — their scope is the request's.
+
+A **correlated reply** carries the org of the request it answers. In frame
+mode a typed reply must carry exactly that org (none for an install-wide
+request); the receiver fails the pending request with `SCOPE_DENIED` when it
+does not, so a mis-scoped reply is never applied. An `error` reply names no
+resource and may omit the org, but one it carries must be the request's. In
+connection mode an org present on a reply must match the request's and the
+connection's; a reply that omits it still settles. A generic reply that
+correlates to no pending request is dropped, never answered — otherwise two
+peers could trade `SCOPE_DENIED` errors indefinitely.
+
+Both peers enforce the same rules with the same functions
+(`checkInboundFrameOrg`, `checkReplyFrameOrg`); the sending side refuses to
+build an org-scoped frame it cannot scope and never stamps an org on an
+install-wide one.
+
 ## 5. Exemplar migration: Agent (M1, this change)
 
 `AgentRepo` is the largest and most-referenced port; it sets the pattern.
@@ -216,4 +257,5 @@ Two structural guards, so the convention cannot silently erode:
   than an org parameter once one install-wide member carried many orgs on one
   socket, so the fence was extended to `src/ws/**` in
   [`k8s-daemon-pool.md`](k8s-daemon-pool.md) M4: a handler resolves resources
-  with the frame's org, or the connection's when it has one.
+  with the frame's org, or the connection's when it has one, and the frame
+  contract that guarantees the org is there is §4.1.

--- a/packages/connection/src/correlator.ts
+++ b/packages/connection/src/correlator.ts
@@ -18,6 +18,7 @@ export interface WireFrameLike {
   id: string
   corr?: string
   type: string
+  orgId?: string | undefined
   payload: unknown
 }
 
@@ -37,6 +38,8 @@ export class WireError extends Error {
 
 interface Pending<F> {
   id: string
+  /** The REQ as issued — a correlated reply is fenced against its type and org before it settles. */
+  request: { type: string; orgId?: string | undefined }
   encoded: string
   resolve: (frame: F) => void
   reject: (err: unknown) => void
@@ -65,6 +68,7 @@ export class ReqRep<F extends WireFrameLike = WireFrameLike> {
     return new Promise<F>((resolve, reject) => {
       const entry: Pending<F> = {
         id: frame.id,
+        request: { type: frame.type, ...(frame.orgId ? { orgId: frame.orgId } : {}) },
         encoded,
         resolve,
         reject,
@@ -126,6 +130,11 @@ export class ReqRep<F extends WireFrameLike = WireFrameLike> {
     if (entry.timer !== undefined) this.clock.clearTimeout(entry.timer)
     entry.resolve(frame)
     return true
+  }
+
+  /** The still-pending REQ a reply with `corr` would settle, if any — read before `settle` to fence the reply. */
+  requested(corr: string): { type: string; orgId?: string | undefined } | undefined {
+    return this.pending.get(corr)?.request
   }
 
   /** Reject one pending request by correlation id (e.g. a REP whose envelope is

--- a/packages/control-plane/src/github/review-broker.service.ts
+++ b/packages/control-plane/src/github/review-broker.service.ts
@@ -291,10 +291,11 @@ export class GithubReviewBrokerService {
   }
 
   /** Persist the exact start barrier before a GitHub hook enters the prompt. */
-  async start(input: HookStart, reportingDaemonId: DaemonId): Promise<void> {
+  async start(input: HookStart, reportingDaemonId: DaemonId, reportingOrgId?: string): Promise<void> {
     const hookId = HookId(input.hookId)
     const initial = await this.deps.hook.getRun(hookId, input.deliveryKey)
     if (!initial) denied('review dispatch fence does not match the accepted hook run')
+    if (reportingOrgId && initial.orgId !== reportingOrgId) denied('organization does not match the accepted hook run')
     if (initial.agentId === null || initial.agentId !== AgentId(input.agentId)) {
       denied('hook start agent does not match the accepted hook run')
     }

--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -12,7 +12,16 @@
  * control via `request`/`send`) — but in Phase 2 only the inbound `auth`/
  * `register` path and the legal-frame gate are exercised.
  */
-import { AnyFrame, type ControlExt, type ErrorCode, isFrame } from '@agentconnect.md/protocol'
+import {
+  AnyFrame,
+  type ControlExt,
+  type ErrorCode,
+  checkInboundFrameOrg,
+  checkReplyFrameOrg,
+  isFrame,
+  isInstallWideFrameType,
+  type FrameOrgPeer
+} from '@agentconnect.md/protocol'
 import { decodeEnvelope, buildEnvelope, encode, type InboundControlExt } from './codec.js'
 import { ReqRep, type RequestOpts } from './correlator.js'
 import type { Transport } from './transport.js'
@@ -21,34 +30,6 @@ import type { DaemonWsDeps } from './deps.js'
 import type { FrameRouter } from './handlers/index.js'
 import { FencingState, checkFencing } from '../orchestrator/fencing.js'
 import { ProtocolError } from '../domain/errors.js'
-
-const INSTALL_WIDE_FRAME_TYPES = new Set([
-  'register',
-  'register/ok',
-  'heartbeat',
-  'capabilities/update',
-  'facts/daemon-runtimes',
-  'facts/memory-connections',
-  'relay/roster',
-  'collaboration/routes',
-  'daemon/drain',
-  'drain/progress',
-  'drain/done',
-  'daemon/restart',
-  'daemon/upgrade',
-  'daemon/bootstrap/result',
-  'config/push',
-  // Duty lease exchange: groups span orgs on one member; grants carry per-entry orgId.
-  'duty/grant',
-  'duty/renewed',
-  'duty/revoke',
-  'duty/release',
-  'duty/claim',
-  'duty/claim/ok',
-  // Existence query from the pool's orphan reconciler: the ids it asks about span every org.
-  'agent/exists',
-  'agent/exists/ok'
-])
 
 export class DaemonConnection implements ConnChannel {
   state: LifecycleState = 'CONNECTING'
@@ -102,8 +83,23 @@ export class DaemonConnection implements ConnChannel {
     }
     const frame = decoded.frame
 
-    // A correlated REP/error settles a CP-issued REQ — never re-dispatched.
-    if (frame.corr && this.correlator.settle(frame)) return
+    // A correlated REP/error settles a CP-issued REQ — never re-dispatched. It is fenced on the
+    // org of the REQ it answers first: a reply naming another org fails that REQ and applies nothing.
+    if (frame.corr) {
+      const request = this.correlator.requested(frame.corr)
+      if (request) {
+        const verdict = checkReplyFrameOrg(request, frame, this.orgPeer())
+        if (!verdict.ok) {
+          this.deps.log.error(
+            { daemonId: this.daemonId, type: frame.type, corr: frame.corr },
+            `daemon reply rejected: ${verdict.message}`
+          )
+          this.correlator.reject(frame.corr, new ProtocolError('SCOPE_DENIED', verdict.message, { retryable: false }))
+          return
+        }
+      }
+      if (this.correlator.settle(frame)) return
+    }
 
     // §2.1 legal-frame gate.
     if (!this.isLegalInState(frame.type)) {
@@ -134,27 +130,29 @@ export class DaemonConnection implements ConnChannel {
     }
   }
 
-  /** Enforce connection-scoped tenancy for ordinary daemons and frame-scoped tenancy for a pool member. */
+  private orgPeer(): FrameOrgPeer {
+    return this.orgId ? { mode: 'connection', orgId: this.orgId } : { mode: 'frame', orgId: null }
+  }
+
+  /**
+   * Connection-scoped tenancy for an ordinary daemon, frame-scoped for a pool member: the shared
+   * frame-scope gate first (org required on an org-scoped frame, forbidden on an install-wide one, equal
+   * to the connection's where it has one), then the org named against the resource the frame targets.
+   */
   private gateOrganization(frame: AnyFrame): boolean {
     if (this.state === 'AUTHENTICATING' || this.state === 'REGISTERING') return true
-    if (this.orgId) {
-      if (frame.orgId && frame.orgId !== this.orgId) {
-        this.sendError(frame.id, 'SCOPE_DENIED', 'organization does not match authenticated connection', false)
-        return false
-      }
-      return true
+    const verdict = checkInboundFrameOrg(frame, this.orgPeer())
+    if (!verdict.ok) {
+      this.sendError(frame.id, 'SCOPE_DENIED', verdict.message, false)
+      return false
     }
-    if (frame.orgId) {
-      const targetedOrgId = this.organizationForInbound(frame)
-      if (targetedOrgId === null || (targetedOrgId && targetedOrgId !== frame.orgId)) {
-        this.sendError(frame.id, 'SCOPE_DENIED', 'organization does not match the targeted resource', false)
-        return false
-      }
-      return true
+    if (!frame.orgId || this.orgId) return true
+    const targetedOrgId = this.organizationForInbound(frame)
+    if (targetedOrgId === null || (targetedOrgId && targetedOrgId !== frame.orgId)) {
+      this.sendError(frame.id, 'SCOPE_DENIED', 'organization does not match the targeted resource', false)
+      return false
     }
-    if (INSTALL_WIDE_FRAME_TYPES.has(frame.type)) return true
-    this.sendError(frame.id, 'SCOPE_DENIED', 'organization is required on an install-wide connection', false)
-    return false
+    return true
   }
 
   private organizationForInbound(frame: AnyFrame): string | null | undefined {
@@ -239,7 +237,7 @@ export class DaemonConnection implements ConnChannel {
     opts?: RequestOpts,
     orgId?: string
   ): Promise<TReply> {
-    const scopedOrgId = orgId ?? this.organizationFor(type, payload)
+    const scopedOrgId = this.outboundOrganization(type, payload, orgId)
     const frame = buildEnvelope(type as Parameters<typeof buildEnvelope>[0], payload, {
       ...(ext ? { ext } : {}),
       ...(scopedOrgId ? { orgId: scopedOrgId } : {})
@@ -250,7 +248,7 @@ export class DaemonConnection implements ConnChannel {
 
   /** Fire-and-forget EVT (C→D). */
   send(type: string, payload: unknown, ext?: ControlExt, orgId?: string): void {
-    const scopedOrgId = orgId ?? this.organizationFor(type, payload)
+    const scopedOrgId = this.outboundOrganization(type, payload, orgId)
     const frame = buildEnvelope(type as Parameters<typeof buildEnvelope>[0], payload, {
       ...(ext ? { ext } : {}),
       ...(scopedOrgId ? { orgId: scopedOrgId } : {})
@@ -258,9 +256,15 @@ export class DaemonConnection implements ConnChannel {
     this.transport.send(encode(frame))
   }
 
+  /** An install-wide frame to a pool member never carries an org, whatever a caller passed; the rest resolve one. */
+  private outboundOrganization(type: string, payload: unknown, explicit?: string): string | undefined {
+    if (!this.orgId && isInstallWideFrameType(type)) return undefined
+    return explicit ?? this.organizationFor(type, payload)
+  }
+
   private organizationFor(type: string, payload: unknown): string | undefined {
     if (this.orgId) return this.orgId
-    if (INSTALL_WIDE_FRAME_TYPES.has(type)) return undefined
+    if (isInstallWideFrameType(type)) return undefined
     const p = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {}
     const spec = p.spec && typeof p.spec === 'object' ? (p.spec as Record<string, unknown>) : undefined
     const state = this.deps.connReg.get(this.daemonId)

--- a/packages/control-plane/src/ws/correlator.ts
+++ b/packages/control-plane/src/ws/correlator.ts
@@ -19,6 +19,8 @@ import { ProtocolError } from '../domain/errors.js'
 
 interface Pending {
   id: string
+  /** The REQ as issued — a correlated reply is fenced against its type and org (frame-scope). */
+  request: { type: string; orgId?: string | undefined }
   encoded: string
   resolve: (frame: AnyFrame) => void
   reject: (err: unknown) => void
@@ -52,6 +54,7 @@ export class ReqRep {
     return new Promise<AnyFrame>((resolve, reject) => {
       const entry: Pending = {
         id: frame.id,
+        request: { type: frame.type, ...(frame.orgId ? { orgId: frame.orgId } : {}) },
         encoded,
         resolve,
         reject,
@@ -93,6 +96,11 @@ export class ReqRep {
     if (entry.timer !== undefined) this.clock.clearTimeout(entry.timer)
     entry.resolve(frame)
     return true
+  }
+
+  /** The still-pending REQ a reply with `corr` would settle, if any — read before `settle` to fence the reply. */
+  requested(corr: string): { type: string; orgId?: string | undefined } | undefined {
+    return this.pending.get(corr)?.request
   }
 
   /** Reject one pending request by correlation id when the peer's REP envelope

--- a/packages/control-plane/src/ws/handlers/github-projection-barrier.test.ts
+++ b/packages/control-plane/src/ws/handlers/github-projection-barrier.test.ts
@@ -26,6 +26,7 @@ const snapshot = {
 function fakeConn() {
   return {
     daemonId: DAEMON_ID,
+    orgId: 'org-a',
     replyTo: vi.fn(),
     sendError: vi.fn()
   } as unknown as DaemonConnection & { replyTo: ReturnType<typeof vi.fn>; sendError: ReturnType<typeof vi.fn> }
@@ -147,7 +148,7 @@ describe('GitHub projection request barriers', () => {
       }
     } as AnyFrame
     const deps = {
-      hook: { recordReport },
+      hook: { recordReport, get: async () => ({ id: HOOK_ID }) },
       githubRunCoordinator: { afterReport },
       clock: { now: () => 1_700_000_000_000 }
     } as unknown as DaemonWsDeps
@@ -193,7 +194,7 @@ describe('GitHub projection request barriers', () => {
       }
     } as AnyFrame
     const deps = {
-      hook: { recordReport },
+      hook: { recordReport, get: async () => ({ id: HOOK_ID }) },
       githubRunCoordinator: { afterReport },
       clock: { now: () => 1_700_000_000_000 }
     } as unknown as DaemonWsDeps
@@ -234,7 +235,7 @@ describe('GitHub projection request barriers', () => {
       }
     } as AnyFrame
     const deps = {
-      hook: { recordReport },
+      hook: { recordReport, get: async () => ({ id: HOOK_ID }) },
       githubRunCoordinator: { afterReport },
       clock: { now: () => 1_700_000_000_000 }
     } as unknown as DaemonWsDeps

--- a/packages/control-plane/src/ws/handlers/hook-report.ts
+++ b/packages/control-plane/src/ws/handlers/hook-report.ts
@@ -16,11 +16,18 @@ import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, HookId } from '../../domain/ids.js'
 import { githubProjectionIntent } from '../../github/projection-intent.js'
 import { hookRuntimeProjectionState } from '../../github/projection-state.js'
+import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 
 export const handleHookReport: Handler = async (frame, conn, deps) => {
   if (!isFrame('hook/report')(frame)) return
   const p = frame.payload
+  // The hook must live in the org the frame acts in (M4): a cross-org id reads as absent through the scoped read.
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId || !(await deps.hook.get(orgId, HookId(p.hookId)))) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'hook is not in the organization this frame acts in', false)
+    return
+  }
   const projectionIntent = githubProjectionIntent(p.event, p.github, p.reviewPolicy)
   const projectionDesiredState =
     p.reviewResult?.state === 'submitted'

--- a/packages/control-plane/src/ws/handlers/hook-start.ts
+++ b/packages/control-plane/src/ws/handlers/hook-start.ts
@@ -2,6 +2,7 @@
 import { isFrame } from '@agentconnect.md/protocol'
 import { DaemonId, HookId } from '../../domain/ids.js'
 import { GithubReviewBrokerError } from '../../github/review-broker.service.js'
+import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 
 export const handleHookStart: Handler = async (frame, conn, deps) => {
@@ -10,8 +11,13 @@ export const handleHookStart: Handler = async (frame, conn, deps) => {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'github review broker is not enabled', false)
     return
   }
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'organization is required', false)
+    return
+  }
   try {
-    await deps.githubReviewBroker.start(frame.payload, DaemonId(conn.daemonId))
+    await deps.githubReviewBroker.start(frame.payload, DaemonId(conn.daemonId), orgId)
     // The OK is the daemon's prompt barrier. Do not acknowledge until both the
     // authoritative HookRun start and its durable R2a projection intent have
     // converged; a retry is safe because both writes are idempotent.

--- a/packages/control-plane/test/integration/hook-report.test.ts
+++ b/packages/control-plane/test/integration/hook-report.test.ts
@@ -55,7 +55,7 @@ async function report(
     payload: { hookId, agentId, deliveryKey, ...outcome }
   } as AnyFrame
   const deps = { hook: repo(), clock: systemClock } as unknown as DaemonWsDeps
-  const conn = { daemonId, replyTo: vi.fn(), sendError: vi.fn() }
+  const conn = { daemonId, orgId: DEFAULT_ORG_ID, replyTo: vi.fn(), sendError: vi.fn() }
   await handleHookReport(frame, conn as unknown as DaemonConnection, deps)
   return { frame, conn }
 }
@@ -1021,13 +1021,13 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     expect(runs[0]).toMatchObject({ deliveryKey: 'd-late', status: 'failed', reason: 'turn failed' })
   })
 
-  it('an unknown hookId completion returns a permanent conflict', async () => {
+  it('an unknown hookId completion is refused permanently — absent in the org the frame acts in', async () => {
     await seedDaemon(prisma, DAEMON)
     const rejected = await report(DAEMON, randomUUID(), randomUUID(), 'd-1', { status: 'success' })
     expect(rejected.conn.sendError).toHaveBeenCalledWith(
       rejected.frame.id,
-      'CONFLICT',
-      'hook completion does not match the accepted dispatch',
+      'SCOPE_DENIED',
+      'hook is not in the organization this frame acts in',
       false
     )
     expect(rejected.conn.replyTo).not.toHaveBeenCalled()

--- a/packages/control-plane/test/integration/hooks-pool-placement.test.ts
+++ b/packages/control-plane/test/integration/hooks-pool-placement.test.ts
@@ -168,7 +168,7 @@ async function report(
     payload: { hookId, agentId, deliveryKey, ...outcome }
   } as AnyFrame
   const deps = { hook: repo(), clock: systemClock } as unknown as DaemonWsDeps
-  const conn = { daemonId, replyTo: vi.fn(), sendError: vi.fn() }
+  const conn = { daemonId, orgId: DEFAULT_ORG_ID, replyTo: vi.fn(), sendError: vi.fn() }
   await handleHookReport(frame, conn as unknown as DaemonConnection, deps)
   return { frame, conn }
 }

--- a/packages/control-plane/test/protocol/fencing.test.ts
+++ b/packages/control-plane/test/protocol/fencing.test.ts
@@ -258,4 +258,116 @@ describe('organization gate', () => {
     conn.send('knowledge/suggestion/review', review, { epoch: 5 }, 'org-b')
     expect(stub.lastSent('knowledge/suggestion/review')?.orgId).toBe('org-b')
   })
+
+  // M4: on an install-wide connection an install-wide frame names no org; one that does is refused.
+  it('rejects an install-wide frame carrying an org from an install-wide daemon', () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    const id = stub.inject(
+      'heartbeat',
+      { load: { cpu: 0, mem: 0, agents: 0 }, health: 'ok', activeSessions: 0 },
+      {
+        orgId: 'org-a'
+      }
+    )
+    const err = stub.lastSent('error')
+    if (!err || !isFrame('error')(err)) throw new Error('expected error frame')
+    expect(err.corr).toBe(id)
+    expect(err.payload.code).toBe('SCOPE_DENIED')
+  })
+
+  it('still takes an install-wide frame carrying the connection org from an org-scoped daemon', () => {
+    const { stub } = readyConn({ sessionEpoch: 5 })
+    stub.inject(
+      'heartbeat',
+      { load: { cpu: 0, mem: 0, agents: 0 }, health: 'ok', activeSessions: 0 },
+      { orgId: 'org-a' }
+    )
+    expect(stub.lastSent('error')).toBeUndefined()
+  })
+
+  it('never stamps an org on an install-wide downlink frame to a pool member, even when a caller passes one', () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    conn.send('daemon/drain', { scope: { kind: 'daemon' }, deadline: new Date().toISOString() }, { epoch: 5 }, 'org-a')
+    expect(stub.lastSent('daemon/drain')?.orgId).toBeUndefined()
+  })
+
+  // A generic reply that correlates to nothing is dropped, never answered — else two peers would trade errors forever.
+  it('drops an uncorrelated error from an install-wide daemon without answering it', () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    stub.inject('error', { code: 'INTERNAL', message: 'late', retryable: false }, { corr: LAUNCH })
+    expect(stub.sent.filter((f) => f.type === 'error')).toEqual([])
+  })
+})
+
+describe('reply organization gate', () => {
+  it('frame mode: a typed reply carrying the request org settles it', async () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    const pending = conn.request('session/list', { agentId: AGENT }, { epoch: 5 })
+    const req = stub.lastSent('session/list')!
+    expect(req.orgId).toBe('org-a')
+    stub.inject('session/list/page', { sessions: [] }, { corr: req.id, orgId: 'org-a' })
+    await expect(pending).resolves.toEqual({ sessions: [] })
+  })
+
+  it('frame mode: a reply naming another org fails the request with SCOPE_DENIED and applies nothing', async () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    const pending = conn.request('session/list', { agentId: AGENT }, { epoch: 5 })
+    const req = stub.lastSent('session/list')!
+    stub.inject('session/list/page', { sessions: [] }, { corr: req.id, orgId: 'org-b' })
+    await expect(pending).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
+    expect(conn.correlator.inflight()).toBe(0)
+  })
+
+  it('frame mode: a reply that omits the request org is refused too', async () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    const pending = conn.request('session/list', { agentId: AGENT }, { epoch: 5 })
+    const req = stub.lastSent('session/list')!
+    stub.inject('session/list/page', { sessions: [] }, { corr: req.id })
+    await expect(pending).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
+  })
+
+  it('frame mode: an error reply needs no org and still rejects the request with its own code', async () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    const pending = conn.request('session/list', { agentId: AGENT }, { epoch: 5 })
+    const req = stub.lastSent('session/list')!
+    stub.inject('error', { code: 'NO_SESSION', message: 'gone', retryable: false }, { corr: req.id })
+    await expect(pending).rejects.toMatchObject({ code: 'NO_SESSION' })
+  })
+
+  it('frame mode: an install-wide reply carrying an org is refused', async () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    conn.orgId = null
+    const pending = conn.request(
+      'daemon/drain',
+      { scope: { kind: 'daemon' }, deadline: new Date().toISOString() },
+      { epoch: 5 }
+    )
+    const req = stub.lastSent('daemon/drain')!
+    stub.inject('drain/done', { released: [] }, { corr: req.id, orgId: 'org-a' })
+    await expect(pending).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
+  })
+
+  it('connection mode: a reply without an org still settles (an older daemon does not echo it)', async () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    const pending = conn.request('session/list', { agentId: AGENT }, { epoch: 5 })
+    const req = stub.lastSent('session/list')!
+    expect(req.orgId).toBe('org-a')
+    stub.inject('session/list/page', { sessions: [] }, { corr: req.id })
+    await expect(pending).resolves.toEqual({ sessions: [] })
+  })
+
+  it('connection mode: a reply naming another org is refused', async () => {
+    const { conn, stub } = readyConn({ sessionEpoch: 5 })
+    const pending = conn.request('session/list', { agentId: AGENT }, { epoch: 5 })
+    const req = stub.lastSent('session/list')!
+    stub.inject('session/list/page', { sessions: [] }, { corr: req.id, orgId: 'org-b' })
+    await expect(pending).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
+  })
 })

--- a/packages/control-plane/test/protocol/frame-org.handler.test.ts
+++ b/packages/control-plane/test/protocol/frame-org.handler.test.ts
@@ -1,0 +1,216 @@
+// The frame-scoped organization contract over the real WS edge (k8s-daemon-pool.md M4): on an
+// install-wide (frame-mode) member every org-scoped frame names its org and the CP checks that
+// org against the resource the frame targets; install-wide frames name none; a correlated reply
+// carries the org of the request it answers. An org-scoped (API-key) connection keeps its
+// connection-bound behavior throughout.
+import { randomUUID } from 'node:crypto'
+import { describe, it, expect } from 'vitest'
+import { isFrame, type FrameType } from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { buildWsHarness } from '../fakes/build-ws.js'
+import type { InMemoryDaemonStub } from '../fakes/daemon-stub.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { AgentId, HookId, OrgId } from '../../src/domain/ids.js'
+import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
+
+const DAEMON = 'd1111111-1111-4111-8111-111111111111'
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const FOREIGN_ORG = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+const FOREIGN_AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
+const AUTH_ID = '99999999-9999-4999-8999-999999999999'
+const REG_ID = '88888888-8888-4888-8888-888888888888'
+
+/** One agent of the default org pinned to the daemon under test, plus a second org with its own agent. */
+async function seedTwoOrgs(): Promise<void> {
+  await prisma.org.create({ data: { id: FOREIGN_ORG, slug: 'foreign-org' } })
+  await prisma.agent.create({
+    data: { id: FOREIGN_AGENT, orgId: FOREIGN_ORG, name: 'foreign', runtime: 'claude', status: 'active' }
+  })
+}
+
+async function ready(h: ReturnType<typeof buildWsHarness>, mode: 'frame' | 'connection'): Promise<InMemoryDaemonStub> {
+  const { stub } = h.connect()
+  if (mode === 'frame') {
+    const saToken = await h.mintPoolMember(DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    stub.inject('auth', { serviceAccountToken: saToken, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
+  } else {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    const token = await h.mintToken(DAEMON)
+    stub.inject('auth', { apiKey: token, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
+  }
+  await stub.expectFrame('auth/ok')
+  stub.inject(
+    'register',
+    {
+      host: 'member-1',
+      capabilities: { platforms: ['slack'], runtimes: ['claude'], acp: true, features: [] },
+      maxAgents: 8,
+      localState: { assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }
+    },
+    { id: REG_ID }
+  )
+  await stub.expectFrame('register/ok')
+  return stub
+}
+
+/** The org-scoped D→C families, each with the smallest valid payload naming the pinned agent. */
+const ORG_SCOPED: Array<{ type: FrameType; payload: unknown }> = [
+  { type: 'usage/report', payload: usageReport() },
+  { type: 'event/session-activity', payload: { sessionId: 's1', agentId: AGENT, revision: '1', ts: now() } },
+  { type: 'event/session-purged', payload: { agentId: AGENT, sessionIds: ['s1'], reason: 'retention', ts: now() } },
+  { type: 'cron/report', payload: { cronId: randomUUID(), agentId: AGENT, firedAt: now() } },
+  { type: 'channel/agents', payload: { platform: 'slack', requesterAgentId: AGENT } },
+  { type: 'gitcred/request', payload: { agentId: AGENT } },
+  { type: 'duty/fetch', payload: { agentId: AGENT } },
+  { type: 'knowledge/search', payload: { requesterAgentId: AGENT, query: 'q' } },
+  { type: 'session/child-status', payload: { parentSessionId: 'p', childSessionId: 'c', childAgentId: AGENT } },
+  { type: 'hook/report', payload: { hookId: randomUUID(), agentId: AGENT, deliveryKey: 'd', status: 'success' } }
+]
+
+function now(): string {
+  return new Date().toISOString()
+}
+
+function usageReport() {
+  return {
+    sessionId: 's1',
+    agentId: AGENT,
+    lastActivityAt: now(),
+    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 }
+  }
+}
+
+function heartbeat() {
+  return { load: { cpu: 0, mem: 0, agents: 0 }, health: 'ok', activeSessions: 0 }
+}
+
+async function errorFor(stub: InMemoryDaemonStub, id: string) {
+  await stub.settled()
+  const err = stub.sent.find((f) => f.type === 'error' && f.corr === id)
+  return err && isFrame('error')(err) ? err.payload : undefined
+}
+
+describe('frame-scoped organization on the daemon WS edge', () => {
+  it('frame mode: every org-scoped family is refused without an org, and with the wrong one', async () => {
+    await seedTwoOrgs()
+    const h = buildWsHarness(prisma)
+    const stub = await ready(h, 'frame')
+    for (const { type, payload } of ORG_SCOPED) {
+      const unscoped = stub.inject(type, payload)
+      expect({ type, error: await errorFor(stub, unscoped) }).toMatchObject({
+        type,
+        error: { code: 'SCOPE_DENIED', message: 'organization is required on an install-wide connection' }
+      })
+      // The pinned agent belongs to the default org; naming the foreign org for it is refused before dispatch.
+      const wrong = stub.inject(type, payload, { orgId: FOREIGN_ORG })
+      expect({ type, error: await errorFor(stub, wrong) }).toMatchObject({
+        type,
+        error: { code: 'SCOPE_DENIED', message: 'organization does not match the targeted resource' }
+      })
+    }
+  })
+
+  it('frame mode: the right org reaches the handler', async () => {
+    await seedTwoOrgs()
+    const h = buildWsHarness(prisma)
+    const stub = await ready(h, 'frame')
+    const id = stub.inject('channel/agents', { platform: 'slack', requesterAgentId: AGENT }, { orgId: DEFAULT_ORG_ID })
+    const ok = await stub.expectFrame('channel/agents/ok')
+    expect(ok.corr).toBe(id)
+    // The reply carries the org of the request it answers.
+    expect(ok.orgId).toBe(DEFAULT_ORG_ID)
+    if (!isFrame('channel/agents/ok')(ok)) throw new Error('expected channel/agents/ok')
+    expect(ok.payload.agents.map((a) => a.agentId)).toContain(AGENT)
+    expect(await errorFor(stub, id)).toBeUndefined()
+  })
+
+  it('frame mode: install-wide frames are refused when they carry an org', async () => {
+    const h = buildWsHarness(prisma)
+    const stub = await ready(h, 'frame')
+    for (const { type, payload } of [
+      { type: 'heartbeat' as const, payload: heartbeat() },
+      { type: 'duty/release' as const, payload: { groupIds: [randomUUID()] } },
+      { type: 'agent/exists' as const, payload: { agentIds: [AGENT] } },
+      { type: 'capabilities/update' as const, payload: { capabilities: { platforms: [], runtimes: [], acp: true } } }
+    ]) {
+      const id = stub.inject(type, payload, { orgId: DEFAULT_ORG_ID })
+      expect({ type, error: await errorFor(stub, id) }).toMatchObject({ type, error: { code: 'SCOPE_DENIED' } })
+    }
+    // Bare, they are taken.
+    const beat = stub.inject('heartbeat', heartbeat())
+    expect(await errorFor(stub, beat)).toBeUndefined()
+  })
+
+  it('frame mode: a hook is checked against the org the frame names through the scoped read', async () => {
+    await seedTwoOrgs()
+    const h = buildWsHarness(prisma)
+    const stub = await ready(h, 'frame')
+    const hookId = randomUUID()
+    await new PgHookRepo(prisma).upsert({
+      hookId: HookId(hookId),
+      orgId: OrgId(DEFAULT_ORG_ID),
+      agentId: AgentId(AGENT),
+      kind: 'webhook',
+      name: 'default-org-hook',
+      sessionMode: 'perThread',
+      targetPlatform: 'slack'
+    })
+    // The registry does not know the foreign agent, so only the handler's scoped read can refuse this.
+    const crossOrg = stub.inject(
+      'hook/report',
+      { hookId, agentId: FOREIGN_AGENT, deliveryKey: 'd', status: 'success' },
+      { orgId: FOREIGN_ORG }
+    )
+    expect(await errorFor(stub, crossOrg)).toMatchObject({
+      code: 'SCOPE_DENIED',
+      message: 'hook is not in the organization this frame acts in'
+    })
+    // In its own org the same report goes through: the pinned agent's daemon may close the run.
+    const own = stub.inject(
+      'hook/report',
+      { hookId, agentId: AGENT, deliveryKey: 'd', status: 'success' },
+      { orgId: DEFAULT_ORG_ID }
+    )
+    await stub.settled()
+    expect(stub.sent.find((f) => f.type === 'ack' && f.corr === own)?.orgId).toBe(DEFAULT_ORG_ID)
+  })
+
+  it('frame mode: a reply that does not carry the request org fails the request and is never applied', async () => {
+    const h = buildWsHarness(prisma)
+    const stub = await ready(h, 'frame')
+    const conn = h.deps.connReg.get(DAEMON)!.conn
+    const pending = conn.request('session/list', { agentId: AGENT })
+    const req = await stub.expectFrame('session/list')
+    expect(req.orgId).toBe(DEFAULT_ORG_ID)
+    stub.inject('session/list/page', { sessions: [] }, { corr: req.id })
+    await expect(pending).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
+    const again = conn.request('session/list', { agentId: AGENT })
+    const req2 = stub.sent.filter((f) => f.type === 'session/list').at(-1)!
+    stub.inject('session/list/page', { sessions: [] }, { corr: req2.id, orgId: DEFAULT_ORG_ID })
+    await expect(again).resolves.toEqual({ sessions: [] })
+  })
+
+  it('connection mode (API key): unscoped frames stay accepted, the connection org is accepted, another is refused', async () => {
+    await seedTwoOrgs()
+    const h = buildWsHarness(prisma)
+    const stub = await ready(h, 'connection')
+    const bare = stub.inject('channel/agents', { platform: 'slack', requesterAgentId: AGENT })
+    expect((await stub.expectFrame('channel/agents/ok')).corr).toBe(bare)
+    const own = stub.inject('usage/report', usageReport(), { orgId: DEFAULT_ORG_ID })
+    expect(await errorFor(stub, own)).toBeUndefined()
+    const beat = stub.inject('heartbeat', heartbeat(), { orgId: DEFAULT_ORG_ID })
+    expect(await errorFor(stub, beat)).toBeUndefined()
+    const foreign = stub.inject('usage/report', usageReport(), { orgId: FOREIGN_ORG })
+    expect(await errorFor(stub, foreign)).toMatchObject({ code: 'SCOPE_DENIED' })
+    // Downlink frames carry the connection org, and a reply that omits it still settles.
+    const conn = h.deps.connReg.get(DAEMON)!.conn
+    const pending = conn.request('session/list', { agentId: AGENT })
+    const req = await stub.expectFrame('session/list')
+    expect(req.orgId).toBe(DEFAULT_ORG_ID)
+    stub.inject('session/list/page', { sessions: [] }, { corr: req.id })
+    await expect(pending).resolves.toEqual({ sessions: [] })
+  })
+})

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -105,7 +105,9 @@ import type {
   ManagedSkillChunk,
   OrganizationSuggestionReadReq,
   OrganizationSuggestionReviewReq,
-  BootstrapLifecycle
+  BootstrapLifecycle,
+  FrameOrgPeer,
+  OrganizationMode
 } from '@agentconnect.md/protocol'
 import {
   buildEnvelope,
@@ -116,7 +118,10 @@ import {
   SESSION_METADATA_ACK_FEATURE,
   SESSION_PURGE_FEATURE,
   ORGANIZATION_KNOWLEDGE_FEATURE,
-  DAEMON_BOOTSTRAP_PROTOCOL_VERSION
+  DAEMON_BOOTSTRAP_PROTOCOL_VERSION,
+  checkInboundFrameOrg,
+  checkReplyFrameOrg,
+  isInstallWideFrameType
 } from '@agentconnect.md/protocol'
 import type { SessionReader } from './session-reader.js'
 import { WorkspaceConflictError, WorkspaceViolationError, type WorkspaceReader } from './workspace-reader.js'
@@ -144,24 +149,6 @@ import type { Logger } from '../log.js'
  *  protocol package (single source of truth) so the daemon's existing import
  *  sites (`./cp/client.js`) keep working unchanged. */
 export { CP_SUBPROTOCOL, CP_WS_PATH } from '@agentconnect.md/protocol'
-
-// Frames that carry no org because they are daemon-level: the CP applies the
-// same list at its edge (ws/connection.ts INSTALL_WIDE_FRAME_TYPES). Duty groups
-// span orgs on one member, so grants carry a per-entry orgId instead.
-const INSTALL_WIDE_FRAME_TYPES = new Set([
-  'relay/roster',
-  'collaboration/routes',
-  'daemon/drain',
-  'daemon/restart',
-  'daemon/upgrade',
-  'config/push',
-  'duty/grant',
-  'duty/renewed',
-  'duty/revoke',
-  'duty/release',
-  'duty/claim',
-  'duty/claim/ok'
-])
 
 const ACK_TIMEOUT_MS = 5000
 const BACKOFF_BASE_MS = 1000
@@ -223,6 +210,8 @@ export interface CpClientDeps {
   orgForAgent?: (agentId: string) => string | undefined
   /** Tenant lookup for integration reports whose payload has no agent id. */
   orgForIntegration?: (integrationId: string) => string | undefined
+  /** Tenant lookup for cron control frames, which name only the cron. */
+  orgForCron?: (cronId: string) => string | undefined
   /** Unservable CP-rule agentIds, surfaced in heartbeat.degradedScopes. Defaults to []. */
   degradedScopes?: () => string[]
   /** Duty-lease digest + headroom for the heartbeat (frames/duty.ts). Only read on
@@ -293,7 +282,7 @@ export class CpClient {
   private stopped = false
   private fatal = false // 4401 — never auto-retry
   private serverFeatures = new Set<string>()
-  private organizationMode: 'connection' | 'frame' = 'connection'
+  private organizationMode: OrganizationMode = 'connection'
   private attempt = 0
   private reconnectTimer?: TimerHandle
   private lastAuthedEpoch = 0 // for resume on reconnect (per-agent seq tail is out of scope)
@@ -469,7 +458,7 @@ export class CpClient {
       dutyLeaseMs?: number
       webAppUrl?: string
       orgSlug?: string
-      organizationMode?: 'connection' | 'frame'
+      organizationMode?: OrganizationMode
       lifecycle?: BootstrapLifecycle
     }
     this.sessionEpoch = ok.sessionEpoch
@@ -881,7 +870,7 @@ export class CpClient {
   /**
    * `duty/release` (D→C REQ → `ack`) — surrender duty groups on drain instead of
    * waiting out the CP's reassignment window. Install-wide: duty groups span
-   * orgs, so the frame carries no org (see {@link INSTALL_WIDE_FRAME_TYPES}).
+   * orgs, so the frame carries no org (protocol `INSTALL_WIDE_FRAME_TYPES`).
    * Best-effort by contract — a failed release just falls back to lease expiry,
    * so callers log rather than fail the drain.
    */
@@ -1087,8 +1076,20 @@ export class CpClient {
       // the handshake continuation gets a chance to run.
       barrier.snapshotApplying = true
     }
-    // A correlated REP/error settles a pending daemon-issued REQ.
-    if (frame.corr && this.correlator.settle(frame)) return
+    // A correlated REP/error settles a pending daemon-issued REQ — after the org fence: a reply that
+    // does not carry the org of the REQ it answers fails that REQ locally and is never applied.
+    if (frame.corr) {
+      const request = this.correlator.requested(frame.corr)
+      if (request) {
+        const verdict = checkReplyFrameOrg(request, frame, this.orgPeer())
+        if (!verdict.ok) {
+          this.deps.log.warn(`cp: dropped ${frame.type} reply to ${request.type}: ${verdict.message}`)
+          this.correlator.reject(frame.corr, new WireError('SCOPE_DENIED', verdict.message, false))
+          return
+        }
+      }
+      if (this.correlator.settle(frame)) return
+    }
     if (barrier?.transport === source && barrier.snapshotApplying) {
       if (barrier.controls.length >= REGISTERING_CONTROL_QUEUE_LIMIT) {
         this.sendError(frame.id, 'PROTOCOL_STATE', 'post-register control queue full', true)
@@ -1122,16 +1123,26 @@ export class CpClient {
       this.sendError(frame.id, 'STALE_EPOCH', 'epoch < current', true)
       return
     }
-    if (this.organizationMode === 'frame' && !frame.orgId && !this.installWideControl(frame.type)) {
-      this.sendError(frame.id, 'SCOPE_DENIED', 'organization is required on an install-wide connection', false)
+    // Org fence (M4): the shared frame-scope gate, then the org named against the resource this
+    // daemon knows the frame targets. A frame that fails is refused with an error and never applied.
+    const verdict = checkInboundFrameOrg(frame, this.orgPeer())
+    if (!verdict.ok) {
+      this.deps.log.warn(`cp: refused ${frame.type}: ${verdict.message}`)
+      this.sendError(frame.id, 'SCOPE_DENIED', verdict.message, false)
       return
     }
     const expectedOrgId = this.organizationForControl(frame)
     if (frame.orgId && expectedOrgId && frame.orgId !== expectedOrgId) {
+      this.deps.log.warn(`cp: refused ${frame.type}: organization does not match the targeted resource`)
       this.sendError(frame.id, 'SCOPE_DENIED', 'organization does not match the targeted resource', false)
       return
     }
     this.dispatchControl(frame)
+  }
+
+  /** How this end reads the wire: frame mode knows no connection org; connection mode learns none either (the CP owns it). */
+  private orgPeer(): FrameOrgPeer {
+    return { mode: this.organizationMode, orgId: null }
   }
 
   private organizationForControl(frame: AnyFrame): string | undefined {
@@ -1150,14 +1161,13 @@ export class CpClient {
     ].find((value): value is string => typeof value === 'string')
     if (agentId) return this.deps.orgForAgent?.(agentId)
     if (typeof payload.integrationId === 'string') return this.deps.orgForIntegration?.(payload.integrationId)
+    if (typeof payload.cronId === 'string') return this.deps.orgForCron?.(payload.cronId)
     return undefined
   }
 
-  private installWideControl(type: string): boolean {
-    return INSTALL_WIDE_FRAME_TYPES.has(type)
-  }
-
+  /** Every D→C send resolves its org here: install-wide frames carry none, org-scoped ones must resolve one in frame mode. */
   private scopedFrame(type: string, payload: unknown, explicitOrgId?: string): AnyFrame {
+    if (isInstallWideFrameType(type)) return buildEnvelope(type as Parameters<typeof buildEnvelope>[0], payload)
     let orgId = explicitOrgId
     if (!orgId && payload && typeof payload === 'object') {
       const p = payload as Record<string, unknown>
@@ -1166,7 +1176,7 @@ export class CpClient {
       )
       if (agentId) orgId = this.deps.orgForAgent?.(agentId)
     }
-    if (this.organizationMode === 'frame' && !orgId && !INSTALL_WIDE_FRAME_TYPES.has(type)) {
+    if (this.organizationMode === 'frame' && !orgId) {
       throw new WireError('SCOPE_DENIED', `cannot resolve organization for ${type}`, false)
     }
     return buildEnvelope(type as Parameters<typeof buildEnvelope>[0], payload, orgId ? { orgId } : {})

--- a/packages/daemon/src/cp/cp-cron.ts
+++ b/packages/daemon/src/cp/cp-cron.ts
@@ -31,6 +31,10 @@ export class CpCronRegistry {
     this.onChange()
   }
 
+  agentForCron(cronId: string): string | undefined {
+    return this.entries.get(cronId)?.agentId
+  }
+
   forAgent(agentId: string): CronDef[] {
     return [...this.entries.values()].filter((entry) => entry.agentId === agentId).map((entry) => entry.cron)
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -22503,6 +22503,10 @@ export class Daemon {
         const agentId = this.cpIntegrations?.agentForIntegration(integrationId)
         return agentId ? (this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId)) : undefined
       },
+      orgForCron: (cronId) => {
+        const agentId = this.cpCrons?.agentForCron(cronId)
+        return agentId ? (this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId)) : undefined
+      },
       degradedScopes: () => this.cpDegradedScopes(),
       duties: () => this.dutyDigest(),
       dutyPending: () => this.pendingDutyAdmissions(),

--- a/packages/daemon/test/cp/client-duty.test.ts
+++ b/packages/daemon/test/cp/client-duty.test.ts
@@ -201,7 +201,8 @@ describe('daemon duty lease exchange', () => {
     // there is nothing local to resolve it from.
     expect(req?.orgId).toBe('org-1')
 
-    t.pushInbound(JSON.stringify(buildEnvelope('duty/fetch/ok', {}, { corr: req!.id as string })))
+    // The reply echoes the request org — a frame-mode member fences it on that.
+    t.pushInbound(JSON.stringify(buildEnvelope('duty/fetch/ok', {}, { corr: req!.id as string, orgId: 'org-1' })))
     await expect(done).resolves.toEqual({})
   })
 

--- a/packages/daemon/test/cp/client-frame-org.test.ts
+++ b/packages/daemon/test/cp/client-frame-org.test.ts
@@ -1,0 +1,248 @@
+// The daemon end of the frame-scoped organization contract (k8s-daemon-pool.md M4): on an
+// install-wide (frame-mode) connection the client refuses to send an org-scoped frame it cannot
+// scope, never stamps an org on an install-wide one, checks every inbound org-scoped control
+// against its own registry before applying it, and fences a correlated reply on the org of the
+// request it answers. On an org-scoped (API-key) connection none of that tightens.
+import { describe, it, expect, vi } from 'vitest'
+import { buildEnvelope } from '@agentconnect.md/protocol'
+import { CpClient, type CpClientDeps } from '../../src/cp/client.js'
+import { FakeTransport } from './fake-transport.js'
+import { FakeClock } from './fake-clock.js'
+
+const DAEMON_ID = '22222222-2222-4222-8222-222222222222'
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const UNKNOWN_AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa9'
+const CRON = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1'
+const ORG_A = 'org-a'
+const ORG_B = 'org-b'
+
+const tick = () => new Promise((r) => setImmediate(r))
+
+async function ready(mode: 'frame' | 'connection') {
+  const t = new FakeTransport()
+  const clock = new FakeClock()
+  const warn = vi.fn()
+  const runCron = vi.fn(() => ({ ok: true }))
+  const deps = {
+    url: 'wss://cp.example.test/daemon/ws',
+    token: 't',
+    daemonId: DAEMON_ID,
+    agentVersion: '0.0.0',
+    host: 'h',
+    heartbeatDefaultMs: 15_000,
+    maxAgents: 4,
+    capabilities: () => ({ platforms: [], runtimes: [], acp: true, features: [] }),
+    runtimeProfiles: () => [],
+    localState: () => ({ assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }),
+    loadSnapshot: () => ({ cpu: 0, mem: 0, agents: 0 }),
+    activeSessions: () => 0,
+    orgForAgent: (agentId: string) => (agentId === AGENT ? ORG_A : undefined),
+    orgForCron: (cronId: string) => (cronId === CRON ? ORG_A : undefined),
+    configApply: {
+      applyConfigPush() {},
+      applyReconcileSnapshot() {},
+      applyDutyGrant() {},
+      applyDutyRevoke() {},
+      upsertCron() {},
+      removeCron() {},
+      runCron,
+      applyRouteAssign() {},
+      applyRouteUpdate() {}
+    },
+    clock,
+    connect: async () => t,
+    log: { trace() {}, debug() {}, info() {}, warn, error() {} },
+    jitter: () => 0
+  } as unknown as CpClientDeps
+  const client = new CpClient(deps)
+  client.start()
+  await tick()
+  const auth = t.lastSent()
+  t.pushInbound(
+    JSON.stringify(
+      buildEnvelope(
+        'auth/ok',
+        {
+          daemonId: DAEMON_ID,
+          sessionEpoch: 1,
+          heartbeatSec: 15,
+          dutyLeaseMs: 120_000,
+          serverTime: '2026-08-14T00:00:00.000Z',
+          organizationMode: mode
+        },
+        { corr: auth.id }
+      )
+    )
+  )
+  await tick()
+  const reg = t.lastSent()
+  t.pushInbound(
+    JSON.stringify(
+      buildEnvelope(
+        'register/ok',
+        {
+          routingEpoch: 1,
+          serverFeatures: [],
+          assignments: [],
+          crons: [],
+          leases: [],
+          drop: { assignments: [], crons: [] }
+        },
+        { corr: reg.id }
+      )
+    )
+  )
+  await tick()
+  return { client, t, warn, runCron }
+}
+
+const sent = (t: FakeTransport) => t.sent.map((raw) => JSON.parse(raw))
+const errorsFor = (t: FakeTransport, corr: string) => sent(t).filter((f) => f.type === 'error' && f.corr === corr)
+
+/** Push one CP control frame and settle its dispatch. */
+async function control(t: FakeTransport, type: string, payload: unknown, orgId?: string): Promise<string> {
+  const frame = buildEnvelope(type as never, payload, { ...(orgId ? { orgId } : {}), ext: { epoch: 1 } })
+  t.pushInbound(JSON.stringify(frame))
+  await tick()
+  return frame.id
+}
+
+describe('frame mode: inbound controls', () => {
+  it('refuses an org-scoped control that names no org, and applies nothing', async () => {
+    const { t, warn, runCron } = await ready('frame')
+    const id = await control(t, 'cron/run', { cronId: CRON })
+    expect(errorsFor(t, id)).toMatchObject([{ payload: { code: 'SCOPE_DENIED' } }])
+    expect(runCron).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('refused cron/run'))
+  })
+
+  it('refuses a control naming an org that does not own the targeted resource', async () => {
+    const { t, runCron } = await ready('frame')
+    const id = await control(t, 'cron/run', { cronId: CRON }, ORG_B)
+    expect(errorsFor(t, id)).toMatchObject([
+      { payload: { code: 'SCOPE_DENIED', message: 'organization does not match the targeted resource' } }
+    ])
+    expect(runCron).not.toHaveBeenCalled()
+  })
+
+  it('applies a control naming the owning org and echoes it on the reply', async () => {
+    const { t, runCron } = await ready('frame')
+    const id = await control(t, 'cron/run', { cronId: CRON }, ORG_A)
+    expect(runCron).toHaveBeenCalledWith(CRON)
+    expect(sent(t).find((f) => f.type === 'ack' && f.corr === id)?.orgId).toBe(ORG_A)
+  })
+
+  it('refuses an install-wide control that carries an org', async () => {
+    const { t } = await ready('frame')
+    const id = await control(t, 'config/push', { keys: {} }, ORG_A)
+    expect(errorsFor(t, id)).toMatchObject([{ payload: { code: 'SCOPE_DENIED' } }])
+    const bare = await control(t, 'config/push', { keys: {} })
+    expect(errorsFor(t, bare)).toEqual([])
+  })
+
+  it('drops an uncorrelated generic reply without answering it', async () => {
+    const { t } = await ready('frame')
+    const before = sent(t).length
+    t.pushInbound(
+      JSON.stringify(buildEnvelope('error', { code: 'INTERNAL', message: 'late', retryable: false }, { corr: CRON }))
+    )
+    await tick()
+    expect(sent(t).length).toBe(before)
+  })
+})
+
+describe('frame mode: outbound frames', () => {
+  it('refuses to send an org-scoped frame it cannot scope', async () => {
+    const { client, t } = await ready('frame')
+    const before = sent(t).length
+    await expect(client.channelAgents({ platform: 'slack', requesterAgentId: UNKNOWN_AGENT })).rejects.toMatchObject({
+      code: 'SCOPE_DENIED'
+    })
+    expect(sent(t).length).toBe(before)
+  })
+
+  it('stamps the resolved org on an org-scoped frame and none on an install-wide one', async () => {
+    const { client, t } = await ready('frame')
+    void client.channelAgents({ platform: 'slack', requesterAgentId: AGENT }).catch(() => {})
+    void client.claimDuty(AGENT).catch(() => {})
+    await tick()
+    expect(sent(t).find((f) => f.type === 'channel/agents')?.orgId).toBe(ORG_A)
+    // The claim names an agent this member knows, and still carries no org: duty frames are install-wide.
+    expect(sent(t).find((f) => f.type === 'duty/claim')).toMatchObject({ payload: { agentId: AGENT } })
+    expect(sent(t).find((f) => f.type === 'duty/claim')?.orgId).toBeUndefined()
+  })
+})
+
+describe('frame mode: correlated replies', () => {
+  it('fails the request when the reply does not carry its org, and never resolves it', async () => {
+    const { client, t, warn } = await ready('frame')
+    const pending = client.fetchDutyAgent(AGENT, ORG_A)
+    await tick()
+    const req = sent(t).find((f) => f.type === 'duty/fetch')!
+    expect(req.orgId).toBe(ORG_A)
+    t.pushInbound(JSON.stringify(buildEnvelope('duty/fetch/ok', {}, { corr: req.id })))
+    await expect(pending).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('dropped duty/fetch/ok reply'))
+  })
+
+  it('fails the request when the reply names another org', async () => {
+    const { client, t } = await ready('frame')
+    const pending = client.fetchDutyAgent(AGENT, ORG_A)
+    await tick()
+    const req = sent(t).find((f) => f.type === 'duty/fetch')!
+    t.pushInbound(JSON.stringify(buildEnvelope('duty/fetch/ok', {}, { corr: req.id, orgId: ORG_B })))
+    await expect(pending).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
+  })
+
+  it('settles the request when the reply carries its org; an error reply needs none', async () => {
+    const { client, t } = await ready('frame')
+    const pending = client.fetchDutyAgent(AGENT, ORG_A)
+    await tick()
+    const req = sent(t).find((f) => f.type === 'duty/fetch')!
+    t.pushInbound(JSON.stringify(buildEnvelope('duty/fetch/ok', {}, { corr: req.id, orgId: ORG_A })))
+    await expect(pending).resolves.toEqual({})
+    const failing = client.fetchDutyAgent(AGENT, ORG_A)
+    await tick()
+    const req2 = sent(t)
+      .filter((f) => f.type === 'duty/fetch')
+      .at(-1)!
+    t.pushInbound(
+      JSON.stringify(
+        buildEnvelope('error', { code: 'LEASE_DENIED', message: 'no', retryable: false }, { corr: req2.id })
+      )
+    )
+    await expect(failing).rejects.toMatchObject({ code: 'LEASE_DENIED' })
+  })
+
+  it('a reply to an install-wide request must not name an org', async () => {
+    const { client, t } = await ready('frame')
+    const pending = client.claimDuty(AGENT)
+    await tick()
+    const req = sent(t).find((f) => f.type === 'duty/claim')!
+    t.pushInbound(JSON.stringify(buildEnvelope('duty/claim/ok', { granted: false }, { corr: req.id, orgId: ORG_A })))
+    await expect(pending).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
+  })
+})
+
+describe('connection mode (API key): unchanged', () => {
+  it('applies an unscoped control and takes an install-wide control that names the org', async () => {
+    const { t, runCron } = await ready('connection')
+    const bare = await control(t, 'cron/run', { cronId: CRON })
+    expect(errorsFor(t, bare)).toEqual([])
+    expect(runCron).toHaveBeenCalledWith(CRON)
+    const push = await control(t, 'config/push', { keys: {} }, ORG_A)
+    expect(errorsFor(t, push)).toEqual([])
+  })
+
+  it('sends an org-scoped frame for an agent it cannot place in an org, and settles an org-less reply', async () => {
+    const { client, t } = await ready('connection')
+    const pending = client.channelAgents({ platform: 'slack', requesterAgentId: UNKNOWN_AGENT })
+    await tick()
+    const req = sent(t).find((f) => f.type === 'channel/agents')!
+    expect(req.orgId).toBeUndefined()
+    t.pushInbound(
+      JSON.stringify(buildEnvelope('channel/agents/ok', { platform: 'slack', agents: [] }, { corr: req.id }))
+    )
+    await expect(pending).resolves.toEqual({ platform: 'slack', agents: [] })
+  })
+})

--- a/packages/protocol/src/frame-scope.test.ts
+++ b/packages/protocol/src/frame-scope.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { FRAME_TYPES } from './frame.js'
+import {
+  INSTALL_WIDE_FRAME_TYPES,
+  GENERIC_REPLY_FRAME_TYPES,
+  checkInboundFrameOrg,
+  checkReplyFrameOrg,
+  isInstallWideFrameType
+} from './frame-scope.js'
+
+const FRAME = { mode: 'frame', orgId: null } as const
+const CONN = { mode: 'connection', orgId: 'org-a' } as const
+
+describe('frame-scope: which frames carry an organization', () => {
+  it('classifies every wire frame type as install-wide, generic reply, or org-scoped', () => {
+    for (const type of INSTALL_WIDE_FRAME_TYPES) expect(FRAME_TYPES).toContain(type)
+    for (const type of GENERIC_REPLY_FRAME_TYPES) expect(FRAME_TYPES).toContain(type)
+    const orgScoped = FRAME_TYPES.filter((t) => !isInstallWideFrameType(t) && !GENERIC_REPLY_FRAME_TYPES.has(t))
+    // The org-scoped families the daemon and CP exchange today; a new type lands here unless listed above.
+    for (const t of ['agent/upsert', 'duty/fetch', 'duty/fetch/ok', 'event/session', 'hook/report', 'session/list'])
+      expect(orgScoped).toContain(t)
+    for (const t of ['heartbeat', 'register/ok', 'duty/claim', 'agent/exists/ok', 'drain/done'])
+      expect(isInstallWideFrameType(t)).toBe(true)
+  })
+
+  describe('inbound gate, frame mode', () => {
+    it('requires the org on an org-scoped frame', () => {
+      expect(checkInboundFrameOrg({ type: 'event/session' }, FRAME)).toMatchObject({ ok: false })
+      expect(checkInboundFrameOrg({ type: 'event/session', orgId: 'org-a' }, FRAME)).toEqual({ ok: true })
+    })
+    it('forbids the org on an install-wide frame', () => {
+      expect(checkInboundFrameOrg({ type: 'heartbeat', orgId: 'org-a' }, FRAME)).toMatchObject({ ok: false })
+      expect(checkInboundFrameOrg({ type: 'heartbeat' }, FRAME)).toEqual({ ok: true })
+    })
+    it('lets an uncorrelated generic reply through to be dropped, never answered', () => {
+      expect(checkInboundFrameOrg({ type: 'error' }, FRAME)).toEqual({ ok: true })
+      expect(checkInboundFrameOrg({ type: 'ack', orgId: 'org-a' }, FRAME)).toEqual({ ok: true })
+    })
+  })
+
+  describe('inbound gate, connection mode', () => {
+    it('accepts a missing org and the connection org, refuses another', () => {
+      expect(checkInboundFrameOrg({ type: 'event/session' }, CONN)).toEqual({ ok: true })
+      expect(checkInboundFrameOrg({ type: 'event/session', orgId: 'org-a' }, CONN)).toEqual({ ok: true })
+      expect(checkInboundFrameOrg({ type: 'heartbeat', orgId: 'org-a' }, CONN)).toEqual({ ok: true })
+      expect(checkInboundFrameOrg({ type: 'event/session', orgId: 'org-b' }, CONN)).toMatchObject({ ok: false })
+    })
+    it('checks nothing when the peer does not know the bound org', () => {
+      const peer = { mode: 'connection', orgId: null } as const
+      expect(checkInboundFrameOrg({ type: 'agent/upsert', orgId: 'org-b' }, peer)).toEqual({ ok: true })
+    })
+  })
+
+  describe('reply gate', () => {
+    const req = { type: 'session/list', orgId: 'org-a' }
+    it('frame mode: a typed reply carries exactly the request org', () => {
+      expect(checkReplyFrameOrg(req, { type: 'session/list/page', orgId: 'org-a' }, FRAME)).toEqual({ ok: true })
+      expect(checkReplyFrameOrg(req, { type: 'session/list/page' }, FRAME)).toMatchObject({ ok: false })
+      expect(checkReplyFrameOrg(req, { type: 'session/list/page', orgId: 'org-b' }, FRAME)).toMatchObject({ ok: false })
+      expect(checkReplyFrameOrg(req, { type: 'ack', orgId: 'org-a' }, FRAME)).toEqual({ ok: true })
+      expect(checkReplyFrameOrg(req, { type: 'ack' }, FRAME)).toMatchObject({ ok: false })
+    })
+    it('frame mode: a reply to an install-wide request carries none', () => {
+      const claim = { type: 'duty/claim' }
+      expect(checkReplyFrameOrg(claim, { type: 'duty/claim/ok' }, FRAME)).toEqual({ ok: true })
+      expect(checkReplyFrameOrg(claim, { type: 'duty/claim/ok', orgId: 'org-a' }, FRAME)).toMatchObject({ ok: false })
+    })
+    it('an error reply may omit the org but must not name another', () => {
+      expect(checkReplyFrameOrg(req, { type: 'error' }, FRAME)).toEqual({ ok: true })
+      expect(checkReplyFrameOrg(req, { type: 'error', orgId: 'org-a' }, FRAME)).toEqual({ ok: true })
+      expect(checkReplyFrameOrg(req, { type: 'error', orgId: 'org-b' }, FRAME)).toMatchObject({ ok: false })
+      expect(checkReplyFrameOrg(req, { type: 'error', orgId: 'org-b' }, CONN)).toMatchObject({ ok: false })
+    })
+    it('connection mode: an org present must be the request org and the connection org; absent is fine', () => {
+      expect(checkReplyFrameOrg(req, { type: 'session/list/page' }, CONN)).toEqual({ ok: true })
+      expect(checkReplyFrameOrg(req, { type: 'session/list/page', orgId: 'org-a' }, CONN)).toEqual({ ok: true })
+      expect(checkReplyFrameOrg(req, { type: 'session/list/page', orgId: 'org-b' }, CONN)).toMatchObject({ ok: false })
+      expect(
+        checkReplyFrameOrg({ type: 'session/list' }, { type: 'session/list/page', orgId: 'org-b' }, CONN)
+      ).toMatchObject({ ok: false })
+    })
+  })
+})

--- a/packages/protocol/src/frame-scope.ts
+++ b/packages/protocol/src/frame-scope.ts
@@ -1,0 +1,108 @@
+// Which daemon↔CP frames carry an organization (k8s-daemon-pool.md M4, daemon-cp-ws-protocol.md §1.1).
+import type { FrameType } from './frame.js'
+
+// Frames about the member or the whole install: they name no organization, and on an install-wide
+// connection they must not carry one. Duty groups span orgs on one member (grants carry a per-entry
+// org); the reconciler's existence query spans every org. Everything else is org-scoped.
+export const INSTALL_WIDE_FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameType>([
+  'auth',
+  'auth/ok',
+  'register',
+  'register/ok',
+  'daemon/bootstrap/result',
+  'capabilities/update',
+  'heartbeat',
+  'facts/runtime-profile',
+  'facts/daemon-runtimes',
+  'facts/memory-connections',
+  'relay/roster',
+  'collaboration/routes',
+  'daemon/drain',
+  'drain/progress',
+  'drain/done',
+  'daemon/restart',
+  'daemon/upgrade',
+  'daemon/control/ack',
+  'config/push',
+  'duty/grant',
+  'duty/renewed',
+  'duty/revoke',
+  'duty/release',
+  'duty/claim',
+  'duty/claim/ok',
+  'agent/exists',
+  'agent/exists/ok'
+])
+
+// Generic replies inherit their request's scope; one that correlates to nothing names nothing and is dropped.
+export const GENERIC_REPLY_FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameType>(['ack', 'error'])
+
+export function isInstallWideFrameType(type: string): boolean {
+  return INSTALL_WIDE_FRAME_TYPES.has(type as FrameType)
+}
+
+/** `connection`: one org bound at auth (API key). `frame`: an install-wide member, every org-scoped frame names its org. */
+export type OrganizationMode = 'connection' | 'frame'
+
+/** The receiving end of a connection: its mode and, on a `connection`-mode peer that knows it, the bound org. */
+export interface FrameOrgPeer {
+  mode: OrganizationMode
+  orgId: string | null
+}
+
+export interface FrameOrgRef {
+  type: string
+  orgId?: string | undefined
+}
+
+export type FrameOrgVerdict = { ok: true } | { ok: false; message: string }
+
+const OK: FrameOrgVerdict = { ok: true }
+
+/**
+ * The connection-layer org gate for an uncorrelated inbound frame. Frame mode: an org-scoped frame
+ * must name its org, an install-wide frame must not. Connection mode: an org named must be the
+ * connection's. Whether the org owns the targeted resource is the receiver's check, after this one.
+ */
+export function checkInboundFrameOrg(frame: FrameOrgRef, peer: FrameOrgPeer): FrameOrgVerdict {
+  if (GENERIC_REPLY_FRAME_TYPES.has(frame.type as FrameType)) return OK
+  if (peer.mode === 'connection') {
+    if (frame.orgId && peer.orgId && frame.orgId !== peer.orgId) {
+      return { ok: false, message: 'organization does not match authenticated connection' }
+    }
+    return OK
+  }
+  if (isInstallWideFrameType(frame.type)) {
+    return frame.orgId ? { ok: false, message: `${frame.type} is install-wide and must not carry an organization` } : OK
+  }
+  return frame.orgId ? OK : { ok: false, message: 'organization is required on an install-wide connection' }
+}
+
+/**
+ * The org gate for a correlated reply, checked against the request it settles. Frame mode: a typed
+ * reply carries exactly the request's org (none for an install-wide request). Connection mode: an
+ * org present must match the request's and the connection's. An `error` reply names no resource,
+ * so it may omit the org, but one it carries must still be the request's.
+ */
+export function checkReplyFrameOrg(request: FrameOrgRef, reply: FrameOrgRef, peer: FrameOrgPeer): FrameOrgVerdict {
+  if (reply.type === 'error') {
+    if (reply.orgId && request.orgId && reply.orgId !== request.orgId) {
+      return { ok: false, message: `error reply to ${request.type} names another organization` }
+    }
+    return OK
+  }
+  if (peer.mode === 'frame') {
+    if (request.orgId) {
+      if (reply.orgId === request.orgId) return OK
+      return { ok: false, message: `${reply.type} does not carry the organization of the ${request.type} it answers` }
+    }
+    if (reply.orgId) {
+      return { ok: false, message: `${reply.type} answers install-wide ${request.type} but names an organization` }
+    }
+    return OK
+  }
+  if (reply.orgId && ((request.orgId && reply.orgId !== request.orgId) || (peer.orgId && reply.orgId !== peer.orgId))) {
+    return { ok: false, message: `${reply.type} names another organization than the ${request.type} it answers` }
+  }
+  return OK
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -104,6 +104,16 @@ export { isFrameType as isKnownFrameType }
 export { decodeEnvelope, buildEnvelope, encode, MAX_FRAME_BYTES } from './codec.js'
 export type { DecodeResult, BuildOpts, InboundControlExt } from './codec.js'
 
+// ── which frames carry an organization (k8s-daemon-pool.md M4) ──
+export {
+  INSTALL_WIDE_FRAME_TYPES,
+  GENERIC_REPLY_FRAME_TYPES,
+  isInstallWideFrameType,
+  checkInboundFrameOrg,
+  checkReplyFrameOrg
+} from './frame-scope.js'
+export type { OrganizationMode, FrameOrgPeer, FrameOrgRef, FrameOrgVerdict } from './frame-scope.js'
+
 // ── relay wires (separate frame unions; shared-bot-relay.md §7/§8) ──
 export * from './frames/relay-cp.js'
 // Manifest-declared Slack shortcut id — defined in the bundler-facing


### PR DESCRIPTION
## Summary

Closes the first open M4 bullet of #955: **a frame-mode connection requires `orgId` on every org-scoped request, event, control frame and correlated reply, and both peers validate the frame org against the targeted resource.**

Most of the machinery already existed after #930 / #965 / #996 / #1066 — the daemon's `scopedFrame`, the CP's `gateOrganization`, `frameOrgId(frame, conn)` and the scoped handler reads. What was missing was the contract itself and its edges:

- the two peers kept **two different, hand-maintained lists** of install-wide frame types (the daemon's covered only C→D types);
- an install-wide frame **carrying** an org was accepted on a frame-mode connection whenever the registry could not resolve a target;
- **correlated replies bypassed the org gate entirely** on both peers — a `session/list/page`, `duty/fetch/ok`, `gitcred/grant`, … was settled without any check that it carried (or matched) the org of the request it answered;
- `hook/report` and `hook/start` reached their repositories without the frame org (the other hook/GitHub frames already checked it in the broker);
- an uncorrelated `error` on a frame-mode connection was answered with a `SCOPE_DENIED` error, which the other peer answered again — a `SCOPE_DENIED` ping-pong between two peers (only reachable when a stray error correlates to nothing, but structural);
- the daemon refused mis-scoped inbound controls silently (error frame, no log) and could not scope a `cron/*` control at all.

## The contract (`packages/protocol/src/frame-scope.ts`, both peers)

Every frame type on the daemon↔CP wire is one of three things. The classification lives in the protocol package once and both peers import it (`INSTALL_WIDE_FRAME_TYPES`, `GENERIC_REPLY_FRAME_TYPES`, `checkInboundFrameOrg`, `checkReplyFrameOrg`).

| Class | Frame types | Frame-mode (install-wide member) | Connection-mode (API key) |
| --- | --- | --- | --- |
| **install-wide** | `auth`, `auth/ok`, `register`, `register/ok`, `daemon/bootstrap/result`, `capabilities/update`, `heartbeat`, `facts/runtime-profile`, `facts/daemon-runtimes`, `facts/memory-connections`, `relay/roster`, `collaboration/routes`, `daemon/drain`, `drain/progress`, `drain/done`, `daemon/restart`, `daemon/upgrade`, `daemon/control/ack`, `config/push`, `duty/grant`, `duty/renewed`, `duty/revoke`, `duty/release`, `duty/claim`, `duty/claim/ok`, `agent/exists`, `agent/exists/ok` | must **not** carry `orgId` → `SCOPE_DENIED` if it does | may carry the connection's org (the CP already stamps it on every downlink frame); another org → `SCOPE_DENIED` |
| **org-scoped** (requests, events, control, typed replies) | `agent/*` lifecycle, launch, permission, wake; `route/assign`, `route/assign/ack`, `route/update`; `cron/*`; `hook/*`, `github/review-*`; `integration/*`; `mcpserver/*`; `memoryconnection/*`; `gitcred/*`; `secrets/*`, `scope-attestation`; `webchat/mcp-grant/*`; `event/session*`, `usage/report`; `session/*` (list/history/tool-body/child-status/visibility); `channel/agents`; `workspace/*`; `task/list`; `memory/*`, `memory/dream/*`, `skills/local`; `knowledge/*`, `skills/org`, `managed-skill/*`; `duty/fetch`, `duty/fetch/ok` | must carry `orgId` → `SCOPE_DENIED` if absent; the receiver checks it against the targeted resource (CP: connection `id → org` maps + the handler's scoped read; daemon: its agent / integration / cron registries) → `SCOPE_DENIED` on mismatch, never applied | may omit it (the org is the connection's); if present must equal the connection's |
| **generic replies** | `ack`, `error` | scope is the request's; uncorrelated → dropped, never answered | same |

**Correlated replies** carry the org of the request they answer. Frame mode: a typed reply must carry exactly that org (none for an install-wide request); the receiver fails the pending request with `SCOPE_DENIED` and applies nothing when it does not. An `error` reply names no resource, so it may omit the org, but one it carries must be the request's. Connection mode: an org present on a reply must match the request's and the connection's; a reply that omits it still settles (an older API-key daemon may not echo it).

The envelope keeps `orgId` optional at the zod level: whether a given frame needs it depends on the connection's mode, which the schema cannot see, so the requirement is enforced by the shared checks at both decode edges instead of by a per-mode envelope schema. `orgId` is required on org-scoped frames in frame mode as of #930 (both peers landed the field and its echo together), so nothing older has to keep working on that path.

## What changed

**protocol**
- New `frame-scope.ts` — the classification and the two checks above; exported from the package root. `codec.test`-style unit tests cover every branch and pin that every wire type is classified.

**control-plane**
- `ws/connection.ts` — the gate is now the shared `checkInboundFrameOrg` (org required on org-scoped, forbidden on install-wide, connection-bound in connection mode) followed by the existing registry target check. Correlated replies are fenced with `checkReplyFrameOrg` against the pending request (`ReqRep.requested(corr)`) **before** they settle; a mis-scoped reply rejects the request with `SCOPE_DENIED` and is logged. Outbound: an install-wide frame to a frame-mode member never carries an org, whatever a caller passes.
- `ws/correlator.ts` — remembers each REQ's `type` / `orgId`; `requested(corr)`.
- `ws/handlers/hook-report.ts`, `hook-start.ts`, `github/review-broker.service.ts#start` — fenced on `frameOrgId`: the hook / accepted run must be in the org the frame acts in (`SCOPE_DENIED` otherwise; the unknown-hook path answers the same code now instead of `CONFLICT` — both are permanent, the daemon dead-letters either).

**daemon**
- `cp/client.ts` — imports the shared classification (drops its own C→D-only list). `scopedFrame` never stamps an org on an install-wide frame (a `duty/claim` for a directory-known agent used to carry one) and still throws `SCOPE_DENIED` for an org-scoped frame it cannot scope in frame mode. Inbound controls go through `checkInboundFrameOrg`, then the registry check (`orgForAgent` / `orgForIntegration` / new `orgForCron`); every refusal is logged and answered with an error, never applied. Correlated replies are fenced on the request org before they settle, rejecting the request with `SCOPE_DENIED`.
- `cp/cp-cron.ts#agentForCron`, `daemon.ts` wires `orgForCron`.
- `@agentconnect.md/connection` `ReqRep` — remembers the REQ; `requested(corr)`.

**docs** — `org-scoped-data-layer.md` gains §4.1 (the frame contract); the M4 paragraph in `k8s-daemon-pool.md` and §1.1 of `daemon-cp-ws-protocol.md` point at it.

## Rollout note

One wire-visible tightening affects an **older frame-mode member talking to a newer CP** during a rollout window: such a member stamped an org on `duty/claim` whenever the claimed agent was already in its collaboration directory, and the new CP refuses an install-wide frame that carries an org. The claim fails for that member until it is replaced (members roll with the CP on the deployment side); a newer member against an older CP is unaffected. No API-key connection behavior changes.

## Test plan

- [x] `packages/protocol` — new `frame-scope.test.ts` (10) + full suite (345)
- [x] `packages/connection` — full suite (27)
- [x] `packages/control-plane` — `test/protocol/fencing.test.ts` (unit, +12: install-wide+org refused, uncorrelated error dropped, reply org gate in both modes) and new `test/protocol/frame-org.handler.test.ts` (integration over `build-ws`: ten org-scoped families without org / wrong org ⇒ `SCOPE_DENIED`, right org reaches the handler and the reply echoes it, install-wide+org refused, hook checked through the scoped read, reply without org fails the request, API-key connection unchanged); full `test:unit` and `test:int` (92 files, 1381 tests)
- [x] `packages/daemon` — new `test/cp/client-frame-org.test.ts` (13: inbound refusals with log lines and no application, outbound refusal / stamping, reply fence, connection mode unchanged); full daemon suite
- [x] `pnpm typecheck` for protocol / connection / control-plane / daemon, `pnpm lint`, `pnpm format:check`

Part of #955 (M4).
