### PR TITLE
refactor(daemon): purify GitHub queue-admission and review-batch coalescing

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -213,6 +213,16 @@ import { GithubFinalPoster, GithubReplyCollector, type GithubCommentAttribution 
 import { finalizeGithubTurn, isGithubFinalChunk, onGithubUpdate } from './platforms/github/turn-output.js'
 import { GithubReviewClient, type GithubReviewEffect } from './github/review.js'
 import { GithubReviewOrchestrator, type GithubReviewHost } from './github/review-orchestrator.js'
+import {
+  collectGithubQueueCandidates,
+  combineCoordinationWaits,
+  githubReviewBatchSettleStep,
+  planGithubReviewBatchCoalesce,
+  planGithubRevisionAdmission,
+  planGithubRevisionAdmissionEffects,
+  planQueuedGithubRevisionRemovals,
+  selectGithubReviewBatchLeader
+} from './github/queue-admission.js'
 import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from './runtimes/registry.js'
 import { installedRuntimeCatalog, installedRuntimes, resolveCommandPath } from './runtimes/probe.js'
 import { startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.js'
@@ -462,28 +472,20 @@ import {
   MAX_TOTAL_TURNS_PER_WINDOW
 } from './daemon/loop-guard-scope.js'
 import {
-  compareGithubPullRevisionRecency,
   foreignHookDispatch,
   githubDeletedHookEvent,
   githubFallbackAllowed,
   githubHookCoordinates,
   githubPullRequestLane,
-  githubPullRevisionStream,
-  githubReviewBatchStream,
   githubReviewResultForCompletion,
   githubThreadWorktreeCleanup,
   hookReportOwner,
-  renderGithubReviewBatchPrompt,
-  GITHUB_REVIEW_BATCH_MAX_COMMENTS,
-  GITHUB_REVIEW_BATCH_MAX_WAIT_MS,
-  GITHUB_REVIEW_BATCH_QUIET_MS,
   MAX_HOOK_REPORT_INFLIGHT,
   type ActiveGithubReplyBatchMeta,
   type ActiveGithubTurnMeta,
   type GithubQueueCandidate,
   type GithubReplyTarget,
   type GithubRevisionAdmissionPlan,
-  type GithubReviewBatch,
   type GithubThreadWorktreeCleanup,
   type HookCompletionOwner,
   type HookDispatchContext,
@@ -8821,52 +8823,16 @@ export class Daemon {
   }
 
   private githubQueueCandidates(): GithubQueueCandidate[] {
-    const candidates: GithubQueueCandidate[] = []
-    for (const [key, entry] of this.activeGateEntries) candidates.push({ key, entry, state: 'active' })
-    for (const [key, queue] of this.serialQueue) {
-      for (const entry of queue) candidates.push({ key, entry, state: 'queued' })
-    }
-    return candidates
+    return collectGithubQueueCandidates(this.activeGateEntries, this.serialQueue)
   }
 
-  /** Pick the newest relay-fired revision across every session key in one trusted GitHub lane. */
   private githubRevisionAdmissionPlan(key: string, incoming: QueueEntry): GithubRevisionAdmissionPlan | undefined {
-    const stream = githubPullRevisionStream(
-      incoming.hookContext,
-      githubHookCoordinates(incoming.agentId, incoming.msg, incoming.integrationId)
-    )
-    if (!stream) return undefined
-    const revisions = [
-      ...this.githubQueueCandidates().filter(
-        (candidate) =>
-          !candidate.entry.cancelledReason &&
-          githubPullRevisionStream(
-            candidate.entry.hookContext,
-            githubHookCoordinates(candidate.entry.agentId, candidate.entry.msg, candidate.entry.integrationId)
-          ) === stream
-      ),
-      { key, entry: incoming, state: 'incoming' as const }
-    ]
-    const winner = revisions.reduce((latest, candidate) =>
-      compareGithubPullRevisionRecency(candidate.entry.hookContext!, latest.entry.hookContext!) > 0 ? candidate : latest
-    )
-    return {
-      winner,
-      superseded: revisions.filter((candidate) => candidate !== winner)
-    }
+    return planGithubRevisionAdmission(key, incoming, this.githubQueueCandidates())
   }
 
   private removeQueuedGithubRevisions(candidates: readonly GithubQueueCandidate[]): void {
-    const removals = new Map<string, Set<QueueEntry>>()
-    for (const candidate of candidates) {
-      if (candidate.state !== 'queued') continue
-      const entries = removals.get(candidate.key) ?? new Set<QueueEntry>()
-      entries.add(candidate.entry)
-      removals.set(candidate.key, entries)
-    }
-    for (const [key, entries] of removals) {
-      const next = (this.serialQueue.get(key) ?? []).filter((entry) => !entries.has(entry))
-      if (next.length > 0) this.serialQueue.set(key, next)
+    for (const [key, next] of planQueuedGithubRevisionRemovals(candidates, this.serialQueue)) {
+      if (next) this.serialQueue.set(key, next)
       else this.serialQueue.delete(key)
     }
   }
@@ -8892,23 +8858,19 @@ export class Daemon {
   }
 
   private extendGithubCoordinationWait(entry: QueueEntry, waits: readonly Promise<void>[]): void {
-    const pending = [...(entry.coordinationWait ? [entry.coordinationWait] : []), ...waits]
-    if (pending.length > 0) entry.coordinationWait = Promise.all(pending).then(() => undefined)
+    const next = combineCoordinationWaits(entry.coordinationWait, waits)
+    if (next) entry.coordinationWait = next
   }
 
   private applyGithubRevisionAdmissionPlan(plan: GithubRevisionAdmissionPlan, incoming: QueueEntry): boolean {
-    const activeLosers = plan.superseded.filter((candidate) => candidate.state === 'active')
-    const terminalLosers = plan.superseded.filter((candidate) => candidate.state !== 'active')
+    const { terminalLosers, activeLosers, winnerLane, winnerNeedsWait, incomingWins } =
+      planGithubRevisionAdmissionEffects(plan, incoming)
     this.removeQueuedGithubRevisions(terminalLosers)
     this.settleSupersededGithubRevisions(
       terminalLosers.map((candidate) => candidate.entry),
       plan.winner.entry
     )
     const waits: Promise<void>[] = []
-    const winnerLane = githubPullRequestLane(
-      plan.winner.entry.hookContext,
-      githubHookCoordinates(plan.winner.entry.agentId, plan.winner.entry.msg, plan.winner.entry.integrationId)
-    )
     for (const candidate of activeLosers) {
       if (candidate.entry.coordinationWait) waits.push(candidate.entry.coordinationWait)
       const activeDone = this.activeDispatchDoneByKey.get(candidate.key)
@@ -8923,60 +8885,19 @@ export class Daemon {
     if (this.safetyDrainingAgents.has(plan.winner.entry.agentId)) {
       waits.push(this.waitForSafetyDrain(plan.winner.entry.agentId))
     }
-    if (plan.winner.state !== 'active') this.extendGithubCoordinationWait(plan.winner.entry, waits)
-    return plan.winner.entry === incoming
+    if (winnerNeedsWait) this.extendGithubCoordinationWait(plan.winner.entry, waits)
+    return incomingWins
   }
 
   private githubReviewBatchLeader(incoming: QueueEntry): QueueEntry | undefined {
-    const batchStream = githubReviewBatchStream(
-      incoming.hookContext,
-      githubHookCoordinates(incoming.agentId, incoming.msg, incoming.integrationId)
-    )
-    if (!batchStream) return undefined
-    return this.githubQueueCandidates()
-      .map((candidate) => candidate.entry)
-      .filter((candidate) => {
-        const batch = candidate.hookContext?.githubReviewBatch
-        return (
-          !candidate.cancelledReason &&
-          githubReviewBatchStream(
-            candidate.hookContext,
-            githubHookCoordinates(candidate.agentId, candidate.msg, candidate.integrationId)
-          ) === batchStream &&
-          batch !== undefined &&
-          !batch.sealed &&
-          batch.items.length < GITHUB_REVIEW_BATCH_MAX_COMMENTS
-        )
-      })
-      .sort((a, b) => compareGithubPullRevisionRecency(a.hookContext!, b.hookContext!))[0]
+    return selectGithubReviewBatchLeader(incoming, this.githubQueueCandidates())
   }
 
   private coalesceGithubReviewBatch(leader: QueueEntry, follower: QueueEntry): boolean {
-    const leaderHook = leader.hookContext
-    const followerHook = follower.hookContext
-    const leaderBatch = leaderHook?.githubReviewBatch
-    const followerItem = followerHook?.githubReviewBatch?.items[0]
-    if (!leaderHook || !followerHook || !leaderBatch || !followerItem || !leader.inboxId || !follower.inboxId) {
-      return false
-    }
-    if (
-      leaderBatch.sealed ||
-      leaderBatch.items.length >= GITHUB_REVIEW_BATCH_MAX_COMMENTS ||
-      leaderBatch.items.some(
-        (item) => item.reply.reviewThreadRootCommentId === followerItem.reply.reviewThreadRootCommentId
-      )
-    ) {
-      return false
-    }
-    const nextHook: HookDispatchContext = {
-      ...leaderHook,
-      githubReviewBatch: {
-        ...leaderBatch,
-        updatedAt: this.clock.now(),
-        items: [...leaderBatch.items, followerItem]
-      }
-    }
-    const report = this.buildHookReport(followerHook, 'success', { reason: 'coalesced_review_batch' })
+    const plan = planGithubReviewBatchCoalesce(leader, follower, this.clock.now())
+    if (!plan || !leader.inboxId || !follower.inboxId) return false
+    const { nextHook } = plan
+    const report = this.buildHookReport(follower.hookContext!, 'success', { reason: 'coalesced_review_batch' })
     try {
       const committed = this.store.coalesceHookInbox({
         leaderId: leader.inboxId,
@@ -8997,34 +8918,28 @@ export class Daemon {
     this.liveInboxIds.delete(follower.inboxId)
     this.sendHookReport(report, follower.inboxId)
     defaultTurnOutputMetrics.queueCoalesced(follower.msg.platform, 1)
-    this.log.info(
-      `github review batch: coalesced thread ${followerItem.reply.reviewThreadRootCommentId} into review ${leaderBatch.reviewId}`
-    )
+    this.log.info(`github review batch: coalesced thread ${plan.threadRootCommentId} into review ${plan.reviewId}`)
     return true
   }
 
   private async settleGithubReviewBatch(entry: QueueEntry): Promise<void> {
     while (true) {
-      const batch = entry.hookContext?.githubReviewBatch
-      if (!batch) return
-      if (batch.sealed) {
-        if (batch.items.length > 1) entry.githubReply = undefined
+      const step = githubReviewBatchSettleStep(
+        entry.hookContext?.githubReviewBatch,
+        Boolean(entry.cancelledReason),
+        this.clock.now()
+      )
+      if (step.action === 'stop') {
+        if (step.clearReply) entry.githubReply = undefined
         return
       }
-      if (entry.cancelledReason) return
-      const deadline = Math.min(
-        batch.updatedAt + GITHUB_REVIEW_BATCH_QUIET_MS,
-        batch.openedAt + GITHUB_REVIEW_BATCH_MAX_WAIT_MS
-      )
-      const delay = deadline - this.clock.now()
-      if (delay > 0) {
-        await new Promise<void>((resolve) => this.clock.setTimeout(resolve, delay))
+      if (step.action === 'wait') {
+        await new Promise<void>((resolve) => this.clock.setTimeout(resolve, step.delayMs))
         continue
       }
-      const sealed: GithubReviewBatch = { ...batch, sealed: true }
-      entry.hookContext = { ...entry.hookContext!, githubReviewBatch: sealed }
-      if (sealed.items.length > 1) {
-        entry.msg = { ...entry.msg, text: renderGithubReviewBatchPrompt(sealed) }
+      entry.hookContext = { ...entry.hookContext!, githubReviewBatch: step.sealed }
+      if (step.promptText !== undefined) {
+        entry.msg = { ...entry.msg, text: step.promptText }
         entry.githubReply = undefined
       }
       this.persistHookPayload(entry, true)

--- a/packages/daemon/src/github/queue-admission.ts
+++ b/packages/daemon/src/github/queue-admission.ts
@@ -1,0 +1,227 @@
+/**
+ * The decision half of GitHub admission into the per-sessionKey serial gate
+ * (webhook-triggers-and-github-events.md): which relay-fired revision of one PR
+ * lane wins, which queued or active turns it supersedes, which review-thread
+ * deliveries coalesce into a single batched review, and when an open batch is
+ * ready to seal. Every function here is pure — it reads explicit queue
+ * snapshots and clock values and returns a plan. The Daemon keeps the appliers
+ * that mutate `serialQueue`/`activeGateEntries`, settle sinks, and write the
+ * durable inbox, because their ordering is production-visible.
+ */
+import {
+  compareGithubPullRevisionRecency,
+  githubHookCoordinates,
+  githubPullRequestLane,
+  githubPullRevisionStream,
+  githubReviewBatchStream,
+  renderGithubReviewBatchPrompt,
+  GITHUB_REVIEW_BATCH_MAX_COMMENTS,
+  GITHUB_REVIEW_BATCH_MAX_WAIT_MS,
+  GITHUB_REVIEW_BATCH_QUIET_MS,
+  type GithubQueueCandidate,
+  type GithubRevisionAdmissionPlan,
+  type GithubReviewBatch,
+  type HookDispatchContext
+} from '../daemon/github-hook-coords.js'
+import type { QueueEntry } from '../daemon/turn-types.js'
+
+/** Flatten the gate's live heads plus every queued entry into one candidate list. */
+export function collectGithubQueueCandidates(
+  activeGateEntries: ReadonlyMap<string, QueueEntry>,
+  serialQueue: ReadonlyMap<string, QueueEntry[]>
+): GithubQueueCandidate[] {
+  const candidates: GithubQueueCandidate[] = []
+  for (const [key, entry] of activeGateEntries) candidates.push({ key, entry, state: 'active' })
+  for (const [key, queue] of serialQueue) {
+    for (const entry of queue) candidates.push({ key, entry, state: 'queued' })
+  }
+  return candidates
+}
+
+/** Pick the newest relay-fired revision across every session key in one trusted GitHub lane. */
+export function planGithubRevisionAdmission(
+  key: string,
+  incoming: QueueEntry,
+  candidates: readonly GithubQueueCandidate[]
+): GithubRevisionAdmissionPlan | undefined {
+  const stream = githubPullRevisionStream(
+    incoming.hookContext,
+    githubHookCoordinates(incoming.agentId, incoming.msg, incoming.integrationId)
+  )
+  if (!stream) return undefined
+  const revisions = [
+    ...candidates.filter(
+      (candidate) =>
+        !candidate.entry.cancelledReason &&
+        githubPullRevisionStream(
+          candidate.entry.hookContext,
+          githubHookCoordinates(candidate.entry.agentId, candidate.entry.msg, candidate.entry.integrationId)
+        ) === stream
+    ),
+    { key, entry: incoming, state: 'incoming' as const }
+  ]
+  const winner = revisions.reduce((latest, candidate) =>
+    compareGithubPullRevisionRecency(candidate.entry.hookContext!, latest.entry.hookContext!) > 0 ? candidate : latest
+  )
+  return {
+    winner,
+    superseded: revisions.filter((candidate) => candidate !== winner)
+  }
+}
+
+/** Per-key replacement queues once the superseded queued entries are dropped; `undefined` means delete the key. */
+export function planQueuedGithubRevisionRemovals(
+  candidates: readonly GithubQueueCandidate[],
+  serialQueue: ReadonlyMap<string, QueueEntry[]>
+): Map<string, QueueEntry[] | undefined> {
+  const removals = new Map<string, Set<QueueEntry>>()
+  for (const candidate of candidates) {
+    if (candidate.state !== 'queued') continue
+    const entries = removals.get(candidate.key) ?? new Set<QueueEntry>()
+    entries.add(candidate.entry)
+    removals.set(candidate.key, entries)
+  }
+  const next = new Map<string, QueueEntry[] | undefined>()
+  for (const [key, entries] of removals) {
+    const kept = (serialQueue.get(key) ?? []).filter((entry) => !entries.has(entry))
+    next.set(key, kept.length > 0 ? kept : undefined)
+  }
+  return next
+}
+
+/** Fold new waits into an entry's existing coordination wait; `undefined` means leave it untouched. */
+export function combineCoordinationWaits(
+  existing: Promise<void> | undefined,
+  waits: readonly Promise<void>[]
+): Promise<void> | undefined {
+  const pending = [...(existing ? [existing] : []), ...waits]
+  if (pending.length === 0) return undefined
+  return Promise.all(pending).then(() => undefined)
+}
+
+export interface GithubRevisionAdmissionEffects {
+  /** Queued or incoming losers: removed from the queue and settled outright. */
+  terminalLosers: GithubQueueCandidate[]
+  /** Losers already generating: interrupted, and their completion awaited by the winner. */
+  activeLosers: GithubQueueCandidate[]
+  /** Lane the winner belongs to, so its own re-admission survives the interrupt. */
+  winnerLane: string | undefined
+  /** The winner is not yet running, so it must absorb the losers' teardown waits. */
+  winnerNeedsWait: boolean
+  /** The caller's own entry won and may proceed. */
+  incomingWins: boolean
+}
+
+export function planGithubRevisionAdmissionEffects(
+  plan: GithubRevisionAdmissionPlan,
+  incoming: QueueEntry
+): GithubRevisionAdmissionEffects {
+  return {
+    terminalLosers: plan.superseded.filter((candidate) => candidate.state !== 'active'),
+    activeLosers: plan.superseded.filter((candidate) => candidate.state === 'active'),
+    winnerLane: githubPullRequestLane(
+      plan.winner.entry.hookContext,
+      githubHookCoordinates(plan.winner.entry.agentId, plan.winner.entry.msg, plan.winner.entry.integrationId)
+    ),
+    winnerNeedsWait: plan.winner.state !== 'active',
+    incomingWins: plan.winner.entry === incoming
+  }
+}
+
+/** Oldest open, unsealed, non-full batch on the incoming delivery's review stream. */
+export function selectGithubReviewBatchLeader(
+  incoming: QueueEntry,
+  candidates: readonly GithubQueueCandidate[]
+): QueueEntry | undefined {
+  const batchStream = githubReviewBatchStream(
+    incoming.hookContext,
+    githubHookCoordinates(incoming.agentId, incoming.msg, incoming.integrationId)
+  )
+  if (!batchStream) return undefined
+  return candidates
+    .map((candidate) => candidate.entry)
+    .filter((candidate) => {
+      const batch = candidate.hookContext?.githubReviewBatch
+      return (
+        !candidate.cancelledReason &&
+        githubReviewBatchStream(
+          candidate.hookContext,
+          githubHookCoordinates(candidate.agentId, candidate.msg, candidate.integrationId)
+        ) === batchStream &&
+        batch !== undefined &&
+        !batch.sealed &&
+        batch.items.length < GITHUB_REVIEW_BATCH_MAX_COMMENTS
+      )
+    })
+    .sort((a, b) => compareGithubPullRevisionRecency(a.hookContext!, b.hookContext!))[0]
+}
+
+export interface GithubReviewBatchCoalescePlan {
+  /** Leader hook context carrying the follower's thread appended to the batch. */
+  nextHook: HookDispatchContext
+  /** Review-thread root comment id folded in, for the operator log line. */
+  threadRootCommentId: string
+  reviewId: string
+}
+
+/** Decide whether a follower review-thread delivery folds into the leader's open batch. */
+export function planGithubReviewBatchCoalesce(
+  leader: QueueEntry,
+  follower: QueueEntry,
+  now: number
+): GithubReviewBatchCoalescePlan | undefined {
+  const leaderHook = leader.hookContext
+  const followerHook = follower.hookContext
+  const leaderBatch = leaderHook?.githubReviewBatch
+  const followerItem = followerHook?.githubReviewBatch?.items[0]
+  if (!leaderHook || !followerHook || !leaderBatch || !followerItem || !leader.inboxId || !follower.inboxId) {
+    return undefined
+  }
+  if (
+    leaderBatch.sealed ||
+    leaderBatch.items.length >= GITHUB_REVIEW_BATCH_MAX_COMMENTS ||
+    leaderBatch.items.some(
+      (item) => item.reply.reviewThreadRootCommentId === followerItem.reply.reviewThreadRootCommentId
+    )
+  ) {
+    return undefined
+  }
+  return {
+    nextHook: {
+      ...leaderHook,
+      githubReviewBatch: { ...leaderBatch, updatedAt: now, items: [...leaderBatch.items, followerItem] }
+    },
+    threadRootCommentId: followerItem.reply.reviewThreadRootCommentId,
+    reviewId: leaderBatch.reviewId
+  }
+}
+
+export type GithubReviewBatchStep =
+  /** Nothing left to settle; `clearReply` drops the single-thread reply target of an already sealed batch. */
+  | { action: 'stop'; clearReply: boolean }
+  | { action: 'wait'; delayMs: number }
+  /** Quiet or max-wait window elapsed; `promptText` is set only for a genuinely multi-thread batch. */
+  | { action: 'seal'; sealed: GithubReviewBatch; promptText?: string }
+
+/** One turn of the batch settle loop: stop, sleep until the next deadline, or seal. */
+export function githubReviewBatchSettleStep(
+  batch: GithubReviewBatch | undefined,
+  cancelled: boolean,
+  now: number
+): GithubReviewBatchStep {
+  if (!batch) return { action: 'stop', clearReply: false }
+  if (batch.sealed) return { action: 'stop', clearReply: batch.items.length > 1 }
+  if (cancelled) return { action: 'stop', clearReply: false }
+  const deadline = Math.min(
+    batch.updatedAt + GITHUB_REVIEW_BATCH_QUIET_MS,
+    batch.openedAt + GITHUB_REVIEW_BATCH_MAX_WAIT_MS
+  )
+  const delayMs = deadline - now
+  if (delayMs > 0) return { action: 'wait', delayMs }
+  const sealed: GithubReviewBatch = { ...batch, sealed: true }
+  return {
+    action: 'seal',
+    sealed,
+    ...(sealed.items.length > 1 ? { promptText: renderGithubReviewBatchPrompt(sealed) } : {})
+  }
+}


### PR DESCRIPTION
## What

Extracts the **decision half** of GitHub admission into the per-sessionKey serial gate out of `daemon.ts` and into a new pure module `packages/daemon/src/github/queue-admission.ts`:

- `collectGithubQueueCandidates` — flatten `activeGateEntries` + `serialQueue` into one candidate list
- `planGithubRevisionAdmission` — latest-wins across every session key in one trusted PR lane
- `planGithubRevisionAdmissionEffects` — partition into terminal vs active losers, winner lane, whether the winner must absorb teardown waits, whether the caller won
- `planQueuedGithubRevisionRemovals` — per-key replacement queues (`undefined` = delete the key)
- `combineCoordinationWaits` — fold new waits into an entry's existing coordination wait
- `selectGithubReviewBatchLeader` — oldest open, unsealed, non-full batch on the review stream
- `planGithubReviewBatchCoalesce` — whether a follower review-thread delivery folds into the leader's batch
- `githubReviewBatchSettleStep` — one turn of the settle loop: stop / wait / seal

The **apply half stays on `Daemon`** as thin same-name methods (`githubQueueCandidates`, `githubRevisionAdmissionPlan`, `removeQueuedGithubRevisions`, `settleSupersededGithubRevisions`, `extendGithubCoordinationWait`, `applyGithubRevisionAdmissionPlan`, `githubReviewBatchLeader`, `coalesceGithubReviewBatch`, `settleGithubReviewBatch`). They still mutate `serialQueue` / `activeGateEntries`, terminate sinks, emit hook completions and evaluations, interrupt active turns, and write the durable inbox **in exactly the previous order** — that ordering is production-visible (it decides whether a GitHub review gets submitted twice or lost), so it was preserved verbatim rather than restructured.

`settleSupersededGithubRevisions` was left entirely on `Daemon`: it is pure side effect (sink teardown, inbox removal, metrics, logging) with no decision core worth splitting.

Behaviour-neutral: no call sites, ordering, or guard conditions changed.

## Verification

- `pnpm typecheck` in `packages/daemon` — clean
- `npx vitest run test/daemon-hook.test.ts test/durable-inbox.test.ts` — 107 passed (these are the only files matching `githubReviewBatch` / `superseded_by_newer_revision` / `coalesced_review_batch`; no test references the extracted method names directly)
- `prettier` + `eslint` clean on both touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)