### PR TITLE
feat(daemon): materialize secondary workspace roots and hand them to shared-isolation sessions

### DIFF
--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -545,6 +545,9 @@ export class SessionManager {
       parentSessionId: effectiveOriginSessionId,
       envSecretNames: secretNames.filter((n) => !fileSecretNames.has(n)),
       fileSecrets: fileSecrets.map((m) => ({ sourceVar: m.sourceVar, pointerVar: m.convention.pointerVar })),
+      // The same list `additionalWorkspaceDirectories` hands the runtime, so the prompt names exactly
+      // the directories the session got.
+      workspaceRoots: this.workspaces.readySecondaryRoots(agent, { isolation: workspaceIsolation }),
       usesSessionTitleTool,
       needsReplyToParent,
       memoryIndex,

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -16,7 +16,7 @@ import { messageOrderingFor } from '../platforms/message-ordering.js'
 import { buildAttachmentBlocks } from './attachment-block.js'
 import { DIRECT_AGENT_CALL_REMINDER, EXPLICIT_MENTION_REMINDER, NO_RESPONSE_REMINDER } from './no-response.js'
 import { planReplay, renderReplayContext } from './turn/replay-plan.js'
-import { AGENT_META_OPENING, buildStandingContext } from './turn/standing-context.js'
+import { AGENT_META_OPENING, buildStandingContext, type StandingContext } from './turn/standing-context.js'
 import { backfillThreadHistory } from './turn/thread-backfill.js'
 import { RecallObserver, runTurnRecall, type MemoryRecallLifecycleEvent } from './turn/memory-recall.js'
 import { openRuntimeSession } from './turn/runtime-session.js'
@@ -532,27 +532,33 @@ export class SessionManager {
     }).materialize.filter((m) => secretNames.includes(m.sourceVar))
     const fileSecretNames = new Set(fileSecrets.map((m) => m.sourceVar))
     const usesMeta = host.usesMetaSystemPrompt?.() ?? false
-    const { memoryAppend, sessionContext, resumeSystemContext, metaContext, parentReplyAppend } = buildStandingContext({
-      agentName: agent.name,
-      agentId: agent.id,
-      agentDescription: agent.description,
-      platform: msg.platform,
-      channel: msg.channel,
-      channelName,
-      slackSelfId: msg.platform === 'slack' && integrationId ? this.deps.slackBotUserIdFor?.(integrationId) : undefined,
-      thread,
-      acpSessionId: rec?.acpSessionId,
-      parentSessionId: effectiveOriginSessionId,
-      envSecretNames: secretNames.filter((n) => !fileSecretNames.has(n)),
-      fileSecrets: fileSecrets.map((m) => ({ sourceVar: m.sourceVar, pointerVar: m.convention.pointerVar })),
-      // The same list `additionalWorkspaceDirectories` hands the runtime, so the prompt names exactly
-      // the directories the session got.
-      workspaceRoots: this.workspaces.readySecondaryRoots(agent, { isolation: workspaceIsolation }),
-      usesSessionTitleTool,
-      needsReplyToParent,
-      memoryIndex,
-      usesMeta
-    })
+    // Composed lazily and memoized, because the workspace roots it names must be sampled where the
+    // additional directories are: on a warm host `openRuntimeSession` performs the preparation
+    // itself, so a context built before that could name a root the runtime never received.
+    let standing: StandingContext | undefined
+    const standingContext = (): StandingContext =>
+      (standing ??= buildStandingContext({
+        agentName: agent.name,
+        agentId: agent.id,
+        agentDescription: agent.description,
+        platform: msg.platform,
+        channel: msg.channel,
+        channelName,
+        slackSelfId:
+          msg.platform === 'slack' && integrationId ? this.deps.slackBotUserIdFor?.(integrationId) : undefined,
+        thread,
+        acpSessionId: rec?.acpSessionId,
+        parentSessionId: effectiveOriginSessionId,
+        envSecretNames: secretNames.filter((n) => !fileSecretNames.has(n)),
+        fileSecrets: fileSecrets.map((m) => ({ sourceVar: m.sourceVar, pointerVar: m.convention.pointerVar })),
+        // The same list `additionalWorkspaceDirectories` hands the runtime, read from the same
+        // accessor, so the prompt names exactly the directories the session got.
+        workspaceRoots: this.workspaces.readySecondaryRoots(agent, { isolation: workspaceIsolation }),
+        usesSessionTitleTool,
+        needsReplyToParent,
+        memoryIndex,
+        usesMeta
+      }))
 
     // Create or re-attach the runtime session (turn/runtime-session.ts). `created` drives the
     // daemon's one-shot `event/session` start emit; the additional-MCP outcome is reported back
@@ -608,8 +614,8 @@ export class SessionManager {
       // metadata-only settings cannot be reversed by a later live selector.
       chatRuntimeChangesAllowed: () => this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true,
       effortOverride: async () => initialEffort ?? (await this.deps.store.getEffortOverride(key)),
-      ...(metaContext !== undefined ? { metaContext } : {}),
-      ...(resumeSystemContext !== undefined ? { resumeSystemContext } : {}),
+      metaContext: () => standingContext().metaContext,
+      resumeSystemContext: () => standingContext().resumeSystemContext,
       usesMeta,
       ...(signal ? { signal } : {}),
       abortable,
@@ -618,6 +624,9 @@ export class SessionManager {
     rec = opened.rec
     const created = opened.created
     const additionalMcpServersAttached = opened.additionalMcpAttached
+    // Resolves the memoized snapshot the runtime session already consumed, or composes it now for a
+    // session that was live and needed no preparation.
+    const { sessionContext, parentReplyAppend } = standingContext()
 
     // A channel-root message posted by this same agent creates the thread's session cursor
     // without running the model. Keep lastDeliveredTs at null: the first real reply must replay

--- a/packages/daemon/src/session/turn/runtime-session.ts
+++ b/packages/daemon/src/session/turn/runtime-session.ts
@@ -50,9 +50,11 @@ export interface OpenRuntimeSessionInput {
   chatRuntimeChangesAllowed: () => boolean
   /** The sticky per-session effort override (chat-selected or turn-supplied). */
   effortOverride: () => Promise<string | undefined>
-  /** Standing context for a fresh session; `resumeSystemContext` for a native resume. */
-  metaContext?: string
-  resumeSystemContext?: string
+  /** Standing context for a fresh session; `resumeSystemContext` for a native resume. Both are
+   *  resolved HERE, after workspace preparation, so what the prompt names and what
+   *  `workspaceDirectories` hands the runtime come from one snapshot. */
+  metaContext?: () => string | undefined
+  resumeSystemContext?: () => string | undefined
   usesMeta: boolean
   signal?: AbortSignal
   abortable: <T>(start: () => PromiseLike<T> | T, signal?: AbortSignal) => Promise<T>
@@ -158,7 +160,7 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
     const acpSessionId = await newRuntimeSession(
       cwd,
       mcpServers,
-      input.metaContext,
+      input.metaContext?.(),
       input.additionalMcpServers?.length ? ordinaryMcpServers : undefined
     )
     created = true
@@ -209,7 +211,7 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
           persistedSessionId,
           cwd,
           mcpServers,
-          input.usesMeta ? input.resumeSystemContext : undefined,
+          input.usesMeta ? input.resumeSystemContext?.() : undefined,
           fallbackMcpServers
         )
       } catch {
@@ -218,7 +220,7 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
       }
     }
     if (!resumed) {
-      const acpSessionId = await newRuntimeSession(cwd, mcpServers, input.metaContext, fallbackMcpServers)
+      const acpSessionId = await newRuntimeSession(cwd, mcpServers, input.metaContext?.(), fallbackMcpServers)
       // A fresh ACP id the CP has never seen (the persisted one couldn't be resumed),
       // so this counts as a create for `event/session`. A resumed session (loadSession
       // above) keeps its id — the CP already knows it — so `created` stays false there.

--- a/packages/daemon/src/session/turn/standing-context.ts
+++ b/packages/daemon/src/session/turn/standing-context.ts
@@ -63,6 +63,8 @@ export type StandingContextInput = {
   envSecretNames: readonly string[]
   /** Secrets materialized to a private file instead of reaching the child env. */
   fileSecrets: readonly StandingContextFileSecret[]
+  /** Secondary workspace roots this session is handed as additional directories. */
+  workspaceRoots?: readonly { path: string; repoFullName: string; branch: string }[]
   usesSessionTitleTool: boolean
   needsReplyToParent: boolean
   /** The agent memory INDEX, already read and trimmed; '' for native/absent memory. */
@@ -75,6 +77,8 @@ export type StandingContextInput = {
 export type StandingContext = {
   memoryAppend: string
   agentMeta: string
+  /** The additional repositories block; '' when the session has no secondary root. */
+  workspaceRootsAppend: string
   collabAppend: string
   parentReplyAppend: string
   /** Durable standing rules re-asserted on session/load — no memory index. */
@@ -196,6 +200,21 @@ function buildAgentMeta(input: StandingContextInput): string {
   ].join('\n')
 }
 
+// The session's secondary workspace roots (multi-repository-workspaces.md decision 10). Standing
+// like the meta block: the set is fixed for the session, and the model must not mistake a root's
+// default branch for anything the current task is pinned to.
+export function buildWorkspaceRootsAppend(
+  roots: readonly { path: string; repoFullName: string; branch: string }[] | undefined
+): string {
+  if (!roots?.length) return ''
+  return [
+    '# Additional repositories',
+    'Additional repositories checked out for this session (each at its default branch; the working ' +
+      'directory stays the primary workspace):',
+    ...roots.map((root) => `- ${root.path} — ${root.repoFullName} (${root.branch})`)
+  ].join('\n')
+}
+
 // Standing guidance for agent↔agent collaboration. `sendMessage` can wake a peer, reach
 // humans, post at a channel root, or reply into a parent session. It has no visible
 // in-thread form: speaking in the current conversation is an ordinary reply. `toAgent`
@@ -273,15 +292,17 @@ export function buildParentReplyAppend(
 export function buildStandingContext(input: StandingContextInput): StandingContext {
   const memoryAppend = buildMemoryAppend(input.memoryIndex)
   const agentMeta = buildAgentMeta(input)
+  const workspaceRootsAppend = buildWorkspaceRootsAppend(input.workspaceRoots)
   const collabAppend = COLLAB_APPEND
   const parentReplyAppend = buildParentReplyAppend(input.needsReplyToParent, input.parentSessionId)
-  const resumeSystemContext = [agentMeta, collabAppend, parentReplyAppend, NO_RESPONSE_RULE]
+  const resumeSystemContext = [agentMeta, workspaceRootsAppend, collabAppend, parentReplyAppend, NO_RESPONSE_RULE]
     .filter(Boolean)
     .join('\n\n')
   const sessionContext = [resumeSystemContext, memoryAppend].filter(Boolean).join('\n\n')
   return {
     memoryAppend,
     agentMeta,
+    workspaceRootsAppend,
     collabAppend,
     parentReplyAppend,
     resumeSystemContext,

--- a/packages/daemon/src/workspace/gitmodules.ts
+++ b/packages/daemon/src/workspace/gitmodules.ts
@@ -1,0 +1,58 @@
+import { gitRepoLabel } from '@agentconnect.md/protocol'
+
+// `.gitmodules` is git config, and decision 11 of docs/designs/multi-repository-workspaces.md needs
+// exactly one thing out of it: which repositories a root already carries as submodules. Reading the
+// file directly keeps that a text question — no `git config -f` subprocess, no submodule lifecycle.
+
+/** Every `url` value under a `[submodule …]` section, in file order. */
+export function parseGitmoduleUrls(text: string): string[] {
+  const urls: string[] = []
+  let inSubmodule = false
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith(';')) continue
+    const section = /^\[([^\]]*)\]/.exec(trimmed)
+    if (section) {
+      inSubmodule = /^submodule(?:[\s."]|$)/i.test(section[1]!.trim())
+      continue
+    }
+    if (!inSubmodule) continue
+    const separator = trimmed.indexOf('=')
+    if (separator < 0) continue
+    if (trimmed.slice(0, separator).trim().toLowerCase() !== 'url') continue
+    const value = trimmed
+      .slice(separator + 1)
+      .trim()
+      .replace(/^"(.*)"$/, '$1')
+    if (value) urls.push(value)
+  }
+  return urls
+}
+
+// Only an absolute github.com address names a repository this daemon can also hold as a root. A
+// relative submodule URL resolves against the superproject's own remote, and any other host is a
+// repository the App never covers — both are simply not the same repository as any root.
+const SCP_ADDRESS = /^[\w.-]+@([\w.-]+):(?!\/)/
+const URL_ADDRESS = /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]*@)?([^/]+)\//i
+
+/** Lowercased `owner/repo` for a github.com submodule URL; undefined for anything else. */
+export function githubSubmoduleRepo(url: string): string | undefined {
+  const raw = url.trim()
+  if (!raw || raw.startsWith('.') || raw.startsWith('/')) return undefined
+  const host =
+    SCP_ADDRESS.exec(raw)?.[1] ?? URL_ADDRESS.exec(raw)?.[1] ?? (/^github\.com\//i.test(raw) ? 'github.com' : undefined)
+  if (host === undefined || host.replace(/:\d+$/, '').toLowerCase() !== 'github.com') return undefined
+  const segments = gitRepoLabel(raw).split('/')
+  if (segments.length !== 2 || segments.some((segment) => !segment)) return undefined
+  return segments.join('/').toLowerCase()
+}
+
+/** The github.com repositories a `.gitmodules` file declares as submodules, lowercased. */
+export function gitmoduleRepos(text: string): Set<string> {
+  const repos = new Set<string>()
+  for (const url of parseGitmoduleUrls(text)) {
+    const repo = githubSubmoduleRepo(url)
+    if (repo) repos.add(repo)
+  }
+  return repos
+}

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -385,9 +385,9 @@ export class WorkspaceManager {
       }
       // Identity is the numeric repo id, so a retired root whose owner/repo was later reused by a
       // DIFFERENT repository is refused rather than adopted — and nothing on disk is touched
-      // (decision 12: retirement, never deletion).
-      const recorded =
-        readSecondaryMaterialization(marker) ?? (await this.reattestSecondaryCheckout(agent, root, marker))
+      // (decision 12: retirement, never deletion). An origin URL cannot stand in for that id: it
+      // names the slug, which is exactly what a reuse keeps. No attestation ⇒ no root.
+      const recorded = readSecondaryMaterialization(marker)
       if (recorded === undefined || recorded.repoId !== root.repoId) {
         workspaceLog.warn(
           `workspace: the checkout at ${subtree} does not attest repository id ${root.repoId} ` +
@@ -419,38 +419,6 @@ export class WorkspaceManager {
       rmSync(path, { recursive: true, force: true })
     }
     renameSync(staged, path)
-  }
-
-  /**
-   * Re-attest a checkout an interrupted materialization left with no marker.
-   *
-   * Only when its `origin` is still this row's repository, and only by writing the marker a
-   * completed materialization would have left — the alternative is a checkout no later session can
-   * attribute and therefore skips forever, which the promised next-session retry rules out.
-   */
-  private async reattestSecondaryCheckout(
-    agent: Agent,
-    root: SecondaryWorkspaceRoot,
-    marker: string
-  ): Promise<SecondaryMaterialization | undefined> {
-    const origin = await this.runnerFor(agent.id, root.path)
-      .withEnv(workspaceGitLocalEnv())
-      .raw(['remote', 'get-url', 'origin'])
-      .catch(() => '')
-    const canonical = (url: string) => normalizeGitUrl(redactGitUrlSecrets(url.trim())).replace(/\.git$/i, '')
-    if (!origin.trim() || canonical(origin).toLowerCase() !== canonical(root.cloneUrl).toLowerCase()) return undefined
-    const branch = await this.resolveRemoteDefaultBranch(agent.id, root)
-    const materialization: SecondaryMaterialization = {
-      repoId: root.repoId,
-      repoFullName: root.repoFullName,
-      branch
-    }
-    writeSecondaryMaterialization(marker, materialization)
-    workspaceLog.warn(
-      `workspace: the checkout of ${root.repoFullName} for agent "${agent.id}" had no materialization ` +
-        `record — re-attested it at ${branch} from its own origin`
-    )
-    return materialization
   }
 
   /** The branch `origin/HEAD` points at, asked of the remote through the clone's own credentials. */

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -20,6 +20,7 @@ import {
   redactGitUrlSecrets
 } from '@agentconnect.md/protocol'
 import type { Agent } from '../agents/agent-schema.js'
+import { formatErr } from '../daemon/text.js'
 import { makeLogger } from '../log.js'
 import { installSkills, type LocalSkillSource } from '../skills/install-skills.js'
 import { acceptedDreamSkillSources } from '../skills/dream-skills.js'
@@ -36,6 +37,7 @@ import {
   writeRepoHelperConfig
 } from './git-injection.js'
 import { LocalGitRunner, type GitRunner } from './git-runner.js'
+import { gitmoduleRepos } from './gitmodules.js'
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
 import { isSessionBranch, sessionBranchName } from './session-branch.js'
 import { DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
@@ -80,6 +82,30 @@ export interface WorkspaceRoot {
   githubApp: boolean
 }
 
+/** One authorized additional repository as a root beside the primary (design decision 1). */
+export interface SecondaryWorkspaceRoot extends WorkspaceRoot {
+  repoFullName: string
+  /** GitHub's numeric repository id — the identity a rename cannot change. */
+  repoId: string
+  /** Empty until `prepareSecondaryRoot` resolves the remote's default; nothing may clone before that. */
+  branch: string
+}
+
+/** A prepared secondary root, as sessions and the standing context see it. */
+export interface ReadyWorkspaceRoot {
+  /** The canonical checkout path handed out as an additional directory. */
+  path: string
+  repoFullName: string
+  branch: string
+}
+
+/** What a secondary root's `.materialization.json` records about the checkout beside it. */
+interface SecondaryMaterialization {
+  repoId: string
+  repoFullName: string
+  branch: string
+}
+
 export interface PrepareSessionWorkspaceRequest {
   sessionKey: string
   isolation: 'shared' | 'session'
@@ -94,7 +120,15 @@ export interface PrepareSessionWorkspaceRequest {
 
 const PULL_TIMEOUT_MS = 4500
 const REVIEW_FETCH_TIMEOUT_MS = 15_000
+const LS_REMOTE_TIMEOUT_MS = 10_000
 const MATERIALIZATION_FILE = 'workspace-materialization.json'
+/** Secondary roots live under one agent-owned parent, one subtree per authorized repository. */
+const SECONDARY_ROOTS_DIR = 'repos'
+const SECONDARY_MATERIALIZATION_FILE = '.materialization.json'
+/** A `.gitmodules` past this is not a submodule declaration anyone wrote; refuse to read it. */
+const MAX_GITMODULES_BYTES = 256 * 1024
+/** GitHub's own owner/repository charset, which is also a plain path segment. */
+const REPO_SEGMENT = /^[A-Za-z0-9._-]+$/
 const CONVERSION_FILE = 'workspace-conversion.json'
 /** Word-pair branch names to try before falling back to a random suffix. */
 const SESSION_BRANCH_DRAWS = 5
@@ -111,6 +145,12 @@ export class WorkspaceManager {
   // Single-flight clone lock. Two concurrent sessions (especially multiple agents sharing one repo
   // checkout) must not race into the same dir — the second awaits the first's in-flight clone.
   readonly cloneInFlight = new Map<string, Promise<void>>()
+  // Same single-flight, one level up: a secondary root's preparation is a clone OR a converge+pull,
+  // and two sessions starting together must share one of them. A separate map because the clone it
+  // performs keys `cloneInFlight` by the very same path.
+  private readonly secondaryInFlight = new Map<string, Promise<ReadyWorkspaceRoot | undefined>>()
+  /** Secondary roots prepared for an agent's current sessions — what the synchronous hand-out reads. */
+  private readonly readyRoots = new Map<string, ReadyWorkspaceRoot[]>()
   private gitRunnerResolver: WorkspaceGitRunnerResolver | undefined
   private pathClearer: WorkspacePathClearer | undefined
   private workspacesLiveInSandboxes = false
@@ -197,6 +237,190 @@ export class WorkspaceManager {
       path: agent.workspace.path,
       worktreesPath: this.worktreesPathFor(agent),
       githubApp: this.usesGithubApp(agent)
+    }
+  }
+
+  /** The agent's own directory — the parent every daemon-owned subtree hangs off. */
+  agentRootFor(agent: Agent): string {
+    return (agent as { dir?: string }).dir ?? dirname(agent.workspace.path)
+  }
+
+  /** The agent's authorized additional repositories as roots, sorted by name (design decision 1/8). */
+  secondaryRoots(agent: Agent): SecondaryWorkspaceRoot[] {
+    const roots: SecondaryWorkspaceRoot[] = []
+    for (const row of agent.workspace.additionalRepos ?? []) {
+      const [owner, repo, ...rest] = row.repoFullName.split('/')
+      // A row that is not two plain segments would place its subtree by its own text; refuse it here.
+      if (rest.length > 0 || !isRepoSegment(owner) || !isRepoSegment(repo)) {
+        workspaceLog.warn(
+          `workspace: agent "${agent.id}" additional repository "${row.repoFullName}" is not a plain owner/repo — skipping it`
+        )
+        continue
+      }
+      const repoFullName = `${owner}/${repo}`
+      const base = join(this.agentRootFor(agent), SECONDARY_ROOTS_DIR, owner, repo)
+      try {
+        roots.push({
+          repoFullName,
+          repoId: row.repoId,
+          // Rows exist only for App-covered repositories, so credentials ride the same helper a
+          // github-app primary does; the branch is the remote's default, resolved at materialization.
+          cloneUrl: authorizeWorkspaceGitUrl(normalizeGithubRepoUrl(`https://github.com/${repoFullName}`)),
+          branch: '',
+          path: join(base, 'checkout'),
+          worktreesPath: join(base, 'worktrees'),
+          githubApp: true
+        })
+      } catch (err) {
+        workspaceLog.warn(
+          `workspace: agent "${agent.id}" additional repository "${repoFullName}" has no authorized clone URL (${formatErr(err)})`
+        )
+      }
+    }
+    return roots.sort((a, b) => (a.repoFullName < b.repoFullName ? -1 : a.repoFullName > b.repoFullName ? 1 : 0))
+  }
+
+  /**
+   * The prepared secondary roots one session is handed — the single answer the additional
+   * directories and the standing context are both derived from, so the prompt cannot name a
+   * directory the runtime did not get.
+   *
+   * Empty under `session` isolation: those sessions get a per-session worktree of every root, which
+   * this phase has not built, and a shared checkout would defeat the isolation they asked for.
+   */
+  readySecondaryRoots(
+    agent: Agent,
+    request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
+  ): readonly ReadyWorkspaceRoot[] {
+    if (this.sandboxMode || request?.isolation === 'session') return []
+    return this.readyRoots.get(agent.id) ?? []
+  }
+
+  /**
+   * Materialize the agent's secondary roots and remember the ones a session may be handed.
+   *
+   * Lazy per decision 7: this runs at session start, and a root that cannot be prepared is omitted
+   * from THIS session rather than failing it. Decision 11 is applied in the same pass — a root that
+   * is already a submodule of an earlier one is neither prepared nor listed, so the model never sees
+   * the same repository twice at two different revisions.
+   */
+  async prepareSecondaryRoots(agent: Agent): Promise<ReadyWorkspaceRoot[]> {
+    // Cluster daemons materialize one checkout through the shim tunnel; secondary roots there are a
+    // non-goal of this phase, and every path below would clone onto the DAEMON's disk instead.
+    if (this.sandboxMode) return []
+    const roots = this.secondaryRoots(agent)
+    if (roots.length === 0) {
+      this.readyRoots.delete(agent.id)
+      return []
+    }
+    const submodules =
+      agent.workspace.mode === 'git-repo' ? this.submoduleReposOf(agent.workspace.path) : new Set<string>()
+    const ready: ReadyWorkspaceRoot[] = []
+    for (const root of roots) {
+      if (submodules.has(root.repoFullName.toLowerCase())) {
+        workspaceLog.info(
+          `workspace: additional repository ${root.repoFullName} is a submodule of another root for agent ` +
+            `"${agent.id}" — reachable through its parent, so it is not checked out separately`
+        )
+        continue
+      }
+      const prepared = await this.prepareSecondaryRoot(agent, root)
+      if (!prepared) continue
+      for (const repo of this.submoduleReposOf(root.path)) submodules.add(repo)
+      ready.push(prepared)
+    }
+    this.readyRoots.set(agent.id, ready)
+    return ready
+  }
+
+  /** The github.com repositories a root carries as submodules; empty when it declares none. */
+  submoduleReposOf(rootPath: string): Set<string> {
+    const file = join(rootPath, '.gitmodules')
+    try {
+      if (statSync(file).size > MAX_GITMODULES_BYTES) return new Set()
+      return gitmoduleRepos(readFileSync(file, 'utf8'))
+    } catch {
+      // No `.gitmodules`, or one this process cannot read: the root simply declares no submodules.
+      return new Set()
+    }
+  }
+
+  /** One secondary root's clone-or-converge, single-flighted per root like the primary's clone. */
+  async prepareSecondaryRoot(agent: Agent, root: SecondaryWorkspaceRoot): Promise<ReadyWorkspaceRoot | undefined> {
+    const key = this.cloneKey(agent.id, root.path)
+    const inflight = this.secondaryInFlight.get(key)
+    if (inflight) return await inflight
+    const started = this.materializeSecondaryRoot(agent, root).finally(() => {
+      this.secondaryInFlight.delete(key)
+    })
+    this.secondaryInFlight.set(key, started)
+    return await started
+  }
+
+  private async materializeSecondaryRoot(
+    agent: Agent,
+    root: SecondaryWorkspaceRoot
+  ): Promise<ReadyWorkspaceRoot | undefined> {
+    const subtree = dirname(root.path)
+    const marker = join(subtree, SECONDARY_MATERIALIZATION_FILE)
+    try {
+      mkdirSync(subtree, { recursive: true, mode: 0o700 })
+      if (!existsSync(join(root.path, '.git'))) {
+        // The branch is not projected by the CP, so the remote's own HEAD decides it — resolved
+        // BEFORE the clone, because `--branch` is how the clone records it.
+        const branch = await this.resolveRemoteDefaultBranch(agent.id, root)
+        await this.cloneRootAt(agent.id, { ...root, branch }, root.path)
+        const materialization: SecondaryMaterialization = {
+          repoId: root.repoId,
+          repoFullName: root.repoFullName,
+          branch
+        }
+        writeFileSync(marker, JSON.stringify(materialization, null, 2) + '\n', { mode: 0o600 })
+        return { path: realpathSync(root.path), repoFullName: root.repoFullName, branch }
+      }
+      const recorded = readSecondaryMaterialization(marker)
+      // Identity is the numeric repo id, so a retired root whose owner/repo was later reused by a
+      // DIFFERENT repository is refused rather than adopted — and nothing on disk is touched
+      // (decision 12: retirement, never deletion).
+      if (recorded === undefined || recorded.repoId !== root.repoId) {
+        workspaceLog.warn(
+          `workspace: the checkout at ${subtree} does not attest repository id ${root.repoId} ` +
+            `(${root.repoFullName}) for agent "${agent.id}" — leaving it untouched and skipping the root`
+        )
+        return undefined
+      }
+      const resolved = { ...root, branch: recorded.branch }
+      await this.convergeOriginInPlaceFor(agent.id, resolved, root.path)
+      await writeRepoHelperConfig(this.runnerFor(agent.id, root.path), agent.id).catch(() => undefined)
+      if (agent.workspace.pullOnNewSession) await this.pullRoot(agent.id, resolved, root.path)
+      return { path: realpathSync(root.path), repoFullName: root.repoFullName, branch: recorded.branch }
+    } catch (err) {
+      // Degradation stays local to the root (decision 7): the session starts without it and the next
+      // one retries. Never throw out of session start over an additional repository.
+      workspaceLog.warn(
+        `workspace: additional repository ${root.repoFullName} is unavailable to agent "${agent.id}" (${formatErr(err)})`
+      )
+      return undefined
+    }
+  }
+
+  /** The branch `origin/HEAD` points at, asked of the remote through the clone's own credentials. */
+  async resolveRemoteDefaultBranch(agentId: string, root: SecondaryWorkspaceRoot): Promise<string> {
+    if (root.githubApp) await preWarmGitCred(agentId, 'clone')
+    const env = root.githubApp
+      ? { ...workspaceGitEnvBase(root.cloneUrl), ...cloneGitEnv(agentId, root.cloneUrl) }
+      : { ...workspaceGitEnvBase(root.cloneUrl), GIT_TERMINAL_PROMPT: '0' }
+    const abort = new AbortController()
+    const timer = setTimeout(() => abort.abort(), LS_REMOTE_TIMEOUT_MS)
+    try {
+      const out = await this.runnerFor(agentId, undefined, abort.signal)
+        .withEnv(env)
+        .raw(['ls-remote', '--symref', root.cloneUrl, 'HEAD'])
+      const branch = parseSymrefDefaultBranch(out)
+      if (branch === undefined) throw new Error(`remote HEAD of ${root.repoFullName} did not resolve to a branch`)
+      return branch
+    } finally {
+      clearTimeout(timer)
     }
   }
 
@@ -445,6 +669,15 @@ export class WorkspaceManager {
   }
 
   async prepareWorkspace(agent: Agent, opts: PrepareWorkspaceOptions = {}): Promise<string> {
+    const acpCwd = await this.preparePrimaryRoot(agent)
+    // Every session goes through here, so this is where the secondary roots become available — and
+    // where a root that has left the set stops being handed out (decision 12).
+    await this.prepareSecondaryRoots(agent)
+    return this.withSkills(agent, acpCwd, opts)
+  }
+
+  /** The primary checkout and the ACP cwd it resolves to — clone or converge+pull, as today. */
+  private async preparePrimaryRoot(agent: Agent): Promise<string> {
     const cwd = agent.workspace.path
     // Fail unsafe config before using either a fresh or existing checkout.
     const agentDir = agent.workspace.mode === 'git-repo' ? normalizeRepoSubdir(agent.workspace.agentDir) : undefined
@@ -453,7 +686,7 @@ export class WorkspaceManager {
 
     if (root === undefined) {
       // Memory lives at the agent ROOT and is seeded separately, so from-scratch just needs an empty workspace dir.
-      return this.withSkills(agent, cwd, opts)
+      return cwd
     }
 
     // git-repo, first session: no checkout yet → clone. Unlike pull, a clone has no
@@ -461,7 +694,7 @@ export class WorkspaceManager {
     // surfaces) rather than silently proceeding with an empty dir (design §4.3).
     if (!existsSync(join(cwd, '.git'))) {
       await this.cloneRootAt(agent.id, root, root.path)
-      return this.withSkills(agent, this.resolveAcpCwd(cwd, agentDir), opts)
+      return this.resolveAcpCwd(cwd, agentDir)
     }
 
     // git-repo, existing checkout: the repo-local helper pin may carry a previous
@@ -481,13 +714,12 @@ export class WorkspaceManager {
     }
 
     if (agent.workspace.pullOnNewSession) await this.pullRoot(agent.id, root, cwd)
-    return this.withSkills(agent, this.resolveAcpCwd(cwd, agentDir), opts)
+    return this.resolveAcpCwd(cwd, agentDir)
   }
 
   /** The agent's worktrees parent. Total by construction — a from-scratch workspace has one too. */
   worktreesPathFor(agent: Agent): string {
-    const agentRoot = (agent as { dir?: string }).dir ?? dirname(agent.workspace.path)
-    return join(agentRoot, 'worktrees')
+    return join(this.agentRootFor(agent), 'worktrees')
   }
 
   /** The primary root's worktrees parent, under the name the daemon and CLI already address it by. */
@@ -500,7 +732,7 @@ export class WorkspaceManager {
     if (lstatSync(worktreesPath).isSymbolicLink()) {
       throw new Error('session worktree root must not be a symlink')
     }
-    const agentRoot = realpathSync((agent as { dir?: string }).dir ?? dirname(agent.workspace.path))
+    const agentRoot = realpathSync(this.agentRootFor(agent))
     const canonicalRoot = realpathSync(worktreesPath)
     const rel = relative(agentRoot, canonicalRoot)
     if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
@@ -1046,8 +1278,8 @@ export class WorkspaceManager {
     cwd: string,
     request?: Pick<PrepareSessionWorkspaceRequest, 'sessionKey' | 'isolation'>
   ): string[] {
-    if (agent.workspace.mode !== 'git-repo') return []
     if (this.sandboxMode) {
+      if (agent.workspace.mode !== 'git-repo') return []
       // `cwd` is in the POD's coordinates, which this daemon cannot `realpathSync` — the path exists
       // on no filesystem it can see, so the check below throws on the workspace it was handed. Undo
       // the lexical join `clusterWorkspaceCwd` made instead; the shim re-checks containment itself.
@@ -1055,15 +1287,20 @@ export class WorkspaceManager {
       if (agentDir === undefined) return []
       return [agentDir.split('/').reduce((path) => dirname(path), cwd)]
     }
-    const expectedRoot =
-      request?.isolation === 'session' ? this.sessionWorktreePath(agent, request.sessionKey) : agent.workspace.path
-    const root = realpathSync(expectedRoot)
-    const canonicalCwd = realpathSync(cwd)
-    const rel = relative(root, canonicalCwd)
-    if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
-      throw new Error(`prepared workspace cwd "${cwd}" resolves outside its checkout root`)
+    // Widening an `agentDir` cwd back to its checkout root — the primary's, and only a git-repo has one.
+    const widened: string[] = []
+    if (agent.workspace.mode === 'git-repo') {
+      const expectedRoot =
+        request?.isolation === 'session' ? this.sessionWorktreePath(agent, request.sessionKey) : agent.workspace.path
+      const root = realpathSync(expectedRoot)
+      const canonicalCwd = realpathSync(cwd)
+      const rel = relative(root, canonicalCwd)
+      if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+        throw new Error(`prepared workspace cwd "${cwd}" resolves outside its checkout root`)
+      }
+      if (root !== canonicalCwd) widened.push(root)
     }
-    return root === canonicalCwd ? [] : [root]
+    return [...widened, ...this.readySecondaryRoots(agent, request).map((root) => root.path)]
   }
 
   resolveAcpCwd(workspaceRoot: string, agentDir: string | undefined): string {
@@ -1255,6 +1492,8 @@ export class WorkspaceManager {
     }
   }
 
+  // Primary only, deliberately: prefetch runs at reconcile, and decision 7 clones a secondary on the
+  // first session that needs it rather than when its row appears.
   async prefetchWorkspace(agent: Agent): Promise<void> {
     if (agent.workspace.mode !== 'git-repo') return
     // Validate at the execution boundary: building the root is what re-authorizes the clone URL.
@@ -1304,6 +1543,34 @@ export class WorkspaceManager {
     })
     this.cloneInFlight.set(key, p)
     return p
+  }
+}
+
+/** A plain path segment that is also a legal GitHub owner or repository name. */
+function isRepoSegment(value: string | undefined): value is string {
+  return value !== undefined && value !== '.' && value !== '..' && REPO_SEGMENT.test(value)
+}
+
+/** `ref: refs/heads/<name>\tHEAD` from `ls-remote --symref`; undefined when HEAD names no branch. */
+export function parseSymrefDefaultBranch(out: string): string | undefined {
+  for (const line of out.split('\n')) {
+    const match = /^ref:\s+refs\/heads\/(\S+)\s+HEAD$/.exec(line.trim())
+    const branch = match?.[1]
+    // A leading dash would reach `clone --branch` as an option, and git's own refname rules bar the rest.
+    if (branch && !branch.startsWith('-')) return branch
+  }
+  return undefined
+}
+
+function readSecondaryMaterialization(file: string): SecondaryMaterialization | undefined {
+  try {
+    const value = JSON.parse(readFileSync(file, 'utf8')) as Partial<SecondaryMaterialization>
+    if (typeof value.repoId !== 'string' || !value.repoId) return undefined
+    if (typeof value.branch !== 'string' || !value.branch) return undefined
+    if (typeof value.repoFullName !== 'string' || !value.repoFullName) return undefined
+    return { repoId: value.repoId, repoFullName: value.repoFullName, branch: value.branch }
+  } catch {
+    return undefined
   }
 }
 

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -369,19 +369,25 @@ export class WorkspaceManager {
         // The branch is not projected by the CP, so the remote's own HEAD decides it — resolved
         // BEFORE the clone, because `--branch` is how the clone records it.
         const branch = await this.resolveRemoteDefaultBranch(agent.id, root)
-        await this.cloneRootAt(agent.id, { ...root, branch }, root.path)
-        const materialization: SecondaryMaterialization = {
-          repoId: root.repoId,
-          repoFullName: root.repoFullName,
-          branch
+        const staged = `${root.path}.clone-${randomUUID()}`
+        try {
+          await this.cloneRootAt(agent.id, { ...root, branch }, staged)
+          // Attest first, publish last. A crash in between leaves a marker with no checkout, which
+          // the next session simply re-clones; the other order is what strands a checkout that no
+          // later session can attribute, and this code never deletes one to recover.
+          writeSecondaryMaterialization(marker, { repoId: root.repoId, repoFullName: root.repoFullName, branch })
+          this.publishSecondaryCheckout(staged, root.path)
+        } catch (err) {
+          rmSync(staged, { recursive: true, force: true })
+          throw err
         }
-        writeFileSync(marker, JSON.stringify(materialization, null, 2) + '\n', { mode: 0o600 })
         return { path: realpathSync(root.path), repoFullName: root.repoFullName, branch }
       }
-      const recorded = readSecondaryMaterialization(marker)
       // Identity is the numeric repo id, so a retired root whose owner/repo was later reused by a
       // DIFFERENT repository is refused rather than adopted — and nothing on disk is touched
       // (decision 12: retirement, never deletion).
+      const recorded =
+        readSecondaryMaterialization(marker) ?? (await this.reattestSecondaryCheckout(agent, root, marker))
       if (recorded === undefined || recorded.repoId !== root.repoId) {
         workspaceLog.warn(
           `workspace: the checkout at ${subtree} does not attest repository id ${root.repoId} ` +
@@ -402,6 +408,49 @@ export class WorkspaceManager {
       )
       return undefined
     }
+  }
+
+  /** Move a staged clone onto the root's path, over nothing or a provably empty leftover. */
+  private publishSecondaryCheckout(staged: string, path: string): void {
+    if (existsSync(path)) {
+      // The same rule the worktree GC applies: reclaim a provably empty directory, report anything
+      // else. A leftover that holds files is a human's or an older attempt's, never ours to remove.
+      if (readdirSync(path).length > 0) throw new Error(`${path} is not empty; refusing to replace it`)
+      rmSync(path, { recursive: true, force: true })
+    }
+    renameSync(staged, path)
+  }
+
+  /**
+   * Re-attest a checkout an interrupted materialization left with no marker.
+   *
+   * Only when its `origin` is still this row's repository, and only by writing the marker a
+   * completed materialization would have left — the alternative is a checkout no later session can
+   * attribute and therefore skips forever, which the promised next-session retry rules out.
+   */
+  private async reattestSecondaryCheckout(
+    agent: Agent,
+    root: SecondaryWorkspaceRoot,
+    marker: string
+  ): Promise<SecondaryMaterialization | undefined> {
+    const origin = await this.runnerFor(agent.id, root.path)
+      .withEnv(workspaceGitLocalEnv())
+      .raw(['remote', 'get-url', 'origin'])
+      .catch(() => '')
+    const canonical = (url: string) => normalizeGitUrl(redactGitUrlSecrets(url.trim())).replace(/\.git$/i, '')
+    if (!origin.trim() || canonical(origin).toLowerCase() !== canonical(root.cloneUrl).toLowerCase()) return undefined
+    const branch = await this.resolveRemoteDefaultBranch(agent.id, root)
+    const materialization: SecondaryMaterialization = {
+      repoId: root.repoId,
+      repoFullName: root.repoFullName,
+      branch
+    }
+    writeSecondaryMaterialization(marker, materialization)
+    workspaceLog.warn(
+      `workspace: the checkout of ${root.repoFullName} for agent "${agent.id}" had no materialization ` +
+        `record — re-attested it at ${branch} from its own origin`
+    )
+    return materialization
   }
 
   /** The branch `origin/HEAD` points at, asked of the remote through the clone's own credentials. */
@@ -1560,6 +1609,18 @@ export function parseSymrefDefaultBranch(out: string): string | undefined {
     if (branch && !branch.startsWith('-')) return branch
   }
   return undefined
+}
+
+/** Write the attestation the way the primary's marker is written: temp file, then atomic rename. */
+function writeSecondaryMaterialization(file: string, value: SecondaryMaterialization): void {
+  const temp = `${file}.tmp`
+  try {
+    writeFileSync(temp, JSON.stringify(value, null, 2) + '\n', { mode: 0o600 })
+    renameSync(temp, file)
+  } catch (err) {
+    rmSync(temp, { force: true })
+    throw err
+  }
 }
 
 function readSecondaryMaterialization(file: string): SecondaryMaterialization | undefined {

--- a/packages/daemon/test/gitmodules.test.ts
+++ b/packages/daemon/test/gitmodules.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { githubSubmoduleRepo, gitmoduleRepos, parseGitmoduleUrls } from '../src/workspace/gitmodules.js'
+
+describe('parseGitmoduleUrls', () => {
+  it('reads the url of every submodule section, in file order', () => {
+    const text = [
+      '[submodule "vendor/shared-library"]',
+      '\tpath = vendor/shared-library',
+      '\turl = https://github.com/example-co/shared-library.git',
+      '[submodule "vendor/infra"]',
+      '\tpath = vendor/infra',
+      '\turl = git@github.com:acme/infra.git',
+      '\tbranch = main'
+    ].join('\n')
+
+    expect(parseGitmoduleUrls(text)).toEqual([
+      'https://github.com/example-co/shared-library.git',
+      'git@github.com:acme/infra.git'
+    ])
+  })
+
+  it('ignores comments, blank lines, and keys outside a submodule section', () => {
+    const text = [
+      '# a comment',
+      '; another one',
+      '[core]',
+      '\turl = https://github.com/acme/not-a-submodule',
+      '',
+      '[submodule.dotted]',
+      '\tURL = "https://github.com/acme/infra"',
+      '\tnot-a-pair'
+    ].join('\n')
+
+    expect(parseGitmoduleUrls(text)).toEqual(['https://github.com/acme/infra'])
+  })
+
+  it('survives an empty or malformed file', () => {
+    expect(parseGitmoduleUrls('')).toEqual([])
+    expect(parseGitmoduleUrls('[submodule "x"')).toEqual([])
+    expect(parseGitmoduleUrls('[submodule "x"]\n\turl =\n')).toEqual([])
+  })
+})
+
+describe('githubSubmoduleRepo', () => {
+  it('normalizes every github.com spelling to a lowercased owner/repo', () => {
+    for (const url of [
+      'https://github.com/Acme/Infra.git',
+      'https://github.com/acme/infra/',
+      'git@github.com:acme/infra.git',
+      'ssh://git@github.com/acme/infra',
+      'github.com/acme/infra',
+      'https://token@github.com/acme/infra.git'
+    ]) {
+      expect(githubSubmoduleRepo(url)).toBe('acme/infra')
+    }
+  })
+
+  it('names no repository for a relative, local, or non-github address', () => {
+    for (const url of [
+      '../shared-library',
+      './vendor/infra',
+      '/srv/mirrors/infra.git',
+      'https://git.example.test/acme/infra.git',
+      'git@git.example.test:acme/infra.git',
+      'https://github.com/acme',
+      'https://github.com/acme/infra/extra',
+      ''
+    ]) {
+      expect(githubSubmoduleRepo(url)).toBeUndefined()
+    }
+  })
+})
+
+describe('gitmoduleRepos', () => {
+  it('collects only the github.com submodules a file declares', () => {
+    const text = [
+      '[submodule "a"]',
+      '\turl = https://github.com/Example-Co/Shared-Library.git',
+      '[submodule "b"]',
+      '\turl = ../sibling-repo',
+      '[submodule "c"]',
+      '\turl = https://git.example.test/acme/infra.git'
+    ].join('\n')
+
+    expect([...gitmoduleRepos(text)]).toEqual(['example-co/shared-library'])
+  })
+})

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import { SessionManager, isStandingContextTitleEcho } from '../src/session/session-manager.js'
+import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
 import { createManagedMemoryProvider } from '../src/memory/provider.js'
 import { writeMemoryFile, MEMORY_INDEX, MAX_INDEX_INJECT_BYTES } from '../src/memory/store.js'
 import { LocalMemoryFs } from '../src/memory/fs.js'
@@ -158,6 +159,44 @@ describe('SessionManager', () => {
     await sm.handle('bot-a', msg({ ts: '100.3', thread: '100.3', text: 'update production' }))
 
     expect(host.newSession).toHaveBeenCalledWith(realpathSync(cwd), [], undefined, undefined, [realpathSync(repoRoot)])
+    await (await store).close()
+  })
+
+  it('names the workspace roots the runtime actually received, sampled after preparation', async () => {
+    const store = await newStore()
+    const host = { ...fakeHost(), usesMetaSystemPrompt: () => true } as any
+    const recovered = {
+      path: '/srv/agents/bot-a/repos/acme/infra/checkout',
+      repoFullName: 'acme/infra',
+      branch: 'trunk'
+    }
+    const ready: Array<typeof recovered> = []
+    // The real hand-out and the real prompt, over a ready list this session's preparation changes.
+    const workspaces = new (class extends WorkspaceManager {
+      override readySecondaryRoots() {
+        return ready
+      }
+    })()
+    // A warm host prepares INSIDE openRuntimeSession, which is where the root recovers.
+    const prepareWorkspace = vi.fn(async () => {
+      ready.push(recovered)
+      return agent.workspace.path
+    })
+    const sm = new SessionManager({
+      store,
+      hostFor: async () => host,
+      isHostRunning: () => true,
+      agentById: () => agent,
+      prepareWorkspace,
+      workspaces,
+      memory
+    })
+
+    await sm.handle('bot-a', msg({ ts: '100.4', thread: '100.4', text: 'read the shared library' }))
+
+    const [, , , systemAppend, additionalDirectories] = host.newSession.mock.calls[0]
+    expect(additionalDirectories).toEqual([recovered.path])
+    expect(systemAppend).toContain(`- ${recovered.path} — acme/infra (trunk)`)
     await (await store).close()
   })
 

--- a/packages/daemon/test/standing-context.test.ts
+++ b/packages/daemon/test/standing-context.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { buildStandingContext, buildWorkspaceRootsAppend } from '../src/session/turn/standing-context.js'
+
+const BASE = {
+  agentName: 'bot-multi',
+  agentId: 'bot-multi',
+  platform: 'slack',
+  channel: 'C123',
+  thread: 'T123',
+  envSecretNames: [],
+  fileSecrets: [],
+  usesSessionTitleTool: false,
+  needsReplyToParent: false,
+  memoryIndex: '',
+  usesMeta: false
+}
+
+const ROOTS = [
+  { path: '/srv/agents/bot-multi/repos/acme/infra/checkout', repoFullName: 'acme/infra', branch: 'trunk' },
+  {
+    path: '/srv/agents/bot-multi/repos/example-co/shared-library/checkout',
+    repoFullName: 'example-co/shared-library',
+    branch: 'main'
+  }
+]
+
+describe('buildWorkspaceRootsAppend', () => {
+  it('names each additional directory with its repository and branch', () => {
+    expect(buildWorkspaceRootsAppend(ROOTS)).toBe(
+      [
+        '# Additional repositories',
+        'Additional repositories checked out for this session (each at its default branch; the working ' +
+          'directory stays the primary workspace):',
+        '- /srv/agents/bot-multi/repos/acme/infra/checkout — acme/infra (trunk)',
+        '- /srv/agents/bot-multi/repos/example-co/shared-library/checkout — example-co/shared-library (main)'
+      ].join('\n')
+    )
+  })
+
+  it('says nothing when the session has no secondary root', () => {
+    expect(buildWorkspaceRootsAppend([])).toBe('')
+    expect(buildWorkspaceRootsAppend(undefined)).toBe('')
+  })
+})
+
+describe('buildStandingContext with workspace roots', () => {
+  it('re-asserts the roots on resume, right after the agent meta block', () => {
+    const context = buildStandingContext({ ...BASE, workspaceRoots: ROOTS })
+
+    expect(context.workspaceRootsAppend).toBe(buildWorkspaceRootsAppend(ROOTS))
+    expect(context.resumeSystemContext).toContain(context.workspaceRootsAppend)
+    expect(context.resumeSystemContext.indexOf('# Additional repositories')).toBeGreaterThan(
+      context.resumeSystemContext.indexOf('# Agent')
+    )
+  })
+
+  it('leaves the context byte-identical when there is no root to name', () => {
+    expect(buildStandingContext({ ...BASE, workspaceRoots: [] })).toEqual(buildStandingContext(BASE))
+  })
+})

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -327,6 +327,57 @@ describe('secondary root materialization', () => {
     expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
   })
 
+  it('re-attests a checkout an interrupted materialization left with no marker', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareWorkspace(agent)
+    restoreAuthorizedOrigins(agent)
+    const subtree = join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra')
+    // Exactly what a daemon exit between the clone and the marker write would leave behind.
+    writeFileSync(join(subtree, 'checkout', 'local-note.txt'), 'work in the checkout\n')
+    rmSync(join(subtree, '.materialization.json'))
+
+    await workspaces.prepareWorkspace(agent)
+
+    expect(materialization(agent, 'acme/infra')).toEqual({
+      repoId: '42',
+      repoFullName: 'acme/infra',
+      branch: 'trunk'
+    })
+    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    // Re-attested, not re-cloned.
+    expect(existsSync(join(subtree, 'checkout', 'local-note.txt'))).toBe(true)
+  })
+
+  it('refuses to re-attest an unmarked checkout of a different repository, and removes nothing', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareWorkspace(agent)
+    restoreAuthorizedOrigins(agent)
+    const subtree = join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra')
+    git(join(subtree, 'checkout'), ['remote', 'set-url', 'origin', 'https://github.com/acme/something-else.git'])
+    rmSync(join(subtree, '.materialization.json'))
+
+    await workspaces.prepareWorkspace(agent)
+
+    expect(workspaces.readySecondaryRoots(agent)).toEqual([])
+    expect(existsSync(join(subtree, '.materialization.json'))).toBe(false)
+    expect(existsSync(join(subtree, 'checkout', '.git'))).toBe(true)
+  })
+
+  it('leaves a half-staged clone from an interrupted attempt alone', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    const subtree = join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra')
+    mkdirSync(join(subtree, 'checkout.clone-8a1f9c02-0000-4000-8000-000000000000'), { recursive: true })
+    writeFileSync(join(subtree, 'checkout.clone-8a1f9c02-0000-4000-8000-000000000000', 'partial.txt'), 'half\n')
+
+    await workspaces.prepareWorkspace(agent)
+
+    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect(existsSync(join(subtree, 'checkout.clone-8a1f9c02-0000-4000-8000-000000000000', 'partial.txt'))).toBe(true)
+  })
+
   it('skips a checkout that does not attest the row repository id, and removes nothing', async () => {
     const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
     serveAll(agent, { 'acme/infra': 'trunk' })

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -327,35 +327,27 @@ describe('secondary root materialization', () => {
     expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
   })
 
-  it('re-attests a checkout an interrupted materialization left with no marker', async () => {
+  it('publishes the clone only after its attestation, so a checkout is never left unattributable', async () => {
     const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
     serveAll(agent, { 'acme/infra': 'trunk' })
+
     await workspaces.prepareWorkspace(agent)
-    restoreAuthorizedOrigins(agent)
+
+    // Every state a crash can leave: no checkout, or a checkout WITH its record. The record is
+    // written before the staged clone is moved into place, so the pair cannot land the other way.
     const subtree = join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra')
-    // Exactly what a daemon exit between the clone and the marker write would leave behind.
-    writeFileSync(join(subtree, 'checkout', 'local-note.txt'), 'work in the checkout\n')
-    rmSync(join(subtree, '.materialization.json'))
-
-    await workspaces.prepareWorkspace(agent)
-
-    expect(materialization(agent, 'acme/infra')).toEqual({
-      repoId: '42',
-      repoFullName: 'acme/infra',
-      branch: 'trunk'
-    })
-    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
-    // Re-attested, not re-cloned.
-    expect(existsSync(join(subtree, 'checkout', 'local-note.txt'))).toBe(true)
+    expect(existsSync(join(subtree, '.materialization.json'))).toBe(true)
+    expect(readdirSync(subtree).filter((entry) => entry.startsWith('checkout.clone-'))).toEqual([])
   })
 
-  it('refuses to re-attest an unmarked checkout of a different repository, and removes nothing', async () => {
+  it('withholds an unattributable checkout rather than re-attesting it from its origin', async () => {
     const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
     serveAll(agent, { 'acme/infra': 'trunk' })
     await workspaces.prepareWorkspace(agent)
     restoreAuthorizedOrigins(agent)
     const subtree = join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra')
-    git(join(subtree, 'checkout'), ['remote', 'set-url', 'origin', 'https://github.com/acme/something-else.git'])
+    // An origin still names the SLUG, which is exactly what a reused name keeps — so a checkout
+    // with no record stays withheld even though its origin matches the row.
     rmSync(join(subtree, '.materialization.json'))
 
     await workspaces.prepareWorkspace(agent)

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -1,0 +1,479 @@
+import { execFileSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, afterEach, describe, expect, it } from 'vitest'
+import type { Agent } from '../src/agents/agent-schema.js'
+import {
+  daemonGitCredentialTarget,
+  gitFor,
+  initGitInjection,
+  workspaceGitLocalEnv
+} from '../src/workspace/git-injection.js'
+import { LocalGitRunner, type GitRunner, type GitLogEntry, type GitPullSummary } from '../src/workspace/git-runner.js'
+import { WorkspaceManager, parseSymrefDefaultBranch } from '../src/workspace/workspace-manager.js'
+
+// Real git against real repositories, no simple-git mock: what this file claims is that the remote's
+// OWN default branch decides a secondary root's checkout, that an existing one is converged rather
+// than re-cloned, and that a failure degrades to "this root is unavailable" — all of which a mocked
+// runner could only restate as the argv this code already builds.
+
+const workspaces = new WorkspaceManager()
+
+// The credential pointers a github-app root's clone carries. Nothing executes the helper here: the
+// fixture remotes are local paths, so git never asks for a credential.
+const SHIM = join(mkdtempSync(join(tmpdir(), 'ac-secondary-shim-')), 'git-credential-helper.sh')
+initGitInjection({
+  targetFor: () => daemonGitCredentialTarget({ shimPath: SHIM, runDir: join(SHIM, '..') }),
+  preWarm: async () => undefined,
+  capabilityFor: (agentId) => `cap-${agentId}`
+})
+
+const roots: string[] = []
+/** Authorized clone URL (minus any `.git`) → the local bare repository standing in for it. */
+const remotes = new Map<string, string>()
+
+afterAll(() => rmSync(join(SHIM, '..'), { recursive: true, force: true }))
+
+afterEach(() => {
+  workspaces.setGitRunnerResolver(undefined)
+  workspaces.setSandboxMode(false)
+  remotes.clear()
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function tempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix))
+  roots.push(root)
+  return root
+}
+
+/** Setup-only env: the daemon's own local policy widened to `file:`, plus a fixture identity. */
+function fixtureEnv(): Record<string, string> {
+  return {
+    ...workspaceGitLocalEnv(),
+    GIT_ALLOW_PROTOCOL: 'file:https:ssh',
+    GIT_AUTHOR_NAME: 'Fixture',
+    GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
+    GIT_COMMITTER_NAME: 'Fixture',
+    GIT_COMMITTER_EMAIL: 'fixture@example.invalid'
+  }
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, env: fixtureEnv(), encoding: 'utf8' })
+}
+
+/** A bare repository whose HEAD names `branch`, holding one commit and an optional `.gitmodules`. */
+function bareRepo(name: string, branch: string, gitmodules?: string): string {
+  const root = tempRoot(`ac-secondary-${name}-`)
+  const bare = join(root, 'origin.git')
+  const seed = join(root, 'seed')
+  git(root, ['init', '-q', '--bare', `--initial-branch=${branch}`, bare])
+  mkdirSync(seed, { recursive: true })
+  git(seed, ['init', '-q', `--initial-branch=${branch}`, '.'])
+  writeFileSync(join(seed, 'README.md'), `${name}\n`)
+  if (gitmodules !== undefined) writeFileSync(join(seed, '.gitmodules'), gitmodules)
+  git(seed, ['add', '-A'])
+  git(seed, ['commit', '-q', '-m', 'initial'])
+  git(seed, ['remote', 'add', 'origin', bare])
+  git(seed, ['push', '-q', 'origin', branch])
+  return bare
+}
+
+/** A `.gitmodules` naming one github.com submodule. */
+function gitmodulesFor(repoFullName: string): string {
+  return `[submodule "${repoFullName}"]\n\tpath = vendor/${repoFullName.split('/')[1]}\n\turl = https://github.com/${repoFullName}.git\n`
+}
+
+function agentFixture(
+  additionalRepos: Array<{ repoFullName: string; repoId: string }>,
+  overrides: { mode?: 'git-repo' | 'from-scratch'; agentDir?: string; pullOnNewSession?: boolean } = {}
+): Agent {
+  const home = tempRoot('ac-secondary-agent-')
+  return {
+    id: 'bot-multi',
+    dir: home,
+    name: 'bot-multi',
+    status: 'active',
+    runtime: 'claude',
+    workspace: {
+      mode: overrides.mode ?? 'git-repo',
+      isolation: 'shared',
+      path: join(home, 'workspace'),
+      gitRepo: 'https://github.com/acme/primary-service.git',
+      gitBranch: 'main',
+      gitCredential: 'github-app',
+      ...(overrides.agentDir !== undefined ? { agentDir: overrides.agentDir } : {}),
+      additionalRepos,
+      pullOnNewSession: overrides.pullOnNewSession ?? true,
+      skills: []
+    },
+    integrations: [],
+    output: { mode: 'medium' },
+    permissions: { policy: 'ask', autoApprove: [] },
+    crons: []
+  } as unknown as Agent
+}
+
+/** Point one root's authorized clone URL at a local bare repository. */
+function serve(cloneUrl: string, bare: string): void {
+  remotes.set(cloneUrl.replace(/\.git$/i, ''), bare)
+}
+
+function substitute(value: string): string {
+  return remotes.get(value.replace(/\.git$/i, '')) ?? value
+}
+
+/**
+ * Real git through the workspace runner seam, with exactly one substitution: a fixture repository's
+ * authorized GitHub URL becomes its local bare path, and `file:` joins the protocol allowlist. The
+ * daemon's origin policy accepts no local path, so a test cannot otherwise reach a remote at all;
+ * every other argument — refspecs, flags, hardening pairs, credential pointers — is what the
+ * workspace manager built.
+ */
+class SeamRunner implements GitRunner {
+  constructor(
+    private readonly cwd: string | undefined,
+    private readonly abort: AbortSignal | undefined,
+    private readonly env: Record<string, string> = {}
+  ) {}
+
+  withEnv(env: Record<string, string>): GitRunner {
+    return new SeamRunner(this.cwd, this.abort, env)
+  }
+
+  private delegate(): GitRunner {
+    const env = { ...this.env, GIT_ALLOW_PROTOCOL: 'file:https:ssh' }
+    for (let index = 0; index < Number(env.GIT_CONFIG_COUNT ?? 0); index += 1) {
+      // Only a remote's URL: rewriting every matching value would flip the `url.*.insteadOf` guard
+      // around and rewrite the substituted path back again.
+      if (/^remote\..*\.url$/i.test(env[`GIT_CONFIG_KEY_${index}`] ?? '')) {
+        env[`GIT_CONFIG_VALUE_${index}`] = substitute(env[`GIT_CONFIG_VALUE_${index}`] ?? '')
+      }
+    }
+    const make = (value: Record<string, string>) => gitFor(this.cwd, this.abort).env(value)
+    return new LocalGitRunner(gitFor(this.cwd, this.abort), this.cwd, make).withEnv(env)
+  }
+
+  raw(args: string[]): Promise<string> {
+    // Only the one subcommand that takes a URL as argv. Substituting every argument would also
+    // rewrite what `remote set-url` records, hiding whether convergence repointed the checkout.
+    return this.delegate().raw(args[0] === 'ls-remote' ? args.map(substitute) : args)
+  }
+
+  clone(repo: string, target: string, options?: string[]): Promise<void> {
+    return this.delegate().clone(substitute(repo), target, options)
+  }
+
+  pull(remote: string, branch: string, options?: string[]): Promise<GitPullSummary> {
+    return this.delegate().pull(remote, branch, options)
+  }
+
+  status() {
+    return this.delegate().status()
+  }
+
+  log(options: { maxCount: number }): Promise<GitLogEntry[]> {
+    return this.delegate().log(options)
+  }
+
+  readBounded(args: string[], maxBytes: number) {
+    return this.delegate().readBounded(args, maxBytes)
+  }
+}
+
+function useSeamRunner(): void {
+  workspaces.setGitRunnerResolver((_agentId, cwd, abort) => new SeamRunner(cwd, abort))
+}
+
+/** The agent's roots, each served by a bare repository whose HEAD names the given branch. */
+function serveAll(agent: Agent, branches: Record<string, string>, gitmodules: Record<string, string> = {}): void {
+  useSeamRunner()
+  if (agent.workspace.mode === 'git-repo') {
+    serve(workspaces.primaryRoot(agent).cloneUrl, bareRepo('primary', 'main', gitmodules['primary']))
+  }
+  for (const root of workspaces.secondaryRoots(agent)) {
+    const branch = branches[root.repoFullName]
+    if (branch === undefined) continue
+    serve(root.cloneUrl, bareRepo(root.repoFullName.replace('/', '-'), branch, gitmodules[root.repoFullName]))
+  }
+}
+
+/** Repoint every fixture checkout at the authorized URL its real clone would have recorded. */
+function restoreAuthorizedOrigins(agent: Agent): void {
+  if (agent.workspace.mode === 'git-repo') {
+    git(agent.workspace.path, ['remote', 'set-url', 'origin', workspaces.primaryRoot(agent).cloneUrl])
+  }
+  for (const root of workspaces.secondaryRoots(agent)) {
+    if (existsSync(join(root.path, '.git'))) git(root.path, ['remote', 'set-url', 'origin', root.cloneUrl])
+  }
+}
+
+function materialization(agent: Agent, repoFullName: string): unknown {
+  const [owner, repo] = repoFullName.split('/')
+  return JSON.parse(
+    readFileSync(join(workspaces.agentRootFor(agent), 'repos', owner!, repo!, '.materialization.json'), 'utf8')
+  )
+}
+
+describe('secondaryRoots (layout)', () => {
+  it('lays each authorized repository out beside the primary, sorted by name', () => {
+    const agent = agentFixture([
+      { repoFullName: 'example-co/shared-library', repoId: '815' },
+      { repoFullName: 'acme/infra', repoId: '42' }
+    ])
+    const home = workspaces.agentRootFor(agent)
+
+    expect(
+      workspaces.secondaryRoots(agent).map((root) => ({
+        repoFullName: root.repoFullName,
+        repoId: root.repoId,
+        path: root.path,
+        worktreesPath: root.worktreesPath,
+        cloneUrl: root.cloneUrl,
+        githubApp: root.githubApp
+      }))
+    ).toEqual([
+      {
+        repoFullName: 'acme/infra',
+        repoId: '42',
+        path: join(home, 'repos', 'acme', 'infra', 'checkout'),
+        worktreesPath: join(home, 'repos', 'acme', 'infra', 'worktrees'),
+        cloneUrl: 'https://github.com/acme/infra',
+        githubApp: true
+      },
+      {
+        repoFullName: 'example-co/shared-library',
+        repoId: '815',
+        path: join(home, 'repos', 'example-co', 'shared-library', 'checkout'),
+        worktreesPath: join(home, 'repos', 'example-co', 'shared-library', 'worktrees'),
+        cloneUrl: 'https://github.com/example-co/shared-library',
+        githubApp: true
+      }
+    ])
+  })
+
+  it('refuses a row that is not two plain path segments', () => {
+    const agent = agentFixture([
+      { repoFullName: '../../etc', repoId: '1' },
+      { repoFullName: 'acme/../infra', repoId: '2' },
+      { repoFullName: 'acme', repoId: '3' },
+      { repoFullName: 'acme/infra/extra', repoId: '4' },
+      { repoFullName: '', repoId: '5' },
+      { repoFullName: 'acme/infra', repoId: '6' }
+    ])
+
+    expect(workspaces.secondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+  })
+})
+
+describe('secondary root materialization', () => {
+  it('clones each root at the remote HEAD it actually reports and records that branch', async () => {
+    const agent = agentFixture([
+      { repoFullName: 'example-co/shared-library', repoId: '815' },
+      { repoFullName: 'acme/infra', repoId: '42' }
+    ])
+    // Neither remote is on `main`: the branch has to come from `ls-remote --symref`, not a default.
+    serveAll(agent, { 'acme/infra': 'trunk', 'example-co/shared-library': 'release/v2' })
+
+    const cwd = await workspaces.prepareWorkspace(agent)
+
+    const home = workspaces.agentRootFor(agent)
+    expect(existsSync(join(home, 'repos', 'acme', 'infra', 'checkout', '.git'))).toBe(true)
+    expect(materialization(agent, 'acme/infra')).toEqual({
+      repoId: '42',
+      repoFullName: 'acme/infra',
+      branch: 'trunk'
+    })
+    expect(materialization(agent, 'example-co/shared-library')).toEqual({
+      repoId: '815',
+      repoFullName: 'example-co/shared-library',
+      branch: 'release/v2'
+    })
+    expect(workspaces.readySecondaryRoots(agent).map((root) => [root.repoFullName, root.branch])).toEqual([
+      ['acme/infra', 'trunk'],
+      ['example-co/shared-library', 'release/v2']
+    ])
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([
+      realpathSync(join(home, 'repos', 'acme', 'infra', 'checkout')),
+      realpathSync(join(home, 'repos', 'example-co', 'shared-library', 'checkout'))
+    ])
+  })
+
+  it('converges and pulls an existing checkout instead of cloning it again', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareWorkspace(agent)
+    restoreAuthorizedOrigins(agent)
+    const checkout = join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout')
+    writeFileSync(join(checkout, 'local-note.txt'), 'kept across sessions\n')
+    // A historical origin the convergence has to repoint at the authorized URL.
+    git(checkout, ['remote', 'set-url', 'origin', 'https://github.com/acme/infra-old.git'])
+
+    await workspaces.prepareWorkspace(agent)
+
+    expect(existsSync(join(checkout, 'local-note.txt'))).toBe(true)
+    expect(git(checkout, ['remote', 'get-url', 'origin']).trim()).toBe('https://github.com/acme/infra')
+    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+  })
+
+  it('skips a checkout that does not attest the row repository id, and removes nothing', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareWorkspace(agent)
+    restoreAuthorizedOrigins(agent)
+    const subtree = join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra')
+    const recorded = materialization(agent, 'acme/infra') as object
+    writeFileSync(join(subtree, '.materialization.json'), JSON.stringify({ ...recorded, repoId: '999' }))
+
+    const cwd = await workspaces.prepareWorkspace(agent)
+
+    expect(workspaces.readySecondaryRoots(agent)).toEqual([])
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([])
+    // Retirement, never deletion (decision 12): the checkout is left exactly where it was.
+    expect(existsSync(join(subtree, 'checkout', '.git'))).toBe(true)
+    expect(readdirSync(subtree).sort()).toEqual(['.materialization.json', 'checkout'])
+  })
+
+  it('omits a root whose clone fails and still prepares the session', async () => {
+    const agent = agentFixture([
+      { repoFullName: 'acme/infra', repoId: '42' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ])
+    // Only one remote is reachable; the other's clone URL resolves to nothing.
+    serveAll(agent, { 'acme/infra': 'trunk' })
+
+    const cwd = await workspaces.prepareWorkspace(agent)
+
+    expect(cwd).toBe(realpathSync(agent.workspace.path))
+    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect(
+      existsSync(join(workspaces.agentRootFor(agent), 'repos', 'example-co', 'shared-library', 'checkout', '.git'))
+    ).toBe(false)
+  })
+
+  it('coalesces two sessions racing into the same root', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+
+    const [first, second] = await Promise.all([workspaces.prepareWorkspace(agent), workspaces.prepareWorkspace(agent)])
+
+    expect(second).toBe(first)
+    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+  })
+})
+
+describe('submodule roots (decision 11)', () => {
+  it('withholds a root the primary already carries as a submodule', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' }, { primary: gitmodulesFor('acme/infra') })
+
+    const cwd = await workspaces.prepareWorkspace(agent)
+
+    expect(workspaces.readySecondaryRoots(agent)).toEqual([])
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([])
+    // Not handed out AND not cloned: the parent's own submodule path is where it is reachable.
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout'))).toBe(false)
+  })
+
+  it('withholds a root an earlier secondary carries as a submodule', async () => {
+    const agent = agentFixture([
+      { repoFullName: 'acme/infra', repoId: '42' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ])
+    // `acme/infra` sorts first, so its `.gitmodules` is read before the root it names is considered.
+    serveAll(
+      agent,
+      { 'acme/infra': 'trunk', 'example-co/shared-library': 'main' },
+      { 'acme/infra': gitmodulesFor('example-co/shared-library') }
+    )
+
+    await workspaces.prepareWorkspace(agent)
+
+    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'repos', 'example-co', 'shared-library', 'checkout'))).toBe(
+      false
+    )
+  })
+})
+
+describe('additionalWorkspaceDirectories with secondary roots', () => {
+  it('widens an agentDir cwd and appends the roots for a shared-isolation session', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }], { agentDir: 'services/api' })
+    useSeamRunner()
+    const primary = bareRepo('primary-with-subdir', 'main')
+    const seed = join(tempRoot('ac-secondary-seed-'), 'seed')
+    git(join(seed, '..'), ['clone', '-q', primary, seed])
+    mkdirSync(join(seed, 'services', 'api'), { recursive: true })
+    writeFileSync(join(seed, 'services', 'api', 'index.ts'), 'export {}\n')
+    git(seed, ['add', '-A'])
+    git(seed, ['commit', '-q', '-m', 'subdir'])
+    git(seed, ['push', '-q', 'origin', 'main'])
+    serve(workspaces.primaryRoot(agent).cloneUrl, primary)
+    serve(workspaces.secondaryRoots(agent)[0]!.cloneUrl, bareRepo('acme-infra', 'trunk'))
+
+    const cwd = await workspaces.prepareWorkspace(agent)
+
+    expect(cwd).toBe(realpathSync(join(agent.workspace.path, 'services', 'api')))
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([
+      realpathSync(agent.workspace.path),
+      realpathSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout'))
+    ])
+  })
+
+  it('leaves a session-isolated session exactly as it was', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    const request = { sessionKey: 'session-a', isolation: 'session' as const }
+    const cwd = await workspaces.prepareSessionWorkspace(agent, request)
+
+    expect(cwd).toBe(realpathSync(workspaces.sessionWorktreePath(agent, 'session-a')))
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([])
+    expect(workspaces.readySecondaryRoots(agent, { isolation: 'session' })).toEqual([])
+    expect(workspaces.readySecondaryRoots(agent, { isolation: 'shared' })).toHaveLength(1)
+  })
+
+  it('hands the roots to a from-scratch agent, which has no checkout of its own', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }], { mode: 'from-scratch' })
+    serveAll(agent, { 'acme/infra': 'trunk' })
+
+    const cwd = await workspaces.prepareWorkspace(agent)
+
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([
+      realpathSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout'))
+    ])
+  })
+
+  it('prepares and hands out nothing when workspaces live in sandboxes', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    workspaces.setSandboxMode(true)
+
+    expect(await workspaces.prepareSecondaryRoots(agent)).toEqual([])
+    expect(workspaces.readySecondaryRoots(agent)).toEqual([])
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'repos'))).toBe(false)
+  })
+})
+
+describe('parseSymrefDefaultBranch', () => {
+  it('reads the branch out of a real `ls-remote --symref` reply', () => {
+    const out = `ref: refs/heads/release/v2\tHEAD\n${'a'.repeat(40)}\tHEAD\n`
+    expect(parseSymrefDefaultBranch(out)).toBe('release/v2')
+  })
+
+  it('returns undefined for a detached or option-shaped HEAD', () => {
+    expect(parseSymrefDefaultBranch(`${'a'.repeat(40)}\tHEAD\n`)).toBeUndefined()
+    expect(parseSymrefDefaultBranch('ref: refs/heads/-oops\tHEAD\n')).toBeUndefined()
+    expect(parseSymrefDefaultBranch('')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Phase 3 of [`docs/designs/multi-repository-workspaces.md`](docs/designs/multi-repository-workspaces.md) — decisions 1, 2 (daemon side), 3, 7, 8, 10 and 11, for **shared-isolation sessions**.

## Why

`AgentSpec.workspace.additionalRepos` already reaches the daemon (#1219) and the primary checkout already runs through a `WorkspaceRoot` (#1218), but nothing reads the list: an agent authorized for a second repository can push to it and call `gh` against it, while having nothing of it on disk. This makes every authorized repository a checkout the session can actually open.

## What

`secondaryRoots(agent)` turns the rows into roots sorted by `repoFullName`, laid out self-similarly beside the primary (decision 8):

```
<agent>/workspace                                     primary clone, unchanged
<agent>/worktrees/<sid>                               primary session worktree, unchanged
<agent>/repos/<owner>/<repo>/.materialization.json    {repoId, repoFullName, branch}
<agent>/repos/<owner>/<repo>/checkout                 the secondary clone
<agent>/repos/<owner>/<repo>/worktrees                reserved for session isolation
```

- **Materialization** runs inside `prepareWorkspace`, after the primary and before it returns, so every session start refreshes the set — and a row that has disappeared stops being handed out immediately. Branch is not projected by the control plane: `git ls-remote --symref` resolves the remote's own HEAD before the clone records it, and the marker keeps it for later sessions. An existing checkout converges its origin, re-pins the credential helper and pulls, exactly as a github-app primary does. Preparation is single-flighted per root, like the primary clone.
- **Degradation is per root** (decision 7): an unresolved default branch, a failed clone, or a marker whose `repoId` is not the row's leaves that one root out of this session with a warning. The session still starts, and the next one retries.
- **Submodule roots are withheld** (decision 11): after each root is prepared its `.gitmodules` is read (plain text, no git subprocess), and a later root that an earlier one already carries as a submodule is neither cloned nor listed. The model never sees one repository twice at two different revisions.
- **Hand-out** is `additionalWorkspaceDirectories` under shared (or unspecified) isolation, alongside today's `agentDir` widening, and for a from-scratch workspace too (decision 5).
- **The prompt names the roots** (decision 10) from the same accessor the directories come from, so the standing context cannot list a directory the runtime did not get.

## Deliberately not here

- Per-session worktrees of the secondary roots under `session` isolation (decision 4) — that path returns exactly what it returns today.
- The retire → sweep → remove cleanup (decision 12). **Nothing in this change removes anything on disk.**
- The cross-repository review path (decision 6) and cluster daemons, which are explicitly out of scope for this phase.

## What to check

- Nothing is ever deleted: the repo-id mismatch branch leaves the checkout exactly where it was, and there is no `rmSync` on any secondary path.
- A failing root degrades locally — no throw escapes into session start.
- A submodule root is neither materialized nor handed out, and processing order (primary, then secondaries by name) is what decides it.
- `session` isolation and the `agentDir` widening behave exactly as before.

## Tests

`test/workspace-secondary-roots.test.ts` runs real git against local bare repositories through the existing runner seam: layout and sort order, a first session cloning at a remote HEAD that is deliberately not `main`, a second session converging and pulling without re-cloning, the repo-id mismatch, a failed clone, the race, both submodule shapes, and every hand-out case (shared, session, `agentDir`, scratch, sandbox mode). `test/gitmodules.test.ts` covers the parser, `test/standing-context.test.ts` the prompt append.
