### PR TITLE
fix: clear a pool member's stale staged-move fence on a move back onto the pool

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -760,6 +760,7 @@ export function buildContainer(
     sessionOwners: connReg,
     placement: placementResolver,
     memberSets: repos.memberSet,
+    liveness: connReg,
     recomputeDuties: (orgId: string) => dutyRecompute.kick(orgId),
     log: { warn: (o, m) => http.log.warn(o, m) }
   })

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1360,6 +1360,7 @@ export function agentRoutes(deps: HttpDeps) {
       sessionOwners: deps.sessionOwners,
       placement: deps.placementResolver,
       memberSets: deps.repos.memberSet,
+      liveness: deps.liveness,
       ...(deps.recomputeDuties ? { recomputeDuties: deps.recomputeDuties } : {}),
       log: app.log
     })

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -1,4 +1,4 @@
-import { onDaemon, placementTargetOf, samePlacement, type PlacementTarget } from '../domain/placement.js'
+import { onDaemon, onSet, placementTargetOf, samePlacement, type PlacementTarget } from '../domain/placement.js'
 import { describe, expect, it } from 'vitest'
 import type { Ack, AgentActivate, AgentDetach } from '@agentconnect.md/protocol'
 import { AgentId, BotId, CronId, DaemonId, IntegrationId, OrgId } from '../domain/ids.js'
@@ -40,6 +40,9 @@ const TARGET = DaemonId('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')
 const INTEGRATION = IntegrationId('22222222-2222-4222-8222-222222222222')
 const BOT = BotId('33333333-3333-4333-8333-333333333333')
 const CRON = CronId('44444444-4444-4444-8444-444444444444')
+const MEMBER = DaemonId('cccccccc-cccc-4ccc-8ccc-cccccccccccc')
+const OFFLINE_MEMBER = DaemonId('dddddddd-dddd-4ddd-8ddd-dddddddddddd')
+const SET = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
 const MODIFIED_AT = new Date('2026-07-11T00:00:00.000Z')
 const SESSION_KEY = { platform: 'slack' as const, channel: 'C-move', thread: 'T-move' }
 const WORKSPACE_REPO_ID = 4242n
@@ -155,11 +158,20 @@ function make(
     workspaceRepoId?: bigint
     sourceDetachStarted?: () => void
     waitSourceDetach?: Promise<void>
+    /** Which set each daemon belongs to (absent daemon ⇒ no set) + each set's members. */
+    sets?: { setIdOf: Record<string, string>; members: Record<string, string[]> }
+    /** Daemon ids the liveness fake reports READY; others read as disconnected. */
+    readyDaemons?: string[]
+    /** Placement columns merged over the initial record (e.g. a `set` placement). */
+    placement?: Partial<AgentRecord>
   } = {}
 ) {
   let current: AgentRecord = {
     ...agent(opts.unplaced ? null : SOURCE),
-    ...(opts.workspace ? { workspace: opts.workspace, workspaceRepoId: opts.workspaceRepoId ?? WORKSPACE_REPO_ID } : {})
+    ...(opts.workspace
+      ? { workspace: opts.workspace, workspaceRepoId: opts.workspaceRepoId ?? WORKSPACE_REPO_ID }
+      : {}),
+    ...(opts.placement ?? {})
   }
   let cronRows = [cron]
   const calls: string[] = []
@@ -296,7 +308,23 @@ function make(
     httpBot: { syncBot: async () => void calls.push('http') } as unknown as HttpBotOrchestrator,
     collabRoutes: { broadcast: async () => void calls.push('collab') } as unknown as CollabRoutesService,
     mutations,
-    sessionOwners: { releaseSession: (key) => void releasedLive.push(key as typeof SESSION_KEY) }
+    sessionOwners: { releaseSession: (key) => void releasedLive.push(key as typeof SESSION_KEY) },
+    ...(opts.sets
+      ? {
+          memberSets: {
+            setIdOf: async (daemonId: string) => opts.sets!.setIdOf[daemonId] ?? null,
+            memberIdsOf: async (setId: string) => opts.sets!.members[setId] ?? []
+          }
+        }
+      : {}),
+    ...(opts.readyDaemons
+      ? {
+          liveness: {
+            get: (daemonId: string) =>
+              opts.readyDaemons!.includes(daemonId) ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined
+          }
+        }
+      : {})
   })
   return { service, calls, activations, detaches, frameOrgs, mutations, releasedLive, current: () => current }
 }
@@ -559,6 +587,65 @@ describe('AgentMoveService', () => {
     await expect(t.service.move(t.current(), onDaemon(TARGET))).rejects.toThrow('placement changed during move')
     expect(t.calls.at(-1)).toBe(`detach:${TARGET}`)
     expect(t.calls).not.toContain(`activate:${SOURCE}`)
+  })
+
+  it('a set commit broadcasts a token-less unstage to live members the move never staged (#1093)', async () => {
+    const t = make({
+      sets: { setIdOf: { [MEMBER]: SET }, members: { [SET]: [MEMBER, OFFLINE_MEMBER] } },
+      readyDaemons: [MEMBER]
+    })
+    await expect(t.service.move(t.current(), onSet(SET))).resolves.toBeDefined()
+
+    // The machine source stays fenced; the live member's possible stale fence is released token-less.
+    expect(t.calls).not.toContain(`activate:${SOURCE}`)
+    expect(t.calls).not.toContain(`activate:${OFFLINE_MEMBER}`)
+    expect(t.calls).toContain(`activate:${MEMBER}`)
+    expect(t.activations).toHaveLength(1)
+    expect(t.activations[0]?.agentId).toBe(AGENT)
+    expect(t.activations[0]?.moveId).toBeUndefined()
+  })
+
+  it('a staged source that is itself a member keeps its exact token and is not broadcast to twice', async () => {
+    const t = make({
+      sets: { setIdOf: { [SOURCE]: SET }, members: { [SET]: [SOURCE] } },
+      readyDaemons: [SOURCE]
+    })
+    await expect(t.service.move(t.current(), onSet(SET))).resolves.toBeDefined()
+
+    expect(t.activations).toHaveLength(1)
+    expect(t.activations[0]?.moveId).toBe(t.detaches[0]?.moveId)
+  })
+
+  it('reconnect recovery releases a reported stale fence for an eligible member that serves nothing', async () => {
+    const t = make({
+      placement: { placementKind: 'set', setId: SET, daemonId: null },
+      sets: { setIdOf: { [MEMBER]: SET }, members: { [SET]: [MEMBER] } },
+      readyDaemons: [MEMBER]
+    })
+    await t.service.recoverStaged(AGENT, MEMBER, STAGED_MOVE)
+
+    expect(t.detaches).toEqual([])
+    expect(t.activations).toHaveLength(1)
+    expect(t.activations[0]).toMatchObject({ agentId: AGENT, moveId: STAGED_MOVE })
+  })
+
+  it('reconnect recovery leaves a fence armed when the reporter is not an eligible holder', async () => {
+    // A daemon in no set reporting a fence for a set-placed agent stays fenced.
+    const nonMember = make({
+      placement: { placementKind: 'set', setId: SET, daemonId: null },
+      sets: { setIdOf: {}, members: { [SET]: [] } },
+      readyDaemons: []
+    })
+    await nonMember.service.recoverStaged(AGENT, SOURCE, STAGED_MOVE)
+    expect(nonMember.activations).toEqual([])
+
+    // A member reporting a fence for a MACHINE-placed agent stays fenced too.
+    const pinned = make({
+      sets: { setIdOf: { [MEMBER]: SET }, members: { [SET]: [MEMBER] } },
+      readyDaemons: [MEMBER]
+    })
+    await pinned.service.recoverStaged(AGENT, MEMBER, STAGED_MOVE)
+    expect(pinned.activations).toEqual([])
   })
 })
 

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -624,9 +624,12 @@ describe('AgentMoveService', () => {
     })
     await t.service.recoverStaged(AGENT, MEMBER, STAGED_MOVE)
 
+    // Token-less, exactly like the commit broadcast: `mayAct` was false, so the reporter releases
+    // its fence without being told to run the agent — the daemon leaves the host down (#1093).
     expect(t.detaches).toEqual([])
     expect(t.activations).toHaveLength(1)
-    expect(t.activations[0]).toMatchObject({ agentId: AGENT, moveId: STAGED_MOVE })
+    expect(t.activations[0]).toMatchObject({ agentId: AGENT })
+    expect(t.activations[0]?.moveId).toBeUndefined()
   })
 
   it('reconnect recovery leaves a fence armed when the reporter is not an eligible holder', async () => {

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -274,7 +274,7 @@ export class AgentMoveService {
       if (!current) return
       if (!(await (this.deps.placement ?? PLACEMENT_ONLY).mayAct(current, daemonId))) {
         // A member that missed a set-commit unstage while offline reports its stale fence here (#1093).
-        await this.unstageReportedFence(current, daemonId, moveId)
+        await this.unstageReportedFence(current, daemonId)
         return
       }
 
@@ -632,13 +632,14 @@ export class AgentMoveService {
   }
 
   /** Reconnect backstop: release a reported fence when the reporter is an eligible set member. */
-  private async unstageReportedFence(agent: AgentRecord, daemonId: DaemonId, moveId: string): Promise<void> {
+  private async unstageReportedFence(agent: AgentRecord, daemonId: DaemonId): Promise<void> {
     const memberSets = this.deps.memberSets
     const target = placementTargetOf(agent)
     if (!memberSets || target.kind !== 'set') return
     const setId = await memberSets.setIdOf(daemonId)
     if (!mayHold(placementColumns(target), { daemonId, scope: claimScopeOf({ setId }) })) return
-    await this.bestEffortUnstage(agent, await this.snapshot(agent), daemonId, moveId)
+    // Token-less like the commit broadcast: `mayAct` said no, so this member must release without running.
+    await this.bestEffortUnstage(agent, await this.snapshot(agent), daemonId)
   }
 
   /** The target set's READY members — who a set commit may need to unstage. */

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -68,6 +68,7 @@ import type { HttpBotOrchestrator } from './httpBot.js'
 import type { CollabRoutesService } from './collabRoutes.service.js'
 import type { AgentMutationGate } from './agentMutationGate.js'
 import type { SessionKey } from '../domain/sessionKey.js'
+import type { DaemonLiveness } from '../ports.js'
 
 export class AgentMoveConflict extends Error {
   constructor(message: string) {
@@ -119,7 +120,9 @@ export interface AgentMoveDeps {
   sessionOwners: { releaseSession(key: SessionKey): void }
   /** Set membership, for deciding whether a detached source is still an eligible holder of the
    *  new placement. Absent ⇒ no source is ever unstaged, the pre-pool behavior. */
-  memberSets?: Pick<MemberSetRepo, 'setIdOf'>
+  memberSets?: Pick<MemberSetRepo, 'setIdOf' | 'memberIdsOf'>
+  /** Live-connection reads for the set-commit unstage broadcast. Absent ⇒ no member is broadcast to. */
+  liveness?: DaemonLiveness
   /** Resolves the members currently serving an agent — the sources a move must quiesce when
    *  placement names no machine of its own. Absent ⇒ placement alone (the pre-duty behavior). */
   placement?: PlacementResolver
@@ -268,7 +271,12 @@ export class AgentMoveService {
     const release = await this.deps.mutations.beginMoveWhenIdle(agentId)
     try {
       const current = await this.deps.agents.getUnscoped(agentId)
-      if (!current || !(await (this.deps.placement ?? PLACEMENT_ONLY).mayAct(current, daemonId))) return
+      if (!current) return
+      if (!(await (this.deps.placement ?? PLACEMENT_ONLY).mayAct(current, daemonId))) {
+        // A member that missed a set-commit unstage while offline reports its stale fence here (#1093).
+        await this.unstageReportedFence(current, daemonId, moveId)
+        return
+      }
 
       const candidate = await this.snapshotOwned(agentId, daemonId, current.orgId)
       const resumed = await this.deps.control.agentActivate(
@@ -312,11 +320,11 @@ export class AgentMoveService {
   private async ensureActiveLocked(agent: AgentRecord): Promise<AgentRecord> {
     const placement = placementTargetOf(agent)
     if (placement.kind === 'unplaced') throw new AgentMoveConflict('agent is not placed')
-    // Repairing a pool placement is the ledger's job, not a synchronous activation: the CP does
-    // not choose which member serves it, so the honest repair is to re-derive its duty group and
-    // let the next lease exchange grant and install it.
+    // Repairing a pool placement is the ledger's job: re-derive the duty group, clear any stale
+    // member fence that would make the next grant a dark hold, and let the lease exchange install.
     if (placement.kind !== 'daemon') {
       this.deps.recomputeDuties?.(agent.orgId)
+      await this.unstageEligibleSources(agent, new Map(), placement)
       await this.convergeDerived(agent, (await this.snapshot(agent)).httpBotIds)
       return agent
     }
@@ -575,52 +583,72 @@ export class AgentMoveService {
     return stable.agent
   }
 
-  /**
-   * Clear the staging fence on a source that is STILL an eligible holder of the new placement.
-   *
-   * A detached source is normally meant to stay fenced — that is the whole point of a hard
-   * cutover, and it is right for every move onto a machine and for a LOCAL daemon losing an agent
-   * to a set: neither may serve it again. `daemon(member) → its own set` is the one transition
-   * where it is wrong. The member is still in that set, so the ledger may hand it the very group
-   * it was just fenced out of — and `installGrantedAgents` skips a move-staged agent, so it would
-   * take the lease, install nothing, and serve nothing, with no other member able to claim it. The
-   * agent would be servable by nobody, which is worse than where it started.
-   *
-   * So the fence is released with the same move token that armed it, which is also what leaves
-   * the member's replica current: if the ledger grants it back, install-on-grant sees the agent
-   * present at the granted revision and skips the fetch entirely. Eligibility is the resolver's
-   * answer, not a kind test — a daemon in no set is never eligible for a set placement and stays
-   * fenced. Best-effort: the fence is the member's own state and a member that cannot be reached
-   * re-registers into a reconcile that has the authoritative placement.
-   */
+  /** Clear staging fences wherever the new placement makes a daemon an eligible holder again (#1093). */
   private async unstageEligibleSources(
     agent: AgentRecord,
     stagedSources: ReadonlyMap<DaemonId, string>,
     target: PlacementTarget
   ): Promise<void> {
-    if (stagedSources.size === 0 || !this.deps.memberSets) return
     const memberSets = this.deps.memberSets
+    if (!memberSets) return
+    // A set commit also clears fences from EARLIER moves off that set (pool→machine→pool), token-less.
+    const staleMembers =
+      target.kind === 'set'
+        ? (await this.liveSetMembers(target.setId)).filter((daemonId) => !stagedSources.has(daemonId))
+        : []
+    if (stagedSources.size === 0 && staleMembers.length === 0) return
     const columns = placementColumns(target)
     const bundle = await this.snapshot(agent)
+    // The arming token releases the fence and leaves the replica current; non-members stay fenced.
     for (const [daemonId, moveId] of stagedSources) {
       const setId = await memberSets.setIdOf(daemonId)
       if (!mayHold(columns, { daemonId, scope: claimScopeOf({ setId }) })) continue
-      try {
-        requireAck(
-          'source unstage',
-          await this.deps.control.agentActivate(
-            daemonId,
-            { ...this.activationDefinition(agent, bundle), moveId },
-            agent.orgId
-          )
-        )
-      } catch (err) {
-        this.deps.log?.warn(
-          { err, agentId: agent.id, daemonId },
-          'agent move: could not clear the source staging fence; its reconnect reconcile is the backstop'
-        )
-      }
+      await this.bestEffortUnstage(agent, bundle, daemonId, moveId)
     }
+    for (const daemonId of staleMembers) await this.bestEffortUnstage(agent, bundle, daemonId)
+  }
+
+  private async bestEffortUnstage(
+    agent: AgentRecord,
+    bundle: MoveBundle,
+    daemonId: DaemonId,
+    moveId?: string
+  ): Promise<void> {
+    try {
+      requireAck(
+        'source unstage',
+        await this.deps.control.agentActivate(
+          daemonId,
+          { ...this.activationDefinition(agent, bundle), ...(moveId === undefined ? {} : { moveId }) },
+          agent.orgId
+        )
+      )
+    } catch (err) {
+      this.deps.log?.warn(
+        { err, agentId: agent.id, daemonId },
+        'agent move: could not clear the source staging fence; its reconnect reconcile is the backstop'
+      )
+    }
+  }
+
+  /** Reconnect backstop: release a reported fence when the reporter is an eligible set member. */
+  private async unstageReportedFence(agent: AgentRecord, daemonId: DaemonId, moveId: string): Promise<void> {
+    const memberSets = this.deps.memberSets
+    const target = placementTargetOf(agent)
+    if (!memberSets || target.kind !== 'set') return
+    const setId = await memberSets.setIdOf(daemonId)
+    if (!mayHold(placementColumns(target), { daemonId, scope: claimScopeOf({ setId }) })) return
+    await this.bestEffortUnstage(agent, await this.snapshot(agent), daemonId, moveId)
+  }
+
+  /** The target set's READY members — who a set commit may need to unstage. */
+  private async liveSetMembers(setId: string): Promise<DaemonId[]> {
+    const { memberSets, liveness } = this.deps
+    if (!memberSets || !liveness) return []
+    return (await memberSets.memberIdsOf(setId)).filter((daemonId) => {
+      const live = liveness.get(daemonId)
+      return live?.reachable === true && live.state === 'READY'
+    }) as DaemonId[]
   }
 
   private async restoreDetachedWorkspace(

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -633,11 +633,10 @@ describe('PUT /agents/:id/daemon — the pool as a placement target', () => {
       daemonId: null,
       status: 'active'
     })
-    // The source is quiesced; the pool member is NOT activated — install-on-grant does that when
-    // the ledger picks a member, and naming one here would only pre-empt a choice that is not the
-    // control plane's to make.
+    // The source is quiesced and no member is chosen — install-on-grant does that when the ledger
+    // picks one. The only member traffic is the token-less stale-fence release (#1093).
     expect(control.calls.filter((c) => c.startsWith('detach:'))).toContain(`detach:${SOURCE}`)
-    expect(control.calls.some((c) => c.startsWith('activate:'))).toBe(false)
+    expect(control.activateCalls.map((a) => [a.daemonId, a.value.moveId])).toEqual([[MEMBER, undefined]])
   })
 
   it('moves back off the pool onto a machine, quiescing the member that holds it', async () => {
@@ -809,5 +808,70 @@ describe('PUT /agents/:id/daemon — converting a member-pinned agent to the poo
     expect(res.statusCode).toBe(200)
     expect(control.calls).toContain(`detach:${SOURCE}`)
     expect(control.calls).not.toContain(`activate:${SOURCE}`)
+  })
+})
+
+describe('PUT /agents/:id/daemon — a two-hop move back onto the pool (#1093)', () => {
+  // pool → machine leaves the sourcing member fenced by design; moving back used to unstage only
+  // the SECOND hop's sources, so the first-hop fence survived on the still-alive member — the
+  // ledger could then grant it the group and `installGrantedAgents` would skip the fenced agent,
+  // a lease held while serving nothing. The set commit now also broadcasts a token-less activate.
+  it('releases the member’s first-hop fence when the agent moves back onto the pool', async () => {
+    await seedMoveDaemons()
+    await seedPoolMember()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    await prisma.agent.update({
+      where: { id: agentId },
+      data: { placementKind: 'set', setId: await poolSetId(prisma), daemonId: null }
+    })
+    // MEMBER holds the agent's duty, so hop 1 quiesces (and fences) it as a source.
+    const groupId = randomUUID()
+    await prisma.dutyGroup.create({
+      data: {
+        id: groupId,
+        orgId: DEFAULT_ORG_ID,
+        holder: MEMBER,
+        term: 1n,
+        expiresAt: new Date(Date.now() + 120_000)
+      }
+    })
+    await prisma.dutyGroupMember.create({
+      data: { kind: 'agent', refId: agentId, groupId, orgId: DEFAULT_ORG_ID }
+    })
+    const control = new MoveControlSpy()
+    running = buildHttpApp(prisma, undefined, poolLive, control as unknown as ControlSender)
+
+    const hop1 = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { daemonId: TARGET }
+    })
+    expect(hop1.statusCode, hop1.body).toBe(200)
+    // The member is fenced and correctly left fenced while the agent is machine-placed.
+    expect(control.detaches.some((d) => d.daemonId === MEMBER)).toBe(true)
+    expect(control.activateCalls.filter((a) => a.daemonId === MEMBER)).toEqual([])
+
+    // Model the ledger sweep dropping the group once the agent left the pool.
+    await prisma.dutyGroupMember.deleteMany({ where: { groupId } })
+    await prisma.dutyGroup.delete({ where: { id: groupId } })
+    const hop1Activates = control.activateCalls.length
+
+    const hop2 = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { placementKind: 'pool' }
+    })
+    expect(hop2.statusCode, hop2.body).toBe(200)
+    expect(hop2.json()).toMatchObject({ placementKind: 'set', daemonId: null })
+
+    // The commit broadcasts a token-less activate to the member the second hop never staged.
+    const memberUnstage = control.activateCalls.slice(hop1Activates).filter((a) => a.daemonId === MEMBER)
+    expect(memberUnstage).toHaveLength(1)
+    expect(memberUnstage[0]!.value.agentId).toBe(agentId)
+    expect(memberUnstage[0]!.value.moveId).toBeUndefined()
+    // The second hop's machine source is not an eligible holder: fenced and left fenced.
+    expect(control.detaches.some((d) => d.daemonId === TARGET)).toBe(true)
+    expect(control.activateCalls.slice(hop1Activates).filter((a) => a.daemonId === TARGET)).toEqual([])
   })
 })

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -869,7 +869,9 @@ describe('PUT /agents/:id/daemon — a two-hop move back onto the pool (#1093)',
     const memberUnstage = control.activateCalls.slice(hop1Activates).filter((a) => a.daemonId === MEMBER)
     expect(memberUnstage).toHaveLength(1)
     expect(memberUnstage[0]!.value.agentId).toBe(agentId)
-    expect(memberUnstage[0]!.value.moveId).toBeUndefined()
+    // Token-less across BOTH hops is what leaves the released member's host down: the daemon reads it
+    // as "release the fence, run nothing", so only a later duty grant can start the agent there.
+    expect(control.activateCalls.filter((a) => a.daemonId === MEMBER).map((a) => a.value.moveId)).toEqual([undefined])
     // The second hop's machine source is not an eligible holder: fenced and left fenced.
     expect(control.detaches.some((d) => d.daemonId === TARGET)).toBe(true)
     expect(control.activateCalls.slice(hop1Activates).filter((a) => a.daemonId === TARGET)).toEqual([])

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -21658,14 +21658,18 @@ export class Daemon {
       },
       applyAgentActivate: (activate: AgentActivate): Promise<Ack> => {
         const { agentId } = activate
-        return this.queueAgentMove('activate', agentId, activate.moveId, async () => {
+        return this.queueAgentMove('activate', agentId, activate.moveId ?? 'unstage', async () => {
           if (this.opts.agentName) {
             return { ok: false, reason: 'agent move is unavailable in --agent single-agent mode' }
           }
           const stage = this.moveStageMetadata.get(agentId)
-          if (stage?.moveId === activate.moveId && stage.state === 'committed') return { ok: true }
+          // A token-less activate releases whatever stale staging fence remains (#1093); none ⇒ no-op.
+          if (activate.moveId === undefined && stage?.state !== 'staging') return { ok: true }
+          // Token-less ⇒ adopt the stored fence's token, so commit supersedes the stale move exactly.
+          const moveId = activate.moveId ?? stage!.moveId
+          if (stage?.moveId === moveId && stage.state === 'committed') return { ok: true }
           if (
-            stage?.moveId !== activate.moveId ||
+            stage?.moveId !== moveId ||
             stage.state !== 'staging' ||
             !this.moveStagedAgents.has(agentId) ||
             !this.drainingAgents.has(agentId)
@@ -21721,10 +21725,12 @@ export class Daemon {
             if (this.agentRemovalPending(agentId)) {
               return { ok: false, reason: 'agent/activate: superseded by a newer agent removal' }
             }
-            // The staged-move gate remains closed, so an authoritative activate
-            // can safely clear a failed-removal crash tombstone before its
-            // reconcile/host proof. Any later failure restores the move gate.
+            // The staged gate stays closed, so a tokened activate may clear a crash tombstone here.
             if (this.removedAgentTombstones.has(agentId) || this.cpDroppedAgents.has(agentId)) {
+              // A token-less unstage is not an authoritative re-add: never resurrect a removed agent.
+              if (activate.moveId === undefined) {
+                return { ok: false, reason: 'agent/activate: a removal tombstone owns this agent' }
+              }
               this.clearRemovalForReadd(agentId)
             }
             // Dependents were pruned while the agent was still invisible. Publish the
@@ -21817,7 +21823,7 @@ export class Daemon {
               }
             }
             try {
-              commitAgentMove(this.agentsDir, agentId, activate.moveId)
+              commitAgentMove(this.agentsDir, agentId, moveId)
             } catch (err) {
               await this.stopHost(agentId).catch(() => {})
               try {
@@ -21831,7 +21837,7 @@ export class Daemon {
               await this.flushReconcile().catch(() => {})
               return { ok: false, reason: `agent/activate: failed to commit staging fence: ${(err as Error).message}` }
             }
-            this.moveStageMetadata.set(agentId, { moveId: activate.moveId, state: 'committed' })
+            this.moveStageMetadata.set(agentId, { moveId, state: 'committed' })
             if (!this.agentDestructivePending(agentId)) this.drainingAgents.delete(agentId)
             return { ok: true }
           } finally {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -21667,6 +21667,9 @@ export class Daemon {
           if (activate.moveId === undefined && stage?.state !== 'staging') return { ok: true }
           // Token-less ⇒ adopt the stored fence's token, so commit supersedes the stale move exactly.
           const moveId = activate.moveId ?? stage!.moveId
+          // An unstage restores the replica, not serving authority: a non-holder must not bind the sandbox (#1093).
+          // Tokened stays host-proving: its target is the placement, or a source whose duty the move never released.
+          const proveHost = activate.moveId !== undefined || this.servesAgent(agentId)
           if (stage?.moveId === moveId && stage.state === 'committed') return { ok: true }
           if (
             stage?.moveId !== moveId ||
@@ -21786,23 +21789,24 @@ export class Daemon {
                 return { ok: false, reason: `agent/activate: workspace preparation failed: ${(err as Error).message}` }
               }
             }
-            // Prove the target can actually initialize ACP while the staging gate is
-            // still closed. Workspace reconciliation happens first so the spawned
-            // runtime and its sandbox bind the new directory, never an unlinked old one.
-            try {
-              await this.ensureHostAsync(agentId, { allowAgentDrain: true })
-            } catch (err) {
-              this.moveStagedAgents.add(agentId)
-              await this.stopHost(agentId).catch(() => {})
+            // Prove ACP can initialize under the still-closed gate; the workspace reconciled first, so the
+            // spawned runtime and its sandbox bind the new directory rather than an unlinked old one.
+            if (proveHost) {
               try {
-                await rollbackPreparedWorkspace?.()
-              } catch (rollbackErr) {
-                this.log.error(
-                  `agent/activate: failed to roll workspace back for "${agentId}": ${formatErr(rollbackErr)}`
-                )
+                await this.ensureHostAsync(agentId, { allowAgentDrain: true })
+              } catch (err) {
+                this.moveStagedAgents.add(agentId)
+                await this.stopHost(agentId).catch(() => {})
+                try {
+                  await rollbackPreparedWorkspace?.()
+                } catch (rollbackErr) {
+                  this.log.error(
+                    `agent/activate: failed to roll workspace back for "${agentId}": ${formatErr(rollbackErr)}`
+                  )
+                }
+                await this.flushReconcile().catch(() => {})
+                return { ok: false, reason: `agent/activate: ${(err as Error).message}` }
               }
-              await this.flushReconcile().catch(() => {})
-              return { ok: false, reason: `agent/activate: ${(err as Error).message}` }
             }
             if (this.agentDestructivePending(agentId)) {
               this.moveStagedAgents.add(agentId)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -21667,9 +21667,6 @@ export class Daemon {
           if (activate.moveId === undefined && stage?.state !== 'staging') return { ok: true }
           // Token-less ⇒ adopt the stored fence's token, so commit supersedes the stale move exactly.
           const moveId = activate.moveId ?? stage!.moveId
-          // An unstage restores the replica, not serving authority: a non-holder must not bind the sandbox (#1093).
-          // Tokened stays host-proving: its target is the placement, or a source whose duty the move never released.
-          const proveHost = activate.moveId !== undefined || this.servesAgent(agentId)
           if (stage?.moveId === moveId && stage.state === 'committed') return { ok: true }
           if (
             stage?.moveId !== moveId ||
@@ -21791,7 +21788,10 @@ export class Daemon {
             }
             // Prove ACP can initialize under the still-closed gate; the workspace reconciled first, so the
             // spawned runtime and its sandbox bind the new directory rather than an unlinked old one.
-            if (proveHost) {
+            // An unstage restores the replica, not serving authority: a non-holder must not bind the sandbox (#1093).
+            // Read HERE, never captured: a revoke landing during the awaits above already stopped this host.
+            // Tokened stays host-proving: its target is the placement, or a source whose duty the move never released.
+            if (activate.moveId !== undefined || this.servesAgent(agentId)) {
               try {
                 await this.ensureHostAsync(agentId, { allowAgentDrain: true })
               } catch (err) {

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -447,6 +447,85 @@ describe('Daemon CP agent → memory + reconcile', () => {
     await daemon.stop()
   })
 
+  it('a token-less activate releases a stale staging fence by committing the stored token (#1093)', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    const { daemon, hosts } = makeDaemon(root)
+    await daemon.start()
+    // The fence a pool member keeps after sourcing a move onto a machine (pool → machine …).
+    await expect(seam(daemon).applyAgentDetach({ agentId: 'bot-a', moveId: MOVE_ID })).resolves.toEqual({ ok: true })
+    expect((daemon as any).cpLocalState().stagedAgents).toEqual([{ agentId: 'bot-a', moveId: MOVE_ID }])
+
+    // … → pool: the CP commits the set placement and broadcasts an activate with NO move token.
+    await expect(
+      seam(daemon).applyAgentActivate({
+        agentId: 'bot-a',
+        spec: { name: 'bot-a', runtime: 'claude' },
+        integrations: [],
+        crons: []
+      })
+    ).resolves.toEqual({ ok: true })
+    expect((daemon as any).agents.has('bot-a')).toBe(true)
+    expect((daemon as any).moveStagedAgents.has('bot-a')).toBe(false)
+    expect((daemon as any).drainingAgents.has('bot-a')).toBe(false)
+    expect(readAgentMoveStage(join(root, 'agents'), 'bot-a')).toEqual({ moveId: MOVE_ID, state: 'committed' })
+    expect((daemon as any).cpLocalState().stagedAgents).toEqual([])
+    expect(hosts.length).toBeGreaterThan(0) // activation proved ACP can start before the ACK
+    await daemon.stop()
+  })
+
+  it('a token-less activate with no staging fence acknowledges without applying anything', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    const { daemon, hosts } = makeDaemon(root)
+    await daemon.start()
+
+    await expect(
+      seam(daemon).applyAgentActivate({
+        agentId: 'bot-a',
+        spec: { name: 'renamed', runtime: 'claude' },
+        integrations: [],
+        crons: []
+      })
+    ).resolves.toEqual({ ok: true })
+    expect((daemon as any).agents.get('bot-a').name).toBe('bot-a') // the bundle was NOT applied
+    expect(existsSync(stagedAgentDir(join(root, 'agents'), 'bot-a'))).toBe(false)
+
+    await expect(
+      seam(daemon).applyAgentActivate({
+        agentId: 'ghost',
+        spec: { name: 'ghost', runtime: 'claude' },
+        integrations: [],
+        crons: []
+      })
+    ).resolves.toEqual({ ok: true })
+    expect((daemon as any).agents.has('ghost')).toBe(false)
+    expect(hosts).toEqual([])
+    await daemon.stop()
+  })
+
+  it('a token-less activate never resurrects a removal-tombstoned agent', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    stageAgentMove(join(root, 'agents'), 'bot-a', MOVE_ID)
+    markAgentRemoval(join(root, 'agents'), 'bot-a', agentRemovalObligationsDir(root))
+    const { daemon } = makeDaemon(root)
+    await daemon.start()
+
+    await expect(
+      seam(daemon).applyAgentActivate({
+        agentId: 'bot-a',
+        spec: { name: 'bot-a', runtime: 'claude' },
+        integrations: [],
+        crons: []
+      })
+    ).resolves.toEqual({ ok: false, reason: 'agent/activate: a removal tombstone owns this agent' })
+    expect((daemon as any).agents.has('bot-a')).toBe(false)
+    expect((daemon as any).moveStagedAgents.has('bot-a')).toBe(true)
+    expect(agentRemovalTombstones(join(root, 'agents'), agentRemovalObligationsDir(root)).has('bot-a')).toBe(true)
+    await daemon.stop()
+  })
+
   it('keeps a newer removal gate latched while an older activation is preparing', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -565,6 +565,47 @@ describe('Daemon CP agent → memory + reconcile', () => {
     await daemon.stop()
   })
 
+  it('a revoke landing mid-activation keeps the unstaged host down (#1093)', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    const { daemon, hosts } = makeDaemon(root)
+    await daemon.start()
+    poolMember(daemon)
+    ;(daemon as any).duties.applyGrant([dutyGrant('bot-a')]) // holds the duty when the frame arrives
+    await expect(seam(daemon).applyAgentDetach({ agentId: 'bot-a', moveId: MOVE_ID })).resolves.toEqual({ ok: true })
+    expect((daemon as any).servesAgent('bot-a')).toBe(true)
+
+    // Land the revoke inside the activation's OWN reconcile — after the bundle apply (the agent is
+    // already unstaged there), before the host start. Awaited interleave, no timers, no sleeps.
+    const reconcile = (daemon as any).flushReconcile.bind(daemon)
+    let landed = false
+    ;(daemon as any).flushReconcile = async () => {
+      await reconcile()
+      if (landed || (daemon as any).moveStagedAgents.has('bot-a')) return
+      landed = true
+      ;(daemon as any).applyDutyRevoke([{ groupId: GROUP_ID, reason: 'superseded' }])
+    }
+
+    await expect(
+      seam(daemon).applyAgentActivate({
+        agentId: 'bot-a',
+        spec: { name: 'bot-a', runtime: 'claude' },
+        integrations: [],
+        crons: []
+      })
+    ).resolves.toEqual({ ok: true })
+
+    // The fence is still released — losing the duty is not a reason to keep a stale fence armed …
+    expect(landed).toBe(true) // the interleave really happened
+    expect((daemon as any).moveStagedAgents.has('bot-a')).toBe(false)
+    expect(readAgentMoveStage(join(root, 'agents'), 'bot-a')).toEqual({ moveId: MOVE_ID, state: 'committed' })
+    // … and the host stays down: holdership is re-read at the start boundary, not captured before it.
+    expect((daemon as any).servesAgent('bot-a')).toBe(false)
+    expect(hosts).toEqual([])
+    expect((daemon as any).hosts.has('bot-a')).toBe(false)
+    await daemon.stop()
+  })
+
   it('a token-less activate with no staging fence acknowledges without applying anything', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -12,7 +12,7 @@ import {
   stageAgentMove,
   stagedAgentDir
 } from '../../src/agents/write-agent.js'
-import { RegisterReq, type AgentSpec } from '@agentconnect.md/protocol'
+import { RegisterReq, type AgentSpec, type DutyGrantEntry } from '@agentconnect.md/protocol'
 import { agentRemovalObligationsDir } from '../../src/paths.js'
 import { fakeSlackAppFactory } from '../fakes/slack-app.js'
 
@@ -20,6 +20,7 @@ const MOVE_ID = '77777777-7777-4777-8777-777777777777'
 const MOVE_ID_2 = '88888888-8888-4888-8888-888888888888'
 const MOVE_ID_3 = '99999999-9999-4999-8999-999999999999'
 const MOVE_ID_4 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const GROUP_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
 function root1(): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-cpagent-'))
@@ -74,6 +75,33 @@ function makeDaemon(root: string) {
 }
 
 const seam = (d: Daemon) => (d as any).cpConfigApply()
+
+/** Make the daemon a duty-governed pool member — `frame` scope is what `dutyEnforced()` reads. */
+function poolMember(daemon: Daemon, client: Record<string, unknown> = {}) {
+  ;(daemon as any).cpClient = {
+    organizationScope: () => 'frame',
+    stop: async () => {},
+    releaseDuties: vi.fn(async () => {}),
+    reportDutiesNow: vi.fn(() => {}),
+    emitMemoryConnectionFacts: vi.fn(() => {}),
+    ...client
+  }
+}
+
+/** A grant for one agent, unstamped so `dutyBundleIsStale` falls back to presence. */
+const dutyGrant = (agentId: string): DutyGrantEntry => ({
+  groupId: GROUP_ID,
+  orgId: 'org-1',
+  term: '1',
+  members: [{ kind: 'agent', refId: agentId }]
+})
+
+const DUTY_BUNDLE = {
+  agentId: 'bot-a',
+  spec: { orgId: 'org-1', name: 'bot-a', runtime: 'claude' },
+  integrations: [],
+  crons: []
+}
 
 describe('Daemon CP agent → memory + reconcile', () => {
   it('keeps a corrupt move tombstone fail-closed without poisoning reconnect registration', async () => {
@@ -471,6 +499,69 @@ describe('Daemon CP agent → memory + reconcile', () => {
     expect(readAgentMoveStage(join(root, 'agents'), 'bot-a')).toEqual({ moveId: MOVE_ID, state: 'committed' })
     expect((daemon as any).cpLocalState().stagedAgents).toEqual([])
     expect(hosts.length).toBeGreaterThan(0) // activation proved ACP can start before the ACK
+    await daemon.stop()
+  })
+
+  it('a token-less activate on a member that holds no duty releases the fence without a host (#1093)', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    const { daemon, hosts } = makeDaemon(root)
+    await daemon.start()
+    const fetchDutyAgent = vi.fn(async () => ({ bundle: DUTY_BUNDLE }))
+    poolMember(daemon, { fetchDutyAgent })
+    expect((daemon as any).servesAgent('bot-a')).toBe(false)
+
+    await expect(seam(daemon).applyAgentDetach({ agentId: 'bot-a', moveId: MOVE_ID })).resolves.toEqual({ ok: true })
+    await expect(
+      seam(daemon).applyAgentActivate({
+        agentId: 'bot-a',
+        spec: { name: 'bot-a', runtime: 'claude' },
+        integrations: [],
+        crons: []
+      })
+    ).resolves.toEqual({ ok: true })
+
+    // The fence is cleared and the replica is current …
+    expect((daemon as any).moveStagedAgents.has('bot-a')).toBe(false)
+    expect((daemon as any).drainingAgents.has('bot-a')).toBe(false)
+    expect(readAgentMoveStage(join(root, 'agents'), 'bot-a')).toEqual({ moveId: MOVE_ID, state: 'committed' })
+    expect((daemon as any).agents.has('bot-a')).toBe(true)
+    // … and NOTHING runs here: a non-holder host would bind the agent's exclusive sandbox channel,
+    // leaving whichever member the ledger picks authorized for ingress but unable to bind.
+    await (daemon as any).flushReconcile()
+    expect(hosts).toEqual([])
+    expect((daemon as any).hosts.has('bot-a')).toBe(false)
+
+    // The duty grant is what starts it, and the current replica makes that install a no-fetch.
+    await (daemon as any).admitDutyGrants([dutyGrant('bot-a')])
+    expect(fetchDutyAgent).not.toHaveBeenCalled()
+    expect((daemon as any).servesAgent('bot-a')).toBe(true)
+    await (daemon as any).ensureHostAsync('bot-a')
+    expect(hosts.map((h) => h.id)).toEqual(['bot-a'])
+    await daemon.stop()
+  })
+
+  it('a token-less activate still proves its host on the member that holds the duty', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    const { daemon, hosts } = makeDaemon(root)
+    await daemon.start()
+    poolMember(daemon)
+    ;(daemon as any).duties.applyGrant([dutyGrant('bot-a')]) // this member holds the agent's duty
+    expect((daemon as any).servesAgent('bot-a')).toBe(true)
+
+    await expect(seam(daemon).applyAgentDetach({ agentId: 'bot-a', moveId: MOVE_ID })).resolves.toEqual({ ok: true })
+    await expect(
+      seam(daemon).applyAgentActivate({
+        agentId: 'bot-a',
+        spec: { name: 'bot-a', runtime: 'claude' },
+        integrations: [],
+        crons: []
+      })
+    ).resolves.toEqual({ ok: true })
+
+    expect((daemon as any).moveStagedAgents.has('bot-a')).toBe(false)
+    expect(hosts.map((h) => h.id)).toEqual(['bot-a']) // the holder proves ACP before the ACK
     await daemon.stop()
   })
 

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -468,7 +468,7 @@ export type AgentDetach = z.infer<typeof AgentDetach>
 
 export const AgentActivate = z.object({
   agentId: z.string().uuid(),
-  /** Absent ⇒ authoritative unstage on a set commit: release any staging fence still held, no-op without one. */
+  /** Absent ⇒ authoritative unstage: release any fence held, and start no host unless the duty is held. */
   moveId: z.string().uuid().optional(),
   /**
    * One authoritative, acknowledged bootstrap bundle. Unlike the live CRUD

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -468,7 +468,8 @@ export type AgentDetach = z.infer<typeof AgentDetach>
 
 export const AgentActivate = z.object({
   agentId: z.string().uuid(),
-  moveId: z.string().uuid(),
+  /** Absent ⇒ authoritative unstage on a set commit: release any staging fence still held, no-op without one. */
+  moveId: z.string().uuid().optional(),
   /**
    * One authoritative, acknowledged bootstrap bundle. Unlike the live CRUD
    * EVTs, these definitions are synchronously persisted under the staging gate


### PR DESCRIPTION
Closes #1093

## Summary

A pool member that was the source of an agent move onto a machine keeps its staged-move fence (`moveStagedAgents` + `<agentsDir>/.staged/<id>`) by design. If the agent later moves back onto the pool while that member pod is still alive, `unstageEligibleSources` only released the fences the second move itself had staged, so the member's first-hop fence survived — a stale fence the ledger cannot see.

## Failure scenario (two hops)

1. Agent placed on the pool; member M holds its duty group.
2. Move pool → machine D: M is detached and fenced — correct, M must not serve the agent while it is machine-placed.
3. Move D → pool: the move detaches D (the only serving daemon) and commits the set placement. M was not a source of this move, so nothing releases its fence from step 2.
4. The ledger may grant M the agent's group; `installGrantedAgents` skips a move-staged agent, so M takes the lease, installs nothing, and serves nothing until the pod recycles — a dark hold no other member can break.

## Fix

- **Control plane** — a move that commits a placement onto a set now also broadcasts a token-less `agent/activate` to every READY member of that set the move never staged (best-effort, bounded by pool size, same warn-and-continue as the existing unstage). `ensureActive` repairs a set placement the same way on retry, and a member that was offline at commit time is unstaged from its reconnect staged-fence report when it is an eligible holder of the set placement. Fences on machines and on daemons outside the target set stay armed — clearing them is exactly the split brain the hard cutover exists to prevent, and nothing is cleared while the agent is placed on a machine.
- **Daemon** — `agent/activate` with no `moveId` is an authoritative unstage: with a staging fence armed it adopts the stored token and runs the activation flow (bundle apply, archive restore, commit with that exact token, drop from `moveStagedAgents`), with no fence it acknowledges as a no-op without applying anything, and it refuses to resurrect an agent owned by a removal tombstone or a pending removal.
- **Protocol** — `AgentActivate.moveId` becomes optional to carry the token-less form.

## An unstage restores a replica, it does not start serving

Reusing the full activation flow for the unstage would have started an ACP host on a member that does not hold the agent's duty, binding the agent's exclusive sandbox channel there. When the ledger then granted the duty to another member, that member would be the only one authorized for ingress while unable to bind — an unavailable agent, which is a worse failure than the dark hold this PR set out to fix.

So the token-less form clears, applies and commits the fence but **leaves the host stopped unless this member already holds serving authority for the agent** — the same duty predicate the install-on-grant path reads, never a placement-kind test. A later duty grant installs and starts it through the normal path, and because the released member's replica is current at the granted revision that install skips the fetch, which was the whole point of unstaging.

That predicate is read **at the host-start boundary, never captured earlier**. The activation awaits a bundle apply, a reconcile and an optional workspace preparation before it would start a host, and a `duty/revoke` landing inside those awaits already stopped this host — acting on a holdership answer read before them would restart it as a non-holder and bind the exclusive sandbox against the member just granted the duty. The window inside `ensureHostAsync` needs no further check: a racing `stopHost` bumps the host-start generation, and `startHostWithRetry` re-checks it after `host.start()` and reaps the child.

The reconnect backstop takes the same shape: it runs after `mayAct` returned false, so it is by definition addressing a non-holder, and it now sends the token-less form rather than the reported token. That leaves one unstage form on the wire with one rule. It stays exact against a concurrent move because the daemon commits its own stored token, and the backstop runs inside the per-agent mutation gate, so no other move can arm a different fence underneath it.

The **tokened** one-hop unstage (`daemon(member) → its own set`, which predates this PR) keeps proving its host, and that asymmetry is deliberate rather than an oversight: nothing in the move releases the source's duty — `agent/detach` does not touch the duty registry, the placement CAS only kicks a recompute, and that recompute vacates a lease solely when the holder became ineligible, which a member of the very set the agent moved onto never is. The source therefore still holds serving authority at the instant the unstage lands. The same argument does not extend to the tokened target activation, where the target must prove ACP before the ACK precisely because it may not hold the lease yet — so the gate is on the unstage form, not on the frame in general.

## Why this shape

The CP cannot enumerate members' fences (they are daemon-local durable state), but the members of the target set are exactly the daemons whose fences the new placement makes wrong — so the commit tells each live member to release whatever fence it still holds, and the daemon stays the authority on whether one exists. The alternative (daemon-side: clear the fence when a duty grant proves a placement committed after the fenced move) needs a placement revision on the wire that does not exist yet; this fix reuses the same `agent/activate` mechanism the one-hop unstage already uses, needs no new wire ordering, and leaves the released member's replica current so a re-grant installs without a fetch. Delivery ordering keeps the token-less form safe: moves are serialized per agent by the CP mutation gate, frames are in-order per connection, and a frame in flight when the socket drops is never delivered later.

## Test plan

- New CP integration test: the full two-hop scenario (pool → machine → pool with the same member alive) asserting the member's fence is fenced after hop 1 and released on hop 2, that every activate the member ever receives is the token-less form (so only a duty grant can start it there), while the machine source stays fenced.
- New CP unit tests: the set-commit broadcast targets only live members the move never staged; a staged member source keeps its exact token (no double activate); reconnect recovery releases a reported stale fence token-less for an eligible member and leaves non-members and machine placements fenced.
- New daemon unit tests: a token-less unstage on a duty-governed member that holds nothing releases the fence, leaves the replica current, and starts **no** host — then a duty grant serves it with no refetch and the host starts; a token-less unstage on the member that does hold the duty still proves its host; a token-less activate acknowledges as a pure no-op without a fence; and it never resurrects a removal-tombstoned agent.
- Ran: protocol tests (345), control-plane `test:unit` (1741) and full `test:int` (1389, Docker), the daemon suite, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

