### PR TITLE
docs(web): the experiment switch hides the console door, not the feature

### DIFF
--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -134,7 +134,8 @@ export default function DaemonsView() {
 function GroupsSection({ groups, daemons }: { groups: MemberSetRow[]; daemons: DaemonRow[] }) {
   const { openModal } = useModal()
   // Experimental: the surface exists in every build and appears only where the deployment asked
-  // for it. The Control Plane's routes are absent there too, so this hides no working door.
+  // for it. The Control Plane serves member sets either way — this hides the console entry point,
+  // not the feature, which is what keeps one server to reason about.
   if (!experimentEnabled('daemon-groups')) return null
   if (!daemons.some((d) => !d.pool) && groups.length === 0) return null
 


### PR DESCRIPTION
Follow-up to #1131, which merged before this review note landed.

The comment on the `daemon-groups` gate in `DaemonsView` said the Control Plane's
routes are absent wherever the console flag is off. They are not — the CP serves
member sets either way, which is the point: the feature stays exercised end to end
with no server-side variant to reason about. A reader following the old sentence
would go looking for a server gate that does not exist.

Comment only; no behavior change.
