### PR TITLE
fix(daemon): give a scratch workspace with App credentials the gitcred capability

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3011,7 +3011,7 @@ export class Daemon {
     // is re-materialized on every spawn, because a resumed Sandbox is a new pod with an empty tmpfs.
     // The daemon-local write (sessionGitEnv) would land the file on this daemon's disk instead.
     const sandboxSessionGit =
-      this.k8sPlane && agent.workspace.mode === 'git-repo' && githubAppCredentials
+      this.k8sPlane && githubAppCredentials
         ? sessionGitConfig(agent.id, this.gitCommitIdentity, sandboxGitCredentialTarget())
         : undefined
     const env: Record<string, string> = {
@@ -3021,11 +3021,13 @@ export class Daemon {
       // MemoryProviderUnavailableError for an unbuildable provider (external, or
       // native on an unregistered runtime) — surfaced here at spawn.
       ...memoryProviderFor(memoryAgent, runtime, baseEnv, this.externalMemoryAdmission(agent.id)).runtimeEnv(),
-      ...(agent.workspace.mode === 'git-repo'
-        ? githubAppCredentials
-          ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, this.gitCommitIdentity))
-          : sessionGitPolicyEnv()
-        : {})
+      // App identity rides with the CREDENTIAL mode, not the workspace mode: a scratch workspace with
+      // authorized repositories needs the capability for its git and gh exactly like a clone does.
+      ...(githubAppCredentials
+        ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, this.gitCommitIdentity))
+        : agent.workspace.mode === 'git-repo'
+          ? sessionGitPolicyEnv()
+          : {})
     }
     // Config-file secrets are materialized by assembleRuntimeLaunch below; the pre-strip merged env
     // is snapshotted so the idle sweep can delete the files and rematerializeConfigFiles() can

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -154,6 +154,42 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     }
   })
 
+  it('hands a scratch workspace with App credentials the same gitcred capability a clone gets', async () => {
+    const root = scaffold()
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      sandboxMechanism: 'bwrap',
+      probeRuntimes: async () => []
+    })
+    try {
+      await daemon.start()
+      const agent = (daemon as any).agents.get('bot-a')
+      const cwd = agent.workspace.path
+      // Authorized repositories are the only repositories a scratch workspace can reach, and its
+      // in-session git and gh authenticate for them through the same helper a clone uses.
+      agent.workspace = {
+        mode: 'from-scratch',
+        path: cwd,
+        gitBranch: 'main',
+        gitCredential: 'github-app',
+        pullOnNewSession: true,
+        skills: []
+      }
+      const scratch = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, { runInSandbox: true, cwd }).host
+      expect((scratch as any).opts.env[GITCRED_CAPABILITY_ENV]).toEqual(expect.any(String))
+      expect((scratch as any).opts.env[GITCRED_AGENT_ENV]).toBe('bot-a')
+      // Without App credentials a scratch workspace still carries no git identity of any kind.
+      agent.workspace = { mode: 'from-scratch', path: cwd, gitBranch: 'main', pullOnNewSession: true, skills: [] }
+      const plain = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, { runInSandbox: true, cwd }).host
+      expect((plain as any).opts.env[GITCRED_CAPABILITY_ENV]).toBeUndefined()
+      expect((plain as any).opts.env.GIT_CONFIG_KEY_0).toBeUndefined()
+    } finally {
+      await daemon.stop().catch(() => undefined)
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('keeps agent tool credentials out of the dream host without re-enabling repository hooks', async () => {
     const root = scaffold()
     const daemon = new Daemon({


### PR DESCRIPTION
## What

`daemon.ts` composes the runtime env's session git identity — including the runtime-only `AC_GITCRED_CAPABILITY` — only when `workspace.mode === 'git-repo'`. A scratch workspace with `gitCredential: github-app` therefore had `AC_AGENT_ID` but no capability, so its in-session `git` and `gh` could not authenticate for the repositories it is authorized for. The gate now follows the credential mode (both the local and the sandbox/pod branch); a git-repo workspace without App credentials keeps its hooks/fsmonitor policy env, and a plain scratch workspace still carries no git env at all.

## Why

The authorization design says a scratch workspace uses the same explicit repository allowlist as a clone and reaches those repositories through the same helper. Found while shipping the in-pod `gh` wrapper (#1244), where the pre-existing gap was documented rather than fixed.

## Tests

`daemon-smoke`: a scratch + App workspace host carries the capability and agent id; a plain scratch host carries neither the capability nor the git policy env.