### PR TITLE
fix(relay): rendezvous a webchat turn through a live same-org daemon when the recorded one is gone

### DIFF
--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -471,3 +471,99 @@ describe('RelayBrowserConnection', () => {
     expect(transport.sent.length).toBe(before) // nothing appended post-close
   })
 })
+
+describe('webchat rendezvous fallback (rollout replaced the recorded daemon)', () => {
+  const DAEMON2 = '88888888-8888-4888-8888-888888888888'
+  const DAEMON3 = '77777777-7777-4777-8777-777777777777'
+
+  function buildRouted(opts: { conns: Record<string, RdAck | 'accept'>; rendezvous?: string }) {
+    const calls: Array<{ daemonId: string; msg: RdMsgWebchat }> = []
+    const connFor = (daemonId: string): RelayDaemonConnection | undefined => {
+      const verdict = opts.conns[daemonId]
+      if (!verdict) return undefined
+      return {
+        sendMsg: async (msg: RdMsgWebchat): Promise<RdAck> => {
+          calls.push({ daemonId, msg })
+          return verdict === 'accept' ? { msgId: msg.msgId, accepted: true } : verdict
+        }
+      } as unknown as RelayDaemonConnection
+    }
+    const rendezvous = vi.fn(() => {
+      const id = opts.rendezvous
+      const conn = id ? connFor(id) : undefined
+      return id && conn ? { daemonId: id, conn } : undefined
+    })
+    const transport = new FakeBrowserTransport()
+    new RelayBrowserConnection(transport, {
+      chatId: CHAT,
+      agentId: AGENT,
+      participants: [{ agentId: AGENT, daemonId: DAEMON, primary: true }],
+      user: USER,
+      daemonConnFor: connFor,
+      rendezvousDaemonConn: rendezvous,
+      register: vi.fn(),
+      unregister: vi.fn(),
+      log: silentLog
+    }).start()
+    return { transport, calls, rendezvous }
+  }
+
+  it('delivers through a live same-org member when the recorded daemon is gone', async () => {
+    const { transport, calls } = buildRouted({ conns: { [DAEMON2]: 'accept' }, rendezvous: DAEMON2 })
+    transport.feed({ text: 'hi' })
+    await tick()
+    expect(calls.map((c) => c.daemonId)).toEqual([DAEMON2])
+    expect(transport.last('ack')).toMatchObject({ ack: { accepted: true, agentId: AGENT } })
+    expect(transport.last('error')).toBeUndefined()
+  })
+
+  it('heals the roster: the next op goes direct instead of repeating the rendezvous', async () => {
+    const { transport, calls, rendezvous } = buildRouted({ conns: { [DAEMON2]: 'accept' }, rendezvous: DAEMON2 })
+    transport.feed({ text: 'hi' })
+    await tick()
+    transport.feed({ text: 'again' })
+    await tick()
+    expect(calls.map((c) => c.daemonId)).toEqual([DAEMON2, DAEMON2])
+    expect(rendezvous).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the offline error when no same-org member is connected', async () => {
+    const { transport, calls } = buildRouted({ conns: {} })
+    transport.feed({ text: 'hi' })
+    await tick()
+    expect(calls).toEqual([])
+    expect(transport.last('error')).toEqual({ type: 'error', message: 'agent daemon offline' })
+  })
+
+  it('follows a not_holder verdict from the rendezvous member to the named holder', async () => {
+    const { transport, calls } = buildRouted({
+      conns: {
+        [DAEMON2]: { msgId: 'x', accepted: false, reason: 'not_holder', holderDaemonId: DAEMON3 },
+        [DAEMON3]: 'accept'
+      },
+      rendezvous: DAEMON2
+    })
+    transport.feed({ text: 'hi' })
+    await tick()
+    expect(calls.map((c) => c.daemonId)).toEqual([DAEMON2, DAEMON3])
+    expect(transport.last('ack')).toMatchObject({ ack: { accepted: true, agentId: AGENT } })
+    // Healed to the holder: a second op goes straight to it.
+    transport.feed({ text: 'again' })
+    await tick()
+    expect(calls.map((c) => c.daemonId)).toEqual([DAEMON2, DAEMON3, DAEMON3])
+  })
+
+  it('heals after the ordinary holder re-route when the recorded daemon still answers', async () => {
+    const { transport, calls } = buildRouted({
+      conns: {
+        [DAEMON]: { msgId: 'x', accepted: false, reason: 'not_holder', holderDaemonId: DAEMON3 },
+        [DAEMON3]: 'accept'
+      }
+    })
+    transport.feed({ text: 'hi' })
+    await tick()
+    transport.feed({ text: 'again' })
+    await tick()
+    expect(calls.map((c) => c.daemonId)).toEqual([DAEMON, DAEMON3, DAEMON3])
+  })
+})

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -93,9 +93,8 @@ export interface RelayBrowserConnDeps {
   remoteMcp?: WebchatRemoteMcpEntitlement
   /** Resolve a live rd/* connection to a participant's daemon (absent if it dropped). */
   daemonConnFor: (daemonId: string) => RelayDaemonConnection | undefined
-  /** Any live same-org connection, tried when the recorded daemon is gone (a rollout replaced
-   *  it): the member claims the duty on receipt or names the holder (§4.4). Absent on an older
-   *  CP whose verify result carries no orgId — the recorded placement then stays load-bearing. */
+  /** Any live duty-governed pool connection, tried when the recorded daemon is gone (a rollout
+   *  replaced it): the member claims the duty on receipt or names the holder (§4.4). */
   rendezvousDaemonConn?: () => { daemonId: string; conn: RelayDaemonConnection } | undefined
   register: (chatId: string, sink: ChatSink) => void
   unregister: (chatId: string, sink: ChatSink) => void

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -93,6 +93,10 @@ export interface RelayBrowserConnDeps {
   remoteMcp?: WebchatRemoteMcpEntitlement
   /** Resolve a live rd/* connection to a participant's daemon (absent if it dropped). */
   daemonConnFor: (daemonId: string) => RelayDaemonConnection | undefined
+  /** Any live same-org connection, tried when the recorded daemon is gone (a rollout replaced
+   *  it): the member claims the duty on receipt or names the holder (§4.4). Absent on an older
+   *  CP whose verify result carries no orgId — the recorded placement then stays load-bearing. */
+  rendezvousDaemonConn?: () => { daemonId: string; conn: RelayDaemonConnection } | undefined
   register: (chatId: string, sink: ChatSink) => void
   unregister: (chatId: string, sink: ChatSink) => void
   log: Logger
@@ -332,7 +336,18 @@ export class RelayBrowserConnection implements ChatSink {
   /** Send one op to one participant's daemon, translating the verdict for the browser. */
   private async sendToParticipant(agentId: string, op: RelayWebchatOp, kind: RelayWebchatOp['op']): Promise<void> {
     const participant = this.byAgentId.get(agentId)
-    const daemon = participant?.daemonId ? this.deps.daemonConnFor(participant.daemonId) : undefined
+    let daemonId = participant?.daemonId
+    let daemon = daemonId ? this.deps.daemonConnFor(daemonId) : undefined
+    if (!daemon) {
+      // A gone recorded member is not a gone agent: a rollout replaced the daemon under the
+      // conversation. Any live same-org member claims the duty on receipt or names the holder.
+      const fallback = this.deps.rendezvousDaemonConn?.()
+      if (fallback) {
+        this.deps.log.info(`webchat: recorded daemon for ${agentId} is gone — rendezvousing via ${fallback.daemonId}`)
+        daemonId = fallback.daemonId
+        daemon = fallback.conn
+      }
+    }
     if (!daemon) {
       // A single-participant conversation keeps the legacy error frame; a
       // multi-agent one degrades per agent so the other targets still run.
@@ -373,8 +388,14 @@ export class RelayBrowserConnection implements ChatSink {
         const holder = this.deps.daemonConnFor(ack.holderDaemonId)
         if (holder) {
           this.deps.log.info(`webchat: re-routing ${agentId} to duty holder ${ack.holderDaemonId}`)
+          daemonId = ack.holderDaemonId
           ack = await holder.sendMsg(rdMsg)
         }
+      }
+      // The member that answered the verdict is serving the agent now — heal the roster entry
+      // so the next op goes direct instead of repeating the rendezvous or the holder hop.
+      if (participant && daemonId && ack.reason !== RD_ACK_NOT_HOLDER && participant.daemonId !== daemonId) {
+        participant.daemonId = daemonId
       }
       const browserAck = {
         accepted: ack.accepted,

--- a/packages/relay/src/relay-browser-server.ts
+++ b/packages/relay/src/relay-browser-server.ts
@@ -107,8 +107,7 @@ export function createRelayBrowserServer(app: FastifyInstance, deps: RelayBrowse
           ...(result.targetSessionId ? { targetSessionId: result.targetSessionId } : {}),
           ...(result.remoteMcp ? { remoteMcp: result.remoteMcp } : {}),
           daemonConnFor: (id) => deps.daemons.get(id),
-          // Org-scoped so a rendezvous can never carry one org's turn to another org's daemon.
-          ...(result.orgId ? { rendezvousDaemonConn: () => deps.daemons.anyFor(result.orgId!) } : {}),
+          rendezvousDaemonConn: () => deps.daemons.rendezvousCandidate(),
           register: (c, sink) => deps.router.register(c, sink),
           unregister: (c, sink) => deps.router.unregister(c, sink),
           log: deps.log

--- a/packages/relay/src/relay-browser-server.ts
+++ b/packages/relay/src/relay-browser-server.ts
@@ -107,6 +107,8 @@ export function createRelayBrowserServer(app: FastifyInstance, deps: RelayBrowse
           ...(result.targetSessionId ? { targetSessionId: result.targetSessionId } : {}),
           ...(result.remoteMcp ? { remoteMcp: result.remoteMcp } : {}),
           daemonConnFor: (id) => deps.daemons.get(id),
+          // Org-scoped so a rendezvous can never carry one org's turn to another org's daemon.
+          ...(result.orgId ? { rendezvousDaemonConn: () => deps.daemons.anyFor(result.orgId!) } : {}),
           register: (c, sink) => deps.router.register(c, sink),
           unregister: (c, sink) => deps.router.unregister(c, sink),
           log: deps.log

--- a/packages/relay/src/relay-daemon-connection.ts
+++ b/packages/relay/src/relay-daemon-connection.ts
@@ -72,6 +72,8 @@ export interface RelayDaemonConnDeps {
 export class RelayDaemonConnection {
   state: State = 'AUTHENTICATING'
   daemonId = ''
+  /** The org the CP resolved this daemon's credential to; scopes the webchat rendezvous fallback. */
+  orgId?: string
 
   /** Optional behaviors this daemon advertised at hello (§8.4). Populated only after a
    *  successful handshake, so a caller that reads it on a non-READY socket correctly
@@ -248,6 +250,7 @@ export class RelayDaemonConnection {
     }
 
     this.daemonId = result.daemonId
+    if (result.orgId) this.orgId = result.orgId
     this.capabilities = new Set(hello.capabilities ?? [])
     this.state = 'READY'
     this.reply(frame, 'rd/hello/ok', { relayId })

--- a/packages/relay/src/relay-daemon-connection.ts
+++ b/packages/relay/src/relay-daemon-connection.ts
@@ -72,8 +72,10 @@ export interface RelayDaemonConnDeps {
 export class RelayDaemonConnection {
   state: State = 'AUTHENTICATING'
   daemonId = ''
-  /** The org the CP resolved this daemon's credential to; scopes the webchat rendezvous fallback. */
-  orgId?: string
+  /** Which verified credential authenticated this socket. `daemon-token` is a TokenReviewed
+   *  install-wide pool identity — duty-governed, so it can rendezvous a webchat trigger.
+   *  `daemon-key` is an org-scoped standalone daemon that would answer `no_agent` instead. */
+  credentialKind?: 'daemon-key' | 'daemon-token'
 
   /** Optional behaviors this daemon advertised at hello (§8.4). Populated only after a
    *  successful handshake, so a caller that reads it on a non-READY socket correctly
@@ -250,7 +252,7 @@ export class RelayDaemonConnection {
     }
 
     this.daemonId = result.daemonId
-    if (result.orgId) this.orgId = result.orgId
+    this.credentialKind = presented.kind
     this.capabilities = new Set(hello.capabilities ?? [])
     this.state = 'READY'
     this.reply(frame, 'rd/hello/ok', { relayId })

--- a/packages/relay/src/relay-daemon-server.test.ts
+++ b/packages/relay/src/relay-daemon-server.test.ts
@@ -83,12 +83,18 @@ describe('createRelayDaemonServer (rd/* accept edge)', () => {
     await tick()
     expect(rd!.size()).toBe(1)
 
+    // The rendezvous fallback is org-scoped: only the verified org resolves a connection.
+    expect(rd!.anyFor('org-1')?.daemonId).toBe(DAEMON_ID)
+    expect(rd!.anyFor('org-1')?.conn.orgId).toBe('org-1')
+    expect(rd!.anyFor('org-2')).toBeUndefined()
+
     // CP-driven revoke: closes the daemon's rd/* socket and clears the map.
     const closed = closeCode(ws)
     rd!.revoke(DAEMON_ID)
     expect(await closed).toBe(4409)
     await tick()
     expect(rd!.size()).toBe(0)
+    expect(rd!.anyFor('org-1')).toBeUndefined()
   })
 
   it('rejects a client that does not offer the rd subprotocol', async () => {

--- a/packages/relay/src/relay-daemon-server.test.ts
+++ b/packages/relay/src/relay-daemon-server.test.ts
@@ -83,10 +83,9 @@ describe('createRelayDaemonServer (rd/* accept edge)', () => {
     await tick()
     expect(rd!.size()).toBe(1)
 
-    // The rendezvous fallback is org-scoped: only the verified org resolves a connection.
-    expect(rd!.anyFor('org-1')?.daemonId).toBe(DAEMON_ID)
-    expect(rd!.anyFor('org-1')?.conn.orgId).toBe('org-1')
-    expect(rd!.anyFor('org-2')).toBeUndefined()
+    // An org-scoped key daemon is outside the duty plane — never a rendezvous candidate.
+    expect(rd!.get(DAEMON_ID)?.credentialKind).toBe('daemon-key')
+    expect(rd!.rendezvousCandidate()).toBeUndefined()
 
     // CP-driven revoke: closes the daemon's rd/* socket and clears the map.
     const closed = closeCode(ws)
@@ -94,7 +93,26 @@ describe('createRelayDaemonServer (rd/* accept edge)', () => {
     expect(await closed).toBe(4409)
     await tick()
     expect(rd!.size()).toBe(0)
-    expect(rd!.anyFor('org-1')).toBeUndefined()
+  })
+
+  it('offers a projected-token pool member as the webchat rendezvous candidate', async () => {
+    const verify = vi.fn(async () => ({ ok: true, daemonId: DAEMON_ID }) as RcVerifyResult)
+    const base = await start(verify)
+    const ws = await dial(base, RELAY_DAEMON_SUBPROTOCOL)
+
+    ws.send(JSON.stringify(buildRelayDaemonFrame('rd/hello', { serviceAccountToken: 't', daemonId: DAEMON_ID })))
+    await nextFrame(ws, 'rd/hello/ok')
+    expect(verify).toHaveBeenCalledWith('daemon-token', 't', DAEMON_ID)
+    await tick()
+
+    const candidate = rd!.rendezvousCandidate()
+    expect(candidate?.daemonId).toBe(DAEMON_ID)
+    expect(candidate?.conn.credentialKind).toBe('daemon-token')
+
+    rd!.revoke(DAEMON_ID)
+    await tick()
+    expect(rd!.rendezvousCandidate()).toBeUndefined()
+    ws.close()
   })
 
   it('rejects a client that does not offer the rd subprotocol', async () => {

--- a/packages/relay/src/relay-daemon-server.ts
+++ b/packages/relay/src/relay-daemon-server.ts
@@ -42,6 +42,9 @@ export interface RelayDaemonServer {
   /** A live `rd/*` connection to `daemonId`, if this relay holds one — the browser
    *  gateway routes a webchat turn onto it. Returns any of the (normally one) sockets. */
   get(daemonId: string): RelayDaemonConnection | undefined
+  /** Any live same-org connection — the webchat rendezvous fallback when a recorded
+   *  member is gone (§4.4): the member either claims the duty or names the holder. */
+  anyFor(orgId: string): { daemonId: string; conn: RelayDaemonConnection } | undefined
   /** Number of authenticated daemon connections (observability / tests). */
   size(): number
 }
@@ -115,6 +118,12 @@ export function createRelayDaemonServer(app: FastifyInstance, deps: RelayDaemonS
     },
     get(daemonId: string): RelayDaemonConnection | undefined {
       return byDaemon.get(daemonId)?.values().next().value
+    },
+    anyFor(orgId: string): { daemonId: string; conn: RelayDaemonConnection } | undefined {
+      for (const [daemonId, set] of byDaemon) {
+        for (const conn of set) if (conn.orgId === orgId) return { daemonId, conn }
+      }
+      return undefined
     },
     size(): number {
       let n = 0

--- a/packages/relay/src/relay-daemon-server.ts
+++ b/packages/relay/src/relay-daemon-server.ts
@@ -42,9 +42,11 @@ export interface RelayDaemonServer {
   /** A live `rd/*` connection to `daemonId`, if this relay holds one — the browser
    *  gateway routes a webchat turn onto it. Returns any of the (normally one) sockets. */
   get(daemonId: string): RelayDaemonConnection | undefined
-  /** Any live same-org connection — the webchat rendezvous fallback when a recorded
-   *  member is gone (§4.4): the member either claims the duty or names the holder. */
-  anyFor(orgId: string): { daemonId: string; conn: RelayDaemonConnection } | undefined
+  /** Any live duty-governed pool connection — the webchat rendezvous fallback when a recorded
+   *  member is gone (§4.4): a pool member claims the duty on receipt or names the holder, and
+   *  a wrong-pool pick self-corrects the same way. Org-scoped `daemon-key` daemons are never
+   *  candidates: they are outside the install's duty plane and must not see other orgs' turns. */
+  rendezvousCandidate(): { daemonId: string; conn: RelayDaemonConnection } | undefined
   /** Number of authenticated daemon connections (observability / tests). */
   size(): number
 }
@@ -119,9 +121,9 @@ export function createRelayDaemonServer(app: FastifyInstance, deps: RelayDaemonS
     get(daemonId: string): RelayDaemonConnection | undefined {
       return byDaemon.get(daemonId)?.values().next().value
     },
-    anyFor(orgId: string): { daemonId: string; conn: RelayDaemonConnection } | undefined {
+    rendezvousCandidate(): { daemonId: string; conn: RelayDaemonConnection } | undefined {
       for (const [daemonId, set] of byDaemon) {
-        for (const conn of set) if (conn.orgId === orgId) return { daemonId, conn }
+        for (const conn of set) if (conn.credentialKind === 'daemon-token') return { daemonId, conn }
       }
       return undefined
     },


### PR DESCRIPTION
## Problem

A webchat conversation resolves each participant's `daemonId` **once, at WS connect** (the CP-verified roster snapshot). A daemon rolling deploy replaces the fleet underneath open conversations; the snapshot goes stale, `daemonConnFor(recorded)` finds no live `rd/*` socket, and every send on the open socket fails with `agent daemon offline` — rendered as "Connection error." in the console — even though a live successor already holds (or can claim) the agent's duty. The conversation only recovers when the browser happens to reconnect its WS and re-verify.

Observed live (#1239): every rollout of the daemon Deployment reproduced it; turns never reached any live daemon (no dispatch logs anywhere), the sandbox pod stayed healthy the whole time, and recovery coincided with WS reconnection — not with anything daemon-side. The "stranded channel" in the original issue analysis was a symptom: the shim channel is lazily bound on the next turn, and the next turn was being dropped at the relay.

## Fix

The activation rendezvous (send-message-routing-rework.md §4.4) already makes **any duty-governed member a correct first hop**: `claimDutyForTrigger` either claims the duty on receipt and serves the turn, or answers `not_holder` with the holder learned from the CP, which the existing re-route follows.

So `sendToParticipant` now treats a gone recorded daemon as "stale recording", not "dead agent":

- when the recorded daemon has no live connection, send to a live **projected-token pool** connection; the existing `not_holder` re-route completes the path (a wrong-pool pick self-corrects the same way);
- candidacy is decided by the **verified credential kind retained from the `rd/hello` handshake**: `daemon-token` is a TokenReviewed install-wide pool identity inside the duty plane, while an org-scoped `daemon-key` daemon is outside it (it would answer `no_agent` rather than claim) and is never selected — which is also what keeps another org's turn content away from standalone daemons;
- after the final verdict, the roster entry is **healed** to the member that answered, so the next op goes direct. This also removes the standing double hop after an ordinary `not_holder` re-route (previously every subsequent send repeated it).

Context fan-out to non-targeted participants keeps its best-effort skip — a missed copy is recovered at that agent's next activation, which now rendezvouses too.

## Tests

- rendezvous delivery when the recorded daemon is gone (ack forwarded, no error frame);
- roster healing: second op goes direct, rendezvous consulted once;
- no candidate ⇒ unchanged `agent daemon offline`;
- `not_holder` chain through the fallback to the named holder, with healing;
- healing after the ordinary holder re-route;
- server-side: a `daemon-token` hello becomes the candidate, a `daemon-key` hello never does, and revoke clears it.

Full relay suite: 502 tests green; typecheck and lint pass.

Fixes #1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)