### PR TITLE
refactor(web): rename experiment flags to feature flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,11 +175,11 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # only API-key daemon auth is accepted.
 # DAEMON_POOL_ENABLED=true
 
-# Experimental console surfaces this deployment turns on — a comma-separated list of
-# ids (packages/web/src/lib/experiments.ts). Unset means none: the surface ships in
-# every build and appears only where an environment asks for it. The Control Plane
+# Console feature flags this deployment turns on — a comma-separated list of ids
+# (packages/web/src/lib/feature-flags.ts). Unset means none: a flagged surface ships
+# in every build and appears only where an environment asks for it. The Control Plane
 # serves the feature either way; this decides whether the console offers it.
 # Known ids: daemon-groups (the org's own member sets), daemon-pool (the install-wide
 # pool: its fleet entry and the Cloud placement option — DAEMON_POOL_ENABLED above is
 # what actually runs one).
-#   EXPERIMENTS="daemon-groups,daemon-pool"
+#   FEATURE_FLAGS="daemon-groups,daemon-pool"

--- a/compose.yaml
+++ b/compose.yaml
@@ -248,9 +248,9 @@ services:
       # targets; unset => all of them). The console owns this decision; the
       # control plane gates on whether the tenant has that connector.
       - SOCIAL_PROVIDERS
-      # Experimental console surfaces this deployment turns on (comma-separated ids;
-      # unset => none). Forwarded from the host so one image serves every deployment.
-      - EXPERIMENTS
+      # Console feature flags this deployment turns on (comma-separated ids; unset =>
+      # none). Forwarded from the host so one image serves every deployment.
+      - FEATURE_FLAGS
     healthcheck:
       test:
         - CMD

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useConsoleData } from '@/lib/data-context'
-import { experimentEnabled } from '@/lib/experiments'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import { useProfile } from '@/lib/profile'
 import { useOrgs } from '@/lib/org-context'
 import {
@@ -338,9 +338,9 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   }, [])
 
   // Cloud is one UI choice AND one server-side placement: the pool, named as itself.
-  // Experimental: with the pool hidden the choice is computed WITHOUT its members, so an
+  // Flagged: with the pool hidden the choice is computed WITHOUT its members, so an
   // untouched form defaults to the first machine rather than submitting a pool placement.
-  const placementDaemons = experimentEnabled('daemon-pool') ? daemons : daemons.filter((d) => !d.pool)
+  const placementDaemons = featureFlagEnabled('daemon-pool') ? daemons : daemons.filter((d) => !d.pool)
   const daemonChoice = addAgentDaemonChoice(placementDaemons, daemonId, memberSets)
   const {
     poolAvailable,
@@ -364,7 +364,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
       : []),
     // The org's own groups sit with Cloud, not with the machines: they are the same KIND of target
     // — the server picks which member serves, and the agent survives losing any one of them.
-    ...(experimentEnabled('daemon-groups') ? offeredGroups : []).map((group) => ({
+    ...(featureFlagEnabled('daemon-groups') ? offeredGroups : []).map((group) => ({
       value: groupPlacementValue(group.setId),
       label: group.name,
       meta: `${group.memberDaemonIds.length} daemon${group.memberDaemonIds.length === 1 ? '' : 's'}`,

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -36,7 +36,7 @@ import {
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { fetchAgentDto, type AgentCallPolicyInput, type UpdateAgentInput } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
-import { experimentEnabled } from '@/lib/experiments'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import { useOrgs } from '@/lib/org-context'
 import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import { Spinner } from '@/components/marks'
@@ -271,7 +271,7 @@ export default function EditAgentModal({
     if (!loaded || autofilledDaemon.current || initialDaemonId.current || daemonId) return
     const ready = (d: (typeof daemons)[number]) => d.status === 'online' && d.caps.features.includes('agent-move-v1')
     // With the pool hidden it is not a default either — an unplaced agent lands on a machine.
-    const offered = experimentEnabled('daemon-pool') ? daemons : daemons.filter((d) => !d.pool)
+    const offered = featureFlagEnabled('daemon-pool') ? daemons : daemons.filter((d) => !d.pool)
     const target = offered.find((d) => d.pool && ready(d)) ?? offered.find(ready)
     if (target) {
       autofilledDaemon.current = true
@@ -363,11 +363,11 @@ export default function EditAgentModal({
     daemons,
     daemonId,
     initialDaemonId.current,
-    experimentEnabled('daemon-pool')
+    featureFlagEnabled('daemon-pool')
   )
   const poolServing = daemons.some((candidate) => candidate.pool && moveReady(candidate))
   const daemonOptions: DaemonSelectOption[] = [
-    // With the experiment off the picker offers Cloud only to an agent already ON it — same rule
+    // With the flag off the picker offers Cloud only to an agent already ON it — same rule
     // the groups below follow, and for the same reason: "No daemon" for a placed agent is untrue.
     ...(daemonChoices.offerPool
       ? [
@@ -395,10 +395,10 @@ export default function EditAgentModal({
     // The org's own groups sit with Cloud: same kind of target, same promise — lose any one member
     // and the duty re-grants to another (daemon-groups.md §2). A group with nothing serving stays
     // listed but disabled, unless it is where the agent already is.
-    // With the experiment off the picker offers no group — EXCEPT the one this agent is already on.
+    // With the flag off the picker offers no group — EXCEPT the one this agent is already on.
     // Dropping it would show "No daemon" for a placed agent, which is simply untrue, and a rollback
     // is exactly when a truthful current placement matters most.
-    ...(experimentEnabled('daemon-groups')
+    ...(featureFlagEnabled('daemon-groups')
       ? memberSets
       : memberSets.filter((group) => groupPlacementValue(group.setId) === initialDaemonId.current)
     ).map((group) => {

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
@@ -20,7 +20,7 @@ export function editAgentDaemonChoices<T extends DaemonChoiceRow>(
   daemons: T[],
   selectedDaemonId: string,
   initialDaemonId: string,
-  /** Is the `daemon-pool` experiment on for this deployment? */
+  /** Is the `daemon-pool` flag on for this deployment? */
   poolOffered: boolean
 ): EditAgentDaemonChoices<T> {
   const selected = daemons.find((daemon) => daemon.daemonId === selectedDaemonId)

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/lib/data'
 import { creatorLabel } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
-import { experimentEnabled } from '@/lib/experiments'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import { useProfile } from '@/lib/profile'
 import { useModal } from '@/components/console/ModalProvider'
 import { VisibilityValue } from '@/components/console/VisibilityField'
@@ -840,7 +840,7 @@ function GroupCard({ daemon, pinnedAgents }: { daemon: DaemonRow; pinnedAgents: 
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   // The pool is managed infrastructure — its membership is the CP's, never an operator's.
-  if (daemon.pool || !experimentEnabled('daemon-groups')) return null
+  if (daemon.pool || !featureFlagEnabled('daemon-groups')) return null
 
   const current = memberSets.find((group) => group.setId === daemon.memberSetId)
   // Agents pinned here are not in the way of joining and do not move with it — they stay pinned to

--- a/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
@@ -92,9 +92,9 @@ function render(): string {
   return html
 }
 
-/** The console shows the pool only where the deployment asked for it (lib/experiments.ts). */
-const setExperiments = (value: string) => {
-  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { EXPERIMENTS: value }
+/** The console shows the pool only where the deployment asked for it (lib/feature-flags.ts). */
+const setFlags = (value: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: value }
 }
 
 beforeEach(() => {
@@ -102,7 +102,7 @@ beforeEach(() => {
   mocks.agents = []
   mocks.memberSets = []
   mocks.push.mockClear()
-  setExperiments('daemon-pool')
+  setFlags('daemon-pool')
 })
 
 describe('DaemonsView pool', () => {
@@ -180,7 +180,7 @@ describe('DaemonsView pool', () => {
   })
 
   it('names nothing about the pool where the deployment did not ask for it', () => {
-    setExperiments('')
+    setFlags('')
     mocks.daemons = [member('p1'), daemon({ daemonId: 'own', name: 'pc.dev' })]
     mocks.agents = [onPool('a1', 'p1')]
 
@@ -192,9 +192,9 @@ describe('DaemonsView pool', () => {
   })
 
   it('keeps the groups an org already made when hiding the pool empties the fleet', () => {
-    // The two experiments are independent switches. Hiding Cloud must not take the group surface
+    // The two flags are independent switches. Hiding Cloud must not take the group surface
     // with it just because the pool rows were the only thing keeping the fleet non-empty.
-    setExperiments('daemon-groups')
+    setFlags('daemon-groups')
     mocks.daemons = [member('p1')]
     mocks.memberSets = [{ setId: 'g1', name: 'edge-eu', memberDaemonIds: [], agentCount: 0 }]
 
@@ -208,7 +208,7 @@ describe('DaemonsView pool', () => {
   it('reads as an empty fleet when the pool is all there is and it is hidden', () => {
     // Not "0 daemons of an unnamed kind": with the pool hidden the org connected nothing,
     // so the page has to say so — a blank fleet with no empty state is a page that broke.
-    setExperiments('')
+    setFlags('')
     mocks.daemons = [member('p1'), member('p2')]
 
     const html = render()

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -12,7 +12,7 @@ import {
   type MemberSetRow
 } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
-import { experimentEnabled } from '@/lib/experiments'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import { useModal } from '@/components/console/ModalProvider'
 import { RestrictedLock } from '@/components/console/VisibilityField'
 import { DaemonUpgradeBadge } from '@/components/console/DaemonUpgradeBadge'
@@ -35,9 +35,9 @@ export default function DaemonsView() {
   // The pool is ONE entry, not one card per Pod: its members are install-wide
   // infrastructure every org sees, replaced without notice, and nothing here is the
   // org's to rename or detach. Everything else is a machine someone connected.
-  // Experimental: where the deployment did not ask for the pool, the page shows the
+  // Flagged: where the deployment did not ask for the pool, the page shows the
   // machines only — the CP still serves it, this is whether the console names it.
-  const showPool = experimentEnabled('daemon-pool')
+  const showPool = featureFlagEnabled('daemon-pool')
   const poolMembers = useMemo(() => (showPool ? daemons.filter((d) => d.pool) : []), [daemons, showPool])
   const ownDaemons = useMemo(() => daemons.filter((d) => !d.pool), [daemons])
   const poolAgents = useMemo(() => {
@@ -142,10 +142,10 @@ export default function DaemonsView() {
  */
 function GroupsSection({ groups, daemons }: { groups: MemberSetRow[]; daemons: DaemonRow[] }) {
   const { openModal } = useModal()
-  // Experimental: the surface exists in every build and appears only where the deployment asked
+  // Flagged: the surface exists in every build and appears only where the deployment asked
   // for it. The Control Plane serves member sets either way — this hides the console entry point,
   // not the feature, which is what keeps one server to reason about.
-  if (!experimentEnabled('daemon-groups')) return null
+  if (!featureFlagEnabled('daemon-groups')) return null
   if (!daemons.some((d) => !d.pool) && groups.length === 0) return null
 
   return (

--- a/packages/web/src/lib/feature-flags.test.ts
+++ b/packages/web/src/lib/feature-flags.test.ts
@@ -1,61 +1,61 @@
 // @vitest-environment happy-dom
 // The parse is the whole contract: what a deployment writes decides what its console shows.
 import { describe, expect, it, afterEach } from 'vitest'
-import { experimentEnabled } from './experiments'
+import { featureFlagEnabled } from './feature-flags'
 
 const setEnv = (value?: string) => {
   ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
-    value === undefined ? {} : { EXPERIMENTS: value }
+    value === undefined ? {} : { FEATURE_FLAGS: value }
 }
 
 afterEach(() => setEnv())
 
-describe('experimentEnabled', () => {
+describe('featureFlagEnabled', () => {
   it('is off unless the deployment asks for it', () => {
-    // A new experiment shipping ON is the failure mode this prevents: every environment would
+    // A new flag shipping ON is the failure mode this prevents: every environment would
     // get it the moment it merged.
     setEnv()
-    expect(experimentEnabled('daemon-groups')).toBe(false)
-    expect(experimentEnabled('daemon-pool')).toBe(false)
+    expect(featureFlagEnabled('daemon-groups')).toBe(false)
+    expect(featureFlagEnabled('daemon-pool')).toBe(false)
     setEnv('')
-    expect(experimentEnabled('daemon-groups')).toBe(false)
-    expect(experimentEnabled('daemon-pool')).toBe(false)
+    expect(featureFlagEnabled('daemon-groups')).toBe(false)
+    expect(featureFlagEnabled('daemon-pool')).toBe(false)
   })
 
-  it('switches each experiment on its own', () => {
+  it('switches each flag on its own', () => {
     // One id in the list turns on THAT surface — groups and the pool ship and roll out apart.
     setEnv('daemon-pool')
-    expect(experimentEnabled('daemon-pool')).toBe(true)
-    expect(experimentEnabled('daemon-groups')).toBe(false)
+    expect(featureFlagEnabled('daemon-pool')).toBe(true)
+    expect(featureFlagEnabled('daemon-groups')).toBe(false)
     setEnv('daemon-groups,daemon-pool')
-    expect(experimentEnabled('daemon-pool')).toBe(true)
-    expect(experimentEnabled('daemon-groups')).toBe(true)
+    expect(featureFlagEnabled('daemon-pool')).toBe(true)
+    expect(featureFlagEnabled('daemon-groups')).toBe(true)
   })
 
   it('reads a comma-separated list, tolerating spacing and case', () => {
     setEnv(' Daemon-Groups , something-else ')
-    expect(experimentEnabled('daemon-groups')).toBe(true)
+    expect(featureFlagEnabled('daemon-groups')).toBe(true)
   })
 
   it('ignores ids it does not know', () => {
     setEnv('not-a-feature')
-    expect(experimentEnabled('daemon-groups')).toBe(false)
+    expect(featureFlagEnabled('daemon-groups')).toBe(false)
   })
 
   it('server and client read the same value, so the gate cannot differ across hydration', () => {
-    // `public-env` injects plain `EXPERIMENTS`; a server branch reading only the build-time twin
+    // `public-env` injects plain `FEATURE_FLAGS`; a server branch reading only the build-time twin
     // would render the surface off and hydrate it on.
     const original = (window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV
     delete (window as unknown as { __AC_ENV?: unknown }).__AC_ENV
-    process.env.EXPERIMENTS = 'daemon-groups'
+    process.env.FEATURE_FLAGS = 'daemon-groups'
     try {
       // The browser branch, with nothing injected: off, because there is nothing to read.
-      expect(experimentEnabled('daemon-groups')).toBe(false)
+      expect(featureFlagEnabled('daemon-groups')).toBe(false)
       // And injected, it is the source both sides agree on.
-      ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { EXPERIMENTS: 'daemon-groups' }
-      expect(experimentEnabled('daemon-groups')).toBe(true)
+      ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: 'daemon-groups' }
+      expect(featureFlagEnabled('daemon-groups')).toBe(true)
     } finally {
-      delete process.env.EXPERIMENTS
+      delete process.env.FEATURE_FLAGS
       ;(window as unknown as { __AC_ENV?: unknown }).__AC_ENV = original
     }
   })

--- a/packages/web/src/lib/feature-flags.ts
+++ b/packages/web/src/lib/feature-flags.ts
@@ -1,20 +1,22 @@
 /**
- * Experimental features, as the console sees them.
+ * Feature flags, as the console sees them.
  *
- * `EXPERIMENTS` is a comma-separated list of the ids below, read at runtime through
+ * `FEATURE_FLAGS` is a comma-separated list of the ids below, read at runtime through
  * `window.__AC_ENV` — so one prebuilt image serves every environment and a deployment decides
- * which experimental surfaces it shows. Unset means none: a new experiment cannot arrive on.
+ * which flagged surfaces it shows. Unset means none: a new flag cannot arrive on.
  *
  * This is a CONSOLE-side switch. The Control Plane serves the feature either way; what an
  * environment turns off here is whether the console offers it, not whether it exists. That is the
  * point — the feature stays exercised end to end wherever it is on, with no server-side variant to
  * reason about.
  *
- * A flag is temporary. When a feature is on everywhere, delete its id here and the checks with it.
+ * A flag is either temporary — an experiment, deleted once its feature is on everywhere — or a
+ * standing switch for a surface only some deployments ever offer. Retiring one is removing its id
+ * here and the checks with it.
  */
 
-/** Every experiment the console knows. Adding one is this union plus its checks. */
-export type ExperimentId =
+/** Every flag the console knows. Adding one is this union plus its checks. */
+export type FeatureFlagId =
   /** Org-scoped daemon groups: the Infra section, the group dialogs, and group entries in the
    *  placement picker (docs/designs/daemon-groups.md §6 PR 2). */
   | 'daemon-groups'
@@ -25,12 +27,12 @@ export type ExperimentId =
 function enabledIds(): ReadonlySet<string> {
   // The server must read the SAME value `PublicEnvScript` injects, in the same precedence, or a
   // runtime-only configuration renders the gate off on the server and on during hydration — which
-  // is a React markup mismatch, not just a flicker. `public-env` resolves plain `EXPERIMENTS`
+  // is a React markup mismatch, not just a flicker. `public-env` resolves plain `FEATURE_FLAGS`
   // first and falls back to the build-time `NEXT_PUBLIC_` twin; so does this.
   const raw =
     (typeof window === 'undefined'
-      ? (process.env.EXPERIMENTS ?? process.env.NEXT_PUBLIC_EXPERIMENTS)
-      : window.__AC_ENV?.EXPERIMENTS) ?? ''
+      ? (process.env.FEATURE_FLAGS ?? process.env.NEXT_PUBLIC_FEATURE_FLAGS)
+      : window.__AC_ENV?.FEATURE_FLAGS) ?? ''
   return new Set(
     raw
       .split(',')
@@ -40,11 +42,11 @@ function enabledIds(): ReadonlySet<string> {
 }
 
 /**
- * Is this experiment on for this deployment?
+ * Is this flag on for this deployment?
  *
  * Not a hook: it reads a value fixed for the life of the page (injected before the bundle runs),
  * so it needs no subscription and can be called from anywhere — a render, a helper, a projection.
  */
-export function experimentEnabled(id: ExperimentId): boolean {
+export function featureFlagEnabled(id: FeatureFlagId): boolean {
   return enabledIds().has(id)
 }

--- a/packages/web/src/lib/public-env.tsx
+++ b/packages/web/src/lib/public-env.tsx
@@ -47,10 +47,10 @@ const KEYS = [
   // (lib/analytics never initializes). POSTHOG_HOST defaults to us.i.posthog.com.
   'POSTHOG_API_KEY',
   'POSTHOG_HOST',
-  // Experimental features this deployment turns on — a comma-separated list of ids
-  // (lib/experiments.ts). Unset ⇒ none: an experimental surface ships in every build and appears
+  // Console feature flags this deployment turns on — a comma-separated list of ids
+  // (lib/feature-flags.ts). Unset ⇒ none: a flagged surface ships in every build and appears
   // only where an environment asks for it, so one prebuilt image serves them all.
-  'EXPERIMENTS'
+  'FEATURE_FLAGS'
 ] as const
 
 interface RuntimeConfigResponse {


### PR DESCRIPTION
## Why

The console's flag list was named for one of its uses, not for what it is. Nothing
about the mechanism is experimental: it is a comma-separated id list a deployment
sets, read at runtime through `window.__AC_ENV`, deciding whether the console
*offers* a surface while the Control Plane serves it either way. Naming it
`EXPERIMENTS` left a standing per-deployment switch — a surface only some
deployments ever offer — with no honest place to live. This renames the mechanism
so it can carry any kind of flag.

## What changed

| Before | After |
| --- | --- |
| `packages/web/src/lib/experiments.ts` | `packages/web/src/lib/feature-flags.ts` |
| `ExperimentId` | `FeatureFlagId` |
| `experimentEnabled(id)` | `featureFlagEnabled(id)` |
| `EXPERIMENTS` / `NEXT_PUBLIC_EXPERIMENTS` | `FEATURE_FLAGS` / `NEXT_PUBLIC_FEATURE_FLAGS` |

Eleven files: the module and its test, the `KEYS` allowlist in `public-env.tsx`,
the four call sites (`DaemonsView`, `DaemonDetailView`, `AddAgentModal`,
`EditAgentModal`) plus the doc comment on `edit-agent-daemon-choice.ts`,
`DaemonsView.pool.test.tsx`, and the pass-through in `.env.example` and
`compose.yaml`.

The module's doc comment also loosens its own rule. It used to assert "a flag is
temporary"; it now says a flag is **either** temporary — an experiment, deleted
once its feature is on everywhere — **or** a standing switch for a surface only
some deployments ever offer. That is the whole point of the rename.

Behavior is unchanged: same parse, same server/client precedence, same two ids
(`daemon-groups`, `daemon-pool`), same default of off.

## Reviewer notes

**The env var is renamed outright, with no alias for the old name.** Everything in
this repository is updated, but the value is actually set through Helm values on
the deployment side, which is outside this repo. An environment that sets the old
key has to be updated in step, or its flags read as off — silently, since an unset
list is a valid "none". Today only one non-production environment sets it at all.

Other `experiment` spellings left in the tree are unrelated and untouched:
`OTEL_EXPERIMENTAL_*`, the ACP experimental session-config option, Next's
`experimental.extensionAlias`, and ordinary English in a few design docs.

## Verification

- `pnpm --filter @agentconnect.md/web typecheck` — clean
- `pnpm --filter @agentconnect.md/web test` — 150 files, 1593 tests, all passing
- `pnpm lint`, `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
