### PR TITLE
refactor(daemon): break the memory and memory-plugin package cycle

### DIFF
--- a/packages/daemon/src/memory-plugin/outbox.ts
+++ b/packages/daemon/src/memory-plugin/outbox.ts
@@ -6,7 +6,7 @@ import type {
   MemoryPluginManifest,
   MemoryPluginOperationStatusInput
 } from '@agentconnect.md/protocol'
-import { canonicalAgentMemoryKey } from '../memory/recall.js'
+import { canonicalAgentMemoryKey } from '../memory/keys.js'
 import type { LocalStore, MemoryCaptureOutboxRow } from '../store/local-store.js'
 import type { MemoryPluginClient } from './client.js'
 import { defaultMemoryPluginMetrics, type MemoryPluginMetrics } from './metrics.js'

--- a/packages/daemon/src/memory/keys.ts
+++ b/packages/daemon/src/memory/keys.ts
@@ -1,0 +1,4 @@
+/** Leaf module: pure memory key normalization, shared by the domain and transport layers. */
+export function canonicalAgentMemoryKey(agentId: string): string {
+  return `ac:agent:${agentId}`
+}

--- a/packages/daemon/src/memory/provider.ts
+++ b/packages/daemon/src/memory/provider.ts
@@ -61,7 +61,7 @@ import {
 } from './runtime/native.js'
 import { appendDistilledMemories, buildDistillationPrompt, parseDistilledMemories } from './distill.js'
 import { describeRuntime, runtimeMemoryDisabledEnv } from './runtime/capabilities.js'
-import { canonicalAgentMemoryKey } from './recall.js'
+import { canonicalAgentMemoryKey } from './keys.js'
 import type { MemoryCaptureConnectionRegistry, MemoryCaptureOutbox } from '../memory-plugin/outbox.js'
 import { defaultMemoryPluginMetrics, type MemoryPluginMetrics } from '../memory-plugin/metrics.js'
 import { MemoryPluginConflictError, MemoryPluginInputError, type MemoryPluginClient } from '../memory-plugin/client.js'

--- a/packages/daemon/src/memory/recall.ts
+++ b/packages/daemon/src/memory/recall.ts
@@ -4,6 +4,7 @@ import {
   MEMORY_RECALL_HARD_LIMITS,
   type CanonicalMemoryRecord as MemoryRecord
 } from '@agentconnect.md/protocol'
+import { canonicalAgentMemoryKey } from './keys.js'
 import type { MemoryScope, RecallRequest } from './types.js'
 
 /** Recall queries are generated from delivered user/peer text, never old memory/tool output. */
@@ -32,10 +33,6 @@ export function recallQueryFromBlocks(blocks: ContentBlock[]): string {
     .join('\n\n')
     .trim()
   return utf8Tail(text, MAX_MEMORY_RECALL_QUERY_BYTES)
-}
-
-export function canonicalAgentMemoryKey(agentId: string): string {
-  return `ac:agent:${agentId}`
 }
 
 /**

--- a/packages/daemon/test/memory-recall.test.ts
+++ b/packages/daemon/test/memory-recall.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { canonicalAgentMemoryKey } from '../src/memory/keys.js'
 import {
   MAX_MEMORY_RECALL_QUERY_BYTES,
-  canonicalAgentMemoryKey,
   recalledMemoryBlock,
   recallQueryFromBlocks,
   sanitizeRecallRecords


### PR DESCRIPTION
`src/memory-plugin/outbox.ts` imported `canonicalAgentMemoryKey` from `src/memory/recall.js` — the transport layer reaching into the domain layer — while `src/memory/` imports `memory-plugin`, making a directory-level import cycle.

## Change

- New leaf module `packages/daemon/src/memory/keys.ts` holding `canonicalAgentMemoryKey`. It imports nothing (in particular nothing from `memory-plugin`).
- `memory/recall.ts`, `memory/provider.ts`, `memory-plugin/outbox.ts` and `test/memory-recall.test.ts` all import from `memory/keys.js`.
- No re-export kept in `recall.ts` — only three importers existed, all updated.

Pure move; no behavior change.

## Verification

- `pnpm typecheck` in `packages/daemon` — clean.
- `npx vitest run test/memory-recall.test.ts test/memory-capture-outbox.test.ts test/memory-plugin-client.test.ts test/managed-distill-outbox.test.ts` — 41 tests passed.
- `prettier --check` and `eslint` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
