### PR TITLE
fix(daemon): partition a CP-addressed session read by the frame's org

### DIFF
--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -796,7 +796,10 @@ is an awaited main-thread `pg.Pool`. A `--k8s` daemon never opens SQLite. The
 transcript fence landed last (#1075): the pool store's `transcript` /
 `transcript_recipient` rows carry `orgId`, and the data plane's separate
 transcript pair — declared but never read or written — is deleted, so exactly one
-store carries the fence. The cross-driver contract suite is real rather than
+store carries the fence. A CP-addressed READ takes its partition from the frame's
+`orgId`, not from the member's own agent registry: a member serves the transcripts of
+every session in its store, including agents it does not hold and therefore cannot
+attribute locally. The cross-driver contract suite is real rather than
 aspirational (#1080): the store suites re-run against a real `postgres:16` on their
 own CI job — which immediately found the activation rendezvous joining its keys with
 NUL, a byte Postgres `TEXT` rejects outright, so paired activation could not settle on

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -428,6 +428,7 @@ export function sessionRoutes(deps: HttpDeps) {
     // false empty page from a machine that never held the session.
     type ContentRead<T> = { ok: true; value: T } | { ok: false; reason: 'unplaced' | 'offline' }
     const readSessionContent = async <T>(
+      req: FastifyRequest,
       session: { daemonId: string | null; contentSetId: string | null },
       read: (daemonId: string) => Promise<T>
     ): Promise<ContentRead<T>> => {
@@ -438,15 +439,23 @@ export function sessionRoutes(deps: HttpDeps) {
           : []
       })
       if (readers.length === 0) return { ok: false, reason: session.daemonId ? 'offline' : 'unplaced' }
+      // EVERY failure moves to the next holder of the same store, not just an unreachable socket:
+      // during a rollout the readers span two images, and one that answers an error is no more
+      // authoritative about rows its peers hold than one whose socket died. A read that no holder
+      // answered still fails LOUD on the last real error — only an unreachable set is a 503 —
+      // so a bug that breaks the read everywhere is never dressed up as unavailability.
+      let failure: unknown
       for (const daemonId of readers) {
         try {
           return { ok: true, value: await read(daemonId) }
         } catch (err) {
-          // Not reachable — try the next holder of the same store. A socket that dies between the
-          // registry lookup and the reply is ordinary during a rollout, and is unavailability too.
-          if (!(err instanceof NoConnection) && !(err instanceof ConnectionClosed)) throw err
+          if (!(err instanceof NoConnection) && !(err instanceof ConnectionClosed)) {
+            failure = err
+            req.log.warn({ err, daemonId }, 'session content read failed on a holder of the store; trying the next one')
+          }
         }
       }
+      if (failure !== undefined) throw failure
       return { ok: false, reason: 'offline' }
     }
 
@@ -938,7 +947,7 @@ export function sessionRoutes(deps: HttpDeps) {
         if (session.contentPurgedAt) {
           return { sessionId: session.id, messages: [], nextCursor: null, liveCursor: null, liveMore: false }
         }
-        const read = await readSessionContent(session, (daemonId) =>
+        const read = await readSessionContent(req, session, (daemonId) =>
           deps.control.sessionHistory(daemonId, session.orgId, {
             agentId: session.agentId,
             sessionId: session.id,
@@ -986,7 +995,7 @@ export function sessionRoutes(deps: HttpDeps) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
         }
         const { session } = owned
-        const read = await readSessionContent(session, (daemonId) =>
+        const read = await readSessionContent(req, session, (daemonId) =>
           deps.control.sessionToolBody(daemonId, session.orgId, {
             agentId: session.agentId,
             sessionId: session.id,

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -786,6 +786,59 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
     expect(spy.histCalls.map((c) => c.daemonId)).toEqual([OTHER_POOL_MEMBER])
   })
 
+  // A rollout spans two images, so one member can answer an error for rows every member holds.
+  // A member that FAILED a read is no more authoritative about its peers' rows than one whose
+  // socket died, so an error moves to the next holder too.
+  it('falls through a peer that answers an error, not only an unreachable one', async () => {
+    await seedAgent(prisma, AGENT)
+    await prisma.daemon.createMany({
+      data: [POOL_MEMBER, OTHER_POOL_MEMBER].map((id) => ({ id, orgId: null, status: 'ready' as const, maxAgents: 4 }))
+    })
+    const setId = await joinPool(prisma, POOL_MEMBER, OTHER_POOL_MEMBER)
+    await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'set', setId, daemonId: null } })
+    await seedSession(AGENT, undefined, setId)
+    const spy = new SpyControl({ sessions: [] }, emptyHist)
+    const firstRefuses = {
+      ...spy,
+      sessionHistory: async (daemonId: string, orgId: string, req: SessionHistoryReq) => {
+        if (daemonId === POOL_MEMBER) throw new Error('cannot resolve the transcript organization')
+        return spy.sessionHistory(daemonId, orgId, req)
+      }
+    }
+    running = buildHttpApp(prisma, undefined, POOL_LIVE, firstRefuses as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(200)
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([OTHER_POOL_MEMBER])
+  })
+
+  // The other half of that rule: a read no holder answered must not be dressed up as a 503, or a
+  // bug that breaks the read on EVERY member reads as "the daemon is offline, try later".
+  it('surfaces the failure when every holder of the store answers an error', async () => {
+    await seedAgent(prisma, AGENT)
+    await prisma.daemon.createMany({
+      data: [POOL_MEMBER, OTHER_POOL_MEMBER].map((id) => ({ id, orgId: null, status: 'ready' as const, maxAgents: 4 }))
+    })
+    const setId = await joinPool(prisma, POOL_MEMBER, OTHER_POOL_MEMBER)
+    await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'set', setId, daemonId: null } })
+    await seedSession(AGENT, undefined, setId)
+    const spy = new SpyControl({ sessions: [] }, emptyHist)
+    const allRefuse = {
+      ...spy,
+      sessionHistory: async (daemonId: string, orgId: string, req: SessionHistoryReq) => {
+        await spy.sessionHistory(daemonId, orgId, req)
+        throw new Error('cannot resolve the transcript organization')
+      }
+    }
+    running = buildHttpApp(prisma, undefined, POOL_LIVE, allRefuse as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(500)
+    expect(spy.histCalls.map((c) => c.daemonId)).toEqual([POOL_MEMBER, OTHER_POOL_MEMBER])
+  })
+
   // Content does not follow an agent move, so neither does reader eligibility. A session recorded
   // on a private store gets no pool reader just because its agent has since moved onto the pool —
   // the pool would answer an EMPTY page, dressing a lost transcript up as an empty one.

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -1659,8 +1659,10 @@ export class CpClient {
         return
       case 'session/list': {
         // Read-only — legal in READY/DRAINING (no epoch mutation). Body-locality §12.
+        // The frame's org is the read's partition on a shared pool store: this member may hold
+        // none of the agents whose sessions it serves, so it cannot resolve one locally.
         Promise.resolve()
-          .then(() => this.deps.sessionRead.list(frame.payload as SessionListReq))
+          .then(() => this.deps.sessionRead.list(frame.payload as SessionListReq, { orgId: frame.orgId }))
           .then((page) => this.reply(frame, 'session/list/page', page))
           .catch((err) => this.sendError(frame.id, 'INTERNAL', `session/list failed: ${(err as Error).message}`, false))
         return
@@ -1670,7 +1672,7 @@ export class CpClient {
         if (!req.agentId)
           this.deps.log.warn('cp: legacy session/history request omitted agentId; owner binding is unavailable')
         Promise.resolve()
-          .then(() => this.deps.sessionRead.history(req))
+          .then(() => this.deps.sessionRead.history(req, { orgId: frame.orgId }))
           .then((page) => this.reply(frame, 'session/history/page', page))
           .catch((err) =>
             this.sendError(frame.id, 'INTERNAL', `session/history failed: ${(err as Error).message}`, false)
@@ -1694,7 +1696,7 @@ export class CpClient {
         if (!req.agentId)
           this.deps.log.warn('cp: legacy session/tool-body request omitted agentId; owner binding is unavailable')
         Promise.resolve()
-          .then(() => this.deps.sessionRead.toolBody(req))
+          .then(() => this.deps.sessionRead.toolBody(req, { orgId: frame.orgId }))
           .then((chunk) => this.reply(frame, 'session/tool-body/chunk', chunk))
           .catch((err) =>
             this.sendError(frame.id, 'INTERNAL', `session/tool-body failed: ${(err as Error).message}`, false)

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -185,10 +185,16 @@ function previewBody(full: ToolBody): ToolBody {
   return preview
 }
 
+/** The org the reading CP named in the frame — the authoritative partition for a shared pool
+ *  store, where a member serves sessions of agents it does not hold and cannot resolve itself. */
+export interface SessionReadScope {
+  orgId?: string
+}
+
 export interface SessionReader {
-  list(req: SessionListReq): Promise<SessionListPage>
-  history(req: SessionHistoryReq): Promise<SessionHistoryPage>
-  toolBody(req: SessionToolBodyReq): Promise<SessionToolBodyChunk>
+  list(req: SessionListReq, scope?: SessionReadScope): Promise<SessionListPage>
+  history(req: SessionHistoryReq, scope?: SessionReadScope): Promise<SessionHistoryPage>
+  toolBody(req: SessionToolBodyReq, scope?: SessionReadScope): Promise<SessionToolBodyChunk>
 }
 
 type TranscriptReadStore = Pick<
@@ -217,7 +223,7 @@ export function createSessionReader(
   transcriptRead: TranscriptReadStore = store
 ): SessionReader {
   return {
-    async list(req) {
+    async list(req, scope) {
       const rows = await store.listSessions(req.agentId)
       // Title = the ingress/runtime/tool title, else a fallback derived from the
       // session's FIRST user message. Before the agent has a meaningful request to
@@ -228,7 +234,12 @@ export function createSessionReader(
         const rawTitle =
           r.title ||
           deriveTitle(
-            await store.firstMessageText(transcriptChannelKey(r.channel, r.transportScope), r.thread, r.agentId)
+            await store.firstMessageText(
+              transcriptChannelKey(r.channel, r.transportScope),
+              r.thread,
+              r.agentId,
+              scope?.orgId
+            )
           )
         enriched.push({ r, rawTitle })
       }
@@ -270,7 +281,7 @@ export function createSessionReader(
       })
       return { sessions }
     },
-    async history(req) {
+    async history(req, scope) {
       const rec = await sessionForRead(store, req.agentId, req.sessionId)
       if (!rec) return { sessionId: req.sessionId, messages: [] }
       const tailing = req.after !== undefined
@@ -299,7 +310,8 @@ export function createSessionReader(
               rec.thread,
               rec.agentId,
               afterRevision,
-              req.limit
+              req.limit,
+              scope?.orgId
             )
           : chronological
             ? await transcriptRead.transcriptPageForAgentByEventTime(
@@ -307,14 +319,16 @@ export function createSessionReader(
                 rec.thread,
                 rec.agentId,
                 eventCursor,
-                req.limit
+                req.limit,
+                scope?.orgId
               )
             : await transcriptRead.transcriptPageForAgent(
                 transcriptChannel,
                 rec.thread,
                 rec.agentId,
                 legacyBefore,
-                req.limit
+                req.limit,
+                scope?.orgId
               )
       const { rows, hasMore } = page
       // rows are newest-first; the page itself is oldest→newest.
@@ -433,7 +447,9 @@ export function createSessionReader(
       return {
         sessionId: req.sessionId,
         messages: kept,
-        liveCursor: String(transcriptPageCursor(page) ?? (await transcriptRead.currentTranscriptRevision(rec.agentId))),
+        liveCursor: String(
+          transcriptPageCursor(page) ?? (await transcriptRead.currentTranscriptRevision(rec.agentId, scope?.orgId))
+        ),
         ...(hasOlder && oldestKept
           ? {
               nextCursor:
@@ -444,7 +460,7 @@ export function createSessionReader(
           : {})
       }
     },
-    async toolBody(req) {
+    async toolBody(req, scope) {
       const rec = await sessionForRead(store, req.agentId, req.sessionId)
       const empty: SessionToolBodyChunk = {
         sessionId: req.sessionId,
@@ -457,7 +473,8 @@ export function createSessionReader(
         transcriptChannelKey(rec.channel, rec.transportScope),
         rec.thread,
         rec.agentId,
-        req.toolCallId
+        req.toolCallId,
+        scope?.orgId
       )
       if (body === undefined) return empty
       const buf = Buffer.from(body, 'utf8')

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1670,6 +1670,15 @@ export class LocalStore {
     return orgId
   }
 
+  /** The org partition a CP-addressed READ belongs to. The reading CP names the org in the
+   *  frame, and that is the authoritative one: a pool member serves the transcripts of every
+   *  member of its store, including agents it does not hold and therefore cannot resolve
+   *  locally. Only a shared store has more than one partition to choose between. */
+  private orgForRead(agentId: string | undefined, orgId: string | undefined): string {
+    if (!this.shared) return LOCAL_TRANSCRIPT_ORG
+    return orgId ?? this.orgFor(agentId)
+  }
+
   /** The org of a row written from a message rather than by an agent: its recipient or
    *  sender when either names one, else an agent already holding a session in the thread —
    *  an observed inbound is recorded before routing picks a recipient, and only a thread
@@ -1712,10 +1721,10 @@ export class LocalStore {
       .map((row) => row.acpSessionId)
   }
 
-  async currentTranscriptRevision(agentId?: string): Promise<number> {
+  async currentTranscriptRevision(agentId?: string, orgId?: string): Promise<number> {
     const row = (await this.db
       .prepare('SELECT COALESCE(MAX(revision), 0) AS revision FROM transcript WHERE orgId = ?')
-      .get(this.orgFor(agentId))) as { revision: number }
+      .get(this.orgForRead(agentId, orgId))) as { revision: number }
     // The in-memory allocator spans every partition; only the answer is org-scoped.
     this.transcriptRevision = Math.max(this.transcriptRevision, row.revision)
     return row.revision
@@ -1783,7 +1792,8 @@ export class LocalStore {
     thread: string,
     agentId: string,
     beforeSeq: number | null,
-    limit: number
+    limit: number,
+    orgId?: string
   ): Promise<{ rows: TranscriptRow[]; hasMore: boolean }> {
     // The delivery-table match is keyed by (channel, thread, ts), but internal rows
     // (reasoning/tool) are NOT deduped by ts and can share a ts with a delivered text row —
@@ -1791,7 +1801,7 @@ export class LocalStore {
     // same ts would be pulled back in. Deliveries only ever concern conversational messages;
     // own internal rows still surface via `sender`.
     const scope = AGENT_DELIVERY_SCOPE_SQL
-    const orgId = this.orgFor(agentId)
+    const partition = this.orgForRead(agentId, orgId)
     const hiddenToolTitles = [...SESSION_TITLE_TOOL_TITLES]
     const rows = (beforeSeq !== null
       ? await this.db
@@ -1801,7 +1811,7 @@ export class LocalStore {
                AND NOT (kind = 'tool' AND text IN (?, ?))
              ORDER BY seq DESC LIMIT ?`
           )
-          .all(orgId, channel, thread, beforeSeq, agentId, agentId, agentId, ...hiddenToolTitles, limit + 1)
+          .all(partition, channel, thread, beforeSeq, agentId, agentId, agentId, ...hiddenToolTitles, limit + 1)
       : await this.db
           .prepare(
             `SELECT * FROM transcript WHERE orgId = ? AND channel = ? AND thread = ?
@@ -1810,7 +1820,7 @@ export class LocalStore {
              ORDER BY seq DESC LIMIT ?`
           )
           .all(
-            orgId,
+            partition,
             channel,
             thread,
             agentId,
@@ -1838,10 +1848,11 @@ export class LocalStore {
     thread: string,
     agentId: string,
     before: TranscriptEventCursor | null,
-    limit: number
+    limit: number,
+    orgId?: string
   ): Promise<{ rows: TranscriptRow[]; hasMore: boolean }> {
     const scope = AGENT_DELIVERY_SCOPE_SQL
-    const orgId = this.orgFor(agentId)
+    const partition = this.orgForRead(agentId, orgId)
     const hiddenToolTitles = [...SESSION_TITLE_TOOL_TITLES]
     const rows = (before !== null
       ? await this.db
@@ -1853,7 +1864,7 @@ export class LocalStore {
              ORDER BY eventTimeUs DESC, seq DESC LIMIT ?`
           )
           .all(
-            orgId,
+            partition,
             channel,
             thread,
             before.eventTimeUs,
@@ -1873,7 +1884,7 @@ export class LocalStore {
              ORDER BY eventTimeUs DESC, seq DESC LIMIT ?`
           )
           .all(
-            orgId,
+            partition,
             channel,
             thread,
             agentId,
@@ -1896,7 +1907,8 @@ export class LocalStore {
     thread: string,
     agentId: string,
     afterRevision: number,
-    limit: number
+    limit: number,
+    orgId?: string
   ): Promise<{ rows: TranscriptRow[]; hasMore: boolean; cursor: number }> {
     const scope = AGENT_DELIVERY_SCOPE_SQL
     const rows = (await this.db
@@ -1908,7 +1920,7 @@ export class LocalStore {
          ORDER BY revision ASC LIMIT ?`
       )
       .all(
-        this.orgFor(agentId),
+        this.orgForRead(agentId, orgId),
         channel,
         thread,
         afterRevision,
@@ -1923,7 +1935,7 @@ export class LocalStore {
     return {
       rows: kept,
       hasMore,
-      cursor: hasMore ? kept[kept.length - 1]!.revision : await this.currentTranscriptRevision(agentId)
+      cursor: hasMore ? kept[kept.length - 1]!.revision : await this.currentTranscriptRevision(agentId, orgId)
     }
   }
 
@@ -3782,13 +3794,15 @@ export class LocalStore {
     channel: string,
     thread: string,
     agentId: string,
-    toolCallId: string
+    toolCallId: string,
+    orgId?: string
   ): Promise<string | undefined> {
     const row = (await this.db
       .prepare(
         'SELECT body FROM transcript WHERE orgId = ? AND channel = ? AND thread = ? AND sender = ? AND tool_call_id = ?'
       )
-      .get(this.orgFor(agentId), channel, thread, agentId, toolCallId)) as { body: string | null } | undefined
+      .get(this.orgForRead(agentId, orgId), channel, thread, agentId, toolCallId)) as
+      { body: string | null } | undefined
     return row?.body ?? undefined
   }
 
@@ -3917,13 +3931,18 @@ export class LocalStore {
    *  supplied one. Before the first meaningful request, this avoids showing only
    *  "Session <id>". Returns undefined when the thread holds no non-agent text row
    *  yet. Indexed by (channel, thread, seq). */
-  async firstMessageText(channel: string, thread: string, agentId: string): Promise<string | undefined> {
+  async firstMessageText(
+    channel: string,
+    thread: string,
+    agentId: string,
+    orgId?: string
+  ): Promise<string | undefined> {
     const row = (await this.db
       .prepare(
         `SELECT text FROM transcript WHERE orgId = ? AND channel = ? AND thread = ? AND kind = 'text'
            AND sender != ? ORDER BY seq ASC LIMIT 1`
       )
-      .get(this.orgFor(agentId), channel, thread, agentId)) as { text: string } | undefined
+      .get(this.orgForRead(agentId, orgId), channel, thread, agentId)) as { text: string } | undefined
     return row?.text
   }
 

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi } from 'vitest'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
 import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
+import { SqliteAsyncDatabase } from '../src/store/sqlite-async-database.js'
 import { createSessionReader } from '../src/cp/session-reader.js'
 import { sessionThreadUrlFor } from '../src/platforms/session-links.js'
 
@@ -853,5 +855,39 @@ describe('SessionReader', () => {
 
     expect(await tailFor('telegram')).toEqual(['observed first', 'older, backfilled after'])
     expect(await tailFor('slack')).toEqual(['older, backfilled after', 'observed first'])
+  })
+  // The pool's shared store is read by every member, and a member holds only the agents whose
+  // duty it took: an idle agent is installed nowhere, so no member can resolve its org locally.
+  // The reading CP names the org in the frame, and that is what the read is partitioned by —
+  // otherwise the transcript is one query away from a live member and answers a hard failure.
+  it('reads a pooled transcript through a member that does not hold the agent', async () => {
+    const database = SqliteAsyncDatabase.adopt(new DatabaseSync(':memory:'))
+    const holder = await LocalStore.open({
+      database,
+      shared: true,
+      ownerId: 'member-1',
+      orgForAgent: (id) => (id === AGENT ? 'org-a' : undefined)
+    })
+    // The peer holds nothing: every agent is unknown to it, as after a rollout.
+    const peer = await LocalStore.open({ database, shared: true, ownerId: 'member-2', orgForAgent: () => undefined })
+    await seedHistorySession(holder)
+    await holder.appendTranscript({
+      channel: transcriptChannelKey('C1', null),
+      thread: 'T1',
+      ts: '1',
+      sender: 'user-1',
+      recipient: AGENT,
+      kind: 'text',
+      text: 'still there'
+    })
+
+    const read = createSessionReader(peer)
+    const page = await read.history({ agentId: AGENT, sessionId: 'acp-1', limit: 20 }, { orgId: 'org-a' })
+    expect(page.messages.map((m) => m.text)).toEqual(['still there'])
+    // Without an org from the frame the peer has nothing to partition by, and says so.
+    await expect(read.history({ agentId: AGENT, sessionId: 'acp-1', limit: 20 })).rejects.toThrow(
+      /cannot resolve the transcript organization/
+    )
+    await holder.close() // one database behind both handles: closing it once is closing it
   })
 })


### PR DESCRIPTION
A pooled session's transcript stopped loading in the console. The live CP log says why:

```
session/history failed: cannot resolve the transcript organization
  for agent 01ffd077-46b5-4b9b-81f2-3b48725454a2
```

#1019 made content readers a property of the STORE, so a retired pool member's sessions are read from any peer on the install-wide Postgres it wrote to. The org fence (#1075) then landed on top and closed the same road: a shared store resolves a transcript read's org partition through `orgForAgent`, the member's own agent registry — and a member holds only the agents whose duty it took, so an idle agent is installed nowhere and NO member can attribute it. Every reader the CP tried failed, and `readSessionContent` rethrows anything that is not a dead socket, so the console got a 500 for rows sitting one query away.

## The org of a CP-addressed read belongs to the request

Not to the serving member's installation state. The CP already stamps the session's own org on the frame — `outbound.ts#sessionHistory` says so, for exactly this reason — and the daemon simply never read it. `session/history`, `session/tool-body` and `session/list` now carry that org into `SessionReader`, which hands it to the store as the partition to read (`LocalStore.orgForRead`). The local registry stays the fallback, and a store no pool shares still owns its single partition.

The write path does not move: the fence is unchanged, and a frame's org already passed `checkInboundFrameOrg` before any handler saw it.

## The guardrail that would have surfaced this

The CP's reader loop now moves to the next holder of the store on EVERY failure, not just an unreachable socket: a rollout's readers span two images, and a member that failed a read is no more authoritative about its peers' rows than one whose socket died. A read no holder answered still fails **loud** on the last real error — only an unreachable set is a 503 — so a bug that breaks the read on every member is never dressed up as "the daemon is offline, try later".

## Tests

- `daemon/test/session-reader.test.ts` — two members over one database; the peer's `orgForAgent` returns undefined for every agent. With the frame's org it reads the transcript; without one it still says it cannot attribute the agent.
- `control-plane/test/integration/sessions.history.route.test.ts` — falls through a holder that answers an error (200 from the peer), and surfaces the failure when every holder errors (500, both tried).

🤖 Generated with [Claude Code](https://claude.com/claude-code)