### PR TITLE
feat(daemon)!: one gateway, one pair per runtime — and a key server that owns the whole pair

### DIFF
--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -10,14 +10,17 @@ runtimeClass, admission policy, egress control, and a managed egress proxy so a 
 key never enters the sandbox — is a separate, later plan. Until it lands, the pod and the
 shared Sandbox namespace are the only isolation boundaries, and a provider key is present inside
 the sandbox, so this shape suits internal dogfooding and self-hosted
-bring-your-own-key. A cloud daemon accepts the runtime-neutral `MODEL_BASE_URL` and
-`MODEL_TOKEN` pair and translates it for Claude, Codex, or OpenCode at spawn; a configured
-key server replaces the static token with a session-scoped pair. The runtime image still
-accepts the legacy deployment-owned `AC_CLAUDE_BASE_URL`/`AC_CLAUDE_API_KEY`,
+bring-your-own-key. A cloud daemon accepts the shared `MODEL_BASE_URL`/`MODEL_TOKEN` pair,
+or a runtime-scoped one that replaces it whole (`ANTHROPIC_MODEL_*` for Claude,
+`OPENAI_MODEL_*` for Codex, `DEEPSEEK_MODEL_*` for the DeepSeek Harness — OpenCode takes the
+shared pair, having no single base of its own), and translates it for that runtime at spawn;
+a configured key server replaces the static token with a session-scoped pair. The runtime
+image still accepts the legacy deployment-owned `AC_CLAUDE_BASE_URL`/`AC_CLAUDE_API_KEY`,
 `AC_CODEX_BASE_URL`/`AC_CODEX_API_KEY` and `AC_DEEPSEEK_BASE_URL`/`AC_DEEPSEEK_API_KEY` pod
-variables as fill-ins, but a daemon-sent value wins. DeepSeek Harness has no neutral-pair
-translation yet — the pod variables are its whole configuration, since a sandbox seeds no
-`$DSH_HOME` credential store. See [key-server.md](key-server.md) for precedence and lifecycle.
+variables as fill-ins, but a daemon-sent value wins — including for DeepSeek Harness, whose
+`DEEPSEEK_BASE_URL`/`DEEPSEEK_API_KEY` the daemon now writes itself; the pod variables remain
+its floor, since a sandbox seeds no `$DSH_HOME` credential store. See
+[key-server.md](key-server.md) for precedence and lifecycle.
 
 ## 1. Why a seam at all
 

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -140,7 +140,7 @@ The daemon does not implement these, but interacts with them through the section
 | `--key-server-token-path <path>` | `KEY_SERVER_TOKEN_PATH`        | File re-read as the key-server bearer token on every request.                                                                                      |
 | `--dry-run`                      | n/a                            | Load and validate all configuration and print the reconcile plan without opening connections/processes.                                            |
 
-General environment equivalents use the `AGENTCONNECT_` prefix, such as `AGENTCONNECT_CP_URL`, `AGENTCONNECT_CP_KEY`, and `AGENTCONNECT_ROOT`. The cloud model seam uses `MODEL_TOKEN`, `MODEL_BASE_URL`, `KEY_SERVER`, and `KEY_SERVER_TOKEN_PATH` as documented above.
+General environment equivalents use the `AGENTCONNECT_` prefix, such as `AGENTCONNECT_CP_URL`, `AGENTCONNECT_CP_KEY`, and `AGENTCONNECT_ROOT`. The cloud model seam uses `MODEL_TOKEN`, `MODEL_BASE_URL`, their runtime-scoped replacements (`ANTHROPIC_MODEL_*`, `OPENAI_MODEL_*`, `DEEPSEEK_MODEL_*`), `KEY_SERVER`, and `KEY_SERVER_TOKEN_PATH` as documented above.
 
 ### 2.4 Mapping In-Process Responsibilities to CLI
 

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -124,13 +124,14 @@ the first layer that yields a key, whole:
 3. the runtime's default public endpoint with whatever credential the runtime
    environment already carries.
 
-A layer answers with a whole pair or not at all — there is no mixing across layers.
-A key server is asked for both fields and its answer is the credential; a daemon
-configured with one keeps no static pair to fall back to, so a grant that omits
-`baseUrl` leaves the runtime on its own default rather than borrowing a URL the
-issuer never named. A present one must be `http(s)`, since it becomes a runtime's
-API base; plain `http` is legal and is the normal choice for a loopback or in-pod
-gateway.
+The daemon contributes no half of a pair: configuring a key server retires its static
+pair, so a grant is never completed from deployment config the issuer never saw. What
+stays beneath a grant is layer 3 itself — the runtime's own environment, including the
+pod's `AC_*_BASE_URL` floor the shim fills in — so a grant that omits `baseUrl` leaves
+whatever base that environment already carries. A key server fronting a gateway must
+therefore name it; only one content with the runtime's existing endpoint may stay
+silent. A present one must be `http(s)`, since it becomes a runtime's API base; plain
+`http` is legal and is the normal choice for a loopback or in-pod gateway.
 
 The cloud daemon's static pair is `MODEL_TOKEN` plus optional `MODEL_BASE_URL`, with a
 per-runtime pair that replaces it whole: `ANTHROPIC_MODEL_TOKEN`/`ANTHROPIC_MODEL_BASE_URL`
@@ -153,9 +154,9 @@ must be an HTTP(S) URL. Each pair is translated at runtime launch:
 | DeepSeek | `DEEPSEEK_API_KEY`                                                                       | `DEEPSEEK_BASE_URL`                                                                                                                  |
 
 Dynamic grants use the same translation. Configuring a key server retires the static
-pair outright — the daemon reads none of these variables — so a grant is the whole
-credential and needs no precedence against them. With no key server the static pair
-wins; with neither, the runtime's existing provider configuration is left unchanged.
+pair outright — the daemon reads none of these variables — so a grant needs no
+precedence against them. With no key server the static pair wins; with neither, the
+runtime's existing provider configuration is left unchanged.
 
 One logical AgentConnect session owns one ACP host when key-server mode is active.
 Provider credentials are process-level settings, so sharing a runtime would let

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -124,11 +124,13 @@ the first layer that yields a key, whole:
 3. the runtime's default public endpoint with whatever credential the runtime
    environment already carries.
 
-Within a layer, an absent `baseUrl` falls through to the next layer's URL — that
-is the one sanctioned mix, so a key-server that only rotates keys and fronts no
-gateway needs no URL opinion. A present one must be `http(s)`, since it becomes a
-runtime's API base; plain `http` is legal and is the normal choice for a loopback
-or in-pod gateway.
+A layer answers with a whole pair or not at all — there is no mixing across layers.
+A key server is asked for both fields and its answer is the credential; a daemon
+configured with one keeps no static pair to fall back to, so a grant that omits
+`baseUrl` leaves the runtime on its own default rather than borrowing a URL the
+issuer never named. A present one must be `http(s)`, since it becomes a runtime's
+API base; plain `http` is legal and is the normal choice for a loopback or in-pod
+gateway.
 
 The cloud daemon's static pair is `MODEL_TOKEN` plus optional `MODEL_BASE_URL`, with a
 per-runtime pair that replaces it whole: `ANTHROPIC_MODEL_TOKEN`/`ANTHROPIC_MODEL_BASE_URL`
@@ -150,11 +152,10 @@ must be an HTTP(S) URL. Each pair is translated at runtime launch:
 | OpenCode | `OPENCODE_CONFIG_CONTENT` → selected provider `options.apiKey` using `{env:MODEL_TOKEN}` | selected provider `options.baseURL`                                                                                                  |
 | DeepSeek | `DEEPSEEK_API_KEY`                                                                       | `DEEPSEEK_BASE_URL`                                                                                                                  |
 
-Dynamic grants use the same translation and override the static token. If IssueKey
-omits `baseUrl`, the inherited one is the static base for the runtime being spawned —
-its own scoped pair when it has one, the shared `MODEL_BASE_URL` otherwise. With no key server,
-the static pair wins; with neither, the runtime's existing provider configuration is
-left unchanged.
+Dynamic grants use the same translation. Configuring a key server retires the static
+pair outright — the daemon reads none of these variables — so a grant is the whole
+credential and needs no precedence against them. With no key server the static pair
+wins; with neither, the runtime's existing provider configuration is left unchanged.
 
 One logical AgentConnect session owns one ACP host when key-server mode is active.
 Provider credentials are process-level settings, so sharing a runtime would let

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -130,8 +130,13 @@ gateway needs no URL opinion. A present one must be `http(s)`, since it becomes 
 runtime's API base; plain `http` is legal and is the normal choice for a loopback
 or in-pod gateway.
 
-The cloud daemon's static pair is `MODEL_TOKEN` plus optional `MODEL_BASE_URL`.
-`MODEL_BASE_URL` must be an HTTP(S) URL. The pair is translated at runtime launch:
+The cloud daemon's static pair is `MODEL_TOKEN` plus optional `MODEL_BASE_URL`, with
+per-provider overrides `MODEL_TOKEN_ANTHROPIC`/`MODEL_BASE_URL_ANTHROPIC` and
+`MODEL_TOKEN_OPENAI`/`MODEL_BASE_URL_OPENAI`. A scoped pair replaces the unscoped one
+whole for that provider and never merges with it, so the atomicity rule above holds
+inside the static layer too — a gateway's Anthropic and OpenAI base paths differ, and
+`IssueKey` is provider-scoped, so the static layer needs the same dimension. Every
+base URL must be an HTTP(S) URL. The pair is translated at runtime launch:
 
 | Runtime  | Token                                                                                    | Base URL                                                                                                                             |
 | -------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -130,19 +130,25 @@ gateway needs no URL opinion. A present one must be `http(s)`, since it becomes 
 runtime's API base; plain `http` is legal and is the normal choice for a loopback
 or in-pod gateway.
 
-The cloud daemon's static pair is `MODEL_TOKEN` plus optional `MODEL_BASE_URL`, with
-per-provider overrides `MODEL_TOKEN_ANTHROPIC`/`MODEL_BASE_URL_ANTHROPIC` and
-`MODEL_TOKEN_OPENAI`/`MODEL_BASE_URL_OPENAI`. A scoped pair replaces the unscoped one
-whole for that provider and never merges with it, so the atomicity rule above holds
-inside the static layer too — a gateway's Anthropic and OpenAI base paths differ, and
-`IssueKey` is provider-scoped, so the static layer needs the same dimension. Every
-base URL must be an HTTP(S) URL. The pair is translated at runtime launch:
+The cloud daemon's static pair is `MODEL_TOKEN` plus optional `MODEL_BASE_URL`, with a
+per-runtime pair that replaces it whole: `ANTHROPIC_MODEL_TOKEN`/`ANTHROPIC_MODEL_BASE_URL`
+for Claude, `OPENAI_MODEL_*` for Codex, `DEEPSEEK_MODEL_*` for the DeepSeek Harness.
+OpenCode has no pair of its own — it picks a provider per model and takes the shared one.
+
+One deployment gateway is still one address; the runtimes just do not agree on where their
+base ends. Claude Code appends `/v1/messages` to its base, while Codex appends `/responses`
+and OpenCode's providers append `/messages`, so the same gateway is `https://gw` for one and
+`https://gw/v1` for the others. The daemon injects each base verbatim and never derives a
+path: the gateway's own layout is the deployment's to know, so composing these variables from
+one address belongs where that layout is configured, not in a runtime guess. Every base URL
+must be an HTTP(S) URL. Each pair is translated at runtime launch:
 
 | Runtime  | Token                                                                                    | Base URL                                                                                                                             |
 | -------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Claude   | `ANTHROPIC_AUTH_TOKEN`                                                                   | `ANTHROPIC_BASE_URL`                                                                                                                 |
 | Codex    | `OPENAI_API_KEY`                                                                         | `CODEX_CONFIG` → `model_provider = "openai"` and `model_providers.openai.base_url`; `OPENAI_BASE_URL` is also set for older adapters |
 | OpenCode | `OPENCODE_CONFIG_CONTENT` → selected provider `options.apiKey` using `{env:MODEL_TOKEN}` | selected provider `options.baseURL`                                                                                                  |
+| DeepSeek | `DEEPSEEK_API_KEY`                                                                       | `DEEPSEEK_BASE_URL`                                                                                                                  |
 
 Dynamic grants use the same translation and override the static token. If IssueKey
 omits `baseUrl`, only the static `MODEL_BASE_URL` is inherited. With no key server,

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -62,7 +62,7 @@ hold to check it are decided together by the key server's own design and the
 deployment that installs both. This document stops at the header.
 
 `provider` names the API dialect the credential must speak (`anthropic` /
-`openai`) and selects which `(key, baseUrl)` pair comes back. There is
+`openai` / `deepseek`) and selects which `(key, baseUrl)` pair comes back. There is
 deliberately **no `model` parameter**: per-model usage attribution belongs to
 whatever observes actual requests (a gateway data path, or the runtime's own usage
 reports), and a spawn-time hint would invite implementations to treat it as truth
@@ -151,7 +151,8 @@ must be an HTTP(S) URL. Each pair is translated at runtime launch:
 | DeepSeek | `DEEPSEEK_API_KEY`                                                                       | `DEEPSEEK_BASE_URL`                                                                                                                  |
 
 Dynamic grants use the same translation and override the static token. If IssueKey
-omits `baseUrl`, only the static `MODEL_BASE_URL` is inherited. With no key server,
+omits `baseUrl`, the inherited one is the static base for the runtime being spawned —
+its own scoped pair when it has one, the shared `MODEL_BASE_URL` otherwise. With no key server,
 the static pair wins; with neither, the runtime's existing provider configuration is
 left unchanged.
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1113,7 +1113,6 @@ export class Daemon {
     this.sandboxMechanism = this.sandboxProbe?.mechanism
     this.clock = opts.clock ?? systemClock
     this.modelKeyNow = opts.clock ? () => this.clock.now() : () => performance.timeOrigin + performance.now()
-    this.staticModelCredentials = this.k8s ? configuredModelCredentials(process.env) : undefined
     const keyServerAddress = opts.keyServer?.trim() || process.env.KEY_SERVER?.trim()
     const keyServerTokenPath = opts.keyServerTokenPath?.trim() || process.env.KEY_SERVER_TOKEN_PATH?.trim()
     if ((keyServerAddress || opts.keyServerClient) && !this.k8s) {
@@ -1127,6 +1126,8 @@ export class Daemon {
       (keyServerAddress
         ? new KeyServerClient(keyServerAddress, { tokenPath: keyServerTokenPath, now: this.modelKeyNow })
         : undefined)
+    // A key server answers with the whole pair, so the daemon's static one is not a layer under it.
+    this.staticModelCredentials = this.k8s && !this.keyServer ? configuredModelCredentials(process.env) : undefined
     this.evalHooks = new DaemonEvaluationHooks(this.evaluationHost(), opts.evaluation)
     this.sessionMetadataOutbox = new SessionMetadataOutbox(this.sessionMetadataHost())
     this.observedChannelsSync = new ObservedChannelsSync(this.observedChannelsSyncHost())
@@ -3081,7 +3082,7 @@ export class Daemon {
         finalizeLaunchEnv: (launchEnv) => {
           if (!this.k8s || !target) return
           if (opts.modelCredential) applyModelCredential(target, launchEnv, opts.modelCredential.credential)
-          else if (!this.keyServer) {
+          else {
             const configured = this.staticModelCredentials?.[target.runtime]
             if (configured) applyStaticModelConfig(target, launchEnv, configured)
           }
@@ -3363,7 +3364,7 @@ export class Daemon {
   private boundModelTarget(sessionKey: string, agentId: string): ModelProviderTarget | undefined {
     const credentialHost = this.modelSessionHosts.get(sessionKey)
     if (credentialHost) return credentialHost.target
-    if (this.keyServer || !this.k8s || !this.staticModelCredentials) return undefined
+    if (!this.k8s || !this.staticModelCredentials) return undefined
     const agent = this.agents.get(agentId)
     const runtime = agent ? this.runtimes[agent.runtime] : undefined
     const target = agent && runtime ? modelProviderTarget(agent, runtime) : undefined
@@ -3418,9 +3419,7 @@ export class Daemon {
           target: entry.target,
           credential: {
             key: entry.grant.key,
-            ...((entry.grant.baseUrl ?? this.staticModelCredentials?.[entry.target.runtime]?.baseUrl)
-              ? { baseUrl: entry.grant.baseUrl ?? this.staticModelCredentials?.[entry.target.runtime]?.baseUrl }
-              : {})
+            ...(entry.grant.baseUrl ? { baseUrl: entry.grant.baseUrl } : {})
           }
         }
       })
@@ -4014,9 +4013,7 @@ export class Daemon {
               target: issued.target,
               credential: {
                 key: issued.grant.key,
-                ...((issued.grant.baseUrl ?? this.staticModelCredentials?.[issued.target.runtime]?.baseUrl)
-                  ? { baseUrl: issued.grant.baseUrl ?? this.staticModelCredentials?.[issued.target.runtime]?.baseUrl }
-                  : {})
+                ...(issued.grant.baseUrl ? { baseUrl: issued.grant.baseUrl } : {})
               }
             }
           }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -210,10 +210,11 @@ import { runtimeHomePath } from './runtimes/runtime-home.js'
 import {
   applyModelCredential,
   applyStaticModelConfig,
-  configuredModelCredential,
+  configuredModelCredentials,
   modelProviderTarget,
   type ModelCredential,
-  type ModelProviderTarget
+  type ModelProviderTarget,
+  type StaticModelCredentials
 } from './runtimes/model-provider-config.js'
 import { DEFAULT_MODEL_KEY_TTL_SECONDS, KeyServerClient, type KeyGrant } from './key-server/client.js'
 import { CuratedRuntimeAdmission } from './runtimes/curated-admission.js'
@@ -833,7 +834,7 @@ export class Daemon {
   private readonly k8s: boolean
   private readonly keyServer?: KeyServerClient
   private readonly modelKeyNow: () => number
-  private readonly staticModelCredential?: ModelCredential
+  private readonly staticModelCredentials?: StaticModelCredentials
   /** Reads this pod's projected CP-audience token; undefined unless the daemon runs
    *  in-cluster AND the volume is actually mounted (decided once, at boot). */
   private readonly clusterIdentityToken?: () => string | undefined
@@ -1112,7 +1113,7 @@ export class Daemon {
     this.sandboxMechanism = this.sandboxProbe?.mechanism
     this.clock = opts.clock ?? systemClock
     this.modelKeyNow = opts.clock ? () => this.clock.now() : () => performance.timeOrigin + performance.now()
-    this.staticModelCredential = this.k8s ? configuredModelCredential(process.env) : undefined
+    this.staticModelCredentials = this.k8s ? configuredModelCredentials(process.env) : undefined
     const keyServerAddress = opts.keyServer?.trim() || process.env.KEY_SERVER?.trim()
     const keyServerTokenPath = opts.keyServerTokenPath?.trim() || process.env.KEY_SERVER_TOKEN_PATH?.trim()
     if ((keyServerAddress || opts.keyServerClient) && !this.k8s) {
@@ -3080,8 +3081,9 @@ export class Daemon {
         finalizeLaunchEnv: (launchEnv) => {
           if (!this.k8s || !target) return
           if (opts.modelCredential) applyModelCredential(target, launchEnv, opts.modelCredential.credential)
-          else if (!this.keyServer && this.staticModelCredential) {
-            applyStaticModelConfig(target, launchEnv, this.staticModelCredential)
+          else if (!this.keyServer) {
+            const configured = this.staticModelCredentials?.[target.provider]
+            if (configured) applyStaticModelConfig(target, launchEnv, configured)
           }
         },
         runtimeReadRoots: runInSandbox
@@ -3361,7 +3363,7 @@ export class Daemon {
   private boundModelTarget(sessionKey: string, agentId: string): ModelProviderTarget | undefined {
     const credentialHost = this.modelSessionHosts.get(sessionKey)
     if (credentialHost) return credentialHost.target
-    if (this.keyServer || !this.k8s || !this.staticModelCredential) return undefined
+    if (this.keyServer || !this.k8s || !this.staticModelCredentials) return undefined
     const agent = this.agents.get(agentId)
     const runtime = agent ? this.runtimes[agent.runtime] : undefined
     return agent && runtime ? modelProviderTarget(agent, runtime) : undefined
@@ -3414,8 +3416,8 @@ export class Daemon {
           target: entry.target,
           credential: {
             key: entry.grant.key,
-            ...((entry.grant.baseUrl ?? this.staticModelCredential?.baseUrl)
-              ? { baseUrl: entry.grant.baseUrl ?? this.staticModelCredential?.baseUrl }
+            ...((entry.grant.baseUrl ?? this.staticModelCredentials?.[entry.target.provider]?.baseUrl)
+              ? { baseUrl: entry.grant.baseUrl ?? this.staticModelCredentials?.[entry.target.provider]?.baseUrl }
               : {})
           }
         }
@@ -4010,8 +4012,8 @@ export class Daemon {
               target: issued.target,
               credential: {
                 key: issued.grant.key,
-                ...((issued.grant.baseUrl ?? this.staticModelCredential?.baseUrl)
-                  ? { baseUrl: issued.grant.baseUrl ?? this.staticModelCredential?.baseUrl }
+                ...((issued.grant.baseUrl ?? this.staticModelCredentials?.[issued.target.provider]?.baseUrl)
+                  ? { baseUrl: issued.grant.baseUrl ?? this.staticModelCredentials?.[issued.target.provider]?.baseUrl }
                   : {})
               }
             }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3366,7 +3366,9 @@ export class Daemon {
     if (this.keyServer || !this.k8s || !this.staticModelCredentials) return undefined
     const agent = this.agents.get(agentId)
     const runtime = agent ? this.runtimes[agent.runtime] : undefined
-    return agent && runtime ? modelProviderTarget(agent, runtime) : undefined
+    const target = agent && runtime ? modelProviderTarget(agent, runtime) : undefined
+    // A partial map binds only the providers it configures; the rest keep their runtime-owned auth.
+    return target && this.staticModelCredentials[target.provider] ? target : undefined
   }
 
   /** Whether a model resolves to a different provider than the one the session's host was

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3082,7 +3082,7 @@ export class Daemon {
           if (!this.k8s || !target) return
           if (opts.modelCredential) applyModelCredential(target, launchEnv, opts.modelCredential.credential)
           else if (!this.keyServer) {
-            const configured = this.staticModelCredentials?.[target.provider]
+            const configured = this.staticModelCredentials?.[target.runtime]
             if (configured) applyStaticModelConfig(target, launchEnv, configured)
           }
         },
@@ -3368,7 +3368,7 @@ export class Daemon {
     const runtime = agent ? this.runtimes[agent.runtime] : undefined
     const target = agent && runtime ? modelProviderTarget(agent, runtime) : undefined
     // A partial map binds only the providers it configures; the rest keep their runtime-owned auth.
-    return target && this.staticModelCredentials[target.provider] ? target : undefined
+    return target && this.staticModelCredentials[target.runtime] ? target : undefined
   }
 
   /** Whether a model resolves to a different provider than the one the session's host was
@@ -3418,8 +3418,8 @@ export class Daemon {
           target: entry.target,
           credential: {
             key: entry.grant.key,
-            ...((entry.grant.baseUrl ?? this.staticModelCredentials?.[entry.target.provider]?.baseUrl)
-              ? { baseUrl: entry.grant.baseUrl ?? this.staticModelCredentials?.[entry.target.provider]?.baseUrl }
+            ...((entry.grant.baseUrl ?? this.staticModelCredentials?.[entry.target.runtime]?.baseUrl)
+              ? { baseUrl: entry.grant.baseUrl ?? this.staticModelCredentials?.[entry.target.runtime]?.baseUrl }
               : {})
           }
         }
@@ -4014,8 +4014,8 @@ export class Daemon {
               target: issued.target,
               credential: {
                 key: issued.grant.key,
-                ...((issued.grant.baseUrl ?? this.staticModelCredentials?.[issued.target.provider]?.baseUrl)
-                  ? { baseUrl: issued.grant.baseUrl ?? this.staticModelCredentials?.[issued.target.provider]?.baseUrl }
+                ...((issued.grant.baseUrl ?? this.staticModelCredentials?.[issued.target.runtime]?.baseUrl)
+                  ? { baseUrl: issued.grant.baseUrl ?? this.staticModelCredentials?.[issued.target.runtime]?.baseUrl }
                   : {})
               }
             }

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -10,15 +10,24 @@ export interface ModelCredential {
   baseUrl?: string
 }
 
+/** Which runtime's own provider-configuration surface a credential must be written onto. */
+export type ModelRuntimeKind = 'claude' | 'codex' | 'opencode' | 'deepseek'
+
 export interface ModelProviderTarget {
   provider: KeyProvider
-  runtime: 'claude' | 'codex' | 'opencode'
+  runtime: ModelRuntimeKind
   opencodeProvider?: string
 }
 
 function isOpenCodeRuntime(runtimeId: string, runtime: RuntimeDef): boolean {
   if (runtimeId === 'opencode') return true
   return [runtime.command, ...runtime.args].some((part) => /(?:^|[\/@])opencode(?:@[^\/]*)?$/.test(part.toLowerCase()))
+}
+
+// The bin, not the package: `dsh-acp` is the single bin of @openma/deepseek-harness-acp.
+function isDeepSeekRuntime(runtimeId: string, runtime: RuntimeDef): boolean {
+  if (runtimeId === 'dsh-acp') return true
+  return [runtime.command, ...runtime.args].some((part) => /(?:^|[\/@])dsh-acp(?:@[^\/]*)?$/.test(part.toLowerCase()))
 }
 
 function applyCodexBaseUrl(env: Record<string, string>, baseUrl: string): void {
@@ -33,6 +42,7 @@ export function modelProviderTarget(
 ): ModelProviderTarget | undefined {
   if (isClaudeRuntimeDef(runtime)) return { provider: 'anthropic', runtime: 'claude' }
   if (sharedCredentialProfile(agent.runtime, runtime) === 'codex') return { provider: 'openai', runtime: 'codex' }
+  if (isDeepSeekRuntime(agent.runtime, runtime)) return { provider: 'deepseek', runtime: 'deepseek' }
   if (!isOpenCodeRuntime(agent.runtime, runtime)) return undefined
 
   const configuredProvider = effectiveModel?.includes('/') ? effectiveModel.split('/', 1)[0]?.trim() : undefined
@@ -54,6 +64,12 @@ export function applyModelCredential(
     env.ANTHROPIC_AUTH_TOKEN = credential.key
     delete env.ANTHROPIC_API_KEY
     if (credential.baseUrl) env.ANTHROPIC_BASE_URL = credential.baseUrl
+    return
+  }
+
+  if (target.runtime === 'deepseek') {
+    env.DEEPSEEK_API_KEY = credential.key
+    if (credential.baseUrl) env.DEEPSEEK_BASE_URL = credential.baseUrl
     return
   }
 
@@ -87,29 +103,39 @@ export function applyModelCredential(
   })
 }
 
-export type StaticModelCredentials = Partial<Record<KeyProvider, ModelCredential>>
+export type StaticModelCredentials = Partial<Record<ModelRuntimeKind, ModelCredential>>
 
-const PROVIDER_ENV_SUFFIX: Record<KeyProvider, string> = { anthropic: '_ANTHROPIC', openai: '_OPENAI' }
+// One gateway, one variable per runtime: each runtime speaks its vendor's dialect at its own
+// path, so the deployment composes the exact base each one needs and the daemon never guesses.
+// OpenCode has no variable of its own — it selects a provider per model and takes the shared pair.
+const RUNTIME_ENV_PREFIX: Partial<Record<ModelRuntimeKind, string>> = {
+  claude: 'ANTHROPIC_',
+  codex: 'OPENAI_',
+  deepseek: 'DEEPSEEK_'
+}
 
-function staticPair(env: NodeJS.ProcessEnv, suffix: string): ModelCredential | undefined {
-  const key = env[`MODEL_TOKEN${suffix}`]?.trim()
-  const baseUrl = env[`MODEL_BASE_URL${suffix}`]?.trim()
+const RUNTIME_KINDS: readonly ModelRuntimeKind[] = ['claude', 'codex', 'opencode', 'deepseek']
+
+function staticPair(env: NodeJS.ProcessEnv, prefix: string): ModelCredential | undefined {
+  const key = env[`${prefix}MODEL_TOKEN`]?.trim()
+  const baseUrl = env[`${prefix}MODEL_BASE_URL`]?.trim()
   if (!key && !baseUrl) return undefined
   if (baseUrl && (!URL.canParse(baseUrl) || !['http:', 'https:'].includes(new URL(baseUrl).protocol))) {
-    throw new Error(`MODEL_BASE_URL${suffix} must be an http(s) URL`)
+    throw new Error(`${prefix}MODEL_BASE_URL must be an http(s) URL`)
   }
   // A URL-only layer uses an internal empty sentinel; applyStaticModelConfig preserves the runtime key.
   return { key: key ?? '', ...(baseUrl ? { baseUrl } : {}) }
 }
 
-// A provider-scoped pair replaces the unscoped one whole, never merges: one gateway's Anthropic and
-// OpenAI paths differ, and splitting a pair aims a key at an endpoint that never issued it.
+// A runtime-scoped pair replaces the shared one whole, never merges: splitting a pair aims a key
+// at an endpoint that never issued it.
 export function configuredModelCredentials(env: NodeJS.ProcessEnv): StaticModelCredentials | undefined {
   const shared = staticPair(env, '')
   const resolved: StaticModelCredentials = {}
-  for (const provider of Object.keys(PROVIDER_ENV_SUFFIX) as KeyProvider[]) {
-    const pair = staticPair(env, PROVIDER_ENV_SUFFIX[provider]) ?? shared
-    if (pair) resolved[provider] = pair
+  for (const kind of RUNTIME_KINDS) {
+    const prefix = RUNTIME_ENV_PREFIX[kind]
+    const pair = (prefix ? staticPair(env, prefix) : undefined) ?? shared
+    if (pair) resolved[kind] = pair
   }
   return Object.keys(resolved).length > 0 ? resolved : undefined
 }
@@ -125,6 +151,7 @@ export function applyStaticModelConfig(
   }
   if (!configured.baseUrl) return
   if (target.runtime === 'claude') env.ANTHROPIC_BASE_URL = configured.baseUrl
+  else if (target.runtime === 'deepseek') env.DEEPSEEK_BASE_URL = configured.baseUrl
   else if (target.runtime === 'codex') applyCodexBaseUrl(env, configured.baseUrl)
   else {
     const providerId = target.opencodeProvider ?? 'openai'

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -87,15 +87,31 @@ export function applyModelCredential(
   })
 }
 
-export function configuredModelCredential(env: NodeJS.ProcessEnv): ModelCredential | undefined {
-  const key = env.MODEL_TOKEN?.trim()
-  const baseUrl = env.MODEL_BASE_URL?.trim()
+export type StaticModelCredentials = Partial<Record<KeyProvider, ModelCredential>>
+
+const PROVIDER_ENV_SUFFIX: Record<KeyProvider, string> = { anthropic: '_ANTHROPIC', openai: '_OPENAI' }
+
+function staticPair(env: NodeJS.ProcessEnv, suffix: string): ModelCredential | undefined {
+  const key = env[`MODEL_TOKEN${suffix}`]?.trim()
+  const baseUrl = env[`MODEL_BASE_URL${suffix}`]?.trim()
   if (!key && !baseUrl) return undefined
   if (baseUrl && (!URL.canParse(baseUrl) || !['http:', 'https:'].includes(new URL(baseUrl).protocol))) {
-    throw new Error('MODEL_BASE_URL must be an http(s) URL')
+    throw new Error(`MODEL_BASE_URL${suffix} must be an http(s) URL`)
   }
   // A URL-only layer uses an internal empty sentinel; applyStaticModelConfig preserves the runtime key.
   return { key: key ?? '', ...(baseUrl ? { baseUrl } : {}) }
+}
+
+// A provider-scoped pair replaces the unscoped one whole, never merges: one gateway's Anthropic and
+// OpenAI paths differ, and splitting a pair aims a key at an endpoint that never issued it.
+export function configuredModelCredentials(env: NodeJS.ProcessEnv): StaticModelCredentials | undefined {
+  const shared = staticPair(env, '')
+  const resolved: StaticModelCredentials = {}
+  for (const provider of Object.keys(PROVIDER_ENV_SUFFIX) as KeyProvider[]) {
+    const pair = staticPair(env, PROVIDER_ENV_SUFFIX[provider]) ?? shared
+    if (pair) resolved[provider] = pair
+  }
+  return Object.keys(resolved).length > 0 ? resolved : undefined
 }
 
 export function applyStaticModelConfig(

--- a/packages/daemon/test/model-key-session.test.ts
+++ b/packages/daemon/test/model-key-session.test.ts
@@ -201,6 +201,11 @@ describe('daemon model-key session lifecycle', () => {
     expect(setModelOverride).toHaveBeenCalledWith('session-a', 'anthropic/claude-opus-4')
   })
 
+  it('keeps no static pair to fall back to when a key server is configured', () => {
+    const withServer = new Daemon({ k8s: true, keyServer: 'https://keys.test', clock: new FakeClock(1_000) }) as any
+    expect(withServer.staticModelCredentials).toBeUndefined()
+  })
+
   it('revokes the fresh grant when replacing the superseded host fails', async () => {
     const h = harness([
       { keyId: 'key-1', key: 'old', requestedAtMs: 1_000, refreshAtMs: 2_000 },

--- a/packages/daemon/test/model-key-session.test.ts
+++ b/packages/daemon/test/model-key-session.test.ts
@@ -164,7 +164,7 @@ describe('daemon model-key session lifecycle', () => {
 
   it('refuses a cross-provider switch on the shared static-credential host', async () => {
     const daemon = new Daemon({ k8s: true, clock: new FakeClock(1_000) }) as any
-    daemon.staticModelCredentials = { anthropic: { key: 'static-token' }, openai: { key: 'static-token' } }
+    daemon.staticModelCredentials = { opencode: { key: 'static-token' } }
     const opencodeAgent = {
       id: 'agent-a',
       runtime: 'opencode',
@@ -182,9 +182,9 @@ describe('daemon model-key session lifecycle', () => {
     expect(setModelOverride).toHaveBeenCalledWith('session-a', 'openai/gpt-5-codex')
   })
 
-  it('leaves a provider the static map never configured switchable', async () => {
+  it('leaves a runtime the static map never configured switchable', async () => {
     const daemon = new Daemon({ k8s: true, clock: new FakeClock(1_000) }) as any
-    daemon.staticModelCredentials = { anthropic: { key: 'static-token' } }
+    daemon.staticModelCredentials = { claude: { key: 'static-token' } }
     const opencodeAgent = {
       id: 'agent-a',
       runtime: 'opencode',
@@ -196,7 +196,7 @@ describe('daemon model-key session lifecycle', () => {
     const setModelOverride = vi.fn()
     daemon.store = { getSession: () => ({ agentId: 'agent-a', acpSessionId: null }), setModelOverride }
 
-    // The OpenAI host runs on runtime-owned auth, so nothing pins it to that provider.
+    // The map configures no opencode pair, so this host runs on runtime-owned auth and stays switchable.
     expect(await daemon.commands.setModelByKey('session-a', 'anthropic/claude-opus-4')).toBe(true)
     expect(setModelOverride).toHaveBeenCalledWith('session-a', 'anthropic/claude-opus-4')
   })

--- a/packages/daemon/test/model-key-session.test.ts
+++ b/packages/daemon/test/model-key-session.test.ts
@@ -164,7 +164,7 @@ describe('daemon model-key session lifecycle', () => {
 
   it('refuses a cross-provider switch on the shared static-credential host', async () => {
     const daemon = new Daemon({ k8s: true, clock: new FakeClock(1_000) }) as any
-    daemon.staticModelCredential = { key: 'static-token' }
+    daemon.staticModelCredentials = { anthropic: { key: 'static-token' }, openai: { key: 'static-token' } }
     const opencodeAgent = {
       id: 'agent-a',
       runtime: 'opencode',
@@ -180,6 +180,25 @@ describe('daemon model-key session lifecycle', () => {
     expect(setModelOverride).not.toHaveBeenCalled()
     expect(await daemon.commands.setModelByKey('session-a', 'openai/gpt-5-codex')).toBe(true)
     expect(setModelOverride).toHaveBeenCalledWith('session-a', 'openai/gpt-5-codex')
+  })
+
+  it('leaves a provider the static map never configured switchable', async () => {
+    const daemon = new Daemon({ k8s: true, clock: new FakeClock(1_000) }) as any
+    daemon.staticModelCredentials = { anthropic: { key: 'static-token' } }
+    const opencodeAgent = {
+      id: 'agent-a',
+      runtime: 'opencode',
+      allowRuntimeChangesInChat: true,
+      runtimeOverrides: { model: 'openai/gpt-5', env: [], secrets: [] }
+    }
+    daemon.runtimes = { opencode: { command: 'opencode', args: ['acp'], env: [] } }
+    daemon.agents.set('agent-a', opencodeAgent)
+    const setModelOverride = vi.fn()
+    daemon.store = { getSession: () => ({ agentId: 'agent-a', acpSessionId: null }), setModelOverride }
+
+    // The OpenAI host runs on runtime-owned auth, so nothing pins it to that provider.
+    expect(await daemon.commands.setModelByKey('session-a', 'anthropic/claude-opus-4')).toBe(true)
+    expect(setModelOverride).toHaveBeenCalledWith('session-a', 'anthropic/claude-opus-4')
   })
 
   it('revokes the fresh grant when replacing the superseded host fails', async () => {

--- a/packages/daemon/test/model-provider-config.test.ts
+++ b/packages/daemon/test/model-provider-config.test.ts
@@ -109,42 +109,76 @@ describe('applyModelCredential', () => {
 
   it('rejects a non-HTTP static gateway URL', () => {
     expect(() => configuredModelCredentials({ MODEL_BASE_URL: 'file:///tmp/provider' })).toThrow(/http\(s\)/)
-    expect(() => configuredModelCredentials({ MODEL_BASE_URL_ANTHROPIC: 'file:///tmp/provider' })).toThrow(
-      /MODEL_BASE_URL_ANTHROPIC must be an http\(s\) URL/
+    expect(() => configuredModelCredentials({ ANTHROPIC_MODEL_BASE_URL: 'file:///tmp/provider' })).toThrow(
+      /ANTHROPIC_MODEL_BASE_URL must be an http\(s\) URL/
     )
   })
 
-  it('reads the unscoped static pair for both providers', () => {
+  it('reads the shared static pair for every runtime', () => {
     expect(configuredModelCredentials({ MODEL_TOKEN: 'k', MODEL_BASE_URL: 'https://gw.example' })).toEqual({
-      anthropic: { key: 'k', baseUrl: 'https://gw.example' },
-      openai: { key: 'k', baseUrl: 'https://gw.example' }
+      claude: { key: 'k', baseUrl: 'https://gw.example' },
+      codex: { key: 'k', baseUrl: 'https://gw.example' },
+      opencode: { key: 'k', baseUrl: 'https://gw.example' },
+      deepseek: { key: 'k', baseUrl: 'https://gw.example' }
     })
   })
 
-  it('lets a provider-scoped pair replace the unscoped one whole', () => {
+  it('lets each runtime carry the base its own dialect needs', () => {
+    expect(
+      configuredModelCredentials({
+        MODEL_TOKEN: 'gw-token',
+        ANTHROPIC_MODEL_BASE_URL: 'https://gw.example',
+        ANTHROPIC_MODEL_TOKEN: 'gw-token',
+        OPENAI_MODEL_BASE_URL: 'https://gw.example/v1',
+        OPENAI_MODEL_TOKEN: 'gw-token',
+        DEEPSEEK_MODEL_BASE_URL: 'https://gw.example/deepseek/v1',
+        DEEPSEEK_MODEL_TOKEN: 'gw-token'
+      })
+    ).toEqual({
+      claude: { key: 'gw-token', baseUrl: 'https://gw.example' },
+      codex: { key: 'gw-token', baseUrl: 'https://gw.example/v1' },
+      opencode: { key: 'gw-token' },
+      deepseek: { key: 'gw-token', baseUrl: 'https://gw.example/deepseek/v1' }
+    })
+  })
+
+  it('replaces the shared pair whole rather than merging into it', () => {
     expect(
       configuredModelCredentials({
         MODEL_TOKEN: 'shared',
-        MODEL_BASE_URL: 'https://gw.example/openai/v1',
-        MODEL_TOKEN_ANTHROPIC: 'anthropic-key',
-        MODEL_BASE_URL_ANTHROPIC: 'https://gw.example/anthropic'
+        MODEL_BASE_URL: 'https://shared.example',
+        ANTHROPIC_MODEL_BASE_URL: 'https://gw.example'
       })
-    ).toEqual({
-      anthropic: { key: 'anthropic-key', baseUrl: 'https://gw.example/anthropic' },
-      openai: { key: 'shared', baseUrl: 'https://gw.example/openai/v1' }
-    })
-  })
-
-  it('scopes a URL-only override without inheriting the unscoped URL', () => {
-    expect(
-      configuredModelCredentials({ MODEL_TOKEN: 'shared', MODEL_BASE_URL_ANTHROPIC: 'https://gw.example/anthropic' })
-    ).toEqual({
-      anthropic: { key: '', baseUrl: 'https://gw.example/anthropic' },
-      openai: { key: 'shared' }
+    ).toMatchObject({
+      // The scoped pair carries no key, so nothing of the shared pair survives into it.
+      claude: { key: '', baseUrl: 'https://gw.example' },
+      codex: { key: 'shared', baseUrl: 'https://shared.example' }
     })
   })
 
   it('is undefined when nothing is configured', () => {
     expect(configuredModelCredentials({})).toBeUndefined()
+  })
+
+  it('aims a deepseek runtime at its own provider variables', () => {
+    const env: Record<string, string> = {}
+    applyModelCredential({ provider: 'deepseek', runtime: 'deepseek' }, env, {
+      key: 'dsh-key',
+      baseUrl: 'https://gw.example/deepseek/v1'
+    })
+    expect(env).toEqual({ DEEPSEEK_API_KEY: 'dsh-key', DEEPSEEK_BASE_URL: 'https://gw.example/deepseek/v1' })
+  })
+
+  it('targets the deepseek harness by its dsh-acp bin', () => {
+    expect(
+      modelProviderTarget(
+        { runtime: 'dsh-acp' } as never,
+        {
+          command: 'npx',
+          args: ['-y', '-p', '@openma/deepseek-harness-acp@^0.4', 'dsh-acp'],
+          env: []
+        } as never
+      )
+    ).toEqual({ provider: 'deepseek', runtime: 'deepseek' })
   })
 })

--- a/packages/daemon/test/model-provider-config.test.ts
+++ b/packages/daemon/test/model-provider-config.test.ts
@@ -4,7 +4,7 @@ import type { RuntimeDef } from '../src/config/config-schema.js'
 import {
   applyModelCredential,
   applyStaticModelConfig,
-  configuredModelCredential,
+  configuredModelCredentials,
   modelProviderTarget
 } from '../src/runtimes/model-provider-config.js'
 
@@ -108,6 +108,43 @@ describe('applyModelCredential', () => {
   })
 
   it('rejects a non-HTTP static gateway URL', () => {
-    expect(() => configuredModelCredential({ MODEL_BASE_URL: 'file:///tmp/provider' })).toThrow(/http\(s\)/)
+    expect(() => configuredModelCredentials({ MODEL_BASE_URL: 'file:///tmp/provider' })).toThrow(/http\(s\)/)
+    expect(() => configuredModelCredentials({ MODEL_BASE_URL_ANTHROPIC: 'file:///tmp/provider' })).toThrow(
+      /MODEL_BASE_URL_ANTHROPIC must be an http\(s\) URL/
+    )
+  })
+
+  it('reads the unscoped static pair for both providers', () => {
+    expect(configuredModelCredentials({ MODEL_TOKEN: 'k', MODEL_BASE_URL: 'https://gw.example' })).toEqual({
+      anthropic: { key: 'k', baseUrl: 'https://gw.example' },
+      openai: { key: 'k', baseUrl: 'https://gw.example' }
+    })
+  })
+
+  it('lets a provider-scoped pair replace the unscoped one whole', () => {
+    expect(
+      configuredModelCredentials({
+        MODEL_TOKEN: 'shared',
+        MODEL_BASE_URL: 'https://gw.example/openai/v1',
+        MODEL_TOKEN_ANTHROPIC: 'anthropic-key',
+        MODEL_BASE_URL_ANTHROPIC: 'https://gw.example/anthropic'
+      })
+    ).toEqual({
+      anthropic: { key: 'anthropic-key', baseUrl: 'https://gw.example/anthropic' },
+      openai: { key: 'shared', baseUrl: 'https://gw.example/openai/v1' }
+    })
+  })
+
+  it('scopes a URL-only override without inheriting the unscoped URL', () => {
+    expect(
+      configuredModelCredentials({ MODEL_TOKEN: 'shared', MODEL_BASE_URL_ANTHROPIC: 'https://gw.example/anthropic' })
+    ).toEqual({
+      anthropic: { key: '', baseUrl: 'https://gw.example/anthropic' },
+      openai: { key: 'shared' }
+    })
+  })
+
+  it('is undefined when nothing is configured', () => {
+    expect(configuredModelCredentials({})).toBeUndefined()
   })
 })

--- a/packages/protocol/src/key-server.ts
+++ b/packages/protocol/src/key-server.ts
@@ -26,7 +26,7 @@ export const KEY_SERVER_REVOKE_KEY_PATH = '/v1/revoke-key' as const
 export const KEY_SERVER_AUTH_HEADER = 'authorization' as const
 
 /** Provider API dialect the credential must speak; selects the (key, baseUrl) pair. */
-export const KeyProvider = z.enum(['anthropic', 'openai'])
+export const KeyProvider = z.enum(['anthropic', 'openai', 'deepseek'])
 export type KeyProvider = z.infer<typeof KeyProvider>
 
 // No `daemonId` field: caller identity belongs to the transport, and a server able to


### PR DESCRIPTION
## Why

Two defects in the static credential layer, both found by pointing a cloud daemon at a real inference gateway.

**1. One `MODEL_BASE_URL` could not name one gateway.** The runtimes disagree on where a base URL ends:

| runtime | appends | so one gateway root `http://gw:8080` must be given as |
|---|---|---|
| claude (Claude Code) | `/v1/messages` | `http://gw:8080` |
| codex | `/responses` | `http://gw:8080/v1` |
| opencode (openai / anthropic) | `/chat/completions` / `/messages` | `http://gw:8080/v1` |

One deployment gateway is still one address — the variable just could not say both forms of it. Verified against a live Envoy AI Gateway: its `AIGatewayRoute`s match on model name with `PathPrefix: /` and rewrite only Host, so the path reaching the upstream is the upstream's own (`/v1/responses` → OpenAI 200, `/v1/messages` → Anthropic).

**2. A key-server grant was whole in its key but not in its base URL.** A response without a `baseUrl` inherited the daemon's static base — so a runtime could be aimed at a gateway the issuer never named while carrying a credential that gateway never saw. That is the same split-pair failure §4 exists to prevent, one field over.

## What

**Runtime-scoped static pairs.** Each runtime reads its own pair, replacing the shared one **whole**: `ANTHROPIC_MODEL_TOKEN`/`ANTHROPIC_MODEL_BASE_URL` (claude), `OPENAI_MODEL_*` (codex), `DEEPSEEK_MODEL_*` (dsh-acp). `MODEL_TOKEN`/`MODEL_BASE_URL` remain the shared fallback, so **no existing deployment changes**. A scoped pair naming only a URL yields an empty key and falls through rather than quietly borrowing the shared token for a different endpoint.

**Scoped by runtime, not by provider.** OpenCode-on-anthropic needs the `/v1` that Claude Code must not have, so a provider key would collide. OpenCode keeps taking the shared pair — it selects a provider per model and has no single base of its own.

**A key server retires the static pair.** Configuring one means the daemon reads none of these variables, so there is no layer under the grant to mix with and nothing to give precedence against. A grant without a `baseUrl` leaves the runtime on its own default instead of borrowing a URL the issuer never named.

**The daemon still injects every base verbatim** and derives no paths. A gateway's layout is the deployment's to know, so composing these variables from one address belongs where that layout is configured — agentconnect-md/workflows#156 does exactly that.

**DeepSeek Harness gains a credential target at all.** `modelProviderTarget` previously returned `undefined` for `dsh-acp`, so the daemon injected nothing. Now `DEEPSEEK_API_KEY`/`DEEPSEEK_BASE_URL`, matching the shim's existing `SANDBOX_PROVIDER_ENV.deepseek` mapping. `KeyProvider` gains `deepseek` (protocol; the daemon is its only consumer).

## Breaking

- A daemon with a key server **no longer inherits a static base URL** for a grant that omits one. A deployment relying on that mix must have its key server return the `baseUrl`.
- Internal to the daemon package: `ModelProviderTarget.runtime` is now `ModelRuntimeKind`; `configuredModelCredential` became `configuredModelCredentials`, returning a per-runtime map.
- The env contract itself is additive.

## Design docs

`key-server.md` §2 (provider enum), §4 (precedence — layers no longer mix, and the static-pair table), `daemon-detailed-design.md` (env list) and `cluster-spawn-and-shim.md` (which said DeepSeek has no neutral-pair translation) all carry the new contract.

## Testing

- `model-provider-config.test.ts` — 12: shared pair covers every runtime, per-runtime bases, whole-pair replacement, scoped URL validation naming the offending variable, deepseek injection, `dsh-acp` targeting by its bin.
- `model-key-session.test.ts` — 12: including a runtime the map never configured staying switchable, and a key-server daemon holding no static pair.
- `shim-provider-env` + `acp-config` — 42
- `pnpm --filter @agentconnect.md/daemon typecheck`, `--filter @agentconnect.md/protocol typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)