### PR TITLE
fix(daemon): survive an oversized frame on the shim accept paths

### DIFF
--- a/packages/connection/src/ws-server-transport.test.ts
+++ b/packages/connection/src/ws-server-transport.test.ts
@@ -6,7 +6,11 @@ class FakeWs {
   protocol = 'agentconnect.rd.v1'
   sent: string[] = []
   closed?: { code: number; reason: string }
+  terminated = 0
   private handlers = new Map<string, Array<(...a: unknown[]) => void>>()
+  terminate(): void {
+    this.terminated += 1
+  }
   send(text: string): void {
     this.sent.push(text)
   }
@@ -65,5 +69,12 @@ describe('WsServerTransport', () => {
     const { ws, t } = make()
     t.close(4409, 'revoked')
     expect(ws.closed).toEqual({ code: 4409, reason: 'revoked' })
+  })
+
+  it('listens for socket errors from construction, so an oversized frame cannot go unhandled', () => {
+    // A real ws socket THROWS on an unlistened 'error', and the peer raising it need not be authenticated.
+    const { ws } = make()
+    ws.emit('error', new RangeError('Max payload size exceeded'))
+    expect(ws.terminated).toBe(1)
   })
 })

--- a/packages/connection/src/ws-server-transport.ts
+++ b/packages/connection/src/ws-server-transport.ts
@@ -27,6 +27,8 @@ export class WsServerTransport implements ServerTransport {
   ) {
     this.subprotocol = ws.protocol
     this.remoteAddr = remoteAddr
+    // An unlistened 'error' (oversized frame, reset) crashes the process; terminate() folds it into close.
+    ws.on('error', () => ws.terminate())
   }
 
   send(text: string): void {

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -136,6 +136,8 @@ export class ShimListener {
         resolve()
       })
     })
+    // The bind-failure listener is gone by now, and a post-listen accept error is fatal unheard.
+    server.on('error', (err) => this.deps.log.warn(`shim: listener socket error: ${err.message}`))
     this.server = server
     this.wss = wss
     this.port = (server.address() as { port: number }).port
@@ -192,6 +194,11 @@ export class ShimListener {
   }
 
   private accept(ws: WebSocket, remoteAddress: string): void {
+    // Attached first: an unlistened 'error' (an oversized frame from an unproved peer) crashes the daemon.
+    ws.on('error', (err: Error) => {
+      this.deps.log.warn(`shim: socket error from ${remoteAddress} (${err.message})`)
+      ws.terminate()
+    })
     let bound: ShimConnection | undefined
     let binding = false
     const frameListeners: Array<(text: string) => void> = []

--- a/packages/daemon/src/shim/server.ts
+++ b/packages/daemon/src/shim/server.ts
@@ -73,6 +73,7 @@ export class ShimServer {
         return
       }
       wss.handleUpgrade(req, socket, head, (ws) => {
+        // Constructed first: it arms the socket's 'error' guard, without which one oversized frame is fatal.
         const raw = new WsServerTransport(ws, req.socket.remoteAddress ?? 'unknown')
         const inbound = bufferInbound(raw)
         const transport: ShimTransport = {
@@ -111,6 +112,8 @@ export class ShimServer {
         resolve()
       })
     })
+    // The bind-failure listener is gone by now, and a post-listen accept error is fatal unheard.
+    server.on('error', (err) => this.deps.log?.warn(`shim: accept socket error: ${err.message}`))
     this.server = server
     this.wss = wss
     this.port = (server.address() as { port: number }).port

--- a/packages/daemon/test/shim-dial-in.test.ts
+++ b/packages/daemon/test/shim-dial-in.test.ts
@@ -497,6 +497,31 @@ describe('shim listener hardening', () => {
     await expect(pending).rejects.toThrow(/daemon shutting down/)
   })
 
+  it('survives an oversized frame from an unauthenticated peer and accepts the next daemon', async () => {
+    // The accept-side mirror of the case above: an unlistened 'error' here ends the shim process.
+    const server = new ShimServer()
+    servers.push(server)
+    const port = await server.start(0, '127.0.0.1')
+    const intruder = await rawDial(port)
+    intruder.socket.send('x'.repeat(MAX_FRAME_BYTES + 1))
+    await intruder.closed
+    // Not one frame: an unproved peer learns nothing about what runs in this pod.
+    expect(intruder.frames).toEqual([])
+
+    // The shim tears its side down before the peer observes the close, so its single slot is free.
+    const daemonSide = await ClientTransport.dial(`ws://127.0.0.1:${port}`, {
+      subprotocol: SHIM_SUBPROTOCOL,
+      path: SHIM_WS_PATH
+    })
+    daemonSide.send(JSON.stringify({ type: 'shim/hello', agentId: 'agent-a', generation: 1 }))
+    const accepted = await server.nextTransport()
+    const seen: string[] = []
+    accepted.onMessage((text) => seen.push(text))
+    await waitFor(() => seen.length === 1)
+    expect(JSON.parse(seen[0]!)).toMatchObject({ type: 'shim/hello', agentId: 'agent-a', generation: 1 })
+    daemonSide.close(1000, 'done')
+  })
+
   it('refuses a dial announcing a generation or an agent below the one it already bound', async () => {
     const { endpoint } = await sandbox({ backoff: fastBackoff() })
     const verifier: PodIdentityVerifier = {

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
+import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
 import { WebSocket } from 'ws'
 import { ShimBindingRegistry, type SpawnRecord } from '../src/shim/binding.js'
 import { noopClusterMetrics, type ClusterMetrics } from '../src/k8s/cluster-metrics.js'
@@ -372,6 +373,23 @@ describe('shim handshake', () => {
     client.socket.send('{not json')
     const { code } = await client.closed
     expect(code).toBe(4400)
+  })
+
+  it('drops an oversized frame from an unauthenticated peer without taking the listener down', async () => {
+    // 256 KiB + 1 from a peer that presented nothing: an unlistened payload-cap 'error' ends the daemon.
+    const { endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' })
+    })
+    const intruder = await rawConnect(endpoint)
+    intruder.socket.send('x'.repeat(MAX_FRAME_BYTES + 1))
+    await intruder.closed
+    // Nothing was disclosed to it either: it never got as far as a frame.
+    expect(intruder.frames).toEqual([])
+
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 'projected-token' })
+    await waitFor(() => client.frames.length > 0)
+    expect(client.frames[0]).toMatchObject({ type: 'shim/bound', agentId: 'agent-a', generation: 3 })
   })
 
   it('closes a second hello arriving while the first is still being reviewed', async () => {


### PR DESCRIPTION
## Summary

Both WebSocket **accept** paths in the sandbox shim capped inbound frames at
`MAX_FRAME_BYTES` but registered no `error` listener on the accepted socket. `ws`
raises `error` when that cap is exceeded, and an unlistened `error` event is an
uncaught exception in Node — so an oversized frame killed the process instead of the
connection. The dial side has guarded exactly this since it shipped
(`ClientTransport`: `ws.on('error', () => ws.terminate())`, with a comment saying the
alternative is a crash); the accept side never got the equivalent. Found by #1096,
which could not ship the reproducing test because an unhandled `error` fails the whole
Vitest run.

## Failure scenario

1. A peer opens the shim socket offering the right subprotocol. It has presented no
   token, no identity, nothing — on `ShimListener` this is every peer that can reach
   the port, since the pool NetworkPolicy admits the namespace and binding is proved
   *after* the socket exists.
2. It sends one frame of `MAX_FRAME_BYTES + 1`.
3. `ws` rejects the frame at the payload cap and emits `error` on the accepted socket.
4. Nothing is listening, so Node throws. The daemon process (or, on the other path,
   the in-sandbox shim process) dies — taking every other channel it was serving with
   it. No authentication, no protocol knowledge, and no valid frame required.

## The fix

Attach the guard at the earliest point the socket exists, before anything can await,
and fold the fault into the close path the connection FSMs already handle rather than
inventing a second error channel.

- `WsServerTransport` arms `ws.on('error', () => ws.terminate())` in its constructor —
  the accept-side mirror of what `ClientTransport` does after `open`.
- `ShimListener.accept()` attaches its own as the first statement, since it drives the
  raw socket directly, and logs the fault against the address it came from.
- Both http servers keep a warning `error` listener after `listen()` resolves. Each one
  removes its bind-failure listener on success, which left a post-listen accept error
  unheard and therefore fatal; `tunnel-host.ts` in the same directory already did this.

## Every instance of the class found

Grepped `new WebSocketServer` / `maxPayload` / accept-side socket handling across
`packages/daemon/src` and `packages/connection/src`.

| Accept path | Fixed by |
| --- | --- |
| `packages/daemon/src/shim/listener.ts` — `ShimListener.accept()` | its own `error` handler, first statement |
| `packages/daemon/src/shim/server.ts` — `ShimServer` upgrade callback | `WsServerTransport`, constructed first |
| `packages/connection/src/ws-server-transport.ts` — `WsServerTransport` | constructor guard |
| `packages/daemon/src/shim/listener.ts` — http server, post-`listen` | warning `error` listener |
| `packages/daemon/src/shim/server.ts` — http server, post-`listen` | warning `error` listener |

Checked and deliberately not changed:

- **The `WebSocketServer` itself needs no `error` listener.** In `noServer` mode it
  never emits `error`, and an unlistened `wsClientError` is not fatal — `ws` aborts the
  handshake itself when nothing is listening.
- **The upgrade handler's `socket.destroy()` paths are safe.** Node removes its own
  socket `error` listener before emitting `upgrade`, but both handlers reach either
  `destroy()` or `handleUpgrade()` synchronously, so there is no window in which an
  error can arrive unlistened.
- **No metric is recorded on the error path.** `error` also covers post-binding network
  faults, so folding it into `handshakeRejected` would misreport them as refusals.

Two accept paths outside this PR's scope have the identical omission and should be
fixed on their own: `packages/control-plane/src/ws/transport.ts` (`WsTransport`, used
by both `gateway.ts` and `relay-gateway.ts`), which is a near-copy of
`WsServerTransport` and fronts a network-reachable endpoint. The relay's two accept
paths consume `WsServerTransport` and are fixed transitively here.

## Test plan

New, one per accept path — an oversized frame from an unauthenticated peer closes that
connection, discloses no frame to it, and leaves the listener alive and binding the
next connection:

- `packages/daemon/test/shim-handshake.test.ts` — against `ShimListener`; the follow-up
  peer completes a real handshake and gets its `shim/bound`.
- `packages/daemon/test/shim-dial-in.test.ts` — against `ShimServer`; the follow-up dial
  takes the single channel slot the terminated intruder released.
- `packages/connection/src/ws-server-transport.test.ts` — unit: the transport listens
  from construction and terminates.

No positive assertion sits behind a fixed sleep; both socket tests await the peer's own
`close` and then `waitFor` the next connection's frame, as the neighbouring tests do.

**Mutation-checked.** With the `ShimListener` guard removed, `shim-handshake` fails the
run with `RangeError: Max payload size exceeded` / `WS_ERR_UNSUPPORTED_MESSAGE_LENGTH`;
with the `WsServerTransport` guard removed, `shim-dial-in` fails the same way and the
connection unit test fails on its assertion. With both in place every suite is clean.

**Ran:** `shim-dial-in`, `shim-handshake`, `shim-channels`, `shim-tunnel` 3× (79 passed
each time), the full `connection` and `relay` suites (the other `WsServerTransport`
consumer), then `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — all clean.

`shim-cancellation` (5), `shim-exec-handler` (1) and `shim-workspace-files` (7) fail on
macOS for environment reasons; the identical failures, same tests by name and same
counts, reproduce on `origin/main` with this branch stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
