### PR TITLE
refactor(daemon): give the memory tools a domain home, invert memory -> mcp

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -94,7 +94,8 @@ import {
 import { configureWorkspaceGitOrigins } from './workspace/git-origin-policy.js'
 import { buildMcpServers } from './mcp/inject.js'
 import { resolveAgentMcpServers, RESERVED_MCP_SERVER_NAME } from './mcp/resolve-servers.js'
-import { toolsForIntegrations, MEMORY_TOOL_NAMES, GITHUB_REVIEW_TOOLS, KNOWLEDGE_TOOLS } from './mcp/tools.js'
+import { toolsForIntegrations, GITHUB_REVIEW_TOOLS, KNOWLEDGE_TOOLS } from './mcp/tools.js'
+import { MEMORY_TOOL_NAMES } from './memory/tools.js'
 import { isSessionTitleToolCall } from './mcp/session-title-tool.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT, readOnlyExtractionMode } from './memory/distill.js'
 import {

--- a/packages/daemon/src/evaluation/environment.ts
+++ b/packages/daemon/src/evaluation/environment.ts
@@ -9,7 +9,7 @@
 import type { AgentAuthorshipClaim, ChannelAgentsOk, CollabRoutesSnapshot } from '@agentconnect.md/protocol'
 import { IntegrationSchema, type BindRuleConfig, type Integration } from '../agents/agent-schema.js'
 import type { ChannelAgentsRequest, SessionContext } from '../mcp/ops.js'
-import type { ToolDescriptor } from '../mcp/tools.js'
+import type { ToolDescriptor } from '../mcp/tool-descriptor.js'
 import type { VirtualPlatform, VirtualPlatformConnection } from './virtual-connections.js'
 
 /** One synthetic integration, projected into both `agent.integrations` and the

--- a/packages/daemon/src/mcp/control-server.ts
+++ b/packages/daemon/src/mcp/control-server.ts
@@ -4,7 +4,7 @@ import { mkdirSync, rmSync, chmodSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { decodeFrames, encodeFrame, type IpcRequest, type IpcResponse } from './ipc.js'
 import { executeTool, type OpsDeps, type SessionContext } from './ops.js'
-import type { ToolDescriptor } from './tools.js'
+import type { ToolDescriptor } from './tool-descriptor.js'
 import type { Logger } from '../log.js'
 
 export interface McpControlDeps extends OpsDeps {

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -1,4 +1,5 @@
-import type { ToolDescriptor } from './tools.js'
+import type { ToolDescriptor } from './tool-descriptor.js'
+import { MEMORY_ACCESS_BLOCKED } from '../memory/tools.js'
 import type { MemoryProvider, MemoryScope } from '../memory/provider.js'
 import {
   rootPostNeedsThreadMaterialization,
@@ -378,12 +379,6 @@ export interface ReplyGithubReviewThreadsResult {
     commentId?: string
   }>
 }
-
-/** Refusal surfaced to the model when an isolated session tries to access
- *  agent memory shared with other users. Phrased so the agent stops retrying
- *  instead of attempting to reconstruct or persist the content another way. */
-export const MEMORY_ACCESS_BLOCKED =
-  'Shared agent memory is unavailable in this session. Keep the information in this conversation instead; do not retry.'
 
 /**
  * A peer-discovery request, i.e. `ChannelAgentsReq` plus the caller's own session

--- a/packages/daemon/src/mcp/tool-descriptor.ts
+++ b/packages/daemon/src/mcp/tool-descriptor.ts
@@ -1,0 +1,35 @@
+import type { JSONValue } from '@modelcontextprotocol/server'
+
+/** A tool descriptor in MCP's `tools/list` shape: name, model-facing description, and an argument JSON Schema. */
+export interface ToolDescriptor {
+  name: string
+  description: string
+  inputSchema: ObjectToolSchema | ObjectUnionSchema
+}
+
+export type ToolProperties = Record<string, JSONValue>
+
+export interface ObjectToolSchema extends Record<string, JSONValue> {
+  type: 'object'
+  properties: ToolProperties
+  required: string[]
+  additionalProperties: false
+}
+
+/** A root object schema whose `oneOf` branches are mutually exclusive call modes (used by sendMessage). */
+export interface ObjectUnionSchema extends Record<string, JSONValue> {
+  type: 'object'
+  oneOf: ObjectToolSchema[]
+}
+
+export const obj = (properties: ToolProperties, required: string[] = []): ObjectToolSchema => ({
+  type: 'object',
+  properties,
+  required,
+  additionalProperties: false
+})
+
+export const unionOf = (oneOf: ObjectToolSchema[]): ObjectUnionSchema => ({
+  type: 'object',
+  oneOf
+})

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -1,48 +1,8 @@
 import type { Integration } from '../agents/agent-schema.js'
-import type { MemoryPluginOperation } from '@agentconnect.md/protocol'
-import type { JSONValue } from '@modelcontextprotocol/server'
+import { obj, unionOf, type ToolDescriptor } from './tool-descriptor.js'
 import { SESSION_TITLE_TOOL_NAME } from './session-title-tool.js'
 import { allAttachmentReadTools, attachmentReadToolsFor } from '../platforms/read-ports.js'
-
-/**
- * A tool descriptor in MCP's `tools/list` shape: a name, a human/model-facing
- * description, and a JSON Schema for the arguments. The daemon owns these
- * definitions; the stdio bridge just relays them to the agent harness verbatim.
- */
-export interface ToolDescriptor {
-  name: string
-  description: string
-  inputSchema: ObjectToolSchema | ObjectUnionSchema
-}
-
-type ToolProperties = Record<string, JSONValue>
-
-interface ObjectToolSchema extends Record<string, JSONValue> {
-  type: 'object'
-  properties: ToolProperties
-  required: string[]
-  additionalProperties: false
-}
-
-/** A root-level object schema that discriminates mutually exclusive call modes via `oneOf`
- *  (used by sendMessage). Each branch is a full {@link ObjectToolSchema} that owns its fields
- *  and enforces `additionalProperties`; the root itself declares no fields. */
-interface ObjectUnionSchema extends Record<string, JSONValue> {
-  type: 'object'
-  oneOf: ObjectToolSchema[]
-}
-
-const obj = (properties: ToolProperties, required: string[] = []): ObjectToolSchema => ({
-  type: 'object',
-  properties,
-  required,
-  additionalProperties: false
-})
-
-const unionOf = (oneOf: ObjectToolSchema[]): ObjectUnionSchema => ({
-  type: 'object',
-  oneOf
-})
+import { EXTERNAL_MEMORY_TOOL_NAMES, MEMORY_TOOLS } from '../memory/tools.js'
 
 /**
  * Session metadata fallback tools. Opt-in via `toolsForIntegrations`'s
@@ -407,61 +367,6 @@ function buildReadTools(platforms: string[]): ToolDescriptor[] {
   ]
 }
 
-/**
- * The agent's long-term memory tools — available to EVERY agent regardless of
- * integrations. Memory is a directory (`<agent-root>/memory/`) with a `MEMORY.md`
- * index (injected into the prompt each session) plus `<topic>.md` files the agent
- * reads on demand. Keep the index short; move detail into topic files.
- */
-export const MEMORY_TOOLS: ToolDescriptor[] = [
-  {
-    name: 'readMemory',
-    description:
-      'Read one of your memory files. Omit `path` (or pass "MEMORY.md") to read the index; pass a topic file name ' +
-      '(e.g. "deploys.md") to read that topic. The index is already shown to you at the start of each session (you ' +
-      'do NOT need to read it first) — use this to pull the detail behind an index entry, or the current contents of ' +
-      'a file before editing it.',
-    inputSchema: obj({
-      path: { type: 'string', description: 'Memory file name (e.g. "deploys.md"). Defaults to the MEMORY.md index.' }
-    })
-  },
-  {
-    name: 'writeMemory',
-    description:
-      'Save durable facts across sessions (conventions, decisions, who to ask, things you had to re-learn). Omit ' +
-      '`path` to target the MEMORY.md index; pass a topic file name (e.g. "deploys.md") for a topic. Keep the INDEX ' +
-      'short — a scannable list linking to topic files (e.g. "- [deploys](deploys.md) — how we ship"); put the detail ' +
-      'in the topic files. Flat directory — no subfolders in the path.\n' +
-      'Two modes:\n' +
-      '• `content` — create a file or fully replace it.\n' +
-      '• `oldString` + `newString` — targeted edit. Copy `oldString` verbatim from a fresh `readMemory` result, or ' +
-      "decode exactly one layer of the injected boundary's documented XML character references first. Never source " +
-      'it from surrounding session context (for example workspace or git status). It must occur exactly once; include ' +
-      'enough file context to make it unique. If unsure, or retrying after a write or failed replace, call `readMemory` ' +
-      'first. Pass `newString: ""` to delete. Prefer this mode for existing files so you do not resend the whole file. ' +
-      'Provide exactly one mode.',
-    inputSchema: obj({
-      path: {
-        type: 'string',
-        description: 'Memory file name (e.g. "deploys.md"). Defaults to the MEMORY.md index. No subdirectories.'
-      },
-      content: {
-        type: 'string',
-        description: 'Full-write mode: the entire new file contents (Markdown). Replaces the file.'
-      },
-      oldString: {
-        type: 'string',
-        description: 'Edit mode: exact text to replace; must occur exactly once in the target memory file.'
-      },
-      newString: { type: 'string', description: 'Edit mode: the replacement text ("" to delete the matched text).' }
-    })
-  }
-]
-
-/** The memory tool names — used to strip them for a `native`-memory agent (which
- *  uses the runtime's own memory instead). */
-export const MEMORY_TOOL_NAMES = new Set(MEMORY_TOOLS.map((t) => t.name))
-
 export const KNOWLEDGE_TOOLS: ToolDescriptor[] = [
   {
     name: 'findKnowledge',
@@ -505,115 +410,6 @@ export const KNOWLEDGE_TOOLS: ToolDescriptor[] = [
     })
   }
 ]
-
-/**
- * Stable AgentConnect record tools for an external-memory provider. These names,
- * descriptions, and argument schemas are core-owned: raw plugin tools are never
- * copied into a model session. Optional write/read actions are projected only
- * when the reviewed manifest declares the corresponding capability.
- */
-const EXTERNAL_MEMORY_TOOLS: Readonly<Record<'recall' | 'create' | 'get' | 'update' | 'delete', ToolDescriptor>> = {
-  recall: {
-    name: 'searchMemory',
-    description:
-      'Search your durable external memory for records relevant to a query. The daemon supplies your trusted agent scope automatically; do not put an agent or user id in the query.',
-    inputSchema: obj(
-      {
-        query: { type: 'string', minLength: 1, description: 'What durable information to search for.' },
-        topK: { type: 'integer', minimum: 1, maximum: 20, description: 'Optional maximum result count.' },
-        maxBytes: {
-          type: 'integer',
-          minimum: 1,
-          maximum: 32768,
-          description: 'Optional total text budget for results.'
-        }
-      },
-      ['query']
-    )
-  },
-  create: {
-    name: 'saveMemory',
-    description:
-      'Save one durable memory record for future sessions. Store a concise, self-contained fact or decision; the daemon supplies your trusted agent scope automatically.',
-    inputSchema: obj(
-      {
-        text: {
-          type: 'string',
-          minLength: 1,
-          maxLength: 131072,
-          description: 'The durable fact or decision to save.'
-        },
-        metadata: {
-          type: 'object',
-          description: 'Optional small JSON metadata object. Do not copy credentials or large payloads here.',
-          additionalProperties: true
-        }
-      },
-      ['text']
-    )
-  },
-  get: {
-    name: 'getMemory',
-    description: 'Get one durable memory record by the opaque record id returned by searchMemory or saveMemory.',
-    inputSchema: obj(
-      { id: { type: 'string', minLength: 1, maxLength: 512, description: 'Opaque memory record id.' } },
-      ['id']
-    )
-  },
-  update: {
-    name: 'updateMemory',
-    description:
-      'Replace one durable memory record by id. Pass the version returned by searchMemory/getMemory when present so a concurrent edit fails instead of being overwritten.',
-    inputSchema: obj(
-      {
-        id: { type: 'string', minLength: 1, maxLength: 512, description: 'Opaque memory record id.' },
-        text: {
-          type: 'string',
-          minLength: 1,
-          maxLength: 131072,
-          description: 'Complete replacement text for the record.'
-        },
-        metadata: { type: 'object', description: 'Optional replacement JSON metadata.', additionalProperties: true },
-        version: {
-          type: 'string',
-          minLength: 1,
-          maxLength: 512,
-          description: 'Optional backend version/ETag from the record being edited.'
-        }
-      },
-      ['id', 'text']
-    )
-  },
-  delete: {
-    name: 'deleteMemory',
-    description:
-      'Delete one durable memory record by id. Pass the version returned by searchMemory/getMemory when present so a backend that supports conditional delete can reject a stale request.',
-    inputSchema: obj(
-      {
-        id: { type: 'string', minLength: 1, maxLength: 512, description: 'Opaque memory record id.' },
-        version: {
-          type: 'string',
-          minLength: 1,
-          maxLength: 512,
-          description: 'Optional backend version/ETag from the record being deleted.'
-        }
-      },
-      ['id']
-    )
-  }
-}
-
-const EXTERNAL_MEMORY_TOOL_OPERATIONS = ['recall', 'create', 'get', 'update', 'delete'] as const
-
-export function externalMemoryTools(capabilities: ReadonlySet<MemoryPluginOperation>): ToolDescriptor[] {
-  return EXTERNAL_MEMORY_TOOL_OPERATIONS.filter((operation) => capabilities.has(operation)).map(
-    (operation) => EXTERNAL_MEMORY_TOOLS[operation]
-  )
-}
-
-export const EXTERNAL_MEMORY_TOOL_NAMES = new Set(
-  EXTERNAL_MEMORY_TOOL_OPERATIONS.map((operation) => EXTERNAL_MEMORY_TOOLS[operation].name)
-)
 
 /**
  * Agent-collaboration tools — available to EVERY agent regardless of platform
@@ -850,14 +646,16 @@ export const ALL_TOOL_NAMES = [
       ...allAttachmentReadTools(),
       ...MEMORY_TOOLS,
       ...KNOWLEDGE_TOOLS,
-      ...Object.values(EXTERNAL_MEMORY_TOOLS),
       ...COLLABORATION_TOOLS,
       // Retired from injection but still dispatched by `executeTool`, so the name stays
       // reserved (no evaluation tool may shadow it) and auto-allowed (a session warm with
       // the old descriptor, or an in-flight orchestration, must not start hitting approval).
       ...RETIRED_ORCHESTRATION_TOOLS,
       ...GITHUB_REVIEW_TOOLS
-    ].map((t) => t.name)
+    ]
+      .map((t) => t.name)
+      // External-memory record tools: only their names are core knowledge here, the descriptors live in memory/.
+      .concat([...EXTERNAL_MEMORY_TOOL_NAMES])
   )
 ]
 

--- a/packages/daemon/src/memory/provider.ts
+++ b/packages/daemon/src/memory/provider.ts
@@ -34,8 +34,8 @@ import type {
 } from '@agentconnect.md/protocol'
 import { randomUUID } from 'node:crypto'
 import type { RuntimeDef } from '../config/config-schema.js'
-import type { ToolDescriptor } from '../mcp/tools.js'
-import { MEMORY_TOOLS, externalMemoryTools } from '../mcp/tools.js'
+import type { ToolDescriptor } from '../mcp/tool-descriptor.js'
+import { MEMORY_TOOLS, externalMemoryTools } from './tools.js'
 import {
   ensureMemory,
   readIndex,

--- a/packages/daemon/src/memory/tools.ts
+++ b/packages/daemon/src/memory/tools.ts
@@ -1,0 +1,158 @@
+import type { MemoryPluginOperation } from '@agentconnect.md/protocol'
+import { obj, type ToolDescriptor } from '../mcp/tool-descriptor.js'
+
+/** Refusal surfaced to the model when an isolated session tries to access agent memory shared with other users. */
+export const MEMORY_ACCESS_BLOCKED =
+  'Shared agent memory is unavailable in this session. Keep the information in this conversation instead; do not retry.'
+
+/** The agent's long-term memory tools, for EVERY agent: `<agent-root>/memory/` with a `MEMORY.md` index plus topic files. */
+export const MEMORY_TOOLS: ToolDescriptor[] = [
+  {
+    name: 'readMemory',
+    description:
+      'Read one of your memory files. Omit `path` (or pass "MEMORY.md") to read the index; pass a topic file name ' +
+      '(e.g. "deploys.md") to read that topic. The index is already shown to you at the start of each session (you ' +
+      'do NOT need to read it first) — use this to pull the detail behind an index entry, or the current contents of ' +
+      'a file before editing it.',
+    inputSchema: obj({
+      path: { type: 'string', description: 'Memory file name (e.g. "deploys.md"). Defaults to the MEMORY.md index.' }
+    })
+  },
+  {
+    name: 'writeMemory',
+    description:
+      'Save durable facts across sessions (conventions, decisions, who to ask, things you had to re-learn). Omit ' +
+      '`path` to target the MEMORY.md index; pass a topic file name (e.g. "deploys.md") for a topic. Keep the INDEX ' +
+      'short — a scannable list linking to topic files (e.g. "- [deploys](deploys.md) — how we ship"); put the detail ' +
+      'in the topic files. Flat directory — no subfolders in the path.\n' +
+      'Two modes:\n' +
+      '• `content` — create a file or fully replace it.\n' +
+      '• `oldString` + `newString` — targeted edit. Copy `oldString` verbatim from a fresh `readMemory` result, or ' +
+      "decode exactly one layer of the injected boundary's documented XML character references first. Never source " +
+      'it from surrounding session context (for example workspace or git status). It must occur exactly once; include ' +
+      'enough file context to make it unique. If unsure, or retrying after a write or failed replace, call `readMemory` ' +
+      'first. Pass `newString: ""` to delete. Prefer this mode for existing files so you do not resend the whole file. ' +
+      'Provide exactly one mode.',
+    inputSchema: obj({
+      path: {
+        type: 'string',
+        description: 'Memory file name (e.g. "deploys.md"). Defaults to the MEMORY.md index. No subdirectories.'
+      },
+      content: {
+        type: 'string',
+        description: 'Full-write mode: the entire new file contents (Markdown). Replaces the file.'
+      },
+      oldString: {
+        type: 'string',
+        description: 'Edit mode: exact text to replace; must occur exactly once in the target memory file.'
+      },
+      newString: { type: 'string', description: 'Edit mode: the replacement text ("" to delete the matched text).' }
+    })
+  }
+]
+
+/** The memory tool names — used to strip them for a `native`-memory agent, which uses the runtime's own memory. */
+export const MEMORY_TOOL_NAMES = new Set(MEMORY_TOOLS.map((t) => t.name))
+/** Core-owned record tools for an external-memory provider: raw plugin tools are never copied into a model session, and optional actions are projected only when the reviewed manifest declares the capability. */
+const EXTERNAL_MEMORY_TOOLS: Readonly<Record<'recall' | 'create' | 'get' | 'update' | 'delete', ToolDescriptor>> = {
+  recall: {
+    name: 'searchMemory',
+    description:
+      'Search your durable external memory for records relevant to a query. The daemon supplies your trusted agent scope automatically; do not put an agent or user id in the query.',
+    inputSchema: obj(
+      {
+        query: { type: 'string', minLength: 1, description: 'What durable information to search for.' },
+        topK: { type: 'integer', minimum: 1, maximum: 20, description: 'Optional maximum result count.' },
+        maxBytes: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 32768,
+          description: 'Optional total text budget for results.'
+        }
+      },
+      ['query']
+    )
+  },
+  create: {
+    name: 'saveMemory',
+    description:
+      'Save one durable memory record for future sessions. Store a concise, self-contained fact or decision; the daemon supplies your trusted agent scope automatically.',
+    inputSchema: obj(
+      {
+        text: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 131072,
+          description: 'The durable fact or decision to save.'
+        },
+        metadata: {
+          type: 'object',
+          description: 'Optional small JSON metadata object. Do not copy credentials or large payloads here.',
+          additionalProperties: true
+        }
+      },
+      ['text']
+    )
+  },
+  get: {
+    name: 'getMemory',
+    description: 'Get one durable memory record by the opaque record id returned by searchMemory or saveMemory.',
+    inputSchema: obj(
+      { id: { type: 'string', minLength: 1, maxLength: 512, description: 'Opaque memory record id.' } },
+      ['id']
+    )
+  },
+  update: {
+    name: 'updateMemory',
+    description:
+      'Replace one durable memory record by id. Pass the version returned by searchMemory/getMemory when present so a concurrent edit fails instead of being overwritten.',
+    inputSchema: obj(
+      {
+        id: { type: 'string', minLength: 1, maxLength: 512, description: 'Opaque memory record id.' },
+        text: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 131072,
+          description: 'Complete replacement text for the record.'
+        },
+        metadata: { type: 'object', description: 'Optional replacement JSON metadata.', additionalProperties: true },
+        version: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 512,
+          description: 'Optional backend version/ETag from the record being edited.'
+        }
+      },
+      ['id', 'text']
+    )
+  },
+  delete: {
+    name: 'deleteMemory',
+    description:
+      'Delete one durable memory record by id. Pass the version returned by searchMemory/getMemory when present so a backend that supports conditional delete can reject a stale request.',
+    inputSchema: obj(
+      {
+        id: { type: 'string', minLength: 1, maxLength: 512, description: 'Opaque memory record id.' },
+        version: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 512,
+          description: 'Optional backend version/ETag from the record being deleted.'
+        }
+      },
+      ['id']
+    )
+  }
+}
+
+const EXTERNAL_MEMORY_TOOL_OPERATIONS = ['recall', 'create', 'get', 'update', 'delete'] as const
+
+export function externalMemoryTools(capabilities: ReadonlySet<MemoryPluginOperation>): ToolDescriptor[] {
+  return EXTERNAL_MEMORY_TOOL_OPERATIONS.filter((operation) => capabilities.has(operation)).map(
+    (operation) => EXTERNAL_MEMORY_TOOLS[operation]
+  )
+}
+
+export const EXTERNAL_MEMORY_TOOL_NAMES = new Set(
+  EXTERNAL_MEMORY_TOOL_OPERATIONS.map((operation) => EXTERNAL_MEMORY_TOOLS[operation].name)
+)

--- a/packages/daemon/src/memory/types.ts
+++ b/packages/daemon/src/memory/types.ts
@@ -10,7 +10,7 @@ import type {
   MemoryPluginOperation
 } from '@agentconnect.md/protocol'
 import type { RuntimeDef } from '../config/config-schema.js'
-import type { ToolDescriptor } from '../mcp/tools.js'
+import type { ToolDescriptor } from '../mcp/tool-descriptor.js'
 import type { MemoryWriteSource, ManagedMemoryHistoryPage } from './store.js'
 import type { DistillationTurn } from './distill.js'
 

--- a/packages/daemon/src/platforms/read-ports.ts
+++ b/packages/daemon/src/platforms/read-ports.ts
@@ -37,7 +37,7 @@
  * names do not move. They live in their platform's own module now, which is the
  * whole point — core no longer knows that either name exists.
  */
-import type { ToolDescriptor } from '../mcp/tools.js'
+import type { ToolDescriptor } from '../mcp/tool-descriptor.js'
 import { SLACK_ATTACHMENT_TOOL } from './slack/attachments.js'
 import { TELEGRAM_ATTACHMENT_TOOL } from './telegram/attachments.js'
 

--- a/packages/daemon/src/platforms/slack/attachments.ts
+++ b/packages/daemon/src/platforms/slack/attachments.ts
@@ -11,7 +11,7 @@
  * shared resource_link points at, and what warm ACP sessions already carry in
  * their descriptor list. The injection mechanism generalized; the name did not.
  */
-import type { ToolDescriptor } from '../../mcp/tools.js'
+import type { ToolDescriptor } from '../../mcp/tool-descriptor.js'
 
 export const SLACK_ATTACHMENT_TOOL: ToolDescriptor = {
   name: 'readSlackFile',

--- a/packages/daemon/src/platforms/telegram/attachments.ts
+++ b/packages/daemon/src/platforms/telegram/attachments.ts
@@ -10,7 +10,7 @@
  *
  * THE NAME IS FROZEN — see the note on Slack's sibling module.
  */
-import type { ToolDescriptor } from '../../mcp/tools.js'
+import type { ToolDescriptor } from '../../mcp/tool-descriptor.js'
 
 export const TELEGRAM_ATTACHMENT_TOOL: ToolDescriptor = {
   name: 'readTelegramFile',

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -4,9 +4,9 @@ import {
   ALL_TOOL_NAMES,
   COLLABORATION_TOOLS,
   GITHUB_REVIEW_TOOLS,
-  RETIRED_ORCHESTRATION_TOOLS,
-  externalMemoryTools
+  RETIRED_ORCHESTRATION_TOOLS
 } from '../src/mcp/tools.js'
+import { externalMemoryTools } from '../src/memory/tools.js'
 import type { Integration } from '../src/agents/agent-schema.js'
 
 const slackInt: Integration = {

--- a/packages/daemon/test/memory-write-gate.test.ts
+++ b/packages/daemon/test/memory-write-gate.test.ts
@@ -9,7 +9,8 @@
  * `write`); this suite mirrors the daemon wiring where reads are always allowed.
  */
 import { describe, it, expect, vi } from 'vitest'
-import { executeTool, MEMORY_ACCESS_BLOCKED, type OpsDeps, type SessionContext } from '../src/mcp/ops.js'
+import { executeTool, type OpsDeps, type SessionContext } from '../src/mcp/ops.js'
+import { MEMORY_ACCESS_BLOCKED } from '../src/memory/tools.js'
 
 const ctx = (): SessionContext => ({
   agentId: 'bot-a',

--- a/packages/daemon/test/memory.test.ts
+++ b/packages/daemon/test/memory.test.ts
@@ -29,7 +29,7 @@ import {
 import { LocalMemoryFs } from '../src/memory/fs.js'
 import { createMemoryReader, MemoryViolationError } from '../src/cp/memory-reader.js'
 import { createManagedMemoryProvider } from '../src/memory/provider.js'
-import { MEMORY_TOOLS } from '../src/mcp/tools.js'
+import { MEMORY_TOOLS } from '../src/memory/tools.js'
 import { executeTool, type OpsDeps, type SessionContext } from '../src/mcp/ops.js'
 
 const local = (dir: string) => new LocalMemoryFs(dir)


### PR DESCRIPTION
## What

`src/memory/` imported `ToolDescriptor`, `MEMORY_TOOLS` and `externalMemoryTools` from `src/mcp/tools.ts` — the domain depended on the transport. Now it does not.

- **Memory tool definitions move to `src/memory/tools.ts`**: `MEMORY_TOOLS`, `MEMORY_TOOL_NAMES`, the core-owned `EXTERNAL_MEMORY_TOOLS` record set, `externalMemoryTools()` and `EXTERNAL_MEMORY_TOOL_NAMES`.
- **`MEMORY_ACCESS_BLOCKED` moves from `src/mcp/ops.ts` to `src/memory/tools.ts`.** Judgement: the string is memory-sharing policy phrased for the model, not tool-dispatch mechanics — domain-owned. `ops.ts` imports it.
- **`ToolDescriptor` gets a pure leaf, `src/mcp/tool-descriptor.ts`** (interface + the `ObjectToolSchema`/`ObjectUnionSchema` shapes + the two `obj`/`unionOf` schema constructors, one definition each, no internal imports).

### Why the leaf and not "host the type in memory/"

The preferred direction (transport knows domain) does apply to the *tool sets* — `mcp/tools.ts` now imports `MEMORY_TOOLS` and `EXTERNAL_MEMORY_TOOL_NAMES` from `memory/tools.ts`. It does not apply to `ToolDescriptor`: it is the MCP `tools/list` wire shape, and its consumers are `mcp/tools.ts`, `mcp/ops.ts`, `mcp/control-server.ts`, `platforms/read-ports.ts`, `platforms/{slack,telegram}/attachments.ts` and `evaluation/environment.ts` as much as `memory/`. Hosting it in `memory/tools.ts` would make Slack attachments and the evaluation harness import the memory domain to name a transport type — a worse dependency than the one being removed. So it lives in a leaf both sides import.

## Delegate policy

No re-export shims. Every importer was retargeted directly (`daemon.ts`, `mcp/ops.ts`, `mcp/control-server.ts`, `mcp/tools.ts`, `evaluation/environment.ts`, `platforms/read-ports.ts`, both platform attachment modules, `memory/{types,provider}.ts`), plus the test imports in `test/mcp-tools.test.ts`, `test/memory.test.ts` and `test/memory-write-gate.test.ts`. `ALL_TOOL_NAMES` now concats `EXTERNAL_MEMORY_TOOL_NAMES` instead of reaching into the descriptor record.

## Verification

- `rg "from '\.\./mcp/" src/memory/` → three hits, all `../mcp/tool-descriptor.js` (the pure leaf). Zero imports of `mcp/tools.js` / `mcp/ops.js`.
- `pnpm --filter @agentconnect.md/daemon typecheck` clean.
- `vitest run test/mcp-tools.test.ts test/mcp-ops.test.ts test/memory-provider-dispatch.test.ts test/external-memory-provider.test.ts test/memory.test.ts test/memory-write-gate.test.ts` → 202 passed.
- prettier `--check` and eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)