### PR TITLE
refactor(daemon): cut the webchat delegate shells

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -404,14 +404,9 @@ import type {
   AgentPermissionDecision,
   Ack,
   DaemonControlAck,
-  WebchatAck,
-  WebchatPost,
-  WebchatRuntimeConfig,
   RdWebchatPost,
-  SessionImageAttachment,
   RdMsg,
   RdMsgWebchat,
-  WebchatImageAttachment,
   RdMsgIm,
   RdMsgPlatformAction,
   RdMsgHook,
@@ -426,7 +421,6 @@ import type {
   MemoryDreamingPolicy,
   ChildSessionStatus,
   ChildSessionStatusProbe,
-  WebchatRemoteMcpEntitlement,
   ExternalSessionAudience,
   ExternalSessionOrigin,
   ChannelAgentsOk,
@@ -496,7 +490,7 @@ import {
   type TurnInterruptReason,
   type TurnLifecycleCleanupOutcome
 } from './daemon/turn-types.js'
-import { UUID_RE, type WebchatSink, type WebchatTurnContext, type WebchatTurnStream } from './webchat/types.js'
+import { UUID_RE, type WebchatSink, type WebchatTurnContext } from './webchat/types.js'
 import { WebchatTransport, type WebchatHost } from './webchat/transport.js'
 import { WebchatMcpRevocations, type WebchatMcpRevocationHost } from './webchat/mcp-revocations.js'
 import * as webchatTurnOutput from './webchat/turn-output.js'
@@ -2607,7 +2601,7 @@ export class Daemon {
       // publishes hostStopping, and fences every older startup/retry generation.
       await this.stopHost(id)
       await this.releaseModelSessionHostsForAgent(id)
-      await this.revokeRemoteWebchatGrantsForAgent(id, 'agent_detached')
+      await this.webchatMcpRevocations.revokeRemoteWebchatGrantsForAgent(id, 'agent_detached')
       // Preserve lifecycle/move gates that predated this reconcile. A plain file/CP
       // removal needs no permanent gate once the host is proven stopped (the agent is
       // absent); a later toStart can then serve it normally. Safety-drain state is NOT
@@ -2689,7 +2683,7 @@ export class Daemon {
               `reconcile: model-session teardown failed for "${a.id}" — releasing admission gate anyway: ${formatErr(err)}`
             )
           }
-          await this.revokeRemoteWebchatGrantsForAgent(a.id, 'agent_detached')
+          await this.webchatMcpRevocations.revokeRemoteWebchatGrantsForAgent(a.id, 'agent_detached')
         } finally {
           if (!wasDraining && !this.agentDestructivePending(a.id)) this.drainingAgents.delete(a.id)
         }
@@ -5423,129 +5417,6 @@ export class Daemon {
     await this.dispatch(agentId, msg, integrationId)
   }
 
-  private dispatchWebchatTurn(
-    agentId: string,
-    chatId: string,
-    text: string,
-    user: string,
-    sink: WebchatSink,
-    requestedTurnId?: string,
-    inlineImages?: WebchatImageAttachment[],
-    requestedRuntime?: WebchatRuntimeConfig,
-    remoteMcp?: WebchatRemoteMcpEntitlement,
-    mentions?: string[],
-    post?: { postId: string; at: number },
-    postSink?: (p: RdWebchatPost) => void,
-    requestedWorktree?: boolean
-  ): WebchatAck {
-    return this.webchatTransport.dispatchWebchatTurn(
-      agentId,
-      chatId,
-      text,
-      user,
-      sink,
-      requestedTurnId,
-      inlineImages,
-      requestedRuntime,
-      remoteMcp,
-      mentions,
-      post,
-      postSink,
-      requestedWorktree
-    )
-  }
-
-  private dispatchWebchatContinuationTurn(
-    agentId: string,
-    chatId: string,
-    targetSessionId: string,
-    text: string,
-    user: string,
-    sink: WebchatSink,
-    requestedTurnId?: string
-  ): Promise<WebchatAck> {
-    return this.webchatTransport.dispatchWebchatContinuationTurn(
-      agentId,
-      chatId,
-      targetSessionId,
-      text,
-      user,
-      sink,
-      requestedTurnId
-    )
-  }
-
-  private handleWebchatClose(conversationId: string): void {
-    this.webchatTransport.handleWebchatClose(conversationId)
-  }
-
-  private webchatSessionKey(conversationId: string, agentId: string): string {
-    return this.webchatTransport.webchatSessionKey(conversationId, agentId)
-  }
-
-  private webchatStreamKey(turnId: string, agentId: string): string {
-    return this.webchatTransport.webchatStreamKey(turnId, agentId)
-  }
-
-  private createWebchatTurnStream(
-    agentId: string,
-    conversationId: string,
-    turnId: string,
-    transport: WebchatSink,
-    runtime?: WebchatRuntimeConfig,
-    remoteMcp?: WebchatRemoteMcpEntitlement,
-    worktree?: boolean
-  ): WebchatTurnStream {
-    return this.webchatTransport.createWebchatTurnStream(
-      agentId,
-      conversationId,
-      turnId,
-      transport,
-      runtime,
-      remoteMcp,
-      worktree
-    )
-  }
-
-  private webchatWakeContext(platform: string, conversationId: string): WebchatTurnContext | undefined {
-    return this.webchatTransport.webchatWakeContext(platform, conversationId)
-  }
-
-  private postAgentWakeInbound(webchat: WebchatTurnContext | undefined, msg: NormalizedMessage): void {
-    this.webchatTransport.postAgentWakeInbound(webchat, msg)
-  }
-
-  private publishWebchatStreamEvent(stream: WebchatTurnStream, event: RdChatEvent): void {
-    this.webchatTransport.publishWebchatStreamEvent(stream, event)
-  }
-
-  private bufferWebchatStreamEvent(stream: WebchatTurnStream, event: RdChatEvent): void {
-    this.webchatTransport.bufferWebchatStreamEvent(stream, event)
-  }
-
-  private deliverWebchatStreamEvent(sink: WebchatSink, event: RdChatEvent): void {
-    this.webchatTransport.deliverWebchatStreamEvent(sink, event)
-  }
-
-  private resumeWebchatStream(
-    agentId: string,
-    conversationId: string,
-    turnId: string,
-    generation: number,
-    afterIndex: number,
-    transport: WebchatSink
-  ): { accepted: boolean; turnId?: string; reason?: string } {
-    return this.webchatTransport.resumeWebchatStream(agentId, conversationId, turnId, generation, afterIndex, transport)
-  }
-
-  private removeWebchatStream(streamKey: string, stream: WebchatTurnStream): void {
-    this.webchatTransport.removeWebchatStream(streamKey, stream)
-  }
-
-  private pruneWebchatStreams(): void {
-    this.webchatTransport.pruneWebchatStreams()
-  }
-
   /** Apply the Agent's configured runtime policy to one live session. Callers that
    *  fence a pending prompt await this; reconciliation fans it out in the background. */
   private async applyConfiguredRuntimeSettings(agent: LoadedAgent, host: AcpHost, sessionId: string): Promise<void> {
@@ -5594,10 +5465,6 @@ export class Daemon {
           this.log.warn(`restore configured runtime settings failed for "${session.key}": ${formatErr(err)}`)
         )
     }
-  }
-
-  private handleWebchatCancel(conversationId: string, agentId?: string): void {
-    this.webchatTransport.handleWebchatCancel(conversationId, agentId)
   }
 
   // Idempotency cache for the at-least-once rd/* wire. IM deliveries additionally
@@ -6337,7 +6204,7 @@ export class Daemon {
         msg.toAgentId,
         reply,
         replyIntegrationId,
-        this.webchatWakeContext(origin.platform, origin.channel),
+        this.webchatTransport.webchatWakeContext(origin.platform, origin.channel),
         callMeta
       ).catch((err) =>
         this.log.error(`relay lineage-reply dispatch failed for agent "${msg.toAgentId}": ${formatErr(err)}`)
@@ -6462,7 +6329,7 @@ export class Daemon {
       msg.toAgentId,
       normalized,
       integrationId,
-      this.webchatWakeContext(platform, sessionChannel),
+      this.webchatTransport.webchatWakeContext(platform, sessionChannel),
       callMeta,
       { ...(pairingKey !== undefined ? { requireDurable: true } : {}) }
     ).catch((err) => {
@@ -6928,7 +6795,7 @@ export class Daemon {
       req.toAgentId,
       normalized,
       integrationId,
-      this.webchatWakeContext(platform, coordChannel),
+      this.webchatTransport.webchatWakeContext(platform, coordChannel),
       callMeta,
       { ...(pairingKey !== undefined ? { requireDurable: true } : {}) }
     ).catch((err) => {
@@ -7178,7 +7045,7 @@ export class Daemon {
         originOwner,
         normalized,
         integrationId,
-        this.webchatWakeContext(originPlatform, local.channel),
+        this.webchatTransport.webchatWakeContext(originPlatform, local.channel),
         callMeta,
         {
           onAdmission: (result) => {
@@ -8258,7 +8125,7 @@ export class Daemon {
       done: (d) => chat({ kind: 'done', done: d })
     }
     const op = msg.payload
-    const key = (): string => this.webchatSessionKey(msg.chatId, msg.agentId)
+    const key = (): string => this.webchatTransport.webchatSessionKey(msg.chatId, msg.agentId)
     // Session-targeted continuation: `turn` dispatches onto the target session's
     // own coordinates; runtime-set ops are refused (this ingress adds human
     // input, never session-global administration); a context copy is a no-op
@@ -8268,20 +8135,22 @@ export class Daemon {
     if (msg.targetSessionId !== undefined) {
       switch (op.op) {
         case 'turn':
-          return this.dispatchWebchatContinuationTurn(
-            msg.agentId,
-            msg.chatId,
-            msg.targetSessionId,
-            op.text,
-            op.user ?? 'webchat',
-            sink,
-            op.turnId
-          ).then((ack) => ({
-            msgId: msg.msgId,
-            accepted: ack.accepted,
-            turnId: ack.turnId,
-            ...(ack.reason ? { reason: ack.reason } : {})
-          }))
+          return this.webchatTransport
+            .dispatchWebchatContinuationTurn(
+              msg.agentId,
+              msg.chatId,
+              msg.targetSessionId,
+              op.text,
+              op.user ?? 'webchat',
+              sink,
+              op.turnId
+            )
+            .then((ack) => ({
+              msgId: msg.msgId,
+              accepted: ack.accepted,
+              turnId: ack.turnId,
+              ...(ack.reason ? { reason: ack.reason } : {})
+            }))
         case 'set_model':
         case 'set_effort':
         case 'set_permission_mode':
@@ -8295,7 +8164,7 @@ export class Daemon {
     }
     switch (op.op) {
       case 'turn': {
-        const ack = this.dispatchWebchatTurn(
+        const ack = this.webchatTransport.dispatchWebchatTurn(
           msg.agentId,
           msg.chatId,
           op.text,
@@ -8318,17 +8187,25 @@ export class Daemon {
         }
       }
       case 'context': {
-        const landedTs = this.recordWebchatContextPost(msg.agentId, msg.chatId, op.post)
+        const landedTs = this.webchatTransport.recordWebchatContextPost(msg.agentId, msg.chatId, op.post)
         // webchat-multi-agents.md §5.2a (#549 parity): an agent-authored peer post
         // does not stay transcript-only — it may continue the conversation for THIS
         // pre-addressed participant. Recording above is unconditional and the ack is
         // unchanged; the activation decision runs its own edge checks and is
         // fire-and-forget, exactly like the `turn` dispatch below it.
-        if (landedTs !== undefined) this.maybeActivateWebchatContinuation(msg.agentId, msg.chatId, op.post, landedTs)
+        if (landedTs !== undefined)
+          this.webchatTransport.maybeActivateWebchatContinuation(msg.agentId, msg.chatId, op.post, landedTs)
         return { msgId: msg.msgId, accepted: true }
       }
       case 'resume': {
-        const resumed = this.resumeWebchatStream(msg.agentId, msg.chatId, op.turnId, op.generation, op.afterIndex, sink)
+        const resumed = this.webchatTransport.resumeWebchatStream(
+          msg.agentId,
+          msg.chatId,
+          op.turnId,
+          op.generation,
+          op.afterIndex,
+          sink
+        )
         return {
           msgId: msg.msgId,
           accepted: resumed.accepted,
@@ -8353,45 +8230,12 @@ export class Daemon {
           ? { msgId: msg.msgId, accepted: true }
           : { msgId: msg.msgId, accepted: false, reason: 'runtime changes are disabled in chat' }
       case 'cancel':
-        this.handleWebchatCancel(msg.chatId, op.agentId ?? msg.agentId)
+        this.webchatTransport.handleWebchatCancel(msg.chatId, op.agentId ?? msg.agentId)
         return { msgId: msg.msgId, accepted: true }
       case 'close':
-        this.handleWebchatClose(msg.chatId)
+        this.webchatTransport.handleWebchatClose(msg.chatId)
         return { msgId: msg.msgId, accepted: true }
     }
-  }
-
-  private appendWebchatTextRow(
-    channel: string,
-    thread: string,
-    ts: string,
-    entry: {
-      sender: string
-      recipient?: string
-      text: string
-      postId?: string
-      trustedAgentBot?: boolean
-      attachments?: SessionImageAttachment[]
-    }
-  ): string {
-    return webchatTurnOutput.appendWebchatTextRow(this.store, channel, thread, ts, entry)
-  }
-
-  private flushHeldWebchatText(wc: NonNullable<Pending['webchat']>): void {
-    webchatTurnOutput.flushHeldWebchatText(wc)
-  }
-
-  private recordWebchatContextPost(agentId: string, chatId: string, contextPost: WebchatPost): string | undefined {
-    return this.webchatTransport.recordWebchatContextPost(agentId, chatId, contextPost)
-  }
-
-  private maybeActivateWebchatContinuation(
-    targetAgentId: string,
-    chatId: string,
-    contextPost: WebchatPost,
-    landedTs: string
-  ): void {
-    this.webchatTransport.maybeActivateWebchatContinuation(targetAgentId, chatId, contextPost, landedTs)
   }
 
   /** Record an unrouted inbound message into the transcript iff a session is
@@ -9676,7 +9520,7 @@ export class Daemon {
           })
           // NOT for §5.2a continuation wakes: their inbound IS a committed peer post the
           // browser already rendered — re-posting it would duplicate that reply.
-          if (callMeta?.conversationContinuation !== true) this.postAgentWakeInbound(webchat, msg)
+          if (callMeta?.conversationContinuation !== true) this.webchatTransport.postAgentWakeInbound(webchat, msg)
         }
         // §8.6, the ONE place every delivery path settles — live dispatch, queued
         // dispatch, and startup replay alike. Completing the rendezvous here rather than
@@ -11224,7 +11068,7 @@ export class Daemon {
         } else if (trimmedWebchatReply) {
           // A real reply that never diverged from the sentinel prefix mid-stream
           // (shorter than the sentinel) is still held — release it before commit.
-          this.flushHeldWebchatText(p.webchat)
+          webchatTurnOutput.flushHeldWebchatText(p.webchat)
           // A continuation turn records its reply at the platform post boundary instead
           // (appending here would duplicate the row), and its roster is fixed at one.
           if (!p.webchat.continuation) {
@@ -11234,11 +11078,17 @@ export class Daemon {
             // post's canonical `at` (minted ONCE here, the origin) carried to every other
             // participant's copy via rd/webchat-post.
             const replyPostId = randomUUID()
-            const replyTs = this.appendWebchatTextRow(p.transcriptChannel, statusThread, monotonicTs(), {
-              postId: replyPostId,
-              sender: agentId,
-              text: p.webchat.replyText
-            })
+            const replyTs = webchatTurnOutput.appendWebchatTextRow(
+              this.store,
+              p.transcriptChannel,
+              statusThread,
+              monotonicTs(),
+              {
+                postId: replyPostId,
+                sender: agentId,
+                text: p.webchat.replyText
+              }
+            )
             // Fan the completed reply out as a canonical conversation post so the
             // relay delivers it to the browser's message log and to the other
             // participants' daemons as context (webchat-multi-agents.md §5.2).
@@ -11399,7 +11249,7 @@ export class Daemon {
         // Continuation: release any held stream text; the platform branch below owns the
         // visible notice + transcript, and the terminal-error `done` waits behind its
         // apply-chain drain so the console cannot admit a next turn mid-flush.
-        this.flushHeldWebchatText(p.webchat)
+        webchatTurnOutput.flushHeldWebchatText(p.webchat)
       } else if (p.webchat) {
         // Reply text (including a runtime's mirrored error text) already streamed to
         // the client via onAcpUpdate; the terminal done frame carries the reason.
@@ -11420,13 +11270,19 @@ export class Daemon {
         })
         const trimmedPartialReply = p.webchat.replyText.trim()
         if (trimmedPartialReply && !isNoResponseBody(trimmedPartialReply)) {
-          this.flushHeldWebchatText(p.webchat)
+          webchatTurnOutput.flushHeldWebchatText(p.webchat)
           const partialPostId = randomUUID()
-          const replyTs = this.appendWebchatTextRow(p.transcriptChannel, statusThread, monotonicTs(), {
-            postId: partialPostId,
-            sender: agentId,
-            text: p.webchat.replyText
-          })
+          const replyTs = webchatTurnOutput.appendWebchatTextRow(
+            this.store,
+            p.transcriptChannel,
+            statusThread,
+            monotonicTs(),
+            {
+              postId: partialPostId,
+              sender: agentId,
+              text: p.webchat.replyText
+            }
+          )
           // A partial reply is still conversation content the other participants
           // should see — fan it out exactly like the success path. Deliberately
           // WITHOUT the author hopCount stamp: a failed turn's fragment must not
@@ -13341,7 +13197,7 @@ export class Daemon {
     const p = this.pending.get(pendingTurnKey(rec.agentId, rec.acpSessionId))
     if (p && p.sessionKey === key && !p.outputSuppressed) {
       if (p.webchat) {
-        this.emitWebchatUpdate(p, { sessionUpdate: 'session_info_update', title: req.title })
+        webchatTurnOutput.emitWebchatUpdate(p.webchat, { sessionUpdate: 'session_info_update', title: req.title })
       }
       if (turnChromeFor(p.platform).dmSessionTitle && p.isDm && p.conn) {
         this.enqueueApply(p, { kind: 'set-title', text: req.title })
@@ -13521,7 +13377,7 @@ export class Daemon {
     // per mapped chunk, instead of driving the Slack renderer — but still records the
     // full activity log below, so a webchat session reads back like any other.
     // A continuation turn drives BOTH: the browser sink and the platform renderer (§5.2).
-    if (p.webchat) this.emitWebchatUpdate(p, update)
+    if (p.webchat) webchatTurnOutput.emitWebchatUpdate(p.webchat, update)
     if ((!p.webchat || p.webchat.continuation) && !isHeadlessGithubFinal && !(p.stageAnswer && isAnswerChunk)) {
       for (const action of p.conv.onUpdate(update)) this.enqueueApply(p, action)
       this.armIdle(p)
@@ -13529,10 +13385,6 @@ export class Daemon {
     }
     // Full activity log (tool/reasoning), recorded regardless of output mode.
     for (const ev of p.rec.onUpdate(update)) this.recordEvent(p.agentId, p.transcriptChannel, p.statusThread, ev)
-  }
-
-  private emitWebchatUpdate(p: Pending, update: any): void {
-    webchatTurnOutput.emitWebchatUpdate(p.webchat!, update)
   }
 
   /** Persist one internal activity event (tool/reasoning). Ordered by row `seq`, so its
@@ -15198,7 +15050,7 @@ export class Daemon {
     if (closed.length) this.log.info(`idle: TTL-closed ${closed.length} session(s) (>${Math.round(ttl / 1000)}s)`)
     // A failed remote revoke is queued durably by the grant ledger; the periodic
     // drain below (and the CP READY replay) delivers it eventually.
-    void this.drainWebchatMcpRevocations()
+    void this.webchatMcpRevocations.drainWebchatMcpRevocations()
     for (const row of closed) {
       void this.releaseModelSessionHost(row.key).catch((error) =>
         this.log.warn(`key-server session cleanup failed for ${row.key} (${formatErr(error)})`)
@@ -15482,14 +15334,14 @@ export class Daemon {
       await this.stopSelectedTurnHosts(targets)
       for (const id of [...this.hosts.keys()]) await this.stopHost(id)
       for (const key of [...this.modelSessionHosts.keys()]) await this.releaseModelSessionHost(key)
-      await this.revokeAllRemoteWebchatGrants('agent_detached')
+      await this.webchatMcpRevocations.revokeAllRemoteWebchatGrants('agent_detached')
       this.draining = false
       released = matched
     } else if (drain.scope.kind === 'agent') {
       await this.stopSelectedTurnHosts(targets)
       await this.stopHost(drain.scope.agentId)
       await this.releaseModelSessionHostsForAgent(drain.scope.agentId)
-      await this.revokeRemoteWebchatGrantsForAgent(drain.scope.agentId, 'agent_detached')
+      await this.webchatMcpRevocations.revokeRemoteWebchatGrantsForAgent(drain.scope.agentId, 'agent_detached')
       if (!this.agentDestructivePending(drain.scope.agentId)) this.drainingAgents.delete(drain.scope.agentId)
       released = matched
     } else {
@@ -15516,24 +15368,9 @@ export class Daemon {
     // the authority fence below aborts and drains those too.
     await this.stopSelectedTurnHosts(targets)
     await this.quiesceAgentWorkspaceAuthority(agentId)
-    await this.revokeRemoteWebchatGrantsForAgent(agentId, 'agent_detached')
+    await this.webchatMcpRevocations.revokeRemoteWebchatGrantsForAgent(agentId, 'agent_detached')
     // gate intentionally left set (drainScope added it): a stopped agent must not
     // auto-respawn on the next message — agent/launch clears the gate.
-  }
-
-  private revokeAllRemoteWebchatGrants(reason: Parameters<RemoteWebchatGrantManager['revokeAll']>[0]): Promise<void> {
-    return this.webchatMcpRevocations.revokeAllRemoteWebchatGrants(reason)
-  }
-
-  private revokeRemoteWebchatGrantsForAgent(
-    agentId: string,
-    reason: Parameters<RemoteWebchatGrantManager['revokeAgent']>[1]
-  ): Promise<void> {
-    return this.webchatMcpRevocations.revokeRemoteWebchatGrantsForAgent(agentId, reason)
-  }
-
-  private drainWebchatMcpRevocations(): Promise<void> {
-    return this.webchatMcpRevocations.drainWebchatMcpRevocations()
   }
 
   /** Take over the durable work of agents this member has just been made responsible for. On a
@@ -15544,7 +15381,7 @@ export class Daemon {
     const grants = this.store.reclaimWebchatMcpGrants(agentIds, 'session_closed', this.clock.now())
     if (grants) {
       this.log.info(`remote MCP: reclaimed ${grants} grant(s) from a former owner`)
-      void this.drainWebchatMcpRevocations()
+      void this.webchatMcpRevocations.drainWebchatMcpRevocations()
     }
     this.dreamRunner().reclaimDreams(agentIds)
   }
@@ -16004,7 +15841,7 @@ export class Daemon {
         row.agentId,
         msg,
         row.integrationId ?? undefined,
-        msg.source === 'agent' ? this.webchatWakeContext(msg.platform, msg.channel) : undefined,
+        msg.source === 'agent' ? this.webchatTransport.webchatWakeContext(msg.platform, msg.channel) : undefined,
         callMeta,
         {
           ...(row.isQueueCmd ? { isQueueCmd: true } : {}),
@@ -16239,7 +16076,8 @@ export class Daemon {
       gitCredServer: () => this.gitCredServer,
       quiesceAgentWorkspaceAuthority: (agentId) => this.quiesceAgentWorkspaceAuthority(agentId),
       discardClusterSandbox: (agentId) => this.discardClusterSandbox(agentId),
-      revokeRemoteWebchatGrantsForAgent: (agentId, reason) => this.revokeRemoteWebchatGrantsForAgent(agentId, reason),
+      revokeRemoteWebchatGrantsForAgent: (agentId, reason) =>
+        this.webchatMcpRevocations.revokeRemoteWebchatGrantsForAgent(agentId, reason),
       stopAgent: (agentId) => this.stopAgent(agentId),
       stopHost: (agentId, deadlineMs) => this.stopHost(agentId, deadlineMs),
       ensureHostAsync: (agentId, opts) => this.ensureHostAsync(agentId, opts),
@@ -16786,7 +16624,7 @@ export class Daemon {
         void this.drainSessionMetadataSnapshots()
         // Replay remote MCP revocations that could not reach the CP (revokes
         // queued while disconnected or left over from a previous process).
-        void this.drainWebchatMcpRevocations()
+        void this.webchatMcpRevocations.drainWebchatMcpRevocations()
         // ...and the retention-GC receipts (#485). A sweep that ran while the CP
         // was unreachable (or before it advertised the feature) left the deleted
         // sessions' metadata rows unmarked; this is the only side that still knows.
@@ -17626,7 +17464,7 @@ export class Daemon {
     // already queued durably in the grant ledger (and any rows this pass could
     // not deliver are replayed by the next boot's orphan sweep), so shutdown
     // proceeds without losing the revocation obligation.
-    await this.revokeAllRemoteWebchatGrants('session_closed')
+    await this.webchatMcpRevocations.revokeAllRemoteWebchatGrants('session_closed')
     // A grant can land right up to the socket close; its release must be settled before that.
     if (this.shutdownDutyDrain) await this.dutyCoordinator.settleLateGrants(shutdownDrain)
     this.shutdownDutyDrain = undefined

--- a/packages/daemon/src/webchat/mcp-revocations.ts
+++ b/packages/daemon/src/webchat/mcp-revocations.ts
@@ -1,7 +1,7 @@
 /**
  * The remote-MCP grant revocation half of webchat: the lifecycle revoke calls and the
- * durable drain that replays whatever they could not deliver. The Daemon keeps thin
- * same-name delegates; everything here reaches back through {@link WebchatMcpRevocationHost}.
+ * durable drain that replays whatever they could not deliver. Callers hold this class
+ * directly; everything here reaches back through {@link WebchatMcpRevocationHost}.
  */
 import { WebchatMcpGrantRevoke } from '@agentconnect.md/protocol'
 import type { CpAgentRegistry } from '../cp/cp-agent-registry.js'

--- a/packages/daemon/src/webchat/transport.ts
+++ b/packages/daemon/src/webchat/transport.ts
@@ -2,8 +2,8 @@
  * The daemon's webchat transport surface: turn admission (ordinary and
  * session-targeted continuation), the bounded reconnectable reply streams, the
  * agent-wake post context, cancel/close, and the peer-post continuation ladder
- * (webchat-multi-agents.md §5). The Daemon keeps thin same-name delegates;
- * everything here reaches back through the narrow {@link WebchatHost} port.
+ * (webchat-multi-agents.md §5). Callers hold this class directly; everything here
+ * reaches back through the narrow {@link WebchatHost} port.
  */
 import { randomUUID } from 'node:crypto'
 import type {

--- a/packages/daemon/src/webchat/turn-output.ts
+++ b/packages/daemon/src/webchat/turn-output.ts
@@ -1,8 +1,8 @@
 /**
  * The webchat turn-output surface: the ACP-update → `WebchatEvent` mapping the turn
  * engine streams through a turn's sink, plus the two transcript helpers that share it.
- * Pure functions over the turn's webchat state (and, where a row is written, the store) —
- * the Daemon keeps thin same-name delegates.
+ * Pure functions over the turn's webchat state (and, where a row is written, the store),
+ * called directly by the turn engine.
  */
 import type { SessionImageAttachment, WebchatEvent } from '@agentconnect.md/protocol'
 import type { LocalStore } from '../store/local-store.js'

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -316,10 +316,12 @@ describe('Daemon CP agent → memory + reconcile', () => {
     let markRevokeStarted!: () => void
     const revokeBlocked = new Promise<void>((resolve) => (releaseRevoke = resolve))
     const revokeStarted = new Promise<void>((resolve) => (markRevokeStarted = resolve))
-    vi.spyOn(daemon as any, 'revokeRemoteWebchatGrantsForAgent').mockImplementationOnce(async () => {
-      markRevokeStarted()
-      await revokeBlocked
-    })
+    vi.spyOn((daemon as any).webchatMcpRevocations, 'revokeRemoteWebchatGrantsForAgent').mockImplementationOnce(
+      async () => {
+        markRevokeStarted()
+        await revokeBlocked
+      }
+    )
 
     const detaching = seam(daemon).applyAgentDetach({
       agentId: 'bot-a',

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -112,7 +112,7 @@ describe('Daemon interrupt safety gates', () => {
     ;(daemon as any).agents.get(AGENT_ID).allowRuntimeChangesInChat = true
 
     try {
-      const key = (daemon as any).webchatSessionKey(CONV_1, AGENT_ID)
+      const key = (daemon as any).webchatTransport.webchatSessionKey(CONV_1, AGENT_ID)
       ;(daemon as any).store.upsertSession({
         key,
         agentId: AGENT_ID,
@@ -125,11 +125,11 @@ describe('Daemon interrupt safety gates', () => {
         updatedAt: Date.now()
       })
       ;(daemon as any).store.setModelOverride(key, 'blocked-model')
-      const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'first', 'alice', stream.sink)
+      const ack = (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV_1, 'first', 'alice', stream.sink)
       await vi.waitFor(() => expect(host.setSessionModel).toHaveBeenCalled(), WAIT)
       expect(hasPending(daemon, 'acp-pre-prompt')).toBe(true)
 
-      ;(daemon as any).handleWebchatCancel(CONV_1)
+      ;(daemon as any).webchatTransport.handleWebchatCancel(CONV_1)
       expect(stream.dones).toEqual([expect.objectContaining({ turnId: ack.turnId, error: 'cancel' })])
       releaseOverride()
 
@@ -168,23 +168,41 @@ describe('Daemon interrupt safety gates', () => {
     await daemon.start()
 
     try {
-      const first = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'first', 'alice', stream.sink)
+      const first = (daemon as any).webchatTransport.dispatchWebchatTurn(
+        AGENT_ID,
+        CONV_1,
+        'first',
+        'alice',
+        stream.sink
+      )
       expect(first.accepted).toBe(true)
       await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
 
-      ;(daemon as any).handleWebchatCancel(CONV_1)
+      ;(daemon as any).webchatTransport.handleWebchatCancel(CONV_1)
       expect(host.cancel).toHaveBeenCalledWith('acp-1')
 
       // The cancel backstop is host-wide. Until the old prompt has yielded, accepting
       // work even in another conversation could let that backstop kill the fresh turn.
-      const tooEarly = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_2, 'too early', 'alice', stream.sink)
+      const tooEarly = (daemon as any).webchatTransport.dispatchWebchatTurn(
+        AGENT_ID,
+        CONV_2,
+        'too early',
+        'alice',
+        stream.sink
+      )
       expect(tooEarly).toMatchObject({ accepted: false, reason: 'busy' })
       expect(host.newSession).toHaveBeenCalledTimes(1)
 
       releaseFirst()
       await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
 
-      const fresh = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_2, 'fresh', 'alice', stream.sink)
+      const fresh = (daemon as any).webchatTransport.dispatchWebchatTurn(
+        AGENT_ID,
+        CONV_2,
+        'fresh',
+        'alice',
+        stream.sink
+      )
       expect(fresh.accepted).toBe(true)
       await vi.waitFor(
         () =>
@@ -310,12 +328,12 @@ describe('Daemon interrupt safety gates', () => {
     await daemon.start()
 
     try {
-      const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold', 'alice', stream.sink)
+      const ack = (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold', 'alice', stream.sink)
       expect(ack.accepted).toBe(true)
       await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
       expect((daemon as any).pending.size).toBe(0)
 
-      ;(daemon as any).handleWebchatCancel(CONV_1)
+      ;(daemon as any).webchatTransport.handleWebchatCancel(CONV_1)
       expect(host.cancel).not.toHaveBeenCalled()
       expect(stream.dones).toEqual([expect.objectContaining({ turnId: ack.turnId, error: 'cancel' })])
 
@@ -353,7 +371,7 @@ describe('Daemon interrupt safety gates', () => {
     await daemon.start()
     const standingContext = vi.fn(() => memoryBlocked)
     ;(daemon as any).memory.standingContextAtSessionStart = standingContext
-    const key = (daemon as any).webchatSessionKey(CONV_1, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV_1, AGENT_ID)
     ;(daemon as any).store.upsertSession({
       key,
       agentId: AGENT_ID,
@@ -367,9 +385,15 @@ describe('Daemon interrupt safety gates', () => {
     })
     expect((daemon as any).store.applyCpCaptureGate(AGENT_ID, 'acp-memory', false, 1)).toBe('applied')
 
-    const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold memory', 'alice', stream.sink)
+    const ack = (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV_1,
+      'cold memory',
+      'alice',
+      stream.sink
+    )
     await vi.waitFor(() => expect(standingContext).toHaveBeenCalled(), WAIT)
-    ;(daemon as any).handleWebchatCancel(CONV_1)
+    ;(daemon as any).webchatTransport.handleWebchatCancel(CONV_1)
     expect(stream.dones).toEqual([expect.objectContaining({ turnId: ack.turnId, error: 'cancel' })])
 
     clock.advance(30_000)
@@ -409,17 +433,23 @@ describe('Daemon interrupt safety gates', () => {
     await daemon.start()
 
     try {
-      const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold', 'alice', stream.sink)
+      const ack = (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold', 'alice', stream.sink)
       expect(ack.accepted).toBe(true)
       await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
 
-      ;(daemon as any).handleWebchatCancel(CONV_1)
+      ;(daemon as any).webchatTransport.handleWebchatCancel(CONV_1)
       clock.advance(30_000)
       await vi.waitFor(() => expect(host.stop).toHaveBeenCalledTimes(1), WAIT)
       expect((daemon as any).inflight.size).toBe(1)
 
       expect((daemon as any).safetyDrainingAgents.has(AGENT_ID)).toBe(true)
-      const retry = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_2, 'must stay blocked', 'alice', stream.sink)
+      const retry = (daemon as any).webchatTransport.dispatchWebchatTurn(
+        AGENT_ID,
+        CONV_2,
+        'must stay blocked',
+        'alice',
+        stream.sink
+      )
       expect(retry).toMatchObject({ accepted: false, reason: 'busy' })
       expect(host.newSession).toHaveBeenCalledTimes(1)
     } finally {
@@ -806,7 +836,13 @@ describe('Daemon interrupt safety gates', () => {
     const stream = webchatSink()
     await daemon.start()
 
-    const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold shutdown', 'alice', stream.sink)
+    const ack = (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV_1,
+      'cold shutdown',
+      'alice',
+      stream.sink
+    )
     await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
     await daemon.stop()
 

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -438,7 +438,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       )
     }
 
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     const usage = (daemon as any).store.getUsage(key)
     expect(usage).toMatchObject({
       totalTokens: 500_000,
@@ -484,7 +484,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       undefined,
       { conversationId: CONV, turnId, sink: cp.sink }
     )
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     expect((daemon as any).store.getUsage(key).costAmount).toBe(0)
 
     // The marker is per-turn, not sticky across the session: no native cost on
@@ -560,7 +560,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       { conversationId: CONV, turnId, sink: cp.sink }
     )
 
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     expect((daemon as any).store.getUsage(key).costAmount).toBeCloseTo(0.21)
     expect(cp.usageReports).toHaveLength(2)
     expect((cp.usageReports.at(-1) as any).usage.costAmount).toBeCloseTo(0.21)
@@ -582,10 +582,10 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     ;(daemon as any).cpClient = cp
 
     // Run one full turn so a session row (with acpSessionId) exists for the conversation.
-    ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
+    ;(daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
     await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
 
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     ;(daemon as any).commands.setModelByKey(key, 'b')
     expect((daemon as any).store.getModelOverride(key)).toBe('b') // sticky
     expect(host.setSessionModel).toHaveBeenCalledWith('acp-wc-1', 'b') // applied live
@@ -607,10 +607,19 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       await daemon.start()
       const cp = fakeCpClient()
 
-      ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink, undefined, undefined, runtime)
+      ;(daemon as any).webchatTransport.dispatchWebchatTurn(
+        AGENT_ID,
+        CONV,
+        'go',
+        'webchat',
+        cp.sink,
+        undefined,
+        undefined,
+        runtime
+      )
       await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
 
-      const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+      const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
       expect({
         model: (daemon as any).store.getModelOverride(key),
         effort: (daemon as any).store.getEffortOverride(key),
@@ -681,7 +690,16 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     const cp = fakeCpClient()
     const runtime = { model: 'b', effort: 'ultracode', permissionMode: 'plan', fastMode: true }
 
-    ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink, undefined, undefined, runtime)
+    ;(daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'go',
+      'webchat',
+      cp.sink,
+      undefined,
+      undefined,
+      runtime
+    )
     await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
 
     writeAgent(root, { ...configured, allowRuntimeChangesInChat: false })
@@ -694,7 +712,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     releaseSecondSession()
     await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
 
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     expect((daemon as any).store.getModelOverride(key)).toBeUndefined()
     expect((daemon as any).store.getEffortOverride(key)).toBeUndefined()
     expect((daemon as any).store.getPermissionModeOverride(key)).toBeUndefined()
@@ -736,12 +754,12 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     ;(daemon as any).cpClient = cp
 
     // Finish a turn first: Pending is gone, but the ACP session remains warm.
-    ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'first', 'webchat', cp.sink)
+    ;(daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'first', 'webchat', cp.sink)
     await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
     expect((daemon as any).pending.size).toBe(0)
     expect(host.newSession).toHaveBeenCalledTimes(1)
 
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     expect((daemon as any).commands.setModelByKey(key, 'b')).toBe(true)
     expect((daemon as any).commands.setEffortByKey(key, 'high')).toBe(true)
     expect((daemon as any).commands.setPermissionModeByKey(key, 'plan')).toBe(true)
@@ -772,7 +790,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     expect((daemon as any).store.getFastModeOverride(key)).toBeUndefined()
 
     // The next turn reuses that same restored session while chat changes remain locked.
-    ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'second', 'webchat', cp.sink)
+    ;(daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'second', 'webchat', cp.sink)
     await vi.waitFor(() => expect(cp.dones).toHaveLength(2), WAIT)
     expect(host.newSession).toHaveBeenCalledTimes(1)
     expect((daemon as any).agents.get(AGENT_ID).allowRuntimeChangesInChat).toBe(false)
@@ -808,11 +826,11 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     const cp = fakeCpClient()
     ;(daemon as any).cpClient = cp
 
-    ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'first', 'webchat', cp.sink)
+    ;(daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'first', 'webchat', cp.sink)
     await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
     expect((daemon as any).pending.size).toBe(0)
 
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     expect((daemon as any).commands.setModelByKey(key, 'b')).toBe(true)
     expect((daemon as any).commands.setEffortByKey(key, 'high')).toBe(true)
     expect((daemon as any).commands.setFastByKey(key, true)).toBe(true)
@@ -833,7 +851,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       expect(host.setSessionFastMode).toHaveBeenCalledWith('acp-wc-1', false)
     }, WAIT)
 
-    ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'second', 'webchat', cp.sink)
+    ;(daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'second', 'webchat', cp.sink)
     await vi.waitFor(() => expect(cp.dones).toHaveLength(2), WAIT)
     expect(host.newSession).toHaveBeenCalledTimes(1)
     await daemon.stop()
@@ -860,7 +878,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     const cp = fakeCpClient()
     ;(daemon as any).cpClient = cp
 
-    ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
+    ;(daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
     await vi.waitFor(
       () =>
         expect([...(daemon as any).pending.values()].some((p: any) => p.webchat?.conversationId === CONV)).toBe(true),
@@ -868,11 +886,11 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     )
 
     const outputsBeforeCancel = cp.outputs.length
-    ;(daemon as any).handleWebchatCancel(CONV)
+    ;(daemon as any).webchatTransport.handleWebchatCancel(CONV)
     expect(host.cancel).toHaveBeenCalledWith('acp-wc-1')
     expect(cp.dones).toEqual([expect.objectContaining({ conversationId: CONV, error: 'cancel' })])
     // NOT muted — a follow-up turn would still dispatch.
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     expect((daemon as any).store.isSessionMuted(key)).toBe(false)
 
     release()
@@ -901,12 +919,12 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     await daemon.start()
     const cp = fakeCpClient()
 
-    const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
+    const ack = (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
     expect(ack.accepted).toBe(true)
     await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
     expect((daemon as any).pending.size).toBe(0)
 
-    ;(daemon as any).handleWebchatCancel(CONV)
+    ;(daemon as any).webchatTransport.handleWebchatCancel(CONV)
     expect(cp.dones).toEqual([expect.objectContaining({ turnId: ack.turnId, error: 'cancel' })])
     expect(host.cancel).not.toHaveBeenCalled()
 
@@ -1056,7 +1074,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     const cp = fakeCpClient()
     ;(daemon as any).cpClient = cp
 
-    const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
+    const ack = (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
 
     expect(ack).toMatchObject({ accepted: false, reason: 'paused' })
     expect(host.prompt).not.toHaveBeenCalled()
@@ -1083,20 +1101,28 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     await daemon.start()
     const cp = fakeCpClient()
 
-    const accepted = [(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'head', 'webchat', cp.sink)]
+    const accepted = [(daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'head', 'webchat', cp.sink)]
     await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1), WAIT)
 
     for (let n = 1; n <= 10; n++) {
-      accepted.push((daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, `queued-${n}`, 'webchat', cp.sink))
+      accepted.push(
+        (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, `queued-${n}`, 'webchat', cp.sink)
+      )
     }
     expect(accepted.every((ack) => ack.accepted)).toBe(true)
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     expect((daemon as any).serialQueue.get(key)).toHaveLength(10)
 
     // The exact-key preflight must reject before returning an accepted ACK. A client
     // therefore never starts waiting for a `done` frame that this non-admitted turn
     // cannot produce.
-    const rejected = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'queue-full', 'webchat', cp.sink)
+    const rejected = (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'queue-full',
+      'webchat',
+      cp.sink
+    )
     expect(rejected).toMatchObject({ accepted: false, reason: 'busy' })
     expect(cp.dones).toEqual([])
 
@@ -1168,7 +1194,12 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       mentionedBots: [] as string[],
       isDm: false
     }
-    await (daemon as any).dispatch(AGENT_ID, msg, undefined, (daemon as any).webchatWakeContext('webchat', CONV))
+    await (daemon as any).dispatch(
+      AGENT_ID,
+      msg,
+      undefined,
+      (daemon as any).webchatTransport.webchatWakeContext('webchat', CONV)
+    )
 
     // Two live posts: the inbound sender message first, then the woken reply.
     expect(posts).toHaveLength(2)
@@ -1337,7 +1368,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
       output: (output: WebchatOutput) => events.push({ kind: 'output', output }),
       done: (done: WebchatDone) => events.push({ kind: 'done', done })
     })
-    const stream = (daemon as any).createWebchatTurnStream(AGENT_ID, CONV, turnId, sink(first))
+    const stream = (daemon as any).webchatTransport.createWebchatTurnStream(AGENT_ID, CONV, turnId, sink(first))
 
     stream.sink.output({ conversationId: CONV, turnId, index: 0, event: { kind: 'message', text: 'first' } })
     const activeResume = (daemon as any).handleRelayMsg(
@@ -1400,7 +1431,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     )
     expect(beforeTurn).toMatchObject({ accepted: false, reason: 'stream_not_found' })
 
-    const stream = (daemon as any).createWebchatTurnStream(AGENT_ID, CONV, turnId, {
+    const stream = (daemon as any).webchatTransport.createWebchatTurnStream(AGENT_ID, CONV, turnId, {
       output: (output: WebchatOutput) => original.push({ kind: 'output', output }),
       done: (done: WebchatDone) => original.push({ kind: 'done', done })
     })
@@ -1455,7 +1486,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     await daemon.start()
 
     const turnId = '77777777-7777-4777-8777-777777777777'
-    const stream = (daemon as any).createWebchatTurnStream(AGENT_ID, CONV, turnId, {
+    const stream = (daemon as any).webchatTransport.createWebchatTurnStream(AGENT_ID, CONV, turnId, {
       output: () => {},
       done: () => {}
     })
@@ -1575,7 +1606,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
     await daemon.start()
     ;(daemon as any).cpClient = fakeCpClient()
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     ;(daemon as any).store.upsertSession({
       key,
       agentId: AGENT_ID,
@@ -1619,7 +1650,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     const { factory } = streamingHost([])
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
     await daemon.start()
-    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
     ;(daemon as any).store.upsertSession({
       key,
       agentId: AGENT_ID,
@@ -1658,8 +1689,8 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
     await daemon.start()
     ;(daemon as any).cpClient = fakeCpClient()
-    const cancel = vi.spyOn(daemon as any, 'handleWebchatCancel')
-    const close = vi.spyOn(daemon as any, 'handleWebchatClose')
+    const cancel = vi.spyOn((daemon as any).webchatTransport, 'handleWebchatCancel')
+    const close = vi.spyOn((daemon as any).webchatTransport, 'handleWebchatClose')
 
     expect((daemon as any).handleRelayMsg(rd({ op: 'cancel' }, { msgId: 'm-cancel' }), () => {})).toEqual({
       msgId: 'm-cancel',
@@ -1681,7 +1712,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
     await daemon.start()
     ;(daemon as any).cpClient = fakeCpClient()
-    const spy = vi.spyOn(daemon as any, 'dispatchWebchatTurn')
+    const spy = vi.spyOn((daemon as any).webchatTransport, 'dispatchWebchatTurn')
 
     // The relay's at-least-once wire can re-send a byte-identical rd/msg on an ack stall.
     const frame = rd({ op: 'turn', text: 'go', user: 'ada' }, { msgId: 'dup-1' })

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -1333,7 +1333,7 @@ describe('daemon durable inbox', () => {
       'bot-a',
       wake,
       undefined,
-      (daemon as any).webchatWakeContext('webchat', conversationId),
+      (daemon as any).webchatTransport.webchatWakeContext('webchat', conversationId),
       { callFrom: 'bot-b', hopCount: 1, deliveryId }
     )
 


### PR DESCRIPTION
Continues the delegate-shell cleanup left over from the coordinator extraction series. This PR cuts the **webchat** cluster: the same-name thin private methods on `Daemon` that only forwarded to `WebchatTransport` / `WebchatMcpRevocations`.

## What changed

**23 shells removed, 0 kept.**

`webchatTransport` (17): `dispatchWebchatTurn`, `dispatchWebchatContinuationTurn`, `handleWebchatClose`, `webchatSessionKey`, `webchatStreamKey`, `createWebchatTurnStream`, `webchatWakeContext`, `postAgentWakeInbound`, `publishWebchatStreamEvent`, `bufferWebchatStreamEvent`, `deliverWebchatStreamEvent`, `resumeWebchatStream`, `removeWebchatStream`, `pruneWebchatStreams`, `handleWebchatCancel`, `recordWebchatContextPost`, `maybeActivateWebchatContinuation`.

`webchatMcpRevocations` (3): `revokeAllRemoteWebchatGrants`, `revokeRemoteWebchatGrantsForAgent`, `drainWebchatMcpRevocations`.

Pure `webchat/turn-output.ts` wrappers (3): `appendWebchatTextRow`, `flushHeldWebchatText`, `emitWebchatUpdate` — these forwarded to the module functions, not a coordinator, so their call sites now call `webchatTurnOutput.*` directly (`appendWebchatTextRow` takes `this.store` explicitly; `emitWebchatUpdate` takes the already-narrowed `p.webchat`, dropping the shell's `!` assertion).

No shell was kept: none added a guard or adapted a signature, and every spy/override seam moves cleanly onto the coordinator instance.

**Call sites rewired in `daemon.ts`: 26** — the `rd/webchat` op switch (`turn` / continuation `turn` / `context` / `resume` / `cancel` / `close`), the five `webchatWakeContext` dispatch sites, `postAgentWakeInbound` in the wake path, the reply-commit and turn-failure paths, session-title emit, `onAcpUpdate`, agent detach/reconcile/stop/drain revokes, the idle sweep, `reclaimInterruptedWork`, the CP-READY replay, and the `workspaceAuthorityHost()` literal member. Seven now-unused type imports were dropped.

**Tests (4 files):** `(daemon as any).<name>(…)` pokes and `vi.spyOn(daemon as any, '<name>')` retargeted to `(daemon as any).webchatTransport` / `.webchatMcpRevocations`. The spied methods live on the coordinator prototypes and the internal calls go through `this.<name>`, so the interception points are unchanged.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` over `daemon-webchat`, `daemon-webchat-continuation`, `daemon-webchat-session-continuation`, `webchat-turn-refresh`, `remote-webchat-grant`, `daemon-remote-mcp-admission`, `daemon-remote-mcp-feature`, `daemon-serial-gate`, `turn-output-seam`, `daemon-interrupt-safety`, `durable-inbox`, `cp/cp-agent-reconcile` — **12 files / 180 tests passed**
- `prettier --check` and `eslint` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)