### PR TITLE
feat(daemon): apply the codex session-config floor at spawn, not only in the pod

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -209,8 +209,10 @@ import { capsFromConfigOptions, augmentEffortOptions } from './runtimes/config-c
 import { isClaudeRuntimeDef } from './runtime-defs/claude-runtime.js'
 import { runtimeHomePath } from './runtimes/runtime-home.js'
 import {
+  applyCodexSessionFloor,
   applyModelCredential,
   applyStaticModelConfig,
+  configuredCodexSessionFloor,
   configuredModelCredentials,
   modelProviderTarget,
   type ModelCredential,
@@ -841,6 +843,9 @@ export class Daemon {
   private readonly keyServer?: KeyServerClient
   private readonly modelKeyNow: () => number
   private readonly staticModelCredentials?: StaticModelCredentials
+  /** Deployment codex session-config floor, daemon-applied at spawn so it also reaches agents
+   *  whose sandbox pod spec predates the value (the pod-env copy is a frozen snapshot). */
+  private readonly codexSessionFloor?: string
   /** Reads this pod's projected CP-audience token; undefined unless the daemon runs
    *  in-cluster AND the volume is actually mounted (decided once, at boot). */
   private readonly clusterIdentityToken?: () => string | undefined
@@ -1135,6 +1140,7 @@ export class Daemon {
     // Base URLs are deployment topology and always come from here, key server or not; an issuer
     // supplies the key alone.
     this.staticModelCredentials = this.k8s ? configuredModelCredentials(process.env) : undefined
+    this.codexSessionFloor = this.k8s ? configuredCodexSessionFloor(process.env) : undefined
     this.evalHooks = new DaemonEvaluationHooks(this.evaluationHost(), opts.evaluation)
     this.sessionMetadataOutbox = new SessionMetadataOutbox(this.sessionMetadataHost())
     this.observedChannelsSync = new ObservedChannelsSync(this.observedChannelsSyncHost())
@@ -3107,6 +3113,8 @@ export class Daemon {
             const configured = this.staticModelCredentials?.[target.runtime]
             if (configured) applyStaticModelConfig(target, launchEnv, configured)
           }
+          // Last, so every key the daemon authored above stays authoritative over the floor.
+          if (this.codexSessionFloor) applyCodexSessionFloor(target, launchEnv, this.codexSessionFloor)
         },
         runtimeReadRoots: runInSandbox
           ? (launchEnv) => this.sandboxRuntimeReadRoots(agent, runtime, launchEnv, githubAppCredentials)

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -3,7 +3,7 @@ import type { RuntimeDef } from '../config/config-schema.js'
 import type { Agent } from '../agents/agent-schema.js'
 import { isClaudeRuntimeDef } from '../runtime-defs/claude-runtime.js'
 import { sharedCredentialProfile } from './runtime-credentials.js'
-import { codexConfigWithBaseUrl, objectFromJson, record } from './codex-config.js'
+import { codexConfigWithBaseUrl, codexConfigWithFloor, objectFromJson, record } from './codex-config.js'
 
 export interface ModelCredential {
   key: string
@@ -101,6 +101,29 @@ export function applyModelCredential(
       }
     }
   })
+}
+
+// The deployment's codex session-config floor, applied by the DAEMON at spawn — not only by the
+// sandbox shim. The shim's pod-env copy (AC_CODEX_CONFIG on the SandboxTemplate) never reaches an
+// agent whose sandbox was minted before the value changed: the pod spec is a frozen snapshot, and
+// daemon-written env is what wins over it. Same merge semantics as the shim's fill-in.
+export function applyCodexSessionFloor(
+  target: ModelProviderTarget,
+  env: Record<string, string>,
+  floorRaw: string
+): void {
+  if (target.runtime !== 'codex') return
+  const merged = codexConfigWithFloor(env.CODEX_CONFIG, floorRaw)
+  if (merged !== undefined) env.CODEX_CONFIG = merged
+}
+
+// Validated at daemon construction so a malformed value fails the member loudly at boot instead
+// of failing every codex spawn one at a time.
+export function configuredCodexSessionFloor(env: NodeJS.ProcessEnv): string | undefined {
+  const raw = env.AC_CODEX_CONFIG?.trim()
+  if (!raw) return undefined
+  objectFromJson(raw, 'AC_CODEX_CONFIG')
+  return raw
 }
 
 export type StaticModelCredentials = Partial<Record<ModelRuntimeKind, ModelCredential>>

--- a/packages/daemon/test/model-provider-config.test.ts
+++ b/packages/daemon/test/model-provider-config.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 import type { Agent } from '../src/agents/agent-schema.js'
 import type { RuntimeDef } from '../src/config/config-schema.js'
 import {
+  applyCodexSessionFloor,
   applyModelCredential,
   applyStaticModelConfig,
+  configuredCodexSessionFloor,
   configuredModelCredentials,
   modelProviderTarget
 } from '../src/runtimes/model-provider-config.js'
@@ -180,5 +182,55 @@ describe('applyModelCredential', () => {
         } as never
       )
     ).toEqual({ provider: 'deepseek', runtime: 'deepseek' })
+  })
+})
+
+describe('applyCodexSessionFloor', () => {
+  const codex = { provider: 'openai', runtime: 'codex' } as const
+  const floor = JSON.stringify({ features: { multi_agent: false }, model: 'gpt-5.5' })
+
+  it('merges the floor under every key the daemon already authored', () => {
+    const env: Record<string, string> = {}
+    applyModelCredential(codex, env, { key: 'k', baseUrl: 'https://gw.example/v1' })
+    applyCodexSessionFloor(codex, env, floor)
+    expect(JSON.parse(env.CODEX_CONFIG)).toEqual({
+      model_provider: 'openai',
+      openai_base_url: 'https://gw.example/v1',
+      features: { multi_agent: false },
+      model: 'gpt-5.5'
+    })
+  })
+
+  it('keeps daemon-sent leaves authoritative, merging shared tables one level deep', () => {
+    const env: Record<string, string> = { CODEX_CONFIG: JSON.stringify({ model: 'o3-mini', features: { web: true } }) }
+    applyCodexSessionFloor(codex, env, floor)
+    expect(JSON.parse(env.CODEX_CONFIG)).toEqual({ model: 'o3-mini', features: { multi_agent: false, web: true } })
+  })
+
+  it('applies with no daemon-sent config at all — the stale-sandbox case the daemon channel exists for', () => {
+    const env: Record<string, string> = {}
+    applyCodexSessionFloor(codex, env, floor)
+    expect(JSON.parse(env.CODEX_CONFIG)).toEqual({ features: { multi_agent: false }, model: 'gpt-5.5' })
+  })
+
+  it('touches no runtime but codex', () => {
+    const env: Record<string, string> = {}
+    applyCodexSessionFloor({ provider: 'deepseek', runtime: 'deepseek' }, env, floor)
+    expect(env).toEqual({})
+  })
+})
+
+describe('configuredCodexSessionFloor', () => {
+  it('returns the raw value once it parses as an object', () => {
+    expect(configuredCodexSessionFloor({ AC_CODEX_CONFIG: ' {"model":"gpt-5.5"} ' })).toBe('{"model":"gpt-5.5"}')
+  })
+
+  it('is undefined when unset or blank', () => {
+    expect(configuredCodexSessionFloor({})).toBeUndefined()
+    expect(configuredCodexSessionFloor({ AC_CODEX_CONFIG: '  ' })).toBeUndefined()
+  })
+
+  it('fails loudly at boot on a malformed value', () => {
+    expect(() => configuredCodexSessionFloor({ AC_CODEX_CONFIG: '[1]' })).toThrow('AC_CODEX_CONFIG')
   })
 })


### PR DESCRIPTION
The deployment's codex session-config floor (`AC_CODEX_CONFIG`, #1252) had one delivery channel: the sandbox pod env. That copy is a frozen snapshot — an agent's Sandbox keeps the spec it was minted with, and even freshly recreated pods use it — so an agent whose sandbox predates a floor change never receives it. Live case on the test deployment today: a codex agent whose sandbox predates the floor kept running the runtime's own default model and default-on features that the pinned egress gateway rejects (both 400 classes the floor exists to prevent), while a freshly minted sandbox beside it carried the full floor. The base URL survived only because the daemon writes provider env at spawn and daemon-written env wins over the pod fill-in — which is exactly the channel the floor was missing.

- The cloud daemon reads `AC_CODEX_CONFIG` from its own environment (`configuredCodexSessionFloor` — validated at boot so a malformed value fails the member loudly, k8s-only, mirroring `configuredModelCredentials`).
- `finalizeLaunchEnv` applies it last via `applyCodexSessionFloor`, so every daemon-authored key (credential, base URL, agent config) stays authoritative; merge semantics are the shim's own `codexConfigWithFloor`, imported rather than restated.
- The pod-env copy stays untouched, as the fill-in for runtimes the daemon aimed nowhere; when both fire the merge is idempotent, and when they disagree the daemon's value wins — the point of the change.

Companion chart PR renders the same value onto the daemon-pool container (workflows, `modelEgress.clients.codex.sessionConfig` → `AC_CODEX_CONFIG`), with a render-contract check that the two surfaces stay byte-identical. This PR is inert until a daemon carrying it ships and that env lands — safe in either order.

Tests: new unit coverage for the merge (daemon-authored keys win, one-level table merge, no-daemon-config case, non-codex no-op) and boot validation; `pnpm typecheck` and lint clean; full-suite failures on this machine are the known Linux-sandbox environmental set, identical on a clean main baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)