### PR TITLE
ci(release): keep the Linux sandbox suite off the release gate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,11 +25,14 @@ jobs:
   # Reuse the same quality gate as pull requests. The reusable workflow runs
   # Build, Check, Unit Test, and sharded Integration tests in parallel against
   # this exact SHA; the publishing job below waits for all of them.
+  # `skip_sandbox` drops the kernel-sandbox suite here — the PR already ran it, and its
+  # bwrap/apt setup is the leg whose failures would strand a merged commit unpublished.
   test:
     name: Test
     uses: ./.github/workflows/test.yaml
     with:
       defer_summaries: true
+      skip_sandbox: true
 
   release:
     needs: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_sandbox:
+        description: 'Skip the Linux kernel sandbox suite (PR runs always keep it)'
+        required: false
+        type: boolean
+        default: false
     outputs:
       build_test_summary:
         description: 'Unit test summary markdown'
@@ -205,8 +210,11 @@ jobs:
   # Exercise the daemon's core sandbox boundaries and confined skills pipeline
   # under the real Linux kernel sandbox. These cases self-skip in the bwrap-free
   # Unit Test job above and run for real here on a bwrap-capable runner.
+  # PR-only gate: release callers pass `skip_sandbox` so it cannot block publication.
+  # `inputs` is empty on `pull_request`, so the unset input reads falsy and PRs run it.
   sandbox-linux:
     name: Sandbox (Linux)
+    if: ${{ !inputs.skip_sandbox }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## What

`test.yaml` gains a `skip_sandbox` workflow_call input (default `false`), and `release.yaml` passes `skip_sandbox: true`. The `Sandbox (Linux)` job now runs on pull requests only — it is skipped when the same reusable workflow runs as the post-merge release gate for `main` / `release`.

Nothing else about the gate changes: Build, Check, Unit Test, Evaluation Gates, Daemon Store (PostgreSQL), and both integration shards still run before publication.

## Why

The sandbox suite reviews a change on the PR that introduces it. Re-running it after merge adds no new signal about the code, but it does add a leg that installs `bubblewrap` over apt and flips `kernel.apparmor_restrict_unprivileged_userns` — infrastructure steps that can fail on a runner for reasons unrelated to the commit. When they fail on the release gate, `semantic-release` never runs and a merged commit sits unpublished.

## Notes

- On `pull_request` the `inputs` context is empty, so the unset input reads falsy and the job runs — the same mechanism the existing `!inputs.defer_summaries` step conditions already rely on.
- A skipped job leaves the reusable-workflow call successful, so `needs: test` in the release job is satisfied.
- `ci`-typed commit, so this does not itself cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)