### PR TITLE
refactor(daemon): re-home the github hook coords, webchat chunking, and fleet upgrade

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5,20 +5,14 @@ import { mkdtemp } from 'node:fs/promises'
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
 import { loadConfig, persistDaemonId, persistRelays, type FlatOverrides } from './config/load-config.js'
 import { readCliEntry, runCliUpgrade } from './lifecycle/cli-upgrade.js'
+import { FleetUpgradeCoordinator } from './lifecycle/fleet-upgrade.js'
 import { ReadinessGate, readinessSinksFromEnv, readinessState, type ReadinessState } from './readiness.js'
 import { sessionRetentionMs, type RuntimeDef } from './config/config-schema.js'
 import { discoverAgentsTolerant, type LoadedAgent } from './agents/load-agents.js'
 import { agentChildEnv } from './agents/agent-env.js'
 import { cpRuntimeEnv } from './agents/cp-overlay.js'
 import { diffAgents } from './reconciler/reconciler.js'
-import {
-  resolveRoot,
-  statePath,
-  agentRemovalObligationsDir,
-  mcpSocketPath,
-  daemonEntryForShims,
-  cliEntryPointer
-} from './paths.js'
+import { resolveRoot, statePath, agentRemovalObligationsDir, mcpSocketPath, daemonEntryForShims } from './paths.js'
 import {
   LocalStore,
   sessionKey,
@@ -223,7 +217,7 @@ import { composeRuntimeLaunch, runtimeSandboxReadRoots } from './launch/compose.
 import { resolveTrustedExecutable, trustedRuntimeReadRoots } from './runtimes/read-roots.js'
 import { nodeExecArgvModuleEntries } from './runtimes/node-exec-argv.js'
 import { makeLogger, type Logger } from './log.js'
-import { CpClient, type BootstrapUpgradeOutcome } from './cp/client.js'
+import { CpClient } from './cp/client.js'
 import { RelayManager } from './cp/relay-manager.js'
 import { CP_IDENTITY_TOKEN_PATH, readClusterIdentityToken } from './cp/cluster-identity.js'
 import { CpCollabRoutes, isSyntheticA2aChannel } from './cp/cp-collab-routes.js'
@@ -240,7 +234,6 @@ import {
   CP_URL_ENV,
   RELAY_DAEMON_SUBPROTOCOL,
   RELAY_DAEMON_WS_PATH,
-  RESERVED_RESTART_CODE,
   K8S_SUPERVISOR,
   AGENT_CONFIG_REVISION_FEATURE,
   DAEMON_BOOTSTRAP_UPGRADE_FEATURE,
@@ -282,7 +275,6 @@ import {
 } from './memory/provider.js'
 import { memoryChannelKey, MemorySandboxUnavailableError, type MemoryFs } from './memory/store.js'
 import { resolveMemoryFs } from './memory/fs.js'
-import { DAEMON_VERSION } from './version.js'
 import { CpCronRegistry } from './cp/cp-cron.js'
 import { DutyRegistry } from './cp/duty-registry.js'
 import { DutyCoordinator, type DutyHost } from './cp/duty-coordinator.js'
@@ -353,7 +345,6 @@ import type {
   EventSession,
   SessionActivity,
   Ack,
-  DaemonControlAck,
   RdWebchatPost,
   RdMsg,
   RdMsgWebchat,
@@ -398,7 +389,7 @@ import {
   type HookCompletionOwner,
   type HookDispatchContext,
   type SessionWorktreeCleanupResult
-} from './daemon/github-hook-coords.js'
+} from './github/hook-coords.js'
 import {
   FailStopError,
   LifecycleCleanupBlockedError,
@@ -920,11 +911,7 @@ export class Daemon {
   // ── lifecycle (§2.5/§5.3/§7.2/§7.3) ──
   private clock: Clock
   private requestExit: (code: number) => void
-  // Guards against a second CP lifecycle command (restart/upgrade) racing one
-  // already in flight (§7.1). Cleared only if an upgrade aborts before exiting.
-  private lifecycleInFlight = false
-  private fleetUpgradeInFlight?: { targetVersion: string; installation: Promise<boolean> }
-  private fleetExitStarted = false
+  private readonly fleetUpgrade: FleetUpgradeCoordinator
   // Whole-daemon drain gate: once set, no new turns are dispatched (SIGTERM, or a
   // scope:daemon drain). Agent-scoped drains gate just their agentId.
   private draining = false
@@ -1144,6 +1131,17 @@ export class Daemon {
       ttlMs: Daemon.PROBE_TTL_MS
     })
     this.requestExit = opts.requestExit ?? ((code) => process.exit(code))
+    this.fleetUpgrade = new FleetUpgradeCoordinator({
+      log: () => this.log,
+      clock: () => this.clock,
+      shutdownDrainMs: () => this.cfg.limits.shutdownDrainMs,
+      supervisor: () => this.opts.supervisor,
+      k8s: () => this.k8s,
+      root: () => this.opts.root,
+      upgradeInstaller: () => this.opts.upgradeInstaller,
+      stop: () => this.stop(),
+      requestExit: (code) => this.requestExit(code)
+    })
   }
 
   /** Say what the boot probe found: missing SRT dependencies silently run agents unconfined AND fail every managed-skill install (#956). */
@@ -13593,116 +13591,6 @@ export class Daemon {
     // negotiates ACK support; scheduling here would hammer legacy EVT delivery.
   }
 
-  private admitFleetExit(
-    kind: 'restart' | 'upgrade',
-    targetVersion?: string
-  ):
-    { accepted: false; reason: string } | { accepted: true; root: string; cliEntry?: string; willDrainUntil?: string } {
-    const refuse = (reason: string) => {
-      this.log.warn(`cp: ${kind} refused — ${reason}`)
-      return { accepted: false as const, reason }
-    }
-    const supervisor = this.opts.supervisor
-    const imageOwnsVersion = "the running version is this pod's image — roll the Deployment instead of self-installing"
-    // Refused on the MODE, not the marker: a live upgrade is delivered without consulting
-    // the advertised capability, so this is the last line of defence, and an inherited
-    // AGENTCONNECT_SUPERVISOR plus a stale cli-entry on the root volume must not reach the
-    // installer — the same invariant bootstrapUpgradeCapable() already holds.
-    if (kind === 'upgrade' && this.k8s) return refuse(imageOwnsVersion)
-    // The kubelet restarts the container in place after the reserved exit code, but never
-    // changes the image, so it supervises restart and not upgrade.
-    if (supervisor === K8S_SUPERVISOR) {
-      if (kind === 'upgrade') return refuse(imageOwnsVersion)
-    } else if (supervisor !== 'cli' && supervisor !== 'service') {
-      const reason = `no supervisor (AGENTCONNECT_SUPERVISOR=${supervisor ?? 'unset'}) — a bare \`run\` cannot ${kind}; use the CLI or an installed service`
-      return refuse(reason)
-    }
-    if (this.lifecycleInFlight) {
-      return refuse('another lifecycle operation is already in progress')
-    }
-
-    const root = resolveRoot(this.opts.root)
-    let cliEntry: string | undefined
-    if (kind === 'upgrade') {
-      cliEntry = readCliEntry(root)
-      if (!cliEntry) {
-        const reason = `cannot locate the CLI (${cliEntryPointer(root)} missing or invalid) to run the upgrade`
-        return refuse(reason)
-      }
-      if (!targetVersion) return refuse('upgrade requires a targetVersion')
-    }
-
-    this.lifecycleInFlight = true
-    const willDrainUntil =
-      kind === 'restart' ? new Date(this.clock.now() + this.cfg.limits.shutdownDrainMs).toISOString() : undefined
-    this.log.info(`cp: ${kind}${targetVersion ? ` → ${targetVersion}` : ''} accepted`)
-    return { accepted: true, root, ...(cliEntry ? { cliEntry } : {}), ...(willDrainUntil ? { willDrainUntil } : {}) }
-  }
-
-  private startFleetUpgrade(cliEntry: string, targetVersion: string, root: string): Promise<boolean> {
-    const installation = Promise.resolve()
-      .then(() => (this.opts.upgradeInstaller ?? runCliUpgrade)(cliEntry, targetVersion, root, this.log))
-      .catch((err) => {
-        this.log.error(`cp: could not install daemon ${targetVersion}: ${formatErr(err)}`)
-        return false
-      })
-      .then((ok) => {
-        if (!ok) {
-          this.log.error(`cp: upgrade to ${targetVersion} aborted — daemon continues on the current version`)
-          this.lifecycleInFlight = false
-          if (this.fleetUpgradeInFlight?.installation === installation) this.fleetUpgradeInFlight = undefined
-        }
-        return ok
-      })
-    this.fleetUpgradeInFlight = { targetVersion, installation }
-    return installation
-  }
-
-  private finishFleetExit(kind: 'restart' | 'upgrade'): void {
-    if (this.fleetExitStarted) return
-    this.fleetExitStarted = true
-    void (async () => {
-      try {
-        await this.stop()
-      } catch (err) {
-        this.log.error(`cp: ${kind} shutdown failed: ${formatErr(err)}`)
-      } finally {
-        this.requestExit(RESERVED_RESTART_CODE)
-      }
-    })()
-  }
-
-  /** Admit immediately, then install before the existing drain-and-relaunch path. */
-  private scheduleFleetExit(kind: 'restart' | 'upgrade', targetVersion?: string): DaemonControlAck {
-    const admission = this.admitFleetExit(kind, targetVersion)
-    if (!admission.accepted) return admission
-    void (async () => {
-      if (kind === 'upgrade' && !(await this.startFleetUpgrade(admission.cliEntry!, targetVersion!, admission.root))) {
-        return
-      }
-      this.finishFleetExit(kind)
-    })()
-
-    return { accepted: true, ...(admission.willDrainUntil ? { willDrainUntil: admission.willDrainUntil } : {}) }
-  }
-
-  private async runBootstrapFleetUpgrade(targetVersion: string): Promise<BootstrapUpgradeOutcome> {
-    if (targetVersion === DAEMON_VERSION) return { status: 'current' }
-    const existing = this.fleetUpgradeInFlight
-    if (existing?.targetVersion === targetVersion) {
-      const installed = await existing.installation
-      return installed
-        ? { status: 'installed', restart: () => this.finishFleetExit('upgrade') }
-        : { status: 'failed', reason: `failed to install ${targetVersion}` }
-    }
-    const admission = this.admitFleetExit('upgrade', targetVersion)
-    if (!admission.accepted) return { status: 'failed', reason: admission.reason }
-    if (!(await this.startFleetUpgrade(admission.cliEntry!, targetVersion, admission.root))) {
-      return { status: 'failed', reason: `failed to install ${targetVersion}` }
-    }
-    return { status: 'installed', restart: () => this.finishFleetExit('upgrade') }
-  }
-
   // ── ConfigApply seam (CP changes config, never live routing) ──
   private cpConfigApply(): ConfigApply {
     return buildConfigApply(this.configApplyHost())
@@ -13786,7 +13674,7 @@ export class Daemon {
         this.observedChannelsSync.retractChannels(integrationId, channelIds),
       runCronNow: (cronId) => this.runCronNow(cronId),
       runDrain: (drain, onProgress) => this.runDrain(drain, onProgress),
-      scheduleFleetExit: (kind, targetVersion) => this.scheduleFleetExit(kind, targetVersion)
+      scheduleFleetExit: (kind, targetVersion) => this.fleetUpgrade.scheduleFleetExit(kind, targetVersion)
     }
   }
 
@@ -13829,7 +13717,7 @@ export class Daemon {
       hostCount: () => this.hosts.size,
       activeSessions: () => this.pending.size,
       bootstrapUpgradeCapable: () => this.bootstrapUpgradeCapable(),
-      runBootstrapFleetUpgrade: (targetVersion) => this.runBootstrapFleetUpgrade(targetVersion),
+      runBootstrapFleetUpgrade: (targetVersion) => this.fleetUpgrade.runBootstrapFleetUpgrade(targetVersion),
       readiness: () => this.readiness,
       probeRuntimesAndEmit: () => this.probeRuntimesAndEmit(),
       syncOrganizationSuggestions: () => this.syncOrganizationSuggestions(),

--- a/packages/daemon/src/daemon/text.ts
+++ b/packages/daemon/src/daemon/text.ts
@@ -21,31 +21,3 @@ export function formatErrWithCauses(err: unknown): string {
   }
   return parts.join('\nCaused by: ')
 }
-
-// Budget for the inline text carried by one WebchatOutput payload. Well under
-// the 256 KiB JSON frame cap so the envelope overhead (conversationId/turnId/index/
-// kind + JSON escaping of control chars, up to a 6× blowup) can never push a chunk
-// over the wire limit. Long agent output is split across several chunks at this size.
-export const WEBCHAT_CHUNK_BYTES = 32 * 1024
-
-/** Split `text` into pieces whose UTF-8 byte length each stays under WEBCHAT_CHUNK_BYTES
- *  so no single relay `rd/chat` payload exceeds the 256 KiB cap. Splits on byte budget
- *  by character (never mid-code-point); short text returns a single piece. */
-export function chunkText(text: string): string[] {
-  if (Buffer.byteLength(text) <= WEBCHAT_CHUNK_BYTES) return [text]
-  const out: string[] = []
-  let buf = ''
-  let bytes = 0
-  for (const ch of text) {
-    const w = Buffer.byteLength(ch)
-    if (bytes + w > WEBCHAT_CHUNK_BYTES && buf) {
-      out.push(buf)
-      buf = ''
-      bytes = 0
-    }
-    buf += ch
-    bytes += w
-  }
-  if (buf) out.push(buf)
-  return out
-}

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -13,7 +13,7 @@ import type { SlackConnection } from '../slack/connection.js'
 import type { TelegramConnection } from '../telegram/connection.js'
 import type { DiscordConnection } from '../discord/connection.js'
 import type { FeishuConnection } from '../feishu/connection.js'
-import type { GithubReplyTarget, HookDispatchContext } from './github-hook-coords.js'
+import type { GithubReplyTarget, HookDispatchContext } from '../github/hook-coords.js'
 import type { WebchatTurnContext } from '../webchat/types.js'
 
 /** Thrown to a `dispatch()` caller when the per-session admission queue is at its depth

--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -7,15 +7,10 @@ import type {
   HookReviewResult,
   RdMsgHook
 } from '@agentconnect.md/protocol'
-import type {
-  GithubReviewEffect,
-  GithubReviewEvent,
-  GithubReviewTarget,
-  GithubReviewVerdict
-} from '../github/review.js'
+import type { GithubReviewEffect, GithubReviewEvent, GithubReviewTarget, GithubReviewVerdict } from './review.js'
 import type { SessionWorktreeRemoval } from '../workspace/workspace-manager.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
-import type { QueueEntry } from './turn-types.js'
+import type { QueueEntry } from '../daemon/turn-types.js'
 
 export function hookSnapshot(msg: RdMsgHook): HookConfigSnapshot | undefined {
   if (

--- a/packages/daemon/src/github/queue-admission.ts
+++ b/packages/daemon/src/github/queue-admission.ts
@@ -22,7 +22,7 @@ import {
   type GithubRevisionAdmissionPlan,
   type GithubReviewBatch,
   type HookDispatchContext
-} from '../daemon/github-hook-coords.js'
+} from './hook-coords.js'
 import type { QueueEntry } from '../daemon/turn-types.js'
 
 /** Flatten the gate's live heads plus every queued entry into one candidate list. */

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -47,7 +47,7 @@ import {
   type HookCompletionOwner,
   type HookDispatchContext,
   type SessionWorktreeCleanupResult
-} from '../daemon/github-hook-coords.js'
+} from './hook-coords.js'
 import type { CallMeta, QueueEntry } from '../daemon/turn-types.js'
 import type { WebchatTurnContext } from '../webchat/types.js'
 import { initiatorLabel } from '../workspace/session-branch.js'

--- a/packages/daemon/src/lifecycle/fleet-upgrade.ts
+++ b/packages/daemon/src/lifecycle/fleet-upgrade.ts
@@ -1,0 +1,146 @@
+import { K8S_SUPERVISOR, RESERVED_RESTART_CODE, type DaemonControlAck } from '@agentconnect.md/protocol'
+import type { Clock } from '@agentconnect.md/connection'
+import { cliEntryPointer, resolveRoot } from '../paths.js'
+import { readCliEntry, runCliUpgrade } from './cli-upgrade.js'
+import type { BootstrapUpgradeOutcome } from '../cp/client.js'
+import type { Logger } from '../log.js'
+import { DAEMON_VERSION } from '../version.js'
+import { formatErr } from '../daemon/text.js'
+
+/** Exactly what the fleet restart/upgrade path touches on the Daemon. */
+export interface FleetUpgradeHost {
+  log: () => Logger
+  clock: () => Clock
+  shutdownDrainMs: () => number
+  /** Who supervises this process — 'cli', 'service', 'k8s', or absent (bare `run`). */
+  supervisor: () => string | undefined
+  k8s: () => boolean
+  root: () => string | undefined
+  upgradeInstaller: () => typeof runCliUpgrade | undefined
+  stop: () => Promise<void>
+  requestExit: (code: number) => void
+}
+
+type FleetExitKind = 'restart' | 'upgrade'
+
+type FleetAdmission =
+  { accepted: false; reason: string } | { accepted: true; root: string; cliEntry?: string; willDrainUntil?: string }
+
+/** CP-commanded daemon restart and self-installing upgrade (§7.1/§7.2). */
+export class FleetUpgradeCoordinator {
+  // Guards against a second CP lifecycle command (restart/upgrade) racing one
+  // already in flight (§7.1). Cleared only if an upgrade aborts before exiting.
+  private lifecycleInFlight = false
+  private fleetUpgradeInFlight?: { targetVersion: string; installation: Promise<boolean> }
+  private fleetExitStarted = false
+
+  constructor(private readonly host: FleetUpgradeHost) {}
+
+  private admitFleetExit(kind: FleetExitKind, targetVersion?: string): FleetAdmission {
+    const log = this.host.log()
+    const refuse = (reason: string) => {
+      log.warn(`cp: ${kind} refused — ${reason}`)
+      return { accepted: false as const, reason }
+    }
+    const supervisor = this.host.supervisor()
+    const imageOwnsVersion = "the running version is this pod's image — roll the Deployment instead of self-installing"
+    // Refused on the MODE, not the marker: a live upgrade is delivered without consulting
+    // the advertised capability, so this is the last line of defence, and an inherited
+    // AGENTCONNECT_SUPERVISOR plus a stale cli-entry on the root volume must not reach the
+    // installer — the same invariant bootstrapUpgradeCapable() already holds.
+    if (kind === 'upgrade' && this.host.k8s()) return refuse(imageOwnsVersion)
+    // The kubelet restarts the container in place after the reserved exit code, but never
+    // changes the image, so it supervises restart and not upgrade.
+    if (supervisor === K8S_SUPERVISOR) {
+      if (kind === 'upgrade') return refuse(imageOwnsVersion)
+    } else if (supervisor !== 'cli' && supervisor !== 'service') {
+      const reason = `no supervisor (AGENTCONNECT_SUPERVISOR=${supervisor ?? 'unset'}) — a bare \`run\` cannot ${kind}; use the CLI or an installed service`
+      return refuse(reason)
+    }
+    if (this.lifecycleInFlight) {
+      return refuse('another lifecycle operation is already in progress')
+    }
+
+    const root = resolveRoot(this.host.root())
+    let cliEntry: string | undefined
+    if (kind === 'upgrade') {
+      cliEntry = readCliEntry(root)
+      if (!cliEntry) {
+        const reason = `cannot locate the CLI (${cliEntryPointer(root)} missing or invalid) to run the upgrade`
+        return refuse(reason)
+      }
+      if (!targetVersion) return refuse('upgrade requires a targetVersion')
+    }
+
+    this.lifecycleInFlight = true
+    const willDrainUntil =
+      kind === 'restart' ? new Date(this.host.clock().now() + this.host.shutdownDrainMs()).toISOString() : undefined
+    log.info(`cp: ${kind}${targetVersion ? ` → ${targetVersion}` : ''} accepted`)
+    return { accepted: true, root, ...(cliEntry ? { cliEntry } : {}), ...(willDrainUntil ? { willDrainUntil } : {}) }
+  }
+
+  private startFleetUpgrade(cliEntry: string, targetVersion: string, root: string): Promise<boolean> {
+    const log = this.host.log()
+    const installation = Promise.resolve()
+      .then(() => (this.host.upgradeInstaller() ?? runCliUpgrade)(cliEntry, targetVersion, root, log))
+      .catch((err) => {
+        log.error(`cp: could not install daemon ${targetVersion}: ${formatErr(err)}`)
+        return false
+      })
+      .then((ok) => {
+        if (!ok) {
+          log.error(`cp: upgrade to ${targetVersion} aborted — daemon continues on the current version`)
+          this.lifecycleInFlight = false
+          if (this.fleetUpgradeInFlight?.installation === installation) this.fleetUpgradeInFlight = undefined
+        }
+        return ok
+      })
+    this.fleetUpgradeInFlight = { targetVersion, installation }
+    return installation
+  }
+
+  private finishFleetExit(kind: FleetExitKind): void {
+    if (this.fleetExitStarted) return
+    this.fleetExitStarted = true
+    void (async () => {
+      try {
+        await this.host.stop()
+      } catch (err) {
+        this.host.log().error(`cp: ${kind} shutdown failed: ${formatErr(err)}`)
+      } finally {
+        this.host.requestExit(RESERVED_RESTART_CODE)
+      }
+    })()
+  }
+
+  /** Admit immediately, then install before the existing drain-and-relaunch path. */
+  scheduleFleetExit(kind: FleetExitKind, targetVersion?: string): DaemonControlAck {
+    const admission = this.admitFleetExit(kind, targetVersion)
+    if (!admission.accepted) return admission
+    void (async () => {
+      if (kind === 'upgrade' && !(await this.startFleetUpgrade(admission.cliEntry!, targetVersion!, admission.root))) {
+        return
+      }
+      this.finishFleetExit(kind)
+    })()
+
+    return { accepted: true, ...(admission.willDrainUntil ? { willDrainUntil: admission.willDrainUntil } : {}) }
+  }
+
+  async runBootstrapFleetUpgrade(targetVersion: string): Promise<BootstrapUpgradeOutcome> {
+    if (targetVersion === DAEMON_VERSION) return { status: 'current' }
+    const existing = this.fleetUpgradeInFlight
+    if (existing?.targetVersion === targetVersion) {
+      const installed = await existing.installation
+      return installed
+        ? { status: 'installed', restart: () => this.finishFleetExit('upgrade') }
+        : { status: 'failed', reason: `failed to install ${targetVersion}` }
+    }
+    const admission = this.admitFleetExit('upgrade', targetVersion)
+    if (!admission.accepted) return { status: 'failed', reason: admission.reason }
+    if (!(await this.startFleetUpgrade(admission.cliEntry!, targetVersion, admission.root))) {
+      return { status: 'failed', reason: `failed to install ${targetVersion}` }
+    }
+    return { status: 'installed', restart: () => this.finishFleetExit('upgrade') }
+  }
+}

--- a/packages/daemon/src/webchat/chunk.ts
+++ b/packages/daemon/src/webchat/chunk.ts
@@ -1,0 +1,26 @@
+// Budget for the inline text carried by one WebchatOutput payload. Well under the 256 KiB
+// JSON frame cap so envelope overhead (conversationId/turnId/index/kind + JSON escaping of
+// control chars, up to a 6x blowup) can never push a chunk over the wire limit.
+export const WEBCHAT_CHUNK_BYTES = 32 * 1024
+
+/** Split `text` into pieces whose UTF-8 byte length each stays under WEBCHAT_CHUNK_BYTES
+ *  so no single relay `rd/chat` payload exceeds the 256 KiB cap. Splits on byte budget
+ *  by character (never mid-code-point); short text returns a single piece. */
+export function chunkText(text: string): string[] {
+  if (Buffer.byteLength(text) <= WEBCHAT_CHUNK_BYTES) return [text]
+  const out: string[] = []
+  let buf = ''
+  let bytes = 0
+  for (const ch of text) {
+    const w = Buffer.byteLength(ch)
+    if (bytes + w > WEBCHAT_CHUNK_BYTES && buf) {
+      out.push(buf)
+      buf = ''
+      bytes = 0
+    }
+    buf += ch
+    bytes += w
+  }
+  if (buf) out.push(buf)
+  return out
+}

--- a/packages/daemon/src/webchat/turn-output.ts
+++ b/packages/daemon/src/webchat/turn-output.ts
@@ -8,7 +8,7 @@ import type { SessionImageAttachment, WebchatEvent } from '@agentconnect.md/prot
 import type { LocalStore } from '../store/local-store.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
 import { isNoResponsePrefix } from '../session/no-response.js'
-import { chunkText } from '../daemon/text.js'
+import { chunkText } from './chunk.js'
 import type { Pending } from '../daemon/turn-types.js'
 
 /** One turn's live webchat state — the sink, its output cursor, and the sentinel hold. */

--- a/packages/daemon/test/daemon-fleet-upgrade.test.ts
+++ b/packages/daemon/test/daemon-fleet-upgrade.test.ts
@@ -36,10 +36,10 @@ describe('daemon fleet upgrade coordination', () => {
     const daemon = new Daemon({ root: scaffold(), supervisor: 'cli', upgradeInstaller, requestExit })
     ;(daemon as any).stop = vi.fn(async () => {})
 
-    expect((daemon as any).scheduleFleetExit('upgrade', '9.9.9')).toEqual({ accepted: true })
+    expect((daemon as any).fleetUpgrade.scheduleFleetExit('upgrade', '9.9.9')).toEqual({ accepted: true })
     await vi.waitFor(() => expect(upgradeInstaller).toHaveBeenCalledTimes(1))
 
-    const reconnectOutcome = (daemon as any).runBootstrapFleetUpgrade('9.9.9')
+    const reconnectOutcome = (daemon as any).fleetUpgrade.runBootstrapFleetUpgrade('9.9.9')
     finishInstall(true)
 
     const outcome = await reconnectOutcome

--- a/packages/daemon/test/daemon-supervisor-k8s.test.ts
+++ b/packages/daemon/test/daemon-supervisor-k8s.test.ts
@@ -61,7 +61,7 @@ describe('daemon lifecycle under the k8s supervisor', () => {
     const realStop = instance.stop.bind(instance)
     ;(instance as any).stop = vi.fn(async () => {})
     try {
-      const ack = (instance as any).scheduleFleetExit('restart')
+      const ack = (instance as any).fleetUpgrade.scheduleFleetExit('restart')
       expect(ack.accepted).toBe(true)
       // The drain window is advertised so the control plane knows how long to wait.
       expect(typeof ack.willDrainUntil).toBe('string')
@@ -76,14 +76,14 @@ describe('daemon lifecycle under the k8s supervisor', () => {
     const instance = daemon({ k8s: true, supervisor: K8S_SUPERVISOR })
     await instance.start()
     try {
-      const ack = (instance as any).admitFleetExit('upgrade', '9.9.9')
+      const ack = (instance as any).fleetUpgrade.admitFleetExit('upgrade', '9.9.9')
       expect(ack.accepted).toBe(false)
       // The reason has to describe the real situation: a cli-entry exists here, so the
       // generic "no supervisor" message would send an operator looking in the wrong place.
       expect(ack.reason).toMatch(/image/)
       expect(ack.reason).not.toMatch(/no supervisor/)
       // A refused admission must not latch the lifecycle, or later restarts wedge.
-      expect((instance as any).lifecycleInFlight).toBe(false)
+      expect((instance as any).fleetUpgrade.lifecycleInFlight).toBe(false)
     } finally {
       await instance.stop()
     }
@@ -98,10 +98,10 @@ describe('daemon lifecycle under the k8s supervisor', () => {
       const instance = daemon({ k8s: true, supervisor: marker })
       await instance.start()
       try {
-        const ack = (instance as any).admitFleetExit('upgrade', '9.9.9')
+        const ack = (instance as any).fleetUpgrade.admitFleetExit('upgrade', '9.9.9')
         expect(ack.accepted).toBe(false)
         expect(ack.reason).toMatch(/image/)
-        expect((instance as any).lifecycleInFlight).toBe(false)
+        expect((instance as any).fleetUpgrade.lifecycleInFlight).toBe(false)
       } finally {
         await instance.stop()
       }
@@ -115,7 +115,7 @@ describe('daemon lifecycle under the k8s supervisor', () => {
     const instance = daemon({ k8s: true, supervisor: 'service' })
     await instance.start()
     try {
-      expect((instance as any).admitFleetExit('restart').accepted).toBe(true)
+      expect((instance as any).fleetUpgrade.admitFleetExit('restart').accepted).toBe(true)
     } finally {
       await instance.stop()
     }
@@ -125,7 +125,7 @@ describe('daemon lifecycle under the k8s supervisor', () => {
     const instance = daemon({ k8s: true })
     await instance.start()
     try {
-      const ack = (instance as any).admitFleetExit('restart')
+      const ack = (instance as any).fleetUpgrade.admitFleetExit('restart')
       expect(ack.accepted).toBe(false)
       // Exiting without a supervisor leaves the daemon down, so the mode alone is not
       // enough — the launcher has to declare that something will bring it back.
@@ -139,7 +139,7 @@ describe('daemon lifecycle under the k8s supervisor', () => {
     const instance = daemon({ supervisor: 'service' })
     await instance.start()
     try {
-      expect((instance as any).admitFleetExit('upgrade', '9.9.9').accepted).toBe(true)
+      expect((instance as any).fleetUpgrade.admitFleetExit('upgrade', '9.9.9').accepted).toBe(true)
     } finally {
       await instance.stop()
     }


### PR DESCRIPTION
Three small, mechanical re-homings — no behavior change.

## 1. `github-hook-coords.ts` → `src/github/hook-coords.ts`
It was already pure GitHub-hook vocabulary sitting under `src/daemon/`. `git mv` plus four importer updates (`daemon.ts`, `daemon/turn-types.ts`, `github/queue-admission.ts`, `github/review-orchestrator.ts`).

## 2. Webchat chunking → `src/webchat/chunk.ts`
`WEBCHAT_CHUNK_BYTES` and `chunkText` exist for the webchat 256 KiB frame cap and had exactly one caller, `webchat/turn-output.ts`. `daemon/text.ts` is now only `formatErr` / `formatErrWithCauses`.

## 3. Fleet restart/upgrade → `src/lifecycle/fleet-upgrade.ts`
`admitFleetExit`, `startFleetUpgrade`, `finishFleetExit`, `scheduleFleetExit`, and `runBootstrapFleetUpgrade` move onto a `FleetUpgradeCoordinator` next to the `runCliUpgrade` installer they drive. It also takes the three fields it exclusively owned: `lifecycleInFlight`, `fleetUpgradeInFlight`, `fleetExitStarted`. The host literal is the whole remaining coupling — `log`, `clock`, `shutdownDrainMs`, `supervisor`, `k8s`, `root`, `upgradeInstaller`, `stop`, `requestExit`.

**No delegates kept.** Call sites rewired to hold the coordinator:
- `configApplyHost().scheduleFleetExit` → `this.fleetUpgrade.scheduleFleetExit(...)`
- `cpClientDepsHost().runBootstrapFleetUpgrade` → `this.fleetUpgrade.runBootstrapFleetUpgrade(...)`
- test pokes in `daemon-fleet-upgrade.test.ts` / `daemon-supervisor-k8s.test.ts` retargeted to `(daemon as any).fleetUpgrade.*`, including the `lifecycleInFlight` assertions.

`DAEMON_VERSION`, `RESERVED_RESTART_CODE`, `DaemonControlAck`, `BootstrapUpgradeOutcome`, and `cliEntryPointer` left `daemon.ts`'s import list with the cluster.

## Verification
`pnpm --filter @agentconnect.md/daemon typecheck`; vitest `daemon-fleet-upgrade`, `daemon-supervisor-k8s`, `daemon-lifecycle`, `daemon-hook`, `daemon-webchat`, `daemon-smoke` (226 tests, all pass); prettier + eslint on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)