### PR TITLE
feat(daemon): add DeepSeek Harness as a curated ACP runtime

### DIFF
--- a/packages/daemon/src/runtimes/curated.ts
+++ b/packages/daemon/src/runtimes/curated.ts
@@ -51,5 +51,13 @@ export const CURATED_RUNTIME_CATALOG: Readonly<Record<string, CuratedRuntimeEntr
   'qoder-cli-cn': {
     name: 'Qoder CN CLI',
     runtime: { command: 'qoderclicn', args: ['--acp'], env: [], skillsAgentId: 'qoder-cn' }
+  },
+  // DeepSeek Harness speaks ACP through @openma/deepseek-harness-acp, which
+  // bundles the harness itself and only reuses $DSH_HOME credentials — so it is
+  // fetched on demand rather than installed into the operator's dsh profile.
+  // `-p` is required: the package's single bin (`dsh-acp`) is not its name.
+  'dsh-acp': {
+    name: 'DeepSeek Harness',
+    runtime: { command: 'npx', args: ['-y', '-p', '@openma/deepseek-harness-acp@^0.4', 'dsh-acp'], env: [] }
   }
 })

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -170,6 +170,8 @@ const QODER_SEED = (brand: string): readonly string[] => [
   'a2a-oauth-tokens.json'
 ]
 const CLAUDE_MODEL_CACHE_KEYS = ['additionalModelOptionsCache'] as const
+/** DeepSeek Harness auth: the managed 0600 credential store plus its .env fallback. */
+const DSH_SEED = ['.credentials.yaml', '.env'] as const
 
 export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // Anthropic Claude Code — seed only the rollout-model cache from ~/.claude.json.
@@ -336,6 +338,11 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
 
   // Factory Droid — ~/.factory.
   'factory-droid': (env) => state(join(home(env), '.factory'), '.factory'),
+
+  // DeepSeek Harness (via the dsh-acp adapter) — $DSH_HOME, default ~/.dsh. Seed
+  // only the managed credential store and its .env fallback; sessions and logs
+  // in the same directory stay agent-private.
+  'dsh-acp': (env) => [...state(env.DSH_HOME, '.dsh', DSH_SEED), ...state(join(home(env), '.dsh'), '.dsh', DSH_SEED)],
 
   // Cognition Devin (for Terminal) — XDG config + data dirs.
   devin: (env) => [

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -236,7 +236,10 @@ const AMBIENT_STATE_ENV = new Set([
   'QODER_CLI_HOME',
   'QODERCN_CONFIG_DIR',
   'QODERCN_CLI_HOME',
-  'GEMINI_CLI_HOME'
+  'GEMINI_CLI_HOME',
+  // DeepSeek Harness state root; $DSH_PATH (the harness install location) is not
+  // user state and stays inherited.
+  'DSH_HOME'
 ])
 
 function inheritedEnvironment(source: NodeJS.ProcessEnv): Record<string, string> {
@@ -287,6 +290,7 @@ const RUNTIME_PRIVATE_ENV: Record<string, RuntimePrivateEnv> = {
     }
     return env
   },
+  'dsh-acp': (home) => ({ DSH_HOME: join(home, '.dsh') }),
   kimi: (home, hostEnv) => {
     const env: Record<string, string> = {}
     if (hostEnv.KIMI_CODE_HOME) env.KIMI_CODE_HOME = join(home, '.kimi-code')

--- a/packages/daemon/test/probe.test.ts
+++ b/packages/daemon/test/probe.test.ts
@@ -226,6 +226,22 @@ describe('isRuntimeAvailable / custom probes', () => {
     ).toBe(true)
   })
 
+  it('dsh-acp is fetched by npx, so ~/.dsh (or $DSH_HOME) is the only install signal', () => {
+    makeExecutable(binDir, 'npx')
+    const rt: RuntimeDef = {
+      command: 'npx',
+      args: ['-y', '-p', '@openma/deepseek-harness-acp@^0.4', 'dsh-acp'],
+      env: []
+    }
+    expect(isRuntimeAvailable('dsh-acp', rt, env())).toBe(false)
+
+    const dshHome = mkdtempSync(join(tmpdir(), 'ac-dsh-home-'))
+    expect(isRuntimeAvailable('dsh-acp', rt, env({ DSH_HOME: dshHome }))).toBe(true)
+
+    mkdirSync(join(home, '.dsh'))
+    expect(isRuntimeAvailable('dsh-acp', rt, env())).toBe(true)
+  })
+
   it('cursor needs the CLI-specific cli-config.json (dir alone is not enough)', () => {
     makeExecutable(binDir, 'cursor-agent')
     const rt: RuntimeDef = { command: 'cursor-agent', args: [], env: [] }

--- a/packages/daemon/test/registry.test.ts
+++ b/packages/daemon/test/registry.test.ts
@@ -239,7 +239,7 @@ describe('resolveRuntimes', () => {
 })
 
 describe('curated native ACP runtimes', () => {
-  it('declares the eight reviewed native ACP commands', () => {
+  it('declares the nine reviewed native ACP commands', () => {
     expect(CURATED_RUNTIME_CATALOG).toEqual({
       'hermes-agent': {
         name: 'Hermes Agent',
@@ -272,6 +272,10 @@ describe('curated native ACP runtimes', () => {
       'qoder-cli-cn': {
         name: 'Qoder CN CLI',
         runtime: { command: 'qoderclicn', args: ['--acp'], env: [], skillsAgentId: 'qoder-cn' }
+      },
+      'dsh-acp': {
+        name: 'DeepSeek Harness',
+        runtime: { command: 'npx', args: ['-y', '-p', '@openma/deepseek-harness-acp@^0.4', 'dsh-acp'], env: [] }
       }
     })
   })

--- a/packages/daemon/test/runtime-home.test.ts
+++ b/packages/daemon/test/runtime-home.test.ts
@@ -114,6 +114,23 @@ describe('private runtime HOME', () => {
     expect(env.GEMINI_CLI_HOME).toBeUndefined()
   })
 
+  it('seeds DeepSeek Harness credentials and pins $DSH_HOME into the private home', () => {
+    const { hostHome, scopeDir } = fixture()
+    const dsh = join(hostHome, '.dsh')
+    mkdirSync(join(dsh, 'sessions'), { recursive: true })
+    writeFileSync(join(dsh, '.credentials.yaml'), 'deepseek: host-key')
+    writeFileSync(join(dsh, '.env'), 'DEEPSEEK_BASE_URL=https://host.example')
+    writeFileSync(join(dsh, 'sessions', 'old.jsonl'), 'do-not-copy')
+
+    const home = prepareRuntimeHome('dsh-acp', scopeDir, { HOME: hostHome })
+    expect(readFileSync(join(home, '.dsh', '.credentials.yaml'), 'utf8')).toContain('host-key')
+    expect(existsSync(join(home, '.dsh', '.env'))).toBe(true)
+    expect(existsSync(join(home, '.dsh', 'sessions'))).toBe(false)
+
+    const env = runtimeHomeEnvironment('dsh-acp', home, {}, { HOME: hostHome, DSH_HOME: '/host/leak' })
+    expect(env.DSH_HOME).toBe(join(home, '.dsh'))
+  })
+
   it('seeds Cline provider auth from its data directory without copying databases', () => {
     const { hostHome, scopeDir } = fixture()
     const clineDir = join(hostHome, '.cline')

--- a/packages/web/src/app/api/acp-registry/route.ts
+++ b/packages/web/src/app/api/acp-registry/route.ts
@@ -32,6 +32,10 @@ const CURATED_AGENTS: Record<string, { name: string; icon: string | null }> = {
   'qoder-cli-cn': {
     name: 'Qoder CN CLI',
     icon: 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/qoder-color.svg'
+  },
+  'dsh-acp': {
+    name: 'DeepSeek Harness',
+    icon: 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/deepseek-color.svg'
   }
 }
 


### PR DESCRIPTION
## What

Adds DeepSeek Harness to the daemon's curated native-ACP catalog, so a host with dsh credentials can run agents on it like any other harness.

DeepSeek Harness speaks ACP through [`@openma/deepseek-harness-acp`](https://github.com/openma-ai/deepseek-harness-acp), whose `dsh-acp` bin serves ACP over stdio (streamed text/reasoning, tool calls with diffs and terminals, plans, permission requests as session modes, config options, slash commands, `session/load`, MCP).

Note for anyone who saw the other repo going around: `agentic-control-plane/dsh-acp-plugin` is **Agentic Control Plane** — a tool-call policy plugin — not Agent Client Protocol. It is not what the daemon needs.

## Why npx instead of installing a dsh plugin

The package lists the harness itself among its dependencies (`@deepseek-ai/dsh`, `dsh-llm`, `dsh-session`, `dsh-credentials`, …), so it **bundles the harness** and only reuses `$DSH_HOME` credentials. That means we can fetch it on demand rather than writing into the operator's dsh profile — matching the rule already stated in `curated.ts`: a launch catalog, not an installer. Same shape as the managed `codex-acp` entry.

`-p` is required because the package's single bin (`dsh-acp`) does not match its name. Pinned to `^0.4` — a pre-1.0 package can change wire behavior silently; upgrading is a one-line bump.

Trade-off worth knowing: ACP sessions run the harness bundled with the adapter, not the plugins in a user's own dsh profile. Serving that case would need an explicit, user-consented "enable ACP in your dsh profile" action in the console, not a silent daemon-side install.

## Changes

- `runtimes/curated.ts` — curated entry `dsh-acp` → `npx -y -p @openma/deepseek-harness-acp@^0.4 dsh-acp`.
- `runtimes/probe.ts` — state locations at `$DSH_HOME` (default `~/.dsh`), seeding only `.credentials.yaml` and its `.env` fallback; sessions/logs stay agent-private. Since npx is on every host, this directory is the only meaningful admission signal.
- `runtimes/runtime-home.ts` — pin `DSH_HOME` into the private runtime HOME and strip the host value from the child env. `DSH_PATH` is an install location, not user state, so it stays inherited.
- `web/api/acp-registry/route.ts` — console display mark.

## Deliberately out of scope

- **Memory policy** — `RUNTIME_MEMORY_POLICIES` entries require a verified auto-memory off-switch. DSH's is unverified, so the runtime stays managed-memory-only (the safe default).
- **Shared credential profile** — seeding is copy-once. Letting a `dsh-acp login` refresh write back to the host `~/.dsh` needs a `SharedCredentialProfile` like claude/codex/qoder, which is its own design.

## Testing

`test/probe.test.ts`, `test/runtime-home.test.ts`, `test/registry.test.ts` — 71 passed. Daemon typecheck, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
