### PR TITLE
feat(protocol)!: retire baseUrl from the IssueKey response; responses parse tolerantly

### DIFF
--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -21,8 +21,8 @@ session" — so the seam is one small service contract, `agentconnect.key-server
 and every issuing strategy lives behind it. A deployment may implement it with a
 plain vault that hands out rotating real keys, or with an LLM egress gateway that
 issues its own gateway-scoped credentials and meters traffic on its data path. The
-daemon cannot tell the difference, by design: it receives an opaque
-`(key, baseUrl)` pair and injects it exactly like the static pair it replaces.
+daemon cannot tell the difference, by design: it receives an opaque key and
+injects it exactly like the static token it replaces.
 
 The contract deliberately carries **no quota, metering, or gateway concepts**.
 Attribution context goes in (org/agent/session), a credential comes out; everything
@@ -37,10 +37,10 @@ This is deliberately not the daemon↔CP WebSocket or a frame group: issuance is
 low-frequency, stateless exchange, and a bare REST surface lets any deployment
 implement the server without speaking AgentConnect's wire protocol.
 
-| Operation   | Route                 | Body → Response                                                                                                       |
-| ----------- | --------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `IssueKey`  | `POST /v1/issue-key`  | `{orgId, agentId, sessionId, provider, ttlSeconds?}` → `{keyId, key, baseUrl?, expiresInSeconds?, refreshInSeconds?}` |
-| `RevokeKey` | `POST /v1/revoke-key` | `{keyId}` → `{}`                                                                                                      |
+| Operation   | Route                 | Body → Response                                                                                             |
+| ----------- | --------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `IssueKey`  | `POST /v1/issue-key`  | `{orgId, agentId, sessionId, provider, ttlSeconds?}` → `{keyId, key, expiresInSeconds?, refreshInSeconds?}` |
+| `RevokeKey` | `POST /v1/revoke-key` | `{keyId}` → `{}`                                                                                            |
 
 **Caller authentication rides the transport, never the body.** Configured with a
 token source, the daemon sends `Authorization: Bearer <token>`; configured with
@@ -62,7 +62,7 @@ hold to check it are decided together by the key server's own design and the
 deployment that installs both. This document stops at the header.
 
 `provider` names the API dialect the credential must speak (`anthropic` /
-`openai` / `deepseek`) and selects which `(key, baseUrl)` pair comes back. There is
+`openai` / `deepseek`) and selects which key comes back. There is
 deliberately **no `model` parameter**: per-model usage attribution belongs to
 whatever observes actual requests (a gateway data path, or the runtime's own usage
 reports), and a spawn-time hint would invite implementations to treat it as truth
@@ -120,8 +120,9 @@ neither completes the other:
   when a key-server address is configured; with none, the daemon's static token; with
   neither, whatever credential the runtime environment already carries.
 - **the base URL** is deployment topology — which gateway this install's runtimes talk
-  to — so it always comes from the daemon's own configuration, key server or not. An
-  `IssueKey` response may carry a `baseUrl`; the daemon does not read it.
+  to — so it always comes from the daemon's own configuration, key server or not. The
+  contract no longer defines a `baseUrl`; responses parse tolerantly, so an issuer
+  still sending the retired field (or adding one later) is stripped, never rejected.
 
 The earlier rule was the opposite: the response pair was atomic, so a key server that
 fronted a gateway had to name it and one that did not had to stay silent. That made

--- a/packages/daemon/test/key-server-client.test.ts
+++ b/packages/daemon/test/key-server-client.test.ts
@@ -32,12 +32,15 @@ describe('KeyServerClient', () => {
     )
     const client = new KeyServerClient('https://keys.example/root/', { tokenPath, fetch, now: () => 10_000 })
 
-    await expect(client.issue(request)).resolves.toMatchObject({
+    const grant = await client.issue(request)
+    expect(grant).toMatchObject({
       keyId: 'key-1',
       requestedAtMs: 10_000,
       refreshAtMs: 910_000,
       expiresAtMs: 1_810_000
     })
+    // The issuer above still sends the retired `baseUrl`; the grant must not carry it.
+    expect('baseUrl' in grant).toBe(false)
     expect(fetch).toHaveBeenCalledWith(
       new URL('https://keys.example/v1/issue-key'),
       expect.objectContaining({

--- a/packages/protocol/src/key-server.test.ts
+++ b/packages/protocol/src/key-server.test.ts
@@ -14,7 +14,6 @@ describe('agentconnect.key-server/v1 schemas', () => {
     const bounded = {
       keyId: 'k-1',
       key: 'jwt…',
-      baseUrl: 'https://gateway.example.test',
       expiresInSeconds: 3600,
       refreshInSeconds: 2880
     }
@@ -26,16 +25,12 @@ describe('agentconnect.key-server/v1 schemas', () => {
     ).toThrow()
   })
 
-  it('takes an http(s) baseUrl and nothing else, since it becomes a runtime API base', () => {
-    // safeParse, not parse().toThrow(): a rejection must arrive as a zod result, and a
-    // predicate that threw natively would satisfy toThrow() while escaping validation.
-    const withUrl = (baseUrl: string) => IssueKeyResponse.safeParse({ keyId: 'k', key: 'x', baseUrl })
-    // Loopback http is the normal shape for an in-pod gateway, so it stays legal.
-    expect(withUrl('http://localhost:8080').success).toBe(true)
-    expect(withUrl('https://gateway.example.test').success).toBe(true)
-    expect(withUrl('file:///etc/passwd').success).toBe(false)
-    expect(withUrl('not a url').success).toBe(false)
-    expect(withUrl('').success).toBe(false)
+  it('strips unknown response fields instead of rejecting the issuance', () => {
+    // The retired `baseUrl` is the live case: an issuer still sending one must not
+    // fail every grant, and the daemon must not see it either — topology is config.
+    const grant = IssueKeyResponse.parse({ keyId: 'k', key: 'x', baseUrl: 'https://gateway.example.test' })
+    expect(grant).toEqual({ keyId: 'k', key: 'x' })
+    expect('baseUrl' in grant).toBe(false)
   })
 
   it('states validity as durations, so ordering never depends on timestamp spelling', () => {

--- a/packages/protocol/src/key-server.ts
+++ b/packages/protocol/src/key-server.ts
@@ -11,8 +11,9 @@ import { z } from 'zod'
  * the only caller; implementations range from a plain key vault that rotates
  * real provider keys to a managed LLM egress layer that issues short-lived
  * session-scoped credentials and meters usage on its own data path. The
- * daemon treats the returned pair as opaque — it never knows which kind it
- * received.
+ * daemon treats the returned key as opaque — it never knows which kind it
+ * received. Where the key is sent is deployment topology, configured on the
+ * daemon; the issuer supplies the credential alone.
  */
 
 export const KEY_SERVER_PROFILE = 'agentconnect.key-server/v1' as const
@@ -25,7 +26,7 @@ export const KEY_SERVER_REVOKE_KEY_PATH = '/v1/revoke-key' as const
 // the request carries no auth header at all. The token is opaque to the daemon.
 export const KEY_SERVER_AUTH_HEADER = 'authorization' as const
 
-/** Provider API dialect the credential must speak; selects the (key, baseUrl) pair. */
+/** Provider API dialect the credential must speak. */
 export const KeyProvider = z.enum(['anthropic', 'openai', 'deepseek'])
 export type KeyProvider = z.infer<typeof KeyProvider>
 
@@ -44,6 +45,10 @@ export const IssueKeyRequest = z
   .strict()
 export type IssueKeyRequest = z.infer<typeof IssueKeyRequest>
 
+// Responses parse tolerantly (unknown fields stripped, not rejected), unlike the `.strict()`
+// requests: the daemon reads many issuers it does not ship with, so a field an issuer still
+// sends (the retired `baseUrl`) or adds later must not fail every issuance. Base URLs are
+// deployment topology and come only from the daemon's own configuration.
 export const IssueKeyResponse = z
   .object({
     // Opaque handle for RevokeKey and audit; the key value never travels again. It names
@@ -51,20 +56,6 @@ export const IssueKeyResponse = z
     // credential, and only it knows whether revoking a keyId may touch other holders.
     keyId: z.string().min(1),
     key: z.string().min(1),
-    // Accepted and ignored: an issuer owns the key, a deployment owns where its runtimes send
-    // it, and the daemon reads its base URL only from its own configuration. The field stays in
-    // the contract because the response is `.strict()` — dropping it would reject every issuer
-    // still sending one — and because a `.url()` here still rejects a nonsense value early.
-    // Restricted to http(s) for the same reason it was when injected.
-    // The predicate must not throw: zod runs refinements even after `.url()` has already
-    // failed, and a bare `new URL(bad)` would escape safeParse as a TypeError.
-    baseUrl: z
-      .string()
-      .url()
-      .refine((u) => URL.canParse(u) && ['http:', 'https:'].includes(new URL(u).protocol), {
-        message: 'baseUrl must be http(s)'
-      })
-      .optional(),
     // Validity as a DURATION from the server's issuance instant, for the same reason the
     // request states one: an absolute instant would be the server's clock, and every reader
     // of it would be a different one. The daemon cannot observe that instant, so it anchors
@@ -76,7 +67,6 @@ export const IssueKeyResponse = z
     // Renew-from hint on the same scale; meaningless without an expiry, so it needs one.
     refreshInSeconds: z.number().int().positive().optional()
   })
-  .strict()
   .refine((r) => r.refreshInSeconds === undefined || r.expiresInSeconds !== undefined, {
     message: 'refreshInSeconds requires expiresInSeconds'
   })
@@ -92,7 +82,8 @@ export type IssueKeyResponse = z.infer<typeof IssueKeyResponse>
 export const RevokeKeyRequest = z.object({ keyId: z.string().min(1) }).strict()
 export type RevokeKeyRequest = z.infer<typeof RevokeKeyRequest>
 
-export const RevokeKeyResponse = z.object({}).strict()
+// Tolerant like IssueKeyResponse: the daemon wants "it is dead", not a shape check.
+export const RevokeKeyResponse = z.object({})
 export type RevokeKeyResponse = z.infer<typeof RevokeKeyResponse>
 
 /** Machine-readable denial reasons the daemon surfaces as attributable errors, never as internal faults. */


### PR DESCRIPTION
## What

- Remove `baseUrl` from `IssueKeyResponse` in the `agentconnect.key-server/v1` contract. #1249 already stopped the daemon from reading it: base URLs are deployment topology, configured on the daemon, and the issuer supplies the credential alone.
- Switch the response schemas (`IssueKeyResponse`, `RevokeKeyResponse`) from `.strict()` to zod's default strip, so responses parse tolerantly: an issuer still sending the retired field — or adding a new one later — is stripped, never rejected. This removes any deploy-order coupling between daemons and issuers. Requests stay `.strict()`.
- `KeyGrant` loses the field through its `extends IssueKeyResponse`; the daemon client test now sends the retired field and asserts the grant does not carry it.
- `docs/designs/key-server.md` §1/§2/§4 updated: the response is `{keyId, key, expiresInSeconds?, refreshInSeconds?}` and the tolerant-reader rule is recorded.

## Why now

The deployed issuer implementation never had its base-URL table configured in any environment, so live responses are already key-only; this makes the contract match both sides' behavior.

## Testing

- `protocol` tests (400) pass; new case: unknown response fields are stripped, not rejected.
- `daemon` key-server tests pass; the 14 failures in shim/sandbox suites reproduce on a clean `main` (environment-dependent, unrelated).
- `pnpm typecheck` and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)