### PR TITLE
feat(compose): ship the connector gateway in the default stack

### DIFF
--- a/compose.env.example
+++ b/compose.env.example
@@ -30,6 +30,9 @@
 # SECRET_CIPHER does not cover. Do not set an admin token; the integration sends none.
 # AGENTCONNECT_OPEN_CONNECTOR_PORT=3100
 # OOMOL_CONNECT_ENCRYPTION_KEY=replace-with-a-stable-random-32-char-secret
+# Require a bearer on the gateway's runtime API. This one value configures both the
+# gateway and the relay that calls it; unset leaves runtime auth off on both.
+# OOMOL_CONNECT_RUNTIME_TOKEN=replace-with-a-stable-random-32-char-secret
 # OAuth providers redirect to <origin>/oauth/callback, so the origin must be
 # browser-reachable. Set it when the stack is not on localhost.
 # AGENTCONNECT_PUBLIC_OPEN_CONNECTOR_URL=http://localhost:3100

--- a/compose.env.example
+++ b/compose.env.example
@@ -24,6 +24,20 @@
 # AGENTCONNECT_API_KEY_PEPPER=replace-with-a-stable-random-32-char-secret
 # AGENTCONNECT_RELAY_TOKEN=replace-with-a-stable-random-32-char-secret
 
+# Connectors. The gateway runs in the stack and is reachable only on loopback.
+# Set an encryption key before real use: without it, connector credentials and
+# OAuth client secrets are plaintext in that service's own SQLite volume, which
+# SECRET_CIPHER does not cover. Do not set an admin token; the integration sends none.
+# AGENTCONNECT_OPEN_CONNECTOR_PORT=3100
+# OOMOL_CONNECT_ENCRYPTION_KEY=replace-with-a-stable-random-32-char-secret
+# OAuth providers redirect to <origin>/oauth/callback, so the origin must be
+# browser-reachable. Set it when the stack is not on localhost.
+# AGENTCONNECT_PUBLIC_OPEN_CONNECTOR_URL=http://localhost:3100
+# Narrow the browsable catalog. Whitelist `*` or unset => every service. The
+# blocklist defaults to the services that overlap AgentConnect's own integrations.
+# OPEN_CONNECTOR_PROVIDER_WHITELIST=*
+# OPEN_CONNECTOR_PROVIDER_BLOCKLIST=github,slack,telegram,discord,discordbot,feishu,feishu_app_bot,feishu_custom_bot
+
 # Browser authentication, provider Apps, displayed sign-in methods, the browser
 # API Resource, and preset-agent behavior are configured in Setup and
 # stored in the deployment database. They are not Compose overrides.

--- a/compose.yaml
+++ b/compose.yaml
@@ -158,6 +158,10 @@ services:
       - LOGTO_MGMT_APP_ID
       - LOGTO_MGMT_APP_SECRET
       - LOGTO_MGMT_RESOURCE
+      # Brokers connector browsing and connection provisioning; the origin stays server-side.
+      - OPEN_CONNECTOR_URL=http://open-connector:3000
+      - OPEN_CONNECTOR_PROVIDER_WHITELIST
+      - OPEN_CONNECTOR_PROVIDER_BLOCKLIST
     healthcheck:
       test:
         - CMD
@@ -193,6 +197,9 @@ services:
       - DAEMON_DIAL_URL=${AGENTCONNECT_RELAY_DAEMON_URL:-ws://localhost:${AGENTCONNECT_RELAY_PORT:-8090}}
       - RELAY_TOKEN=${AGENTCONNECT_RELAY_TOKEN:-local-only-relay-token-0000000000000000}
       - GITHUB_APP_WEBHOOK_SECRET
+      # Egress for open_connector bindings — the relay calls its runtime action API.
+      - OPEN_CONNECTOR_URL=http://open-connector:3000
+      - OPEN_CONNECTOR_RUNTIME_TOKEN
     healthcheck:
       test:
         - CMD
@@ -255,8 +262,30 @@ services:
     restart: unless-stopped
     stop_grace_period: 30s
 
+  # Connector gateway backing the console's "Add connectors" catalog. Its admin API and
+  # web console are unauthenticated, so it stays on loopback like Setup Server and Postgres.
+  # Leave OOMOL_CONNECT_ADMIN_TOKEN unset: the Control Plane client sends no bearer token.
+  open-connector:
+    image: ghcr.io/oomol-lab/open-connector:${AGENTCONNECT_OPEN_CONNECTOR_VERSION:-latest}
+    pull_policy: missing
+    environment:
+      - PORT=3000
+      - OOMOL_CONNECT_DATA_DIR=/app/data
+      # Unset => provider credentials and OAuth client secrets are plaintext in this
+      # service's SQLite. That store is outside SECRET_CIPHER; set a key before real use.
+      - OOMOL_CONNECT_ENCRYPTION_KEY
+      # Browser-reachable origin the provider redirects to at <origin>/oauth/callback.
+      - OOMOL_CONNECT_ORIGIN=${AGENTCONNECT_PUBLIC_OPEN_CONNECTOR_URL:-http://localhost:${AGENTCONNECT_OPEN_CONNECTOR_PORT:-3100}}
+    init: true
+    ports:
+      - 127.0.0.1:${AGENTCONNECT_OPEN_CONNECTOR_PORT:-3100}:3000
+    volumes:
+      - open-connector-data:/app/data
+    restart: unless-stopped
+
 volumes:
   migration-files:
+  open-connector-data:
   postgres-data:
 
 networks:

--- a/compose.yaml
+++ b/compose.yaml
@@ -199,7 +199,9 @@ services:
       - GITHUB_APP_WEBHOOK_SECRET
       # Egress for open_connector bindings — the relay calls its runtime action API.
       - OPEN_CONNECTOR_URL=http://open-connector:3000
-      - OPEN_CONNECTOR_RUNTIME_TOKEN
+      # One host variable drives both ends so runtime auth is never half-configured; the
+      # relay sends no bearer when it resolves empty, matching a gateway with auth off.
+      - OPEN_CONNECTOR_RUNTIME_TOKEN=${OOMOL_CONNECT_RUNTIME_TOKEN:-}
     healthcheck:
       test:
         - CMD
@@ -276,6 +278,8 @@ services:
       - OOMOL_CONNECT_ENCRYPTION_KEY
       # Browser-reachable origin the provider redirects to at <origin>/oauth/callback.
       - OOMOL_CONNECT_ORIGIN=${AGENTCONNECT_PUBLIC_OPEN_CONNECTOR_URL:-http://localhost:${AGENTCONNECT_OPEN_CONNECTOR_PORT:-3100}}
+      # Bare pass-through so an unset value stays unset here rather than arriving empty.
+      - OOMOL_CONNECT_RUNTIME_TOKEN
     init: true
     ports:
       - 127.0.0.1:${AGENTCONNECT_OPEN_CONNECTOR_PORT:-3100}:3000

--- a/packages/control-plane/src/http/routes/connectors.ts
+++ b/packages/control-plane/src/http/routes/connectors.ts
@@ -12,7 +12,8 @@
  * any provider), and (2) provision the connection PROFILE in open-connector
  * (`<orgHash>--<userHash>--<name>`). If step 2's api-key save fails, step 1 is rolled back.
  * The profile is composed HERE and only here — it is persisted as the connection's alias
- * binding marker, and reconnect/relay replay read it back rather than recomposing it.
+ * binding marker, and reconnect/relay replay read it back rather than recomposing it. It
+ * pins every runtime action: the relay translates to /v1/actions, never OC's own /mcp.
  */
 import type { FastifyInstance } from 'fastify'
 import type { ZodTypeProvider } from '../plugins/zod.js'


### PR DESCRIPTION
## Why

Browsing connectors required standing up the gateway yourself and then discovering `OPEN_CONNECTOR_URL`, which no user-facing documentation described. Neither `compose.yaml` nor `compose.env.example` passed those variables through, so on a self-hosted stack the feature was effectively unreachable — the routes 404 and the console hides the **Add connectors** menu item whenever the URL is unset.

Rather than document a wiring exercise, run the gateway as part of the stack so the feature is on by default and there is no URL for anyone to configure.

## What changed

- New `open-connector` service on `ghcr.io/oomol-lab/open-connector`, with its own named volume for the gateway's SQLite. The image publishes both `amd64` and `arm64`, so `platform` is deliberately not pinned.
- `control-plane` and `relay` reach it by service name (`http://open-connector:3000`); the whitelist, blocklist, and runtime-token variables pass through for anyone who wants to narrow the catalog.
- The published port is hard loopback (`127.0.0.1:3100:3000`), following Setup Server and Postgres rather than `AGENTCONNECT_BIND_ADDRESS`, because the gateway's admin API and console are unauthenticated. It still has to be browser-reachable: configuring an OAuth client secret and receiving the OAuth callback both happen against that origin.
- `compose.env.example` documents the encryption key, the OAuth origin, and the catalog filters as commented-out overrides.

## Reviewer notes

Two limits are called out in `compose.env.example` instead of being papered over:

- Connector credentials and OAuth client secrets live in the gateway's own SQLite volume, **outside `SECRET_CIPHER`**. `OOMOL_CONNECT_ENCRYPTION_KEY` is what protects them, and that volume is a second backup target.
- `OOMOL_CONNECT_ADMIN_TOKEN` must stay unset — `ConnectorsClient` sends no bearer token, so setting one breaks catalog browsing.

This also corrects two comments that claimed the gateway ignores the connection profile at runtime. It does not: the relay sends `connectionName: <profile>` on every `tools/call`, translating to `/v1/actions` and never touching the gateway's own `/mcp`. That makes the pre-existing cross-org profile-collision caveat above `composeProfileName` live rather than inert, so its wording is corrected too. Changing the naming scheme itself is deliberately out of scope here — it would strand profiles already provisioned under the current scheme and needs a migration or a one-time reconnect. It is being handled separately.

## Verification

Booted the service and exercised the two endpoints the control plane calls, both with no auth header, matching how `ConnectorsClient` calls them:

- `/api/providers` → 1277 providers, ready ~2s after start
- `/api/oauth/configs` → 66 entries, `configured: 0`

The second result confirms the fresh-stack behaviour: `filterCatalog` strips every unconfigured `oauth2` method, so a new deployment browses api-key and no-auth services only until someone configures a client secret. SQLite was confirmed to land in the mounted volume. `docker compose config` validates.

Documentation for this lands separately in the docs repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
