### PR TITLE
feat(daemon)!: the key is issued, the base URL is deployed

### DIFF
--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -111,27 +111,30 @@ overstating the degradation window by the same amount.
   `expiresInSeconds` and strictly less than it. Daemons renew inside that window
   instead of inventing their own margin.
 
-## 4. Injection: one precedence chain, pairs never split
+## 4. Injection: the key is issued, the base URL is deployed
 
-The response pair is atomic with respect to injection — a dynamic key must never
-be combined with a static base URL or vice versa (a gateway credential aimed at a
-public endpoint 401s; a real key aimed at a gateway bypasses whatever the
-deployment put there). The daemon resolves the pair for a spawn top-down and takes
-the first layer that yields a key, whole:
+Key and base URL answer to different owners, so they come from different places and
+neither completes the other:
 
-1. `IssueKey` response — when a key-server address is configured;
-2. the daemon's static config pair — when no key-server is configured;
-3. the runtime's default public endpoint with whatever credential the runtime
-   environment already carries.
+- **the key** is per-session identity, and an `IssueKey` response is its only source
+  when a key-server address is configured; with none, the daemon's static token; with
+  neither, whatever credential the runtime environment already carries.
+- **the base URL** is deployment topology — which gateway this install's runtimes talk
+  to — so it always comes from the daemon's own configuration, key server or not. An
+  `IssueKey` response may carry a `baseUrl`; the daemon does not read it.
 
-The daemon contributes no half of a pair: configuring a key server retires its static
-pair, so a grant is never completed from deployment config the issuer never saw. What
-stays beneath a grant is layer 3 itself — the runtime's own environment, including the
-pod's `AC_*_BASE_URL` floor the shim fills in — so a grant that omits `baseUrl` leaves
-whatever base that environment already carries. A key server fronting a gateway must
-therefore name it; only one content with the runtime's existing endpoint may stay
-silent. A present one must be `http(s)`, since it becomes a runtime's API base; plain
-`http` is legal and is the normal choice for a loopback or in-pod gateway.
+The earlier rule was the opposite: the response pair was atomic, so a key server that
+fronted a gateway had to name it and one that did not had to stay silent. That made
+every issuer restate a fact it does not own — the address is the same for every session
+the install ever runs, and it is already written down where the gateway is deployed.
+Restating it invites the two copies to disagree, and the disagreement surfaces as a
+runtime aimed somewhere the deployment never put a gateway.
+
+What remains beneath both is the runtime's own environment, including the pod's
+`AC_*_BASE_URL` floor the shim fills in: a daemon with no base URL configured for a
+runtime leaves that environment as it found it. A configured base URL must be
+`http(s)`, since it becomes a runtime's API base; plain `http` is legal and is the
+normal choice for a loopback or in-pod gateway.
 
 The cloud daemon's static pair is `MODEL_TOKEN` plus optional `MODEL_BASE_URL`, with a
 per-runtime pair that replaces it whole: `ANTHROPIC_MODEL_TOKEN`/`ANTHROPIC_MODEL_BASE_URL`
@@ -153,10 +156,10 @@ must be an HTTP(S) URL. Each pair is translated at runtime launch:
 | OpenCode | `OPENCODE_CONFIG_CONTENT` → selected provider `options.apiKey` using `{env:MODEL_TOKEN}` | selected provider `options.baseURL`                                                                                                  |
 | DeepSeek | `DEEPSEEK_API_KEY`                                                                       | `DEEPSEEK_BASE_URL`                                                                                                                  |
 
-Dynamic grants use the same translation. Configuring a key server retires the static
-pair outright — the daemon reads none of these variables — so a grant needs no
-precedence against them. With no key server the static pair wins; with neither, the
-runtime's existing provider configuration is left unchanged.
+Dynamic grants use the same translation for their key, and take their base URL from
+these same variables — a key server changes where the token comes from, never where the
+runtime points. With neither a key server nor a static token, the runtime's existing
+provider configuration is left unchanged.
 
 One logical AgentConnect session owns one ACP host when key-server mode is active.
 Provider credentials are process-level settings, so sharing a runtime would let

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1132,8 +1132,9 @@ export class Daemon {
       (keyServerAddress
         ? new KeyServerClient(keyServerAddress, { tokenPath: keyServerTokenPath, now: this.modelKeyNow })
         : undefined)
-    // A key server answers with the whole pair, so the daemon's static one is not a layer under it.
-    this.staticModelCredentials = this.k8s && !this.keyServer ? configuredModelCredentials(process.env) : undefined
+    // Base URLs are deployment topology and always come from here, key server or not; an issuer
+    // supplies the key alone.
+    this.staticModelCredentials = this.k8s ? configuredModelCredentials(process.env) : undefined
     this.evalHooks = new DaemonEvaluationHooks(this.evaluationHost(), opts.evaluation)
     this.sessionMetadataOutbox = new SessionMetadataOutbox(this.sessionMetadataHost())
     this.observedChannelsSync = new ObservedChannelsSync(this.observedChannelsSyncHost())
@@ -3395,7 +3396,7 @@ export class Daemon {
   private boundModelTarget(sessionKey: string, agentId: string): ModelProviderTarget | undefined {
     const credentialHost = this.modelSessionHosts.get(sessionKey)
     if (credentialHost) return credentialHost.target
-    if (!this.k8s || !this.staticModelCredentials) return undefined
+    if (this.keyServer || !this.k8s || !this.staticModelCredentials) return undefined
     const agent = this.agents.get(agentId)
     const runtime = agent ? this.runtimes[agent.runtime] : undefined
     const target = agent && runtime ? modelProviderTarget(agent, runtime) : undefined
@@ -3418,6 +3419,12 @@ export class Daemon {
   private async modelSessionSdkQuiescent(entry: ModelSessionHost): Promise<boolean> {
     const acpSessionId = (await this.store.getSession(entry.sessionKey))?.acpSessionId
     return this.sessionSdkQuiescent(entry.agentId, acpSessionId)
+  }
+
+  /** The deployment's base for a target, the only source of one — an IssueKey `baseUrl` is not read. */
+  private staticModelBaseUrl(target: ModelProviderTarget): { baseUrl?: string } {
+    const baseUrl = this.staticModelCredentials?.[target.runtime]?.baseUrl
+    return baseUrl ? { baseUrl } : {}
   }
 
   private async issueModelKey(
@@ -3450,7 +3457,7 @@ export class Daemon {
           target: entry.target,
           credential: {
             key: entry.grant.key,
-            ...(entry.grant.baseUrl ? { baseUrl: entry.grant.baseUrl } : {})
+            ...this.staticModelBaseUrl(entry.target)
           }
         }
       })
@@ -4044,7 +4051,7 @@ export class Daemon {
               target: issued.target,
               credential: {
                 key: issued.grant.key,
-                ...(issued.grant.baseUrl ? { baseUrl: issued.grant.baseUrl } : {})
+                ...this.staticModelBaseUrl(issued.target)
               }
             }
           }

--- a/packages/daemon/test/model-key-session.test.ts
+++ b/packages/daemon/test/model-key-session.test.ts
@@ -201,9 +201,20 @@ describe('daemon model-key session lifecycle', () => {
     expect(setModelOverride).toHaveBeenCalledWith('session-a', 'anthropic/claude-opus-4')
   })
 
-  it('keeps no static pair to fall back to when a key server is configured', () => {
-    const withServer = new Daemon({ k8s: true, keyServer: 'https://keys.test', clock: new FakeClock(1_000) }) as any
-    expect(withServer.staticModelCredentials).toBeUndefined()
+  it('reads the deployment base URLs even when a key server is configured', () => {
+    const env = process.env.ANTHROPIC_MODEL_BASE_URL
+    process.env.ANTHROPIC_MODEL_BASE_URL = 'https://gw.example'
+    try {
+      const withServer = new Daemon({ k8s: true, keyServer: 'https://keys.test', clock: new FakeClock(1_000) }) as any
+      expect(withServer.staticModelCredentials.claude).toEqual({ key: '', baseUrl: 'https://gw.example' })
+      // The issuer owns the key; where it is sent is the deployment's, so a grant URL is not read.
+      expect(withServer.staticModelBaseUrl({ provider: 'anthropic', runtime: 'claude' })).toEqual({
+        baseUrl: 'https://gw.example'
+      })
+    } finally {
+      if (env === undefined) delete process.env.ANTHROPIC_MODEL_BASE_URL
+      else process.env.ANTHROPIC_MODEL_BASE_URL = env
+    }
   })
 
   it('revokes the fresh grant when replacing the superseded host fails', async () => {

--- a/packages/protocol/src/key-server.ts
+++ b/packages/protocol/src/key-server.ts
@@ -51,11 +51,11 @@ export const IssueKeyResponse = z
     // credential, and only it knows whether revoking a keyId may touch other holders.
     keyId: z.string().min(1),
     key: z.string().min(1),
-    // Atomic with `key` — inject both or neither. Absent ⇒ the daemon falls through to its
-    // next base-URL layer (static config, then runtime default). Restricted to http(s): it
-    // becomes a runtime's API base, so any other scheme is a value the daemon would inject
-    // and only fail on at request time. Plain http stays legal for a loopback or in-pod
-    // gateway, which is where it is the normal choice.
+    // Accepted and ignored: an issuer owns the key, a deployment owns where its runtimes send
+    // it, and the daemon reads its base URL only from its own configuration. The field stays in
+    // the contract because the response is `.strict()` — dropping it would reject every issuer
+    // still sending one — and because a `.url()` here still rejects a nonsense value early.
+    // Restricted to http(s) for the same reason it was when injected.
     // The predicate must not throw: zod runs refinements even after `.url()` has already
     // failed, and a bare `new URL(bad)` would escape safeParse as a TypeError.
     baseUrl: z


### PR DESCRIPTION
## Why

An `IssueKey` response could name a base URL, so the address of this install's gateway was stated twice — once where the gateway is deployed, and once by every issuer, for every session, forever. Two copies of one fact disagree eventually, and the disagreement surfaces as a runtime aimed somewhere no gateway was ever put.

The two fields also answer to different owners. A key is per-session identity and only an issuer can mint one. A base URL is deployment topology: it is the same for every session the install ever runs, and it is already written down where the gateway is deployed.

## What

- The daemon reads its base URL **only from its own configuration**, key server or not. `staticModelCredentials` is populated whenever `--k8s`, and a new `staticModelBaseUrl(target)` is the single source for a spawn's base.
- `IssueKeyResponse.baseUrl` stays in the contract — the response is `.strict()`, so dropping it would reject every issuer still sending one — but nothing reads it. The schema comment says so.
- `boundModelTarget` keeps its key-server guard: with an issuer, a session owns its own host and can rebind, so it is not the shared-static-host case.
- `key-server.md` §4 is rewritten from "one precedence chain, pairs never split" to the ownership split, including why the previous rule was wrong.

## Breaking

A key server that supplied the base URL no longer decides where runtimes point. The deployment must configure it (`ANTHROPIC_MODEL_BASE_URL` / `OPENAI_MODEL_BASE_URL` / `DEEPSEEK_MODEL_BASE_URL`, or the shared `MODEL_BASE_URL`). The chart side is agentconnect-md/workflows#157.

## Testing

- `model-key-session.test.ts` — 12, including a key-server daemon that still reads the deployment base and resolves it for a target.
- `model-provider-config.test.ts` — 12; `key-server-client.test.ts` — 5
- `pnpm --filter @agentconnect.md/daemon typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)