### PR TITLE
fix(daemon): project the pod codex base URL into CODEX_CONFIG in the sandbox shim

### DIFF
--- a/packages/daemon/src/runtimes/codex-config.ts
+++ b/packages/daemon/src/runtimes/codex-config.ts
@@ -1,0 +1,50 @@
+// Codex's live base-URL surface is CODEX_CONFIG (codex-acp projects it into each session's
+// config over app-server); the OPENAI_BASE_URL env var is routing-inert to the pinned runtime.
+// This module is import-free on purpose: the sandbox shim bundle must not drag the daemon's
+// credential paths into the runtime image (see tsdown.shim.config.ts).
+
+export function objectFromJson(raw: string | undefined, label: string): Record<string, unknown> {
+  if (!raw?.trim()) return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new Error(`${label} must be a valid JSON object`)
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON object`)
+  }
+  return parsed as Record<string, unknown>
+}
+
+export function record(value: unknown, label: string): Record<string, unknown> {
+  if (value === undefined) return {}
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${label} must be a JSON object`)
+  return value as Record<string, unknown>
+}
+
+/** The one merge shape aiming codex at a base URL; throws on a malformed CODEX_CONFIG. */
+export function codexConfigWithBaseUrl(raw: string | undefined, baseUrl: string): string {
+  const config = objectFromJson(raw, 'CODEX_CONFIG')
+  const providers = record(config.model_providers, 'CODEX_CONFIG.model_providers')
+  const openai = record(providers.openai, 'CODEX_CONFIG.model_providers.openai')
+  return JSON.stringify({
+    ...config,
+    model_provider: 'openai',
+    model_providers: {
+      ...providers,
+      openai: { name: 'OpenAI', ...openai, base_url: baseUrl, env_key: 'OPENAI_API_KEY' }
+    }
+  })
+}
+
+/** Fill-in variant for the sandbox shim: undefined when the daemon already aimed codex somewhere. */
+export function codexConfigWithBaseUrlFillIn(raw: string | undefined, baseUrl: string): string | undefined {
+  const config = objectFromJson(raw, 'CODEX_CONFIG')
+  const provider = config.model_provider
+  if (typeof provider === 'string' && provider !== 'openai') return undefined
+  const providers = record(config.model_providers, 'CODEX_CONFIG.model_providers')
+  const openai = record(providers.openai, 'CODEX_CONFIG.model_providers.openai')
+  if (typeof openai.base_url === 'string' && openai.base_url.trim()) return undefined
+  return codexConfigWithBaseUrl(raw, baseUrl)
+}

--- a/packages/daemon/src/runtimes/codex-config.ts
+++ b/packages/daemon/src/runtimes/codex-config.ts
@@ -1,5 +1,8 @@
 // Codex's live base-URL surface is CODEX_CONFIG (codex-acp projects it into each session's
 // config over app-server); the OPENAI_BASE_URL env var is routing-inert to the pinned runtime.
+// The override must be the top-level `openai_base_url` key: Codex merges configured
+// `model_providers` with entry().or_insert(), so a `model_providers.openai` entry can never
+// replace the built-in provider and its base_url is discarded.
 // This module is import-free on purpose: the sandbox shim bundle must not drag the daemon's
 // credential paths into the runtime image (see tsdown.shim.config.ts).
 
@@ -26,16 +29,7 @@ export function record(value: unknown, label: string): Record<string, unknown> {
 /** The one merge shape aiming codex at a base URL; throws on a malformed CODEX_CONFIG. */
 export function codexConfigWithBaseUrl(raw: string | undefined, baseUrl: string): string {
   const config = objectFromJson(raw, 'CODEX_CONFIG')
-  const providers = record(config.model_providers, 'CODEX_CONFIG.model_providers')
-  const openai = record(providers.openai, 'CODEX_CONFIG.model_providers.openai')
-  return JSON.stringify({
-    ...config,
-    model_provider: 'openai',
-    model_providers: {
-      ...providers,
-      openai: { name: 'OpenAI', ...openai, base_url: baseUrl, env_key: 'OPENAI_API_KEY' }
-    }
-  })
+  return JSON.stringify({ ...config, model_provider: 'openai', openai_base_url: baseUrl })
 }
 
 /** Fill-in variant for the sandbox shim: undefined when the daemon already aimed codex somewhere. */
@@ -43,8 +37,6 @@ export function codexConfigWithBaseUrlFillIn(raw: string | undefined, baseUrl: s
   const config = objectFromJson(raw, 'CODEX_CONFIG')
   const provider = config.model_provider
   if (typeof provider === 'string' && provider !== 'openai') return undefined
-  const providers = record(config.model_providers, 'CODEX_CONFIG.model_providers')
-  const openai = record(providers.openai, 'CODEX_CONFIG.model_providers.openai')
-  if (typeof openai.base_url === 'string' && openai.base_url.trim()) return undefined
+  if (typeof config.openai_base_url === 'string' && config.openai_base_url.trim()) return undefined
   return codexConfigWithBaseUrl(raw, baseUrl)
 }

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -3,6 +3,7 @@ import type { RuntimeDef } from '../config/config-schema.js'
 import type { Agent } from '../agents/agent-schema.js'
 import { isClaudeRuntimeDef } from '../runtime-defs/claude-runtime.js'
 import { sharedCredentialProfile } from './runtime-credentials.js'
+import { codexConfigWithBaseUrl, objectFromJson, record } from './codex-config.js'
 
 export interface ModelCredential {
   key: string
@@ -15,43 +16,13 @@ export interface ModelProviderTarget {
   opencodeProvider?: string
 }
 
-function objectFromJson(raw: string | undefined, label: string): Record<string, unknown> {
-  if (!raw?.trim()) return {}
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(raw)
-  } catch {
-    throw new Error(`${label} must be a valid JSON object`)
-  }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error(`${label} must be a JSON object`)
-  }
-  return parsed as Record<string, unknown>
-}
-
-function record(value: unknown, label: string): Record<string, unknown> {
-  if (value === undefined) return {}
-  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${label} must be a JSON object`)
-  return value as Record<string, unknown>
-}
-
 function isOpenCodeRuntime(runtimeId: string, runtime: RuntimeDef): boolean {
   if (runtimeId === 'opencode') return true
   return [runtime.command, ...runtime.args].some((part) => /(?:^|[\/@])opencode(?:@[^\/]*)?$/.test(part.toLowerCase()))
 }
 
 function applyCodexBaseUrl(env: Record<string, string>, baseUrl: string): void {
-  const config = objectFromJson(env.CODEX_CONFIG, 'CODEX_CONFIG')
-  const providers = record(config.model_providers, 'CODEX_CONFIG.model_providers')
-  const openai = record(providers.openai, 'CODEX_CONFIG.model_providers.openai')
-  env.CODEX_CONFIG = JSON.stringify({
-    ...config,
-    model_provider: 'openai',
-    model_providers: {
-      ...providers,
-      openai: { name: 'OpenAI', ...openai, base_url: baseUrl, env_key: 'OPENAI_API_KEY' }
-    }
-  })
+  env.CODEX_CONFIG = codexConfigWithBaseUrl(env.CODEX_CONFIG, baseUrl)
   env.OPENAI_BASE_URL = baseUrl
 }
 

--- a/packages/daemon/src/shim/acp-runner.ts
+++ b/packages/daemon/src/shim/acp-runner.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process'
+import { codexConfigWithBaseUrlFillIn } from '../runtimes/codex-config.js'
 import { AcpStreamPayloadSchema, type AcpOpen } from './acp-stream.js'
 import type { ShimEvent } from './protocol.js'
 
@@ -34,19 +35,21 @@ function podBaseEnv(podEnv: Record<string, string | undefined>): Record<string, 
   return env
 }
 
-/** Provider env for the REQUESTED command (its registry identity, not the resolved path). */
+/** Provider profile of the REQUESTED command (its registry identity, not the resolved path). */
+export function sandboxProfile(command: string): keyof typeof SANDBOX_PROVIDER_ENV | undefined {
+  const base = command.split(/[\\/]/).pop() ?? ''
+  if (/^claude(?:$|[-.@])/i.test(base)) return 'claude'
+  if (/^codex(?:$|[-.@])/i.test(base)) return 'codex'
+  if (/^dsh(?:$|[-.@])/i.test(base)) return 'deepseek'
+  return undefined
+}
+
+/** Provider env for the requested command's profile. */
 export function sandboxProviderEnv(
   command: string,
   podEnv: Record<string, string | undefined>
 ): Record<string, string> {
-  const base = command.split(/[\\/]/).pop() ?? ''
-  const profile = /^claude(?:$|[-.@])/i.test(base)
-    ? 'claude'
-    : /^codex(?:$|[-.@])/i.test(base)
-      ? 'codex'
-      : /^dsh(?:$|[-.@])/i.test(base)
-        ? 'deepseek'
-        : undefined
+  const profile = sandboxProfile(command)
   if (!profile) return {}
   const env: Record<string, string> = {}
   for (const [source, target] of Object.entries(SANDBOX_PROVIDER_ENV[profile])) {
@@ -54,6 +57,25 @@ export function sandboxProviderEnv(
     if (value) env[target] = value
   }
   return env
+}
+
+// Codex reads its base URL from CODEX_CONFIG (codex-acp projects it into the session config);
+// the OPENAI_BASE_URL env var is routing-inert to the pinned runtime, so a codex pod URL must
+// also land in the config. Fill-in like the env loop: a daemon-aimed config stays authoritative.
+export function fillInCodexBaseUrl(
+  env: Record<string, string>,
+  podEnv: Record<string, string | undefined>,
+  warn?: (message: string) => void
+): void {
+  const baseUrl = podEnv.AC_CODEX_BASE_URL?.trim()
+  if (!baseUrl) return
+  try {
+    const merged = codexConfigWithBaseUrlFillIn(env.CODEX_CONFIG, baseUrl)
+    if (merged !== undefined) env.CODEX_CONFIG = merged
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    warn?.(`acp: leaving the pod codex base URL unprojected — ${reason}`)
+  }
 }
 
 /**
@@ -109,8 +131,12 @@ export class AcpRunner {
       if (resolved) env[hint.envVar] = resolved
     }
     // Fill-in only, like hints: an env the daemon decided (per-agent key/gateway) stays authoritative.
-    for (const [name, value] of Object.entries(sandboxProviderEnv(payload.command, this.deps.podEnv ?? {}))) {
+    const podEnv = this.deps.podEnv ?? {}
+    for (const [name, value] of Object.entries(sandboxProviderEnv(payload.command, podEnv))) {
       if (!env[name]) env[name] = value
+    }
+    if (sandboxProfile(payload.command) === 'codex') {
+      fillInCodexBaseUrl(env, podEnv, (message) => this.deps.log?.warn(message))
     }
     const command = this.deps.resolveCommand?.(payload.command, env) ?? payload.command
     const child = spawn(command, payload.args, {

--- a/packages/daemon/test/model-provider-config.test.ts
+++ b/packages/daemon/test/model-provider-config.test.ts
@@ -68,13 +68,7 @@ describe('applyModelCredential', () => {
     expect(JSON.parse(env.CODEX_CONFIG)).toEqual({
       features: { apps: false },
       model_provider: 'openai',
-      model_providers: {
-        openai: {
-          name: 'OpenAI',
-          base_url: 'https://gateway.example/openai/v1',
-          env_key: 'OPENAI_API_KEY'
-        }
-      }
+      openai_base_url: 'https://gateway.example/openai/v1'
     })
   })
 
@@ -109,7 +103,7 @@ describe('applyModelCredential', () => {
     expect(env.OPENAI_API_KEY).toBe('runtime-key')
     expect(JSON.parse(env.CODEX_CONFIG)).toMatchObject({
       model_provider: 'openai',
-      model_providers: { openai: { base_url: 'https://gateway.example/openai/v1' } }
+      openai_base_url: 'https://gateway.example/openai/v1'
     })
   })
 

--- a/packages/daemon/test/shim-provider-env.test.ts
+++ b/packages/daemon/test/shim-provider-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { AcpRunner, sandboxProviderEnv, type EmitEvent } from '../src/shim/acp-runner.js'
+import { AcpRunner, fillInCodexBaseUrl, sandboxProviderEnv, type EmitEvent } from '../src/shim/acp-runner.js'
 import type { ShimEvent } from '../src/shim/protocol.js'
 
 const POD_ENV = {
@@ -59,7 +59,7 @@ async function spawnAndReadEnv(command: string, requestEnv: Record<string, strin
     command,
     args: [
       '-e',
-      'process.stdout.write(JSON.stringify({A: process.env.ANTHROPIC_API_KEY ?? null, B: process.env.ANTHROPIC_BASE_URL ?? null, O: process.env.OPENAI_API_KEY ?? null, D: process.env.DEEPSEEK_API_KEY ?? null}))'
+      'process.stdout.write(JSON.stringify({A: process.env.ANTHROPIC_API_KEY ?? null, B: process.env.ANTHROPIC_BASE_URL ?? null, O: process.env.OPENAI_API_KEY ?? null, D: process.env.DEEPSEEK_API_KEY ?? null, C: process.env.CODEX_CONFIG ?? null}))'
     ],
     env: requestEnv
   })
@@ -70,12 +70,12 @@ async function spawnAndReadEnv(command: string, requestEnv: Record<string, strin
 describe('AcpRunner provider env fill-in', () => {
   it('fills pod provider vars into a claude spawn and keeps codex vars out', async () => {
     const seen = await spawnAndReadEnv('claude-agent-acp', { PATH: process.env.PATH ?? '' })
-    expect(seen).toEqual({ A: 'sk-claude-pod', B: 'https://claude-egress.internal', O: null, D: null })
+    expect(seen).toEqual({ A: 'sk-claude-pod', B: 'https://claude-egress.internal', O: null, D: null, C: null })
   })
 
   it('fills the deepseek pod vars into a dsh-acp spawn', async () => {
     const seen = await spawnAndReadEnv('dsh-acp', { PATH: process.env.PATH ?? '' })
-    expect(seen).toEqual({ A: null, B: null, O: null, D: 'sk-deepseek-pod' })
+    expect(seen).toEqual({ A: null, B: null, O: null, D: 'sk-deepseek-pod', C: null })
   })
 
   it('lets a daemon-sent value win over the pod value', async () => {
@@ -85,5 +85,80 @@ describe('AcpRunner provider env fill-in', () => {
     })
     expect(seen.A).toBe('sk-from-daemon')
     expect(seen.B).toBe('https://claude-egress.internal')
+  })
+})
+
+describe('fillInCodexBaseUrl', () => {
+  const codexProviders = (config: string) =>
+    (JSON.parse(config) as { model_providers: { openai: Record<string, unknown> } }).model_providers.openai
+
+  it('creates CODEX_CONFIG aiming the built-in openai provider at the pod URL', () => {
+    const env: Record<string, string> = {}
+    fillInCodexBaseUrl(env, POD_ENV)
+    expect(JSON.parse(env.CODEX_CONFIG!)).toEqual({
+      model_provider: 'openai',
+      model_providers: {
+        openai: { name: 'OpenAI', base_url: 'https://codex-egress.internal', env_key: 'OPENAI_API_KEY' }
+      }
+    })
+  })
+
+  it('merges into a daemon-sent config, preserving unrelated fields', () => {
+    const env = { CODEX_CONFIG: JSON.stringify({ features: { apps: false }, model: 'gpt-5.3-codex' }) }
+    fillInCodexBaseUrl(env, POD_ENV)
+    const config = JSON.parse(env.CODEX_CONFIG) as Record<string, unknown>
+    expect(config.features).toEqual({ apps: false })
+    expect(config.model).toBe('gpt-5.3-codex')
+    expect(codexProviders(env.CODEX_CONFIG).base_url).toBe('https://codex-egress.internal')
+  })
+
+  it('leaves a daemon-aimed base_url alone', () => {
+    const daemonConfig = JSON.stringify({
+      model_providers: { openai: { base_url: 'https://daemon-decided.internal' } }
+    })
+    const env = { CODEX_CONFIG: daemonConfig }
+    fillInCodexBaseUrl(env, POD_ENV)
+    expect(env.CODEX_CONFIG).toBe(daemonConfig)
+  })
+
+  it('leaves a config that selects a different model provider alone', () => {
+    const daemonConfig = JSON.stringify({ model_provider: 'custom-gateway' })
+    const env = { CODEX_CONFIG: daemonConfig }
+    fillInCodexBaseUrl(env, POD_ENV)
+    expect(env.CODEX_CONFIG).toBe(daemonConfig)
+  })
+
+  it('warns and leaves a malformed config untouched instead of throwing', () => {
+    const env = { CODEX_CONFIG: 'not json' }
+    const warnings: string[] = []
+    fillInCodexBaseUrl(env, POD_ENV, (message) => warnings.push(message))
+    expect(env.CODEX_CONFIG).toBe('not json')
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('does nothing without a pod base URL', () => {
+    const env: Record<string, string> = {}
+    fillInCodexBaseUrl(env, { AC_CODEX_BASE_URL: '  ' })
+    expect(env.CODEX_CONFIG).toBeUndefined()
+  })
+})
+
+describe('AcpRunner codex config projection', () => {
+  it('projects the pod codex base URL into CODEX_CONFIG on a codex spawn', async () => {
+    const seen = await spawnAndReadEnv('codex-acp', { PATH: process.env.PATH ?? '' })
+    expect(seen.O).toBe('sk-codex-pod')
+    const config = JSON.parse(seen.C!) as Record<string, unknown>
+    expect(config).toMatchObject({
+      model_provider: 'openai',
+      model_providers: { openai: { base_url: 'https://codex-egress.internal', env_key: 'OPENAI_API_KEY' } }
+    })
+  })
+
+  it('keeps a daemon-sent CODEX_CONFIG base_url authoritative over the pod value', async () => {
+    const daemonConfig = JSON.stringify({
+      model_providers: { openai: { base_url: 'https://daemon-decided.internal' } }
+    })
+    const seen = await spawnAndReadEnv('codex-acp', { PATH: process.env.PATH ?? '', CODEX_CONFIG: daemonConfig })
+    expect(seen.C).toBe(daemonConfig)
   })
 })

--- a/packages/daemon/test/shim-provider-env.test.ts
+++ b/packages/daemon/test/shim-provider-env.test.ts
@@ -89,17 +89,12 @@ describe('AcpRunner provider env fill-in', () => {
 })
 
 describe('fillInCodexBaseUrl', () => {
-  const codexProviders = (config: string) =>
-    (JSON.parse(config) as { model_providers: { openai: Record<string, unknown> } }).model_providers.openai
-
   it('creates CODEX_CONFIG aiming the built-in openai provider at the pod URL', () => {
     const env: Record<string, string> = {}
     fillInCodexBaseUrl(env, POD_ENV)
     expect(JSON.parse(env.CODEX_CONFIG!)).toEqual({
       model_provider: 'openai',
-      model_providers: {
-        openai: { name: 'OpenAI', base_url: 'https://codex-egress.internal', env_key: 'OPENAI_API_KEY' }
-      }
+      openai_base_url: 'https://codex-egress.internal'
     })
   })
 
@@ -109,13 +104,11 @@ describe('fillInCodexBaseUrl', () => {
     const config = JSON.parse(env.CODEX_CONFIG) as Record<string, unknown>
     expect(config.features).toEqual({ apps: false })
     expect(config.model).toBe('gpt-5.3-codex')
-    expect(codexProviders(env.CODEX_CONFIG).base_url).toBe('https://codex-egress.internal')
+    expect(config.openai_base_url).toBe('https://codex-egress.internal')
   })
 
-  it('leaves a daemon-aimed base_url alone', () => {
-    const daemonConfig = JSON.stringify({
-      model_providers: { openai: { base_url: 'https://daemon-decided.internal' } }
-    })
+  it('leaves a daemon-aimed openai_base_url alone', () => {
+    const daemonConfig = JSON.stringify({ openai_base_url: 'https://daemon-decided.internal' })
     const env = { CODEX_CONFIG: daemonConfig }
     fillInCodexBaseUrl(env, POD_ENV)
     expect(env.CODEX_CONFIG).toBe(daemonConfig)
@@ -150,14 +143,12 @@ describe('AcpRunner codex config projection', () => {
     const config = JSON.parse(seen.C!) as Record<string, unknown>
     expect(config).toMatchObject({
       model_provider: 'openai',
-      model_providers: { openai: { base_url: 'https://codex-egress.internal', env_key: 'OPENAI_API_KEY' } }
+      openai_base_url: 'https://codex-egress.internal'
     })
   })
 
-  it('keeps a daemon-sent CODEX_CONFIG base_url authoritative over the pod value', async () => {
-    const daemonConfig = JSON.stringify({
-      model_providers: { openai: { base_url: 'https://daemon-decided.internal' } }
-    })
+  it('keeps a daemon-sent CODEX_CONFIG base URL authoritative over the pod value', async () => {
+    const daemonConfig = JSON.stringify({ openai_base_url: 'https://daemon-decided.internal' })
     const seen = await spawnAndReadEnv('codex-acp', { PATH: process.env.PATH ?? '', CODEX_CONFIG: daemonConfig })
     expect(seen.C).toBe(daemonConfig)
   })


### PR DESCRIPTION
## Problem

A sandbox deployment can inject `AC_CODEX_BASE_URL` (a model-egress gateway URL) into the runtime pod via SandboxTemplate env. The shim mapped it onto `OPENAI_BASE_URL` alone — but the pinned Codex runtime never consults that env var for routing. Codex's only live base-URL surface is `CODEX_CONFIG`, which codex-acp projects into each session's config over app-server. (In current codex-rs, the `OPENAI_BASE_URL` env var is read only by the network-proxy credential broker to extend its trusted-host binding; the provider base URL resolves solely from config.) So the pod-injected URL landed on a routing-inert variable, and codex traffic kept aiming at the provider default while claude — whose `ANTHROPIC_BASE_URL` mapping targets a real consuming surface — routed fine.

Within the config, the override must be the **top-level `openai_base_url` key**: Codex merges configured `model_providers` with `entry().or_insert()`, so a `model_providers.openai` entry can never replace the built-in provider and its `base_url` is discarded. The daemon-side credential path previously wrote that discarded shape too; this PR moves both writers onto the supported key (present across the pinned codex-acp lines, `^0.145.0` and `^0.147.0`).

## Fix

The shim now also merges the pod URL into `CODEX_CONFIG`, with the same fill-in semantics as the existing env loop:

- a config the daemon already aimed stays authoritative — an existing top-level `openai_base_url`, or a `model_provider` selecting something other than `openai`, leaves the config untouched;
- a malformed `CODEX_CONFIG` is left as-is with a warning instead of failing the spawn;
- the merge shape (`model_provider: 'openai'`, `openai_base_url`) is extracted into `runtimes/codex-config.ts`, a zero-import module now shared by the daemon-side credential path (`applyCodexBaseUrl`) and the shim — one source of truth for the JSON shape, and the shim bundle stays free of the daemon's credential graph (per the constraint documented in `tsdown.shim.config.ts`).

`sandboxProviderEnv`'s profile detection is factored out as `sandboxProfile` so the codex-only projection reuses the same registry-identity matching.

## Tests

- `fillInCodexBaseUrl` unit coverage: creates the config when absent, merges while preserving unrelated fields, defers to a daemon-aimed `openai_base_url` or non-openai `model_provider`, warns on malformed config, skips a blank pod value.
- `AcpRunner` spawn-through coverage: a codex spawn sees the projected `CODEX_CONFIG`; a daemon-sent base URL survives the pod value.
- Existing spawn tests extended to assert claude/deepseek spawns get no `CODEX_CONFIG`.

`pnpm typecheck`, lint, and the daemon build (including the shim self-containment assertion) pass. The full daemon suite has 14 pre-existing failures on this machine (git child-process detection in `shim-cancellation`/`shim-workspace-files`) that reproduce identically on `main` without this diff; CI runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)