### PR TITLE
fix(control-plane): shred an org whose transit key never existed

### DIFF
--- a/docs/designs/per-org-secret-encryption.md
+++ b/docs/designs/per-org-secret-encryption.md
@@ -335,10 +335,14 @@ encrypt/decrypt capability it has today, widened only to the org key prefix, and
 
 **Vault privileges for the shredder.** Two calls per key: `POST
 transit/keys/<name>/config` with `deletion_allowed=true`, then `DELETE
-transit/keys/<name>`, scoped to the org key prefix. No list capability is
-required. A deployment that never configures a shredder simply accumulates
-unreferenced keys, which is the right default for self-hosted and development
-installs.
+transit/keys/<name>`, scoped to the org key prefix. No list or read capability
+is required — Transit reports a missing key on both calls as HTTP 400 with a
+"no existing key" / "could not delete key; not found" error, and the shredder
+reads that as done. That case is ordinary, not a crash artefact: org keys are
+created lazily on first encrypt (§4), so an organization that never sealed a
+secret leaves a tombstone with no key behind it. A deployment that never
+configures a shredder simply accumulates unreferenced keys, which is the right
+default for self-hosted and development installs.
 
 **What the guarantee is.** After a successful shred, database backups taken
 before the deletion no longer decrypt that organization's secrets. This is a

--- a/packages/control-plane/src/secrets/shred.test.ts
+++ b/packages/control-plane/src/secrets/shred.test.ts
@@ -114,12 +114,46 @@ describe('VaultTransitKeyDestroyer', () => {
     expect(vault.calls.some((c) => c.path.endsWith('keys') || c.method === 'LIST')).toBe(false)
   })
 
-  it('treats an already-absent key as done — the previous run died between destroy and clear', async () => {
+  it('treats an absent key as done — Transit answers the config write with 400, not 404', async () => {
+    // Real Vault wording. This is the org that never sealed a secret (keys are
+    // created lazily on first encrypt) — and the previous run that died between
+    // destroy and clear looks identical.
+    const vault = fakeVault(() => ({
+      status: 400,
+      body: { errors: ['no existing key named ac-cp-org-gone could be found'] }
+    }))
+    await expect(
+      new VaultTransitKeyDestroyer(http(vault.fetchImpl)).destroy('transit', 'ac-cp-org-gone')
+    ).resolves.toBeUndefined()
+    expect(vault.calls).toHaveLength(1) // stopped after the config call
+  })
+
+  it('treats a key that vanished between the config write and the delete as done', async () => {
+    const vault = fakeVault((method) =>
+      method === 'DELETE'
+        ? { status: 400, body: { errors: ['error deleting key ac-cp-org-gone: could not delete key; not found'] } }
+        : { status: 204 }
+    )
+    await expect(
+      new VaultTransitKeyDestroyer(http(vault.fetchImpl)).destroy('transit', 'ac-cp-org-gone')
+    ).resolves.toBeUndefined()
+    expect(vault.calls).toHaveLength(2)
+  })
+
+  it('still accepts a plain 404 as absent', async () => {
     const vault = fakeVault(() => ({ status: 404, body: { errors: [] } }))
     await expect(
       new VaultTransitKeyDestroyer(http(vault.fetchImpl)).destroy('transit', 'ac-cp-org-gone')
     ).resolves.toBeUndefined()
-    expect(vault.calls).toHaveLength(1) // stopped after the 404 config call
+  })
+
+  it('does NOT read every 400 as absent — a different refusal keeps the tombstone', async () => {
+    const vault = fakeVault(() => ({ status: 400, body: { errors: ['deletion is not allowed for this key'] } }))
+    const err = await new VaultTransitKeyDestroyer(http(vault.fetchImpl))
+      .destroy('transit', 'ac-cp-org-org-aaa')
+      .catch((e: unknown) => e as Error)
+    expect((err as Error).message).toContain('400')
+    expect((err as Error).message).toContain('deletion is not allowed')
   })
 
   it('surfaces a refusal as an error (status + Vault errors[], no payload) so the tombstone survives', async () => {

--- a/packages/control-plane/src/secrets/shred.ts
+++ b/packages/control-plane/src/secrets/shred.ts
@@ -24,7 +24,7 @@
  * discretion via `log`.
  */
 import type { PrismaClient } from '../generated/prisma/client.js'
-import { describeVaultError, VaultHttp } from './vault-http.js'
+import { formatVaultError, readVaultErrors, VaultHttp } from './vault-http.js'
 
 export interface KeyDestroyer {
   /** Destroy one transit key at its pinned mount. Absent ⇒ resolve (already shredded). */
@@ -72,8 +72,10 @@ export async function shredPendingKeys(
 
 /**
  * Vault Transit's two-step destroy: a key is undeletable until its config says
- * otherwise, so allow deletion and then delete. A missing key is success — the
- * previous run destroyed it and died before clearing the row.
+ * otherwise, so allow deletion and then delete. A missing key is success: either
+ * the previous run destroyed it and died before clearing the row, or the org
+ * never sealed a secret — org keys are created lazily on first encrypt, so an
+ * organization that stored nothing has a tombstone but no key at all.
  */
 export class VaultTransitKeyDestroyer implements KeyDestroyer {
   constructor(private readonly http: VaultHttp) {}
@@ -82,13 +84,23 @@ export class VaultTransitKeyDestroyer implements KeyDestroyer {
     const configured = await this.http.request('POST', `${mount}/keys/${keyName}/config`, {
       deletion_allowed: true
     })
-    if (configured.status === 404) return // already gone
     if (!configured.ok) {
-      throw new Error(`vault transit allow-deletion failed: ${await describeVaultError(configured)}`)
+      const errors = await readVaultErrors(configured)
+      if (isAbsentKey(configured.status, errors)) return // already gone (or never created)
+      throw new Error(`vault transit allow-deletion failed: ${formatVaultError(configured.status, errors)}`)
     }
     const deleted = await this.http.request('DELETE', `${mount}/keys/${keyName}`)
-    if (!deleted.ok && deleted.status !== 404) {
-      throw new Error(`vault transit key delete failed: ${await describeVaultError(deleted)}`)
+    if (!deleted.ok) {
+      const errors = await readVaultErrors(deleted)
+      if (isAbsentKey(deleted.status, errors)) return
+      throw new Error(`vault transit key delete failed: ${formatVaultError(deleted.status, errors)}`)
     }
   }
+}
+
+// Transit reports a missing key as HTTP 400 with one of these `errors[]`, never as a 404 (that is what a GET would say, and the shredder has no read capability).
+const ABSENT_KEY_ERROR = /no existing key named .* could be found|could not delete key; not found/
+
+function isAbsentKey(status: number, errors: string[]): boolean {
+  return status === 404 || (status === 400 && errors.some((e) => ABSENT_KEY_ERROR.test(e)))
 }

--- a/packages/control-plane/src/secrets/vault-http.ts
+++ b/packages/control-plane/src/secrets/vault-http.ts
@@ -110,14 +110,22 @@ export class VaultHttp {
   }
 }
 
-/** Status + Vault's `errors[]` only — NEVER the request/response payloads. */
-export async function describeVaultError(res: Response): Promise<string> {
-  let errors = ''
+/** Vault's `errors[]` strings — empty for a non-JSON or non-Vault body, which is never echoed. */
+export async function readVaultErrors(res: Response): Promise<string[]> {
   try {
-    const json = (await res.json()) as { errors?: string[] }
-    if (Array.isArray(json.errors) && json.errors.length > 0) errors = ` (${json.errors.join('; ')})`
+    const json = (await res.json()) as { errors?: unknown }
+    return Array.isArray(json.errors) ? json.errors.filter((e): e is string => typeof e === 'string') : []
   } catch {
-    // non-JSON error body — status alone is enough (and never echo the body)
+    return []
   }
-  return `HTTP ${res.status}${errors}`
+}
+
+/** Status + Vault's `errors[]` only — NEVER the request/response payloads. */
+export function formatVaultError(status: number, errors: string[]): string {
+  return `HTTP ${status}${errors.length > 0 ? ` (${errors.join('; ')})` : ''}`
+}
+
+/** {@link readVaultErrors} + {@link formatVaultError} for callers that only need the message. */
+export async function describeVaultError(res: Response): Promise<string> {
+  return formatVaultError(res.status, await readVaultErrors(res))
 }


### PR DESCRIPTION
## Problem

`secrets:shred` fails on every run for a deleted organization with:

```
failed to destroy <key> — vault transit allow-deletion failed: HTTP 400 (no existing key named <key> could be found)
```

Vault Transit reports a missing key on `POST keys/<name>/config` (and on `DELETE keys/<name>`) as **HTTP 400** with that `errors[]` text, never as 404 — 404 is what a `GET` would say, and the shredder has no read capability. `VaultTransitKeyDestroyer` only recognised 404 as "already gone", so the tombstone stayed forever.

This is the ordinary case, not a crash artefact: org keys are created lazily on first encrypt, so an organization that is created and then deleted without ever sealing a secret leaves a `pending_key_shred` row with no key behind it.

## Fix

- `vault-http.ts`: split `describeVaultError` into `readVaultErrors` + `formatVaultError` so a caller can inspect Vault's `errors[]` before deciding (still never echoes a body).
- `shred.ts`: on both calls, treat 400 + `no existing key named … could be found` / `could not delete key; not found` as done, keep plain 404 as absent, and keep every other 400 (e.g. `deletion is not allowed for this key`) as a failure that preserves the tombstone.
- Tests: the fake Vault now answers with the real wording; added the delete-side vanish, the plain-404, and the "other 400 is still an error" cases.
- Design doc §6: state the real Transit answer and that the never-created key is the expected case.

No policy change on the deployment side is needed — still `update` on `keys/<prefix>*/config` and `delete` on `keys/<prefix>*`, no read.

## Verification

- `vitest --project unit src/secrets/shred.test.ts src/secrets/vault-transit.test.ts` — 29 passed
- control-plane `typecheck`, eslint, prettier — clean

After this ships, the next `secrets:shred` run clears the stuck row on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
