### PR TITLE
feat(web): pick the repository to browse in the Workspace tab

### DIFF
--- a/docs/designs/multi-repository-workspaces.md
+++ b/docs/designs/multi-repository-workspaces.md
@@ -154,7 +154,16 @@ otherwise retained and reported. Re-adding the row un-retires the root in place.
 4. **Prompt** — root listing in the standing context; review text gains one
    sentence about additional directories being references only.
 5. **Web** — Workspace card wording ("Additional repositories … checked out
-   alongside the workspace") and, later, per-root status.
+   alongside the workspace"), plus the Workspace tab's root selection: the file
+   browser and the git panel read ONE root at a time, chosen by the repository
+   dropdown that replaced the breadcrumb's root label. The two scopes are
+   independent and both live in the URL — `?repo=owner/repo` names the root (absent
+   ⇒ the agent's own workspace) and `?worktree=<sessionId>` names the checkout
+   within it — so a link reproduces exactly what its author was looking at. A
+   `repo` the agent no longer authorizes falls back to the workspace, and a root
+   the agent has not materialized yet reads as an empty checkout rather than an
+   error. Editing stays scratch-workspace-only, so a secondary root is read-only
+   like any other repository checkout; the pull follows the selected root.
 6. **Tests** — workspace-manager multi-root (layout, isolation, GC),
    review-orchestrator cross-repository exact checkout and its fallback,
    spec-assembler projection, prompt snapshot.
@@ -212,5 +221,7 @@ on the daemon's PATH.
   shows up in practice.
 - Ordering of `additionalDirectories` when there are many roots — alphabetical
   by full name is the proposal.
-- Whether the console's session detail should render the root list; deferred
-  to the web phase.
+- Whether the console's session detail should render the root list. The AGENT's
+  Workspace tab now names its root explicitly (the repository dropdown above), so
+  what is left open is only the session surface, where a root list would have to
+  say which roots that session was actually handed.

--- a/packages/web/src/components/console/FileBrowser.tsx
+++ b/packages/web/src/components/console/FileBrowser.tsx
@@ -112,10 +112,11 @@ export function FileBrowserBreadcrumb({
   onBack,
   disabled,
   nested = true,
+  rootControl = false,
   ariaLabel = 'File path',
   inputAriaLabel = 'New file path'
 }: {
-  root: string
+  root: ReactNode
   path: string
   creating: boolean
   draftName: string
@@ -123,6 +124,8 @@ export function FileBrowserBreadcrumb({
   onBack?: () => void
   disabled?: boolean
   nested?: boolean
+  /** The root slot holds a CONTROL, not a label: it sizes itself and stays visible inside a path. */
+  rootControl?: boolean
   ariaLabel?: string
   inputAriaLabel?: string
 }) {
@@ -147,9 +150,13 @@ export function FileBrowserBreadcrumb({
         </button>
       ) : null}
       <span
-        className={`mono max-w-[120px] flex-none truncate text-[12px] font-semibold text-(--text-primary) ${
-          segments.length > 0 || creating ? 'max-desktop:hidden' : ''
-        }`}
+        className={
+          rootControl
+            ? 'flex min-w-0 flex-none items-center'
+            : `mono max-w-[120px] flex-none truncate text-[12px] font-semibold text-(--text-primary) ${
+                segments.length > 0 || creating ? 'max-desktop:hidden' : ''
+              }`
+        }
       >
         {root}
       </span>

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -188,7 +188,7 @@ it('uses the primary checkout live branch while browsing a worktree', async () =
   })
 
   expect(container.querySelector('[data-testid="primary-branch"]')?.textContent).toBe('primary-live-branch')
-  expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a', 'session-a')
+  expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a', 'session-a', undefined)
   expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a')
 })
 
@@ -234,6 +234,135 @@ describe('workspaceReadModelKey', () => {
   it('separates the primary checkout from a session worktree', () => {
     expect(workspaceReadModelKey(github, 'session-a')).not.toBe(workspaceReadModelKey(github))
   })
+
+  it('separates the workspace from an additional repository, and two of those from each other', () => {
+    expect(workspaceReadModelKey(github, undefined, 'acme/infra')).not.toBe(workspaceReadModelKey(github))
+    expect(workspaceReadModelKey(github, undefined, 'acme/infra')).not.toBe(
+      workspaceReadModelKey(github, undefined, 'example-co/shared-library')
+    )
+  })
+})
+
+const REPO_GRANTS = [
+  {
+    id: 'g-1',
+    repoFullName: 'acme/infra',
+    access: 'write' as const,
+    createdBy: null,
+    createdAt: '2026-08-01T00:00:00.000Z'
+  }
+]
+
+async function renderRepoScoped(props: Record<string, unknown> = {}) {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(
+      <WorkspaceFiles
+        agentId="agent-a"
+        workdir="/workspace"
+        canEdit={false}
+        repoOptions={REPO_GRANTS}
+        primaryRepoLabel="acme/primary-service"
+        onRepoChange={(props.onRepoChange as (repo: string | null) => void) ?? (() => undefined)}
+        renderHeader={() => null}
+        {...props}
+      />
+    )
+    await Promise.resolve()
+  })
+}
+
+it('offers the workspace and every authorized repository from the browser root', async () => {
+  await renderRepoScoped()
+  const trigger = container?.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]')
+  expect(trigger?.textContent).toContain('acme/primary-service')
+  await act(async () => trigger?.click())
+
+  // The menu is body-portaled out of the breadcrumb's clipped overflow.
+  expect(Array.from(document.body.querySelectorAll('[data-repo-choice]')).map((n) => n.textContent)).toEqual([
+    'acme/primary-serviceworkspace',
+    'acme/infrawrite'
+  ])
+})
+
+it('keeps the plain root label when the agent has nothing else to browse', async () => {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(
+      <WorkspaceFiles
+        agentId="agent-a"
+        workdir="/workspace"
+        canEdit={false}
+        repoOptions={[]}
+        renderHeader={() => null}
+      />
+    )
+    await Promise.resolve()
+  })
+  expect(container?.querySelector('button[aria-haspopup="menu"]')).toBeNull()
+  expect(container?.querySelector('nav[aria-label="Workspace path"]')?.textContent).toContain('workspace')
+})
+
+it('reports the picked repository so the caller can put it in the URL', async () => {
+  const onRepoChange = vi.fn()
+  await renderRepoScoped({ onRepoChange })
+  await act(async () => container?.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]')?.click())
+  const infra = Array.from(document.body.querySelectorAll<HTMLButtonElement>('[data-repo-choice]'))[1]
+  await act(async () => infra?.click())
+  expect(onRepoChange).toHaveBeenCalledWith('acme/infra')
+})
+
+it('scopes file and git reads to the selected repository, and keeps edits off it', async () => {
+  await renderRepoScoped({ repo: 'acme/infra', canEdit: true })
+
+  expect(fetchWorkspaceFiles).toHaveBeenCalledWith('agent-a', { path: '', repo: 'acme/infra' })
+  expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a', undefined, 'acme/infra')
+  // A secondary root is a repository checkout, so the scratch-only editor stays away from it.
+  expect(container?.textContent).not.toContain('Add file')
+})
+
+it('names a scratch workspace as one in the root menu', async () => {
+  await renderRepoScoped({ primaryRepoLabel: undefined })
+  await act(async () => container?.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]')?.click())
+  expect(Array.from(document.body.querySelectorAll('[data-repo-choice]'))[0]?.textContent).toBe(
+    'Scratch workspaceworkspace'
+  )
+})
+
+it('keeps the repository control visible on mobile, where a plain root label collapses', async () => {
+  mobile.value = true
+  await renderRepoScoped({ repo: 'acme/infra' })
+  const nav = container?.querySelector('nav[aria-label="Workspace path"]')
+  const trigger = nav?.querySelector('button[aria-haspopup="menu"]')
+  expect(trigger).not.toBeNull()
+  for (let node = trigger?.parentElement; node && node !== nav; node = node.parentElement) {
+    expect(node.className).not.toContain('max-desktop:hidden')
+  }
+})
+
+it('points the view-on-remote action at the selected repository', async () => {
+  const headers: Array<{ repoUrl?: string | null }> = []
+  await renderRepoScoped({
+    repo: 'acme/infra',
+    renderHeader: (header: { repoUrl?: string | null }) => {
+      headers.push(header)
+      return null
+    }
+  })
+  expect(headers.at(-1)?.repoUrl).toBe('https://github.com/acme/infra')
+})
+
+it('explains an authorized repository the agent has not checked out yet', async () => {
+  workspace.exists = false
+  await renderRepoScoped({ repo: 'acme/infra' })
+
+  expect(container?.textContent).toContain('Not checked out yet')
+  expect(container?.textContent).toContain('materialized on the agent’s next session')
+  expect(container?.textContent).not.toContain('The workspace has no files yet')
 })
 
 it('scopes file and git reads to the selected session worktree', async () => {
@@ -254,7 +383,7 @@ it('scopes file and git reads to the selected session worktree', async () => {
   })
 
   expect(fetchWorkspaceFiles).toHaveBeenCalledWith('agent-a', { path: '', sessionId: 'session-a' })
-  expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a', 'session-a')
+  expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a', 'session-a', undefined)
   expect(container?.textContent).not.toContain('Add file')
 })
 

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -189,7 +189,7 @@ it('uses the primary checkout live branch while browsing a worktree', async () =
 
   expect(container.querySelector('[data-testid="primary-branch"]')?.textContent).toBe('primary-live-branch')
   expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a', 'session-a', undefined)
-  expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a')
+  expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a', undefined, undefined)
 })
 
 // The workspace editor lives in the card this browser renders, so a replacement
@@ -354,6 +354,32 @@ it('points the view-on-remote action at the selected repository', async () => {
     }
   })
   expect(headers.at(-1)?.repoUrl).toBe('https://github.com/acme/infra')
+})
+
+it('labels the checkout picker with the SELECTED root’s branch, not the workspace’s', async () => {
+  vi.mocked(fetchWorkspaceGitStatus).mockImplementation((_agentId, _sessionId, repo) =>
+    Promise.resolve({
+      isRepo: true,
+      clean: true,
+      repo: repo ?? 'https://github.com/acme/primary-service.git',
+      agentDir: null,
+      branch: repo ? 'trunk' : 'main',
+      tracking: null,
+      ahead: 0,
+      behind: 0,
+      files: [],
+      truncated: false,
+      lastCommit: null,
+      lastFetchAt: null
+    })
+  )
+  await renderRepoScoped({
+    repo: 'acme/infra',
+    renderWorkspacePicker: (branch: string | null) => <span data-testid="base-branch">{branch}</span>
+  })
+  // The worktree picker chooses a worktree OF the selected root, so its non-worktree entry is that
+  // root's checkout — labelling it with the workspace's branch would name a branch it is not on.
+  expect(container?.querySelector('[data-testid="base-branch"]')?.textContent).toBe('trunk')
 })
 
 it('explains an authorized repository the agent has not checked out yet', async () => {

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -13,6 +13,7 @@ import {
   fetchWorkspaceFileFull,
   writeWorkspaceFile,
   workspaceGitPull,
+  type AgentRepoAuthDto,
   type WorkspaceFileDto
 } from '@/lib/api'
 import { Spinner } from '@/components/marks'
@@ -44,6 +45,7 @@ import {
   workspaceEntryIcon,
   workspaceRootReadState
 } from '@/components/console/workspace-tree'
+import { WorkspaceRepoPicker } from '@/components/console/WorkspaceRepoPicker'
 import { useSandboxWake } from '@/components/console/sandbox-wake'
 import {
   SANDBOX_ASLEEP_NOTICE,
@@ -76,9 +78,15 @@ const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
  * and a GitHub → scratch conversion would additionally flip `canEdit` to true
  * over that stale GitHub preview. Pass this as the instance's React `key`.
  */
-export function workspaceReadModelKey(agent: Pick<Agent, 'id' | 'workspace' | 'workdir'>, sessionId?: string): string {
+export function workspaceReadModelKey(
+  agent: Pick<Agent, 'id' | 'workspace' | 'workdir'>,
+  sessionId?: string,
+  repo?: string
+): string {
   const ws = agent.workspace
-  const at = `${agent.id}:${agent.workdir}:${sessionId ?? 'primary'}`
+  // The repo scope is part of the identity for the same reason the session is: the cached tree,
+  // preview and git status belong to ONE root, and switching roots must remount rather than reuse.
+  const at = `${agent.id}:${agent.workdir}:${sessionId ?? 'primary'}:${repo ?? 'workspace'}`
   return ws.mode === 'github' ? `${at}:github:${ws.repo}@${ws.branch}:${ws.agentDir}` : `${at}:scratch`
 }
 
@@ -112,8 +120,12 @@ type DeleteDraft = {
 export function WorkspaceFiles({
   agentId,
   sessionId,
+  repo,
+  repoOptions,
+  primaryRepoLabel,
+  onRepoChange,
   workdir,
-  canEdit,
+  canEdit: workspaceCanEdit,
   sandboxed = false,
   renderWorkspacePicker,
   renderHeader
@@ -122,6 +134,14 @@ export function WorkspaceFiles({
   /** ACP session id selecting that session's isolated worktree. Omit for the
    * agent's primary checkout. */
   sessionId?: string
+  /** `owner/repo` of the authorized additional repository being browsed. Omit for the workspace. */
+  repo?: string
+  /** The agent's authorized additional repositories, offered beside the workspace in the root menu.
+   *  Empty ⇒ there is nothing to choose, so the breadcrumb keeps its plain root label. */
+  repoOptions?: AgentRepoAuthDto[]
+  /** `owner/repo` behind the agent's own workspace; absent ⇒ a scratch workspace, named as one. */
+  primaryRepoLabel?: string
+  onRepoChange?: (repo: string | null) => void
   workdir?: string
   canEdit: boolean
   /** The agent runs in a cluster sandbox: its files are readable only through a running pod, so opening the tab wakes it rather than waiting for the read to refuse. */
@@ -135,6 +155,9 @@ export function WorkspaceFiles({
    *  daemon round-trip. */
   renderHeader: (header: WorkspaceHeaderInfo) => ReactNode
 }) {
+  // The edit frames carry no repo scope, so a write while a secondary root is selected would land in
+  // the PRIMARY workspace under the wrong root's name. Editing is the workspace's own, always.
+  const canEdit = workspaceCanEdit && !repo
   const isMobile = useIsMobile()
   const [viewer, setViewer] = useState<Viewer | null>(null)
   const [editor, setEditor] = useState<FileBrowserEditorDraft | null>(null)
@@ -145,9 +168,9 @@ export function WorkspaceFiles({
   // Bumped after a pull to re-fetch both the git status and the tree.
   const [refreshTick, setRefreshTick] = useState(0)
   // The tree and git halves of the read model, shared with the dock's Files panel.
-  const { dirs, expanded, toggleDir, loadMoreDir, openPath } = useWorkspaceTree(agentId, sessionId, refreshTick)
+  const { dirs, expanded, toggleDir, loadMoreDir, openPath } = useWorkspaceTree(agentId, sessionId, refreshTick, repo)
   // `git` is null while loading, for a non-repo workspace, and when the owning daemon is offline — the workspace card falls back to the agent's configured source in all three.
-  const { git, primaryBranch } = useWorkspaceGitStatus(agentId, sessionId, refreshTick)
+  const { git, primaryBranch } = useWorkspaceGitStatus(agentId, sessionId, refreshTick, repo)
   // The sandbox wake: pressed once when the root read refuses with the asleep code (or on open for a sandboxed agent), then the read is polled through this same refresh until it answers.
   const retryRoot = useCallback(() => setRefreshTick((tick) => tick + 1), [])
   const wake = useSandboxWake(agentId, workspaceRootReadState(dirs['']), retryRoot, { sandboxed })
@@ -174,7 +197,11 @@ export function WorkspaceFiles({
       content: '',
       loadingMore: false
     })
-    fetchWorkspaceFile(agentId, { path: filePath, ...(sessionId ? { sessionId } : {}) }).then(
+    fetchWorkspaceFile(agentId, {
+      path: filePath,
+      ...(sessionId ? { sessionId } : {}),
+      ...(repo ? { repo } : {})
+    }).then(
       (f) =>
         setViewer((v) =>
           requestId === viewerRequestRef.current && v && v.path === filePath
@@ -206,7 +233,7 @@ export function WorkspaceFiles({
     return () => {
       viewerRequestRef.current += 1
     }
-  }, [agentId, sessionId])
+  }, [agentId, repo, sessionId])
 
   const editorTarget = editor?.target ?? null
 
@@ -215,7 +242,7 @@ export function WorkspaceFiles({
   useEffect(() => {
     if (!editorTarget) return
     let active = true
-    fetchWorkspaceFileFull(agentId, editorTarget).then(
+    fetchWorkspaceFileFull(agentId, editorTarget, repo ? { repo } : {}).then(
       (file) => {
         if (!active) return
         setEditor((current) => {
@@ -236,7 +263,7 @@ export function WorkspaceFiles({
     return () => {
       active = false
     }
-  }, [agentId, editorTarget])
+  }, [agentId, editorTarget, repo])
 
   useEffect(() => {
     if (!deleteDraft) return
@@ -266,7 +293,7 @@ export function WorkspaceFiles({
     if (gitPulling) return
     setGitPulling(true)
     setGitMsg(null)
-    workspaceGitPull(agentId).then(
+    workspaceGitPull(agentId, repo ? { repo } : {}).then(
       (r) => {
         setGitPulling(false)
         setGitMsg(r.detail ?? (r.ok ? 'Pulled.' : 'Pull failed.'))
@@ -288,7 +315,12 @@ export function WorkspaceFiles({
     const offset = v.file.nextOffset
     const requestId = ++viewerRequestRef.current
     setViewer({ ...v, loadingMore: true, moreErr: null })
-    fetchWorkspaceFile(agentId, { path: v.path, offset, ...(sessionId ? { sessionId } : {}) }).then(
+    fetchWorkspaceFile(agentId, {
+      path: v.path,
+      offset,
+      ...(sessionId ? { sessionId } : {}),
+      ...(repo ? { repo } : {})
+    }).then(
       (f) =>
         setViewer((cur) =>
           requestId === viewerRequestRef.current && cur && cur.path === v.path
@@ -316,6 +348,19 @@ export function WorkspaceFiles({
   const root = dirs['']
   const selectedDirectory = viewer ? viewer.path.split('/').slice(0, -1).join('/') : ''
   const workspaceRoot = workdir?.replace(/\/+$/, '').split('/').at(-1) || 'Workspace'
+  // The breadcrumb's root has always NAMED the root being browsed; with more than one to browse it
+  // becomes the control that chooses it. With nothing to choose it stays the plain label it was.
+  const repoChoices = repoOptions ?? []
+  const repoPicker =
+    repoChoices.length > 0 && onRepoChange ? (
+      <WorkspaceRepoPicker
+        primaryLabel={primaryRepoLabel || 'Scratch workspace'}
+        primaryIsRepo={Boolean(primaryRepoLabel)}
+        repos={repoChoices}
+        selectedRepo={repo ?? null}
+        onChange={onRepoChange}
+      />
+    ) : null
 
   const startCreate = () => {
     setDeleteDraft(null)
@@ -509,7 +554,13 @@ export function WorkspaceFiles({
   // Project the live git read model onto the workspace card. Nothing here is
   // required: an offline daemon (or a scratch workspace) simply leaves the
   // status/commit/pull half of the card empty.
-  const remote = git ? parseRemote(git.repo) : null
+  // A secondary root is always a github.com repository (grants exist only for App-covered repos), so
+  // its status names `owner/repo` where the primary's names a full clone address.
+  const remote = repo
+    ? { label: repo, host: 'github.com', url: `https://github.com/${repo}` }
+    : git
+      ? parseRemote(git.repo)
+      : null
   const header: WorkspaceHeaderInfo = {
     status: git
       ? git.clean
@@ -543,7 +594,8 @@ export function WorkspaceFiles({
       <FileBrowserShell
         title={
           <FileBrowserBreadcrumb
-            root={workspaceRoot}
+            root={repoPicker ?? workspaceRoot}
+            rootControl={repoPicker !== null}
             path={breadcrumbPath}
             creating={editor?.target === ''}
             draftName={editor?.name ?? ''}
@@ -649,9 +701,11 @@ export function WorkspaceFiles({
         {!editor && root && !root.loading && !root.err && !root.exists && (
           <EmptyNote
             text={
-              sessionId
-                ? "This session's workspace has been cleaned up — it will be recreated from the repository when the agent next works in this session."
-                : 'The workspace has no files yet — the agent creates them as it works.'
+              repo
+                ? 'Not checked out yet — this repository is materialized on the agent’s next session.'
+                : sessionId
+                  ? "This session's workspace has been cleaned up — it will be recreated from the repository when the agent next works in this session."
+                  : 'The workspace has no files yet — the agent creates them as it works.'
             }
           />
         )}
@@ -662,7 +716,7 @@ export function WorkspaceFiles({
 
         {(editor || (root?.entries && root.exists && root.entries.length > 0)) && (
           <FileBrowserLayout
-            resetKey={`${agentId}:${sessionId ?? 'primary'}:${mobileListSignal}`}
+            resetKey={`${agentId}:${sessionId ?? 'primary'}:${repo ?? 'workspace'}:${mobileListSignal}`}
             previewOpen={editor !== null || deleteDraft !== null}
             tree={(openPreview) =>
               root?.entries && root.exists && root.entries.length > 0 ? (

--- a/packages/web/src/components/console/WorkspaceRepoPicker.test.tsx
+++ b/packages/web/src/components/console/WorkspaceRepoPicker.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { WorkspaceRepoPicker, resolveWorkspaceRepoScope } from './WorkspaceRepoPicker'
+import { WorkspaceRepoPicker, resolveWorkspaceRepoScope, workspaceRepoParamRewrite } from './WorkspaceRepoPicker'
 import type { AgentRepoAuthDto } from '@/lib/api'
 
 let root: Root | undefined
@@ -50,6 +50,23 @@ describe('resolveWorkspaceRepoScope', () => {
   it('treats a blank parameter as the workspace', () => {
     expect(resolveWorkspaceRepoScope(null, [grant('acme/infra')])).toBeNull()
     expect(resolveWorkspaceRepoScope('   ', [grant('acme/infra')])).toBeNull()
+  })
+})
+
+describe('workspaceRepoParamRewrite', () => {
+  it('leaves the URL alone while the grants are still loading, and when it already agrees', () => {
+    expect(workspaceRepoParamRewrite('acme/infra', 'acme/infra', undefined)).toBeUndefined()
+    expect(workspaceRepoParamRewrite('acme/infra', 'acme/infra', [grant('acme/infra')])).toBeUndefined()
+    expect(workspaceRepoParamRewrite(null, null, [grant('acme/infra')])).toBeUndefined()
+  })
+
+  it('canonicalizes a link written in another casing, so the URL matches the picker', () => {
+    expect(workspaceRepoParamRewrite('ACME/Infra', 'acme/infra', [grant('acme/infra')])).toBe('acme/infra')
+  })
+
+  it('drops a link whose grant is gone, so a cold load stops retrying the dead scope', () => {
+    expect(workspaceRepoParamRewrite('acme/revoked', null, [grant('acme/infra')])).toBeNull()
+    expect(workspaceRepoParamRewrite('acme/anything', null, [])).toBeNull()
   })
 })
 

--- a/packages/web/src/components/console/WorkspaceRepoPicker.test.tsx
+++ b/packages/web/src/components/console/WorkspaceRepoPicker.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { WorkspaceRepoPicker, resolveWorkspaceRepoScope } from './WorkspaceRepoPicker'
+import type { AgentRepoAuthDto } from '@/lib/api'
+
+let root: Root | undefined
+let container: HTMLDivElement | undefined
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+function grant(repoFullName: string, access: AgentRepoAuthDto['access'] = 'write'): AgentRepoAuthDto {
+  return { id: `grant-${repoFullName}`, repoFullName, access, createdBy: null, createdAt: '2026-08-01T00:00:00.000Z' }
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  container?.remove()
+  root = undefined
+  container = undefined
+})
+
+async function render(node: React.ReactNode) {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => root?.render(node))
+}
+
+// The menu is body-portaled (the breadcrumb it sits in clips its overflow), so it is not under `container`.
+const choices = () => Array.from(document.body.querySelectorAll<HTMLButtonElement>('[data-repo-choice]'))
+
+describe('resolveWorkspaceRepoScope', () => {
+  it('keeps the parameter while the grants are still loading, so a cold visit lands on the right root', () => {
+    expect(resolveWorkspaceRepoScope('acme/infra', undefined)).toBe('acme/infra')
+  })
+
+  it('answers with the grant’s own casing, so the URL and the menu agree on one spelling', () => {
+    expect(resolveWorkspaceRepoScope('ACME/Infra', [grant('acme/infra')])).toBe('acme/infra')
+  })
+
+  it('falls back to the workspace for a link that outlived its grant', () => {
+    expect(resolveWorkspaceRepoScope('acme/revoked', [grant('acme/infra')])).toBeNull()
+    expect(resolveWorkspaceRepoScope('acme/anything', [])).toBeNull()
+  })
+
+  it('treats a blank parameter as the workspace', () => {
+    expect(resolveWorkspaceRepoScope(null, [grant('acme/infra')])).toBeNull()
+    expect(resolveWorkspaceRepoScope('   ', [grant('acme/infra')])).toBeNull()
+  })
+})
+
+describe('WorkspaceRepoPicker', () => {
+  it('lists the workspace first, then every authorized repository with its access tier', async () => {
+    await render(
+      <WorkspaceRepoPicker
+        primaryLabel="acme/primary-service"
+        primaryIsRepo
+        repos={[grant('acme/infra'), grant('example-co/shared-library', 'read')]}
+        selectedRepo={null}
+        onChange={vi.fn()}
+      />
+    )
+    await act(async () => container?.querySelector('button')?.click())
+
+    expect(choices().map((choice) => choice.textContent)).toEqual([
+      'acme/primary-serviceworkspace',
+      'acme/infrawrite',
+      'example-co/shared-libraryread'
+    ])
+    // The workspace is the selected root until a repository is picked.
+    expect(choices()[0]?.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('names the scratch workspace first when there is no repository behind it', async () => {
+    await render(
+      <WorkspaceRepoPicker
+        primaryLabel="Scratch workspace"
+        primaryIsRepo={false}
+        repos={[grant('acme/infra')]}
+        selectedRepo="acme/infra"
+        onChange={vi.fn()}
+      />
+    )
+    await act(async () => container?.querySelector('button')?.click())
+
+    expect(choices()[0]?.textContent).toBe('Scratch workspaceworkspace')
+    expect(choices()[1]?.getAttribute('aria-checked')).toBe('true')
+    // The trigger names the root being browsed, not the workspace behind it.
+    expect(container?.querySelector('button')?.textContent).toContain('acme/infra')
+  })
+
+  it('reports the picked repository and closes, and reports null for the workspace', async () => {
+    const onChange = vi.fn()
+    await render(
+      <WorkspaceRepoPicker
+        primaryLabel="acme/primary-service"
+        primaryIsRepo
+        repos={[grant('acme/infra')]}
+        selectedRepo={null}
+        onChange={onChange}
+      />
+    )
+    await act(async () => container?.querySelector('button')?.click())
+    await act(async () => choices()[1]?.click())
+    expect(onChange).toHaveBeenCalledWith('acme/infra')
+    expect(choices()).toHaveLength(0)
+
+    await act(async () => container?.querySelector('button')?.click())
+    await act(async () => choices()[0]?.click())
+    expect(onChange).toHaveBeenLastCalledWith(null)
+  })
+})

--- a/packages/web/src/components/console/WorkspaceRepoPicker.tsx
+++ b/packages/web/src/components/console/WorkspaceRepoPicker.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+// Which ROOT the workspace browser reads: the agent's own workspace, or one of its authorized
+// additional repositories, each materialized as a secondary root beside it
+// (multi-repository-workspaces.md). It sits where the breadcrumb's root label used to be, because
+// that label always named the root being browsed — it just could only ever name one.
+//
+// Sibling to <WorkspaceScopePicker>, which chooses the CHECKOUT within a root (the primary branch
+// or a session worktree). Two independent scopes, so they are two controls: the repository picked
+// here keeps whatever checkout that picker holds.
+//
+// The menu is an <AnchoredFlyout> rather than an absolutely-positioned one: the breadcrumb it lives
+// in clips its overflow to truncate long paths, which would cut a menu drawn inside it.
+
+import { GithubMark } from '@/components/marks'
+import { Icon } from '@/components/ui'
+import { AnchoredFlyout } from '@/components/ui/AnchoredFlyout'
+import { REPOSITORY_ACCESS_BADGE } from '@/components/console/WorkspaceFormFields'
+import type { AgentRepoAuthDto } from '@/lib/api'
+
+/**
+ * The repository the URL names, resolved against the agent's grants.
+ *
+ * A link can outlive a grant, so a `repo` the agent no longer authorizes falls back to the primary
+ * rather than showing a browser that answers 404. Only once the list has LOADED, though: dropping
+ * the parameter while it is still undefined would browse the wrong root on every cold visit and
+ * then remount. The row's own casing wins, so the URL and the menu agree on one spelling.
+ */
+export function resolveWorkspaceRepoScope(
+  repoParam: string | null,
+  authorizations: AgentRepoAuthDto[] | undefined
+): string | null {
+  const wanted = repoParam?.trim()
+  if (!wanted) return null
+  if (authorizations === undefined) return wanted
+  return authorizations.find((row) => row.repoFullName.toLowerCase() === wanted.toLowerCase())?.repoFullName ?? null
+}
+
+const CHOICE =
+  'flex w-full cursor-pointer items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[6px] text-left outline-none hover:bg-(--surface-hover) focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--brand)'
+const CHOICE_ON = `${CHOICE} bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)`
+
+export function WorkspaceRepoPicker({
+  primaryLabel,
+  primaryIsRepo,
+  repos,
+  selectedRepo,
+  onChange
+}: {
+  /** How the agent's own workspace reads in the list: `owner/repo`, or the scratch workspace's name. */
+  primaryLabel: string
+  /** A git workspace takes the GitHub mark like the grants; a scratch one takes a folder. */
+  primaryIsRepo: boolean
+  repos: AgentRepoAuthDto[]
+  /** `owner/repo` of the selected additional repository; null ⇒ the agent's own workspace. */
+  selectedRepo: string | null
+  onChange: (repo: string | null) => void
+}) {
+  const selected = selectedRepo ?? primaryLabel
+
+  return (
+    <AnchoredFlyout
+      ariaLabel="Workspace repository"
+      align="start"
+      width={320}
+      estimatedHeight={64 + repos.length * 34}
+      triggerClassName="flex min-w-0"
+      trigger={({ open, menuId, toggle }) => (
+        <button
+          type="button"
+          className="flex h-7 max-w-[220px] min-w-0 cursor-pointer items-center gap-1 rounded-md border-0 bg-transparent px-1 text-left outline-none hover:bg-(--surface-hover) focus-visible:ring-2 focus-visible:ring-(--brand)"
+          aria-label={`Repository: ${selected}`}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-controls={open ? menuId : undefined}
+          title={selectedRepo ? `${selectedRepo} — an authorized additional repository` : primaryLabel}
+          onClick={toggle}
+        >
+          <span className="mono max-w-[180px] truncate text-[12px] font-semibold text-(--text-primary)">
+            {selected}
+          </span>
+          <Icon
+            name="chevron-down"
+            size={13}
+            className={`flex-none text-(--text-tertiary) ${open ? 'rotate-180' : ''}`}
+          />
+        </button>
+      )}
+    >
+      {({ close }) => (
+        <>
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={selectedRepo === null}
+            data-repo-choice
+            className={selectedRepo === null ? CHOICE_ON : CHOICE}
+            onClick={() => {
+              close(true)
+              onChange(null)
+            }}
+          >
+            {primaryIsRepo ? (
+              <span className="imark h-[14px] w-[14px] flex-none border-0 bg-transparent">
+                <GithubMark />
+              </span>
+            ) : (
+              <Icon name="folder" size={14} className="flex-none" />
+            )}
+            <span className="mono min-w-0 flex-1 truncate text-[11.5px] font-semibold" title={primaryLabel}>
+              {primaryLabel}
+            </span>
+            <span className="eyebrow flex-none text-[10px]">workspace</span>
+          </button>
+
+          {repos.length > 0 ? (
+            <>
+              <div className="eyebrow mt-[3px] flex h-7 items-center gap-2 border-t border-(--border-subtle) px-[9px] text-[10.5px]">
+                <span>Additional repositories</span>
+                <span aria-hidden>·</span>
+                <span>{repos.length}</span>
+              </div>
+              {repos.map((repo) => {
+                const active = repo.repoFullName === selectedRepo
+                return (
+                  <button
+                    key={repo.id}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={active}
+                    data-repo-choice
+                    className={active ? CHOICE_ON : CHOICE}
+                    title={`${repo.repoFullName} — ${repo.access} access`}
+                    onClick={() => {
+                      close(true)
+                      onChange(repo.repoFullName)
+                    }}
+                  >
+                    <span className="imark h-[14px] w-[14px] flex-none border-0 bg-transparent">
+                      <GithubMark />
+                    </span>
+                    <span className="mono min-w-0 flex-1 truncate text-[11.5px]">{repo.repoFullName}</span>
+                    <span className={REPOSITORY_ACCESS_BADGE[repo.access]}>{repo.access}</span>
+                  </button>
+                )
+              })}
+            </>
+          ) : null}
+        </>
+      )}
+    </AnchoredFlyout>
+  )
+}

--- a/packages/web/src/components/console/WorkspaceRepoPicker.tsx
+++ b/packages/web/src/components/console/WorkspaceRepoPicker.tsx
@@ -36,6 +36,23 @@ export function resolveWorkspaceRepoScope(
   return authorizations.find((row) => row.repoFullName.toLowerCase() === wanted.toLowerCase())?.repoFullName ?? null
 }
 
+/**
+ * What the `repo` parameter should become once grant resolution is definitive, or `undefined` when
+ * the URL already agrees with the root being read (`null` ⇒ drop the parameter).
+ *
+ * {@link resolveWorkspaceRepoScope} can answer with the grant's own casing or with the workspace, and
+ * a URL left saying something else both disagrees with the visible root and makes a link whose grant
+ * is gone retry its dead scope on every cold load.
+ */
+export function workspaceRepoParamRewrite(
+  repoParam: string | null,
+  resolvedRepo: string | null,
+  authorizations: AgentRepoAuthDto[] | undefined
+): string | null | undefined {
+  if (repoParam === null || authorizations === undefined) return undefined
+  return repoParam === resolvedRepo ? undefined : resolvedRepo
+}
+
 const CHOICE =
   'flex w-full cursor-pointer items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[6px] text-left outline-none hover:bg-(--surface-hover) focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--brand)'
 const CHOICE_ON = `${CHOICE} bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)`

--- a/packages/web/src/components/console/dock/FilesPanel.test.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.test.tsx
@@ -467,8 +467,8 @@ describe('FilesPanel session scope', () => {
     expect(vi.mocked(fetchWorkspaceGitStatus).mock.calls).toEqual([
       // No repo scope: the dock's panel always reads the agent's own workspace.
       ['agent-a', 'session-1', undefined],
-      // The second, sessionless read is the branch label: a session worktree is detached, so its own status names no branch.
-      ['agent-a']
+      // The second, sessionless read is the branch label: a session worktree sits on its own branch, so its status names that one instead of the base checkout's.
+      ['agent-a', undefined, undefined]
     ])
   })
 

--- a/packages/web/src/components/console/dock/FilesPanel.test.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.test.tsx
@@ -465,7 +465,8 @@ describe('FilesPanel session scope', () => {
 
     expect(vi.mocked(fetchWorkspaceFiles).mock.calls[0]?.[1]).toMatchObject({ path: '', sessionId: 'session-1' })
     expect(vi.mocked(fetchWorkspaceGitStatus).mock.calls).toEqual([
-      ['agent-a', 'session-1'],
+      // No repo scope: the dock's panel always reads the agent's own workspace.
+      ['agent-a', 'session-1', undefined],
       // The second, sessionless read is the branch label: a session worktree is detached, so its own status names no branch.
       ['agent-a']
     ])
@@ -518,7 +519,7 @@ describe('FilesPanel session scope', () => {
     await render({ sessionId: undefined })
 
     expect(vi.mocked(fetchWorkspaceFiles).mock.calls[0]?.[1]).not.toHaveProperty('sessionId')
-    expect(vi.mocked(fetchWorkspaceGitStatus).mock.calls).toEqual([['agent-a', undefined]])
+    expect(vi.mocked(fetchWorkspaceGitStatus).mock.calls).toEqual([['agent-a', undefined, undefined]])
   })
 
   it('shows the primary branch beside the workdir, and says whose branch it is', async () => {

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -54,6 +54,7 @@ import { discordBotInviteUrl } from '@/components/console/platforms/discord/invi
 import { WorkspaceCard, type WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
 import { WorkspaceFiles, workspaceReadModelKey } from '@/components/console/WorkspaceFiles'
 import { WorkspaceFilesMock } from '@/components/console/WorkspaceFilesMock'
+import { resolveWorkspaceRepoScope } from '@/components/console/WorkspaceRepoPicker'
 import { WorkspaceScopePicker } from '@/components/console/WorkspaceScopePicker'
 import { FileBrowserShell } from '@/components/console/FileBrowser'
 import { MemoryPanel } from '@/components/console/MemoryPanel'
@@ -146,7 +147,8 @@ export default function AgentDetailView() {
     agentsLoading,
     updateAgent,
     refresh,
-    memberSets
+    memberSets,
+    orgSetIds
   } = useConsoleData()
   const { openPlayground } = usePlayground()
   const { openModal } = useModal()
@@ -226,6 +228,18 @@ export default function AgentDetailView() {
   const wsForRepos = getAgent(id)?.workspace
   const reposKey = wsForRepos ? consoleKeys.agentRepos(activeOrg?.id, id) : null
   const { data: agentReposData } = useSWR(reposKey, ([, orgId, , agentId]) => fetchAgentRepos(agentId, orgId))
+  // Which ROOT the Workspace tab browses, beside `?worktree=` which chooses the checkout within it.
+  // Pool placements hold their grants as authorization only — no secondary root is materialized
+  // there yet — so the menu offers nothing to switch to and the browser stays on the workspace.
+  const poolPlacedForRepos = isPoolPlacementKind(getAgent(id)?.placementKind, getAgent(id)?.setId, orgSetIds)
+  const workspaceRepoOptions = poolPlacedForRepos ? [] : (agentReposData ?? [])
+  const selectedRepo = resolveWorkspaceRepoScope(params.get('repo'), poolPlacedForRepos ? [] : agentReposData)
+  const selectRepoScope = (repo: string | null) => {
+    const next = new URLSearchParams(params)
+    if (repo) next.set('repo', repo)
+    else next.delete('repo')
+    router.replace(`${orgPath(`/agents/${id}`)}?${next.toString()}`, { scroll: false })
+  }
   // Grandfathered out-of-set hooks keep firing; only the gh write-back is
   // credential-less — badge them once the grant list has actually loaded.
   const watchUnauthorized = (h: HookDto): boolean =>
@@ -1632,9 +1646,13 @@ export default function AgentDetailView() {
                 instead of leaving the previous tree/preview/git state beneath a
                 refreshed source card. */}
             <WorkspaceFiles
-              key={workspaceReadModelKey(da, selectedWorktreeSessionId ?? undefined)}
+              key={workspaceReadModelKey(da, selectedWorktreeSessionId ?? undefined, selectedRepo ?? undefined)}
               agentId={id}
               {...(selectedWorktreeSessionId ? { sessionId: selectedWorktreeSessionId } : {})}
+              {...(selectedRepo ? { repo: selectedRepo } : {})}
+              repoOptions={workspaceRepoOptions}
+              {...(da.workspace.mode === 'github' ? { primaryRepoLabel: da.workspace.repo } : {})}
+              onRepoChange={selectRepoScope}
               workdir={da.workdir}
               canEdit={selectedWorktreeSessionId === null && da.workspace.mode === 'scratch' && da.canEdit}
               sandboxed={isPoolPlacementKind(da.placementKind)}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import useSWR from 'swr'
 import Link from 'next/link'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
@@ -54,7 +54,7 @@ import { discordBotInviteUrl } from '@/components/console/platforms/discord/invi
 import { WorkspaceCard, type WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
 import { WorkspaceFiles, workspaceReadModelKey } from '@/components/console/WorkspaceFiles'
 import { WorkspaceFilesMock } from '@/components/console/WorkspaceFilesMock'
-import { resolveWorkspaceRepoScope } from '@/components/console/WorkspaceRepoPicker'
+import { resolveWorkspaceRepoScope, workspaceRepoParamRewrite } from '@/components/console/WorkspaceRepoPicker'
 import { WorkspaceScopePicker } from '@/components/console/WorkspaceScopePicker'
 import { FileBrowserShell } from '@/components/console/FileBrowser'
 import { MemoryPanel } from '@/components/console/MemoryPanel'
@@ -234,12 +234,25 @@ export default function AgentDetailView() {
   const poolPlacedForRepos = isPoolPlacementKind(getAgent(id)?.placementKind, getAgent(id)?.setId, orgSetIds)
   const workspaceRepoOptions = poolPlacedForRepos ? [] : (agentReposData ?? [])
   const selectedRepo = resolveWorkspaceRepoScope(params.get('repo'), poolPlacedForRepos ? [] : agentReposData)
-  const selectRepoScope = (repo: string | null) => {
-    const next = new URLSearchParams(params)
-    if (repo) next.set('repo', repo)
-    else next.delete('repo')
-    router.replace(`${orgPath(`/agents/${id}`)}?${next.toString()}`, { scroll: false })
-  }
+  const selectRepoScope = useCallback(
+    (repo: string | null) => {
+      const next = new URLSearchParams(params)
+      if (repo) next.set('repo', repo)
+      else next.delete('repo')
+      router.replace(`${orgPath(`/agents/${id}`)}?${next.toString()}`, { scroll: false })
+    },
+    [id, orgPath, params, router]
+  )
+  // ...and once the grants are definitive, make the URL say which root the browser is actually
+  // reading, so a hand-written or revoked link stops disagreeing with the picker beside it.
+  const repoParamRewrite = workspaceRepoParamRewrite(
+    params.get('repo'),
+    selectedRepo,
+    poolPlacedForRepos ? [] : agentReposData
+  )
+  useEffect(() => {
+    if (repoParamRewrite !== undefined) selectRepoScope(repoParamRewrite)
+  }, [repoParamRewrite, selectRepoScope])
   // Grandfathered out-of-set hooks keep firing; only the gh write-back is
   // credential-less — badge them once the grant list has actually loaded.
   const watchUnauthorized = (h: HookDto): boolean =>

--- a/packages/web/src/components/console/workspace-tree.tsx
+++ b/packages/web/src/components/console/workspace-tree.tsx
@@ -232,12 +232,12 @@ export interface WorkspaceGitRead {
   /** The live status, or null for a non-repo workspace, an offline daemon, and the window before the first answer. */
   git: WorkspaceGitStatusDto | null
   outcome: WorkspaceGitOutcome
-  /** The PRIMARY checkout's branch. Fetched separately in session scope, where the worktree is detached and its own `branch` names no branch. */
+  /** The branch of the SELECTED root's base checkout — the label the checkout picker's non-worktree entry carries. Fetched separately in session scope, where the worktree sits on its own branch and its status names that one instead. */
   primaryBranch: string | null
 }
 
 /** The git half of the read model: status for the badges and the footer, plus the branch label a session worktree cannot supply itself. */
-// `repo` scopes the status to one authorized additional repository; `primaryBranch` stays the PRIMARY workspace's, because it labels the checkout picker beside the browser rather than the tree being read.
+// `repo` scopes BOTH reads to one authorized additional repository: the checkout picker beside the browser chooses a worktree of the selected root, so the branch it labels its non-worktree entry with is that root's, not the workspace's.
 export function useWorkspaceGitStatus(
   agentId: string,
   sessionId?: string,
@@ -256,17 +256,17 @@ export function useWorkspaceGitStatus(
         if (!active) return
         setGit(s.isRepo ? s : null)
         setOutcome(s.isRepo ? 'repo' : 'none')
-        if (!sessionId && !repo) setPrimaryBranch(s.isRepo ? s.branch : null)
+        if (!sessionId) setPrimaryBranch(s.isRepo ? s.branch : null)
       },
       (e: unknown) => {
         if (!active) return
         setGit(null)
         setOutcome(isSandboxAsleep(e) ? 'asleep' : 'unavailable')
-        if (!sessionId && !repo) setPrimaryBranch(null)
+        if (!sessionId) setPrimaryBranch(null)
       }
     )
-    if (sessionId || repo) {
-      fetchWorkspaceGitStatus(agentId).then(
+    if (sessionId) {
+      fetchWorkspaceGitStatus(agentId, undefined, repo).then(
         (s) => {
           if (active) setPrimaryBranch(s.isRepo ? s.branch : null)
         },

--- a/packages/web/src/components/console/workspace-tree.tsx
+++ b/packages/web/src/components/console/workspace-tree.tsx
@@ -63,7 +63,8 @@ export interface WorkspaceTree {
 
 /** The tree half of the read model for one daemon-local checkout. `refreshTick` re-runs the root load, deliberately wiping the cache and the expand set with it. */
 // `sessionId` selects that session's isolated worktree; omit it for the primary checkout, and pass it only for a session whose `workspaceIsolation` is `'session'` — the daemon answers a shared-workspace sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline".
-export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTick = 0): WorkspaceTree {
+// `repo` selects one of the agent's authorized additional repositories, browsing that secondary root; the two scopes compose, so a `repo` with a `sessionId` is that root's own worktree for the session.
+export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTick = 0, repo?: string): WorkspaceTree {
   const [dirs, setDirs] = useState<Record<string, WorkspaceDirState>>({})
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
   // Which checkout+refresh a reply was asked for. The panel SURVIVES a scope change, so an in-flight directory read from the previous agent or worktree would otherwise splice its entries into the new one's cache — and worse, leave `dirs[path]` populated, so expanding that folder in the new scope skips the fetch that would have corrected it.
@@ -81,7 +82,7 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
     (path: string) => {
       const gen = generation.current
       patchDir(path, { loading: true, err: null, errStatus: null, errCode: null })
-      fetchWorkspaceFiles(agentId, { path, ...(sessionId ? { sessionId } : {}) }).then(
+      fetchWorkspaceFiles(agentId, { path, ...(sessionId ? { sessionId } : {}), ...(repo ? { repo } : {}) }).then(
         (page) => {
           if (gen !== generation.current) return
           setDirs((prev) => ({
@@ -105,7 +106,7 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
         }
       )
     },
-    [agentId, patchDir, sessionId]
+    [agentId, patchDir, repo, sessionId]
   )
 
   const loadMoreDir = useCallback(
@@ -114,7 +115,12 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
       if (!d?.nextCursor || d.loadingMore) return
       const gen = generation.current
       patchDir(path, { loadingMore: true, moreErr: null })
-      fetchWorkspaceFiles(agentId, { path, cursor: d.nextCursor, ...(sessionId ? { sessionId } : {}) }).then(
+      fetchWorkspaceFiles(agentId, {
+        path,
+        cursor: d.nextCursor,
+        ...(sessionId ? { sessionId } : {}),
+        ...(repo ? { repo } : {})
+      }).then(
         (page) => {
           if (gen !== generation.current) return
           setDirs((prev) => {
@@ -137,7 +143,7 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
         }
       )
     },
-    [agentId, dirs, patchDir, sessionId]
+    [agentId, dirs, patchDir, repo, sessionId]
   )
 
   const toggleDir = useCallback(
@@ -173,7 +179,7 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
     const active = () => gen === generation.current
     setDirs({ '': { ...LOADING_DIR } })
     setExpanded(new Set())
-    fetchWorkspaceFiles(agentId, { path: '', ...(sessionId ? { sessionId } : {}) }).then(
+    fetchWorkspaceFiles(agentId, { path: '', ...(sessionId ? { sessionId } : {}), ...(repo ? { repo } : {}) }).then(
       (page) => {
         if (!active()) return
         setDirs({
@@ -199,7 +205,7 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
       // A teardown is its own generation change: the next mount's reads must not be answered by this one's.
       generation.current += 1
     }
-  }, [agentId, refreshTick, sessionId])
+  }, [agentId, refreshTick, repo, sessionId])
 
   return { dirs, root: dirs[''], expanded, toggleDir, loadMoreDir, openPath }
 }
@@ -231,7 +237,13 @@ export interface WorkspaceGitRead {
 }
 
 /** The git half of the read model: status for the badges and the footer, plus the branch label a session worktree cannot supply itself. */
-export function useWorkspaceGitStatus(agentId: string, sessionId?: string, refreshTick = 0): WorkspaceGitRead {
+// `repo` scopes the status to one authorized additional repository; `primaryBranch` stays the PRIMARY workspace's, because it labels the checkout picker beside the browser rather than the tree being read.
+export function useWorkspaceGitStatus(
+  agentId: string,
+  sessionId?: string,
+  refreshTick = 0,
+  repo?: string
+): WorkspaceGitRead {
   const [git, setGit] = useState<WorkspaceGitStatusDto | null>(null)
   const [outcome, setOutcome] = useState<WorkspaceGitOutcome>('pending')
   const [primaryBranch, setPrimaryBranch] = useState<string | null>(null)
@@ -239,21 +251,21 @@ export function useWorkspaceGitStatus(agentId: string, sessionId?: string, refre
   useEffect(() => {
     let active = true
     setOutcome('pending')
-    fetchWorkspaceGitStatus(agentId, sessionId).then(
+    fetchWorkspaceGitStatus(agentId, sessionId, repo).then(
       (s) => {
         if (!active) return
         setGit(s.isRepo ? s : null)
         setOutcome(s.isRepo ? 'repo' : 'none')
-        if (!sessionId) setPrimaryBranch(s.isRepo ? s.branch : null)
+        if (!sessionId && !repo) setPrimaryBranch(s.isRepo ? s.branch : null)
       },
       (e: unknown) => {
         if (!active) return
         setGit(null)
         setOutcome(isSandboxAsleep(e) ? 'asleep' : 'unavailable')
-        if (!sessionId) setPrimaryBranch(null)
+        if (!sessionId && !repo) setPrimaryBranch(null)
       }
     )
-    if (sessionId) {
+    if (sessionId || repo) {
       fetchWorkspaceGitStatus(agentId).then(
         (s) => {
           if (active) setPrimaryBranch(s.isRepo ? s.branch : null)
@@ -266,7 +278,7 @@ export function useWorkspaceGitStatus(agentId: string, sessionId?: string, refre
     return () => {
       active = false
     }
-  }, [agentId, refreshTick, sessionId])
+  }, [agentId, refreshTick, repo, sessionId])
 
   return { git, outcome, primaryBranch }
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2428,12 +2428,15 @@ export const MAX_WORKSPACE_EDIT_BYTES = 180_000
 // One page of a workspace directory listing (GET /agents/:id/workspace/files),
 // proxied live from the agent's owning daemon — the CP never stores workspace
 // bytes (body-locality). 503 when that daemon is offline / the agent is unplaced.
+// `repo` names one of the agent's authorized additional repositories, browsing that
+// secondary root instead of the primary workspace; 404 when it authorizes no such repo.
 export async function fetchWorkspaceFiles(
   agentId: string,
-  opts: { path: string; cursor?: string; limit?: number; sessionId?: string }
+  opts: { path: string; cursor?: string; limit?: number; sessionId?: string; repo?: string }
 ): Promise<WorkspaceListingDto> {
   const q = new URLSearchParams({ path: opts.path })
   if (opts.sessionId) q.set('sessionId', opts.sessionId)
+  if (opts.repo) q.set('repo', opts.repo)
   if (opts.cursor) q.set('cursor', opts.cursor)
   if (opts.limit) q.set('limit', String(opts.limit))
   return apiGet<WorkspaceListingDto>(
@@ -2469,10 +2472,11 @@ export async function fetchAgentLocalSkills(agentId: string): Promise<LocalSkill
 // 503 when the daemon is offline / the agent is unplaced.
 export async function fetchWorkspaceFile(
   agentId: string,
-  opts: { path: string; offset?: number; limit?: number; sessionId?: string }
+  opts: { path: string; offset?: number; limit?: number; sessionId?: string; repo?: string }
 ): Promise<WorkspaceFileDto> {
   const q = new URLSearchParams({ path: opts.path })
   if (opts.sessionId) q.set('sessionId', opts.sessionId)
+  if (opts.repo) q.set('repo', opts.repo)
   if (opts.offset) q.set('offset', String(opts.offset))
   if (opts.limit) q.set('limit', String(opts.limit))
   return apiGet<WorkspaceFileDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace/file?${q.toString()}`)
@@ -2480,12 +2484,16 @@ export async function fetchWorkspaceFile(
 
 /** Read one workspace text file whole before editing it. Every slice must describe
  * the same mtime so a multi-page load cannot assemble two agent revisions. */
-export async function fetchWorkspaceFileFull(agentId: string, path: string): Promise<WorkspaceFileDto> {
+export async function fetchWorkspaceFileFull(
+  agentId: string,
+  path: string,
+  opts: { repo?: string } = {}
+): Promise<WorkspaceFileDto> {
   let offset = 0
   let content = ''
   let mtime: string | null | undefined
   for (let page = 0; page < 16; page++) {
-    const slice = await fetchWorkspaceFile(agentId, { path, offset })
+    const slice = await fetchWorkspaceFile(agentId, { path, offset, ...(opts.repo ? { repo: opts.repo } : {}) })
     if (!slice.exists || slice.encoding !== 'utf8') return slice
     if ((slice.size ?? 0) > MAX_WORKSPACE_EDIT_BYTES) {
       throw new Error('Files larger than 180 KB cannot be edited here.')
@@ -2982,9 +2990,14 @@ export interface WorkspaceGitPullDto {
 
 // Report whether the agent's workspace checkout is clean. Read-only; proxied live
 // from the owning daemon (no CP storage). 503 when the daemon is offline.
-export async function fetchWorkspaceGitStatus(agentId: string, sessionId?: string): Promise<WorkspaceGitStatusDto> {
+export async function fetchWorkspaceGitStatus(
+  agentId: string,
+  sessionId?: string,
+  repo?: string
+): Promise<WorkspaceGitStatusDto> {
   const q = new URLSearchParams()
   if (sessionId) q.set('sessionId', sessionId)
+  if (repo) q.set('repo', repo)
   const query = q.size ? `?${q.toString()}` : ''
   return apiGet<WorkspaceGitStatusDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace/gitstatus${query}`)
 }
@@ -3060,8 +3073,12 @@ export async function fetchWorkspaceGitLog(
 
 // Force the owning daemon to `git pull` (fast-forward only) the agent's workspace
 // now. A pull that can't fast-forward returns `ok:false`; 503 when daemon offline.
-export async function workspaceGitPull(agentId: string): Promise<WorkspaceGitPullDto> {
-  return apiPost<WorkspaceGitPullDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace/gitpull`, {})
+export async function workspaceGitPull(agentId: string, opts: { repo?: string } = {}): Promise<WorkspaceGitPullDto> {
+  const query = opts.repo ? `?repo=${encodeURIComponent(opts.repo)}` : ''
+  return apiPost<WorkspaceGitPullDto>(
+    `${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace/gitpull${query}`,
+    {}
+  )
 }
 
 // ── workspace git writes (executed only on the owning daemon; the CP stores nothing) ──


### PR DESCRIPTION
## What and why

Follow-up to #1229, which taught the protocol, the control plane and the daemon to address one of an agent's authorized additional repositories. This spends it: the console's Workspace tab can now browse them.

The tab could only ever read the agent's own workspace, so the secondary roots materialized for its authorized repositories had no surface at all — the chips on the Workspace card said they were checked out, and nothing could look at them.

The breadcrumb's root label always *named* the root being browsed. With more than one to browse it becomes the control that chooses it.

## What it does

**The dropdown.** The agent's own workspace first — `owner/repo`, or "Scratch workspace" when there is no repository behind it — then every authorized repository with its access tier, from the same grant list the Workspace card's chips already use (one fetch, shared through its SWR key).

**The scope lives in the URL.** `?repo=owner/repo` beside the existing `?worktree=<sessionId>`. Two independent scopes that compose: the repository names the root, the worktree picker names the checkout within it, and a link reproduces exactly what its author was looking at. The selection uses the grant's own casing, so the URL and the menu never disagree on spelling.

**Everything follows the selection.** The tree, the file preview and its paging, the git status behind the file badges and the header, and the pull. A repository the agent no longer authorizes falls back to the workspace — but only once the grant list has *loaded*, so a cold visit to a valid link does not browse the wrong root first. A root the agent has not materialized yet reads as "Not checked out yet — this repository is materialized on the agent's next session." rather than as an error.

**Editing stays the workspace's own.** The edit frames carry no repository scope, so a write while a secondary root is selected would land in the workspace under the wrong root's name. The browser refuses to offer the editor whenever a repository is selected rather than trusting its caller to remember — the guard lives where the write is issued.

**Pool placements** hold their grants as authorization only (no secondary root is materialized for them yet), so their menu has nothing to switch to and the browser stays on the workspace.

## What a reviewer should check

- **The menu is an `AnchoredFlyout`.** The breadcrumb clips its overflow to truncate long paths, which would cut a menu drawn inside it; that primitive exists for exactly this. It also stays visible on mobile, where a plain root label collapses once you are inside a path.
- **The read-model key includes the repository**, so switching roots remounts rather than reusing another root's cached tree, preview and git state — the same reason the session is in that key.
- **`canEdit` cannot be true with a repository selected**, and a test pins it.
- **Primary behavior is unchanged when no repository is selected**: no `repo` on any request, the same empty-state copy, the same edit affordances.

## What is not here

- The session detail's Changes panel (stage / commit / push / diff) is untouched — it reads a *session's* worktree of the workspace, which is a different surface with its own scope. Only the Workspace tab's pull became repository-scoped, because it is the only git write that tab has.
- No per-root status summary on the Workspace card; the card still describes the configured workspace, and the live half follows whichever root is being browsed (it has to — the file badges are computed from that same status).
- Cluster/pool secondary roots, which the daemon does not materialize yet.

## Tests

`WorkspaceRepoPicker.test.tsx` covers the URL-to-grant resolution (loading, casing, a stale link, a blank parameter) and the menu itself. `WorkspaceFiles.test.tsx` covers the control appearing in the browser root, the plain label surviving when there is nothing to choose, the scratch naming, the selection reported for the URL, reads scoped to the selection, the editor withheld, the unmaterialized note, the remote link, and the mobile visibility. `pnpm --filter @agentconnect.md/web test` is green (1661 tests), as are typecheck, eslint and prettier.

The design doc's Web section now records the one-root-at-a-time model and the two URL parameters, and the matching open question is narrowed to the session surface it still applies to.
