### PR TITLE
feat(usage): carry a session cost as an exact decimal, edge to aggregate

### DIFF
--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -484,6 +484,15 @@ the authenticated WebSocket connection. CP accepts `event/session` and
 with placement moves excluded while the write runs. A `sessionId` is bound to
 the first accepted `agentId` and can never be reassigned by a later report.
 
+A usage report's `costAmount` is money, so it may be either a fixed-point
+decimal STRING (unsigned, non-exponential, up to 20 integer and 18 fractional
+digits) or a JSON number, and the CP's ingress normalizes it to the decimal
+string before anything accumulates. Storage is `NUMERIC(38,18)` and range
+aggregates diff and sum in decimal, so no cost passes through binary floating
+point after the edge. The number branch exists for daemons that predate the
+string; an amount that cannot be normalized drops the cost and keeps the
+session's token counts.
+
 Phase state machine: `start → (plan ↔ problem)* → end`. The daemon collapses
 ACP `session/update` streams into these milestones; CP persists the metadata,
 never the stream. `GET /sessions/:id` and `GET /sessions` read that stored

--- a/packages/control-plane/prisma/migrations/20260829000000_usage_cost_numeric/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260829000000_usage_cost_numeric/migration.sql
@@ -1,0 +1,18 @@
+-- Exact money. A cost is metered by one party, accumulated here, and billed by
+-- another, so the two usage tables hold it as NUMERIC(38,18) instead of double
+-- precision: 20 integer digits for any plausible amount, 18 fractional for the
+-- sub-cent per-token prices the smallest reports carry.
+--
+-- Postgres casts float8 to numeric through the double's shortest round-tripping
+-- decimal, so an amount written as 0.41 lands as 0.41 rather than its binary tail.
+-- An existing amount with more than 20 integer digits would overflow the new type
+-- and fail this statement — that is corrupt data, and refusing it is the point.
+
+-- AlterTable
+ALTER TABLE "public"."session_usage"
+  ALTER COLUMN "costAmount" SET DATA TYPE NUMERIC(38,18),
+  ALTER COLUMN "costAmount" SET DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "public"."session_spend"
+  ALTER COLUMN "cumulativeCost" SET DATA TYPE NUMERIC(38,18);

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1377,7 +1377,9 @@ model SessionUsage {
   cachedWriteTokens Int         @default(0)
   contextUsed       Int?
   contextSize       Int?
-  costAmount        Float       @default(0)
+  // Exact money: an amount is metered by one party and billed by another, so it is
+  // NUMERIC end to end and never a binary float. Reports carry it as a decimal string.
+  costAmount        Decimal     @default(0) @db.Decimal(38, 18)
   costCurrency      String?
   startedAt         DateTime    @default(now()) @db.Timestamptz(6)
   lastActivityAt    DateTime    @db.Timestamptz(6)
@@ -1421,7 +1423,9 @@ model SessionSpend {
   cumulativeThoughtTokens     Int         @default(0)
   cumulativeCachedReadTokens  Int         @default(0)
   cumulativeCachedWriteTokens Int         @default(0)
-  cumulativeCost              Float // session's cumulative cost as of `at`; window spend = diff of consecutive cumulatives
+  // Session's cumulative cost as of `at`; window spend = diff of consecutive cumulatives.
+  // NUMERIC like the snapshot: the diffs feed billing, so no step may round.
+  cumulativeCost              Decimal     @db.Decimal(38, 18)
 
   agent Agent @relation(fields: [agentId], references: [id], onDelete: Cascade)
 

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -12,6 +12,7 @@ import {
   ApprovalsReviewer,
   AgentPermissionRequestRecord,
   CanonicalMemoryRecord,
+  DecimalAmount,
   FeishuRegion,
   MemoryFileHistoryEvent,
   MemoryPluginHistoryEvent,
@@ -3261,9 +3262,22 @@ export const AgentWakeDto = z.object({ state: z.enum(['running', 'starting', 'un
 /** The batch body of the service-authenticated usage endpoint. Its element IS the
  *  daemon EVT's payload schema, deliberately: one payload, two authenticated
  *  adapters, one writer — reusing the wire schema is what keeps them from drifting.
- *  The report never names its own source; the adapter stamps it. */
+ *  The report never names its own source; the adapter stamps it.
+ *
+ *  Two fields are narrowed for this ingress, because its reports are what gets
+ *  BILLED: the cost is the exact decimal string only (never a JSON number, so no
+ *  amount reaches billing through a float), and both the amount and its currency are
+ *  mandatory. A missing amount must not be read as zero spend, so one bad report
+ *  fails the whole batch — which the caller then retries in full. */
 export const UsageReportBatchBody = z.object({
-  reports: z.array(UsageReport).min(1).max(1000)
+  reports: z
+    .array(
+      UsageReport.extend({
+        usage: UsageReport.shape.usage.extend({ costAmount: DecimalAmount, costCurrency: z.string().min(1) })
+      })
+    )
+    .min(1)
+    .max(1000)
 })
 export type UsageReportBatchBodyT = z.infer<typeof UsageReportBatchBody>
 
@@ -3277,6 +3291,11 @@ export const UsageQueryDto = z.object({
   tz: z.coerce.number().int().min(-900).max(900).default(0)
 })
 
+/** An amount in an aggregate RESPONSE. A plain string, not `DecimalAmount`: these are
+ *  derived by subtraction, so a downward correction can still make one negative, and a
+ *  reader is better served by the real figure than by a schema that refuses to send it. */
+const AggregateAmountDto = z.string()
+
 /** Per-agent rollup over the selected range (summed tokens/cost + session count). */
 export const UsageAgentDto = z.object({
   agentId: z.string(),
@@ -3287,7 +3306,7 @@ export const UsageAgentDto = z.object({
   thoughtTokens: z.number(),
   cachedReadTokens: z.number(),
   cachedWriteTokens: z.number(),
-  costAmount: z.number()
+  costAmount: AggregateAmountDto
 })
 export const UsageModelDto = UsageAgentDto.omit({ agentId: true }).extend({
   model: z.string().nullable()
@@ -3296,10 +3315,12 @@ export const UsageDto = z.object({
   range: UsageRange,
   accessSyncDegraded: z.boolean().optional(),
   accessIssues: z.array(SessionAccessIssueDto).optional(),
+  // Every amount is an exact decimal string: this aggregate is what billing reads, so
+  // the roll-up never rounds and the console only formats what it is given.
   totals: z.object({
     sessions: z.number(),
     totalTokens: z.number(),
-    costAmount: z.number(),
+    costAmount: AggregateAmountDto,
     costCurrency: z.string().nullable()
   }),
   agents: z.array(UsageAgentDto),
@@ -3313,9 +3334,9 @@ export const UsageDto = z.object({
     points: z.array(
       z.object({
         start: z.string(),
-        costAmount: z.number(),
-        byAgent: z.record(z.string(), z.number()),
-        byModel: z.record(z.string(), z.number())
+        costAmount: AggregateAmountDto,
+        byAgent: z.record(z.string(), AggregateAmountDto),
+        byModel: z.record(z.string(), AggregateAmountDto)
       })
     )
   })

--- a/packages/control-plane/src/http/routes/internal-usage.ts
+++ b/packages/control-plane/src/http/routes/internal-usage.ts
@@ -26,6 +26,12 @@
  * the caller retries the WHOLE batch and no per-item receipt is needed. Reports for
  * an agent that no longer exists are dropped by the store rather than failing the
  * batch, so one stale row can never wedge a retry loop.
+ *
+ * These reports are the ones that get billed, so the body schema is stricter than the
+ * daemon EVT's: the cost must be the exact decimal string and its currency must be
+ * present, and a batch that violates either is refused whole (400) before anything is
+ * written. Silently treating a missing amount as zero spend is the failure this
+ * prevents — the caller retries once its own metering is complete.
  */
 import { timingSafeEqual } from 'node:crypto'
 import { z } from 'zod'
@@ -34,6 +40,7 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import { UsageReportBatchBody } from '../dto/index.js'
+import { normalizeUsageReport } from '../../usage/writer.js'
 
 /** The bearer credential, or null when the header is absent or not a bearer. */
 function bearerOf(req: FastifyRequest): string | null {
@@ -94,7 +101,9 @@ export function internalUsageRoutes(deps: HttpDeps) {
         schema: { hide: true, body: UsageReportBatchBody, response: { 204: z.null() } }
       },
       async (req, reply) => {
-        await deps.usageWriter.recordBatch('gateway', req.body.reports)
+        // The schema already refused anything unnormalizable, so this only canonicalizes
+        // (`"12.50"` → `"12.5"`) — the writer's input is then one exact shape, always.
+        await deps.usageWriter.recordBatch('gateway', req.body.reports.map(normalizeUsageReport))
         return reply.code(204).send(null)
       }
     )

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -24,6 +24,7 @@ import type {
   AgentIcon,
   AgentMemoryBinding,
   ApprovalsReviewer,
+  DecimalAmount,
   GithubPublishedComment,
   OrganizationSuggestionInfo
 } from '@agentconnect.md/protocol'
@@ -1684,7 +1685,8 @@ export interface WebchatMcpOperationRepo {
 // SessionUsageRepo (C6) — per-session token accounting for the usage dashboard
 // ───────────────────────────────────────────────────────────────────────────
 
-/** The token/cost snapshot carried by a `usage/report` EVT (protocol `SessionUsage`). */
+/** The token/cost snapshot carried by a `usage/report` EVT (protocol `SessionUsage`).
+ *  Read shape: `costAmount` is a number because the session views only display it. */
 export interface SessionUsageCounts {
   /** Daemon timestamp of the cumulative snapshot; orders competing list/detail reads. */
   reportedAt?: string
@@ -1700,6 +1702,11 @@ export interface SessionUsageCounts {
   costCurrency?: string
 }
 
+/** What the store ACCEPTS: the same counts, with the cost already normalized to the
+ *  exact decimal string by the ingress adapter. Nothing past an adapter writes money
+ *  as a float, so the write path cannot reintroduce one. */
+export type NormalizedUsageCounts = Omit<SessionUsageCounts, 'costAmount'> & { costAmount?: DecimalAmount }
+
 /** Which authenticated ingress metered the session — stamped by the adapter that
  *  accepted the report, never self-reported by the payload. */
 export type UsageSource = 'daemon' | 'gateway'
@@ -1714,7 +1721,7 @@ export interface SessionUsageInput {
   model?: string | null
   source: UsageSource
   lastActivityAt: Date
-  usage: SessionUsageCounts
+  usage: NormalizedUsageCounts
 }
 
 /** Per-agent rollup over a time window (summed tokens/cost + session count). */
@@ -1727,7 +1734,7 @@ export interface AgentUsageAggregate {
   thoughtTokens: number
   cachedReadTokens: number
   cachedWriteTokens: number
-  costAmount: number
+  costAmount: DecimalAmount
 }
 
 /** Per-model rollup over a time window. `null` is usage whose daemon did not
@@ -1741,7 +1748,7 @@ export interface ModelUsageAggregate {
   thoughtTokens: number
   cachedReadTokens: number
   cachedWriteTokens: number
-  costAmount: number
+  costAmount: DecimalAmount
 }
 
 /** One spend-over-time bucket: total cost of sessions whose last activity fell in
@@ -1750,18 +1757,20 @@ export interface ModelUsageAggregate {
  *  chart (model key ''=unreported); only non-zero deltas get a key. */
 export interface SpendBucket {
   start: string
-  costAmount: number
-  byAgent: Record<string, number>
-  byModel: Record<string, number>
+  costAmount: DecimalAmount
+  byAgent: Record<string, DecimalAmount>
+  byModel: Record<string, DecimalAmount>
 }
 
 /** Org-wide usage aggregate for a range: workspace totals + agent/model breakdowns.
+ *  Every amount is an exact decimal string — the aggregate is what billing reads,
+ *  so no step of the roll-up may go through a float.
  *  `costCurrency` is the single distinct currency across the range, or null when
  *  none/mixed (amounts are summed as-is).
  *  `series` is the spend-over-time chart data: cost bucketed by hour (d1) or day
  *  (longer ranges), with empty buckets filled to 0 across the whole window. */
 export interface UsageAggregate {
-  totals: { sessions: number; totalTokens: number; costAmount: number; costCurrency: string | null }
+  totals: { sessions: number; totalTokens: number; costAmount: DecimalAmount; costCurrency: string | null }
   agents: AgentUsageAggregate[]
   models: ModelUsageAggregate[]
   series: { bucket: 'hour' | 'day'; points: SpendBucket[] }

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -15,13 +15,16 @@
  * Prisma surfaces these `_sum` values as `number` (safe to 2^53), which is plenty
  * for workspace-wide token totals.
  *
- * COST is the exception to all of that: it is `NUMERIC(38,18)` and every diff and sum
- * below runs on `Decimal`, never on a JS number. Billing reads these aggregates, so a
- * float anywhere in the roll-up would be a rounding error in someone's invoice.
+ * COST is the exception to all of that: it is `NUMERIC(38,18)`, it is read out as TEXT,
+ * and every diff and sum below runs on integers scaled by that column's scale. Billing
+ * reads these aggregates, so no step may round — not through a float, and not through
+ * `Prisma.Decimal` either, whose arithmetic rounds to 20 significant digits and would
+ * turn an exact `123.123456789012345678` into `123.12345678901234568` on the first
+ * subtraction. Scaled `bigint` has no precision setting to get wrong.
  */
 import type { PrismaLike } from '../prisma.js'
 import { Prisma } from '../../generated/prisma/client.js'
-import type { DecimalAmount } from '@agentconnect.md/protocol'
+import { type DecimalAmount, scaleAmount, unscaleAmount } from '@agentconnect.md/protocol'
 import type {
   SessionUsageRepo,
   SessionUsageInput,
@@ -37,28 +40,17 @@ import { visibilityWhere } from '../../authorization/policy.js'
 import type { AgentId, OrgId } from '../../domain/ids.js'
 import { sessionViewerSql } from './session-access-sql.js'
 
-const ZERO = new Prisma.Decimal(0)
-
-/** A bucket mid-accumulation: `Decimal` sums, keyed maps, serialized once at the end. */
-interface DecimalBucket {
+/** A bucket mid-accumulation: scaled-integer sums, serialized once at the end. */
+interface ScaledBucket {
   start: string
-  costAmount: Prisma.Decimal
-  byAgent: Map<string, Prisma.Decimal>
-  byModel: Map<string, Prisma.Decimal>
+  costAmount: bigint
+  byAgent: Map<string, bigint>
+  byModel: Map<string, bigint>
 }
 
-/** `Decimal` → the exact decimal string the aggregate returns. `toFixed()` never
- *  yields exponent notation; the trailing-zero trim is what makes it canonical.
- *  A derived delta may be negative until the checkpoint merge fences it, so this
- *  keeps a sign rather than refusing the value a reader would then never see. */
-function amount(value: Prisma.Decimal): DecimalAmount {
-  const text = value.toFixed()
-  return text.includes('.') ? text.replace(/0+$/, '').replace(/\.$/, '') : text
-}
-
-/** Serialize a keyed `Decimal` map for the response. */
-function amounts(by: Map<string, Prisma.Decimal>): Record<string, DecimalAmount> {
-  return Object.fromEntries([...by].map(([key, value]) => [key, amount(value)]))
+/** Serialize a keyed scaled-integer map for the response. */
+function amounts(by: Map<string, bigint>): Record<string, DecimalAmount> {
+  return Object.fromEntries([...by].map(([key, value]) => [key, unscaleAmount(value)]))
 }
 
 function agentViewerSql(orgId: OrgId, viewer?: ViewCtx): Prisma.Sql {
@@ -323,10 +315,10 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // Floor `since` to the start of its local bucket, expressed as a UTC instant.
     const floorSince = Math.floor((since.getTime() - offMs) / stepMs) * stepMs + offMs
     const n = Math.floor((now - floorSince) / stepMs) + 1
-    // Buckets accumulate in `Decimal` and are serialized once, at the end.
-    const points: DecimalBucket[] = Array.from({ length: n }, (_, i) => ({
+    // Buckets accumulate as scaled integers and are serialized once, at the end.
+    const points: ScaledBucket[] = Array.from({ length: n }, (_, i) => ({
       start: new Date(floorSince + i * stepMs).toISOString(),
-      costAmount: ZERO,
+      costAmount: 0n,
       byAgent: new Map(),
       byModel: new Map()
     }))
@@ -346,9 +338,9 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     const SEP = '\0'
     const [inRange, baselineRows] = await Promise.all([
       this.db.$queryRaw<
-        Array<{ agentId: string; sessionId: string; at: Date; cumulativeCost: Prisma.Decimal; model: string | null }>
+        Array<{ agentId: string; sessionId: string; at: Date; cumulativeCost: string; model: string | null }>
       >(Prisma.sql`
-        SELECT sp."agentId", sp."sessionId", sp."at", sp."cumulativeCost", NULLIF(sp."model", '') AS model
+        SELECT sp."agentId", sp."sessionId", sp."at", sp."cumulativeCost"::text, NULLIF(sp."model", '') AS model
         FROM "session_spend" sp
         JOIN "agent" a ON a."id" = sp."agentId"
         LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
@@ -357,9 +349,9 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
           AND ${sessionScope ?? Prisma.sql`TRUE`}
         ORDER BY sp."at" ASC
       `),
-      this.db.$queryRaw<Array<{ agentId: string; sessionId: string; cumulativeCost: Prisma.Decimal }>>(Prisma.sql`
+      this.db.$queryRaw<Array<{ agentId: string; sessionId: string; cumulativeCost: string }>>(Prisma.sql`
         SELECT DISTINCT ON (sp."agentId", sp."sessionId")
-               sp."agentId", sp."sessionId", sp."cumulativeCost"
+               sp."agentId", sp."sessionId", sp."cumulativeCost"::text
         FROM "session_spend" sp
         JOIN "agent" a ON a."id" = sp."agentId"
         LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
@@ -371,29 +363,30 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     ])
     // Per-session running cumulative, seeded from the last pre-window report so the
     // first in-window delta counts only spend incurred inside the window.
-    const prevCost = new Map<string, Prisma.Decimal>(
-      baselineRows.map((r) => [r.agentId + SEP + r.sessionId, r.cumulativeCost])
+    const prevCost = new Map<string, bigint>(
+      baselineRows.map((r) => [r.agentId + SEP + r.sessionId, scaleAmount(r.cumulativeCost)])
     )
-    const perAgentCost = new Map<string, Prisma.Decimal>()
-    const perModelCost = new Map<string, Prisma.Decimal>()
-    let totalCost = ZERO
+    const perAgentCost = new Map<string, bigint>()
+    const perModelCost = new Map<string, bigint>()
+    let totalCost = 0n
     // `inRange` is globally at-ascending, so each session's rows are visited in
     // chronological order — exactly what the running diff needs.
     for (const row of inRange) {
       const skey = row.agentId + SEP + row.sessionId
-      const delta = row.cumulativeCost.minus(prevCost.get(skey) ?? ZERO)
-      prevCost.set(skey, row.cumulativeCost)
-      totalCost = totalCost.plus(delta)
-      perAgentCost.set(row.agentId, (perAgentCost.get(row.agentId) ?? ZERO).plus(delta))
+      const cumulative = scaleAmount(row.cumulativeCost)
+      const delta = cumulative - (prevCost.get(skey) ?? 0n)
+      prevCost.set(skey, cumulative)
+      totalCost += delta
+      perAgentCost.set(row.agentId, (perAgentCost.get(row.agentId) ?? 0n) + delta)
       const modelKey = row.model ?? ''
-      perModelCost.set(modelKey, (perModelCost.get(modelKey) ?? ZERO).plus(delta))
+      perModelCost.set(modelKey, (perModelCost.get(modelKey) ?? 0n) + delta)
       const idx = Math.floor((row.at.getTime() - floorSince) / stepMs)
       if (idx >= 0 && idx < n) {
         const pt = points[idx]!
-        pt.costAmount = pt.costAmount.plus(delta)
-        if (!delta.isZero()) {
-          pt.byAgent.set(row.agentId, (pt.byAgent.get(row.agentId) ?? ZERO).plus(delta))
-          pt.byModel.set(modelKey, (pt.byModel.get(modelKey) ?? ZERO).plus(delta))
+        pt.costAmount += delta
+        if (delta !== 0n) {
+          pt.byAgent.set(row.agentId, (pt.byAgent.get(row.agentId) ?? 0n) + delta)
+          pt.byModel.set(modelKey, (pt.byModel.get(modelKey) ?? 0n) + delta)
         }
       }
     }
@@ -407,7 +400,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       thoughtTokens: Number(g.thoughtTokens),
       cachedReadTokens: Number(g.cachedReadTokens),
       cachedWriteTokens: Number(g.cachedWriteTokens),
-      costAmount: amount(perAgentCost.get(g.agentId) ?? ZERO)
+      costAmount: unscaleAmount(perAgentCost.get(g.agentId) ?? 0n)
     }))
     // Sort by token spend so the console's "top agents" ordering is stable.
     agents.sort((a, b) => b.totalTokens - a.totalTokens)
@@ -421,7 +414,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       thoughtTokens: Number(g.thoughtTokens),
       cachedReadTokens: Number(g.cachedReadTokens),
       cachedWriteTokens: Number(g.cachedWriteTokens),
-      costAmount: amount(perModelCost.get(g.model ?? '') ?? ZERO)
+      costAmount: unscaleAmount(perModelCost.get(g.model ?? '') ?? 0n)
     }))
     models.sort((a, b) => b.totalTokens - a.totalTokens)
 
@@ -456,13 +449,13 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
 
     const series: SpendBucket[] = points.map((pt) => ({
       start: pt.start,
-      costAmount: amount(pt.costAmount),
+      costAmount: unscaleAmount(pt.costAmount),
       byAgent: amounts(pt.byAgent),
       byModel: amounts(pt.byModel)
     }))
 
     return {
-      totals: { ...totals, costAmount: amount(totalCost), costCurrency },
+      totals: { ...totals, costAmount: unscaleAmount(totalCost), costCurrency },
       agents,
       models,
       series: { bucket, points: series }

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -14,9 +14,14 @@
  * (a single session won't exceed 2^31), but Postgres `SUM(int)` returns `bigint`;
  * Prisma surfaces these `_sum` values as `number` (safe to 2^53), which is plenty
  * for workspace-wide token totals.
+ *
+ * COST is the exception to all of that: it is `NUMERIC(38,18)` and every diff and sum
+ * below runs on `Decimal`, never on a JS number. Billing reads these aggregates, so a
+ * float anywhere in the roll-up would be a rounding error in someone's invoice.
  */
 import type { PrismaLike } from '../prisma.js'
 import { Prisma } from '../../generated/prisma/client.js'
+import type { DecimalAmount } from '@agentconnect.md/protocol'
 import type {
   SessionUsageRepo,
   SessionUsageInput,
@@ -31,6 +36,30 @@ import type {
 import { visibilityWhere } from '../../authorization/policy.js'
 import type { AgentId, OrgId } from '../../domain/ids.js'
 import { sessionViewerSql } from './session-access-sql.js'
+
+const ZERO = new Prisma.Decimal(0)
+
+/** A bucket mid-accumulation: `Decimal` sums, keyed maps, serialized once at the end. */
+interface DecimalBucket {
+  start: string
+  costAmount: Prisma.Decimal
+  byAgent: Map<string, Prisma.Decimal>
+  byModel: Map<string, Prisma.Decimal>
+}
+
+/** `Decimal` → the exact decimal string the aggregate returns. `toFixed()` never
+ *  yields exponent notation; the trailing-zero trim is what makes it canonical.
+ *  A derived delta may be negative until the checkpoint merge fences it, so this
+ *  keeps a sign rather than refusing the value a reader would then never see. */
+function amount(value: Prisma.Decimal): DecimalAmount {
+  const text = value.toFixed()
+  return text.includes('.') ? text.replace(/0+$/, '').replace(/\.$/, '') : text
+}
+
+/** Serialize a keyed `Decimal` map for the response. */
+function amounts(by: Map<string, Prisma.Decimal>): Record<string, DecimalAmount> {
+  return Object.fromEntries([...by].map(([key, value]) => [key, amount(value)]))
+}
 
 function agentViewerSql(orgId: OrgId, viewer?: ViewCtx): Prisma.Sql {
   const visible = viewer
@@ -60,7 +89,9 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       cachedWriteTokens: u.cachedWriteTokens ?? 0,
       contextUsed: u.contextUsed ?? null,
       contextSize: u.contextSize ?? null,
-      costAmount: u.costAmount ?? 0,
+      // Already the canonical decimal string (the ingress adapter normalized it);
+      // it binds as text and Postgres casts it to the column's NUMERIC exactly.
+      costAmount: u.costAmount ?? '0',
       costCurrency: u.costCurrency ?? null
     }
     // Both writes select through `agent`, so an agent deleted between metering and
@@ -83,7 +114,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       SELECT ${input.agentId}::uuid, ${input.sessionId}::text, ${f.platform}::text, ${f.channel}::text, ${source},
              ${f.totalTokens}::int, ${f.inputTokens}::int, ${f.outputTokens}::int, ${f.thoughtTokens}::int,
              ${f.cachedReadTokens}::int, ${f.cachedWriteTokens}::int, ${f.contextUsed}::int, ${f.contextSize}::int,
-             ${f.costAmount}::double precision, ${f.costCurrency}::text, ${input.lastActivityAt}::timestamptz, NOW()
+             ${f.costAmount}::numeric, ${f.costCurrency}::text, ${input.lastActivityAt}::timestamptz, NOW()
       ${owner}
       ON CONFLICT ("agentId", "sessionId") DO UPDATE SET
         "platform" = EXCLUDED."platform",
@@ -118,7 +149,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
              ${input.model ?? null}::text, ${source},
              ${f.totalTokens}::int, ${f.inputTokens}::int, ${f.outputTokens}::int,
              ${f.thoughtTokens}::int, ${f.cachedReadTokens}::int, ${f.cachedWriteTokens}::int,
-             ${f.costAmount}::double precision
+             ${f.costAmount}::numeric
       ${owner}
       ON CONFLICT ("agentId", "sessionId", "at") DO UPDATE SET
         "model" = EXCLUDED."model",
@@ -148,7 +179,9 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       cachedWriteTokens: usage.cachedWriteTokens,
       ...(usage.contextUsed !== null ? { contextUsed: usage.contextUsed } : {}),
       ...(usage.contextSize !== null ? { contextSize: usage.contextSize } : {}),
-      ...(usage.costAmount !== 0 || usage.costCurrency ? { costAmount: usage.costAmount } : {}),
+      // The session views only DISPLAY this one, so it degrades to a number here
+      // rather than pushing the decimal string through every session read.
+      ...(!usage.costAmount.isZero() || usage.costCurrency ? { costAmount: usage.costAmount.toNumber() } : {}),
       ...(usage.costCurrency ? { costCurrency: usage.costCurrency } : {})
     }
   }
@@ -290,11 +323,12 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // Floor `since` to the start of its local bucket, expressed as a UTC instant.
     const floorSince = Math.floor((since.getTime() - offMs) / stepMs) * stepMs + offMs
     const n = Math.floor((now - floorSince) / stepMs) + 1
-    const points: SpendBucket[] = Array.from({ length: n }, (_, i) => ({
+    // Buckets accumulate in `Decimal` and are serialized once, at the end.
+    const points: DecimalBucket[] = Array.from({ length: n }, (_, i) => ({
       start: new Date(floorSince + i * stepMs).toISOString(),
-      costAmount: 0,
-      byAgent: {},
-      byModel: {}
+      costAmount: ZERO,
+      byAgent: new Map(),
+      byModel: new Map()
     }))
 
     // Spend timeline → range spend by DIFFING consecutive cumulatives per session.
@@ -312,7 +346,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     const SEP = '\0'
     const [inRange, baselineRows] = await Promise.all([
       this.db.$queryRaw<
-        Array<{ agentId: string; sessionId: string; at: Date; cumulativeCost: number; model: string | null }>
+        Array<{ agentId: string; sessionId: string; at: Date; cumulativeCost: Prisma.Decimal; model: string | null }>
       >(Prisma.sql`
         SELECT sp."agentId", sp."sessionId", sp."at", sp."cumulativeCost", NULLIF(sp."model", '') AS model
         FROM "session_spend" sp
@@ -323,7 +357,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
           AND ${sessionScope ?? Prisma.sql`TRUE`}
         ORDER BY sp."at" ASC
       `),
-      this.db.$queryRaw<Array<{ agentId: string; sessionId: string; cumulativeCost: number }>>(Prisma.sql`
+      this.db.$queryRaw<Array<{ agentId: string; sessionId: string; cumulativeCost: Prisma.Decimal }>>(Prisma.sql`
         SELECT DISTINCT ON (sp."agentId", sp."sessionId")
                sp."agentId", sp."sessionId", sp."cumulativeCost"
         FROM "session_spend" sp
@@ -337,27 +371,29 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     ])
     // Per-session running cumulative, seeded from the last pre-window report so the
     // first in-window delta counts only spend incurred inside the window.
-    const prevCost = new Map<string, number>(baselineRows.map((r) => [r.agentId + SEP + r.sessionId, r.cumulativeCost]))
-    const perAgentCost = new Map<string, number>()
-    const perModelCost = new Map<string, number>()
-    let totalCost = 0
+    const prevCost = new Map<string, Prisma.Decimal>(
+      baselineRows.map((r) => [r.agentId + SEP + r.sessionId, r.cumulativeCost])
+    )
+    const perAgentCost = new Map<string, Prisma.Decimal>()
+    const perModelCost = new Map<string, Prisma.Decimal>()
+    let totalCost = ZERO
     // `inRange` is globally at-ascending, so each session's rows are visited in
     // chronological order — exactly what the running diff needs.
     for (const row of inRange) {
       const skey = row.agentId + SEP + row.sessionId
-      const delta = row.cumulativeCost - (prevCost.get(skey) ?? 0)
+      const delta = row.cumulativeCost.minus(prevCost.get(skey) ?? ZERO)
       prevCost.set(skey, row.cumulativeCost)
-      totalCost += delta
-      perAgentCost.set(row.agentId, (perAgentCost.get(row.agentId) ?? 0) + delta)
+      totalCost = totalCost.plus(delta)
+      perAgentCost.set(row.agentId, (perAgentCost.get(row.agentId) ?? ZERO).plus(delta))
       const modelKey = row.model ?? ''
-      perModelCost.set(modelKey, (perModelCost.get(modelKey) ?? 0) + delta)
+      perModelCost.set(modelKey, (perModelCost.get(modelKey) ?? ZERO).plus(delta))
       const idx = Math.floor((row.at.getTime() - floorSince) / stepMs)
       if (idx >= 0 && idx < n) {
         const pt = points[idx]!
-        pt.costAmount += delta
-        if (delta !== 0) {
-          pt.byAgent[row.agentId] = (pt.byAgent[row.agentId] ?? 0) + delta
-          pt.byModel[modelKey] = (pt.byModel[modelKey] ?? 0) + delta
+        pt.costAmount = pt.costAmount.plus(delta)
+        if (!delta.isZero()) {
+          pt.byAgent.set(row.agentId, (pt.byAgent.get(row.agentId) ?? ZERO).plus(delta))
+          pt.byModel.set(modelKey, (pt.byModel.get(modelKey) ?? ZERO).plus(delta))
         }
       }
     }
@@ -371,7 +407,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       thoughtTokens: Number(g.thoughtTokens),
       cachedReadTokens: Number(g.cachedReadTokens),
       cachedWriteTokens: Number(g.cachedWriteTokens),
-      costAmount: perAgentCost.get(g.agentId) ?? 0
+      costAmount: amount(perAgentCost.get(g.agentId) ?? ZERO)
     }))
     // Sort by token spend so the console's "top agents" ordering is stable.
     agents.sort((a, b) => b.totalTokens - a.totalTokens)
@@ -385,7 +421,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       thoughtTokens: Number(g.thoughtTokens),
       cachedReadTokens: Number(g.cachedReadTokens),
       cachedWriteTokens: Number(g.cachedWriteTokens),
-      costAmount: perModelCost.get(g.model ?? '') ?? 0
+      costAmount: amount(perModelCost.get(g.model ?? '') ?? ZERO)
     }))
     models.sort((a, b) => b.totalTokens - a.totalTokens)
 
@@ -418,6 +454,18 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
         })
     const costCurrency = currencies.length === 1 ? currencies[0]!.costCurrency : null
 
-    return { totals: { ...totals, costAmount: totalCost, costCurrency }, agents, models, series: { bucket, points } }
+    const series: SpendBucket[] = points.map((pt) => ({
+      start: pt.start,
+      costAmount: amount(pt.costAmount),
+      byAgent: amounts(pt.byAgent),
+      byModel: amounts(pt.byModel)
+    }))
+
+    return {
+      totals: { ...totals, costAmount: amount(totalCost), costCurrency },
+      agents,
+      models,
+      series: { bucket, points: series }
+    }
   }
 }

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -134,7 +134,7 @@ function usageCounts(u: {
   cachedWriteTokens: number
   contextUsed: number | null
   contextSize: number | null
-  costAmount: number
+  costAmount: Prisma.Decimal // NUMERIC(38,18) — the session views only display it
   costCurrency: string | null
 }): SessionUsageCounts {
   return {
@@ -147,7 +147,7 @@ function usageCounts(u: {
     cachedWriteTokens: u.cachedWriteTokens,
     ...(u.contextUsed !== null ? { contextUsed: u.contextUsed } : {}),
     ...(u.contextSize !== null ? { contextSize: u.contextSize } : {}),
-    ...(u.costAmount !== 0 || u.costCurrency ? { costAmount: u.costAmount } : {}),
+    ...(!u.costAmount.isZero() || u.costCurrency ? { costAmount: u.costAmount.toNumber() } : {}),
     ...(u.costCurrency ? { costCurrency: u.costCurrency } : {})
   }
 }

--- a/packages/control-plane/src/usage/writer.ts
+++ b/packages/control-plane/src/usage/writer.ts
@@ -11,13 +11,20 @@
  * delta. Storage stays cumulative too (`SessionUsage` snapshot + `SessionSpend`
  * checkpoint), so a duplicate delivery is an idempotent no-op and range readers
  * derive spend by diffing consecutive checkpoints.
+ *
+ * Money is the one field the two adapters see differently. A report may carry
+ * `costAmount` as the exact decimal string OR — from any daemon shipped so far — as a
+ * JSON number, so an adapter NORMALIZES to the decimal string before it gets here.
+ * The writer itself only accepts the normalized shape: the money path below it has no
+ * float in it, and no future caller can add one back without changing this type.
  */
+import { type DecimalAmount, normalizeReportedCostAmount } from '@agentconnect.md/protocol'
 import { AgentId } from '../domain/ids.js'
 import type { SessionUsageRepo, UsageSource } from '../persistence/ports.js'
 
 export type { UsageSource }
 
-/** One session's cumulative usage snapshot, shared by both ingress adapters. */
+/** One session's cumulative usage snapshot as REPORTED — the shared wire payload. */
 export interface SessionUsageReport {
   sessionId: string // ACP session id (agent-assigned; NOT a wire UUID)
   agentId: string
@@ -35,21 +42,40 @@ export interface SessionUsageReport {
     cachedWriteTokens?: number
     contextUsed?: number
     contextSize?: number
-    costAmount?: number
+    costAmount?: number | DecimalAmount
     costCurrency?: string
   }
 }
 
+/** The same report with its cost normalized — what an adapter hands the writer. */
+export type NormalizedSessionUsageReport = Omit<SessionUsageReport, 'usage'> & {
+  usage: Omit<SessionUsageReport['usage'], 'costAmount'> & { costAmount?: DecimalAmount }
+}
+
+/**
+ * Normalize a reported cost to the canonical decimal string.
+ *
+ * An unusable amount (negative, non-finite, out of the column's range, or a malformed
+ * string) drops the cost and KEEPS the token counts: cost is best-effort telemetry on
+ * the daemon path, and losing a session's token history over a bad price is worse than
+ * losing the price. The gateway path does not use this leniency — it refuses the batch.
+ */
+export function normalizeUsageReport(report: SessionUsageReport): NormalizedSessionUsageReport {
+  const { costAmount, ...rest } = report.usage
+  const normalized = costAmount === undefined ? undefined : (normalizeReportedCostAmount(costAmount) ?? undefined)
+  return { ...report, usage: { ...rest, ...(normalized !== undefined ? { costAmount: normalized } : {}) } }
+}
+
 export interface UsageWriter {
-  record(source: UsageSource, report: SessionUsageReport): Promise<void>
-  recordBatch(source: UsageSource, reports: readonly SessionUsageReport[]): Promise<void>
+  record(source: UsageSource, report: NormalizedSessionUsageReport): Promise<void>
+  recordBatch(source: UsageSource, reports: readonly NormalizedSessionUsageReport[]): Promise<void>
 }
 
 /** The `UsageWriter` over the CP's own usage store. */
 export class SessionUsageWriter implements UsageWriter {
   constructor(private readonly usage: SessionUsageRepo) {}
 
-  async record(source: UsageSource, report: SessionUsageReport): Promise<void> {
+  async record(source: UsageSource, report: NormalizedSessionUsageReport): Promise<void> {
     await this.usage.record({
       sessionId: report.sessionId,
       agentId: AgentId(report.agentId),
@@ -66,7 +92,7 @@ export class SessionUsageWriter implements UsageWriter {
    *  and writing serially keeps a large batch from monopolizing the connection pool.
    *  Each write is independently idempotent, so a caller that retries the whole batch
    *  after a mid-batch failure re-applies the landed prefix harmlessly. */
-  async recordBatch(source: UsageSource, reports: readonly SessionUsageReport[]): Promise<void> {
+  async recordBatch(source: UsageSource, reports: readonly NormalizedSessionUsageReport[]): Promise<void> {
     for (const report of reports) await this.record(source, report)
   }
 }

--- a/packages/control-plane/src/ws/handlers/usage-report.ts
+++ b/packages/control-plane/src/ws/handlers/usage-report.ts
@@ -8,9 +8,15 @@
  * aggregate real usage over time. Token counts + cost are metadata, never the message
  * stream (which stays daemon-local, §1/§12).
  * Reports are accepted only for agents currently placed on the authenticated daemon.
+ *
+ * A daemon reports `costAmount` as a JSON number (or, once it is taught to, as the
+ * exact decimal string); either way this adapter normalizes before the writer, so the
+ * float stops at the edge. An amount that cannot be normalized is dropped rather than
+ * refused — token history is worth more than one unusable price.
  */
 import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId } from '../../domain/ids.js'
+import { normalizeUsageReport } from '../../usage/writer.js'
 import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 import { runForReportingAgent } from './reporting-agent.js'
@@ -21,7 +27,11 @@ export const handleUsageReport: Handler = async (frame, conn, deps) => {
   if (!orgId) return
   const p = frame.payload
   const agentId = AgentId(p.agentId)
+  const report = normalizeUsageReport(p)
+  if (p.usage.costAmount !== undefined && report.usage.costAmount === undefined) {
+    deps.log.error({ agentId: p.agentId, sessionId: p.sessionId }, 'usage/report: unusable cost amount, dropped')
+  }
   await runForReportingAgent(orgId, agentId, DaemonId(conn.daemonId), deps, async () => {
-    await deps.usageWriter.record('daemon', p)
+    await deps.usageWriter.record('daemon', report)
   })
 }

--- a/packages/control-plane/test/integration/usage-report-ingress.test.ts
+++ b/packages/control-plane/test/integration/usage-report-ingress.test.ts
@@ -24,7 +24,7 @@ const AGENT_A = '11111111-1111-4111-8111-111111111111'
 const GONE = '99999999-9999-4999-8999-999999999999'
 const URL = '/api/v1/internal/usage/reports'
 
-function report(sessionId: string, agentId: string, costAmount: number, at: Date) {
+function report(sessionId: string, agentId: string, costAmount: string, at: Date) {
   return {
     sessionId,
     agentId,
@@ -82,7 +82,7 @@ describe('POST /internal/usage/reports — the gateway-source usage adapter', ()
         method: 'POST',
         url: URL,
         headers: { authorization: `Bearer ${TOKEN}` },
-        payload: { reports: [report('s-unconfigured', AGENT_A, 1, new Date())] }
+        payload: { reports: [report('s-unconfigured', AGENT_A, '1', new Date())] }
       })
       // 404, not 401: an unconfigured deployment exposes no surface to probe.
       expect(res.statusCode).toBe(404)
@@ -92,7 +92,7 @@ describe('POST /internal/usage/reports — the gateway-source usage adapter', ()
   it('refuses a missing, malformed, or wrong bearer without touching the store', async () => {
     await seedAgent(prisma, AGENT_A)
     await withApp(true, async (app) => {
-      const payload = { reports: [report('s-unauthorized', AGENT_A, 1, new Date())] }
+      const payload = { reports: [report('s-unauthorized', AGENT_A, '1', new Date())] }
       for (const headers of [
         {},
         { authorization: TOKEN }, // no scheme
@@ -111,7 +111,7 @@ describe('POST /internal/usage/reports — the gateway-source usage adapter', ()
     await seedAgent(prisma, AGENT_A)
     const at = new Date()
     const payload = {
-      reports: [report('s-one', AGENT_A, 1.25, at), report('s-two', AGENT_A, 2.5, at)]
+      reports: [report('s-one', AGENT_A, '1.25', at), report('s-two', AGENT_A, '2.5', at)]
     }
     await withApp(true, async (app) => {
       for (const _attempt of [1, 2]) {
@@ -129,15 +129,46 @@ describe('POST /internal/usage/reports — the gateway-source usage adapter', ()
       where: { agentId: AGENT_A },
       orderBy: { sessionId: 'asc' }
     })
-    expect(snapshots.map((row) => [row.sessionId, row.source, row.costAmount])).toEqual([
-      ['s-one', 'gateway', 1.25],
-      ['s-two', 'gateway', 2.5]
+    // The reported decimal string is what landed — NUMERIC, not a float that read back
+    // as 1.2500000000000002.
+    expect(snapshots.map((row) => [row.sessionId, row.source, row.costAmount.toFixed(2)])).toEqual([
+      ['s-one', 'gateway', '1.25'],
+      ['s-two', 'gateway', '2.50']
     ])
     // Cumulative upserts: the second delivery converges onto the same checkpoints
     // rather than appending a second one per session.
     const checkpoints = await prisma.sessionSpend.findMany({ where: { agentId: AGENT_A } })
     expect(checkpoints).toHaveLength(2)
     expect(checkpoints.every((row) => row.source === 'gateway')).toBe(true)
+  })
+
+  it('refuses the WHOLE batch when a billable amount is a float, out of range, or absent', async () => {
+    await seedAgent(prisma, AGENT_A)
+    const at = new Date()
+    const good = report('s-good', AGENT_A, '1', at)
+    const bad: Array<[string, unknown]> = [
+      // A JSON number is the shape that would put a float on the money path.
+      ['a JSON number', { ...report('s-float', AGENT_A, '1', at), usage: { totalTokens: 1, costAmount: 1.25 } }],
+      ['exponent notation', report('s-exp', AGENT_A, '1.25e-2', at)],
+      ['a negative amount', report('s-negative', AGENT_A, '-1', at)],
+      ['more than 18 decimals', report('s-scale', AGENT_A, '0.0000000000000000001', at)],
+      // Absent must never be read as zero spend — the caller retries once it knows.
+      ['no amount', { ...report('s-missing', AGENT_A, '1', at), usage: { totalTokens: 1, costCurrency: 'USD' } }],
+      ['no currency', { ...report('s-nocur', AGENT_A, '1', at), usage: { totalTokens: 1, costAmount: '1' } }]
+    ]
+    await withApp(true, async (app) => {
+      for (const [what, offender] of bad) {
+        const res = await app.inject({
+          method: 'POST',
+          url: URL,
+          headers: { authorization: `Bearer ${TOKEN}` },
+          payload: { reports: [good, offender] }
+        })
+        expect(res.statusCode, what).toBe(400)
+      }
+    })
+    // Not one row: the valid sibling of a refused report is not written either.
+    expect(await prisma.sessionUsage.count({ where: { agentId: AGENT_A } })).toBe(0)
   })
 
   it('drops a report for an agent that no longer exists and still accepts the batch', async () => {
@@ -148,7 +179,7 @@ describe('POST /internal/usage/reports — the gateway-source usage adapter', ()
         url: URL,
         headers: { authorization: `Bearer ${TOKEN}` },
         payload: {
-          reports: [report('s-gone', GONE, 9, new Date()), report('s-live', AGENT_A, 3, new Date())]
+          reports: [report('s-gone', GONE, '9', new Date()), report('s-live', AGENT_A, '3', new Date())]
         }
       })
       // 204, not 500: a deleted agent must not wedge the caller in a retry loop.
@@ -166,7 +197,7 @@ describe('POST /internal/usage/reports — the gateway-source usage adapter', ()
         method: 'POST',
         url: URL,
         headers: { authorization: `Bearer ${PROJECTED}` },
-        payload: { reports: [report('s-projected', AGENT_A, 4, new Date())] }
+        payload: { reports: [report('s-projected', AGENT_A, '4', new Date())] }
       })
       expect(res.statusCode).toBe(204)
     })
@@ -185,7 +216,7 @@ describe('POST /internal/usage/reports — the gateway-source usage adapter', ()
         method: 'POST',
         url: URL,
         headers: { authorization: 'Bearer some-other-pods-token' },
-        payload: { reports: [report('s-rejected', AGENT_A, 1, new Date())] }
+        payload: { reports: [report('s-rejected', AGENT_A, '1', new Date())] }
       })
       expect(res.statusCode).toBe(401)
     })
@@ -200,7 +231,7 @@ describe('POST /internal/usage/reports — the gateway-source usage adapter', ()
         method: 'POST',
         url: URL,
         headers: { authorization: `Bearer ${PROJECTED}` },
-        payload: { reports: [report('s-outage', AGENT_A, 1, new Date())] }
+        payload: { reports: [report('s-outage', AGENT_A, '1', new Date())] }
       })
       expect(res.statusCode).toBe(503)
     })
@@ -215,7 +246,7 @@ describe('POST /internal/usage/reports — the gateway-source usage adapter', ()
           method: 'POST',
           url: URL,
           headers: { authorization: `Bearer ${credential}` },
-          payload: { reports: [report('s-both', AGENT_A, 1, new Date())] }
+          payload: { reports: [report('s-both', AGENT_A, '1', new Date())] }
         })
         expect(res.statusCode).toBe(204)
       }
@@ -243,7 +274,7 @@ describe('the shared store semantics both adapters get', () => {
     const repo = new PgSessionUsageRepo(prisma)
     const early = new Date(Date.now() - 60_000)
     const late = new Date()
-    const write = (at: Date, costAmount: number, totalTokens: number) =>
+    const write = (at: Date, costAmount: string, totalTokens: number) =>
       repo.record({
         agentId: AgentId(AGENT_A),
         sessionId: 'late',
@@ -252,13 +283,13 @@ describe('the shared store semantics both adapters get', () => {
         usage: { totalTokens, costAmount, costCurrency: 'USD' }
       })
 
-    await write(late, 5, 500)
-    await write(early, 2, 200) // an out-of-order delivery arriving after a newer one
+    await write(late, '5', 500)
+    await write(early, '2', 200) // an out-of-order delivery arriving after a newer one
 
     const snapshot = await prisma.sessionUsage.findUnique({
       where: { agentId_sessionId: { agentId: AGENT_A, sessionId: 'late' } }
     })
-    expect(snapshot!.costAmount).toBeCloseTo(5)
+    expect(snapshot!.costAmount.toFixed(0)).toBe('5')
     expect(snapshot!.totalTokens).toBe(500)
     expect(snapshot!.lastActivityAt.getTime()).toBe(late.getTime())
     // The timeline still keeps both cumulatives, so a range query can diff them.
@@ -266,7 +297,7 @@ describe('the shared store semantics both adapters get', () => {
       where: { agentId: AGENT_A, sessionId: 'late' },
       orderBy: { at: 'asc' }
     })
-    expect(checkpoints.map((row) => row.cumulativeCost)).toEqual([2, 5])
+    expect(checkpoints.map((row) => row.cumulativeCost.toFixed(0))).toEqual(['2', '5'])
   })
 
   it('re-applies an unchanged snapshot idempotently rather than skipping it', async () => {
@@ -278,7 +309,7 @@ describe('the shared store semantics both adapters get', () => {
       sessionId: 'replay',
       source: 'gateway' as const,
       lastActivityAt: at,
-      usage: { totalTokens: 10, costAmount: 0.5, costCurrency: 'USD' }
+      usage: { totalTokens: 10, costAmount: '0.5', costCurrency: 'USD' }
     }
     await repo.record(input)
     await repo.record({ ...input, usage: { ...input.usage, totalTokens: 20 } })

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -8,22 +8,19 @@
  *    excluding sessions whose last activity falls outside the range.
  */
 import { describe, it, expect, vi } from 'vitest'
-import { canonicalizeDecimalAmount } from '@agentconnect.md/protocol'
+import { sumAmounts } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { buildWsHarness } from '../fakes/build-ws.js'
 import { buildHttpApp } from '../fakes/build-http.js'
 import { seedAgent, seedSessionMeta } from '../fixtures/seed.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
-import { Prisma } from '../../src/generated/prisma/client.js'
 import { PgSessionUsageRepo } from '../../src/persistence/repositories/session-usage.repo.js'
 import { AgentId } from '../../src/domain/ids.js'
 
-/** Sum the series' decimal-string amounts exactly. Every cost the API returns is a
- *  decimal string, so a test that re-added them as floats would drift where the
- *  aggregate does not — 0.1 + 0.2 + 0.05 is exactly 0.35 here, not 0.35000000000000003. */
-function sum(points: Array<{ costAmount: string }>): string | null {
-  const total = points.reduce((acc, p) => acc.plus(p.costAmount), new Prisma.Decimal(0))
-  return canonicalizeDecimalAmount(total.toFixed())
+/** Sum the series' decimal-string amounts exactly — the same primitive the aggregate
+ *  itself adds with, so the test cannot drift where the implementation does not. */
+function sum(points: Array<{ costAmount: string }>): string {
+  return sumAmounts(points.map((p) => p.costAmount))
 }
 
 // Console routes are org-scoped: /orgs/:orgId/… (devAuth = seeded owner of the default org).
@@ -528,6 +525,44 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
       expect(body.totals.costAmount).toBe('2.5')
       expect(body.agents.find((a) => a.agentId === AGENT_A)!.costAmount).toBe('2.5')
       expect(sum(body.series.points)).toBe('2.5')
+    } finally {
+      await close()
+    }
+  })
+
+  it('serves an amount at the column’s full precision without rounding a digit', async () => {
+    await seedAgent(prisma, AGENT_A)
+    const repo = new PgSessionUsageRepo(prisma)
+    const at = new Date(Date.now() - 60_000)
+    await seedVisibleSession(AGENT_A, 'wide', at)
+    // 18 fractional digits on a 3-digit integer part — 21 significant, one past what a
+    // 20-significant-digit decimal library keeps. Diffing this against a zero baseline
+    // is where the aggregate used to round it to …34568.
+    const exact = '123.123456789012345678'
+    await repo.record({
+      agentId: AgentId(AGENT_A),
+      sessionId: 'wide',
+      source: 'gateway',
+      lastActivityAt: at,
+      usage: { costAmount: exact, costCurrency: 'USD' }
+    })
+
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d1` })
+      const body = res.json() as {
+        totals: { costAmount: string }
+        agents: { agentId: string; costAmount: string }[]
+        series: { points: { costAmount: string }[] }
+      }
+      expect(body.totals.costAmount).toBe(exact)
+      expect(body.agents.find((a) => a.agentId === AGENT_A)!.costAmount).toBe(exact)
+      expect(sum(body.series.points)).toBe(exact)
+      // And it survived storage at full width, not just the roll-up.
+      const row = await prisma.sessionUsage.findUnique({
+        where: { agentId_sessionId: { agentId: AGENT_A, sessionId: 'wide' } }
+      })
+      expect(row!.costAmount.toFixed()).toBe(exact)
     } finally {
       await close()
     }

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -8,13 +8,23 @@
  *    excluding sessions whose last activity falls outside the range.
  */
 import { describe, it, expect, vi } from 'vitest'
+import { canonicalizeDecimalAmount } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { buildWsHarness } from '../fakes/build-ws.js'
 import { buildHttpApp } from '../fakes/build-http.js'
 import { seedAgent, seedSessionMeta } from '../fixtures/seed.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { Prisma } from '../../src/generated/prisma/client.js'
 import { PgSessionUsageRepo } from '../../src/persistence/repositories/session-usage.repo.js'
 import { AgentId } from '../../src/domain/ids.js'
+
+/** Sum the series' decimal-string amounts exactly. Every cost the API returns is a
+ *  decimal string, so a test that re-added them as floats would drift where the
+ *  aggregate does not — 0.1 + 0.2 + 0.05 is exactly 0.35 here, not 0.35000000000000003. */
+function sum(points: Array<{ costAmount: string }>): string | null {
+  const total = points.reduce((acc, p) => acc.plus(p.costAmount), new Prisma.Decimal(0))
+  return canonicalizeDecimalAmount(total.toFixed())
+}
 
 // Console routes are org-scoped: /orgs/:orgId/… (devAuth = seeded owner of the default org).
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -85,7 +95,7 @@ describe('usage/report handler — persists per-session token usage', () => {
     expect(row!.totalTokens).toBe(4820)
     expect(row!.inputTokens).toBe(3600)
     expect(row!.cachedReadTokens).toBe(512)
-    expect(row!.costAmount).toBeCloseTo(0.41)
+    expect(row!.costAmount.toFixed(2)).toBe('0.41')
     // The source is stamped from the authenticated adapter, not the payload.
     expect(row!.source).toBe('daemon')
     expect(await prisma.sessionSpend.findFirst({ where: { agentId: AGENT_A, sessionId: 'acp-sess-1' } })).toMatchObject(
@@ -141,13 +151,13 @@ describe('usage/report handler — persists per-session token usage', () => {
     try {
       const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d30` })
       expect(res.statusCode).toBe(200)
-      const body = res.json() as { series: { points: { costAmount: number }[] } }
+      const body = res.json() as { series: { points: { costAmount: string }[] } }
       const points = body.series.points
       // The regression: $1 stays in yesterday's bucket and $1 in today's. The old
       // latest-wins snapshot would show $0 yesterday and the full $2 today.
-      expect(points.at(-2)!.costAmount).toBeCloseTo(1)
-      expect(points.at(-1)!.costAmount).toBeCloseTo(1)
-      expect(points.reduce((s, p) => s + p.costAmount, 0)).toBeCloseTo(2)
+      expect(points.at(-2)!.costAmount).toBe('1')
+      expect(points.at(-1)!.costAmount).toBe('1')
+      expect(sum(points)).toBe('2')
     } finally {
       await close()
     }
@@ -184,7 +194,7 @@ describe('usage/report handler — persists per-session token usage', () => {
       expect(res.statusCode).toBe(200)
       const models = (
         res.json() as {
-          models: Array<{ model: string | null; sessions: number; totalTokens: number; costAmount: number }>
+          models: Array<{ model: string | null; sessions: number; totalTokens: number; costAmount: string }>
         }
       ).models
       expect(models).toEqual([
@@ -197,7 +207,7 @@ describe('usage/report handler — persists per-session token usage', () => {
           thoughtTokens: 0,
           cachedReadTokens: 0,
           cachedWriteTokens: 0,
-          costAmount: 1.5
+          costAmount: '1.5'
         },
         {
           model: 'model-a',
@@ -208,7 +218,7 @@ describe('usage/report handler — persists per-session token usage', () => {
           thoughtTokens: 0,
           cachedReadTokens: 0,
           cachedWriteTokens: 0,
-          costAmount: 1
+          costAmount: '1'
         },
         {
           model: null,
@@ -219,7 +229,7 @@ describe('usage/report handler — persists per-session token usage', () => {
           thoughtTokens: 0,
           cachedReadTokens: 0,
           cachedWriteTokens: 0,
-          costAmount: 0.5
+          costAmount: '0.5'
         }
       ])
     } finally {
@@ -367,10 +377,10 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
       expect(res.statusCode).toBe(200)
       const body = res.json() as {
         range: string
-        totals: { sessions: number; totalTokens: number; costAmount: number; costCurrency: string | null }
-        agents: { agentId: string; sessions: number; totalTokens: number; costAmount: number }[]
-        models: { model: string | null; sessions: number; totalTokens: number; costAmount: number }[]
-        series: { bucket: 'hour' | 'day'; points: { start: string; costAmount: number }[] }
+        totals: { sessions: number; totalTokens: number; costAmount: string; costCurrency: string | null }
+        agents: { agentId: string; sessions: number; totalTokens: number; costAmount: string }[]
+        models: { model: string | null; sessions: number; totalTokens: number; costAmount: string }[]
+        series: { bucket: 'hour' | 'day'; points: { start: string; costAmount: string }[] }
       }
 
       expect(body.range).toBe('d30')
@@ -380,21 +390,19 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
       // 100-day row is out of window → excluded. So the series sums to 0.35.
       expect(body.series.bucket).toBe('day')
       expect(body.series.points.length).toBeGreaterThanOrEqual(30)
-      const seriesTotal = body.series.points.reduce((s, p) => s + p.costAmount, 0)
-      expect(seriesTotal).toBeCloseTo(0.35)
-      expect(body.series.points.at(-1)!.costAmount).toBeCloseTo(0.35)
+      expect(sum(body.series.points)).toBe('0.35')
+      expect(body.series.points.at(-1)!.costAmount).toBe('0.35')
 
       // A local-tz offset only shifts bucket boundaries — it must never drop or
       // double-count cost. Across extreme offsets the series still sums to 0.35.
       for (const tz of [-720, 780]) {
         const r = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d30&tz=${tz}` })
-        const s = (r.json() as typeof body).series.points.reduce((acc, p) => acc + p.costAmount, 0)
-        expect(s).toBeCloseTo(0.35)
+        expect(sum((r.json() as typeof body).series.points)).toBe('0.35')
       }
       // Stale a-old row excluded: 3 in-range sessions, 3500 tokens.
       expect(body.totals.sessions).toBe(3)
       expect(body.totals.totalTokens).toBe(3500)
-      expect(body.totals.costAmount).toBeCloseTo(0.35)
+      expect(body.totals.costAmount).toBe('0.35')
       // Single distinct non-null currency across the range → surfaced (the stale
       // row has no currency and is out of window anyway).
       expect(body.totals.costCurrency).toBe('USD')
@@ -414,8 +422,8 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
         { model: 'claude-sonnet-4-5', sessions: 2, totalTokens: 3000 },
         { model: 'gpt-5.6', sessions: 1, totalTokens: 500 }
       ])
-      expect(body.models[0]!.costAmount).toBeCloseTo(0.3)
-      expect(body.models[1]!.costAmount).toBeCloseTo(0.05)
+      expect(body.models[0]!.costAmount).toBe('0.3')
+      expect(body.models[1]!.costAmount).toBe('0.05')
     } finally {
       await close()
     }
@@ -464,7 +472,7 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
       sessionId: 'dup',
       source: 'daemon' as const,
       lastActivityAt: at,
-      usage: { totalTokens: 100, costAmount: 1, costCurrency: 'USD' }
+      usage: { totalTokens: 100, costAmount: '1', costCurrency: 'USD' }
     }
     // Three identical cumulative $1 reports raced together — the old derive-delta
     // write appended one row each ($3); the cumulative upsert on (agent, session,
@@ -476,11 +484,11 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     try {
       const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d1` })
       const body = res.json() as {
-        totals: { costAmount: number }
-        series: { points: { costAmount: number }[] }
+        totals: { costAmount: string }
+        series: { points: { costAmount: string }[] }
       }
-      expect(body.totals.costAmount).toBeCloseTo(1) // not 3
-      expect(body.series.points.reduce((s, p) => s + p.costAmount, 0)).toBeCloseTo(1)
+      expect(body.totals.costAmount).toBe('1') // not 3
+      expect(sum(body.series.points)).toBe('1')
     } finally {
       await close()
     }
@@ -493,10 +501,10 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     await seedVisibleSession(AGENT_A, 'corr', min(10))
     // Same session, in report order: $1 → $2 → corrected down to $1.5 → $2.5.
     for (const [m, cost] of [
-      [40, 1],
-      [30, 2],
-      [20, 1.5],
-      [10, 2.5]
+      [40, '1'],
+      [30, '2'],
+      [20, '1.5'],
+      [10, '2.5']
     ] as const) {
       await repo.record({
         agentId: AgentId(AGENT_A),
@@ -511,15 +519,15 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     try {
       const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d1` })
       const body = res.json() as {
-        totals: { costAmount: number }
-        agents: { agentId: string; costAmount: number }[]
-        series: { points: { costAmount: number }[] }
+        totals: { costAmount: string }
+        agents: { agentId: string; costAmount: string }[]
+        series: { points: { costAmount: string }[] }
       }
       // Deltas 1, +1, −0.5, +1 net to the final cumulative 2.5 — not 7 (summing
       // reports) and not 5.5 (ignoring the correction).
-      expect(body.totals.costAmount).toBeCloseTo(2.5)
-      expect(body.agents.find((a) => a.agentId === AGENT_A)!.costAmount).toBeCloseTo(2.5)
-      expect(body.series.points.reduce((s, p) => s + p.costAmount, 0)).toBeCloseTo(2.5)
+      expect(body.totals.costAmount).toBe('2.5')
+      expect(body.agents.find((a) => a.agentId === AGENT_A)!.costAmount).toBe('2.5')
+      expect(sum(body.series.points)).toBe('2.5')
     } finally {
       await close()
     }
@@ -536,29 +544,29 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
       sessionId: 'span-win',
       source: 'daemon',
       lastActivityAt: new Date(now - 40 * DAY_MS),
-      usage: { costAmount: 10, costCurrency: 'USD' }
+      usage: { costAmount: '10', costCurrency: 'USD' }
     })
     await repo.record({
       agentId: AgentId(AGENT_A),
       sessionId: 'span-win',
       source: 'daemon',
       lastActivityAt: new Date(now - 5 * 60_000),
-      usage: { costAmount: 11, costCurrency: 'USD' }
+      usage: { costAmount: '11', costCurrency: 'USD' }
     })
 
     const { app, close } = buildHttpApp(prisma)
     try {
       const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d30` })
       const body = res.json() as {
-        totals: { costAmount: number }
-        agents: { agentId: string; costAmount: number }[]
-        series: { points: { costAmount: number }[] }
+        totals: { costAmount: string }
+        agents: { agentId: string; costAmount: string }[]
+        series: { points: { costAmount: string }[] }
       }
       // Only the $1 incurred inside the window — the $10 baseline is excluded, and
       // the card, the agent row, and the chart all agree (never $11).
-      expect(body.totals.costAmount).toBeCloseTo(1)
-      expect(body.agents.find((a) => a.agentId === AGENT_A)!.costAmount).toBeCloseTo(1)
-      expect(body.series.points.reduce((s, p) => s + p.costAmount, 0)).toBeCloseTo(1)
+      expect(body.totals.costAmount).toBe('1')
+      expect(body.agents.find((a) => a.agentId === AGENT_A)!.costAmount).toBe('1')
+      expect(sum(body.series.points)).toBe('1')
     } finally {
       await close()
     }

--- a/packages/protocol/src/decimal-amount.test.ts
+++ b/packages/protocol/src/decimal-amount.test.ts
@@ -4,7 +4,10 @@ import {
   ReportedCostAmount,
   canonicalizeDecimalAmount,
   decimalAmountFromNumber,
-  normalizeReportedCostAmount
+  normalizeReportedCostAmount,
+  scaleAmount,
+  sumAmounts,
+  unscaleAmount
 } from './decimal-amount.js'
 
 describe('canonicalizeDecimalAmount', () => {
@@ -85,6 +88,49 @@ describe('normalizeReportedCostAmount', () => {
   it('accepts both reported shapes and yields one', () => {
     expect(normalizeReportedCostAmount(12.5)).toBe('12.5')
     expect(normalizeReportedCostAmount('12.50')).toBe('12.5')
+  })
+})
+
+describe('exact arithmetic', () => {
+  it('round-trips the full width of the column through the scaled form', () => {
+    // 20 integer + 18 fractional digits — 38 significant, past what a
+    // 20-significant-digit decimal library would keep through one operation.
+    const widest = '99999999999999999999.999999999999999999'
+    expect(unscaleAmount(scaleAmount(widest))).toBe(widest)
+  })
+
+  it('adds a full-scale amount without dropping a digit', () => {
+    // The regression: a decimal library rounds `123.123456789012345678` to
+    // `123.12345678901234568` the moment it is added to zero.
+    expect(sumAmounts(['123.123456789012345678', '0'])).toBe('123.123456789012345678')
+    expect(sumAmounts(['123.123456789012345678', '0.000000000000000002'])).toBe('123.12345678901234568')
+  })
+
+  it('adds without the drift a float sum would show', () => {
+    expect(sumAmounts(['0.1', '0.2'])).toBe('0.3') // 0.30000000000000004 as numbers
+    expect(sumAmounts(['0.1', '0.2', '0.05'])).toBe('0.35')
+  })
+
+  it('keeps sub-cent precision across many rows', () => {
+    expect(sumAmounts(Array.from({ length: 1000 }, () => '0.000000000000000001'))).toBe('0.000000000000001')
+  })
+
+  it.each([
+    [[], '0'],
+    [['0'], '0'],
+    [['12.50', '0.50'], '13'],
+    [['1', '-0.5'], '0.5'], // a netted downward correction
+    [['99999999999999999999', '1'], '100000000000000000000']
+  ])('sums %j to %j', (amounts, expected) => {
+    expect(sumAmounts(amounts)).toBe(expected)
+  })
+
+  it('signs a negative result, which a subtraction can produce', () => {
+    expect(unscaleAmount(-scaleAmount('0.25'))).toBe('-0.25')
+  })
+
+  it('ignores an unscalable amount instead of poisoning the total', () => {
+    expect(sumAmounts(['1.5', 'oops', ''])).toBe('1.5')
   })
 })
 

--- a/packages/protocol/src/decimal-amount.test.ts
+++ b/packages/protocol/src/decimal-amount.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DecimalAmount,
+  ReportedCostAmount,
+  canonicalizeDecimalAmount,
+  decimalAmountFromNumber,
+  normalizeReportedCostAmount
+} from './decimal-amount.js'
+
+describe('canonicalizeDecimalAmount', () => {
+  it.each([
+    ['0', '0'],
+    ['12.75', '12.75'],
+    ['0.00000125', '0.00000125'],
+    ['0.000000000000000001', '0.000000000000000001'], // exactly 18 fractional digits
+    ['99999999999999999999', '99999999999999999999'] // exactly 20 integer digits
+  ])('keeps canonical %j', (input, expected) => {
+    expect(canonicalizeDecimalAmount(input)).toBe(expected)
+  })
+
+  it.each([
+    ['12.50', '12.5'],
+    ['12.000', '12'],
+    ['0.0', '0']
+  ])('canonicalizes the trailing zeros of %j', (input, expected) => {
+    expect(canonicalizeDecimalAmount(input)).toBe(expected)
+  })
+
+  it.each([
+    '-1', // signed
+    '+1',
+    '1e-7', // exponential
+    '1E7',
+    '01.5', // redundant leading zero
+    '1.', // no fractional digits
+    '.5',
+    '1_000',
+    '1,5',
+    '',
+    ' 1 ',
+    'NaN',
+    'Infinity',
+    '0.0000000000000000001', // 19 fractional digits — past the column's scale
+    '100000000000000000000' // 21 integer digits — past the column's precision
+  ])('refuses %j', (input) => {
+    expect(canonicalizeDecimalAmount(input)).toBeNull()
+  })
+})
+
+describe('decimalAmountFromNumber', () => {
+  it.each([
+    [0, '0'],
+    [12.75, '12.75'],
+    // The number as WRITTEN, not the binary approximation: toFixed(18) would
+    // expand 0.1 to 0.100000000000000006.
+    [0.1, '0.1'],
+    [0.41, '0.41'],
+    [1e-7, '0.0000001'], // exponential notation is expanded, never passed through
+    [1.25e-8, '0.0000000125']
+  ])('normalizes %j', (input, expected) => {
+    expect(decimalAmountFromNumber(input)).toBe(expected)
+  })
+
+  it('rounds half up, once, at the scale of the column', () => {
+    // 5e-19 is exactly half of the smallest storable unit ⇒ rounds up to it.
+    expect(decimalAmountFromNumber(5e-19)).toBe('0.000000000000000001')
+    // 4e-19 is below the halfway point ⇒ rounds down to zero.
+    expect(decimalAmountFromNumber(4e-19)).toBe('0')
+  })
+
+  it('carries the rounding increment through a run of nines', () => {
+    expect(decimalAmountFromNumber(9.99e-19)).toBe('0.000000000000000001')
+  })
+
+  it.each([-1, -0.5, Number.NaN, Number.POSITIVE_INFINITY, 1e20, 1e21])('refuses %j', (input) => {
+    expect(decimalAmountFromNumber(input)).toBeNull()
+  })
+
+  it('treats negative zero as zero', () => {
+    expect(decimalAmountFromNumber(-0)).toBe('0')
+  })
+})
+
+describe('normalizeReportedCostAmount', () => {
+  it('accepts both reported shapes and yields one', () => {
+    expect(normalizeReportedCostAmount(12.5)).toBe('12.5')
+    expect(normalizeReportedCostAmount('12.50')).toBe('12.5')
+  })
+})
+
+describe('schemas', () => {
+  it('DecimalAmount takes the decimal string only', () => {
+    expect(DecimalAmount.safeParse('0.25').success).toBe(true)
+    expect(DecimalAmount.safeParse('1e-7').success).toBe(false)
+    expect(DecimalAmount.safeParse(0.25).success).toBe(false)
+  })
+
+  it('ReportedCostAmount takes either reported shape', () => {
+    expect(ReportedCostAmount.safeParse('0.25').success).toBe(true)
+    expect(ReportedCostAmount.safeParse(0.25).success).toBe(true)
+    expect(ReportedCostAmount.safeParse('abc').success).toBe(false)
+  })
+})

--- a/packages/protocol/src/decimal-amount.ts
+++ b/packages/protocol/src/decimal-amount.ts
@@ -1,0 +1,127 @@
+/**
+ * `decimal-amount.ts` — the exact money type of the usage report contract.
+ *
+ * A cost is metered by one party, accumulated by another, and eventually billed:
+ * binary floating point is wrong for every step of that, so an amount travels as a
+ * fixed-point DECIMAL STRING and is stored as `NUMERIC(38,18)`. The canonical form is
+ * non-negative, never exponential, unsigned, with no redundant leading or trailing
+ * zeros — `"0"`, `"0.00000125"`, `"12.75"`.
+ *
+ * A report may still arrive as a JSON number (that is what every daemon sends today),
+ * so `ReportedCostAmount` accepts both and the CP's ingress adapters normalize to the
+ * canonical string BEFORE anything accumulates. The number branch is a compatibility
+ * shape, not a second money type: nothing downstream of an adapter sees it.
+ */
+import { z } from 'zod'
+
+/** `NUMERIC(38,18)` — the column both usage tables use. */
+export const MAX_AMOUNT_PRECISION = 38
+export const MAX_AMOUNT_SCALE = 18
+/** 20 — what precision leaves for the integer part. */
+export const MAX_AMOUNT_INTEGER_DIGITS = MAX_AMOUNT_PRECISION - MAX_AMOUNT_SCALE
+
+/** Canonical: unsigned, non-exponential, no redundant leading zero. */
+const CANONICAL = /^(0|[1-9][0-9]*)(?:\.([0-9]+))?$/
+/** Same, but leading zeros allowed — what an expansion or a rounding carry produces. */
+const FIXED_POINT = /^([0-9]+)(?:\.([0-9]+))?$/
+const EXPONENTIAL = /^([0-9]+)(?:\.([0-9]+))?[eE]([+-]?[0-9]+)$/
+
+function stripTrailingZeros(frac: string): string {
+  let end = frac.length
+  while (end > 0 && frac[end - 1] === '0') end -= 1
+  return frac.slice(0, end)
+}
+
+function stripLeadingZeros(int: string): string {
+  let start = 0
+  while (start < int.length - 1 && int[start] === '0') start += 1
+  return int.slice(start)
+}
+
+function join(int: string, frac: string): string {
+  return frac.length > 0 ? `${int}.${frac}` : int
+}
+
+/** `1.25e-8` → `"0.0000000125"`. Exponential notation is never canonical, but
+ *  `String(1.25e-8)` produces it, so the number branch has to expand it first. */
+function fromExponential(text: string): string | null {
+  const m = EXPONENTIAL.exec(text)
+  if (!m) return null
+  const digits = m[1]! + (m[2] ?? '')
+  // Where the point lands inside `digits` once the exponent is applied.
+  const point = m[1]!.length + Number(m[3]!)
+  if (point <= 0) return `0.${'0'.repeat(-point)}${digits}`
+  if (point >= digits.length) return digits + '0'.repeat(point - digits.length)
+  return `${digits.slice(0, point)}.${digits.slice(point)}`
+}
+
+/** ROUND_HALF_UP to `scale` places, applied at most once — at the ingress adapter. */
+function roundHalfUp(int: string, frac: string, scale: number): { int: string; frac: string } {
+  if (frac.length <= scale) return { int, frac }
+  const kept = frac.slice(0, scale)
+  if (frac.charCodeAt(scale) < 0x35) return { int, frac: kept } // '5'
+  const digits = [...int, ...kept]
+  let i = digits.length - 1
+  while (i >= 0 && digits[i] === '9') {
+    digits[i] = '0'
+    i -= 1
+  }
+  if (i < 0) digits.unshift('1')
+  else digits[i] = String(Number(digits[i]) + 1)
+  // A carry past the leading digit lengthens the integer part by one.
+  const intLen = int.length + (digits.length - int.length - kept.length)
+  return { int: digits.slice(0, intLen).join(''), frac: digits.slice(intLen).join('') }
+}
+
+/**
+ * A decimal string in canonical form, or `null` when it is not a usable amount.
+ *
+ * Redundant TRAILING zeros are canonicalized rather than refused — `"12.50"` is a
+ * money-shaped value a metering source will send, and rejecting a whole batch over a
+ * cosmetic zero would drop real spend. Everything that changes the value (a sign, an
+ * exponent, a leading zero, more than 18 fractional or 20 integer digits) is refused.
+ */
+export function canonicalizeDecimalAmount(text: string): DecimalAmount | null {
+  const m = CANONICAL.exec(text)
+  if (!m) return null
+  const int = m[1]!
+  const frac = m[2] ?? ''
+  if (int.length > MAX_AMOUNT_INTEGER_DIGITS || frac.length > MAX_AMOUNT_SCALE) return null
+  return join(int, stripTrailingZeros(frac))
+}
+
+/**
+ * A JSON number's own decimal value in canonical form, or `null` when unusable.
+ *
+ * `String(value)` on purpose, not `toFixed`: it yields the shortest round-tripping
+ * decimal, which is the number as it was written on the wire (`0.1` → `"0.1"`), where
+ * `toFixed(18)` would expand the binary approximation (`"0.100000000000000006"`).
+ */
+export function decimalAmountFromNumber(value: number): DecimalAmount | null {
+  if (!Number.isFinite(value) || value < 0) return null
+  const text = String(value)
+  const fixed = text.includes('e') || text.includes('E') ? fromExponential(text) : text
+  const m = fixed === null ? null : FIXED_POINT.exec(fixed)
+  if (!m) return null
+  const rounded = roundHalfUp(m[1]!, m[2] ?? '', MAX_AMOUNT_SCALE)
+  const int = stripLeadingZeros(rounded.int)
+  if (int.length > MAX_AMOUNT_INTEGER_DIGITS) return null
+  return join(int, stripTrailingZeros(rounded.frac))
+}
+
+/** Normalize either reported shape to the canonical string, or `null` if unusable. */
+export function normalizeReportedCostAmount(value: number | string): DecimalAmount | null {
+  return typeof value === 'number' ? decimalAmountFromNumber(value) : canonicalizeDecimalAmount(value)
+}
+
+/** A fixed-point decimal amount. The only money shape anything downstream of an
+ *  ingress adapter handles — storage, aggregation, and every API response. */
+export const DecimalAmount = z.string().refine((text) => canonicalizeDecimalAmount(text) !== null, {
+  message: `expected an unsigned fixed-point decimal with at most ${MAX_AMOUNT_INTEGER_DIGITS} integer and ${MAX_AMOUNT_SCALE} fractional digits`
+})
+export type DecimalAmount = string
+
+/** What a usage REPORT may carry: the canonical string, or a JSON number from a
+ *  daemon that predates it. Adapters normalize; nothing else accepts the union. */
+export const ReportedCostAmount = z.union([z.number(), DecimalAmount])
+export type ReportedCostAmount = z.infer<typeof ReportedCostAmount>

--- a/packages/protocol/src/decimal-amount.ts
+++ b/packages/protocol/src/decimal-amount.ts
@@ -114,6 +114,40 @@ export function normalizeReportedCostAmount(value: number | string): DecimalAmou
   return typeof value === 'number' ? decimalAmountFromNumber(value) : canonicalizeDecimalAmount(value)
 }
 
+// ── exact arithmetic ────────────────────────────────────────────────────────
+// Amounts are added and subtracted as integers scaled by `MAX_AMOUNT_SCALE`, which
+// is exact for every value the column can hold. A decimal LIBRARY is deliberately
+// not used here: decimal.js (what Prisma's `Decimal` is) rounds arithmetic to 20
+// SIGNIFICANT digits by default, so subtracting zero from an exact
+// `123.123456789012345678` already returns `123.12345678901234568`. Scaled `bigint`
+// has no precision setting to get wrong.
+
+/** `"12.5"` → `12500000000000000000n`. Unusable input scales to `0n`. */
+export function scaleAmount(text: string): bigint {
+  const negative = text.startsWith('-')
+  const [int = '', frac = ''] = (negative ? text.slice(1) : text).split('.')
+  if (int.length === 0 || !/^[0-9]*$/.test(int) || !/^[0-9]*$/.test(frac)) return 0n
+  const scaled = BigInt(`${int}${frac.slice(0, MAX_AMOUNT_SCALE).padEnd(MAX_AMOUNT_SCALE, '0')}`)
+  return negative ? -scaled : scaled
+}
+
+/** `12500000000000000000n` → `"12.5"`, canonical. Keeps a sign: a window delta is a
+ *  subtraction, so it can be negative even though no reported amount ever is. */
+export function unscaleAmount(scaled: bigint): DecimalAmount {
+  const negative = scaled < 0n
+  const digits = (negative ? -scaled : scaled).toString().padStart(MAX_AMOUNT_SCALE + 1, '0')
+  const int = digits.slice(0, digits.length - MAX_AMOUNT_SCALE)
+  const frac = stripTrailingZeros(digits.slice(digits.length - MAX_AMOUNT_SCALE))
+  return `${negative ? '-' : ''}${join(stripLeadingZeros(int), frac)}`
+}
+
+/** Add decimal amounts exactly. */
+export function sumAmounts(amounts: Iterable<string>): DecimalAmount {
+  let total = 0n
+  for (const amount of amounts) total += scaleAmount(amount)
+  return unscaleAmount(total)
+}
+
 /** A fixed-point decimal amount. The only money shape anything downstream of an
  *  ingress adapter handles — storage, aggregation, and every API response. */
 export const DecimalAmount = z.string().refine((text) => canonicalizeDecimalAmount(text) !== null, {

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { ReportedCostAmount } from '../decimal-amount.js'
 import { SessionUsage } from './session.js'
 import { Platform } from './route.js'
 import { HeartbeatDuties } from './duty.js'
@@ -195,6 +196,13 @@ export const SessionPurged = z.object({
 })
 export type SessionPurged = z.infer<typeof SessionPurged>
 
+/** A report's usage: `SessionUsage`, except that the cost may arrive as the exact
+ *  decimal string OR as a JSON number from a daemon that predates it. Only the
+ *  REPORT accepts the union — the CP's ingress adapter normalizes to the decimal
+ *  string, so storage and every reader downstream see one money shape. */
+export const ReportedSessionUsage = SessionUsage.extend({ costAmount: ReportedCostAmount.optional() })
+export type ReportedSessionUsage = z.infer<typeof ReportedSessionUsage>
+
 /**
  * Per-session token-usage report — D→C EVT. The daemon meters usage from the
  * agent's ACP stream and reports the session's CUMULATIVE snapshot (latest-wins)
@@ -211,7 +219,7 @@ export const UsageReport = z.object({
   // `null` is an explicit runtime-owned default/unknown; absent is an old daemon.
   observedModel: z.string().nullable().optional(),
   lastActivityAt: z.string(), // ISO ts of the session's last activity
-  usage: SessionUsage
+  usage: ReportedSessionUsage
 })
 export type UsageReport = z.infer<typeof UsageReport>
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -156,5 +156,8 @@ export {
   ReportedCostAmount,
   canonicalizeDecimalAmount,
   decimalAmountFromNumber,
-  normalizeReportedCostAmount
+  normalizeReportedCostAmount,
+  scaleAmount,
+  sumAmounts,
+  unscaleAmount
 } from './decimal-amount.js'

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -146,3 +146,15 @@ export { MAX_REPO_SUBDIR_LENGTH, RepoSubdirError, normalizeRepoSubdir } from './
 // ── §5 platform manifest — pre-dispatch capability table, read by every host ──
 export { DEFAULT_MANIFEST, manifestFor } from './platform-manifest.js'
 export type { MembershipEnumeration, PlatformManifest } from './platform-manifest.js'
+
+// ── exact money — the decimal amount every reported/stored/served cost uses ──
+export {
+  DecimalAmount,
+  MAX_AMOUNT_INTEGER_DIGITS,
+  MAX_AMOUNT_PRECISION,
+  MAX_AMOUNT_SCALE,
+  ReportedCostAmount,
+  canonicalizeDecimalAmount,
+  decimalAmountFromNumber,
+  normalizeReportedCostAmount
+} from './decimal-amount.js'

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -12,6 +12,7 @@ import {
   type Agent
 } from '@/lib/data'
 import { creatorLabel, fmtCost, fmtCountCompact, memberDisplayName } from '@/lib/api'
+import { amountToNumber } from '@/lib/amount'
 import { useConsoleData } from '@/lib/data-context'
 import { IntegrationMarks } from '@/components/console/IntegrationMarks'
 import { useModal } from '@/components/console/ModalProvider'
@@ -90,9 +91,11 @@ export default function AgentsView() {
     const u = usageByAgent.get(a.id)
     return u ? u.totalTokens : parseCompact(a.tokens)
   }
+  // The aggregate reports an exact decimal string; sorting and formatting are the
+  // only things this view does with it, so it becomes a number right here.
   const cost24h = (a: Agent) => {
     const u = usageByAgent.get(a.id)
-    return u ? u.costAmount : parseCompact(a.cost)
+    return u ? amountToNumber(u.costAmount) : parseCompact(a.cost)
   }
   // Creator names remain available to sorting and assistive text; rows show only avatars.
   const memberById = useMemo(() => new Map(members.map((m) => [m.userId, m])), [members])
@@ -309,7 +312,7 @@ export default function AgentsView() {
             },
             {
               label: 'Spend 24h',
-              value: fmtCost(usage24h?.totals.costAmount ?? 0, currency),
+              value: fmtCost(amountToNumber(usage24h?.totals.costAmount ?? '0'), currency),
               dim: ''
             }
           ].map((m, i, arr) => (
@@ -521,7 +524,7 @@ export default function AgentsView() {
         </div>
         <div className="card stat">
           <div className="statlbl">Spend (24h)</div>
-          <div className="statval">{fmtCost(usage24h?.totals.costAmount ?? 0, currency)}</div>
+          <div className="statval">{fmtCost(amountToNumber(usage24h?.totals.costAmount ?? '0'), currency)}</div>
         </div>
       </div>
       <div className="card">
@@ -692,7 +695,9 @@ export default function AgentsView() {
                   return (
                     <>
                       <span className={`mono ${cell}`}>{u ? fmtCountCompact(u.totalTokens) : a.tokens}</span>
-                      <span className={`mono ${cell}`}>{u ? fmtCost(u.costAmount, currency) : a.cost}</span>
+                      <span className={`mono ${cell}`}>
+                        {u ? fmtCost(amountToNumber(u.costAmount), currency) : a.cost}
+                      </span>
                     </>
                   )
                 })()}

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 import { Bar, BarChart, Legend, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { fetchUsage, fmtCost, fmtCountCompact as fmtCompact, type UsageRange } from '@/lib/api'
+import { amountToNumber, sumAmounts } from '@/lib/amount'
 import { agentLabel, modelLabel, runtimeLabel } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { AgentIconView, ModelMark, Spinner } from '@/components/marks'
@@ -113,7 +114,9 @@ export default function UsageView() {
   // match the incoming chart and swapping skeleton→data causes no layout shift.
   const skelBars = range === 'd1' ? 24 : range === 'd7' ? 7 : range === 'd90' ? 90 : 30
   const totalTokens = data?.totals.totalTokens ?? 0
-  const totalSpend = data?.totals.costAmount ?? 0
+  // Amounts arrive as exact decimal strings; a number appears only where the value is
+  // being formatted or turned into pixels, never where two amounts are added.
+  const totalSpend = amountToNumber(data?.totals.costAmount ?? '0')
   const totalSessions = data?.totals.sessions ?? 0
   // Currency reported for this workspace's sessions (null when none/mixed → the
   // formatter falls back to USD). Amounts are summed as-is, so a mixed-currency
@@ -148,7 +151,7 @@ export default function UsageView() {
     model: string
     totalTokens: number
     sessions: number
-    costAmount: number
+    costAmount: string
   }
   let entries: Entry[]
   if (groupBy === 'model') {
@@ -174,11 +177,11 @@ export default function UsageView() {
         model: '',
         totalTokens: 0,
         sessions: 0,
-        costAmount: 0
+        costAmount: '0'
       }
       g.totalTokens += e.totalTokens
       g.sessions += e.sessions
-      g.costAmount += e.costAmount
+      g.costAmount = sumAmounts([g.costAmount, e.costAmount])
       byRuntime.set(rt, g)
     }
     entries = [...byRuntime.values()].sort((a, b) => b.totalTokens - a.totalTokens)
@@ -200,7 +203,7 @@ export default function UsageView() {
     model: e.model,
     sessions: e.sessions.toLocaleString('en-US'),
     tokens: fmtCompact(e.totalTokens),
-    spend: fmtCost(e.costAmount, currency),
+    spend: fmtCost(amountToNumber(e.costAmount), currency),
     pct: totalTokens > 0 ? Math.round((e.totalTokens / totalTokens) * 100) : 0,
     barPct: Math.round((e.totalTokens / maxTok) * 100)
   }))
@@ -326,12 +329,16 @@ export default function UsageView() {
           // console's agent list. Absent on an older CP → flat brand bars.
           const hasBreakdown = pts.some((p) => p.byAgent || p.byModel)
           const agentMeta = new Map(enriched.map((e) => [e.agentId, e]))
+          // Bar heights are geometry, so each amount becomes a number here — the one
+          // place in this view where a cost is allowed to be a float.
+          const plot = (by: Record<string, string>): Record<string, number> =>
+            Object.fromEntries(Object.entries(by).map(([k, v]) => [k, amountToNumber(v)]))
           const recs = pts.map((p) => {
-            if (!hasBreakdown) return { '': p.costAmount }
-            if (groupBy === 'model') return p.byModel ?? {}
-            if (groupBy === 'agent') return p.byAgent ?? {}
+            if (!hasBreakdown) return { '': amountToNumber(p.costAmount) }
+            if (groupBy === 'model') return plot(p.byModel ?? {})
+            if (groupBy === 'agent') return plot(p.byAgent ?? {})
             const rec: Record<string, number> = {}
-            for (const [id, v] of Object.entries(p.byAgent ?? {})) {
+            for (const [id, v] of Object.entries(plot(p.byAgent ?? {}))) {
               const rt = agentMeta.get(id)?.runtime || 'unknown'
               rec[rt] = (rec[rt] ?? 0) + v
             }
@@ -367,7 +374,7 @@ export default function UsageView() {
           const chartData = recs.map((rec, i) => {
             const row: Record<string, number | string> = {
               label: bucketLabel(pts[i]!.start, data.series!.bucket),
-              __total: pts[i]!.costAmount
+              __total: amountToNumber(pts[i]!.costAmount)
             }
             stackKeys.forEach((k, si) => {
               row[`s${si}`] =

--- a/packages/web/src/lib/amount.test.ts
+++ b/packages/web/src/lib/amount.test.ts
@@ -2,28 +2,9 @@ import { describe, expect, it } from 'vitest'
 import { amountToNumber, sumAmounts } from './amount.js'
 
 describe('sumAmounts', () => {
-  it('adds without the drift a float sum would show', () => {
-    // 0.1 + 0.2 as numbers is 0.30000000000000004.
-    expect(sumAmounts(['0.1', '0.2'])).toBe('0.3')
+  it('is the protocol package’s exact addition, re-exported', () => {
     expect(sumAmounts(['0.1', '0.2', '0.05'])).toBe('0.35')
-  })
-
-  it('keeps sub-cent precision across many rows', () => {
-    expect(sumAmounts(Array.from({ length: 1000 }, () => '0.000000000000000001'))).toBe('0.000000000000001')
-  })
-
-  it.each([
-    [[], '0'],
-    [['0'], '0'],
-    [['12.50', '0.50'], '13'],
-    [['1', '-0.5'], '0.5'], // a netted downward correction
-    [['99999999999999999999', '1'], '100000000000000000000']
-  ])('sums %j to %j', (amounts, expected) => {
-    expect(sumAmounts(amounts)).toBe(expected)
-  })
-
-  it('ignores an unparseable amount instead of poisoning the total with NaN', () => {
-    expect(sumAmounts(['1.5', 'oops', ''])).toBe('1.5')
+    expect(sumAmounts(['123.123456789012345678', '0'])).toBe('123.123456789012345678')
   })
 })
 

--- a/packages/web/src/lib/amount.test.ts
+++ b/packages/web/src/lib/amount.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { amountToNumber, sumAmounts } from './amount.js'
+
+describe('sumAmounts', () => {
+  it('adds without the drift a float sum would show', () => {
+    // 0.1 + 0.2 as numbers is 0.30000000000000004.
+    expect(sumAmounts(['0.1', '0.2'])).toBe('0.3')
+    expect(sumAmounts(['0.1', '0.2', '0.05'])).toBe('0.35')
+  })
+
+  it('keeps sub-cent precision across many rows', () => {
+    expect(sumAmounts(Array.from({ length: 1000 }, () => '0.000000000000000001'))).toBe('0.000000000000001')
+  })
+
+  it.each([
+    [[], '0'],
+    [['0'], '0'],
+    [['12.50', '0.50'], '13'],
+    [['1', '-0.5'], '0.5'], // a netted downward correction
+    [['99999999999999999999', '1'], '100000000000000000000']
+  ])('sums %j to %j', (amounts, expected) => {
+    expect(sumAmounts(amounts)).toBe(expected)
+  })
+
+  it('ignores an unparseable amount instead of poisoning the total with NaN', () => {
+    expect(sumAmounts(['1.5', 'oops', ''])).toBe('1.5')
+  })
+})
+
+describe('amountToNumber', () => {
+  it('converts for display and geometry', () => {
+    expect(amountToNumber('12.5')).toBe(12.5)
+    expect(amountToNumber('0')).toBe(0)
+  })
+
+  it('degrades an unusable amount to zero rather than NaN', () => {
+    expect(amountToNumber('oops')).toBe(0)
+  })
+})

--- a/packages/web/src/lib/amount.ts
+++ b/packages/web/src/lib/amount.ts
@@ -1,0 +1,47 @@
+/**
+ * `amount.ts` — exact arithmetic on the decimal-string amounts the CP returns.
+ *
+ * Usage costs arrive as fixed-point decimal strings (the CP stores them as
+ * `NUMERIC(38,18)` and never rounds), so the console must not re-add them as floats:
+ * a runtime rollup of three agents' spend should equal the workspace total exactly,
+ * not miss it by 1e-16 and render a different figure in two cards.
+ *
+ * Scaled `bigint` rather than a decimal library: one dependency-free primitive that
+ * covers what the console actually does — add, then hand the result to a formatter.
+ */
+
+/** Fractional digits the CP's amount column carries. */
+const SCALE = 18
+
+/** `"12.5"` → `12500000000000000000n`. Unparseable input contributes nothing. */
+function toScaled(text: string): bigint {
+  const negative = text.startsWith('-')
+  const [int = '', frac = ''] = (negative ? text.slice(1) : text).split('.')
+  if (!/^[0-9]*$/.test(int) || !/^[0-9]*$/.test(frac)) return 0n
+  const digits = `${int || '0'}${frac.slice(0, SCALE).padEnd(SCALE, '0')}`
+  const scaled = BigInt(digits)
+  return negative ? -scaled : scaled
+}
+
+/** `12500000000000000000n` → `"12.5"` (canonical: no trailing zeros). */
+function fromScaled(scaled: bigint): string {
+  const negative = scaled < 0n
+  const digits = (negative ? -scaled : scaled).toString().padStart(SCALE + 1, '0')
+  const int = digits.slice(0, digits.length - SCALE)
+  const frac = digits.slice(digits.length - SCALE).replace(/0+$/, '')
+  return `${negative ? '-' : ''}${int}${frac ? `.${frac}` : ''}`
+}
+
+/** Add decimal-string amounts exactly. */
+export function sumAmounts(amounts: Iterable<string>): string {
+  let total = 0n
+  for (const amount of amounts) total += toScaled(amount)
+  return fromScaled(total)
+}
+
+/** An amount as a number, for pixel geometry and `Intl` formatting only — never to
+ *  add two amounts together. */
+export function amountToNumber(amount: string): number {
+  const value = Number(amount)
+  return Number.isFinite(value) ? value : 0
+}

--- a/packages/web/src/lib/amount.ts
+++ b/packages/web/src/lib/amount.ts
@@ -1,43 +1,11 @@
 /**
- * `amount.ts` — exact arithmetic on the decimal-string amounts the CP returns.
+ * `amount.ts` — the console's view of the decimal-string amounts the CP returns.
  *
- * Usage costs arrive as fixed-point decimal strings (the CP stores them as
- * `NUMERIC(38,18)` and never rounds), so the console must not re-add them as floats:
- * a runtime rollup of three agents' spend should equal the workspace total exactly,
- * not miss it by 1e-16 and render a different figure in two cards.
- *
- * Scaled `bigint` rather than a decimal library: one dependency-free primitive that
- * covers what the console actually does — add, then hand the result to a formatter.
+ * Exact addition comes from the protocol package, so the console and the control plane
+ * add money the same way: scaled integers, never a float and never a decimal library
+ * whose arithmetic rounds to a significant-digit precision.
  */
-
-/** Fractional digits the CP's amount column carries. */
-const SCALE = 18
-
-/** `"12.5"` → `12500000000000000000n`. Unparseable input contributes nothing. */
-function toScaled(text: string): bigint {
-  const negative = text.startsWith('-')
-  const [int = '', frac = ''] = (negative ? text.slice(1) : text).split('.')
-  if (!/^[0-9]*$/.test(int) || !/^[0-9]*$/.test(frac)) return 0n
-  const digits = `${int || '0'}${frac.slice(0, SCALE).padEnd(SCALE, '0')}`
-  const scaled = BigInt(digits)
-  return negative ? -scaled : scaled
-}
-
-/** `12500000000000000000n` → `"12.5"` (canonical: no trailing zeros). */
-function fromScaled(scaled: bigint): string {
-  const negative = scaled < 0n
-  const digits = (negative ? -scaled : scaled).toString().padStart(SCALE + 1, '0')
-  const int = digits.slice(0, digits.length - SCALE)
-  const frac = digits.slice(digits.length - SCALE).replace(/0+$/, '')
-  return `${negative ? '-' : ''}${int}${frac ? `.${frac}` : ''}`
-}
-
-/** Add decimal-string amounts exactly. */
-export function sumAmounts(amounts: Iterable<string>): string {
-  let total = 0n
-  for (const amount of amounts) total += toScaled(amount)
-  return fromScaled(total)
-}
+export { sumAmounts } from '@agentconnect.md/protocol'
 
 /** An amount as a number, for pixel geometry and `Intl` formatting only — never to
  *  add two amounts together. */

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3326,7 +3326,9 @@ export interface UsageAgentDto {
   thoughtTokens: number
   cachedReadTokens: number
   cachedWriteTokens: number
-  costAmount: number
+  /** Exact decimal string — the CP never rounds a cost. Format it; add with
+   *  `sumAmounts` from `lib/amount` rather than as a float. */
+  costAmount: string
 }
 
 export interface UsageModelDto extends Omit<UsageAgentDto, 'agentId'> {
@@ -3337,7 +3339,7 @@ export interface UsageDto {
   range: UsageRange
   accessSyncDegraded?: boolean
   accessIssues?: SessionAccessIssue[]
-  totals: { sessions: number; totalTokens: number; costAmount: number; costCurrency: string | null }
+  totals: { sessions: number; totalTokens: number; costAmount: string; costCurrency: string | null }
   agents: UsageAgentDto[]
   models: UsageModelDto[]
   // Spend-over-time chart: cost bucketed by hour (d1) or day (longer ranges),
@@ -3348,9 +3350,9 @@ export interface UsageDto {
     bucket: 'hour' | 'day'
     points: {
       start: string
-      costAmount: number
-      byAgent?: Record<string, number>
-      byModel?: Record<string, number>
+      costAmount: string
+      byAgent?: Record<string, string>
+      byModel?: Record<string, string>
     }[]
   }
 }


### PR DESCRIPTION
A usage cost is metered by one party, accumulated by the control plane, and billed
by a third. Binary floating point is wrong for every step of that, so this moves the
whole money path onto a fixed-point decimal — from the moment a report is accepted to
the amounts the aggregate serves.

Only the **type** changes here. Window semantics, source filtering, and checkpoint
merge rules are untouched.

## What changed

| Layer | Before | After |
|---|---|---|
| report payload (`usage/report`, batch ingress) | `costAmount: number` | `number` **or** an exact decimal string; each ingress adapter normalizes |
| `UsageWriter` | took the reported payload | takes `NormalizedSessionUsageReport` — a float cannot reach it |
| `session_usage.costAmount`, `session_spend.cumulativeCost` | `Float` | `NUMERIC(38,18)` (+ migration) |
| range aggregate | JS `+` / `-` over numbers | `Decimal` diffs and sums throughout |
| `GET /usage` amounts | numbers | exact decimal strings (totals, agent/model breakdowns, every series bucket) |
| service-authenticated batch | same shape as the daemon EVT | decimal string only, currency mandatory, batch refused whole |
| console | re-added the numbers | formats strings; sums exactly where it rolls rows up |

New: `packages/protocol/src/decimal-amount.ts` (the canonical form, its validator, and
normalization from either reported shape) and `packages/web/src/lib/amount.ts` (exact
addition over scaled `bigint`, no dependency).

The canonical form is unsigned, never exponential, at most 20 integer and 18 fractional
digits: `"0"`, `"0.00000125"`, `"12.75"`.

## Why the two ingresses differ

The batch endpoint's reports are the ones that get billed, so it is deliberately
stricter than the daemon EVT: the amount must be the decimal string, its currency must
be present, and a batch that violates either is refused whole with a `400` before any
row is written — the caller retries in full once its own metering is complete. Reading
a missing amount as zero spend is the failure that prevents.

The daemon EVT stays lenient. A daemon reports a JSON number today, and an amount that
cannot be normalized drops the cost and keeps the session's token counts: losing a
session's token history over one bad price is the worse trade. That is logged, not
silent.

## Reviewer notes — four calls worth checking

1. **`"12.50"` is accepted and canonicalized to `"12.5"`, not refused.** A sign, an
   exponent, a redundant leading zero, more than 18 fractional or 20 integer digits all
   are refused. Strict canonical-only input would fail an entire batch over a cosmetic
   trailing zero and drop real spend with it.
2. **`GET /usage` cost fields flip from number to string on `/api/v1`,** with no second
   versioned tree. The console is updated in this PR; the MCP `getUsage` tool passes the
   response through untyped. This is the shape the usage contract calls for, but it is a
   response change on a released surface — say so if you want it staged differently.
3. **The response schema for an aggregate amount is a plain string, not the strict
   non-negative decimal.** A window delta is derived by subtraction, so a downward
   correction can still produce a negative figure until checkpoint merge is monotonic;
   answering `500` on a real number would be worse than returning a signed string.
4. **The per-session snapshot read keeps a number** (`SessionUsageDto.costAmount`) — the
   session views only display it, so the decimal string stops at the aggregate.

The migration casts `float8` to `NUMERIC` through the double's shortest round-tripping
decimal, so an amount written as `0.41` lands as `0.41` rather than its binary tail. An
existing amount with more than 20 integer digits would overflow and fail the statement;
that is corrupt data and refusing it is intended.

## Verification

| Suite | Result |
|---|---|
| `pnpm typecheck` (workspace) | clean |
| `@agentconnect.md/protocol` | 387 passed — 41 new for the decimal contract |
| control-plane `test:unit` | 1765 passed |
| control-plane `test:int` | 1434 passed, including the new migration applying in global setup |
| `@agentconnect.md/web` | 1590 passed, including the new exact-sum tests |
| `pnpm lint`, `pnpm format:check` | clean |

The daemon suite has 9 failures in its shim workspace-file, git-runner, and exec tests.
They reproduce identically on an untouched checkout at a different commit, touch nothing
in this diff, and are not caused by this change.

New tests worth reading: the ingress spec now pins that a float amount, exponent
notation, a negative amount, more than 18 decimals, a missing amount, and a missing
currency each refuse the whole batch — and that the valid sibling of a refused report is
not written either. The aggregate spec asserts exact strings, so `0.1 + 0.2 + 0.05` is
`"0.35"` rather than `0.35000000000000003`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
