### PR TITLE
fix(web): prevent add menus from being clipped

### DIFF
--- a/packages/web/src/components/console/McpServersCard.tsx
+++ b/packages/web/src/components/console/McpServersCard.tsx
@@ -29,12 +29,12 @@ import { credentialFieldsFor, initialAuthType, type CredentialField } from '@/li
 import { VisibilityField, VisibilityValue, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
 import { ProviderMark, ToolTile, ToolTileGrid, useConnectorIcons } from '@/components/console/ToolTile'
 import { ConnectorsModal } from '@/components/console/ConnectorsModal'
+import { AnchoredFlyout } from '@/components/ui/AnchoredFlyout'
 import { LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 
 export function McpServersCard({ canWrite }: { canWrite: boolean }) {
   const { mcpProviders, mcpProvidersLoading, connectorsEnabled } = useConsoleData()
-  const [menuOpen, setMenuOpen] = useState(false)
   const [creating, setCreating] = useState(false)
   const [editing, setEditing] = useState<McpProviderDto | null>(null)
   const [deleting, setDeleting] = useState<McpProviderDto | null>(null)
@@ -62,60 +62,71 @@ export function McpServersCard({ canWrite }: { canWrite: boolean }) {
       <div className="cardhead justify-between">
         <span className="cardtitle">Connectors & MCP servers</span>
         {canWrite && (
-          <span className="relative">
-            <Button variant="secondary" size="xs" onClick={() => setMenuOpen((v) => !v)}>
-              <Icon name="plus" size={14} />
-              Add
-              <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
-            </Button>
-            {menuOpen && (
+          <AnchoredFlyout
+            ariaLabel="Add connector or MCP server"
+            estimatedHeight={canAddConnectors ? 154 : 78}
+            trigger={({ open, menuId, toggle }) => (
+              <Button
+                variant="secondary"
+                size="xs"
+                onClick={toggle}
+                ariaExpanded={open}
+                ariaHasPopup="menu"
+                ariaControls={open ? menuId : undefined}
+              >
+                <Icon name="plus" size={14} />
+                Add
+                <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
+              </Button>
+            )}
+          >
+            {({ close }) => (
               <>
-                <span className="fixed inset-0 z-30" onClick={() => setMenuOpen(false)} />
-                <div className="absolute right-0 top-[calc(100%+5px)] z-40 min-w-[280px] rounded-lg border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
-                  {canAddConnectors && (
-                    <button
-                      onClick={() => {
-                        setMenuOpen(false)
-                        setAddingConnectors(true)
-                      }}
-                      className="flex w-full cursor-pointer items-start gap-[9px] rounded-[6px] border-0 bg-transparent p-[10px] text-left hover:bg-(--surface-hover)"
-                    >
-                      <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
-                        <Icon name="blocks" size={16} color="var(--brand)" />
-                      </span>
-                      <span className="flex min-w-0 flex-col">
-                        <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                          Add connectors
-                        </span>
-                        <span className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
-                          Browse and connect open-connector providers
-                        </span>
-                      </span>
-                    </button>
-                  )}
+                {canAddConnectors && (
                   <button
+                    role="menuitem"
                     onClick={() => {
-                      setMenuOpen(false)
-                      setCreating(true)
+                      close()
+                      setAddingConnectors(true)
                     }}
                     className="flex w-full cursor-pointer items-start gap-[9px] rounded-[6px] border-0 bg-transparent p-[10px] text-left hover:bg-(--surface-hover)"
                   >
                     <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
-                      <Icon name="plug" size={16} color="var(--brand)" />
+                      <Icon name="blocks" size={16} color="var(--brand)" />
                     </span>
                     <span className="flex min-w-0 flex-col">
                       <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                        Custom MCP provider
+                        Add connectors
                       </span>
                       <span className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
-                        Connect an upstream MCP server by URL
+                        Browse and connect open-connector providers
                       </span>
                     </span>
                   </button>
-                </div>
+                )}
+                <button
+                  role="menuitem"
+                  onClick={() => {
+                    close()
+                    setCreating(true)
+                  }}
+                  className="flex w-full cursor-pointer items-start gap-[9px] rounded-[6px] border-0 bg-transparent p-[10px] text-left hover:bg-(--surface-hover)"
+                >
+                  <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
+                    <Icon name="plug" size={16} color="var(--brand)" />
+                  </span>
+                  <span className="flex min-w-0 flex-col">
+                    <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                      Custom MCP provider
+                    </span>
+                    <span className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
+                      Connect an upstream MCP server by URL
+                    </span>
+                  </span>
+                </button>
               </>
             )}
-          </span>
+          </AnchoredFlyout>
         )}
       </div>
 

--- a/packages/web/src/components/console/SkillSourcesCard.test.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.test.tsx
@@ -56,8 +56,8 @@ async function typeInto(element: HTMLInputElement, value: string): Promise<void>
 // `scope` matters once a dialog is open: the card's own header keeps rendering
 // behind the scrim, so "Install" is ambiguous unless the lookup is scoped.
 function buttonWithText(text: string, scope = ''): HTMLButtonElement {
-  const root = scope ? host.querySelector(scope) : host
-  const found = [...(root?.querySelectorAll('button') ?? [])].find((b) => b.textContent?.includes(text))
+  const searchRoot = scope === 'body' ? document.body : scope ? host.querySelector(scope) : host
+  const found = [...(searchRoot?.querySelectorAll('button') ?? [])].find((b) => b.textContent?.includes(text))
   if (!found) throw new Error(`no button labeled "${text}"${scope ? ` under ${scope}` : ''}`)
   return found
 }
@@ -96,6 +96,31 @@ afterEach(async () => {
 })
 
 describe('organization Skills library', () => {
+  it('portals the Add menu beyond the clipping card boundary', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () => new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+    )
+
+    await act(async () => {
+      root.render(
+        <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+          <SkillSourcesCard canWrite={true} canManage={true} />
+        </SWRConfig>
+      )
+    })
+    await act(async () => buttonWithText('Add').click())
+
+    const card = host.querySelector('.card')
+    const searchAction = buttonWithText('Search skills.sh', 'body')
+    const importAction = buttonWithText('Import from GitHub', 'body')
+    expect(card?.classList.contains('overflow-hidden')).toBe(true)
+    expect(card?.contains(searchAction)).toBe(false)
+    expect(card?.contains(importAction)).toBe(false)
+  })
+
   it('renders Git sources and accepted managed skills as tiles in one card', async () => {
     const managed: ManagedSkillDto = {
       id: '66666666-6666-4666-8666-666666666666',
@@ -175,7 +200,7 @@ describe('organization Skills library', () => {
       )
     })
     await act(async () => buttonWithText('Add').click())
-    await act(async () => buttonWithText('Search skills.sh').click())
+    await act(async () => buttonWithText('Search skills.sh', 'body').click())
 
     await typeInto(host.querySelector<HTMLInputElement>('input.inp')!, 'pdf')
     await settleUntil(() => host.textContent?.includes('169.9K installs') === true, 40)

--- a/packages/web/src/components/console/SkillSourcesCard.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.tsx
@@ -31,6 +31,7 @@ import {
 import { consoleKeys } from '@/lib/swr-keys'
 import { ManagedSkillTile } from '@/components/console/ManagedSkillTile'
 import { InstallRegistrySkillModal } from '@/components/console/InstallRegistrySkillModal'
+import { AnchoredFlyout } from '@/components/ui/AnchoredFlyout'
 import { VisibilityField, VisibilityValue, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
 import { SkillMark, SkillSourceLine, ToolTile, ToolTileGrid } from '@/components/console/ToolTile'
 import { GithubMark, LoadingState } from '@/components/marks'
@@ -48,7 +49,6 @@ export function SkillSourcesCard({ canWrite, canManage }: { canWrite: boolean; c
   const { skillSources, skillSourcesLoading } = useConsoleData()
   const { activeOrg } = useOrgs()
   const { mutate: mutateSWR } = useSWRConfig()
-  const [menuOpen, setMenuOpen] = useState(false)
   const [creating, setCreating] = useState(false)
   const [browsing, setBrowsing] = useState(false)
   const [editing, setEditing] = useState<SkillSourceDto | null>(null)
@@ -63,7 +63,6 @@ export function SkillSourcesCard({ canWrite, canManage }: { canWrite: boolean; c
   const managedRows = managedSkills.data ?? []
   const loading = skillSourcesLoading || managedSkills.isLoading
   const empty = skillSources.length === 0 && managedRows.length === 0
-
   const archiveManagedSkill = async (skill: ManagedSkillDto) => {
     setManagedActionError(null)
     try {
@@ -90,58 +89,69 @@ export function SkillSourcesCard({ canWrite, canManage }: { canWrite: boolean; c
             <Toggle checked={includeArchived} onChange={setIncludeArchived} />
           </label>
           {canWrite && (
-            <span className="relative">
-              <Button variant="secondary" size="xs" onClick={() => setMenuOpen((v) => !v)}>
-                <Icon name="plus" size={14} />
-                Add
-                <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
-              </Button>
-              {menuOpen && (
+            <AnchoredFlyout
+              ariaLabel="Add skill source"
+              estimatedHeight={154}
+              trigger={({ open, menuId, toggle }) => (
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  onClick={toggle}
+                  ariaExpanded={open}
+                  ariaHasPopup="menu"
+                  ariaControls={open ? menuId : undefined}
+                >
+                  <Icon name="plus" size={14} />
+                  Add
+                  <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
+                </Button>
+              )}
+            >
+              {({ close }) => (
                 <>
-                  <span className="fixed inset-0 z-30" onClick={() => setMenuOpen(false)} />
-                  <div className="absolute right-0 top-[calc(100%+5px)] z-40 min-w-[280px] rounded-lg border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
-                    <button
-                      onClick={() => {
-                        setMenuOpen(false)
-                        setBrowsing(true)
-                      }}
-                      className="flex w-full cursor-pointer items-start gap-[9px] rounded-[6px] border-0 bg-transparent p-[10px] text-left hover:bg-(--surface-hover)"
-                    >
-                      <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
-                        <Icon name="search" size={16} color="var(--brand)" />
+                  <button
+                    role="menuitem"
+                    onClick={() => {
+                      close()
+                      setBrowsing(true)
+                    }}
+                    className="flex w-full cursor-pointer items-start gap-[9px] rounded-[6px] border-0 bg-transparent p-[10px] text-left hover:bg-(--surface-hover)"
+                  >
+                    <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
+                      <Icon name="search" size={16} color="var(--brand)" />
+                    </span>
+                    <span className="flex min-w-0 flex-col">
+                      <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                        Search skills.sh
                       </span>
-                      <span className="flex min-w-0 flex-col">
-                        <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                          Search skills.sh
-                        </span>
-                        <span className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
-                          Find a skill in the public registry by name
-                        </span>
+                      <span className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
+                        Find a skill in the public registry by name
                       </span>
-                    </button>
-                    <button
-                      onClick={() => {
-                        setMenuOpen(false)
-                        setCreating(true)
-                      }}
-                      className="flex w-full cursor-pointer items-start gap-[9px] rounded-[6px] border-0 bg-transparent p-[10px] text-left hover:bg-(--surface-hover)"
-                    >
-                      <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
-                        <GithubMark color="var(--brand)" />
+                    </span>
+                  </button>
+                  <button
+                    role="menuitem"
+                    onClick={() => {
+                      close()
+                      setCreating(true)
+                    }}
+                    className="flex w-full cursor-pointer items-start gap-[9px] rounded-[6px] border-0 bg-transparent p-[10px] text-left hover:bg-(--surface-hover)"
+                  >
+                    <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
+                      <GithubMark color="var(--brand)" />
+                    </span>
+                    <span className="flex min-w-0 flex-col">
+                      <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                        Import from GitHub
                       </span>
-                      <span className="flex min-w-0 flex-col">
-                        <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                          Import from GitHub
-                        </span>
-                        <span className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
-                          Register a repository you already know
-                        </span>
+                      <span className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
+                        Register a repository you already know
                       </span>
-                    </button>
-                  </div>
+                    </span>
+                  </button>
                 </>
               )}
-            </span>
+            </AnchoredFlyout>
           )}
         </span>
       </div>

--- a/packages/web/src/components/ui.tsx
+++ b/packages/web/src/components/ui.tsx
@@ -107,7 +107,11 @@ export function Button({
   type = 'button',
   disabled = false,
   style,
-  className
+  className,
+  ariaLabel,
+  ariaExpanded,
+  ariaHasPopup,
+  ariaControls
 }: {
   variant?: ButtonVariant
   size?: ButtonSize
@@ -117,6 +121,10 @@ export function Button({
   disabled?: boolean
   style?: CSSProperties
   className?: string
+  ariaLabel?: string
+  ariaExpanded?: boolean
+  ariaHasPopup?: 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog'
+  ariaControls?: string
 }) {
   const sizeCls = size === 'lg' ? ' lg' : size === 'sm' ? ' sm' : size === 'xs' ? ' xs' : ''
   return (
@@ -126,6 +134,10 @@ export function Button({
       className={`dsbtn${sizeCls} dsbtn-${variant}${className ? ` ${className}` : ''}`}
       onClick={onClick}
       style={style}
+      aria-label={ariaLabel}
+      aria-expanded={ariaExpanded}
+      aria-haspopup={ariaHasPopup}
+      aria-controls={ariaControls}
     >
       {children}
     </button>

--- a/packages/web/src/components/ui/AnchoredFlyout.test.tsx
+++ b/packages/web/src/components/ui/AnchoredFlyout.test.tsx
@@ -38,7 +38,7 @@ describe('shared AnchoredFlyout', () => {
     ).toMatchObject({ left: 8, top: 55, width: 234 })
   })
 
-  it('portals its menu to body and dismisses through the backdrop', () => {
+  it('portals its menu to body and distinguishes internal from external scrolling', () => {
     act(() =>
       root.render(
         <div className="overflow-hidden">
@@ -61,6 +61,13 @@ describe('shared AnchoredFlyout', () => {
     expect(menu?.getAttribute('role')).toBe('menu')
     expect(host.contains(menu)).toBe(false)
 
+    act(() => menu?.dispatchEvent(new Event('scroll')))
+    expect(document.body.querySelector('[data-anchored-flyout]')).toBe(menu)
+
+    act(() => host.dispatchEvent(new Event('scroll')))
+    expect(document.body.querySelector('[data-anchored-flyout]')).toBeNull()
+
+    act(() => host.querySelector('button')?.click())
     act(() => document.body.querySelector<HTMLElement>('[data-anchored-flyout-backdrop]')?.click())
     expect(document.body.querySelector('[data-anchored-flyout]')).toBeNull()
   })

--- a/packages/web/src/components/ui/AnchoredFlyout.test.tsx
+++ b/packages/web/src/components/ui/AnchoredFlyout.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { AnchoredFlyout, placeAnchoredFlyout } from './AnchoredFlyout'
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+describe('shared AnchoredFlyout', () => {
+  it('clamps horizontally and flips above when the lower edge is crowded', () => {
+    expect(
+      placeAnchoredFlyout(
+        { left: 900, right: 950, top: 700, bottom: 730 },
+        { width: 1000, height: 800 },
+        { width: 280, estimatedHeight: 154, align: 'end', gap: 5, margin: 8 }
+      )
+    ).toEqual({ left: 670, bottom: 105, width: 280, maxHeight: 687 })
+    expect(
+      placeAnchoredFlyout(
+        { left: 190, right: 240, top: 20, bottom: 50 },
+        { width: 250, height: 800 },
+        { width: 280, estimatedHeight: 154, align: 'end', gap: 5, margin: 8 }
+      )
+    ).toMatchObject({ left: 8, top: 55, width: 234 })
+  })
+
+  it('portals its menu to body and dismisses through the backdrop', () => {
+    act(() =>
+      root.render(
+        <div className="overflow-hidden">
+          <AnchoredFlyout
+            ariaLabel="Add things"
+            trigger={({ open, toggle, menuId }) => (
+              <button aria-expanded={open} aria-controls={open ? menuId : undefined} onClick={toggle}>
+                Add
+              </button>
+            )}
+          >
+            {({ close }) => <button onClick={() => close()}>One action</button>}
+          </AnchoredFlyout>
+        </div>
+      )
+    )
+
+    act(() => host.querySelector('button')?.click())
+    const menu = document.body.querySelector<HTMLElement>('[data-anchored-flyout]')
+    expect(menu?.getAttribute('role')).toBe('menu')
+    expect(host.contains(menu)).toBe(false)
+
+    act(() => document.body.querySelector<HTMLElement>('[data-anchored-flyout-backdrop]')?.click())
+    expect(document.body.querySelector('[data-anchored-flyout]')).toBeNull()
+  })
+})

--- a/packages/web/src/components/ui/AnchoredFlyout.tsx
+++ b/packages/web/src/components/ui/AnchoredFlyout.tsx
@@ -69,6 +69,7 @@ export function AnchoredFlyout({
   triggerClassName = ''
 }: AnchoredFlyoutProps) {
   const triggerRef = useRef<HTMLSpanElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
   const [style, setStyle] = useState<AnchoredFlyoutStyle | null>(null)
   const menuId = useId()
   const open = style !== null
@@ -100,14 +101,18 @@ export function AnchoredFlyout({
       event.preventDefault()
       close(true)
     }
-    const onViewportChange = () => close()
+    const onScroll = (event: Event) => {
+      if (menuRef.current && event.composedPath().includes(menuRef.current)) return
+      close()
+    }
+    const onResize = () => close()
     document.addEventListener('keydown', onKeyDown, true)
-    window.addEventListener('scroll', onViewportChange, true)
-    window.addEventListener('resize', onViewportChange)
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('resize', onResize)
     return () => {
       document.removeEventListener('keydown', onKeyDown, true)
-      window.removeEventListener('scroll', onViewportChange, true)
-      window.removeEventListener('resize', onViewportChange)
+      window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('resize', onResize)
     }
   }, [close, open])
 
@@ -127,6 +132,7 @@ export function AnchoredFlyout({
               onClick={() => close(true)}
             />
             <div
+              ref={menuRef}
               data-anchored-flyout
               id={menuId}
               role="menu"

--- a/packages/web/src/components/ui/AnchoredFlyout.tsx
+++ b/packages/web/src/components/ui/AnchoredFlyout.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useCallback, useEffect, useId, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+export type AnchoredFlyoutStyle = Pick<CSSProperties, 'top' | 'bottom' | 'left' | 'width' | 'maxHeight'>
+
+export interface AnchoredFlyoutControls {
+  open: boolean
+  menuId: string
+  toggle: () => void
+  /** Close after choosing an item. Pass true for dismissals that should return
+   * keyboard focus to the trigger (Escape/backdrop already do this). */
+  close: (restoreFocus?: boolean) => void
+}
+
+interface AnchoredFlyoutProps {
+  trigger: (controls: AnchoredFlyoutControls) => ReactNode
+  children: (controls: Pick<AnchoredFlyoutControls, 'close'>) => ReactNode
+  ariaLabel: string
+  width?: number
+  estimatedHeight?: number
+  align?: 'start' | 'end'
+  gap?: number
+  viewportMargin?: number
+  className?: string
+  triggerClassName?: string
+}
+
+/** Place a fixed flyout inside the viewport, preferring below its trigger and
+ * flipping above when that side has meaningfully more space. */
+export function placeAnchoredFlyout(
+  trigger: { left: number; right: number; top: number; bottom: number },
+  viewport: { width: number; height: number },
+  options: {
+    width: number
+    estimatedHeight: number
+    align: 'start' | 'end'
+    gap: number
+    margin: number
+  }
+): AnchoredFlyoutStyle {
+  const width = Math.min(options.width, Math.max(0, viewport.width - options.margin * 2))
+  const maxLeft = Math.max(options.margin, viewport.width - width - options.margin)
+  const alignedLeft = options.align === 'end' ? trigger.right - width : trigger.left
+  const left = Math.min(Math.max(options.margin, alignedLeft), maxLeft)
+  const roomBelow = Math.max(0, viewport.height - trigger.bottom - options.gap - options.margin)
+  const roomAbove = Math.max(0, trigger.top - options.gap - options.margin)
+
+  if (roomBelow >= options.estimatedHeight || roomBelow >= roomAbove) {
+    return { left, top: trigger.bottom + options.gap, width, maxHeight: roomBelow }
+  }
+  return { left, bottom: viewport.height - trigger.top + options.gap, width, maxHeight: roomAbove }
+}
+
+/** Shared body-portaled menu surface for controls inside clipped cards,
+ * drawers, and scroll containers. The caller owns the trigger and menu items;
+ * this primitive owns anchoring, collision handling, layering, and dismissal. */
+export function AnchoredFlyout({
+  trigger,
+  children,
+  ariaLabel,
+  width = 280,
+  estimatedHeight = 160,
+  align = 'end',
+  gap = 5,
+  viewportMargin = 8,
+  className = '',
+  triggerClassName = ''
+}: AnchoredFlyoutProps) {
+  const triggerRef = useRef<HTMLSpanElement>(null)
+  const [style, setStyle] = useState<AnchoredFlyoutStyle | null>(null)
+  const menuId = useId()
+  const open = style !== null
+
+  const close = useCallback((restoreFocus = false) => {
+    setStyle(null)
+    if (restoreFocus) {
+      requestAnimationFrame(() => triggerRef.current?.querySelector<HTMLElement>('button, [href]')?.focus())
+    }
+  }, [])
+
+  const toggle = () => {
+    if (open) return close(true)
+    const anchor = triggerRef.current
+    if (!anchor) return
+    setStyle(
+      placeAnchoredFlyout(
+        anchor.getBoundingClientRect(),
+        { width: window.innerWidth, height: window.innerHeight },
+        { width, estimatedHeight, align, gap, margin: viewportMargin }
+      )
+    )
+  }
+
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      close(true)
+    }
+    const onViewportChange = () => close()
+    document.addEventListener('keydown', onKeyDown, true)
+    window.addEventListener('scroll', onViewportChange, true)
+    window.addEventListener('resize', onViewportChange)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true)
+      window.removeEventListener('scroll', onViewportChange, true)
+      window.removeEventListener('resize', onViewportChange)
+    }
+  }, [close, open])
+
+  const controls = { open, menuId, toggle, close }
+  return (
+    <>
+      <span ref={triggerRef} className={triggerClassName}>
+        {trigger(controls)}
+      </span>
+      {style &&
+        createPortal(
+          <>
+            <span
+              data-anchored-flyout-backdrop
+              aria-hidden="true"
+              className="fixed inset-0 z-[1090]"
+              onClick={() => close(true)}
+            />
+            <div
+              data-anchored-flyout
+              id={menuId}
+              role="menu"
+              aria-label={ariaLabel}
+              className={`fixed z-[1100] overflow-y-auto rounded-lg border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg) ${className}`}
+              style={style}
+            >
+              {children({ close })}
+            </div>
+          </>,
+          document.body
+        )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

- add a shared `AnchoredFlyout` UI primitive backed by a body portal
- migrate the Skills library and MCP server Add menus to the shared primitive
- add viewport clamping, vertical flipping, dismissal, focus restoration, and ARIA relationships
- keep shared UI infrastructure outside the console feature folder

## Why

The Skills library Add menu was rendered inside an `overflow-hidden` card, so the lower menu option was clipped. Removing the card overflow would weaken the card boundary and would not protect menus from other clipping or stacking contexts. Portaling the flyout to `document.body` fixes the root cause and gives other action menus a reusable positioning layer.

## Impact

The Skills and MCP Add menus now remain visible near viewport edges and inside clipped or scrollable containers. Their actions and visual styling are unchanged.

## Validation

- 6 focused Vitest tests passed
- TypeScript typecheck passed
- ESLint passed, including the repository pre-push check
- Docker production build passed on the deployment host
- rebuilt web container reported healthy and the HTTPS gateway returned 200
