### PR TITLE
refactor(daemon): extract transcript ingest from SessionManager.handle()

### DIFF
--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -2,7 +2,6 @@ import type { ContentBlock, McpServer } from '@agentclientprotocol/sdk'
 import { LocalStore, sessionKey, transcriptChannelKey, type TranscriptEntry } from '../store/local-store.js'
 import { isSyntheticA2aChannel } from '../cp/cp-collab-routes.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
-import { SLACK_RESPONSE_FINAL_EVENT_TAG } from '@agentconnect.md/message'
 import { WorkspaceManager } from '../workspace/workspace-manager.js'
 import { initiatorLabel } from '../workspace/session-branch.js'
 import { memoryKindOf, type MemoryProvider, type MemoryScope } from '../memory/provider.js'
@@ -14,18 +13,14 @@ import type { Agent } from '../agents/agent-schema.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import { stableTurnId, type Attachment, type NormalizedMessage } from '../messages/normalized.js'
 import { messageOrderingFor } from '../platforms/message-ordering.js'
-import {
-  buildAttachmentBlocks,
-  attachmentMention,
-  hydrateTranscriptImage,
-  transcriptImageAttachments
-} from './attachment-block.js'
+import { buildAttachmentBlocks } from './attachment-block.js'
 import { DIRECT_AGENT_CALL_REMINDER, EXPLICIT_MENTION_REMINDER, NO_RESPONSE_REMINDER } from './no-response.js'
 import { planReplay, renderReplayContext } from './turn/replay-plan.js'
 import { AGENT_META_OPENING, buildStandingContext } from './turn/standing-context.js'
 import { backfillThreadHistory } from './turn/thread-backfill.js'
 import { RecallObserver, runTurnRecall, type MemoryRecallLifecycleEvent } from './turn/memory-recall.js'
 import { openRuntimeSession } from './turn/runtime-session.js'
+import { ingestInboundTranscript } from './turn/transcript-ingest.js'
 
 // The recall lifecycle contract lives with the collaborator that emits it; re-exported
 // here because SessionManagerDeps is the seam production wires its observer through.
@@ -387,64 +382,20 @@ export class SessionManager {
     let rec = this.deps.store.getSession(key)
     const transcriptChannel = transcriptChannelKey(msg.channel, transportScope)
 
-    // record the triggering message in the transcript (with an attachment mention
-    // for prompt replay; a bounded inline image stays daemon-local for UI replay).
-    // A platform image is only an auth-gated URL, so fetch it here — the bytes are
-    // memoized on the attachment and reused by the prompt blocks below (one fetch).
-    await hydrateTranscriptImage(msg.attachments, {
-      download: (att) => this.deps.downloadAttachment?.(agentId, att) ?? Promise.resolve(null),
-      ...(this.deps.attachmentMaxBytes !== undefined ? { maxBytes: this.deps.attachmentMaxBytes } : {})
-    })
-    const mention = attachmentMention(msg.attachments)
-    const transcriptAttachments = transcriptImageAttachments(msg.attachments)
-    const transcriptText = mention ? `${msg.text}\n${mention}`.trim() : msg.text
-    // Webchat rows dedup on (channel, thread, ts) alone, and a carried canonical
-    // `at` can land on a millisecond a DIFFERENT post (a peer's context copy)
-    // already occupies on this daemon — probe the slot and bump instead of
-    // letting INSERT OR IGNORE silently drop this message. An identical row
-    // (the co-hosted-participant fan-out case) keeps the shared slot.
-    if (msg.platform === 'webchat') {
-      let slot = BigInt(ts)
-      for (let attempt = 0; attempt < 32; attempt++) {
-        const existing = this.deps.store.transcriptTextAt(transcriptChannel, thread, String(slot), {
-          sender: msg.sender.id,
-          recipient: agentId
-        })
-        // Mirror the daemon-side probe (§6): matching canonical postId is what
-        // proves the occupant is this same post; (sender, text) only decides
-        // for legacy rows without an id on either side.
-        const samePost =
-          existing !== undefined &&
-          (msg.transcriptPostId && existing.postId
-            ? existing.postId === msg.transcriptPostId
-            : existing.sender === msg.sender.id && existing.text === transcriptText)
-        if (!existing || samePost) break
-        slot += 1n
-      }
-      ts = String(slot)
-    }
-    this.deps.store.appendTranscript({
-      channel: transcriptChannel,
+    // Hydrate the inbound image and record the triggering message (turn/transcript-ingest.ts);
+    // it returns the ts the row actually landed on (webchat slot probe) and the hydrated
+    // attachments, whose bytes the prompt blocks below reuse.
+    const ingested = await ingestInboundTranscript({
+      store: this.deps.store,
+      agentId,
+      msg,
+      transcriptChannel,
       thread,
       ts,
-      sender: msg.sender.id,
-      // The canonical webchat post identity travels with the canonical ts —
-      // identical on every participant copy even when `ts` was bumped (§6).
-      ...(msg.transcriptPostId ? { postId: msg.transcriptPostId } : {}),
-      // Provider send time for platforms whose message ids are not
-      // chronological (Telegram/Feishu; Discord decodes its snowflake at
-      // normalization) — the merged conversation view orders on this axis.
-      ...(msg.platformTimeMs ? { eventTimeUs: msg.platformTimeMs * 1000 } : {}),
-      // This message was delivered TO this agent (handle() runs for `agentId`), so tag the
-      // recipient — the console session view scopes to what THIS agent received + produced.
-      recipient: agentId,
-      // A response finalization is the same Slack message as the post that opened it, so
-      // it lands on that row and refreshes it to the completed text.
-      ...(msg.ingressEventTag === SLACK_RESPONSE_FINAL_EVENT_TAG ? { authoritative: true } : {}),
-      kind: 'text',
-      text: transcriptText,
-      ...(transcriptAttachments.length ? { attachments: transcriptAttachments } : {})
+      download: (att) => this.deps.downloadAttachment?.(agentId, att) ?? Promise.resolve(null),
+      ...(this.deps.attachmentMaxBytes !== undefined ? { attachmentMaxBytes: this.deps.attachmentMaxBytes } : {})
     })
+    ts = ingested.ts
 
     const isNewLogicalSession = rec === undefined
     if (rec) {
@@ -780,10 +731,10 @@ export class SessionManager {
     }
 
     // §9.2 attachments on the current message → image/resource/resource_link blocks.
-    if (msg.attachments?.length) {
+    if (ingested.attachments?.length) {
       const attBlocks = await abortable(
         () =>
-          buildAttachmentBlocks(msg.attachments!, {
+          buildAttachmentBlocks(ingested.attachments!, {
             download: (att) => this.deps.downloadAttachment?.(agentId, att) ?? Promise.resolve(null),
             supports: (kind) => host.promptSupports?.(kind) ?? false,
             ...(this.deps.attachmentMaxBytes !== undefined ? { maxBytes: this.deps.attachmentMaxBytes } : {})

--- a/packages/daemon/src/session/turn/transcript-ingest.ts
+++ b/packages/daemon/src/session/turn/transcript-ingest.ts
@@ -1,0 +1,124 @@
+import { SLACK_RESPONSE_FINAL_EVENT_TAG } from '@agentconnect.md/message'
+import type { LocalStore } from '../../store/local-store.js'
+import type { Attachment, NormalizedMessage } from '../../messages/normalized.js'
+import { attachmentMention, hydrateTranscriptImage, transcriptImageAttachments } from '../attachment-block.js'
+
+/** The two transcript seams the ingest owns — the slot probe and the row append. */
+type IngestStore = Pick<LocalStore, 'transcriptTextAt' | 'appendTranscript'>
+
+/** What a probe found sitting on a candidate webchat slot. */
+export interface SlotOccupant {
+  sender: string
+  text: string
+  postId: string | null
+}
+
+/** The identity a webchat row must carry to be recognized as this same post. */
+export interface SlotClaim {
+  sender: string
+  text: string
+  /** Canonical relay-minted post id, when the turn carries one. */
+  postId?: string
+}
+
+/** Webchat rows dedup on (channel, thread, ts) alone, and a carried canonical `at` can land
+ *  on a millisecond a DIFFERENT post (a peer's context copy) already occupies on this daemon —
+ *  walk forward to the first free-or-same slot instead of letting INSERT OR IGNORE silently
+ *  drop this message. An identical row (the co-hosted-participant fan-out case) keeps the
+ *  shared slot. Pure: the caller injects the probe. */
+export function probeWebchatSlot(
+  start: string,
+  claim: SlotClaim,
+  probe: (ts: string) => SlotOccupant | undefined
+): string {
+  let slot = BigInt(start)
+  for (let attempt = 0; attempt < 32; attempt++) {
+    const existing = probe(String(slot))
+    // Mirror the daemon-side probe (§6): matching canonical postId is what proves the occupant
+    // is this same post; (sender, text) only decides for legacy rows without an id on either side.
+    const samePost =
+      existing !== undefined &&
+      (claim.postId && existing.postId
+        ? existing.postId === claim.postId
+        : existing.sender === claim.sender && existing.text === claim.text)
+    if (!existing || samePost) break
+    slot += 1n
+  }
+  return String(slot)
+}
+
+export interface TranscriptIngestInput {
+  store: IngestStore
+  /** The agent this activation runs for — the transcript row's recipient. */
+  agentId: string
+  msg: NormalizedMessage
+  /** Transcript primary-key coordinates already resolved by the caller. */
+  transcriptChannel: string
+  thread: string
+  ts: string
+  /** Download an inbound attachment's bytes (§9.2); resolves null when unavailable. */
+  download: (att: Attachment) => Promise<Buffer | null>
+  /** Inline cap (bytes) for attachments; files over it stay un-hydrated. */
+  attachmentMaxBytes?: number
+}
+
+export interface TranscriptIngestResult {
+  /** The ts the row actually landed on — bumped when a webchat slot was already taken. */
+  ts: string
+  /** The inbound attachments after image hydration; their bytes are memoized on the
+   *  attachment objects and reused by the prompt blocks (one fetch per image). */
+  attachments: Attachment[] | undefined
+}
+
+/**
+ * Record the triggering message in the transcript (with an attachment mention for prompt
+ * replay; a bounded inline image stays daemon-local for UI replay). A platform image is only
+ * an auth-gated URL, so fetch it here — the bytes are memoized on the attachment and reused
+ * by the prompt blocks the caller builds later.
+ */
+export async function ingestInboundTranscript(input: TranscriptIngestInput): Promise<TranscriptIngestResult> {
+  const { store, agentId, msg, transcriptChannel, thread } = input
+  await hydrateTranscriptImage(msg.attachments, {
+    download: input.download,
+    ...(input.attachmentMaxBytes !== undefined ? { maxBytes: input.attachmentMaxBytes } : {})
+  })
+  const mention = attachmentMention(msg.attachments)
+  const transcriptAttachments = transcriptImageAttachments(msg.attachments)
+  const transcriptText = mention ? `${msg.text}\n${mention}`.trim() : msg.text
+  const ts =
+    msg.platform === 'webchat'
+      ? probeWebchatSlot(
+          input.ts,
+          {
+            sender: msg.sender.id,
+            text: transcriptText,
+            ...(msg.transcriptPostId ? { postId: msg.transcriptPostId } : {})
+          },
+          (slot) =>
+            store.transcriptTextAt(transcriptChannel, thread, slot, { sender: msg.sender.id, recipient: agentId })
+        )
+      : input.ts
+  store.appendTranscript({
+    channel: transcriptChannel,
+    thread,
+    ts,
+    sender: msg.sender.id,
+    // The canonical webchat post identity travels with the canonical ts —
+    // identical on every participant copy even when `ts` was bumped (§6).
+    ...(msg.transcriptPostId ? { postId: msg.transcriptPostId } : {}),
+    // Provider send time for platforms whose message ids are not chronological
+    // (Telegram/Feishu; Discord decodes its snowflake at normalization) — the
+    // merged conversation view orders on this axis.
+    ...(msg.platformTimeMs ? { eventTimeUs: msg.platformTimeMs * 1000 } : {}),
+    // This message was delivered TO this agent (handle() runs for `agentId`), so tag the
+    // recipient — the console session view scopes to what THIS agent received + produced.
+    recipient: agentId,
+    // A response finalization is the same Slack message as the post that opened it, so
+    // it lands on that row and refreshes it to the completed text.
+    ...(msg.ingressEventTag === SLACK_RESPONSE_FINAL_EVENT_TAG ? { authoritative: true } : {}),
+    kind: 'text',
+    text: transcriptText,
+    ...(transcriptAttachments.length ? { attachments: transcriptAttachments } : {})
+  })
+  return { ts, attachments: msg.attachments }
+}


### PR DESCRIPTION
`SessionManager.handle()`'s early phase did three things inline: hydrate the inbound
attachment image, probe a free webchat transcript timestamp slot, and append the inbound
message row. This moves all three into `session/turn/transcript-ingest.ts` as one effectful
collaborator with explicit inputs (store seams, download + inline cap, msg, transcript
coordinates) and explicit outputs — the ts the row actually landed on, and the hydrated
attachments the prompt blocks reuse.

The webchat slot walk becomes `probeWebchatSlot`, a pure function with the store probe
injected, which also delivers the standalone slot-probe extraction.

`TranscriptRecorder` was checked first and is a different concept (it turns the ACP
`session/update` stream into activity-log events), so it is not extended here.

Behavior is byte-identical: same probing order and 32-attempt bound, same append payload
shape, same one-fetch memoization feeding `buildAttachmentBlocks`.

## Verification

- `pnpm typecheck` (daemon) — clean
- `vitest run test/session-manager.test.ts test/daemon-transcript.test.ts test/attachment-block.test.ts test/daemon-webchat.test.ts` — 180 passed
- prettier + eslint on both touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
