### PR TITLE
refactor(daemon): cut the duty coordinator's delegate shells

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -322,7 +322,7 @@ import { resolveMemoryFs } from './memory/fs.js'
 import { createWorkspaceGit } from './cp/workspace-git.js'
 import { DAEMON_VERSION } from './version.js'
 import { CpCronRegistry } from './cp/cp-cron.js'
-import { DutyRegistry, type DutyApplyResult } from './cp/duty-registry.js'
+import { DutyRegistry } from './cp/duty-registry.js'
 import { DutyCoordinator, type DutyHost } from './cp/duty-coordinator.js'
 import { CpAgentRegistry } from './cp/cp-agent-registry.js'
 import {
@@ -432,12 +432,7 @@ import type {
   ExternalSessionOrigin,
   ChannelAgentsOk,
   TaskList,
-  TaskListReq,
-  DutyAgentBundle,
-  DutyGrantEntry,
-  DutyMemberRef,
-  DutyRevoke,
-  HeartbeatDuties
+  TaskListReq
 } from '@agentconnect.md/protocol'
 import { formatErr } from './daemon/text.js'
 import {
@@ -1482,7 +1477,7 @@ export class Daemon {
     // Duty gate: on a pooled daemon only the agents whose group this member
     // holds get physical connections — every consolidator derives from here, so
     // opening and closing sockets on a grant/revoke needs no other change.
-    if (this.dutyEnforced()) {
+    if (this.dutyCoordinator.dutyEnforced()) {
       const held = this.duties.agents()
       agents = agents.filter((agent) => held.has(agent.id))
     }
@@ -1838,7 +1833,9 @@ export class Daemon {
         agentIds: () =>
           [...this.agents.values()]
             .filter(
-              (agent) => memoryKindOf(agent) === 'managed' && (!this.dutyEnforced() || this.duties.holdsAgent(agent.id))
+              (agent) =>
+                memoryKindOf(agent) === 'managed' &&
+                (!this.dutyCoordinator.dutyEnforced() || this.duties.holdsAgent(agent.id))
             )
             .map((agent) => agent.id),
         reachable: (agentId) => !this.k8sPlane || this.k8sPlane.runsInSandbox(agentId),
@@ -2515,17 +2512,6 @@ export class Daemon {
    */
   private reconcileRun?: Promise<void>
   private reconcilePending = false
-  // The duty-driven platform convergence counters live on the coordinator; the reconcile pass and
-  // the shutdown release read and publish them through these same-name accessors.
-  private get dutyConnectionsRequested(): number {
-    return this.dutyCoordinator.dutyConnectionsRequested
-  }
-  private get dutyConnectionsConverged(): number {
-    return this.dutyCoordinator.dutyConnectionsConverged
-  }
-  private set dutyConnectionsConverged(value: number) {
-    this.dutyCoordinator.dutyConnectionsConverged = value
-  }
   // Register snapshots publish agents before integrations. Carry newly-owned (installed or
   // duty-gained) inbox rows across coalesced passes and replay only after convergence is idle.
   private readonly pendingInboxReplayAgents = new Set<string>()
@@ -2555,8 +2541,8 @@ export class Daemon {
     // CLAIMED, not consumed: the request is marked satisfied only where the sockets actually
     // converge. This pass can throw at a dozen places before it reaches the platform layer, and a
     // fence whose sockets are still open must not be forgotten because one reconcile failed.
-    const dutyClaimed = this.dutyConnectionsRequested
-    const dutyDirty = dutyClaimed !== this.dutyConnectionsConverged
+    const dutyClaimed = this.dutyCoordinator.dutyConnectionsRequested
+    const dutyDirty = dutyClaimed !== this.dutyCoordinator.dutyConnectionsConverged
     const snapshot = this.loadAgentList(true)
     const files = snapshot.agents
     const nextFileAgents = new Map(files.map((a) => [a.id, a]))
@@ -2741,7 +2727,7 @@ export class Daemon {
       // Converged for real: the sockets a duty change invalidated are closed. Publishing the
       // CLAIMED value (not the current one) leaves a duty change that landed mid-pass outstanding,
       // so the trailing re-run still converges it.
-      if (dutyDirty) this.dutyConnectionsConverged = dutyClaimed
+      if (dutyDirty) this.dutyCoordinator.dutyConnectionsConverged = dutyClaimed
     }
     // The live roster just changed shape — re-announce any agent-derived register
     // capabilities. No-op when nothing changed. Optional call: tests inject
@@ -5785,8 +5771,8 @@ export class Daemon {
     // this member does not hold is claimed on receipt — winning serves it here,
     // losing answers `not_holder` so the router re-routes. The verdict is NOT
     // cached in relayMsgAcks: a later grant must not keep replaying a refusal.
-    if (this.dutyEnforced() && !this.duties.holdsAgent(msg.agentId)) {
-      const task = this.claimDutyForTrigger(msg.agentId).then((claimed) => {
+    if (this.dutyCoordinator.dutyEnforced() && !this.duties.holdsAgent(msg.agentId)) {
+      const task = this.dutyCoordinator.claimDutyForTrigger(msg.agentId).then((claimed) => {
         this.pendingRelayMsgAcks.delete(dedupKey)
         if (claimed.granted) return this.handleRelayMsg(msg, chat, post)
         return {
@@ -8011,7 +7997,7 @@ export class Daemon {
 
   /** Whether this member serves the agent's ingress edges and sweeps: the duty holder, or any local daemon. */
   private servesAgent(agentId: string): boolean {
-    return !this.dutyEnforced() || this.duties.holdsAgent(agentId)
+    return !this.dutyCoordinator.dutyEnforced() || this.duties.holdsAgent(agentId)
   }
 
   /** Deadline fired (§3.5): mark every still-open subtask timed_out, then WAKE the main's
@@ -9027,88 +9013,6 @@ export class Daemon {
     }
   }
 
-  // Duty grant admission, install, and convergence live in `cp/duty-coordinator.ts`; these are the
-  // thin same-name delegates the daemon's own paths (and the tests) still reach them through.
-  private dutyDigest(): HeartbeatDuties {
-    return this.dutyCoordinator.dutyDigest()
-  }
-
-  private dutyHeadroom(): number {
-    return this.dutyCoordinator.dutyHeadroom()
-  }
-
-  private dutyHeadroomForPendingClaim(): number {
-    return this.dutyCoordinator.dutyHeadroomForPendingClaim()
-  }
-
-  private dutyEnforced(): boolean {
-    return this.dutyCoordinator.dutyEnforced()
-  }
-
-  private applyDutyGrant(grants: DutyGrantEntry[]): void {
-    this.dutyCoordinator.applyDutyGrant(grants)
-  }
-
-  private admitDutyGrants(entries: DutyGrantEntry[]): Promise<Set<string>> {
-    return this.dutyCoordinator.admitDutyGrants(entries)
-  }
-
-  private settleDutyChange(result: DutyApplyResult): void {
-    this.dutyCoordinator.settleDutyChange(result)
-  }
-
-  private withdrawDutyGroups(groupIds: Iterable<string>): string[] {
-    return this.dutyCoordinator.withdrawDutyGroups(groupIds)
-  }
-
-  private pendingDutyAdmissions(): string[] {
-    return this.dutyCoordinator.pendingDutyAdmissions()
-  }
-
-  private installGrantedAgents(entries: DutyGrantEntry[]): Promise<Set<string>> {
-    return this.dutyCoordinator.installGrantedAgents(entries)
-  }
-
-  private dutyBundleIsStale(member: DutyMemberRef): boolean {
-    return this.dutyCoordinator.dutyBundleIsStale(member)
-  }
-
-  private installDutyAgent(agentId: string, orgId: string): Promise<void> {
-    return this.dutyCoordinator.installDutyAgent(agentId, orgId)
-  }
-
-  private runDutyAgentInstall(agentId: string, orgId: string): Promise<void> {
-    return this.dutyCoordinator.runDutyAgentInstall(agentId, orgId)
-  }
-
-  private applyDutyDefinitions(bundle: DutyAgentBundle): void {
-    this.dutyCoordinator.applyDutyDefinitions(bundle)
-  }
-
-  private applyDutyRevoke(revocations: DutyRevoke['revocations']): void {
-    this.dutyCoordinator.applyDutyRevoke(revocations)
-  }
-
-  private fenceDuties(groupIds: string[]): void {
-    this.dutyCoordinator.fenceDuties(groupIds)
-  }
-
-  private claimDutyForTrigger(agentId: string): Promise<{ granted: boolean; holder?: string }> {
-    return this.dutyCoordinator.claimDutyForTrigger(agentId)
-  }
-
-  private joinInFlightDutyClaims(): Promise<void> {
-    return this.dutyCoordinator.joinInFlightDutyClaims()
-  }
-
-  private onDutyChanged(): void {
-    this.dutyCoordinator.onDutyChanged()
-  }
-
-  private convergeDutyConnections(delayMs?: number): void {
-    this.dutyCoordinator.convergeDutyConnections(delayMs)
-  }
-
   /** Arm this agent's cron + dream schedules, or disarm them when its duty lives
    *  elsewhere — a cron is an ingress edge, so it fires only at the holder. */
   private syncAgentSchedules(a: { id: string; crons: CronDef[]; memory?: Agent['memory'] }): void {
@@ -9196,23 +9100,6 @@ export class Daemon {
       this.log.info(`dream schedule of agent "${agentId}": firing the occurrence a duty handover missed`)
       this.onDreamScheduleFire(agentId)
     }
-  }
-
-  private stopServingAgent(agentId: string): void {
-    this.dutyCoordinator.stopServingAgent(agentId)
-  }
-
-  private stopServingAgentSettled(agentId: string): Promise<void> {
-    return this.dutyCoordinator.stopServingAgentSettled(agentId)
-  }
-
-  /** The duty teardown still settling for this agent, if any. */
-  private dutyHostStop(agentId: string): Promise<void> | undefined {
-    return this.dutyCoordinator.dutyHostStop(agentId)
-  }
-
-  private confirmDutyTeardown(agentIds: string[], target: number, deadlineAt: number): Promise<string | undefined> {
-    return this.dutyCoordinator.confirmDutyTeardown(agentIds, target, deadlineAt)
   }
 
   private cpDegradedScopes(): string[] {
@@ -15495,7 +15382,7 @@ export class Daemon {
     if (!plane) return
     for (const { agentId, since } of plane.launchedAgents()) {
       // Suspend is the holder's decision (k8s-daemon-pool §4); an ex-holder must not touch its successor's pod.
-      if (this.dutyEnforced() && !this.duties.holdsAgent(agentId)) continue
+      if (this.dutyCoordinator.dutyEnforced() && !this.duties.holdsAgent(agentId)) continue
       // A live host owns the decision above; suspending under it would pull the pod out from
       // beneath a runtime that is merely between turns.
       if (
@@ -15527,11 +15414,11 @@ export class Daemon {
   private adoptClusterSandbox(agentId: string): void {
     const plane = this.k8sPlane
     if (!plane) return
-    const prior = this.dutyHostStop(agentId) ?? Promise.resolve()
+    const prior = this.dutyCoordinator.dutyHostStop(agentId) ?? Promise.resolve()
     void prior
       .catch(() => undefined)
       .then(async () => {
-        if (this.dutyEnforced() && !this.duties.holdsAgent(agentId)) return
+        if (this.dutyCoordinator.dutyEnforced() && !this.duties.holdsAgent(agentId)) return
         await plane.adoptAgent(agentId)
       })
       .catch((err) =>
@@ -15681,35 +15568,9 @@ export class Daemon {
     }
     // Whole-daemon drain surrenders the duty leases too: the CP can re-grant
     // them to a survivor immediately instead of waiting out the reassign window.
-    if (drain.scope.kind === 'daemon') await this.releaseAllDuties()
+    if (drain.scope.kind === 'daemon') await this.dutyCoordinator.releaseAllDuties()
     this.log.info(`drain[${drain.scope.kind}]: done — released ${released.length} session(s)`)
     return { released }
-  }
-
-  // The shutdown drain/converge cluster lives in `cp/duty-coordinator.ts`; these are the thin
-  // same-name delegates the drain orchestrators (and the tests) still reach it through.
-  private releaseAllDuties(): Promise<void> {
-    return this.dutyCoordinator.releaseAllDuties()
-  }
-
-  private dutyGroupBusy(groupId: string): boolean {
-    return this.dutyCoordinator.dutyGroupBusy(groupId)
-  }
-
-  private releaseDutiesForShutdown(drain: ShutdownDutyDrain): Promise<void> {
-    return this.dutyCoordinator.releaseDutiesForShutdown(drain)
-  }
-
-  private settleLateGrants(drain: ShutdownDutyDrain): Promise<void> {
-    return this.dutyCoordinator.settleLateGrants(drain)
-  }
-
-  private awaitDutyConvergence(target: number, deadlineAt: number): Promise<boolean> {
-    return this.dutyCoordinator.awaitDutyConvergence(target, deadlineAt)
-  }
-
-  private releaseDutyAcknowledged(groupId: string, deadlineAt: number): Promise<boolean> {
-    return this.dutyCoordinator.releaseDutyAcknowledged(groupId, deadlineAt)
   }
 
   private sleepUntil(at: number): Promise<void> {
@@ -16016,7 +15877,9 @@ export class Daemon {
   /** SIGTERM drain budget: a pool member holds duty leases and waits for turns instead of cutting
    *  them (`poolShutdownDrainMs`); a local daemon keeps the short window its service manager allows. */
   private shutdownDrainBudgetMs(): number {
-    return this.k8s || this.dutyEnforced() ? this.cfg.limits.poolShutdownDrainMs : this.cfg.limits.shutdownDrainMs
+    return this.k8s || this.dutyCoordinator.dutyEnforced()
+      ? this.cfg.limits.poolShutdownDrainMs
+      : this.cfg.limits.shutdownDrainMs
   }
 
   /** §2.5 SIGTERM / daemon shutdown: gate new turns, then await in-flight turns up
@@ -16462,8 +16325,8 @@ export class Daemon {
       activationCapabilityError: (agent) => this.activationCapabilityError(agent),
       servesAgent: (agentId) => this.servesAgent(agentId),
       closeUnusedPlatformConnections: () => this.closeUnusedPlatformConnections(),
-      applyDutyGrant: (grants) => this.applyDutyGrant(grants),
-      applyDutyRevoke: (revocations) => this.applyDutyRevoke(revocations),
+      applyDutyGrant: (grants) => this.dutyCoordinator.applyDutyGrant(grants),
+      applyDutyRevoke: (revocations) => this.dutyCoordinator.applyDutyRevoke(revocations),
       decideEditorPermission: (req) => this.decideEditorPermission(req),
       leaveConversation: (leave) => this.leaveConversation(leave),
       retractChannels: (integrationId, channelIds) => this.retractChannels(integrationId, channelIds),
@@ -17029,9 +16892,9 @@ export class Daemon {
         return agentId ? (this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId)) : undefined
       },
       degradedScopes: () => this.cpDegradedScopes(),
-      duties: () => this.dutyDigest(),
-      dutyPending: () => this.pendingDutyAdmissions(),
-      onDutyFence: (groupIds) => this.fenceDuties(groupIds),
+      duties: () => this.dutyCoordinator.dutyDigest(),
+      dutyPending: () => this.dutyCoordinator.pendingDutyAdmissions(),
+      onDutyFence: (groupIds) => this.dutyCoordinator.fenceDuties(groupIds),
       configApply: this.cpConfigApply(),
       sessionRead: createSessionReader(this.store, (session) => this.sessionThreadUrl(session)),
       // §5.4: serve a CP-forwarded status probe for a child session we own. Authorization is
@@ -17076,8 +16939,9 @@ export class Daemon {
               }
             }
           : {}),
-        knowsAgent: (id) => this.agents.has(id) && (!this.dutyEnforced() || this.duties.holdsAgent(id)),
-        claimDuty: async (id) => this.dutyEnforced() && (await this.claimDutyForTrigger(id)).granted,
+        knowsAgent: (id) => this.agents.has(id) && (!this.dutyCoordinator.dutyEnforced() || this.duties.holdsAgent(id)),
+        claimDuty: async (id) =>
+          this.dutyCoordinator.dutyEnforced() && (await this.dutyCoordinator.claimDutyForTrigger(id)).granted,
         log: this.log
       }),
       memoryReader: createMemoryReader((id) => this.memoryFsFor(id), this.memory),
@@ -17753,7 +17617,7 @@ export class Daemon {
       lapsedAgents: new Set(),
       loopDone: false
     }
-    if (this.dutyEnforced()) {
+    if (this.dutyCoordinator.dutyEnforced()) {
       this.shutdownDutyDrain = shutdownDrain
       this.cpClient?.reportDutiesNow?.()
     }
@@ -17797,9 +17661,9 @@ export class Daemon {
     // the moment its own turns are done — idle groups at once, busy ones as they settle — so a
     // successor takes them while this member is still waiting on the slowest turn. The turn wait
     // stops short of the budget by the release reserve, so the last releases still land inside it.
-    const dutyDrain = this.releaseDutiesForShutdown(shutdownDrain)
+    const dutyDrain = this.dutyCoordinator.releaseDutiesForShutdown(shutdownDrain)
     await this.drainForShutdown(
-      this.dutyEnforced()
+      this.dutyCoordinator.dutyEnforced()
         ? Math.max(0, drainDeadlineAt - Daemon.DUTY_RELEASE_RESERVE_MS - this.clock.now())
         : this.shutdownDrainBudgetMs()
     )
@@ -17835,7 +17699,7 @@ export class Daemon {
     // proceeds without losing the revocation obligation.
     await this.revokeAllRemoteWebchatGrants('session_closed')
     // A grant can land right up to the socket close; its release must be settled before that.
-    if (this.shutdownDutyDrain) await this.settleLateGrants(shutdownDrain)
+    if (this.shutdownDutyDrain) await this.dutyCoordinator.settleLateGrants(shutdownDrain)
     this.shutdownDutyDrain = undefined
     await Promise.resolve(this.cpClient?.stop()).catch((e) => errors.push(e))
     await Promise.resolve(this.sessionMetadataOutbox.inFlightDrain()).catch((e) => errors.push(e))

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -534,7 +534,7 @@ describe('Daemon CP agent → memory + reconcile', () => {
     expect((daemon as any).hosts.has('bot-a')).toBe(false)
 
     // The duty grant is what starts it, and the current replica makes that install a no-fetch.
-    await (daemon as any).admitDutyGrants([dutyGrant('bot-a')])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([dutyGrant('bot-a')])
     expect(fetchDutyAgent).not.toHaveBeenCalled()
     expect((daemon as any).servesAgent('bot-a')).toBe(true)
     await (daemon as any).ensureHostAsync('bot-a')
@@ -584,7 +584,7 @@ describe('Daemon CP agent → memory + reconcile', () => {
       await reconcile()
       if (landed || (daemon as any).moveStagedAgents.has('bot-a')) return
       landed = true
-      ;(daemon as any).applyDutyRevoke([{ groupId: GROUP_ID, reason: 'superseded' }])
+      ;(daemon as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP_ID, reason: 'superseded' }])
     }
 
     await expect(

--- a/packages/daemon/test/daemon-duty-drain.test.ts
+++ b/packages/daemon/test/daemon-duty-drain.test.ts
@@ -74,13 +74,14 @@ async function boot(opts: { releaseDuties?: (groupIds: string[]) => Promise<void
       bundle: bundle(agentId, agentId === AGENT ? 'scout' : 'ranger')
     }))
   }
-  await (daemon as any).admitDutyGrants([grant(GROUP, AGENT), grant(GROUP_B, AGENT_B)])
+  await (daemon as any).dutyCoordinator.admitDutyGrants([grant(GROUP, AGENT), grant(GROUP_B, AGENT_B)])
   expect(duties(daemon).groupIds().sort()).toEqual([GROUP, GROUP_B])
   return { daemon, clock, calls, releaseDuties, stop, reportDutiesNow }
 }
 
 const duties = (d: Daemon) => (d as any).duties as DutyRegistry
-const digest = (d: Daemon) => (d as any).dutyDigest() as { held: unknown[]; headroom: number; draining?: boolean }
+const digest = (d: Daemon) =>
+  (d as any).dutyCoordinator.dutyDigest() as { held: unknown[]; headroom: number; draining?: boolean }
 
 describe('shutdown drain of a duty-holding member', () => {
   it('declares draining and releases each idle group with an awaited ack before the socket closes', async () => {
@@ -124,7 +125,7 @@ describe('shutdown drain of a duty-holding member', () => {
 
     const stopping = daemon.stop()
     // An exchange that began before the SIGTERM commits its vacancy grant and delivers it now.
-    ;(daemon as any).applyDutyGrant([grant(LATE, 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3')])
+    ;(daemon as any).dutyCoordinator.applyDutyGrant([grant(LATE, 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3')])
     await stopping
 
     expect(fetchDutyAgent).not.toHaveBeenCalledWith(
@@ -148,7 +149,7 @@ describe('shutdown drain of a duty-holding member', () => {
 
     const stopping = daemon.stop()
     // A late grant for another agent, and a replacement of the busy group at a bumped term.
-    ;(daemon as any).applyDutyGrant([
+    ;(daemon as any).dutyCoordinator.applyDutyGrant([
       grant(LATE, 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3'),
       { ...grant(GROUP, AGENT), term: '2' }
     ])
@@ -188,7 +189,7 @@ describe('shutdown drain of a duty-holding member', () => {
 
     const stopping = daemon.stop()
     // A split: agent A re-homed under a NEW group id, delivered after the latch.
-    ;(daemon as any).applyDutyGrant([grant(LATE, AGENT)])
+    ;(daemon as any).dutyCoordinator.applyDutyGrant([grant(LATE, AGENT)])
     await stopping
 
     // GROUP lapses (its host would not stop), and so does the late grant that covers the same agent.
@@ -209,12 +210,12 @@ describe('shutdown drain of a duty-holding member', () => {
       }),
       cancel: vi.fn(async () => {})
     })
-    ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
+    ;(daemon as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
     await flush()
     const warn = vi.spyOn((daemon as any).log, 'warn')
 
     const stopping = daemon.stop()
-    ;(daemon as any).applyDutyGrant([{ ...grant(GROUP, AGENT), term: '2' }])
+    ;(daemon as any).dutyCoordinator.applyDutyGrant([{ ...grant(GROUP, AGENT), term: '2' }])
     await stopping
 
     expect(calls.releases).toEqual([[GROUP_B]])
@@ -226,7 +227,7 @@ describe('shutdown drain of a duty-holding member', () => {
     {
       const { daemon, calls } = await boot()
       // Only GROUP is held, so the loop has nothing to do once it is revoked.
-      ;(daemon as any).applyDutyRevoke([{ groupId: GROUP_B, reason: 'gone' }])
+      ;(daemon as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP_B, reason: 'gone' }])
       await flush()
       let finishReconcile!: () => void
       const gate = new Promise<void>((resolve) => {
@@ -237,11 +238,11 @@ describe('shutdown drain of a duty-holding member', () => {
         await gate
         await runReconcile()
       }
-      ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
+      ;(daemon as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
       expect(duties(daemon).size()).toBe(0)
 
       const stopping = daemon.stop()
-      ;(daemon as any).applyDutyGrant([{ ...grant(GROUP, AGENT), term: '2' }])
+      ;(daemon as any).dutyCoordinator.applyDutyGrant([{ ...grant(GROUP, AGENT), term: '2' }])
       await flush()
       // Loop done at once (nothing held), host long gone — still no ack while the socket teardown pends.
       expect(calls.releases).toEqual([])
@@ -254,14 +255,14 @@ describe('shutdown drain of a duty-holding member', () => {
     {
       const { daemon, clock, calls } = await boot()
       ;(daemon as any).cfg.limits.poolShutdownDrainMs = 1_500
-      ;(daemon as any).applyDutyRevoke([{ groupId: GROUP_B, reason: 'gone' }])
+      ;(daemon as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP_B, reason: 'gone' }])
       await flush()
       ;(daemon as any).runReconcile = () => new Promise<void>(() => {})
-      ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
+      ;(daemon as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
       const warn = vi.spyOn((daemon as any).log, 'warn')
 
       const stopping = daemon.stop()
-      ;(daemon as any).applyDutyGrant([{ ...grant(GROUP, AGENT), term: '2' }])
+      ;(daemon as any).dutyCoordinator.applyDutyGrant([{ ...grant(GROUP, AGENT), term: '2' }])
       // The 1.5s budget is the thing under test, so it is elapsed in virtual time, not slept.
       await runVirtual(clock, stopping, 2_000)
 
@@ -272,9 +273,9 @@ describe('shutdown drain of a duty-holding member', () => {
 
   it('a CP-commanded rebalance drain still ignores grants that land while it is suspended', async () => {
     const { daemon, releaseDuties } = await boot()
-    const admit = vi.spyOn(daemon as any, 'admitDutyGrants')
+    const admit = vi.spyOn((daemon as any).dutyCoordinator, 'admitDutyGrants')
     ;(daemon as any).dutyClaimsSuspended = true
-    ;(daemon as any).applyDutyGrant([
+    ;(daemon as any).dutyCoordinator.applyDutyGrant([
       grant('11111111-1111-4111-8111-111111111114', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4')
     ])
     await flush()

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -99,7 +99,7 @@ async function boot(scope: 'frame' | 'connection' = 'frame') {
     reportDutiesNow: vi.fn(() => {}),
     fetchDutyAgent
   }
-  await (daemon as any).admitDutyGrants([grant()])
+  await (daemon as any).dutyCoordinator.admitDutyGrants([grant()])
   return { daemon, root, clock, fetchDutyAgent }
 }
 
@@ -127,16 +127,16 @@ async function bootMidAdmission() {
     reportDutiesNow: vi.fn(() => {}),
     fetchDutyAgent
   }
-  const admitted = (daemon as any).admitDutyGrants([grant()]) as Promise<Set<string>>
+  const admitted = (daemon as any).dutyCoordinator.admitDutyGrants([grant()]) as Promise<Set<string>>
   await vi.waitFor(() => expect(fetchDutyAgent).toHaveBeenCalled())
   return { daemon, admitted, release }
 }
 
 const duties = (d: Daemon) => (d as any).duties as DutyRegistry
-const pending = (d: Daemon): string[] => (d as any).pendingDutyAdmissions()
+const pending = (d: Daemon): string[] => (d as any).dutyCoordinator.pendingDutyAdmissions()
 const served = (d: Daemon): string[] => (d as any).transportAgents().map((a: { id: string }) => a.id)
 /** Fence the given groups, as the client's per-group deadline does when one elapses. */
-const fence = (d: Daemon, groupIds: string[] = [GROUP]) => (d as any).fenceDuties(groupIds)
+const fence = (d: Daemon, groupIds: string[] = [GROUP]) => (d as any).dutyCoordinator.fenceDuties(groupIds)
 
 /** Put a live Slack socket in the pool under the granted agent's own credentials, exactly as a
  *  successful `reconcileSlackConnections` would. Its key is what consolidation asks for while the
@@ -271,7 +271,7 @@ describe('the duty self-fence', () => {
     ;(daemon as any).cpClient.fetchDutyAgent = vi.fn(async () => ({
       bundle: bundle(AGENT_B, 'ranger', INTEGRATION_B, { botToken: 'xoxb-b', appToken: 'xapp-b' })
     }))
-    await (daemon as any).admitDutyGrants([grant(GROUP_B, AGENT_B)])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant(GROUP_B, AGENT_B)])
     expect(served(daemon).sort()).toEqual([AGENT, AGENT_B].sort())
     const socketA = liveSlackSocket(daemon)
     const socketB = liveSlackSocket(daemon, INTEGRATION_B, { botToken: 'xoxb-b', appToken: 'xapp-b' })
@@ -301,7 +301,7 @@ describe('the duty self-fence', () => {
     // `applyRevoke` reports an agent as lost only when it is in NO held group any more, and the
     // teardown follows that, not the group membership — so a shared agent keeps serving.
     const { daemon } = await boot()
-    await (daemon as any).admitDutyGrants([grant(GROUP_B, AGENT)])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant(GROUP_B, AGENT)])
     expect(duties(daemon).digest()).toHaveLength(2)
 
     fence(daemon, [GROUP])
@@ -333,7 +333,7 @@ describe('the duty self-fence', () => {
   it('a revoke landing mid-admission refuses it the same way', async () => {
     const { daemon, admitted, release } = await bootMidAdmission()
 
-    ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
+    ;(daemon as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
     release()
 
     expect([...(await admitted)]).toEqual([GROUP])
@@ -345,7 +345,7 @@ describe('the duty self-fence', () => {
   it('a drain release mid-admission refuses it, so nothing installs itself back after drain/done', async () => {
     const { daemon, admitted, release } = await bootMidAdmission()
 
-    await (daemon as any).releaseAllDuties()
+    await (daemon as any).dutyCoordinator.releaseAllDuties()
     release()
 
     expect([...(await admitted)]).toEqual([GROUP])
@@ -388,7 +388,7 @@ describe('the duty self-fence', () => {
 
     // What a reconnect looks like: the CP still leases the group to this member, sees a
     // digest that omits it, and reissues the grant.
-    await (daemon as any).admitDutyGrants([grant()])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant()])
 
     expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '1' }])
     expect(served(daemon)).toContain(AGENT)

--- a/packages/daemon/test/daemon-duty-inbox-replay.test.ts
+++ b/packages/daemon/test/daemon-duty-inbox-replay.test.ts
@@ -112,13 +112,16 @@ async function boot(root: string) {
   return { daemon, ...g, fetchDutyAgent }
 }
 
-const admit = (d: Daemon, term = '1') => (d as any).admitDutyGrants([grant(term)]) as Promise<Set<string>>
-const fence = (d: Daemon) => (d as any).fenceDuties([GROUP])
+const admit = (d: Daemon, term = '1') =>
+  (d as any).dutyCoordinator.admitDutyGrants([grant(term)]) as Promise<Set<string>>
+const fence = (d: Daemon) => (d as any).dutyCoordinator.fenceDuties([GROUP])
 const holds = (d: Daemon): boolean => (d as any).duties.holdsAgent(AGENT)
 /** The reconcile a duty change requests has run to completion. */
 const settled = (d: Daemon) =>
   vi.waitFor(() => {
-    expect((d as any).dutyConnectionsConverged).toBe((d as any).dutyConnectionsRequested)
+    expect((d as any).dutyCoordinator.dutyConnectionsConverged).toBe(
+      (d as any).dutyCoordinator.dutyConnectionsRequested
+    )
     expect((d as any).reconcileRun).toBeUndefined()
   }, WAIT)
 

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -163,7 +163,7 @@ describe('installing an agent a duty grant covers', () => {
     const cp = registries(daemon)
     expect(cp.agents.has(AGENT)).toBe(false)
 
-    await (daemon as any).installGrantedAgents([grant()])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
 
     expect(fetchDutyAgent).toHaveBeenCalledWith(AGENT, ORG)
     expect(cp.agents.has(AGENT)).toBe(true)
@@ -182,7 +182,7 @@ describe('installing an agent a duty grant covers', () => {
     const fetchDutyAgent = vi.fn(async () => ({ bundle: bundleWithDefinitions() }))
     const daemon = await boot({ fetchDutyAgent })
 
-    await (daemon as any).installGrantedAgents([grant()])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
 
     // The proxy def is keyed (org, name) and must carry the bearer grant key —
     // presence of the NAME alone is exactly the broken state this fixes.
@@ -211,7 +211,7 @@ describe('installing an agent a duty grant covers', () => {
       return { bundle: bundleWithDefinitions('oct_retiring', 1_000) }
     })
     const daemon = await boot({ fetchDutyAgent })
-    const install = (daemon as any).installGrantedAgents([grant()])
+    const install = (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
 
     // The rotation's live push lands first, through the real frame handler.
     ;(daemon as any).cpConfigApply().applyMcpServerUpsert(proxyDef('oct_fresh', 2_000))
@@ -228,7 +228,7 @@ describe('installing an agent a duty grant covers', () => {
     const fetchDutyAgent = vi.fn(async () => ({ bundle: bundleWithDefinitions('oct_retiring', 1_000) }))
     const daemon = await boot({ fetchDutyAgent })
 
-    await (daemon as any).installGrantedAgents([grant()])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
     expect(bearerOf(daemon)).toBe('Bearer oct_retiring')
     ;(daemon as any).cpConfigApply().applyMcpServerUpsert(proxyDef('oct_fresh', 2_000))
 
@@ -240,7 +240,7 @@ describe('installing an agent a duty grant covers', () => {
     const fetchDutyAgent = vi.fn(async () => ({ bundle: bundleWithDefinitions() }))
     const daemon = await boot({ fetchDutyAgent })
 
-    await (daemon as any).installGrantedAgents([grant()])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
 
     expect(JSON.stringify((daemon as any).cpMcpDefs.effective(ORG))).not.toContain('issuedAt')
     await daemon.stop()
@@ -250,7 +250,7 @@ describe('installing an agent a duty grant covers', () => {
     const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
     const daemon = await boot({ fetchDutyAgent })
 
-    await (daemon as any).installGrantedAgents([grant()])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
 
     expect(registries(daemon).agents.has(AGENT)).toBe(true)
     expect((daemon as any).memoryConnections.connectionIds()).toEqual([])
@@ -274,7 +274,7 @@ describe('installing an agent a duty grant covers', () => {
       return realAgentUpsert(id, spec)
     }
 
-    await (daemon as any).installGrantedAgents([grant()])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
 
     // Registry-before-agent: static memory admission must never see the agent
     // before at least a probing (fail-closed) connection entry exists.
@@ -286,8 +286,8 @@ describe('installing an agent a duty grant covers', () => {
     const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
     const daemon = await boot({ fetchDutyAgent })
 
-    await (daemon as any).installGrantedAgents([grant()])
-    await (daemon as any).installGrantedAgents([grant()])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
 
     expect(fetchDutyAgent).toHaveBeenCalledTimes(1)
     await daemon.stop()
@@ -305,7 +305,7 @@ describe('installing an agent a duty grant covers', () => {
     cp.agents.upsert(AGENT, { ...bundle('3').spec })
     expect(cp.agents.appliedRevision(AGENT)).toBe(3n)
 
-    await (daemon as any).installGrantedAgents([grantAt('7')])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grantAt('7')])
 
     expect(fetchDutyAgent).toHaveBeenCalledWith(AGENT, ORG)
     expect(cp.agents.appliedRevision(AGENT)).toBe(7n)
@@ -319,7 +319,7 @@ describe('installing an agent a duty grant covers', () => {
 
     cp.agents.upsert(AGENT, { ...bundle('7').spec })
 
-    await (daemon as any).installGrantedAgents([grantAt('7')])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grantAt('7')])
 
     // The common path stays free: a regrant of a current replica costs no round trip.
     expect(fetchDutyAgent).not.toHaveBeenCalled()
@@ -334,7 +334,7 @@ describe('installing an agent a duty grant covers', () => {
     const daemon = await boot({ fetchDutyAgent })
     registries(daemon).agents.upsert(AGENT, { ...bundle('7').spec })
 
-    await (daemon as any).installGrantedAgents([grantAt('3')])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grantAt('3')])
 
     expect(fetchDutyAgent).not.toHaveBeenCalled()
     await daemon.stop()
@@ -354,9 +354,9 @@ describe('installing an agent a duty grant covers', () => {
     const daemon = await boot({ fetchDutyAgent })
     registries(daemon).agents.upsert(AGENT, { ...bundle('3').spec })
 
-    const admission = (daemon as any).admitDutyGrants([grantAt('7')])
+    const admission = (daemon as any).dutyCoordinator.admitDutyGrants([grantAt('7')])
     await vi.waitFor(() => expect(fetchDutyAgent).toHaveBeenCalled())
-    ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'gone' }])
+    ;(daemon as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP, reason: 'gone' }])
     releaseFetch()
 
     await expect(admission).resolves.toEqual(new Set([GROUP]))
@@ -369,7 +369,7 @@ describe('installing an agent a duty grant covers', () => {
     const daemon = await boot({ fetchDutyAgent })
     ;(daemon as any).moveStagedAgents.add(AGENT)
 
-    await (daemon as any).installGrantedAgents([grant()])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
 
     expect(fetchDutyAgent).not.toHaveBeenCalled()
     expect(registries(daemon).agents.has(AGENT)).toBe(false)
@@ -381,7 +381,7 @@ describe('installing an agent a duty grant covers', () => {
     const daemon = await boot({ fetchDutyAgent })
     vi.spyOn(daemon as any, 'agentRemovalPending').mockReturnValue(true)
 
-    await (daemon as any).installGrantedAgents([grant()])
+    await (daemon as any).dutyCoordinator.installGrantedAgents([grant()])
 
     expect(fetchDutyAgent).not.toHaveBeenCalled()
     await daemon.stop()
@@ -394,7 +394,7 @@ describe('installing an agent a duty grant covers', () => {
       })
     })
 
-    await expect((daemon as any).installGrantedAgents([grant()])).resolves.toEqual(new Set([GROUP]))
+    await expect((daemon as any).dutyCoordinator.installGrantedAgents([grant()])).resolves.toEqual(new Set([GROUP]))
     expect(registries(daemon).agents.has(AGENT)).toBe(false)
     await daemon.stop()
   })
@@ -413,7 +413,7 @@ describe('a group is not held until it is servable', () => {
     const daemon = await boot({ fetchDutyAgent })
 
     // The EVT entry point, exactly as ConfigApply calls it — returns immediately.
-    ;(daemon as any).applyDutyGrant([grant()])
+    ;(daemon as any).dutyCoordinator.applyDutyGrant([grant()])
     await vi.waitFor(() => expect(fetchDutyAgent).toHaveBeenCalled())
 
     // Load-bearing: this is the routing window. A digest that already advertised
@@ -436,7 +436,7 @@ describe('a group is not held until it is servable', () => {
       })
     })
 
-    await (daemon as any).admitDutyGrants([grant()])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant()])
 
     // Not held ⇒ absent from the digest ⇒ the CP sees a lease this member does
     // not report and reissues it through its missing-regrant path. Holding it
@@ -451,7 +451,7 @@ describe('a group is not held until it is servable', () => {
   it('an EMPTY reply refuses the group — the CP is saying we do not hold it', async () => {
     const daemon = await boot({ fetchDutyAgent: vi.fn(async () => ({})) })
 
-    await expect((daemon as any).admitDutyGrants([grant()])).resolves.toEqual(new Set([GROUP]))
+    await expect((daemon as any).dutyCoordinator.admitDutyGrants([grant()])).resolves.toEqual(new Set([GROUP]))
 
     expect(duties(daemon).digest()).toEqual([])
     expect(registries(daemon).agents.has(AGENT)).toBe(false)
@@ -464,7 +464,7 @@ describe('a group is not held until it is servable', () => {
       throw new Error('agent root is not writable')
     })
 
-    await (daemon as any).admitDutyGrants([grant()])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant()])
 
     expect(duties(daemon).digest()).toEqual([])
     expect(registries(daemon).agents.has(AGENT)).toBe(false)
@@ -479,7 +479,7 @@ describe('a group is not held until it is servable', () => {
       )
     })
 
-    await (daemon as any).admitDutyGrants([grant([AGENT, other])])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant([AGENT, other])])
 
     expect(duties(daemon).digest()).toEqual([])
     await daemon.stop()
@@ -494,18 +494,18 @@ describe('a group is not held until it is servable', () => {
     const daemon = await boot({ fetchDutyAgent })
     const advance = shiftClock(daemon)
 
-    await (daemon as any).admitDutyGrants([grant()])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant()])
     expect(duties(daemon).digest()).toEqual([])
 
     // Inside the retry window a regrant is refused again WITHOUT another fetch —
     // a permanently failing agent cannot outpace the beat that regrants it.
     broken = false
-    await (daemon as any).admitDutyGrants([grant()])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant()])
     expect(fetchDutyAgent).toHaveBeenCalledTimes(1)
     expect(duties(daemon).digest()).toEqual([])
 
     advance(20_000)
-    await (daemon as any).admitDutyGrants([grant()])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant()])
 
     expect(fetchDutyAgent).toHaveBeenCalledTimes(2)
     expect(duties(daemon).digest()).toEqual([{ groupId: GROUP, term: '1' }])
@@ -517,8 +517,8 @@ describe('a group is not held until it is servable', () => {
     const fetchDutyAgent = vi.fn(async () => ({ bundle: bundle() }))
     const daemon = await boot({ fetchDutyAgent })
 
-    await (daemon as any).admitDutyGrants([grant()])
-    await (daemon as any).admitDutyGrants([{ ...grant(), term: '2' }])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant()])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([{ ...grant(), term: '2' }])
 
     // The common path is unchanged: only a genuinely new agent waits.
     expect(fetchDutyAgent).toHaveBeenCalledTimes(1)
@@ -544,7 +544,7 @@ describe('the rendezvous claim ordering', () => {
     const cp = registries(daemon)
 
     let settled = false
-    const claim = (daemon as any).claimDutyForTrigger(AGENT).then((result: unknown) => {
+    const claim = (daemon as any).dutyCoordinator.claimDutyForTrigger(AGENT).then((result: unknown) => {
       settled = true
       return result
     })
@@ -571,7 +571,7 @@ describe('the rendezvous claim ordering', () => {
       })
     })
 
-    await expect((daemon as any).claimDutyForTrigger(AGENT)).resolves.toEqual({ granted: false })
+    await expect((daemon as any).dutyCoordinator.claimDutyForTrigger(AGENT)).resolves.toEqual({ granted: false })
 
     // The grant was never applied, so the answer and the local state agree:
     // saying "not me" while still holding the lease is the split brain this
@@ -588,7 +588,7 @@ describe('the rendezvous claim ordering', () => {
       fetchDutyAgent: vi.fn(async () => ({}))
     })
 
-    await expect((daemon as any).claimDutyForTrigger(AGENT)).resolves.toEqual({ granted: false })
+    await expect((daemon as any).dutyCoordinator.claimDutyForTrigger(AGENT)).resolves.toEqual({ granted: false })
 
     expect(duties(daemon).digest()).toEqual([])
     expect(registries(daemon).agents.has(AGENT)).toBe(false)
@@ -602,7 +602,7 @@ describe('the rendezvous claim ordering', () => {
     const grants = vi.spyOn((daemon as any).store, 'reclaimWebchatMcpGrants')
     const dreams = vi.spyOn((daemon as any).dreamRunner(), 'reclaimDreams')
 
-    await (daemon as any).admitDutyGrants([grant()])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant()])
 
     expect(duties(daemon).holdsAgent(AGENT)).toBe(true)
     expect(grants).toHaveBeenCalledWith([AGENT], 'session_closed', expect.any(Number))
@@ -611,7 +611,7 @@ describe('the rendezvous claim ordering', () => {
     // A re-grant of a group already held gains no agent, so it reclaims nothing.
     grants.mockClear()
     dreams.mockClear()
-    await (daemon as any).admitDutyGrants([grant()])
+    await (daemon as any).dutyCoordinator.admitDutyGrants([grant()])
     expect(grants).not.toHaveBeenCalled()
     expect(dreams).not.toHaveBeenCalled()
     await daemon.stop()

--- a/packages/daemon/test/daemon-duty-replacement.test.ts
+++ b/packages/daemon/test/daemon-duty-replacement.test.ts
@@ -102,14 +102,15 @@ async function boot(broken = new Set<string>()) {
     reportDutiesNow: vi.fn(() => {}),
     fetchDutyAgent
   }
-  await (daemon as any).admitDutyGrants([grant(GROUP, '1', [AGENT_A, AGENT_C])])
+  await (daemon as any).dutyCoordinator.admitDutyGrants([grant(GROUP, '1', [AGENT_A, AGENT_C])])
   return { daemon, root, broken, fetchDutyAgent }
 }
 
 const duties = (d: Daemon) => (d as any).duties as DutyRegistry
 const served = (d: Daemon): string[] => (d as any).transportAgents().map((a: { id: string }) => a.id)
 const schedules = (d: Daemon, agentId: string): number => (d as any).scheduler.count(agentId)
-const admit = (d: Daemon, entries: DutyGrantEntry[]) => (d as any).admitDutyGrants(entries) as Promise<Set<string>>
+const admit = (d: Daemon, entries: DutyGrantEntry[]) =>
+  (d as any).dutyCoordinator.admitDutyGrants(entries) as Promise<Set<string>>
 
 /** Put a live Slack socket in the pool under this agent's own credentials, as a successful
  *  `reconcileSlackConnections` would — what consolidation must stop asking for once it is dropped. */
@@ -231,8 +232,8 @@ describe('a refused replacement still applies its removals', () => {
       throw new Error('control plane unreachable')
     })
     const admitted = admit(daemon, [grant(GROUP, '2', [AGENT_C, AGENT_B])])
-    await vi.waitFor(() => expect((daemon as any).pendingDutyAdmissions()).toEqual([GROUP]))
-    ;(daemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
+    await vi.waitFor(() => expect((daemon as any).dutyCoordinator.pendingDutyAdmissions()).toEqual([GROUP]))
+    ;(daemon as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
     release()
 
     expect([...(await admitted)]).toEqual([GROUP])
@@ -256,7 +257,7 @@ describe('a refused replacement still applies its removals', () => {
       throw new Error('control plane unreachable')
     })
     const stale = admit(daemon, [grant(GROUP, '2', [AGENT_C, AGENT_B])])
-    await vi.waitFor(() => expect((daemon as any).pendingDutyAdmissions()).toEqual([GROUP]))
+    await vi.waitFor(() => expect((daemon as any).dutyCoordinator.pendingDutyAdmissions()).toEqual([GROUP]))
 
     // The newer grant lands and completes first — both its agents are already installed.
     await admit(daemon, [grant(GROUP, '3', [AGENT_A, AGENT_C])])

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -415,7 +415,7 @@ describe('daemon --k8s mode', () => {
         }))
       }
       const grant = { groupId: GROUP, orgId: 'org-1', term: '1', members: [{ kind: 'agent', refId: AGENT }] }
-      await (k8sDaemon as any).admitDutyGrants([grant])
+      await (k8sDaemon as any).dutyCoordinator.admitDutyGrants([grant])
       await vi.waitFor(() => expect(events).toEqual([`adopt:${AGENT}`]))
       // A stopped host stands in for the ex-holder's runtime; the release must wait for it to be down.
       let hostDown = false
@@ -425,7 +425,7 @@ describe('daemon --k8s mode', () => {
           hostDown = true
         }
       })
-      ;(k8sDaemon as any).applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
+      ;(k8sDaemon as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP, reason: 'superseded' }])
       expect(events).toEqual([`adopt:${AGENT}`])
       await vi.waitFor(() => expect(events).toEqual([`adopt:${AGENT}`, `release:${AGENT}`]))
       expect(hostDown).toBe(true)

--- a/packages/daemon/test/daemon-session-metadata-outbox-pool.test.ts
+++ b/packages/daemon/test/daemon-session-metadata-outbox-pool.test.ts
@@ -200,7 +200,7 @@ describe('session-metadata outbox ownership on a daemon pool (#1023)', () => {
     expect(shared.pendingSessionMetadataSnapshot(AGENT_A, 'acp-moved')?.nextAttemptAt).toBe(PARK_MS)
 
     // The grant lands on B well before the parked backoff would have expired.
-    b.inner.settleDutyChange(b.inner.duties.applyGrant([grant(GROUP_A, AGENT_A)]))
+    b.inner.dutyCoordinator.settleDutyChange(b.inner.duties.applyGrant([grant(GROUP_A, AGENT_A)]))
     await vi.waitFor(() => expect(b.syncEventSession).toHaveBeenCalledOnce())
     expect(b.synced).toEqual([{ orgId: ORG, agentId: AGENT_A, sessionId: 'acp-moved' }])
     expect(shared.hasPendingSessionMetadata()).toBe(false)
@@ -239,7 +239,7 @@ describe('session-metadata outbox ownership on a daemon pool (#1023)', () => {
     hold(a.inner, GROUP_A, AGENT_A)
     seedSnapshot(shared, AGENT_A, 'acp-handoff', 1, 'daemon-a')
 
-    b.inner.settleDutyChange(b.inner.duties.applyGrant([grant(GROUP_A, AGENT_A)]))
+    b.inner.dutyCoordinator.settleDutyChange(b.inner.duties.applyGrant([grant(GROUP_A, AGENT_A)]))
     await vi.waitFor(() => expect(b.syncEventSession).toHaveBeenCalledOnce())
     expect(b.synced).toEqual([{ orgId: ORG, agentId: AGENT_A, sessionId: 'acp-handoff' }])
     expect(shared.hasPendingSessionMetadata()).toBe(false)

--- a/packages/daemon/test/daemon-session-sweeps-pool.test.ts
+++ b/packages/daemon/test/daemon-session-sweeps-pool.test.ts
@@ -290,7 +290,7 @@ describe('session sweeps on a daemon pool are holder-only (#1032)', () => {
     await b.inner.drainSessionPurges()
     expect(b.emitSessionPurged).not.toHaveBeenCalled()
     // The grant lands: the receipt is this member's to report now, and it is reported exactly once.
-    b.inner.settleDutyChange(b.inner.duties.applyGrant([grant(GROUP_A, AGENT_A)]))
+    b.inner.dutyCoordinator.settleDutyChange(b.inner.duties.applyGrant([grant(GROUP_A, AGENT_A)]))
     await vi.waitFor(() => expect(b.emitSessionPurged).toHaveBeenCalledOnce())
     expect(b.emitSessionPurged.mock.calls[0]![0]).toMatchObject({ agentId: AGENT_A, sessionIds: ['acp-left'] })
     await b.inner.drainSessionPurges()

--- a/packages/daemon/test/orchestration.test.ts
+++ b/packages/daemon/test/orchestration.test.ts
@@ -423,8 +423,8 @@ describe('pool duty gate on deadlines', () => {
       fetchDutyAgent: vi.fn()
     }
   }
-  const hold = (d: Daemon) => (d as any).settleDutyChange((d as any).duties.applyGrant([grant()]))
-  const drop = (d: Daemon) => (d as any).applyDutyRevoke([{ groupId: GROUP, reason: 'reassigned' }])
+  const hold = (d: Daemon) => (d as any).dutyCoordinator.settleDutyChange((d as any).duties.applyGrant([grant()]))
+  const drop = (d: Daemon) => (d as any).dutyCoordinator.applyDutyRevoke([{ groupId: GROUP, reason: 'reassigned' }])
 
   /** Two members over ONE store: the same root, so both LocalStores open the same database. */
   async function bootPool() {

--- a/packages/daemon/test/schedule-catchup.test.ts
+++ b/packages/daemon/test/schedule-catchup.test.ts
@@ -102,8 +102,8 @@ const grant = () => ({
   term: '1',
   members: [{ kind: 'agent' as const, refId: AGENT }]
 })
-const hold = (inner: any) => inner.settleDutyChange(inner.duties.applyGrant([grant()]))
-const drop = (inner: any) => inner.applyDutyRevoke([{ groupId: GROUP, reason: 'reassigned' }])
+const hold = (inner: any) => inner.dutyCoordinator.settleDutyChange(inner.duties.applyGrant([grant()]))
+const drop = (inner: any) => inner.dutyCoordinator.applyDutyRevoke([{ groupId: GROUP, reason: 'reassigned' }])
 
 const agentOf = (inner: any) => inner.agents.get(AGENT)
 


### PR DESCRIPTION
## What

Cuts the **duty** cluster of same-name thin delegates off `Daemon`. The coordinator (`src/cp/duty-coordinator.ts`) already owns the logic; the shells only existed so the daemon's own paths and the tests could keep calling the old names.

- **32 shells removed, 0 kept** — 29 private methods (`dutyDigest`, `dutyHeadroom`, `dutyHeadroomForPendingClaim`, `dutyEnforced`, `applyDutyGrant`, `admitDutyGrants`, `settleDutyChange`, `withdrawDutyGroups`, `pendingDutyAdmissions`, `installGrantedAgents`, `dutyBundleIsStale`, `installDutyAgent`, `runDutyAgentInstall`, `applyDutyDefinitions`, `applyDutyRevoke`, `fenceDuties`, `claimDutyForTrigger`, `joinInFlightDutyClaims`, `onDutyChanged`, `convergeDutyConnections`, `stopServingAgent`, `stopServingAgentSettled`, `dutyHostStop`, `confirmDutyTeardown`, `releaseAllDuties`, `dutyGroupBusy`, `releaseDutiesForShutdown`, `settleLateGrants`, `awaitDutyConvergence`, `releaseDutyAcknowledged`) plus the `dutyConnectionsRequested` getter and the `dutyConnectionsConverged` getter/setter pair. Every one was a pure forward with no guard, no signature adaptation, and no override seam that had to stay on `Daemon` — so none was kept.
- **24 internal call sites rewired** to `this.dutyCoordinator.<name>`, including the `configApplyHost()` literal (`applyDutyGrant`, `applyDutyRevoke`), the `CpClientDeps` literal (`duties`, `dutyPending`, `onDutyFence`), and `createAgentWaker`'s `knowsAgent`/`claimDuty`.
- Six now-unused type imports (`DutyApplyResult`, `DutyAgentBundle`, `DutyGrantEntry`, `DutyMemberRef`, `DutyRevoke`, `HeartbeatDuties`) dropped from `daemon.ts`.
- 11 test files rewritten to poke `(daemon as any).dutyCoordinator.<name>`. The one spy — `vi.spyOn(daemon, 'admitDutyGrants')` in `daemon-duty-drain.test.ts` — now targets the coordinator instance; `applyDutyGrant` reaches `admitDutyGrants` through `this.` on the coordinator's prototype, so the interception still holds.

Zero behavior change; `daemon.ts` shrinks by ~140 lines.

## Verification

- `tsc -p tsconfig.typecheck.json` clean, `eslint` and `prettier --check` clean on all 12 touched files.
- Green, run one file at a time: `daemon-duty-install`, `daemon-duty-fence`, `daemon-duty-drain`, `daemon-duty-replacement`, `daemon-duty-inbox-replay`, `cp/client-duty`, `cp/client-duty-fence`, `cp/cp-agent-reconcile`, `daemon-k8s-mode`, `schedule-catchup`, `orchestration`, `daemon-session-sweeps-pool`, `daemon-session-metadata-outbox-pool`. Running the duty suites in one parallel batch produces flaky 5s timeouts locally under load (a different set each run); each file passes on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)