### PR TITLE
test(control-plane): match the cron audit rows by cron id

### DIFF
--- a/packages/control-plane/test/integration/crons.route.test.ts
+++ b/packages/control-plane/test/integration/crons.route.test.ts
@@ -392,13 +392,15 @@ describe('cron replication CP→daemon (REST → cron/upsert·remove)', () => {
     await app.app.inject({ method: 'PUT', url: `${ORG}/crons/${cronId}`, payload: body(agentId) })
     await app.app.inject({ method: 'DELETE', url: `${ORG}/crons/${cronId}` })
 
-    // The audit append is fire-and-forget off the request path — poll for it.
+    // Both appends are fire-and-forget: order is not guaranteed, and a prior test's row can outlive the sweep.
     await vi.waitFor(async () => {
-      const rows = await prisma.auditEvent.findMany({ where: { kind: 'cron_change' }, orderBy: { id: 'asc' } })
-      expect(rows).toHaveLength(2)
-      expect(rows.map((r) => r.frameType)).toEqual(['cron/upsert', 'cron/remove'])
-      expect((rows[0]!.details as { cronId: string }).cronId).toBe(cronId)
-      expect(rows[0]!.agentId).toBe(agentId)
+      const rows = await prisma.auditEvent.findMany({
+        where: { kind: 'cron_change', details: { path: ['cronId'], equals: cronId } }
+      })
+      expect(rows.sort((x, y) => (x.frameType ?? '').localeCompare(y.frameType ?? ''))).toMatchObject([
+        { frameType: 'cron/remove', agentId },
+        { frameType: 'cron/upsert', agentId }
+      ])
     })
   })
 })


### PR DESCRIPTION
## What

`crons.route.test.ts` — "PUT and DELETE append cron_change audit rows (§3.12)" now
scopes its audit query to the cron under test and asserts the two rows as a set,
instead of reading every `cron_change` row and asserting positionally.

```ts
const rows = await prisma.auditEvent.findMany({
  where: { kind: 'cron_change', details: { path: ['cronId'], equals: cronId } }
})
expect(rows.sort((x, y) => (x.frameType ?? '').localeCompare(y.frameType ?? ''))).toMatchObject([
  { frameType: 'cron/remove', agentId },
  { frameType: 'cron/upsert', agentId }
])
```

## Why

The old assertion (`toHaveLength(2)`, a positional `['cron/upsert', 'cron/remove']`
order, and `rows[0].details.cronId`) is unsafe for two independent reasons — the same
pair already fixed for `hook_change` in #1132:

1. Both routes append the audit row fire-and-forget after the response
   (`void deps.repos.audit.append(...).catch(() => {})` in `src/http/routes/crons.ts`),
   so the upsert and remove rows race each other into the `audit_event` sequence.
   Production code guarantees nothing about their relative order.
2. An earlier test's fire-and-forget append can commit *after* the per-test sweep in
   `test/setup.db.ts`, leaving a foreign row with a lower id and an older `createdAt`
   in the table. That breaks the length check and the positional ones alike. Ordering
   on `createdAt` is not a fix — the leaked row is older on that column too.

## Reviewer notes

- Coverage is preserved: both append sites stamp `agentId` (the remove path from
  `existing.agentId`) and put `cronId` in `details`, so the JSON path filter selects
  exactly this test's pair and `agentId` stays assertable on both rows.
- Test only; no production behaviour changes.

## Verification

- `vitest run --project integration test/integration/crons.route.test.ts` — 18/18 pass
- `pnpm --filter @agentconnect.md/control-plane typecheck` clean, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
