### PR TITLE
refactor(daemon): extract SandboxLease from the K8s driver

### DIFF
--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -6,15 +6,8 @@ import type { ShimConnection } from '../shim/connection.js'
 import { ShimSession } from '../shim/session.js'
 import { createRemoteRuntime } from './remote-runtime.js'
 import type { SpawnRecord } from '../shim/binding.js'
-import {
-  GuardedResumeRejectedError,
-  OperatingModeRejectedError,
-  isSandboxReady,
-  type OperatingMode,
-  type Sandbox,
-  type SandboxClaim,
-  type SandboxApi
-} from './sandbox-api.js'
+import { isSandboxReady, type OperatingMode, type SandboxClaim, type SandboxApi } from './sandbox-api.js'
+import { SandboxLease } from './sandbox-lease.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import {
   AC_LABEL_AGENT,
@@ -78,7 +71,6 @@ export interface K8sDriverDeps {
 }
 
 const DEFAULT_READY_TIMEOUT_MS = 90_000
-const MAX_MODE_ATTEMPTS = 5
 
 /**
  * How to read a channel that has not arrived: `starting` means the pod is not up yet, so
@@ -107,17 +99,8 @@ export interface Launch {
 export class K8sDriver implements SpawnDriver {
   private readonly metrics: ClusterMetrics
   private readonly launches = new Map<string, Launch>()
-  /** Live work per Sandbox: binds, workspace preparation, and runtimes that have not exited. */
-  private readonly busy = new Map<string, number>()
-  /** Per-SANDBOX transition queue. A guarded write protects competing writes, but it cannot
-   *  protect a decision that performs NO write: a later wake could observe Running and
-   *  return while an earlier suspend patch was still in flight, and the older write would
-   *  then land last and reverse the newer decision. Serializing removes that entirely. */
-  private readonly modeQueue = new Map<string, Promise<void>>()
-  /** Idle suspensions in flight, per agent. `busy` COUNTS work but does not exclude it, so a
-   *  dispatch admitted while the suspend was mid-write would otherwise lose its pod. Acquisition
-   *  waits this out and then re-claims, which is the ordinary resume path. */
-  private readonly suspending = new Map<string, Promise<void>>()
+  /** Holds, mode serialization, and the idle-suspension gates — see `SandboxLease`. */
+  private readonly lease: SandboxLease
   /** Logical channels per agent, which survive the shim's credential renewals. */
   private readonly sessions = new Map<string, ShimSession>()
   /** Takeover re-derivations in flight, per agent; a concurrent acquisition waits for the answer. */
@@ -131,6 +114,12 @@ export class K8sDriver implements SpawnDriver {
   constructor(private readonly deps: K8sDriverDeps) {
     this.clock = deps.clock ?? systemClock
     this.metrics = deps.metrics ?? noopClusterMetrics
+    this.lease = new SandboxLease({
+      api: deps.api,
+      warmPoolName: deps.warmPoolName,
+      log: deps.log,
+      metrics: this.metrics
+    })
   }
 
   claimName(agentId: string): string {
@@ -149,7 +138,7 @@ export class K8sDriver implements SpawnDriver {
     // An idle suspension mid-write is the one state a cached launch must not be read through: its
     // pod is being deleted. Waiting lets it finish and forget the launch, so the line below claims
     // a new one — the same resume this call would have done a moment later anyway.
-    const suspending = this.suspending.get(agentId)
+    const suspending = this.lease.suspensionOf(agentId)
     if (suspending) await suspending
     // A takeover re-derivation is the same answer from the cluster; wait for it rather than race it.
     const adopting = this.adopting.get(agentId)
@@ -317,12 +306,8 @@ export class K8sDriver implements SpawnDriver {
    * sweep, so the next pass finds it quiet, whereas waiting here would hold a suspend decision
    * open across a turn that has already made it stale.
    *
-   * Work admitted AFTER that check is a different problem, and `busy` cannot solve it: it counts
-   * holders, it does not exclude them, so a dispatch arriving during the Kubernetes write would
-   * lose the pod underneath itself and then find its launch forgotten. The decision is therefore
-   * published before the first await, and acquisition waits it out (`ensureSandbox`) instead of
-   * racing it. Publication is synchronous with the `busy` read, which is what makes the pair
-   * atomic: a holder either shows up in that read, or arrives to a gate that is already closed.
+   * Work admitted AFTER that check is `SandboxLease`'s problem: it publishes the suspension gate
+   * before its first await, and acquisition waits that out (`ensureSandbox`) instead of racing it.
    *
    * The launch is forgotten on success, deliberately: the pod it names is being deleted, and the
    * replacement must be bound at a new generation. Leaving it to the channel-loss path instead
@@ -331,25 +316,12 @@ export class K8sDriver implements SpawnDriver {
   async suspendIfIdle(agentId: string): Promise<'suspended' | 'busy' | 'absent'> {
     const launch = this.launches.get(agentId)
     if (!launch) return 'absent'
-    if (this.suspending.has(agentId)) return 'busy'
-    if ((this.busy.get(launch.sandboxName) ?? 0) > 0) return 'busy'
-    let opened: () => void = () => {}
-    this.suspending.set(agentId, new Promise<void>((resolve) => (opened = resolve)))
-    this.retain(launch.sandboxName)
-    try {
-      await this.queueMode(launch.sandboxName, 'Suspended')
+    return await this.lease.suspendIfIdle(agentId, launch.sandboxName, () => {
       if (this.launches.get(agentId) === launch) {
         this.sessions.delete(agentId)
         this.forgetLaunch(agentId)
       }
-      return 'suspended'
-    } finally {
-      this.release(launch.sandboxName)
-      // Dropped BEFORE the gate opens, so a waiter that resumes cannot observe a suspension that
-      // is still registered and refuse itself in `suspendIfIdle`'s place.
-      this.suspending.delete(agentId)
-      opened()
-    }
+    })
   }
 
   /** Agents this daemon holds a Sandbox for, and since when — the idle sweep's candidates. */
@@ -357,143 +329,22 @@ export class K8sDriver implements SpawnDriver {
     return [...this.launches.values()].map(({ agentId, since }) => ({ agentId, since }))
   }
 
-  /**
-   * Move a Sandbox to a mode, re-reading and re-deciding when the guarded write is rejected.
-   *
-   * The rejection deliberately does not claim what the intervening state was, so the only
-   * correct response is to look again — and the retry budget is finite because a permanently
-   * invalid patch would otherwise loop forever.
-   */
+  /** Move this agent's Sandbox to a mode, through the lease's per-Sandbox transition queue. */
   private setMode(agentId: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
     const launch = this.launches.get(agentId)
     if (!launch) return Promise.reject(new Error(`no sandbox launch recorded for agent ${agentId}`))
-    return this.queueMode(launch.sandboxName, desired)
-  }
-
-  /** Queued per Sandbox because it is the object both decisions patch. */
-  private queueMode(sandboxName: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
-    const previous = this.modeQueue.get(sandboxName) ?? Promise.resolve()
-    const next = previous.catch(() => undefined).then(() => this.applyMode(sandboxName, desired))
-    // Keep the chain even when a link rejects, so a failed transition cannot strand the queue.
-    this.modeQueue.set(
-      sandboxName,
-      next.then(
-        () => undefined,
-        () => undefined
-      )
-    )
-    return next
-  }
-
-  private async applyMode(sandboxName: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
-    // The mode observed on the FIRST read, before this call changed anything. A later attempt
-    // sees the state we produced, which would say nothing about where the launch started.
-    let first: OperatingMode | undefined
-    let lastRejection: GuardedResumeRejectedError | OperatingModeRejectedError | undefined
-    for (let attempt = 1; attempt <= MAX_MODE_ATTEMPTS; attempt += 1) {
-      const sandbox = await this.deps.api.getSandbox(sandboxName)
-      const observed = sandbox.spec?.operatingMode ?? 'Running'
-      if (observed === desired) return first ?? observed
-      first ??= observed
-      try {
-        if (desired === 'Running' && observed === 'Suspended') {
-          const image = await this.resolveResumeImage(sandboxName, sandbox)
-          await this.deps.api.resumeWithRuntimeImage(sandboxName, image)
-          if (image.observedImage === image.targetImage) {
-            this.deps.log.info(`cluster: sandbox ${sandboxName} → Running`)
-          } else {
-            this.deps.log.info(
-              `cluster: sandbox ${sandboxName} runtime image ${image.observedImage} → ${image.targetImage}; resumed`
-            )
-          }
-        } else {
-          await this.deps.api.setOperatingMode(sandboxName, desired, observed)
-          this.deps.log.info(`cluster: sandbox ${sandboxName} → ${desired}`)
-        }
-        return first
-      } catch (err) {
-        if (!(err instanceof OperatingModeRejectedError) && !(err instanceof GuardedResumeRejectedError)) throw err
-        lastRejection = err
-        this.metrics.writeRetry('rejected_precondition')
-        this.deps.log.debug?.(`cluster: ${desired} write for ${sandboxName} rejected (attempt ${attempt}) — re-reading`)
-      }
-    }
-    if (lastRejection instanceof GuardedResumeRejectedError) {
-      throw new Error(
-        `sandbox ${sandboxName} guarded mode/image resume was rejected after ${MAX_MODE_ATTEMPTS} attempts`,
-        { cause: lastRejection.cause }
-      )
-    }
-    throw new Error(
-      `sandbox ${sandboxName} would not accept ${desired} after ${MAX_MODE_ATTEMPTS} attempts — ` +
-        `the guarded mode write was repeatedly rejected`,
-      { cause: lastRejection?.cause }
-    )
-  }
-
-  private async resolveResumeImage(
-    sandboxName: string,
-    sandbox: Sandbox
-  ): Promise<{ containerIndex: number; observedName: string; observedImage: string; targetImage: string }> {
-    const pool = await this.deps.api.getWarmPool(this.deps.warmPoolName)
-    const templateName = pool.spec?.sandboxTemplateRef?.name
-    if (!templateName?.trim()) {
-      throw new Error(`sandbox warm pool ${this.deps.warmPoolName} has no sandboxTemplateRef.name`)
-    }
-    if (templateName.trim() !== templateName) {
-      throw new Error(`sandbox warm pool ${this.deps.warmPoolName} has invalid sandboxTemplateRef.name`)
-    }
-    const template = await this.deps.api.getSandboxTemplate(templateName)
-    const targetContainers = (template.spec?.podTemplate?.spec?.containers ?? []).filter(
-      (container) => container.name === 'runtime'
-    )
-    if (targetContainers.length > 1) throw new Error(`sandbox template ${templateName} has multiple runtime containers`)
-    const targetImage = targetContainers[0]?.image
-    if (!targetImage?.trim()) throw new Error(`sandbox template ${templateName} runtime container has no image`)
-    if (targetImage.trim() !== targetImage) {
-      throw new Error(`sandbox template ${templateName} runtime container has invalid image`)
-    }
-    const containers = sandbox.spec?.podTemplate?.spec?.containers ?? []
-    const containerIndexes = containers.flatMap((container, index) => (container.name === 'runtime' ? [index] : []))
-    if (containerIndexes.length === 0) throw new Error(`sandbox ${sandboxName} has no runtime container`)
-    if (containerIndexes.length > 1) throw new Error(`sandbox ${sandboxName} has multiple runtime containers`)
-    const containerIndex = containerIndexes[0]!
-    const observedImage = containers[containerIndex]?.image
-    if (!observedImage?.trim()) throw new Error(`sandbox ${sandboxName} runtime container has no image`)
-    if (observedImage.trim() !== observedImage) {
-      throw new Error(`sandbox ${sandboxName} runtime container has invalid image`)
-    }
-    return { containerIndex, observedName: 'runtime', observedImage, targetImage }
-  }
-
-  private forgetSandbox(name: string): void {
-    this.busy.delete(name)
-    this.modeQueue.delete(name)
+    return this.lease.queueMode(launch.sandboxName, desired)
   }
 
   /** Hold the agent's Sandbox for `work`, including workspace preparation before launch. */
   async withSandbox<T>(agentId: string, work: () => Promise<T>): Promise<T> {
     const launch = await this.ensureSandbox(agentId)
-    this.retain(launch.sandboxName)
+    this.lease.retain(launch.sandboxName)
     try {
       return await work()
     } finally {
-      this.release(launch.sandboxName)
+      this.lease.release(launch.sandboxName)
     }
-  }
-
-  /** Count work on a Sandbox so the idle sweep cannot suspend it. */
-  private retain(sandboxName: string): void {
-    this.busy.set(sandboxName, (this.busy.get(sandboxName) ?? 0) + 1)
-  }
-
-  private release(sandboxName: string): void {
-    const left = (this.busy.get(sandboxName) ?? 0) - 1
-    if (left > 0) {
-      this.busy.set(sandboxName, left)
-      return
-    }
-    this.busy.delete(sandboxName)
   }
 
   /** Forget an agent and delete its claim; the volume goes with it, which is the intent. */
@@ -507,7 +358,7 @@ export class K8sDriver implements SpawnDriver {
     this.releases.set(agentId, (this.releases.get(agentId) ?? 0) + 1)
     const launch = this.launches.get(agentId)
     this.launches.delete(agentId)
-    if (launch) this.forgetSandbox(launch.sandboxName)
+    if (launch) this.lease.forgetSandbox(launch.sandboxName)
     this.workspaceRoots.delete(agentId)
     // Otherwise `runsInSandbox` keeps answering true for a pod that is not this member's to use.
     this.sessions.delete(agentId)
@@ -567,11 +418,11 @@ export class K8sDriver implements SpawnDriver {
     grants: ShimCapability[] = RUNTIME_GRANTS
   ): Promise<ShimConnection> {
     const launch = await this.ensureSandbox(agentId, timer)
-    this.retain(launch.sandboxName)
+    this.lease.retain(launch.sandboxName)
     try {
       return await this.bindChannel(agentId, launch, timer, grants)
     } finally {
-      this.release(launch.sandboxName)
+      this.lease.release(launch.sandboxName)
     }
   }
 
@@ -675,7 +526,7 @@ export class K8sDriver implements SpawnDriver {
     let held: string | undefined
     try {
       const bound = await this.ensureSandbox(agentId, timer)
-      this.retain(bound.sandboxName)
+      this.lease.retain(bound.sandboxName)
       held = bound.sandboxName
       await this.ensureBoundChannel(agentId, timer)
       this.metrics.channel('bound')
@@ -700,10 +551,10 @@ export class K8sDriver implements SpawnDriver {
       // Runtime exit releases the hold so the next idle sweep can suspend the Sandbox.
       const sandboxName = held
       held = undefined
-      runtime.onExit(() => this.release(sandboxName))
+      runtime.onExit(() => this.lease.release(sandboxName))
       return runtime
     } catch (err) {
-      if (held) this.release(held)
+      if (held) this.lease.release(held)
       timer.finish(err instanceof LaunchTimeoutError ? 'timeout' : 'error')
       throw err
     }

--- a/packages/daemon/src/k8s/sandbox-lease.ts
+++ b/packages/daemon/src/k8s/sandbox-lease.ts
@@ -1,0 +1,200 @@
+import type { ClusterMetrics } from '../metrics/cluster-metrics.js'
+import {
+  GuardedResumeRejectedError,
+  OperatingModeRejectedError,
+  type OperatingMode,
+  type Sandbox,
+  type SandboxApi
+} from './sandbox-api.js'
+
+const MAX_MODE_ATTEMPTS = 5
+
+export interface SandboxLeaseDeps {
+  api: SandboxApi
+  /** Pool whose template names the runtime image a resume must converge onto. */
+  warmPoolName: string
+  log: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
+  metrics: ClusterMetrics
+}
+
+/**
+ * Who holds a Sandbox and who may change its operating mode.
+ *
+ * Three pieces of state that only make sense together: the per-Sandbox work count, the
+ * per-Sandbox transition queue that serializes mode writes, and the per-agent gate that an
+ * idle suspension publishes so acquisition waits it out instead of racing it.
+ */
+export class SandboxLease {
+  /** Live work per Sandbox: binds, workspace preparation, and runtimes that have not exited. */
+  private readonly busy = new Map<string, number>()
+  /** Per-SANDBOX transition queue. A guarded write protects competing writes, but it cannot
+   *  protect a decision that performs NO write: a later wake could observe Running and
+   *  return while an earlier suspend patch was still in flight, and the older write would
+   *  then land last and reverse the newer decision. Serializing removes that entirely. */
+  private readonly modeQueue = new Map<string, Promise<void>>()
+  /** Idle suspensions in flight, per agent. `busy` COUNTS work but does not exclude it, so a
+   *  dispatch admitted while the suspend was mid-write would otherwise lose its pod. Acquisition
+   *  waits this out and then re-claims, which is the ordinary resume path. */
+  private readonly suspending = new Map<string, Promise<void>>()
+
+  constructor(private readonly deps: SandboxLeaseDeps) {}
+
+  /** Count work on a Sandbox so the idle sweep cannot suspend it. */
+  retain(sandboxName: string): void {
+    this.busy.set(sandboxName, (this.busy.get(sandboxName) ?? 0) + 1)
+  }
+
+  release(sandboxName: string): void {
+    const left = (this.busy.get(sandboxName) ?? 0) - 1
+    if (left > 0) {
+      this.busy.set(sandboxName, left)
+      return
+    }
+    this.busy.delete(sandboxName)
+  }
+
+  /** The suspension gate to wait on before reading a cached launch, or undefined when none is open. */
+  suspensionOf(agentId: string): Promise<void> | undefined {
+    return this.suspending.get(agentId)
+  }
+
+  /**
+   * Suspend a quiet Sandbox, declining when work already holds it.
+   *
+   * Work admitted AFTER that check is a different problem, and `busy` cannot solve it: it counts
+   * holders, it does not exclude them, so a dispatch arriving during the Kubernetes write would
+   * lose the pod underneath itself and then find its launch forgotten. The decision is therefore
+   * published before the first await, and acquisition waits it out instead of racing it.
+   * Publication is synchronous with the `busy` read, which is what makes the pair atomic: a
+   * holder either shows up in that read, or arrives to a gate that is already closed.
+   *
+   * `onSuspended` runs once the write lands, for the launch-side state the caller owns.
+   */
+  async suspendIfIdle(agentId: string, sandboxName: string, onSuspended: () => void): Promise<'suspended' | 'busy'> {
+    if (this.suspending.has(agentId)) return 'busy'
+    if ((this.busy.get(sandboxName) ?? 0) > 0) return 'busy'
+    let opened: () => void = () => {}
+    this.suspending.set(agentId, new Promise<void>((resolve) => (opened = resolve)))
+    this.retain(sandboxName)
+    try {
+      await this.queueMode(sandboxName, 'Suspended')
+      onSuspended()
+      return 'suspended'
+    } finally {
+      this.release(sandboxName)
+      // Dropped BEFORE the gate opens, so a waiter that resumes cannot observe a suspension that
+      // is still registered and refuse itself in this call's place.
+      this.suspending.delete(agentId)
+      opened()
+    }
+  }
+
+  /** Queued per Sandbox because it is the object both decisions patch. */
+  queueMode(sandboxName: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
+    const previous = this.modeQueue.get(sandboxName) ?? Promise.resolve()
+    const next = previous.catch(() => undefined).then(() => this.applyMode(sandboxName, desired))
+    // Keep the chain even when a link rejects, so a failed transition cannot strand the queue.
+    this.modeQueue.set(
+      sandboxName,
+      next.then(
+        () => undefined,
+        () => undefined
+      )
+    )
+    return next
+  }
+
+  /** Drop the holds and the queue for a Sandbox this member no longer serves. */
+  forgetSandbox(sandboxName: string): void {
+    this.busy.delete(sandboxName)
+    this.modeQueue.delete(sandboxName)
+  }
+
+  /**
+   * Move a Sandbox to a mode, re-reading and re-deciding when the guarded write is rejected.
+   *
+   * The rejection deliberately does not claim what the intervening state was, so the only
+   * correct response is to look again — and the retry budget is finite because a permanently
+   * invalid patch would otherwise loop forever.
+   */
+  private async applyMode(sandboxName: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
+    // The mode observed on the FIRST read, before this call changed anything. A later attempt
+    // sees the state we produced, which would say nothing about where the launch started.
+    let first: OperatingMode | undefined
+    let lastRejection: GuardedResumeRejectedError | OperatingModeRejectedError | undefined
+    for (let attempt = 1; attempt <= MAX_MODE_ATTEMPTS; attempt += 1) {
+      const sandbox = await this.deps.api.getSandbox(sandboxName)
+      const observed = sandbox.spec?.operatingMode ?? 'Running'
+      if (observed === desired) return first ?? observed
+      first ??= observed
+      try {
+        if (desired === 'Running' && observed === 'Suspended') {
+          const image = await this.resolveResumeImage(sandboxName, sandbox)
+          await this.deps.api.resumeWithRuntimeImage(sandboxName, image)
+          if (image.observedImage === image.targetImage) {
+            this.deps.log.info(`cluster: sandbox ${sandboxName} → Running`)
+          } else {
+            this.deps.log.info(
+              `cluster: sandbox ${sandboxName} runtime image ${image.observedImage} → ${image.targetImage}; resumed`
+            )
+          }
+        } else {
+          await this.deps.api.setOperatingMode(sandboxName, desired, observed)
+          this.deps.log.info(`cluster: sandbox ${sandboxName} → ${desired}`)
+        }
+        return first
+      } catch (err) {
+        if (!(err instanceof OperatingModeRejectedError) && !(err instanceof GuardedResumeRejectedError)) throw err
+        lastRejection = err
+        this.deps.metrics.writeRetry('rejected_precondition')
+        this.deps.log.debug?.(`cluster: ${desired} write for ${sandboxName} rejected (attempt ${attempt}) — re-reading`)
+      }
+    }
+    if (lastRejection instanceof GuardedResumeRejectedError) {
+      throw new Error(
+        `sandbox ${sandboxName} guarded mode/image resume was rejected after ${MAX_MODE_ATTEMPTS} attempts`,
+        { cause: lastRejection.cause }
+      )
+    }
+    throw new Error(
+      `sandbox ${sandboxName} would not accept ${desired} after ${MAX_MODE_ATTEMPTS} attempts — ` +
+        `the guarded mode write was repeatedly rejected`,
+      { cause: lastRejection?.cause }
+    )
+  }
+
+  private async resolveResumeImage(
+    sandboxName: string,
+    sandbox: Sandbox
+  ): Promise<{ containerIndex: number; observedName: string; observedImage: string; targetImage: string }> {
+    const pool = await this.deps.api.getWarmPool(this.deps.warmPoolName)
+    const templateName = pool.spec?.sandboxTemplateRef?.name
+    if (!templateName?.trim()) {
+      throw new Error(`sandbox warm pool ${this.deps.warmPoolName} has no sandboxTemplateRef.name`)
+    }
+    if (templateName.trim() !== templateName) {
+      throw new Error(`sandbox warm pool ${this.deps.warmPoolName} has invalid sandboxTemplateRef.name`)
+    }
+    const template = await this.deps.api.getSandboxTemplate(templateName)
+    const targetContainers = (template.spec?.podTemplate?.spec?.containers ?? []).filter(
+      (container) => container.name === 'runtime'
+    )
+    if (targetContainers.length > 1) throw new Error(`sandbox template ${templateName} has multiple runtime containers`)
+    const targetImage = targetContainers[0]?.image
+    if (!targetImage?.trim()) throw new Error(`sandbox template ${templateName} runtime container has no image`)
+    if (targetImage.trim() !== targetImage) {
+      throw new Error(`sandbox template ${templateName} runtime container has invalid image`)
+    }
+    const containers = sandbox.spec?.podTemplate?.spec?.containers ?? []
+    const containerIndexes = containers.flatMap((container, index) => (container.name === 'runtime' ? [index] : []))
+    if (containerIndexes.length === 0) throw new Error(`sandbox ${sandboxName} has no runtime container`)
+    if (containerIndexes.length > 1) throw new Error(`sandbox ${sandboxName} has multiple runtime containers`)
+    const containerIndex = containerIndexes[0]!
+    const observedImage = containers[containerIndex]?.image
+    if (!observedImage?.trim()) throw new Error(`sandbox ${sandboxName} runtime container has no image`)
+    if (observedImage.trim() !== observedImage) {
+      throw new Error(`sandbox ${sandboxName} runtime container has invalid image`)
+    }
+    return { containerIndex, observedName: 'runtime', observedImage, targetImage }
+  }
+}


### PR DESCRIPTION
`K8sDriver` carried eight concurrent maps. Three of them are one mechanism — who holds a Sandbox and who may change its operating mode — so this PR moves them into a new `SandboxLease` (`packages/daemon/src/k8s/sandbox-lease.ts`):

- `busy` — per-Sandbox work refcount (it *counts* holders, it does not exclude them; the nested retain from `launch` → `ensureBoundChannel` is intentional reentrancy and keeps counting semantics)
- `modeQueue` — per-Sandbox serialized transition chain, still kept alive across a rejected link so one failure cannot wedge the queue
- `suspending` — per-agent idle-suspension gate

Moved with them: `retain`/`release`, `queueMode`/`applyMode`, `resolveResumeImage` (only `applyMode` calls it), `forgetSandbox`, and the lease-side half of `suspendIfIdle`. `MAX_MODE_ATTEMPTS` moved too.

`K8sDriver` keeps its full public surface as thin delegation and constructs the lease in its constructor.

### Invariants preserved
- `SandboxLease.suspendIfIdle` publishes the `suspending` gate **synchronously before its first await**, in the same synchronous window as the `busy` read.
- `ensureSandbox` still awaits `suspending` → `adopting` → reads `launches`, in that order.
- `forgetSandbox` is still called only from `releaseAgent`; `forgetLaunch` still does not touch `busy`/`modeQueue`.
- `suspendIfIdle` spans lease *and* launch/session state, so the driver method still orchestrates: it resolves the launch (returning `absent` when there is none) and hands the lease a callback for the `sessions`/`forgetLaunch` half. No cross-map logic moved into the lease.

### Verification
- `pnpm typecheck` in `packages/daemon` — clean.
- `npx vitest run test/k8s-driver.test.ts test/k8s-driver-takeover.test.ts test/k8s-runtime-plane.test.ts test/cluster-cold-start.test.ts test/daemon-k8s-mode.test.ts` — 5 files, 86 tests, all pass.
- `prettier --check` and `eslint` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
