### PR TITLE
refactor(daemon): cut the connection + observed-channel delegate shells

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -134,7 +134,7 @@ import {
   type SlackAppFactory,
   type SlackStatusOptions
 } from './slack/connection.js'
-import { TelegramConnection, type TelegramObservedChat } from './telegram/connection.js'
+import { TelegramConnection } from './telegram/connection.js'
 import { DiscordConnection } from './discord/connection.js'
 import { FeishuConnection } from './feishu/connection.js'
 import { SlackNameResolver } from './slack/name-resolver.js'
@@ -365,7 +365,6 @@ import type {
 } from '@agentclientprotocol/sdk'
 import type { Agent, CronDef, Integration } from './agents/agent-schema.js'
 import { fromPlatformMessage, stableMessageId, stableTurnId, type NormalizedMessage } from './messages/normalized.js'
-import { ConnectionPool } from './platforms/registry.js'
 import {
   ConnectionReconciler,
   type ConnectionReconcilerHost,
@@ -392,8 +391,6 @@ import type {
   McpTransportCapabilities,
   RuntimeModelCatalog,
   IntegrationChannel,
-  IntegrationLeave,
-  IntegrationLeaveOk,
   Drain,
   DrainProgress,
   DrainDone,
@@ -716,25 +713,8 @@ export class Daemon {
    *  daemon drain cannot leave a timer behind. The callback re-validates everything it
    *  needs, so a lease dropped by stopHost simply makes the wake a no-op. */
   private bgWakeTimers = new Set<TimerHandle>()
-  // §7.5 platform connection lifecycle — the pools, the openers, the prune pass and the
-  // Slack startup retries all live in the reconciler; the delegates below are what the
-  // rest of this class (and the tests) still reach it through.
+  // §7.5 platform connection lifecycle: pools, openers, the prune pass and the Slack startup retries.
   private readonly connections: ConnectionReconciler
-  private get slackPool(): ConnectionPool<SlackConnection> {
-    return this.connections.slackPool
-  }
-  private get slackSharedPool(): ConnectionPool<SlackConnection> {
-    return this.connections.slackSharedPool
-  }
-  private get telegramPool(): ConnectionPool<TelegramConnection> {
-    return this.connections.telegramPool
-  }
-  private get discordPool(): ConnectionPool<DiscordConnection> {
-    return this.connections.discordPool
-  }
-  private get feishuPool(): ConnectionPool<FeishuConnection> {
-    return this.connections.feishuPool
-  }
   /**
    * §7.3 turn-output surfaces — the converger factory, the applier, and the
    * opaque per-turn state slot, as ONE trio per platform. The bodies still live
@@ -1338,13 +1318,15 @@ export class Daemon {
       unbindIntegration: (integrationId) => this.unbindIntegration(integrationId),
       slackNameResolver: () => this.nameResolver,
       channelNameResolver: () => this.channelNameResolver,
-      refreshChannels: (conn) => this.refreshChannels(conn),
+      refreshChannels: (conn) => this.connections.refreshChannels(conn),
       onInbound: (msg, srcIntegrationIds) => this.onInbound(msg, srcIntegrationIds),
       srcIntegrationIds: (conn) => this.srcIntegrationIds(conn),
       waitForConnectionUses: (conn) => this.waitForConnectionUses(conn),
-      observeTelegramChat: (chat, integrationIds) => this.observeTelegramChat(chat, integrationIds),
-      refreshObservedChannels: () => this.refreshObservedChannels(),
-      retractChannels: (integrationId, channelIds) => this.retractChannels(integrationId, channelIds),
+      observeTelegramChat: (chat, integrationIds) =>
+        this.observedChannelsSync.observeTelegramChat(chat, integrationIds),
+      refreshObservedChannels: () => this.observedChannelsSync.refreshObservedChannels(),
+      retractChannels: (integrationId, channelIds) =>
+        this.observedChannelsSync.retractChannels(integrationId, channelIds),
       integrationConfigById: (integrationId) => this.integrationConfigById(integrationId),
       integrationIdForTransportScope: (agentId, platform, transportScope) =>
         this.integrationIdForTransportScope(agentId, platform, transportScope),
@@ -1919,14 +1901,14 @@ export class Daemon {
         // A freshly-resolved Telegram/Discord/Feishu channel name should also refresh that
         // integration's observed-channel snapshot (approach-A discovery) so the console
         // shows the human name rather than the raw chat/channel id.
-        this.refreshObservedChannels()
+        this.observedChannelsSync.refreshObservedChannels()
       },
       {
         // A newly-learnt scope changes which rows the observed set collapses onto (a
         // Discord thread folds into its channel), so re-emit the snapshot with it.
         saveScope: (id, scope) => {
           this.store.setChannelScope(id, scope, Date.now())
-          this.refreshObservedChannels()
+          this.observedChannelsSync.refreshObservedChannels()
         },
         saveAvatar: (source, id, avatarUrl) => {
           const scope = this.transportScopeForIntegrationIds(this.srcIntegrationIds(source))
@@ -2338,22 +2320,22 @@ export class Daemon {
     // open consolidated Slack connections, resolve bot user ids (merged rules are per-message)
     await this.connections.openInitialSlackConnections(agents)
     // Open send-only Slack clients for HTTP bots (inbound lives on the relay).
-    await this.openHttpSlackConnections(agents)
+    await this.connections.openHttpSlackConnections(agents)
     // Long-poll / gateway / WS platform connects (Telegram/Discord/Feishu) must NOT gate
     // boot: their start() awaits a bot-identity handshake (e.g. Telegram getMe) that can
     // HANG indefinitely when the platform API is unreachable — which would otherwise stall
     // the daemon before it ever reaches startCpClient() below, taking CP + Slack (via the
     // relay) down with it. Fire them in the background so the rest of boot proceeds; each
     // reconcile already catches its own per-token failures and leaves other tokens intact.
-    void this.reconcileTelegramConnections().catch((err) =>
-      this.log.error(`telegram: initial connect failed: ${formatErr(err)}`)
-    )
-    void this.reconcileDiscordConnections().catch((err) =>
-      this.log.error(`discord: initial connect failed: ${formatErr(err)}`)
-    )
-    void this.reconcileFeishuConnections().catch((err) =>
-      this.log.error(`feishu: initial connect failed: ${formatErr(err)}`)
-    )
+    void this.connections
+      .reconcileTelegramConnections()
+      .catch((err) => this.log.error(`telegram: initial connect failed: ${formatErr(err)}`))
+    void this.connections
+      .reconcileDiscordConnections()
+      .catch((err) => this.log.error(`discord: initial connect failed: ${formatErr(err)}`))
+    void this.connections
+      .reconcileFeishuConnections()
+      .catch((err) => this.log.error(`feishu: initial connect failed: ${formatErr(err)}`))
 
     // register crons (sync per agent — the same converge reconcile re-runs on change)
     for (const a of agents) this.syncAgentSchedules(a)
@@ -2713,11 +2695,11 @@ export class Daemon {
     // Reconcile exactly once from the final live roster. The close phase is strict:
     // detach ACKs only after last-reference connections have actually stopped.
     if (connectionsDirty) {
-      await this.closeUnusedPlatformConnections()
-      await this.reconcileSlackConnections()
-      await this.reconcileTelegramConnections()
-      await this.reconcileDiscordConnections()
-      await this.reconcileFeishuConnections()
+      await this.connections.closeUnusedPlatformConnections()
+      await this.connections.reconcileSlackConnections()
+      await this.connections.reconcileTelegramConnections()
+      await this.connections.reconcileDiscordConnections()
+      await this.connections.reconcileFeishuConnections()
       // Converged for real: the sockets a duty change invalidated are closed. Publishing the
       // CLAIMED value (not the current one) leaves a duty change that landed mid-pass outstanding,
       // so the trailing re-run still converges it.
@@ -2753,75 +2735,6 @@ export class Daemon {
         `workspace: prefetch clone for "${agent.id}" failed (will retry at first session): ${formatErr(err)}`
       )
     )
-  }
-
-  /** §7.5 platform lifecycle delegates — the bodies live in ConnectionReconciler; the
-   *  same-name methods stay here because callers (and tests) reach them through the class. */
-  private async closeUnusedPlatformConnections(): Promise<void> {
-    await this.connections.closeUnusedPlatformConnections()
-  }
-
-  private async reconcileSlackConnections(): Promise<void> {
-    await this.connections.reconcileSlackConnections()
-  }
-
-  private async openHttpSlackConnections(agents: LoadedAgent[]): Promise<void> {
-    await this.connections.openHttpSlackConnections(agents)
-  }
-
-  private async reconcileTelegramConnections(): Promise<void> {
-    await this.connections.reconcileTelegramConnections()
-  }
-
-  private async reconcileDiscordConnections(): Promise<void> {
-    await this.connections.reconcileDiscordConnections()
-  }
-
-  private async reconcileFeishuConnections(): Promise<void> {
-    await this.connections.reconcileFeishuConnections()
-  }
-
-  private backfillChannelNames(): void {
-    this.connections.backfillChannelNames()
-  }
-
-  private refreshObservedChannels(): void {
-    this.observedChannelsSync.refreshObservedChannels()
-  }
-
-  private async leaveConversation(leave: IntegrationLeave): Promise<IntegrationLeaveOk> {
-    return this.connections.leaveConversation(leave)
-  }
-
-  private clearRetractionOnTraffic(msg: NormalizedMessage, srcIntegrationIds?: string[]): void {
-    this.observedChannelsSync.clearRetractionOnTraffic(msg, srcIntegrationIds)
-  }
-
-  private retractChannels(integrationId: string, channelIds: readonly string[]): void {
-    this.observedChannelsSync.retractChannels(integrationId, channelIds)
-  }
-
-  private observeTelegramChat(chat: TelegramObservedChat, integrationIds: readonly string[]): void {
-    this.observedChannelsSync.observeTelegramChat(chat, integrationIds)
-  }
-
-  private spaceFor(platform: string, channelId: string): { id: string; name?: string } | undefined {
-    return this.observedChannelsSync.spaceFor(platform, channelId)
-  }
-
-  private collapseObserved(
-    observed: { id: string; name?: string }[],
-    platform: string
-  ): { id: string; name?: string; spaceId?: string; space?: string }[] {
-    return this.observedChannelsSync.collapseObserved(observed, platform)
-  }
-
-  private async refreshChannels(conn: SlackConnection): Promise<void> {
-    await this.connections.refreshChannels(conn)
-  }
-
-  private maybeIntroduceOnJoin(platform: string, integrationId: string, channels: { id: string }[]): void {
-    this.connections.maybeIntroduceOnJoin(platform, integrationId, channels)
   }
 
   /** Code/socket carve-backs below the denied host HOME/daemon root. Every input
@@ -5118,7 +5031,7 @@ export class Daemon {
       return { kind: 'rejected', reason: 'gated' }
     }
     const agentAuthored = this.isAgentBotMessage(msg)
-    this.clearRetractionOnTraffic(msg, srcIntegrationIds)
+    this.observedChannelsSync.clearRetractionOnTraffic(msg, srcIntegrationIds)
     msg.transportScope ??= this.transportScopeForIntegrationIds(srcIntegrationIds)
     if (msg.sender.avatarUrl && msg.transportScope)
       this.store.setProfileAvatar(msg.transportScope, msg.sender.id, msg.sender.avatarUrl, Date.now())
@@ -10523,7 +10436,7 @@ export class Daemon {
       // A first-seen chat widens the observed reachable set (approach-A discovery) —
       // report it after the session row exists so the console cannot miss a name
       // lookup that completed during cold session startup.
-      this.refreshObservedChannels()
+      this.observedChannelsSync.refreshObservedChannels()
     }
     try {
       onSessionReady?.(sessionId)
@@ -14059,7 +13972,7 @@ export class Daemon {
     const kind = observed === 'channel' && current?.kind === 'mpim' ? ('mpim' as const) : observed
     const known = this.store.getDisplayNames([channel]).get(channel)
     // Which Discord server the channel belongs to — see spaceFor. Direct rows have none.
-    const found = kind === 'channel' ? this.spaceFor(msg.platform, channel) : undefined
+    const found = kind === 'channel' ? this.observedChannelsSync.spaceFor(msg.platform, channel) : undefined
     const space = found ? { spaceId: found.id, ...(found.name ? { space: found.name } : {}) } : undefined
     // Compare against what a write would actually change — a partially resolved space
     // (id known, name not yet) must not re-emit the snapshot on every message.
@@ -16091,12 +16004,13 @@ export class Daemon {
       ): Promise<T> => this.enqueueAgentWorkspacePreparation(agent, operation, expectedWarmHost, allowAgentDrain),
       activationCapabilityError: (agent) => this.activationCapabilityError(agent),
       servesAgent: (agentId) => this.servesAgent(agentId),
-      closeUnusedPlatformConnections: () => this.closeUnusedPlatformConnections(),
+      closeUnusedPlatformConnections: () => this.connections.closeUnusedPlatformConnections(),
       applyDutyGrant: (grants) => this.dutyCoordinator.applyDutyGrant(grants),
       applyDutyRevoke: (revocations) => this.dutyCoordinator.applyDutyRevoke(revocations),
       decideEditorPermission: (req) => this.decideEditorPermission(req),
-      leaveConversation: (leave) => this.leaveConversation(leave),
-      retractChannels: (integrationId, channelIds) => this.retractChannels(integrationId, channelIds),
+      leaveConversation: (leave) => this.connections.leaveConversation(leave),
+      retractChannels: (integrationId, channelIds) =>
+        this.observedChannelsSync.retractChannels(integrationId, channelIds),
       runCronNow: (cronId) => this.runCronNow(cronId),
       runDrain: (drain, onProgress) => this.runDrain(drain, onProgress),
       scheduleFleetExit: (kind, targetVersion) => this.scheduleFleetExit(kind, targetVersion)

--- a/packages/daemon/src/messages/channel-intro.ts
+++ b/packages/daemon/src/messages/channel-intro.ts
@@ -8,7 +8,7 @@ import type { NormalizedMessage } from './normalized.js'
  * wake) so those peers can record it in their memory and know who to delegate to later.
  * The filter is load-bearing: `listAgents` is org-wide by default. This module
  * is the pure decision layer + the synthetic-turn builder; the daemon wires the
- * durable state and dispatch around it (see Daemon.maybeIntroduceOnJoin).
+ * durable state and dispatch around it (see ConnectionReconciler.maybeIntroduceOnJoin).
  *
  * The whole feature is opt-in per agent (`agent.introduceOnJoin`, default off).
  */

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -116,8 +116,7 @@ export interface ConnectionReconcilerHost extends PlatformActionSink {
   unbindIntegration(integrationId: string): void
   slackNameResolver(): SlackNameResolver | undefined
   channelNameResolver(): ChannelNameResolver | undefined
-  /** The Daemon's same-name delegate back into `ConnectionReconciler.refreshChannels` —
-   *  every internal re-list goes through it so the membership refresh stays one seam. */
+  /** Host hop back into `ConnectionReconciler.refreshChannels` — every internal re-list goes through it so the membership refresh stays one seam. */
   refreshChannels(conn: SlackConnection): Promise<void>
   onInbound(msg: NormalizedMessage, srcIntegrationIds?: string[]): void
   srcIntegrationIds(conn: unknown): string[]

--- a/packages/daemon/test/channel-intro.test.ts
+++ b/packages/daemon/test/channel-intro.test.ts
@@ -163,8 +163,10 @@ describe('Daemon.maybeIntroduceOnJoin: the intro turn carries its own discovery 
     }
     const introduce = (channels: string[]): void =>
       (
-        daemon as never as { maybeIntroduceOnJoin: (p: string, i: string, c: { id: string }[]) => void }
-      ).maybeIntroduceOnJoin(
+        daemon as never as {
+          connections: { maybeIntroduceOnJoin: (p: string, i: string, c: { id: string }[]) => void }
+        }
+      ).connections.maybeIntroduceOnJoin(
         // The caller (Slack's authoritative-snapshot refresh) names its platform as data.
         'slack',
         'int-1',

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -725,7 +725,7 @@ describe('Daemon CP agent → memory + reconcile', () => {
         config: { appToken: 'xapp-only', botToken: 'xoxb-only' }
       }
     ]
-    ;(daemon as any).slackPool.add(connection)
+    ;(daemon as any).connections.slackPool.add(connection)
     ;(daemon as any).connByIntegration.set('int-only', connection)
     const releaseDispatch = (daemon as any).beginActiveDispatch('bot-a') as () => void
 

--- a/packages/daemon/test/daemon-duty-drain.test.ts
+++ b/packages/daemon/test/daemon-duty-drain.test.ts
@@ -310,11 +310,11 @@ describe('shutdown drain of a duty-holding member', () => {
     const { daemon, calls } = await boot()
     // A live direct socket for agent A's group, as reconcile would have opened it while held.
     const conn = { botToken: 'xoxb-test', appToken: 'xapp-test', botUserId: 'U1', stop: vi.fn(async () => {}) }
-    ;(daemon as any).slackPool.add(conn)
+    ;(daemon as any).connections.slackPool.add(conn)
     ;(daemon as any).connByIntegration.set('22222222-2222-4222-8222-222222222222', conn)
     let socketOpenAtRelease: boolean | undefined
     ;(daemon as any).cpClient.releaseDuties = vi.fn(async (groupIds: string[]) => {
-      if (groupIds[0] === GROUP) socketOpenAtRelease = (daemon as any).slackPool.all().includes(conn)
+      if (groupIds[0] === GROUP) socketOpenAtRelease = (daemon as any).connections.slackPool.all().includes(conn)
       calls.releases.push(groupIds)
     })
 

--- a/packages/daemon/test/daemon-duty-fence.test.ts
+++ b/packages/daemon/test/daemon-duty-fence.test.ts
@@ -147,13 +147,13 @@ function liveSlackSocket(
   creds = { botToken: 'xoxb-test', appToken: 'xapp-test' }
 ) {
   const conn = { ...creds, botUserId: `U-${integrationId.slice(-1)}`, stop: vi.fn(async () => {}) }
-  ;(d as any).slackPool.add(conn)
+  ;(d as any).connections.slackPool.add(conn)
   ;(d as any).connByIntegration.set(integrationId, conn)
   ;(d as any).botUserIds[integrationId] = conn.botUserId
   return conn
 }
 
-const pooled = (d: Daemon): unknown[] => (d as any).slackPool.all()
+const pooled = (d: Daemon): unknown[] => (d as any).connections.slackPool.all()
 
 describe('the duty self-fence', () => {
   it('releases every held group and stops serving its agents, with no configuration asking for it', async () => {

--- a/packages/daemon/test/daemon-duty-replacement.test.ts
+++ b/packages/daemon/test/daemon-duty-replacement.test.ts
@@ -122,13 +122,13 @@ function liveSlackSocket(d: Daemon, agentId: string) {
     botUserId: `U-${NAMES[agentId]}`,
     stop: vi.fn(async () => {})
   }
-  ;(d as any).slackPool.add(conn)
+  ;(d as any).connections.slackPool.add(conn)
   ;(d as any).connByIntegration.set(integrationId, conn)
   ;(d as any).botUserIds[integrationId] = conn.botUserId
   return conn
 }
 
-const pooled = (d: Daemon): unknown[] => (d as any).slackPool.all()
+const pooled = (d: Daemon): unknown[] => (d as any).connections.slackPool.all()
 
 describe('a refused replacement still applies its removals', () => {
   it('drops the departed agent, keeps the group serving the rest, and stays at the old term', async () => {

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -1151,7 +1151,7 @@ describe('daemon durable inbox', () => {
       setStatus: vi.fn(async () => {}),
       postMessage: vi.fn(async () => {})
     }
-    vi.spyOn(daemon as any, 'reconcileSlackConnections').mockImplementation(async () => {
+    vi.spyOn((daemon as any).connections, 'reconcileSlackConnections').mockImplementation(async () => {
       const integration = (daemon as any).agents
         .get('ghost')
         ?.integrations.find((candidate: { id: string }) => candidate.id === integrationId)

--- a/packages/daemon/test/feishu-region-reconcile.test.ts
+++ b/packages/daemon/test/feishu-region-reconcile.test.ts
@@ -77,29 +77,31 @@ describe('feishu reconcile — region change on the same appId', () => {
   it('evicts the stale per-integration mapping + stops the old-domain connection', async () => {
     const daemon = new Daemon({ root: configRoot(), hostFactory: () => ({ start: vi.fn(), stop: vi.fn() }) as never })
     const d = daemon as unknown as {
-      feishuPool: { add(c: FeishuConnection): void; all(): FeishuConnection[] }
+      connections: {
+        feishuPool: { add(c: FeishuConnection): void; all(): FeishuConnection[] }
+        closeUnusedPlatformConnections: () => Promise<void>
+      }
       fsConnByIntegration: Map<string, FeishuConnection>
       botUserIds: Record<string, string | undefined>
-      closeUnusedPlatformConnections: () => Promise<void>
     }
 
     const intId = 'int-1'
     const { conn: stale, closed } = fakeFeishuConn('cli_x', 'feishu', 'ou_old')
     // Existing state: the app is connected to the FEISHU gateway and routed there.
-    d.feishuPool.add(stale)
+    d.connections.feishuPool.add(stale)
     d.fsConnByIntegration.set(intId, stale)
     d.botUserIds[intId] = 'ou_old'
 
     // Desired state: the same appId now wants the LARK gateway.
     seedAgent(daemon, 'agent-1', intId, 'cli_x', 'lark')
 
-    await d.closeUnusedPlatformConnections()
+    await d.connections.closeUnusedPlatformConnections()
 
     // The stale old-domain connection is stopped and dropped from the live list, and its
     // routing mapping is evicted — so a failed replacement can never leave the integration
     // pointed at the wrong-region client (it re-binds only on a successful new connect).
     expect(closed).toHaveBeenCalled()
-    expect(d.feishuPool.all()).not.toContain(stale)
+    expect(d.connections.feishuPool.all()).not.toContain(stale)
     expect(d.fsConnByIntegration.has(intId)).toBe(false)
     expect(d.botUserIds[intId]).toBeUndefined()
 

--- a/packages/daemon/test/platform-registry-drift.test.ts
+++ b/packages/daemon/test/platform-registry-drift.test.ts
@@ -58,11 +58,11 @@ describe('daemon platform registry (audit F16)', () => {
     // Pools are per (platform, MODE) — Slack runs a socket pool beside a send-only
     // shared one — so the mode suffix is dropped before comparing.
     const poolPlatforms = [
-      daemon.slackPool,
-      daemon.slackSharedPool,
-      daemon.telegramPool,
-      daemon.discordPool,
-      daemon.feishuPool
+      daemon.connections.slackPool,
+      daemon.connections.slackSharedPool,
+      daemon.connections.telegramPool,
+      daemon.connections.discordPool,
+      daemon.connections.feishuPool
     ].map((pool: { name: string }) => pool.name.split('/')[0])
     expect(sorted([...new Set(poolPlatforms)])).toEqual(sorted(platformIds()))
   })

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -364,7 +364,7 @@ describe('Daemon.reconcileSlackConnections', () => {
     await daemon.start()
 
     const shared = { botToken: 'xoxb-shared', botUserId: 'U_SHARED', stop: vi.fn().mockResolvedValue(undefined) }
-    ;(daemon as any).slackSharedPool.add(shared)
+    ;(daemon as any).connections.slackSharedPool.add(shared)
     ;(daemon as any).agents = new Map([
       [
         'bot-shared',
@@ -376,16 +376,16 @@ describe('Daemon.reconcileSlackConnections', () => {
         }
       ]
     ])
-    const refresh = vi.spyOn(daemon as any, 'refreshChannels').mockResolvedValue(undefined)
+    const refresh = vi.spyOn((daemon as any).connections, 'refreshChannels').mockResolvedValue(undefined)
 
-    await (daemon as any).openHttpSlackConnections([...(daemon as any).agents.values()])
+    await (daemon as any).connections.openHttpSlackConnections([...(daemon as any).agents.values()])
 
     expect((daemon as any).connByIntegration.get('int-shared')).toBe(shared)
     expect(refresh).toHaveBeenCalledOnce()
     expect(refresh).toHaveBeenCalledWith(shared)
 
     // A normal reconcile of an unchanged binding should not re-list Slack channels.
-    await (daemon as any).openHttpSlackConnections([...(daemon as any).agents.values()])
+    await (daemon as any).connections.openHttpSlackConnections([...(daemon as any).agents.values()])
     expect(refresh).toHaveBeenCalledOnce()
     await daemon.stop()
   })
@@ -398,8 +398,8 @@ describe('Daemon.reconcileSlackConnections', () => {
     // Two live sockets: conn-A (appToken A) and conn-B (appToken B, shared/already open).
     const connA = fakeConn('xapp-A', 'xoxb-A', 'U_A')
     const connB = fakeConn('xapp-B', 'xoxb-B', 'U_B')
-    ;(daemon as any).slackPool.add(connA)
-    ;(daemon as any).slackPool.add(connB)
+    ;(daemon as any).connections.slackPool.add(connA)
+    ;(daemon as any).connections.slackPool.add(connB)
     ;(daemon as any).connByIntegration.set('int-1', connA)
     ;(daemon as any).connByIntegration.set('int-other', connB)
     ;(daemon as any).botUserIds = { 'int-1': 'U_A', 'int-other': 'U_B' }
@@ -422,7 +422,7 @@ describe('Daemon.reconcileSlackConnections', () => {
       ]
     ])
 
-    await (daemon as any).reconcileSlackConnections()
+    await (daemon as any).connections.reconcileSlackConnections()
 
     // int-1 must now resolve to conn-B (not the stale conn-A).
     expect((daemon as any).connByIntegration.get('int-1')).toBe(connB)
@@ -437,7 +437,7 @@ describe('Daemon.reconcileSlackConnections', () => {
 
     const conn = fakeConn('xapp-A', 'xoxb-A', 'U_A')
     const stop = vi.spyOn(conn, 'stop')
-    ;(daemon as any).slackPool.add(conn)
+    ;(daemon as any).connections.slackPool.add(conn)
     ;(daemon as any).connByIntegration.set('int-detached', conn)
     ;(daemon as any).connByIntegration.set('int-live', conn)
     ;(daemon as any).botUserIds = { 'int-detached': 'U_A', 'int-live': 'U_A' }
@@ -455,18 +455,18 @@ describe('Daemon.reconcileSlackConnections', () => {
       ]
     ])
 
-    await (daemon as any).closeUnusedPlatformConnections()
+    await (daemon as any).connections.closeUnusedPlatformConnections()
     expect(stop).not.toHaveBeenCalled()
-    expect((daemon as any).slackPool.all()).toEqual([conn])
+    expect((daemon as any).connections.slackPool.all()).toEqual([conn])
     expect((daemon as any).connByIntegration.has('int-detached')).toBe(false)
     expect((daemon as any).connByIntegration.get('int-live')).toBe(conn)
     expect((daemon as any).botUserIds['int-detached']).toBeUndefined()
     expect((daemon as any).channelSnapshots.has('int-detached')).toBe(false)
 
     ;(daemon as any).agents = new Map()
-    await (daemon as any).closeUnusedPlatformConnections()
+    await (daemon as any).connections.closeUnusedPlatformConnections()
     expect(stop).toHaveBeenCalledTimes(1)
-    expect((daemon as any).slackPool.all()).toEqual([])
+    expect((daemon as any).connections.slackPool.all()).toEqual([])
     await daemon.stop()
   })
 
@@ -486,9 +486,9 @@ describe('Daemon.reconcileSlackConnections', () => {
     const telegramOld = conn('tg-old')
     const discordLive = conn('dc-live')
     const discordOld = conn('dc-old')
-    for (const c of [sharedLive, sharedOld]) (daemon as any).slackSharedPool.add(c)
-    for (const c of [telegramLive, telegramOld]) (daemon as any).telegramPool.add(c)
-    for (const c of [discordLive, discordOld]) (daemon as any).discordPool.add(c)
+    for (const c of [sharedLive, sharedOld]) (daemon as any).connections.slackSharedPool.add(c)
+    for (const c of [telegramLive, telegramOld]) (daemon as any).connections.telegramPool.add(c)
+    for (const c of [discordLive, discordOld]) (daemon as any).connections.discordPool.add(c)
     ;(daemon as any).agents = new Map([
       [
         'bot-live',
@@ -503,7 +503,7 @@ describe('Daemon.reconcileSlackConnections', () => {
       ]
     ])
 
-    await (daemon as any).closeUnusedPlatformConnections()
+    await (daemon as any).connections.closeUnusedPlatformConnections()
     expect(sharedOld.stop).toHaveBeenCalledTimes(1)
     expect(telegramOld.stop).toHaveBeenCalledTimes(1)
     expect(discordOld.stop).toHaveBeenCalledTimes(1)
@@ -512,7 +512,7 @@ describe('Daemon.reconcileSlackConnections', () => {
     expect(discordLive.stop).not.toHaveBeenCalled()
 
     ;(daemon as any).agents = new Map()
-    await (daemon as any).closeUnusedPlatformConnections()
+    await (daemon as any).connections.closeUnusedPlatformConnections()
     expect(sharedLive.stop).toHaveBeenCalledTimes(1)
     expect(telegramLive.stop).toHaveBeenCalledTimes(1)
     expect(discordLive.stop).toHaveBeenCalledTimes(1)
@@ -526,12 +526,12 @@ describe('Daemon.reconcileSlackConnections', () => {
 
     const connection = fakeConn('xapp-final', 'xoxb-final', 'U_FINAL')
     const stop = vi.spyOn(connection, 'stop')
-    ;(daemon as any).slackPool.add(connection)
+    ;(daemon as any).connections.slackPool.add(connection)
     ;(daemon as any).agents = new Map()
     const release = (daemon as any).holdReplyConnection(connection) as () => void
 
     let settled = false
-    const close = (daemon as any).closeUnusedPlatformConnections().then(() => {
+    const close = (daemon as any).connections.closeUnusedPlatformConnections().then(() => {
       settled = true
     })
     await new Promise((resolve) => setImmediate(resolve))
@@ -541,7 +541,7 @@ describe('Daemon.reconcileSlackConnections', () => {
     release()
     await close
     expect(stop).toHaveBeenCalledTimes(1)
-    expect((daemon as any).slackPool.all()).toEqual([])
+    expect((daemon as any).connections.slackPool.all()).toEqual([])
     await daemon.stop()
   })
 })
@@ -572,7 +572,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
       .spyOn((daemon as any).store, 'observedChannels')
       .mockReturnValue([{ id: '-100123', name: 'Team Chat' }, { id: '-100456' }])
 
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
 
     // Only the Telegram integration is enumerated — Slack has its own membership snapshot.
     expect(observed).toHaveBeenCalledOnce()
@@ -611,7 +611,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
       .spyOn((daemon as any).store, 'observedChannels')
       .mockReturnValue([{ id: '900123', name: 'general' }, { id: '900456' }])
 
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
 
     expect(observed).toHaveBeenCalledWith(
       'bot-dc',
@@ -659,7 +659,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
       .mockReturnValue([{ id: 'oc_group', name: 'Product Chat' }])
     const noteMessage = vi.spyOn((daemon as any).channelNameResolver, 'noteMessage').mockImplementation(() => {})
 
-    ;(daemon as any).backfillChannelNames()
+    ;(daemon as any).connections.backfillChannelNames()
 
     expect(noteMessage).toHaveBeenCalledWith(conn, {
       channel: 'oc_group',
@@ -708,7 +708,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
     })
     store.setDisplayName('oc_old', 'Old chat', 1)
 
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
     expect(emit).not.toHaveBeenCalled()
 
     store.upsertSession({
@@ -726,7 +726,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
     })
     store.setDisplayName('oc_new', 'New chat', 2)
 
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
     expect(emit).toHaveBeenCalledOnce()
     expect(emit).toHaveBeenCalledWith({
       integrationId: 'fs-new',
@@ -785,7 +785,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
     // Model the Lark lookup finishing while cold ACP startup is still blocked: there
     // is a resolved name, but no session row for discovery to publish yet.
     ;(daemon as any).store.setDisplayName('oc_group', 'Product Chat', Date.now())
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
     expect(emit).not.toHaveBeenCalled()
 
     releaseSession()
@@ -822,7 +822,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
       { id: '900001', name: 'general' }
     ])
 
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
 
     const channels = [{ id: '900123', name: 'general' }]
     expect(emit).toHaveBeenCalledWith({ integrationId: 'dc-int', channels, authoritative: false })
@@ -850,7 +850,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
       { id: '900123', name: 'general' }
     ])
 
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
 
     const channels = [
       { id: '900777', name: '@yulong', kind: 'im' },
@@ -886,7 +886,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
         scope === scopeA ? [{ id: '-100', name: 'Team A' }] : [{ id: '-200', name: 'Team B' }]
       )
 
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
 
     expect(observed).toHaveBeenCalledWith('bot-tg2', 'telegram', scopeA)
     expect(observed).toHaveBeenCalledWith('bot-tg2', 'telegram', scopeB)
@@ -927,7 +927,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
     ;(daemon as any).store.setDisplayName('-100999', 'New private group', Date.now())
     vi.spyOn((daemon as any).store, 'observedChannels').mockReturnValue([])
 
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
 
     const channels = [{ id: '-100999', kind: 'channel', name: 'New private group' }]
     expect((daemon as any).channelSnapshots.get('tg-int')).toEqual({ channels, authoritative: false })
@@ -983,7 +983,7 @@ describe('Daemon.leaveConversation', () => {
     ;(daemon as any).connForIntegration = () =>
       Object.assign(Object.create(TelegramConnection.prototype), { leaveChannel })
 
-    const verdict = await (daemon as any).leaveConversation({
+    const verdict = await (daemon as any).connections.leaveConversation({
       integrationId: 'tg-int',
       target: { kind: 'conversation', channel: '-100123' }
     })
@@ -1011,7 +1011,7 @@ describe('Daemon.leaveConversation', () => {
         leaveChannel: vi.fn().mockRejectedValue(new Error('CHAT_ADMIN_REQUIRED'))
       })
 
-    const verdict = await (daemon as any).leaveConversation({
+    const verdict = await (daemon as any).connections.leaveConversation({
       integrationId: 'tg-int',
       target: { kind: 'conversation', channel: '-100123' }
     })
@@ -1037,14 +1037,14 @@ describe('Daemon.leaveConversation', () => {
     ;(daemon as any).connForIntegration = () =>
       Object.assign(Object.create(TelegramConnection.prototype), { leaveChannel: vi.fn().mockResolvedValue(undefined) })
 
-    await (daemon as any).leaveConversation({
+    await (daemon as any).connections.leaveConversation({
       integrationId: 'tg-int',
       target: { kind: 'conversation', channel: '-100123' }
     })
     // The chat is still all over session history — nothing deletes sessions on leave.
     vi.spyOn((daemon as any).store, 'observedChannels').mockReturnValue([{ id: '-100123', name: 'Team Chat' }])
     emit.mockClear()
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
 
     expect((daemon as any).channelSnapshots.get('tg-int').channels).toEqual([])
     expect(emit.mock.calls.flatMap((c: unknown[]) => (c[0] as { channels: unknown[] }).channels)).toEqual([])
@@ -1057,7 +1057,7 @@ describe('Daemon.leaveConversation', () => {
     telegramAgent(daemon)
     ;(daemon as any).connForIntegration = () =>
       Object.assign(Object.create(TelegramConnection.prototype), { leaveChannel: vi.fn().mockResolvedValue(undefined) })
-    await (daemon as any).leaveConversation({
+    await (daemon as any).connections.leaveConversation({
       integrationId: 'tg-int',
       target: { kind: 'conversation', channel: '-100123' }
     })
@@ -1065,7 +1065,7 @@ describe('Daemon.leaveConversation', () => {
 
     // A platform only delivers messages for a conversation the bot is IN, so traffic
     // is proof it was re-invited — otherwise "leave" would be irreversible from here.
-    ;(daemon as any).clearRetractionOnTraffic(
+    ;(daemon as any).observedChannelsSync.clearRetractionOnTraffic(
       { source: 'user', channel: '-100123', sender: { id: 'U1', isBot: false } },
       ['tg-int']
     )
@@ -1090,13 +1090,16 @@ describe('Daemon.leaveConversation', () => {
     })
     ;(daemon as any).connForIntegration = () =>
       Object.assign(Object.create(DiscordConnection.prototype), { leaveSpace: vi.fn().mockResolvedValue(undefined) })
-    await (daemon as any).leaveConversation({ integrationId: 'dc-int', target: { kind: 'space', spaceId: 'G1' } })
+    await (daemon as any).connections.leaveConversation({
+      integrationId: 'dc-int',
+      target: { kind: 'space', spaceId: 'G1' }
+    })
 
     // Session history holds the THREAD, which collapses onto the left channel C1.
     vi.spyOn((daemon as any).store, 'observedChannels').mockReturnValue([{ id: 'T-in-C1' }])
     vi.spyOn((daemon as any).observedChannelsSync, 'collapseObserved').mockReturnValue([{ id: 'C1', spaceId: 'G1' }])
     emit.mockClear()
-    ;(daemon as any).refreshObservedChannels()
+    ;(daemon as any).observedChannelsSync.refreshObservedChannels()
 
     expect((daemon as any).channelSnapshots.get('dc-int').channels).toEqual([])
   })
@@ -1108,7 +1111,7 @@ describe('Daemon.leaveConversation', () => {
     // Retract while the CP link is DOWN: the EVT is fire-and-forget and simply lost.
     ;(daemon as any).cpClient = undefined
     ;(daemon as any).channelSnapshots.set('tg-int', { channels: [{ id: '-100123' }], authoritative: false })
-    ;(daemon as any).retractChannels('tg-int', ['-100123'])
+    ;(daemon as any).observedChannelsSync.retractChannels('tg-int', ['-100123'])
 
     const emit = vi.fn()
     ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
@@ -1128,7 +1131,7 @@ describe('Daemon.leaveConversation', () => {
     ;(first as any).cpClient = undefined // CP unreachable: the retraction EVT is lost
     telegramAgent(first)
     ;(first as any).channelSnapshots.set('tg-int', { channels: [{ id: '-100123' }], authoritative: false })
-    ;(first as any).retractChannels('tg-int', ['-100123'])
+    ;(first as any).observedChannelsSync.retractChannels('tg-int', ['-100123'])
     await first.stop()
 
     // A fresh process over the SAME root: the tombstone survived, the snapshot did not.
@@ -1158,7 +1161,7 @@ describe('Daemon.leaveConversation', () => {
         leaveChannel: vi.fn().mockRejectedValue(new Error('Bad Request: chat not found'))
       })
 
-    const verdict = await (daemon as any).leaveConversation({
+    const verdict = await (daemon as any).connections.leaveConversation({
       integrationId: 'tg-int',
       target: { kind: 'conversation', channel: '-100123' }
     })
@@ -1178,7 +1181,7 @@ describe('Daemon.leaveConversation', () => {
         leaveChannel: vi.fn().mockRejectedValue(new Error('Too Many Requests: retry after 30'))
       })
 
-    const verdict = await (daemon as any).leaveConversation({
+    const verdict = await (daemon as any).connections.leaveConversation({
       integrationId: 'tg-int',
       target: { kind: 'conversation', channel: '-100123' }
     })
@@ -1197,7 +1200,7 @@ describe('Daemon.leaveConversation', () => {
     ;(daemon as any).connForIntegration = () =>
       Object.assign(Object.create(DiscordConnection.prototype), { leaveSpace })
 
-    const verdict = await (daemon as any).leaveConversation({
+    const verdict = await (daemon as any).connections.leaveConversation({
       integrationId: 'dc-int',
       target: { kind: 'conversation', channel: 'C9' }
     })
@@ -1226,7 +1229,7 @@ describe('Daemon.leaveConversation', () => {
     ;(daemon as any).connForIntegration = () =>
       Object.assign(Object.create(DiscordConnection.prototype), { leaveSpace: vi.fn().mockResolvedValue(undefined) })
 
-    const verdict = await (daemon as any).leaveConversation({
+    const verdict = await (daemon as any).connections.leaveConversation({
       integrationId: 'dc-int',
       target: { kind: 'space', spaceId: 'G1' }
     })

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -148,7 +148,10 @@ describe('Telegram conversation discovery', () => {
     const emitIntegrationChannels = vi.fn()
     ;(daemon as any).cpClient = { emitIntegrationChannels, stop: vi.fn().mockResolvedValue(undefined) }
 
-    ;(daemon as any).observeTelegramChat({ id: '-200', name: 'new private group', isPrivate: true }, ['i-tg'])
+    ;(daemon as any).observedChannelsSync.observeTelegramChat(
+      { id: '-200', name: 'new private group', isPrivate: true },
+      ['i-tg']
+    )
 
     const channels = [{ id: '-200', name: 'new private group', isPrivate: true, kind: 'channel' }]
     expect(emitIntegrationChannels).toHaveBeenCalledWith({


### PR DESCRIPTION
## What

Cuts the §7.5 platform-lifecycle delegate block off `Daemon`: 16 same-name private shells that were each a single call into `ConnectionReconciler` / `ObservedChannelsSync`, plus the five pool getters (`slackPool`, `slackSharedPool`, `telegramPool`, `discordPool`, `feishuPool`).

Callers now hold the coordinator directly:

- `ConnectionReconcilerHost` literal: `refreshChannels`, `observeTelegramChat`, `refreshObservedChannels`, `retractChannels` → `this.connections.*` / `this.observedChannelsSync.*`.
- CP-command host literal: `closeUnusedPlatformConnections`, `leaveConversation`, `retractChannels` → same.
- Plain internal call sites (reconcile pass, start-up Slack open, channel-name resolution, inbound traffic, space lookup) rewritten the same way.

**No shell kept** — none was load-bearing.

Two seams handled per plan:

- `test/reconcile-watch.test.ts` spied on `Daemon.refreshChannels` because the reconciler deliberately calls back through `host.refreshChannels`. The host member now calls `this.connections.refreshChannels(conn)` and the spy targets `(daemon as any).connections` — the arrow resolves the method off the instance at call time, so the spy still intercepts every internal re-list. Same assertions, unchanged.
- `retractChannels` / `observeTelegramChat` / `collapseObserved` follow the existing precedent of retargeting at `(daemon as any).observedChannelsSync`.

Two now-stale one-line comments updated (`ConnectionReconcilerHost.refreshChannels` doc, `channel-intro.ts` cross-reference). No coordinator logic touched.

Zero behavior change.

## Verification

- `pnpm typecheck` clean.
- `npx vitest run` over `reconcile-watch`, `durable-inbox`, `daemon-duty-fence`, `daemon-duty-replacement`, `daemon-duty-drain`, `feishu-region-reconcile`, `channel-intro`, `telegram-threading`, `platform-registry-drift`, `cp/cp-agent-reconcile`, `transport-identity`, `route-rules`, `observed-channels` — 242 tests pass (two 5s timeouts seen only under 13-file parallel load; both files pass on their own, and identically on the base commit).
- `prettier --check` + `eslint` clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)