### PR TITLE
chore(control-plane): drop the dead cluster-identity daemon reads

### DIFF
--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -191,11 +191,6 @@ export interface DaemonRepo {
   provision(daemonId: DaemonId, orgId: OrgId, createdByUserId?: string): Promise<DaemonRecord>
   /** Resolve one install-wide pool member by its reviewed ServiceAccount subject and Pod UID. */
   resolvePoolClusterIdentity(clusterIdentity: string, clusterPodUid: string): Promise<DaemonRecord>
-  /** The Kubernetes identity a daemon record is bound to, or null for an unknown/key daemon. */
-  findClusterIdentity(daemonId: DaemonId): Promise<{ orgId: string | null; clusterIdentity: string } | null>
-  /** Ids of the org's daemons bound to a Kubernetes identity — the ones the control
-   *  plane provisioned for a cluster envelope rather than a human attaching a machine. */
-  clusterBoundIds(orgId: OrgId): Promise<string[]>
   /**
    * Idempotent on `daemonId`. Bumps `sessionEpoch` (the fencing root) in ONE
    * transaction and sets status `authenticating`. Returns the new strictly-

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -123,22 +123,6 @@ export class PgDaemonRepo implements DaemonRepo {
     }
   }
 
-  async findClusterIdentity(daemonId: DaemonId): Promise<{ orgId: string | null; clusterIdentity: string } | null> {
-    const row = await this.db.daemon.findUnique({
-      where: { id: daemonId },
-      select: { orgId: true, clusterIdentity: true }
-    })
-    return row?.clusterIdentity ? { orgId: row.orgId, clusterIdentity: row.clusterIdentity } : null
-  }
-
-  async clusterBoundIds(orgId: OrgId): Promise<string[]> {
-    const rows = await this.db.daemon.findMany({
-      where: { orgId, clusterIdentity: { not: null } },
-      select: { id: true }
-    })
-    return rows.map((row) => row.id)
-  }
-
   async upsertOnAuth(input: AuthReqInput): Promise<{ daemon: DaemonRecord; sessionEpoch: bigint }> {
     return withAmbientTx(this.db, async (tx) => {
       const daemon = await tx.daemon.upsert({


### PR DESCRIPTION
`DaemonRepo.findClusterIdentity` and `DaemonRepo.clusterBoundIds` are the last two reads left over from the per-org execution envelope. #964 deleted the model they served, #1086 dropped its tables, and #1106 removed the resolver and the `adoptForIdentity` helper next to them; these two were deliberately left out of that change to keep it scoped.

## Why they are dead

Both are dead by grep: across every package neither name appears anywhere but its own definition in `daemon.repo.ts` and its declaration in `ports.ts` — no caller, no test, not even a fake. `PgDaemonRepo` remains the only `implements DaemonRepo` in the tree, so each port declaration has exactly one implementer to remove it from.

`clusterBoundIds` in particular could not have had a live caller even if something wanted one. It selects an org-scoped row carrying a `clusterIdentity`, and the only writer of that column is `resolvePoolClusterIdentity`, which always writes `orgId: null` together with a Pod UID — so the query's own predicate matches nothing the code can produce. Its doc comment said as much: it described the rows as "the ones the control plane provisioned for a cluster envelope".

## Not in this change

`daemon_cluster_identity_envelope_key`, the partial unique index over `clusterIdentity WHERE clusterPodUid IS NULL`, is untouched here. Dropping it is a migration and gets its own PR.

## Verification

`pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, and the full control-plane suite (`test:unit` + `test:int`, 93 files / 1381 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
