### PR TITLE
test(daemon): drive the channel-layer tests over the dial-in shim pair

### DIFF
--- a/packages/daemon/test/fakes/shim-sandbox.ts
+++ b/packages/daemon/test/fakes/shim-sandbox.ts
@@ -1,0 +1,75 @@
+import type { Backoff, Clock } from '@agentconnect.md/connection'
+import { ShimClient, type ShimClientDeps, type ShimTransport } from '../../src/shim/client.js'
+import { ShimDialer, type ShimDialerDeps } from '../../src/shim/dialer.js'
+import { ShimServer } from '../../src/shim/server.js'
+
+/** The production shape a test drives: the daemon dials IN, and the pod runs a ShimServer. */
+export interface ShimSandboxOptions {
+  handle?: ShimClientDeps['handle']
+  backoff?: Backoff
+  clock?: Clock
+  /** The pod's workspace mount as the shim reports it in its identity. */
+  workspaceRoot?: string
+}
+
+export interface ShimSandbox {
+  /** Where the daemon dials — a real loopback port. */
+  endpoint: string
+  port: number
+  server: ShimServer
+  client: ShimClient
+}
+
+/**
+ * Per-file fixtures for a real sandbox shim: a listening {@link ShimServer} with a
+ * {@link ShimClient} attached to whatever daemon it accepts, plus the dialers under test.
+ *
+ * A factory rather than module state because this suite runs `isolate: false`, so a shared
+ * registry would leak one file's servers into the next.
+ */
+export function shimFixtures(): {
+  clients: ShimClient[]
+  dialers: ShimDialer[]
+  servers: ShimServer[]
+  sandbox: (options?: ShimSandboxOptions) => Promise<ShimSandbox>
+  dialer: (deps: ShimDialerDeps) => ShimDialer
+  cleanup: () => Promise<void>
+} {
+  const clients: ShimClient[] = []
+  const dialers: ShimDialer[] = []
+  const servers: ShimServer[] = []
+
+  async function sandbox(options: ShimSandboxOptions = {}): Promise<ShimSandbox> {
+    const server = new ShimServer()
+    servers.push(server)
+    const port = await server.start(0, '127.0.0.1')
+    const client = new ShimClient({
+      endpoint: 'accepted-daemon-channel',
+      acceptDialIn: true,
+      dial: () => server.nextTransport() as Promise<ShimTransport>,
+      readToken: () => 'projected-token',
+      workspaceRoot: options.workspaceRoot ?? '/agent',
+      ...(options.handle ? { handle: options.handle } : {}),
+      ...(options.backoff ? { backoff: options.backoff } : {}),
+      ...(options.clock ? { clock: options.clock } : {}),
+      log: { info: () => {}, warn: () => {} }
+    })
+    clients.push(client)
+    void client.start().catch(() => undefined)
+    return { endpoint: `ws://127.0.0.1:${port}`, port, server, client }
+  }
+
+  function dialer(deps: ShimDialerDeps): ShimDialer {
+    const instance = new ShimDialer(deps)
+    dialers.push(instance)
+    return instance
+  }
+
+  async function cleanup(): Promise<void> {
+    for (const client of clients.splice(0)) client.stop()
+    for (const instance of dialers.splice(0)) instance.stop()
+    await Promise.all(servers.splice(0).map((server) => server.stop()))
+  }
+
+  return { clients, dialers, servers, sandbox, dialer, cleanup }
+}

--- a/packages/daemon/test/shim-cancellation.test.ts
+++ b/packages/daemon/test/shim-cancellation.test.ts
@@ -4,28 +4,25 @@ import { randomUUID } from 'node:crypto'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
+import { Backoff, FakeClock } from '@agentconnect.md/connection'
 import type { ShimConnection } from '../src/shim/connection.js'
-import { ShimListener } from '../src/shim/listener.js'
-import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import { ShimChannel, ShimRequestAbortedError } from '../src/shim/channels.js'
 import { createExecHandler } from '../src/shim/exec-handler.js'
 import { ShimGitRunner } from '../src/shim/git-exec.js'
 import type { ShimFrame } from '../src/shim/protocol.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
+import { shimFixtures } from './fakes/shim-sandbox.js'
 
 // Cancellation across the channel, end to end: real socket, real shim client, real hanging git.
 // The point is not that the daemon's promise rejects — a bare timeout already did that — but that
 // the CHILD DIES. An abandoned git keeps index.lock and wedges the next session's pull, which is
 // exactly what simple-git's signal handling prevents on the local runner.
 
-const listeners: ShimListener[] = []
-const clients: ShimClient[] = []
+const fixtures = shimFixtures()
 const roots: string[] = []
 
 afterEach(async () => {
-  for (const client of clients.splice(0)) client.stop()
-  await Promise.all(listeners.splice(0).map((instance) => instance.stop()))
+  await fixtures.cleanup()
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
 
@@ -56,11 +53,11 @@ function blockingRepository(): { root: string; env: Record<string, string>; mark
   }
 }
 
-/** Real listener + real shim client, the client serving git through the production handler. */
+/** Real dialer + real shim server, the in-pod client serving git through the production handler. */
 async function channelUnderTest(
   workspaceRoot: string,
   options: { credentialTtlMs?: number; shimClock?: FakeClock } = {}
-): Promise<{ channel: ShimChannel; connection: ShimConnection; sent: ShimFrame[]; listener: ShimListener }> {
+): Promise<{ channel: ShimChannel; connection: ShimConnection; sent: ShimFrame[] }> {
   const record: SpawnRecord = {
     agentId: 'agent-a',
     generation: 1,
@@ -68,56 +65,38 @@ async function channelUnderTest(
     podUid: 'pod-uid-1',
     grants: ['exec', 'materialize']
   } as SpawnRecord
-  const listener = new ShimListener({
+  const { endpoint } = await fixtures.sandbox({
+    workspaceRoot,
+    clock: options.shimClock ?? new FakeClock(),
+    backoff: new Backoff({ jitter: () => 0 }),
+    handle: createExecHandler({ workspaceRoot, log: { info: () => {}, warn: () => {} } })
+  })
+  const dialer = fixtures.dialer({
     verifier: { reviewToken: async () => ({ authenticated: true, podName: 'runtime-1', podUid: 'pod-uid-1' }) },
-    spawnRecordForPod: () => record,
     now: () => Date.now(),
     ...(options.credentialTtlMs !== undefined ? { credentialTtlMs: options.credentialTtlMs } : {}),
     log: { info: () => {}, warn: () => {} }
   })
-  listeners.push(listener)
-  const port = await listener.start(0, '127.0.0.1')
+  const connection = await dialer.connect(endpoint, record, 5_000)
 
-  const client = new ShimClient({
-    endpoint: `ws://127.0.0.1:${port}`,
-    dial: (url, opts) =>
-      ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
-    readToken: () => 'projected-token',
-    clock: options.shimClock ?? new FakeClock(),
-    backoff: new Backoff({ jitter: () => 0 }),
-    handle: createExecHandler({ workspaceRoot, log: { info: () => {}, warn: () => {} } }),
-    log: { info: () => {}, warn: () => {} }
-  })
-  clients.push(client)
-  void client.start()
-
-  const deadline = Date.now() + 5_000
-  for (;;) {
-    const connection = listener.connectionsFor('agent-a')[0]
-    if (connection) {
-      // Observed so a test can read the REAL request id. Sending a cancel for an invented id
-      // proves nothing — the lookup misses whether or not the fencing is there, which is how the
-      // first version of the stale-generation test below passed against unfenced code.
-      const sent: ShimFrame[] = []
-      const observed: ShimConnection = {
-        binding: connection.binding,
-        issuedCredential: connection.issuedCredential,
-        send: (frame) => {
-          sent.push(frame)
-          connection.send(frame)
-        },
-        onFrame: (listen) => connection.onFrame(listen),
-        close: (reason) => connection.close(reason)
-      }
-      return {
-        channel: new ShimChannel(observed, connection.issuedCredential, timers),
-        connection: observed,
-        sent,
-        listener
-      }
-    }
-    if (Date.now() > deadline) throw new Error('no channel bound in time')
-    await new Promise((resolve) => setTimeout(resolve, 20))
+  // Observed so a test can read the REAL request id. Sending a cancel for an invented id
+  // proves nothing — the lookup misses whether or not the fencing is there, which is how the
+  // first version of the stale-generation test below passed against unfenced code.
+  const sent: ShimFrame[] = []
+  const observed: ShimConnection = {
+    binding: connection.binding,
+    issuedCredential: connection.issuedCredential,
+    send: (frame) => {
+      sent.push(frame)
+      connection.send(frame)
+    },
+    onFrame: (listen) => connection.onFrame(listen),
+    close: (reason) => connection.close(reason)
+  }
+  return {
+    channel: new ShimChannel(observed, connection.issuedCredential, timers),
+    connection: observed,
+    sent
   }
 }
 
@@ -227,7 +206,7 @@ describe('shim work spanning a credential renewal', () => {
       .request('exec', { tool: 'git', args: ['config', '--get', `user.${marker}`], env }, { timeoutMs: 120_000 })
       .catch(() => undefined)
     expect(await until(() => liveGitChildren(marker) > 0)).toBe(true)
-    for (const client of clients) client.stop()
+    for (const client of fixtures.clients) client.stop()
     expect(await until(() => liveGitChildren(marker) === 0)).toBe(true)
   })
 })

--- a/packages/daemon/test/shim-channels.test.ts
+++ b/packages/daemon/test/shim-channels.test.ts
@@ -6,11 +6,10 @@ import { materializeConfigFiles, materializeConfigFilesThrough, configFilesDir }
 import { LocalFileSink, applyFileSinkPayload, resolveSinkPath, FileSinkPayloadSchema } from '../src/shim/file-sink.js'
 import { ShimChannel, ShimFileSink } from '../src/shim/channels.js'
 import { SANDBOX_TUNNEL_PATHS, TunnelPayloadSchema } from '../src/shim/tunnel.js'
-import { ClientTransport } from '@agentconnect.md/connection'
+import type { SpawnRecord } from '../src/shim/binding.js'
 import type { ShimConnection } from '../src/shim/connection.js'
-import { ShimListener } from '../src/shim/listener.js'
-import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import type { ShimCapability, ShimFrame } from '../src/shim/protocol.js'
+import { shimFixtures } from './fakes/shim-sandbox.js'
 
 function agentDir(): string {
   return mkdtempSync(join(tmpdir(), 'ac-sink-'))
@@ -214,80 +213,64 @@ describe('tunnels', () => {
 })
 
 describe('materialization over a real daemon-and-shim pair', () => {
-  const listeners: ShimListener[] = []
+  const fixtures = shimFixtures()
   afterEach(async () => {
-    await Promise.all(listeners.splice(0).map((instance) => instance.stop()))
+    await fixtures.cleanup()
   })
 
+  // The production shape: the daemon dials into the pod, and the pod's ShimServer accepts.
   async function pair(grants: ShimCapability[]): Promise<{
-    instance: ShimListener
-    client: ShimClient
     channel: ShimChannel
     handled: Array<{ capability: ShimCapability; payload: unknown }>
     sandboxRoot: string
   }> {
     const sandboxRoot = mkdtempSync(join(tmpdir(), 'ac-sandbox-'))
-    const instance = new ShimListener({
-      verifier: { reviewToken: async () => ({ authenticated: true, podName: 'p', podUid: 'u' }) },
-      spawnRecordForPod: () => ({ agentId: 'agent-a', sandboxUid: 'sandbox-1', generation: 3, grants }),
-      now: () => Date.now(),
-      log: { info: () => {}, warn: () => {} }
-    })
-    listeners.push(instance)
-    const port = await instance.start(0, '127.0.0.1')
     const handled: Array<{ capability: ShimCapability; payload: unknown }> = []
-    const client = new ShimClient({
-      endpoint: `ws://127.0.0.1:${port}`,
-      dial: (url, opts) =>
-        ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
-      readToken: () => 'projected-token',
+    const { endpoint } = await fixtures.sandbox({
+      workspaceRoot: sandboxRoot,
       handle: async (capability, payload) => {
         handled.push({ capability, payload })
         // The shim performs the write itself, re-validating the path on its own side.
         await applyFileSinkPayload(payload)
         return null
-      },
+      }
+    })
+    const dialer = fixtures.dialer({
+      verifier: { reviewToken: async () => ({ authenticated: true, podName: 'sandbox-pod-1', podUid: 'u' }) },
       log: { info: () => {}, warn: () => {} }
     })
-    await client.start()
-    let connection: ShimConnection | undefined
-    for (let i = 0; i < 200 && !connection; i += 1) {
-      connection = instance.connectionsFor('agent-a')[0]
-      if (!connection) await new Promise((resolve) => setTimeout(resolve, 10))
+    const record: SpawnRecord = {
+      agentId: 'agent-a',
+      sandboxUid: 'sandbox-1',
+      generation: 3,
+      grants,
+      podName: 'sandbox-pod-1'
     }
-    if (!connection) throw new Error('no bound connection')
+    const connection = await dialer.connect(endpoint, record, 5_000)
     const channel = new ShimChannel(connection, connection.issuedCredential, timers)
     connection.onFrame((text) => channel.accept(text))
-    return { instance, client, channel, handled, sandboxRoot }
+    return { channel, handled, sandboxRoot }
   }
 
   it('writes a secret into the sandbox filesystem, decided by the daemon', async () => {
-    const { client, channel, handled, sandboxRoot } = await pair(['materialize'])
-    try {
-      const result = await materializeConfigFilesThrough(
-        sandboxRoot,
-        { KUBECONFIG_DATA: 'apiVersion: v1\n' },
-        new ShimFileSink(channel)
-      )
-      expect(result.env.KUBECONFIG).toBe(join(configFilesDir(sandboxRoot), 'kubeconfig'))
-      // The file exists because the SHIM wrote it, over a real socket, after its own
-      // validation — neither half of this is stubbed.
-      expect(readFileSync(join(configFilesDir(sandboxRoot), 'kubeconfig'), 'utf8')).toBe('apiVersion: v1\n')
-      expect(handled.map((entry) => entry.capability)).toEqual(['materialize', 'materialize'])
-    } finally {
-      client.stop()
-    }
+    const { channel, handled, sandboxRoot } = await pair(['materialize'])
+    const result = await materializeConfigFilesThrough(
+      sandboxRoot,
+      { KUBECONFIG_DATA: 'apiVersion: v1\n' },
+      new ShimFileSink(channel)
+    )
+    expect(result.env.KUBECONFIG).toBe(join(configFilesDir(sandboxRoot), 'kubeconfig'))
+    // The file exists because the SHIM wrote it, over a real socket, after its own
+    // validation — neither half of this is stubbed.
+    expect(readFileSync(join(configFilesDir(sandboxRoot), 'kubeconfig'), 'utf8')).toBe('apiVersion: v1\n')
+    expect(handled.map((entry) => entry.capability)).toEqual(['materialize', 'materialize'])
   }, 20_000)
 
   it('is refused by the shim when the launch never received the capability', async () => {
     // The grant list is enforced on both sides deliberately. Here the binding carries only
     // `exec`, so the shim refuses a materialize request even though the daemon asked.
-    const { client, channel, handled } = await pair(['exec'])
-    try {
-      await expect(channel.request('materialize', { op: 'clear', root: '/tmp' })).rejects.toThrow(/not granted/)
-      expect(handled).toEqual([])
-    } finally {
-      client.stop()
-    }
+    const { channel, handled } = await pair(['exec'])
+    await expect(channel.request('materialize', { op: 'clear', root: '/tmp' })).rejects.toThrow(/not granted/)
+    expect(handled).toEqual([])
   }, 20_000)
 })

--- a/packages/daemon/test/shim-dial-in.test.ts
+++ b/packages/daemon/test/shim-dial-in.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Backoff, ClientTransport, DEFAULT_BACKOFF_BASE_MS } from '@agentconnect.md/connection'
 import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
 import { WebSocket } from 'ws'
-import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import { ShimDialer, STARTUP_DIAL_BACKOFF, type ShimDialerDeps } from '../src/shim/dialer.js'
 import { ShimServer } from '../src/shim/server.js'
 import { ShimSession } from '../src/shim/session.js'
@@ -17,6 +16,7 @@ import {
   type ShimDialHello,
   type ShimFrame
 } from '../src/shim/protocol.js'
+import { shimFixtures } from './fakes/shim-sandbox.js'
 import { runVirtual, VirtualClock } from './fakes/virtual-clock.js'
 
 // Zero-jitter millisecond backoff so reconnect tests never sleep real seconds.
@@ -27,38 +27,14 @@ const pausedBackoff = (): Backoff => new Backoff({ baseMs: 10_000, jitter: () =>
 
 const quiet = { info: () => {}, warn: () => {} }
 
-const clients: ShimClient[] = []
-const dialers: ShimDialer[] = []
-const servers: ShimServer[] = []
+const fixtures = shimFixtures()
+const { dialers, sandbox, servers } = fixtures
 const sockets: WebSocket[] = []
 
 afterEach(async () => {
   for (const socket of sockets.splice(0)) socket.close()
-  for (const client of clients.splice(0)) client.stop()
-  for (const dialer of dialers.splice(0)) dialer.stop()
-  await Promise.all(servers.splice(0).map((server) => server.stop()))
+  await fixtures.cleanup()
 })
-
-async function sandbox(
-  options: { handle?: (capability: string, payload: unknown) => Promise<unknown>; backoff?: Backoff } = {}
-) {
-  const server = new ShimServer()
-  servers.push(server)
-  const port = await server.start(0, '127.0.0.1')
-  const client = new ShimClient({
-    endpoint: 'accepted-daemon-channel',
-    acceptDialIn: true,
-    dial: () => server.nextTransport() as Promise<ShimTransport>,
-    readToken: () => 'projected-token',
-    workspaceRoot: '/agent',
-    ...(options.handle ? { handle: options.handle as never } : {}),
-    ...(options.backoff ? { backoff: options.backoff } : {}),
-    log: { info: () => {}, warn: () => {} }
-  })
-  clients.push(client)
-  void client.start().catch(() => undefined)
-  return { endpoint: `ws://127.0.0.1:${port}`, client }
-}
 
 async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
   const deadline = Date.now() + timeoutMs


### PR DESCRIPTION
`test/shim-channels.test.ts` and `test/shim-cancellation.test.ts` test `ShimChannel`,
cancellation semantics, and `ShimFileSink` — all endpoint-agnostic — but built their fake
daemon endpoint out of `ShimListener`, the daemon-side dial-out listener that production no
longer uses. Production is the other direction: the daemon dials INTO the pod with
`ShimDialer`, and the pod accepts on `ShimServer`.

## What moved

- New `packages/daemon/test/fakes/shim-sandbox.ts` — `shimFixtures()`, the dial-in
  sandbox fixture `shim-dial-in.test.ts` already had inline (a `ShimServer` on loopback with a
  dial-in `ShimClient` attached to whatever daemon it accepts), plus the dialer/client/server
  registries and one `cleanup()`. It is a **factory**, not module-level state, because this
  suite runs `isolate: false` and a shared registry would leak one file's servers into the next.
  Options grew `clock` and `workspaceRoot` for the two migrated files.
- `shim-dial-in.test.ts` now imports that fixture instead of defining it; its own `sockets`
  array and everything else is untouched.
- `shim-channels.test.ts` — the `pair()` helper now dials in through `ShimDialer`. Grants come
  from the `SpawnRecord` passed to `connect()` rather than from `spawnRecordForPod`. The
  per-test `try/finally { client.stop() }` is gone: fixture `cleanup()` owns that now.
- `shim-cancellation.test.ts` — `channelUnderTest()` likewise. `credentialTtlMs` moved to
  `ShimDialer` deps, and the shim's `FakeClock`/zero-jitter `Backoff` go through the fixture,
  so the half-TTL renewal test still fires on the shim's own clock.

No production changes, no thin delegate shells, and `listener.ts` is deliberately left in
place — the follow-up PR deletes it.

## Verification

- `pnpm typecheck` (daemon) clean; prettier + eslint clean on the four touched files.
- `vitest run test/shim-cancellation.test.ts test/shim-channels.test.ts test/shim-dial-in.test.ts test/shim-handshake.test.ts`:
  **70 passed / 5 failed — identical to the same run on `main`**, same five test names, same
  assertion (`liveGitChildren(marker) > 0` never becomes true on this runner). `shim-cancellation`
  is a known pre-existing baseline failure; this PR migrates its scaffold, not its bug, and its
  failure set is unchanged rather than larger. `shim-channels`, `shim-dial-in`, and
  `shim-handshake` are fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
