### PR TITLE
fix(web): group placement reads as a group, not as "pool"

### DIFF
--- a/packages/web/src/components/console/modals/GroupModal.tsx
+++ b/packages/web/src/components/console/modals/GroupModal.tsx
@@ -1,7 +1,7 @@
 // No 'use client' here: rendered only by ModalProvider (the client boundary).
 
 import { useRef, useState } from 'react'
-import type { DaemonRow, MemberSetRow } from '@/lib/data'
+import type { MemberSetRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Button, Icon } from '@/components/ui'
 
@@ -19,7 +19,7 @@ import { Button, Icon } from '@/components/ui'
  * own, so one refusal reports itself and leaves the rest of the edit intact.
  */
 export default function GroupModal({ group, onClose }: { group?: MemberSetRow; onClose: () => void }) {
-  const { createGroup, renameGroup, enrollInGroup, withdrawFromGroup, daemons, agents } = useConsoleData()
+  const { createGroup, renameGroup, enrollInGroup, withdrawFromGroup, daemons } = useConsoleData()
   const [name, setName] = useState(group?.name ?? '')
   // The membership this dialog is editing, seeded from the group and applied on save.
   const [members, setMembers] = useState<string[]>(group?.memberDaemonIds ?? [])
@@ -33,7 +33,6 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
   // A daemon the org owns is a candidate unless it is in a DIFFERENT group: a daemon is in at most
   // one, and moving it between groups is a two-phase transition, not a checkbox.
   const candidates = daemons.filter((d) => !d.pool && (!d.memberSetId || d.memberSetId === group?.setId))
-  const pinnedCount = (daemon: DaemonRow) => agents.filter((a) => a.daemon === daemon.daemonId).length
 
   const toggle = (daemonId: string) =>
     setMembers((current) =>
@@ -100,9 +99,6 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
             <div className="overflow-hidden rounded-lg border border-(--border-subtle)">
               {candidates.map((daemon) => {
                 const checked = members.includes(daemon.daemonId)
-                // Its own agents stay its own — worth saying where there are any, because a group
-                // reads like a pool and the question "do I lose these?" is the one being asked.
-                const pinned = pinnedCount(daemon)
                 return (
                   <button
                     key={daemon.daemonId}
@@ -125,11 +121,7 @@ export default function GroupModal({ group, onClose }: { group?: MemberSetRow; o
                         {daemon.name}
                       </span>
                       <span className="block truncate font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-                        {pinned > 0
-                          ? `Keeps its ${pinned} own agent${pinned === 1 ? '' : 's'}`
-                          : daemon.status === 'online'
-                            ? 'Online'
-                            : 'Offline'}
+                        {daemon.status === 'online' ? 'Online' : 'Offline'}
                       </span>
                     </span>
                   </button>

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -11,6 +11,7 @@ import { unverifiedConversationNotice } from '@/lib/session-access-notifications
 import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import {
+  agentDaemonLabel,
   agentLabel,
   agentPermissionDisplay,
   displayedEffort,
@@ -25,6 +26,7 @@ import {
   MOCK_PREFIX,
   permissionModeLabel,
   pgPrompts,
+  POOL_PLACEMENT,
   platName,
   preferredModelFor,
   rosterParticipantName,
@@ -1488,6 +1490,7 @@ export default function SessionDetailView() {
     sessionsLoading,
     crons,
     daemons,
+    memberSets,
     members,
     sessionActivityVersionById,
     sessionStreamGeneration,
@@ -3375,10 +3378,19 @@ export default function SessionDetailView() {
     focusedSession?.daemon && focusedSession.daemon !== '—' ? focusedSession.daemon : focusedAgent?.daemon
   const focusedDaemon =
     focusedDaemonId && focusedDaemonId !== '—' ? daemons.find((d) => d.daemonId === focusedDaemonId) : undefined
+  // What ran it, else where it is PLACED. `Agent.daemon` carries a placement sentinel for a set
+  // placement, not a member id (lib/data.ts POOL_PLACEMENT), so resolving it as a machine renders
+  // the literal "pool" — and renders it for Cloud and for every group alike, since only `setId`
+  // tells those apart. `agentDaemonLabel` is the one projection that knows the difference.
   const focusedDaemonName =
-    focusedDaemonId && focusedDaemonId !== '—'
-      ? (focusedDaemon?.name ?? (focusedDaemonId.length > 12 ? focusedDaemonId.slice(0, 8) : focusedDaemonId))
-      : ''
+    focusedDaemon?.name ??
+    (focusedAgent
+      ? agentDaemonLabel(focusedAgent, daemons, memberSets)
+      : focusedDaemonId && focusedDaemonId !== '—' && focusedDaemonId !== POOL_PLACEMENT
+        ? focusedDaemonId.length > 12
+          ? focusedDaemonId.slice(0, 8)
+          : focusedDaemonId
+        : '')
   // A cron-triggered session carries `user === "cron:<scheduleId>"`. When that's the
   // shown participant, render the chip as a link back to the owning schedule
   // (name-first once the crons list resolves it; the raw `cron:<id>` still links if


### PR DESCRIPTION
Two display fixes for the corrected join semantics (#1148).

**The picker row restated the default.** Joining a group does not move a machine's pinned agents, so `Keeps its N own agents` announces the default — every row would carry it, and it displaced the one fact that varies and that the operator is choosing on: whether the machine is online. The line only made sense while it was correcting the previous behaviour.

**The session header printed a placement sentinel.** `Agent.daemon` carries `POOL_PLACEMENT` — the literal string `pool` — for any set placement, because a set names no machine. `SessionDetailView` resolved it as a member id, found nothing, and rendered the sentinel. So every set-placed agent read `Daemon: pool`, Cloud and each organization group alike, since only `setId` plus the org's own group list distinguishes them.

It now falls back to `agentDaemonLabel`, the projection that already knows the difference, so a group shows its name and the pool shows Cloud. A session that recorded the member which actually served it still shows that machine — better provenance than the placement.

1,580 web tests pass; lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)