### PR TITLE
feat(control-plane): org-scoped member sets — the mechanism (daemon-groups.md §6 PR 2)

### DIFF
--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -238,7 +238,10 @@ taken **inside the transaction that writes**, under a per-daemon advisory lock e
 of "is this daemon in a set" also takes — enrolment, withdrawal, the `daemon`-placement
 guard, and the ledger's two claim paths. Without it a placement reading "in no set" and an
 enrolment reading "nothing pinned here" both commit, or a claim lands a live lease on a
-member a withdrawal has just decided was idle. The set's own row carries the second fence:
+member a withdrawal has just decided was idle. Renewal is one of those writers and not
+obviously so: it carries no expiry predicate, so it REVIVES every group its holder still
+names — which is why the withdrawal also vacates what is left on commit, exactly as the
+transition above says. The set's own row carries the second fence:
 `FOR SHARE` on every path that adds a reference to it, `FOR UPDATE` on the delete, so a
 placement cannot slip past the delete's reference count and be silently `SET NULL`ed.
 Membership is likewise re-read once the connection is registered, so a change committing

--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -2,9 +2,12 @@
 
 **Status:** PR 1 (§6, §8) is **built and deployed** — #1003 folded the pool into the
 `member_set` model with zero behavior change, and every #991 test passed unchanged.
-PR 2, the org-scoped sets this document exists for, is designed and not built
-(#1000). ([k8s-daemon-pool.md](k8s-daemon-pool.md) §14 records the pool as the
-degenerate case of what this document generalizes.)
+PR 2's **mechanism** is built (#1000): org sets exist, the ledger's door is membership
+rather than install-wideness, `auth/ok` announces the set, and the daemon's enforcement
+predicate reads it. Two pieces of PR 2 are deliberately still open — the console surface,
+and the one-action live membership transitions of §3 (what shipped instead is recorded
+there). ([k8s-daemon-pool.md](k8s-daemon-pool.md) §14 records the pool as the degenerate
+case of what this document generalizes.)
 
 A _daemon group_ is a named set of daemons within which an agent's duty may be claimed.
 The k8s pool is one such group, and since #1003 it is an explicit one: a `member_set` row,
@@ -213,6 +216,28 @@ moves them explicitly afterwards, which the existing move machinery already does
 transitions carry a generation so a stale ack (from a previous attempt, or from a
 daemon that reconnected mid-transition) cannot commit the wrong step.
 
+**What shipped, and what the above is still owed.** The mechanism PR (#1000) took the
+same safety rule — never commit while the old authority might still be serving — but
+paid for it with **preconditions instead of choreography**, so no new wire frame, fence
+column, or transition generation exists yet:
+
+- _Join_ is refused (409) while the daemon has directly placed agents, rather than
+  running the move once per agent inside one fence. The operator re-places them first,
+  with the move machinery that already exists.
+- _Leave_ is refused (409) while the daemon holds a **live** duty lease, rather than
+  sending a correlated withdrawal and committing on the ack. Draining the daemon, or
+  simply letting its leases lapse, is the "stop and confirm" step — a lapsed lease is
+  strictly later than that member's own self-fence horizon, which is the same evidence
+  the unreachable-leaver path above waits for.
+- Either way the daemon relearns its set the one way it ever learns it: the CP closes
+  the socket with `1012` and the reconnect's `auth/ok` carries the new membership. Both
+  admitted transitions leave nothing running to disturb, so the reconnect costs nothing.
+
+That is strictly narrower than §3, never wider: every transition it performs is one §3
+also permits. What is owed is the operator ergonomics — the one-action enrol-with-agents
+and drain-and-leave — which is where the correlated request, the leaving fence, and the
+transition generation earn their keep.
+
 ## 4. What does not change
 
 Stated so nobody rebuilds it: install-on-grant, the self-fence, the withdrawal guard,
@@ -262,11 +287,14 @@ was a set all along. Also: a new org-less daemon row (a Pod that just authentica
 must be enrolled in the org-less set as part of `upsertOnAuth`, so pool membership stays
 automatic; a `daemon`-kind daemon row is never enrolled anywhere by itself.
 
-**PR 2 — org sets (#1000, open).** Console: set CRUD in org settings, membership on the daemon detail,
-one more placement entry per set. The three duty handlers and the heartbeat handler:
+**PR 2 — org sets (#1000).** The three duty handlers and the heartbeat handler:
 `SCOPE_DENIED` becomes "in no set". `auth/ok` announces the daemon's set; the daemon's
 enforcement predicate reads it. Nothing in the ledger changes — PR 1 already made it
-set-shaped.
+set-shaped. Org-set CRUD and membership are an org-scoped REST surface
+(`/orgs/:orgId/member-sets`), and the daemon read model carries its set. **Shipped as the
+mechanism**, with the transition ergonomics reduced to the preconditions §3 records.
+Console — set CRUD in org settings, membership on the daemon detail, one more placement
+entry per set — is still to come; the data and wire formats it needs are in place.
 
 Load-bearing tests, all mutation-checked: an org-scoped member of set G in org X claims
 a `set`-placed agent of X in G; the same member is refused a `set` agent of X in another

--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -233,6 +233,17 @@ column, or transition generation exists yet:
   the socket with `1012` and the reconnect's `auth/ok` carries the new membership. Both
   admitted transitions leave nothing running to disturb, so the reconnect costs nothing.
 
+A precondition is only a fence if the state it read cannot change under it, so each one is
+taken **inside the transaction that writes**, under a per-daemon advisory lock every writer
+of "is this daemon in a set" also takes — enrolment, withdrawal, the `daemon`-placement
+guard, and the ledger's two claim paths. Without it a placement reading "in no set" and an
+enrolment reading "nothing pinned here" both commit, or a claim lands a live lease on a
+member a withdrawal has just decided was idle. The set's own row carries the second fence:
+`FOR SHARE` on every path that adds a reference to it, `FOR UPDATE` on the delete, so a
+placement cannot slip past the delete's reference count and be silently `SET NULL`ed.
+Membership is likewise re-read once the connection is registered, so a change committing
+during a handshake either is seen by that read or finds the connection and closes it.
+
 That is strictly narrower than §3, never wider: every transition it performs is one §3
 also permits. What is owed is the operator ergonomics — the one-action enrol-with-agents
 and drain-and-leave — which is where the correlated request, the leaving fence, and the

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -425,6 +425,8 @@ export function buildContainer(
     },
     // Resolves the daemon's org slug for the org-scoped deep link (`…/<orgSlug>/sessions/…`).
     repos.org,
+    // The set `auth/ok` announces — the daemon's duty-enforcement predicate (daemon-groups.md §3).
+    repos.memberSet,
     clusterIdentity
   )
   const apiKeys = new ApiKeyService(codec, repos.apiKey, repos.daemon, repos.audit, clock)
@@ -1034,6 +1036,7 @@ export function buildContainer(
       agent: repos.agent,
       assignment: repos.assignment,
       memberSet: repos.memberSet,
+      dutyGroup: repos.dutyGroup,
       daemonLifecycleOp: repos.daemonLifecycleOp,
       cron: repos.cron,
       hook: repos.hook,

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1411,6 +1411,7 @@ export function buildContainer(
     recoverStagedAgent: (agentId, daemonId, moveId) => stagedAgentMoves.recoverStaged(agentId, daemonId, moveId),
     collabRoutes,
     dutyLease,
+    memberSets: repos.memberSet,
     agentBundle: (agent) => stagedAgentMoves.bundleFor(agent),
     cron: repos.cron,
     hook: repos.hook,

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -27,6 +27,7 @@ import type {
   AgentConfigWriter,
   McpProviderRepo,
   MemberSetRepo,
+  DutyGroupRepo,
   McpProviderSecretStore,
   McpGrantRepo,
   SkillSourceRepo,
@@ -175,6 +176,9 @@ export interface HttpDeps {
     agentConfig: AgentConfigWriter
     /** The sets a duty may be claimed within — the console resolves a placement target to one. */
     memberSet: MemberSetRepo
+    /** The duty ledger, read-only here: a membership change must not take a live lease away from
+     *  a machine that could still be serving it (daemon-groups.md §3). */
+    dutyGroup: Pick<DutyGroupRepo, 'listHeldBy'>
     /** Org-level MCP provider metadata (never upstream header values / grant keys). */
     mcpProvider: McpProviderRepo
     /** The ONLY read/write path for upstream MCP auth headers (store-only, never DTO'd). */

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -220,6 +220,10 @@ export const DaemonViewDto = z.object({
    *  retention sweep deletes them — 'never' disables the sweep, otherwise an
    *  integer day count as '<n>d' (e.g. '7d'). */
   sessionRetention: z.string().regex(SESSION_RETENTION_RE),
+  /** The member set this daemon belongs to (docs/designs/daemon-groups.md §2), or null when it
+   *  owns its agents outright. A member serves only what it holds a duty lease for, so this is
+   *  what says whether an agent may be pinned here or must be placed on the set. */
+  memberSetId: z.string().nullable(),
   // ── visibility / sharing (docs/designs/resource-visibility.md) ──
   visibility: ResourceVisibilityEnum,
   sharedWith: z.array(z.string()), // complete app_user.id audience when restricted
@@ -230,6 +234,24 @@ export const DaemonViewDto = z.object({
   canManageLifecycle: z.boolean()
 })
 export const DaemonListDto = z.array(DaemonViewDto)
+
+// ── member sets (docs/designs/daemon-groups.md) ──
+// A named set of this organization's daemons within which an agent's duty may be claimed. The
+// install-wide pool is the org-less set and is never one of these — it belongs to no organization.
+
+/** One of an organization's member sets, with its current members. */
+export const MemberSetDto = z.object({
+  setId: z.string().uuid(),
+  name: z.string(),
+  /** Daemon ids currently enrolled. A daemon is in at most one set. */
+  memberDaemonIds: z.array(z.string().uuid())
+})
+export const MemberSetListDto = z.array(MemberSetDto)
+
+export const MemberSetBody = z.object({ name: z.string().trim().min(1).max(64) })
+
+/** `…/member-sets/:id/members/:daemonId` — the enrolment target. */
+export const MemberSetMemberParams = z.object({ id: z.string(), daemonId: z.string() })
 
 /** `PATCH /daemons/:id` — console daemon settings: a human-friendly display name
  *  and/or the finished-session retention window ("Expire sessions"). */

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -244,7 +244,10 @@ export const MemberSetDto = z.object({
   setId: z.string().uuid(),
   name: z.string(),
   /** Daemon ids currently enrolled. A daemon is in at most one set. */
-  memberDaemonIds: z.array(z.string().uuid())
+  memberDaemonIds: z.array(z.string().uuid()),
+  /** Agents placed on this set. The console shows the same count on the install-wide pool and on
+   *  a cluster, so a set that cannot answer it cannot be presented beside them. */
+  agentCount: z.number().int()
 })
 export const MemberSetListDto = z.array(MemberSetDto)
 

--- a/packages/control-plane/src/http/plugins/openapi.ts
+++ b/packages/control-plane/src/http/plugins/openapi.ts
@@ -58,6 +58,7 @@ export const Tag = {
   Profile: 'Profile',
   Members: 'Members',
   Daemons: 'Daemons',
+  MemberSets: 'Member sets',
   DaemonKeys: 'Daemon keys',
   ApiKeys: 'API keys',
   Agents: 'Agents',
@@ -86,6 +87,10 @@ const TAG_DESCRIPTIONS: ReadonlyArray<{ name: string; description: string }> = [
   {
     name: Tag.Daemons,
     description: 'Edge daemons — the message + agent-execution units. Enrollment tokens and lifecycle.'
+  },
+  {
+    name: Tag.MemberSets,
+    description: 'Named sets of daemons an agent’s duty may be claimed within — the failover unit.'
   },
   { name: Tag.DaemonKeys, description: 'A daemon’s API keys (issue, list, revoke).' },
   { name: Tag.ApiKeys, description: 'Your personal API keys — create, list, revoke.' },

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -169,6 +169,7 @@ function toDto(
     // values, so a fallback here just keeps an unexpected stored value from
     // failing the whole response's schema serialization.
     sessionRetention: SESSION_RETENTION_RE.test(view.sessionRetention) ? view.sessionRetention : '7d',
+    memberSetId: view.memberSetId,
     visibility: view.visibility,
     sharedWith: view.sharedWith,
     canEdit: orgOwned && canEdit(view, ctx),

--- a/packages/control-plane/src/http/routes/member-sets.ts
+++ b/packages/control-plane/src/http/routes/member-sets.ts
@@ -53,12 +53,27 @@ function conflict(reply: FastifyReply, message: string): FastifyReply {
 }
 
 export function memberSetRoutes(deps: HttpDeps) {
-  /** One set plus its members — the only projection these routes return. */
-  const toDto = async (set: { id: string; name: string }) => ({
-    setId: set.id,
-    name: set.name,
-    memberDaemonIds: await deps.repos.memberSet.memberIdsOf(set.id)
-  })
+  /** One set plus its members and what is placed on it — the only projection these routes return. */
+  const toDto = async (set: { id: string; name: string }) => {
+    const [memberDaemonIds, agentCounts] = await Promise.all([
+      deps.repos.memberSet.memberIdsOf(set.id),
+      deps.repos.memberSet.agentCountsOf([set.id])
+    ])
+    return { setId: set.id, name: set.name, memberDaemonIds, agentCount: agentCounts.get(set.id) ?? 0 }
+  }
+
+  /** The list read, batched: one membership query and one count query for every set at once. */
+  const toDtoList = async (sets: { id: string; name: string }[]) => {
+    const agentCounts = await deps.repos.memberSet.agentCountsOf(sets.map((s) => s.id))
+    return Promise.all(
+      sets.map(async (set) => ({
+        setId: set.id,
+        name: set.name,
+        memberDaemonIds: await deps.repos.memberSet.memberIdsOf(set.id),
+        agentCount: agentCounts.get(set.id) ?? 0
+      }))
+    )
+  }
 
   /** Resolve a path id to one of THIS org's sets. Null ⇒ 404, including for the org-less pool:
    *  it is not this organization's to see or change. */
@@ -82,10 +97,7 @@ export function memberSetRoutes(deps: HttpDeps) {
           response: { 200: MemberSetListDto }
         }
       },
-      async (req) => {
-        const sets = await deps.repos.memberSet.listForOrg(orgOf(req))
-        return Promise.all(sets.map(toDto))
-      }
+      async (req) => toDtoList(await deps.repos.memberSet.listForOrg(orgOf(req)))
     )
 
     r.post(

--- a/packages/control-plane/src/http/routes/member-sets.ts
+++ b/packages/control-plane/src/http/routes/member-sets.ts
@@ -34,6 +34,7 @@ import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import { DaemonId, type OrgId } from '../../domain/ids.js'
 import {
+  DaemonAlreadyInSet,
   DaemonHasPlacedAgents,
   DaemonHoldsDuty,
   MemberSetInUse,
@@ -201,6 +202,9 @@ export function memberSetRoutes(deps: HttpDeps) {
         try {
           await deps.repos.memberSet.enrollOperator(set.id, daemonId)
         } catch (err) {
+          if (err instanceof DaemonAlreadyInSet) {
+            return conflict(reply, 'the daemon is already in another member set')
+          }
           if (err instanceof DaemonHasPlacedAgents) {
             return conflict(reply, `move this daemon's ${err.placed} placed agent(s) onto a member set first`)
           }

--- a/packages/control-plane/src/http/routes/member-sets.ts
+++ b/packages/control-plane/src/http/routes/member-sets.ts
@@ -33,7 +33,12 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import { DaemonId, type OrgId } from '../../domain/ids.js'
-import { MemberSetInUse, MemberSetTenancyMismatch } from '../../persistence/errors.js'
+import {
+  DaemonHasPlacedAgents,
+  DaemonHoldsDuty,
+  MemberSetInUse,
+  MemberSetTenancyMismatch
+} from '../../persistence/errors.js'
 import { orgOf, denyViewerWrite } from '../rbac.js'
 import {
   MemberSetBody,
@@ -191,14 +196,14 @@ export function memberSetRoutes(deps: HttpDeps) {
         }
         if (daemon.memberSetId === set.id) return toDto(set)
         if (daemon.memberSetId) return conflict(reply, 'the daemon is already in another member set')
-        // A pinned agent on a machine that enforces duties is placed and unservable at once (§3).
-        const pinned = await deps.repos.agent.listForDaemon(daemonId)
-        if (pinned.length > 0) {
-          return conflict(reply, `move this daemon's ${pinned.length} placed agent(s) onto a member set first`)
-        }
+        // Every precondition is the repository's, taken with the row under the per-daemon fence —
+        // a check made out here could only be re-decided by a concurrent placement (§3).
         try {
-          await deps.repos.memberSet.enroll(set.id, daemonId)
+          await deps.repos.memberSet.enrollOperator(set.id, daemonId)
         } catch (err) {
+          if (err instanceof DaemonHasPlacedAgents) {
+            return conflict(reply, `move this daemon's ${err.placed} placed agent(s) onto a member set first`)
+          }
           // The set's tenancy invariant, surfaced rather than swallowed: the daemon is not this
           // org's. The org-fenced read above already refuses that, so this is a concurrent change.
           if (err instanceof MemberSetTenancyMismatch) return conflict(reply, 'the daemon is not in this organization')
@@ -234,14 +239,16 @@ export function memberSetRoutes(deps: HttpDeps) {
         }
         // Stop the old authority and CONFIRM it stopped, before committing the change (§3). A live
         // lease is exactly "it may still be serving"; a lapsed one is not, because the daemon's own
-        // self-fence fires strictly before the CP's reassignment horizon.
-        const now = new Date(deps.clock.now())
-        const held = await deps.repos.dutyGroup.listHeldBy(daemonId)
-        const live = held.filter((g) => g.expiresAt !== null && g.expiresAt > now)
-        if (live.length > 0) {
-          return conflict(reply, `drain this daemon first — it still holds ${live.length} duty group(s)`)
+        // self-fence fires strictly before the CP's reassignment horizon. The repository takes that
+        // check and the delete together under the per-daemon fence, so a claim cannot land between.
+        try {
+          await deps.repos.memberSet.withdraw(daemonId, new Date(deps.clock.now()))
+        } catch (err) {
+          if (err instanceof DaemonHoldsDuty) {
+            return conflict(reply, `drain this daemon first — it still holds ${err.held} duty group(s)`)
+          }
+          throw err
         }
-        await deps.repos.memberSet.withdraw(daemonId)
         deps.liveness.reconnectForMemberSet?.(daemonId)
         return toDto(set)
       }

--- a/packages/control-plane/src/http/routes/member-sets.ts
+++ b/packages/control-plane/src/http/routes/member-sets.ts
@@ -1,0 +1,238 @@
+/**
+ * `http/routes/member-sets.ts` (docs/designs/daemon-groups.md §2, §3) — an organization's own
+ * member sets: named sets of its daemons within which an agent's duty may be claimed. Pointing an
+ * agent at a set instead of a machine is what gives self-hosted installs the lease-driven failover
+ * the install-wide pool already has.
+ *
+ * The install-wide pool is NOT reachable here. It is the org-less set, it belongs to no
+ * organization, and its membership is automatic (a Pod is enrolled when it authenticates), so
+ * every route below is fenced on the path org and answers 404 for a set that is not this org's.
+ *
+ * The tenancy invariants are the repository's, not this file's (`member-set.repo.ts`): an org set
+ * accepts only that org's daemons, and a `set`-placed agent may reference only the org-less set or
+ * one of its own. What this file owns is the TRANSITION safety of §3 — a membership change moves
+ * runtime authority, so each direction is admitted only from a state where nothing is being taken
+ * away from a running machine:
+ *
+ * - _Join_ requires the daemon to have no directly placed agents. A set member serves only what it
+ *   holds a lease for, so a machine that still has agents pinned to it would render them
+ *   unservable the moment it enrolled. Move them onto the set first; the design's one-action
+ *   version (the move convention applied per agent inside one fence) is a follow-up.
+ * - _Leave_ requires the daemon to hold no LIVE duty lease. That is the design's "stop the old
+ *   authority and confirm it stopped, then commit", satisfied by an existing primitive rather than
+ *   a new one: drain the daemon (or let its leases lapse — a lapsed lease is strictly later than
+ *   the daemon's own self-fence, so it has provably stopped serving), then leave.
+ *
+ * Either way the daemon learns its new set the way it learns any set — from `auth/ok` — so a
+ * connected one is closed with `1012` and reads it on the reconnect. Membership is never
+ * negotiated on the wire; the CP tells the daemon, the daemon does not tell.
+ */
+import type { FastifyInstance, FastifyReply } from 'fastify'
+import { z } from 'zod'
+import type { ZodTypeProvider } from '../plugins/zod.js'
+import { Tag } from '../plugins/openapi.js'
+import type { HttpDeps } from '../deps.js'
+import { DaemonId, type OrgId } from '../../domain/ids.js'
+import { MemberSetInUse, MemberSetTenancyMismatch } from '../../persistence/errors.js'
+import { orgOf, denyViewerWrite } from '../rbac.js'
+import {
+  MemberSetBody,
+  MemberSetDto,
+  MemberSetListDto,
+  MemberSetMemberParams,
+  IdParam,
+  ErrorDto
+} from '../dto/index.js'
+
+function notFound(reply: FastifyReply): FastifyReply {
+  return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'member set not found' })
+}
+
+function conflict(reply: FastifyReply, message: string): FastifyReply {
+  return reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
+}
+
+export function memberSetRoutes(deps: HttpDeps) {
+  /** One set plus its members — the only projection these routes return. */
+  const toDto = async (set: { id: string; name: string }) => ({
+    setId: set.id,
+    name: set.name,
+    memberDaemonIds: await deps.repos.memberSet.memberIdsOf(set.id)
+  })
+
+  /** Resolve a path id to one of THIS org's sets. Null ⇒ 404, including for the org-less pool:
+   *  it is not this organization's to see or change. */
+  const ownSet = async (orgId: OrgId, setId: string) => {
+    const set = await deps.repos.memberSet.get(setId)
+    return set && set.orgId === orgId ? set : null
+  }
+
+  return async function memberSetRoutesPlugin(app: FastifyInstance): Promise<void> {
+    const r = app.withTypeProvider<ZodTypeProvider>()
+
+    r.get(
+      '/member-sets',
+      {
+        schema: {
+          tags: [Tag.MemberSets],
+          summary: 'List member sets',
+          description:
+            'The organization’s member sets — named sets of its daemons within which an agent’s duty may be claimed. The install-wide pool is not among them.',
+          operationId: 'listMemberSets',
+          response: { 200: MemberSetListDto }
+        }
+      },
+      async (req) => {
+        const sets = await deps.repos.memberSet.listForOrg(orgOf(req))
+        return Promise.all(sets.map(toDto))
+      }
+    )
+
+    r.post(
+      '/member-sets',
+      {
+        schema: {
+          tags: [Tag.MemberSets],
+          summary: 'Create a member set',
+          description: 'Create an empty member set. Daemons join it afterwards, one set per daemon.',
+          operationId: 'createMemberSet',
+          body: MemberSetBody,
+          response: { 201: MemberSetDto, 403: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return reply
+        const set = await deps.repos.memberSet.createForOrg(orgOf(req), req.body.name)
+        return reply.code(201).send(await toDto(set))
+      }
+    )
+
+    r.patch(
+      '/member-sets/:id',
+      {
+        schema: {
+          tags: [Tag.MemberSets],
+          summary: 'Rename a member set',
+          description: 'Change a member set’s display name. Membership and placements are untouched.',
+          operationId: 'renameMemberSet',
+          params: IdParam,
+          body: MemberSetBody,
+          response: { 200: MemberSetDto, 403: ErrorDto, 404: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return reply
+        const set = await deps.repos.memberSet.renameForOrg(orgOf(req), req.params.id, req.body.name)
+        return set ? toDto(set) : notFound(reply)
+      }
+    )
+
+    r.delete(
+      '/member-sets/:id',
+      {
+        schema: {
+          tags: [Tag.MemberSets],
+          summary: 'Delete a member set',
+          description:
+            'Delete an EMPTY member set. A set that still has members, or agents placed on it, returns 409 — dropping it would silently unplace them.',
+          operationId: 'deleteMemberSet',
+          params: IdParam,
+          response: { 204: z.null(), 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return reply
+        try {
+          const deleted = await deps.repos.memberSet.deleteForOrg(orgOf(req), req.params.id)
+          return deleted ? reply.code(204).send(null) : notFound(reply)
+        } catch (err) {
+          if (err instanceof MemberSetInUse) {
+            return conflict(reply, 'remove its daemons and re-place its agents before deleting the set')
+          }
+          throw err
+        }
+      }
+    )
+
+    r.put(
+      '/member-sets/:id/members/:daemonId',
+      {
+        schema: {
+          tags: [Tag.MemberSets],
+          summary: 'Enroll a daemon in a member set',
+          description:
+            'Add one of the organization’s daemons to the set. Refused (409) while the daemon still has agents pinned directly to it — a member serves only what it holds a duty lease for, so those agents must be placed on the set first — or while it is already in another set. A connected daemon reconnects to pick up its new set.',
+          operationId: 'enrollDaemonInMemberSet',
+          params: MemberSetMemberParams,
+          response: { 200: MemberSetDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return reply
+        const orgId = orgOf(req)
+        const set = await ownSet(orgId, req.params.id)
+        if (!set) return notFound(reply)
+        const daemonId = DaemonId(req.params.daemonId)
+        const daemon = await deps.registry.getAvailable(orgId, daemonId)
+        if (!daemon) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
+        }
+        if (daemon.memberSetId === set.id) return toDto(set)
+        if (daemon.memberSetId) return conflict(reply, 'the daemon is already in another member set')
+        // A pinned agent on a machine that enforces duties is placed and unservable at once (§3).
+        const pinned = await deps.repos.agent.listForDaemon(daemonId)
+        if (pinned.length > 0) {
+          return conflict(reply, `move this daemon's ${pinned.length} placed agent(s) onto a member set first`)
+        }
+        try {
+          await deps.repos.memberSet.enroll(set.id, daemonId)
+        } catch (err) {
+          // The set's tenancy invariant, surfaced rather than swallowed: the daemon is not this
+          // org's. The org-fenced read above already refuses that, so this is a concurrent change.
+          if (err instanceof MemberSetTenancyMismatch) return conflict(reply, 'the daemon is not in this organization')
+          throw err
+        }
+        deps.liveness.reconnectForMemberSet?.(daemonId)
+        return toDto(set)
+      }
+    )
+
+    r.delete(
+      '/member-sets/:id/members/:daemonId',
+      {
+        schema: {
+          tags: [Tag.MemberSets],
+          summary: 'Withdraw a daemon from a member set',
+          description:
+            'Remove one daemon from the set. Refused (409) while it still holds a live duty lease: drain it first (or wait for its leases to lapse, which is strictly later than its own self-fence) so it has provably stopped serving before the duties re-grant elsewhere. The set’s agents stay placed on the set and re-grant to its remaining members.',
+          operationId: 'withdrawDaemonFromMemberSet',
+          params: MemberSetMemberParams,
+          response: { 200: MemberSetDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return reply
+        const orgId = orgOf(req)
+        const set = await ownSet(orgId, req.params.id)
+        if (!set) return notFound(reply)
+        const daemonId = DaemonId(req.params.daemonId)
+        const daemon = await deps.registry.getAvailable(orgId, daemonId)
+        if (!daemon || daemon.memberSetId !== set.id) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon is not in this set' })
+        }
+        // Stop the old authority and CONFIRM it stopped, before committing the change (§3). A live
+        // lease is exactly "it may still be serving"; a lapsed one is not, because the daemon's own
+        // self-fence fires strictly before the CP's reassignment horizon.
+        const now = new Date(deps.clock.now())
+        const held = await deps.repos.dutyGroup.listHeldBy(daemonId)
+        const live = held.filter((g) => g.expiresAt !== null && g.expiresAt > now)
+        if (live.length > 0) {
+          return conflict(reply, `drain this daemon first — it still holds ${live.length} duty group(s)`)
+        }
+        await deps.repos.memberSet.withdraw(daemonId)
+        deps.liveness.reconnectForMemberSet?.(daemonId)
+        return toDto(set)
+      }
+    )
+  }
+}

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -25,6 +25,7 @@ import { humanAuthPlugin } from './plugins/auth.js'
 import { healthRoutes } from './routes/health.js'
 import { runtimeConfigRoutes } from './routes/runtime-config.js'
 import { daemonRoutes } from './routes/daemons.js'
+import { memberSetRoutes } from './routes/member-sets.js'
 import { keyRoutes } from './routes/keys.js'
 import { agentRoutes } from './routes/agents.js'
 import { agentRepoRoutes } from './routes/agent-repos.js'
@@ -288,6 +289,7 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
           scope.addHook('preValidation', makeOrgScope(deps.repos.org))
           await scope.register(orgScopedRoutes(deps))
           await scope.register(daemonRoutes(deps))
+          await scope.register(memberSetRoutes(deps))
           await scope.register(keyRoutes(deps))
           await scope.register(agentRoutes(deps))
           await scope.register(agentRepoRoutes(deps))

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -57,6 +57,40 @@ export class MemberSetInUse extends Error {
 }
 
 /**
+ * Thrown by `enrollOperator` when the daemon still has agents pinned directly to it. A set member
+ * serves only what it holds a lease for, so those agents would be placed and unservable the moment
+ * the membership row landed (docs/designs/daemon-groups.md §3) — they are re-placed onto the set
+ * first. Taken under the per-daemon fence, so it cannot race a concurrent placement.
+ */
+export class DaemonHasPlacedAgents extends Error {
+  readonly code = 'DAEMON_HAS_PLACED_AGENTS' as const
+  constructor(
+    readonly daemonId: string,
+    readonly placed: number
+  ) {
+    super(`daemon ${daemonId} still has ${placed} directly placed agent(s)`)
+    this.name = 'DaemonHasPlacedAgents'
+  }
+}
+
+/**
+ * Thrown by `withdraw` when the daemon still holds a live duty lease. Committing the withdrawal
+ * then would let a successor claim work the leaver may still be running — the split the ledger
+ * exists to prevent (§3). A lapsed lease is not this: it is strictly later than the member's own
+ * self-fence, so by then it has provably stopped serving.
+ */
+export class DaemonHoldsDuty extends Error {
+  readonly code = 'DAEMON_HOLDS_DUTY' as const
+  constructor(
+    readonly daemonId: string,
+    readonly held: number
+  ) {
+    super(`daemon ${daemonId} still holds ${held} live duty group(s)`)
+    this.name = 'DaemonHoldsDuty'
+  }
+}
+
+/**
  * Thrown by the placement writers when a `daemon` placement names a machine that is in a member
  * set (docs/designs/daemon-groups.md §3). A set member serves only what it holds a lease for, so
  * an agent pinned to one would be unservable — the agent belongs on the set instead.

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -44,6 +44,35 @@ export class MemberSetTenancyMismatch extends Error {
 }
 
 /**
+ * Thrown by `deleteForOrg` when the set still has members or `set`-placed agents. Dropping it
+ * would unplace those agents by cascade (`Agent.setId` is SetNull), so the set is emptied
+ * deliberately or not at all.
+ */
+export class MemberSetInUse extends Error {
+  readonly code = 'MEMBER_SET_IN_USE' as const
+  constructor(readonly setId: string) {
+    super(`member set ${setId} still has members or placed agents`)
+    this.name = 'MemberSetInUse'
+  }
+}
+
+/**
+ * Thrown by the placement writers when a `daemon` placement names a machine that is in a member
+ * set (docs/designs/daemon-groups.md §3). A set member serves only what it holds a lease for, so
+ * an agent pinned to one would be unservable — the agent belongs on the set instead.
+ */
+export class DaemonPlacementInSet extends Error {
+  readonly code = 'DAEMON_PLACEMENT_IN_SET' as const
+  constructor(
+    readonly agentId: string,
+    readonly daemonId: string
+  ) {
+    super(`agent ${agentId} may not be pinned to daemon ${daemonId}, which is a member set member`)
+    this.name = 'DaemonPlacementInSet'
+  }
+}
+
+/**
  * Thrown by the placement writers when a `set` placement names a set the agent may not reference
  * (docs/designs/daemon-groups.md §2, third write-time invariant): only the org-less set or a set
  * of the agent's own org. Without it, `mayHold`'s single rule would let org X's members claim an

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -74,6 +74,23 @@ export class DaemonHasPlacedAgents extends Error {
 }
 
 /**
+ * Thrown by `enrollOperator` when the daemon is already in a DIFFERENT set. A daemon is in at most
+ * one, and the insert is idempotent, so without this check the losing half of two concurrent
+ * enrolments would silently no-op and still answer 200 — naming a set the daemon never joined.
+ * Moving a daemon between sets is a two-phase transition (§3), never this path.
+ */
+export class DaemonAlreadyInSet extends Error {
+  readonly code = 'DAEMON_ALREADY_IN_SET' as const
+  constructor(
+    readonly daemonId: string,
+    readonly setId: string
+  ) {
+    super(`daemon ${daemonId} is already a member of member set ${setId}`)
+    this.name = 'DaemonAlreadyInSet'
+  }
+}
+
+/**
  * Thrown by `withdraw` when the daemon still holds a live duty lease. Committing the withdrawal
  * then would let a successor claim work the leaver may still be running — the split the ledger
  * exists to prevent (§3). A lapsed lease is not this: it is strictly later than the member's own

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5016,8 +5016,12 @@ export interface MemberSetRepo {
    *  org-less install-wide pool. An org set answers `[]`: its machines may keep private stores, so
    *  none of them can stand in for another's transcripts (domain/session-content.ts). */
   sharedStoreMemberIdsOf(setId: string): Promise<string[]>
-  /** Record a membership under the set's tenancy invariant; throws MemberSetTenancyMismatch. */
+  /** Record a membership under the set's tenancy invariant; throws MemberSetTenancyMismatch.
+   *  The automatic path (a pool Pod on auth) — no operator precondition. */
   enroll(setId: string, daemonId: DaemonId): Promise<void>
+  /** The operator path: the same row, plus §3's join precondition taken under the per-daemon
+   *  fence. Throws `DaemonHasPlacedAgents` when agents are still pinned to the machine. */
+  enrollOperator(setId: string, daemonId: DaemonId): Promise<void>
   /** One org's sets, by name. The org-less pool is never among them — it belongs to no org. */
   listForOrg(orgId: string): Promise<MemberSetRecord[]>
   /** Agents placed on each of these sets, in one query — the list read must not be N+1. Sets with
@@ -5030,8 +5034,10 @@ export interface MemberSetRepo {
   /** Drop one of an org's sets. Refused while anything still points at it: throws
    *  `MemberSetInUse` when it has members or `set`-placed agents. False ⇒ no such set. */
   deleteForOrg(orgId: string, setId: string): Promise<boolean>
-  /** Drop a membership row. Idempotent; the caller owns the transition's safety (§3). */
-  withdraw(daemonId: DaemonId): Promise<void>
+  /** Drop a membership row, refusing (`DaemonHoldsDuty`) while the daemon holds a live lease at
+   *  `now` — §3's stop-and-confirm, taken with the delete under the per-daemon fence so the
+   *  ledger cannot grant it one in between. */
+  withdraw(daemonId: DaemonId, now: Date): Promise<void>
 }
 
 // DutyGroupRepo (k8s daemons) — the CP-hosted duty ledger

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5020,6 +5020,9 @@ export interface MemberSetRepo {
   enroll(setId: string, daemonId: DaemonId): Promise<void>
   /** One org's sets, by name. The org-less pool is never among them — it belongs to no org. */
   listForOrg(orgId: string): Promise<MemberSetRecord[]>
+  /** Agents placed on each of these sets, in one query — the list read must not be N+1. Sets with
+   *  no agents are absent from the map, not zero-valued. */
+  agentCountsOf(setIds: readonly string[]): Promise<Map<string, number>>
   /** Create an org's set. The org-less pool is minted by migration and never through this. */
   createForOrg(orgId: string, name: string): Promise<MemberSetRecord>
   /** Rename one of an org's sets. Null ⇒ no such set in that org. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -179,6 +179,8 @@ export interface DaemonRecord {
   sessionRetention: string
   lastModifiedAt: Date // last human edit (provision/rename); defaults to createdAt
   lastModifiedBy: AgentCreator | null // WebUI user who last edited it; null ⇒ never edited by a human
+  /** The member set this daemon is in (daemon-groups.md §2); null ⇒ it owns its agents outright. */
+  memberSetId: string | null
 }
 
 export interface DaemonRepo {
@@ -5006,6 +5008,8 @@ export interface MemberSetRepo {
   get(setId: string): Promise<MemberSetRecord | null>
   /** Which set this daemon is a member of — the claim scope of its connection (§3). */
   setIdOf(daemonId: DaemonId): Promise<string | null>
+  /** That set whole — what `auth/ok` announces, so the daemon is told a name and not just an id. */
+  setOf(daemonId: DaemonId): Promise<MemberSetRecord | null>
   /** The set's members, sorted. The read path for "who could serve a `set`-placed agent". */
   memberIdsOf(setId: string): Promise<string[]>
   /** The set's members, sorted, but ONLY for a set whose members share one content store — the
@@ -5014,6 +5018,17 @@ export interface MemberSetRepo {
   sharedStoreMemberIdsOf(setId: string): Promise<string[]>
   /** Record a membership under the set's tenancy invariant; throws MemberSetTenancyMismatch. */
   enroll(setId: string, daemonId: DaemonId): Promise<void>
+  /** One org's sets, by name. The org-less pool is never among them — it belongs to no org. */
+  listForOrg(orgId: string): Promise<MemberSetRecord[]>
+  /** Create an org's set. The org-less pool is minted by migration and never through this. */
+  createForOrg(orgId: string, name: string): Promise<MemberSetRecord>
+  /** Rename one of an org's sets. Null ⇒ no such set in that org. */
+  renameForOrg(orgId: string, setId: string, name: string): Promise<MemberSetRecord | null>
+  /** Drop one of an org's sets. Refused while anything still points at it: throws
+   *  `MemberSetInUse` when it has members or `set`-placed agents. False ⇒ no such set. */
+  deleteForOrg(orgId: string, setId: string): Promise<boolean>
+  /** Drop a membership row. Idempotent; the caller owns the transition's safety (§3). */
+  withdraw(daemonId: DaemonId): Promise<void>
 }
 
 // DutyGroupRepo (k8s daemons) — the CP-hosted duty ledger

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -39,7 +39,7 @@ import { lockSkillSourceNameScopes } from '../skill-source-lock.js'
 import { tryLockMemoryConnectionScopes } from '../memory-connection-lock.js'
 import { PgHookRepo } from './hook.repo.js'
 import { lockAgentPlacement, revokeActiveWebchatMcpDelegations } from './agent-placement.js'
-import { assertAgentMayUseSet } from './member-set.repo.js'
+import { assertAgentMayUseSet, assertDaemonNotInSet } from './member-set.repo.js'
 
 /** An agent may be created already placed. A `set` placement names a set rather than a machine, so
  *  the create input carries a kind and the columns follow from it rather than from a daemon id. */
@@ -316,6 +316,7 @@ export class PgAgentRepo implements AgentRepo {
       // Third write-time invariant (daemon-groups.md §2): a create places too, so it takes it.
       if (input.placementKind === 'set' && input.setId)
         await assertAgentMayUseSet(tx, { id: input.id, orgId: input.orgId }, input.setId)
+      if (input.placementKind !== 'set' && input.daemonId) await assertDaemonNotInSet(tx, input.id, input.daemonId)
       const a = await tx.agent.create({
         data: {
           id: input.id,
@@ -831,6 +832,7 @@ export class PgAgentRepo implements AgentRepo {
       if (!current) return
       // Third write-time invariant (daemon-groups.md §2), inside the transaction that writes it.
       if (target.kind === 'set') await assertAgentMayUseSet(tx, { id: agentId, orgId: current.orgId }, target.setId)
+      if (target.kind === 'daemon') await assertDaemonNotInSet(tx, agentId, target.daemonId)
       const columns = placementColumns(target)
       await tx.agent.update({
         where: { id: agentId },
@@ -870,6 +872,7 @@ export class PgAgentRepo implements AgentRepo {
         const current = await lockAgentPlacement(tx, agentId)
         if (!current || !samePlacement(placementTargetOf(current), expected)) return null
         if (target.kind === 'set') await assertAgentMayUseSet(tx, { id: agentId, orgId: current.orgId }, target.setId)
+        if (target.kind === 'daemon') await assertDaemonNotInSet(tx, agentId, target.daemonId)
         const a = await tx.agent.update({
           where: {
             id: agentId,

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -28,8 +28,14 @@ import { lockResourceWriteMemberships } from '../resource-membership-lock.js'
 
 // The daemon row plus its joined creator + last-modifier users — every read that
 // feeds `toRecord` carries both joins so the console never needs a second query.
-type DaemonWithUsers = Daemon & { createdBy: User | null; lastModifiedBy: User | null }
-const withUsers = { createdBy: true, lastModifiedBy: true } as const
+type DaemonWithUsers = Daemon & {
+  createdBy: User | null
+  lastModifiedBy: User | null
+  // Membership rides every read: the console shows the set on the daemon, and it is what makes
+  // "pinned here" versus "claimable within a set" legible at all (daemon-groups.md §2).
+  setMembership?: { setId: string } | null
+}
+const withUsers = { createdBy: true, lastModifiedBy: true, setMembership: { select: { setId: true } } } as const
 
 function toRecord(d: DaemonWithUsers): DaemonRecord {
   return {
@@ -61,7 +67,8 @@ function toRecord(d: DaemonWithUsers): DaemonRecord {
     lastModifiedAt: d.lastModifiedAt,
     lastModifiedBy: d.lastModifiedBy
       ? { userId: d.lastModifiedBy.id, displayName: d.lastModifiedBy.displayName, email: d.lastModifiedBy.email }
-      : null
+      : null,
+    memberSetId: d.setMembership?.setId ?? null
   }
 }
 

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -369,15 +369,23 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
 
   async renewHeld(holder: DaemonId, now: Date, leaseMs: number): Promise<string[]> {
     const expiresAt = new Date(now.getTime() + leaseMs)
-    // Holder-conditional and term-preserving: a lapsed-but-unclaimed lease
-    // renews (the CP "confirms the same terms"); a reassigned one matches zero
-    // rows and the digest diff surfaces the supersession.
-    const rows = await this.prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
-      UPDATE "duty_group" SET "expiresAt" = ${expiresAt}, "updatedAt" = ${now}
-      WHERE "holder" = ${holder}::uuid
-      RETURNING id
-    `)
-    return rows.map((r) => r.id).sort()
+    return withTx(this.prisma, async (tx) => {
+      // Renewal REVIVES a lapsed lease — it carries no expiry predicate, by design ("the CP
+      // confirms the same terms"). So it is a lease-creating write as far as a withdrawal is
+      // concerned, and it takes the same membership fence the claim paths do: without it a beat
+      // landing just after a withdrawal read "nothing live" makes every lapsed group live again
+      // under a daemon that is no longer a member (daemon-groups.md §3).
+      await lockDaemonMembership(tx, holder)
+      // Holder-conditional and term-preserving: a lapsed-but-unclaimed lease
+      // renews; a reassigned one matches zero rows and the digest diff surfaces
+      // the supersession.
+      const rows = await tx.$queryRaw<{ id: string }[]>(Prisma.sql`
+        UPDATE "duty_group" SET "expiresAt" = ${expiresAt}, "updatedAt" = ${now}
+        WHERE "holder" = ${holder}::uuid
+        RETURNING id
+      `)
+      return rows.map((r) => r.id).sort()
+    })
   }
 
   async release(holder: DaemonId, groupIds: string[]): Promise<void> {

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -15,6 +15,7 @@ import type {
 } from '../ports.js'
 import type { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import { withTx } from '../prisma.js'
+import { lockDaemonMembership } from './member-set.repo.js'
 
 // Serializes the writers that CREATE or REWRITE rows for an org (applyReconcile
 // and claimAgentHome) — row locks cannot fence rows that do not exist yet.
@@ -331,6 +332,11 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     // SKIP LOCKED keeps racing claimants from queueing on each other's rows —
     // they simply take disjoint vacancies.
     return withTx(this.prisma, async (tx) => {
+      // The membership fence, before the claim reads eligibility from `member_set_member`: a
+      // withdrawal holding it has already decided this member holds nothing live, and a grant
+      // committing after that decision would hand work to a machine that is about to stop being
+      // a member (daemon-groups.md §3).
+      await lockDaemonMembership(tx, holder)
       const granted = await tx.$queryRaw<Row[]>(Prisma.sql`
         WITH picked AS (
           SELECT id FROM "duty_group"
@@ -563,6 +569,9 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       // Org scope fences row creation against applyReconcile; the FOR UPDATE row
       // lock below fences the lease against claimVacant/renewHeld/release.
       await lockOrgDutyScope(tx, orgId)
+      // The membership fence: eligibility is a `member_set_member` lookup, so a withdrawal that
+      // decided this member was idle must not have a lease appear under it afterwards.
+      await lockDaemonMembership(tx, holder)
       // The rendezvous is a claim path, so it takes the same eligibility gate — inside the
       // transaction, against the live row, because this path can MINT a group and a check made
       // before the lock would let a member reach through it for an agent it may not hold.

--- a/packages/control-plane/src/persistence/repositories/member-set.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/member-set.repo.ts
@@ -111,6 +111,16 @@ export class PgMemberSetRepo implements MemberSetRepo {
     return rows.map((r) => ({ id: r.id, orgId: r.orgId, name: r.name }))
   }
 
+  async agentCountsOf(setIds: readonly string[]): Promise<Map<string, number>> {
+    if (setIds.length === 0) return new Map()
+    const rows = await this.prisma.agent.groupBy({
+      by: ['setId'],
+      where: { setId: { in: [...setIds] } },
+      _count: { _all: true }
+    })
+    return new Map(rows.flatMap((r) => (r.setId ? [[r.setId, r._count._all] as const] : [])))
+  }
+
   async createForOrg(orgId: string, name: string): Promise<MemberSetRecord> {
     const row = await this.prisma.memberSet.create({ data: { id: randomUUID(), orgId, name } })
     return { id: row.id, orgId: row.orgId, name: row.name }

--- a/packages/control-plane/src/persistence/repositories/member-set.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/member-set.repo.ts
@@ -228,6 +228,14 @@ export class PgMemberSetRepo implements MemberSetRepo {
       const live = Number(held?.n ?? 0n)
       if (live > 0) throw new DaemonHoldsDuty(daemonId, live)
       await tx.memberSetMember.deleteMany({ where: { daemonId } })
+      // Vacate what it still nominally holds, as §3's commit step says. Every one of these is
+      // already lapsed — the check above just proved it — so this takes nothing from anyone; what
+      // it removes is the ex-member's ability to REVIVE them, since renewal is holder-conditional
+      // and carries no expiry predicate. `term` is untouched: monotonicity is the whole token.
+      await tx.dutyGroup.updateMany({
+        where: { holder: daemonId },
+        data: { holder: null, expiresAt: null, confirmedTerm: null, confirmedHolder: null }
+      })
     })
   }
 }

--- a/packages/control-plane/src/persistence/repositories/member-set.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/member-set.repo.ts
@@ -1,17 +1,18 @@
 /**
  * Member sets — the named sets of daemons within which an agent's duty may be claimed
- * (docs/designs/daemon-groups.md §2). The install-wide pool is the ONE org-less row; org sets
- * arrive with the console CRUD in PR 2.
+ * (docs/designs/daemon-groups.md §2). The install-wide pool is the ONE org-less row; an org's own
+ * sets are rows with its `orgId`, created by an operator.
  *
  * Everything tenancy-shaped lives on the WRITE side here. `enrollDaemonInSet` is the only writer
  * of `member_set_member`, and it is where "an org-less set accepts only org-less daemons, an org
  * set only that org's daemons" is enforced — which is precisely what lets the ledger's read path
  * be one membership lookup with no tenancy branch.
  */
+import { randomUUID } from 'node:crypto'
 import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
 import type { DaemonId } from '../../domain/ids.js'
 import type { MemberSetRecord, MemberSetRepo } from '../ports.js'
-import { AgentSetPlacementDenied, MemberSetTenancyMismatch } from '../errors.js'
+import { AgentSetPlacementDenied, DaemonPlacementInSet, MemberSetInUse, MemberSetTenancyMismatch } from '../errors.js'
 
 /** The ONLY writer of `member_set_member`: the set's org and the daemon's org must be the same
  *  value, null (cross-org) included, or the row is refused. */
@@ -46,6 +47,22 @@ export async function assertAgentMayUseSet(
   if (!row || (row.orgId !== null && row.orgId !== agent.orgId)) throw new AgentSetPlacementDenied(agent.id, setId)
 }
 
+/**
+ * The converse of that invariant, and the reason it can be enforced statically (§3): a `daemon`
+ * placement may not name a machine that is in a set. Such a machine serves only what it holds a
+ * lease for, so an agent pinned to it would be placed and unservable at once.
+ */
+export async function assertDaemonNotInSet(
+  tx: Prisma.TransactionClient,
+  agentId: string,
+  daemonId: string
+): Promise<void> {
+  const [row] = await tx.$queryRaw<{ one: number }[]>(
+    Prisma.sql`SELECT 1 AS one FROM "member_set_member" WHERE "daemonId" = ${daemonId}::uuid`
+  )
+  if (row) throw new DaemonPlacementInSet(agentId, daemonId)
+}
+
 export class PgMemberSetRepo implements MemberSetRepo {
   constructor(private readonly prisma: PrismaClient) {}
 
@@ -62,6 +79,11 @@ export class PgMemberSetRepo implements MemberSetRepo {
   async setIdOf(daemonId: DaemonId): Promise<string | null> {
     const row = await this.prisma.memberSetMember.findUnique({ where: { daemonId }, select: { setId: true } })
     return row?.setId ?? null
+  }
+
+  async setOf(daemonId: DaemonId): Promise<MemberSetRecord | null> {
+    const row = await this.prisma.memberSetMember.findUnique({ where: { daemonId }, select: { set: true } })
+    return row ? { id: row.set.id, orgId: row.set.orgId, name: row.set.name } : null
   }
 
   async memberIdsOf(setId: string): Promise<string[]> {
@@ -82,5 +104,40 @@ export class PgMemberSetRepo implements MemberSetRepo {
 
   async enroll(setId: string, daemonId: DaemonId): Promise<void> {
     await this.prisma.$transaction((tx) => enrollDaemonInSet(tx, setId, daemonId))
+  }
+
+  async listForOrg(orgId: string): Promise<MemberSetRecord[]> {
+    const rows = await this.prisma.memberSet.findMany({ where: { orgId }, orderBy: { name: 'asc' } })
+    return rows.map((r) => ({ id: r.id, orgId: r.orgId, name: r.name }))
+  }
+
+  async createForOrg(orgId: string, name: string): Promise<MemberSetRecord> {
+    const row = await this.prisma.memberSet.create({ data: { id: randomUUID(), orgId, name } })
+    return { id: row.id, orgId: row.orgId, name: row.name }
+  }
+
+  async renameForOrg(orgId: string, setId: string, name: string): Promise<MemberSetRecord | null> {
+    const { count } = await this.prisma.memberSet.updateMany({ where: { id: setId, orgId }, data: { name } })
+    return count === 0 ? null : { id: setId, orgId, name }
+  }
+
+  async deleteForOrg(orgId: string, setId: string): Promise<boolean> {
+    return this.prisma.$transaction(async (tx) => {
+      const row = await tx.memberSet.findFirst({ where: { id: setId, orgId }, select: { id: true } })
+      if (!row) return false
+      // Both cascades are silent — `member_set_member` is Cascade and `Agent.setId` is SetNull —
+      // so a set with either still pointing at it is refused rather than emptied on the way out.
+      const [members, agents] = await Promise.all([
+        tx.memberSetMember.count({ where: { setId } }),
+        tx.agent.count({ where: { setId } })
+      ])
+      if (members > 0 || agents > 0) throw new MemberSetInUse(setId)
+      await tx.memberSet.delete({ where: { id: setId } })
+      return true
+    })
+  }
+
+  async withdraw(daemonId: DaemonId): Promise<void> {
+    await this.prisma.memberSetMember.deleteMany({ where: { daemonId } })
   }
 }

--- a/packages/control-plane/src/persistence/repositories/member-set.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/member-set.repo.ts
@@ -36,7 +36,8 @@ import {
   MemberSetInUse,
   MemberSetTenancyMismatch,
   DaemonHasPlacedAgents,
-  DaemonHoldsDuty
+  DaemonHoldsDuty,
+  DaemonAlreadyInSet
 } from '../errors.js'
 
 /**
@@ -159,6 +160,16 @@ export class PgMemberSetRepo implements MemberSetRepo {
       // would be placed and unservable the moment this row lands. `assertDaemonNotInSet` takes the
       // same lock, so a placement racing this one either loses the machine or loses the pin.
       await lockDaemonMembership(tx, daemonId)
+      // Re-read membership UNDER the lock. The insert is idempotent, so the losing half of two
+      // concurrent enrolments into different sets would otherwise no-op and still answer success,
+      // naming a set the daemon never joined. Re-entering the set it is already in stays a no-op.
+      const [current] = await tx.$queryRaw<{ setId: string }[]>(
+        Prisma.sql`SELECT "setId" FROM "member_set_member" WHERE "daemonId" = ${daemonId}::uuid`
+      )
+      if (current) {
+        if (current.setId !== setId) throw new DaemonAlreadyInSet(daemonId, current.setId)
+        return
+      }
       const [pinned] = await tx.$queryRaw<{ n: bigint }[]>(
         Prisma.sql`SELECT count(*) AS n FROM "agent" WHERE "daemonId" = ${daemonId}::uuid`
       )

--- a/packages/control-plane/src/persistence/repositories/member-set.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/member-set.repo.ts
@@ -7,22 +7,68 @@
  * of `member_set_member`, and it is where "an org-less set accepts only org-less daemons, an org
  * set only that org's daemons" is enforced — which is precisely what lets the ledger's read path
  * be one membership lookup with no tenancy branch.
+ *
+ * ## The two fences
+ *
+ * Every invariant here is a check paired with a write, and both halves have concurrent writers, so
+ * each pair needs something to serialize on:
+ *
+ * - **Per daemon** — {@link lockDaemonMembership}, an advisory transaction lock every writer of
+ *   "is this daemon in a set" and every reader that acts on the answer takes: enrolment,
+ *   withdrawal, the `daemon`-placement guard, and the ledger's two claim paths. Without it, a
+ *   placement that read "in no set" and an enrolment that read "no pinned agents" both commit and
+ *   leave a set member with a pinned, unservable agent; or a claim commits a live lease onto a
+ *   member the withdrawal has just decided was idle.
+ * - **Per set** — the `member_set` row itself, read `FOR SHARE` by everything that adds a
+ *   reference to it and `FOR UPDATE` by the delete. Counting references without that lets a
+ *   placement land after the count and be silently `SET NULL`ed by the cascade.
+ *
+ * Both are ordinary Postgres, taken inside the transaction that writes, so they hold across
+ * control-plane instances rather than only within one process.
  */
 import { randomUUID } from 'node:crypto'
 import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
 import type { DaemonId } from '../../domain/ids.js'
 import type { MemberSetRecord, MemberSetRepo } from '../ports.js'
-import { AgentSetPlacementDenied, DaemonPlacementInSet, MemberSetInUse, MemberSetTenancyMismatch } from '../errors.js'
+import {
+  AgentSetPlacementDenied,
+  DaemonPlacementInSet,
+  MemberSetInUse,
+  MemberSetTenancyMismatch,
+  DaemonHasPlacedAgents,
+  DaemonHoldsDuty
+} from '../errors.js'
+
+/**
+ * The per-daemon membership fence. Held for the rest of the transaction, so a check and the write
+ * it justifies are one step to every other writer. Keyed on the daemon alone: two daemons never
+ * contend, and the ledger's claim paths are already serialized per member.
+ */
+export async function lockDaemonMembership(tx: Prisma.TransactionClient, daemonId: string): Promise<void> {
+  const key = JSON.stringify(['member-set-membership', daemonId])
+  await tx.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0)) IS NULL AS "locked"`)
+}
+
+/** The per-set reference fence, reader side: the set may not be deleted while this transaction
+ *  adds something that points at it. Null ⇒ no such set. */
+async function shareSetRow(tx: Prisma.TransactionClient, setId: string): Promise<{ orgId: string | null } | null> {
+  const [row] = await tx.$queryRaw<{ orgId: string | null }[]>(
+    Prisma.sql`SELECT "orgId" FROM "member_set" WHERE id = ${setId}::uuid FOR SHARE`
+  )
+  return row ?? null
+}
 
 /** The ONLY writer of `member_set_member`: the set's org and the daemon's org must be the same
- *  value, null (cross-org) included, or the row is refused. */
+ *  value, null (cross-org) included, or the row is refused. Takes both fences — the daemon's,
+ *  so a concurrent placement cannot pin an agent to the machine it is enrolling, and the set's,
+ *  so a concurrent delete cannot drop the set this row points at. */
 export async function enrollDaemonInSet(tx: Prisma.TransactionClient, setId: string, daemonId: string): Promise<void> {
-  const [pair] = await tx.$queryRaw<{ setOrgId: string | null; daemonOrgId: string | null }[]>(Prisma.sql`
-    SELECT s."orgId" AS "setOrgId", d."orgId" AS "daemonOrgId"
-    FROM "member_set" s, "daemon" d
-    WHERE s.id = ${setId}::uuid AND d.id = ${daemonId}::uuid
-  `)
-  if (!pair || pair.setOrgId !== pair.daemonOrgId) throw new MemberSetTenancyMismatch(setId, daemonId)
+  await lockDaemonMembership(tx, daemonId)
+  const set = await shareSetRow(tx, setId)
+  const [daemon] = await tx.$queryRaw<{ orgId: string | null }[]>(
+    Prisma.sql`SELECT "orgId" FROM "daemon" WHERE id = ${daemonId}::uuid`
+  )
+  if (!set || !daemon || set.orgId !== daemon.orgId) throw new MemberSetTenancyMismatch(setId, daemonId)
   // Idempotent: re-auth re-enrolls the same member. Moving a daemon BETWEEN sets is a two-phase
   // generation-fenced transition (§3), never this path, so a conflicting row is left alone.
   await tx.$executeRaw(Prisma.sql`
@@ -34,29 +80,29 @@ export async function enrollDaemonInSet(tx: Prisma.TransactionClient, setId: str
 /**
  * The third write-time invariant, taken inside the transaction that writes the placement: a
  * `set`-placed agent may reference only the org-less set or a set of its own org. The read path
- * never re-checks it.
+ * never re-checks it. `FOR SHARE` so the set cannot be deleted out from under the placement.
  */
 export async function assertAgentMayUseSet(
   tx: Prisma.TransactionClient,
   agent: { id: string; orgId: string },
   setId: string
 ): Promise<void> {
-  const [row] = await tx.$queryRaw<{ orgId: string | null }[]>(
-    Prisma.sql`SELECT "orgId" FROM "member_set" WHERE id = ${setId}::uuid`
-  )
+  const row = await shareSetRow(tx, setId)
   if (!row || (row.orgId !== null && row.orgId !== agent.orgId)) throw new AgentSetPlacementDenied(agent.id, setId)
 }
 
 /**
  * The converse of that invariant, and the reason it can be enforced statically (§3): a `daemon`
  * placement may not name a machine that is in a set. Such a machine serves only what it holds a
- * lease for, so an agent pinned to it would be placed and unservable at once.
+ * lease for, so an agent pinned to it would be placed and unservable at once. Under the daemon
+ * fence, so this cannot race an enrolment that is deciding the machine has nothing pinned to it.
  */
 export async function assertDaemonNotInSet(
   tx: Prisma.TransactionClient,
   agentId: string,
   daemonId: string
 ): Promise<void> {
+  await lockDaemonMembership(tx, daemonId)
   const [row] = await tx.$queryRaw<{ one: number }[]>(
     Prisma.sql`SELECT 1 AS one FROM "member_set_member" WHERE "daemonId" = ${daemonId}::uuid`
   )
@@ -106,6 +152,22 @@ export class PgMemberSetRepo implements MemberSetRepo {
     await this.prisma.$transaction((tx) => enrollDaemonInSet(tx, setId, daemonId))
   }
 
+  async enrollOperator(setId: string, daemonId: DaemonId): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      // The precondition and the row in ONE transaction under the daemon fence (§3): a machine
+      // that enforces duties serves only what it holds a lease for, so an agent still pinned to it
+      // would be placed and unservable the moment this row lands. `assertDaemonNotInSet` takes the
+      // same lock, so a placement racing this one either loses the machine or loses the pin.
+      await lockDaemonMembership(tx, daemonId)
+      const [pinned] = await tx.$queryRaw<{ n: bigint }[]>(
+        Prisma.sql`SELECT count(*) AS n FROM "agent" WHERE "daemonId" = ${daemonId}::uuid`
+      )
+      const placed = Number(pinned?.n ?? 0n)
+      if (placed > 0) throw new DaemonHasPlacedAgents(daemonId, placed)
+      await enrollDaemonInSet(tx, setId, daemonId)
+    })
+  }
+
   async listForOrg(orgId: string): Promise<MemberSetRecord[]> {
     const rows = await this.prisma.memberSet.findMany({ where: { orgId }, orderBy: { name: 'asc' } })
     return rows.map((r) => ({ id: r.id, orgId: r.orgId, name: r.name }))
@@ -133,7 +195,12 @@ export class PgMemberSetRepo implements MemberSetRepo {
 
   async deleteForOrg(orgId: string, setId: string): Promise<boolean> {
     return this.prisma.$transaction(async (tx) => {
-      const row = await tx.memberSet.findFirst({ where: { id: setId, orgId }, select: { id: true } })
+      // `FOR UPDATE` on the set row is the reference fence's writer side: every path that adds a
+      // reference reads the same row `FOR SHARE` first, so nothing can commit a member or a
+      // placement between the counts below and the delete.
+      const [row] = await tx.$queryRaw<{ id: string }[]>(
+        Prisma.sql`SELECT id FROM "member_set" WHERE id = ${setId}::uuid AND "orgId" = ${orgId} FOR UPDATE`
+      )
       if (!row) return false
       // Both cascades are silent — `member_set_member` is Cascade and `Agent.setId` is SetNull —
       // so a set with either still pointing at it is refused rather than emptied on the way out.
@@ -147,7 +214,20 @@ export class PgMemberSetRepo implements MemberSetRepo {
     })
   }
 
-  async withdraw(daemonId: DaemonId): Promise<void> {
-    await this.prisma.memberSetMember.deleteMany({ where: { daemonId } })
+  async withdraw(daemonId: DaemonId, now: Date): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      // Stop-and-confirm, as one step (§3). Under the daemon fence the ledger's claim paths cannot
+      // hand this member a lease between the check and the delete, so "it holds nothing live" is
+      // still true at the moment it stops being a member — which is what keeps a successor from
+      // taking work the leaver may still be running.
+      await lockDaemonMembership(tx, daemonId)
+      const [held] = await tx.$queryRaw<{ n: bigint }[]>(Prisma.sql`
+        SELECT count(*) AS n FROM "duty_group"
+        WHERE "holder" = ${daemonId}::uuid AND "expiresAt" IS NOT NULL AND "expiresAt" > ${now}
+      `)
+      const live = Number(held?.n ?? 0n)
+      if (live > 0) throw new DaemonHoldsDuty(daemonId, live)
+      await tx.memberSetMember.deleteMany({ where: { daemonId } })
+    })
   }
 }

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -29,7 +29,9 @@ export interface ClientCtx {
 
 /** Outcome of `DaemonAuth.authenticate` (design §2.3). */
 export type AuthResult =
-  | { ok: true; daemonId: DaemonId; orgId: OrgId | null; okFrame: AuthOk }
+  // `setId` is the connection's claim scope (daemon-groups.md §3), resolved once here so the
+  // duty handlers read it off the connection instead of asking the ledger on every frame.
+  | { ok: true; daemonId: DaemonId; orgId: OrgId | null; setId: string | null; okFrame: AuthOk }
   | { ok: false; closeCode: 4401 | 4409 | 1011; reason: string }
 
 /**
@@ -239,6 +241,9 @@ export interface DaemonView {
   sharedWith: string[]
   /** Console-set finished-session retention window ('never' | '7d' | '30d' | '90d'). */
   sessionRetention: string
+  /** The member set this daemon belongs to, if any (daemon-groups.md §2) — null for a machine
+   *  that owns its agents outright. An install-wide daemon is always the org-less set's. */
+  memberSetId: string | null
 }
 
 /**
@@ -254,6 +259,11 @@ export interface DaemonLiveness {
   get(daemonId: string): { state: string; reachable: boolean; sessionEpoch: number } | undefined
   /** Close the same non-READY epoch so an auth-time bootstrap directive cannot be missed. */
   reconnectForBootstrap?(daemonId: string, sessionEpoch: number): boolean
+  /** Close this daemon's socket so it handshakes again. `auth/ok` is where a daemon learns its
+   *  member set (daemon-groups.md §3), so that is how a membership change reaches a connected
+   *  one — no wire negotiation, and the reconnect's register reconcile settles the rest.
+   *  False ⇒ nothing was connected, and the daemon will read the change on its next auth. */
+  reconnectForMemberSet?(daemonId: string): boolean
 }
 
 /**

--- a/packages/control-plane/src/registry/authService.test.ts
+++ b/packages/control-plane/src/registry/authService.test.ts
@@ -47,6 +47,11 @@ function makeEpoch(bump: () => Promise<{ sessionEpoch: bigint }>): EpochService 
   return { bumpSessionEpoch: bump } as unknown as EpochService
 }
 
+/** The pool, as the ledger's one org-less set. `auth/ok` announces it, and it is the whole
+ *  reason the daemon on the other end enforces duty leases at all (daemon-groups.md §3). */
+const POOL_SET = { id: '9f11e5e7-0000-4000-8000-000000000001', orgId: null, name: 'Cloud' }
+const memberSets = { setOf: async () => POOL_SET }
+
 function svc(
   repo: ApiKeyRepo,
   epoch: EpochService,
@@ -59,7 +64,8 @@ function svc(
     epoch,
     clock,
     { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs, WEB_APP_URL: webAppUrl },
-    orgs
+    orgs,
+    memberSets
   )
 }
 
@@ -78,6 +84,55 @@ describe('DaemonAuthService.authenticate — close-code contract', () => {
     expect(r.okFrame.dutyLeaseMs).toBe(DUTY_LEASE_DEFAULTS.leaseMs)
     expect(r.okFrame.webAppUrl).toBeUndefined() // omitted when WEB_APP_URL is unset
     expect(repo.touchLastUsed).toHaveBeenCalledOnce()
+  })
+
+  it('announces the daemon’s member set — the daemon’s whole duty-enforcement predicate', async () => {
+    const { token } = codec.mint()
+    const r = await svc(makeRepo(), okEpoch).authenticate({ apiKey: token, agentVersion: '1' }, ctx)
+    if (!r.ok) throw new Error('expected ok')
+    expect(r.okFrame.memberSet).toEqual({ setId: POOL_SET.id, name: POOL_SET.name })
+    // The connection carries it too, so the duty handlers read a set instead of asking per frame.
+    expect(r.setId).toBe(POOL_SET.id)
+  })
+
+  it('announces no set for a daemon in none, and that daemon owns its agents outright', async () => {
+    const { token } = codec.mint()
+    const service = new DaemonAuthService(
+      codec,
+      makeRepo(),
+      okEpoch,
+      clock,
+      { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs },
+      { slugById: async () => null },
+      { setOf: async () => null }
+    )
+    const r = await service.authenticate({ apiKey: token, agentVersion: '1' }, ctx)
+    if (!r.ok) throw new Error('expected ok')
+    expect(r.okFrame.memberSet).toBeUndefined()
+    expect(r.setId).toBeNull()
+  })
+
+  it('fails the handshake 1011 when the membership cannot be read — never “in no set” by accident', async () => {
+    // Silently announcing no set would make a pool member serve its agents unfenced. A retry is
+    // the only safe answer to a blip here.
+    const { token } = codec.mint()
+    const service = new DaemonAuthService(
+      codec,
+      makeRepo(),
+      okEpoch,
+      clock,
+      { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs },
+      { slugById: async () => null },
+      {
+        setOf: async () => {
+          throw new Error('db down')
+        }
+      }
+    )
+    expect(await service.authenticate({ apiKey: token, agentVersion: '1' }, ctx)).toMatchObject({
+      ok: false,
+      closeCode: 1011
+    })
   })
 
   it('includes the configured Web App URL in auth/ok (for daemon session deep links)', async () => {
@@ -203,6 +258,7 @@ describe('DaemonAuthService.authenticate — the in-cluster token path', () => {
       clock,
       { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs },
       orgs,
+      memberSets,
       { verify }
     )
   }
@@ -251,6 +307,7 @@ describe('DaemonAuthService.authenticate — the in-cluster token path', () => {
       clock,
       { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs },
       orgs,
+      memberSets,
       {
         verify: async () => null
       }

--- a/packages/control-plane/src/registry/authService.ts
+++ b/packages/control-plane/src/registry/authService.ts
@@ -24,7 +24,7 @@
  */
 import type { AuthReq, AuthOk } from '@agentconnect.md/protocol'
 import type { AuthResult, ClientCtx, ClusterDaemonIdentity, DaemonAuth, VerifiedClusterDaemon } from '../ports.js'
-import type { ApiKeyRepo, OrgRepo } from '../persistence/ports.js'
+import type { ApiKeyRepo, MemberSetRepo, OrgRepo } from '../persistence/ports.js'
 import type { EpochService } from '../orchestrator/epoch.js'
 import type { Clock } from '../domain/clock.js'
 import { DaemonId, OrgId } from '../domain/ids.js'
@@ -51,6 +51,10 @@ export class DaemonAuthService implements DaemonAuth {
     // Resolves the daemon's org slug for the org-scoped session deep link. Only `slugById`
     // is used; a failed lookup degrades to no `orgSlug` (never fails the handshake).
     private readonly orgs: Pick<OrgRepo, 'slugById'>,
+    /** The set this connection may claim within (daemon-groups.md §3), announced on `auth/ok`.
+     *  NOT optional: a missing reader would hand every member `auth/ok` with no set, and the whole
+     *  duty ledger would go quiet — a wiring hole must not be able to look like an empty pool. */
+    private readonly memberSets: Pick<MemberSetRepo, 'setOf'>,
     /** Absent when this deployment provisions no clusters — then only the key path exists. */
     private readonly clusterIdentity?: ClusterDaemonIdentity
   ) {}
@@ -144,6 +148,16 @@ export class DaemonAuthService implements DaemonAuth {
     // not fail an otherwise-good auth — the daemon just omits the org segment if absent.
     const orgSlug = orgId ? await this.orgs.slugById(OrgId(orgId)).catch(() => null) : null
 
+    // The daemon's member set (daemon-groups.md §3). NOT best-effort: an unread membership would
+    // hand a set member `auth/ok` with no set, and it would then serve its agents outright instead
+    // of only what it holds a lease for. A blip is 1011 — the daemon retries.
+    let memberSet
+    try {
+      memberSet = await this.memberSets.setOf(DaemonId(daemonId))
+    } catch {
+      return { ok: false, closeCode: 1011, reason: 'SERVER_INTERNAL' }
+    }
+
     const okFrame: AuthOk = {
       daemonId, // authoritative id (what the credential resolves to) — the daemon adopts this
       sessionEpoch: Number(sessionEpoch), // wire is a JS number; DB stores bigint
@@ -155,10 +169,17 @@ export class DaemonAuthService implements DaemonAuth {
       organizationMode: orgId ? 'connection' : 'frame',
       ...(this.config.WEB_APP_URL ? { webAppUrl: this.config.WEB_APP_URL } : {}),
       ...(orgSlug ? { orgSlug } : {}),
+      ...(memberSet ? { memberSet: { setId: memberSet.id, name: memberSet.name } } : {}),
       // A reconnecting daemon (resume present) is told to do a full register reconcile.
       ...(req.resume ? { resume: { accepted: false } } : {})
     }
 
-    return { ok: true, daemonId: DaemonId(daemonId), orgId: orgId ? OrgId(orgId) : null, okFrame }
+    return {
+      ok: true,
+      daemonId: DaemonId(daemonId),
+      orgId: orgId ? OrgId(orgId) : null,
+      setId: memberSet?.id ?? null,
+      okFrame
+    }
   }
 }

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -88,7 +88,8 @@ function toView(d: DaemonRecord, profiles: RuntimeProfileRecord[]): DaemonView {
     createdByUserId: d.createdByUserId,
     visibility: d.visibility,
     sharedWith: d.sharedWith,
-    sessionRetention: d.sessionRetention
+    sessionRetention: d.sessionRetention,
+    memberSetId: d.memberSetId
   }
 }
 

--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -36,6 +36,10 @@ export class DaemonConnection implements ConnChannel {
   daemonId = '' // set on auth/ok; "" until then (ConnChannel requires a string)
   /** Auth-scoped org; null for an install-wide pool member. */
   orgId: string | null = null
+  /** The member set this connection may claim duties within (daemon-groups.md §3), resolved at
+   *  auth; null ⇒ in no set, and the duty handlers refuse it. Tenancy is NOT re-checked from it:
+   *  the write-time invariants on membership already decide what being in this set means. */
+  setId: string | null = null
   /** Current fencing epoch for this daemon (set on auth/ok). */
   sessionEpoch = 0
   /** Per-agent fencing baseline (current launch + next-expected inbound seq). */

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -17,6 +17,7 @@ import type {
   IntegrationChannelRepo,
   CronRepo,
   HookRepo,
+  MemberSetRepo,
   AgentRepo,
   ExternalMemoryConnectionRepo,
   WebchatConversationRepo,
@@ -104,6 +105,9 @@ export interface DaemonWsDeps {
   collabRoutes: CollabRoutesService
   /** The duty lease exchange riding the heartbeat (k8s daemons). */
   dutyLease: DutyLeaseService
+  /** The set a connection may claim duties within (daemon-groups.md §3), re-read once the
+   *  connection is registered so a membership change cannot slip through the handshake. */
+  memberSets: Pick<MemberSetRepo, 'setIdOf'>
   /** Assembles one agent's complete installable definition for `duty/fetch` —
    *  the same bundle an `agent/activate` carries; absent ⇒ the fetch answers
    *  empty and the member installs nothing. */

--- a/packages/control-plane/src/ws/handlers/auth.ts
+++ b/packages/control-plane/src/ws/handlers/auth.ts
@@ -9,6 +9,7 @@
  * `auth/ok` REP (`corr` = the `auth` frame id) is sent.
  */
 import { CloseCode, isFrame } from '@agentconnect.md/protocol'
+import { DaemonId } from '../../domain/ids.js'
 import type { Handler } from './index.js'
 
 export const handleAuth: Handler = async (frame, conn, deps) => {
@@ -58,6 +59,18 @@ export const handleAuth: Handler = async (frame, conn, deps) => {
     orgByMcpServer: new Map(),
     orgByMemoryConnection: new Map()
   })
+
+  // Membership is re-read AFTER the connection is in the registry (daemon-groups.md §3). A change
+  // that commits before this read is seen here; one that commits after finds the connection and
+  // closes it. Reading only during `authenticate` left the window between: the change would close
+  // nothing, and this socket would carry the stale set for as long as it stayed up. Answering a
+  // mismatch by closing our own socket costs one reconnect in a race nobody will ever observe,
+  // and needs no extra state to detect.
+  const settledSetId = await deps.memberSets.setIdOf(DaemonId(verdict.daemonId)).catch(() => verdict.setId)
+  if (settledSetId !== verdict.setId) {
+    conn.close(1012, 'member set changed during the handshake — reconnect to re-register')
+    return
+  }
 
   let okFrame = verdict.okFrame
   if (req.bootstrapProtocolVersion === 1) {

--- a/packages/control-plane/src/ws/handlers/auth.ts
+++ b/packages/control-plane/src/ws/handlers/auth.ts
@@ -66,7 +66,17 @@ export const handleAuth: Handler = async (frame, conn, deps) => {
   // nothing, and this socket would carry the stale set for as long as it stayed up. Answering a
   // mismatch by closing our own socket costs one reconnect in a race nobody will ever observe,
   // and needs no extra state to detect.
-  const settledSetId = await deps.memberSets.setIdOf(DaemonId(verdict.daemonId)).catch(() => verdict.setId)
+  //
+  // Fails CLOSED, exactly like the lookup that built `auth/ok`: this read IS the window's only
+  // guard, so treating a blip as "the old value still holds" would re-open the hole it exists to
+  // close. 1011 is transient to the daemon — it retries.
+  let settledSetId: string | null
+  try {
+    settledSetId = await deps.memberSets.setIdOf(DaemonId(verdict.daemonId))
+  } catch {
+    conn.close(1011, 'SERVER_INTERNAL')
+    return
+  }
   if (settledSetId !== verdict.setId) {
     conn.close(1012, 'member set changed during the handshake — reconnect to re-register')
     return

--- a/packages/control-plane/src/ws/handlers/auth.ts
+++ b/packages/control-plane/src/ws/handlers/auth.ts
@@ -27,6 +27,7 @@ export const handleAuth: Handler = async (frame, conn, deps) => {
 
   conn.daemonId = verdict.daemonId
   conn.orgId = verdict.orgId
+  conn.setId = verdict.setId
   conn.sessionEpoch = verdict.okFrame.sessionEpoch
   conn.state = 'REGISTERING'
 

--- a/packages/control-plane/src/ws/handlers/duty-claim.ts
+++ b/packages/control-plane/src/ws/handlers/duty-claim.ts
@@ -3,22 +3,28 @@
 // here. Winning creates or takes the lease and the member serves the trigger;
 // losing names the incumbent so the relay can re-route in one more hop.
 import { isFrame } from '@agentconnect.md/protocol'
-import { AgentId, DaemonId } from '../../domain/ids.js'
+import { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import type { Handler } from './index.js'
 
 export const handleDutyClaim: Handler = async (frame, conn, deps) => {
   if (!isFrame('duty/claim')(frame)) return
-  // The duty ledger is install-wide: an org-scoped connection never holds duties.
-  if (conn.orgId !== null) {
-    conn.sendError(frame.id, 'SCOPE_DENIED', 'duty ledger requires an install-wide connection', false)
+  // The ledger's door (daemon-groups.md §3): whoever is in a member set may claim, whatever its
+  // tenancy; a connection in no set holds its agents outright and never enters the ledger. The
+  // per-agent narrowing is the predicate's, inside the transaction.
+  if (conn.setId === null) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'duty ledger requires membership in a member set', false)
     return
   }
   const agentId = AgentId(frame.payload.agentId)
-  // The CP resolves the org from the agent itself — a claimant never asserts it.
+  // The CP resolves the org from the agent itself — a claimant never asserts it. An org-scoped
+  // member reads org-fenced: the write-time invariants make it ineligible for every other org's
+  // agents anyway, so nothing is lost by never loading one.
   // Install-wide read (INSTALL_WIDE_FRAME_TYPES): `duty/claim` carries no org by design,
   // because the member is asking about an agent it does not yet serve.
-  // eslint-disable-next-line no-restricted-syntax -- install-wide rendezvous frame, no frame org exists
-  const agent = await deps.agent.getUnscoped(agentId)
+  const agent = conn.orgId
+    ? await deps.agent.get(OrgId(conn.orgId), agentId)
+    : // eslint-disable-next-line no-restricted-syntax -- install-wide rendezvous frame, no frame org exists
+      await deps.agent.getUnscoped(agentId)
   if (!agent) {
     conn.replyTo(frame, 'duty/claim/ok', { granted: false })
     return

--- a/packages/control-plane/src/ws/handlers/duty-fetch.test.ts
+++ b/packages/control-plane/src/ws/handlers/duty-fetch.test.ts
@@ -12,6 +12,7 @@ const AGENT = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const INTEGRATION = '11111111-1111-4111-8111-111111111111'
 const CRON = '22222222-2222-4222-8222-222222222222'
 const ORG = 'org-a'
+const SET = '33333333-3333-4333-8333-333333333333'
 
 const AGENT_RECORD = { id: AGENT, orgId: ORG, daemonId: DAEMON }
 
@@ -52,11 +53,12 @@ function fetchFrame(agentId = AGENT, orgId: string | null = ORG): AnyFrame {
   } as AnyFrame
 }
 
-/** An install-wide connection — the only kind that can hold duties. */
-function fakeConn(orgId: string | null = null) {
+/** A connection in a member set — the only kind that can hold duties (daemon-groups.md §3). */
+function fakeConn(orgId: string | null = null, setId: string | null = SET) {
   return {
     daemonId: DAEMON,
     orgId,
+    setId,
     replyTo: vi.fn(),
     sendError: vi.fn()
   } as unknown as DaemonConnection & { replyTo: ReturnType<typeof vi.fn>; sendError: ReturnType<typeof vi.fn> }
@@ -85,8 +87,8 @@ function fakeDeps(
 }
 
 describe('handleDutyFetch', () => {
-  it('refuses an org-scoped connection — the duty ledger is install-wide', async () => {
-    const conn = fakeConn(ORG)
+  it('refuses a connection in no member set — membership is the door', async () => {
+    const conn = fakeConn(ORG, null)
     const agentBundle = vi.fn(async () => BUNDLE)
     const frame = fetchFrame()
 
@@ -95,11 +97,24 @@ describe('handleDutyFetch', () => {
     expect(conn.sendError).toHaveBeenCalledWith(
       frame.id,
       'SCOPE_DENIED',
-      'duty ledger requires an install-wide connection',
+      'duty ledger requires membership in a member set',
       false
     )
     expect(conn.replyTo).not.toHaveBeenCalled()
     expect(agentBundle).not.toHaveBeenCalled()
+  })
+
+  it('admits an ORG-SCOPED connection that is in a set — tenancy is not the door', async () => {
+    // The narrowing is the write-time membership invariants', not this handler's: an org set can
+    // only ever contain that org's daemons, so "in a set" already implies the tenancy fence.
+    const conn = fakeConn(ORG, SET)
+    const agentBundle = vi.fn(async () => BUNDLE)
+    const frame = fetchFrame()
+
+    await handleDutyFetch(frame, conn, fakeDeps({ agent: AGENT_RECORD, holdsAgent: true, agentBundle }))
+
+    expect(conn.sendError).not.toHaveBeenCalled()
+    expect(conn.replyTo).toHaveBeenCalledWith(frame, 'duty/fetch/ok', { bundle: BUNDLE })
   })
 
   it('refuses a fetch that names no organization', async () => {

--- a/packages/control-plane/src/ws/handlers/duty-fetch.ts
+++ b/packages/control-plane/src/ws/handlers/duty-fetch.ts
@@ -11,9 +11,9 @@ import type { Handler } from './index.js'
 
 export const handleDutyFetch: Handler = async (frame, conn, deps) => {
   if (!isFrame('duty/fetch')(frame)) return
-  // The duty ledger is install-wide: an org-scoped connection never holds duties.
-  if (conn.orgId !== null) {
-    conn.sendError(frame.id, 'SCOPE_DENIED', 'duty ledger requires an install-wide connection', false)
+  // The ledger's door (daemon-groups.md §3): membership in a member set, not install-wideness.
+  if (conn.setId === null) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'duty ledger requires membership in a member set', false)
     return
   }
   const orgId = frameOrgId(frame, conn)

--- a/packages/control-plane/src/ws/handlers/duty-release.ts
+++ b/packages/control-plane/src/ws/handlers/duty-release.ts
@@ -7,9 +7,9 @@ import type { Handler } from './index.js'
 
 export const handleDutyRelease: Handler = async (frame, conn, deps) => {
   if (!isFrame('duty/release')(frame)) return
-  // The duty ledger is install-wide: an org-scoped connection never holds duties.
-  if (conn.orgId !== null) {
-    conn.sendError(frame.id, 'SCOPE_DENIED', 'duty ledger requires an install-wide connection', false)
+  // The ledger's door (daemon-groups.md §3): membership in a member set, not install-wideness.
+  if (conn.setId === null) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'duty ledger requires membership in a member set', false)
     return
   }
   await deps.dutyLease.release(DaemonId(conn.daemonId), frame.payload.groupIds)

--- a/packages/control-plane/src/ws/handlers/heartbeat.ts
+++ b/packages/control-plane/src/ws/handlers/heartbeat.ts
@@ -23,15 +23,14 @@ export const handleHeartbeat: Handler = async (frame, conn, deps) => {
     state.reachable = true
   }
 
-  // Duty lease exchange (k8s daemons; frames/duty.ts): renewal is the heartbeat,
-  // grants and revocations ride back as EVTs on the same connection. Install-wide
-  // (frame-mode) connections only — duty groups span orgs, so an org-scoped
-  // daemon's `duties` is dropped rather than let it claim other orgs' members.
-  // Started BEFORE any await: the service's per-daemon lane is reserved
+  // Duty lease exchange (frames/duty.ts): renewal is the heartbeat, grants and revocations ride
+  // back as EVTs on the same connection. Members of a member set only (daemon-groups.md §3) — a
+  // daemon in no set owns its agents outright, so its `duties` is dropped rather than let it into
+  // the ledger. Started BEFORE any await: the service's per-daemon lane is reserved
   // synchronously, so a duty/release dispatched after this beat queues behind
   // its exchange — ledger operations keep the daemon's frame order.
   const lease =
-    hb.duties && conn.orgId === null
+    hb.duties && conn.setId !== null
       ? deps.dutyLease.onHeartbeat(did, hb.duties, (type, payload) =>
           conn.send(type, payload, state ? { epoch: state.sessionEpoch } : undefined)
         )

--- a/packages/control-plane/src/ws/registry.ts
+++ b/packages/control-plane/src/ws/registry.ts
@@ -90,6 +90,17 @@ export class ConnectionRegistry {
     return true
   }
 
+  /** A membership change reaches a connected daemon by making it handshake again: `auth/ok` is
+   *  where it is told its set (daemon-groups.md §3), and the reconnect's register reconcile
+   *  settles what it should be running. `1012` is transient to the daemon, so it comes straight
+   *  back. False ⇒ nothing was connected, and the next auth reads the change anyway. */
+  reconnectForMemberSet(daemonId: string): boolean {
+    const state = this.byDaemon.get(daemonId)
+    if (!state?.reachable) return false
+    state.conn.close(1012, 'member set changed — reconnect to re-register')
+    return true
+  }
+
   has(daemonId: string): boolean {
     return this.byDaemon.has(daemonId)
   }

--- a/packages/control-plane/test/fakes/build-app.ts
+++ b/packages/control-plane/test/fakes/build-app.ts
@@ -104,13 +104,15 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
 
   const codec = new ApiKeyCodec({ API_KEY_PEPPER: TEST_API_KEY_PEPPER })
   const epoch = new EpochService(repos.daemon, clock)
+  const memberSets = new PgMemberSetRepo(prisma)
   const auth = new DaemonAuthService(
     codec,
     repos.apiKey,
     epoch,
     clock,
     { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs },
-    new PgOrgRepo(prisma)
+    new PgOrgRepo(prisma),
+    memberSets
   )
   const registry = new DaemonRegistryService(repos.daemon, repos.runtimeProfile, repos.daemonLifecycleOp, clock)
   const orchestrator = new Placement(
@@ -127,7 +129,6 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
     PLATFORMS
   )
   const connReg = new ConnectionRegistry()
-  const memberSets = new PgMemberSetRepo(prisma)
   const placementResolver = new PlacementResolver({
     duties: new PgDutyGroupRepo(prisma),
     liveMembers: async (setId) => {

--- a/packages/control-plane/test/fakes/build-app.ts
+++ b/packages/control-plane/test/fakes/build-app.ts
@@ -149,6 +149,7 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
     createDaemonWsServer(app, {
       log: { error: (o, m) => app.log.error(o, m) },
       auth,
+      memberSets,
       lifecycleOps: repos.daemonLifecycleOp,
       registry,
       orchestrator,

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -382,6 +382,7 @@ export function buildHttpApp(
       agent: agentRepo,
       assignment: new PgAssignmentRepo(prisma),
       memberSet: memberSets,
+      dutyGroup: dutyGroupRepo,
       daemonLifecycleOp: daemonLifecycleOpRepo,
       cron: new PgCronRepo(prisma),
       hook: hookRepo,
@@ -478,7 +479,8 @@ export function buildHttpApp(
       epoch,
       clock,
       { HEARTBEAT_SEC: 15, DUTY_LEASE_MS: DUTY_LEASE_DEFAULTS.leaseMs },
-      new PgOrgRepo(prisma)
+      new PgOrgRepo(prisma),
+      memberSets
     ),
     apiKeys: apiKeyService,
     oauth: new OAuthService(oauthRepo, apiKeyService, codec, clock),

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -302,6 +302,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
   const deps: DaemonWsDeps = {
     log: { error: () => undefined },
     auth,
+    memberSets,
     lifecycleOps: repos.daemonLifecycleOp,
     registry,
     orchestrator,

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -164,6 +164,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
   const dutyLeaseMs = opts.dutyLease?.leaseMs ?? 120_000
 
   const epoch = new EpochService(repos.daemon, clock)
+  const memberSets = new PgMemberSetRepo(prisma)
   // Fake in-cluster identity: token → install-wide daemon, no TokenReview.
   const poolTokens = new Map<string, string>()
   const auth = new DaemonAuthService(
@@ -173,6 +174,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     clock,
     { HEARTBEAT_SEC: opts.heartbeatSec ?? 15, DUTY_LEASE_MS: dutyLeaseMs },
     new PgOrgRepo(prisma),
+    memberSets,
     {
       verify: async (token: string) => {
         const daemonId = poolTokens.get(token)
@@ -185,7 +187,6 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
   const sender = new ControlSender(connReg, repos.launch)
   const relays = opts.relays ?? []
   const dutyGroupRepo = new PgDutyGroupRepo(prisma)
-  const memberSets = new PgMemberSetRepo(prisma)
   const placementResolver = new PlacementResolver({
     duties: dutyGroupRepo,
     liveMembers: async (setId) => {

--- a/packages/control-plane/test/integration/member-sets.route.test.ts
+++ b/packages/control-plane/test/integration/member-sets.route.test.ts
@@ -24,6 +24,7 @@ interface SetBody {
   setId: string
   name: string
   memberDaemonIds: string[]
+  agentCount: number
 }
 
 describe('member sets — CRUD is org-fenced (real Postgres)', () => {
@@ -33,7 +34,7 @@ describe('member sets — CRUD is org-fenced (real Postgres)', () => {
       const created = await app.inject({ method: 'POST', url: `${ORG}/member-sets`, payload: { name: 'lab' } })
       expect(created.statusCode).toBe(201)
       const set = created.json() as SetBody
-      expect(set).toMatchObject({ name: 'lab', memberDaemonIds: [] })
+      expect(set).toMatchObject({ name: 'lab', memberDaemonIds: [], agentCount: 0 })
 
       // The pool exists, and it is not listed: it belongs to no organization.
       const pool = await poolSetId(prisma)
@@ -52,6 +53,21 @@ describe('member sets — CRUD is org-fenced (real Postgres)', () => {
 
       expect((await app.inject({ method: 'DELETE', url: `${ORG}/member-sets/${set.setId}` })).statusCode).toBe(204)
       expect(((await app.inject({ method: 'GET', url: `${ORG}/member-sets` })).json() as SetBody[]).length).toBe(0)
+    } finally {
+      await close()
+    }
+  })
+
+  it('reports what is placed on the set — the count the console shows beside the pool and a cluster', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const set = (
+        await app.inject({ method: 'POST', url: `${ORG}/member-sets`, payload: { name: 'lab' } })
+      ).json() as SetBody
+      await seedAgent(prisma, AGENT, { setId: set.setId })
+
+      const listed = (await app.inject({ method: 'GET', url: `${ORG}/member-sets` })).json() as SetBody[]
+      expect(listed).toEqual([{ setId: set.setId, name: 'lab', memberDaemonIds: [], agentCount: 1 }])
     } finally {
       await close()
     }

--- a/packages/control-plane/test/integration/member-sets.route.test.ts
+++ b/packages/control-plane/test/integration/member-sets.route.test.ts
@@ -1,0 +1,165 @@
+/**
+ * `/member-sets` — an organization's own member sets (docs/designs/daemon-groups.md §2, §3).
+ *
+ * Two things are load-bearing here and neither is CRUD. First, the route is fenced on the path
+ * org and the install-wide pool is not this organization's to see or touch. Second, membership
+ * moves runtime authority, so each direction is admitted only from a state where nothing is
+ * taken away from a running machine: a daemon with pinned agents may not join, and a daemon
+ * holding a live duty lease may not leave.
+ */
+import { randomUUID } from 'node:crypto'
+import { describe, it, expect } from 'vitest'
+import { prisma } from '../setup.db.js'
+import { buildHttpApp } from '../fakes/build-http.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { poolSetId } from '../fakes/member-set.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const DAEMON = 'd1111111-1111-4111-8111-111111111111'
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const GROUP = '99999999-9999-4999-8999-999999999991'
+
+interface SetBody {
+  setId: string
+  name: string
+  memberDaemonIds: string[]
+}
+
+describe('member sets — CRUD is org-fenced (real Postgres)', () => {
+  it('creates, lists, renames and deletes, and never sees the install-wide pool', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const created = await app.inject({ method: 'POST', url: `${ORG}/member-sets`, payload: { name: 'lab' } })
+      expect(created.statusCode).toBe(201)
+      const set = created.json() as SetBody
+      expect(set).toMatchObject({ name: 'lab', memberDaemonIds: [] })
+
+      // The pool exists, and it is not listed: it belongs to no organization.
+      const pool = await poolSetId(prisma)
+      const listed = (await app.inject({ method: 'GET', url: `${ORG}/member-sets` })).json() as SetBody[]
+      expect(listed.map((s) => s.setId)).toEqual([set.setId])
+      expect(
+        await app.inject({ method: 'PATCH', url: `${ORG}/member-sets/${pool}`, payload: { name: 'mine' } })
+      ).toMatchObject({ statusCode: 404 })
+
+      const renamed = await app.inject({
+        method: 'PATCH',
+        url: `${ORG}/member-sets/${set.setId}`,
+        payload: { name: 'lab-2' }
+      })
+      expect((renamed.json() as SetBody).name).toBe('lab-2')
+
+      expect((await app.inject({ method: 'DELETE', url: `${ORG}/member-sets/${set.setId}` })).statusCode).toBe(204)
+      expect(((await app.inject({ method: 'GET', url: `${ORG}/member-sets` })).json() as SetBody[]).length).toBe(0)
+    } finally {
+      await close()
+    }
+  })
+
+  it('refuses to delete a set that still has members', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      await seedDaemon(prisma, DAEMON)
+      const set = (
+        await app.inject({ method: 'POST', url: `${ORG}/member-sets`, payload: { name: 'lab' } })
+      ).json() as SetBody
+      await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${set.setId}/members/${DAEMON}` })
+
+      expect((await app.inject({ method: 'DELETE', url: `${ORG}/member-sets/${set.setId}` })).statusCode).toBe(409)
+    } finally {
+      await close()
+    }
+  })
+})
+
+describe('member sets — the enrolment transitions (real Postgres)', () => {
+  async function withSet(app: ReturnType<typeof buildHttpApp>['app']): Promise<string> {
+    const set = (
+      await app.inject({ method: 'POST', url: `${ORG}/member-sets`, payload: { name: 'lab' } })
+    ).json() as SetBody
+    return set.setId
+  }
+
+  it('enrolls a daemon with nothing pinned to it, and reports it on the daemon', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      await seedDaemon(prisma, DAEMON)
+      const setId = await withSet(app)
+
+      const joined = await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${DAEMON}` })
+      expect(joined.statusCode).toBe(200)
+      expect((joined.json() as SetBody).memberDaemonIds).toEqual([DAEMON])
+
+      const daemons = (await app.inject({ method: 'GET', url: `${ORG}/daemons` })).json() as {
+        daemonId: string
+        memberSetId: string | null
+      }[]
+      expect(daemons.find((d) => d.daemonId === DAEMON)?.memberSetId).toBe(setId)
+    } finally {
+      await close()
+    }
+  })
+
+  it('refuses a daemon that still has agents pinned to it — they would become unservable', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      await seedDaemon(prisma, DAEMON)
+      await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+      const setId = await withSet(app)
+
+      const res = await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${DAEMON}` })
+      expect(res.statusCode).toBe(409)
+      expect(await prisma.memberSetMember.count()).toBe(0)
+    } finally {
+      await close()
+    }
+  })
+
+  it('refuses a daemon of another organization', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const other = await prisma.org.create({ data: { slug: `mset-${randomUUID().slice(0, 8)}` } })
+      const theirs = randomUUID()
+      await prisma.daemon.create({ data: { id: theirs, orgId: other.id, maxAgents: 8, status: 'ready' } })
+      const setId = await withSet(app)
+
+      expect(
+        (await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${theirs}` })).statusCode
+      ).toBe(404)
+    } finally {
+      await close()
+    }
+  })
+
+  it('refuses withdrawal while the daemon still holds a live duty lease', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      await seedDaemon(prisma, DAEMON)
+      const setId = await withSet(app)
+      await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${DAEMON}` })
+      // A lease that has not lapsed is exactly "this machine may still be serving" — the state the
+      // design's two-phase removal exists to avoid committing over.
+      await prisma.dutyGroup.create({
+        data: {
+          id: GROUP,
+          orgId: DEFAULT_ORG_ID,
+          holder: DAEMON,
+          term: 1n,
+          expiresAt: new Date(Date.now() + 60_000)
+        }
+      })
+
+      const refused = await app.inject({ method: 'DELETE', url: `${ORG}/member-sets/${setId}/members/${DAEMON}` })
+      expect(refused.statusCode).toBe(409)
+
+      // Once the lease has lapsed the daemon has provably self-fenced, and it may leave.
+      await prisma.dutyGroup.update({ where: { id: GROUP }, data: { expiresAt: new Date(Date.now() - 1) } })
+      const withdrawn = await app.inject({ method: 'DELETE', url: `${ORG}/member-sets/${setId}/members/${DAEMON}` })
+      expect(withdrawn.statusCode).toBe(200)
+      expect((withdrawn.json() as SetBody).memberDaemonIds).toEqual([])
+    } finally {
+      await close()
+    }
+  })
+})

--- a/packages/control-plane/test/protocol/auth.handler.test.ts
+++ b/packages/control-plane/test/protocol/auth.handler.test.ts
@@ -20,6 +20,7 @@ import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
 import { DaemonId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { buildWsHarness } from '../fakes/build-ws.js'
+import { PgMemberSetRepo } from '../../src/persistence/repositories/member-set.repo.js'
 import { InMemoryDaemonStub } from '../fakes/daemon-stub.js'
 
 const DAEMON = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -92,6 +93,43 @@ describe('auth handler — valid key mints next epoch; invalid key closes 4401',
     // Crucially: the epoch did NOT bump (still 1).
     const row = await repo.getUnscoped(DaemonId(DAEMON))
     expect(row?.sessionEpoch).toBe(1n)
+  })
+
+  it('closes rather than admits when the settled membership cannot be read', async () => {
+    // This second read is the ONLY guard on the window between the membership lookup that built
+    // `auth/ok` and the connection reaching the registry (daemon-groups.md §3), so a blip must not
+    // be taken as "the old value still holds" — that is exactly the hole it exists to close.
+    const h = buildWsHarness(prisma)
+    h.deps.memberSets.setIdOf = async () => {
+      throw new Error('db down')
+    }
+    const apiKey = await h.mintToken(DAEMON)
+
+    const { stub } = h.connect()
+    stub.inject('auth', authPayload(apiKey), { id: AUTH_ID })
+
+    await vi.waitFor(() => {
+      if (!stub.closed) throw new Error('not closed yet')
+    })
+    expect(stub.closed?.code).toBe(1011)
+    expect(stub.lastSent('auth/ok')).toBeUndefined()
+  })
+
+  it('closes 1012 when the membership changed during the handshake, so the daemon reads it afresh', async () => {
+    const h = buildWsHarness(prisma)
+    const apiKey = await h.mintToken(DAEMON)
+    // The change lands after `authenticate` read "no set" and before the connection is indexed:
+    // the route's own close finds nothing, so this read is what catches it.
+    const setId = await new PgMemberSetRepo(prisma).createForOrg(DEFAULT_ORG_ID, 'lab')
+    h.deps.memberSets.setIdOf = async () => setId.id
+
+    const { stub } = h.connect()
+    stub.inject('auth', authPayload(apiKey), { id: AUTH_ID })
+
+    await vi.waitFor(() => {
+      if (!stub.closed) throw new Error('not closed yet')
+    })
+    expect(stub.closed?.code).toBe(1012)
   })
 
   it('a key bound to a different daemonId is rejected 4401 (no bump)', async () => {

--- a/packages/control-plane/test/protocol/drain.test.ts
+++ b/packages/control-plane/test/protocol/drain.test.ts
@@ -128,6 +128,7 @@ function build(): Built {
   const deps: DaemonWsDeps = {
     log: { error: vi.fn() },
     auth: {} as DaemonWsDeps['auth'],
+    memberSets: {} as DaemonWsDeps['memberSets'],
     lifecycleOps: {} as DaemonWsDeps['lifecycleOps'],
     registry: {} as DaemonWsDeps['registry'],
     orchestrator: {} as DaemonWsDeps['orchestrator'],

--- a/packages/control-plane/test/protocol/fencing.test.ts
+++ b/packages/control-plane/test/protocol/fencing.test.ts
@@ -36,6 +36,7 @@ function fencingDeps(clock: FakeClock): DaemonWsDeps {
   return {
     log: { error: () => undefined },
     auth: {} as DaemonWsDeps['auth'],
+    memberSets: {} as DaemonWsDeps['memberSets'],
     lifecycleOps: {} as DaemonWsDeps['lifecycleOps'],
     registry: {} as DaemonWsDeps['registry'],
     orchestrator: {} as DaemonWsDeps['orchestrator'],

--- a/packages/control-plane/test/repo/org-member-set.test.ts
+++ b/packages/control-plane/test/repo/org-member-set.test.ts
@@ -308,6 +308,30 @@ describe('the membership fences (real Postgres)', () => {
     expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBe(setId)
   })
 
+  it('a renewal cannot revive a lapsed lease across a withdrawal', async () => {
+    // Renewal carries no expiry predicate — it revives every row this holder still names — so it
+    // is a lease-CREATING write as far as withdrawal is concerned. Both take the daemon fence, and
+    // the commit vacates what is left, so a beat landing either side cannot resurrect the holding.
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    await sets().enroll(setId, DaemonId(MEMBER_G))
+    const agentId = await setAgent(DEFAULT_ORG_ID, setId, 'lapsing')
+    await ledger().claimAgentHome(ORG_X, agentId, DaemonId(MEMBER_G), T0, LEASE_MS)
+
+    const afterLapse = new Date(T0.getTime() + LEASE_MS + 1)
+    const [withdrawal] = await Promise.allSettled([
+      sets().withdraw(DaemonId(MEMBER_G), afterLapse),
+      ledger().renewHeld(DaemonId(MEMBER_G), afterLapse, LEASE_MS)
+    ])
+    // Whichever order they took, the forbidden pair — a live lease held by a non-member — is out.
+    const stillMember = (await sets().setIdOf(DaemonId(MEMBER_G))) !== null
+    const stillLive = (await ledger().listHeldBy(DaemonId(MEMBER_G))).filter(
+      (g) => g.expiresAt !== null && g.expiresAt > afterLapse
+    )
+    expect(stillMember || stillLive.length === 0).toBe(true)
+    if (withdrawal.status === 'fulfilled') expect(stillLive).toEqual([])
+  })
+
   it('refuses withdrawal while a live lease is held, and takes it once the lease lapses', async () => {
     await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
     const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id

--- a/packages/control-plane/test/repo/org-member-set.test.ts
+++ b/packages/control-plane/test/repo/org-member-set.test.ts
@@ -14,6 +14,7 @@ import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
 import { PgMemberSetRepo } from '../../src/persistence/repositories/member-set.repo.js'
 import {
+  DaemonAlreadyInSet,
   DaemonHasPlacedAgents,
   DaemonHoldsDuty,
   DaemonPlacementInSet,
@@ -252,6 +253,33 @@ describe('the membership fences (real Postgres)', () => {
     const enrolled = (await sets().setIdOf(DaemonId(MEMBER_G))) !== null
     const pinned = await prisma.agent.count({ where: { daemonId: MEMBER_G } })
     expect(enrolled && pinned > 0).toBe(false)
+  })
+
+  it('never answers success for the loser of two concurrent enrolments into different sets', async () => {
+    // The insert is idempotent, so without a membership re-read under the lock the loser would
+    // no-op and still return 200 naming a set the daemon never joined.
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const a = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-a')).id
+    const b = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-b')).id
+
+    const outcomes = await Promise.allSettled([
+      sets().enrollOperator(a, DaemonId(MEMBER_G)),
+      sets().enrollOperator(b, DaemonId(MEMBER_G))
+    ])
+    expect(outcomes.filter((o) => o.status === 'fulfilled')).toHaveLength(1)
+    const loser = outcomes.find((o) => o.status === 'rejected')
+    expect((loser as PromiseRejectedResult).reason).toBeInstanceOf(DaemonAlreadyInSet)
+    // And the winner is the one the surviving row actually names.
+    const winner = outcomes[0]!.status === 'fulfilled' ? a : b
+    expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBe(winner)
+  })
+
+  it('is idempotent for the set the daemon is already in', async () => {
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    await sets().enrollOperator(setId, DaemonId(MEMBER_G))
+    await sets().enrollOperator(setId, DaemonId(MEMBER_G))
+    expect(await sets().memberIdsOf(setId)).toEqual([MEMBER_G])
   })
 
   it('refuses withdrawal for a lease claimed concurrently, never committing over a live holder', async () => {

--- a/packages/control-plane/test/repo/org-member-set.test.ts
+++ b/packages/control-plane/test/repo/org-member-set.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Org-scoped member sets — the eligibility matrix (docs/designs/daemon-groups.md §3, §6 PR 2).
+ *
+ * The point of the whole shape is that admitting org-scoped claimants into the ledger widens
+ * NOTHING: `mayHold` stays one rule, and the tenancy narrowing follows from what membership is
+ * allowed to mean. So this file is the matrix that proves it — one member of one org's set, and
+ * every agent it must NOT be able to claim, each refused by the same predicate that grants it its
+ * own. If any row here flips, an organization's machine can reach another organization's work.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
+import { PgMemberSetRepo } from '../../src/persistence/repositories/member-set.repo.js'
+import { DaemonPlacementInSet, MemberSetInUse } from '../../src/persistence/errors.js'
+import { onDaemon, onSet } from '../../src/domain/placement.js'
+import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { seedPoolMember } from '../fakes/member-set.js'
+
+const ORG_X = OrgId(DEFAULT_ORG_ID)
+const MEMBER_G = 'd1111111-1111-4111-8111-111111111111' // org X, in set G
+const MEMBER_H = 'd2222222-2222-4222-8222-222222222222' // org X, in set H
+const PINNED = 'd3333333-3333-4333-8333-333333333333' // org X, in no set
+const POOL_MEMBER = 'd4444444-4444-4444-8444-444444444444'
+const T0 = new Date('2026-01-01T00:00:00Z')
+const LEASE_MS = 120_000
+
+const sets = () => new PgMemberSetRepo(prisma)
+const agents = () => new PgAgentRepo(prisma)
+const ledger = () => new PgDutyGroupRepo(prisma)
+
+/** An agent of `orgId`, placed on `setId`, with its duty group materialized by a first claim. */
+async function setAgent(orgId: string, setId: string, name: string): Promise<AgentId> {
+  const id = AgentId(randomUUID())
+  await agents().create({ id, orgId: OrgId(orgId), name, runtime: 'claude', placementKind: 'set', setId })
+  return id
+}
+
+/** A second organization with a daemon and a set of its own. */
+async function otherOrg(): Promise<{ orgId: string; setId: string; daemonId: string }> {
+  const org = await prisma.org.create({ data: { slug: `org-set-${randomUUID().slice(0, 8)}` } })
+  const setId = (await sets().createForOrg(org.id, 'their-group')).id
+  const daemonId = randomUUID()
+  await prisma.daemon.create({ data: { id: daemonId, orgId: org.id, maxAgents: 8, status: 'ready' } })
+  await sets().enroll(setId, DaemonId(daemonId))
+  return { orgId: org.id, setId, daemonId }
+}
+
+describe('an org set member’s eligibility (real Postgres)', () => {
+  let setG: string
+  let setH: string
+
+  beforeEach(async () => {
+    await prisma.daemon.createMany({
+      data: [MEMBER_G, MEMBER_H, PINNED].map((id) => ({ id, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' }))
+    })
+    setG = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    setH = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-h')).id
+    await sets().enroll(setG, DaemonId(MEMBER_G))
+    await sets().enroll(setH, DaemonId(MEMBER_H))
+  })
+
+  it('claims a set-placed agent of its own org in its own set', async () => {
+    const agentId = await setAgent(DEFAULT_ORG_ID, setG, 'ours')
+    expect(await ledger().claimAgentHome(ORG_X, agentId, DaemonId(MEMBER_G), T0, LEASE_MS)).toMatchObject({
+      granted: true,
+      holder: MEMBER_G
+    })
+  })
+
+  it('is refused an agent of its own org in ANOTHER set', async () => {
+    const agentId = await setAgent(DEFAULT_ORG_ID, setH, 'theirs')
+    expect(await ledger().claimAgentHome(ORG_X, agentId, DaemonId(MEMBER_G), T0, LEASE_MS)).toMatchObject({
+      granted: false
+    })
+  })
+
+  it('is refused a pool agent — a group never reaches the pool', async () => {
+    const poolSet = await seedPoolMember(prisma, POOL_MEMBER)
+    const agentId = await setAgent(DEFAULT_ORG_ID, poolSet, 'cloudy')
+    expect(await ledger().claimAgentHome(ORG_X, agentId, DaemonId(MEMBER_G), T0, LEASE_MS)).toMatchObject({
+      granted: false
+    })
+    // …and the pool member holds it, which is what makes the refusal a fence and not an outage.
+    expect(await ledger().claimAgentHome(ORG_X, agentId, DaemonId(POOL_MEMBER), T0, LEASE_MS)).toMatchObject({
+      granted: true,
+      holder: POOL_MEMBER
+    })
+  })
+
+  it('is refused a machine-placed agent, even one on a machine of its own org', async () => {
+    const agentId = AgentId(randomUUID())
+    await agents().create({
+      id: agentId,
+      orgId: ORG_X,
+      name: 'pinned',
+      runtime: 'claude',
+      daemonId: DaemonId(PINNED)
+    })
+    expect(await ledger().claimAgentHome(ORG_X, agentId, DaemonId(MEMBER_G), T0, LEASE_MS)).toMatchObject({
+      granted: false
+    })
+  })
+
+  it('is refused every agent of another organization, whatever its placement', async () => {
+    const other = await otherOrg()
+    const theirs = await setAgent(other.orgId, other.setId, 'theirs')
+    expect(await ledger().claimAgentHome(OrgId(other.orgId), theirs, DaemonId(MEMBER_G), T0, LEASE_MS)).toMatchObject({
+      granted: false
+    })
+    // Their own member holds it — the refusal is tenancy, not a broken set.
+    expect(
+      await ledger().claimAgentHome(OrgId(other.orgId), theirs, DaemonId(other.daemonId), T0, LEASE_MS)
+    ).toMatchObject({ granted: true, holder: other.daemonId })
+  })
+
+  it('a pool member is refused every org-set agent — the pool does not absorb groups', async () => {
+    await seedPoolMember(prisma, POOL_MEMBER)
+    const agentId = await setAgent(DEFAULT_ORG_ID, setG, 'ours')
+    expect(await ledger().claimAgentHome(ORG_X, agentId, DaemonId(POOL_MEMBER), T0, LEASE_MS)).toMatchObject({
+      granted: false
+    })
+    expect(await ledger().claimVacant(DaemonId(POOL_MEMBER), 5, T0, LEASE_MS)).toEqual([])
+  })
+
+  it('re-grants a stopped member’s agents to another member of the same set', async () => {
+    // The rollout property, for a local set: a member goes away, its lease lapses, and a peer
+    // takes the group over with nothing sent to make it happen. A daemon is in at most one set,
+    // so the peer here is the one that was in none.
+    await sets().enroll(setG, DaemonId(PINNED))
+    const agentId = await setAgent(DEFAULT_ORG_ID, setG, 'failover')
+    await ledger().claimAgentHome(ORG_X, agentId, DaemonId(MEMBER_G), T0, LEASE_MS)
+
+    const afterLapse = new Date(T0.getTime() + LEASE_MS + 1)
+    const taken = await ledger().claimVacant(DaemonId(PINNED), 5, afterLapse, LEASE_MS)
+    expect(taken).toHaveLength(1)
+    expect(taken[0]!.members).toEqual([{ kind: 'agent', refId: agentId }])
+  })
+})
+
+describe('a set member is not a placement target (real Postgres)', () => {
+  it('refuses pinning an agent to a machine that is in a set, on create and on move', async () => {
+    await prisma.daemon.createMany({
+      data: [MEMBER_G, PINNED].map((id) => ({ id, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' }))
+    })
+    const setG = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    await sets().enroll(setG, DaemonId(MEMBER_G))
+
+    // A member serves only what it holds a lease for, so a pinned agent there would be placed and
+    // unservable at once — the converse of the invariant that lets `mayHold` stay one rule.
+    await expect(
+      agents().create({
+        id: AgentId(randomUUID()),
+        orgId: ORG_X,
+        name: 'pinned-to-member',
+        runtime: 'claude',
+        daemonId: DaemonId(MEMBER_G)
+      })
+    ).rejects.toBeInstanceOf(DaemonPlacementInSet)
+
+    const agentId = AgentId(randomUUID())
+    await agents().create({ id: agentId, orgId: ORG_X, name: 'movable', runtime: 'claude', daemonId: DaemonId(PINNED) })
+    await expect(agents().setPlacement(agentId, onDaemon(DaemonId(MEMBER_G)))).rejects.toBeInstanceOf(
+      DaemonPlacementInSet
+    )
+    // The set itself is a legal target for the same agent — the refusal is about the machine.
+    await agents().setPlacement(agentId, onSet(setG))
+    expect(await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).toMatchObject({
+      placementKind: 'set',
+      setId: setG,
+      daemonId: null
+    })
+  })
+})
+
+describe('org set lifecycle (real Postgres)', () => {
+  it('lists, renames, and deletes only within the owning org, and never the pool', async () => {
+    const repo = sets()
+    const created = await repo.createForOrg(DEFAULT_ORG_ID, 'group-g')
+    const other = await otherOrg()
+
+    expect(await repo.listForOrg(DEFAULT_ORG_ID)).toEqual([{ id: created.id, orgId: DEFAULT_ORG_ID, name: 'group-g' }])
+    expect(await repo.renameForOrg(other.orgId, created.id, 'stolen')).toBeNull()
+    expect(await repo.renameForOrg(DEFAULT_ORG_ID, created.id, 'group-g2')).toMatchObject({ name: 'group-g2' })
+    expect(await repo.deleteForOrg(other.orgId, created.id)).toBe(false)
+    expect(await repo.deleteForOrg(DEFAULT_ORG_ID, created.id)).toBe(true)
+  })
+
+  it('refuses to delete a set that still has members or placed agents', async () => {
+    const repo = sets()
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await repo.createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+
+    await repo.enroll(setId, DaemonId(MEMBER_G))
+    await expect(repo.deleteForOrg(DEFAULT_ORG_ID, setId)).rejects.toBeInstanceOf(MemberSetInUse)
+
+    await repo.withdraw(DaemonId(MEMBER_G))
+    await setAgent(DEFAULT_ORG_ID, setId, 'still-placed')
+    // `Agent.setId` is SetNull, so deleting here would silently unplace the agent instead.
+    await expect(repo.deleteForOrg(DEFAULT_ORG_ID, setId)).rejects.toBeInstanceOf(MemberSetInUse)
+  })
+
+  it('announces the set whole, so `auth/ok` can name it', async () => {
+    const repo = sets()
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await repo.createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    await repo.enroll(setId, DaemonId(MEMBER_G))
+
+    expect(await repo.setOf(DaemonId(MEMBER_G))).toEqual({ id: setId, orgId: DEFAULT_ORG_ID, name: 'group-g' })
+    expect(await repo.setOf(DaemonId(POOL_MEMBER))).toBeNull()
+  })
+
+  it('answers no shared-store members for an org set — its machines may keep private stores', async () => {
+    const repo = sets()
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await repo.createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    await repo.enroll(setId, DaemonId(MEMBER_G))
+
+    expect(await repo.memberIdsOf(setId)).toEqual([MEMBER_G])
+    expect(await repo.sharedStoreMemberIdsOf(setId)).toEqual([])
+  })
+})

--- a/packages/control-plane/test/repo/org-member-set.test.ts
+++ b/packages/control-plane/test/repo/org-member-set.test.ts
@@ -13,7 +13,12 @@ import { prisma } from '../setup.db.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
 import { PgMemberSetRepo } from '../../src/persistence/repositories/member-set.repo.js'
-import { DaemonPlacementInSet, MemberSetInUse } from '../../src/persistence/errors.js'
+import {
+  DaemonHasPlacedAgents,
+  DaemonHoldsDuty,
+  DaemonPlacementInSet,
+  MemberSetInUse
+} from '../../src/persistence/errors.js'
 import { onDaemon, onSet } from '../../src/domain/placement.js'
 import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
@@ -196,7 +201,7 @@ describe('org set lifecycle (real Postgres)', () => {
     await repo.enroll(setId, DaemonId(MEMBER_G))
     await expect(repo.deleteForOrg(DEFAULT_ORG_ID, setId)).rejects.toBeInstanceOf(MemberSetInUse)
 
-    await repo.withdraw(DaemonId(MEMBER_G))
+    await repo.withdraw(DaemonId(MEMBER_G), T0)
     await setAgent(DEFAULT_ORG_ID, setId, 'still-placed')
     // `Agent.setId` is SetNull, so deleting here would silently unplace the agent instead.
     await expect(repo.deleteForOrg(DEFAULT_ORG_ID, setId)).rejects.toBeInstanceOf(MemberSetInUse)
@@ -220,5 +225,99 @@ describe('org set lifecycle (real Postgres)', () => {
 
     expect(await repo.memberIdsOf(setId)).toEqual([MEMBER_G])
     expect(await repo.sharedStoreMemberIdsOf(setId)).toEqual([])
+  })
+})
+
+describe('the membership fences (real Postgres)', () => {
+  it('serializes enrolment against a concurrent pin, so neither state can be half-committed', async () => {
+    // The finding: both writers used to check and commit in separate transactions, so a placement
+    // reading "in no set" and an enrolment reading "no pinned agents" could both win — leaving a
+    // set member with an agent pinned to it and no way to serve it.
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    const agentId = AgentId(randomUUID())
+
+    const outcomes = await Promise.allSettled([
+      sets().enrollOperator(setId, DaemonId(MEMBER_G)),
+      agents().create({
+        id: agentId,
+        orgId: ORG_X,
+        name: 'racer',
+        runtime: 'claude',
+        daemonId: DaemonId(MEMBER_G)
+      })
+    ])
+    // Exactly one wins — and whichever it is, the forbidden pair never exists.
+    expect(outcomes.filter((o) => o.status === 'fulfilled')).toHaveLength(1)
+    const enrolled = (await sets().setIdOf(DaemonId(MEMBER_G))) !== null
+    const pinned = await prisma.agent.count({ where: { daemonId: MEMBER_G } })
+    expect(enrolled && pinned > 0).toBe(false)
+  })
+
+  it('refuses withdrawal for a lease claimed concurrently, never committing over a live holder', async () => {
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    await sets().enroll(setId, DaemonId(MEMBER_G))
+    const agentId = await setAgent(DEFAULT_ORG_ID, setId, 'contended')
+
+    const [claim, withdrawal] = await Promise.allSettled([
+      ledger().claimAgentHome(ORG_X, agentId, DaemonId(MEMBER_G), T0, LEASE_MS),
+      sets().withdraw(DaemonId(MEMBER_G), T0)
+    ])
+    // Either the claim lost (no lease, withdrawal committed) or it won and the withdrawal was
+    // refused — never "granted a live lease AND no longer a member".
+    const granted = claim.status === 'fulfilled' && claim.value.granted
+    const stillMember = (await sets().setIdOf(DaemonId(MEMBER_G))) !== null
+    expect(granted && !stillMember).toBe(false)
+    if (granted) expect(withdrawal.status).toBe('rejected')
+  })
+
+  it('refuses to delete a set a placement is landing on, rather than silently unplacing it', async () => {
+    const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    const agentId = AgentId(randomUUID())
+
+    const [placement, deletion] = await Promise.allSettled([
+      agents().create({ id: agentId, orgId: ORG_X, name: 'landing', runtime: 'claude', placementKind: 'set', setId }),
+      sets().deleteForOrg(DEFAULT_ORG_ID, setId)
+    ])
+    // `Agent.setId` is SetNull, so a delete that raced past the count would leave the agent
+    // unplaced with no trace. The set survives whenever the placement did.
+    const placed = placement.status === 'fulfilled'
+    const deleted = deletion.status === 'fulfilled' && deletion.value === true
+    expect(placed && deleted).toBe(false)
+    if (placed) {
+      expect(await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).toMatchObject({ setId })
+    }
+  })
+
+  it('refuses enrolment while agents are pinned, and takes it once they are re-placed', async () => {
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    const agentId = AgentId(randomUUID())
+    await agents().create({
+      id: agentId,
+      orgId: ORG_X,
+      name: 'pinned',
+      runtime: 'claude',
+      daemonId: DaemonId(MEMBER_G)
+    })
+
+    await expect(sets().enrollOperator(setId, DaemonId(MEMBER_G))).rejects.toBeInstanceOf(DaemonHasPlacedAgents)
+    await agents().setPlacement(agentId, onSet(setId))
+    await sets().enrollOperator(setId, DaemonId(MEMBER_G))
+    expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBe(setId)
+  })
+
+  it('refuses withdrawal while a live lease is held, and takes it once the lease lapses', async () => {
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    await sets().enroll(setId, DaemonId(MEMBER_G))
+    const agentId = await setAgent(DEFAULT_ORG_ID, setId, 'held')
+    await ledger().claimAgentHome(ORG_X, agentId, DaemonId(MEMBER_G), T0, LEASE_MS)
+
+    await expect(sets().withdraw(DaemonId(MEMBER_G), T0)).rejects.toBeInstanceOf(DaemonHoldsDuty)
+    // A lapsed lease is strictly later than the member's own self-fence: it has stopped serving.
+    await sets().withdraw(DaemonId(MEMBER_G), new Date(T0.getTime() + LEASE_MS + 1))
+    expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBeNull()
   })
 })

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -283,6 +283,9 @@ export class CpClient {
   private fatal = false // 4401 — never auto-retry
   private serverFeatures = new Set<string>()
   private organizationMode: OrganizationMode = 'connection'
+  /** The member set the CP announced at `auth/ok` (daemon-groups.md §3); null ⇒ in none. Never
+   *  asserted from here — membership is the CP's to record and this connection's to be told. */
+  private memberSetRef: { setId: string; name: string } | null = null
   private attempt = 0
   private reconnectTimer?: TimerHandle
   private lastAuthedEpoch = 0 // for resume on reconnect (per-agent seq tail is out of scope)
@@ -459,15 +462,17 @@ export class CpClient {
       webAppUrl?: string
       orgSlug?: string
       organizationMode?: OrganizationMode
+      memberSet?: { setId: string; name: string }
       lifecycle?: BootstrapLifecycle
     }
     this.sessionEpoch = ok.sessionEpoch
     this.organizationMode = ok.organizationMode ?? 'connection'
+    this.memberSetRef = ok.memberSet ?? null
     this.dutyLeaseMs = ok.dutyLeaseMs
     // A CP that announces its horizon is a CP that confirms renewals — both landed together.
     this.dutyRenewalsConfirmed = ok.dutyLeaseMs !== undefined
     // Once per connection, and only where a lease can exist: a member fencing on a guess should say so.
-    if (!this.dutyRenewalsConfirmed && this.organizationMode === 'frame' && this.deps.duties) {
+    if (!this.dutyRenewalsConfirmed && this.memberSetRef && this.deps.duties) {
       this.deps.log.warn(
         `cp: no duty lease horizon in auth/ok — self-fencing on the built-in ${DUTY_LEASE_FALLBACK_MS}ms default, ` +
           'anchored on the heartbeats sent rather than on renewals confirmed'
@@ -933,6 +938,12 @@ export class CpClient {
    *  only on the latter. */
   organizationScope(): 'connection' | 'frame' {
     return this.organizationMode
+  }
+
+  /** The member set this connection belongs to, as `auth/ok` announced it; null ⇒ in none
+   *  (daemon-groups.md §3). This is the duty-enforcement predicate: membership, not tenancy. */
+  memberSet(): { setId: string; name: string } | null {
+    return this.memberSetRef
   }
 
   /** Additive CP feature negotiation for rolling daemon/CP upgrades. */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13422,12 +13422,13 @@ export class Daemon {
     return max - this.duties.agents().size - Math.max(0, this.inFlightDutyClaims.size - 1)
   }
 
-  /** True when duty leases gate service: a tenancy question, not an option. An install-wide
-   *  (frame-scope) member serves only what it holds a lease for; an org-scoped daemon owns its
-   *  agents outright and never participates in the ledger. */
+  /** True when duty leases gate service: a membership question, not an option (daemon-groups.md
+   *  §3). A member of a member set — the install-wide pool or an organization's own — serves only
+   *  what it holds a lease for; a daemon in no set owns its agents outright and never participates
+   *  in the ledger. The set is what `auth/ok` announced, and nothing else stands in for it. */
   private dutyEnforced(): boolean {
     // `cpClient` lands in start(); transportAgents can run before that in tests.
-    return this.cpClient?.organizationScope?.() === 'frame'
+    return this.cpClient?.memberSet?.() != null
   }
 
   /** `duty/grant` EVT: admit the grants off the frame-dispatch path, so a slow

--- a/packages/daemon/test/cp/client-duty-fence.test.ts
+++ b/packages/daemon/test/cp/client-duty-fence.test.ts
@@ -10,6 +10,9 @@ const DAEMON_ID = '22222222-2222-4222-8222-222222222222'
 const GROUP = '11111111-1111-4111-8111-111111111111'
 const GROUP_B = '11111111-1111-4111-8111-111111111112'
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+// The install-wide pool, as `auth/ok` announces it — membership is what puts this daemon in the
+// duty ledger at all (daemon-groups.md §3), so a lease can only exist while it carries one.
+const POOL_SET = { setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }
 const LEASE_MS = 120_000
 // The shipped fence: 3/4 of the horizon past the last heartbeat that carried duties.
 const FENCE_MS = 90_000
@@ -44,7 +47,8 @@ async function handshake(t: FakeTransport, epoch: number, dutyLeaseMs?: number):
           heartbeatSec: BEAT_MS / 1000,
           ...(dutyLeaseMs !== undefined ? { dutyLeaseMs } : {}),
           serverTime: '2026-08-14T00:00:00.000Z',
-          organizationMode: 'frame'
+          organizationMode: 'frame',
+          memberSet: POOL_SET
         },
         { corr: auth.id }
       )

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -80,6 +80,7 @@ const seam = (d: Daemon) => (d as any).cpConfigApply()
 function poolMember(daemon: Daemon, client: Record<string, unknown> = {}) {
   ;(daemon as any).cpClient = {
     organizationScope: () => 'frame',
+    memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
     reportDutiesNow: vi.fn(() => {}),

--- a/packages/daemon/test/daemon-duty-drain.test.ts
+++ b/packages/daemon/test/daemon-duty-drain.test.ts
@@ -66,6 +66,7 @@ async function boot(opts: { releaseDuties?: (groupIds: string[]) => Promise<void
   })
   ;(daemon as any).cpClient = {
     organizationScope: () => 'frame',
+    memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
     stop,
     releaseDuties,
     reportDutiesNow,

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -89,6 +89,8 @@ async function boot(scope: 'frame' | 'connection' = 'frame') {
   const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
   ;(daemon as any).cpClient = {
     organizationScope: () => scope,
+    // Membership, not tenancy, is what makes duties enforced (daemon-groups.md §3).
+    memberSet: () => (scope === 'frame' ? { setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' } : null),
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
     // An admission reports its new digest immediately: the CP holds every projection that
@@ -116,6 +118,7 @@ async function bootMidAdmission() {
   })
   ;(daemon as any).cpClient = {
     organizationScope: () => 'frame',
+    memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
     // An admission reports its new digest immediately: the CP holds every projection that

--- a/packages/daemon/test/daemon-duty-inbox-replay.test.ts
+++ b/packages/daemon/test/daemon-duty-inbox-replay.test.ts
@@ -102,6 +102,7 @@ async function boot(root: string) {
   const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
   ;(daemon as any).cpClient = {
     organizationScope: () => 'frame',
+    memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
     reportDutiesNow: vi.fn(() => {}),

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -119,6 +119,7 @@ async function boot(client: Record<string, unknown>) {
   await daemon.start()
   ;(daemon as any).cpClient = {
     organizationScope: () => 'frame',
+    memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
     // An admission reports its new digest immediately: the CP holds every projection that

--- a/packages/daemon/test/daemon-duty-replacement.test.ts
+++ b/packages/daemon/test/daemon-duty-replacement.test.ts
@@ -93,6 +93,7 @@ async function boot(broken = new Set<string>()) {
   })
   ;(daemon as any).cpClient = {
     organizationScope: () => 'frame',
+    memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
     // An admission reports its new digest immediately: the CP holds every projection that

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -369,8 +369,12 @@ describe('daemon --k8s mode', () => {
     })
     try {
       await k8sDaemon.start()
-      // An install-wide member: the duty ledger decides which agents it serves.
-      ;(k8sDaemon as any).cpClient = { organizationScope: () => 'frame', stop: async () => {} }
+      // A member of the install-wide pool: the duty ledger decides which agents it serves.
+      ;(k8sDaemon as any).cpClient = {
+        organizationScope: () => 'frame',
+        memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
+        stop: async () => {}
+      }
       ;(k8sDaemon as any).duties.applyGrant([
         {
           groupId: '11111111-1111-4111-8111-111111111111',
@@ -406,6 +410,7 @@ describe('daemon --k8s mode', () => {
       await k8sDaemon.start()
       ;(k8sDaemon as any).cpClient = {
         organizationScope: () => 'frame',
+        memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
         stop: async () => {},
         releaseDuties: vi.fn(async () => {}),
         reportDutiesNow: vi.fn(() => {}),

--- a/packages/daemon/test/daemon-loop-guard-pool.test.ts
+++ b/packages/daemon/test/daemon-loop-guard-pool.test.ts
@@ -63,6 +63,8 @@ async function boot(root: string, daemonId: string, scope: 'frame' | 'legacy') {
   inner.cfg.daemonId = daemonId
   inner.cpClient = {
     organizationScope: () => scope,
+    // Membership, not tenancy, is what makes duties enforced (daemon-groups.md §3).
+    memberSet: () => (scope === 'frame' ? { setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' } : null),
     state: 'READY',
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),

--- a/packages/daemon/test/daemon-session-metadata-outbox-pool.test.ts
+++ b/packages/daemon/test/daemon-session-metadata-outbox-pool.test.ts
@@ -82,6 +82,8 @@ async function boot(root: string, daemonId: string, scope: 'frame' | 'install' =
   })
   inner.cpClient = {
     organizationScope: () => scope,
+    // Membership, not tenancy, is what makes duties enforced (daemon-groups.md §3).
+    memberSet: () => (scope === 'frame' ? { setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' } : null),
     state: 'READY',
     supportsServerFeature: (feature: string) => feature === 'session-metadata-ack-v1',
     syncEventSession,

--- a/packages/daemon/test/daemon-session-sweeps-pool.test.ts
+++ b/packages/daemon/test/daemon-session-sweeps-pool.test.ts
@@ -64,6 +64,7 @@ async function boot(root: string, daemonId: string) {
   const emitSessionPurged = vi.fn(async () => 'acknowledged' as const)
   inner.cpClient = {
     organizationScope: () => 'frame',
+    memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
     state: 'READY',
     emitSessionPurged,
     stop: async () => {},

--- a/packages/daemon/test/orchestration.test.ts
+++ b/packages/daemon/test/orchestration.test.ts
@@ -416,6 +416,7 @@ describe('pool duty gate on deadlines', () => {
   function frameScope(daemon: Daemon) {
     ;(daemon as any).cpClient = {
       organizationScope: () => 'frame',
+      memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
       stop: async () => {},
       releaseDuties: vi.fn(async () => {}),
       reportDutiesNow: vi.fn(() => {}),

--- a/packages/daemon/test/schedule-catchup.test.ts
+++ b/packages/daemon/test/schedule-catchup.test.ts
@@ -79,6 +79,7 @@ async function boot(root: string) {
   // Duty leases gate service, exactly like an install-wide pool member.
   inner.cpClient = {
     organizationScope: () => 'frame',
+    memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
     stop: async () => {},
     releaseDuties: vi.fn(async () => {}),
     reportDutiesNow: vi.fn(() => {}),

--- a/packages/protocol/src/frames/auth.ts
+++ b/packages/protocol/src/frames/auth.ts
@@ -51,6 +51,11 @@ export const AuthOk = z.object({
   // Single-org daemons inherit tenant context from auth; install-wide pool members require
   // every org-scoped post-auth frame to carry `Envelope.orgId`.
   organizationMode: z.enum(['connection', 'frame']).default('connection'),
+  // The member set this daemon belongs to (docs/designs/daemon-groups.md §3); absent means it is
+  // in none. Membership is never negotiated on the wire — the CP tells the daemon, the daemon does
+  // not tell — and this is the daemon's whole duty-enforcement predicate: in a set it serves only
+  // what it holds a lease for, in no set it owns its agents outright.
+  memberSet: z.object({ setId: z.string().uuid(), name: z.string() }).optional(),
   // Base URL of the Web App console (the CP's own public origin), so the daemon can build
   // session deep links without local config. Omitted when the CP has no console URL
   // configured; a daemon-local `webAppUrl` overrides it.


### PR DESCRIPTION
The second half of [daemon-groups.md](https://github.com/agentconnect-md/agentconnect/blob/main/docs/designs/daemon-groups.md) (#994), as its **mechanism**: an organization can now form a member set out of its own daemons, point agents at it, and get the same lease-driven failover the install-wide pool already has. For local daemons this is the cross-machine generalization of the singleton pid lock — today two daemons configured with the same bot token fight over the platform API.

Nothing in the duty ledger changed. PR 1 (#1003) already made eligibility one membership lookup, so this opens the door and stops.

## What lands

**The door.** `duty/claim`, `duty/fetch`, `duty/release` and the heartbeat admit any connection that is in a member set. `SCOPE_DENIED` now means "in no set" rather than "not install-wide". Tenancy is deliberately *not* re-checked there: the write-time invariants on membership already decide what being in a set means — an org set can only contain that org's daemons — so `mayHold` stays one rule and the narrowing follows.

**The announcement.** `auth/ok` carries the daemon's set, and that is the daemon's whole duty-enforcement predicate: a member serves only what it holds a lease for, a daemon in no set owns its agents outright. `dutyEnforced()` no longer reads the organization mode at all. Membership is never negotiated on the wire — the control plane tells the daemon, the daemon does not tell.

**The converse invariant.** A `daemon` placement may not name a machine that is in a set. Such an agent would be placed and unservable at once, and refusing it statically is what lets the eligibility predicate stay branch-free.

**The surface.** Org-set CRUD and membership at `/orgs/:orgId/member-sets`, and the daemon read model carries its set. The org-less pool is not reachable there — it belongs to no organization. The console is **not** in this PR; the data and wire formats it needs are.

## Membership transitions: preconditions, not choreography

§3 asks for two-phase generation-fenced transitions. This PR takes the same safety rule — never commit while the old authority might still be serving — and pays for it with preconditions, so no new frame, fence column, or transition generation exists yet:

- **Join** is refused (409) while the daemon still has agents pinned directly to it. Re-place them on the set first, with the move machinery that already exists.
- **Leave** is refused (409) while the daemon holds a *live* duty lease. Drain it, or let the lease lapse — a lapsed lease is strictly later than that member's own self-fence horizon, which is the same evidence the design's unreachable-leaver path waits for.
- Either way the daemon relearns its set the one way it ever learns it: the socket closes `1012` and the reconnect's `auth/ok` carries the new membership. Both admitted transitions leave nothing running to disturb, so the reconnect costs nothing.

That is strictly narrower than §3, never wider: every transition it performs is one §3 also permits. What is still owed is the operator ergonomics — one-action enrol-with-agents and drain-and-leave — which is where the correlated withdrawal and the transition generation earn their keep. Recorded in the design doc rather than left implicit.

## Reviewing

The load-bearing question is whether admitting org-scoped claimants widened anything. `test/repo/org-member-set.test.ts` is the matrix that answers it: a member of set G in org X claims a `set`-placed agent of X in G, and is refused an agent of X in another set, any agent of another org, any pool agent, and any pinned agent; a pool member is refused every org-set agent; a stopped member's agents re-grant to a peer with nothing sent. `test/integration/member-sets.route.test.ts` covers the org fence and both transition refusals; `authService.test.ts` locks the announcement, including that an unreadable membership fails the handshake `1011` rather than quietly announcing "no set".

`test/fakes/build-ws.ts` and friends had to grow the new repo argument, which is why `DaemonAuthService` takes it as a **required** constructor parameter: a wiring hole that omitted it would look exactly like an empty pool and silence the whole ledger. That is how the one regression in this branch was found.

## Verification

- control-plane integration: 1407 passed
- control-plane unit: 1752 passed
- daemon: 3805 passed; 15 pre-existing local failures in `shim-*` / `workspace-git-runner-seam` / `acp-matrix`, reproduced identically with `packages/daemon/src` reverted to the parent commit
- protocol / relay / connection: 345 / 496 / 28 passed
- typecheck, lint, format clean

Closes #1000. Tracked under #955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
