### PR TITLE
test(daemon): cover the dial-in Kubernetes-identity handshake invariants

### DIFF
--- a/packages/daemon/test/shim-dial-in.test.ts
+++ b/packages/daemon/test/shim-dial-in.test.ts
@@ -1,21 +1,39 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Backoff, ClientTransport } from '@agentconnect.md/connection'
+import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import { WebSocket } from 'ws'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
-import { ShimDialer } from '../src/shim/dialer.js'
+import { ShimDialer, type ShimDialerDeps } from '../src/shim/dialer.js'
 import { ShimServer } from '../src/shim/server.js'
 import { ShimSession } from '../src/shim/session.js'
+import { noopClusterMetrics, type ClusterMetrics } from '../src/k8s/cluster-metrics.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
-import type { ShimConnection } from '../src/shim/listener.js'
-import { SHIM_SUBPROTOCOL, SHIM_TOKEN_AUDIENCE, SHIM_WS_PATH } from '../src/shim/protocol.js'
+import type { PodIdentityVerifier, ShimConnection } from '../src/shim/listener.js'
+import {
+  SHIM_SUBPROTOCOL,
+  SHIM_TOKEN_AUDIENCE,
+  SHIM_WS_PATH,
+  parseShimFrame,
+  type ShimDialHello,
+  type ShimFrame
+} from '../src/shim/protocol.js'
+import { runVirtual, VirtualClock } from './fakes/virtual-clock.js'
 
 // Zero-jitter millisecond backoff so reconnect tests never sleep real seconds.
 const fastBackoff = (): Backoff => new Backoff({ baseMs: 5, jitter: () => 0 })
 
+/** A retry delay far past every dial deadline here, so a refusal test observes exactly one attempt. */
+const pausedBackoff = (): Backoff => new Backoff({ baseMs: 10_000, jitter: () => 0 })
+
+const quiet = { info: () => {}, warn: () => {} }
+
 const clients: ShimClient[] = []
 const dialers: ShimDialer[] = []
 const servers: ShimServer[] = []
+const sockets: WebSocket[] = []
 
 afterEach(async () => {
+  for (const socket of sockets.splice(0)) socket.close()
   for (const client of clients.splice(0)) client.stop()
   for (const dialer of dialers.splice(0)) dialer.stop()
   await Promise.all(servers.splice(0).map((server) => server.stop()))
@@ -60,6 +78,108 @@ function record(generation = 1): SpawnRecord {
   }
 }
 
+/** Records only what these tests assert on; the rest is a no-op. */
+function countingMetrics(): { metrics: ClusterMetrics; rejections: string[]; tokenReviews: () => number } {
+  const rejections: string[] = []
+  let tokenReviews = 0
+  return {
+    rejections,
+    tokenReviews: () => tokenReviews,
+    metrics: {
+      ...noopClusterMetrics,
+      handshakeRejected: (reason) => rejections.push(reason),
+      tokenReviewRejected: () => (tokenReviews += 1)
+    }
+  }
+}
+
+/** The sandbox side of one scripted dial: what the shim was sent, and how the daemon closed. */
+interface ScriptedPeer {
+  received: ShimFrame[]
+  closed?: { code: number; reason: string }
+  /** Answer the daemon on this socket — including frames a real shim would never send. */
+  reply: (frame: unknown) => void
+}
+
+/** A raw socket to the shim port, used where the assertion IS the close code. */
+async function rawDial(port: number): Promise<{
+  socket: WebSocket
+  frames: string[]
+  closed: Promise<{ code: number; reason: string }>
+}> {
+  const socket = new WebSocket(`ws://127.0.0.1:${port}${SHIM_WS_PATH}`, [SHIM_SUBPROTOCOL])
+  sockets.push(socket)
+  const frames: string[] = []
+  socket.on('message', (data: Buffer) => frames.push(data.toString()))
+  const closed = new Promise<{ code: number; reason: string }>((resolve) =>
+    socket.on('close', (code, reason) => resolve({ code, reason: reason.toString() }))
+  )
+  await new Promise<void>((resolve, reject) => {
+    socket.once('open', resolve)
+    socket.once('error', reject)
+  })
+  return { socket, frames, closed }
+}
+
+/** Dials for real, recording how the peer closed on us — the close code IS the fence's answer. */
+function recordingDial(closes: Array<{ code: number; reason: string }>): NonNullable<ShimDialerDeps['dial']> {
+  return async (url, opts) => {
+    const transport = (await ClientTransport.dial(url, opts)) as ShimTransport
+    transport.onClose((code, reason) => closes.push({ code, reason }))
+    return transport
+  }
+}
+
+/** A dialer on an in-memory sandbox: `answer` plays the shim, so handshakes run on virtual time with no I/O. */
+function scriptedDialer(deps: {
+  answer: (hello: ShimDialHello, peer: ScriptedPeer) => void
+  verifier: PodIdentityVerifier
+  clock: VirtualClock
+  metrics?: ClusterMetrics
+  warnings?: string[]
+}): { dialer: ShimDialer; peers: ScriptedPeer[] } {
+  const peers: ScriptedPeer[] = []
+  const dial: NonNullable<ShimDialerDeps['dial']> = async () => {
+    let onMessage: (text: string) => void = () => {}
+    let onClose: (code: number, reason: string) => void = () => {}
+    const peer: ScriptedPeer = {
+      received: [],
+      reply: (frame) => queueMicrotask(() => onMessage(JSON.stringify(frame)))
+    }
+    peers.push(peer)
+    const transport: ShimTransport = {
+      send: (text) => {
+        const frame = parseShimFrame(text)
+        if (!frame) return
+        peer.received.push(frame)
+        if (frame.type === 'shim/hello' && 'agentId' in frame) deps.answer(frame, peer)
+      },
+      onMessage: (cb) => (onMessage = cb),
+      onClose: (cb) => (onClose = cb),
+      close: (code, reason) => {
+        peer.closed ??= { code, reason }
+        queueMicrotask(() => onClose(code, reason))
+      }
+    }
+    return transport
+  }
+  const dialer = new ShimDialer({
+    verifier: deps.verifier,
+    dial,
+    clock: deps.clock,
+    now: () => deps.clock.now(),
+    backoff: pausedBackoff,
+    ...(deps.metrics ? { metrics: deps.metrics } : {}),
+    log: { info: () => {}, warn: (message) => deps.warnings?.push(message) }
+  })
+  dialers.push(dialer)
+  return { dialer, peers }
+}
+
+/** The dial has no socket, so its endpoint is only ever echoed back into the fake. */
+const SCRIPTED_ENDPOINT = 'ws://sandbox.invalid'
+const REQUEST_ID = '11111111-1111-4111-8111-111111111111'
+
 describe('sandbox shim dial-in', () => {
   it('lets the daemon dial a pod IP, TokenReviews its identity, and serves a granted request', async () => {
     const served: unknown[] = []
@@ -99,20 +219,6 @@ describe('sandbox shim dial-in', () => {
         capability: 'materialize'
       }).ok
     ).toBe(true)
-  })
-
-  it('refuses a pod whose reviewed identity does not match the Pod IP launch record', async () => {
-    const { endpoint } = await sandbox()
-    const dialer = new ShimDialer({
-      verifier: {
-        reviewToken: async () => ({ authenticated: true, podName: 'different-pod', podUid: 'pod-uid-2' })
-      },
-      log: { info: () => {}, warn: () => {} }
-    })
-    dialers.push(dialer)
-
-    await expect(dialer.connect(endpoint, record(), 1)).rejects.toThrow(/pod identity|not accepted|connect/)
-    expect(dialer.connectionsFor('agent-a')).toEqual([])
   })
 
   it('waits for the replacement connection while a bound channel is reconnecting', async () => {
@@ -180,4 +286,239 @@ describe('sandbox shim dial-in', () => {
     await expect(dialer.connect(endpoint, record(), 25)).rejects.toThrow(/binding timed out/)
     expect(dialer.connectionsFor('agent-a')).toEqual([])
   })
+})
+
+/** k8s-daemon-pool §7: what the daemon accepts as proof that the socket it dialed is the pod it launched. */
+describe('dial-in identity handshake', () => {
+  it('fails the dial when the shim answers with anything but its identity', async () => {
+    const clock = new VirtualClock()
+    const warnings: string[] = []
+    const reviewToken = vi.fn(async () => ({ authenticated: true, podName: 'sandbox-pod-1', podUid: 'pod-uid-1' }))
+    const { dialer, peers } = scriptedDialer({
+      // A well-formed frame that is not the identity: a peer skipping straight to traffic.
+      answer: (_hello, peer) => peer.reply({ type: 'shim/response', id: REQUEST_ID, ok: true }),
+      verifier: { reviewToken },
+      clock,
+      warnings
+    })
+
+    await expect(runVirtual(clock, dialer.connect(SCRIPTED_ENDPOINT, record(), 500))).rejects.toThrow(
+      /could not connect to sandbox shim/
+    )
+    expect(peers).toHaveLength(1)
+    expect(peers[0]!.closed).toEqual({ code: 4403, reason: 'not bound' })
+    expect(warnings.some((line) => line.includes('shim did not present its identity'))).toBe(true)
+    // Nothing was reviewed, because nothing was presented.
+    expect(reviewToken).not.toHaveBeenCalled()
+    expect(dialer.connectionsFor('agent-a')).toEqual([])
+  })
+
+  it('refuses a dial whose TokenReview does not authenticate, and counts it as an identity failure', async () => {
+    const clock = new VirtualClock()
+    const counted = countingMetrics()
+    const { dialer, peers } = scriptedDialer({
+      answer: (_hello, peer) => peer.reply({ type: 'shim/identity', token: 'not-a-valid-token' }),
+      verifier: { reviewToken: async () => ({ authenticated: false, error: 'token has been invalidated' }) },
+      clock,
+      metrics: counted.metrics
+    })
+
+    await expect(runVirtual(clock, dialer.connect(SCRIPTED_ENDPOINT, record(), 500))).rejects.toThrow(
+      /could not connect to sandbox shim/
+    )
+    // An API-server identity failure is not this daemon fencing a launch, so both counters move.
+    expect(counted.tokenReviews()).toBe(1)
+    expect(counted.rejections).toEqual(['unauthenticated'])
+    expect(peers[0]!.received.at(-1)).toEqual({
+      type: 'shim/rejected',
+      reason: 'unauthenticated',
+      message: 'not accepted'
+    })
+    expect(peers[0]!.closed).toEqual({ code: 4403, reason: 'unauthenticated' })
+    expect(dialer.connectionsFor('agent-a')).toEqual([])
+  })
+
+  it('refuses a shim whose reviewed identity names a pod other than the one dialed', async () => {
+    // A sibling sandbox answering on the dialed address: a pod IP is reusable, so the launch record decides.
+    const clock = new VirtualClock()
+    const counted = countingMetrics()
+    const warnings: string[] = []
+    const { dialer, peers } = scriptedDialer({
+      answer: (_hello, peer) => peer.reply({ type: 'shim/identity', token: 'genuine-token-of-another-pod' }),
+      verifier: { reviewToken: async () => ({ authenticated: true, podName: 'sandbox-pod-2', podUid: 'pod-uid-2' }) },
+      clock,
+      metrics: counted.metrics,
+      warnings
+    })
+
+    await expect(runVirtual(clock, dialer.connect(SCRIPTED_ENDPOINT, record(), 500))).rejects.toThrow(
+      /could not connect to sandbox shim/
+    )
+    expect(counted.rejections).toEqual(['unknown_pod'])
+    // The token itself was accepted, so the identity counter must stay clear.
+    expect(counted.tokenReviews()).toBe(0)
+    expect(peers[0]!.received.at(-1)).toMatchObject({ type: 'shim/rejected', reason: 'unknown_pod' })
+    expect(
+      warnings.some((line) => line.includes('dialed pod sandbox-pod-1 presented identity for sandbox-pod-2'))
+    ).toBe(true)
+    expect(dialer.connectionsFor('agent-a')).toEqual([])
+  })
+
+  it('authenticates only a token minted for the shim audience, and asks for no other', async () => {
+    // Audience separation is what makes handing over the pod's own token safe; the verifier models that rule.
+    const mintedForShim = 'token-for-the-shim-hop'
+    const audiences: string[][] = []
+    const verifier: PodIdentityVerifier = {
+      reviewToken: async (token, requested) => {
+        audiences.push(requested)
+        return requested.includes(SHIM_TOKEN_AUDIENCE) && token === mintedForShim
+          ? { authenticated: true, podName: 'sandbox-pod-1', podUid: 'pod-uid-1' }
+          : { authenticated: false, error: 'audiences is not valid for this token' }
+      }
+    }
+
+    const boundClock = new VirtualClock()
+    const scoped = scriptedDialer({
+      answer: (_hello, peer) => peer.reply({ type: 'shim/identity', token: mintedForShim }),
+      verifier,
+      clock: boundClock
+    })
+    const connection = await runVirtual(boundClock, scoped.dialer.connect(SCRIPTED_ENDPOINT, record(), 500))
+    expect(connection.binding).toMatchObject({ podName: 'sandbox-pod-1', podUid: 'pod-uid-1', generation: 1 })
+
+    // Same pod, same verifier, a token minted for a different hop: it authenticates nothing here.
+    const refusedClock = new VirtualClock()
+    const counted = countingMetrics()
+    const crossHop = scriptedDialer({
+      answer: (_hello, peer) => peer.reply({ type: 'shim/identity', token: 'token-for-another-hop' }),
+      verifier,
+      clock: refusedClock,
+      metrics: counted.metrics
+    })
+    await expect(runVirtual(refusedClock, crossHop.dialer.connect(SCRIPTED_ENDPOINT, record(), 500))).rejects.toThrow(
+      /could not connect to sandbox shim/
+    )
+    expect(counted.rejections).toEqual(['unauthenticated'])
+    expect(crossHop.dialer.connectionsFor('agent-a')).toEqual([])
+    // And this hop never widened what it asked for, on either dial.
+    expect(audiences).toEqual([[SHIM_TOKEN_AUDIENCE], [SHIM_TOKEN_AUDIENCE]])
+  })
+
+  it('supersedes the older launch dial and drops the credential it issued', async () => {
+    const clock = new VirtualClock()
+    const { dialer, peers } = scriptedDialer({
+      answer: (_hello, peer) => peer.reply({ type: 'shim/identity', token: 'projected-token' }),
+      verifier: { reviewToken: async () => ({ authenticated: true, podName: 'sandbox-pod-1', podUid: 'pod-uid-1' }) },
+      clock
+    })
+
+    const first = await runVirtual(clock, dialer.connect(SCRIPTED_ENDPOINT, record(1), 500))
+    const second = await runVirtual(clock, dialer.connect(SCRIPTED_ENDPOINT, record(2), 500))
+
+    expect(second.binding.generation).toBe(2)
+    expect(dialer.connectionsFor('agent-a')).toEqual([second])
+    expect(peers[0]!.closed).toEqual({ code: 4000, reason: 'superseded by a newer launch' })
+    // The superseded launch authorizes nothing at its OWN generation, which is the replay case.
+    expect(dialer.authorize({ credential: first.issuedCredential, generation: 1, capability: 'materialize' })).toEqual({
+      ok: false,
+      failure: 'unknown_credential'
+    })
+    expect(dialer.authorize({ credential: second.issuedCredential, generation: 2, capability: 'materialize' }).ok).toBe(
+      true
+    )
+  })
+})
+
+/** The other side of §7: what the in-sandbox listener refuses before anything is authenticated. */
+describe('shim listener hardening', () => {
+  it('refuses a second daemon connection while one is active, disclosing nothing', async () => {
+    const served: unknown[] = []
+    const { endpoint } = await sandbox({
+      handle: async (_capability, payload) => {
+        served.push(payload)
+        return { written: true }
+      }
+    })
+    const dialer = new ShimDialer({
+      verifier: {
+        reviewToken: async () => ({ authenticated: true, podName: 'sandbox-pod-1', podUid: 'pod-uid-1' })
+      },
+      log: quiet
+    })
+    dialers.push(dialer)
+    const connection = await dialer.connect(endpoint, record(), 5_000)
+
+    // NetworkPolicy admits the whole pool namespace, so the single-slot rule is what stops a second daemon.
+    const port = Number(new URL(endpoint).port)
+    const intruder = await rawDial(port)
+    expect(await intruder.closed).toEqual({ code: 4403, reason: 'unavailable' })
+    // Not one frame: no projected token, no binding, nothing that says what runs in this pod.
+    expect(intruder.frames).toEqual([])
+
+    // And the active channel is undisturbed rather than displaced.
+    const session = new ShimSession('agent-a', 1, {
+      setTimeout: (fn, ms) => setTimeout(fn, ms),
+      clearTimeout: (handle) => clearTimeout(handle as NodeJS.Timeout)
+    })
+    session.attach(connection)
+    await expect(session.request('materialize', { path: 'config.json' })).resolves.toEqual({ written: true })
+    expect(served).toEqual([{ path: 'config.json' }])
+    expect(dialer.connectionsFor('agent-a')).toEqual([connection])
+  })
+
+  it('drops the dial when the sandbox sends an oversized frame before authenticating', async () => {
+    const server = new ShimServer()
+    servers.push(server)
+    const port = await server.start(0, '127.0.0.1')
+    const accepted = server.nextTransport()
+    const closes: Array<{ code: number; reason: string }> = []
+    const dialer = new ShimDialer({
+      verifier: {
+        reviewToken: async () => ({ authenticated: true, podName: 'sandbox-pod-1', podUid: 'pod-uid-1' })
+      },
+      dial: recordingDial(closes),
+      backoff: pausedBackoff,
+      log: quiet
+    })
+    dialers.push(dialer)
+    // Left pending: the assertion is what happens to the socket, not a deadline this test times.
+    const pending = dialer.connect(`ws://127.0.0.1:${port}`, record(), 30_000)
+    void pending.catch(() => undefined)
+
+    // Instead of its identity, 256 KiB + 1 of it: an unproved peer must not choose what the daemon buffers.
+    const shimSide = await accepted
+    shimSide.send('x'.repeat(MAX_FRAME_BYTES + 1))
+
+    await waitFor(() => closes.length > 0)
+    // Torn down rather than closed politely: the frame never became a message at all.
+    expect(closes.map((close) => close.code)).toEqual([1006])
+    expect(dialer.connectionsFor('agent-a')).toEqual([])
+    dialer.stop()
+    await expect(pending).rejects.toThrow(/daemon shutting down/)
+  })
+
+  it('refuses a dial announcing a generation or an agent below the one it already bound', async () => {
+    const { endpoint } = await sandbox({ backoff: fastBackoff() })
+    const verifier: PodIdentityVerifier = {
+      reviewToken: async () => ({ authenticated: true, podName: 'sandbox-pod-1', podUid: 'pod-uid-1' })
+    }
+    const held = new ShimDialer({ verifier, backoff: fastBackoff, log: quiet })
+    dialers.push(held)
+    await held.connect(endpoint, record(2), 8_000)
+    // Free the shim's single slot without advancing the highest generation it has bound.
+    held.stop()
+
+    for (const stale of [record(1), { ...record(2), agentId: 'agent-b' }]) {
+      const closes: Array<{ code: number; reason: string }> = []
+      const dialer = new ShimDialer({ verifier, dial: recordingDial(closes), backoff: fastBackoff, log: quiet })
+      dialers.push(dialer)
+      // Left pending: the assertion is the shim's answer, not a deadline this test would time.
+      const pending = dialer.connect(endpoint, stale, 30_000)
+      void pending.catch(() => undefined)
+      await waitFor(() => closes.some((close) => close.code === 4403 && close.reason === 'stale generation'))
+      expect(dialer.connectionsFor(stale.agentId)).toEqual([])
+      dialer.stop()
+      await expect(pending).rejects.toThrow(/daemon shutting down/)
+    }
+  }, 30_000)
 })


### PR DESCRIPTION
## Summary

Closes the coverage gaps in the daemon→shim dial-in handshake described by
[`docs/designs/k8s-daemon-pool.md` §7](docs/designs/k8s-daemon-pool.md) (issue #955, M3 exit criterion).

The path had a happy case and a reconnect case, but almost none of its **refusals** were
asserted. Where a negative case existed at all, it was on the accept-side listener — a
different code path whose decisions differ (its wire rejection is deliberately uniform,
the dialer's is not; it looks a pod up in a spawn registry, the dialer matches against the
launch it dialed). This adds the missing negatives against the dialer, the in-sandbox
listener and the binding registry.

Test-only. No production code was changed — including for the defect in the next section,
which is reported rather than patched.

## Defect found, NOT fixed — an oversized pre-authentication frame crashes the receiving process

Both WebSocket accept paths cap inbound frames at `MAX_FRAME_BYTES` (256 KiB) via `maxPayload`,
but neither registers an `'error'` listener on the accepted socket. `ws` emits `'error'` on the
socket when the cap is exceeded, and an `'error'` event with no listener is an **uncaught
exception** in Node — the process dies.

- `packages/daemon/src/shim/server.ts` — the in-sandbox listener. Reachable by anything the
  sandbox NetworkPolicy admits, **before** any token is presented.
- `packages/daemon/src/shim/listener.ts` — the accept-side listener, same shape, same
  pre-authentication exposure.

Reproduced directly: connect with the right subprotocol, send `MAX_FRAME_BYTES + 1` bytes, and
the peer correctly sees close 1009 while the receiving process takes
`RangeError: Max payload size exceeded (WS_ERR_UNSUPPORTED_MESSAGE_LENGTH)` as an uncaught
exception. Under Vitest this fails the whole run even though every assertion passed, which is
why the shim-side half of invariant 7 could not be committed as a test here — the missing
handler turns it into a run-level failure.

The dial-out side already guards exactly this case
(`packages/connection/src/ws-client-transport.ts`: `ws.on('error', () => ws.terminate())`, with a
comment noting that otherwise "that crashes the process"). The accept side simply never got the
same guard. The fix is that one line on each accepted socket, but it is a production behaviour
change and belongs in its own PR rather than hidden in a test suite.

Invariant 7 is therefore covered here in the direction that is safe today: the daemon's own
socket, which does hold the guard, drops the dial when the sandbox sends an oversized frame
before authenticating.

## Not implemented: the term

§7 specifies the fence as **term** alongside generation ("a dial carrying a higher term
supersedes and closes the current connection, a lower term is refused, and the same term is
accepted only from the same holder"). There is no `term` anywhere in `packages/daemon/src/shim/`
today — the duty ledger has one (`src/cp/duty-registry.ts`), but it is not plumbed into the
handshake. What exists is the **generation**, which already enforces exactly those three rules
(`ShimBindingRegistry.bind()`), so this PR covers the generation and leaves the term to whichever
change introduces it. Two consequences worth recording:

- the "higher term supersedes and closes the current connection" clause is not realised at the
  shim: while a channel is active, a second dial is refused with `unavailable` regardless of what
  it announces. Supersession happens daemon-side instead, in `ShimDialer.connect()`, which stops
  the older dial before starting the new one (now covered).
- the lower-and-same fences do exist at the shim, keyed on generation (now covered).

## Invariant → test coverage

| § | Invariant | Status | Test |
| - | --------- | ------ | ---- |
| 1 | Shim presents its audience-restricted projected token on accept | existing | `shim-dial-in.test.ts` › `lets the daemon dial a pod IP, TokenReviews its identity, and serves a granted request` |
| 1 | A dialer that never receives an identity frame fails the connection | **added** | `dial-in identity handshake` › `fails the dial when the shim answers with anything but its identity` |
| 2 | TokenReview rejection ⇒ refused, `tokenReviewRejected` fires | **added** (dialer) | `dial-in identity handshake` › `refuses a dial whose TokenReview does not authenticate, and counts it as an identity failure` |
| 2 | Same, on the accept-side listener | existing | `shim-handshake.test.ts` › `counts an API-server token rejection apart from this daemon fencing a frame` |
| 3 | A token naming a DIFFERENT pod than the one dialed is refused | **strengthened** | `dial-in identity handshake` › `refuses a shim whose reviewed identity names a pod other than the one dialed` |
| 4 | The verifier is called with the expected audience | existing | `shim-dial-in.test.ts` › `lets the daemon dial a pod IP…` (asserts `[SHIM_TOKEN_AUDIENCE]`) |
| 4 | A token for another audience does not authenticate this hop | **added** | `dial-in identity handshake` › `authenticates only a token minted for the shim audience, and asks for no other` |
| 5 | Higher fence supersedes and closes the current connection | **added** (generation, daemon-side) | `dial-in identity handshake` › `supersedes the older launch dial and drops the credential it issued` |
| 5 | Lower fence refused | **added** (at the shim) | `shim listener hardening` › `refuses a dial announcing a generation or an agent below the one it already bound` |
| 5 | Lower fence refused, at the registry | existing | `shim-handshake.test.ts` › `rejects a lower generation instead of replacing the current binding` |
| 5 | Same fence accepted only from the same holder (transport-break recovery) | existing | `shim-handshake.test.ts` › `allows the same generation from the same pod: renewal and reconnect do not relaunch` + `refuses the same generation from a DIFFERENT pod, which is the ambiguous case` |
| 5 | The term itself | **not implemented** | see above |
| 6 | A second concurrent dial neither displaces nor discloses | **added** | `shim listener hardening` › `refuses a second daemon connection while one is active, disclosing nothing` |
| 6 | Queued-slot behaviour on replacement | existing | `shim-dial-in.test.ts` › `waits for the replacement connection while a bound channel is reconnecting` + `replays frames that arrived while the accepted daemon socket was still unclaimed` |
| 7 | An oversized pre-authentication frame closes the connection | **added** (daemon socket) | `shim listener hardening` › `drops the dial when the sandbox sends an oversized frame before authenticating` |
| 7 | Same, on the in-sandbox listener | **blocked** | crashes the process — see the defect section |
| 8 | Stale generation refused with 4403 | **added** | `shim listener hardening` › `refuses a dial announcing a generation or an agent below the one it already bound` |
| 8 | Generation fence at the registry (replay) | existing | `shim-handshake.test.ts` › `refuses a stale generation even with a live credential` + `re-binds a rescheduled pod under a NEW uid and drops the previous credential` |

The pod-mismatch case is marked *strengthened* rather than *existing*: the test that carried
that name asserted `rejects.toThrow(/pod identity|not accepted|connect/)` behind a **1 ms** dial
deadline, so it passed on the timeout — the word `connect` matches
`could not connect to sandbox shim: binding timed out after 1ms` — and would have gone on passing
with the pod check deleted. It is replaced by a version that asserts the `unknown_pod` counter,
that the identity counter stays clear, the rejection the shim receives, and the daemon's own
diagnosis.

## How the new tests are built

No new harness. The dialer cases inject a `ShimTransport` that plays the sandbox in memory —
the same shape the existing `ShimClient` tests use — driven by the suite's `VirtualClock` /
`runVirtual` from `test/fakes/virtual-clock.ts`. Each refusal is therefore exactly one dial
attempt with no socket and no wall-clock sleep (retry backoff is parked past the deadline on
purpose). The listener cases keep real sockets, because there the close code *is* the assertion,
and they wait on `waitFor`, never on a fixed sleep.

## Test plan

Mutation-checked — each new test was confirmed to fail when the guard it covers is disabled:

| Guard disabled | Test that failed |
| -------------- | ---------------- |
| `review.podName !== record.podName` in `dialer.ts` | `refuses a shim whose reviewed identity names a pod other than the one dialed` |
| the `active \|\| queued` refusal in `server.ts` | `refuses a second daemon connection while one is active, disclosing nothing` |
| the `highestBinding` fence in `client.ts` | `refuses a dial announcing a generation or an agent below the one it already bound` |

Stability — `shim-dial-in`, `shim-handshake`, `shim-channels`, `shim-tunnel`, `shim-pod-env`,
`shim-provider-env` run **3×**, `85 passed (85)` every time, no unhandled errors. The new file
runs in ~190 ms.

```
pnpm --filter @agentconnect.md/daemon exec vitest run test/shim-*.test.ts
pnpm typecheck   # clean (needs pnpm build first, for @agentconnect.md/protocol types)
pnpm lint        # clean
pnpm format:check # clean
```

`shim-cancellation` (5), `shim-exec-handler` (1) and `shim-workspace-files` (7) fail on this
macOS sandbox for environment reasons. Verified identical on `origin/main` before any change on
this branch — same three files, same 13 failures, same assertions — and identical again with the
change applied. Untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
