### PR TITLE
fix(control-plane): let an agent enabling an org MCP provider move daemons

### DIFF
--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1098,7 +1098,8 @@ export function agentRoutes(deps: HttpDeps) {
 
     // Reflect an enable-list edit onto every daemon serving the agent (a duty holder installed
     // the same list and needs the same defs): provision the newly-enabled registry providers,
-    // retire the disabled ones that nobody there still uses.
+    // retire the disabled ones that nobody there still uses. Never throws — its callers have
+    // already committed the row, and a failed sync converges on the daemon's next register.
     const syncMcpDefsForAgent = async (
       agent: AgentRecord,
       before: readonly string[],
@@ -1107,10 +1108,14 @@ export function agentRoutes(deps: HttpDeps) {
       const added = after.filter((n) => !before.includes(n))
       const removed = before.filter((n) => !after.includes(n))
       if (added.length === 0 && removed.length === 0) return
-      const targets = await deps.agentDelivery.daemonsFor(agent)
-      if (targets.length === 0) return
-      await pushMcpDefs(await registryProvidersOf(agent.orgId, added), targets)
-      await dropMcpDefsIfUnused(agent.orgId, await registryProvidersOf(agent.orgId, removed), targets)
+      try {
+        const targets = await deps.agentDelivery.daemonsFor(agent)
+        if (targets.length === 0) return
+        await pushMcpDefs(await registryProvidersOf(agent.orgId, added), targets)
+        await dropMcpDefsIfUnused(agent.orgId, await registryProvidersOf(agent.orgId, removed), targets)
+      } catch (err) {
+        app.log.warn({ agentId: agent.id, err }, 'mcp def sync failed (reconcile will converge)')
+      }
     }
 
     // A caller may DISABLE a registry MCP provider they can't see (one already on the

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1096,6 +1096,56 @@ export function agentRoutes(deps: HttpDeps) {
       }
     }
 
+    /** The org MCP-registry rows an enable-list names, by name. A name with no row
+     *  is a daemon-local def (the operator's `config.json`) and is absent here. */
+    const registryProvidersOf = async (orgId: OrgId, names: readonly string[]) => {
+      const wanted = new Set(names)
+      const rows = wanted.size === 0 ? [] : await deps.repos.mcpProvider.listForOrg(orgId)
+      return new Map(rows.filter((p) => wanted.has(p.name)).map((p) => [p.name, p] as const))
+    }
+
+    /** Registry-before-agent ordering, the MCP twin of `pushExternalMemoryToDaemon`: a daemon must
+     *  hold the proxy def of every registry provider the agent enables before it applies the spec
+     *  that only NAMES them. Best-effort — `mcpserver/upsert` is an unacknowledged EVT. */
+    const pushMcpDefsToDaemon = async (agent: AgentRecord, daemonId: string): Promise<void> => {
+      try {
+        const providers = await registryProvidersOf(agent.orgId, agent.mcpServers)
+        if (providers.size === 0) return
+        const base = await relayProxyBase()
+        if (!base) return
+        for (const provider of providers.values()) {
+          const grant = currentMcpGrant(await deps.repos.mcpGrant.activeForProvider(provider.orgId, provider.id))
+          if (grant) await deps.control.mcpServerUpsert(daemonId, mcpProxyDef(provider, grant, base))
+        }
+      } catch {
+        // The def is grant-bearing; log stable identifiers only.
+        app.log.warn({ agentId: agent.id, daemonId }, 'mcp def staging failed (backstop: reconnect roster)')
+      }
+    }
+
+    /** Drop those registry defs from a daemon serving no agent that still enables them — the move's
+     *  source-side and abort-side cleanup. Usage is delivery-set membership, not placement. */
+    const removeMcpDefsFromDaemonIfUnused = async (
+      orgId: OrgId,
+      daemonId: string,
+      names: readonly string[]
+    ): Promise<void> => {
+      try {
+        const providers = await registryProvidersOf(orgId, names)
+        if (providers.size === 0) return
+        const peers = await deps.repos.agent.list(orgId)
+        for (const name of providers.keys()) {
+          const stillOn = new Set(
+            await deps.agentDelivery.daemonsForAgents(peers.filter((a) => a.mcpServers.includes(name)))
+          )
+          if (!stillOn.has(daemonId)) await deps.control.mcpServerRemove(daemonId, orgId, name)
+        }
+      } catch (err) {
+        // Offline/version-skewed daemon converges the full def set on reconnect.
+        app.log.warn({ daemonId, err }, 'mcp def removal deferred')
+      }
+    }
+
     // A caller may DISABLE a registry MCP provider they can't see (one already on the
     // agent), but may not ADD one back — the enable-list surface mirrors provider
     // visibility. Returns a 403 message for any newly-added name that resolves to a
@@ -2378,6 +2428,10 @@ export function agentRoutes(deps: HttpDeps) {
           ? placement.kind === 'set' && placement.setId === targetSetId
           : placement.kind === 'daemon' && placement.daemonId === req.body.daemonId
 
+        // Resolved once for every candidate: which enable-list names are org registry
+        // providers rather than daemon-local defs. See the facts check in `admits`.
+        const registryProviders = await registryProvidersOf(existing.orgId, existing.mcpServers)
+
         /** Why this daemon cannot take the agent, or null when it can. */
         const admits = async (daemon: DaemonView): Promise<string | null> => {
           if (!moveReady(daemon.daemonId)) return 'target daemon is not ready'
@@ -2413,13 +2467,19 @@ export function agentRoutes(deps: HttpDeps) {
             return `target daemon does not support model ${existing.model} for runtime ${existing.runtime}`
           }
           for (const name of existing.mcpServers) {
-            const server = daemon.mcpServers.find((candidate) => candidate.name === name)
-            if (!server) return `target daemon cannot attach MCP server ${name}`
+            // The CP pushes a registry def only to daemons already serving an enabling agent, so
+            // "the target holds no such fact yet" is not "it cannot attach it" — reading that as a
+            // refusal pinned every connector-using agent to its daemon (#1192). The move stages the
+            // def below and its transport is always the relay-proxied `http`; only a daemon-LOCAL
+            // name (the operator's `config.json`) is genuinely host-bound.
+            const transport =
+              daemon.mcpServers.find((candidate) => candidate.name === name)?.transport ??
+              (registryProviders.has(name) ? 'http' : undefined)
+            if (!transport) return `target daemon cannot attach MCP server ${name}`
             const caps = targetRuntime?.mcpCapabilities
-            const transportSupported =
-              server.transport === 'stdio' || !caps || (server.transport === 'http' ? caps.http : caps.sse)
+            const transportSupported = transport === 'stdio' || !caps || (transport === 'http' ? caps.http : caps.sse)
             if (!transportSupported) {
-              return `target runtime ${existing.runtime} does not support MCP ${server.transport} transport for ${name}`
+              return `target runtime ${existing.runtime} does not support MCP ${transport} transport for ${name}`
             }
           }
           // Capacity is a per-member fact even on a set: "some member has headroom" is exactly
@@ -2486,7 +2546,14 @@ export function agentRoutes(deps: HttpDeps) {
         // DELETE stays impossible throughout because this agent's committed
         // binding keeps its "no agent bound" scan refusing (409).
         let targetStaged = false
+        let mcpStaged = false
         try {
+          // Same registry-before-agent ordering for the MCP proxy defs: without it the target
+          // installs a spec naming providers it has no definition for, and every session it starts
+          // before the next reconcile runs without those tools. The cleanup obligation is marked
+          // before the send, because an unacknowledged EVT that threw may still have applied.
+          mcpStaged = registryProviders.size > 0
+          await pushMcpDefsToDaemon(existing, target.daemonId)
           // The connection registry is a separate private wire. Stage it before
           // agent/activate so target admission cannot observe a dangling binding.
           // This also repairs a target that committed the move but lost the reply.
@@ -2561,6 +2628,10 @@ export function agentRoutes(deps: HttpDeps) {
               existing.memory.connectionId
             )
           }
+          // The source serves the agent no longer, so it must not keep a grant-bearing def unused.
+          if (existing.daemonId && mcpStaged) {
+            await removeMcpDefsFromDaemonIfUnused(existing.orgId, existing.daemonId, existing.mcpServers)
+          }
           return toDto(
             moved,
             ctxOf(req),
@@ -2584,6 +2655,11 @@ export function agentRoutes(deps: HttpDeps) {
           // removes a definition whose ACK may merely have been lost.
           if (targetStaged && existing.memory?.provider === 'external') {
             await removeExternalMemoryFromDaemonIfUnused(existing.orgId, target.daemonId, existing.memory.connectionId)
+          }
+          // Same re-read for the staged MCP defs: an authoritative target keeps them, and a move
+          // that never committed leaves none behind.
+          if (mcpStaged) {
+            await removeMcpDefsFromDaemonIfUnused(existing.orgId, target.daemonId, existing.mcpServers)
           }
         }
       }

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -56,6 +56,7 @@ import {
   type AgentSkillSourceFence,
   type AgentWorkspace,
   type AssignedOrganizationMetadata,
+  type McpProviderRecord,
   isSyntheticEmail
 } from '../../persistence/ports.js'
 import type { DaemonView } from '../../ports.js'
@@ -1035,115 +1036,81 @@ export function agentRoutes(deps: HttpDeps) {
       return url ? relayHttpOrigin(url) : null
     }
 
-    // Reflect an agent's MCP enable-list change onto its daemon's proxy-def set: push
-    // the relay proxy def for each newly-enabled REGISTRY provider, and drop a def once
-    // no placed agent on that daemon still enables it. A registry provider's def (which
-    // carries the grant key + relay URL) reaches a daemon ONLY via provider CRUD or this
-    // transition — so without this, enabling an already-registered provider never
-    // provisions the def and the next session can't resolve the server (register/ok
-    // reconcile is the slow backstop). Names that aren't registry providers are
-    // daemon-local defs and left alone. Best-effort + never throws: an offline daemon
-    // (or transient error) is covered by the reconcile roster on its next register.
+    // A registry provider's def (grant key + relay proxy URL) reaches a daemon ONLY by CP push:
+    // provider CRUD, an enable-list edit, a move, or the register/ok reconcile as the slow
+    // backstop. The two primitives below are that push and its inverse; every caller is
+    // best-effort, because an offline daemon converges on its next register.
+    /** The org registry rows among these names. A name with no row is a daemon-local def
+     *  (the operator's `config.json`) — never pushed, never removed, and absent here. */
+    const registryProvidersOf = async (orgId: OrgId, names: readonly string[]) => {
+      const wanted = new Set(names)
+      const rows = wanted.size === 0 ? [] : await deps.repos.mcpProvider.listForOrg(orgId)
+      return rows.filter((p) => wanted.has(p.name))
+    }
+    // One daemon's send, never surfaced: offline is the reconcile backstop, and the error is not
+    // logged because a codec/transport error can retain the grant-bearing payload.
+    const sendMcp = async (daemonId: string, fn: () => Promise<void>) => {
+      try {
+        await fn()
+      } catch (err) {
+        if (!(err instanceof NoConnection)) app.log.warn({ daemonId }, 'mcp def send failed (reconcile will converge)')
+      }
+    }
+    /** Push each provider's proxy def to these daemons. Nothing to push without a live relay. */
+    const pushMcpDefs = async (providers: readonly McpProviderRecord[], daemonIds: readonly string[]) => {
+      if (providers.length === 0 || daemonIds.length === 0) return
+      try {
+        const base = await relayProxyBase()
+        if (!base) return
+        for (const provider of providers) {
+          const grant = currentMcpGrant(await deps.repos.mcpGrant.activeForProvider(provider.orgId, provider.id))
+          if (!grant) continue
+          const spec = mcpProxyDef(provider, grant, base)
+          for (const daemonId of daemonIds) await sendMcp(daemonId, () => deps.control.mcpServerUpsert(daemonId, spec))
+        }
+      } catch (err) {
+        app.log.warn({ err }, 'mcp def push failed (reconcile will converge)')
+      }
+    }
+    /** Drop each provider's def from those of these daemons that serve NO agent still enabling
+     *  it. "Still used" is delivery-set membership, not placement: a duty holder counts. */
+    const dropMcpDefsIfUnused = async (
+      orgId: OrgId,
+      providers: readonly McpProviderRecord[],
+      daemonIds: readonly string[]
+    ) => {
+      if (providers.length === 0 || daemonIds.length === 0) return
+      try {
+        const peers = await deps.repos.agent.list(orgId)
+        for (const { name } of providers) {
+          const stillOn = new Set(
+            await deps.agentDelivery.daemonsForAgents(peers.filter((a) => a.mcpServers.includes(name)))
+          )
+          for (const daemonId of daemonIds) {
+            if (!stillOn.has(daemonId))
+              await sendMcp(daemonId, () => deps.control.mcpServerRemove(daemonId, orgId, name))
+          }
+        }
+      } catch (err) {
+        app.log.warn({ err }, 'mcp def removal deferred (reconcile will converge)')
+      }
+    }
+
+    // Reflect an enable-list edit onto every daemon serving the agent (a duty holder installed
+    // the same list and needs the same defs): provision the newly-enabled registry providers,
+    // retire the disabled ones that nobody there still uses.
     const syncMcpDefsForAgent = async (
       agent: AgentRecord,
       before: readonly string[],
       after: readonly string[]
     ): Promise<void> => {
-      const orgId = agent.orgId
       const added = after.filter((n) => !before.includes(n))
       const removed = before.filter((n) => !after.includes(n))
       if (added.length === 0 && removed.length === 0) return
-      // Every daemon serving this agent, not just its placement: a duty holder
-      // installed the same enable-list and needs the same defs.
       const targets = await deps.agentDelivery.daemonsFor(agent)
       if (targets.length === 0) return
-      try {
-        const byName = new Map((await deps.repos.mcpProvider.listForOrg(orgId)).map((p) => [p.name, p]))
-        const send = async (fn: () => Promise<void>) => {
-          try {
-            await fn()
-          } catch (err) {
-            if (!(err instanceof NoConnection)) throw err // offline ⇒ reconcile backstop
-          }
-        }
-        if (added.some((n) => byName.has(n))) {
-          const base = await relayProxyBase()
-          for (const name of added) {
-            const provider = base ? byName.get(name) : undefined
-            if (!provider) continue
-            const grant = currentMcpGrant(await deps.repos.mcpGrant.activeForProvider(provider.orgId, provider.id))
-            if (!grant) continue
-            const spec = mcpProxyDef(provider, grant, base!)
-            for (const daemonId of targets) await send(() => deps.control.mcpServerUpsert(daemonId, spec))
-          }
-        }
-        if (removed.some((n) => byName.has(n))) {
-          const peers = await deps.repos.agent.list(orgId)
-          for (const name of removed) {
-            if (!byName.has(name)) continue
-            // "Still used" is delivery-set membership, not placement: a target that
-            // serves any other agent enabling the name keeps the def.
-            const stillOn = new Set(
-              await deps.agentDelivery.daemonsForAgents(peers.filter((a) => a.mcpServers.includes(name)))
-            )
-            for (const daemonId of targets) {
-              if (!stillOn.has(daemonId)) await send(() => deps.control.mcpServerRemove(daemonId, orgId, name))
-            }
-          }
-        }
-      } catch (err) {
-        app.log.warn({ agentId: agent.id, err }, 'mcp def sync failed (reconcile will converge)')
-      }
-    }
-
-    /** The org MCP-registry rows an enable-list names, by name. A name with no row
-     *  is a daemon-local def (the operator's `config.json`) and is absent here. */
-    const registryProvidersOf = async (orgId: OrgId, names: readonly string[]) => {
-      const wanted = new Set(names)
-      const rows = wanted.size === 0 ? [] : await deps.repos.mcpProvider.listForOrg(orgId)
-      return new Map(rows.filter((p) => wanted.has(p.name)).map((p) => [p.name, p] as const))
-    }
-
-    /** Registry-before-agent ordering, the MCP twin of `pushExternalMemoryToDaemon`: a daemon must
-     *  hold the proxy def of every registry provider the agent enables before it applies the spec
-     *  that only NAMES them. Best-effort — `mcpserver/upsert` is an unacknowledged EVT. */
-    const pushMcpDefsToDaemon = async (agent: AgentRecord, daemonId: string): Promise<void> => {
-      try {
-        const providers = await registryProvidersOf(agent.orgId, agent.mcpServers)
-        if (providers.size === 0) return
-        const base = await relayProxyBase()
-        if (!base) return
-        for (const provider of providers.values()) {
-          const grant = currentMcpGrant(await deps.repos.mcpGrant.activeForProvider(provider.orgId, provider.id))
-          if (grant) await deps.control.mcpServerUpsert(daemonId, mcpProxyDef(provider, grant, base))
-        }
-      } catch {
-        // The def is grant-bearing; log stable identifiers only.
-        app.log.warn({ agentId: agent.id, daemonId }, 'mcp def staging failed (backstop: reconnect roster)')
-      }
-    }
-
-    /** Drop those registry defs from a daemon serving no agent that still enables them — the move's
-     *  source-side and abort-side cleanup. Usage is delivery-set membership, not placement. */
-    const removeMcpDefsFromDaemonIfUnused = async (
-      orgId: OrgId,
-      daemonId: string,
-      names: readonly string[]
-    ): Promise<void> => {
-      try {
-        const providers = await registryProvidersOf(orgId, names)
-        if (providers.size === 0) return
-        const peers = await deps.repos.agent.list(orgId)
-        for (const name of providers.keys()) {
-          const stillOn = new Set(
-            await deps.agentDelivery.daemonsForAgents(peers.filter((a) => a.mcpServers.includes(name)))
-          )
-          if (!stillOn.has(daemonId)) await deps.control.mcpServerRemove(daemonId, orgId, name)
-        }
-      } catch (err) {
-        // Offline/version-skewed daemon converges the full def set on reconnect.
-        app.log.warn({ daemonId, err }, 'mcp def removal deferred')
-      }
+      await pushMcpDefs(await registryProvidersOf(agent.orgId, added), targets)
+      await dropMcpDefsIfUnused(agent.orgId, await registryProvidersOf(agent.orgId, removed), targets)
     }
 
     // A caller may DISABLE a registry MCP provider they can't see (one already on the
@@ -2428,9 +2395,10 @@ export function agentRoutes(deps: HttpDeps) {
           ? placement.kind === 'set' && placement.setId === targetSetId
           : placement.kind === 'daemon' && placement.daemonId === req.body.daemonId
 
-        // Resolved once for every candidate: which enable-list names are org registry
-        // providers rather than daemon-local defs. See the facts check in `admits`.
+        // The org registry rows the agent enables — read once for every candidate's facts check
+        // below, then staged on the target.
         const registryProviders = await registryProvidersOf(existing.orgId, existing.mcpServers)
+        const registryTransport = new Map(registryProviders.map((p) => [p.name, p.transport] as const))
 
         /** Why this daemon cannot take the agent, or null when it can. */
         const admits = async (daemon: DaemonView): Promise<string | null> => {
@@ -2470,11 +2438,9 @@ export function agentRoutes(deps: HttpDeps) {
             // The CP pushes a registry def only to daemons already serving an enabling agent, so
             // "the target holds no such fact yet" is not "it cannot attach it" — reading that as a
             // refusal pinned every connector-using agent to its daemon (#1192). The move stages the
-            // def below and its transport is always the relay-proxied `http`; only a daemon-LOCAL
-            // name (the operator's `config.json`) is genuinely host-bound.
+            // def; only a daemon-LOCAL name (the operator's `config.json`) is genuinely host-bound.
             const transport =
-              daemon.mcpServers.find((candidate) => candidate.name === name)?.transport ??
-              (registryProviders.has(name) ? 'http' : undefined)
+              daemon.mcpServers.find((candidate) => candidate.name === name)?.transport ?? registryTransport.get(name)
             if (!transport) return `target daemon cannot attach MCP server ${name}`
             const caps = targetRuntime?.mcpCapabilities
             const transportSupported = transport === 'stdio' || !caps || (transport === 'http' ? caps.http : caps.sse)
@@ -2546,14 +2512,11 @@ export function agentRoutes(deps: HttpDeps) {
         // DELETE stays impossible throughout because this agent's committed
         // binding keeps its "no agent bound" scan refusing (409).
         let targetStaged = false
-        let mcpStaged = false
         try {
-          // Same registry-before-agent ordering for the MCP proxy defs: without it the target
-          // installs a spec naming providers it has no definition for, and every session it starts
-          // before the next reconcile runs without those tools. The cleanup obligation is marked
-          // before the send, because an unacknowledged EVT that threw may still have applied.
-          mcpStaged = registryProviders.size > 0
-          await pushMcpDefsToDaemon(existing, target.daemonId)
+          // Registry-before-agent for the MCP defs too: the target refuses `agent/activate` for a
+          // name it holds no def for, and a registry def reaches it only by CP push. An EVT with
+          // no ACK — if it did not land, that activation refusal is the failure.
+          await pushMcpDefs(registryProviders, [target.daemonId])
           // The connection registry is a separate private wire. Stage it before
           // agent/activate so target admission cannot observe a dangling binding.
           // This also repairs a target that committed the move but lost the reply.
@@ -2628,10 +2591,7 @@ export function agentRoutes(deps: HttpDeps) {
               existing.memory.connectionId
             )
           }
-          // The source serves the agent no longer, so it must not keep a grant-bearing def unused.
-          if (existing.daemonId && mcpStaged) {
-            await removeMcpDefsFromDaemonIfUnused(existing.orgId, existing.daemonId, existing.mcpServers)
-          }
+          if (existing.daemonId) await dropMcpDefsIfUnused(existing.orgId, registryProviders, [existing.daemonId])
           return toDto(
             moved,
             ctxOf(req),
@@ -2656,11 +2616,8 @@ export function agentRoutes(deps: HttpDeps) {
           if (targetStaged && existing.memory?.provider === 'external') {
             await removeExternalMemoryFromDaemonIfUnused(existing.orgId, target.daemonId, existing.memory.connectionId)
           }
-          // Same re-read for the staged MCP defs: an authoritative target keeps them, and a move
-          // that never committed leaves none behind.
-          if (mcpStaged) {
-            await removeMcpDefsFromDaemonIfUnused(existing.orgId, target.daemonId, existing.mcpServers)
-          }
+          // Same usage re-read for the staged MCP defs: an authoritative target keeps them.
+          await dropMcpDefsIfUnused(existing.orgId, registryProviders, [target.daemonId])
         }
       }
     )

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
-import type { Ack, AgentActivate, AgentDetach, MemoryConnectionSpec } from '@agentconnect.md/protocol'
+import type { Ack, AgentActivate, AgentDetach, McpServerSpec, MemoryConnectionSpec } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
@@ -40,6 +40,7 @@ class MoveControlSpy {
    *  that asserts it was RELEASED has to compare the tokens, not just the call order. */
   readonly detaches: { daemonId: string; value: AgentDetach }[] = []
   readonly activateCalls: { daemonId: string; value: AgentActivate }[] = []
+  readonly mcpUpserts: { daemonId: string; spec: McpServerSpec }[] = []
 
   async agentDetach(daemonId: string, value: AgentDetach): Promise<Ack> {
     this.calls.push(`detach:${daemonId}`)
@@ -59,6 +60,13 @@ class MoveControlSpy {
   }
   async memoryConnectionRemove(daemonId: string, connectionId: string): Promise<void> {
     this.calls.push(`memory-remove:${daemonId}:${connectionId}`)
+  }
+  async mcpServerUpsert(daemonId: string, spec: McpServerSpec): Promise<void> {
+    this.calls.push(`mcp-upsert:${daemonId}:${spec.name}`)
+    this.mcpUpserts.push({ daemonId, spec })
+  }
+  async mcpServerRemove(daemonId: string, _orgId: string, name: string): Promise<void> {
+    this.calls.push(`mcp-remove:${daemonId}:${name}`)
   }
 }
 
@@ -266,6 +274,73 @@ describe('PUT /agents/:id/daemon', () => {
       provider: 'external',
       connectionId: connection.id
     })
+  })
+
+  it('stages an org MCP provider on a target that never held its def, and cleans up either way', async () => {
+    await seedMoveDaemons()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: SOURCE })
+    const control = new MoveControlSpy()
+    running = buildHttpApp(prisma, { RELAY_STALE_MS: 60_000 }, live, control as unknown as ControlSender)
+    await running.deps.repos.relay.upsertByName('move-relay', 'wss://relay.example/rd', new Date())
+    const provider = await running.deps.repos.mcpProvider.create({
+      orgId: OrgId(DEFAULT_ORG_ID),
+      name: 'grafana-viewer',
+      url: 'https://grafana.example/mcp'
+    })
+    const grant = await running.deps.repos.mcpGrant.mintFor(OrgId(DEFAULT_ORG_ID), provider.id)
+    await prisma.agent.update({
+      where: { id: agentId },
+      data: { runtimeOverrides: { mcpServers: [provider.name] } }
+    })
+    // The target hosts no agent enabling the provider, so the CP has never pushed it
+    // the def — the state that used to make the move unreachable (#1192).
+    expect((await prisma.daemon.findUnique({ where: { id: TARGET } }))?.mcpServers).toEqual([])
+
+    // An aborted move leaves the target holding nothing it has no use for.
+    control.failSourceDetach = true
+    const failed = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { daemonId: TARGET }
+    })
+    expect(failed.statusCode).toBe(503)
+    // The revoke rides the handler's `finally`, which outlives the sent response.
+    await vi.waitFor(() =>
+      expect(control.calls).toEqual([
+        `mcp-upsert:${TARGET}:${provider.name}`,
+        `detach:${SOURCE}`,
+        `mcp-remove:${TARGET}:${provider.name}`
+      ])
+    )
+    expect((await prisma.agent.findUnique({ where: { id: agentId } }))?.daemonId).toBe(SOURCE)
+
+    control.failSourceDetach = false
+    control.calls.length = 0
+    const res = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { daemonId: TARGET }
+    })
+    expect(res.statusCode, res.body).toBe(200)
+    // Staged BEFORE activation, and the source loses a grant-bearing def it no
+    // longer serves any agent for — while the target, now authoritative, keeps
+    // the def the same post-response usage re-read looks at.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(control.calls).toEqual([
+      `mcp-upsert:${TARGET}:${provider.name}`,
+      `detach:${SOURCE}`,
+      `detach:${TARGET}`,
+      `activate:${TARGET}`,
+      `mcp-remove:${SOURCE}:${provider.name}`
+    ])
+    expect(control.mcpUpserts[0]?.spec).toMatchObject({
+      name: provider.name,
+      transport: 'http',
+      url: `https://relay.example/mcp/${provider.id}`,
+      headers: [{ name: 'Authorization', value: `Bearer ${grant.key}` }]
+    })
+    expect(control.activations.at(-1)?.spec.mcpServers).toEqual([provider.name])
   })
 
   it('rejects an unready, unsupported, incompatible, or full target before detaching source', async () => {


### PR DESCRIPTION
Fixes #1192.

## The chicken-and-egg

Move admission required the **target daemon's registered facts** to already list every name in the agent's `mcpServers` enable-list:

```ts
const server = daemon.mcpServers.find((candidate) => candidate.name === name)
if (!server) return `target daemon cannot attach MCP server ${name}`
```

That is the right gate for a **daemon-local** def — an operator's stdio command or private URL in `config.json` is genuinely host-bound. It is the wrong gate for an **org registry provider**, whose definition is a relay-proxied `http` def the CP itself delivers, and delivers only to daemons that already serve an enabling agent (`syncMcpDefsForAgent`, `daemonsEnabling`, `desiredMcpServers`). The target could never hold the def before the move, and the move refused because it did not hold it — so any agent using an org connector was pinned to its current daemon.

## The fix

**Admission** resolves a name the target has no fact for against the org registry: a row means the def is CP-deliverable, so the name is admitted and the row's transport is validated against the target runtime's `mcpCapabilities`. A name with no row is daemon-local and keeps the 409 exactly as before.

**Staging** is not optional on top of that: the daemon's `agent/activate` refuses a spec naming an MCP server it has no def for (`MCP server "x" is not configured on this daemon`), so the def has to be on the target *before* activation — the same reason the handler already stages external memory first. The move pushes the registry defs to the target before `agent/activate`; cleanup rides the same usage re-read as the memory path, so an aborted move leaves nothing behind on the target and a committed one drops the grant-bearing def from a source that no longer serves any agent enabling it.

The push and its inverse are the two branches `syncMcpDefsForAgent` already had inline; they are extracted as `pushMcpDefs` / `dropMcpDefsIfUnused` and shared, so the enable-list edit and the move drive the same pair. Nothing about the move service or the wire changes. Pool/set targets were already covered from the other direction — `duty/fetch` builds its bundle from the shared projector, which carries both definition kinds.

## Test

One integration case in `agents.move.route.test.ts` reproduces the issue's setup — an agent enabling an org provider, a target daemon whose facts are empty — and asserts the def is staged before `activate:TARGET`, that an aborted move revokes it from the target, and that a committed one revokes it from the source. The existing "unready, unsupported, incompatible, or full target" case still asserts the 409 for a name with no registry row.

`test:unit` (1778) and `test:int` (1455) pass.
