### PR TITLE
fix(web): hide node count and version on the managed cloud pool card

### DIFF
--- a/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
@@ -116,8 +116,9 @@ describe('DaemonsView pool', () => {
     const html = render()
 
     expect(html.match(/AgentConnect Cloud/g)).toHaveLength(1)
-    // Serving nodes only: a row left behind by a replaced Pod must not inflate the count.
-    expect(html).toContain('2 nodes')
+    // Cloud topology stays internal: no node count, no version on the managed card.
+    expect(html).not.toContain('nodes')
+    expect(html).not.toContain('1.41.0')
     // Pod identity is cluster churn — never a name this page puts in front of anyone.
     expect(html).not.toContain('pool-member-p1')
   })
@@ -137,8 +138,7 @@ describe('DaemonsView pool', () => {
 
     const html = render()
 
-    expect(html).toContain('no nodes serving')
-    expect(html).not.toContain('nodes ·')
+    expect(html).toContain('not serving')
   })
 
   it('keeps the org’s own machines as their own cards under a labelled section', () => {

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -293,11 +293,8 @@ function PoolFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: numb
   const s = status(poolFleetStatus(members))
   const serving = members.filter((m) => m.status === 'online')
   const online = serving.length > 0
-  // The serving members share a release (they roll together); an idle pool has no version
-  // worth quoting, so the strip drops it rather than naming a Pod that is gone.
-  const meta = online
-    ? `Managed by AgentConnect · ${serving.length} node${serving.length === 1 ? '' : 's'} · ${serving[0]!.version}`
-    : 'Managed by AgentConnect · no nodes serving'
+  // Node count and version stay internal — the cloud pool doesn't expose its topology.
+  const meta = online ? 'Managed by AgentConnect' : 'Managed by AgentConnect · not serving'
   // Opens one member's detail for the runtimes, models and MCP servers the pool offers —
   // a serving one, since a member that stopped answering can no longer describe itself.
   const target = serving[0] ?? members[members.length - 1]!


### PR DESCRIPTION
## Summary
- The AgentConnect Cloud card's subtitle is now just "Managed by AgentConnect" (or "Managed by AgentConnect · not serving" when no pod is online) — the serving node count and release version are no longer exposed to org users.
- The self-hosted `ClusterFleetCard` is unchanged: an operator still sees their own cluster's node count and capacity.
- Updated `DaemonsView.pool.test.tsx` to assert the managed card exposes neither node count nor version, and to match the new offline copy.

## Test plan
- `pnpm --filter @agentconnect.md/web test` — all 1634 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)