### PR TITLE
fix(control-plane): hash org/user ids into the connector profile name

### DIFF
--- a/packages/control-plane/src/connectors/filter.test.ts
+++ b/packages/control-plane/src/connectors/filter.test.ts
@@ -5,6 +5,7 @@ import {
   isValidConnectionName,
   parseBlocklist,
   parseWhitelist,
+  PROFILE_HASH_LEN,
   type OcOAuthConfig,
   type OcProvider
 } from './filter.js'
@@ -105,12 +106,44 @@ describe('parseBlocklist', () => {
 })
 
 describe('composeProfileName', () => {
-  it('prefixes the first 8 id chars and stays within open-connector 64-char limit', () => {
+  it('hashes each id to a fixed-width segment and keeps the connection name verbatim', () => {
     const name = composeProfileName('clorg1234567890abcdef', 'cluser1234567890abcdef', 'my-conn')
-    expect(name).toBe('clorg123--cluser12--my-conn')
-    // Worst case: 8 + 2 + 8 + 2 + 32 = 52 ≤ 64.
+    const [org, user, conn] = name.split('--')
+    expect(org).toHaveLength(PROFILE_HASH_LEN)
+    expect(user).toHaveLength(PROFILE_HASH_LEN)
+    expect(conn).toBe('my-conn')
+    expect(composeProfileName('clorg1234567890abcdef', 'cluser1234567890abcdef', 'my-conn')).toBe(name)
+  })
+
+  it('stays within open-connector 64-char limit at the longest legal connection name', () => {
+    // Worst case: 13 + 2 + 13 + 2 + 32 = 62 ≤ 64.
     const max = composeProfileName('x'.repeat(30), 'y'.repeat(30), 'z'.repeat(32))
+    expect(max.length).toBe(62)
     expect(max.length).toBeLessThanOrEqual(64)
+  })
+
+  it('composes a name open-connector accepts — its charset, alphanumeric-led, ≤64', () => {
+    // Fixed-width base36 is [0-9a-z], so no digest can start the profile with _ or -.
+    for (let i = 0; i < 200; i++) {
+      const profile = composeProfileName(`c${i}org`, `c${i}user`, 'prod_gmail-1')
+      expect(profile).toMatch(/^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/)
+    }
+  })
+
+  it('separates ids that shared a truncated cuid prefix (the collision this replaced)', () => {
+    // Two orgs created in the same ~36ms bucket, whose creating users also were, both
+    // naming a connection "gmail": identical under `<id[0..8]>`, so one org's saved
+    // credential overwrote the other's and its agents then ran actions as that org.
+    const truncated = (o: string, u: string, n: string) => `${o.slice(0, 8)}--${u.slice(0, 8)}--${n}`
+    const a = ['clzzzzzzAAAAAAA', 'clyyyyyyBBBBBBB', 'gmail'] as const
+    const b = ['clzzzzzzCCCCCCC', 'clyyyyyyDDDDDDD', 'gmail'] as const
+    expect(truncated(...a)).toBe(truncated(...b))
+    expect(composeProfileName(...a)).not.toBe(composeProfileName(...b))
+  })
+
+  it('domain-separates the org and user segments', () => {
+    const [org, user] = composeProfileName('same-id', 'same-id', 'c').split('--')
+    expect(org).not.toBe(user)
   })
 })
 

--- a/packages/control-plane/src/connectors/filter.ts
+++ b/packages/control-plane/src/connectors/filter.ts
@@ -3,6 +3,7 @@
  * network client lives in `client.ts`. Ported from the web's former
  * `lib/open-connector.ts` so the same catalog filter is now CP-owned.
  */
+import { createHash } from 'node:crypto'
 
 /** How the CP namespaces a connection as an open-connector profile, and the header
  *  that selects it when the relay calls open-connector's runtime API. */
@@ -10,9 +11,9 @@ export const CONNECTOR_ALIAS_HEADER = 'x-oomol-connector-alias'
 /** The open-connector `service` a connection is bound to, carried to the relay so its
  *  synthesized MCP proxy lists/calls that service's actions. Not a secret. */
 export const CONNECTOR_SERVICE_HEADER = 'x-oomol-connector-service'
-/** Chars of the org/user id used in the profile prefix — kept short so the composed
- *  `<org>--<user>--<name>` fits open-connector's 64-char connection-name limit. */
-export const PROFILE_ID_PREFIX_LEN = 8
+/** Base36 width of each hashed id in the profile prefix — 64 digest bits at fixed width,
+ *  so `<org>--<user>--<name>` peaks at 62 of open-connector's 64 connection-name chars. */
+export const PROFILE_HASH_LEN = 13
 
 // ── upstream shapes (subset we consume; mirrors open-connector web/src/model.ts) ──
 export interface OcAuthDefinition {
@@ -104,19 +105,31 @@ export function isValidConnectionName(name: string): boolean {
   return /^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$/.test(name)
 }
 
+/** 64 sha256 bits as fixed-width base36 — `[0-9a-z]` only, so a composed profile stays
+ *  inside open-connector's charset and always starts alphanumeric. Domain-separated so an
+ *  id appearing in both roles doesn't hash to the same segment twice. */
+function hashIdSegment(domain: string, id: string): string {
+  const digest = createHash('sha256').update(`${domain}\0${id}`, 'utf8').digest()
+  return digest.readBigUInt64BE(0).toString(36).padStart(PROFILE_HASH_LEN, '0')
+}
+
 /**
  * The open-connector connection PROFILE name for an org+user+connection:
- * `<orgId[0..8]>--<userId[0..8]>--<connectionName>`. Truncated id prefixes keep it
- * within open-connector's 64-char limit.
+ * `<hash(orgId)>--<hash(userId)>--<connectionName>`.
  *
- * CAVEAT: `@@unique([orgId, name])` guarantees per-org provider-row uniqueness but does
- * NOT guarantee open-connector PROFILE uniqueness across orgs — two orgs whose 8-char id
- * prefixes AND user prefix AND connection name all coincide map to the same OC profile.
- * That's improbable (cuid prefixes are a `c` + truncated ms timestamp) and inert while OC
- * doesn't honor the alias at runtime; revisit with a hashed prefix if it ever bites.
+ * HASHED, not truncated: `@@unique([orgId, name])` gives per-org row uniqueness but not
+ * cross-org PROFILE uniqueness, and an 8-char cuid prefix (`c` + base36 ms) only resolved
+ * creation time to ~36ms buckets. Two orgs sharing a bucket, whose creating users also
+ * shared one, and using a common connection name ("gmail") composed the SAME profile — and
+ * a shared profile means one org's `saveConnection` overwrites the other's stored
+ * credential, after which its agents run actions as that other org. 64 digest bits per id
+ * make that collision negligible.
+ *
+ * Only the create route composes a profile. It is then persisted as the connection's
+ * `x-oomol-connector-alias` binding marker and read back from there by reconnect and by
+ * relay-binding replay, so connections provisioned under the older scheme keep resolving
+ * under their stored name — changing this function renames nothing that already exists.
  */
 export function composeProfileName(orgId: string, userId: string, connectionName: string): string {
-  const org = orgId.slice(0, PROFILE_ID_PREFIX_LEN)
-  const user = userId.slice(0, PROFILE_ID_PREFIX_LEN)
-  return `${org}--${user}--${connectionName}`
+  return `${hashIdSegment('org', orgId)}--${hashIdSegment('user', userId)}--${connectionName}`
 }

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1338,7 +1338,7 @@ export const CreateConnectorConnectionBody = z
   .object({
     service: z.string().min(1),
     // The org-unique connection name — also the MCP provider `name`. Restricted so the
-    // composed open-connector profile `<org8>--<user8>--<name>` fits its 64-char limit.
+    // composed open-connector profile `<orgHash>--<userHash>--<name>` fits its 64-char limit.
     connectionName: z
       .string()
       .trim()

--- a/packages/control-plane/src/http/routes/connectors.ts
+++ b/packages/control-plane/src/http/routes/connectors.ts
@@ -10,9 +10,9 @@
  * `open_connector` MCP provider named `connectionName` (org-unique via
  * @@unique([orgId,name]) ⇒ 409 on dup; mints a grant + pushes the relay binding like
  * any provider), and (2) provision the connection PROFILE in open-connector
- * (`<org>--<user>--<name>`). If step 2's api-key save fails, step 1 is rolled back.
- * NOTE: this phase records the provider row; open-connector's /mcp does not yet honor
- * the profile alias (deferred), so runtime tool calls resolve its default connection.
+ * (`<orgHash>--<userHash>--<name>`). If step 2's api-key save fails, step 1 is rolled back.
+ * The profile is composed HERE and only here — it is persisted as the connection's alias
+ * binding marker, and reconnect/relay replay read it back rather than recomposing it.
  */
 import type { FastifyInstance } from 'fastify'
 import type { ZodTypeProvider } from '../plugins/zod.js'

--- a/packages/control-plane/test/integration/connectors.route.test.ts
+++ b/packages/control-plane/test/integration/connectors.route.test.ts
@@ -9,7 +9,13 @@ import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
-import { ConnectorsClient, composeProfileName } from '../../src/connectors/index.js'
+import {
+  ConnectorsClient,
+  composeProfileName,
+  CONNECTOR_ALIAS_HEADER,
+  CONNECTOR_SERVICE_HEADER
+} from '../../src/connectors/index.js'
+import { OrgId } from '../../src/domain/ids.js'
 import type { FetchLike } from '../../src/github/api.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -305,6 +311,36 @@ describe('connectors routes', () => {
     const reconnectSave = saves[1]?.body as { connectionName: string; values: { apiKey: string } }
     expect(reconnectSave.connectionName).toBe(composeProfileName(DEFAULT_ORG_ID, DEFAULT_OWNER_ID, 'prod'))
     expect(reconnectSave.values.apiKey).toBe('sk_rotated')
+  })
+
+  it('reconnects a connection provisioned under the older profile scheme, using its stored alias', async () => {
+    // Profiles are composed at CREATE and persisted as the alias binding marker; every
+    // later read goes to the row, never back through composeProfileName. That is what
+    // lets the composition change (truncated id prefixes → hashed ones) ship without
+    // renaming — or re-provisioning — connections that already exist upstream.
+    const { client, calls } = stubConnectors()
+    const app = appWith(client)
+    const created = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/connectors/connections`,
+      payload: { service: 'stripe', connectionName: 'legacy', authType: 'api_key', values: { apiKey: 'sk_x' } }
+    })
+    const id = created.json().id
+    const legacyProfile = `${DEFAULT_ORG_ID.slice(0, 8)}--${DEFAULT_OWNER_ID.slice(0, 8)}--legacy`
+    expect(legacyProfile).not.toBe(composeProfileName(DEFAULT_ORG_ID, DEFAULT_OWNER_ID, 'legacy'))
+    await app.deps.repos.mcpProviderSecret.put(OrgId(DEFAULT_ORG_ID), id, [
+      { name: CONNECTOR_ALIAS_HEADER, value: legacyProfile },
+      { name: CONNECTOR_SERVICE_HEADER, value: 'stripe' }
+    ])
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/connectors/connections/${id}/reconnect`,
+      payload: { authType: 'api_key', values: { apiKey: 'sk_rotated' } }
+    })
+    expect(res.statusCode).toBe(200)
+    const saves = calls.filter((c) => c.method === 'PUT' && c.url.includes('/api/connections/stripe'))
+    expect((saves.at(-1)?.body as { connectionName: string }).connectionName).toBe(legacyProfile)
   })
 
   it('404s reconnect of an unknown id', async () => {


### PR DESCRIPTION
## The bug

`composeProfileName` built an open-connector connection profile as
`<orgId[0..8]>--<userId[0..8]>--<connectionName>`.

An 8-char cuid prefix is `c` plus a base36 millisecond timestamp, so it only resolved
creation time to roughly 36ms buckets. Two orgs created in the same bucket, whose creating
users were also created in the same bucket, and which both picked a common connection name
(`gmail`, `notion` — the likely component) composed the **same** profile.

That is not inert:

- the relay sends `connectionName: ctx.profile` on every `tools/call` to
  `/v1/actions/<actionId>` (`packages/relay/src/mcp/open-connector.ts`);
- the create route provisions the credential under that same profile
  (`packages/control-plane/src/http/routes/connectors.ts`).

So a collision meant org B's `saveConnection` PUT overwrote org A's stored credential, and
org A's agents then executed actions with org B's credential — a cross-org credential bleed.

## The fix

Each id is now 64 bits of `sha256` rendered as fixed-width base36:

```
<hash(orgId)>--<hash(userId)>--<connectionName>
```

- **Charset.** Base36 is `[0-9a-z]`, inside open-connector's `[A-Za-z0-9_-]`, and it always
  starts alphanumeric — unlike base64url, whose leading `-`/`_` would violate the rule. It
  also contains no `-`, so the `--` separators stay unambiguous.
- **Length.** 13 + 2 + 13 + 2 + 32 = **62** of the 64-char limit at the longest connection
  name the API edge allows.
- The two segments are domain-separated, so an id appearing in both roles cannot hash to the
  same segment twice.

`PROFILE_ID_PREFIX_LEN` is replaced by `PROFILE_HASH_LEN = 13`.

## Existing connections: no migration needed, and that is pinned by a test

The concern that already-provisioned profiles would stop resolving does not apply here.
`composeProfileName` runs in exactly one production place — the create route. The composed
value is then persisted as the connection's `x-oomol-connector-alias` binding marker, and
every later consumer reads it back from that row rather than recomposing it:

- reconnect (`http/routes/connectors.ts`) — deliberately, since the alias carries the
  *creator's* userId, so recomputing would drift for a non-creator caller;
- relay-binding replay (`orchestrator/mcpReplay.ts`) — reads from the secret store.

Connections provisioned under the older scheme therefore keep resolving under their stored
name. A new hashed profile also cannot collide with a legacy one: legacy segments are always
exactly 8 chars, hashed ones 13.

A new integration test plants a legacy-format alias on a real provider row and asserts that
reconnect saves under it verbatim — that is the invariant the no-migration decision rests on,
so it is now guarded rather than assumed.

**Residual, for the reviewer's awareness:** an org pair that *already* collided still shares
its upstream profile. The CP cannot repair that on its own — it never stores credential
values (they go straight upstream), so re-provisioning under a new name is impossible without
the user's credentials. The remedy is deleting and recreating the connection, which lands on
a hashed profile. No collision detector for existing rows is included here.

## Also

The route header carried a note claiming open-connector "does not yet honor the profile
alias (deferred)". That is now actively misleading — the relay's synthesized MCP server sends
the profile as `connectionName` on every action run, which is exactly why the collision has
teeth. Replaced with a note on where the profile is composed and where it is read back.

## Verification

- `filter.test.ts` — 16 pass, including a case that shows both id pairs producing an
  identical *truncated* profile and distinct hashed ones.
- Full control-plane integration suite — 95 files / 1419 tests pass, the new connectors test
  among them.
- `typecheck`, `eslint`, `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
