### PR TITLE
feat(control-plane): pool capacity gauges — the vacant-duty alarm (k8s-daemon-pool.md §12)

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -14,7 +14,7 @@
 import type { FastifyInstance, FastifyServerOptions } from 'fastify'
 import type { PrismaClient } from './generated/prisma/client.js'
 import type { WebSocketServer } from 'ws'
-import { HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED } from '@agentconnect.md/protocol'
+import { DUTY_GRANT_MEMBERS_MAX, HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED } from '@agentconnect.md/protocol'
 
 import { type AppConfig, resolveWebAppUrl } from './config/env.js'
 import { resolveGithubAppConfig } from './github/config.js'
@@ -153,6 +153,7 @@ import { replayMemoryConnectionsTo, syncMemoryConnectionsToDaemons } from './orc
 import { relayHttpOrigin } from './orchestrator/mcpProvider.js'
 import { CollabRoutesService } from './orchestrator/collabRoutes.service.js'
 import { DutyLeaseService, DUTY_LEASE_DEFAULTS } from './orchestrator/dutyLease.js'
+import { registerPoolMetrics } from './observability/pool-metrics.js'
 import { AgentDelivery } from './orchestrator/agentDelivery.js'
 import { AgentRoutingConverger } from './orchestrator/agentRouting.js'
 import { PlacementResolver, type ResolvableAgent } from './orchestrator/placementResolver.js'
@@ -702,6 +703,15 @@ export function buildContainer(
     { warn: (o, m) => http.log.warn(o, m), error: (o, m) => http.log.error(o, m) },
     agentRouting
   )
+  // Pool capacity gauges (observability/pool-metrics.ts) — the §12 "alarm on vacant-duty age",
+  // reading the same lease horizon and deliverability cap the claim paths gate on.
+  const poolMetrics = registerPoolMetrics({
+    repo: repos.dutyGroup,
+    clock,
+    liveMs: DUTY_LEASE_DEFAULTS.leaseMs,
+    maxMembers: DUTY_GRANT_MEMBERS_MAX,
+    log: { warn: (o, m) => http.log.warn(o, m) }
+  })
   const agentMutations = new AgentMutationGate()
 
   // Relay roster (shared-bot-relay.md §5): computed from the durable `relay` table
@@ -1740,6 +1750,7 @@ export function buildContainer(
       for (const reaper of pendingInstallReapers) reaper.stop()
       relaySweeper.stop()
       dutyRecompute.stop()
+      poolMetrics.stop()
       sessionAccessWarmer.stop()
       for (const loop of backgroundLoops) loop.stop()
       visibilityPush.stop()

--- a/packages/control-plane/src/observability/pool-metrics.test.ts
+++ b/packages/control-plane/src/observability/pool-metrics.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { poolObservations, readPoolObservations, type PoolMetricsDeps } from './pool-metrics.js'
+import type { PoolTelemetryRow } from '../persistence/ports.js'
+
+const NOW = new Date('2026-01-01T00:00:00Z')
+
+const row = (over: Partial<PoolTelemetryRow> = {}): PoolTelemetryRow => ({
+  setId: '00000000-0000-4000-8000-000000000001',
+  setName: 'pool',
+  installWide: true,
+  liveMembers: 3,
+  capacityAgents: 24,
+  dutyAgents: 20,
+  vacantGroups: 0,
+  oversizedVacantGroups: 0,
+  oldestVacancySec: 0,
+  ...over
+})
+
+const deps = (over: Partial<PoolMetricsDeps> = {}): PoolMetricsDeps => ({
+  repo: { poolTelemetry: async () => [row()] },
+  clock: { now: () => NOW.getTime() } as PoolMetricsDeps['clock'],
+  liveMs: 120_000,
+  maxMembers: 1000,
+  ...over
+})
+
+const valueOf = (obs: ReturnType<typeof poolObservations>, metric: string) =>
+  obs.find((o) => o.metric === metric)?.value
+
+describe('poolObservations', () => {
+  it('headroom is the unspent budget, and goes negative when the ledger is over it', () => {
+    expect(valueOf(poolObservations([row()]), 'headroom')).toBe(4)
+    // Members leaving while their leases are still live is exactly the shape a capacity alert
+    // must catch, so the gauge reports the overdraft rather than clamping it to zero.
+    expect(valueOf(poolObservations([row({ capacityAgents: 8, dutyAgents: 20 })]), 'headroom')).toBe(-12)
+  })
+
+  it('labels the org-less set as the install-wide pool and every other set as an org one', () => {
+    const [install] = poolObservations([row()])
+    expect(install!.attrs).toEqual({ set: 'pool', scope: 'install' })
+    const [org] = poolObservations([row({ installWide: false, setName: 'acme' })])
+    expect(org!.attrs).toEqual({ set: 'acme', scope: 'org' })
+  })
+
+  it('reports every set, so one full pool cannot be averaged away by an idle one', () => {
+    const obs = poolObservations([row(), row({ setName: 'other', installWide: false, dutyAgents: 24 })])
+    expect(obs.filter((o) => o.metric === 'headroom').map((o) => [o.attrs.set, o.value])).toEqual([
+      ['pool', 4],
+      ['other', 0]
+    ])
+  })
+})
+
+describe('readPoolObservations', () => {
+  it('reads the ledger at the clock, with the lease horizon and deliverability cap it was given', async () => {
+    const seen: unknown[] = []
+    const obs = await readPoolObservations(
+      deps({
+        repo: {
+          poolTelemetry: async (now, liveMs, maxMembers) => {
+            seen.push([now, liveMs, maxMembers])
+            return [row()]
+          }
+        }
+      })
+    )
+    expect(seen).toEqual([[NOW, 120_000, 1000]])
+    expect(valueOf(obs!, 'members')).toBe(3)
+  })
+
+  // The defect this exists to prevent: observing zeros on a database blip is indistinguishable
+  // from a full pool with no headroom, which fires the capacity alert on an unrelated outage.
+  it('skips the collection entirely when the ledger cannot be read', async () => {
+    const warned: unknown[] = []
+    const result = await readPoolObservations(
+      deps({
+        repo: {
+          poolTelemetry: async () => {
+            throw new Error('connection terminated')
+          }
+        },
+        log: { warn: (o) => warned.push(o) }
+      })
+    )
+    expect(result).toBeNull()
+    expect(warned).toHaveLength(1)
+  })
+})

--- a/packages/control-plane/src/observability/pool-metrics.test.ts
+++ b/packages/control-plane/src/observability/pool-metrics.test.ts
@@ -9,6 +9,7 @@ const row = (over: Partial<PoolTelemetryRow> = {}): PoolTelemetryRow => ({
   setName: 'pool',
   installWide: true,
   liveMembers: 3,
+  unboundedMembers: 0,
   capacityAgents: 24,
   dutyAgents: 20,
   vacantGroups: 0,
@@ -41,6 +42,27 @@ describe('poolObservations', () => {
     expect(install!.attrs).toEqual({ set: 'pool', scope: 'install' })
     const [org] = poolObservations([row({ installWide: false, setName: 'acme' })])
     expect(org!.attrs).toEqual({ set: 'acme', scope: 'org' })
+  })
+
+  // `maxAgents <= 0` is the daemon's sentinel for "no ceiling" (Daemon.dutyHeadroomForPendingClaim
+  // returns +Infinity for it), so a set holding one has no finite budget at all. Reporting the
+  // summed sentinel would say the opposite of what the member does — a pool that accepts
+  // everything would advertise zero capacity and fire the "full" alarm forever.
+  it('reports no capacity or headroom for a set with an unbounded member, rather than zero', () => {
+    const obs = poolObservations([row({ unboundedMembers: 1, capacityAgents: 16, dutyAgents: 20 })])
+    expect(obs.map((o) => o.metric)).not.toContain('capacity')
+    expect(obs.map((o) => o.metric)).not.toContain('headroom')
+    // Everything that is still well defined keeps flowing, and the omission is explainable.
+    expect(valueOf(obs, 'unbounded')).toBe(1)
+    expect(valueOf(obs, 'used')).toBe(20)
+    expect(valueOf(obs, 'members')).toBe(3)
+  })
+
+  it('a fully bounded set still reports both, and unbounded reads zero', () => {
+    const obs = poolObservations([row()])
+    expect(valueOf(obs, 'capacity')).toBe(24)
+    expect(valueOf(obs, 'headroom')).toBe(4)
+    expect(valueOf(obs, 'unbounded')).toBe(0)
   })
 
   it('reports every set, so one full pool cannot be averaged away by an idle one', () => {

--- a/packages/control-plane/src/observability/pool-metrics.ts
+++ b/packages/control-plane/src/observability/pool-metrics.ts
@@ -35,7 +35,7 @@ export interface PoolMetricsDeps {
 }
 
 export type PoolMetricName =
-  'members' | 'capacity' | 'used' | 'headroom' | 'vacantGroups' | 'vacantAge' | 'undeliverable'
+  'members' | 'unbounded' | 'capacity' | 'used' | 'headroom' | 'vacantGroups' | 'vacantAge' | 'undeliverable'
 
 export interface PoolObservation {
   metric: PoolMetricName
@@ -48,11 +48,19 @@ export function poolObservations(rows: readonly PoolTelemetryRow[]): PoolObserva
   return rows.flatMap((row) => {
     const attrs = { set: row.setName, scope: row.installWide ? ('install' as const) : ('org' as const) }
     const at = (metric: PoolMetricName, value: number): PoolObservation => ({ metric, value, attrs })
+    // `maxAgents <= 0` is the daemon's UNBOUNDED sentinel, not a ceiling of zero, so a set holding
+    // such a member HAS no finite budget. Capacity and headroom are therefore not reported at all
+    // rather than reported as a number: folding the sentinel into the sum would advertise a member
+    // that accepts everything as contributing nothing, and the "pool is full" alarm would fire
+    // permanently on a pool that can never be full — the signal inverted. Omitting the series
+    // leaves that alert with no data, which it already treats as OK. `unbounded` is what makes the
+    // gap legible on the dashboard instead of looking like a broken exporter.
+    const bounded = row.unboundedMembers === 0
     return [
       at('members', row.liveMembers),
-      at('capacity', row.capacityAgents),
+      at('unbounded', row.unboundedMembers),
+      ...(bounded ? [at('capacity', row.capacityAgents), at('headroom', row.capacityAgents - row.dutyAgents)] : []),
       at('used', row.dutyAgents),
-      at('headroom', row.capacityAgents - row.dutyAgents),
       at('vacantGroups', row.vacantGroups),
       at('vacantAge', row.oldestVacancySec),
       at('undeliverable', row.oversizedVacantGroups)
@@ -89,9 +97,15 @@ function createGauges(): Record<PoolMetricName, ObservableGauge> {
       unit: '{member}',
       description: 'Pool members seen within the duty lease horizon'
     }),
+    unbounded: meter.createObservableGauge('agentconnect.pool.unbounded_members', {
+      unit: '{member}',
+      description:
+        'Live members configured with no ceiling (maxAgents <= 0). Non-zero ⇒ capacity and headroom are not reported for this set, because it has no finite budget'
+    }),
     capacity: meter.createObservableGauge('agentconnect.pool.capacity.agents', {
       unit: '{agent}',
-      description: 'Duty budget the live members of a set can spend (sum of maxAgents)'
+      description:
+        'Duty budget the live BOUNDED members of a set can spend (sum of maxAgents). Not reported at all while any member is unbounded'
     }),
     used: meter.createObservableGauge('agentconnect.pool.duty.agents', {
       unit: '{agent}',
@@ -117,8 +131,8 @@ function createGauges(): Record<PoolMetricName, ObservableGauge> {
 }
 
 /**
- * Register the batch callback. One ledger read per collection interval feeds every gauge, so the
- * seven series of a set are one consistent snapshot rather than seven independently-timed reads.
+ * Register the batch callback. One ledger read per collection interval feeds every gauge, so a
+ * set’s series are one consistent snapshot rather than several independently-timed reads.
  */
 export function registerPoolMetrics(deps: PoolMetricsDeps): PoolMetricsHandle {
   const gauges = createGauges()

--- a/packages/control-plane/src/observability/pool-metrics.ts
+++ b/packages/control-plane/src/observability/pool-metrics.ts
@@ -1,0 +1,144 @@
+/**
+ * Pool capacity gauges — the "alarm on vacant-duty age" the pool design leaves to the CP
+ * (k8s-daemon-pool.md §12: the CP "never load-balances, never schedules, never picks; it only
+ * refuses invalid claims and alarms on vacant-duty age. A human scales the Deployment.").
+ *
+ * The CP is the ledger, so it is the only place that can answer "is the pool big enough" without
+ * a second opinion: capacity and unmet demand are both read from `duty_group` through the same
+ * predicates the claim paths gate on. Two signals, deliberately paired — headroom is the leading
+ * one (scale before it hurts), vacancy age the lagging one (something is already unserved).
+ *
+ * Every CP replica observes the same install-wide numbers, so these are fleet totals repeated per
+ * pod, not per-pod shards: aggregate them with `max by (...)`, never `sum`.
+ */
+import { metrics, type BatchObservableResult, type ObservableGauge } from '@opentelemetry/api'
+import type { PoolTelemetryRow } from '../persistence/ports.js'
+import type { Clock } from '../domain/clock.js'
+
+/** The ledger read these gauges project. */
+export interface PoolTelemetrySource {
+  poolTelemetry(now: Date, liveMs: number, maxMembers: number): Promise<PoolTelemetryRow[]>
+}
+
+export interface PoolMetricsLog {
+  warn(obj: unknown, msg?: string): void
+}
+
+export interface PoolMetricsDeps {
+  repo: PoolTelemetrySource
+  clock: Clock
+  /** Liveness horizon — pass the duty lease's `leaseMs` so "live" means what the ledger means. */
+  liveMs: number
+  /** Deliverability cap — pass `DUTY_GRANT_MEMBERS_MAX` so "claimable" means what the claim means. */
+  maxMembers: number
+  log?: PoolMetricsLog
+}
+
+export type PoolMetricName =
+  'members' | 'capacity' | 'used' | 'headroom' | 'vacantGroups' | 'vacantAge' | 'undeliverable'
+
+export interface PoolObservation {
+  metric: PoolMetricName
+  value: number
+  attrs: { set: string; scope: 'install' | 'org' }
+}
+
+/** Ledger rows → the series each gauge reports. Pure, so the alert's input is testable on its own. */
+export function poolObservations(rows: readonly PoolTelemetryRow[]): PoolObservation[] {
+  return rows.flatMap((row) => {
+    const attrs = { set: row.setName, scope: row.installWide ? ('install' as const) : ('org' as const) }
+    const at = (metric: PoolMetricName, value: number): PoolObservation => ({ metric, value, attrs })
+    return [
+      at('members', row.liveMembers),
+      at('capacity', row.capacityAgents),
+      at('used', row.dutyAgents),
+      at('headroom', row.capacityAgents - row.dutyAgents),
+      at('vacantGroups', row.vacantGroups),
+      at('vacantAge', row.oldestVacancySec),
+      at('undeliverable', row.oversizedVacantGroups)
+    ]
+  })
+}
+
+/**
+ * One collection's worth of observations, or `null` to report nothing at all.
+ *
+ * A collection that cannot read the ledger must skip rather than observe zeros: a zeroed headroom
+ * gauge is indistinguishable from a full pool, so a database blip would fire the capacity alert.
+ */
+export async function readPoolObservations(deps: PoolMetricsDeps): Promise<PoolObservation[] | null> {
+  try {
+    const rows = await deps.repo.poolTelemetry(new Date(deps.clock.now()), deps.liveMs, deps.maxMembers)
+    return poolObservations(rows)
+  } catch (err) {
+    deps.log?.warn({ err }, 'pool-metrics: ledger read failed, skipping this collection')
+    return null
+  }
+}
+
+export interface PoolMetricsHandle {
+  /** Unregister the callback. MUST run before Prisma disconnects, or a collection races shutdown. */
+  stop(): void
+}
+
+const meter = metrics.getMeter('@agentconnect.md/control-plane-pool', '1.0.0')
+
+function createGauges(): Record<PoolMetricName, ObservableGauge> {
+  return {
+    members: meter.createObservableGauge('agentconnect.pool.members', {
+      unit: '{member}',
+      description: 'Pool members seen within the duty lease horizon'
+    }),
+    capacity: meter.createObservableGauge('agentconnect.pool.capacity.agents', {
+      unit: '{agent}',
+      description: 'Duty budget the live members of a set can spend (sum of maxAgents)'
+    }),
+    used: meter.createObservableGauge('agentconnect.pool.duty.agents', {
+      unit: '{agent}',
+      description: 'Distinct agents covered by unexpired leases the set holds'
+    }),
+    headroom: meter.createObservableGauge('agentconnect.pool.headroom.agents', {
+      unit: '{agent}',
+      description: 'Unspent duty budget: capacity minus duty-covered agents. At or below zero the pool is full'
+    }),
+    vacantGroups: meter.createObservableGauge('agentconnect.duty.vacant.groups', {
+      unit: '{group}',
+      description: 'Vacant duty groups the set is eligible to claim and can deliver — unmet demand'
+    }),
+    vacantAge: meter.createObservableGauge('agentconnect.duty.vacant.oldest_age', {
+      unit: 's',
+      description: 'Age of the oldest claimable vacancy. Sustained above a beat means nothing could take it'
+    }),
+    undeliverable: meter.createObservableGauge('agentconnect.duty.undeliverable.groups', {
+      unit: '{group}',
+      description: 'Vacant groups over the wire member cap — never claimable at any pool size; needs a dedicated daemon'
+    })
+  }
+}
+
+/**
+ * Register the batch callback. One ledger read per collection interval feeds every gauge, so the
+ * seven series of a set are one consistent snapshot rather than seven independently-timed reads.
+ */
+export function registerPoolMetrics(deps: PoolMetricsDeps): PoolMetricsHandle {
+  const gauges = createGauges()
+  const observed = Object.values(gauges)
+  let stopped = false
+
+  const callback = async (result: BatchObservableResult): Promise<void> => {
+    if (stopped) return
+    const observations = await readPoolObservations(deps)
+    // Re-checked after the await: a shutdown that began mid-read must not observe against a
+    // provider that is going away, nor keep the ledger read alive past Prisma's disconnect.
+    if (stopped || !observations) return
+    for (const o of observations) result.observe(gauges[o.metric], o.value, o.attrs)
+  }
+
+  meter.addBatchObservableCallback(callback, observed)
+  return {
+    stop() {
+      stopped = true
+      meter.removeBatchObservableCallback(callback, observed)
+    }
+  }
+}

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5084,6 +5084,26 @@ export interface AgentHomeClaim {
 /** Pure plan callback run inside the reconcile transaction's org snapshot (orchestrator/dutyGroup.ts). */
 export type DutyReconcilePlanner = (existing: DutyGroupRecord[]) => DutyReconcilePlan
 
+/** One member set's capacity and unmet demand, as {@link DutyGroupRepo.poolTelemetry} reads it. */
+export interface PoolTelemetryRow {
+  setId: string
+  setName: string
+  /** The org-less set — the install-wide pool. */
+  installWide: boolean
+  /** Members seen within the lease horizon. */
+  liveMembers: number
+  /** Σ `maxAgents` over those members — the duty budget the pool can currently spend. */
+  capacityAgents: number
+  /** Distinct agents covered by unexpired leases those members hold — the budget spent. */
+  dutyAgents: number
+  /** Vacant groups this set is eligible to claim and CAN deliver — unmet demand. */
+  vacantGroups: number
+  /** Vacant, eligible, but over the wire's member cap: never claimable at any pool size (D16). */
+  oversizedVacantGroups: number
+  /** Age of the oldest {@link PoolTelemetryRow.vacantGroups} entry. Sustained ⇒ nothing could take it. */
+  oldestVacancySec: number
+}
+
 export interface DutyGroupRepo {
   /** Recompute input + console/introspection read. */
   listForOrg(orgId: OrgId): Promise<DutyGroupRecord[]>
@@ -5121,6 +5141,12 @@ export interface DutyGroupRepo {
   /** Keyset rotation over orgs that can need a recompute — any org owning an
    *  agent or an existing duty group. */
   listDutyOrgs(afterOrgId: string | null, limit: number): Promise<string[]>
+  /** Per-set capacity and unmet demand, for the pool gauges (observability/pool-metrics.ts).
+   *  Read-only and derived entirely from the ledger, so it states what the claim paths would
+   *  decide rather than a second opinion about it: `liveMs` is the same liveness horizon
+   *  {@link DutyGroupRepo.newerGenerationLive} uses, `maxMembers` the same deliverability cap
+   *  {@link DutyGroupRepo.claimVacant} gates on. */
+  poolTelemetry(now: Date, liveMs: number, maxMembers: number): Promise<PoolTelemetryRow[]>
   /** The placement fence, re-derived from the eligibility predicate: vacate every held group its
    *  holder may no longer hold — an agent moved off a set onto a machine, or off one machine
    *  onto another. Same rule as {@link DutyGroupRepo.claimVacant}, read from the holder's side, so

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5092,7 +5092,11 @@ export interface PoolTelemetryRow {
   installWide: boolean
   /** Members seen within the lease horizon. */
   liveMembers: number
-  /** Σ `maxAgents` over those members — the duty budget the pool can currently spend. */
+  /** Of those, the ones running UNBOUNDED (`maxAgents <= 0`, the daemon's sentinel for no ceiling).
+   *  Non-zero means this set has no finite budget, so capacity and headroom are not defined for it. */
+  unboundedMembers: number
+  /** Σ `maxAgents` over the BOUNDED members — the duty budget the pool can currently spend.
+   *  Meaningless while {@link PoolTelemetryRow.unboundedMembers} is non-zero. */
   capacityAgents: number
   /** Distinct agents covered by unexpired leases those members hold — the budget spent. */
   dutyAgents: number

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -414,8 +414,17 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
         FROM "daemon" d JOIN "member_set_member" msm ON msm."daemonId" = d.id
         WHERE d."lastSeenAt" >= ${liveSince}
       ),
+      -- maxAgents <= 0 is the daemon's UNBOUNDED sentinel, not a ceiling of zero
+      -- (Daemon.dutyHeadroomForPendingClaim returns +Infinity for it; the heartbeat's finite
+      -- number is only a batching hint). Summing it raw would report a member that accepts
+      -- everything as contributing nothing, so a pool with no ceiling would read as permanently
+      -- full. Counted separately instead, and the capacity sum covers the bounded members only —
+      -- which also keeps a negative value, allowed by the wire schema, out of the arithmetic.
       cap AS (
-        SELECT "setId", count(*)::int AS members, COALESCE(sum("maxAgents"), 0)::int AS capacity
+        SELECT "setId",
+               count(*)::int AS members,
+               count(*) FILTER (WHERE "maxAgents" <= 0)::int AS unbounded,
+               COALESCE(sum("maxAgents") FILTER (WHERE "maxAgents" > 0), 0)::int AS capacity
         FROM live GROUP BY "setId"
       ),
       -- Used capacity read the way the member gates itself (§12): duty-covered agents, deduped,
@@ -459,6 +468,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       )
       SELECT s.id AS "setId", s.name AS "setName", (s."orgId" IS NULL) AS "installWide",
              COALESCE(cap.members, 0)::int AS "liveMembers",
+             COALESCE(cap.unbounded, 0)::int AS "unboundedMembers",
              COALESCE(cap.capacity, 0)::int AS "capacityAgents",
              COALESCE(used.agents, 0)::int AS "dutyAgents",
              COALESCE(vac.groups, 0)::int AS "vacantGroups",

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -10,7 +10,8 @@ import type {
   DutyGrantRecord,
   DutyGroupRecord,
   DutyGroupRepo,
-  DutyReconcilePlanner
+  DutyReconcilePlanner,
+  PoolTelemetryRow
 } from '../ports.js'
 import type { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import { withTx } from '../prisma.js'
@@ -402,6 +403,73 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       LIMIT 1
     `)
     return rows.length > 0
+  }
+
+  async poolTelemetry(now: Date, liveMs: number, maxMembers: number): Promise<PoolTelemetryRow[]> {
+    // Liveness is the ledger's one notion of it, as everywhere else: seen within the lease horizon.
+    const liveSince = new Date(now.getTime() - liveMs)
+    return this.prisma.$queryRaw<PoolTelemetryRow[]>(Prisma.sql`
+      WITH live AS (
+        SELECT d.id, msm."setId", d."maxAgents"
+        FROM "daemon" d JOIN "member_set_member" msm ON msm."daemonId" = d.id
+        WHERE d."lastSeenAt" >= ${liveSince}
+      ),
+      cap AS (
+        SELECT "setId", count(*)::int AS members, COALESCE(sum("maxAgents"), 0)::int AS capacity
+        FROM live GROUP BY "setId"
+      ),
+      -- Used capacity read the way the member gates itself (§12): duty-covered agents, deduped,
+      -- under UNEXPIRED leases only, so a lapsed lease frees its headroom here exactly when it
+      -- frees it at the claim.
+      used AS (
+        SELECT l."setId", count(DISTINCT m."refId")::int AS agents
+        FROM "duty_group" g
+        JOIN live l ON l.id = g."holder"
+        JOIN "duty_group_member" m ON m."groupId" = g.id AND m."kind" = 'agent'
+        WHERE g."expiresAt" IS NOT NULL AND g."expiresAt" > ${now}
+        GROUP BY l."setId"
+      ),
+      -- A vacancy counts against a set only when that set could actually take it, which is the
+      -- claimVacant eligibility gate restated set-wise: every RESOLVABLE agent in the group is
+      -- set-placed into one and the same set. Without this the count is dominated by the singleton
+      -- rows of machine-placed agents, which are vacant by design and forever (§6).
+      vacant AS (
+        SELECT g.id,
+               -- Single-valued by the HAVING below; uuid has no min(), so take it from the array.
+               (array_agg(DISTINCT a."setId"))[1] AS "setId",
+               GREATEST(EXTRACT(EPOCH FROM (${now}::timestamptz - COALESCE(g."expiresAt", g."updatedAt"))), 0) AS age,
+               (SELECT count(*) FROM "duty_group_member" dm WHERE dm."groupId" = g.id) AS size
+        FROM "duty_group" g
+        JOIN "duty_group_member" m ON m."groupId" = g.id AND m."kind" = 'agent'
+        JOIN "agent" a ON a.id = m."refId"
+        WHERE g."holder" IS NULL OR g."expiresAt" IS NULL OR g."expiresAt" < ${now}
+        GROUP BY g.id
+        HAVING count(*) FILTER (WHERE a."placementKind" <> 'set' OR a."setId" IS NULL) = 0
+           AND count(DISTINCT a."setId") = 1
+      ),
+      -- Oversized groups are split out, never folded into the claimable count: they are
+      -- undeliverable on this wire at any pool size (§5), so counting them as unmet demand would
+      -- pin a capacity alert high forever. They are their own signal — D16, a dedicated daemon.
+      vac AS (
+        SELECT "setId",
+               count(*) FILTER (WHERE size <= ${maxMembers})::int AS groups,
+               count(*) FILTER (WHERE size > ${maxMembers})::int AS oversized,
+               COALESCE(max(age) FILTER (WHERE size <= ${maxMembers}), 0)::double precision AS oldest
+        FROM vacant GROUP BY "setId"
+      )
+      SELECT s.id AS "setId", s.name AS "setName", (s."orgId" IS NULL) AS "installWide",
+             COALESCE(cap.members, 0)::int AS "liveMembers",
+             COALESCE(cap.capacity, 0)::int AS "capacityAgents",
+             COALESCE(used.agents, 0)::int AS "dutyAgents",
+             COALESCE(vac.groups, 0)::int AS "vacantGroups",
+             COALESCE(vac.oversized, 0)::int AS "oversizedVacantGroups",
+             COALESCE(vac.oldest, 0)::double precision AS "oldestVacancySec"
+      FROM "member_set" s
+      LEFT JOIN cap ON cap."setId" = s.id
+      LEFT JOIN used ON used."setId" = s.id
+      LEFT JOIN vac ON vac."setId" = s.id
+      ORDER BY s.id
+    `)
   }
 
   async confirmHeld(holder: DaemonId, reported: readonly DutyDigestEntry[]): Promise<string[]> {

--- a/packages/control-plane/test/repo/duty-group.repo.test.ts
+++ b/packages/control-plane/test/repo/duty-group.repo.test.ts
@@ -449,3 +449,127 @@ describe('DutyGroupRepo — the rollout barrier `newerGenerationLive` (real Post
     expect(row.generationSince).toEqual(after(20_000))
   })
 })
+
+describe('DutyGroupRepo — pool telemetry (real Postgres)', () => {
+  const MAX_MEMBERS = 1000
+  /** An ORG-scoped daemon — the machine placement the pool must not read as its own demand. */
+  const LOCAL = DaemonId('d4444444-4444-4444-8444-444444444444')
+  /** The pool set's row, whatever the migration named it. */
+  const poolRow = async (repo: PgDutyGroupRepo, now = T0, maxMembers = MAX_MEMBERS) =>
+    (await repo.poolTelemetry(now, LEASE_MS, maxMembers)).find((r) => r.installWide)!
+
+  async function liveMember(id: string, maxAgents = 8, lastSeenAt: Date | null = T0) {
+    await prisma.daemon.create({ data: { id, orgId: null, maxAgents, status: 'ready', lastSeenAt } })
+  }
+
+  it('capacity is the live members budget; a member past the lease horizon leaves it', async () => {
+    await liveMember(M1, 8)
+    await liveMember(M2, 4, after(-LEASE_MS - 1))
+    await joinPool(prisma, M1, M2)
+    const repo = new PgDutyGroupRepo(prisma, minter())
+
+    const row = await poolRow(repo)
+    expect(row).toMatchObject({ liveMembers: 1, capacityAgents: 8, dutyAgents: 0 })
+
+    // Its beat resumes ⇒ its budget is spendable again.
+    await prisma.daemon.update({ where: { id: M2 }, data: { lastSeenAt: T0 } })
+    expect(await poolRow(repo)).toMatchObject({ liveMembers: 2, capacityAgents: 12 })
+  })
+
+  // The property the whole alert rests on: `duty_group` holds one permanently-vacant singleton per
+  // machine-placed agent (§6). Counting those as unmet demand would pin the alarm high forever.
+  it('a machine-placed agent vacancy is not the pool unmet demand', async () => {
+    await liveMember(M1)
+    await joinPool(prisma, M1)
+    await prisma.daemon.create({ data: { id: LOCAL, orgId: DEFAULT_ORG_ID, maxAgents: 4, status: 'ready' } })
+    await prisma.agent.create({
+      data: {
+        id: A1,
+        orgId: DEFAULT_ORG_ID,
+        name: 'on-a-machine',
+        runtime: 'claude',
+        placementKind: 'daemon',
+        daemonId: LOCAL
+      }
+    })
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [], [A1], T0)
+
+    // The row exists and is vacant — and is invisible to the pool's demand.
+    expect(await prisma.dutyGroup.count()).toBe(1)
+    expect(await poolRow(repo, after(600_000))).toMatchObject({ vacantGroups: 0, oldestVacancySec: 0 })
+  })
+
+  it('a set-placed vacancy is demand, and ages from the moment its lease lapsed', async () => {
+    await liveMember(M1)
+    const setId = await joinPool(prisma, M1)
+    await prisma.agent.create({
+      data: { id: A1, orgId: DEFAULT_ORG_ID, name: 'pooled', runtime: 'claude', placementKind: 'set', setId }
+    })
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [], [A1], T0)
+    expect(await poolRow(repo)).toMatchObject({ vacantGroups: 1, dutyAgents: 0 })
+
+    // Held: it leaves the demand and spends a unit of budget.
+    await repo.claimVacant(M1, 10, T0, LEASE_MS)
+    expect(await poolRow(repo, after(1000))).toMatchObject({ vacantGroups: 0, dutyAgents: 1, capacityAgents: 8 })
+
+    // Lapsed: back to demand, aged from `expiresAt` — not from the read — and the budget is free.
+    const lapsed = after(LEASE_MS + 60_000)
+    expect(await poolRow(repo, lapsed)).toMatchObject({ vacantGroups: 1, dutyAgents: 0, oldestVacancySec: 60 })
+  })
+
+  // An oversized group is undeliverable on the wire at ANY pool size (§5) — scaling the Deployment
+  // would never clear it, so it must not be able to hold the capacity alert up.
+  it('an oversized vacancy is reported apart from the claimable demand', async () => {
+    await liveMember(M1)
+    const setId = await joinPool(prisma, M1)
+    await prisma.agent.createMany({
+      data: [
+        { id: A1, orgId: DEFAULT_ORG_ID, name: 'pooled', runtime: 'claude', placementKind: 'set', setId },
+        { id: A2, orgId: DEFAULT_ORG_ID, name: 'pooled-2', runtime: 'claude', placementKind: 'set', setId }
+      ]
+    })
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    // One group of two members (agent+bot), one singleton; a cap of 1 makes the pair oversized.
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
+    // The claimable singleton, lapsed 60s ago — the only age the pool should report.
+    await repo.claimVacant(M1, 10, T0, LEASE_MS, { maxMembers: 1 })
+    // The undeliverable pair, made FAR older than that. A never-claimed group ages from
+    // `updatedAt`, which only raw SQL can backdate past Prisma's @updatedAt.
+    await prisma.$executeRaw`
+      UPDATE "duty_group" SET "updatedAt" = ${after(-3_600_000)}
+      WHERE (SELECT count(*) FROM "duty_group_member" m WHERE m."groupId" = "duty_group".id) > 1`
+
+    const row = await poolRow(repo, after(LEASE_MS + 60_000), 1)
+    expect(row).toMatchObject({ vacantGroups: 1, oversizedVacantGroups: 1 })
+    // The age is the claimable one's; the hour-old undeliverable group cannot pin the alert up.
+    expect(row.oldestVacancySec).toBe(60)
+  })
+
+  it('a group mixing a set-placed and a machine-placed agent is demand for nobody', async () => {
+    await liveMember(M1)
+    const setId = await joinPool(prisma, M1)
+    await prisma.daemon.create({ data: { id: LOCAL, orgId: DEFAULT_ORG_ID, maxAgents: 4, status: 'ready' } })
+    await prisma.agent.createMany({
+      data: [
+        { id: A1, orgId: DEFAULT_ORG_ID, name: 'pooled', runtime: 'claude', placementKind: 'set', setId },
+        { id: A2, orgId: DEFAULT_ORG_ID, name: 'machined', runtime: 'claude', placementKind: 'daemon', daemonId: LOCAL }
+      ]
+    })
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    // Two agents joined by one bot ⇒ ONE component holding both, claimable by neither side.
+    await reconcile(
+      repo,
+      [
+        { agentId: A1, botId: B1 },
+        { agentId: A2, botId: B1 }
+      ],
+      [],
+      T0
+    )
+
+    expect(await prisma.dutyGroup.count()).toBe(1)
+    expect(await poolRow(repo, after(600_000))).toMatchObject({ vacantGroups: 0, oversizedVacantGroups: 0 })
+  })
+})

--- a/packages/control-plane/test/repo/duty-group.repo.test.ts
+++ b/packages/control-plane/test/repo/duty-group.repo.test.ts
@@ -519,6 +519,37 @@ describe('DutyGroupRepo — pool telemetry (real Postgres)', () => {
     expect(await poolRow(repo, lapsed)).toMatchObject({ vacantGroups: 1, dutyAgents: 0, oldestVacancySec: 60 })
   })
 
+  // maxAgents <= 0 is the daemon's UNBOUNDED sentinel, not a ceiling of zero, and the wire schema
+  // (z.number().int()) admits negatives too. Folding either into the sum would report a member
+  // that accepts everything as contributing nothing.
+  it('counts an unbounded member apart and keeps its sentinel out of the capacity sum', async () => {
+    await liveMember(M1, 8)
+    await liveMember(M2, 0)
+    await joinPool(prisma, M1, M2)
+    const repo = new PgDutyGroupRepo(prisma, minter())
+
+    const row = await poolRow(repo)
+    expect(row).toMatchObject({ liveMembers: 2, unboundedMembers: 1, capacityAgents: 8 })
+
+    // A negative ceiling is the same sentinel, and must not subtract from the budget either.
+    await prisma.daemon.update({ where: { id: M2 }, data: { maxAgents: -4 } })
+    expect(await poolRow(repo)).toMatchObject({ unboundedMembers: 1, capacityAgents: 8 })
+
+    // Give it a real ceiling and the set becomes bounded again, budget included.
+    await prisma.daemon.update({ where: { id: M2 }, data: { maxAgents: 4 } })
+    expect(await poolRow(repo)).toMatchObject({ unboundedMembers: 0, capacityAgents: 12 })
+  })
+
+  it('an unbounded member that has gone quiet stops making the set unbounded', async () => {
+    await liveMember(M1, 8)
+    await liveMember(M2, 0, after(-LEASE_MS - 1))
+    await joinPool(prisma, M1, M2)
+    const repo = new PgDutyGroupRepo(prisma, minter())
+
+    // Liveness gates this exactly as it gates capacity: a dead member constrains nothing.
+    expect(await poolRow(repo)).toMatchObject({ liveMembers: 1, unboundedMembers: 0, capacityAgents: 8 })
+  })
+
   // An oversized group is undeliverable on the wire at ANY pool size (§5) — scaling the Deployment
   // would never clear it, so it must not be able to hold the capacity alert up.
   it('an oversized vacancy is reported apart from the claimable demand', async () => {


### PR DESCRIPTION
## Why

`k8s-daemon-pool.md` §12 leaves the control plane exactly one observability job:

> The CP never load-balances, never schedules, never picks; it only refuses invalid claims and **alarms on vacant-duty age**. A human scales the Deployment.

That alarm was never built. "Is the pool big enough?" had no observable at all — the ledger knew the answer and never said it.

## What

`DutyGroupRepo.poolTelemetry` — one read per member set returning live members, the duty budget they can spend, the budget spent, and the unmet demand — projected onto seven observable gauges in `observability/pool-metrics.ts`.

Two paired signals, deliberately: **headroom leads** (scale before it hurts), **vacancy age lags** (something is already unserved).

| Gauge | Meaning |
| --- | --- |
| `agentconnect.pool.members` | members seen within the lease horizon |
| `agentconnect.pool.capacity.agents` | Σ `maxAgents` over them — the budget |
| `agentconnect.pool.duty.agents` | distinct agents under unexpired leases — the budget spent |
| `agentconnect.pool.headroom.agents` | capacity − spent; ≤ 0 means full |
| `agentconnect.duty.vacant.groups` | claimable vacancies — unmet demand |
| `agentconnect.duty.vacant.oldest_age` | age of the oldest one — the §12 alarm |
| `agentconnect.duty.undeliverable.groups` | vacant but over the wire's member cap (D16) |

## The part that makes it work

The read reuses the claim paths' own predicates instead of restating them, so the gauges say what a claim *would decide*:

- **Eligibility, set-wise.** Most `duty_group` rows are singletons of machine-placed agents, vacant by design and forever (§6). Counting them would pin the alarm high permanently. A vacancy counts for a set only when every resolvable agent in the group is set-placed into that set — so a group mixing a set-placed and a machine-placed agent is demand for nobody, exactly as it is claimable by nobody.
- **Liveness** is the lease horizon, the ledger's one notion of it.
- **Deliverability.** An oversized group is undeliverable at *any* pool size (§5), so it gets its own gauge and is kept out of both the claimable count and the age. Scaling would never clear it, so it must not be able to hold a capacity alert up.

A collection that cannot read the ledger observes **nothing** rather than zeros: a zeroed headroom gauge is indistinguishable from a full pool, so a database blip would otherwise fire the capacity alert.

## Cost

One read per metric-export interval per replica (60s by default), on the control plane's own database — the data plane is untouched. Measured on real Postgres: 14 ms at 1k `duty_group` rows, 69 ms at 6k, 182 ms at 26k, roughly linear.

Every replica observes the same install-wide totals, so these aggregate with `max by (set)`, never `sum`.

## Tests

Five integration cases on real Postgres pinning the semantics above — including that a machine-placed vacancy is not pool demand, that a mixed group is demand for nobody, and that an hour-old undeliverable vacancy cannot raise the reported age — plus unit cases for the headroom projection and the skip-on-read-failure guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
