### PR TITLE
fix(daemon): materialize the session gitconfig into the sandbox pod at launch

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -28,7 +28,13 @@ import {
   type ClaudeProtectedSettings,
   ULTRACODE_EFFORT
 } from '../runtime-defs/claude-runtime.js'
-import { LocalDriver, type AcpSandboxLaunch, type SpawnDriver, type SpawnedRuntime } from './spawn-driver.js'
+import {
+  LocalDriver,
+  type AcpSandboxLaunch,
+  type SpawnDriver,
+  type SpawnFile,
+  type SpawnedRuntime
+} from './spawn-driver.js'
 import type { Logger } from '../log.js'
 import { accountAppIsolation } from './account-apps.js'
 import { permissionPresetSettings, type SessionApprovalsReviewer } from './permission-modes.js'
@@ -576,6 +582,8 @@ export class AcpHost {
        */
       onSdkLifecycle?: (sessionId: string, message: unknown) => void
       env?: Record<string, string>
+      /** Files `env` points at, written by the driver in the runtime's own filesystem before start. */
+      files?: SpawnFile[]
       /** Disposable compatibility probes suppress raw child stderr so a harness
        * cannot print credential material or host paths outside our sanitizer. */
       suppressChildStderr?: boolean
@@ -660,6 +668,7 @@ export class AcpHost {
       // PATH, point at it so an out-of-the-box Claude Code install just works. The
       // lookup belongs to the driver: only it knows the filesystem the runtime sees.
       ...(this.isClaudeRuntime() ? { hints: [{ envVar: 'CLAUDE_CODE_EXECUTABLE', command: 'claude' }] } : {}),
+      ...(this.opts.files?.length ? { files: this.opts.files } : {}),
       ...(this.opts.suppressChildStderr !== undefined ? { suppressChildStderr: this.opts.suppressChildStderr } : {}),
       ...(this.opts.sandbox ? { sandbox: this.opts.sandbox } : {})
     })

--- a/packages/daemon/src/acp/spawn-driver.ts
+++ b/packages/daemon/src/acp/spawn-driver.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { existsSync, realpathSync } from 'node:fs'
 import { Readable, Writable } from 'node:stream'
+import { LocalFileSink } from '../shim/file-sink.js'
 import { resolveCommandPath } from '../runtimes/probe.js'
 import { sandboxWrap, type SandboxMechanism } from './sandbox.js'
 import type { ClaudeProtectedSettings } from '../runtime-defs/claude-runtime.js'
@@ -37,12 +38,22 @@ export interface ExecutableHint {
   command: string
 }
 
+/** One daemon-decided file the driver must write in the TARGET filesystem before the runtime starts. */
+export interface SpawnFile {
+  root: string
+  relPath: string[]
+  content: string
+}
+
 export interface SpawnRequest {
   command: string
   args: string[]
   /** The complete child environment; the driver adds nothing but resolved hints. */
   env: Record<string, string>
   hints?: ExecutableHint[]
+  /** Files env pointers reference (session gitconfig): the daemon decides the content, but only the
+   *  driver knows whose filesystem the runtime reads, so the write travels with the launch. */
+  files?: SpawnFile[]
   /** Disposable probes suppress raw stderr so a harness cannot print credential
    *  material or host paths outside our sanitizer. */
   suppressChildStderr?: boolean
@@ -76,6 +87,8 @@ export class LocalDriver implements SpawnDriver {
   constructor(private opts: { log?: Logger } = {}) {}
 
   async launch(request: SpawnRequest): Promise<SpawnedRuntime> {
+    const sink = new LocalFileSink()
+    for (const file of request.files ?? []) await sink.write(file.root, file.relPath, file.content)
     const env = { ...request.env }
     for (const hint of request.hints ?? []) {
       if (env[hint.envVar]) continue

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { mkdtemp } from 'node:fs/promises'
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
@@ -68,6 +68,7 @@ import {
   initGitInjection,
   probeGitVersion,
   sandboxGitCredentialTarget,
+  sessionGitConfig,
   sessionGitEnv,
   sessionGitPolicyEnv
 } from './workspace/git-injection.js'
@@ -2999,6 +3000,14 @@ export class Daemon {
     const memoryAgent =
       memoryKindOf(agent) === 'native' && runInSandbox ? { ...agent, dir: runtimeHomePath(agent.dir) } : agent
     const runtimeEnv = Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
+    // On --k8s the runtime runs in the agent's pod, so the session gitconfig has to be COMPUTED in
+    // pod coordinates and WRITTEN there: the file travels with the launch (SpawnRequest.files) and
+    // is re-materialized on every spawn, because a resumed Sandbox is a new pod with an empty tmpfs.
+    // The daemon-local write (sessionGitEnv) would land the file on this daemon's disk instead.
+    const sandboxSessionGit =
+      this.k8sPlane && agent.workspace.mode === 'git-repo' && githubAppCredentials
+        ? sessionGitConfig(agent.id, this.gitCommitIdentity, sandboxGitCredentialTarget())
+        : undefined
     const env: Record<string, string> = {
       ...baseEnv,
       // Memory backend env: managed disables the runtime's own memory; native
@@ -3008,7 +3017,7 @@ export class Daemon {
       ...memoryProviderFor(memoryAgent, runtime, baseEnv, this.externalMemoryAdmission(agent.id)).runtimeEnv(),
       ...(agent.workspace.mode === 'git-repo'
         ? githubAppCredentials
-          ? sessionGitEnv(agent.id, this.gitCommitIdentity)
+          ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, this.gitCommitIdentity))
           : sessionGitPolicyEnv()
         : {})
     }
@@ -3039,8 +3048,12 @@ export class Daemon {
         delete runtimeEnv[secret.name]
       }
     }
+    // The cluster driver routes every pod launch by AC_AGENT_ID, credentials or not.
+    if (this.k8sPlane) env.AC_AGENT_ID = agent.id
     const shimDirs = new Set<string>()
-    if (githubAppCredentials && this.ghBinDir) {
+    // The gh wrapper is a DAEMON path: prepending it to a pod launch would name a dir the pod
+    // never had, and the pod image ships no wrapper (gh there degrades to unauthenticated).
+    if (githubAppCredentials && this.ghBinDir && !this.k8sPlane) {
       // gh wrapper (multi-repo #457): PATH prepend + the agent identity the
       // wrapper hands to the hidden token helper. sessionGitEnv supplies the
       // matching runtime-only capability; a user PATH override must not
@@ -3131,6 +3144,17 @@ export class Daemon {
       // Pairs the runtime's terminal exit with the ordinary rebuild — see reapTerminalHost.
       onTerminal: () => this.reapTerminalHost(agentId, constructed.host),
       env: launch.env,
+      ...(sandboxSessionGit
+        ? {
+            files: [
+              {
+                root: dirname(sandboxSessionGit.path),
+                relPath: [basename(sandboxSessionGit.path)],
+                content: sandboxSessionGit.content
+              }
+            ]
+          }
+        : {}),
       inheritProcessEnv: launch.inheritProcessEnv,
       runtimeId: agent.runtime,
       isolateAccountApps: cfg.security.isolateAccountApps,

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -3,6 +3,7 @@ import { systemClock, type Clock } from '@agentconnect.md/connection'
 import type { SpawnDriver, SpawnRequest, SpawnedRuntime } from '../acp/spawn-driver.js'
 import type { ShimCapability } from '../shim/protocol.js'
 import type { ShimConnection } from '../shim/connection.js'
+import { ShimFileSink } from '../shim/channels.js'
 import { ShimSession } from '../shim/session.js'
 import { createRemoteRuntime } from './remote-runtime.js'
 import type { SpawnRecord } from '../shim/binding.js'
@@ -281,6 +282,10 @@ export class K8sDriver implements SpawnDriver {
       this.metrics.channel('bound')
       const session = this.binder.sessionFor(agentId)
       if (!session) throw new Error(`no shim session for agent ${agentId} after binding its channel`)
+      // Fail-closed and per-launch: the env below points at these files, and a resumed Sandbox is a
+      // NEW pod whose tmpfs starts empty — so the write belongs to every launch, not to the bind.
+      const sink = new ShimFileSink(session)
+      for (const file of request.files ?? []) await sink.write(file.root, file.relPath, file.content)
       const runtime = createRemoteRuntime({
         session,
         request,

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -424,9 +424,11 @@ function targetOf(agentId: string): GitCredentialTarget {
  *  repo-local pin (previous agent generation) can never desync the two.
  *  The socket rides along for a target that is not this daemon's filesystem: the helper cannot
  *  derive a daemon root it does not have. */
-export function gitCredentialEnv(agentId: string): Record<string, string> {
+export function gitCredentialEnv(
+  agentId: string,
+  target: GitCredentialTarget = targetOf(agentId)
+): Record<string, string> {
   if (!capabilityFor) throw new Error('git credential injection is not initialized')
-  const target = targetOf(agentId)
   return {
     [GITCRED_CAPABILITY_ENV]: capabilityFor(agentId),
     [GITCRED_AGENT_ENV]: agentId,
@@ -434,8 +436,8 @@ export function gitCredentialEnv(agentId: string): Record<string, string> {
   }
 }
 
-function quotedHelper(agentId: string): string {
-  const { helper } = targetOf(agentId)
+function quotedHelper(agentId: string, target: GitCredentialTarget = targetOf(agentId)): string {
+  const { helper } = target
   return `!'${helper.replaceAll("'", "'\\''")}' ${agentId}`
 }
 
@@ -474,9 +476,11 @@ export function cloneGitEnv(agentId: string, repository?: string): Record<string
  */
 export function sessionGitConfig(
   agentId: string,
-  commitIdentity?: GitCommitIdentity
+  commitIdentity?: GitCommitIdentity,
+  // Explicit for a spawn that KNOWS where the runtime will run (a --k8s launch always lands in the
+  // pod), so the env cannot depend on whether the shim channel happens to be attached right now.
+  target: GitCredentialTarget = targetOf(agentId)
 ): { path: string; content: string; env: Record<string, string> } {
-  const target = targetOf(agentId)
   const file = join(target.configDir, `${agentId}.gitconfig`)
   const lines = [
     '# agentconnect session git config — regenerated on agent start; NO secrets.',
@@ -484,7 +488,7 @@ export function sessionGitConfig(
     ...(target.hostConfig ? ['[include]', `\tpath = ${target.hostConfig}`] : []),
     '[credential "https://github.com"]',
     '\thelper = ', // reset the accumulated helper list for github.com
-    `\thelper = ${quotedHelper(agentId)}`,
+    `\thelper = ${quotedHelper(agentId, target)}`,
     '\tuseHttpPath = true',
     ''
   ]
@@ -492,7 +496,7 @@ export function sessionGitConfig(
     path: file,
     content: lines.join('\n'),
     env: {
-      ...gitCredentialEnv(agentId),
+      ...gitCredentialEnv(agentId, target),
       ...sessionGitPolicyEnv(),
       GIT_CONFIG_GLOBAL: file,
       GIT_TERMINAL_PROMPT: '0',

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -716,6 +716,17 @@ describe('pointers for an agent whose git runs in a sandbox pod', () => {
     expect(pod.content).not.toContain(homedir())
   })
 
+  it('computes pod coordinates for an EXPLICIT sandbox target, whatever targetFor answers', () => {
+    // The spawn path knows a --k8s launch lands in the pod before the shim channel is attached,
+    // so its env must not depend on binding order: 'agent-1' resolves to the daemon target here.
+    const pod = sessionGitConfig('agent-1', undefined, sandboxGitCredentialTarget())
+    expect(pod.path).toBe(`${SANDBOX_GIT_CONFIG_DIR}/agent-1.gitconfig`)
+    expect(pod.env.GIT_CONFIG_GLOBAL).toBe(pod.path)
+    expect(pod.env[GITCRED_SOCKET_ENV]).toBe(SANDBOX_TUNNEL_PATHS.gitcred)
+    expect(pod.content).toContain(`!'${SANDBOX_GIT_CREDENTIAL_HELPER}' agent-1`)
+    expect(pod.content).not.toContain(homedir())
+  })
+
   it('refuses to WRITE a pod gitconfig, rather than writing it here', () => {
     // The whole class of bug in one assertion: a synchronous write of `/run/agentconnect/...`
     // lands on the daemon's disk, creating the file a check would look for while the pod has none.

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -698,6 +698,51 @@ describe('cluster spawn driver', () => {
     const { instance } = driver(api)
     await expect(instance.launch({ command: 'claude-code-acp', args: [], env: {} })).rejects.toThrow(/AC_AGENT_ID/)
   })
+
+  /** A connection whose pod side answers every shim/request, recording the order it served them. */
+  function answeringConnection(served: Array<{ capability: string; payload: unknown }>, refuse?: string) {
+    const listeners: Array<(text: string) => void> = []
+    return {
+      binding: { agentId: 'agent-a', generation: 1, grants: ['acp'], podName: 'p', podUid: 'u' },
+      issuedCredential: 'cred',
+      send: (frame: { type: string; id: string; capability?: string; payload?: unknown }) => {
+        if (frame.type !== 'shim/request') return
+        served.push({ capability: frame.capability!, payload: frame.payload })
+        const reply =
+          refuse && frame.capability === refuse
+            ? { type: 'shim/response', id: frame.id, ok: false, error: 'sink refused' }
+            : { type: 'shim/response', id: frame.id, ok: true, payload: { streamId: 's-1' } }
+        for (const listener of listeners) listener(JSON.stringify(reply))
+      },
+      onFrame: (listener: (text: string) => void) => listeners.push(listener),
+      close: () => {}
+    } as unknown as ShimConnection
+  }
+
+  it('materializes the launch files in the pod before opening the runtime', async () => {
+    const served: Array<{ capability: string; payload: unknown }> = []
+    const { api } = fakeApi()
+    const { instance } = driver(api, { connectChannel: async () => answeringConnection(served) })
+    const files = [{ root: '/run/agentconnect/git', relPath: ['agent-a.gitconfig'], content: '[credential]\n' }]
+    await instance.launch({ ...(launchRequest as object), files } as never)
+    expect(served.map((request) => request.capability)).toEqual(['materialize', 'acp'])
+    expect(served[0]!.payload).toEqual({
+      op: 'write',
+      root: '/run/agentconnect/git',
+      relPath: ['agent-a.gitconfig'],
+      content: '[credential]\n'
+    })
+  })
+
+  it('fails the launch when a file cannot be materialized, releasing the hold', async () => {
+    const served: Array<{ capability: string; payload: unknown }> = []
+    const { api } = fakeApi()
+    const { instance } = driver(api, { connectChannel: async () => answeringConnection(served, 'materialize') })
+    const files = [{ root: '/run/agentconnect/git', relPath: ['agent-a.gitconfig'], content: 'x' }]
+    await expect(instance.launch({ ...(launchRequest as object), files } as never)).rejects.toThrow(/sink refused/)
+    // Fail-closed: the runtime was never asked to open against env pointing at a file that is not there.
+    expect(served.map((request) => request.capability)).toEqual(['materialize'])
+  })
 })
 
 /**


### PR DESCRIPTION
## Problem

Editing a cluster agent's workspace to a git-repo + github-app configuration rejected activation with:

> workspace edit rejected: agent/activate: agent … runs its git in a sandbox — materialize its gitconfig instead of writing it

#858 split the session gitconfig into data (`sessionGitConfig`) and write (`sessionGitEnv`) and made the write refuse a sandbox target — correctly, since a synchronous write of `/run/agentconnect/git/…` lands on the daemon's own disk. But the promised other half never existed: nothing carried the pod's copy through the shim's materialize channel, so the activate proof spawn hit the guard and every such edit was rejected. The workspace side (clone/pull/repo-local helper pin via the shim runner) already worked; only the runtime's session env channel was missing.

## Fix

- **`SpawnRequest.files`** — daemon-decided files the driver writes in the TARGET filesystem before the runtime starts, the same decision/placement split `FileSink` documents. `LocalDriver` applies them via `LocalFileSink`; **`K8sDriver`** writes them through `ShimFileSink` after binding the channel and before `acp open`, fail-closed, and on **every** launch — the gitconfig lives on the pod's tmpfs, and a resumed Sandbox is a new pod with an empty one (matching the "regenerated per launch" contract in `sandbox-paths.ts`).
- **`createHost`** computes the pod copy with an explicit `sandboxGitCredentialTarget()` instead of the `runsInSandbox`-driven resolver, so the launch env cannot depend on whether the shim channel happens to be attached yet (`sessionGitConfig` accepts the target). The env rides `opts.env` as before; the content rides `AcpHost`'s new `files` pass-through. The daemon-local path is unchanged, and the `sessionGitEnv` guard stays — it now guards a path that has a real implementation.

Two adjacent gaps in the same launch path:
- `AC_AGENT_ID` is now set for every `--k8s` launch. `K8sDriver.launch` requires it, but only the gh-wrapper branch set it, so a non-github-app cluster agent could never start a runtime.
- The gh wrapper's PATH prepend no longer travels with a pod launch — it names a daemon-local dir the pod never had, and the image ships no wrapper (`gh` in the pod degrades to unauthenticated; a pod-side wrapper is a follow-up).

## Tests

- `k8s-driver.test.ts`: launch materializes `files` in the pod **before** opening the runtime; a refused write fails the launch fail-closed.
- `git-injection.test.ts`: an explicit sandbox target yields pure pod coordinates regardless of what `targetFor` answers.
- Full daemon suite (minus acp-matrix and the known baseline files): 264 files / 4058 tests pass; the one `scheduler.test.ts` DST failure is a suite-order flake that also occurs without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)