### PR TITLE
refactor(daemon): lift the k8s plane's closure state into two classes

### DIFF
--- a/packages/daemon/src/k8s/channel-loss-watcher.ts
+++ b/packages/daemon/src/k8s/channel-loss-watcher.ts
@@ -1,0 +1,139 @@
+import type { SandboxReadiness } from './driver.js'
+
+/** How long a pod that is UP may go without a shim channel before the launch counts as lost. */
+export const DEFAULT_REBIND_GRACE_MS = 20_000
+
+/** One agent's pending loss decision: why the channel dropped, and how long the pod may take. */
+interface LossWatch {
+  reason: string
+  timer?: NodeJS.Timeout
+  /** Set once the pod has been observed coming up, so its arrival restarts the grace window. */
+  podWasStarting: boolean
+  /** When an unbound channel becomes a loss whatever the pod is doing. */
+  ceiling: number
+}
+
+export interface ChannelLossWatcherDeps {
+  /** Whether the pod that should hold this agent's channel is up. */
+  sandboxReadiness: (agentId: string, opts: { signal?: AbortSignal }) => Promise<SandboxReadiness>
+  /** Live shim channels for the agent — a non-empty list means a replacement has bound. */
+  connectionsFor: (agentId: string) => readonly unknown[]
+  /** Ceiling contribution: how long a pod may take to come up at all. Read per watch, because the
+   *  driver exposes it as a getter and the plane builds this watcher before the driver exists. */
+  podUpTimeoutMs: () => number
+  /** How long a pod that is up may go without a shim channel before the launch counts as lost. */
+  rebindGraceMs?: number
+  onChannelLost: (agentId: string, reason: string) => void
+  now?: () => number
+  log?: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
+}
+
+/**
+ * The grace window between a shim socket closing and its launch being declared lost.
+ *
+ * A closed socket is not a lost launch; renewals reconnect underneath the logical session. Loss is
+ * reported only if no replacement binds for the same launch within the window — and the window is
+ * measured from the right event: time spent waiting for a pod that is still coming up is waited
+ * out rather than counted, with `podUpTimeoutMs` as the ceiling that decides in the end.
+ */
+export class ChannelLossWatcher {
+  private readonly watches = new Map<string, LossWatch>()
+  private readonly graceMs: number
+  /** How often to re-read a pod that is still coming up. Deliberately well under the grace: this
+   *  is a wait for an event, not a window being spent, and the pod's arrival restarts the window. */
+  private readonly podUpPollMs: number
+
+  constructor(private readonly deps: ChannelLossWatcherDeps) {
+    this.graceMs = deps.rebindGraceMs ?? DEFAULT_REBIND_GRACE_MS
+    this.podUpPollMs = Math.max(1, Math.min(2_000, Math.floor(this.graceMs / 4)))
+  }
+
+  private now(): number {
+    return this.deps.now?.() ?? Date.now()
+  }
+
+  /**
+   * Start the grace window for a channel that dropped, measured from the right event.
+   *
+   * The window is for a pod that IS up and whose shim has not come back. While the pod is still
+   * coming up nothing can dial it at all — a cold start pays PVC provisioning and an image pull —
+   * so that time is waited out rather than counted, and the window restarts once the pod is Ready.
+   */
+  schedule(agentId: string, reason: string): void {
+    this.cancel(agentId)
+    const watch: LossWatch = {
+      reason,
+      podWasStarting: false,
+      ceiling: this.now() + this.deps.podUpTimeoutMs() + this.graceMs
+    }
+    this.watches.set(agentId, watch)
+    this.arm(agentId, watch, this.graceMs)
+  }
+
+  cancel(agentId: string): void {
+    const watch = this.watches.get(agentId)
+    if (!watch) return
+    clearTimeout(watch.timer)
+    this.watches.delete(agentId)
+  }
+
+  /** Drop every pending decision — nobody waits on a loss once the plane is going down. */
+  cancelAll(): void {
+    for (const agentId of [...this.watches.keys()]) this.cancel(agentId)
+  }
+
+  private arm(agentId: string, watch: LossWatch, delayMs: number): void {
+    watch.timer = setTimeout(() => void this.run(agentId, watch), delayMs)
+    watch.timer.unref?.()
+  }
+
+  /** True while this watch is still the current one and nothing has rebound underneath it. */
+  private stillOpen(agentId: string, watch: LossWatch): boolean {
+    if (this.watches.get(agentId) !== watch) return false
+    if (this.deps.connectionsFor(agentId).length === 0) return true
+    this.cancel(agentId)
+    return false
+  }
+
+  private async run(agentId: string, watch: LossWatch): Promise<void> {
+    if (!this.stillOpen(agentId, watch)) return
+    // The read itself is bounded by what is LEFT of the ceiling, and by nothing else. The API
+    // server has no request deadline of its own, so a read that is accepted and never answered
+    // would hold this decision open forever — the launch stuck, its host dead, and nothing to
+    // rebuild it: the outcome this whole window exists to remove.
+    const remainingMs = watch.ceiling - this.now()
+    const readiness =
+      remainingMs <= 0
+        ? ('absent' as const)
+        : await this.deps
+            .sandboxReadiness(agentId, { signal: AbortSignal.timeout(remainingMs) })
+            .catch((err: unknown) => {
+              // An unreadable Sandbox proves nothing about the pod, so it counts as still coming
+              // up — and the ceiling below, which the abort cannot outlive, decides in the end.
+              this.deps.log?.warn(`k8s: could not read the sandbox for agent ${agentId} — ${(err as Error).message}`)
+              return 'starting' as const
+            })
+    // Re-checked after the round trip: a replacement may have bound, or the agent gone away.
+    if (!this.stillOpen(agentId, watch)) return
+    if (this.now() < watch.ceiling) {
+      if (readiness === 'starting') {
+        watch.podWasStarting = true
+        this.deps.log?.debug?.(`k8s: agent ${agentId} has no shim channel yet — its sandbox pod is still coming up`)
+        this.arm(agentId, watch, this.podUpPollMs)
+        return
+      }
+      // The pod has just come up, so its shim gets the whole grace window to dial in — the clock
+      // starts here rather than at a socket that dropped while there was no pod to dial at all.
+      if (readiness === 'ready' && watch.podWasStarting) {
+        watch.podWasStarting = false
+        this.arm(agentId, watch, this.graceMs)
+        return
+      }
+    }
+    this.watches.delete(agentId)
+    this.deps.log?.warn(
+      `k8s: no shim channel for agent ${agentId} after ${this.graceMs}ms with its pod ${readiness} — reporting loss`
+    )
+    this.deps.onChannelLost(agentId, watch.reason)
+  }
+}

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -5,15 +5,15 @@ import { PROBE_CLAIM_EXPIRES_ANNOTATION, PROBE_CLAIM_LABEL, PROBE_CLAIM_TTL_MS, 
 import { clusterMetrics } from '../metrics/cluster-metrics.js'
 import { ShimDialer } from '../shim/dialer.js'
 import { ShimGitRunner } from '../shim/git-exec.js'
-import { TunnelProxy } from '../shim/tunnel-proxy.js'
 import { ShimFileSink } from '../shim/channels.js'
+import { ChannelLossWatcher } from './channel-loss-watcher.js'
+import { TunnelBinder } from './tunnel-binder.js'
 import { ShimWorkspaceFiles } from '../shim/workspace-files-channel.js'
 import { ShimMemoryFs } from '../shim/memory-fs-channel.js'
 import type { WorkspaceFiles } from '../workspace/workspace-files.js'
 import type { MemoryFs } from '../memory/fs.js'
 import { DEFAULT_SHIM_LISTEN_PORT, DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
 import type { TunnelName } from '../shim/tunnel.js'
-import type { ShimSession } from '../shim/session.js'
 import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-runtimes.js'
 import type { GitRunner } from '../workspace/git-runner.js'
 
@@ -21,19 +21,6 @@ const SILENT = { info: () => {}, warn: () => {} }
 
 /** A probe drives every runtime through `initialize` plus a session, on a possibly cold pod. */
 const PROBE_TIMEOUT_MS = 180_000
-
-/** How long a pod that is UP may go without a shim channel before the launch counts as lost. */
-const DEFAULT_REBIND_GRACE_MS = 20_000
-
-/** One agent's pending loss decision: why the channel dropped, and how long the pod may take. */
-interface LossWatch {
-  reason: string
-  timer?: NodeJS.Timeout
-  /** Set once the pod has been observed coming up, so its arrival restarts the grace window. */
-  podWasStarting: boolean
-  /** When an unbound channel becomes a loss whatever the pod is doing. */
-  ceiling: number
-}
 
 /**
  * Assembles the k8s execution plane: the shim dialer, the driver, and the seams that make an
@@ -186,13 +173,29 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       return new SandboxApi(new K8sHttp(config), settings.sandboxNamespace)
     })()
 
+  // Built before the dialer and the driver because both wire into them; their deps read the driver
+  // lazily, which is what lets the three refer to each other without an ordering problem.
+  const lossWatcher = new ChannelLossWatcher({
+    sandboxReadiness: (agentId, opts) => driver.sandboxReadiness(agentId, opts),
+    connectionsFor: (agentId) => dialer.connectionsFor(agentId),
+    podUpTimeoutMs: () => driver.podUpTimeoutMs,
+    onChannelLost: (agentId, reason) => driver.onChannelLost(agentId, reason),
+    ...(options.rebindGraceMs === undefined ? {} : { rebindGraceMs: options.rebindGraceMs }),
+    log: options.log ?? SILENT
+  })
+  const tunnels = new TunnelBinder({
+    ...(options.tunnelsFor === undefined ? {} : { tunnelsFor: options.tunnelsFor }),
+    ...(options.tunnelSocketPath === undefined ? {} : { tunnelSocketPath: options.tunnelSocketPath }),
+    log: options.log ?? SILENT
+  })
+
   const dialer = new ShimDialer({
     verifier: { reviewToken: (token, audiences) => api.reviewToken(token, audiences) },
     now: () => Date.now(),
     metrics: clusterMetrics,
     onConnection: (connection) => {
       // A rebind cancels any pending loss check: this IS the replacement it was waiting for.
-      cancelLossCheck(connection.binding.agentId)
+      lossWatcher.cancel(connection.binding.agentId)
       driver.onChannelBound(connection)
       options.onSandboxBound?.(connection.binding.agentId)
     },
@@ -200,45 +203,13 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     // `ShimSession.lose()` is terminal — reporting loss here killed the runtime on every
     // routine renewal, which is the exact failure ShimSession exists to prevent. Loss is reported
     // only if no replacement binds for the same launch within the grace window.
-    onConnectionLost: (agentId, reason) => scheduleLossCheck(agentId, reason),
+    onConnectionLost: (agentId, reason) => lossWatcher.schedule(agentId, reason),
     ...(options.credentialTtlMs === undefined ? {} : { credentialTtlMs: options.credentialTtlMs }),
     log: options.log ?? SILENT
   })
   // The one condition that means "this agent's work happens in a pod". Defined once because two
   // callers must agree on it: the git runner, and the credential pointers that git will read.
   const runsInSandbox = (agentId: string): boolean => driver.sessionFor(agentId)?.isAttached() === true
-
-  // One proxy per agent, replaced when a NEW launch binds: its streams belong to a pod, and a
-  // proxy kept across incarnations would answer connections for a sandbox that no longer exists.
-  const proxies = new Map<string, { generation: number; proxy: TunnelProxy }>()
-
-  async function ensureTunnels(agentId: string, session: ShimSession): Promise<void> {
-    const wanted = options.tunnelsFor?.(agentId) ?? []
-    const socketPathFor = options.tunnelSocketPath
-    if (wanted.length === 0 || !socketPathFor) return
-    const existing = proxies.get(agentId)
-    // Stopped counts as gone: a proxy whose session was lost can never serve again, and reusing
-    // one would leave the sandbox with a socket whose daemon end refuses every connection.
-    if (existing && (existing.generation !== session.generation || existing.proxy.isStopped())) {
-      existing.proxy.stop(`superseded by generation ${session.generation}`)
-      proxies.delete(agentId)
-    }
-    let entry = proxies.get(agentId)
-    if (!entry) {
-      entry = {
-        generation: session.generation,
-        proxy: new TunnelProxy({ session, socketPathFor, log: options.log ?? SILENT })
-      }
-      proxies.set(agentId, entry)
-    }
-    // Sequential rather than concurrent: this is on the launch path, the list has two members at
-    // most, and one failing tunnel must not lose the report of the other.
-    for (const tunnel of wanted) {
-      await entry.proxy.ensure(tunnel).catch((err: unknown) => {
-        options.log?.warn(`k8s: agent ${agentId} has no ${tunnel} tunnel — ${(err as Error).message}`)
-      })
-    }
-  }
 
   const runtimeProbeAgentId = probeAgentId(settings.memberId)
   const driver = new K8sDriver({
@@ -256,7 +227,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
             }
           }
         : undefined,
-    onChannelReady: ensureTunnels,
+    onChannelReady: (agentId, session) => tunnels.ensure(agentId, session),
     connectChannel: (record, podIp, timeoutMs) =>
       dialer.connect(shimEndpoint(podIp, settings.shimPort), record, timeoutMs),
     revokeChannel: (agentId) => dialer.revokeAgent(agentId),
@@ -265,93 +236,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     log: options.log ?? SILENT
   })
 
-  // A renewal reconnects immediately, so a
-  // replacement that has not arrived well inside the request deadline is a pod that is gone.
-  const REBIND_GRACE_MS = options.rebindGraceMs ?? DEFAULT_REBIND_GRACE_MS
-  // How often to re-read a pod that is still coming up. Deliberately well under the grace: this
-  // is a wait for an event, not a window being spent, and the pod's arrival restarts the window.
-  const POD_UP_POLL_MS = Math.max(1, Math.min(2_000, Math.floor(REBIND_GRACE_MS / 4)))
-  const lossWatches = new Map<string, LossWatch>()
   let probeInFlight: Promise<K8sRuntimeTable> | undefined
-
-  /**
-   * Start the grace window for a channel that dropped, measured from the right event.
-   *
-   * The window is for a pod that IS up and whose shim has not come back. While the pod is still
-   * coming up nothing can dial it at all — a cold start pays PVC provisioning and an image pull —
-   * so that time is waited out rather than counted, and the window restarts once the pod is
-   * Ready. `driver.podUpTimeoutMs` is the ceiling: a pod that never arrives still reports loss.
-   */
-  function scheduleLossCheck(agentId: string, reason: string): void {
-    cancelLossCheck(agentId)
-    const watch: LossWatch = {
-      reason,
-      podWasStarting: false,
-      ceiling: Date.now() + driver.podUpTimeoutMs + REBIND_GRACE_MS
-    }
-    lossWatches.set(agentId, watch)
-    armLossCheck(agentId, watch, REBIND_GRACE_MS)
-  }
-
-  function armLossCheck(agentId: string, watch: LossWatch, delayMs: number): void {
-    watch.timer = setTimeout(() => void runLossCheck(agentId, watch), delayMs)
-    watch.timer.unref?.()
-  }
-
-  function cancelLossCheck(agentId: string): void {
-    const watch = lossWatches.get(agentId)
-    if (!watch) return
-    clearTimeout(watch.timer)
-    lossWatches.delete(agentId)
-  }
-
-  /** True while this watch is still the current one and nothing has rebound underneath it. */
-  function lossWatchStillOpen(agentId: string, watch: LossWatch): boolean {
-    if (lossWatches.get(agentId) !== watch) return false
-    if (dialer.connectionsFor(agentId).length === 0) return true
-    cancelLossCheck(agentId)
-    return false
-  }
-
-  async function runLossCheck(agentId: string, watch: LossWatch): Promise<void> {
-    if (!lossWatchStillOpen(agentId, watch)) return
-    // The read itself is bounded by what is LEFT of the ceiling, and by nothing else. The API
-    // server has no request deadline of its own, so a read that is accepted and never answered
-    // would hold this decision open forever — the launch stuck, its host dead, and nothing to
-    // rebuild it: the outcome this whole window exists to remove.
-    const remainingMs = watch.ceiling - Date.now()
-    const readiness =
-      remainingMs <= 0
-        ? ('absent' as const)
-        : await driver.sandboxReadiness(agentId, { signal: AbortSignal.timeout(remainingMs) }).catch((err: unknown) => {
-            // An unreadable Sandbox proves nothing about the pod, so it counts as still coming
-            // up — and the ceiling below, which the abort cannot outlive, decides in the end.
-            options.log?.warn(`k8s: could not read the sandbox for agent ${agentId} — ${(err as Error).message}`)
-            return 'starting' as const
-          })
-    // Re-checked after the round trip: a replacement may have bound, or the agent gone away.
-    if (!lossWatchStillOpen(agentId, watch)) return
-    if (Date.now() < watch.ceiling) {
-      if (readiness === 'starting') {
-        watch.podWasStarting = true
-        options.log?.debug?.(`k8s: agent ${agentId} has no shim channel yet — its sandbox pod is still coming up`)
-        armLossCheck(agentId, watch, POD_UP_POLL_MS)
-        return
-      }
-      // The pod has just come up, so its shim gets the whole grace window to dial in — the clock
-      // starts here rather than at a socket that dropped while there was no pod to dial at all.
-      if (readiness === 'ready' && watch.podWasStarting) {
-        watch.podWasStarting = false
-        armLossCheck(agentId, watch, REBIND_GRACE_MS)
-        return
-      }
-    }
-    lossWatches.delete(agentId)
-    options.log?.warn(
-      `k8s: no shim channel for agent ${agentId} after ${REBIND_GRACE_MS}ms with its pod ${readiness} — reporting loss`
-    )
-    driver.onChannelLost(agentId, watch.reason)
-  }
 
   function probeRuntimes(): Promise<K8sRuntimeTable> {
     if (probeInFlight) return probeInFlight
@@ -383,9 +268,8 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     // Close the pod's channel first: it may otherwise keep using a binding this member no longer honours.
     dialer.revokeAgent(agentId)
     // After the revoke, whose close schedules one: nobody here waits on a loss for an agent not served here.
-    cancelLossCheck(agentId)
-    proxies.get(agentId)?.proxy.stop(reason)
-    proxies.delete(agentId)
+    lossWatcher.cancel(agentId)
+    tunnels.release(agentId, reason)
     driver.releaseAgent(agentId)
   }
 
@@ -430,9 +314,8 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       await driver.removeAgent(agentId)
     },
     stop: async () => {
-      for (const agentId of [...lossWatches.keys()]) cancelLossCheck(agentId)
-      for (const { proxy } of proxies.values()) proxy.stop('daemon is shutting down')
-      proxies.clear()
+      lossWatcher.cancelAll()
+      tunnels.releaseAll('daemon is shutting down')
       dialer.stop()
     }
   }

--- a/packages/daemon/src/k8s/tunnel-binder.ts
+++ b/packages/daemon/src/k8s/tunnel-binder.ts
@@ -1,0 +1,69 @@
+import { TunnelProxy, type TunnelProxyDeps } from '../shim/tunnel-proxy.js'
+import type { TunnelName } from '../shim/tunnel.js'
+
+/** What a bound channel has to offer this binder: the proxy's own session surface plus the
+ *  generation that says which pod incarnation it belongs to. `ShimSession` satisfies it. */
+export type TunnelSession = TunnelProxyDeps['session'] & { generation: number }
+
+export interface TunnelBinderDeps {
+  /**
+   * Which daemon-side sockets an agent's sandbox needs a tunnel to, and where each one lives.
+   *
+   * Both halves are the DAEMON's to answer: only it knows that this agent authenticates git
+   * through a GitHub App, and only it knows the path its own server listens on. The binder holds
+   * the mechanism and no policy — omit either and no tunnel is opened.
+   */
+  tunnelsFor?: (agentId: string) => TunnelName[]
+  tunnelSocketPath?: (tunnel: TunnelName) => string | undefined
+  log: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
+}
+
+/**
+ * One TunnelProxy per agent, replaced when a NEW launch binds: its streams belong to a pod, and a
+ * proxy kept across incarnations would answer connections for a sandbox that no longer exists.
+ */
+export class TunnelBinder {
+  private readonly proxies = new Map<string, { generation: number; proxy: TunnelProxy }>()
+
+  constructor(private readonly deps: TunnelBinderDeps) {}
+
+  /** Open every tunnel this agent wants on the session that just bound. */
+  async ensure(agentId: string, session: TunnelSession): Promise<void> {
+    const wanted = this.deps.tunnelsFor?.(agentId) ?? []
+    const socketPathFor = this.deps.tunnelSocketPath
+    if (wanted.length === 0 || !socketPathFor) return
+    const existing = this.proxies.get(agentId)
+    // Stopped counts as gone: a proxy whose session was lost can never serve again, and reusing
+    // one would leave the sandbox with a socket whose daemon end refuses every connection.
+    if (existing && (existing.generation !== session.generation || existing.proxy.isStopped())) {
+      existing.proxy.stop(`superseded by generation ${session.generation}`)
+      this.proxies.delete(agentId)
+    }
+    let entry = this.proxies.get(agentId)
+    if (!entry) {
+      entry = {
+        generation: session.generation,
+        proxy: new TunnelProxy({ session, socketPathFor, log: this.deps.log })
+      }
+      this.proxies.set(agentId, entry)
+    }
+    // Sequential rather than concurrent: this is on the launch path, the list has two members at
+    // most, and one failing tunnel must not lose the report of the other.
+    for (const tunnel of wanted) {
+      await entry.proxy.ensure(tunnel).catch((err: unknown) => {
+        this.deps.log.warn(`k8s: agent ${agentId} has no ${tunnel} tunnel — ${(err as Error).message}`)
+      })
+    }
+  }
+
+  /** Drop the agent's proxy: this member no longer serves the launch its streams belong to. */
+  release(agentId: string, reason: string): void {
+    this.proxies.get(agentId)?.proxy.stop(reason)
+    this.proxies.delete(agentId)
+  }
+
+  releaseAll(reason: string): void {
+    for (const { proxy } of this.proxies.values()) proxy.stop(reason)
+    this.proxies.clear()
+  }
+}

--- a/packages/daemon/test/k8s-channel-loss-watcher.test.ts
+++ b/packages/daemon/test/k8s-channel-loss-watcher.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ChannelLossWatcher } from '../src/k8s/channel-loss-watcher.js'
+import type { SandboxReadiness } from '../src/k8s/driver.js'
+
+const log = { info: () => {}, warn: () => {}, debug: () => {} }
+
+const GRACE_MS = 100
+const POD_UP_MS = 1_000
+
+/** A watcher whose pod readiness and live channels a test drives, plus the losses it reported. */
+function watcher(readiness: SandboxReadiness = 'starting') {
+  const state = { readiness, connections: 0, reads: 0 }
+  const onChannelLost = vi.fn()
+  const subject = new ChannelLossWatcher({
+    sandboxReadiness: async (_agentId, _opts) => {
+      state.reads += 1
+      return state.readiness
+    },
+    connectionsFor: () => new Array<unknown>(state.connections),
+    podUpTimeoutMs: () => POD_UP_MS,
+    onChannelLost,
+    rebindGraceMs: GRACE_MS,
+    log
+  })
+  return { subject, state, onChannelLost }
+}
+
+describe('channel loss watcher', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('waits out a pod that is still coming up instead of spending the grace window on it', async () => {
+    const { subject, state, onChannelLost } = watcher('starting')
+    subject.schedule('agent-a', 'socket closed')
+
+    // Well past the grace window: a cold start pays PVC provisioning and an image pull, and none of
+    // that time is a shim failing to dial — nothing can dial a pod that is not up.
+    await vi.advanceTimersByTimeAsync(GRACE_MS * 5)
+
+    expect(onChannelLost).not.toHaveBeenCalled()
+    expect(state.reads).toBeGreaterThan(1)
+  })
+
+  it('gives the shim a whole fresh grace window once its pod comes up', async () => {
+    const { subject, state, onChannelLost } = watcher('starting')
+    subject.schedule('agent-a', 'socket closed')
+    await vi.advanceTimersByTimeAsync(GRACE_MS)
+    state.readiness = 'ready'
+
+    // The pod arriving restarts the clock: the window is for a shim that has somewhere to dial.
+    await vi.advanceTimersByTimeAsync(GRACE_MS - 1)
+    expect(onChannelLost).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS)
+    expect(onChannelLost).toHaveBeenCalledWith('agent-a', 'socket closed')
+  })
+
+  it('reports loss once the ceiling passes even while the pod claims to be starting', async () => {
+    const { subject, onChannelLost } = watcher('starting')
+    subject.schedule('agent-a', 'socket closed')
+
+    await vi.advanceTimersByTimeAsync(POD_UP_MS + GRACE_MS * 2)
+
+    expect(onChannelLost).toHaveBeenCalledWith('agent-a', 'socket closed')
+  })
+
+  it('drops the decision when a replacement channel binds', async () => {
+    const { subject, onChannelLost } = watcher('ready')
+    subject.schedule('agent-a', 'socket closed')
+    subject.cancel('agent-a')
+
+    await vi.advanceTimersByTimeAsync(POD_UP_MS + GRACE_MS * 2)
+
+    expect(onChannelLost).not.toHaveBeenCalled()
+  })
+
+  it('drops a decision whose agent has a live channel again by the time it runs', async () => {
+    const { subject, state, onChannelLost } = watcher('ready')
+    subject.schedule('agent-a', 'socket closed')
+    state.connections = 1
+
+    await vi.advanceTimersByTimeAsync(POD_UP_MS + GRACE_MS * 2)
+
+    expect(onChannelLost).not.toHaveBeenCalled()
+    // Nothing was read: a bound channel settles the question without an API round trip.
+    expect(state.reads).toBe(0)
+  })
+
+  it('cancels every pending decision when the plane goes down', async () => {
+    const { subject, onChannelLost } = watcher('ready')
+    subject.schedule('agent-a', 'socket closed')
+    subject.schedule('agent-b', 'socket closed')
+    subject.cancelAll()
+
+    await vi.advanceTimersByTimeAsync(POD_UP_MS + GRACE_MS * 2)
+
+    expect(onChannelLost).not.toHaveBeenCalled()
+  })
+})

--- a/packages/daemon/test/k8s-tunnel-binder.test.ts
+++ b/packages/daemon/test/k8s-tunnel-binder.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TunnelBinder, type TunnelSession } from '../src/k8s/tunnel-binder.js'
+
+const log = { info: () => {}, warn: () => {}, debug: () => {} }
+
+/** A bound channel of a given incarnation, and the proxy teardown it observed. */
+function fakeSession(generation: number) {
+  const request = vi.fn(async () => ({ socketPath: '/pod/gitcred.sock' }))
+  const offEvent = vi.fn()
+  const session = {
+    agentId: 'agent-a',
+    generation,
+    request,
+    onEvent: vi.fn(),
+    offEvent,
+    onAttach: vi.fn(),
+    offAttach: vi.fn(),
+    onLost: vi.fn()
+  }
+  return { session: session as unknown as TunnelSession, request, offEvent }
+}
+
+function binder() {
+  return new TunnelBinder({ tunnelsFor: () => ['gitcred'], tunnelSocketPath: () => '/daemon/gitcred.sock', log })
+}
+
+describe('tunnel binder', () => {
+  it('opens the wanted tunnels on the session that bound', async () => {
+    const { session, request } = fakeSession(1)
+    await binder().ensure('agent-a', session)
+
+    expect(request).toHaveBeenCalledWith('tunnel', { op: 'listen', tunnel: 'gitcred' })
+  })
+
+  it('keeps one proxy per agent across preparations of the same launch', async () => {
+    const subject = binder()
+    const { session, request } = fakeSession(1)
+    await subject.ensure('agent-a', session)
+    await subject.ensure('agent-a', session)
+
+    // The listen is idempotent on the pod, but repeating it would cost a round trip per launch.
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('replaces the proxy when a new launch binds, because its streams belong to the old pod', async () => {
+    const subject = binder()
+    const first = fakeSession(1)
+    const second = fakeSession(2)
+    await subject.ensure('agent-a', first.session)
+    await subject.ensure('agent-a', second.session)
+
+    expect(first.offEvent).toHaveBeenCalled()
+    expect(second.request).toHaveBeenCalledWith('tunnel', { op: 'listen', tunnel: 'gitcred' })
+  })
+
+  it('opens nothing when the daemon serves no socket for the tunnel', async () => {
+    const { session, request } = fakeSession(1)
+    await new TunnelBinder({ tunnelsFor: () => ['gitcred'], log }).ensure('agent-a', session)
+
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('stops the agent proxy when the launch is no longer served here', async () => {
+    const subject = binder()
+    const { session, offEvent } = fakeSession(1)
+    await subject.ensure('agent-a', session)
+    subject.release('agent-a', 'agent no longer served here')
+
+    expect(offEvent).toHaveBeenCalled()
+  })
+
+  it('stops every proxy when the plane goes down', async () => {
+    const subject = binder()
+    const first = fakeSession(1)
+    await subject.ensure('agent-a', first.session)
+    subject.releaseAll('daemon is shutting down')
+
+    expect(first.offEvent).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
`startK8sRuntimePlane` was ~450 lines, of which two stateful machines lived in closures over the factory's locals — untestable except through a whole assembled plane.

## What moved

**`k8s/channel-loss-watcher.ts` — `ChannelLossWatcher`** (was `lossWatches` + `scheduleLossCheck`/`armLossCheck`/`cancelLossCheck`/`lossWatchStillOpen`/`runLossCheck`). Same logic verbatim: ceiling from `podUpTimeoutMs + grace`, `podWasStarting` reset on a pod coming up, the `AbortSignal.timeout(remaining)` bound on the readiness read, and the post-round-trip recheck. Deps injected — `sandboxReadiness`, `connectionsFor`, `podUpTimeoutMs()`, `onChannelLost`, `now`, `log`. `DEFAULT_REBIND_GRACE_MS` moved with it.

**`k8s/tunnel-binder.ts` — `TunnelBinder`** (was the `proxies` map + `ensureTunnels`). Generation-scoped `TunnelProxy` lifecycle, plus `release`/`releaseAll` for the two teardown paths the factory had inline. Its session parameter is typed `TunnelSession` (`TunnelProxyDeps['session'] & { generation }`) rather than `ShimSession`, so it asks for what it uses and a test can stand one up.

`runtime-plane.ts` is now 333 lines of assembly; the two objects are constructed before the dialer and driver and read the driver lazily, which is what lets the three refer to each other.

## Call sites rewired

No delegating shells were kept. Every internal caller holds the object: `dialer.onConnection` → `lossWatcher.cancel`, `onConnectionLost` → `lossWatcher.schedule`, `driver.onChannelReady` → `tunnels.ensure`, `releaseAgent` → `lossWatcher.cancel` + `tunnels.release`, `stop` → `lossWatcher.cancelAll` + `tunnels.releaseAll`. Nothing outside the file referenced the removed names.

## Tests

New direct unit coverage, in the style of `k8s-sandbox-lease.test.ts`:

- `test/k8s-channel-loss-watcher.test.ts` (6) — still-starting reschedule, pod-up restarts the whole grace, ceiling exceeded → loss, `cancel` on rebind, a live channel settling it without an API read, `cancelAll`. Fake timers throughout.
- `test/k8s-tunnel-binder.test.ts` (6) — listen on bind, one proxy reused within a generation, replacement on a new generation (old proxy stopped), no socket → no tunnel, `release`/`releaseAll`.

## Verification

`pnpm typecheck` clean. `k8s-channel-loss-watcher`, `k8s-tunnel-binder`, `k8s-runtime-plane`, `k8s-driver`, `cluster-cold-start` — 60 + 12 tests pass. `prettier --check` and `eslint` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
