### PR TITLE
feat(daemon): exact review checkout for a pull request on a secondary repository

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6201,6 +6201,8 @@ export class Daemon {
       cleanupSessionWorktree: (rec) => this.cleanupSessionWorktree(rec),
       prepareAgentWorkspace: (agent, expectedWarmHost, request) =>
         this.prepareAgentWorkspace(agent, expectedWarmHost, request),
+      sessionHasReferenceDirectories: (agent, request) =>
+        this.workspaces.sessionAdditionalRoots(agent, request).length > 0,
       warmHostFor: (agentId) => (this.readyHosts.has(agentId) ? this.hosts.get(agentId) : undefined),
       anchorTrigger: (agentId, msg, target, anchorText, label, safetyGithubLane) =>
         this.anchorTrigger(agentId, msg, target, anchorText, label, safetyGithubLane),

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -105,6 +105,8 @@ export interface GithubReviewHost {
     expectedWarmHost?: AcpHost,
     request?: PrepareSessionWorkspaceRequest
   ): Promise<string>
+  /** Whether a prepared session was handed reference directories beside its working directory. */
+  sessionHasReferenceDirectories(agent: Agent, request: PrepareSessionWorkspaceRequest): boolean
   /** The agent's warm ACP host, only once it is ready. */
   warmHostFor(agentId: string): AcpHost | undefined
   anchorTrigger(
@@ -440,7 +442,20 @@ export class GithubReviewOrchestrator {
     }
   }
 
-  githubWorkspaceMatches(agent: Agent, github: GithubHookMetadata): boolean {
+  /**
+   * The workspace root a hook's repository resolves to: the primary, one of the agent's authorized
+   * additional repositories, or none at all — which is what keeps the revision-only fallback a
+   * safety net rather than the ordinary path (multi-repository-workspaces.md decision 6).
+   */
+  reviewRootFor(agent: Agent, github: GithubHookMetadata): 'primary' | { repoFullName: string } | undefined {
+    if (this.githubWorkspaceMatches(agent, github)) return 'primary'
+    const hookRepo = githubRepoKey(github.repoFullName)
+    if (hookRepo === undefined) return undefined
+    const row = (agent.workspace.additionalRepos ?? []).find((entry) => githubRepoKey(entry.repoFullName) === hookRepo)
+    return row ? { repoFullName: row.repoFullName } : undefined
+  }
+
+  private githubWorkspaceMatches(agent: Agent, github: GithubHookMetadata): boolean {
     if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) return false
     try {
       const clone = normalizeGitCloneUrl(agent.workspace.gitRepo)
@@ -515,25 +530,34 @@ export class GithubReviewOrchestrator {
         return { workspaceIsolation: 'shared' as const, forceWorkspaceIsolation: true as const }
       }
     }
-    if (!this.githubWorkspaceMatches(agent, github)) {
+    // A secondary root reviews exactly like the primary, with the root swapped (decision 6); no root
+    // at all is what the revision-only fallback exists for.
+    const reviewRoot = this.reviewRootFor(agent, github)
+    if (reviewRoot === undefined) {
       return useRevisionOnlyWorkspace()
     }
 
     try {
-      const preparedWorkspaceCwd = await this.host.prepareAgentWorkspace(agent, warmHost, {
+      const request: PrepareSessionWorkspaceRequest = {
         sessionKey: key,
         isolation: 'session',
         initiatedBy: await this.sessionInitiatorLabel(entry.msg),
+        ...(reviewRoot === 'primary' ? {} : { reviewRepoFullName: reviewRoot.repoFullName }),
         review: {
           pullNumber: github.pullNumber,
           baseSha: github.baseSha,
           headSha: github.headSha,
           ...(github.mergeCommitSha ? { mergeCommitSha: github.mergeCommitSha } : {})
         }
-      })
+      }
+      const preparedWorkspaceCwd = await this.host.prepareAgentWorkspace(agent, warmHost, request)
       entry.msg.text +=
         `\n\nTrusted review workspace:\n${revisionLine}\n` +
-        'The daemon fetched and verified this isolated checkout at the exact head or a merge whose parents are exactly the base and head above. Before trusting local traces, verify `git rev-parse HEAD`; do not switch to or inspect another checkout.'
+        'The daemon fetched and verified this isolated checkout at the exact head or a merge whose parents are exactly the base and head above. Before trusting local traces, verify `git rev-parse HEAD`; do not switch to or inspect another checkout.' +
+        // Decision 10: the other roots stand at their default branches, so only the cwd is the revision.
+        (this.host.sessionHasReferenceDirectories(agent, request)
+          ? ' Additional repositories are available as separate directories at their default branches for reference only; the reviewed revision is the working directory.'
+          : '')
       return { workspaceIsolation: 'session', forceWorkspaceIsolation: true, preparedWorkspaceCwd }
     } catch (err) {
       this.log.warn(
@@ -930,5 +954,16 @@ export class GithubReviewOrchestrator {
       // inline ahead of the footer sentence.
       ...(agent?.iconUrl ? { iconUrl: agent.iconUrl } : {})
     }
+  }
+}
+
+/** A github.com `owner/repo` as roots are compared by it: case-insensitive, blind to `.git`. */
+function githubRepoKey(repoFullName: string): string | undefined {
+  try {
+    return normalizeGithubRepoUrl(repoFullName)
+      .replace(/\.git$/i, '')
+      .toLowerCase()
+  } catch {
+    return undefined
   }
 }

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -553,7 +553,7 @@ export class SessionManager {
         fileSecrets: fileSecrets.map((m) => ({ sourceVar: m.sourceVar, pointerVar: m.convention.pointerVar })),
         // The same list `additionalWorkspaceDirectories` hands the runtime, read from the same
         // accessor, so the prompt names exactly the directories the session got.
-        workspaceRoots: this.workspaces.readySecondaryRoots(agent, workspaceRequest),
+        workspaceRoots: this.workspaces.sessionAdditionalRoots(agent, workspaceRequest),
         usesSessionTitleTool,
         needsReplyToParent,
         memoryIndex,

--- a/packages/daemon/src/session/turn/standing-context.ts
+++ b/packages/daemon/src/session/turn/standing-context.ts
@@ -63,7 +63,7 @@ export type StandingContextInput = {
   envSecretNames: readonly string[]
   /** Secrets materialized to a private file instead of reaching the child env. */
   fileSecrets: readonly StandingContextFileSecret[]
-  /** Secondary workspace roots this session is handed as additional directories. */
+  /** The workspace roots this session is handed as additional directories, beside its own cwd. */
   workspaceRoots?: readonly { path: string; repoFullName: string; branch: string }[]
   usesSessionTitleTool: boolean
   needsReplyToParent: boolean
@@ -200,17 +200,18 @@ function buildAgentMeta(input: StandingContextInput): string {
   ].join('\n')
 }
 
-// The session's secondary workspace roots (multi-repository-workspaces.md decision 10). Standing
+// The session's additional workspace roots (multi-repository-workspaces.md decision 10). Standing
 // like the meta block: the set is fixed for the session, and the model must not mistake a root's
-// default branch for anything the current task is pinned to.
+// default branch for anything the current task is pinned to — the cwd may be a reviewed secondary
+// root, which puts the PRIMARY on this list instead.
 export function buildWorkspaceRootsAppend(
   roots: readonly { path: string; repoFullName: string; branch: string }[] | undefined
 ): string {
   if (!roots?.length) return ''
   return [
     '# Additional repositories',
-    'Additional repositories checked out for this session (each at its default branch; the working ' +
-      'directory stays the primary workspace):',
+    'Additional repositories checked out for this session (each at its default branch, for reference ' +
+      'only; the working directory is none of them):',
     ...roots.map((root) => `- ${root.path} — ${root.repoFullName} (${root.branch})`)
   ].join('\n')
 }

--- a/packages/daemon/src/workspace/secondary-layout.ts
+++ b/packages/daemon/src/workspace/secondary-layout.ts
@@ -9,6 +9,12 @@ import { join } from 'node:path'
 export const SECONDARY_ROOTS_DIR = 'repos'
 /** What a secondary root's subtree records about the checkout beside it. */
 export const SECONDARY_MATERIALIZATION_FILE = '.materialization.json'
+
+/** Where a root's subtree records that one session's working directory is ITS worktree, not the
+ *  primary's — durable, because a restart re-prepares the same session from the disk alone. */
+export function sessionCwdMarkerIn(subtree: string, sessionWorktreeId: string): string {
+  return join(subtree, `.session-cwd-${sessionWorktreeId}.json`)
+}
 /** GitHub's own owner/repository charset, which is also a plain path segment. */
 const REPO_SEGMENT = /^[A-Za-z0-9._-]+$/
 

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -43,6 +43,7 @@ import {
   isRepoSegment,
   secondaryRootsDirIn,
   secondarySubtreesIn,
+  sessionCwdMarkerIn,
   SECONDARY_MATERIALIZATION_FILE,
   type SecondarySubtree
 } from './secondary-layout.js'
@@ -127,16 +128,6 @@ export type SessionRootScope = Pick<PrepareSessionWorkspaceRequest, 'isolation' 
   sessionKey?: string
 }
 
-/** The roots one prepared session stands in and rides with, as its later hand-outs read them. */
-interface SessionRootRecord {
-  /** The reviewed secondary root that took the working directory. */
-  repoFullName: string
-  /** That root's own session checkout — where the runtime was told to stand. */
-  cwd: string
-  /** Every other root the session was handed, in hand-out order. */
-  additional: ReadyWorkspaceRoot[]
-}
-
 /** What a secondary root's `.materialization.json` records about the checkout beside it. */
 interface SecondaryMaterialization {
   repoId: string
@@ -188,11 +179,6 @@ export class WorkspaceManager {
   private readonly secondaryInFlight = new Map<string, Promise<SecondaryWorkspaceRoot | undefined>>()
   /** Secondary roots prepared for an agent's current sessions — what the synchronous hand-out reads. */
   private readonly readyRoots = new Map<string, SecondaryWorkspaceRoot[]>()
-  // What one session's roots resolved to, recorded only when a review made a SECONDARY root its cwd
-  // (decision 5). Written where the cwd is decided and read by the synchronous hand-outs that follow,
-  // so the additional directories and the standing context cannot disagree with the directories the
-  // runtime was actually given — including for a caller whose own isolation says otherwise.
-  private readonly sessionRoots = new Map<string, SessionRootRecord>()
   private gitRunnerResolver: WorkspaceGitRunnerResolver | undefined
   private pathClearer: WorkspacePathClearer | undefined
   private workspacesLiveInSandboxes = false
@@ -376,10 +362,7 @@ export class WorkspaceManager {
     if (this.sandboxMode) return []
     // The root a review made the cwd is not an additional directory of its own session.
     const ready = this.sessionSecondaryRoots(agent, this.sessionCwdRepoFullName(agent, request))
-    const id =
-      request?.isolation === 'session' && request.sessionKey !== undefined
-        ? this.sessionWorktreeId(request.sessionKey)
-        : undefined
+    const id = this.sessionWorktreeIdFor(agent, request)
     const roots: ReadyWorkspaceRoot[] = []
     for (const root of ready) {
       if (id === undefined) {
@@ -404,8 +387,6 @@ export class WorkspaceManager {
    * `agentDir` cwd back to it instead.
    */
   sessionAdditionalRoots(agent: Agent, request?: SessionRootScope): readonly ReadyWorkspaceRoot[] {
-    const recorded = this.sessionRootRecord(agent, request)
-    if (recorded) return recorded.additional
     const primary = this.primaryReferenceRoot(agent, request)
     const secondaries = this.readySecondaryRoots(agent, request)
     return primary ? [primary, ...secondaries] : secondaries
@@ -415,7 +396,7 @@ export class WorkspaceManager {
   private primaryReferenceRoot(agent: Agent, request?: SessionRootScope): ReadyWorkspaceRoot | undefined {
     if (this.sandboxMode || agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) return undefined
     if (this.sessionCwdRepoFullName(agent, request) === undefined) return undefined
-    const path = this.sessionRootPath(agent.workspace.path, this.worktreesPathFor(agent), request)
+    const path = this.sessionRootPath(agent, agent.workspace.path, this.worktreesPathFor(agent), request)
     // Same proof the secondaries answer to: a checkout the session did not get is not named here.
     if (!existsSync(join(path, '.git'))) return undefined
     return {
@@ -425,11 +406,19 @@ export class WorkspaceManager {
     }
   }
 
-  /** One root's directory for a session: its per-session worktree under `session`, the checkout itself under `shared`. */
-  private sessionRootPath(checkout: string, worktreesPath: string, request?: SessionRootScope): string {
-    return request?.isolation === 'session' && request.sessionKey !== undefined
-      ? join(worktreesPath, this.sessionWorktreeId(request.sessionKey))
-      : checkout
+  /** One root's directory for a session: its per-session worktree, or the checkout itself when the
+   *  session shares every root (decision 4). */
+  private sessionRootPath(agent: Agent, checkout: string, worktreesPath: string, request?: SessionRootScope): string {
+    const id = this.sessionWorktreeIdFor(agent, request)
+    return id === undefined ? checkout : join(worktreesPath, id)
+  }
+
+  /** The id naming this session's worktrees, or undefined when it shares the roots' checkouts. A
+   *  session whose cwd is a reviewed root is per-session by construction, whatever the caller says. */
+  private sessionWorktreeIdFor(agent: Agent, request?: SessionRootScope): string | undefined {
+    if (request?.sessionKey === undefined) return undefined
+    if (request.isolation !== 'session' && this.sessionCwdRepoFullName(agent, request) === undefined) return undefined
+    return this.sessionWorktreeId(request.sessionKey)
   }
 
   /** The prepared secondary roots minus one, named case-insensitively. */
@@ -438,25 +427,44 @@ export class WorkspaceManager {
     return (this.readyRoots.get(agent.id) ?? []).filter((root) => repoKey(root.repoFullName) !== skip)
   }
 
-  /** The secondary root holding this session's cwd: named by the request, else the one preparation
-   *  recorded for that session key. */
+  /** The secondary root holding this session's cwd: named by the request, else attested on disk. */
   private sessionCwdRepoFullName(agent: Agent, request?: SessionRootScope): string | undefined {
     if (request?.reviewRepoFullName !== undefined) return request.reviewRepoFullName
-    return this.sessionRootRecord(agent, request)?.repoFullName
+    if (request?.sessionKey === undefined) return undefined
+    return this.sessionCwdSubtree(agent, request.sessionKey)?.repoFullName
   }
 
-  /** What preparation resolved for this session — absent unless a review made a secondary root the
-   *  cwd, and skipped whenever the caller names the reviewed root itself (which resolves live). */
-  private sessionRootRecord(agent: Agent, request?: SessionRootScope): SessionRootRecord | undefined {
-    if (request?.reviewRepoFullName !== undefined || request?.sessionKey === undefined) return undefined
-    return this.sessionRoots.get(sessionScopeKey(agent.id, request.sessionKey))
+  /**
+   * The secondary subtree whose worktree IS one session's working directory, read off the disk.
+   *
+   * Durable on purpose: a host eviction or a daemon restart re-prepares the same session from a
+   * request that carries no review at all, and process memory would have the session silently resume
+   * in the primary while its standing prompt still names the reviewed revision as the cwd. Both the
+   * marker and that worktree must be present — a marker whose worktree the GC already took names
+   * nothing, so a leftover cannot capture a later session that hashes to the same id.
+   */
+  private sessionCwdSubtree(agent: Agent, sessionKey: string): SecondarySubtree | undefined {
+    const id = this.sessionWorktreeId(sessionKey)
+    return secondarySubtreesIn(this.agentRootFor(agent)).find(
+      (entry) => existsSync(sessionCwdMarkerIn(entry.subtree, id)) && existsSync(join(entry.worktreesPath, id, '.git'))
+    )
   }
 
-  /** Record (or forget) the roots one session resolved to. */
-  private recordSessionRoots(agentId: string, sessionKey: string, record?: SessionRootRecord): void {
-    const key = sessionScopeKey(agentId, sessionKey)
-    if (record === undefined) this.sessionRoots.delete(key)
-    else this.sessionRoots.set(key, record)
+  /** Attest that this session's working directory is one root's worktree, or drop that attestation. */
+  private recordSessionCwdRoot(subtree: string, sessionWorktreeId: string, repoFullName?: string): void {
+    const marker = sessionCwdMarkerIn(subtree, sessionWorktreeId)
+    if (repoFullName === undefined) {
+      rmSync(marker, { force: true })
+      return
+    }
+    const temp = `${marker}.tmp`
+    try {
+      writeFileSync(temp, JSON.stringify({ repoFullName }, null, 2) + '\n', { mode: 0o600 })
+      renameSync(temp, marker)
+    } catch (err) {
+      rmSync(temp, { force: true })
+      throw err
+    }
   }
 
   /**
@@ -993,8 +1001,6 @@ export class WorkspaceManager {
    */
   async removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
     const roots = this.sessionWorktreeRoots(agent)
-    // Nothing outlives the session's worktrees, the record of which roots it stood in included.
-    this.recordSessionRoots(agent.id, sessionKey)
     if (roots.length === 0) return { outcome: 'failed', error: 'agent workspace is not a Git repository' }
     const id = this.sessionWorktreeId(sessionKey)
     let retained: SessionWorktreeRemoval | undefined
@@ -1081,9 +1087,11 @@ export class WorkspaceManager {
     id: string
   ): Promise<SessionWorktreeRemoval> {
     const rootGit = () => this.runnerFor(agent.id, root.path).withEnv(workspaceGitLocalEnv())
-    // Drop the stale Git registration and this worktree's daemon-owned review refs.
-    // Ref deletion is best-effort: most worktrees never had review refs.
+    // Drop the stale Git registration, this worktree's daemon-owned review refs, and the attestation
+    // that it was a session's working directory. Ref deletion is best-effort: most worktrees never
+    // had review refs.
     const cleanupRegistrations = async () => {
+      this.recordSessionCwdRoot(dirname(root.path), id)
       await rootGit().raw(['worktree', 'prune'])
       for (const name of ['base', 'head', 'merge']) {
         await rootGit()
@@ -1305,19 +1313,18 @@ export class WorkspaceManager {
       if (agent.workspace.mode !== 'git-repo' || request.isolation !== 'session' || request.review) {
         throw new Error('github revision-only workspace requires an isolated git-repo review session')
       }
-      this.recordSessionRoots(agent.id, request.sessionKey)
       return this.prepareGithubRevisionOnlyWorkspace(agent, this.sessionWorktreeId(request.sessionKey))
     }
     // Resolved before anything is materialized: a review naming a repository this agent has no root
     // for must leave no worktree behind for the caller's revision-only fallback to step around.
     const reviewRoot = this.reviewedSecondaryRoot(agent, request)
     const primary = await this.prepareWorkspace(agent, opts)
-    if (request.isolation === 'shared') {
-      this.recordSessionRoots(agent.id, request.sessionKey)
-      return primary
-    }
-    if (reviewRoot) return await this.prepareReviewedRootWorkspace(agent, reviewRoot, request, opts)
-    this.recordSessionRoots(agent.id, request.sessionKey)
+    if (request.isolation === 'shared') return primary
+    // A session that already stands in a reviewed root keeps standing there. The request that
+    // re-prepares it after a host eviction or a daemon restart carries no review at all, so the
+    // attestation on disk — not this process's memory — is what holds the working directory still.
+    const cwdRoot = reviewRoot ?? this.resumedReviewedRoot(agent, request)
+    if (cwdRoot) return await this.prepareReviewedRootWorkspace(agent, cwdRoot, request, opts)
 
     // A from-scratch primary keeps its scratch directory as the cwd — isolation has no clone to
     // branch it off — but its secondaries still get per-session worktrees (decisions 4 and 5).
@@ -1354,23 +1361,24 @@ export class WorkspaceManager {
     if (!prepared) {
       throw new Error(`github review checkout of ${root.repoFullName} is unavailable to agent "${agent.id}"`)
     }
-    const cwd = this.resolveAcpCwd(await this.prepareRootSessionWorktree(agent, prepared, request), undefined)
+    const cwd = await this.prepareRootSessionWorktree(agent, prepared, request)
+    // Attested once that worktree exists, so a later preparation of the same session — including one
+    // in a fresh process, carrying no review — resolves the same working directory.
+    this.recordSessionCwdRoot(dirname(prepared.path), this.sessionWorktreeId(request.sessionKey), prepared.repoFullName)
     await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent, prepared.repoFullName), request)
-    // Recorded once the whole session exists, so every later hand-out names these exact directories
-    // however the caller describes the session's isolation.
-    const scope: SessionRootScope = {
-      isolation: 'session',
-      sessionKey: request.sessionKey,
-      reviewRepoFullName: prepared.repoFullName
-    }
-    this.recordSessionRoots(agent.id, request.sessionKey, {
-      repoFullName: prepared.repoFullName,
-      cwd,
-      additional: [...this.sessionAdditionalRoots(agent, scope)]
-    })
     // The same post-steps the primary cwd gets, deliberately: skills install into the working
     // directory, and the reviewed root is the one the model stands in. `agentDir` is the primary's.
-    return this.withSkills(agent, cwd, opts)
+    return this.withSkills(agent, this.resolveAcpCwd(cwd, undefined), opts)
+  }
+
+  /** The root a session already stands in, as a root this preparation can drive — nothing when the
+   *  attestation names a repository the agent's rows no longer authorize. */
+  private resumedReviewedRoot(agent: Agent, request: SessionRootScope): SecondaryWorkspaceRoot | undefined {
+    if (this.sandboxMode || request.sessionKey === undefined) return undefined
+    const recorded = this.sessionCwdSubtree(agent, request.sessionKey)
+    if (recorded === undefined) return undefined
+    const key = repoKey(recorded.repoFullName)
+    return this.secondaryRoots(agent).find((entry) => repoKey(entry.repoFullName) === key)
   }
 
   /** The roots that ride along this session, with the label their per-root failure is reported under. */
@@ -1706,20 +1714,16 @@ export class WorkspaceManager {
   /** The directory this session's cwd must sit under: the reviewed secondary root's, else the
    *  primary's. Undefined when the agent has no primary checkout and no review named a root. */
   private sessionCwdRootPath(agent: Agent, request?: SessionRootScope): string | undefined {
-    // A recorded session names its own working directory, so its containment never depends on what
-    // the caller believes this session's isolation to be.
-    const recorded = this.sessionRootRecord(agent, request)
-    if (recorded) return recorded.cwd
-    const reviewed = request?.reviewRepoFullName
+    const reviewed = this.sessionCwdRepoFullName(agent, request)
     if (reviewed !== undefined) {
       const key = repoKey(reviewed)
-      const root = this.secondaryRoots(agent).find((entry) => repoKey(entry.repoFullName) === key)
-      // A root the rows no longer name cannot vouch for the cwd; fall through to the primary, which
-      // the cwd is not under either, so the containment check refuses it.
-      if (root) return this.sessionRootPath(root.path, root.worktreesPath, request)
+      const root = secondarySubtreesIn(this.agentRootFor(agent)).find((entry) => repoKey(entry.repoFullName) === key)
+      // A subtree that is no longer on disk cannot vouch for the cwd; fall through to the primary,
+      // which the cwd is not under either, so the containment check refuses it.
+      if (root) return this.sessionRootPath(agent, root.path, root.worktreesPath, request)
     }
     if (agent.workspace.mode !== 'git-repo') return undefined
-    return this.sessionRootPath(agent.workspace.path, this.worktreesPathFor(agent), request)
+    return this.sessionRootPath(agent, agent.workspace.path, this.worktreesPathFor(agent), request)
   }
 
   resolveAcpCwd(workspaceRoot: string, agentDir: string | undefined): string {
@@ -1971,11 +1975,6 @@ function repoKey(repoFullName: string): string {
     .trim()
     .replace(/\.git$/i, '')
     .toLowerCase()
-}
-
-/** One agent's session, as the per-session root snapshot keys it. */
-function sessionScopeKey(agentId: string, sessionKey: string): string {
-  return `${agentId}\u0000${sessionKey}`
 }
 
 /** `ref: refs/heads/<name>\tHEAD` from `ls-remote --symref`; undefined when HEAD names no branch. */

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -13,6 +13,7 @@ import {
 } from 'node:fs'
 import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path'
 import {
+  gitRepoLabel,
   normalizeGitCloneUrl,
   normalizeGithubRepoUrl,
   normalizeGitUrl,
@@ -120,8 +121,21 @@ export type RetiredRootRemoval =
   | { outcome: 'retained'; reason: 'worktrees' | 'dirty' | 'unique-commits' }
   | { outcome: 'failed'; error: string }
 
-/** How one session addresses the agent's roots: the isolation, plus the key that names its worktrees. */
-export type SessionRootScope = Pick<PrepareSessionWorkspaceRequest, 'isolation'> & { sessionKey?: string }
+/** How one session addresses the agent's roots: the isolation, the key that names its worktrees, and
+ *  the secondary root a review made the working directory. */
+export type SessionRootScope = Pick<PrepareSessionWorkspaceRequest, 'isolation' | 'reviewRepoFullName'> & {
+  sessionKey?: string
+}
+
+/** The roots one prepared session stands in and rides with, as its later hand-outs read them. */
+interface SessionRootRecord {
+  /** The reviewed secondary root that took the working directory. */
+  repoFullName: string
+  /** That root's own session checkout — where the runtime was told to stand. */
+  cwd: string
+  /** Every other root the session was handed, in hand-out order. */
+  additional: ReadyWorkspaceRoot[]
+}
 
 /** What a secondary root's `.materialization.json` records about the checkout beside it. */
 interface SecondaryMaterialization {
@@ -137,6 +151,10 @@ export interface PrepareSessionWorkspaceRequest {
    * worktree's branch. Presentation only; never an identity or auth input. */
   initiatedBy?: string
   review?: GithubReviewWorkspaceRevision
+  /** `owner/repo` the review is about — only meaningful with `review`. When it names a secondary
+   * root, that root's exact worktree is this session's cwd and every other root rides along at its
+   * default branch (decisions 5 and 6). Absent, or the primary, is the ordinary review. */
+  reviewRepoFullName?: string
   /** Use an empty daemon-owned cwd when an exact local review checkout is
    * unavailable. The model must inspect the trusted revision through GitHub. */
   githubReviewRevisionOnly?: true
@@ -170,6 +188,11 @@ export class WorkspaceManager {
   private readonly secondaryInFlight = new Map<string, Promise<SecondaryWorkspaceRoot | undefined>>()
   /** Secondary roots prepared for an agent's current sessions — what the synchronous hand-out reads. */
   private readonly readyRoots = new Map<string, SecondaryWorkspaceRoot[]>()
+  // What one session's roots resolved to, recorded only when a review made a SECONDARY root its cwd
+  // (decision 5). Written where the cwd is decided and read by the synchronous hand-outs that follow,
+  // so the additional directories and the standing context cannot disagree with the directories the
+  // runtime was actually given — including for a caller whose own isolation says otherwise.
+  private readonly sessionRoots = new Map<string, SessionRootRecord>()
   private gitRunnerResolver: WorkspaceGitRunnerResolver | undefined
   private pathClearer: WorkspacePathClearer | undefined
   private workspacesLiveInSandboxes = false
@@ -304,6 +327,34 @@ export class WorkspaceManager {
     return roots.sort((a, b) => (a.repoFullName < b.repoFullName ? -1 : a.repoFullName > b.repoFullName ? 1 : 0))
   }
 
+  /** The primary clone's `owner/repo`, when it names github.com — an App-backed URL is canonicalized
+   *  there by the daemon, an anonymous one must already say so. */
+  private primaryRepoFullName(agent: Agent): string | undefined {
+    if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) return undefined
+    if (!this.usesGithubApp(agent) && !this.isTrustedGithubOrigin(agent.workspace.gitRepo)) return undefined
+    const label = gitRepoLabel(agent.workspace.gitRepo)
+    return label.split('/').length === 2 ? label : undefined
+  }
+
+  /**
+   * The secondary root a review names, or undefined when it names the primary (or names nothing) and
+   * the session is the ordinary one.
+   *
+   * A name that matches no root at all THROWS: the caller asked for an exact checkout of a repository
+   * this agent has no root for, which is precisely the case the review orchestrator degrades to
+   * revision-only inspection.
+   */
+  reviewedSecondaryRoot(agent: Agent, scope: SessionRootScope): SecondaryWorkspaceRoot | undefined {
+    const name = scope.reviewRepoFullName
+    if (name === undefined) return undefined
+    const wanted = repoKey(name)
+    const root = this.secondaryRoots(agent).find((entry) => repoKey(entry.repoFullName) === wanted)
+    if (root) return root
+    const primary = this.primaryRepoFullName(agent)
+    if (primary !== undefined && repoKey(primary) === wanted) return undefined
+    throw new Error(`github review repository "${name}" is not a workspace root of agent "${agent.id}"`)
+  }
+
   /**
    * The prepared secondary roots one session is handed — the single answer the additional
    * directories and the standing context are both derived from, so the prompt cannot name a
@@ -316,7 +367,8 @@ export class WorkspaceManager {
    */
   readySecondaryRoots(agent: Agent, request?: SessionRootScope): readonly ReadyWorkspaceRoot[] {
     if (this.sandboxMode) return []
-    const ready = this.readyRoots.get(agent.id) ?? []
+    // The root a review made the cwd is not an additional directory of its own session.
+    const ready = this.sessionSecondaryRoots(agent, this.sessionCwdRepoFullName(agent, request))
     const id =
       request?.isolation === 'session' && request.sessionKey !== undefined
         ? this.sessionWorktreeId(request.sessionKey)
@@ -334,6 +386,70 @@ export class WorkspaceManager {
       roots.push({ path: realpathSync(cwd), repoFullName: root.repoFullName, branch: root.branch })
     }
     return roots
+  }
+
+  /**
+   * Every root one session is handed as an additional directory — the secondaries above, plus the
+   * PRIMARY when it is not this session's working directory (decision 5).
+   *
+   * The primary only ever rides along when a review made a secondary root the cwd; an ordinary
+   * session stands in the primary itself, where {@link additionalWorkspaceDirectories} widens an
+   * `agentDir` cwd back to it instead.
+   */
+  sessionAdditionalRoots(agent: Agent, request?: SessionRootScope): readonly ReadyWorkspaceRoot[] {
+    const recorded = this.sessionRootRecord(agent, request)
+    if (recorded) return recorded.additional
+    const primary = this.primaryReferenceRoot(agent, request)
+    const secondaries = this.readySecondaryRoots(agent, request)
+    return primary ? [primary, ...secondaries] : secondaries
+  }
+
+  /** The primary's own session directory, as a reference root beside a reviewed secondary's cwd. */
+  private primaryReferenceRoot(agent: Agent, request?: SessionRootScope): ReadyWorkspaceRoot | undefined {
+    if (this.sandboxMode || agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) return undefined
+    if (this.sessionCwdRepoFullName(agent, request) === undefined) return undefined
+    const path = this.sessionRootPath(agent.workspace.path, this.worktreesPathFor(agent), request)
+    // Same proof the secondaries answer to: a checkout the session did not get is not named here.
+    if (!existsSync(join(path, '.git'))) return undefined
+    return {
+      path: realpathSync(path),
+      repoFullName: gitRepoLabel(agent.workspace.gitRepo),
+      branch: agent.workspace.gitBranch
+    }
+  }
+
+  /** One root's directory for a session: its per-session worktree under `session`, the checkout itself under `shared`. */
+  private sessionRootPath(checkout: string, worktreesPath: string, request?: SessionRootScope): string {
+    return request?.isolation === 'session' && request.sessionKey !== undefined
+      ? join(worktreesPath, this.sessionWorktreeId(request.sessionKey))
+      : checkout
+  }
+
+  /** The prepared secondary roots minus one, named case-insensitively. */
+  private sessionSecondaryRoots(agent: Agent, excluded?: string): SecondaryWorkspaceRoot[] {
+    const skip = excluded === undefined ? undefined : repoKey(excluded)
+    return (this.readyRoots.get(agent.id) ?? []).filter((root) => repoKey(root.repoFullName) !== skip)
+  }
+
+  /** The secondary root holding this session's cwd: named by the request, else the one preparation
+   *  recorded for that session key. */
+  private sessionCwdRepoFullName(agent: Agent, request?: SessionRootScope): string | undefined {
+    if (request?.reviewRepoFullName !== undefined) return request.reviewRepoFullName
+    return this.sessionRootRecord(agent, request)?.repoFullName
+  }
+
+  /** What preparation resolved for this session — absent unless a review made a secondary root the
+   *  cwd, and skipped whenever the caller names the reviewed root itself (which resolves live). */
+  private sessionRootRecord(agent: Agent, request?: SessionRootScope): SessionRootRecord | undefined {
+    if (request?.reviewRepoFullName !== undefined || request?.sessionKey === undefined) return undefined
+    return this.sessionRoots.get(sessionScopeKey(agent.id, request.sessionKey))
+  }
+
+  /** Record (or forget) the roots one session resolved to. */
+  private recordSessionRoots(agentId: string, sessionKey: string, record?: SessionRootRecord): void {
+    const key = sessionScopeKey(agentId, sessionKey)
+    if (record === undefined) this.sessionRoots.delete(key)
+    else this.sessionRoots.set(key, record)
   }
 
   /**
@@ -870,6 +986,8 @@ export class WorkspaceManager {
    */
   async removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
     const roots = this.sessionWorktreeRoots(agent)
+    // Nothing outlives the session's worktrees, the record of which roots it stood in included.
+    this.recordSessionRoots(agent.id, sessionKey)
     if (roots.length === 0) return { outcome: 'failed', error: 'agent workspace is not a Git repository' }
     const id = this.sessionWorktreeId(sessionKey)
     let retained: SessionWorktreeRemoval | undefined
@@ -1180,10 +1298,19 @@ export class WorkspaceManager {
       if (agent.workspace.mode !== 'git-repo' || request.isolation !== 'session' || request.review) {
         throw new Error('github revision-only workspace requires an isolated git-repo review session')
       }
+      this.recordSessionRoots(agent.id, request.sessionKey)
       return this.prepareGithubRevisionOnlyWorkspace(agent, this.sessionWorktreeId(request.sessionKey))
     }
+    // Resolved before anything is materialized: a review naming a repository this agent has no root
+    // for must leave no worktree behind for the caller's revision-only fallback to step around.
+    const reviewRoot = this.reviewedSecondaryRoot(agent, request)
     const primary = await this.prepareWorkspace(agent, opts)
-    if (request.isolation === 'shared') return primary
+    if (request.isolation === 'shared') {
+      this.recordSessionRoots(agent.id, request.sessionKey)
+      return primary
+    }
+    if (reviewRoot) return await this.prepareReviewedRootWorkspace(agent, reviewRoot, request, opts)
+    this.recordSessionRoots(agent.id, request.sessionKey)
 
     // A from-scratch primary keeps its scratch directory as the cwd — isolation has no clone to
     // branch it off — but its secondaries still get per-session worktrees (decisions 4 and 5).
@@ -1191,34 +1318,90 @@ export class WorkspaceManager {
       agent.workspace.mode === 'git-repo'
         ? await this.prepareRootSessionWorktree(agent, this.primaryRoot(agent), request)
         : undefined
-    await this.prepareSecondarySessionWorktrees(agent, request)
+    await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent), request)
     if (cwd === undefined) return primary
     const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
     return this.withSkills(agent, this.resolveAcpCwd(cwd, agentDir), opts)
   }
 
   /**
-   * Every prepared secondary root's worktree for this session, at the SAME id as the primary's.
+   * A review whose subject is a secondary root: that root's exact worktree is the session's cwd, and
+   * the primary plus the remaining secondaries ride along at their default branches (decisions 5/6).
+   *
+   * The root is materialized HERE even when it is a submodule of another one (decision 11): such a
+   * root is withheld from ordinary sessions as an additional directory, but a review of its own pull
+   * request still gets the exact checkout every authorized repository is promised.
+   */
+  private async prepareReviewedRootWorkspace(
+    agent: Agent,
+    root: SecondaryWorkspaceRoot,
+    request: PrepareSessionWorkspaceRequest,
+    opts: PrepareWorkspaceOptions
+  ): Promise<string> {
+    // Preparation already materialized every root it hands out; only a root it WITHHELD — a submodule
+    // root, or one it skipped — is materialized here, so an ordinary session's converge/pull is not
+    // repeated and decision 11 still owes this repository an exact checkout of its own pull request.
+    const prepared =
+      this.sessionSecondaryRoots(agent).find((entry) => repoKey(entry.repoFullName) === repoKey(root.repoFullName)) ??
+      (await this.prepareSecondaryRoot(agent, root))
+    if (!prepared) {
+      throw new Error(`github review checkout of ${root.repoFullName} is unavailable to agent "${agent.id}"`)
+    }
+    const cwd = this.resolveAcpCwd(await this.prepareRootSessionWorktree(agent, prepared, request), undefined)
+    await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent, prepared.repoFullName), request)
+    // Recorded once the whole session exists, so every later hand-out names these exact directories
+    // however the caller describes the session's isolation.
+    const scope: SessionRootScope = {
+      isolation: 'session',
+      sessionKey: request.sessionKey,
+      reviewRepoFullName: prepared.repoFullName
+    }
+    this.recordSessionRoots(agent.id, request.sessionKey, {
+      repoFullName: prepared.repoFullName,
+      cwd,
+      additional: [...this.sessionAdditionalRoots(agent, scope)]
+    })
+    // The same post-steps the primary cwd gets, deliberately: skills install into the working
+    // directory, and the reviewed root is the one the model stands in. `agentDir` is the primary's.
+    return this.withSkills(agent, cwd, opts)
+  }
+
+  /** The roots that ride along this session, with the label their per-root failure is reported under. */
+  private referenceRootsOf(agent: Agent, cwdRepoFullName?: string): { root: WorkspaceRoot; label: string }[] {
+    return [
+      ...(cwdRepoFullName !== undefined && agent.workspace.mode === 'git-repo'
+        ? [{ root: this.primaryRoot(agent), label: 'the workspace repository' }]
+        : []),
+      ...this.sessionSecondaryRoots(agent, cwdRepoFullName).map((root) => ({
+        root,
+        label: `additional repository ${root.repoFullName}`
+      }))
+    ]
+  }
+
+  /**
+   * Every reference root's worktree for this session, at the SAME id as the working directory's.
    *
    * Never a review checkout: the reviewed revision belongs to the one root the session is about,
    * and the others ride along at their default branch as references (decision 5). Per-root failure
    * is local like a clone failure (decision 7) — that root is absent from this session and nothing
    * else about it changes.
    */
-  private async prepareSecondarySessionWorktrees(agent: Agent, request: PrepareSessionWorkspaceRequest): Promise<void> {
+  private async prepareReferenceSessionWorktrees(
+    agent: Agent,
+    roots: readonly { root: WorkspaceRoot; label: string }[],
+    request: PrepareSessionWorkspaceRequest
+  ): Promise<void> {
     const rootRequest: PrepareSessionWorkspaceRequest = {
       sessionKey: request.sessionKey,
       isolation: 'session',
       ...(request.initiatedBy !== undefined ? { initiatedBy: request.initiatedBy } : {})
     }
-    for (const root of this.readyRoots.get(agent.id) ?? []) {
+    for (const { root, label } of roots) {
       try {
         await this.prepareRootSessionWorktree(agent, root, rootRequest)
       } catch (err) {
-        workspaceLog.warn(
-          `workspace: additional repository ${root.repoFullName} has no session worktree for agent ` +
-            `"${agent.id}" (${formatErr(err)})`
-        )
+        workspaceLog.warn(`workspace: ${label} has no session worktree for agent "${agent.id}" (${formatErr(err)})`)
       }
     }
   }
@@ -1485,7 +1668,7 @@ export class WorkspaceManager {
   additionalWorkspaceDirectories(
     agent: Agent,
     cwd: string,
-    request?: Pick<PrepareSessionWorkspaceRequest, 'sessionKey' | 'isolation'>
+    request?: Pick<PrepareSessionWorkspaceRequest, 'sessionKey' | 'isolation' | 'reviewRepoFullName'>
   ): string[] {
     if (this.sandboxMode) {
       if (agent.workspace.mode !== 'git-repo') return []
@@ -1496,20 +1679,40 @@ export class WorkspaceManager {
       if (agentDir === undefined) return []
       return [agentDir.split('/').reduce((path) => dirname(path), cwd)]
     }
-    // Widening an `agentDir` cwd back to its checkout root — the primary's, and only a git-repo has one.
+    // Containment is proven against the root this session actually stands in — the primary, or the
+    // secondary a review made the working directory (decision 5). Widening an `agentDir` cwd back to
+    // its checkout root is the primary's alone; a reviewed root has no `agentDir`.
     const widened: string[] = []
-    if (agent.workspace.mode === 'git-repo') {
-      const expectedRoot =
-        request?.isolation === 'session' ? this.sessionWorktreePath(agent, request.sessionKey) : agent.workspace.path
-      const root = realpathSync(expectedRoot)
+    const cwdRoot = this.sessionCwdRootPath(agent, request)
+    if (cwdRoot !== undefined) {
+      const root = realpathSync(cwdRoot)
       const canonicalCwd = realpathSync(cwd)
       const rel = relative(root, canonicalCwd)
       if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
         throw new Error(`prepared workspace cwd "${cwd}" resolves outside its checkout root`)
       }
-      if (root !== canonicalCwd) widened.push(root)
+      if (root !== canonicalCwd && this.sessionCwdRepoFullName(agent, request) === undefined) widened.push(root)
     }
-    return [...widened, ...this.readySecondaryRoots(agent, request).map((root) => root.path)]
+    return [...widened, ...this.sessionAdditionalRoots(agent, request).map((root) => root.path)]
+  }
+
+  /** The directory this session's cwd must sit under: the reviewed secondary root's, else the
+   *  primary's. Undefined when the agent has no primary checkout and no review named a root. */
+  private sessionCwdRootPath(agent: Agent, request?: SessionRootScope): string | undefined {
+    // A recorded session names its own working directory, so its containment never depends on what
+    // the caller believes this session's isolation to be.
+    const recorded = this.sessionRootRecord(agent, request)
+    if (recorded) return recorded.cwd
+    const reviewed = request?.reviewRepoFullName
+    if (reviewed !== undefined) {
+      const key = repoKey(reviewed)
+      const root = this.secondaryRoots(agent).find((entry) => repoKey(entry.repoFullName) === key)
+      // A root the rows no longer name cannot vouch for the cwd; fall through to the primary, which
+      // the cwd is not under either, so the containment check refuses it.
+      if (root) return this.sessionRootPath(root.path, root.worktreesPath, request)
+    }
+    if (agent.workspace.mode !== 'git-repo') return undefined
+    return this.sessionRootPath(agent.workspace.path, this.worktreesPathFor(agent), request)
   }
 
   resolveAcpCwd(workspaceRoot: string, agentDir: string | undefined): string {
@@ -1753,6 +1956,19 @@ export class WorkspaceManager {
     this.cloneInFlight.set(key, p)
     return p
   }
+}
+
+/** The identity two `owner/repo` names are compared by: case-insensitive and blind to a `.git` suffix. */
+function repoKey(repoFullName: string): string {
+  return repoFullName
+    .trim()
+    .replace(/\.git$/i, '')
+    .toLowerCase()
+}
+
+/** One agent's session, as the per-session root snapshot keys it. */
+function sessionScopeKey(agentId: string, sessionKey: string): string {
+  return `${agentId}\u0000${sessionKey}`
 }
 
 /** `ref: refs/heads/<name>\tHEAD` from `ls-remote --symref`; undefined when HEAD names no branch. */

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -349,7 +349,14 @@ export class WorkspaceManager {
     if (name === undefined) return undefined
     const wanted = repoKey(name)
     const root = this.secondaryRoots(agent).find((entry) => repoKey(entry.repoFullName) === wanted)
-    if (root) return root
+    if (root) {
+      // A sandboxed workspace materializes one checkout through the shim tunnel, so a secondary root
+      // has nowhere to live there — the review keeps the revision-only fallback, as it does today.
+      if (this.sandboxMode) {
+        throw new Error(`github review of ${root.repoFullName} needs a local workspace root (agent "${agent.id}")`)
+      }
+      return root
+    }
     const primary = this.primaryRepoFullName(agent)
     if (primary !== undefined && repoKey(primary) === wanted) return undefined
     throw new Error(`github review repository "${name}" is not a workspace root of agent "${agent.id}"`)

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -1313,18 +1313,23 @@ export class WorkspaceManager {
       if (agent.workspace.mode !== 'git-repo' || request.isolation !== 'session' || request.review) {
         throw new Error('github revision-only workspace requires an isolated git-repo review session')
       }
-      return this.prepareGithubRevisionOnlyWorkspace(agent, this.sessionWorktreeId(request.sessionKey))
+      const id = this.sessionWorktreeId(request.sessionKey)
+      // The cwd becomes the primary's own empty directory, so no root may go on attesting that this
+      // session stands in it — a surviving attestation would refuse the very fallback prepared here.
+      this.forgetSessionCwdRoots(agent, id)
+      return this.prepareGithubRevisionOnlyWorkspace(agent, id)
     }
     // Resolved before anything is materialized: a review naming a repository this agent has no root
     // for must leave no worktree behind for the caller's revision-only fallback to step around.
     const reviewRoot = this.reviewedSecondaryRoot(agent, request)
     const primary = await this.prepareWorkspace(agent, opts)
-    if (request.isolation === 'shared') return primary
     // A session that already stands in a reviewed root keeps standing there. The request that
-    // re-prepares it after a host eviction or a daemon restart carries no review at all, so the
-    // attestation on disk — not this process's memory — is what holds the working directory still.
+    // re-prepares it after a host eviction or a daemon restart carries no review at all — and, for a
+    // scratch workspace, reports `shared` isolation — so this is resolved BEFORE either shortcut: the
+    // attestation on disk, not this process's memory, is what holds the working directory still.
     const cwdRoot = reviewRoot ?? this.resumedReviewedRoot(agent, request)
     if (cwdRoot) return await this.prepareReviewedRootWorkspace(agent, cwdRoot, request, opts)
+    if (request.isolation === 'shared') return primary
 
     // A from-scratch primary keeps its scratch directory as the cwd — isolation has no clone to
     // branch it off — but its secondaries still get per-session worktrees (decisions 4 and 5).
@@ -1362,13 +1367,23 @@ export class WorkspaceManager {
       throw new Error(`github review checkout of ${root.repoFullName} is unavailable to agent "${agent.id}"`)
     }
     const cwd = await this.prepareRootSessionWorktree(agent, prepared, request)
-    // Attested once that worktree exists, so a later preparation of the same session — including one
-    // in a fresh process, carrying no review — resolves the same working directory.
-    this.recordSessionCwdRoot(dirname(prepared.path), this.sessionWorktreeId(request.sessionKey), prepared.repoFullName)
     await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent, prepared.repoFullName), request)
     // The same post-steps the primary cwd gets, deliberately: skills install into the working
     // directory, and the reviewed root is the one the model stands in. `agentDir` is the primary's.
-    return this.withSkills(agent, this.resolveAcpCwd(cwd, undefined), opts)
+    const acpCwd = await this.withSkills(agent, this.resolveAcpCwd(cwd, undefined), opts)
+    // Attested LAST, because the attestation says a session was placed here: a preparation that
+    // failed a post-step must leave the caller's revision-only fallback a primary cwd it can use,
+    // while a later preparation of a placed session — in a fresh process, carrying no review —
+    // resolves this same working directory.
+    this.recordSessionCwdRoot(dirname(prepared.path), this.sessionWorktreeId(request.sessionKey), prepared.repoFullName)
+    return acpCwd
+  }
+
+  /** Drop every root's attestation that it holds one session's working directory. */
+  private forgetSessionCwdRoots(agent: Agent, sessionWorktreeId: string): void {
+    for (const entry of secondarySubtreesIn(this.agentRootFor(agent))) {
+      this.recordSessionCwdRoot(entry.subtree, sessionWorktreeId)
+    }
   }
 
   /** The root a session already stands in, as a root this preparation can drive — nothing when the

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -694,6 +694,159 @@ describe('Daemon rd/msg hook fires', () => {
     )
     expect(entry.msg.text).toContain('Trusted review workspace')
     expect(entry.msg.text).toContain('verify `git rev-parse HEAD`')
+    // A session with no other root has no reference directories to speak of.
+    expect(entry.msg.text).not.toContain('Additional repositories are available')
+    await daemon.stop()
+  })
+
+  it('reviews an authorized additional repository against that root, with the others as references', async () => {
+    const root = scaffold({
+      workspace: {
+        mode: 'git-repo',
+        path: join(tmpdir(), 'agentconnect-secondary-review-workspace'),
+        gitRepo: 'https://github.com/acme/primary-service',
+        gitBranch: 'main',
+        gitCredential: 'github-app',
+        pullOnNewSession: true,
+        additionalRepos: [{ repoFullName: 'acme/infra', repoId: '123' }]
+      }
+    })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
+    await daemon.start()
+    const dispatchDaemonId = (daemon as any).cfg.daemonId as string
+    const prepare = vi
+      .spyOn(daemon as any, 'prepareAgentWorkspace')
+      .mockResolvedValue('/agent/repos/acme/infra/worktrees/review')
+    // What preparation would have handed this session beside the reviewed root's own worktree.
+    vi.spyOn((daemon as any).workspaces, 'sessionAdditionalRoots').mockReturnValue([
+      { path: '/agent/worktrees/review', repoFullName: 'acme/primary-service', branch: 'main' }
+    ])
+    const headSha = 'a'.repeat(40)
+    const baseSha = 'b'.repeat(40)
+    const entry = {
+      msg: { text: 'Review this pull request.' },
+      hookContext: {
+        hookId: HOOK_ID,
+        agentId: AGENT_ID,
+        deliveryKey: 'secondary-review',
+        firedAt: new Date().toISOString(),
+        event: 'pull_request:synchronize',
+        snapshot: {
+          configRevision: '1',
+          dispatchRevision: '1',
+          dispatchDaemonId,
+          reviewPolicy: 'full',
+          reportingMode: 'check',
+          gateMode: 'informational'
+        },
+        github: {
+          repoId: '123',
+          repoFullName: 'acme/infra',
+          sourceInstallationId: '456',
+          subjectKind: 'pull_request',
+          pullNumber: 461,
+          headSha,
+          baseSha,
+          reportSha: headSha
+        }
+      }
+    }
+
+    await expect(
+      (daemon as any).githubReviews.prepareGithubReviewWorkspace(
+        entry,
+        'hook:acme/infra#461',
+        (daemon as any).agents.get(AGENT_ID)
+      )
+    ).resolves.toEqual({
+      workspaceIsolation: 'session',
+      forceWorkspaceIsolation: true,
+      preparedWorkspaceCwd: '/agent/repos/acme/infra/worktrees/review'
+    })
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({ id: AGENT_ID }),
+      undefined,
+      expect.objectContaining({
+        sessionKey: 'hook:acme/infra#461',
+        isolation: 'session',
+        reviewRepoFullName: 'acme/infra',
+        review: { pullNumber: 461, baseSha, headSha }
+      })
+    )
+    expect(entry.msg.text).toContain('Trusted review workspace')
+    expect(entry.msg.text).toContain(
+      'Additional repositories are available as separate directories at their default branches for reference only; the reviewed revision is the working directory.'
+    )
+    await daemon.stop()
+  })
+
+  it('falls back to revision-only inspection for a repository that is no root of this agent', async () => {
+    const root = scaffold({
+      workspace: {
+        mode: 'git-repo',
+        path: join(tmpdir(), 'agentconnect-unauthorized-review-workspace'),
+        gitRepo: 'https://github.com/acme/primary-service',
+        gitBranch: 'main',
+        gitCredential: 'github-app',
+        pullOnNewSession: true,
+        additionalRepos: [{ repoFullName: 'acme/infra', repoId: '123' }]
+      }
+    })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
+    await daemon.start()
+    const dispatchDaemonId = (daemon as any).cfg.daemonId as string
+    const prepare = vi.spyOn(daemon as any, 'prepareAgentWorkspace').mockResolvedValue('/agent/worktrees/revision-only')
+    const headSha = 'a'.repeat(40)
+    const baseSha = 'b'.repeat(40)
+    const entry = {
+      msg: { text: 'Review this pull request.' },
+      hookContext: {
+        hookId: HOOK_ID,
+        agentId: AGENT_ID,
+        deliveryKey: 'unauthorized-review',
+        firedAt: new Date().toISOString(),
+        event: 'pull_request:synchronize',
+        snapshot: {
+          configRevision: '1',
+          dispatchRevision: '1',
+          dispatchDaemonId,
+          reviewPolicy: 'full',
+          reportingMode: 'check',
+          gateMode: 'informational'
+        },
+        github: {
+          repoId: '999',
+          repoFullName: 'example-co/elsewhere',
+          sourceInstallationId: '456',
+          subjectKind: 'pull_request',
+          pullNumber: 461,
+          headSha,
+          baseSha,
+          reportSha: headSha
+        }
+      }
+    }
+
+    await expect(
+      (daemon as any).githubReviews.prepareGithubReviewWorkspace(
+        entry,
+        'hook:example-co/elsewhere#461',
+        (daemon as any).agents.get(AGENT_ID)
+      )
+    ).resolves.toEqual({
+      workspaceIsolation: 'session',
+      forceWorkspaceIsolation: true,
+      preparedWorkspaceCwd: '/agent/worktrees/revision-only'
+    })
+    // No exact checkout is attempted at all: the only preparation is the empty revision-only cwd.
+    expect(prepare).toHaveBeenCalledTimes(1)
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({ id: AGENT_ID }),
+      undefined,
+      expect.objectContaining({ githubReviewRevisionOnly: true })
+    )
+    expect(entry.msg.text).toContain('Trusted review revision')
+    expect(entry.msg.text).toContain('No trusted local pull-request checkout is available')
     await daemon.stop()
   })
 

--- a/packages/daemon/test/github/review-root.test.ts
+++ b/packages/daemon/test/github/review-root.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import type { GithubHookMetadata } from '@agentconnect.md/protocol'
+import type { Agent } from '../../src/agents/agent-schema.js'
+import { GithubReviewOrchestrator } from '../../src/github/review-orchestrator.js'
+
+// Which workspace root a hook's repository resolves to (multi-repository-workspaces.md decision 6).
+// Pure resolution: it reads the agent definition alone, so the host port is never touched.
+const orchestrator = new GithubReviewOrchestrator({} as never)
+
+function agentFixture(
+  workspace: Partial<Agent['workspace']> & Record<string, unknown> = {},
+  additionalRepos: Array<{ repoFullName: string; repoId: string }> = []
+): Agent {
+  return {
+    id: 'bot-review',
+    name: 'bot-review',
+    status: 'active',
+    runtime: 'claude',
+    workspace: {
+      mode: 'git-repo',
+      isolation: 'shared',
+      path: '/srv/agents/bot-review/workspace',
+      gitRepo: 'https://github.com/acme/primary-service.git',
+      gitBranch: 'main',
+      gitCredential: 'github-app',
+      additionalRepos,
+      pullOnNewSession: true,
+      skills: [],
+      ...workspace
+    },
+    integrations: [],
+    output: { mode: 'medium' },
+    permissions: { policy: 'ask', autoApprove: [] },
+    crons: []
+  } as unknown as Agent
+}
+
+function hook(repoFullName: string): GithubHookMetadata {
+  return {
+    repoId: '123',
+    repoFullName,
+    sourceInstallationId: '456',
+    subjectKind: 'pull_request',
+    pullNumber: 42
+  } as GithubHookMetadata
+}
+
+describe('reviewRootFor', () => {
+  it('resolves the workspace repository to the primary root', () => {
+    expect(orchestrator.reviewRootFor(agentFixture(), hook('acme/primary-service'))).toBe('primary')
+  })
+
+  it('resolves an authorized additional repository to its own root, whatever its case or suffix', () => {
+    const agent = agentFixture({}, [
+      { repoFullName: 'example-co/shared-library', repoId: '815' },
+      { repoFullName: 'acme/infra', repoId: '42' }
+    ])
+
+    expect(orchestrator.reviewRootFor(agent, hook('Acme/Infra'))).toEqual({ repoFullName: 'acme/infra' })
+    expect(orchestrator.reviewRootFor(agent, hook('example-co/shared-library.git'))).toEqual({
+      repoFullName: 'example-co/shared-library'
+    })
+  })
+
+  it('resolves a repository that is neither the workspace nor an authorized row to no root', () => {
+    const agent = agentFixture({}, [{ repoFullName: 'acme/infra', repoId: '42' }])
+
+    expect(orchestrator.reviewRootFor(agent, hook('example-co/elsewhere'))).toBeUndefined()
+    expect(orchestrator.reviewRootFor(agent, hook('not a repository'))).toBeUndefined()
+  })
+
+  it('never reads an anonymous non-GitHub workspace as the hook repository', () => {
+    const agent = agentFixture({ gitRepo: 'https://git.example.test/acme/primary-service.git', gitCredential: 'none' })
+
+    expect(orchestrator.reviewRootFor(agent, hook('acme/primary-service'))).toBeUndefined()
+  })
+
+  it('resolves nothing for a workspace that is not a repository at all', () => {
+    const agent = agentFixture({ mode: 'from-scratch', gitRepo: undefined }, [
+      { repoFullName: 'acme/infra', repoId: '42' }
+    ])
+
+    expect(orchestrator.reviewRootFor(agent, hook('acme/primary-service'))).toBeUndefined()
+    // A scratch workspace still reviews its authorized repositories against their own roots.
+    expect(orchestrator.reviewRootFor(agent, hook('acme/infra'))).toEqual({ repoFullName: 'acme/infra' })
+  })
+})

--- a/packages/daemon/test/standing-context.test.ts
+++ b/packages/daemon/test/standing-context.test.ts
@@ -29,8 +29,8 @@ describe('buildWorkspaceRootsAppend', () => {
     expect(buildWorkspaceRootsAppend(ROOTS)).toBe(
       [
         '# Additional repositories',
-        'Additional repositories checked out for this session (each at its default branch; the working ' +
-          'directory stays the primary workspace):',
+        'Additional repositories checked out for this session (each at its default branch, for reference ' +
+          'only; the working directory is none of them):',
         '- /srv/agents/bot-multi/repos/acme/infra/checkout — acme/infra (trunk)',
         '- /srv/agents/bot-multi/repos/example-co/shared-library/checkout — example-co/shared-library (main)'
       ].join('\n')

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -679,7 +679,7 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     const shared = realpathSync(worktreeOf(agent, 'example-co/shared-library', 'session-review'))
     expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([primaryWorktree, shared])
     // And the same answer without the request naming the review, which is how a session's later
-    // hand-outs ask: preparation remembered which root took the cwd.
+    // hand-outs ask: the reviewed root's own subtree attests that it took the cwd.
     expect(
       workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: 'session-review', isolation: 'session' })
     ).toEqual([primaryWorktree, shared])
@@ -698,6 +698,48 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     expect(git(primaryWorktree, ['rev-parse', 'HEAD']).trim()).toBe(
       git(agent.workspace.path, ['rev-parse', 'refs/remotes/origin/main']).trim()
     )
+  })
+
+  it('keeps a resumed session in the reviewed root, in a process that never prepared it', async () => {
+    const agent = agentFixture([
+      { repoFullName: 'acme/infra', repoId: '42' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ])
+    serveAll(agent, { 'acme/infra': 'trunk', 'example-co/shared-library': 'main' })
+    const pull = seedPullRequest(remoteOf('acme/infra'), 'trunk', 17)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, reviewRequest('session-resume', 'acme/infra', 17, pull))
+    restoreAuthorizedOrigins(agent)
+
+    // A daemon restart or a host eviction re-prepares the SAME session from a request carrying no
+    // review at all, in a manager that remembers nothing.
+    const restarted = new WorkspaceManager()
+    restarted.setGitRunnerResolver((_agentId, dir, abort) => new SeamRunner(dir, abort))
+    const resumed = { sessionKey: 'session-resume', isolation: 'session' as const }
+
+    const resumedCwd = await restarted.prepareSessionWorkspace(agent, resumed)
+
+    expect(resumedCwd).toBe(cwd)
+    expect(git(resumedCwd, ['rev-parse', 'HEAD']).trim()).toBe(pull.merge)
+    expect(restarted.additionalWorkspaceDirectories(agent, resumedCwd, resumed)).toEqual([
+      realpathSync(restarted.sessionWorktreePath(agent, 'session-resume')),
+      realpathSync(worktreeOf(agent, 'example-co/shared-library', 'session-resume'))
+    ])
+  })
+
+  it('lets a swept session fall back to the primary, so a stale attestation captures nothing', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    const pull = seedPullRequest(remoteOf('acme/infra'), 'trunk', 18)
+    await workspaces.prepareSessionWorkspace(agent, reviewRequest('session-swept', 'acme/infra', 18, pull))
+    expect(await workspaces.removeSessionWorktree(agent, 'session-swept')).toEqual({ outcome: 'removed' })
+    restoreAuthorizedOrigins(agent)
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, {
+      sessionKey: 'session-swept',
+      isolation: 'session'
+    })
+
+    expect(cwd).toBe(realpathSync(workspaces.sessionWorktreePath(agent, 'session-swept')))
   })
 
   it('checks the reviewed root out at the exact head when the pull request has no merge ref', async () => {
@@ -791,8 +833,8 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     )
 
     expect(cwd).toBe(realpathSync(worktreeOf(agent, 'acme/infra', 'session-scratch')))
-    // A scratch workspace reports `shared` isolation of its own, having no clone to branch: the
-    // reviewed session's directories are still the ones preparation resolved.
+    // A scratch workspace reports `shared` isolation of its own, having no clone to branch: a
+    // session standing in a reviewed root is per-session whatever that report says.
     expect(
       workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: 'session-scratch', isolation: 'shared' })
     ).toEqual([realpathSync(worktreeOf(agent, 'example-co/shared-library', 'session-scratch'))])

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -596,6 +596,215 @@ describe('sandbox write roots', () => {
   })
 })
 
+describe('review of a secondary root (decisions 5, 6 and 11)', () => {
+  /** The local bare repository standing in for one root's authorized clone URL. */
+  function remoteOf(repoFullName: string): string {
+    return remotes.get(`https://github.com/${repoFullName}`)!
+  }
+
+  /** The refs GitHub publishes for one pull request, seeded into a fixture remote. */
+  function seedPullRequest(
+    bare: string,
+    branch: string,
+    pullNumber: number,
+    options: { merge?: boolean } = {}
+  ): { base: string; head: string; merge?: string } {
+    const home = tempRoot('ac-secondary-pull-')
+    const seed = join(home, 'seed')
+    git(home, ['clone', '-q', bare, 'seed'])
+    const base = git(seed, ['rev-parse', 'HEAD']).trim()
+    git(seed, ['checkout', '-q', '-b', `pull-${pullNumber}`])
+    writeFileSync(join(seed, `feature-${pullNumber}.txt`), 'proposed change\n')
+    git(seed, ['add', '-A'])
+    git(seed, ['commit', '-q', '-m', `feature ${pullNumber}`])
+    const head = git(seed, ['rev-parse', 'HEAD']).trim()
+    const refs = [`${head}:refs/pull/${pullNumber}/head`]
+    let merge: string | undefined
+    if (options.merge !== false) {
+      git(seed, ['checkout', '-q', branch])
+      git(seed, ['merge', '-q', '--no-ff', '-m', `merge ${pullNumber}`, head])
+      merge = git(seed, ['rev-parse', 'HEAD']).trim()
+      refs.push(`${merge}:refs/pull/${pullNumber}/merge`)
+    }
+    // The branch itself stays where it was: a pull request is its refs, not a pushed base.
+    git(seed, ['push', '-q', 'origin', ...refs])
+    // The daemon fetches the base BY SHA, which a fixture remote has to allow the way GitHub does.
+    git(bare, ['config', 'uploadpack.allowAnySHA1InWant', 'true'])
+    return { base, head, ...(merge !== undefined ? { merge } : {}) }
+  }
+
+  function reviewRequest(
+    sessionKey: string,
+    repoFullName: string,
+    pullNumber: number,
+    pull: { base: string; head: string; merge?: string }
+  ) {
+    return {
+      sessionKey,
+      isolation: 'session' as const,
+      reviewRepoFullName: repoFullName,
+      review: {
+        pullNumber,
+        baseSha: pull.base,
+        headSha: pull.head,
+        ...(pull.merge !== undefined ? { mergeCommitSha: pull.merge } : {})
+      }
+    }
+  }
+
+  const worktreeOf = (agent: Agent, repoFullName: string, sessionKey: string) =>
+    join(
+      workspaces.agentRootFor(agent),
+      'repos',
+      ...repoFullName.split('/'),
+      'worktrees',
+      workspaces.sessionWorktreeId(sessionKey)
+    )
+
+  it('makes the reviewed root the cwd at the exact merge, with every other root a default-branch reference', async () => {
+    const agent = agentFixture([
+      { repoFullName: 'acme/infra', repoId: '42' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ])
+    serveAll(agent, { 'acme/infra': 'trunk', 'example-co/shared-library': 'main' })
+    const pull = seedPullRequest(remoteOf('acme/infra'), 'trunk', 7)
+    const request = reviewRequest('session-review', 'acme/infra', 7, pull)
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, request)
+
+    expect(cwd).toBe(realpathSync(worktreeOf(agent, 'acme/infra', 'session-review')))
+    expect(git(cwd, ['rev-parse', 'HEAD']).trim()).toBe(pull.merge)
+    // The primary and the other secondary ride along, each at its own default branch.
+    const primaryWorktree = realpathSync(workspaces.sessionWorktreePath(agent, 'session-review'))
+    const shared = realpathSync(worktreeOf(agent, 'example-co/shared-library', 'session-review'))
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([primaryWorktree, shared])
+    // And the same answer without the request naming the review, which is how a session's later
+    // hand-outs ask: preparation remembered which root took the cwd.
+    expect(
+      workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: 'session-review', isolation: 'session' })
+    ).toEqual([primaryWorktree, shared])
+    expect(
+      workspaces
+        .sessionAdditionalRoots(agent, { sessionKey: 'session-review', isolation: 'session' })
+        .map((root) => [root.repoFullName, root.branch])
+    ).toEqual([
+      ['acme/primary-service', 'main'],
+      ['example-co/shared-library', 'main']
+    ])
+    // The reviewed root is the working directory, so it is nobody's additional directory.
+    expect(workspaces.readySecondaryRoots(agent, request).map((root) => root.repoFullName)).toEqual([
+      'example-co/shared-library'
+    ])
+    expect(git(primaryWorktree, ['rev-parse', 'HEAD']).trim()).toBe(
+      git(agent.workspace.path, ['rev-parse', 'refs/remotes/origin/main']).trim()
+    )
+  })
+
+  it('checks the reviewed root out at the exact head when the pull request has no merge ref', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    const pull = seedPullRequest(remoteOf('acme/infra'), 'trunk', 11, { merge: false })
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, reviewRequest('session-head', 'acme/infra', 11, pull))
+
+    expect(cwd).toBe(realpathSync(worktreeOf(agent, 'acme/infra', 'session-head')))
+    expect(git(cwd, ['rev-parse', 'HEAD']).trim()).toBe(pull.head)
+  })
+
+  it('materializes a submodule root for its own review, which ordinary sessions still never see', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' }, { primary: gitmodulesFor('acme/infra') })
+    const ordinary = { sessionKey: 'session-plain', isolation: 'session' as const }
+    const ordinaryCwd = await workspaces.prepareSessionWorkspace(agent, ordinary)
+    expect(workspaces.additionalWorkspaceDirectories(agent, ordinaryCwd, ordinary)).toEqual([])
+    restoreAuthorizedOrigins(agent)
+    const pull = seedPullRequest(remoteOf('acme/infra'), 'trunk', 4)
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, reviewRequest('session-sub', 'acme/infra', 4, pull))
+
+    expect(cwd).toBe(realpathSync(worktreeOf(agent, 'acme/infra', 'session-sub')))
+    expect(git(cwd, ['rev-parse', 'HEAD']).trim()).toBe(pull.merge)
+    // Its own review gets the exact checkout; an ordinary session still reaches it only through the
+    // parent's submodule path, so it is handed to nobody as an additional directory.
+    expect(workspaces.readySecondaryRoots(agent)).toEqual([])
+    expect(workspaces.additionalWorkspaceDirectories(agent, ordinaryCwd, ordinary)).toEqual([])
+  })
+
+  it('refuses a review of a repository this agent has no root for, leaving nothing behind', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    const pull = { base: 'a'.repeat(40), head: 'b'.repeat(40) }
+
+    await expect(
+      workspaces.prepareSessionWorkspace(agent, reviewRequest('session-unknown', 'example-co/elsewhere', 9, pull))
+    ).rejects.toThrow('is not a workspace root')
+
+    // Nothing was materialized for it, and no worktree was left for the caller's fallback to remove.
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'repos', 'example-co'))).toBe(false)
+    expect(existsSync(workspaces.sessionWorktreePath(agent, 'session-unknown'))).toBe(false)
+  })
+
+  it('keeps the primary the working directory when the review names it', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    const pull = seedPullRequest(remoteOf('acme/primary-service'), 'main', 12)
+
+    const cwd = await workspaces.prepareSessionWorkspace(
+      agent,
+      reviewRequest('session-primary', 'acme/primary-service.git', 12, pull)
+    )
+
+    expect(cwd).toBe(realpathSync(workspaces.sessionWorktreePath(agent, 'session-primary')))
+    expect(git(cwd, ['rev-parse', 'HEAD']).trim()).toBe(pull.merge)
+    expect(
+      workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: 'session-primary', isolation: 'session' })
+    ).toEqual([realpathSync(worktreeOf(agent, 'acme/infra', 'session-primary'))])
+  })
+
+  it('hands a reviewed session the directories it was prepared with, whatever isolation a later read names', async () => {
+    const agent = agentFixture(
+      [
+        { repoFullName: 'acme/infra', repoId: '42' },
+        { repoFullName: 'example-co/shared-library', repoId: '815' }
+      ],
+      { mode: 'from-scratch' }
+    )
+    serveAll(agent, { 'acme/infra': 'trunk', 'example-co/shared-library': 'main' })
+    const pull = seedPullRequest(remoteOf('acme/infra'), 'trunk', 31)
+
+    const cwd = await workspaces.prepareSessionWorkspace(
+      agent,
+      reviewRequest('session-scratch', 'acme/infra', 31, pull)
+    )
+
+    expect(cwd).toBe(realpathSync(worktreeOf(agent, 'acme/infra', 'session-scratch')))
+    // A scratch workspace reports `shared` isolation of its own, having no clone to branch: the
+    // reviewed session's directories are still the ones preparation resolved.
+    expect(
+      workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: 'session-scratch', isolation: 'shared' })
+    ).toEqual([realpathSync(worktreeOf(agent, 'example-co/shared-library', 'session-scratch'))])
+  })
+
+  it('sweeps the reviewed root’s worktree and its review refs with the rest of the session', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    const pull = seedPullRequest(remoteOf('acme/infra'), 'trunk', 21)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, reviewRequest('session-gc', 'acme/infra', 21, pull))
+    const checkout = join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout')
+    const id = workspaces.sessionWorktreeId('session-gc')
+    expect(git(checkout, ['for-each-ref', '--format=%(refname)', `refs/agentconnect/reviews/${id}`]).trim()).not.toBe(
+      ''
+    )
+
+    expect(await workspaces.removeSessionWorktree(agent, 'session-gc')).toEqual({ outcome: 'removed' })
+
+    expect(existsSync(cwd)).toBe(false)
+    expect(existsSync(workspaces.sessionWorktreePath(agent, 'session-gc'))).toBe(false)
+    // The daemon-owned review refs are per root, and they go with that root's worktree.
+    expect(git(checkout, ['for-each-ref', '--format=%(refname)', `refs/agentconnect/reviews/${id}`]).trim()).toBe('')
+  })
+})
+
 describe('removeSessionWorktree across every root (decision 4)', () => {
   it('removes the primary and every secondary worktree of one session', async () => {
     const agent = agentFixture([

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -744,6 +744,19 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     expect(existsSync(workspaces.sessionWorktreePath(agent, 'session-unknown'))).toBe(false)
   })
 
+  it('refuses a secondary root’s review where workspaces live in sandboxes, leaving the fallback to the caller', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    workspaces.setSandboxMode(true)
+    const pull = { base: 'a'.repeat(40), head: 'b'.repeat(40) }
+
+    await expect(
+      workspaces.prepareSessionWorkspace(agent, reviewRequest('session-sandbox', 'acme/infra', 5, pull))
+    ).rejects.toThrow('needs a local workspace root')
+
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'repos'))).toBe(false)
+  })
+
   it('keeps the primary the working directory when the review names it', async () => {
     const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
     serveAll(agent, { 'acme/infra': 'trunk' })

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -726,6 +726,52 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     ])
   })
 
+  it('keeps a resumed scratch-workspace session in the reviewed root, whose isolation reads shared', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }], { mode: 'from-scratch' })
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    const pull = seedPullRequest(remoteOf('acme/infra'), 'trunk', 19)
+    const cwd = await workspaces.prepareSessionWorkspace(
+      agent,
+      reviewRequest('session-scratch-resume', 'acme/infra', 19, pull)
+    )
+    restoreAuthorizedOrigins(agent)
+
+    // A scratch workspace has no clone to branch, so its sessions report `shared` isolation — which
+    // must not send this one back to the scratch directory it never worked in.
+    const restarted = new WorkspaceManager()
+    restarted.setGitRunnerResolver((_agentId, dir, abort) => new SeamRunner(dir, abort))
+
+    const resumedCwd = await restarted.prepareSessionWorkspace(agent, {
+      sessionKey: 'session-scratch-resume',
+      isolation: 'shared'
+    })
+
+    expect(resumedCwd).toBe(cwd)
+    expect(git(resumedCwd, ['rev-parse', 'HEAD']).trim()).toBe(pull.merge)
+  })
+
+  it('drops the attestation when the session degrades to a revision-only workspace', async () => {
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    const pull = seedPullRequest(remoteOf('acme/infra'), 'trunk', 20)
+    await workspaces.prepareSessionWorkspace(agent, reviewRequest('session-degraded', 'acme/infra', 20, pull))
+
+    // A later delivery whose exact checkout is unavailable takes the empty daemon-owned cwd instead.
+    const revisionOnly = {
+      sessionKey: 'session-degraded',
+      isolation: 'session' as const,
+      githubReviewRevisionOnly: true as const
+    }
+    const cwd = await workspaces.prepareSessionWorkspace(agent, revisionOnly)
+
+    expect(cwd).toBe(realpathSync(workspaces.sessionWorktreePath(agent, 'session-degraded')))
+    // No root still claims the working directory, so the fallback cwd is accepted rather than
+    // measured against a checkout the session no longer stands in.
+    expect(() =>
+      workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: 'session-degraded', isolation: 'session' })
+    ).not.toThrow()
+  })
+
   it('lets a swept session fall back to the primary, so a stale attestation captures nothing', async () => {
     const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
     serveAll(agent, { 'acme/infra': 'trunk' })


### PR DESCRIPTION
## What

Phase 5 of [`docs/designs/multi-repository-workspaces.md`](docs/designs/multi-repository-workspaces.md) — decisions 5, 6, 10 and the review half of 11, which is the reason the design exists.

A GitHub review whose subject repository is one of the agent's authorized **additional** repositories used to degrade to `useRevisionOnlyWorkspace()`: an empty directory plus a prompt telling the model to inspect the revision through GitHub reads only. Now it gets that root's own exact, verified checkout — the same `fetchReviewRevisionIn` + worktree path the primary already had, with the root swapped.

## Resulting session layout

| | |
| --- | --- |
| `cwd` | the reviewed root's per-session worktree, at the exact head (or a merge whose parents are exactly the trusted base and head) |
| `additionalDirectories` | the primary's session worktree and every other secondary's, each at its default branch |

The standing context lists those directories, and the trusted-review prompt gains one sentence (decision 10) saying they are references only — for a primary review with secondaries too, where it is equally true.

## How

- `PrepareSessionWorkspaceRequest.reviewRepoFullName` names the root a review is about. A secondary root is prepared explicitly — including a submodule root, which ordinary sessions still never receive as an additional directory (decision 11) — and its worktree becomes the cwd with the same post-steps the primary cwd gets. Naming the primary, or naming nothing, behaves exactly as before. Naming no root at all throws before anything is materialized, which is the orchestrator's existing "exact checkout unavailable" signal.
- The per-session root snapshot now records which root took the working directory and which rode along, so `additionalWorkspaceDirectories` and the standing context are derived from one answer and cannot disagree with the directories the runtime actually received.
- `githubWorkspaceMatches` becomes `reviewRootFor(agent, github)` → `'primary' | { repoFullName } | undefined`, keeping the github-app/anonymous host rules for the primary and matching the rows case-insensitively with any `.git` suffix stripped.

## What a reviewer should check

- **The fallback is unchanged.** No root ⇒ `useRevisionOnlyWorkspace()` exactly as today; any throw from the secondary path degrades through the same `catch` the primary path already used.
- **The submodule root is materialized only for its own review.** It is still absent from every ordinary session's additional directories.
- **The containment check is generalized, not removed.** `cwd` must still resolve inside this session's own cwd root; the `agentDir` widening stays the primary's alone.
- **Cluster daemons are unchanged.** `sandboxMode` hands out no roots and refuses session isolation, so a pool member's review keeps the revision-only fallback.
- **Cleanup parity is asserted, not assumed.** A test proves the reviewed root's worktree and its per-root `refs/agentconnect/reviews/<id>/*` are swept with the rest of the session.

Tests are real-git against local bare repositories seeded with `refs/pull/<n>/{head,merge}`: exact merge, exact head when there is no merge ref, submodule root, unknown repository, primary named explicitly, isolation reported differently after preparation, and the sweep. Plus `reviewRootFor` unit cases and the orchestrator's prompt/fallback paths.

## Not in this PR

Web wording for the Workspace card, and any documentation change — the design document already describes this phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
