### PR TITLE
refactor(daemon): unify the cold-session re-checks into a named fence

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -407,6 +407,8 @@ import {
   turnState,
   LIVE_CHROME_BOUNDARY_MESSAGE_TYPES,
   type CallMeta,
+  type ColdFenceContext,
+  type ColdFenceSite,
   type DaemonConverger,
   type DaemonRenderAction,
   type LiveChromeBoundaryMessageType,
@@ -8264,6 +8266,61 @@ export class Daemon {
     return undefined
   }
 
+  /** One named fence for the cold-session window: re-read the dispatch gate and, when it is open,
+   *  unwind exactly the state this call point owns. Returns the reason, or undefined to continue.
+   *  Throws LifecycleCleanupBlockedError instead of returning when cleanup stayed blocked. */
+  private async coldSessionFence(
+    entry: QueueEntry,
+    key: string,
+    site: ColdFenceSite,
+    ctx: ColdFenceContext
+  ): Promise<TurnInterruptReason | undefined> {
+    const gate = await this.dispatchGateReason(entry)
+    if (!gate) return undefined
+    ctx.finishEvaluation('turn.cancelled', { reason: gate })
+    let cleanupOutcome: TurnLifecycleCleanupOutcome | undefined
+    if (site === 'initialized') {
+      await this.finishSessionInitialization(entry.agentId)
+      ctx.restoreDeliveryBinding?.()
+      // session/new|load can return after host termination. Do not publish idle until cleanup settles.
+      cleanupOutcome = await this.waitForTurnLifecycleCleanup(entry, key, entry.selectedHost)
+      if (!cleanupOutcome.blocked) {
+        const interruptedSession = await this.store.getSession(key)
+        if (ctx.created === true && ctx.sessionId !== undefined && interruptedSession?.acpSessionId === ctx.sessionId) {
+          // The runtime created this ACP session after the turn was already terminal. Do not let a
+          // quick pause→unpause (or loop reset) revive that never-prompted session as valid state.
+          await this.store.upsertSession({
+            ...interruptedSession,
+            acpSessionId: null,
+            state: 'idle',
+            lastDeliveredTs: null,
+            updatedAt: this.clock.now()
+          })
+        } else {
+          await this.store.setSessionState(key, 'idle', this.clock.now())
+        }
+      }
+    }
+    if (site !== 'admitted') ctx.clearActivity?.()
+    this.terminateQueuedSink(entry)
+    if (site === 'initialized') ctx.releaseReplyConn?.()
+    if (entry.hookContext && this.reportsHookOutcome(entry)) {
+      // Only the ready fence has a session id to attribute the cancellation to.
+      const payload =
+        site === 'ready' && ctx.sessionId !== undefined ? { sessionId: ctx.sessionId, reason: gate } : { reason: gate }
+      await this.emitHookCompletion(entry.hookContext, 'failed', payload, entry)
+    }
+    this.log.info(`dispatch: skipped ${site} turn ${entry.msg.msgId} (${gate})`)
+    if (cleanupOutcome?.blocked) throw new LifecycleCleanupBlockedError(key, cleanupOutcome.error)
+    return gate
+  }
+
+  /** The cold-start catch: was this a cancel or a genuine start failure? Same predicate as the
+   *  fences, but the reaction is a classification inside a catch, not a state unwind. */
+  private async classifyColdStartFailure(entry: QueueEntry): Promise<TurnInterruptReason | undefined> {
+    return await this.dispatchGateReason(entry)
+  }
+
   private beginActiveDispatch(agentId: string, key: string): () => void {
     let resolveDone!: () => void
     const done = new Promise<void>((resolve) => (resolveDone = resolve))
@@ -8525,16 +8582,8 @@ export class Daemon {
     }
     // Pause/loop protection may race admission after dispatch() checked its gate but
     // before this loop starts. `cancelledReason` also remembers a quick reset.
-    const initialGate = await this.dispatchGateReason(entry)
-    if (initialGate) {
-      finishEvaluation('turn.cancelled', { reason: initialGate })
-      this.terminateQueuedSink(entry)
-      if (hookContext && this.reportsHookOutcome(entry)) {
-        await this.emitHookCompletion(hookContext, 'failed', { reason: initialGate }, entry)
-      }
-      this.log.info(`dispatch: skipped admitted turn ${msg.msgId} (${initialGate})`)
-      return null
-    }
+    const initialGate = await this.coldSessionFence(entry, key, 'admitted', { finishEvaluation })
+    if (initialGate) return null
     if (hookContext && !hookContext.turnStartedAt) {
       hookContext.turnStartedAt = new Date(this.clock.now()).toISOString()
       try {
@@ -8717,7 +8766,7 @@ export class Daemon {
       restoreDeliveryBinding()
       // handle() boots the host (hostFor → ensureHostAsync → host.start()), so a
       // failed agent start / ACP handshake surfaces HERE, before the prompt below.
-      const interrupted = await this.dispatchGateReason(entry)
+      const interrupted = await this.classifyColdStartFailure(entry)
       let cleanupOutcome!: TurnLifecycleCleanupOutcome
       try {
         // Keep this cold dispatch owned and non-idle until host cleanup settles.
@@ -8779,41 +8828,15 @@ export class Daemon {
     // pause landed in that window, no Pending existed for the transition hook to cancel.
     // Re-check before publishing metadata or prompting, restore the new row to idle, and
     // clear the transient Slack activity indicator.
-    const initializedGate = await this.dispatchGateReason(entry)
-    if (initializedGate) {
-      finishEvaluation('turn.cancelled', { reason: initializedGate })
-      await this.finishSessionInitialization(agentId)
-      restoreDeliveryBinding()
-      // session/new|load can return after host termination. Do not publish idle
-      // until cleanup has settled.
-      const cleanupOutcome = await this.waitForTurnLifecycleCleanup(entry, key, entry.selectedHost)
-      if (!cleanupOutcome.blocked) {
-        const interruptedSession = await this.store.getSession(key)
-        if (created && interruptedSession?.acpSessionId === sessionId) {
-          // The runtime created this ACP session after the turn was already terminal.
-          // Do not let a quick pause→unpause (or loop reset) revive that never-prompted
-          // session as if it were valid conversation state.
-          await this.store.upsertSession({
-            ...interruptedSession,
-            acpSessionId: null,
-            state: 'idle',
-            lastDeliveredTs: null,
-            updatedAt: this.clock.now()
-          })
-        } else {
-          await this.store.setSessionState(key, 'idle', this.clock.now())
-        }
-      }
-      this.showActivity(replyConn, msg.channel, statusThread, '')
-      this.terminateQueuedSink(entry)
-      releaseReplyConn()
-      if (hookContext && this.reportsHookOutcome(entry)) {
-        await this.emitHookCompletion(hookContext, 'failed', { reason: initializedGate }, entry)
-      }
-      this.log.info(`dispatch: skipped initialized turn ${msg.msgId} (${initializedGate})`)
-      if (cleanupOutcome.blocked) throw new LifecycleCleanupBlockedError(key, cleanupOutcome.error)
-      return null
-    }
+    const initializedGate = await this.coldSessionFence(entry, key, 'initialized', {
+      finishEvaluation,
+      clearActivity: () => this.showActivity(replyConn, msg.channel, statusThread, ''),
+      releaseReplyConn,
+      restoreDeliveryBinding,
+      sessionId,
+      created
+    })
+    if (initializedGate) return null
     // A cold session can await workspace/host/session initialization while the Agent is
     // reconciled. Persist staged first-turn choices only against the current authority,
     // never the Agent snapshot captured before sessions.handle().
@@ -9056,16 +9079,13 @@ export class Daemon {
       // Pause/loop protection may land while a slow host is starting or sticky
       // overrides are being restored. At this point Pending exists but no prompt has
       // begun; re-check so a cancel that had no live host cannot race into new work.
-      const readyGate = await this.dispatchGateReason(entry)
+      const readyGate = await this.coldSessionFence(entry, key, 'ready', {
+        finishEvaluation,
+        clearActivity: () => this.showActivity(replyConn, msg.channel, statusThread, ''),
+        sessionId
+      })
       if (readyGate) {
-        finishEvaluation('turn.cancelled', { reason: readyGate })
-        this.showActivity(replyConn, msg.channel, statusThread, '')
-        this.terminateQueuedSink(entry)
         if (readyGate === 'loop protection') finalPhase = 'problem'
-        if (hookContext && this.reportsHookOutcome(entry)) {
-          await this.emitHookCompletion(hookContext, 'failed', { sessionId, reason: readyGate }, entry)
-        }
-        this.log.info(`dispatch: skipped ready turn ${msg.msgId} (${readyGate})`)
         return null
       }
       // Capture the model for THIS session/turn after sticky overrides are applied.

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -289,6 +289,26 @@ export interface QueueEntry {
   inboxHandedOff?: boolean
 }
 
+/** Where in the cold-session window a fence sits. The site name is also the log label, and it
+ *  selects which unwind steps the call point owns — see `Daemon.coldSessionFence`. */
+export type ColdFenceSite = 'admitted' | 'initialized' | 'ready'
+
+/** The per-turn handles a cold fence needs to unwind its call point's state. Which fields are
+ *  read depends on the site: `admitted` runs before any host work and uses only the reporter. */
+export interface ColdFenceContext {
+  finishEvaluation: (type: 'turn.cancelled', data: Record<string, unknown>) => void
+  /** Clear the transient platform activity indicator. Unused at `admitted` — none is showing yet. */
+  clearActivity?: () => void
+  /** Release the reply-connection lease. Only `initialized` owns it; `ready` leaves it to the outer finally. */
+  releaseReplyConn?: () => void
+  /** Undo the delivery-binding install done before session/new|load. */
+  restoreDeliveryBinding?: () => void
+  /** The ACP session id, once known. `ready` reports it in the hook payload. */
+  sessionId?: string
+  /** sessions.handle() created this ACP session on this very turn. */
+  created?: boolean
+}
+
 export interface MemoryExtractionCollector {
   chunks: string[]
   sessionKey?: string

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -477,6 +477,84 @@ describe('Daemon interrupt safety gates', () => {
     }
   }, 15_000)
 
+  // The cold fence's 'initialized' site owns the created-session nulling: a session/new that
+  // lands after the turn went terminal must not survive as revivable conversation state.
+  it('nulls out an ACP session created after a cold cancel, and leaves a rebound row alone', async () => {
+    const runCase = async (rebind: boolean) => {
+      const clock = new FakeClock()
+      let releaseSession!: () => void
+      const sessionBlocked = new Promise<void>((resolve) => (releaseSession = resolve))
+      const host = {
+        start: vi.fn(async () => {}),
+        newSession: vi.fn(async () => {
+          await sessionBlocked
+          return 'late-session'
+        }),
+        hasSession: vi.fn(() => true),
+        modelOptions: vi.fn(() => null),
+        prompt: vi.fn(async () => ({ stopReason: 'end_turn' })),
+        cancel: vi.fn(async () => {}),
+        stop: vi.fn(async () => {})
+      }
+      const daemon = new Daemon({
+        slackAppFactory: fakeSlackAppFactory(),
+        root: scaffold(),
+        hostFactory: () => host as any,
+        clock
+      })
+      const stream = webchatSink()
+      await daemon.start()
+      const key = (daemon as any).webchatTransport.webchatSessionKey(CONV_1, AGENT_ID)
+      try {
+        const ack = await (daemon as any).webchatTransport.dispatchWebchatTurn(
+          AGENT_ID,
+          CONV_1,
+          'cold',
+          'alice',
+          stream.sink
+        )
+        expect(ack.accepted).toBe(true)
+        await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
+
+        if (rebind) {
+          // Stand in for a later turn that rebound the row after session/new wrote it: the
+          // fence awaits cleanup before reading the row back, so land the rebind in there.
+          const original = (daemon as any).waitForTurnLifecycleCleanup.bind(daemon)
+          ;(daemon as any).waitForTurnLifecycleCleanup = async (...args: unknown[]) => {
+            const outcome = await original(...args)
+            const row = await (daemon as any).store.getSession(key)
+            await (daemon as any).store.upsertSession({
+              ...row,
+              acpSessionId: 'next-turn-session',
+              lastDeliveredTs: '999',
+              updatedAt: clock.now()
+            })
+            return outcome
+          }
+        }
+        await (daemon as any).webchatTransport.handleWebchatCancel(CONV_1)
+        releaseSession()
+        await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
+        expect(host.prompt).not.toHaveBeenCalled()
+
+        const settled = await (daemon as any).store.getSession(key)
+        expect(settled.state).toBe('idle')
+        if (rebind) {
+          expect(settled.acpSessionId).toBe('next-turn-session')
+          expect(settled.lastDeliveredTs).toBe('999')
+        } else {
+          expect(settled.acpSessionId).toBeNull()
+          expect(settled.lastDeliveredTs).toBeNull()
+        }
+      } finally {
+        releaseSession()
+        await daemon.stop()
+      }
+    }
+    await runCase(false)
+    await runCase(true)
+  }, 30_000)
+
   it('keeps host respawn gated until an existing host teardown settles', async () => {
     let releaseStop!: () => void
     const stopBlocked = new Promise<void>((resolve) => (releaseStop = resolve))


### PR DESCRIPTION
PR-2 of the `dispatchOne` decomposition (PR-1, TurnPlan, was #1237).

## What moved

`dispatchOne` re-read the dispatch gate at **four** points in the cold-session window. The *predicate* was already unified as `dispatchGateReason`; the *reaction* at each site was spelled out inline, and the four bodies differ in subtle, load-bearing ways.

Three of them are genuine fences and now share one named helper:

```ts
private async coldSessionFence(entry, key, site: ColdFenceSite, ctx: ColdFenceContext)
  : Promise<TurnInterruptReason | undefined>
```

| site | position | owns |
|---|---|---|
| `admitted` | before `bindSessionSource`, before any host work | evaluation + `terminateQueuedSink(entry)` + hook completion + log |
| `initialized` | after `sessions.handle()` returned, before metadata/prompting | + `finishSessionInitialization`, `restoreDeliveryBinding`, `waitForTurnLifecycleCleanup`, the created-session nulling, `releaseReplyConn`, the `LifecycleCleanupBlockedError` rethrow |
| `ready` | after `Pending` exists, before `host.prompt` | evaluation + clear activity + `terminateQueuedSink` + hook completion **with `sessionId`** |

The site name doubles as the log label, so `dispatch: skipped {admitted,initialized,ready} turn …` is emitted from one place.

The fourth site is **not** a fence and was deliberately not folded in. It is a classifier inside the `catch` of `sessions.handle()` that selects between `terminateQueuedSink(entry, interrupted)` and `surfaceTurnFailure(...)`, and it must run after `finishSessionInitialization` + `restoreDeliveryBinding` and *before* `waitForTurnLifecycleCleanup`, whose outcome then gates the session-row writes. It gets a name and a doc comment instead:

```ts
/** The cold-start catch: was this a cancel or a genuine start failure? */
private async classifyColdStartFailure(entry: QueueEntry)
```

`ColdFenceSite` / `ColdFenceContext` live in `src/daemon/turn-types.ts` alongside `QueueEntry` and `TurnInterruptReason`.

## Behavior

Byte-identical. The per-site differences that the unification had to preserve, and does:

- `terminateQueuedSink(entry)` **without** a reason at every fence — only the cold-start catch passes one.
- `releaseReplyConn()` at `initialized` only; `ready` leaves the lease to the outer `finally`, `admitted` does not hold one yet.
- `waitForTurnLifecycleCleanup` at `initialized` only; the outer `finally` owns it for `ready`.
- The **created-session nulling** (`acpSessionId: null`, `lastDeliveredTs: null`) stays gated on `created === true && row.acpSessionId === sessionId`, with `setSessionState(key,'idle')` as the else branch.
- The hook-completion payload carries `sessionId` at `ready` and nowhere else.
- `finalPhase = 'problem'` on `'loop protection'` stays at the call site — it is `try`-scoped state that PR-3 owns.
- `LifecycleCleanupBlockedError` still throws before the caller's `return null`.

No shells were kept: every call site holds the new methods directly.

## Tests

Added `nulls out an ACP session created after a cold cancel, and leaves a rebound row alone` to `test/daemon-interrupt-safety.test.ts` — the created-session nulling is the only thing preventing a quick pause→unpause from reviving a never-prompted ACP session, and nothing covered it directly. Verified it fails (`expected 'late-session' to be null`) when the branch is disabled. The negative half asserts a row a later turn already rebound is left alone.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean
- `daemon-interrupt-safety`, `daemon-serial-gate`, `daemon-loop-guard-pool`, `durable-inbox`, `daemon-webchat`, `daemon-hook`, `daemon-smoke`, `turn-plan` — 232 passed
- `prettier --check` + `eslint` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)