### PR TITLE
refactor(daemon): extract the pure turn plan out of dispatchOne

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -146,7 +146,6 @@ import {
   isSlackStatusBarText,
   slackAgentPostOptions,
   slackPostOptions,
-  slackStatusOptions,
   type SlackTurnState
 } from './platforms/slack/turn-output.js'
 import { ChannelNameResolver } from './messages/channel-name-resolver.js'
@@ -335,7 +334,7 @@ import {
   telegramMessageId as telegramMessageIdExternal,
   telegramReplyTarget as telegramReplyTargetExternal
 } from './platforms/telegram/threading.js'
-import { TurnOutputRegistry, type TurnOutputContext } from './platforms/turn-output.js'
+import { TurnOutputRegistry } from './platforms/turn-output.js'
 import type {
   RegisterReq,
   RelayRosterEntry,
@@ -370,7 +369,8 @@ import type {
   TaskListReq
 } from '@agentconnect.md/protocol'
 import { formatErr } from './daemon/text.js'
-import { isBuiltinSystemToolCall, noneSuppressedApprovalSurface } from './daemon/tool-classification.js'
+import { isBuiltinSystemToolCall } from './daemon/tool-classification.js'
+import { buildTurnPlan } from './daemon/turn-plan.js'
 import {
   isTrustedHumanTurn,
   loopGuardScope,
@@ -440,7 +440,6 @@ import {
 } from './daemon/helpers.js'
 import {
   ABSORBED_CONTEXT_TS_MEMORY,
-  AGENT_CALL_HOP_LIMIT_NOTICE,
   BG_TASK_WAKE_GRACE_MS,
   CANCEL_FORCE_MS,
   DEFAULT_WEB_APP_URL,
@@ -8587,61 +8586,30 @@ export class Daemon {
         )
       }
     }
-    const agentName = agent.displayName?.trim() || agent.name
-    const iconUrl = agent.iconUrl
+    // Every decision this turn can make before it touches a host, a row or a connection.
+    const plan = buildTurnPlan({
+      entry,
+      agent,
+      sessionKey: key,
+      evaluationTurnId,
+      // Read here, not in the planner: the sticky override is live daemon state.
+      stickyOutputMode: await this.store.getOutputModeOverride(key),
+      hostAlreadyRunning: this.hostStarts.has(agentId) || this.modelSessionHosts.get(key)?.host !== undefined,
+      protectedAddresses: this.compoundMentionAddresses(agentId, msg),
+      codexUsageIsPerPrompt: this.isCodexRuntime(agentId),
+      features: { turnFinalContextRefresh: this.cfg.features.turnFinalContextRefresh },
+      turnSurfaces: this.turnSurfaces
+    })
+    const { agentName, iconUrl, mode, showFooter, statusThread, transcriptChannel, statusOptions, turnCtx } = plan
     // The recorder captures the full activity log (tool/reasoning) independent of
     // output mode — `conv` (built below, once the session key is known) only decides
     // what reaches Slack, never the transcript.
     const rec = new TranscriptRecorder()
-    // Output verbosity for THIS turn: the sticky per-session override (status-bar picker)
-    // wins over the agent default. Resolved BEFORE replyConn because `none` is a session-only
-    // mode — the converger records the reply into the transcript (via `recordOnly` posts) but
-    // delivers nothing to the IM, so it takes the same null-connection seam as headless/webchat.
-    const mode = (await this.store.getOutputModeOverride(key)) ?? agent.output.mode
-    // Footer visibility is an agent-level delivery choice, snapshotted for this turn
-    // alongside output mode. Turning it off removes attribution and session-link chrome
-    // on every platform without changing the recorded transcript.
-    const showFooter = agent.output.showFooter
-    // A headless cron fire has no platform target — leave the connection unset so
-    // every apply/status action no-ops (the transcript still records everything).
-    // webchat likewise has no Slack connection: its reply streams through the relay
-    // reply sink as `rd/chat`, so `conv`'s Slack actions never apply.
-    // `none` output mode joins them: no status, status-bar, or reply reaches the channel;
-    // only the converger's `recordOnly` body posts land in the transcript.
-    // A continuation turn keeps its platform reply connection: its webchat stream is
-    // an additional sink, not a replacement (§5.2 dual sinks).
-    const replyConn =
-      msg.headless || (webchat && !webchat.continuation) || mode === 'none'
-        ? undefined
-        : this.replyConnFor(agentId, integrationId)
-    // Capture cold/warm BEFORE sessions.handle(), which boots the host via hostFor().
-    const wasRunning = this.hostStarts.has(agentId) || this.modelSessionHosts.get(key)?.host !== undefined
-    const statusThread = msg.thread ?? msg.msgId
-    const currentTranscriptChannel = () => transcriptChannelKey(msg.channel, msg.transportScope)
     // Daemon-side rendering only (not ACP); a fresh converger is built per turn, so a change
-    // applies from the next turn on, not mid-turn (see `mode`, resolved above before replyConn).
-    // §7.3: the platform's own production rules (chunk ceilings, parse mode, hint
-    // policy) and its opaque per-turn state both come from its output surface.
-    const turnSurface = this.turnSurfaces.for(msg.platform)
-    const turnCtx: TurnOutputContext<NormalizedMessage> = {
-      mode,
-      isDm: msg.isDm,
-      showFooter,
-      message: msg,
-      // send-message-routing-rework.md §5.3: compound shared-bot addresses this
-      // conversation can contain, so the splitter never cuts `<@U_SHARED> reviewer` in
-      // half. Only the Slack surface has such addresses; every other surface ignores it.
-      protectedAddresses: this.compoundMentionAddresses(agentId, msg)
-    }
-    const conv = turnSurface.createConverger(turnCtx)
-    const statusOptions = slackStatusOptions(msg.platform, agentName, iconUrl)
-    this.showActivity(
-      replyConn,
-      msg.channel,
-      statusThread,
-      wasRunning ? 'is thinking…' : 'is starting up…',
-      statusOptions
-    )
+    // applies from the next turn on, not mid-turn (see `mode`, resolved inside the plan).
+    const conv = plan.turnSurface.createConverger(turnCtx)
+    const replyConn = plan.suppressReplyConn ? undefined : this.replyConnFor(agentId, integrationId)
+    this.showActivity(replyConn, msg.channel, statusThread, plan.startupActivityLabel, statusOptions)
     // handle() writes the row to `prompting` before returning; if it throws after
     // that (workspace/attachment failure), the try/finally below is never entered,
     // so reset to `idle` here — otherwise the session stays `prompting` forever and
@@ -8650,12 +8618,7 @@ export class Daemon {
     // Install the exact route before session/new|load: adapters may emit metadata
     // (including a restored title) while SessionManager is still initializing.
     const previousDeliveryBinding = this.sessionDeliveryBindings.get(key)
-    const deliveryBinding: SessionDeliveryBinding = {
-      agentId,
-      platform: msg.platform,
-      ...(integrationId !== undefined ? { integrationId } : {}),
-      isDm: msg.isDm
-    }
+    const deliveryBinding = plan.deliveryBinding
     this.sessionDeliveryBindings.set(key, deliveryBinding)
     this.sessionInitializationsByAgent.set(agentId, (this.sessionInitializationsByAgent.get(agentId) ?? 0) + 1)
     const restoreDeliveryBinding = () => {
@@ -8733,7 +8696,7 @@ export class Daemon {
           // roster continuation carries CallMeta for its hop/rendezvous chain but is a
           // conversation post, not an address — it must not defeat the response-choice
           // rule (webchat-multi-agents.md §5.2a).
-          directAgentCall: callMeta !== undefined && callMeta.conversationContinuation !== true,
+          directAgentCall: plan.directAgentCall,
           // Memory READS (index injection + auto-recall) are no longer session-
           // gated — every session may use shared memory (#653). WRITES stay gated
           // (memory write tools via memoryAccessAllowed; post-turn distillation via
@@ -8779,7 +8742,7 @@ export class Daemon {
             webchat,
             replyConn,
             channel: msg.channel,
-            transcriptChannel: currentTranscriptChannel(),
+            transcriptChannel,
             thread: msg.thread,
             statusThread
           })
@@ -8801,7 +8764,6 @@ export class Daemon {
       throw err
     }
     const { sessionId, blocks, created } = handled
-    const transcriptChannel = currentTranscriptChannel()
     evaluationSessionId = sessionId
     if (handled.skipped) {
       finishEvaluation('turn.cancelled', { reason: 'already_delivered' })
@@ -8945,9 +8907,8 @@ export class Daemon {
       replyText: '',
       attemptReplyText: '',
       attemptAnswerUpdates: [],
-      stageAnswer:
-        this.cfg.features.turnFinalContextRefresh && !webchat && !githubReply && originKindOf(msg.platform) === 'chat',
-      webchatRefresh: this.cfg.features.turnFinalContextRefresh && !!webchat && msg.platform === 'webchat',
+      stageAnswer: plan.stageAnswer,
+      webchatRefresh: plan.webchatRefresh,
       builtinSystemToolCallIds: new Set(),
       hiddenSessionTitleToolCallIds: new Set(),
       // One id for this turn's complete logical response (§5.1), minted before any
@@ -8956,48 +8917,44 @@ export class Daemon {
       // §4.1: the author's OWN turn depth, stamped on every body it posts so the next
       // routing edge advances from it. A human/root turn carries none and is depth 0; the
       // model can neither read nor set this.
-      sourceHopCount: callMeta?.hopCount ?? 0,
+      sourceHopCount: plan.sourceHopCount,
       // §5.3: compound shared-bot addresses a split must never cut in half.
-      protectedAddresses: turnCtx.protectedAddresses ?? [],
+      protectedAddresses: plan.protectedAddresses,
       agentId,
       agentName,
-      requesterId: msg.sender.id,
+      requesterId: plan.requesterId,
       ...(integrationId !== undefined ? { integrationId } : {}),
       ...(iconUrl ? { iconUrl } : {}),
       platform: msg.platform,
       isDm: msg.isDm,
-      loopGuardScope: loopGuardScope(msg),
+      loopGuardScope: plan.loopGuardScope,
       sessionKey: key,
       acpSessionId: sessionId,
       ...(entry.selectedHost ? { selectedHost: entry.selectedHost } : {}),
       channel: msg.channel,
       transcriptChannel,
       thread: msg.thread,
-      turnState: turnSurface.initialTurnState(turnCtx),
+      turnState: plan.turnSurface.initialTurnState(turnCtx),
       statusThread,
       conn: replyConn,
       // Snapshot alongside `conn`: true only when `none` removed THIS turn's Slack permission
       // card surface (not Telegram/Discord/Feishu, webchat, or headless). Frozen for the turn
       // so a mid-turn mode flip can't desync the permission policy from the already-cleared
       // connection (auto-allow regression).
-      approvalSurfaceSuppressed: noneSuppressedApprovalSurface(mode, {
-        platform: msg.platform,
-        webchat,
-        headless: msg.headless
-      }),
+      approvalSurfaceSuppressed: plan.approvalSurfaceSuppressed,
       approvalWaitMs: 0,
       approvalWaitDepth: 0,
       runtimeCostReported: false,
       usageReportSent: false,
       evaluationTurnId,
-      showStatusBar: agent.output.showStatusBar,
+      showStatusBar: plan.showStatusBar,
       statusCancellable: true,
       applyChain: Promise.resolve(),
       done,
       resolveDone,
       ...(callMeta ? { callMeta } : {}),
       ...(pendingWebchat ? { webchat: pendingWebchat } : {}),
-      ...(githubReply && entry.posterPublishState !== 'in_flight' && entry.posterPublishState !== 'settled'
+      ...(plan.githubTurnEligible && githubReply
         ? {
             github: {
               ...this.githubReviews.makeGithubReply(agentId, githubReply, sessionId),
@@ -9019,15 +8976,12 @@ export class Daemon {
       return undefined
     })
     if (activeGithub) this.activeGithubTurnMeta.set(key, activeGithub)
-    const githubReplyBatch = hookContext?.githubReviewBatch
-    const activeGithubReplyBatch =
-      githubReplyBatch?.sealed && githubReplyBatch.items.length > 1 ? { entry, sessionId, called: false } : undefined
+    const activeGithubReplyBatch = plan.githubReplyBatchActive ? { entry, sessionId, called: false } : undefined
     if (activeGithubReplyBatch) this.activeGithubReplyBatchMeta.set(key, activeGithubReplyBatch)
     let finalPhase: EventSession['phase'] = 'end'
     let turnModel: string | undefined
     let propagatingTurnError = false
-    const hopLimitNotice =
-      callMeta && hasReachedAgentCallHopLimit(p.sourceHopCount + 1) ? AGENT_CALL_HOP_LIMIT_NOTICE : undefined
+    const hopLimitNotice = plan.hopLimitNotice
     const currentAttributionInfo = async (): Promise<SlackAttributionInfo> => ({
       botName: agent.name,
       botUrl: this.agentLink(agentId),
@@ -9135,7 +9089,7 @@ export class Daemon {
       // sections then include it in their initial chat.postMessage, where Slack's
       // unfurl controls are supported; onFinal normally observes the same footer and
       // becomes a no-op instead of introducing URLs later through chat.update.
-      if (showFooter && turnChromeFor(p.platform).attributionFooter) {
+      if (plan.attributionFooterEnabled) {
         const attribution = buildAttributionBlocks(await currentAttributionInfo())
         p.attribution = { blocks: attribution.blocks, key: JSON.stringify(attribution.blocks) }
       }
@@ -9145,7 +9099,8 @@ export class Daemon {
       if (conv instanceof FeishuConverger) {
         for (const action of conv.onStart()) this.enqueueApply(p, action)
       }
-      if (!wasRunning) this.showActivity(replyConn, msg.channel, statusThread, 'is thinking…', statusOptions)
+      if (!plan.hostAlreadyRunning)
+        this.showActivity(replyConn, msg.channel, statusThread, 'is thinking…', statusOptions)
       // Post/refresh the session status bar up front — with the model now known (session
       // created) plus any usage carried over from prior turns — so it sits at the top of
       // the thread before the reply streams in.
@@ -9221,7 +9176,7 @@ export class Daemon {
       let generation = 0
       let regenerationStartedAt: number | undefined
       let regenerationApprovalWaitBaseline = 0
-      const codexUsageIsPerPrompt = this.isCodexRuntime(agentId)
+      const codexUsageIsPerPrompt = plan.codexUsageIsPerPrompt
 
       while (true) {
         if (p.stageAnswer) this.discardStagedAttempt(p)
@@ -9537,7 +9492,7 @@ export class Daemon {
         // A runtime may only publish its final session-scoped model during prompt.
         // Refresh before enqueueing the final body so any not-yet-sent section is born
         // with the final metadata; an already-sent section is updated in place below.
-        if (showFooter && turnChromeFor(p.platform).attributionFooter && finalAttributionInfo) {
+        if (plan.attributionFooterEnabled && finalAttributionInfo) {
           const attribution = buildAttributionBlocks(finalAttributionInfo)
           p.attribution = { blocks: attribution.blocks, key: JSON.stringify(attribution.blocks) }
         }

--- a/packages/daemon/src/daemon/turn-plan.ts
+++ b/packages/daemon/src/daemon/turn-plan.ts
@@ -1,0 +1,183 @@
+/**
+ * The pure decision layer of one dispatched turn (design §6.9): every choice
+ * `dispatchOne` makes from the agent snapshot, the inbound message and the
+ * registries, before it touches a host, a store row or a connection.
+ *
+ * Purity is the point. Anything that reads live daemon state (the sticky output
+ * mode, whether the host is already running, the compound mention addresses)
+ * enters as a pre-awaited input field rather than a call from inside the planner,
+ * so the whole plan is a total function of its input and can be unit-tested
+ * without booting a daemon.
+ */
+import { hasReachedAgentCallHopLimit, originKindOf } from '@agentconnect.md/protocol'
+import type { Agent } from '../agents/agent-schema.js'
+import type { NormalizedMessage } from '../messages/normalized.js'
+import { slackStatusOptions } from '../platforms/slack/turn-output.js'
+import { turnChromeFor } from '../platforms/turn-chrome.js'
+import { TurnOutputRegistry, type TurnOutputContext, type TurnOutputSurface } from '../platforms/turn-output.js'
+import { transcriptChannelKey } from '../store/local-store.js'
+import { AGENT_CALL_HOP_LIMIT_NOTICE } from './constants.js'
+import { loopGuardScope } from './loop-guard-scope.js'
+import { noneSuppressedApprovalSurface } from './tool-classification.js'
+import type { DaemonConverger, DaemonRenderAction, Pending, QueueEntry, SessionDeliveryBinding } from './turn-types.js'
+
+export type OutputMode = 'none' | 'minimal' | 'low' | 'medium' | 'high'
+
+type DaemonTurnOutputRegistry = TurnOutputRegistry<Pending, DaemonRenderAction, DaemonConverger, NormalizedMessage>
+type DaemonTurnOutputSurface = TurnOutputSurface<Pending, DaemonRenderAction, DaemonConverger, NormalizedMessage>
+
+export interface TurnPlanInput {
+  entry: QueueEntry
+  agent: Pick<Agent, 'name' | 'displayName' | 'iconUrl' | 'output'>
+  /** Logical session key for this turn. */
+  sessionKey: string
+  /** Stable evaluation turn id, minted before the plan so the harness closures can use it. */
+  evaluationTurnId: string
+  /** Pre-awaited `store.getOutputModeOverride(sessionKey)`; undefined ⇒ agent default. */
+  stickyOutputMode: OutputMode | undefined
+  /** `hostStarts.has(agentId) || modelSessionHosts.get(key)?.host !== undefined`, read cold. */
+  hostAlreadyRunning: boolean
+  /** `daemon.compoundMentionAddresses(agentId, msg)`. */
+  protectedAddresses: readonly string[]
+  /** Pre-computed `isCodexRuntime(agentId)` — it reads the runtime command config, not just the name. */
+  codexUsageIsPerPrompt: boolean
+  features: { turnFinalContextRefresh: boolean }
+  turnSurfaces: DaemonTurnOutputRegistry
+}
+
+export interface TurnPlan {
+  readonly sessionKey: string
+  readonly agentId: string
+  readonly agentName: string
+  readonly iconUrl?: string
+  readonly platform: string
+  readonly isDm: boolean
+  readonly channel: string
+  readonly thread?: string
+  readonly statusThread: string
+  readonly transcriptChannel: string
+  readonly integrationId?: string
+  readonly requesterId: string
+
+  readonly initializeOnly: boolean
+  readonly evaluationTurnId: string
+
+  readonly mode: OutputMode
+  readonly showFooter: boolean
+  readonly showStatusBar: boolean
+  readonly attributionFooterEnabled: boolean
+  readonly approvalSurfaceSuppressed: boolean
+
+  /** True when this turn takes the null-connection seam: headless, non-continuation webchat, or `none`. */
+  readonly suppressReplyConn: boolean
+  readonly startupActivityLabel: 'is thinking…' | 'is starting up…'
+  readonly hostAlreadyRunning: boolean
+
+  readonly turnSurface: DaemonTurnOutputSurface
+  readonly turnCtx: TurnOutputContext<NormalizedMessage>
+  readonly statusOptions: ReturnType<typeof slackStatusOptions>
+  readonly protectedAddresses: readonly string[]
+
+  readonly stageAnswer: boolean
+  readonly webchatRefresh: boolean
+  readonly loopGuardScope: string
+  readonly sourceHopCount: number
+  readonly hopLimitNotice?: string
+  readonly directAgentCall: boolean
+  readonly codexUsageIsPerPrompt: boolean
+
+  readonly githubTurnEligible: boolean
+  readonly githubReplyBatchActive: boolean
+  readonly deliveryBinding: SessionDeliveryBinding
+}
+
+/** Decide everything this turn can decide before it runs. Total over its input. */
+export function buildTurnPlan(input: TurnPlanInput): TurnPlan {
+  const { entry, agent, turnSurfaces } = input
+  const { agentId, msg, integrationId, webchat, callMeta, githubReply, hookContext } = entry
+  const agentName = agent.displayName?.trim() || agent.name
+  const iconUrl = agent.iconUrl
+  // Output verbosity for THIS turn: the sticky per-session override (status-bar picker)
+  // wins over the agent default. Resolved BEFORE the reply connection because `none` is a
+  // session-only mode — the converger records the reply into the transcript (via `recordOnly`
+  // posts) but delivers nothing to the IM, so it takes the same null-connection seam.
+  const mode: OutputMode = input.stickyOutputMode ?? agent.output.mode
+  // Footer visibility is an agent-level delivery choice, snapshotted for this turn alongside
+  // output mode. Turning it off removes attribution and session-link chrome on every platform.
+  const showFooter = agent.output.showFooter
+  // A headless cron fire has no platform target, and webchat streams through the relay reply
+  // sink instead — both leave the connection unset so every apply/status action no-ops.
+  // `none` joins them: only the converger's `recordOnly` bodies land in the transcript.
+  // A continuation turn keeps its platform connection: webchat is an additional sink (§5.2).
+  const suppressReplyConn = msg.headless || (webchat !== undefined && !webchat.continuation) || mode === 'none'
+  // §7.3: the platform's own production rules and its opaque per-turn state both come
+  // from its output surface. The converger itself is built per turn at the call site.
+  const turnSurface = turnSurfaces.for(msg.platform)
+  const turnCtx: TurnOutputContext<NormalizedMessage> = {
+    mode,
+    isDm: msg.isDm,
+    showFooter,
+    message: msg,
+    // send-message-routing-rework.md §5.3: compound shared-bot addresses this conversation
+    // can contain, so the splitter never cuts `<@U_SHARED> reviewer` in half.
+    protectedAddresses: input.protectedAddresses
+  }
+  const sourceHopCount = callMeta?.hopCount ?? 0
+  const githubReplyBatch = hookContext?.githubReviewBatch
+  return {
+    sessionKey: input.sessionKey,
+    agentId,
+    agentName,
+    ...(iconUrl ? { iconUrl } : {}),
+    platform: msg.platform,
+    isDm: msg.isDm,
+    channel: msg.channel,
+    ...(msg.thread !== undefined ? { thread: msg.thread } : {}),
+    statusThread: msg.thread ?? msg.msgId,
+    transcriptChannel: transcriptChannelKey(msg.channel, msg.transportScope),
+    ...(integrationId !== undefined ? { integrationId } : {}),
+    requesterId: msg.sender.id,
+    initializeOnly: callMeta?.initializeOnly === true,
+    evaluationTurnId: input.evaluationTurnId,
+    mode,
+    showFooter,
+    showStatusBar: agent.output.showStatusBar,
+    attributionFooterEnabled: showFooter && turnChromeFor(msg.platform).attributionFooter === true,
+    // True only when `none` removed THIS turn's chat-input permission card surface. Frozen for
+    // the turn so a mid-turn mode flip cannot desync policy from the cleared connection.
+    approvalSurfaceSuppressed: noneSuppressedApprovalSurface(mode, {
+      platform: msg.platform,
+      webchat,
+      headless: msg.headless
+    }),
+    suppressReplyConn,
+    // Cold/warm is captured BEFORE sessions.handle(), which boots the host via hostFor().
+    startupActivityLabel: input.hostAlreadyRunning ? 'is thinking…' : 'is starting up…',
+    hostAlreadyRunning: input.hostAlreadyRunning,
+    turnSurface,
+    turnCtx,
+    statusOptions: slackStatusOptions(msg.platform, agentName, iconUrl),
+    protectedAddresses: input.protectedAddresses,
+    stageAnswer:
+      input.features.turnFinalContextRefresh && !webchat && !githubReply && originKindOf(msg.platform) === 'chat',
+    webchatRefresh: input.features.turnFinalContextRefresh && !!webchat && msg.platform === 'webchat',
+    loopGuardScope: loopGuardScope(msg),
+    sourceHopCount,
+    ...(callMeta && hasReachedAgentCallHopLimit(sourceHopCount + 1)
+      ? { hopLimitNotice: AGENT_CALL_HOP_LIMIT_NOTICE }
+      : {}),
+    // CallMeta is the trusted distinction between a real A2A delivery and a synthetic
+    // `source: agent` wake; a webchat roster continuation is a post, not an address.
+    directAgentCall: callMeta !== undefined && callMeta.conversationContinuation !== true,
+    codexUsageIsPerPrompt: input.codexUsageIsPerPrompt,
+    githubTurnEligible:
+      githubReply !== undefined && entry.posterPublishState !== 'in_flight' && entry.posterPublishState !== 'settled',
+    githubReplyBatchActive: !!(githubReplyBatch?.sealed && githubReplyBatch.items.length > 1),
+    deliveryBinding: {
+      agentId,
+      platform: msg.platform,
+      ...(integrationId !== undefined ? { integrationId } : {}),
+      isDm: msg.isDm
+    }
+  }
+}

--- a/packages/daemon/test/turn-plan.test.ts
+++ b/packages/daemon/test/turn-plan.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest'
+import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
+import { buildTurnPlan, type TurnPlanInput } from '../src/daemon/turn-plan.js'
+import { AGENT_CALL_HOP_LIMIT_NOTICE } from '../src/daemon/constants.js'
+import { transcriptChannelKey } from '../src/store/local-store.js'
+import { TurnOutputRegistry, type TurnOutputSurface } from '../src/platforms/turn-output.js'
+import type { NormalizedMessage } from '../src/messages/normalized.js'
+import type {
+  CallMeta,
+  DaemonConverger,
+  DaemonRenderAction,
+  Pending,
+  QueueEntry,
+  WebchatTurnContext
+} from '../src/daemon/turn-types.js'
+
+/**
+ * The PURE half of one dispatched turn: every decision `dispatchOne` makes before
+ * it touches a host, a store row, or a connection. No daemon boot, no I/O.
+ */
+
+type Surface = TurnOutputSurface<Pending, DaemonRenderAction, DaemonConverger, NormalizedMessage>
+
+const surfaceFor = (platform: string): Surface =>
+  ({
+    platform,
+    createConverger: () => ({ label: platform }),
+    initialTurnState: () => ({ seed: platform }),
+    apply: async () => {}
+  }) as unknown as Surface
+
+const surfaces = new TurnOutputRegistry<Pending, DaemonRenderAction, DaemonConverger, NormalizedMessage>(
+  surfaceFor('slack')
+)
+for (const platform of ['telegram', 'discord', 'feishu']) surfaces.register(surfaceFor(platform))
+
+const message = (over: Partial<NormalizedMessage> = {}): NormalizedMessage =>
+  ({
+    msgId: 'm1',
+    traceId: 't1',
+    source: 'user',
+    platform: 'slack',
+    channel: 'C1',
+    sender: { id: 'U1', isBot: false },
+    text: 'hello',
+    mentionedBots: [],
+    isDm: false,
+    ...over
+  }) as NormalizedMessage
+
+const webchatCtx = (over: Partial<WebchatTurnContext> = {}): WebchatTurnContext =>
+  ({ conversationId: 'c1', turnId: 'wt1', sink: { done: () => {} }, ...over }) as unknown as WebchatTurnContext
+
+const entryFor = (over: Partial<QueueEntry> = {}): QueueEntry =>
+  ({ agentId: 'a1', msg: message(), initAbort: new AbortController(), ...over }) as unknown as QueueEntry
+
+const agentFor = (over: Partial<TurnPlanInput['agent']> = {}): TurnPlanInput['agent'] => ({
+  name: 'ada',
+  output: { mode: 'low', showFooter: true, showStatusBar: false },
+  ...over
+})
+
+const planFor = (over: Partial<TurnPlanInput> = {}) =>
+  buildTurnPlan({
+    entry: entryFor(),
+    agent: agentFor(),
+    sessionKey: 'slack:C1:T1',
+    evaluationTurnId: 'turn-1',
+    stickyOutputMode: undefined,
+    hostAlreadyRunning: true,
+    protectedAddresses: [],
+    codexUsageIsPerPrompt: false,
+    features: { turnFinalContextRefresh: true },
+    turnSurfaces: surfaces,
+    ...over
+  })
+
+describe('buildTurnPlan', () => {
+  it('lets a sticky output override win over the agent default, and falls back without one', () => {
+    expect(planFor({ stickyOutputMode: 'high' }).mode).toBe('high')
+    expect(planFor().mode).toBe('low')
+    expect(
+      planFor({ agent: agentFor({ output: { mode: 'medium', showFooter: true, showStatusBar: false } }) }).mode
+    ).toBe('medium')
+  })
+
+  it('takes the null-connection seam for headless, non-continuation webchat, and `none`', () => {
+    expect(planFor({ entry: entryFor({ msg: message({ headless: true }) }) }).suppressReplyConn).toBe(true)
+    expect(planFor({ entry: entryFor({ webchat: webchatCtx() }) }).suppressReplyConn).toBe(true)
+    // §5.2 dual sinks: a continuation keeps its platform connection.
+    expect(planFor({ entry: entryFor({ webchat: webchatCtx({ continuation: true }) }) }).suppressReplyConn).toBe(false)
+    expect(planFor({ stickyOutputMode: 'none' }).suppressReplyConn).toBe(true)
+    expect(planFor().suppressReplyConn).toBe(false)
+    // Mode wins even over a continuation's dual sink.
+    expect(
+      planFor({ stickyOutputMode: 'none', entry: entryFor({ webchat: webchatCtx({ continuation: true }) }) })
+        .suppressReplyConn
+    ).toBe(true)
+  })
+
+  it('suppresses the approval surface only for a `none` Slack turn with a live chat surface', () => {
+    expect(planFor({ stickyOutputMode: 'none' }).approvalSurfaceSuppressed).toBe(true)
+    for (const platform of ['telegram', 'discord', 'feishu', 'webchat']) {
+      expect(
+        planFor({ stickyOutputMode: 'none', entry: entryFor({ msg: message({ platform }) }) }).approvalSurfaceSuppressed
+      ).toBe(false)
+    }
+    expect(
+      planFor({ stickyOutputMode: 'none', entry: entryFor({ webchat: webchatCtx() }) }).approvalSurfaceSuppressed
+    ).toBe(false)
+    expect(
+      planFor({ stickyOutputMode: 'none', entry: entryFor({ msg: message({ headless: true }) }) })
+        .approvalSurfaceSuppressed
+    ).toBe(false)
+    expect(planFor().approvalSurfaceSuppressed).toBe(false)
+  })
+
+  it('labels startup activity by whether the host is already running', () => {
+    expect(planFor({ hostAlreadyRunning: true }).startupActivityLabel).toBe('is thinking…')
+    expect(planFor({ hostAlreadyRunning: false }).startupActivityLabel).toBe('is starting up…')
+  })
+
+  it('routes the final context refresh to exactly one of stageAnswer / webchatRefresh', () => {
+    const chat = planFor()
+    expect([chat.stageAnswer, chat.webchatRefresh]).toEqual([true, false])
+
+    const wc = planFor({
+      entry: entryFor({ webchat: webchatCtx(), msg: message({ platform: 'webchat' }) })
+    })
+    expect([wc.stageAnswer, wc.webchatRefresh]).toEqual([false, true])
+
+    const off = planFor({ features: { turnFinalContextRefresh: false } })
+    expect([off.stageAnswer, off.webchatRefresh]).toEqual([false, false])
+
+    const gh = planFor({ entry: entryFor({ githubReply: { owner: 'o' } as never }) })
+    expect([gh.stageAnswer, gh.webchatRefresh]).toEqual([false, false])
+  })
+
+  it('enables the attribution footer only where the platform has that chrome', () => {
+    expect(planFor().attributionFooterEnabled).toBe(true)
+    const telegram = planFor({ entry: entryFor({ msg: message({ platform: 'telegram' }) }) })
+    expect(telegram.showFooter).toBe(true)
+    expect(telegram.attributionFooterEnabled).toBe(false)
+    expect(
+      planFor({ agent: agentFor({ output: { mode: 'low', showFooter: false, showStatusBar: false } }) })
+        .attributionFooterEnabled
+    ).toBe(false)
+  })
+
+  it('carries the hop-limit notice only for a call that reaches the limit', () => {
+    const call = (hopCount: number): CallMeta => ({ hopCount }) as unknown as CallMeta
+    expect(planFor({ entry: entryFor({ callMeta: call(MAX_AGENT_CALL_HOPS - 1) }) }).hopLimitNotice).toBe(
+      AGENT_CALL_HOP_LIMIT_NOTICE
+    )
+    expect(planFor({ entry: entryFor({ callMeta: call(MAX_AGENT_CALL_HOPS - 2) }) }).hopLimitNotice).toBeUndefined()
+    // A human turn is depth 0 and never carries the notice, whatever the limit.
+    expect(planFor().hopLimitNotice).toBeUndefined()
+  })
+
+  it('gates a github turn on the poster publish state', () => {
+    const githubReply = { owner: 'o' } as never
+    expect(planFor({ entry: entryFor({ githubReply }) }).githubTurnEligible).toBe(true)
+    expect(planFor({ entry: entryFor({ githubReply, posterPublishState: 'not_started' }) }).githubTurnEligible).toBe(
+      true
+    )
+    for (const posterPublishState of ['in_flight', 'settled'] as const) {
+      expect(planFor({ entry: entryFor({ githubReply, posterPublishState }) }).githubTurnEligible).toBe(false)
+    }
+    expect(planFor().githubTurnEligible).toBe(false)
+  })
+
+  it('activates a github reply batch only when it is sealed and holds more than one item', () => {
+    const batch = (over: Record<string, unknown>) => entryFor({ hookContext: { githubReviewBatch: over } as never })
+    expect(planFor({ entry: batch({ sealed: true, items: [1, 2] }) }).githubReplyBatchActive).toBe(true)
+    expect(planFor({ entry: batch({ sealed: true, items: [1] }) }).githubReplyBatchActive).toBe(false)
+    expect(planFor({ entry: batch({ sealed: false, items: [1, 2] }) }).githubReplyBatchActive).toBe(false)
+    expect(planFor().githubReplyBatchActive).toBe(false)
+  })
+
+  it('keys the transcript channel by channel plus transport scope', () => {
+    expect(planFor().transcriptChannel).toBe(transcriptChannelKey('C1', undefined))
+    const scoped = planFor({ entry: entryFor({ msg: message({ transportScope: 'bot-7' }) }) })
+    expect(scoped.transcriptChannel).toBe(transcriptChannelKey('C1', 'bot-7'))
+    const nulled = planFor({ entry: entryFor({ msg: message({ transportScope: null as never }) }) })
+    expect(nulled.transcriptChannel).toBe(transcriptChannelKey('C1', null))
+  })
+
+  it('falls the status thread back to the message id at a channel root', () => {
+    expect(planFor().statusThread).toBe('m1')
+    expect(planFor({ entry: entryFor({ msg: message({ thread: 'T9' }) }) }).statusThread).toBe('T9')
+  })
+
+  it('is deterministic — the same input plans the same turn', () => {
+    const entry = entryFor({ msg: message({ thread: 'T9', transportScope: 'bot-7' }), callMeta: {} as CallMeta })
+    const input = { entry, protectedAddresses: ['<@U_SHARED> reviewer'] }
+    const a = planFor(input)
+    const b = planFor(input)
+    expect(a).toEqual(b)
+    // A fresh turn context per plan — the converger it seeds must never be shared.
+    expect(a.turnCtx).not.toBe(b.turnCtx)
+    expect(a.turnCtx).toEqual(b.turnCtx)
+  })
+})


### PR DESCRIPTION
PR-1 of the `dispatchOne` decomposition. Pure moves and pure functions only — no behavior change.

## What moved

New `packages/daemon/src/daemon/turn-plan.ts` — `buildTurnPlan(input): TurnPlan`, a total function of the queue entry, the agent snapshot, `cfg.features`, the turn-output registry, and a handful of pre-awaited scalars. It decides:

- `agentName` / `iconUrl` / `statusOptions`, `statusThread`, `transcriptChannel` (the old `currentTranscriptChannel()` closure collapses to one field)
- `mode` (sticky override wins over the agent default) and the chrome snapshot `showFooter` / `showStatusBar` / `attributionFooterEnabled`
- `suppressReplyConn` — the null-connection seam predicate (headless / non-continuation webchat / `none`), with the continuation dual-sink preserved verbatim
- `startupActivityLabel` from `hostAlreadyRunning`, shared by both `showActivity` call sites
- `turnSurface` + `turnCtx` (the converger and turn state are still constructed at the call site — a fresh converger per turn, never memoized)
- `initializeOnly`, `stageAnswer`, `webchatRefresh`, `loopGuardScope`, `approvalSurfaceSuppressed`, `sourceHopCount`, `hopLimitNotice`, `directAgentCall`, `codexUsageIsPerPrompt`, `githubTurnEligible`, `githubReplyBatchActive`, `deliveryBinding`

Anything that reads live daemon state enters as an input field instead of a call inside the planner: `stickyOutputMode` (`store.getOutputModeOverride`), `hostAlreadyRunning`, `protectedAddresses`, `codexUsageIsPerPrompt`, `features`, `turnSurfaces`. In `dispatchOne` the `Map.set` for the delivery binding, `restoreDeliveryBinding`, the `Object.assign` onto the shared `webchat` object, and every store/host interaction stay exactly where they were.

Deviation from the spec, worth a note: `codexUsageIsPerPrompt` is passed in already computed rather than derived from a `runtime: string` input — `isCodexRuntime` reads the runtime's configured command/args, not just the runtime name, so deriving it inside the planner would not have been pure. No same-name shells were kept; `dispatchOne` destructures the plan's widely-used scalars and reads the rest as `plan.*`.

## Invariants preserved

- `mode` is resolved before the reply connection — now structurally, since one expression returns both
- `showActivity` still fires before `holdReplyConnection` and before `sessions.handle()`
- `approvalSurfaceSuppressed` still comes from the same `mode` the connection decision used, never a second store read
- The `Pending` literal keeps every field; it now initializes the read-only ones from the plan

## Tests

Added `packages/daemon/test/turn-plan.test.ts` (12 cases, pure, no daemon boot): sticky-mode precedence, the null-connection seam matrix including the continuation dual sink and `none` winning over it, the `approvalSurfaceSuppressed` platform matrix, the startup label, the `stageAnswer`/`webchatRefresh` truth table, footer-vs-platform-chrome, hop-limit notice, github eligibility and batch activation, transcript-channel keying (including a `null` transport scope), status-thread fallback, and determinism (deep-equal plans, fresh `turnCtx`).

Verification: `pnpm --filter @agentconnect.md/daemon typecheck`, prettier + eslint on the touched files, and `vitest run` over `turn-plan`, `daemon-smoke`, `daemon-serial-gate`, `turn-output-seam`, `daemon-webchat`, `attribution`, `daemon-interrupt-safety`, `durable-inbox`, `turn-output-workflow`, `webchat-turn-refresh`, both webchat-continuation suites, `daemon-permission-autoallow`, `turn-chrome`, `daemon-hook`, `daemon-message-agent`, `daemon-transcript`, `evaluation-events`, `session-manager`, `daemon-lifecycle`, `render`, `feishu-streaming-card`, `daemon-commands`, `daemon-loop-guard-pool`, `daemon-platform-authorship`, `telegram-threading`, `daemon-agent-mention-routing`, `daemon-remote-mcp-admission`, `daemon-duty-inbox-replay`, `daemon-runtime-auth` — 874 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)