### PR TITLE
fix(web): read Cloud placement capabilities from a serving pool member

### DIFF
--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -43,7 +43,7 @@ import { Spinner } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
 import { DaemonSelect, type DaemonSelectOption } from '@/components/console/DaemonSelect'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
-import { editAgentDaemonChoices } from './edit-agent-daemon-choice'
+import { editAgentCapabilitySource, editAgentDaemonChoices } from './edit-agent-daemon-choice'
 import { VisibilityField, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
 import { AgentCallVisibility } from '@/components/console/AgentCallVisibility'
 import {
@@ -340,10 +340,15 @@ export default function EditAgentModal({
   const memberOf = (group: MemberSetRow | undefined) =>
     group && daemons.find((d) => group.memberDaemonIds.includes(d.daemonId) && moveReady(d))
   const selectedGroupServing = memberOf(selectedGroup) !== undefined
-  // The daemon whose reported CAPABILITIES the form reads (runtimes, models, sandbox). For a group
-  // that is one live member standing in for the set — the same one the server would pick — exactly
-  // as the pool has always been probed. It is never the placement.
-  const daemon = selectedGroup ? memberOf(selectedGroup) : daemons.find((d) => d.daemonId === daemonId)
+  const daemonChoices = editAgentDaemonChoices(
+    daemons,
+    daemonId,
+    initialDaemonId.current,
+    featureFlagEnabled('daemon-pool')
+  )
+  // The daemon whose reported CAPABILITIES the form reads — one live member for a set target, and
+  // never the placement itself.
+  const daemon = editAgentCapabilitySource(daemons, daemonId, memberSets, daemonChoices.poolChoice)
   const sourceDaemon = daemons.find((d) => d.daemonId === initialDaemonId.current)
   const daemonChanged = daemonId !== initialDaemonId.current
   const initialPlacement = daemonChanged && !initialDaemonId.current
@@ -359,12 +364,6 @@ export default function EditAgentModal({
     ? selectedSandboxRequired || (daemon?.caps.features.includes('sandbox') ?? false)
     : sandboxSupported
   const effectiveRunInSandbox = selectedSandboxRequired || (selectedSandboxSupported && runInSandbox)
-  const daemonChoices = editAgentDaemonChoices(
-    daemons,
-    daemonId,
-    initialDaemonId.current,
-    featureFlagEnabled('daemon-pool')
-  )
   const poolServing = daemons.some((candidate) => candidate.pool && moveReady(candidate))
   const daemonOptions: DaemonSelectOption[] = [
     // With the flag off the picker offers Cloud only to an agent already ON it — same rule

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { editAgentDaemonChoices } from './edit-agent-daemon-choice'
+import { editAgentCapabilitySource, editAgentDaemonChoices } from './edit-agent-daemon-choice'
 
 type Row = {
   caps: { features: string[] }
@@ -113,5 +113,31 @@ describe('editAgentDaemonChoices', () => {
     const choices = editAgentDaemonChoices([row('grouped', false, 'online', true, 'set-1'), row('free')], '', '', true)
 
     expect(choices.localChoices.map((d) => d.daemonId).sort()).toEqual(['free', 'grouped'])
+  })
+})
+
+describe('editAgentCapabilitySource', () => {
+  const group = { setId: 'g1', name: 'Group 1', memberDaemonIds: ['grouped-offline', 'grouped'], agentCount: 0 }
+
+  it('resolves the Cloud placement to a serving pool member', () => {
+    // `POOL_PLACEMENT` matches no daemon row. Resolving it to nothing is what fell the runtime and
+    // model pickers back to the static fallback list, hiding whatever the pool actually reports.
+    const daemons = [row('local-1'), row('pool-offline', true, 'offline'), row('pool-serving', true)]
+    const poolChoice = editAgentDaemonChoices(daemons, 'pool', 'pool', true).poolChoice
+
+    expect(editAgentCapabilitySource(daemons, 'pool', [], poolChoice)?.daemonId).toBe('pool-serving')
+  })
+
+  it('resolves a group placement to one live member, never the placement', () => {
+    const daemons = [row('grouped-offline', false, 'offline', true, 'g1'), row('grouped', false, 'online', true, 'g1')]
+
+    expect(editAgentCapabilitySource(daemons, 'set:g1', [group], undefined)?.daemonId).toBe('grouped')
+  })
+
+  it('reads a machine placement from that machine', () => {
+    const daemons = [row('local-1'), row('local-2')]
+
+    expect(editAgentCapabilitySource(daemons, 'local-2', [group], undefined)?.daemonId).toBe('local-2')
+    expect(editAgentCapabilitySource(daemons, 'gone', [group], undefined)).toBeUndefined()
   })
 })

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
@@ -1,4 +1,4 @@
-import { POOL_PLACEMENT, type DaemonRow } from '@/lib/data'
+import { groupSetIdOf, POOL_PLACEMENT, type DaemonRow, type MemberSetRow } from '@/lib/data'
 
 type DaemonChoiceRow = Pick<DaemonRow, 'pool' | 'daemonId' | 'status' | 'memberSetId'> & {
   caps: Pick<DaemonRow['caps'], 'features'>
@@ -52,4 +52,20 @@ export function editAgentDaemonChoices<T extends DaemonChoiceRow>(
     localChoices,
     offerPool: (poolOffered && poolChoice !== undefined) || alreadyOnPool
   }
+}
+
+/** The daemon whose reported CAPABILITIES the Edit form reads (runtimes, models, sandbox). A set
+ *  target — Cloud or a group — resolves to one live member standing in for the set, the same one the
+ *  server would pick; it is never the placement. `POOL_PLACEMENT` matches no row, and resolving it
+ *  to nothing is what fell the runtime picker back to the static list and hid the pool's runtimes. */
+export function editAgentCapabilitySource<T extends DaemonChoiceRow>(
+  daemons: T[],
+  selectedDaemonId: string,
+  groups: readonly MemberSetRow[],
+  poolChoice: T | undefined
+): T | undefined {
+  const group = groups.find((candidate) => candidate.setId === groupSetIdOf(selectedDaemonId))
+  if (group) return daemons.find((daemon) => group.memberDaemonIds.includes(daemon.daemonId) && moveReady(daemon))
+  if (selectedDaemonId === POOL_PLACEMENT) return poolChoice
+  return daemons.find((daemon) => daemon.daemonId === selectedDaemonId)
 }


### PR DESCRIPTION
## Problem

Editing an agent placed on **AgentConnect Cloud** showed only Claude Code / Codex / opencode in the Runtime picker — the deployment's own runtimes (e.g. deepseek) reported by the cloud daemon were missing, Model read `—`, and Run in sandbox read `Unavailable`.

Root cause: `EditAgentModal` resolved its capability source with a plain lookup — `daemons.find((d) => d.daemonId === daemonId)` — but the Cloud placement is the virtual `POOL_PLACEMENT` (`'pool'`), which matches no daemon row. With `daemon === undefined`, `reportedRuntimeIds` was empty and the picker fell back to the static `FALLBACK_RUNTIME_IDS`. (The duplicated "Claude Code" row in the picker was the same symptom: the agent's real runtime id isn't in the fallback list, so it got prepended.) A group placement already resolved to one live member; the pool branch was simply missing. `AddAgentModal` has never had the bug — `add-agent-daemon-choice.ts` resolves the source to `poolDaemons[0]`.

## Change

- `edit-agent-daemon-choice.ts`: new pure `editAgentCapabilitySource(daemons, selectedDaemonId, groups, poolChoice)` — a set target (Cloud or a group) resolves to one serving member standing in for the set; a machine placement reads itself. Never the placement.
- `EditAgentModal.tsx`: `daemon` now comes from that function, reusing the `poolChoice` `editAgentDaemonChoices` already computes.

## Tests

3 new cases in `edit-agent-daemon-choice.test.ts` (Cloud → serving pool member, group → serving member, machine → itself / missing → undefined). Full web suite: 150 files / 1596 tests pass; typecheck, eslint, prettier clean.

Note: this makes the UI read what the pool member reports — it assumes the cloud daemon does advertise deepseek in `runtimeModels`. If it still doesn't appear after this, the next place to look is daemon-side runtime probing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)