### PR TITLE
refactor(web): make SessionStep.turnId a guaranteed invariant

### DIFF
--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -187,9 +187,18 @@ function newPlaygroundSessionId(agentId: string): string {
   return `${PG_PREFIX}${agentId}_${randomUuid()}`
 }
 
-function stampStep(step: SessionStep, observedAtMs = Date.now()): SessionStep {
+// A step on its way in: a producer may omit `turnId` (a locally-pushed warning has no stream
+// turn) — `stampStep` mints one, so every step that reaches state carries a durable turn identity.
+type UnstampedStep = Omit<SessionStep, 'turnId'> & { turnId?: string }
+
+function stampStep(step: UnstampedStep, observedAtMs = Date.now()): SessionStep {
   return {
     ...step,
+    // The single choke point every live step passes through, so it is the one place that
+    // guarantees `turnId`: keep the wire/user turnId when present, else mint one. A minted id is
+    // per-step (a standalone warning is its own trivial turn); real multi-step agent turns always
+    // arrive with the wire turnId, so this never splits one.
+    turnId: step.turnId ?? `local:${randomUuid()}`,
     time: step.time ?? liveStepTime(),
     observedAtMs: step.observedAtMs ?? observedAtMs
   }
@@ -411,7 +420,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const pushStep = useCallback(
-    (id: string, step: SessionStep): void => mutateSteps(id, (steps) => [...steps, stampStep(step)]),
+    (id: string, step: UnstampedStep): void => mutateSteps(id, (steps) => [...steps, stampStep(step)]),
     [mutateSteps]
   )
 
@@ -452,7 +461,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     (id: string, ev: WebchatEvent, agentId: string | undefined, turnId: string): void => {
       const observedAtMs = Date.now()
       const who = participantName(id, agentId)
-      const lane = (extra: Omit<SessionStep, 'text'> & { text: string }): SessionStep =>
+      const lane = (extra: Omit<SessionStep, 'text' | 'turnId'> & { text: string }): SessionStep =>
         stampStep({ ...extra, turnId, ...(agentId ? { agentId } : {}), ...(who ? { who } : {}) }, observedAtMs)
       mutateSteps(id, (steps) => {
         // Concurrent participant streams interleave: accumulate each chunk into

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -3040,10 +3040,10 @@ export default function SessionDetailView() {
   // `key` never depends on presentation fields (`time`, `wake`) that change as it grows.
   const rowAnchor = (m: SessionMessageDto): string =>
     `${conversationSourceSessionByMessageRef.current.get(m) ?? session.id}#${m.seq}`
-  // Live steps have no persisted `seq`; their turn identity is the stream `turnId`, and a bare
-  // step (a live user line) falls back to its authoring participant + observed time.
-  const liveAnchor = (stp: SessionStep): string =>
-    `live:${stp.turnId ?? `${stp.agentId ?? stp.who ?? ''}@${stp.observedAtMs ?? stp.time ?? ''}`}`
+  // Live steps have no persisted `seq`; their turn identity is the step's `turnId`, which
+  // `stampStep` guarantees for every live step (minting one for a standalone line) — so no
+  // presentation-field fallback is needed here.
+  const liveAnchor = (stp: SessionStep): string => `live:${stp.turnId}`
   const speakers = new Map<string, SessionParticipant>()
   const rememberParticipant = (id: string, participant: Omit<SessionParticipant, 'id'>): void => {
     const current = speakers.get(id)

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -5,6 +5,7 @@ import type { AgentIcon } from '@/lib/agent-icon'
 import type { DaemonSessionRetention, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { platformLabel } from '@/lib/platform-labels'
+import { randomUuid } from '@/lib/random-uuid'
 
 export type LifecycleStatusKey = 'upgrading' | 'restarting'
 export type ConnectionStatusKey = 'online' | 'paused' | 'offline'
@@ -984,9 +985,12 @@ export interface SessionImage {
 export interface SessionStep {
   kind: LaneKind
   who?: string
-  /** Stable identity of the live webchat turn. Pair with `agentId` when
-   *  folding interleaved participant streams into conversation blocks. */
-  turnId?: string
+  /** Stable identity of the turn this step belongs to — the wire/user turnId for a live webchat
+   *  turn, or a minted id for a standalone step (a locally-pushed warning is its own trivial
+   *  turn). Guaranteed present: `stampStep` mints one when a producer omits it, so consumers
+   *  (lane grouping, transcript turn keys) can rely on it. Pair with `agentId` when folding
+   *  interleaved participant streams into conversation blocks. */
+  turnId: string
   /** Authoring participant of a live multi-agent webchat step — keys the per-agent
    *  stream lane accumulation and the per-block attribution label. */
   agentId?: string
@@ -1611,7 +1615,11 @@ export function getAgent(id: string): Agent {
   return AGENTS.find((a) => a.id === id) ?? AGENTS[0]!
 }
 
-const RAW_SESSIONS_BY_AGENT: Record<string, Session[]> = {
+// Mock sessions author steps without a stream turnId; the transform below mints one so demo data
+// satisfies the `SessionStep.turnId` invariant exactly as `stampStep` does for live steps.
+type MockStep = Omit<SessionStep, 'turnId'> & { turnId?: string }
+type MockSession = Omit<Session, 'steps'> & { steps: MockStep[] }
+const RAW_SESSIONS_BY_AGENT: Record<string, MockSession[]> = {
   deploy: [
     {
       id: 'd1',
@@ -1833,8 +1841,12 @@ const RAW_SESSIONS_BY_AGENT: Record<string, Session[]> = {
   ]
 }
 
+const mintStepTurnIds = (s: MockSession): Session => ({
+  ...s,
+  steps: s.steps.map((step) => ({ ...step, turnId: step.turnId ?? `mock:${randomUuid()}` }))
+})
 const SESSIONS_BY_AGENT: Record<string, Session[]> = Object.fromEntries(
-  Object.entries(RAW_SESSIONS_BY_AGENT).map(([id, list]) => [id, list.map(tagTitle)])
+  Object.entries(RAW_SESSIONS_BY_AGENT).map(([id, list]) => [id, list.map((s) => tagTitle(mintStepTurnIds(s)))])
 )
 
 export function getSessions(agentId: string): Session[] {

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1841,10 +1841,21 @@ const RAW_SESSIONS_BY_AGENT: Record<string, MockSession[]> = {
   ]
 }
 
-const mintStepTurnIds = (s: MockSession): Session => ({
-  ...s,
-  steps: s.steps.map((step) => ({ ...step, turnId: step.turnId ?? `mock:${randomUuid()}` }))
-})
+const mintStepTurnIds = (s: MockSession): Session => {
+  // One turnId per LOGICAL turn, not per step: a `msg` opens a new turn and the agent's following
+  // plan/tool/edit/done steps carry it, so an answer groups as ONE bot turn (the session-detail
+  // builder folds bot output by turnId via liveBotTurnKey). This mirrors a real webchat turn, whose
+  // reply steps all share the one wire turnId.
+  let turnId = `mock:${randomUuid()}`
+  return {
+    ...s,
+    steps: s.steps.map((step) => {
+      if (step.turnId !== undefined) return step as SessionStep
+      if (step.kind === 'msg') turnId = `mock:${randomUuid()}`
+      return { ...step, turnId }
+    })
+  }
+}
 const SESSIONS_BY_AGENT: Record<string, Session[]> = Object.fromEntries(
   Object.entries(RAW_SESSIONS_BY_AGENT).map(([id, list]) => [id, list.map((s) => tagTitle(mintStepTurnIds(s)))])
 )

--- a/packages/web/src/lib/session-transcript.test.ts
+++ b/packages/web/src/lib/session-transcript.test.ts
@@ -40,7 +40,7 @@ describe('reconcilePersistedLiveSteps', () => {
   const agentId = 'agent'
 
   function prompt(text: string, observedAtMs: number): SessionStep {
-    return { kind: 'msg', who: '@you', text, observedAtMs }
+    return { kind: 'msg', who: '@you', turnId: `u:${observedAtMs}`, text, observedAtMs }
   }
 
   function persistedPrompt(seq: number, text: string, ts: number): SessionMessageDto {
@@ -50,7 +50,7 @@ describe('reconcilePersistedLiveSteps', () => {
   it('preserves an unpersisted failed turn when a tail refresh is empty', () => {
     const live = [
       prompt('ship it', 1_785_000_000_000),
-      { kind: 'done', text: '⚠️ Could not reach the agent.', observedAtMs: 1_785_000_000_100 }
+      { kind: 'done', turnId: 'warn-1', text: '⚠️ Could not reach the agent.', observedAtMs: 1_785_000_000_100 }
     ] satisfies SessionStep[]
 
     expect(reconcilePersistedLiveSteps(live, [], agentId)).toBe(live)
@@ -61,9 +61,9 @@ describe('reconcilePersistedLiveSteps', () => {
     const retriedAt = failedAt + 30_000
     const live = [
       prompt('ship it', failedAt),
-      { kind: 'done', text: '⚠️ Could not reach the agent.', observedAtMs: failedAt + 100 },
+      { kind: 'done', turnId: 'warn-1', text: '⚠️ Could not reach the agent.', observedAtMs: failedAt + 100 },
       prompt('ship it', retriedAt),
-      { kind: 'done', text: 'deployed', observedAtMs: retriedAt + 1_000 }
+      { kind: 'done', turnId: 'ok-1', text: 'deployed', observedAtMs: retriedAt + 1_000 }
     ] satisfies SessionStep[]
 
     expect(reconcilePersistedLiveSteps(live, [persistedPrompt(1, 'ship it', retriedAt + 50)], agentId)).toEqual(
@@ -75,7 +75,7 @@ describe('reconcilePersistedLiveSteps', () => {
     const at = 1_785_000_000_000
     const live = [
       prompt('yes', at),
-      { kind: 'done', text: '⚠️ Could not reach the agent.', observedAtMs: at + 100 }
+      { kind: 'done', turnId: 'warn-2', text: '⚠️ Could not reach the agent.', observedAtMs: at + 100 }
     ] satisfies SessionStep[]
     const peerRows = [
       { seq: 1, ts: String(at + 50), text: 'yes', sender: 'bot-b', kind: 'text' }
@@ -92,7 +92,14 @@ describe('reconcilePersistedLiveSteps', () => {
   // it renders as a standalone step, identified only by its canonical postId.
   it('drops a standalone agent-post step once ITS postId lands in a persisted row (adopted-conversation refresh)', () => {
     const live = [
-      { kind: 'done', text: 'Sent "hello" to bot-b', agentId: 'bot-a', postId: 'post-1', observedAtMs: 1 }
+      {
+        kind: 'done',
+        turnId: 'post-1',
+        text: 'Sent "hello" to bot-b',
+        agentId: 'bot-a',
+        postId: 'post-1',
+        observedAtMs: 1
+      }
     ] satisfies SessionStep[]
 
     expect(
@@ -102,7 +109,14 @@ describe('reconcilePersistedLiveSteps', () => {
 
   it('keeps a standalone agent-post step whose postId has not been persisted yet', () => {
     const live = [
-      { kind: 'done', text: 'Sent "hello" to bot-b', agentId: 'bot-a', postId: 'post-1', observedAtMs: 1 }
+      {
+        kind: 'done',
+        turnId: 'post-1',
+        text: 'Sent "hello" to bot-b',
+        agentId: 'bot-a',
+        postId: 'post-1',
+        observedAtMs: 1
+      }
     ] satisfies SessionStep[]
 
     expect(
@@ -115,7 +129,7 @@ describe('reconcilePersistedLiveSteps', () => {
   // matching must not be gated by sender the way the prompt heuristic is.
   it('drops a peer participant’s post confirmed by a row from that peer’s OWN session', () => {
     const live = [
-      { kind: 'done', text: 'hi from bot-b', agentId: 'bot-b', postId: 'post-2', observedAtMs: 1 }
+      { kind: 'done', turnId: 'post-2', text: 'hi from bot-b', agentId: 'bot-b', postId: 'post-2', observedAtMs: 1 }
     ] satisfies SessionStep[]
 
     expect(
@@ -126,9 +140,9 @@ describe('reconcilePersistedLiveSteps', () => {
   it('reconciles a standalone post step and a prompt-anchored turn independently in the same refresh', () => {
     const at = 1_785_000_000_000
     const live = [
-      { kind: 'done', text: 'stale post', agentId: 'bot-a', postId: 'post-3', observedAtMs: at },
+      { kind: 'done', turnId: 'post-3', text: 'stale post', agentId: 'bot-a', postId: 'post-3', observedAtMs: at },
       prompt('ship it', at + 1_000),
-      { kind: 'done', text: 'deployed', observedAtMs: at + 2_000 }
+      { kind: 'done', turnId: 'ok-2', text: 'deployed', observedAtMs: at + 2_000 }
     ] satisfies SessionStep[]
 
     const persisted = [


### PR DESCRIPTION
## What & why

Follow-up to #1248 (stable transcript turn keys). That PR had the transcript builder invent a
durable anchor for **live** steps with a fallback — `turnId ?? \`${author}@${observedAtMs}\``.
This makes the fallback unnecessary by guaranteeing the invariant at the source.

**Every live `SessionStep` now has a `turnId`.**

- **`stampStep`** — the single function every provider step passes through — mints a `local:`
  turnId when a producer omits one. A locally-pushed warning is its own trivial turn, so a
  per-step id is correct; real multi-step agent turns always arrive with the **required wire
  `turnId`** (`OrderedWebchatOutput.turnId`), so minting never splits one. `pushStep` / `lane`
  inputs go `turnId`-optional while the stamped output stays required.
- **`SessionStep.turnId` is now required.** Mock sessions mint a `mock:` id in the existing
  `RAW_SESSIONS_BY_AGENT` → `SESSIONS_BY_AGENT` transform (one place, not 22 literals); the
  `session-transcript` fixtures carry explicit ids.
- **Consumer simplifies**: `liveAnchor` collapses to `` `live:${stp.turnId}` `` — no
  presentation-field fallback. (Bonus: the invariant also hardens the lane-grouping path.)

Minted ids never collide with the streaming/cursor logic — that only ever compares **wire**
turnIds, and minted ones carry a `local:` / `mock:` prefix.

## Depends on

Stacks on #1248 (it simplifies the `liveAnchor` that PR introduced). Merge after #1248.

## Test plan

- [x] `tsc --noEmit` — 0 errors (the required-type change enforces a turnId at every producer).
- [x] `session-transcript`, `session-work`, `stick-to-bottom`, `webchat-stream`,
      `webchat-delta-buffer`, `PlaygroundSend`, `data` — 122 passing.
- [x] eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
