### PR TITLE
fix(daemon): the mcp-bridge exits with its harness instead of stranding itself

### DIFF
--- a/packages/daemon/src/mcp/bridge.ts
+++ b/packages/daemon/src/mcp/bridge.ts
@@ -18,6 +18,8 @@ class IpcClient {
   private pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>()
   private buf = ''
   private ready: Promise<void>
+  /** Installed once the bridge serves stdio; a closed control socket then ends the process. */
+  onClose?: () => void
 
   constructor(
     endpoint: string,
@@ -44,6 +46,7 @@ class IpcClient {
     this.socket.on('close', () => {
       for (const p of this.pending.values()) p.reject(new Error('daemon connection closed'))
       this.pending.clear()
+      this.onClose?.()
     })
   }
 
@@ -121,6 +124,16 @@ export async function runBridge(opts: { lazyTools?: boolean } = {}): Promise<voi
       return { content: [{ type: 'text', text: (err as Error).message }], isError: true }
     }
   })
+
+  // Nothing else settles a request queued after the socket died, so a call would hang forever.
+  ipc.onClose = () => {
+    process.stderr.write('mcp-bridge: daemon control socket closed, exiting\n')
+    process.exit(1)
+  }
+  // stdin EOF means the harness is gone; the stdio transport never watches for it, so the live socket would strand us.
+  const exitWhenHarnessGone = (): void => process.exit(0)
+  process.stdin.on('end', exitWhenHarnessGone)
+  process.stdin.on('close', exitWhenHarnessGone)
 
   await server.connect(new StdioServerTransport())
 }

--- a/packages/daemon/test/mcp-bridge-e2e.test.ts
+++ b/packages/daemon/test/mcp-bridge-e2e.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, realpathSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve, sep } from 'node:path'
 import net from 'node:net'
+import { spawn, type ChildProcess } from 'node:child_process'
 import { Client } from '@modelcontextprotocol/client'
 import { StdioClientTransport } from '@modelcontextprotocol/client/stdio'
 import { McpControlServer } from '../src/mcp/control-server.js'
@@ -25,6 +26,7 @@ const tools = toolsForIntegrations(
 let server: McpControlServer | undefined
 let privateServer: net.Server | undefined
 const privateSockets = new Set<net.Socket>()
+const bridges = new Set<ChildProcess>()
 const tempRoots: string[] = []
 let client: Client | undefined
 function tempRoot(prefix: string): string {
@@ -37,6 +39,8 @@ function tempRoot(prefix: string): string {
 }
 
 afterEach(async () => {
+  for (const bridge of bridges) if (bridge.exitCode === null) bridge.kill('SIGKILL')
+  bridges.clear()
   await client?.close().catch(() => {})
   await server?.stop()
   for (const socket of privateSockets) socket.destroy()
@@ -264,4 +268,72 @@ describe('mcp-bridge end-to-end (real stdio MCP handshake)', () => {
       })
     )
   }, 20_000)
+
+  // A bridge that outlives its harness holds ~230 MB of RSS per session for the daemon's
+  // lifetime (#936), so both ends of its lifetime have to terminate the process.
+  describe('lifetime', () => {
+    // Answers listTools so the bridge reaches its serving state, and reports when it got there.
+    async function serveBridge(socketPath: string): Promise<{ listed: Promise<void> }> {
+      let observeList!: () => void
+      const listed = new Promise<void>((resolve) => (observeList = resolve))
+      privateServer = net.createServer((socket) => {
+        privateSockets.add(socket)
+        socket.setEncoding('utf8')
+        let buffer = ''
+        socket.on('close', () => privateSockets.delete(socket))
+        socket.on('data', (chunk: string) => {
+          buffer += chunk
+          const decoded = decodeFrames<IpcPrivateRequest>(buffer)
+          buffer = decoded.rest
+          for (const request of decoded.messages) {
+            socket.write(encodeFrame({ id: request.id, ok: true, result: { tools: [] } }))
+            observeList()
+          }
+        })
+      })
+      await new Promise<void>((resolve, reject) => {
+        privateServer!.once('error', reject)
+        privateServer!.listen(socketPath, resolve)
+      })
+      return { listed }
+    }
+
+    // Spawned the way an agent harness does — stdio pipes we own, so we can close stdin.
+    function spawnBridge(socketPath: string): ChildProcess {
+      const child = spawn(
+        process.execPath,
+        ['--conditions', 'development', '--import', 'tsx', cliEntry, 'mcp-bridge'],
+        {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: { ...process.env, AC_MCP_ENDPOINT: socketPath, AC_MCP_TOKEN: 'lifetime-token' }
+        }
+      )
+      bridges.add(child)
+      return child
+    }
+
+    function exitOf(child: ChildProcess): Promise<number | null> {
+      return new Promise((resolve) => child.once('exit', (code) => resolve(code)))
+    }
+
+    it('exits when the harness closes its stdin', async () => {
+      const path = join(tempRoot('ac-bridge-stdin-'), 'mcp.sock')
+      const { listed } = await serveBridge(path)
+      const bridge = spawnBridge(path)
+      await listed
+      // What a dying harness does to the bridge: EOF on stdin, control socket still live.
+      bridge.stdin!.end()
+      await expect(exitOf(bridge)).resolves.toBe(0)
+    }, 20_000)
+
+    it('exits when the daemon control socket closes', async () => {
+      const path = join(tempRoot('ac-bridge-socket-'), 'mcp.sock')
+      const { listed } = await serveBridge(path)
+      const bridge = spawnBridge(path)
+      await listed
+      // stdin stays open here: only the daemon went away, as on a daemon restart.
+      for (const socket of privateSockets) socket.destroy()
+      await expect(exitOf(bridge)).resolves.toBe(1)
+    }, 20_000)
+  })
 })


### PR DESCRIPTION
## What was wrong

A bridge spawned for one ACP session outlived the harness that spawned it. `StdioServerTransport` never watches stdin for EOF, so nothing in the bridge observed the harness going away, and its live control socket kept the process in the event loop for the rest of the daemon's lifetime. Sessions accumulated one orphan apiece, ~230 MB RSS each, reclaimed only by killing them by hand.

Reproduced locally: spawn the real `mcp-bridge`, let the parent exit, and the process stays resident indefinitely with the socket as its only remaining handle.

## The fix

Two exit paths, installed before the transport starts reading stdin:

- **stdin EOF ends the process.** This is the leak itself — the harness is gone, so the bridge has no reason to exist.
- **A closed control socket ends it too.** This also settles what was otherwise an unsettleable hang: only the socket's `close` handler ever rejects pending requests, so a call queued after it had already fired waited forever.

`unref()`-ing the socket instead would be wrong, and I checked rather than assuming: before the transport starts reading stdin the socket is the only thing holding the loop, so an unref'd bridge exits mid-handshake whenever the daemon does not answer instantly (verified with a control server that delays its reply — the bridge dies before it gets the tool list).

## Tests

A new `lifetime` block in the bridge e2e file spawns the real bridge and drives each end of its lifetime separately: closing stdin with the socket still live (expects exit 0), and destroying the socket with stdin still open (expects exit 1). Both time out against the unfixed bridge.

Full daemon suite: 3906 passed. The 15 failures are pre-existing on this machine — the same files fail identically on the base commit (sandbox-exec permissions and a runtime quota).

Fixes #936
