### PR TITLE
refactor(daemon): extract the runtime-session opener from SessionManager.handle()

### DIFF
--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -25,6 +25,7 @@ import { planReplay, renderReplayContext } from './turn/replay-plan.js'
 import { AGENT_META_OPENING, buildStandingContext } from './turn/standing-context.js'
 import { backfillThreadHistory } from './turn/thread-backfill.js'
 import { RecallObserver, runTurnRecall, type MemoryRecallLifecycleEvent } from './turn/memory-recall.js'
+import { openRuntimeSession } from './turn/runtime-session.js'
 
 // The recall lifecycle contract lives with the collaborator that emits it; re-exported
 // here because SessionManagerDeps is the seam production wires its observer through.
@@ -553,80 +554,6 @@ export class SessionManager {
     if (hostCold && this.deps.resolvePreparedWorkspace) {
       preparedCwd = await abortable(() => this.deps.resolvePreparedWorkspace!(agent), signal)
     }
-    // The sticky per-session effort override rides session `_meta` on new/load so the
-    // `ultracode` sentinel (rejected by the `thought_level` select) takes effect.
-    // Resolve chat authority immediately before each request, then fence the await:
-    // metadata-only settings cannot be reversed by a later live selector.
-    const sessionStartEffort = (): { value?: string; chatSelected: boolean } => {
-      const allowed = this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true
-      if (!allowed) return { chatSelected: false }
-      const value = initialEffort ?? this.deps.store.getEffortOverride(key)
-      return { value, chatSelected: value !== undefined }
-    }
-    const runtimeWorkspaceDirectories = (cwd: string): string[] =>
-      this.workspaces.additionalWorkspaceDirectories(agent, cwd, {
-        sessionKey: key,
-        isolation: workspaceIsolation
-      })
-    let additionalMcpServersAttached = options.additionalMcpServers?.length ? true : undefined
-    const withAdditionalMcpFallback = async <T>(
-      primary: () => Promise<T>,
-      fallback: (() => Promise<T>) | undefined
-    ): Promise<T> => {
-      try {
-        return await primary()
-      } catch (error) {
-        if (signal?.aborted || !fallback) throw error
-        const result = await fallback()
-        additionalMcpServersAttached = false
-        return result
-      }
-    }
-    const newRuntimeSession = async (
-      cwd: string,
-      mcpServers: McpServer[],
-      systemAppend?: string,
-      fallbackMcpServers?: McpServer[]
-    ): Promise<string> => {
-      const additionalDirectories = runtimeWorkspaceDirectories(cwd)
-      while (true) {
-        const selected = sessionStartEffort()
-        const create = (servers: McpServer[]) =>
-          abortable(() => host.newSession(cwd, servers, selected.value, systemAppend, additionalDirectories), signal)
-        const sessionId = await withAdditionalMcpFallback(
-          () => create(mcpServers),
-          fallbackMcpServers ? () => create(fallbackMcpServers) : undefined
-        )
-        if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return sessionId
-        host.discardSession(sessionId)
-      }
-    }
-    const loadRuntimeSession = async (
-      sessionId: string,
-      cwd: string,
-      mcpServers: McpServer[],
-      systemAppend?: string,
-      fallbackMcpServers?: McpServer[]
-    ): Promise<boolean> => {
-      const selected = sessionStartEffort()
-      const additionalDirectories = runtimeWorkspaceDirectories(cwd)
-      const load = (servers: McpServer[]) =>
-        abortable(
-          () => host.loadSession(sessionId, cwd, servers, selected.value, systemAppend, additionalDirectories),
-          signal
-        )
-      await withAdditionalMcpFallback(
-        () => load(mcpServers),
-        fallbackMcpServers ? () => load(fallbackMcpServers) : undefined
-      )
-      if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return true
-      // The pinned Claude adapter treats a repeated load of the same session/cwd/MCP
-      // fingerprint as idempotent, so another load cannot replace metadata-only effort.
-      // Forget this local attachment and let the caller create a fresh safe session.
-      host.discardSession(sessionId)
-      return false
-    }
-
     // Agent memory INDEX (memory/provider.ts), read fresh. Applied only when THIS
     // call creates a fresh session (a resumed session already carries it from its first
     // turn). Every session may READ shared memory (#653): the index is injected whenever
@@ -672,88 +599,44 @@ export class SessionManager {
       usesMeta
     })
 
-    // Whether THIS call created a brand-new ACP session (vs. resuming/recreating one
-    // the CP already knows). Drives the daemon's one-shot `event/session` start emit.
-    let created = false
-    if (!rec || !rec.acpSessionId) {
-      // brand-new session; use the pre-host preparation when the host was cold, else
-      // prepare now (warm host — ordering vs spawn is moot).
-      const cwd =
-        options.preparedWorkspaceCwd ??
-        (workspaceIsolation === 'shared' ? preparedCwd : undefined) ??
-        (await abortable(
-          () =>
-            this.deps.prepareWorkspace?.(agent, expectedWarmHost, workspaceRequest) ??
-            this.workspaces.prepareWorkspace(agent),
-          signal
-        ))
-      const ordinaryMcpServers =
-        this.deps.mcpServersFor?.({
-          agent,
-          platform: msg.platform,
-          channel: msg.channel,
-          thread,
-          ...(integrationId !== undefined ? { integrationId } : {}),
-          ...(transportScope !== undefined ? { transportScope } : {}),
-          isDm: msg.isDm
-        }) ?? []
-      const mcpServers = [...ordinaryMcpServers, ...(options.additionalMcpServers ?? [])]
-      const acpSessionId = await newRuntimeSession(
-        cwd,
-        mcpServers,
-        metaContext,
-        options.additionalMcpServers?.length ? ordinaryMcpServers : undefined
-      )
-      created = true
-      rec = {
+    // Create or re-attach the runtime session (turn/runtime-session.ts). `created` drives the
+    // daemon's one-shot `event/session` start emit; the additional-MCP outcome is reported back
+    // rather than written into a shared mutable.
+    const opened = await openRuntimeSession({
+      host,
+      agent,
+      rec,
+      identity: {
         key,
         agentId,
         platform: msg.platform,
         channel: msg.channel,
         thread,
         transportScope: transportScope ?? null,
-        acpSessionId,
-        state: 'idle',
-        lastDeliveredTs: null,
-        updatedAt: Date.now(),
-        // The source that created the session (first-wins in the store; read back
-        // as `session/list`'s triggeredBy). Hook routing identity remains separate
-        // from the GitHub actor credited on the transcript row above.
         triggeredBy: msg.sessionTriggerId ?? msg.sender.id,
         ...(msg.threadUrl ? { threadUrl: msg.threadUrl } : {}),
         memoryProvider: currentMemoryProvider,
         workspaceIsolation,
-        // Durable parent link, set once at spawn (first-wins in the store).
         ...(effectiveOriginSessionId ? { originSessionId: effectiveOriginSessionId } : {}),
-        // Durable report-back obligation (sticky-true in the store).
-        ...(needsReplyToParent ? { needsParentReply: 1 } : {})
-      }
-      this.deps.store.upsertSession(rec)
-      if (isNewLogicalSession && msg.initialSessionTitle?.trim()) {
-        this.deps.store.setSessionTitle(key, msg.initialSessionTitle.trim())
-      }
-    } else if (host.hasSession?.(rec.acpSessionId) === false) {
-      const persistedSessionId = rec.acpSessionId
-      // Persisted, but unknown to THIS agent process (daemon restart / host eviction):
-      // prompting it would yield ACP "Session not found". Prefer native resume
-      // (session/load — the agent restores its own history, so the §8.5 gap replay
-      // below only re-feeds messages it missed). If the agent can't load it, recreate
-      // a fresh session and replay the whole thread as context (lastDeliveredTs=null).
-      // Resume: use the pre-host preparation when the host cold-started here (persisted
-      // session after restart/eviction — skills must precede spawn), else prepare now.
-      const cwd =
-        options.preparedWorkspaceCwd ??
-        (workspaceIsolation === 'shared' ? preparedCwd : undefined) ??
-        (await abortable(
-          () =>
-            this.deps.prepareWorkspace?.(agent, expectedWarmHost, workspaceRequest) ??
-            this.workspaces.prepareWorkspace(agent),
-          signal
-        ))
-      // Resolved once, shared by both paths: session/load must re-attach the same
-      // MCP servers a fresh session would get (the agent doesn't persist them
-      // across processes), and resolving twice would register two bridge tokens.
-      const ordinaryMcpServers =
+        ...(needsReplyToParent ? { needsParentReply: true } : {}),
+        ...(isNewLogicalSession && msg.initialSessionTitle?.trim()
+          ? { initialTitle: msg.initialSessionTitle.trim() }
+          : {})
+      },
+      store: this.deps.store,
+      ...(options.preparedWorkspaceCwd !== undefined ? { preparedWorkspaceCwd: options.preparedWorkspaceCwd } : {}),
+      ...(preparedCwd !== undefined ? { preparedCwd } : {}),
+      ...(expectedWarmHost !== undefined ? { expectedWarmHost } : {}),
+      prepareWorkspace: (a, warmHost) =>
+        Promise.resolve(
+          this.deps.prepareWorkspace?.(a, warmHost, workspaceRequest) ?? this.workspaces.prepareWorkspace(a)
+        ),
+      workspaceDirectories: (cwd) =>
+        this.workspaces.additionalWorkspaceDirectories(agent, cwd, {
+          sessionKey: key,
+          isolation: workspaceIsolation
+        }),
+      mcpServersFor: () =>
         this.deps.mcpServersFor?.({
           agent,
           platform: msg.platform,
@@ -762,37 +645,24 @@ export class SessionManager {
           ...(integrationId !== undefined ? { integrationId } : {}),
           ...(transportScope !== undefined ? { transportScope } : {}),
           isDm: msg.isDm
-        }) ?? []
-      const mcpServers = [...ordinaryMcpServers, ...(options.additionalMcpServers ?? [])]
-      const fallbackMcpServers = options.additionalMcpServers?.length ? ordinaryMcpServers : undefined
-      let resumed = false
-      if (host.loadSupported?.()) {
-        // §7.3 closed/evicted → resuming: mark the re-attach so a TTL-closed session
-        // isn't seen as `closed` mid-load, then fall through to `prompting` below.
-        this.deps.store.setSessionState(key, 'resuming', Date.now())
-        try {
-          resumed = await loadRuntimeSession(
-            persistedSessionId,
-            cwd,
-            mcpServers,
-            usesMeta ? resumeSystemContext : undefined,
-            fallbackMcpServers
-          )
-        } catch {
-          if (signal?.aborted) throw interrupted(signal)
-          // agent couldn't load it (GC'd / not durably persisted) — recreate below
-        }
-      }
-      if (!resumed) {
-        const acpSessionId = await newRuntimeSession(cwd, mcpServers, metaContext, fallbackMcpServers)
-        // A fresh ACP id the CP has never seen (the persisted one couldn't be resumed),
-        // so this counts as a create for `event/session`. A resumed session (loadSession
-        // above) keeps its id — the CP already knows it — so `created` stays false there.
-        created = true
-        rec = { ...rec, acpSessionId, state: 'idle', lastDeliveredTs: null, updatedAt: Date.now() }
-        this.deps.store.upsertSession(rec)
-      }
-    }
+        }) ?? [],
+      ...(options.additionalMcpServers !== undefined ? { additionalMcpServers: options.additionalMcpServers } : {}),
+      // The sticky per-session effort override rides session `_meta` on new/load so the
+      // `ultracode` sentinel (rejected by the `thought_level` select) takes effect. Chat
+      // authority is resolved immediately before each request, then the await is fenced:
+      // metadata-only settings cannot be reversed by a later live selector.
+      chatRuntimeChangesAllowed: () => this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true,
+      effortOverride: () => initialEffort ?? this.deps.store.getEffortOverride(key),
+      ...(metaContext !== undefined ? { metaContext } : {}),
+      ...(resumeSystemContext !== undefined ? { resumeSystemContext } : {}),
+      usesMeta,
+      ...(signal ? { signal } : {}),
+      abortable,
+      interrupted
+    })
+    rec = opened.rec
+    const created = opened.created
+    const additionalMcpServersAttached = opened.additionalMcpAttached
 
     // A channel-root message posted by this same agent creates the thread's session cursor
     // without running the model. Keep lastDeliveredTs at null: the first real reply must replay

--- a/packages/daemon/src/session/turn/runtime-session.ts
+++ b/packages/daemon/src/session/turn/runtime-session.ts
@@ -1,0 +1,237 @@
+import type { McpServer } from '@agentclientprotocol/sdk'
+import type { AcpHost } from '../../acp/acp-host.js'
+import type { Agent } from '../../agents/agent-schema.js'
+import type { LocalStore, SessionRecord } from '../../store/local-store.js'
+
+/** The store writes the opener owns — the session row plus the ingress-supplied title. */
+type OpenerStore = Pick<LocalStore, 'setSessionState' | 'upsertSession' | 'setSessionTitle'>
+
+/** Everything the create branch needs to mint the brand-new session row. */
+export interface RuntimeSessionIdentity {
+  key: string
+  agentId: string
+  platform: string
+  channel: string
+  thread: string
+  transportScope: string | null
+  triggeredBy: string
+  threadUrl?: string
+  memoryProvider: SessionRecord['memoryProvider']
+  workspaceIsolation: 'shared' | 'session'
+  /** Durable parent link (§5.3), set once at spawn (first-wins in the store). */
+  originSessionId?: string
+  /** Durable report-back obligation (sticky-true in the store). */
+  needsParentReply?: boolean
+  /** Ingress-supplied title, already trimmed and only for a brand-new logical session. */
+  initialTitle?: string
+}
+
+export interface OpenRuntimeSessionInput {
+  host: AcpHost
+  agent: Agent
+  /** The session row as handle() reconciled it; undefined ⇒ no logical session yet. */
+  rec: SessionRecord | undefined
+  identity: RuntimeSessionIdentity
+  store: OpenerStore
+  /** Daemon-verified cwd prepared before handle() (GitHub exact-ref turns). */
+  preparedWorkspaceCwd?: string
+  /** Pre-host preparation from a cold hostFor; only a shared workspace may consume it. */
+  preparedCwd?: string
+  /** Ordinary warm host carrying generation identity into the preparation seam. */
+  expectedWarmHost?: AcpHost
+  prepareWorkspace: (agent: Agent, expectedWarmHost?: AcpHost) => Promise<string>
+  /** Extra roots the runtime may read beyond cwd, per workspace isolation. */
+  workspaceDirectories: (cwd: string) => string[]
+  /** The default MCP servers for this turn's platform binding, resolved once. */
+  mcpServersFor: () => McpServer[]
+  /** Trusted descriptors bound to an overridden host; dropped if the runtime rejects them. */
+  additionalMcpServers?: McpServer[]
+  /** Current chat authority for runtime changes, re-read immediately before each request. */
+  chatRuntimeChangesAllowed: () => boolean
+  /** The sticky per-session effort override (chat-selected or turn-supplied). */
+  effortOverride: () => string | undefined
+  /** Standing context for a fresh session; `resumeSystemContext` for a native resume. */
+  metaContext?: string
+  resumeSystemContext?: string
+  usesMeta: boolean
+  signal?: AbortSignal
+  abortable: <T>(start: () => PromiseLike<T> | T, signal?: AbortSignal) => Promise<T>
+  interrupted: (signal: AbortSignal) => Error
+}
+
+export interface OpenRuntimeSessionResult {
+  sessionId: string
+  /** The session row after create/recreate; unchanged when the runtime session was live. */
+  rec: SessionRecord
+  /** Whether THIS call created a brand-new ACP session (vs. resuming a known one). */
+  created: boolean
+  /** False when the runtime rejected the trusted additional descriptors and only the
+   *  ordinary server set succeeded. Absent when no additional descriptors existed. */
+  additionalMcpAttached?: boolean
+}
+
+/**
+ * Open the ACP runtime session backing this turn: create a brand-new one, or re-attach a
+ * persisted one the host no longer knows (native `session/load`, else silently rebuild).
+ * The additional-MCP outcome is reported through the return value rather than a mutable
+ * the caller shares with this decision.
+ */
+export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promise<OpenRuntimeSessionResult> {
+  const { host, agent, identity, store, signal, abortable, interrupted } = input
+  let rec = input.rec
+  let additionalMcpAttached: boolean | undefined = input.additionalMcpServers?.length ? true : undefined
+  let created = false
+
+  const sessionStartEffort = (): { value?: string; chatSelected: boolean } => {
+    if (!input.chatRuntimeChangesAllowed()) return { chatSelected: false }
+    const value = input.effortOverride()
+    return { value, chatSelected: value !== undefined }
+  }
+  const withAdditionalMcpFallback = async <T>(
+    primary: () => Promise<T>,
+    fallback: (() => Promise<T>) | undefined
+  ): Promise<T> => {
+    try {
+      return await primary()
+    } catch (error) {
+      if (signal?.aborted || !fallback) throw error
+      const result = await fallback()
+      additionalMcpAttached = false
+      return result
+    }
+  }
+  const newRuntimeSession = async (
+    cwd: string,
+    mcpServers: McpServer[],
+    systemAppend?: string,
+    fallbackMcpServers?: McpServer[]
+  ): Promise<string> => {
+    const additionalDirectories = input.workspaceDirectories(cwd)
+    while (true) {
+      const selected = sessionStartEffort()
+      const create = (servers: McpServer[]) =>
+        abortable(() => host.newSession(cwd, servers, selected.value, systemAppend, additionalDirectories), signal)
+      const sessionId = await withAdditionalMcpFallback(
+        () => create(mcpServers),
+        fallbackMcpServers ? () => create(fallbackMcpServers) : undefined
+      )
+      if (!selected.chatSelected || input.chatRuntimeChangesAllowed()) return sessionId
+      host.discardSession(sessionId)
+    }
+  }
+  const loadRuntimeSession = async (
+    sessionId: string,
+    cwd: string,
+    mcpServers: McpServer[],
+    systemAppend?: string,
+    fallbackMcpServers?: McpServer[]
+  ): Promise<boolean> => {
+    const selected = sessionStartEffort()
+    const additionalDirectories = input.workspaceDirectories(cwd)
+    const load = (servers: McpServer[]) =>
+      abortable(
+        () => host.loadSession(sessionId, cwd, servers, selected.value, systemAppend, additionalDirectories),
+        signal
+      )
+    await withAdditionalMcpFallback(
+      () => load(mcpServers),
+      fallbackMcpServers ? () => load(fallbackMcpServers) : undefined
+    )
+    if (!selected.chatSelected || input.chatRuntimeChangesAllowed()) return true
+    // The pinned Claude adapter treats a repeated load of the same session/cwd/MCP
+    // fingerprint as idempotent, so another load cannot replace metadata-only effort.
+    // Forget this local attachment and let the caller create a fresh safe session.
+    host.discardSession(sessionId)
+    return false
+  }
+  // Use the pre-host preparation when the host was cold, else prepare now (warm host —
+  // ordering vs spawn is moot). Only a shared workspace may consume the pre-host cwd.
+  const resolveCwd = async (): Promise<string> =>
+    input.preparedWorkspaceCwd ??
+    (identity.workspaceIsolation === 'shared' ? input.preparedCwd : undefined) ??
+    (await abortable(() => input.prepareWorkspace(agent, input.expectedWarmHost), signal))
+
+  if (!rec || !rec.acpSessionId) {
+    const cwd = await resolveCwd()
+    const ordinaryMcpServers = input.mcpServersFor()
+    const mcpServers = [...ordinaryMcpServers, ...(input.additionalMcpServers ?? [])]
+    const acpSessionId = await newRuntimeSession(
+      cwd,
+      mcpServers,
+      input.metaContext,
+      input.additionalMcpServers?.length ? ordinaryMcpServers : undefined
+    )
+    created = true
+    rec = {
+      key: identity.key,
+      agentId: identity.agentId,
+      platform: identity.platform,
+      channel: identity.channel,
+      thread: identity.thread,
+      transportScope: identity.transportScope,
+      acpSessionId,
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now(),
+      // The source that created the session (first-wins in the store; read back
+      // as `session/list`'s triggeredBy). Hook routing identity remains separate
+      // from the GitHub actor credited on the transcript row.
+      triggeredBy: identity.triggeredBy,
+      ...(identity.threadUrl ? { threadUrl: identity.threadUrl } : {}),
+      memoryProvider: identity.memoryProvider,
+      workspaceIsolation: identity.workspaceIsolation,
+      ...(identity.originSessionId ? { originSessionId: identity.originSessionId } : {}),
+      ...(identity.needsParentReply ? { needsParentReply: 1 } : {})
+    }
+    store.upsertSession(rec)
+    if (identity.initialTitle) store.setSessionTitle(identity.key, identity.initialTitle)
+  } else if (host.hasSession?.(rec.acpSessionId) === false) {
+    const persistedSessionId = rec.acpSessionId
+    // Persisted, but unknown to THIS agent process (daemon restart / host eviction):
+    // prompting it would yield ACP "Session not found". Prefer native resume
+    // (session/load — the agent restores its own history, so the §8.5 gap replay
+    // only re-feeds messages it missed). If the agent can't load it, recreate a
+    // fresh session and replay the whole thread as context (lastDeliveredTs=null).
+    const cwd = await resolveCwd()
+    // Resolved once, shared by both paths: session/load must re-attach the same
+    // MCP servers a fresh session would get (the agent doesn't persist them
+    // across processes), and resolving twice would register two bridge tokens.
+    const ordinaryMcpServers = input.mcpServersFor()
+    const mcpServers = [...ordinaryMcpServers, ...(input.additionalMcpServers ?? [])]
+    const fallbackMcpServers = input.additionalMcpServers?.length ? ordinaryMcpServers : undefined
+    let resumed = false
+    if (host.loadSupported?.()) {
+      // §7.3 closed/evicted → resuming: mark the re-attach so a TTL-closed session
+      // isn't seen as `closed` mid-load, then fall through to `prompting` later.
+      store.setSessionState(identity.key, 'resuming', Date.now())
+      try {
+        resumed = await loadRuntimeSession(
+          persistedSessionId,
+          cwd,
+          mcpServers,
+          input.usesMeta ? input.resumeSystemContext : undefined,
+          fallbackMcpServers
+        )
+      } catch {
+        if (signal?.aborted) throw interrupted(signal)
+        // agent couldn't load it (GC'd / not durably persisted) — recreate below
+      }
+    }
+    if (!resumed) {
+      const acpSessionId = await newRuntimeSession(cwd, mcpServers, input.metaContext, fallbackMcpServers)
+      // A fresh ACP id the CP has never seen (the persisted one couldn't be resumed),
+      // so this counts as a create for `event/session`. A resumed session (loadSession
+      // above) keeps its id — the CP already knows it — so `created` stays false there.
+      created = true
+      rec = { ...rec, acpSessionId, state: 'idle', lastDeliveredTs: null, updatedAt: Date.now() }
+      store.upsertSession(rec)
+    }
+  }
+
+  return {
+    sessionId: rec.acpSessionId!,
+    rec,
+    created,
+    ...(additionalMcpAttached !== undefined ? { additionalMcpAttached } : {})
+  }
+}


### PR DESCRIPTION
## What

Extracts the runtime-session opener out of `SessionManager.handle()` into a new
collaborator, `packages/daemon/src/session/turn/runtime-session.ts`.

Moved verbatim (relocated by content, not rewritten):

- the session-start closure cluster — `sessionStartEffort`, `runtimeWorkspaceDirectories`,
  `withAdditionalMcpFallback`, `newRuntimeSession`, `loadRuntimeSession` — which captured
  ~12 locals of `handle()`;
- the create/resume decision block: the create branch, and the resume/recreate branch with
  its `catch {}` silent-rebuild fallback for `loadSession` failures.

`handle()` now calls `openRuntimeSession({ … })` with explicit inputs (host, agent, the
session row, a session-identity descriptor, the store writes it owns, `preparedCwd` /
`preparedWorkspaceCwd` / `expectedWarmHost` + the workspace preparer, the workspace
directories provider, the MCP server resolver, the chat-authority and effort-override
lookups, the standing-context strings, and the turn's `abortable` / `interrupted` fence —
the same seam-passing convention `turn/memory-recall.ts` already uses).

## Key improvement

`additionalMcpServersAttached` was a mutable in `handle()` written from inside the
`withAdditionalMcpFallback` closure and read again much later. It is now part of the
opener's **return value**: `{ sessionId, rec, created, additionalMcpAttached }`. Nothing
is shared through a captured mutable across that seam anymore.

## No behavior change

Preserved exactly: the `loadSession` `catch {}` silent-rebuild fallback (including the
`signal?.aborted` rethrow), the `store.setSessionState('resuming') → upsertSession →
setSessionTitle` ordering, the `host.hasSession?.()` / `host.loadSupported?.()` checks, the
effort re-validation loop with `discardSession`, and the cwd precedence
(`preparedWorkspaceCwd` → shared-isolation `preparedCwd` → prepare now). The
`initializeOnly` early-return and its interaction with the opener's `created` /
`additionalMcpAttached` results are unchanged. `daemon.ts` is untouched.

`session-manager.ts`: 46 insertions, 176 deletions.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean
- `npx vitest run test/session-manager.test.ts test/daemon-smoke.test.ts` — 133 passed
  (gap replay, session rebuild, session load, and MCP fallback describes all green)
- `prettier --check` / `eslint` on both touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
