### PR TITLE
fix(web): improve mobile chat readability

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -2439,6 +2439,19 @@
     padding: 0;
     font-size: inherit;
   }
+  @media (max-width: 768px) {
+    /* Preserve diagrams and command output on narrow screens. Wrapping preformatted
+       text made columns unreadable and could still leave the right side concealed
+       beneath the sticky composer; a contained horizontal scroller keeps the chat
+       column fixed while letting the reader inspect the original layout. */
+    .mdtxt pre {
+      overflow-x: auto;
+      overflow-y: hidden;
+      white-space: pre;
+      overflow-wrap: normal;
+      word-break: normal;
+    }
+  }
   .mdtxt a {
     color: var(--text-link);
     text-decoration: none;

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -146,11 +146,11 @@ type ComposerMenuKey = 'permission' | 'model' | 'effort' | 'addAgent'
 // strength fails contrast on the light surface.
 // SELF_BUBBLE is the reader's own, deliberately neutral, tail corner mirrored.
 // Full literal strings so Tailwind's scanner sees them (STYLE.md §8).
-// The 35px right inset is the user side's mark column (26px avatar + 9px gap): it
-// stops a long agent bubble short of where the reader's own avatar sits, so the two
-// columns of bubbles share one right edge instead of the bot side running under it.
+// Desktop reserves the user-side mark column (26px avatar + 9px gap) so both bubble
+// columns share one right edge. Mobile removes that redundant reserve and trims the
+// bubble padding while preserving the same multi-agent avatar and colour language.
 const AGENT_BUBBLE =
-  'w-fit max-w-[calc(100%-35px)] rounded-[12px_12px_12px_4px] border px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary) border-[color:color-mix(in_oklab,var(--agent-accent,var(--indigo-500))_var(--bubble-edge),var(--surface-card))] bg-[color:color-mix(in_oklab,var(--agent-accent,var(--indigo-500))_var(--bubble-tint),var(--surface-card))]'
+  'w-fit max-w-full rounded-[12px_12px_12px_4px] border px-2.5 py-2 font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary) desktop:max-w-[calc(100%-35px)] desktop:px-3 desktop:py-[9px] border-[color:color-mix(in_oklab,var(--agent-accent,var(--indigo-500))_var(--bubble-edge),var(--surface-card))] bg-[color:color-mix(in_oklab,var(--agent-accent,var(--indigo-500))_var(--bubble-tint),var(--surface-card))]'
 const AGENT_NAME =
   'font-sans text-[13px] font-semibold leading-normal text-[color:color-mix(in_oklab,var(--agent-accent,var(--indigo-500))_62%,var(--text-primary))]'
 const SELF_BUBBLE =
@@ -4010,9 +4010,9 @@ export default function SessionDetailView() {
           last child is the sticky composer, and a bottom gutter under it is a strip
           the composer stops short of. (Longhand `pb-*` always sorts after shorthand
           `p-*`, so the cancel wins — STYLE.md §8.) */}
-          <div className="flex flex-1 flex-col gap-4 p-4 max-desktop:pb-0 desktop:gap-0 desktop:p-0">
+          <div className="flex flex-1 flex-col gap-4 p-3 max-desktop:pb-0 desktop:gap-0 desktop:p-0">
             {turns.length > 0 && (
-              <div className="flex flex-col gap-4 desktop:gap-[15px]">
+              <div className="flex flex-col gap-4 max-desktop:pb-3 desktop:gap-[15px]">
                 {turns.map((turn, ti) => (
                   // The turn's clock time is its own centred line above the message —
                   // a shared separator for both sides, instead of a label-row tail
@@ -4146,7 +4146,10 @@ export default function SessionDetailView() {
                           .filter(Boolean)
                           .join('\n\n')
                         return (
-                          <div key={`${session.id}:${ti}`} className="group/turn flex items-start gap-[10px]">
+                          <div
+                            key={`${session.id}:${ti}`}
+                            className="group/turn flex items-start gap-2 desktop:gap-[10px]"
+                          >
                             <span className="av h-[26px] w-[26px] flex-none rounded-md">
                               <AgentIconView
                                 icon={((turn.agentId ? agentById.get(turn.agentId) : owner) ?? owner)?.icon}
@@ -4161,11 +4164,9 @@ export default function SessionDetailView() {
                               <div className="mb-[5px] flex items-center gap-[7px]">
                                 <span className={AGENT_NAME}>{turn.agentName}</span>
                               </div>
-                              {/* One bubble PER text step, not one around the set: each step is
-                            its own delivered message (a turn that answers in two chunks
-                            arrives as two), so bubbling them together would merge messages
-                            the platform kept apart. `w-fit` keeps a short reply from
-                            drawing a full-width card. */}
+                              {/* One bubble per text step: a turn that answers in two chunks
+                            arrives as two delivered messages, so one wrapper around the set
+                            would merge messages the platform kept apart. */}
                               {textSteps.map((st, si) => (
                                 <div key={si} className={`${AGENT_BUBBLE} ${si > 0 ? 'mt-2' : ''}`}>
                                   {st.image && (


### PR DESCRIPTION
## Summary

- tighten the mobile session gutter from 16px to 12px
- reduce the mobile agent/avatar gap and bubble padding while preserving desktop spacing
- let agent bubbles use the remaining mobile row instead of reserving the reader-avatar column twice
- keep preformatted diagrams and command output intact with contained horizontal scrolling on narrow screens

## Why

Long agent responses had too little usable width on small screens. The transcript gutter, agent avatar column, bubble padding, and an additional reader-avatar reserve compounded until prose and diagrams wrapped aggressively. This keeps the existing multi-agent bubble language while reclaiming mobile reading width; desktop layout is unchanged.

## Comparison

| Before | After |
| --- | --- |
| ![Mobile chat before](https://github.com/stkevintan/agentconnect/releases/download/pr-1112-assets/mobile-chat-readability-before.jpg) | ![Mobile chat after](https://github.com/stkevintan/agentconnect/releases/download/pr-1112-assets/mobile-chat-readability-after.jpg) |

Both screenshots use a 390×844 viewport and the same mocked session and theme.

## Validation

- `prettier --check` for the changed web files
- ESLint for `SessionDetailView.tsx`
- `tsc --noEmit -p packages/web/tsconfig.json`
- 73 focused Vitest tests across `SessionDetailView.viewer` and `MessageText`
- repository pre-push `eslint .`
- manual 390×844 browser verification with no page-level horizontal overflow
