### PR TITLE
refactor(daemon): cut the GitHub review delegate shells from Daemon

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -72,10 +72,7 @@ import type {
   StartOrchestrationReq,
   StartOrchestrationResult,
   OrchestrationOwnerReq,
-  SetSessionTitleReq,
-  SubmitGithubReviewReq,
-  ReplyGithubReviewThreadsReq,
-  ReplyGithubReviewThreadsResult
+  SetSessionTitleReq
 } from './mcp/ops.js'
 import { GitCredentialCache } from './cp/git-credential.js'
 import {
@@ -208,9 +205,7 @@ import {
   type ScheduleDefinition
 } from './scheduler/scheduler.js'
 import { DreamScheduler } from './scheduler/dream-scheduler.js'
-import { GithubFinalPoster, GithubReplyCollector, type GithubCommentAttribution } from './github/poster.js'
 import { finalizeGithubTurn, isGithubFinalChunk, onGithubUpdate } from './platforms/github/turn-output.js'
-import { GithubReviewClient, type GithubReviewEffect } from './github/review.js'
 import { GithubReviewOrchestrator, type GithubReviewHost } from './github/review-orchestrator.js'
 import {
   collectGithubQueueCandidates,
@@ -406,15 +401,12 @@ import type {
   RdMsgWebchat,
   RdMsgIm,
   RdMsgPlatformAction,
-  RdMsgHook,
   RdAck,
   RdAgentMsgFwd,
   RdAgentMsgAck,
   RdAgentMsgDeliveryKind,
   RdChatEvent,
-  GithubHookMetadata,
   GitCommitIdentity,
-  HookReviewResult,
   MemoryDreamingPolicy,
   ChildSessionStatus,
   ChildSessionStatusProbe,
@@ -456,7 +448,6 @@ import {
   type GithubQueueCandidate,
   type GithubReplyTarget,
   type GithubRevisionAdmissionPlan,
-  type GithubThreadWorktreeCleanup,
   type HookCompletionOwner,
   type HookDispatchContext,
   type SessionWorktreeCleanupResult
@@ -2117,8 +2108,8 @@ export class Daemon {
       startOrchestration: (req) => this.startOrchestration(req),
       getOrchestration: (req) => Promise.resolve(this.getOrchestrationForOwner(req)),
       cancelOrchestration: (req) => Promise.resolve(this.cancelOrchestrationForOwner(req)),
-      submitGithubReview: (req) => this.submitGithubReview(req),
-      replyGithubReviewThreads: (req) => this.replyGithubReviewThreads(req),
+      submitGithubReview: (req) => this.githubReviews.submitGithubReview(req),
+      replyGithubReviewThreads: (req) => this.githubReviews.replyGithubReviewThreads(req),
       memory: this.memory,
       // Every session may READ shared agent memory; only a non-isolated session
       // may WRITE it, so a private DM/A2A turn can use existing memory but cannot
@@ -5479,7 +5470,8 @@ export class Daemon {
     }
 
     if (msg.source === 'hook') {
-      const task = this.dispatchRelayHook(msg)
+      const task = this.githubReviews
+        .dispatchRelayHook(msg)
         .catch((err): RdAck => {
           this.log.error(`hook admission failed for ${dedupKey}: ${formatErr(err)}`)
           return { msgId: msg.msgId, accepted: false, reason: 'durability' }
@@ -7911,11 +7903,6 @@ export class Daemon {
     if (armed || disarmed) this.log.info(`orchestration: armed ${armed} and disarmed ${disarmed} deadline(s)`)
   }
 
-  /** The GitHub review client owned by {@link GithubReviewOrchestrator}. */
-  private get githubReviewClient(): GithubReviewClient {
-    return this.githubReviews.githubReviewClient
-  }
-
   /** Everything the GitHub hook-dispatch and formal-review seam reaches back for. */
   private githubReviewHost(): GithubReviewHost {
     return {
@@ -7949,82 +7936,11 @@ export class Daemon {
         this.dispatch(agentId, msg, integrationId, webchat, callMeta, opts, githubReply, hookContext),
       activeGithubTurn: (key) => this.activeGithubTurnMeta.get(key),
       activeGithubReplyBatch: (key) => this.activeGithubReplyBatchMeta.get(key),
-      makeGithubReply: (agentId, ref, sessionId) => this.makeGithubReply(agentId, ref, sessionId),
       agentLink: (agentId) => this.agentLink(agentId),
       sessionLink: (acpSessionId, source) => this.sessionLink(acpSessionId, source),
       runtimeNames: () => this.runtimeNames,
       hostForStoredSession: (agentId, acpSessionId) => this.hostForStoredSession(agentId, acpSessionId)
     }
-  }
-
-  private dispatchRelayHook(msg: RdMsgHook): Promise<RdAck> {
-    return this.githubReviews.dispatchRelayHook(msg)
-  }
-
-  private onHookFire(msg: RdMsgHook): Promise<{ accepted: boolean; reason?: string }> {
-    return this.githubReviews.onHookFire(msg)
-  }
-
-  private completeGithubThreadWorktreeCleanup(
-    hook: HookDispatchContext,
-    key: string,
-    cleanup: GithubThreadWorktreeCleanup,
-    owner: HookCompletionOwner
-  ): Promise<void> {
-    return this.githubReviews.completeGithubThreadWorktreeCleanup(hook, key, cleanup, owner)
-  }
-
-  private githubFormalReviewEnabled(entry: QueueEntry): boolean {
-    return this.githubReviews.githubFormalReviewEnabled(entry)
-  }
-
-  private ensureGithubPullRevision(entry: QueueEntry, required: boolean): Promise<GithubHookMetadata | undefined> {
-    return this.githubReviews.ensureGithubPullRevision(entry, required)
-  }
-
-  private githubWorkspaceMatches(agent: Agent, github: GithubHookMetadata): boolean {
-    return this.githubReviews.githubWorkspaceMatches(agent, github)
-  }
-
-  private sessionInitiatorLabel(msg: NormalizedMessage): string {
-    return this.githubReviews.sessionInitiatorLabel(msg)
-  }
-
-  private prepareGithubReviewWorkspace(
-    entry: QueueEntry,
-    key: string,
-    agent: Agent
-  ): Promise<{
-    workspaceIsolation?: 'shared' | 'session'
-    forceWorkspaceIsolation?: true
-    preparedWorkspaceCwd?: string
-  }> {
-    return this.githubReviews.prepareGithubReviewWorkspace(entry, key, agent)
-  }
-
-  private prepareGithubTurn(entry: QueueEntry, sessionId: string): Promise<ActiveGithubTurnMeta | undefined> {
-    return this.githubReviews.prepareGithubTurn(entry, sessionId)
-  }
-
-  private persistGithubReviewEffect(
-    active: ActiveGithubTurnMeta,
-    attemptId: string,
-    effect: GithubReviewEffect,
-    required = false
-  ): HookReviewResult {
-    return this.githubReviews.persistGithubReviewEffect(active, attemptId, effect, required)
-  }
-
-  private reconcileGithubReviewAttempt(active: ActiveGithubTurnMeta): Promise<void> {
-    return this.githubReviews.reconcileGithubReviewAttempt(active)
-  }
-
-  private submitGithubReview(req: SubmitGithubReviewReq): Promise<GithubReviewEffect> {
-    return this.githubReviews.submitGithubReview(req)
-  }
-
-  private replyGithubReviewThreads(req: ReplyGithubReviewThreadsReq): Promise<ReplyGithubReviewThreadsResult> {
-    return this.githubReviews.replyGithubReviewThreads(req)
   }
 
   /** The op-switch behind {@link handleRelayMsg} (dedup handled by the caller). */
@@ -10203,7 +10119,7 @@ export class Daemon {
     const persistedSessionId = this.store.getSession(key)?.acpSessionId
     let remoteMcpServer: import('@agentclientprotocol/sdk').McpServer | undefined
     try {
-      const reviewWorkspace = await this.prepareGithubReviewWorkspace(entry, key, agent)
+      const reviewWorkspace = await this.githubReviews.prepareGithubReviewWorkspace(entry, key, agent)
       if (this.keyServer) {
         const firstTurnModel = agent.allowRuntimeChangesInChat ? webchat?.runtime?.model : undefined
         entry.selectedHost = await this.ensureModelSessionHost(agent, key, firstTurnModel)
@@ -10522,7 +10438,12 @@ export class Daemon {
       ...(callMeta ? { callMeta } : {}),
       ...(pendingWebchat ? { webchat: pendingWebchat } : {}),
       ...(githubReply && entry.posterPublishState !== 'in_flight' && entry.posterPublishState !== 'settled'
-        ? { github: { ...this.makeGithubReply(agentId, githubReply, sessionId), deferredFinalTranscript: false } }
+        ? {
+            github: {
+              ...this.githubReviews.makeGithubReply(agentId, githubReply, sessionId),
+              deferredFinalTranscript: false
+            }
+          }
         : {})
     }
     this.pending.set(pendingTurnKey(agentId, sessionId), p)
@@ -10533,7 +10454,7 @@ export class Daemon {
     // §6.7 active-turn context: expose THIS turn's trusted callMeta by logical sessionKey so
     // a nested messageAgent made during the turn can auto-inherit hop/origin + reply-correlation.
     if (callMeta) this.activeTurnCallMeta.set(key, callMeta)
-    const activeGithub = await this.prepareGithubTurn(entry, sessionId).catch((err) => {
+    const activeGithub = await this.githubReviews.prepareGithubTurn(entry, sessionId).catch((err) => {
       this.log.warn(`github review: turn setup failed (${formatErr(err)})`)
       return undefined
     })
@@ -15690,7 +15611,7 @@ export class Daemon {
         const key = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, row.agentId, msg.transportScope)
         const owner: HookCompletionOwner = { inboxId: row.id }
         this.liveInboxIds.add(row.id)
-        if (cleanup) void this.completeGithubThreadWorktreeCleanup(hookContext, key, cleanup, owner)
+        if (cleanup) void this.githubReviews.completeGithubThreadWorktreeCleanup(hookContext, key, cleanup, owner)
         else this.emitHookCompletion(hookContext, 'success', { reason: 'deleted_event_ignored' }, owner)
         replayedMaintenance += 1
         continue
@@ -16166,18 +16087,6 @@ export class Daemon {
       undefined,
       onSessionReady ? { onSessionReady } : undefined
     )
-  }
-
-  private makeGithubReply(
-    agentId: string,
-    ref: GithubReplyTarget,
-    sessionId: string
-  ): { poster: GithubFinalPoster; collector: GithubReplyCollector } {
-    return this.githubReviews.makeGithubReply(agentId, ref, sessionId)
-  }
-
-  private githubCommentAttribution(agentId: string, sessionId: string): GithubCommentAttribution {
-    return this.githubReviews.githubCommentAttribution(agentId, sessionId)
   }
 
   /**

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -124,12 +124,6 @@ export interface GithubReviewHost {
   /** Turn-finalization in dispatchOne reads these maps too, so they stay on the Daemon. */
   activeGithubTurn(key: string): ActiveGithubTurnMeta | undefined
   activeGithubReplyBatch(key: string): ActiveGithubReplyBatchMeta | undefined
-  /** Routed back through the Daemon delegate so a per-turn override is honored. */
-  makeGithubReply(
-    agentId: string,
-    ref: GithubReplyTarget,
-    sessionId: string
-  ): { poster: GithubFinalPoster; collector: GithubReplyCollector }
   agentLink(agentId: string): string
   sessionLink(acpSessionId: string, source?: string): string
   runtimeNames(): Record<string, string>
@@ -870,9 +864,9 @@ export class GithubReviewOrchestrator {
       }
       item.publishState = 'in_flight'
       this.host.persistHookState(active.entry, undefined, true)
-      const published = await this.host
-        .makeGithubReply(req.agentId, item.reply, active.sessionId)
-        .poster.publish(supplied.get(root)!)
+      const published = await this.makeGithubReply(req.agentId, item.reply, active.sessionId).poster.publish(
+        supplied.get(root)!
+      )
       if (published) item.publishedComment = published
       item.publishState = 'settled'
       this.host.persistHookState(active.entry, undefined, true)

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -139,7 +139,7 @@ describe('Daemon rd/msg hook fires', () => {
     ;(daemon as any).runtimeNames.claude = 'Claude Code'
     await (daemon as any).ensureHostAsync(AGENT_ID)
 
-    expect((daemon as any).githubCommentAttribution(AGENT_ID, 'acp-hook-1')).toMatchObject({
+    expect((daemon as any).githubReviews.githubCommentAttribution(AGENT_ID, 'acp-hook-1')).toMatchObject({
       agentName: 'Review Bot',
       runtime: 'Claude Code',
       model: 'claude-sonnet-4-5',
@@ -182,7 +182,7 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
-    ;(daemon as any).makeGithubReply = vi.fn(() => ({
+    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
       poster: { publish: vi.fn(async () => {}) },
       collector: new GithubReplyCollector()
     }))
@@ -296,7 +296,7 @@ describe('Daemon rd/msg hook fires', () => {
       prompt: vi.fn(async (sid: string) => {
         activeReviewAuthorities = (daemon as any).activeGithubTurnMeta.size
         try {
-          await (daemon as any).submitGithubReview({
+          await (daemon as any).githubReviews.submitGithubReview({
             agentId: AGENT_ID,
             platform: 'hook',
             channel: 'acme/infra',
@@ -341,7 +341,7 @@ describe('Daemon rd/msg hook fires', () => {
       publish: vi.fn(async () => ({ kind: 'review_comment' as const, commentId: '3566000000' }))
     }
     const makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
-    ;(daemon as never as { makeGithubReply: typeof makeGithubReply }).makeGithubReply = makeGithubReply
+    ;(daemon as any).githubReviews.makeGithubReply = makeGithubReply
 
     const dispatchDaemonId = (daemon as any).cfg.daemonId as string
     const ack = await (daemon as any).handleRelayMsg(
@@ -432,7 +432,7 @@ describe('Daemon rd/msg hook fires', () => {
         prompt: vi.fn(async (sid: string, blocks: unknown) => {
           prompts.push(JSON.stringify(blocks))
           if (prompts.length === 1) {
-            await (daemon as any).replyGithubReviewThreads({
+            await (daemon as any).githubReviews.replyGithubReviewThreads({
               agentId: AGENT_ID,
               platform: target?.platform ?? 'hook',
               channel: target?.channel ?? 'acme/infra',
@@ -480,15 +480,17 @@ describe('Daemon rd/msg hook fires', () => {
           setStatus: vi.fn(async () => {})
         })
       }
-      ;(daemon as any).makeGithubReply = vi.fn((_agentId: string, ref: { reviewThreadRootCommentId?: string }) => ({
-        collector: new GithubReplyCollector(),
-        poster: {
-          publish: vi.fn(async (body: string) => {
-            published.push({ root: ref.reviewThreadRootCommentId, body })
-            return { kind: 'review_comment' as const, commentId: String(9000 + published.length) }
-          })
-        }
-      }))
+      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(
+        (_agentId: string, ref: { reviewThreadRootCommentId?: string }) => ({
+          collector: new GithubReplyCollector(),
+          poster: {
+            publish: vi.fn(async (body: string) => {
+              published.push({ root: ref.reviewThreadRootCommentId, body })
+              return { kind: 'review_comment' as const, commentId: String(9000 + published.length) }
+            })
+          }
+        })
+      )
 
       const reviewComment = (deliveryKey: string, commentId: string, rootId: string, body: string): RdMsgHook =>
         fire({
@@ -601,14 +603,14 @@ describe('Daemon rd/msg hook fires', () => {
       }
     }
 
-    const ordinary = await (daemon as any).prepareGithubTurn({ hookContext: hook }, 'acp-issue-comment')
+    const ordinary = await (daemon as any).githubReviews.prepareGithubTurn({ hookContext: hook }, 'acp-issue-comment')
 
     const explicitHook = {
       ...hook,
       deliveryKey: 'explicit-review-comment',
       github: { ...hook.github, explicitReviewRequest: true }
     }
-    const explicit = await (daemon as any).prepareGithubTurn(
+    const explicit = await (daemon as any).githubReviews.prepareGithubTurn(
       { hookContext: explicitHook },
       'acp-explicit-review-comment'
     )
@@ -666,7 +668,11 @@ describe('Daemon rd/msg hook fires', () => {
     }
 
     await expect(
-      (daemon as any).prepareGithubReviewWorkspace(entry, 'hook:acme/infra#461', (daemon as any).agents.get(AGENT_ID))
+      (daemon as any).githubReviews.prepareGithubReviewWorkspace(
+        entry,
+        'hook:acme/infra#461',
+        (daemon as any).agents.get(AGENT_ID)
+      )
     ).resolves.toEqual({
       workspaceIsolation: 'session',
       forceWorkspaceIsolation: true,
@@ -738,7 +744,11 @@ describe('Daemon rd/msg hook fires', () => {
     }
 
     await expect(
-      (daemon as any).prepareGithubReviewWorkspace(entry, 'hook:acme/infra#461', (daemon as any).agents.get(AGENT_ID))
+      (daemon as any).githubReviews.prepareGithubReviewWorkspace(
+        entry,
+        'hook:acme/infra#461',
+        (daemon as any).agents.get(AGENT_ID)
+      )
     ).resolves.toEqual({
       workspaceIsolation: 'session',
       forceWorkspaceIsolation: true,
@@ -805,7 +815,11 @@ describe('Daemon rd/msg hook fires', () => {
     }
 
     await expect(
-      (daemon as any).prepareGithubReviewWorkspace(entry, 'hook:acme/infra#461', (daemon as any).agents.get(AGENT_ID))
+      (daemon as any).githubReviews.prepareGithubReviewWorkspace(
+        entry,
+        'hook:acme/infra#461',
+        (daemon as any).agents.get(AGENT_ID)
+      )
     ).resolves.toEqual({})
     expect(prepare).not.toHaveBeenCalled()
     expect(entry.msg.text).toBe('Answer this pull request question.')
@@ -851,7 +865,7 @@ describe('Daemon rd/msg hook fires', () => {
       }
     }
 
-    const active = await (daemon as any).prepareGithubTurn({ hookContext: hook }, 'acp-old-relay')
+    const active = await (daemon as any).githubReviews.prepareGithubTurn({ hookContext: hook }, 'acp-old-relay')
 
     expect(startHook).toHaveBeenCalledOnce()
     expect(active).toBeUndefined()
@@ -940,7 +954,7 @@ describe('Daemon rd/msg hook fires', () => {
       const publishBarrier = new Promise<void>((resolve) => (releasePublish = resolve))
       const poster = { publish: vi.fn(() => publishBarrier) }
       const makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
-      ;(daemon as never as { makeGithubReply: typeof makeGithubReply }).makeGithubReply = makeGithubReply
+      ;(daemon as any).githubReviews.makeGithubReply = makeGithubReply
 
       const msg = fire({
         sessionKey: `acme/infra#${number}`,
@@ -1091,7 +1105,7 @@ describe('Daemon rd/msg hook fires', () => {
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
       const poster = { publish: vi.fn(async () => {}) }
       const makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
-      ;(daemon as never as { makeGithubReply: typeof makeGithubReply }).makeGithubReply = makeGithubReply
+      ;(daemon as any).githubReviews.makeGithubReply = makeGithubReply
       const hookState = vi.spyOn((daemon as any).store, 'updateInboxHookState')
 
       await (daemon as any).handleRelayMsg(
@@ -1187,7 +1201,7 @@ describe('Daemon rd/msg hook fires', () => {
     }
 
     await expect(
-      (daemon as any).submitGithubReview({
+      (daemon as any).githubReviews.submitGithubReview({
         agentId: AGENT_ID,
         platform: 'hook',
         channel: 'acme/infra',
@@ -1342,13 +1356,13 @@ describe('Daemon rd/msg hook fires', () => {
       })
     }
     ;(restarted as any).cpClient = cp
-    const reconcile = vi.spyOn((restarted as any).githubReviewClient, 'reconcile').mockResolvedValue({
+    const reconcile = vi.spyOn((restarted as any).githubReviews.githubReviewClient, 'reconcile').mockResolvedValue({
       state: 'ambiguous',
       code: 'ambiguous_write',
       message: 'marker is not visible yet'
     })
     const poster = { publish: vi.fn(async () => {}) }
-    ;(restarted as any).makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+    ;(restarted as any).githubReviews.makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
 
     await restarted.start()
     await vi.waitFor(() => expect(hookReports).toHaveLength(1), WAIT)
@@ -1433,7 +1447,7 @@ describe('Daemon rd/msg hook fires', () => {
     ;(restarted as never as { cpClient: unknown }).cpClient = cp
     const poster = { publish: vi.fn(async () => {}) }
     const makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
-    ;(restarted as never as { makeGithubReply: typeof makeGithubReply }).makeGithubReply = makeGithubReply
+    ;(restarted as any).githubReviews.makeGithubReply = makeGithubReply
 
     await restarted.start()
 
@@ -1632,7 +1646,7 @@ describe('Daemon rd/msg hook fires', () => {
     // Stub the github poster so the turn-end publish resolves without a real mint.
     const poster = { publish: vi.fn(async () => {}) }
     const makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
-    ;(daemon as never as { makeGithubReply: typeof makeGithubReply }).makeGithubReply = makeGithubReply
+    ;(daemon as any).githubReviews.makeGithubReply = makeGithubReply
 
     // 1) An `opened` fire creates the session for acme/infra#42.
     await (daemon as any).handleRelayMsg(ghFire('issues', 'opened', 'd-open'), () => {})
@@ -2079,7 +2093,7 @@ describe('Daemon rd/msg hook fires', () => {
     ;(daemon as any).cfg.limits.shutdownDrainMs = 0
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
-    ;(daemon as any).makeGithubReply = vi.fn(() => ({
+    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
       poster: { publish: vi.fn(async () => {}) },
       collector: new GithubReplyCollector()
     }))
@@ -2187,7 +2201,7 @@ describe('Daemon rd/msg hook fires', () => {
     const restarted = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: restartedHost.factory })
     const restartedCp = fakeCpClient()
     ;(restarted as never as { cpClient: unknown }).cpClient = restartedCp
-    ;(restarted as any).makeGithubReply = vi.fn(() => ({
+    ;(restarted as any).githubReviews.makeGithubReply = vi.fn(() => ({
       poster: { publish: vi.fn(async () => {}) },
       collector: new GithubReplyCollector()
     }))
@@ -2251,7 +2265,7 @@ describe('Daemon rd/msg hook fires', () => {
       postContext: vi.fn(async () => {}),
       setStatus: vi.fn(async () => {})
     })
-    ;(daemon as any).makeGithubReply = vi.fn(() => ({
+    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
       poster: { publish: vi.fn(async () => {}) },
       collector: new GithubReplyCollector()
     }))


### PR DESCRIPTION
## What

Cuts the GitHub-review cluster of same-name thin delegate shells left on `Daemon`
by the `GithubReviewOrchestrator` extraction. Callers now hold the coordinator
directly. Zero behavior change.

**17 shells removed, 0 kept:**
`dispatchRelayHook`, `onHookFire`, `completeGithubThreadWorktreeCleanup`,
`githubFormalReviewEnabled`, `ensureGithubPullRevision`, `githubWorkspaceMatches`,
`sessionInitiatorLabel`, `prepareGithubReviewWorkspace`, `prepareGithubTurn`,
`persistGithubReviewEffect`, `reconcileGithubReviewAttempt`, `submitGithubReview`,
`replyGithubReviewThreads`, `makeGithubReply`, `githubCommentAttribution`, plus the
`githubReviewClient` private getter (the orchestrator already exposes the client as a
public readonly field, so the test pin repoints there — no new getter needed).

**6 internal call sites rewired** to `this.githubReviews.*`: the MCP ops deps
(`submitGithubReview`, `replyGithubReviewThreads`), relay hook admission
(`dispatchRelayHook`), durable-inbox replay (`completeGithubThreadWorktreeCleanup`),
and `dispatchOne` (`prepareGithubReviewWorkspace`, `prepareGithubTurn`,
`makeGithubReply`). Nine shells had no internal caller at all — only tests.

## The one permitted coordinator edit

`makeGithubReply` was deliberately routed orchestrator -> `host.makeGithubReply` ->
Daemon delegate so that a per-turn test override took effect. The round-trip is
removed: `GithubReviewHost.makeGithubReply` is deleted and the orchestrator calls its
own `this.makeGithubReply`. Because the method lives on the orchestrator's prototype
and is reached through `this`, the retargeted test overrides
(`(daemon as any).githubReviews.makeGithubReply = …`) still intercept the internal
call — verified by the batched-reply and final-poster tests that assert on those spies.

## Verification

- `pnpm typecheck` clean; `eslint` + `prettier --check` clean on touched files.
- `npx vitest run test/daemon-hook.test.ts test/mcp-ops.test.ts test/mcp-tools.test.ts test/workspace.test.ts test/durable-inbox.test.ts` → 5 files, 287 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)