### PR TITLE
docs(relay): point the Slack module's comments at their post-move paths

### DIFF
--- a/packages/relay/src/platforms/slack/http-ingest.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.ts
@@ -2,7 +2,7 @@
  * `SlackHttpIngest` (shared-bot-relay.md §12) — per-HTTP-bot inbound handler,
  * held by the relay. Inbound no longer rides a Socket Mode websocket: the relay
  * exposes ONE shared HTTP Events API surface (`/slack/events` + `/slack/interactions`,
- * see `slack-http-ingress.ts`) behind the pool's stable public URL, and after the
+ * see `http-ingress.ts`) behind the pool's stable public URL, and after the
  * POST is demuxed to a bot + its signing secret verified, the route calls
  * {@link SlackHttpIngest.handleEvent} / {@link SlackHttpIngest.handleInteraction}.
  * There is no MANUAL-ack seam anymore: Slack's HTTP 200 IS the ack. We answer 200

--- a/packages/relay/src/platforms/slack/ingress-plugin.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.ts
@@ -12,11 +12,11 @@
  *    table);
  *  - the verify/handle pair, delegating to the SAME primitives the manager's
  *    `resolveVerified` ladder uses today (`verifySlackSignature`, the ingest's
- *    `handleEvent`/`handleInteraction`), so the staged route adoption (the
- *    file-move PR) cannot diverge from the live path.
+ *    `handleEvent`/`handleInteraction`), so the staged route adoption cannot
+ *    diverge from the live path.
  *
- * The ingest CLASS stays in `slack-http-ingest.ts` for this PR — contract
- * adoption and file moves are separate steps, per the S2/S3 sequencing.
+ * The module's other halves sit beside this file: the ingest class in
+ * `http-ingest.ts`, the shared HTTP Events API routes in `http-ingress.ts`.
  */
 import { createHash } from 'node:crypto'
 import type { RdMsgPlatformAction } from '@agentconnect.md/protocol'


### PR DESCRIPTION
The Slack HTTP ingest and ingress routes moved into the platform module in ce6c623f8:

```
packages/relay/src/slack-http-ingest.ts  -> packages/relay/src/platforms/slack/http-ingest.ts
packages/relay/src/slack-http-ingress.ts -> packages/relay/src/platforms/slack/http-ingress.ts
```

#1105 fixed the design docs that still named the pre-move paths; two comments inside the module itself still did too.

**`http-ingest.ts`** — its header sent the reader to `slack-http-ingress.ts` for the shared route surface. That file is now `http-ingress.ts`, its sibling in the same directory.

**`ingress-plugin.ts`** — its header closed with "The ingest CLASS stays in `slack-http-ingest.ts` for this PR — contract adoption and file moves are separate steps, per the S2/S3 sequencing". Both steps have since landed, so the sentence named a dead path *and* described the move as still pending. It now says where the module's other two halves are. The bullet above it drops its "(the file-move PR)" parenthetical for the same reason, which leaves the wording the Feishu plugin's header already carries.

Comment text only — no behavior change. The `slack-http-ingest(...)` prefixes in that file's warn lines are deliberately left alone: they are runtime log identifiers rather than path references, and renaming them would change what the relay writes to its logs.

`pnpm format:check` passes; `grep` for either pre-move name now returns only those log labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
