### PR TITLE
fix(control-plane): joining a group leaves pinned agents alone

### DIFF
--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -224,6 +224,14 @@ column, or transition generation exists yet:
 - Either way the daemon relearns its set the one way it ever learns it: the CP closes
   the socket with `1012` and the reconnect's `auth/ok` carries the new membership. Both
   admitted transitions leave nothing running to disturb, so the reconnect costs nothing.
+- **Membership is the ledger predicate on BOTH sides of the wire**, and it has to be the
+  same one. The daemon gates service on it (`dutyEnforced`) and must gate duty REPORTING
+  on it too: the heartbeat digest is what asks for a lease at all. That reporting was for
+  a while gated on `organizationMode === 'frame'` instead, which gave the same answer only
+  while the install-wide pool was the one set that existed — an org's own machines
+  authenticate in `connection` mode, so the moment an org could own a group its members
+  went duty-gated and silent, refusing to serve what they held no lease for while never
+  asking for one. Every agent on such a member goes dark until the two agree again.
 
 A precondition is only a fence if the state it read cannot change under it, so each one is
 taken **inside the transaction that writes**, under a per-daemon advisory lock every writer

--- a/docs/designs/daemon-groups.md
+++ b/docs/designs/daemon-groups.md
@@ -185,30 +185,22 @@ set nothing may claim what it is giving up or taking on.
   stop, so the transition is one phase: write the row, send the scope update, the daemon
   starts reporting `duties` and claims on its next beat.
 
-**Enrolling a daemon that has directly placed agents.** A `daemon`-placed agent is
-outside the ledger; the moment its machine enforces duties it serves only what it holds
-a lease for, so every agent still pinned to it would become unservable. That state is
-not allowed to exist, and the transition that avoids it is **the existing agent move**,
-run once per pinned agent with the set as the target — not a new mechanism: (1) mark
-the daemon **entering** (a claim fence on those agents' groups, so no member can win them
-mid-transition); (2) for each pinned agent, the move's detach step stops runtime
-authority on the machine and confirms it, exactly as a machine-to-machine move does;
-(3) commit in one transaction — the agents become `set`-placed on that set, the
-membership row is written, the fence lifts — and the daemon receives its new scope; on
-its next beat it claims those groups back and re-activates them (it is a member and it
-still has the replicas installed, so install-on-grant is a refresh, not a fetch). The
-operator sees one action; underneath it is the move convention applied N times inside
-one fence. If the machine is unreachable, the same rule as the move applies:
-enrollment uses the move's existing force-reassign contract — the operator explicitly
-confirms the source is permanently stopped, and on that confirmation the agents become
-set-placed without the detach and are claimable immediately. There is nothing else to
-wait for: a directly placed machine is outside the ledger, so it holds no lease and
-runs no self-fence — the operator's assertion _is_ the safety boundary, exactly as it
-is for a forced machine-to-machine move today. (The lease/self-fence horizon governs
-the _removal_ path above, where the leaver was a set member and does hold leases; the
-two paths have different boundaries because the source is in the ledger in one and not
-in the other.) The converse is enforced statically: a `daemon` placement may not name a
-machine that is in a set (the console does not offer it; the route refuses it).
+**Enrolling a daemon that has directly placed agents.** Nothing happens to them. The
+first version of this section claimed the opposite — that a machine which enforces duties
+serves only what it holds a lease for, so its pinned agents would go dark the moment the
+membership row landed, and therefore the join had to be a per-agent move onto the set.
+The premise was wrong. Duty eligibility for a `daemon` placement is
+`agent.daemonId = holder`, with **no membership term**: joining a set does not widen who
+may hold a pinned agent, so its machine remains the only possible holder. It does enforce
+duties now, so it serves that agent through a lease instead of outright — but the lease is
+one no peer can take. The join is therefore a single membership row plus the scope update
+the daemon already gets, and the agents keep running where they are.
+
+The converse follows from the same predicate: an agent **may** be pinned to a machine
+that is in an organization's group. The one refusal that survives is the install-wide
+pool, and identity is why — a pool member is a Pod the reconciler retires without notice,
+so a pin to one names something that stops existing. That is a statement about
+replaceability, not about membership.
 
 Leaving a set does not move agents by itself: they stay `set`-placed and re-grant to
 the remaining members. An operator who wants them pinned back to the leaving machine
@@ -221,11 +213,9 @@ same safety rule — never commit while the old authority might still be serving
 paid for it with **preconditions instead of choreography**, so no new wire frame, fence
 column, or transition generation exists yet:
 
-- _Join_ **is** the transition, as above: the pinned agents are detached on the machine and
-  re-placed onto the set with the membership row in one transaction, and the machine claims
-  them back as a member. What it does not carry is the "entering" claim fence — a peer can
-  win a group between the commit and the machine's re-claim, costing one extra move rather
-  than correctness. `force` is the move's own contract for a machine that cannot ack.
+- _Join_ needs no transition at all, per the correction above: one membership row, and the
+  agents pinned there keep running. It briefly shipped as a per-agent move onto the set —
+  detach, re-place, one transaction — which stopped work it had no reason to stop.
 - _Leave_ is refused (409) while the daemon holds a **live** duty lease, rather than
   sending a correlated withdrawal and committing on the ack. Draining the daemon, or
   simply letting its leases lapse, is the "stop and confirm" step — a lapsed lease is

--- a/packages/control-plane/src/http/agent-moves.ts
+++ b/packages/control-plane/src/http/agent-moves.ts
@@ -29,7 +29,6 @@ export function buildAgentMoves(deps: HttpDeps, log: FastifyBaseLogger): AgentMo
     sessionOwners: deps.sessionOwners,
     placement: deps.placementResolver,
     memberSets: deps.repos.memberSet,
-    memberSetWrites: deps.repos.memberSet,
     liveness: deps.liveness,
     ...(deps.recomputeDuties ? { recomputeDuties: deps.recomputeDuties } : {}),
     log

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -253,15 +253,6 @@ export const MemberSetListDto = z.array(MemberSetDto)
 
 export const MemberSetBody = z.object({ name: z.string().trim().min(1).max(64) })
 
-/** The operator's "the source is permanently stopped" assertion, as a query switch. It is the
- *  move's own force contract (daemon-groups.md §3): a directly placed machine is outside the
- *  ledger, so it holds no lease and runs no self-fence — the assertion IS the safety boundary. */
-export const ForceQuery = z.object({
-  // `z.stringbool()`, NOT `z.coerce.boolean()` — the latter truthy-coerces the STRING "false",
-  // so `?force=false` would assert the very thing the operator was declining to assert.
-  force: z.stringbool().optional()
-})
-
 /** `…/member-sets/:id/members/:daemonId` — the enrolment target. */
 export const MemberSetMemberParams = z.object({ id: z.string(), daemonId: z.string() })
 

--- a/packages/control-plane/src/http/routes/member-sets.ts
+++ b/packages/control-plane/src/http/routes/member-sets.ts
@@ -35,20 +35,16 @@ import type { HttpDeps } from '../deps.js'
 import { DaemonId, type OrgId } from '../../domain/ids.js'
 import {
   DaemonAlreadyInSet,
-  DaemonHasPlacedAgents,
   DaemonHoldsDuty,
   MemberSetInUse,
   MemberSetTenancyMismatch
 } from '../../persistence/errors.js'
-import { AgentMoveConflict, AgentMoveFailed } from '../../orchestrator/agentMove.js'
-import { buildAgentMoves } from '../agent-moves.js'
 import { orgOf, denyViewerWrite } from '../rbac.js'
 import {
   MemberSetBody,
   MemberSetDto,
   MemberSetListDto,
   MemberSetMemberParams,
-  ForceQuery,
   IdParam,
   ErrorDto
 } from '../dto/index.js'
@@ -93,8 +89,6 @@ export function memberSetRoutes(deps: HttpDeps) {
 
   return async function memberSetRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
-    /** Built per call, like the agents route's: the move graph is stateless and this is a rare op. */
-    const moves = (instance: FastifyInstance) => buildAgentMoves(deps, instance.log)
 
     r.get(
       '/member-sets',
@@ -184,10 +178,9 @@ export function memberSetRoutes(deps: HttpDeps) {
           tags: [Tag.MemberSets],
           summary: 'Enroll a daemon in a member set',
           description:
-            'Add one of the organization’s daemons to the set. Agents pinned to that machine come WITH it: each is stopped there and re-placed on the set in one step, and the daemon claims them back as a member. Refused (409) if the machine cannot confirm it stopped — retry with it online, or `force` to commit on the operator’s assertion that it is permanently stopped — or if it is already in another set.',
+            'Add one of the organization’s daemons to the set. Agents pinned to that machine stay pinned to it and keep running: a `daemon` placement is eligible for exactly that machine, so joining changes how it holds them (a duty lease) rather than who serves them. Refused (409) only if it is already in another set.',
           operationId: 'enrollDaemonInMemberSet',
           params: MemberSetMemberParams,
-          querystring: ForceQuery,
           response: { 200: MemberSetDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
         }
       },
@@ -203,32 +196,23 @@ export function memberSetRoutes(deps: HttpDeps) {
         }
         if (daemon.memberSetId === set.id) return toDto(set)
         if (daemon.memberSetId) return conflict(reply, 'the daemon is already in another member set')
-        // Agents pinned here do not block the join — they come WITH it (§3). The orchestrator
-        // stops each one on the machine, then places them on the set and writes the membership row
-        // in one transaction; `force` is the move's own contract for a machine that cannot ack.
+        // Agents pinned here neither block the join nor move: the ledger's eligibility predicate
+        // has no membership term for a `daemon` placement, so this machine stays their only
+        // possible holder (§3). Joining changes HOW it holds them, not who serves them.
         try {
-          await moves(app).enrollInSet(daemonId, set.id, orgId, req.query.force ? 'best-effort' : 'required')
+          await deps.repos.memberSet.enrollOperator(set.id, daemonId)
         } catch (err) {
-          if (err instanceof AgentMoveConflict) return conflict(reply, err.message)
-          if (err instanceof AgentMoveFailed) {
-            // The machine could not confirm it stopped. Committing anyway is the operator's call,
-            // exactly as it is for a machine-to-machine move.
-            return conflict(
-              reply,
-              `${err.message}. Retry with the daemon online, or confirm it is permanently stopped to force it.`
-            )
-          }
           if (err instanceof DaemonAlreadyInSet) {
             return conflict(reply, 'the daemon is already in another member set')
-          }
-          if (err instanceof DaemonHasPlacedAgents) {
-            return conflict(reply, `an agent was placed on this daemon mid-enrolment (${err.placed}); retry`)
           }
           // The set's tenancy invariant, surfaced rather than swallowed: the daemon is not this
           // org's. The org-fenced read above already refuses that, so this is a concurrent change.
           if (err instanceof MemberSetTenancyMismatch) return conflict(reply, 'the daemon is not in this organization')
           throw err
         }
+        // Duty is what it holds them by now, so the org's groups are re-derived before the machine
+        // comes back and claims — otherwise its first beat as a member finds nothing to take.
+        deps.recomputeDuties?.(orgId)
         deps.liveness.reconnectForMemberSet?.(daemonId)
         return toDto(set)
       }

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -51,7 +51,7 @@ import {
   type PlacementTarget
 } from '../domain/placement.js'
 import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
-import { convergeAgentRouting, httpBotIdsForAgent } from './agentRouting.js'
+import { convergeAgentRouting } from './agentRouting.js'
 import { cronToUpsert, integrationToSpec, isGatedAgent, httpIntegrationToSpec } from './placement.js'
 import {
   mcpDefsForAgents,
@@ -121,9 +121,6 @@ export interface AgentMoveDeps {
   /** Set membership, for deciding whether a detached source is still an eligible holder of the
    *  new placement. Absent ⇒ no source is ever unstaged, the pre-pool behavior. */
   memberSets?: Pick<MemberSetRepo, 'setIdOf' | 'memberIdsOf'>
-  /** The §3 enrolment commit — placements and the membership row in one transaction. Absent ⇒
-   *  a daemon with pinned agents cannot be enrolled, which is the pre-transition behavior. */
-  memberSetWrites?: Pick<MemberSetRepo, 'enrollWithPlacedAgents'>
   /** Live-connection reads for the set-commit unstage broadcast. Absent ⇒ no member is broadcast to. */
   liveness?: DaemonLiveness
   /** Resolves the members currently serving an agent — the sources a move must quiesce when
@@ -232,86 +229,6 @@ export class AgentMoveService {
     return this.withMoveGate(agent.id, async () =>
       this.moveLocked(await this.reloadAfterGate(agent), target, editor, 'best-effort')
     )
-  }
-
-  /**
-   * Enroll a daemon that still has agents pinned to it (daemon-groups.md §3).
-   *
-   * The operator sees one action; underneath it is the move convention applied once per pinned
-   * agent. A machine that enforces duties serves only what it holds a lease for, so a pinned agent
-   * would become unservable the instant the membership row lands — which is why this is a
-   * transition and not a validation. In order:
-   *
-   * 1. take each agent's move gate, so nothing else re-places it underneath;
-   * 2. DETACH it on the machine — the same confirmed step a machine-to-machine move uses, which is
-   *    what stops runtime authority before the placement changes hands;
-   * 3. commit placements + membership in ONE transaction (the repository's).
-   *
-   * Nothing is activated here. The machine is a member now, so it claims those groups back on its
-   * next beat and re-activates them from replicas it still has — install-on-grant as a refresh.
-   *
-   * `best-effort` is the move's own force contract, for a machine that cannot acknowledge: the
-   * operator asserts it is stopped, and that assertion IS the safety boundary — a directly placed
-   * machine is outside the ledger, so it holds no lease and runs no self-fence to wait out.
-   */
-  async enrollInSet(
-    daemonId: DaemonId,
-    setId: string,
-    orgId: string,
-    sourceDetachMode: SourceDetachMode = 'required'
-  ): Promise<void> {
-    const pinned = await this.deps.agents.listForDaemon(daemonId)
-    const releases: Array<() => void> = []
-    try {
-      for (const agent of pinned) {
-        const release = this.deps.mutations.tryBeginMove(agent.id)
-        if (!release) throw new AgentMoveConflict(`${agent.name} is already being modified or moved; retry`)
-        releases.push(release)
-      }
-      for (const agent of pinned) {
-        try {
-          requireAck('source cutover', await this.detach(daemonId, agent.id, agent.orgId, { discardActiveTurns: true }))
-        } catch (err) {
-          if (sourceDetachMode === 'required') {
-            if (err instanceof AgentMoveFailed) throw err
-            throw new AgentMoveFailed(`could not stop ${agent.name} on this daemon`, err)
-          }
-          this.deps.log?.warn({ err, agentId: agent.id, daemonId }, 'group enrolment: forced past an unacked detach')
-        }
-        // Durable and hot session affinity, released exactly as a move releases it. Without this
-        // the assignment rows survive, the machine's next register replays them into the owner
-        // index, and affinity traffic keeps arriving at a daemon that may no longer hold the duty.
-        const released = await this.deps.assignments.releaseForAgent(agent.id, daemonId, new Date())
-        for (const key of released) this.deps.sessionOwners.releaseSession(key)
-      }
-      await this.deps.memberSetWrites?.enrollWithPlacedAgents(
-        setId,
-        daemonId,
-        pinned.map((a) => a.id)
-      )
-    } finally {
-      for (const release of releases) release()
-    }
-    // The agents are `set`-placed now, so their duty groups are the org's to recompute and the
-    // ledger's to grant — nothing here activates them.
-    this.deps.recomputeDuties?.(orgId)
-    // Ingress follows the HOLDER, and these agents no longer have a placement that names one — the
-    // ledger's grant does. Re-converge so the projections stop addressing the machine directly.
-    // The HTTP bots are part of that: an `rc/bot-assign` names the daemon relay callbacks go to, so
-    // leaving it alone would keep public ingress arriving at the machine we just detached from.
-    const syncedBots = new Set<string>()
-    for (const agent of pinned) {
-      // One rebuild per bot, not per agent: an assign table covers every agent on that bot already.
-      const httpBotIds = (await httpBotIdsForAgent(this.deps, agent.id).catch(() => [])).filter(
-        (botId) => !syncedBots.has(botId)
-      )
-      for (const botId of httpBotIds) syncedBots.add(botId)
-      await convergeAgentRouting(
-        this.deps,
-        { agentId: agent.id, orgId: agent.orgId, httpBotIds },
-        { warn: (obj, msg) => this.deps.log?.warn(obj, msg) }
-      ).catch(() => {})
-    }
   }
 
   /** Cold-edit any workspace definition. The daemon reconciles mode/repo/branch

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5019,14 +5019,10 @@ export interface MemberSetRepo {
   /** Record a membership under the set's tenancy invariant; throws MemberSetTenancyMismatch.
    *  The automatic path (a pool Pod on auth) — no operator precondition. */
   enroll(setId: string, daemonId: DaemonId): Promise<void>
-  /** The operator path: the same row, plus §3's join precondition taken under the per-daemon
-   *  fence. Throws `DaemonHasPlacedAgents` when agents are still pinned to the machine. */
+  /** The operator path: the same row, written under the per-daemon fence so two enrolments into
+   *  different sets cannot both report success (§3). Agents pinned to the machine are untouched —
+   *  it stays their only eligible holder. Throws `DaemonAlreadyInSet`. */
   enrollOperator(setId: string, daemonId: DaemonId): Promise<void>
-  /** §3's commit step for a machine that HAS pinned agents: re-place the named agents onto the set
-   *  and write the membership row in ONE transaction. The caller must already have stopped runtime
-   *  authority for each — this only settles the durable state. Throws `DaemonHasPlacedAgents` when
-   *  something is still pinned that the caller did not name. */
-  enrollWithPlacedAgents(setId: string, daemonId: DaemonId, agentIds: readonly AgentId[]): Promise<void>
   /** One org's sets, by name. The org-less pool is never among them — it belongs to no org. */
   listForOrg(orgId: string): Promise<MemberSetRecord[]>
   /** Agents placed on each of these sets, in one query — the list read must not be N+1. Sets with

--- a/packages/control-plane/src/persistence/repositories/member-set.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/member-set.repo.ts
@@ -15,10 +15,10 @@
  *
  * - **Per daemon** — {@link lockDaemonMembership}, an advisory transaction lock every writer of
  *   "is this daemon in a set" and every reader that acts on the answer takes: enrolment,
- *   withdrawal, the `daemon`-placement guard, and the ledger's two claim paths. Without it, a
- *   placement that read "in no set" and an enrolment that read "no pinned agents" both commit and
- *   leave a set member with a pinned, unservable agent; or a claim commits a live lease onto a
- *   member the withdrawal has just decided was idle.
+ *   withdrawal, the pool-placement guard, and the ledger's two claim paths. Without it, a
+ *   placement that read "not a pool Pod" and a pool enrolment both commit and leave an agent
+ *   pinned to a Pod the reconciler may retire; or a claim commits a live lease onto a member the
+ *   withdrawal has just decided was idle.
  * - **Per set** — the `member_set` row itself, read `FOR SHARE` by everything that adds a
  *   reference to it and `FOR UPDATE` by the delete. Counting references without that lets a
  *   placement land after the count and be silently `SET NULL`ed by the cascade.
@@ -28,15 +28,13 @@
  */
 import { randomUUID } from 'node:crypto'
 import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
-import type { AgentId, DaemonId } from '../../domain/ids.js'
+import type { DaemonId } from '../../domain/ids.js'
 import type { MemberSetRecord, MemberSetRepo } from '../ports.js'
-import { settlePlacementChange } from './agent-placement.js'
 import {
   AgentSetPlacementDenied,
   DaemonPlacementInSet,
   MemberSetInUse,
   MemberSetTenancyMismatch,
-  DaemonHasPlacedAgents,
   DaemonHoldsDuty,
   DaemonAlreadyInSet
 } from '../errors.js'
@@ -94,10 +92,8 @@ export async function assertAgentMayUseSet(
 }
 
 /**
- * The converse of that invariant, and the reason it can be enforced statically (§3): a `daemon`
- * placement may not name a machine that is in a set. Such a machine serves only what it holds a
- * lease for, so an agent pinned to it would be placed and unservable at once. Under the daemon
- * fence, so this cannot race an enrolment that is deciding the machine has nothing pinned to it.
+ * A `daemon` placement may not name a POOL member (§3). Under the daemon fence, so it cannot race
+ * the enrolment that is putting the machine there.
  */
 export async function assertDaemonNotInSet(
   tx: Prisma.TransactionClient,
@@ -105,9 +101,16 @@ export async function assertDaemonNotInSet(
   daemonId: string
 ): Promise<void> {
   await lockDaemonMembership(tx, daemonId)
-  const [row] = await tx.$queryRaw<{ one: number }[]>(
-    Prisma.sql`SELECT 1 AS one FROM "member_set_member" WHERE "daemonId" = ${daemonId}::uuid`
-  )
+  // Only the install-wide pool refuses a pin, and not because membership conflicts with one — a
+  // `daemon` placement is eligible for exactly that machine either way. It is that a pool member
+  // is a REPLACEABLE identity: the reconciler retires Pods without notice, so a pin to one is a
+  // pointer that outlives what it names. An org's own machines are stable, so pinning an agent to
+  // one is allowed whether or not it has joined a group.
+  const [row] = await tx.$queryRaw<{ one: number }[]>(Prisma.sql`
+    SELECT 1 AS one FROM "member_set_member" m
+    JOIN "member_set" s ON s.id = m."setId"
+    WHERE m."daemonId" = ${daemonId}::uuid AND s."orgId" IS NULL
+  `)
   if (row) throw new DaemonPlacementInSet(agentId, daemonId)
 }
 
@@ -154,55 +157,17 @@ export class PgMemberSetRepo implements MemberSetRepo {
     await this.prisma.$transaction((tx) => enrollDaemonInSet(tx, setId, daemonId))
   }
 
-  async enrollWithPlacedAgents(setId: string, daemonId: DaemonId, agentIds: readonly AgentId[]): Promise<void> {
-    await this.prisma.$transaction(async (tx) => {
-      // §3's commit step, as ONE transaction: the agents stop being pinned to the machine and the
-      // machine becomes a member together. Either order on its own is a state the invariants
-      // forbid — a member with a pinned agent, or agents on a set with nothing in it — and a crash
-      // between two statements would leave exactly that.
-      await lockDaemonMembership(tx, daemonId)
-      const [current] = await tx.$queryRaw<{ setId: string }[]>(
-        Prisma.sql`SELECT "setId" FROM "member_set_member" WHERE "daemonId" = ${daemonId}::uuid`
-      )
-      if (current) {
-        if (current.setId !== setId) throw new DaemonAlreadyInSet(daemonId, current.setId)
-      }
-      for (const agentId of agentIds) {
-        const [agent] = await tx.$queryRaw<{ orgId: string }[]>(
-          Prisma.sql`SELECT "orgId" FROM "agent" WHERE id = ${agentId}::uuid AND "daemonId" = ${daemonId}::uuid FOR UPDATE`
-        )
-        // Raced away or already re-placed since the caller read it: nothing to move, and the
-        // membership row below is what the whole operation is for.
-        if (!agent) continue
-        await assertAgentMayUseSet(tx, { id: agentId, orgId: agent.orgId }, setId)
-        await tx.$executeRaw(Prisma.sql`
-          UPDATE "agent"
-          SET "placementKind" = 'set', "setId" = ${setId}::uuid, "daemonId" = NULL,
-              "configRevision" = "configRevision" + 1
-          WHERE id = ${agentId}::uuid
-        `)
-        // The same settlement every other placement writer performs, in the same transaction:
-        // webchat MCP delegations are placement-bound grants and hook dispatches made before the
-        // change must read stale. This IS a real placement change — `daemon` to `set`.
-        await settlePlacementChange(tx, agentId)
-      }
-      // Anything still pinned here that the caller did not name would be unservable the moment the
-      // row below lands, so the whole operation fails rather than create that state.
-      const [left] = await tx.$queryRaw<{ n: bigint }[]>(
-        Prisma.sql`SELECT count(*) AS n FROM "agent" WHERE "daemonId" = ${daemonId}::uuid`
-      )
-      const stillPinned = Number(left?.n ?? 0n)
-      if (stillPinned > 0) throw new DaemonHasPlacedAgents(daemonId, stillPinned)
-      if (!current) await enrollDaemonInSet(tx, setId, daemonId)
-    })
-  }
-
+  /**
+   * Join, keeping whatever is pinned to the machine (daemon-groups.md §3).
+   *
+   * Pinning and membership are not in conflict, and the ledger is where that is decided: a
+   * `daemon` placement is eligible for exactly that machine — `agent."daemonId" = holder`, with no
+   * membership term in the predicate — so the machine remains the ONLY daemon that may hold those
+   * agents, member or not. It enforces duties now, so it serves them through a lease instead of
+   * outright; that lease is one nothing else can take. Nothing moves and nothing is stopped.
+   */
   async enrollOperator(setId: string, daemonId: DaemonId): Promise<void> {
     await this.prisma.$transaction(async (tx) => {
-      // The precondition and the row in ONE transaction under the daemon fence (§3): a machine
-      // that enforces duties serves only what it holds a lease for, so an agent still pinned to it
-      // would be placed and unservable the moment this row lands. `assertDaemonNotInSet` takes the
-      // same lock, so a placement racing this one either loses the machine or loses the pin.
       await lockDaemonMembership(tx, daemonId)
       // Re-read membership UNDER the lock. The insert is idempotent, so the losing half of two
       // concurrent enrolments into different sets would otherwise no-op and still answer success,
@@ -214,11 +179,6 @@ export class PgMemberSetRepo implements MemberSetRepo {
         if (current.setId !== setId) throw new DaemonAlreadyInSet(daemonId, current.setId)
         return
       }
-      const [pinned] = await tx.$queryRaw<{ n: bigint }[]>(
-        Prisma.sql`SELECT count(*) AS n FROM "agent" WHERE "daemonId" = ${daemonId}::uuid`
-      )
-      const placed = Number(pinned?.n ?? 0n)
-      if (placed > 0) throw new DaemonHasPlacedAgents(daemonId, placed)
       await enrollDaemonInSet(tx, setId, daemonId)
     })
   }

--- a/packages/control-plane/test/integration/member-sets.route.test.ts
+++ b/packages/control-plane/test/integration/member-sets.route.test.ts
@@ -2,17 +2,16 @@
  * `/member-sets` — an organization's own member sets (docs/designs/daemon-groups.md §2, §3).
  *
  * Two things are load-bearing here and neither is CRUD. First, the route is fenced on the path
- * org and the install-wide pool is not this organization's to see or touch. Second, membership
- * moves runtime authority, so each direction is admitted only from a state where nothing is
- * taken away from a running machine: a daemon with pinned agents may not join, and a daemon
- * holding a live duty lease may not leave.
+ * org and the install-wide pool is not this organization's to see or touch. Second, the two
+ * directions are asymmetric: joining takes nothing away — a pinned agent stays pinned, because a
+ * `daemon` placement is eligible for exactly that machine — while leaving is refused while the
+ * machine still holds a live duty lease.
  */
 import { randomUUID } from 'node:crypto'
 import { describe, it, expect } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { buildHttpApp } from '../fakes/build-http.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
-import type { HttpBotOrchestrator } from '../../src/orchestrator/httpBot.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { poolSetId } from '../fakes/member-set.js'
 
@@ -118,107 +117,27 @@ describe('member sets — the enrolment transitions (real Postgres)', () => {
     }
   })
 
-  it('refuses an offline daemon that cannot confirm it stopped its agents, and forces past it', async () => {
-    // §3: pinned agents come WITH the join. What blocks it is the machine being unable to
-    // acknowledge that it stopped serving them — the same boundary a machine-to-machine move has.
+  it('keeps the pinned agents on the machine, and lets nothing else hold them', async () => {
+    // §3: a pin narrows to exactly one machine. The join is a membership row, not a transition —
+    // the agent stays where it was and the machine stays its only eligible holder.
     const { app, close } = buildHttpApp(prisma)
     try {
       await seedDaemon(prisma, DAEMON)
       await seedAgent(prisma, AGENT, { daemonId: DAEMON })
       const setId = await withSet(app)
 
-      const res = await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${DAEMON}` })
-      expect(res.statusCode).toBe(409)
-      expect(res.json().message).toMatch(/permanently stopped/)
-      expect(await prisma.memberSetMember.count()).toBe(0)
-
-      // `force=false` is DECLINING to assert, not asserting: truthy string coercion here would
-      // turn the safety switch on for anyone who spelled it out.
-      const declined = await app.inject({
-        method: 'PUT',
-        url: `${ORG}/member-sets/${setId}/members/${DAEMON}?force=false`
-      })
-      expect(declined.statusCode).toBe(409)
-      expect(await prisma.memberSetMember.count()).toBe(0)
-
-      // The operator asserts it is stopped: the agents move onto the set and the machine joins.
-      const forced = await app.inject({
-        method: 'PUT',
-        url: `${ORG}/member-sets/${setId}/members/${DAEMON}?force=true`
-      })
-      expect(forced.statusCode).toBe(200)
-      expect((forced.json() as SetBody).memberDaemonIds).toEqual([DAEMON])
+      const joined = await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${DAEMON}` })
+      expect(joined.statusCode).toBe(200)
+      expect((joined.json() as SetBody).memberDaemonIds).toEqual([DAEMON])
       expect(await prisma.agent.findUniqueOrThrow({ where: { id: AGENT } })).toMatchObject({
-        placementKind: 'set',
-        setId,
-        daemonId: null
+        placementKind: 'daemon',
+        daemonId: DAEMON,
+        setId: null
       })
-    } finally {
-      await close()
-    }
-  })
-
-  it('settles the moved agents\u2019 placement-bound state, as every other placement writer does', async () => {
-    const { app, close } = buildHttpApp(prisma)
-    try {
-      await seedDaemon(prisma, DAEMON)
-      await seedAgent(prisma, AGENT, { daemonId: DAEMON })
-      const before = await prisma.hookDef.findMany({ where: { agentId: AGENT }, select: { dispatchRevision: true } })
-      const setId = await withSet(app)
-
-      await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${DAEMON}?force=true` })
-
-      // A hook dispatch prepared before the change must read stale: whoever holds the duty now is
-      // not the machine the dispatch was compiled against.
-      const after = await prisma.hookDef.findMany({ where: { agentId: AGENT }, select: { dispatchRevision: true } })
-      after.forEach((hook, i) => expect(hook.dispatchRevision).toBeGreaterThan(before[i]!.dispatchRevision))
-      // And the durable session affinity the machine owned is released rather than replayed on its
-      // next register into an owner index that no longer reflects who serves the agent.
-      expect(await prisma.assignment.count({ where: { agentId: AGENT, daemonId: DAEMON, state: 'active' } })).toBe(0)
-    } finally {
-      await close()
-    }
-  })
-
-  it('rebuilds the HTTP bots’ assign tables, so public ingress stops naming the machine', async () => {
-    // The `rc/bot-assign` table is compiled, not resolved per callback: it names the daemon the
-    // relay forwards to. Enrolment takes the agent off that machine, so leaving the table alone
-    // would keep addressing it for the whole window before the ledger grants the duty back.
-    const synced: string[] = []
-    const { app, close } = buildHttpApp(prisma, undefined, undefined, undefined, {
-      httpBot: { syncBot: async (id: string) => void synced.push(id) } as unknown as HttpBotOrchestrator
-    })
-    try {
-      await seedDaemon(prisma, DAEMON)
-      await seedAgent(prisma, AGENT, { daemonId: DAEMON })
-      const httpBot = randomUUID()
-      const classicBot = randomUUID()
-      await prisma.bot.createMany({
-        data: [
-          { id: httpBot, orgId: DEFAULT_ORG_ID, platform: 'slack', name: 'shared', shareable: true, transport: 'http' },
-          { id: classicBot, orgId: DEFAULT_ORG_ID, platform: 'slack', name: 'classic' }
-        ]
-      })
-      await prisma.integration.createMany({
-        data: [
-          { id: randomUUID(), orgId: DEFAULT_ORG_ID, agentId: AGENT, botId: httpBot, platform: 'slack', name: 'http' },
-          {
-            id: randomUUID(),
-            orgId: DEFAULT_ORG_ID,
-            agentId: AGENT,
-            botId: classicBot,
-            platform: 'slack',
-            name: 'classic'
-          }
-        ]
-      })
-      const setId = await withSet(app)
-
-      await app.inject({ method: 'PUT', url: `${ORG}/member-sets/${setId}/members/${DAEMON}?force=true` })
-
-      // Only the HTTP one: a classic bot's egress is the daemon's own socket, with no CP-side
-      // table naming it.
-      expect(synced).toEqual([httpBot])
+      // And the set reports what is placed ON it, which is still nothing: the agent is on a
+      // machine that happens to be a member, not on the group.
+      const listed = (await app.inject({ method: 'GET', url: `${ORG}/member-sets` })).json() as SetBody[]
+      expect(listed.find((s) => s.setId === setId)?.agentCount).toBe(0)
     } finally {
       await close()
     }

--- a/packages/control-plane/test/repo/org-member-set.test.ts
+++ b/packages/control-plane/test/repo/org-member-set.test.ts
@@ -15,7 +15,6 @@ import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.r
 import { PgMemberSetRepo } from '../../src/persistence/repositories/member-set.repo.js'
 import {
   DaemonAlreadyInSet,
-  DaemonHasPlacedAgents,
   DaemonHoldsDuty,
   DaemonPlacementInSet,
   MemberSetInUse
@@ -23,7 +22,7 @@ import {
 import { onDaemon, onSet } from '../../src/domain/placement.js'
 import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
-import { seedPoolMember } from '../fakes/member-set.js'
+import { poolSetId, seedPoolMember } from '../fakes/member-set.js'
 
 const ORG_X = OrgId(DEFAULT_ORG_ID)
 const MEMBER_G = 'd1111111-1111-4111-8111-111111111111' // org X, in set G
@@ -147,31 +146,37 @@ describe('an org set member’s eligibility (real Postgres)', () => {
 })
 
 describe('a set member is not a placement target (real Postgres)', () => {
-  it('refuses pinning an agent to a machine that is in a set, on create and on move', async () => {
+  it('pins to a member of an org group, and refuses only a pool Pod', async () => {
     await prisma.daemon.createMany({
       data: [MEMBER_G, PINNED].map((id) => ({ id, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' }))
     })
     const setG = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
     await sets().enroll(setG, DaemonId(MEMBER_G))
 
-    // A member serves only what it holds a lease for, so a pinned agent there would be placed and
-    // unservable at once — the converse of the invariant that lets `mayHold` stay one rule.
-    await expect(
-      agents().create({
-        id: AgentId(randomUUID()),
-        orgId: ORG_X,
-        name: 'pinned-to-member',
-        runtime: 'claude',
-        daemonId: DaemonId(MEMBER_G)
-      })
-    ).rejects.toBeInstanceOf(DaemonPlacementInSet)
+    // Membership does not make a machine an illegal pin target: a `daemon` placement is eligible
+    // for exactly that machine either way, so it stays the agent's only possible holder.
+    const pinnedToMember = AgentId(randomUUID())
+    await agents().create({
+      id: pinnedToMember,
+      orgId: ORG_X,
+      name: 'pinned-to-member',
+      runtime: 'claude',
+      daemonId: DaemonId(MEMBER_G)
+    })
+    expect(await prisma.agent.findUniqueOrThrow({ where: { id: pinnedToMember } })).toMatchObject({
+      placementKind: 'daemon',
+      daemonId: MEMBER_G
+    })
 
+    // The install-wide pool is the exception, and identity is why: the reconciler retires Pods
+    // without notice, so a pin to one names something that stops existing.
+    const poolDaemon = DaemonId(randomUUID())
+    await prisma.daemon.create({ data: { id: poolDaemon, orgId: null, maxAgents: 8, status: 'ready' } })
+    await sets().enroll(await poolSetId(prisma), poolDaemon)
     const agentId = AgentId(randomUUID())
     await agents().create({ id: agentId, orgId: ORG_X, name: 'movable', runtime: 'claude', daemonId: DaemonId(PINNED) })
-    await expect(agents().setPlacement(agentId, onDaemon(DaemonId(MEMBER_G)))).rejects.toBeInstanceOf(
-      DaemonPlacementInSet
-    )
-    // The set itself is a legal target for the same agent — the refusal is about the machine.
+    await expect(agents().setPlacement(agentId, onDaemon(poolDaemon))).rejects.toBeInstanceOf(DaemonPlacementInSet)
+    // The set itself is a legal target for the same agent.
     await agents().setPlacement(agentId, onSet(setG))
     expect(await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).toMatchObject({
       placementKind: 'set',
@@ -230,10 +235,10 @@ describe('org set lifecycle (real Postgres)', () => {
 })
 
 describe('the membership fences (real Postgres)', () => {
-  it('serializes enrolment against a concurrent pin, so neither state can be half-committed', async () => {
-    // The finding: both writers used to check and commit in separate transactions, so a placement
-    // reading "in no set" and an enrolment reading "no pinned agents" could both win — leaving a
-    // set member with an agent pinned to it and no way to serve it.
+  it('lets an org-group enrolment and a concurrent pin both win — the pair is no longer forbidden', async () => {
+    // This pair used to be the thing the fence existed to prevent. It is legal now: a `daemon`
+    // placement names exactly one machine whether or not that machine is in a group, so a member
+    // with an agent pinned to it is a state the ledger can serve, not one it has to rule out.
     await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
     const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
     const agentId = AgentId(randomUUID())
@@ -248,11 +253,34 @@ describe('the membership fences (real Postgres)', () => {
         daemonId: DaemonId(MEMBER_G)
       })
     ])
-    // Exactly one wins — and whichever it is, the forbidden pair never exists.
+    expect(outcomes.map((o) => o.status)).toEqual(['fulfilled', 'fulfilled'])
+    expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBe(setId)
+    expect(await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).toMatchObject({
+      placementKind: 'daemon',
+      daemonId: MEMBER_G
+    })
+    // And the machine can hold it, which is what makes the pair legal rather than merely allowed.
+    expect(await ledger().claimAgentHome(ORG_X, agentId, DaemonId(MEMBER_G), T0, LEASE_MS)).toMatchObject({
+      granted: true
+    })
+  })
+
+  it('still serializes a pool enrolment against a concurrent pin, where the pair IS forbidden', async () => {
+    // The pool keeps the old fence for the reason it always had one: its members are replaceable
+    // Pods, so an agent pinned to one names something the reconciler may retire.
+    const pod = DaemonId(randomUUID())
+    await prisma.daemon.create({ data: { id: pod, orgId: null, maxAgents: 8, status: 'ready' } })
+    const pool = await poolSetId(prisma)
+    const agentId = AgentId(randomUUID())
+
+    const outcomes = await Promise.allSettled([
+      sets().enroll(pool, pod),
+      agents().create({ id: agentId, orgId: ORG_X, name: 'pool-racer', runtime: 'claude', daemonId: pod })
+    ])
+    const inPool = (await sets().setIdOf(pod)) !== null
+    const pinned = await prisma.agent.count({ where: { daemonId: pod } })
+    expect(inPool && pinned > 0).toBe(false)
     expect(outcomes.filter((o) => o.status === 'fulfilled')).toHaveLength(1)
-    const enrolled = (await sets().setIdOf(DaemonId(MEMBER_G))) !== null
-    const pinned = await prisma.agent.count({ where: { daemonId: MEMBER_G } })
-    expect(enrolled && pinned > 0).toBe(false)
   })
 
   it('never answers success for the loser of two concurrent enrolments into different sets', async () => {
@@ -318,24 +346,6 @@ describe('the membership fences (real Postgres)', () => {
     }
   })
 
-  it('refuses enrolment while agents are pinned, and takes it once they are re-placed', async () => {
-    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
-    const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
-    const agentId = AgentId(randomUUID())
-    await agents().create({
-      id: agentId,
-      orgId: ORG_X,
-      name: 'pinned',
-      runtime: 'claude',
-      daemonId: DaemonId(MEMBER_G)
-    })
-
-    await expect(sets().enrollOperator(setId, DaemonId(MEMBER_G))).rejects.toBeInstanceOf(DaemonHasPlacedAgents)
-    await agents().setPlacement(agentId, onSet(setId))
-    await sets().enrollOperator(setId, DaemonId(MEMBER_G))
-    expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBe(setId)
-  })
-
   it('a renewal cannot revive a lapsed lease across a withdrawal', async () => {
     // Renewal carries no expiry predicate — it revives every row this holder still names — so it
     // is a lease-CREATING write as far as withdrawal is concerned. Both take the daemon fence, and
@@ -375,9 +385,11 @@ describe('the membership fences (real Postgres)', () => {
 })
 
 describe('enrolling a daemon that still has agents pinned to it (real Postgres)', () => {
-  it('re-places them onto the set and writes the membership row in ONE transaction', async () => {
-    // §3: a pinned agent does not BLOCK the join, it comes with it. Either half alone is a state
-    // the invariants forbid — a member with a pinned agent, or agents on a set with nothing in it.
+  it('leaves them pinned, and the machine still holds their duty', async () => {
+    // §3: pinning and membership are not in conflict. The ledger's eligibility predicate has no
+    // membership term for a `daemon` placement — it is `agent."daemonId" = holder` — so this
+    // machine remains the ONLY daemon that may hold these agents. Joining changes how it holds
+    // them (a lease it alone can take) rather than who serves them, so nothing moves.
     await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
     const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
     const a1 = AgentId(randomUUID())
@@ -389,45 +401,53 @@ describe('enrolling a daemon that still has agents pinned to it (real Postgres)'
       await agents().create({ id, orgId: ORG_X, name, runtime: 'claude', daemonId: DaemonId(MEMBER_G) })
     }
 
-    await sets().enrollWithPlacedAgents(setId, DaemonId(MEMBER_G), [a1, a2])
+    await sets().enrollOperator(setId, DaemonId(MEMBER_G))
 
     expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBe(setId)
     for (const id of [a1, a2]) {
       expect(await prisma.agent.findUniqueOrThrow({ where: { id } })).toMatchObject({
-        placementKind: 'set',
-        setId,
-        daemonId: null
+        placementKind: 'daemon',
+        daemonId: MEMBER_G,
+        setId: null
       })
     }
-    // And the machine can now hold their duty, which is the point of the whole transition.
+    // It enforces duties now, so it serves them through a lease — and that lease is one nothing
+    // else can take, which is what makes keeping the pin safe.
     const claim = await ledger().claimAgentHome(ORG_X, a1, DaemonId(MEMBER_G), T0, LEASE_MS)
     expect(claim).toMatchObject({ granted: true, holder: MEMBER_G })
   })
 
-  it('refuses when an agent was pinned mid-transition rather than leaving it unservable', async () => {
-    await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
+  it('refuses a peer member the duty of an agent pinned to another machine', async () => {
+    // The other half of the same predicate, and the reason a pin survives the join: a `daemon`
+    // placement narrows to one machine, so a sibling member is never an eligible holder.
+    await prisma.daemon.createMany({
+      data: [
+        { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' },
+        { id: MEMBER_H, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' }
+      ]
+    })
     const setId = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
-    const named = AgentId(randomUUID())
-    const unnamed = AgentId(randomUUID())
-    await agents().create({ id: named, orgId: ORG_X, name: 'named', runtime: 'claude', daemonId: DaemonId(MEMBER_G) })
-    await agents().create({ id: unnamed, orgId: ORG_X, name: 'late', runtime: 'claude', daemonId: DaemonId(MEMBER_G) })
+    const pinned = AgentId(randomUUID())
+    await agents().create({ id: pinned, orgId: ORG_X, name: 'pinned', runtime: 'claude', daemonId: DaemonId(MEMBER_G) })
+    await sets().enrollOperator(setId, DaemonId(MEMBER_G))
+    await sets().enrollOperator(setId, DaemonId(MEMBER_H))
 
-    // The caller only knew about one; the other would be placed and unservable the moment the
-    // membership row landed, so nothing commits.
-    await expect(sets().enrollWithPlacedAgents(setId, DaemonId(MEMBER_G), [named])).rejects.toBeInstanceOf(
-      DaemonHasPlacedAgents
-    )
-    expect(await sets().setIdOf(DaemonId(MEMBER_G))).toBeNull()
-    expect(await prisma.agent.findUniqueOrThrow({ where: { id: named } })).toMatchObject({ placementKind: 'daemon' })
+    expect(await ledger().claimAgentHome(ORG_X, pinned, DaemonId(MEMBER_H), T0, LEASE_MS)).toMatchObject({
+      granted: false
+    })
+    expect(await ledger().claimAgentHome(ORG_X, pinned, DaemonId(MEMBER_G), T0, LEASE_MS)).toMatchObject({
+      granted: true,
+      holder: MEMBER_G
+    })
   })
 
   it('is idempotent for a daemon already in the set, and refuses one in another', async () => {
     await prisma.daemon.create({ data: { id: MEMBER_G, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' } })
     const g = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-g')).id
     const h = (await sets().createForOrg(DEFAULT_ORG_ID, 'group-h')).id
-    await sets().enrollWithPlacedAgents(g, DaemonId(MEMBER_G), [])
-    await sets().enrollWithPlacedAgents(g, DaemonId(MEMBER_G), [])
+    await sets().enrollOperator(g, DaemonId(MEMBER_G))
+    await sets().enrollOperator(g, DaemonId(MEMBER_G))
     expect(await sets().memberIdsOf(g)).toEqual([MEMBER_G])
-    await expect(sets().enrollWithPlacedAgents(h, DaemonId(MEMBER_G), [])).rejects.toBeInstanceOf(DaemonAlreadyInSet)
+    await expect(sets().enrollOperator(h, DaemonId(MEMBER_G))).rejects.toBeInstanceOf(DaemonAlreadyInSet)
   })
 })

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -946,6 +946,20 @@ export class CpClient {
     return this.memberSetRef
   }
 
+  /**
+   * Does this connection take part in the duty ledger? MEMBERSHIP decides, and it must be the same
+   * predicate the daemon gates service on (`dutyEnforced`), or the two disagree in the worst
+   * possible direction: it refuses to serve what it holds no lease for while never asking for one.
+   *
+   * This used to read `organizationMode === 'frame'`, which was the same answer only while the
+   * install-wide pool was the one set that existed — org-scoped daemons authenticate in
+   * `connection` mode, so once an org could own a group its members went duty-gated and silent,
+   * and the CP never granted them anything.
+   */
+  private reportsDuties(): boolean {
+    return this.memberSetRef !== null
+  }
+
   /** Additive CP feature negotiation for rolling daemon/CP upgrades. */
   supportsServerFeature(feature: string): boolean {
     return this.serverFeatures.has(feature)
@@ -1256,10 +1270,10 @@ export class CpClient {
    * for an agent that is already running, which is the gap a peer wake falls into.
    *
    * Coalesced onto one extra beat: an admission routinely settles several groups, and each one
-   * calls this. Dormant off a frame-mode connection, where there is no digest at all.
+   * calls this. Dormant off a non-member connection, where there is no digest at all.
    */
   reportDutiesNow(): void {
-    if (this.organizationMode !== 'frame' || this.state !== 'READY' || this.dutyReportTimer !== undefined) return
+    if (!this.reportsDuties() || this.state !== 'READY' || this.dutyReportTimer !== undefined) return
     this.dutyReportTimer = this.deps.clock.setTimeout(() => {
       this.dutyReportTimer = undefined
       if (this.state === 'READY') this.sendHeartbeat()
@@ -1267,9 +1281,9 @@ export class CpClient {
   }
 
   private sendHeartbeat(): void {
-    // The duty lease exchange rides this beat (frames/duty.ts). Absent on a
-    // single-org daemon, which keeps the whole CP-side path dormant.
-    const duties = this.organizationMode === 'frame' ? this.deps.duties?.() : undefined
+    // The duty lease exchange rides this beat (frames/duty.ts). Absent on a daemon in no member
+    // set, which keeps the whole CP-side path dormant.
+    const duties = this.reportsDuties() ? this.deps.duties?.() : undefined
     const live = this.transport
     live?.send(
       encode(

--- a/packages/daemon/test/cp/client-duty-fence.test.ts
+++ b/packages/daemon/test/cp/client-duty-fence.test.ts
@@ -81,6 +81,9 @@ interface Options {
   /** Omit the duty getter (or scope the connection to one org) — then no lease can exist. */
   duties?: boolean
   organizationMode?: 'connection' | 'frame'
+  /** The set the re-handshake announces. Membership — NOT the org mode — is what puts a connection
+   *  in the ledger, so an org-scoped member reports duties exactly as a pool member does. */
+  memberSet?: { setId: string; name: string }
   /** The groups the daemon holds; the digest projects these and a renewal refreshes exactly them. */
   held?: string[]
 }
@@ -134,7 +137,8 @@ async function ready(opts: Options = {}) {
   await tick()
   await handshake(link.current, 1, opts.noHorizon ? undefined : LEASE_MS)
   if (opts.organizationMode === 'connection') {
-    // Re-run the handshake as an org-scoped connection: the same client, no duty exchange.
+    // Re-run the handshake as an org-scoped connection: the same client, and a duty exchange only
+    // if this one announces a member set.
     link.current.simulateClose(1012, 'rescope')
     clock.advance(1000)
     await tick()
@@ -150,7 +154,8 @@ async function ready(opts: Options = {}) {
             heartbeatSec: BEAT_MS / 1000,
             dutyLeaseMs: LEASE_MS,
             serverTime: '2026-08-14T00:00:00.000Z',
-            organizationMode: 'connection'
+            organizationMode: 'connection',
+            ...(opts.memberSet ? { memberSet: opts.memberSet } : {})
           },
           { corr: auth.id }
         )
@@ -521,7 +526,7 @@ describe('the duty self-fence deadline', () => {
     expect(onDutyFence).not.toHaveBeenCalled()
   })
 
-  it('never arms on an org-scoped connection, where the ledger stays dormant', async () => {
+  it('never arms for a connection in NO member set, where the ledger stays dormant', async () => {
     const { link, clock, onDutyFence } = await ready({ organizationMode: 'connection' })
     await advance(clock, BEAT_MS)
     expect(beats(link.current).at(-1).payload).not.toHaveProperty('duties')
@@ -530,6 +535,17 @@ describe('the duty self-fence deadline', () => {
     link.current.simulateClose(1006, 'gone')
     await advance(clock, 10 * LEASE_MS)
     expect(onDutyFence).not.toHaveBeenCalled()
+  })
+
+  it('reports duties for an ORG-SCOPED member — membership decides, not the org mode', async () => {
+    // The regression this pins: duty reporting used to be gated on `organizationMode === 'frame'`,
+    // which was the same answer only while the install-wide pool was the one set that existed. An
+    // org's own group member authenticates in `connection` mode, so it went duty-gated and silent
+    // — it refused to serve what it held no lease for while never asking the CP for one.
+    const orgGroup = { setId: '9f11e5e7-0000-4000-8000-000000000002', name: 'edge' }
+    const { link, clock } = await ready({ organizationMode: 'connection', memberSet: orgGroup })
+    await advance(clock, BEAT_MS)
+    expect(beats(link.current).at(-1).payload).toHaveProperty('duties')
   })
 
   it('adopts each renewal horizon the CP announces', async () => {

--- a/packages/daemon/test/cp/client-duty.test.ts
+++ b/packages/daemon/test/cp/client-duty.test.ts
@@ -13,7 +13,15 @@ const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const silent = { trace() {}, debug() {}, info() {}, warn() {}, error() {} }
 const tick = () => new Promise((r) => setImmediate(r))
 
-async function readyClient(over: Partial<CpClientDeps> = {}, organizationMode: 'connection' | 'frame' = 'frame') {
+/** The install-wide pool, as `auth/ok` announces it. Membership — not the org mode — is what puts
+ *  a connection in the duty ledger (daemon-groups.md §3), so it is what these tests vary. */
+const POOL_SET = { setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }
+
+async function readyClient(
+  over: Partial<CpClientDeps> = {},
+  organizationMode: 'connection' | 'frame' = 'frame',
+  memberSet: { setId: string; name: string } | null = POOL_SET
+) {
   const t = new FakeTransport()
   const clock = new FakeClock()
   const configApply = {
@@ -93,7 +101,8 @@ async function readyClient(over: Partial<CpClientDeps> = {}, organizationMode: '
           sessionEpoch: 5,
           heartbeatSec: 15,
           serverTime: '2026-06-26T00:00:00.000Z',
-          organizationMode
+          organizationMode,
+          ...(memberSet ? { memberSet } : {})
         },
         { corr: auth.id }
       )
@@ -142,13 +151,25 @@ describe('daemon duty lease exchange', () => {
     expect(duties).toHaveBeenCalled()
   })
 
-  it('an org-scoped daemon never sends duties, even when the getter is present', async () => {
+  it('a daemon in NO member set never sends duties, even when the getter is present', async () => {
     const duties = vi.fn(() => ({ held: [], headroom: 4 }))
-    const { t, clock } = await readyClient({ duties }, 'connection')
+    const { t, clock } = await readyClient({ duties }, 'connection', null)
 
     const hb = await beat(t, clock)
     expect(hb?.payload).not.toHaveProperty('duties')
     expect(duties).not.toHaveBeenCalled()
+  })
+
+  it('an ORG-SCOPED member sends them all the same — the org mode is not the predicate', async () => {
+    // This is the regression: the gate used to read `organizationMode === 'frame'`, which agreed
+    // with membership only while the pool was the one set that existed. An org's own group member
+    // authenticates in `connection` mode, so it went duty-gated and silent — refusing to serve
+    // what it held no lease for while never asking the CP for one.
+    const duties = vi.fn(() => ({ held: [{ groupId: GROUP, term: '7' }], headroom: 1 }))
+    const { t, clock } = await readyClient({ duties }, 'connection', { setId: GROUP, name: 'edge' })
+
+    const hb = await beat(t, clock)
+    expect(hb?.payload).toMatchObject({ duties: { held: [{ groupId: GROUP, term: '7' }], headroom: 1 } })
   })
 
   it('a daemon with no duty getter sends a plain heartbeat (path dormant)', async () => {

--- a/packages/web/src/components/console/modals/GroupModal.tsx
+++ b/packages/web/src/components/console/modals/GroupModal.tsx
@@ -12,12 +12,11 @@ import { Button, Icon } from '@/components/ui'
  * filled where it is created is not a feature, and "which machines are in it" is the only thing
  * about a group worth editing besides its name.
  *
- * Agents pinned to a machine do not block it joining — they come WITH it (§3): the control plane
- * stops each on that machine and re-places it on the group in one step, and the machine claims them
- * back as a member. So the row says what will happen rather than refusing. Leaving is the asymmetric
- * one, refused while the machine still holds live work; that lives on the daemon's own page next to
- * the drain state. Each membership write is applied on its own, so one refusal reports itself and
- * leaves the rest of the edit intact.
+ * Agents pinned to a machine neither block the join nor move (§3): a pin narrows to exactly one
+ * machine, so joining changes how it holds them — a duty lease nothing else may take — not who
+ * serves them. Leaving is the asymmetric one, refused while the machine still holds live work; that
+ * lives on the daemon's own page next to the drain state. Each membership write is applied on its
+ * own, so one refusal reports itself and leaves the rest of the edit intact.
  */
 export default function GroupModal({ group, onClose }: { group?: MemberSetRow; onClose: () => void }) {
   const { createGroup, renameGroup, enrollInGroup, withdrawFromGroup, daemons, agents } = useConsoleData()
@@ -26,14 +25,6 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
   const [members, setMembers] = useState<string[]>(group?.memberDaemonIds ?? [])
   const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
-  // The ONE machine that could not confirm it stopped its agents. The operator's assertion is
-  // about that machine, so it is carried per daemon: forcing A must never wave B through a failure
-  // nobody was shown. Null ⇒ nothing to force (§3).
-  const [forceDaemonId, setForceDaemonId] = useState<string | null>(null)
-  // The assertion itself, ticked separately from pressing the button (product-conventions.md, "Moving
-  // an agent from an unavailable daemon"): forcing is disaster recovery, and it is only safe because
-  // the operator states the machine can never come back.
-  const [forceConfirmed, setForceConfirmed] = useState(false)
   // A group created by a failed attempt. Names are not unique, so retrying without this would
   // create a second one and leave the first empty.
   const createdSetId = useRef<string | null>(null)
@@ -42,27 +33,17 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
   // A daemon the org owns is a candidate unless it is in a DIFFERENT group: a daemon is in at most
   // one, and moving it between groups is a two-phase transition, not a checkbox.
   const candidates = daemons.filter((d) => !d.pool && (!d.memberSetId || d.memberSetId === group?.setId))
-  const forcedDaemonName = daemons.find((d) => d.daemonId === forceDaemonId)?.name ?? 'the daemon'
   const pinnedCount = (daemon: DaemonRow) => agents.filter((a) => a.daemon === daemon.daemonId).length
 
-  const toggle = (daemonId: string) => {
-    // Editing the membership retracts a pending assertion: it was made about one machine in one
-    // plan, and this is a different plan.
-    setForceDaemonId(null)
-    setForceConfirmed(false)
+  const toggle = (daemonId: string) =>
     setMembers((current) =>
       current.includes(daemonId) ? current.filter((id) => id !== daemonId) : [...current, daemonId]
     )
-  }
 
-  /** `forcing` is the ONE machine the operator has just asserted is stopped, never a mode. */
-  const save = async (forcing: string | null = null) => {
+  const save = async () => {
     if (saving || !trimmed) return
-    if (forcing && !forceConfirmed) return
     setSaving(true)
     setErr(null)
-    setForceDaemonId(null)
-    setForceConfirmed(false)
     let daemonId: string | undefined
     try {
       // Reuse the group a previous attempt created: it exists, and a second one with the same name
@@ -71,19 +52,15 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
       if (group && trimmed !== group.name) await renameGroup(setId, trimmed)
       const before = new Set(group?.memberDaemonIds ?? [])
       const after = new Set(members)
-      // Each membership write is its own request with its own precondition, applied one at a time:
-      // a refusal names the machine that caused it, and every machine after it stays untouched
-      // rather than riding through on an assertion made about a different one.
-      for (daemonId of members.filter((id) => !before.has(id))) {
-        await enrollInGroup(setId, daemonId, daemonId === forcing ? { force: true } : {})
-      }
+      // Each membership write is its own request with its own precondition, applied one at a time,
+      // so a refusal names the machine that caused it and leaves the rest of the edit intact.
+      for (daemonId of members.filter((id) => !before.has(id))) await enrollInGroup(setId, daemonId)
       for (daemonId of [...before].filter((id) => !after.has(id))) await withdrawFromGroup(setId, daemonId)
       onClose()
     } catch (e) {
+      const name = daemons.find((d) => d.daemonId === daemonId)?.name
       const message = e instanceof Error ? e.message : String(e)
-      setErr(message)
-      // Offer the assertion only for the machine that actually failed to confirm.
-      if (daemonId && /permanently stopped/.test(message)) setForceDaemonId(daemonId)
+      setErr(name ? `${name}: ${message}` : message)
       setSaving(false)
     }
   }
@@ -123,10 +100,9 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
             <div className="overflow-hidden rounded-lg border border-(--border-subtle)">
               {candidates.map((daemon) => {
                 const checked = members.includes(daemon.daemonId)
-                const wasMember = group?.memberDaemonIds.includes(daemon.daemonId) ?? false
-                // What joining will DO to this machine's own agents — they move onto the group with
-                // it, which is the one consequence worth stating before the click.
-                const bringing = checked && !wasMember ? pinnedCount(daemon) : 0
+                // Its own agents stay its own — worth saying where there are any, because a group
+                // reads like a pool and the question "do I lose these?" is the one being asked.
+                const pinned = pinnedCount(daemon)
                 return (
                   <button
                     key={daemon.daemonId}
@@ -149,8 +125,8 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
                         {daemon.name}
                       </span>
                       <span className="block truncate font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-                        {bringing > 0
-                          ? `Its ${bringing} agent${bringing === 1 ? '' : 's'} move onto the group with it`
+                        {pinned > 0
+                          ? `Keeps its ${pinned} own agent${pinned === 1 ? '' : 's'}`
                           : daemon.status === 'online'
                             ? 'Online'
                             : 'Offline'}
@@ -172,35 +148,12 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
             {err}
           </div>
         )}
-        {forceDaemonId && (
-          <label className="mt-[10px] flex cursor-pointer items-start gap-2.5 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[10px]">
-            <input
-              type="checkbox"
-              className="mt-[2px] flex-none accent-(--brand)"
-              checked={forceConfirmed}
-              onChange={(e) => setForceConfirmed(e.target.checked)}
-            />
-            <span className="font-sans text-[12px] font-normal leading-[1.5] text-(--text-secondary)">
-              I confirm that <span className="font-semibold text-(--text-primary)">{forcedDaemonName}</span> is
-              permanently stopped and cannot reconnect. If it is still running, both copies may process messages.
-            </span>
-          </label>
-        )}
       </div>
       <div className="modalfoot">
         <div className="flex-1" />
         <Button variant="ghost" onClick={onClose}>
           Cancel
         </Button>
-        {forceDaemonId && (
-          <Button
-            variant="danger"
-            onClick={() => void save(forceDaemonId)}
-            className={!saving && forceConfirmed ? undefined : 'cursor-default opacity-50'}
-          >
-            Force join
-          </Button>
-        )}
         <Button onClick={() => void save()} className={!saving && trimmed ? undefined : 'cursor-default opacity-50'}>
           {saving ? 'Saving…' : group ? 'Save' : 'Create group'}
         </Button>

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.test.ts
@@ -101,9 +101,9 @@ describe('addAgentDaemonChoice', () => {
     ])
 
     expect(choice.availableGroups).toEqual([])
-    // A daemon in a group is served THROUGH the group: offering it alone would create an agent
-    // that machine may not serve (daemon-groups.md §3).
-    expect(choice.localDaemons.map((d) => d.daemonId)).toEqual(['local-1'])
+    // Its member is still offered on its own: pinning to a machine in a group is legal, and the
+    // group being unserved is exactly when naming the machine is the useful choice.
+    expect(choice.localDaemons.map((d) => d.daemonId).sort()).toEqual(['g-offline', 'local-1'])
     expect(choice.placement).toEqual({ kind: 'daemon', daemonId: 'local-1' })
   })
 

--- a/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/add-agent-daemon-choice.ts
@@ -34,9 +34,10 @@ export function addAgentDaemonChoice<T extends DaemonChoiceRow>(
   groups: readonly MemberSetRow[] = []
 ): AddAgentDaemonChoice<T> {
   const poolDaemons = daemons.filter((daemon) => daemon.pool && daemon.status === 'online')
-  // A daemon in a group is served THROUGH the group, so offering it as its own target would
-  // create an agent the machine may not serve (daemon-groups.md §3).
-  const localDaemons = onlineFirst(daemons.filter((daemon) => !daemon.pool && !daemon.memberSetId))
+  // Group membership does not disqualify a machine as a target: a `daemon` placement is eligible
+  // for exactly that machine either way, so it stays the agent's only holder (daemon-groups.md §3).
+  // Only Cloud members are excluded, and above — a pool Pod is a replaceable identity to pin to.
+  const localDaemons = onlineFirst(daemons.filter((daemon) => !daemon.pool))
   const liveMemberOf = (group: MemberSetRow): T | undefined =>
     daemons.find((daemon) => daemon.status === 'online' && group.memberDaemonIds.includes(daemon.daemonId))
   // Every group is OFFERED; only a serving one is selectable. Hiding an empty group answered the

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
@@ -80,21 +80,11 @@ describe('editAgentDaemonChoices', () => {
     expect(choices.localChoices.map((choice) => choice.daemonId)).toEqual(['local-ready', 'local-offline', 'local-old'])
   })
 
-  it('drops a daemon that is in a group — it is served through the group, not on its own', () => {
-    // Submitting one would be a `daemon` placement the control plane refuses (daemon-groups.md §3).
+  it('offers a daemon that is in a group — membership does not disqualify it as a target', () => {
+    // A `daemon` placement is eligible for exactly that machine either way, so it stays the only
+    // holder whether or not it has joined one (daemon-groups.md §3).
     const choices = editAgentDaemonChoices([row('grouped', false, 'online', true, 'set-1'), row('free')], '', '')
 
-    expect(choices.localChoices.map((d) => d.daemonId)).toEqual(['free'])
-  })
-
-  it('keeps the agent’s CURRENT machine listed even if it has since joined a group', () => {
-    // An option naming where the agent already is cannot be a placement the server refused.
-    const choices = editAgentDaemonChoices(
-      [row('grouped', false, 'online', true, 'set-1'), row('free')],
-      'grouped',
-      'grouped'
-    )
-
-    expect(choices.localChoices.map((d) => d.daemonId)).toContain('grouped')
+    expect(choices.localChoices.map((d) => d.daemonId).sort()).toEqual(['free', 'grouped'])
   })
 })

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
@@ -32,13 +32,10 @@ export function editAgentDaemonChoices<T extends DaemonChoiceRow>(
     (initial?.pool ? initial : undefined) ??
     poolMembers.find(moveReady) ??
     poolMembers[0]
-  // A daemon in a group is served THROUGH the group (daemon-groups.md §3), so it is not a target
-  // of its own: submitting one is a `daemon` placement the control plane refuses. The agent's
-  // CURRENT machine stays listed regardless — an option that names where the agent already is can
-  // never be a placement the server has not already accepted.
-  const localChoices = daemons.filter(
-    (daemon) => !daemon.pool && (!daemon.memberSetId || daemon.daemonId === initialDaemonId)
-  )
+  // Group membership does not disqualify a machine as a target: a `daemon` placement is eligible
+  // for exactly that machine either way (daemon-groups.md §3). Only Cloud members are excluded,
+  // and above — a pool Pod is a replaceable identity to pin to.
+  const localChoices = daemons.filter((daemon) => !daemon.pool)
   localChoices.sort((a, b) => Number(moveReady(b)) - Number(moveReady(a)))
   return {
     poolChoice,

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -843,8 +843,9 @@ function GroupCard({ daemon, pinnedAgents }: { daemon: DaemonRow; pinnedAgents: 
   if (daemon.pool || !experimentEnabled('daemon-groups')) return null
 
   const current = memberSets.find((group) => group.setId === daemon.memberSetId)
-  const blockedReason =
-    !current && pinnedAgents > 0 ? `${pinnedAgents} agent${pinnedAgents === 1 ? '' : 's'} placed here` : null
+  // Agents pinned here are not in the way of joining and do not move with it — they stay pinned to
+  // this machine, which remains their only eligible holder (daemon-groups.md §3).
+  const keeps = !current && pinnedAgents > 0 ? `${pinnedAgents} agent${pinnedAgents === 1 ? '' : 's'}` : null
 
   const run = async (fn: () => Promise<void>) => {
     setBusy(true)
@@ -893,7 +894,7 @@ function GroupCard({ daemon, pinnedAgents }: { daemon: DaemonRow; pinnedAgents: 
                 variant="secondary"
                 size="sm"
                 onClick={() => void run(() => enrollInGroup(group.setId, daemon.daemonId))}
-                className={busy || blockedReason ? 'cursor-default opacity-50' : undefined}
+                className={busy ? 'cursor-default opacity-50' : undefined}
               >
                 <Icon name="boxes" size={14} />
                 Join {group.name}
@@ -901,10 +902,10 @@ function GroupCard({ daemon, pinnedAgents }: { daemon: DaemonRow; pinnedAgents: 
             ))
           )}
         </div>
-        {blockedReason && memberSets.length > 0 && (
+        {keeps && memberSets.length > 0 && (
           <p className="mt-[10px] font-sans text-[12px] font-normal leading-[1.55] text-(--text-tertiary)">
-            Move the {blockedReason} onto a group first: a group member serves only the work it is granted, so an agent
-            pinned to this machine would have nowhere to run the moment it joins.
+            Joining keeps the {keeps} pinned here — a pinned agent names one machine, so this one stays the only place
+            it runs. Place an agent on the group itself to let any member serve it.
           </p>
         )}
         {err && (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -4427,18 +4427,12 @@ export async function deleteMemberSet(setId: string): Promise<void> {
   await apiDelete<void>(`${orgBase()}/member-sets/${encodeURIComponent(setId)}`)
 }
 
-/** Enroll a daemon. Agents pinned to it come WITH it — the CP stops each on that machine and
- *  re-places it on the set in one step. 409 when the machine cannot confirm it stopped (retry
- *  online, or `force` on the operator's assertion that it is permanently stopped), or when it is
+/** Enroll a daemon. Agents pinned to it stay pinned and keep running — a pin narrows to exactly
+ *  one machine, so joining changes how it holds them, not who serves them. 409 only when it is
  *  already in another set. */
-export async function enrollDaemonInMemberSet(
-  setId: string,
-  daemonId: string,
-  options: { force?: boolean } = {}
-): Promise<MemberSetDto> {
-  const query = options.force ? '?force=true' : ''
+export async function enrollDaemonInMemberSet(setId: string, daemonId: string): Promise<MemberSetDto> {
   return apiPut<MemberSetDto>(
-    `${orgBase()}/member-sets/${encodeURIComponent(setId)}/members/${encodeURIComponent(daemonId)}${query}`
+    `${orgBase()}/member-sets/${encodeURIComponent(setId)}/members/${encodeURIComponent(daemonId)}`
   )
 }
 

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -175,7 +175,7 @@ interface ConsoleData {
   deleteGroup: (setId: string) => Promise<void>
   /** Enroll a daemon — agents pinned to it move onto the group with it. 409 when the machine
    *  cannot confirm it stopped them; `force` commits on the operator's assertion that it is. */
-  enrollInGroup: (setId: string, daemonId: string, options?: { force?: boolean }) => Promise<void>
+  enrollInGroup: (setId: string, daemonId: string) => Promise<void>
   /** Withdraw a daemon (409 while it holds a live duty lease — drain it first). */
   withdrawFromGroup: (setId: string, daemonId: string) => Promise<void>
   /** Whether the open-connector integration is configured on the CP (gates the
@@ -1266,8 +1266,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   )
 
   const enrollInGroup = useCallback(
-    async (setId: string, daemonId: string, options: { force?: boolean } = {}) => {
-      await enrollDaemonInMemberSet(setId, daemonId, options)
+    async (setId: string, daemonId: string) => {
+      await enrollDaemonInMemberSet(setId, daemonId)
       settleGroupWrite()
     },
     [settleGroupWrite]


### PR DESCRIPTION
Reverses the core of #1130.

## The premise was wrong

#1130 made joining a group stop every agent pinned to the machine and re-place it
onto the group, on the reasoning that a machine which enforces duties serves only
what it holds a lease for — so a pinned agent would be placed and unservable the
moment the membership row landed.

The ledger does not say that. `eligibleAgent` in `duty-group.repo.ts`:

```sql
CASE agent."placementKind"
  WHEN 'set' THEN EXISTS (… member_set_member ms WHERE ms."setId"=agent."setId" AND ms."daemonId"=holder)
  ELSE agent."daemonId" IS NOT NULL AND agent."daemonId" = holder
END
```

A `daemon` placement has **no membership term**. Joining a group does not widen who
may hold a pinned agent — that machine stays the only one that may. It enforces
duties now, so it serves them through a lease rather than outright, and that lease
is one no peer can take (`daemonId = holder` fails for every sibling).

So the join is one membership row plus the scope update the daemon already gets on
its `1012` reconnect. Nothing is stopped, no turns are cancelled, and there is no
force path or split-brain to warn about.

## What that removes

- `AgentMoveService.enrollInSet` and its `memberSetWrites` dep
- `MemberSetRepo.enrollWithPlacedAgents`
- the `force` query switch on the enrolment route, and the modal's force-confirm UI
- the `DaemonHasPlacedAgents` refusal from `enrollOperator`

Net −277 lines.

## The converse, and the one refusal that survives

The same predicate says an agent **may** be pinned to a machine that is in an
organization's group, so `assertDaemonNotInSet` no longer refuses that. It still
refuses a pin to an install-wide **pool** member, for a reason that was always the
real one: a pool member is a Pod the reconciler retires without notice, so a pin to
it names something that stops existing. Replaceability, not membership.

## Tests

Rewritten around the corrected rule rather than deleted:

- a machine with two pinned agents joins → both stay `daemon`-placed on it, and
  `claimAgentHome` grants it their duty
- a **peer** member is refused that duty — the half that makes keeping the pin safe
- a pin racing an org-group enrolment: both now commit, and the machine can hold the
  result. The same race against a **pool** enrolment still serializes.
- the route test asserts the set's `agentCount` stays 0: the agent is on a machine
  that happens to be a member, not on the group

1,755 unit / 1,422 integration / 1,581 web all pass; lint and format clean.

`docs/designs/daemon-groups.md` §3 records the correction rather than being quietly
rewritten — the old reasoning is stated and marked wrong, so the next reader does not
re-derive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
