### PR TITLE
docs(designs): point the relay Slack HTTP ingest references at their current path

### DIFF
--- a/docs/designs/loop-breaker-design.md
+++ b/docs/designs/loop-breaker-design.md
@@ -180,8 +180,8 @@ Implementation entry points:
   durable counter and latch.
 - [`packages/daemon/src/slack/connection.ts`](../../packages/daemon/src/slack/connection.ts):
   direct Slack ingress.
-- [`packages/relay/src/slack-http-ingest.ts`](../../packages/relay/src/slack-http-ingest.ts):
-  HTTP Slack ingress.
+- [`packages/relay/src/platforms/slack/http-ingest.ts`](../../packages/relay/src/platforms/slack/http-ingest.ts):
+  HTTP Slack ingress — the relay's per-bot inbound handler.
 
 ### 4.1 Messages Counted
 

--- a/docs/designs/send-message-routing-rework.md
+++ b/docs/designs/send-message-routing-rework.md
@@ -562,8 +562,8 @@ The main implementation surfaces are:
 - `packages/daemon/src/slack/connection.ts`: retain AgentConnect-authored events,
   stamp response/recipient/pairing state, split only at mention-safe boundaries,
   and surface only the finalized routing event.
-- `packages/relay/src/slack-http-ingest.ts`: stop dropping AgentConnect message
-  echoes while retaining structural/chrome filtering.
+- `packages/relay/src/platforms/slack/http-ingest.ts`: stop dropping AgentConnect
+  message echoes while retaining structural/chrome filtering.
 - `packages/relay/src/relay-ingress-manager.ts`: replace blanket managed-agent
   suppression with author verification, source-hop transition/cap enforcement,
   per-edge policy checks, and cross-daemon participant fan-out — with the paired


### PR DESCRIPTION
## What

Two design docs pointed at the relay's Slack HTTP ingest by its pre-move path.
The file moved into its platform module when the per-platform ingress refactor
landed:

```
packages/relay/src/slack-http-ingest.ts
-> packages/relay/src/platforms/slack/http-ingest.ts
```

- `docs/designs/loop-breaker-design.md` — the reference was a **relative markdown
  link**, so it resolved to nothing. This was the only broken relative link in
  the repository.
- `docs/designs/send-message-routing-rework.md` — the same file named as a bare
  code span in the implementation map, so no link checker would have caught it.

The loop-breaker bullet also gets one clarifying clause. A sibling
`http-ingress.ts` now sits next to `http-ingest.ts` holding the shared route
surface, so "HTTP Slack ingress" alone no longer identifies which of the two the
bullet means; it now reads "the relay's per-bot inbound handler", which is what
`http-ingest.ts` actually is and the relay-side counterpart to the
`packages/daemon/src/slack/connection.ts` bullet above it.

## Verification

Walked every tracked markdown file, extracted `](...)` targets plus reference
definitions that are not http/https/mailto/anchors, and asserted each resolves
on disk:

```
88 markdown files, 356 relative targets, 0 broken   (was 1)
```

The other three bullets in that loop-breaker list (`daemon.ts`,
`store/local-store.ts`, `slack/connection.ts`) were each confirmed to exist.
`pnpm format:check` passes.

## Deliberately not changed

A wider sweep of backticked `packages/...` paths in docs turns up a few more
that do not resolve, but none are stale-path rot — checked against history,
each either was never built or records its own removal:

| Doc | Path | Why left alone |
| --- | --- | --- |
| `agent-capability-benchmark-harness.md` | `packages/bench` | never existed — proposed harness |
| `linear-integration.md` | `daemon/src/linear/*` | never existed — unimplemented integration |
| `send-message-routing-rework.md` | `daemon/src/state-store.ts` | never existed under that name |
| `superpowers/plans/2026-08-06-notification-center-consolidation.md` | `SessionAccessNotice.*` | a plan describing files its own execution deleted |

Rewriting those would mean editing proposals to match code that was never
written, which is a different change from repairing a moved-file reference.

Separately, `packages/relay/src/platforms/slack/` still carries a couple of
code comments naming the old filenames (`ingress-plugin.ts` says the ingest
class "stays in `slack-http-ingest.ts` for this PR"). Left for a source-side
change rather than mixed into a docs fix.
