### PR TITLE
fix(web): follow the console design for daemon groups

### DIFF
--- a/packages/web/src/app/(app)/[slug]/daemons/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/daemons/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import DaemonsView from '@/components/console/views/DaemonsView'
 
-export const metadata: Metadata = { title: 'Daemons · AgentConnect' }
+export const metadata: Metadata = { title: 'Infra · AgentConnect' }
 
 export default function Page() {
   return <DaemonsView />

--- a/packages/web/src/components/console/DaemonSelect.tsx
+++ b/packages/web/src/components/console/DaemonSelect.tsx
@@ -17,9 +17,10 @@ export interface DaemonSelectOption {
 /** A set target is drawn as a target, never as the member that happens to answer for it. */
 const isSet = (option: Pick<DaemonSelectOption, 'kind'>): boolean => option.kind === 'pool' || option.kind === 'group'
 const iconFor = (option: DaemonSelectOption): string =>
-  option.kind === 'pool' ? 'cloud' : option.kind === 'group' ? 'boxes' : option.value ? 'server' : 'server-off'
-const badgeFor = (option: DaemonSelectOption): string | null =>
-  option.kind === 'pool' ? 'Cloud' : option.kind === 'group' ? 'Group' : null
+  option.kind === 'pool' ? 'cloud' : option.kind === 'group' ? 'layers' : option.value ? 'server' : 'server-off'
+// Cloud is a product and carries its name as a badge; a group carries its own name already, and the
+// design's group row has no badge — the layers mark is what says "a set, not a machine".
+const badgeFor = (option: DaemonSelectOption): string | null => (option.kind === 'pool' ? 'Cloud' : null)
 
 function enabledIndex(options: readonly DaemonSelectOption[], start: number, delta: 1 | -1): number {
   if (!options.length) return -1

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -338,7 +338,15 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
 
   // Cloud is one UI choice AND one server-side placement: the pool, named as itself.
   const daemonChoice = addAgentDaemonChoice(daemons, daemonId, memberSets)
-  const { poolAvailable, availableGroups, daemon, localDaemons, placement, value: effectiveDaemonId } = daemonChoice
+  const {
+    poolAvailable,
+    availableGroups,
+    offeredGroups,
+    daemon,
+    localDaemons,
+    placement,
+    value: effectiveDaemonId
+  } = daemonChoice
   const daemonOptions: DaemonSelectOption[] = [
     ...(poolAvailable
       ? [
@@ -352,11 +360,16 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
       : []),
     // The org's own groups sit with Cloud, not with the machines: they are the same KIND of target
     // — the server picks which member serves, and the agent survives losing any one of them.
-    ...availableGroups.map((group) => ({
+    ...offeredGroups.map((group) => ({
       value: groupPlacementValue(group.setId),
       label: group.name,
-      detail: `${group.memberDaemonIds.length} daemon${group.memberDaemonIds.length === 1 ? '' : 's'} — any one of them can serve this agent.`,
-      kind: 'group' as const
+      detail: availableGroups.includes(group)
+        ? 'Any daemon in the group.'
+        : group.memberDaemonIds.length === 0
+          ? 'No daemons in this group yet.'
+          : 'No daemon in this group is serving right now.',
+      kind: 'group' as const,
+      disabled: !availableGroups.includes(group)
     })),
     ...localDaemons.map((candidate) => ({
       value: candidate.daemonId,

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -392,8 +392,10 @@ export default function EditAgentModal({
         value: groupPlacementValue(group.setId),
         label: group.name,
         detail: serving
-          ? `${group.memberDaemonIds.length} daemon${group.memberDaemonIds.length === 1 ? '' : 's'} — any one of them can serve this agent.`
-          : 'No daemon in this group is serving right now.',
+          ? 'Any daemon in the group.'
+          : group.memberDaemonIds.length === 0
+            ? 'No daemons in this group yet.'
+            : 'No daemon in this group is serving right now.',
         kind: 'group' as const,
         disabled: !current && !serving
       }

--- a/packages/web/src/components/console/modals/GroupModal.tsx
+++ b/packages/web/src/components/console/modals/GroupModal.tsx
@@ -1,31 +1,55 @@
 // No 'use client' here: rendered only by ModalProvider (the client boundary).
 
 import { useState } from 'react'
-import type { MemberSetRow } from '@/lib/data'
+import type { DaemonRow, MemberSetRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Button, Icon } from '@/components/ui'
 
 /**
- * Create or rename a daemon group (docs/designs/daemon-groups.md §2).
+ * New / Edit group (docs/designs/daemon-groups.md §2) — name and membership in one dialog.
  *
- * A group has exactly one editable property — its name. Membership is not here: enrolling a daemon
- * moves runtime authority and is refused while agents are still pinned to it, so it belongs on the
- * daemon whose authority is moving, next to the state that decides whether it is allowed.
+ * Membership belongs here rather than only on each daemon's own page: a group that cannot be
+ * filled where it is created is not a feature, and "which machines are in it" is the only thing
+ * about a group worth editing besides its name.
+ *
+ * The two directions are not symmetric, and the dialog says so before it lets you act (§3):
+ * joining is refused while agents are still pinned to that machine — a member serves only what it
+ * holds a lease for, so those agents would be placed and unservable at once — and leaving is
+ * refused while it still holds live work. Each row is applied on its own, so one refusal reports
+ * itself and leaves the rest of the edit intact.
  */
 export default function GroupModal({ group, onClose }: { group?: MemberSetRow; onClose: () => void }) {
-  const { createGroup, renameGroup } = useConsoleData()
+  const { createGroup, renameGroup, enrollInGroup, withdrawFromGroup, daemons, agents } = useConsoleData()
   const [name, setName] = useState(group?.name ?? '')
+  // The membership this dialog is editing, seeded from the group and applied on save.
+  const [members, setMembers] = useState<string[]>(group?.memberDaemonIds ?? [])
   const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const trimmed = name.trim()
+
+  // A daemon the org owns is a candidate unless it is in a DIFFERENT group: a daemon is in at most
+  // one, and moving it between groups is a two-phase transition, not a checkbox.
+  const candidates = daemons.filter((d) => !d.pool && (!d.memberSetId || d.memberSetId === group?.setId))
+  const pinnedCount = (daemon: DaemonRow) => agents.filter((a) => a.daemon === daemon.daemonId).length
+
+  const toggle = (daemonId: string) =>
+    setMembers((current) =>
+      current.includes(daemonId) ? current.filter((id) => id !== daemonId) : [...current, daemonId]
+    )
 
   const save = async () => {
     if (saving || !trimmed) return
     setSaving(true)
     setErr(null)
     try {
-      if (group) await renameGroup(group.setId, trimmed)
-      else await createGroup(trimmed)
+      const setId = group ? group.setId : (await createGroup(trimmed)).setId
+      if (group && trimmed !== group.name) await renameGroup(setId, trimmed)
+      const before = new Set(group?.memberDaemonIds ?? [])
+      const after = new Set(members)
+      // Each membership write is its own request with its own precondition, so they are applied one
+      // at a time: a refusal names the machine that caused it instead of failing the whole dialog.
+      for (const daemonId of members.filter((id) => !before.has(id))) await enrollInGroup(setId, daemonId)
+      for (const daemonId of [...before].filter((id) => !after.has(id))) await withdrawFromGroup(setId, daemonId)
       onClose()
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
@@ -37,10 +61,10 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
     <>
       <div className="modalhead">
         <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
-          <Icon name="boxes" size={15} color="var(--brand)" />
+          <Icon name="layers" size={15} color="var(--brand)" />
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">
-          {group ? 'Rename group' : 'New group'}
+          {group ? 'Edit group' : 'New group'}
         </span>
         <button className="iconbtn" onClick={onClose}>
           <Icon name="x" size={16} />
@@ -51,21 +75,68 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
           <span className="fldlbl">Name</span>
           <input
             className="inp focus:border-(--brand) focus:outline-none"
-            placeholder="lab"
+            placeholder="edge-pool"
             value={name}
             maxLength={64}
             onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && void save()}
             autoFocus
           />
         </div>
-        {!group && (
-          <p className="mt-[14px] font-sans text-[12.5px] font-normal leading-[1.6] text-(--text-secondary)">
-            A group is a set of your daemons an agent can be placed on instead of one machine. Whichever member is
-            serving runs the agent, so losing any one of them moves its work to another. Add daemons from their own
-            pages once the group exists.
-          </p>
-        )}
+        <div className="fld mt-[14px]">
+          <span className="fldlbl">Daemons</span>
+          {candidates.length === 0 ? (
+            <div className="rounded-lg border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[14px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+              No daemons available. Connect one, or remove it from its current group first.
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-lg border border-(--border-subtle)">
+              {candidates.map((daemon) => {
+                const checked = members.includes(daemon.daemonId)
+                const pinned = pinnedCount(daemon)
+                // Pinned agents block only a JOIN — a machine already in the group has none.
+                const blocked = !checked && !group?.memberDaemonIds.includes(daemon.daemonId) && pinned > 0
+                return (
+                  <button
+                    key={daemon.daemonId}
+                    type="button"
+                    className={`flex w-full items-center gap-[10px] border-0 border-b border-(--border-subtle) bg-(--surface-card) px-3 py-[10px] text-left last:border-b-0 ${
+                      blocked ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:bg-(--surface-hover)'
+                    }`}
+                    disabled={blocked}
+                    onClick={() => toggle(daemon.daemonId)}
+                  >
+                    <span
+                      className={`flex h-[18px] w-[18px] flex-none items-center justify-center rounded-[5px] border ${
+                        checked ? 'border-(--brand) bg-(--brand)' : 'border-(--border-strong) bg-(--surface-card)'
+                      }`}
+                    >
+                      {checked && <Icon name="check" size={13} color="#fff" />}
+                    </span>
+                    <span className="flex h-6 w-6 flex-none items-center justify-center rounded-md bg-(--surface-sunken)">
+                      <Icon name="server" size={13} color="var(--text-tertiary)" />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="mono block truncate text-[12.5px] font-medium text-(--text-primary)">
+                        {daemon.name}
+                      </span>
+                      <span className="block truncate font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+                        {blocked
+                          ? `Move its ${pinned} placed agent${pinned === 1 ? '' : 's'} onto a group first`
+                          : daemon.status === 'online'
+                            ? 'Online'
+                            : 'Offline'}
+                      </span>
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+        <p className="mt-[12px] font-sans text-[12px] font-normal leading-[1.6] text-(--text-tertiary)">
+          An agent placed on this group runs on whichever member is serving, so it keeps running when any single one
+          does not.
+        </p>
         {err && (
           <div className="mt-[14px] flex items-start gap-2 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[11px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--status-error)">
             <Icon name="triangle-alert" size={15} />

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
@@ -10,6 +10,8 @@ export interface AddAgentDaemonChoice<T extends DaemonChoiceRow> {
   poolAvailable: boolean
   /** Groups with at least one member serving — the only ones an agent can start on. */
   availableGroups: MemberSetRow[]
+  /** Every group, in listing order: an unservable one is shown disabled, never hidden. */
+  offeredGroups: readonly MemberSetRow[]
   /**
    * The daemon whose reported CAPABILITIES the form reads (runtimes, models, sandbox). For a set
    * target that is one live member standing in for the set, which is exactly what the server will
@@ -37,7 +39,10 @@ export function addAgentDaemonChoice<T extends DaemonChoiceRow>(
   const localDaemons = onlineFirst(daemons.filter((daemon) => !daemon.pool && !daemon.memberSetId))
   const liveMemberOf = (group: MemberSetRow): T | undefined =>
     daemons.find((daemon) => daemon.status === 'online' && group.memberDaemonIds.includes(daemon.daemonId))
+  // Every group is OFFERED; only a serving one is selectable. Hiding an empty group answered the
+  // operator's "where is the group I just made?" with silence.
   const availableGroups = groups.filter((group) => liveMemberOf(group) !== undefined)
+  const offeredGroups = groups
 
   const selectedGroup = availableGroups.find((group) => groupSetIdOf(selectedValue) === group.setId)
   const selectedLocal = localDaemons.find((daemon) => daemon.daemonId === selectedValue)
@@ -66,6 +71,7 @@ export function addAgentDaemonChoice<T extends DaemonChoiceRow>(
   return {
     poolAvailable: poolDaemons.length > 0,
     availableGroups,
+    offeredGroups,
     daemon,
     daemonId: selectedGroup ? null : value || null,
     localDaemons,

--- a/packages/web/src/components/console/nav.ts
+++ b/packages/web/src/components/console/nav.ts
@@ -23,7 +23,7 @@ export const NAV_GROUPS: NavItem[][] = [
     { href: '/integrations', label: 'Integrations', icon: 'plug' },
     { href: '/usage', label: 'Analytics', icon: 'circle-gauge' }
   ],
-  [{ href: '/daemons', label: 'Daemons', icon: 'server' }]
+  [{ href: '/daemons', label: 'Infra', icon: 'server' }]
 ]
 
 // Bottom tab bar (mobile only) — exactly the design's 5-slot bar: the 4 primary
@@ -45,7 +45,7 @@ export const MORE_ROWS: NavItem[] = [
   { href: '/tools', label: 'Tools & Skills', icon: 'blocks' },
   { href: '/knowledge', label: 'Knowledge', icon: 'book-open' },
   { href: '/integrations', label: 'Integrations', icon: 'plug' },
-  { href: '/daemons', label: 'Daemons', icon: 'server' },
+  { href: '/daemons', label: 'Infra', icon: 'server' },
   { href: '/settings', label: 'Settings', icon: 'settings' }
 ]
 
@@ -58,7 +58,7 @@ export const SECTIONS: { prefix: string; label: string }[] = [
   // Merged conversation pages live in the Sessions section (§5.3).
   { prefix: '/conversations', label: 'Sessions' },
   { prefix: '/crons', label: 'Schedules' },
-  { prefix: '/daemons', label: 'Daemons' },
+  { prefix: '/daemons', label: 'Infra' },
   { prefix: '/tools', label: 'Tools & Skills' },
   { prefix: '/knowledge', label: 'Knowledge' },
   { prefix: '/integrations', label: 'Integrations' },

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -95,7 +95,6 @@ export default function DaemonsView() {
             </span>
           </div>
           {poolMembers.length > 0 && <PoolFleetCard members={poolMembers} hosted={poolAgents} />}
-          <GroupsSection groups={memberSets} daemons={daemons} />
           {ownDaemons.length > 0 && (
             <>
               {/* The section label earns its place only next to the Cloud entry — without
@@ -113,6 +112,9 @@ export default function DaemonsView() {
               </div>
             </>
           )}
+          {/* Last, as the design orders it: the machines are the inventory, a group is what you
+              point an agent at once they exist. */}
+          <GroupsSection groups={memberSets} daemons={daemons} />
         </>
       )}
     </div>
@@ -120,106 +122,103 @@ export default function DaemonsView() {
 }
 
 /**
- * The organization's own groups (docs/designs/daemon-groups.md §2) — a named set of its daemons an
- * agent can be placed on instead of one machine.
+ * Daemon groups — the organization's own member sets (docs/designs/daemon-groups.md §2), as the
+ * console design draws them: a table under the machines, not cards among them. A group is a
+ * placement TARGET whose members are interchangeable, which is exactly what "Any daemon in the
+ * group" says and why the row borrows none of a daemon's telemetry.
  *
- * Sits with Cloud rather than with the machines below, because that is what it IS: a placement
- * target whose members are interchangeable, not a machine with a host and a CPU. Deliberately
- * borrows none of a daemon's telemetry — a group has no version, load or uptime of its own, and
- * the moment it shows one it starts reading like whichever member happened to answer.
- *
- * The section renders even with no groups, but only once the org has a daemon that could join one:
- * before that it is an answer to a question nobody has asked yet.
+ * Renders once the org has a daemon that could join one, or as soon as a group exists — before
+ * that it answers a question nobody has asked.
  */
 function GroupsSection({ groups, daemons }: { groups: MemberSetRow[]; daemons: DaemonRow[] }) {
   const { openModal } = useModal()
-  const joinable = daemons.some((d) => !d.pool)
-  if (!joinable && groups.length === 0) return null
+  if (!daemons.some((d) => !d.pool) && groups.length === 0) return null
 
   return (
     <>
       <div className="mt-6 mb-[9px] flex min-h-[26px] items-center gap-[9px]">
-        <span className="font-sans text-[13px] font-semibold leading-normal">Groups</span>
+        <span className="font-sans text-[13px] font-semibold leading-normal">Daemon groups</span>
         <span className="mono text-[11.5px] text-(--text-tertiary)">{groups.length}</span>
         <div className="flex-1" />
         <button
-          className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary) hover:text-(--text-primary)"
+          className="inline-flex cursor-pointer items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand)"
           onClick={() => openModal('group')}
         >
-          <Icon name="plus" size={14} />
+          <Icon name="plus" size={13} />
           New group
         </button>
       </div>
-      {groups.length === 0 ? (
-        <div className="card px-4 py-[15px] font-sans text-[12.5px] font-normal leading-[1.6] text-(--text-secondary)">
-          Place an agent on a group instead of one machine and it keeps running when that machine does not — whichever
-          member is serving picks the work up.
+      <div className="card">
+        <div className={`row h ${GROUP_COLS}`}>
+          <span>Group</span>
+          <span>Status</span>
+          <span>Daemons</span>
+          <span className="text-right">Agents</span>
+          <span />
         </div>
-      ) : (
-        <div className="flex flex-col gap-3 desktop:gap-[14px]">
-          {groups.map((group) => (
-            <GroupCard key={group.setId} group={group} daemons={daemons} />
-          ))}
-        </div>
-      )}
+        {groups.length === 0 ? (
+          <div className="px-4 py-[18px] font-sans text-[12.5px] font-normal leading-[1.6] text-(--text-secondary)">
+            Place an agent on a group instead of one machine and it keeps running when that machine does not — whichever
+            member is serving picks the work up.
+          </div>
+        ) : (
+          groups.map((group) => <GroupRow key={group.setId} group={group} daemons={daemons} />)
+        )}
+      </div>
     </>
   )
 }
 
-function GroupCard({ group, daemons }: { group: MemberSetRow; daemons: DaemonRow[] }) {
+/** The design's column track for the group table — header and rows share it verbatim. */
+const GROUP_COLS = 'grid-cols-[2.2fr_.9fr_1.9fr_.55fr_32px] gap-x-[14px]'
+
+function GroupRow({ group, daemons }: { group: MemberSetRow; daemons: DaemonRow[] }) {
   const { openModal } = useModal()
   const [menuOpen, setMenuOpen] = useState(false)
   const s = status(groupFleetStatus(group, daemons))
-  const members = group.memberDaemonIds.length
-  const serving = daemons.filter((d) => group.memberDaemonIds.includes(d.daemonId) && d.status === 'online').length
-  const meta =
-    members === 0
-      ? 'No daemons yet — add one from its own page.'
-      : `${members} daemon${members === 1 ? '' : 's'} · ${serving} serving`
+  const members = daemons.filter((d) => group.memberDaemonIds.includes(d.daemonId))
+  const serving = members.filter((d) => d.status === 'online').length
+  // Names the members, because "which machines is this" is the question a group row answers that a
+  // count cannot — falling back to the count once the list would not fit.
+  const memberText =
+    members.length === 0
+      ? 'No daemons yet'
+      : members.length <= 2
+        ? members.map((d) => d.name).join(', ')
+        : `${members.length} daemons · ${serving} serving`
 
   return (
-    <div className="card flex items-center gap-3 overflow-visible p-[14px] max-desktop:rounded-lg desktop:gap-[14px] desktop:px-4 desktop:py-[15px]">
-      <span className="relative flex h-10 w-10 flex-none items-center justify-center rounded-md bg-(--brand-soft) desktop:h-9 desktop:w-9">
-        <Icon name="boxes" size={20} color={serving > 0 ? 'var(--brand)' : 'var(--text-tertiary)'} />
-        <span
-          className="absolute -right-[3px] -bottom-[3px] h-3 w-3 rounded-full border-2 border-(--surface-card) desktop:hidden"
-          style={{ background: s.dot }}
-        />
-      </span>
-      <div className="flex min-w-0 flex-1 flex-col gap-[2px] desktop:gap-0">
-        <div className="flex min-w-0 items-center gap-[6px] desktop:gap-2">
-          <span className="truncate font-sans text-[14px] font-semibold leading-normal desktop:text-[13.5px]">
-            {group.name}
-          </span>
-          <span className="dot hidden flex-none desktop:inline-block" style={{ background: s.dot }} />
-        </div>
-        <div className="truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary) desktop:text-[11.5px] desktop:leading-[1.5]">
-          {meta}
-          <span className="desktop:hidden">{` · ${group.agentCount} agent${group.agentCount === 1 ? '' : 's'}`}</span>
+    <div className={`row click ${GROUP_COLS}`} onClick={() => openModal('group', group)}>
+      <div className="flex min-w-0 items-center gap-[10px]">
+        <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-subtle) bg-(--surface-sunken)">
+          <Icon name="layers" size={15} color={serving > 0 ? 'var(--brand)' : 'var(--text-tertiary)'} />
+        </span>
+        <div className="min-w-0">
+          <div className="mono truncate text-[13px] font-semibold text-(--text-primary)">{group.name}</div>
+          <div className="truncate text-[11px] text-(--text-tertiary)">Any daemon in the group</div>
         </div>
       </div>
-      <div className="hidden flex-none text-right desktop:block">
-        <div className="mono text-[14px] leading-normal font-semibold">{group.agentCount}</div>
-        <div className="font-sans text-[10.5px] font-normal leading-normal text-(--text-tertiary)">
-          agents on this group
-        </div>
+      <div className="flex items-center gap-[7px]">
+        <span className="dot" style={{ background: s.dot }} />
+        <span className="font-sans text-[12.5px] font-medium leading-normal" style={{ color: s.text }}>
+          {s.label}
+        </span>
       </div>
-      <span
-        className="badge flex-none max-desktop:px-[10px] max-desktop:py-[3px] max-desktop:text-[12px]"
-        style={{ background: s.bg, color: s.text }}
-      >
-        {s.label}
-      </span>
-      <div className="relative flex-none">
-        <button className="iconbtn" aria-label="Group actions" onClick={() => setMenuOpen((v) => !v)}>
+      <span className="mono truncate text-[12px] text-(--text-secondary)">{memberText}</span>
+      <span className="mono text-right text-[13px] text-(--text-primary)">{group.agentCount}</span>
+      <span className="relative flex justify-end" onClick={(e) => e.stopPropagation()}>
+        <button
+          className="iconbtn h-7 w-7"
+          aria-label="Group actions"
+          title="Group actions"
+          onClick={() => setMenuOpen((v) => !v)}
+        >
           <Icon name="ellipsis" size={16} />
         </button>
         {menuOpen && (
           <>
-            <div className="fixed inset-0 z-[45]" onClick={() => setMenuOpen(false)} />
-            {/* `.dmenu` is the row-overflow menu every card here uses — it anchors inside the card
-                instead of off the page edge, which a raw right-0 popover does not. */}
-            <div className="dmenu">
+            <div className="fixed inset-0 z-[49]" onClick={() => setMenuOpen(false)} />
+            <span className="dmenu top-8">
               <button
                 className="dmi"
                 onClick={() => {
@@ -228,8 +227,9 @@ function GroupCard({ group, daemons }: { group: MemberSetRow; daemons: DaemonRow
                 }}
               >
                 <Icon name="pencil" size={15} />
-                Rename
+                Edit group
               </button>
+              <span className="dmsep" />
               <button
                 className="dmi danger"
                 onClick={() => {
@@ -238,12 +238,12 @@ function GroupCard({ group, daemons }: { group: MemberSetRow; daemons: DaemonRow
                 }}
               >
                 <Icon name="trash-2" size={15} />
-                Delete group
+                Remove group
               </button>
-            </div>
+            </span>
           </>
         )}
-      </div>
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
Follow-up to #1115. I built that groups surface from the Infra screen I had read and never grepped the design for the **groups UI itself** — which, it turns out, specifies all of it. This corrects the console against the design, and closes the gap none of it would have fixed.

## Against the design

| | Was | Now |
| --- | --- | --- |
| Section | "Groups" | **"Daemon groups"** |
| Nav item | "Daemons" | **"Infra"** |
| Mark | `boxes` | **`layers`** — section, picker and dialog |
| Layout | cards among the machines | **a table under them**: Group / Status / Daemons / Agents, the row reading the name over "Any daemon in the group" |
| Row menu | Rename / Delete group | **Edit group / Remove group** |
| Position | above the daemons | **last on the page** — the machines are the inventory, a group is what you point an agent at once they exist |

The whole row opens the editor, not just the overflow menu.

## The gap that mattered more

A group could be **created but never filled**. Membership only existed on each daemon's own page, so the flow after "New group" was a dead end — which is exactly how it was reported.

Membership is now in the group dialog, where the group is made. Each daemon is a row with its state on it, and the join precondition is stated *before* the click rather than arriving as a 409: a machine with agents still pinned to it reads "Move its N placed agents onto a group first" and is not selectable. Each membership write is applied on its own, so one refusal names the machine that caused it instead of failing the whole edit.

The daemon-detail control stays — it is the right place for *leaving*, next to the drain state that decides whether leaving is allowed.

## The picker

It listed only groups with a live member, so a group you had just created was simply absent — answering "where is the group I made?" with silence. Every group is listed now; an unservable one is shown disabled with the reason (`No daemons in this group yet` / `No daemon in this group is serving right now`), which is what the edit picker already did.

Styling follows the design's group row: the `layers` mark and "Any daemon in the group", with no invented badge. Cloud keeps its badge — it is a product name, where a group carries its own.

## Reviewing

No control-plane change and no new API surface; this is presentation plus one behavior fix (membership in the dialog). `add-agent-daemon-choice` gains `offeredGroups` beside `availableGroups` — offered is every group, available is the selectable subset — so "listed" and "selectable" stop being the same decision.

Verified against a live control plane and Postgres: the section renders as the design's table, the row opens Edit group, the dialog lists the org's daemon with its blocked reason inline, and the Add-agent picker shows the group.

web: 1569 tests pass; typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
