### PR TITLE
feat(memory): make [[links]] a real graph, and adopt the maintenance policies

### DIFF
--- a/packages/daemon/src/mcp/ops/memory.ts
+++ b/packages/daemon/src/mcp/ops/memory.ts
@@ -100,7 +100,16 @@ export async function readMemory(
   const scope = memoryScopeFor(ctx, deps)
   try {
     const path = parseArgs(READ_MEMORY_ARGS, args).path ?? 'MEMORY.md'
-    return await deps.memory.read(scope, path)
+    const result = await deps.memory.read(scope, path)
+    // One hop of the `[[name]]` graph, returned as its OWN fields — never spliced into
+    // `content`, which the agent may hand straight back to `writeMemory`.
+    const related = await deps.memory.neighbors?.(scope, path).catch(() => undefined)
+    if (!related || (related.links.length === 0 && related.backlinks.length === 0)) return result
+    return {
+      ...result,
+      ...(related.links.length > 0 ? { links: related.links } : {}),
+      ...(related.backlinks.length > 0 ? { backlinks: related.backlinks } : {})
+    }
   } catch (err) {
     toToolError(err)
   }

--- a/packages/daemon/src/memory/providers/dispatching.ts
+++ b/packages/daemon/src/memory/providers/dispatching.ts
@@ -10,6 +10,7 @@ import {
   type MemoryProvider,
   type MemoryProviderKind,
   type MemoryRecord,
+  type MemoryNeighborsResult,
   type MemoryReadResult,
   type MemoryScope,
   type MemoryWriteResult,
@@ -132,6 +133,13 @@ export class DispatchingMemoryProvider implements MemoryProvider {
   }
   read(scope: MemoryScope, path: string): Promise<MemoryReadResult> {
     return this.forAgent(scope.agentId).read(scope, path)
+  }
+
+  /** Delegate the memory graph too — without this the tool layer only ever sees the
+   *  dispatcher, so `readMemory` would silently never return links or backlinks. */
+  async neighbors(scope: MemoryScope, path: string): Promise<MemoryNeighborsResult> {
+    const provider = this.forAgent(scope.agentId)
+    return (await provider.neighbors?.(scope, path)) ?? { links: [], backlinks: [] }
   }
   write(
     scope: MemoryScope,

--- a/packages/daemon/src/memory/providers/managed.ts
+++ b/packages/daemon/src/memory/providers/managed.ts
@@ -169,10 +169,10 @@ export class ManagedMemoryProvider implements MemoryProvider {
   /** One hop of the `[[name]]` graph, from the layer that actually holds the file:
    *  under channel scope that is the channel folder, with the shared base as fallback. */
   async neighbors(scope: MemoryScope, path: string): Promise<MemoryNeighborsResult> {
-    for (const root of this.readRoots(scope)) {
-      if ((await readMemoryFileIfPresent(root, path)) !== null) return memoryNeighbors(root, path)
-    }
-    return { links: [], backlinks: [] }
+    // Pass the whole overlay: an edge may cross layers (a channel memory linking to a
+    // shared base one, or vice versa), so scanning only the file's own layer would
+    // drop those edges and could describe a shadowed file instead of the live one.
+    return memoryNeighbors(this.readRoots(scope), path)
   }
 
   async write(

--- a/packages/daemon/src/memory/providers/managed.ts
+++ b/packages/daemon/src/memory/providers/managed.ts
@@ -5,6 +5,7 @@ import { MEMORY_TOOLS } from '../tools.js'
 import {
   ensureMemory,
   readIndex,
+  memoryNeighbors,
   readMemoryFileIfPresent,
   writeMemoryFile,
   listMemory,
@@ -22,6 +23,7 @@ import type {
   MemoryExtractor,
   MemoryProvider,
   MemoryRecord,
+  MemoryNeighborsResult,
   MemoryReadResult,
   MemoryScope,
   MemoryWriteResult,
@@ -162,6 +164,15 @@ export class ManagedMemoryProvider implements MemoryProvider {
       if (content !== null) return { path, content }
     }
     return { path, content: '' }
+  }
+
+  /** One hop of the `[[name]]` graph, from the layer that actually holds the file:
+   *  under channel scope that is the channel folder, with the shared base as fallback. */
+  async neighbors(scope: MemoryScope, path: string): Promise<MemoryNeighborsResult> {
+    for (const root of this.readRoots(scope)) {
+      if ((await readMemoryFileIfPresent(root, path)) !== null) return memoryNeighbors(root, path)
+    }
+    return { links: [], backlinks: [] }
   }
 
   async write(

--- a/packages/daemon/src/memory/store.ts
+++ b/packages/daemon/src/memory/store.ts
@@ -44,7 +44,13 @@ export {
   type MemoryFs
 } from './fs.js'
 
-import { memoryNameForTopic, memoryRefToTopic, parseMemoryFrontmatter, stampMemoryHeader } from './frontmatter.js'
+import {
+  memoryLinkTargets,
+  memoryNameForTopic,
+  memoryRefToTopic,
+  parseMemoryFrontmatter,
+  stampMemoryHeader
+} from './frontmatter.js'
 
 export const MEMORY_DIRNAME = 'memory'
 export { MEMORY_INDEX }
@@ -698,4 +704,68 @@ export async function listMemory(fs: MemoryFs): Promise<MemoryFile[]> {
   }
   files.sort((a, b) => (a.name === MEMORY_INDEX ? -1 : b.name === MEMORY_INDEX ? 1 : a.name.localeCompare(b.name)))
   return files
+}
+
+/** One end of a `[[name]]` edge, with the description that makes it worth following. */
+export interface MemoryNeighbor {
+  name: string
+  topic: string
+  description?: string
+  /** False for a link to a memory that does not exist yet — a deliberate note-to-self. */
+  exists: boolean
+}
+
+export interface MemoryNeighbors {
+  /** Memories this one links out to. */
+  links: MemoryNeighbor[]
+  /** Memories that link to this one. */
+  backlinks: MemoryNeighbor[]
+}
+
+/** Cap on either side of the neighbour list, so a heavily linked memory cannot
+ *  balloon a tool result. */
+const MAX_NEIGHBORS = 20
+
+/**
+ * One hop of the memory graph around a topic (#41): what it links to, and what links
+ * back. Descriptions come along so a link is actionable without a second read — the
+ * whole point of the edges being there.
+ */
+export async function memoryNeighbors(fs: MemoryFs, relPath: string): Promise<MemoryNeighbors> {
+  const topic = memoryTopicName(memoryRefToTopic(relPath))
+  const self = memoryNameForTopic(topic)
+
+  const described = new Map<string, { topic: string; description?: string }>()
+  const outgoing = new Map<string, string[]>()
+  for (const file of await listMemory(fs)) {
+    const raw = await fs.readFile(`${MEMORY_DIRNAME}/${file.name}`)
+    if (raw === null) continue
+    const parsed = parseMemoryFrontmatter(raw.content)
+    const name = parsed.header.name || memoryNameForTopic(file.name)
+    described.set(name, {
+      topic: file.name,
+      ...(parsed.header.description ? { description: parsed.header.description } : {})
+    })
+    outgoing.set(name, memoryLinkTargets(parsed.body))
+  }
+
+  const toNeighbor = (name: string): MemoryNeighbor => {
+    const known = described.get(name)
+    return {
+      name,
+      topic: known?.topic ?? `${name}.md`,
+      ...(known?.description ? { description: known.description } : {}),
+      exists: known !== undefined
+    }
+  }
+
+  const links = (outgoing.get(self) ?? [])
+    .filter((name) => name !== self)
+    .slice(0, MAX_NEIGHBORS)
+    .map(toNeighbor)
+  const backlinks = [...outgoing.entries()]
+    .filter(([name, targets]) => name !== self && targets.includes(self))
+    .slice(0, MAX_NEIGHBORS)
+    .map(([name]) => toNeighbor(name))
+  return { links, backlinks }
 }

--- a/packages/daemon/src/memory/store.ts
+++ b/packages/daemon/src/memory/store.ts
@@ -731,22 +731,28 @@ const MAX_NEIGHBORS = 20
  * back. Descriptions come along so a link is actionable without a second read — the
  * whole point of the edges being there.
  */
-export async function memoryNeighbors(fs: MemoryFs, relPath: string): Promise<MemoryNeighbors> {
+export async function memoryNeighbors(roots: MemoryFs | MemoryFs[], relPath: string): Promise<MemoryNeighbors> {
   const topic = memoryTopicName(memoryRefToTopic(relPath))
   const self = memoryNameForTopic(topic)
 
   const described = new Map<string, { topic: string; description?: string }>()
   const outgoing = new Map<string, string[]>()
-  for (const file of await listMemory(fs)) {
-    const raw = await fs.readFile(`${MEMORY_DIRNAME}/${file.name}`)
-    if (raw === null) continue
-    const parsed = parseMemoryFrontmatter(raw.content)
-    const name = parsed.header.name || memoryNameForTopic(file.name)
-    described.set(name, {
-      topic: file.name,
-      ...(parsed.header.description ? { description: parsed.header.description } : {})
-    })
-    outgoing.set(name, memoryLinkTargets(parsed.body))
+  // Walk the read overlay in precedence order (channel first, then the shared base)
+  // and let the FIRST layer win, so a neighbour's metadata always describes the same
+  // file a later `readMemory` would actually open.
+  for (const fs of Array.isArray(roots) ? roots : [roots]) {
+    for (const file of await listMemory(fs)) {
+      const raw = await fs.readFile(`${MEMORY_DIRNAME}/${file.name}`)
+      if (raw === null) continue
+      const parsed = parseMemoryFrontmatter(raw.content)
+      const name = parsed.header.name || memoryNameForTopic(file.name)
+      if (described.has(name)) continue // shadowed by a higher-precedence layer
+      described.set(name, {
+        topic: file.name,
+        ...(parsed.header.description ? { description: parsed.header.description } : {})
+      })
+      outgoing.set(name, memoryLinkTargets(parsed.body))
+    }
   }
 
   const toNeighbor = (name: string): MemoryNeighbor => {

--- a/packages/daemon/src/memory/tools.ts
+++ b/packages/daemon/src/memory/tools.ts
@@ -13,9 +13,14 @@ export const MEMORY_TOOLS: ToolDescriptor[] = [
       'Read one of your memory files. Omit `path` (or pass "MEMORY.md") to read the index; pass a topic file name ' +
       '(e.g. "deploys.md") to read that topic. The index is already shown to you at the start of each session (you ' +
       'do NOT need to read it first) — use this to pull the detail behind an index entry, or the current contents of ' +
-      'a file before editing it.',
+      'a file before editing it. Also accepts a `[[name]]` link exactly as it appears in a memory body. The result ' +
+      'carries `links` (memories this one points to) and `backlinks` (memories pointing at it), each with its ' +
+      'description — follow one by reading it. Those fields are NOT part of the file: never write them back.',
     inputSchema: obj({
-      path: { type: 'string', description: 'Memory file name (e.g. "deploys.md"). Defaults to the MEMORY.md index.' }
+      path: {
+        type: 'string',
+        description: 'Memory file name (e.g. "deploys.md"), or a "[[name]]" link. Defaults to the MEMORY.md index.'
+      }
     })
   },
   {

--- a/packages/daemon/src/memory/types.ts
+++ b/packages/daemon/src/memory/types.ts
@@ -71,6 +71,12 @@ export interface RecallRequest {
 
 export type RecallPolicy = MemoryRecallPolicy
 
+/** One hop of the `[[name]]` memory graph around a file (#41). */
+export interface MemoryNeighborsResult {
+  links: { name: string; topic: string; description?: string; exists: boolean }[]
+  backlinks: { name: string; topic: string; description?: string; exists: boolean }[]
+}
+
 export interface FileMemoryAdmin {
   shape: 'files'
   list(scope: MemoryScope): Promise<MemoryEntry[]>
@@ -166,6 +172,10 @@ export interface MemoryProvider {
   /** Agent-scoped variant implemented by the dispatcher. Tool/CP callers must
    * prefer this when their `MemoryProvider` can serve more than one agent. */
   adminSurfaceForAgent?(agentId: string): MemoryAdminSurface
+
+  /** One hop of the memory graph around a file. Only the managed file store has a
+   *  graph; other providers omit it and callers degrade to no related links. */
+  neighbors?(scope: MemoryScope, path: string): Promise<MemoryNeighborsResult>
 
   /** @deprecated migration alias; live injection uses toolsForAgent. */
   tools(): ToolDescriptor[]

--- a/packages/daemon/src/session/turn/standing-context.ts
+++ b/packages/daemon/src/session/turn/standing-context.ts
@@ -97,17 +97,24 @@ function buildMemoryAppend(memoryIndex: string): string {
   if (!memoryIndex) return ''
   return (
     `# Persistent memory\n` +
-    `You keep a persistent memory across sessions. Your context is periodically ` +
-    `compacted, and this index is re-read at the START of every session — it is your main way to recover ` +
-    `what you learned. Record durable facts PROACTIVELY, without being asked — conventions, decisions, ` +
-    `who to ask, project/channel context, and anything you had to re-learn: write a topic file with ` +
-    `\`writeMemory\` as you go, and read one with \`readMemory\` when it is relevant.\n\n` +
-    `Start each topic file with a header, then the body:\n` +
+    `You keep a persistent memory across sessions. Your context is periodically compacted, and this index is ` +
+    `re-read at the START of every session — it is your main way to recover what you learned. Record durable ` +
+    `facts PROACTIVELY, without being asked, with \`writeMemory\`; read one with \`readMemory\`.\n\n` +
+    `ONE FILE = ONE FACT. Give each a short kebab-case name and start it with a header:\n` +
     `\`\`\`\n---\ndescription: one line saying what this holds — it is how a future session decides to open it\n` +
     `type: user | feedback | project | reference\n---\n\`\`\`\n` +
-    `Link related memories inline as \`[[topic-name]]\` (no \`.md\`); \`readMemory\` accepts that form directly, ` +
-    `so a link you read is a reference you can follow. MEMORY.md below is GENERATED from those descriptions — ` +
-    `do not hand-edit it; to change how a topic appears in the index, change that topic's \`description\`.\n\n` +
+    `\`user\`: who the people here are — role, expertise, preferences. \`feedback\`: guidance you were given about ` +
+    `how to work, corrections and confirmed approaches alike; include WHY, and how to apply it. \`project\`: ` +
+    `ongoing work, goals, or constraints you could not derive from the code or git history; write dates absolute, ` +
+    `never "yesterday". \`reference\`: pointers to external resources — URLs, dashboards, tickets.\n\n` +
+    `Link related memories inline as \`[[topic-name]]\` (no \`.md\`), and link liberally: a \`[[name]]\` with no file ` +
+    `behind it yet is fine — it marks something worth writing later, not an error. \`readMemory\` takes that form ` +
+    `directly and reports each memory's links and backlinks, so following one is cheap.\n\n` +
+    `Before saving, check whether a file already covers it: UPDATE that file instead of creating a near-duplicate, ` +
+    `and delete a memory that turns out to be wrong. Do NOT save what the repository already records — code ` +
+    `structure, past fixes, git history, CLAUDE.md — or what only matters to the conversation you are in.\n\n` +
+    `MEMORY.md below is GENERATED from those descriptions — do not hand-edit it; to change how a topic appears, ` +
+    `change that topic's \`description\`.\n\n` +
     `Only text inside the memory-file boundary below belongs to \`MEMORY.md\`; everything outside it is ` +
     `session context and not a valid source for \`oldString\`. This injected index is a start-of-session ` +
     `snapshot. Its body uses one layer of XML character-reference encoding: \`&amp;\`, \`&lt;\`, and \`&gt;\` ` +

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -22,6 +22,8 @@ import {
   writeMemoryFile
 } from '../src/memory/store.js'
 import { appendDistilledMemories } from '../src/memory/distill.js'
+import { createMemoryProvider } from '../src/memory/providers/factory.js'
+import { memoryChannelKey } from '../src/memory/store.js'
 
 const fs = () => new LocalMemoryFs(mkdtempSync(join(tmpdir(), 'ac-fm-')))
 
@@ -260,5 +262,57 @@ describe('memory graph (one hop)', () => {
 
     const { links } = await memoryNeighbors(f, '[[solo]]')
     expect(links.map((n) => n.name)).toEqual(['other'])
+  })
+})
+
+describe('memory graph through the live provider path', () => {
+  const withHeader = (description: string, body: string) => `---\ndescription: ${description}\n---\n${body}\n`
+
+  // The tool layer only ever sees the DISPATCHER, so exercising the managed provider
+  // directly is not enough: this is the path production actually takes.
+  const dispatcher = (dir: string) =>
+    createMemoryProvider({
+      memoryFsFor: () => new LocalMemoryFs(dir),
+      providerKindFor: () => 'managed' as const
+    } as never)
+
+  it('returns links through the dispatcher, not just the managed provider', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-disp-'))
+    const provider = dispatcher(dir)
+    const scope = { agentId: 'bot-a' }
+    provider.ensure(scope, 'bot')
+    await provider.write(scope, 'a.md', withHeader('the a one', 'points at [[b]]'), undefined, 'tool')
+    await provider.write(scope, 'b.md', withHeader('the b one', 'leaf'), undefined, 'tool')
+
+    const related = await provider.neighbors?.(scope, 'a.md')
+    expect(related?.links).toEqual([{ name: 'b', topic: 'b.md', description: 'the b one', exists: true }])
+    expect((await provider.neighbors?.(scope, 'b.md'))?.backlinks.map((n) => n.name)).toEqual(['a'])
+  })
+
+  it('follows edges across the channel/base overlay, preferring the shadowing file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-overlay-'))
+    const provider = dispatcher(dir)
+    const base = { agentId: 'bot-a' }
+    const chan = { agentId: 'bot-a', channelKey: memoryChannelKey('C1'), channel: 'C1' }
+    provider.ensure(base, 'bot')
+    provider.ensure(chan, 'bot')
+
+    // Shared base holds `policy`; the channel layer holds a note linking to it.
+    await provider.write(base, 'policy.md', withHeader('the shared policy', 'base text'), undefined, 'tool')
+    await provider.write(chan, 'note.md', withHeader('a channel note', 'per [[policy]]'), undefined, 'tool')
+
+    // The cross-layer edge resolves, using the base file's description.
+    const fromNote = await provider.neighbors?.(chan, 'note.md')
+    expect(fromNote?.links).toEqual([
+      { name: 'policy', topic: 'policy.md', description: 'the shared policy', exists: true }
+    ])
+    // …and the base memory sees the channel note linking back to it.
+    expect((await provider.neighbors?.(chan, 'policy.md'))?.backlinks.map((n) => n.name)).toEqual(['note'])
+
+    // When the channel shadows a base file, the neighbour describes the file that
+    // `readMemory` would actually open — the channel one.
+    await provider.write(chan, 'policy.md', withHeader('the channel override', 'chan text'), undefined, 'tool')
+    const shadowed = await provider.neighbors?.(chan, 'note.md')
+    expect(shadowed?.links[0]?.description).toBe('the channel override')
   })
 })

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -14,7 +14,13 @@ import {
   parseMemoryFrontmatter,
   stampMemoryHeader
 } from '../src/memory/frontmatter.js'
-import { ensureMemory, MAX_MEMORY_FILE_BYTES, readMemoryFile, writeMemoryFile } from '../src/memory/store.js'
+import {
+  ensureMemory,
+  MAX_MEMORY_FILE_BYTES,
+  memoryNeighbors,
+  readMemoryFile,
+  writeMemoryFile
+} from '../src/memory/store.js'
 import { appendDistilledMemories } from '../src/memory/distill.js'
 
 const fs = () => new LocalMemoryFs(mkdtempSync(join(tmpdir(), 'ac-fm-')))
@@ -212,5 +218,47 @@ describe('distillation and the generated index', () => {
     // Every fact landed in its topic file even though the index had to be truncated.
     expect(await readMemoryFile(f, 'd-11.md')).toContain('fact 11')
     expect(Buffer.byteLength(await readMemoryFile(f, 'MEMORY.md'))).toBeLessThanOrEqual(MAX_MEMORY_FILE_BYTES)
+  })
+})
+
+describe('memory graph (one hop)', () => {
+  const write = (f: ReturnType<typeof fs>, topic: string, description: string, body: string) =>
+    writeMemoryFile(f, topic, `---\ndescription: ${description}\n---\n${body}\n`, undefined, 'tool')
+
+  it('reports outgoing links and backlinks, each with its description', async () => {
+    const f = fs()
+    await ensureMemory(f, 'bot')
+    await write(f, 'deploys.md', 'how we ship', 'pipeline owns it, see [[runtimes]]')
+    await write(f, 'runtimes.md', 'which runtimes we support', 'claude and codex')
+    await write(f, 'oncall.md', 'who to page', 'escalate per [[deploys]]')
+
+    const from = await memoryNeighbors(f, 'deploys.md')
+    expect(from.links).toEqual([
+      { name: 'runtimes', topic: 'runtimes.md', description: 'which runtimes we support', exists: true }
+    ])
+    // oncall links to deploys, so deploys sees it as a backlink.
+    expect(from.backlinks).toEqual([{ name: 'oncall', topic: 'oncall.md', description: 'who to page', exists: true }])
+
+    // The graph is symmetric from the other end.
+    expect((await memoryNeighbors(f, 'runtimes.md')).backlinks.map((n) => n.name)).toEqual(['deploys'])
+  })
+
+  it('keeps a link to a memory that does not exist yet, marked as such', async () => {
+    const f = fs()
+    await ensureMemory(f, 'bot')
+    await write(f, 'a.md', 'has a forward reference', 'todo: write [[not-yet]]')
+
+    const { links } = await memoryNeighbors(f, 'a.md')
+    expect(links).toEqual([{ name: 'not-yet', topic: 'not-yet.md', exists: false }])
+  })
+
+  it('accepts a [[link]] as the lookup and ignores a self-link', async () => {
+    const f = fs()
+    await ensureMemory(f, 'bot')
+    await write(f, 'solo.md', 'points at itself', 'see [[solo]] and [[other]]')
+    await write(f, 'other.md', 'the other one', 'x')
+
+    const { links } = await memoryNeighbors(f, '[[solo]]')
+    expect(links.map((n) => n.name)).toEqual(['other'])
   })
 })


### PR DESCRIPTION
Follow-up to #1254. @pchsu spotted that I'd shipped the `[[name]]` *syntax* but not the **graph** — links were inert unless the agent chose to follow one by hand — and suggested I look at how Claude Code's own prompt maintains memory (which I can read, since I run under it). Both are addressed here.

## The graph actually works

`memoryNeighbors` walks one hop around a memory: what it **links** to and what **backlinks** to it, each carrying the `description` that makes the link worth following. `readMemory` returns them as their own `links` / `backlinks` fields — **deliberately not spliced into `content`**, which the agent may hand straight back to `writeMemory`; merging them would round-trip presentation into stored data (and corrupt the console view, which reads through the same provider).

Details that matter:
- A link to a memory that **doesn't exist yet** is kept and marked `exists: false` — Claude Code treats a dangling `[[name]]` as a note-to-self, and so do we.
- Self-links dropped; each side capped so a hub memory can't balloon a tool result.
- Only the managed file store has a graph, so the provider method is optional — other providers degrade to no related links.

## The prompt now teaches maintenance, not just format

Ported from Claude Code's memory instructions:
- **ONE FILE = ONE FACT**, short kebab-case name (ours previously invited dumping-ground "topic" files).
- What each `type` means — `user` / `feedback` (with **why** and how to apply) / `project` (absolute dates) / `reference`.
- **Link liberally**; a dangling `[[name]]` is a marker, not an error.
- **Dedupe**: check for a file that already covers it and *update* it; delete memories that turn out to be wrong.
- **Don't store what the repo already records** (code structure, past fixes, git history, CLAUDE.md) or what only matters to the current conversation.

That last pair is the real anti-bloat rule — we had nothing equivalent.

## Tests

Links + backlinks with descriptions and symmetry, dangling links, `[[link]]` accepted as the lookup, self-link exclusion. Memory + MCP + evaluation suites green (11 files); typecheck and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)