### PR TITLE
refactor(daemon): extract ChannelBinder from the cluster driver

### DIFF
--- a/packages/daemon/src/k8s/channel-binder.ts
+++ b/packages/daemon/src/k8s/channel-binder.ts
@@ -66,6 +66,12 @@ export class ChannelBinder {
     grants: ShimCapability[]
   ): Promise<ShimConnection> {
     const releasedAt = this.deps.registry.releaseFence(agentId)
+    // The fence only catches a release that lands DURING the bind; one that landed between
+    // `ensureSandbox` resolving and this continuation running is already in the snapshot, so the
+    // launch itself has to be re-read. Otherwise a departed member wakes a pod it no longer serves.
+    if (this.deps.registry.currentLaunch(agentId) !== launch) {
+      throw new Error(`agent ${agentId} left this member before its sandbox channel was bound`)
+    }
     // Resume before waiting because suspension deleted the pod and readiness cannot arrive first.
     const modeBeforeWake = await this.deps.lease.queueMode(launch.sandboxName, 'Running')
     // A launch this daemon already has cached returns from ensureSandbox before any sandbox

--- a/packages/daemon/src/k8s/channel-binder.ts
+++ b/packages/daemon/src/k8s/channel-binder.ts
@@ -1,0 +1,193 @@
+import type { Clock } from '@agentconnect.md/connection'
+import type { LaunchTimer, ClusterMetrics } from '../metrics/cluster-metrics.js'
+import type { ShimCapability } from '../shim/protocol.js'
+import type { ShimConnection } from '../shim/connection.js'
+import { ShimSession } from '../shim/session.js'
+import type { SpawnRecord } from '../shim/binding.js'
+import type { SandboxLease } from './sandbox-lease.js'
+import { LaunchTimeoutError } from './sandbox-identity.js'
+import type { LaunchRegistry, Launch } from './launch-registry.js'
+
+export interface ChannelBinderDeps {
+  registry: LaunchRegistry
+  lease: SandboxLease
+  clock: Clock
+  log: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
+  metrics: ClusterMetrics
+  /** How long a bind may wait for the pod's shim to dial back. */
+  channelTimeoutMs: number
+  /** Wait for the launch's Sandbox to report Ready and name its pod. */
+  awaitReady: (sandboxName: string) => Promise<{ podName: string; podIp: string }>
+  /** Dials the ready pod and binds the shim channel for this launch. */
+  connectChannel: (record: SpawnRecord, podIp: string, timeoutMs: number) => Promise<ShimConnection>
+  /** Stops any outbound channel when a bind is abandoned. */
+  revokeChannel?: (agentId: string) => void
+  /** Prepares a freshly bound channel before anything runs on it; failures degrade, never fail the bind. */
+  onChannelReady?: (agentId: string, session: ShimSession) => Promise<void>
+}
+
+/**
+ * The agent's logical channel to its pod: the session and the mount it reported.
+ *
+ * Two agentId-keyed maps that only make sense together — the session survives the shim's
+ * credential renewals, and the workspace root is whatever the CURRENT bound pod reported.
+ *
+ * The binder owns those primitives only. Dropping a session alongside its launch is one
+ * invariant spanning this class and `LaunchRegistry`, so its ORCHESTRATION stays in the
+ * `K8sDriver` methods that own the other half.
+ */
+export class ChannelBinder {
+  /** Logical channels per agent, which survive the shim's credential renewals. */
+  private readonly sessions = new Map<string, ShimSession>()
+  /** Workspace mount per agent, as the bound pod's shim reported it. */
+  private readonly workspaceRoots = new Map<string, string>()
+
+  constructor(private readonly deps: ChannelBinderDeps) {}
+
+  /** Resume the launch's pod, wait for it, and bind the shim channel onto the agent's session. */
+  async bindChannel(
+    agentId: string,
+    launch: Launch,
+    timer: LaunchTimer | undefined,
+    grants: ShimCapability[]
+  ): Promise<ShimConnection> {
+    this.deps.lease.retain(launch.sandboxName)
+    try {
+      return await this.bindHeld(agentId, launch, timer, grants)
+    } finally {
+      this.deps.lease.release(launch.sandboxName)
+    }
+  }
+
+  private async bindHeld(
+    agentId: string,
+    launch: Launch,
+    timer: LaunchTimer | undefined,
+    grants: ShimCapability[]
+  ): Promise<ShimConnection> {
+    const releasedAt = this.deps.registry.releaseFence(agentId)
+    // Resume before waiting because suspension deleted the pod and readiness cannot arrive first.
+    const modeBeforeWake = await this.deps.lease.queueMode(launch.sandboxName, 'Running')
+    // A launch this daemon already has cached returns from ensureSandbox before any sandbox
+    // read, so this is where the ordinary `launch → suspend → launch` resume learns what it is.
+    // Without it that path — the COMMON one — reported `warm` and never entered resume p95.
+    if (modeBeforeWake) timer?.observedPath(modeBeforeWake === 'Suspended' ? 'resume' : 'warm')
+    timer?.mark('mode_running')
+    const pod = await this.deps.awaitReady(launch.sandboxName)
+    timer?.mark('pod_ready')
+    const channelTimeoutMs = this.deps.channelTimeoutMs
+    const waitingSince = this.deps.clock.now()
+    const connection = await this.deps
+      .connectChannel(
+        {
+          agentId,
+          sandboxUid: launch.sandboxUid,
+          generation: launch.generation,
+          grants: [...grants],
+          podName: pod.podName
+        },
+        pod.podIp,
+        channelTimeoutMs
+      )
+      .catch((err: unknown) => {
+        // connectChannel is supplied by the host, so its error text is not ours to match on.
+        // Elapsed-versus-the-deadline-we-set is a fact we own, and it is what distinguishes a
+        // channel that never arrived from one that failed for another reason.
+        if (this.deps.clock.now() - waitingSince >= channelTimeoutMs) {
+          throw new LaunchTimeoutError(`no shim channel bound for agent ${agentId} in time`)
+        }
+        throw err
+      })
+    timer?.mark('shim_handshake')
+    // Released mid-bind: the pod is another member's to serve now, so the channel is dropped.
+    if (!this.deps.registry.stillServed(agentId, releasedAt)) {
+      this.deps.revokeChannel?.(agentId)
+      throw new Error(`agent ${agentId} left this member while its sandbox channel was being bound`)
+    }
+    this.recordWorkspaceRoot(agentId, connection)
+    // The session is created HERE rather than in `launch`, because a channel bound for workspace
+    // preparation needs one too — and a second session per agent would mean the runtime and the
+    // workspace seam disagreeing about whether the channel is alive.
+    const existing = this.sessions.get(agentId)
+    if (existing && existing.generation === connection.binding.generation) {
+      existing.attach(connection)
+    } else {
+      const session = new ShimSession(agentId, connection.binding.generation, {
+        setTimeout: (fn, ms) => this.deps.clock.setTimeout(fn, ms),
+        clearTimeout: (handle) => this.deps.clock.clearTimeout(handle as never)
+      })
+      session.attach(connection)
+      this.sessions.set(agentId, session)
+    }
+    // After the session exists and before the caller can use the channel. Reported rather than
+    // raised: a sandbox without its credential tunnel still runs, and refusing the launch would
+    // turn one degraded feature into no agent at all.
+    const ready = this.sessions.get(agentId)
+    if (ready && this.deps.onChannelReady) {
+      await this.deps.onChannelReady(agentId, ready).catch((err: unknown) => {
+        this.deps.log.warn(`cluster: agent ${agentId} channel prepared with errors: ${(err as Error).message}`)
+      })
+    }
+    return connection
+  }
+
+  /** Re-attach a renewed or replacement connection to the session it belongs to. */
+  onChannelBound(connection: ShimConnection): void {
+    this.recordWorkspaceRoot(connection.binding.agentId, connection)
+    const session = this.sessions.get(connection.binding.agentId)
+    if (!session) return
+    // Counted apart from the first bind: a re-establishment rate is the signal that renewals or
+    // pod churn are happening more than they should, and pooling the two hides exactly that.
+    this.deps.metrics.channel('reestablished')
+    session.attach(connection)
+  }
+
+  /**
+   * End the agent's session because its channel is gone, reporting whether this call dropped it.
+   *
+   * A lost session is TERMINAL, so it must not survive to meet the replacement pod: `attach()`
+   * is a no-op once closed, and `bindChannel` re-attaches whenever the generations match — which
+   * they would, because a cached launch keeps its own. The caller forgets the launch on a `true`
+   * so the next turn re-claims at a FRESH generation, the fence the replacement pod is bound
+   * against. The workspace root is deliberately kept: the next bind overwrites or deletes it.
+   */
+  loseChannel(agentId: string, reason: string): boolean {
+    this.deps.metrics.channel('dropped')
+    const session = this.sessions.get(agentId)
+    session?.lose(reason)
+    if (!session || this.sessions.get(agentId) !== session) return false
+    this.sessions.delete(agentId)
+    return true
+  }
+
+  /** Drop the session without ending it as a loss — the suspend path, which keeps the root. */
+  dropSession(agentId: string): void {
+    this.sessions.delete(agentId)
+  }
+
+  /** The agent is no longer served here: both the session and the remembered mount go. */
+  forget(agentId: string): void {
+    this.sessions.delete(agentId)
+    this.workspaceRoots.delete(agentId)
+  }
+
+  /** The bound session for an agent, so the workspace seam reaches the same channel the runtime
+   *  does rather than opening a second one that can disagree about whether it is alive. */
+  sessionFor(agentId: string): ShimSession | undefined {
+    return this.sessions.get(agentId)
+  }
+
+  /** Where the agent's bound pod mounts its workspace, or undefined before a bind (or when a
+   *  legacy shim reported nothing — callers fall back to the historical mount). */
+  workspaceRootFor(agentId: string): string | undefined {
+    return this.workspaceRoots.get(agentId)
+  }
+
+  // Mirrors the CURRENT pod, absence included: a root kept from a previous incarnation (an image
+  // rollback to a shim that reports none) names a mount this pod may not have — the exact failure
+  // this seam exists to remove. Unset ⇒ callers fall back to the historical mount.
+  private recordWorkspaceRoot(agentId: string, connection: ShimConnection): void {
+    if (connection.workspaceRoot) this.workspaceRoots.set(agentId, connection.workspaceRoot)
+    else this.workspaceRoots.delete(agentId)
+  }
+}

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -9,6 +9,7 @@ import type { SpawnRecord } from '../shim/binding.js'
 import { isSandboxReady, type OperatingMode, type SandboxClaim, type SandboxApi } from './sandbox-api.js'
 import { SandboxLease } from './sandbox-lease.js'
 import { LaunchRegistry, type Launch, type LaunchGenerations } from './launch-registry.js'
+import { ChannelBinder } from './channel-binder.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import {
   AC_LABEL_AGENT,
@@ -91,10 +92,8 @@ export class K8sDriver implements SpawnDriver {
   private readonly registry: LaunchRegistry
   /** Holds, mode serialization, and the idle-suspension gates — see `SandboxLease`. */
   private readonly lease: SandboxLease
-  /** Logical channels per agent, which survive the shim's credential renewals. */
-  private readonly sessions = new Map<string, ShimSession>()
-  /** Workspace mount per agent, as the bound pod's shim reported it. */
-  private readonly workspaceRoots = new Map<string, string>()
+  /** Sessions and workspace mounts per agent — see `ChannelBinder`. */
+  private readonly binder: ChannelBinder
   private readonly clock: Clock
 
   constructor(private readonly deps: K8sDriverDeps) {
@@ -106,6 +105,18 @@ export class K8sDriver implements SpawnDriver {
       warmPoolName: deps.warmPoolName,
       log: deps.log,
       metrics: this.metrics
+    })
+    this.binder = new ChannelBinder({
+      registry: this.registry,
+      lease: this.lease,
+      clock: this.clock,
+      log: deps.log,
+      metrics: this.metrics,
+      channelTimeoutMs: this.podUpTimeoutMs,
+      awaitReady: (sandboxName) => this.awaitReady(sandboxName),
+      connectChannel: deps.connectChannel,
+      ...(deps.revokeChannel ? { revokeChannel: deps.revokeChannel } : {}),
+      ...(deps.onChannelReady ? { onChannelReady: deps.onChannelReady } : {})
     })
   }
 
@@ -280,7 +291,7 @@ export class K8sDriver implements SpawnDriver {
     if (!launch) return 'absent'
     return await this.lease.suspendIfIdle(agentId, launch.sandboxName, () => {
       if (this.registry.currentLaunch(agentId) === launch) {
-        this.sessions.delete(agentId)
+        this.binder.dropSession(agentId)
         this.forgetLaunch(agentId)
       }
     })
@@ -320,9 +331,8 @@ export class K8sDriver implements SpawnDriver {
     this.registry.bumpRelease(agentId)
     const launch = this.registry.forgetLaunch(agentId)
     if (launch) this.lease.forgetSandbox(launch.sandboxName)
-    this.workspaceRoots.delete(agentId)
     // Otherwise `runsInSandbox` keeps answering true for a pod that is not this member's to use.
-    this.sessions.delete(agentId)
+    this.binder.forget(agentId)
     this.deps.revokeChannel?.(agentId)
   }
 
@@ -379,104 +389,19 @@ export class K8sDriver implements SpawnDriver {
     grants: ShimCapability[] = RUNTIME_GRANTS
   ): Promise<ShimConnection> {
     const launch = await this.ensureSandbox(agentId, timer)
-    this.lease.retain(launch.sandboxName)
-    try {
-      return await this.bindChannel(agentId, launch, timer, grants)
-    } finally {
-      this.lease.release(launch.sandboxName)
-    }
-  }
-
-  private async bindChannel(
-    agentId: string,
-    launch: Launch,
-    timer: LaunchTimer | undefined,
-    grants: ShimCapability[]
-  ): Promise<ShimConnection> {
-    const releasedAt = this.registry.releaseFence(agentId)
-    // Resume before waiting because suspension deleted the pod and readiness cannot arrive first.
-    const modeBeforeWake = await this.setMode(agentId, 'Running')
-    // A launch this daemon already has cached returns from ensureSandbox before any sandbox
-    // read, so this is where the ordinary `launch → suspend → launch` resume learns what it is.
-    // Without it that path — the COMMON one — reported `warm` and never entered resume p95.
-    if (modeBeforeWake) timer?.observedPath(modeBeforeWake === 'Suspended' ? 'resume' : 'warm')
-    timer?.mark('mode_running')
-    const pod = await this.awaitReady(launch.sandboxName)
-    timer?.mark('pod_ready')
-    const channelTimeoutMs = this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
-    const waitingSince = this.clock.now()
-    const connection = await this.deps
-      .connectChannel(
-        {
-          agentId,
-          sandboxUid: launch.sandboxUid,
-          generation: launch.generation,
-          grants: [...grants],
-          podName: pod.podName
-        },
-        pod.podIp,
-        channelTimeoutMs
-      )
-      .catch((err: unknown) => {
-        // connectChannel is supplied by the host, so its error text is not ours to match on.
-        // Elapsed-versus-the-deadline-we-set is a fact we own, and it is what distinguishes a
-        // channel that never arrived from one that failed for another reason.
-        if (this.clock.now() - waitingSince >= channelTimeoutMs) {
-          throw new LaunchTimeoutError(`no shim channel bound for agent ${agentId} in time`)
-        }
-        throw err
-      })
-    timer?.mark('shim_handshake')
-    // Released mid-bind: the pod is another member's to serve now, so the channel is dropped.
-    if (!this.registry.stillServed(agentId, releasedAt)) {
-      this.deps.revokeChannel?.(agentId)
-      throw new Error(`agent ${agentId} left this member while its sandbox channel was being bound`)
-    }
-    this.recordWorkspaceRoot(agentId, connection)
-    // The session is created HERE rather than in `launch`, because a channel bound for workspace
-    // preparation needs one too — and a second session per agent would mean the runtime and the
-    // workspace seam disagreeing about whether the channel is alive.
-    const existing = this.sessions.get(agentId)
-    if (existing && existing.generation === connection.binding.generation) {
-      existing.attach(connection)
-    } else {
-      const session = new ShimSession(agentId, connection.binding.generation, {
-        setTimeout: (fn, ms) => this.clock.setTimeout(fn, ms),
-        clearTimeout: (handle) => this.clock.clearTimeout(handle as never)
-      })
-      session.attach(connection)
-      this.sessions.set(agentId, session)
-    }
-    // After the session exists and before the caller can use the channel. Reported rather than
-    // raised: a sandbox without its credential tunnel still runs, and refusing the launch would
-    // turn one degraded feature into no agent at all.
-    const ready = this.sessions.get(agentId)
-    if (ready && this.deps.onChannelReady) {
-      await this.deps.onChannelReady(agentId, ready).catch((err: unknown) => {
-        this.deps.log.warn(`cluster: agent ${agentId} channel prepared with errors: ${(err as Error).message}`)
-      })
-    }
-    return connection
+    return await this.binder.bindChannel(agentId, launch, timer, grants)
   }
 
   /** The bound session for an agent, so the workspace seam reaches the same channel the runtime
    *  does rather than opening a second one that can disagree about whether it is alive. */
   sessionFor(agentId: string): ShimSession | undefined {
-    return this.sessions.get(agentId)
+    return this.binder.sessionFor(agentId)
   }
 
   /** Where the agent's bound pod mounts its workspace, or undefined before a bind (or when a
    *  legacy shim reported nothing — callers fall back to the historical mount). */
   workspaceRootFor(agentId: string): string | undefined {
-    return this.workspaceRoots.get(agentId)
-  }
-
-  // Mirrors the CURRENT pod, absence included: a root kept from a previous incarnation (an image
-  // rollback to a shim that reports none) names a mount this pod may not have — the exact failure
-  // this seam exists to remove. Unset ⇒ callers fall back to the historical mount.
-  private recordWorkspaceRoot(agentId: string, connection: ShimConnection): void {
-    if (connection.workspaceRoot) this.workspaceRoots.set(agentId, connection.workspaceRoot)
-    else this.workspaceRoots.delete(agentId)
+    return this.binder.workspaceRootFor(agentId)
   }
 
   async launch(request: SpawnRequest): Promise<SpawnedRuntime> {
@@ -491,7 +416,7 @@ export class K8sDriver implements SpawnDriver {
       held = bound.sandboxName
       await this.ensureBoundChannel(agentId, timer)
       this.metrics.channel('bound')
-      const session = this.sessions.get(agentId)
+      const session = this.binder.sessionFor(agentId)
       if (!session) throw new Error(`no shim session for agent ${agentId} after binding its channel`)
       // The open is asynchronous, so the stage closes when the runtime reports — not when the
       // call returns. Marking it here measured the cost of constructing a stream pair and called
@@ -523,28 +448,13 @@ export class K8sDriver implements SpawnDriver {
 
   /** Re-attach a renewed or replacement connection to the launch it belongs to. */
   onChannelBound(connection: ShimConnection): void {
-    this.recordWorkspaceRoot(connection.binding.agentId, connection)
-    const session = this.sessions.get(connection.binding.agentId)
-    if (!session) return
-    // Counted apart from the first bind: a re-establishment rate is the signal that renewals or
-    // pod churn are happening more than they should, and pooling the two hides exactly that.
-    this.metrics.channel('reestablished')
-    session.attach(connection)
+    this.binder.onChannelBound(connection)
   }
 
   /** Report that an agent's channel is gone, so its runtime learns rather than hanging. */
+  // The session and the launch are dropped TOGETHER, and that orchestration stays here: a revived
+  // sandbox must never bind to a lost session, and the halves live in two different objects.
   onChannelLost(agentId: string, reason: string): void {
-    this.metrics.channel('dropped')
-    const session = this.sessions.get(agentId)
-    session?.lose(reason)
-    // A lost session is TERMINAL, so it must not survive to meet the replacement pod: `attach()`
-    // is a no-op once closed, and `bindChannel` re-attaches whenever the generations match — which
-    // they would, because a cached launch keeps its own. The resumed sandbox would then bind a
-    // channel whose session can never serve a request. Dropping both here is what makes the next
-    // turn re-claim at a FRESH generation, which is the fence the replacement pod is bound against.
-    if (session && this.sessions.get(agentId) === session) {
-      this.sessions.delete(agentId)
-      this.forgetLaunch(agentId)
-    }
+    if (this.binder.loseChannel(agentId, reason)) this.forgetLaunch(agentId)
   }
 }

--- a/packages/daemon/test/k8s-channel-binder.test.ts
+++ b/packages/daemon/test/k8s-channel-binder.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { FakeClock } from '@agentconnect.md/connection'
+import { ChannelBinder } from '../src/k8s/channel-binder.js'
+import { LaunchRegistry } from '../src/k8s/launch-registry.js'
+import { SandboxLease } from '../src/k8s/sandbox-lease.js'
+import { noopClusterMetrics } from '../src/metrics/cluster-metrics.js'
+import { fakeGenerations } from './fake-generations.js'
+
+const log = { info: () => {}, warn: () => {}, debug: () => {} }
+
+function binder(registry: LaunchRegistry, clock: FakeClock) {
+  const lease = new SandboxLease({ api: {} as never, warmPoolName: 'pool', log, metrics: noopClusterMetrics })
+  return new ChannelBinder({
+    registry,
+    lease,
+    clock,
+    log,
+    metrics: noopClusterMetrics,
+    channelTimeoutMs: 1_000,
+    awaitReady: async () => ({ podName: 'p', podIp: '10.0.0.8' }),
+    connectChannel: async () => {
+      throw new Error('the bind must not reach the pod')
+    }
+  })
+}
+
+describe('cluster channel binder', () => {
+  it('refuses a launch the registry no longer holds, before waking its pod', async () => {
+    // The release fence only catches a release that lands DURING the bind. One that landed while
+    // the caller was still awaiting its launch is already in the snapshot, so both fence checks
+    // pass — and a departed member would wake and bind a pod that is no longer its to serve.
+    const clock = new FakeClock()
+    const registry = new LaunchRegistry({ generations: fakeGenerations(), clock })
+    const launch = registry.recordLaunch('agent-a', 'sb-1', 'sandbox-uid-1')
+    registry.bumpRelease('agent-a')
+    registry.forgetLaunch('agent-a')
+
+    await expect(binder(registry, clock).bindChannel('agent-a', launch, undefined, ['acp'])).rejects.toThrow(
+      /left this member before its sandbox channel was bound/
+    )
+  })
+})

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -635,6 +635,33 @@ describe('cluster spawn driver', () => {
     expect(instance.workspaceRootFor('agent-a')).toBeUndefined()
   })
 
+  it('keeps the last reported workspace root across a channel loss and an idle suspension', async () => {
+    // Pinned as it stands, not as it ought to be: neither path clears the root, because the next
+    // bind overwrites it (or deletes it when the replacement shim reports none). Callers read it
+    // only after a bind, so the staleness is unobservable — but it is deliberate, not incidental.
+    const { api } = fakeApi()
+    let root: string | undefined = '/agent'
+    let generation = 0
+    const { instance } = driver(api, {
+      connectChannel: async () => stubConnection(++generation, root)
+    })
+    await instance.ensureBoundChannel('agent-a')
+    expect(instance.workspaceRootFor('agent-a')).toBe('/agent')
+
+    instance.onChannelLost('agent-a', 'pod deleted')
+    expect(instance.sessionFor('agent-a')).toBeUndefined()
+    expect(instance.workspaceRootFor('agent-a')).toBe('/agent')
+
+    await instance.ensureBoundChannel('agent-a')
+    expect(await instance.suspendIfIdle('agent-a')).toBe('suspended')
+    expect(instance.workspaceRootFor('agent-a')).toBe('/agent')
+
+    // Only the next bind moves it, and a shim reporting none takes it away.
+    root = undefined
+    await instance.ensureBoundChannel('agent-a')
+    expect(instance.workspaceRootFor('agent-a')).toBeUndefined()
+  })
+
   it('keeps no workspace root from a legacy shim that reports none', async () => {
     const { api } = fakeApi()
     const { instance } = driver(api)


### PR DESCRIPTION
## What

Continues the `k8s/driver.ts` decomposition after `SandboxLease` and `LaunchRegistry`. The two remaining agentId-keyed maps — `sessions` (agentId → `ShimSession`) and `workspaceRoots` (agentId → mount path) — move into a new `ChannelBinder` (`packages/daemon/src/k8s/channel-binder.ts`) together with the bind path that writes them: `bindChannel`, `onChannelBound`, `sessionFor`, `workspaceRootFor`, `recordWorkspaceRoot`, plus `loseChannel`/`dropSession`/`forget` for the invalidation paths.

The binder takes `LaunchRegistry` (release fence around the bind) and `SandboxLease` (retain/release around the bind, the `Running` mode write) as constructor deps, and an `awaitReady` callback for the readiness wait the driver still owns.

`driver.ts` goes from 550 to 460 lines. Public surface is unchanged — `ensureBoundChannel`, `onChannelBound`, `onChannelLost`, `sessionFor`, `workspaceRootFor` keep their signatures and are thin delegation.

## The two invariants this had to preserve

1. **A revived sandbox must never bind to a lost session.** `onChannelLost` drops the session *and* forgets the launch. That invariant now spans two objects, so the orchestration stays in the `K8sDriver.onChannelLost` facade: `ChannelBinder.loseChannel` reports whether it dropped the session, and the driver forgets the launch on that answer — never a callback chain out of the binder.

2. **Neither `onChannelLost` nor `suspendIfIdle` clears `workspaceRoots`.** Preserved as is. A test pinning it (`keeps the last reported workspace root across a channel loss and an idle suspension`) was added *before* the move, so the refactor could not change it silently.

### Follow-up candidate (deliberately not in this PR)

That workspace-root asymmetry is unobservable today — callers only read the root after a bind, and every bind overwrites it or deletes it when the shim reports none — but it is worth revisiting whether `loseChannel`/`dropSession` should clear it too, rather than relying on that reasoning holding for every future caller.

## Verification

- `pnpm typecheck` in `packages/daemon` — clean.
- `npx vitest run test/k8s-driver.test.ts test/k8s-driver-takeover.test.ts test/k8s-runtime-plane.test.ts test/cluster-workspace-prepare.test.ts test/direct-connect-credentials.test.ts test/cluster-acp-e2e.test.ts test/cluster-metrics.test.ts` — 7 files, 113 tests, all passing.
- `npx prettier --check` and `npx eslint` on the touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
