### PR TITLE
test(control-plane): match the hook audit rows by hook id

### DIFF
--- a/packages/control-plane/test/integration/hooks.route.test.ts
+++ b/packages/control-plane/test/integration/hooks.route.test.ts
@@ -771,11 +771,15 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
     }
     await a.app.inject({ method: 'DELETE', url: `${ORG}/hooks/${id}` })
 
+    // Both appends are fire-and-forget: order is not guaranteed, and a prior test's row can outlive the sweep.
     await vi.waitFor(async () => {
-      const rows = await prisma.auditEvent.findMany({ where: { kind: 'hook_change' }, orderBy: { id: 'asc' } })
-      expect(rows.length).toBeGreaterThanOrEqual(2)
-      expect((rows[0]!.details as { hookId: string }).hookId).toBe(id)
-      expect(rows[0]!.agentId).toBe(agentId)
+      const rows = await prisma.auditEvent.findMany({
+        where: { kind: 'hook_change', details: { path: ['hookId'], equals: id } }
+      })
+      expect(rows.sort((x, y) => (x.frameType ?? '').localeCompare(y.frameType ?? ''))).toMatchObject([
+        { frameType: 'rc/hook-assign', agentId },
+        { frameType: 'rc/hook-remove', agentId }
+      ])
     })
   })
 })


### PR DESCRIPTION
## Problem

`hooks.route.test.ts` → "POST and DELETE append hook_change audit rows" fails intermittently in CI with

```
AssertionError: expected 'a2875466-…' to be '03b34035-…'
```

Two different hook ids, in a test that creates exactly one hook.

## Why

The test read **every** `hook_change` row in the table and asserted positionally:

```ts
const rows = await prisma.auditEvent.findMany({ where: { kind: 'hook_change' }, orderBy: { id: 'asc' } })
expect((rows[0]!.details as { hookId: string }).hookId).toBe(id)
```

Two things break that, and neither is what the test is trying to prove:

1. **A row can leak in from an earlier test.** All three audit appends in `src/http/routes/hooks.ts` are fire-and-forget (`void deps.repos.audit.append(...).catch(() => {})`) after the response is sent. An earlier test's append can take its sequence value before the per-test sweep in `test/setup.db.ts` and commit after it, leaving a row from a *different* hook with a **lower id and an older `createdAt`** sitting in front of this test's pair. That is the failure above — the foreign hook id lands in `rows[0]`.
2. **The two appends race each other.** The POST's append is still in flight when the test injects the DELETE, so create-before-remove is not an order production code guarantees.

Worth noting for anyone reading the failure the same way I first did: `AuditEvent.id` is `BigInt @default(autoincrement())`, so it *is* monotonic — `orderBy: { id: 'asc' }` was genuine insertion order. The flake is contamination, not a non-monotonic key. Switching the sort to `createdAt` would **not** have fixed it, since the leaked row is older on that column too.

## Fix

Filter the query to this test's hook and assert the two rows as a set:

```ts
const rows = await prisma.auditEvent.findMany({
  where: { kind: 'hook_change', details: { path: ['hookId'], equals: id } }
})
expect(rows.sort((x, y) => (x.frameType ?? '').localeCompare(y.frameType ?? ''))).toMatchObject([
  { frameType: 'rc/hook-assign', agentId },
  { frameType: 'rc/hook-remove', agentId }
])
```

This also strengthens the test slightly: it now pins both rows' `frameType` and `agentId`, where before only the first row was checked at all.

## Verification

Beyond running the suite, I reproduced the contamination directly. In a throwaway copy of the file I injected a simulated leaked row (`id: -1n`, `createdAt` 60s earlier, a different hookId) and ran three assertion variants against it:

| Assertion | Result |
| --- | --- |
| old, `orderBy: { id: 'asc' }` | **fails** — same `expected '<uuid>' to be '<uuid>'` signature as CI |
| `orderBy: [{ createdAt: 'asc' }, { id: 'asc' }]` | **fails** — the leaked row is older too |
| new, filtered + set assertion | **passes** |

Probe file deleted. Then: `hooks.route.test.ts` green 3× consecutively (21 tests), the full control-plane integration suite green (95 files / 1418 tests), plus typecheck, eslint and prettier.

## Notes for the reviewer

- Test-only. No production behaviour changes.
- `crons.route.test.ts` → "PUT and DELETE append cron_change audit rows (§3.12)" has the same pattern and is more exposed (`toHaveLength(2)` plus a positional frameType order over an unscoped query). Left out to keep this PR to one change; it deserves the same treatment.
- The comment at `test/setup.db.ts:53` justifies skipping `RESTART IDENTITY` with "every assertion over it is relative (`orderBy id`)". Still true for the two `mcp_tool_call` assertions, but that assumption is what invited this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
