### PR TITLE
feat(daemon): a WorkspaceFs seam and session worktrees on the sandbox volume

### DIFF
--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -147,8 +147,13 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
   const clusterIdentityToken = host.clusterIdentityToken()
   const echoDaemonId = host.echoDaemonId()
 
-  // This daemon's own coordinates: `agent.workspace.path` and the session worktrees beside it.
-  const daemonWorkspaceLocation = async (id: string, sessionId?: string): Promise<WorkspaceLocation | undefined> => {
+  // This daemon's own coordinates: `agent.workspace.path` and the session worktrees beside it. The
+  // session KEY travels with an isolated one, because the worktree is named by it in either
+  // filesystem and the pod's path is composed rather than translated.
+  const daemonWorkspaceLocation = async (
+    id: string,
+    sessionId?: string
+  ): Promise<(WorkspaceLocation & { sessionKey?: string }) | undefined> => {
     const agent = host.agents().get(id)
     if (!agent) return undefined
     if (!sessionId) {
@@ -156,14 +161,14 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
     }
     const session = await host.store().getSessionByAcpIdForAgent(id, sessionId)
     if (agent.workspace.mode !== 'git-repo' || session?.workspaceIsolation !== 'session') return undefined
-    return { root: host.workspaces().sessionWorktreePath(agent, session.key), scratch: false }
+    return { root: host.workspaces().sessionWorktreePath(agent, session.key), scratch: false, sessionKey: session.key }
   }
 
   // Where that workspace actually is, which under --k8s is the sandbox pod's volume. ONE resolver
   // for the file reader and the git seam: the directory the console browses and the one it commits
   // are the same directory, and describing them two different ways is what broke both panels.
-  // A defined location for a sessionId means that session IS isolated, which --k8s refuses —
-  // passed through so it is refused loudly rather than silently naming the shared checkout.
+  // A defined location for a sessionId means that session IS isolated, so on a cluster it names the
+  // per-session worktree on the pod's volume rather than the shared checkout.
   const workspaceLocation = async (id: string, sessionId?: string): Promise<WorkspaceLocation | undefined> => {
     const agent = host.agents().get(id)
     const local = await daemonWorkspaceLocation(id, sessionId)
@@ -174,7 +179,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
         agent,
         local.root,
         host.k8sPlane()?.workspaceRootFor(id),
-        sessionId ? { isolation: 'session' } : undefined
+        local.sessionKey === undefined ? undefined : { isolation: 'session', sessionKey: local.sessionKey }
       )
     return root === undefined ? undefined : { root, scratch: local.scratch }
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -153,7 +153,8 @@ import { ChannelNameResolver } from './messages/channel-name-resolver.js'
 import {
   WorkspaceManager,
   type PrepareSessionWorkspaceRequest,
-  type RetiredRootRemoval
+  type RetiredRootRemoval,
+  type SessionWorktreeRemoval
 } from './workspace/workspace-manager.js'
 import { ManagedSkillCache } from './skills/managed-skill-cache.js'
 import {
@@ -1521,6 +1522,8 @@ export class Daemon {
       // resolver answers undefined for any without a bound channel, so an agent this daemon has
       // not launched into a sandbox keeps its local behaviour.
       this.workspaces.setGitRunnerResolver((agentId, cwd, abort) => this.k8sPlane?.gitRunnerFor(agentId, cwd, abort))
+      // And its filesystem twin, so the worktree paths ask the POD and compose the POD's coordinates.
+      this.workspaces.setFsResolver((agentId) => this.k8sPlane?.workspaceFsFor(agentId))
       // And the one destructive operation a cluster workspace needs, for the same reason: a
       // partial clone sits on a volume no `rmSync` here can reach.
       this.workspaces.setPathClearer((agentId, root) => this.k8sPlane!.clearPath(agentId, root))
@@ -2739,16 +2742,12 @@ export class Daemon {
     // git-repo checkouts for cluster agents arrive with the materialize/runner phases.
     if (this.k8sPlane) {
       const plane = this.k8sPlane
-      // One Sandbox lease around the WHOLE preparation, not just the bind: everything below runs
-      // in the pod, so a rollout's drain request landing mid-clone would otherwise suspend the pod
-      // underneath a turn this daemon already admitted.
-      return await plane.withSandbox(agent.id, async () => {
-        await plane.ensureChannel(agent.id)
-        // The pod's own preparation: clone and pull happen on its volume through the runner, and
-        // none of the local work below runs — its mkdir, `existsSync(.git)` and skills installation
-        // all land on this daemon's disk, describing a filesystem the runtime never reads.
-        return await this.workspaces.prepareClusterWorkspace(agent, plane.workspaceRootFor(agent.id), request)
-      })
+      // The pod's own preparation: clone and pull happen on its volume through the runner, and
+      // none of the local work below runs — its mkdir, `existsSync(.git)` and skills installation
+      // all land on this daemon's disk, describing a filesystem the runtime never reads.
+      return await this.withAgentVolume(agent.id, () =>
+        this.workspaces.prepareClusterWorkspace(agent, plane.workspaceRootFor(agent.id), request)
+      )
     }
     if (!this.opts.hostFactory) assertExclusiveAgentWorkspaces([agent as LoadedAgent])
     const opts = {
@@ -2759,6 +2758,23 @@ export class Daemon {
     return request
       ? this.workspaces.prepareSessionWorkspace(agent, request, opts)
       : this.workspaces.prepareWorkspace(agent, opts)
+  }
+
+  /**
+   * Run `work` with the agent's workspace volume reachable, whatever holds it.
+   *
+   * On a cluster that is one Sandbox lease around the WHOLE operation, not just the bind: everything
+   * inside runs in the pod, so a rollout's drain request landing mid-clone — or an idle sweep landing
+   * mid-removal — would otherwise suspend the pod underneath work this daemon already admitted, and a
+   * suspended pod serves neither exec nor fs. Locally there is nothing to hold.
+   */
+  private async withAgentVolume<T>(agentId: string, work: () => Promise<T>): Promise<T> {
+    const plane = this.k8sPlane
+    if (!plane) return await work()
+    return await plane.withSandbox(agentId, async () => {
+      await plane.ensureChannel(agentId)
+      return await work()
+    })
   }
 
   private runAgentWorkspacePrefetch(agent: Agent): Promise<void> {
@@ -12476,7 +12492,11 @@ export class Daemon {
       ) {
         return { outcome: 'not_applicable' }
       }
-      const result = await this.workspaces.removeSessionWorktree(currentAgent, rec.key)
+      // The volume has to be up and bound for the removal, as it was for the preparation. A pod that
+      // will not come up is THIS session's failure, never the whole sweep's — it retries next pass.
+      const result = await this.withAgentVolume(rec.agentId, () =>
+        this.workspaces.removeSessionWorktree(currentAgent, rec.key)
+      ).catch((err: unknown): SessionWorktreeRemoval => ({ outcome: 'failed', error: (err as Error).message }))
       // `partial` too: a kept aggregate can still have removed another root's worktree, and a warm
       // attachment naming a directory that is gone would skip preparation on its next turn.
       const changed = result.outcome === 'removed' || result.outcome === 'absent' || result.partial === true
@@ -14983,6 +15003,7 @@ export class Daemon {
     await this.readiness?.stop().catch(() => undefined)
     this.readiness = undefined
     this.workspaces.setGitRunnerResolver(undefined)
+    this.workspaces.setFsResolver(undefined)
     this.workspaces.setPathClearer(undefined)
     this.workspaces.setSandboxMode(false)
     await Promise.allSettled(hostStarts)

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -10,7 +10,9 @@ import { ChannelLossWatcher } from './channel-loss-watcher.js'
 import { TunnelBinder } from './tunnel-binder.js'
 import { ShimWorkspaceFiles } from '../shim/workspace-files-channel.js'
 import { ShimMemoryFs } from '../shim/memory-fs-channel.js'
+import { ShimWorkspaceFs } from '../shim/workspace-fs-channel.js'
 import type { WorkspaceFiles } from '../workspace/workspace-files.js'
+import type { WorkspacePlacement } from '../workspace/workspace-fs.js'
 import type { MemoryFs } from '../memory/fs.js'
 import { DEFAULT_SHIM_LISTEN_PORT, DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
 import type { TunnelName } from '../shim/tunnel.js'
@@ -125,6 +127,10 @@ export interface K8sRuntimePlane {
    *  git runner because they are separate capabilities (`read` vs `exec`) and a channel is not a
    *  blanket permission — not because the two ever disagree about which filesystem to use. */
   workspaceFilesFor: (agentId: string) => WorkspaceFiles | undefined
+  /** Where the agent's WORKSPACE files live and which coordinates they are addressed in — the
+   *  filesystem twin of `gitRunnerFor`, answering on the same condition. Undefined keeps the caller
+   *  on this daemon's own disk, which is what a self-hosted agent beside a cluster one needs. */
+  workspaceFsFor: (agentId: string) => WorkspacePlacement | undefined
   /** The agent's managed memory tree on that same volume, on the same condition: one root beside
    *  the checkout (`<mount>/.agentconnect/memory`), so it follows the agent across members and
    *  survives a rollout, and is reachable exactly when the sandbox is. */
@@ -291,6 +297,11 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     workspaceFilesFor: (agentId) => {
       if (!runsInSandbox(agentId)) return undefined
       return new ShimWorkspaceFiles(driver.sessionFor(agentId)!)
+    },
+    workspaceFsFor: (agentId) => {
+      if (!runsInSandbox(agentId)) return undefined
+      const mount = driver.workspaceRootFor(agentId) ?? DEFAULT_SHIM_WORKSPACE_ROOT
+      return { fs: new ShimWorkspaceFs(driver.sessionFor(agentId)!, mount), mount }
     },
     memoryFsFor: (agentId) => {
       if (!runsInSandbox(agentId)) return undefined

--- a/packages/daemon/src/shim/exec-handler.ts
+++ b/packages/daemon/src/shim/exec-handler.ts
@@ -134,15 +134,16 @@ function canonical(path: string): string {
 }
 
 /**
- * Refuse an absolute path that escapes the workspace root, for a path that does not exist yet.
+ * Refuse an operand that escapes the workspace root, for a path that does not exist yet.
  *
  * Lexical rather than `realpath`, because a clone target is precisely a path that is not there:
  * containment is decided on the normalized form, and the ROOT is canonicalized so a symlinked mount
- * still compares correctly.
+ * still compares correctly. A RELATIVE operand is resolved against the fenced cwd first, the way git
+ * itself resolves it — checking only absolute ones let `../escaped` through the fence untouched.
  */
-function assertInsideRoot(root: string, requested: string): void {
+function assertInsideRoot(root: string, cwd: string, requested: string): void {
   const base = canonical(root)
-  const target = normalize(resolve(requested))
+  const target = normalize(isAbsolute(requested) ? resolve(requested) : resolve(cwd, requested))
   if (target !== base && !target.startsWith(base + sep)) {
     throw new ExecRefusedError(`path escapes the workspace root: ${requested}`)
   }
@@ -246,11 +247,13 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps, abort?: AbortSign
   }
   const cwd = resolveCwd(deps.workspaceRoot, parsed.cwd)
   // Both WRITE a path from argv, which the cwd fence never looks at: a clone's target, and the
-  // directory `worktree add`/`remove` creates or deletes. Checked on the side holding the filesystem.
+  // directory `worktree add`/`remove` creates or deletes. EVERY operand is checked, resolved as git
+  // would resolve it — an allowlist of "which operand is the path" is the thing that goes stale, and
+  // the others (a subcommand verb, a URL, a start-point ref) sit under the cwd and pass anyway.
   if (subcommand === 'clone' || subcommand === 'worktree') {
     for (const argument of rest) {
-      if (argument.startsWith('-') || !isAbsolute(argument)) continue
-      assertInsideRoot(deps.workspaceRoot, argument)
+      if (argument.startsWith('-')) continue
+      assertInsideRoot(deps.workspaceRoot, cwd, argument)
     }
   }
   // The caller's deadline governs, bounded by this side's ceiling: a compromised daemon must not

--- a/packages/daemon/src/shim/exec-handler.ts
+++ b/packages/daemon/src/shim/exec-handler.ts
@@ -17,6 +17,7 @@ import { applyMemoryFsPayload, isMemoryFsPayload } from './memory-fs-channel.js'
  * which through `-c`, hooks and `--upload-pack` reaches arbitrary execution.
  */
 export const ALLOWED_GIT_SUBCOMMANDS = new Set([
+  'branch',
   'check-ref-format',
   'clean',
   'clone',
@@ -24,12 +25,15 @@ export const ALLOWED_GIT_SUBCOMMANDS = new Set([
   'diff',
   'fetch',
   'log',
+  'ls-remote',
   'pull',
   'remote',
   'reset',
   'rev-list',
   'rev-parse',
+  'show-ref',
   'status',
+  'symbolic-ref',
   'update-ref',
   'worktree'
 ])
@@ -241,10 +245,9 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps, abort?: AbortSign
     }
   }
   const cwd = resolveCwd(deps.workspaceRoot, parsed.cwd)
-  // A clone WRITES to a path in argv, which the cwd fence above never looks at. The daemon sends a
-  // relative target for exactly that reason, so an absolute one is either a mistake or an attempt to
-  // write outside the workspace — and this side is the one holding the filesystem.
-  if (subcommand === 'clone') {
+  // Both WRITE a path from argv, which the cwd fence never looks at: a clone's target, and the
+  // directory `worktree add`/`remove` creates or deletes. Checked on the side holding the filesystem.
+  if (subcommand === 'clone' || subcommand === 'worktree') {
     for (const argument of rest) {
       if (argument.startsWith('-') || !isAbsolute(argument)) continue
       assertInsideRoot(deps.workspaceRoot, argument)

--- a/packages/daemon/src/shim/fd-memory-fs.ts
+++ b/packages/daemon/src/shim/fd-memory-fs.ts
@@ -219,6 +219,23 @@ export function createFdMemoryFsExecutor(anchor: string): MemoryFsExecutor {
       await withDir(root, rel, true, async () => undefined)
     },
 
+    async rmdir(root, rel) {
+      return await withParent(root, rel, false, async (parent, leaf) => {
+        try {
+          await fs.rmdir(parent.childPath(leaf))
+          return true
+        } catch (err) {
+          // Non-empty (or not a directory at all) is kept, which is the whole point of the operation.
+          if (isErrno(err, 'ENOTEMPTY') || isErrno(err, 'EEXIST') || isErrno(err, 'ENOTDIR')) return false
+          if (isErrno(err, 'ENOENT')) return true
+          throw err
+        }
+      }).catch((err: unknown) => {
+        if (err instanceof MissingPathError) return true
+        throw err
+      })
+    },
+
     async rename(root, from, to) {
       return await withParent(root, from, false, async (source, sourceLeaf) => {
         try {

--- a/packages/daemon/src/shim/fd-memory-fs.ts
+++ b/packages/daemon/src/shim/fd-memory-fs.ts
@@ -174,6 +174,23 @@ export function createFdMemoryFsExecutor(anchor: string): MemoryFsExecutor {
       })
     },
 
+    async stat(root, rel) {
+      // The root itself has no leaf to lstat, so it is answered by whether the descent reaches it.
+      if (memoryRelSegments(rel).length === 0) {
+        return await withDir(root, rel, false, async () => 'dir' as const).catch((err: unknown) => {
+          if (err instanceof MissingPathError) return 'missing' as const
+          throw err
+        })
+      }
+      return await withParent(root, rel, false, async (parent, leaf) => {
+        const st = await parent.lstatChild(leaf)
+        return st.isDirectory() ? ('dir' as const) : st.isFile() ? ('file' as const) : ('other' as const)
+      }).catch((err: unknown) => {
+        if (err instanceof MissingPathError) return 'missing' as const
+        throw err
+      })
+    },
+
     async readdir(root, rel) {
       return await withDir(root, rel, false, async (dir) => {
         const entries: MemoryFsEntry[] = []

--- a/packages/daemon/src/shim/memory-fs-channel.ts
+++ b/packages/daemon/src/shim/memory-fs-channel.ts
@@ -11,6 +11,10 @@
  *
  * The pod side (`fd-memory-fs.ts`) works from open descriptors like the workspace's; the daemon
  * side (`ShimMemoryFs`) is a pass-through that reassembles slices and chunks into the port's calls.
+ *
+ * The primitives are not memory's alone — `shim/workspace-fs-channel.ts` is a second caller, for the
+ * worktree tree on the same mount. The `memory-` op names are the wire contract a running pod already
+ * speaks and are left as they are; the prefix is that contract's history, not the channel's scope.
  */
 import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
@@ -27,6 +31,7 @@ import {
   type MemoryFsWriteOptions
 } from '../memory/fs.js'
 import { createFdMemoryFsExecutor } from './fd-memory-fs.js'
+import type { WorkspaceFsKind } from '../workspace/workspace-fs.js'
 import type { ShimRequester } from './channels.js'
 
 /** Absolute because it is a path in the POD's coordinates, and the shim's fence compares absolutes. */
@@ -58,6 +63,7 @@ export const MemoryFsPayloadSchema = z.discriminatedUnion('op', [
     temp: RelSchema,
     ifMatchMtime: z.string().optional()
   }),
+  z.object({ op: z.literal('memory-stat'), root: RootSchema, rel: RelSchema }),
   z.object({ op: z.literal('memory-readdir'), root: RootSchema, rel: RelSchema }),
   z.object({ op: z.literal('memory-mkdir'), root: RootSchema, rel: RelSchema }),
   z.object({ op: z.literal('memory-rename'), root: RootSchema, from: RelSchema, to: RelSchema }),
@@ -85,6 +91,7 @@ const ReadReplySchema = z.discriminatedUnion('exists', [
 export type MemoryFsReadReply = z.infer<typeof ReadReplySchema>
 
 const StatReplySchema = z.object({ size: z.number().int().nonnegative(), mtime: z.string() })
+export const KindReplySchema = z.enum(['file', 'dir', 'missing', 'other'])
 const EntriesReplySchema = z.array(
   z.object({
     name: z.string(),
@@ -109,6 +116,8 @@ export interface MemoryFsExecutor {
   read(root: string, rel: string, offset: number, limit: number, encoding: MemoryFsEncoding): Promise<MemoryFsReadReply>
   append(root: string, rel: string, content: Buffer, create: boolean, mode?: number): Promise<{ size: number }>
   commit(root: string, rel: string, temp: string, ifMatchMtime?: string): Promise<MemoryFsFileStat>
+  /** What one path IS, never following a symlink; `other` covers a link and every non-regular entry. */
+  stat(root: string, rel: string): Promise<WorkspaceFsKind>
   readdir(root: string, rel: string): Promise<MemoryFsEntry[]>
   mkdir(root: string, rel: string): Promise<void>
   rename(root: string, from: string, to: string): Promise<boolean>
@@ -152,6 +161,8 @@ function run(parsed: MemoryFsPayload, executor: MemoryFsExecutor): Promise<unkno
       )
     case 'memory-commit':
       return executor.commit(parsed.root, parsed.rel, parsed.temp, parsed.ifMatchMtime)
+    case 'memory-stat':
+      return executor.stat(parsed.root, parsed.rel)
     case 'memory-readdir':
       return executor.readdir(parsed.root, parsed.rel)
     case 'memory-mkdir':
@@ -172,6 +183,23 @@ const READ_RESTARTS = 3
 
 /** A bound shim channel that knows which agent it serves (a `ShimSession`). */
 export type ShimMemoryChannel = ShimRequester & { readonly agentId: string }
+
+/** One channel round trip, with the two typed refusals rebuilt as the SAME classes the local port
+ *  throws, so callers cannot tell the two trees apart. */
+export async function requestMemoryFs<T>(
+  channel: ShimMemoryChannel,
+  payload: MemoryFsPayload,
+  schema: z.ZodType<T>,
+  timeoutMs: number
+): Promise<T> {
+  const raw = await channel.request('read', payload, { timeoutMs })
+  const reply = MemoryFsReplySchema.parse(raw)
+  if (!reply.ok) {
+    if (reply.refusal.kind === 'conflict') throw new MemoryConflictError(reply.refusal.message)
+    throw new MemoryPathError(reply.refusal.message)
+  }
+  return schema.parse(reply.value)
+}
 
 /**
  * The daemon's side: the port over an agent's bound shim channel. Every containment check and every
@@ -194,15 +222,8 @@ export class ShimMemoryFs implements MemoryFs {
     return new ShimMemoryFs(this.channel, joinRel(this.root, rel), this.timeoutMs)
   }
 
-  private async run<T>(payload: MemoryFsPayload, schema: z.ZodType<T>): Promise<T> {
-    const raw = await this.channel.request('read', payload, { timeoutMs: this.timeoutMs })
-    const reply = MemoryFsReplySchema.parse(raw)
-    // Rebuilt as the SAME classes the local port throws, so callers cannot tell the two trees apart.
-    if (!reply.ok) {
-      if (reply.refusal.kind === 'conflict') throw new MemoryConflictError(reply.refusal.message)
-      throw new MemoryPathError(reply.refusal.message)
-    }
-    return schema.parse(reply.value)
+  private run<T>(payload: MemoryFsPayload, schema: z.ZodType<T>): Promise<T> {
+    return requestMemoryFs(this.channel, payload, schema, this.timeoutMs)
   }
 
   async readFile(rel: string, encoding: MemoryFsEncoding = 'utf8'): Promise<MemoryFsFile | null> {

--- a/packages/daemon/src/shim/memory-fs-channel.ts
+++ b/packages/daemon/src/shim/memory-fs-channel.ts
@@ -66,6 +66,7 @@ export const MemoryFsPayloadSchema = z.discriminatedUnion('op', [
   z.object({ op: z.literal('memory-stat'), root: RootSchema, rel: RelSchema }),
   z.object({ op: z.literal('memory-readdir'), root: RootSchema, rel: RelSchema }),
   z.object({ op: z.literal('memory-mkdir'), root: RootSchema, rel: RelSchema }),
+  z.object({ op: z.literal('memory-rmdir'), root: RootSchema, rel: RelSchema }),
   z.object({ op: z.literal('memory-rename'), root: RootSchema, from: RelSchema, to: RelSchema }),
   z.object({ op: z.literal('memory-rm'), root: RootSchema, rel: RelSchema }),
   z.object({ op: z.literal('memory-utimes'), root: RootSchema, rel: RelSchema, mtime: z.string() })
@@ -120,6 +121,8 @@ export interface MemoryFsExecutor {
   stat(root: string, rel: string): Promise<WorkspaceFsKind>
   readdir(root: string, rel: string): Promise<MemoryFsEntry[]>
   mkdir(root: string, rel: string): Promise<void>
+  /** Remove `rel` only if it is an empty directory, answering whether it went. */
+  rmdir(root: string, rel: string): Promise<boolean>
   rename(root: string, from: string, to: string): Promise<boolean>
   rm(root: string, rel: string): Promise<void>
   utimes(root: string, rel: string, mtime: string): Promise<void>
@@ -167,6 +170,8 @@ function run(parsed: MemoryFsPayload, executor: MemoryFsExecutor): Promise<unkno
       return executor.readdir(parsed.root, parsed.rel)
     case 'memory-mkdir':
       return executor.mkdir(parsed.root, parsed.rel).then(() => null)
+    case 'memory-rmdir':
+      return executor.rmdir(parsed.root, parsed.rel)
     case 'memory-rename':
       return executor.rename(parsed.root, parsed.from, parsed.to)
     case 'memory-rm':

--- a/packages/daemon/src/shim/workspace-fs-channel.ts
+++ b/packages/daemon/src/shim/workspace-fs-channel.ts
@@ -1,0 +1,85 @@
+/**
+ * The workspace-tree half of the `read` capability: a cluster agent's worktrees live on its sandbox
+ * volume, and this is how the daemon's `WorkspaceFs` seam reaches them.
+ *
+ * It is the same fd-anchored channel the managed memory tree rides — `memory-fs-channel.ts` — with
+ * one more primitive (`stat`) and a different tree under the same mount. Reusing it rather than
+ * opening a second one is the point: containment on the pod is the descent from an open descriptor,
+ * which is stronger than any name check this side could make, and there must be exactly one
+ * implementation of it.
+ *
+ * Paths arrive ABSOLUTE, in the pod's coordinates (`<mount>/worktrees/<sid>`), because that is what
+ * the daemon composes and what git in the pod is given. They are turned into mount-relative ones
+ * here; anything that is not under the mount is refused before it reaches the wire.
+ */
+import { isAbsolute, relative, sep } from 'node:path'
+import type { WorkspaceFs, WorkspaceFsKind } from '../workspace/workspace-fs.js'
+import { KindReplySchema, ShimMemoryFs, requestMemoryFs, type ShimMemoryChannel } from './memory-fs-channel.js'
+
+const DEFAULT_TIMEOUT_MS = 30_000
+
+/** The daemon's side of the seam for one agent's sandbox volume. */
+export class ShimWorkspaceFs implements WorkspaceFs {
+  private readonly files: ShimMemoryFs
+
+  constructor(
+    private readonly channel: ShimMemoryChannel,
+    /** The pod's workspace mount; every path handed to this instance must sit under it. */
+    private readonly mount: string,
+    private readonly timeoutMs = DEFAULT_TIMEOUT_MS
+  ) {
+    this.files = new ShimMemoryFs(channel, mount, timeoutMs)
+  }
+
+  async stat(path: string): Promise<WorkspaceFsKind> {
+    return await requestMemoryFs(
+      this.channel,
+      { op: 'memory-stat', root: this.mount, rel: this.rel(path) },
+      KindReplySchema,
+      this.timeoutMs
+    )
+  }
+
+  async readdir(path: string): Promise<string[]> {
+    return (await this.files.readdir(this.rel(path))).map((entry) => entry.name)
+  }
+
+  async mkdir(path: string): Promise<void> {
+    // No mode: the volume is this agent's alone, so the local 0o700 has no second principal to exclude.
+    await this.files.mkdir(this.rel(path))
+  }
+
+  async readFile(path: string): Promise<string | undefined> {
+    try {
+      return (await this.files.readFile(this.rel(path)))?.content
+    } catch {
+      // Unreadable reads as absent, matching the local seam — every caller reads a marker it may not find.
+      return undefined
+    }
+  }
+
+  async writeFile(path: string, content: string, options: { mode?: number } = {}): Promise<void> {
+    // Staged as appended chunks beside the target and published by one rename, on the pod.
+    await this.files.writeFile(this.rel(path), content, options)
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    // The pod answers a missing source as data; the local seam throws, so raise it here too.
+    if (!(await this.files.rename(this.rel(from), this.rel(to)))) {
+      throw new Error(`workspace rename source does not exist: ${from}`)
+    }
+  }
+
+  async rmTree(path: string): Promise<void> {
+    await this.files.rm(this.rel(path))
+  }
+
+  /** Mount-relative, POSIX-separated; a path the daemon did not compose under the mount is refused. */
+  private rel(path: string): string {
+    const rel = relative(this.mount, path)
+    if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+      throw new Error(`workspace path is outside the sandbox mount: ${path}`)
+    }
+    return rel.split(sep).join('/')
+  }
+}

--- a/packages/daemon/src/shim/workspace-fs-channel.ts
+++ b/packages/daemon/src/shim/workspace-fs-channel.ts
@@ -13,6 +13,7 @@
  * here; anything that is not under the mount is refused before it reaches the wire.
  */
 import { isAbsolute, relative, sep } from 'node:path'
+import { z } from 'zod'
 import { MemoryPathError } from '../memory/fs.js'
 import type { WorkspaceFs, WorkspaceFsKind } from '../workspace/workspace-fs.js'
 import { KindReplySchema, ShimMemoryFs, requestMemoryFs, type ShimMemoryChannel } from './memory-fs-channel.js'
@@ -71,6 +72,15 @@ export class ShimWorkspaceFs implements WorkspaceFs {
     if (!(await this.files.rename(this.rel(from), this.rel(to)))) {
       throw new Error(`workspace rename source does not exist: ${from}`)
     }
+  }
+
+  async rmdir(path: string): Promise<boolean> {
+    return await requestMemoryFs(
+      this.channel,
+      { op: 'memory-rmdir', root: this.mount, rel: this.rel(path) },
+      z.boolean(),
+      this.timeoutMs
+    )
   }
 
   async rmTree(path: string): Promise<void> {

--- a/packages/daemon/src/shim/workspace-fs-channel.ts
+++ b/packages/daemon/src/shim/workspace-fs-channel.ts
@@ -13,6 +13,7 @@
  * here; anything that is not under the mount is refused before it reaches the wire.
  */
 import { isAbsolute, relative, sep } from 'node:path'
+import { MemoryPathError } from '../memory/fs.js'
 import type { WorkspaceFs, WorkspaceFsKind } from '../workspace/workspace-fs.js'
 import { KindReplySchema, ShimMemoryFs, requestMemoryFs, type ShimMemoryChannel } from './memory-fs-channel.js'
 
@@ -52,9 +53,11 @@ export class ShimWorkspaceFs implements WorkspaceFs {
   async readFile(path: string): Promise<string | undefined> {
     try {
       return (await this.files.readFile(this.rel(path)))?.content
-    } catch {
-      // Unreadable reads as absent, matching the local seam — every caller reads a marker it may not find.
-      return undefined
+    } catch (err) {
+      // A refusal reads as absent, like the local seam's catch. A transport failure must NOT: "the
+      // channel dropped" is not evidence that the marker is missing, and a caller would act on it.
+      if (err instanceof MemoryPathError) return undefined
+      throw err
     }
   }
 

--- a/packages/daemon/src/workspace/workspace-fs.ts
+++ b/packages/daemon/src/workspace/workspace-fs.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from 'node:crypto'
+import { lstatSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+
+/**
+ * What one path IS, resolved WITHOUT following a symlink.
+ *
+ * `other` is the answer for a symlink and for every non-regular entry, and every caller treats it
+ * as a refusal — which is what the local code expressed by throwing on `lstatSync().isSymbolicLink()`.
+ * `missing` is data, never an error: absence is the ordinary answer to "is the checkout there".
+ */
+export type WorkspaceFsKind = 'file' | 'dir' | 'missing' | 'other'
+
+/**
+ * The filesystem twin of `GitRunner`: the workspace file operations the daemon actually performs,
+ * as a frozen inventory rather than a general-purpose `node:fs`.
+ *
+ * It exists for the same reason the git seam does. A cluster-backed agent's workspace lives on its
+ * sandbox pod's volume, so every `existsSync`/`mkdirSync`/`rmSync` in the worktree paths inspects
+ * the wrong disk — silently, because the daemon's own directory answers plausibly. The orchestration
+ * stays here and only the execution moves.
+ *
+ * Paths are ABSOLUTE, in the coordinates of the filesystem that holds them: this daemon's disk for a
+ * local agent, the pod's mount for a sandboxed one. Deriving the members from what the code already
+ * calls (rather than from what a filesystem can do) is what keeps the move mechanical.
+ */
+export interface WorkspaceFs {
+  /** Never follows a symlink — see {@link WorkspaceFsKind}. */
+  stat(path: string): Promise<WorkspaceFsKind>
+  /** Entry names, not paths. Callers prove the directory is there first; one that cannot be read
+   *  must fail rather than read as empty, since "empty" is what licenses a removal. */
+  readdir(path: string): Promise<string[]>
+  /** Recursive, like `mkdir -p`. */
+  mkdir(path: string, mode?: number): Promise<void>
+  /** The file's text, or undefined when it is absent or unreadable — every caller reads a marker
+   *  it is willing to find missing. */
+  readFile(path: string): Promise<string | undefined>
+  /** Atomic: staged beside the target, then published by one rename. */
+  writeFile(path: string, content: string, options?: { mode?: number }): Promise<void>
+  rename(from: string, to: string): Promise<void>
+  /** Recursive and forgiving, like `rm -rf`. */
+  rmTree(path: string): Promise<void>
+}
+
+/**
+ * Where one agent's workspace files live: the filesystem that holds them, and the mount its paths
+ * are composed in.
+ *
+ * The two travel together because they are one answer. A daemon that knew which filesystem to ask
+ * but not which coordinates to ask in would compose `<agentDir>/worktrees` and send it to a pod that
+ * has no such path — the exact failure this seam exists to remove.
+ */
+export interface WorkspacePlacement {
+  fs: WorkspaceFs
+  /** The pod's workspace mount; every path the manager composes for this agent hangs off it. */
+  mount: string
+}
+
+/** Today's behaviour: the daemon's own disk, through `node:fs`. */
+export class LocalWorkspaceFs implements WorkspaceFs {
+  async stat(path: string): Promise<WorkspaceFsKind> {
+    try {
+      const stats = lstatSync(path)
+      return stats.isDirectory() ? 'dir' : stats.isFile() ? 'file' : 'other'
+    } catch {
+      // Unreadable reads as absent, exactly as the `existsSync` this replaces did.
+      return 'missing'
+    }
+  }
+
+  async readdir(path: string): Promise<string[]> {
+    return readdirSync(path)
+  }
+
+  async mkdir(path: string, mode?: number): Promise<void> {
+    mkdirSync(path, { recursive: true, ...(mode === undefined ? {} : { mode }) })
+  }
+
+  async readFile(path: string): Promise<string | undefined> {
+    try {
+      return readFileSync(path, 'utf8')
+    } catch {
+      return undefined
+    }
+  }
+
+  async writeFile(path: string, content: string, options: { mode?: number } = {}): Promise<void> {
+    // A per-write temp name rather than a fixed `.tmp`: two writers publishing the same marker must
+    // not stage into one another's file, and the rename is what makes either one whole.
+    const temp = `${path}.${randomUUID()}.tmp`
+    try {
+      writeFileSync(temp, content, options.mode === undefined ? {} : { mode: options.mode })
+      renameSync(temp, path)
+    } catch (err) {
+      rmSync(temp, { force: true })
+      throw err
+    }
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    renameSync(from, to)
+  }
+
+  async rmTree(path: string): Promise<void> {
+    rmSync(path, { recursive: true, force: true })
+  }
+}
+
+/** One instance is enough: it holds no state, and every local agent shares this disk. */
+export const localWorkspaceFs = new LocalWorkspaceFs()

--- a/packages/daemon/src/workspace/workspace-fs.ts
+++ b/packages/daemon/src/workspace/workspace-fs.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { lstatSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { lstatSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, rmdirSync, writeFileSync } from 'node:fs'
 
 /**
  * What one path IS, resolved WITHOUT following a symlink.
@@ -37,6 +37,15 @@ export interface WorkspaceFs {
   /** Atomic: staged beside the target, then published by one rename. */
   writeFile(path: string, content: string, options?: { mode?: number }): Promise<void>
   rename(from: string, to: string): Promise<void>
+  /**
+   * Remove a directory ONLY if it is empty, answering whether it went.
+   *
+   * Distinct from {@link rmTree} because "reclaim a provably empty leftover" is not a tree removal:
+   * proving emptiness and then deleting recursively are two operations, and on a volume the agent's
+   * runtime is writing to, anything that appears between them is deleted by a removal the proof
+   * licensed. Here the kernel decides both at once, so the race resolves as "kept", not as data loss.
+   */
+  rmdir(path: string): Promise<boolean>
   /** Recursive and forgiving, like `rm -rf`. */
   rmTree(path: string): Promise<void>
 }
@@ -98,6 +107,19 @@ export class LocalWorkspaceFs implements WorkspaceFs {
 
   async rename(from: string, to: string): Promise<void> {
     renameSync(from, to)
+  }
+
+  async rmdir(path: string): Promise<boolean> {
+    try {
+      rmdirSync(path)
+      return true
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code
+      // Already gone counts as removed; anything the kernel refuses to empty is kept, not forced.
+      if (code === 'ENOENT') return true
+      if (code === 'ENOTEMPTY' || code === 'EEXIST' || code === 'ENOTDIR') return false
+      throw err
+    }
   }
 
   async rmTree(path: string): Promise<void> {

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -38,6 +38,7 @@ import {
   writeRepoHelperConfig
 } from './git-injection.js'
 import { LocalGitRunner, type GitRunner } from './git-runner.js'
+import { localWorkspaceFs, type WorkspaceFs, type WorkspacePlacement } from './workspace-fs.js'
 import { gitmoduleRepos } from './gitmodules.js'
 import {
   isRepoSegment,
@@ -128,6 +129,11 @@ export type SessionRootScope = Pick<PrepareSessionWorkspaceRequest, 'isolation' 
   sessionKey?: string
 }
 
+/** How one session addresses a CLUSTER agent's checkout: the isolation, plus the key that names its
+ *  worktree. Both are needed — the daemon composes the pod path itself, and an isolation with no key
+ *  names no worktree. */
+export type ClusterSessionScope = Pick<PrepareSessionWorkspaceRequest, 'isolation'> & { sessionKey?: string }
+
 /** What a secondary root's `.materialization.json` records about the checkout beside it. */
 interface SecondaryMaterialization {
   repoId: string
@@ -180,11 +186,16 @@ export class WorkspaceManager {
   /** Secondary roots prepared for an agent's current sessions — what the synchronous hand-out reads. */
   private readonly readyRoots = new Map<string, SecondaryWorkspaceRoot[]>()
   private gitRunnerResolver: WorkspaceGitRunnerResolver | undefined
+  private fsResolver: WorkspaceFsResolver | undefined
   private pathClearer: WorkspacePathClearer | undefined
   private workspacesLiveInSandboxes = false
 
   setGitRunnerResolver(resolver: WorkspaceGitRunnerResolver | undefined): void {
     this.gitRunnerResolver = resolver
+  }
+
+  setFsResolver(resolver: WorkspaceFsResolver | undefined): void {
+    this.fsResolver = resolver
   }
 
   setPathClearer(clearer: WorkspacePathClearer | undefined): void {
@@ -202,6 +213,16 @@ export class WorkspaceManager {
   /** The agent's own runner; undefined means its workspace is reachable locally. */
   resolveGitRunner(agentId: string, cwd?: string, abort?: AbortSignal): GitRunner | undefined {
     return this.gitRunnerResolver?.(agentId, cwd, abort)
+  }
+
+  /** The filesystem this agent's workspace files live in — this daemon's own when nothing claims it. */
+  fsFor(agentId: string): WorkspaceFs {
+    return this.fsResolver?.(agentId)?.fs ?? localWorkspaceFs
+  }
+
+  /** The mount this agent's workspace paths are composed in; undefined ⇒ this daemon's own disk. */
+  sandboxMountFor(agentId: string): string | undefined {
+    return this.fsResolver?.(agentId)?.mount
   }
 
   /** The clearer's error message, or undefined when it succeeded or none is registered. */
@@ -257,13 +278,21 @@ export class WorkspaceManager {
     )
   }
 
-  /** The agent's primary checkout as a root. Throws like `gitRepoOf` when the workspace is not a repository. */
+  /** The agent's primary checkout as a root, in the coordinates of whichever filesystem holds it.
+   *  Throws like `gitRepoOf` when the workspace is not a repository. */
   primaryRoot(agent: Agent): WorkspaceRoot {
+    return this.primaryRootAt(agent, this.sandboxMountFor(agent.id))
+  }
+
+  /** The same root addressed in one sandbox mount's coordinates; `mount` undefined means this disk.
+   *  The cluster path names the mount explicitly rather than asking the resolver, because it already
+   *  holds the one its own channel reported and must not depend on a second lookup agreeing. */
+  primaryRootAt(agent: Agent, mount: string | undefined): WorkspaceRoot {
     return {
       cloneUrl: this.gitRepoOf(agent),
       branch: agent.workspace.gitBranch,
-      path: agent.workspace.path,
-      worktreesPath: this.worktreesPathFor(agent),
+      path: mount === undefined ? agent.workspace.path : this.clusterWorkspaceCheckout(agent, mount),
+      worktreesPath: this.worktreesPathAt(agent, mount),
       githubApp: this.usesGithubApp(agent)
     }
   }
@@ -451,20 +480,19 @@ export class WorkspaceManager {
   }
 
   /** Attest that this session's working directory is one root's worktree, or drop that attestation. */
-  private recordSessionCwdRoot(subtree: string, sessionWorktreeId: string, repoFullName?: string): void {
+  private async recordSessionCwdRoot(
+    agentId: string,
+    subtree: string,
+    sessionWorktreeId: string,
+    repoFullName?: string
+  ): Promise<void> {
+    const fs = this.fsFor(agentId)
     const marker = sessionCwdMarkerIn(subtree, sessionWorktreeId)
     if (repoFullName === undefined) {
-      rmSync(marker, { force: true })
+      await fs.rmTree(marker)
       return
     }
-    const temp = `${marker}.tmp`
-    try {
-      writeFileSync(temp, JSON.stringify({ repoFullName }, null, 2) + '\n', { mode: 0o600 })
-      renameSync(temp, marker)
-    } catch (err) {
-      rmSync(temp, { force: true })
-      throw err
-    }
+    await fs.writeFile(marker, JSON.stringify({ repoFullName }, null, 2) + '\n', { mode: 0o600 })
   }
 
   /**
@@ -905,8 +933,20 @@ export class WorkspaceManager {
     return this.resolveAcpCwd(cwd, agentDir)
   }
 
-  /** The agent's worktrees parent. Total by construction — a from-scratch workspace has one too. */
+  /** The agent's worktrees parent, wherever its workspace lives. Total by construction — a
+   *  from-scratch workspace has one too. */
   worktreesPathFor(agent: Agent): string {
+    return this.worktreesPathAt(agent, this.sandboxMountFor(agent.id))
+  }
+
+  /** The same parent in one mount's coordinates: beside the pod's checkout, or under the agent
+   *  directory when there is no mount. */
+  worktreesPathAt(agent: Agent, mount: string | undefined): string {
+    return mount === undefined ? this.localWorktreesPathFor(agent) : join(mount, 'worktrees')
+  }
+
+  /** THIS daemon's disk, always — for the callers whose subject is this host's own filesystem. */
+  localWorktreesPathFor(agent: Agent): string {
     return join(this.agentRootFor(agent), 'worktrees')
   }
 
@@ -924,40 +964,54 @@ export class WorkspaceManager {
    * boundary or it stays invisible until the next spawn.
    */
   trustedWorkspaceWriteRoots(agent: Agent): string[] {
+    // This host's own sandbox boundary, so a pod path here would carve out nothing.
     return [
-      ...(agent.workspace.mode === 'git-repo' ? [this.sessionWorktreeRoot(agent)] : []),
+      ...(agent.workspace.mode === 'git-repo' ? [this.localWorktreesPathFor(agent)] : []),
       this.secondaryRootsDir(agent)
     ]
   }
 
-  // Containment is per AGENT, not per root: every root's worktrees parent must resolve inside the agent directory.
-  validateWorktreesRoot(agent: Agent, worktreesPath: string): string {
-    if (lstatSync(worktreesPath).isSymbolicLink()) {
+  /**
+   * Containment for a worktrees parent, per AGENT rather than per root.
+   *
+   * Locally that means resolving symlinks and proving the canonical path stays inside the agent
+   * directory. On a pod there is nothing here to resolve them with — and nothing to gain: the shim's
+   * fd-anchored descent IS the containment, and it is stronger than any name check this side can
+   * make. So the daemon only proves it composed the path under the mount it was given.
+   */
+  async validateWorktreesRoot(agent: Agent, worktreesPath: string): Promise<string> {
+    const mount = this.sandboxMountFor(agent.id)
+    if ((await this.fsFor(agent.id).stat(worktreesPath)) === 'other') {
       throw new Error('session worktree root must not be a symlink')
+    }
+    if (mount !== undefined) {
+      if (escapesRoot(mount, worktreesPath)) throw new Error('session worktree root resolves outside the mount')
+      return worktreesPath
     }
     const agentRoot = realpathSync(this.agentRootFor(agent))
     const canonicalRoot = realpathSync(worktreesPath)
-    const rel = relative(agentRoot, canonicalRoot)
-    if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+    if (escapesRoot(agentRoot, canonicalRoot)) {
       throw new Error('session worktree root resolves outside the agent directory')
     }
     return canonicalRoot
   }
 
-  prepareSessionWorktreeRoot(agent: Agent): string {
-    return this.prepareWorktreesRoot(agent, this.worktreesPathFor(agent))
+  prepareSessionWorktreeRoot(agent: Agent, worktreesPath = this.worktreesPathFor(agent)): Promise<string> {
+    return this.prepareWorktreesRoot(agent, worktreesPath)
   }
 
-  prepareWorktreesRoot(agent: Agent, worktreesPath: string): string {
-    if (existsSync(worktreesPath) && lstatSync(worktreesPath).isSymbolicLink()) {
+  async prepareWorktreesRoot(agent: Agent, worktreesPath: string): Promise<string> {
+    const fs = this.fsFor(agent.id)
+    if ((await fs.stat(worktreesPath)) === 'other') {
       throw new Error('session worktree root must not be a symlink')
     }
-    mkdirSync(worktreesPath, { recursive: true, mode: 0o700 })
-    return this.validateWorktreesRoot(agent, worktreesPath)
+    await fs.mkdir(worktreesPath, 0o700)
+    return await this.validateWorktreesRoot(agent, worktreesPath)
   }
 
+  /** An `rmSync`, so its subject can only ever be this daemon's own disk. */
   clearSessionWorktrees(agent: Agent): void {
-    rmSync(this.sessionWorktreeRoot(agent), { recursive: true, force: true })
+    rmSync(this.localWorktreesPathFor(agent), { recursive: true, force: true })
   }
 
   sessionWorktreeId(sessionKey: string): string {
@@ -973,13 +1027,22 @@ export class WorkspaceManager {
    *  (decision 12), while a subtree a failed clone left behind owns none and has no checkout for
    *  Git to run in, which would fail the whole session's cleanup forever. */
   sessionWorktreeRoots(agent: Agent): Pick<WorkspaceRoot, 'path' | 'worktreesPath'>[] {
+    const mount = this.sandboxMountFor(agent.id)
     return [
       ...(agent.workspace.mode === 'git-repo'
-        ? [{ path: agent.workspace.path, worktreesPath: this.worktreesPathFor(agent) }]
+        ? [
+            {
+              path: mount === undefined ? agent.workspace.path : this.clusterWorkspaceCheckout(agent, mount),
+              worktreesPath: this.worktreesPathAt(agent, mount)
+            }
+          ]
         : []),
-      ...secondarySubtreesIn(this.agentRootFor(agent))
-        .filter((entry) => existsSync(join(entry.path, '.git')))
-        .map(({ path, worktreesPath }) => ({ path, worktreesPath }))
+      // A sandboxed workspace has only the primary checkout, so these subtrees would judge this disk.
+      ...(this.sandboxMode
+        ? []
+        : secondarySubtreesIn(this.agentRootFor(agent))
+            .filter((entry) => existsSync(join(entry.path, '.git')))
+            .map(({ path, worktreesPath }) => ({ path, worktreesPath })))
     ]
   }
 
@@ -1086,12 +1149,13 @@ export class WorkspaceManager {
     root: Pick<WorkspaceRoot, 'path' | 'worktreesPath'>,
     id: string
   ): Promise<SessionWorktreeRemoval> {
+    const fs = this.fsFor(agent.id)
     const rootGit = () => this.runnerFor(agent.id, root.path).withEnv(workspaceGitLocalEnv())
     // Drop the stale Git registration, this worktree's daemon-owned review refs, and the attestation
     // that it was a session's working directory. Ref deletion is best-effort: most worktrees never
     // had review refs.
     const cleanupRegistrations = async () => {
-      this.recordSessionCwdRoot(dirname(root.path), id)
+      await this.recordSessionCwdRoot(agent.id, dirname(root.path), id)
       await rootGit().raw(['worktree', 'prune'])
       for (const name of ['base', 'head', 'merge']) {
         await rootGit()
@@ -1101,7 +1165,7 @@ export class WorkspaceManager {
     }
     try {
       const rootPath = root.worktreesPath
-      if (!existsSync(rootPath)) {
+      if ((await fs.stat(rootPath)) === 'missing') {
         // No root ⇒ no worktree directory can exist; Git may still hold a stale
         // registration/review refs for it.
         await cleanupRegistrations()
@@ -1110,19 +1174,20 @@ export class WorkspaceManager {
       // Re-derive cwd from the CANONICAL root: a symlinked root (or symlinked
       // ancestor) must never redirect the destructive branches below outside the
       // agent directory.
-      const cwd = join(this.validateWorktreesRoot(agent, rootPath), id)
-      if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) throw new Error('session worktree path is a symlink')
-      if (!existsSync(cwd)) {
+      const cwd = join(await this.validateWorktreesRoot(agent, rootPath), id)
+      const kind = await fs.stat(cwd)
+      if (kind === 'other') throw new Error('session worktree path is a symlink')
+      if (kind === 'missing') {
         await cleanupRegistrations()
         return { outcome: 'absent' }
       }
-      if (!existsSync(join(cwd, '.git'))) {
+      if ((await fs.stat(join(cwd, '.git'))) === 'missing') {
         // The `.git` marker is gone, so Git no longer considers this a worktree —
         // but a NONEMPTY directory may hold exactly the untracked work this GC
         // promises never to auto-delete (`status` can't run without the marker).
         // Reclaim only a provably empty leftover; report anything else.
-        if (readdirSync(cwd).length > 0) return { outcome: 'retained', reason: 'dirty' }
-        rmSync(cwd, { recursive: true, force: true })
+        if ((await fs.readdir(cwd)).length > 0) return { outcome: 'retained', reason: 'dirty' }
+        await fs.rmTree(cwd)
         await cleanupRegistrations()
         return { outcome: 'removed' }
       }
@@ -1164,6 +1229,13 @@ export class WorkspaceManager {
     } catch (err) {
       return { outcome: 'failed', error: (err as Error).message }
     }
+  }
+
+  /** The path a caller may hold onto. Locally that is the canonical one, since a symlinked ancestor
+   *  would otherwise let two names for one directory disagree; on a pod there is no symlink to
+   *  resolve from here, and the shim's own descent is what decides where the name lands. */
+  canonicalWorkspacePath(agentId: string, path: string): string {
+    return this.sandboxMountFor(agentId) === undefined ? realpathSync(path) : path
   }
 
   exactObjectId(value: string, label: string): string {
@@ -1261,22 +1333,27 @@ export class WorkspaceManager {
     }
   }
 
-  prepareGithubRevisionOnlyWorkspace(agent: Agent, id: string): string {
-    const root = this.prepareSessionWorktreeRoot(agent)
+  async prepareGithubRevisionOnlyWorkspace(
+    agent: Agent,
+    id: string,
+    worktreesPath = this.worktreesPathFor(agent)
+  ): Promise<string> {
+    const fs = this.fsFor(agent.id)
+    const root = await this.prepareSessionWorktreeRoot(agent, worktreesPath)
     const cwd = join(root, id)
-    if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) {
+    if ((await fs.stat(cwd)) === 'other') {
       throw new Error('github review workspace path must not be a symlink')
     }
     const staged = `${cwd}.review-${randomUUID()}`
-    mkdirSync(staged, { recursive: true, mode: 0o700 })
+    await fs.mkdir(staged, 0o700)
     try {
-      rmSync(cwd, { recursive: true, force: true })
-      renameSync(staged, cwd)
+      await fs.rmTree(cwd)
+      await fs.rename(staged, cwd)
     } catch (err) {
-      rmSync(staged, { recursive: true, force: true })
+      await fs.rmTree(staged)
       throw err
     }
-    return realpathSync(cwd)
+    return this.canonicalWorkspacePath(agent.id, cwd)
   }
 
   async addRootSessionWorktree(
@@ -1316,8 +1393,8 @@ export class WorkspaceManager {
       const id = this.sessionWorktreeId(request.sessionKey)
       // The cwd becomes the primary's own empty directory, so no root may go on attesting that this
       // session stands in it — a surviving attestation would refuse the very fallback prepared here.
-      this.forgetSessionCwdRoots(agent, id)
-      return this.prepareGithubRevisionOnlyWorkspace(agent, id)
+      await this.forgetSessionCwdRoots(agent, id)
+      return await this.prepareGithubRevisionOnlyWorkspace(agent, id)
     }
     // Resolved before anything is materialized: a review naming a repository this agent has no root
     // for must leave no worktree behind for the caller's revision-only fallback to step around.
@@ -1375,14 +1452,19 @@ export class WorkspaceManager {
     // failed a post-step must leave the caller's revision-only fallback a primary cwd it can use,
     // while a later preparation of a placed session — in a fresh process, carrying no review —
     // resolves this same working directory.
-    this.recordSessionCwdRoot(dirname(prepared.path), this.sessionWorktreeId(request.sessionKey), prepared.repoFullName)
+    await this.recordSessionCwdRoot(
+      agent.id,
+      dirname(prepared.path),
+      this.sessionWorktreeId(request.sessionKey),
+      prepared.repoFullName
+    )
     return acpCwd
   }
 
   /** Drop every root's attestation that it holds one session's working directory. */
-  private forgetSessionCwdRoots(agent: Agent, sessionWorktreeId: string): void {
+  private async forgetSessionCwdRoots(agent: Agent, sessionWorktreeId: string): Promise<void> {
     for (const entry of secondarySubtreesIn(this.agentRootFor(agent))) {
-      this.recordSessionCwdRoot(entry.subtree, sessionWorktreeId)
+      await this.recordSessionCwdRoot(agent.id, entry.subtree, sessionWorktreeId)
     }
   }
 
@@ -1442,25 +1524,26 @@ export class WorkspaceManager {
     root: WorkspaceRoot,
     request: PrepareSessionWorkspaceRequest
   ): Promise<string> {
+    const fs = this.fsFor(agent.id)
     const id = this.sessionWorktreeId(request.sessionKey)
-    const worktreesRoot = this.prepareWorktreesRoot(agent, root.worktreesPath)
+    const worktreesRoot = await this.prepareWorktreesRoot(agent, root.worktreesPath)
     const cwd = join(worktreesRoot, id)
-    if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) {
+    if ((await fs.stat(cwd)) === 'other') {
       throw new Error('session worktree path must not be a symlink')
     }
     const review = request.review ? await this.fetchReviewRevisionIn(agent.id, root, id, request.review) : undefined
     const target = review?.checkout ?? `refs/remotes/origin/${root.branch}`
-    let attached = existsSync(join(cwd, '.git'))
+    let attached = (await fs.stat(join(cwd, '.git'))) !== 'missing'
     if (attached) {
       try {
         await this.revParse(agent.id, cwd, 'HEAD')
       } catch {
         attached = false
-        rmSync(cwd, { recursive: true, force: true })
+        await fs.rmTree(cwd)
       }
     }
     if (!attached) {
-      rmSync(cwd, { recursive: true, force: true })
+      await fs.rmTree(cwd)
       await this.runnerFor(agent.id, root.path).withEnv(workspaceGitLocalEnv()).raw(['worktree', 'prune'])
       // prepareWorkspace's pull is best-effort (and may be disabled), but this
       // checkout runs in the daemon process. Unsafe executable config must gate
@@ -1481,25 +1564,24 @@ export class WorkspaceManager {
     return cwd
   }
 
-  clusterWorkspaceCwd(
-    agent: Agent,
-    runtimeRoot: string | undefined,
-    request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
-  ): string {
-    this.refuseSessionIsolationInCluster(agent, request)
-    const checkout = this.clusterWorkspaceCheckout(agent, runtimeRoot)
-    if (agent.workspace.mode === 'from-scratch') return checkout
+  clusterWorkspaceCwd(agent: Agent, runtimeRoot: string | undefined, request?: ClusterSessionScope): string {
+    const root = this.clusterSessionRootAt(agent, runtimeRoot, request)
+    if (agent.workspace.mode === 'from-scratch') return root
     // The configured working subdirectory is applied LEXICALLY here: validating it means resolving
     // symlinks and stat-ing, which only means something in the filesystem that holds it — so the shim
     // does that when it refuses a cwd outside its own root.
     const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
-    return agentDir === undefined ? checkout : join(checkout, ...agentDir.split('/'))
+    return agentDir === undefined ? root : join(root, ...agentDir.split('/'))
   }
 
-  refuseSessionIsolationInCluster(agent: Agent, request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>): void {
-    if (request?.isolation === 'session') {
-      throw new Error(`session-isolated workspaces are not supported with --k8s yet (agent "${agent.id}")`)
+  /** The checkout root a cluster session stands in: its own worktree beside the checkout when the
+   *  session is isolated, the checkout itself when every session shares it. */
+  private clusterSessionRootAt(agent: Agent, runtimeRoot: string | undefined, request?: ClusterSessionScope): string {
+    const mount = runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
+    if (agent.workspace.mode !== 'git-repo' || request?.isolation !== 'session' || request.sessionKey === undefined) {
+      return this.clusterWorkspaceCheckout(agent, mount)
     }
+    return join(this.worktreesPathAt(agent, mount), this.sessionWorktreeId(request.sessionKey))
   }
 
   clusterWorkspaceCheckout(agent: Agent, runtimeRoot: string | undefined): string {
@@ -1511,19 +1593,17 @@ export class WorkspaceManager {
     agent: Agent,
     local: string | undefined,
     runtimeRoot: string | undefined,
-    request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
+    request?: ClusterSessionScope
   ): string | undefined {
     if (local === undefined || !this.sandboxMode) return local
-    this.refuseSessionIsolationInCluster(agent, request)
-    return this.clusterWorkspaceCheckout(agent, runtimeRoot)
+    return this.clusterSessionRootAt(agent, runtimeRoot, request)
   }
 
   async prepareClusterWorkspace(
     agent: Agent,
     runtimeRoot: string | undefined,
-    request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
+    request?: PrepareSessionWorkspaceRequest
   ): Promise<string> {
-    const acpCwd = this.clusterWorkspaceCwd(agent, runtimeRoot, request)
     const root = runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
     const checkout = join(root, SANDBOX_CHECKOUT_DIR)
     const targetMarker = this.materializationKey(agent)
@@ -1548,7 +1628,7 @@ export class WorkspaceManager {
       // Provable by construction: the checkout is gone, so the volume holds exactly the scratch
       // workspace the configuration asks for. Recording it is what ends the conversion.
       if (conversionDue) this.recordMaterializationBestEffort(agent)
-      return acpCwd
+      return await this.prepareClusterSessionCwd(agent, root, request)
     }
     // Validated at the execution boundary, exactly as the local path does: a hand-edited agent.json
     // must not turn daemon-managed git into a local-path or remote-helper launcher.
@@ -1618,15 +1698,42 @@ export class WorkspaceManager {
       const head = await this.clusterCheckoutBranch(agent.id, checkout)
       volumeMatchesConfig = head === agent.workspace.gitBranch && (repositoryAttested || pulled)
     }
-    if (!volumeMatchesConfig) {
+    if (volumeMatchesConfig) {
+      this.recordMaterializationBestEffort(agent)
+    } else {
       workspaceLog.warn(
         `workspace: the volume for agent "${agent.id}" does not provably hold ${repository} @ ` +
           `${agent.workspace.gitBranch} — leaving its materialization marker unchanged`
       )
-      return acpCwd
     }
-    this.recordMaterializationBestEffort(agent)
-    return acpCwd
+    return await this.prepareClusterSessionCwd(agent, root, request)
+  }
+
+  /**
+   * The pod cwd one session stands in, once its checkout is ready.
+   *
+   * The same three shapes the local path has, against the same portable code: a shared session gets
+   * the checkout, an isolated one its own `<mount>/worktrees/<sid>` (which is also what gives a pool
+   * agent an exact same-repository review checkout), and a review with no local checkout to trust
+   * gets an empty daemon-owned directory beside them.
+   */
+  private async prepareClusterSessionCwd(
+    agent: Agent,
+    mount: string,
+    request?: PrepareSessionWorkspaceRequest
+  ): Promise<string> {
+    if (request?.githubReviewRevisionOnly) {
+      if (agent.workspace.mode !== 'git-repo' || request.isolation !== 'session' || request.review) {
+        throw new Error('github revision-only workspace requires an isolated git-repo review session')
+      }
+      const id = this.sessionWorktreeId(request.sessionKey)
+      return await this.prepareGithubRevisionOnlyWorkspace(agent, id, this.worktreesPathAt(agent, mount))
+    }
+    // A from-scratch workspace keeps the mount: isolation has no clone to branch off, as locally.
+    if (request?.isolation === 'session' && agent.workspace.mode === 'git-repo') {
+      await this.prepareRootSessionWorktree(agent, this.primaryRootAt(agent, mount), request)
+    }
+    return this.clusterWorkspaceCwd(agent, mount, request)
   }
 
   recordMaterializationBestEffort(agent: Agent): void {
@@ -1984,6 +2091,12 @@ export class WorkspaceManager {
   }
 }
 
+/** Whether `path` sits outside `root`, on paths both already expressed in the same coordinates. */
+function escapesRoot(root: string, path: string): boolean {
+  const rel = relative(root, path)
+  return isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)
+}
+
 /** The identity two `owner/repo` names are compared by: case-insensitive and blind to a `.git` suffix. */
 function repoKey(repoFullName: string): string {
   return repoFullName
@@ -2037,6 +2150,15 @@ class UntrustedGithubWorkspaceOriginError extends Error {
 // Resolves where one agent's git runs. Per-agent because a cluster workspace's runner is bound to
 // that agent's own sandbox channel; undefined means local, so self-hosting needs no registration.
 export type WorkspaceGitRunnerResolver = (agentId: string, cwd?: string, abort?: AbortSignal) => GitRunner | undefined
+
+/**
+ * Resolves WHERE one agent's workspace files are — the filesystem twin of the runner resolver above.
+ *
+ * Per agent for the same reason, and it answers with the mount as well as the filesystem because the
+ * two are one fact: a manager that knew which filesystem to ask but not which coordinates to ask in
+ * would compose this daemon's paths and send them to a pod that has none of them.
+ */
+export type WorkspaceFsResolver = (agentId: string) => WorkspacePlacement | undefined
 
 // Every git operation here routes through this: a direct gitFor still passes locally and then runs
 // a cluster agent's git on the wrong filesystem.
@@ -2210,10 +2332,6 @@ export type SessionWorktreeRemoval = (
  * can see. The root comes from the bound shim's hello; a legacy shim that reported none
  * gets the one mount layout such images ever had.
  */
-
-/** A logical-session worktree needs a daemon-owned parent beside the checkout, `worktree add` in the
- *  sandbox, and a retention GC that reads the pod's tree — a separate migration, and a clear error
- *  beats a mystery one from git inside the sandbox. */
 
 /** Where a CLUSTER agent's tree ROOT is in the pod's coordinates: the mounted volume for a
  *  from-scratch workspace, and the checkout one level down (away from the runtime's HOME) for a

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -1186,8 +1186,12 @@ export class WorkspaceManager {
         // but a NONEMPTY directory may hold exactly the untracked work this GC
         // promises never to auto-delete (`status` can't run without the marker).
         // Reclaim only a provably empty leftover; report anything else.
-        if ((await fs.readdir(cwd)).length > 0) return { outcome: 'retained', reason: 'dirty' }
-        await fs.rmTree(cwd)
+        //
+        // ONE operation, never a proof followed by a recursive delete: the runtime is still running
+        // on this tree, so anything written between the two would be destroyed by a removal that the
+        // emptiness proof licensed. `rmdir` refuses a non-empty directory itself, so a file that
+        // arrives first keeps the session instead of being deleted.
+        if (!(await fs.rmdir(cwd))) return { outcome: 'retained', reason: 'dirty' }
         await cleanupRegistrations()
         return { outcome: 'removed' }
       }

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -12,6 +12,7 @@ import {
   sandboxGitCredentialTarget
 } from '../src/workspace/git-injection.js'
 import { SANDBOX_CHECKOUT_DIR } from '../src/shim/sandbox-paths.js'
+import { PodWorkspaceFs } from './fixtures/pod-workspace-fs.js'
 import type { GitRunner } from '../src/workspace/git-runner.js'
 import type { Agent } from '../src/agents/agent-schema.js'
 
@@ -30,6 +31,7 @@ import type { Agent } from '../src/agents/agent-schema.js'
 
 const POD_ROOT = '/agent'
 const CHECKOUT = `${POD_ROOT}/${SANDBOX_CHECKOUT_DIR}`
+const WORKTREES = `${POD_ROOT}/worktrees`
 
 interface Invocation {
   cwd: string | undefined
@@ -53,6 +55,23 @@ let clearFails = false
 /** The repo-local helper pin failing AFTER a successful clone — it runs outside the clone's own
  *  cleanup, so the checkout survives while nothing has proved it. */
 let helperWriteFails = false
+/** The pod's volume as this daemon can see it: only through the workspace-fs seam. */
+let pod = new PodWorkspaceFs(POD_ROOT)
+/** What `rev-parse --verify <ref>^{commit}` answers, so a review can be verified without a real git. */
+let revs: Record<string, string> = {}
+/** `rev-list --count` — anything but '0' is work the worktree GC must refuse to discard. */
+let uniqueCommits = '0'
+/** `status --porcelain` in a worktree; non-empty is a dirty tree. */
+let worktreeStatus = ''
+/** GitHub's merge ref is optional, and a conflicted PR simply has none. */
+let mergeRefAvailable = false
+/** What HEAD resolves to in whichever worktree is being asked; `worktree add` and `reset` move it. */
+let headRev: string | undefined
+
+/** A ref name as a commit id, the way `worktree add`/`reset` move HEAD onto their start point. */
+function resolve(ref: string): string {
+  return revs[ref] ?? ref
+}
 
 function recordingRunner(cwd: string | undefined, env: Record<string, string> = {}): GitRunner {
   const run = async (args: string[]): Promise<string> => {
@@ -64,6 +83,36 @@ function recordingRunner(cwd: string | undefined, env: Record<string, string> = 
     if (args[0] === 'config' && args.includes('--add') && helperWriteFails) throw new Error('helper pin refused')
     if (args[0] === 'remote' && args[1] === 'get-url') return originUrl
     if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return headBranch
+    if (args[0] === 'rev-parse' && args[1] === '--verify') {
+      const ref = args[2]!.replace(/\^\{commit\}$/, '')
+      const sha = ref === 'HEAD' ? headRev : revs[ref]
+      if (sha === undefined) throw new Error(`unknown revision ${ref}`)
+      return sha
+    }
+    // No branch of that name yet, so the first drawn one is the one `worktree add` gets.
+    if (args[0] === 'show-ref') throw new Error('no such ref')
+    // `worktree add` is what CREATES the directory on the volume, so the fake pod learns about it here.
+    if (args[0] === 'worktree' && args[1] === 'add') {
+      const target = args.at(-2)!
+      void pod.mkdir(target)
+      void pod.writeFile(`${target}/.git`, 'gitdir: ...')
+      headRev = resolve(args.at(-1)!)
+      return ''
+    }
+    if (args[0] === 'worktree' && args[1] === 'remove') {
+      void pod.rmTree(args[2]!)
+      return ''
+    }
+    if (args[0] === 'reset' && args[1] === '--hard') {
+      headRev = resolve(args[2]!)
+      return ''
+    }
+    if (args[0] === 'fetch' && args.some((arg) => arg.includes('/merge:')) && !mergeRefAvailable) {
+      throw new Error('no merge ref for a conflicted pull request')
+    }
+    if (args[0] === 'status') return worktreeStatus
+    if (args[0] === 'rev-list' && args.includes('--count')) return uniqueCommits
+    if (args[0] === 'symbolic-ref') return 'dev/alice/quiet-harbor'
     return ''
   }
   const runner: GitRunner = {
@@ -122,8 +171,15 @@ beforeEach(() => {
   pullFails = false
   clearFails = false
   helperWriteFails = false
-  // Every agent here runs in a pod, so both seams resolve to the sandbox.
+  pod = new PodWorkspaceFs(POD_ROOT)
+  revs = {}
+  uniqueCommits = '0'
+  worktreeStatus = ''
+  mergeRefAvailable = false
+  headRev = undefined
+  // Every agent here runs in a pod, so all three seams resolve to the sandbox.
   workspaces.setGitRunnerResolver((_agentId, cwd) => recordingRunner(cwd))
+  workspaces.setFsResolver(() => ({ fs: pod, mount: POD_ROOT }))
   workspaces.setPathClearer(async (_agentId, root) => {
     cleared.push(root)
     // Emptying the checkout is precisely what makes the pod's probe stop finding one.
@@ -144,6 +200,7 @@ beforeEach(() => {
 
 afterEach(() => {
   workspaces.setGitRunnerResolver(undefined)
+  workspaces.setFsResolver(undefined)
   workspaces.setPathClearer(undefined)
   workspaces.setSandboxMode(false)
 })
@@ -176,12 +233,19 @@ describe('clusterWorkspaceCwd', () => {
     expect(workspaces.additionalWorkspaceDirectories(clusterAgent(), CHECKOUT)).toEqual([])
   })
 
-  it('still refuses session isolation rather than half-supporting it', () => {
-    // A logical-session worktree needs a daemon-owned parent, `worktree add` in the sandbox, and a
-    // retention GC that reads the pod's tree — none of which this change provides.
-    expect(() => workspaces.clusterWorkspaceCwd(clusterAgent(), POD_ROOT, { isolation: 'session' })).toThrow(
-      /session-isolated workspaces are not supported/
-    )
+  it('puts a session-isolated cwd in the worktree that session owns, beside the checkout', () => {
+    const id = workspaces.sessionWorktreeId('sess-1')
+    expect(
+      workspaces.clusterWorkspaceCwd(clusterAgent(), POD_ROOT, { isolation: 'session', sessionKey: 'sess-1' })
+    ).toBe(`${WORKTREES}/${id}`)
+    // And the configured working subdirectory still applies, one level inside THAT worktree.
+    const agent = clusterAgent({ agentDir: 'services/api' })
+    const scope = { isolation: 'session' as const, sessionKey: 'sess-1' }
+    const cwd = workspaces.clusterWorkspaceCwd(agent, POD_ROOT, scope)
+    expect(cwd).toBe(`${WORKTREES}/${id}/services/api`)
+    // The repository root handed alongside it is the WORKTREE, not the shared checkout — widened
+    // lexically, because the path exists on no filesystem this daemon could resolve it against.
+    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, scope)).toEqual([`${WORKTREES}/${id}`])
   })
 })
 
@@ -575,5 +639,158 @@ describe('replacing a cluster workspace in place', () => {
       workspaces.prepareWorkspaceForActivation(clusterAgent({ mode: 'from-scratch', path }))
     ).resolves.toBeTypeOf('function')
     rmSync(dirname(path), { recursive: true, force: true })
+  })
+})
+
+/**
+ * Session isolation on a pool member, which `--k8s` refused outright until the workspace-fs seam
+ * existed. Everything here is the SAME code the self-hosted path runs — the only difference is which
+ * filesystem answers `stat`/`mkdir`/`rmTree` and which coordinates the paths are composed in.
+ */
+describe('per-session worktrees on the pod volume', () => {
+  const SESSION = { sessionKey: 'sess-1', isolation: 'session' as const, initiatedBy: 'alice' }
+
+  function worktreeOf(key: string): string {
+    return `${WORKTREES}/${workspaces.sessionWorktreeId(key)}`
+  }
+
+  it('creates the worktree beside the checkout, through `worktree add` in the pod', async () => {
+    const cwd = await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, SESSION)
+    expect(cwd).toBe(worktreeOf('sess-1'))
+
+    // The parent is the pod's, created through the seam rather than with a daemon-side mkdir.
+    expect(await pod.stat(WORKTREES)).toBe('dir')
+    const add = calls.find((call) => call.args[0] === 'worktree' && call.args[1] === 'add')
+    // Run from the CHECKOUT (the object store the worktree hangs off), targeting the pod path.
+    expect(add).toMatchObject({ cwd: CHECKOUT })
+    expect(add!.args).toContain(worktreeOf('sess-1'))
+    expect(add!.args).toContain('refs/remotes/origin/main')
+    // Nothing about it names the daemon's own bookkeeping directory.
+    expect(JSON.stringify(add!.args)).not.toContain('/daemon/agents')
+    // And nothing was created on this daemon's disk — no `node:fs` ran on either path.
+    expect(existsSync(WORKTREES)).toBe(false)
+    expect(existsSync('/daemon/agents/agent-cluster/worktrees')).toBe(false)
+  })
+
+  it('reuses an attached worktree on the next turn instead of adding a second one', async () => {
+    await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, SESSION)
+    checkoutExists = true
+    calls.length = 0
+
+    const cwd = await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, SESSION)
+    expect(cwd).toBe(worktreeOf('sess-1'))
+    expect(calls.some((call) => call.args[0] === 'worktree' && call.args[1] === 'add')).toBe(false)
+    // And it was reused because the POD said the `.git` marker is there, not this daemon's disk.
+    expect(pod.files.has(`${worktreeOf('sess-1')}/.git`)).toBe(true)
+  })
+
+  it('gives a second session its own worktree', async () => {
+    await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, SESSION)
+    checkoutExists = true
+    const other = await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, {
+      ...SESSION,
+      sessionKey: 'sess-2'
+    })
+    expect(other).toBe(worktreeOf('sess-2'))
+    expect(other).not.toBe(worktreeOf('sess-1'))
+  })
+
+  it('fetches the reviewed refs and checks the exact head out, which pool agents never had', async () => {
+    const base = 'a'.repeat(40)
+    const head = 'b'.repeat(40)
+    const id = workspaces.sessionWorktreeId('sess-1')
+    revs[`refs/agentconnect/reviews/${id}/base`] = base
+    revs[`refs/agentconnect/reviews/${id}/head`] = head
+
+    const cwd = await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, {
+      ...SESSION,
+      review: { pullNumber: 7, baseSha: base, headSha: head }
+    })
+    expect(cwd).toBe(worktreeOf('sess-1'))
+
+    const fetch = calls.find((call) => call.args[0] === 'fetch')
+    expect(fetch).toMatchObject({ cwd: CHECKOUT })
+    expect(fetch!.args).toContain(`+refs/pull/7/head:refs/agentconnect/reviews/${id}/head`)
+    // The exact head is the start point, and HEAD is re-verified against it after the checkout.
+    expect(calls.find((call) => call.args[0] === 'worktree' && call.args[1] === 'add')!.args.at(-1)).toBe(head)
+  })
+
+  it('refuses a review worktree whose head ref is not the verified revision', async () => {
+    const base = 'a'.repeat(40)
+    const head = 'b'.repeat(40)
+    const id = workspaces.sessionWorktreeId('sess-1')
+    revs[`refs/agentconnect/reviews/${id}/base`] = base
+    // The head ref resolving elsewhere is exactly the case the verification exists for.
+    revs[`refs/agentconnect/reviews/${id}/head`] = 'c'.repeat(40)
+    await expect(
+      workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, {
+        ...SESSION,
+        review: { pullNumber: 7, baseSha: base, headSha: head }
+      })
+    ).rejects.toThrow(/did not resolve to the requested SHA/)
+  })
+
+  it('hands a revision-only review an empty pod directory, with no checkout to trust', async () => {
+    const cwd = await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, {
+      ...SESSION,
+      githubReviewRevisionOnly: true
+    })
+    expect(cwd).toBe(worktreeOf('sess-1'))
+    // Staged then published by a rename, on the volume — and empty, so no `worktree add` ran.
+    expect(await pod.stat(cwd)).toBe('dir')
+    expect(await pod.readdir(cwd)).toEqual([])
+    expect(calls.some((call) => call.args[0] === 'worktree' && call.args[1] === 'add')).toBe(false)
+  })
+
+  it('removes the worktree through the seam, in the pod coordinates it was created in', async () => {
+    await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, SESSION)
+    checkoutExists = true
+    calls.length = 0
+
+    expect(await workspaces.removeSessionWorktree(clusterAgent(), 'sess-1')).toEqual({ outcome: 'removed' })
+    const flat = calls.map((call) => call.args.join(' '))
+    expect(flat).toContain(`worktree remove ${worktreeOf('sess-1')}`)
+    expect(flat).toContain('worktree prune')
+    expect(await pod.stat(worktreeOf('sess-1'))).toBe('missing')
+  })
+
+  it('keeps a dirty worktree, judged by the POD and not by an empty directory on this disk', async () => {
+    await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, SESSION)
+    checkoutExists = true
+    worktreeStatus = ' M a.txt\n'
+
+    expect(await workspaces.removeSessionWorktree(clusterAgent(), 'sess-1')).toEqual({
+      outcome: 'retained',
+      reason: 'dirty'
+    })
+    expect(await pod.stat(worktreeOf('sess-1'))).toBe('dir')
+  })
+
+  it('keeps a worktree holding commits no remote can reach', async () => {
+    await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, SESSION)
+    checkoutExists = true
+    uniqueCommits = '2'
+
+    expect(await workspaces.removeSessionWorktree(clusterAgent(), 'sess-1')).toEqual({
+      outcome: 'retained',
+      reason: 'unique-commits'
+    })
+  })
+
+  it('refuses a worktrees parent the pod does not report as a directory', async () => {
+    // On the pod the fd-anchored descent is the containment; the daemon still refuses what it sees.
+    pod.links.add(WORKTREES)
+    await expect(workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, SESSION)).rejects.toThrow(
+      /must not be a symlink/
+    )
+  })
+
+  it('leaves a shared session on the checkout, with no worktree at all', async () => {
+    const cwd = await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, {
+      sessionKey: 'sess-1',
+      isolation: 'shared'
+    })
+    expect(cwd).toBe(CHECKOUT)
+    expect(await pod.stat(WORKTREES)).toBe('missing')
   })
 })

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -766,6 +766,23 @@ describe('per-session worktrees on the pod volume', () => {
     expect(await pod.stat(worktreeOf('sess-1'))).toBe('dir')
   })
 
+  it('keeps a leftover the runtime refilled, instead of deleting it recursively', async () => {
+    // The `.git` marker is gone, so this is the reclaim-a-provably-empty-leftover branch. On the pod
+    // the runtime is still writing to the volume, so emptiness cannot be proved in one round trip and
+    // acted on in another — the removal itself has to refuse a directory that is no longer empty.
+    await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, SESSION)
+    checkoutExists = true
+    const cwd = worktreeOf('sess-1')
+    pod.files.delete(`${cwd}/.git`)
+    pod.files.set(`${cwd}/work.txt`, 'untracked work')
+
+    expect(await workspaces.removeSessionWorktree(clusterAgent(), 'sess-1')).toEqual({
+      outcome: 'retained',
+      reason: 'dirty'
+    })
+    expect(await pod.stat(`${cwd}/work.txt`)).toBe('file')
+  })
+
   it('keeps a worktree holding commits no remote can reach', async () => {
     await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT, SESSION)
     checkoutExists = true

--- a/packages/daemon/test/fixtures/memory-fs-pod.ts
+++ b/packages/daemon/test/fixtures/memory-fs-pod.ts
@@ -66,6 +66,14 @@ export function pathExecutor(): MemoryFsExecutor {
       const st = await fsp.stat(target)
       return { size: st.size, mtime: st.mtime.toISOString() }
     },
+    async stat(root, rel) {
+      try {
+        const st = await fsp.lstat(abs(root, rel))
+        return st.isDirectory() ? 'dir' : st.isFile() ? 'file' : 'other'
+      } catch {
+        return 'missing'
+      }
+    },
     async readdir(root, rel) {
       let dirents
       try {

--- a/packages/daemon/test/fixtures/memory-fs-pod.ts
+++ b/packages/daemon/test/fixtures/memory-fs-pod.ts
@@ -92,6 +92,17 @@ export function pathExecutor(): MemoryFsExecutor {
     async mkdir(root, rel) {
       await fsp.mkdir(abs(root, rel), { recursive: true })
     },
+    async rmdir(root, rel) {
+      try {
+        await fsp.rmdir(abs(root, rel))
+        return true
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code
+        if (code === 'ENOENT') return true
+        if (code === 'ENOTEMPTY' || code === 'EEXIST' || code === 'ENOTDIR') return false
+        throw err
+      }
+    },
     async rename(root, from, to) {
       try {
         await fsp.lstat(abs(root, from))

--- a/packages/daemon/test/fixtures/pod-workspace-fs.ts
+++ b/packages/daemon/test/fixtures/pod-workspace-fs.ts
@@ -1,0 +1,80 @@
+import type { WorkspaceFs, WorkspaceFsKind } from '../../src/workspace/workspace-fs.js'
+
+/**
+ * A pod volume as a map of paths, for tests whose subject is WHICH pod path the daemon touches.
+ *
+ * The real sandbox side is `ShimWorkspaceFs` over the fd-anchored channel and is exercised against a
+ * real tree in `workspace-fs.test.ts`; here the point is that the daemon composes and inspects the
+ * pod's coordinates at all, so an in-memory tree keeps the assertions about coordinates rather than
+ * about a filesystem.
+ */
+export class PodWorkspaceFs implements WorkspaceFs {
+  readonly dirs = new Set<string>()
+  readonly files = new Map<string, string>()
+  /** Paths the pod reports as neither file nor directory — a symlink is the one that matters. */
+  readonly links = new Set<string>()
+  readonly removed: string[] = []
+
+  constructor(...seedDirs: string[]) {
+    for (const dir of seedDirs) this.dirs.add(dir)
+  }
+
+  async stat(path: string): Promise<WorkspaceFsKind> {
+    if (this.links.has(path)) return 'other'
+    if (this.dirs.has(path)) return 'dir'
+    if (this.files.has(path)) return 'file'
+    return 'missing'
+  }
+
+  async readdir(path: string): Promise<string[]> {
+    const prefix = `${path}/`
+    const names = new Set<string>()
+    for (const entry of [...this.dirs, ...this.files.keys()]) {
+      if (!entry.startsWith(prefix)) continue
+      names.add(entry.slice(prefix.length).split('/')[0]!)
+    }
+    return [...names]
+  }
+
+  async mkdir(path: string): Promise<void> {
+    for (const part of ancestors(path)) this.dirs.add(part)
+  }
+
+  async readFile(path: string): Promise<string | undefined> {
+    return this.files.get(path)
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content)
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    if ((await this.stat(from)) === 'missing') throw new Error(`rename source does not exist: ${from}`)
+    for (const entry of [...this.dirs]) {
+      if (entry === from || entry.startsWith(`${from}/`)) {
+        this.dirs.delete(entry)
+        this.dirs.add(to + entry.slice(from.length))
+      }
+    }
+    for (const [entry, value] of [...this.files]) {
+      if (entry === from || entry.startsWith(`${from}/`)) {
+        this.files.delete(entry)
+        this.files.set(to + entry.slice(from.length), value)
+      }
+    }
+  }
+
+  async rmTree(path: string): Promise<void> {
+    this.removed.push(path)
+    for (const entry of [...this.dirs]) if (entry === path || entry.startsWith(`${path}/`)) this.dirs.delete(entry)
+    for (const entry of [...this.files.keys()]) {
+      if (entry === path || entry.startsWith(`${path}/`)) this.files.delete(entry)
+    }
+  }
+}
+
+/** Every directory on the way to `path`, so a recursive mkdir leaves each one stat-able. */
+function ancestors(path: string): string[] {
+  const parts = path.split('/').filter(Boolean)
+  return parts.map((_, index) => `/${parts.slice(0, index + 1).join('/')}`)
+}

--- a/packages/daemon/test/fixtures/pod-workspace-fs.ts
+++ b/packages/daemon/test/fixtures/pod-workspace-fs.ts
@@ -64,6 +64,13 @@ export class PodWorkspaceFs implements WorkspaceFs {
     }
   }
 
+  async rmdir(path: string): Promise<boolean> {
+    if ((await this.readdir(path)).length > 0) return false
+    this.dirs.delete(path)
+    this.removed.push(path)
+    return true
+  }
+
   async rmTree(path: string): Promise<void> {
     this.removed.push(path)
     for (const entry of [...this.dirs]) if (entry === path || entry.startsWith(`${path}/`)) this.dirs.delete(entry)

--- a/packages/daemon/test/shim-exec-handler.test.ts
+++ b/packages/daemon/test/shim-exec-handler.test.ts
@@ -94,6 +94,59 @@ describe('sandbox exec handler', () => {
     }
   })
 
+  it('serves the worktree inventory the pod-side session paths need', async () => {
+    // Each of these is called by the worktree and secondary-root paths, which run in the pod once
+    // the workspace-fs seam lets them. A subcommand the daemon calls and this side refuses is a
+    // session that fails on a pool member and works self-hosted.
+    const root = repository()
+    for (const args of [
+      ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+      ['show-ref', '--verify', '--quiet', 'refs/heads/main'],
+      ['branch', '--list']
+    ]) {
+      const result = (await handler(root)('exec', { tool: 'git', args })) as GitExecResult
+      expect(result.code).toBe(0)
+    }
+    for (const subcommand of ['branch', 'ls-remote', 'show-ref', 'symbolic-ref']) {
+      expect(ALLOWED_GIT_SUBCOMMANDS.has(subcommand)).toBe(true)
+    }
+  })
+
+  it('still refuses every execution option on the newly permitted subcommands', async () => {
+    // Widening the inventory must not widen what an argument may do: `-c` is refused as a PREFIX,
+    // in each of its accepted spellings, whatever subcommand carries it.
+    const root = repository()
+    const attacks = [
+      ['-c', 'core.pager=sh -c "id"', 'branch'],
+      ['branch', '-ccore.pager=EVIL'],
+      ['show-ref', '--config-env=core.pager=EVIL'],
+      ['symbolic-ref', '--config=core.pager=EVIL'],
+      ['ls-remote', '--upload-pack=sh -c "id"', 'origin'],
+      ['branch', '--exec-path=/tmp/evil']
+    ]
+    for (const args of attacks) {
+      await expect(handler(root)('exec', { tool: 'git', args })).rejects.toBeInstanceOf(ExecRefusedError)
+    }
+  })
+
+  it('refuses a worktree path outside the workspace root, which the cwd fence never sees', async () => {
+    // `worktree add`/`remove` name an absolute directory in argv and create or delete it, exactly as
+    // a clone target does — so the same containment applies, on the side holding the filesystem.
+    const root = repository()
+    const outside = mkdtempSync(join(tmpdir(), 'ac-worktree-outside-'))
+    roots.push(outside)
+    await expect(
+      handler(root)('exec', {
+        tool: 'git',
+        args: ['worktree', 'add', '-b', 'dev/alice/quiet-harbor', join(outside, 'stolen'), 'HEAD'],
+        cwd: root
+      })
+    ).rejects.toBeInstanceOf(ExecRefusedError)
+    await expect(
+      handler(root)('exec', { tool: 'git', args: ['worktree', 'remove', join(root, '..', 'escaped')], cwd: root })
+    ).rejects.toBeInstanceOf(ExecRefusedError)
+  })
+
   it('refuses a cwd outside the workspace root, whatever the daemon asked for', async () => {
     const root = repository()
     const outside = mkdtempSync(join(tmpdir(), 'ac-outside-'))

--- a/packages/daemon/test/shim-exec-handler.test.ts
+++ b/packages/daemon/test/shim-exec-handler.test.ts
@@ -130,8 +130,8 @@ describe('sandbox exec handler', () => {
   })
 
   it('refuses a worktree path outside the workspace root, which the cwd fence never sees', async () => {
-    // `worktree add`/`remove` name an absolute directory in argv and create or delete it, exactly as
-    // a clone target does — so the same containment applies, on the side holding the filesystem.
+    // `worktree add`/`remove` name a directory in argv and create or delete it, exactly as a clone
+    // target does — so the same containment applies, on the side holding the filesystem.
     const root = repository()
     const outside = mkdtempSync(join(tmpdir(), 'ac-worktree-outside-'))
     roots.push(outside)
@@ -145,6 +145,26 @@ describe('sandbox exec handler', () => {
     await expect(
       handler(root)('exec', { tool: 'git', args: ['worktree', 'remove', join(root, '..', 'escaped')], cwd: root })
     ).rejects.toBeInstanceOf(ExecRefusedError)
+  })
+
+  it('refuses a RELATIVE operand that escapes, which git resolves against the cwd', async () => {
+    // The trap an absolute-only check leaves open: git resolves `../escaped` against the cwd, so the
+    // fence passes it untouched and the write lands outside the root anyway.
+    const root = repository()
+    for (const args of [
+      ['worktree', 'add', '../escaped', 'HEAD'],
+      ['worktree', 'remove', '../escaped'],
+      ['clone', 'https://github.com/acme/repo.git', '../escaped']
+    ]) {
+      await expect(handler(root)('exec', { tool: 'git', args, cwd: root })).rejects.toBeInstanceOf(ExecRefusedError)
+    }
+    // A relative operand that stays inside is what the daemon actually sends, and it still runs.
+    const inside = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['worktree', 'add', '--detach', 'worktrees/one', 'HEAD'],
+      cwd: root
+    })) as GitExecResult
+    expect(inside.code).toBe(0)
   })
 
   it('refuses a cwd outside the workspace root, whatever the daemon asked for', async () => {

--- a/packages/daemon/test/workspace-fs.test.ts
+++ b/packages/daemon/test/workspace-fs.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { LocalWorkspaceFs, type WorkspaceFs } from '../src/workspace/workspace-fs.js'
 import { ShimWorkspaceFs } from '../src/shim/workspace-fs-channel.js'
+import { ShimChannelLostError } from '../src/shim/channels.js'
 import { pathExecutor, shimRequester } from './fixtures/memory-fs-pod.js'
 
 /**
@@ -130,6 +131,17 @@ describe('ShimWorkspaceFs (the pod side)', () => {
     // side, and the frame is never sent so the pod is never asked to judge it.
     await expect(fs.stat('/etc/passwd')).rejects.toThrow(/outside the sandbox mount/)
     expect(requester.frames).toEqual([])
+  })
+
+  it('reports a lost channel as a failure rather than as an absent marker', async () => {
+    const mount = tempRoot()
+    // A refusal is data ("not there"); a transport failure is not, and a caller that read it as one
+    // would treat a dropped channel as evidence about the volume.
+    const fs = new ShimWorkspaceFs(
+      { agentId: 'bot-a', request: async () => Promise.reject(new ShimChannelLostError('renewal')) },
+      mount
+    )
+    await expect(fs.readFile(join(mount, 'marker.json'))).rejects.toBeInstanceOf(ShimChannelLostError)
   })
 
   it('keeps the local seam untouched by the channel — the daemon disk is still node:fs', async () => {

--- a/packages/daemon/test/workspace-fs.test.ts
+++ b/packages/daemon/test/workspace-fs.test.ts
@@ -111,6 +111,23 @@ for (const { name, fs, root } of subjects()) {
       await expect(fs.rename(join(root, 'rename', 'ghost'), published)).rejects.toThrow()
     })
 
+    it('reclaims an empty directory in ONE operation, and keeps one that is not', async () => {
+      // The removal itself decides, rather than a separate emptiness proof licensing a recursive
+      // delete: on a volume the runtime is writing to, whatever lands between the two would go.
+      const empty = join(root, 'rmdir', 'empty')
+      const held = join(root, 'rmdir', 'held')
+      await fs.mkdir(empty)
+      await fs.mkdir(held)
+      writeFileSync(join(held, 'work.txt'), 'untracked work')
+
+      expect(await fs.rmdir(empty)).toBe(true)
+      expect(await fs.stat(empty)).toBe('missing')
+      expect(await fs.rmdir(held)).toBe(false)
+      expect(await fs.stat(join(held, 'work.txt'))).toBe('file')
+      // Nothing to remove is not a failure — the caller already saw it there a moment ago.
+      expect(await fs.rmdir(join(root, 'rmdir', 'gone'))).toBe(true)
+    })
+
     it('removes a whole tree, and says nothing when there is none', async () => {
       const tree = join(root, 'rm', 'a', 'b')
       await fs.mkdir(tree)

--- a/packages/daemon/test/workspace-fs.test.ts
+++ b/packages/daemon/test/workspace-fs.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { LocalWorkspaceFs, type WorkspaceFs } from '../src/workspace/workspace-fs.js'
+import { ShimWorkspaceFs } from '../src/shim/workspace-fs-channel.js'
+import { pathExecutor, shimRequester } from './fixtures/memory-fs-pod.js'
+
+/**
+ * The two halves of the workspace-fs seam, held to ONE contract.
+ *
+ * That is the whole point of the seam: a cluster agent's worktree paths and a self-hosted one's run
+ * the same code, and the only thing that differs is which filesystem answers. So the behaviours are
+ * asserted against both implementations from one table — a divergence here is a divergence in what a
+ * pool agent's session worktree does, which is exactly the class of bug the seam replaces.
+ *
+ * `stat` carries the most weight: it is what the local code expressed as `existsSync` plus an
+ * `lstatSync().isSymbolicLink()` refusal, and collapsing those into one answer is what makes the
+ * refusal portable.
+ */
+
+const roots: string[] = []
+afterAll(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function tempRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'ac-wsfs-'))
+  roots.push(dir)
+  return dir
+}
+
+/** The same tree reached two ways: directly, and through the shim channel anchored at its mount. */
+function subjects(): Array<{ name: string; fs: WorkspaceFs; root: string }> {
+  const local = tempRoot()
+  const mount = tempRoot()
+  return [
+    { name: 'LocalWorkspaceFs', fs: new LocalWorkspaceFs(), root: local },
+    { name: 'ShimWorkspaceFs', fs: new ShimWorkspaceFs(shimRequester(mount, pathExecutor()), mount), root: mount }
+  ]
+}
+
+for (const { name, fs, root } of subjects()) {
+  describe(name, () => {
+    it('answers what a path IS, and never follows a symlink to say it', async () => {
+      const dir = join(root, 'stat')
+      await fs.mkdir(dir)
+      writeFileSync(join(dir, 'file.txt'), 'x')
+      mkdirSync(join(dir, 'sub'))
+      symlinkSync(join(dir, 'sub'), join(dir, 'link-to-dir'))
+
+      expect(await fs.stat(dir)).toBe('dir')
+      expect(await fs.stat(join(dir, 'file.txt'))).toBe('file')
+      expect(await fs.stat(join(dir, 'sub'))).toBe('dir')
+      // The refusal the worktree paths depend on: a symlink is never a directory they may use.
+      expect(await fs.stat(join(dir, 'link-to-dir'))).toBe('other')
+      expect(await fs.stat(join(dir, 'nope'))).toBe('missing')
+    })
+
+    it('creates parents on the way, like `mkdir -p`', async () => {
+      const nested = join(root, 'mk', 'a', 'b')
+      await fs.mkdir(nested)
+      expect(await fs.stat(nested)).toBe('dir')
+      // Idempotent: session preparation runs it on every turn.
+      await fs.mkdir(nested)
+      expect(await fs.stat(nested)).toBe('dir')
+    })
+
+    it('lists entry names, and reads a file back or nothing at all', async () => {
+      const dir = join(root, 'list')
+      await fs.mkdir(join(dir, 'child'))
+      writeFileSync(join(dir, 'a.txt'), 'A')
+      expect((await fs.readdir(dir)).sort()).toEqual(['a.txt', 'child'])
+      expect(await fs.readFile(join(dir, 'a.txt'))).toBe('A')
+      expect(await fs.readFile(join(dir, 'missing.txt'))).toBeUndefined()
+    })
+
+    it('publishes a write atomically and leaves no staging file behind', async () => {
+      const dir = join(root, 'write')
+      await fs.mkdir(dir)
+      const file = join(dir, 'marker.json')
+      await fs.writeFile(file, '{"v":1}\n', { mode: 0o600 })
+      expect(readFileSync(file, 'utf8')).toBe('{"v":1}\n')
+      // Nothing half-written survives: the directory holds the target and only the target.
+      expect(readdirSync(dir)).toEqual(['marker.json'])
+
+      // A second write replaces the contents rather than appending to what was there.
+      await fs.writeFile(file, '{"v":2}\n')
+      expect(readFileSync(file, 'utf8')).toBe('{"v":2}\n')
+      expect(readdirSync(dir)).toEqual(['marker.json'])
+    })
+
+    it('renames a staged directory onto its published name', async () => {
+      const staged = join(root, 'rename', 'staged')
+      const published = join(root, 'rename', 'published')
+      await fs.mkdir(staged)
+      await fs.rename(staged, published)
+      expect(await fs.stat(staged)).toBe('missing')
+      expect(await fs.stat(published)).toBe('dir')
+      // A source that is not there is a failure, not a silent no-op — the caller stages first.
+      await expect(fs.rename(join(root, 'rename', 'ghost'), published)).rejects.toThrow()
+    })
+
+    it('removes a whole tree, and says nothing when there is none', async () => {
+      const tree = join(root, 'rm', 'a', 'b')
+      await fs.mkdir(tree)
+      writeFileSync(join(tree, 'deep.txt'), 'x')
+      await fs.rmTree(join(root, 'rm', 'a'))
+      expect(await fs.stat(join(root, 'rm', 'a'))).toBe('missing')
+      await expect(fs.rmTree(join(root, 'rm', 'gone'))).resolves.toBeUndefined()
+    })
+  })
+}
+
+describe('ShimWorkspaceFs (the pod side)', () => {
+  it('refuses a path outside the mount before it reaches the wire', async () => {
+    const mount = tempRoot()
+    const requester = shimRequester(mount, pathExecutor())
+    const fs = new ShimWorkspaceFs(requester, mount)
+    // The daemon composes every path it sends under the mount; one that is not is a bug on this
+    // side, and the frame is never sent so the pod is never asked to judge it.
+    await expect(fs.stat('/etc/passwd')).rejects.toThrow(/outside the sandbox mount/)
+    expect(requester.frames).toEqual([])
+  })
+
+  it('keeps the local seam untouched by the channel — the daemon disk is still node:fs', async () => {
+    const local = tempRoot()
+    const fs = new LocalWorkspaceFs()
+    await fs.mkdir(join(local, 'worktrees'), 0o700)
+    // The mode is honoured here, where a second principal on the host could otherwise read it.
+    expect(lstatSync(join(local, 'worktrees')).mode & 0o777).toBe(0o700)
+  })
+})

--- a/packages/daemon/test/workspace-git-runner-seam.test.ts
+++ b/packages/daemon/test/workspace-git-runner-seam.test.ts
@@ -323,12 +323,16 @@ describe('consoleWorkspaceRoot', () => {
     expect(workspaces.consoleWorkspaceRoot(agentAt('/local/ws'), undefined, '/agent')).toBeUndefined()
   })
 
-  it('refuses a session-isolated worktree loudly rather than naming the shared checkout', () => {
+  it('names the per-session worktree on the volume, never the shared checkout', () => {
     workspaces.setSandboxMode(true)
-    expect(() =>
+    // The console addresses the repository the session stands in, and for an isolated session that
+    // is its own worktree — naming the shared checkout would answer about a different tree.
+    const id = workspaces.sessionWorktreeId('sess-1')
+    expect(
       workspaces.consoleWorkspaceRoot(agentAt('/local/ws'), '/local/ws/.sessions/abc', '/agent', {
-        isolation: 'session'
+        isolation: 'session',
+        sessionKey: 'sess-1'
       })
-    ).toThrow(/session-isolated/)
+    ).toBe(`/agent/worktrees/${id}`)
   })
 })

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -1065,8 +1065,20 @@ describe('workspaces.clusterWorkspaceCwd(--k8s pod coordinates)', () => {
     expect(workspaces.clusterWorkspaceCwd(agent, '/agent')).not.toContain('/var/lib/agentconnect')
   })
 
-  it('refuses session isolation, whose worktrees still assume the daemon filesystem', () => {
+  it('puts a session-isolated cwd in its own worktree beside the checkout', () => {
+    // The worktrees parent is the pod's, not the agent directory's: the daemon composes it in the
+    // coordinates the runtime and the shim both read.
+    const agent = gitRepoAgent('/var/lib/agentconnect/agents/bot-git/workspace')
+    const id = workspaces.sessionWorktreeId('sess-1')
+    expect(workspaces.clusterWorkspaceCwd(agent, '/agent', { isolation: 'session', sessionKey: 'sess-1' })).toBe(
+      `/agent/worktrees/${id}`
+    )
+  })
+
+  it('keeps a from-scratch workspace on the mount, which has no clone to branch a worktree off', () => {
     const agent = fromScratchAgent('/var/lib/agentconnect/agents/bot-a/workspace')
-    expect(() => workspaces.clusterWorkspaceCwd(agent, '/agent', { isolation: 'session' })).toThrow(/session-isolated/)
+    expect(workspaces.clusterWorkspaceCwd(agent, '/agent', { isolation: 'session', sessionKey: 'sess-1' })).toBe(
+      '/agent'
+    )
   })
 })


### PR DESCRIPTION
Phase 7, part 1 of [`docs/designs/multi-repository-workspaces.md`](docs/designs/multi-repository-workspaces.md) — the "Phase 7: cluster daemons" section is the spec.

## What and why

On a cluster (`--k8s`) daemon the workspace lives on the sandbox pod's volume, mounted where the pod reports (`/agent` today), while the daemon process runs on another machine. Every `node:fs` call in the session-worktree paths therefore inspected the daemon's own disk — and answered plausibly, which is what made it worth fencing off rather than debugging. That, and only that, is why session isolation was refused there: `refuseSessionIsolationInCluster` was a migration guard from the cwd-coordinates fix, not a design decision. Nothing about the pod forbids any of it — its ACP runtime already takes a per-session `cwd`, `git worktree` is in the exec allowlist, and the volume survives suspend/resume.

So this adds the filesystem twin of `GitRunner`, moves the worktree paths onto it, and drops the refusal. A pool agent with a `git-repo` workspace and `isolation: 'session'` now gets `<mount>/worktrees/<sid>`, and a formal review of the workspace repository gets its exact checkout there — which pool agents have never had; they fell back to revision-only inspection.

## The seam

`packages/daemon/src/workspace/workspace-fs.ts`. Derived from what the code already calls, not from what a filesystem can do:

| Op | Used for | `LocalWorkspaceFs` | `ShimWorkspaceFs` |
| --- | --- | --- | --- |
| `stat` → `file`/`dir`/`missing`/`other` | is `.git` there, does the worktree exist, the symlink refusal | `lstatSync` | new `stat` op on the channel |
| `readdir` | judging an empty leftover | `readdirSync` | `readdir` |
| `mkdir` (recursive) | the worktrees parent | `mkdirSync` | `mkdir` |
| `readFile` / atomic `writeFile` | the session-cwd attestation | `node:fs` | `read` / `append`+`commit` |
| `rename` | publishing a staged directory | `renameSync` | `rename` |
| `rmTree` | a broken worktree, a leftover | `rmSync` | the recursive fd-anchored `rm` |

`stat` never follows a symlink, so a link reads as `other` — that single answer is what the local code expressed as `existsSync` plus an `lstatSync().isSymbolicLink()` refusal, and collapsing them is what makes the refusal portable.

`ShimWorkspaceFs` is the daemon-side client of the same fd-anchored channel the managed memory tree already rides, which is "memory" only by its previous caller. It gains one op (`stat`); the wire op names are left as they are, since they are the contract a pod that is already running speaks, and a rename would break memory reads on such a pod for nothing. The neutral naming lives in the daemon-side types.

`WorkspaceManager.setFsResolver` sits beside `setGitRunnerResolver` and answers with the **mount** as well as the filesystem, because those are one fact: knowing which filesystem to ask but not which coordinates to ask in is exactly how the daemon's own paths end up being sent to a pod that has none of them. `primaryRootAt(agent, mount)` / `worktreesPathAt(agent, mount)` take one explicitly where the caller already holds it.

Also here: the exec allowlist gains `symbolic-ref`, `branch`, `show-ref` and `ls-remote` — each already called by these paths — and `worktree` argv now gets the same absolute-path containment `clone` has, since `worktree add`/`remove` create and delete a directory named in argv that the cwd fence never inspects.

## What a reviewer should check

- **No `node:fs` is left in the worktree paths.** `prepareWorktreesRoot`, `validateWorktreesRoot`, `prepareRootSessionWorktree`, `removeRootSessionWorktree`, `prepareGithubRevisionOnlyWorkspace`, `sessionWorktreeRoots` and the session-cwd attestation all go through `fsFor(agentId)`. The remaining `node:fs` in `workspace-manager.ts` is the local-only work: materialization markers beside the daemon's bookkeeping path, activation, staged clones, and the secondary roots (next change).
- **Local behaviour is byte-identical.** A self-hosted daemon registers no resolver, so every path takes `LocalWorkspaceFs` and the same realpath-inside-the-agent-directory containment as before. `trustedWorkspaceWriteRoots` deliberately stays on the local path — its subject is this host's own OS sandbox boundary, where a pod path would carve out nothing.
- **Containment on the sandbox is the shim's descent.** The daemon composes `<mount>/worktrees/<sid>` and proves only that it composed it under the mount; the pod resolves it from an open descriptor one component at a time, refusing symlinks, which is stronger than any name check this side could make. `ShimWorkspaceFs` refuses a path outside the mount before the frame is sent.
- **The allowlist additions keep the prefix refusals.** There is a test per new subcommand proving `-c` / `-c<k=v>` / `--config=` / `--config-env=` / `--exec-path` / `--upload-pack` are still refused on it.
- **The retention sweep holds the volume.** Removal now runs inside the same Sandbox lease + bound channel that preparation uses — a suspended pod serves neither exec nor fs — and a pod that will not come up fails that one session rather than aborting the sweep.

## Not here

Secondary roots on the pod, and cross-repository review there: `prepareSecondaryRoots` keeps its sandbox short-circuit and `sessionWorktreeRoots` skips the local subtree scan for a sandboxed agent. That is the next change. No web, protocol or control-plane surface moves.

## Tests

- `test/workspace-fs.test.ts` — both implementations held to one contract, including the symlink → `other` answer and the atomic write.
- `test/cluster-workspace-prepare.test.ts` — session isolation creates the worktree through `worktree add` in the pod, a second turn reuses it, a second session gets its own, a review fetches the refs and checks out the verified head (and refuses a head ref that resolves elsewhere), a revision-only review yields an empty pod directory, removal removes and retains through the seam, and nothing lands on the daemon's disk.
- `test/shim-exec-handler.test.ts` — the new subcommands run, their execution options are still refused, and a `worktree` path outside the root is refused.
