### PR TITLE
feat(daemon): browse a secondary root's files and git on a cluster agent

### DIFF
--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -164,7 +164,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
     // Derived from the SCOPE's own target, not the primary workspace's credential mode: a manual
     // GitHub workspace may authorize an App-covered repository, whose secondary root then needs the
     // helper the primary does not. The helper itself is URL-routed, so it only answers for that root.
-    (id, repo) => (workspaceScope.target(id, repo)?.githubApp ? gitCredentialEnv(id) : {}),
+    (id, repo) => (workspaceScope.usesGithubApp(id, repo) ? gitCredentialEnv(id) : {}),
     workspaceScope.target,
     // Registered on `register/ok` only, and reset by every reconnect — a console commit is
     // refused as data whenever it is absent (workspace-git.ts explains why).

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -217,7 +217,8 @@ export function createWorkspaceGit(
   credentialEnvByAgent: (agentId: string, repo?: string) => Record<string, string> = () => ({}),
   /** The origin and branch of the scope being operated on — the agent's primary workspace, or the
    *  secondary root `repo` names. A pull reaches THAT repository's remote, never the primary's. */
-  workspaceTargetByAgent: (agentId: string, repo?: string) => WorkspaceGitTarget | undefined = () => undefined,
+  workspaceTargetByAgent: (agentId: string, repo?: string) => Promise<WorkspaceGitTarget | undefined> = async () =>
+    undefined,
   /** The identity the CP registered on `register/ok`. Absent ⇒ a console commit is REFUSED as
    *  data: git would otherwise guess the host operator's passwd identity and attribute the
    *  commit to them, which is worse than not committing. */
@@ -281,7 +282,7 @@ export function createWorkspaceGit(
     git: GitRunner,
     repo?: string
   ): Promise<{ origin: string; branch: string } | undefined> {
-    const target = workspaceTargetByAgent(agentId, repo)
+    const target = await workspaceTargetByAgent(agentId, repo)
     let currentOrigin: string | undefined
     let expectedOrigin: string
     try {
@@ -491,7 +492,7 @@ export function createWorkspaceGit(
       // `dev/<user>/<words>` wants the commits it adds over the base branch, not the repository's
       // history — the base's newest commit is not this session's work. On the base branch itself
       // there is nothing to exclude, so the full history stands (the agent workspace page's view).
-      const baseRef = await logBaseRef(git, workspaceTargetByAgent(req.agentId, req.repo)?.branch)
+      const baseRef = await logBaseRef(git, (await workspaceTargetByAgent(req.agentId, req.repo))?.branch)
       const range = baseRef ? `${baseRef}..HEAD` : 'HEAD'
 
       // One extra row proves there are more commits than the caller asked for.

--- a/packages/daemon/src/cp/workspace-scope.ts
+++ b/packages/daemon/src/cp/workspace-scope.ts
@@ -40,7 +40,9 @@ export interface WorkspaceScope {
   location(agentId: string, sessionId?: string, repo?: string): Promise<WorkspaceLocation | undefined>
   gitRoot(agentId: string, sessionId?: string, repo?: string): Promise<string | undefined>
   /** The origin and branch a network git operation on this scope may reach. */
-  target(agentId: string, repo?: string): WorkspaceGitTarget | undefined
+  target(agentId: string, repo?: string): Promise<WorkspaceGitTarget | undefined>
+  /** Whether git on this scope rides the daemon credential helper; answered without touching any volume. */
+  usesGithubApp(agentId: string, repo?: string): boolean
 }
 
 export function createWorkspaceScope(deps: WorkspaceScopeDeps): WorkspaceScope {
@@ -70,7 +72,7 @@ export function createWorkspaceScope(deps: WorkspaceScopeDeps): WorkspaceScope {
     repo: string,
     sessionId?: string
   ): Promise<LocalLocation | undefined> => {
-    const root = deps.workspaces.consoleSecondaryRoot(agent, repo)
+    const root = await deps.workspaces.consoleSecondaryRoot(agent, repo)
     if (!root) return undefined
     // A secondary root is a git checkout whatever the primary workspace mode is — never scratch.
     if (!sessionId) return { root: root.path, scratch: false }
@@ -106,11 +108,11 @@ export function createWorkspaceScope(deps: WorkspaceScopeDeps): WorkspaceScope {
   return {
     location,
     gitRoot: async (agentId, sessionId, repo) => (await location(agentId, sessionId, repo))?.root,
-    target: (agentId, repo) => {
+    target: async (agentId, repo) => {
       const agent = deps.agentOf(agentId)
       if (!agent) return undefined
       if (repo !== undefined) {
-        const root = deps.workspaces.consoleSecondaryRoot(agent, repo)
+        const root = await deps.workspaces.consoleSecondaryRoot(agent, repo)
         // Rows exist only for App-covered repositories, so a secondary root always rides the helper;
         // the branch is the one its `.materialization.json` attests, never the primary's.
         return root ? { repo: root.cloneUrl, branch: root.branch, githubApp: true } : undefined
@@ -119,6 +121,12 @@ export function createWorkspaceScope(deps: WorkspaceScopeDeps): WorkspaceScope {
       return workspace.mode === 'git-repo' && workspace.gitRepo
         ? { repo: workspace.gitRepo, branch: workspace.gitBranch, githubApp: workspace.gitCredential === 'github-app' }
         : undefined
+    },
+    usesGithubApp: (agentId, repo) => {
+      const workspace = deps.agentOf(agentId)?.workspace
+      // Rows exist only for App-covered repositories, so a secondary root always rides the helper.
+      if (repo !== undefined) return workspace !== undefined
+      return workspace?.mode === 'git-repo' && workspace.gitCredential === 'github-app'
     }
   }
 }

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -372,11 +372,14 @@ export class WorkspaceManager {
    * A root the disk does not attest yet is still returned: its checkout simply does not exist, and
    * that reads as an empty workspace rather than an error (the browser's `exists:false`).
    */
-  consoleSecondaryRoot(agent: Agent, repoFullName: string): SecondaryWorkspaceRoot | undefined {
+  /** The secondary root the console browses, in the coordinates that hold it (a pod mount under --k8s). */
+  async consoleSecondaryRoot(agent: Agent, repoFullName: string): Promise<SecondaryWorkspaceRoot | undefined> {
     const wanted = repoKey(repoFullName)
-    const root = this.secondaryRoots(agent).find((entry) => repoKey(entry.repoFullName) === wanted)
+    const root = this.secondaryRootsFor(agent).find((entry) => repoKey(entry.repoFullName) === wanted)
     if (!root) return undefined
-    const recorded = readSecondaryMaterialization(join(dirname(root.path), SECONDARY_MATERIALIZATION_FILE))
+    const recorded = parseSecondaryMaterialization(
+      await this.fsFor(agent.id).readFile(join(dirname(root.path), SECONDARY_MATERIALIZATION_FILE))
+    )
     // Identity is the numeric repo id, exactly as materialization checks it: a subtree left by a
     // DIFFERENT repository that once held this slug attests nothing about this root's branch.
     return recorded?.repoId === root.repoId ? { ...root, branch: recorded.branch } : root
@@ -1713,9 +1716,8 @@ export class WorkspaceManager {
     repoScope?: string
   ): string | undefined {
     if (local === undefined || !this.sandboxMode) return local
-    // A cluster daemon materializes ONE checkout through the shim tunnel, so a secondary root has
-    // nowhere to live there yet — answer with no root rather than serving the primary's files.
-    if (repoScope !== undefined) return undefined
+    // A secondary root's location already came from the mount-aware roots, so it needs no translation.
+    if (repoScope !== undefined) return local
     return this.clusterSessionRootAt(agent, runtimeRoot, request)
   }
 
@@ -2264,16 +2266,6 @@ export function parseSymrefDefaultBranch(out: string): string | undefined {
     if (branch && !branch.startsWith('-')) return branch
   }
   return undefined
-}
-
-/** The same attestation off THIS disk, for the console seam, which answers synchronously and whose
- *  cluster branch discards the answer before it is used. */
-function readSecondaryMaterialization(file: string): SecondaryMaterialization | undefined {
-  try {
-    return parseSecondaryMaterialization(readFileSync(file, 'utf8'))
-  } catch {
-    return undefined
-  }
 }
 
 /** A secondary root's attestation as the seam read it; undefined for absent, unreadable or partial. */

--- a/packages/daemon/test/workspace-repo-scope.test.ts
+++ b/packages/daemon/test/workspace-repo-scope.test.ts
@@ -9,6 +9,7 @@ import { createWorkspaceReader, WorkspaceViolationError } from '../src/cp/worksp
 import { createWorkspaceScope, type WorkspaceScopeSession } from '../src/cp/workspace-scope.js'
 import { workspaceGitLocalEnv } from '../src/workspace/git-injection.js'
 import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
+import { PodWorkspaceFs } from './fixtures/pod-workspace-fs.js'
 
 /**
  * The console's `repo` scope (multi-repository-workspaces.md): every workspace read and git
@@ -197,12 +198,12 @@ describe('workspace git follows the repo scope', () => {
     writeFileSync(join(secondaryCheckout, 'SECONDARY-ONLY.md'), 'the additional repository\n')
   })
 
-  it('targets the secondary repository’s own remote and attested branch, not the primary’s', () => {
-    const target = scope.target(AGENT, AUTHORIZED)
+  it('targets the secondary repository’s own remote and attested branch, not the primary’s', async () => {
+    const target = await scope.target(AGENT, AUTHORIZED)
     expect(target).toMatchObject({ branch: 'trunk', githubApp: true })
     expect(target?.repo).toContain(AUTHORIZED)
     // A scratch primary has no clone at all, which is exactly what a pull of it must keep answering.
-    expect(scope.target(AGENT)).toBeUndefined()
+    await expect(scope.target(AGENT)).resolves.toBeUndefined()
   })
 
   it('refuses to pull a checkout whose origin is not that repository’s', async () => {
@@ -221,7 +222,7 @@ describe('workspace git follows the repo scope', () => {
 })
 
 describe('a secondary root is App-covered whatever the primary workspace is', () => {
-  it('marks the root App-backed for a MANUAL GitHub primary, whose own clone is anonymous', () => {
+  it('marks the root App-backed for a MANUAL GitHub primary, whose own clone is anonymous', async () => {
     // A manual GitHub workspace may explicitly authorize its own App-covered repositories. Deriving
     // the credential decision from the PRIMARY's mode would leave those roots' private clones
     // anonymous; the scope's target is what says which credentials each root needs.
@@ -245,19 +246,45 @@ describe('a secondary root is App-covered whatever the primary workspace is', ()
       sessionOf: async () => undefined,
       runtimeRootOf: () => undefined
     })
-    expect(manualScope.target('bot-manual')).toMatchObject({ githubApp: false })
-    expect(manualScope.target('bot-manual', AUTHORIZED)).toMatchObject({ githubApp: true, branch: '' })
+    await expect(manualScope.target('bot-manual')).resolves.toMatchObject({ githubApp: false })
+    await expect(manualScope.target('bot-manual', AUTHORIZED)).resolves.toMatchObject({ githubApp: true, branch: '' })
+    expect(manualScope.usesGithubApp('bot-manual')).toBe(false)
+    expect(manualScope.usesGithubApp('bot-manual', AUTHORIZED)).toBe(true)
   })
 })
 
-describe('cluster daemons have nowhere to put a secondary root yet', () => {
-  it('answers no root for a repo scope in sandbox mode, instead of serving the primary', async () => {
+describe('a cluster daemon addresses a secondary root on the pod volume', () => {
+  const POD_ROOT = '/agent'
+  const POD_SECONDARY = `${POD_ROOT}/repos/${AUTHORIZED}`
+
+  it('resolves the checkout, its session worktree and the attested branch in pod coordinates', async () => {
+    const pod = new PodWorkspaceFs(POD_ROOT, `${POD_SECONDARY}/checkout`, `${POD_SECONDARY}/worktrees`)
+    pod.files.set(
+      `${POD_SECONDARY}/.materialization.json`,
+      JSON.stringify({ repoId: AUTHORIZED_ID, repoFullName: AUTHORIZED, branch: 'pod-trunk' })
+    )
     workspaces.setSandboxMode(true)
+    workspaces.setFsResolver(() => ({ fs: pod, mount: POD_ROOT }))
+    const podScope = createWorkspaceScope({
+      workspaces,
+      agentOf: (id) => (id === AGENT ? agent : undefined),
+      sessionOf: async (_agentId, acpSessionId) =>
+        acpSessionId === 'acp-iso' ? { key: 'iso-key', workspaceIsolation: 'session' } : undefined,
+      runtimeRootOf: () => POD_ROOT
+    })
     try {
-      await expect(scope.location(AGENT, undefined, AUTHORIZED)).resolves.toBeUndefined()
-      // The primary is unaffected: it still resolves to the sandbox checkout.
-      await expect(scope.location(AGENT)).resolves.toBeDefined()
+      await expect(podScope.location(AGENT, undefined, AUTHORIZED)).resolves.toMatchObject({
+        root: `${POD_SECONDARY}/checkout`,
+        scratch: false
+      })
+      const worktree = await podScope.location(AGENT, 'acp-iso', AUTHORIZED)
+      expect(worktree?.root).toBe(`${POD_SECONDARY}/worktrees/${workspaces.sessionWorktreeId('iso-key')}`)
+      // The branch comes from the marker ON THE VOLUME, read through the seam — never this disk.
+      await expect(podScope.target(AGENT, AUTHORIZED)).resolves.toMatchObject({ branch: 'pod-trunk', githubApp: true })
+      // The primary still resolves to the sandbox checkout, untouched by the repo scope.
+      await expect(podScope.location(AGENT)).resolves.toBeDefined()
     } finally {
+      workspaces.setFsResolver(undefined)
       workspaces.setSandboxMode(false)
     }
   })


### PR DESCRIPTION
## What

`WorkspaceManager.consoleSecondaryRoot` now resolves a secondary root in the coordinates that hold it (the sandbox mount under `--k8s`) and reads its `.materialization.json` through the workspace-fs seam; `consoleWorkspaceRoot` passes a repo-scoped location through instead of answering no root. The scope's git `target` became async for that read; the credential-env decision uses a new synchronous `usesGithubApp` that needs no volume.

## Why

#1229 deferred the console's repo scope on cluster daemons because a pod had nowhere to hold a secondary root. #1236 put the roots on the sandbox volume, so the Workspace tab's repo dropdown now works for pool-placed agents too — files, git status/diff/log and pull follow the selected root there as on a self-hosted daemon.

## Review notes

- Local behavior unchanged (`secondaryRootsFor` yields the local paths when no mount is bound).
- The pod-coordinate case is tested against the `PodWorkspaceFs` fixture: checkout, session worktree, and the branch attested by the marker on the volume.
- Not here: `gh` inside the pod.