### PR TITLE
fix(control-plane): reserve admin and billing as org slugs

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2042,6 +2042,8 @@ export const AcceptedOrgInviteLinkDto = z.object({
  *  shadow them (`/{slug}/…` shares the segment with these). Grows with every
  *  new top-level console page. The default org's `-` is safe by regex. */
 const RESERVED_SLUGS = new Set([
+  'admin', // gateway-owned prefix (admin-server), not a console page
+  'billing',
   'agents',
   'sessions',
   'daemons',


### PR DESCRIPTION
## What

Add `admin` and `billing` to `RESERVED_SLUGS` in `packages/control-plane/src/http/dto/index.ts`.

## Why

Org pages live at `/{slug}/...`, sharing the first path segment with console-owned routes. The gateway already claims the `/admin` prefix for admin-server, and `/billing` is a top-level path — but neither word was in the reserved-slug list, so an org could register either slug and have its pages shadowed by the gateway/console.

## Notes for reviewers

- This zod refine only blocks new org creation/rename. Existing orgs already named `admin` or `billing` (if any) are not migrated — flagging in case a startup check or migration is wanted as a follow-up.
- The CP list is the single source of truth; web has no duplicated client-side reserved list (`proxy.ts` only special-cases the default org's `-`).
- Pre-existing local typecheck error in `src/ws/handlers/usage-report.ts` reproduces on a clean tree (stale protocol build) and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)