### PR TITLE
ci: bound the sandbox job's apt step so a stuck mirror cannot hang a run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -224,15 +224,18 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Generate Prisma client
         run: pnpm -r prisma:generate
+      # This is the only apt on the critical path, and a runner's mirror can black-hole a fetch
+      # for hours; the acquire timeouts fail one over in seconds and the step cap bounds the rest.
       - name: Install and enable the Linux kernel sandbox
+        timeout-minutes: 5
+        env:
+          APT_OPTS: -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 -o Acquire::Retries=2
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends bubblewrap ripgrep socat
-          # Ubuntu 24.04 runners restrict unprivileged user namespaces via
-          # AppArmor; bwrap (and therefore the SRT sandbox) requires them.
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y --no-install-recommends bubblewrap ripgrep socat
+          # Ubuntu 24.04 runners restrict unprivileged userns via AppArmor; bwrap (so the SRT sandbox) needs them.
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
-          # Fail loudly rather than letting sandbox-dependent suites silently
-          # skip if bwrap cannot start on this runner.
+          # Fail loudly rather than letting sandbox-dependent suites silently skip if bwrap cannot start.
           bwrap --unshare-user --unshare-pid --ro-bind / / --proc /proc /usr/bin/true
       - name: Core sandbox suite
         run: pnpm --filter @agentconnect.md/daemon exec vitest run test/sandbox.test.ts


### PR DESCRIPTION
`Sandbox (Linux)` has been stalling for tens of minutes at a time. The hang is
not in the sandbox suites — those never start. It is the step before them, the
only apt install on the critical path.

A hosted runner's package mirror intermittently accepts the connection and then
never answers. apt's default per-fetch timeout is 120s, and `update` pulls dozens
of index files, so one bad mirror turns into a silent multi-hour stall. With no
cap on the step, the job then holds a runner and a required check until an
unrelated push cancels it.

Measured over the last 40 runs of this workflow: a healthy job finishes in
157-237s and this step in 12s, while affected runs sat on it for 10 to 60+
minutes before being cancelled. Several were stuck simultaneously, and other runs
in the same window passed normally, which is what an intermittent mirror looks
like.

Two bounds, both on that step:

- Acquire timeouts and retries, so a dead mirror fails over to the fallback in
  seconds rather than minutes.
- `timeout-minutes: 5`, so anything still able to stall surfaces as a fast,
  re-runnable failure instead of an occupied runner. Normal is 12s, so the cap is
  far from the healthy path; it is deliberately on the step rather than the job,
  since the job's own 237s worst case leaves too little headroom for a 5 minute
  cap to be safe there.

Pre-existing comments in the step are condensed to one line each, per the repo's
comment style.
