### PR TITLE
feat(web): put the daemon pool behind an experiment switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,4 +179,7 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # ids (packages/web/src/lib/experiments.ts). Unset means none: the surface ships in
 # every build and appears only where an environment asks for it. The Control Plane
 # serves the feature either way; this decides whether the console offers it.
-#   EXPERIMENTS="daemon-groups"
+# Known ids: daemon-groups (the org's own member sets), daemon-pool (the install-wide
+# pool: its fleet entry and the Cloud placement option — DAEMON_POOL_ENABLED above is
+# what actually runs one).
+#   EXPERIMENTS="daemon-groups,daemon-pool"

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -338,7 +338,10 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   }, [])
 
   // Cloud is one UI choice AND one server-side placement: the pool, named as itself.
-  const daemonChoice = addAgentDaemonChoice(daemons, daemonId, memberSets)
+  // Experimental: with the pool hidden the choice is computed WITHOUT its members, so an
+  // untouched form defaults to the first machine rather than submitting a pool placement.
+  const placementDaemons = experimentEnabled('daemon-pool') ? daemons : daemons.filter((d) => !d.pool)
+  const daemonChoice = addAgentDaemonChoice(placementDaemons, daemonId, memberSets)
   const {
     poolAvailable,
     availableGroups,

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -271,7 +271,9 @@ export default function EditAgentModal({
   useEffect(() => {
     if (!loaded || autofilledDaemon.current || initialDaemonId.current || daemonId) return
     const ready = (d: (typeof daemons)[number]) => d.status === 'online' && d.caps.features.includes('agent-move-v1')
-    const target = daemons.find((d) => d.pool && ready(d)) ?? daemons.find(ready)
+    // With the pool hidden it is not a default either — an unplaced agent lands on a machine.
+    const offered = experimentEnabled('daemon-pool') ? daemons : daemons.filter((d) => !d.pool)
+    const target = offered.find((d) => d.pool && ready(d)) ?? offered.find(ready)
     if (target) {
       autofilledDaemon.current = true
       setDaemonId(target.daemonId)
@@ -361,7 +363,9 @@ export default function EditAgentModal({
   const daemonChoices = editAgentDaemonChoices(daemons, daemonId, initialDaemonId.current)
   const poolServing = daemons.some((candidate) => candidate.pool && moveReady(candidate))
   const daemonOptions: DaemonSelectOption[] = [
-    ...(daemonChoices.poolChoice || isPoolPlacementKind(agent.placementKind)
+    // With the experiment off the picker offers Cloud only to an agent already ON it — same rule
+    // the groups below follow, and for the same reason: "No daemon" for a placed agent is untrue.
+    ...((experimentEnabled('daemon-pool') && daemonChoices.poolChoice) || isPoolPlacementKind(agent.placementKind)
       ? [
           {
             // The POOL, named as itself. The server picks the member — and re-picks it after every

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -28,7 +28,6 @@ import {
   groupPlacementValue,
   groupSetIdOf,
   type MemberSetRow,
-  isPoolPlacementKind,
   placementValueOf,
   type Agent,
   type AgentCallPolicy,
@@ -360,12 +359,17 @@ export default function EditAgentModal({
     ? selectedSandboxRequired || (daemon?.caps.features.includes('sandbox') ?? false)
     : sandboxSupported
   const effectiveRunInSandbox = selectedSandboxRequired || (selectedSandboxSupported && runInSandbox)
-  const daemonChoices = editAgentDaemonChoices(daemons, daemonId, initialDaemonId.current)
+  const daemonChoices = editAgentDaemonChoices(
+    daemons,
+    daemonId,
+    initialDaemonId.current,
+    experimentEnabled('daemon-pool')
+  )
   const poolServing = daemons.some((candidate) => candidate.pool && moveReady(candidate))
   const daemonOptions: DaemonSelectOption[] = [
     // With the experiment off the picker offers Cloud only to an agent already ON it — same rule
     // the groups below follow, and for the same reason: "No daemon" for a placed agent is untrue.
-    ...((experimentEnabled('daemon-pool') && daemonChoices.poolChoice) || isPoolPlacementKind(agent.placementKind)
+    ...(daemonChoices.offerPool
       ? [
           {
             // The POOL, named as itself. The server picks the member — and re-picks it after every

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
@@ -28,7 +28,8 @@ describe('editAgentDaemonChoices', () => {
     const choices = editAgentDaemonChoices(
       [row('local-1'), row('pool-1', true), row('pool-2', true), row('pool-3', true), row('local-2')],
       'local-1',
-      'local-1'
+      'local-1',
+      true
     )
 
     expect(choices.poolChoice?.daemonId).toBe('pool-1')
@@ -40,7 +41,8 @@ describe('editAgentDaemonChoices', () => {
     const choices = editAgentDaemonChoices(
       [row('pool-offline', true, 'offline'), row('pool-serving', true), row('local-1')],
       'pool-serving',
-      'local-1'
+      'local-1',
+      true
     )
 
     expect(choices.poolChoice?.daemonId).toBe('pool-serving')
@@ -51,7 +53,8 @@ describe('editAgentDaemonChoices', () => {
     const choices = editAgentDaemonChoices(
       [row('pool-source', true, 'offline'), row('pool-serving', true), row('local-1')],
       'local-1',
-      'pool-source'
+      'pool-source',
+      true
     )
 
     expect(choices.poolChoice?.daemonId).toBe('pool-serving')
@@ -62,7 +65,8 @@ describe('editAgentDaemonChoices', () => {
     const choices = editAgentDaemonChoices(
       [row('pool-source', true, 'offline'), row('pool-serving', true), row('local-1')],
       'pool-source',
-      'pool-source'
+      'pool-source',
+      true
     )
 
     expect(choices.poolChoice?.daemonId).toBe('pool-serving')
@@ -73,17 +77,40 @@ describe('editAgentDaemonChoices', () => {
     const choices = editAgentDaemonChoices(
       [row('local-offline', false, 'offline'), row('local-old', false, 'online', false), row('local-ready')],
       'local-offline',
-      'local-offline'
+      'local-offline',
+      true
     )
 
     expect(choices.poolChoice).toBeUndefined()
     expect(choices.localChoices.map((choice) => choice.daemonId)).toEqual(['local-ready', 'local-offline', 'local-old'])
   })
 
+  it('lists Cloud only where the deployment offers the pool', () => {
+    const daemons = [row('pool-1', true), row('local-1')]
+
+    expect(editAgentDaemonChoices(daemons, 'local-1', 'local-1', true).offerPool).toBe(true)
+    expect(editAgentDaemonChoices(daemons, 'local-1', 'local-1', false).offerPool).toBe(false)
+  })
+
+  it('keeps Cloud listed for an agent already on it, so a rollback still tells the truth', () => {
+    // Both halves matter: the pool answers as itself even with every member gone, which is exactly
+    // when a placed agent would otherwise read as "No daemon".
+    expect(editAgentDaemonChoices([row('pool-1', true)], 'pool', 'pool', false).offerPool).toBe(true)
+    expect(editAgentDaemonChoices([row('local-1')], 'pool', 'pool', false).offerPool).toBe(true)
+  })
+
+  it('does not reopen the hidden pool for a group-placed agent', () => {
+    // A group placement is a `set` too. Classified by kind rather than by the resolved placement,
+    // every group-placed agent would be handed the Cloud target the deployment just hid.
+    const choices = editAgentDaemonChoices([row('pool-1', true), row('local-1')], 'set:g1', 'set:g1', false)
+
+    expect(choices.offerPool).toBe(false)
+  })
+
   it('offers a daemon that is in a group — membership does not disqualify it as a target', () => {
     // A `daemon` placement is eligible for exactly that machine either way, so it stays the only
     // holder whether or not it has joined one (daemon-groups.md §3).
-    const choices = editAgentDaemonChoices([row('grouped', false, 'online', true, 'set-1'), row('free')], '', '')
+    const choices = editAgentDaemonChoices([row('grouped', false, 'online', true, 'set-1'), row('free')], '', '', true)
 
     expect(choices.localChoices.map((d) => d.daemonId).sort()).toEqual(['free', 'grouped'])
   })

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
@@ -1,4 +1,4 @@
-import type { DaemonRow } from '@/lib/data'
+import { POOL_PLACEMENT, type DaemonRow } from '@/lib/data'
 
 type DaemonChoiceRow = Pick<DaemonRow, 'pool' | 'daemonId' | 'status' | 'memberSetId'> & {
   caps: Pick<DaemonRow['caps'], 'features'>
@@ -11,12 +11,17 @@ export interface EditAgentDaemonChoices<T extends DaemonChoiceRow> {
   poolChoice: T | undefined
   currentPoolChoice: T | undefined
   localChoices: T[]
+  /** Does the picker list Cloud at all? Only where the deployment offers the pool — plus, always,
+   *  an agent already ON it, whose current placement stays truthful through a rollback. */
+  offerPool: boolean
 }
 
 export function editAgentDaemonChoices<T extends DaemonChoiceRow>(
   daemons: T[],
   selectedDaemonId: string,
-  initialDaemonId: string
+  initialDaemonId: string,
+  /** Is the `daemon-pool` experiment on for this deployment? */
+  poolOffered: boolean
 ): EditAgentDaemonChoices<T> {
   const selected = daemons.find((daemon) => daemon.daemonId === selectedDaemonId)
   const initial = daemons.find((daemon) => daemon.daemonId === initialDaemonId)
@@ -37,10 +42,14 @@ export function editAgentDaemonChoices<T extends DaemonChoiceRow>(
   // and above — a pool Pod is a replaceable identity to pin to.
   const localChoices = daemons.filter((daemon) => !daemon.pool)
   localChoices.sort((a, b) => Number(moveReady(b)) - Number(moveReady(a)))
+  // The RESOLVED placement, never `placementKind`: a group placement is a `set` too, so classifying
+  // by kind alone hands every group-placed agent the Cloud target the deployment just hid.
+  const alreadyOnPool = initialDaemonId === POOL_PLACEMENT
   return {
     poolChoice,
     currentPoolChoice:
       initial?.pool && poolChoice?.daemonId !== initial.daemonId && recoveryTarget ? initial : undefined,
-    localChoices
+    localChoices,
+    offerPool: (poolOffered && poolChoice !== undefined) || alreadyOnPool
   }
 }

--- a/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
@@ -14,6 +14,7 @@ import type { Agent, DaemonRow } from '@/lib/data'
 const mocks = vi.hoisted(() => ({
   daemons: [] as unknown[],
   agents: [] as unknown[],
+  memberSets: [] as unknown[],
   push: vi.fn()
 }))
 
@@ -26,7 +27,7 @@ vi.mock('@/lib/data-context', () => ({
     daemons: mocks.daemons,
     daemonsLoading: false,
     agents: mocks.agents,
-    memberSets: [],
+    memberSets: mocks.memberSets,
     refreshDaemons: vi.fn(async () => {}),
     renameDaemon: vi.fn()
   })
@@ -99,6 +100,7 @@ const setExperiments = (value: string) => {
 beforeEach(() => {
   mocks.daemons = []
   mocks.agents = []
+  mocks.memberSets = []
   mocks.push.mockClear()
   setExperiments('daemon-pool')
 })
@@ -187,6 +189,20 @@ describe('DaemonsView pool', () => {
     expect(html).not.toContain('AgentConnect Cloud')
     expect(html).not.toContain('agents on Cloud')
     expect(html).toContain('pc.dev')
+  })
+
+  it('keeps the groups an org already made when hiding the pool empties the fleet', () => {
+    // The two experiments are independent switches. Hiding Cloud must not take the group surface
+    // with it just because the pool rows were the only thing keeping the fleet non-empty.
+    setExperiments('daemon-groups')
+    mocks.daemons = [member('p1')]
+    mocks.memberSets = [{ setId: 'g1', name: 'edge-eu', memberDaemonIds: [], agentCount: 0 }]
+
+    const html = render()
+
+    expect(html).toContain('No daemons connected')
+    expect(html).toContain('Daemon groups')
+    expect(html).toContain('edge-eu')
   })
 
   it('reads as an empty fleet when the pool is all there is and it is hidden', () => {

--- a/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
@@ -91,10 +91,16 @@ function render(): string {
   return html
 }
 
+/** The console shows the pool only where the deployment asked for it (lib/experiments.ts). */
+const setExperiments = (value: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { EXPERIMENTS: value }
+}
+
 beforeEach(() => {
   mocks.daemons = []
   mocks.agents = []
   mocks.push.mockClear()
+  setExperiments('daemon-pool')
 })
 
 describe('DaemonsView pool', () => {
@@ -166,6 +172,29 @@ describe('DaemonsView pool', () => {
   })
 
   it('still shows the empty state when there is no daemon of any kind', () => {
+    const html = render()
+
+    expect(html).toContain('No daemons connected')
+  })
+
+  it('names nothing about the pool where the deployment did not ask for it', () => {
+    setExperiments('')
+    mocks.daemons = [member('p1'), daemon({ daemonId: 'own', name: 'pc.dev' })]
+    mocks.agents = [onPool('a1', 'p1')]
+
+    const html = render()
+
+    expect(html).not.toContain('AgentConnect Cloud')
+    expect(html).not.toContain('agents on Cloud')
+    expect(html).toContain('pc.dev')
+  })
+
+  it('reads as an empty fleet when the pool is all there is and it is hidden', () => {
+    // Not "0 daemons of an unnamed kind": with the pool hidden the org connected nothing,
+    // so the page has to say so — a blank fleet with no empty state is a page that broke.
+    setExperiments('')
+    mocks.daemons = [member('p1'), member('p2')]
+
     const html = render()
 
     expect(html).toContain('No daemons connected')

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -35,7 +35,10 @@ export default function DaemonsView() {
   // The pool is ONE entry, not one card per Pod: its members are install-wide
   // infrastructure every org sees, replaced without notice, and nothing here is the
   // org's to rename or detach. Everything else is a machine someone connected.
-  const poolMembers = useMemo(() => daemons.filter((d) => d.pool), [daemons])
+  // Experimental: where the deployment did not ask for the pool, the page shows the
+  // machines only — the CP still serves it, this is whether the console names it.
+  const showPool = experimentEnabled('daemon-pool')
+  const poolMembers = useMemo(() => (showPool ? daemons.filter((d) => d.pool) : []), [daemons, showPool])
   const ownDaemons = useMemo(() => daemons.filter((d) => !d.pool), [daemons])
   const poolAgents = useMemo(() => {
     const memberIds = new Set(poolMembers.map((m) => m.daemonId))
@@ -68,7 +71,7 @@ export default function DaemonsView() {
       </div>
       {daemonsLoading && daemons.length === 0 ? (
         <LoadingState fill />
-      ) : daemons.length === 0 ? (
+      ) : poolMembers.length === 0 && ownDaemons.length === 0 ? (
         <div className="card flex flex-col items-center gap-3 px-6 py-[44px] text-center">
           <span className="flex h-[46px] w-[46px] items-center justify-center rounded-[11px] border border-(--border-subtle) bg-(--surface-sunken)">
             <Icon name="server" size={22} color="var(--text-tertiary)" />

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -71,53 +71,59 @@ export default function DaemonsView() {
       </div>
       {daemonsLoading && daemons.length === 0 ? (
         <LoadingState fill />
-      ) : poolMembers.length === 0 && ownDaemons.length === 0 ? (
-        <div className="card flex flex-col items-center gap-3 px-6 py-[44px] text-center">
-          <span className="flex h-[46px] w-[46px] items-center justify-center rounded-[11px] border border-(--border-subtle) bg-(--surface-sunken)">
-            <Icon name="server" size={22} color="var(--text-tertiary)" />
-          </span>
-          <div className="font-sans text-[15px] font-semibold leading-normal">No daemons connected</div>
-          <div className="max-w-[380px] font-sans text-[13px] font-normal leading-[1.55] text-(--text-secondary)">
-            Run the daemon on a machine where agents should execute. It connects to the control plane and shows up here.
-          </div>
-          <Button variant="secondary" size="sm" onClick={() => openModal('daemon')}>
-            <Icon name="plus" size={15} />
-            Add daemon
-          </Button>
-        </div>
       ) : (
         <>
-          {/* Mobile-only fleet summary strip. */}
-          <div className="mb-3 flex items-center gap-2 desktop:hidden">
-            <span className="inline-flex items-center gap-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-secondary)">
-              <span className="h-2 w-2 rounded-full bg-(--status-online)" />
-              {online} online
-            </span>
-            <span className="inline-flex items-center gap-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-secondary)">
-              <span className="h-2 w-2 rounded-full bg-(--status-paused)" />
-              {paused} paused
-            </span>
-          </div>
-          {poolMembers.length > 0 && <PoolFleetCard members={poolMembers} hosted={poolAgents} />}
-          {ownDaemons.length > 0 && (
-            <>
-              {/* The section label earns its place only next to the Cloud entry — without
-                  one there is nothing to tell these cards apart from. */}
-              {poolMembers.length > 0 && (
-                <div className="mt-6 mb-[9px] flex min-h-[26px] items-center gap-[9px]">
-                  <span className="font-sans text-[13px] font-semibold leading-normal">Daemons</span>
-                  <span className="mono text-[11.5px] text-(--text-tertiary)">{ownDaemons.length}</span>
-                </div>
-              )}
-              <div className="grid grid-cols-1 gap-3 desktop:grid-cols-3 desktop:gap-[14px]">
-                {ownDaemons.map((m) => (
-                  <DaemonCard key={m.daemonId} m={m} hosted={hostedByDaemon.get(m.daemonId) ?? 0} />
-                ))}
+          {poolMembers.length === 0 && ownDaemons.length === 0 ? (
+            <div className="card flex flex-col items-center gap-3 px-6 py-[44px] text-center">
+              <span className="flex h-[46px] w-[46px] items-center justify-center rounded-[11px] border border-(--border-subtle) bg-(--surface-sunken)">
+                <Icon name="server" size={22} color="var(--text-tertiary)" />
+              </span>
+              <div className="font-sans text-[15px] font-semibold leading-normal">No daemons connected</div>
+              <div className="max-w-[380px] font-sans text-[13px] font-normal leading-[1.55] text-(--text-secondary)">
+                Run the daemon on a machine where agents should execute. It connects to the control plane and shows up
+                here.
               </div>
+              <Button variant="secondary" size="sm" onClick={() => openModal('daemon')}>
+                <Icon name="plus" size={15} />
+                Add daemon
+              </Button>
+            </div>
+          ) : (
+            <>
+              {/* Mobile-only fleet summary strip. */}
+              <div className="mb-3 flex items-center gap-2 desktop:hidden">
+                <span className="inline-flex items-center gap-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-secondary)">
+                  <span className="h-2 w-2 rounded-full bg-(--status-online)" />
+                  {online} online
+                </span>
+                <span className="inline-flex items-center gap-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-secondary)">
+                  <span className="h-2 w-2 rounded-full bg-(--status-paused)" />
+                  {paused} paused
+                </span>
+              </div>
+              {poolMembers.length > 0 && <PoolFleetCard members={poolMembers} hosted={poolAgents} />}
+              {ownDaemons.length > 0 && (
+                <>
+                  {/* The section label earns its place only next to the Cloud entry — without
+                      one there is nothing to tell these cards apart from. */}
+                  {poolMembers.length > 0 && (
+                    <div className="mt-6 mb-[9px] flex min-h-[26px] items-center gap-[9px]">
+                      <span className="font-sans text-[13px] font-semibold leading-normal">Daemons</span>
+                      <span className="mono text-[11.5px] text-(--text-tertiary)">{ownDaemons.length}</span>
+                    </div>
+                  )}
+                  <div className="grid grid-cols-1 gap-3 desktop:grid-cols-3 desktop:gap-[14px]">
+                    {ownDaemons.map((m) => (
+                      <DaemonCard key={m.daemonId} m={m} hosted={hostedByDaemon.get(m.daemonId) ?? 0} />
+                    ))}
+                  </div>
+                </>
+              )}
             </>
           )}
           {/* Last, as the design orders it: the machines are the inventory, a group is what you
-              point an agent at once they exist. */}
+              point an agent at once they exist. Outside the empty-fleet branch on purpose: an org
+              whose only machines were pool members still manages the groups it already made. */}
           <GroupsSection groups={memberSets} daemons={daemons} />
         </>
       )}

--- a/packages/web/src/lib/experiments.test.ts
+++ b/packages/web/src/lib/experiments.test.ts
@@ -16,8 +16,20 @@ describe('experimentEnabled', () => {
     // get it the moment it merged.
     setEnv()
     expect(experimentEnabled('daemon-groups')).toBe(false)
+    expect(experimentEnabled('daemon-pool')).toBe(false)
     setEnv('')
     expect(experimentEnabled('daemon-groups')).toBe(false)
+    expect(experimentEnabled('daemon-pool')).toBe(false)
+  })
+
+  it('switches each experiment on its own', () => {
+    // One id in the list turns on THAT surface — groups and the pool ship and roll out apart.
+    setEnv('daemon-pool')
+    expect(experimentEnabled('daemon-pool')).toBe(true)
+    expect(experimentEnabled('daemon-groups')).toBe(false)
+    setEnv('daemon-groups,daemon-pool')
+    expect(experimentEnabled('daemon-pool')).toBe(true)
+    expect(experimentEnabled('daemon-groups')).toBe(true)
   })
 
   it('reads a comma-separated list, tolerating spacing and case', () => {

--- a/packages/web/src/lib/experiments.ts
+++ b/packages/web/src/lib/experiments.ts
@@ -16,9 +16,11 @@
 /** Every experiment the console knows. Adding one is this union plus its checks. */
 export type ExperimentId =
   /** Org-scoped daemon groups: the Infra section, the group dialogs, and group entries in the
-   *  placement picker (docs/designs/daemon-groups.md §6 PR 2). The install-wide pool is not an
-   *  experiment and is unaffected. */
-  'daemon-groups'
+   *  placement picker (docs/designs/daemon-groups.md §6 PR 2). */
+  | 'daemon-groups'
+  /** The install-wide daemon pool: its fleet entry and the Cloud placement option. An agent
+   *  ALREADY on the pool still names it — hiding a live placement is not hiding an entry point. */
+  | 'daemon-pool'
 
 function enabledIds(): ReadonlySet<string> {
   // The server must read the SAME value `PublicEnvScript` injects, in the same precedence, or a


### PR DESCRIPTION
## What

Adds a second console experiment id, `daemon-pool`, so a deployment decides whether the console shows the install-wide daemon pool — the same shape `daemon-groups` already uses. Enable it with `EXPERIMENTS="daemon-groups,daemon-pool"`; unset means off, so it arrives hidden everywhere and is turned on per environment.

Console-side on purpose. The Control Plane places on the pool either way, and `DAEMON_POOL_ENABLED` is still what decides whether a pool exists at all — this only decides whether the console names it.

## Off, the switch hides the three places the console names the pool

- the single "AgentConnect Cloud" fleet entry on the daemons page;
- the Cloud option in the create-agent placement picker — computed **without** pool members, so an untouched form falls back to the first machine instead of quietly submitting a pool placement;
- the same option in the agent editor, plus the unplaced-agent autofill that used to prefer a pool member.

## Two behaviors worth calling out

- **An agent already on the pool keeps naming it** in the editor — the same exception groups make, for the same reason: "No daemon" for a placed agent is untrue, and a rollback is exactly when a truthful current placement matters most.
- **The empty state still works.** With the pool hidden and nothing else connected, the page reads as the empty fleet it is rather than rendering blank.

## Tests

`experiments.test.ts` covers the two ids switching independently; `DaemonsView.pool.test.tsx` renders the page with the switch off and asserts the pool is unnamed and the empty state survives. Full web suite passes (1583 tests), typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
