### PR TITLE
perf(web): batch streamed text deltas per lane

### DIFF
--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -57,6 +57,7 @@ import {
   laneKey,
   lanesOf as lanesOfLanes
 } from '@/lib/webchat-lanes'
+import { createWebchatDeltaBuffer, type WebchatDeltaBuffer } from '@/lib/webchat-delta-buffer'
 
 interface PlaygroundData {
   /** Composer buffer for one session id (each live conversation has its own).
@@ -565,6 +566,20 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [mutateSteps, participantName]
   )
 
+  // WebSocket messages arrive as separate browser tasks, so React cannot batch
+  // their state updates automatically. Accumulate text per participant lane for
+  // one animation frame (with a 50 ms background-tab cap) and commit once.
+  const applyEventRef = useRef(applyEvent)
+  applyEventRef.current = applyEvent
+  const deltaBufferRef = useRef<WebchatDeltaBuffer | null>(null)
+  if (!deltaBufferRef.current) {
+    deltaBufferRef.current = createWebchatDeltaBuffer((batch) => {
+      applyEventRef.current(batch.sessionId, batch.event, laneAgentId(batch.laneKey), batch.turnId)
+    })
+  }
+  const deltaBuffer = deltaBufferRef.current
+  useEffect(() => () => deltaBuffer.discardAll(), [deltaBuffer])
+
   /** Fold a status snapshot (model / context / tokens / cost) into the session's headline
    *  fields + `usage` — this is the live status bar, NOT a transcript step. Only defined
    *  fields overwrite, so a partial snapshot (context-only mid-turn) never clears the
@@ -648,6 +663,9 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   }, [])
   const getBusyLaneAgentIds = useCallback((id: string): string[] => busyLaneAgents[id] ?? [], [busyLaneAgents])
   const dropLanes = (id: string): void => {
+    // Preserve text already received before surfacing a terminal connection
+    // error; otherwise the final sub-frame would disappear from the transcript.
+    deltaBuffer.flushSession(id)
     for (const key of lanesOf(id)) streamCursors.current.delete(key)
     syncBusyLanes(id)
   }
@@ -673,11 +691,21 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         if (output.status) applyStatus(id, output.status, agentId)
         const event = output.event
         if (event) {
-          if (event.kind === 'session_info') applyTitle(id, event.title, agentId)
-          else applyEvent(id, event, agentId, output.turnId)
+          if (event.kind === 'message' || event.kind === 'thinking') {
+            deltaBuffer.enqueue(cursorKey, id, output.turnId, event)
+          } else {
+            // Tool/supersession events are ordering fences: make preceding text
+            // visible before applying the non-text event.
+            deltaBuffer.flush(cursorKey)
+            if (event.kind === 'session_info') applyTitle(id, event.title, agentId)
+            else applyEvent(id, event, agentId, output.turnId)
+          }
         }
       }
       if (!result.done) return
+      // `done` is a hard fence and must not clear busy state before the last
+      // buffered reply text has committed.
+      deltaBuffer.flush(cursorKey)
       reconnectAttempts.current.delete(id)
       streamCursors.current.delete(cursorKey)
       syncBusyLanes(id)
@@ -699,7 +727,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       // The turn stays busy until every targeted participant's lane finished.
       if (lanesOf(id).length === 0) setBusy(id, false)
     },
-    [applyEvent, applyStatus, applyTitle, failStream, participantName, pushStep, setBusy]
+    [applyEvent, applyStatus, applyTitle, deltaBuffer, failStream, participantName, pushStep, setBusy]
   )
 
   const receiveOutput = useCallback(
@@ -974,6 +1002,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 // targets of a multi-agent turn keep streaming.
                 const key = cursorKeyFor(id, m.ack.agentId)
                 if (key) {
+                  deltaBuffer.flush(key)
                   streamCursors.current.delete(key)
                   syncBusyLanes(id)
                 }
@@ -1015,7 +1044,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       conns.current.set(id, conn)
       return conn
     },
-    [activeOrg, failStream, receiveDone, receiveOutput, pushStep, setBusy]
+    [activeOrg, deltaBuffer, failStream, receiveDone, receiveOutput, pushStep, setBusy]
   )
 
   const openPlayground = useCallback(

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -256,3 +256,97 @@ describe('agent-initiated post frames', () => {
     expect(posts[0]).toMatchObject({ kind: 'done', agentId: 'agent-2', text: 'hi from B' })
   })
 })
+
+describe('stream text delta batching', () => {
+  class CapturingDeltaSocket extends StubSocket {
+    static instances: CapturingDeltaSocket[] = []
+    onopen?: () => void
+    onmessage?: (e: { data: string }) => void
+    onerror?: (e: unknown) => void
+    onclose?: () => void
+    constructor() {
+      super()
+      CapturingDeltaSocket.instances.push(this)
+    }
+  }
+
+  async function openStream() {
+    CapturingDeltaSocket.instances = []
+    Reflect.set(globalThis, 'WebSocket', CapturingDeltaSocket)
+    const api = await import('@/lib/api')
+    vi.mocked(api.webchatWsUrl).mockResolvedValue('wss://relay.test/ws')
+    await act(async () => {
+      pgSend('s1', 'agent-1', 'hello', 'c1')
+    })
+    const socket = CapturingDeltaSocket.instances[0]!
+    await act(async () => {
+      socket.readyState = 1
+      socket.onopen?.()
+    })
+    const turn = JSON.parse(String(socket.send.mock.calls.at(-1)?.[0])) as { turnId: string }
+    return { socket, turnId: turn.turnId }
+  }
+
+  function captureAnimationFrames() {
+    let nextId = 1
+    const frames = new Map<number, FrameRequestCallback>()
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      const id = nextId++
+      frames.set(id, callback)
+      return id
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+      frames.delete(id)
+    })
+    return () => {
+      const callbacks = [...frames.values()]
+      frames.clear()
+      for (const callback of callbacks) callback(16)
+    }
+  }
+
+  it('commits several same-frame message deltas as one transcript update', async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    act(() => {
+      for (const [index, text] of ['Hel', 'lo', '!'].entries()) {
+        socket.onmessage?.({
+          data: JSON.stringify({
+            type: 'output',
+            output: { turnId, agentId: 'agent-1', index, event: { kind: 'message', text } }
+          })
+        })
+      }
+    })
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toEqual([])
+
+    act(runFrame)
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toMatchObject([
+      { kind: 'done', text: 'Hello!' }
+    ])
+  })
+
+  it('flushes the final text before applying done', async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId, agentId: 'agent-1', index: 0, event: { kind: 'thinking', text: 'complete' } }
+        })
+      })
+      socket.onmessage?.({
+        data: JSON.stringify({ type: 'done', done: { turnId, agentId: 'agent-1', lastIndex: 0 } })
+      })
+    })
+
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toMatchObject([
+      { kind: 'plan', text: 'complete' }
+    ])
+    act(runFrame)
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toHaveLength(1)
+  })
+})

--- a/packages/web/src/lib/webchat-delta-buffer.test.ts
+++ b/packages/web/src/lib/webchat-delta-buffer.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createWebchatDeltaBuffer,
+  type WebchatDeltaScheduler,
+  type WebchatTextDeltaBatch
+} from './webchat-delta-buffer'
+
+function harness() {
+  let nextId = 1
+  const frames = new Map<number, FrameRequestCallback>()
+  const timers = new Map<number, () => void>()
+  const scheduler: WebchatDeltaScheduler = {
+    requestFrame: (callback) => {
+      const id = nextId++
+      frames.set(id, callback)
+      return id
+    },
+    cancelFrame: (id) => frames.delete(id),
+    setTimer: (callback) => {
+      const id = nextId++
+      timers.set(id, callback)
+      return id
+    },
+    clearTimer: (id) => timers.delete(Number(id))
+  }
+  const flushed: WebchatTextDeltaBatch[] = []
+  const buffer = createWebchatDeltaBuffer((batch) => flushed.push(batch), { scheduler })
+  return {
+    buffer,
+    flushed,
+    runFrame: () => frames.values().next().value?.(16),
+    runTimer: () => timers.values().next().value?.(),
+    pendingFrames: () => frames.size,
+    pendingTimers: () => timers.size
+  }
+}
+
+describe('webchat delta buffer', () => {
+  it('merges same-kind deltas in one lane into one frame commit', () => {
+    const h = harness()
+    h.buffer.enqueue('s:a', 's', 't1', { kind: 'message', text: 'Hel' })
+    h.buffer.enqueue('s:a', 's', 't1', { kind: 'message', text: 'lo' })
+    h.buffer.enqueue('s:a', 's', 't1', { kind: 'message', text: '!' })
+
+    expect(h.flushed).toEqual([])
+    h.runFrame()
+    expect(h.flushed).toEqual([
+      { laneKey: 's:a', sessionId: 's', turnId: 't1', event: { kind: 'message', text: 'Hello!' } }
+    ])
+    expect(h.pendingFrames()).toBe(0)
+    expect(h.pendingTimers()).toBe(0)
+  })
+
+  it('buffers participant lanes independently', () => {
+    const h = harness()
+    h.buffer.enqueue('s:a', 's', 't1', { kind: 'message', text: 'A' })
+    h.buffer.enqueue('s:b', 's', 't1', { kind: 'message', text: 'B' })
+
+    h.buffer.flush('s:a')
+    expect(h.flushed.map((batch) => batch.event.text)).toEqual(['A'])
+    expect(h.pendingFrames()).toBe(1)
+    h.runFrame()
+    expect(h.flushed.map((batch) => batch.event.text)).toEqual(['A', 'B'])
+  })
+
+  it('flushes synchronously at kind and turn boundaries', () => {
+    const h = harness()
+    h.buffer.enqueue('s:a', 's', 't1', { kind: 'thinking', text: 'plan' })
+    h.buffer.enqueue('s:a', 's', 't1', { kind: 'message', text: 'answer' })
+    h.buffer.enqueue('s:a', 's', 't2', { kind: 'message', text: 'next' })
+
+    expect(h.flushed.map((batch) => [batch.turnId, batch.event.kind, batch.event.text])).toEqual([
+      ['t1', 'thinking', 'plan'],
+      ['t1', 'message', 'answer']
+    ])
+    h.runFrame()
+    expect(h.flushed.at(-1)).toMatchObject({ turnId: 't2', event: { text: 'next' } })
+  })
+
+  it('uses the max-wait timer when animation frames are throttled', () => {
+    const h = harness()
+    h.buffer.enqueue('s:a', 's', 't1', { kind: 'message', text: 'visible' })
+    h.runTimer()
+
+    expect(h.flushed).toHaveLength(1)
+    expect(h.pendingFrames()).toBe(0)
+    expect(h.pendingTimers()).toBe(0)
+  })
+
+  it('flushes every lane in a session and discards scheduled work on teardown', () => {
+    const h = harness()
+    h.buffer.enqueue('s:a', 's', 't1', { kind: 'message', text: 'A' })
+    h.buffer.enqueue('s:b', 's', 't1', { kind: 'message', text: 'B' })
+    h.buffer.enqueue('other:a', 'other', 't2', { kind: 'message', text: 'C' })
+    h.buffer.flushSession('s')
+
+    expect(h.flushed.map((batch) => batch.event.text)).toEqual(['A', 'B'])
+    h.buffer.discardAll()
+    expect(h.pendingFrames()).toBe(0)
+    expect(h.pendingTimers()).toBe(0)
+    expect(h.flushed).toHaveLength(2)
+  })
+
+  it('does not double-flush when a stale scheduled callback runs', () => {
+    const h = harness()
+    h.buffer.enqueue('s:a', 's', 't1', { kind: 'message', text: 'once' })
+    h.buffer.flush('s:a')
+    h.runFrame()
+    h.runTimer()
+    expect(h.flushed).toHaveLength(1)
+  })
+})

--- a/packages/web/src/lib/webchat-delta-buffer.ts
+++ b/packages/web/src/lib/webchat-delta-buffer.ts
@@ -1,0 +1,101 @@
+export type WebchatTextDelta = { kind: 'message' | 'thinking'; text: string }
+
+export interface WebchatTextDeltaBatch {
+  laneKey: string
+  sessionId: string
+  turnId: string
+  event: WebchatTextDelta
+}
+
+interface ScheduledBatch extends WebchatTextDeltaBatch {
+  frameId: number
+  timerId: number
+}
+
+export interface WebchatDeltaScheduler {
+  requestFrame: (callback: FrameRequestCallback) => number
+  cancelFrame: (id: number) => void
+  setTimer: (callback: () => void, delayMs: number) => number
+  clearTimer: (id: number) => void
+}
+
+export interface WebchatDeltaBuffer {
+  enqueue: (laneKey: string, sessionId: string, turnId: string, event: WebchatTextDelta) => void
+  flush: (laneKey: string) => void
+  flushSession: (sessionId: string) => void
+  discardAll: () => void
+}
+
+export const WEBCHAT_DELTA_MAX_WAIT_MS = 50
+
+const browserScheduler: WebchatDeltaScheduler = {
+  requestFrame: (callback) => window.requestAnimationFrame(callback),
+  cancelFrame: (id) => window.cancelAnimationFrame(id),
+  setTimer: (callback, delayMs) => window.setTimeout(callback, delayMs),
+  clearTimer: (id) => window.clearTimeout(id)
+}
+
+/**
+ * Coalesce high-frequency text deltas independently per participant lane.
+ * The next animation frame normally supplies the ~16 ms boundary; the timer
+ * caps latency when rAF is throttled (for example in a background tab).
+ */
+export function createWebchatDeltaBuffer(
+  onFlush: (batch: WebchatTextDeltaBatch) => void,
+  options: { maxWaitMs?: number; scheduler?: WebchatDeltaScheduler } = {}
+): WebchatDeltaBuffer {
+  const maxWaitMs = options.maxWaitMs ?? WEBCHAT_DELTA_MAX_WAIT_MS
+  const scheduler = options.scheduler ?? browserScheduler
+  const pending = new Map<string, ScheduledBatch>()
+
+  const flushBatch = (laneKey: string, expected?: ScheduledBatch): void => {
+    const batch = pending.get(laneKey)
+    if (!batch || (expected && batch !== expected)) return
+    pending.delete(laneKey)
+    scheduler.cancelFrame(batch.frameId)
+    scheduler.clearTimer(batch.timerId)
+    onFlush({
+      laneKey: batch.laneKey,
+      sessionId: batch.sessionId,
+      turnId: batch.turnId,
+      event: batch.event
+    })
+  }
+
+  const enqueue = (laneKey: string, sessionId: string, turnId: string, event: WebchatTextDelta): void => {
+    const current = pending.get(laneKey)
+    if (current && current.sessionId === sessionId && current.turnId === turnId && current.event.kind === event.kind) {
+      current.event.text += event.text
+      return
+    }
+    if (current) flushBatch(laneKey, current)
+
+    const batch: ScheduledBatch = {
+      laneKey,
+      sessionId,
+      turnId,
+      event: { ...event },
+      frameId: 0,
+      timerId: 0
+    }
+    batch.frameId = scheduler.requestFrame(() => flushBatch(laneKey, batch))
+    batch.timerId = scheduler.setTimer(() => flushBatch(laneKey, batch), maxWaitMs)
+    pending.set(laneKey, batch)
+  }
+
+  const flushSession = (sessionId: string): void => {
+    for (const [laneKey, batch] of pending) {
+      if (batch.sessionId === sessionId) flushBatch(laneKey, batch)
+    }
+  }
+
+  const discardAll = (): void => {
+    for (const batch of pending.values()) {
+      scheduler.cancelFrame(batch.frameId)
+      scheduler.clearTimer(batch.timerId)
+    }
+    pending.clear()
+  }
+
+  return { enqueue, flush: flushBatch, flushSession, discardAll }
+}


### PR DESCRIPTION
## Summary

- buffer streamed `message` and `thinking` deltas independently per participant lane
- flush on the next animation frame, with a 50 ms fallback when `requestAnimationFrame` is throttled
- preserve event ordering by flushing at turn, event-kind, tool, supersession, failure, rejection, and done boundaries
- cancel scheduled work when the provider unmounts

## Why

Each WebSocket output arrives in a separate browser task, so React cannot automatically batch the resulting state updates. Committing every token-sized delta repeatedly invalidates the transcript and reruns the React Markdown pipeline.

## Impact

A synthetic 360-delta benchmark using the existing `SlackMrkdwnText` renderer measured:

| Delta interval | Commits after buffering | Commit reduction |
| ---: | ---: | ---: |
| 1 ms | 22 | 93.9% |
| 2 ms | 44 | 87.8% |
| 4 ms | 87 | 75.8% |
| 8 ms | 173 | 51.9% |

At a 4 ms delta interval, median Markdown render CPU time fell from 1518 ms to 428 ms (71.8% less, 3.55x faster). This is a Node SSR microbenchmark intended to isolate Markdown parsing/rendering cost, not a browser FPS measurement.

## Validation

- `vitest`: 21 tests passed
- TypeScript: passed
- ESLint: passed
- Next.js production build: passed
- Docker web image built and smoke-tested against the HTTPS gateway