### PR TITLE
feat(daemon): secondary workspace roots and cross-repository review on the sandbox volume

### DIFF
--- a/docs/designs/multi-repository-workspaces.md
+++ b/docs/designs/multi-repository-workspaces.md
@@ -1,7 +1,7 @@
 # Multi-Repository Workspaces: Secondary Roots and Cross-Repository Review
 
-> **Status:** Implemented for self-hosted daemons (phases 1–6). Phase 7 — the
-> same roots on cluster (pod) daemons — is proposed below.
+> **Status:** Implemented, on self-hosted daemons (phases 1–6) and on cluster
+> (pod) daemons (phase 7). `gh` inside the pod remains a separate item.
 >
 > Before this design an agent's workspace was exactly one repository.
 > Additional repositories existed only as an authorization allowlist
@@ -10,8 +10,7 @@
 > consequences: a GitHub review of an authorized-but-secondary repository had no
 > trusted checkout and degraded to a "revision-only" empty directory, and an
 > ordinary session could not read the secondary repositories at all except
-> through the network. On self-hosted daemons that is no longer the case; on
-> cluster (pod) daemons it still is, which is what phase 7 addresses.
+> through the network. Neither is the case any more, on either driver.
 >
 > This design turns the allowlist into **workspace roots**: one primary root
 > (today's workspace) plus zero or more secondary roots, materialized by the
@@ -173,15 +172,16 @@ otherwise retained and reported. Re-adding the row un-retires the root in place.
 On a cluster daemon the workspace lives on the sandbox pod's volume, mounted at
 the root the pod reports (`/agent` today), and the daemon process runs on
 another machine. Every `node:fs` call in `workspace-manager.ts` therefore
-inspects the daemon's own disk, which is why the session-worktree path is
+inspected the daemon's own disk, which is why the session-worktree path was
 refused there (`refuseSessionIsolationInCluster`, a migration guard from the
-cwd-coordinates fix, not a design choice) and why phases 3–5 skip `sandboxMode`.
+cwd-coordinates fix, not a design choice) and why phases 3–5 skipped
+`sandboxMode`.
 Nothing about the pod forbids any of it: the pod's ACP runtime already takes a
 per-session `cwd`, `git worktree` is in the exec allowlist, the volume survives
 suspend/resume, and git credentials in the pod are routed by URL through the
 tunnelled helper — a secondary repository authenticates today.
 
-What is missing is one seam, the filesystem twin of `GitRunner`:
+What was missing is one seam, the filesystem twin of `GitRunner`:
 
 | Op                                                  | Used for                                                | Local         | Sandbox                                                                                                                                     |
 | --------------------------------------------------- | ------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -202,17 +202,21 @@ workspace-fs channel rather than duplicated. Containment on the sandbox side is
 the shim's fd-anchored descent, which is stronger than the daemon's lexical
 checks; the daemon keeps only path composition in the pod's coordinates
 (`<mount>/worktrees/<sid>`, `<mount>/repos/<owner>/<repo>/{checkout,worktrees/<sid>}`).
-The exec allowlist gains `symbolic-ref`, `branch`, `show-ref`, `ls-remote` and
-`show`, which the worktree and secondary-root paths already use locally.
+The exec allowlist gains `symbolic-ref`, `branch`, `show-ref` and `ls-remote`,
+which the worktree and secondary-root paths already use locally (`show` has no
+caller and stays out).
 
 With the seam in place the worktree, secondary-root, retirement and review-cwd
-code stops touching `node:fs` directly and runs unchanged on both drivers;
-`refuseSessionIsolationInCluster` and the `sandboxMode` short-circuits go away.
-Two PRs: the seam plus session worktrees on the pod (which also gives pool
-agents an exact same-repository review checkout for the first time), then
-secondary roots and cross-repository review on the pod. `gh` inside the pod
-stays a separate item: the runtime image ships no `gh` and the wrapper is a file
-on the daemon's PATH.
+code no longer touches `node:fs` directly and runs unchanged on both drivers;
+`refuseSessionIsolationInCluster` and the `sandboxMode` short-circuits are gone,
+and the hand-out and GC entry points that used to answer from a synchronous
+`existsSync` are asynchronous so the pod can answer them. Shipped as two PRs:
+the seam plus session worktrees on the pod (which also gives pool agents an
+exact same-repository review checkout for the first time), then secondary roots
+and cross-repository review on the pod. `gh` inside the pod stays a separate
+item: the runtime image ships no `gh` and the wrapper is a file on the daemon's
+PATH. So does the console's own workspace browsing, which still answers with no
+root for a secondary repository on a cluster agent.
 
 ## Open questions
 

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -184,7 +184,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
       [],
       undefined,
       undefined,
-      workspaces.additionalWorkspaceDirectories(agent, cwd)
+      await workspaces.additionalWorkspaceDirectories(agent, cwd)
     )
 
     const send = async (text: string) => {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6219,8 +6219,8 @@ export class Daemon {
       cleanupSessionWorktree: (rec) => this.cleanupSessionWorktree(rec),
       prepareAgentWorkspace: (agent, expectedWarmHost, request) =>
         this.prepareAgentWorkspace(agent, expectedWarmHost, request),
-      sessionHasReferenceDirectories: (agent, request) =>
-        this.workspaces.sessionAdditionalRoots(agent, request).length > 0,
+      sessionHasReferenceDirectories: async (agent, request) =>
+        (await this.workspaces.sessionAdditionalRoots(agent, request)).length > 0,
       warmHostFor: (agentId) => (this.readyHosts.has(agentId) ? this.hosts.get(agentId) : undefined),
       anchorTrigger: (agentId, msg, target, anchorText, label, safetyGithubLane) =>
         this.anchorTrigger(agentId, msg, target, anchorText, label, safetyGithubLane),
@@ -12479,7 +12479,7 @@ export class Daemon {
     const agent = this.agents.get(rec.agentId)
     // A scratch agent has no primary worktree but may still own one per secondary root, so the
     // gate is "any root that can hold one" rather than "the primary is a repository".
-    if (!agent || rec.workspaceIsolation === 'shared' || !this.workspaces.hasSessionWorktreeRoots(agent)) {
+    if (!agent || rec.workspaceIsolation === 'shared' || !(await this.workspaces.hasSessionWorktreeRoots(agent))) {
       return { outcome: 'not_applicable' }
     }
     return this.withWorkspaceAdmissionFence(rec.agentId, async () => {
@@ -12490,7 +12490,7 @@ export class Daemon {
       if (
         !currentAgent ||
         rec.workspaceIsolation === 'shared' ||
-        !this.workspaces.hasSessionWorktreeRoots(currentAgent)
+        !(await this.workspaces.hasSessionWorktreeRoots(currentAgent))
       ) {
         return { outcome: 'not_applicable' }
       }
@@ -12615,8 +12615,6 @@ export class Daemon {
    * awaited Git operations cannot have started against a root this pass is about to remove.
    */
   private async sweepRetiredWorkspaceRoots(): Promise<void> {
-    // Cluster daemons keep one checkout on a pod volume; there is no `repos/` subtree on this disk.
-    if (this.workspaces.sandboxMode) return
     let removed = 0
     let active = 0
     const retained: string[] = []
@@ -12624,7 +12622,16 @@ export class Daemon {
     for (const agent of [...this.agents.values()]) {
       if (this.draining) break
       if (!this.servesAgent(agent.id)) continue
-      const pending = this.workspaces.retiredSecondaryRoots(agent)
+      // On a cluster the subtrees are on the pod's volume, so an agent whose sandbox is not already
+      // bound is skipped: retiring a root is never worth waking a suspended pod, and the next pass
+      // that finds one bound sweeps it.
+      if (this.workspaces.sandboxMode && this.workspaces.sandboxMountFor(agent.id) === undefined) continue
+      const pending = await this.withAgentVolume(agent.id, () => this.workspaces.retiredSecondaryRoots(agent)).catch(
+        (err: unknown) => {
+          failures.push((err as Error).message)
+          return []
+        }
+      )
       if (pending.length === 0) continue
       if (await this.agentWorkspaceActive(agent.id)) {
         active += pending.length
@@ -12634,13 +12641,20 @@ export class Daemon {
         if (await this.agentWorkspaceActive(agent.id)) return undefined
         const current = this.agents.get(agent.id)
         if (!current) return undefined
-        // Re-listed inside the fence: the spec may have re-authorized a repository while this pass
-        // waited for the queue, which un-retires its root in place.
-        const results: RetiredRootRemoval[] = []
-        for (const root of this.workspaces.retiredSecondaryRoots(current)) {
-          results.push(await this.workspaces.removeRetiredSecondaryRoot(current, root))
-        }
-        return results
+        // The volume has to be up and bound for the removal, as it was for the preparation.
+        return await this.withAgentVolume(agent.id, async () => {
+          // Re-listed inside the fence: the spec may have re-authorized a repository while this pass
+          // waited for the queue, which un-retires its root in place.
+          const results: RetiredRootRemoval[] = []
+          for (const root of await this.workspaces.retiredSecondaryRoots(current)) {
+            results.push(await this.workspaces.removeRetiredSecondaryRoot(current, root))
+          }
+          return results
+        })
+      }).catch((err: unknown): RetiredRootRemoval[] => {
+        // A pod that will not come up is THIS agent's failure, never the whole sweep's.
+        failures.push((err as Error).message)
+        return []
       })
       if (outcomes === undefined) {
         active += pending.length

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12478,8 +12478,9 @@ export class Daemon {
     if (await this.sessionRetentionActive(rec)) return { outcome: 'active' }
     const agent = this.agents.get(rec.agentId)
     // A scratch agent has no primary worktree but may still own one per secondary root, so the
-    // gate is "any root that can hold one" rather than "the primary is a repository".
-    if (!agent || rec.workspaceIsolation === 'shared' || !(await this.workspaces.hasSessionWorktreeRoots(agent))) {
+    // prefilter is "could this agent own one at all" rather than "the primary is a repository" —
+    // and it is answered from the spec, because the disk that holds the roots is not bound yet.
+    if (!agent || rec.workspaceIsolation === 'shared' || !this.workspaces.mayOwnSessionWorktrees(agent)) {
       return { outcome: 'not_applicable' }
     }
     return this.withWorkspaceAdmissionFence(rec.agentId, async () => {
@@ -12490,15 +12491,22 @@ export class Daemon {
       if (
         !currentAgent ||
         rec.workspaceIsolation === 'shared' ||
-        !(await this.workspaces.hasSessionWorktreeRoots(currentAgent))
+        !this.workspaces.mayOwnSessionWorktrees(currentAgent)
       ) {
         return { outcome: 'not_applicable' }
       }
-      // The volume has to be up and bound for the removal, as it was for the preparation. A pod that
-      // will not come up is THIS session's failure, never the whole sweep's — it retries next pass.
-      const result = await this.withAgentVolume(rec.agentId, () =>
-        this.workspaces.removeSessionWorktree(currentAgent, rec.key)
+      // The volume has to be up and bound for the removal, as it was for the preparation — and for
+      // the question of WHICH roots exist, which is asked of the filesystem that holds them: on a
+      // suspended sandbox this daemon's own disk would answer "none" for a scratch agent whose pod
+      // volume carries secondary worktrees, and the session row would be deleted without them ever
+      // being judged. A pod that will not come up is THIS session's failure, never the whole
+      // sweep's — it retries next pass.
+      const result = await this.withAgentVolume(rec.agentId, async () =>
+        (await this.workspaces.hasSessionWorktreeRoots(currentAgent))
+          ? await this.workspaces.removeSessionWorktree(currentAgent, rec.key)
+          : undefined
       ).catch((err: unknown): SessionWorktreeRemoval => ({ outcome: 'failed', error: (err as Error).message }))
+      if (result === undefined) return { outcome: 'not_applicable' }
       // `partial` too: a kept aggregate can still have removed another root's worktree, and a warm
       // attachment naming a directory that is gone would skip preparation on its next turn.
       const changed = result.outcome === 'removed' || result.outcome === 'absent' || result.partial === true

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -106,7 +106,7 @@ export interface GithubReviewHost {
     request?: PrepareSessionWorkspaceRequest
   ): Promise<string>
   /** Whether a prepared session was handed reference directories beside its working directory. */
-  sessionHasReferenceDirectories(agent: Agent, request: PrepareSessionWorkspaceRequest): boolean
+  sessionHasReferenceDirectories(agent: Agent, request: PrepareSessionWorkspaceRequest): Promise<boolean>
   /** The agent's warm ACP host, only once it is ready. */
   warmHostFor(agentId: string): AcpHost | undefined
   anchorTrigger(
@@ -555,7 +555,7 @@ export class GithubReviewOrchestrator {
         `\n\nTrusted review workspace:\n${revisionLine}\n` +
         'The daemon fetched and verified this isolated checkout at the exact head or a merge whose parents are exactly the base and head above. Before trusting local traces, verify `git rev-parse HEAD`; do not switch to or inspect another checkout.' +
         // Decision 10: the other roots stand at their default branches, so only the cwd is the revision.
-        (this.host.sessionHasReferenceDirectories(agent, request)
+        ((await this.host.sessionHasReferenceDirectories(agent, request))
           ? ' Additional repositories are available as separate directories at their default branches for reference only; the reviewed revision is the working directory.'
           : '')
       return { workspaceIsolation: 'session', forceWorkspaceIsolation: true, preparedWorkspaceCwd }

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -535,30 +535,31 @@ export class SessionManager {
     // Composed lazily and memoized, because the workspace roots it names must be sampled where the
     // additional directories are: on a warm host `openRuntimeSession` performs the preparation
     // itself, so a context built before that could name a root the runtime never received.
-    let standing: StandingContext | undefined
-    const standingContext = (): StandingContext =>
-      (standing ??= buildStandingContext({
-        agentName: agent.name,
-        agentId: agent.id,
-        agentDescription: agent.description,
-        platform: msg.platform,
-        channel: msg.channel,
-        channelName,
-        slackSelfId:
-          msg.platform === 'slack' && integrationId ? this.deps.slackBotUserIdFor?.(integrationId) : undefined,
-        thread,
-        acpSessionId: rec?.acpSessionId,
-        parentSessionId: effectiveOriginSessionId,
-        envSecretNames: secretNames.filter((n) => !fileSecretNames.has(n)),
-        fileSecrets: fileSecrets.map((m) => ({ sourceVar: m.sourceVar, pointerVar: m.convention.pointerVar })),
-        // The same list `additionalWorkspaceDirectories` hands the runtime, read from the same
-        // accessor, so the prompt names exactly the directories the session got.
-        workspaceRoots: this.workspaces.sessionAdditionalRoots(agent, workspaceRequest),
-        usesSessionTitleTool,
-        needsReplyToParent,
-        memoryIndex,
-        usesMeta
-      }))
+    let standing: Promise<StandingContext> | undefined
+    const standingContext = (): Promise<StandingContext> =>
+      (standing ??= (async () =>
+        buildStandingContext({
+          agentName: agent.name,
+          agentId: agent.id,
+          agentDescription: agent.description,
+          platform: msg.platform,
+          channel: msg.channel,
+          channelName,
+          slackSelfId:
+            msg.platform === 'slack' && integrationId ? this.deps.slackBotUserIdFor?.(integrationId) : undefined,
+          thread,
+          acpSessionId: rec?.acpSessionId,
+          parentSessionId: effectiveOriginSessionId,
+          envSecretNames: secretNames.filter((n) => !fileSecretNames.has(n)),
+          fileSecrets: fileSecrets.map((m) => ({ sourceVar: m.sourceVar, pointerVar: m.convention.pointerVar })),
+          // The same list `additionalWorkspaceDirectories` hands the runtime, read from the same
+          // accessor, so the prompt names exactly the directories the session got.
+          workspaceRoots: await this.workspaces.sessionAdditionalRoots(agent, workspaceRequest),
+          usesSessionTitleTool,
+          needsReplyToParent,
+          memoryIndex,
+          usesMeta
+        }))())
 
     // Create or re-attach the runtime session (turn/runtime-session.ts). `created` drives the
     // daemon's one-shot `event/session` start emit; the additional-MCP outcome is reported back
@@ -614,8 +615,8 @@ export class SessionManager {
       // metadata-only settings cannot be reversed by a later live selector.
       chatRuntimeChangesAllowed: () => this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true,
       effortOverride: async () => initialEffort ?? (await this.deps.store.getEffortOverride(key)),
-      metaContext: () => standingContext().metaContext,
-      resumeSystemContext: () => standingContext().resumeSystemContext,
+      metaContext: async () => (await standingContext()).metaContext,
+      resumeSystemContext: async () => (await standingContext()).resumeSystemContext,
       usesMeta,
       ...(signal ? { signal } : {}),
       abortable,
@@ -626,7 +627,7 @@ export class SessionManager {
     const additionalMcpServersAttached = opened.additionalMcpAttached
     // Resolves the memoized snapshot the runtime session already consumed, or composes it now for a
     // session that was live and needed no preparation.
-    const { sessionContext, parentReplyAppend } = standingContext()
+    const { sessionContext, parentReplyAppend } = await standingContext()
 
     // A channel-root message posted by this same agent creates the thread's session cursor
     // without running the model. Keep lastDeliveredTs at null: the first real reply must replay

--- a/packages/daemon/src/session/turn/runtime-session.ts
+++ b/packages/daemon/src/session/turn/runtime-session.ts
@@ -41,7 +41,7 @@ export interface OpenRuntimeSessionInput {
   expectedWarmHost?: AcpHost
   prepareWorkspace: (agent: Agent, expectedWarmHost?: AcpHost) => Promise<string>
   /** Extra roots the runtime may read beyond cwd, per workspace isolation. */
-  workspaceDirectories: (cwd: string) => string[]
+  workspaceDirectories: (cwd: string) => Promise<string[]>
   /** The default MCP servers for this turn's platform binding, resolved once. */
   mcpServersFor: () => McpServer[]
   /** Trusted descriptors bound to an overridden host; dropped if the runtime rejects them. */
@@ -53,8 +53,8 @@ export interface OpenRuntimeSessionInput {
   /** Standing context for a fresh session; `resumeSystemContext` for a native resume. Both are
    *  resolved HERE, after workspace preparation, so what the prompt names and what
    *  `workspaceDirectories` hands the runtime come from one snapshot. */
-  metaContext?: () => string | undefined
-  resumeSystemContext?: () => string | undefined
+  metaContext?: () => Promise<string | undefined>
+  resumeSystemContext?: () => Promise<string | undefined>
   usesMeta: boolean
   signal?: AbortSignal
   abortable: <T>(start: () => PromiseLike<T> | T, signal?: AbortSignal) => Promise<T>
@@ -108,7 +108,7 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
     systemAppend?: string,
     fallbackMcpServers?: McpServer[]
   ): Promise<string> => {
-    const additionalDirectories = input.workspaceDirectories(cwd)
+    const additionalDirectories = await input.workspaceDirectories(cwd)
     while (true) {
       const selected = await sessionStartEffort()
       const create = (servers: McpServer[]) =>
@@ -129,7 +129,7 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
     fallbackMcpServers?: McpServer[]
   ): Promise<boolean> => {
     const selected = await sessionStartEffort()
-    const additionalDirectories = input.workspaceDirectories(cwd)
+    const additionalDirectories = await input.workspaceDirectories(cwd)
     const load = (servers: McpServer[]) =>
       abortable(
         () => host.loadSession(sessionId, cwd, servers, selected.value, systemAppend, additionalDirectories),
@@ -160,7 +160,7 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
     const acpSessionId = await newRuntimeSession(
       cwd,
       mcpServers,
-      input.metaContext?.(),
+      await input.metaContext?.(),
       input.additionalMcpServers?.length ? ordinaryMcpServers : undefined
     )
     created = true
@@ -211,7 +211,7 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
           persistedSessionId,
           cwd,
           mcpServers,
-          input.usesMeta ? input.resumeSystemContext?.() : undefined,
+          input.usesMeta ? await input.resumeSystemContext?.() : undefined,
           fallbackMcpServers
         )
       } catch {
@@ -220,7 +220,7 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
       }
     }
     if (!resumed) {
-      const acpSessionId = await newRuntimeSession(cwd, mcpServers, input.metaContext?.(), fallbackMcpServers)
+      const acpSessionId = await newRuntimeSession(cwd, mcpServers, await input.metaContext?.(), fallbackMcpServers)
       // A fresh ACP id the CP has never seen (the persisted one couldn't be resumed),
       // so this counts as a create for `event/session`. A resumed session (loadSession
       // above) keeps its id — the CP already knows it — so `created` stays false there.

--- a/packages/daemon/src/workspace/secondary-layout.ts
+++ b/packages/daemon/src/workspace/secondary-layout.ts
@@ -69,8 +69,10 @@ export function secondarySubtreesIn(agentRoot: string): SecondarySubtree[] {
  *
  * `parent` is already in that filesystem's coordinates — `<agentRoot>/repos` on this disk,
  * `<mount>/repos` on a sandbox volume — and `stat` never follows a symlink, so an entry that is not
- * a real directory is skipped exactly as the synchronous twin above skips it. That twin stays for
- * the launch path, which computes a sandbox boundary before any agent seam exists.
+ * a real directory is skipped exactly as the synchronous twin above skips it. Unlike that twin it
+ * RAISES when the filesystem cannot answer (see {@link realDirEntriesUnder}). The twin stays for the
+ * launch path, which computes a sandbox boundary before any agent seam exists, and where an
+ * unreadable directory means one less carve-back rather than one less safety check.
  */
 export async function secondarySubtreesUnder(fs: WorkspaceFs, parent: string): Promise<SecondarySubtree[]> {
   const out: SecondarySubtree[] = []
@@ -88,20 +90,23 @@ export async function secondarySubtreesUnder(fs: WorkspaceFs, parent: string): P
   return out
 }
 
-/** {@link realDirEntries} over a workspace filesystem; an unreadable parent reports no entries. */
+/**
+ * {@link realDirEntries} over a workspace filesystem.
+ *
+ * Absence is data and raises nothing; a filesystem that could not ANSWER is not, and must not read
+ * as an empty tree. An empty answer here licenses resuming a cross-repository session in the primary
+ * checkout and licenses judging only the primary worktree, so a dropped shim channel — or a
+ * directory this process cannot list — has to abort the operation instead.
+ */
 async function realDirEntriesUnder(fs: WorkspaceFs, dir: string): Promise<string[]> {
-  try {
-    if ((await fs.stat(dir)) !== 'dir') return []
-    const names: string[] = []
-    for (const name of await fs.readdir(dir)) {
-      if (!isRepoSegment(name)) continue
-      if ((await fs.stat(join(dir, name))) !== 'dir') continue
-      names.push(name)
-    }
-    return names.sort()
-  } catch {
-    return []
+  if ((await fs.stat(dir)) !== 'dir') return []
+  const names: string[] = []
+  for (const name of await fs.readdir(dir)) {
+    if (!isRepoSegment(name)) continue
+    if ((await fs.stat(join(dir, name))) !== 'dir') continue
+    names.push(name)
   }
+  return names.sort()
 }
 
 /** The materialized secondary checkouts under `<agentRoot>/repos`, for callers that only need those. */

--- a/packages/daemon/src/workspace/secondary-layout.ts
+++ b/packages/daemon/src/workspace/secondary-layout.ts
@@ -1,5 +1,6 @@
 import { lstatSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
+import type { WorkspaceFs } from './workspace-fs.js'
 
 // The on-disk shape of an agent's secondary roots (multi-repository-workspaces.md §"Directory
 // layout"), separate from the manager so the launch path can read it without the whole workspace
@@ -61,6 +62,46 @@ export function secondarySubtreesIn(agentRoot: string): SecondarySubtree[] {
     }
   }
   return out
+}
+
+/**
+ * The same subtrees under one parent, read through a workspace filesystem rather than `node:fs`.
+ *
+ * `parent` is already in that filesystem's coordinates — `<agentRoot>/repos` on this disk,
+ * `<mount>/repos` on a sandbox volume — and `stat` never follows a symlink, so an entry that is not
+ * a real directory is skipped exactly as the synchronous twin above skips it. That twin stays for
+ * the launch path, which computes a sandbox boundary before any agent seam exists.
+ */
+export async function secondarySubtreesUnder(fs: WorkspaceFs, parent: string): Promise<SecondarySubtree[]> {
+  const out: SecondarySubtree[] = []
+  for (const owner of await realDirEntriesUnder(fs, parent)) {
+    for (const repo of await realDirEntriesUnder(fs, join(parent, owner))) {
+      const subtree = join(parent, owner, repo)
+      out.push({
+        repoFullName: `${owner}/${repo}`,
+        subtree,
+        path: join(subtree, 'checkout'),
+        worktreesPath: join(subtree, 'worktrees')
+      })
+    }
+  }
+  return out
+}
+
+/** {@link realDirEntries} over a workspace filesystem; an unreadable parent reports no entries. */
+async function realDirEntriesUnder(fs: WorkspaceFs, dir: string): Promise<string[]> {
+  try {
+    if ((await fs.stat(dir)) !== 'dir') return []
+    const names: string[] = []
+    for (const name of await fs.readdir(dir)) {
+      if (!isRepoSegment(name)) continue
+      if ((await fs.stat(join(dir, name))) !== 'dir') continue
+      names.push(name)
+    }
+    return names.sort()
+  } catch {
+    return []
+  }
 }
 
 /** The materialized secondary checkouts under `<agentRoot>/repos`, for callers that only need those. */

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -42,6 +42,7 @@ import { gitmoduleRepos } from './gitmodules.js'
 import {
   isRepoSegment,
   secondaryRootsDirIn,
+  secondarySubtreesIn,
   secondarySubtreesUnder,
   sessionCwdMarkerIn,
   SECONDARY_MATERIALIZATION_FILE,
@@ -1113,16 +1114,23 @@ export class WorkspaceManager {
   }
 
   /**
-   * Whether the agent could own a per-session worktree AT ALL, from its spec rather than from a
-   * disk — the prefilter for a caller that has not bound the agent's volume yet.
+   * Whether the agent could own a per-session worktree AT ALL — the prefilter for a caller that has
+   * not bound the agent's volume yet, and which may only ever err towards `true`.
    *
    * Deliberately not {@link hasSessionWorktreeRoots}: that one reads the filesystem holding the
    * roots, which for a suspended sandbox is this daemon's own, where a scratch agent's pod-side
    * secondary worktrees are invisible. Answering "no" there is what would let the retention GC
    * delete a session row without ever applying the dirty/unique-commit rules to those worktrees.
+   *
+   * The rows are not the whole answer either: a retired root keeps its worktrees after its row
+   * disappears (decision 12), so a scratch agent whose last authorization was removed may still own
+   * one. Locally that is a cheap listing of `repos`; on a pod only the volume can say, so the answer
+   * is "maybe" and the bound predicate inside the fence decides.
    */
   mayOwnSessionWorktrees(agent: Agent): boolean {
-    return agent.workspace.mode === 'git-repo' || (agent.workspace.additionalRepos ?? []).length > 0
+    if (agent.workspace.mode === 'git-repo') return true
+    if ((agent.workspace.additionalRepos ?? []).length > 0) return true
+    return this.sandboxMode || secondarySubtreesIn(this.agentRootFor(agent)).length > 0
   }
 
   /**

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -1106,9 +1106,23 @@ export class WorkspaceManager {
   }
 
   /** Whether the agent has any root a session worktree could live under — a scratch workspace with
-   *  secondary roots does, which is what makes it a candidate for the retention GC. */
+   *  secondary roots does, which is what makes it a candidate for the retention GC. Reads the
+   *  filesystem that holds the roots, so its caller must already hold that agent's volume. */
   async hasSessionWorktreeRoots(agent: Agent): Promise<boolean> {
     return (await this.sessionWorktreeRoots(agent)).length > 0
+  }
+
+  /**
+   * Whether the agent could own a per-session worktree AT ALL, from its spec rather than from a
+   * disk — the prefilter for a caller that has not bound the agent's volume yet.
+   *
+   * Deliberately not {@link hasSessionWorktreeRoots}: that one reads the filesystem holding the
+   * roots, which for a suspended sandbox is this daemon's own, where a scratch agent's pod-side
+   * secondary worktrees are invisible. Answering "no" there is what would let the retention GC
+   * delete a session row without ever applying the dirty/unique-commit rules to those worktrees.
+   */
+  mayOwnSessionWorktrees(agent: Agent): boolean {
+    return agent.workspace.mode === 'git-repo' || (agent.workspace.additionalRepos ?? []).length > 0
   }
 
   /**

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -1,7 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto'
 import {
   existsSync,
-  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -43,7 +42,7 @@ import { gitmoduleRepos } from './gitmodules.js'
 import {
   isRepoSegment,
   secondaryRootsDirIn,
-  secondarySubtreesIn,
+  secondarySubtreesUnder,
   sessionCwdMarkerIn,
   SECONDARY_MATERIALIZATION_FILE,
   type SecondarySubtree
@@ -297,18 +296,40 @@ export class WorkspaceManager {
     }
   }
 
+  /** The primary checkout in one mount's coordinates — total, unlike {@link primaryRootAt}, so the
+   *  callers that only need the directory do not have to be about a repository. */
+  private primaryCheckoutAt(agent: Agent, mount: string | undefined): string {
+    return mount === undefined ? agent.workspace.path : this.clusterWorkspaceCheckout(agent, mount)
+  }
+
   /** The agent's own directory — the parent every daemon-owned subtree hangs off. */
   agentRootFor(agent: Agent): string {
     return (agent as { dir?: string }).dir ?? dirname(agent.workspace.path)
   }
 
-  /** `<agentRoot>/repos` — the parent every secondary root's subtree hangs off. */
+  /** `<agentRoot>/repos` — the parent every secondary root's subtree hangs off on THIS disk. */
   secondaryRootsDir(agent: Agent): string {
     return secondaryRootsDirIn(this.agentRootFor(agent))
   }
 
+  /** The same parent in one mount's coordinates: `<mount>/repos` on a pod volume, else this disk. */
+  private secondaryRootsDirAt(agent: Agent, mount: string | undefined): string {
+    return mount === undefined ? this.secondaryRootsDir(agent) : secondaryRootsDirIn(mount)
+  }
+
+  /** The agent's authorized additional repositories as roots, in the coordinates that hold them. */
+  private secondaryRootsFor(agent: Agent): SecondaryWorkspaceRoot[] {
+    return this.secondaryRootsAt(agent, this.sandboxMountFor(agent.id))
+  }
+
   /** The agent's authorized additional repositories as roots, sorted by name (design decision 1/8). */
   secondaryRoots(agent: Agent): SecondaryWorkspaceRoot[] {
+    return this.secondaryRootsAt(agent, undefined)
+  }
+
+  /** The same roots addressed in one sandbox mount's coordinates, mirroring {@link primaryRootAt}. */
+  secondaryRootsAt(agent: Agent, mount: string | undefined): SecondaryWorkspaceRoot[] {
+    const parent = this.secondaryRootsDirAt(agent, mount)
     const roots: SecondaryWorkspaceRoot[] = []
     for (const row of agent.workspace.additionalRepos ?? []) {
       const [owner, repo, ...rest] = row.repoFullName.split('/')
@@ -320,7 +341,7 @@ export class WorkspaceManager {
         continue
       }
       const repoFullName = `${owner}/${repo}`
-      const base = join(this.secondaryRootsDir(agent), owner, repo)
+      const base = join(parent, owner, repo)
       try {
         roots.push({
           repoFullName,
@@ -381,15 +402,8 @@ export class WorkspaceManager {
     const name = scope.reviewRepoFullName
     if (name === undefined) return undefined
     const wanted = repoKey(name)
-    const root = this.secondaryRoots(agent).find((entry) => repoKey(entry.repoFullName) === wanted)
-    if (root) {
-      // A sandboxed workspace materializes one checkout through the shim tunnel, so a secondary root
-      // has nowhere to live there — the review keeps the revision-only fallback, as it does today.
-      if (this.sandboxMode) {
-        throw new Error(`github review of ${root.repoFullName} needs a local workspace root (agent "${agent.id}")`)
-      }
-      return root
-    }
+    const root = this.secondaryRootsFor(agent).find((entry) => repoKey(entry.repoFullName) === wanted)
+    if (root) return root
     const primary = this.primaryRepoFullName(agent)
     if (primary !== undefined && repoKey(primary) === wanted) return undefined
     throw new Error(`github review repository "${name}" is not a workspace root of agent "${agent.id}"`)
@@ -405,11 +419,11 @@ export class WorkspaceManager {
    * out the checkout, `session` the worktree keyed by that session. A root whose worktree could not
    * be created contributes nothing to that session and is simply absent here.
    */
-  readySecondaryRoots(agent: Agent, request?: SessionRootScope): readonly ReadyWorkspaceRoot[] {
-    if (this.sandboxMode) return []
+  async readySecondaryRoots(agent: Agent, request?: SessionRootScope): Promise<readonly ReadyWorkspaceRoot[]> {
+    const fs = this.fsFor(agent.id)
     // The root a review made the cwd is not an additional directory of its own session.
-    const ready = this.sessionSecondaryRoots(agent, this.sessionCwdRepoFullName(agent, request))
-    const id = this.sessionWorktreeIdFor(agent, request)
+    const ready = this.sessionSecondaryRoots(agent, await this.sessionCwdRepoFullName(agent, request))
+    const id = await this.sessionWorktreeIdFor(agent, request)
     const roots: ReadyWorkspaceRoot[] = []
     for (const root of ready) {
       if (id === undefined) {
@@ -419,8 +433,12 @@ export class WorkspaceManager {
       const cwd = join(root.worktreesPath, id)
       // The `.git` marker is what `worktree add` writes, so its presence is the proof that this
       // root's per-session checkout exists rather than a directory a failed attempt left behind.
-      if (!existsSync(join(cwd, '.git'))) continue
-      roots.push({ path: realpathSync(cwd), repoFullName: root.repoFullName, branch: root.branch })
+      if ((await fs.stat(join(cwd, '.git'))) === 'missing') continue
+      roots.push({
+        path: this.canonicalWorkspacePath(agent.id, cwd),
+        repoFullName: root.repoFullName,
+        branch: root.branch
+      })
     }
     return roots
   }
@@ -433,21 +451,30 @@ export class WorkspaceManager {
    * session stands in the primary itself, where {@link additionalWorkspaceDirectories} widens an
    * `agentDir` cwd back to it instead.
    */
-  sessionAdditionalRoots(agent: Agent, request?: SessionRootScope): readonly ReadyWorkspaceRoot[] {
-    const primary = this.primaryReferenceRoot(agent, request)
-    const secondaries = this.readySecondaryRoots(agent, request)
+  async sessionAdditionalRoots(agent: Agent, request?: SessionRootScope): Promise<readonly ReadyWorkspaceRoot[]> {
+    const primary = await this.primaryReferenceRoot(agent, request)
+    const secondaries = await this.readySecondaryRoots(agent, request)
     return primary ? [primary, ...secondaries] : secondaries
   }
 
   /** The primary's own session directory, as a reference root beside a reviewed secondary's cwd. */
-  private primaryReferenceRoot(agent: Agent, request?: SessionRootScope): ReadyWorkspaceRoot | undefined {
-    if (this.sandboxMode || agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) return undefined
-    if (this.sessionCwdRepoFullName(agent, request) === undefined) return undefined
-    const path = this.sessionRootPath(agent, agent.workspace.path, this.worktreesPathFor(agent), request)
+  private async primaryReferenceRoot(
+    agent: Agent,
+    request?: SessionRootScope
+  ): Promise<ReadyWorkspaceRoot | undefined> {
+    if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) return undefined
+    if ((await this.sessionCwdRepoFullName(agent, request)) === undefined) return undefined
+    const mount = this.sandboxMountFor(agent.id)
+    const path = await this.sessionRootPath(
+      agent,
+      this.primaryCheckoutAt(agent, mount),
+      this.worktreesPathAt(agent, mount),
+      request
+    )
     // Same proof the secondaries answer to: a checkout the session did not get is not named here.
-    if (!existsSync(join(path, '.git'))) return undefined
+    if ((await this.fsFor(agent.id).stat(join(path, '.git'))) === 'missing') return undefined
     return {
-      path: realpathSync(path),
+      path: this.canonicalWorkspacePath(agent.id, path),
       repoFullName: gitRepoLabel(agent.workspace.gitRepo),
       branch: agent.workspace.gitBranch
     }
@@ -455,16 +482,23 @@ export class WorkspaceManager {
 
   /** One root's directory for a session: its per-session worktree, or the checkout itself when the
    *  session shares every root (decision 4). */
-  private sessionRootPath(agent: Agent, checkout: string, worktreesPath: string, request?: SessionRootScope): string {
-    const id = this.sessionWorktreeIdFor(agent, request)
+  private async sessionRootPath(
+    agent: Agent,
+    checkout: string,
+    worktreesPath: string,
+    request?: SessionRootScope
+  ): Promise<string> {
+    const id = await this.sessionWorktreeIdFor(agent, request)
     return id === undefined ? checkout : join(worktreesPath, id)
   }
 
   /** The id naming this session's worktrees, or undefined when it shares the roots' checkouts. A
    *  session whose cwd is a reviewed root is per-session by construction, whatever the caller says. */
-  private sessionWorktreeIdFor(agent: Agent, request?: SessionRootScope): string | undefined {
+  private async sessionWorktreeIdFor(agent: Agent, request?: SessionRootScope): Promise<string | undefined> {
     if (request?.sessionKey === undefined) return undefined
-    if (request.isolation !== 'session' && this.sessionCwdRepoFullName(agent, request) === undefined) return undefined
+    if (request.isolation !== 'session' && (await this.sessionCwdRepoFullName(agent, request)) === undefined) {
+      return undefined
+    }
     return this.sessionWorktreeId(request.sessionKey)
   }
 
@@ -475,10 +509,16 @@ export class WorkspaceManager {
   }
 
   /** The secondary root holding this session's cwd: named by the request, else attested on disk. */
-  private sessionCwdRepoFullName(agent: Agent, request?: SessionRootScope): string | undefined {
+  private async sessionCwdRepoFullName(agent: Agent, request?: SessionRootScope): Promise<string | undefined> {
     if (request?.reviewRepoFullName !== undefined) return request.reviewRepoFullName
     if (request?.sessionKey === undefined) return undefined
-    return this.sessionCwdSubtree(agent, request.sessionKey)?.repoFullName
+    return (await this.sessionCwdSubtree(agent, request.sessionKey))?.repoFullName
+  }
+
+  /** Every `repos/<owner>/<repo>` subtree the agent's own filesystem holds, in ITS coordinates. */
+  private async secondarySubtreesFor(agent: Agent): Promise<SecondarySubtree[]> {
+    const mount = this.sandboxMountFor(agent.id)
+    return await secondarySubtreesUnder(this.fsFor(agent.id), this.secondaryRootsDirAt(agent, mount))
   }
 
   /**
@@ -490,11 +530,15 @@ export class WorkspaceManager {
    * marker and that worktree must be present — a marker whose worktree the GC already took names
    * nothing, so a leftover cannot capture a later session that hashes to the same id.
    */
-  private sessionCwdSubtree(agent: Agent, sessionKey: string): SecondarySubtree | undefined {
+  private async sessionCwdSubtree(agent: Agent, sessionKey: string): Promise<SecondarySubtree | undefined> {
+    const fs = this.fsFor(agent.id)
     const id = this.sessionWorktreeId(sessionKey)
-    return secondarySubtreesIn(this.agentRootFor(agent)).find(
-      (entry) => existsSync(sessionCwdMarkerIn(entry.subtree, id)) && existsSync(join(entry.worktreesPath, id, '.git'))
-    )
+    for (const entry of await this.secondarySubtreesFor(agent)) {
+      if ((await fs.stat(sessionCwdMarkerIn(entry.subtree, id))) === 'missing') continue
+      if ((await fs.stat(join(entry.worktreesPath, id, '.git'))) === 'missing') continue
+      return entry
+    }
+    return undefined
   }
 
   /** Attest that this session's working directory is one root's worktree, or drop that attestation. */
@@ -522,16 +566,15 @@ export class WorkspaceManager {
    * the same repository twice at two different revisions.
    */
   async prepareSecondaryRoots(agent: Agent): Promise<SecondaryWorkspaceRoot[]> {
-    // Cluster daemons materialize one checkout through the shim tunnel; secondary roots there are a
-    // non-goal of this phase, and every path below would clone onto the DAEMON's disk instead.
-    if (this.sandboxMode) return []
-    const roots = this.secondaryRoots(agent)
+    const roots = this.secondaryRootsFor(agent)
     if (roots.length === 0) {
       this.readyRoots.delete(agent.id)
       return []
     }
     const submodules =
-      agent.workspace.mode === 'git-repo' ? this.submoduleReposOf(agent.workspace.path) : new Set<string>()
+      agent.workspace.mode === 'git-repo'
+        ? await this.submoduleReposOf(agent.id, this.primaryCheckoutAt(agent, this.sandboxMountFor(agent.id)))
+        : new Set<string>()
     const ready: SecondaryWorkspaceRoot[] = []
     for (const root of roots) {
       if (submodules.has(root.repoFullName.toLowerCase())) {
@@ -543,7 +586,7 @@ export class WorkspaceManager {
       }
       const prepared = await this.prepareSecondaryRoot(agent, root)
       if (!prepared) continue
-      for (const repo of this.submoduleReposOf(root.path)) submodules.add(repo)
+      for (const repo of await this.submoduleReposOf(agent.id, root.path)) submodules.add(repo)
       ready.push(prepared)
     }
     this.readyRoots.set(agent.id, ready)
@@ -551,15 +594,12 @@ export class WorkspaceManager {
   }
 
   /** The github.com repositories a root carries as submodules; empty when it declares none. */
-  submoduleReposOf(rootPath: string): Set<string> {
-    const file = join(rootPath, '.gitmodules')
-    try {
-      if (statSync(file).size > MAX_GITMODULES_BYTES) return new Set()
-      return gitmoduleRepos(readFileSync(file, 'utf8'))
-    } catch {
-      // No `.gitmodules`, or one this process cannot read: the root simply declares no submodules.
-      return new Set()
-    }
+  async submoduleReposOf(agentId: string, rootPath: string): Promise<Set<string>> {
+    // The seam answers what a path IS, not how big it is, so the bound is applied to the text it
+    // returned — a `.gitmodules` past it is not a declaration anyone wrote, whichever disk holds it.
+    const text = await this.fsFor(agentId).readFile(join(rootPath, '.gitmodules'))
+    if (text === undefined || text.length > MAX_GITMODULES_BYTES) return new Set()
+    return gitmoduleRepos(text)
   }
 
   /** One secondary root's clone-or-converge, single-flighted per root like the primary's clone. */
@@ -578,11 +618,12 @@ export class WorkspaceManager {
     agent: Agent,
     root: SecondaryWorkspaceRoot
   ): Promise<SecondaryWorkspaceRoot | undefined> {
+    const fs = this.fsFor(agent.id)
     const subtree = dirname(root.path)
     const marker = join(subtree, SECONDARY_MATERIALIZATION_FILE)
     try {
-      mkdirSync(subtree, { recursive: true, mode: 0o700 })
-      if (!existsSync(join(root.path, '.git'))) {
+      await fs.mkdir(subtree, 0o700)
+      if ((await fs.stat(join(root.path, '.git'))) === 'missing') {
         // The branch is not projected by the CP, so the remote's own HEAD decides it — resolved
         // BEFORE the clone, because `--branch` is how the clone records it.
         const branch = await this.resolveRemoteDefaultBranch(agent.id, root)
@@ -592,19 +633,23 @@ export class WorkspaceManager {
           // Attest first, publish last. A crash in between leaves a marker with no checkout, which
           // the next session simply re-clones; the other order is what strands a checkout that no
           // later session can attribute, and this code never deletes one to recover.
-          writeSecondaryMaterialization(marker, { repoId: root.repoId, repoFullName: root.repoFullName, branch })
-          this.publishSecondaryCheckout(staged, root.path)
+          await fs.writeFile(
+            marker,
+            JSON.stringify({ repoId: root.repoId, repoFullName: root.repoFullName, branch }, null, 2) + '\n',
+            { mode: 0o600 }
+          )
+          await this.publishSecondaryCheckout(agent.id, staged, root.path)
         } catch (err) {
-          rmSync(staged, { recursive: true, force: true })
+          await fs.rmTree(staged)
           throw err
         }
-        return { ...root, path: realpathSync(root.path), branch }
+        return { ...root, path: this.canonicalWorkspacePath(agent.id, root.path), branch }
       }
       // Identity is the numeric repo id, so a retired root whose owner/repo was later reused by a
       // DIFFERENT repository is refused rather than adopted — and nothing on disk is touched
       // (decision 12: retirement, never deletion). An origin URL cannot stand in for that id: it
       // names the slug, which is exactly what a reuse keeps. No attestation ⇒ no root.
-      const recorded = readSecondaryMaterialization(marker)
+      const recorded = parseSecondaryMaterialization(await fs.readFile(marker))
       if (recorded === undefined || recorded.repoId !== root.repoId) {
         workspaceLog.warn(
           `workspace: the checkout at ${subtree} does not attest repository id ${root.repoId} ` +
@@ -616,7 +661,7 @@ export class WorkspaceManager {
       await this.convergeOriginInPlaceFor(agent.id, resolved, root.path)
       await writeRepoHelperConfig(this.runnerFor(agent.id, root.path), agent.id).catch(() => undefined)
       if (agent.workspace.pullOnNewSession) await this.pullRoot(agent.id, resolved, root.path)
-      return { ...resolved, path: realpathSync(root.path) }
+      return { ...resolved, path: this.canonicalWorkspacePath(agent.id, root.path) }
     } catch (err) {
       // Degradation stays local to the root (decision 7): the session starts without it and the next
       // one retries. Never throw out of session start over an additional repository.
@@ -628,14 +673,16 @@ export class WorkspaceManager {
   }
 
   /** Move a staged clone onto the root's path, over nothing or a provably empty leftover. */
-  private publishSecondaryCheckout(staged: string, path: string): void {
-    if (existsSync(path)) {
-      // The same rule the worktree GC applies: reclaim a provably empty directory, report anything
-      // else. A leftover that holds files is a human's or an older attempt's, never ours to remove.
-      if (readdirSync(path).length > 0) throw new Error(`${path} is not empty; refusing to replace it`)
-      rmSync(path, { recursive: true, force: true })
+  private async publishSecondaryCheckout(agentId: string, staged: string, path: string): Promise<void> {
+    const fs = this.fsFor(agentId)
+    // The same rule the worktree GC applies: reclaim a provably empty directory, report anything
+    // else. A leftover that holds files is a human's or an older attempt's, never ours to remove.
+    // One operation, never a proof followed by a delete — `rmdir` refuses a directory that is not
+    // empty itself, so a file that arrives first keeps it instead of being discarded.
+    if ((await fs.stat(path)) !== 'missing' && !(await fs.rmdir(path))) {
+      throw new Error(`${path} is not empty; refusing to replace it`)
     }
-    renameSync(staged, path)
+    await fs.rename(staged, path)
   }
 
   /** The branch `origin/HEAD` points at, asked of the remote through the clone's own credentials. */
@@ -1044,30 +1091,24 @@ export class WorkspaceManager {
    *  MATERIALIZED secondary subtree on disk — a retired root's worktrees are this session's too
    *  (decision 12), while a subtree a failed clone left behind owns none and has no checkout for
    *  Git to run in, which would fail the whole session's cleanup forever. */
-  sessionWorktreeRoots(agent: Agent): Pick<WorkspaceRoot, 'path' | 'worktreesPath'>[] {
+  async sessionWorktreeRoots(agent: Agent): Promise<Pick<WorkspaceRoot, 'path' | 'worktreesPath'>[]> {
+    const fs = this.fsFor(agent.id)
     const mount = this.sandboxMountFor(agent.id)
-    return [
-      ...(agent.workspace.mode === 'git-repo'
-        ? [
-            {
-              path: mount === undefined ? agent.workspace.path : this.clusterWorkspaceCheckout(agent, mount),
-              worktreesPath: this.worktreesPathAt(agent, mount)
-            }
-          ]
-        : []),
-      // A sandboxed workspace has only the primary checkout, so these subtrees would judge this disk.
-      ...(this.sandboxMode
-        ? []
-        : secondarySubtreesIn(this.agentRootFor(agent))
-            .filter((entry) => existsSync(join(entry.path, '.git')))
-            .map(({ path, worktreesPath }) => ({ path, worktreesPath })))
-    ]
+    const roots: Pick<WorkspaceRoot, 'path' | 'worktreesPath'>[] =
+      agent.workspace.mode === 'git-repo'
+        ? [{ path: this.primaryCheckoutAt(agent, mount), worktreesPath: this.worktreesPathAt(agent, mount) }]
+        : []
+    for (const { path, worktreesPath } of await this.secondarySubtreesFor(agent)) {
+      if ((await fs.stat(join(path, '.git'))) === 'missing') continue
+      roots.push({ path, worktreesPath })
+    }
+    return roots
   }
 
   /** Whether the agent has any root a session worktree could live under — a scratch workspace with
    *  secondary roots does, which is what makes it a candidate for the retention GC. */
-  hasSessionWorktreeRoots(agent: Agent): boolean {
-    return this.sessionWorktreeRoots(agent).length > 0
+  async hasSessionWorktreeRoots(agent: Agent): Promise<boolean> {
+    return (await this.sessionWorktreeRoots(agent)).length > 0
   }
 
   /**
@@ -1081,7 +1122,7 @@ export class WorkspaceManager {
    * tells the caller its warm attachment is stale even though the session survives.
    */
   async removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
-    const roots = this.sessionWorktreeRoots(agent)
+    const roots = await this.sessionWorktreeRoots(agent)
     if (roots.length === 0) return { outcome: 'failed', error: 'agent workspace is not a Git repository' }
     const id = this.sessionWorktreeId(sessionKey)
     let retained: SessionWorktreeRemoval | undefined
@@ -1100,11 +1141,14 @@ export class WorkspaceManager {
 
   /** The agent's secondary subtrees whose `.materialization.json` no longer matches a current row —
    *  by repository id, and by the directory a rename moved the repository out of (decision 12). */
-  retiredSecondaryRoots(agent: Agent): RetiredWorkspaceRoot[] {
-    const authorized = new Map(this.secondaryRoots(agent).map((root) => [root.repoId, root.repoFullName]))
+  async retiredSecondaryRoots(agent: Agent): Promise<RetiredWorkspaceRoot[]> {
+    const fs = this.fsFor(agent.id)
+    const authorized = new Map(this.secondaryRootsFor(agent).map((root) => [root.repoId, root.repoFullName]))
     const retired: RetiredWorkspaceRoot[] = []
-    for (const entry of secondarySubtreesIn(this.agentRootFor(agent))) {
-      const recorded = readSecondaryMaterialization(join(entry.subtree, SECONDARY_MATERIALIZATION_FILE))
+    for (const entry of await this.secondarySubtreesFor(agent)) {
+      const recorded = parseSecondaryMaterialization(
+        await fs.readFile(join(entry.subtree, SECONDARY_MATERIALIZATION_FILE))
+      )
       // No attestation ⇒ not ours to judge, let alone remove: materialization already refuses to
       // adopt such a subtree, and removing one would be exactly the deletion decision 12 forbids.
       if (recorded === undefined) continue
@@ -1123,12 +1167,13 @@ export class WorkspaceManager {
    * clone is the object store that worktree reads.
    */
   async removeRetiredSecondaryRoot(agent: Agent, root: RetiredWorkspaceRoot): Promise<RetiredRootRemoval> {
+    const fs = this.fsFor(agent.id)
     try {
-      const subtree = this.validateSecondarySubtree(agent, root.subtree)
-      if (existsSync(root.worktreesPath) && readdirSync(root.worktreesPath).length > 0) {
+      const subtree = await this.validateSecondarySubtree(agent, root.subtree)
+      if ((await fs.stat(root.worktreesPath)) !== 'missing' && (await fs.readdir(root.worktreesPath)).length > 0) {
         return { outcome: 'retained', reason: 'worktrees' }
       }
-      if (existsSync(join(root.path, '.git'))) {
+      if ((await fs.stat(join(root.path, '.git'))) !== 'missing') {
         const git = this.runnerFor(agent.id, root.path).withEnv(workspaceGitLocalEnv())
         if ((await git.raw(['status', '--porcelain'])).trim() !== '') return { outcome: 'retained', reason: 'dirty' }
         // EVERY local ref, not just HEAD: this removes the object store itself, so a side branch, a
@@ -1136,26 +1181,35 @@ export class WorkspaceManager {
         // daemon's own review refs are disposable — they were fetched verbatim from the remote.
         const unique = await git.raw(['rev-list', '--count', '--all', '--not', '--remotes', '--glob=refs/agentconnect'])
         if (unique.trim() !== '0') return { outcome: 'retained', reason: 'unique-commits' }
-      } else if (existsSync(root.path) && readdirSync(root.path).length > 0) {
-        // No `.git` to interrogate, but a nonempty directory may be exactly the untracked work this
-        // GC promises never to auto-delete — the same rule the worktree GC applies to a bare leftover.
+      } else if (!(await fs.rmdir(root.path))) {
+        // No `.git` to interrogate, so the checkout may hold exactly the untracked work this GC
+        // promises never to auto-delete. `rmdir` reclaims it only if the kernel finds it empty —
+        // one operation, rather than a proof the runtime can invalidate before the delete uses it.
         return { outcome: 'retained', reason: 'dirty' }
       }
-      rmSync(subtree, { recursive: true, force: true })
+      await fs.rmTree(subtree)
       return { outcome: 'removed' }
     } catch (err) {
       return { outcome: 'failed', error: (err as Error).message }
     }
   }
 
-  /** Canonicalize a secondary subtree and prove it still resolves inside the agent directory, the
-   *  same way every destructive worktree path goes through {@link validateWorktreesRoot}. */
-  private validateSecondarySubtree(agent: Agent, subtree: string): string {
-    if (lstatSync(subtree).isSymbolicLink()) throw new Error('secondary root subtree must not be a symlink')
+  /** Canonicalize a secondary subtree and prove it still resolves inside the parent that holds the
+   *  agent's roots, the same way every destructive worktree path goes through
+   *  {@link validateWorktreesRoot} — and by the same rule on a pod, where there is no symlink to
+   *  resolve from here and the shim's own descent is the containment. */
+  private async validateSecondarySubtree(agent: Agent, subtree: string): Promise<string> {
+    const mount = this.sandboxMountFor(agent.id)
+    if ((await this.fsFor(agent.id).stat(subtree)) === 'other') {
+      throw new Error('secondary root subtree must not be a symlink')
+    }
+    if (mount !== undefined) {
+      if (escapesRoot(mount, subtree)) throw new Error('secondary root subtree resolves outside the mount')
+      return subtree
+    }
     const agentRoot = realpathSync(this.agentRootFor(agent))
     const canonical = realpathSync(subtree)
-    const rel = relative(agentRoot, canonical)
-    if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+    if (escapesRoot(agentRoot, canonical)) {
       throw new Error('secondary root subtree resolves outside the agent directory')
     }
     return canonical
@@ -1426,7 +1480,7 @@ export class WorkspaceManager {
     // re-prepares it after a host eviction or a daemon restart carries no review at all — and, for a
     // scratch workspace, reports `shared` isolation — so this is resolved BEFORE either shortcut: the
     // attestation on disk, not this process's memory, is what holds the working directory still.
-    const cwdRoot = reviewRoot ?? this.resumedReviewedRoot(agent, request)
+    const cwdRoot = reviewRoot ?? (await this.resumedReviewedRoot(agent, request))
     if (cwdRoot) return await this.prepareReviewedRootWorkspace(agent, cwdRoot, request, opts)
     if (request.isolation === 'shared') return primary
 
@@ -1440,6 +1494,21 @@ export class WorkspaceManager {
     if (cwd === undefined) return primary
     const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
     return this.withSkills(agent, this.resolveAcpCwd(cwd, agentDir), opts)
+  }
+
+  /** The post-clone skills step, which only this daemon's own disk has: a pod's runtime gets its
+   *  skills from the launch phase, so installing them here would write on the wrong filesystem.
+   *  Asked of the DAEMON, not of the agent's mount — a channel that dropped mid-preparation must not
+   *  turn "the pod owns this" into "write it here". */
+  private async withLocalSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOptions): Promise<string> {
+    return this.sandboxMode ? acpCwd : await this.withSkills(agent, acpCwd, opts)
+  }
+
+  /** The ACP cwd inside one prepared root: validated against this disk locally, composed lexically on
+   *  a pod — where the same join `clusterWorkspaceCwd` makes is what the shim's descent re-checks. */
+  private resolveRootAcpCwd(agentId: string, root: string, agentDir: string | undefined): string {
+    if (this.sandboxMountFor(agentId) === undefined) return this.resolveAcpCwd(root, agentDir)
+    return agentDir === undefined ? root : join(root, ...agentDir.split('/'))
   }
 
   /**
@@ -1469,7 +1538,7 @@ export class WorkspaceManager {
     await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent, prepared.repoFullName), request)
     // The same post-steps the primary cwd gets, deliberately: skills install into the working
     // directory, and the reviewed root is the one the model stands in. `agentDir` is the primary's.
-    const acpCwd = await this.withSkills(agent, this.resolveAcpCwd(cwd, undefined), opts)
+    const acpCwd = await this.withLocalSkills(agent, this.resolveRootAcpCwd(agent.id, cwd, undefined), opts)
     // Attested LAST, because the attestation says a session was placed here: a preparation that
     // failed a post-step must leave the caller's revision-only fallback a primary cwd it can use,
     // while a later preparation of a placed session — in a fresh process, carrying no review —
@@ -1485,19 +1554,22 @@ export class WorkspaceManager {
 
   /** Drop every root's attestation that it holds one session's working directory. */
   private async forgetSessionCwdRoots(agent: Agent, sessionWorktreeId: string): Promise<void> {
-    for (const entry of secondarySubtreesIn(this.agentRootFor(agent))) {
+    for (const entry of await this.secondarySubtreesFor(agent)) {
       await this.recordSessionCwdRoot(agent.id, entry.subtree, sessionWorktreeId)
     }
   }
 
   /** The root a session already stands in, as a root this preparation can drive — nothing when the
    *  attestation names a repository the agent's rows no longer authorize. */
-  private resumedReviewedRoot(agent: Agent, request: SessionRootScope): SecondaryWorkspaceRoot | undefined {
-    if (this.sandboxMode || request.sessionKey === undefined) return undefined
-    const recorded = this.sessionCwdSubtree(agent, request.sessionKey)
+  private async resumedReviewedRoot(
+    agent: Agent,
+    request: SessionRootScope
+  ): Promise<SecondaryWorkspaceRoot | undefined> {
+    if (request.sessionKey === undefined) return undefined
+    const recorded = await this.sessionCwdSubtree(agent, request.sessionKey)
     if (recorded === undefined) return undefined
     const key = repoKey(recorded.repoFullName)
-    return this.secondaryRoots(agent).find((entry) => repoKey(entry.repoFullName) === key)
+    return this.secondaryRootsFor(agent).find((entry) => repoKey(entry.repoFullName) === key)
   }
 
   /** The roots that ride along this session, with the label their per-root failure is reported under. */
@@ -1738,10 +1810,11 @@ export class WorkspaceManager {
   /**
    * The pod cwd one session stands in, once its checkout is ready.
    *
-   * The same three shapes the local path has, against the same portable code: a shared session gets
-   * the checkout, an isolated one its own `<mount>/worktrees/<sid>` (which is also what gives a pool
-   * agent an exact same-repository review checkout), and a review with no local checkout to trust
-   * gets an empty daemon-owned directory beside them.
+   * The same shapes the local path has, against the same portable code: a shared session gets the
+   * checkout, an isolated one its own `<mount>/worktrees/<sid>` (which is also what gives a pool
+   * agent an exact same-repository review checkout), a review of a secondary root that root's own
+   * exact worktree, and a review with no local checkout to trust an empty daemon-owned directory
+   * beside them.
    */
   private async prepareClusterSessionCwd(
     agent: Agent,
@@ -1753,11 +1826,26 @@ export class WorkspaceManager {
         throw new Error('github revision-only workspace requires an isolated git-repo review session')
       }
       const id = this.sessionWorktreeId(request.sessionKey)
+      // The cwd becomes the primary's own empty directory, so no root may go on attesting that this
+      // session stands in it — a surviving attestation would refuse the very fallback prepared here.
+      await this.forgetSessionCwdRoots(agent, id)
       return await this.prepareGithubRevisionOnlyWorkspace(agent, id, this.worktreesPathAt(agent, mount))
     }
-    // A from-scratch workspace keeps the mount: isolation has no clone to branch off, as locally.
-    if (request?.isolation === 'session' && agent.workspace.mode === 'git-repo') {
-      await this.prepareRootSessionWorktree(agent, this.primaryRootAt(agent, mount), request)
+    // Resolved before anything is materialized, as locally: a review naming a repository this agent
+    // has no root for leaves no worktree behind for the caller's revision-only fallback.
+    const reviewRoot = request ? this.reviewedSecondaryRoot(agent, request) : undefined
+    // The volume's own secondary roots, in the pod's coordinates — the same pass `prepareWorkspace`
+    // makes locally, and where a root that has left the set stops being handed out (decision 12).
+    await this.prepareSecondaryRoots(agent)
+    const cwdRoot = reviewRoot ?? (request ? await this.resumedReviewedRoot(agent, request) : undefined)
+    if (cwdRoot && request) return await this.prepareReviewedRootWorkspace(agent, cwdRoot, request, {})
+    if (request?.isolation === 'session') {
+      // A from-scratch workspace keeps the mount: isolation has no clone to branch off, as locally —
+      // but its secondaries still get per-session worktrees (decisions 4 and 5).
+      if (agent.workspace.mode === 'git-repo') {
+        await this.prepareRootSessionWorktree(agent, this.primaryRootAt(agent, mount), request)
+      }
+      await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent), request)
     }
     return this.clusterWorkspaceCwd(agent, mount, request)
   }
@@ -1828,50 +1916,64 @@ export class WorkspaceManager {
     return this.resolveAcpCwd(agent.workspace.path, agentDir)
   }
 
-  additionalWorkspaceDirectories(
+  async additionalWorkspaceDirectories(
     agent: Agent,
     cwd: string,
     request?: Pick<PrepareSessionWorkspaceRequest, 'sessionKey' | 'isolation' | 'reviewRepoFullName'>
-  ): string[] {
+  ): Promise<string[]> {
+    const widened = await this.widenedCwdRoot(agent, cwd, request)
+    const roots = await this.sessionAdditionalRoots(agent, request)
+    return [...(widened === undefined ? [] : [widened]), ...roots.map((root) => root.path)]
+  }
+
+  /**
+   * The checkout root an `agentDir` cwd is widened back to, so repo-wide tools reach `.git` and its
+   * siblings — undefined when the cwd already IS that root, or when a review made a secondary root
+   * the working directory (decision 5), which has no `agentDir` of its own.
+   */
+  private async widenedCwdRoot(agent: Agent, cwd: string, request?: SessionRootScope): Promise<string | undefined> {
     if (this.sandboxMode) {
-      if (agent.workspace.mode !== 'git-repo') return []
+      if (agent.workspace.mode !== 'git-repo') return undefined
+      if ((await this.sessionCwdRepoFullName(agent, request)) !== undefined) return undefined
       // `cwd` is in the POD's coordinates, which this daemon cannot `realpathSync` — the path exists
       // on no filesystem it can see, so the check below throws on the workspace it was handed. Undo
       // the lexical join `clusterWorkspaceCwd` made instead; the shim re-checks containment itself.
       const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
-      if (agentDir === undefined) return []
-      return [agentDir.split('/').reduce((path) => dirname(path), cwd)]
+      if (agentDir === undefined) return undefined
+      return agentDir.split('/').reduce((path) => dirname(path), cwd)
     }
     // Containment is proven against the root this session actually stands in — the primary, or the
-    // secondary a review made the working directory (decision 5). Widening an `agentDir` cwd back to
-    // its checkout root is the primary's alone; a reviewed root has no `agentDir`.
-    const widened: string[] = []
-    const cwdRoot = this.sessionCwdRootPath(agent, request)
-    if (cwdRoot !== undefined) {
-      const root = realpathSync(cwdRoot)
-      const canonicalCwd = realpathSync(cwd)
-      const rel = relative(root, canonicalCwd)
-      if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
-        throw new Error(`prepared workspace cwd "${cwd}" resolves outside its checkout root`)
-      }
-      if (root !== canonicalCwd && this.sessionCwdRepoFullName(agent, request) === undefined) widened.push(root)
+    // secondary a review made the working directory. Widening is the primary's alone.
+    const cwdRoot = await this.sessionCwdRootPath(agent, request)
+    if (cwdRoot === undefined) return undefined
+    const root = realpathSync(cwdRoot)
+    const canonicalCwd = realpathSync(cwd)
+    if (escapesRoot(root, canonicalCwd)) {
+      throw new Error(`prepared workspace cwd "${cwd}" resolves outside its checkout root`)
     }
-    return [...widened, ...this.sessionAdditionalRoots(agent, request).map((root) => root.path)]
+    if (root === canonicalCwd) return undefined
+    return (await this.sessionCwdRepoFullName(agent, request)) === undefined ? root : undefined
   }
 
   /** The directory this session's cwd must sit under: the reviewed secondary root's, else the
    *  primary's. Undefined when the agent has no primary checkout and no review named a root. */
-  private sessionCwdRootPath(agent: Agent, request?: SessionRootScope): string | undefined {
-    const reviewed = this.sessionCwdRepoFullName(agent, request)
+  private async sessionCwdRootPath(agent: Agent, request?: SessionRootScope): Promise<string | undefined> {
+    const mount = this.sandboxMountFor(agent.id)
+    const reviewed = await this.sessionCwdRepoFullName(agent, request)
     if (reviewed !== undefined) {
       const key = repoKey(reviewed)
-      const root = secondarySubtreesIn(this.agentRootFor(agent)).find((entry) => repoKey(entry.repoFullName) === key)
+      const root = (await this.secondarySubtreesFor(agent)).find((entry) => repoKey(entry.repoFullName) === key)
       // A subtree that is no longer on disk cannot vouch for the cwd; fall through to the primary,
       // which the cwd is not under either, so the containment check refuses it.
-      if (root) return this.sessionRootPath(agent, root.path, root.worktreesPath, request)
+      if (root) return await this.sessionRootPath(agent, root.path, root.worktreesPath, request)
     }
     if (agent.workspace.mode !== 'git-repo') return undefined
-    return this.sessionRootPath(agent, agent.workspace.path, this.worktreesPathFor(agent), request)
+    return await this.sessionRootPath(
+      agent,
+      this.primaryCheckoutAt(agent, mount),
+      this.worktreesPathAt(agent, mount),
+      request
+    )
   }
 
   resolveAcpCwd(workspaceRoot: string, agentDir: string | undefined): string {
@@ -2102,7 +2204,7 @@ export class WorkspaceManager {
       } catch (e) {
         // A failed clone leaves a half-written dir whose stray `.git` would make
         // every later attempt think the checkout exists — clean before rethrowing.
-        rmSync(join(cwd, '.git'), { recursive: true, force: true })
+        await this.fsFor(agentId).rmTree(join(cwd, '.git'))
         throw e
       }
       // Pin the repo-local helper so AGENT-run git in this checkout authenticates
@@ -2142,21 +2244,21 @@ export function parseSymrefDefaultBranch(out: string): string | undefined {
   return undefined
 }
 
-/** Write the attestation the way the primary's marker is written: temp file, then atomic rename. */
-function writeSecondaryMaterialization(file: string, value: SecondaryMaterialization): void {
-  const temp = `${file}.tmp`
+/** The same attestation off THIS disk, for the console seam, which answers synchronously and whose
+ *  cluster branch discards the answer before it is used. */
+function readSecondaryMaterialization(file: string): SecondaryMaterialization | undefined {
   try {
-    writeFileSync(temp, JSON.stringify(value, null, 2) + '\n', { mode: 0o600 })
-    renameSync(temp, file)
-  } catch (err) {
-    rmSync(temp, { force: true })
-    throw err
+    return parseSecondaryMaterialization(readFileSync(file, 'utf8'))
+  } catch {
+    return undefined
   }
 }
 
-function readSecondaryMaterialization(file: string): SecondaryMaterialization | undefined {
+/** A secondary root's attestation as the seam read it; undefined for absent, unreadable or partial. */
+function parseSecondaryMaterialization(text: string | undefined): SecondaryMaterialization | undefined {
+  if (text === undefined) return undefined
   try {
-    const value = JSON.parse(readFileSync(file, 'utf8')) as Partial<SecondaryMaterialization>
+    const value = JSON.parse(text) as Partial<SecondaryMaterialization>
     if (typeof value.repoId !== 'string' || !value.repoId) return undefined
     if (typeof value.branch !== 'string' || !value.branch) return undefined
     if (typeof value.repoFullName !== 'string' || !value.repoFullName) return undefined

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -1045,9 +1045,11 @@ describe('secondary roots on the pod volume', () => {
       mode: 'from-scratch',
       additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }]
     } as Partial<Agent['workspace']>)
-    // The spec-only prefilter says yes before any volume is bound; the roots themselves need one.
+    // The prefilter says yes before any volume is bound; the roots themselves need one. It says yes
+    // for a scratch agent with no rows LEFT too — a retired root keeps its worktrees (decision 12),
+    // and on a pod only the volume can say whether one is there.
     expect(workspaces.mayOwnSessionWorktrees(agent)).toBe(true)
-    expect(workspaces.mayOwnSessionWorktrees(clusterAgent({ mode: 'from-scratch' }))).toBe(false)
+    expect(workspaces.mayOwnSessionWorktrees(clusterAgent({ mode: 'from-scratch' }))).toBe(true)
 
     await workspaces.prepareClusterWorkspace(agent, POD_ROOT, { sessionKey: 'sess-1', isolation: 'session' })
 

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -1017,4 +1017,48 @@ describe('secondary roots on the pod volume', () => {
     })
     expect(await pod.stat(`${INFRA}/checkout/.git`)).toBe('file')
   })
+
+  it('raises rather than reading a volume that cannot answer as a tree with no roots', async () => {
+    // An empty answer here licenses resuming a cross-repository session in the primary checkout and
+    // licenses judging only the primary worktree — so a channel that dropped must abort the
+    // operation, not degrade into "this agent has no secondary roots".
+    const agent = agentWithRoots()
+    const request = { sessionKey: 'sess-1', isolation: 'session' as const }
+    await workspaces.prepareClusterWorkspace(agent, POD_ROOT, request)
+    pod.unreadable.add(REPOS)
+
+    await expect(workspaces.retiredSecondaryRoots(clusterAgent())).rejects.toThrow(/cannot list/)
+    await expect(workspaces.sessionWorktreeRoots(agent)).rejects.toThrow(/cannot list/)
+    await expect(
+      workspaces.additionalWorkspaceDirectories(agent, `${WORKTREES}/${workspaces.sessionWorktreeId('sess-1')}`, {
+        sessionKey: 'sess-1',
+        isolation: 'session'
+      })
+    ).rejects.toThrow(/cannot list/)
+  })
+
+  it('finds a scratch agent’s secondary worktrees, which have no primary beside them', async () => {
+    // The case the retention GC must not answer from this daemon's own disk: a from-scratch agent
+    // owns no primary root at all, so its pod-side secondary worktrees are the ONLY thing the
+    // dirty/unique-commit rules have to judge.
+    const agent = clusterAgent({
+      mode: 'from-scratch',
+      additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }]
+    } as Partial<Agent['workspace']>)
+    // The spec-only prefilter says yes before any volume is bound; the roots themselves need one.
+    expect(workspaces.mayOwnSessionWorktrees(agent)).toBe(true)
+    expect(workspaces.mayOwnSessionWorktrees(clusterAgent({ mode: 'from-scratch' }))).toBe(false)
+
+    await workspaces.prepareClusterWorkspace(agent, POD_ROOT, { sessionKey: 'sess-1', isolation: 'session' })
+
+    expect(await workspaces.hasSessionWorktreeRoots(agent)).toBe(true)
+    expect(await workspaces.sessionWorktreeRoots(agent)).toEqual([
+      { path: `${INFRA}/checkout`, worktreesPath: `${INFRA}/worktrees` }
+    ])
+    worktreeStatus = ' M a.txt\n'
+    expect(await workspaces.removeSessionWorktree(agent, 'sess-1')).toEqual({
+      outcome: 'retained',
+      reason: 'dirty'
+    })
+  })
 })

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -67,10 +67,25 @@ let worktreeStatus = ''
 let mergeRefAvailable = false
 /** What HEAD resolves to in whichever worktree is being asked; `worktree add` and `reset` move it. */
 let headRev: string | undefined
+/** What each secondary remote's `ls-remote --symref` reports as its default branch. */
+let remoteDefaultBranch: Record<string, string> = {}
+/** Clone URLs the remote refuses, so one root can fail while the others materialize. */
+let cloneRefusals = new Set<string>()
 
 /** A ref name as a commit id, the way `worktree add`/`reset` move HEAD onto their start point. */
 function resolve(ref: string): string {
   return revs[ref] ?? ref
+}
+
+/** `owner/repo` for a github.com clone URL, which is how the fake remotes are keyed. */
+function repoOfUrl(url: string): string {
+  return url.replace(/^https:\/\/github\.com\//, '').replace(/\.git$/, '')
+}
+
+/** The origin a secondary root's own checkout (or worktree) reports, from its pod path. */
+function secondaryOriginOf(cwd: string | undefined): string | undefined {
+  const match = cwd?.match(/^\/agent\/repos\/([^/]+)\/([^/]+)\//)
+  return match ? `https://github.com/${match[1]}/${match[2]}` : undefined
 }
 
 function recordingRunner(cwd: string | undefined, env: Record<string, string> = {}): GitRunner {
@@ -81,7 +96,14 @@ function recordingRunner(cwd: string | undefined, env: Record<string, string> = 
       return '.git'
     }
     if (args[0] === 'config' && args.includes('--add') && helperWriteFails) throw new Error('helper pin refused')
-    if (args[0] === 'remote' && args[1] === 'get-url') return originUrl
+    // A secondary root's checkout carries its OWN origin; only the primary answers the volume's.
+    if (args[0] === 'remote' && args[1] === 'get-url') return secondaryOriginOf(cwd) ?? originUrl
+    if (args[0] === 'ls-remote') {
+      const url = args.at(-2)!
+      const branch = remoteDefaultBranch[repoOfUrl(url)]
+      if (branch === undefined) throw new Error(`no remote at ${url}`)
+      return `ref: refs/heads/${branch}\tHEAD\n${'a'.repeat(40)}\tHEAD\n`
+    }
     if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return headBranch
     if (args[0] === 'rev-parse' && args[1] === '--verify') {
       const ref = args[2]!.replace(/\^\{commit\}$/, '')
@@ -120,7 +142,13 @@ function recordingRunner(cwd: string | undefined, env: Record<string, string> = 
     raw: run,
     clone: async (repo, target, options = []) => {
       calls.push({ cwd, args: ['clone', repo, target, ...options], env })
-      if (cloneFails) throw new Error('remote hung up')
+      if (cloneFails || cloneRefusals.has(repo)) throw new Error('remote hung up')
+      // A secondary root stages into an absolute path on the volume, and the seam has to SEE the
+      // checkout appear there; the primary's target is relative and is probed through git instead.
+      if (target.startsWith('/')) {
+        void pod.mkdir(target)
+        void pod.writeFile(`${target}/.git`, 'gitdir: ...')
+      }
     },
     pull: async (remote, branch, options = []) => {
       calls.push({ cwd, args: ['pull', remote, branch, ...options], env })
@@ -177,6 +205,8 @@ beforeEach(() => {
   worktreeStatus = ''
   mergeRefAvailable = false
   headRev = undefined
+  remoteDefaultBranch = {}
+  cloneRefusals = new Set()
   // Every agent here runs in a pod, so all three seams resolve to the sandbox.
   workspaces.setGitRunnerResolver((_agentId, cwd) => recordingRunner(cwd))
   workspaces.setFsResolver(() => ({ fs: pod, mount: POD_ROOT }))
@@ -221,19 +251,19 @@ describe('clusterWorkspaceCwd', () => {
     )
   })
 
-  it('names the enclosing checkout in the POD coordinates the cwd is in', () => {
+  it('names the enclosing checkout in the POD coordinates the cwd is in', async () => {
     // The runtime gets the repository root separately so repo-wide tools can reach `.git` and
     // siblings. Deriving it the local way means `realpathSync` on a path that exists on no
     // filesystem this daemon can see — which throws, and takes every cluster session with it.
     const agent = clusterAgent({ agentDir: 'services/api' })
-    expect(workspaces.additionalWorkspaceDirectories(agent, workspaces.clusterWorkspaceCwd(agent, POD_ROOT))).toEqual([
-      CHECKOUT
-    ])
+    expect(
+      await workspaces.additionalWorkspaceDirectories(agent, workspaces.clusterWorkspaceCwd(agent, POD_ROOT))
+    ).toEqual([CHECKOUT])
     // No subdirectory means the cwd already IS the root, and a second copy of it says nothing.
-    expect(workspaces.additionalWorkspaceDirectories(clusterAgent(), CHECKOUT)).toEqual([])
+    expect(await workspaces.additionalWorkspaceDirectories(clusterAgent(), CHECKOUT)).toEqual([])
   })
 
-  it('puts a session-isolated cwd in the worktree that session owns, beside the checkout', () => {
+  it('puts a session-isolated cwd in the worktree that session owns, beside the checkout', async () => {
     const id = workspaces.sessionWorktreeId('sess-1')
     expect(
       workspaces.clusterWorkspaceCwd(clusterAgent(), POD_ROOT, { isolation: 'session', sessionKey: 'sess-1' })
@@ -245,7 +275,7 @@ describe('clusterWorkspaceCwd', () => {
     expect(cwd).toBe(`${WORKTREES}/${id}/services/api`)
     // The repository root handed alongside it is the WORKTREE, not the shared checkout — widened
     // lexically, because the path exists on no filesystem this daemon could resolve it against.
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, scope)).toEqual([`${WORKTREES}/${id}`])
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, scope)).toEqual([`${WORKTREES}/${id}`])
   })
 })
 
@@ -809,5 +839,182 @@ describe('per-session worktrees on the pod volume', () => {
     })
     expect(cwd).toBe(CHECKOUT)
     expect(await pod.stat(WORKTREES)).toBe('missing')
+  })
+})
+
+/**
+ * Secondary workspace roots on the pod volume (multi-repository-workspaces.md phase 7).
+ *
+ * Same code as the self-hosted path, same decisions — the only difference is which filesystem
+ * answers `stat`/`readdir`/`mkdir`/`rename`/`rmdir` and which coordinates the paths are composed in.
+ * So every assertion here is about the POD's `<mount>/repos/<owner>/<repo>` tree, and about nothing
+ * appearing on this daemon's own disk, where the runtime would never see it.
+ */
+describe('secondary roots on the pod volume', () => {
+  const REPOS = `${POD_ROOT}/repos`
+  const INFRA = `${REPOS}/acme/infra`
+  const SHARED = `${REPOS}/example-co/shared-library`
+
+  function agentWithRoots(rows = [{ repoFullName: 'acme/infra', repoId: '42' }]): Agent {
+    return clusterAgent({ additionalRepos: rows } as Partial<Agent['workspace']>)
+  }
+
+  function worktreeOf(subtree: string, key: string): string {
+    return `${subtree}/worktrees/${workspaces.sessionWorktreeId(key)}`
+  }
+
+  beforeEach(() => {
+    remoteDefaultBranch = { 'acme/infra': 'trunk', 'example-co/shared-library': 'release' }
+  })
+
+  it('materializes each root under the mount, attested through the seam', async () => {
+    await workspaces.prepareClusterWorkspace(agentWithRoots(), POD_ROOT)
+
+    // The clone stages beside the checkout and is published by a rename, on the volume.
+    const clone = calls.find((call) => call.args[0] === 'clone' && call.args[1].includes('acme/infra'))
+    expect(clone!.args[2]).toMatch(new RegExp(`^${INFRA}/checkout\\.clone-`))
+    // `--branch` carries what the REMOTE reported, since the CP projects no branch for a secondary.
+    expect(clone!.args).toContain('trunk')
+    expect(await pod.stat(`${INFRA}/checkout/.git`)).toBe('file')
+    expect(JSON.parse((await pod.readFile(`${INFRA}/.materialization.json`))!)).toEqual({
+      repoId: '42',
+      repoFullName: 'acme/infra',
+      branch: 'trunk'
+    })
+    // Nothing landed on the daemon's own disk, where the runtime would never see it.
+    expect(existsSync(REPOS)).toBe(false)
+    expect(existsSync('/daemon/agents/agent-cluster/repos')).toBe(false)
+  })
+
+  it('hands a shared session the checkouts and an isolated one the worktrees, in pod paths', async () => {
+    const agent = agentWithRoots([
+      { repoFullName: 'acme/infra', repoId: '42' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ])
+    const shared = { sessionKey: 'sess-1', isolation: 'shared' as const }
+    expect(await workspaces.prepareClusterWorkspace(agent, POD_ROOT, shared)).toBe(CHECKOUT)
+    expect(await workspaces.additionalWorkspaceDirectories(agent, CHECKOUT, shared)).toEqual([
+      `${INFRA}/checkout`,
+      `${SHARED}/checkout`
+    ])
+
+    checkoutExists = true
+    const isolated = { sessionKey: 'sess-2', isolation: 'session' as const, initiatedBy: 'alice' }
+    const cwd = await workspaces.prepareClusterWorkspace(agent, POD_ROOT, isolated)
+    expect(cwd).toBe(`${WORKTREES}/${workspaces.sessionWorktreeId('sess-2')}`)
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, isolated)).toEqual([
+      worktreeOf(INFRA, 'sess-2'),
+      worktreeOf(SHARED, 'sess-2')
+    ])
+    // Each root's worktree was added from ITS own checkout, at the branch that root's remote reported.
+    const add = calls.filter((call) => call.args[0] === 'worktree' && call.args[1] === 'add')
+    expect(add.find((call) => call.cwd === `${INFRA}/checkout`)!.args).toContain('refs/remotes/origin/trunk')
+    expect(add.find((call) => call.cwd === `${SHARED}/checkout`)!.args).toContain('refs/remotes/origin/release')
+  })
+
+  it('withholds a root the primary already carries as a submodule, read off the volume', async () => {
+    // Decision 11: two copies of one repository at two revisions is what this prevents, and the
+    // `.gitmodules` that says so is a file on the POD — the daemon has no local checkout to read.
+    pod.files.set(`${CHECKOUT}/.gitmodules`, '[submodule "infra"]\n\turl = https://github.com/acme/infra.git\n')
+    const agent = agentWithRoots()
+
+    const cwd = await workspaces.prepareClusterWorkspace(agent, POD_ROOT)
+
+    expect(calls.some((call) => call.args[0] === 'clone' && call.args[1].includes('acme/infra'))).toBe(false)
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([])
+  })
+
+  it('omits a root the remote refuses and still starts the session', async () => {
+    // Decision 7: degradation stays local to the root. The session comes up without it, and the
+    // next one retries.
+    cloneRefusals.add('https://github.com/example-co/shared-library')
+    const agent = agentWithRoots([
+      { repoFullName: 'acme/infra', repoId: '42' },
+      { repoFullName: 'example-co/shared-library', repoId: '815' }
+    ])
+    const request = { sessionKey: 'sess-1', isolation: 'session' as const }
+
+    const cwd = await workspaces.prepareClusterWorkspace(agent, POD_ROOT, request)
+
+    expect(cwd).toBe(`${WORKTREES}/${workspaces.sessionWorktreeId('sess-1')}`)
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([worktreeOf(INFRA, 'sess-1')])
+    expect(await pod.stat(`${SHARED}/checkout/.git`)).toBe('missing')
+  })
+
+  it('makes a reviewed secondary root the cwd at the exact head, with the primary alongside', async () => {
+    const base = 'a'.repeat(40)
+    const head = 'b'.repeat(40)
+    const id = workspaces.sessionWorktreeId('sess-review')
+    revs[`refs/agentconnect/reviews/${id}/base`] = base
+    revs[`refs/agentconnect/reviews/${id}/head`] = head
+    const agent = agentWithRoots()
+    const request = {
+      sessionKey: 'sess-review',
+      isolation: 'session' as const,
+      reviewRepoFullName: 'acme/infra',
+      review: { pullNumber: 9, baseSha: base, headSha: head }
+    }
+
+    const cwd = await workspaces.prepareClusterWorkspace(agent, POD_ROOT, request)
+
+    expect(cwd).toBe(worktreeOf(INFRA, 'sess-review'))
+    // The reviewed refs were fetched into the SECONDARY root's own object store, not the primary's.
+    const fetch = calls.find((call) => call.args[0] === 'fetch')
+    expect(fetch).toMatchObject({ cwd: `${INFRA}/checkout` })
+    expect(fetch!.args).toContain(`+refs/pull/9/head:refs/agentconnect/reviews/${id}/head`)
+    const reviewAdd = calls.find(
+      (call) => call.args[0] === 'worktree' && call.args[1] === 'add' && call.cwd === `${INFRA}/checkout`
+    )
+    expect(reviewAdd!.args.at(-1)).toBe(head)
+    // The primary rides along at its default branch, and the attestation holds the cwd across a
+    // restart — a later hand-out that carries no review resolves the same working directory.
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([`${WORKTREES}/${id}`])
+    expect(JSON.parse((await pod.readFile(`${INFRA}/.session-cwd-${id}.json`))!)).toEqual({
+      repoFullName: 'acme/infra'
+    })
+    expect(
+      await workspaces.additionalWorkspaceDirectories(agent, cwd, {
+        sessionKey: 'sess-review',
+        isolation: 'session'
+      })
+    ).toEqual([`${WORKTREES}/${id}`])
+  })
+
+  it('retires a root the rows no longer authorize, and removes it once nothing holds it', async () => {
+    const agent = agentWithRoots()
+    await workspaces.prepareClusterWorkspace(agent, POD_ROOT, {
+      sessionKey: 'sess-1',
+      isolation: 'session' as const
+    })
+    const retiredAgent = clusterAgent()
+    const [retired] = await workspaces.retiredSecondaryRoots(retiredAgent)
+    expect(retired).toMatchObject({ repoFullName: 'acme/infra', repoId: '42', subtree: INFRA })
+
+    // A worktree of it is a live session's directory, so the whole subtree stays — its clone is the
+    // object store that worktree reads.
+    expect(await workspaces.removeRetiredSecondaryRoot(retiredAgent, retired!)).toEqual({
+      outcome: 'retained',
+      reason: 'worktrees'
+    })
+    expect(await pod.stat(`${INFRA}/checkout/.git`)).toBe('file')
+
+    checkoutExists = true
+    expect(await workspaces.removeSessionWorktree(agent, 'sess-1')).toEqual({ outcome: 'removed' })
+    expect(await workspaces.removeRetiredSecondaryRoot(retiredAgent, retired!)).toEqual({ outcome: 'removed' })
+    expect(await pod.stat(INFRA)).toBe('missing')
+    expect(await workspaces.retiredSecondaryRoots(retiredAgent)).toEqual([])
+  })
+
+  it('keeps a retired root whose checkout holds commits no remote can reach', async () => {
+    await workspaces.prepareClusterWorkspace(agentWithRoots(), POD_ROOT)
+    const retiredAgent = clusterAgent()
+    const [retired] = await workspaces.retiredSecondaryRoots(retiredAgent)
+    uniqueCommits = '3'
+
+    expect(await workspaces.removeRetiredSecondaryRoot(retiredAgent, retired!)).toEqual({
+      outcome: 'retained',
+      reason: 'unique-commits'
+    })
+    expect(await pod.stat(`${INFRA}/checkout/.git`)).toBe('file')
   })
 })

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -718,7 +718,7 @@ describe('Daemon rd/msg hook fires', () => {
       .spyOn(daemon as any, 'prepareAgentWorkspace')
       .mockResolvedValue('/agent/repos/acme/infra/worktrees/review')
     // What preparation would have handed this session beside the reviewed root's own worktree.
-    vi.spyOn((daemon as any).workspaces, 'sessionAdditionalRoots').mockReturnValue([
+    vi.spyOn((daemon as any).workspaces, 'sessionAdditionalRoots').mockResolvedValue([
       { path: '/agent/worktrees/review', repoFullName: 'acme/primary-service', branch: 'main' }
     ])
     const headSha = 'a'.repeat(40)

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -2069,6 +2069,14 @@ describe('Daemon CP drain (#109)', () => {
 })
 
 describe('Daemon session retention GC (#485)', () => {
+  // `start()` fires its own retention pass, and the sweep drops a call that lands while one is
+  // running — so a test that just called it could assert against a pass that judged the clock it
+  // had before the advance. Wait the startup pass out, then sweep for real.
+  const sweepRetention = async (daemon: Daemon) => {
+    while ((daemon as any).sessionRetentionSweepInFlight) await new Promise((resolve) => setTimeout(resolve, 5))
+    await (daemon as any).sweepSessionRetention()
+  }
+
   const seedSession = async (daemon: Daemon, key: string, state: 'idle' | 'prompting' | 'closed', updatedAt: number) =>
     await (daemon as any).store.upsertSession({
       key,
@@ -2123,7 +2131,7 @@ describe('Daemon session retention GC (#485)', () => {
     await seedSession(daemon, 'expired-closed', 'closed', 0)
 
     clock.advance(8 * 24 * 3_600_000)
-    await (daemon as any).sweepSessionRetention()
+    await sweepRetention(daemon)
     expect(await (daemon as any).store.getSession('expired-closed')).toBeDefined()
 
     await daemon.stop()
@@ -2144,7 +2152,7 @@ describe('Daemon session retention GC (#485)', () => {
     await seedSession(daemon, 'expired-a', 'closed', 0)
     await seedSession(daemon, 'expired-b', 'idle', 0)
     clock.advance(8 * 24 * 3_600_000)
-    await (daemon as any).sweepSessionRetention()
+    await sweepRetention(daemon)
     await vi.waitFor(() => expect(emitSessionPurged).toHaveBeenCalledOnce(), WAIT)
 
     // One frame per agent, carrying the ACP session ids — the only session
@@ -2213,7 +2221,7 @@ describe('Daemon session retention GC (#485)', () => {
 
     await seedSession(daemon, 'expired-a', 'closed', 0)
     clock.advance(8 * 24 * 3_600_000)
-    await (daemon as any).sweepSessionRetention()
+    await sweepRetention(daemon)
 
     // Not even attempted: the receipt is durable and the reconnect drains it, so a
     // request here would only log a failure on every sweep of a local-only daemon.
@@ -2242,7 +2250,7 @@ describe('Daemon session retention GC (#485)', () => {
 
     await seedSession(daemon, 'expired-a', 'closed', 0)
     clock.advance(8 * 24 * 3_600_000)
-    await (daemon as any).sweepSessionRetention()
+    await sweepRetention(daemon)
     await (daemon as any).drainSessionPurges()
 
     expect(await (daemon as any).store.listSessionPurges(10, 0)).toMatchObject([
@@ -2282,7 +2290,7 @@ describe('Daemon session retention GC (#485)', () => {
     })
 
     clock.advance(8 * 24 * 3_600_000)
-    await (daemon as any).sweepSessionRetention()
+    await sweepRetention(daemon)
     expect(await (daemon as any).store.getSession('expired-queued')).toBeDefined()
 
     await daemon.stop()

--- a/packages/daemon/test/fixtures/pod-workspace-fs.ts
+++ b/packages/daemon/test/fixtures/pod-workspace-fs.ts
@@ -14,6 +14,8 @@ export class PodWorkspaceFs implements WorkspaceFs {
   /** Paths the pod reports as neither file nor directory — a symlink is the one that matters. */
   readonly links = new Set<string>()
   readonly removed: string[] = []
+  /** Paths whose listing the channel cannot answer — a dropped shim connection, not an empty tree. */
+  readonly unreadable = new Set<string>()
 
   constructor(...seedDirs: string[]) {
     for (const dir of seedDirs) this.dirs.add(dir)
@@ -27,6 +29,7 @@ export class PodWorkspaceFs implements WorkspaceFs {
   }
 
   async readdir(path: string): Promise<string[]> {
+    if (this.unreadable.has(path)) throw new Error(`workspace channel cannot list ${path}`)
     const prefix = `${path}/`
     const names = new Set<string>()
     for (const entry of [...this.dirs, ...this.files.keys()]) {

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -173,7 +173,7 @@ describe('SessionManager', () => {
     const ready: Array<typeof recovered> = []
     // The real hand-out and the real prompt, over a ready list this session's preparation changes.
     const workspaces = new (class extends WorkspaceManager {
-      override readySecondaryRoots() {
+      override async readySecondaryRoots() {
         return ready
       }
     })()

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -959,6 +959,20 @@ describe('removeSessionWorktree across every root (decision 4)', () => {
     expect(await workspaces.hasSessionWorktreeRoots(agent)).toBe(true)
   })
 
+  it('keeps a scratch agent in scope once its last row is gone, because the root only retired', () => {
+    // The prefilter the retention GC applies before it binds anything. A retired root keeps its
+    // worktrees (decision 12), so the rows alone would let this session's worktree be purged
+    // without the dirty/unique-commit rules ever running against it.
+    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }], { mode: 'from-scratch' })
+    serveAll(agent, { 'acme/infra': 'trunk' })
+    mkdirSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout'), { recursive: true })
+    const retired = { ...agent, workspace: { ...agent.workspace, additionalRepos: [] } } as Agent
+
+    expect(workspaces.mayOwnSessionWorktrees(retired)).toBe(true)
+    // A scratch agent that never had one is out of scope, and takes no admission fence for nothing.
+    expect(workspaces.mayOwnSessionWorktrees(agentFixture([], { mode: 'from-scratch' }))).toBe(false)
+  })
+
   it('reports absent when no root has a worktree for the session', async () => {
     const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
     serveAll(agent, { 'acme/infra': 'trunk' })

--- a/packages/daemon/test/workspace-secondary-roots.test.ts
+++ b/packages/daemon/test/workspace-secondary-roots.test.ts
@@ -301,11 +301,11 @@ describe('secondary root materialization', () => {
       repoFullName: 'example-co/shared-library',
       branch: 'release/v2'
     })
-    expect(workspaces.readySecondaryRoots(agent).map((root) => [root.repoFullName, root.branch])).toEqual([
+    expect((await workspaces.readySecondaryRoots(agent)).map((root) => [root.repoFullName, root.branch])).toEqual([
       ['acme/infra', 'trunk'],
       ['example-co/shared-library', 'release/v2']
     ])
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([
       realpathSync(join(home, 'repos', 'acme', 'infra', 'checkout')),
       realpathSync(join(home, 'repos', 'example-co', 'shared-library', 'checkout'))
     ])
@@ -325,7 +325,7 @@ describe('secondary root materialization', () => {
 
     expect(existsSync(join(checkout, 'local-note.txt'))).toBe(true)
     expect(git(checkout, ['remote', 'get-url', 'origin']).trim()).toBe('https://github.com/acme/infra')
-    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect((await workspaces.readySecondaryRoots(agent)).map((root) => root.repoFullName)).toEqual(['acme/infra'])
   })
 
   it('publishes the clone only after its attestation, so a checkout is never left unattributable', async () => {
@@ -353,7 +353,7 @@ describe('secondary root materialization', () => {
 
     await workspaces.prepareWorkspace(agent)
 
-    expect(workspaces.readySecondaryRoots(agent)).toEqual([])
+    expect(await workspaces.readySecondaryRoots(agent)).toEqual([])
     expect(existsSync(join(subtree, '.materialization.json'))).toBe(false)
     expect(existsSync(join(subtree, 'checkout', '.git'))).toBe(true)
   })
@@ -367,7 +367,7 @@ describe('secondary root materialization', () => {
 
     await workspaces.prepareWorkspace(agent)
 
-    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect((await workspaces.readySecondaryRoots(agent)).map((root) => root.repoFullName)).toEqual(['acme/infra'])
     expect(existsSync(join(subtree, 'checkout.clone-8a1f9c02-0000-4000-8000-000000000000', 'partial.txt'))).toBe(true)
   })
 
@@ -382,8 +382,8 @@ describe('secondary root materialization', () => {
 
     const cwd = await workspaces.prepareWorkspace(agent)
 
-    expect(workspaces.readySecondaryRoots(agent)).toEqual([])
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([])
+    expect(await workspaces.readySecondaryRoots(agent)).toEqual([])
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([])
     // Retirement, never deletion (decision 12): the checkout is left exactly where it was.
     expect(existsSync(join(subtree, 'checkout', '.git'))).toBe(true)
     expect(readdirSync(subtree).sort()).toEqual(['.materialization.json', 'checkout'])
@@ -400,7 +400,7 @@ describe('secondary root materialization', () => {
     const cwd = await workspaces.prepareWorkspace(agent)
 
     expect(cwd).toBe(realpathSync(agent.workspace.path))
-    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect((await workspaces.readySecondaryRoots(agent)).map((root) => root.repoFullName)).toEqual(['acme/infra'])
     expect(
       existsSync(join(workspaces.agentRootFor(agent), 'repos', 'example-co', 'shared-library', 'checkout', '.git'))
     ).toBe(false)
@@ -413,7 +413,7 @@ describe('secondary root materialization', () => {
     const [first, second] = await Promise.all([workspaces.prepareWorkspace(agent), workspaces.prepareWorkspace(agent)])
 
     expect(second).toBe(first)
-    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect((await workspaces.readySecondaryRoots(agent)).map((root) => root.repoFullName)).toEqual(['acme/infra'])
   })
 })
 
@@ -424,8 +424,8 @@ describe('submodule roots (decision 11)', () => {
 
     const cwd = await workspaces.prepareWorkspace(agent)
 
-    expect(workspaces.readySecondaryRoots(agent)).toEqual([])
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([])
+    expect(await workspaces.readySecondaryRoots(agent)).toEqual([])
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([])
     // Not handed out AND not cloned: the parent's own submodule path is where it is reachable.
     expect(existsSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout'))).toBe(false)
   })
@@ -444,7 +444,7 @@ describe('submodule roots (decision 11)', () => {
 
     await workspaces.prepareWorkspace(agent)
 
-    expect(workspaces.readySecondaryRoots(agent).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect((await workspaces.readySecondaryRoots(agent)).map((root) => root.repoFullName)).toEqual(['acme/infra'])
     expect(existsSync(join(workspaces.agentRootFor(agent), 'repos', 'example-co', 'shared-library', 'checkout'))).toBe(
       false
     )
@@ -469,7 +469,7 @@ describe('additionalWorkspaceDirectories with secondary roots', () => {
     const cwd = await workspaces.prepareWorkspace(agent)
 
     expect(cwd).toBe(realpathSync(join(agent.workspace.path, 'services', 'api')))
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([
       realpathSync(agent.workspace.path),
       realpathSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout'))
     ])
@@ -490,7 +490,7 @@ describe('additionalWorkspaceDirectories with secondary roots', () => {
     const subtree = (repoFullName: string) => join(workspaces.agentRootFor(agent), 'repos', ...repoFullName.split('/'))
     const worktree = (repoFullName: string) => join(subtree(repoFullName), 'worktrees', id)
     expect(cwd).toBe(realpathSync(workspaces.sessionWorktreePath(agent, 'session-a')))
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([
       realpathSync(worktree('acme/infra')),
       realpathSync(worktree('example-co/shared-library'))
     ])
@@ -499,12 +499,12 @@ describe('additionalWorkspaceDirectories with secondary roots', () => {
     expect(git(worktree('acme/infra'), ['rev-parse', 'HEAD']).trim()).toBe(
       git(join(subtree('acme/infra'), 'checkout'), ['rev-parse', 'refs/remotes/origin/trunk']).trim()
     )
-    expect(workspaces.readySecondaryRoots(agent, request).map((root) => [root.path, root.branch])).toEqual([
+    expect((await workspaces.readySecondaryRoots(agent, request)).map((root) => [root.path, root.branch])).toEqual([
       [realpathSync(worktree('acme/infra')), 'trunk'],
       [realpathSync(worktree('example-co/shared-library')), 'release/v2']
     ])
     // The shared view of the same prepared set still names the checkouts.
-    expect(workspaces.readySecondaryRoots(agent, { isolation: 'shared' }).map((root) => root.path)).toEqual([
+    expect((await workspaces.readySecondaryRoots(agent, { isolation: 'shared' })).map((root) => root.path)).toEqual([
       realpathSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout')),
       realpathSync(join(workspaces.agentRootFor(agent), 'repos', 'example-co', 'shared-library', 'checkout'))
     ])
@@ -527,7 +527,7 @@ describe('additionalWorkspaceDirectories with secondary roots', () => {
       workspaces.sessionWorktreeId('session-a')
     )
     expect(existsSync(join(worktree, '.git'))).toBe(true)
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([realpathSync(worktree)])
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([realpathSync(worktree)])
   })
 
   it('omits a root whose session worktree cannot be created and still prepares the session', async () => {
@@ -545,7 +545,7 @@ describe('additionalWorkspaceDirectories with secondary roots', () => {
 
     const cwd = await workspaces.prepareSessionWorkspace(agent, request)
 
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([
       realpathSync(
         join(
           workspaces.agentRootFor(agent),
@@ -565,19 +565,9 @@ describe('additionalWorkspaceDirectories with secondary roots', () => {
 
     const cwd = await workspaces.prepareWorkspace(agent)
 
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd)).toEqual([
       realpathSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout'))
     ])
-  })
-
-  it('prepares and hands out nothing when workspaces live in sandboxes', async () => {
-    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
-    serveAll(agent, { 'acme/infra': 'trunk' })
-    workspaces.setSandboxMode(true)
-
-    expect(await workspaces.prepareSecondaryRoots(agent)).toEqual([])
-    expect(workspaces.readySecondaryRoots(agent)).toEqual([])
-    expect(existsSync(join(workspaces.agentRootFor(agent), 'repos'))).toBe(false)
   })
 })
 
@@ -677,22 +667,25 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     // The primary and the other secondary ride along, each at its own default branch.
     const primaryWorktree = realpathSync(workspaces.sessionWorktreePath(agent, 'session-review'))
     const shared = realpathSync(worktreeOf(agent, 'example-co/shared-library', 'session-review'))
-    expect(workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([primaryWorktree, shared])
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([primaryWorktree, shared])
     // And the same answer without the request naming the review, which is how a session's later
     // hand-outs ask: the reviewed root's own subtree attests that it took the cwd.
     expect(
-      workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: 'session-review', isolation: 'session' })
+      await workspaces.additionalWorkspaceDirectories(agent, cwd, {
+        sessionKey: 'session-review',
+        isolation: 'session'
+      })
     ).toEqual([primaryWorktree, shared])
     expect(
-      workspaces
-        .sessionAdditionalRoots(agent, { sessionKey: 'session-review', isolation: 'session' })
-        .map((root) => [root.repoFullName, root.branch])
+      (await workspaces.sessionAdditionalRoots(agent, { sessionKey: 'session-review', isolation: 'session' })).map(
+        (root) => [root.repoFullName, root.branch]
+      )
     ).toEqual([
       ['acme/primary-service', 'main'],
       ['example-co/shared-library', 'main']
     ])
     // The reviewed root is the working directory, so it is nobody's additional directory.
-    expect(workspaces.readySecondaryRoots(agent, request).map((root) => root.repoFullName)).toEqual([
+    expect((await workspaces.readySecondaryRoots(agent, request)).map((root) => root.repoFullName)).toEqual([
       'example-co/shared-library'
     ])
     expect(git(primaryWorktree, ['rev-parse', 'HEAD']).trim()).toBe(
@@ -720,7 +713,7 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
 
     expect(resumedCwd).toBe(cwd)
     expect(git(resumedCwd, ['rev-parse', 'HEAD']).trim()).toBe(pull.merge)
-    expect(restarted.additionalWorkspaceDirectories(agent, resumedCwd, resumed)).toEqual([
+    expect(await restarted.additionalWorkspaceDirectories(agent, resumedCwd, resumed)).toEqual([
       realpathSync(restarted.sessionWorktreePath(agent, 'session-resume')),
       realpathSync(worktreeOf(agent, 'example-co/shared-library', 'session-resume'))
     ])
@@ -767,9 +760,12 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     expect(cwd).toBe(realpathSync(workspaces.sessionWorktreePath(agent, 'session-degraded')))
     // No root still claims the working directory, so the fallback cwd is accepted rather than
     // measured against a checkout the session no longer stands in.
-    expect(() =>
-      workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: 'session-degraded', isolation: 'session' })
-    ).not.toThrow()
+    await expect(
+      workspaces.additionalWorkspaceDirectories(agent, cwd, {
+        sessionKey: 'session-degraded',
+        isolation: 'session'
+      })
+    ).resolves.toBeDefined()
   })
 
   it('lets a swept session fall back to the primary, so a stale attestation captures nothing', async () => {
@@ -804,7 +800,7 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     serveAll(agent, { 'acme/infra': 'trunk' }, { primary: gitmodulesFor('acme/infra') })
     const ordinary = { sessionKey: 'session-plain', isolation: 'session' as const }
     const ordinaryCwd = await workspaces.prepareSessionWorkspace(agent, ordinary)
-    expect(workspaces.additionalWorkspaceDirectories(agent, ordinaryCwd, ordinary)).toEqual([])
+    expect(await workspaces.additionalWorkspaceDirectories(agent, ordinaryCwd, ordinary)).toEqual([])
     restoreAuthorizedOrigins(agent)
     const pull = seedPullRequest(remoteOf('acme/infra'), 'trunk', 4)
 
@@ -814,8 +810,8 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     expect(git(cwd, ['rev-parse', 'HEAD']).trim()).toBe(pull.merge)
     // Its own review gets the exact checkout; an ordinary session still reaches it only through the
     // parent's submodule path, so it is handed to nobody as an additional directory.
-    expect(workspaces.readySecondaryRoots(agent)).toEqual([])
-    expect(workspaces.additionalWorkspaceDirectories(agent, ordinaryCwd, ordinary)).toEqual([])
+    expect(await workspaces.readySecondaryRoots(agent)).toEqual([])
+    expect(await workspaces.additionalWorkspaceDirectories(agent, ordinaryCwd, ordinary)).toEqual([])
   })
 
   it('refuses a review of a repository this agent has no root for, leaving nothing behind', async () => {
@@ -832,19 +828,6 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     expect(existsSync(workspaces.sessionWorktreePath(agent, 'session-unknown'))).toBe(false)
   })
 
-  it('refuses a secondary root’s review where workspaces live in sandboxes, leaving the fallback to the caller', async () => {
-    const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
-    serveAll(agent, { 'acme/infra': 'trunk' })
-    workspaces.setSandboxMode(true)
-    const pull = { base: 'a'.repeat(40), head: 'b'.repeat(40) }
-
-    await expect(
-      workspaces.prepareSessionWorkspace(agent, reviewRequest('session-sandbox', 'acme/infra', 5, pull))
-    ).rejects.toThrow('needs a local workspace root')
-
-    expect(existsSync(join(workspaces.agentRootFor(agent), 'repos'))).toBe(false)
-  })
-
   it('keeps the primary the working directory when the review names it', async () => {
     const agent = agentFixture([{ repoFullName: 'acme/infra', repoId: '42' }])
     serveAll(agent, { 'acme/infra': 'trunk' })
@@ -858,7 +841,10 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     expect(cwd).toBe(realpathSync(workspaces.sessionWorktreePath(agent, 'session-primary')))
     expect(git(cwd, ['rev-parse', 'HEAD']).trim()).toBe(pull.merge)
     expect(
-      workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: 'session-primary', isolation: 'session' })
+      await workspaces.additionalWorkspaceDirectories(agent, cwd, {
+        sessionKey: 'session-primary',
+        isolation: 'session'
+      })
     ).toEqual([realpathSync(worktreeOf(agent, 'acme/infra', 'session-primary'))])
   })
 
@@ -882,7 +868,10 @@ describe('review of a secondary root (decisions 5, 6 and 11)', () => {
     // A scratch workspace reports `shared` isolation of its own, having no clone to branch: a
     // session standing in a reviewed root is per-session whatever that report says.
     expect(
-      workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: 'session-scratch', isolation: 'shared' })
+      await workspaces.additionalWorkspaceDirectories(agent, cwd, {
+        sessionKey: 'session-scratch',
+        isolation: 'shared'
+      })
     ).toEqual([realpathSync(worktreeOf(agent, 'example-co/shared-library', 'session-scratch'))])
   })
 
@@ -967,7 +956,7 @@ describe('removeSessionWorktree across every root (decision 4)', () => {
     await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
 
     expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
-    expect(workspaces.hasSessionWorktreeRoots(agent)).toBe(true)
+    expect(await workspaces.hasSessionWorktreeRoots(agent)).toBe(true)
   })
 
   it('reports absent when no root has a worktree for the session', async () => {
@@ -995,12 +984,12 @@ describe('retire → sweep → remove (decision 12)', () => {
     restoreAuthorizedOrigins(agent)
 
     const after = reauthorized(agent, [{ repoFullName: 'acme/infra', repoId: '42' }])
-    expect(workspaces.retiredSecondaryRoots(after).map((root) => root.repoFullName)).toEqual([
+    expect((await workspaces.retiredSecondaryRoots(after)).map((root) => root.repoFullName)).toEqual([
       'example-co/shared-library'
     ])
     // Retirement alone removes nothing, and it drops out of the hand-out at once.
     await workspaces.prepareWorkspace(after)
-    expect(workspaces.readySecondaryRoots(after).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect((await workspaces.readySecondaryRoots(after)).map((root) => root.repoFullName)).toEqual(['acme/infra'])
     expect(
       existsSync(join(workspaces.agentRootFor(agent), 'repos', 'example-co', 'shared-library', 'checkout', '.git'))
     ).toBe(true)
@@ -1013,9 +1002,9 @@ describe('retire → sweep → remove (decision 12)', () => {
 
     // Same repository id, new slug: the old directory is retired while the new one materializes.
     const renamed = reauthorized(agent, [{ repoFullName: 'acme/infrastructure', repoId: '42' }])
-    expect(workspaces.retiredSecondaryRoots(renamed).map((root) => root.repoFullName)).toEqual(['acme/infra'])
+    expect((await workspaces.retiredSecondaryRoots(renamed)).map((root) => root.repoFullName)).toEqual(['acme/infra'])
     // Re-authorizing the original slug un-retires it with nothing on disk having changed.
-    expect(workspaces.retiredSecondaryRoots(agent)).toEqual([])
+    expect(await workspaces.retiredSecondaryRoots(agent)).toEqual([])
   })
 
   it('leaves a subtree with no attestation alone rather than retiring it', async () => {
@@ -1024,7 +1013,7 @@ describe('retire → sweep → remove (decision 12)', () => {
     await workspaces.prepareWorkspace(agent)
     rmSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', '.materialization.json'))
 
-    expect(workspaces.retiredSecondaryRoots(reauthorized(agent, []))).toEqual([])
+    expect(await workspaces.retiredSecondaryRoots(reauthorized(agent, []))).toEqual([])
   })
 
   it('refuses a retired root while any worktree of it survives, and removes it once none does', async () => {
@@ -1032,7 +1021,7 @@ describe('retire → sweep → remove (decision 12)', () => {
     serveAll(agent, { 'acme/infra': 'trunk' })
     await workspaces.prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
     const after = reauthorized(agent, [])
-    const [retired] = workspaces.retiredSecondaryRoots(after)
+    const [retired] = await workspaces.retiredSecondaryRoots(after)
 
     expect(await workspaces.removeRetiredSecondaryRoot(after, retired!)).toEqual({
       outcome: 'retained',
@@ -1051,7 +1040,7 @@ describe('retire → sweep → remove (decision 12)', () => {
     await workspaces.prepareWorkspace(agent)
     restoreAuthorizedOrigins(agent)
     const after = reauthorized(agent, [])
-    const [retired] = workspaces.retiredSecondaryRoots(after)
+    const [retired] = await workspaces.retiredSecondaryRoots(after)
     writeFileSync(join(retired!.path, 'unsaved.txt'), 'work\n')
 
     expect(await workspaces.removeRetiredSecondaryRoot(after, retired!)).toEqual({
@@ -1074,7 +1063,7 @@ describe('retire → sweep → remove (decision 12)', () => {
     await workspaces.prepareWorkspace(agent)
     restoreAuthorizedOrigins(agent)
     const after = reauthorized(agent, [])
-    const [retired] = workspaces.retiredSecondaryRoots(after)
+    const [retired] = await workspaces.retiredSecondaryRoots(after)
     // Removing the clone destroys its whole object store, so what the CHECKED-OUT branch can reach
     // does not speak for the work: a side branch and a stash are both invisible from `trunk`.
     git(retired!.path, ['checkout', '-q', '-b', 'side'])
@@ -1107,7 +1096,7 @@ describe('retire → sweep → remove (decision 12)', () => {
     serveAll(agent, { 'acme/infra': 'trunk' })
     await workspaces.prepareWorkspace(agent)
     const after = reauthorized(agent, [])
-    const [retired] = workspaces.retiredSecondaryRoots(after)
+    const [retired] = await workspaces.retiredSecondaryRoots(after)
     // A subtree that is itself a symlink is refused, so removal can never reach what it points at.
     const elsewhere = tempRoot('ac-secondary-outside-')
     writeFileSync(join(elsewhere, 'precious.txt'), 'not ours\n')
@@ -1119,7 +1108,7 @@ describe('retire → sweep → remove (decision 12)', () => {
     expect(result.outcome).toBe('failed')
     expect(existsSync(join(elsewhere, 'precious.txt'))).toBe(true)
     // And a symlinked subtree is not even listed as a candidate on the next pass.
-    expect(workspaces.retiredSecondaryRoots(after)).toEqual([])
+    expect(await workspaces.retiredSecondaryRoots(after)).toEqual([])
   })
 })
 

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -390,10 +390,10 @@ describe('prepareSessionWorkspace', () => {
     expect(again).toBe(first)
     expect(second).not.toBe(first)
     expect(
-      workspaces.additionalWorkspaceDirectories(agent, first, { sessionKey: 'session-a', isolation: 'session' })
+      await workspaces.additionalWorkspaceDirectories(agent, first, { sessionKey: 'session-a', isolation: 'session' })
     ).toEqual([realpathSync(workspaces.sessionWorktreePath(agent, 'session-a'))])
     expect(
-      workspaces.additionalWorkspaceDirectories(agent, second, { sessionKey: 'session-b', isolation: 'session' })
+      await workspaces.additionalWorkspaceDirectories(agent, second, { sessionKey: 'session-b', isolation: 'session' })
     ).toEqual([realpathSync(workspaces.sessionWorktreePath(agent, 'session-b'))])
   })
 


### PR DESCRIPTION
Phase 7 part 2 of [`docs/designs/multi-repository-workspaces.md`](https://github.com/agentconnect-md/agentconnect/blob/main/docs/designs/multi-repository-workspaces.md). #1225 put the `WorkspaceFs` seam and the primary root's session worktrees on the pod volume; this puts the **secondary roots** there too, so a cluster agent gets the same `additionalDirectories` and the same exact cross-repository review checkout a self-hosted one has had since phase 3.

## What

Every secondary-root path now takes its filesystem from `fsFor(agentId)` and its paths from the placement's mount:

- `secondaryRootsAt(agent, mount)` composes `<mount>/repos/<owner>/<repo>/{checkout,worktrees}` the way `primaryRootAt` composes the primary's; `secondaryRoots(agent)` stays the mount-less form.
- Materialization stages a clone (through `cloneRootAt`, which already goes through the shim runner) and publishes it by `rename`; the default branch comes from `ls-remote --symref`; `.materialization.json` and the `.session-cwd-<id>.json` attestation are read and written through the seam; `.gitmodules` is read from the checkout that carries it, so decision 11's submodule dedupe works on the volume.
- The subtree scan behind the ready-roots snapshot, `sessionWorktreeRoots`, and the retirement sweep goes through `readdir` (new `secondarySubtreesUnder(fs, parent)` beside the synchronous twin the launch path still needs for its sandbox boundary).
- `prepareClusterWorkspace` runs the same secondary preparation and session-isolation handling `prepareWorkspace` runs locally — review of a secondary root included: that root's exact worktree becomes the cwd, the primary and the remaining roots ride along at their default branches.
- Every `sandboxMode ⇒ skip` in these paths is gone, including the one that made a review of a secondary root on a pool agent fall back to revision-only.

Because a pod cannot be stat-ed synchronously, the hand-out and GC entry points that answered from `existsSync` are now async: `readySecondaryRoots`, `sessionAdditionalRoots`, `additionalWorkspaceDirectories`, `sessionWorktreeRoots` / `hasSessionWorktreeRoots`, `retiredSecondaryRoots`, `submoduleReposOf`. The ripple is mechanical — the runtime-session callbacks (`workspaceDirectories`, `metaContext`, `resumeSystemContext`) and the session manager's memoized standing context become promises.

`sweepRetiredWorkspaceRoots` runs its listing and its removal under `withAgentVolume`, like the session-worktree removal already does, and skips a sandboxed agent whose channel is not already bound rather than waking a suspended pod for a GC pass. The admission fence and the idle re-check are unchanged.

## Why

Phase 7 of the design: nothing about the pod ever forbade any of this — the runtime takes a per-session `cwd`, `git worktree` is in the exec allowlist, the volume survives suspend/resume, and git credentials in the pod are routed by URL. The only thing missing was the filesystem seam, and #1225 built it. Until now a pool agent's authorized additional repositories existed as an allowlist and nothing else: no checkout, and a review of one of them degraded to an empty directory plus "inspect it through GitHub".

## What a reviewer should check

- **No `node:fs` on any path a sandboxed agent reaches.** What remains is daemon-side bookkeeping (the workspace materialization/conversion markers), activation and prefetch (local-only by construction), and the local branch of a mount-aware split. The "which world am I in" decisions (`withLocalSkills`, the lexical `agentDir` widening) ask `sandboxMode` rather than the agent's mount, so a channel that dropped mid-preparation cannot turn "the pod owns this" into "write it here".
- **The delete-licensing discipline #1225 established.** Where an emptiness proof licenses a delete it is one `rmdir`, not a `readdir` followed by a recursive remove: publishing a staged clone over a leftover, and reclaiming a retired checkout that has no `.git`. The subtree removal that Git's own `status` / `rev-list` checks license stays an `rmTree`, under the admission fence that has already proven the agent idle.
- **The review cwd swap**, and that the attestation is written last so a restart — whose request carries no review at all — resolves the same working directory.
- **Local behaviour is byte-identical.** The two self-hosted tests that pinned the old cluster short-circuits are deleted; the rest of `workspace-secondary-roots.test.ts` only gained `await`. One `daemon-lifecycle` helper now waits the startup retention pass out before sweeping — the sweep drops a call that lands while one is running, and these tests were relying on it having finished.

## Tests

`test/cluster-workspace-prepare.test.ts` gains a block over the same fake shim runner and fake pod filesystem: roots materialize under `<mount>/repos/…` with their marker through the seam; shared sessions get the checkouts and isolated ones the per-session worktrees, each added from its own checkout at its own remote's default branch; submodule dedupe from a `.gitmodules` read off the volume; a root the remote refuses is omitted and the session still starts; a review of a secondary root puts the cwd at `<mount>/repos/o/r/worktrees/<sid>` at the exact head with the primary alongside; a retired root is detected and removed, refused while a worktree survives or while its checkout holds commits no remote can reach.

## Not here

`gh` inside the pod — the runtime image ships none and the wrapper is a file on the daemon's PATH. Nor the console's own workspace browsing, which still answers with no root for a secondary repository on a cluster agent (#1229 deferred it, and it needs the read seam rather than this one).
