### PR TITLE
fix(control-plane): re-serve a still-leased grant when a session-access check cannot run

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -999,7 +999,8 @@ export function buildContainer(
     clock,
     ...sessionAccessTtls,
     identityTtlMs: config.SESSION_ACCESS_IDENTITY_TTL_SEC * 1000,
-    log: { debug: (o, m) => http.log.debug(o, m) }
+    // Lazy over `http.log` (assigned below; only ever called at resolve time).
+    log: { warn: (o, m) => http.log.warn(o, m), debug: (o, m) => http.log.debug(o, m) }
   })
   const feishuSessionAccess = new FeishuSessionAccessService({
     bots: repos.bot,

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1007,7 +1007,9 @@ export function buildContainer(
     botSecrets: repos.botSecret,
     clock,
     ...(logtoIdentity ? { identity: logtoIdentity } : {}),
-    ...(opts.feishuFetch ? { fetchImpl: opts.feishuFetch } : {})
+    ...(opts.feishuFetch ? { fetchImpl: opts.feishuFetch } : {}),
+    // Lazy over `http.log` (assigned below; only ever called at resolve time).
+    log: { warn: (o, m) => http.log.warn(o, m) }
   })
 
   // Built once and shared between the route deps (the live paths) and the

--- a/packages/control-plane/src/http/feishu-session-access.test.ts
+++ b/packages/control-plane/src/http/feishu-session-access.test.ts
@@ -159,6 +159,89 @@ describe('FeishuSessionAccessService', () => {
     })
   })
 
+  describe('grace on an unverifiable check', () => {
+    /** A chat whose member list reads once, then stops answering — with a clock the test drives. */
+    function flakyChat(members: string[] = ['on_member']) {
+      let answering = true
+      let time = 1_000
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.endsWith('/tenant_access_token/internal')) return json({ code: 0, tenant_access_token: 'tenant-token' })
+        if (!answering) return json({ code: 99991672, msg: 'missing scope' })
+        return json({ code: 0, data: { items: members.map((id) => ({ member_id: id })), has_more: false } })
+      })
+      return {
+        fetchImpl,
+        stop: () => (answering = false),
+        advance: (ms: number) => (time += ms),
+        now: () => time
+      }
+    }
+
+    it('re-serves an admission this viewer already earned, and does not call it degraded', async () => {
+      const chat = flakyChat()
+      const resolver = service(chat.fetchImpl, chat.now)
+
+      await resolver.resolve([scope()], viewer())
+      // Past the member-list lease, so the audience is re-read — and the app can no longer read it.
+      chat.advance(120_001)
+      chat.stop()
+
+      await expect(resolver.resolve([scope()], viewer())).resolves.toEqual({
+        allowedScopes: [{ id: scope().id, aclRevision: 2n }],
+        degraded: false,
+        accessIssues: []
+      })
+    })
+
+    it('admits nobody who was never admitted', async () => {
+      const chat = flakyChat()
+      chat.stop()
+
+      await expect(service(chat.fetchImpl, chat.now).resolve([scope()], viewer())).resolves.toEqual({
+        allowedScopes: [],
+        degraded: true,
+        accessIssues: [{ provider: 'feishu', region: 'lark', reason: 'unavailable' }]
+      })
+    })
+
+    it('lets a decided exclusion disarm the grace, so a later outage cannot resurrect the admission', async () => {
+      const chat = flakyChat()
+      const resolver = service(chat.fetchImpl, chat.now)
+
+      await resolver.resolve([scope()], viewer())
+      // The viewer leaves the chat, and the audience says so.
+      chat.advance(120_001)
+      chat.fetchImpl.mockImplementation(async (url: string) =>
+        url.endsWith('/tenant_access_token/internal')
+          ? json({ code: 0, tenant_access_token: 'tenant-token' })
+          : json({ code: 0, data: { items: [], has_more: false } })
+      )
+      expect((await resolver.resolve([scope()], viewer())).allowedScopes).toHaveLength(0)
+
+      chat.advance(120_001)
+      chat.fetchImpl.mockImplementation(async (url: string) =>
+        url.endsWith('/tenant_access_token/internal')
+          ? json({ code: 0, tenant_access_token: 'tenant-token' })
+          : json({ code: 99991672, msg: 'missing scope' })
+      )
+      expect((await resolver.resolve([scope()], viewer())).degraded).toBe(true)
+    })
+
+    it('expires one member-list lease past the admission rather than renewing while the app is down', async () => {
+      const chat = flakyChat()
+      const resolver = service(chat.fetchImpl, chat.now)
+
+      await resolver.resolve([scope()], viewer())
+      chat.stop()
+      chat.advance(239_999)
+      expect((await resolver.resolve([scope()], viewer())).allowedScopes).toHaveLength(1)
+
+      // A graced serve does not re-arm the grace, so the boundary stays anchored to the real admission.
+      chat.advance(2)
+      expect((await resolver.resolve([scope()], viewer())).degraded).toBe(true)
+    })
+  })
+
   it('classifies exhausted tenant quota and backs off other chats in the same organization', async () => {
     const fetchImpl = vi.fn(async (url: string) =>
       url.endsWith('/tenant_access_token/internal')

--- a/packages/control-plane/src/http/feishu-session-access.ts
+++ b/packages/control-plane/src/http/feishu-session-access.ts
@@ -70,6 +70,11 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
    *  this used to keep alongside. Entries carry their own TTL — see the
    *  fetchMethod, which sets it from the answer it got. */
   private readonly membership: LRUCache<string, MembershipResult, MembershipLookup>
+  /** (chat credential, viewer's union_ids) the audience really ADMITTED, armed for one member-list
+   *  lease past its own. Unlike `membership` this is per viewer — it is the only record that a
+   *  PERSON was inside, and it is what lets an unverifiable check re-serve that instead of hiding
+   *  the conversation. The decision itself stays derived; this caches no audience. */
+  private readonly gracedAllows: LRUCache<string, true>
   private readonly quotaBlockedUntil = new Map<string, number>()
 
   constructor(
@@ -79,8 +84,12 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
       clock: Clock
       fetchImpl?: FetchLike
       identity?: Pick<LogtoIdentityService, 'feishuIdentitiesFor'>
+      /** Optional so tests can omit it, but without one the grace leaves no trace and an app that
+       *  stays unreachable stops being visible at the moment it starts costing something. */
+      log?: { warn?: (obj: object, msg: string) => void }
     }
   ) {
+    this.gracedAllows = new LRUCache(cacheOptions(deps.clock, MAX_CACHE_ENTRIES))
     this.membership = new LRUCache({
       ...cacheOptions(deps.clock, MAX_CACHE_ENTRIES),
       // A per-entry TTL is always set below; this only stops lru-cache from
@@ -207,8 +216,10 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
     if (unionIds.length === 0) {
       return { decision: 'unknown', issue: { provider: 'feishu', region, reason: 'authorization' } }
     }
+    const chatKey = [bot.id, bot.credentialRevision, scope.resourceKey].join(':')
+    const graceKey = [scope.id, scope.aclRevision.toString(), chatKey, unionIds.join(',')].join(':')
     const membership = await this.membershipFor(
-      [bot.id, bot.credentialRevision, scope.resourceKey].join(':'),
+      chatKey,
       `${scope.orgId}:${region}`,
       region,
       scope.resourceKey,
@@ -217,9 +228,27 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
       signal
     )
     if (membership.status === 'members') {
-      return { decision: unionIds.some((unionId) => membership.unionIds.has(unionId)) ? 'allow' : 'deny' }
+      const admitted = unionIds.some((unionId) => membership.unionIds.has(unionId))
+      // Only a decided admission arms the grace — for ONE more member-list lease — and a graced serve
+      // never re-arms it, so an app that stays unreachable expires the grant on schedule. A decided
+      // exclusion disarms it: once the audience has answered "not a member", a later outage may not
+      // resurrect what that answer took away.
+      if (admitted) this.gracedAllows.set(graceKey, true, { ttl: MEMBER_LIST_TTL_MS * 2 })
+      else this.gracedAllows.delete(graceKey)
+      return { decision: admitted ? 'allow' : 'deny' }
     }
-    if (membership.status === 'deny') return { decision: 'deny' }
+    if (membership.status === 'deny') {
+      this.gracedAllows.delete(graceKey)
+      return { decision: 'deny' }
+    }
+    // An unverifiable check is not a denial: re-serve an admission this viewer already earned.
+    if (this.gracedAllows.has(graceKey)) {
+      this.deps.log?.warn?.(
+        { provider: 'feishu', region, reason: membership.issue.reason },
+        'feishu access check degraded — re-serving an admission this viewer already earned'
+      )
+      return { decision: 'allow' }
+    }
     return { decision: 'unknown', issue: membership.issue }
   }
 

--- a/packages/control-plane/src/http/github-session-access.test.ts
+++ b/packages/control-plane/src/http/github-session-access.test.ts
@@ -158,6 +158,81 @@ describe('GithubSessionAccessService', () => {
     })
   })
 
+  describe('grace on an unverifiable check', () => {
+    it('re-serves an allow this viewer already earned, and does not call it degraded', async () => {
+      const h = make(true, vi.fn().mockResolvedValue('read'))
+
+      await h.service.resolve([scope], viewer)
+      // Past the allow lease, so the verdict is re-decided — and the provider is now unreachable.
+      h.clock.advance(120_001)
+      h.permissionForUser.mockRejectedValue(new Error('provider unavailable'))
+
+      // Nothing is hidden, so nothing is reported: the viewer sees what they saw a moment ago.
+      await expect(h.service.resolve([scope], viewer)).resolves.toEqual({
+        allowedScopes: [{ id: scope.id, aclRevision: scope.aclRevision }],
+        degraded: false
+      })
+    })
+
+    it('admits nobody who was never allowed', async () => {
+      const h = make(true, vi.fn().mockRejectedValue(new Error('provider unavailable')))
+
+      await expect(h.service.resolve([scope], viewer)).resolves.toEqual({ allowedScopes: [], degraded: true })
+    })
+
+    it('expires one lease past the verdict rather than renewing for as long as the provider is down', async () => {
+      const h = make(true, vi.fn().mockResolvedValue('read'))
+
+      await h.service.resolve([scope], viewer)
+      h.permissionForUser.mockRejectedValue(new Error('provider unavailable'))
+      // Inside the grace (allow lease + one more), the grant is still served.
+      h.clock.advance(239_999)
+      expect((await h.service.resolve([scope], viewer)).allowedScopes).toHaveLength(1)
+
+      // A graced serve does not re-arm the grace, so the boundary stays anchored to the real allow.
+      h.clock.advance(2)
+      await expect(h.service.resolve([scope], viewer)).resolves.toEqual({ allowedScopes: [], degraded: true })
+    })
+
+    it('lets a decided denial disarm the grace, so a later outage cannot resurrect the grant', async () => {
+      const h = make(true, vi.fn().mockResolvedValue('read'))
+
+      await h.service.resolve([scope], viewer)
+      h.clock.advance(120_001)
+      h.permissionForUser.mockResolvedValue('none')
+      await expect(h.service.resolve([scope], viewer)).resolves.toEqual({ allowedScopes: [], degraded: false })
+
+      // The deny is cached for 30 s; past it the check runs again and now cannot reach GitHub at all.
+      h.clock.advance(30_001)
+      h.permissionForUser.mockRejectedValue(new Error('provider unavailable'))
+      await expect(h.service.resolve([scope], viewer)).resolves.toEqual({ allowedScopes: [], degraded: true })
+    })
+
+    it('names the cause and whether the grant survived, so a blip leaves a trace', async () => {
+      const warn = vi.fn()
+      const clock = new FakeClock(EPOCH)
+      const permissionForUser = vi.fn().mockResolvedValue('read')
+      const service = new GithubSessionAccessService({
+        installations: { get: vi.fn().mockResolvedValue(installation) } as never,
+        github: { repoRefById: vi.fn().mockResolvedValue(PRIVATE_SHAPE) },
+        userAuthz: { permissionForUser },
+        clock,
+        log: { debug: vi.fn(), warn }
+      })
+
+      await service.resolve([scope], viewer)
+      clock.advance(120_001)
+      permissionForUser.mockRejectedValue(Object.assign(new Error('boom'), { code: 'ETIMEDOUT' }))
+      await service.resolve([scope], viewer)
+
+      // A CAUSE, never a TARGET — the error's code, never its message.
+      expect(warn).toHaveBeenCalledWith(
+        { provider: 'github', cause: 'ETIMEDOUT', graced: true },
+        expect.stringContaining('degraded')
+      )
+    })
+  })
+
   it('reads a repository shape once for every viewer that asks about it', async () => {
     const h = make(false)
 

--- a/packages/control-plane/src/http/github-session-access.ts
+++ b/packages/control-plane/src/http/github-session-access.ts
@@ -28,6 +28,13 @@ const DEFAULT_PUBLIC_TTL_MS = 3_600_000
 // identity serving lease must not stretch unlink residue.
 const UNLINK_RESIDUE_CAP_MS = PROVIDER_IDENTITY_TTL_MS
 
+/** A CAUSE, never a TARGET (the slack-session-access.ts discipline): the error's code or class name, never its message. */
+function degradedCause(err: unknown): string {
+  if (!(err instanceof Error)) return typeof err
+  const code = (err as { code?: unknown }).code
+  return typeof code === 'string' || typeof code === 'number' ? String(code) : err.name
+}
+
 type Decision = 'allow' | 'deny' | 'unknown'
 /** Narrowed `repoRefById` result; null = outside the installation's grant. */
 type RepoShape = { fullName: string; private: boolean } | null
@@ -71,6 +78,9 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
   readonly provider = 'github'
   /** Per-viewer verdicts. Every entry carries its own TTL — see `putCache`. */
   private readonly cache: LRUCache<string, Decision>
+  /** Keys this viewer was really ALLOWED on, armed for one lease past the verdict's own.
+   *  Presence is what lets an unverifiable check re-serve a grant instead of hiding the session. */
+  private readonly gracedAllows: LRUCache<string, true>
   /** (installation, repo) → shape. Shared across viewers, unlike `cache`.
    *  `fetch` hands concurrent callers of one key the same promise, and drops
    *  the entry when the lookup rejects, so a failed lookup stays a
@@ -101,13 +111,16 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
       publicTtlMs?: number
       /** `SESSION_ACCESS_IDENTITY_TTL_SEC` in ms; defaults so tests can omit it. */
       identityTtlMs?: number
-      log?: { debug: (obj: object, msg: string) => void }
+      /** `warn` is optional so tests can omit it, but without one a degraded check leaves no trace at all —
+       *  which is what made an intermittent GitHub blip indistinguishable, after the fact, from a real denial. */
+      log?: { debug: (obj: object, msg: string) => void; warn?: (obj: object, msg: string) => void }
     }
   ) {
     this.recheckMs = deps.recheckMs ?? DEFAULT_RECHECK_MS
     this.publicTtlMs = deps.publicTtlMs ?? DEFAULT_PUBLIC_TTL_MS
     this.identityTtlMs = deps.identityTtlMs ?? PROVIDER_IDENTITY_TTL_MS
     this.cache = new LRUCache(cacheOptions(deps.clock, MAX_CACHE_ENTRIES))
+    this.gracedAllows = new LRUCache(cacheOptions(deps.clock, MAX_CACHE_ENTRIES))
     this.shapes = new LRUCache({
       ...cacheOptions(deps.clock, MAX_CACHE_ENTRIES),
       ttl: this.recheckMs,
@@ -175,23 +188,28 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
 
     let decision: Decision
     let identityBacked = false
+    let cause: string | undefined
     try {
       const observed = await this.shapeOf(`${installation.installationId}:${scope.resourceKey}`, {
         github,
         ins: installation,
         repoId: BigInt(scope.resourceKey)
       })
-      // Only reachable if the entry is dropped mid-flight. Fail closed rather
-      // than reading it as "no such repository", which is a deny we cannot back.
-      if (!observed) return 'unknown'
-      const repo = observed.shape
-      if (!repo) decision = 'deny'
+      // `undefined` (entry dropped mid-flight) is NOT `null` (out of the installation's grant):
+      // fail closed rather than reading it as "no such repository", which is a deny we cannot back.
+      const repo = observed?.shape
+      if (repo === undefined) {
+        decision = 'unknown'
+        cause = 'shape_evicted'
+      } else if (!repo) decision = 'deny'
       else if (!repo.private) decision = 'allow'
       else if (!this.deps.userAuthz) decision = 'deny'
       else {
         const [owner, name] = repo.fullName.split('/')
-        if (!owner || !name) decision = 'unknown'
-        else {
+        if (!owner || !name) {
+          decision = 'unknown'
+          cause = 'repo_name_unparsed'
+        } else {
           identityBacked = true
           decision =
             (await this.deps.userAuthz.permissionForUser(userId, installation, owner, name, {
@@ -209,6 +227,21 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
       }
     } catch (err) {
       decision = err instanceof UserAuthzDeniedError ? 'deny' : 'unknown'
+      if (decision === 'unknown') cause = degradedCause(err)
+    }
+    // An unverifiable check is not a denial. Re-serve an allow this viewer already earned rather than
+    // hiding the session behind a provider blip — nobody who was never allowed is admitted, and the
+    // price is that a revocation landing DURING the outage bites up to one extra lease later.
+    // A graced serve is deliberately not `degraded`: nothing is hidden, so the console has nothing to warn about.
+    if (decision === 'unknown') {
+      const graced = this.gracedAllows.has(key)
+      this.deps.log?.warn?.(
+        { provider: 'github', cause, graced },
+        graced
+          ? 'github access check degraded — re-serving an allow this viewer already earned'
+          : 'github access check degraded — affected sessions are hidden until access can be verified'
+      )
+      if (graced) return 'allow'
     }
     this.putCache(key, decision, identityBacked)
     return decision
@@ -302,5 +335,11 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
     const allowTtl = identityBacked ? Math.min(this.recheckMs, UNLINK_RESIDUE_CAP_MS) : this.recheckMs
     const ttl = decision === 'allow' ? allowTtl : decision === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
     this.cache.set(key, decision, { ttl })
+    // Only a decided `allow` arms the grace — for ONE more lease, so it inherits the identity cap above —
+    // and a graced serve never re-arms it, so a provider that stays unreachable expires the grant on
+    // schedule instead of renewing it for as long as it is down. A decided `deny` disarms it outright:
+    // once GitHub has answered "no", an outage after that may not resurrect what the answer took away.
+    if (decision === 'allow') this.gracedAllows.set(key, true, { ttl: allowTtl * 2 })
+    else if (decision === 'deny') this.gracedAllows.delete(key)
   }
 }

--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -257,6 +257,80 @@ describe('SlackSessionAccessService', () => {
     })
   })
 
+  describe('grace on an unverifiable check', () => {
+    /** A public channel every workspace member reads, until `answering` starts refusing. */
+    function flakyPublicChannel() {
+      let answering = true
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (!answering) return json({ ok: false, error: 'ratelimited' })
+        if (url.includes('conversations.info')) {
+          return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+        }
+        return json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+      })
+      return { fetchImpl, stop: () => (answering = false) }
+    }
+
+    it('re-serves an allow this principal already earned, and does not call it degraded', async () => {
+      const clock = new FakeClock(EPOCH)
+      const slack = flakyPublicChannel()
+      const resolver = service(slack.fetchImpl, undefined, { clock })
+
+      await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+      // Past the allow lease, so the verdict is re-decided — and Slack has stopped answering.
+      clock.advance(120_001)
+      slack.stop()
+
+      await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))).resolves.toEqual({
+        allowedScopes: [{ id: scope().id, aclRevision: 2n }],
+        degraded: false,
+        accessIssues: []
+      })
+    })
+
+    it('admits nobody who was never allowed', async () => {
+      const resolver = service(async () => json({ ok: false, error: 'ratelimited' }), undefined, {})
+
+      await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))).resolves.toEqual({
+        allowedScopes: [],
+        degraded: true,
+        accessIssues: [{ provider: 'slack', reason: 'unavailable' }]
+      })
+    })
+
+    it('expires one lease past the verdict rather than renewing while Slack is down', async () => {
+      const clock = new FakeClock(EPOCH)
+      const slack = flakyPublicChannel()
+      const resolver = service(slack.fetchImpl, undefined, { clock })
+
+      await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+      slack.stop()
+      clock.advance(239_999)
+      expect((await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))).allowedScopes).toHaveLength(1)
+
+      // A graced serve does not re-arm the grace, so the boundary stays anchored to the real allow.
+      clock.advance(2)
+      expect((await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))).degraded).toBe(true)
+    })
+
+    it('counts what the grace absorbed, so an app that stays down is still visible to an operator', async () => {
+      const warn = vi.fn()
+      const clock = new FakeClock(EPOCH)
+      const slack = flakyPublicChannel()
+      const resolver = service(slack.fetchImpl, { warn }, { clock })
+
+      await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+      clock.advance(120_001)
+      slack.stop()
+      await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0]?.[0]).toEqual({ provider: 'slack', gracedScopes: 1, totalScopes: 1 })
+      // A scope key names a channel; the operator needs the rate, not the target.
+      expect(JSON.stringify(warn.mock.calls[0]?.[0])).not.toContain('C_')
+    })
+  })
+
   // Degradation is the ONLY trace a hidden session leaves: every failure above
   // collapses to `unknown`, the session is omitted, and the caller is told
   // "not visible". Without this line an operator cannot tell a Slack blip from

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -80,7 +80,8 @@ type LocalReason =
   | `http_${number}`
 
 /** A verdict, plus — when it is `unknown` — why the check could not answer. */
-type Verdict = { decision: Decision; reason?: DegradedReason }
+/** `graced` marks an allow re-served over an unverifiable check, so `resolve` can count what the grace absorbed. */
+type Verdict = { decision: Decision; reason?: DegradedReason; graced?: true }
 /** Slack answered `ok: false`: a definitive denial, or a check that could not
  *  run and the code Slack gave for it. */
 type FailureVerdict = { decision: 'deny' } | { decision: 'unknown'; reason: DegradedReason }
@@ -253,6 +254,9 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
    *  A cached `unknown` keeps the reason it was reached by, so a resolve that
    *  rides one is not the one degraded resolve that cannot say why. */
   private readonly cache: LRUCache<string, Verdict>
+  /** Keys a principal was really ALLOWED on, armed for one lease past the verdict's own.
+   *  Presence is what lets an unverifiable check re-serve a grant instead of hiding the session. */
+  private readonly gracedAllows: LRUCache<string, true>
   /** (realm, ANSWERING bot, its credential revision, principal) → standing.
    *  The bot id is load-bearing: bots in one workspace hold different grants,
    *  so a verdict is reusable only under the credential that produced it —
@@ -301,6 +305,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     this.recheckMs = deps.recheckMs ?? DEFAULT_RECHECK_MS
     this.publicTtlMs = deps.publicTtlMs ?? DEFAULT_PUBLIC_TTL_MS
     this.cache = new LRUCache(cacheOptions(deps.clock, MAX_CACHE_ENTRIES))
+    this.gracedAllows = new LRUCache(cacheOptions(deps.clock, MAX_CACHE_ENTRIES))
     this.workspaceAccessCache = new LRUCache(cacheOptions(deps.clock, MAX_CACHE_ENTRIES))
     this.audiences = new LRUCache({
       ...cacheOptions(deps.clock, MAX_CACHE_ENTRIES),
@@ -388,6 +393,16 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
         'slack access check degraded — affected sessions are hidden until access can be verified'
       )
     }
+    // What the grace absorbed. Deliberately NOT `degraded`: no session is missing, so the console has
+    // nothing to tell the member — but the operator still needs the rate, or a Slack that stays down
+    // stops being visible here at exactly the moment it starts costing something.
+    const gracedScopes = decisions.filter(({ verdict }) => verdict.graced).length
+    if (gracedScopes > 0) {
+      this.deps.log?.warn(
+        { provider: 'slack', gracedScopes, totalScopes: decisions.length },
+        'slack access check degraded — re-serving grants these principals already earned'
+      )
+    }
     return {
       allowedScopes: decisions
         .filter(({ verdict }) => verdict.decision === 'allow')
@@ -414,9 +429,14 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
         this.putCache(key, verdict)
       }
       if (verdict.decision === 'allow') return verdict
-      // The FIRST cause is kept, not the last, so one degraded scope reports
-      // one reason and the counts in `resolve` still sum to `unknownScopes`.
-      if (verdict.decision === 'unknown') unknownReason ??= verdict.reason ?? 'unreported'
+      if (verdict.decision === 'unknown') {
+        // An unverifiable check is not a denial: re-serve an allow this principal already earned
+        // rather than hiding the conversation behind a Slack-side blip.
+        if (this.gracedAllows.has(key)) return { decision: 'allow', graced: true }
+        // The FIRST cause is kept, not the last, so one degraded scope reports
+        // one reason and the counts in `resolve` still sum to `unknownScopes`.
+        unknownReason ??= verdict.reason ?? 'unreported'
+      }
     }
     return unknownReason ? { decision: 'unknown', reason: unknownReason } : { decision: 'deny' }
   }
@@ -839,6 +859,12 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     // What this relaxes is exactly the §2.1 conversion window, bounded by touch-revalidation.
     const ttl = decision === 'allow' ? this.recheckMs : decision === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
     this.cache.set(key, verdict, { ttl })
+    // Only a decided `allow` arms the grace — for ONE more lease — and a graced serve never re-arms it,
+    // so a Slack that stays unreachable expires the grant on schedule instead of renewing it for as long
+    // as it is down. A decided `deny` disarms it outright: once Slack has answered "no", an outage after
+    // that may not resurrect what the answer took away.
+    if (decision === 'allow') this.gracedAllows.set(key, true, { ttl: this.recheckMs * 2 })
+    else if (decision === 'deny') this.gracedAllows.delete(key)
   }
 
   private putWorkspaceAccess(key: string, checked: CheckedWorkspaceAccess): void {


### PR DESCRIPTION
## What happened

A console user opened a GitHub-sourced session link, got **"Session unavailable — session isn't available to you"**, and found the same link working again about two minutes later. Nothing was wrong with the data: the row was `visibility=external, externalProvider=github, externalResolution=settled`, its scope was live, and the provider's read sync was enabled the whole time.

The 404 came from the authorization decision, not from absence. Reconstructed from the request log:

| | result | latency |
|---|---|---|
| T+0s | 200 | 26 ms |
| T+72s | **404** | **1390 ms** — a cold sweep that really called upstream |
| T+86s … T+165s | 404 ×9 | 6–37 ms — the negative answer served straight from cache |
| T+186s | 200 | 44 ms |

## Why

An external-visibility session is authorized **solely** by its provider scope — `can()` gives no role, not even owner, any say. Every session-access plugin re-decides on a lease, and a re-decision means live provider calls on the request path. Any failure in any leg was mapped to `unknown`, which drops the scope, which the session routes serve as a plain 404 — indistinguishable from a session that does not exist.

The GitHub check made it worse in two ways: for a repository that needs a per-viewer permission check it runs a live identity lookup *plus* a live permission read every recheck period (`maxCacheAgeMs: 0` — the permission is the revocable fact, so it is demanded age-zero), and it swallowed every failure with no log line anywhere. The only way to reconstruct the incident afterwards was to read latencies out of the access log.

**All three plugins had the same gap.** Slack was already given the observability half of this treatment — [it warns and reports `accessIssues`](https://github.com/agentconnect-md/agentconnect/blob/main/packages/control-plane/src/http/slack-session-access.ts) — but never the availability half, so a Slack blip still hid conversations. Feishu had neither.

## What this changes

**An unverifiable check is not a denial.** Each plugin now keeps a bounded record of what a viewer was *really* granted and re-serves that grant when the check cannot run. Nobody who was never granted access is admitted. The price, accepted deliberately: a revocation landing **during** the outage takes up to one extra lease to bite.

Two rules keep the grace from becoming a back door, and hold in all three:

- **Only a decided grant arms it, and a graced serve never re-arms it** — a provider that stays down expires the grant on schedule instead of renewing it for as long as it is down.
- **A decided denial disarms it outright** — once the provider has answered "no", a later outage cannot resurrect what that answer took away. Without this, "removed from the repo → deny → 30 s later a provider blip" would have handed the grant back.

Per plugin:

- **GitHub** — armed beside the existing per-viewer verdict. The grace is one more lease (`allowTtl * 2`), so it inherits the existing identity-backed cap rather than following the recheck knob past it.
- **Slack** — the same shape, armed beside its per-principal verdict.
- **Feishu** — the record had to be invented. It caches the chat's member list *shared across viewers* and derives each verdict by intersecting that list with the caller's union_ids, so nothing there remembered that a **person** was admitted. The new record is that and only that: it caches no audience, and the decision stays derived.

No new environment variable — every window is derived from the leases already configured.

On logging: GitHub now warns with the `cause` (an error code or class name, never a message) and whether the grant survived. Slack counts what the grace absorbed and reports one line per resolve, matching its existing counts-not-targets discipline. Feishu gains a `warn` seam for the same reason. A graced serve is deliberately **not** reported as `degraded` — nothing is hidden, so the console has nothing to tell the member — which is exactly why the operator-side count matters: without it a provider that stays down goes quiet in the logs at the moment it starts costing something.

## Reviewer notes

- **A separate bug this work surfaced, not fixed here.** `viewerFor` catches an `addViewerIdentities` failure with a warn and continues, so an identity-provider outage yields a viewer with *fewer* identities rather than an error. Slack's `resolve` then sees zero principals and returns `{ allowedScopes: [], degraded: false }` — a **confident** "no access", not a degraded one, and the grace cannot cover it because its key carries the principal. That is a silent wrong answer rather than a failed check, its fix touches shared code plus all three plugins' degraded semantics, and folding it in here would make this diff much harder to review. Feishu already reports that case as `unknown`.
- **No change to the snapshot layer.** A degraded sweep resolving to an empty allow-list still replaces a healthy snapshot, but with the grace in place that outcome now only occurs when the viewer genuinely has no prior grant — which is the case that *should* stay hidden.
- **Known remaining gap:** a first-ever cold visit that coincides with an outage (or one right after a restart, with every cache cold) has no grant to re-serve and is still hidden. Closing that would mean persisting authorization verdicts, which is a different order of change.

## Testing

`pnpm --filter @agentconnect.md/control-plane test:unit` — 1778 passing, including thirteen new cases across the three plugins covering: the grant survives a blip and is not called degraded; a viewer who was never granted access is still refused; the grace expires one lease past the verdict rather than renewing while the provider is down; a decided denial disarms it; and the logs name the cause and what the grace absorbed without naming a target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
