### PR TITLE
refactor(daemon): neutralize the send queue and the interaction-actor type

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -957,7 +957,7 @@ Discord, and Lark / Feishu use the common platform-driver boundary.
 
 ### 9.1 Outbound: ACP `session/update` -> Slack (Convergence + Translation)
 
-Goal: **channel contains only start / plan / problem / finish + link**, while details remain in Web App. ACP Host converges streaming updates through the mode-aware `OutputConverger` in `packages/daemon/src/slack/render.ts`; outbound writes are serialized by `SlackSendQueue` in `packages/daemon/src/slack/send-queue.ts`.
+Goal: **channel contains only start / plan / problem / finish + link**, while details remain in Web App. ACP Host converges streaming updates through the mode-aware `OutputConverger` in `packages/daemon/src/slack/render.ts`; outbound writes are serialized by `PlatformSendQueue` in `packages/daemon/src/platforms/send-queue.ts`.
 
 **`medium` / `high` message-style progress:**
 
@@ -989,7 +989,7 @@ Goal: **channel contains only start / plan / problem / finish + link**, while de
 
 **`none` mode:** Full body still records in session transcript through a `recordOnly` post handled before checking platform connection, but send nothing to IM. Reuse headless/webchat's `replyConn = undefined`; activity/status/typing/reply/footer are all no-op. Background completion notifications gated at `≥ medium` do not fire.
 
-Thread semantics: main progress goes at the thread anchor or, for a subscribed thread, uses `thread_ts`; tool-output messages reply in the same thread. `SlackSendQueue` rate-limits API calls, including the `chat.postMessage` Tier3 limit of 50rpm. The effective output mode is the per-session override when present, otherwise `agent.output.mode`.
+Thread semantics: main progress goes at the thread anchor or, for a subscribed thread, uses `thread_ts`; tool-output messages reply in the same thread. `PlatformSendQueue` rate-limits API calls, including the `chat.postMessage` Tier3 limit of 50rpm. The effective output mode is the per-session override when present, otherwise `agent.output.mode`.
 
 ### 9.2 Inbound Attachments -> ACP `session/prompt` Content
 

--- a/docs/designs/feishu-integration.md
+++ b/docs/designs/feishu-integration.md
@@ -272,7 +272,7 @@ IntegrationFeishuConfig }`.
     `listMembers` through `im.chatMembers.get`, `listChannels` through
     `im.chat.list`, and `getUserProfile` through `contact.user.get`. The latter
     needs additional permission and degrades when unavailable.
-  - Reuse `SlackSendQueue` from `src/slack/send-queue.ts` for FIFO outbound
+  - Reuse `PlatformSendQueue` from `src/platforms/send-queue.ts` for FIFO outbound
     delivery.
   - **Three-second constraint:** event callbacks must return within three
     seconds. A handler only normalizes and enqueues through `onMessage`; it

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -401,7 +401,7 @@ misconfiguration warning.
 ### 5.3 Rate limiting
 
 Linear allows 5 000 requests/hour per OAuth app per workspace (per its
-published rate-limiting docs). The per-integration send queue (reuse `SlackSendQueue`) enforces FIFO plus a
+published rate-limiting docs). The per-integration send queue (reuse `PlatformSendQueue`) enforces FIFO plus a
 minimum interval (~1 s for activities), and the converger's coalescing keeps
 a busy turn to tens of activities, not hundreds. `plan` and `external-urls`
 updates are debounced (last-write-wins within the idle window).

--- a/packages/daemon/src/commands/handlers.ts
+++ b/packages/daemon/src/commands/handlers.ts
@@ -29,7 +29,7 @@ import { loopGuardScope, loopGuardScopeFromCoords } from '../daemon/loop-guard-s
 import type { PlatformConnection } from '../platforms/connection-reconciler.js'
 import { parseTelegramSelect, telegramSelectButtons } from '../platforms/telegram/command-chrome.js'
 import type { TelegramCallback, TelegramConnection } from '../telegram/connection.js'
-import type { InteractionActor } from '../slack/connection.js'
+import type { InteractionActor } from '../platforms/contract.js'
 import type { StatusBarInfo } from '../slack/render.js'
 import { buildDiscordSelectComponents, type DiscordComponents } from '../discord/render.js'
 import { MAX_QUEUED_PER_SESSION } from '../daemon/constants.js'

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -12,8 +12,7 @@ import type { Agent } from '../agents/agent-schema.js'
 import { platformIntegrationConfig } from '../platforms/integration-config.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
-import { SlackSendQueue } from '../slack/send-queue.js'
-import type { InteractionActor } from '../slack/connection.js'
+import { PlatformSendQueue } from '../platforms/send-queue.js'
 import { normalizeDiscordMessage, type DiscordMessageLike } from './normalize.js'
 import { DISCORD_APP_COMMANDS } from './app-commands.js'
 import {
@@ -24,7 +23,7 @@ import {
   type DiscordComponents,
   type DiscordSelectKind
 } from './render.js'
-import type { PlatformConnection } from '../platforms/contract.js'
+import type { InteractionActor, PlatformConnection } from '../platforms/contract.js'
 
 /**
  * §Discord edge unit. Mirrors slack/connection.ts + telegram/connection.ts but over
@@ -163,7 +162,7 @@ export class DiscordConnection implements PlatformConnection {
   // All outbound writes funnel through one queue so streamed edits are FIFO-ordered
   // per connection (discord.js handles REST rate limits, but the queue keeps a
   // post-then-edit pair from racing on the same progress message).
-  private queue: SlackSendQueue
+  private queue: PlatformSendQueue
   // Status-component message → session key, so a button interaction (which carries
   // only channel+message id, not the session key) resolves back to its session.
   // Keyed `${channelId}:${messageId}`.
@@ -189,7 +188,7 @@ export class DiscordConnection implements PlatformConnection {
 
   constructor(private deps: DiscordDeps) {
     this.botToken = deps.group.botToken
-    this.queue = new SlackSendQueue(deps.sendIntervalMs ?? 350)
+    this.queue = new PlatformSendQueue(deps.sendIntervalMs ?? 350)
     this.client = new Client({
       intents: [
         GatewayIntentBits.Guilds,

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -14,8 +14,7 @@ import { integrationCore, platformIntegrationConfig } from '../platforms/integra
 import type { ReplyAttributionInfo } from '../messages/attribution.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
-import { SlackSendQueue } from '../slack/send-queue.js'
-import type { InteractionActor } from '../slack/connection.js'
+import { PlatformSendQueue } from '../platforms/send-queue.js'
 import { feishuEventToMessageLike, normalizeFeishuMessage, type FeishuRawEvent } from './normalize.js'
 import {
   buildCompletedReplyCard,
@@ -26,7 +25,7 @@ import {
   FEISHU_REPLY_CANCEL_OPTION,
   FEISHU_STREAMING_ELEMENT_ID
 } from './render.js'
-import type { PlatformConnection } from '../platforms/contract.js'
+import type { InteractionActor, PlatformConnection } from '../platforms/contract.js'
 
 /**
  * §Feishu / Lark edge unit. Mirrors discord/connection.ts but over the official
@@ -563,7 +562,7 @@ export class FeishuConnection implements PlatformConnection {
   private handle: FeishuClientHandle
   // All outbound writes funnel through one queue so streamed edits are FIFO-ordered
   // per connection (keeps a post-then-edit pair from racing on the same progress msg).
-  private queue: SlackSendQueue
+  private queue: PlatformSendQueue
   /** CardKit sequence numbers are scoped to a card entity and must increase across
    * element, settings, and full-card updates. */
   private streamingCards = new Map<
@@ -608,7 +607,7 @@ export class FeishuConnection implements PlatformConnection {
     this.region = deps.group.region
     this.mode = deps.group.mode
     this.handle = factory(deps.group.appId, deps.group.appSecret, deps.group.region)
-    this.queue = new SlackSendQueue(deps.sendIntervalMs ?? 350)
+    this.queue = new PlatformSendQueue(deps.sendIntervalMs ?? 350)
   }
 
   async start(): Promise<void> {

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -15,7 +15,8 @@ import type { LocalStore } from '../store/local-store.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import type { AcpPermissionPolicyEvent } from '../acp/acp-host.js'
 import type { DaemonEvaluationHooks } from '../evaluation/daemon-hooks.js'
-import { SlackConnection, type InteractionActor } from '../slack/connection.js'
+import { SlackConnection } from '../slack/connection.js'
+import type { InteractionActor } from '../platforms/contract.js'
 import {
   buildElicitationCard,
   buildElicitationResolvedCard,

--- a/packages/daemon/src/platforms/contract.ts
+++ b/packages/daemon/src/platforms/contract.ts
@@ -35,6 +35,16 @@
  * the registry lands. This one is daemon-owned.
  */
 
+/** The human behind one interactive click (button / select / modal submit). Carried
+ *  alongside the action so the daemon records WHO changed a session, which a bare
+ *  `sessionKey` cannot say. */
+export interface InteractionActor {
+  userId: string
+  /** Only set where the platform reports it on the interaction (Discord does; a Slack
+   *  `block_actions` payload carries no bot flag on its `user`). */
+  isBot?: boolean
+}
+
 /** One conversation as the platform describes it. Members beyond `id` are
  *  optional because no platform reports all of them (`isMpim`/`user` are Slack's;
  *  `isIm` drives DM canonicalization and session classification on every

--- a/packages/daemon/src/platforms/send-queue.ts
+++ b/packages/daemon/src/platforms/send-queue.ts
@@ -1,20 +1,19 @@
 /**
- * §9.1 SlackSendQueue: serialize outbound Slack Web API writes (chat.postMessage
- * / chat.update / assistant.threads.setStatus / assistant.threads.setTitle) per connection and space them by a
- * minimum interval so streamed edits don't trip Slack's Tier-3 rate limit
- * (chat.postMessage ~50 rpm). FIFO: preserves the order the converger emits.
+ * PlatformSendQueue: serialize a connection's outbound chat-platform writes and
+ * space them by a minimum interval, so streamed edits don't trip a provider's
+ * per-method rate limit. FIFO: preserves the order the converger emits.
  *
  * The first task runs immediately; each subsequent task waits until at least
  * `minIntervalMs` after the previous one *started*. `enqueue` resolves/rejects
- * with the task's own result, so callers can still await a posted message ts.
+ * with the task's own result, so callers can still await a posted message id.
  *
- * Each task is bounded by `taskTimeoutMs`: if a single call hangs (e.g. a Slack
+ * Each task is bounded by `taskTimeoutMs`: if a single call hangs (e.g. a provider
  * API stall during a socket reconnect), it is abandoned so the queue keeps moving
  * and a best-effort status update can never block real message delivery. The
  * abandoned call's promise still settles in the background; the caller just sees a
  * timeout rejection (which, for a progress/plan post, the daemon treats as "no ts").
  */
-export class SlackSendQueue {
+export class PlatformSendQueue {
   private chain: Promise<unknown> = Promise.resolve()
   // -inf so the very first task never waits, regardless of the clock's origin.
   private lastStart = Number.NEGATIVE_INFINITY
@@ -49,7 +48,7 @@ export class SlackSendQueue {
       const timer = setTimeout(() => {
         if (settled) return
         settled = true
-        reject(new Error(`SlackSendQueue: task exceeded ${this.taskTimeoutMs}ms — abandoned`))
+        reject(new Error(`PlatformSendQueue: task exceeded ${this.taskTimeoutMs}ms — abandoned`))
       }, this.taskTimeoutMs)
       p.then(
         (v) => {

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -12,7 +12,7 @@ import { integrationCore, platformIntegrationConfig } from '../platforms/integra
 import { normalizeSlackEvent, toAttachment, type SlackFile, type SlackMessageEvent } from './normalize.js'
 import type { Attachment, NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
-import { SlackSendQueue } from './send-queue.js'
+import { PlatformSendQueue } from '../platforms/send-queue.js'
 import {
   STATUS_ACTION,
   ELICIT_ACTION_PREFIX,
@@ -26,7 +26,7 @@ import {
   type StatusBarInfo,
   type StatusModalIdentity
 } from './render.js'
-import type { PlatformConnection } from '../platforms/contract.js'
+import type { InteractionActor, PlatformConnection } from '../platforms/contract.js'
 
 export interface ConsolidatedGroup {
   appToken: string
@@ -230,16 +230,6 @@ export function consolidateShared(agents: Agent[]): Map<string, ConsolidatedGrou
   return groups
 }
 
-/** The human behind one interactive click (button / select / modal submit). Carried
- *  alongside the action so the daemon records WHO changed a session, which a bare
- *  `sessionKey` cannot say. */
-export interface InteractionActor {
-  userId: string
-  /** Only set where the platform reports it on the interaction (Discord does; a Slack
-   *  `block_actions` payload carries no bot flag on its `user`). */
-  isBot?: boolean
-}
-
 export interface SlackDeps {
   group: ConsolidatedGroup
   onMessage: (msg: NormalizedMessage) => void
@@ -282,7 +272,7 @@ export interface SlackDeps {
   log?: Logger
   /** When true, hand Bolt LogLevel.DEBUG so socket-mode internals are visible. */
   boltDebug?: boolean
-  /** Min spacing (ms) between outbound writes (§9.1 SlackSendQueue). Tests pass 0. */
+  /** Min spacing (ms) between outbound writes (serialized send-queue). Tests pass 0. */
   sendIntervalMs?: number
   /**
    * SEND-ONLY mode (shared-bot-relay.md §11): the bot's INBOUND lives on a relay,
@@ -572,7 +562,7 @@ export class SlackConnection implements PlatformConnection {
   private app: AppLike
   // §9.1: all outbound writes (post/update/setStatus/setTitle) funnel through one queue so
   // streamed edits are FIFO-ordered and rate-limited per Slack app connection.
-  private queue: SlackSendQueue
+  private queue: PlatformSendQueue
   /** Cooldown after Slack proves this installation lacks chat:write.customize. */
   private customUsernameRetryAt = 0
   /** Slack app/workspace ids are public metadata used only for the OAuth settings link. */
@@ -615,7 +605,7 @@ export class SlackConnection implements PlatformConnection {
       : deps.sendOnly
         ? sendOnlyApp(deps.group.botToken)
         : realSocketModeApp({ token: deps.group.botToken, appToken: deps.group.appToken }, deps.boltDebug)
-    this.queue = new SlackSendQueue(deps.sendIntervalMs ?? 350)
+    this.queue = new PlatformSendQueue(deps.sendIntervalMs ?? 350)
   }
 
   async start(): Promise<void> {
@@ -1118,7 +1108,7 @@ export class SlackConnection implements PlatformConnection {
         return true
       })
     } catch (err) {
-      // Catch both Slack API failures and SlackSendQueue's outer timeout rejection.
+      // Catch both Slack API failures and PlatformSendQueue's outer timeout rejection.
       this.deps.log?.debug(`slack: chat.update (blocks) failed (ch=${channel} ts=${ts}): ${(err as Error).message}`)
       return false
     }

--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -3,7 +3,7 @@ import type { Agent } from '../agents/agent-schema.js'
 import { platformIntegrationConfig } from '../platforms/integration-config.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
-import { SlackSendQueue } from '../slack/send-queue.js'
+import { PlatformSendQueue } from '../platforms/send-queue.js'
 import { isTelegramMembershipServiceMessage, normalizeTelegramMessage, type TelegramMessage } from './normalize.js'
 import type { PlatformConnection } from '../platforms/contract.js'
 
@@ -218,7 +218,7 @@ export class TelegramConnection implements PlatformConnection {
   private bot: TelegramBotHandle
   // All outbound writes funnel through one queue so streamed edits are FIFO-ordered
   // and rate-limited per bot connection (Telegram tolerates ~1 msg/s per chat).
-  private queue: SlackSendQueue
+  private queue: PlatformSendQueue
   /** The bot token this connection authenticated with (used to detect a swap). */
   readonly botToken: string
   /** The bot's numeric user id (as string), resolved at start() via getMe. */
@@ -235,7 +235,7 @@ export class TelegramConnection implements PlatformConnection {
   ) {
     this.botToken = deps.group.botToken
     this.bot = factory(deps.group.botToken)
-    this.queue = new SlackSendQueue(deps.sendIntervalMs ?? 350)
+    this.queue = new PlatformSendQueue(deps.sendIntervalMs ?? 350)
   }
 
   async start(): Promise<void> {

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -1096,7 +1096,7 @@ describe('SlackConnection.updateBlocks', () => {
     )
     ;(conn as any).queue = {
       enqueue: vi.fn(async () => {
-        throw new Error('SlackSendQueue: task exceeded 30000ms — abandoned')
+        throw new Error('PlatformSendQueue: task exceeded 30000ms — abandoned')
       })
     }
 

--- a/packages/daemon/test/send-queue.test.ts
+++ b/packages/daemon/test/send-queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { SlackSendQueue } from '../src/slack/send-queue.js'
+import { PlatformSendQueue } from '../src/platforms/send-queue.js'
 
 /** A fake clock + sleep so spacing is asserted deterministically (no real timers). */
 function fakeClock() {
@@ -15,17 +15,17 @@ function fakeClock() {
   }
 }
 
-describe('SlackSendQueue', () => {
+describe('PlatformSendQueue', () => {
   it('runs the first task immediately (no initial wait) and returns its result', async () => {
     const clk = fakeClock()
-    const q = new SlackSendQueue(1000, clk.now, clk.sleep)
+    const q = new PlatformSendQueue(1000, clk.now, clk.sleep)
     expect(await q.enqueue(async () => 'first')).toBe('first')
     expect(clk.sleeps).toEqual([])
   })
 
   it('preserves FIFO order and spaces subsequent tasks by minIntervalMs', async () => {
     const clk = fakeClock()
-    const q = new SlackSendQueue(100, clk.now, clk.sleep)
+    const q = new PlatformSendQueue(100, clk.now, clk.sleep)
     const order: number[] = []
     const ps = [1, 2, 3].map((n) => q.enqueue(async () => (order.push(n), n)))
     expect(await Promise.all(ps)).toEqual([1, 2, 3])
@@ -35,7 +35,7 @@ describe('SlackSendQueue', () => {
   })
 
   it('a throwing task rejects its own promise but does not break the chain', async () => {
-    const q = new SlackSendQueue(0)
+    const q = new PlatformSendQueue(0)
     const ran: string[] = []
     const p1 = q.enqueue(async () => {
       throw new Error('boom')
@@ -51,7 +51,7 @@ describe('SlackSendQueue', () => {
 
   it('abandons a hung task after the per-task timeout so the queue keeps moving', async () => {
     // real timer for the timeout; fake clock only for spacing (minInterval 0)
-    const q = new SlackSendQueue(
+    const q = new PlatformSendQueue(
       0,
       () => 0,
       async () => {},


### PR DESCRIPTION
De-baseclass Slack, part 1. Two pieces of platform-neutral machinery lived under `src/slack/` while being imported by telegram, discord and feishu.

## What moved

**`SlackSendQueue` → `PlatformSendQueue`, `src/slack/send-queue.ts` → `src/platforms/send-queue.ts`.**
The class is a plain FIFO + min-interval + per-task-timeout queue with nothing Slack-specific in it; only its doc comment claimed Slack Tier-3 / `chat.postMessage` specifics, which was already wrong for the three other connections using it. The comment is rewritten in platform-neutral terms and the timeout rejection message now reads `PlatformSendQueue: …`.

**`InteractionActor` → `src/platforms/contract.ts`.**
The type described cross-platform interaction semantics but was declared in `src/slack/connection.ts`, so discord, feishu, commands and the permissions coordinator all reached into the Slack module for it. It is self-contained (two primitive fields), so hosting it in the Layer-1 contract file creates **no import cycle** — `platforms/contract.ts` still imports nothing from `slack/`.

## What was kept

**No shells.** Importer churn was 9 files for the send queue and 4 for the actor type — both well under the threshold — so every caller was retargeted at the real owner and no deprecated re-export remains in `src/slack/`.

Design docs that named the old class or path (`feishu-integration.md`, `linear-integration.md`, `daemon-detailed-design.md`) were updated in the same commit.

Pure moves + renames; zero behavior change.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean
- `vitest run test/send-queue.test.ts test/daemon-commands.test.ts test/telegram-threading.test.ts test/reconcile-watch.test.ts` — 122 passed
- `vitest run test/connection.test.ts` — 42 passed (it asserts on the queue's timeout-rejection string, updated with the rename)
- `prettier --check` + `eslint` on all touched files — clean
- `rg -a SlackSendQueue` over the repo — no hits left

🤖 Generated with [Claude Code](https://claude.com/claude-code)