### PR TITLE
feat(control-plane): a daemon with agents on it can join a group

### DIFF
--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -221,9 +221,11 @@ same safety rule — never commit while the old authority might still be serving
 paid for it with **preconditions instead of choreography**, so no new wire frame, fence
 column, or transition generation exists yet:
 
-- _Join_ is refused (409) while the daemon has directly placed agents, rather than
-  running the move once per agent inside one fence. The operator re-places them first,
-  with the move machinery that already exists.
+- _Join_ **is** the transition, as above: the pinned agents are detached on the machine and
+  re-placed onto the set with the membership row in one transaction, and the machine claims
+  them back as a member. What it does not carry is the "entering" claim fence — a peer can
+  win a group between the commit and the machine's re-claim, costing one extra move rather
+  than correctness. `force` is the move's own contract for a machine that cannot ack.
 - _Leave_ is refused (409) while the daemon holds a **live** duty lease, rather than
   sending a correlated withdrawal and committing on the ack. Draining the daemon, or
   simply letting its leases lapse, is the "stop and confirm" step — a lapsed lease is
@@ -248,9 +250,9 @@ Membership is likewise re-read once the connection is registered, so a change co
 during a handshake either is seen by that read or finds the connection and closes it.
 
 That is strictly narrower than §3, never wider: every transition it performs is one §3
-also permits. What is owed is the operator ergonomics — the one-action enrol-with-agents
-and drain-and-leave — which is where the correlated request, the leaving fence, and the
-transition generation earn their keep.
+also permits. What is owed is the leaving half — the one-action drain-and-leave — which is where the
+correlated withdrawal request, the leaving fence, and the transition generation earn their
+keep, plus the entering fence that would save the extra move on join.
 
 ## 4. What does not change
 

--- a/packages/control-plane/src/http/agent-moves.ts
+++ b/packages/control-plane/src/http/agent-moves.ts
@@ -1,0 +1,37 @@
+/**
+ * The one `AgentMoveService` wiring, shared by every route that moves runtime authority.
+ *
+ * It was assembled inline in `routes/agents.ts`, which was fine while agent placement was the only
+ * caller. Group enrolment is the second (daemon-groups.md §3): enrolling a machine that still has
+ * pinned agents IS the move convention, run once per agent, so it needs the same graph — and a
+ * second hand-built copy of an eighteen-dependency bundle is a copy that drifts.
+ */
+import type { FastifyBaseLogger } from 'fastify'
+import { AgentMoveService } from '../orchestrator/agentMove.js'
+import type { HttpDeps } from './deps.js'
+
+export function buildAgentMoves(deps: HttpDeps, log: FastifyBaseLogger): AgentMoveService {
+  return new AgentMoveService({
+    agents: deps.repos.agent,
+    assignments: deps.repos.assignment,
+    integrations: deps.repos.integration,
+    integrationChannels: deps.repos.integrationChannel,
+    bots: deps.repos.bot,
+    botSecrets: deps.repos.botSecret,
+    platforms: deps.platforms,
+    specs: deps.agentSpecs,
+    crons: deps.repos.cron,
+    control: deps.control,
+    hooks: deps.hooks,
+    httpBot: deps.httpBot,
+    collabRoutes: deps.collabRoutes,
+    mutations: deps.agentMutations,
+    sessionOwners: deps.sessionOwners,
+    placement: deps.placementResolver,
+    memberSets: deps.repos.memberSet,
+    memberSetWrites: deps.repos.memberSet,
+    liveness: deps.liveness,
+    ...(deps.recomputeDuties ? { recomputeDuties: deps.recomputeDuties } : {}),
+    log
+  })
+}

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -253,6 +253,11 @@ export const MemberSetListDto = z.array(MemberSetDto)
 
 export const MemberSetBody = z.object({ name: z.string().trim().min(1).max(64) })
 
+/** The operator's "the source is permanently stopped" assertion, as a query switch. It is the
+ *  move's own force contract (daemon-groups.md §3): a directly placed machine is outside the
+ *  ledger, so it holds no lease and runs no self-fence — the assertion IS the safety boundary. */
+export const ForceQuery = z.object({ force: z.coerce.boolean().optional() })
+
 /** `…/member-sets/:id/members/:daemonId` — the enrolment target. */
 export const MemberSetMemberParams = z.object({ id: z.string(), daemonId: z.string() })
 

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -256,7 +256,11 @@ export const MemberSetBody = z.object({ name: z.string().trim().min(1).max(64) }
 /** The operator's "the source is permanently stopped" assertion, as a query switch. It is the
  *  move's own force contract (daemon-groups.md §3): a directly placed machine is outside the
  *  ledger, so it holds no lease and runs no self-fence — the assertion IS the safety boundary. */
-export const ForceQuery = z.object({ force: z.coerce.boolean().optional() })
+export const ForceQuery = z.object({
+  // `z.stringbool()`, NOT `z.coerce.boolean()` — the latter truthy-coerces the STRING "false",
+  // so `?force=false` would assert the very thing the operator was declining to assert.
+  force: z.stringbool().optional()
+})
 
 /** `…/member-sets/:id/members/:daemonId` — the enrolment target. */
 export const MemberSetMemberParams = z.object({ id: z.string(), daemonId: z.string() })

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -86,7 +86,7 @@ import { makeSessionAccessResolver } from '../session-access.js'
 import { resolveShareSet } from '../sharing.js'
 import { resolveAgentIconUrl, type IconUrlBases } from '../../agents/agent-icon.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
-import { AgentMoveConflict, AgentMoveFailed, AgentMoveService } from '../../orchestrator/agentMove.js'
+import { AgentMoveConflict, AgentMoveFailed } from '../../orchestrator/agentMove.js'
 import { AgentWakeCoordinator } from '../../orchestrator/agentWake.js'
 import { convergeIntegrationGating } from '../../orchestrator/integrationPush.js'
 import { ProtocolError } from '../../domain/errors.js'
@@ -195,6 +195,7 @@ import {
 } from '../dto/index.js'
 import { provisionDaemonConnect } from '../onboarding.js'
 import { Tag } from '../plugins/openapi.js'
+import { buildAgentMoves } from '../agent-moves.js'
 import { GithubApiError } from '../../github/api.js'
 import { LogtoApiError } from '../../github/logto-identity.js'
 import { UserAuthzDeniedError } from '../../github/user-authz.js'
@@ -1342,28 +1343,7 @@ export function agentRoutes(deps: HttpDeps) {
       }
     }
 
-    const agentMoves = new AgentMoveService({
-      agents: deps.repos.agent,
-      assignments: deps.repos.assignment,
-      integrations: deps.repos.integration,
-      integrationChannels: deps.repos.integrationChannel,
-      bots: deps.repos.bot,
-      botSecrets: deps.repos.botSecret,
-      platforms: deps.platforms,
-      specs: deps.agentSpecs,
-      crons: deps.repos.cron,
-      control: deps.control,
-      hooks: deps.hooks,
-      httpBot: deps.httpBot,
-      collabRoutes: deps.collabRoutes,
-      mutations: deps.agentMutations,
-      sessionOwners: deps.sessionOwners,
-      placement: deps.placementResolver,
-      memberSets: deps.repos.memberSet,
-      liveness: deps.liveness,
-      ...(deps.recomputeDuties ? { recomputeDuties: deps.recomputeDuties } : {}),
-      log: app.log
-    })
+    const agentMoves = buildAgentMoves(deps, app.log)
     const refreshMutationAgent = (observed: AgentRecord) => refreshAgentUnderMutation(deps.repos.agent, observed)
 
     r.post(

--- a/packages/control-plane/src/http/routes/member-sets.ts
+++ b/packages/control-plane/src/http/routes/member-sets.ts
@@ -40,12 +40,15 @@ import {
   MemberSetInUse,
   MemberSetTenancyMismatch
 } from '../../persistence/errors.js'
+import { AgentMoveConflict, AgentMoveFailed } from '../../orchestrator/agentMove.js'
+import { buildAgentMoves } from '../agent-moves.js'
 import { orgOf, denyViewerWrite } from '../rbac.js'
 import {
   MemberSetBody,
   MemberSetDto,
   MemberSetListDto,
   MemberSetMemberParams,
+  ForceQuery,
   IdParam,
   ErrorDto
 } from '../dto/index.js'
@@ -90,6 +93,8 @@ export function memberSetRoutes(deps: HttpDeps) {
 
   return async function memberSetRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
+    /** Built per call, like the agents route's: the move graph is stateless and this is a rare op. */
+    const moves = (instance: FastifyInstance) => buildAgentMoves(deps, instance.log)
 
     r.get(
       '/member-sets',
@@ -179,9 +184,10 @@ export function memberSetRoutes(deps: HttpDeps) {
           tags: [Tag.MemberSets],
           summary: 'Enroll a daemon in a member set',
           description:
-            'Add one of the organization’s daemons to the set. Refused (409) while the daemon still has agents pinned directly to it — a member serves only what it holds a duty lease for, so those agents must be placed on the set first — or while it is already in another set. A connected daemon reconnects to pick up its new set.',
+            'Add one of the organization’s daemons to the set. Agents pinned to that machine come WITH it: each is stopped there and re-placed on the set in one step, and the daemon claims them back as a member. Refused (409) if the machine cannot confirm it stopped — retry with it online, or `force` to commit on the operator’s assertion that it is permanently stopped — or if it is already in another set.',
           operationId: 'enrollDaemonInMemberSet',
           params: MemberSetMemberParams,
+          querystring: ForceQuery,
           response: { 200: MemberSetDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
         }
       },
@@ -197,16 +203,26 @@ export function memberSetRoutes(deps: HttpDeps) {
         }
         if (daemon.memberSetId === set.id) return toDto(set)
         if (daemon.memberSetId) return conflict(reply, 'the daemon is already in another member set')
-        // Every precondition is the repository's, taken with the row under the per-daemon fence —
-        // a check made out here could only be re-decided by a concurrent placement (§3).
+        // Agents pinned here do not block the join — they come WITH it (§3). The orchestrator
+        // stops each one on the machine, then places them on the set and writes the membership row
+        // in one transaction; `force` is the move's own contract for a machine that cannot ack.
         try {
-          await deps.repos.memberSet.enrollOperator(set.id, daemonId)
+          await moves(app).enrollInSet(daemonId, set.id, orgId, req.query.force ? 'best-effort' : 'required')
         } catch (err) {
+          if (err instanceof AgentMoveConflict) return conflict(reply, err.message)
+          if (err instanceof AgentMoveFailed) {
+            // The machine could not confirm it stopped. Committing anyway is the operator's call,
+            // exactly as it is for a machine-to-machine move.
+            return conflict(
+              reply,
+              `${err.message}. Retry with the daemon online, or confirm it is permanently stopped to force it.`
+            )
+          }
           if (err instanceof DaemonAlreadyInSet) {
             return conflict(reply, 'the daemon is already in another member set')
           }
           if (err instanceof DaemonHasPlacedAgents) {
-            return conflict(reply, `move this daemon's ${err.placed} placed agent(s) onto a member set first`)
+            return conflict(reply, `an agent was placed on this daemon mid-enrolment (${err.placed}); retry`)
           }
           // The set's tenancy invariant, surfaced rather than swallowed: the daemon is not this
           // org's. The org-fenced read above already refuses that, so this is a concurrent change.

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -278,6 +278,11 @@ export class AgentMoveService {
           }
           this.deps.log?.warn({ err, agentId: agent.id, daemonId }, 'group enrolment: forced past an unacked detach')
         }
+        // Durable and hot session affinity, released exactly as a move releases it. Without this
+        // the assignment rows survive, the machine's next register replays them into the owner
+        // index, and affinity traffic keeps arriving at a daemon that may no longer hold the duty.
+        const released = await this.deps.assignments.releaseForAgent(agent.id, daemonId, new Date())
+        for (const key of released) this.deps.sessionOwners.releaseSession(key)
       }
       await this.deps.memberSetWrites?.enrollWithPlacedAgents(
         setId,

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -121,6 +121,9 @@ export interface AgentMoveDeps {
   /** Set membership, for deciding whether a detached source is still an eligible holder of the
    *  new placement. Absent ⇒ no source is ever unstaged, the pre-pool behavior. */
   memberSets?: Pick<MemberSetRepo, 'setIdOf' | 'memberIdsOf'>
+  /** The §3 enrolment commit — placements and the membership row in one transaction. Absent ⇒
+   *  a daemon with pinned agents cannot be enrolled, which is the pre-transition behavior. */
+  memberSetWrites?: Pick<MemberSetRepo, 'enrollWithPlacedAgents'>
   /** Live-connection reads for the set-commit unstage broadcast. Absent ⇒ no member is broadcast to. */
   liveness?: DaemonLiveness
   /** Resolves the members currently serving an agent — the sources a move must quiesce when
@@ -229,6 +232,73 @@ export class AgentMoveService {
     return this.withMoveGate(agent.id, async () =>
       this.moveLocked(await this.reloadAfterGate(agent), target, editor, 'best-effort')
     )
+  }
+
+  /**
+   * Enroll a daemon that still has agents pinned to it (daemon-groups.md §3).
+   *
+   * The operator sees one action; underneath it is the move convention applied once per pinned
+   * agent. A machine that enforces duties serves only what it holds a lease for, so a pinned agent
+   * would become unservable the instant the membership row lands — which is why this is a
+   * transition and not a validation. In order:
+   *
+   * 1. take each agent's move gate, so nothing else re-places it underneath;
+   * 2. DETACH it on the machine — the same confirmed step a machine-to-machine move uses, which is
+   *    what stops runtime authority before the placement changes hands;
+   * 3. commit placements + membership in ONE transaction (the repository's).
+   *
+   * Nothing is activated here. The machine is a member now, so it claims those groups back on its
+   * next beat and re-activates them from replicas it still has — install-on-grant as a refresh.
+   *
+   * `best-effort` is the move's own force contract, for a machine that cannot acknowledge: the
+   * operator asserts it is stopped, and that assertion IS the safety boundary — a directly placed
+   * machine is outside the ledger, so it holds no lease and runs no self-fence to wait out.
+   */
+  async enrollInSet(
+    daemonId: DaemonId,
+    setId: string,
+    orgId: string,
+    sourceDetachMode: SourceDetachMode = 'required'
+  ): Promise<void> {
+    const pinned = await this.deps.agents.listForDaemon(daemonId)
+    const releases: Array<() => void> = []
+    try {
+      for (const agent of pinned) {
+        const release = this.deps.mutations.tryBeginMove(agent.id)
+        if (!release) throw new AgentMoveConflict(`${agent.name} is already being modified or moved; retry`)
+        releases.push(release)
+      }
+      for (const agent of pinned) {
+        try {
+          requireAck('source cutover', await this.detach(daemonId, agent.id, agent.orgId, { discardActiveTurns: true }))
+        } catch (err) {
+          if (sourceDetachMode === 'required') {
+            if (err instanceof AgentMoveFailed) throw err
+            throw new AgentMoveFailed(`could not stop ${agent.name} on this daemon`, err)
+          }
+          this.deps.log?.warn({ err, agentId: agent.id, daemonId }, 'group enrolment: forced past an unacked detach')
+        }
+      }
+      await this.deps.memberSetWrites?.enrollWithPlacedAgents(
+        setId,
+        daemonId,
+        pinned.map((a) => a.id)
+      )
+    } finally {
+      for (const release of releases) release()
+    }
+    // The agents are `set`-placed now, so their duty groups are the org's to recompute and the
+    // ledger's to grant — nothing here activates them.
+    this.deps.recomputeDuties?.(orgId)
+    // Ingress follows the HOLDER, and these agents no longer have a placement that names one — the
+    // ledger's grant does. Re-converge so the projections stop addressing the machine directly.
+    for (const agent of pinned) {
+      await convergeAgentRouting(
+        this.deps,
+        { agentId: agent.id, orgId: agent.orgId, httpBotIds: [] },
+        { warn: (obj, msg) => this.deps.log?.warn(obj, msg) }
+      ).catch(() => {})
+    }
   }
 
   /** Cold-edit any workspace definition. The daemon reconciles mode/repo/branch

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -51,7 +51,7 @@ import {
   type PlacementTarget
 } from '../domain/placement.js'
 import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
-import { convergeAgentRouting } from './agentRouting.js'
+import { convergeAgentRouting, httpBotIdsForAgent } from './agentRouting.js'
 import { cronToUpsert, integrationToSpec, isGatedAgent, httpIntegrationToSpec } from './placement.js'
 import {
   mcpDefsForAgents,
@@ -297,10 +297,18 @@ export class AgentMoveService {
     this.deps.recomputeDuties?.(orgId)
     // Ingress follows the HOLDER, and these agents no longer have a placement that names one — the
     // ledger's grant does. Re-converge so the projections stop addressing the machine directly.
+    // The HTTP bots are part of that: an `rc/bot-assign` names the daemon relay callbacks go to, so
+    // leaving it alone would keep public ingress arriving at the machine we just detached from.
+    const syncedBots = new Set<string>()
     for (const agent of pinned) {
+      // One rebuild per bot, not per agent: an assign table covers every agent on that bot already.
+      const httpBotIds = (await httpBotIdsForAgent(this.deps, agent.id).catch(() => [])).filter(
+        (botId) => !syncedBots.has(botId)
+      )
+      for (const botId of httpBotIds) syncedBots.add(botId)
       await convergeAgentRouting(
         this.deps,
-        { agentId: agent.id, orgId: agent.orgId, httpBotIds: [] },
+        { agentId: agent.id, orgId: agent.orgId, httpBotIds },
         { warn: (obj, msg) => this.deps.log?.warn(obj, msg) }
       ).catch(() => {})
     }

--- a/packages/control-plane/src/orchestrator/agentRouting.ts
+++ b/packages/control-plane/src/orchestrator/agentRouting.ts
@@ -40,6 +40,26 @@ export interface RoutingTarget {
   httpBotIds: readonly string[]
 }
 
+/** The repositories that answer "which `rc/bot-assign` tables name this agent's serving daemon". */
+export interface HttpBotLookupDeps {
+  integrations: Pick<IntegrationRepo, 'listForAgent'>
+  bots: { getUnscoped(botId: string): Promise<{ transport: string } | null> }
+}
+
+/**
+ * Resolve an agent's HTTP-transport bots — the `RoutingTarget.httpBotIds` for a caller that has no
+ * move bundle to read them off. Anything that changes who serves an agent needs this, so it lives
+ * beside the convergence rather than being re-derived per caller.
+ */
+export async function httpBotIdsForAgent(deps: HttpBotLookupDeps, agentId: AgentId): Promise<string[]> {
+  const httpBotIds = new Set<string>()
+  for (const integration of await deps.integrations.listForAgent(agentId)) {
+    const bot = await deps.bots.getUnscoped(integration.botId)
+    if (bot?.transport === 'http') httpBotIds.add(integration.botId)
+  }
+  return [...httpBotIds]
+}
+
 /**
  * Push all three projections for one agent. Each job is independently caught: they are pushes
  * over a live wire, every one of them has a reconnect/replay backstop, and a transient failure in
@@ -116,17 +136,8 @@ export class AgentRoutingConverger {
   async converge(agentIds: readonly string[]): Promise<void> {
     const agents = await this.deps.agents.listByIds(agentIds as AgentId[])
     for (const agent of agents) {
-      const integrations = await this.deps.integrations.listForAgent(agent.id)
-      const httpBotIds = new Set<string>()
-      for (const integration of integrations) {
-        const bot = await this.deps.bots.getUnscoped(integration.botId)
-        if (bot?.transport === 'http') httpBotIds.add(integration.botId)
-      }
-      await convergeAgentRouting(
-        this.deps,
-        { agentId: agent.id, orgId: agent.orgId, httpBotIds: [...httpBotIds] },
-        this.deps.log
-      )
+      const httpBotIds = await httpBotIdsForAgent(this.deps, agent.id)
+      await convergeAgentRouting(this.deps, { agentId: agent.id, orgId: agent.orgId, httpBotIds }, this.deps.log)
     }
   }
 }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5022,6 +5022,11 @@ export interface MemberSetRepo {
   /** The operator path: the same row, plus §3's join precondition taken under the per-daemon
    *  fence. Throws `DaemonHasPlacedAgents` when agents are still pinned to the machine. */
   enrollOperator(setId: string, daemonId: DaemonId): Promise<void>
+  /** §3's commit step for a machine that HAS pinned agents: re-place the named agents onto the set
+   *  and write the membership row in ONE transaction. The caller must already have stopped runtime
+   *  authority for each — this only settles the durable state. Throws `DaemonHasPlacedAgents` when
+   *  something is still pinned that the caller did not name. */
+  enrollWithPlacedAgents(setId: string, daemonId: DaemonId, agentIds: readonly AgentId[]): Promise<void>
   /** One org's sets, by name. The org-less pool is never among them — it belongs to no org. */
   listForOrg(orgId: string): Promise<MemberSetRecord[]>
   /** Agents placed on each of these sets, in one query — the list read must not be N+1. Sets with

--- a/packages/control-plane/src/persistence/repositories/agent-placement.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-placement.ts
@@ -53,6 +53,21 @@ export async function revokeActiveWebchatMcpDelegations(
  * Conditional by design: a row some other writer has since placed elsewhere is not this
  * removal's to null, so it is left alone and reported as unsettled.
  */
+/**
+ * What a real placement change settles besides the columns, in the SAME transaction that writes
+ * them: webchat MCP delegations are placement-bound grants, and each hook's `dispatchRevision`
+ * is what makes a pre-change dispatch stale.
+ *
+ * Extracted because it now has three callers — `setPlacement`, `movePlacement`, and group
+ * enrolment — and a placement writer that forgets it leaves grants and dispatches valid across a
+ * change of who serves the agent. Call it only when the placement actually moved; re-writing the
+ * same target is not a change and must not churn revisions.
+ */
+export async function settlePlacementChange(tx: Prisma.TransactionClient, agentId: string): Promise<void> {
+  await revokeActiveWebchatMcpDelegations(tx, agentId, new Date())
+  await tx.hookDef.updateMany({ where: { agentId }, data: { dispatchRevision: { increment: 1 } } })
+}
+
 export async function settleCascadedUnplacement(tx: Prisma.TransactionClient, agentId: string): Promise<boolean> {
   const current = await lockAgentPlacement(tx, agentId)
   // A `set` agent has no daemonId for the FK to have nulled, so it is not this removal's to

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -38,7 +38,7 @@ import { lockResourceWriteMemberships } from '../resource-membership-lock.js'
 import { lockSkillSourceNameScopes } from '../skill-source-lock.js'
 import { tryLockMemoryConnectionScopes } from '../memory-connection-lock.js'
 import { PgHookRepo } from './hook.repo.js'
-import { lockAgentPlacement, revokeActiveWebchatMcpDelegations } from './agent-placement.js'
+import { lockAgentPlacement, settlePlacementChange } from './agent-placement.js'
 import { assertAgentMayUseSet, assertDaemonNotInSet } from './member-set.repo.js'
 
 /** An agent may be created already placed. A `set` placement names a set rather than a machine, so
@@ -846,13 +846,7 @@ export class PgAgentRepo implements AgentRepo {
         }
       })
       if (target.kind !== 'unplaced') await settlePresetPlacement(tx, agentId)
-      if (!samePlacement(placementTargetOf(current), target)) {
-        await revokeActiveWebchatMcpDelegations(tx, agentId, new Date())
-        await tx.hookDef.updateMany({
-          where: { agentId },
-          data: { dispatchRevision: { increment: 1 } }
-        })
-      }
+      if (!samePlacement(placementTargetOf(current), target)) await settlePlacementChange(tx, agentId)
     })
   }
 
@@ -892,13 +886,7 @@ export class PgAgentRepo implements AgentRepo {
           include: withUsers
         })
         if (target.kind !== 'unplaced') await settlePresetPlacement(tx, agentId)
-        if (!samePlacement(expected, target)) {
-          await revokeActiveWebchatMcpDelegations(tx, agentId, new Date())
-          await tx.hookDef.updateMany({
-            where: { agentId },
-            data: { dispatchRevision: { increment: 1 } }
-          })
-        }
+        if (!samePlacement(expected, target)) await settlePlacementChange(tx, agentId)
         return toRecord(a)
       })
     } catch (err) {

--- a/packages/control-plane/src/persistence/repositories/member-set.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/member-set.repo.ts
@@ -30,6 +30,7 @@ import { randomUUID } from 'node:crypto'
 import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
 import type { AgentId, DaemonId } from '../../domain/ids.js'
 import type { MemberSetRecord, MemberSetRepo } from '../ports.js'
+import { settlePlacementChange } from './agent-placement.js'
 import {
   AgentSetPlacementDenied,
   DaemonPlacementInSet,
@@ -180,6 +181,10 @@ export class PgMemberSetRepo implements MemberSetRepo {
               "configRevision" = "configRevision" + 1
           WHERE id = ${agentId}::uuid
         `)
+        // The same settlement every other placement writer performs, in the same transaction:
+        // webchat MCP delegations are placement-bound grants and hook dispatches made before the
+        // change must read stale. This IS a real placement change — `daemon` to `set`.
+        await settlePlacementChange(tx, agentId)
       }
       // Anything still pinned here that the caller did not name would be unservable the moment the
       // row below lands, so the whole operation fails rather than create that state.

--- a/packages/control-plane/src/persistence/repositories/member-set.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/member-set.repo.ts
@@ -28,7 +28,7 @@
  */
 import { randomUUID } from 'node:crypto'
 import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
-import type { DaemonId } from '../../domain/ids.js'
+import type { AgentId, DaemonId } from '../../domain/ids.js'
 import type { MemberSetRecord, MemberSetRepo } from '../ports.js'
 import {
   AgentSetPlacementDenied,
@@ -151,6 +151,45 @@ export class PgMemberSetRepo implements MemberSetRepo {
 
   async enroll(setId: string, daemonId: DaemonId): Promise<void> {
     await this.prisma.$transaction((tx) => enrollDaemonInSet(tx, setId, daemonId))
+  }
+
+  async enrollWithPlacedAgents(setId: string, daemonId: DaemonId, agentIds: readonly AgentId[]): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      // §3's commit step, as ONE transaction: the agents stop being pinned to the machine and the
+      // machine becomes a member together. Either order on its own is a state the invariants
+      // forbid — a member with a pinned agent, or agents on a set with nothing in it — and a crash
+      // between two statements would leave exactly that.
+      await lockDaemonMembership(tx, daemonId)
+      const [current] = await tx.$queryRaw<{ setId: string }[]>(
+        Prisma.sql`SELECT "setId" FROM "member_set_member" WHERE "daemonId" = ${daemonId}::uuid`
+      )
+      if (current) {
+        if (current.setId !== setId) throw new DaemonAlreadyInSet(daemonId, current.setId)
+      }
+      for (const agentId of agentIds) {
+        const [agent] = await tx.$queryRaw<{ orgId: string }[]>(
+          Prisma.sql`SELECT "orgId" FROM "agent" WHERE id = ${agentId}::uuid AND "daemonId" = ${daemonId}::uuid FOR UPDATE`
+        )
+        // Raced away or already re-placed since the caller read it: nothing to move, and the
+        // membership row below is what the whole operation is for.
+        if (!agent) continue
+        await assertAgentMayUseSet(tx, { id: agentId, orgId: agent.orgId }, setId)
+        await tx.$executeRaw(Prisma.sql`
+          UPDATE "agent"
+          SET "placementKind" = 'set', "setId" = ${setId}::uuid, "daemonId" = NULL,
+              "configRevision" = "configRevision" + 1
+          WHERE id = ${agentId}::uuid
+        `)
+      }
+      // Anything still pinned here that the caller did not name would be unservable the moment the
+      // row below lands, so the whole operation fails rather than create that state.
+      const [left] = await tx.$queryRaw<{ n: bigint }[]>(
+        Prisma.sql`SELECT count(*) AS n FROM "agent" WHERE "daemonId" = ${daemonId}::uuid`
+      )
+      const stillPinned = Number(left?.n ?? 0n)
+      if (stillPinned > 0) throw new DaemonHasPlacedAgents(daemonId, stillPinned)
+      if (!current) await enrollDaemonInSet(tx, setId, daemonId)
+    })
   }
 
   async enrollOperator(setId: string, daemonId: DaemonId): Promise<void> {

--- a/packages/control-plane/test/integration/member-sets.route.test.ts
+++ b/packages/control-plane/test/integration/member-sets.route.test.ts
@@ -131,6 +131,15 @@ describe('member sets — the enrolment transitions (real Postgres)', () => {
       expect(res.json().message).toMatch(/permanently stopped/)
       expect(await prisma.memberSetMember.count()).toBe(0)
 
+      // `force=false` is DECLINING to assert, not asserting: truthy string coercion here would
+      // turn the safety switch on for anyone who spelled it out.
+      const declined = await app.inject({
+        method: 'PUT',
+        url: `${ORG}/member-sets/${setId}/members/${DAEMON}?force=false`
+      })
+      expect(declined.statusCode).toBe(409)
+      expect(await prisma.memberSetMember.count()).toBe(0)
+
       // The operator asserts it is stopped: the agents move onto the set and the machine joins.
       const forced = await app.inject({
         method: 'PUT',
@@ -143,6 +152,28 @@ describe('member sets — the enrolment transitions (real Postgres)', () => {
         setId,
         daemonId: null
       })
+    } finally {
+      await close()
+    }
+  })
+
+  it('settles the moved agents\u2019 placement-bound state, as every other placement writer does', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      await seedDaemon(prisma, DAEMON)
+      await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+      const before = await prisma.hookDef.findMany({ where: { agentId: AGENT }, select: { dispatchRevision: true } })
+      const setId = await withSet(app)
+
+      await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${DAEMON}?force=true` })
+
+      // A hook dispatch prepared before the change must read stale: whoever holds the duty now is
+      // not the machine the dispatch was compiled against.
+      const after = await prisma.hookDef.findMany({ where: { agentId: AGENT }, select: { dispatchRevision: true } })
+      after.forEach((hook, i) => expect(hook.dispatchRevision).toBeGreaterThan(before[i]!.dispatchRevision))
+      // And the durable session affinity the machine owned is released rather than replayed on its
+      // next register into an owner index that no longer reflects who serves the agent.
+      expect(await prisma.assignment.count({ where: { agentId: AGENT, daemonId: DAEMON, state: 'active' } })).toBe(0)
     } finally {
       await close()
     }

--- a/packages/control-plane/test/integration/member-sets.route.test.ts
+++ b/packages/control-plane/test/integration/member-sets.route.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { buildHttpApp } from '../fakes/build-http.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import type { HttpBotOrchestrator } from '../../src/orchestrator/httpBot.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { poolSetId } from '../fakes/member-set.js'
 
@@ -174,6 +175,50 @@ describe('member sets — the enrolment transitions (real Postgres)', () => {
       // And the durable session affinity the machine owned is released rather than replayed on its
       // next register into an owner index that no longer reflects who serves the agent.
       expect(await prisma.assignment.count({ where: { agentId: AGENT, daemonId: DAEMON, state: 'active' } })).toBe(0)
+    } finally {
+      await close()
+    }
+  })
+
+  it('rebuilds the HTTP bots’ assign tables, so public ingress stops naming the machine', async () => {
+    // The `rc/bot-assign` table is compiled, not resolved per callback: it names the daemon the
+    // relay forwards to. Enrolment takes the agent off that machine, so leaving the table alone
+    // would keep addressing it for the whole window before the ledger grants the duty back.
+    const synced: string[] = []
+    const { app, close } = buildHttpApp(prisma, undefined, undefined, undefined, {
+      httpBot: { syncBot: async (id: string) => void synced.push(id) } as unknown as HttpBotOrchestrator
+    })
+    try {
+      await seedDaemon(prisma, DAEMON)
+      await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+      const httpBot = randomUUID()
+      const classicBot = randomUUID()
+      await prisma.bot.createMany({
+        data: [
+          { id: httpBot, orgId: DEFAULT_ORG_ID, platform: 'slack', name: 'shared', shareable: true, transport: 'http' },
+          { id: classicBot, orgId: DEFAULT_ORG_ID, platform: 'slack', name: 'classic' }
+        ]
+      })
+      await prisma.integration.createMany({
+        data: [
+          { id: randomUUID(), orgId: DEFAULT_ORG_ID, agentId: AGENT, botId: httpBot, platform: 'slack', name: 'http' },
+          {
+            id: randomUUID(),
+            orgId: DEFAULT_ORG_ID,
+            agentId: AGENT,
+            botId: classicBot,
+            platform: 'slack',
+            name: 'classic'
+          }
+        ]
+      })
+      const setId = await withSet(app)
+
+      await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${DAEMON}?force=true` })
+
+      // Only the HTTP one: a classic bot's egress is the daemon's own socket, with no CP-side
+      // table naming it.
+      expect(synced).toEqual([httpBot])
     } finally {
       await close()
     }

--- a/packages/control-plane/test/integration/member-sets.route.test.ts
+++ b/packages/control-plane/test/integration/member-sets.route.test.ts
@@ -117,7 +117,9 @@ describe('member sets — the enrolment transitions (real Postgres)', () => {
     }
   })
 
-  it('refuses a daemon that still has agents pinned to it — they would become unservable', async () => {
+  it('refuses an offline daemon that cannot confirm it stopped its agents, and forces past it', async () => {
+    // §3: pinned agents come WITH the join. What blocks it is the machine being unable to
+    // acknowledge that it stopped serving them — the same boundary a machine-to-machine move has.
     const { app, close } = buildHttpApp(prisma)
     try {
       await seedDaemon(prisma, DAEMON)
@@ -126,7 +128,21 @@ describe('member sets — the enrolment transitions (real Postgres)', () => {
 
       const res = await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${DAEMON}` })
       expect(res.statusCode).toBe(409)
+      expect(res.json().message).toMatch(/permanently stopped/)
       expect(await prisma.memberSetMember.count()).toBe(0)
+
+      // The operator asserts it is stopped: the agents move onto the set and the machine joins.
+      const forced = await app.inject({
+        method: 'PUT',
+        url: `${ORG}/member-sets/${setId}/members/${DAEMON}?force=true`
+      })
+      expect(forced.statusCode).toBe(200)
+      expect((forced.json() as SetBody).memberDaemonIds).toEqual([DAEMON])
+      expect(await prisma.agent.findUniqueOrThrow({ where: { id: AGENT } })).toMatchObject({
+        placementKind: 'set',
+        setId,
+        daemonId: null
+      })
     } finally {
       await close()
     }

--- a/packages/control-plane/test/repo/org-member-set.test.ts
+++ b/packages/control-plane/test/repo/org-member-set.test.ts
@@ -373,3 +373,61 @@ describe('the membership fences (real Postgres)', () => {
     expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBeNull()
   })
 })
+
+describe('enrolling a daemon that still has agents pinned to it (real Postgres)', () => {
+  it('re-places them onto the set and writes the membership row in ONE transaction', async () => {
+    // §3: a pinned agent does not BLOCK the join, it comes with it. Either half alone is a state
+    // the invariants forbid — a member with a pinned agent, or agents on a set with nothing in it.
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    const a1 = AgentId(randomUUID())
+    const a2 = AgentId(randomUUID())
+    for (const [id, name] of [
+      [a1, 'pinned-1'],
+      [a2, 'pinned-2']
+    ] as const) {
+      await agents().create({ id, orgId: ORG_X, name, runtime: 'claude', daemonId: DaemonId(MEMBER_G) })
+    }
+
+    await sets().enrollWithPlacedAgents(setId, DaemonId(MEMBER_G), [a1, a2])
+
+    expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBe(setId)
+    for (const id of [a1, a2]) {
+      expect(await prisma.agent.findUniqueOrThrow({ where: { id } })).toMatchObject({
+        placementKind: 'set',
+        setId,
+        daemonId: null
+      })
+    }
+    // And the machine can now hold their duty, which is the point of the whole transition.
+    const claim = await ledger().claimAgentHome(ORG_X, a1, DaemonId(MEMBER_G), T0, LEASE_MS)
+    expect(claim).toMatchObject({ granted: true, holder: MEMBER_G })
+  })
+
+  it('refuses when an agent was pinned mid-transition rather than leaving it unservable', async () => {
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    const named = AgentId(randomUUID())
+    const unnamed = AgentId(randomUUID())
+    await agents().create({ id: named, orgId: ORG_X, name: 'named', runtime: 'claude', daemonId: DaemonId(MEMBER_G) })
+    await agents().create({ id: unnamed, orgId: ORG_X, name: 'late', runtime: 'claude', daemonId: DaemonId(MEMBER_G) })
+
+    // The caller only knew about one; the other would be placed and unservable the moment the
+    // membership row landed, so nothing commits.
+    await expect(sets().enrollWithPlacedAgents(setId, DaemonId(MEMBER_G), [named])).rejects.toBeInstanceOf(
+      DaemonHasPlacedAgents
+    )
+    expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBeNull()
+    expect(await prisma.agent.findUniqueOrThrow({ where: { id: named } })).toMatchObject({ placementKind: 'daemon' })
+  })
+
+  it('is idempotent for a daemon already in the set, and refuses one in another', async () => {
+    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+    const g = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
+    const h = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-h')).id
+    await sets().enrollWithPlacedAgents(g, DaemonId(MEMBER_G), [])
+    await sets().enrollWithPlacedAgents(g, DaemonId(MEMBER_G), [])
+    expect(await sets().memberIdsOf(g)).toEqual([MEMBER_G])
+    await expect(sets().enrollWithPlacedAgents(h, DaemonId(MEMBER_G), [])).rejects.toBeInstanceOf(DaemonAlreadyInSet)
+  })
+})

--- a/packages/web/src/components/console/modals/GroupModal.tsx
+++ b/packages/web/src/components/console/modals/GroupModal.tsx
@@ -12,11 +12,12 @@ import { Button, Icon } from '@/components/ui'
  * filled where it is created is not a feature, and "which machines are in it" is the only thing
  * about a group worth editing besides its name.
  *
- * The two directions are not symmetric, and the dialog says so before it lets you act (§3):
- * joining is refused while agents are still pinned to that machine — a member serves only what it
- * holds a lease for, so those agents would be placed and unservable at once — and leaving is
- * refused while it still holds live work. Each row is applied on its own, so one refusal reports
- * itself and leaves the rest of the edit intact.
+ * Agents pinned to a machine do not block it joining — they come WITH it (§3): the control plane
+ * stops each on that machine and re-places it on the group in one step, and the machine claims them
+ * back as a member. So the row says what will happen rather than refusing. Leaving is the asymmetric
+ * one, refused while the machine still holds live work; that lives on the daemon's own page next to
+ * the drain state. Each membership write is applied on its own, so one refusal reports itself and
+ * leaves the rest of the edit intact.
  */
 export default function GroupModal({ group, onClose }: { group?: MemberSetRow; onClose: () => void }) {
   const { createGroup, renameGroup, enrollInGroup, withdrawFromGroup, daemons, agents } = useConsoleData()
@@ -25,6 +26,10 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
   const [members, setMembers] = useState<string[]>(group?.memberDaemonIds ?? [])
   const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  // Set when a machine could not confirm it stopped its agents: the operator may assert it is
+  // permanently stopped, which is the move's own force contract and the only safety boundary a
+  // machine outside the ledger has (§3).
+  const [forceOffer, setForceOffer] = useState(false)
   const trimmed = name.trim()
 
   // A daemon the org owns is a candidate unless it is in a DIFFERENT group: a daemon is in at most
@@ -37,10 +42,11 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
       current.includes(daemonId) ? current.filter((id) => id !== daemonId) : [...current, daemonId]
     )
 
-  const save = async () => {
+  const save = async (force = false) => {
     if (saving || !trimmed) return
     setSaving(true)
     setErr(null)
+    if (force) setForceOffer(false)
     try {
       const setId = group ? group.setId : (await createGroup(trimmed)).setId
       if (group && trimmed !== group.name) await renameGroup(setId, trimmed)
@@ -48,11 +54,13 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
       const after = new Set(members)
       // Each membership write is its own request with its own precondition, so they are applied one
       // at a time: a refusal names the machine that caused it instead of failing the whole dialog.
-      for (const daemonId of members.filter((id) => !before.has(id))) await enrollInGroup(setId, daemonId)
+      for (const daemonId of members.filter((id) => !before.has(id))) await enrollInGroup(setId, daemonId, { force })
       for (const daemonId of [...before].filter((id) => !after.has(id))) await withdrawFromGroup(setId, daemonId)
       onClose()
     } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e))
+      const message = e instanceof Error ? e.message : String(e)
+      setErr(message)
+      setForceOffer(/permanently stopped/.test(message))
       setSaving(false)
     }
   }
@@ -92,17 +100,15 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
             <div className="overflow-hidden rounded-lg border border-(--border-subtle)">
               {candidates.map((daemon) => {
                 const checked = members.includes(daemon.daemonId)
-                const pinned = pinnedCount(daemon)
-                // Pinned agents block only a JOIN — a machine already in the group has none.
-                const blocked = !checked && !group?.memberDaemonIds.includes(daemon.daemonId) && pinned > 0
+                const wasMember = group?.memberDaemonIds.includes(daemon.daemonId) ?? false
+                // What joining will DO to this machine's own agents — they move onto the group with
+                // it, which is the one consequence worth stating before the click.
+                const bringing = checked && !wasMember ? pinnedCount(daemon) : 0
                 return (
                   <button
                     key={daemon.daemonId}
                     type="button"
-                    className={`flex w-full items-center gap-[10px] border-0 border-b border-(--border-subtle) bg-(--surface-card) px-3 py-[10px] text-left last:border-b-0 ${
-                      blocked ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:bg-(--surface-hover)'
-                    }`}
-                    disabled={blocked}
+                    className="flex w-full cursor-pointer items-center gap-[10px] border-0 border-b border-(--border-subtle) bg-(--surface-card) px-3 py-[10px] text-left last:border-b-0 hover:bg-(--surface-hover)"
                     onClick={() => toggle(daemon.daemonId)}
                   >
                     <span
@@ -120,8 +126,8 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
                         {daemon.name}
                       </span>
                       <span className="block truncate font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-                        {blocked
-                          ? `Move its ${pinned} placed agent${pinned === 1 ? '' : 's'} onto a group first`
+                        {bringing > 0
+                          ? `Its ${bringing} agent${bringing === 1 ? '' : 's'} move onto the group with it`
                           : daemon.status === 'online'
                             ? 'Online'
                             : 'Offline'}
@@ -149,6 +155,15 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
         <Button variant="ghost" onClick={onClose}>
           Cancel
         </Button>
+        {forceOffer && (
+          <Button
+            variant="danger"
+            onClick={() => void save(true)}
+            className={saving ? 'cursor-default opacity-50' : undefined}
+          >
+            It is stopped — join anyway
+          </Button>
+        )}
         <Button onClick={() => void save()} className={!saving && trimmed ? undefined : 'cursor-default opacity-50'}>
           {saving ? 'Saving…' : group ? 'Save' : 'Create group'}
         </Button>

--- a/packages/web/src/components/console/modals/GroupModal.tsx
+++ b/packages/web/src/components/console/modals/GroupModal.tsx
@@ -1,6 +1,6 @@
 // No 'use client' here: rendered only by ModalProvider (the client boundary).
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import type { DaemonRow, MemberSetRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Button, Icon } from '@/components/ui'
@@ -26,10 +26,13 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
   const [members, setMembers] = useState<string[]>(group?.memberDaemonIds ?? [])
   const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
-  // Set when a machine could not confirm it stopped its agents: the operator may assert it is
-  // permanently stopped, which is the move's own force contract and the only safety boundary a
-  // machine outside the ledger has (§3).
-  const [forceOffer, setForceOffer] = useState(false)
+  // The ONE machine that could not confirm it stopped its agents. The operator's assertion is
+  // about that machine, so it is carried per daemon: forcing A must never wave B through a failure
+  // nobody was shown. Null ⇒ nothing to force (§3).
+  const [forceDaemonId, setForceDaemonId] = useState<string | null>(null)
+  // A group created by a failed attempt. Names are not unique, so retrying without this would
+  // create a second one and leave the first empty.
+  const createdSetId = useRef<string | null>(null)
   const trimmed = name.trim()
 
   // A daemon the org owns is a candidate unless it is in a DIFFERENT group: a daemon is in at most
@@ -42,25 +45,33 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
       current.includes(daemonId) ? current.filter((id) => id !== daemonId) : [...current, daemonId]
     )
 
-  const save = async (force = false) => {
+  /** `forcing` is the ONE machine the operator has just asserted is stopped, never a mode. */
+  const save = async (forcing: string | null = null) => {
     if (saving || !trimmed) return
     setSaving(true)
     setErr(null)
-    if (force) setForceOffer(false)
+    setForceDaemonId(null)
+    let daemonId: string | undefined
     try {
-      const setId = group ? group.setId : (await createGroup(trimmed)).setId
+      // Reuse the group a previous attempt created: it exists, and a second one with the same name
+      // is indistinguishable from it.
+      const setId = group ? group.setId : (createdSetId.current ??= (await createGroup(trimmed)).setId)
       if (group && trimmed !== group.name) await renameGroup(setId, trimmed)
       const before = new Set(group?.memberDaemonIds ?? [])
       const after = new Set(members)
-      // Each membership write is its own request with its own precondition, so they are applied one
-      // at a time: a refusal names the machine that caused it instead of failing the whole dialog.
-      for (const daemonId of members.filter((id) => !before.has(id))) await enrollInGroup(setId, daemonId, { force })
-      for (const daemonId of [...before].filter((id) => !after.has(id))) await withdrawFromGroup(setId, daemonId)
+      // Each membership write is its own request with its own precondition, applied one at a time:
+      // a refusal names the machine that caused it, and every machine after it stays untouched
+      // rather than riding through on an assertion made about a different one.
+      for (daemonId of members.filter((id) => !before.has(id))) {
+        await enrollInGroup(setId, daemonId, daemonId === forcing ? { force: true } : {})
+      }
+      for (daemonId of [...before].filter((id) => !after.has(id))) await withdrawFromGroup(setId, daemonId)
       onClose()
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
       setErr(message)
-      setForceOffer(/permanently stopped/.test(message))
+      // Offer the assertion only for the machine that actually failed to confirm.
+      if (daemonId && /permanently stopped/.test(message)) setForceDaemonId(daemonId)
       setSaving(false)
     }
   }
@@ -155,13 +166,13 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
         <Button variant="ghost" onClick={onClose}>
           Cancel
         </Button>
-        {forceOffer && (
+        {forceDaemonId && (
           <Button
             variant="danger"
-            onClick={() => void save(true)}
+            onClick={() => void save(forceDaemonId)}
             className={saving ? 'cursor-default opacity-50' : undefined}
           >
-            It is stopped — join anyway
+            {daemons.find((d) => d.daemonId === forceDaemonId)?.name ?? 'It'} is stopped — join anyway
           </Button>
         )}
         <Button onClick={() => void save()} className={!saving && trimmed ? undefined : 'cursor-default opacity-50'}>

--- a/packages/web/src/components/console/modals/GroupModal.tsx
+++ b/packages/web/src/components/console/modals/GroupModal.tsx
@@ -30,6 +30,10 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
   // about that machine, so it is carried per daemon: forcing A must never wave B through a failure
   // nobody was shown. Null ⇒ nothing to force (§3).
   const [forceDaemonId, setForceDaemonId] = useState<string | null>(null)
+  // The assertion itself, ticked separately from pressing the button (product-conventions.md, "Moving
+  // an agent from an unavailable daemon"): forcing is disaster recovery, and it is only safe because
+  // the operator states the machine can never come back.
+  const [forceConfirmed, setForceConfirmed] = useState(false)
   // A group created by a failed attempt. Names are not unique, so retrying without this would
   // create a second one and leave the first empty.
   const createdSetId = useRef<string | null>(null)
@@ -38,19 +42,27 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
   // A daemon the org owns is a candidate unless it is in a DIFFERENT group: a daemon is in at most
   // one, and moving it between groups is a two-phase transition, not a checkbox.
   const candidates = daemons.filter((d) => !d.pool && (!d.memberSetId || d.memberSetId === group?.setId))
+  const forcedDaemonName = daemons.find((d) => d.daemonId === forceDaemonId)?.name ?? 'the daemon'
   const pinnedCount = (daemon: DaemonRow) => agents.filter((a) => a.daemon === daemon.daemonId).length
 
-  const toggle = (daemonId: string) =>
+  const toggle = (daemonId: string) => {
+    // Editing the membership retracts a pending assertion: it was made about one machine in one
+    // plan, and this is a different plan.
+    setForceDaemonId(null)
+    setForceConfirmed(false)
     setMembers((current) =>
       current.includes(daemonId) ? current.filter((id) => id !== daemonId) : [...current, daemonId]
     )
+  }
 
   /** `forcing` is the ONE machine the operator has just asserted is stopped, never a mode. */
   const save = async (forcing: string | null = null) => {
     if (saving || !trimmed) return
+    if (forcing && !forceConfirmed) return
     setSaving(true)
     setErr(null)
     setForceDaemonId(null)
+    setForceConfirmed(false)
     let daemonId: string | undefined
     try {
       // Reuse the group a previous attempt created: it exists, and a second one with the same name
@@ -160,6 +172,20 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
             {err}
           </div>
         )}
+        {forceDaemonId && (
+          <label className="mt-[10px] flex cursor-pointer items-start gap-2.5 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[10px]">
+            <input
+              type="checkbox"
+              className="mt-[2px] flex-none accent-(--brand)"
+              checked={forceConfirmed}
+              onChange={(e) => setForceConfirmed(e.target.checked)}
+            />
+            <span className="font-sans text-[12px] font-normal leading-[1.5] text-(--text-secondary)">
+              I confirm that <span className="font-semibold text-(--text-primary)">{forcedDaemonName}</span> is
+              permanently stopped and cannot reconnect. If it is still running, both copies may process messages.
+            </span>
+          </label>
+        )}
       </div>
       <div className="modalfoot">
         <div className="flex-1" />
@@ -170,9 +196,9 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
           <Button
             variant="danger"
             onClick={() => void save(forceDaemonId)}
-            className={saving ? 'cursor-default opacity-50' : undefined}
+            className={!saving && forceConfirmed ? undefined : 'cursor-default opacity-50'}
           >
-            {daemons.find((d) => d.daemonId === forceDaemonId)?.name ?? 'It'} is stopped — join anyway
+            Force join
           </Button>
         )}
         <Button onClick={() => void save()} className={!saving && trimmed ? undefined : 'cursor-default opacity-50'}>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -4427,10 +4427,18 @@ export async function deleteMemberSet(setId: string): Promise<void> {
   await apiDelete<void>(`${orgBase()}/member-sets/${encodeURIComponent(setId)}`)
 }
 
-/** Enroll a daemon. 409 while agents are still pinned to it, or while it is in another set. */
-export async function enrollDaemonInMemberSet(setId: string, daemonId: string): Promise<MemberSetDto> {
+/** Enroll a daemon. Agents pinned to it come WITH it — the CP stops each on that machine and
+ *  re-places it on the set in one step. 409 when the machine cannot confirm it stopped (retry
+ *  online, or `force` on the operator's assertion that it is permanently stopped), or when it is
+ *  already in another set. */
+export async function enrollDaemonInMemberSet(
+  setId: string,
+  daemonId: string,
+  options: { force?: boolean } = {}
+): Promise<MemberSetDto> {
+  const query = options.force ? '?force=true' : ''
   return apiPut<MemberSetDto>(
-    `${orgBase()}/member-sets/${encodeURIComponent(setId)}/members/${encodeURIComponent(daemonId)}`
+    `${orgBase()}/member-sets/${encodeURIComponent(setId)}/members/${encodeURIComponent(daemonId)}${query}`
   )
 }
 

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -173,8 +173,9 @@ interface ConsoleData {
   renameGroup: (setId: string, name: string) => Promise<void>
   /** Delete an EMPTY group (409 while it has members or placed agents), then re-pull. */
   deleteGroup: (setId: string) => Promise<void>
-  /** Enroll a daemon (409 while agents are pinned to it, or it is in another group). */
-  enrollInGroup: (setId: string, daemonId: string) => Promise<void>
+  /** Enroll a daemon — agents pinned to it move onto the group with it. 409 when the machine
+   *  cannot confirm it stopped them; `force` commits on the operator's assertion that it is. */
+  enrollInGroup: (setId: string, daemonId: string, options?: { force?: boolean }) => Promise<void>
   /** Withdraw a daemon (409 while it holds a live duty lease — drain it first). */
   withdrawFromGroup: (setId: string, daemonId: string) => Promise<void>
   /** Whether the open-connector integration is configured on the CP (gates the
@@ -1265,8 +1266,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   )
 
   const enrollInGroup = useCallback(
-    async (setId: string, daemonId: string) => {
-      await enrollDaemonInMemberSet(setId, daemonId)
+    async (setId: string, daemonId: string, options: { force?: boolean } = {}) => {
+      await enrollDaemonInMemberSet(setId, daemonId, options)
       settleGroupWrite()
     },
     [settleGroupWrite]


### PR DESCRIPTION
Enrolling a daemon that has agents on it answered **"move its N placed agents onto a group first"** — but the only way to move an agent onto a group is for that group to have a live member, and the member you are trying to add is the one that would be it. A dead end, reported as one.

It was also never what the design asked for. [daemon-groups.md](https://github.com/agentconnect-md/agentconnect/blob/main/docs/designs/daemon-groups.md) §3:

> the transition that avoids it is **the existing agent move**, run once per pinned agent with the set as the target — not a new mechanism… **The operator sees one action**; underneath it is the move convention applied N times inside one fence.

I shipped the precondition instead and recorded the debt. This pays it.

## The transition

`AgentMoveService.enrollInSet` does, in order:

1. **Take each pinned agent's move gate**, so nothing re-places one underneath the transition.
2. **Detach it on the machine** — the same confirmed step a machine-to-machine move uses. This is the load-bearing part: it stops runtime authority *before* the placement changes hands, so the machine is never still serving an agent the ledger has already made claimable.
3. **Commit placements + membership in ONE transaction.** Either half alone is a state the invariants forbid — a member with a pinned agent, or agents on a set with nothing in it — and a crash between two statements would leave exactly that. The repository re-checks under the per-daemon fence that nothing else got pinned meanwhile, and fails rather than create it.

Nothing is activated here. The machine is a member now, so it claims those groups back on its next beat and re-activates from replicas it still has — install-on-grant as a refresh.

**Force.** A machine that cannot acknowledge the detach is refused; `?force=true` commits on the operator's assertion that it is permanently stopped. That is the move's own contract and the only boundary available: a directly placed machine is outside the ledger, so it holds no lease and runs no self-fence to wait out.

## What it does not do

The design also wants an **"entering" claim fence** so no peer can win those groups mid-transition. This does not have one: between the commit and the machine's re-claim, another member may take a group. That costs one extra move, not correctness — the detach already guarantees the old machine has stopped. Recorded in §3 next to the leaving half, which is still owed in full.

## Console

The dialog now states the consequence instead of refusing: a checked machine reads *"Its 2 agents move onto the group with it"*. The force button appears only after a machine has actually failed to confirm — it is an assertion about the world, not a checkbox to pre-tick.

## Reviewing

`AgentMoveService`'s eighteen-dependency wiring moves out of `routes/agents.ts` into `http/agent-moves.ts`. Group enrolment is its second caller, and a second hand-built copy of that bundle is a copy that drifts.

Tests: the repository transition (agents re-placed + membership in one commit, then the machine can actually claim their duty), the mid-transition pin refusing rather than stranding an agent, idempotence and the wrong-set refusal, plus the route's refuse-then-force path.

Verified against a live control plane: joining an offline daemon with a pinned agent returns `could not stop builder on this daemon…`, and `?force=true` moves `builder` from `daemon`-placed to `set`-placed and enrolls the machine in one call.

control-plane integration 1421, unit 1751; web 1569; typecheck, lint, format clean.

Part of #955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
