### PR TITLE
feat(web): per-feature experiment switches, starting with daemon groups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,3 +165,9 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # a member identity from any other namespace is refused. 'false' (default) ⇒ off,
 # only API-key daemon auth is accepted.
 # DAEMON_POOL_ENABLED=true
+
+# Experimental console surfaces this deployment turns on — a comma-separated list of
+# ids (packages/web/src/lib/experiments.ts). Unset means none: the surface ships in
+# every build and appears only where an environment asks for it. The Control Plane
+# serves the feature either way; this decides whether the console offers it.
+#   EXPERIMENTS="daemon-groups"

--- a/compose.yaml
+++ b/compose.yaml
@@ -237,6 +237,9 @@ services:
       # targets; unset => all of them). The console owns this decision; the
       # control plane gates on whether the tenant has that connector.
       - SOCIAL_PROVIDERS
+      # Experimental console surfaces this deployment turns on (comma-separated ids;
+      # unset => none). Forwarded from the host so one image serves every deployment.
+      - EXPERIMENTS
     healthcheck:
       test:
         - CMD

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,5 +1,0 @@
-# Experimental features this deployment turns on in the CONSOLE — a comma-separated
-# list of ids (src/lib/experiments.ts). Unset means none: the surface ships in every
-# build and appears only where an environment asks for it. The Control Plane serves
-# the feature either way; this decides whether the console offers it.
-#   EXPERIMENTS="daemon-groups"

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,0 +1,5 @@
+# Experimental features this deployment turns on in the CONSOLE — a comma-separated
+# list of ids (src/lib/experiments.ts). Unset means none: the surface ships in every
+# build and appears only where an environment asks for it. The Control Plane serves
+# the feature either way; this decides whether the console offers it.
+#   EXPERIMENTS="daemon-groups"

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useConsoleData } from '@/lib/data-context'
+import { experimentEnabled } from '@/lib/experiments'
 import { useProfile } from '@/lib/profile'
 import { useOrgs } from '@/lib/org-context'
 import {
@@ -360,7 +361,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
       : []),
     // The org's own groups sit with Cloud, not with the machines: they are the same KIND of target
     // — the server picks which member serves, and the agent survives losing any one of them.
-    ...offeredGroups.map((group) => ({
+    ...(experimentEnabled('daemon-groups') ? offeredGroups : []).map((group) => ({
       value: groupPlacementValue(group.setId),
       label: group.name,
       detail: availableGroups.includes(group)

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -386,7 +386,13 @@ export default function EditAgentModal({
     // The org's own groups sit with Cloud: same kind of target, same promise — lose any one member
     // and the duty re-grants to another (daemon-groups.md §2). A group with nothing serving stays
     // listed but disabled, unless it is where the agent already is.
-    ...(experimentEnabled('daemon-groups') ? memberSets : []).map((group) => {
+    // With the experiment off the picker offers no group — EXCEPT the one this agent is already on.
+    // Dropping it would show "No daemon" for a placed agent, which is simply untrue, and a rollback
+    // is exactly when a truthful current placement matters most.
+    ...(experimentEnabled('daemon-groups')
+      ? memberSets
+      : memberSets.filter((group) => groupPlacementValue(group.setId) === initialDaemonId.current)
+    ).map((group) => {
       const serving = group.memberDaemonIds.some((id) => moveReady(daemons.find((d) => d.daemonId === id)))
       const current = groupPlacementValue(group.setId) === initialDaemonId.current
       return {

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -37,6 +37,7 @@ import {
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { fetchAgentDto, type AgentCallPolicyInput, type UpdateAgentInput } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
+import { experimentEnabled } from '@/lib/experiments'
 import { useOrgs } from '@/lib/org-context'
 import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import { Spinner } from '@/components/marks'
@@ -385,7 +386,7 @@ export default function EditAgentModal({
     // The org's own groups sit with Cloud: same kind of target, same promise — lose any one member
     // and the duty re-grants to another (daemon-groups.md §2). A group with nothing serving stays
     // listed but disabled, unless it is where the agent already is.
-    ...memberSets.map((group) => {
+    ...(experimentEnabled('daemon-groups') ? memberSets : []).map((group) => {
       const serving = group.memberDaemonIds.some((id) => moveReady(daemons.find((d) => d.daemonId === id)))
       const current = groupPlacementValue(group.setId) === initialDaemonId.current
       return {

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/lib/data'
 import { creatorLabel } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
+import { experimentEnabled } from '@/lib/experiments'
 import { useProfile } from '@/lib/profile'
 import { useModal } from '@/components/console/ModalProvider'
 import { VisibilityValue } from '@/components/console/VisibilityField'
@@ -839,7 +840,7 @@ function GroupCard({ daemon, pinnedAgents }: { daemon: DaemonRow; pinnedAgents: 
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   // The pool is managed infrastructure — its membership is the CP's, never an operator's.
-  if (daemon.pool) return null
+  if (daemon.pool || !experimentEnabled('daemon-groups')) return null
 
   const current = memberSets.find((group) => group.setId === daemon.memberSetId)
   const blockedReason =

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -12,6 +12,7 @@ import {
   type MemberSetRow
 } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
+import { experimentEnabled } from '@/lib/experiments'
 import { useModal } from '@/components/console/ModalProvider'
 import { RestrictedLock } from '@/components/console/VisibilityField'
 import { DaemonUpgradeBadge } from '@/components/console/DaemonUpgradeBadge'
@@ -132,6 +133,9 @@ export default function DaemonsView() {
  */
 function GroupsSection({ groups, daemons }: { groups: MemberSetRow[]; daemons: DaemonRow[] }) {
   const { openModal } = useModal()
+  // Experimental: the surface exists in every build and appears only where the deployment asked
+  // for it. The Control Plane's routes are absent there too, so this hides no working door.
+  if (!experimentEnabled('daemon-groups')) return null
   if (!daemons.some((d) => !d.pool) && groups.length === 0) return null
 
   return (

--- a/packages/web/src/lib/experiments.test.ts
+++ b/packages/web/src/lib/experiments.test.ts
@@ -29,4 +29,22 @@ describe('experimentEnabled', () => {
     setEnv('not-a-feature')
     expect(experimentEnabled('daemon-groups')).toBe(false)
   })
+
+  it('server and client read the same value, so the gate cannot differ across hydration', () => {
+    // `public-env` injects plain `EXPERIMENTS`; a server branch reading only the build-time twin
+    // would render the surface off and hydrate it on.
+    const original = (window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV
+    delete (window as unknown as { __AC_ENV?: unknown }).__AC_ENV
+    process.env.EXPERIMENTS = 'daemon-groups'
+    try {
+      // The browser branch, with nothing injected: off, because there is nothing to read.
+      expect(experimentEnabled('daemon-groups')).toBe(false)
+      // And injected, it is the source both sides agree on.
+      ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { EXPERIMENTS: 'daemon-groups' }
+      expect(experimentEnabled('daemon-groups')).toBe(true)
+    } finally {
+      delete process.env.EXPERIMENTS
+      ;(window as unknown as { __AC_ENV?: unknown }).__AC_ENV = original
+    }
+  })
 })

--- a/packages/web/src/lib/experiments.test.ts
+++ b/packages/web/src/lib/experiments.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+// The parse is the whole contract: what a deployment writes decides what its console shows.
+import { describe, expect, it, afterEach } from 'vitest'
+import { experimentEnabled } from './experiments'
+
+const setEnv = (value?: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
+    value === undefined ? {} : { EXPERIMENTS: value }
+}
+
+afterEach(() => setEnv())
+
+describe('experimentEnabled', () => {
+  it('is off unless the deployment asks for it', () => {
+    // A new experiment shipping ON is the failure mode this prevents: every environment would
+    // get it the moment it merged.
+    setEnv()
+    expect(experimentEnabled('daemon-groups')).toBe(false)
+    setEnv('')
+    expect(experimentEnabled('daemon-groups')).toBe(false)
+  })
+
+  it('reads a comma-separated list, tolerating spacing and case', () => {
+    setEnv(' Daemon-Groups , something-else ')
+    expect(experimentEnabled('daemon-groups')).toBe(true)
+  })
+
+  it('ignores ids it does not know', () => {
+    setEnv('not-a-feature')
+    expect(experimentEnabled('daemon-groups')).toBe(false)
+  })
+})

--- a/packages/web/src/lib/experiments.ts
+++ b/packages/web/src/lib/experiments.ts
@@ -21,10 +21,14 @@ export type ExperimentId =
   'daemon-groups'
 
 function enabledIds(): ReadonlySet<string> {
+  // The server must read the SAME value `PublicEnvScript` injects, in the same precedence, or a
+  // runtime-only configuration renders the gate off on the server and on during hydration — which
+  // is a React markup mismatch, not just a flicker. `public-env` resolves plain `EXPERIMENTS`
+  // first and falls back to the build-time `NEXT_PUBLIC_` twin; so does this.
   const raw =
-    (typeof window === 'undefined' ? undefined : window.__AC_ENV?.EXPERIMENTS) ??
-    process.env.NEXT_PUBLIC_EXPERIMENTS ??
-    ''
+    (typeof window === 'undefined'
+      ? (process.env.EXPERIMENTS ?? process.env.NEXT_PUBLIC_EXPERIMENTS)
+      : window.__AC_ENV?.EXPERIMENTS) ?? ''
   return new Set(
     raw
       .split(',')

--- a/packages/web/src/lib/experiments.ts
+++ b/packages/web/src/lib/experiments.ts
@@ -1,0 +1,44 @@
+/**
+ * Experimental features, as the console sees them.
+ *
+ * `EXPERIMENTS` is a comma-separated list of the ids below, read at runtime through
+ * `window.__AC_ENV` — so one prebuilt image serves every environment and a deployment decides
+ * which experimental surfaces it shows. Unset means none: a new experiment cannot arrive on.
+ *
+ * This is a CONSOLE-side switch. The Control Plane serves the feature either way; what an
+ * environment turns off here is whether the console offers it, not whether it exists. That is the
+ * point — the feature stays exercised end to end wherever it is on, with no server-side variant to
+ * reason about.
+ *
+ * A flag is temporary. When a feature is on everywhere, delete its id here and the checks with it.
+ */
+
+/** Every experiment the console knows. Adding one is this union plus its checks. */
+export type ExperimentId =
+  /** Org-scoped daemon groups: the Infra section, the group dialogs, and group entries in the
+   *  placement picker (docs/designs/daemon-groups.md §6 PR 2). The install-wide pool is not an
+   *  experiment and is unaffected. */
+  'daemon-groups'
+
+function enabledIds(): ReadonlySet<string> {
+  const raw =
+    (typeof window === 'undefined' ? undefined : window.__AC_ENV?.EXPERIMENTS) ??
+    process.env.NEXT_PUBLIC_EXPERIMENTS ??
+    ''
+  return new Set(
+    raw
+      .split(',')
+      .map((entry) => entry.trim().toLowerCase())
+      .filter(Boolean)
+  )
+}
+
+/**
+ * Is this experiment on for this deployment?
+ *
+ * Not a hook: it reads a value fixed for the life of the page (injected before the bundle runs),
+ * so it needs no subscription and can be called from anywhere — a render, a helper, a projection.
+ */
+export function experimentEnabled(id: ExperimentId): boolean {
+  return enabledIds().has(id)
+}

--- a/packages/web/src/lib/public-env.tsx
+++ b/packages/web/src/lib/public-env.tsx
@@ -46,7 +46,11 @@ const KEYS = [
   // project key (phc_…) — safe in the browser. Unset ⇒ analytics is a no-op
   // (lib/analytics never initializes). POSTHOG_HOST defaults to us.i.posthog.com.
   'POSTHOG_API_KEY',
-  'POSTHOG_HOST'
+  'POSTHOG_HOST',
+  // Experimental features this deployment turns on — a comma-separated list of ids
+  // (lib/experiments.ts). Unset ⇒ none: an experimental surface ships in every build and appears
+  // only where an environment asks for it, so one prebuilt image serves them all.
+  'EXPERIMENTS'
 ] as const
 
 interface RuntimeConfigResponse {


### PR DESCRIPTION
An experimental surface should be exercisable in one environment without a branch to rebase or a build to keep apart. This adds the switch, with daemon groups as its first entry.

## The mechanism

`EXPERIMENTS` is a comma-separated list of ids, read at runtime through `window.__AC_ENV` — the same path every other runtime value takes, so one prebuilt image serves every environment and each decides what it shows.

- **Unset means none.** A new experiment cannot arrive already on: an environment has to ask for it.
- **Unknown ids are ignored**, so an environment can be configured ahead of the release that adds a feature and rolled back behind it without its configuration becoming invalid.
- **Adding one** is a member of the `ExperimentId` union plus its checks.

```
EXPERIMENTS="daemon-groups"
```

## Console-side, deliberately

The Control Plane serves daemon groups either way. What an environment turns off is whether the **console offers** the feature, not whether it exists — so there is no server-side variant to reason about, and wherever it is on the feature is exercised end to end against the same server behaviour every other environment gets.

## What `daemon-groups` gates

The Infra section, the New/Edit group dialogs, the group entries in the placement picker, and the daemon-detail membership card. The install-wide pool is not an experiment and is untouched — with the flag off the console is exactly what it was before daemon groups landed.

## Reviewing

`experimentEnabled` is a plain function, not a hook: the value is fixed for the life of the page (injected before the bundle runs), so it needs no subscription and can be called from a render, a helper or a projection alike.

Verified against a live control plane, same build both ways: with the flag unset the Infra page shows only the daemon card; with `EXPERIMENTS=daemon-groups` the Daemon groups table appears with its group. The injected `window.__AC_ENV` carries `{"EXPERIMENTS":"daemon-groups"}`.

**A flag is temporary.** When a feature is on everywhere, its id and its checks should come out — a permanently half-on feature is two products.

web: 1580 tests pass; typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
