### PR TITLE
fix(daemon): report the sandbox probe verdict at startup (#956)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ The Compose stack does not run agent daemons. Add a daemon from the Web console,
 then run its generated command on each machine that should host agents,
 workspaces, and runtime credentials.
 
+A Linux daemon host also needs `bwrap`, `socat`, and `rg` (ripgrep) on the
+daemon's own `PATH`, plus unprivileged user namespaces. They back the kernel
+sandbox that confines agent runtimes and installs managed skills; without them
+agents run unconfined and managed skills are unavailable. The daemon probes for
+them at startup and logs `sandbox: unavailable — …` when the probe fails.
+
 Past the local stack — sign-in, public URLs, and provider apps — a guided path
 helps. Open Claude Code in the checkout and ask it to set up AgentConnect:
 [`.claude/skills/agentconnect-setup`](.claude/skills/agentconnect-setup/SKILL.md)

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -358,7 +358,12 @@ the exact-pinned `@anthropic-ai/sandbox-runtime` package, backed by `bubblewrap`
 and launches a separate SRT provider process for each ordinary ACP host so policy
 state is never shared between agents. The host must provide working `bwrap`,
 `socat`, and `rg` executables and permit unprivileged user namespaces. Startup
-performs a live probe rather than treating installed binaries as sufficient.
+performs a live probe rather than treating installed binaries as sufficient, and
+logs its verdict: `sandbox: bwrap ready`, or a warning carrying the provider's
+own failure text and the daemon's `PATH`. A failed probe is not confined to
+agent launches — managed skill installation runs the pinned skills CLI inside
+the same kernel sandbox and has no fail-open path, so it fails on every
+reconcile until the missing dependencies are installed.
 
 An enabled sandbox gives the runtime a private HOME, hides daemon-owned agent
 metadata and the host source from which that runtime state was seeded, and

--- a/packages/daemon/src/acp/sandbox.ts
+++ b/packages/daemon/src/acp/sandbox.ts
@@ -69,22 +69,34 @@ function sandboxProviderLauncher(): { cmd: string; args: string[] } {
   return { cmd: process.execPath, args: [entry] }
 }
 
-let cachedHostSandbox: { value: SandboxMechanism | undefined } | undefined
+/** A host probe result: the live mechanism, or why this host cannot confine. */
+export interface SandboxProbe {
+  mechanism: SandboxMechanism | undefined
+  /** The provider's own failure text — the missing dependency names live here. */
+  reason?: string
+}
+
+let cachedHostSandbox: SandboxProbe | undefined
 
 /** Live Linux SRT/bwrap support on this host, or undefined (⇒ fail-open). */
 export function detectSandbox(env: NodeJS.ProcessEnv = process.env): SandboxMechanism | undefined {
-  if (env === process.env && cachedHostSandbox) return cachedHostSandbox.value
-  const value = probeSandbox(env)
-  if (env === process.env) cachedHostSandbox = { value }
-  return value
+  return probeSandboxHost(env).mechanism
+}
+
+/** The same one-shot probe, keeping the failure reason for the startup preflight log. */
+export function probeSandboxHost(env: NodeJS.ProcessEnv = process.env): SandboxProbe {
+  if (env === process.env && cachedHostSandbox) return cachedHostSandbox
+  const probe = probeSandbox(env)
+  if (env === process.env) cachedHostSandbox = probe
+  return probe
 }
 
 /** Keep the live SRT launch out of every Daemon constructor after the first one.
  * Production has one daemon, while a Linux test process may construct hundreds. */
-function probeSandbox(env: NodeJS.ProcessEnv): SandboxMechanism | undefined {
+function probeSandbox(env: NodeJS.ProcessEnv): SandboxProbe {
   // This rollout is intentionally Linux-only. macOS needs a runtime-neutral
   // credential strategy before private HOME + Seatbelt can be enabled safely.
-  if (process.platform !== 'linux') return undefined
+  if (process.platform !== 'linux') return { mechanism: undefined, reason: `unsupported platform ${process.platform}` }
 
   const root = mkdtempSync(join(tmpdir(), 'agentconnect-srt-probe-'))
   try {
@@ -107,16 +119,33 @@ function probeSandbox(env: NodeJS.ProcessEnv): SandboxMechanism | undefined {
     })
     const probe = spawnSync(launch.cmd, launch.args, {
       env: { ...env, HOME: privateHome },
-      stdio: 'ignore',
+      stdio: ['ignore', 'ignore', 'pipe'],
+      encoding: 'utf8',
       timeout: 10_000,
       windowsHide: true
     })
-    return probe.status === 0 ? 'bwrap' : undefined
-  } catch {
-    return undefined
+    if (probe.status === 0) return { mechanism: 'bwrap' }
+    return { mechanism: undefined, reason: probeFailureReason(probe) }
+  } catch (error) {
+    return { mechanism: undefined, reason: boundedReason(error instanceof Error ? error.message : String(error)) }
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
+}
+
+/** SRT reports missing host dependencies on the provider's stderr; prefer that over a bare exit code. */
+function probeFailureReason(probe: { stderr?: string; status: number | null; signal: string | null; error?: Error }) {
+  const stderr = boundedReason(probe.stderr ?? '')
+  if (stderr) return stderr
+  if (probe.error) return boundedReason(probe.error.message)
+  if (probe.signal) return `the SRT probe was killed by ${probe.signal}`
+  return `the SRT probe exited with status ${probe.status ?? 'unknown'}`
+}
+
+/** One bounded log line: SRT's message is multi-line and the daemon logger is line-oriented. */
+function boundedReason(text: string): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim()
+  return collapsed.length > 300 ? `${collapsed.slice(0, 297)}...` : collapsed
 }
 
 /** True when `p` resolves to a strict descendant of `root` (never `root` itself). */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -37,7 +37,13 @@ import {
   type StoredUsage
 } from './store/local-store.js'
 import { AcpHost, turnFailureCode, turnFailureReason, type AcpPermissionPolicyEvent } from './acp/acp-host.js'
-import { detectSandbox, sandboxBoundary, SandboxError, type SandboxMechanism } from './acp/sandbox.js'
+import {
+  probeSandboxHost,
+  sandboxBoundary,
+  SandboxError,
+  type SandboxMechanism,
+  type SandboxProbe
+} from './acp/sandbox.js'
 import { effectiveRunInSandbox, prepareRuntimeLaunch } from './acp/runtime-launch.js'
 import {
   permissionModeDisplayLabel,
@@ -2284,6 +2290,9 @@ export class Daemon {
   // per-agent requests are ineffective; security.requireSandbox refuses startup
   // (including on unsupported macOS/Windows hosts).
   private sandboxMechanism: SandboxMechanism | undefined
+  // The same detection, with the provider's failure text kept for the startup
+  // preflight log. undefined when this daemon never probes (--k8s, injected null).
+  private readonly sandboxProbe: SandboxProbe | undefined
   // `--k8s`: this daemon supervises runtimes in sandbox pods instead of local
   // subprocesses, so every "daemon and runtime share one machine" behavior is off.
   private readonly k8s: boolean
@@ -2557,8 +2566,13 @@ export class Daemon {
     this.clusterIdentityToken = this.k8s && readClusterIdentityToken() ? () => readClusterIdentityToken() : undefined
     // A k8s runtime is isolated by its own pod, so the in-process SRT mechanism is
     // not part of that shape — it stays off even if this host happens to support it.
-    this.sandboxMechanism =
-      opts.sandboxMechanism === null || this.k8s ? undefined : (opts.sandboxMechanism ?? detectSandbox())
+    this.sandboxProbe =
+      opts.sandboxMechanism === null || this.k8s
+        ? undefined
+        : opts.sandboxMechanism
+          ? { mechanism: opts.sandboxMechanism }
+          : probeSandboxHost()
+    this.sandboxMechanism = this.sandboxProbe?.mechanism
     this.clock = opts.clock ?? systemClock
     if (opts.evaluation?.capabilityProfile && !opts.evaluation.observer) {
       throw new Error('evaluation capability profile requires an evaluation observer')
@@ -2580,6 +2594,19 @@ export class Daemon {
       ttlMs: Daemon.PROBE_TTL_MS
     })
     this.requestExit = opts.requestExit ?? ((code) => process.exit(code))
+  }
+
+  /** Say what the boot probe found: missing SRT dependencies silently run agents unconfined AND fail every managed-skill install (#956). */
+  private logSandboxPreflight(): void {
+    // Linux-only: macOS/Windows have no mechanism by design, and --k8s isolates by pod.
+    if (this.k8s || process.platform !== 'linux' || !this.sandboxProbe) return
+    if (this.sandboxProbe.mechanism) {
+      this.log.info(`sandbox: ${this.sandboxProbe.mechanism} ready`)
+      return
+    }
+    this.log.warn(
+      `sandbox: unavailable — ${this.sandboxProbe.reason || 'the live SRT probe failed'}; agents run unconfined and managed skills cannot be installed. Install bwrap, socat, and rg on the daemon's own PATH (PATH=${process.env.PATH ?? ''})`
+    )
   }
 
   private emitEvaluation(input: EvaluationEventInput): void {
@@ -2929,6 +2956,7 @@ export class Daemon {
     })
     this.cfg = cfg
     configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
+    this.logSandboxPreflight()
     if (cfg.security.requireSandbox && !this.sandboxMechanism) {
       throw new Error(
         this.k8s

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -17,7 +17,14 @@ import {
   writeFileSync
 } from 'node:fs'
 import { SandboxManager, SandboxRuntimeConfigSchema } from '@anthropic-ai/sandbox-runtime'
-import { sandboxWrap, sandboxBoundary, SandboxError, detectSandbox, writeSandboxSettings } from '../src/acp/sandbox.js'
+import {
+  sandboxWrap,
+  sandboxBoundary,
+  SandboxError,
+  detectSandbox,
+  probeSandboxHost,
+  writeSandboxSettings
+} from '../src/acp/sandbox.js'
 import { claudeInnerSandboxSettings } from '../src/acp/claude-runtime.js'
 import { clearConfigFiles, configFilesDir, materializeConfigFiles } from '../src/agents/config-file-env.js'
 
@@ -85,6 +92,24 @@ describe('sandboxWrap', () => {
     expect(settings.git.safeDirectories).toEqual([realpathSync(workspace)])
     expect(settingsPath.startsWith(`${workspace}/`)).toBe(false)
     expect(statSync(settingsPath).mode & 0o777).toBe(0o600)
+  })
+})
+
+// #956: a host missing SRT's own dependencies confines nothing and installs no
+// managed skills. The probe already knew; the reason has to survive it so the
+// daemon's startup preflight can name what is missing.
+describe('probeSandboxHost', () => {
+  it.skipIf(process.platform === 'linux')('names the unsupported platform', () => {
+    expect(probeSandboxHost()).toEqual({ mechanism: undefined, reason: `unsupported platform ${process.platform}` })
+  })
+
+  it.runIf(process.platform === 'linux')('keeps the provider failure as one bounded line', () => {
+    // An empty PATH is how the reported host looked to the daemon: SRT's rg/socat lookup fails.
+    const probe = probeSandboxHost({ ...process.env, PATH: '/nonexistent' })
+    expect(probe.mechanism).toBeUndefined()
+    expect(probe.reason).toBeTruthy()
+    expect(probe.reason).not.toContain('\n')
+    expect(probe.reason!.length).toBeLessThanOrEqual(300)
   })
 })
 


### PR DESCRIPTION
Closes #956.

## The problem

On a host without `rg` and `socat`, SRT refuses to initialize. That takes down two things at once, and both are silent:

- **Managed skills.** Every install routes through the kernel sandbox unconditionally on Linux, so the skills CLI cell exits 1 and `installSkills` does its fail-closed cleanup — one `WARN`, then all previously managed skills are cleared, on every reconcile.
- **Agent confinement.** The same missing dependencies make `detectSandbox()` return `undefined`, so agent hosts fail open and run **unconfined**. Nothing said so. Only `security.requireSandbox` turns it into a boot refusal.

The daemon already knew at startup: `detectSandbox()` runs a live SRT launch through the same provider, which fails the identical dependency check. The probe just threw the reason away (`stdio: 'ignore'`, `catch { return undefined }`) and logged nothing either way.

## The change

- `probeSandbox` keeps the provider's own stderr — where `Sandbox dependencies not available: ripgrep (rg) not found, socat not installed` appears — collapsed to one bounded line. `detectSandbox()` keeps its exact signature and behavior; the new `probeSandboxHost()` exposes `{ mechanism, reason }`.
- The daemon logs the verdict at startup, before the `requireSandbox` refusal: `sandbox: bwrap ready`, or a warning carrying SRT's own text, both consequences named, and the daemon's `PATH`. That last part is deliberate — the reporter's `rg` was a shell function, so `command -v rg` succeeded interactively while the daemon's `PATH` had no such binary. Linux-only: macOS/Windows have no mechanism by design, and `--k8s` isolates by pod.
- README documents `bwrap`, `socat`, and `rg` as daemon-host prerequisites next to the connect step. The design doc's "startup performs a live probe" sentence now also records that the verdict is logged and that a failed probe takes managed skills down with it.

## What this does not do

The issue also asks for a degraded state in the console. `health` is a hardcoded `'ok'` literal in the heartbeat and the `'ok' | 'degraded'` enum has never been emitted, so lighting it up is a daemon + protocol + control-plane + web change and belongs in its own PR. The public docs site is a separate repository and needs the prerequisite line too.

## Testing

- `test/sandbox.test.ts`: a Linux case reproduces the reported host by probing with a bogus `PATH` — SRT resolves `bwrap`/`socat` through `which`, so the failure is deterministic — and asserts the reason survives, single-line and bounded. Plus a non-Linux case for the platform reason.
- Daemon `typecheck`, `eslint`, and `prettier` are clean; `test/sandbox.test.ts` passes locally (Linux-gated cases skip on macOS and run in the `Sandbox (Linux)` CI job).
- The daemon suite has 14 pre-existing failures on this machine in `shim-*` and `workspace-git-runner-seam`; re-running those four files on a clean tree reproduces the same 14, so they are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
