### PR TITLE
fix(daemon): preempt a running review when a newer revision lands

### DIFF
--- a/packages/control-plane/src/github/run-reporter.test.ts
+++ b/packages/control-plane/src/github/run-reporter.test.ts
@@ -1227,59 +1227,70 @@ describe('GithubRunReporter', () => {
   })
 
   it.each([
-    ['no current PR', [], 'no_current_pull_request'],
-    ['stale head', [{ pullNumber: 9, headSha: 'd'.repeat(40) }], 'stale_head'],
+    ['no current PR', [], 'no_current_pull_request', 'neutral', 'Revision is no longer current'],
+    [
+      'stale head',
+      [{ pullNumber: 9, headSha: 'd'.repeat(40) }],
+      'stale_head',
+      'neutral',
+      'Revision is no longer current'
+    ],
     [
       'shared head across open PRs',
       [
         { pullNumber: 9, headSha: 'c'.repeat(40) },
         { pullNumber: 10, headSha: 'c'.repeat(40) }
       ],
-      'shared_head_multiple_prs'
+      'shared_head_multiple_prs',
+      'action_required',
+      'Pull request association needs attention'
     ]
-  ] as const)('fails closed for %s without replacing canonical desired intent', async (_label, pulls, errorCode) => {
-    const p = projection({
-      desiredState: 'success',
-      observedState: 'in_progress',
-      checkRunId: '90071992547409931'
-    })
-    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url.includes('/pulls?')) {
-        return Response.json(pulls.map((pull) => associatedPull(p, pull.pullNumber, pull.headSha)))
+  ] as const)(
+    'fails closed for %s without replacing canonical desired intent',
+    async (_label, pulls, errorCode, blockedState, blockedTitle) => {
+      const p = projection({
+        desiredState: 'success',
+        observedState: 'in_progress',
+        checkRunId: '90071992547409931'
+      })
+      const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.includes('/pulls?')) {
+          return Response.json(pulls.map((pull) => associatedPull(p, pull.pullNumber, pull.headSha)))
+        }
+        return Response.json({
+          id: p.checkRunId,
+          external_id: p.externalId,
+          status: 'completed',
+          conclusion: blockedState,
+          output: { summary: JSON.parse(String(init?.body)).output.summary }
+        })
+      })
+      const { reporter, hooks } = worker(p, fetchImpl)
+
+      await reporter.tick()
+
+      const expectedSubjects =
+        errorCode === 'stale_head'
+          ? []
+          : pulls.map((pull) => ({ pullNumber: pull.pullNumber, headSha: pull.headSha, baseSha: 'b'.repeat(40) }))
+      expect(hooks.synchronizeReviewSubjects).toHaveBeenCalledWith(p.id, p.generation, expectedSubjects, errorCode)
+      const patchCall = fetchImpl.mock.calls.find(([, init]) => init?.method === 'PATCH')
+      const patchBody = JSON.parse(String(patchCall?.[1]?.body)) as {
+        conclusion: string
+        output: { title: string; summary: string }
       }
-      return Response.json({
-        id: p.checkRunId,
-        external_id: p.externalId,
-        status: 'completed',
-        conclusion: 'action_required',
-        output: { summary: JSON.parse(String(init?.body)).output.summary }
-      })
-    })
-    const { reporter, hooks } = worker(p, fetchImpl)
-
-    await reporter.tick()
-
-    const expectedSubjects =
-      errorCode === 'stale_head'
-        ? []
-        : pulls.map((pull) => ({ pullNumber: pull.pullNumber, headSha: pull.headSha, baseSha: 'b'.repeat(40) }))
-    expect(hooks.synchronizeReviewSubjects).toHaveBeenCalledWith(p.id, p.generation, expectedSubjects, errorCode)
-    const patchCall = fetchImpl.mock.calls.find(([, init]) => init?.method === 'PATCH')
-    const patchBody = JSON.parse(String(patchCall?.[1]?.body)) as {
-      conclusion: string
-      output: { title: string; summary: string }
+      expect(patchBody.conclusion).toBe(blockedState)
+      expect(patchBody.output.title).toBe(blockedTitle)
+      expect(patchBody.output.summary).toContain(`Association: ${errorCode}`)
+      expect(hooks.completeProjectionWrite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          observedState: blockedState,
+          settledErrorCode: errorCode
+        })
+      )
+      expect(p.desiredState).toBe('success')
     }
-    expect(patchBody.conclusion).toBe('action_required')
-    expect(patchBody.output.title).toBe('Pull request association needs attention')
-    expect(patchBody.output.summary).toContain(`Association: ${errorCode}`)
-    expect(hooks.completeProjectionWrite).toHaveBeenCalledWith(
-      expect.objectContaining({
-        observedState: 'action_required',
-        settledErrorCode: errorCode
-      })
-    )
-    expect(p.desiredState).toBe('success')
-  })
+  )
 
   it('falls back to the base repository open-PR list for a fork head SHA', async () => {
     const p = projection({ desiredState: 'success', observedState: 'in_progress' })
@@ -1344,7 +1355,7 @@ describe('GithubRunReporter', () => {
   it('does not re-read or rewrite a settled association block in the same generation', async () => {
     const p = projection({
       desiredState: 'success',
-      observedState: 'action_required',
+      observedState: 'neutral',
       subjectSyncGeneration: 1n,
       subjectSyncErrorCode: 'stale_head',
       lastErrorCode: 'stale_head',

--- a/packages/control-plane/src/github/run-reporter.test.ts
+++ b/packages/control-plane/src/github/run-reporter.test.ts
@@ -643,6 +643,33 @@ describe('GithubRunReporter', () => {
     )
   })
 
+  it('keeps a superseded revision non-passing under a cleanup tombstone', async () => {
+    const p = projection({ desiredState: 'failure', tombstonedAt: new Date(NOW - 1_000) })
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes('/pulls?')) return Response.json([])
+      return Response.json(
+        { id: '90071992547409931', external_id: p.externalId, status: 'completed', conclusion: 'action_required' },
+        { status: 201 }
+      )
+    })
+    const { reporter, hooks } = worker(p, fetchImpl)
+
+    await reporter.tick()
+
+    const mutation = fetchImpl.mock.calls.find(([, init]) => init?.method === 'POST')
+    const body = JSON.parse(String(mutation?.[1]?.body)) as {
+      conclusion: string
+      output: { title: string }
+    }
+    // Organization deletion settles a tombstone only on `failure` or an association
+    // `action_required`; a neutral cleanup Check would leave the barrier pending forever.
+    expect(body.conclusion).toBe('action_required')
+    expect(body.output.title).toBe('Pull request association needs attention')
+    expect(hooks.completeProjectionWrite).toHaveBeenCalledWith(
+      expect.objectContaining({ observedState: 'action_required', settledErrorCode: 'no_current_pull_request' })
+    )
+  })
+
   it('keeps snapshotted attribution as plain text after the Agent has been deleted', async () => {
     const p = projection({ desiredState: 'failure', tombstonedAt: new Date(NOW - 1_000) })
     const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {

--- a/packages/control-plane/src/github/run-reporter.ts
+++ b/packages/control-plane/src/github/run-reporter.ts
@@ -115,7 +115,16 @@ interface CheckPresentation {
   requestReviewAction?: boolean
 }
 
-const ASSOCIATION_BLOCKED_STATE: ProjectionDesiredState = 'action_required'
+/** A head GitHub no longer presents was superseded; only an unreadable association needs a human. */
+function associationBlockedState(code: SubjectAssociationErrorCode): ProjectionDesiredState {
+  return code === 'stale_head' || code === 'no_current_pull_request' ? 'neutral' : 'action_required'
+}
+
+function associationCheckTitle(code: SubjectAssociationErrorCode): string {
+  return associationBlockedState(code) === 'neutral'
+    ? 'Revision is no longer current'
+    : 'Pull request association needs attention'
+}
 
 export interface GithubRunReporterLog {
   info(obj: unknown, msg?: string): void
@@ -471,7 +480,7 @@ export class GithubRunReporter {
         : null
     if (
       settledAssociationError &&
-      projection.observedState === ASSOCIATION_BLOCKED_STATE &&
+      projection.observedState === associationBlockedState(settledAssociationError) &&
       projection.writePhase === null &&
       projection.writeMarker === null
     ) {
@@ -544,7 +553,7 @@ export class GithubRunReporter {
       if (!association.synchronized) return
       associationError = association.errorCode
       if (associationError) {
-        effectiveState = ASSOCIATION_BLOCKED_STATE
+        effectiveState = associationBlockedState(associationError)
       }
     }
 
@@ -1104,7 +1113,7 @@ function checkOutputTitle(
   associationError: SubjectAssociationErrorCode | null,
   presentation: CheckPresentation
 ): string {
-  if (associationError) return 'Pull request association needs attention'
+  if (associationError) return associationCheckTitle(associationError)
   if (state === 'skipped' && presentation.skippedLabel) return presentation.skippedLabel
   return CHECK_OUTPUT_TITLE[state]
 }

--- a/packages/control-plane/src/github/run-reporter.ts
+++ b/packages/control-plane/src/github/run-reporter.ts
@@ -55,6 +55,9 @@ const CHECK_OUTPUT_TITLE: Record<ProjectionDesiredState, string> = {
   timed_out: 'Review exceeded its time limit'
 }
 
+const REVISION_NOT_CURRENT_TITLE = 'Revision is no longer current'
+const ASSOCIATION_ATTENTION_TITLE = 'Pull request association needs attention'
+
 const TERMINAL_CHECK_STATES = new Set<string>([
   'success',
   'action_required',
@@ -115,15 +118,11 @@ interface CheckPresentation {
   requestReviewAction?: boolean
 }
 
-/** A head GitHub no longer presents was superseded; only an unreadable association needs a human. */
-function associationBlockedState(code: SubjectAssociationErrorCode): ProjectionDesiredState {
+/** A head GitHub no longer presents was superseded, not a human's problem. Cleanup is exempt:
+ *  organization deletion settles a tombstone only on a durably non-passing Check. */
+function associationBlockedState(code: SubjectAssociationErrorCode, tombstoned: boolean): ProjectionDesiredState {
+  if (tombstoned) return 'action_required'
   return code === 'stale_head' || code === 'no_current_pull_request' ? 'neutral' : 'action_required'
-}
-
-function associationCheckTitle(code: SubjectAssociationErrorCode): string {
-  return associationBlockedState(code) === 'neutral'
-    ? 'Revision is no longer current'
-    : 'Pull request association needs attention'
 }
 
 export interface GithubRunReporterLog {
@@ -480,7 +479,7 @@ export class GithubRunReporter {
         : null
     if (
       settledAssociationError &&
-      projection.observedState === associationBlockedState(settledAssociationError) &&
+      projection.observedState === associationBlockedState(settledAssociationError, projection.tombstonedAt !== null) &&
       projection.writePhase === null &&
       projection.writeMarker === null
     ) {
@@ -553,7 +552,7 @@ export class GithubRunReporter {
       if (!association.synchronized) return
       associationError = association.errorCode
       if (associationError) {
-        effectiveState = associationBlockedState(associationError)
+        effectiveState = associationBlockedState(associationError, projection.tombstonedAt !== null)
       }
     }
 
@@ -1113,7 +1112,7 @@ function checkOutputTitle(
   associationError: SubjectAssociationErrorCode | null,
   presentation: CheckPresentation
 ): string {
-  if (associationError) return associationCheckTitle(associationError)
+  if (associationError) return state === 'neutral' ? REVISION_NOT_CURRENT_TITLE : ASSOCIATION_ATTENTION_TITLE
   if (state === 'skipped' && presentation.skippedLabel) return presentation.skippedLabel
   return CHECK_OUTPUT_TITLE[state]
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6783,8 +6783,9 @@ export class Daemon {
     plan: GithubRevisionAdmissionPlan,
     incoming: QueueEntry
   ): Promise<boolean> {
-    const { terminalLosers, activeLosers, winnerLane, winnerNeedsWait, incomingWins } =
+    const { terminalLosers, activeLosers, preemptableActiveLosers, winnerLane, winnerNeedsWait, incomingWins } =
       planGithubRevisionAdmissionEffects(plan, incoming)
+    const preemptable = new Set(preemptableActiveLosers)
     this.removeQueuedGithubRevisions(terminalLosers)
     await this.settleSupersededGithubRevisions(
       terminalLosers.map((candidate) => candidate.entry),
@@ -6795,7 +6796,7 @@ export class Daemon {
       if (candidate.entry.coordinationWait) waits.push(candidate.entry.coordinationWait)
       const activeDone = this.activeDispatchDoneByKey.get(candidate.key)
       if (activeDone) waits.push(activeDone)
-      if (candidate.entry.cancelledReason) continue
+      if (candidate.entry.cancelledReason || !preemptable.has(candidate)) continue
       await this.interruptTurn(candidate.entry.agentId, candidate.key, 'superseded', undefined, {
         preserveQueued: true,
         allowSameKeyAdmissions: true,

--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -159,12 +159,15 @@ export function githubPullRequestLane(
   ])
 }
 
+/** Deliveries that establish a new head; a re-request only reopens the revision already current. */
+const GITHUB_PULL_REVISION_EVENTS = new Set(['pull_request:opened', 'pull_request:synchronize'])
+
 export function githubPullRevisionStream(
   hook: GithubCoordinatedHook | undefined,
   coords: GithubHookCoordinates
 ): string | undefined {
   const lane = githubPullRequestLane(hook, coords)
-  if (!lane || hook?.event !== 'pull_request:synchronize' || !hook.github?.headSha) return undefined
+  if (!lane || !hook || !GITHUB_PULL_REVISION_EVENTS.has(hook.event ?? '') || !hook.github?.headSha) return undefined
   return JSON.stringify(['revision', lane])
 }
 

--- a/packages/daemon/src/github/queue-admission.ts
+++ b/packages/daemon/src/github/queue-admission.ts
@@ -102,8 +102,10 @@ export function combineCoordinationWaits(
 export interface GithubRevisionAdmissionEffects {
   /** Queued or incoming losers: removed from the queue and settled outright. */
   terminalLosers: GithubQueueCandidate[]
-  /** Losers already generating: interrupted, and their completion awaited by the winner. */
+  /** Losers already generating: their completion is awaited by the winner. */
   activeLosers: GithubQueueCandidate[]
+  /** Active losers reviewing a different head: only a genuinely newer revision preempts running work. */
+  preemptableActiveLosers: GithubQueueCandidate[]
   /** Lane the winner belongs to, so its own re-admission survives the interrupt. */
   winnerLane: string | undefined
   /** The winner is not yet running, so it must absorb the losers' teardown waits. */
@@ -116,9 +118,14 @@ export function planGithubRevisionAdmissionEffects(
   plan: GithubRevisionAdmissionPlan,
   incoming: QueueEntry
 ): GithubRevisionAdmissionEffects {
+  const winnerHead = plan.winner.entry.hookContext?.github?.headSha
+  const activeLosers = plan.superseded.filter((candidate) => candidate.state === 'active')
   return {
     terminalLosers: plan.superseded.filter((candidate) => candidate.state !== 'active'),
-    activeLosers: plan.superseded.filter((candidate) => candidate.state === 'active'),
+    activeLosers,
+    preemptableActiveLosers: activeLosers.filter(
+      (candidate) => candidate.entry.hookContext?.github?.headSha !== winnerHead
+    ),
     winnerLane: githubPullRequestLane(
       plan.winner.entry.hookContext,
       githubHookCoordinates(plan.winner.entry.agentId, plan.winner.entry.msg, plan.winner.entry.integrationId)

--- a/packages/daemon/test/github-queue-admission.test.ts
+++ b/packages/daemon/test/github-queue-admission.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import type { GithubQueueCandidate } from '../src/github/hook-coords.js'
+import { planGithubRevisionAdmission, planGithubRevisionAdmissionEffects } from '../src/github/queue-admission.js'
+import type { QueueEntry } from '../src/daemon/turn-types.js'
+
+const KEY = 'acme/infra#42'
+const HEAD_A = 'a'.repeat(40)
+const HEAD_B = 'b'.repeat(40)
+
+const entry = (deliveryKey: string, event: string, headSha: string, firedAt: string): QueueEntry =>
+  ({
+    agentId: 'agent-1',
+    msg: { platform: 'github', channel: KEY },
+    hookContext: {
+      hookId: 'hook-1',
+      agentId: 'agent-1',
+      deliveryKey,
+      firedAt,
+      event,
+      github: {
+        repoId: '123',
+        repoFullName: 'acme/infra',
+        sourceInstallationId: '456',
+        subjectKind: 'pull_request',
+        pullNumber: 42,
+        headSha,
+        baseSha: '0'.repeat(40),
+        reportSha: headSha
+      }
+    }
+  }) as unknown as QueueEntry
+
+const active = (entry: QueueEntry): GithubQueueCandidate[] => [{ key: KEY, entry, state: 'active' }]
+
+describe('planGithubRevisionAdmission', () => {
+  it('preempts a running pull_request:opened review with a newer pushed revision', () => {
+    const opened = entry('opened', 'pull_request:opened', HEAD_A, '2026-08-19T01:24:44.000Z')
+    const pushed = entry('pushed', 'pull_request:synchronize', HEAD_B, '2026-08-19T01:28:20.000Z')
+
+    const plan = planGithubRevisionAdmission(KEY, pushed, active(opened))
+
+    expect(plan?.winner.entry).toBe(pushed)
+    const effects = planGithubRevisionAdmissionEffects(plan!, pushed)
+    expect(effects.incomingWins).toBe(true)
+    expect(effects.preemptableActiveLosers.map((candidate) => candidate.entry)).toEqual([opened])
+  })
+
+  it('waits out a running review of the same head instead of restarting it', () => {
+    const opened = entry('opened', 'pull_request:opened', HEAD_A, '2026-08-19T01:24:44.000Z')
+    const redelivered = entry('redelivered', 'pull_request:synchronize', HEAD_A, '2026-08-19T01:25:00.000Z')
+
+    const plan = planGithubRevisionAdmission(KEY, redelivered, active(opened))
+
+    const effects = planGithubRevisionAdmissionEffects(plan!, redelivered)
+    expect(effects.activeLosers.map((candidate) => candidate.entry)).toEqual([opened])
+    expect(effects.preemptableActiveLosers).toEqual([])
+  })
+
+  it('leaves a re-request out of latest-wins, since it opens no new revision', () => {
+    const opened = entry('opened', 'pull_request:opened', HEAD_A, '2026-08-19T01:24:44.000Z')
+    const rerequested = entry('rerequested', 'check_run:rerequested', HEAD_A, '2026-08-19T01:26:00.000Z')
+
+    expect(planGithubRevisionAdmission(KEY, rerequested, active(opened))).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

Latest-wins for PR revisions already exists — `planGithubRevisionAdmission` picks the newest relay-fired revision in a lane and interrupts the losers with `superseded`. But `githubPullRevisionStream` only produced a stream for `pull_request:synchronize`, so a review still generating for `pull_request:opened` was invisible to it and could never be a candidate.

The result, whenever a push follows shortly after a PR is opened:

- the `opened` review keeps running against a head that is no longer current (after a force-push, one that no longer exists at all);
- the new revision waits behind it in the per-PR serial gate, so its Check stays `queued` for the whole preceding turn;
- both revisions share one session, so the console shows that session busy while the new revision's Check reads `queued` — which looks like a stuck projection and is not one.

When the superseded review finally finished, its association read found no open PR at that head and the Check settled `action_required` / "Pull request association needs attention" — a red mark for work that was simply pushed past.

## Change

**daemon** — `githubPullRevisionStream` now covers the deliveries that establish a new head (`pull_request:opened`, `pull_request:synchronize`). A re-request or review-request reopens the revision already current, so it deliberately stays out of latest-wins.

Widening the set alone would let a same-head delivery interrupt an equivalent review in flight, so `planGithubRevisionAdmissionEffects` gains `preemptableActiveLosers`: an active loser is interrupted only when its head differs from the winner's. Same-head losers are still awaited, just not restarted.

**control-plane** — `stale_head` and `no_current_pull_request` now settle the Check as `neutral`, titled "Revision is no longer current". `pr_association_incomplete` and `shared_head_multiple_prs` keep `action_required`, since an unreadable or ambiguous association is the only case a maintainer can act on.

## Tests

- `packages/daemon/test/github-queue-admission.test.ts` — new: a pushed revision preempts a running `opened` review; a same-head redelivery waits it out; a re-request stays out of latest-wins. The first two fail without the daemon change.
- `packages/control-plane/src/github/run-reporter.test.ts` — the association table now asserts per-code state and title.

`pnpm --filter @agentconnect.md/daemon typecheck`, `pnpm --filter @agentconnect.md/control-plane typecheck`, the control-plane unit project, and the daemon `daemon-hook` + new admission files all pass. The daemon suite's shim/workspace and `acp-matrix` failures reproduce unchanged on `main` in this environment.