### PR TITLE
chore(control-plane): drop the per-org cluster-identity daemon resolver

### DIFF
--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -189,28 +189,6 @@ export interface DaemonRepo {
    * `createdByUserId` stamps the WebUI principal who provisioned it (console "Created" row).
    */
   provision(daemonId: DaemonId, orgId: OrgId, createdByUserId?: string): Promise<DaemonRecord>
-  /**
-   * The daemon record bound to a verified Kubernetes identity, JIT-provisioning one on
-   * first sight — the same shape as `UserRepo`'s OIDC-subject provisioning. The store's
-   * envelope-only unique index makes the binding one-to-one, so an envelope never ends up
-   * with two records competing for its placements; the identity is namespace-derived, so
-   * a rebuilt envelope resolves back to the same row and keeps its history.
-   *
-   * `adoptDaemonId` names the record the retired API-key path already pinned for this
-   * envelope. On the first token connect it is bound to the identity rather than left
-   * beside a fresh one, so an org provisioned before this path keeps its placements and
-   * history. Ignored once the identity is bound, or if that record is another org's or
-   * already carries an identity.
-   *
-   * Null when the identity is already bound to a daemon in ANOTHER org: an envelope identity may
-   * not move tenants, and refusing is the only answer that cannot leak one org's
-   * placements to another.
-   */
-  resolveClusterIdentity(
-    orgId: OrgId,
-    clusterIdentity: string,
-    opts?: { adoptDaemonId?: string }
-  ): Promise<DaemonRecord | null>
   /** Resolve one install-wide pool member by its reviewed ServiceAccount subject and Pod UID. */
   resolvePoolClusterIdentity(clusterIdentity: string, clusterPodUid: string): Promise<DaemonRecord>
   /** The Kubernetes identity a daemon record is bound to, or null for an unknown/key daemon. */

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -65,8 +65,7 @@ function toRecord(d: DaemonWithUsers): DaemonRecord {
   }
 }
 
-// What an install-wide pool member is, as a where-clause: org-less, cluster-reviewed, and
-// bound to one Pod UID. An envelope daemon carries an identity but no Pod, so it never matches.
+// What an install-wide pool member is, as a where-clause: org-less, cluster-reviewed, Pod-bound.
 const POOL_MEMBER_WHERE = { orgId: null, clusterIdentity: { not: null }, clusterPodUid: { not: null } } as const
 
 /** ONE definition of "retired", shared by the worklist read and the delete that acts on it: a
@@ -105,39 +104,6 @@ export class PgDaemonRepo implements DaemonRepo {
     })
   }
 
-  async resolveClusterIdentity(
-    orgId: OrgId,
-    clusterIdentity: string,
-    opts: { adoptDaemonId?: string } = {}
-  ): Promise<DaemonRecord | null> {
-    const existing = await this.db.daemon.findFirst({
-      where: { clusterIdentity, clusterPodUid: null },
-      include: withUsers
-    })
-    if (existing) return existing.orgId === orgId ? toRecord(existing) : null
-    const adopted = opts.adoptDaemonId ? await this.adoptForIdentity(orgId, clusterIdentity, opts.adoptDaemonId) : null
-    if (adopted) return adopted
-    try {
-      return await withAmbientTx(this.db, async (tx) => {
-        await lockResourceWriteMemberships(tx, { orgId, visibility: 'org' })
-        const daemon = await tx.daemon.create({
-          data: { id: randomUUID(), orgId, clusterIdentity, status: 'provisioned' },
-          include: withUsers
-        })
-        return toRecord(daemon)
-      })
-    } catch (error) {
-      // A concurrent first connect won the unique index; its row is the binding.
-      if ((error as { code?: string }).code !== 'P2002') throw error
-      const raced = await this.db.daemon.findFirst({
-        where: { clusterIdentity, clusterPodUid: null },
-        include: withUsers
-      })
-      if (!raced) throw error
-      return raced.orgId === orgId ? toRecord(raced) : null
-    }
-  }
-
   async resolvePoolClusterIdentity(clusterIdentity: string, clusterPodUid: string): Promise<DaemonRecord> {
     const where = { clusterIdentity_clusterPodUid: { clusterIdentity, clusterPodUid } }
     const existing = await this.db.daemon.findUnique({ where, include: withUsers })
@@ -171,30 +137,6 @@ export class PgDaemonRepo implements DaemonRepo {
       select: { id: true }
     })
     return rows.map((row) => row.id)
-  }
-
-  /** Bind an envelope's existing daemon record — the one the API-key path pinned — to the
-   *  identity now authenticating for it, so an org provisioned before the token path keeps
-   *  its placements and history instead of gaining a second record beside them. Conditional
-   *  on the row being this org's and still unbound; anything else falls through to a create. */
-  private async adoptForIdentity(
-    orgId: OrgId,
-    clusterIdentity: string,
-    daemonId: string
-  ): Promise<DaemonRecord | null> {
-    try {
-      const claimed = await this.db.daemon.updateMany({
-        where: { id: daemonId, orgId, clusterIdentity: null },
-        data: { clusterIdentity }
-      })
-      if (claimed.count !== 1) return null
-    } catch (error) {
-      // Another identity claimed this record first; it is not this envelope's to adopt.
-      if ((error as { code?: string }).code !== 'P2002') throw error
-      return null
-    }
-    const daemon = await this.db.daemon.findUnique({ where: { id: daemonId }, include: withUsers })
-    return daemon ? toRecord(daemon) : null
   }
 
   async upsertOnAuth(input: AuthReqInput): Promise<{ daemon: DaemonRecord; sessionEpoch: bigint }> {

--- a/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
+++ b/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
@@ -9,114 +9,12 @@ import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
 
-const IDENTITY = 'system:serviceaccount:ac-org-example:ac-daemon'
 const INSTALL_IDENTITY = 'system:serviceaccount:agentconnect:ac-cloud-daemon'
 const POD_UID_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const POD_UID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 const DEF_ORG = OrgId(DEFAULT_ORG_ID)
 
-describe('DaemonRepo.resolveClusterIdentity', () => {
-  it('provisions a record on first sight and returns the same one afterwards', async () => {
-    const repo = new PgDaemonRepo(prisma)
-
-    const first = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
-    const second = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
-
-    expect(first).not.toBeNull()
-    expect(second?.id).toBe(first!.id)
-    expect(first!.orgId).toBe(DEFAULT_ORG_ID)
-    // Provisioned, not authenticating: `upsertOnAuth` still mints the epoch afterwards.
-    expect(await prisma.daemon.count({ where: { clusterIdentity: IDENTITY } })).toBe(1)
-  })
-
-  it('keeps the record — and its history — when the envelope is rebuilt', async () => {
-    const repo = new PgDaemonRepo(prisma)
-    const provisioned = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
-    await repo.upsertOnAuth({ daemonId: DaemonId(provisioned!.id), orgId: DEF_ORG, agentVersion: '1.0.0' })
-    await prisma.daemon.update({ where: { id: provisioned!.id }, data: { name: 'named by a human' } })
-
-    // A torn-down and re-provisioned envelope derives the same namespace, so the same
-    // identity arrives again — and must not strand the placements under a fresh record.
-    const afterRebuild = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
-
-    expect(afterRebuild?.id).toBe(provisioned!.id)
-    expect(afterRebuild?.name).toBe('named by a human')
-    expect(afterRebuild?.sessionEpoch).toBe(1n)
-  })
-
-  it('binds one record per identity, so two orgs cannot share one envelope', async () => {
-    const repo = new PgDaemonRepo(prisma)
-    const other = await prisma.org.create({ data: { slug: 'other-cluster-org' } })
-
-    const mine = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
-    const theirs = await repo.resolveClusterIdentity(OrgId(other.id), IDENTITY)
-
-    expect(mine).not.toBeNull()
-    // Refused rather than re-bound: an identity may not move tenants.
-    expect(theirs).toBeNull()
-    expect(await prisma.daemon.count({ where: { clusterIdentity: IDENTITY } })).toBe(1)
-  })
-
-  it('adopts the record the key path already pinned, instead of stranding it', async () => {
-    const repo = new PgDaemonRepo(prisma)
-    // An envelope provisioned before the token path: its daemon record exists and carries
-    // the placements and history the key-backed connection built up.
-    const keyBacked = DaemonId('55555555-5555-4555-8555-555555555555')
-    await repo.provision(keyBacked, DEF_ORG)
-    await repo.upsertOnAuth({ daemonId: keyBacked, orgId: DEF_ORG, agentVersion: '1.0.0' })
-
-    const bound = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY, { adoptDaemonId: keyBacked })
-
-    expect(bound?.id).toBe(keyBacked)
-    expect(bound?.sessionEpoch).toBe(1n)
-    expect(await prisma.daemon.count({ where: { orgId: DEFAULT_ORG_ID } })).toBe(1)
-  })
-
-  it('ignores an adoption candidate that already carries another identity', async () => {
-    const repo = new PgDaemonRepo(prisma)
-    const taken = await repo.resolveClusterIdentity(DEF_ORG, 'system:serviceaccount:ac-org-other:ac-daemon')
-
-    const bound = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY, { adoptDaemonId: taken!.id })
-
-    expect(bound).not.toBeNull()
-    expect(bound!.id).not.toBe(taken!.id)
-    expect(await prisma.daemon.findUnique({ where: { id: taken!.id } })).toMatchObject({
-      clusterIdentity: 'system:serviceaccount:ac-org-other:ac-daemon'
-    })
-  })
-
-  it('ignores an adoption candidate belonging to another org', async () => {
-    const repo = new PgDaemonRepo(prisma)
-    const other = await prisma.org.create({ data: { slug: 'adoption-other-org' } })
-    const theirs = DaemonId('66666666-6666-4666-8666-666666666666')
-    await repo.provision(theirs, OrgId(other.id))
-
-    const bound = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY, { adoptDaemonId: theirs })
-
-    expect(bound!.id).not.toBe(theirs)
-    expect(await prisma.daemon.findUnique({ where: { id: theirs } })).toMatchObject({ clusterIdentity: null })
-  })
-
-  it('gives distinct identities distinct records within one org', async () => {
-    const repo = new PgDaemonRepo(prisma)
-
-    const a = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
-    const b = await repo.resolveClusterIdentity(DEF_ORG, 'system:serviceaccount:ac-org-second:ac-daemon')
-
-    expect(a!.id).not.toBe(b!.id)
-  })
-
-  it('leaves a key-authenticated daemon in the same org unbound', async () => {
-    const repo = new PgDaemonRepo(prisma)
-    const laptop = DaemonId('44444444-4444-4444-8444-444444444444')
-    await repo.provision(laptop, DEF_ORG)
-
-    const envelope = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
-
-    expect(envelope!.id).not.toBe(laptop)
-    expect(await prisma.daemon.findUnique({ where: { id: laptop } })).toMatchObject({ clusterIdentity: null })
-  })
-
+describe('DaemonRepo.resolvePoolClusterIdentity', () => {
   it('keeps pool member Pods out of owned reads while exposing them to availability reads', async () => {
     const repo = new PgDaemonRepo(prisma)
     const other = await prisma.org.create({ data: { slug: 'install-daemon-other-org' } })
@@ -160,14 +58,10 @@ describe('DaemonRepo pool-member retirement', () => {
     const serving = await repo.resolvePoolClusterIdentity(INSTALL_IDENTITY, POD_UID_B)
     await prisma.daemon.update({ where: { id: gone.id }, data: { lastSeenAt: HOUR_AGO } })
     await prisma.daemon.update({ where: { id: serving.id }, data: { lastSeenAt: new Date() } })
-    // Neither of these is a pool member: an envelope daemon is bound to a namespace rather
-    // than a Pod, and a laptop has no identity at all. Both are long silent regardless.
-    const envelope = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
+    // Not a pool member: a laptop has no cluster identity at all, and is long silent regardless.
     const laptop = DaemonId('77777777-7777-4777-8777-777777777777')
     await repo.provision(laptop, DEF_ORG)
-    for (const id of [envelope!.id, laptop]) {
-      await prisma.daemon.update({ where: { id }, data: { lastSeenAt: HOUR_AGO } })
-    }
+    await prisma.daemon.update({ where: { id: laptop }, data: { lastSeenAt: HOUR_AGO } })
 
     const retired = await repo.findRetiredPoolMembers(CUTOFF)
 
@@ -195,12 +89,9 @@ describe('DaemonRepo pool-member retirement', () => {
     const hosted = AgentId('a9999999-9999-4999-8999-999999999999')
     await seedAgent(prisma, hosted, { daemonId: pod.id })
     await new PgAgentRepo(prisma).setPlacement(hosted, onDaemon(pod.id))
-    const envelope = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY)
     const laptop = DaemonId('88888888-8888-4888-8888-888888888888')
     await repo.provision(laptop, DEF_ORG)
-    for (const id of [envelope!.id, laptop]) {
-      await prisma.daemon.update({ where: { id }, data: { lastSeenAt: HOUR_AGO } })
-    }
+    await prisma.daemon.update({ where: { id: laptop }, data: { lastSeenAt: HOUR_AGO } })
     const fence = { retiredBefore: CUTOFF, sessionEpoch: pod.sessionEpoch }
 
     expect(await repo.retirePoolMember(pod.id, fence)).toEqual({
@@ -214,10 +105,8 @@ describe('DaemonRepo pool-member retirement', () => {
     })
     // Gone, so a repeat (a peer replica sweeping the same row) is a no-op, not an error.
     expect(await repo.retirePoolMember(pod.id, fence)).toMatchObject({ deleted: false })
-    expect(await repo.retirePoolMember(envelope!.id, fence)).toMatchObject({ deleted: false })
     expect(await repo.retirePoolMember(laptop, fence)).toMatchObject({ deleted: false })
     expect(await prisma.daemon.findUnique({ where: { id: pod.id } })).toBeNull()
-    expect(await prisma.daemon.findUnique({ where: { id: envelope!.id } })).not.toBeNull()
     expect(await prisma.daemon.findUnique({ where: { id: laptop } })).not.toBeNull()
   })
 


### PR DESCRIPTION
`DaemonRepo.resolveClusterIdentity` was the per-org execution envelope's authentication path: it resolved a daemon row by `clusterIdentity` with `clusterPodUid: null` — the shape only an org-scoped in-cluster daemon ever had. #964 deleted the envelope outright (the operator, the `AgentConnectOrg` CR, the control plane's spec projector) and #1086 dropped its tables, leaving this method with no production caller.

## Verification that it is dead

- A repo-wide grep for `resolveClusterIdentity` and `adoptForIdentity` hits only `daemon.repo.ts`, its `DaemonRepo` port declaration, and `test/repo/daemon-cluster-identity.repo.test.ts`.
- `PgDaemonRepo` is the sole `DaemonRepo` implementation, so there is no second binding to check.
- The one remaining in-cluster authentication path is `resolvePoolClusterIdentity`. `ClusterDaemonIdentityService` depends on `Pick<DaemonRepo, 'resolvePoolClusterIdentity'>` — exactly that one member — so it could not reach this method even by accident.

## What is removed

- `PgDaemonRepo.resolveClusterIdentity` and its `DaemonRepo` port declaration.
- `adoptForIdentity`, whose only caller it was.
- The eight repository tests that were the method's last references.

## What stays

The pool-member coverage in the same test file: those tests exercise `resolvePoolClusterIdentity` and the retirement sweep, and they keep running (6 tests, all passing). Their "envelope daemon" negative controls do go — with no writer of a pod-less identity row left, that control asserted against a state the code can no longer produce. The laptop control still covers "refuses anything that is not a pool member".

`daemon_cluster_identity_envelope_key`, the partial unique index over `clusterIdentity WHERE clusterPodUid IS NULL`, is left alone. Dropping it is a migration and belongs in its own change.

## Checks

`pnpm typecheck`, `pnpm lint`, and `pnpm format:check` are clean. Control-plane `test:unit` passes (1737 tests). The touched integration file passes, as do the neighbouring daemon-auth suites — `auth.handler`, `observer-register.handler`, and `daemons.route` (65 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
