### PR TITLE
feat(daemon): per-session worktrees for secondary roots and the retire-sweep-remove lifecycle

### DIFF
--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -130,10 +130,9 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     runtimeEnv,
     agentEnv,
     configFileDir: agent.dir,
-    // Same sandbox write carve-back the daemon grants: without it a sandboxed chat run against a
-    // git-repo agent cannot write its own session worktrees.
-    trustedWorkspaceWriteRoots:
-      runInSandbox && agent.workspace.mode === 'git-repo' ? [workspaces.sessionWorktreeRoot(agent)] : undefined,
+    // Same sandbox write carve-back the daemon grants: without it a sandboxed chat run cannot write
+    // its own session worktrees, nor read the secondary roots beside them.
+    trustedWorkspaceWriteRoots: runInSandbox ? workspaces.trustedWorkspaceWriteRoots(agent) : undefined,
     // No daemon here, so there is no MCP bridge socket, gh wrapper, or git-credential shim to carve
     // back: mcpSocketPath / allowModelToolUnixSockets / runtimeReadRoots stay genuinely unused.
     sandboxMechanism

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -118,6 +118,13 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   // The standalone chat CLI runs one agent locally, so it owns a plane with nothing registered
   // on it: git runs here and no path lives in a sandbox.
   const workspaces = new WorkspaceManager()
+  // Before the launch policy, not after: the sandbox boundary is computed from what is ON DISK, so
+  // a first run that assembled first would confine the runtime out of the checkouts it just cloned.
+  // The daemon's cold-host gate prepares in this order too (startHostWithRetry).
+  const cwd = await workspaces.prepareWorkspace(agent, {
+    skillsStateDir: join(root, 'skill-installs'),
+    skillsAgentId: entry?.skillsAgentId ?? null
+  })
   const assembled = assembleRuntimeLaunch({
     runtimeId: agent.runtime,
     runtime,
@@ -169,12 +176,8 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   }
   process.once('SIGINT', onSigint)
   try {
-    const cwd = await workspaces.prepareWorkspace(agent, {
-      skillsStateDir: join(root, 'skill-installs'),
-      skillsAgentId: entry?.skillsAgentId ?? null
-    })
-    // Runtime adapters may discover skills only during initialization. Finish the
-    // complete clone/pull + unified-skill reconciliation before the child starts.
+    // Runtime adapters may discover skills only during initialization, and the clone/pull +
+    // unified-skill reconciliation above is complete before the child starts.
     await host.start()
     const sessionId = await host.newSession(
       cwd,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -150,7 +150,11 @@ import {
   type SlackTurnState
 } from './platforms/slack/turn-output.js'
 import { ChannelNameResolver } from './messages/channel-name-resolver.js'
-import { WorkspaceManager, type PrepareSessionWorkspaceRequest } from './workspace/workspace-manager.js'
+import {
+  WorkspaceManager,
+  type PrepareSessionWorkspaceRequest,
+  type RetiredRootRemoval
+} from './workspace/workspace-manager.js'
 import { ManagedSkillCache } from './skills/managed-skill-cache.js'
 import {
   OutputConverger,
@@ -3065,10 +3069,7 @@ export class Daemon {
         runtimeReadRoots: runInSandbox
           ? (launchEnv) => this.sandboxRuntimeReadRoots(agent, runtime, launchEnv, githubAppCredentials)
           : undefined,
-        trustedWorkspaceWriteRoots:
-          runInSandbox && agent.workspace.mode === 'git-repo'
-            ? [this.workspaces.sessionWorktreeRoot(agent)]
-            : undefined,
+        trustedWorkspaceWriteRoots: runInSandbox ? this.workspaces.trustedWorkspaceWriteRoots(agent) : undefined,
         sandboxMechanism: this.sandboxMechanism,
         mcpSocketPath: mcpSocketPath(this.root),
         allowModelToolUnixSockets: githubAppCredentials,
@@ -12456,7 +12457,9 @@ export class Daemon {
   private async cleanupSessionWorktree(rec: SessionRecord): Promise<SessionWorktreeCleanupResult> {
     if (await this.sessionRetentionActive(rec)) return { outcome: 'active' }
     const agent = this.agents.get(rec.agentId)
-    if (!agent || agent.workspace.mode !== 'git-repo' || rec.workspaceIsolation === 'shared') {
+    // A scratch agent has no primary worktree but may still own one per secondary root, so the
+    // gate is "any root that can hold one" rather than "the primary is a repository".
+    if (!agent || rec.workspaceIsolation === 'shared' || !this.workspaces.hasSessionWorktreeRoots(agent)) {
       return { outcome: 'not_applicable' }
     }
     return this.withWorkspaceAdmissionFence(rec.agentId, async () => {
@@ -12464,7 +12467,11 @@ export class Daemon {
       // queued mutation boundary. In that case it owns the worktree, so defer.
       if (await this.sessionRetentionActive(rec)) return { outcome: 'active' }
       const currentAgent = this.agents.get(rec.agentId)
-      if (!currentAgent || currentAgent.workspace.mode !== 'git-repo' || rec.workspaceIsolation === 'shared') {
+      if (
+        !currentAgent ||
+        rec.workspaceIsolation === 'shared' ||
+        !this.workspaces.hasSessionWorktreeRoots(currentAgent)
+      ) {
         return { outcome: 'not_applicable' }
       }
       const result = await this.workspaces.removeSessionWorktree(currentAgent, rec.key)
@@ -12482,76 +12489,149 @@ export class Daemon {
   }
 
   private async sweepSessionRetention(): Promise<void> {
-    const windowMs = sessionRetentionMs(this.cfg.sessions.retention)
-    if (windowMs === null) return
     if (this.sessionRetentionSweepInFlight) return
     this.sessionRetentionSweepInFlight = true
     try {
-      // Holder-only on a pool: the active-turn exclusions are member-local, so only the holder can judge a row.
-      const expired = (await this.store.listExpiredSessions(this.clock.now() - windowMs)).filter((rec) =>
-        this.servesAgent(rec.agentId)
-      )
-      if (!expired.length) return
-      // ONE stamp for the whole pass, not one per session: it is the sweep that
-      // deleted them, and a shared value lets the drain report a pass as a single
-      // frame while still carrying each row's true purge time (a per-session
-      // millisecond would force either one frame per session or a batch stamp
-      // that backdates every row to the oldest in the backlog).
-      const purgedAt = this.clock.now()
-      let removed = 0
-      let retained = 0
-      let active = 0
-      let failed = 0
-      for (const rec of expired) {
-        if (this.draining) return
-        const res = await this.cleanupSessionWorktree(rec)
-        if (res.outcome === 'active') {
-          active += 1
-          continue
-        }
-        if (res.outcome === 'retained') {
-          retained += 1
-          this.log.info(
-            `retention: keeping session ${rec.key} — worktree has ${
-              res.reason === 'dirty' ? 'uncommitted/untracked changes' : 'commits not on any remote'
-            } (delete or push them to release it)`
-          )
-          continue
-        }
-        if (res.outcome === 'failed') {
-          failed += 1
-          this.log.warn(`retention: keeping session ${rec.key} — worktree cleanup failed (${res.error})`)
-          continue
-        }
-        // Re-check synchronously after the git awaits: a message admitted mid-cleanup
-        // owns the serial gate now, and deleting the row underneath its turn would
-        // orphan the state the turn is about to write. The worktree (if any) is
-        // already gone, but prepareSessionWorkspace recreates it on that same turn.
-        if (await this.sessionRetentionActive(rec)) {
-          active += 1
-          continue
-        }
-        // The purge receipt is written in deleteSession's transaction: the CP holds
-        // the only surviving record of this session, and it must be told that the
-        // content behind it is gone (drained below, durably, on ACK).
-        if (
-          await this.store.deleteSession(rec.key, { reason: 'retention', at: purgedAt, ownerId: this.cfg.daemonId })
-        ) {
-          removed += 1
-          if (rec.acpSessionId) this.sdkLease.delete(sdkLeaseKey(rec.agentId, rec.acpSessionId))
-          await this.releaseModelSessionHost(rec.key)
-        }
-      }
-      this.log.info(
-        `retention: session GC removed ${removed}/${expired.length} expired session(s)` +
-          (retained ? `, ${retained} retained (dirty/unique commits)` : '') +
-          (active ? `, ${active} still active` : '') +
-          (failed ? `, ${failed} failed` : '')
-      )
-      if (removed) void this.drainSessionPurges()
+      await this.sweepExpiredSessions()
+      // Decision 12's removal step rides the same sweep, but not the retention window: a retired
+      // root is not an expired session, and an install that keeps sessions forever still retires.
+      await this.sweepRetiredWorkspaceRoots()
     } finally {
       this.sessionRetentionSweepInFlight = false
     }
+  }
+
+  private async sweepExpiredSessions(): Promise<void> {
+    const windowMs = sessionRetentionMs(this.cfg.sessions.retention)
+    if (windowMs === null) return
+    // Holder-only on a pool: the active-turn exclusions are member-local, so only the holder can judge a row.
+    const expired = (await this.store.listExpiredSessions(this.clock.now() - windowMs)).filter((rec) =>
+      this.servesAgent(rec.agentId)
+    )
+    if (!expired.length) return
+    // ONE stamp for the whole pass, not one per session: it is the sweep that
+    // deleted them, and a shared value lets the drain report a pass as a single
+    // frame while still carrying each row's true purge time (a per-session
+    // millisecond would force either one frame per session or a batch stamp
+    // that backdates every row to the oldest in the backlog).
+    const purgedAt = this.clock.now()
+    let removed = 0
+    let retained = 0
+    let active = 0
+    let failed = 0
+    for (const rec of expired) {
+      if (this.draining) return
+      const res = await this.cleanupSessionWorktree(rec)
+      if (res.outcome === 'active') {
+        active += 1
+        continue
+      }
+      if (res.outcome === 'retained') {
+        retained += 1
+        this.log.info(
+          `retention: keeping session ${rec.key} — worktree has ${
+            res.reason === 'dirty' ? 'uncommitted/untracked changes' : 'commits not on any remote'
+          } (delete or push them to release it)`
+        )
+        continue
+      }
+      if (res.outcome === 'failed') {
+        failed += 1
+        this.log.warn(`retention: keeping session ${rec.key} — worktree cleanup failed (${res.error})`)
+        continue
+      }
+      // Re-check synchronously after the git awaits: a message admitted mid-cleanup
+      // owns the serial gate now, and deleting the row underneath its turn would
+      // orphan the state the turn is about to write. The worktree (if any) is
+      // already gone, but prepareSessionWorkspace recreates it on that same turn.
+      if (await this.sessionRetentionActive(rec)) {
+        active += 1
+        continue
+      }
+      // The purge receipt is written in deleteSession's transaction: the CP holds
+      // the only surviving record of this session, and it must be told that the
+      // content behind it is gone (drained below, durably, on ACK).
+      if (await this.store.deleteSession(rec.key, { reason: 'retention', at: purgedAt, ownerId: this.cfg.daemonId })) {
+        removed += 1
+        if (rec.acpSessionId) this.sdkLease.delete(sdkLeaseKey(rec.agentId, rec.acpSessionId))
+        await this.releaseModelSessionHost(rec.key)
+      }
+    }
+    this.log.info(
+      `retention: session GC removed ${removed}/${expired.length} expired session(s)` +
+        (retained ? `, ${retained} retained (dirty/unique commits)` : '') +
+        (active ? `, ${active} still active` : '') +
+        (failed ? `, ${failed} failed` : '')
+    )
+    if (removed) void this.drainSessionPurges()
+  }
+
+  /** Whether an agent still holds live work of ANY kind — the per-agent form of the retention
+   *  sweep's session exclusion, for a decision about a ROOT (which every session shares) rather
+   *  than about one session. `workspaceMutationBusy` is the same "the agent could be writing"
+   *  rule the console's workspace writes refuse on; the rest is the durable and gate-owned work
+   *  that carries no active dispatch yet. */
+  private async agentWorkspaceActive(agentId: string): Promise<boolean> {
+    if (!this.servesAgent(agentId) || this.workspaceMutationBusy(agentId)) return true
+    for (const entry of this.activeGateEntries.values()) if (entry.agentId === agentId) return true
+    for (const turn of this.pending.values()) if (turn.agentId === agentId) return true
+    return await this.store.agentHasPendingInboxRows(agentId)
+  }
+
+  /**
+   * Decision 12's removal step: a retired secondary root leaves disk only from this sweep, only
+   * while its agent holds nothing at all, and only through the dirty/unique-commit rules a session
+   * worktree gets. Everything else is retained and reported.
+   *
+   * The idle check is re-taken INSIDE the admission fence, which is what makes it a decision rather
+   * than a guess: the fence blocks turn admission synchronously, so a session admitted during the
+   * awaited Git operations cannot have started against a root this pass is about to remove.
+   */
+  private async sweepRetiredWorkspaceRoots(): Promise<void> {
+    // Cluster daemons keep one checkout on a pod volume; there is no `repos/` subtree on this disk.
+    if (this.workspaces.sandboxMode) return
+    let removed = 0
+    let active = 0
+    const retained: string[] = []
+    const failures: string[] = []
+    for (const agent of [...this.agents.values()]) {
+      if (this.draining) break
+      if (!this.servesAgent(agent.id)) continue
+      const pending = this.workspaces.retiredSecondaryRoots(agent)
+      if (pending.length === 0) continue
+      if (await this.agentWorkspaceActive(agent.id)) {
+        active += pending.length
+        continue
+      }
+      const outcomes = await this.withWorkspaceAdmissionFence(agent.id, async () => {
+        if (await this.agentWorkspaceActive(agent.id)) return undefined
+        const current = this.agents.get(agent.id)
+        if (!current) return undefined
+        // Re-listed inside the fence: the spec may have re-authorized a repository while this pass
+        // waited for the queue, which un-retires its root in place.
+        const results: RetiredRootRemoval[] = []
+        for (const root of this.workspaces.retiredSecondaryRoots(current)) {
+          results.push(await this.workspaces.removeRetiredSecondaryRoot(current, root))
+        }
+        return results
+      })
+      if (outcomes === undefined) {
+        active += pending.length
+        continue
+      }
+      for (const outcome of outcomes) {
+        if (outcome.outcome === 'removed') removed += 1
+        else if (outcome.outcome === 'retained') retained.push(outcome.reason)
+        else failures.push(outcome.error)
+      }
+    }
+    if (removed === 0 && active === 0 && retained.length === 0 && failures.length === 0) return
+    this.log.info(
+      `retention: retired roots: removed ${removed}, retained ${retained.length}` +
+        (retained.length ? ` (${[...new Set(retained)].join(', ')})` : '') +
+        `, active ${active}` +
+        (failures.length ? `, ${failures.length} failed (${[...new Set(failures)].join('; ')})` : '')
+    )
   }
 
   /**

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12475,7 +12475,10 @@ export class Daemon {
         return { outcome: 'not_applicable' }
       }
       const result = await this.workspaces.removeSessionWorktree(currentAgent, rec.key)
-      if ((result.outcome === 'removed' || result.outcome === 'absent') && rec.acpSessionId) {
+      // `partial` too: a kept aggregate can still have removed another root's worktree, and a warm
+      // attachment naming a directory that is gone would skip preparation on its next turn.
+      const changed = result.outcome === 'removed' || result.outcome === 'absent' || result.partial === true
+      if (changed && rec.acpSessionId) {
         // The session row intentionally survives lifecycle cleanup. Evict only
         // this stale warm binding so the next reopened/comment turn recreates
         // the worktree and runs session/load/new before prompting in its cwd.

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -12,6 +12,7 @@ import {
   runtimeHomePath
 } from '../runtimes/runtime-home.js'
 import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
+import { secondaryCheckoutsIn } from '../workspace/secondary-layout.js'
 import {
   CLAUDE_PROFILE_ENV,
   claudeProtectedSettings,
@@ -436,7 +437,9 @@ export function prepareRuntimeLaunch(opts: {
     // Codex's :workspace profile protects `.git`. Re-open only the canonical
     // metadata directory already covered by the outer sandbox's writable root;
     // session worktree indexes and refs live below this main checkout directory.
-    const writableGitMetadataRoots = boundary.gitSafeDirectories.flatMap((workspaceRoot) => {
+    // A secondary root materialized after this spawn is reopened on the next one.
+    const gitMetadataOwners = [...boundary.gitSafeDirectories, ...secondaryCheckoutsIn(agentRoot)]
+    const writableGitMetadataRoots = gitMetadataOwners.flatMap((workspaceRoot) => {
       const gitDir = join(workspaceRoot, '.git')
       if (!existsSync(gitDir) || !lstatSync(gitDir).isDirectory()) return []
       const canonical = realpathSync(gitDir)

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -553,7 +553,7 @@ export class SessionManager {
         fileSecrets: fileSecrets.map((m) => ({ sourceVar: m.sourceVar, pointerVar: m.convention.pointerVar })),
         // The same list `additionalWorkspaceDirectories` hands the runtime, read from the same
         // accessor, so the prompt names exactly the directories the session got.
-        workspaceRoots: this.workspaces.readySecondaryRoots(agent, { isolation: workspaceIsolation }),
+        workspaceRoots: this.workspaces.readySecondaryRoots(agent, workspaceRequest),
         usesSessionTitleTool,
         needsReplyToParent,
         memoryIndex,

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2575,6 +2575,15 @@ export class LocalStore {
     return row !== undefined
   }
 
+  /** The same question asked of a whole AGENT, for a decision about something every one of its
+   *  sessions shares — a retired workspace root. Completed rows are excluded for the same reason. */
+  async agentHasPendingInboxRows(agentId: string): Promise<boolean> {
+    const row = (await this.db
+      .prepare('SELECT 1 AS present FROM inbox WHERE agentId = ? AND completedAt IS NULL LIMIT 1')
+      .get(agentId)) as { present: number } | undefined
+    return row !== undefined
+  }
+
   /** Retention-GC delete (#485): remove one session row and its dependent rows —
    *  mute, memory-capture gate, durable inbox, permission-request history.
    *  Two deliberate survivors:

--- a/packages/daemon/src/workspace/secondary-layout.ts
+++ b/packages/daemon/src/workspace/secondary-layout.ts
@@ -1,0 +1,77 @@
+import { lstatSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+// The on-disk shape of an agent's secondary roots (multi-repository-workspaces.md §"Directory
+// layout"), separate from the manager so the launch path can read it without the whole workspace
+// module: a sandboxed runtime's boundary is computed from these paths before any session exists.
+
+/** Secondary roots live under one agent-owned parent, one subtree per authorized repository. */
+export const SECONDARY_ROOTS_DIR = 'repos'
+/** What a secondary root's subtree records about the checkout beside it. */
+export const SECONDARY_MATERIALIZATION_FILE = '.materialization.json'
+/** GitHub's own owner/repository charset, which is also a plain path segment. */
+const REPO_SEGMENT = /^[A-Za-z0-9._-]+$/
+
+/** A plain path segment that is also a legal GitHub owner or repository name. */
+export function isRepoSegment(value: string | undefined): value is string {
+  return value !== undefined && value !== '.' && value !== '..' && REPO_SEGMENT.test(value)
+}
+
+/** `<agentRoot>/repos` — the parent every secondary root's subtree hangs off. */
+export function secondaryRootsDirIn(agentRoot: string): string {
+  return join(agentRoot, SECONDARY_ROOTS_DIR)
+}
+
+/** One secondary subtree's daemon-owned paths, in the shape a `WorkspaceRoot` needs. */
+export interface SecondarySubtree {
+  repoFullName: string
+  /** The whole `repos/<owner>/<repo>` subtree — what retirement removal deletes. */
+  subtree: string
+  /** The clone itself. */
+  path: string
+  /** Where this root's per-session worktrees live. */
+  worktreesPath: string
+}
+
+/**
+ * Every `repos/<owner>/<repo>` subtree ON DISK, authorized or retired, sorted by name.
+ *
+ * Reading the disk rather than the agent's rows is the point: a root that left the set still owns
+ * worktrees and a checkout, and nothing else would ever look at them again. A symlinked parent or
+ * entry is skipped rather than followed — no destructive caller may be redirected by one.
+ */
+export function secondarySubtreesIn(agentRoot: string): SecondarySubtree[] {
+  const parent = secondaryRootsDirIn(agentRoot)
+  const out: SecondarySubtree[] = []
+  for (const owner of realDirEntries(parent)) {
+    for (const repo of realDirEntries(join(parent, owner))) {
+      const subtree = join(parent, owner, repo)
+      out.push({
+        repoFullName: `${owner}/${repo}`,
+        subtree,
+        path: join(subtree, 'checkout'),
+        worktreesPath: join(subtree, 'worktrees')
+      })
+    }
+  }
+  return out
+}
+
+/** The materialized secondary checkouts under `<agentRoot>/repos`, for callers that only need those. */
+export function secondaryCheckoutsIn(agentRoot: string): string[] {
+  return secondarySubtreesIn(agentRoot).map((entry) => entry.path)
+}
+
+/** Real (never symlinked) child directories whose names are legal repository segments. */
+function realDirEntries(dir: string): string[] {
+  try {
+    if (lstatSync(dir).isSymbolicLink()) return []
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && isRepoSegment(entry.name))
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    // No `repos` parent, no owner directory, or one this process cannot read: no subtrees.
+    return []
+  }
+}

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -838,13 +838,17 @@ export class WorkspaceManager {
   }
 
   /** Every root that can hold a per-session worktree: the primary when there is one, plus every
-   *  secondary subtree ON DISK — a retired root's worktrees are this session's too (decision 12). */
+   *  MATERIALIZED secondary subtree on disk — a retired root's worktrees are this session's too
+   *  (decision 12), while a subtree a failed clone left behind owns none and has no checkout for
+   *  Git to run in, which would fail the whole session's cleanup forever. */
   sessionWorktreeRoots(agent: Agent): Pick<WorkspaceRoot, 'path' | 'worktreesPath'>[] {
     return [
       ...(agent.workspace.mode === 'git-repo'
         ? [{ path: agent.workspace.path, worktreesPath: this.worktreesPathFor(agent) }]
         : []),
-      ...secondarySubtreesIn(this.agentRootFor(agent)).map(({ path, worktreesPath }) => ({ path, worktreesPath }))
+      ...secondarySubtreesIn(this.agentRootFor(agent))
+        .filter((entry) => existsSync(join(entry.path, '.git')))
+        .map(({ path, worktreesPath }) => ({ path, worktreesPath }))
     ]
   }
 
@@ -859,7 +863,10 @@ export class WorkspaceManager {
    * all of them uniformly (decision 4) and they share the session's id.
    *
    * Aggregated conservatively: one retained root keeps the session (its work is still there), a
-   * failure is reported as a failure, and `absent` means no root had anything to remove.
+   * failure is reported as a failure, and `absent` means no root had anything to remove. Removal is
+   * per root and cannot be made atomic — Git refuses a worktree that went dirty since it was judged
+   * — so a kept aggregate that nonetheless removed something is flagged `partial`, which is what
+   * tells the caller its warm attachment is stale even though the session survives.
    */
   async removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
     const roots = this.sessionWorktreeRoots(agent)
@@ -874,7 +881,9 @@ export class WorkspaceManager {
       else if (result.outcome === 'failed') failed ??= result
       else if (result.outcome === 'removed') removed = true
     }
-    return retained ?? failed ?? (removed ? { outcome: 'removed' } : { outcome: 'absent' })
+    const kept = retained ?? failed
+    if (kept) return removed ? { ...kept, partial: true } : kept
+    return removed ? { outcome: 'removed' } : { outcome: 'absent' }
   }
 
   /** The agent's secondary subtrees whose `.materialization.json` no longer matches a current row —
@@ -910,9 +919,11 @@ export class WorkspaceManager {
       if (existsSync(join(root.path, '.git'))) {
         const git = this.runnerFor(agent.id, root.path).withEnv(workspaceGitLocalEnv())
         if ((await git.raw(['status', '--porcelain'])).trim() !== '') return { outcome: 'retained', reason: 'dirty' }
-        if ((await git.raw(['rev-list', '--count', 'HEAD', '--not', '--remotes'])).trim() !== '0') {
-          return { outcome: 'retained', reason: 'unique-commits' }
-        }
+        // EVERY local ref, not just HEAD: this removes the object store itself, so a side branch, a
+        // local tag or a stash entry is work the checked-out branch cannot speak for. Only this
+        // daemon's own review refs are disposable — they were fetched verbatim from the remote.
+        const unique = await git.raw(['rev-list', '--count', '--all', '--not', '--remotes', '--glob=refs/agentconnect'])
+        if (unique.trim() !== '0') return { outcome: 'retained', reason: 'unique-commits' }
       } else if (existsSync(root.path) && readdirSync(root.path).length > 0) {
         // No `.git` to interrogate, but a nonempty directory may be exactly the untracked work this
         // GC promises never to auto-delete — the same rule the worktree GC applies to a bare leftover.
@@ -1917,12 +1928,17 @@ export type WorkspacePathClearer = (agentId: string, root: string) => Promise<st
  * never stored — the id is a hex hash, so the path always sits under the agent's
  * worktrees root. */
 
-export type SessionWorktreeRemoval =
+export type SessionWorktreeRemoval = (
   | { outcome: 'removed' }
   | { outcome: 'absent' }
   /** The worktree holds work the daemon must not discard — the caller keeps the session. */
   | { outcome: 'retained'; reason: 'dirty' | 'unique-commits' }
   | { outcome: 'failed'; error: string }
+) & {
+  /** Another root's worktree DID go even though the aggregate keeps the session, so a warm runtime
+   *  attachment now names directories that are gone and the caller must evict it anyway. */
+  partial?: true
+}
 
 /** Retention GC (#485): remove one logical session's worktree, but only when it
  * is provably safe — no dirty/untracked files and no commit unreachable from

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -38,6 +38,13 @@ import {
 } from './git-injection.js'
 import { LocalGitRunner, type GitRunner } from './git-runner.js'
 import { gitmoduleRepos } from './gitmodules.js'
+import {
+  isRepoSegment,
+  secondaryRootsDirIn,
+  secondarySubtreesIn,
+  SECONDARY_MATERIALIZATION_FILE,
+  type SecondarySubtree
+} from './secondary-layout.js'
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
 import { isSessionBranch, sessionBranchName } from './session-branch.js'
 import { DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
@@ -93,11 +100,28 @@ export interface SecondaryWorkspaceRoot extends WorkspaceRoot {
 
 /** A prepared secondary root, as sessions and the standing context see it. */
 export interface ReadyWorkspaceRoot {
-  /** The canonical checkout path handed out as an additional directory. */
+  /** The canonical directory handed out as an additional directory — the checkout under `shared`
+   *  isolation, this session's own worktree of it under `session` (decision 4). */
   path: string
   repoFullName: string
   branch: string
 }
+
+/** A secondary subtree the agent's rows no longer name — retired, never deleted on sight (decision 12). */
+export interface RetiredWorkspaceRoot extends SecondarySubtree {
+  /** The repository id its `.materialization.json` attests, for the sweep's log line. */
+  repoId: string
+}
+
+/** What a retired root's removal did, in the vocabulary the worktree GC already reports. */
+export type RetiredRootRemoval =
+  | { outcome: 'removed' }
+  /** The subtree holds work (or a live session's worktree) the daemon must not discard. */
+  | { outcome: 'retained'; reason: 'worktrees' | 'dirty' | 'unique-commits' }
+  | { outcome: 'failed'; error: string }
+
+/** How one session addresses the agent's roots: the isolation, plus the key that names its worktrees. */
+export type SessionRootScope = Pick<PrepareSessionWorkspaceRequest, 'isolation'> & { sessionKey?: string }
 
 /** What a secondary root's `.materialization.json` records about the checkout beside it. */
 interface SecondaryMaterialization {
@@ -122,13 +146,8 @@ const PULL_TIMEOUT_MS = 4500
 const REVIEW_FETCH_TIMEOUT_MS = 15_000
 const LS_REMOTE_TIMEOUT_MS = 10_000
 const MATERIALIZATION_FILE = 'workspace-materialization.json'
-/** Secondary roots live under one agent-owned parent, one subtree per authorized repository. */
-const SECONDARY_ROOTS_DIR = 'repos'
-const SECONDARY_MATERIALIZATION_FILE = '.materialization.json'
 /** A `.gitmodules` past this is not a submodule declaration anyone wrote; refuse to read it. */
 const MAX_GITMODULES_BYTES = 256 * 1024
-/** GitHub's own owner/repository charset, which is also a plain path segment. */
-const REPO_SEGMENT = /^[A-Za-z0-9._-]+$/
 const CONVERSION_FILE = 'workspace-conversion.json'
 /** Word-pair branch names to try before falling back to a random suffix. */
 const SESSION_BRANCH_DRAWS = 5
@@ -148,9 +167,9 @@ export class WorkspaceManager {
   // Same single-flight, one level up: a secondary root's preparation is a clone OR a converge+pull,
   // and two sessions starting together must share one of them. A separate map because the clone it
   // performs keys `cloneInFlight` by the very same path.
-  private readonly secondaryInFlight = new Map<string, Promise<ReadyWorkspaceRoot | undefined>>()
+  private readonly secondaryInFlight = new Map<string, Promise<SecondaryWorkspaceRoot | undefined>>()
   /** Secondary roots prepared for an agent's current sessions — what the synchronous hand-out reads. */
-  private readonly readyRoots = new Map<string, ReadyWorkspaceRoot[]>()
+  private readonly readyRoots = new Map<string, SecondaryWorkspaceRoot[]>()
   private gitRunnerResolver: WorkspaceGitRunnerResolver | undefined
   private pathClearer: WorkspacePathClearer | undefined
   private workspacesLiveInSandboxes = false
@@ -245,6 +264,11 @@ export class WorkspaceManager {
     return (agent as { dir?: string }).dir ?? dirname(agent.workspace.path)
   }
 
+  /** `<agentRoot>/repos` — the parent every secondary root's subtree hangs off. */
+  secondaryRootsDir(agent: Agent): string {
+    return secondaryRootsDirIn(this.agentRootFor(agent))
+  }
+
   /** The agent's authorized additional repositories as roots, sorted by name (design decision 1/8). */
   secondaryRoots(agent: Agent): SecondaryWorkspaceRoot[] {
     const roots: SecondaryWorkspaceRoot[] = []
@@ -258,7 +282,7 @@ export class WorkspaceManager {
         continue
       }
       const repoFullName = `${owner}/${repo}`
-      const base = join(this.agentRootFor(agent), SECONDARY_ROOTS_DIR, owner, repo)
+      const base = join(this.secondaryRootsDir(agent), owner, repo)
       try {
         roots.push({
           repoFullName,
@@ -285,15 +309,31 @@ export class WorkspaceManager {
    * directories and the standing context are both derived from, so the prompt cannot name a
    * directory the runtime did not get.
    *
-   * Empty under `session` isolation: those sessions get a per-session worktree of every root, which
-   * this phase has not built, and a shared checkout would defeat the isolation they asked for.
+   * WHICH roots is preparation's answer (the snapshot below); which PATH each one contributes is
+   * the session's, because isolation applies to every root uniformly (decision 4): `shared` hands
+   * out the checkout, `session` the worktree keyed by that session. A root whose worktree could not
+   * be created contributes nothing to that session and is simply absent here.
    */
-  readySecondaryRoots(
-    agent: Agent,
-    request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
-  ): readonly ReadyWorkspaceRoot[] {
-    if (this.sandboxMode || request?.isolation === 'session') return []
-    return this.readyRoots.get(agent.id) ?? []
+  readySecondaryRoots(agent: Agent, request?: SessionRootScope): readonly ReadyWorkspaceRoot[] {
+    if (this.sandboxMode) return []
+    const ready = this.readyRoots.get(agent.id) ?? []
+    const id =
+      request?.isolation === 'session' && request.sessionKey !== undefined
+        ? this.sessionWorktreeId(request.sessionKey)
+        : undefined
+    const roots: ReadyWorkspaceRoot[] = []
+    for (const root of ready) {
+      if (id === undefined) {
+        roots.push({ path: root.path, repoFullName: root.repoFullName, branch: root.branch })
+        continue
+      }
+      const cwd = join(root.worktreesPath, id)
+      // The `.git` marker is what `worktree add` writes, so its presence is the proof that this
+      // root's per-session checkout exists rather than a directory a failed attempt left behind.
+      if (!existsSync(join(cwd, '.git'))) continue
+      roots.push({ path: realpathSync(cwd), repoFullName: root.repoFullName, branch: root.branch })
+    }
+    return roots
   }
 
   /**
@@ -304,7 +344,7 @@ export class WorkspaceManager {
    * is already a submodule of an earlier one is neither prepared nor listed, so the model never sees
    * the same repository twice at two different revisions.
    */
-  async prepareSecondaryRoots(agent: Agent): Promise<ReadyWorkspaceRoot[]> {
+  async prepareSecondaryRoots(agent: Agent): Promise<SecondaryWorkspaceRoot[]> {
     // Cluster daemons materialize one checkout through the shim tunnel; secondary roots there are a
     // non-goal of this phase, and every path below would clone onto the DAEMON's disk instead.
     if (this.sandboxMode) return []
@@ -315,7 +355,7 @@ export class WorkspaceManager {
     }
     const submodules =
       agent.workspace.mode === 'git-repo' ? this.submoduleReposOf(agent.workspace.path) : new Set<string>()
-    const ready: ReadyWorkspaceRoot[] = []
+    const ready: SecondaryWorkspaceRoot[] = []
     for (const root of roots) {
       if (submodules.has(root.repoFullName.toLowerCase())) {
         workspaceLog.info(
@@ -346,7 +386,7 @@ export class WorkspaceManager {
   }
 
   /** One secondary root's clone-or-converge, single-flighted per root like the primary's clone. */
-  async prepareSecondaryRoot(agent: Agent, root: SecondaryWorkspaceRoot): Promise<ReadyWorkspaceRoot | undefined> {
+  async prepareSecondaryRoot(agent: Agent, root: SecondaryWorkspaceRoot): Promise<SecondaryWorkspaceRoot | undefined> {
     const key = this.cloneKey(agent.id, root.path)
     const inflight = this.secondaryInFlight.get(key)
     if (inflight) return await inflight
@@ -360,7 +400,7 @@ export class WorkspaceManager {
   private async materializeSecondaryRoot(
     agent: Agent,
     root: SecondaryWorkspaceRoot
-  ): Promise<ReadyWorkspaceRoot | undefined> {
+  ): Promise<SecondaryWorkspaceRoot | undefined> {
     const subtree = dirname(root.path)
     const marker = join(subtree, SECONDARY_MATERIALIZATION_FILE)
     try {
@@ -381,7 +421,7 @@ export class WorkspaceManager {
           rmSync(staged, { recursive: true, force: true })
           throw err
         }
-        return { path: realpathSync(root.path), repoFullName: root.repoFullName, branch }
+        return { ...root, path: realpathSync(root.path), branch }
       }
       // Identity is the numeric repo id, so a retired root whose owner/repo was later reused by a
       // DIFFERENT repository is refused rather than adopted — and nothing on disk is touched
@@ -399,7 +439,7 @@ export class WorkspaceManager {
       await this.convergeOriginInPlaceFor(agent.id, resolved, root.path)
       await writeRepoHelperConfig(this.runnerFor(agent.id, root.path), agent.id).catch(() => undefined)
       if (agent.workspace.pullOnNewSession) await this.pullRoot(agent.id, resolved, root.path)
-      return { path: realpathSync(root.path), repoFullName: root.repoFullName, branch: recorded.branch }
+      return { ...resolved, path: realpathSync(root.path) }
     } catch (err) {
       // Degradation stays local to the root (decision 7): the session starts without it and the next
       // one retries. Never throw out of session start over an additional repository.
@@ -744,6 +784,21 @@ export class WorkspaceManager {
     return this.worktreesPathFor(agent)
   }
 
+  /**
+   * The daemon-owned parents a sandboxed runtime must be able to write, given that
+   * `sandboxBoundary` denies read on the agent directory and carves back only what it is told.
+   *
+   * The secondary parent is granted to EVERY sandboxed agent, scratch included: a host is
+   * long-lived per agent, so a root materialized under a running one has to already be inside the
+   * boundary or it stays invisible until the next spawn.
+   */
+  trustedWorkspaceWriteRoots(agent: Agent): string[] {
+    return [
+      ...(agent.workspace.mode === 'git-repo' ? [this.sessionWorktreeRoot(agent)] : []),
+      this.secondaryRootsDir(agent)
+    ]
+  }
+
   // Containment is per AGENT, not per root: every root's worktrees parent must resolve inside the agent directory.
   validateWorktreesRoot(agent: Agent, worktreesPath: string): string {
     if (lstatSync(worktreesPath).isSymbolicLink()) {
@@ -782,12 +837,105 @@ export class WorkspaceManager {
     return join(this.sessionWorktreeRoot(agent), this.sessionWorktreeId(sessionKey))
   }
 
+  /** Every root that can hold a per-session worktree: the primary when there is one, plus every
+   *  secondary subtree ON DISK — a retired root's worktrees are this session's too (decision 12). */
+  sessionWorktreeRoots(agent: Agent): Pick<WorkspaceRoot, 'path' | 'worktreesPath'>[] {
+    return [
+      ...(agent.workspace.mode === 'git-repo'
+        ? [{ path: agent.workspace.path, worktreesPath: this.worktreesPathFor(agent) }]
+        : []),
+      ...secondarySubtreesIn(this.agentRootFor(agent)).map(({ path, worktreesPath }) => ({ path, worktreesPath }))
+    ]
+  }
+
+  /** Whether the agent has any root a session worktree could live under — a scratch workspace with
+   *  secondary roots does, which is what makes it a candidate for the retention GC. */
+  hasSessionWorktreeRoots(agent: Agent): boolean {
+    return this.sessionWorktreeRoots(agent).length > 0
+  }
+
+  /**
+   * Remove one logical session's worktree from EVERY root that has one, since isolation applies to
+   * all of them uniformly (decision 4) and they share the session's id.
+   *
+   * Aggregated conservatively: one retained root keeps the session (its work is still there), a
+   * failure is reported as a failure, and `absent` means no root had anything to remove.
+   */
   async removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
-    if (agent.workspace.mode !== 'git-repo') {
-      return { outcome: 'failed', error: 'agent workspace is not a Git repository' }
+    const roots = this.sessionWorktreeRoots(agent)
+    if (roots.length === 0) return { outcome: 'failed', error: 'agent workspace is not a Git repository' }
+    const id = this.sessionWorktreeId(sessionKey)
+    let retained: SessionWorktreeRemoval | undefined
+    let failed: SessionWorktreeRemoval | undefined
+    let removed = false
+    for (const root of roots) {
+      const result = await this.removeRootSessionWorktree(agent, root, id)
+      if (result.outcome === 'retained') retained ??= result
+      else if (result.outcome === 'failed') failed ??= result
+      else if (result.outcome === 'removed') removed = true
     }
-    const root = { path: agent.workspace.path, worktreesPath: this.worktreesPathFor(agent) }
-    return await this.removeRootSessionWorktree(agent, root, this.sessionWorktreeId(sessionKey))
+    return retained ?? failed ?? (removed ? { outcome: 'removed' } : { outcome: 'absent' })
+  }
+
+  /** The agent's secondary subtrees whose `.materialization.json` no longer matches a current row —
+   *  by repository id, and by the directory a rename moved the repository out of (decision 12). */
+  retiredSecondaryRoots(agent: Agent): RetiredWorkspaceRoot[] {
+    const authorized = new Map(this.secondaryRoots(agent).map((root) => [root.repoId, root.repoFullName]))
+    const retired: RetiredWorkspaceRoot[] = []
+    for (const entry of secondarySubtreesIn(this.agentRootFor(agent))) {
+      const recorded = readSecondaryMaterialization(join(entry.subtree, SECONDARY_MATERIALIZATION_FILE))
+      // No attestation ⇒ not ours to judge, let alone remove: materialization already refuses to
+      // adopt such a subtree, and removing one would be exactly the deletion decision 12 forbids.
+      if (recorded === undefined) continue
+      if (authorized.get(recorded.repoId) === entry.repoFullName) continue
+      retired.push({ ...entry, repoId: recorded.repoId })
+    }
+    return retired
+  }
+
+  /**
+   * Remove one retired secondary subtree — the only path that deletes a root, and only from the
+   * caller that has already proven the agent idle under its admission fence.
+   *
+   * The checkout gets exactly the rules a session worktree gets: clean tree, no commit unreachable
+   * from a remote. A live (or retained) worktree under it keeps the whole subtree, because its
+   * clone is the object store that worktree reads.
+   */
+  async removeRetiredSecondaryRoot(agent: Agent, root: RetiredWorkspaceRoot): Promise<RetiredRootRemoval> {
+    try {
+      const subtree = this.validateSecondarySubtree(agent, root.subtree)
+      if (existsSync(root.worktreesPath) && readdirSync(root.worktreesPath).length > 0) {
+        return { outcome: 'retained', reason: 'worktrees' }
+      }
+      if (existsSync(join(root.path, '.git'))) {
+        const git = this.runnerFor(agent.id, root.path).withEnv(workspaceGitLocalEnv())
+        if ((await git.raw(['status', '--porcelain'])).trim() !== '') return { outcome: 'retained', reason: 'dirty' }
+        if ((await git.raw(['rev-list', '--count', 'HEAD', '--not', '--remotes'])).trim() !== '0') {
+          return { outcome: 'retained', reason: 'unique-commits' }
+        }
+      } else if (existsSync(root.path) && readdirSync(root.path).length > 0) {
+        // No `.git` to interrogate, but a nonempty directory may be exactly the untracked work this
+        // GC promises never to auto-delete — the same rule the worktree GC applies to a bare leftover.
+        return { outcome: 'retained', reason: 'dirty' }
+      }
+      rmSync(subtree, { recursive: true, force: true })
+      return { outcome: 'removed' }
+    } catch (err) {
+      return { outcome: 'failed', error: (err as Error).message }
+    }
+  }
+
+  /** Canonicalize a secondary subtree and prove it still resolves inside the agent directory, the
+   *  same way every destructive worktree path goes through {@link validateWorktreesRoot}. */
+  private validateSecondarySubtree(agent: Agent, subtree: string): string {
+    if (lstatSync(subtree).isSymbolicLink()) throw new Error('secondary root subtree must not be a symlink')
+    const agentRoot = realpathSync(this.agentRootFor(agent))
+    const canonical = realpathSync(subtree)
+    const rel = relative(agentRoot, canonical)
+    if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+      throw new Error('secondary root subtree resolves outside the agent directory')
+    }
+    return canonical
   }
 
   // Takes only the root's on-disk halves: the GC has no network target, so it must not need an authorized clone URL.
@@ -1024,11 +1172,44 @@ export class WorkspaceManager {
       return this.prepareGithubRevisionOnlyWorkspace(agent, this.sessionWorktreeId(request.sessionKey))
     }
     const primary = await this.prepareWorkspace(agent, opts)
-    if (agent.workspace.mode !== 'git-repo' || request.isolation === 'shared') return primary
+    if (request.isolation === 'shared') return primary
 
-    const cwd = await this.prepareRootSessionWorktree(agent, this.primaryRoot(agent), request)
+    // A from-scratch primary keeps its scratch directory as the cwd — isolation has no clone to
+    // branch it off — but its secondaries still get per-session worktrees (decisions 4 and 5).
+    const cwd =
+      agent.workspace.mode === 'git-repo'
+        ? await this.prepareRootSessionWorktree(agent, this.primaryRoot(agent), request)
+        : undefined
+    await this.prepareSecondarySessionWorktrees(agent, request)
+    if (cwd === undefined) return primary
     const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
     return this.withSkills(agent, this.resolveAcpCwd(cwd, agentDir), opts)
+  }
+
+  /**
+   * Every prepared secondary root's worktree for this session, at the SAME id as the primary's.
+   *
+   * Never a review checkout: the reviewed revision belongs to the one root the session is about,
+   * and the others ride along at their default branch as references (decision 5). Per-root failure
+   * is local like a clone failure (decision 7) — that root is absent from this session and nothing
+   * else about it changes.
+   */
+  private async prepareSecondarySessionWorktrees(agent: Agent, request: PrepareSessionWorkspaceRequest): Promise<void> {
+    const rootRequest: PrepareSessionWorkspaceRequest = {
+      sessionKey: request.sessionKey,
+      isolation: 'session',
+      ...(request.initiatedBy !== undefined ? { initiatedBy: request.initiatedBy } : {})
+    }
+    for (const root of this.readyRoots.get(agent.id) ?? []) {
+      try {
+        await this.prepareRootSessionWorktree(agent, root, rootRequest)
+      } catch (err) {
+        workspaceLog.warn(
+          `workspace: additional repository ${root.repoFullName} has no session worktree for agent ` +
+            `"${agent.id}" (${formatErr(err)})`
+        )
+      }
+    }
   }
 
   /** The stable per-session worktree of one root, checked out at the reviewed revision when there is one. */
@@ -1561,11 +1742,6 @@ export class WorkspaceManager {
     this.cloneInFlight.set(key, p)
     return p
   }
-}
-
-/** A plain path segment that is also a legal GitHub owner or repository name. */
-function isRepoSegment(value: string | undefined): value is string {
-  return value !== undefined && value !== '.' && value !== '..' && REPO_SEGMENT.test(value)
 }
 
 /** `ref: refs/heads/<name>\tHEAD` from `ls-remote --symref`; undefined when HEAD names no branch. */

--- a/packages/daemon/test/chat.test.ts
+++ b/packages/daemon/test/chat.test.ts
@@ -97,11 +97,14 @@ describe('runChat', () => {
     expect(out.text()).toContain('echo:hi')
   }, 20_000)
 
-  it('finishes workspace preparation before starting the runtime host', async () => {
+  // Before the LAUNCH, not just before start(): a sandboxed run computes its boundary from what is
+  // on disk, so a workspace materialized afterwards would be outside the policy the child gets.
+  it('finishes workspace preparation before assembling the launch or starting the host', async () => {
     const files = scaffold()
     const workspace = join(files.agentsDir, 'ws')
     const runtime = { command: process.execPath, args: [], env: [] }
     const host = quietHost()
+    let preparedBeforeLaunch = false
     host.start = vi.fn(async () => {
       expect(existsSync(workspace)).toBe(true)
     })
@@ -121,9 +124,14 @@ describe('runChat', () => {
         runtimes: { fake: runtime }
       }),
       installed: (runtimes) => runtimes,
-      hostFactory: () => host
+      // Called strictly after the launch is assembled, so this pins the earlier ordering.
+      hostFactory: () => {
+        preparedBeforeLaunch = existsSync(workspace)
+        return host
+      }
     })
 
+    expect(preparedBeforeLaunch).toBe(true)
     expect(host.start).toHaveBeenCalledOnce()
     expect(host.newSession).toHaveBeenCalledOnce()
   })

--- a/packages/daemon/test/daemon-retired-roots-sweep.test.ts
+++ b/packages/daemon/test/daemon-retired-roots-sweep.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Daemon } from '../src/daemon.js'
+import { FakeClock } from './cp/fake-clock.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+
+/**
+ * multi-repository-workspaces.md decision 12 at the daemon boundary: a retired secondary root is
+ * removed only from the idle sweep, only while its agent holds nothing, and only under the
+ * workspace admission fence. What this file claims is that GATE — the dirty/unique-commit rules
+ * are the workspace manager's own and are proven against real repositories there.
+ */
+
+const AGENT = 'bot-roots'
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-retired-roots-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  const agentDir = join(root, 'agents', AGENT)
+  mkdirSync(agentDir, { recursive: true })
+  writeFileSync(
+    join(agentDir, 'agent.json'),
+    JSON.stringify({
+      id: AGENT,
+      name: AGENT,
+      status: 'active',
+      runtime: 'claude',
+      // No `additionalRepos`, so every subtree seeded below is retired by construction.
+      workspace: { mode: 'from-scratch', path: join(agentDir, 'workspace') },
+      integrations: [],
+      output: { mode: 'low' }
+    })
+  )
+  return root
+}
+
+/** A materialized secondary subtree with an empty checkout — attested, idle, nothing to keep. */
+function seedRetiredRoot(root: string, repoFullName: string, repoId: string): string {
+  const subtree = join(root, 'agents', AGENT, 'repos', ...repoFullName.split('/'))
+  mkdirSync(join(subtree, 'checkout'), { recursive: true })
+  writeFileSync(
+    join(subtree, '.materialization.json'),
+    JSON.stringify({ repoId, repoFullName, branch: 'main' }, null, 2)
+  )
+  return subtree
+}
+
+/** Boot, then let the startup sweep settle so each case seeds into a quiet daemon. */
+async function boot(root: string) {
+  const clock = new FakeClock()
+  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => ({}) as any, clock })
+  await daemon.start()
+  const inner = daemon as any
+  await vi.waitFor(() => expect(inner.sessionRetentionSweepInFlight).toBe(false))
+  return { daemon, inner }
+}
+
+describe('retired workspace roots are swept only while the agent is quiescent (decision 12)', () => {
+  it('keeps a retired root while a turn holds the agent and removes it once nothing does', async () => {
+    const root = scaffold()
+    const { daemon, inner } = await boot(root)
+    const subtree = seedRetiredRoot(root, 'acme/infra', '42')
+
+    // An admitted dispatch is exactly what the workspace admission fence protects the tree from.
+    const release = inner.beginActiveDispatch(AGENT, `slack:C1:t1:${AGENT}`)
+    await inner.sweepSessionRetention()
+    expect(existsSync(subtree)).toBe(true)
+
+    release()
+    await inner.sweepSessionRetention()
+    expect(existsSync(subtree)).toBe(false)
+    await daemon.stop()
+  }, 15_000)
+
+  it('keeps a retired root while a durable inbox row is still open for the agent', async () => {
+    const root = scaffold()
+    const { daemon, inner } = await boot(root)
+    const subtree = seedRetiredRoot(root, 'example-co/shared-library', '815')
+    expect(await inner.store.agentHasPendingInboxRows(AGENT)).toBe(false)
+    // Admitted work that has not reached a live dispatch yet: the row is the only thing that says so.
+    inner.store.agentHasPendingInboxRows = async () => true
+
+    await inner.sweepSessionRetention()
+    expect(existsSync(subtree)).toBe(true)
+
+    inner.store.agentHasPendingInboxRows = async () => false
+    await inner.sweepSessionRetention()
+    expect(existsSync(subtree)).toBe(false)
+    await daemon.stop()
+  }, 15_000)
+
+  it('leaves a subtree that carries no attestation, and one whose worktrees are not empty', async () => {
+    const root = scaffold()
+    const { daemon, inner } = await boot(root)
+    const attested = seedRetiredRoot(root, 'acme/infra', '42')
+    mkdirSync(join(attested, 'worktrees', 'a1b2c3'), { recursive: true })
+    const unattested = join(root, 'agents', AGENT, 'repos', 'acme', 'mystery')
+    mkdirSync(join(unattested, 'checkout'), { recursive: true })
+
+    await inner.sweepSessionRetention()
+
+    expect(existsSync(attested)).toBe(true)
+    expect(existsSync(unattested)).toBe(true)
+    await daemon.stop()
+  }, 15_000)
+})

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -17,6 +17,7 @@ import { delimiter, dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import { prepareRuntimeLaunch } from '../src/launch/prepare.js'
 import { composeRuntimeLaunch, runtimeSandboxReadRoots } from '../src/launch/compose.js'
+import { CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV } from '../src/acp/codex-permission-profiles.js'
 import { runtimeMemoryCapabilities } from '../src/memory/runtime/capabilities.js'
 import { MemoryProviderUnavailableError } from '../src/memory/provider.js'
 import type { RuntimeDef } from '../src/config/config-schema.js'
@@ -312,6 +313,40 @@ describe('prepareRuntimeLaunch', () => {
     const agent = prepareRuntimeLaunch(base)
     expect(agent.env.npm_config_cache).toBeUndefined()
     expect(coveredBy(agent.sandbox!.writable, join(hostHome, '.npm'))).toBe(false)
+  })
+
+  // multi-repository-workspaces.md decision 8: the secondary roots live under the agent dir, which
+  // the boundary denies wholesale — without this carve-back a sandboxed runtime cannot see them.
+  it('carves back the secondary-roots parent and every existing secondary .git for Codex', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const worktrees = join(scopeDir, 'worktrees')
+    const repos = join(scopeDir, 'repos')
+    const secondaryGit = join(repos, 'acme', 'infra', 'checkout', '.git')
+    mkdirSync(secondaryGit, { recursive: true })
+    mkdirSync(join(cwd, '.git'), { recursive: true })
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      trustedWorkspaceWriteRoots: [worktrees, repos],
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const policy = JSON.parse(readFileSync(launch.sandbox!.settingsPath, 'utf8'))
+    expect(coveredBy(policy.filesystem.allowWrite, realpathSync(repos))).toBe(true)
+    expect(coveredBy(policy.filesystem.allowRead, realpathSync(secondaryGit))).toBe(true)
+    // Codex's :workspace profile protects `.git`; both the primary's and each secondary's are
+    // reopened, and only because they sit inside a writable root.
+    const profile = JSON.parse(launch.env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]!) as { configOverrides: string[] }
+    const writes = profile.configOverrides.filter((value) => value.includes('filesystem='))
+    expect(writes.some((value) => value.includes(`"${realpathSync(secondaryGit)}" = "write"`))).toBe(true)
+    expect(writes.some((value) => value.includes(`"${realpathSync(join(cwd, '.git'))}" = "write"`))).toBe(true)
   })
 
   it('rejects root-level protected paths instead of generating an ineffective policy', () => {

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -7,6 +7,7 @@ import {
   readdirSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -474,16 +475,88 @@ describe('additionalWorkspaceDirectories with secondary roots', () => {
     ])
   })
 
-  it('leaves a session-isolated session exactly as it was', async () => {
-    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
-    serveAll(agent, { 'acme/infra': 'trunk' })
+  it('hands a session-isolated session each root at its own per-session worktree', async () => {
+    const agent = agentFixture([
+      { repoFullName: 'acme/infra', repoId: '42' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ])
+    serveAll(agent, { 'acme/infra': 'trunk', 'example-co/shared-library': 'release/v2' })
     const request = { sessionKey: 'session-a', isolation: 'session' as const }
+
     const cwd = await workspaces.prepareSessionWorkspace(agent, request)
 
+    // The SAME id across every root of one session, which is what makes the set removable as one.
+    const id = workspaces.sessionWorktreeId('session-a')
+    const subtree = (repoFullName: string) => join(workspaces.agentRootFor(agent), 'repos', ...repoFullName.split('/'))
+    const worktree = (repoFullName: string) => join(subtree(repoFullName), 'worktrees', id)
     expect(cwd).toBe(realpathSync(workspaces.sessionWorktreePath(agent, 'session-a')))
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([])
-    expect(workspaces.readySecondaryRoots(agent, { isolation: 'session' })).toEqual([])
-    expect(workspaces.readySecondaryRoots(agent, { isolation: 'shared' })).toHaveLength(1)
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([
+      realpathSync(worktree('acme/infra')),
+      realpathSync(worktree('example-co/shared-library'))
+    ])
+    // Each at its own default branch, and never the shared checkout a session-isolated agent asked
+    // not to be given.
+    expect(git(worktree('acme/infra'), ['rev-parse', 'HEAD']).trim()).toBe(
+      git(join(subtree('acme/infra'), 'checkout'), ['rev-parse', 'refs/remotes/origin/trunk']).trim()
+    )
+    expect(workspaces.readySecondaryRoots(agent, request).map((root) => [root.path, root.branch])).toEqual([
+      [realpathSync(worktree('acme/infra')), 'trunk'],
+      [realpathSync(worktree('example-co/shared-library')), 'release/v2']
+    ])
+    // The shared view of the same prepared set still names the checkouts.
+    expect(workspaces.readySecondaryRoots(agent, { isolation: 'shared' }).map((root) => root.path)).toEqual([
+      realpathSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout')),
+      realpathSync(join(workspaces.agentRootFor(agent), 'repos', 'example-co', 'shared-library', 'checkout'))
+    ])
+  })
+
+  it('gives a from-scratch agent secondary worktrees while its scratch directory stays the cwd', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }], { mode: 'from-scratch' })
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    const request = { sessionKey: 'session-a', isolation: 'session' as const }
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, request)
+
+    expect(cwd).toBe(agent.workspace.path)
+    const worktree = join(
+      workspaces.agentRootFor(agent),
+      'repos',
+      'acme',
+      'infra',
+      'worktrees',
+      workspaces.sessionWorktreeId('session-a')
+    )
+    expect(existsSync(join(worktree, '.git'))).toBe(true)
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([realpathSync(worktree)])
+  })
+
+  it('omits a root whose session worktree cannot be created and still prepares the session', async () => {
+    const agent = agentFixture([
+      { repoFullName: 'acme/infra', repoId: '42' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ])
+    serveAll(agent, { 'acme/infra': 'trunk', 'example-co/shared-library': 'main' })
+    await workspaces.prepareWorkspace(agent)
+    restoreAuthorizedOrigins(agent)
+    // A symlinked worktrees parent is refused for a secondary exactly as it is for the primary.
+    const subtree = join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra')
+    symlinkSync(tempRoot('ac-secondary-elsewhere-'), join(subtree, 'worktrees'), 'dir')
+    const request = { sessionKey: 'session-a', isolation: 'session' as const }
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, request)
+
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([
+      realpathSync(
+        join(
+          workspaces.agentRootFor(agent),
+          'repos',
+          'example-co',
+          'shared-library',
+          'worktrees',
+          workspaces.sessionWorktreeId('session-a')
+        )
+      )
+    ])
   })
 
   it('hands the roots to a from-scratch agent, which has no checkout of its own', async () => {
@@ -505,6 +578,189 @@ describe('additionalWorkspaceDirectories with secondary roots', () => {
     expect(await workspaces.prepareSecondaryRoots(agent)).toEqual([])
     expect(workspaces.readySecondaryRoots(agent)).toEqual([])
     expect(existsSync(join(workspaces.agentRootFor(agent), 'repos'))).toBe(false)
+  })
+})
+
+describe('sandbox write roots', () => {
+  it('grants the secondary parent to every sandboxed agent, scratch workspaces included', () => {
+    const repo = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    const scratch = agentFixture([], { mode: 'from-scratch' })
+
+    // A row added under a long-lived host must already be inside the boundary, so the PARENT is
+    // granted rather than the roots that happen to exist right now.
+    expect(workspaces.trustedWorkspaceWriteRoots(repo)).toEqual([
+      join(workspaces.agentRootFor(repo), 'worktrees'),
+      join(workspaces.agentRootFor(repo), 'repos')
+    ])
+    expect(workspaces.trustedWorkspaceWriteRoots(scratch)).toEqual([join(workspaces.agentRootFor(scratch), 'repos')])
+  })
+})
+
+describe('removeSessionWorktree across every root (decision 4)', () => {
+  it('removes the primary and every secondary worktree of one session', async () => {
+    const agent = agentFixture([
+      { repoFullName: 'acme/infra', repoId: '42' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ])
+    serveAll(agent, { 'acme/infra': 'trunk', 'example-co/shared-library': 'main' })
+    await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
+    const id = workspaces.sessionWorktreeId('session-a')
+    const secondary = (repoFullName: string) =>
+      join(workspaces.agentRootFor(agent), 'repos', ...repoFullName.split('/'), 'worktrees', id)
+
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+
+    expect(existsSync(workspaces.sessionWorktreePath(agent, 'session-a'))).toBe(false)
+    expect(existsSync(secondary('acme/infra'))).toBe(false)
+    expect(existsSync(secondary('example-co/shared-library'))).toBe(false)
+  })
+
+  it('keeps every root when one secondary worktree is dirty', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
+    const secondary = join(
+      workspaces.agentRootFor(agent),
+      'repos',
+      'acme',
+      'infra',
+      'worktrees',
+      workspaces.sessionWorktreeId('session-a')
+    )
+    writeFileSync(join(secondary, 'scratch.txt'), 'unsaved\n')
+
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({
+      outcome: 'retained',
+      reason: 'dirty'
+    })
+    expect(existsSync(join(secondary, 'scratch.txt'))).toBe(true)
+  })
+
+  it('removes a scratch agent’s secondary worktrees, which have no primary beside them', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }], { mode: 'from-scratch' })
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
+
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(workspaces.hasSessionWorktreeRoots(agent)).toBe(true)
+  })
+
+  it('reports absent when no root has a worktree for the session', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareWorkspace(agent)
+
+    expect(await workspaces.removeSessionWorktree(agent, 'session-never-opened')).toEqual({ outcome: 'absent' })
+  })
+})
+
+describe('retire → sweep → remove (decision 12)', () => {
+  /** The agent again, with a different set of authorized rows over the SAME agent directory. */
+  function reauthorized(agent: Agent, rows: Array<{ repoFullName: string; repoId: string }>): Agent {
+    return { ...agent, workspace: { ...agent.workspace, additionalRepos: rows } } as Agent
+  }
+
+  it('retires a subtree whose repository id is no longer authorized', async () => {
+    const agent = agentFixture([
+      { repoFullName: 'acme/infra', repoId: '42' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ])
+    serveAll(agent, { 'acme/infra': 'trunk', 'example-co/shared-library': 'main' })
+    await workspaces.prepareWorkspace(agent)
+    restoreAuthorizedOrigins(agent)
+
+    const after = reauthorized(agent, [{ repoFullName: 'acme/infra', repoId: '42' }])
+    expect(workspaces.retiredSecondaryRoots(after).map((root) => root.repoFullName)).toEqual([
+      'example-co/shared-library'
+    ])
+    // Retirement alone removes nothing, and it drops out of the hand-out at once.
+    await workspaces.prepareWorkspace(after)
+    expect(workspaces.readySecondaryRoots(after).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect(
+      existsSync(join(workspaces.agentRootFor(agent), 'repos', 'example-co', 'shared-library', 'checkout', '.git'))
+    ).toBe(true)
+  })
+
+  it('retires the directory a rename moved the repository out of, and re-authorizing un-retires in place', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareWorkspace(agent)
+
+    // Same repository id, new slug: the old directory is retired while the new one materializes.
+    const renamed = reauthorized(agent, [{ repoFullName: 'acme/infrastructure', repoId: '42' }])
+    expect(workspaces.retiredSecondaryRoots(renamed).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    // Re-authorizing the original slug un-retires it with nothing on disk having changed.
+    expect(workspaces.retiredSecondaryRoots(agent)).toEqual([])
+  })
+
+  it('leaves a subtree with no attestation alone rather than retiring it', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareWorkspace(agent)
+    rmSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', '.materialization.json'))
+
+    expect(workspaces.retiredSecondaryRoots(reauthorized(agent, []))).toEqual([])
+  })
+
+  it('refuses a retired root while any worktree of it survives, and removes it once none does', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
+    const after = reauthorized(agent, [])
+    const [retired] = workspaces.retiredSecondaryRoots(after)
+
+    expect(await workspaces.removeRetiredSecondaryRoot(after, retired!)).toEqual({
+      outcome: 'retained',
+      reason: 'worktrees'
+    })
+    expect(existsSync(retired!.subtree)).toBe(true)
+
+    await workspaces.removeSessionWorktree(after, 'session-a')
+    expect(await workspaces.removeRetiredSecondaryRoot(after, retired!)).toEqual({ outcome: 'removed' })
+    expect(existsSync(retired!.subtree)).toBe(false)
+  })
+
+  it('refuses a retired root whose checkout is dirty or holds commits no remote has', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareWorkspace(agent)
+    restoreAuthorizedOrigins(agent)
+    const after = reauthorized(agent, [])
+    const [retired] = workspaces.retiredSecondaryRoots(after)
+    writeFileSync(join(retired!.path, 'unsaved.txt'), 'work\n')
+
+    expect(await workspaces.removeRetiredSecondaryRoot(after, retired!)).toEqual({
+      outcome: 'retained',
+      reason: 'dirty'
+    })
+
+    git(retired!.path, ['add', '-A'])
+    git(retired!.path, ['commit', '-q', '-m', 'local only'])
+    expect(await workspaces.removeRetiredSecondaryRoot(after, retired!)).toEqual({
+      outcome: 'retained',
+      reason: 'unique-commits'
+    })
+    expect(existsSync(retired!.subtree)).toBe(true)
+  })
+
+  it('never follows a symlinked subtree', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareWorkspace(agent)
+    const after = reauthorized(agent, [])
+    const [retired] = workspaces.retiredSecondaryRoots(after)
+    // A subtree that is itself a symlink is refused, so removal can never reach what it points at.
+    const elsewhere = tempRoot('ac-secondary-outside-')
+    writeFileSync(join(elsewhere, 'precious.txt'), 'not ours\n')
+    rmSync(retired!.subtree, { recursive: true, force: true })
+    symlinkSync(elsewhere, retired!.subtree, 'dir')
+
+    const result = await workspaces.removeRetiredSecondaryRoot(after, retired!)
+
+    expect(result.outcome).toBe('failed')
+    expect(existsSync(join(elsewhere, 'precious.txt'))).toBe(true)
+    // And a symlinked subtree is not even listed as a candidate on the next pass.
+    expect(workspaces.retiredSecondaryRoots(after)).toEqual([])
   })
 })
 

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -615,7 +615,7 @@ describe('removeSessionWorktree across every root (decision 4)', () => {
     expect(existsSync(secondary('example-co/shared-library'))).toBe(false)
   })
 
-  it('keeps every root when one secondary worktree is dirty', async () => {
+  it('keeps the session when one secondary worktree is dirty, and reports that another root went', async () => {
     const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
     serveAll(agent, { 'acme/infra': 'trunk' })
     await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
@@ -629,11 +629,26 @@ describe('removeSessionWorktree across every root (decision 4)', () => {
     )
     writeFileSync(join(secondary, 'scratch.txt'), 'unsaved\n')
 
+    // `partial` is what the caller needs: the clean primary is already gone, so a warm attachment
+    // pointed at it is stale even though the retained secondary keeps the session.
     expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({
       outcome: 'retained',
-      reason: 'dirty'
+      reason: 'dirty',
+      partial: true
     })
     expect(existsSync(join(secondary, 'scratch.txt'))).toBe(true)
+    expect(existsSync(workspaces.sessionWorktreePath(agent, 'session-a'))).toBe(false)
+  })
+
+  it('ignores a subtree a failed clone left behind instead of failing the whole cleanup', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
+    // Exactly what a failed secondary preparation leaves: the subtree exists with no checkout and
+    // no worktrees, so there is no repository for Git to run in.
+    mkdirSync(join(workspaces.agentRootFor(agent), 'repos', 'example-co', 'shared-library'), { recursive: true })
+
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
   })
 
   it('removes a scratch agent’s secondary worktrees, which have no primary beside them', async () => {
@@ -736,6 +751,40 @@ describe('retire → sweep → remove (decision 12)', () => {
 
     git(retired!.path, ['add', '-A'])
     git(retired!.path, ['commit', '-q', '-m', 'local only'])
+    expect(await workspaces.removeRetiredSecondaryRoot(after, retired!)).toEqual({
+      outcome: 'retained',
+      reason: 'unique-commits'
+    })
+    expect(existsSync(retired!.subtree)).toBe(true)
+  })
+
+  it('refuses a retired root whose unique work is on another local ref, not the checked-out one', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    await workspaces.prepareWorkspace(agent)
+    restoreAuthorizedOrigins(agent)
+    const after = reauthorized(agent, [])
+    const [retired] = workspaces.retiredSecondaryRoots(after)
+    // Removing the clone destroys its whole object store, so what the CHECKED-OUT branch can reach
+    // does not speak for the work: a side branch and a stash are both invisible from `trunk`.
+    git(retired!.path, ['checkout', '-q', '-b', 'side'])
+    writeFileSync(join(retired!.path, 'sidework.txt'), 'work\n')
+    git(retired!.path, ['add', '-A'])
+    git(retired!.path, ['commit', '-q', '-m', 'side only'])
+    git(retired!.path, ['checkout', '-q', 'trunk'])
+    expect(git(retired!.path, ['status', '--porcelain']).trim()).toBe('')
+
+    expect(await workspaces.removeRetiredSecondaryRoot(after, retired!)).toEqual({
+      outcome: 'retained',
+      reason: 'unique-commits'
+    })
+
+    git(retired!.path, ['branch', '-q', '-D', 'side'])
+    writeFileSync(join(retired!.path, 'stashed.txt'), 'work\n')
+    git(retired!.path, ['add', '-A'])
+    git(retired!.path, ['stash', '-q'])
+    expect(git(retired!.path, ['status', '--porcelain']).trim()).toBe('')
+
     expect(await workspaces.removeRetiredSecondaryRoot(after, retired!)).toEqual({
       outcome: 'retained',
       reason: 'unique-commits'


### PR DESCRIPTION
Phase 4 of [`docs/designs/multi-repository-workspaces.md`](docs/designs/multi-repository-workspaces.md): decisions **4** and **12**, plus the sandbox carve-back the previous phase (#1220) left out.

## What and why

**Decision 4 — isolation applies to every root uniformly.** #1220 materialized the secondary roots and handed them to `shared`-isolation sessions; a `session`-isolated one got nothing secondary at all, because handing it the shared checkout would defeat exactly the isolation it asked for. It now gets a per-session worktree of every ready root at `<agentRoot>/repos/<owner>/<repo>/worktrees/<sid>`, keyed by the **same** `<sid>` as the primary's, and those worktrees — not the checkouts — are what `additionalWorkspaceDirectories` and the standing context hand out. A root whose worktree cannot be created is omitted from that session and logged; it never fails the session (decision 7's degradation, one level down). A `from-scratch` primary keeps its scratch directory as `cwd` and still gets its secondaries' worktrees (decision 5).

A same-repository review needed no new code: `request.review` still applies only to the primary, and the secondaries ride along as default-branch reference worktrees, which is what decision 5 asks for.

**`removeSessionWorktree` covers every root.** The primary when there is one, plus every `repos/*/*` subtree on disk — retired ones included, since their worktrees belong to the same session and nothing else would ever remove them. Aggregated conservatively: any retained keeps the session (with that reason), any failure is reported as a failure, otherwise removed, otherwise absent. Every per-root protection is the existing `removeRootSessionWorktree`, unchanged.

**Decision 12 — retire → sweep → remove.** Retirement is implicit: a subtree whose `.materialization.json` names a repository the agent's `additionalRepos` no longer authorize (by `repoId`, and a directory a rename has moved the repository out of) is retired. It drops out of the hand-out at once and **nothing is deleted at reconcile or session start**. `retiredSecondaryRoots` lists them; `removeRetiredSecondaryRoot` removes one only when `worktrees/` is empty and the checkout passes the same clean-tree / no-unique-commit checks a worktree gets, behind the same symlink and containment refusals. The daemon runs it from the idle sweep only, per agent, inside `withWorkspaceAdmissionFence`, with a per-agent "any live work" predicate re-checked inside the fence. Re-authorizing a repository un-retires its root in place — `prepareSecondaryRoot` already accepts a checkout whose marker matches.

**Sandbox carve-back.** `sandboxBoundary` denies read on the whole agent directory and re-opens only `cwd`, the runtime HOME, memory and the trusted write roots — so `<agentRoot>/repos` was invisible to a confined runtime, which #1220 missed. It is now a trusted workspace write root for **every** sandboxed agent (scratch included: a host is long-lived per agent, so a row added later must already be inside the boundary), and the Codex permission profile additionally re-opens the `.git` of every secondary checkout that exists at spawn.

## What a reviewer should check

- **Nothing is removed outside the fenced idle sweep.** `removeRetiredSecondaryRoot` is called from one place; the agent-idle check is taken optimistically and again *inside* `withWorkspaceAdmissionFence`, which publishes the fence synchronously so no turn can be admitted (and therefore no workspace prepared) during the awaited Git operations. Retirement itself is a read.
- **A retired root gets the same protections as a worktree** — clean `status --porcelain`, `rev-list --count HEAD --not --remotes == 0`, a non-empty `worktrees/` refuses, a bare non-empty directory with no `.git` refuses, and a symlinked subtree is neither listed nor followed.
- **Scratch agents.** `cleanupSessionWorktree`'s gate moved from "the primary is a Git repository" to "any root that can hold a worktree", since a scratch agent now has secondary worktrees to collect; `shared` isolation is still `not_applicable`.
- **Sandbox boundary** — `<agentRoot>/repos` is a write root for every sandboxed agent, and only the `.git` directories that sit inside a writable root are re-opened for Codex.

## Deliberately not here

The cross-repository review `cwd` swap (decision 6) — resolving a hook's repository to a root and giving that root's exact checkout the `cwd`. That is the next PR. Cluster daemons are still skipped throughout (`sandboxMode`), as in #1220.

## Tests

`test/workspace-secondary-roots.test.ts` gains the session-isolation layout and hand-out, the scratch case, per-root worktree failure, cross-root removal and its aggregation, retirement by id and by rename, and every `removeRetiredSecondaryRoot` refusal — all against real repositories through the existing runner seam. `test/daemon-retired-roots-sweep.test.ts` is new and covers the daemon's gate: a retired root is kept while a turn (or an open durable inbox row) holds the agent and removed once nothing does. `test/runtime-launch.test.ts` covers the boundary.
