### PR TITLE
fix(memory): settle index ownership at dream adoption

### DIFF
--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -22,6 +22,7 @@ import {
 } from '@agentconnect.md/protocol'
 import {
   MEMORY_INDEX,
+  regenerateMemoryIndexHoldingLock,
   MEMORY_HISTORY_FILENAME,
   MAX_INDEX_INJECT_BYTES,
   MAX_MEMORY_FILE_BYTES,
@@ -1123,6 +1124,12 @@ export class DreamRunner {
           // snapshot must fence on this adoption rather than classify it as
           // distill-only drift and roll over it.
           recordExternalMemoryMutation(fs, 'dream')
+          // The adopted store has a hand-authored MEMORY.md while ordinary writes
+          // regenerate it from the topic descriptions — two writers with no defined
+          // precedence. Settle it here, inside the same lock: if the adopted topics
+          // give the generator anything to work with, it owns the index from now on
+          // instead of silently replacing the dream's copy at some later write.
+          await regenerateMemoryIndexHoldingLock(fs, 'dream').catch(() => {})
           // Dream adoption copies history as part of the atomic store swap, so
           // tighten that copied/appended sidecar before releasing the same lock.
           await enforceMemoryHistoryRetentionHoldingLock(fs).catch(() => {})

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -19,6 +19,7 @@ import {
   MAX_MEMORY_FILE_BYTES,
   memoryNeighbors,
   readMemoryFile,
+  regenerateMemoryIndexHoldingLock,
   writeMemoryFile
 } from '../src/memory/store.js'
 import { appendDistilledMemories } from '../src/memory/distill.js'
@@ -314,5 +315,32 @@ describe('memory graph through the live provider path', () => {
     await provider.write(chan, 'policy.md', withHeader('the channel override', 'chan text'), undefined, 'tool')
     const shadowed = await provider.neighbors?.(chan, 'note.md')
     expect(shadowed?.links[0]?.description).toBe('the channel override')
+  })
+})
+
+describe('dream adoption and index ownership', () => {
+  it('hands the index to the generator at adopt, when the adopted topics support it', async () => {
+    // Simulates the adopt swap: a hand-authored MEMORY.md written straight to disk
+    // (as adopt does), alongside topics that DO carry descriptions.
+    const f = fs()
+    await ensureMemory(f, 'bot')
+    await f.writeFile('memory/MEMORY.md', '# bot memory\n\nthe dream wrote this by hand\n', {})
+    await f.writeFile('memory/a.md', '---\ndescription: from the dream\n---\na\n', {})
+
+    await regenerateMemoryIndexHoldingLock(f, 'dream')
+    const index = await readMemoryFile(f, 'MEMORY.md')
+    expect(index).toContain('- [a](a.md) — from the dream')
+    expect(index).not.toContain('the dream wrote this by hand')
+    expect(index).toContain('# bot memory') // the heading is still preserved
+  })
+
+  it('leaves a dream-authored index alone when nothing can be generated from it', async () => {
+    const f = fs()
+    await ensureMemory(f, 'bot')
+    await f.writeFile('memory/MEMORY.md', '# bot memory\n\ncurated by the dream\n', {})
+    await f.writeFile('memory/a.md', 'no header here\n', {})
+
+    await regenerateMemoryIndexHoldingLock(f, 'dream')
+    expect(await readMemoryFile(f, 'MEMORY.md')).toContain('curated by the dream')
   })
 })


### PR DESCRIPTION
Step 1 of the memory-write-path unification @pchsu called for. This one is a contained bug fix; the architectural change lands separately.

## The bug

Dream adoption writes a hand-authored `MEMORY.md` straight to disk (raw `fs.writeFile`, bypassing `writeMemoryFile`), while ordinary writes regenerate the index from topic descriptions (#1254). That leaves **two writers with no defined precedence**: the dream's index survived the swap, then got silently replaced at some arbitrary later write — the first time any described topic existed.

Latent today only because most stores predate headers.

## The fix

Settle ownership inside the adoption lock. After the swap, ask the generator to rebuild:

- adopted topics carry descriptions → the generator takes the index **immediately** and keeps it, rather than ambushing the user later;
- they don't → the dream's index stands, and nothing can clobber it out of nowhere (clobbering required a described topic, which by definition doesn't exist).

Either way the store is self-consistent the moment adoption returns.

## Tests

Both directions: a dream-authored index yields to the generator when adopted topics have descriptions (heading preserved), and is left intact when they don't. Memory + dream + evaluation + channel suites green (6 files).

## What's next

Steps 2–4 unify the paths properly — one memory harness (tools + shared format/policy prompt) parameterized only by memory root, with distill and dream calling the same tools (live root vs staged root) instead of each returning bespoke JSON the daemon translates. That step retires the proposal's `index` field and touches protocol/CP/web, so it ships on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)