### PR TITLE
test(control-plane): prove reconnect as a combined multi-org snapshot (#955 M4)

### DIFF
--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -217,6 +217,8 @@ defined in `packages/protocol/src/frames/register.ts`.
 
 **Reconcile contract:** `register/ok` is the **source of truth**. On receipt the daemon: (1) starts/keeps every assignment & cron in the snapshot, (2) releases everything in `drop`, (3) adopts `routingEpoch` as its current routing fence. **CP wins all conflicts.** This makes reconnect convergence idempotent — re-issuing the same snapshot is a no-op.
 
+**Multi-org reconnect (install-wide members).** On a frame-mode connection `register/ok` is the **combined multi-org snapshot** (k8s-daemon-pool.md D9): the frame itself is install-wide and carries no envelope `orgId`, while every payload entry — agent spec, cron, integration, MCP and memory definition, collaboration route — names its own organization, and the roster is the union `pinned-to-me ∪ agents in the duties I hold` across every org the member serves, with ownership-aware `drop` sets for what moved or was deleted while it was away. Agent entries carry the current `Agent.configRevision`, so the daemon's `stale|conflict|idempotent|apply` compare converges edits missed offline. Two revision-fenced streams on the same connection finish the job: the register-time visibility replay re-sends the capture-gate set per organization as org-scoped `session/visibility/snapshot` frames, and the first heartbeat's duty exchange re-issues missing or stale-term grants revision-stamped (`frames/duty.ts`; k8s-daemon-pool.md §5), so the member refetches only frozen bundles. There is no `subscribe(org)`, org room, or per-org socket; `packages/control-plane/test/protocol/multi-org-reconnect.test.ts` pins the property end to end.
+
 ### 3.3a `capabilities/update` (EVT, D→C)
 
 A fire-and-forget full-replace of the connection's registered

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -674,12 +674,23 @@ that connection. Both peers enforce it with the shared classification in
 install-wide frame with one, an org that does not own the targeted resource,
 or a reply that does not carry its request's org is refused with
 `SCOPE_DENIED` and never applied (the contract in detail:
-[`org-scoped-data-layer.md`](org-scoped-data-layer.md) §4.1). Reconnect state is a combined multi-org snapshot or revision-fenced stream
-on the same member connection — deliberately **not** `subscribe(org)`, an org
-room, or an org-specific socket — reusing the watermark machinery that already
-exists in production (`Agent.configRevision` with the daemon-side
-`stale|conflict|idempotent|apply` compare, and `SessionMeta.visibilityRev` +
-replay-on-register).
+[`org-scoped-data-layer.md`](org-scoped-data-layer.md) §4.1). Reconnect state is a
+combined multi-org snapshot plus two revision-fenced streams on the same member
+connection — deliberately **not** `subscribe(org)`, an org room, or an
+org-specific socket. `register/ok` is the snapshot: one install-wide frame (no
+envelope org) whose roster is the union pinned-to-me ∪ duty-held across every
+served org, each entry naming its own org and each agent spec carrying its
+current `Agent.configRevision`, with ownership-aware drop sets for what moved or
+was deleted while the member was away; the daemon applies it through the
+existing `stale|conflict|idempotent|apply` compare. The streams reuse the
+production watermarks rather than inventing new ones: the register-time
+visibility replay converges `SessionMeta.visibilityRev` per org over org-scoped
+`session/visibility/snapshot` frames on the same connection, and the first
+heartbeat's duty exchange re-issues missing or stale-term grants stamped with
+each agent's current revision, so the member refetches only frozen bundles.
+`packages/control-plane/test/protocol/multi-org-reconnect.test.ts` pins the
+end-to-end property: two orgs mutated while a member is away converge through
+one reconnect with no org-specific frame shape.
 
 **Platform credentials are duty-scoped; agent secrets stay pointer-based.** An
 agent's secrets are materialized at spawn through the shim, but a duty holder

--- a/packages/control-plane/test/fakes/daemon-stub.ts
+++ b/packages/control-plane/test/fakes/daemon-stub.ts
@@ -47,8 +47,11 @@ export class InMemoryDaemonStub implements Transport {
   private inflight: Promise<void>[] = []
   /** Resolvers waiting on `expectFrame(type)`. */
   private waiters: Array<{ type: FrameType; resolve: (f: CapturedFrame) => void }> = []
-  /** Auto-responders: REQ type → (reqFrame) → REP {type,payload}. */
-  private responders = new Map<FrameType, (req: CapturedFrame) => { type: FrameType; payload: unknown }>()
+  /** Auto-responders: REQ type → (reqFrame) → REP {type,payload,orgId?} (frame mode: an org-scoped REQ's reply must carry its org). */
+  private responders = new Map<
+    FrameType,
+    (req: CapturedFrame) => { type: FrameType; payload: unknown; orgId?: string }
+  >()
 
   constructor(opts: StubOpts = {}) {
     this.subprotocol = opts.subprotocol ?? 'agentconnect.v1'
@@ -60,7 +63,10 @@ export class InMemoryDaemonStub implements Transport {
    * would. The responder maps the request frame to the reply payload. Lets a test
    * drive flows (e.g. rebalance) that block on an ack without hand-injecting each.
    */
-  respondTo(type: FrameType, responder: (req: CapturedFrame) => { type: FrameType; payload: unknown }): void {
+  respondTo(
+    type: FrameType,
+    responder: (req: CapturedFrame) => { type: FrameType; payload: unknown; orgId?: string }
+  ): void {
     this.responders.set(type, responder)
   }
 
@@ -85,8 +91,8 @@ export class InMemoryDaemonStub implements Transport {
     // the issuing `request(...)` has returned its promise first).
     const responder = this.responders.get(frame.type)
     if (responder) {
-      const { type, payload } = responder(frame)
-      queueMicrotask(() => this.reply(frame.id, type, payload))
+      const { type, payload, orgId } = responder(frame)
+      queueMicrotask(() => this.inject(type, payload, { corr: frame.id, ...(orgId ? { orgId } : {}) }))
     }
   }
 

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -67,12 +67,14 @@ export async function seedAgent(
     runtimeOverrides?: Record<string, unknown>
     /** A `set` placement: placed, but naming no machine — which member serves it is the ledger's. */
     setId?: string
+    /** Owning organization; defaults to the seeded one (multi-org tests pass their own). */
+    orgId?: string
   } = {}
 ): Promise<AgentId> {
   await prisma.agent.create({
     data: {
       id,
-      orgId: DEFAULT_ORG_ID,
+      orgId: opts.orgId ?? DEFAULT_ORG_ID,
       name: opts.name ?? `agent-${id.slice(0, 4)}`,
       runtime: opts.runtime ?? 'claude',
       daemonId: opts.daemonId,
@@ -96,19 +98,20 @@ export async function seedDutyGroup(
   groupId: string,
   holder: string,
   agentIds: string[],
-  opts: { expiresAt?: Date; term?: bigint } = {}
+  opts: { expiresAt?: Date; term?: bigint; orgId?: string } = {}
 ): Promise<void> {
+  const orgId = opts.orgId ?? DEFAULT_ORG_ID
   await prisma.dutyGroup.create({
     data: {
       id: groupId,
-      orgId: DEFAULT_ORG_ID,
+      orgId,
       holder,
       term: opts.term ?? 1n,
       expiresAt: opts.expiresAt ?? new Date(Date.now() + 120_000)
     }
   })
   await prisma.dutyGroupMember.createMany({
-    data: agentIds.map((refId) => ({ kind: 'agent' as const, refId, groupId, orgId: DEFAULT_ORG_ID }))
+    data: agentIds.map((refId) => ({ kind: 'agent' as const, refId, groupId, orgId }))
   })
 }
 
@@ -127,13 +130,15 @@ export async function seedSessionMeta(
     parentSessionId?: string
     lastActivityAt?: Date
     model?: string
+    /** Owning organization; defaults to the seeded one (multi-org tests pass their own). */
+    orgId?: string
   } = {}
 ): Promise<string> {
   await prisma.sessionMeta.create({
     data: {
       id,
       agentId,
-      orgId: DEFAULT_ORG_ID,
+      orgId: opts.orgId ?? DEFAULT_ORG_ID,
       platform: opts.platform ?? 'slack',
       channel: opts.channel ?? '#general',
       phase: 'start',

--- a/packages/control-plane/test/protocol/multi-org-reconnect.test.ts
+++ b/packages/control-plane/test/protocol/multi-org-reconnect.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Reconnect state as a combined multi-org snapshot (k8s-daemon-pool.md M4).
+ *
+ * A pool member serves several organizations over ONE install-wide connection, so
+ * its reconnect story must converge every org it serves without `subscribe(org)`,
+ * an org room, or an org-specific socket. The mechanism is three existing pieces
+ * on the same wire, and this suite pins each one end to end over real Postgres:
+ *
+ *  1. `register/ok` — the combined snapshot: ONE install-wide frame (no envelope
+ *     org) whose payload entries each carry their own org, covering every org the
+ *     member serves — including edits and deletes that landed while it was away.
+ *  2. The register-time visibility replay — org-scoped `session/visibility/snapshot`
+ *     frames on the same connection, one bucket per org, acked per revision.
+ *  3. The duty exchange's reconnect crossing point — a stale digest term is
+ *     answered by re-issuing the grant at the current term, stamped with each
+ *     org's current `Agent.configRevision`, on install-wide `duty/grant` frames.
+ */
+import { describe, it, expect } from 'vitest'
+import { isFrame, SESSION_VISIBILITY_FEATURE } from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { buildWsHarness, type WsHarness } from '../fakes/build-ws.js'
+import type { CapturedFrame, InMemoryDaemonStub } from '../fakes/daemon-stub.js'
+import { poolSetId } from '../fakes/member-set.js'
+import { seedAgent, seedDutyGroup, seedSessionMeta } from '../fixtures/seed.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { PgAgentRepo, PgDutyGroupRepo, PgLaunchRepo, PgSessionRepo } from '../../src/persistence/index.js'
+import { ControlSender } from '../../src/orchestrator/outbound.js'
+import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
+import { SessionVisibilityPushService } from '../../src/orchestrator/visibilityPush.js'
+import { OrgId, SessionId } from '../../src/domain/ids.js'
+
+const MEMBER = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd1'
+const ORG_B = 'org-b-multi-reconnect'
+const AGENT_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaab1'
+const AGENT_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2'
+const GROUP_A = '00000000-0000-4000-8000-00000000a0a1'
+const GROUP_B = '00000000-0000-4000-8000-00000000b0b2'
+const CRON_A = '00000000-0000-4000-8000-00000000c0a1'
+const CRON_B = '00000000-0000-4000-8000-00000000c0b2'
+
+const LEASE_MS = 120_000
+
+/** Both orgs' agents duty-held by MEMBER: one live group per org (components are per org). */
+async function seedTwoOrgHoldings(h: WsHarness): Promise<void> {
+  await prisma.org.create({ data: { id: ORG_B, slug: ORG_B } })
+  const setId = await poolSetId(prisma)
+  await seedAgent(prisma, AGENT_A, { setId, name: 'agent-a' })
+  await seedAgent(prisma, AGENT_B, { setId, name: 'agent-b', orgId: ORG_B })
+  const expiresAt = new Date(h.clock.now() + LEASE_MS)
+  await seedDutyGroup(prisma, GROUP_A, MEMBER, [AGENT_A], { expiresAt })
+  await seedDutyGroup(prisma, GROUP_B, MEMBER, [AGENT_B], { expiresAt, orgId: ORG_B })
+}
+
+async function connectAndAuth(h: WsHarness, saToken: string) {
+  const { conn, stub } = h.connect()
+  stub.inject('auth', { serviceAccountToken: saToken, daemonId: MEMBER, agentVersion: '1.4.0' })
+  await stub.expectFrame('auth/ok')
+  return { conn, stub }
+}
+
+async function register(
+  stub: InMemoryDaemonStub,
+  localState: {
+    crons?: string[]
+    agents?: { agentId: string; origin: 'cp' | 'unknown' }[]
+  } = {},
+  features: string[] = []
+): Promise<CapturedFrame> {
+  stub.inject('register', {
+    host: 'member-1',
+    capabilities: { platforms: ['slack'], runtimes: ['claude'], acp: true, features },
+    maxAgents: 8,
+    localState: {
+      assignments: [],
+      crons: localState.crons ?? [],
+      leases: [],
+      agents: localState.agents ?? [],
+      integrations: [],
+      stagedAgents: []
+    }
+  })
+  return stub.expectFrame('register/ok')
+}
+
+async function seedCron(id: string, orgId: string, agentId: string): Promise<void> {
+  await prisma.cronDef.create({
+    data: { id, orgId, agentId, schedule: '0 9 * * *', timezone: 'UTC', trigger: 'daily check-in', enabled: true }
+  })
+}
+
+describe('reconnect state as a combined multi-org snapshot (M4)', () => {
+  it('one install-wide register/ok converges two orgs edited and deleted while the member was away', async () => {
+    const h = buildWsHarness(prisma)
+    const saToken = await h.mintPoolMember(MEMBER)
+    const first = await connectAndAuth(h, saToken)
+    await seedTwoOrgHoldings(h)
+    await seedCron(CRON_A, DEFAULT_ORG_ID, AGENT_A)
+    await seedCron(CRON_B, ORG_B, AGENT_B)
+
+    // The pre-disconnect snapshot already combines both orgs on one org-free envelope.
+    const ok1 = await register(first.stub)
+    if (!isFrame('register/ok')(ok1)) throw new Error('expected register/ok')
+    expect(ok1.orgId).toBeUndefined()
+    const byAgent = new Map(ok1.payload.agents.map((a) => [a.agentId, a]))
+    expect(byAgent.get(AGENT_A)?.orgId).toBe(DEFAULT_ORG_ID)
+    expect(byAgent.get(AGENT_B)?.orgId).toBe(ORG_B)
+    expect(new Map(ok1.payload.crons.map((c) => [c.cronId, c.orgId]))).toEqual(
+      new Map([
+        [CRON_A, DEFAULT_ORG_ID],
+        [CRON_B, ORG_B]
+      ])
+    )
+    const revisionBefore = BigInt(byAgent.get(AGENT_A)!.configRevision!)
+
+    // The link drops; both orgs mutate while the member is away.
+    first.stub.close(1000, 'link lost')
+    await prisma.agent.update({
+      where: { id: AGENT_A },
+      data: { name: 'renamed-while-away', configRevision: { increment: 1n } }
+    })
+    await prisma.agent.delete({ where: { id: AGENT_B } }) // duty membership and the local replica outlive the row
+
+    // Reconnect claiming both replicas: ONE snapshot converges both orgs.
+    const second = await connectAndAuth(h, saToken)
+    const ok2 = await register(second.stub, {
+      crons: [CRON_A, CRON_B],
+      agents: [
+        { agentId: AGENT_A, origin: 'cp' },
+        { agentId: AGENT_B, origin: 'cp' }
+      ]
+    })
+    if (!isFrame('register/ok')(ok2)) throw new Error('expected register/ok')
+    expect(ok2.orgId).toBeUndefined()
+
+    // The edited org converges through the revision fence; the deleted org through the drop set.
+    const agentA = ok2.payload.agents.find((a) => a.agentId === AGENT_A)
+    expect(agentA).toMatchObject({ orgId: DEFAULT_ORG_ID, name: 'renamed-while-away' })
+    expect(BigInt(agentA!.configRevision!)).toBe(revisionBefore + 1n)
+    expect(ok2.payload.agents.map((a) => a.agentId)).not.toContain(AGENT_B)
+    expect(ok2.payload.drop.agents).toEqual([{ agentId: AGENT_B, action: 'remove' }])
+    expect(ok2.payload.crons.map((c) => c.cronId)).toEqual([CRON_A])
+    expect(ok2.payload.drop.crons).toEqual([CRON_B])
+  })
+
+  it('register-time visibility replay reaches both orgs as org-scoped snapshots on the same connection', async () => {
+    const h = buildWsHarness(prisma)
+    const saToken = await h.mintPoolMember(MEMBER)
+    await seedTwoOrgHoldings(h)
+
+    // Both orgs tightened a session while the member was away.
+    const sessions = new PgSessionRepo(prisma)
+    const sessionA = await seedSessionMeta(prisma, `s-a-${MEMBER.slice(0, 8)}`, AGENT_A)
+    const sessionB = await seedSessionMeta(prisma, `s-b-${MEMBER.slice(0, 8)}`, AGENT_B, { orgId: ORG_B })
+    await sessions.setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(sessionA), 'private')
+    await sessions.setVisibility(OrgId(ORG_B), SessionId(sessionB), 'private')
+
+    // The replay service as the container wires it, over the harness's live registry.
+    h.deps.visibilityPush = new SessionVisibilityPushService({
+      repos: { session: sessions, agent: new PgAgentRepo(prisma) },
+      control: new ControlSender(h.deps.connReg, new PgLaunchRepo(prisma)),
+      connReg: h.deps.connReg,
+      placement: new PlacementResolver({ duties: new PgDutyGroupRepo(prisma), clock: h.clock }),
+      duties: new PgDutyGroupRepo(prisma),
+      clock: h.clock
+    })
+
+    const { stub } = await connectAndAuth(h, saToken)
+    // Frame mode: the ack must carry the org of the snapshot it answers.
+    stub.respondTo('session/visibility/snapshot', (req) => ({
+      type: 'ack',
+      payload: { ok: true },
+      ...(req.orgId ? { orgId: req.orgId } : {})
+    }))
+    const ok = await register(stub, {}, [SESSION_VISIBILITY_FEATURE])
+    expect(isFrame('register/ok')(ok)).toBe(true)
+    await stub.settled()
+
+    // One org-scoped snapshot per org, entries never mixed across orgs.
+    const snapshots = stub.sent.filter((f) => f.type === 'session/visibility/snapshot')
+    const byOrg = new Map(
+      snapshots.map((f) => [
+        f.orgId,
+        (f.payload as { entries: { sessionId: string; visibilityRev: number }[] }).entries
+      ])
+    )
+    expect([...byOrg.keys()].sort()).toEqual([DEFAULT_ORG_ID, ORG_B].sort())
+    expect(byOrg.get(DEFAULT_ORG_ID)).toEqual([
+      expect.objectContaining({ sessionId: sessionA, agentId: AGENT_A, visibility: 'private', visibilityRev: 1 })
+    ])
+    expect(byOrg.get(ORG_B)).toEqual([
+      expect.objectContaining({ sessionId: sessionB, agentId: AGENT_B, visibility: 'private', visibilityRev: 1 })
+    ])
+
+    // The acks landed as watermarks: nothing is left unconverged in either org.
+    expect(await sessions.countUnackedVisibilityForAgents([AGENT_A])).toBe(0)
+    expect(await sessions.countUnackedVisibilityForAgents([AGENT_B])).toBe(0)
+  })
+
+  it('a stale digest re-issues both orgs at current terms and revisions on install-wide duty frames', async () => {
+    const h = buildWsHarness(prisma)
+    const saToken = await h.mintPoolMember(MEMBER)
+    await seedTwoOrgHoldings(h)
+    // Both orgs' terms and specs moved while the member was away.
+    await prisma.dutyGroup.updateMany({ where: { id: { in: [GROUP_A, GROUP_B] } }, data: { term: 2n } })
+    await prisma.agent.update({ where: { id: AGENT_A }, data: { configRevision: { increment: 1n } } })
+    await prisma.agent.update({ where: { id: AGENT_B }, data: { configRevision: { increment: 1n } } })
+    const currentRevision = async (id: string) =>
+      (await prisma.agent.findUniqueOrThrow({ where: { id }, select: { configRevision: true } })).configRevision
+
+    const { stub } = await connectAndAuth(h, saToken)
+    await register(stub)
+
+    // The reconnect crossing point: the digest still carries the pre-disconnect terms.
+    stub.inject('heartbeat', {
+      load: { cpu: 0.1, mem: 0.1, agents: 2 },
+      health: 'ok',
+      activeSessions: 0,
+      duties: {
+        held: [
+          { groupId: GROUP_A, term: '1' },
+          { groupId: GROUP_B, term: '1' }
+        ],
+        headroom: 0
+      }
+    })
+    await stub.settled()
+
+    const grants = stub.sent.filter((f) => f.type === 'duty/grant')
+    expect(grants).toHaveLength(1)
+    expect(grants[0]!.orgId).toBeUndefined() // duty frames are install-wide; the org rides each entry
+    if (!isFrame('duty/grant')(grants[0]!)) throw new Error('expected duty/grant')
+    expect(grants[0]!.payload.grants).toEqual([
+      {
+        groupId: GROUP_A,
+        orgId: DEFAULT_ORG_ID,
+        term: '2',
+        members: [{ kind: 'agent', refId: AGENT_A, configRevision: (await currentRevision(AGENT_A)).toString() }]
+      },
+      {
+        groupId: GROUP_B,
+        orgId: ORG_B,
+        term: '2',
+        members: [{ kind: 'agent', refId: AGENT_B, configRevision: (await currentRevision(AGENT_B)).toString() }]
+      }
+    ])
+    // Nothing was revoked, and the renewal confirmation closed the exchange.
+    expect(stub.sent.filter((f) => f.type === 'duty/revoke')).toEqual([])
+    const order = stub.sent.map((f) => f.type)
+    expect(order.indexOf('duty/renewed')).toBeGreaterThan(order.indexOf('duty/grant'))
+  })
+})


### PR DESCRIPTION
## Summary

Closes the last open M4 item of #955: reconnect state as a **combined multi-org snapshot** on the same member connection — never `subscribe(org)`, an org room, an org-specific socket, or an org-specific data-plane schema. The survey found the mechanism already shipped; the deliverable is the end-to-end multi-org proof plus the design docs stating the semantics as they are.

## What the scout found

A frame-mode member's reconnect already converges through three existing pieces on one wire:

1. **`register/ok` is the combined snapshot.** One install-wide frame (no envelope `orgId`) whose roster is the union `pinned-to-me ∪ duty-held` across every served org (`Placement.reconcile` + `servedAgents`). Every payload entry — agent spec, cron, integration, MCP/memory definition, collaboration route — names its own org; agent specs carry the current `Agent.configRevision` and apply through the daemon's existing `stale|conflict|idempotent|apply` compare; ownership-aware `drop` sets converge moves and deletes missed offline.
2. **Register-time visibility replay.** `SessionVisibilityPushService.replayTo` runs on every register (and again on duty confirmation), two-phased (unacked pages, then all-private pages), scoped to the served-agent union, chunked **per org** into org-scoped `session/visibility/snapshot` frames — `SessionMeta.visibilityRev`/`visibilityAckedRev` are the watermarks.
3. **The duty exchange's reconnect crossing point.** The first heartbeat's digest diff re-issues held groups the member lost or knows at a stale term, each grant entry stamped with its org and the agent's current `configRevision`, so the member refetches (`duty/fetch`) only frozen bundles. The daemon-side self-fence (0.75 × lease horizon) guarantees a long disconnect empties the digest, which is exactly what makes the missing-regrant path the re-install.

Candidates checked and found covered by durable backstops: staged agent moves (durable fence + `recoverStagedAgent`), lifecycle ops (`settleLifecycleOpOnReady`), hook redelivery (durable `HookRun` rows + reconciler + inbox replay on duty gain), purge receipts and session-metadata outboxes (owner-leased, drained on reconnect), org environment changes (revision bump inside the write transaction, roster as the offline backstop), org knowledge (daemon-initiated pull, no replica).

## What was actually missing

Only the proof. Every existing test exercised the pieces single-org; nothing pinned the M4 property itself — that two orgs' state mutated **while a member is away** converges through one reconnect with no org-specific frame shape.

## Fix

- `packages/control-plane/test/protocol/multi-org-reconnect.test.ts` — three end-to-end tests over real Postgres:
  - one install-wide `register/ok` converges two orgs edited (revision bump) and deleted (drop-set `remove`) while the member was away, crons included, per-entry orgs asserted, envelope org-free;
  - register-time visibility replay reaches both orgs as org-scoped snapshots on the same connection, acks recorded per revision;
  - a stale digest re-issues both orgs' groups at current terms with per-entry `configRevision` stamps on install-wide `duty/grant` frames, renewal confirmation last.
- Test fixtures: `seedAgent` / `seedDutyGroup` / `seedSessionMeta` accept an optional org; the daemon stub's auto-responder can org-stamp a correlated reply (frame mode requires an org-scoped request's reply to carry its org).
- Docs: `k8s-daemon-pool.md` §10 (D9) and `daemon-cp-ws-protocol.md` §3.3 now describe the reconnect semantics as shipped, naming the suite that pins them.

No production code changed — the tests flushed out no gap.

## Test plan

- `pnpm --filter @agentconnect.md/control-plane test:int` — full integration project (93 files, 1388 tests) green, including the new suite
- `pnpm --filter @agentconnect.md/control-plane test:unit` — green
- `pnpm --filter @agentconnect.md/protocol test` — green
- Post-rebase re-run of the touched protocol suites (`multi-org-reconnect`, `register.handler`, `duty-lease.handler`, `frame-org.handler`, `reconnect`, `session-visibility.route`) — green
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
