### PR TITLE
feat(daemon): accept AC_CODEX_CONFIG as the pod's codex session-config floor

### DIFF
--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -20,7 +20,11 @@ image still accepts the legacy deployment-owned `AC_CLAUDE_BASE_URL`/`AC_CLAUDE_
 variables as fill-ins, but a daemon-sent value wins — including for DeepSeek Harness, whose
 `DEEPSEEK_BASE_URL`/`DEEPSEEK_API_KEY` the daemon now writes itself; the pod variables remain
 its floor, since a sandbox seeds no `$DSH_HOME` credential store. See
-[key-server.md](key-server.md) for precedence and lifecycle.
+[key-server.md](key-server.md) for precedence and lifecycle. The pod may also carry
+`AC_CODEX_CONFIG`, a JSON object of codex session config the deployment asserts about its
+endpoint (for example, disabling a feature whose request shape the endpoint's gateway
+rejects); the shim merges it under any daemon-sent `CODEX_CONFIG`, so every top-level key the
+daemon decided stays authoritative.
 
 ## 1. Why a seam at all
 

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -23,8 +23,9 @@ its floor, since a sandbox seeds no `$DSH_HOME` credential store. See
 [key-server.md](key-server.md) for precedence and lifecycle. The pod may also carry
 `AC_CODEX_CONFIG`, a JSON object of codex session config the deployment asserts about its
 endpoint (for example, disabling a feature whose request shape the endpoint's gateway
-rejects); the shim merges it under any daemon-sent `CODEX_CONFIG`, so every top-level key the
-daemon decided stays authoritative.
+rejects); the shim merges it under any daemon-sent `CODEX_CONFIG`, one level deep for a table
+both carry (the daemon always sends `features`), so every leaf the daemon decided stays
+authoritative.
 
 ## 1. Why a seam at all
 

--- a/packages/daemon/src/runtimes/codex-config.ts
+++ b/packages/daemon/src/runtimes/codex-config.ts
@@ -32,11 +32,23 @@ export function codexConfigWithBaseUrl(raw: string | undefined, baseUrl: string)
   return JSON.stringify({ ...config, model_provider: 'openai', openai_base_url: baseUrl })
 }
 
-/** Deployment floor for the sandbox shim: pod-asserted config keys sit under any daemon-sent key. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Deployment floor for the sandbox shim: pod-asserted config keys sit under any daemon-sent key.
+ *  A table both sides carry merges one level deep — the daemon always sends `features` (account
+ *  apps off), and replacing the whole table would silently drop the floor's other entries. */
 export function codexConfigWithFloor(raw: string | undefined, floorRaw: string): string | undefined {
   const floor = objectFromJson(floorRaw, 'AC_CODEX_CONFIG')
   if (Object.keys(floor).length === 0) return undefined
-  return JSON.stringify({ ...floor, ...objectFromJson(raw, 'CODEX_CONFIG') })
+  const config = objectFromJson(raw, 'CODEX_CONFIG')
+  const merged: Record<string, unknown> = { ...floor, ...config }
+  for (const [key, floorValue] of Object.entries(floor)) {
+    const configValue = config[key]
+    if (isPlainObject(floorValue) && isPlainObject(configValue)) merged[key] = { ...floorValue, ...configValue }
+  }
+  return JSON.stringify(merged)
 }
 
 /** Fill-in variant for the sandbox shim: undefined when the daemon already aimed codex somewhere. */

--- a/packages/daemon/src/runtimes/codex-config.ts
+++ b/packages/daemon/src/runtimes/codex-config.ts
@@ -32,6 +32,13 @@ export function codexConfigWithBaseUrl(raw: string | undefined, baseUrl: string)
   return JSON.stringify({ ...config, model_provider: 'openai', openai_base_url: baseUrl })
 }
 
+/** Deployment floor for the sandbox shim: pod-asserted config keys sit under any daemon-sent key. */
+export function codexConfigWithFloor(raw: string | undefined, floorRaw: string): string | undefined {
+  const floor = objectFromJson(floorRaw, 'AC_CODEX_CONFIG')
+  if (Object.keys(floor).length === 0) return undefined
+  return JSON.stringify({ ...floor, ...objectFromJson(raw, 'CODEX_CONFIG') })
+}
+
 /** Fill-in variant for the sandbox shim: undefined when the daemon already aimed codex somewhere. */
 export function codexConfigWithBaseUrlFillIn(raw: string | undefined, baseUrl: string): string | undefined {
   const config = objectFromJson(raw, 'CODEX_CONFIG')

--- a/packages/daemon/src/shim/acp-runner.ts
+++ b/packages/daemon/src/shim/acp-runner.ts
@@ -95,7 +95,8 @@ export function fillInCodexBaseUrl(
 
 // Deployment-asserted codex session config (AC_CODEX_CONFIG, a JSON object) — endpoint knowledge
 // like "this gateway rejects a newer tool type", which only the deployment holds. Floor semantics
-// match the env loop: every top-level key the daemon sent stays authoritative.
+// match the env loop — every leaf the daemon sent stays authoritative — with shared tables merged
+// one level deep, because the daemon always sends `features` (account apps off).
 export function fillInCodexConfigFloor(
   env: Record<string, string>,
   podEnv: Record<string, string | undefined>,

--- a/packages/daemon/src/shim/acp-runner.ts
+++ b/packages/daemon/src/shim/acp-runner.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { codexConfigWithBaseUrlFillIn } from '../runtimes/codex-config.js'
+import { codexConfigWithBaseUrlFillIn, codexConfigWithFloor } from '../runtimes/codex-config.js'
 import { AcpStreamPayloadSchema, type AcpOpen } from './acp-stream.js'
 import { SANDBOX_GH_WRAPPER_DIR } from './sandbox-paths.js'
 import type { ShimEvent } from './protocol.js'
@@ -93,6 +93,25 @@ export function fillInCodexBaseUrl(
   }
 }
 
+// Deployment-asserted codex session config (AC_CODEX_CONFIG, a JSON object) — endpoint knowledge
+// like "this gateway rejects a newer tool type", which only the deployment holds. Floor semantics
+// match the env loop: every top-level key the daemon sent stays authoritative.
+export function fillInCodexConfigFloor(
+  env: Record<string, string>,
+  podEnv: Record<string, string | undefined>,
+  warn?: (message: string) => void
+): void {
+  const floorRaw = podEnv.AC_CODEX_CONFIG?.trim()
+  if (!floorRaw) return
+  try {
+    const merged = codexConfigWithFloor(env.CODEX_CONFIG, floorRaw)
+    if (merged !== undefined) env.CODEX_CONFIG = merged
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    warn?.(`acp: leaving the pod codex config floor unapplied — ${reason}`)
+  }
+}
+
 /**
  * Runs the ACP runtime inside the sandbox and relays its stdio.
  *
@@ -154,6 +173,9 @@ export class AcpRunner {
       if (!env[name]) env[name] = value
     }
     if (sandboxProfile(payload.command) === 'codex') {
+      // Floor before URL: the daemon-sent config wins either way, and a floor that carries no
+      // aim never blocks the base-url fill-in below.
+      fillInCodexConfigFloor(env, podEnv, (message) => this.deps.log?.warn(message))
       fillInCodexBaseUrl(env, podEnv, (message) => this.deps.log?.warn(message))
     }
     const command = this.deps.resolveCommand?.(payload.command, env) ?? payload.command

--- a/packages/daemon/test/shim-provider-env.test.ts
+++ b/packages/daemon/test/shim-provider-env.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { AcpRunner, fillInCodexBaseUrl, sandboxProviderEnv, type EmitEvent } from '../src/shim/acp-runner.js'
+import {
+  AcpRunner,
+  fillInCodexBaseUrl,
+  fillInCodexConfigFloor,
+  sandboxProviderEnv,
+  type EmitEvent
+} from '../src/shim/acp-runner.js'
 import type { ShimEvent } from '../src/shim/protocol.js'
 
 const POD_ENV = {
@@ -136,6 +142,59 @@ describe('fillInCodexBaseUrl', () => {
   })
 })
 
+describe('fillInCodexConfigFloor', () => {
+  const FLOOR_ENV = { AC_CODEX_CONFIG: JSON.stringify({ features: { multi_agent: false } }) }
+
+  it('creates CODEX_CONFIG from the pod floor alone', () => {
+    const env: Record<string, string> = {}
+    fillInCodexConfigFloor(env, FLOOR_ENV)
+    expect(JSON.parse(env.CODEX_CONFIG!)).toEqual({ features: { multi_agent: false } })
+  })
+
+  it('keeps every daemon-sent top-level key over the floor and preserves the rest', () => {
+    const env = { CODEX_CONFIG: JSON.stringify({ features: { apps: false }, model: 'gpt-5.3-codex' }) }
+    fillInCodexConfigFloor(env, FLOOR_ENV)
+    const config = JSON.parse(env.CODEX_CONFIG) as Record<string, unknown>
+    expect(config.features).toEqual({ apps: false })
+    expect(config.model).toBe('gpt-5.3-codex')
+  })
+
+  it('composes with the base-url fill-in: floor config never blocks the pod aim', () => {
+    const env: Record<string, string> = {}
+    fillInCodexConfigFloor(env, { ...POD_ENV, ...FLOOR_ENV })
+    fillInCodexBaseUrl(env, { ...POD_ENV, ...FLOOR_ENV })
+    expect(JSON.parse(env.CODEX_CONFIG!)).toEqual({
+      features: { multi_agent: false },
+      model_provider: 'openai',
+      openai_base_url: 'https://codex-egress.internal'
+    })
+  })
+
+  it('warns and leaves a malformed floor unapplied instead of throwing', () => {
+    const env: Record<string, string> = {}
+    const warnings: string[] = []
+    fillInCodexConfigFloor(env, { AC_CODEX_CONFIG: 'not json' }, (message) => warnings.push(message))
+    expect(env.CODEX_CONFIG).toBeUndefined()
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('warns and leaves a malformed daemon config untouched instead of throwing', () => {
+    const env = { CODEX_CONFIG: 'not json' }
+    const warnings: string[] = []
+    fillInCodexConfigFloor(env, FLOOR_ENV, (message) => warnings.push(message))
+    expect(env.CODEX_CONFIG).toBe('not json')
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('does nothing on an absent, blank, or empty-object floor', () => {
+    for (const value of [undefined, '  ', '{}']) {
+      const env: Record<string, string> = {}
+      fillInCodexConfigFloor(env, { AC_CODEX_CONFIG: value })
+      expect(env.CODEX_CONFIG).toBeUndefined()
+    }
+  })
+})
+
 describe('AcpRunner codex config projection', () => {
   it('projects the pod codex base URL into CODEX_CONFIG on a codex spawn', async () => {
     const seen = await spawnAndReadEnv('codex-acp', { PATH: process.env.PATH ?? '' })
@@ -151,5 +210,31 @@ describe('AcpRunner codex config projection', () => {
     const daemonConfig = JSON.stringify({ openai_base_url: 'https://daemon-decided.internal' })
     const seen = await spawnAndReadEnv('codex-acp', { PATH: process.env.PATH ?? '', CODEX_CONFIG: daemonConfig })
     expect(seen.C).toBe(daemonConfig)
+  })
+
+  it('merges the pod config floor under the daemon aim on a codex spawn', async () => {
+    const chunks: string[] = []
+    let onExit: (() => void) | undefined
+    const exited = new Promise<void>((resolve) => (onExit = resolve))
+    const emit: EmitEvent = (event: ShimEvent['event']) => {
+      if (event.kind === 'chunk') chunks.push(Buffer.from(event.data, 'base64').toString('utf8'))
+      if (event.kind === 'exit') onExit?.()
+    }
+    const podEnv = { ...POD_ENV, AC_CODEX_CONFIG: JSON.stringify({ features: { multi_agent: false } }) }
+    const runner = new AcpRunner({ emit, resolveCommand: () => process.execPath, podEnv })
+    await runner.apply({
+      op: 'open',
+      command: 'codex-acp',
+      args: ['-e', 'process.stdout.write(process.env.CODEX_CONFIG ?? "")'],
+      env: {
+        PATH: process.env.PATH ?? '',
+        CODEX_CONFIG: JSON.stringify({ openai_base_url: 'https://daemon-decided.internal' })
+      }
+    })
+    await exited
+    expect(JSON.parse(chunks.join(''))).toEqual({
+      features: { multi_agent: false },
+      openai_base_url: 'https://daemon-decided.internal'
+    })
   })
 })

--- a/packages/daemon/test/shim-provider-env.test.ts
+++ b/packages/daemon/test/shim-provider-env.test.ts
@@ -151,12 +151,27 @@ describe('fillInCodexConfigFloor', () => {
     expect(JSON.parse(env.CODEX_CONFIG!)).toEqual({ features: { multi_agent: false } })
   })
 
-  it('keeps every daemon-sent top-level key over the floor and preserves the rest', () => {
+  it('merges a shared table one level deep — the daemon features never evict the floor entries', () => {
+    // The daemon's default codex launch always sends `features` (account apps off), so a
+    // whole-table replacement would silently drop the floor. Regression: this exact pair once
+    // produced only `{"features":{"apps":false}}`.
     const env = { CODEX_CONFIG: JSON.stringify({ features: { apps: false }, model: 'gpt-5.3-codex' }) }
     fillInCodexConfigFloor(env, FLOOR_ENV)
     const config = JSON.parse(env.CODEX_CONFIG) as Record<string, unknown>
-    expect(config.features).toEqual({ apps: false })
+    expect(config.features).toEqual({ apps: false, multi_agent: false })
     expect(config.model).toBe('gpt-5.3-codex')
+  })
+
+  it('keeps a daemon-sent leaf authoritative over the same floor leaf', () => {
+    const env = { CODEX_CONFIG: JSON.stringify({ features: { multi_agent: true } }) }
+    fillInCodexConfigFloor(env, FLOOR_ENV)
+    expect(JSON.parse(env.CODEX_CONFIG)).toEqual({ features: { multi_agent: true } })
+  })
+
+  it('lets a daemon non-table value replace a floor table outright', () => {
+    const env = { CODEX_CONFIG: JSON.stringify({ features: 'inherit' }) }
+    fillInCodexConfigFloor(env, FLOOR_ENV)
+    expect(JSON.parse(env.CODEX_CONFIG)).toEqual({ features: 'inherit' })
   })
 
   it('composes with the base-url fill-in: floor config never blocks the pod aim', () => {
@@ -228,12 +243,13 @@ describe('AcpRunner codex config projection', () => {
       args: ['-e', 'process.stdout.write(process.env.CODEX_CONFIG ?? "")'],
       env: {
         PATH: process.env.PATH ?? '',
-        CODEX_CONFIG: JSON.stringify({ openai_base_url: 'https://daemon-decided.internal' })
+        // The default launch shape: the daemon aims codex and disables account apps.
+        CODEX_CONFIG: JSON.stringify({ features: { apps: false }, openai_base_url: 'https://daemon-decided.internal' })
       }
     })
     await exited
     expect(JSON.parse(chunks.join(''))).toEqual({
-      features: { multi_agent: false },
+      features: { apps: false, multi_agent: false },
       openai_base_url: 'https://daemon-decided.internal'
     })
   })


### PR DESCRIPTION
## What

The runtime sandbox pod gains one deployment-owned variable, `AC_CODEX_CONFIG`: a JSON object of codex session config the deployment asserts about its model endpoint. The shim merges it **under** any daemon-sent `CODEX_CONFIG` — one level deep for a table both sides carry, since the daemon's default launch always sends `features` (account apps off) — so every leaf the daemon decided stays authoritative. The existing `AC_CODEX_BASE_URL` fill-in composes on top. Malformed values warn and leave the config untouched, matching the base-url fill-in's behavior.

## Why

The pod env already carries the endpoint floor for codex — base URL and key — but had no channel for endpoint knowledge that lives in codex's session config. The concrete case: a deployment's model gateway may reject a request shape a newer codex feature emits (a tool type its schema does not know), and the fix is to disable that feature for sandboxes aimed at that endpoint. That is knowledge only the deployment holds, on the seam the chart already owns ("everything about the endpoint is TOLD to the deployment"), so it belongs beside the other `AC_CODEX_*` fill-ins rather than in daemon defaults.

No behavior changes for pods that do not set the variable; an older runtime image ignores it harmlessly.

## Tests

`shim-provider-env.test.ts`: floor-alone projection, the one-level-deep shared-table merge (regression for the default account-apps launch, where a whole-table replacement dropped the floor), daemon-leaf precedence, non-table replacement, composition with the base-url fill-in, malformed floor/daemon-config warning paths, blank/empty no-op, and a real-runner spawn asserting the merged env the child receives under the default launch shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)