### PR TITLE
refactor(daemon): extract the gap-replay decision into a pure planReplay

### DIFF
--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -21,6 +21,7 @@ import {
   transcriptImageAttachments
 } from './attachment-block.js'
 import { DIRECT_AGENT_CALL_REMINDER, EXPLICIT_MENTION_REMINDER, NO_RESPONSE_REMINDER } from './no-response.js'
+import { planReplay, renderReplayContext } from './turn/replay-plan.js'
 import { AGENT_META_OPENING, buildStandingContext } from './turn/standing-context.js'
 
 /** Metadata-only semantic lifecycle for one provider-neutral recall attempt. Query
@@ -52,10 +53,6 @@ export type MemoryRecallLifecycleEvent =
       timedOut: boolean
       aborted: boolean
     }
-
-// Cap on transcript entries replayed as catch-up context in one prompt (§8.5),
-// so a long-quiet thread / large backfilled history can't blow up the prompt.
-const MAX_REPLAY_ENTRIES = 50
 
 /** Mint a Slack message id for a wall-clock instant. This is NOT part of the
  * message-ordering strategy: its only callers are the warm-thread provider
@@ -927,99 +924,40 @@ export class SessionManager {
           ? this.deps.store.transcriptSinceForAgent(transcriptChannel, thread, markerBefore, agentId)
           : this.deps.store.transcriptSince(transcriptChannel, thread, markerBefore, agentId)
       ).filter((e) => withinSnapshot(e.ts))
-      // SQLite's text order puts UUID-like legacy coordinates after real platform
-      // ids. Keep those old rows as context, but before the real timeline — which
-      // only a platform whose ids carry a native order can express.
-      if (ordering !== undefined) gap.sort((a, b) => ordering.compare(a.ts, b.ts))
-      // A session initialized from this agent's own channel-root post has never run a model
-      // turn. Replay that one root exactly once, alongside the first real reply, so the new ACP
-      // session understands what the thread is about. Ordinary own-authored rows stay filtered:
-      // after this activation advances the cursor, the root cannot re-enter a later prompt.
-      const participantGap = gap.filter(
-        (e) => e.sender !== agentId || (firstPromptAfterOwnRootInitialization && e.ts === thread)
-      )
-      // The initialized root is the only own-authored row admitted above, and it is the
-      // founding context for a runtime session that has never seen a prompt. Keep it outside
-      // the ordinary bounded suffix so a busy thread cannot evict it before first activation.
-      const initializedRoot = firstPromptAfterOwnRootInitialization
-        ? participantGap.find((e) => e.sender === agentId && e.ts === thread)
-        : undefined
-      const boundedReplay = (entries: typeof participantGap) => {
-        const includesInitializedRoot =
-          initializedRoot !== undefined && entries.some((e) => e.ts === initializedRoot.ts)
-        const remainder = includesInitializedRoot ? entries.filter((e) => e.ts !== initializedRoot.ts) : entries
-        const suffix = remainder.slice(-MAX_REPLAY_ENTRIES)
+      // The whole gap-replay decision lives in turn/replay-plan.ts; handle() only applies it.
+      const plan = planReplay({
+        gap,
+        agentId,
+        thread,
+        triggerTs: ts,
+        markerBefore,
+        ordering,
+        firstPromptAfterOwnRootInitialization
+      })
+      const renderContext = (entries: readonly TranscriptEntry[]): string =>
+        renderReplayContext(entries, this.deps.quoteForContextEvent)
+      if (plan.shape === 'skip') {
+        rec.lastDeliveredTs = plan.deliveredThrough
+        rec.state = 'idle'
+        rec.updatedAt = Date.now()
+        // A skipped activation still took on the obligation — persist it so the next real turn
+        // (and any resume) carries the directive.
+        if (needsReplyToParent) rec.needsParentReply = 1
+        this.deps.store.upsertSession(rec)
         return {
-          context: includesInitializedRoot ? [initializedRoot, ...suffix] : suffix,
-          elided: remainder.length - suffix.length
+          sessionId: rec.acpSessionId!,
+          blocks: [],
+          created,
+          skipped: true,
+          ...(additionalMcpServersAttached !== undefined ? { additionalMcpServersAttached } : {})
         }
       }
-      const renderContext = (entries: typeof participantGap): string =>
-        entries
-          .flatMap((event) => {
-            const quote = this.deps.quoteForContextEvent?.(event, entries)
-            return [...(quote ? [quote] : []), `[${event.sender}] ${event.text}`]
-          })
-          .join('\n')
-      // Own authored rows are not repeated to the model, but they ARE first-class events
-      // in the shared log and therefore may advance this agent's read cursor once the
-      // surrounding stable window is consumed.
-      // With no native ordering there is no "newest row" to reason about, so the
-      // cursor advances to the trigger itself — the pre-seam non-Slack rule.
-      const deliveredThrough =
-        ordering !== undefined
-          ? ordering.coordinate(ts) !== null
-            ? (gap.filter((e) => ordering.coordinate(e.ts) !== null).at(-1)?.ts ?? markerBefore)
-            : (participantGap.at(-1)?.ts ?? markerBefore)
-          : ts
-      const triggerWasAlreadyDelivered =
-        markerBefore !== null && ordering !== undefined && ordering.compare(ts, markerBefore) <= 0
-
-      // A stale Socket Mode event may be the wake-up signal even though the snapshot
-      // contains newer instructions. In that case the old `context + current` shape is
-      // actively wrong: it puts the obsolete trigger last. Deliver one chronological
-      // unread batch so the newest human instruction is last and therefore salient.
-      // Only a natively ordered platform can tell "newer" from "older" at all; the
-      // rest keep the plain in-order shape below.
-      const hasMessageAfterTrigger =
-        ordering !== undefined && participantGap.some((e) => ordering.compare(e.ts, ts) > 0)
-      if (hasMessageAfterTrigger || triggerWasAlreadyDelivered) {
-        const { context, elided } = boundedReplay(participantGap)
-        if (context.length === 0) {
-          rec.lastDeliveredTs = deliveredThrough
-          rec.state = 'idle'
-          rec.updatedAt = Date.now()
-          // A skipped activation still took on the obligation — persist it so the next real turn
-          // (and any resume) carries the directive.
-          if (needsReplyToParent) rec.needsParentReply = 1
-          this.deps.store.upsertSession(rec)
-          return {
-            sessionId: rec.acpSessionId!,
-            blocks: [],
-            created,
-            skipped: true,
-            ...(additionalMcpServersAttached !== undefined ? { additionalMcpServersAttached } : {})
-          }
-        }
-        const head =
-          elided > 0
-            ? `(unread thread messages, oldest to newest — ${elided} earlier message(s) elided)`
-            : '(unread thread messages, oldest to newest)'
-        blocks.push({ type: 'text', text: `${head}\n${renderContext(context)}` })
+      const context = plan.context
+      if (plan.shape === 'batch') {
+        blocks.push({ type: 'text', text: `${plan.head}\n${renderContext(context)}` })
         contextEventTs = context.map((entry) => entry.ts)
       } else {
-        // Normal in-order activation: preserve the established context-prefix + current
-        // prompt shape, while never replaying this agent's own recorded messages.
-        const allContext = participantGap.filter((e) => e.ts !== ts)
-        const { context, elided } = boundedReplay(allContext)
-        if (context.length > 0) {
-          const head =
-            elided > 0
-              ? `(thread context you may have missed — ${elided} earlier message(s) elided)`
-              : '(thread context you may have missed)'
-          const ctxText = renderContext(context)
-          blocks.push({ type: 'text', text: `${head}\n${ctxText}` })
-        }
+        if (context.length > 0) blocks.push({ type: 'text', text: `${plan.head}\n${renderContext(context)}` })
         const quotedBlock = quotedSourceBlock(msg, { replayed: context })
         if (quotedBlock) blocks.push({ type: 'text', text: quotedBlock })
         // session-concept §2.1: inbound human input carries its sender (`from`), so deliver the
@@ -1030,7 +968,7 @@ export class SessionManager {
         blocks.push({ type: 'text', text: msg.source === 'user' ? `[${msg.sender.id}] ${msg.text}` : msg.text })
         contextEventTs = [...context.map((entry) => entry.ts), ts]
       }
-      rec.lastDeliveredTs = deliveredThrough ?? ts
+      rec.lastDeliveredTs = plan.deliveredThrough ?? ts
       contextRevision = this.deps.store.threadTranscriptRevision(transcriptChannel, thread, agentId)
     }
 

--- a/packages/daemon/src/session/turn/replay-plan.ts
+++ b/packages/daemon/src/session/turn/replay-plan.ts
@@ -1,0 +1,129 @@
+import type { TranscriptEntry } from '../../store/local-store.js'
+import type { MessageOrdering } from '../../platforms/message-ordering.js'
+
+// Cap on transcript entries replayed as catch-up context in one prompt (§8.5),
+// so a long-quiet thread / large backfilled history can't blow up the prompt.
+export const MAX_REPLAY_ENTRIES = 50
+
+/** Everything the gap-replay decision reads. Every field is already resolved by the
+ * caller — this input carries no store, no host, and no live message object. */
+export type ReplayPlanInput = {
+  /** The unread transcript rows since the read cursor, already snapshot-filtered. */
+  gap: readonly TranscriptEntry[]
+  /** The agent whose turn this is; its own rows are never replayed back to it. */
+  agentId: string
+  /** The activating message's id. */
+  triggerTs: string
+  /** The thread root's id — the one own-authored row an initialized session replays. */
+  thread: string
+  /** The read cursor this turn started from, or `null` for a from-scratch catch-up. */
+  markerBefore: string | null
+  /** This platform's ordering strategy; `undefined` means the ids are opaque. */
+  ordering: MessageOrdering | undefined
+  /** Is this the first real prompt of a session initialized from the agent's own root post? */
+  firstPromptAfterOwnRootInitialization: boolean
+  /** Replay cap override, for tests. */
+  maxReplayEntries?: number
+}
+
+/** The decided replay for one activation. `batch` delivers one chronological unread
+ * run (the trigger is stale or already delivered), `inorder` keeps the established
+ * context-prefix + current-prompt shape, and `skip` means the activation has nothing
+ * left to say and should return early while still advancing the cursor. */
+export type ReplayPlan = {
+  shape: 'batch' | 'inorder' | 'skip'
+  /** The entries to render as replayed context, oldest to newest. */
+  context: readonly TranscriptEntry[]
+  /** How many older entries the bounded suffix dropped. */
+  elided: number
+  /** Heading line that precedes the rendered context; empty on `skip`. */
+  head: string
+  /** Where the read cursor should land, or `null` when nothing can advance it. */
+  deliveredThrough: string | null
+}
+
+/** Decide how one activation replays its transcript gap (§8.5 thread catch-up). Pure:
+ * the caller fetches the gap, then applies the returned plan (pushes blocks, advances
+ * the cursor, takes the early return on `skip`). */
+export function planReplay(input: ReplayPlanInput): ReplayPlan {
+  const { agentId, thread, triggerTs: ts, markerBefore, ordering, firstPromptAfterOwnRootInitialization } = input
+  const cap = input.maxReplayEntries ?? MAX_REPLAY_ENTRIES
+
+  // SQLite's text order puts UUID-like legacy coordinates after real platform
+  // ids. Keep those old rows as context, but before the real timeline — which
+  // only a platform whose ids carry a native order can express.
+  const gap = ordering !== undefined ? [...input.gap].sort((a, b) => ordering.compare(a.ts, b.ts)) : [...input.gap]
+  // A session initialized from this agent's own channel-root post has never run a model
+  // turn. Replay that one root exactly once, alongside the first real reply, so the new ACP
+  // session understands what the thread is about. Ordinary own-authored rows stay filtered:
+  // after this activation advances the cursor, the root cannot re-enter a later prompt.
+  const participantGap = gap.filter(
+    (e) => e.sender !== agentId || (firstPromptAfterOwnRootInitialization && e.ts === thread)
+  )
+  // The initialized root is the only own-authored row admitted above, and it is the
+  // founding context for a runtime session that has never seen a prompt. Keep it outside
+  // the ordinary bounded suffix so a busy thread cannot evict it before first activation.
+  const initializedRoot = firstPromptAfterOwnRootInitialization
+    ? participantGap.find((e) => e.sender === agentId && e.ts === thread)
+    : undefined
+  const boundedReplay = (entries: readonly TranscriptEntry[]) => {
+    const includesInitializedRoot = initializedRoot !== undefined && entries.some((e) => e.ts === initializedRoot.ts)
+    const remainder = includesInitializedRoot ? entries.filter((e) => e.ts !== initializedRoot.ts) : entries
+    const suffix = remainder.slice(-cap)
+    return {
+      context: includesInitializedRoot ? [initializedRoot, ...suffix] : suffix,
+      elided: remainder.length - suffix.length
+    }
+  }
+  // Own authored rows are not repeated to the model, but they ARE first-class events
+  // in the shared log and therefore may advance this agent's read cursor once the
+  // surrounding stable window is consumed. With no native ordering there is no "newest
+  // row" to reason about, so the cursor advances to the trigger itself.
+  const deliveredThrough =
+    ordering !== undefined
+      ? ordering.coordinate(ts) !== null
+        ? (gap.filter((e) => ordering.coordinate(e.ts) !== null).at(-1)?.ts ?? markerBefore)
+        : (participantGap.at(-1)?.ts ?? markerBefore)
+      : ts
+  const triggerWasAlreadyDelivered =
+    markerBefore !== null && ordering !== undefined && ordering.compare(ts, markerBefore) <= 0
+  // A stale Socket Mode event may be the wake-up signal even though the snapshot
+  // contains newer instructions. In that case the old `context + current` shape is
+  // actively wrong: it puts the obsolete trigger last. Deliver one chronological
+  // unread batch so the newest human instruction is last and therefore salient.
+  // Only a natively ordered platform can tell "newer" from "older" at all.
+  const hasMessageAfterTrigger = ordering !== undefined && participantGap.some((e) => ordering.compare(e.ts, ts) > 0)
+
+  if (hasMessageAfterTrigger || triggerWasAlreadyDelivered) {
+    const { context, elided } = boundedReplay(participantGap)
+    if (context.length === 0) return { shape: 'skip', context: [], elided: 0, head: '', deliveredThrough }
+    const head =
+      elided > 0
+        ? `(unread thread messages, oldest to newest — ${elided} earlier message(s) elided)`
+        : '(unread thread messages, oldest to newest)'
+    return { shape: 'batch', context, elided, head, deliveredThrough }
+  }
+
+  // Normal in-order activation: preserve the established context-prefix + current
+  // prompt shape, while never replaying this agent's own recorded messages.
+  const { context, elided } = boundedReplay(participantGap.filter((e) => e.ts !== ts))
+  const head =
+    elided > 0
+      ? `(thread context you may have missed — ${elided} earlier message(s) elided)`
+      : '(thread context you may have missed)'
+  return { shape: 'inorder', context, elided, head, deliveredThrough }
+}
+
+/** Render replayed entries as the `[sender] text` lines the prompt carries, with each
+ * entry's optional quote line ahead of it. */
+export function renderReplayContext(
+  entries: readonly TranscriptEntry[],
+  quoteFor?: (event: TranscriptEntry, replayed: readonly TranscriptEntry[]) => string | undefined
+): string {
+  return entries
+    .flatMap((event) => {
+      const quote = quoteFor?.(event, entries)
+      return [...(quote ? [quote] : []), `[${event.sender}] ${event.text}`]
+    })
+    .join('\n')
+}

--- a/packages/daemon/test/replay-plan.test.ts
+++ b/packages/daemon/test/replay-plan.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import type { TranscriptEntry } from '../src/store/local-store.js'
+import { messageOrderingFor } from '../src/platforms/message-ordering.js'
+import { MAX_REPLAY_ENTRIES, planReplay, renderReplayContext } from '../src/session/turn/replay-plan.js'
+
+const slack = messageOrderingFor('slack')
+const CH = 'C1'
+const THREAD = '1700000000.000100'
+
+function entry(ts: string, sender: string, text = `msg ${ts}`): TranscriptEntry {
+  return { channel: CH, thread: THREAD, ts, sender, kind: 'text', text }
+}
+
+// A Slack id for `seconds` past the thread root's epoch second.
+function at(seconds: number, micros = 0): string {
+  return `${1700000000 + seconds}.${String(micros).padStart(6, '0')}`
+}
+
+function plan(over: Partial<Parameters<typeof planReplay>[0]> = {}) {
+  return planReplay({
+    gap: [],
+    agentId: 'bot',
+    thread: THREAD,
+    triggerTs: at(10),
+    markerBefore: null,
+    ordering: slack,
+    firstPromptAfterOwnRootInitialization: false,
+    ...over
+  })
+}
+
+describe('planReplay — in-order activation', () => {
+  it('replays the gap as context and excludes the trigger itself', () => {
+    const p = plan({ gap: [entry(at(1), 'u1'), entry(at(2), 'u2'), entry(at(10), 'u3')], triggerTs: at(10) })
+    expect(p.shape).toBe('inorder')
+    expect(p.context.map((e) => e.ts)).toEqual([at(1), at(2)])
+    expect(p.elided).toBe(0)
+    expect(p.head).toBe('(thread context you may have missed)')
+  })
+
+  it('never replays the agent own rows back to it', () => {
+    const p = plan({ gap: [entry(at(1), 'bot'), entry(at(2), 'u1'), entry(at(10), 'u1')] })
+    expect(p.context.map((e) => e.sender)).toEqual(['u1'])
+  })
+
+  it('sorts a natively ordered gap before deciding, keeping legacy ids first', () => {
+    const p = plan({ gap: [entry(at(2), 'u1'), entry('legacy-uuid', 'u1'), entry(at(1), 'u1')] })
+    expect(p.context.map((e) => e.ts)).toEqual(['legacy-uuid', at(1), at(2)])
+  })
+})
+
+describe('planReplay — bounded replay cap', () => {
+  it('keeps the newest MAX_REPLAY_ENTRIES and reports the elided count', () => {
+    const gap = Array.from({ length: MAX_REPLAY_ENTRIES + 3 }, (_, i) => entry(at(1, i + 1), 'u1'))
+    const p = plan({ gap, triggerTs: at(99) })
+    expect(p.context).toHaveLength(MAX_REPLAY_ENTRIES)
+    expect(p.context[0]!.ts).toBe(at(1, 4))
+    expect(p.elided).toBe(3)
+    expect(p.head).toBe('(thread context you may have missed — 3 earlier message(s) elided)')
+  })
+
+  it('caps the batch shape too, with the unread heading', () => {
+    const gap = Array.from({ length: MAX_REPLAY_ENTRIES + 1 }, (_, i) => entry(at(20, i + 1), 'u1'))
+    const p = plan({ gap, triggerTs: at(10) })
+    expect(p.shape).toBe('batch')
+    expect(p.elided).toBe(1)
+    expect(p.head).toBe('(unread thread messages, oldest to newest — 1 earlier message(s) elided)')
+  })
+
+  it('honours a cap override', () => {
+    const gap = [entry(at(1), 'u1'), entry(at(2), 'u1'), entry(at(3), 'u1')]
+    const p = plan({ gap, maxReplayEntries: 2 })
+    expect(p.context.map((e) => e.ts)).toEqual([at(2), at(3)])
+    expect(p.elided).toBe(1)
+  })
+})
+
+describe('planReplay — deliveredThrough', () => {
+  it('advances to the newest ordered row, including the agent own rows', () => {
+    const p = plan({ gap: [entry(at(1), 'u1'), entry(at(5), 'bot')], triggerTs: at(3) })
+    expect(p.deliveredThrough).toBe(at(5))
+  })
+
+  it('falls back to the previous marker when the gap holds no ordered row', () => {
+    const p = plan({ gap: [], triggerTs: at(3), markerBefore: at(2) })
+    expect(p.deliveredThrough).toBe(at(2))
+  })
+
+  it('advances only through the participant gap when the trigger is synthetic', () => {
+    const p = plan({
+      gap: [entry(at(1), 'u1'), entry(at(5), 'bot')],
+      triggerTs: 'cron-uuid',
+      markerBefore: at(0)
+    })
+    expect(p.deliveredThrough).toBe(at(1))
+  })
+
+  it('advances to the trigger itself when the platform ids are opaque', () => {
+    const p = plan({ gap: [entry('b', 'u1')], ordering: undefined, triggerTs: 'z' })
+    expect(p.shape).toBe('inorder')
+    expect(p.deliveredThrough).toBe('z')
+  })
+})
+
+describe('planReplay — own-root initialization', () => {
+  it('replays the initializing root once alongside the first real reply', () => {
+    const p = plan({
+      gap: [entry(THREAD, 'bot', 'root post'), entry(at(10), 'u1')],
+      triggerTs: at(10),
+      firstPromptAfterOwnRootInitialization: true
+    })
+    expect(p.context.map((e) => e.text)).toEqual(['root post'])
+    expect(p.deliveredThrough).toBe(at(10))
+  })
+
+  it('keeps the root outside the bounded suffix so a busy thread cannot evict it', () => {
+    const gap = [entry(THREAD, 'bot', 'root post'), ...Array.from({ length: 4 }, (_, i) => entry(at(1, i + 1), 'u1'))]
+    const p = plan({ gap, triggerTs: at(99), firstPromptAfterOwnRootInitialization: true, maxReplayEntries: 2 })
+    expect(p.context.map((e) => e.ts)).toEqual([THREAD, at(1, 3), at(1, 4)])
+    expect(p.elided).toBe(2)
+  })
+
+  it('leaves own rows filtered when the session did not initialize from its own root', () => {
+    const p = plan({ gap: [entry(THREAD, 'bot', 'root post'), entry(at(10), 'u1')], triggerTs: at(10) })
+    expect(p.context).toEqual([])
+  })
+})
+
+describe('planReplay — batch and skip', () => {
+  it('batches when the snapshot holds a message newer than a stale trigger', () => {
+    const p = plan({ gap: [entry(at(10), 'u1', 'old'), entry(at(20), 'u2', 'new')], triggerTs: at(10) })
+    expect(p.shape).toBe('batch')
+    expect(p.context.map((e) => e.text)).toEqual(['old', 'new'])
+    expect(p.head).toBe('(unread thread messages, oldest to newest)')
+  })
+
+  it('batches when the trigger was already delivered', () => {
+    const p = plan({ gap: [entry(at(5), 'u1')], triggerTs: at(3), markerBefore: at(4) })
+    expect(p.shape).toBe('batch')
+  })
+
+  it('skips when an already-delivered trigger leaves nothing to replay', () => {
+    const p = plan({ gap: [entry(at(5), 'bot')], triggerTs: at(3), markerBefore: at(4) })
+    expect(p.shape).toBe('skip')
+    expect(p.context).toEqual([])
+    expect(p.deliveredThrough).toBe(at(5))
+  })
+
+  it('never skips a plain in-order activation with an empty gap', () => {
+    const p = plan({ gap: [], triggerTs: at(3) })
+    expect(p.shape).toBe('inorder')
+    expect(p.context).toEqual([])
+  })
+})
+
+describe('planReplay — snapshot cutoff exclusion', () => {
+  it('is confined to the rows the caller admitted through its cutoff', () => {
+    const cutoff = at(15)
+    const all = [entry(at(10), 'u1', 'inside'), entry(at(20), 'u1', 'after cutoff')]
+    const p = plan({ gap: all.filter((e) => slack!.withinCutoff(e.ts, cutoff)), triggerTs: at(10) })
+    expect(p.shape).toBe('inorder')
+    expect(p.context).toEqual([])
+    expect(p.deliveredThrough).toBe(at(10))
+  })
+
+  it('the same gap without the cutoff filter batches the newer row instead', () => {
+    const p = plan({ gap: [entry(at(10), 'u1', 'inside'), entry(at(20), 'u1', 'after cutoff')], triggerTs: at(10) })
+    expect(p.shape).toBe('batch')
+    expect(p.context.map((e) => e.text)).toEqual(['inside', 'after cutoff'])
+  })
+})
+
+describe('renderReplayContext', () => {
+  it('renders one [sender] text line per entry', () => {
+    expect(renderReplayContext([entry(at(1), 'u1', 'hi'), entry(at(2), 'u2', 'yo')])).toBe('[u1] hi\n[u2] yo')
+  })
+
+  it('puts an entry quote line ahead of the entry', () => {
+    const rendered = renderReplayContext([entry(at(1), 'u1', 'hi')], (e) => `> quoting ${e.ts}`)
+    expect(rendered).toBe(`> quoting ${at(1)}\n[u1] hi`)
+  })
+})


### PR DESCRIPTION
`SessionManager.handle()` carried the entire transcript gap-replay decision inline — the bounded replay suffix, the initialized-root exemption, the read-cursor advance, and the batch / in-order / skip shape choice — interleaved with the block-pushing that *applies* that decision. That made every boundary case reachable only end-to-end, through a full session-manager fixture.

## What changed

- New `packages/daemon/src/session/turn/replay-plan.ts` exporting a pure `planReplay(input): ReplayPlan`. It takes the already-fetched (and already snapshot-filtered) gap plus the resolved facts — `agentId`, `thread`, `triggerTs`, `markerBefore`, the platform `ordering` strategy, `firstPromptAfterOwnRootInitialization` — and returns `{ shape: 'batch' | 'inorder' | 'skip', context, elided, head, deliveredThrough }`. `renderReplayContext(entries, quoteFor?)` moved with it. `MAX_REPLAY_ENTRIES` now lives there (overridable per call for tests).
- `handle()` now only *applies* the plan: pushes the context/quote/trigger blocks, sets `contextEventTs`, advances `rec.lastDeliveredTs`, and takes the skipped early-return on `shape: 'skip'`. Net −62 lines in `session-manager.ts`.
- Behavior-identical: no predicate, ordering rule, heading string, or cursor rule was changed. `daemon.ts` untouched.

## New tests

`packages/daemon/test/replay-plan.test.ts` (21 tests) covers what was previously only implied end-to-end:

- bounded replay cap (both shapes, plus the elided-count headings)
- `deliveredThrough` advancement — newest ordered row including own rows, marker fallback, synthetic trigger, opaque-id platform
- own-root-initialization first prompt, including the root staying outside the bounded suffix
- snapshot-cutoff exclusion (cutoff-filtered gap stays in-order; unfiltered gap batches)
- the skip decision, and that a plain in-order activation with an empty gap never skips

## Verification

- `pnpm typecheck` (daemon) — clean
- `npx vitest run test/replay-plan.test.ts test/session-manager.test.ts test/thread-context.test.ts` — 121 passed (95 session-manager, 21 new, 5 thread-context)
- `prettier --check` and `eslint` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
