### PR TITLE
perf(ci): give the evaluation gates their own runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,20 +131,6 @@ jobs:
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
         run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm test:unit
-      # The three evaluation gates in ONE Vitest run. As separate steps they each paid Vitest
-      # startup, config load and transform, and `eval:parity`'s three files could not fill four
-      # workers — 95.5s together against 43.3s merged, locally. `scripts/eval-gates.test.mjs`
-      # fails if the merged list drifts from the three per-gate scripts, which stay for local use.
-      #
-      # Covers: evaluation contracts, the Collaboration Arena gate (collaboration-arena.md §14
-      # step 3), and cross-surface activation parity (docs/designs/activation-parity.md) — a PR
-      # that changes "who does this message activate" must keep every leg green or declare the
-      # divergence in evals/parity/spec.ts with a citation.
-      - name: Evaluation gates
-        env:
-          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/unit-test-summary.md
-          PROMPTFOO_DISABLE_TELEMETRY: '1'
-        run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm eval:gates
       - name: Merge unit test summaries
         if: ${{ !cancelled() }}
         env:
@@ -179,6 +165,42 @@ jobs:
             cat "$CAPTURED_JOB_SUMMARY"
             echo '__AGENTCONNECT_UNIT_TEST_SUMMARY__'
           } >> "$GITHUB_OUTPUT"
+
+  # The evaluation gates, off the Unit Test job's critical path. They are ~48s of the ~3m27s that
+  # job took, and it is the slowest in the workflow, so they buy back most of that on their own
+  # runner. `evals/README.md` calls these the deterministic, credential-free layer — the real
+  # Promptfoo evaluation (`eval:addons`) needs model credentials and never ran here.
+  #
+  # No `prisma:generate` step: this closure reaches evals/, packages/daemon and the protocol-side
+  # packages, none of which import the generated client.
+  evals:
+    name: Evaluation Gates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      # Evaluation contracts, the Collaboration Arena gate (collaboration-arena.md §14 step 3), and
+      # cross-surface activation parity (docs/designs/activation-parity.md) — a PR that changes
+      # "who does this message activate" on one surface must either keep every leg green or declare
+      # the divergence in evals/parity/spec.ts with a citation.
+      #
+      # One Vitest run rather than three: `scripts/eval-gates.test.mjs` keeps the merged list equal
+      # to the union of the three per-gate scripts, which stay for local use.
+      - name: Evaluation gates
+        env:
+          PROMPTFOO_DISABLE_TELEMETRY: '1'
+        run: pnpm eval:gates
 
   # Exercise the daemon's core sandbox boundaries and confined skills pipeline
   # under the real Linux kernel sandbox. These cases self-skip in the bwrap-free


### PR DESCRIPTION
Follow-up to #1088. The Unit Test job is the workflow's critical path at **3m27s**, about a minute ahead of the next job, and **48s** of it is the evaluation gates running after the unit suite.

Moving them to their own job takes that off the path:

```
before                          after (projected)
Unit Test        3m27s          Unit Test        ~2m39s
  setup            47s          Evaluation Gates ~1m35s   (new runner, parallel)
  Unit tests     1m49s          Check             2m25s
  Evaluation gates 48s          Sandbox (Linux)   2m35s
```

Unit Test lands roughly level with Check and Sandbox, and the gates run beside it instead of after it.

## On the earlier estimate

I said this split was worth only ~25s [earlier in the thread](https://github.com/agentconnect-md/agentconnect/pull/1088). That was measured when Sandbox (Linux) sat at 3m07s and capped the gain. Sandbox has since dropped to 2m35s and the gap opened to about a minute, so the same change is worth more now. The number changed, not the reasoning.

## What does not move

There is no root Vitest config, so `eval:gates` runs the default reporters, writes no job summary, and never appeared in the unit job's `merge-vitest-summaries` list. `build_test_summary` and the `workflow_call` outputs are untouched.

No `prisma:generate` step in the new job: the gates' import closure reaches `evals/`, `packages/daemon` and the protocol-side packages, none of which import the generated client — same reasoning the daemon suite already relies on.

## Why not run them conditionally instead

Worth recording, since it was the first thing considered. The gates' transitive import closure is 341 files over `evals/**`, `packages/daemon/**` and `@agentconnect.md/{activation-policy,connection,k8s-client,message,protocol}` — it cannot reach control-plane, relay, web, setup, cli, observability or memory-plugin-mem0. So a paths filter would be sound on today's graph.

It was dropped anyway. Per `evals/README.md` these are the *deterministic, credential-free* layer — event schema, observer non-interference, permission decisions, redaction, ATIF, and the activation-parity invariant that a PR changing "who does this message activate" must keep every leg green or declare the divergence in `evals/parity/spec.ts` with a citation. They are invariants, not the model evaluation their directory name suggests; the real Promptfoo run (`eval:addons`) needs model credentials and has never run in CI. Gating invariants on a static reachability filter buys 48s times a hit rate, and carries the tail risk of a non-import coupling slipping through. A dedicated runner buys the same time unconditionally.

## Test plan

- `pnpm eval:gates` — 28 files, 188 tests, all pass, 42.4s
- `node --test scripts/*.test.mjs` — 17 pass, including the guard that keeps `eval:gates` equal to the union of the three per-gate scripts
- Workflow parses; `unit` is back to Checkout / Install / Prisma / Unit tests / merge+publish, and `evals` is Checkout / Install / Evaluation gates
- `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtPhRcPGtRX8RZqApUZRGu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtPhRcPGtRX8RZqApUZRGu)_