### PR TITLE
refactor(daemon): extract command execution into commands/handlers.ts

### DIFF
--- a/packages/daemon/src/commands/handlers.ts
+++ b/packages/daemon/src/commands/handlers.ts
@@ -1,0 +1,864 @@
+/**
+ * The daemon-side COMMAND EXECUTION layer: everything that happens AFTER
+ * `parseCommand` recognizes an in-conversation control command (`!stop` `!cancel`
+ * `!resume` `!queue` `/status` `/fast` `/models` `/effort` `/permission`), plus the
+ * other chat-side session controls that share its cores — the Slack status-bar
+ * interaction, the Discord select card, the Telegram callback tap, and the by-key
+ * model / effort / permission / fast / output setters the webchat frames drive.
+ *
+ * The parser stays in `./commands.js` and the select projections in
+ * `./select-projection.js`; this module is the stateful half that pairs with them.
+ * It owns no daemon state — every read and every single-point write goes through
+ * {@link CommandHost} — and the Daemon keeps thin same-name delegates for the
+ * ingress paths (and the tests) that already call these by name.
+ */
+import type { AcpHost } from '../acp/acp-host.js'
+import { permissionPresetSettings } from '../acp/permission-modes.js'
+import { applySelect, selectCardText, selectDisplay, selectLabel, selectOptions } from './select-projection.js'
+import type { SelectSetters } from './select-projection.js'
+import type { AgentCommand } from './commands.js'
+import type { Logger } from '../log.js'
+import type { LoadedAgent } from '../agents/load-agents.js'
+import type { NormalizedMessage } from '../messages/normalized.js'
+import { routeRules, type RouteVia } from '../router/routing-table.js'
+import { conversationAdmitted, integrationRouting, type RoutingRule } from '../router/routing-rule.js'
+import { sessionKey, type LocalStore, type SessionRecord } from '../store/local-store.js'
+import { CommandChromeRegistry, type SelectKind } from '../platforms/command-chrome.js'
+import { loopGuardScopesFor } from '../platforms/loop-guard.js'
+import { loopGuardScope, loopGuardScopeFromCoords } from '../daemon/loop-guard-scope.js'
+import type { PlatformConnection } from '../platforms/connection-reconciler.js'
+import { parseTelegramSelect, telegramSelectButtons } from '../platforms/telegram/command-chrome.js'
+import type { TelegramCallback, TelegramConnection } from '../telegram/connection.js'
+import type { InteractionActor } from '../slack/connection.js'
+import type { StatusBarInfo } from '../slack/render.js'
+import { buildDiscordSelectComponents, type DiscordComponents } from '../discord/render.js'
+import { MAX_QUEUED_PER_SESSION } from '../daemon/constants.js'
+import {
+  pendingTurnKey,
+  QueueFullError,
+  type Pending,
+  type QueueEntry,
+  type TurnInterruptReason
+} from '../daemon/turn-types.js'
+
+/** Exactly what command execution touches on the Daemon — reads plus single-point writes. */
+export interface CommandHost {
+  log(): Logger
+  store(): LocalStore
+  /** The served agent roster; commands read integrations, admission and chat authority off it. */
+  agents(): ReadonlyMap<string, LoadedAgent>
+  /** Live turns keyed by (agentId, acpSessionId) — read for the status bar and loop-guard state. */
+  pending(): ReadonlyMap<string, Pending>
+  /** Session keys a turn currently owns, and the per-key queue behind them. */
+  inflight(): ReadonlySet<string>
+  serialQueue(): ReadonlyMap<string, QueueEntry[]>
+  /** The gate's currently admitted entry per session key — a cold turn owns its key here. */
+  activeGateEntries(): ReadonlyMap<string, QueueEntry>
+  /** The §7.4 per-platform command presentation surfaces (reply / status / select card). */
+  commandChrome(): CommandChromeRegistry<NormalizedMessage, StatusBarInfo>
+  /** True when this session runs on its own credential host rather than the shared static one. */
+  hasModelSessionHost(key: string): boolean
+  modelCrossesHostProvider(key: string, agentId: string, model: string): boolean
+  hostForStoredSession(agentId: string, acpSessionId: string): AcpHost | undefined
+  statusInfoFrom(agentId: string, sessionKey: string, acpSessionId?: string): StatusBarInfo
+  emitStatusBar(p: Pending): void
+  interruptTurn(agentId: string, key: string, reason: TurnInterruptReason, acpSessionId?: string): void
+  /** `!queue` admission through the unified per-sessionKey gate — it decides run-now vs enqueue. */
+  dispatchQueueCommand(agentId: string, msg: NormalizedMessage, integrationId: string): Promise<void>
+  replyConnFor(agentId: string, integrationId?: string): PlatformConnection | undefined
+  sessionLink(acpSessionId: string, source?: string): string
+  sessionLinkSource(platform: string, integrationId?: string): string | undefined
+  /** Thread affinity for the routing ladder a command reuses. */
+  threadOwner(channel: string, thread: string, transportScope?: string | null): string | null
+  mergedRulesForSource(srcIntegrationIds?: readonly string[]): RoutingRule[]
+  transportScopeForIntegrationIds(integrationIds?: readonly string[]): string | undefined
+  integrationBelongsToSource(integrationId: string, srcIntegrationIds?: readonly string[]): boolean
+  /** The integrations one live platform connection is bound to (a Telegram callback's source). */
+  srcIntegrationIds(conn: unknown): string[]
+  /** `!resume` re-arms this member's own loop-scope enforcement. */
+  clearEnforcedLoopScope(scope: string): void
+}
+
+export class CommandHandlers {
+  constructor(private readonly host: CommandHost) {}
+
+  /**
+   * Record who drove one chat-side session action. The platform interaction is the only
+   * place the acting user exists — the session key alone says what changed, never by whom —
+   * so it is logged at every funnel point. `unknown` when an ingress could not report an
+   * actor (today: relay-forwarded Slack actions, whose frame carries no user).
+   */
+  logSessionAction(verb: string, sessionKey: string, actor?: InteractionActor): void {
+    const who = actor ? `${actor.userId}${actor.isBot ? ' (bot)' : ''}` : 'unknown'
+    this.host.log().info(`session ${sessionKey}: "${verb}" by ${who}`)
+  }
+
+  /** Resolve a session only while its Agent explicitly permits chat-side runtime changes. */
+  chatRuntimeSession(key: string) {
+    const rec = this.host.store().getSession(key)
+    return rec && this.host.agents().get(rec.agentId)?.allowRuntimeChangesInChat === true ? rec : undefined
+  }
+
+  /** Switch a session's model by its local key — the core shared by the webchat
+   *  `set-model` frame and the Slack status-bar select. Records the sticky per-session
+   *  override (re-applied on every turn by dispatch) and, if the ACP session is warm,
+   *  applies it live now and re-pushes the status bar. Never changes the agent default. */
+  setModelByKey(key: string, model: string): boolean {
+    const rec = this.chatRuntimeSession(key)
+    if (!rec) return false
+    const crossProvider = this.host.modelCrossesHostProvider(key, rec.agentId, model)
+    // The shared static-credential host has no per-session restart to pick a new binding up,
+    // so a cross-provider pick there could never be credentialed — refuse it outright rather
+    // than storing an override that can only ever fail.
+    if (crossProvider && !this.host.hasModelSessionHost(key)) {
+      this.host.log().warn(`session ${key}: cross-provider model switch rejected — the static credential host is bound`)
+      return false
+    }
+    this.host.store().setModelOverride(key, model)
+    this.host.log().info(`session ${key} model override → "${model}"`)
+    // A running credential host keeps the provider it started with; the sticky override is
+    // what the next start reads, so the switch lands there instead of live.
+    if (crossProvider) {
+      this.host.log().info(`session ${key}: provider change applies when its credential host next starts`)
+      return true
+    }
+    const acpSessionId = rec.acpSessionId
+    const host = acpSessionId ? this.host.hostForStoredSession(rec.agentId, acpSessionId) : undefined
+    if (!acpSessionId || !host?.hasSession(acpSessionId)) return true // no live session — applies next turn
+    void host
+      .setSessionModel(acpSessionId, model)
+      .then((applied) => {
+        const p = this.host.pending().get(pendingTurnKey(rec.agentId, acpSessionId))
+        if (applied && p) this.host.emitStatusBar(p) // reflect the new model on the status bar
+      })
+      .catch((err) => this.host.log().warn(`set-model failed: ${(err as Error).message}`))
+    return true
+  }
+
+  /** Cancel the in-flight turn for a local session key — the `!cancel` core (interrupt,
+   *  NO mute) shared by the Slack status-bar Cancel button. No-op if nothing is running. */
+  cancelSessionByKey(key: string): boolean {
+    const rec = this.host.store().getSession(key)
+    // Cancel a gate-owned/queued session even if it has no live ACP turn yet (§6.9 #390):
+    // interruptTurn drains the queue by key and cancels the ACP turn only if one exists.
+    if (!this.host.inflight().has(key)) return false
+    const agentId = rec?.agentId ?? this.host.serialQueue().get(key)?.[0]?.agentId
+    if (!agentId) return false
+    this.host.interruptTurn(agentId, key, 'cancel', rec?.acpSessionId ?? undefined)
+    return true // reports whether a turn was actually interrupted (nothing else reads it)
+  }
+
+  /** Switch a session's reasoning effort by its local key — the effort counterpart of
+   *  {@link setModelByKey}. Records the sticky override and, if the ACP session is warm,
+   *  applies it live via the `thought_level` select. `ultracode` can't ride the select
+   *  (setSessionEffort returns false); it's honored via session `_meta` when the session
+   *  is next (re)created or resumed, and the override still shows on the bar meanwhile. */
+  setEffortByKey(key: string, effort: string): boolean {
+    const rec = this.chatRuntimeSession(key)
+    if (!rec) return false
+    this.host.store().setEffortOverride(key, effort)
+    this.host.log().info(`session ${key} effort override → "${effort}"`)
+    const acpSessionId = rec.acpSessionId
+    const host = acpSessionId ? this.host.hostForStoredSession(rec.agentId, acpSessionId) : undefined
+    if (!acpSessionId || !host?.hasSession(acpSessionId)) {
+      this.refreshStatusBarForKey(key)
+      return true
+    }
+    void host
+      .setSessionEffort(acpSessionId, effort)
+      .then(() => this.refreshStatusBarForKey(key))
+      .catch((err) => this.host.log().warn(`set-effort failed: ${(err as Error).message}`))
+    return true
+  }
+
+  /** Apply one composite session permission value to a warm host. Older injected host
+   * fakes retain the two-setter fallback; real AcpHosts own the validation/decomposition. */
+  async applySessionPermissionPreset(host: AcpHost, sessionId: string, preset: string): Promise<void> {
+    if (typeof host.setSessionPermissionPreset === 'function') {
+      await host.setSessionPermissionPreset(sessionId, preset)
+      return
+    }
+    const settings = permissionPresetSettings(preset)
+    if (settings.approvalsReviewer === 'user' && typeof host.setSessionApprovalsReviewer === 'function') {
+      await host.setSessionApprovalsReviewer(sessionId, 'user')
+    }
+    await host.setSessionPermissionMode(sessionId, settings.permissionMode)
+    if (settings.approvalsReviewer === 'auto_review' && typeof host.setSessionApprovalsReviewer === 'function') {
+      await host.setSessionApprovalsReviewer(sessionId, 'auto_review')
+    }
+  }
+
+  /** Every chat-side permission-preset change funnels through the same Agent-level
+   * guard before a sticky override can be written, including stale callbacks and
+   * relay frames. */
+  setPermissionModeByKey(key: string, permissionPreset: string): boolean {
+    const rec = this.chatRuntimeSession(key)
+    if (!rec) return false
+    this.host.store().setPermissionModeOverride(key, permissionPreset)
+    this.host.log().info(`session ${key} permission preset override → "${permissionPreset}"`)
+    const acpSessionId = rec.acpSessionId
+    const host = acpSessionId ? this.host.hostForStoredSession(rec.agentId, acpSessionId) : undefined
+    if (!acpSessionId || !host?.hasSession(acpSessionId)) {
+      this.refreshStatusBarForKey(key)
+      return true
+    }
+    void this.applySessionPermissionPreset(host, acpSessionId, permissionPreset)
+      .then(() => this.refreshStatusBarForKey(key))
+      .catch((err) => this.host.log().warn(`set-permission-preset failed: ${(err as Error).message}`))
+    return true
+  }
+
+  /** Toggle a session's fast mode by its local key — the fast-mode counterpart of
+   *  {@link setModelByKey}. Records the sticky override and applies it live when the
+   *  current model offers a fast toggle. */
+  setFastByKey(key: string, fastMode: boolean): boolean {
+    const rec = this.chatRuntimeSession(key)
+    if (!rec) return false
+    this.host.store().setFastModeOverride(key, fastMode)
+    this.host.log().info(`session ${key} fast-mode override → ${fastMode}`)
+    const acpSessionId = rec.acpSessionId
+    const host = acpSessionId ? this.host.hostForStoredSession(rec.agentId, acpSessionId) : undefined
+    if (!acpSessionId || !host?.hasSession(acpSessionId)) {
+      this.refreshStatusBarForKey(key)
+      return true
+    }
+    void host
+      .setSessionFastMode(acpSessionId, fastMode)
+      .then(() => this.refreshStatusBarForKey(key))
+      .catch((err) => this.host.log().warn(`set-fast failed: ${(err as Error).message}`))
+    return true
+  }
+
+  /** Re-emit the status bar for a session's in-flight turn (if any) so a config change
+   *  (model / effort / fast) is reflected. No-op when the session is idle. */
+  refreshStatusBarForKey(key: string): void {
+    const rec = this.host.store().getSession(key)
+    const p = rec?.acpSessionId ? this.host.pending().get(pendingTurnKey(rec.agentId, rec.acpSessionId)) : undefined
+    if (p) this.host.emitStatusBar(p)
+  }
+
+  /** Set a session's Slack output verbosity by its local key. Purely daemon-side (no ACP):
+   *  the next turn's OutputConverger reads this override, so an in-flight turn keeps its
+   *  current verbosity and the change takes effect from the next turn. */
+  setOutputModeByKey(key: string, mode: 'none' | 'minimal' | 'low' | 'medium' | 'high'): boolean {
+    if (!this.host.store().getSession(key)) return false
+    this.host.store().setOutputModeOverride(key, mode)
+    this.host.log().info(`session ${key} output-mode override → "${mode}"`)
+    this.refreshStatusBarForKey(key)
+    return true // reports whether the override was recorded (nothing else reads it)
+  }
+  /** Route a Slack status-bar Block Kit interaction (model / effort / fast select or the
+   *  Cancel button) to the shared key-based cores. `sessionKey` rides the block; no-op on
+   *  an unknown key. */
+  handleStatusAction(a: {
+    kind: 'set-model' | 'set-effort' | 'set-permission-mode' | 'set-fast' | 'set-output' | 'cancel'
+    sessionKey: string
+    actor?: InteractionActor
+    model?: string
+    effort?: string
+    permissionMode?: string
+    fastMode?: boolean
+    outputMode?: 'none' | 'minimal' | 'low' | 'medium' | 'high'
+  }): void {
+    // A status-bar tap carries no author in the transcript, so the operator behind a
+    // cancelled turn or a switched model is otherwise unrecoverable. Record it here,
+    // at the one point every ingress funnels through — but only when the verb actually
+    // applied, so a refused or no-op click never reads as a change someone made.
+    let applied = false
+    if (a.kind === 'cancel') applied = this.cancelSessionByKey(a.sessionKey)
+    else if (a.kind === 'set-model') {
+      if (a.model) applied = this.setModelByKey(a.sessionKey, a.model)
+    } else if (a.kind === 'set-effort') {
+      if (a.effort) applied = this.setEffortByKey(a.sessionKey, a.effort)
+    } else if (a.kind === 'set-permission-mode') {
+      if (a.permissionMode) applied = this.setPermissionModeByKey(a.sessionKey, a.permissionMode)
+    } else if (a.kind === 'set-fast') {
+      if (a.fastMode !== undefined) applied = this.setFastByKey(a.sessionKey, a.fastMode)
+    } else if (a.kind === 'set-output') {
+      if (a.outputMode) applied = this.setOutputModeByKey(a.sessionKey, a.outputMode)
+    }
+    if (applied) this.logSessionAction(a.kind, a.sessionKey, a.actor)
+  }
+
+  /**
+   * A tapped Discord select-card button (`/models` `/effort` `/permission`): resolve the
+   * session from the button's key, apply the chosen option, and return the re-rendered
+   * card so the connection edits the message in place (new current flagged). Undefined
+   * when the session is gone or the option index is stale (options changed) — the
+   * connection then leaves the card as-is. Mirrors handleTelegramCallback.
+   */
+  handleDiscordSelect(a: {
+    kind: SelectKind
+    index: number
+    sessionKey: string
+    actor?: InteractionActor
+  }): { text: string; components: DiscordComponents } | undefined {
+    const rec = this.host.store().getSession(a.sessionKey)
+    if (!rec) return undefined
+    const info = this.host.statusInfoFrom(rec.agentId, a.sessionKey, rec.acpSessionId ?? undefined)
+    const { options } = selectOptions(a.kind, info)
+    const value = options[a.index]
+    if (value === undefined) return undefined
+    // Recorded only once the choice actually applied — a refused or stale select
+    // changes nothing and must not read as though someone had changed it. The card is
+    // still re-rendered either way, as before.
+    if (applySelect(a.kind, a.sessionKey, value, this.selectSetters))
+      this.logSessionAction(`select:${a.kind}`, a.sessionKey, a.actor)
+    const components = buildDiscordSelectComponents(a.kind, value, options)
+    if (!components) return undefined
+    return { text: selectCardText(a.kind, value), components }
+  }
+  isSessionMuted(key: string): boolean {
+    return this.host.store().isSessionMuted(key)
+  }
+
+  setSessionMuted(key: string, muted: boolean): void {
+    this.host.store().setSessionMuted(key, muted)
+  }
+
+  /**
+   * Resolve a command's target from the channel's latest session when the routing ladder
+   * couldn't (no mention entity / thread / dm rule matched — e.g. a group `/status@bot`).
+   * Picks the agent that owns the most-recent session in the channel and its integration
+   * for this platform while preserving the conversation gate that routing would have
+   * applied. Null when there's no session, no matching integration, or the conversation
+   * is not admitted.
+   */
+  resolveCommandTargetFromLatest(
+    msg: NormalizedMessage,
+    srcIntegrationIds?: readonly string[]
+  ): { agentId: string; integrationId: string; via: RouteVia } | null {
+    const transportScope = msg.transportScope ?? this.host.transportScopeForIntegrationIds(srcIntegrationIds)
+    // Only where the thread coordinate identifies the session (Slack/Discord) does it
+    // participate in the lookup; reply-threading platforms mint a fresh thread per
+    // command, so their commands resolve through the channel's latest session.
+    const thread = this.host.commandChrome().threadIdentifiesSession(msg.platform) ? msg.thread : undefined
+    const candidates: Array<{
+      agentId: string
+      integrationId: string
+      updatedAt: number
+    }> = []
+    for (const [agentId, agent] of this.host.agents()) {
+      for (const integration of agent.integrations) {
+        if (
+          integration.platform !== msg.platform ||
+          !this.host.integrationBelongsToSource(integration.id, srcIntegrationIds) ||
+          !this.commandSenderAllowed(agentId, integration.id, msg)
+        )
+          continue
+        const latest = this.host.store().latestSessionForTransport(agentId, msg.channel, transportScope, thread)
+        if (latest) candidates.push({ agentId, integrationId: integration.id, updatedAt: latest.updatedAt })
+      }
+    }
+    candidates.sort(
+      (a, b) =>
+        b.updatedAt - a.updatedAt ||
+        a.agentId.localeCompare(b.agentId) ||
+        a.integrationId.localeCompare(b.integrationId)
+    )
+    const latest = candidates[0]
+    return latest ? { agentId: latest.agentId, integrationId: latest.integrationId, via: 'thread' } : null
+  }
+
+  /** Validate the relay-arbitrated command target against the local agent spec. Shared
+   *  bot IMs bypass routeRules' arbitration, but must retain its bot rejection and
+   *  conversation admission before executing a control command. */
+  resolveExplicitCommandTarget(
+    agentId: string,
+    integrationId: string,
+    msg: NormalizedMessage
+  ): { agentId: string; integrationId: string; via: RouteVia } | null {
+    if (!this.commandSenderAllowed(agentId, integrationId, msg)) return null
+    return { agentId, integrationId, via: 'thread' }
+  }
+
+  /** Recovery path for a channel-wide Slack top-level loop latch. The triggering
+   *  message itself was rejected, so its warning thread may have no thread owner or
+   *  latest session to route a bare `!resume` through. Select only an integration
+   *  that admits this conversation, preferring an explicitly mentioned bot. */
+  resolveTopLevelResumeTarget(
+    msg: NormalizedMessage,
+    srcIntegrationIds?: readonly string[]
+  ): { agentId: string; integrationId: string; via: RouteVia } | null {
+    const coarseScope = loopGuardScopesFor(msg).coarse
+    if (!coarseScope || !this.host.store().isLoopGuardOpen(coarseScope)) return null
+    const candidates: Array<{
+      agentId: string
+      integrationId: string
+      via: RouteVia
+      mentioned: boolean
+    }> = []
+    for (const [agentId, agent] of this.host.agents()) {
+      for (const integration of agent.integrations) {
+        // Only reachable when the message's platform has a coarse loop-guard
+        // circuit (loopGuardScopesFor), so filtering by the MESSAGE's platform is
+        // the platform-neutral statement of the old `!== 'slack'` literal.
+        if (
+          integration.platform !== msg.platform ||
+          !this.host.integrationBelongsToSource(integration.id, srcIntegrationIds) ||
+          !this.commandSenderAllowed(agentId, integration.id, msg)
+        )
+          continue
+        const botUserId = integrationRouting(integration).staticBotUserId
+        const mentioned = botUserId !== undefined && msg.mentionedBots.includes(botUserId)
+        candidates.push({
+          agentId,
+          integrationId: integration.id,
+          via: mentioned ? 'mention' : 'auto',
+          mentioned
+        })
+      }
+    }
+    candidates.sort(
+      (a, b) =>
+        Number(b.mentioned) - Number(a.mentioned) ||
+        a.agentId.localeCompare(b.agentId) ||
+        a.integrationId.localeCompare(b.integrationId)
+    )
+    return candidates[0] ?? null
+  }
+
+  /** Final command admission at the concrete integration. Commands that resolve their
+   *  target outside the routing ladder still repeat bot rejection and conversation gating. */
+  commandSenderAllowed(agentId: string, integrationId: string, msg: NormalizedMessage): boolean {
+    if (msg.sender.isBot) return false
+    const integration = this.host
+      .agents()
+      .get(agentId)
+      ?.integrations.find((candidate) => candidate.id === integrationId && candidate.platform === msg.platform)
+    if (!integration) return false
+    const routing = integrationRouting(integration)
+    // Control commands resolve their target OUTSIDE routeRules' scope filter (latest-
+    // session fallbacks), so they must repeat the admission check — a channel switched
+    // Off, or an Off conversation of a gated integration, takes no commands either.
+    return conversationAdmitted(routing, msg.channel)
+  }
+
+  /**
+   * Handle an in-conversation control command. Resolves the target agent via the
+   * same routing ladder as a normal message (so thread affinity and conversation
+   * admission apply), then acts on that agent's session in this
+   * (channel, thread).
+   */
+  handleCommand(
+    command: AgentCommand,
+    msg: NormalizedMessage,
+    explicitTarget?: { agentId: string; integrationId: string; via: RouteVia },
+    srcIntegrationIds?: readonly string[]
+  ): boolean {
+    let target =
+      explicitTarget ??
+      routeRules(msg, this.host.mergedRulesForSource(srcIntegrationIds), (c, t) =>
+        this.host.threadOwner(c, t, msg.transportScope)
+      )
+    if (!target) {
+      // Routing found no agent — the common group case: a bare `/status@bot` carries no
+      // mention entity, no reply, and its fresh thread has no session. Resolve the agent
+      // from the channel's latest session so the command still lands on it (subject to
+      // that agent's conversation admission).
+      target = this.resolveCommandTargetFromLatest(msg, srcIntegrationIds)
+    }
+    if (!target && command.kind === 'resume') target = this.resolveTopLevelResumeTarget(msg, srcIntegrationIds)
+    if (!target) {
+      this.host.log().debug(`command: '${command.kind}' in ch=${msg.channel} — no agent resolved, ignoring`)
+      return false
+    }
+    if (!this.commandSenderAllowed(target.agentId, target.integrationId, msg)) {
+      this.host.log().warn(`command: '${command.kind}' rejected for unauthorized sender ${msg.sender.id}`)
+      return false
+    }
+    const conn = this.host.replyConnFor(target.agentId, target.integrationId)
+    // Where the command was sent — the reply lands here (Slack thread_ts; Telegram
+    // replies to the command message via its chrome surface's reply anchor). Kept separate from the session the
+    // command ACTS on, resolved just below.
+    const replyThread = msg.thread ?? msg.msgId
+    // Resolve the session the command acts on. A command that isn't in a session's own
+    // thread — notably ANY bare Telegram command, which keys to its own fresh reply
+    // thread — falls back to the agent's latest session in this channel, so /stop
+    // /cancel /status /fast /models /effort /permission /queue all operate on it rather
+    // than on a phantom empty thread. `thread`/`key` follow the resolved session so a
+    // `/queue` dispatch continues it and the sticky overrides land on the right key.
+    let thread = replyThread
+    let key = sessionKey(msg.platform, msg.channel, thread, target.agentId, msg.transportScope)
+    let rec = this.host.store().getSession(key)
+    // A cold turn owns its logical key before SessionManager persists the session row.
+    // Prefer that exact live gate over the channel's latest historical session; otherwise
+    // a `!stop` sent in the cold thread can mute/cancel an older thread and leave the
+    // actual turn running. Check all gate representations because commands can race the
+    // short hand-offs between them.
+    const gateActiveFor = (candidateKey: string): boolean =>
+      this.host.activeGateEntries().has(candidateKey) || (this.host.serialQueue().get(candidateKey)?.length ?? 0) > 0
+    let directGateActive = gateActiveFor(key)
+    if (!rec && !directGateActive) {
+      const latest = this.host.store().latestSessionForTransport(target.agentId, msg.channel, msg.transportScope)
+      if (latest) {
+        rec = latest
+        key = latest.key
+        thread = latest.thread
+        directGateActive = gateActiveFor(key)
+      }
+    }
+    const acpSessionId = rec?.acpSessionId
+    // §6.9 #390: liveness is observed on the LOGICAL sessionKey gate (a turn currently
+    // owns the key), not just the ACP-id-keyed `pending` — so `!cancel`/`!stop`/`!queue`
+    // also see a session that is gate-owned or queued (cold session with no ACP id yet).
+    const inflight = directGateActive
+    // Post a short control reply on the platform's own surface (§7.4 command
+    // chrome): Slack threads on `thread_ts`; Telegram replies to the command
+    // message (reply-based threading), which is also a non-numeric `tg:`/`dm`
+    // thread so it never posts as a forum topic.
+    const chrome = this.host.commandChrome().for(msg.platform)
+    const chromeCtx = { channel: msg.channel, replyThread, sessionKey: key }
+    const reply = (text: string): void => {
+      if (!conn) return
+      chrome.reply(conn, msg, chromeCtx, text)
+    }
+
+    if (command.kind === 'resume') {
+      // Commands sent outside the session thread (notably bare Telegram commands)
+      // may have resolved `thread` through latestSession above. Reset the scope the
+      // command actually targets, not the fresh command-message thread.
+      const directScope =
+        thread === replyThread
+          ? loopGuardScope(msg)
+          : loopGuardScopeFromCoords(msg.platform, msg.channel, thread, msg.isDm, msg.transportScope)
+      const topLevelScope = loopGuardScopesFor(msg).coarse
+      // A top-level feedback loop posts its warning into the triggering root. A
+      // trusted !resume from that warning thread (or elsewhere in the channel)
+      // must reset the shared channel circuit, not a never-open per-thread key.
+      const scope = topLevelScope && this.host.store().isLoopGuardOpen(topLevelScope) ? topLevelScope : directScope
+      const stillStopping =
+        [...this.host.activeGateEntries().values()].some(
+          (entry) => entry.cancelledReason === 'loop protection' && loopGuardScope(entry.msg) === scope
+        ) ||
+        [...this.host.pending().values()].some((pending) => {
+          return pending.outputSuppressed === 'loop protection' && pending.loopGuardScope === scope
+        })
+      if (stillStopping) {
+        reply('Loop protection is still stopping the previous turn. Try `!resume` again in a moment.')
+        return true
+      }
+      const wasOpen = this.host.store().isLoopGuardOpen(scope)
+      this.host.store().resetLoopGuard(scope)
+      this.host.clearEnforcedLoopScope(scope)
+      const wasMuted = this.isSessionMuted(key)
+      if (wasMuted) this.setSessionMuted(key, false)
+      if (wasOpen || wasMuted) {
+        this.host.log().info(`loop guard: explicitly reset ${scope} by ${msg.sender.id}`)
+        reply('▶️ Resumed. Loop protection is reset; send a new message to continue.')
+      } else {
+        reply('Loop protection is not active in this conversation.')
+      }
+      return true
+    }
+
+    if (command.kind === 'stop') {
+      // Mute the session's thread whether or not a turn is in flight: `!stop` is an
+      // explicit stand-down — implicit routing (thread affinity / keyword / auto)
+      // stays off until the user @mentions the agent again (onInbound clears it).
+      if (rec || inflight) this.setSessionMuted(key, true)
+      const muteNote = 'Muted in this thread — @mention me to resume.'
+      if (!inflight) {
+        reply(rec ? `🔇 Nothing is running. ${muteNote}` : 'Nothing is running to stop.')
+        return true
+      }
+      this.host.interruptTurn(target.agentId, key, 'stop', acpSessionId ?? undefined)
+      reply(`🛑 Stopped. ${muteNote}`)
+      return true
+    }
+
+    if (command.kind === 'cancel') {
+      // `!cancel` interrupts the in-flight turn but does NOT mute — the session stays
+      // live so a follow-up message dispatches normally. No-op (with a note) when idle.
+      if (!inflight) {
+        reply('Nothing is running to cancel.')
+        return true
+      }
+      this.host.interruptTurn(target.agentId, key, 'cancel', acpSessionId ?? undefined)
+      reply('🛑 Cancelled.')
+      return true
+    }
+
+    if (command.kind === 'status') {
+      // `/status` — the on-demand replacement for Telegram's (removed) status bar:
+      // reply with the session's model / context / tokens (the latest session in this
+      // channel, per the resolution above). No-op note when there's none.
+      if (!rec) {
+        reply('No active session here yet — send me a message to start one.')
+        return true
+      }
+      const info = this.host.statusInfoFrom(target.agentId, key, acpSessionId ?? undefined)
+      const link = acpSessionId
+        ? this.host.sessionLink(acpSessionId, this.host.sessionLinkSource(msg.platform, target.integrationId))
+        : undefined
+      // Presentation is the platform's (§7.4): HTML chrome + View link on Telegram,
+      // markdown + a real link button on Discord, plain text + a 🔗 line on Feishu,
+      // the compact pipe-linked status line on Slack.
+      if (conn) chrome.status(conn, msg, chromeCtx, info, link)
+      return true
+    }
+
+    if (
+      (command.kind === 'fast' ||
+        command.kind === 'model' ||
+        command.kind === 'effort' ||
+        command.kind === 'permission') &&
+      this.host.agents().get(target.agentId)?.allowRuntimeChangesInChat !== true
+    ) {
+      reply('Runtime settings can only be changed by an Agent editor from the Agent page.')
+      return true
+    }
+
+    if (command.kind === 'fast') {
+      // `/fast on|off` — toggle the session's fast mode (the control the status-bar
+      // Fast button used to offer). Records the sticky override + applies live if warm.
+      if (!rec) {
+        reply('No active session here to configure.')
+        return true
+      }
+      if (command.enable === null) {
+        reply('Usage: `/fast on` or `/fast off`.')
+        return true
+      }
+      this.setFastByKey(key, command.enable)
+      reply(command.enable ? '⚡ Fast mode on.' : '🐢 Fast mode off.')
+      return true
+    }
+
+    if (command.kind === 'model' || command.kind === 'effort' || command.kind === 'permission') {
+      // `/models`, `/effort`, `/permission` — on-demand session controls.
+      // Telegram status-bar dropdowns. A bare command renders a tappable card on Telegram
+      // AND Discord (numbered text list on Slack); an argument selects directly. Records
+      // the sticky per-session override + applies it live when the ACP session is warm.
+      if (!rec) {
+        reply('No active session here to configure.')
+        return true
+      }
+      // Platforms with tappable cards render one (§7.4), replied under the command;
+      // false falls back to the numbered text list (Slack, or a Discord select over
+      // its 25-button ceiling).
+      const selectCard = chrome.selectCard?.bind(chrome)
+      const renderCard =
+        selectCard && conn
+          ? (kind: SelectKind, current: string | undefined, options: string[]) =>
+              selectCard(conn, msg, chromeCtx, { kind, current, options, header: selectCardText(kind, current) })
+          : undefined
+      this.handleSelectCommand(
+        command.kind,
+        command.value,
+        target.agentId,
+        key,
+        acpSessionId ?? undefined,
+        reply,
+        renderCard
+      )
+      return true
+    }
+
+    // queue — now just admission through the UNIFIED per-sessionKey gate (§6.9 #390): the
+    // gate itself decides run-now vs enqueue-behind-the-turn; `!queue` only differs in the
+    // ACK wording and the queue_full reply. Depth cap + queue-full fast-fail live in the
+    // gate (dispatch → QueueFullError), so there is no second FIFO here anymore.
+    if (!command.text) {
+      reply('Usage: `!queue <message>` — runs when the current turn finishes.')
+      return true
+    }
+    // Dispatch/queue into the resolved session's thread (the fallback may have retargeted
+    // it from the bare command thread to the channel's latest session).
+    const payload: NormalizedMessage = { ...msg, text: command.text, thread }
+    // Reject fast (matching the old depth-cap ACK) before admitting so the user sees the
+    // "queue full" note rather than a silent drop; the gate would reject identically.
+    if (inflight && (this.host.serialQueue().get(key)?.length ?? 0) >= MAX_QUEUED_PER_SESSION) {
+      this.host.log().warn(`command: queue → agent "${target.agentId}" session ${key} full, rejected`)
+      reply(`Queue is full (${MAX_QUEUED_PER_SESSION} pending) — wait for the current turn to finish.`)
+      return true
+    }
+    void this.host.dispatchQueueCommand(target.agentId, payload, target.integrationId).catch((err) => {
+      if (err instanceof QueueFullError) return // already reported above; race-safe no-op
+      this.host.log().error(`queued dispatch failed for agent "${target.agentId}": ${(err as Error).stack ?? err}`)
+    })
+    if (!inflight) {
+      this.host.log().info(`command: queue → agent "${target.agentId}" idle, dispatching now`)
+      reply(`▶️ Running now — the session was idle.`)
+    } else {
+      const depth = this.host.serialQueue().get(key)?.length ?? 0
+      this.host.log().info(`command: queue → agent "${target.agentId}" session ${key} (depth ${depth})`)
+      reply(`📥 Queued (#${depth}) — will run when the current turn finishes.`)
+    }
+    return true
+  }
+
+  /** Sticky-override setters handed to the pure select projections. */
+  private readonly selectSetters: SelectSetters = {
+    model: (key, value) => this.setModelByKey(key, value),
+    effort: (key, value) => this.setEffortByKey(key, value),
+    permission: (key, value) => this.setPermissionModeByKey(key, value)
+  }
+
+  /**
+   * Back the `/models` `/effort` `/permission` commands. A bare command lists the current
+   * selectable values — as a tappable inline-keyboard card when `card` is provided
+   * (Telegram), else a numbered text list. An argument applies a choice, matched by exact
+   * id, unique case-insensitive substring, or 1-based list index. Options come from the
+   * live host's config selectors (statusInfoFrom); when the host is cold a given value is
+   * accepted optimistically and takes effect on the next turn.
+   */
+  handleSelectCommand(
+    kind: SelectKind,
+    value: string | null,
+    agentId: string,
+    key: string,
+    acpSessionId: string | undefined,
+    reply: (text: string) => void,
+    renderCard?: (kind: SelectKind, current: string | undefined, options: string[]) => boolean
+  ): void {
+    const label = selectLabel(kind)
+    const info = this.host.statusInfoFrom(agentId, key, acpSessionId)
+    const { current, options } = selectOptions(kind, info)
+    const cmd = kind === 'model' ? 'models' : kind
+
+    const disp = (v: string) => selectDisplay(kind, v)
+
+    if (value === null) {
+      if (options.length === 0) {
+        reply(
+          current
+            ? `${label}: ${disp(current)} (no other options offered${kind === 'effort' ? ' — the current model may not support effort' : ''}).`
+            : `No ${label.toLowerCase()} options available yet — send me a message first, then try /${cmd} again.`
+        )
+        return
+      }
+      // A tappable card (Telegram / Discord) when available; false ⇒ fall back to text.
+      if (renderCard?.(kind, current, options)) return
+      const lines = options.map((o, i) => `${i + 1}. ${disp(o)}${o === current ? '  ✓ (current)' : ''}`)
+      reply(`${label} — reply \`/${cmd} <name or number>\`:\n${lines.join('\n')}`)
+      return
+    }
+
+    // Resolve the chosen value against the offered options (when we have them). Match
+    // the raw value OR its display label, so `/permission full access` resolves too.
+    let resolved: string | undefined
+    if (options.length === 0) {
+      resolved = value.trim() // host cold — accept optimistically, applies next turn
+    } else {
+      const v = value.trim()
+      const idx = Number(v)
+      if (Number.isInteger(idx) && idx >= 1 && idx <= options.length) resolved = options[idx - 1]
+      else {
+        const lc = v.toLowerCase()
+        const exact = (o: string) => o.toLowerCase() === lc || disp(o).toLowerCase() === lc
+        const partial = (o: string) => o.toLowerCase().includes(lc) || disp(o).toLowerCase().includes(lc)
+        resolved = options.find(exact) ?? (options.filter(partial).length === 1 ? options.find(partial) : undefined)
+      }
+    }
+    if (!resolved) {
+      reply(
+        `Unknown ${label.toLowerCase()} "${value.trim()}".${options.length ? ` Options: ${options.map(disp).join(', ')}` : ''}`
+      )
+      return
+    }
+    if (!applySelect(kind, key, resolved, this.selectSetters)) {
+      reply('Runtime settings can only be changed by an Agent editor from the Agent page.')
+      return
+    }
+    reply(
+      options.length === 0
+        ? `${label} set to ${disp(resolved)} — applies on your next message.`
+        : `✅ ${label} set to ${disp(resolved)}.`
+    )
+  }
+
+  /**
+   * Handle a tapped session-control card button (Telegram inline keyboard). Decodes
+   * `<kindCode>:<optionIndex>`, resolves the channel's latest admitted session, applies
+   * the picked value, acks the tap, and
+   * re-renders the card with the new current marked. Best-effort throughout — a tap
+   * must never throw out of the update pump.
+   */
+  handleTelegramCallback(cb: TelegramCallback, conn: TelegramConnection): void {
+    const tap = parseTelegramSelect(cb.data)
+    if (!tap) {
+      void conn.answerCallback(cb.id)
+      return
+    }
+    const { kind, index: idx } = tap
+    const srcIntegrationIds = this.host.srcIntegrationIds(conn)
+    const session = this.commandSessionForLatest(
+      cb.channel,
+      srcIntegrationIds,
+      this.host.transportScopeForIntegrationIds(srcIntegrationIds)
+    )
+    if (!session) {
+      void conn.answerCallback(cb.id, 'No active session here.')
+      return
+    }
+    if (this.host.agents().get(session.agentId)?.allowRuntimeChangesInChat !== true) {
+      void conn.answerCallback(cb.id, 'Ask an Agent editor to change runtime settings.')
+      return
+    }
+    const info = this.host.statusInfoFrom(session.agentId, session.key, session.acpSessionId)
+    const { options } = selectOptions(kind, info)
+    const value = options[idx]
+    if (value === undefined) {
+      void conn.answerCallback(cb.id, 'Options changed — reopen the menu.')
+      return
+    }
+    if (!applySelect(kind, session.key, value, this.selectSetters)) return
+    // Telegram names the tapping user on the callback itself; record only the applied
+    // change, matching the other funnels.
+    this.logSessionAction(`select:${kind}`, session.key, { userId: cb.userId })
+    void conn.answerCallback(cb.id, `${selectLabel(kind)} → ${value}`)
+    void conn.editCard(
+      cb.channel,
+      cb.messageId,
+      selectCardText(kind, value),
+      telegramSelectButtons(kind, value, options)
+    )
+  }
+
+  /** The newest addressable session for a platform-scoped interaction (a Telegram
+   *  command/callback, a Slack message shortcut): scan the caller's own-platform
+   *  integrations, retain conversation routing gates, newest first. The caller is
+   *  already platform-specific — it names its platform as data, not as a branch. */
+  latestAdmittedSession(
+    platform: string,
+    channel: string,
+    srcIntegrationIds: readonly string[],
+    transportScope?: string,
+    thread?: string
+  ): SessionRecord | null {
+    const candidates: SessionRecord[] = []
+    for (const [agentId, agent] of this.host.agents()) {
+      for (const integration of agent.integrations) {
+        if (integration.platform !== platform || !srcIntegrationIds.includes(integration.id)) continue
+        const routing = integrationRouting(integration)
+        if (!conversationAdmitted(routing, channel)) continue
+        const session = this.host.store().latestSessionForTransport(agentId, channel, transportScope, thread)
+        if (session) candidates.push(session)
+      }
+    }
+    candidates.sort((a, b) => b.updatedAt - a.updatedAt || a.agentId.localeCompare(b.agentId))
+    return candidates[0] ?? null
+  }
+
+  /** The channel's latest admitted session for a Telegram command/callback. */
+  commandSessionForLatest(
+    channel: string,
+    srcIntegrationIds: readonly string[],
+    transportScope?: string
+  ): { agentId: string; key: string; acpSessionId?: string } | null {
+    const latest = this.latestAdmittedSession('telegram', channel, srcIntegrationIds, transportScope)
+    return latest ? { agentId: latest.agentId, key: latest.key, acpSessionId: latest.acpSessionId ?? undefined } : null
+  }
+
+  /** Resolve a direct Slack message shortcut to the newest addressable session in
+   *  that exact bot-scoped conversation, retaining conversation routing gates. */
+  slackShortcutSession(
+    shortcut: { channel: string; thread: string },
+    srcIntegrationIds: readonly string[]
+  ): string | undefined {
+    const transportScope = this.host.transportScopeForIntegrationIds(srcIntegrationIds)
+    return this.latestAdmittedSession('slack', shortcut.channel, srcIntegrationIds, transportScope, shortcut.thread)
+      ?.key
+  }
+}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -38,7 +38,7 @@ import {
 import { AcpHost, turnFailureCode, turnFailureReason, type AcpPermissionPolicyEvent } from './acp/acp-host.js'
 import { probeSandboxHost, SandboxError, type SandboxMechanism, type SandboxProbe } from './acp/sandbox.js'
 import { effectiveRunInSandbox, prepareRuntimeLaunch } from './launch/prepare.js'
-import { permissionPresetSettings, permissionPresetValues, selectedPermissionPreset } from './acp/permission-modes.js'
+import { permissionPresetValues, selectedPermissionPreset } from './acp/permission-modes.js'
 import {
   SessionManager,
   transcriptCoords,
@@ -119,14 +119,7 @@ import {
   type RouteVia
 } from './router/routing-table.js'
 import { parseCommand, type AgentCommand } from './commands/commands.js'
-import {
-  applySelect,
-  selectCardText,
-  selectDisplay,
-  selectLabel,
-  selectOptions,
-  type SelectSetters
-} from './commands/select-projection.js'
+import { CommandHandlers, type CommandHost } from './commands/handlers.js'
 import {
   rulesFromAgent,
   resolveCpRule,
@@ -146,7 +139,6 @@ import { TelegramConnection, type TelegramCallback, type TelegramObservedChat } 
 import { DiscordConnection } from './discord/connection.js'
 import { FeishuConnection } from './feishu/connection.js'
 import { SlackNameResolver } from './slack/name-resolver.js'
-import { loopGuardScopesFor } from './platforms/loop-guard.js'
 import {
   integrationConfig,
   integrationCore,
@@ -170,11 +162,7 @@ import { conversationAudienceFor } from './platforms/session-audience.js'
 import { turnChromeFor } from './platforms/turn-chrome.js'
 import { CommandChromeRegistry, type SelectKind } from './platforms/command-chrome.js'
 import { slackCommandChrome } from './platforms/slack/command-chrome.js'
-import {
-  parseTelegramSelect,
-  telegramCommandChrome,
-  telegramSelectButtons
-} from './platforms/telegram/command-chrome.js'
+import { telegramCommandChrome } from './platforms/telegram/command-chrome.js'
 import { discordCommandChrome } from './platforms/discord/command-chrome.js'
 import { feishuCommandChrome } from './platforms/feishu/command-chrome.js'
 import {
@@ -211,12 +199,7 @@ import {
   type StatusModalIdentity
 } from './slack/render.js'
 import { TelegramConverger, type TelegramAction } from './telegram/render.js'
-import {
-  DiscordConverger,
-  buildDiscordSelectComponents,
-  type DiscordAction,
-  type DiscordComponents
-} from './discord/render.js'
+import { DiscordConverger, type DiscordAction, type DiscordComponents } from './discord/render.js'
 import { FeishuConverger, type FeishuAction } from './feishu/render.js'
 import {
   Scheduler,
@@ -475,7 +458,6 @@ import {
 import {
   isTrustedHumanTurn,
   loopGuardScope,
-  loopGuardScopeFromCoords,
   usesLoopGuard,
   LOOP_GUARD_WINDOW_MS,
   MAX_AUTOMATIC_TURNS_PER_WINDOW,
@@ -1172,6 +1154,8 @@ export class Daemon {
   private readonly observedChannelsSync: ObservedChannelsSync
   private readonly webchatTransport: WebchatTransport
   private readonly webchatMcpRevocations: WebchatMcpRevocations
+  // In-conversation command execution (commands/handlers.ts), behind the delegates below.
+  private readonly commands: CommandHandlers
   // §7.3 force-cancel backstops, keyed by (agentId, acpSessionId); cleared at turn end.
   private cancelTimers = new Map<string, TimerHandle>()
   // Backstop for an interrupt that lands before a Pending/ACP session id exists
@@ -1285,6 +1269,7 @@ export class Daemon {
     this.connections = new ConnectionReconciler(this.connectionReconcilerHost())
     this.webchatTransport = new WebchatTransport(this.webchatHost())
     this.webchatMcpRevocations = new WebchatMcpRevocations(this.webchatMcpRevocationHost())
+    this.commands = new CommandHandlers(this.commandHost())
     this.curatedRuntimeAdmission = new CuratedRuntimeAdmission({
       now: () => this.clock.now(),
       ttlMs: Daemon.PROBE_TTL_MS
@@ -1348,6 +1333,40 @@ export class Daemon {
   /** The narrow port the §7.5 connection lifecycle reaches the daemon through. The action
    *  sink half is what the command handlers implement — connection construction is the only
    *  place that wires them. */
+  private commandHost(): CommandHost {
+    return {
+      log: () => this.log,
+      store: () => this.store,
+      agents: () => this.agents,
+      pending: () => this.pending,
+      inflight: () => this.inflight,
+      serialQueue: () => this.serialQueue,
+      activeGateEntries: () => this.activeGateEntries,
+      commandChrome: () => this.commandChrome,
+      hasModelSessionHost: (key) => this.modelSessionHosts.has(key),
+      modelCrossesHostProvider: (key, agentId, model) => this.modelCrossesHostProvider(key, agentId, model),
+      hostForStoredSession: (agentId, acpSessionId) => this.hostForStoredSession(agentId, acpSessionId),
+      statusInfoFrom: (agentId, sessionKey, acpSessionId) => this.statusInfoFrom(agentId, sessionKey, acpSessionId),
+      emitStatusBar: (p) => this.emitStatusBar(p),
+      interruptTurn: (agentId, key, reason, acpSessionId) => this.interruptTurn(agentId, key, reason, acpSessionId),
+      dispatchQueueCommand: async (agentId, msg, integrationId) => {
+        await this.dispatch(agentId, msg, integrationId, undefined, undefined, { isQueueCmd: true })
+      },
+      replyConnFor: (agentId, integrationId) => this.replyConnFor(agentId, integrationId),
+      sessionLink: (acpSessionId, source) => this.sessionLink(acpSessionId, source),
+      sessionLinkSource: (platform, integrationId) => this.sessionLinkSource(platform, integrationId),
+      threadOwner: (channel, thread, transportScope) => this.sessions.threadOwner(channel, thread, transportScope),
+      mergedRulesForSource: (srcIntegrationIds) => this.mergedRulesForSource(srcIntegrationIds),
+      transportScopeForIntegrationIds: (integrationIds) => this.transportScopeForIntegrationIds(integrationIds),
+      integrationBelongsToSource: (integrationId, srcIntegrationIds) =>
+        this.integrationBelongsToSource(integrationId, srcIntegrationIds),
+      srcIntegrationIds: (conn) => this.srcIntegrationIds(conn),
+      clearEnforcedLoopScope: (scope) => {
+        this.enforcedLoopScopes.delete(scope)
+      }
+    }
+  }
+
   private connectionReconcilerHost(): ConnectionReconcilerHost {
     return {
       log: () => this.log,
@@ -5581,130 +5600,92 @@ export class Daemon {
     this.webchatTransport.pruneWebchatStreams()
   }
 
-  /**
-   * Record who drove one chat-side session action. The platform interaction is the only
-   * place the acting user exists — the session key alone says what changed, never by whom —
-   * so it is logged at every funnel point. `unknown` when an ingress could not report an
-   * actor (today: relay-forwarded Slack actions, whose frame carries no user).
-   */
+  // Command execution lives in commands/handlers.ts; these same-name delegates are what
+  // the ingress paths, the platform connection callbacks and the webchat frames call.
   private logSessionAction(verb: string, sessionKey: string, actor?: InteractionActor): void {
-    const who = actor ? `${actor.userId}${actor.isBot ? ' (bot)' : ''}` : 'unknown'
-    this.log.info(`session ${sessionKey}: "${verb}" by ${who}`)
+    this.commands.logSessionAction(verb, sessionKey, actor)
   }
 
-  /** Resolve a session only while its Agent explicitly permits chat-side runtime changes. */
-  private chatRuntimeSession(key: string) {
-    const rec = this.store.getSession(key)
-    return rec && this.agents.get(rec.agentId)?.allowRuntimeChangesInChat === true ? rec : undefined
-  }
-
-  /** Switch a session's model by its local key — the core shared by the webchat
-   *  `set-model` frame and the Slack status-bar select. Records the sticky per-session
-   *  override (re-applied on every turn by dispatch) and, if the ACP session is warm,
-   *  applies it live now and re-pushes the status bar. Never changes the agent default. */
   private setModelByKey(key: string, model: string): boolean {
-    const rec = this.chatRuntimeSession(key)
-    if (!rec) return false
-    const crossProvider = this.modelCrossesHostProvider(key, rec.agentId, model)
-    // The shared static-credential host has no per-session restart to pick a new binding up,
-    // so a cross-provider pick there could never be credentialed — refuse it outright rather
-    // than storing an override that can only ever fail.
-    if (crossProvider && !this.modelSessionHosts.has(key)) {
-      this.log.warn(`session ${key}: cross-provider model switch rejected — the static credential host is bound`)
-      return false
-    }
-    this.store.setModelOverride(key, model)
-    this.log.info(`session ${key} model override → "${model}"`)
-    // A running credential host keeps the provider it started with; the sticky override is
-    // what the next start reads, so the switch lands there instead of live.
-    if (crossProvider) {
-      this.log.info(`session ${key}: provider change applies when its credential host next starts`)
-      return true
-    }
-    const acpSessionId = rec.acpSessionId
-    const host = acpSessionId ? this.hostForStoredSession(rec.agentId, acpSessionId) : undefined
-    if (!acpSessionId || !host?.hasSession(acpSessionId)) return true // no live session — applies next turn
-    void host
-      .setSessionModel(acpSessionId, model)
-      .then((applied) => {
-        const p = this.pending.get(pendingTurnKey(rec.agentId, acpSessionId))
-        if (applied && p) this.emitStatusBar(p) // reflect the new model on the status bar
-      })
-      .catch((err) => this.log.warn(`set-model failed: ${(err as Error).message}`))
-    return true
+    return this.commands.setModelByKey(key, model)
   }
 
-  /** Cancel the in-flight turn for a local session key — the `!cancel` core (interrupt,
-   *  NO mute) shared by the Slack status-bar Cancel button. No-op if nothing is running. */
-  private cancelSessionByKey(key: string): boolean {
-    const rec = this.store.getSession(key)
-    // Cancel a gate-owned/queued session even if it has no live ACP turn yet (§6.9 #390):
-    // interruptTurn drains the queue by key and cancels the ACP turn only if one exists.
-    if (!this.inflight.has(key)) return false
-    const agentId = rec?.agentId ?? this.serialQueue.get(key)?.[0]?.agentId
-    if (!agentId) return false
-    this.interruptTurn(agentId, key, 'cancel', rec?.acpSessionId ?? undefined)
-    return true // reports whether a turn was actually interrupted (nothing else reads it)
-  }
-
-  /** Switch a session's reasoning effort by its local key — the effort counterpart of
-   *  {@link setModelByKey}. Records the sticky override and, if the ACP session is warm,
-   *  applies it live via the `thought_level` select. `ultracode` can't ride the select
-   *  (setSessionEffort returns false); it's honored via session `_meta` when the session
-   *  is next (re)created or resumed, and the override still shows on the bar meanwhile. */
   private setEffortByKey(key: string, effort: string): boolean {
-    const rec = this.chatRuntimeSession(key)
-    if (!rec) return false
-    this.store.setEffortOverride(key, effort)
-    this.log.info(`session ${key} effort override → "${effort}"`)
-    const acpSessionId = rec.acpSessionId
-    const host = acpSessionId ? this.hostForStoredSession(rec.agentId, acpSessionId) : undefined
-    if (!acpSessionId || !host?.hasSession(acpSessionId)) {
-      this.refreshStatusBarForKey(key)
-      return true
-    }
-    void host
-      .setSessionEffort(acpSessionId, effort)
-      .then(() => this.refreshStatusBarForKey(key))
-      .catch((err) => this.log.warn(`set-effort failed: ${(err as Error).message}`))
-    return true
+    return this.commands.setEffortByKey(key, effort)
   }
 
-  /** Apply one composite session permission value to a warm host. Older injected host
-   * fakes retain the two-setter fallback; real AcpHosts own the validation/decomposition. */
-  private async applySessionPermissionPreset(host: AcpHost, sessionId: string, preset: string): Promise<void> {
-    if (typeof host.setSessionPermissionPreset === 'function') {
-      await host.setSessionPermissionPreset(sessionId, preset)
-      return
-    }
-    const settings = permissionPresetSettings(preset)
-    if (settings.approvalsReviewer === 'user' && typeof host.setSessionApprovalsReviewer === 'function') {
-      await host.setSessionApprovalsReviewer(sessionId, 'user')
-    }
-    await host.setSessionPermissionMode(sessionId, settings.permissionMode)
-    if (settings.approvalsReviewer === 'auto_review' && typeof host.setSessionApprovalsReviewer === 'function') {
-      await host.setSessionApprovalsReviewer(sessionId, 'auto_review')
-    }
-  }
-
-  /** Every chat-side permission-preset change funnels through the same Agent-level
-   * guard before a sticky override can be written, including stale callbacks and
-   * relay frames. */
   private setPermissionModeByKey(key: string, permissionPreset: string): boolean {
-    const rec = this.chatRuntimeSession(key)
-    if (!rec) return false
-    this.store.setPermissionModeOverride(key, permissionPreset)
-    this.log.info(`session ${key} permission preset override → "${permissionPreset}"`)
-    const acpSessionId = rec.acpSessionId
-    const host = acpSessionId ? this.hostForStoredSession(rec.agentId, acpSessionId) : undefined
-    if (!acpSessionId || !host?.hasSession(acpSessionId)) {
-      this.refreshStatusBarForKey(key)
-      return true
-    }
-    void this.applySessionPermissionPreset(host, acpSessionId, permissionPreset)
-      .then(() => this.refreshStatusBarForKey(key))
-      .catch((err) => this.log.warn(`set-permission-preset failed: ${(err as Error).message}`))
-    return true
+    return this.commands.setPermissionModeByKey(key, permissionPreset)
+  }
+
+  private setFastByKey(key: string, fastMode: boolean): boolean {
+    return this.commands.setFastByKey(key, fastMode)
+  }
+
+  private applySessionPermissionPreset(host: AcpHost, sessionId: string, preset: string): Promise<void> {
+    return this.commands.applySessionPermissionPreset(host, sessionId, preset)
+  }
+
+  private refreshStatusBarForKey(key: string): void {
+    this.commands.refreshStatusBarForKey(key)
+  }
+
+  private isSessionMuted(key: string): boolean {
+    return this.commands.isSessionMuted(key)
+  }
+
+  private setSessionMuted(key: string, muted: boolean): void {
+    this.commands.setSessionMuted(key, muted)
+  }
+
+  private handleCommand(
+    command: AgentCommand,
+    msg: NormalizedMessage,
+    explicitTarget?: { agentId: string; integrationId: string; via: RouteVia },
+    srcIntegrationIds?: readonly string[]
+  ): boolean {
+    return this.commands.handleCommand(command, msg, explicitTarget, srcIntegrationIds)
+  }
+
+  private handleSelectCommand(
+    kind: SelectKind,
+    value: string | null,
+    agentId: string,
+    key: string,
+    acpSessionId: string | undefined,
+    reply: (text: string) => void,
+    renderCard?: (kind: SelectKind, current: string | undefined, options: string[]) => boolean
+  ): void {
+    this.commands.handleSelectCommand(kind, value, agentId, key, acpSessionId, reply, renderCard)
+  }
+
+  private resolveExplicitCommandTarget(
+    agentId: string,
+    integrationId: string,
+    msg: NormalizedMessage
+  ): { agentId: string; integrationId: string; via: RouteVia } | null {
+    return this.commands.resolveExplicitCommandTarget(agentId, integrationId, msg)
+  }
+
+  private handleStatusAction(a: Parameters<CommandHandlers['handleStatusAction']>[0]): void {
+    this.commands.handleStatusAction(a)
+  }
+
+  private handleDiscordSelect(
+    a: Parameters<CommandHandlers['handleDiscordSelect']>[0]
+  ): { text: string; components: DiscordComponents } | undefined {
+    return this.commands.handleDiscordSelect(a)
+  }
+
+  private handleTelegramCallback(cb: TelegramCallback, conn: TelegramConnection): void {
+    this.commands.handleTelegramCallback(cb, conn)
+  }
+
+  private slackShortcutSession(
+    shortcut: { channel: string; thread: string },
+    srcIntegrationIds: readonly string[]
+  ): string | undefined {
+    return this.commands.slackShortcutSession(shortcut, srcIntegrationIds)
   }
 
   /** Apply the Agent's configured runtime policy to one live session. Callers that
@@ -5755,46 +5736,6 @@ export class Daemon {
           this.log.warn(`restore configured runtime settings failed for "${session.key}": ${formatErr(err)}`)
         )
     }
-  }
-
-  /** Toggle a session's fast mode by its local key — the fast-mode counterpart of
-   *  {@link setModelByKey}. Records the sticky override and applies it live when the
-   *  current model offers a fast toggle. */
-  private setFastByKey(key: string, fastMode: boolean): boolean {
-    const rec = this.chatRuntimeSession(key)
-    if (!rec) return false
-    this.store.setFastModeOverride(key, fastMode)
-    this.log.info(`session ${key} fast-mode override → ${fastMode}`)
-    const acpSessionId = rec.acpSessionId
-    const host = acpSessionId ? this.hostForStoredSession(rec.agentId, acpSessionId) : undefined
-    if (!acpSessionId || !host?.hasSession(acpSessionId)) {
-      this.refreshStatusBarForKey(key)
-      return true
-    }
-    void host
-      .setSessionFastMode(acpSessionId, fastMode)
-      .then(() => this.refreshStatusBarForKey(key))
-      .catch((err) => this.log.warn(`set-fast failed: ${(err as Error).message}`))
-    return true
-  }
-
-  /** Re-emit the status bar for a session's in-flight turn (if any) so a config change
-   *  (model / effort / fast) is reflected. No-op when the session is idle. */
-  private refreshStatusBarForKey(key: string): void {
-    const rec = this.store.getSession(key)
-    const p = rec?.acpSessionId ? this.pending.get(pendingTurnKey(rec.agentId, rec.acpSessionId)) : undefined
-    if (p) this.emitStatusBar(p)
-  }
-
-  /** Set a session's Slack output verbosity by its local key. Purely daemon-side (no ACP):
-   *  the next turn's OutputConverger reads this override, so an in-flight turn keeps its
-   *  current verbosity and the change takes effect from the next turn. */
-  private setOutputModeByKey(key: string, mode: 'none' | 'minimal' | 'low' | 'medium' | 'high'): boolean {
-    if (!this.store.getSession(key)) return false
-    this.store.setOutputModeOverride(key, mode)
-    this.log.info(`session ${key} output-mode override → "${mode}"`)
-    this.refreshStatusBarForKey(key)
-    return true // reports whether the override was recorded (nothing else reads it)
   }
 
   private handleWebchatCancel(conversationId: string, agentId?: string): void {
@@ -9116,68 +9057,6 @@ export class Daemon {
     this.webchatTransport.maybeActivateWebchatContinuation(targetAgentId, chatId, contextPost, landedTs)
   }
 
-  /** Route a Slack status-bar Block Kit interaction (model / effort / fast select or the
-   *  Cancel button) to the shared key-based cores. `sessionKey` rides the block; no-op on
-   *  an unknown key. */
-  private handleStatusAction(a: {
-    kind: 'set-model' | 'set-effort' | 'set-permission-mode' | 'set-fast' | 'set-output' | 'cancel'
-    sessionKey: string
-    actor?: InteractionActor
-    model?: string
-    effort?: string
-    permissionMode?: string
-    fastMode?: boolean
-    outputMode?: 'none' | 'minimal' | 'low' | 'medium' | 'high'
-  }): void {
-    // A status-bar tap carries no author in the transcript, so the operator behind a
-    // cancelled turn or a switched model is otherwise unrecoverable. Record it here,
-    // at the one point every ingress funnels through — but only when the verb actually
-    // applied, so a refused or no-op click never reads as a change someone made.
-    let applied = false
-    if (a.kind === 'cancel') applied = this.cancelSessionByKey(a.sessionKey)
-    else if (a.kind === 'set-model') {
-      if (a.model) applied = this.setModelByKey(a.sessionKey, a.model)
-    } else if (a.kind === 'set-effort') {
-      if (a.effort) applied = this.setEffortByKey(a.sessionKey, a.effort)
-    } else if (a.kind === 'set-permission-mode') {
-      if (a.permissionMode) applied = this.setPermissionModeByKey(a.sessionKey, a.permissionMode)
-    } else if (a.kind === 'set-fast') {
-      if (a.fastMode !== undefined) applied = this.setFastByKey(a.sessionKey, a.fastMode)
-    } else if (a.kind === 'set-output') {
-      if (a.outputMode) applied = this.setOutputModeByKey(a.sessionKey, a.outputMode)
-    }
-    if (applied) this.logSessionAction(a.kind, a.sessionKey, a.actor)
-  }
-
-  /**
-   * A tapped Discord select-card button (`/models` `/effort` `/permission`): resolve the
-   * session from the button's key, apply the chosen option, and return the re-rendered
-   * card so the connection edits the message in place (new current flagged). Undefined
-   * when the session is gone or the option index is stale (options changed) — the
-   * connection then leaves the card as-is. Mirrors handleTelegramCallback.
-   */
-  private handleDiscordSelect(a: {
-    kind: SelectKind
-    index: number
-    sessionKey: string
-    actor?: InteractionActor
-  }): { text: string; components: DiscordComponents } | undefined {
-    const rec = this.store.getSession(a.sessionKey)
-    if (!rec) return undefined
-    const info = this.statusInfoFrom(rec.agentId, a.sessionKey, rec.acpSessionId ?? undefined)
-    const { options } = selectOptions(a.kind, info)
-    const value = options[a.index]
-    if (value === undefined) return undefined
-    // Recorded only once the choice actually applied — a refused or stale select
-    // changes nothing and must not read as though someone had changed it. The card is
-    // still re-rendered either way, as before.
-    if (applySelect(a.kind, a.sessionKey, value, this.selectSetters))
-      this.logSessionAction(`select:${a.kind}`, a.sessionKey, a.actor)
-    const components = buildDiscordSelectComponents(a.kind, value, options)
-    if (!components) return undefined
-    return { text: selectCardText(a.kind, value), components }
-  }
-
   /** Record an unrouted inbound message into the transcript iff a session is
    *  *recently active* in its thread (§8.5 catch-up). Platform ingresses have already
    *  removed their own echoes. The recency gate bounds
@@ -9732,561 +9611,6 @@ export class Daemon {
    *  work. A peer owns the trip's warning and its own backlog, so each member stops its turns
    *  once per latch, on the first admission it refuses, not on every subsequent message. */
   private enforcedLoopScopes = new Map<string, number>()
-
-  private isSessionMuted(key: string): boolean {
-    return this.store.isSessionMuted(key)
-  }
-
-  private setSessionMuted(key: string, muted: boolean): void {
-    this.store.setSessionMuted(key, muted)
-  }
-
-  /**
-   * Resolve a command's target from the channel's latest session when the routing ladder
-   * couldn't (no mention entity / thread / dm rule matched — e.g. a group `/status@bot`).
-   * Picks the agent that owns the most-recent session in the channel and its integration
-   * for this platform while preserving the conversation gate that routing would have
-   * applied. Null when there's no session, no matching integration, or the conversation
-   * is not admitted.
-   */
-  private resolveCommandTargetFromLatest(
-    msg: NormalizedMessage,
-    srcIntegrationIds?: readonly string[]
-  ): { agentId: string; integrationId: string; via: RouteVia } | null {
-    const transportScope = msg.transportScope ?? this.transportScopeForIntegrationIds(srcIntegrationIds)
-    // Only where the thread coordinate identifies the session (Slack/Discord) does it
-    // participate in the lookup; reply-threading platforms mint a fresh thread per
-    // command, so their commands resolve through the channel's latest session.
-    const thread = this.commandChrome.threadIdentifiesSession(msg.platform) ? msg.thread : undefined
-    const candidates: Array<{
-      agentId: string
-      integrationId: string
-      updatedAt: number
-    }> = []
-    for (const [agentId, agent] of this.agents) {
-      for (const integration of agent.integrations) {
-        if (
-          integration.platform !== msg.platform ||
-          !this.integrationBelongsToSource(integration.id, srcIntegrationIds) ||
-          !this.commandSenderAllowed(agentId, integration.id, msg)
-        )
-          continue
-        const latest = this.store.latestSessionForTransport(agentId, msg.channel, transportScope, thread)
-        if (latest) candidates.push({ agentId, integrationId: integration.id, updatedAt: latest.updatedAt })
-      }
-    }
-    candidates.sort(
-      (a, b) =>
-        b.updatedAt - a.updatedAt ||
-        a.agentId.localeCompare(b.agentId) ||
-        a.integrationId.localeCompare(b.integrationId)
-    )
-    const latest = candidates[0]
-    return latest ? { agentId: latest.agentId, integrationId: latest.integrationId, via: 'thread' } : null
-  }
-
-  /** Validate the relay-arbitrated command target against the local agent spec. Shared
-   *  bot IMs bypass routeRules' arbitration, but must retain its bot rejection and
-   *  conversation admission before executing a control command. */
-  private resolveExplicitCommandTarget(
-    agentId: string,
-    integrationId: string,
-    msg: NormalizedMessage
-  ): { agentId: string; integrationId: string; via: RouteVia } | null {
-    if (!this.commandSenderAllowed(agentId, integrationId, msg)) return null
-    return { agentId, integrationId, via: 'thread' }
-  }
-
-  /** Recovery path for a channel-wide Slack top-level loop latch. The triggering
-   *  message itself was rejected, so its warning thread may have no thread owner or
-   *  latest session to route a bare `!resume` through. Select only an integration
-   *  that admits this conversation, preferring an explicitly mentioned bot. */
-  private resolveTopLevelResumeTarget(
-    msg: NormalizedMessage,
-    srcIntegrationIds?: readonly string[]
-  ): { agentId: string; integrationId: string; via: RouteVia } | null {
-    const coarseScope = loopGuardScopesFor(msg).coarse
-    if (!coarseScope || !this.store.isLoopGuardOpen(coarseScope)) return null
-    const candidates: Array<{
-      agentId: string
-      integrationId: string
-      via: RouteVia
-      mentioned: boolean
-    }> = []
-    for (const [agentId, agent] of this.agents) {
-      for (const integration of agent.integrations) {
-        // Only reachable when the message's platform has a coarse loop-guard
-        // circuit (loopGuardScopesFor), so filtering by the MESSAGE's platform is
-        // the platform-neutral statement of the old `!== 'slack'` literal.
-        if (
-          integration.platform !== msg.platform ||
-          !this.integrationBelongsToSource(integration.id, srcIntegrationIds) ||
-          !this.commandSenderAllowed(agentId, integration.id, msg)
-        )
-          continue
-        const botUserId = integrationRouting(integration).staticBotUserId
-        const mentioned = botUserId !== undefined && msg.mentionedBots.includes(botUserId)
-        candidates.push({
-          agentId,
-          integrationId: integration.id,
-          via: mentioned ? 'mention' : 'auto',
-          mentioned
-        })
-      }
-    }
-    candidates.sort(
-      (a, b) =>
-        Number(b.mentioned) - Number(a.mentioned) ||
-        a.agentId.localeCompare(b.agentId) ||
-        a.integrationId.localeCompare(b.integrationId)
-    )
-    return candidates[0] ?? null
-  }
-
-  /** Final command admission at the concrete integration. Commands that resolve their
-   *  target outside the routing ladder still repeat bot rejection and conversation gating. */
-  private commandSenderAllowed(agentId: string, integrationId: string, msg: NormalizedMessage): boolean {
-    if (msg.sender.isBot) return false
-    const integration = this.agents
-      .get(agentId)
-      ?.integrations.find((candidate) => candidate.id === integrationId && candidate.platform === msg.platform)
-    if (!integration) return false
-    const routing = integrationRouting(integration)
-    // Control commands resolve their target OUTSIDE routeRules' scope filter (latest-
-    // session fallbacks), so they must repeat the admission check — a channel switched
-    // Off, or an Off conversation of a gated integration, takes no commands either.
-    return conversationAdmitted(routing, msg.channel)
-  }
-
-  /**
-   * Handle an in-conversation control command. Resolves the target agent via the
-   * same routing ladder as a normal message (so thread affinity and conversation
-   * admission apply), then acts on that agent's session in this
-   * (channel, thread).
-   */
-  private handleCommand(
-    command: AgentCommand,
-    msg: NormalizedMessage,
-    explicitTarget?: { agentId: string; integrationId: string; via: RouteVia },
-    srcIntegrationIds?: readonly string[]
-  ): boolean {
-    let target =
-      explicitTarget ??
-      routeRules(msg, this.mergedRulesForSource(srcIntegrationIds), (c, t) =>
-        this.sessions.threadOwner(c, t, msg.transportScope)
-      )
-    if (!target) {
-      // Routing found no agent — the common group case: a bare `/status@bot` carries no
-      // mention entity, no reply, and its fresh thread has no session. Resolve the agent
-      // from the channel's latest session so the command still lands on it (subject to
-      // that agent's conversation admission).
-      target = this.resolveCommandTargetFromLatest(msg, srcIntegrationIds)
-    }
-    if (!target && command.kind === 'resume') target = this.resolveTopLevelResumeTarget(msg, srcIntegrationIds)
-    if (!target) {
-      this.log.debug(`command: '${command.kind}' in ch=${msg.channel} — no agent resolved, ignoring`)
-      return false
-    }
-    if (!this.commandSenderAllowed(target.agentId, target.integrationId, msg)) {
-      this.log.warn(`command: '${command.kind}' rejected for unauthorized sender ${msg.sender.id}`)
-      return false
-    }
-    const conn = this.replyConnFor(target.agentId, target.integrationId)
-    // Where the command was sent — the reply lands here (Slack thread_ts; Telegram
-    // replies to the command message via its chrome surface's reply anchor). Kept separate from the session the
-    // command ACTS on, resolved just below.
-    const replyThread = msg.thread ?? msg.msgId
-    // Resolve the session the command acts on. A command that isn't in a session's own
-    // thread — notably ANY bare Telegram command, which keys to its own fresh reply
-    // thread — falls back to the agent's latest session in this channel, so /stop
-    // /cancel /status /fast /models /effort /permission /queue all operate on it rather
-    // than on a phantom empty thread. `thread`/`key` follow the resolved session so a
-    // `/queue` dispatch continues it and the sticky overrides land on the right key.
-    let thread = replyThread
-    let key = sessionKey(msg.platform, msg.channel, thread, target.agentId, msg.transportScope)
-    let rec = this.store.getSession(key)
-    // A cold turn owns its logical key before SessionManager persists the session row.
-    // Prefer that exact live gate over the channel's latest historical session; otherwise
-    // a `!stop` sent in the cold thread can mute/cancel an older thread and leave the
-    // actual turn running. Check all gate representations because commands can race the
-    // short hand-offs between them.
-    const gateActiveFor = (candidateKey: string): boolean =>
-      this.activeGateEntries.has(candidateKey) || (this.serialQueue.get(candidateKey)?.length ?? 0) > 0
-    let directGateActive = gateActiveFor(key)
-    if (!rec && !directGateActive) {
-      const latest = this.store.latestSessionForTransport(target.agentId, msg.channel, msg.transportScope)
-      if (latest) {
-        rec = latest
-        key = latest.key
-        thread = latest.thread
-        directGateActive = gateActiveFor(key)
-      }
-    }
-    const acpSessionId = rec?.acpSessionId
-    // §6.9 #390: liveness is observed on the LOGICAL sessionKey gate (a turn currently
-    // owns the key), not just the ACP-id-keyed `pending` — so `!cancel`/`!stop`/`!queue`
-    // also see a session that is gate-owned or queued (cold session with no ACP id yet).
-    const inflight = directGateActive
-    // Post a short control reply on the platform's own surface (§7.4 command
-    // chrome): Slack threads on `thread_ts`; Telegram replies to the command
-    // message (reply-based threading), which is also a non-numeric `tg:`/`dm`
-    // thread so it never posts as a forum topic.
-    const chrome = this.commandChrome.for(msg.platform)
-    const chromeCtx = { channel: msg.channel, replyThread, sessionKey: key }
-    const reply = (text: string): void => {
-      if (!conn) return
-      chrome.reply(conn, msg, chromeCtx, text)
-    }
-
-    if (command.kind === 'resume') {
-      // Commands sent outside the session thread (notably bare Telegram commands)
-      // may have resolved `thread` through latestSession above. Reset the scope the
-      // command actually targets, not the fresh command-message thread.
-      const directScope =
-        thread === replyThread
-          ? loopGuardScope(msg)
-          : loopGuardScopeFromCoords(msg.platform, msg.channel, thread, msg.isDm, msg.transportScope)
-      const topLevelScope = loopGuardScopesFor(msg).coarse
-      // A top-level feedback loop posts its warning into the triggering root. A
-      // trusted !resume from that warning thread (or elsewhere in the channel)
-      // must reset the shared channel circuit, not a never-open per-thread key.
-      const scope = topLevelScope && this.store.isLoopGuardOpen(topLevelScope) ? topLevelScope : directScope
-      const stillStopping =
-        [...this.activeGateEntries.values()].some(
-          (entry) => entry.cancelledReason === 'loop protection' && loopGuardScope(entry.msg) === scope
-        ) ||
-        [...this.pending.values()].some((pending) => {
-          return pending.outputSuppressed === 'loop protection' && pending.loopGuardScope === scope
-        })
-      if (stillStopping) {
-        reply('Loop protection is still stopping the previous turn. Try `!resume` again in a moment.')
-        return true
-      }
-      const wasOpen = this.store.isLoopGuardOpen(scope)
-      this.store.resetLoopGuard(scope)
-      this.enforcedLoopScopes.delete(scope)
-      const wasMuted = this.isSessionMuted(key)
-      if (wasMuted) this.setSessionMuted(key, false)
-      if (wasOpen || wasMuted) {
-        this.log.info(`loop guard: explicitly reset ${scope} by ${msg.sender.id}`)
-        reply('▶️ Resumed. Loop protection is reset; send a new message to continue.')
-      } else {
-        reply('Loop protection is not active in this conversation.')
-      }
-      return true
-    }
-
-    if (command.kind === 'stop') {
-      // Mute the session's thread whether or not a turn is in flight: `!stop` is an
-      // explicit stand-down — implicit routing (thread affinity / keyword / auto)
-      // stays off until the user @mentions the agent again (onInbound clears it).
-      if (rec || inflight) this.setSessionMuted(key, true)
-      const muteNote = 'Muted in this thread — @mention me to resume.'
-      if (!inflight) {
-        reply(rec ? `🔇 Nothing is running. ${muteNote}` : 'Nothing is running to stop.')
-        return true
-      }
-      this.interruptTurn(target.agentId, key, 'stop', acpSessionId ?? undefined)
-      reply(`🛑 Stopped. ${muteNote}`)
-      return true
-    }
-
-    if (command.kind === 'cancel') {
-      // `!cancel` interrupts the in-flight turn but does NOT mute — the session stays
-      // live so a follow-up message dispatches normally. No-op (with a note) when idle.
-      if (!inflight) {
-        reply('Nothing is running to cancel.')
-        return true
-      }
-      this.interruptTurn(target.agentId, key, 'cancel', acpSessionId ?? undefined)
-      reply('🛑 Cancelled.')
-      return true
-    }
-
-    if (command.kind === 'status') {
-      // `/status` — the on-demand replacement for Telegram's (removed) status bar:
-      // reply with the session's model / context / tokens (the latest session in this
-      // channel, per the resolution above). No-op note when there's none.
-      if (!rec) {
-        reply('No active session here yet — send me a message to start one.')
-        return true
-      }
-      const info = this.statusInfoFrom(target.agentId, key, acpSessionId ?? undefined)
-      const link = acpSessionId
-        ? this.sessionLink(acpSessionId, this.sessionLinkSource(msg.platform, target.integrationId))
-        : undefined
-      // Presentation is the platform's (§7.4): HTML chrome + View link on Telegram,
-      // markdown + a real link button on Discord, plain text + a 🔗 line on Feishu,
-      // the compact pipe-linked status line on Slack.
-      if (conn) chrome.status(conn, msg, chromeCtx, info, link)
-      return true
-    }
-
-    if (
-      (command.kind === 'fast' ||
-        command.kind === 'model' ||
-        command.kind === 'effort' ||
-        command.kind === 'permission') &&
-      this.agents.get(target.agentId)?.allowRuntimeChangesInChat !== true
-    ) {
-      reply('Runtime settings can only be changed by an Agent editor from the Agent page.')
-      return true
-    }
-
-    if (command.kind === 'fast') {
-      // `/fast on|off` — toggle the session's fast mode (the control the status-bar
-      // Fast button used to offer). Records the sticky override + applies live if warm.
-      if (!rec) {
-        reply('No active session here to configure.')
-        return true
-      }
-      if (command.enable === null) {
-        reply('Usage: `/fast on` or `/fast off`.')
-        return true
-      }
-      this.setFastByKey(key, command.enable)
-      reply(command.enable ? '⚡ Fast mode on.' : '🐢 Fast mode off.')
-      return true
-    }
-
-    if (command.kind === 'model' || command.kind === 'effort' || command.kind === 'permission') {
-      // `/models`, `/effort`, `/permission` — on-demand session controls.
-      // Telegram status-bar dropdowns. A bare command renders a tappable card on Telegram
-      // AND Discord (numbered text list on Slack); an argument selects directly. Records
-      // the sticky per-session override + applies it live when the ACP session is warm.
-      if (!rec) {
-        reply('No active session here to configure.')
-        return true
-      }
-      // Platforms with tappable cards render one (§7.4), replied under the command;
-      // false falls back to the numbered text list (Slack, or a Discord select over
-      // its 25-button ceiling).
-      const selectCard = chrome.selectCard?.bind(chrome)
-      const renderCard =
-        selectCard && conn
-          ? (kind: SelectKind, current: string | undefined, options: string[]) =>
-              selectCard(conn, msg, chromeCtx, { kind, current, options, header: selectCardText(kind, current) })
-          : undefined
-      this.handleSelectCommand(
-        command.kind,
-        command.value,
-        target.agentId,
-        key,
-        acpSessionId ?? undefined,
-        reply,
-        renderCard
-      )
-      return true
-    }
-
-    // queue — now just admission through the UNIFIED per-sessionKey gate (§6.9 #390): the
-    // gate itself decides run-now vs enqueue-behind-the-turn; `!queue` only differs in the
-    // ACK wording and the queue_full reply. Depth cap + queue-full fast-fail live in the
-    // gate (dispatch → QueueFullError), so there is no second FIFO here anymore.
-    if (!command.text) {
-      reply('Usage: `!queue <message>` — runs when the current turn finishes.')
-      return true
-    }
-    // Dispatch/queue into the resolved session's thread (the fallback may have retargeted
-    // it from the bare command thread to the channel's latest session).
-    const payload: NormalizedMessage = { ...msg, text: command.text, thread }
-    // Reject fast (matching the old depth-cap ACK) before admitting so the user sees the
-    // "queue full" note rather than a silent drop; the gate would reject identically.
-    if (inflight && (this.serialQueue.get(key)?.length ?? 0) >= MAX_QUEUED_PER_SESSION) {
-      this.log.warn(`command: queue → agent "${target.agentId}" session ${key} full, rejected`)
-      reply(`Queue is full (${MAX_QUEUED_PER_SESSION} pending) — wait for the current turn to finish.`)
-      return true
-    }
-    void this.dispatch(target.agentId, payload, target.integrationId, undefined, undefined, { isQueueCmd: true }).catch(
-      (err) => {
-        if (err instanceof QueueFullError) return // already reported above; race-safe no-op
-        this.log.error(`queued dispatch failed for agent "${target.agentId}": ${(err as Error).stack ?? err}`)
-      }
-    )
-    if (!inflight) {
-      this.log.info(`command: queue → agent "${target.agentId}" idle, dispatching now`)
-      reply(`▶️ Running now — the session was idle.`)
-    } else {
-      const depth = this.serialQueue.get(key)?.length ?? 0
-      this.log.info(`command: queue → agent "${target.agentId}" session ${key} (depth ${depth})`)
-      reply(`📥 Queued (#${depth}) — will run when the current turn finishes.`)
-    }
-    return true
-  }
-
-  /** Sticky-override setters handed to the pure select projections. */
-  private readonly selectSetters: SelectSetters = {
-    model: (key, value) => this.setModelByKey(key, value),
-    effort: (key, value) => this.setEffortByKey(key, value),
-    permission: (key, value) => this.setPermissionModeByKey(key, value)
-  }
-
-  /**
-   * Back the `/models` `/effort` `/permission` commands. A bare command lists the current
-   * selectable values — as a tappable inline-keyboard card when `card` is provided
-   * (Telegram), else a numbered text list. An argument applies a choice, matched by exact
-   * id, unique case-insensitive substring, or 1-based list index. Options come from the
-   * live host's config selectors (statusInfoFrom); when the host is cold a given value is
-   * accepted optimistically and takes effect on the next turn.
-   */
-  private handleSelectCommand(
-    kind: SelectKind,
-    value: string | null,
-    agentId: string,
-    key: string,
-    acpSessionId: string | undefined,
-    reply: (text: string) => void,
-    renderCard?: (kind: SelectKind, current: string | undefined, options: string[]) => boolean
-  ): void {
-    const label = selectLabel(kind)
-    const info = this.statusInfoFrom(agentId, key, acpSessionId)
-    const { current, options } = selectOptions(kind, info)
-    const cmd = kind === 'model' ? 'models' : kind
-
-    const disp = (v: string) => selectDisplay(kind, v)
-
-    if (value === null) {
-      if (options.length === 0) {
-        reply(
-          current
-            ? `${label}: ${disp(current)} (no other options offered${kind === 'effort' ? ' — the current model may not support effort' : ''}).`
-            : `No ${label.toLowerCase()} options available yet — send me a message first, then try /${cmd} again.`
-        )
-        return
-      }
-      // A tappable card (Telegram / Discord) when available; false ⇒ fall back to text.
-      if (renderCard?.(kind, current, options)) return
-      const lines = options.map((o, i) => `${i + 1}. ${disp(o)}${o === current ? '  ✓ (current)' : ''}`)
-      reply(`${label} — reply \`/${cmd} <name or number>\`:\n${lines.join('\n')}`)
-      return
-    }
-
-    // Resolve the chosen value against the offered options (when we have them). Match
-    // the raw value OR its display label, so `/permission full access` resolves too.
-    let resolved: string | undefined
-    if (options.length === 0) {
-      resolved = value.trim() // host cold — accept optimistically, applies next turn
-    } else {
-      const v = value.trim()
-      const idx = Number(v)
-      if (Number.isInteger(idx) && idx >= 1 && idx <= options.length) resolved = options[idx - 1]
-      else {
-        const lc = v.toLowerCase()
-        const exact = (o: string) => o.toLowerCase() === lc || disp(o).toLowerCase() === lc
-        const partial = (o: string) => o.toLowerCase().includes(lc) || disp(o).toLowerCase().includes(lc)
-        resolved = options.find(exact) ?? (options.filter(partial).length === 1 ? options.find(partial) : undefined)
-      }
-    }
-    if (!resolved) {
-      reply(
-        `Unknown ${label.toLowerCase()} "${value.trim()}".${options.length ? ` Options: ${options.map(disp).join(', ')}` : ''}`
-      )
-      return
-    }
-    if (!applySelect(kind, key, resolved, this.selectSetters)) {
-      reply('Runtime settings can only be changed by an Agent editor from the Agent page.')
-      return
-    }
-    reply(
-      options.length === 0
-        ? `${label} set to ${disp(resolved)} — applies on your next message.`
-        : `✅ ${label} set to ${disp(resolved)}.`
-    )
-  }
-
-  /**
-   * Handle a tapped session-control card button (Telegram inline keyboard). Decodes
-   * `<kindCode>:<optionIndex>`, resolves the channel's latest admitted session, applies
-   * the picked value, acks the tap, and
-   * re-renders the card with the new current marked. Best-effort throughout — a tap
-   * must never throw out of the update pump.
-   */
-  private handleTelegramCallback(cb: TelegramCallback, conn: TelegramConnection): void {
-    const tap = parseTelegramSelect(cb.data)
-    if (!tap) {
-      void conn.answerCallback(cb.id)
-      return
-    }
-    const { kind, index: idx } = tap
-    const srcIntegrationIds = this.srcIntegrationIds(conn)
-    const session = this.commandSessionForLatest(
-      cb.channel,
-      srcIntegrationIds,
-      this.transportScopeForIntegrationIds(srcIntegrationIds)
-    )
-    if (!session) {
-      void conn.answerCallback(cb.id, 'No active session here.')
-      return
-    }
-    if (this.agents.get(session.agentId)?.allowRuntimeChangesInChat !== true) {
-      void conn.answerCallback(cb.id, 'Ask an Agent editor to change runtime settings.')
-      return
-    }
-    const info = this.statusInfoFrom(session.agentId, session.key, session.acpSessionId)
-    const { options } = selectOptions(kind, info)
-    const value = options[idx]
-    if (value === undefined) {
-      void conn.answerCallback(cb.id, 'Options changed — reopen the menu.')
-      return
-    }
-    if (!applySelect(kind, session.key, value, this.selectSetters)) return
-    // Telegram names the tapping user on the callback itself; record only the applied
-    // change, matching the other funnels.
-    this.logSessionAction(`select:${kind}`, session.key, { userId: cb.userId })
-    void conn.answerCallback(cb.id, `${selectLabel(kind)} → ${value}`)
-    void conn.editCard(
-      cb.channel,
-      cb.messageId,
-      selectCardText(kind, value),
-      telegramSelectButtons(kind, value, options)
-    )
-  }
-
-  /** The newest addressable session for a platform-scoped interaction (a Telegram
-   *  command/callback, a Slack message shortcut): scan the caller's own-platform
-   *  integrations, retain conversation routing gates, newest first. The caller is
-   *  already platform-specific — it names its platform as data, not as a branch. */
-  private latestAdmittedSession(
-    platform: string,
-    channel: string,
-    srcIntegrationIds: readonly string[],
-    transportScope?: string,
-    thread?: string
-  ): SessionRecord | null {
-    const candidates: SessionRecord[] = []
-    for (const [agentId, agent] of this.agents) {
-      for (const integration of agent.integrations) {
-        if (integration.platform !== platform || !srcIntegrationIds.includes(integration.id)) continue
-        const routing = integrationRouting(integration)
-        if (!conversationAdmitted(routing, channel)) continue
-        const session = this.store.latestSessionForTransport(agentId, channel, transportScope, thread)
-        if (session) candidates.push(session)
-      }
-    }
-    candidates.sort((a, b) => b.updatedAt - a.updatedAt || a.agentId.localeCompare(b.agentId))
-    return candidates[0] ?? null
-  }
-
-  /** The channel's latest admitted session for a Telegram command/callback. */
-  private commandSessionForLatest(
-    channel: string,
-    srcIntegrationIds: readonly string[],
-    transportScope?: string
-  ): { agentId: string; key: string; acpSessionId?: string } | null {
-    const latest = this.latestAdmittedSession('telegram', channel, srcIntegrationIds, transportScope)
-    return latest ? { agentId: latest.agentId, key: latest.key, acpSessionId: latest.acpSessionId ?? undefined } : null
-  }
-
-  /** Resolve a direct Slack message shortcut to the newest addressable session in
-   *  that exact bot-scoped conversation, retaining conversation routing gates. */
-  private slackShortcutSession(
-    shortcut: { channel: string; thread: string },
-    srcIntegrationIds: readonly string[]
-  ): string | undefined {
-    const transportScope = this.transportScopeForIntegrationIds(srcIntegrationIds)
-    return this.latestAdmittedSession('slack', shortcut.channel, srcIntegrationIds, transportScope, shortcut.thread)
-      ?.key
-  }
 
   /** Local layer (agent.json) ∪ resolved CP layer; unservable CP rules are dropped + warn-logged. */
   private mergedRules(): RoutingRule[] {


### PR DESCRIPTION
## What

Moves the 24 command-execution methods off the `Daemon` class into a new `CommandHandlers` class in `packages/daemon/src/commands/handlers.ts` (~780 lines relocated; `daemon.ts` −792/+114).

Relocated by name: `logSessionAction`, `chatRuntimeSession`, `setModelByKey`, `cancelSessionByKey`, `setEffortByKey`, `applySessionPermissionPreset`, `setPermissionModeByKey`, `setFastByKey`, `refreshStatusBarForKey`, `setOutputModeByKey`, `handleStatusAction`, `handleDiscordSelect`, `isSessionMuted`, `setSessionMuted`, `resolveCommandTargetFromLatest`, `resolveExplicitCommandTarget`, `resolveTopLevelResumeTarget`, `commandSenderAllowed`, `handleCommand`, `handleSelectCommand`, `handleTelegramCallback`, `latestAdmittedSession`, `commandSessionForLatest`, `slackShortcutSession` — plus the `selectSetters` table they hand to the pure projections.

## Shape

- The parser stays in `commands/commands.ts` and the pure select projections in `commands/select-projection.ts` (extracted in #1151); `handlers.ts` is the stateful half that pairs with them.
- The slice owns **no Daemon state**. Every read and every single-point write goes through the new `CommandHost` interface (24 members: `store`, `log`, `agents`, `pending`, `inflight`, `serialQueue`, `activeGateEntries`, `commandChrome`, `hasModelSessionHost`, `modelCrossesHostProvider`, `hostForStoredSession`, `statusInfoFrom`, `emitStatusBar`, `interruptTurn`, `dispatchQueueCommand`, `replyConnFor`, `sessionLink`/`sessionLinkSource`, `threadOwner`, `mergedRulesForSource`, `transportScopeForIntegrationIds`, `integrationBelongsToSource`, `srcIntegrationIds`, `clearEnforcedLoopScope`), built by `Daemon.commandHost()` next to the other host builders.
- The Daemon keeps thin same-name private delegates for every method an ingress path, a platform connection callback or a test calls by name — so `handleCommand`'s two entry points (`onInboundOutcome`, `handleRelayIm`), the existing `PlatformActionSink` wiring on the connection reconciler (`handleStatusAction` / `handleDiscordSelect` / `handleTelegramCallback` / `slackShortcutSession`), the webchat runtime-control ops, and the tests that poke or patch `isSessionMuted` / `setSessionMuted` / `setModelByKey` / … are untouched. The reconciler itself is not rewritten.
- `applyConfiguredRuntimeSettings` / `restoreConfiguredRuntimeSettings` deliberately stay on the Daemon: they are a runtime-config concern, not a command. They call the `applySessionPermissionPreset` / `refreshStatusBarForKey` delegates.

No behavior change.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean
- `prettier --check` + `eslint` on both touched files — clean
- `vitest run` on: `daemon-commands` (main pin, 54 tests), `commands`, `session-action-audit`, `model-catalog-daemon`, `model-key-session`, `telegram-threading`, `attribution`, `no-response`, `daemon-agent-mention-routing`, `daemon-interrupt-safety`, plus `daemon-webchat`, `command-chrome`, `platform-contract`, `platform-registry-drift`, `slack-status-actor`, `discord-app-commands`, `relay-persist` — all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)