### PR TITLE
refactor(daemon): extract the launch assembly into src/launch/assemble.ts

### DIFF
--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -5,7 +5,7 @@ import { loadConfig } from '../config/load-config.js'
 import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from '../runtimes/registry.js'
 import { selectAgent } from '../agents/load-agents.js'
 import { agentChildEnv } from '../agents/agent-env.js'
-import { cleanupConfigFiles, materializeConfigFiles } from '../shim/config-file-env.js'
+import { cleanupConfigFiles } from '../shim/config-file-env.js'
 import { memoryKindOf, memoryProviderFor } from '../memory/provider.js'
 import { WorkspaceManager } from '../workspace/workspace-manager.js'
 import { configureWorkspaceGitOrigins } from '../workspace/git-origin-policy.js'
@@ -18,7 +18,7 @@ import { installedRuntimeCatalog } from '../runtimes/probe.js'
 import { probeAllRuntimes, type ProbeOptions, type RuntimeProbeResult } from '../runtimes/runtime-prober.js'
 import { defaultProbeHostFactory } from '../acp/probe-host-factory.js'
 import { CuratedRuntimeAdmission } from '../runtimes/curated-admission.js'
-import { composeRuntimeLaunch } from '../launch/compose.js'
+import { assembleRuntimeLaunch } from '../launch/assemble.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { persistSkillSandboxRequirement } from '../skills/skill-sandbox-policy.js'
 
@@ -110,19 +110,15 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
 
   const agentEnv = agentChildEnv(agent)
   const runtimeEnv = Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
-  // Config-file secrets: same materialization the daemon performs at host spawn
-  // (shim/config-file-env.ts) — *_DATA content becomes a file, the pointer var
-  // replaces the raw value in the child env.
-  const configFiles = materializeConfigFiles(agent.dir, { ...runtimeEnv, ...agentEnv })
-  for (const name of configFiles.strip) {
-    delete agentEnv[name]
-    delete runtimeEnv[name]
-  }
-  Object.assign(agentEnv, configFiles.env)
-  for (const notice of configFiles.notices) out.write(`⚠️ ${notice}\n`)
   const memoryAgent =
     memoryKindOf(agent) === 'native' && runInSandbox ? { ...agent, dir: runtimeHomePath(agent.dir) } : agent
-  const composed = composeRuntimeLaunch({
+  // Memory backend env joins the agent env BEFORE materialization, as the daemon does, so
+  // config-file detection sees the same child env on both paths.
+  Object.assign(agentEnv, memoryProviderFor(memoryAgent, runtime, agentEnv).runtimeEnv())
+  // The standalone chat CLI runs one agent locally, so it owns a plane with nothing registered
+  // on it: git runs here and no path lives in a sandbox.
+  const workspaces = new WorkspaceManager()
+  const assembled = assembleRuntimeLaunch({
     runtimeId: agent.runtime,
     runtime,
     provider: memoryKindOf(agent),
@@ -131,20 +127,25 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     runInSandbox,
     daemonRoot: root,
     agentsRoot: cfg.agentsDir,
-    explicitEnv: {
-      ...runtimeEnv,
-      ...agentEnv,
-      ...memoryProviderFor(memoryAgent, runtime, agentEnv).runtimeEnv()
-    },
+    runtimeEnv,
+    agentEnv,
+    configFileDir: agent.dir,
+    // Same sandbox write carve-back the daemon grants: without it a sandboxed chat run against a
+    // git-repo agent cannot write its own session worktrees.
+    trustedWorkspaceWriteRoots:
+      runInSandbox && agent.workspace.mode === 'git-repo' ? [workspaces.sessionWorktreeRoot(agent)] : undefined,
+    // No daemon here, so there is no MCP bridge socket, gh wrapper, or git-credential shim to carve
+    // back: mcpSocketPath / allowModelToolUnixSockets / runtimeReadRoots stay genuinely unused.
     sandboxMechanism
   })
+  for (const notice of assembled.configFiles?.notices ?? []) out.write(`⚠️ ${notice}\n`)
   const hostOptions: ConstructorParameters<typeof AcpHost>[1] = {
     onUpdate: renderUpdate(out),
     runtimeId: agent.runtime,
     isolateAccountApps: cfg.security.isolateAccountApps,
-    env: composed.launch.env,
-    inheritProcessEnv: composed.launch.inheritProcessEnv,
-    sandbox: composed.launch.sandbox,
+    env: assembled.launch.env,
+    inheritProcessEnv: assembled.launch.inheritProcessEnv,
+    sandbox: assembled.launch.sandbox,
     configPrefs: {
       model: agent.runtimeOverrides?.model,
       permissionMode: agent.permissionMode,
@@ -154,8 +155,8 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     }
   }
   const host = opts.hostFactory
-    ? opts.hostFactory(composed.runtime, hostOptions)
-    : new AcpHost(composed.runtime, hostOptions)
+    ? opts.hostFactory(assembled.runtime, hostOptions)
+    : new AcpHost(assembled.runtime, hostOptions)
   // The adapter child runs in its own process group (see AcpHost.start), so a
   // terminal Ctrl-C no longer kills it as a side effect — Node's default SIGINT
   // exit would skip the finally below and leak it. Stop the host, then re-exit.
@@ -169,9 +170,6 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   }
   process.once('SIGINT', onSigint)
   try {
-    // The standalone chat CLI runs one agent locally, so it owns a plane with nothing registered
-    // on it: git runs here and no path lives in a sandbox.
-    const workspaces = new WorkspaceManager()
     const cwd = await workspaces.prepareWorkspace(agent, {
       skillsStateDir: join(root, 'skill-installs'),
       skillsAgentId: entry?.skillsAgentId ?? null

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -213,7 +213,8 @@ import {
 } from './runtimes/model-provider-config.js'
 import { DEFAULT_MODEL_KEY_TTL_SECONDS, KeyServerClient, type KeyGrant } from './key-server/client.js'
 import { CuratedRuntimeAdmission } from './runtimes/curated-admission.js'
-import { composeRuntimeLaunch, runtimeSandboxReadRoots } from './launch/compose.js'
+import { runtimeSandboxReadRoots } from './launch/compose.js'
+import { assembleRuntimeLaunch } from './launch/assemble.js'
 import { resolveTrustedExecutable, trustedRuntimeReadRoots } from './runtimes/read-roots.js'
 import { nodeExecArgvModuleEntries } from './runtimes/node-exec-argv.js'
 import { makeLogger, type Logger } from './log.js'
@@ -2990,13 +2991,9 @@ export class Daemon {
           : sessionGitPolicyEnv()
         : {})
     }
-    // Config-file secrets (shim/config-file-env.ts): materialize `*_DATA`
-    // contents under the agent dir and point the tool-native env vars
-    // (KUBECONFIG / DOCKER_CONFIG) at the result; the raw values are stripped
-    // from the child env. Detection spans the runtime-def env too, so an
-    // explicit pointer var configured anywhere wins and skips materialization.
-    // The pre-strip merged env is snapshotted so the idle sweep can delete the
-    // files and rematerializeConfigFiles() can re-write them before a later turn.
+    // Config-file secrets are materialized by assembleRuntimeLaunch below; the pre-strip merged env
+    // is snapshotted so the idle sweep can delete the files and rematerializeConfigFiles() can
+    // re-write them before a later turn.
     if (excludeAgentToolCredentials) {
       // A dream host needs NONE of the agent's tool credentials. Do NOT
       // materialize config files (it has no cleanup path), and DELETE the raw
@@ -3020,18 +3017,6 @@ export class Daemon {
         delete env[secret.name]
         delete runtimeEnv[secret.name]
       }
-    } else {
-      const configFileSourceEnv = { ...runtimeEnv, ...env }
-      const configFiles = materializeConfigFiles(agent.dir, configFileSourceEnv)
-      for (const name of configFiles.strip) {
-        delete env[name]
-        delete runtimeEnv[name]
-      }
-      Object.assign(env, configFiles.env)
-      this.queueSpawnNotices(agentId, configFiles.notices)
-      if (Object.keys(configFiles.env).length > 0) {
-        configFileState = { childEnv: configFileSourceEnv, materialized: true }
-      }
     }
     const shimDirs = new Set<string>()
     if (githubAppCredentials && this.ghBinDir) {
@@ -3045,14 +3030,7 @@ export class Daemon {
     if (shimDirs.size > 0) {
       env.PATH = `${[...shimDirs].join(':')}:${env.PATH ?? process.env.PATH ?? ''}`
     }
-    const launchEnv = { ...runtimeEnv, ...env }
     const target = opts.modelCredential?.target ?? modelProviderTarget(agent, runtime)
-    if (this.k8s && target) {
-      if (opts.modelCredential) applyModelCredential(target, launchEnv, opts.modelCredential.credential)
-      else if (!this.keyServer && this.staticModelCredential) {
-        applyStaticModelConfig(target, launchEnv, this.staticModelCredential)
-      }
-    }
     // OS sandbox decision (issue #312). security.requireSandbox forces every agent
     // on; otherwise the per-agent preference is effective only when this host has a
     // mechanism. The writable set is derived from the TRUSTED agent dir
@@ -3064,7 +3042,7 @@ export class Daemon {
     let launch: ReturnType<typeof prepareRuntimeLaunch>
     let launchRuntime = runtime
     try {
-      const composed = composeRuntimeLaunch({
+      const assembled = assembleRuntimeLaunch({
         runtimeId: agent.runtime,
         runtime,
         provider: memoryKindOf(agent),
@@ -3073,14 +3051,24 @@ export class Daemon {
         runInSandbox,
         daemonRoot: this.root,
         agentsRoot: cfg.agentsDir,
+        runtimeEnv,
+        agentEnv: env,
+        // A dream host materializes nothing: it has no cleanup path and needs none of these secrets.
+        ...(excludeAgentToolCredentials ? {} : { configFileDir: agent.dir }),
+        finalizeLaunchEnv: (launchEnv) => {
+          if (!this.k8s || !target) return
+          if (opts.modelCredential) applyModelCredential(target, launchEnv, opts.modelCredential.credential)
+          else if (!this.keyServer && this.staticModelCredential) {
+            applyStaticModelConfig(target, launchEnv, this.staticModelCredential)
+          }
+        },
         runtimeReadRoots: runInSandbox
-          ? this.sandboxRuntimeReadRoots(agent, runtime, launchEnv, githubAppCredentials)
+          ? (launchEnv) => this.sandboxRuntimeReadRoots(agent, runtime, launchEnv, githubAppCredentials)
           : undefined,
         trustedWorkspaceWriteRoots:
           runInSandbox && agent.workspace.mode === 'git-repo'
             ? [this.workspaces.sessionWorktreeRoot(agent)]
             : undefined,
-        explicitEnv: launchEnv,
         sandboxMechanism: this.sandboxMechanism,
         mcpSocketPath: mcpSocketPath(this.root),
         allowModelToolUnixSockets: githubAppCredentials,
@@ -3088,8 +3076,14 @@ export class Daemon {
         // must not travel with the launch.
         ...(this.k8s ? { k8s: true as const } : {})
       })
-      launch = composed.launch
-      launchRuntime = composed.runtime
+      if (assembled.configFiles) {
+        this.queueSpawnNotices(agentId, assembled.configFiles.notices)
+        if (Object.keys(assembled.configFiles.env).length > 0) {
+          configFileState = { childEnv: assembled.configFiles.sourceEnv, materialized: true }
+        }
+      }
+      launch = assembled.launch
+      launchRuntime = assembled.runtime
     } catch (err) {
       if (err instanceof SandboxError) {
         throw new Error(

--- a/packages/daemon/src/launch/assemble.ts
+++ b/packages/daemon/src/launch/assemble.ts
@@ -1,0 +1,102 @@
+import { materializeConfigFiles, type MaterializeResult } from '../shim/config-file-env.js'
+import { composeRuntimeLaunch, type ComposedRuntimeLaunch } from './compose.js'
+import type { SandboxMechanism } from '../acp/sandbox.js'
+import type { MemoryProviderKind } from '../memory/provider.js'
+import type { RuntimeDef } from '../config/config-schema.js'
+
+/** Config-file materialization result plus the pre-strip env it was planned from
+ * (the daemon snapshots that env so an idle sweep can re-write the files later). */
+export interface AssembledConfigFiles extends MaterializeResult {
+  sourceEnv: Record<string, string>
+}
+
+export interface AssembledRuntimeLaunch extends ComposedRuntimeLaunch {
+  /** The merged env handed to the launch (`runtimeEnv` under `agentEnv`), after materialization. */
+  launchEnv: Record<string, string>
+  /** Undefined when `configFileDir` was omitted, i.e. materialization was skipped. */
+  configFiles?: AssembledConfigFiles
+}
+
+/** Every parameter a launch site may vary. Optional fields are declared here so
+ * that a caller omitting one is a visible choice rather than invisible drift. */
+export interface AssembleRuntimeLaunchOptions {
+  runtimeId: string
+  runtime: RuntimeDef
+  provider: MemoryProviderKind
+  scopeDir: string
+  cwd: string
+  runInSandbox: boolean
+  daemonRoot?: string
+  agentsRoot?: string
+  /** Runtime-def env; config-file data vars are stripped from it in place. */
+  runtimeEnv: Record<string, string>
+  /** Agent/session env; config-file pointer vars are merged into it in place. */
+  agentEnv: Record<string, string>
+  /** Agent dir receiving materialized config-file secrets; omit to skip materialization. */
+  configFileDir?: string
+  /** Last mutation of the merged launch env before read roots and compose (k8s model credentials). */
+  finalizeLaunchEnv?: (launchEnv: Record<string, string>) => void
+  /** Daemon-owned code/socket/config carve-backs; a function receives the final launch env. */
+  runtimeReadRoots?: string[] | ((launchEnv: Record<string, string>) => string[] | undefined)
+  trustedWorkspaceWriteRoots?: string[]
+  sandboxMechanism?: SandboxMechanism
+  mcpSocketPath?: string
+  allowModelToolUnixSockets?: boolean
+  isolateHome?: boolean
+  stateSourceEnv?: NodeJS.ProcessEnv
+  hostEnv?: NodeJS.ProcessEnv
+  k8s?: boolean
+  hostPackageCache?: boolean
+}
+
+/**
+ * The single launch-assembly entry: materialize config-file secrets, merge the
+ * resulting child env, then compose the runtime launch from it.
+ *
+ * Config-file secrets (shim/config-file-env.ts) materialize `*_DATA` contents
+ * under the agent dir and point the tool-native env vars (KUBECONFIG /
+ * DOCKER_CONFIG) at the result; the raw values are stripped from the child env.
+ * Detection spans the runtime-def env too, so an explicit pointer var configured
+ * anywhere wins and skips materialization.
+ */
+export function assembleRuntimeLaunch(opts: AssembleRuntimeLaunchOptions): AssembledRuntimeLaunch {
+  let configFiles: AssembledConfigFiles | undefined
+  if (opts.configFileDir !== undefined) {
+    const sourceEnv = { ...opts.runtimeEnv, ...opts.agentEnv }
+    const materialized = materializeConfigFiles(opts.configFileDir, sourceEnv)
+    for (const name of materialized.strip) {
+      delete opts.agentEnv[name]
+      delete opts.runtimeEnv[name]
+    }
+    Object.assign(opts.agentEnv, materialized.env)
+    configFiles = { ...materialized, sourceEnv }
+  }
+
+  const launchEnv = { ...opts.runtimeEnv, ...opts.agentEnv }
+  opts.finalizeLaunchEnv?.(launchEnv)
+  const runtimeReadRoots =
+    typeof opts.runtimeReadRoots === 'function' ? opts.runtimeReadRoots(launchEnv) : opts.runtimeReadRoots
+
+  const composed = composeRuntimeLaunch({
+    runtimeId: opts.runtimeId,
+    runtime: opts.runtime,
+    provider: opts.provider,
+    scopeDir: opts.scopeDir,
+    cwd: opts.cwd,
+    runInSandbox: opts.runInSandbox,
+    daemonRoot: opts.daemonRoot,
+    agentsRoot: opts.agentsRoot,
+    explicitEnv: launchEnv,
+    runtimeReadRoots,
+    trustedWorkspaceWriteRoots: opts.trustedWorkspaceWriteRoots,
+    sandboxMechanism: opts.sandboxMechanism,
+    mcpSocketPath: opts.mcpSocketPath,
+    allowModelToolUnixSockets: opts.allowModelToolUnixSockets,
+    isolateHome: opts.isolateHome,
+    stateSourceEnv: opts.stateSourceEnv,
+    hostEnv: opts.hostEnv,
+    ...(opts.k8s ? { k8s: true as const } : {}),
+    ...(opts.hostPackageCache ? { hostPackageCache: true as const } : {})
+  })
+  return { ...composed, launchEnv, ...(configFiles ? { configFiles } : {}) }
+}


### PR DESCRIPTION
## What

The config-file materialize/strip/merge sequence that precedes `composeRuntimeLaunch` was duplicated verbatim in `daemon.ts` and `cli/chat.ts`. This extracts it into one entry, `assembleRuntimeLaunch()` in `src/launch/assemble.ts`, with explicit typed options covering the union of the production call sites' parameters (`runtimeReadRoots`, `trustedWorkspaceWriteRoots`, `mcpSocketPath`, `allowModelToolUnixSockets`, `k8s`, …) — so a caller omitting a sandbox parameter is a **visible choice** rather than invisible drift.

## ⚠️ This PR changes `chat` behavior

The duplication had already drifted. `chat` omitted the sandbox-root parameters, so a chat-run agent got **different OS-sandbox roots** than the same agent under the daemon. Two omissions chat *can* compute are now fixed:

1. **`trustedWorkspaceWriteRoots`** — a sandboxed `git-repo` agent under chat previously had **no write carve-back for its session worktree root** (`<agentDir>/worktrees`). It now gets the same carve-back the daemon grants. `sessionWorktreeRoot()` is a pure path derivation, so chat computes it with no extra I/O.
2. **memory backend env ordering** — chat merged `memoryProviderFor(...).runtimeEnv()` into `explicitEnv` *after* materialization; the daemon merges it into the agent env *before*. Chat now matches the daemon, so config-file detection sees the same child env on both paths. No convention var is a memory var today, so this is ordering fidelity rather than an observable change.

### Deliberately still omitted by chat, and why

- **`mcpSocketPath`** — a chat run has no daemon and therefore no MCP control socket.
- **`allowModelToolUnixSockets`** — gated on github-app git credentials, which only the daemon provisions.
- **`runtimeReadRoots`** — the daemon's `sandboxRuntimeReadRoots()` carves back the MCP bridge socket, the daemon CLI module entries, the `gh` wrapper dir, and the git-credential shim/socket. None of those exist in a chat run, and chat wires no `mcpServers` into its `AcpHost`. Carving them back would grant reads to paths the chat child cannot use.
- **`k8s`** — chat is always local.

## Other notes

- In `daemon.ts` the `gh` shim `PATH`/`AC_AGENT_ID` mutation now runs *before* materialization instead of between materialization and the env merge. `materializeConfigFiles` reads only convention data vars, so the only effect is that the snapshot used by `rematerializeConfigFiles()` also carries `PATH`/`AC_AGENT_ID` — inert for re-materialization.
- Materialization now sits inside the existing `try` that maps `SandboxError`, so a (currently non-existent) materialization throw would be wrapped as `runtime launch preparation failed` rather than propagating raw.
- The dream-host path (`excludeAgentToolCredentials`) keeps its credential deletions in `daemon.ts` and simply omits `configFileDir`, which skips materialization exactly as the old `else` branch did.
- `runtime-prober` and `evaluation/runner` stay on `composeRuntimeLaunch`: neither has an agent config-file dir to materialize or a cleanup path for one.

## Verification

- `pnpm typecheck` — clean
- `vitest run test/runtime-launch.test.ts test/chat.test.ts test/daemon-smoke.test.ts` — 65 passed
- `vitest run test/config-file-env.test.ts test/daemon-lifecycle.test.ts test/session-manager.test.ts test/workspace.test.ts test/git-injection.test.ts` — 273 passed
- `prettier --check` + `eslint` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)