### PR TITLE
fix(console): prefer current visible daemon names

### DIFF
--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -89,7 +89,7 @@ export function agentDaemonLabel(
   daemons: readonly Pick<DaemonRow, 'daemonId' | 'name'>[]
 ): string {
   if (isPoolPlacementKind(agent.placementKind)) return POOL_LABEL
-  return agent.daemonName ?? daemons.find((daemon) => daemon.daemonId === agent.daemon)?.name ?? '—'
+  return daemons.find((daemon) => daemon.daemonId === agent.daemon)?.name ?? agent.daemonName ?? '—'
 }
 
 /** One status for the whole pool: online while any member is serving. */

--- a/packages/web/src/lib/placement-value.test.ts
+++ b/packages/web/src/lib/placement-value.test.ts
@@ -49,6 +49,11 @@ describe('agentDaemonLabel', () => {
   it('uses the Agent projection outside the visible fleet and never falls back to a raw daemon id', () => {
     const daemonId = 'd8e6ea1f-c9bb-4d7b-8b75-e4db14e84999'
     expect(agentDaemonLabel({ daemon: daemonId, daemonName: 'Daemon A', placementKind: 'daemon' }, [])).toBe('Daemon A')
+    expect(
+      agentDaemonLabel({ daemon: daemonId, daemonName: 'Old name', placementKind: 'daemon' }, [
+        { daemonId, name: 'Renamed daemon' }
+      ])
+    ).toBe('Renamed daemon')
     expect(agentDaemonLabel({ daemon: daemonId, placementKind: 'daemon' }, [])).toBe('—')
     expect(agentDaemonLabel({ daemon: POOL_PLACEMENT, placementKind: 'set' }, [])).toBe(POOL_LABEL)
   })


### PR DESCRIPTION
## Summary
- prefer the visible fleet name over the Agent projection when both are available
- preserve the projected daemon name as the fallback for Agents whose daemon is not list-visible
- cover the rename freshness ordering in the shared label resolver

Follow-up to #1092.

## Testing
- pnpm --filter @agentconnect.md/web exec vitest run src/lib/placement-value.test.ts
- pnpm exec eslint packages/web/src/lib/data.ts packages/web/src/lib/placement-value.test.ts
- pre-push eslint .

Created by Codex . GPT-5.6