### PR TITLE
fix(daemon): report each runtime probe as it lands, stop starving package launchers

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -19268,6 +19268,14 @@ export class Daemon {
     ]
   }
 
+  /** The `facts/daemon-runtimes` snapshot for the currently reported runtime set. */
+  private emitDaemonRuntimeFacts(): void {
+    this.cpClient?.emitDaemonRuntimes?.(
+      this.reportedRuntimeIds().map((id) => this.runtimeProfileFor(id)),
+      this.mcpServerFactsFromDefs()
+    )
+  }
+
   /** How long a completed probe sweep stays fresh — reconnects within this window
    *  re-emit the cached profiles instead of re-spawning every agent. */
   private static readonly PROBE_TTL_MS = 5 * 60_000
@@ -19302,10 +19310,7 @@ export class Daemon {
     // that (re)asserts the runtime list. Unconditional — unlike the fake-host guard
     // below, an injected prober must not re-enable local spawning in this mode.
     if (this.k8s) {
-      this.cpClient?.emitDaemonRuntimes?.(
-        this.reportedRuntimeIds().map((id) => this.runtimeProfileFor(id)),
-        this.mcpServerFactsFromDefs()
-      )
+      this.emitDaemonRuntimeFacts()
       return
     }
     // With a hostFactory (unit tests use fake in-memory hosts) we don't spawn real
@@ -19327,11 +19332,7 @@ export class Daemon {
     const curatedCandidates = this.curatedRuntimeAdmission.probeCandidates(this.runtimeCatalog)
     if (fresh && Object.keys(curatedCandidates).length === 0) {
       // Recent results still valid — just re-assert the snapshot to the (new) connection.
-      const ids = this.reportedRuntimeIds()
-      this.cpClient?.emitDaemonRuntimes?.(
-        ids.map((id) => this.runtimeProfileFor(id)),
-        this.mcpServerFactsFromDefs()
-      )
+      this.emitDaemonRuntimeFacts()
       return
     }
 
@@ -19355,12 +19356,25 @@ export class Daemon {
         log: this.log,
         isolateAccountApps: this.cfg.security.isolateAccountApps
       })
+      // Apply and report every result the moment it lands. A package-launcher
+      // runtime building its install tree takes minutes on first use, and holding
+      // the whole sweep for it also held back the runtimes that answered in
+      // seconds. `facts/daemon-runtimes` is idempotent REPLACE fenced by `seq`
+      // (design runtime-model-catalog.md §6), so per-result frames converge.
+      const applied = new Set<string>()
+      const onResult = (result: RuntimeProbeResult): void => {
+        if (applied.has(result.runtime)) return
+        applied.add(result.runtime)
+        this.applyProbeResult(result)
+        this.emitDaemonRuntimeFacts()
+      }
       const batches: Array<Promise<RuntimeProbeResult[]>> = []
       if (Object.keys(ordinaryRuntimes).length > 0) {
         batches.push(
           probe(ordinaryRuntimes, {
             log: this.log,
             hostFactory: probeHostFactory,
+            onResult,
             launchFor: (id, runtime, scopeDir, cwd) =>
               prepareRuntimeLaunch({
                 runtimeId: id,
@@ -19375,7 +19389,8 @@ export class Daemon {
                     ? runtimeSandboxReadRoots(runtime, process.env).readRoots
                     : undefined,
                 explicitEnv: Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value])),
-                sandboxMechanism: this.sandboxMechanism
+                sandboxMechanism: this.sandboxMechanism,
+                hostPackageCache: true
               })
           })
         )
@@ -19386,6 +19401,7 @@ export class Daemon {
             curated: true,
             log: this.log,
             hostFactory: probeHostFactory,
+            onResult,
             runInSandbox: this.sandboxMechanism !== undefined,
             daemonRoot: this.root,
             agentsRoot: this.cfg.agentsDir,
@@ -19396,110 +19412,14 @@ export class Daemon {
         )
       }
       const results = (await Promise.all(batches)).flat()
-      for (const result of results) {
-        if (this.runtimeCatalog.entries[result.runtime]?.source === 'curated') {
-          this.curatedRuntimeAdmission.record(result)
-        }
-      }
-      this.refreshAdmittedRuntimes()
-      for (const r of results) {
-        // Successful probes (including empty selectors) and auth failures are
-        // authoritative. Preserve a non-empty cache-hydrated list across other
-        // startup probe failures: disposable probe homes can fail while established
-        // agent homes remain usable. Cached provenance keeps model gates permissive
-        // until a later successful probe supplies live knowledge.
-        const keepCachedAdvertisement =
-          !r.ok &&
-          !r.authRequired &&
-          this.runtimeModelsSource.get(r.runtime) === 'cached' &&
-          (this.runtimeModels.get(r.runtime)?.length ?? 0) > 0
-        if (!keepCachedAdvertisement) {
-          this.runtimeModels.set(r.runtime, r.ok ? r.models : [])
-          this.runtimeModelsSource.set(r.runtime, 'probed')
-        }
-        if (r.ok && r.acpProtocolVersion !== undefined) this.runtimeAcpVersions.set(r.runtime, r.acpProtocolVersion)
-        else this.runtimeAcpVersions.delete(r.runtime)
-        if (r.ok && r.probedVersion) this.runtimeProbedVersions.set(r.runtime, r.probedVersion)
-        else this.runtimeProbedVersions.delete(r.runtime)
-        // Same overwrite rule: an unreachable runtime falls back to "not probed"
-        // (⇒ session resolution turns optimistic again rather than trusting stale caps).
-        if (r.ok && r.mcpCapabilities) this.runtimeMcpCaps.set(r.runtime, r.mcpCapabilities)
-        else this.runtimeMcpCaps.delete(r.runtime)
-        // Login state is live knowledge from this probe only: set on an ACP
-        // auth-required rejection, cleared on success or any OTHER failure kind
-        // (a timeout says nothing about credentials).
-        if (!r.ok && r.authRequired) this.runtimeAuthRequired.add(r.runtime)
-        else this.runtimeAuthRequired.delete(r.runtime)
-      }
-      // Phase 1 of catalog discovery (design runtime-model-catalog.md §3.3): the
-      // probe session's config options are already in hand — seed the cache with
-      // the default model's caps + runtime-level permission modes, then let the
-      // discovery gate decide whether a full phase-2 discovery is due. Failures
-      // deliberately skip this block: the last-good catalog is never cleared.
-      for (const r of results) {
-        if (!r.ok) continue
-        const entry = this.runtimeCatalog.entries[r.runtime]
-        if (!entry || this.runtimes[r.runtime] === undefined) continue // curated candidates pre-admission stay out
-        try {
-          const fp = catalogFingerprint(r.runtime, r.probedVersion, entry.runtime)
-          if (r.configOptions) {
-            const caps = capsFromConfigOptions(r.configOptions)
-            const existing = this.store.getRuntimeCatalogMeta(r.runtime)
-            // Phase 1 must not flip a driver-built catalog back to 'acp'.
-            const source = existing && existing.fingerprint === fp ? existing.source : 'acp'
-            // The probe session sits on `currentModel` — which may be the literal
-            // "default" a runtime advertises. Seed that model's caps under its real
-            // id (so selecting "default" shows the runtime's own effort/fast), but
-            // keep meta.defaultModel to a CONCRETE resolved id (never "default") —
-            // it feeds the console's preselection + "Default (…)" hint, and a
-            // native driver may still overwrite it with a concrete default.
-            const seedModel = caps.currentModel
-            const defaultModel = seedModel && seedModel !== 'default' ? seedModel : undefined
-            this.store.recordRuntimeCatalogMeta({
-              runtimeId: r.runtime,
-              fingerprint: fp,
-              source,
-              ...(defaultModel ? { defaultModel } : {}),
-              ...(caps.permissionModes ? { permissionModes: caps.permissionModes } : {}),
-              ...(caps.currentPermissionMode ? { defaultPermissionMode: caps.currentPermissionMode } : {}),
-              observedAt: this.clock.now()
-            })
-            if (seedModel) {
-              this.store.upsertRuntimeModelCap({
-                runtimeId: r.runtime,
-                modelId: seedModel,
-                fingerprint: fp,
-                caps: {
-                  efforts: caps.efforts,
-                  ...(caps.defaultEffort ? { defaultEffort: caps.defaultEffort } : {}),
-                  fastMode: caps.fastMode
-                },
-                observedAt: this.clock.now()
-              })
-            }
-            this.rebuildRuntimeCatalog(r.runtime)
-          }
-          this.modelCatalogSvc?.noteProbe({
-            runtimeId: r.runtime,
-            rt: entry.runtime,
-            probedVersion: r.probedVersion,
-            models: r.models
-          })
-        } catch (err) {
-          this.log.warn(`catalog: phase-1 seed for ${r.runtime} failed: ${formatErr(err)}`)
-        }
-      }
+      // An injected prober (tests) may not drive the incremental callback.
+      for (const result of results) onResult(result)
       if (Object.keys(ordinaryRuntimes).length > 0) this.lastProbeAtMs = this.clock.now()
       const okCount = results.filter((r) => r.ok).length
       this.log.info(`probe: sweep complete — ${okCount}/${results.length} runtime(s) reachable`)
-      // Emit only once the sweep is done, so the CP sees a consistent snapshot.
-      // `facts/daemon-runtimes` replaces the CP's runtime + MCP-server lists wholesale,
-      // so entries removed since the last report are pruned rather than left stale.
-      const ids = this.reportedRuntimeIds()
-      this.cpClient?.emitDaemonRuntimes?.(
-        ids.map((id) => this.runtimeProfileFor(id)),
-        this.mcpServerFactsFromDefs()
-      )
+      // Each result already emitted the REPLACE snapshot that prunes vanished ids, so
+      // only a sweep that produced none still owes the CP one.
+      if (applied.size === 0) this.emitDaemonRuntimeFacts()
       // Probe results can change runtime-derived registration capabilities, and
       // register ran before this sweep — re-announce if the set moved.
       this.cpClient?.updateCapabilities?.()
@@ -19513,6 +19433,100 @@ export class Daemon {
         this.curatedProbePending = false
         void this.probeRuntimesAndEmit(includePendingOrdinary)
       }
+    }
+  }
+
+  /** Fold one probe result into admission, advertised models/caps and the model
+   *  catalog. Called per result so a slow runtime delays only itself. */
+  private applyProbeResult(r: RuntimeProbeResult): void {
+    if (this.runtimeCatalog.entries[r.runtime]?.source === 'curated') this.curatedRuntimeAdmission.record(r)
+    this.refreshAdmittedRuntimes()
+    // Successful probes (including empty selectors) and auth failures are
+    // authoritative. Preserve a non-empty cache-hydrated list across other
+    // startup probe failures: disposable probe homes can fail while established
+    // agent homes remain usable. Cached provenance keeps model gates permissive
+    // until a later successful probe supplies live knowledge.
+    const keepCachedAdvertisement =
+      !r.ok &&
+      !r.authRequired &&
+      this.runtimeModelsSource.get(r.runtime) === 'cached' &&
+      (this.runtimeModels.get(r.runtime)?.length ?? 0) > 0
+    if (!keepCachedAdvertisement) {
+      this.runtimeModels.set(r.runtime, r.ok ? r.models : [])
+      this.runtimeModelsSource.set(r.runtime, 'probed')
+    }
+    if (r.ok && r.acpProtocolVersion !== undefined) this.runtimeAcpVersions.set(r.runtime, r.acpProtocolVersion)
+    else this.runtimeAcpVersions.delete(r.runtime)
+    if (r.ok && r.probedVersion) this.runtimeProbedVersions.set(r.runtime, r.probedVersion)
+    else this.runtimeProbedVersions.delete(r.runtime)
+    // Same overwrite rule: an unreachable runtime falls back to "not probed"
+    // (⇒ session resolution turns optimistic again rather than trusting stale caps).
+    if (r.ok && r.mcpCapabilities) this.runtimeMcpCaps.set(r.runtime, r.mcpCapabilities)
+    else this.runtimeMcpCaps.delete(r.runtime)
+    // Login state is live knowledge from this probe only: set on an ACP
+    // auth-required rejection, cleared on success or any OTHER failure kind
+    // (a timeout says nothing about credentials).
+    if (!r.ok && r.authRequired) this.runtimeAuthRequired.add(r.runtime)
+    else this.runtimeAuthRequired.delete(r.runtime)
+    this.seedCatalogFromProbe(r)
+  }
+
+  /** Phase 1 of catalog discovery (design runtime-model-catalog.md §3.3): the probe
+   *  session's config options are already in hand — seed the cache with the default
+   *  model's caps + runtime-level permission modes, then let the discovery gate decide
+   *  whether a full phase-2 discovery is due. A failed probe deliberately skips this:
+   *  the last-good catalog is never cleared. */
+  private seedCatalogFromProbe(r: RuntimeProbeResult): void {
+    if (!r.ok) return
+    const entry = this.runtimeCatalog.entries[r.runtime]
+    if (!entry || this.runtimes[r.runtime] === undefined) return // curated candidates pre-admission stay out
+    try {
+      const fp = catalogFingerprint(r.runtime, r.probedVersion, entry.runtime)
+      if (r.configOptions) {
+        const caps = capsFromConfigOptions(r.configOptions)
+        const existing = this.store.getRuntimeCatalogMeta(r.runtime)
+        // Phase 1 must not flip a driver-built catalog back to 'acp'.
+        const source = existing && existing.fingerprint === fp ? existing.source : 'acp'
+        // The probe session sits on `currentModel` — which may be the literal
+        // "default" a runtime advertises. Seed that model's caps under its real
+        // id (so selecting "default" shows the runtime's own effort/fast), but
+        // keep meta.defaultModel to a CONCRETE resolved id (never "default") —
+        // it feeds the console's preselection + "Default (…)" hint, and a
+        // native driver may still overwrite it with a concrete default.
+        const seedModel = caps.currentModel
+        const defaultModel = seedModel && seedModel !== 'default' ? seedModel : undefined
+        this.store.recordRuntimeCatalogMeta({
+          runtimeId: r.runtime,
+          fingerprint: fp,
+          source,
+          ...(defaultModel ? { defaultModel } : {}),
+          ...(caps.permissionModes ? { permissionModes: caps.permissionModes } : {}),
+          ...(caps.currentPermissionMode ? { defaultPermissionMode: caps.currentPermissionMode } : {}),
+          observedAt: this.clock.now()
+        })
+        if (seedModel) {
+          this.store.upsertRuntimeModelCap({
+            runtimeId: r.runtime,
+            modelId: seedModel,
+            fingerprint: fp,
+            caps: {
+              efforts: caps.efforts,
+              ...(caps.defaultEffort ? { defaultEffort: caps.defaultEffort } : {}),
+              fastMode: caps.fastMode
+            },
+            observedAt: this.clock.now()
+          })
+        }
+        this.rebuildRuntimeCatalog(r.runtime)
+      }
+      this.modelCatalogSvc?.noteProbe({
+        runtimeId: r.runtime,
+        rt: entry.runtime,
+        probedVersion: r.probedVersion,
+        models: r.models
+      })
+    } catch (err) {
+      this.log.warn(`catalog: phase-1 seed for ${r.runtime} failed: ${formatErr(err)}`)
     }
   }
 
@@ -19533,10 +19547,7 @@ export class Daemon {
    * converges with the new provider set.
    */
   private onMcpDefsChanged(): void {
-    this.cpClient?.emitDaemonRuntimes?.(
-      this.reportedRuntimeIds().map((id) => this.runtimeProfileFor(id)),
-      this.mcpServerFactsFromDefs()
-    )
+    this.emitDaemonRuntimeFacts()
   }
 
   private externalMemoryAdmission(agentId: string): { assertReady(connectionId: string): void } {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -19417,9 +19417,24 @@ export class Daemon {
       if (Object.keys(ordinaryRuntimes).length > 0) this.lastProbeAtMs = this.clock.now()
       const okCount = results.filter((r) => r.ok).length
       this.log.info(`probe: sweep complete — ${okCount}/${results.length} runtime(s) reachable`)
+      // Admission freshness is measured from the END of the sweep that observed it,
+      // because armRuntimeProbeRefresh() only starts the next one from here. Stamping
+      // each result when it landed would expire a runtime that answered in seconds one
+      // whole slow-launcher install before its next probe — unlaunchable, and pruned
+      // from the snapshot — so restamp the batch now that every result is in.
+      const reportedBefore = this.reportedRuntimeIds().join(' ')
+      for (const result of results) {
+        if (this.runtimeCatalog.entries[result.runtime]?.source === 'curated') {
+          this.curatedRuntimeAdmission.record(result)
+        }
+      }
+      this.refreshAdmittedRuntimes()
       // Each result already emitted the REPLACE snapshot that prunes vanished ids, so
-      // only a sweep that produced none still owes the CP one.
-      if (applied.size === 0) this.emitDaemonRuntimeFacts()
+      // the CP is owed one only when the sweep produced none, or when restamping
+      // brought a runtime back that had expired mid-sweep.
+      if (applied.size === 0 || this.reportedRuntimeIds().join(' ') !== reportedBefore) {
+        this.emitDaemonRuntimeFacts()
+      }
       // Probe results can change runtime-derived registration capabilities, and
       // register ran before this sweep — re-announce if the set moved.
       this.cpClient?.updateCapabilities?.()

--- a/packages/daemon/src/launch/compose.ts
+++ b/packages/daemon/src/launch/compose.ts
@@ -158,6 +158,8 @@ export function composeRuntimeLaunch(opts: {
   allowModelToolUnixSockets?: boolean
   /** True in --k8s: the runtime runs in a sandbox pod, so this daemon's env must not travel. */
   k8s?: boolean
+  /** Probe launches only — keep npx/uvx on the host package cache. */
+  hostPackageCache?: boolean
 }): ComposedRuntimeLaunch {
   const policyId = runtimeMemoryPolicyId(opts.runtime, opts.runtimeId)
   const capabilities = runtimeMemoryCapabilities(opts.runtime, opts.runtimeId)
@@ -189,7 +191,8 @@ export function composeRuntimeLaunch(opts: {
     trustedWorkspaceWriteRoots: opts.trustedWorkspaceWriteRoots,
     sandboxMechanism: opts.sandboxMechanism,
     mcpSocketPath: opts.mcpSocketPath,
-    allowModelToolUnixSockets: opts.allowModelToolUnixSockets
+    allowModelToolUnixSockets: opts.allowModelToolUnixSockets,
+    ...(opts.hostPackageCache ? { hostPackageCache: true as const } : {})
   })
   if (sandboxAccess?.claudeExecutable && !launch.env.CLAUDE_CODE_EXECUTABLE) {
     launch.env.CLAUDE_CODE_EXECUTABLE = sandboxAccess.claudeExecutable

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -5,7 +5,12 @@ import { sandboxBoundary, writeSandboxSettings, type SandboxMechanism } from '..
 import type { RuntimeDef } from '../config/config-schema.js'
 import { compactReadRoots } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../runtimes/runtime-credentials.js'
-import { prepareRuntimeHome, runtimeHomeEnvironment, runtimeHomePath } from '../runtimes/runtime-home.js'
+import {
+  hostPackageCacheEnv,
+  prepareRuntimeHome,
+  runtimeHomeEnvironment,
+  runtimeHomePath
+} from '../runtimes/runtime-home.js'
 import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
 import {
   CLAUDE_PROFILE_ENV,
@@ -169,6 +174,10 @@ export function prepareRuntimeLaunch(opts: {
   /** Permit the runtime-native tool sandbox to reach a daemon-owned Unix
    * channel. An enabled outer sandbox remains the surrounding boundary. */
   allowModelToolUnixSockets?: boolean
+  /** Probe launches only: keep npx/uvx on the HOST package cache (see
+   * hostPackageCacheEnv). A probe never runs a model turn; an agent launch must not
+   * get this, so its confined tool use cannot write another runtime's install tree. */
+  hostPackageCache?: boolean
 }): PreparedRuntimeLaunch {
   const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   if (!opts.runInSandbox && !opts.isolateHome) {
@@ -286,8 +295,10 @@ export function prepareRuntimeLaunch(opts: {
     credentials?.seedExclusions
   )
   credentials?.preparePrivateHome(runtimeHome)
+  const packageCacheEnv = opts.hostPackageCache ? hostPackageCacheEnv(opts.runtime?.command, stateSourceEnv) : {}
   const env = {
     ...runtimeHomeEnvironment(opts.runtimeId, runtimeHome, opts.explicitEnv, opts.hostEnv),
+    ...packageCacheEnv,
     ...credentials?.env
   }
 
@@ -331,6 +342,17 @@ export function prepareRuntimeLaunch(opts: {
       if (broadened) {
         throw new Error(`shared credential write root "${trusted}" would reopen protected path "${broadened}"`)
       }
+      return trusted
+    })
+  )
+  // npm/uv must WRITE their cache (tarballs, index, the npx install tree), so the
+  // pinned host cache needs a write carve-back below the hidden host HOME. Same rule
+  // as a shared credential root: it may sit under a protected root, never contain one.
+  const packageCacheWriteRoots = compactReadRoots(
+    Object.values(packageCacheEnv).map((path) => {
+      const trusted = safeRoot(path, 'host package cache root')
+      const broadened = protectedRoots.find((denied) => inside(trusted, denied))
+      if (broadened) throw new Error(`host package cache root "${trusted}" would reopen protected path "${broadened}"`)
       return trusted
     })
   )
@@ -381,7 +403,7 @@ export function prepareRuntimeLaunch(opts: {
     runtimeHome,
     mcpSocketPath: opts.mcpSocketPath,
     trustedReadRoots: [...trustedRuntimeReadRoots, ...providerCredentialReadRoots],
-    trustedWriteRoots: [...credentialWritableRoots, ...trustedWorkspaceWriteRoots]
+    trustedWriteRoots: [...credentialWritableRoots, ...trustedWorkspaceWriteRoots, ...packageCacheWriteRoots]
   })
   // SRT write roots must exist before spawn.
   // This also initializes workspace/memory for a newly-created agent.

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -118,7 +118,7 @@ export interface RuntimeStateLocation {
 
 // --- home / XDG path resolution (honors the standard env overrides) ----------
 
-function home(env: NodeJS.ProcessEnv): string {
+export function home(env: NodeJS.ProcessEnv): string {
   return (isWin ? env.USERPROFILE : env.HOME) || homedir()
 }
 function xdgConfigHome(env: NodeJS.ProcessEnv): string {
@@ -371,7 +371,7 @@ export const CUSTOM_PROBES: Record<string, RuntimeProbe> = Object.fromEntries(
  * one of these, the launcher being on `$PATH` says nothing about whether the
  * wrapped agent is installed, so such runtimes require a custom probe to count.
  */
-const PACKAGE_LAUNCHERS = new Set(['npx', 'uvx'])
+export const PACKAGE_LAUNCHERS = new Set(['npx', 'uvx'])
 const CURATED_RUNTIME_IDS = new Set([...Object.keys(CURATED_RUNTIME_CATALOG), 'hermes'])
 
 /** Is this runtime actually usable on this host? */

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -11,7 +11,7 @@ import {
   writeFileSync
 } from 'node:fs'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
-import { runtimeStateLocations } from './probe.js'
+import { home as hostHomeDir, runtimeStateLocations } from './probe.js'
 import { extractOmpCredentials } from './omp-credentials.js'
 
 const MAX_SEED_FILE_BYTES = 2 * 1024 * 1024
@@ -252,6 +252,26 @@ function inheritedEnvironment(source: NodeJS.ProcessEnv): Record<string, string>
     out[name] = value
   }
   return out
+}
+
+/** Launcher caches a disposable probe HOME keeps on the HOST: npx/uvx otherwise rebuild
+ *  their whole install tree per sweep (~210s for a 700-package harness), and the bytes
+ *  are content-addressed packages, not user state. Probe launches only — see the
+ *  `hostPackageCache` option in prepareRuntimeLaunch for why an agent must not get it. */
+export function hostPackageCacheEnv(
+  command: string | undefined,
+  hostEnv: NodeJS.ProcessEnv = process.env
+): Record<string, string> {
+  if (command === 'npx') {
+    return {
+      npm_config_cache: hostEnv.npm_config_cache || hostEnv.NPM_CONFIG_CACHE || join(hostHomeDir(hostEnv), '.npm')
+    }
+  }
+  if (command === 'uvx') {
+    const cacheHome = hostEnv.XDG_CACHE_HOME || join(hostHomeDir(hostEnv), '.cache')
+    return { UV_CACHE_DIR: hostEnv.UV_CACHE_DIR || join(cacheHome, 'uv') }
+  }
+  return {}
 }
 
 type RuntimePrivateEnv = (home: string, hostEnv: NodeJS.ProcessEnv) => Record<string, string>

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -22,6 +22,7 @@ import type { Logger } from '../log.js'
 import type { SandboxMechanism } from '../acp/sandbox.js'
 import type { PreparedRuntimeLaunch } from '../launch/prepare.js'
 import { composeRuntimeLaunch } from '../launch/compose.js'
+import { PACKAGE_LAUNCHERS } from './probe.js'
 
 const PROCESS_ENV_KEYS = new Set(['PATH', 'PATHEXT', 'SystemRoot'])
 const CERTIFICATE_ENV_KEYS = new Set([
@@ -146,6 +147,9 @@ export interface ProbeOptions {
   log?: Logger
   /** Constructs the probe client per runtime — `defaultProbeHostFactory()` in production. */
   hostFactory: ProbeHostFactory
+  /** Called as each probe resolves, so a caller reports incrementally instead of
+   *  at the sweep barrier — one slow runtime then delays only itself. */
+  onResult?: (result: RuntimeProbeResult) => void
   /** Curated candidates require a disposable final managed launch plan. */
   curated?: boolean
   /** Full host environment used for allowlisted credential seeding and redaction. */
@@ -166,7 +170,17 @@ export interface ProbeOptions {
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000
+/** A package launcher builds its install tree on first use — measured at ~210s for a
+ *  harness that pulls 700 packages — so its deadline only reaps a genuinely stuck
+ *  child. Results are reported per probe (ProbeOptions.onResult), so a slow install no
+ *  longer holds back the runtimes that already answered. */
+const PACKAGE_LAUNCHER_TIMEOUT_MS = 6 * 60_000
 const DEFAULT_CONCURRENCY = 3
+
+/** Spawn + initialize + session/new budget for one runtime. */
+export function probeTimeoutMs(rt: RuntimeDef): number {
+  return PACKAGE_LAUNCHERS.has(rt.command) ? PACKAGE_LAUNCHER_TIMEOUT_MS : DEFAULT_TIMEOUT_MS
+}
 
 /** Probe temp roots are `ac-probe-<daemon-pid>-<random>` directly under the OS
  *  temp dir. The PID lets a sweeper distinguish a live concurrent daemon from
@@ -467,7 +481,8 @@ export function preparedProbeLaunch(
     sandboxMechanism: opts.sandboxMechanism,
     mcpSocketPath: opts.mcpSocketPath,
     stateSourceEnv: sourceEnv,
-    hostEnv: probeEnv
+    hostEnv: probeEnv,
+    hostPackageCache: true
   })
   if (id === 'hermes-agent' || id === 'hermes') sanitizeHermesProbeDotEnv(composed.launch)
   if (id === 'maki') removeMakiProbeMcpConfig(composed.launch)
@@ -490,7 +505,7 @@ export async function probeRuntime(
   cwd: string,
   opts: ProbeOptions
 ): Promise<RuntimeProbeResult> {
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const timeoutMs = opts.timeoutMs ?? probeTimeoutMs(rt)
   let host: AcpProbeClient | undefined
   let redactValues: string[] = []
 
@@ -583,7 +598,14 @@ export async function probeAllRuntimes(
       const runtimeDir = join(cwd, Buffer.from(id).toString('base64url'))
       const runtimeCwd = join(runtimeDir, 'workspace')
       mkdirSync(runtimeCwd, { recursive: true })
-      results.push(await probeRuntime(id, runtimes[id]!, runtimeCwd, opts))
+      const result = await probeRuntime(id, runtimes[id]!, runtimeCwd, opts)
+      results.push(result)
+      try {
+        opts.onResult?.(result)
+      } catch (err) {
+        // A reporting failure must never abort the remaining probes.
+        opts.log?.warn(`probe: reporting ${id} failed: ${(err as Error).message}`)
+      }
     }
   }
 

--- a/packages/daemon/test/curated-runtime-daemon.test.ts
+++ b/packages/daemon/test/curated-runtime-daemon.test.ts
@@ -257,6 +257,51 @@ describe('daemon curated runtime admission', () => {
     }
   }, 15_000)
 
+  // Admission freshness has to survive a slow co-probe: the next sweep is scheduled from
+  // sweep completion, so a runtime stamped when it landed would go unlaunchable (and get
+  // pruned from the snapshot) for the rest of a long package-launcher install.
+  it('keeps a fast curated result admitted when a slow co-probe outlasts its TTL', async () => {
+    const clock = new FakeClock(100)
+    // 'hermes-agent' answers immediately; the sweep then burns more than the 5-minute
+    // admission TTL before returning, exactly like a cold npx install.
+    const probe = vi.fn(
+      async (
+        runtimes: Record<string, unknown>,
+        options: { onResult?: (r: Record<string, unknown>) => void }
+      ): Promise<Array<Record<string, unknown>>> => {
+        const results = Object.keys(runtimes).map((runtime) => ({ runtime, ok: true, models: [] }))
+        for (const result of results) options.onResult?.(result)
+        clock.advance(6 * 60_000)
+        return results
+      }
+    )
+    const daemon = new Daemon({ clock, probeRuntimes: probe as never, sandboxMechanism: null })
+
+    try {
+      ;(daemon as any).cfg = { security: { isolateAccountApps: true } }
+      ;(daemon as any).root = '/tmp/curated-admission-ttl-test'
+      ;(daemon as any).runtimeCatalog = catalog()
+      ;(daemon as any).refreshAdmittedRuntimes()
+      const emitted: string[][] = []
+      ;(daemon as any).cpClient = {
+        emitDaemonRuntimes: (profiles: Array<{ runtime: string }>) => emitted.push(profiles.map((p) => p.runtime)),
+        stop: vi.fn(async () => {})
+      }
+
+      await (daemon as any).probeRuntimesAndEmit(true)
+
+      expect(probe).toHaveBeenCalled()
+      expect(Object.keys((daemon as any).runtimes).sort()).toEqual(['explicit', 'hermes-agent'])
+      expect(() => (daemon as any).curatedRuntimeAdmission.assertLaunch('hermes-agent', 'curated')).not.toThrow()
+      // The restamp brought it back, so the CP sees it in the final snapshot too.
+      expect(emitted.at(-1)).toContain('hermes-agent')
+    } finally {
+      ;(daemon as any).draining = true
+      const timer = (daemon as any).runtimeProbeTimer
+      if (timer !== undefined) clock.clearTimeout(timer)
+    }
+  }, 15_000)
+
   it('refreshes curated admission after the TTL without requiring a CP reconnect', async () => {
     const clock = new FakeClock(100)
     const probe = vi.fn(async (runtimes: Record<string, unknown>) =>

--- a/packages/daemon/test/curated-runtime-daemon.test.ts
+++ b/packages/daemon/test/curated-runtime-daemon.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Daemon } from '../src/daemon.js'
+import { CuratedRuntimeAdmission } from '../src/runtimes/curated-admission.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 import { FakeClock } from './cp/fake-clock.js'
 
@@ -195,6 +196,62 @@ describe('daemon curated runtime admission', () => {
       ;(daemon as any).noteRuntimeAuthFromTurn('explicit', false)
       expect(emitted.length).toBe(beforeClear + 1)
       expect(emitted[emitted.length - 1]!.find((p) => p.runtime === 'explicit')?.authRequired).toBeUndefined()
+    } finally {
+      await daemon.stop()
+    }
+  }, 15_000)
+
+  // The sweep used to apply every result at one barrier, so a curated runtime whose
+  // package launcher spends minutes building its install tree also held back the
+  // runtimes that answered in seconds — including their admission.
+  it('reports each probe as it lands instead of waiting for the slowest runtime', async () => {
+    let releaseCurated = (): void => {}
+    let gate: Promise<void> | undefined
+    const probe = vi.fn(
+      async (runtimes: Record<string, unknown>, options: { onResult?: (r: Record<string, unknown>) => void }) => {
+        const results: Array<Record<string, unknown>> = []
+        for (const runtime of Object.keys(runtimes)) {
+          if (runtime === 'hermes-agent' && gate) await gate
+          const result = { runtime, ok: true, models: [] }
+          options.onResult?.(result)
+          results.push(result)
+        }
+        return results
+      }
+    )
+    const daemon = new Daemon({
+      root: root(),
+      resolveCatalog: async () => catalog(),
+      installed: (runtimes) => runtimes,
+      probeRuntimes: probe as never,
+      hostFactory: () => ({}) as never
+    })
+
+    try {
+      await daemon.start()
+      await waitForProbe(daemon, probe)
+      const emitted: string[][] = []
+      ;(daemon as any).cpClient = {
+        emitDaemonRuntimes: (profiles: Array<{ runtime: string }>) => emitted.push(profiles.map((p) => p.runtime)),
+        stop: vi.fn(async () => {})
+      }
+      // Re-arm a full sweep whose curated probe blocks until released.
+      ;(daemon as any).lastProbeAtMs = 0
+      ;(daemon as any).curatedRuntimeAdmission = new CuratedRuntimeAdmission()
+      ;(daemon as any).refreshAdmittedRuntimes()
+      gate = new Promise<void>((resolve) => {
+        releaseCurated = resolve
+      })
+      const sweep = (daemon as any).probeRuntimesAndEmit(true)
+
+      // The fast runtime is reported while the curated probe is still in flight.
+      await vi.waitFor(() => expect(emitted.at(-1)).toContain('explicit'), WAIT)
+      expect((daemon as any).probing).toBe(true)
+      expect(emitted.at(-1)).not.toContain('hermes-agent')
+
+      releaseCurated()
+      await sweep
+      expect(emitted.at(-1)!.slice().sort()).toEqual(['explicit', 'hermes-agent'])
     } finally {
       await daemon.stop()
     }

--- a/packages/daemon/test/runtime-home.test.ts
+++ b/packages/daemon/test/runtime-home.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
 import { DatabaseSync } from 'node:sqlite'
-import { prepareRuntimeHome, runtimeHomeEnvironment } from '../src/runtimes/runtime-home.js'
+import { hostPackageCacheEnv, prepareRuntimeHome, runtimeHomeEnvironment } from '../src/runtimes/runtime-home.js'
 import { extractOmpCredentials } from '../src/runtimes/omp-credentials.js'
 
 function fixture(): { root: string; hostHome: string; scopeDir: string } {
@@ -363,5 +363,29 @@ describe('private runtime HOME', () => {
 
     expect(() => extractOmpCredentials(sourcePath, destinationPath)).toThrow(/symlink/i)
     expect(readFileSync(outsidePath, 'utf8')).toBe('outside')
+  })
+})
+
+describe('hostPackageCacheEnv', () => {
+  it('pins npx at the host npm cache so a fresh probe HOME does not rebuild the tree', () => {
+    expect(hostPackageCacheEnv('npx', { HOME: '/host' })).toEqual({ npm_config_cache: join('/host', '.npm') })
+  })
+
+  it('honors an ambient npm cache override', () => {
+    expect(hostPackageCacheEnv('npx', { HOME: '/host', NPM_CONFIG_CACHE: '/shared/npm' })).toEqual({
+      npm_config_cache: '/shared/npm'
+    })
+  })
+
+  it('pins uvx at the host uv cache, honoring XDG_CACHE_HOME', () => {
+    expect(hostPackageCacheEnv('uvx', { HOME: '/host' })).toEqual({ UV_CACHE_DIR: join('/host', '.cache', 'uv') })
+    expect(hostPackageCacheEnv('uvx', { HOME: '/host', XDG_CACHE_HOME: '/xdg' })).toEqual({
+      UV_CACHE_DIR: join('/xdg', 'uv')
+    })
+  })
+
+  it('pins nothing for a real binary distribution', () => {
+    expect(hostPackageCacheEnv('qodercli', { HOME: '/host' })).toEqual({})
+    expect(hostPackageCacheEnv(undefined, { HOME: '/host' })).toEqual({})
   })
 })

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -287,6 +287,33 @@ describe('prepareRuntimeLaunch', () => {
     )
   })
 
+  // A probe HOME is disposable, so npx would resolve and link its whole install tree
+  // every sweep (~210s for a large harness) unless the host package cache survives.
+  // Writable, because npm writes tarballs, its index and the _npx tree there.
+  it('pins the host package cache for a probe launch and carves it back writable', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const base = {
+      runtimeId: 'dsh-acp',
+      runtime: { command: 'npx', args: ['-y', '-p', 'pkg', 'bin'], env: [] } as RuntimeDef,
+      scopeDir,
+      cwd,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap' as const,
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    }
+
+    const probe = prepareRuntimeLaunch({ ...base, hostPackageCache: true })
+    expect(probe.env.npm_config_cache).toBe(join(hostHome, '.npm'))
+    expect(coveredBy(probe.sandbox!.writable, realpathSync(join(hostHome, '.npm')))).toBe(true)
+
+    // An agent launch keeps the private cache: its model-driven tool use must not be
+    // able to write the install trees other runtimes launch from.
+    const agent = prepareRuntimeLaunch(base)
+    expect(agent.env.npm_config_cache).toBeUndefined()
+    expect(coveredBy(agent.sandbox!.writable, join(hostHome, '.npm'))).toBe(false)
+  })
+
   it('rejects root-level protected paths instead of generating an ineffective policy', () => {
     const { scopeDir, cwd, hostHome } = fixture()
     expect(() =>

--- a/packages/daemon/test/runtime-prober.test.ts
+++ b/packages/daemon/test/runtime-prober.test.ts
@@ -15,6 +15,7 @@ import {
   curatedProbeEnvironment,
   probeRuntime,
   probeAllRuntimes,
+  probeTimeoutMs,
   sweepStaleProbeRoots,
   type ProbeHostPolicy
 } from '../src/runtimes/runtime-prober.js'
@@ -331,6 +332,60 @@ describe('probeAllRuntimes', () => {
 
   it('returns [] for no runtimes', async () => {
     expect(await probeAllRuntimes({}, { hostFactory: () => fakeHost({}) })).toEqual([])
+  })
+
+  // The sweep used to apply every result at one barrier, so a runtime whose package
+  // launcher spends minutes building its install tree also held back the runtimes that
+  // answered in seconds. Each result must surface as it lands.
+  it('reports each result as it resolves, before the slow ones finish', async () => {
+    let releaseSlow = (): void => {}
+    const slow = new Promise<string>((resolve) => {
+      releaseSlow = () => resolve('sess-slow')
+    })
+    const reported: string[] = []
+    const sweep = probeAllRuntimes(
+      { fast: rt, slow: rt },
+      {
+        concurrency: 2,
+        hostFactory: (_rt, id) => fakeHost(id === 'slow' ? { newSession: () => slow } : {}),
+        onResult: (result) => reported.push(result.runtime)
+      }
+    )
+    await vi.waitFor(() => expect(reported).toEqual(['fast']))
+    releaseSlow()
+    const results = await sweep
+    expect(reported).toEqual(['fast', 'slow'])
+    expect(results.every((r) => r.ok)).toBe(true)
+  })
+
+  it('keeps probing when a result callback throws', async () => {
+    const warn = vi.fn()
+    const results = await probeAllRuntimes(
+      { a: rt, b: rt },
+      {
+        concurrency: 1,
+        hostFactory: () => fakeHost({}),
+        log: { warn, info: vi.fn(), debug: vi.fn(), error: vi.fn() } as never,
+        onResult: () => {
+          throw new Error('cp write failed')
+        }
+      }
+    )
+    expect(results.map((r) => r.runtime).sort()).toEqual(['a', 'b'])
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('probeTimeoutMs', () => {
+  // A package launcher resolves and links its whole tree on first use (~210s measured
+  // for a 700-package harness), so 30s could never admit one: the deadline is a
+  // hang reaper for those, not a latency budget.
+  it.each(['npx', 'uvx'])('gives %s launchers a hang-reaper deadline', (command) => {
+    expect(probeTimeoutMs({ command, args: [], env: [] })).toBe(6 * 60_000)
+  })
+
+  it('keeps the tight 30s budget for a real binary distribution', () => {
+    expect(probeTimeoutMs({ command: 'qodercli', args: ['--acp'], env: [] })).toBe(30_000)
   })
 
   // Models the real leak: omp's own daemon escapes the adapter's process group, so it


### PR DESCRIPTION
## Why

`dsh-acp` (DeepSeek Harness, added in #1142) could never be admitted on this host even though `~/.dsh` was fully populated. The host probe accepted it; the curated ACP admission probe then failed **every sweep, forever**:

```
INFO  runtimes pending ACP admission: omp, qoder-cli, qoder-cli-cn, dsh-acp
WARN  probe: dsh-acp failed — probe timed out after 30000ms
INFO  probe: sweep complete — 3/4 runtime(s) reachable
```

Three things stacked up. Measured against `@openma/deepseek-harness-acp` (174KB adapter, ~700 packages once `@deepseek-ai/dsh` and its siblings resolve):

| | to `initialize` |
| --- | --- |
| fresh HOME, fresh cache (what the probe did every 5 min) | **217s** |
| fresh HOME, host `~/.npm` warm with the deps' tarballs | **211s** |
| cache root already holding the `_npx/<hash>` install tree | **2.7s** |

1. **The sweep applied every result at one barrier.** `const results = (await Promise.all(batches)).flat()` gated admission, model state, catalog seeding and the facts frame — so `omp`/`qoder-cli`/`qoder-cli-cn`, which answered in ~4s, waited on the slow one.
2. **The per-probe deadline was a flat 30s** for spawn + initialize + session/new — an order of magnitude below a package launcher's first install.
3. **The disposable probe HOME dropped every `npm_config_*`**, so each sweep rebuilt the tree from nothing and re-paid ~210s and ~300MB. Note from the table that sharing tarballs buys only ~3%: what matters is whether the `_npx/<hash>` **install tree** exists, and that tree lives inside the cache root.

`codex-acp` is also npx-distributed but is a `managed` winner, so it probes through the ordinary path (inherited env, warm host cache) and passes in ~4s. `dsh-acp` is the only npx-shaped **curated** entry, and curated probes are the ones pinned to a disposable HOME.

## What changed

**Report per probe, not per sweep** — `ProbeOptions.onResult` fires as each probe resolves; the daemon folds it through the new `applyProbeResult` / `seedCatalogFromProbe` and emits right there. `facts/daemon-runtimes` is an idempotent REPLACE fenced by `seq` (runtime-model-catalog.md §6), so per-result frames converge, and a sweep's **last** frame is byte-for-byte the snapshot that used to be sent once at the end. The end-of-sweep emit now only fires when a sweep produced no results at all.

**The deadline becomes a hang reaper** — `probeTimeoutMs(rt)`: 6 min for `npx`/`uvx`, unchanged 30s for real binaries. Safe now that a slow probe no longer holds anyone else's report. It stays under the re-probe cadence in practice, and an overrun degrades to one extra no-op sweep (`this.probing` folds the TTL tick into `curatedProbePending`).

**Probe launches keep npx/uvx on the host package cache** — `hostPackageCacheEnv()` pins `npm_config_cache` (or `UV_CACHE_DIR`), so the install tree survives across sweeps. Deliberately probe-only via the explicit `hostPackageCache` option: a probe never runs a model turn, so an agent's confined tool use must not be able to write the install trees other runtimes launch from. Sandboxed probes carve the cache back **writable** (npm writes tarballs, its index, and the `_npx` tree) under the rule shared credential roots already use — may sit below a protected root, never contain one.

## Verification

On a bwrap host (`sandbox: bwrap ready`), running the real curated probe:

- **Cold**: builds the 357MB tree from inside the sandbox in 208s, then admits.
- **Warm**: `probe: dsh-acp ok (dsh-acp v0.4.9, models: deepseek-v4-flash, deepseek-v4-pro)` in **4.0s**, with `onResult` firing at the same instant.

Tests: 9 focused files / 188 tests green after rebase, including new coverage for incremental reporting (prober + daemon level), a throwing result callback not aborting the remaining probes, the timeout tiers, `hostPackageCacheEnv`, and probe-vs-agent cache/writable-root behavior. `tsc`, eslint and prettier clean.

## Known first-install flake (pre-existing, not introduced here)

Cold sandboxed installs of this size can trip npx's own concurrency lock: `npm error code ECOMPROMISED / Lock compromised`. `libnpmexec/with-lock.js` locks `<installDir>/concurrency.lock`, renews it with a 1s `utimes` timer and self-checks `ino` + second-resolution `mtime`; during a ~200s install the timer gets starved and the check aborts. It is probabilistic (1 success / 2 failures in my sandboxed runs; an unsandboxed run also succeeded) and it is **not** the sandbox revoking anything — a 25-tick `utimes` loop inside the same sandbox landed every write. It only affects the first install on a host: the next sweep retries, and once the tree exists every probe is the ~4s path. Removing that window needs a dedicated pre-warm step, which is a separate decision — doing it outside the sandbox would run 700 packages' postinstall scripts unconfined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)