### PR TITLE
feat(web): add credits via Stripe Checkout on the billing page

### DIFF
--- a/packages/web/src/app/(app)/[slug]/billing/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/billing/page.tsx
@@ -1,8 +1,15 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import BillingView from '@/components/console/views/BillingView'
+import { LoadingState } from '@/components/marks'
 
 export const metadata: Metadata = { title: 'Billing · AgentConnect' }
 
+// BillingView reads ?checkout/purchase (the Stripe return) via useSearchParams → Suspense.
 export default function Page() {
-  return <BillingView />
+  return (
+    <Suspense fallback={<LoadingState fill />}>
+      <BillingView />
+    </Suspense>
+  )
 }

--- a/packages/web/src/components/console/views/BillingView.checkout.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.checkout.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+/**
+ * The checkout-return state machine's two safety properties, pinned:
+ *
+ * 1. `expired` is NOT an authoritative no-charge answer. The mirrored contract
+ *    (billing-api.ts) says a paid session may complete an intent an expiry guess
+ *    had already marked `expired`, so a poll that reads `expired` must keep
+ *    reconciling — and the banner it can end on must never claim nothing was
+ *    charged.
+ *
+ * 2. A transient poll failure must not abandon confirmation. The return params
+ *    are cleaned from the URL on claim, so the purchase id lives only in state;
+ *    a single network blip or 5xx must retry, not become a dead end.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BillingError } from '@/lib/billing-api'
+
+const mocks = vi.hoisted(() => ({
+  fetchPurchase: vi.fn<() => Promise<unknown>>()
+}))
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, myRole: 'owner', orgPath: (p: string) => p, loading: false })
+}))
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/acme/billing',
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams('checkout=success&purchase=pur_1')
+}))
+vi.mock('@/lib/billing-api', async () => {
+  const real = await vi.importActual<typeof import('@/lib/billing-api')>('@/lib/billing-api')
+  return {
+    ...real,
+    createBillingPurchase: vi.fn(),
+    fetchBillingPurchase: mocks.fetchPurchase,
+    fetchBillingAccount: async () => ({ orgId: 'org-1', balanceMicro: 0 }),
+    fetchBillingTransactions: async () => ({ items: [], nextCursor: null })
+  }
+})
+
+const BillingView = (await import('./BillingView')).default
+
+let host: HTMLElement
+let root: Root
+
+async function render() {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root.render(<BillingView />)
+  })
+}
+
+/** Let the pending poll timer fire and its fetch settle. */
+async function tick(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: 'billing' }
+  mocks.fetchPurchase.mockReset()
+})
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+  vi.useRealTimers()
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = {}
+})
+
+const purchase = (status: string) => ({ id: 'pur_1', status, amountMicro: 50_000_000, receiptUrl: null })
+
+describe('checkout return: expired is not terminal', () => {
+  it('keeps polling after an expired reading and still lands on completed', async () => {
+    mocks.fetchPurchase
+      .mockResolvedValueOnce(purchase('expired'))
+      .mockResolvedValueOnce(purchase('expired'))
+      .mockResolvedValue(purchase('completed'))
+    await render()
+    await tick(0) // attempt 1 → expired
+    expect(host.innerHTML).toContain('Confirming your payment')
+    await tick(2_500) // attempt 2 → expired, still confirming
+    expect(host.innerHTML).toContain('Confirming your payment')
+    await tick(2_500) // attempt 3 → completed
+    expect(host.innerHTML).toContain('$50.00 added')
+    expect(mocks.fetchPurchase).toHaveBeenCalledTimes(3)
+  })
+
+  it('never claims "nothing was charged" for an expired purchase', async () => {
+    mocks.fetchPurchase.mockResolvedValue(purchase('expired'))
+    await render()
+    await tick(0)
+    for (let i = 0; i < 120; i++) await tick(2_500) // exhaust the poll budget
+    expect(host.innerHTML).toContain('Checkout session expired')
+    expect(host.innerHTML).not.toContain('Nothing was charged')
+  })
+})
+
+describe('checkout return: transient poll failures', () => {
+  it('retries through a network error instead of abandoning the purchase', async () => {
+    mocks.fetchPurchase
+      .mockRejectedValueOnce(new BillingError('billing request failed (HTTP 503)', 503))
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValue(purchase('completed'))
+    await render()
+    await tick(0)
+    expect(host.innerHTML).toContain('Confirming your payment')
+    await tick(2_500)
+    expect(host.innerHTML).toContain('Confirming your payment')
+    await tick(2_500)
+    expect(host.innerHTML).toContain('$50.00 added')
+  })
+
+  it('a permanent refusal keeps the purchase id and offers a manual retry', async () => {
+    mocks.fetchPurchase
+      .mockRejectedValueOnce(new BillingError('forbidden', 403))
+      .mockResolvedValue(purchase('completed'))
+    await render()
+    await tick(0)
+    expect(host.innerHTML).toContain('Could not check the payment')
+    const retry = Array.from(host.querySelectorAll('button')).find((b) => b.textContent?.includes('Check again'))
+    expect(retry).toBeTruthy()
+    await act(async () => retry!.click())
+    await tick(0)
+    expect(host.innerHTML).toContain('$50.00 added')
+  })
+})

--- a/packages/web/src/components/console/views/BillingView.flag.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.flag.test.tsx
@@ -18,7 +18,16 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/lib/org-context', () => ({
   useOrgs: () => ({ activeOrg: { id: 'org-1' }, myRole: 'owner', orgPath: (p: string) => p, loading: false })
 }))
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/acme/billing',
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams()
+}))
 vi.mock('@/lib/billing-api', () => ({
+  PURCHASE_MIN_MICRO: 5_000_000,
+  PURCHASE_MAX_MICRO: 2_000_000_000,
+  createBillingPurchase: vi.fn(),
+  fetchBillingPurchase: vi.fn(),
   fetchBillingAccount: mocks.fetchAccount,
   fetchBillingTransactions: mocks.fetchTransactions,
   fmtMicroUsd: (micro: number) => `$${micro / 1_000_000}`

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -11,6 +11,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import {
+  BillingError,
+  BillingShapeError,
   PURCHASE_MAX_MICRO,
   PURCHASE_MIN_MICRO,
   createBillingPurchase,
@@ -74,15 +76,23 @@ function Notice({ title, body }: { title: string; body: string }) {
 // purchase settles when the service — fed by its webhook and its own Stripe
 // reconcile — reports `completed`. `cancel` means the user backed out of the
 // hosted page: nothing was charged and there is nothing to poll.
+//
+// `failed` is the only polled status this page treats as an authoritative
+// no-charge answer. `expired` is NOT one: the mirrored contract says a paid
+// session may complete an intent an expiry guess had already marked `expired`,
+// so an expired reading keeps reconciling for the full poll budget and the
+// banner it ends on never claims nothing was charged. Transient poll failures
+// don't abandon the confirmation either — the purchase id is kept, retried
+// within the same budget, and surfaced with a manual retry if it runs out.
 
 type CheckoutReturn =
   | { phase: 'confirming'; purchaseId: string; attempt: number }
   | { phase: 'still-pending'; purchaseId: string }
   | { phase: 'completed'; purchase: BillingPurchase }
   | { phase: 'failed' }
-  | { phase: 'expired' }
+  | { phase: 'expired'; purchaseId: string }
   | { phase: 'canceled' }
-  | { phase: 'error'; message: string }
+  | { phase: 'error'; purchaseId: string; message: string }
 
 const BANNER_TONE: Record<CheckoutReturn['phase'], { border: string; bg: string; icon: string }> = {
   confirming: { border: 'var(--status-info)', bg: 'var(--status-info-soft)', icon: 'clock' },
@@ -119,16 +129,27 @@ function checkoutCopy(state: CheckoutReturn): { title: string; body: string } {
     case 'expired':
       return {
         title: 'Checkout session expired',
-        body: "The Stripe session timed out before payment completed. Nothing was charged — start a new one when you're ready."
+        body: 'The Stripe session timed out and no payment confirmation has arrived. If you left without paying, nothing was charged. If you paid just as the session closed, the credits still post automatically once Stripe confirms — they will show in the transactions below.'
       }
     case 'canceled':
       return { title: 'Checkout canceled', body: 'You left the Stripe page before paying. Nothing was charged.' }
     case 'error':
-      return { title: 'Could not check the payment', body: state.message }
+      return {
+        title: 'Could not check the payment',
+        body: `${state.message} — if the payment went through, the credits still post automatically; you can also check again now.`
+      }
   }
 }
 
-function CheckoutBanner({ state, onDismiss }: { state: CheckoutReturn; onDismiss: () => void }) {
+function CheckoutBanner({
+  state,
+  onDismiss,
+  onRetry
+}: {
+  state: CheckoutReturn
+  onDismiss: () => void
+  onRetry: () => void
+}) {
   const tone = BANNER_TONE[state.phase]
   const copy = checkoutCopy(state)
   const busy = state.phase === 'confirming'
@@ -148,6 +169,13 @@ function CheckoutBanner({ state, onDismiss }: { state: CheckoutReturn; onDismiss
         {busy && (
           <div className="mono mt-2 text-[11.5px] text-(--text-tertiary)">
             checking payment status · attempt {state.phase === 'confirming' ? state.attempt : 0}
+          </div>
+        )}
+        {state.phase === 'error' && (
+          <div className="mt-2">
+            <Button size="xs" variant="secondary" onClick={onRetry}>
+              Check again
+            </Button>
           </div>
         )}
         {state.phase === 'completed' && state.purchase.receiptUrl && (
@@ -353,11 +381,25 @@ export default function BillingView() {
             setCheckout({ phase: 'completed', purchase })
             refreshMoney()
           } else if (purchase.status === 'failed') setCheckout({ phase: 'failed' })
-          else if (purchase.status === 'expired') setCheckout({ phase: 'expired' })
-          else if (attempt >= POLL_MAX_ATTEMPTS) setCheckout({ phase: 'still-pending', purchaseId })
+          // `expired` is not authoritative (see the contract note above): keep
+          // reconciling like `pending`; only which banner ends the budget differs.
+          else if (attempt >= POLL_MAX_ATTEMPTS)
+            setCheckout(
+              purchase.status === 'expired' ? { phase: 'expired', purchaseId } : { phase: 'still-pending', purchaseId }
+            )
           else setCheckout({ phase: 'confirming', purchaseId, attempt: attempt + 1 })
         } catch (e) {
-          if (!cancelled) setCheckout({ phase: 'error', message: (e as Error).message })
+          if (cancelled) return
+          // The URL was already cleaned, so giving up here would lose the
+          // purchase id for good. Retry transient failures (network, 5xx) inside
+          // the same budget; only a client-side refusal — shape drift or a 4xx —
+          // or an exhausted budget lands on the error banner, which keeps the id
+          // and offers a manual "Check again".
+          const permanent =
+            e instanceof BillingShapeError || (e instanceof BillingError && e.status >= 400 && e.status < 500)
+          if (!permanent && attempt < POLL_MAX_ATTEMPTS)
+            setCheckout({ phase: 'confirming', purchaseId, attempt: attempt + 1 })
+          else setCheckout({ phase: 'error', purchaseId, message: (e as Error).message })
         }
       },
       attempt === 1 ? 0 : POLL_INTERVAL_MS
@@ -401,7 +443,17 @@ export default function BillingView() {
         <p className="psub mt-0 flex-1">Prepaid balance for this organization, and what has been credited to it.</p>
       </div>
 
-      {checkout && <CheckoutBanner state={checkout} onDismiss={() => setCheckout(null)} />}
+      {checkout && (
+        <CheckoutBanner
+          state={checkout}
+          onDismiss={() => setCheckout(null)}
+          onRetry={() =>
+            setCheckout((c) =>
+              c && c.phase === 'error' ? { phase: 'confirming', purchaseId: c.purchaseId, attempt: 1 } : c
+            )
+          }
+        />
+      )}
 
       {account.error && (
         <div className="card mb-4 flex items-center gap-3 px-4 py-3">
@@ -417,7 +469,7 @@ export default function BillingView() {
 
       {acct && (
         <>
-          <div className="mb-4 grid items-stretch gap-4 md:grid-cols-2">
+          <div className="mb-4 grid items-stretch gap-4 desktop:grid-cols-2">
             {/* One figure, no in-flight caveat: v1 has no hold layer, so the balance
                 is every reconciliation fact there is. A suspended/low-balance badge
                 belongs here once the service can report a state at all. */}

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -1,12 +1,25 @@
 'use client'
 
 // Billing page. It renders what the billing service returns and nothing more —
-// no prices, no entitlement rules of its own. Paying for credit is not here yet:
-// it arrives with the service's payment channel, and this page's whole part in it
-// will be a redirect to the checkout URL the API hands back.
+// no prices, no entitlement rules of its own. Paying for credit is here, and the
+// console's whole part in it is: pick an amount, POST it, redirect to the Stripe
+// checkout URL the API hands back, and — after Stripe returns the browser — poll
+// the purchase until the service says the payment settled. The return redirect
+// itself is never treated as proof of payment.
 
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
-import { fetchBillingAccount, fetchBillingTransactions, fmtMicroUsd } from '@/lib/billing-api'
+import {
+  PURCHASE_MAX_MICRO,
+  PURCHASE_MIN_MICRO,
+  createBillingPurchase,
+  fetchBillingAccount,
+  fetchBillingPurchase,
+  fetchBillingTransactions,
+  fmtMicroUsd,
+  type BillingPurchase
+} from '@/lib/billing-api'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { useOrgs } from '@/lib/org-context'
 import { consoleKeys } from '@/lib/swr-keys'
@@ -22,6 +35,13 @@ const KIND_LABEL: Record<string, string> = {
   promo: 'Promotional credit',
   refund: 'Refund'
 }
+
+const PRESETS_USD = [10, 50, 100]
+const MIN_USD = PURCHASE_MIN_MICRO / 1_000_000
+const MAX_USD = PURCHASE_MAX_MICRO / 1_000_000
+/** 2.5s cadence; ~5 minutes before the poll goes quiet ("safe to leave"). */
+const POLL_INTERVAL_MS = 2_500
+const POLL_MAX_ATTEMPTS = 120
 
 function fmtWhen(iso: string): string {
   return new Date(iso).toLocaleString('en-US', {
@@ -49,9 +69,244 @@ function Notice({ title, body }: { title: string; body: string }) {
   )
 }
 
+// ── The checkout return, as a state machine ──────────────────────────────────
+// `?checkout=success&purchase=<id>` only means "the browser came back"; the
+// purchase settles when the service — fed by its webhook and its own Stripe
+// reconcile — reports `completed`. `cancel` means the user backed out of the
+// hosted page: nothing was charged and there is nothing to poll.
+
+type CheckoutReturn =
+  | { phase: 'confirming'; purchaseId: string; attempt: number }
+  | { phase: 'still-pending'; purchaseId: string }
+  | { phase: 'completed'; purchase: BillingPurchase }
+  | { phase: 'failed' }
+  | { phase: 'expired' }
+  | { phase: 'canceled' }
+  | { phase: 'error'; message: string }
+
+const BANNER_TONE: Record<CheckoutReturn['phase'], { border: string; bg: string; icon: string }> = {
+  confirming: { border: 'var(--status-info)', bg: 'var(--status-info-soft)', icon: 'clock' },
+  'still-pending': { border: 'var(--status-info)', bg: 'var(--status-info-soft)', icon: 'clock' },
+  completed: { border: 'var(--status-online)', bg: 'var(--status-online-soft)', icon: 'check' },
+  failed: { border: 'var(--status-error)', bg: 'var(--status-error-soft)', icon: 'x' },
+  expired: { border: 'var(--status-paused)', bg: 'var(--status-paused-soft)', icon: 'timer-off' },
+  canceled: { border: 'var(--border-strong)', bg: 'var(--surface-sunken)', icon: 'undo-2' },
+  error: { border: 'var(--status-error)', bg: 'var(--status-error-soft)', icon: 'triangle-alert' }
+}
+
+function checkoutCopy(state: CheckoutReturn): { title: string; body: string } {
+  switch (state.phase) {
+    case 'confirming':
+      return {
+        title: 'Confirming your payment',
+        body: 'You came back from Stripe, but the payment counts only once Stripe tells us it settled. Credits post as soon as that lands — usually seconds. Safe to leave this page; the balance updates on its own.'
+      }
+    case 'still-pending':
+      return {
+        title: 'Payment still settling',
+        body: 'Stripe has not confirmed the payment yet. Some payment methods settle over several minutes — credits post automatically once it lands, and it is safe to leave this page.'
+      }
+    case 'completed':
+      return {
+        title: `${fmtMicroUsd(state.purchase.amountMicro)} added`,
+        body: 'The payment settled and the credits are on your balance.'
+      }
+    case 'failed':
+      return {
+        title: "Payment didn't go through",
+        body: 'Stripe declined the payment, so nothing was charged and your balance is unchanged. You can try again with the same or a different method.'
+      }
+    case 'expired':
+      return {
+        title: 'Checkout session expired',
+        body: "The Stripe session timed out before payment completed. Nothing was charged — start a new one when you're ready."
+      }
+    case 'canceled':
+      return { title: 'Checkout canceled', body: 'You left the Stripe page before paying. Nothing was charged.' }
+    case 'error':
+      return { title: 'Could not check the payment', body: state.message }
+  }
+}
+
+function CheckoutBanner({ state, onDismiss }: { state: CheckoutReturn; onDismiss: () => void }) {
+  const tone = BANNER_TONE[state.phase]
+  const copy = checkoutCopy(state)
+  const busy = state.phase === 'confirming'
+  return (
+    <div
+      className="mb-4 flex items-start gap-3 rounded-[10px] border px-4 py-3.5"
+      style={{ borderColor: tone.border, background: tone.bg }}
+    >
+      <span className="mt-[1px] flex-none" style={{ color: tone.border }}>
+        <Icon name={tone.icon} size={17} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="font-sans text-[13.5px] font-semibold leading-normal">{copy.title}</div>
+        <div className="mt-[3px] max-w-[720px] font-sans text-[12.5px] font-normal leading-[1.6] text-(--text-secondary)">
+          {copy.body}
+        </div>
+        {busy && (
+          <div className="mono mt-2 text-[11.5px] text-(--text-tertiary)">
+            checking payment status · attempt {state.phase === 'confirming' ? state.attempt : 0}
+          </div>
+        )}
+        {state.phase === 'completed' && state.purchase.receiptUrl && (
+          <a
+            className="mt-2 inline-flex items-center gap-1 font-sans text-[12px] font-medium text-(--text-brand) hover:underline"
+            href={state.purchase.receiptUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View receipt
+            <Icon name="arrow-up-right" size={12} />
+          </a>
+        )}
+      </div>
+      {!busy && (
+        <Button size="xs" variant="ghost" onClick={onDismiss} ariaLabel="Dismiss">
+          <Icon name="x" size={14} />
+        </Button>
+      )}
+    </div>
+  )
+}
+
+// ── Add credits (owners only — the service enforces this; the UI just agrees) ─
+
+function AddCreditsCard({ orgId, returnPath }: { orgId: string; returnPath: string }) {
+  const [preset, setPreset] = useState<number>(50)
+  const [custom, setCustom] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const usd = custom !== '' ? Number.parseFloat(custom) : preset
+  const cents = Number.isFinite(usd) ? Math.round(usd * 100) : Number.NaN
+  const valid = Number.isFinite(cents) && cents >= MIN_USD * 100 && cents <= MAX_USD * 100
+  const invalidCustom = custom !== '' && !valid
+
+  const submit = async () => {
+    if (!valid || submitting) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const { url } = await createBillingPurchase(orgId, {
+        amountMicro: cents * 10_000,
+        // Replay protection for THIS click; the service's crash-window and
+        // webhook idempotency are what actually guard the money.
+        idempotencyKey: crypto.randomUUID(),
+        returnPath
+      })
+      window.location.assign(url)
+      // `submitting` stays true — the page is navigating away.
+    } catch (e) {
+      setError((e as Error).message)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="card flex flex-col">
+      <div className="cardhead">
+        <span className="cardtitle">Add credits</span>
+      </div>
+      <div className="flex flex-1 flex-col p-4">
+        <div className="grid grid-cols-4 gap-2">
+          {PRESETS_USD.map((v) => {
+            const on = custom === '' && preset === v
+            return (
+              <button
+                key={v}
+                type="button"
+                className="mono flex h-[38px] cursor-pointer items-center justify-center rounded-[9px] text-[14px] font-semibold"
+                style={
+                  on
+                    ? { border: '1.5px solid var(--brand)', background: 'var(--brand-soft)' }
+                    : { border: '1px solid var(--border-default)', background: 'var(--surface-card)' }
+                }
+                onClick={() => {
+                  setPreset(v)
+                  setCustom('')
+                }}
+              >
+                ${v}
+              </button>
+            )
+          })}
+          <div
+            className="flex h-[38px] items-center gap-1.5 rounded-[6px] border px-2.5"
+            style={{ borderColor: invalidCustom ? 'var(--status-error)' : 'var(--border-default)' }}
+          >
+            <span className="mono text-[12.5px] text-(--text-tertiary)">$</span>
+            <input
+              value={custom}
+              onChange={(e) => setCustom(e.target.value)}
+              placeholder="Other"
+              inputMode="decimal"
+              aria-label="Custom amount in USD"
+              className="mono w-full min-w-0 border-0 bg-transparent text-[12.5px] outline-none"
+            />
+          </div>
+        </div>
+        <div
+          className="mt-2 font-sans text-[11.5px] font-normal leading-[1.5]"
+          style={{ color: invalidCustom ? 'var(--status-error)' : 'var(--text-tertiary)' }}
+        >
+          {invalidCustom
+            ? `Enter an amount between $${MIN_USD.toFixed(2)} and $${MAX_USD.toLocaleString('en-US', { minimumFractionDigits: 2 })}.`
+            : `Minimum $${MIN_USD.toFixed(2)}, maximum $${MAX_USD.toLocaleString('en-US', { minimumFractionDigits: 2 })} per purchase.`}
+        </div>
+        {error && (
+          <div className="mt-2 flex items-center gap-2 font-sans text-[12px] text-(--status-error)">
+            <Icon name="triangle-alert" size={14} />
+            <span className="min-w-0 flex-1">{error}</span>
+          </div>
+        )}
+        <div className="mt-3">
+          <Button size="md" disabled={!valid || submitting} onClick={() => void submit()} className="w-full">
+            <span className="inline-flex items-center gap-2">
+              <Icon name={submitting ? 'loader-circle' : 'plus'} size={15} />
+              {submitting ? 'Opening Stripe checkout…' : `Add ${valid ? fmtMicroUsd(cents * 10_000) : 'credits'}`}
+            </span>
+          </Button>
+        </div>
+        <div className="mt-auto flex items-start gap-2 pt-3.5">
+          <span className="mt-[2px] flex-none text-(--text-tertiary)">
+            <Icon name="lock" size={13} />
+          </span>
+          <span className="font-sans text-[11.5px] font-normal leading-[1.55] text-(--text-tertiary)">
+            Payment is handled on Stripe's hosted page. Card details never touch AgentConnect.
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function MembersDontPayCard() {
+  return (
+    <div className="card flex flex-col">
+      <div className="cardhead">
+        <span className="cardtitle">Add credits</span>
+      </div>
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 p-5 text-center">
+        <span className="flex h-9 w-9 items-center justify-center rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) text-(--text-tertiary)">
+          <Icon name="user-round-cog" size={17} />
+        </span>
+        <div className="font-sans text-[13px] font-semibold">Owners add credits</div>
+        <div className="max-w-[300px] font-sans text-[12px] font-normal leading-[1.6] text-(--text-tertiary)">
+          You can see the balance and every transaction. Ask an org owner to top up.
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function BillingView() {
-  const { activeOrg, loading: orgLoading } = useOrgs()
+  const { activeOrg, myRole, loading: orgLoading } = useOrgs()
   const orgId = activeOrg?.id ?? null
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
   // Hooks run before any early return, so the flag has to gate the KEYS, not just
   // the render: a null key is what stops SWR from fetching. Checking it only below
   // would let a deep link on a console without billing still call the service —
@@ -63,6 +318,55 @@ export default function BillingView() {
   const transactions = useSWR(fetching ? consoleKeys.billingTransactions(orgId) : null, () =>
     fetchBillingTransactions(orgId!)
   )
+
+  // The return from Stripe. Claimed once from the URL, which is then cleaned so
+  // a refresh or a shared link does not replay the banner.
+  const [checkout, setCheckout] = useState<CheckoutReturn | null>(null)
+  const claimed = useRef(false)
+  useEffect(() => {
+    if (claimed.current || !offered) return
+    const result = searchParams.get('checkout')
+    const purchaseId = searchParams.get('purchase')
+    if (!result) return
+    claimed.current = true
+    if (result === 'success' && purchaseId) setCheckout({ phase: 'confirming', purchaseId, attempt: 1 })
+    else if (result === 'cancel') setCheckout({ phase: 'canceled' })
+    router.replace(pathname)
+  }, [offered, searchParams, router, pathname])
+
+  // Poll until the service reports a terminal status. Each poll also makes the
+  // service reconcile against Stripe directly, so a lost webhook delays nothing.
+  const refreshMoney = useCallback(() => {
+    void account.mutate()
+    void transactions.mutate()
+  }, [account.mutate, transactions.mutate])
+  useEffect(() => {
+    if (!orgId || checkout?.phase !== 'confirming') return
+    const { purchaseId, attempt } = checkout
+    let cancelled = false
+    const timer = setTimeout(
+      async () => {
+        try {
+          const purchase = await fetchBillingPurchase(orgId, purchaseId)
+          if (cancelled) return
+          if (purchase.status === 'completed') {
+            setCheckout({ phase: 'completed', purchase })
+            refreshMoney()
+          } else if (purchase.status === 'failed') setCheckout({ phase: 'failed' })
+          else if (purchase.status === 'expired') setCheckout({ phase: 'expired' })
+          else if (attempt >= POLL_MAX_ATTEMPTS) setCheckout({ phase: 'still-pending', purchaseId })
+          else setCheckout({ phase: 'confirming', purchaseId, attempt: attempt + 1 })
+        } catch (e) {
+          if (!cancelled) setCheckout({ phase: 'error', message: (e as Error).message })
+        }
+      },
+      attempt === 1 ? 0 : POLL_INTERVAL_MS
+    )
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [orgId, checkout, refreshMoney])
 
   // Deep-link landing for a console that does not offer billing: the rail hides
   // the entry, so anyone here typed the URL or followed an old bookmark. Gated on
@@ -97,6 +401,8 @@ export default function BillingView() {
         <p className="psub mt-0 flex-1">Prepaid balance for this organization, and what has been credited to it.</p>
       </div>
 
+      {checkout && <CheckoutBanner state={checkout} onDismiss={() => setCheckout(null)} />}
+
       {account.error && (
         <div className="card mb-4 flex items-center gap-3 px-4 py-3">
           <Icon name="triangle-alert" size={18} color="var(--status-error)" />
@@ -111,12 +417,21 @@ export default function BillingView() {
 
       {acct && (
         <>
-          {/* One figure, no in-flight caveat: v1 has no hold layer, so the balance
-              is every reconciliation fact there is. A suspended/low-balance badge
-              belongs here once the service can report a state at all. */}
-          <div className="card stat mb-4 max-w-[320px]">
-            <div className="statlbl">Balance</div>
-            <div className="statval">{fmtMicroUsd(acct.balanceMicro)}</div>
+          <div className="mb-4 grid items-stretch gap-4 md:grid-cols-2">
+            {/* One figure, no in-flight caveat: v1 has no hold layer, so the balance
+                is every reconciliation fact there is. A suspended/low-balance badge
+                belongs here once the service can report a state at all. */}
+            <div className="card stat">
+              <div className="statlbl">Balance</div>
+              <div className="statval">{fmtMicroUsd(acct.balanceMicro)}</div>
+            </div>
+            {/* Only owners move money — the service enforces it (403); the page
+                just doesn't offer members a form that would be refused. */}
+            {myRole === 'owner' ? (
+              <AddCreditsCard orgId={orgId} returnPath={pathname} />
+            ) : myRole ? (
+              <MembersDontPayCard />
+            ) : null}
           </div>
 
           <div className="card">

--- a/packages/web/src/lib/billing-api.test.ts
+++ b/packages/web/src/lib/billing-api.test.ts
@@ -4,7 +4,14 @@
 // a response that does not match is REFUSED at the boundary, so the page shows
 // its error card instead of rendering `$NaN` where a balance belongs.
 import { describe, expect, it } from 'vitest'
-import { assertAccount, assertTransactionsPage, BillingShapeError, fmtMicroUsd } from './billing-api'
+import {
+  assertAccount,
+  assertPurchase,
+  assertPurchaseCreated,
+  assertTransactionsPage,
+  BillingShapeError,
+  fmtMicroUsd
+} from './billing-api'
 
 const tx = { id: 't1', kind: 'purchase', amountMicro: 25_000_000, at: '2026-08-17T09:25:33.751Z' }
 
@@ -55,5 +62,34 @@ describe('assertTransactionsPage', () => {
 
   it('refuses a body that is not a page at all', () => {
     expect(() => assertTransactionsPage({ items: 'nope', nextCursor: null })).toThrow(BillingShapeError)
+  })
+})
+
+describe('assertPurchase', () => {
+  const purchase = { id: 'p1', status: 'pending', amountMicro: 50_000_000, receiptUrl: null }
+
+  it('accepts the documented shape, with and without a receipt', () => {
+    expect(() => assertPurchase(purchase)).not.toThrow()
+    expect(() =>
+      assertPurchase({ ...purchase, status: 'completed', receiptUrl: 'https://pay.stripe.com/receipts/x' })
+    ).not.toThrow()
+  })
+
+  it('refuses an unknown status — the poll branches on it, so an unknown value would spin forever', () => {
+    expect(() => assertPurchase({ ...purchase, status: 'settling' })).toThrow(BillingShapeError)
+  })
+
+  it('refuses an unusable amount or receipt', () => {
+    expect(() => assertPurchase({ ...purchase, amountMicro: '50' })).toThrow(BillingShapeError)
+    expect(() => assertPurchase({ ...purchase, receiptUrl: undefined })).toThrow(BillingShapeError)
+    expect(() => assertPurchase(null)).toThrow(BillingShapeError)
+  })
+})
+
+describe('assertPurchaseCreated', () => {
+  it('accepts the documented shape and refuses anything without the redirect URL', () => {
+    expect(() => assertPurchaseCreated({ purchaseId: 'p1', url: 'https://checkout.stripe.com/x' })).not.toThrow()
+    expect(() => assertPurchaseCreated({ purchaseId: 'p1' })).toThrow(BillingShapeError)
+    expect(() => assertPurchaseCreated(null)).toThrow(BillingShapeError)
   })
 })

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -7,9 +7,10 @@
 // question, so "flag on, endpoint missing" reports a broken deployment instead of
 // looking like billing was never enabled.
 //
-// The service currently exposes reads only; paying for credit arrives with its
-// payment channel, and the console's knowledge of it will stop at "redirect to
-// the URL the API returned".
+// Paying for credit: the console's whole knowledge of the payment channel is
+// "POST an amount, redirect to the URL the API returned, then poll the purchase
+// until the service says Stripe confirmed it". The return redirect is never
+// treated as proof of payment — only the polled status is.
 //
 // ── The wire contract is DUPLICATED, on purpose ──────────────────────────────
 // The types below are a copy. The authority is the billing service's own zod
@@ -53,6 +54,30 @@ export interface BillingTransactionsPage {
   nextCursor: string | null
 }
 
+/** `pending` until Stripe confirms settlement; a paid session may complete an
+ *  intent an expiry guess had already marked `expired`. */
+export type BillingPurchaseStatus = 'pending' | 'completed' | 'failed' | 'expired'
+const PURCHASE_STATUSES: readonly string[] = ['pending', 'completed', 'failed', 'expired']
+
+export interface BillingPurchase {
+  id: string
+  status: BillingPurchaseStatus
+  amountMicro: number
+  /** Stripe-hosted receipt for a completed purchase; may lag completion. */
+  receiptUrl: string | null
+}
+
+export interface BillingPurchaseCreated {
+  purchaseId: string
+  /** Stripe-hosted checkout page; the console full-page redirects to it. */
+  url: string
+}
+
+/** Design defaults ($5–$2,000), mirrored for inline validation copy only — the
+ *  service enforces its own (operator-tunable) bounds authoritatively. */
+export const PURCHASE_MIN_MICRO = 5_000_000
+export const PURCHASE_MAX_MICRO = 2_000_000_000
+
 /** Billing base URL, or null when this deployment has no billing service. */
 export function billingBase(): string | null {
   const runtime = typeof window !== 'undefined' ? window.__AC_ENV?.BILLING_URL : process.env.BILLING_URL
@@ -92,6 +117,28 @@ export function assertAccount(body: unknown): asserts body is BillingAccount {
   if (!b || typeof b.orgId !== 'string' || !isFiniteNumber(b.balanceMicro)) throw new BillingShapeError('account')
 }
 
+export function assertPurchase(body: unknown): asserts body is BillingPurchase {
+  const b = body as Partial<BillingPurchase> | null
+  // Status IS checked against the known set, unlike a ledger `kind`: polling
+  // branches on it, and an unknown status would spin forever — the error card
+  // ("console out of date with the service") is the better failure.
+  if (
+    !b ||
+    typeof b.id !== 'string' ||
+    typeof b.status !== 'string' ||
+    !PURCHASE_STATUSES.includes(b.status) ||
+    !isFiniteNumber(b.amountMicro) ||
+    !(b.receiptUrl === null || typeof b.receiptUrl === 'string')
+  ) {
+    throw new BillingShapeError('purchase')
+  }
+}
+
+export function assertPurchaseCreated(body: unknown): asserts body is BillingPurchaseCreated {
+  const b = body as Partial<BillingPurchaseCreated> | null
+  if (!b || typeof b.purchaseId !== 'string' || typeof b.url !== 'string') throw new BillingShapeError('purchase')
+}
+
 export function assertTransactionsPage(body: unknown): asserts body is BillingTransactionsPage {
   const b = body as Partial<BillingTransactionsPage> | null
   if (!b || !Array.isArray(b.items)) throw new BillingShapeError('transaction page')
@@ -107,11 +154,12 @@ export function assertTransactionsPage(body: unknown): asserts body is BillingTr
   }
 }
 
-async function request<T>(path: string): Promise<T> {
+async function request<T>(path: string, init?: { method: 'POST'; body: unknown }): Promise<T> {
   const base = billingBase()
   if (!base) throw new BillingError('billing is not configured for this deployment', 0)
 
   const headers: Record<string, string> = {}
+  if (init) headers['content-type'] = 'application/json'
   const token = await getToken()
   if (token) headers.authorization = `Bearer ${token}`
   const email = (await getUser())?.email
@@ -119,7 +167,11 @@ async function request<T>(path: string): Promise<T> {
   const idToken = await getIdTokenRaw()
   if (idToken) headers['x-ac-id-token'] = idToken
 
-  const res = await fetch(`${base}/api/v1${path}`, { cache: 'no-store', headers })
+  const res = await fetch(`${base}/api/v1${path}`, {
+    cache: 'no-store',
+    headers,
+    ...(init ? { method: init.method, body: JSON.stringify(init.body) } : {})
+  })
   if (!res.ok) {
     const body = (await res.json().catch(() => ({}))) as { message?: string }
     throw new BillingError(body.message ?? `billing request failed (HTTP ${res.status})`, res.status)
@@ -139,6 +191,27 @@ export async function fetchBillingTransactions(orgId: string, cursor?: string): 
   const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''
   const body = await request<unknown>(`${orgPath(orgId)}/transactions${query}`)
   assertTransactionsPage(body)
+  return body
+}
+
+/** Start a purchase: the service persists the intent, mints a Stripe Checkout
+ *  Session, and hands back the hosted URL. `idempotencyKey` makes the request
+ *  replay-safe (same key + same amount returns the same purchase; a different
+ *  amount under the same key is refused). `returnPath` is a console path — the
+ *  service pins the origin — that Stripe sends the browser back to with
+ *  `?checkout=success|cancel&purchase=<id>`. */
+export async function createBillingPurchase(
+  orgId: string,
+  args: { amountMicro: number; idempotencyKey: string; returnPath: string }
+): Promise<BillingPurchaseCreated> {
+  const body = await request<unknown>(`${orgPath(orgId)}/purchases`, { method: 'POST', body: args })
+  assertPurchaseCreated(body)
+  return body
+}
+
+export async function fetchBillingPurchase(orgId: string, id: string): Promise<BillingPurchase> {
+  const body = await request<unknown>(`${orgPath(orgId)}/purchases/${encodeURIComponent(id)}`)
+  assertPurchase(body)
   return body
 }
 


### PR DESCRIPTION
The console's whole part in paying for credit: pick an amount, POST it, redirect to the Stripe-hosted checkout URL the billing service returns, and — after Stripe sends the browser back — poll the purchase until the service says the payment settled. No card field ever renders in the console, and the return redirect is never treated as proof of payment.

## What's in here

- **Add credits card** (org owners only — the service enforces this with 403; members see who to ask instead): $10 / $50 / $100 presets plus a custom field validated against the design bounds ($5–$2,000; the service's own bounds stay authoritative), then a full-page redirect to Stripe. Each click sends a fresh idempotency key; the service's crash-window and webhook idempotency are what actually guard the money.
- **Checkout return handling**: `?checkout=success&purchase=<id>` is claimed once and cleaned from the URL, then a "Confirming your payment" banner polls the purchase (2.5s cadence, attempt counter, goes quiet after ~5 minutes with "safe to leave" copy). Completed refreshes the balance + ledger and links the Stripe-hosted receipt; failed / expired / canceled each state plainly that nothing was charged.
- **Mirror update** for the service's new `POST /purchases` and `GET /purchases/:id` (`lib/billing-api.ts`), with boundary shape checks: an unknown purchase status is refused (the poll branches on it — spinning forever on an unrecognized value would be the worse failure). Authority side: agentconnect-md/extensions#67, the same change set.
- Billing page wraps in `Suspense` (`useSearchParams`).

## Testing

- `billing-api.test.ts`: purchase/created shape assertions (unknown status refused, missing url refused).
- `BillingView.flag.test.tsx` still pins the flag-off behavior: no requests leave a console without the `billing` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)