### PR TITLE
chore(control-plane): drop the pod-less cluster-identity unique index

### DIFF
--- a/packages/control-plane/prisma/migrations/20260827000000_drop_pod_less_cluster_identity_index/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260827000000_drop_pod_less_cluster_identity_index/migration.sql
@@ -1,0 +1,19 @@
+-- `daemon_cluster_identity_envelope_key` kept the per-org execution envelope's rows
+-- one-to-one by ServiceAccount subject: a `clusterIdentity` with no `clusterPodUid`.
+-- #964 deleted the envelope, #1086 dropped its tables, and #1106 and #1108 removed
+-- the last repository reads of that shape.
+--
+-- Nothing can write the shape any more. `ClusterDaemonIdentityService.verify` refuses
+-- a token TokenReview reports without a Pod UID, and the column's sole writer,
+-- `PgDaemonRepo.resolvePoolClusterIdentity`, always writes the subject and the
+-- reviewed Pod UID together. The index's predicate therefore matches no row the
+-- control plane can create, and `daemon_cluster_identity_pod_key` is the whole of the
+-- uniqueness pool members actually rely on.
+--
+-- It is also the one index on this table with no counterpart in schema.prisma, which
+-- cannot express a partial unique index; it has only ever existed in migration SQL.
+--
+-- FORWARD-ONLY, but cheap to be wrong about: this drops a constraint rather than data,
+-- so a binary from before it keeps working against the migrated database — it simply
+-- cannot produce the rows the index used to reject.
+DROP INDEX IF EXISTS "daemon_cluster_identity_envelope_key";

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -373,8 +373,7 @@ model Daemon {
   agentVersion  String?
   machineId     String? @db.Uuid // 🅼 AuthReq.machineId (stored, stub-enforced)
   tokenFp       String? // `id` of the authenticating ApiKey (audit; written by upsertOnAuth)
-  /// The Kubernetes ServiceAccount subject TokenReview reports. Envelope rows are unique by
-  /// subject; pool members share the subject and are unique by the bound token's Pod UID.
+  /// The Kubernetes ServiceAccount subject TokenReview reports; pool members share it and are unique by the reviewed Pod UID.
   clusterIdentity String?
   clusterPodUid   String?
   attestationFp String? // 🅼 last accepted attestation digest


### PR DESCRIPTION
The migration deferred by #1106 and #1108. Independent of both — it touches only `prisma/`, so it can merge in either order.

`daemon_cluster_identity_envelope_key` is a partial unique index over `daemon("clusterIdentity") WHERE "clusterIdentity" IS NOT NULL AND "clusterPodUid" IS NULL` — the per-org execution envelope's rule that one ServiceAccount subject means one daemon row. #964 deleted the envelope, #1086 dropped its tables, and #1106 and #1108 removed the last repository reads of that shape. The index outlived all of it.

## Why nothing can write the shape it constrains

Two facts, and the predicate is unreachable:

- `ClusterDaemonIdentityService.verify` returns `null` when TokenReview reports no Pod UID, so an identity that reaches the database always carries one.
- The column's sole writer, `PgDaemonRepo.resolvePoolClusterIdentity`, always writes the subject and the reviewed Pod UID in the same statement.

`daemon_cluster_identity_pod_key` — the one actually declared in `schema.prisma` — is the whole of the uniqueness pool members rely on, and it is untouched. The dropped index is the only index on this table with no counterpart in the schema, because Prisma cannot express a partial unique index; it has only ever existed in migration SQL.

The stale `///` doc comment on `clusterIdentity` goes with it. It still read "Envelope rows are unique by subject", a sentence about the deleted model, and now says only what remains true of pool members.

## Verification

Applied every migration twice against a real Postgres:

| | indexes on `daemon` mentioning `clusterIdentity` |
| --- | --- |
| this branch | `daemon_cluster_identity_pod_key` |
| this migration held back | `daemon_cluster_identity_envelope_key`, `daemon_cluster_identity_pod_key` |

So the drop is doing real work rather than being hidden by its own `IF EXISTS`.

`pnpm typecheck`, `pnpm lint`, `pnpm format:check`, and the control-plane suite (`test:unit` + `test:int`, 93 files / 1381 tests) all pass on the migrated schema.

Forward-only, and cheap to be wrong about: this drops a constraint rather than data, so a binary from before the migration keeps working against a migrated database — it simply cannot produce the rows the index used to reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
