### PR TITLE
feat(memory): the dream writes the same memory format as everyone else

### DIFF
--- a/packages/daemon/src/dream/dreamer.ts
+++ b/packages/daemon/src/dream/dreamer.ts
@@ -3,6 +3,7 @@ import { posix } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import { MAX_ORGANIZATION_SUGGESTION_BODY_BYTES, type SkillBundleTextFile } from '@agentconnect.md/protocol'
 import { MEMORY_INDEX, MAX_INDEX_INJECT_BYTES, MAX_MEMORY_FILE_BYTES } from '../memory/store.js'
+import { MEMORY_FORMAT_GUIDANCE } from '../memory/frontmatter.js'
 
 /**
  * Pure dream-pipeline pieces (design: docs/designs/memory-dreaming.md §4–5):
@@ -144,7 +145,7 @@ Rebuild the memory store in four phases:
 1. Orient: read the existing store; understand its topics and index.
 2. Gather signal: mine the transcripts for corrections, preference shifts, decisions, and recurring patterns.
 3. Consolidate: merge duplicates; where entries contradict, keep the latest value; convert relative dates to absolute dates; drop transient task progress, pleasantries, and secrets.
-4. Prune and index: rebuild the index with one short line per topic; demote verbose entries into topic files.
+4. Prune and index: give every topic file a good \`description\` header — the index is GENERATED from those, so a weak description is what makes a memory unfindable later; demote verbose entries into topic files.
 
 Rules:
 - Unlike per-turn distillation, you MAY rewrite, merge, and delete entries — but only inside the returned proposal.
@@ -154,10 +155,13 @@ Rules:
 - Rename, merge, or split files only when a material content change makes the existing structure misleading. Prefer the smallest diff when multiple proposals are equally faithful.
 - Every memory must be self-contained and understandable without the conversation.
 - Topic filenames are lowercase kebab-case .md names.
+
+${MEMORY_FORMAT_GUIDANCE}
+
 - Never include credentials, tokens, or other secrets.
 - Return JSON only with four explicit categories:
   {"agentMemory":{"index":"<full MEMORY.md text>","files":[{"path":"topic.md","content":"full file text"}]},"agentSkills":[],"organizationKnowledge":[],"organizationSkills":[]}.
-- agentMemory.index is always the complete, non-empty MEMORY.md text. When there are no persistent agent memories, return "# Memory\n\n_No persistent memories yet._\n" rather than an empty string.
+- agentMemory.index is always the complete, non-empty MEMORY.md text. It is a review preview: once adopted, the index is regenerated from the topic descriptions, so spend your effort on those rather than on index prose. When there are no persistent agent memories, return "# Memory\n\n_No persistent memories yet._\n" rather than an empty string.
 - organizationKnowledge entries are owner-review proposals in exactly this shape: {"operation":"create|update","targetId":"uuid only for update","targetRevision":1,"title":"...","summary":"...","tags":["..."],"content":"Markdown","sessionIds":["..."]}. The citation property is named "sessionIds" (never "groundedSessionIds").
 - Propose organization knowledge only when it is reusable across multiple agents or represents a durable organization-wide convention. Agent-specific facts stay in agentMemory.
 - Before proposing organization knowledge, check what already exists with the listKnowledge / findKnowledge tools. If an existing entry covers the same subject, propose an "update" to its exact id/revision (never a near-duplicate "create").

--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -20,6 +20,7 @@ import {
   OrganizationSuggestionContentBody,
   organizationSuggestionCanonical
 } from '@agentconnect.md/protocol'
+import { normalizeMemoryHeader } from '../memory/frontmatter.js'
 import {
   MEMORY_INDEX,
   regenerateMemoryIndexHoldingLock,
@@ -800,7 +801,10 @@ export class DreamRunner {
       // parseDreamProposal already enforced TOPIC_RE — belt and suspenders here
       // because these names become filesystem paths.
       if (!stagedPathOk(file.path)) continue
-      await fs.writeFile(join(out, file.path), file.content)
+      // The dream writes frontmatter as free text, so re-render its known scalars through
+      // the shared quoting rule before staging — a description holding `: ` or ` #` would
+      // otherwise be invalid YAML, and auto-adopt would make that malformed topic live.
+      await fs.writeFile(join(out, file.path), normalizeMemoryHeader(file.content))
     }
     await this.stageSkills(fs, base, proposal)
     return this.stageOrganizationSuggestions(fs, base, proposal)

--- a/packages/daemon/src/memory/frontmatter.ts
+++ b/packages/daemon/src/memory/frontmatter.ts
@@ -127,6 +127,26 @@ export function buildMemoryHeader(fields: { description?: string; type?: MemoryE
   return lines.length > 0 ? `${FENCE}\n${lines.join('\n')}\n${FENCE}\n\n` : ''
 }
 
+/**
+ * Make a model-written header safe to store, without rewriting anything we do not
+ * own. Only the VALUE of a top-level known key is re-rendered through the shared
+ * quoting rule, so `description: ship: prod` becomes a properly quoted scalar while
+ * comments, nested blocks, and unknown keys survive byte-for-byte. Idempotent: a
+ * value that is already correctly quoted round-trips to itself.
+ */
+export function normalizeMemoryHeader(text: string): string {
+  const parsed = parseMemoryFrontmatter(text)
+  if (!parsed.hadHeader) return text
+  const lines = parsed.headerLines.map((line) => {
+    if (/^\s/.test(line)) return line
+    const match = KEY_LINE.exec(line)
+    if (!match || !KNOWN.has(match[1]!)) return line
+    const value = unquote(match[2]!)
+    return value ? `${match[1]}: ${quoteIfNeeded(value)}` : line
+  })
+  return `${FENCE}\n${lines.join('\n')}\n${FENCE}\n\n${parsed.body.replace(/^\n+/, '')}`
+}
+
 /** Coerce a model-supplied string to one of our types, or undefined if it is not one. */
 export function asMemoryEntryType(value: unknown): MemoryEntryType | undefined {
   return typeof value === 'string' && (MEMORY_ENTRY_TYPES as readonly string[]).includes(value)

--- a/packages/daemon/src/memory/frontmatter.ts
+++ b/packages/daemon/src/memory/frontmatter.ts
@@ -108,11 +108,15 @@ export function parseMemoryFrontmatter(text: string): ParsedMemory {
   }
 }
 
-/** Quote only when a plain YAML scalar would be ambiguous: a `key: value` split
- *  (`: `), a trailing colon, an inline comment (` #`), a leading indicator, or edge
- *  whitespace. An ISO timestamp's colons are safe and stay unquoted. */
+/**
+ * Quote unless the value is unambiguously a plain YAML scalar. Conservative on
+ * purpose: a stored description must survive any strict YAML reader, so this covers
+ * every leading indicator character (`- ? : , [ ] { } # & * ! | > ' " % @ \``), a
+ * `key: value` split, a trailing colon, an inline ` #` comment, and edge whitespace.
+ * An ISO timestamp's interior colons are safe and stay unquoted.
+ */
 function quoteIfNeeded(value: string): string {
-  return /^[\s"'[{&*!|>%@`-]|: |:$| #|\s$/.test(value) ? JSON.stringify(value) : value
+  return /^[\s\-?:,[\]{}#&*!|>'"%@`]|: |:$| #|\s$/.test(value) ? JSON.stringify(value) : value
 }
 
 /**

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -15,6 +15,7 @@ import {
   stampMemoryHeader,
   MEMORY_FORMAT_GUIDANCE
 } from '../src/memory/frontmatter.js'
+import { dreamSystemPrompt } from '../src/dream/dreamer.js'
 import {
   ensureMemory,
   MAX_MEMORY_FILE_BYTES,
@@ -435,8 +436,11 @@ describe('distilled memories carry a description', () => {
     expect(parsed[0]?.description).toBe('multi line')
   })
 
-  it('teaches the SAME format text everywhere — the drift that caused this', () => {
-    // The distiller and the per-turn prompt must not restate the format separately.
+  it('teaches the SAME format text in every trigger — the drift that caused this', () => {
+    // Per-turn, distillation, and dreaming all write memory files. Each restating the
+    // format is exactly how they diverged, so all three embed the one shared text.
     expect(MEMORY_DISTILLATION_SYSTEM_PROMPT).toContain(MEMORY_FORMAT_GUIDANCE)
+    expect(dreamSystemPrompt(false)).toContain(MEMORY_FORMAT_GUIDANCE)
+    expect(dreamSystemPrompt(true)).toContain(MEMORY_FORMAT_GUIDANCE)
   })
 })

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -13,10 +13,10 @@ import {
   memoryRefToTopic,
   parseMemoryFrontmatter,
   stampMemoryHeader,
-  MEMORY_FORMAT_GUIDANCE
+  MEMORY_FORMAT_GUIDANCE,
+  normalizeMemoryHeader
 } from '../src/memory/frontmatter.js'
 import { dreamSystemPrompt } from '../src/dream/dreamer.js'
-import { normalizeMemoryHeader } from '../src/memory/frontmatter.js'
 import {
   ensureMemory,
   MAX_MEMORY_FILE_BYTES,

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -16,6 +16,7 @@ import {
   MEMORY_FORMAT_GUIDANCE
 } from '../src/memory/frontmatter.js'
 import { dreamSystemPrompt } from '../src/dream/dreamer.js'
+import { normalizeMemoryHeader } from '../src/memory/frontmatter.js'
 import {
   ensureMemory,
   MAX_MEMORY_FILE_BYTES,
@@ -442,5 +443,46 @@ describe('distilled memories carry a description', () => {
     expect(MEMORY_DISTILLATION_SYSTEM_PROMPT).toContain(MEMORY_FORMAT_GUIDANCE)
     expect(dreamSystemPrompt(false)).toContain(MEMORY_FORMAT_GUIDANCE)
     expect(dreamSystemPrompt(true)).toContain(MEMORY_FORMAT_GUIDANCE)
+  })
+})
+
+describe('normalizing model-written frontmatter', () => {
+  it('re-quotes an unsafe description the dream wrote as free text', () => {
+    // The dream emits frontmatter as opaque text; `ship: prod` would split the
+    // key/value and — with auto-adopt on — go live malformed.
+    const raw = '---\ndescription: ship: prod #now\ntype: project\n---\nbody\n'
+    const fixed = normalizeMemoryHeader(raw)
+    // Our own parser is lenient, so the point is the STORED bytes: the value is now a
+    // properly quoted scalar that a strict YAML reader accepts, matching what the
+    // distillation path already writes.
+    expect(fixed).toContain('description: "ship: prod #now"')
+    expect(parseMemoryFrontmatter(fixed).header.description).toBe('ship: prod #now')
+    expect(parseMemoryFrontmatter(fixed).header.type).toBe('project')
+    expect(fixed).toContain('body')
+  })
+
+  it('is idempotent and leaves everything it does not own untouched', () => {
+    const raw = [
+      '---',
+      '# a comment',
+      'description: "already: quoted"',
+      'metadata:',
+      '  node_type: memory',
+      'custom: keep-me',
+      '---',
+      '',
+      'body',
+      ''
+    ].join('\n')
+    const once = normalizeMemoryHeader(raw)
+    expect(once).toBe(normalizeMemoryHeader(once))
+    for (const kept of ['# a comment', 'metadata:', '  node_type: memory', 'custom: keep-me']) {
+      expect(once).toContain(kept)
+    }
+    expect(parseMemoryFrontmatter(once).header.description).toBe('already: quoted')
+  })
+
+  it('leaves a headerless dream file alone', () => {
+    expect(normalizeMemoryHeader('just a note\n')).toBe('just a note\n')
   })
 })

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -461,6 +461,25 @@ describe('normalizing model-written frontmatter', () => {
     expect(fixed).toContain('body')
   })
 
+  it('quotes EVERY YAML indicator a description can start with', () => {
+    // `#` would read as a comment (null value) and `?` is outright invalid; the rest
+    // are indicators too. Table-driven so a future edit cannot quietly drop one.
+    const leading = ['-', '?', ':', ',', '[', ']', '{', '}', '#', '&', '*', '!', '|', '>', "'", '"', '%', '@', '`']
+    for (const ch of leading) {
+      const value = `${ch} release policy`
+      const fixed = normalizeMemoryHeader(`---\ndescription: ${value}\n---\nbody\n`)
+      // Stored as a quoted scalar…
+      expect(fixed).toContain(`description: ${JSON.stringify(value)}`)
+      // …and still reads back as exactly what the model meant.
+      expect(parseMemoryFrontmatter(fixed).header.description).toBe(value)
+    }
+  })
+
+  it('leaves an ordinary description unquoted', () => {
+    const fixed = normalizeMemoryHeader('---\ndescription: how we ship to prod\n---\nbody\n')
+    expect(fixed).toContain('description: how we ship to prod')
+  })
+
   it('is idempotent and leaves everything it does not own untouched', () => {
     const raw = [
       '---',


### PR DESCRIPTION
Completes the **prompt half** of the write-path unification (#1256, #1257).

All three triggers that write memory files — an ordinary turn, per-turn distillation, and a dream — now embed the one shared `MEMORY_FORMAT_GUIDANCE`, with a test asserting all three contain it. Each restating the format in its own words is precisely how they drifted: the headers/`[[links]]` work initially reached only the conversational prompt.

Dream-consolidated topics now carry `description` / `type` headers and links like any other memory. That also makes #1256 fully effective: once descriptions exist, the generated index takes over at adoption, so the proposal's `index` becomes a **review preview** rather than a competing source of truth. The prompt now states that and redirects the model's effort from index prose to good descriptions — a weak description is what makes a memory unfindable later.

The proposal JSON contract is unchanged here; retiring `index` touches protocol/CP/web and ships separately.

Suites green (memory, frontmatter, dreamer, dream-runner, distiller, evaluation — 6 files); typecheck and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)