### PR TITLE
fix(control-plane): terminate an accepted socket that errors instead of crashing

### DIFF
--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -143,6 +143,8 @@ export function buildApp(deps: BuildAppDeps): App {
     http: container.http,
     mountWs() {
       if (!wss) {
+        // Fastify drops its bind-failure listener once listen() resolves, so a later accept error is fatal unheard.
+        container.http.server.on('error', (err) => container.http.log.warn(`http server socket error: ${err.message}`))
         wss = container.wsGateway(container.http)
         // The relay control gateway rides the same http.Server on its own path;
         // mount it alongside so one `mountWs()` call attaches both edges.

--- a/packages/control-plane/src/ws/transport.ts
+++ b/packages/control-plane/src/ws/transport.ts
@@ -41,6 +41,8 @@ export class WsTransport implements Transport {
   ) {
     this.subprotocol = ws.protocol
     this.remoteAddr = remoteAddr
+    // An unlistened 'error' (oversized frame, reset) crashes the process; terminate() folds it into close.
+    ws.on('error', () => ws.terminate())
   }
 
   send(text: string): void {

--- a/packages/control-plane/test/integration/ws-handshake.test.ts
+++ b/packages/control-plane/test/integration/ws-handshake.test.ts
@@ -14,7 +14,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { WebSocket } from 'ws'
-import { isFrame, type AnyFrame } from '@agentconnect.md/protocol'
+import { MAX_FRAME_BYTES, isFrame, type AnyFrame } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { buildDaemonApp, type DaemonApp } from '../fakes/build-app.js'
 
@@ -104,6 +104,30 @@ describe('ws gateway — real socket handshake over agentconnect.v1', () => {
       expect(row?.status).toBe('ready')
       expect(row?.sessionEpoch).toBe(1n)
       expect(row?.host).toBe('host-1')
+    } finally {
+      ws.close()
+    }
+  })
+
+  it('survives an oversized frame from an unauthenticated peer and still accepts the next daemon', async () => {
+    const { url, token } = await start()
+    // 256 KiB + 1 from a peer that presented no key: an unlistened payload-cap 'error' ends the process.
+    const intruder = await dial(url, SUBPROTOCOL)
+    const seen: string[] = []
+    intruder.on('message', (data: Buffer) => seen.push(data.toString()))
+    const intruderClosed = new Promise<void>((resolve) => intruder.once('close', () => resolve()))
+    intruder.send('x'.repeat(MAX_FRAME_BYTES + 1))
+    await intruderClosed
+    // Not one frame: an unproved peer learns nothing about this control plane.
+    expect(seen).toEqual([])
+
+    // The gateway is still up — a real daemon completes the full handshake behind it.
+    const ws = await dial(url, SUBPROTOCOL)
+    try {
+      sendFrame(ws, 'auth', { apiKey: token, daemonId: DAEMON, agentVersion: '1.4.0' })
+      const ok = await nextFrame(ws, 'auth/ok')
+      if (!isFrame('auth/ok')(ok)) throw new Error('expected auth/ok')
+      expect(ok.payload.daemonId).toBe(DAEMON)
     } finally {
       ws.close()
     }


### PR DESCRIPTION
`WsTransport` bridged `message` and `close` off the accepted socket but never `error`. The `ws` library raises `error` when a peer exceeds `maxPayload: MAX_FRAME_BYTES`, and an unlistened `error` event is an uncaught exception in Node — so one oversized frame from a peer that has authenticated nothing took the whole control plane down rather than the connection.

`WsTransport` fronts **both** accept paths, the daemon WS endpoint (`ws/gateway.ts`) and the relay control gateway (`ws/relay-gateway.ts`), so one guard armed in the constructor — before anything can await — covers both. `terminate()` folds the fault into the normal `close` path every connection FSM above already handles.

Fastify also drops its bind-failure listener from the http server once `listen()` resolves, which leaves a later accept error unheard and therefore fatal; `mountWs()` now keeps a warning listener on the live server. The two `WebSocketServer`s need none: in `noServer` mode they emit no `error`, and an unlistened `wsClientError` aborts the handshake on its own.

Same defect class as #1100, which fixes it for the shared connection transport and the daemon's two shim accept paths. Independent of that PR — different package, different class — and based on `main`.

## Test

One case over a real socket: an oversized frame from an unauthenticated peer closes that connection with no frame disclosed to it, and the gateway still completes a full handshake for the next daemon.

Mutation-checked — with `ws.on('error', ...)` removed the case fails the whole Vitest run:

```
RangeError: Max payload size exceeded
Serialized Error: { code: 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH' }
```

`pnpm --filter @agentconnect.md/control-plane test` — 1389 passed, plus typecheck, lint and format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
