### PR TITLE
perf(daemon): batch store round trips and coalesce the streaming tool writes

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -16269,6 +16269,9 @@ export class Daemon {
       }
       // …and any trailing reasoning the agent emitted after its last reply.
       for (const ev of rec.onFinal()) this.recordEvent(agentId, transcriptChannel, statusThread, ev)
+      // The turn is over, so nothing more will supersede a coalesced tool body: make the last
+      // state of every streamed tool call durable now rather than on the buffer's own timer.
+      this.store.flushToolCallWrites()
       await p.applyChain
       // Every section has now been delivered, so the complete logical response exists and
       // exactly one of its messages can be marked final (§5.5). Must run AFTER applyChain:
@@ -23758,6 +23761,9 @@ export class Daemon {
         : this.shutdownDrainBudgetMs()
     )
     await dutyDrain
+    // Every turn has settled: land whatever a tool call was still streaming when the drain
+    // began, while the mutation listener is still there to invalidate the live views.
+    this.store.flushToolCallWrites()
     this.store.setTranscriptMutationListener()
     for (const { timer } of this.transcriptActivityTimers.values()) this.clock.clearTimeout(timer)
     this.transcriptActivityTimers.clear()

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -31,11 +31,103 @@ export interface StoreStatement {
   all(...params: unknown[]): unknown[]
 }
 
+/** One statement of a batch. `run` reports `changes`; `read` returns `rows`. */
+export interface StoreBatchStatement {
+  sql: string
+  params: unknown[]
+  kind: 'run' | 'read'
+}
+
+export interface StoreBatchResult {
+  changes: number
+  rows: unknown[]
+}
+
 export interface StoreDatabase {
   exec(sql: string): void
   prepare(sql: string): StoreStatement
+  /** Run an ordered statement list and return its results in the same order. Each statement
+   *  commits on its own, exactly as the single-statement path does. */
+  batch(statements: StoreBatchStatement[]): StoreBatchResult[]
   close(): void
 }
+
+/** The `node:sqlite` backend as a `StoreDatabase`. Its batch is a plain in-process sequence:
+ *  an embedded database has no round trip for a batch to save. */
+export function sqliteStoreDatabase(database: DatabaseSync): StoreDatabase {
+  return {
+    exec: (sql) => database.exec(sql),
+    prepare: (sql) => database.prepare(sql) as unknown as StoreStatement,
+    close: () => database.close(),
+    batch: (statements) =>
+      statements.map(({ sql, params, kind }) => {
+        const statement = database.prepare(sql)
+        const bound = params as SQLInputValue[]
+        if (kind === 'read') return { changes: 0, rows: statement.all(...bound) }
+        return { changes: Number(statement.run(...bound).changes), rows: [] }
+      })
+  }
+}
+
+/** The facade every LocalStore method uses: draining the coalescing buffer before each
+ *  statement is what makes it invisible — no read reaches the database without passing here. */
+function drainPendingWritesFirst(backend: StoreDatabase, drain: () => void): StoreDatabase {
+  return {
+    exec: (sql) => {
+      drain()
+      backend.exec(sql)
+    },
+    batch: (statements) => {
+      drain()
+      return backend.batch(statements)
+    },
+    close: () => backend.close(),
+    prepare: (sql) => {
+      const statement = backend.prepare(sql)
+      return {
+        run: (...params) => {
+          drain()
+          return statement.run(...params)
+        },
+        get: (...params) => {
+          drain()
+          return statement.get(...params)
+        },
+        all: (...params) => {
+          drain()
+          return statement.all(...params)
+        }
+      }
+    }
+  }
+}
+
+/** One coalesced streaming tool-call write, already fenced: `orgId` was resolved when the
+ *  update was enqueued, from the same agent the unbuffered write would have resolved it from. */
+interface PendingToolWrite {
+  orgId: string
+  channel: string
+  thread: string
+  agentId: string
+  toolCallId: string
+  title: string
+  body: string
+  bytes: number
+}
+
+/** The partition a coalesced write lands in — its notification and revision scope. */
+const threadKeyOf = (write: PendingToolWrite): string => [write.orgId, write.channel, write.thread].join('\0')
+
+/** How long a streaming tool-call body may sit unwritten. Short enough that a crash loses at
+ *  most this much of an in-flight tool body, long enough to swallow a chunk burst. */
+const TOOL_WRITE_FLUSH_MS = 200
+
+/** Rows the coalescing buffer may hold — one per tool call in flight — before it flushes early. */
+const MAX_PENDING_TOOL_WRITES = 64
+
+/** The bound that actually caps memory: a single body may reach 1 MiB, so counting rows alone
+ *  would let 64 of them buffer far more than this. Reaching it flushes early, same as the count. */
+const MAX_PENDING_TOOL_WRITE_BYTES = 4 * 1024 * 1024
 
 /** The daemon's agent registry, projected to the org that owns one agent. */
 export type OrgForAgent = (agentId: string) => string | undefined
@@ -766,6 +858,9 @@ const SCHEMA_MIGRATIONS: ((db: StoreDatabase, store: { shared: boolean }) => voi
 ]
 
 export class LocalStore {
+  /** The backend as given. Only the tool-write flush uses it directly; everything else goes
+   *  through `db`, which drains that buffer first. */
+  private backend: StoreDatabase
   private db: StoreDatabase
   private readonly shared: boolean
   private readonly ownerId?: string
@@ -775,6 +870,10 @@ export class LocalStore {
   private readonly orgForAgent?: OrgForAgent
   private transcriptRevision = 0
   private transcriptMutationListener?: (mutation: TranscriptMutation) => void
+  private readonly pendingToolWrites = new Map<string, PendingToolWrite>()
+  private pendingToolWriteBytes = 0
+  private toolWriteTimer?: ReturnType<typeof setTimeout>
+  private flushingToolWrites = false
 
   constructor(source: LocalStoreSource) {
     // This database holds every platform message body, agent reply, tool payload and
@@ -792,13 +891,15 @@ export class LocalStore {
       const dir = dirname(source)
       mkdirSync(dir, { recursive: true, mode: 0o700 })
       restrictPath(dir, 0o700)
-      this.db = new DatabaseSync(source) as StoreDatabase
+      this.backend = sqliteStoreDatabase(new DatabaseSync(source))
+      this.db = drainPendingWritesFirst(this.backend, () => this.flushToolCallWrites())
       this.db.exec('PRAGMA journal_mode = WAL')
       // WAL mode publishes two siblings alongside the database; they carry the same
       // rows, so restricting only the main file would leave the content readable.
       for (const p of [source, `${source}-wal`, `${source}-shm`]) restrictPath(p, 0o600)
     } else {
-      this.db = source.database
+      this.backend = source.database
+      this.db = drainPendingWritesFirst(this.backend, () => this.flushToolCallWrites())
       this.shared = source.shared === true
       this.ownerId = source.ownerId
       this.orgForAgent = source.orgForAgent
@@ -3171,39 +3272,61 @@ export class LocalStore {
     const { attachments, trustedAgentBot, quoted, quoteJson, authoritative, orgAgentId, ...entry } = e
     const durableQuoteJson = quoted?.text ? JSON.stringify(quoted) : (quoteJson ?? null)
     const orgId = this.transcriptOrg(e.channel, e.thread, e.recipient, e.sender, orgAgentId)
-    const revision = this.transcriptRevision + 1
-    const inserted = this.db
-      .prepare(
-        `INSERT OR IGNORE INTO transcript
+    // The row, its delivery record, and the thread revision the caller needs next, in one
+    // round trip. `transcript_recipient` is a different table, so its insert moving ahead of
+    // the in-place upgrades below changes nothing either statement can observe.
+    const recordsDelivery = !!e.recipient && !!e.ts
+    const { changes, revision } = this.writeTranscriptRows(orgId, e.channel, e.thread, [
+      {
+        kind: 'run',
+        sql: `INSERT OR IGNORE INTO transcript
            (orgId, channel, thread, ts, sender, kind, text, recipient, eventTimeUs, attachmentsJson, quoteJson, trustedAgentBot, revision, postId)
          VALUES
-           (@orgId, @channel, @thread, @ts, @sender, @kind, @text, @recipient, @eventTimeUs, @attachmentsJson, @quoteJson, @trustedAgentBot, @revision, @postId)`
-      )
-      .run({
-        ...entry,
-        orgId,
-        recipient: e.recipient ?? null,
-        postId: e.postId ?? null,
-        eventTimeUs: e.eventTimeUs ?? transcriptEventTimeUs(e.ts),
-        attachmentsJson: attachments?.length ? JSON.stringify(attachments) : null,
-        quoteJson: durableQuoteJson,
-        trustedAgentBot: trustedAgentBot ? 1 : null,
-        revision
-      } as unknown as SqlParams)
-    if (Number(inserted.changes) === 1) this.transcriptRevision = this.threadRevisionInOrg(orgId, e.channel, e.thread)
+           (@orgId, @channel, @thread, @ts, @sender, @kind, @text, @recipient, @eventTimeUs, @attachmentsJson, @quoteJson, @trustedAgentBot, @revision, @postId)`,
+        params: [
+          {
+            ...entry,
+            orgId,
+            recipient: e.recipient ?? null,
+            postId: e.postId ?? null,
+            eventTimeUs: e.eventTimeUs ?? transcriptEventTimeUs(e.ts),
+            attachmentsJson: attachments?.length ? JSON.stringify(attachments) : null,
+            quoteJson: durableQuoteJson,
+            trustedAgentBot: trustedAgentBot ? 1 : null,
+            revision: this.transcriptRevision + 1
+          } as unknown as SqlParams
+        ]
+      },
+      // Recorded separately so it survives the text-row dedup above: if this same
+      // (channel, thread, ts) was already recorded by another agent, the INSERT OR IGNORE
+      // dropped this row and its `recipient`, but the message WAS delivered to this agent too.
+      ...(recordsDelivery
+        ? [
+            {
+              kind: 'run' as const,
+              sql: 'INSERT OR IGNORE INTO transcript_recipient (orgId, channel, thread, ts, agentId) VALUES (?, ?, ?, ?, ?)',
+              params: [orgId, e.channel, e.thread, e.ts, e.recipient]
+            }
+          ]
+        : [])
+    ])
+    const inserted = changes[0] ?? 0
+    const delivered = recordsDelivery ? (changes[1] ?? 0) : 0
+    if (inserted === 1) this.transcriptRevision = revision
     // The closing edit of a streamed reply lands on the row its own post created, so the
     // text is refreshed in place rather than lost to INSERT OR IGNORE. Scoped to text
     // rows on identical coordinates, and only ever toward the authoritative version.
-    if (Number(inserted.changes) === 0 && authoritative && e.kind === 'text') {
-      const rev = this.transcriptRevision + 1
-      const refreshed = this.db
-        .prepare(
-          `UPDATE transcript SET text = ?, revision = ?
-           WHERE orgId = ? AND channel = ? AND thread = ? AND ts = ? AND kind = 'text' AND text IS NOT ?`
-        )
-        .run(e.text, rev, orgId, e.channel, e.thread, e.ts, e.text)
-      if (Number(refreshed.changes) === 1) {
-        this.transcriptRevision = this.threadRevisionInOrg(orgId, e.channel, e.thread)
+    if (inserted === 0 && authoritative && e.kind === 'text') {
+      const refreshed = this.writeTranscriptRows(orgId, e.channel, e.thread, [
+        {
+          kind: 'run',
+          sql: `UPDATE transcript SET text = ?, revision = ?
+           WHERE orgId = ? AND channel = ? AND thread = ? AND ts = ? AND kind = 'text' AND text IS NOT ?`,
+          params: [e.text, this.transcriptRevision + 1, orgId, e.channel, e.thread, e.ts, e.text]
+        }
+      ])
+      if (refreshed.changes[0] === 1) {
+        this.transcriptRevision = refreshed.revision
         this.notifyTranscriptMutation(e.channel, e.thread, e.recipient ? [e.recipient] : [], this.transcriptRevision)
       }
     }
@@ -3211,7 +3334,7 @@ export class LocalStore {
     // snapshot. Upgrade only toward trusted=true; an untrusted replay can never clear or
     // manufacture provenance, and the stable text-row coordinates keep this scoped.
     const provenanceUpgraded =
-      Number(inserted.changes) === 0 && trustedAgentBot
+      inserted === 0 && trustedAgentBot
         ? this.db
             .prepare(
               `UPDATE transcript SET trustedAgentBot = 1
@@ -3224,7 +3347,7 @@ export class LocalStore {
     // postId column value) and re-observed by a copy that carries it. Upgrade in
     // place; an identity can be added but never changed or cleared.
     const postIdUpgraded =
-      Number(inserted.changes) === 0 && e.postId
+      inserted === 0 && e.postId
         ? this.db
             .prepare(
               `UPDATE transcript SET postId = ?
@@ -3236,7 +3359,7 @@ export class LocalStore {
     // provider send time (an early observer wrote the row with the derived
     // axis). Explicit values only — two derived computations must never flap.
     const eventTimeUpgraded =
-      Number(inserted.changes) === 0 && e.eventTimeUs
+      inserted === 0 && e.eventTimeUs
         ? this.db
             .prepare(
               `UPDATE transcript SET eventTimeUs = ?
@@ -3249,7 +3372,7 @@ export class LocalStore {
     // place instead of leaving attachmentsJson pinned to NULL (the console would then
     // show only the `[attached: …]` label).
     const attachmentsUpgraded =
-      Number(inserted.changes) === 0 && attachments?.length
+      inserted === 0 && attachments?.length
         ? this.db
             .prepare(
               `UPDATE transcript SET attachmentsJson = ?
@@ -3261,7 +3384,7 @@ export class LocalStore {
     // (or a corrected selected passage). Upgrade it without ever clearing a quote when
     // a provider snapshot subsequently re-appends the same text row without metadata.
     const quoteUpgraded =
-      Number(inserted.changes) === 0 && durableQuoteJson !== null
+      inserted === 0 && durableQuoteJson !== null
         ? this.db
             .prepare(
               `UPDATE transcript SET quoteJson = ?
@@ -3270,19 +3393,7 @@ export class LocalStore {
             )
             .run(durableQuoteJson, orgId, e.channel, e.thread, e.ts, durableQuoteJson)
         : undefined
-    // Record the delivery separately so it survives the text-row dedup above: if this same
-    // (channel, thread, ts) was already recorded by another agent, the INSERT OR IGNORE
-    // dropped this row and its `recipient`, but the message WAS delivered to this agent too.
-    const delivered =
-      e.recipient && e.ts
-        ? this.db
-            .prepare(
-              'INSERT OR IGNORE INTO transcript_recipient (orgId, channel, thread, ts, agentId) VALUES (?, ?, ?, ?, ?)'
-            )
-            .run(orgId, e.channel, e.thread, e.ts, e.recipient)
-        : undefined
-
-    if (Number(inserted.changes) === 1) {
+    if (inserted === 1) {
       this.notifyTranscriptMutation(e.channel, e.thread, [e.sender, e.recipient], this.transcriptRevision)
     } else if (
       Number(provenanceUpgraded?.changes ?? 0) === 1 ||
@@ -3290,24 +3401,31 @@ export class LocalStore {
       Number(quoteUpgraded?.changes ?? 0) === 1 ||
       Number(postIdUpgraded?.changes ?? 0) === 1 ||
       Number(eventTimeUpgraded?.changes ?? 0) === 1 ||
-      Number(delivered?.changes ?? 0) === 1
+      delivered === 1
     ) {
-      const deliveryRevision = this.transcriptRevision + 1
-      this.db
-        .prepare(
-          "UPDATE transcript SET revision = ? WHERE orgId = ? AND channel = ? AND thread = ? AND ts = ? AND kind = 'text'"
-        )
-        .run(deliveryRevision, orgId, e.channel, e.thread, e.ts)
-      this.transcriptRevision = this.threadRevisionInOrg(orgId, e.channel, e.thread)
       // An in-place upgrade mutates the SHARED row: every agent whose scoped
       // view already contains it must be invalidated, not just this append's
       // sender/recipient — a co-hosted participant delivered earlier would
       // otherwise keep serving the stale copy until an unrelated mutation.
-      const sharedRecipients = (
-        this.db
-          .prepare('SELECT agentId FROM transcript_recipient WHERE orgId = ? AND channel = ? AND thread = ? AND ts = ?')
-          .all(orgId, e.channel, e.thread, e.ts) as { agentId: string }[]
-      ).map((r) => r.agentId)
+      const bumped = this.db.batch([
+        {
+          kind: 'run',
+          sql: "UPDATE transcript SET revision = ? WHERE orgId = ? AND channel = ? AND thread = ? AND ts = ? AND kind = 'text'",
+          params: [this.transcriptRevision + 1, orgId, e.channel, e.thread, e.ts]
+        },
+        {
+          kind: 'read',
+          sql: 'SELECT COALESCE(MAX(revision), 0) AS revision FROM transcript WHERE orgId = ? AND channel = ? AND thread = ?',
+          params: [orgId, e.channel, e.thread]
+        },
+        {
+          kind: 'read',
+          sql: 'SELECT agentId FROM transcript_recipient WHERE orgId = ? AND channel = ? AND thread = ? AND ts = ?',
+          params: [orgId, e.channel, e.thread, e.ts]
+        }
+      ])
+      this.transcriptRevision = Number((bumped[1]?.rows[0] as { revision: number } | undefined)?.revision ?? 0)
+      const sharedRecipients = (bumped[2]?.rows as { agentId: string }[]).map((r) => r.agentId)
       this.notifyTranscriptMutation(
         e.channel,
         e.thread,
@@ -3331,33 +3449,40 @@ export class LocalStore {
     body: string
   }): void {
     const orgId = this.orgFor(e.sender)
-    const revision = this.transcriptRevision + 1
-    const inserted = this.db
-      .prepare(
-        `INSERT OR IGNORE INTO transcript
+    const { changes, revision } = this.writeTranscriptRows(orgId, e.channel, e.thread, [
+      {
+        kind: 'run',
+        sql: `INSERT OR IGNORE INTO transcript
            (orgId, channel, thread, ts, sender, kind, text, tool_call_id, body, eventTimeUs, revision)
-         VALUES (@orgId, @channel, @thread, @ts, @sender, 'tool', @text, @toolCallId, @body, @eventTimeUs, @revision)`
-      )
-      .run({
-        orgId,
-        channel: e.channel,
-        thread: e.thread,
-        ts: e.ts,
-        sender: e.sender,
-        text: e.title,
-        toolCallId: e.toolCallId,
-        body: e.body,
-        eventTimeUs: transcriptEventTimeUs(e.ts),
-        revision
-      })
-    if (Number(inserted.changes) === 1) {
-      this.transcriptRevision = this.threadRevisionInOrg(orgId, e.channel, e.thread)
+         VALUES (@orgId, @channel, @thread, @ts, @sender, 'tool', @text, @toolCallId, @body, @eventTimeUs, @revision)`,
+        params: [
+          {
+            orgId,
+            channel: e.channel,
+            thread: e.thread,
+            ts: e.ts,
+            sender: e.sender,
+            text: e.title,
+            toolCallId: e.toolCallId,
+            body: e.body,
+            eventTimeUs: transcriptEventTimeUs(e.ts),
+            revision: this.transcriptRevision + 1
+          }
+        ]
+      }
+    ])
+    if (changes[0] === 1) {
+      this.transcriptRevision = revision
       this.notifyTranscriptMutation(e.channel, e.thread, [e.sender], this.transcriptRevision)
     }
   }
 
-  /** Later update for one agent's tool call. `seq`/`ts` keep their first-seen
-   *  values; a peer reusing the same session-local tool id cannot overwrite it. */
+  /** Later update for one agent's tool call. `seq`/`ts` keep their first-seen values; a peer
+   *  reusing the same session-local tool id cannot overwrite it. The store's highest-frequency
+   *  writer, and every write is a full latest-wins overlay of the merged ToolBody rather than an
+   *  append — so the burst is coalesced per row, and writing only its last state leaves exactly
+   *  the row the per-chunk path left. Flushed before any other statement, on
+   *  {@link TOOL_WRITE_FLUSH_MS}, at either buffer bound, at turn end, and on drain. */
   updateToolCall(
     channel: string,
     thread: string,
@@ -3365,18 +3490,135 @@ export class LocalStore {
     toolCallId: string,
     patch: { title: string; body: string }
   ): void {
+    // Resolved here, not at flush time: the org fence must reject an unattributable agent at
+    // the same call, with the same inputs, as the per-chunk write it replaces.
     const orgId = this.orgFor(agentId)
-    const revision = this.transcriptRevision + 1
-    const updated = this.db
-      .prepare(
-        `UPDATE transcript SET text = ?, body = ?, revision = ?
+    const key = [orgId, channel, thread, agentId, toolCallId].join('\0')
+    this.pendingToolWriteBytes -= this.pendingToolWrites.get(key)?.bytes ?? 0
+    const bytes = patch.title.length + patch.body.length
+    this.pendingToolWrites.set(key, { orgId, channel, thread, agentId, toolCallId, bytes, ...patch })
+    this.pendingToolWriteBytes += bytes
+    if (this.pendingToolWrites.size >= MAX_PENDING_TOOL_WRITES) this.flushToolCallWrites()
+    else if (this.pendingToolWriteBytes >= MAX_PENDING_TOOL_WRITE_BYTES) this.flushToolCallWrites()
+    else this.armToolWriteFlush()
+  }
+
+  /** Write every buffered streaming tool-call update, plus the post-write revision of each
+   *  thread they touched, in one round trip — so buffered content is durable before a shutdown
+   *  and never outlives the turn that produced it. Entries survive a failed flush, and the timer
+   *  is re-armed, so a retry re-applies them. */
+  flushToolCallWrites(): void {
+    if (this.flushingToolWrites || this.pendingToolWrites.size === 0) return
+    this.clearToolWriteFlush()
+    const pending = [...this.pendingToolWrites.values()]
+    // Distinct threads in write order, so each one's revision read rides the same round trip.
+    const threads = new Map<string, PendingToolWrite>()
+    for (const write of pending) threads.set(threadKeyOf(write), write)
+    const threadList = [...threads.values()]
+    this.flushingToolWrites = true
+    let results: StoreBatchResult[]
+    try {
+      results = this.backend.batch([
+        ...pending.map((write, index) => ({
+          kind: 'run' as const,
+          sql: `UPDATE transcript SET text = ?, body = ?, revision = ?
          WHERE orgId = ? AND channel = ? AND thread = ? AND sender = ? AND tool_call_id = ?
-           AND (text IS NOT ? OR body IS NOT ?)`
-      )
-      .run(patch.title, patch.body, revision, orgId, channel, thread, agentId, toolCallId, patch.title, patch.body)
-    if (Number(updated.changes) === 1) {
-      this.transcriptRevision = this.threadRevisionInOrg(orgId, channel, thread)
-      this.notifyTranscriptMutation(channel, thread, [agentId], this.transcriptRevision)
+           AND (text IS NOT ? OR body IS NOT ?)`,
+          params: [
+            write.title,
+            write.body,
+            this.transcriptRevision + index + 1,
+            write.orgId,
+            write.channel,
+            write.thread,
+            write.agentId,
+            write.toolCallId,
+            write.title,
+            write.body
+          ]
+        })),
+        ...threadList.map((write) => ({
+          kind: 'read' as const,
+          sql: 'SELECT COALESCE(MAX(revision), 0) AS revision FROM transcript WHERE orgId = ? AND channel = ? AND thread = ?',
+          params: [write.orgId, write.channel, write.thread]
+        }))
+      ])
+    } catch (error) {
+      // Nothing is dropped: the entries stay buffered and the timer comes back, so a store that
+      // goes quiet after the failure still lands them instead of holding them until the next call.
+      this.armToolWriteFlush()
+      throw error
+    } finally {
+      this.flushingToolWrites = false
+    }
+    this.pendingToolWrites.clear()
+    this.pendingToolWriteBytes = 0
+    const revisions = new Map<string, number>()
+    for (const [index, write] of threadList.entries()) {
+      const row = results[pending.length + index]?.rows[0] as { revision: number } | undefined
+      revisions.set(threadKeyOf(write), Number(row?.revision ?? 0))
+    }
+    // The allocator spans every partition, so it takes the highest revision any thread now
+    // carries — a thread whose write was a no-op must never pull it back below one already issued.
+    this.transcriptRevision = Math.max(this.transcriptRevision, ...revisions.values())
+    // One notification per thread that actually changed, carrying that thread's own revision —
+    // the per-chunk path emitted one per write, and every intermediate one is now superseded.
+    const changed = new Map<string, string[]>()
+    for (const [index, write] of pending.entries()) {
+      if (Number(results[index]?.changes ?? 0) !== 1) continue
+      const key = threadKeyOf(write)
+      const agentIds = changed.get(key)
+      if (agentIds) agentIds.push(write.agentId)
+      else changed.set(key, [write.agentId])
+    }
+    for (const write of threadList) {
+      const key = threadKeyOf(write)
+      const agentIds = changed.get(key)
+      if (agentIds) this.notifyTranscriptMutation(write.channel, write.thread, agentIds, revisions.get(key) ?? 0)
+    }
+  }
+
+  private armToolWriteFlush(): void {
+    if (this.toolWriteTimer || this.pendingToolWrites.size === 0) return
+    this.toolWriteTimer = setTimeout(() => {
+      this.toolWriteTimer = undefined
+      // The backend reported this through its own failure channel and the entries are still
+      // buffered; an idempotent latest-wins overlay is always safe to re-apply.
+      try {
+        this.flushToolCallWrites()
+      } catch {
+        this.armToolWriteFlush()
+      }
+    }, TOOL_WRITE_FLUSH_MS)
+    this.toolWriteTimer.unref?.()
+  }
+
+  private clearToolWriteFlush(): void {
+    if (!this.toolWriteTimer) return
+    clearTimeout(this.toolWriteTimer)
+    this.toolWriteTimer = undefined
+  }
+
+  /** One round trip for a transcript mutation plus the thread revision the caller needs next.
+   *  Each statement still commits on its own, so a failure leaves what the same sequence of
+   *  single-statement calls would have left. */
+  private writeTranscriptRows(
+    orgId: string,
+    channel: string,
+    thread: string,
+    statements: StoreBatchStatement[]
+  ): { changes: number[]; revision: number } {
+    const results = this.db.batch([
+      ...statements,
+      {
+        kind: 'read',
+        sql: 'SELECT COALESCE(MAX(revision), 0) AS revision FROM transcript WHERE orgId = ? AND channel = ? AND thread = ?',
+        params: [orgId, channel, thread]
+      }
+    ])
+    return {
+      changes: results.slice(0, -1).map((result) => Number(result.changes)),
+      revision: Number((results.at(-1)?.rows[0] as { revision: number } | undefined)?.revision ?? 0)
     }
   }
 
@@ -5114,6 +5356,9 @@ export class LocalStore {
   }
 
   close(): void {
+    // Last chance for a buffered tool body: the backend is about to go away.
+    this.flushToolCallWrites()
+    this.clearToolWriteFlush()
     this.db.close()
   }
 }

--- a/packages/daemon/src/store/postgres-config.ts
+++ b/packages/daemon/src/store/postgres-config.ts
@@ -20,6 +20,8 @@ export const DataPlaneConfigSchema = z
   .object({
     version: z.literal(1),
     databaseUrl: PostgresUrl,
+    // Sizes the migration pool only. Runtime traffic goes through one worker-thread client, so
+    // this is not a concurrency knob and raising it buys the store no parallelism.
     maxConnections: z.number().int().min(1).max(32).default(4)
   })
   .strict()

--- a/packages/daemon/src/store/postgres-store-worker.js
+++ b/packages/daemon/src/store/postgres-store-worker.js
@@ -69,6 +69,25 @@ async function execute(message) {
     await client.end()
     return
   }
+  // One hand-off, N statements, each still on its own commit: a failure names its statement and
+  // abandons the rest, leaving what the same statements run as separate calls would have left.
+  if (message.kind === 'batch') {
+    const statements = message.statements ?? []
+    const results = []
+    for (let index = 0; index < statements.length; index++) {
+      try {
+        results.push((await runStatement(statements[index])) ?? { rows: [], changes: 0 })
+      } catch (error) {
+        const detail = error instanceof Error && error.stack ? error.stack : String(error)
+        throw new Error(`batch statement ${index + 1} of ${statements.length} failed: ${detail}`)
+      }
+    }
+    return results
+  }
+  return runStatement(message)
+}
+
+async function runStatement(message) {
   if (/^\s*PRAGMA\s+journal_mode/i.test(message.sql)) return
   const setVersion = /^\s*PRAGMA\s+user_version\s*=\s*(\d+)/i.exec(message.sql)
   if (setVersion) {

--- a/packages/daemon/src/store/postgres-sync-database.ts
+++ b/packages/daemon/src/store/postgres-sync-database.ts
@@ -1,6 +1,12 @@
 import { MessageChannel, receiveMessageOnPort, Worker } from 'node:worker_threads'
 import type { DataPlaneConfig } from './postgres-config.js'
-import type { StoreDatabase, StoreRunResult, StoreStatement } from './local-store.js'
+import type {
+  StoreBatchResult,
+  StoreBatchStatement,
+  StoreDatabase,
+  StoreRunResult,
+  StoreStatement
+} from './local-store.js'
 
 // Stored schema name — the pool's data lives here, so the literal outlives the vocabulary rename.
 const POOL_STORE_SCHEMA = 'agentconnect_cloud_store'
@@ -213,6 +219,16 @@ export class PostgresSyncDatabase implements StoreDatabase {
     return { rows: value?.rows ?? [], changes: value?.changes ?? 0 }
   }
 
+  /** One round trip for an ordered statement list. The worker still runs each statement on its
+   *  own — same rewrite, same per-statement commit — so only the number of blocking hand-offs
+   *  changes. An error names the statement that failed and abandons the rest, exactly as the
+   *  equivalent run of single-statement calls would. */
+  batch(statements: StoreBatchStatement[]): StoreBatchResult[] {
+    if (statements.length === 0) return []
+    const value = this.request('batch', '', [], statements) as { rows?: unknown[]; changes?: number }[] | undefined
+    return (value ?? []).map((result) => ({ rows: result?.rows ?? [], changes: result?.changes ?? 0 }))
+  }
+
   finishSchemaInitialization(): void {
     this.request('finishSchemaInitialization', '', [])
   }
@@ -225,11 +241,11 @@ export class PostgresSyncDatabase implements StoreDatabase {
     this.replies.close()
   }
 
-  private request(kind: string, sql: string, params: unknown[]): unknown {
+  private request(kind: string, sql: string, params: unknown[], statements?: StoreBatchStatement[]): unknown {
     if (this.closed) throw new Error('PostgreSQL pool store is closed')
     const id = this.nextId++
     const signal = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT))
-    this.worker.postMessage({ id, kind, sql, params, signal })
+    this.worker.postMessage({ id, kind, sql, params, statements, signal })
     if (Atomics.wait(signal, 0, 0, 30_000) === 'timed-out') {
       const error = new Error('PostgreSQL pool store operation timed out after 30 seconds')
       this.onFailure(error)

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
-import { LocalStore, sessionKey, type StoreDatabase } from '../src/store/local-store.js'
+import { LocalStore, sessionKey, sqliteStoreDatabase, type StoreDatabase } from '../src/store/local-store.js'
 import { openPostgresLocalStore, usingPostgresStore } from './store-postgres/backend.js'
 
 /** True in the `store-postgres` project, where every store below is the real pool store. */
@@ -29,7 +29,7 @@ function sharedMembers(first: string, second: string): [LocalStore, LocalStore] 
       openPostgresLocalStore({ shared: true, ownerId: first, orgForAgent: oneOrg }),
       openPostgresLocalStore({ shared: true, ownerId: second, orgForAgent: oneOrg })
     ]
-  const database = new DatabaseSync(':memory:') as unknown as StoreDatabase
+  const database = sqliteStoreDatabase(new DatabaseSync(':memory:'))
   return [
     new LocalStore({ database, shared: true, ownerId: first, orgForAgent: oneOrg }),
     new LocalStore({ database, shared: true, ownerId: second, orgForAgent: oneOrg })
@@ -624,11 +624,13 @@ describe('LocalStore', () => {
 
     // Slip the peer's whole write in between our read and our compare-and-set, exactly once.
     let raced = false
+    const backing = sqliteStoreDatabase(database)
     const racing: StoreDatabase = {
-      exec: (sql) => database.exec(sql),
-      close: () => database.close(),
+      exec: (sql) => backing.exec(sql),
+      close: () => backing.close(),
+      batch: (statements) => backing.batch(statements),
       prepare: (sql) => {
-        const statement = database.prepare(sql)
+        const statement = backing.prepare(sql)
         if (!sql.startsWith('SELECT usage FROM sessions')) return statement
         return {
           run: (...params) => statement.run(...params),
@@ -2084,7 +2086,7 @@ describe('sandbox generations', () => {
 describe('transcript org fence on a shared store', () => {
   const orgs: Record<string, string> = { 'agent-a': 'org-a', 'agent-b': 'org-b' }
   const twoOrgMembers = (): [LocalStore, LocalStore] => {
-    const database = new DatabaseSync(':memory:') as unknown as StoreDatabase
+    const database = sqliteStoreDatabase(new DatabaseSync(':memory:'))
     const orgForAgent = (agentId: string): string | undefined => orgs[agentId]
     return [
       new LocalStore({ database, shared: true, ownerId: 'member-1', orgForAgent }),

--- a/packages/daemon/test/postgres-pool-store.int.test.ts
+++ b/packages/daemon/test/postgres-pool-store.int.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 import { PostgresDataPlane } from '../src/store/postgres-data-plane.js'
+import { PostgresSyncDatabase } from '../src/store/postgres-sync-database.js'
 import type { LocalStore } from '../src/store/local-store.js'
 import { STORE_RETENTION_RULES, StoreRetentionSweeper } from '../src/store/retention.js'
 
@@ -306,6 +307,65 @@ describe.skipIf(!databaseUrl)('PostgreSQL pool member store', () => {
     } finally {
       await second.close()
       await first.close()
+    }
+  })
+
+  it('lands a coalesced tool-call burst as the last body the burst produced', async () => {
+    const suffix = randomUUID()
+    const agentId = `agent-${suffix}`
+    const channel = `C-${suffix}`
+    const thread = `T-${suffix}`
+    const config = { version: 1 as const, databaseUrl: databaseUrl!, maxConnections: 2 }
+    const member = await PostgresDataPlane.open(config, (id) => (id === agentId ? `org-${suffix}` : undefined))
+    try {
+      member.store.insertToolCall({
+        channel,
+        thread,
+        ts: '1',
+        sender: agentId,
+        toolCallId: 'tc-1',
+        title: 'Bash',
+        body: '{"status":"pending"}'
+      })
+      for (let chunk = 1; chunk <= 8; chunk++) {
+        member.store.updateToolCall(channel, thread, agentId, 'tc-1', {
+          title: 'Bash',
+          body: `{"status":"in_progress","chunk":${chunk}}`
+        })
+      }
+      const row = member.store.threadTranscript(channel, thread, agentId).find((entry) => entry.kind === 'tool')
+      // Every intermediate body was superseded; the row carries the last one the burst produced,
+      // and the revision the pool's sequence handed the write that landed it.
+      expect(row?.body).toBe('{"status":"in_progress","chunk":8}')
+      expect(Number(row?.revision)).toBeGreaterThan(0)
+      // The read the CP's bounded tool-body fetch actually takes, drained by the same facade.
+      expect(member.store.getToolBodyForAgent(channel, thread, agentId, 'tc-1')).toBe(
+        '{"status":"in_progress","chunk":8}'
+      )
+    } finally {
+      await member.close()
+    }
+  })
+
+  it('answers a batch in order and names the statement that failed', () => {
+    const database = new PostgresSyncDatabase({ version: 1, databaseUrl: databaseUrl!, maxConnections: 2 })
+    database.finishSchemaInitialization()
+    try {
+      expect(
+        database.batch([
+          { kind: 'read', sql: 'SELECT 1 AS one', params: [] },
+          { kind: 'read', sql: 'SELECT 2 AS one', params: [] }
+        ])
+      ).toMatchObject([{ rows: [{ one: 1 }] }, { rows: [{ one: 2 }] }])
+      // A failure is attributed to its statement, never collapsed into "the batch failed".
+      expect(() =>
+        database.batch([
+          { kind: 'read', sql: 'SELECT 1 AS one', params: [] },
+          { kind: 'read', sql: 'SELECT * FROM a_table_that_does_not_exist', params: [] }
+        ])
+      ).toThrow(/batch statement 2 of 2 failed/)
+    } finally {
+      database.close()
     }
   })
 

--- a/packages/daemon/test/store-postgres/backend.ts
+++ b/packages/daemon/test/store-postgres/backend.ts
@@ -22,7 +22,12 @@ export function usingPostgresStore(): boolean {
 
 /** A suite closes its store freely, so the worker-wide connection must survive that. */
 function borrowed(database: StoreDatabase): StoreDatabase {
-  return { exec: (sql) => database.exec(sql), prepare: (sql) => database.prepare(sql), close: () => undefined }
+  return {
+    exec: (sql) => database.exec(sql),
+    prepare: (sql) => database.prepare(sql),
+    batch: (statements) => database.batch(statements),
+    close: () => undefined
+  }
 }
 
 export interface PostgresLocalStoreOptions {

--- a/packages/daemon/test/store-retention.test.ts
+++ b/packages/daemon/test/store-retention.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import { DatabaseSync } from 'node:sqlite'
-import { LocalStore, sessionKey, type StoreDatabase } from '../src/store/local-store.js'
+import { LocalStore, sessionKey, sqliteStoreDatabase } from '../src/store/local-store.js'
 import {
   DEFAULT_STORE_HORIZON_MS,
   STORE_ORPHAN_DELETE_ENV,
@@ -36,7 +36,7 @@ function sharedMembers(first: string, second: string): [LocalStore, LocalStore] 
       openPostgresLocalStore({ shared: true, ownerId: first, orgForAgent: oneOrg }),
       openPostgresLocalStore({ shared: true, ownerId: second, orgForAgent: oneOrg })
     ]
-  const database = new DatabaseSync(':memory:') as unknown as StoreDatabase
+  const database = sqliteStoreDatabase(new DatabaseSync(':memory:'))
   return [
     new LocalStore({ database, shared: true, ownerId: first, orgForAgent: oneOrg }),
     new LocalStore({ database, shared: true, ownerId: second, orgForAgent: oneOrg })
@@ -44,7 +44,7 @@ function sharedMembers(first: string, second: string): [LocalStore, LocalStore] 
 }
 
 const solo = (): LocalStore =>
-  pg ? openPostgresLocalStore() : new LocalStore({ database: new DatabaseSync(':memory:') as never })
+  pg ? openPostgresLocalStore() : new LocalStore({ database: sqliteStoreDatabase(new DatabaseSync(':memory:')) })
 
 /** One row in every table the rule table names, all stamped `at`. */
 function seedEveryTable(s: LocalStore, agentId: string, tag: string, at: number, owner: string): void {

--- a/packages/daemon/test/store-round-trips.test.ts
+++ b/packages/daemon/test/store-round-trips.test.ts
@@ -1,0 +1,306 @@
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, it, vi } from 'vitest'
+import { LocalStore, sqliteStoreDatabase, type StoreDatabase } from '../src/store/local-store.js'
+
+/**
+ * Round trips, not statements. A pool member's store is one worker thread holding one
+ * PostgreSQL client, and every call blocks the daemon's event loop until it answers — so the
+ * cost of a turn is how many times the store is asked, and these are the numbers that pin it.
+ * A change that reintroduces per-chunk chatter fails here instead of quietly costing latency.
+ */
+function countingStore(): {
+  store: LocalStore
+  roundTrips: () => number
+  reset: () => void
+} {
+  const backing = sqliteStoreDatabase(new DatabaseSync(':memory:'))
+  let count = 0
+  const counting: StoreDatabase = {
+    exec: (sql) => {
+      count++
+      backing.exec(sql)
+    },
+    batch: (statements) => {
+      count++
+      return backing.batch(statements)
+    },
+    close: () => backing.close(),
+    prepare: (sql) => {
+      const statement = backing.prepare(sql)
+      return {
+        run: (...params) => {
+          count++
+          return statement.run(...params)
+        },
+        get: (...params) => {
+          count++
+          return statement.get(...params)
+        },
+        all: (...params) => {
+          count++
+          return statement.all(...params)
+        }
+      }
+    }
+  }
+  return {
+    store: new LocalStore({ database: counting }),
+    roundTrips: () => count,
+    reset: () => {
+      count = 0
+    }
+  }
+}
+
+const CHANNEL = 'C1'
+const THREAD = 'T1'
+const AGENT = 'bot-a'
+
+const body = (n: number): string => JSON.stringify({ toolCallId: 'tc-1', status: 'in_progress', chunk: n })
+
+function seeded(): ReturnType<typeof countingStore> {
+  const counting = countingStore()
+  counting.store.insertToolCall({
+    channel: CHANNEL,
+    thread: THREAD,
+    ts: '1',
+    sender: AGENT,
+    toolCallId: 'tc-1',
+    title: 'Bash',
+    body: body(0)
+  })
+  counting.reset()
+  return counting
+}
+
+const toolRow = (store: LocalStore): { text: string; body: string } =>
+  store.threadTranscript(CHANNEL, THREAD).find((row) => row.kind === 'tool') as unknown as {
+    text: string
+    body: string
+  }
+
+describe('store round trips per streaming turn', () => {
+  it('costs one round trip to append a transcript row, its delivery, and read the thread revision', () => {
+    const { store, roundTrips, reset } = countingStore()
+    reset()
+    store.appendTranscript({
+      channel: CHANNEL,
+      thread: THREAD,
+      ts: '1',
+      sender: 'U1',
+      recipient: AGENT,
+      kind: 'text',
+      text: 'question?'
+    })
+    expect(roundTrips()).toBe(1)
+  })
+
+  it('costs one round trip to insert a tool row and read the thread revision', () => {
+    const { store, roundTrips, reset } = countingStore()
+    reset()
+    store.insertToolCall({
+      channel: CHANNEL,
+      thread: THREAD,
+      ts: '1',
+      sender: AGENT,
+      toolCallId: 'tc-1',
+      title: 'Bash',
+      body: body(0)
+    })
+    expect(roundTrips()).toBe(1)
+  })
+
+  it('costs one round trip for a whole tool_call_update burst, not two per chunk', () => {
+    const { store, roundTrips } = seeded()
+    for (let chunk = 1; chunk <= 12; chunk++) {
+      store.updateToolCall(CHANNEL, THREAD, AGENT, 'tc-1', { title: 'Bash', body: body(chunk) })
+    }
+    // Nothing has been asked of the store yet: the burst is still one buffered row.
+    expect(roundTrips()).toBe(0)
+    store.flushToolCallWrites()
+    // The coalesced write and the revision the mutation notice carries ride the same batch.
+    expect(roundTrips()).toBe(1)
+    expect(toolRow(store).body).toBe(body(12))
+  })
+
+  it('keeps the buffer bounded: a burst past the row bound flushes instead of growing', () => {
+    const { store, roundTrips, reset } = seeded()
+    for (let call = 0; call < 200; call++) {
+      store.insertToolCall({
+        channel: CHANNEL,
+        thread: THREAD,
+        ts: '1',
+        sender: AGENT,
+        toolCallId: `tc-${call}`,
+        title: 'Bash',
+        body: body(0)
+      })
+    }
+    reset()
+    for (let call = 0; call < 200; call++) {
+      store.updateToolCall(CHANNEL, THREAD, AGENT, `tc-${call}`, { title: 'Bash', body: body(call + 1) })
+    }
+    // Bounded at 64 rows, so 200 tool calls in flight flush three times — one round trip each —
+    // and the last 8 stay buffered for the next flush point.
+    expect(roundTrips()).toBe(3)
+  })
+
+  it('flushes early when the buffered bodies outgrow the byte bound, not just the row bound', () => {
+    const { store, roundTrips, reset } = seeded()
+    // Eight rows is far under the 64-row bound, but 8 MiB of bodies is over the byte bound.
+    for (let call = 0; call < 8; call++) {
+      store.insertToolCall({
+        channel: CHANNEL,
+        thread: THREAD,
+        ts: '1',
+        sender: AGENT,
+        toolCallId: `big-${call}`,
+        title: 'Bash',
+        body: body(0)
+      })
+    }
+    reset()
+    const megabyte = 'x'.repeat(1024 * 1024)
+    for (let call = 0; call < 8; call++) {
+      store.updateToolCall(CHANNEL, THREAD, AGENT, `big-${call}`, { title: 'Bash', body: megabyte })
+    }
+    expect(roundTrips()).toBeGreaterThan(0)
+  })
+})
+
+describe('the coalescing buffer is invisible to a reader', () => {
+  it('serves the latest body to a read that lands mid-burst', () => {
+    const { store } = seeded()
+    store.updateToolCall(CHANNEL, THREAD, AGENT, 'tc-1', { title: 'Bash', body: body(1) })
+    store.updateToolCall(CHANNEL, THREAD, AGENT, 'tc-1', { title: 'Bash', body: body(2) })
+    // No explicit flush: the read itself drains the buffer.
+    expect(toolRow(store).body).toBe(body(2))
+    store.updateToolCall(CHANNEL, THREAD, AGENT, 'tc-1', { title: 'Ripgrep', body: body(3) })
+    expect(toolRow(store)).toMatchObject({ text: 'Ripgrep', body: body(3) })
+  })
+
+  it('lets another transcript write pass only after the buffered one has landed', () => {
+    const { store } = seeded()
+    store.updateToolCall(CHANNEL, THREAD, AGENT, 'tc-1', { title: 'Bash', body: body(9) })
+    store.appendTranscript({ channel: CHANNEL, thread: THREAD, ts: '2', sender: AGENT, kind: 'text', text: 'done' })
+    const rows = store.threadTranscript(CHANNEL, THREAD)
+    // Ordering is preserved: the tool row still precedes the reply it ran for.
+    expect(rows.map((row) => row.kind)).toEqual(['tool', 'text'])
+    expect(toolRow(store).body).toBe(body(9))
+  })
+
+  it('raises one mutation notice per flush, carrying the revision the flushed row landed on', () => {
+    const { store } = seeded()
+    const seen: { revision: number; agentIds: string[] }[] = []
+    store.setTranscriptMutationListener((mutation) => seen.push(mutation))
+    for (let chunk = 1; chunk <= 5; chunk++) {
+      store.updateToolCall(CHANNEL, THREAD, AGENT, 'tc-1', { title: 'Bash', body: body(chunk) })
+    }
+    expect(seen).toEqual([])
+    store.flushToolCallWrites()
+    expect(seen).toHaveLength(1)
+    expect(seen[0]!.agentIds).toEqual([AGENT])
+    expect(seen[0]!.revision).toBe(store.currentTranscriptRevision())
+  })
+
+  it('lands a buffered body on close, so a drain cannot lose it', () => {
+    const backing = sqliteStoreDatabase(new DatabaseSync(':memory:'))
+    // A store closing over a borrowed database: `close` must flush without ending the backend.
+    const borrowed: StoreDatabase = { ...backing, close: () => undefined }
+    const first = new LocalStore({ database: borrowed })
+    first.insertToolCall({
+      channel: CHANNEL,
+      thread: THREAD,
+      ts: '1',
+      sender: AGENT,
+      toolCallId: 'tc-1',
+      title: 'Bash',
+      body: body(0)
+    })
+    first.updateToolCall(CHANNEL, THREAD, AGENT, 'tc-1', { title: 'Bash', body: body(7) })
+    first.close()
+    expect(toolRow(new LocalStore({ database: borrowed })).body).toBe(body(7))
+  })
+
+  it('writes a buffered body on its own timer when nothing else touches the store', async () => {
+    vi.useFakeTimers()
+    try {
+      const { store, roundTrips } = seeded()
+      store.updateToolCall(CHANNEL, THREAD, AGENT, 'tc-1', { title: 'Bash', body: body(4) })
+      expect(roundTrips()).toBe(0)
+      await vi.advanceTimersByTimeAsync(1_000)
+      // The round trip proves the timer wrote; a read here would have drained it either way.
+      expect(roundTrips()).toBe(1)
+      expect(toolRow(store).body).toBe(body(4))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('never re-issues a revision after a flush that spanned several threads', () => {
+    const { store } = countingStore()
+    const rows: { thread: string; id: string }[] = [
+      { thread: 'T1', id: 'tc-a' },
+      { thread: 'T2', id: 'tc-b' },
+      { thread: 'T1', id: 'tc-c' }
+    ]
+    for (const { thread, id } of rows) {
+      store.insertToolCall({
+        channel: CHANNEL,
+        thread,
+        ts: id,
+        sender: AGENT,
+        toolCallId: id,
+        title: 'Bash',
+        body: body(0)
+      })
+    }
+    // Interleaved threads, so the thread read last is NOT the one holding the highest revision.
+    for (const { thread, id } of rows) {
+      store.updateToolCall(CHANNEL, thread, AGENT, id, { title: 'Bash', body: body(1) })
+    }
+    store.flushToolCallWrites()
+    const issued = ['T1', 'T2'].flatMap((thread) =>
+      store.threadTranscript(CHANNEL, thread).map((row) => Number(row.revision))
+    )
+    store.appendTranscript({ channel: CHANNEL, thread: 'T2', ts: 'next', sender: AGENT, kind: 'text', text: 'done' })
+    const after = store.threadTranscript(CHANNEL, 'T2').map((row) => Number(row.revision))
+    // The allocator spans every partition: the next row must outrank every revision already out.
+    expect(Math.max(...after)).toBeGreaterThan(Math.max(...issued))
+    expect(new Set(issued).size).toBe(issued.length)
+  })
+
+  it('refuses an unattributable agent at the call that enqueued it, not at the flush', () => {
+    const backing = sqliteStoreDatabase(new DatabaseSync(':memory:'))
+    const shared = new LocalStore({
+      database: backing,
+      shared: true,
+      ownerId: 'member-1',
+      orgForAgent: (id) => (id === AGENT ? 'org-a' : undefined)
+    })
+    expect(() => shared.updateToolCall(CHANNEL, THREAD, 'stranger', 'tc-1', { title: 'Bash', body: body(1) })).toThrow(
+      /cannot resolve the transcript organization/
+    )
+    shared.close()
+  })
+})
+
+describe('the batch statement seam', () => {
+  it('returns one result per statement, in order, with reads and writes told apart', () => {
+    const backing = sqliteStoreDatabase(new DatabaseSync(':memory:'))
+    const store = new LocalStore({ database: backing })
+    store.appendTranscript({ channel: CHANNEL, thread: THREAD, ts: '1', sender: 'U1', kind: 'text', text: 'one' })
+    const results = backing.batch([
+      {
+        kind: 'run',
+        sql: "UPDATE transcript SET text = 'two' WHERE channel = ? AND thread = ?",
+        params: [CHANNEL, THREAD]
+      },
+      { kind: 'read', sql: 'SELECT text FROM transcript WHERE channel = ? AND thread = ?', params: [CHANNEL, THREAD] }
+    ])
+    expect(results).toHaveLength(2)
+    expect(results[0]).toEqual({ changes: 1, rows: [] })
+    expect(results[1]!.rows).toEqual([{ text: 'two' }])
+    store.close()
+  })
+})


### PR DESCRIPTION
## Summary

A pool member's data-plane store has a concurrency of exactly one. `postgres-data-plane.ts`
creates a `pg.Pool` sized by `maxConnections`, but uses it **only** for the migration in
`open()` and `pool.end()` in `close()` — no runtime query goes through it. All runtime traffic
goes through `postgres-sync-database.ts`: one worker thread holding one `pg.Client`, where
`request()` does one `postMessage` and then `Atomics.wait` on the main thread. One statement
per round trip, event loop stopped for the duration.

So the member's ceiling is roughly `1 / round-trip`, shared by every agent it serves, and the
lever is **round trips per unit of work**, not statements. Two semantics-preserving changes:

**1. A batch round trip in the bridge.** `StoreDatabase` gains `batch()`: one hand-off carrying
an ordered statement list, one ordered result array back. The `node:sqlite` backend implements
it as a plain in-process sequence — an embedded database has no round trip to save. The
single-statement path is untouched; batch is purely additive.

**2. Coalescing the highest-frequency writer.** `updateToolCall` is the store's only per-chunk
writer (see the count below). Its burst is now buffered per row and flushed before any other
store statement, on a 200 ms timer, at a row or byte bound, at turn end, and on drain.

## Measured round trips

Counted with a `StoreDatabase` wrapper that increments on every `exec`/`batch`/`run`/`get`/`all`,
driving the same representative turn against the store at `main` and on this branch: one inbound
message, six tool calls of five streamed updates each, three reasoning blocks, one reply.

**Before — 84 round trips**

| call site | calls | each | total |
| --- | --- | --- | --- |
| `updateToolCall` (streaming) | 30 | 2 | **60** |
| `insertToolCall` | 6 | 2 | 12 |
| `appendTranscript` (reasoning) | 3 | 2 | 6 |
| `appendTranscript` (inbound, with recipient) | 1 | 3 | 3 |
| `appendTranscript` (reply, with recipient) | 1 | 3 | 3 |
| | | | **84** |

**After — 17 round trips**

| call site | calls | each | total |
| --- | --- | --- | --- |
| `updateToolCall` (streaming) | 30 | 0 (buffered) | **0** |
| `flushToolCallWrites` | 6 | 1 | 6 |
| `insertToolCall` | 6 | 1 | 6 |
| `appendTranscript` (all kinds) | 5 | 1 | 5 |
| | | | **17** |

**84 → 17, a 4.9x reduction.** The count confirmed the hypothesis rather than assuming it:
`updateToolCall` was 60 of the 84 (71%). It is also the only per-chunk writer in the daemon —
`agent_thought_chunk` accumulates in memory and only flushes at a tool boundary, and the
platform-send appends are gated by the apply chain, not by chunks. The next-most-frequent
writer, `setUsageSnapshot`, fires on a runtime cadence and is about two orders of magnitude
below, so it was left alone.

`test/store-round-trips.test.ts` pins these counts, so a change that reintroduces per-chunk
chatter fails a test instead of quietly costing latency.

## Transaction semantics: preserved, not changed

**Today's single statements are autocommit, and the batch keeps them that way.** The worker
loops the statement list and runs each one on its own, with the same rewrite and the same
per-statement commit — only the number of blocking hand-offs changes, never what a statement
does. A failure names the statement (`batch statement 2 of 3 failed: …`) and abandons the rest,
so the statements that already ran stay committed, exactly as the equivalent run of
single-statement calls would have left them.

This is deliberately *not* the all-or-nothing option. Wrapping a converted sequence in one
transaction would change failure semantics from partial-progress to all-or-nothing at every
call site at once, which is a behaviour change smuggled in behind a performance change. The
transcript-revision transaction that already exists per statement is untouched.

The 30 s `Atomics.wait` now covers a whole batch. No batch introduced here can approach it: the
transcript batches are 2–3 statements, and the coalescing buffer is bounded at 64 rows or 4 MiB,
so the worst batch is 64 single-row updates plus one revision read per touched thread.

## Reader safety

The buffer is invisible to a reader by construction. Every `LocalStore` method goes through a
facade that drains pending writes before the statement, so no read can reach the database
without passing through it — verified across all 16 transcript readers, including the ones the
BFF's bounded reads land on (`transcriptTailForAgent`, `getToolBodyForAgent`). The mutation
listener carries no content; it is a metadata-only invalidation the console re-reads against,
and it already debounces at 250 ms, so a 200 ms flush sits inside latency the live view tolerates.

Coalescing cannot create a gap because each tool write is a **full latest-wins overlay** of the
merged `ToolBody`, never an append (`transcript-recorder.ts` `merge()` returns the whole body).
A reader sees either an older complete body or the newest — never a partial one. Ownership and
org fencing are resolved at the enqueueing call, not at flush time, so an unattributable agent
is rejected at the same call with the same inputs as the per-chunk write it replaces.

## What I inherited vs. wrote

This branch was handed to me uncommitted. The shape was right and I kept it: the additive
`batch()` seam, the autocommit choice, the per-statement error attribution, the drain facade,
buffering `updateToolCall`, the turn-end and drain flush points, and the round-trip test.

What I changed:

- **Fixed a revision-allocator bug.** The inherited flush assigned `this.transcriptRevision`
  from the last thread it happened to iterate. When a flush spans threads whose maxima differ,
  that pulls the allocator *below* a revision already issued, and the next append re-issues it —
  a duplicate revision, which a `revision > afterRevision` tail reader silently skips. Verified
  by reproducing it (revision 6 handed out twice) and now pinned by a test.
- **Folded the thread-revision reads into the flush batch.** The inherited flush cost 2 round
  trips (batch, then one revision read per thread). It is now exactly 1. This is the difference
  between 23 and 17 on the turn above.
- **Re-arm the timer when a flush fails from any path.** The inherited code only re-armed from
  the timer's own catch, so a failure during a read-triggered drain left the buffer un-timed
  until the next store call.
- **Added a byte bound.** A single tool body may reach 1 MiB, so a 64-row bound alone permitted
  a 64 MiB buffer. `MAX_PENDING_TOOL_WRITE_BYTES` (4 MiB) is the bound that actually caps memory.
- **Fixed an integration test that could not pass.** It called `threadTranscript` without an
  agent id against a shared store, which throws on the org fence; it now passes the agent and
  additionally asserts through `getToolBodyForAgent`, the read the bounded tool-body fetch takes.
- Corrected a comment that claimed the row bound "writes through" when the code flushes, and
  condensed the multi-paragraph comment blocks per the repo's comment style.

## Left alone deliberately

- **The async-store refactor.** Making `LocalStore`'s ~201 methods async was considered and
  deferred; it is not in scope here.
- **`maxConnections`.** Its name invites exactly the wrong tuning, so it now carries a one-line
  note that it sizes only the migration pool and is not a concurrency knob. The field itself is
  unchanged.
- **`setUsageSnapshot` and the platform-send appends.** The count says they are not the hot path.
- **Failure propagation from a drain.** A failed flush still throws out of whatever statement
  triggered the drain, and the entries stay buffered for retry. On the shared-store path a store
  write failure is already fatal (the daemon logs and exits), so surfacing it loudly is right.

## Test plan

- `vitest run test/store-*.test.ts` — 30 passed.
- The Postgres-backed project (`vitest.postgres.config.ts`, Testcontainers `postgres:16-alpine`)
  — 112 passed, 10 skipped. Run 3x, stable.
- Transcript and session suites (`local-store`, `local-store-permissions`,
  `local-store-sql-portability`, `daemon-transcript`, `a2a-transcript-privacy`, `session-reader`,
  `session-manager`, `session-branch`, `session-action-audit`, `session-capture-gate`, the pooled
  session suites, webchat continuation) — 291 passed. Core set run 3x, stable.
- Full daemon suite — 3818 passed, 15 failed. All 15 are the known macOS-environment failures in
  `shim-cancellation`, `shim-exec-handler`, `shim-workspace-files`, `workspace-git-runner-seam`
  and `acp-matrix`; verified byte-identical on `main` (same 5 files, same 15 tests).
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
