### PR TITLE
feat(web): name the pool after whoever owns it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,5 +181,7 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # serves the feature either way; this decides whether the console offers it.
 # Known ids: daemon-groups (the org's own member sets), daemon-pool (the install-wide
 # pool: its fleet entry and the Cloud placement option — DAEMON_POOL_ENABLED above is
-# what actually runs one).
+# what actually runs one), managed (this deployment IS AgentConnect's managed cloud, so
+# the pool is named "AgentConnect Cloud" and metered as the plan's included usage; leave
+# it off when self-hosting and the same pool reads as your own cluster).
 #   FEATURE_FLAGS="daemon-groups,daemon-pool"

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -9,7 +9,8 @@ import { useProfile } from '@/lib/profile'
 import { useOrgs } from '@/lib/org-context'
 import {
   FALLBACK_RUNTIME_IDS,
-  POOL_LABEL,
+  poolLabel,
+  poolTagline,
   groupPlacementValue,
   approvalsReviewerDefault,
   loginRequiredRuntimeIds,
@@ -356,8 +357,8 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
       ? [
           {
             value: '',
-            label: POOL_LABEL,
-            title: 'Model usage included — no API key needed.',
+            label: poolLabel(),
+            title: poolTagline(),
             kind: 'pool' as const
           }
         ]

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -23,7 +23,8 @@ import {
   selectedPermissionPreset,
   supportsModes,
   agentLabel,
-  POOL_LABEL,
+  poolLabel,
+  poolTagline,
   POOL_PLACEMENT,
   groupPlacementValue,
   groupSetIdOf,
@@ -375,9 +376,9 @@ export default function EditAgentModal({
             // The POOL, named as itself. The server picks the member — and re-picks it after every
             // rollout, which is the whole reason this stopped being a member id.
             value: POOL_PLACEMENT,
-            label: POOL_LABEL,
+            label: poolLabel(),
             ...(poolServing ? {} : { meta: 'unavailable' }),
-            title: poolServing ? 'Model usage included — no API key needed.' : 'Cloud is currently unavailable.',
+            title: poolServing ? poolTagline() : `${poolLabel()} is currently unavailable.`,
             kind: 'pool' as const,
             disabled: initialDaemonId.current !== POOL_PLACEMENT && !poolServing
           }
@@ -388,7 +389,7 @@ export default function EditAgentModal({
           {
             value: daemonChoices.currentPoolChoice.daemonId,
             label: 'Current placement',
-            title: 'Currently on an unavailable Cloud node — select Cloud above to recover.'
+            title: `Currently on an unavailable node — select ${poolLabel()} above to recover.`
           }
         ]
       : []),
@@ -613,7 +614,7 @@ export default function EditAgentModal({
       if (!targetReady) {
         setErr(
           daemonId === POOL_PLACEMENT
-            ? 'Cloud has no online member right now; try again shortly.'
+            ? `${poolLabel()} has no online member right now; try again shortly.`
             : selectedGroup
               ? `No daemon in ${selectedGroup.name} is serving right now; try again shortly.`
               : 'Choose an online daemon that supports agent moves.'
@@ -630,7 +631,7 @@ export default function EditAgentModal({
       }
       if (runtimeUnavailable) {
         setErr(
-          `${daemon?.name ?? POOL_LABEL} does not advertise the ${runtimeLabel(runtime, runtimeMeta?.name)} runtime.`
+          `${daemon?.name ?? poolLabel()} does not advertise the ${runtimeLabel(runtime, runtimeMeta?.name)} runtime.`
         )
         return
       }
@@ -638,7 +639,7 @@ export default function EditAgentModal({
         // Reachable only when the target DOES advertise models (see
         // `modelUnavailable`), so the picker always has a real id to point at —
         // never a synthesized "Default" the runtime does not offer.
-        setErr(`${daemon?.name ?? POOL_LABEL} does not advertise model “${selectedModel}”. Choose one of its models.`)
+        setErr(`${daemon?.name ?? poolLabel()} does not advertise model “${selectedModel}”. Choose one of its models.`)
         return
       }
     }

--- a/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
@@ -53,6 +53,7 @@ function daemon(over: Partial<DaemonRow>): DaemonRow {
     host: 'edge-1',
     cpu: 10,
     mem: 20,
+    loadAgents: 0,
     caps: { platforms: [], runtimes: [], acp: true, features: [] },
     runtimeModels: [],
     mcpServers: [],
@@ -92,7 +93,8 @@ function render(): string {
   return html
 }
 
-/** The console shows the pool only where the deployment asked for it (lib/feature-flags.ts). */
+/** The console shows the pool only where the deployment asked for it, and names it after the
+ *  product only on the managed install (lib/feature-flags.ts). */
 const setFlags = (value: string) => {
   ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: value }
 }
@@ -102,7 +104,7 @@ beforeEach(() => {
   mocks.agents = []
   mocks.memberSets = []
   mocks.push.mockClear()
-  setFlags('daemon-pool')
+  setFlags('daemon-pool,managed')
 })
 
 describe('DaemonsView pool', () => {
@@ -188,6 +190,7 @@ describe('DaemonsView pool', () => {
 
     expect(html).not.toContain('AgentConnect Cloud')
     expect(html).not.toContain('agents on Cloud')
+    expect(html).not.toContain('Kubernetes cluster')
     expect(html).toContain('pc.dev')
   })
 
@@ -214,5 +217,74 @@ describe('DaemonsView pool', () => {
     const html = render()
 
     expect(html).toContain('No daemons connected')
+  })
+})
+
+describe('DaemonsView pool — self-hosted', () => {
+  // Without `managed` the pool is not a product this org bought: it is the operator's own
+  // cluster, and the card has to say so or a self-hoster reads their own machines as a bill.
+  beforeEach(() => setFlags('daemon-pool'))
+
+  it('names the cluster rather than the product', () => {
+    mocks.daemons = [member('p1'), member('p2')]
+
+    const html = render()
+
+    expect(html).not.toContain('AgentConnect Cloud')
+    expect(html).not.toContain('Managed by AgentConnect')
+    expect(html.match(/Kubernetes cluster/g)).toHaveLength(1)
+    expect(html).toContain('2 nodes')
+  })
+
+  it('quotes the cluster’s own budget: agents running against the ceiling its members report', () => {
+    mocks.daemons = [member('p1', { conns: '20', loadAgents: 7 }), member('p2', { conns: '40', loadAgents: 27 })]
+    mocks.agents = [onPool('a1', 'p1'), onPool('a2', 'p2')]
+
+    const html = render()
+
+    expect(html).toContain('34 / 60')
+    expect(html).toContain('57%')
+    expect(html).toContain('Sandbox capacity in use')
+    // The org's OWN agents there — a different number from the slots every org's agents fill.
+    expect(html).toContain('agents on cluster')
+    expect(html).toContain('>2<')
+  })
+
+  it('counts only the serving members towards the ceiling', () => {
+    mocks.daemons = [member('p1', { conns: '10', loadAgents: 5 }), member('gone', { status: 'offline', conns: '10' })]
+
+    const html = render()
+
+    expect(html).toContain('5 / 10')
+  })
+
+  it('withholds the bar when a member is unbounded — no ceiling is not a ceiling of zero', () => {
+    // `maxAgents <= 0` is the daemon's UNBOUNDED sentinel (observability/pool-metrics.ts): a
+    // cluster holding one has no finite budget, so quoting a total would advertise "full" about
+    // a pool that can never be.
+    mocks.daemons = [member('p1', { conns: '20', loadAgents: 7 }), member('p2', { conns: '0', loadAgents: 3 })]
+
+    const html = render()
+
+    expect(html).not.toContain('Sandbox capacity in use')
+    expect(html).toContain('agents on cluster')
+  })
+
+  it('says nothing about capacity while nothing is serving', () => {
+    mocks.daemons = [member('p1', { status: 'offline', conns: '20' })]
+
+    const html = render()
+
+    expect(html).toContain('no nodes serving')
+    expect(html).not.toContain('Sandbox capacity in use')
+  })
+
+  it('still shows the whole cluster as ONE entry', () => {
+    mocks.daemons = [member('p1'), member('p2'), member('p3')]
+
+    const html = render()
+
+    expect(html.match(/agents on cluster/g)).toHaveLength(1)
+    expect(html).not.toContain('pool-member-p1')
   })
 })

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import {
   POOL_LABEL,
   groupFleetStatus,
+  poolLabel,
   poolFleetStatus,
   presentedDaemonStatus,
   status,
@@ -38,6 +39,9 @@ export default function DaemonsView() {
   // Flagged: where the deployment did not ask for the pool, the page shows the
   // machines only — the CP still serves it, this is whether the console names it.
   const showPool = featureFlagEnabled('daemon-pool')
+  // Whose infrastructure the pool IS decides how it reads: the managed install sells it as
+  // AgentConnect Cloud, and a self-hosted one is looking at its own cluster.
+  const managed = featureFlagEnabled('managed')
   const poolMembers = useMemo(() => (showPool ? daemons.filter((d) => d.pool) : []), [daemons, showPool])
   const ownDaemons = useMemo(() => daemons.filter((d) => !d.pool), [daemons])
   const poolAgents = useMemo(() => {
@@ -101,7 +105,12 @@ export default function DaemonsView() {
                   {paused} paused
                 </span>
               </div>
-              {poolMembers.length > 0 && <PoolFleetCard members={poolMembers} hosted={poolAgents} />}
+              {poolMembers.length > 0 &&
+                (managed ? (
+                  <PoolFleetCard members={poolMembers} hosted={poolAgents} />
+                ) : (
+                  <ClusterFleetCard members={poolMembers} hosted={poolAgents} />
+                ))}
               {ownDaemons.length > 0 && (
                 <>
                   {/* The section label earns its place only next to the Cloud entry — without
@@ -263,15 +272,16 @@ function GroupRow({ group, daemons }: { group: MemberSetRow; daemons: DaemonRow[
 }
 
 /**
- * The whole pool as one entry (design: the Infra screen's `cloudSlot`).
+ * The whole pool as one entry on the MANAGED install (design: the Infra screen's `cloudSlot`).
  *
  * Deliberately nothing per-member: a member is a Pod, so its name, host, CPU and memory
  * are cluster churn no reader outside the cluster can act on, and a card each turned a
  * rolling deployment into a fleet of look-alike daemons. What is true of the pool is what
  * shows — is it serving, on what release, and how many agents run there.
  *
- * No utilization bar and no "Manage": the design's are a billing plan's included-usage and
- * upgrade path, and inventing either from load telemetry would read as a real quota.
+ * No utilization bar: the design's is a billing plan's included usage, and inventing that from
+ * load telemetry would read as a real quota. `ClusterFleetCard` has one because a self-hoster's
+ * ceiling is their cluster's own, which the members do report.
  */
 function PoolFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: number }) {
   const { orgPath } = useOrgs()
@@ -331,6 +341,113 @@ function PoolFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: numb
 // Bar colour tracks the hotter of the two utilizations (matches the design).
 function loadBarColor(load: number): string {
   return load >= 80 ? 'var(--status-paused)' : load >= 60 ? 'var(--amber-500)' : 'var(--brand)'
+}
+
+/**
+ * The same pool on a SELF-HOSTED install (design: the Infra screen's `clusterSlot`).
+ *
+ * Nothing here is a product the org bought: it is the operator's own cluster, so it is named as
+ * one, and the strip quotes the cluster's REAL budget — the agent ceiling its members report,
+ * against the agents they are running — rather than a plan's included usage. That is the one
+ * number a self-hoster can act on, and the reason the managed card has no bar: there the same
+ * pixels would have to mean billing, which no load telemetry can honestly say.
+ *
+ * Still one entry, never one card per member, and for the unchanged reason: a member is a Pod.
+ */
+function ClusterFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: number }) {
+  const { orgPath } = useOrgs()
+  const router = useRouter()
+  const s = status(poolFleetStatus(members))
+  const serving = members.filter((m) => m.status === 'online')
+  const online = serving.length > 0
+  // The serving members share a release (they roll together); an idle cluster has no version
+  // worth quoting, so the strip drops it rather than naming a Pod that is gone.
+  const meta = online
+    ? `${serving.length} node${serving.length === 1 ? '' : 's'} · ${serving[0]!.version}`
+    : 'no nodes serving'
+  // Capacity is the sum of what the serving members will run, matched against what they ARE
+  // running — the same pair the CP's placement check uses. A member reporting `maxAgents <= 0`
+  // is UNBOUNDED, not a ceiling of zero: a cluster holding one has no finite budget, so the bar
+  // is withheld instead of quoting a total that says "full" about a pool that can never be.
+  const caps = serving.map((m) => Number(m.conns))
+  const bounded = caps.length > 0 && caps.every((c) => Number.isFinite(c) && c > 0)
+  const capacity = bounded ? caps.reduce((sum, c) => sum + c, 0) : 0
+  const used = serving.reduce((sum, m) => sum + m.loadAgents, 0)
+  const pct = capacity > 0 ? Math.min(100, Math.round((used / capacity) * 100)) : 0
+  // Opens one member's detail for the runtimes, models and MCP servers the cluster offers —
+  // a serving one, since a member that stopped answering can no longer describe itself.
+  const target = serving[0] ?? members[members.length - 1]!
+  const open = () => router.push(orgPath(`/daemons/${target.daemonId}`))
+
+  return (
+    <div
+      className="card click flex items-center gap-3 overflow-visible p-[14px] max-desktop:rounded-lg desktop:gap-[14px] desktop:px-4 desktop:py-[15px]"
+      onClick={open}
+    >
+      <span className="relative flex h-10 w-10 flex-none items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-sunken) desktop:h-9 desktop:w-9">
+        <Icon name="boxes" size={19} color={online ? 'var(--brand)' : 'var(--text-tertiary)'} />
+        {/* Mobile puts the status dot on the avatar corner; desktop shows it in the badge. */}
+        <span
+          className="absolute -right-[3px] -bottom-[3px] h-3 w-3 rounded-full border-2 border-(--surface-card) desktop:hidden"
+          style={{ background: s.dot }}
+        />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-[2px] desktop:gap-0">
+        <div className="flex min-w-0 items-center gap-[6px] desktop:gap-2">
+          <span className="truncate font-sans text-[14px] font-semibold leading-normal desktop:text-[13.5px]">
+            {poolLabel()}
+          </span>
+          <span
+            className="badge hidden flex-none items-center gap-[6px] desktop:inline-flex"
+            style={{ background: s.bg, color: s.text }}
+          >
+            <span className="dot h-[6px] w-[6px]" style={{ background: s.dot }} />
+            {s.label}
+          </span>
+        </div>
+        <div className="truncate font-mono text-[12px] font-normal leading-normal text-(--text-tertiary) desktop:text-[11px] desktop:leading-[1.5]">
+          {meta}
+          <span className="desktop:hidden">{` · ${hosted} agent${hosted === 1 ? '' : 's'}`}</span>
+        </div>
+      </div>
+      <div className="hidden flex-none items-center gap-7 desktop:flex">
+        {capacity > 0 && (
+          <div className="w-[184px]">
+            <div className="mb-[5px] flex items-baseline justify-between gap-[10px]">
+              <span className="mono text-[11.5px] text-(--text-secondary)">
+                {used} / {capacity}
+              </span>
+              <span className="mono text-[11px] text-(--text-tertiary)">{pct}%</span>
+            </div>
+            <span className="block h-1 overflow-hidden rounded-sm bg-(--surface-active)">
+              <span className="block h-full" style={{ width: `${pct}%`, background: loadBarColor(pct) }} />
+            </span>
+            <div className="mt-[5px] font-sans text-[10.5px] font-normal leading-normal text-(--text-tertiary)">
+              Sandbox capacity in use
+            </div>
+          </div>
+        )}
+        <div className="text-right">
+          <div className="mono text-[14px] leading-normal font-semibold">{hosted}</div>
+          <div className="mt-[2px] font-sans text-[10.5px] font-normal leading-normal text-(--text-tertiary)">
+            agents on cluster
+          </div>
+        </div>
+        {/* Opens what the card opens: on a self-hosted install the cluster's runtimes, models and
+            MCP servers ARE what there is to manage — the console mints no cluster credentials. */}
+        <Button variant="secondary" size="sm" onClick={open}>
+          Manage
+        </Button>
+      </div>
+      <span
+        className="badge flex-none max-desktop:px-[10px] max-desktop:py-[3px] max-desktop:text-[12px] desktop:hidden"
+        style={{ background: s.bg, color: s.text }}
+      >
+        {s.label}
+      </span>
+      <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="desktop:hidden" />
+    </div>
+  )
 }
 
 function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -16,7 +16,7 @@ import type {
   Workspace,
   PlacementKindValue
 } from '@/lib/data'
-import { POOL_LABEL, isSelfSender, lifecycleStatus, MOCK_MODE, placementValueOf } from '@/lib/data'
+import { isSelfSender, lifecycleStatus, MOCK_MODE, placementValueOf, poolLabel } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
 import {
@@ -2064,7 +2064,7 @@ export function daemonFromDto(d: DaemonViewDto): DaemonRow {
     // provisioned-but-never-connected row. Never the raw hostname. A pool member's
     // name is its Pod, which is meaningless outside the cluster and changes on every
     // roll — the pool is one managed thing everywhere it is named, so use that label.
-    name: pool ? POOL_LABEL : d.name || d.daemonId.slice(0, 8),
+    name: pool ? poolLabel() : d.name || d.daemonId.slice(0, 8),
     version: d.agentVersion || PLACEHOLDER,
     latestVersion: d.latestVersion,
     releaseChannel: d.releaseChannel,
@@ -2081,6 +2081,7 @@ export function daemonFromDto(d: DaemonViewDto): DaemonRow {
     // `load.{cpu,mem}` are 0..1 fractions; surface them as percentages.
     cpu: d.load ? Math.round(d.load.cpu * 100) : 0,
     mem: d.load ? Math.round(d.load.mem * 100) : 0,
+    loadAgents: d.load?.agents ?? 0,
     caps: d.capabilities,
     // Per-runtime available models, observed from the daemon's runtime profiles.
     runtimeModels: (d.runtimeProfiles ?? []).map((p) => ({

--- a/packages/web/src/lib/daemon-notifications.test.tsx
+++ b/packages/web/src/lib/daemon-notifications.test.tsx
@@ -43,6 +43,7 @@ const mockDaemon = (id: string, name: string, op?: DaemonRow['lifecycleOp']): Da
   host: 'localhost',
   cpu: 10,
   mem: 20,
+  loadAgents: 0,
   caps: { platforms: [], runtimes: [], acp: true, features: [] },
   runtimeModels: [],
   mcpServers: [],

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -3,6 +3,7 @@
 
 import type { AgentIcon } from '@/lib/agent-icon'
 import type { DaemonSessionRetention, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import { platformLabel } from '@/lib/platform-labels'
 
 export type LifecycleStatusKey = 'upgrading' | 'restarting'
@@ -55,10 +56,27 @@ export function presentedDaemonStatus(daemon: Pick<DaemonRow, 'status' | 'lifecy
   return daemon.lifecycleStatus ?? daemon.status
 }
 
-/** What every surface calls an install-wide pool member. The CP names those rows after the
- *  Pod they run in, which is churn nobody outside the cluster should read: the pool is one
- *  managed thing, so `daemonFromDto` labels each member with this instead. */
+/** What a MANAGED deployment calls the pool: it is AgentConnect's own infrastructure, so it is
+ *  named after the product. The CP names pool rows after the Pod they run in, which is churn
+ *  nobody outside the cluster should read — the pool is one thing wherever it is named. */
 export const POOL_LABEL = 'AgentConnect Cloud'
+/** What a SELF-HOSTED deployment calls the same pool: the operator's own cluster, not a product
+ *  they bought. No cluster identity reaches the console (the CP carries one bit, not a name —
+ *  k8s-daemon-pool.md §3), so this names what it is rather than inventing which one it is. */
+export const CLUSTER_LABEL = 'Kubernetes cluster'
+/** The pool's name for THIS deployment. Not a constant, because the same pool is a product on the
+ *  managed install and the operator's own cluster everywhere else (lib/feature-flags.ts `managed`).
+ *  Every surface that names the pool goes through here, so no two of them disagree. */
+export function poolLabel(): string {
+  return featureFlagEnabled('managed') ? POOL_LABEL : CLUSTER_LABEL
+}
+/** One line on what placing an agent there buys you — included model usage on the managed
+ *  install, the operator's own cluster everywhere else. */
+export function poolTagline(): string {
+  return featureFlagEnabled('managed')
+    ? 'Model usage included — no API key needed.'
+    : 'Runs your agents on your own cluster.'
+}
 /** `Agent.daemon` for a pool placement. It names the POOL, never a member: no member id survives
  *  a rollout, which is precisely why the placement stopped carrying one. */
 export const POOL_PLACEMENT = 'pool'
@@ -122,7 +140,7 @@ export function agentDaemonLabel(
 ): string {
   if (isSetPlacementKind(agent.placementKind)) {
     const group = agent.setId ? groups.find((candidate) => candidate.setId === agent.setId) : undefined
-    return group?.name ?? POOL_LABEL
+    return group?.name ?? poolLabel()
   }
   return daemons.find((daemon) => daemon.daemonId === agent.daemon)?.name ?? agent.daemonName ?? '—'
 }
@@ -1982,6 +2000,9 @@ export interface DaemonRow {
   host: string
   cpu: number // 0-100 CPU utilization
   mem: number // 0-100 memory utilization
+  /** Agents this daemon is currently running — the numerator the CP's own placement check
+   *  compares against `conns` (its `maxAgents` ceiling). 0 until it reports load. */
+  loadAgents: number
   caps: DaemonCaps
   /** Available models per runtime, observed from the daemon's runtime profiles.
    *  `version` is the runtime's own release (e.g. claude-agent-acp 0.54.1), '' when

--- a/packages/web/src/lib/feature-flags.test.ts
+++ b/packages/web/src/lib/feature-flags.test.ts
@@ -17,6 +17,8 @@ describe('featureFlagEnabled', () => {
     setEnv()
     expect(featureFlagEnabled('daemon-groups')).toBe(false)
     expect(featureFlagEnabled('daemon-pool')).toBe(false)
+    // `managed` off is the SELF-HOSTED reading, which is what an unconfigured install is.
+    expect(featureFlagEnabled('managed')).toBe(false)
     setEnv('')
     expect(featureFlagEnabled('daemon-groups')).toBe(false)
     expect(featureFlagEnabled('daemon-pool')).toBe(false)
@@ -30,6 +32,10 @@ describe('featureFlagEnabled', () => {
     setEnv('daemon-groups,daemon-pool')
     expect(featureFlagEnabled('daemon-pool')).toBe(true)
     expect(featureFlagEnabled('daemon-groups')).toBe(true)
+    // The pool can be offered without being AgentConnect's: that pair is the self-hoster.
+    expect(featureFlagEnabled('managed')).toBe(false)
+    setEnv('daemon-pool,managed')
+    expect(featureFlagEnabled('managed')).toBe(true)
   })
 
   it('reads a comma-separated list, tolerating spacing and case', () => {

--- a/packages/web/src/lib/feature-flags.ts
+++ b/packages/web/src/lib/feature-flags.ts
@@ -23,6 +23,10 @@ export type FeatureFlagId =
   /** The install-wide daemon pool: its fleet entry and the Cloud placement option. An agent
    *  ALREADY on the pool still names it — hiding a live placement is not hiding an entry point. */
   | 'daemon-pool'
+  /** This deployment IS AgentConnect's managed cloud: the pool is the product, so the Infra page
+   *  names it "AgentConnect Cloud" and quotes the plan's included usage. Off — a self-hosted
+   *  install — the same pool is the operator's OWN cluster, named and metered as such. */
+  | 'managed'
 
 function enabledIds(): ReadonlySet<string> {
   // The server must read the SAME value `PublicEnvScript` injects, in the same precedence, or a

--- a/packages/web/src/lib/placement-value.test.ts
+++ b/packages/web/src/lib/placement-value.test.ts
@@ -1,6 +1,7 @@
 // Placement projection regressions for machine and set targets.
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import {
+  CLUSTER_LABEL,
   POOL_LABEL,
   POOL_PLACEMENT,
   agentDaemonLabel,
@@ -9,7 +10,8 @@ import {
   groupPlacementValue,
   groupSetIdOf,
   isPoolPlacementKind,
-  placementValueOf
+  placementValueOf,
+  poolLabel
 } from '@/lib/data'
 import type { Agent, DaemonRow } from '@/lib/data'
 
@@ -62,7 +64,7 @@ describe('agentDaemonLabel', () => {
       )
     ).toBe('Renamed daemon')
     expect(agentDaemonLabel({ daemon: daemonId, placementKind: 'daemon' }, [], [])).toBe('—')
-    expect(agentDaemonLabel({ daemon: POOL_PLACEMENT, placementKind: 'set' }, [], [])).toBe(POOL_LABEL)
+    expect(agentDaemonLabel({ daemon: POOL_PLACEMENT, placementKind: 'set' }, [], [])).toBe(poolLabel())
   })
 })
 
@@ -119,19 +121,36 @@ describe('placementValueOf with the org’s own groups', () => {
     expect(groupSetIdOf(null)).toBeNull()
   })
 
-  it('labels a group by its name and everything else the pool by Cloud', () => {
+  it('labels a group by its name and everything else by whatever this deployment calls the pool', () => {
     const groups = [{ setId: 'set-lab', name: 'lab' }]
     expect(agentDaemonLabel({ daemon: POOL_PLACEMENT, placementKind: 'set', setId: 'set-lab' }, [], groups)).toBe('lab')
     expect(agentDaemonLabel({ daemon: POOL_PLACEMENT, placementKind: 'set', setId: 'set-pool' }, [], groups)).toBe(
-      POOL_LABEL
+      poolLabel()
     )
     // A group whose name has not loaded yet still reads as a placement, never as a raw set id.
     expect(agentDaemonLabel({ daemon: POOL_PLACEMENT, placementKind: 'set', setId: 'set-lab' }, [], [])).toBe(
-      POOL_LABEL
+      poolLabel()
     )
   })
 
   it('round-trips the value the picker submits', () => {
     expect(groupSetIdOf(groupPlacementValue('set-lab'))).toBe('set-lab')
+  })
+})
+
+describe('what the console calls the pool', () => {
+  // One name, resolved in one place: a deployment that shows "Kubernetes cluster" on its Infra
+  // page and offers "AgentConnect Cloud" in the placement picker has named two things.
+  afterEach(() => {
+    delete process.env.FEATURE_FLAGS
+  })
+
+  it('is the product on a managed install and the operator’s own cluster everywhere else', () => {
+    const pool = { daemon: POOL_PLACEMENT, placementKind: 'set' as const }
+    expect(poolLabel()).toBe(CLUSTER_LABEL)
+    expect(agentDaemonLabel(pool, [], [])).toBe(CLUSTER_LABEL)
+    process.env.FEATURE_FLAGS = 'managed'
+    expect(poolLabel()).toBe(POOL_LABEL)
+    expect(agentDaemonLabel(pool, [], [])).toBe(POOL_LABEL)
   })
 })


### PR DESCRIPTION
## Why

The Infra page called the daemon pool **AgentConnect Cloud** on every install. That is only true on the managed one — a self-hoster running the pool in their own Kubernetes cluster was reading their own machines as a product they bought, complete with a product's branding.

## What

A new console feature flag, **`managed`** (`packages/web/src/lib/feature-flags.ts`, off by default like every other flag, documented in `.env.example`).

**`managed` on** — nothing changes. `PoolFleetCard` as it is today: "AgentConnect Cloud", `Managed by AgentConnect · N nodes · version`, "agents on Cloud".

**`managed` off** — the same pool renders the design's cluster entry (`ClusterFleetCard`): the cluster named as one, an inline status badge, `N nodes · version`, the `used / cap · pct%` bar under "Sandbox capacity in use", "agents on cluster", and **Manage**.

The capacity strip quotes numbers the cluster actually reports — `used` = Σ `load.agents` of the serving members (new `DaemonRow.loadAgents`, mapped from the DTO), `cap` = Σ `maxAgents` — never a billing quota. If any serving member reports `maxAgents <= 0`, the daemon's UNBOUNDED sentinel that `control-plane/src/observability/pool-metrics.ts` already treats this way, the bar is withheld entirely rather than quoting a total that would read "full" about a pool that can never be. The managed card still has no bar, for the unchanged reason: there the same pixels would have to mean included usage, which no load telemetry can honestly say.

## Beyond the Infra page, deliberately

The pool is also named in the placement pickers. Leaving those on "AgentConnect Cloud" while Infra said "Kubernetes cluster" would name two different things, so the label resolves once, through `poolLabel()` in `lib/data.ts` — `api.ts`, `AddAgentModal`, `EditAgentModal` and `agentDaemonLabel` all read it, and the two Cloud-specific strings in `EditAgentModal` became label-parameterized with it. `POOL_LABEL` stays the managed name; `CLUSTER_LABEL` is the self-hosted one.

## Where this stops short of the mock

- **The cluster's own name.** The design shows `acme-prod` / `aws · us-west-2`. No cluster identity reaches the console — `DAEMON_POOL_ENABLED` is one bit, not a name (k8s-daemon-pool.md §3) — so the card uses the design's own word for an unnamed cluster and quotes `N nodes · version` for context. A real name needs a CP-side field first.
- **The `…` menu** (Mint a new token / Disconnect cluster) is omitted: neither action exists, and a menu of dead items is worse than no menu.
- **Manage** opens what clicking the card opens — a serving member's detail, which on a self-hosted install is what there is to manage.

## Testing

`pnpm --filter @agentconnect.md/web test` — 1600 passing, including six new cases for the self-hosted entry (names the cluster not the product, the capacity pair, serving-members-only, the unbounded withhold, nothing serving, still one entry) and the `managed` cases in the flag parser and the label resolver. Typecheck, eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)