### PR TITLE
feat(web): say that additional repositories are checked out alongside the workspace

### DIFF
--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -264,7 +264,7 @@ export function WorkspaceCard({
               <span
                 key={r.id}
                 className="inline-flex h-6 flex-none items-center gap-[6px] rounded-[5px] border border-(--border-subtle) bg-(--surface-card) py-0 pr-1 pl-2"
-                title={`${r.repoFullName} — ${r.access} access, checked out alongside the workspace; added by ${creatorLabel(r.createdBy, me)}`}
+                title={`${r.repoFullName} — ${r.access} access${agent.placementKind === 'pool' ? '' : ', checked out alongside the workspace'}; added by ${creatorLabel(r.createdBy, me)}`}
               >
                 <span className="imark h-[14px] w-[14px] border-0 bg-transparent">
                   <GithubMark />

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -27,7 +27,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import { GithubMark, LoadingState } from '@/components/marks'
 import { Icon } from '@/components/ui'
-import type { Agent, WorkspaceStatusInfo } from '@/lib/data'
+import { isPoolPlacementKind, type Agent, type WorkspaceStatusInfo } from '@/lib/data'
 import { creatorLabel, fetchAgentRepos } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { useProfile } from '@/lib/profile'
@@ -77,7 +77,9 @@ export function WorkspaceCard({
 }) {
   const { activeOrg } = useOrgs()
   const { me } = useProfile()
-  const { refresh } = useConsoleData()
+  const { refresh, orgSetIds } = useConsoleData()
+  // Pool placements do not materialize secondary roots yet, so their chips stay authorization-only.
+  const poolPlaced = isPoolPlacementKind(agent.placementKind, agent.setId, orgSetIds)
   // Non-null ⇒ the unified workspace editor is open. The authorization
   // shortcut starts it directly in its additional-repository subview.
   const [editState, setEditState] = useState<{
@@ -264,7 +266,7 @@ export function WorkspaceCard({
               <span
                 key={r.id}
                 className="inline-flex h-6 flex-none items-center gap-[6px] rounded-[5px] border border-(--border-subtle) bg-(--surface-card) py-0 pr-1 pl-2"
-                title={`${r.repoFullName} — ${r.access} access${agent.placementKind === 'pool' ? '' : ', checked out alongside the workspace'}; added by ${creatorLabel(r.createdBy, me)}`}
+                title={`${r.repoFullName} — ${r.access} access${poolPlaced ? '' : ', checked out alongside the workspace'}; added by ${creatorLabel(r.createdBy, me)}`}
               >
                 <span className="imark h-[14px] w-[14px] border-0 bg-transparent">
                   <GithubMark />

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -264,7 +264,7 @@ export function WorkspaceCard({
               <span
                 key={r.id}
                 className="inline-flex h-6 flex-none items-center gap-[6px] rounded-[5px] border border-(--border-subtle) bg-(--surface-card) py-0 pr-1 pl-2"
-                title={`${r.repoFullName} — ${r.access} access, added by ${creatorLabel(r.createdBy, me)}`}
+                title={`${r.repoFullName} — ${r.access} access, checked out alongside the workspace; added by ${creatorLabel(r.createdBy, me)}`}
               >
                 <span className="imark h-[14px] w-[14px] border-0 bg-transparent">
                   <GithubMark />

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.test.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 const repositoryModal = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }))
 
 vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (path: string) => path }) }))
+vi.mock('@/lib/data-context', () => ({ useConsoleData: () => ({ orgSetIds: new Set<string>() }) }))
 vi.mock('@/components/console/modals/AddAgentRepoModal', () => ({
   default: (props: Record<string, unknown>) => {
     repositoryModal.props = props

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -599,7 +599,7 @@ export default function EditWorkspaceModal({
                 <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
                   {githubWorkspace && !githubWorkspace.installationId
                     ? 'This manual checkout can authorize only its workspace repository. Changes here apply immediately.'
-                    : 'Authorize repositories this agent can use in addition to its workspace. Changes here apply immediately.'}
+                    : 'Authorize repositories this agent can use in addition to its workspace. Each one is checked out alongside the workspace and available in the agent’s sessions; a review of its pull requests runs on an exact checkout of it. Changes here apply immediately.'}
                 </div>
               </div>
               {!manualWorkspaceAuthorization && (

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -8,7 +8,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { GithubMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
-import { agentLabel, type Agent } from '@/lib/data'
+import { agentLabel, isPoolPlacementKind, type Agent } from '@/lib/data'
+import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
 import {
   ApiError,
@@ -74,6 +75,9 @@ export default function EditWorkspaceModal({
   onChanged: () => void
 }) {
   const { orgPath } = useOrgs()
+  const { orgSetIds } = useConsoleData()
+  // Pool placements do not materialize secondary roots yet, so they keep the authorization-only wording.
+  const poolPlaced = isPoolPlacementKind(agent.placementKind, agent.setId, orgSetIds)
   const githubWorkspace = agent.workspace.mode === 'github' ? agent.workspace : null
   const currentWrite = githubWorkspace ? !!githubWorkspace.installationId && githubWorkspace.gitAccess !== 'read' : null
   const currentAgentDir = agentDirInputValue(githubWorkspace?.agentDir)
@@ -599,7 +603,7 @@ export default function EditWorkspaceModal({
                 <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
                   {githubWorkspace && !githubWorkspace.installationId
                     ? 'This manual checkout can authorize only its workspace repository. Changes here apply immediately.'
-                    : agent.placementKind === 'pool'
+                    : poolPlaced
                       ? 'Authorize repositories this agent can use in addition to its workspace. Changes here apply immediately.'
                       : 'Authorize repositories this agent can use in addition to its workspace. Each one is checked out alongside the workspace and available in the agent’s sessions; a review of its pull requests runs on an exact checkout of it. Changes here apply immediately.'}
                 </div>

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -599,7 +599,9 @@ export default function EditWorkspaceModal({
                 <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
                   {githubWorkspace && !githubWorkspace.installationId
                     ? 'This manual checkout can authorize only its workspace repository. Changes here apply immediately.'
-                    : 'Authorize repositories this agent can use in addition to its workspace. Each one is checked out alongside the workspace and available in the agent’s sessions; a review of its pull requests runs on an exact checkout of it. Changes here apply immediately.'}
+                    : agent.placementKind === 'pool'
+                      ? 'Authorize repositories this agent can use in addition to its workspace. Changes here apply immediately.'
+                      : 'Authorize repositories this agent can use in addition to its workspace. Each one is checked out alongside the workspace and available in the agent’s sessions; a review of its pull requests runs on an exact checkout of it. Changes here apply immediately.'}
                 </div>
               </div>
               {!manualWorkspaceAuthorization && (


### PR DESCRIPTION
## What

Two copy changes in the console's workspace editor and Workspace card: the "Additional repositories" section and each repository chip now say the repository is **checked out alongside the workspace** and available in the agent's sessions, and that a review of its pull requests runs on an exact checkout of it.

## Why

Phase 6 of `docs/designs/multi-repository-workspaces.md`: authorizing a repository is no longer only a credential grant. The daemon materializes every authorized repository as a secondary workspace root (#1220, #1221) and reviews its pull requests on an exact checkout, so the wording that presented the list as "repositories this agent can use" undersold what the row does.

## Notes for review

Text only — no behavior, no new fields, no per-root status yet.