### PR TITLE
perf(daemon): pace the first sandbox dial for a pod that just started

### DIFF
--- a/packages/daemon/src/shim/dialer.ts
+++ b/packages/daemon/src/shim/dialer.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, normalize } from 'node:path'
-import { Backoff, ClientTransport, systemClock, type Clock } from '@agentconnect.md/connection'
+import { Backoff, ClientTransport, systemClock, type BackoffOpts, type Clock } from '@agentconnect.md/connection'
 import { noopClusterMetrics, type ClusterMetrics } from '../metrics/cluster-metrics.js'
 import { ShimBindingRegistry, type Binding, type SpawnRecord } from './binding.js'
 import type { PodIdentityVerifier, ShimConnection } from './listener.js'
@@ -13,13 +13,19 @@ import {
 } from './protocol.js'
 import type { ShimTransport } from './client.js'
 
+/** What a supervised dial is waiting on: a pod whose listener is still coming up, or a peer that went away. */
+export type ShimDialPhase = 'startup' | 'reconnect'
+
+/** Startup pacing: the pod was created moments ago, so a refusal means "not listening yet" and is met in ~100ms. */
+export const STARTUP_DIAL_BACKOFF: BackoffOpts = { baseMs: 100 }
+
 export interface ShimDialerDeps {
   verifier: PodIdentityVerifier
   now?: () => number
   clock?: Clock
   dial?: (url: string, opts: { subprotocol: string; path: string }) => Promise<ShimTransport>
-  /** Per-dial reconnect backoff factory. Injected so tests reconnect in milliseconds. */
-  backoff?: () => Backoff
+  /** Per-phase backoff factory. Injected so tests dial and reconnect in milliseconds. */
+  backoff?: (phase: ShimDialPhase) => Backoff
   credentialTtlMs?: number
   metrics?: ClusterMetrics
   log: { info: (message: string) => void; warn: (message: string) => void }
@@ -126,8 +132,10 @@ export class ShimDialer {
 
   private async supervise(dial: SupervisedDial, timeoutMs: number): Promise<void> {
     const deadline = this.clock.now() + timeoutMs
-    const backoff = this.deps.backoff?.() ?? new Backoff()
-    let first = true
+    // Two policies, because a refused dial means something different before the first bind than after it.
+    const startup = this.deps.backoff?.('startup') ?? new Backoff(STARTUP_DIAL_BACKOFF)
+    const reconnect = this.deps.backoff?.('reconnect') ?? new Backoff()
+    let everBound = false
     while (!dial.stopped) {
       try {
         const { connection, closed } = await this.dialAndBind(dial, timeoutMs)
@@ -136,8 +144,8 @@ export class ShimDialer {
           return
         }
         dial.current = connection
-        backoff.reset()
-        first = false
+        reconnect.reset()
+        everBound = true
         if (!dial.readySettled) {
           dial.readySettled = true
           dial.resolveReady(connection)
@@ -151,11 +159,11 @@ export class ShimDialer {
         this.registry.revokeIssued(connection.issuedCredential)
         if (dial.stopped) return
         this.deps.onConnectionLost?.(dial.record.agentId, `shim channel closed (${close.code})`)
-        const delay = close.reason === 'rebinding' ? 0 : backoff.next()
+        const delay = close.reason === 'rebinding' ? 0 : reconnect.next()
         if (delay > 0) await this.delay(delay)
       } catch (error) {
         if (dial.stopped) return
-        if (this.clock.now() >= deadline && first) {
+        if (this.clock.now() >= deadline && !everBound) {
           const failure = new Error(`could not connect to sandbox shim: ${(error as Error).message}`)
           if (!dial.readySettled) {
             dial.readySettled = true
@@ -165,7 +173,7 @@ export class ShimDialer {
           if (this.dials.get(dial.record.agentId) === dial) this.dials.delete(dial.record.agentId)
           return
         }
-        const delay = backoff.next()
+        const delay = everBound ? reconnect.next() : startup.next()
         this.deps.log.warn(`shim: sandbox dial failed, retrying in ${delay}ms (${(error as Error).message})`)
         await this.delay(delay)
       }

--- a/packages/daemon/test/shim-dial-in.test.ts
+++ b/packages/daemon/test/shim-dial-in.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { Backoff, ClientTransport } from '@agentconnect.md/connection'
+import { Backoff, ClientTransport, DEFAULT_BACKOFF_BASE_MS } from '@agentconnect.md/connection'
 import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
 import { WebSocket } from 'ws'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
-import { ShimDialer, type ShimDialerDeps } from '../src/shim/dialer.js'
+import { ShimDialer, STARTUP_DIAL_BACKOFF, type ShimDialerDeps } from '../src/shim/dialer.js'
 import { ShimServer } from '../src/shim/server.js'
 import { ShimSession } from '../src/shim/session.js'
 import { noopClusterMetrics, type ClusterMetrics } from '../src/metrics/cluster-metrics.js'
@@ -137,9 +137,16 @@ function scriptedDialer(deps: {
   clock: VirtualClock
   metrics?: ClusterMetrics
   warnings?: string[]
+  /** Dials refused before the sandbox answers — a pod whose container started but whose shim is not listening. */
+  refusals?: number
+  /** Injected backoff; `'shipped'` runs the real per-phase policies instead of {@link pausedBackoff}. */
+  backoff?: NonNullable<ShimDialerDeps['backoff']> | 'shipped'
+  onConnection?: (connection: ShimConnection) => void
 }): { dialer: ShimDialer; peers: ScriptedPeer[] } {
   const peers: ScriptedPeer[] = []
+  let refusals = deps.refusals ?? 0
   const dial: NonNullable<ShimDialerDeps['dial']> = async () => {
+    if (refusals-- > 0) throw new Error('connect ECONNREFUSED')
     let onMessage: (text: string) => void = () => {}
     let onClose: (code: number, reason: string) => void = () => {}
     const peer: ScriptedPeer = {
@@ -168,8 +175,9 @@ function scriptedDialer(deps: {
     dial,
     clock: deps.clock,
     now: () => deps.clock.now(),
-    backoff: pausedBackoff,
+    ...(deps.backoff === 'shipped' ? {} : { backoff: deps.backoff ?? pausedBackoff }),
     ...(deps.metrics ? { metrics: deps.metrics } : {}),
+    ...(deps.onConnection ? { onConnection: deps.onConnection } : {}),
     log: { info: () => {}, warn: (message) => deps.warnings?.push(message) }
   })
   dialers.push(dialer)
@@ -426,6 +434,73 @@ describe('dial-in identity handshake', () => {
     expect(dialer.authorize({ credential: second.issuedCredential, generation: 2, capability: 'materialize' }).ok).toBe(
       true
     )
+  })
+})
+
+/** How long a supervised dial waits between attempts, which is not one question but two. */
+describe('dial pacing', () => {
+  const bindsAsPodOne: PodIdentityVerifier = {
+    reviewToken: async () => ({ authenticated: true, podName: 'sandbox-pod-1', podUid: 'pod-uid-1' })
+  }
+
+  it('retries a refused first dial on a startup-sized delay, not a reconnect-sized one', async () => {
+    // A pod reports Ready when its container process starts, so the first dial of a resume is
+    // routinely refused while the shim is still binding its port — a wait measured in hundreds
+    // of milliseconds, which the shared reconnect base turned into a guaranteed 1-2s per wake.
+    const clock = new VirtualClock()
+    const warnings: string[] = []
+    const { dialer, peers } = scriptedDialer({
+      refusals: 1,
+      answer: (_hello, peer) => peer.reply({ type: 'shim/identity', token: 'projected-token' }),
+      verifier: bindsAsPodOne,
+      clock,
+      backoff: 'shipped',
+      warnings
+    })
+
+    const startedAt = clock.now()
+    // Horizon over any first retry this could produce and far under the dial deadline, so a
+    // regression to the coarse default is fired and fails an assertion instead of the test timeout.
+    const connection = await runVirtual(clock, dialer.connect(SCRIPTED_ENDPOINT, record(), 30_000), 2_500)
+
+    expect(connection.binding).toMatchObject({ podName: 'sandbox-pod-1', generation: 1 })
+    // The refused dial never reached a peer, so the bind is the second attempt.
+    expect(peers).toHaveLength(1)
+    const delays = warnings.map((line) => Number(/retrying in (\d+)ms/.exec(line)?.[1]))
+    expect(delays).toHaveLength(1)
+    expect(delays[0]).toBeGreaterThanOrEqual(STARTUP_DIAL_BACKOFF.baseMs ?? DEFAULT_BACKOFF_BASE_MS)
+    // Sub-200ms is the property: base plus its 0-100% jitter must stay far below the shared default.
+    expect(delays[0]).toBeLessThan(200)
+    expect(clock.now() - startedAt).toBeLessThan(200)
+  })
+
+  it('keeps the coarse shared delay for a reconnect once a channel has bound', async () => {
+    // A peer that went away after answering is the case the shared default is right for: the pod
+    // is not starting, something ended an established channel, and redialing it hard helps nobody.
+    const clock = new VirtualClock()
+    const bound: ShimConnection[] = []
+    let resolveRebound: () => void = () => {}
+    const rebound = new Promise<void>((resolve) => (resolveRebound = resolve))
+    const { dialer } = scriptedDialer({
+      answer: (_hello, peer) => peer.reply({ type: 'shim/identity', token: 'projected-token' }),
+      verifier: bindsAsPodOne,
+      clock,
+      backoff: 'shipped',
+      onConnection: (connection) => {
+        bound.push(connection)
+        if (bound.length === 2) resolveRebound()
+      }
+    })
+
+    const first = await runVirtual(clock, dialer.connect(SCRIPTED_ENDPOINT, record(), 30_000), 900)
+    const droppedAt = clock.now()
+    first.close('force reconnect')
+    // Horizon above the coarse delay and under the dial deadline: only the reconnect wait is skipped.
+    await runVirtual(clock, rebound, 5_000)
+
+    expect(bound).toHaveLength(2)
+    expect(bound[1]).not.toBe(first)
+    expect(clock.now() - droppedAt).toBeGreaterThanOrEqual(DEFAULT_BACKOFF_BASE_MS)
   })
 })
 


### PR DESCRIPTION
## Summary

The duty holder dials a sandbox shim the moment the pod reports `Ready`, but `Ready` only
means the container process started — the shim is not accepting on its port yet, so the
first dial of a resume is routinely refused. `ShimDialer` then retried that refusal on the
shared `Backoff` default (`baseMs` 1000 plus 0-100% jitter), so the second attempt landed
1000-2000 ms out for a listener that was typically a couple of hundred milliseconds away.

The pre-bind dial now runs its own policy sized for a pod we just started: `baseMs` 100,
same exponential growth, same jitter, same cap. Reconnect pacing is untouched.

## The waste this removes

From the measurement in #1121, on one live resume:

```
02:27:51      pod Ready / container started
02:27:51.409  shim: sandbox dial failed, retrying in 1262ms (connect ECONNREFUSED)
02:27:52.684  shim: bound agent … generation 13
```

The bind itself costs ~10 ms once the listener is up; the rest is the backoff overshooting.
That is ~1.3 s on every wake path — a platform message, a cron fire and a webhook all reach
the sandbox through this dial — and roughly 12% of a measured resume. It should show up as
the `shim_handshake` stage of `agentconnect.cluster.launch.stage_duration` dropping by about
a second on the `resume` path.

## How the initial dial is distinguished, and why this shape

`supervise()` already tracked whether anything had ever bound for this dial (the `first`
flag that decides whether a failure is terminal). That flag is now named `everBound` and is
what selects between two backoff instances:

- `startup` — nothing has bound yet, so a refusal means "the listener inside the pod I just
  created is not up yet". `STARTUP_DIAL_BACKOFF = { baseMs: 100 }`.
- `reconnect` — a channel was established and ended, so a refusal means "the peer went
  away, and I do not know why". The shared default, unchanged, and still the instance that
  is `reset()` on every successful bind and drawn from on the `close.reason === 'rebinding'`
  path.

Two named instances rather than a tuned constant, because the two waits are answers to
different questions and the code should say which one it is asking. The injected test seam
is preserved and widened rather than duplicated: `backoff?: (phase: ShimDialPhase) => Backoff`,
so an existing `() => Backoff` factory still satisfies it and still pins both phases.

## Retry-budget equivalence

Growth, jitter and the 30 s cap are unchanged, so this is more, smaller attempts inside the
same deadline rather than a shorter total: the startup ladder is 100, 200, 400, 800, 1600 …
(each plus 0-100% jitter) instead of 1000, 2000, 4000 …, converging on the same cap. The
terminal condition is still "a pre-bind failure observed at or past `deadline`", the caller
is still bounded by `awaitReady`'s own timer at `timeoutMs`, and `readyTimeoutMs` and the
`LaunchTimeoutError` path are untouched. An unreachable sandbox fails in the same wall-clock
time, having tried more often on the way there.

## Test plan

Extends `packages/daemon/test/shim-dial-in.test.ts` (the dial-in home suite) with a
`dial pacing` block, on the suite's virtual clock — no positive assertion behind a fixed
sleep:

- **a refused first dial is retried sub-200 ms**: the scripted sandbox refuses one dial and
  then answers. The logged retry delay is `>= STARTUP_DIAL_BACKOFF.baseMs` and `< 200`, and
  the whole refuse-then-bind sequence costs under 200 ms of virtual time. Reverting the base
  to 1000 fails it with `expected 1837 to be less than 200`.
- **a reconnect still waits the coarse delay**: after a channel binds and is dropped, the
  rebind lands at least `DEFAULT_BACKOFF_BASE_MS` of virtual time later. Pointing the
  post-close delay at the startup policy fails it with `expected 183 to be greater than or
  equal to 1000`.

Ran `shim-dial-in`, `shim-handshake`, `shim-channels`, `shim-tunnel` 3x (81 passed each
time), plus the suites that exercise the dialer's shipped defaults against a real socket —
`cluster-cold-start`, `cluster-acp-e2e`, `cluster-metrics`, `k8s-runtime-plane`,
`cluster-workspace-prepare` (60 passed). `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
all clean. `shim-cancellation`, `shim-exec-handler`, `shim-workspace-files`,
`workspace-git-runner-seam` and `acp-matrix` fail identically on this branch and on a clean
tree at `origin/main` (5 files / 15 tests, same locations) — a local macOS environment
issue, not this change.

Closes #1121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
