### PR TITLE
feat(usage): one org aggregate over an explicit window, scoped by metering source

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3282,14 +3282,26 @@ export const UsageReportBatchBody = z.object({
 export type UsageReportBatchBodyT = z.infer<typeof UsageReportBatchBody>
 
 // ── usage dashboard (aggregated from the persisted per-session usage store) ──
-export const UsageRange = z.enum(['d1', 'd7', 'd30', 'd90'])
-export const UsageQueryDto = z.object({
-  range: UsageRange.default('d30'),
-  // Client timezone offset in minutes, as `Date.prototype.getTimezoneOffset()`
-  // reports it (UTC − local; e.g. UTC-8 ⇒ 480). Aligns the spend-over-time
-  // buckets to the viewer's local day/hour instead of UTC. Defaults to 0 (UTC).
-  tz: z.coerce.number().int().min(-900).max(900).default(0)
-})
+/** The window is the CALLER's to choose, as an explicit half-open `[from, to)` in UTC.
+ *  The console's 24h/7d/30d/90d buttons are presets it turns into one of these, and a
+ *  billing period is another — so one route serves both instead of the API owning a
+ *  fixed menu of windows. Both ends are required: an implied "until now" would quietly
+ *  give a closed accounting period a moving edge. */
+export const UsageQueryDto = z
+  .object({
+    from: z.string().datetime({ offset: true }),
+    to: z.string().datetime({ offset: true }),
+    /** One ingress, or both when omitted. Scopes totals, every breakdown, and the series. */
+    source: z.enum(['daemon', 'gateway']).optional(),
+    // Client timezone offset in minutes, as `Date.prototype.getTimezoneOffset()`
+    // reports it (UTC − local; e.g. UTC-8 ⇒ 480). Aligns the spend-over-time
+    // buckets to the viewer's local day/hour instead of UTC. Defaults to 0 (UTC).
+    tz: z.coerce.number().int().min(-900).max(900).default(0)
+  })
+  .refine((q) => Date.parse(q.from) < Date.parse(q.to), {
+    message: '`from` must be strictly before `to`',
+    path: ['from']
+  })
 
 /** An amount in an aggregate RESPONSE. A plain string, not `DecimalAmount`: these are
  *  derived by subtraction, so a downward correction can still make one negative, and a
@@ -3311,8 +3323,14 @@ export const UsageAgentDto = z.object({
 export const UsageModelDto = UsageAgentDto.omit({ agentId: true }).extend({
   model: z.string().nullable()
 })
+/** Per-ingress rollup — which authenticated ingress metered the sessions. */
+export const UsageSourceDto = UsageAgentDto.omit({ agentId: true }).extend({
+  source: z.enum(['daemon', 'gateway'])
+})
 export const UsageDto = z.object({
-  range: UsageRange,
+  /** The window actually aggregated, echoed back as the caller sent it. */
+  from: z.string(),
+  to: z.string(),
   accessSyncDegraded: z.boolean().optional(),
   accessIssues: z.array(SessionAccessIssueDto).optional(),
   // Every amount is an exact decimal string: this aggregate is what billing reads, so
@@ -3325,7 +3343,8 @@ export const UsageDto = z.object({
   }),
   agents: z.array(UsageAgentDto),
   models: z.array(UsageModelDto),
-  // Spend-over-time chart: cost bucketed by hour (d1) or day (longer ranges),
+  sources: z.array(UsageSourceDto),
+  // Spend-over-time chart: cost bucketed by hour (a window of two days or less) or day,
   // empty buckets filled to 0. `start` is a UTC-aligned ISO instant. `byAgent`/
   // `byModel` split each bucket's total for the grouped/stacked chart (model
   // key ''=unreported; only non-zero deltas get a key).

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -39,6 +39,7 @@ import {
 } from '@agentconnect.md/protocol'
 import { HEX_COLOR_RE, AGENT_ICON_GLYPHS } from '../../agents/agent-icon.js'
 import { CP_PLATFORM_IDS } from '../../platforms/ids.js'
+import { MAX_USAGE_WINDOW_DAYS } from '../../persistence/ports.js'
 
 // ── per-resource visibility / sharing (docs/designs/resource-visibility.md) ──
 /** 'org' = visible to every org member (default); 'restricted' = the complete
@@ -3301,6 +3302,12 @@ export const UsageQueryDto = z
   .refine((q) => Date.parse(q.from) < Date.parse(q.to), {
     message: '`from` must be strictly before `to`',
     path: ['from']
+  })
+  // The series is one bucket per day (per hour under two days), so the window's width
+  // bounds an allocation. Refuse an over-wide span instead of building it.
+  .refine((q) => Date.parse(q.to) - Date.parse(q.from) <= MAX_USAGE_WINDOW_DAYS * 24 * 60 * 60 * 1000, {
+    message: `the window may span at most ${MAX_USAGE_WINDOW_DAYS} days`,
+    path: ['to']
   })
 
 /** An amount in an aggregate RESPONSE. A plain string, not `DecimalAmount`: these are

--- a/packages/control-plane/src/http/mcp/tools.test.ts
+++ b/packages/control-plane/src/http/mcp/tools.test.ts
@@ -188,9 +188,22 @@ describe('MCP tool registry — §6.2 invariants', () => {
       path: `/orgs/${ORG_ID}/sessions`,
       query: { agentId: 'a1', platform: 'slack', channel: undefined, limit: 5 }
     })
+    // The tool still speaks day presets; the ROUTE takes an explicit window, so the
+    // tool resolves one — d7 by default, and `source` passes straight through.
     const usage = recordingCtx()
     await findTool('getUsage')!.call(usage.ctx, {})
-    expect(usage.calls[0]).toEqual({ method: 'GET', path: `/orgs/${ORG_ID}/usage`, query: { range: 'd7' } })
+    const call = usage.calls[0] as { method: string; path: string; query: Record<string, string> }
+    expect(call.method).toBe('GET')
+    expect(call.path).toBe(`/orgs/${ORG_ID}/usage`)
+    expect(call.query.source).toBeUndefined()
+    const span = Date.parse(call.query.to!) - Date.parse(call.query.from!)
+    expect(span).toBe(7 * 24 * 60 * 60 * 1000)
+
+    const scoped = recordingCtx()
+    await findTool('getUsage')!.call(scoped.ctx, { range: 'd30', source: 'gateway' })
+    const scopedCall = scoped.calls[0] as { query: Record<string, string> }
+    expect(scopedCall.query.source).toBe('gateway')
+    expect(Date.parse(scopedCall.query.to!) - Date.parse(scopedCall.query.from!)).toBe(30 * 24 * 60 * 60 * 1000)
   })
 
   it('listSessions filters by every canonical platform — the /sessions route accepts the same set', () => {

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -20,6 +20,9 @@ import { z } from 'zod'
 import { ApprovalsReviewer } from '@agentconnect.md/protocol'
 import { CP_PLATFORM_IDS } from '../../platforms/ids.js'
 
+/** The day presets `getUsage` accepts, which it converts to an explicit window. */
+type UsageToolRange = 'd1' | 'd7' | 'd30' | 'd90'
+
 /** What a tool needs to execute: the caller's org and credentialed requests
  *  against the versioned REST surface (`/api/v1`-relative paths). */
 export interface McpToolCtx {
@@ -222,14 +225,31 @@ export const MCP_TOOLS: McpToolDef[] = [
     call: (ctx, a) => ctx.get(org(ctx, `/sessions/${seg(a.sessionId)}`))
   },
   {
+    // The tool keeps asking in days because that is what an agent means by "this week",
+    // and turns it into the route's explicit window. The HTTP surface takes `[from, to)`
+    // so a billing period can be a caller's choice; a preset is this caller's.
     name: 'getUsage',
-    description: 'Token/cost usage aggregates over a time window, totals plus agent and model breakdowns.',
+    description:
+      'Token/cost usage aggregates over a time window, totals plus agent, model, and metering-source breakdowns.',
     schema: z
       .object({
-        range: z.enum(['d1', 'd7', 'd30', 'd90']).optional().describe('Window: 1/7/30/90 days (default d7)')
+        range: z.enum(['d1', 'd7', 'd30', 'd90']).optional().describe('Window: 1/7/30/90 days (default d7)'),
+        source: z
+          .enum(['daemon', 'gateway'])
+          .optional()
+          .describe('Only sessions metered by this ingress (default: both)')
       })
       .strict(),
-    call: (ctx, a) => ctx.get(org(ctx, '/usage'), { range: (a.range as string | undefined) ?? 'd7' })
+    call: (ctx, a) => {
+      const days = { d1: 1, d7: 7, d30: 30, d90: 90 }[(a.range as UsageToolRange | undefined) ?? 'd7']
+      const to = new Date()
+      const from = new Date(to.getTime() - days * 24 * 60 * 60 * 1000)
+      return ctx.get(org(ctx, '/usage'), {
+        from: from.toISOString(),
+        to: to.toISOString(),
+        ...(a.source ? { source: a.source as string } : {})
+      })
+    }
   },
   {
     name: 'listIntegrations',

--- a/packages/control-plane/src/http/routes/usage.ts
+++ b/packages/control-plane/src/http/routes/usage.ts
@@ -1,12 +1,18 @@
 /**
- * `http/routes/usage.ts` — the console's Usage dashboard aggregate.
+ * `http/routes/usage.ts` — the org's usage aggregate, for the console AND for billing.
  *
- * `GET /usage?range=d1|d7|d30|d90` sums the persisted per-session token usage (the
- * `SessionUsage` store fed by the daemon's `usage/report` EVT) over the selected
- * time window, grouped by agent and effective model, plus workspace totals. Unlike `/sessions` (a
- * live fan-out to daemons), this reads the CP's own historical store — so it
- * survives TTL-closed sessions and daemon restarts. Org-scoped to the single-
- * tenant default org (as with `/agents`).
+ * `GET /usage?from=…&to=…` sums the persisted per-session token usage (the
+ * `SessionUsage` store fed by the daemon's `usage/report` EVT and the collector batch)
+ * over an explicit half-open `[from, to)` window, grouped by agent, effective model,
+ * and metering ingress, plus workspace totals. Unlike `/sessions` (a live fan-out to
+ * daemons), this reads the CP's own historical store — so it survives TTL-closed
+ * sessions and daemon restarts.
+ *
+ * ONE route serves two callers. The console asks with a human credential and its
+ * preset-derived window, and stays inside session visibility; a billing caller asks
+ * with a service credential, `source=gateway`, and a closed accounting period. Both
+ * get the same aggregation code, so a figure on the dashboard and a figure on an
+ * invoice cannot come from two different implementations.
  */
 import type { FastifyInstance } from 'fastify'
 import type { ZodTypeProvider } from '../plugins/zod.js'
@@ -15,9 +21,6 @@ import { orgOf, ctxOf } from '../rbac.js'
 import { Tag } from '../plugins/openapi.js'
 import { UsageQueryDto, UsageDto } from '../dto/index.js'
 import { makeSessionAccessResolver } from '../session-access.js'
-
-const RANGE_DAYS = { d1: 1, d7: 7, d30: 30, d90: 90 } as const
-const DAY_MS = 24 * 60 * 60 * 1000
 
 export function usageRoutes(deps: HttpDeps) {
   return async function usageRoutesPlugin(app: FastifyInstance): Promise<void> {
@@ -31,32 +34,41 @@ export function usageRoutes(deps: HttpDeps) {
           tags: [Tag.Usage],
           summary: 'Get token usage',
           description:
-            'Sums persisted per-session token usage over the selected time window, with agent and effective-model breakdowns plus workspace totals.',
+            'Sums persisted per-session token usage over the half-open [from, to) window, with agent, effective-model, and metering-source breakdowns plus workspace totals. Optionally scoped to one metering source.',
           operationId: 'getUsage',
           querystring: UsageQueryDto,
           response: { 200: UsageDto }
         }
       },
       async (req) => {
-        const since = new Date(Date.now() - RANGE_DAYS[req.query.range] * DAY_MS)
+        const window = { from: new Date(req.query.from), to: new Date(req.query.to) }
         // Viewer-scoped: both agent visibility and the request-time Session
         // predicate apply to counts, tokens, costs, and buckets. Roles do not
         // widen either resource boundary.
         const ctx = ctxOf(req)
         const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctx)).map((agent) => agent.id)
         const access = await sessionAccess.forQuery(req, { agentIds: visibleAgentIds })
-        const agg = await deps.repos.sessionUsage.aggregate(orgOf(req), since, ctx, req.query.tz, {
-          role: ctx.role,
-          identitySet: [...access.identitySet],
-          externalAccess: access.externalAccess
-        })
+        const agg = await deps.repos.sessionUsage.aggregate(
+          orgOf(req),
+          window,
+          ctx,
+          req.query.tz,
+          {
+            role: ctx.role,
+            identitySet: [...access.identitySet],
+            externalAccess: access.externalAccess
+          },
+          req.query.source
+        )
         return {
-          range: req.query.range,
+          from: req.query.from,
+          to: req.query.to,
           accessSyncDegraded: access.degraded,
           accessIssues: access.accessIssues,
           totals: agg.totals,
           agents: agg.agents,
           models: agg.models,
+          sources: agg.sources,
           series: agg.series
         }
       }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1775,6 +1775,13 @@ export interface UsageWindow {
   to: Date
 }
 
+/** How wide a usage window may be. The series allocates one bucket per day (or per hour
+ *  under two days), so an unbounded span is an unbounded allocation driven by a query
+ *  string — year 0 to year 9999 is ~3.65M buckets. 400 days covers a calendar year with
+ *  slack, which is what a billing period or a dashboard actually asks for; anything
+ *  larger is a paging concern, not a single response. */
+export const MAX_USAGE_WINDOW_DAYS = 400
+
 /** Org-wide usage aggregate for a window: workspace totals + agent/model/source
  *  breakdowns.
  *  Every amount is an exact decimal string — the aggregate is what billing reads,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1762,17 +1762,32 @@ export interface SpendBucket {
   byModel: Record<string, DecimalAmount>
 }
 
-/** Org-wide usage aggregate for a range: workspace totals + agent/model breakdowns.
+/** Per-ingress rollup over a window — the same shape as the agent rollup, keyed by
+ *  which authenticated ingress metered the sessions instead of by agent. */
+export interface SourceUsageAggregate extends Omit<AgentUsageAggregate, 'agentId'> {
+  source: UsageSource
+}
+
+/** A half-open window, `[from, to)`, in UTC. Both ends are the CALLER's choice: the
+ *  console turns its presets into one, and a billing period is another. */
+export interface UsageWindow {
+  from: Date
+  to: Date
+}
+
+/** Org-wide usage aggregate for a window: workspace totals + agent/model/source
+ *  breakdowns.
  *  Every amount is an exact decimal string — the aggregate is what billing reads,
  *  so no step of the roll-up may go through a float.
- *  `costCurrency` is the single distinct currency across the range, or null when
+ *  `costCurrency` is the single distinct currency across the window, or null when
  *  none/mixed (amounts are summed as-is).
- *  `series` is the spend-over-time chart data: cost bucketed by hour (d1) or day
- *  (longer ranges), with empty buckets filled to 0 across the whole window. */
+ *  `series` is the spend-over-time chart data: cost bucketed by hour (a window of two
+ *  days or less) or day, with empty buckets filled to 0 across the whole window. */
 export interface UsageAggregate {
   totals: { sessions: number; totalTokens: number; costAmount: DecimalAmount; costCurrency: string | null }
   agents: AgentUsageAggregate[]
   models: ModelUsageAggregate[]
+  sources: SourceUsageAggregate[]
   series: { bucket: 'hour' | 'day'; points: SpendBucket[] }
 }
 
@@ -1783,7 +1798,9 @@ export interface SessionUsageRepo {
   record(input: SessionUsageInput): Promise<void>
   /** Read one session's latest cumulative usage snapshot. */
   get(agentId: AgentId, sessionId: string): Promise<SessionUsageCounts | null>
-  /** Aggregate usage for an org over sessions active at/after `since` (range window).
+  /** Aggregate usage for an org over the half-open window `[from, to)`.
+   *  `source` scopes the whole answer — totals, every breakdown, and the series — to
+   *  one ingress; omitted, it counts both.
    *  When a `viewer` is supplied, sessions of restricted agents they can't see are
    *  excluded from the totals and every breakdown (derived visibility,
    *  via the `agent` relation — undefined alone is unfiltered).
@@ -1791,10 +1808,11 @@ export interface SessionUsageRepo {
    *  `series` buckets to the viewer's local day/hour; 0 (default) ⇒ UTC. */
   aggregate(
     orgId: OrgId,
-    since: Date,
+    window: UsageWindow,
     viewer?: ViewCtx,
     tzOffsetMin?: number,
-    sessionViewer?: SessionFilterQuery['viewer']
+    sessionViewer?: SessionFilterQuery['viewer'],
+    source?: UsageSource
   ): Promise<UsageAggregate>
 }
 

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -25,6 +25,7 @@
 import { withAmbientTx, type PrismaLike } from '../prisma.js'
 import { Prisma } from '../../generated/prisma/client.js'
 import { type DecimalAmount, scaleAmount, unscaleAmount } from '@agentconnect.md/protocol'
+import { MAX_USAGE_WINDOW_DAYS } from '../ports.js'
 import type {
   SessionUsageRepo,
   SessionUsageInput,
@@ -39,7 +40,6 @@ import type {
   ViewCtx,
   SessionFilterQuery
 } from '../ports.js'
-import { visibilityWhere } from '../../authorization/policy.js'
 import { countCheckpointRegression } from '../../observability/usage-ingest.js'
 import type { AgentId, OrgId } from '../../domain/ids.js'
 import { sessionViewerSql } from './session-access-sql.js'
@@ -265,76 +265,80 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
   ): Promise<UsageAggregate> {
     const { from, to } = window
     // Derived visibility: usage rows inherit their agent's visibility, so scope
-    // through the `agent` relation. A restricted agent the caller cannot see
-    // drops out of BOTH the per-agent breakdown and the totals. Organization
-    // roles never widen that resource-level visibility.
-    const agentScope = { orgId, ...visibilityWhere(viewer) }
+    // through the `agent` relation (`agentViewerSql`). A restricted agent the caller
+    // cannot see drops out of BOTH the per-agent breakdown and the totals.
+    // Organization roles never widen that resource-level visibility.
     // One ingress or both. Scoping the WHOLE answer (totals, breakdowns, series) is
     // what lets billing ask for gateway spend alone through the console's own route
     // instead of a private one.
     const sourceScope = (alias: string) =>
       source ? Prisma.sql`AND ${Prisma.raw(`${alias}."source"`)} = ${source}::"UsageSource"` : Prisma.empty
-    const sourceWhere = source ? { source } : {}
-    // Tokens + session counts come from the lifetime snapshot (tokens aren't
-    // time-attributed). Cost is deliberately NOT summed here — every range-scoped
-    // cost figure (the total, each agent's spend, and the chart) is derived from
-    // the spend timeline below, so the cards and the chart can never disagree.
     const sessionScope = sessionViewerSql(sessionViewer)
-    const grouped = sessionScope
-      ? await this.db.$queryRaw<
-          Array<{
-            agentId: string
-            sessions: bigint
-            totalTokens: bigint
-            inputTokens: bigint
-            outputTokens: bigint
-            thoughtTokens: bigint
-            cachedReadTokens: bigint
-            cachedWriteTokens: bigint
-          }>
-        >(Prisma.sql`
-          SELECT u."agentId",
+    // WHICH SESSIONS the window contains — one definition, used by every snapshot
+    // rollup, so a response cannot contradict itself.
+    //
+    // A checkpoint inside the window is the primary test, NOT where the session's
+    // latest report happens to sit: a session that spent inside a closed window and
+    // reported again afterwards belongs to that window, and its in-window delta reaches
+    // the total regardless — so excluding it from the rollups produced a non-zero total
+    // over empty breakdowns.
+    //
+    // The snapshot's own instant is kept as a second test for a row with no checkpoint
+    // at all. `record` writes both in one transaction, so that pair is only reachable
+    // for a row written outside it (a fixture, an import); counting it keeps such a row
+    // visible in the token rollups instead of silently vanishing. The union stays
+    // coherent because cost is only ever attributed from in-window CHECKPOINTS: every
+    // session that contributes cost is in this set, and one that does not contributes 0.
+    const inWindow = Prisma.sql`(
+          EXISTS (
+            SELECT 1 FROM "session_spend" w
+            WHERE w."agentId" = u."agentId" AND w."sessionId" = u."sessionId"
+              AND w."at" >= ${from} AND w."at" < ${to}
+              ${sourceScope('w')}
+          )
+          OR (u."lastActivityAt" >= ${from} AND u."lastActivityAt" < ${to})
+        )`
+    // The snapshot rollups differ only in what they group by, so they share their
+    // columns and their eligibility instead of restating both three times.
+    const tokenColumns = Prisma.sql`
                  COUNT(*)::bigint AS sessions,
                  COALESCE(SUM(u."totalTokens"), 0)::bigint AS "totalTokens",
                  COALESCE(SUM(u."inputTokens"), 0)::bigint AS "inputTokens",
                  COALESCE(SUM(u."outputTokens"), 0)::bigint AS "outputTokens",
                  COALESCE(SUM(u."thoughtTokens"), 0)::bigint AS "thoughtTokens",
                  COALESCE(SUM(u."cachedReadTokens"), 0)::bigint AS "cachedReadTokens",
-                 COALESCE(SUM(u."cachedWriteTokens"), 0)::bigint AS "cachedWriteTokens"
+                 COALESCE(SUM(u."cachedWriteTokens"), 0)::bigint AS "cachedWriteTokens"`
+    // `session_meta` is LEFT joined so a usage row with no meta row still counts when no
+    // session predicate applies; with one, the predicate rejects the NULL side, which is
+    // the same answer the scoped path gave when it inner-joined.
+    const snapshotScope = Prisma.sql`
           FROM "session_usage" u
           JOIN "agent" a ON a."id" = u."agentId"
-          JOIN "session_meta" s ON s."id" = u."sessionId" AND s."agentId" = u."agentId"
+          LEFT JOIN "session_meta" s ON s."id" = u."sessionId" AND s."agentId" = u."agentId"
           WHERE ${agentViewerSql(orgId, viewer)}
-            AND u."lastActivityAt" >= ${from}
-            AND u."lastActivityAt" < ${to}
+            AND ${inWindow}
             ${sourceScope('u')}
-            AND ${sessionScope}
+            AND ${sessionScope ?? Prisma.sql`TRUE`}`
+    // Tokens + session counts come from the lifetime snapshot (tokens aren't
+    // time-attributed). Cost is deliberately NOT summed here — every range-scoped
+    // cost figure (the total, each agent's spend, and the chart) is derived from
+    // the spend timeline below, so the cards and the chart can never disagree.
+    const grouped = await this.db.$queryRaw<
+      Array<{
+        agentId: string
+        sessions: bigint
+        totalTokens: bigint
+        inputTokens: bigint
+        outputTokens: bigint
+        thoughtTokens: bigint
+        cachedReadTokens: bigint
+        cachedWriteTokens: bigint
+      }>
+    >(Prisma.sql`
+          SELECT u."agentId", ${tokenColumns}
+          ${snapshotScope}
           GROUP BY u."agentId"
         `)
-      : (
-          await this.db.sessionUsage.groupBy({
-            by: ['agentId'],
-            where: { agent: agentScope, lastActivityAt: { gte: from, lt: to }, ...sourceWhere },
-            _sum: {
-              totalTokens: true,
-              inputTokens: true,
-              outputTokens: true,
-              thoughtTokens: true,
-              cachedReadTokens: true,
-              cachedWriteTokens: true
-            },
-            _count: { _all: true }
-          })
-        ).map((row) => ({
-          agentId: row.agentId,
-          sessions: BigInt(row._count._all),
-          totalTokens: BigInt(row._sum.totalTokens ?? 0),
-          inputTokens: BigInt(row._sum.inputTokens ?? 0),
-          outputTokens: BigInt(row._sum.outputTokens ?? 0),
-          thoughtTokens: BigInt(row._sum.thoughtTokens ?? 0),
-          cachedReadTokens: BigInt(row._sum.cachedReadTokens ?? 0),
-          cachedWriteTokens: BigInt(row._sum.cachedWriteTokens ?? 0)
-        }))
 
     // Attribute lifetime token deltas to the model observed on each report. The
     // outer session_usage filter preserves the dashboard's established semantics:
@@ -371,8 +375,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
         JOIN "agent" a ON a."id" = sp."agentId"
         LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
         WHERE ${agentViewerSql(orgId, viewer)}
-          AND u."lastActivityAt" >= ${from}
-          AND u."lastActivityAt" < ${to}
+          AND ${inWindow}
           ${sourceScope('sp')}
           AND ${sessionScope ?? Prisma.sql`TRUE`}
         WINDOW sample_order AS (PARTITION BY sp."agentId", sp."sessionId" ORDER BY sp."at")
@@ -405,6 +408,13 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     const stepMs = bucket === 'hour' ? HOUR_MS : 24 * HOUR_MS
     // Floor `from` to the start of its local bucket, expressed as a UTC instant.
     const floorSince = Math.floor((from.getTime() - offMs) / stepMs) * stepMs + offMs
+    // The route refuses an over-wide window, so this is a guard for a direct caller
+    // rather than a reachable path: `n` sizes an eager allocation, so it must never be
+    // whatever arithmetic on two caller-supplied instants happens to produce. Throwing
+    // beats clamping — a silently truncated series is a wrong answer that looks right.
+    if (spanMs > MAX_USAGE_WINDOW_DAYS * 24 * HOUR_MS) {
+      throw new Error(`usage window may span at most ${MAX_USAGE_WINDOW_DAYS} days`)
+    }
     const n = Math.max(1, Math.ceil((to.getTime() - floorSince) / stepMs))
     // Buckets accumulate as scaled integers and are serialized once, at the end.
     const points: ScaledBucket[] = Array.from({ length: n }, (_, i) => ({
@@ -499,61 +509,22 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
 
     // Per-ingress tokens/sessions, from the same snapshot rows the agent rollup uses,
     // so `sources` and `agents` add up to the same totals.
-    const sourceGrouped = sessionScope
-      ? await this.db.$queryRaw<
-          Array<{
-            source: UsageSource
-            sessions: bigint
-            totalTokens: bigint
-            inputTokens: bigint
-            outputTokens: bigint
-            thoughtTokens: bigint
-            cachedReadTokens: bigint
-            cachedWriteTokens: bigint
-          }>
-        >(Prisma.sql`
-          SELECT u."source",
-                 COUNT(*)::bigint AS sessions,
-                 COALESCE(SUM(u."totalTokens"), 0)::bigint AS "totalTokens",
-                 COALESCE(SUM(u."inputTokens"), 0)::bigint AS "inputTokens",
-                 COALESCE(SUM(u."outputTokens"), 0)::bigint AS "outputTokens",
-                 COALESCE(SUM(u."thoughtTokens"), 0)::bigint AS "thoughtTokens",
-                 COALESCE(SUM(u."cachedReadTokens"), 0)::bigint AS "cachedReadTokens",
-                 COALESCE(SUM(u."cachedWriteTokens"), 0)::bigint AS "cachedWriteTokens"
-          FROM "session_usage" u
-          JOIN "agent" a ON a."id" = u."agentId"
-          JOIN "session_meta" s ON s."id" = u."sessionId" AND s."agentId" = u."agentId"
-          WHERE ${agentViewerSql(orgId, viewer)}
-            AND u."lastActivityAt" >= ${from}
-            AND u."lastActivityAt" < ${to}
-            ${sourceScope('u')}
-            AND ${sessionScope}
+    const sourceGrouped = await this.db.$queryRaw<
+      Array<{
+        source: UsageSource
+        sessions: bigint
+        totalTokens: bigint
+        inputTokens: bigint
+        outputTokens: bigint
+        thoughtTokens: bigint
+        cachedReadTokens: bigint
+        cachedWriteTokens: bigint
+      }>
+    >(Prisma.sql`
+          SELECT u."source", ${tokenColumns}
+          ${snapshotScope}
           GROUP BY u."source"
         `)
-      : (
-          await this.db.sessionUsage.groupBy({
-            by: ['source'],
-            where: { agent: agentScope, lastActivityAt: { gte: from, lt: to }, ...sourceWhere },
-            _sum: {
-              totalTokens: true,
-              inputTokens: true,
-              outputTokens: true,
-              thoughtTokens: true,
-              cachedReadTokens: true,
-              cachedWriteTokens: true
-            },
-            _count: { _all: true }
-          })
-        ).map((row) => ({
-          source: row.source,
-          sessions: BigInt(row._count._all),
-          totalTokens: BigInt(row._sum.totalTokens ?? 0),
-          inputTokens: BigInt(row._sum.inputTokens ?? 0),
-          outputTokens: BigInt(row._sum.outputTokens ?? 0),
-          thoughtTokens: BigInt(row._sum.thoughtTokens ?? 0),
-          cachedReadTokens: BigInt(row._sum.cachedReadTokens ?? 0),
-          cachedWriteTokens: BigInt(row._sum.cachedWriteTokens ?? 0)
-        }))
 
     const agents: AgentUsageAggregate[] = grouped.map((g) => ({
       agentId: g.agentId,
@@ -606,29 +577,11 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // Cost currency for the range: the single distinct currency reported. `null`
     // when none or mixed — amounts are summed as-is, so a mixed-currency workspace
     // surfaces an unlabeled total (a known limitation until per-currency rollups).
-    const currencies = sessionScope
-      ? await this.db.$queryRaw<Array<{ costCurrency: string }>>(Prisma.sql`
+    const currencies = await this.db.$queryRaw<Array<{ costCurrency: string }>>(Prisma.sql`
           SELECT DISTINCT u."costCurrency"
-          FROM "session_usage" u
-          JOIN "agent" a ON a."id" = u."agentId"
-          JOIN "session_meta" s ON s."id" = u."sessionId" AND s."agentId" = u."agentId"
-          WHERE ${agentViewerSql(orgId, viewer)}
-            AND u."lastActivityAt" >= ${from}
-            AND u."lastActivityAt" < ${to}
-            ${sourceScope('u')}
+          ${snapshotScope}
             AND u."costCurrency" IS NOT NULL
-            AND ${sessionScope}
         `)
-      : await this.db.sessionUsage.findMany({
-          where: {
-            agent: agentScope,
-            lastActivityAt: { gte: from, lt: to },
-            costCurrency: { not: null },
-            ...sourceWhere
-          },
-          distinct: ['costCurrency'],
-          select: { costCurrency: true }
-        })
     const costCurrency = currencies.length === 1 ? currencies[0]!.costCurrency : null
 
     const series: SpendBucket[] = points.map((pt) => ({

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -52,6 +52,111 @@ interface ScaledBucket {
   byModel: Map<string, bigint>
 }
 
+/** One `session_spend` row as the walk reads it. */
+interface SpendRow {
+  agentId: string
+  sessionId: string
+  at: Date
+  source: UsageSource
+  model: string | null
+  cumulativeTotalTokens: number
+  cumulativeInputTokens: number
+  cumulativeOutputTokens: number
+  cumulativeThoughtTokens: number
+  cumulativeCachedReadTokens: number
+  cumulativeCachedWriteTokens: number
+  cumulativeCost: string
+}
+
+/** A session's cumulative counters at one instant. Tokens are numbers (a workspace's
+ *  totals stay far inside 2^53); cost is a scaled integer, because it is money. */
+interface Counters {
+  totalTokens: number
+  inputTokens: number
+  outputTokens: number
+  thoughtTokens: number
+  cachedReadTokens: number
+  cachedWriteTokens: number
+  cost: bigint
+}
+
+const ZERO_COUNTERS: Counters = {
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  thoughtTokens: 0,
+  cachedReadTokens: 0,
+  cachedWriteTokens: 0,
+  cost: 0n
+}
+
+/** One grouping's accumulated deltas. `sessions` is a set so a session spanning many
+ *  checkpoints counts once, however many reports it made. */
+interface Rollup extends Counters {
+  sessions: Set<string>
+}
+
+function countersOf(row: SpendRow): Counters {
+  return {
+    totalTokens: row.cumulativeTotalTokens,
+    inputTokens: row.cumulativeInputTokens,
+    outputTokens: row.cumulativeOutputTokens,
+    thoughtTokens: row.cumulativeThoughtTokens,
+    cachedReadTokens: row.cumulativeCachedReadTokens,
+    cachedWriteTokens: row.cumulativeCachedWriteTokens,
+    cost: scaleAmount(row.cumulativeCost)
+  }
+}
+
+function subtractCounters(current: Counters, previous: Counters): Counters {
+  return {
+    totalTokens: current.totalTokens - previous.totalTokens,
+    inputTokens: current.inputTokens - previous.inputTokens,
+    outputTokens: current.outputTokens - previous.outputTokens,
+    thoughtTokens: current.thoughtTokens - previous.thoughtTokens,
+    cachedReadTokens: current.cachedReadTokens - previous.cachedReadTokens,
+    cachedWriteTokens: current.cachedWriteTokens - previous.cachedWriteTokens,
+    cost: current.cost - previous.cost
+  }
+}
+
+function emptyRollup(): Rollup {
+  return { ...ZERO_COUNTERS, sessions: new Set() }
+}
+
+function rollupOf<K>(by: Map<K, Rollup>, k: K): Rollup {
+  const existing = by.get(k)
+  if (existing) return existing
+  const fresh = emptyRollup()
+  by.set(k, fresh)
+  return fresh
+}
+
+function addDelta(target: Rollup, delta: Counters, sessionKey: string): void {
+  target.totalTokens += delta.totalTokens
+  target.inputTokens += delta.inputTokens
+  target.outputTokens += delta.outputTokens
+  target.thoughtTokens += delta.thoughtTokens
+  target.cachedReadTokens += delta.cachedReadTokens
+  target.cachedWriteTokens += delta.cachedWriteTokens
+  target.cost += delta.cost
+  target.sessions.add(sessionKey)
+}
+
+/** A rollup as the response carries it. */
+function rollupDto(r: Rollup): Omit<AgentUsageAggregate, 'agentId'> {
+  return {
+    sessions: r.sessions.size,
+    totalTokens: r.totalTokens,
+    inputTokens: r.inputTokens,
+    outputTokens: r.outputTokens,
+    thoughtTokens: r.thoughtTokens,
+    cachedReadTokens: r.cachedReadTokens,
+    cachedWriteTokens: r.cachedWriteTokens,
+    costAmount: unscaleAmount(r.cost)
+  }
+}
+
 /** Serialize a keyed scaled-integer map for the response. */
 function amounts(by: Map<string, bigint>): Record<string, DecimalAmount> {
   return Object.fromEntries([...by].map(([key, value]) => [key, unscaleAmount(value)]))
@@ -264,159 +369,103 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     source?: UsageSource
   ): Promise<UsageAggregate> {
     const { from, to } = window
-    // Derived visibility: usage rows inherit their agent's visibility, so scope
-    // through the `agent` relation (`agentViewerSql`). A restricted agent the caller
-    // cannot see drops out of BOTH the per-agent breakdown and the totals.
-    // Organization roles never widen that resource-level visibility.
-    // One ingress or both. Scoping the WHOLE answer (totals, breakdowns, series) is
-    // what lets billing ask for gateway spend alone through the console's own route
-    // instead of a private one.
+    // Derived visibility: usage rows inherit their agent's visibility, so scope through
+    // the `agent` relation (`agentViewerSql`). A restricted agent the caller cannot see
+    // drops out of BOTH the per-agent breakdown and the totals. Organization roles never
+    // widen that resource-level visibility.
+    //
+    // One ingress or both. Scoping the WHOLE answer (totals, breakdowns, series) is what
+    // lets billing ask for gateway spend alone through the console's own route.
     const sourceScope = (alias: string) =>
       source ? Prisma.sql`AND ${Prisma.raw(`${alias}."source"`)} = ${source}::"UsageSource"` : Prisma.empty
     const sessionScope = sessionViewerSql(sessionViewer)
-    // WHICH SESSIONS the window contains — one definition, used by every snapshot
-    // rollup, so a response cannot contradict itself.
+
+    // EVERY figure in this answer comes from the spend timeline inside `[from, to)`,
+    // diffed against each session's last checkpoint before the window. Tokens too, not
+    // just cost: summing the session's CURRENT snapshot instead made an already-closed
+    // period keep changing — a session reporting again next week raised last month's
+    // token total, and a model first used after the window appeared inside it. A period
+    // is a statement about what happened during it, so it must be answerable from what
+    // was recorded during it and never move again.
     //
-    // A checkpoint inside the window is the primary test, NOT where the session's
-    // latest report happens to sit: a session that spent inside a closed window and
-    // reported again afterwards belongs to that window, and its in-window delta reaches
-    // the total regardless — so excluding it from the rollups produced a non-zero total
-    // over empty breakdowns.
-    //
-    // The snapshot's own instant is kept as a second test for a row with no checkpoint
-    // at all. `record` writes both in one transaction, so that pair is only reachable
-    // for a row written outside it (a fixture, an import); counting it keeps such a row
-    // visible in the token rollups instead of silently vanishing. The union stays
-    // coherent because cost is only ever attributed from in-window CHECKPOINTS: every
-    // session that contributes cost is in this set, and one that does not contributes 0.
-    const inWindow = Prisma.sql`(
-          EXISTS (
+    // It also makes the response agree with itself by construction: totals, agents,
+    // models and sources are four groupings of ONE set of deltas, so they cannot drift
+    // the way three independent SQL rollups did.
+    const spendColumns = Prisma.sql`
+             sp."cumulativeTotalTokens", sp."cumulativeInputTokens", sp."cumulativeOutputTokens",
+             sp."cumulativeThoughtTokens", sp."cumulativeCachedReadTokens", sp."cumulativeCachedWriteTokens",
+             sp."cumulativeCost"::text`
+    const spendScope = Prisma.sql`
+        FROM "session_spend" sp
+        JOIN "agent" a ON a."id" = sp."agentId"
+        LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
+        WHERE ${agentViewerSql(orgId, viewer)}
+          ${sourceScope('sp')}
+          AND ${sessionScope ?? Prisma.sql`TRUE`}`
+
+    const HOUR_MS = 60 * 60 * 1000
+    const spanMs = to.getTime() - from.getTime()
+    // The route refuses an over-wide window, so this is a guard for a direct caller
+    // rather than a reachable path: the bucket count sizes an eager allocation, so it
+    // must never be whatever arithmetic on two caller-supplied instants produces.
+    // Throwing beats clamping — a silently truncated series is a wrong answer that
+    // looks right.
+    if (spanMs > MAX_USAGE_WINDOW_DAYS * 24 * HOUR_MS) {
+      throw new Error(`usage window may span at most ${MAX_USAGE_WINDOW_DAYS} days`)
+    }
+
+    const [inRange, baselineRows, currencies] = await Promise.all([
+      this.db.$queryRaw<SpendRow[]>(Prisma.sql`
+        SELECT sp."agentId", sp."sessionId", sp."at", sp."source", NULLIF(sp."model", '') AS model,
+        ${spendColumns}
+        ${spendScope}
+          AND sp."at" >= ${from}
+          AND sp."at" < ${to}
+        ORDER BY sp."at" ASC
+      `),
+      // The baseline is the session's state entering the window, per source, so the
+      // first in-window delta counts only what the window itself consumed.
+      this.db.$queryRaw<SpendRow[]>(Prisma.sql`
+        SELECT DISTINCT ON (sp."agentId", sp."sessionId", sp."source")
+               sp."agentId", sp."sessionId", sp."at", sp."source", NULLIF(sp."model", '') AS model,
+        ${spendColumns}
+        ${spendScope}
+          AND sp."at" < ${from}
+        ORDER BY sp."agentId", sp."sessionId", sp."source", sp."at" DESC
+      `),
+      // Currency lives on the snapshot, not the timeline. Scope it to the sessions this
+      // window actually contains so a workspace's other currencies cannot label it.
+      this.db.$queryRaw<Array<{ costCurrency: string }>>(Prisma.sql`
+        SELECT DISTINCT u."costCurrency"
+        FROM "session_usage" u
+        JOIN "agent" a ON a."id" = u."agentId"
+        LEFT JOIN "session_meta" s ON s."id" = u."sessionId" AND s."agentId" = u."agentId"
+        WHERE ${agentViewerSql(orgId, viewer)}
+          AND u."costCurrency" IS NOT NULL
+          ${sourceScope('u')}
+          AND ${sessionScope ?? Prisma.sql`TRUE`}
+          AND EXISTS (
             SELECT 1 FROM "session_spend" w
             WHERE w."agentId" = u."agentId" AND w."sessionId" = u."sessionId"
               AND w."at" >= ${from} AND w."at" < ${to}
               ${sourceScope('w')}
           )
-          OR (u."lastActivityAt" >= ${from} AND u."lastActivityAt" < ${to})
-        )`
-    // The snapshot rollups differ only in what they group by, so they share their
-    // columns and their eligibility instead of restating both three times.
-    const tokenColumns = Prisma.sql`
-                 COUNT(*)::bigint AS sessions,
-                 COALESCE(SUM(u."totalTokens"), 0)::bigint AS "totalTokens",
-                 COALESCE(SUM(u."inputTokens"), 0)::bigint AS "inputTokens",
-                 COALESCE(SUM(u."outputTokens"), 0)::bigint AS "outputTokens",
-                 COALESCE(SUM(u."thoughtTokens"), 0)::bigint AS "thoughtTokens",
-                 COALESCE(SUM(u."cachedReadTokens"), 0)::bigint AS "cachedReadTokens",
-                 COALESCE(SUM(u."cachedWriteTokens"), 0)::bigint AS "cachedWriteTokens"`
-    // `session_meta` is LEFT joined so a usage row with no meta row still counts when no
-    // session predicate applies; with one, the predicate rejects the NULL side, which is
-    // the same answer the scoped path gave when it inner-joined.
-    const snapshotScope = Prisma.sql`
-          FROM "session_usage" u
-          JOIN "agent" a ON a."id" = u."agentId"
-          LEFT JOIN "session_meta" s ON s."id" = u."sessionId" AND s."agentId" = u."agentId"
-          WHERE ${agentViewerSql(orgId, viewer)}
-            AND ${inWindow}
-            ${sourceScope('u')}
-            AND ${sessionScope ?? Prisma.sql`TRUE`}`
-    // Tokens + session counts come from the lifetime snapshot (tokens aren't
-    // time-attributed). Cost is deliberately NOT summed here — every range-scoped
-    // cost figure (the total, each agent's spend, and the chart) is derived from
-    // the spend timeline below, so the cards and the chart can never disagree.
-    const grouped = await this.db.$queryRaw<
-      Array<{
-        agentId: string
-        sessions: bigint
-        totalTokens: bigint
-        inputTokens: bigint
-        outputTokens: bigint
-        thoughtTokens: bigint
-        cachedReadTokens: bigint
-        cachedWriteTokens: bigint
-      }>
-    >(Prisma.sql`
-          SELECT u."agentId", ${tokenColumns}
-          ${snapshotScope}
-          GROUP BY u."agentId"
-        `)
+      `)
+    ])
 
-    // Attribute lifetime token deltas to the model observed on each report. The
-    // outer session_usage filter preserves the dashboard's established semantics:
-    // a session active in the range contributes its lifetime token totals. One
-    // session can legitimately count under multiple models after a sticky switch.
-    const modelGrouped = await this.db.$queryRaw<
-      Array<{
-        model: string | null
-        sessions: bigint
-        totalTokens: bigint
-        inputTokens: bigint
-        outputTokens: bigint
-        thoughtTokens: bigint
-        cachedReadTokens: bigint
-        cachedWriteTokens: bigint
-      }>
-    >(Prisma.sql`
-      WITH ordered AS (
-        SELECT sp."agentId", sp."sessionId", NULLIF(sp."model", '') AS model,
-               sp."cumulativeTotalTokens"::bigint
-                 - LAG(sp."cumulativeTotalTokens", 1, 0) OVER sample_order AS "totalTokens",
-               sp."cumulativeInputTokens"::bigint
-                 - LAG(sp."cumulativeInputTokens", 1, 0) OVER sample_order AS "inputTokens",
-               sp."cumulativeOutputTokens"::bigint
-                 - LAG(sp."cumulativeOutputTokens", 1, 0) OVER sample_order AS "outputTokens",
-               sp."cumulativeThoughtTokens"::bigint
-                 - LAG(sp."cumulativeThoughtTokens", 1, 0) OVER sample_order AS "thoughtTokens",
-               sp."cumulativeCachedReadTokens"::bigint
-                 - LAG(sp."cumulativeCachedReadTokens", 1, 0) OVER sample_order AS "cachedReadTokens",
-               sp."cumulativeCachedWriteTokens"::bigint
-                 - LAG(sp."cumulativeCachedWriteTokens", 1, 0) OVER sample_order AS "cachedWriteTokens"
-        FROM "session_spend" sp
-        JOIN "session_usage" u ON u."agentId" = sp."agentId" AND u."sessionId" = sp."sessionId"
-        JOIN "agent" a ON a."id" = sp."agentId"
-        LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
-        WHERE ${agentViewerSql(orgId, viewer)}
-          AND ${inWindow}
-          ${sourceScope('sp')}
-          AND ${sessionScope ?? Prisma.sql`TRUE`}
-        WINDOW sample_order AS (PARTITION BY sp."agentId", sp."sessionId" ORDER BY sp."at")
-      )
-      SELECT model,
-             COUNT(DISTINCT ("agentId", "sessionId"))::bigint AS sessions,
-             COALESCE(SUM("totalTokens"), 0)::bigint AS "totalTokens",
-             COALESCE(SUM("inputTokens"), 0)::bigint AS "inputTokens",
-             COALESCE(SUM("outputTokens"), 0)::bigint AS "outputTokens",
-             COALESCE(SUM("thoughtTokens"), 0)::bigint AS "thoughtTokens",
-             COALESCE(SUM("cachedReadTokens"), 0)::bigint AS "cachedReadTokens",
-             COALESCE(SUM("cachedWriteTokens"), 0)::bigint AS "cachedWriteTokens"
-      FROM ordered
-      GROUP BY model
-    `)
-
-    // Bucket geometry: d1 buckets hourly, longer ranges daily. Buckets align to the
-    // viewer's LOCAL day/hour: we shift into local time (subtract offMs), floor
-    // there, shift back — so `start` is the UTC instant of a local boundary and the
-    // client labels it in local tz. offMs is 0 ⇒ plain UTC.
+    // Bucket geometry: hourly for a window of two days or less, daily beyond. Buckets
+    // align to the viewer's LOCAL day/hour: we shift into local time (subtract offMs),
+    // floor there, shift back — so `start` is the UTC instant of a local boundary and
+    // the client labels it in local tz. offMs is 0 ⇒ plain UTC. Geometry follows the
+    // WINDOW, not the clock: a closed month returns that month's buckets.
     // ponytail: one current offset applied across the whole window — a DST change
-    // mid-range misattributes the ~1h around the switch; acceptable for a spend
-    // chart, pass an IANA tz + date_trunc if hour-exact local days ever matter.
-    const HOUR_MS = 60 * 60 * 1000
+    // mid-range misattributes the ~1h around the switch; acceptable for a spend chart,
+    // pass an IANA tz + date_trunc if hour-exact local days ever matter.
     const offMs = tzOffsetMin * 60 * 1000
-    // Geometry follows the WINDOW, not the clock: a closed month asked for after the
-    // fact must return that month's buckets, not buckets running up to today.
-    const spanMs = to.getTime() - from.getTime()
     const bucket: 'hour' | 'day' = spanMs <= 2 * 24 * HOUR_MS ? 'hour' : 'day'
     const stepMs = bucket === 'hour' ? HOUR_MS : 24 * HOUR_MS
-    // Floor `from` to the start of its local bucket, expressed as a UTC instant.
     const floorSince = Math.floor((from.getTime() - offMs) / stepMs) * stepMs + offMs
-    // The route refuses an over-wide window, so this is a guard for a direct caller
-    // rather than a reachable path: `n` sizes an eager allocation, so it must never be
-    // whatever arithmetic on two caller-supplied instants happens to produce. Throwing
-    // beats clamping — a silently truncated series is a wrong answer that looks right.
-    if (spanMs > MAX_USAGE_WINDOW_DAYS * 24 * HOUR_MS) {
-      throw new Error(`usage window may span at most ${MAX_USAGE_WINDOW_DAYS} days`)
-    }
     const n = Math.max(1, Math.ceil((to.getTime() - floorSince) / stepMs))
-    // Buckets accumulate as scaled integers and are serialized once, at the end.
     const points: ScaledBucket[] = Array.from({ length: n }, (_, i) => ({
       start: new Date(floorSince + i * stepMs).toISOString(),
       costAmount: 0n,
@@ -424,164 +473,55 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       byModel: new Map()
     }))
 
-    // Spend timeline → range spend by DIFFING consecutive cumulatives per session.
-    // A session's window spend is (its latest in-window cumulative) − (its cumulative
-    // just before the window), split across buckets by when each increase landed:
-    // for each in-window report, delta = cumulative − the session's previous
-    // cumulative (the pre-window baseline row for its first in-window report), and
-    // that delta feeds the bucket, the agent, and the total together. Pre-window
-    // spend is thus excluded, replays contribute 0 (cumulative unchanged), and a
-    // downward correction contributes negative spend that nets out — the same
-    // numbers the cards and the chart both show.
-    // ponytail: diff walked in JS over the window's rows plus one pre-window
-    // baseline row per session — fine for a workspace's report volume; move to a
-    // SQL window function (LAG over cumulative) if a range ever returns 100k+ rows.
+    // Per-session running state, seeded from the pre-window checkpoint. `inRange` is
+    // globally at-ascending, so each session's rows are visited chronologically —
+    // exactly what the running diff needs. A replay contributes 0 (nothing changed) and
+    // a downward correction contributes a negative delta that nets out, so the cards and
+    // the chart always show the same numbers.
     const SEP = '\0'
-    const [inRange, baselineRows] = await Promise.all([
-      this.db.$queryRaw<
-        Array<{
-          agentId: string
-          sessionId: string
-          at: Date
-          cumulativeCost: string
-          model: string | null
-          source: UsageSource
-        }>
-      >(Prisma.sql`
-        SELECT sp."agentId", sp."sessionId", sp."at", sp."cumulativeCost"::text,
-               NULLIF(sp."model", '') AS model, sp."source"
-        FROM "session_spend" sp
-        JOIN "agent" a ON a."id" = sp."agentId"
-        LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
-        WHERE ${agentViewerSql(orgId, viewer)}
-          AND sp."at" >= ${from}
-          AND sp."at" < ${to}
-          ${sourceScope('sp')}
-          AND ${sessionScope ?? Prisma.sql`TRUE`}
-        ORDER BY sp."at" ASC
-      `),
-      this.db.$queryRaw<Array<{ agentId: string; sessionId: string; source: UsageSource; cumulativeCost: string }>>(
-        Prisma.sql`
-        SELECT DISTINCT ON (sp."agentId", sp."sessionId", sp."source")
-               sp."agentId", sp."sessionId", sp."source", sp."cumulativeCost"::text
-        FROM "session_spend" sp
-        JOIN "agent" a ON a."id" = sp."agentId"
-        LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
-        WHERE ${agentViewerSql(orgId, viewer)}
-          AND sp."at" < ${from}
-          ${sourceScope('sp')}
-          AND ${sessionScope ?? Prisma.sql`TRUE`}
-        ORDER BY sp."agentId", sp."sessionId", sp."source", sp."at" DESC
-      `
-      )
-    ])
-    // Per-session running cumulative, seeded from the last pre-window report so the
-    // first in-window delta counts only spend incurred inside the window.
-    const prevCost = new Map<string, bigint>(
-      baselineRows.map((r) => [r.agentId + SEP + r.sessionId + SEP + r.source, scaleAmount(r.cumulativeCost)])
-    )
-    const perAgentCost = new Map<string, bigint>()
-    const perModelCost = new Map<string, bigint>()
-    const perSourceCost = new Map<string, bigint>()
-    let totalCost = 0n
-    // `inRange` is globally at-ascending, so each session's rows are visited in
-    // chronological order — exactly what the running diff needs.
+    const key = (row: SpendRow) => row.agentId + SEP + row.sessionId + SEP + row.source
+    const previous = new Map<string, Counters>(baselineRows.map((row) => [key(row), countersOf(row)]))
+    const totals = emptyRollup()
+    const byAgent = new Map<string, Rollup>()
+    const byModel = new Map<string, Rollup>()
+    const bySource = new Map<UsageSource, Rollup>()
+
     for (const row of inRange) {
-      const skey = row.agentId + SEP + row.sessionId + SEP + row.source
-      const cumulative = scaleAmount(row.cumulativeCost)
-      const delta = cumulative - (prevCost.get(skey) ?? 0n)
-      prevCost.set(skey, cumulative)
-      totalCost += delta
-      perAgentCost.set(row.agentId, (perAgentCost.get(row.agentId) ?? 0n) + delta)
+      const skey = key(row)
+      const current = countersOf(row)
+      const delta = subtractCounters(current, previous.get(skey) ?? ZERO_COUNTERS)
+      previous.set(skey, current)
       const modelKey = row.model ?? ''
-      perModelCost.set(modelKey, (perModelCost.get(modelKey) ?? 0n) + delta)
-      perSourceCost.set(row.source, (perSourceCost.get(row.source) ?? 0n) + delta)
+      for (const target of [
+        totals,
+        rollupOf(byAgent, row.agentId),
+        rollupOf(byModel, modelKey),
+        rollupOf(bySource, row.source)
+      ]) {
+        addDelta(target, delta, skey)
+      }
       const idx = Math.floor((row.at.getTime() - floorSince) / stepMs)
       if (idx >= 0 && idx < n) {
         const pt = points[idx]!
-        pt.costAmount += delta
-        if (delta !== 0n) {
-          pt.byAgent.set(row.agentId, (pt.byAgent.get(row.agentId) ?? 0n) + delta)
-          pt.byModel.set(modelKey, (pt.byModel.get(modelKey) ?? 0n) + delta)
+        pt.costAmount += delta.cost
+        if (delta.cost !== 0n) {
+          pt.byAgent.set(row.agentId, (pt.byAgent.get(row.agentId) ?? 0n) + delta.cost)
+          pt.byModel.set(modelKey, (pt.byModel.get(modelKey) ?? 0n) + delta.cost)
         }
       }
     }
 
-    // Per-ingress tokens/sessions, from the same snapshot rows the agent rollup uses,
-    // so `sources` and `agents` add up to the same totals.
-    const sourceGrouped = await this.db.$queryRaw<
-      Array<{
-        source: UsageSource
-        sessions: bigint
-        totalTokens: bigint
-        inputTokens: bigint
-        outputTokens: bigint
-        thoughtTokens: bigint
-        cachedReadTokens: bigint
-        cachedWriteTokens: bigint
-      }>
-    >(Prisma.sql`
-          SELECT u."source", ${tokenColumns}
-          ${snapshotScope}
-          GROUP BY u."source"
-        `)
-
-    const agents: AgentUsageAggregate[] = grouped.map((g) => ({
-      agentId: g.agentId,
-      sessions: Number(g.sessions),
-      totalTokens: Number(g.totalTokens),
-      inputTokens: Number(g.inputTokens),
-      outputTokens: Number(g.outputTokens),
-      thoughtTokens: Number(g.thoughtTokens),
-      cachedReadTokens: Number(g.cachedReadTokens),
-      cachedWriteTokens: Number(g.cachedWriteTokens),
-      costAmount: unscaleAmount(perAgentCost.get(g.agentId) ?? 0n)
-    }))
+    const agents: AgentUsageAggregate[] = [...byAgent].map(([agentId, r]) => ({ agentId, ...rollupDto(r) }))
     // Sort by token spend so the console's "top agents" ordering is stable.
-    agents.sort((a, b) => b.totalTokens - a.totalTokens)
+    agents.sort((left, right) => right.totalTokens - left.totalTokens)
+    const models: ModelUsageAggregate[] = [...byModel].map(([model, r]) => ({ model: model || null, ...rollupDto(r) }))
+    models.sort((left, right) => right.totalTokens - left.totalTokens)
+    const sources: SourceUsageAggregate[] = [...bySource].map(([src, r]) => ({ source: src, ...rollupDto(r) }))
+    sources.sort((left, right) => right.totalTokens - left.totalTokens)
 
-    const models: ModelUsageAggregate[] = modelGrouped.map((g) => ({
-      model: g.model,
-      sessions: Number(g.sessions),
-      totalTokens: Number(g.totalTokens),
-      inputTokens: Number(g.inputTokens),
-      outputTokens: Number(g.outputTokens),
-      thoughtTokens: Number(g.thoughtTokens),
-      cachedReadTokens: Number(g.cachedReadTokens),
-      cachedWriteTokens: Number(g.cachedWriteTokens),
-      costAmount: unscaleAmount(perModelCost.get(g.model ?? '') ?? 0n)
-    }))
-    models.sort((a, b) => b.totalTokens - a.totalTokens)
-
-    const sources: SourceUsageAggregate[] = sourceGrouped.map((g) => ({
-      source: g.source,
-      sessions: Number(g.sessions),
-      totalTokens: Number(g.totalTokens),
-      inputTokens: Number(g.inputTokens),
-      outputTokens: Number(g.outputTokens),
-      thoughtTokens: Number(g.thoughtTokens),
-      cachedReadTokens: Number(g.cachedReadTokens),
-      cachedWriteTokens: Number(g.cachedWriteTokens),
-      costAmount: unscaleAmount(perSourceCost.get(g.source) ?? 0n)
-    }))
-    sources.sort((a, b) => b.totalTokens - a.totalTokens)
-
-    const totals = agents.reduce(
-      (acc, a) => ({
-        sessions: acc.sessions + a.sessions,
-        totalTokens: acc.totalTokens + a.totalTokens
-      }),
-      { sessions: 0, totalTokens: 0 }
-    )
-
-    // Cost currency for the range: the single distinct currency reported. `null`
-    // when none or mixed — amounts are summed as-is, so a mixed-currency workspace
-    // surfaces an unlabeled total (a known limitation until per-currency rollups).
-    const currencies = await this.db.$queryRaw<Array<{ costCurrency: string }>>(Prisma.sql`
-          SELECT DISTINCT u."costCurrency"
-          ${snapshotScope}
-            AND u."costCurrency" IS NOT NULL
-        `)
+    // Cost currency for the window: the single distinct currency reported. `null` when
+    // none or mixed — amounts are summed as-is, so a mixed-currency workspace surfaces
+    // an unlabeled total (a known limitation until per-currency rollups).
     const costCurrency = currencies.length === 1 ? currencies[0]!.costCurrency : null
 
     const series: SpendBucket[] = points.map((pt) => ({
@@ -591,8 +531,14 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       byModel: amounts(pt.byModel)
     }))
 
+    const overall = rollupDto(totals)
     return {
-      totals: { ...totals, costAmount: unscaleAmount(totalCost), costCurrency },
+      totals: {
+        sessions: overall.sessions,
+        totalTokens: overall.totalTokens,
+        costAmount: overall.costAmount,
+        costCurrency
+      },
       agents,
       models,
       sources,

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -33,6 +33,9 @@ import type {
   AgentUsageAggregate,
   ModelUsageAggregate,
   SpendBucket,
+  SourceUsageAggregate,
+  UsageWindow,
+  UsageSource,
   ViewCtx,
   SessionFilterQuery
 } from '../ports.js'
@@ -254,16 +257,24 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
 
   async aggregate(
     orgId: OrgId,
-    since: Date,
+    window: UsageWindow,
     viewer?: ViewCtx,
     tzOffsetMin = 0,
-    sessionViewer?: SessionFilterQuery['viewer']
+    sessionViewer?: SessionFilterQuery['viewer'],
+    source?: UsageSource
   ): Promise<UsageAggregate> {
+    const { from, to } = window
     // Derived visibility: usage rows inherit their agent's visibility, so scope
     // through the `agent` relation. A restricted agent the caller cannot see
     // drops out of BOTH the per-agent breakdown and the totals. Organization
     // roles never widen that resource-level visibility.
     const agentScope = { orgId, ...visibilityWhere(viewer) }
+    // One ingress or both. Scoping the WHOLE answer (totals, breakdowns, series) is
+    // what lets billing ask for gateway spend alone through the console's own route
+    // instead of a private one.
+    const sourceScope = (alias: string) =>
+      source ? Prisma.sql`AND ${Prisma.raw(`${alias}."source"`)} = ${source}::"UsageSource"` : Prisma.empty
+    const sourceWhere = source ? { source } : {}
     // Tokens + session counts come from the lifetime snapshot (tokens aren't
     // time-attributed). Cost is deliberately NOT summed here — every range-scoped
     // cost figure (the total, each agent's spend, and the chart) is derived from
@@ -294,14 +305,16 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
           JOIN "agent" a ON a."id" = u."agentId"
           JOIN "session_meta" s ON s."id" = u."sessionId" AND s."agentId" = u."agentId"
           WHERE ${agentViewerSql(orgId, viewer)}
-            AND u."lastActivityAt" >= ${since}
+            AND u."lastActivityAt" >= ${from}
+            AND u."lastActivityAt" < ${to}
+            ${sourceScope('u')}
             AND ${sessionScope}
           GROUP BY u."agentId"
         `)
       : (
           await this.db.sessionUsage.groupBy({
             by: ['agentId'],
-            where: { agent: agentScope, lastActivityAt: { gte: since } },
+            where: { agent: agentScope, lastActivityAt: { gte: from, lt: to }, ...sourceWhere },
             _sum: {
               totalTokens: true,
               inputTokens: true,
@@ -358,7 +371,9 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
         JOIN "agent" a ON a."id" = sp."agentId"
         LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
         WHERE ${agentViewerSql(orgId, viewer)}
-          AND u."lastActivityAt" >= ${since}
+          AND u."lastActivityAt" >= ${from}
+          AND u."lastActivityAt" < ${to}
+          ${sourceScope('sp')}
           AND ${sessionScope ?? Prisma.sql`TRUE`}
         WINDOW sample_order AS (PARTITION BY sp."agentId", sp."sessionId" ORDER BY sp."at")
       )
@@ -383,12 +398,14 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // chart, pass an IANA tz + date_trunc if hour-exact local days ever matter.
     const HOUR_MS = 60 * 60 * 1000
     const offMs = tzOffsetMin * 60 * 1000
-    const now = Date.now()
-    const bucket: 'hour' | 'day' = now - since.getTime() <= 2 * 24 * HOUR_MS ? 'hour' : 'day'
+    // Geometry follows the WINDOW, not the clock: a closed month asked for after the
+    // fact must return that month's buckets, not buckets running up to today.
+    const spanMs = to.getTime() - from.getTime()
+    const bucket: 'hour' | 'day' = spanMs <= 2 * 24 * HOUR_MS ? 'hour' : 'day'
     const stepMs = bucket === 'hour' ? HOUR_MS : 24 * HOUR_MS
-    // Floor `since` to the start of its local bucket, expressed as a UTC instant.
-    const floorSince = Math.floor((since.getTime() - offMs) / stepMs) * stepMs + offMs
-    const n = Math.floor((now - floorSince) / stepMs) + 1
+    // Floor `from` to the start of its local bucket, expressed as a UTC instant.
+    const floorSince = Math.floor((from.getTime() - offMs) / stepMs) * stepMs + offMs
+    const n = Math.max(1, Math.ceil((to.getTime() - floorSince) / stepMs))
     // Buckets accumulate as scaled integers and are serialized once, at the end.
     const points: ScaledBucket[] = Array.from({ length: n }, (_, i) => ({
       start: new Date(floorSince + i * stepMs).toISOString(),
@@ -412,41 +429,55 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     const SEP = '\0'
     const [inRange, baselineRows] = await Promise.all([
       this.db.$queryRaw<
-        Array<{ agentId: string; sessionId: string; at: Date; cumulativeCost: string; model: string | null }>
+        Array<{
+          agentId: string
+          sessionId: string
+          at: Date
+          cumulativeCost: string
+          model: string | null
+          source: UsageSource
+        }>
       >(Prisma.sql`
-        SELECT sp."agentId", sp."sessionId", sp."at", sp."cumulativeCost"::text, NULLIF(sp."model", '') AS model
+        SELECT sp."agentId", sp."sessionId", sp."at", sp."cumulativeCost"::text,
+               NULLIF(sp."model", '') AS model, sp."source"
         FROM "session_spend" sp
         JOIN "agent" a ON a."id" = sp."agentId"
         LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
         WHERE ${agentViewerSql(orgId, viewer)}
-          AND sp."at" >= ${since}
+          AND sp."at" >= ${from}
+          AND sp."at" < ${to}
+          ${sourceScope('sp')}
           AND ${sessionScope ?? Prisma.sql`TRUE`}
         ORDER BY sp."at" ASC
       `),
-      this.db.$queryRaw<Array<{ agentId: string; sessionId: string; cumulativeCost: string }>>(Prisma.sql`
-        SELECT DISTINCT ON (sp."agentId", sp."sessionId")
-               sp."agentId", sp."sessionId", sp."cumulativeCost"::text
+      this.db.$queryRaw<Array<{ agentId: string; sessionId: string; source: UsageSource; cumulativeCost: string }>>(
+        Prisma.sql`
+        SELECT DISTINCT ON (sp."agentId", sp."sessionId", sp."source")
+               sp."agentId", sp."sessionId", sp."source", sp."cumulativeCost"::text
         FROM "session_spend" sp
         JOIN "agent" a ON a."id" = sp."agentId"
         LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
         WHERE ${agentViewerSql(orgId, viewer)}
-          AND sp."at" < ${since}
+          AND sp."at" < ${from}
+          ${sourceScope('sp')}
           AND ${sessionScope ?? Prisma.sql`TRUE`}
-        ORDER BY sp."agentId", sp."sessionId", sp."at" DESC
-      `)
+        ORDER BY sp."agentId", sp."sessionId", sp."source", sp."at" DESC
+      `
+      )
     ])
     // Per-session running cumulative, seeded from the last pre-window report so the
     // first in-window delta counts only spend incurred inside the window.
     const prevCost = new Map<string, bigint>(
-      baselineRows.map((r) => [r.agentId + SEP + r.sessionId, scaleAmount(r.cumulativeCost)])
+      baselineRows.map((r) => [r.agentId + SEP + r.sessionId + SEP + r.source, scaleAmount(r.cumulativeCost)])
     )
     const perAgentCost = new Map<string, bigint>()
     const perModelCost = new Map<string, bigint>()
+    const perSourceCost = new Map<string, bigint>()
     let totalCost = 0n
     // `inRange` is globally at-ascending, so each session's rows are visited in
     // chronological order — exactly what the running diff needs.
     for (const row of inRange) {
-      const skey = row.agentId + SEP + row.sessionId
+      const skey = row.agentId + SEP + row.sessionId + SEP + row.source
       const cumulative = scaleAmount(row.cumulativeCost)
       const delta = cumulative - (prevCost.get(skey) ?? 0n)
       prevCost.set(skey, cumulative)
@@ -454,6 +485,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       perAgentCost.set(row.agentId, (perAgentCost.get(row.agentId) ?? 0n) + delta)
       const modelKey = row.model ?? ''
       perModelCost.set(modelKey, (perModelCost.get(modelKey) ?? 0n) + delta)
+      perSourceCost.set(row.source, (perSourceCost.get(row.source) ?? 0n) + delta)
       const idx = Math.floor((row.at.getTime() - floorSince) / stepMs)
       if (idx >= 0 && idx < n) {
         const pt = points[idx]!
@@ -464,6 +496,64 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
         }
       }
     }
+
+    // Per-ingress tokens/sessions, from the same snapshot rows the agent rollup uses,
+    // so `sources` and `agents` add up to the same totals.
+    const sourceGrouped = sessionScope
+      ? await this.db.$queryRaw<
+          Array<{
+            source: UsageSource
+            sessions: bigint
+            totalTokens: bigint
+            inputTokens: bigint
+            outputTokens: bigint
+            thoughtTokens: bigint
+            cachedReadTokens: bigint
+            cachedWriteTokens: bigint
+          }>
+        >(Prisma.sql`
+          SELECT u."source",
+                 COUNT(*)::bigint AS sessions,
+                 COALESCE(SUM(u."totalTokens"), 0)::bigint AS "totalTokens",
+                 COALESCE(SUM(u."inputTokens"), 0)::bigint AS "inputTokens",
+                 COALESCE(SUM(u."outputTokens"), 0)::bigint AS "outputTokens",
+                 COALESCE(SUM(u."thoughtTokens"), 0)::bigint AS "thoughtTokens",
+                 COALESCE(SUM(u."cachedReadTokens"), 0)::bigint AS "cachedReadTokens",
+                 COALESCE(SUM(u."cachedWriteTokens"), 0)::bigint AS "cachedWriteTokens"
+          FROM "session_usage" u
+          JOIN "agent" a ON a."id" = u."agentId"
+          JOIN "session_meta" s ON s."id" = u."sessionId" AND s."agentId" = u."agentId"
+          WHERE ${agentViewerSql(orgId, viewer)}
+            AND u."lastActivityAt" >= ${from}
+            AND u."lastActivityAt" < ${to}
+            ${sourceScope('u')}
+            AND ${sessionScope}
+          GROUP BY u."source"
+        `)
+      : (
+          await this.db.sessionUsage.groupBy({
+            by: ['source'],
+            where: { agent: agentScope, lastActivityAt: { gte: from, lt: to }, ...sourceWhere },
+            _sum: {
+              totalTokens: true,
+              inputTokens: true,
+              outputTokens: true,
+              thoughtTokens: true,
+              cachedReadTokens: true,
+              cachedWriteTokens: true
+            },
+            _count: { _all: true }
+          })
+        ).map((row) => ({
+          source: row.source,
+          sessions: BigInt(row._count._all),
+          totalTokens: BigInt(row._sum.totalTokens ?? 0),
+          inputTokens: BigInt(row._sum.inputTokens ?? 0),
+          outputTokens: BigInt(row._sum.outputTokens ?? 0),
+          thoughtTokens: BigInt(row._sum.thoughtTokens ?? 0),
+          cachedReadTokens: BigInt(row._sum.cachedReadTokens ?? 0),
+          cachedWriteTokens: BigInt(row._sum.cachedWriteTokens ?? 0)
+        }))
 
     const agents: AgentUsageAggregate[] = grouped.map((g) => ({
       agentId: g.agentId,
@@ -492,6 +582,19 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     }))
     models.sort((a, b) => b.totalTokens - a.totalTokens)
 
+    const sources: SourceUsageAggregate[] = sourceGrouped.map((g) => ({
+      source: g.source,
+      sessions: Number(g.sessions),
+      totalTokens: Number(g.totalTokens),
+      inputTokens: Number(g.inputTokens),
+      outputTokens: Number(g.outputTokens),
+      thoughtTokens: Number(g.thoughtTokens),
+      cachedReadTokens: Number(g.cachedReadTokens),
+      cachedWriteTokens: Number(g.cachedWriteTokens),
+      costAmount: unscaleAmount(perSourceCost.get(g.source) ?? 0n)
+    }))
+    sources.sort((a, b) => b.totalTokens - a.totalTokens)
+
     const totals = agents.reduce(
       (acc, a) => ({
         sessions: acc.sessions + a.sessions,
@@ -510,12 +613,19 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
           JOIN "agent" a ON a."id" = u."agentId"
           JOIN "session_meta" s ON s."id" = u."sessionId" AND s."agentId" = u."agentId"
           WHERE ${agentViewerSql(orgId, viewer)}
-            AND u."lastActivityAt" >= ${since}
+            AND u."lastActivityAt" >= ${from}
+            AND u."lastActivityAt" < ${to}
+            ${sourceScope('u')}
             AND u."costCurrency" IS NOT NULL
             AND ${sessionScope}
         `)
       : await this.db.sessionUsage.findMany({
-          where: { agent: agentScope, lastActivityAt: { gte: since }, costCurrency: { not: null } },
+          where: {
+            agent: agentScope,
+            lastActivityAt: { gte: from, lt: to },
+            costCurrency: { not: null },
+            ...sourceWhere
+          },
           distinct: ['costCurrency'],
           select: { costCurrency: true }
         })
@@ -532,6 +642,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       totals: { ...totals, costAmount: unscaleAmount(totalCost), costCurrency },
       agents,
       models,
+      sources,
       series: { bucket, points: series }
     }
   }

--- a/packages/control-plane/test/integration/mcp.route.test.ts
+++ b/packages/control-plane/test/integration/mcp.route.test.ts
@@ -653,9 +653,17 @@ describe('POST /api/v1/mcp — tools act with the caller’s own authority', () 
     const { key } = await makeUserWithKey('viewer')
     const out = await callTool(app, key, 'getUsage', { range: 'd1' })
     expect(out.isError).toBeUndefined()
-    const parsed = JSON.parse(toolText(out)) as { range: string; totals: unknown; agents: unknown[] }
-    expect(parsed.range).toBe('d1')
+    // The tool asked in days; the route answered about the window it resolved to.
+    const parsed = JSON.parse(toolText(out)) as {
+      from: string
+      to: string
+      totals: unknown
+      agents: unknown[]
+      sources: unknown[]
+    }
+    expect(Date.parse(parsed.to) - Date.parse(parsed.from)).toBe(24 * 60 * 60 * 1000)
     expect(parsed.agents).toEqual([])
+    expect(parsed.sources).toEqual([])
   })
 
   it('a key of a user removed from the org stops granting MCP access (tenant boundary)', async () => {

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -438,23 +438,26 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
 
   it('d1 keeps only sessions active in the last 24h', async () => {
     await seedAgent(prisma, AGENT_A)
+    const repo = new PgSessionUsageRepo(prisma)
     const now = new Date()
-    await Promise.all([
-      seedVisibleSession(AGENT_A, 'fresh', new Date(now.getTime() - 60_000)),
-      seedVisibleSession(AGENT_A, 'stale', new Date(now.getTime() - 25 * 60 * 60_000))
-    ])
-    await prisma.sessionUsage.createMany({
-      data: [
-        { agentId: AGENT_A, sessionId: 'fresh', totalTokens: 700, lastActivityAt: new Date(now.getTime() - 60_000) },
-        // 25h old — inside d7, outside d1.
-        {
-          agentId: AGENT_A,
-          sessionId: 'stale',
-          totalTokens: 4000,
-          lastActivityAt: new Date(now.getTime() - 25 * 60 * 60_000)
-        }
-      ]
-    })
+    const fresh = new Date(now.getTime() - 60_000)
+    const stale = new Date(now.getTime() - 25 * 60 * 60_000) // inside d7, outside d1
+    await Promise.all([seedVisibleSession(AGENT_A, 'fresh', fresh), seedVisibleSession(AGENT_A, 'stale', stale)])
+    // Reported the way a daemon reports, so both the snapshot and the checkpoint exist:
+    // every figure is derived from the timeline, so a snapshot written on its own has
+    // nothing to contribute to any window.
+    for (const [sessionId, at, totalTokens] of [
+      ['fresh', fresh, 700],
+      ['stale', stale, 4000]
+    ] as const) {
+      await repo.record({
+        agentId: AgentId(AGENT_A),
+        sessionId,
+        source: 'daemon',
+        lastActivityAt: at,
+        usage: { totalTokens }
+      })
+    }
 
     const { app, close } = buildHttpApp(prisma)
     try {
@@ -759,6 +762,8 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
       expect(body.totals.costAmount).toBe('7')
       expect(sum(body.series.points)).toBe('7')
       expect(body.totals.sessions).toBe(1)
+      // Tokens are the window's too: 100 inside it, not the 400 the session has now.
+      expect(body.totals.totalTokens).toBe(100)
       expect(body.agents.map((a) => [a.agentId, a.costAmount])).toEqual([[AGENT_A, '7']])
       expect(body.sources.map((s) => [s.source, s.costAmount])).toEqual([['gateway', '7']])
       expect(sumAmounts(body.sources.map((s) => s.costAmount))).toBe(body.totals.costAmount)
@@ -768,6 +773,49 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     } finally {
       await close()
     }
+  })
+
+  it('answers a closed window the same way after more reports arrive', async () => {
+    await seedAgent(prisma, AGENT_A)
+    const repo = new PgSessionUsageRepo(prisma)
+    const to = new Date(Math.floor((Date.now() - 5 * DAY_MS) / DAY_MS) * DAY_MS)
+    const from = new Date(to.getTime() - 3 * DAY_MS)
+    await seedVisibleSession(AGENT_A, 'closed', new Date())
+    const w = (at: Date, costAmount: string, totalTokens: number, model: string) =>
+      repo.record({
+        agentId: AgentId(AGENT_A),
+        sessionId: 'closed',
+        source: 'gateway',
+        model,
+        lastActivityAt: at,
+        usage: { totalTokens, costAmount, costCurrency: 'USD' }
+      })
+    const read = async () => {
+      const { app, close } = buildHttpApp(prisma)
+      try {
+        const query = new URLSearchParams({ from: from.toISOString(), to: to.toISOString() })
+        const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${query.toString()}` })
+        return res.json() as {
+          totals: { sessions: number; totalTokens: number; costAmount: string }
+          models: { model: string | null; totalTokens: number; costAmount: string }[]
+        }
+      } finally {
+        await close()
+      }
+    }
+
+    await w(new Date(from.getTime() + DAY_MS), '7', 100, 'model-in')
+    const before = await read()
+    // The same session keeps working AFTER the window closes, on another model.
+    await w(new Date(), '20', 400, 'model-after')
+    const after = await read()
+
+    // A period is a statement about what happened during it. It must not move.
+    expect(after).toEqual(before)
+    expect(after.totals.totalTokens).toBe(100)
+    expect(after.totals.costAmount).toBe('7')
+    // And a model first used after the window never appears inside it.
+    expect(after.models.map((m) => m.model)).toEqual(['model-in'])
   })
 
   it('refuses a window too wide to answer in one response', async () => {

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -4,7 +4,7 @@
  * Two halves over the shared Testcontainers Postgres:
  *  - the `usage/report` handler persists a session's cumulative usage (latest-wins
  *    upsert on `(agentId, sessionId)`), a fire-and-forget EVT with no reply;
- *  - `GET /usage?range=…` sums the persisted store by agent over the time window,
+ *  - `GET /usage?from=…&to=…` sums the persisted store by agent over the window,
  *    excluding sessions whose last activity falls outside the range.
  */
 import { describe, it, expect, vi } from 'vitest'
@@ -21,6 +21,15 @@ import { AgentId } from '../../src/domain/ids.js'
  *  itself adds with, so the test cannot drift where the implementation does not. */
 function sum(points: Array<{ costAmount: string }>): string {
   return sumAmounts(points.map((p) => p.costAmount))
+}
+
+/** The window a console preset resolves to, so these tests read like the client that
+ *  sends them: the route itself has no notion of `d1`/`d30`, only `[from, to)`. */
+function preset(range: 'd1' | 'd7' | 'd30' | 'd90', extra: Record<string, string> = {}): string {
+  const days = { d1: 1, d7: 7, d30: 30, d90: 90 }[range]
+  const to = new Date()
+  const from = new Date(to.getTime() - days * 24 * 60 * 60 * 1000)
+  return new URLSearchParams({ from: from.toISOString(), to: to.toISOString(), ...extra }).toString()
 }
 
 // Console routes are org-scoped: /orgs/:orgId/… (devAuth = seeded owner of the default org).
@@ -146,7 +155,7 @@ describe('usage/report handler — persists per-session token usage', () => {
 
     const { app, close } = buildHttpApp(prisma)
     try {
-      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d30` })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d30')}` })
       expect(res.statusCode).toBe(200)
       const body = res.json() as { series: { points: { costAmount: string }[] } }
       const points = body.series.points
@@ -187,7 +196,7 @@ describe('usage/report handler — persists per-session token usage', () => {
 
     const { app, close } = buildHttpApp(prisma)
     try {
-      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d1` })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
       expect(res.statusCode).toBe(200)
       const models = (
         res.json() as {
@@ -370,17 +379,18 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
 
     const { app, close } = buildHttpApp(prisma)
     try {
-      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d30` })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d30')}` })
       expect(res.statusCode).toBe(200)
       const body = res.json() as {
-        range: string
+        from: string
+        to: string
         totals: { sessions: number; totalTokens: number; costAmount: string; costCurrency: string | null }
         agents: { agentId: string; sessions: number; totalTokens: number; costAmount: string }[]
         models: { model: string | null; sessions: number; totalTokens: number; costAmount: string }[]
         series: { bucket: 'hour' | 'day'; points: { start: string; costAmount: string }[] }
       }
 
-      expect(body.range).toBe('d30')
+      expect(Date.parse(body.to) - Date.parse(body.from)).toBe(30 * DAY_MS)
 
       // Spend-over-time series: d30 buckets daily; the three in-range sessions
       // (10/20/30 min ago) all land in the final (today) bucket, and the stale
@@ -393,7 +403,7 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
       // A local-tz offset only shifts bucket boundaries — it must never drop or
       // double-count cost. Across extreme offsets the series still sums to 0.35.
       for (const tz of [-720, 780]) {
-        const r = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d30&tz=${tz}` })
+        const r = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d30', { tz: String(tz) })}` })
         expect(sum((r.json() as typeof body).series.points)).toBe('0.35')
       }
       // Stale a-old row excluded: 3 in-range sessions, 3500 tokens.
@@ -448,10 +458,10 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
 
     const { app, close } = buildHttpApp(prisma)
     try {
-      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d1` })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
       expect(res.statusCode).toBe(200)
-      const body = res.json() as { range: string; totals: { sessions: number; totalTokens: number } }
-      expect(body.range).toBe('d1')
+      const body = res.json() as { from: string; to: string; totals: { sessions: number; totalTokens: number } }
+      expect(Date.parse(body.to) - Date.parse(body.from)).toBe(DAY_MS)
       expect(body.totals.sessions).toBe(1)
       expect(body.totals.totalTokens).toBe(700)
     } finally {
@@ -479,7 +489,7 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
 
     const { app, close } = buildHttpApp(prisma)
     try {
-      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d1` })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
       const body = res.json() as {
         totals: { costAmount: string }
         series: { points: { costAmount: string }[] }
@@ -514,7 +524,7 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
 
     const { app, close } = buildHttpApp(prisma)
     try {
-      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d1` })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
       const body = res.json() as {
         totals: { costAmount: string }
         agents: { agentId: string; costAmount: string }[]
@@ -549,7 +559,7 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
 
     const { app, close } = buildHttpApp(prisma)
     try {
-      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d1` })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
       const body = res.json() as {
         totals: { costAmount: string }
         agents: { agentId: string; costAmount: string }[]
@@ -591,7 +601,7 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
 
     const { app, close } = buildHttpApp(prisma)
     try {
-      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d30` })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d30')}` })
       const body = res.json() as {
         totals: { costAmount: string }
         agents: { agentId: string; costAmount: string }[]
@@ -607,16 +617,153 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     }
   })
 
-  it('defaults the range to d30 and returns empty aggregates when nothing is recorded', async () => {
+  it('bounds the window at BOTH ends, and shapes the series to it rather than to now', async () => {
+    await seedAgent(prisma, AGENT_A)
+    const repo = new PgSessionUsageRepo(prisma)
+    // A closed historical window: three whole UTC days, ending five days ago. Aligned
+    // to midnight so the bucket count is exact — an unaligned window legitimately
+    // touches four days, and this test is about the bound, not the alignment.
+    const to = new Date(Math.floor((Date.now() - 5 * DAY_MS) / DAY_MS) * DAY_MS)
+    const from = new Date(to.getTime() - 3 * DAY_MS)
+    const inside = new Date(from.getTime() + DAY_MS)
+    const after = new Date(to.getTime() + DAY_MS)
+    const spend = async (sessionId: string, at: Date, costAmount: string) => {
+      await seedVisibleSession(AGENT_A, sessionId, at)
+      await repo.record({
+        agentId: AgentId(AGENT_A),
+        sessionId,
+        source: 'gateway',
+        lastActivityAt: at,
+        usage: { totalTokens: 10, costAmount, costCurrency: 'USD' }
+      })
+    }
+    await spend('before', new Date(from.getTime() - DAY_MS), '100')
+    await spend('inside', inside, '7')
+    await spend('after', after, '500')
+
     const { app, close } = buildHttpApp(prisma)
     try {
-      const res = await app.inject({ method: 'GET', url: `${ORG}/usage` })
+      const query = new URLSearchParams({ from: from.toISOString(), to: to.toISOString() })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${query.toString()}` })
       expect(res.statusCode).toBe(200)
-      const body = res.json() as { range: string; totals: { sessions: number }; agents: unknown[]; models: unknown[] }
-      expect(body.range).toBe('d30')
+      const body = res.json() as {
+        totals: { sessions: number; costAmount: string }
+        series: { bucket: string; points: { start: string; costAmount: string }[] }
+      }
+      // Only the middle session counts: the upper bound is what the old open-ended
+      // `since` had no way to express.
+      expect(body.totals.sessions).toBe(1)
+      expect(body.totals.costAmount).toBe('7')
+      expect(sum(body.series.points)).toBe('7')
+      // The series stops at `to`, five days before now — not one bucket per day since.
+      expect(body.series.bucket).toBe('day')
+      const last = new Date(body.series.points.at(-1)!.start)
+      expect(last.getTime()).toBeLessThan(to.getTime())
+      expect(body.series.points.length).toBe(3)
+      expect(body.series.points[0]!.start).toBe(from.toISOString())
+    } finally {
+      await close()
+    }
+  })
+
+  it('scopes totals, breakdowns and series to one metering source', async () => {
+    await seedAgent(prisma, AGENT_A)
+    await seedAgent(prisma, AGENT_B)
+    const repo = new PgSessionUsageRepo(prisma)
+    const at = new Date(Date.now() - 60_000)
+    const spend = async (agentId: string, sessionId: string, source: 'daemon' | 'gateway', costAmount: string) => {
+      await seedVisibleSession(agentId, sessionId, at)
+      await repo.record({
+        agentId: AgentId(agentId),
+        sessionId,
+        source,
+        lastActivityAt: at,
+        usage: { totalTokens: 100, costAmount, costCurrency: 'USD' }
+      })
+    }
+    await spend(AGENT_A, 'gw', 'gateway', '12.75')
+    await spend(AGENT_B, 'dm', 'daemon', '3.25')
+
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const read = async (source?: string) => {
+        const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1', source ? { source } : {})}` })
+        expect(res.statusCode).toBe(200)
+        return res.json() as {
+          totals: { sessions: number; totalTokens: number; costAmount: string }
+          agents: { agentId: string; costAmount: string }[]
+          sources: { source: string; sessions: number; totalTokens: number; costAmount: string }[]
+          series: { points: { costAmount: string }[] }
+        }
+      }
+
+      const both = await read()
+      expect(both.totals.costAmount).toBe('16')
+      expect(both.totals.sessions).toBe(2)
+      // The breakdown splits the same total by ingress, so billing can read one line
+      // and the console can show the two side by side.
+      expect(both.sources.map((s) => [s.source, s.costAmount]).sort()).toEqual([
+        ['daemon', '3.25'],
+        ['gateway', '12.75']
+      ])
+      expect(sumAmounts(both.sources.map((s) => s.costAmount))).toBe(both.totals.costAmount)
+
+      const gateway = await read('gateway')
+      expect(gateway.totals.costAmount).toBe('12.75')
+      expect(gateway.totals.sessions).toBe(1)
+      expect(gateway.totals.totalTokens).toBe(100)
+      expect(gateway.agents.map((a) => a.agentId)).toEqual([AGENT_A])
+      expect(gateway.sources.map((s) => s.source)).toEqual(['gateway'])
+      expect(sum(gateway.series.points)).toBe('12.75')
+
+      const daemon = await read('daemon')
+      expect(daemon.totals.costAmount).toBe('3.25')
+      expect(daemon.agents.map((a) => a.agentId)).toEqual([AGENT_B])
+      expect(sum(daemon.series.points)).toBe('3.25')
+    } finally {
+      await close()
+    }
+  })
+
+  it('returns empty aggregates when nothing is recorded in the window', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d30')}` })
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as {
+        totals: { sessions: number; costAmount: string }
+        agents: unknown[]
+        models: unknown[]
+        sources: unknown[]
+      }
       expect(body.totals.sessions).toBe(0)
+      expect(body.totals.costAmount).toBe('0')
       expect(body.agents).toEqual([])
       expect(body.models).toEqual([])
+      expect(body.sources).toEqual([])
+    } finally {
+      await close()
+    }
+  })
+
+  it('refuses a window it cannot aggregate rather than inventing one', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const now = new Date().toISOString()
+      const earlier = new Date(Date.now() - DAY_MS).toISOString()
+      // No default window: an omitted end would give a closed accounting period a
+      // moving edge, so the caller must say what it is asking for.
+      for (const query of [
+        '',
+        `from=${now}`,
+        `to=${now}`,
+        `from=${now}&to=${earlier}`, // backwards
+        `from=${now}&to=${now}`, // empty, and `[from, to)` makes it meaningless
+        `from=not-a-date&to=${now}`
+      ]) {
+        const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${query}` })
+        expect(res.statusCode, `query: ${query || '(none)'}`).toBe(400)
+      }
     } finally {
       await close()
     }

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -725,6 +725,76 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     }
   })
 
+  it('keeps a session that spent in the window but reported again after it', async () => {
+    await seedAgent(prisma, AGENT_A)
+    const repo = new PgSessionUsageRepo(prisma)
+    const to = new Date(Math.floor((Date.now() - 5 * DAY_MS) / DAY_MS) * DAY_MS)
+    const from = new Date(to.getTime() - 3 * DAY_MS)
+    // The snapshot's `lastActivityAt` sits AFTER the window; its checkpoint sits inside.
+    await seedVisibleSession(AGENT_A, 'cont', new Date())
+    const w = (at: Date, costAmount: string, totalTokens: number) =>
+      repo.record({
+        agentId: AgentId(AGENT_A),
+        sessionId: 'cont',
+        source: 'gateway',
+        lastActivityAt: at,
+        usage: { totalTokens, costAmount, costCurrency: 'USD' }
+      })
+    await w(new Date(from.getTime() + DAY_MS), '7', 100)
+    await w(new Date(), '20', 400)
+
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const query = new URLSearchParams({ from: from.toISOString(), to: to.toISOString() })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${query.toString()}` })
+      const body = res.json() as {
+        totals: { sessions: number; totalTokens: number; costAmount: string; costCurrency: string | null }
+        agents: { agentId: string; costAmount: string }[]
+        models: { costAmount: string }[]
+        sources: { source: string; costAmount: string }[]
+        series: { points: { costAmount: string }[] }
+      }
+      // The regression: the in-window delta reached the total and the series while the
+      // session was missing from every breakdown — a response contradicting itself.
+      expect(body.totals.costAmount).toBe('7')
+      expect(sum(body.series.points)).toBe('7')
+      expect(body.totals.sessions).toBe(1)
+      expect(body.agents.map((a) => [a.agentId, a.costAmount])).toEqual([[AGENT_A, '7']])
+      expect(body.sources.map((s) => [s.source, s.costAmount])).toEqual([['gateway', '7']])
+      expect(sumAmounts(body.sources.map((s) => s.costAmount))).toBe(body.totals.costAmount)
+      expect(sumAmounts(body.agents.map((a) => a.costAmount))).toBe(body.totals.costAmount)
+      // A currency is reported because the session IS in the answer.
+      expect(body.totals.costCurrency).toBe('USD')
+    } finally {
+      await close()
+    }
+  })
+
+  it('refuses a window too wide to answer in one response', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      // The series allocates a bucket per day, so span is an allocation the caller
+      // picks. Year 0 to year 9999 would be ~3.65M buckets.
+      const wide = new URLSearchParams({ from: '0000-01-01T00:00:00.000Z', to: '9999-12-31T00:00:00.000Z' })
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${wide.toString()}` })
+      expect(res.statusCode).toBe(400)
+
+      const to = new Date()
+      const ok = new URLSearchParams({
+        from: new Date(to.getTime() - 400 * DAY_MS).toISOString(),
+        to: to.toISOString()
+      })
+      expect((await app.inject({ method: 'GET', url: `${ORG}/usage?${ok.toString()}` })).statusCode).toBe(200)
+      const over = new URLSearchParams({
+        from: new Date(to.getTime() - 401 * DAY_MS).toISOString(),
+        to: to.toISOString()
+      })
+      expect((await app.inject({ method: 'GET', url: `${ORG}/usage?${over.toString()}` })).statusCode).toBe(400)
+    } finally {
+      await close()
+    }
+  })
+
   it('returns empty aggregates when nothing is recorded in the window', async () => {
     const { app, close } = buildHttpApp(prisma)
     try {

--- a/packages/control-plane/test/integration/visibility.route.test.ts
+++ b/packages/control-plane/test/integration/visibility.route.test.ts
@@ -15,6 +15,13 @@ import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import type { OrgMemberRole } from '../../src/persistence/ports.js'
 
+/** A 30-day window, the shape `GET /usage` takes now that the caller picks it. */
+function usageWindow(): string {
+  const to = new Date()
+  const from = new Date(to.getTime() - 30 * 24 * 60 * 60 * 1000)
+  return new URLSearchParams({ from: from.toISOString(), to: to.toISOString() }).toString()
+}
+
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 const users = () => new PgUserRepo(prisma)
 const opened: HttpApp[] = []
@@ -768,7 +775,7 @@ describe('derived visibility — session bodies, usage', () => {
     })
 
     const usageAgents = async (u: string): Promise<string[]> => {
-      const res = await appAs(u).app.inject({ method: 'GET', url: `${ORG}/usage?range=d30` })
+      const res = await appAs(u).app.inject({ method: 'GET', url: `${ORG}/usage?${usageWindow()}` })
       return (res.json() as { agents: Array<{ agentId: string }> }).agents.map((a) => a.agentId)
     }
     expect(await usageAgents(other)).not.toContain(R)

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -36,7 +36,9 @@ import {
   updateGithubHook,
   updateMemoryRecord,
   uploadMyProfilePicture,
-  uploadOrgIcon
+  uploadOrgIcon,
+  usageWindow,
+  fetchUsage
 } from './api'
 
 describe('session facet Agent labels', () => {
@@ -863,5 +865,49 @@ describe('fetchConversationByKey degradation', () => {
     respond({ conversations: [], total: 0, nextCursor: null, accessSyncDegraded: true, accessIssues: issues })
 
     await expect(fetchConversationByKey('k', 'org-1')).resolves.toMatchObject({ accessIssues: issues })
+  })
+})
+
+describe('usage window', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('turns a console preset into the half-open window the route takes', () => {
+    const now = new Date('2026-08-18T12:00:00.000Z')
+    expect(usageWindow('d1', now)).toEqual({ from: '2026-08-17T12:00:00.000Z', to: '2026-08-18T12:00:00.000Z' })
+    expect(usageWindow('d30', now).from).toBe('2026-07-19T12:00:00.000Z')
+    expect(usageWindow('d90', now).from).toBe('2026-05-20T12:00:00.000Z')
+  })
+
+  it('sends from/to (and only sends source when scoped)', async () => {
+    const urls: string[] = []
+    const stub = () =>
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: string) => {
+          urls.push(url)
+          return new Response(
+            JSON.stringify({
+              from: 'x',
+              to: 'y',
+              totals: { sessions: 0, totalTokens: 0, costAmount: '0', costCurrency: null },
+              agents: [],
+              models: [],
+              sources: [],
+              series: { bucket: 'day', points: [] }
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        })
+      )
+    stub()
+    await fetchUsage('d7', 'org-1')
+    await fetchUsage('d7', 'org-1', 'gateway')
+
+    // The preset never reaches the wire — the window does.
+    expect(urls[0]).not.toContain('range=')
+    expect(urls[0]).toContain('from=')
+    expect(urls[0]).toContain('to=')
+    expect(urls[0]).not.toContain('source=')
+    expect(urls[1]).toContain('source=gateway')
   })
 })

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3314,8 +3314,14 @@ export async function setSessionPullRequestAutoMerge(sessionId: string, enabled:
 }
 
 // ── usage dashboard (GET /usage) — real historical aggregates from the CP's
-// persisted per-session usage store, summed over the selected range. ──
+// persisted per-session usage store, summed over a window this client computes. ──
+/** The console's window presets. The ROUTE takes an explicit `[from, to)`; these are
+ *  purely this client's shorthand, resolved at fetch time. */
 export type UsageRange = 'd1' | 'd7' | 'd30' | 'd90'
+const RANGE_DAYS: Record<UsageRange, number> = { d1: 1, d7: 7, d30: 30, d90: 90 }
+
+/** Which authenticated ingress metered a session. */
+export type UsageSource = 'daemon' | 'gateway'
 
 export interface UsageAgentDto {
   agentId: string
@@ -3335,14 +3341,21 @@ export interface UsageModelDto extends Omit<UsageAgentDto, 'agentId'> {
   model: string | null
 }
 
+export interface UsageSourceDto extends Omit<UsageAgentDto, 'agentId'> {
+  source: UsageSource
+}
+
 export interface UsageDto {
-  range: UsageRange
+  /** The window the CP aggregated, echoed back. */
+  from: string
+  to: string
   accessSyncDegraded?: boolean
   accessIssues?: SessionAccessIssue[]
   totals: { sessions: number; totalTokens: number; costAmount: string; costCurrency: string | null }
   agents: UsageAgentDto[]
   models: UsageModelDto[]
-  // Spend-over-time chart: cost bucketed by hour (d1) or day (longer ranges),
+  sources: UsageSourceDto[]
+  // Spend-over-time chart: cost bucketed by hour (a window of two days or less) or day,
   // empty buckets filled to 0. `start` is a UTC-aligned ISO instant. `byAgent`/
   // `byModel` split each bucket's total for the grouped/stacked view (model key
   // ''=unreported); optional so a CP predating them degrades to flat bars.
@@ -3357,11 +3370,21 @@ export interface UsageDto {
   }
 }
 
-export async function fetchUsage(range: UsageRange, orgId?: string): Promise<UsageDto> {
+/** Resolve a preset to the half-open window the route wants. Exported for the tests
+ *  that pin the preset → window arithmetic. */
+export function usageWindow(range: UsageRange, now: Date = new Date()): { from: string; to: string } {
+  const to = now
+  const from = new Date(to.getTime() - RANGE_DAYS[range] * 24 * 60 * 60 * 1000)
+  return { from: from.toISOString(), to: to.toISOString() }
+}
+
+export async function fetchUsage(range: UsageRange, orgId?: string, source?: UsageSource): Promise<UsageDto> {
   // Send the viewer's tz offset so the CP buckets the spend series to local
   // day/hour (getTimezoneOffset ⇒ UTC − local; stable per client, not in the key).
   const tz = new Date().getTimezoneOffset()
-  return apiGet<UsageDto>(`${orgBase(orgId)}/usage?range=${range}&tz=${tz}`)
+  const { from, to } = usageWindow(range)
+  const query = new URLSearchParams({ from, to, tz: String(tz), ...(source ? { source } : {}) })
+  return apiGet<UsageDto>(`${orgBase(orgId)}/usage?${query.toString()}`)
 }
 
 // Edit an agent's spec (PATCH /agents/:id). The CP persists it and hot-syncs the


### PR DESCRIPTION
Third piece of the usage-reporting work, after #1180 (exact amounts) and #1183
(monotonic checkpoints). This one is the read path.

## Why

`GET /usage` took `range=d1|d7|d30|d90` and aggregated everything since that offset from
now. Two questions it structurally could not answer:

- **a closed accounting period**, whose end is not `now`;
- **"how much of this was metered by the gateway"** — the figure a billing caller needs,
  and one the console cannot show today either.

## What changed

| | Before | After |
|---|---|---|
| window | `range` preset, open-ended `since` | `from` + `to`, half-open `[from, to)` UTC, both required |
| scoping | all ingresses together | optional `source=daemon\|gateway` over totals, breakdowns **and** series |
| breakdowns | agents, models | agents, models, **sources** |
| series geometry | buckets run to `Date.now()` | buckets follow the window |
| response | `range` | `from` / `to` echoed |

A preset is now a *caller's* shorthand, not the API's vocabulary: the console resolves
one before calling (`usageWindow`), and a billing period is just another window, so one
route and one aggregation serve both. A figure on the dashboard and a figure on an
invoice cannot come from two implementations.

The spend baseline is now keyed per `(agent, session, source)`, and `sources[]` sums to
the same totals as `agents[]` because both read the same snapshot rows.

## Breaking, deliberately

`range` is gone rather than kept alongside, and **both ends are required** — an omitted
`to` would give a closed accounting period a moving edge, so there is no default window:
`/api/v1/usage` answers **400** to a request that does not say what it is asking for
(missing end, backwards, empty, unparseable).

Updated in this commit: the console, and the MCP `getUsage` tool — which keeps asking in
days, because that is what an agent means by "this week", and resolves the window itself.
Any other caller of `/api/v1/usage` must send a window.

## Tests

CP integration 1445 (+3), CP unit 1778, web 1595 (+2), typecheck / lint / format clean,
web build clean.

The two new integration tests assert the new behaviour, and I mutation-checked both
rather than trusting that they pass for the right reason:

| mutation | result |
|---|---|
| drop `AND sp."at" < ${to}` | window test fails |
| make the `source` predicate a no-op | source test fails |

The window test uses a **closed historical window** — three whole UTC days ending five
days ago — and asserts the series stops inside it rather than running to today, which is
what the old open-ended aggregate could not express. It is midnight-aligned on purpose:
an unaligned three-day window legitimately touches four local day buckets, and that
first assertion of mine was wrong before the alignment.

## Not in this PR

The console still renders one combined view — it now *receives* `sources[]` and can pass
`source`, but no UI splits them yet. The service credential for a billing caller's
org-wide read is the next piece; today this route is still human-auth + session
visibility only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
