### PR TITLE
fix(daemon): treat a raced-away memory path as absent, not ENOENT

### DIFF
--- a/packages/daemon/src/agents/memory-fs.ts
+++ b/packages/daemon/src/agents/memory-fs.ts
@@ -152,7 +152,13 @@ async function walkContained(root: string, parts: string[], create: boolean): Pr
       stat = await fsp.lstat(candidate)
     }
     if (!stat.isDirectory()) throw new MemoryPathError('memory path contains a symlink or non-directory')
-    parent = await fsp.realpath(candidate)
+    try {
+      parent = await fsp.realpath(candidate)
+    } catch (err) {
+      // A concurrent rm can drop the component between lstat and realpath; absent stays data on the read side.
+      if (!isErrno(err, 'ENOENT') || create) throw err
+      return null
+    }
     if (!under(realRoot, parent)) throw new MemoryPathError('path resolves outside the memory root')
   }
   return parent


### PR DESCRIPTION
## What happened

`Test / Unit Test` failed on main with one test down in `packages/daemon/test/dream-runner.test.ts`:

```
FAIL  daemon  test/dream-runner.test.ts > DreamRunner pipeline
      > cancel-wins when it lands during staging: no completed status, staging removed

Error: ENOENT: no such file or directory, realpath '/tmp/ac-dream-.../memory-dreams/drm-.../output'
 ❯ walkContained src/agents/memory-fs.ts:155:14
 ❯ LocalMemoryFs.readdir src/agents/memory-fs.ts:289:17
 ❯ DreamRunner.stagedFiles src/agents/dream-runner.ts:1523:21
 ❯ test/dream-runner.test.ts:445:18
```

Not an assertion failure — `stagedFiles()` itself threw.

## Root cause

`walkContained()` canonicalises a path one component at a time:

```ts
stat = await fsp.lstat(candidate)      // ENOENT here → absent is data, read side returns null
...
parent = await fsp.realpath(candidate) // unguarded
```

Between those two syscalls there is a window where a concurrent `rm` can drop the component. `lstat` succeeds, `realpath` then fails with ENOENT, and the error escapes the whole read.

The dream cancel-wins path removes the staging directory (`fs.rm(join(base, 'output'))`) exactly while a reader may be listing it, so this is reachable outside the test: a review-screen read of a dream that is being canceled or discarded gets ENOENT rather than "no staging", contradicting the `Missing staging is DATA` contract on `stagedFiles`/`stagedRead`.

## Fix

Give `realpath` the same ENOENT handling `lstat` already has — absent on the read side, still an error when creating. Every read-side caller (`readFile`, `readdir`, `rename`, `rm`, `utimes`, `readContainedMemoryFile`) already maps `null` to "not there", so the semantics are unchanged apart from no longer throwing.

## On reproduction and coverage

The trigger is probabilistic, the mechanism is not. The failure needs the concurrent `rm` to complete entirely between two adjacent syscalls, which needs the scheduler to preempt the reader in that window — it did on a loaded runner, and did not in 25 local runs of the file or in a 400-round targeted race harness against the unfixed code.

No new test: the window cannot be constructed deterministically at this layer. An existing directory that passes `lstat().isDirectory()` always resolves under `realpath` unless something removes it concurrently, so a regression test would have to inject a fault into `node:fs/promises`. The existing `cancel-wins when it lands during staging` test is the coverage — it is the one that caught this.

## Verification

- `memory-*` and `dream-*` daemon unit files: 196 passed, 1 skipped
- `typecheck` and prettier clean
