### PR TITLE
test: deflake the timing-based daemon and control-plane suites

### DIFF
--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -1097,8 +1097,8 @@ describe('session visibility — PUT /sessions/:id/visibility (§4.3)', () => {
         SELECT count(*)::int AS n FROM pg_stat_activity
         WHERE datname = current_database() AND wait_event_type = 'Lock'`
       if ((waiters[0]?.n ?? 0) > 0) break
-      if (i > 400) throw new Error('the queued PUT never blocked on the row lock')
-      await new Promise((resolve) => setTimeout(resolve, 25))
+      if (i > 2_000) throw new Error('the queued PUT never blocked on the row lock')
+      await new Promise((resolve) => setTimeout(resolve, 10))
     }
     commitTighten()
     await tighten

--- a/packages/control-plane/test/integration/slack-platform-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-platform-install.route.test.ts
@@ -4,7 +4,7 @@
  * the unauthenticated OAuth callback (create / re-install / cross-org refusal),
  * and the revocation path from `rc/bot-revoked`.
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
@@ -21,6 +21,23 @@ import type {
   SlackOAuthExchangeResult,
   SlackRotateResult
 } from '../../src/http/slack-config-api.js'
+
+/** Wait until a backend is genuinely queued on a row lock — the interleaving each race below is
+ *  written for. Sleeping a fixed guess instead runs a DIFFERENT interleaving whenever the runner
+ *  is slower than the guess, silently, and the race the test names then goes uncovered. */
+async function awaitLockWaiter(): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const rows = await prisma.$queryRaw<Array<{ waiting: bigint }>>`
+        SELECT count(*)::bigint AS "waiting"
+        FROM pg_stat_activity
+        WHERE datname = current_database() AND wait_event_type = 'Lock'
+      `
+      expect(Number(rows[0]?.waiting ?? 0n)).toBeGreaterThanOrEqual(1)
+    },
+    { timeout: 20_000, interval: 10 }
+  )
+}
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 const PLATFORM = {
@@ -782,7 +799,7 @@ describe('GET /integrations/slack/platform/callback', () => {
     // The toggle: its optimistic pre-check reads ONE member (the review's stale
     // snapshot), then blocks on the row lock inside setShareable.
     const toggle = app.app.inject({ method: 'PATCH', url: `${ORG}/bots/${bot.id}`, payload: { shareable: false } })
-    await new Promise((resolve) => setTimeout(resolve, 150)) // let the toggle reach the lock
+    await awaitLockWaiter() // the toggle is on the lock, so the admission below really is the loser
     admit()
     await admission
     const res = await toggle
@@ -1059,7 +1076,7 @@ describe('GET /integrations/slack/platform-install/:id (completion signal)', () 
       url: `${ORG}/integrations`,
       payload: { platform: 'slack', agentId: target, botId }
     })
-    await new Promise((resolve) => setTimeout(resolve, 150))
+    await awaitLockWaiter()
     disable()
     await winner
     const res = await reuse
@@ -1091,7 +1108,7 @@ describe('GET /integrations/slack/platform-install/:id (completion signal)', () 
       url: `${ORG}/integrations`,
       payload: { platform: 'slack', agentId: target, botId }
     })
-    await new Promise((resolve) => setTimeout(resolve, 150))
+    await awaitLockWaiter()
     admitOther()
     await winner
     const res = await reuse
@@ -1125,7 +1142,7 @@ describe('GET /integrations/slack/platform-install/:id (completion signal)', () 
       url: `${ORG}/integrations`,
       payload: { platform: 'slack', agentId: target, botId }
     })
-    await new Promise((resolve) => setTimeout(resolve, 150))
+    await awaitLockWaiter()
     revoke()
     await winner
     const res = await reuse

--- a/packages/control-plane/test/social-identity-mutation-gate.test.ts
+++ b/packages/control-plane/test/social-identity-mutation-gate.test.ts
@@ -21,7 +21,9 @@ function deferred() {
 }
 
 async function waitForBlockedAdvisoryLock(): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt++) {
+  // A generous ceiling on purpose: the poll ends the moment the waiter appears, so the only
+  // thing a bigger bound buys is not failing a correct run on a runner that scheduled slowly.
+  for (let attempt = 0; attempt < 1_000; attempt++) {
     const [row] = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
       SELECT COUNT(*)::int AS "count"
       FROM pg_locks

--- a/packages/daemon/test/daemon-duty-drain.test.ts
+++ b/packages/daemon/test/daemon-duty-drain.test.ts
@@ -9,6 +9,8 @@ import { join } from 'node:path'
 import type { DutyGrantEntry } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import type { DutyRegistry } from '../src/cp/duty-registry.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { VirtualClock, runVirtual, settle as flush } from './fakes/virtual-clock.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const AGENT_B = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
@@ -43,9 +45,12 @@ const bundle = (agentId: string, name: string) => ({
   crons: []
 })
 
-/** A frame-scope member holding two single-agent groups, with an instrumented stub CP client. */
+/** A frame-scope member holding two single-agent groups, with an instrumented stub CP client.
+ *  Every deadline the drain measures — the budget, the release backoff, the "still busy" sleep —
+ *  runs on the injected clock, so a test skips them in virtual time instead of sleeping them. */
 async function boot(opts: { releaseDuties?: (groupIds: string[]) => Promise<void> } = {}) {
-  const daemon = new Daemon({ root: scaffold() })
+  const clock = new VirtualClock()
+  const daemon = new Daemon({ root: scaffold(), slackAppFactory: fakeSlackAppFactory(), clock })
   await daemon.start()
   const calls: { order: string[]; releases: string[][] } = { order: [], releases: [] }
   const releaseDuties = vi.fn(async (groupIds: string[]) => {
@@ -70,7 +75,7 @@ async function boot(opts: { releaseDuties?: (groupIds: string[]) => Promise<void
   }
   await (daemon as any).admitDutyGrants([grant(GROUP, AGENT), grant(GROUP_B, AGENT_B)])
   expect(duties(daemon).groupIds().sort()).toEqual([GROUP, GROUP_B])
-  return { daemon, calls, releaseDuties, stop, reportDutiesNow }
+  return { daemon, clock, calls, releaseDuties, stop, reportDutiesNow }
 }
 
 const duties = (d: Daemon) => (d as any).duties as DutyRegistry
@@ -135,7 +140,7 @@ describe('shutdown drain of a duty-holding member', () => {
 
   it('a late grant is not acknowledged while the loop is still waiting on a busy group', async () => {
     const LATE = '11111111-1111-4111-8111-111111111113'
-    const { daemon, calls } = await boot()
+    const { daemon, clock, calls } = await boot()
     const settle = (daemon as any).beginActiveDispatch(AGENT, 'slack:C1:T2') as () => void
     const cancel = vi.fn(async () => {})
     ;(daemon as any).hosts.set(AGENT, { stop: vi.fn(async () => {}), cancel })
@@ -147,14 +152,16 @@ describe('shutdown drain of a duty-holding member', () => {
       { ...grant(GROUP, AGENT), term: '2' }
     ])
     await vi.waitFor(() => expect(calls.releases).toEqual([[GROUP_B]]))
-    await new Promise((resolve) => setTimeout(resolve, 150))
+    // The loop is now parked on its "still busy" deadline, which is virtual and unfired, so
+    // draining the macrotask queue is proof that nothing further CAN happen — not a guess.
+    await flush()
     // Nothing late is acknowledged, the busy group is still held at its old term, its turn untouched.
     expect(calls.releases).toEqual([[GROUP_B]])
     expect(duties(daemon).get(GROUP)?.term).toBe('1')
     expect(cancel).not.toHaveBeenCalled()
 
     settle()
-    await stopping
+    await runVirtual(clock, stopping)
     // The loop releases GROUP after its turn; only then the late grants (GROUP again is idempotent).
     expect(calls.releases.slice(0, 2)).toEqual([[GROUP_B], [GROUP]])
     expect(
@@ -202,7 +209,7 @@ describe('shutdown drain of a duty-holding member', () => {
       cancel: vi.fn(async () => {})
     })
     ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await flush()
     const warn = vi.spyOn((daemon as any).log, 'warn')
 
     const stopping = daemon.stop()
@@ -219,7 +226,7 @@ describe('shutdown drain of a duty-holding member', () => {
       const { daemon, calls } = await boot()
       // Only GROUP is held, so the loop has nothing to do once it is revoked.
       ;(daemon as any).applyDutyRevoke([{ groupId: GROUP_B, reason: 'gone' }])
-      await new Promise((resolve) => setTimeout(resolve, 20))
+      await flush()
       let finishReconcile!: () => void
       const gate = new Promise<void>((resolve) => {
         finishReconcile = resolve
@@ -234,7 +241,7 @@ describe('shutdown drain of a duty-holding member', () => {
 
       const stopping = daemon.stop()
       ;(daemon as any).applyDutyGrant([{ ...grant(GROUP, AGENT), term: '2' }])
-      await new Promise((resolve) => setTimeout(resolve, 200))
+      await flush()
       // Loop done at once (nothing held), host long gone — still no ack while the socket teardown pends.
       expect(calls.releases).toEqual([])
 
@@ -244,17 +251,18 @@ describe('shutdown drain of a duty-holding member', () => {
     }
     // Never confirmed: lapses.
     {
-      const { daemon, calls } = await boot()
+      const { daemon, clock, calls } = await boot()
       ;(daemon as any).cfg.limits.poolShutdownDrainMs = 1_500
       ;(daemon as any).applyDutyRevoke([{ groupId: GROUP_B, reason: 'gone' }])
-      await new Promise((resolve) => setTimeout(resolve, 20))
+      await flush()
       ;(daemon as any).runReconcile = () => new Promise<void>(() => {})
       ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
       const warn = vi.spyOn((daemon as any).log, 'warn')
 
       const stopping = daemon.stop()
       ;(daemon as any).applyDutyGrant([{ ...grant(GROUP, AGENT), term: '2' }])
-      await stopping
+      // The 1.5s budget is the thing under test, so it is elapsed in virtual time, not slept.
+      await runVirtual(clock, stopping, 2_000)
 
       expect(calls.releases).toEqual([])
       expect(warn.mock.calls.some(([m]) => /late grant .* connection teardown unconfirmed/.test(String(m)))).toBe(true)
@@ -268,7 +276,7 @@ describe('shutdown drain of a duty-holding member', () => {
     ;(daemon as any).applyDutyGrant([
       grant('11111111-1111-4111-8111-111111111114', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4')
     ])
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await flush()
     expect(admit).not.toHaveBeenCalled()
     expect(releaseDuties).not.toHaveBeenCalled()
     ;(daemon as any).dutyClaimsSuspended = false
@@ -316,14 +324,15 @@ describe('shutdown drain of a duty-holding member', () => {
   })
 
   it('a group whose teardown cannot be confirmed by the deadline is not released — its lease is left to lapse', async () => {
-    const { daemon, releaseDuties } = await boot()
+    const { daemon, clock, releaseDuties } = await boot()
     ;(daemon as any).cfg.limits.poolShutdownDrainMs = 1_500
     // The reconcile that carries the connection convergence never finishes.
     ;(daemon as any).runReconcile = () => new Promise<void>(() => {})
     const info = vi.spyOn((daemon as any).log, 'info')
     const warn = vi.spyOn((daemon as any).log, 'warn')
 
-    await daemon.stop()
+    // The budget it never confirms within is elapsed in virtual time.
+    await runVirtual(clock, daemon.stop(), 2_000)
 
     expect(releaseDuties).not.toHaveBeenCalled()
     expect(warn.mock.calls.some(([m]) => /not released, its lease lapses/.test(String(m)))).toBe(true)
@@ -334,7 +343,7 @@ describe('shutdown drain of a duty-holding member', () => {
   })
 
   it('a busy group waits for its turn to finish while idle groups are released at once — no turn is cancelled', async () => {
-    const { daemon, calls } = await boot()
+    const { daemon, clock, calls } = await boot()
     // Agent A owns admitted work: an active dispatch lease, exactly what a running turn holds.
     const settle = (daemon as any).beginActiveDispatch(AGENT, 'slack:C1:T1') as () => void
     const cancel = vi.fn(async () => {})
@@ -343,19 +352,21 @@ describe('shutdown drain of a duty-holding member', () => {
     const stopping = daemon.stop()
     // Group B (idle) goes immediately; group A is still held while its turn runs.
     await vi.waitFor(() => expect(calls.releases).toEqual([[GROUP_B]]))
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    // Parked on the loop's virtual "still busy" deadline: draining the queue settles everything
+    // that could still happen, so the negative assertions below are exhaustive rather than timed.
+    await flush()
     expect(duties(daemon).groupIds()).toEqual([GROUP])
     expect(cancel).not.toHaveBeenCalled()
 
     settle()
-    await stopping
+    await runVirtual(clock, stopping)
     expect(calls.releases).toEqual([[GROUP_B], [GROUP]])
     expect(cancel).not.toHaveBeenCalled()
     expect(calls.order.at(-1)).toBe('socket-close')
   })
 
   it('a release the CP never acknowledges is retried until the drain deadline, then counted and left to lapse', async () => {
-    const { daemon, releaseDuties } = await boot({
+    const { daemon, clock, releaseDuties } = await boot({
       releaseDuties: async () => {
         throw new Error('control plane unreachable (client DEGRADED)')
       }
@@ -364,9 +375,11 @@ describe('shutdown drain of a duty-holding member', () => {
     const info = vi.spyOn((daemon as any).log, 'info')
     const warn = vi.spyOn((daemon as any).log, 'warn')
 
-    const startedAt = Date.now()
-    await daemon.stop()
-    const elapsed = Date.now() - startedAt
+    const startedAt = clock.now()
+    // Budget and backoff both run on the injected clock, so the ladder below is exercised in
+    // virtual time — and the bound is asserted against that clock, never against the wall one.
+    await runVirtual(clock, daemon.stop(), 3_000)
+    const elapsed = clock.now() - startedAt
 
     // Retried (1s backoff, then 2s would overrun) and bounded by the budget, not by the retries.
     expect(releaseDuties.mock.calls.length).toBeGreaterThanOrEqual(2)
@@ -380,7 +393,7 @@ describe('shutdown drain of a duty-holding member', () => {
   })
 
   it('an org-scoped daemon is not duty-governed and stops as before — no digest bit, no release', async () => {
-    const daemon = new Daemon({ root: scaffold() })
+    const daemon = new Daemon({ root: scaffold(), slackAppFactory: fakeSlackAppFactory() })
     await daemon.start()
     const releaseDuties = vi.fn(async () => {})
     const reportDutiesNow = vi.fn()

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -9,6 +9,7 @@ import type { DutyGrantEntry } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import type { DutyRegistry } from '../src/cp/duty-registry.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { VirtualClock, runVirtual } from './fakes/virtual-clock.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const AGENT_B = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2'
@@ -77,10 +78,13 @@ const bundle = (
   ]
 })
 
-/** A daemon holding one granted duty, with a stub CP client — only the duty surface runs. */
+/** A daemon holding one granted duty, with a stub CP client — only the duty surface runs.
+ *  The convergence retry the fence falls back to is armed on the injected clock, so a test can
+ *  elapse it in virtual time rather than sleeping out its real one-second ladder. */
 async function boot(scope: 'frame' | 'connection' = 'frame') {
   const root = scaffold()
-  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root })
+  const clock = new VirtualClock()
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, clock })
   await daemon.start()
   const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
   ;(daemon as any).cpClient = {
@@ -94,7 +98,7 @@ async function boot(scope: 'frame' | 'connection' = 'frame') {
     fetchDutyAgent
   }
   await (daemon as any).admitDutyGrants([grant()])
-  return { daemon, root, fetchDutyAgent }
+  return { daemon, root, clock, fetchDutyAgent }
 }
 
 /** A daemon with an admission held open at the `duty/fetch` round trip, so a withdrawal can land
@@ -222,7 +226,7 @@ describe('the duty self-fence', () => {
     // A reconcile has a dozen ways to throw before it reaches the platform layer (workspace
     // authority, host teardown, a platform close). If the request were consumed by that pass, the
     // fenced agent would keep its socket — and its direct ingress — indefinitely.
-    const { daemon } = await boot()
+    const { daemon, clock } = await boot()
     const conn = liveSlackSocket(daemon)
     const realLoad = (daemon as any).loadAgentList.bind(daemon)
     let failures = 0
@@ -233,8 +237,13 @@ describe('the duty self-fence', () => {
 
     fence(daemon)
 
-    // The pass that carried the fence threw; the retry converges it anyway.
-    await vi.waitFor(() => expect(conn.stop).toHaveBeenCalled(), { timeout: 10_000 })
+    // The pass that carried the fence threw; the retry converges it anyway. Its one-second
+    // backoff is elapsed on the injected clock, so what is asserted is that a retry HAPPENS —
+    // never that a loaded runner got through the real ladder inside the test budget.
+    await runVirtual(
+      clock,
+      vi.waitFor(() => expect(conn.stop).toHaveBeenCalled(), { timeout: 20_000, interval: 5 })
+    )
     expect(failures).toBeGreaterThan(1) // the first pass really did throw
     expect(pooled(daemon)).not.toContain(conn)
     await daemon.stop()

--- a/packages/daemon/test/daemon-serial-gate.test.ts
+++ b/packages/daemon/test/daemon-serial-gate.test.ts
@@ -443,8 +443,9 @@ describe('P4 serial gate', () => {
     const stop = daemon.stop()
     await p1.catch(() => {})
     await stop
-    await new Promise((r) => setTimeout(r, 10))
-    expect(settled).toBe(true)
+    // Wait for the settlement itself. A fixed ten milliseconds was a bet that the drop landed
+    // within them, and the assertion is positive, so a slow runner failed it outright.
+    await vi.waitFor(() => expect(settled).toBe(true), WAIT)
     expect((daemon as any).serialQueue.has(key)).toBe(false)
   }, 15_000)
 

--- a/packages/daemon/test/dream-scheduler.test.ts
+++ b/packages/daemon/test/dream-scheduler.test.ts
@@ -76,9 +76,10 @@ describe('DreamScheduler', () => {
   it('fires onFire for the scheduled agent', async () => {
     const { fired, scheduler } = make()
     scheduler.sync('a1', { enabled: true, schedule: EVERY_SECOND })
-    await new Promise((r) => setTimeout(r, 1400))
+    // Wait for the tick itself, not for a window a tick usually fits in: the cron is real, so a
+    // runner slow enough to miss a fixed one-second-and-a-bit sleep failed this for no reason.
+    await vi.waitFor(() => expect(fired.length).toBeGreaterThanOrEqual(1), { timeout: 30_000, interval: 10 })
     scheduler.stop()
-    expect(fired.length).toBeGreaterThanOrEqual(1)
     expect(new Set(fired)).toEqual(new Set(['a1']))
   })
 
@@ -86,6 +87,8 @@ describe('DreamScheduler', () => {
     const { fired, scheduler } = make()
     scheduler.sync('a1', { enabled: true, schedule: EVERY_SECOND })
     scheduler.stop()
+    // A genuine real wait, and deliberately so: proving nothing fires needs a window in which a
+    // live job WOULD have. Slowness only widens it, so this cannot fail from a loaded runner.
     await new Promise((r) => setTimeout(r, 1200))
     expect(fired).toHaveLength(0)
   })

--- a/packages/daemon/test/fakes/virtual-clock.ts
+++ b/packages/daemon/test/fakes/virtual-clock.ts
@@ -1,0 +1,97 @@
+import type { Clock, TimerHandle } from '@agentconnect.md/connection'
+
+/**
+ * A daemon `Clock` whose time only moves when a test asks it to, plus {@link runVirtual} to
+ * drive it while the daemon is parked on one of its own deadlines — a drain budget, a release
+ * backoff, a convergence retry. Those deadlines are seconds long by design, so waiting them out
+ * for real is what puts these suites near the 5s per-test budget on a loaded runner.
+ *
+ * `@agentconnect.md/connection`'s FakeClock is the same idea but advances by a caller-chosen
+ * span; here the test does not know the span, only that the daemon is waiting for something, so
+ * this one fires the EARLIEST armed timer and moves time exactly to its deadline.
+ */
+export class VirtualClock implements Clock {
+  private t: number
+  private seq = 0
+  private readonly timers = new Map<number, { at: number; fn: () => void }>()
+
+  constructor(startMs = 1_700_000_000_000) {
+    this.t = startMs
+  }
+
+  now(): number {
+    return this.t
+  }
+
+  setTimeout(fn: () => void, ms: number): TimerHandle {
+    const id = ++this.seq
+    this.timers.set(id, { at: this.t + Math.max(0, ms), fn })
+    return id
+  }
+
+  clearTimeout(handle: TimerHandle): void {
+    this.timers.delete(handle as number)
+  }
+
+  /** Armed-timer count — lets a test assert that a deadline was armed, or cancelled. */
+  get pending(): number {
+    return this.timers.size
+  }
+
+  /**
+   * Fire the earliest armed timer due within `horizonMs`, moving time to its deadline.
+   * Returns false when nothing qualifies.
+   *
+   * The horizon is the safety rail: a daemon also arms hour-scale periodic sweeps on this
+   * clock, and firing one because it happened to be the only thing armed would jump virtual
+   * time far past anything the test is about.
+   */
+  fireNext(horizonMs: number): boolean {
+    let next: { id: number; at: number; fn: () => void } | undefined
+    for (const [id, entry] of this.timers) {
+      if (entry.at > this.t + horizonMs) continue
+      if (!next || entry.at < next.at) next = { id, ...entry }
+    }
+    if (!next) return false
+    this.timers.delete(next.id)
+    this.t = Math.max(this.t, next.at)
+    next.fn()
+    return true
+  }
+}
+
+/**
+ * Await `work`, firing the deadlines it parks on so a wait the daemon measures in seconds costs
+ * a test nothing. Real I/O still runs to completion: every fire is preceded by {@link settle},
+ * which drains the macrotask queue, and time never moves while the work is settling on its own.
+ *
+ * `horizonMs` bounds which deadlines may be skipped — keep it just above the longest wait the
+ * test means to skip, so a longer budget the test is actually asserting against stays real.
+ */
+export async function runVirtual<T>(clock: VirtualClock, work: Promise<T>, horizonMs = 1_500): Promise<T> {
+  let settled = false
+  const done = work.then(
+    (value) => {
+      settled = true
+      return value
+    },
+    (error: unknown) => {
+      settled = true
+      throw error
+    }
+  )
+  void done.catch(() => undefined)
+  for (let turns = 0; !settled && turns < 20_000; turns++) {
+    await settle()
+    if (settled) break
+    clock.fireNext(horizonMs)
+  }
+  return done
+}
+
+/** Drain the macrotask queue — every I/O completion already queued lands — without moving
+ *  virtual time. What a "nothing further happened" assertion waits on instead of a fixed sleep:
+ *  the daemon is parked on a virtual deadline nobody fired, so it demonstrably cannot proceed. */
+export async function settle(turns = 8): Promise<void> {
+  for (let i = 0; i < turns; i++) await new Promise((resolve) => setImmediate(resolve))
+}

--- a/packages/daemon/test/shim-dial-in.test.ts
+++ b/packages/daemon/test/shim-dial-in.test.ts
@@ -5,6 +5,7 @@ import { ShimDialer } from '../src/shim/dialer.js'
 import { ShimServer } from '../src/shim/server.js'
 import { ShimSession } from '../src/shim/session.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
+import type { ShimConnection } from '../src/shim/listener.js'
 import { SHIM_SUBPROTOCOL, SHIM_TOKEN_AUDIENCE, SHIM_WS_PATH } from '../src/shim/protocol.js'
 
 // Zero-jitter millisecond backoff so reconnect tests never sleep real seconds.
@@ -117,26 +118,34 @@ describe('sandbox shim dial-in', () => {
   it('waits for the replacement connection while a bound channel is reconnecting', async () => {
     // Both reconnect loops run on injected zero-jitter backoffs, so the redial and the
     // sandbox re-attach race each other every run instead of sleeping jittered seconds.
+    //
+    // The dial's own `onConnection` hook is what the redial is awaited on. Waiting inside
+    // `connect()` instead would put the supervised redial in a race with that call's real
+    // wall-clock binding deadline, which is what made this flaky on a loaded runner (#938):
+    // the assertion here is about ordering, so it must not be timed against one.
+    const bound: ShimConnection[] = []
     const { endpoint } = await sandbox({ backoff: fastBackoff() })
     const dialer = new ShimDialer({
       verifier: {
         reviewToken: async () => ({ authenticated: true, podName: 'sandbox-pod-1', podUid: 'pod-uid-1' })
       },
       backoff: fastBackoff,
+      onConnection: (connection) => void bound.push(connection),
       log: { info: () => {}, warn: () => {} }
     })
     dialers.push(dialer)
 
     const first = await dialer.connect(endpoint, record(), 8_000)
+    await waitFor(() => bound.length === 1)
     first.close('force reconnect')
-    // The rebind can outrun a poll, so wait for the first connection to be dropped rather
-    // than for an observable zero-connection window.
-    await waitFor(() => !dialer.connectionsFor('agent-a').includes(first))
+    await waitFor(() => bound.length === 2, 30_000)
 
+    // Already bound, so this resolves from the dial's current connection rather than waiting.
     const replacement = await dialer.connect(endpoint, record(), 8_000)
+    expect(replacement).toBe(bound[1])
     expect(replacement).not.toBe(first)
     expect(dialer.connectionsFor('agent-a')).toEqual([replacement])
-  }, 10_000)
+  }, 40_000)
 
   it('replays frames that arrived while the accepted daemon socket was still unclaimed', async () => {
     const server = new ShimServer()
@@ -146,7 +155,10 @@ describe('sandbox shim dial-in', () => {
       subprotocol: SHIM_SUBPROTOCOL,
       path: SHIM_WS_PATH
     })
-    // The hello lands before the channel FSM attaches — the queued-across-backoff case.
+    // The hello lands before the channel FSM attaches — the queued-across-backoff case. The
+    // settle below is the only real wait left in this file, and it is a one-directional one:
+    // too short and the frame takes the live path instead of the replayed one, which weakens
+    // what is covered but can never fail the assertion, so a slow runner is safe here.
     daemonSide.send(JSON.stringify({ type: 'shim/hello', agentId: 'agent-a', generation: 1 }))
     await new Promise((resolve) => setTimeout(resolve, 50))
     const accepted = await server.nextTransport()


### PR DESCRIPTION
## Summary

Tests that failed on CI or under full-suite load in the last two days and passed on rerun were all
waiting on the wall clock. This replaces those waits with the signal each one is actually about — a
hook the code already emits, a lock the database can be asked about, or a deadline moved on an
injected clock — so the assertions are about ordering and outcome rather than about how fast the
runner happened to be. No timeout is merely raised, and no behaviour under test changes.

Two of the reported failures needed nothing: `daemon-agent-mention-routing` and
`daemon-platform-authorship` timed out because `Daemon.start()` built a real `@slack/web-api` client
and dialled slack.com, and #1083 already gave both suites the injected fake. `duty-recompute`'s
"stop() cancels a pending kick" already lost its ~20 ms wait in #1084, which replaced it with
`clock.pendingTimers()` plus `settle()`. Both are re-verified here rather than re-fixed.

Closes #938.

## Per test

**`daemon/test/shim-dial-in.test.ts` — "waits for the replacement connection while a bound channel
is reconnecting"** (#938). It waited for the redial inside a second `dialer.connect(…, 8_000)`,
which times the supervised reconnect against that call's real binding deadline — the reported
`binding timed out after 8000ms` on a loaded runner. The dialer already announces every bound
connection through `onConnection`, so the test now collects them and waits for the second to arrive;
the `connect()` that follows resolves from the dial's current connection instead of racing anything.

**`daemon/test/daemon-duty-fence.test.ts` — "closes it on a retry when the reconcile pass carrying
the fence throws"**. The fence's convergence retry backs off a real second
(`DUTY_CONVERGE_RETRY_BASE_MS`), and the test waited it out under a 10 s `vi.waitFor` inside a 5 s
test budget it could never spend. The daemon takes a `clock`, so the suite injects one and elapses
the backoff in virtual time; what is asserted is that a retry happens. 1431 ms → 491 ms.

**`daemon/test/daemon-duty-drain.test.ts` — five tests**. Every deadline the shutdown drain measures
— the `poolShutdownDrainMs` budget, the release-ack backoff ladder, the "still busy, look again"
sleep — runs on the daemon's injected clock, so `boot()` now supplies one:

- _a release the CP never acknowledges is retried until the drain deadline_ burned ~2 s of real
  backoff inside the 5 s budget and asserted `Date.now()` elapsed under 6 s — a wall-clock bound on
  a loaded runner. Both the ladder and the bound are now the injected clock's. 2413 ms → 474 ms.
- _a group whose teardown cannot be confirmed by the deadline_ slept out its 1.5 s budget.
  1960 ms → 511 ms.
- _a late regrant … lapses if it never confirms_ slept 20 ms + 200 ms + a 1.5 s budget.
  2615 ms → 949 ms.
- _a busy group waits for its turn to finish_ and _a late grant is not acknowledged while the loop is
  still waiting on a busy group_ each slept out the loop's 1 s re-check plus a fixed 50/150 ms
  "nothing else happened" window. 1512/1412 ms → 577/481 ms.

The negative assertions ("nothing further was acknowledged") no longer sleep a guess: the loop is
parked on a virtual deadline nobody fired, so draining the macrotask queue proves nothing _can_
happen rather than betting that nothing did in 150 ms.

**`daemon/test/fakes/virtual-clock.ts`** (new) is the seam: a `Clock` whose time moves only on
request, `runVirtual` to fire the deadlines a promise parks on, and `settle` to drain the macrotask
queue without moving time. `runVirtual` takes a horizon so only the waits a test means to skip are
skippable — a daemon also arms hour-scale sweeps on the same clock, and one of those firing because
it was the only thing armed would jump virtual time past everything the test is about.

**`daemon/test/dream-scheduler.test.ts` — "fires onFire for the scheduled agent"**. Slept 1400 ms and
then asserted a once-per-second cron had fired — a positive assertion behind a fixed window, so a
slow runner failed it outright. Now a bounded `vi.waitFor` on the fire itself. 1400 ms → 111 ms. The
paired "stops firing once stopped" keeps its real 1200 ms: proving nothing fires needs a window in
which a live job would have, and slowness only widens it.

**`daemon/test/daemon-serial-gate.test.ts` — "the queue drains on shutdown"**. `expect(settled).toBe(true)`
behind a fixed 10 ms wait — the one positive assertion of that shape in the file. Now a bounded
`vi.waitFor`. The file's other fixed waits are all negative assertions ("the second prompt must NOT
have started"), where a slow runner only widens the window, and are left alone deliberately.

**`control-plane/test/integration/slack-platform-install.route.test.ts` — four concurrency tests**.
Each set up a row-lock race by sleeping 150 ms and hoping the request had reached the lock. Too short
a sleep does not fail the test; it silently runs a _different_ interleaving than the one the test
names, so the race goes uncovered. They now poll `pg_stat_activity` for a backend genuinely queued on
a lock, which is the probe `members.route`, `org-invite-links` and `session-visibility` already use.

**`control-plane/test/social-identity-mutation-gate.test.ts` and
`test/integration/session-visibility.route.test.ts`**. Both already polled the right signal but with
tight ceilings (1 s, and a 25 ms interval). Ceilings widened and the interval tightened — the poll
ends the instant the waiter appears, so a larger bound only buys not failing a correct run.

## Verification

Each touched suite three times, plus the whole daemon unit suite and the control-plane unit and
integration suites, plus `typecheck`, `lint`, and `format:check`.

`shim-workspace-files`, `shim-exec-handler` and `workspace-git-runner-seam` fail identically on a
clean `origin/main` in this sandbox (9 tests, filesystem/git environment), and are untouched here.
