### PR TITLE
refactor(daemon): invert the probe host dependency behind AcpProbeClient

### DIFF
--- a/packages/daemon/src/acp/probe-client.ts
+++ b/packages/daemon/src/acp/probe-client.ts
@@ -1,0 +1,28 @@
+import type { McpServer, SessionConfigOption } from '@agentclientprotocol/sdk'
+import type { McpTransportCapabilities } from '@agentconnect.md/protocol'
+import type { AcpHost, ModelOptions } from './acp-host.js'
+
+/**
+ * The narrow slice of an ACP agent host that runtime probing and model
+ * enumeration need: spawn, one disposable session, read the advertised
+ * selectors, tear down. Keeping it an interface is what lets `runtimes/*`
+ * depend on a contract instead of the concrete {@link AcpHost}.
+ *
+ * The optional members are optional on purpose — a probe fake implements only
+ * what the path it exercises calls, and every caller already guards them.
+ */
+export interface AcpProbeClient {
+  start(): Promise<void>
+  newSession(cwd: string, mcpServers?: McpServer[]): Promise<string>
+  modelOptions(sessionId?: string): ModelOptions | null
+  sessionConfigOptions?(sessionId: string): SessionConfigOption[] | undefined
+  setSessionModel?(sessionId: string, model: string): Promise<boolean>
+  acpProtocolVersion(): number | undefined
+  acpAgentInfo?(): { name: string; title?: string; version?: string } | undefined
+  mcpCapabilities?(): McpTransportCapabilities | null
+  stop(deadlineMs?: number): Promise<void>
+}
+
+// AcpHost is the production implementation — structural conformance fails to compile here.
+type ProbeClientShaped<T extends AcpProbeClient> = T
+export type AcpHostIsProbeClient = ProbeClientShaped<AcpHost>

--- a/packages/daemon/src/acp/probe-host-factory.ts
+++ b/packages/daemon/src/acp/probe-host-factory.ts
@@ -1,0 +1,16 @@
+import type { Logger } from '../log.js'
+import type { ProbeHostFactory } from '../runtimes/runtime-prober.js'
+import { AcpHost } from './acp-host.js'
+
+/** The production {@link ProbeHostFactory}: a real AcpHost per probed runtime. */
+export function defaultProbeHostFactory(opts: { log?: Logger; isolateAccountApps?: boolean } = {}): ProbeHostFactory {
+  // A probe session produces no user-facing turns, so session/update is dropped.
+  return (rt, id, _cwd, policy) =>
+    new AcpHost(rt, {
+      onUpdate: () => {},
+      log: opts.log,
+      runtimeId: id,
+      isolateAccountApps: opts.isolateAccountApps,
+      ...policy
+    })
+}

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -16,6 +16,7 @@ import { resolveRoot } from '../paths.js'
 import { runtimeHomePath } from '../runtimes/runtime-home.js'
 import { installedRuntimeCatalog } from '../runtimes/probe.js'
 import { probeAllRuntimes, type ProbeOptions, type RuntimeProbeResult } from '../runtimes/runtime-prober.js'
+import { defaultProbeHostFactory } from '../acp/probe-host-factory.js'
 import { CuratedRuntimeAdmission } from '../runtimes/curated-admission.js'
 import { composeRuntimeLaunch } from '../launch/compose.js'
 import type { RuntimeDef } from '../config/config-schema.js'
@@ -88,7 +89,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
       { [agent.runtime]: runtime },
       {
         curated: true,
-        isolateAccountApps: cfg.security.isolateAccountApps,
+        hostFactory: defaultProbeHostFactory({ isolateAccountApps: cfg.security.isolateAccountApps }),
         runInSandbox,
         daemonRoot: root,
         agentsRoot: cfg.agentsDir,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -228,6 +228,7 @@ import {
 } from './runtimes/runtime-prober.js'
 import { ModelCatalogService, catalogFingerprint } from './runtimes/model-catalog.js'
 import { makeModelEnumerator } from './runtimes/model-enumerator.js'
+import { defaultProbeHostFactory } from './acp/probe-host-factory.js'
 import { capsFromConfigOptions, augmentEffortOptions } from './runtimes/config-caps.js'
 import { isClaudeRuntimeDef } from './runtime-defs/claude-runtime.js'
 import { runtimeHomePath } from './runtimes/runtime-home.js'
@@ -1931,12 +1932,15 @@ export class Daemon {
       store: this.store,
       log: this.log,
       now: () => this.clock.now(),
-      // No hostFactory seam here: daemon unit tests never reach the enumerator
-      // (the probe sweep early-returns under the fake-host guard, so noteProbe
-      // never fires); enumerator tests inject a fake EnumerateFn instead.
+      // Daemon unit tests never reach the enumerator (the probe sweep early-returns
+      // under the fake-host guard, so noteProbe never fires); enumerator tests inject
+      // a fake EnumerateFn instead.
       enumerate: makeModelEnumerator({
         log: this.log,
-        isolateAccountApps: this.cfg.security.isolateAccountApps,
+        hostFactory: defaultProbeHostFactory({
+          log: this.log,
+          isolateAccountApps: this.cfg.security.isolateAccountApps
+        }),
         sandboxMechanism: this.sandboxMechanism,
         daemonRoot: root,
         agentsRoot: this.cfg.agentsDir,
@@ -19341,12 +19345,16 @@ export class Daemon {
     this.log.info(`probe: sweeping ${probeCount} runtime(s): ${probeIds.join(', ') || '(none)'}`)
     try {
       const probe = this.opts.probeRuntimes ?? probeAllRuntimes
+      const probeHostFactory = defaultProbeHostFactory({
+        log: this.log,
+        isolateAccountApps: this.cfg.security.isolateAccountApps
+      })
       const batches: Array<Promise<RuntimeProbeResult[]>> = []
       if (Object.keys(ordinaryRuntimes).length > 0) {
         batches.push(
           probe(ordinaryRuntimes, {
             log: this.log,
-            isolateAccountApps: this.cfg.security.isolateAccountApps,
+            hostFactory: probeHostFactory,
             launchFor: (id, runtime, scopeDir, cwd) =>
               prepareRuntimeLaunch({
                 runtimeId: id,
@@ -19371,7 +19379,7 @@ export class Daemon {
           probe(curatedCandidates, {
             curated: true,
             log: this.log,
-            isolateAccountApps: this.cfg.security.isolateAccountApps,
+            hostFactory: probeHostFactory,
             runInSandbox: this.sandboxMechanism !== undefined,
             daemonRoot: this.root,
             agentsRoot: this.cfg.agentsDir,

--- a/packages/daemon/src/runtimes/model-enumerator.ts
+++ b/packages/daemon/src/runtimes/model-enumerator.ts
@@ -1,11 +1,16 @@
 import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import type { RuntimeDef } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
 import type { SandboxMechanism } from '../acp/sandbox.js'
-import { AcpHost } from '../acp/acp-host.js'
-import { preparedProbeLaunch, probeCallbacks, type ProbeHostPolicy, type ProbeLaunchPlan } from './runtime-prober.js'
+import type { AcpProbeClient } from '../acp/probe-client.js'
+import {
+  preparedProbeLaunch,
+  probeCallbacks,
+  type ProbeHostFactory,
+  type ProbeHostPolicy,
+  type ProbeLaunchPlan
+} from './runtime-prober.js'
 import { capsFromConfigOptions } from './config-caps.js'
 import type { EnumerateFn } from './model-catalog.js'
 
@@ -23,13 +28,12 @@ import type { EnumerateFn } from './model-catalog.js'
  */
 export interface ModelEnumeratorDeps {
   log?: Logger
-  isolateAccountApps?: boolean
   sandboxMechanism?: SandboxMechanism
   daemonRoot?: string
   agentsRoot?: string
   mcpSocketPath?: string
-  /** Test seam — mirrors ProbeOptions.hostFactory. */
-  hostFactory?: (rt: RuntimeDef, id: string, cwd: string, policy: ProbeHostPolicy) => AcpHost
+  /** Constructs the probe client — `defaultProbeHostFactory()` in production. */
+  hostFactory: ProbeHostFactory
 }
 
 /** Kept short so restore-before-kill always fits inside the total budget. */
@@ -45,14 +49,14 @@ function withTimeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
 
 export function makeModelEnumerator(deps: ModelEnumeratorDeps): EnumerateFn {
   return async (runtimeId, rt, modelIds, budget) => {
-    if (!deps.sandboxMechanism && !deps.hostFactory) {
+    if (!deps.sandboxMechanism) {
       deps.log?.debug(`catalog: ${runtimeId} skipped because no supported OS sandbox is available`)
       return undefined
     }
     const scope = mkdtempSync(join(tmpdir(), 'ac-catalog-'))
     const cwd = join(scope, 'workspace')
     mkdirSync(cwd, { recursive: true })
-    let host: AcpHost | undefined
+    let host: AcpProbeClient | undefined
     try {
       let launch: ProbeLaunchPlan | undefined
       try {
@@ -79,15 +83,7 @@ export function makeModelEnumerator(deps: ModelEnumeratorDeps): EnumerateFn {
         ...(launch.sandbox ? { sandbox: launch.sandbox } : {})
       }
       const effectiveRuntime = launch.runtime ?? rt
-      host = deps.hostFactory
-        ? deps.hostFactory(effectiveRuntime, runtimeId, cwd, policy)
-        : new AcpHost(effectiveRuntime, {
-            onUpdate: () => {},
-            log: deps.log,
-            runtimeId,
-            isolateAccountApps: deps.isolateAccountApps,
-            ...policy
-          })
+      host = deps.hostFactory(effectiveRuntime, runtimeId, cwd, policy)
       const activeHost = host
 
       const deadline = Date.now() + budget.totalMs
@@ -95,6 +91,8 @@ export function makeModelEnumerator(deps: ModelEnumeratorDeps): EnumerateFn {
       const sid = await withTimeout(activeHost.newSession(cwd, []), budget.perModelMs, `${runtimeId} session/new`)
       const initial = activeHost.sessionConfigOptions?.(sid)
       if (!initial) return { models: [], aborted: 'runtime advertises no session config options' }
+      const setSessionModel = activeHost.setSessionModel?.bind(activeHost)
+      if (!setSessionModel) return { models: [], aborted: 'runtime cannot switch the session model' }
       const initialModel = capsFromConfigOptions(initial).currentModel
 
       const collected: Awaited<ReturnType<EnumerateFn>> & object = { models: [] }
@@ -105,7 +103,7 @@ export function makeModelEnumerator(deps: ModelEnumeratorDeps): EnumerateFn {
           break
         }
         try {
-          await withTimeout(activeHost.setSessionModel(sid, id), budget.perModelMs, `${runtimeId} set model ${id}`)
+          await withTimeout(setSessionModel(sid, id), budget.perModelMs, `${runtimeId} set model ${id}`)
         } catch (err) {
           deps.log?.debug(`catalog: ${runtimeId} model "${id}" skipped: ${(err as Error).message}`)
           continue
@@ -138,11 +136,9 @@ export function makeModelEnumerator(deps: ModelEnumeratorDeps): EnumerateFn {
         initialModel &&
         initialModel !== capsFromConfigOptions(activeHost.sessionConfigOptions?.(sid) ?? []).currentModel
       ) {
-        await withTimeout(
-          activeHost.setSessionModel(sid, initialModel),
-          RESTORE_GRACE_MS,
-          `${runtimeId} restore model`
-        ).catch((err) => deps.log?.debug(`catalog: ${runtimeId} restore selection failed: ${(err as Error).message}`))
+        await withTimeout(setSessionModel(sid, initialModel), RESTORE_GRACE_MS, `${runtimeId} restore model`).catch(
+          (err) => deps.log?.debug(`catalog: ${runtimeId} restore selection failed: ${(err as Error).message}`)
+        )
       }
       return collected
     } finally {

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -15,7 +15,8 @@ import { dirname, join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import type { McpTransportCapabilities } from '@agentconnect.md/protocol'
 import type { SessionConfigOption } from '@agentclientprotocol/sdk'
-import { AcpHost, type ModelOptions } from '../acp/acp-host.js'
+import type { ModelOptions } from '../acp/acp-host.js'
+import type { AcpProbeClient } from '../acp/probe-client.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
 import type { SandboxMechanism } from '../acp/sandbox.js'
@@ -69,6 +70,9 @@ export const probeCallbacks = {
 
 export type ProbeHostPolicy = typeof probeCallbacks &
   Partial<Pick<PreparedRuntimeLaunch, 'env' | 'inheritProcessEnv' | 'sandbox'>>
+
+/** Constructs the ACP client a probe drives — injected, so `runtimes/*` never names AcpHost. */
+export type ProbeHostFactory = (rt: RuntimeDef, id: string, cwd: string, policy: ProbeHostPolicy) => AcpProbeClient
 
 export interface ProbeLaunchPlan extends PreparedRuntimeLaunch {
   runtime?: RuntimeDef
@@ -140,10 +144,8 @@ export interface ProbeOptions {
   /** Max runtimes probed concurrently (each is a subprocess). Default 3. */
   concurrency?: number
   log?: Logger
-  /** Mirrors daemon security.isolateAccountApps for probe subprocesses. */
-  isolateAccountApps?: boolean
-  /** Seam for tests — construct a host for a runtime. Defaults to a real AcpHost. */
-  hostFactory?: (rt: RuntimeDef, id: string, cwd: string, policy: ProbeHostPolicy) => AcpHost
+  /** Constructs the probe client per runtime — `defaultProbeHostFactory()` in production. */
+  hostFactory: ProbeHostFactory
   /** Curated candidates require a disposable final managed launch plan. */
   curated?: boolean
   /** Full host environment used for allowlisted credential seeding and redaction. */
@@ -313,31 +315,6 @@ export function sweepStaleProbeRoots(opts: { log?: Logger; maxAgeMs?: number; tm
   return removed
 }
 
-function makeHost(
-  rt: RuntimeDef,
-  log?: Logger,
-  runtimeId?: string,
-  isolateAccountApps?: boolean,
-  launch?: ReturnType<NonNullable<ProbeOptions['launchFor']>>
-): AcpHost {
-  const prepared = launch
-    ? {
-        env: launch.env,
-        inheritProcessEnv: launch.inheritProcessEnv,
-        ...(launch.sandbox ? { sandbox: launch.sandbox } : {})
-      }
-    : {}
-  // A probe session produces no user-facing turns, so session/update is dropped.
-  return new AcpHost(rt, {
-    onUpdate: () => {},
-    log,
-    runtimeId,
-    isolateAccountApps,
-    ...probeCallbacks,
-    ...prepared
-  })
-}
-
 function sanitizeProbeDiagnostic(error: unknown, env: NodeJS.ProcessEnv, privateValues: string[] = []): string {
   let message = error instanceof Error ? error.message : String(error)
   const values = [...PROVIDER_ENV_KEYS].map((name) => env[name]).concat(privateValues)
@@ -469,7 +446,7 @@ export function preparedProbeLaunch(
   id: string,
   runtime: RuntimeDef,
   cwd: string,
-  opts: ProbeOptions
+  opts: Omit<ProbeOptions, 'hostFactory'>
 ): ProbeLaunchPlan | undefined {
   const scopeDir = dirname(cwd)
   const sourceEnv = opts.hostEnv ?? process.env
@@ -511,10 +488,10 @@ export async function probeRuntime(
   id: string,
   rt: RuntimeDef,
   cwd: string,
-  opts: ProbeOptions = {}
+  opts: ProbeOptions
 ): Promise<RuntimeProbeResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
-  let host: AcpHost | undefined
+  let host: AcpProbeClient | undefined
   let redactValues: string[] = []
 
   let timer: ReturnType<typeof setTimeout> | undefined
@@ -536,9 +513,7 @@ export async function probeRuntime(
           }
         : {})
     }
-    host = opts.hostFactory
-      ? opts.hostFactory(effectiveRuntime, id, cwd, hostPolicy)
-      : makeHost(effectiveRuntime, opts.log, id, opts.isolateAccountApps, launch)
+    host = opts.hostFactory(effectiveRuntime, id, cwd, hostPolicy)
     const activeHost = host
     let probeSessionId: string | undefined
     const run = async (): Promise<ModelOptions | null> => {
@@ -590,7 +565,7 @@ export async function probeRuntime(
  */
 export async function probeAllRuntimes(
   runtimes: Record<string, RuntimeDef>,
-  opts: ProbeOptions = {}
+  opts: ProbeOptions
 ): Promise<RuntimeProbeResult[]> {
   const ids = Object.keys(runtimes)
   if (ids.length === 0) return []

--- a/packages/daemon/test/runtime-prober.test.ts
+++ b/packages/daemon/test/runtime-prober.test.ts
@@ -18,21 +18,22 @@ import {
   sweepStaleProbeRoots,
   type ProbeHostPolicy
 } from '../src/runtimes/runtime-prober.js'
-import { modelOptionsFrom, type AcpHost } from '../src/acp/acp-host.js'
+import { modelOptionsFrom } from '../src/acp/acp-host.js'
+import type { AcpProbeClient } from '../src/acp/probe-client.js'
 import type { RuntimeDef } from '../src/config/config-schema.js'
 
 const rt: RuntimeDef = { command: 'npx', args: ['-y', 'pkg'], env: [] }
 
-/** Minimal AcpHost stand-in — only the methods the prober calls. */
+/** Minimal probe client — only the methods the prober calls. */
 function fakeHost(behavior: {
   start?: () => Promise<void>
   newSession?: () => Promise<string>
-  models?: ReturnType<AcpHost['modelOptions']>
+  models?: ReturnType<AcpProbeClient['modelOptions']>
   acp?: number
-  mcp?: ReturnType<AcpHost['mcpCapabilities']>
+  mcp?: ReturnType<NonNullable<AcpProbeClient['mcpCapabilities']>>
   agentInfo?: { name: string; title?: string; version?: string }
   onStop?: () => void
-}): AcpHost {
+}): AcpProbeClient {
   return {
     start: behavior.start ?? (async () => {}),
     newSession: behavior.newSession ?? (async () => 'sess-1'),
@@ -43,7 +44,7 @@ function fakeHost(behavior: {
     stop: async () => {
       behavior.onStop?.()
     }
-  } as unknown as AcpHost
+  }
 }
 
 const successfulHost = (newSession = vi.fn(async () => 'sess-1')) => fakeHost({ newSession })
@@ -329,7 +330,7 @@ describe('probeAllRuntimes', () => {
   })
 
   it('returns [] for no runtimes', async () => {
-    expect(await probeAllRuntimes({})).toEqual([])
+    expect(await probeAllRuntimes({}, { hostFactory: () => fakeHost({}) })).toEqual([])
   })
 
   // Models the real leak: omp's own daemon escapes the adapter's process group, so it


### PR DESCRIPTION
## What

`src/runtimes/runtime-prober.ts` and `src/runtimes/model-enumerator.ts` constructed `AcpHost` themselves, so the runtimes layer depended on the concrete ACP host class (and its whole transitive graph) just to spawn a throwaway probe session.

- **New `src/acp/probe-client.ts`** — `AcpProbeClient`, exactly the surface the two probe paths use: `start`, `newSession`, `modelOptions`, optional `sessionConfigOptions` / `setSessionModel` / `acpAgentInfo` / `mcpCapabilities`, `acpProtocolVersion`, `stop`. `AcpHost` conformance is asserted at the type level in the same file.
- **New `src/acp/probe-host-factory.ts`** — `defaultProbeHostFactory({ log, isolateAccountApps })`, the production factory; the old private `makeHost()` / inline `new AcpHost(...)` in both runtimes files are gone.
- `ProbeOptions.hostFactory` and `ModelEnumeratorDeps.hostFactory` are now **required** and typed `ProbeHostFactory` (returns `AcpProbeClient`); local host variables are `AcpProbeClient`. `isolateAccountApps` moved off both option bags into the factory, which is what actually consumed it.
- Injected at the call sites: `daemon.ts` (both probe batches, via a local `probeHostFactory`, and the model enumerator) and `cli/chat.ts`. This is a different seam from the `Daemon` option `hostFactory` used by the webchat tests — that one is untouched.
- `test/runtime-prober.test.ts` fake is now typed `AcpProbeClient` and no longer needs `as unknown as AcpHost`.

Result: `grep -rn "acp-host" packages/daemon/src/runtimes/` yields exactly one hit — `import type { ModelOptions }` in `runtime-prober.ts`. Zero value-level imports of `acp/acp-host` from `src/runtimes/*`.

Behavior note: the enumerator's skip guard was `!sandboxMechanism && !hostFactory`; with the factory always present it is now `!sandboxMechanism`, identical in production (the factory was never set there) and the fake-host path opts in by setting `sandboxMechanism`.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean
- `npx vitest run test/runtime-prober.test.ts test/model-catalog-daemon.test.ts test/chat.test.ts test/acp-host.test.ts test/runtime-launch.test.ts` — 5 files, 111 tests, all pass
- `prettier --check` + `eslint` on every touched file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)