### PR TITLE
fix(control-plane): map Logto's identity-already-in-use 422 to a 409

### DIFF
--- a/packages/control-plane/src/http/routes/me-social-identities.test.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.test.ts
@@ -64,6 +64,51 @@ describe('my social identities routes', () => {
     }
   })
 
+  it('maps "identity already in use" to a 409 the console can explain, never the 502 fallback', async () => {
+    // The 502 fallback is replaced by the edge (Cloudflare) with a CORS-less
+    // error page, so the browser reports a CORS failure instead of the conflict.
+    const identity = {
+      linkSocialIdentity: vi.fn(async () => {
+        throw new LogtoApiError('identity already in use', 422, false, 'user.identity_already_in_use')
+      })
+    }
+    const app = await slackApp({ logtoIdentity: identity } as unknown as HttpDeps)
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/me/social-identities',
+        payload: { connectorId: 'github-connector', connectorData: { code: 'c' } }
+      })
+      expect(res.statusCode).toBe(409)
+      expect(res.json()).toMatchObject({
+        code: 'user.identity_already_in_use',
+        message: 'this social account is already linked to another user'
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('maps other Logto 422s to the 400 "authorization invalid" answer', async () => {
+    const identity = {
+      linkSocialIdentity: vi.fn(async () => {
+        throw new LogtoApiError('connector session not found', 422, false, 'session.verification_session_not_found')
+      })
+    }
+    const app = await slackApp({ logtoIdentity: identity } as unknown as HttpDeps)
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/me/social-identities',
+        payload: { connectorId: 'github-connector', connectorData: { code: 'c' } }
+      })
+      expect(res.statusCode).toBe(400)
+      expect(res.json()).toMatchObject({ code: 'SOCIAL_AUTHORIZATION_INVALID' })
+    } finally {
+      await app.close()
+    }
+  })
+
   it('accepts slack as a linkable target, matching the console provider list', async () => {
     // The console offers Slack, so this route must resolve it. It gates on shape
     // and on the tenant having the connector — never on its own provider list.

--- a/packages/control-plane/src/http/routes/me-social-identities.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.ts
@@ -119,7 +119,20 @@ function logtoFailure(reply: FastifyReply, error: unknown, operation: Operation)
       message: 'connect another sign-in method before removing this one'
     })
   }
-  if (error.status === 400) {
+  // Logto says the just-authorized identity belongs to a different user. A real
+  // conflict the user must resolve — never the 502 fallback, which the edge
+  // (Cloudflare) replaces with its own CORS-less error page.
+  if (error.status === 422 && error.code === 'user.identity_already_in_use') {
+    return reply.code(409).send({
+      error: 'Conflict',
+      statusCode: 409,
+      code: error.code,
+      message: 'this social account is already linked to another user'
+    })
+  }
+  // Logto reports the other connector-response problems as 422s too — same
+  // remedy as a 400: the authorization is unusable, start over.
+  if (error.status === 400 || error.status === 422) {
     return reply.code(400).send({
       error: 'Bad Request',
       statusCode: 400,


### PR DESCRIPTION
## Problem

Linking a social account that already belongs to another user made Logto answer 422 (`user.identity_already_in_use`), which fell through to the route's 502 fallback. The edge (Cloudflare) replaces 5xx responses with its own CORS-less error page, so the browser reported a CORS failure instead of the actual conflict — the console could not explain what went wrong.

## Fix

- Map `422 user.identity_already_in_use` to a **409** with a message the console can show: "this social account is already linked to another user".
- Treat Logto's other 422s (e.g. `session.verification_session_not_found`) like 400s — the authorization is unusable, start over (`SOCIAL_AUTHORIZATION_INVALID`).

## Tests

Two new unit tests cover both mappings; `pnpm --filter @agentconnect.md/control-plane test:unit` passes (161 files, 1780 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)