### PR TITLE
feat(web): show usage debits in the billing history

### DIFF
--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -19,6 +19,7 @@ import {
   fetchBillingAccount,
   fetchBillingPurchase,
   fetchBillingTransactions,
+  fmtDecimalUsd,
   fmtMicroUsd,
   type BillingPurchase
 } from '@/lib/billing-api'
@@ -516,13 +517,17 @@ export default function BillingView() {
                 <div key={t.id} className={`row ${TX_GRID}`}>
                   <span className="min-w-0">
                     <span className="block truncate font-sans text-[13px] font-medium leading-normal">
-                      {KIND_LABEL[t.kind] ?? t.kind}
+                      {t.type === 'debit' ? `Usage — ${t.period}` : (KIND_LABEL[t.kind] ?? t.kind)}
                     </span>
                     <span className="block font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
                       {fmtWhen(t.at)}
                     </span>
                   </span>
-                  <span className="mono text-right text-[13px]">{fmtMicroUsd(t.amountMicro)}</span>
+                  {/* A debit is recorded as a positive amount that was taken away, so
+                      the sign belongs here rather than in what the service sends. */}
+                  <span className="mono text-right text-[13px]">
+                    {t.type === 'debit' ? `-${fmtDecimalUsd(t.amount)}` : fmtMicroUsd(t.amountMicro)}
+                  </span>
                 </div>
               ))
             )}

--- a/packages/web/src/lib/billing-api.test.ts
+++ b/packages/web/src/lib/billing-api.test.ts
@@ -9,11 +9,19 @@ import {
   assertPurchase,
   assertPurchaseCreated,
   assertTransactionsPage,
+  fmtDecimalUsd,
   BillingShapeError,
   fmtMicroUsd
 } from './billing-api'
 
-const tx = { id: 't1', kind: 'purchase', amountMicro: 25_000_000, at: '2026-08-17T09:25:33.751Z' }
+const tx = { type: 'credit', id: 't1', kind: 'purchase', amountMicro: 25_000_000, at: '2026-08-17T09:25:33.751Z' }
+const debit = {
+  type: 'debit',
+  id: 'd1',
+  period: '2026-08',
+  amount: '0.450000000000000001',
+  at: '2026-08-20T10:00:00.000Z'
+}
 
 describe('assertAccount', () => {
   it('accepts the documented shape', () => {
@@ -47,6 +55,31 @@ describe('assertTransactionsPage', () => {
     // Deliberate: the row renders the raw value as its label. Refusing the whole
     // page because the service added a kind would be the worse failure.
     expect(() => assertTransactionsPage({ items: [{ ...tx, kind: 'chargeback' }], nextCursor: null })).not.toThrow()
+  })
+
+  it('accepts a debit row', () => {
+    expect(() => assertTransactionsPage({ items: [tx, debit], nextCursor: null })).not.toThrow()
+  })
+
+  it('refuses a row whose type this build cannot read', () => {
+    // Unlike an unknown `kind`, an unknown `type` has no sensible fallback rendering.
+    expect(() => assertTransactionsPage({ items: [{ ...tx, type: 'hold' }], nextCursor: null })).toThrow(
+      BillingShapeError
+    )
+    expect(() => assertTransactionsPage({ items: [{ id: 'x', at: tx.at }], nextCursor: null })).toThrow(
+      BillingShapeError
+    )
+  })
+
+  it('refuses a debit whose amount arrived as a number', () => {
+    // The service sends a decimal string precisely so 18 decimals survive the wire;
+    // accepting a number here would hide the day that stops being true.
+    expect(() => assertTransactionsPage({ items: [{ ...debit, amount: 0.45 }], nextCursor: null })).toThrow(
+      BillingShapeError
+    )
+    expect(() => assertTransactionsPage({ items: [{ ...debit, period: 8 }], nextCursor: null })).toThrow(
+      BillingShapeError
+    )
   })
 
   it('refuses a row with an unusable amount or timestamp', () => {
@@ -91,5 +124,16 @@ describe('assertPurchaseCreated', () => {
     expect(() => assertPurchaseCreated({ purchaseId: 'p1', url: 'https://checkout.stripe.com/x' })).not.toThrow()
     expect(() => assertPurchaseCreated({ purchaseId: 'p1' })).toThrow(BillingShapeError)
     expect(() => assertPurchaseCreated(null)).toThrow(BillingShapeError)
+  })
+})
+
+describe('fmtDecimalUsd', () => {
+  it('rounds an exact decimal to cents for display', () => {
+    expect(fmtDecimalUsd('0.450000000000000001')).toBe('$0.45')
+    expect(fmtDecimalUsd('1234.5')).toBe('$1,234.50')
+  })
+
+  it('shows the raw string rather than $NaN when it is not a number', () => {
+    expect(fmtDecimalUsd('twelve')).toBe('$twelve')
   })
 })

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -40,13 +40,36 @@ export interface BillingAccount {
   balanceMicro: number
 }
 
-export interface BillingTransaction {
+// The history merges both ledger sides, so a row is one of two shapes and `type` says
+// which. The two arms carry money in different units, and that is the service's
+// decision rather than an inconsistency to smooth over here:
+//
+//   credit → integer microUSD, the unit money arrives in through a payment channel;
+//   debit  → a decimal STRING, because a posted usage amount can carry 18 decimals and
+//            a statement line is a reconciliation fact. The service rounds in exactly
+//            two places and a history row is neither of them, so it hands the exact
+//            value over and formatting it for a human is this side's job.
+export interface BillingCredit {
+  type: 'credit'
   id: string
   kind: 'purchase' | 'adjustment' | 'promo' | 'refund'
   amountMicro: number
   /** ISO 8601 instant. */
   at: string
 }
+
+export interface BillingDebit {
+  type: 'debit'
+  id: string
+  /** The UTC billing period the usage fell in, `YYYY-MM`. */
+  period: string
+  /** Decimal string, NOT a number. Parse it only to display it. */
+  amount: string
+  /** ISO 8601 instant. */
+  at: string
+}
+
+export type BillingTransaction = BillingCredit | BillingDebit
 
 export interface BillingTransactionsPage {
   items: BillingTransaction[]
@@ -143,14 +166,28 @@ export function assertTransactionsPage(body: unknown): asserts body is BillingTr
   const b = body as Partial<BillingTransactionsPage> | null
   if (!b || !Array.isArray(b.items)) throw new BillingShapeError('transaction page')
   if (!(b.nextCursor === null || typeof b.nextCursor === 'string')) throw new BillingShapeError('transaction page')
-  for (const t of b.items) {
-    // `kind` is checked as a string, not against the known set: a ledger kind
-    // this build has not heard of renders with its raw value as the label, and
-    // refusing the whole page over one unknown label would be the worse failure.
-    if (!t || typeof t.id !== 'string' || typeof t.at !== 'string' || !isFiniteNumber(t.amountMicro)) {
+  for (const row of b.items) {
+    // A loose record rather than a partial of the union: the two arms disagree on
+    // `type`, so their intersection is uninhabited and every field below would narrow
+    // to `never`.
+    const t = row as unknown as Record<string, unknown> | null
+    if (!t || typeof t.id !== 'string' || typeof t.at !== 'string') throw new BillingShapeError('transaction')
+    // An unknown `type` is refused, unlike an unknown `kind` below: a row whose shape
+    // this build cannot read has no sensible fallback rendering, where an unfamiliar
+    // ledger kind is only a label.
+    if (t.type === 'credit') {
+      if (!isFiniteNumber(t.amountMicro)) throw new BillingShapeError('transaction')
+      // Checked as a string rather than against the known set, deliberately: a kind
+      // this build has not heard of renders with its raw value as the label, and
+      // refusing the whole page over one unknown label would be the worse failure.
+      if (typeof t.kind !== 'string') throw new BillingShapeError('transaction')
+    } else if (t.type === 'debit') {
+      // A string, and never coerced to a number here — the exact value is what the
+      // service sent, and only the display rounds it.
+      if (typeof t.amount !== 'string' || typeof t.period !== 'string') throw new BillingShapeError('transaction')
+    } else {
       throw new BillingShapeError('transaction')
     }
-    if (typeof t.kind !== 'string') throw new BillingShapeError('transaction')
   }
 }
 
@@ -218,6 +255,14 @@ export async function fetchBillingPurchase(orgId: string, id: string): Promise<B
 const MICRO_PER_USD = 1_000_000
 
 /** Render microUSD as dollars. Display only — never a step in a calculation. */
+/** A decimal-string amount, for display only. `Number` is fine HERE and only here: the
+ *  value shown is rounded to cents anyway and the exact string stays untouched in the
+ *  data. Never feed the result back to the service. */
+export function fmtDecimalUsd(amount: string): string {
+  const n = Number(amount)
+  return Number.isFinite(n) ? fmtMicroUsd(n * MICRO_PER_USD) : `$${amount}`
+}
+
 export function fmtMicroUsd(micro: number): string {
   const sign = micro < 0 ? '-' : ''
   return `${sign}$${(Math.abs(micro) / MICRO_PER_USD).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`


### PR DESCRIPTION
The billing service now posts what an org has spent, so its transaction history is a
merge of both ledger sides rather than credits alone. Without this the balance would
fall with nothing on the page to explain it.

**This is the consuming half of the change.** The authority is the billing service's own
zod schema, which every response is serialized through; the matching service-side change
lands first, so this can be merged after it without a window where the console refuses a
shape the service is already sending.

## What changed

A row is now one of two shapes, discriminated by `type`, and the two arms carry money in
different units on purpose:

| arm | unit | why |
| --- | --- | --- |
| `credit` | integer microUSD | the unit money arrives in through a payment channel |
| `debit` | decimal **string** | a posted usage amount can carry 18 decimals, and a statement line is a reconciliation fact — the service rounds in exactly two places and this is neither |

`fmtDecimalUsd` renders a debit for display only, and never feeds the result back onto
the wire.

## The boundary check's asymmetry is deliberate

It refuses an unknown `type` while still tolerating an unknown `kind`: a row whose SHAPE
this build cannot read has no sensible fallback rendering, where an unfamiliar ledger
kind is only a label and refusing the whole page over one would be the worse failure.

It also refuses a debit amount that arrives as a **number** — the string exists so 18
decimals survive the wire, and accepting a number would hide the day that stops being
true. Mutation-checked: relaxing that one condition reddens exactly that test.

## Tests

130 pass in `packages/web`; 18 in the billing client's own boundary suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)