### PR TITLE
fix(console): preserve daemon display names for agents

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -711,6 +711,7 @@ export const AgentDto = z.object({
   // durable, so the console must read readiness from `placementReady` rather than from a machine.
   placementKind: z.enum(['daemon', 'set']),
   daemonId: z.string().nullable(),
+  daemonName: z.string().nullable(), // display-only placement metadata; does not grant daemon access
   setId: z.string().nullable(), // the `set`-kind ref; null for a `daemon` placement
   /** Can a session start right now? For a `daemon` placement that is its daemon's liveness; for a
    *  `set` placement it is "some live member could serve this", which is the question the console

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -311,6 +311,7 @@ function toDto(
     status: a.status,
     placementKind: a.placementKind,
     daemonId: a.daemonId,
+    daemonName: a.daemonId ? placementView.daemonName : null,
     setId: a.setId,
     placementReady: placementView.ready,
     workspace: workspaceToDto(a.workspace),
@@ -340,22 +341,22 @@ function toDto(
   }
 }
 
-/**
- * What placement says the console needs to know: the sandbox policy (#642) and whether a session
- * can start right now. Both come from ONE resolution of "who may serve this agent", so they can
- * never disagree — and for a set placement that resolution is "is any member live", not "is the
- * member this row names live", which is the question a rollout made unanswerable (#987).
- */
+/** One placement resolution supplies its display name, sandbox policy, and readiness. */
 interface PlacementView {
+  daemonName: string | null
   sandbox: SandboxPolicy
   ready: boolean
 }
 
-const NO_PLACEMENT: PlacementView = { sandbox: UNAVAILABLE_SANDBOX, ready: false }
+const NO_PLACEMENT: PlacementView = { daemonName: null, sandbox: UNAVAILABLE_SANDBOX, ready: false }
 
 function placementViewOf(deps: HttpDeps, daemon: DaemonView | null): PlacementView {
   const live = daemon ? deps.liveness.get(daemon.daemonId) : undefined
-  return { sandbox: sandboxPolicyOf(daemon), ready: live?.reachable === true && live.state === 'READY' }
+  return {
+    daemonName: daemon?.name ?? null,
+    sandbox: sandboxPolicyOf(daemon),
+    ready: live?.reachable === true && live.state === 'READY'
+  }
 }
 
 /**

--- a/packages/control-plane/test/integration/visibility.route.test.ts
+++ b/packages/control-plane/test/integration/visibility.route.test.ts
@@ -75,6 +75,30 @@ describe('agent visibility — list & get', () => {
     expect(granteeList.length).toBe(2) // org + shared
     expect(otherList.length).toBe(1) // org only
   })
+
+  it('projects a visible agent’s daemon name even when that daemon is outside the viewer’s audience', async () => {
+    const viewer = await makeUser('agent-daemon-name-viewer', 'collaborator')
+    const daemonId = randomUUID()
+    const agentId = randomUUID()
+    await seedDaemon(prisma, daemonId, { visibility: 'restricted', sharedWith: [DEFAULT_OWNER_ID] })
+    await prisma.daemon.update({ where: { id: daemonId }, data: { name: 'Daemon A' } })
+    await seedAgent(prisma, agentId, { daemonId, visibility: 'org' })
+
+    const app = appAs(viewer).app
+    const daemons = await app.inject({ method: 'GET', url: `${ORG}/daemons` })
+    expect((daemons.json() as Array<{ daemonId: string }>).some((daemon) => daemon.daemonId === daemonId)).toBe(false)
+
+    const list = await app.inject({ method: 'GET', url: `${ORG}/agents` })
+    expect(list.statusCode).toBe(200)
+    expect((list.json() as Array<Record<string, unknown>>).find((agent) => agent.id === agentId)).toMatchObject({
+      daemonId,
+      daemonName: 'Daemon A'
+    })
+
+    const detail = await app.inject({ method: 'GET', url: `${ORG}/agents/${agentId}` })
+    expect(detail.statusCode).toBe(200)
+    expect(detail.json()).toMatchObject({ daemonId, daemonName: 'Daemon A' })
+  })
 })
 
 describe('agent visibility — write gates', () => {

--- a/packages/web/src/components/console/AgentCallVisibility.tsx
+++ b/packages/web/src/components/console/AgentCallVisibility.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { Agent, AgentCallPolicy, DaemonRow } from '@/lib/data'
-import { agentLabel, agentModelDisplay } from '@/lib/data'
+import { agentDaemonLabel, agentLabel, agentModelDisplay } from '@/lib/data'
 import { AgentIconView } from '@/components/marks'
 import { Icon } from '@/components/ui'
 
@@ -37,10 +37,6 @@ export interface AgentCallVisibilityProps {
   variant?: 'card' | 'inline' | 'section'
   /** Extra classes for the root (e.g. the detail grid's `order-*`). */
   className?: string
-}
-
-function daemonLabel(agent: Agent): string {
-  return !agent.daemon || agent.daemon === '—' ? 'unplaced' : agent.daemon
 }
 
 /** Stands in for granted peers this viewer can't resolve (restricted agents are
@@ -127,12 +123,12 @@ export function AgentCallVisibility({
     const q = query.trim().toLowerCase()
     if (!q) return availablePeers
     return availablePeers.filter((candidate) =>
-      [agentLabel(candidate), candidate.name, candidate.model, candidate.runtime, daemonLabel(candidate)]
+      [agentLabel(candidate), candidate.name, candidate.model, candidate.runtime, agentDaemonLabel(candidate, daemons)]
         .join(' ')
         .toLowerCase()
         .includes(q)
     )
-  }, [availablePeers, query])
+  }, [availablePeers, daemons, query])
 
   useEffect(() => {
     const onPointerDown = (event: PointerEvent) => {
@@ -350,7 +346,7 @@ export function AgentCallVisibility({
                       </span>
                     </span>
                     <span className="max-w-[90px] flex-none truncate font-mono text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                      {daemonLabel(peer)}
+                      {agentDaemonLabel(peer, daemons)}
                     </span>
                   </button>
                 ))

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 import Link from 'next/link'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import {
+  agentDaemonLabel,
   agentEffortDisplay,
   agentLabel,
   agentModelDisplay,
@@ -465,14 +466,10 @@ export default function AgentDetailView() {
         refresh()
       }
     : undefined
-  // `da.daemon` is the owning daemonId — resolve it to the daemon's display name
-  // (never the raw UUID/host). Short id if the daemon isn't in the fleet; '—' if unplaced.
-  const daemonLabel = owningDaemon?.name ?? (da.daemon.length > 12 ? da.daemon.slice(0, 8) : da.daemon)
-  // Header + config Daemon row show "name · region"; region is a placeholder for
-  // live agents, so only append it when we actually have one.
+  const daemonLabel = agentDaemonLabel(da, daemons)
+  // Append region only when the Agent projection has a real one.
   const daemonLine = da.region && da.region !== '—' ? `${daemonLabel} · ${da.region}` : daemonLabel
-  // Link the daemon references (header meta + General card) to the daemon's detail
-  // page — but only when it's actually in the fleet, else the link would 404.
+  // Only a daemon in the viewer's fleet has a working detail route.
   const daemonHref = orgPath(`/daemons/${da.daemon}`)
   const outputModeLabel =
     da.outputMode && da.outputMode !== '—' ? da.outputMode[0]!.toUpperCase() + da.outputMode.slice(1) : da.outputMode

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -2,7 +2,15 @@
 
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
-import { agentLabel, agentModelDisplay, effectiveAgentStatus, runtimeLabel, status, type Agent } from '@/lib/data'
+import {
+  agentDaemonLabel,
+  agentLabel,
+  agentModelDisplay,
+  effectiveAgentStatus,
+  runtimeLabel,
+  status,
+  type Agent
+} from '@/lib/data'
 import { creatorLabel, fmtCost, fmtCountCompact, memberDisplayName } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
 import { IntegrationMarks } from '@/components/console/IntegrationMarks'
@@ -64,10 +72,8 @@ export default function AgentsView() {
   // name ran long.)
   const cols =
     'grid-cols-[minmax(148px,1.6fr)_92px_minmax(80px,.85fr)_72px_minmax(90px,1.2fr)_minmax(140px,.95fr)_108px_88px_80px_28px]'
-  // Resolve an agent's owning daemonId to the daemon's display name (never the raw
-  // UUID/host); short id if it's not in the fleet, '—' if unplaced.
-  const daemonName = (id: string) =>
-    daemons.find((d) => d.daemonId === id)?.name ?? (id.length > 12 ? id.slice(0, 8) : id)
+  // Prefer the Agent projection because its daemon may be outside this viewer's fleet.
+  const daemonName = (agent: Agent) => agentDaemonLabel(agent, daemons)
   // Live 24h usage (GET /usage?range=d1) keyed by agent for the Tokens 24h column.
   const usageByAgent = new Map((usage24h?.agents ?? []).map((u) => [u.agentId, u]))
   // Per-agent "Sessions 24h": the live usage rollup when the CP reports one, else the
@@ -162,7 +168,7 @@ export default function AgentsView() {
     const by: Record<SortKey, (x: Agent, y: Agent) => number> = {
       agent: (x, y) => agentLabel(x).localeCompare(agentLabel(y)),
       status: (x, y) => statusRank(x) - statusRank(y),
-      daemon: (x, y) => daemonName(x.daemon).localeCompare(daemonName(y.daemon)),
+      daemon: (x, y) => daemonName(x).localeCompare(daemonName(y)),
       creator: (x, y) => creatorText(x).localeCompare(creatorText(y)),
       repo: (x, y) => repoText(x).localeCompare(repoText(y)),
       sessions: (x, y) => sessions24h(x.id) - sessions24h(y.id),
@@ -618,7 +624,7 @@ export default function AgentsView() {
                   the dash — same affordance as the Integrations cell (preset-agents.md
                   §3.4): with no daemon in the org yet it launches the join-command
                   dialog; otherwise the edit modal carries the daemon picker. */}
-                {daemonName(a.daemon) === '—' ? (
+                {daemonName(a) === '—' ? (
                   <div className="min-w-0 pr-3">
                     <span
                       className="addchip"
@@ -634,11 +640,8 @@ export default function AgentsView() {
                     </span>
                   </div>
                 ) : (
-                  <div
-                    className="mono min-w-0 truncate pr-3 text-[12px] text-(--text-primary)"
-                    title={daemonName(a.daemon)}
-                  >
-                    {daemonName(a.daemon)}
+                  <div className="mono min-w-0 truncate pr-3 text-[12px] text-(--text-primary)" title={daemonName(a)}>
+                    {daemonName(a)}
                   </div>
                 )}
                 {a.createdBy ? (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -318,6 +318,7 @@ export interface AgentDto {
   placementKind?: PlacementKindValue
   placementReady?: boolean
   daemonId: string | null
+  daemonName: string | null
   setId?: string | null
   workspace: AgentWorkspaceDto
   workspaceRepoId?: string | null
@@ -1813,6 +1814,7 @@ export function agentFromDto(d: AgentDto): Agent {
     placementKind: d.placementKind ?? 'daemon',
     placementReady: d.placementReady ?? false,
     daemon: placementValueOf(d) ?? PLACEHOLDER,
+    ...(d.daemonName ? { daemonName: d.daemonName } : {}),
     region: PLACEHOLDER,
     repo: ws.mode === 'github' ? ws.repo : PLACEHOLDER,
     workdir: ws.mode === 'github' ? ws.agentDir : PLACEHOLDER,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -83,6 +83,15 @@ export function placementValueOf(dto: { placementKind?: PlacementKindValue; daem
   return isPoolPlacementKind(dto.placementKind) ? POOL_PLACEMENT : (dto.daemonId ?? null)
 }
 
+/** Resolve placement display text without exposing an unresolved daemon id. */
+export function agentDaemonLabel(
+  agent: Pick<Agent, 'daemon' | 'daemonName' | 'placementKind'>,
+  daemons: readonly Pick<DaemonRow, 'daemonId' | 'name'>[]
+): string {
+  if (isPoolPlacementKind(agent.placementKind)) return POOL_LABEL
+  return agent.daemonName ?? daemons.find((daemon) => daemon.daemonId === agent.daemon)?.name ?? '—'
+}
+
 /** One status for the whole pool: online while any member is serving. */
 export function poolFleetStatus(members: Pick<DaemonRow, 'status'>[]): ConnectionStatusKey {
   return members.some((m) => m.status === 'online') ? 'online' : 'offline'
@@ -345,6 +354,8 @@ export interface Agent {
    *  live", which is the question the console used to answer with a dead member's liveness. */
   placementReady?: boolean
   daemon: string
+  /** Display name projected with the Agent; available even when the daemon itself is not visible. */
+  daemonName?: string
   region: string
   /** Convenience mirror of the workspace for list views: github repo, else '—'. */
   repo: string
@@ -1223,6 +1234,7 @@ export const AGENTS: Agent[] = (
       organizationVariables: [],
       organizationSecretKeys: [],
       daemon: 'edge-1',
+      daemonName: 'edge-1',
       region: 'us-west',
       repo: 'acme/infra',
       workdir: './services/api',
@@ -1315,6 +1327,7 @@ export const AGENTS: Agent[] = (
       organizationVariables: [],
       organizationSecretKeys: [],
       daemon: 'edge-1',
+      daemonName: 'edge-1',
       region: 'us-west',
       repo: 'acme/web',
       workdir: './',
@@ -1393,6 +1406,7 @@ export const AGENTS: Agent[] = (
       organizationVariables: [],
       organizationSecretKeys: [],
       daemon: 'edge-2',
+      daemonName: 'edge-2',
       region: 'us-east',
       repo: '—',
       workdir: '/var/agentconnect/ws/oncall-bot',
@@ -1460,6 +1474,7 @@ export const AGENTS: Agent[] = (
       organizationVariables: [],
       organizationSecretKeys: [],
       daemon: 'edge-1',
+      daemonName: 'edge-1',
       region: 'us-west',
       repo: 'acme/docs',
       workdir: './',

--- a/packages/web/src/lib/placement-value.test.ts
+++ b/packages/web/src/lib/placement-value.test.ts
@@ -1,11 +1,13 @@
-// The console's ONE mapping from a DTO's placement pair to the value it selects on.
-//
-// A pool placement carries `daemonId: null` by design — no member id survives a rollout — so
-// anything that derives "is this the pool?" from `daemonId` being non-null reads a pool agent as
-// unplaced. That is what made a reloaded agent lose its Cloud selection: the list projection went
-// through the mapping and the editor's own re-fetch did not.
+// Placement projection regressions for machine and set targets.
 import { describe, it, expect } from 'vitest'
-import { POOL_PLACEMENT, effectiveAgentStatus, agentIsPlaced, placementValueOf } from '@/lib/data'
+import {
+  POOL_LABEL,
+  POOL_PLACEMENT,
+  agentDaemonLabel,
+  effectiveAgentStatus,
+  agentIsPlaced,
+  placementValueOf
+} from '@/lib/data'
 import type { Agent, DaemonRow } from '@/lib/data'
 
 const poolAgent = (over: Partial<Agent> = {}): Pick<Agent, 'status' | 'daemon' | 'placementKind' | 'placementReady'> =>
@@ -40,6 +42,15 @@ describe('placementValueOf', () => {
     expect(placementValueOf({ placementKind: 'daemon', daemonId: null })).toBeNull()
     // An older CP omits the field entirely; that has to keep meaning `daemon`.
     expect(placementValueOf({ daemonId: 'dmn_1' })).toBe('dmn_1')
+  })
+})
+
+describe('agentDaemonLabel', () => {
+  it('uses the Agent projection outside the visible fleet and never falls back to a raw daemon id', () => {
+    const daemonId = 'd8e6ea1f-c9bb-4d7b-8b75-e4db14e84999'
+    expect(agentDaemonLabel({ daemon: daemonId, daemonName: 'Daemon A', placementKind: 'daemon' }, [])).toBe('Daemon A')
+    expect(agentDaemonLabel({ daemon: daemonId, placementKind: 'daemon' }, [])).toBe('—')
+    expect(agentDaemonLabel({ daemon: POOL_PLACEMENT, placementKind: 'set' }, [])).toBe(POOL_LABEL)
   })
 })
 


### PR DESCRIPTION
## Summary

- project the owning daemon display name with each Agent DTO, independently of whether the viewer may list or open that daemon
- use one daemon-label resolver across the Agents list, Agent details, and peer-visibility picker
- replace unresolved daemon identifiers with an em dash instead of leaking an ID prefix

## Root cause

The Agent API returned only `daemonId`, so the Console tried to resolve the label from the viewer's separately authorized daemon list. Agent and Daemon visibility are intentionally independent; when an Agent was visible but its Daemon was not, that lookup failed and the UI rendered the daemon ID prefix instead of its display name.

The new projection carries only the display name. Daemon list and detail authorization remain unchanged.

## Validation

- `pnpm --filter @agentconnect.md/control-plane typecheck`
- focused Control Plane integration regression for the cross-visibility projection
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web exec vitest run src/lib/placement-value.test.ts`
- ESLint on changed files and the repository pre-push lint

Fixes #711

Created by Codex . GPT-5.6
