### PR TITLE
feat(protocol,cp): project the agent's additional repositories into the agent spec

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -515,7 +515,9 @@ export function buildContainer(
       http.log.error(
         { agentId, keys },
         'organization environment keys resolved to nothing and were removed from the agent projection'
-      )
+      ),
+    // The additional-repository allowlist the workspace projection mirrors.
+    repos.agentRepoAuth
   )
 
   // Browser webchat token mint/verify (§10, A4): a short-lived HS256 JWT bound to

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1612,14 +1612,11 @@ export function buildContainer(
                   if (!agent) return
                   await agentDelivery.upsert(agent, (err, daemonId) => {
                     if (err instanceof NoConnection) {
-                      http.log.debug(
-                        { agentId, daemonId },
-                        'github rename: workspace agent/upsert skipped — daemon offline'
-                      )
+                      http.log.debug({ agentId, daemonId }, 'github rename: agent/upsert skipped — daemon offline')
                     } else {
                       http.log.warn(
                         { err, agentId, daemonId },
-                        'github rename: workspace agent/upsert failed (backstop: reconnect roster)'
+                        'github rename: agent/upsert failed (backstop: reconnect roster)'
                       )
                     }
                   })

--- a/packages/control-plane/src/http/routes/agent-repos.ts
+++ b/packages/control-plane/src/http/routes/agent-repos.ts
@@ -21,6 +21,7 @@ import { GithubApiError } from '../../github/api.js'
 import { UserAuthzDeniedError } from '../../github/user-authz.js'
 import { LogtoApiError } from '../../github/logto-identity.js'
 import { AgentId, OrgId } from '../../domain/ids.js'
+import { NoConnection } from '../../orchestrator/outbound.js'
 import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView } from '../../authorization/policy.js'
 import { Tag } from '../plugins/openapi.js'
@@ -75,6 +76,25 @@ export function agentRepoRoutes(deps: HttpDeps) {
     }
     const agentNotFound = (reply: FastifyReply) =>
       reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+
+    // A grant rides `AgentSpec.workspace.additionalRepos`, so authorizing or revoking
+    // one is a spec edit. Re-read the agent (the repo advanced its configRevision in
+    // the same transaction) and push, exactly as the agents route's replicateUpsert.
+    // Best-effort: the register/ok reconcile roster is the backstop.
+    const replicateUpsert = async (agent: AgentRecord): Promise<void> => {
+      const fresh = await deps.repos.agent.get(agent.orgId, agent.id)
+      if (!fresh) return
+      await deps.agentDelivery.upsert(fresh, (err, daemonId) => {
+        if (err instanceof NoConnection) {
+          app.log.debug({ agentId: agent.id, daemonId }, 'agent/upsert skipped: daemon offline')
+        } else {
+          app.log.warn(
+            { err, agentId: agent.id, daemonId },
+            'agent/upsert live reconcile failed (backstop: reconnect roster)'
+          )
+        }
+      })
+    }
 
     r.get(
       '/agents/:agentId/repos',
@@ -216,6 +236,7 @@ export function agentRepoRoutes(deps: HttpDeps) {
               details: { repoAuthId: row.id, repoFullName: row.repoFullName, access: row.access }
             })
             .catch(() => {})
+          await replicateUpsert(agent)
           return toDto(row)
         } catch (e) {
           if (e instanceof UserAuthzDeniedError) {
@@ -400,6 +421,7 @@ export function agentRepoRoutes(deps: HttpDeps) {
             details: { repoAuthId: row.id, repoFullName: row.repoFullName, redundantWorkspaceGrant }
           })
           .catch(() => {})
+        await replicateUpsert(agent)
         return reply.code(204).send(null)
       }
     )

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -444,7 +444,8 @@ describe('AgentMoveService', () => {
     expect(t.activations[1]?.spec.workspace).toEqual({
       mode: 'scratch',
       isolation: 'shared',
-      gitCredential: 'github-app'
+      gitCredential: 'github-app',
+      additionalRepos: []
     })
     expect(BigInt(t.activations[1]!.spec.configRevision!)).toBeGreaterThan(
       BigInt(t.activations[0]!.spec.configRevision!)

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -1,6 +1,6 @@
 import { onDaemon, onSet, placementTargetOf, samePlacement, type PlacementTarget } from '../domain/placement.js'
 import { describe, expect, it } from 'vitest'
-import type { Ack, AgentActivate, AgentDetach } from '@agentconnect.md/protocol'
+import type { Ack, AgentActivate, AgentDetach, AgentUpsert } from '@agentconnect.md/protocol'
 import { AgentId, BotId, CronId, DaemonId, IntegrationId, OrgId } from '../domain/ids.js'
 import type {
   AgentRecord,
@@ -166,6 +166,10 @@ function make(
     placement?: Partial<AgentRecord>
     /** A repository grant that commits inside the detach → workspace-CAS window. */
     grantDuringWorkspaceCas?: { repoFullName: string; repoId: bigint }
+    /** A repository grant that commits while the rejected workspace activation is in flight. */
+    grantDuringWorkspaceActivate?: { repoFullName: string; repoId: bigint }
+    /** The grant `setWorkspaceRepoId` finds redundant and deletes after the activation. */
+    redundantGrant?: { repoFullName: string; repoId: bigint }
   } = {}
 ) {
   let current: AgentRecord = {
@@ -175,10 +179,11 @@ function make(
       : {}),
     ...(opts.placement ?? {})
   }
-  let grants: Array<{ repoFullName: string; repoId: bigint }> = []
+  let grants: Array<{ repoFullName: string; repoId: bigint }> = opts.redundantGrant ? [opts.redundantGrant] : []
   let cronRows = [cron]
   const calls: string[] = []
   const activations: AgentActivate[] = []
+  const upserts: AgentUpsert[] = []
   const detaches: AgentDetach[] = []
   // The org each control frame was scoped to — undefined is what an install-wide
   // member's connection rejects, so it is the interesting value here.
@@ -232,7 +237,13 @@ function make(
       }
       return current
     },
-    setWorkspaceRepoId: async () => true,
+    setWorkspaceRepoId: async (_id: string, repoId: bigint) => {
+      // Like the real cleanup: it drops the now-redundant grant AND advances the revision,
+      // both after the activation has already been sent.
+      grants = grants.filter((grant) => grant.repoId !== repoId)
+      current = { ...current, workspaceRepoId: repoId, configRevision: current.configRevision + 1n }
+      return true
+    },
     movePlacement: async (_id: string, expected: PlacementTarget, target: PlacementTarget) => {
       if (opts.casMiss || !samePlacement(placementTargetOf(current), expected)) return null
       current = agent(target.kind === 'daemon' ? target.daemonId : null)
@@ -271,6 +282,12 @@ function make(
       }
       appliedRevisions.set(daemonId, incoming)
       if (value.reconcileWorkspace && opts.rejectWorkspaceActivate && activations.length === 1) {
+        // A grant landing while the rejected activation was in flight: the rollback CAS below
+        // then commits on top of ITS revision.
+        if (opts.grantDuringWorkspaceActivate) {
+          grants = [...grants, opts.grantDuringWorkspaceActivate]
+          current = { ...current, configRevision: current.configRevision + 1n }
+        }
         return ack(false, 'clone failed')
       }
       if (value.reconcileWorkspace && opts.rejectWorkspaceRestore && activations.length === 2) {
@@ -282,6 +299,11 @@ function make(
       }
       if (daemonId === TARGET && opts.failTargetActivate) return ack(false, 'cannot start')
       return ack()
+    },
+    agentUpsert: async (daemonId: string, value: AgentUpsert, orgId?: string) => {
+      calls.push(`upsert:${daemonId}`)
+      upserts.push(value)
+      frameOrgs.push(orgId)
     }
   } as unknown as ControlSender
   const service = new AgentMoveService({
@@ -347,7 +369,7 @@ function make(
         }
       : {})
   })
-  return { service, calls, activations, detaches, frameOrgs, mutations, releasedLive, current: () => current }
+  return { service, calls, activations, upserts, detaches, frameOrgs, mutations, releasedLive, current: () => current }
 }
 
 describe('AgentMoveService', () => {
@@ -408,11 +430,14 @@ describe('AgentMoveService', () => {
       spec: { workspace: { mode: 'github', gitRepo: GITHUB_WORKSPACE.gitRepo } }
     })
     expect(t.detaches[0]?.moveId).toBe(t.activations[0]?.moveId)
-    expect(t.calls).toEqual([`detach:${SOURCE}`, `activate:${SOURCE}`, 'hooks', 'collab'])
+    // The trailing upsert re-projects the spec after the redundant-grant cleanup, which
+    // runs (and advances the revision) only once the activation has been accepted.
+    expect(t.calls).toEqual([`detach:${SOURCE}`, `activate:${SOURCE}`, `upsert:${SOURCE}`, 'hooks', 'collab'])
   })
 
   it('re-reads the repository allowlist after the workspace CAS so the activation matches its revision', async () => {
     const t = make({ grantDuringWorkspaceCas: { repoFullName: 'example-co/shared-library', repoId: 815n } })
+    const before = t.current().configRevision
 
     await t.service.setWorkspace(t.current(), GITHUB_WORKSPACE, WORKSPACE_REPO_ID)
 
@@ -422,7 +447,43 @@ describe('AgentMoveService', () => {
     expect(t.activations[0]?.spec.workspace).toMatchObject({
       additionalRepos: [{ repoFullName: 'example-co/shared-library', repoId: '815' }]
     })
-    expect(t.activations[0]?.spec.configRevision).toBe(t.current().configRevision.toString())
+    expect(BigInt(t.activations[0]!.spec.configRevision!)).toBeGreaterThan(before)
+  })
+
+  it('re-reads the repository allowlist after the rollback CAS as well', async () => {
+    const t = make({
+      rejectWorkspaceActivate: true,
+      grantDuringWorkspaceActivate: { repoFullName: 'example-co/shared-library', repoId: 815n }
+    })
+
+    await expect(t.service.setWorkspace(t.current(), GITHUB_WORKSPACE, WORKSPACE_REPO_ID)).rejects.toThrow(
+      'workspace edit rejected: clone failed'
+    )
+
+    // The restore activates the post-rollback revision, which sits above the grant's — so it
+    // has to carry the grant too, or the next roster repeats that revision with other content.
+    expect(t.activations).toHaveLength(2)
+    expect(t.activations[1]?.spec.workspace).toMatchObject({
+      additionalRepos: [{ repoFullName: 'example-co/shared-library', repoId: '815' }]
+    })
+    expect(t.activations[1]?.spec.configRevision).toBe(t.current().configRevision.toString())
+  })
+
+  it('re-projects the spec after the redundant-grant cleanup that follows the activation', async () => {
+    const redundantGrant = { repoFullName: 'acme/infra', repoId: WORKSPACE_REPO_ID }
+    const t = make({ redundantGrant })
+
+    await t.service.setWorkspace(t.current(), GITHUB_WORKSPACE, WORKSPACE_REPO_ID)
+
+    // The activation still listed the grant — cleanup runs after it — so without this push the
+    // daemon would keep the new PRIMARY repository as an additional one until it reconnected.
+    expect(t.activations[0]?.spec.workspace).toMatchObject({
+      additionalRepos: [redundantGrant.repoFullName].map((r) => ({ repoFullName: r }))
+    })
+    expect(t.upserts).toHaveLength(1)
+    expect(t.upserts[0]?.spec.workspace).toMatchObject({ additionalRepos: [] })
+    expect(t.upserts[0]?.spec.configRevision).toBe(t.current().configRevision.toString())
+    expect(BigInt(t.upserts[0]!.spec.configRevision!)).toBeGreaterThan(BigInt(t.activations[0]!.spec.configRevision!))
   })
 
   it('reconciles an access edit so the daemon can preserve the matching checkout', async () => {

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -164,6 +164,8 @@ function make(
     readyDaemons?: string[]
     /** Placement columns merged over the initial record (e.g. a `set` placement). */
     placement?: Partial<AgentRecord>
+    /** A repository grant that commits inside the detach → workspace-CAS window. */
+    grantDuringWorkspaceCas?: { repoFullName: string; repoId: bigint }
   } = {}
 ) {
   let current: AgentRecord = {
@@ -173,6 +175,7 @@ function make(
       : {}),
     ...(opts.placement ?? {})
   }
+  let grants: Array<{ repoFullName: string; repoId: bigint }> = []
   let cronRows = [cron]
   const calls: string[] = []
   const activations: AgentActivate[] = []
@@ -193,6 +196,12 @@ function make(
       workspaceRepoId?: bigint
     ) => {
       if (opts.workspacePersistenceFailsBeforeCommit) throw new Error('database unavailable')
+      // A grant landing between the pre-detach snapshot and this CAS: it advances the same
+      // per-agent revision counter, so the CAS below commits on top of ITS revision.
+      if (opts.grantDuringWorkspaceCas) {
+        grants = [...grants, opts.grantDuringWorkspaceCas]
+        current = { ...current, configRevision: current.configRevision + 1n }
+      }
       current = {
         ...current,
         workspace,
@@ -289,11 +298,23 @@ function make(
     } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['botSecrets'],
     platforms: PLATFORMS,
     // The real assembler over a fake store — exercises project()/secretsOf() as prod does.
-    specs: new AgentSpecAssembler({
-      get: async () => ({}),
-      merge: async () => {},
-      keys: async () => new Map()
-    } as unknown as ConstructorParameters<typeof AgentSpecAssembler>[0]),
+    specs: new AgentSpecAssembler(
+      {
+        get: async () => ({}),
+        merge: async () => {},
+        keys: async () => new Map()
+      } as unknown as ConstructorParameters<typeof AgentSpecAssembler>[0],
+      {},
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      // Reads `grants` on every call, so a mid-move write is observable to a re-read.
+      {
+        listForAgent: async () => grants.map((grant) => ({ ...grant, access: 'read' }))
+      } as unknown as ConstructorParameters<typeof AgentSpecAssembler>[7]
+    ),
     crons: { listForAgent: async () => cronRows } as unknown as ConstructorParameters<
       typeof AgentMoveService
     >[0]['crons'],
@@ -388,6 +409,20 @@ describe('AgentMoveService', () => {
     })
     expect(t.detaches[0]?.moveId).toBe(t.activations[0]?.moveId)
     expect(t.calls).toEqual([`detach:${SOURCE}`, `activate:${SOURCE}`, 'hooks', 'collab'])
+  })
+
+  it('re-reads the repository allowlist after the workspace CAS so the activation matches its revision', async () => {
+    const t = make({ grantDuringWorkspaceCas: { repoFullName: 'example-co/shared-library', repoId: 815n } })
+
+    await t.service.setWorkspace(t.current(), GITHUB_WORKSPACE, WORKSPACE_REPO_ID)
+
+    // The pre-detach snapshot saw no grant; shipping that list at the post-CAS revision
+    // would be the equal-revision/different-content violation the daemon refuses forever.
+    expect(t.activations).toHaveLength(1)
+    expect(t.activations[0]?.spec.workspace).toMatchObject({
+      additionalRepos: [{ repoFullName: 'example-co/shared-library', repoId: '815' }]
+    })
+    expect(t.activations[0]?.spec.configRevision).toBe(t.current().configRevision.toString())
   })
 
   it('reconciles an access edit so the daemon can preserve the matching checkout', async () => {

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -21,6 +21,7 @@ import {
   type Ack,
   type AgentActivate,
   type DutyAgentBundle,
+  type AgentAdditionalRepo,
   type AgentSkillEntry,
   type ManagedSkillEntry,
   type CronUpsert,
@@ -152,6 +153,9 @@ interface MoveBundle {
    * target daemon.
    */
   organizationEnvironment: OrganizationEnvironmentValues
+  /** The agent's authorized additional repositories — pinned for the same reason
+   *  as skills: a bare project() would ship [] and clear them on the target. */
+  additionalRepos: AgentAdditionalRepo[]
 }
 
 interface ActivationSnapshot {
@@ -776,14 +780,16 @@ export class AgentMoveService {
 
   /** Read every placement-dependent wire definition. */
   private async snapshot(agent: AgentRecord): Promise<MoveBundle> {
-    const [integrations, cronRows, secrets, skills, managedSkills, organizationEnvironment] = await Promise.all([
-      this.deps.integrations.listForAgent(agent.id),
-      this.deps.crons.listForAgent(agent.id),
-      this.deps.specs.secretsOf(agent),
-      this.deps.specs.skillsOf(agent),
-      this.deps.specs.managedSkillsOf(agent),
-      this.deps.specs.organizationEnvironmentOf(agent)
-    ])
+    const [integrations, cronRows, secrets, skills, managedSkills, organizationEnvironment, additionalRepos] =
+      await Promise.all([
+        this.deps.integrations.listForAgent(agent.id),
+        this.deps.crons.listForAgent(agent.id),
+        this.deps.specs.secretsOf(agent),
+        this.deps.specs.skillsOf(agent),
+        this.deps.specs.managedSkillsOf(agent),
+        this.deps.specs.organizationEnvironmentOf(agent),
+        this.deps.specs.additionalReposOf(agent)
+      ])
     const specs = await Promise.all(
       integrations.map(async (integration) => {
         const [bot, secret, channels] = await Promise.all([
@@ -818,7 +824,8 @@ export class AgentMoveService {
       secrets,
       skills,
       managedSkills,
-      organizationEnvironment
+      organizationEnvironment,
+      additionalRepos
     }
   }
 
@@ -833,7 +840,8 @@ export class AgentMoveService {
         bundle.secrets,
         bundle.skills,
         bundle.managedSkills,
-        bundle.organizationEnvironment
+        bundle.organizationEnvironment,
+        bundle.additionalRepos
       ),
       integrations: bundle.integrations.map(({ spec }) => spec),
       crons: bundle.crons

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -732,15 +732,28 @@ export class AgentMoveService {
     // edit's, and the daemon's fence refuses a bundle whose spec is not newer than the one it just
     // applied. Replaying `original` therefore could not restore anything the target had accepted —
     // every rejected edit ended fail-closed with the agent staged and offline.
+    //
+    // The list is read against THAT row for the same reason the forward activation reads it after
+    // its own CAS: a grant writer that committed while the rejected activation was in flight sits
+    // under this restore's revision, so the caller's copy would ship stale content at it.
+    let restoredBundle: MoveBundle
+    try {
+      restoredBundle = { ...bundle, additionalRepos: await this.deps.specs.additionalReposOf(restored) }
+    } catch (err) {
+      throw new AgentMoveFailClosed(
+        'workspace edit was rejected and the authorized repositories could not be re-read for its rollback',
+        err
+      )
+    }
     await this.restoreDetachedWorkspace(
       (await (this.deps.placement ?? PLACEMENT_ONLY).servingDaemon(converted))!,
       restored,
-      bundle,
+      restoredBundle,
       moveId,
       'workspace activation rejection',
       reason
     )
-    await this.convergeDerived(restored, bundle.httpBotIds)
+    await this.convergeDerived(restored, restoredBundle.httpBotIds)
     throw new AgentMoveFailed(`workspace edit rejected${reason ? `: ${reason}` : ''}`)
   }
 
@@ -756,7 +769,12 @@ export class AgentMoveService {
     try {
       // Classify the target as the implicit workspace repo and remove the now-
       // redundant explicit grant without tombstoning valid review projections.
-      if (!(await this.deps.agents.setWorkspaceRepoId(agent.id, workspaceRepoId))) {
+      if (await this.deps.agents.setWorkspaceRepoId(agent.id, workspaceRepoId)) {
+        // The cleanup runs AFTER the activation, and it both advances the revision and can drop a
+        // row the activation still listed in `workspace.additionalRepos` — so the daemon would
+        // otherwise carry the new primary repo as an additional one until it reconnected.
+        await this.pushPostCleanupSpec(agent)
+      } else {
         this.deps.log?.warn(
           { agentId: agent.id, workspaceRepoId: workspaceRepoId.toString() },
           'workspace edit: redundant repository grant cleanup deferred'
@@ -768,6 +786,23 @@ export class AgentMoveService {
       this.deps.log?.warn({ err, agentId: agent.id }, 'workspace edit: repository grant cleanup deferred')
     }
     await this.convergeDerived(agent, httpBotIds)
+  }
+
+  /** Best-effort: the reconnect roster is the backstop, and the edit itself already committed. */
+  private async pushPostCleanupSpec(agent: AgentRecord): Promise<void> {
+    const fresh = await this.deps.agents.getUnscoped(agent.id)
+    if (!fresh) return
+    const spec = await this.deps.specs.assemble(fresh)
+    for (const daemonId of await (this.deps.placement ?? PLACEMENT_ONLY).servingDaemons(fresh)) {
+      try {
+        await this.deps.control.agentUpsert(daemonId, { agentId: fresh.id, spec }, fresh.orgId)
+      } catch (err) {
+        this.deps.log?.warn(
+          { err, agentId: fresh.id, daemonId },
+          'workspace edit: post-cleanup agent/upsert failed (backstop: reconnect roster)'
+        )
+      }
+    }
   }
 
   /**

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -467,12 +467,27 @@ export class AgentMoveService {
       }
     }
 
+    // Everything sent from here on carries a POST-CAS `configRevision`, so the repository
+    // allowlist has to be read after the CAS too. Its writers — the grant routes and the
+    // asynchronous rename repair — advance the same per-agent counter without holding this
+    // section, so replaying the pre-detach list at the newer revision is exactly the
+    // equal-revision/different-content violation the daemon refuses on every reconnect.
+    let postCas: MoveBundle
+    try {
+      postCas = { ...bundle, additionalRepos: await this.deps.specs.additionalReposOf(converted) }
+    } catch (err) {
+      throw new AgentMoveFailed(
+        'workspace edit could not re-read the authorized repositories; retry the same edit',
+        err
+      )
+    }
+
     let activated: Ack
     try {
       activated = await this.deps.control.agentActivate(
         daemonId,
         {
-          ...this.activationDefinition(converted, bundle),
+          ...this.activationDefinition(converted, postCas),
           moveId,
           reconcileWorkspace: true
         },
@@ -484,7 +499,7 @@ export class AgentMoveService {
       throw new AgentMoveFailed('workspace edit outcome is uncertain; retry the same edit', err)
     }
     if (!activated.ok) {
-      await this.rollbackWorkspaceChange(agent, converted, bundle, moveId, activated.reason)
+      await this.rollbackWorkspaceChange(agent, converted, postCas, moveId, activated.reason)
     }
 
     await this.finalizeWorkspaceChange(converted, workspaceRepoId, bundle.httpBotIds)

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.test.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import { AgentSpecAssembler } from './agentSpecAssembler.js'
-import type { AgentRecord, AgentSecretStore } from '../persistence/ports.js'
+import type { AgentRepoAuthorizationRepo, AgentRecord, AgentSecretStore } from '../persistence/ports.js'
 import { AgentId, OrgId } from '../domain/ids.js'
 
 const AGENT: AgentRecord = {
@@ -51,6 +51,35 @@ function storeWith(values: Record<string, Record<string, string>>): AgentSecretS
     merge: async () => {},
     keys: async () => new Map()
   }
+}
+
+const unused = () => Promise.reject(new Error('not used by this test'))
+
+/** Only `listForAgent` participates in the projection; the writers stay inert. */
+function repoAuthWith(rows: Array<[fullName: string, repoId: bigint]>): AgentRepoAuthorizationRepo {
+  return {
+    listForAgent: async (agentId) =>
+      rows.map(([repoFullName, repoId], index) => ({
+        id: `auth-${index}`,
+        agentId,
+        repoId,
+        repoFullName,
+        access: 'read' as const,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        createdBy: null
+      })),
+    create: unused,
+    get: unused,
+    updateAccess: unused,
+    updateFullName: unused,
+    remove: unused,
+    removeWithReviewProjectionCleanup: unused
+  }
+}
+
+/** The assembler's optional dependencies are positional; only the allowlist matters here. */
+function assemblerWith(agentRepoAuth: AgentRepoAuthorizationRepo): AgentSpecAssembler {
+  return new AgentSpecAssembler(storeWith({}), {}, undefined, undefined, undefined, undefined, undefined, agentRepoAuth)
 }
 
 describe('AgentSpecAssembler', () => {
@@ -157,6 +186,55 @@ describe('AgentSpecAssembler', () => {
         []
       )
     ).toThrow('git clone url must use https or ssh')
+  })
+
+  it('projects the agent’s authorized repositories onto a scratch workspace, sorted by full name', async () => {
+    const specs = assemblerWith(
+      repoAuthWith([
+        ['example-co/shared-library', 815n],
+        ['acme/infra', 4711n]
+      ])
+    )
+
+    const spec = await specs.assemble(AGENT)
+
+    expect(spec.workspace).toMatchObject({
+      mode: 'scratch',
+      additionalRepos: [
+        { repoFullName: 'acme/infra', repoId: '4711' },
+        { repoFullName: 'example-co/shared-library', repoId: '815' }
+      ]
+    })
+  })
+
+  it('projects the same list onto a github workspace', async () => {
+    const specs = assemblerWith(repoAuthWith([['example-co/shared-library', 815n]]))
+
+    const spec = await specs.assemble({
+      ...AGENT,
+      workspace: { mode: 'github', gitRepo: 'https://github.com/acme/primary-service' }
+    })
+
+    expect(spec.workspace).toMatchObject({
+      mode: 'github',
+      additionalRepos: [{ repoFullName: 'example-co/shared-library', repoId: '815' }]
+    })
+  })
+
+  it('projects an empty list for an agent with no grants, and with no allowlist dependency at all', async () => {
+    expect((await assemblerWith(repoAuthWith([])).assemble(AGENT)).workspace).toMatchObject({ additionalRepos: [] })
+    expect((await new AgentSpecAssembler(storeWith({})).assemble(AGENT)).workspace).toMatchObject({
+      additionalRepos: []
+    })
+  })
+
+  it('project trusts the caller-snapshotted allowlist (the move bundle pins it)', () => {
+    const specs = assemblerWith(repoAuthWith([['acme/infra', 4711n]]))
+    const pinned = [{ repoFullName: 'example-co/shared-library', repoId: '815' }]
+
+    const spec = specs.project(AGENT, {}, [], [], undefined, pinned)
+
+    expect(spec.workspace).toMatchObject({ additionalRepos: pinned })
   })
 
   it('applies the instance-owned icon bases to the spec iconUrl', async () => {

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
@@ -19,12 +19,14 @@ import {
   normalizeGitCloneUrl,
   normalizeGithubRepoUrl,
   redactGitUrlSecrets,
+  type AgentAdditionalRepo,
   type AgentSkillEntry,
   type ManagedSkillEntry,
   type AgentSpec
 } from '@agentconnect.md/protocol'
 import type {
   AgentRecord,
+  AgentRepoAuthorizationRepo,
   AgentSecretStore,
   OrganizationEnvironmentResolver,
   OrganizationKnowledgeRepo,
@@ -59,18 +61,23 @@ export class AgentSpecAssembler {
     // Reports a key that resolved to nothing — an organization variable colliding
     // with an agent secret, or an organization secret with no stored material (§9).
     // ID/key only: never a value.
-    private readonly onTombstonedEnvironmentKeys?: (agentId: string, keys: readonly string[]) => void
+    private readonly onTombstonedEnvironmentKeys?: (agentId: string, keys: readonly string[]) => void,
+    // Optional for minimal test graphs: the agent's additional-repository allowlist,
+    // projected onto the workspace (multi-repository-workspaces.md decision 2).
+    // Absent ⇒ [], exactly the pre-feature projection.
+    private readonly agentRepoAuth?: AgentRepoAuthorizationRepo
   ) {}
 
   /** Fetch the agent's secret values + resolve its skills, then project the spec. */
   async assemble(a: AgentRecord): Promise<AssembledAgentSpec> {
-    const [secrets, skillEntries, managedSkillEntries, organization] = await Promise.all([
+    const [secrets, skillEntries, managedSkillEntries, organization, additionalRepos] = await Promise.all([
       this.secrets.get(a.orgId, a.id),
       resolveAgentSkillEntries(a, this.skillSources, (invalid) => this.onInvalidSkillSource?.(a.id, invalid)),
       this.managedSkillsOf(a),
-      this.organizationEnvironmentOf(a)
+      this.organizationEnvironmentOf(a),
+      this.additionalReposOf(a)
     ])
-    return this.project(a, secrets, skillEntries, managedSkillEntries, organization)
+    return this.project(a, secrets, skillEntries, managedSkillEntries, organization, additionalRepos)
   }
 
   /** The organization contribution to one agent's effective environment. */
@@ -105,6 +112,16 @@ export class AgentSpecAssembler {
    *  exposed here so move code needs no separate secrets dependency. */
   secretsOf(a: Pick<AgentRecord, 'id' | 'orgId'>): Promise<Record<string, string>> {
     return this.secrets.get(a.orgId, a.id)
+  }
+
+  /** The agent's authorized additional repositories, sorted by full name so the
+   *  projection is stable (a reordered read must not change the spec digest).
+   *  Pinned into the move {@link MoveBundle} for the same reason as skills. */
+  async additionalReposOf(a: Pick<AgentRecord, 'id'>): Promise<AgentAdditionalRepo[]> {
+    const rows = (await this.agentRepoAuth?.listForAgent(a.id)) ?? []
+    return rows
+      .map((row) => ({ repoFullName: row.repoFullName, repoId: row.repoId.toString() }))
+      .sort((x, y) => (x.repoFullName < y.repoFullName ? -1 : x.repoFullName > y.repoFullName ? 1 : 0))
   }
 
   /** Resolve the agent's skill entries — pinned into the move {@link MoveBundle} so
@@ -154,14 +171,23 @@ export class AgentSpecAssembler {
     secrets: Record<string, string>,
     skillEntries: AgentSkillEntry[],
     managedSkillEntries: ManagedSkillEntry[] = [],
-    organization: OrganizationEnvironmentValues = emptyOrganizationEnvironmentValues()
+    organization: OrganizationEnvironmentValues = emptyOrganizationEnvironmentValues(),
+    additionalRepos: AgentAdditionalRepo[] = []
   ): AssembledAgentSpec {
     // Resolve by key across both sources BEFORE splitting into the two wire maps
     // (organization-secrets-and-variables.md §3.2), so the winner of a collision
     // is deterministic and a write-only key can never be declassified into `env`.
     const effective = resolveEffectiveEnvironment(a.env, secrets, organization)
     if (effective.tombstoned.length > 0) this.onTombstonedEnvironmentKeys?.(a.id, effective.tombstoned)
-    return agentRecordToSpec(a, effective.secrets, this.iconBases, skillEntries, managedSkillEntries, effective.env)
+    return agentRecordToSpec(
+      a,
+      effective.secrets,
+      this.iconBases,
+      skillEntries,
+      managedSkillEntries,
+      effective.env,
+      additionalRepos
+    )
   }
 }
 
@@ -182,7 +208,10 @@ export function agentRecordToSpec(
   // The RESOLVED variable map (agent-local merged with assigned organization
   // entries). Defaults to the agent's own env so a caller with no organization
   // context — hand-authored tests, minimal graphs — behaves exactly as before.
-  env: Record<string, string> = a.env
+  env: Record<string, string> = a.env,
+  // The agent's `AgentRepoAuthorization` rows, already sorted by full name.
+  // Defaults to [] so a caller with no allowlist context projects as before.
+  additionalRepos: AgentAdditionalRepo[] = []
 ): AssembledAgentSpec {
   // Domain AgentWorkspace uses `gitBranch`; the wire AgentWorkspace uses `branch`.
   // App-backed GitHub workspaces have one implicit repo. Scratch workspaces have
@@ -201,9 +230,10 @@ export function agentRecordToSpec(
               : normalizeGitCloneUrl(redactGitUrlSecrets(a.workspace.gitRepo)),
           branch: a.workspace.gitBranch ?? 'main',
           ...(a.workspace.agentDir !== undefined ? { agentDir: a.workspace.agentDir } : {}),
-          ...(a.workspace.installationId !== undefined ? { gitCredential: 'github-app' as const } : {})
+          ...(a.workspace.installationId !== undefined ? { gitCredential: 'github-app' as const } : {}),
+          additionalRepos
         }
-      : { mode: 'scratch', isolation: a.workspace.isolation ?? 'shared', gitCredential: 'github-app' }
+      : { mode: 'scratch', isolation: a.workspace.isolation ?? 'shared', gitCredential: 'github-app', additionalRepos }
   return {
     agentId: a.id,
     orgId: a.orgId,

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -300,7 +300,8 @@ describe('agentRecordToSpec runtime overrides', () => {
     expect(agentRecordToSpec(agent, {}).workspace).toEqual({
       mode: 'scratch',
       isolation: 'shared',
-      gitCredential: 'github-app'
+      gitCredential: 'github-app',
+      additionalRepos: []
     })
     // The preset marker always ships (definite record field) so the daemon can
     // gate preset-only behavior such as `agentconnect-admin` attachment.

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2473,8 +2473,9 @@ export interface HookRepo {
   recordDeliveryResult(hookId: HookId, input: HookDeliveryInput): Promise<HookDeliveryRecordResult>
   /** Refresh mutable GitHub endpoint/display names after a newly observed,
    * accepted delivery, but only while it remains the org/repo's newest
-   * observation. Returns changed hooks for relay convergence and changed
-   * App-backed workspaces for daemon config convergence. */
+   * observation. Returns changed hooks for relay convergence, plus every agent whose
+   * spec the rename edited — App-backed workspaces and additional-repository grant
+   * owners alike — for daemon config convergence. */
   refreshGithubRepoFullName(
     sourceHookId: HookId,
     repoId: bigint,

--- a/packages/control-plane/src/persistence/repositories/agent-repo-auth.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-repo-auth.repo.ts
@@ -6,6 +6,12 @@
  * here. Rows are hard-deleted on revoke — unlike installations there is no
  * provenance pointer into this table, and an already-minted token surviving
  * to its ≤1h expiry is the documented revocation window.
+ *
+ * `repoId` + `repoFullName` are projected onto `AgentSpec.workspace.additionalRepos`
+ * (multi-repository-workspaces.md decision 2), so every writer that changes either
+ * bumps the owning agent's `configRevision` in the SAME transaction. Without it the
+ * daemon receives new spec content at the applied revision and refuses it as an
+ * invariant violation — permanently, on every reconnect.
  */
 import type { AgentRepoAuthorization, PrismaClient, User } from '../../generated/prisma/client.js'
 import { Prisma } from '../../generated/prisma/client.js'
@@ -15,6 +21,7 @@ import { AgentId } from '../../domain/ids.js'
 import { PgHookRepo } from './hook.repo.js'
 import { lockHookReviewAgentRepoScope } from '../review-projection-lock.js'
 import { AgentWorkspaceRepoConflict } from '../errors.js'
+import { bumpAgentConfigRevisions } from './organization-environment-fence.js'
 
 const withCreator = { createdBy: true } as const
 
@@ -66,6 +73,7 @@ export class PgAgentRepoAuthorizationRepo implements AgentRepoAuthorizationRepo 
         },
         include: withCreator
       })
+      await bumpAgentConfigRevisions(tx, [input.agentId])
       return toRecord(row)
     })
   }
@@ -91,12 +99,24 @@ export class PgAgentRepoAuthorizationRepo implements AgentRepoAuthorizationRepo 
   }
 
   async updateFullName(id: string, repoFullName: string): Promise<void> {
-    // updateMany (not update) so a concurrently-deleted row is a count of 0, not a throw.
-    await this.db.agentRepoAuthorization.updateMany({ where: { id }, data: { repoFullName } })
+    await this.transaction(async (tx) => {
+      // updateMany (not update) so a concurrently-deleted row is a count of 0, not a throw.
+      const changed = await tx.agentRepoAuthorization.updateMany({
+        where: { id, repoFullName: { not: repoFullName } },
+        data: { repoFullName }
+      })
+      if (changed.count === 0) return
+      const row = await tx.agentRepoAuthorization.findUnique({ where: { id }, select: { agentId: true } })
+      if (row) await bumpAgentConfigRevisions(tx, [row.agentId])
+    })
   }
 
   async remove(id: string): Promise<void> {
-    await this.db.agentRepoAuthorization.deleteMany({ where: { id } })
+    await this.transaction(async (tx) => {
+      const row = await tx.agentRepoAuthorization.findUnique({ where: { id }, select: { agentId: true } })
+      const removed = await tx.agentRepoAuthorization.deleteMany({ where: { id } })
+      if (removed.count > 0 && row) await bumpAgentConfigRevisions(tx, [row.agentId])
+    })
   }
 
   async removeWithReviewProjectionCleanup(
@@ -118,7 +138,8 @@ export class PgAgentRepoAuthorizationRepo implements AgentRepoAuthorizationRepo 
         // the shared lock order without opening a no-row race.
         await new PgHookRepo(tx).tombstoneReviewProjectionsForAgentRepo(agentId, repoId, at, desiredState)
       }
-      await tx.agentRepoAuthorization.deleteMany({ where: { id, agentId, repoId } })
+      const removed = await tx.agentRepoAuthorization.deleteMany({ where: { id, agentId, repoId } })
+      if (removed.count > 0) await bumpAgentConfigRevisions(tx, [agentId])
     })
   }
 }

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -62,6 +62,7 @@ import {
 } from '../review-projection-lock.js'
 import { authoritativeHookProjectionState } from '../../github/projection-state.js'
 import { AgentWorkspaceIntegrationConflict, HookMissing } from '../errors.js'
+import { bumpAgentConfigRevisions } from './organization-environment-fence.js'
 
 type HookWithUsers = HookDef & {
   createdBy: User | null
@@ -1023,10 +1024,24 @@ export class PgHookRepo implements HookRepo {
           data: { name: repoFullName }
         })
       }
+      // The grants carry the renamed display name into `workspace.additionalRepos`,
+      // so their owners join the same configuration-ordering domain as the workspace
+      // agents below — read the owners BEFORE the write erases the predicate.
+      const renamedGrantAgentIds = [
+        ...new Set(
+          (
+            await tx.agentRepoAuthorization.findMany({
+              where: { repoId, agent: { orgId }, repoFullName: { not: repoFullName } },
+              select: { agentId: true }
+            })
+          ).map((row) => row.agentId)
+        )
+      ]
       await tx.agentRepoAuthorization.updateMany({
         where: { repoId, agent: { orgId }, repoFullName: { not: repoFullName } },
         data: { repoFullName }
       })
+      await bumpAgentConfigRevisions(tx, renamedGrantAgentIds)
       const gitRepo = normalizeGitUrl(repoFullName)
       const workspaceWhere = {
         orgId,

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -1024,9 +1024,9 @@ export class PgHookRepo implements HookRepo {
           data: { name: repoFullName }
         })
       }
-      // The grants carry the renamed display name into `workspace.additionalRepos`,
-      // so their owners join the same configuration-ordering domain as the workspace
-      // agents below — read the owners BEFORE the write erases the predicate.
+      // The grants carry the renamed display name into `workspace.additionalRepos`, so their
+      // owners join the same configuration-ordering domain — and the same convergence fan-out —
+      // as the workspace agents below. Read the owners BEFORE the write erases the predicate.
       const renamedGrantAgentIds = [
         ...new Set(
           (
@@ -1075,7 +1075,11 @@ export class PgHookRepo implements HookRepo {
                 include: withUsers
               })
             ).map(toRecord)
-      return { hooks, agentIds: changedAgents.map((agent) => AgentId(agent.id)) }
+      // Both kinds of renamed agent need the live push: the workspace URL and the grant's
+      // display name are two fields of the SAME spec, and an owner left out here keeps the
+      // stale name on every connected daemon until it reconnects.
+      const renamedAgentIds = [...new Set([...changedAgents.map((agent) => agent.id), ...renamedGrantAgentIds])].sort()
+      return { hooks, agentIds: renamedAgentIds.map((id) => AgentId(id)) }
     })
   }
 

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -286,6 +286,7 @@ export function buildHttpApp(
   const hookRepo = new PgHookRepo(prisma)
   const hookSecretStore = new PgHookSecretStore(prisma, cipher)
   const githubInstallationRepo = new PgGithubInstallationRepo(prisma)
+  const agentRepoAuthRepo = new PgAgentRepoAuthorizationRepo(prisma)
   // An empty relay registry ⇒ multi-agent installs 409 (no relay) and hook broadcasts are
   // no-ops — exactly the prod graph with no relay dialed in, unless a test wires one up.
   const relayReg = new RelayRegistry()
@@ -327,7 +328,9 @@ export function buildHttpApp(
     skillSourceRepo,
     organizationKnowledgeRepo,
     undefined,
-    organizationEnvironmentResolver
+    organizationEnvironmentResolver,
+    undefined,
+    agentRepoAuthRepo
   )
   const agentDelivery = new AgentDelivery({ control: sender, specs: agentSpecs, placement: placementResolver })
 
@@ -397,7 +400,7 @@ export function buildHttpApp(
       org: orgRepo,
       waitlist: waitlistRepo,
       githubInstallation: githubInstallationRepo,
-      agentRepoAuth: new PgAgentRepoAuthorizationRepo(prisma),
+      agentRepoAuth: agentRepoAuthRepo,
       integration: integrationRepo,
       bot: botRepo,
       botSecret: botSecretStore,

--- a/packages/control-plane/test/integration/agent-repos.route.test.ts
+++ b/packages/control-plane/test/integration/agent-repos.route.test.ts
@@ -22,7 +22,7 @@
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { generateKeyPairSync, randomUUID } from 'node:crypto'
-import type { Ack, AgentActivate, AgentDetach } from '@agentconnect.md/protocol'
+import type { Ack, AgentActivate, AgentDetach, AgentUpsert } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent } from '../fixtures/seed.js'
 import { buildHttpApp, TEST_API_KEY_PEPPER, type HttpApp } from '../fakes/build-http.js'
@@ -132,6 +132,22 @@ class WorkspaceControlSpy {
     this.activations.push(value)
     return this.activations.length === 1 ? this.firstActivateAck : { ok: true }
   }
+}
+
+/** Records the `agent/upsert` pushes the grant routes make. */
+class UpsertSpy {
+  readonly upserts: AgentUpsert[] = []
+  async agentUpsert(_daemonId: string, u: AgentUpsert): Promise<void> {
+    this.upserts.push(u)
+  }
+}
+
+function replicatingApp(control: UpsertSpy): HttpApp {
+  const a = buildHttpApp(prisma, { PUBLIC_RELAY_URL: RELAY_URL }, undefined, control as unknown as ControlSender, {
+    github: stubbedGithub()
+  })
+  opened.push(a)
+  return a
 }
 
 function workspaceApp(control: WorkspaceControlSpy): HttpApp {
@@ -323,6 +339,33 @@ describe('agent repo authorizations REST — grant, list, revoke, gates', () => 
         'acme/tools'
       ])
     })
+  })
+
+  it('a grant and its revoke re-project workspace.additionalRepos at an advanced config revision', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const agentId = await workspaceAgent()
+    await seedInstallation()
+    const spy = new UpsertSpy()
+    const a = replicatingApp(spy)
+
+    const created = await post(a, agentId, { repoFullName: 'acme/tools', access: 'read' })
+    expect(created.statusCode).toBe(200)
+    expect(spy.upserts).toHaveLength(1)
+    expect(spy.upserts[0]!.spec.workspace).toMatchObject({
+      additionalRepos: [{ repoFullName: 'acme/tools', repoId: '111' }]
+    })
+
+    const repoAuthId = (created.json() as { id: string }).id
+    const revoked = await a.app.inject({
+      method: 'DELETE',
+      url: `${ORG}/agents/${agentId}/repos/${repoAuthId}`
+    })
+    expect(revoked.statusCode).toBe(204)
+    expect(spy.upserts).toHaveLength(2)
+    expect(spy.upserts[1]!.spec.workspace).toMatchObject({ additionalRepos: [] })
+    // Equal revision + changed content is refused daemon-side, so the row writes
+    // must advance the revision in the same transaction.
+    expect(BigInt(spy.upserts[1]!.spec.configRevision!)).toBeGreaterThan(BigInt(spy.upserts[0]!.spec.configRevision!))
   })
 
   it('POST lets a scratch workspace authorize covered repositories', async () => {

--- a/packages/control-plane/test/integration/agents.replication.route.test.ts
+++ b/packages/control-plane/test/integration/agents.replication.route.test.ts
@@ -195,7 +195,8 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
         // A decimal STRING because the column is a bigint; "1" here because this
         // PATCH is the seeded agent's first configuration write.
         configRevision: '1',
-        workspace: { mode: 'scratch', isolation: 'shared', gitCredential: 'github-app' }
+        // The additional-repository allowlist rides the workspace; always shipped so a revoke replicates.
+        workspace: { mode: 'scratch', isolation: 'shared', gitCredential: 'github-app', additionalRepos: [] }
       }
     })
 
@@ -270,7 +271,8 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
       mode: 'github',
       isolation: 'shared',
       gitRepo: 'https://github.com/acme/monorepo',
-      branch: 'main'
+      branch: 'main',
+      additionalRepos: []
     })
   })
 

--- a/packages/control-plane/test/integration/app.smoke.test.ts
+++ b/packages/control-plane/test/integration/app.smoke.test.ts
@@ -222,7 +222,8 @@ describe('Phase 5 — whole-app assembly via buildApp (REST + WS share one DB/or
         isolation: 'session',
         gitRepo: 'https://github.com/acme/infra',
         branch: 'main',
-        agentDir: 'services/api'
+        agentDir: 'services/api',
+        additionalRepos: []
       })
     } finally {
       ws.close()

--- a/packages/control-plane/test/protocol/register.handler.test.ts
+++ b/packages/control-plane/test/protocol/register.handler.test.ts
@@ -233,7 +233,8 @@ describe('register handler — authoritative reconcile snapshot + idempotency + 
       runInSandbox: false,
       // Preset marker — always shipped so the daemon can gate preset-only capabilities.
       builtin: false,
-      workspace: { mode: 'scratch', isolation: 'shared', gitCredential: 'github-app' }
+      // The additional-repository allowlist rides the workspace; always shipped so a revoke replicates.
+      workspace: { mode: 'scratch', isolation: 'shared', gitCredential: 'github-app', additionalRepos: [] }
     })
 
     // drop: the stale local keys the CP no longer owns for this daemon.

--- a/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
+++ b/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
@@ -1662,7 +1662,9 @@ describe('R1/R2a persistence foundation', () => {
       : { hooks: [], agentIds: [] }
 
     expect(changed.hooks.map((hook) => hook.id).sort()).toEqual([...hookIds].sort())
-    expect(changed.agentIds).toEqual([workspaceAgentId])
+    // Both kinds of renamed agent converge: the App-backed workspace and the grant owner,
+    // whose `workspace.additionalRepos` entry carries the same display name.
+    expect([...changed.agentIds].sort()).toEqual([agentId, workspaceAgentId].sort())
     expect(
       await prisma.hookDef.findMany({
         where: { id: { in: hookIds } },

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -215,6 +215,11 @@ export const AgentSchema = z.object({
     // clone/fetch/push authenticate via the local credential helper backed by
     // CP-minted short-lived installation tokens — nothing durable on this host.
     gitCredential: z.enum(['github-app']).optional(),
+    // The agent's additional-repository allowlist, replicated from the CP
+    // (multi-repository-workspaces.md decision 2). A later phase materializes these
+    // as secondary workspace roots; nothing reads the list yet. `repoId` is GitHub's
+    // numeric repository id as a decimal string, so a rename cannot orphan an entry.
+    additionalRepos: z.array(z.object({ repoFullName: z.string(), repoId: z.string() })).default([]),
     pullOnNewSession: z.boolean().default(true),
     // DEPRECATED: superseded by the top-level `skills` field (AgentSkillEntry[]).
     // Kept so historical agent.json files still parse; nothing consumes it.

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -865,6 +865,9 @@ export function applySpecFields(
     // workspaces with explicit repo grants. Mirror it exactly, including clear.
     if (ws.gitCredential !== undefined) existing.gitCredential = ws.gitCredential
     else delete existing.gitCredential
+    // The CP is the authority on the additional-repository allowlist and always ships
+    // the full set, so mirror it exactly — [] must replicate as a cleared list.
+    existing.additionalRepos = ws.additionalRepos
     if (opts.creating && existing.path === undefined) {
       existing.path = join(opts.agentDir, 'workspace')
     }

--- a/packages/daemon/test/agents.test.ts
+++ b/packages/daemon/test/agents.test.ts
@@ -227,4 +227,17 @@ describe('AgentSchema defaults', () => {
     })
     expect(parsed.permissionMode).toBe('default')
   })
+
+  it('round-trips the CP-replicated additional-repository allowlist, defaulting to none', () => {
+    const base = { id: 'x', name: 'x', status: 'active', runtime: 'claude', integrations: [] }
+    const additionalRepos = [{ repoFullName: 'example-co/shared-library', repoId: '815' }]
+
+    expect(
+      AgentSchema.parse({ ...base, workspace: { mode: 'from-scratch', path: './workspace' } }).workspace.additionalRepos
+    ).toEqual([])
+    expect(
+      AgentSchema.parse({ ...base, workspace: { mode: 'from-scratch', path: './workspace', additionalRepos } })
+        .workspace.additionalRepos
+    ).toEqual(additionalRepos)
+  })
 })

--- a/packages/daemon/test/write-agent.test.ts
+++ b/packages/daemon/test/write-agent.test.ts
@@ -463,6 +463,24 @@ describe('writeAgentSpec — merge (agent.json exists)', () => {
     })
   })
 
+  it('mirrors the CP additional-repository allowlist, including its removal', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-write-agent-'))
+    const file = seedAgent(dir, 'bot-a', {
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: './workspace' }
+    })
+    const additionalRepos = [{ repoFullName: 'example-co/shared-library', repoId: '815' }]
+
+    writeAgentSpec(dir, 'bot-a', baseSpec({ workspace: { mode: 'scratch', additionalRepos } }), deps)
+    expect(readJson(file).workspace).toMatchObject({ additionalRepos })
+
+    writeAgentSpec(dir, 'bot-a', baseSpec({ workspace: { mode: 'scratch', additionalRepos: [] } }), deps)
+    expect(readJson(file).workspace).toMatchObject({ additionalRepos: [] })
+  })
+
   it('persists and normalizes a GitHub working subdirectory', () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-write-agent-'))
     const file = seedAgent(dir, 'bot-a', {

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -401,6 +401,7 @@ describe('agent spec / CRUD frames (CP→daemon spec sync)', () => {
     expect(ws.agentDir).toBe('./services/api')
     expect(ws.branch).toBe('main') // zod default
     expect(ws.isolation).toBe('shared')
+    expect(ws.additionalRepos).toEqual([]) // zod default
   })
 
   it('spec.workspace accepts scratch with explicit-repo GitHub credentials', () => {
@@ -415,8 +416,36 @@ describe('agent spec / CRUD frames (CP→daemon spec sync)', () => {
     expect(r.frame.payload.spec.workspace).toEqual({
       mode: 'scratch',
       isolation: 'shared',
-      gitCredential: 'github-app'
+      gitCredential: 'github-app',
+      additionalRepos: []
     })
+  })
+
+  it('spec.workspace round-trips the additional-repository allowlist on both modes', () => {
+    const additionalRepos = [
+      { repoFullName: 'acme/infra', repoId: '4711' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ]
+    const scratch = decodeEnvelope(
+      envelope('agent/upsert', {
+        agentId: AGENT_ID,
+        spec: { name: 'fresh', workspace: { mode: 'scratch', gitCredential: 'github-app', additionalRepos } }
+      })
+    )
+    if (!scratch.ok || !isFrame('agent/upsert')(scratch.frame)) throw new Error('expected agent/upsert')
+    expect(scratch.frame.payload.spec.workspace?.additionalRepos).toEqual(additionalRepos)
+
+    const github = decodeEnvelope(
+      envelope('agent/upsert', {
+        agentId: AGENT_ID,
+        spec: {
+          name: 'deploy-bot',
+          workspace: { mode: 'github', gitRepo: 'https://github.com/acme/primary-service', additionalRepos }
+        }
+      })
+    )
+    if (!github.ok || !isFrame('agent/upsert')(github.frame)) throw new Error('expected agent/upsert')
+    expect(github.frame.payload.spec.workspace?.additionalRepos).toEqual(additionalRepos)
   })
 
   it('agent/upsert and agent/remove decode for live CRUD', () => {

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -13,6 +13,11 @@ import { normalizeGitHubSkillSource } from '../git-url.js'
  * with no live caller and has been removed.
  */
 
+// One repository of the agent's additional-repository allowlist (multi-repository-workspaces.md decision 2).
+// `repoId` is GitHub's numeric repository id as a decimal string — rename-immune, the identity minting matches on.
+export const AgentAdditionalRepo = z.object({ repoFullName: z.string(), repoId: z.string() })
+export type AgentAdditionalRepo = z.infer<typeof AgentAdditionalRepo>
+
 /**
  * Where the agent runs. Two modes; the **path is always daemon-generated** —
  * never specified by the caller (UX picks the mode, the machine owns the dir).
@@ -24,6 +29,11 @@ import { normalizeGitHubSkillSource } from '../git-url.js'
  *   `agentDir` (a subdir of the repo, repo-root if omitted). **Multiple agents
  *   may share one repo** — they differ by `agentDir`, so the repo is not an
  *   owned entity, just shared config on each agent.
+ *
+ * Both modes carry `additionalRepos`: the agent's additional-repository
+ * allowlist, projected by the CP so the daemon has the set before a session
+ * starts. A later phase materializes them as secondary workspace roots; today
+ * nothing on the daemon reads the list.
  */
 export const AgentWorkspace = z.discriminatedUnion('mode', [
   z.object({
@@ -33,7 +43,8 @@ export const AgentWorkspace = z.discriminatedUnion('mode', [
     isolation: z.enum(['shared', 'session']).default('shared'),
     // Scratch has no implicit/default repository. The credential helper still
     // lets git/gh request explicitly authorized repositories by name.
-    gitCredential: z.enum(['github-app']).optional()
+    gitCredential: z.enum(['github-app']).optional(),
+    additionalRepos: z.array(AgentAdditionalRepo).default([])
   }),
   z.object({
     mode: z.literal('github'),
@@ -45,7 +56,8 @@ export const AgentWorkspace = z.discriminatedUnion('mode', [
     // the pre-github-app behavior). 'github-app' ⇒ the daemon pulls short-lived
     // CP-minted installation tokens over gitcred/request and injects them via
     // the local credential helper — no durable git credential on the host.
-    gitCredential: z.enum(['github-app']).optional()
+    gitCredential: z.enum(['github-app']).optional(),
+    additionalRepos: z.array(AgentAdditionalRepo).default([])
   })
 ])
 export type AgentWorkspace = z.infer<typeof AgentWorkspace>


### PR DESCRIPTION
Phase 1 of [`docs/designs/multi-repository-workspaces.md`](https://github.com/agentconnect-md/agentconnect/blob/main/docs/designs/multi-repository-workspaces.md) — decision 2. **No behavior change: nothing reads the new field yet.**

## Why

Today the daemon learns about an agent's `AgentRepoAuthorization` rows only at token-mint time, and only as a denial. A later phase materializes those repositories on disk as secondary workspace roots, which means the daemon needs the whole set *before* a session starts, not on first `git`/`gh` call.

## What

- **Protocol** — `AgentWorkspace` gains `additionalRepos: [{ repoFullName, repoId }]` on **both** the `scratch` and `github` variants, `.default([])`. `repoId` is GitHub's numeric repository id carried as a decimal string: rename-immune, and the same identity the per-repository minting already matches on. Branch is deliberately not projected — the daemon resolves `origin/HEAD` at clone time.
- **Control plane** — `AgentSpecAssembler` joins the agent's grant rows and projects them **sorted by `repoFullName`**, so a reordered read cannot change the spec digest. The agent-move bundle pins the resolved list the same way it pins skills, so `agent/activate` can never ship an empty one over a populated allowlist.
- **Daemon** — `agent.json`'s workspace schema mirrors the field with the same default, and the CP-spec merge copies it through (including `[]`, so a revoke replicates). No reader.

## Re-projection and the revision fence

The grant rows now ride the spec, so a row write is a spec edit. The routes did not push anything before, and — more importantly — an equal `configRevision` carrying different content is *refused* daemon-side as an invariant violation, permanently, on every reconnect. So every writer that can change `repoId`/`repoFullName` now advances the owning agent's `configRevision` in the **same transaction** (via the existing `bumpAgentConfigRevisions` helper): grant create, revoke, the mint-gate rename refresh, and the hook-side rename repair. `POST`/`DELETE /agents/:agentId/repos` then re-read the agent and push `agent/upsert`, best-effort, exactly like the agents route — the `register/ok` reconcile roster stays the backstop.

`PATCH` (access-tier upgrade) is untouched: the tier is not projected, so its content is unchanged.

## What a reviewer should check

- both workspace variants default `additionalRepos` to `[]`, and the projection is sorted;
- the move bundle pins the list rather than letting `project()` default it away;
- a grant add/remove re-projects the spec **and** advances `configRevision` in one transaction — including the two rename paths.

## Tests

- protocol: codec round-trip on both variants + the `[]` defaults;
- CP unit: projection on scratch and github, empty for no grants and for a graph with no allowlist dependency, and `project()` trusting a pinned list;
- CP integration: grant → push carries the entry, revoke → push carries `[]`, with a strictly greater `configRevision`;
- daemon: `AgentSchema` round-trip/default and `writeAgentSpec` mirroring the list including its removal.

`pnpm typecheck`, `pnpm --filter @agentconnect.md/protocol test`, the full control-plane `test:unit` + `test:int` suites, and the touched daemon suites all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
