### PR TITLE
feat(web): the self-hosted pool gets its own page, not a Pod's

### DIFF
--- a/packages/web/src/app/(app)/[slug]/daemons/cluster/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/daemons/cluster/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next'
+import ClusterDetailView from '@/components/console/views/ClusterDetailView'
+
+export const metadata: Metadata = { title: 'Cluster · AgentConnect' }
+
+export default function Page() {
+  return <ClusterDetailView />
+}

--- a/packages/web/src/components/console/CompactToggleField.test.tsx
+++ b/packages/web/src/components/console/CompactToggleField.test.tsx
@@ -42,4 +42,23 @@ describe('CompactToggleField', () => {
     expect(html).toContain('Sandboxing is not available for the current selection')
     expect(html).toContain('aria-label="Run in sandbox: Unavailable" disabled=""')
   })
+
+  it('says nothing about the OS sandbox on a cluster placement', () => {
+    // A cluster runtime is isolated by its own pod, so the in-process SRT mechanism is off
+    // there and the member advertises neither capability. Rendered literally the field said
+    // "Unavailable" about the placement whose isolation is strongest.
+    const html = renderToStaticMarkup(
+      <SandboxField checked={false} supported={false} required={false} clusterPlacement onChange={() => undefined} />
+    )
+
+    expect(html).toBe('')
+  })
+
+  it('still explains an unconfined MACHINE — there "Unavailable" is true and worth reading', () => {
+    const html = renderToStaticMarkup(
+      <SandboxField checked={false} supported={false} required={false} onChange={() => undefined} />
+    )
+
+    expect(html).toContain('Run in sandbox')
+  })
 })

--- a/packages/web/src/components/console/SandboxField.tsx
+++ b/packages/web/src/components/console/SandboxField.tsx
@@ -1,11 +1,24 @@
 import { CompactToggleField } from '@/components/console/CompactToggleField'
 
+/**
+ * The OS-sandbox toggle: a private HOME and a workspace-confined runtime, on the machine the
+ * agent is placed on.
+ *
+ * It renders nothing for a CLUSTER placement. A cluster runtime is isolated by its own pod, so
+ * the in-process SRT mechanism is deliberately off there (`daemon.ts` — it stays off even on a
+ * host that supports it) and the member advertises neither `sandbox` nor `sandbox-required`.
+ * Read literally that made the field say "Unavailable" about the one placement whose isolation
+ * is strongest — a disabled control answering a question the operator cannot ask and should not
+ * have to un-learn. On a real machine the row stays, "Unavailable" included: there it is true,
+ * and why an agent is unconfined is worth reading.
+ */
 export function SandboxField({
   checked,
   supported,
   required,
   disabled,
   disabledDetail,
+  clusterPlacement = false,
   onChange
 }: {
   checked: boolean
@@ -13,8 +26,11 @@ export function SandboxField({
   required: boolean
   disabled?: boolean
   disabledDetail?: string
+  /** The selected placement is the cluster/pool, whose isolation is the pod, not this toggle. */
+  clusterPlacement?: boolean
   onChange: (checked: boolean) => void
 }) {
+  if (clusterPlacement) return null
   const status = required ? 'Required' : !supported ? 'Unavailable' : checked ? 'On' : 'Off'
   const detail = required
     ? 'Sandboxing is required on the selected computer. The runtime uses a private HOME and is confined to its workspace.'

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -18,7 +18,7 @@ import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigat
 import { ConsoleDataProvider, useConsoleData } from '@/lib/data-context'
 import { OrgProvider, useOrgs, orgColor, subPath } from '@/lib/org-context'
 import { ApiError, getMyAccess, type OrgDto } from '@/lib/api'
-import { agentLabel } from '@/lib/data'
+import { agentLabel, poolLabel } from '@/lib/data'
 import { detailCrumb, type CrumbSlot } from '@/lib/crumb'
 import { PlaygroundProvider } from './PlaygroundProvider'
 import { ModalProvider, useModal } from './ModalProvider'
@@ -565,7 +565,8 @@ function ShellChromeInner({ children }: { children: ReactNode }) {
       const agent = agents.find((a) => a.id === id)
       return agent ? agentLabel(agent) : undefined
     }
-    if (section === 'daemons') return daemons.find((d) => d.daemonId === id)?.name
+    // `cluster` is the pool's own page, not a daemon id — no member id survives a rollout.
+    if (section === 'daemons') return id === 'cluster' ? poolLabel() : daemons.find((d) => d.daemonId === id)?.name
     if (section === 'sessions') return allSessions.find((s) => s.id === id)?.title
     if (section === 'crons') return crons.find((c) => c.id === id)?.name
     return undefined

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -1172,6 +1172,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                 checked={effectiveRunInSandbox}
                 supported={sandboxSupported}
                 required={sandboxRequired}
+                clusterPlacement={placement?.kind === 'pool'}
                 onChange={setRunInSandbox}
               />
               <OutputModeField

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -991,6 +991,7 @@ export default function EditAgentModal({
                   required={selectedSandboxRequired}
                   disabled={placementRequested}
                   disabledDetail="Save the computer change before adjusting sandboxing."
+                  clusterPlacement={daemonId === POOL_PLACEMENT}
                   onChange={setRunInSandbox}
                 />
                 <OutputModeField

--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -73,8 +73,22 @@ function member(id: string, over: Partial<DaemonRow> = {}): DaemonRow {
   } as DaemonRow
 }
 
-const onPool = (id: string, daemonId: string, over: Partial<Agent> = {}): Agent =>
-  ({ id, daemon: daemonId, name: id, status: 'online', runtime: 'claude', model: 'opus', ...over }) as Agent
+/** An agent placed on the POOL as the live console models it: `agentFromDto` maps a set
+ *  placement to the `pool` sentinel, never the ephemeral member id holding the duty. Getting
+ *  this wrong in a fixture is exactly how a page can report an empty cluster and still pass. */
+const onPool = (id: string, over: Partial<Agent> = {}): Agent =>
+  ({
+    id,
+    daemon: 'pool',
+    placementKind: 'set',
+    setId: null,
+    placementReady: true,
+    name: id,
+    status: 'online',
+    runtime: 'claude',
+    model: 'opus',
+    ...over
+  }) as Agent
 
 function render(): string {
   const host = document.createElement('div')
@@ -153,19 +167,21 @@ describe('ClusterDetailView', () => {
         ]
       })
     ] as unknown[]
-    mocks.agents = [onPool('a1', 'p1')]
+    mocks.agents = [onPool('a1')]
 
     const html = render()
 
     expect(html).toContain('2 models')
     expect(html).toContain('v0.54.1')
+    // The disclosure is operable, not hover-only: a real button carrying aria-expanded.
+    expect(html).toContain('aria-expanded')
     expect(html).toContain('1 agent')
     expect(html).toContain('no agents')
   })
 
   it('lists the agents on the cluster and the connections they hold', () => {
     mocks.daemons = [member('p1')]
-    mocks.agents = [onPool('a1', 'p1'), onPool('a2', 'p1')]
+    mocks.agents = [onPool('a1'), onPool('a2')]
     mocks.integrations = [
       {
         id: 'i1',
@@ -207,6 +223,31 @@ describe('ClusterDetailView', () => {
     expect(html).not.toContain('Mint')
     expect(html).not.toContain('Rotate')
     expect(html).not.toContain('tail · local time')
+  })
+
+  it('opens a runtime’s models from the keyboard, not a hover alone', () => {
+    mocks.daemons = [
+      member('p1', {
+        runtimeModels: [{ runtime: 'claude', version: '0.54.1', models: ['opus', 'sonnet'], acpProtocolVersion: 1 }]
+      })
+    ] as unknown[]
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root: Root = createRoot(host)
+    act(() => {
+      root.render(<ClusterDetailView />)
+    })
+    expect(host.innerHTML).not.toContain('sonnet')
+    act(() => {
+      host.querySelector<HTMLButtonElement>('button[aria-expanded]')?.click()
+    })
+    const opened = host.innerHTML
+    act(() => root.unmount())
+    host.remove()
+
+    expect(opened).toContain('sonnet')
+    expect(opened).toContain('aria-expanded="true"')
   })
 
   it('says so when no pool member has registered at all', () => {

--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -1,0 +1,225 @@
+// @vitest-environment happy-dom
+/**
+ * The self-hosted pool has ONE detail page, and it is the cluster's — not a member's.
+ * A member is a Pod: the pool rolls, every replacement mints another daemon row, and no
+ * member id survives that. So everything on this page is an aggregate over the serving
+ * members, and the two things the design offered that the console cannot honestly serve
+ * — a mint/rotate-token action and a live log tail — are absent by construction.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent, DaemonRow } from '@/lib/data'
+
+const mocks = vi.hoisted(() => ({
+  daemons: [] as unknown[],
+  agents: [] as unknown[],
+  integrations: [] as unknown[],
+  daemonsLoading: false,
+  push: vi.fn()
+}))
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mocks.push }) }))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-pool' }, myRole: 'viewer', orgPath: (p: string) => `/acme${p}` })
+}))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    daemons: mocks.daemons,
+    daemonsLoading: mocks.daemonsLoading,
+    agents: mocks.agents,
+    integrations: mocks.integrations
+  })
+}))
+vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
+
+const ClusterDetailView = (await import('./ClusterDetailView')).default
+
+function member(id: string, over: Partial<DaemonRow> = {}): DaemonRow {
+  return {
+    daemonId: id,
+    pool: true,
+    memberSetId: 'pool',
+    name: 'AgentConnect Cloud',
+    version: '1.41.0',
+    latestVersion: '1.41.0',
+    releaseChannel: 'latest',
+    upgradeAvailable: false,
+    availableVersions: [],
+    lifecycleOp: null,
+    lifecycleStatus: null,
+    canManageLifecycle: false,
+    status: 'online',
+    host: `pool-member-${id}`,
+    cpu: 20,
+    mem: 40,
+    loadAgents: 0,
+    caps: { platforms: [], runtimes: [], acp: true, features: [] },
+    runtimeModels: [],
+    mcpServers: [],
+    activeSessions: '0',
+    conns: '32',
+    uptime: '1m',
+    createdBy: '',
+    createdAt: '',
+    lastModifiedBy: '',
+    lastModifiedAt: '',
+    sessionRetention: '7d',
+    visibility: 'org',
+    sharedWith: [],
+    canEdit: false,
+    canManageSharing: false,
+    ...over
+  } as DaemonRow
+}
+
+const onPool = (id: string, daemonId: string, over: Partial<Agent> = {}): Agent =>
+  ({ id, daemon: daemonId, name: id, status: 'online', runtime: 'claude', model: 'opus', ...over }) as Agent
+
+function render(): string {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root: Root = createRoot(host)
+  act(() => {
+    root.render(<ClusterDetailView />)
+  })
+  const html = host.innerHTML
+  act(() => root.unmount())
+  host.remove()
+  return html
+}
+
+const setFlags = (value: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: value }
+}
+
+beforeEach(() => {
+  mocks.daemons = []
+  mocks.agents = []
+  mocks.integrations = []
+  mocks.daemonsLoading = false
+  mocks.push.mockClear()
+  setFlags('daemon-pool')
+})
+
+describe('ClusterDetailView', () => {
+  it('names the cluster and reads its nodes as one fleet', () => {
+    mocks.daemons = [member('p1'), member('p2'), member('gone', { status: 'offline' })]
+
+    const html = render()
+
+    expect(html).toContain('Kubernetes cluster')
+    expect(html).toContain('2 nodes serving')
+    expect(html).toContain('2 / 3')
+    // Pod identity is cluster churn — never a name this page puts in front of anyone.
+    expect(html).not.toContain('pool-member-p1')
+  })
+
+  it('sums the ceiling and the load its serving members report', () => {
+    mocks.daemons = [
+      member('p1', { conns: '20', loadAgents: 7, cpu: 30, mem: 50 }),
+      member('p2', { conns: '40', loadAgents: 27, cpu: 50, mem: 70 }),
+      member('gone', { status: 'offline', conns: '99', loadAgents: 99 })
+    ]
+
+    const html = render()
+
+    expect(html).toContain('34 / 60')
+    expect(html).toContain('Agent ceiling')
+    expect(html).toContain('>60<')
+    // Utilization is the average across the serving nodes, never the dead one's.
+    expect(html).toContain('40%')
+    expect(html).toContain('60%')
+  })
+
+  it('names an unbounded cluster ∞ rather than a ceiling of zero', () => {
+    mocks.daemons = [member('p1', { conns: '20', loadAgents: 7 }), member('p2', { conns: '0', loadAgents: 3 })]
+
+    const html = render()
+
+    expect(html).toContain('10 / ∞')
+    expect(html).toContain('unbounded')
+  })
+
+  it('unions the runtimes and models across the serving nodes', () => {
+    mocks.daemons = [
+      member('p1', {
+        runtimeModels: [{ runtime: 'claude', version: '0.54.1', models: ['opus'], acpProtocolVersion: 1 }]
+      }),
+      member('p2', {
+        runtimeModels: [
+          { runtime: 'claude', version: '0.54.1', models: ['opus', 'sonnet'], acpProtocolVersion: 1 },
+          { runtime: 'codex', version: '', models: [], acpProtocolVersion: 1 }
+        ]
+      })
+    ] as unknown[]
+    mocks.agents = [onPool('a1', 'p1')]
+
+    const html = render()
+
+    expect(html).toContain('2 models')
+    expect(html).toContain('v0.54.1')
+    expect(html).toContain('1 agent')
+    expect(html).toContain('no agents')
+  })
+
+  it('lists the agents on the cluster and the connections they hold', () => {
+    mocks.daemons = [member('p1')]
+    mocks.agents = [onPool('a1', 'p1'), onPool('a2', 'p1')]
+    mocks.integrations = [
+      {
+        id: 'i1',
+        agentId: 'a1',
+        name: 'acme-ops',
+        platform: 'slack',
+        workspace: 'acme.slack.com',
+        status: 'online',
+        channels: [{ channelId: 'C1', name: 'deploys', trigger: 'mention' }]
+      },
+      {
+        id: 'i2',
+        agentId: 'elsewhere',
+        name: 'other',
+        platform: 'slack',
+        workspace: 'x',
+        status: 'online',
+        channels: []
+      }
+    ]
+
+    const html = render()
+
+    expect(html).toContain('Agents on this cluster')
+    expect(html).toContain('Connections held here')
+    expect(html).toContain('acme-ops')
+    expect(html).toContain('1 channel')
+    // An integration whose agent runs elsewhere is not held here.
+    expect(html).not.toContain('>other<')
+  })
+
+  it('offers neither a token action nor a log tail', () => {
+    // The console mints no cluster credentials, and a fabricated log stream would be
+    // indistinguishable from real telemetry.
+    mocks.daemons = [member('p1')]
+
+    const html = render()
+
+    expect(html).not.toContain('Mint')
+    expect(html).not.toContain('Rotate')
+    expect(html).not.toContain('tail · local time')
+  })
+
+  it('says so when no pool member has registered at all', () => {
+    const html = render()
+
+    expect(html).toContain('No cluster connected')
+  })
+
+  it('waits rather than 404s while the fleet is still loading', () => {
+    mocks.daemonsLoading = true
+
+    const html = render()
+
+    expect(html).not.toContain('No cluster connected')
+  })
+})

--- a/packages/web/src/components/console/views/ClusterDetailView.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.tsx
@@ -15,6 +15,7 @@ import {
   agentLabel,
   agentModelDisplay,
   effectiveAgentStatus,
+  isPoolPlacementKind,
   platName,
   poolFleetStatus,
   poolLabel,
@@ -48,14 +49,28 @@ export default function ClusterDetailView() {
   const acpRegistry = useAcpRegistry()
   const { orgPath } = useOrgs()
   const router = useRouter()
-  const { daemons, agents, integrations, daemonsLoading } = useConsoleData()
-  const [openRuntime, setOpenRuntime] = useState<string | null>(null)
+  const { daemons, agents, integrations, orgSetIds, daemonsLoading } = useConsoleData()
+  // Independent disclosures — more than one runtime's models can be open at once, matching
+  // the daemon detail page's tap expansion.
+  const [openRuntimes, setOpenRuntimes] = useState<Set<string>>(new Set())
+  const toggleRuntime = (rid: string) =>
+    setOpenRuntimes((prev) => {
+      const next = new Set(prev)
+      if (next.has(rid)) next.delete(rid)
+      else next.add(rid)
+      return next
+    })
 
   const showPool = featureFlagEnabled('daemon-pool')
   const members = useMemo(() => (showPool ? daemons.filter((d) => d.pool) : []), [daemons, showPool])
   const serving = useMemo(() => members.filter((m) => m.status === 'online'), [members])
-  const memberIds = useMemo(() => new Set(members.map((m) => m.daemonId)), [members])
-  const hosted = useMemo(() => agents.filter((a) => memberIds.has(a.daemon)), [agents, memberIds])
+  // Pool agents carry the POOL sentinel, never a member id: the Pod holding the duty is
+  // ephemeral, so `agentFromDto` maps a set placement to `daemon: POOL_PLACEMENT`. Matching
+  // member ids here would report an empty cluster however many agents run on it.
+  const hosted = useMemo(
+    () => agents.filter((a) => isPoolPlacementKind(a.placementKind, a.setId, orgSetIds)),
+    [agents, orgSetIds]
+  )
 
   // The runtimes the cluster offers: a member that stopped answering can no longer serve
   // one, so the union is over the serving members only.
@@ -134,6 +149,9 @@ export default function ClusterDetailView() {
   // The serving members roll together, so they share a release; an idle cluster has no
   // version worth quoting rather than one belonging to a Pod that is gone.
   const version = online ? serving[0]!.version : '—'
+  // One serving member stands in for the set when reading what it can run — the same
+  // substitution Add-agent and Edit-agent make (edit-agent-daemon-choice.ts).
+  const capabilitySource = serving[0]
 
   const labeled = (label: string, value: string) => (
     <div className="row grid-cols-[1fr_auto]">
@@ -238,7 +256,7 @@ export default function ClusterDetailView() {
         <div className="cardhead">
           <span className="cardtitle">Runtimes</span>
           <span className="ml-auto font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-            Hover a runtime for its models
+            Open a runtime for its models
           </span>
         </div>
         {runtimes.length > 0 ? (
@@ -248,44 +266,56 @@ export default function ClusterDetailView() {
             // Id namespaces differ across daemon generations ('claude' vs 'claude-acp'),
             // so agents match on the display family rather than the raw id.
             const users = hosted.filter((a) => a.runtime === rt.runtime || runtimeLabel(a.runtime) === label)
-            const open = openRuntime === rt.runtime && rt.models.length > 0
+            const hasModels = rt.models.length > 0
+            const open = openRuntimes.has(rt.runtime) && hasModels
             return (
-              <div
-                key={rt.runtime}
-                onMouseEnter={() => setOpenRuntime(rt.runtime)}
-                onMouseLeave={() => setOpenRuntime(null)}
-                className="row relative grid-cols-[1.4fr_.7fr_.9fr_.9fr] gap-[14px]"
-              >
-                <span className="inline-flex min-w-0 items-center gap-[9px]">
-                  <span className="imark h-[22px] w-[22px]">
-                    <AgentMark model={rt.runtime} />
-                  </span>
-                  <span className="truncate font-sans text-[13px] font-semibold leading-normal">{label}</span>
-                  {rt.authRequired && (
-                    <span
-                      className="flex flex-none"
-                      title="A node's probe was rejected with 'authentication required' — sign in to the runtime on that node."
-                    >
-                      <Icon name="triangle-alert" size={13} color="var(--amber-500)" />
+              <div key={rt.runtime}>
+                {/* A real button, not a hover target: the model list is the only place the
+                    cluster's models are readable, and a pointer is not the only input. */}
+                <button
+                  type="button"
+                  aria-expanded={open}
+                  disabled={!hasModels}
+                  onClick={() => toggleRuntime(rt.runtime)}
+                  className="row grid w-full grid-cols-[1.4fr_.7fr_.9fr_.9fr_auto] gap-[14px] border-0 bg-transparent text-left enabled:cursor-pointer enabled:hover:bg-(--surface-hover)"
+                >
+                  <span className="inline-flex min-w-0 items-center gap-[9px]">
+                    <span className="imark h-[22px] w-[22px]">
+                      <AgentMark model={rt.runtime} />
                     </span>
-                  )}
-                </span>
-                <span className="mono text-[12px] text-(--text-secondary)">
-                  {rt.version ? `v${rt.version.replace(/^v/, '')}` : '—'}
-                </span>
-                <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
-                  {users.length > 0 ? `${users.length} agent${users.length === 1 ? '' : 's'}` : 'no agents'}
-                </span>
-                <span className="mono text-[12px] text-(--text-tertiary)">
-                  {rt.models.length} model{rt.models.length === 1 ? '' : 's'}
-                </span>
+                    <span className="truncate font-sans text-[13px] font-semibold leading-normal">{label}</span>
+                    {rt.authRequired && (
+                      <span
+                        className="flex flex-none"
+                        title="A node's probe was rejected with 'authentication required' — sign in to the runtime on that node."
+                      >
+                        <Icon name="triangle-alert" size={13} color="var(--amber-500)" />
+                      </span>
+                    )}
+                  </span>
+                  <span className="mono text-[12px] text-(--text-secondary)">
+                    {rt.version ? `v${rt.version.replace(/^v/, '')}` : '—'}
+                  </span>
+                  <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+                    {users.length > 0 ? `${users.length} agent${users.length === 1 ? '' : 's'}` : 'no agents'}
+                  </span>
+                  <span className="mono text-[12px] text-(--text-tertiary)">
+                    {rt.models.length} model{rt.models.length === 1 ? '' : 's'}
+                  </span>
+                  <Icon
+                    name={open ? 'chevron-up' : 'chevron-down'}
+                    size={15}
+                    color="var(--text-tertiary)"
+                    className={hasModels ? '' : 'invisible'}
+                  />
+                </button>
                 {open && (
-                  <div className="absolute top-[calc(100%_-_4px)] left-4 z-40 w-[420px] max-w-[calc(100%_-_32px)] overflow-hidden rounded-[9px] border border-(--border-default) bg-(--surface-card) py-1 shadow-(--shadow-lg)">
-                    <div className="px-[13px] pt-[7px] pb-1 font-sans text-[10px] font-semibold tracking-[.05em] uppercase leading-normal text-(--text-tertiary)">
+                  <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 py-[10px]">
+                    <div className="pb-1 font-sans text-[10px] font-semibold tracking-[.05em] uppercase leading-normal text-(--text-tertiary)">
                       Models
                     </div>
                     {rt.models.map((m) => (
-                      <div key={m} className="mono truncate px-[13px] py-[5px] text-[11.5px]">
+                      <div key={m} className="mono truncate py-[3px] text-[11.5px]">
                         {m}
                       </div>
                     ))}
@@ -308,10 +338,10 @@ export default function ClusterDetailView() {
           </div>
           {hosted.length > 0 ? (
             hosted.map((a) => {
-              // A pool agent runs on the member holding its duty; its status is that
-              // member's, which is why the daemon row is looked up rather than assumed.
-              const home = members.find((m) => m.daemonId === a.daemon)
-              const as = status(effectiveAgentStatus(a, home))
+              // No member stands for the pool's agents individually — the Pod holding a duty
+              // is ephemeral. Status comes from the placement (effectiveAgentStatus reads the
+              // pool branch first), and the models a serving member reports name the cluster's.
+              const as = status(effectiveAgentStatus(a, undefined))
               return (
                 <div
                   key={a.id}
@@ -325,7 +355,7 @@ export default function ClusterDetailView() {
                     {agentLabel(a)}
                   </span>
                   <span className="min-w-0 truncate font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
-                    {agentModelDisplay(home, a.runtime, a.model)}
+                    {agentModelDisplay(capabilitySource, a.runtime, a.model)}
                   </span>
                   <span className="badge" style={{ background: as.bg, color: as.text }}>
                     <span className="dot h-[6px] w-[6px]" style={{ background: as.dot }} />

--- a/packages/web/src/components/console/views/ClusterDetailView.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.tsx
@@ -1,0 +1,413 @@
+'use client'
+
+// Cluster detail — the self-hosted pool read as ONE thing (design: the Cloud/cluster
+// detail screen, `cd.isCluster`). A pool member is a Pod: no member id survives a
+// rollout, so opening the Infra card must not land on one machine's page and call it
+// the cluster. Everything here aggregates the serving members.
+//
+// The design's mint/rotate-token action and its log tail are deliberately absent: the
+// console mints no cluster credentials, and inventing a log stream would be
+// indistinguishable from real telemetry (same call the daemon detail page made).
+
+import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  agentLabel,
+  agentModelDisplay,
+  effectiveAgentStatus,
+  platName,
+  poolFleetStatus,
+  poolLabel,
+  runtimeLabel,
+  status,
+  type DaemonRow,
+  type McpServerInfo
+} from '@/lib/data'
+import { useConsoleData } from '@/lib/data-context'
+import { featureFlagEnabled } from '@/lib/feature-flags'
+import { NotFound } from '@/components/console/NotFound'
+import { AgentIconView, AgentMark, LoadingState, PlatformMark } from '@/components/marks'
+import { Icon } from '@/components/ui'
+import { useOrgs } from '@/lib/org-context'
+import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
+
+// Bar colour tracks the reading, matching the Infra list and the daemon detail page.
+function barColor(pct: number): string {
+  return pct >= 80 ? 'var(--status-paused)' : pct >= 60 ? 'var(--amber-500)' : 'var(--brand)'
+}
+
+/** A runtime as the whole cluster offers it — the union over its serving members. */
+interface ClusterRuntime {
+  runtime: string
+  version: string
+  models: string[]
+  authRequired: boolean
+}
+
+export default function ClusterDetailView() {
+  const acpRegistry = useAcpRegistry()
+  const { orgPath } = useOrgs()
+  const router = useRouter()
+  const { daemons, agents, integrations, daemonsLoading } = useConsoleData()
+  const [openRuntime, setOpenRuntime] = useState<string | null>(null)
+
+  const showPool = featureFlagEnabled('daemon-pool')
+  const members = useMemo(() => (showPool ? daemons.filter((d) => d.pool) : []), [daemons, showPool])
+  const serving = useMemo(() => members.filter((m) => m.status === 'online'), [members])
+  const memberIds = useMemo(() => new Set(members.map((m) => m.daemonId)), [members])
+  const hosted = useMemo(() => agents.filter((a) => memberIds.has(a.daemon)), [agents, memberIds])
+
+  // The runtimes the cluster offers: a member that stopped answering can no longer serve
+  // one, so the union is over the serving members only.
+  const runtimes = useMemo<ClusterRuntime[]>(() => {
+    const byId = new Map<string, ClusterRuntime>()
+    for (const m of serving) {
+      for (const rt of m.runtimeModels) {
+        const prev = byId.get(rt.runtime)
+        if (!prev) {
+          byId.set(rt.runtime, {
+            runtime: rt.runtime,
+            version: rt.version,
+            models: [...rt.models],
+            authRequired: rt.authRequired === true
+          })
+          continue
+        }
+        if (!prev.version) prev.version = rt.version
+        for (const model of rt.models) if (!prev.models.includes(model)) prev.models.push(model)
+        prev.authRequired ||= rt.authRequired === true
+      }
+    }
+    return [...byId.values()]
+  }, [serving])
+
+  const mcpServers = useMemo<McpServerInfo[]>(() => {
+    const byName = new Map<string, McpServerInfo>()
+    for (const m of serving) for (const s of m.mcpServers) if (!byName.has(s.name)) byName.set(s.name, s)
+    return [...byName.values()]
+  }, [serving])
+
+  // The connections the cluster holds: an integration is held wherever its agent runs.
+  const conns = useMemo(() => {
+    const hostedIds = new Set(hosted.map((a) => a.id))
+    return integrations.filter((i) => i.agentId !== undefined && hostedIds.has(i.agentId))
+  }, [hosted, integrations])
+
+  if (members.length === 0) {
+    if (daemonsLoading)
+      return (
+        <div className="wrap max-w-[1240px]">
+          <LoadingState fill />
+        </div>
+      )
+    return (
+      <div className="wrap max-w-[1240px]">
+        <NotFound
+          icon="server-off"
+          kind="CLUSTER"
+          title="No cluster connected"
+          pre="No pool member has registered with this control plane. Install the daemon runtime on a cluster and it appears here."
+          actionLabel="Back to daemons"
+          actionHref={orgPath('/daemons')}
+          searchLabel="Search daemons"
+        />
+      </div>
+    )
+  }
+
+  const s = status(poolFleetStatus(members))
+  const online = serving.length > 0
+
+  // `maxAgents <= 0` is the daemon's UNBOUNDED sentinel, not a ceiling of zero — a cluster
+  // holding one has no finite budget, so it reads ∞ rather than a total that says "full".
+  const caps = serving.map((m) => Number(m.conns))
+  const unbounded = caps.some((c) => !Number.isFinite(c) || c <= 0)
+  const capacity = unbounded ? 0 : caps.reduce((sum, c) => sum + c, 0)
+  const used = serving.reduce((sum, m) => sum + m.loadAgents, 0)
+  const capacityPct = capacity > 0 ? Math.min(100, Math.round((used / capacity) * 100)) : 0
+  const capacityLabel = `${used} / ${unbounded ? '∞' : capacity}`
+  const avg = (pick: (m: DaemonRow) => number) =>
+    serving.length > 0 ? Math.round(serving.reduce((sum, m) => sum + pick(m), 0) / serving.length) : 0
+  const cpu = avg((m) => m.cpu)
+  const mem = avg((m) => m.mem)
+  const sessions = serving.reduce((sum, m) => sum + Number(m.activeSessions ?? 0), 0)
+  // The serving members roll together, so they share a release; an idle cluster has no
+  // version worth quoting rather than one belonging to a Pod that is gone.
+  const version = online ? serving[0]!.version : '—'
+
+  const labeled = (label: string, value: string) => (
+    <div className="row grid-cols-[1fr_auto]">
+      <span className="font-sans text-[13px] font-normal leading-normal text-(--text-tertiary)">{label}</span>
+      <span className="mono text-[12.5px]">{value}</span>
+    </div>
+  )
+
+  const stat = (icon: string, label: string, value: string) => (
+    <div className="card stat">
+      <div className="statlbl">
+        <Icon name={icon} size={14} />
+        {label}
+      </div>
+      <div className="statval">{value}</div>
+    </div>
+  )
+
+  return (
+    <div className="wrap max-w-[1240px] px-4 pt-[14px] pb-1 desktop:p-0">
+      {/* header — no action button: a self-hoster's cluster credentials are minted on the
+          cluster, never here, so there is nothing for this page to offer. */}
+      <div className="mb-5 flex items-start gap-4">
+        <span className="relative flex h-13 w-13 flex-none items-center justify-center rounded-lg border border-(--border-subtle) bg-(--surface-sunken)">
+          <Icon name="boxes" size={26} color={online ? 'var(--brand)' : 'var(--text-tertiary)'} />
+          <span
+            className="dot absolute -right-1 -bottom-1 h-[14px] w-[14px] border-[2.5px] border-(--surface-app)"
+            style={{ background: s.dot }}
+          />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-[10px]">
+            <h1 className="ptitle">{poolLabel()}</h1>
+            <span className="badge" style={{ background: s.bg, color: s.text }}>
+              <span className="dot h-[6px] w-[6px]" style={{ background: s.dot }} />
+              {s.label}
+            </span>
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2">
+            <span className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+              <Icon name="server" size={14} color="var(--text-tertiary)" />
+              {online ? `${serving.length} node${serving.length === 1 ? '' : 's'} serving` : 'no nodes serving'}
+            </span>
+            <span className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+              <Icon name="tag" size={14} color="var(--text-tertiary)" />
+              <span className="mono text-[12px]">{version}</span>
+            </span>
+            <span className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+              <Icon name="layers" size={14} color="var(--text-tertiary)" />
+              Runs your agents on your own cluster
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* metric strip */}
+      <div className="mb-[18px] grid grid-cols-2 gap-[14px] desktop:grid-cols-4">
+        {stat('bot', 'Agents on cluster', String(hosted.length))}
+        {stat('server', 'Nodes serving', `${serving.length} / ${members.length}`)}
+        {stat('layers', 'Sandbox capacity', capacityLabel)}
+        {stat('activity', 'Active sessions', String(sessions))}
+      </div>
+
+      <div className="mb-[18px] grid grid-cols-1 items-start gap-[18px] desktop:grid-cols-[1.15fr_1fr]">
+        {/* capacity + utilization, the numbers the cluster's own members report */}
+        <div className="card">
+          <div className="cardhead">
+            <span className="cardtitle">Capacity</span>
+            <span className="mono ml-auto text-[11px] text-(--text-tertiary)">across serving nodes</span>
+          </div>
+          <div className="flex flex-col gap-[14px] px-4 py-[15px]">
+            <ResourceBar
+              label="Sandbox capacity in use"
+              detail={capacityLabel}
+              pct={capacityPct}
+              // An unbounded cluster has no fraction to fill: the track stays empty rather
+              // than drawing a 0% that reads as a measurement.
+              muted={unbounded}
+            />
+            <ResourceBar label="CPU" detail={`${cpu}%`} pct={cpu} />
+            <ResourceBar label="Memory" detail={`${mem}%`} pct={mem} />
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="cardhead">
+            <span className="cardtitle">Details</span>
+          </div>
+          <div className="py-[6px]">
+            {labeled('Nodes', `${serving.length} serving of ${members.length}`)}
+            {labeled('Status', s.label)}
+            {labeled('Version', version)}
+            {labeled('Agent ceiling', unbounded ? 'unbounded' : String(capacity))}
+            {labeled('Placement', 'pool')}
+            {labeled('MCP servers', String(mcpServers.length))}
+          </div>
+        </div>
+      </div>
+
+      {/* runtimes the cluster offers */}
+      <div className="card mb-[18px]">
+        <div className="cardhead">
+          <span className="cardtitle">Runtimes</span>
+          <span className="ml-auto font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+            Hover a runtime for its models
+          </span>
+        </div>
+        {runtimes.length > 0 ? (
+          runtimes.map((rt) => {
+            const meta = acpRuntime(acpRegistry, rt.runtime)
+            const label = runtimeLabel(rt.runtime, meta?.name)
+            // Id namespaces differ across daemon generations ('claude' vs 'claude-acp'),
+            // so agents match on the display family rather than the raw id.
+            const users = hosted.filter((a) => a.runtime === rt.runtime || runtimeLabel(a.runtime) === label)
+            const open = openRuntime === rt.runtime && rt.models.length > 0
+            return (
+              <div
+                key={rt.runtime}
+                onMouseEnter={() => setOpenRuntime(rt.runtime)}
+                onMouseLeave={() => setOpenRuntime(null)}
+                className="row relative grid-cols-[1.4fr_.7fr_.9fr_.9fr] gap-[14px]"
+              >
+                <span className="inline-flex min-w-0 items-center gap-[9px]">
+                  <span className="imark h-[22px] w-[22px]">
+                    <AgentMark model={rt.runtime} />
+                  </span>
+                  <span className="truncate font-sans text-[13px] font-semibold leading-normal">{label}</span>
+                  {rt.authRequired && (
+                    <span
+                      className="flex flex-none"
+                      title="A node's probe was rejected with 'authentication required' — sign in to the runtime on that node."
+                    >
+                      <Icon name="triangle-alert" size={13} color="var(--amber-500)" />
+                    </span>
+                  )}
+                </span>
+                <span className="mono text-[12px] text-(--text-secondary)">
+                  {rt.version ? `v${rt.version.replace(/^v/, '')}` : '—'}
+                </span>
+                <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+                  {users.length > 0 ? `${users.length} agent${users.length === 1 ? '' : 's'}` : 'no agents'}
+                </span>
+                <span className="mono text-[12px] text-(--text-tertiary)">
+                  {rt.models.length} model{rt.models.length === 1 ? '' : 's'}
+                </span>
+                {open && (
+                  <div className="absolute top-[calc(100%_-_4px)] left-4 z-40 w-[420px] max-w-[calc(100%_-_32px)] overflow-hidden rounded-[9px] border border-(--border-default) bg-(--surface-card) py-1 shadow-(--shadow-lg)">
+                    <div className="px-[13px] pt-[7px] pb-1 font-sans text-[10px] font-semibold tracking-[.05em] uppercase leading-normal text-(--text-tertiary)">
+                      Models
+                    </div>
+                    {rt.models.map((m) => (
+                      <div key={m} className="mono truncate px-[13px] py-[5px] text-[11.5px]">
+                        {m}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          })
+        ) : (
+          <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+            No runtimes reported — no node has advertised its runtime profiles yet.
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 items-start gap-[18px] desktop:grid-cols-2">
+        <div className="card">
+          <div className="cardhead">
+            <span className="cardtitle">Agents on this cluster</span>
+          </div>
+          {hosted.length > 0 ? (
+            hosted.map((a) => {
+              // A pool agent runs on the member holding its duty; its status is that
+              // member's, which is why the daemon row is looked up rather than assumed.
+              const home = members.find((m) => m.daemonId === a.daemon)
+              const as = status(effectiveAgentStatus(a, home))
+              return (
+                <div
+                  key={a.id}
+                  className="row click grid-cols-[auto_1.6fr_1fr_auto] gap-3"
+                  onClick={() => router.push(orgPath(`/agents/${a.id}`))}
+                >
+                  <span className="av h-7 w-7 rounded-[7px]">
+                    <AgentIconView icon={a.icon} runtime={a.runtime} size={28} />
+                  </span>
+                  <span className="min-w-0 truncate font-sans text-[13px] font-semibold leading-normal">
+                    {agentLabel(a)}
+                  </span>
+                  <span className="min-w-0 truncate font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+                    {agentModelDisplay(home, a.runtime, a.model)}
+                  </span>
+                  <span className="badge" style={{ background: as.bg, color: as.text }}>
+                    <span className="dot h-[6px] w-[6px]" style={{ background: as.dot }} />
+                    {as.label}
+                  </span>
+                </div>
+              )
+            })
+          ) : (
+            <div className="px-4 py-7 text-center">
+              <div className="font-sans text-[13px] font-medium leading-normal text-(--text-secondary)">
+                No agents run here yet
+              </div>
+              <div className="mt-[3px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                Place an agent on {poolLabel()} to start handling messages.
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="card">
+          <div className="cardhead">
+            <span className="cardtitle">Connections held here</span>
+          </div>
+          {conns.length > 0 ? (
+            conns.map((c) => {
+              const cs = status(c.status)
+              return (
+                <div key={c.id ?? c.name} className="row grid-cols-[auto_1.6fr_1fr_auto] gap-3">
+                  <span className="imark h-6 w-6">
+                    <PlatformMark platform={c.platform} fillPct={100} />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block truncate font-sans text-[13px] font-semibold leading-normal">{c.name}</span>
+                    <span className="mono block truncate text-[11px] text-(--text-tertiary)">
+                      {c.workspace || platName(c.platform)}
+                    </span>
+                  </span>
+                  <span className="mono min-w-0 truncate text-[12px] text-(--text-secondary)">
+                    {c.channels.length} channel{c.channels.length === 1 ? '' : 's'}
+                  </span>
+                  <span className="badge" style={{ background: cs.bg, color: cs.text }}>
+                    <span className="dot h-[6px] w-[6px]" style={{ background: cs.dot }} />
+                    {cs.label}
+                  </span>
+                </div>
+              )
+            })
+          ) : (
+            <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+              No integration tokens are held on this cluster.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** One labelled utilization bar (design: the cluster detail's `cd.resources` rows). */
+function ResourceBar({
+  label,
+  detail,
+  pct,
+  muted = false
+}: {
+  label: string
+  detail: string
+  pct: number
+  muted?: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-[6px]">
+      <div className="flex items-baseline gap-2">
+        <span className="flex-1 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+          {label}
+        </span>
+        <span className="mono text-[12.5px]">{detail}</span>
+      </div>
+      <span className="block h-[6px] overflow-hidden rounded-[3px] bg-(--surface-active)">
+        {!muted && <span className="block h-full" style={{ width: `${pct}%`, background: barColor(pct) }} />}
+      </span>
+    </div>
+  )
+}

--- a/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
@@ -78,7 +78,9 @@ function daemon(over: Partial<DaemonRow>): DaemonRow {
 const member = (id: string, over: Partial<DaemonRow> = {}): DaemonRow =>
   daemon({ daemonId: id, pool: true, name: 'AgentConnect Cloud', host: `pool-member-${id}`, ...over })
 
-const onPool = (id: string, daemonId: string): Agent => ({ id, daemon: daemonId }) as Agent
+/** An agent placed on the POOL as the live console models it: `agentFromDto` maps a set
+ *  placement to the `pool` sentinel, never the ephemeral member id holding the duty. */
+const onPool = (id: string): Agent => ({ id, daemon: 'pool', placementKind: 'set', setId: null }) as Agent
 
 function render(): string {
   const host = document.createElement('div')
@@ -122,7 +124,7 @@ describe('DaemonsView pool', () => {
 
   it('counts the agents across every member, not just the one it links to', () => {
     mocks.daemons = [member('p1'), member('p2')]
-    mocks.agents = [onPool('a1', 'p1'), onPool('a2', 'p2'), onPool('a3', 'p2')]
+    mocks.agents = [onPool('a1'), onPool('a2'), onPool('a3')]
 
     const html = render()
 
@@ -184,7 +186,7 @@ describe('DaemonsView pool', () => {
   it('names nothing about the pool where the deployment did not ask for it', () => {
     setFlags('')
     mocks.daemons = [member('p1'), daemon({ daemonId: 'own', name: 'pc.dev' })]
-    mocks.agents = [onPool('a1', 'p1')]
+    mocks.agents = [onPool('a1')]
 
     const html = render()
 
@@ -238,7 +240,7 @@ describe('DaemonsView pool — self-hosted', () => {
 
   it('quotes the cluster’s own budget: agents running against the ceiling its members report', () => {
     mocks.daemons = [member('p1', { conns: '20', loadAgents: 7 }), member('p2', { conns: '40', loadAgents: 27 })]
-    mocks.agents = [onPool('a1', 'p1'), onPool('a2', 'p2')]
+    mocks.agents = [onPool('a1'), onPool('a2')]
 
     const html = render()
 

--- a/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
@@ -258,15 +258,17 @@ describe('DaemonsView pool — self-hosted', () => {
     expect(html).toContain('5 / 10')
   })
 
-  it('withholds the bar when a member is unbounded — no ceiling is not a ceiling of zero', () => {
+  it('names an unbounded cluster ∞ — no ceiling is not a ceiling of zero', () => {
     // `maxAgents <= 0` is the daemon's UNBOUNDED sentinel (observability/pool-metrics.ts): a
     // cluster holding one has no finite budget, so quoting a total would advertise "full" about
-    // a pool that can never be.
+    // a pool that can never be. What it IS running is still worth reading.
     mocks.daemons = [member('p1', { conns: '20', loadAgents: 7 }), member('p2', { conns: '0', loadAgents: 3 })]
 
     const html = render()
 
-    expect(html).not.toContain('Sandbox capacity in use')
+    expect(html).toContain('10 / ∞')
+    expect(html).toContain('no limit')
+    expect(html).toContain('Sandbox capacity in use')
     expect(html).toContain('agents on cluster')
   })
 
@@ -277,6 +279,34 @@ describe('DaemonsView pool — self-hosted', () => {
 
     expect(html).toContain('no nodes serving')
     expect(html).not.toContain('Sandbox capacity in use')
+  })
+
+  it('offers no Manage button — the card already opens what it would open', () => {
+    mocks.daemons = [member('p1')]
+
+    const html = render()
+
+    expect(html).not.toContain('Manage')
+  })
+
+  it('opens the CLUSTER, never one of its Pods', () => {
+    // A member id does not survive a rollout, so landing on one machine's page would name
+    // the cluster after a Pod that is already gone.
+    mocks.daemons = [member('dead', { status: 'offline' }), member('serving')]
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root: Root = createRoot(host)
+    act(() => {
+      root.render(<DaemonsView />)
+    })
+    act(() => {
+      host.querySelector<HTMLElement>('.card.click')?.click()
+    })
+    act(() => root.unmount())
+    host.remove()
+
+    expect(mocks.push).toHaveBeenCalledWith('/acme/daemons/cluster')
   })
 
   it('still shows the whole cluster as ONE entry', () => {

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import {
   POOL_LABEL,
   groupFleetStatus,
+  isPoolPlacementKind,
   poolLabel,
   poolFleetStatus,
   presentedDaemonStatus,
@@ -22,7 +23,7 @@ import { Button, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 
 export default function DaemonsView() {
-  const { daemons, daemonsLoading, agents, memberSets } = useConsoleData()
+  const { daemons, daemonsLoading, agents, memberSets, orgSetIds } = useConsoleData()
   const { openModal } = useModal()
 
   // Hosted-agent count per daemon — agents assigned to it (mirrors the detail
@@ -44,10 +45,13 @@ export default function DaemonsView() {
   const managed = featureFlagEnabled('managed')
   const poolMembers = useMemo(() => (showPool ? daemons.filter((d) => d.pool) : []), [daemons, showPool])
   const ownDaemons = useMemo(() => daemons.filter((d) => !d.pool), [daemons])
-  const poolAgents = useMemo(() => {
-    const memberIds = new Set(poolMembers.map((m) => m.daemonId))
-    return agents.filter((a) => memberIds.has(a.daemon)).length
-  }, [agents, poolMembers])
+  // Pool agents carry the POOL sentinel, never a member id: the Pod holding the duty is
+  // ephemeral, so `agentFromDto` maps a set placement to `daemon: POOL_PLACEMENT`. Counting
+  // member ids reported an empty pool however many agents were placed on it.
+  const poolAgents = useMemo(
+    () => (showPool ? agents.filter((a) => isPoolPlacementKind(a.placementKind, a.setId, orgSetIds)).length : 0),
+    [agents, orgSetIds, showPool]
+  )
 
   // Fleet summary for the mobile-only strip below — counted over what the page SHOWS,
   // so the pool contributes one entry rather than one per member.

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -367,17 +367,16 @@ function ClusterFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: n
     : 'no nodes serving'
   // Capacity is the sum of what the serving members will run, matched against what they ARE
   // running — the same pair the CP's placement check uses. A member reporting `maxAgents <= 0`
-  // is UNBOUNDED, not a ceiling of zero: a cluster holding one has no finite budget, so the bar
-  // is withheld instead of quoting a total that says "full" about a pool that can never be.
+  // is UNBOUNDED, not a ceiling of zero: a cluster holding one has no finite budget, so the
+  // strip names that ∞ rather than quoting a total that says "full" about a pool that can never be.
   const caps = serving.map((m) => Number(m.conns))
-  const bounded = caps.length > 0 && caps.every((c) => Number.isFinite(c) && c > 0)
-  const capacity = bounded ? caps.reduce((sum, c) => sum + c, 0) : 0
+  const unbounded = caps.some((c) => !Number.isFinite(c) || c <= 0)
+  const capacity = unbounded ? 0 : caps.reduce((sum, c) => sum + c, 0)
   const used = serving.reduce((sum, m) => sum + m.loadAgents, 0)
   const pct = capacity > 0 ? Math.min(100, Math.round((used / capacity) * 100)) : 0
-  // Opens one member's detail for the runtimes, models and MCP servers the cluster offers —
-  // a serving one, since a member that stopped answering can no longer describe itself.
-  const target = serving[0] ?? members[members.length - 1]!
-  const open = () => router.push(orgPath(`/daemons/${target.daemonId}`))
+  // Opens the CLUSTER, not a member: no member id survives a rollout, so landing on one
+  // machine's page would name the cluster after a Pod that is already gone.
+  const open = () => router.push(orgPath('/daemons/cluster'))
 
   return (
     <div
@@ -411,16 +410,19 @@ function ClusterFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: n
         </div>
       </div>
       <div className="hidden flex-none items-center gap-7 desktop:flex">
-        {capacity > 0 && (
+        {caps.length > 0 && (
           <div className="w-[184px]">
             <div className="mb-[5px] flex items-baseline justify-between gap-[10px]">
               <span className="mono text-[11.5px] text-(--text-secondary)">
-                {used} / {capacity}
+                {used} / {unbounded ? '∞' : capacity}
               </span>
-              <span className="mono text-[11px] text-(--text-tertiary)">{pct}%</span>
+              {/* An unbounded cluster has no fraction to be: the slot reads why, not "0%". */}
+              <span className="mono text-[11px] text-(--text-tertiary)">{unbounded ? 'no limit' : `${pct}%`}</span>
             </div>
             <span className="block h-1 overflow-hidden rounded-sm bg-(--surface-active)">
-              <span className="block h-full" style={{ width: `${pct}%`, background: loadBarColor(pct) }} />
+              {!unbounded && (
+                <span className="block h-full" style={{ width: `${pct}%`, background: loadBarColor(pct) }} />
+              )}
             </span>
             <div className="mt-[5px] font-sans text-[10.5px] font-normal leading-normal text-(--text-tertiary)">
               Sandbox capacity in use
@@ -433,11 +435,6 @@ function ClusterFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: n
             agents on cluster
           </div>
         </div>
-        {/* Opens what the card opens: on a self-hosted install the cluster's runtimes, models and
-            MCP servers ARE what there is to manage — the console mints no cluster credentials. */}
-        <Button variant="secondary" size="sm" onClick={open}>
-          Manage
-        </Button>
       </div>
       <span
         className="badge flex-none max-desktop:px-[10px] max-desktop:py-[3px] max-desktop:text-[12px] desktop:hidden"


### PR DESCRIPTION
Opening the Infra cluster card landed on one member's daemon detail. A member is a Pod: it is named after the Pod, its id does not survive a rollout, and its CPU bar, version and agent list describe one replica while the card that opened it described the fleet. The page a self-hoster reached was therefore about something they cannot name, act on, or return to.

## What this adds

`/daemons/cluster` — the design's cluster detail, aggregated over the **serving** members:

- their summed agent ceiling and load, and their averaged CPU / memory
- the union of their runtimes and models (hover a runtime for its models)
- the agents placed on the pool, and the connections those agents hold

No member id appears anywhere on it. The design's mint/rotate-token action and its log tail are left out for the reasons the daemon detail page already left them out: the console mints no cluster credentials, and a fabricated log stream is indistinguishable from real telemetry.

## Two fixes to the card that opens it

- `maxAgents <= 0` is UNBOUNDED, so the capacity strip now reads `used / ∞ · no limit` instead of withholding itself. What an unbounded cluster is running is still worth reading — it is only the fraction that does not exist.
- The **Manage** button is gone: it opened exactly what clicking the card opens.

## Verification

`typecheck`, `eslint`, `prettier --check`, and the full web suite (151 files / 1615 tests) pass. New `ClusterDetailView.test.tsx` covers the aggregation, the ∞ ceiling, the absent token action and log tail, and the empty/loading states; `DaemonsView.pool.test.tsx` gains the ∞ strip, the missing Manage button, and the cluster-not-Pod navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)