### PR TITLE
fix(daemon): pair the injected codex key with its api-key auth request

### DIFF
--- a/packages/daemon/src/runtimes/codex-config.ts
+++ b/packages/daemon/src/runtimes/codex-config.ts
@@ -11,6 +11,23 @@
 // session with -32000, because a bare env key is not an account to codex's account/read.
 export const CODEX_DEFAULT_AUTH_REQUEST = JSON.stringify({ methodId: 'api-key' })
 
+/** The gateway variant, for a credential that names its endpoint: codex-acp holds it as an
+ *  in-process provider (base URL + auth header, responses wire), authRequired() short-circuits
+ *  before account/read, and nothing touches the shared auth.json — so a persisted account of any
+ *  shape cannot override the grant and concurrently launching hosts share no credential state. */
+export function codexGatewayAuthRequest(baseUrl: string, key: string): string {
+  return JSON.stringify({
+    methodId: 'gateway',
+    _meta: {
+      gateway: {
+        baseUrl,
+        headers: { Authorization: `Bearer ${key}` },
+        providerName: 'AgentConnect model egress'
+      }
+    }
+  })
+}
+
 /** True when a persisted auth.json pins an API key other than the launch's own — the file codex
  *  minted from an EARLIER injected grant, which would make account/read report authentication
  *  present and the current key go unconsumed. A tokens-bearing file is a human ChatGPT login and

--- a/packages/daemon/src/runtimes/codex-config.ts
+++ b/packages/daemon/src/runtimes/codex-config.ts
@@ -6,6 +6,11 @@
 // This module is import-free on purpose: the sandbox shim bundle must not drag the daemon's
 // credential paths into the runtime image (see tsdown.shim.config.ts).
 
+// codex-acp's self-service auth order: with this set it answers its own authRequired by logging
+// in with the OPENAI_API_KEY env; without it a fresh CODEX_HOME (no auth.json) refuses every
+// session with -32000, because a bare env key is not an account to codex's account/read.
+export const CODEX_DEFAULT_AUTH_REQUEST = JSON.stringify({ methodId: 'api-key' })
+
 export function objectFromJson(raw: string | undefined, label: string): Record<string, unknown> {
   if (!raw?.trim()) return {}
   let parsed: unknown

--- a/packages/daemon/src/runtimes/codex-config.ts
+++ b/packages/daemon/src/runtimes/codex-config.ts
@@ -6,15 +6,15 @@
 // This module is import-free on purpose: the sandbox shim bundle must not drag the daemon's
 // credential paths into the runtime image (see tsdown.shim.config.ts).
 
-// codex-acp's self-service auth order: with this set it answers its own authRequired by logging
-// in with the OPENAI_API_KEY env; without it a fresh CODEX_HOME (no auth.json) refuses every
-// session with -32000, because a bare env key is not an account to codex's account/read.
-export const CODEX_DEFAULT_AUTH_REQUEST = JSON.stringify({ methodId: 'api-key' })
+/** The runtime's own default endpoint — the third layer of the sanctioned injection precedence
+ *  (issued base > deployment base > this), so an endpoint-less key still rides the gateway
+ *  method against exactly the URL codex's built-in provider would have used. */
+export const CODEX_DEFAULT_ENDPOINT = 'https://api.openai.com/v1'
 
-/** The gateway variant, for a credential that names its endpoint: codex-acp holds it as an
- *  in-process provider (base URL + auth header, responses wire), authRequired() short-circuits
- *  before account/read, and nothing touches the shared auth.json — so a persisted account of any
- *  shape cannot override the grant and concurrently launching hosts share no credential state. */
+/** The gateway auth request: codex-acp holds the grant as an in-process provider (base URL +
+ *  auth header, responses wire), authRequired() short-circuits before account/read, and nothing
+ *  touches the shared auth.json — so a persisted account of any shape cannot override the grant
+ *  and concurrently launching hosts share no credential state. */
 export function codexGatewayAuthRequest(baseUrl: string, key: string): string {
   return JSON.stringify({
     methodId: 'gateway',
@@ -26,23 +26,6 @@ export function codexGatewayAuthRequest(baseUrl: string, key: string): string {
       }
     }
   })
-}
-
-/** True when a persisted auth.json pins an API key other than the launch's own — the file codex
- *  minted from an EARLIER injected grant, which would make account/read report authentication
- *  present and the current key go unconsumed. A tokens-bearing file is a human ChatGPT login and
- *  never stale on this rule; an unparseable file is stale (replacing it is the only recovery). */
-export function codexAuthPinsAnotherKey(raw: string, envKey: string): boolean {
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(raw)
-  } catch {
-    return true
-  }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return true
-  const auth = parsed as Record<string, unknown>
-  if (auth.tokens) return false
-  return typeof auth.OPENAI_API_KEY === 'string' ? auth.OPENAI_API_KEY !== envKey : false
 }
 
 export function objectFromJson(raw: string | undefined, label: string): Record<string, unknown> {

--- a/packages/daemon/src/runtimes/codex-config.ts
+++ b/packages/daemon/src/runtimes/codex-config.ts
@@ -11,6 +11,23 @@
 // session with -32000, because a bare env key is not an account to codex's account/read.
 export const CODEX_DEFAULT_AUTH_REQUEST = JSON.stringify({ methodId: 'api-key' })
 
+/** True when a persisted auth.json pins an API key other than the launch's own — the file codex
+ *  minted from an EARLIER injected grant, which would make account/read report authentication
+ *  present and the current key go unconsumed. A tokens-bearing file is a human ChatGPT login and
+ *  never stale on this rule; an unparseable file is stale (replacing it is the only recovery). */
+export function codexAuthPinsAnotherKey(raw: string, envKey: string): boolean {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return true
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return true
+  const auth = parsed as Record<string, unknown>
+  if (auth.tokens) return false
+  return typeof auth.OPENAI_API_KEY === 'string' ? auth.OPENAI_API_KEY !== envKey : false
+}
+
 export function objectFromJson(raw: string | undefined, label: string): Record<string, unknown> {
   if (!raw?.trim()) return {}
   let parsed: unknown

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -7,6 +7,7 @@ import {
   CODEX_DEFAULT_AUTH_REQUEST,
   codexConfigWithBaseUrl,
   codexConfigWithFloor,
+  codexGatewayAuthRequest,
   objectFromJson,
   record
 } from './codex-config.js'
@@ -82,10 +83,16 @@ export function applyModelCredential(
   if (target.runtime === 'codex') {
     env.OPENAI_API_KEY = credential.key
     // The key alone is not enough on a fresh CODEX_HOME: codex counts only an account (auth.json)
-    // as authentication, and this is what lets codex-acp mint one from the key on demand.
-    env.DEFAULT_AUTH_REQUEST = CODEX_DEFAULT_AUTH_REQUEST
+    // as authentication, and a default auth request is what lets codex-acp satisfy authRequired
+    // itself. A credential that names its endpoint rides the GATEWAY method — process-ephemeral,
+    // so no persisted account (any shape) can override this launch's grant and concurrent hosts
+    // share no credential state; only the endpoint-less shape still logs in as an account.
+    env.DEFAULT_AUTH_REQUEST = credential.baseUrl
+      ? codexGatewayAuthRequest(credential.baseUrl, credential.key)
+      : CODEX_DEFAULT_AUTH_REQUEST
     if (!credential.baseUrl) return
-    // codex-acp projects CODEX_CONFIG into config.toml; OPENAI_BASE_URL preserves older-adapter compatibility.
+    // Kept beside the gateway method: an older codex-acp ignores an unknown methodId, and resumed
+    // threads pinned to the built-in provider still route by CODEX_CONFIG's openai_base_url.
     applyCodexBaseUrl(env, credential.baseUrl)
     return
   }

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -4,7 +4,6 @@ import type { Agent } from '../agents/agent-schema.js'
 import { isClaudeRuntimeDef } from '../runtime-defs/claude-runtime.js'
 import { sharedCredentialProfile } from './runtime-credentials.js'
 import {
-  CODEX_DEFAULT_ENDPOINT,
   codexConfigWithBaseUrl,
   codexConfigWithFloor,
   codexGatewayAuthRequest,
@@ -86,11 +85,11 @@ export function applyModelCredential(
     // as authentication, and a default auth request is what lets codex-acp satisfy authRequired
     // itself. Every injected credential rides the GATEWAY method — process-ephemeral, so no
     // persisted account (any shape) can override this launch's grant and concurrent hosts share
-    // no credential state. An endpoint-less key (a vault rotating real provider keys) falls
-    // through to the runtime's own default endpoint, the injection precedence's third layer —
-    // the same URL the built-in provider would have used, never the shared account store.
-    env.DEFAULT_AUTH_REQUEST = codexGatewayAuthRequest(credential.baseUrl ?? CODEX_DEFAULT_ENDPOINT, credential.key)
+    // no credential state. An endpoint-less key (a vault rotating real provider keys) carries NO
+    // request from here: the pod's AC_CODEX_BASE_URL floor outranks the runtime default and only
+    // the shim can see it, so the layer that knows the effective endpoint composes the request.
     if (!credential.baseUrl) return
+    env.DEFAULT_AUTH_REQUEST = codexGatewayAuthRequest(credential.baseUrl, credential.key)
     // Kept beside the gateway method: an older codex-acp ignores an unknown methodId, and resumed
     // threads pinned to the built-in provider still route by CODEX_CONFIG's openai_base_url.
     applyCodexBaseUrl(env, credential.baseUrl)

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -4,7 +4,7 @@ import type { Agent } from '../agents/agent-schema.js'
 import { isClaudeRuntimeDef } from '../runtime-defs/claude-runtime.js'
 import { sharedCredentialProfile } from './runtime-credentials.js'
 import {
-  CODEX_DEFAULT_AUTH_REQUEST,
+  CODEX_DEFAULT_ENDPOINT,
   codexConfigWithBaseUrl,
   codexConfigWithFloor,
   codexGatewayAuthRequest,
@@ -84,12 +84,12 @@ export function applyModelCredential(
     env.OPENAI_API_KEY = credential.key
     // The key alone is not enough on a fresh CODEX_HOME: codex counts only an account (auth.json)
     // as authentication, and a default auth request is what lets codex-acp satisfy authRequired
-    // itself. A credential that names its endpoint rides the GATEWAY method — process-ephemeral,
-    // so no persisted account (any shape) can override this launch's grant and concurrent hosts
-    // share no credential state; only the endpoint-less shape still logs in as an account.
-    env.DEFAULT_AUTH_REQUEST = credential.baseUrl
-      ? codexGatewayAuthRequest(credential.baseUrl, credential.key)
-      : CODEX_DEFAULT_AUTH_REQUEST
+    // itself. Every injected credential rides the GATEWAY method — process-ephemeral, so no
+    // persisted account (any shape) can override this launch's grant and concurrent hosts share
+    // no credential state. An endpoint-less key (a vault rotating real provider keys) falls
+    // through to the runtime's own default endpoint, the injection precedence's third layer —
+    // the same URL the built-in provider would have used, never the shared account store.
+    env.DEFAULT_AUTH_REQUEST = codexGatewayAuthRequest(credential.baseUrl ?? CODEX_DEFAULT_ENDPOINT, credential.key)
     if (!credential.baseUrl) return
     // Kept beside the gateway method: an older codex-acp ignores an unknown methodId, and resumed
     // threads pinned to the built-in provider still route by CODEX_CONFIG's openai_base_url.

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -3,7 +3,13 @@ import type { RuntimeDef } from '../config/config-schema.js'
 import type { Agent } from '../agents/agent-schema.js'
 import { isClaudeRuntimeDef } from '../runtime-defs/claude-runtime.js'
 import { sharedCredentialProfile } from './runtime-credentials.js'
-import { codexConfigWithBaseUrl, codexConfigWithFloor, objectFromJson, record } from './codex-config.js'
+import {
+  CODEX_DEFAULT_AUTH_REQUEST,
+  codexConfigWithBaseUrl,
+  codexConfigWithFloor,
+  objectFromJson,
+  record
+} from './codex-config.js'
 
 export interface ModelCredential {
   key: string
@@ -75,6 +81,9 @@ export function applyModelCredential(
 
   if (target.runtime === 'codex') {
     env.OPENAI_API_KEY = credential.key
+    // The key alone is not enough on a fresh CODEX_HOME: codex counts only an account (auth.json)
+    // as authentication, and this is what lets codex-acp mint one from the key on demand.
+    env.DEFAULT_AUTH_REQUEST = CODEX_DEFAULT_AUTH_REQUEST
     if (!credential.baseUrl) return
     // codex-acp projects CODEX_CONFIG into config.toml; OPENAI_BASE_URL preserves older-adapter compatibility.
     applyCodexBaseUrl(env, credential.baseUrl)

--- a/packages/daemon/src/shim/acp-runner.ts
+++ b/packages/daemon/src/shim/acp-runner.ts
@@ -1,11 +1,10 @@
 import { spawn, type ChildProcess } from 'node:child_process'
-import { existsSync, readFileSync, unlinkSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync } from 'node:fs'
 import {
-  CODEX_DEFAULT_AUTH_REQUEST,
-  codexAuthPinsAnotherKey,
+  CODEX_DEFAULT_ENDPOINT,
   codexConfigWithBaseUrlFillIn,
-  codexConfigWithFloor
+  codexConfigWithFloor,
+  codexGatewayAuthRequest
 } from '../runtimes/codex-config.js'
 import { AcpStreamPayloadSchema, type AcpOpen } from './acp-stream.js'
 import { SANDBOX_GH_WRAPPER_DIR } from './sandbox-paths.js'
@@ -185,35 +184,17 @@ export class AcpRunner {
       fillInCodexConfigFloor(env, podEnv, (message) => this.deps.log?.warn(message))
       fillInCodexBaseUrl(env, podEnv, (message) => this.deps.log?.warn(message))
       // A key without this is unusable on a fresh CODEX_HOME: codex-acp answers authRequired
-      // itself only when told which method — same fill-in rule, a daemon-sent value wins.
-      if (env.OPENAI_API_KEY && !env.DEFAULT_AUTH_REQUEST) env.DEFAULT_AUTH_REQUEST = CODEX_DEFAULT_AUTH_REQUEST
-      this.reconcileCodexApiKeyAuth(env)
+      // itself only when told which method. Always the GATEWAY method — process-ephemeral, so an
+      // injected key never becomes a shared account that outlives or races its launch; an
+      // endpoint-less key rides the runtime's own default endpoint, exactly like the daemon's
+      // composition. Same fill-in rule as everything here: a daemon-sent value wins.
+      if (env.OPENAI_API_KEY && !env.DEFAULT_AUTH_REQUEST) {
+        const base = podEnv.AC_CODEX_BASE_URL?.trim() || CODEX_DEFAULT_ENDPOINT
+        env.DEFAULT_AUTH_REQUEST = codexGatewayAuthRequest(base, env.OPENAI_API_KEY)
+      }
     }
     const command = this.deps.resolveCommand?.(payload.command, env) ?? payload.command
     return this.spawnChild(command, payload, env)
-  }
-
-  /** Codex persists an injected api-key grant as CODEX_HOME/auth.json, and an existing account
-   *  makes account/read report authentication present — so a persisted EARLIER grant would keep
-   *  every later launch on its key, unrevocable. Removing a file that pins another key returns
-   *  the launch to authRequired, and codex-acp re-mints from the key this launch carries. Human
-   *  ChatGPT logins (tokens files) are never touched, and neither is a file that already matches. */
-  private reconcileCodexApiKeyAuth(env: Record<string, string>): void {
-    if (env.DEFAULT_AUTH_REQUEST !== CODEX_DEFAULT_AUTH_REQUEST || !env.OPENAI_API_KEY) return
-    const home = env.CODEX_HOME || (env.HOME ? join(env.HOME, '.codex') : undefined)
-    if (!home) return
-    const authPath = join(home, 'auth.json')
-    try {
-      if (!existsSync(authPath)) return
-      if (!codexAuthPinsAnotherKey(readFileSync(authPath, 'utf8'), env.OPENAI_API_KEY)) return
-      unlinkSync(authPath)
-      this.deps.log?.info(
-        `acp: removed a codex auth.json pinning an earlier injected key — this launch's key takes over`
-      )
-    } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error)
-      this.deps.log?.warn(`acp: leaving codex auth.json unreconciled — ${reason}`)
-    }
   }
 
   private spawnChild(command: string, payload: AcpOpen, env: Record<string, string>): void {

--- a/packages/daemon/src/shim/acp-runner.ts
+++ b/packages/daemon/src/shim/acp-runner.ts
@@ -4,7 +4,8 @@ import {
   CODEX_DEFAULT_ENDPOINT,
   codexConfigWithBaseUrlFillIn,
   codexConfigWithFloor,
-  codexGatewayAuthRequest
+  codexGatewayAuthRequest,
+  objectFromJson
 } from '../runtimes/codex-config.js'
 import { AcpStreamPayloadSchema, type AcpOpen } from './acp-stream.js'
 import { SANDBOX_GH_WRAPPER_DIR } from './sandbox-paths.js'
@@ -184,13 +185,26 @@ export class AcpRunner {
       fillInCodexConfigFloor(env, podEnv, (message) => this.deps.log?.warn(message))
       fillInCodexBaseUrl(env, podEnv, (message) => this.deps.log?.warn(message))
       // A key without this is unusable on a fresh CODEX_HOME: codex-acp answers authRequired
-      // itself only when told which method. Always the GATEWAY method — process-ephemeral, so an
-      // injected key never becomes a shared account that outlives or races its launch; an
-      // endpoint-less key rides the runtime's own default endpoint, exactly like the daemon's
-      // composition. Same fill-in rule as everything here: a daemon-sent value wins.
+      // itself only when told which method. Always the GATEWAY method — process-ephemeral, so a
+      // key never becomes a shared account that outlives or races its launch. The base is the
+      // FINAL effective aim, read after every fill-in above: CODEX_CONFIG's openai_base_url
+      // (daemon, agent, or pod, already layered), a runtime-owned OPENAI_BASE_URL, and only then
+      // the public default — and a runtime that selected its own provider composes nothing, auth
+      // included. Same fill-in rule as everything here: a daemon-sent value wins.
       if (env.OPENAI_API_KEY && !env.DEFAULT_AUTH_REQUEST) {
-        const base = podEnv.AC_CODEX_BASE_URL?.trim() || CODEX_DEFAULT_ENDPOINT
-        env.DEFAULT_AUTH_REQUEST = codexGatewayAuthRequest(base, env.OPENAI_API_KEY)
+        try {
+          const config = objectFromJson(env.CODEX_CONFIG, 'CODEX_CONFIG')
+          const provider = config.model_provider
+          if (typeof provider !== 'string' || provider === 'openai') {
+            const aimed = typeof config.openai_base_url === 'string' ? config.openai_base_url.trim() : ''
+            const base = aimed || env.OPENAI_BASE_URL?.trim() || CODEX_DEFAULT_ENDPOINT
+            env.DEFAULT_AUTH_REQUEST = codexGatewayAuthRequest(base, env.OPENAI_API_KEY)
+          }
+        } catch (error) {
+          // Composing blind could aim the key at the wrong service; failing auth is recoverable.
+          const reason = error instanceof Error ? error.message : String(error)
+          this.deps.log?.warn(`acp: leaving the codex auth request uncomposed — ${reason}`)
+        }
       }
     }
     const command = this.deps.resolveCommand?.(payload.command, env) ?? payload.command

--- a/packages/daemon/src/shim/acp-runner.ts
+++ b/packages/daemon/src/shim/acp-runner.ts
@@ -1,6 +1,10 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { codexConfigWithBaseUrlFillIn, codexConfigWithFloor } from '../runtimes/codex-config.js'
+import {
+  CODEX_DEFAULT_AUTH_REQUEST,
+  codexConfigWithBaseUrlFillIn,
+  codexConfigWithFloor
+} from '../runtimes/codex-config.js'
 import { AcpStreamPayloadSchema, type AcpOpen } from './acp-stream.js'
 import { SANDBOX_GH_WRAPPER_DIR } from './sandbox-paths.js'
 import type { ShimEvent } from './protocol.js'
@@ -178,6 +182,9 @@ export class AcpRunner {
       // aim never blocks the base-url fill-in below.
       fillInCodexConfigFloor(env, podEnv, (message) => this.deps.log?.warn(message))
       fillInCodexBaseUrl(env, podEnv, (message) => this.deps.log?.warn(message))
+      // A key without this is unusable on a fresh CODEX_HOME: codex-acp answers authRequired
+      // itself only when told which method — same fill-in rule, a daemon-sent value wins.
+      if (env.OPENAI_API_KEY && !env.DEFAULT_AUTH_REQUEST) env.DEFAULT_AUTH_REQUEST = CODEX_DEFAULT_AUTH_REQUEST
     }
     const command = this.deps.resolveCommand?.(payload.command, env) ?? payload.command
     const child = spawn(command, payload.args, {

--- a/packages/daemon/src/shim/acp-runner.ts
+++ b/packages/daemon/src/shim/acp-runner.ts
@@ -1,7 +1,9 @@
 import { spawn, type ChildProcess } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   CODEX_DEFAULT_AUTH_REQUEST,
+  codexAuthPinsAnotherKey,
   codexConfigWithBaseUrlFillIn,
   codexConfigWithFloor
 } from '../runtimes/codex-config.js'
@@ -185,8 +187,36 @@ export class AcpRunner {
       // A key without this is unusable on a fresh CODEX_HOME: codex-acp answers authRequired
       // itself only when told which method — same fill-in rule, a daemon-sent value wins.
       if (env.OPENAI_API_KEY && !env.DEFAULT_AUTH_REQUEST) env.DEFAULT_AUTH_REQUEST = CODEX_DEFAULT_AUTH_REQUEST
+      this.reconcileCodexApiKeyAuth(env)
     }
     const command = this.deps.resolveCommand?.(payload.command, env) ?? payload.command
+    return this.spawnChild(command, payload, env)
+  }
+
+  /** Codex persists an injected api-key grant as CODEX_HOME/auth.json, and an existing account
+   *  makes account/read report authentication present — so a persisted EARLIER grant would keep
+   *  every later launch on its key, unrevocable. Removing a file that pins another key returns
+   *  the launch to authRequired, and codex-acp re-mints from the key this launch carries. Human
+   *  ChatGPT logins (tokens files) are never touched, and neither is a file that already matches. */
+  private reconcileCodexApiKeyAuth(env: Record<string, string>): void {
+    if (env.DEFAULT_AUTH_REQUEST !== CODEX_DEFAULT_AUTH_REQUEST || !env.OPENAI_API_KEY) return
+    const home = env.CODEX_HOME || (env.HOME ? join(env.HOME, '.codex') : undefined)
+    if (!home) return
+    const authPath = join(home, 'auth.json')
+    try {
+      if (!existsSync(authPath)) return
+      if (!codexAuthPinsAnotherKey(readFileSync(authPath, 'utf8'), env.OPENAI_API_KEY)) return
+      unlinkSync(authPath)
+      this.deps.log?.info(
+        `acp: removed a codex auth.json pinning an earlier injected key — this launch's key takes over`
+      )
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      this.deps.log?.warn(`acp: leaving codex auth.json unreconciled — ${reason}`)
+    }
+  }
+
+  private spawnChild(command: string, payload: AcpOpen, env: Record<string, string>): void {
     const child = spawn(command, payload.args, {
       stdio: ['pipe', 'pipe', 'inherit'],
       env,

--- a/packages/daemon/test/codex-config.test.ts
+++ b/packages/daemon/test/codex-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { codexAuthPinsAnotherKey } from '../src/runtimes/codex-config.js'
+
+describe('codexAuthPinsAnotherKey', () => {
+  it('flags a file minted from a different injected key', () => {
+    expect(codexAuthPinsAnotherKey(JSON.stringify({ OPENAI_API_KEY: 'sk-old', tokens: null }), 'sk-new')).toBe(true)
+  })
+
+  it('accepts a file that already carries the launch key', () => {
+    expect(codexAuthPinsAnotherKey(JSON.stringify({ OPENAI_API_KEY: 'sk-now', tokens: null }), 'sk-now')).toBe(false)
+  })
+
+  it('never flags a human ChatGPT login, whatever key rides beside the tokens', () => {
+    const chatgpt = JSON.stringify({ OPENAI_API_KEY: 'sk-derived', tokens: { id_token: 'x' } })
+    expect(codexAuthPinsAnotherKey(chatgpt, 'sk-injected')).toBe(false)
+  })
+
+  it('leaves a keyless account shape alone rather than guessing', () => {
+    expect(codexAuthPinsAnotherKey(JSON.stringify({ OPENAI_API_KEY: null, tokens: null }), 'sk-now')).toBe(false)
+  })
+
+  it('flags an unparseable file — replacing it is the only recovery', () => {
+    expect(codexAuthPinsAnotherKey('not json', 'sk-now')).toBe(true)
+    expect(codexAuthPinsAnotherKey('[1,2]', 'sk-now')).toBe(true)
+  })
+})

--- a/packages/daemon/test/codex-config.test.ts
+++ b/packages/daemon/test/codex-config.test.ts
@@ -1,26 +1,21 @@
 import { describe, expect, it } from 'vitest'
-import { codexAuthPinsAnotherKey } from '../src/runtimes/codex-config.js'
+import { CODEX_DEFAULT_ENDPOINT, codexGatewayAuthRequest } from '../src/runtimes/codex-config.js'
 
-describe('codexAuthPinsAnotherKey', () => {
-  it('flags a file minted from a different injected key', () => {
-    expect(codexAuthPinsAnotherKey(JSON.stringify({ OPENAI_API_KEY: 'sk-old', tokens: null }), 'sk-new')).toBe(true)
+describe('codexGatewayAuthRequest', () => {
+  it('carries the pair as one gateway grant — base routed, key in the auth header', () => {
+    expect(JSON.parse(codexGatewayAuthRequest('https://gw.example/v1', 'sk-issued'))).toEqual({
+      methodId: 'gateway',
+      _meta: {
+        gateway: {
+          baseUrl: 'https://gw.example/v1',
+          headers: { Authorization: 'Bearer sk-issued' },
+          providerName: 'AgentConnect model egress'
+        }
+      }
+    })
   })
 
-  it('accepts a file that already carries the launch key', () => {
-    expect(codexAuthPinsAnotherKey(JSON.stringify({ OPENAI_API_KEY: 'sk-now', tokens: null }), 'sk-now')).toBe(false)
-  })
-
-  it('never flags a human ChatGPT login, whatever key rides beside the tokens', () => {
-    const chatgpt = JSON.stringify({ OPENAI_API_KEY: 'sk-derived', tokens: { id_token: 'x' } })
-    expect(codexAuthPinsAnotherKey(chatgpt, 'sk-injected')).toBe(false)
-  })
-
-  it('leaves a keyless account shape alone rather than guessing', () => {
-    expect(codexAuthPinsAnotherKey(JSON.stringify({ OPENAI_API_KEY: null, tokens: null }), 'sk-now')).toBe(false)
-  })
-
-  it('flags an unparseable file — replacing it is the only recovery', () => {
-    expect(codexAuthPinsAnotherKey('not json', 'sk-now')).toBe(true)
-    expect(codexAuthPinsAnotherKey('[1,2]', 'sk-now')).toBe(true)
+  it('names the runtime default endpoint an endpoint-less key falls through to', () => {
+    expect(CODEX_DEFAULT_ENDPOINT).toBe('https://api.openai.com/v1')
   })
 })

--- a/packages/daemon/test/model-provider-config.test.ts
+++ b/packages/daemon/test/model-provider-config.test.ts
@@ -66,9 +66,18 @@ describe('applyModelCredential', () => {
       baseUrl: 'https://gateway.example/openai/v1'
     })
     expect(env.OPENAI_API_KEY).toBe('issued')
-    // With the key alone codex still refuses a fresh CODEX_HOME (-32000): this is what lets
-    // codex-acp answer its own authRequired by minting an account from the env key.
-    expect(JSON.parse(env.DEFAULT_AUTH_REQUEST)).toEqual({ methodId: 'api-key' })
+    // An endpoint-carrying credential authenticates as a GATEWAY: process-ephemeral, so no
+    // persisted account can override this launch's grant and concurrent hosts share nothing.
+    expect(JSON.parse(env.DEFAULT_AUTH_REQUEST)).toEqual({
+      methodId: 'gateway',
+      _meta: {
+        gateway: {
+          baseUrl: 'https://gateway.example/openai/v1',
+          headers: { Authorization: 'Bearer issued' },
+          providerName: 'AgentConnect model egress'
+        }
+      }
+    })
     expect(env.OPENAI_BASE_URL).toBe('https://gateway.example/openai/v1')
     expect(JSON.parse(env.CODEX_CONFIG)).toEqual({
       features: { apps: false },
@@ -185,6 +194,16 @@ describe('applyModelCredential', () => {
         } as never
       )
     ).toEqual({ provider: 'deepseek', runtime: 'deepseek' })
+  })
+})
+
+describe('applyModelCredential codex auth request', () => {
+  it('falls back to the api-key account login only for an endpoint-less credential', () => {
+    const env: Record<string, string> = {}
+    applyModelCredential({ provider: 'openai', runtime: 'codex' }, env, { key: 'real-provider-key' })
+    expect(env.OPENAI_API_KEY).toBe('real-provider-key')
+    expect(JSON.parse(env.DEFAULT_AUTH_REQUEST)).toEqual({ methodId: 'api-key' })
+    expect(env.CODEX_CONFIG).toBeUndefined()
   })
 })
 

--- a/packages/daemon/test/model-provider-config.test.ts
+++ b/packages/daemon/test/model-provider-config.test.ts
@@ -198,11 +198,18 @@ describe('applyModelCredential', () => {
 })
 
 describe('applyModelCredential codex auth request', () => {
-  it('falls back to the api-key account login only for an endpoint-less credential', () => {
+  it('rides an endpoint-less key on the runtime default endpoint — never the account store', () => {
+    // The key-server contract supports a plain vault rotating real provider keys with no base
+    // URL; the grant still authenticates as a process-ephemeral gateway, against the same URL
+    // the built-in provider would have used.
     const env: Record<string, string> = {}
     applyModelCredential({ provider: 'openai', runtime: 'codex' }, env, { key: 'real-provider-key' })
     expect(env.OPENAI_API_KEY).toBe('real-provider-key')
-    expect(JSON.parse(env.DEFAULT_AUTH_REQUEST)).toEqual({ methodId: 'api-key' })
+    expect(JSON.parse(env.DEFAULT_AUTH_REQUEST)._meta.gateway).toEqual({
+      baseUrl: 'https://api.openai.com/v1',
+      headers: { Authorization: 'Bearer real-provider-key' },
+      providerName: 'AgentConnect model egress'
+    })
     expect(env.CODEX_CONFIG).toBeUndefined()
   })
 })

--- a/packages/daemon/test/model-provider-config.test.ts
+++ b/packages/daemon/test/model-provider-config.test.ts
@@ -66,6 +66,9 @@ describe('applyModelCredential', () => {
       baseUrl: 'https://gateway.example/openai/v1'
     })
     expect(env.OPENAI_API_KEY).toBe('issued')
+    // With the key alone codex still refuses a fresh CODEX_HOME (-32000): this is what lets
+    // codex-acp answer its own authRequired by minting an account from the env key.
+    expect(JSON.parse(env.DEFAULT_AUTH_REQUEST)).toEqual({ methodId: 'api-key' })
     expect(env.OPENAI_BASE_URL).toBe('https://gateway.example/openai/v1')
     expect(JSON.parse(env.CODEX_CONFIG)).toEqual({
       features: { apps: false },

--- a/packages/daemon/test/model-provider-config.test.ts
+++ b/packages/daemon/test/model-provider-config.test.ts
@@ -198,19 +198,14 @@ describe('applyModelCredential', () => {
 })
 
 describe('applyModelCredential codex auth request', () => {
-  it('rides an endpoint-less key on the runtime default endpoint — never the account store', () => {
+  it('sends no auth request for an endpoint-less key — the shim owns the effective endpoint', () => {
     // The key-server contract supports a plain vault rotating real provider keys with no base
-    // URL; the grant still authenticates as a process-ephemeral gateway, against the same URL
-    // the built-in provider would have used.
+    // URL, and the pod's AC_CODEX_BASE_URL floor outranks the runtime default endpoint. Only the
+    // shim can see that floor, so the daemon must not pre-compose a request that would send the
+    // issued key past it to public OpenAI.
     const env: Record<string, string> = {}
     applyModelCredential({ provider: 'openai', runtime: 'codex' }, env, { key: 'real-provider-key' })
-    expect(env.OPENAI_API_KEY).toBe('real-provider-key')
-    expect(JSON.parse(env.DEFAULT_AUTH_REQUEST)._meta.gateway).toEqual({
-      baseUrl: 'https://api.openai.com/v1',
-      headers: { Authorization: 'Bearer real-provider-key' },
-      providerName: 'AgentConnect model egress'
-    })
-    expect(env.CODEX_CONFIG).toBeUndefined()
+    expect(env).toEqual({ OPENAI_API_KEY: 'real-provider-key' })
   })
 })
 

--- a/packages/daemon/test/shim-provider-env.test.ts
+++ b/packages/daemon/test/shim-provider-env.test.ts
@@ -91,37 +91,16 @@ describe('AcpRunner provider env fill-in', () => {
     expect(seen).toEqual({ A: null, B: null, O: null, D: 'sk-deepseek-pod', C: null, R: null })
   })
 
-  it('removes an auth.json pinning an earlier injected key, and leaves a matching or human one', async () => {
-    const { mkdtempSync, mkdirSync, writeFileSync, existsSync } = await import('node:fs')
-    const { join } = await import('node:path')
-    const { tmpdir } = await import('node:os')
-    const codexHome = join(mkdtempSync(join(tmpdir(), 'codex-auth-')), '.codex')
-    mkdirSync(codexHome)
-    const authPath = join(codexHome, 'auth.json')
-    const base = { PATH: process.env.PATH ?? '', CODEX_HOME: codexHome }
-
-    // Stale grant: a file minted from an earlier key must not short-circuit this launch's auth.
-    writeFileSync(authPath, JSON.stringify({ OPENAI_API_KEY: 'sk-earlier-grant', tokens: null }))
-    await spawnAndReadEnv('codex-acp', base)
-    expect(existsSync(authPath)).toBe(false)
-
-    // Current grant: an account that already matches stays — no login round trip to re-mint it.
-    writeFileSync(authPath, JSON.stringify({ OPENAI_API_KEY: 'sk-codex-pod', tokens: null }))
-    await spawnAndReadEnv('codex-acp', base)
-    expect(existsSync(authPath)).toBe(true)
-
-    // Human ChatGPT login: tokens files are never the injection mechanism's to remove.
-    writeFileSync(authPath, JSON.stringify({ OPENAI_API_KEY: null, tokens: { id_token: 'x' } }))
-    await spawnAndReadEnv('codex-acp', base)
-    expect(existsSync(authPath)).toBe(true)
-  })
-
-  it('pairs a codex key with the api-key default auth request, and lets a daemon-sent one win', async () => {
+  it('pairs a codex key with a gateway auth request, and lets a daemon-sent one win', async () => {
     const filled = await spawnAndReadEnv('codex-acp', { PATH: process.env.PATH ?? '' })
     expect(filled.O).toBe('sk-codex-pod')
-    // Without this a fresh CODEX_HOME answers every session with -32000: the env key is not an
-    // account, and the auth request is what lets codex-acp mint one from it.
-    expect(JSON.parse(filled.R!)).toEqual({ methodId: 'api-key' })
+    // Without this a fresh CODEX_HOME answers every session with -32000 — and the gateway method
+    // keeps the grant process-ephemeral, so an injected key never becomes a shared account.
+    expect(JSON.parse(filled.R!)._meta.gateway).toEqual({
+      baseUrl: 'https://codex-egress.internal',
+      headers: { Authorization: 'Bearer sk-codex-pod' },
+      providerName: 'AgentConnect model egress'
+    })
     const daemonSent = await spawnAndReadEnv('codex-acp', {
       PATH: process.env.PATH ?? '',
       DEFAULT_AUTH_REQUEST: '{"methodId":"chat-gpt"}'

--- a/packages/daemon/test/shim-provider-env.test.ts
+++ b/packages/daemon/test/shim-provider-env.test.ts
@@ -65,7 +65,7 @@ async function spawnAndReadEnv(command: string, requestEnv: Record<string, strin
     command,
     args: [
       '-e',
-      'process.stdout.write(JSON.stringify({A: process.env.ANTHROPIC_API_KEY ?? null, B: process.env.ANTHROPIC_BASE_URL ?? null, O: process.env.OPENAI_API_KEY ?? null, D: process.env.DEEPSEEK_API_KEY ?? null, C: process.env.CODEX_CONFIG ?? null}))'
+      'process.stdout.write(JSON.stringify({A: process.env.ANTHROPIC_API_KEY ?? null, B: process.env.ANTHROPIC_BASE_URL ?? null, O: process.env.OPENAI_API_KEY ?? null, D: process.env.DEEPSEEK_API_KEY ?? null, C: process.env.CODEX_CONFIG ?? null, R: process.env.DEFAULT_AUTH_REQUEST ?? null}))'
     ],
     env: requestEnv
   })
@@ -76,12 +76,32 @@ async function spawnAndReadEnv(command: string, requestEnv: Record<string, strin
 describe('AcpRunner provider env fill-in', () => {
   it('fills pod provider vars into a claude spawn and keeps codex vars out', async () => {
     const seen = await spawnAndReadEnv('claude-agent-acp', { PATH: process.env.PATH ?? '' })
-    expect(seen).toEqual({ A: 'sk-claude-pod', B: 'https://claude-egress.internal', O: null, D: null, C: null })
+    expect(seen).toEqual({
+      A: 'sk-claude-pod',
+      B: 'https://claude-egress.internal',
+      O: null,
+      D: null,
+      C: null,
+      R: null
+    })
   })
 
   it('fills the deepseek pod vars into a dsh-acp spawn', async () => {
     const seen = await spawnAndReadEnv('dsh-acp', { PATH: process.env.PATH ?? '' })
-    expect(seen).toEqual({ A: null, B: null, O: null, D: 'sk-deepseek-pod', C: null })
+    expect(seen).toEqual({ A: null, B: null, O: null, D: 'sk-deepseek-pod', C: null, R: null })
+  })
+
+  it('pairs a codex key with the api-key default auth request, and lets a daemon-sent one win', async () => {
+    const filled = await spawnAndReadEnv('codex-acp', { PATH: process.env.PATH ?? '' })
+    expect(filled.O).toBe('sk-codex-pod')
+    // Without this a fresh CODEX_HOME answers every session with -32000: the env key is not an
+    // account, and the auth request is what lets codex-acp mint one from it.
+    expect(JSON.parse(filled.R!)).toEqual({ methodId: 'api-key' })
+    const daemonSent = await spawnAndReadEnv('codex-acp', {
+      PATH: process.env.PATH ?? '',
+      DEFAULT_AUTH_REQUEST: '{"methodId":"chat-gpt"}'
+    })
+    expect(daemonSent.R).toBe('{"methodId":"chat-gpt"}')
   })
 
   it('lets a daemon-sent value win over the pod value', async () => {

--- a/packages/daemon/test/shim-provider-env.test.ts
+++ b/packages/daemon/test/shim-provider-env.test.ts
@@ -91,6 +91,31 @@ describe('AcpRunner provider env fill-in', () => {
     expect(seen).toEqual({ A: null, B: null, O: null, D: 'sk-deepseek-pod', C: null, R: null })
   })
 
+  it('removes an auth.json pinning an earlier injected key, and leaves a matching or human one', async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, existsSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+    const codexHome = join(mkdtempSync(join(tmpdir(), 'codex-auth-')), '.codex')
+    mkdirSync(codexHome)
+    const authPath = join(codexHome, 'auth.json')
+    const base = { PATH: process.env.PATH ?? '', CODEX_HOME: codexHome }
+
+    // Stale grant: a file minted from an earlier key must not short-circuit this launch's auth.
+    writeFileSync(authPath, JSON.stringify({ OPENAI_API_KEY: 'sk-earlier-grant', tokens: null }))
+    await spawnAndReadEnv('codex-acp', base)
+    expect(existsSync(authPath)).toBe(false)
+
+    // Current grant: an account that already matches stays — no login round trip to re-mint it.
+    writeFileSync(authPath, JSON.stringify({ OPENAI_API_KEY: 'sk-codex-pod', tokens: null }))
+    await spawnAndReadEnv('codex-acp', base)
+    expect(existsSync(authPath)).toBe(true)
+
+    // Human ChatGPT login: tokens files are never the injection mechanism's to remove.
+    writeFileSync(authPath, JSON.stringify({ OPENAI_API_KEY: null, tokens: { id_token: 'x' } }))
+    await spawnAndReadEnv('codex-acp', base)
+    expect(existsSync(authPath)).toBe(true)
+  })
+
   it('pairs a codex key with the api-key default auth request, and lets a daemon-sent one win', async () => {
     const filled = await spawnAndReadEnv('codex-acp', { PATH: process.env.PATH ?? '' })
     expect(filled.O).toBe('sk-codex-pod')

--- a/packages/daemon/test/shim-provider-env.test.ts
+++ b/packages/daemon/test/shim-provider-env.test.ts
@@ -51,7 +51,11 @@ describe('sandboxProviderEnv', () => {
 
 // Spawn through the real runner: resolveCommand maps the registry command to node so the
 // child can print the environment it actually received.
-async function spawnAndReadEnv(command: string, requestEnv: Record<string, string>): Promise<Record<string, string>> {
+async function spawnAndReadEnv(
+  command: string,
+  requestEnv: Record<string, string>,
+  podEnv: Record<string, string | undefined> = POD_ENV
+): Promise<Record<string, string>> {
   const chunks: string[] = []
   let onExit: (() => void) | undefined
   const exited = new Promise<void>((resolve) => (onExit = resolve))
@@ -59,7 +63,7 @@ async function spawnAndReadEnv(command: string, requestEnv: Record<string, strin
     if (event.kind === 'chunk') chunks.push(Buffer.from(event.data, 'base64').toString('utf8'))
     if (event.kind === 'exit') onExit?.()
   }
-  const runner = new AcpRunner({ emit, resolveCommand: () => process.execPath, podEnv: POD_ENV })
+  const runner = new AcpRunner({ emit, resolveCommand: () => process.execPath, podEnv })
   await runner.apply({
     op: 'open',
     command,
@@ -106,6 +110,35 @@ describe('AcpRunner provider env fill-in', () => {
       DEFAULT_AUTH_REQUEST: '{"methodId":"chat-gpt"}'
     })
     expect(daemonSent.R).toBe('{"methodId":"chat-gpt"}')
+  })
+
+  it('falls to the runtime default endpoint only when the pod floor carries no base either', async () => {
+    // A daemon-injected key with no daemon URL and no pod URL: the endpoint-less shape bottoms
+    // out at the injection precedence's last layer, still as a process-ephemeral gateway grant.
+    const seen = await spawnAndReadEnv(
+      'codex-acp',
+      { PATH: process.env.PATH ?? '', OPENAI_API_KEY: 'sk-issued' },
+      { AC_CODEX_API_KEY: 'sk-pod-unused' }
+    )
+    expect(seen.O).toBe('sk-issued')
+    expect(JSON.parse(seen.R!)._meta.gateway).toEqual({
+      baseUrl: 'https://api.openai.com/v1',
+      headers: { Authorization: 'Bearer sk-issued' },
+      providerName: 'AgentConnect model egress'
+    })
+  })
+
+  it('routes a daemon-injected key by the pod base-URL floor when the daemon named no endpoint', async () => {
+    // The reported cloud shape: issued key, base URL present only in the live pod. The request
+    // must aim at the pod's gateway — composing the public endpoint here would send the issued
+    // key straight past the floor.
+    const seen = await spawnAndReadEnv('codex-acp', { PATH: process.env.PATH ?? '', OPENAI_API_KEY: 'sk-issued' })
+    expect(seen.O).toBe('sk-issued')
+    expect(JSON.parse(seen.R!)._meta.gateway).toEqual({
+      baseUrl: 'https://codex-egress.internal',
+      headers: { Authorization: 'Bearer sk-issued' },
+      providerName: 'AgentConnect model egress'
+    })
   })
 
   it('lets a daemon-sent value win over the pod value', async () => {

--- a/packages/daemon/test/shim-provider-env.test.ts
+++ b/packages/daemon/test/shim-provider-env.test.ts
@@ -128,6 +128,33 @@ describe('AcpRunner provider env fill-in', () => {
     })
   })
 
+  it('aims a runtime-owned key at the runtime-owned custom endpoint, never past it', async () => {
+    // No key server, no static credential: key and endpoint both belong to the runtime. The pod
+    // floor and the public default must not outrank the runtime's live surface.
+    const seen = await spawnAndReadEnv('codex-acp', {
+      PATH: process.env.PATH ?? '',
+      OPENAI_API_KEY: 'sk-runtime-own',
+      CODEX_CONFIG: JSON.stringify({ openai_base_url: 'https://runtime-own.example/v1' })
+    })
+    expect(JSON.parse(seen.R!)._meta.gateway.baseUrl).toBe('https://runtime-own.example/v1')
+
+    const envAimed = await spawnAndReadEnv(
+      'codex-acp',
+      { PATH: process.env.PATH ?? '', OPENAI_API_KEY: 'sk-runtime-own', OPENAI_BASE_URL: 'https://env-own.example' },
+      { AC_CODEX_API_KEY: 'sk-pod-unused' }
+    )
+    expect(JSON.parse(envAimed.R!)._meta.gateway.baseUrl).toBe('https://env-own.example')
+  })
+
+  it('composes nothing for a runtime that selected its own model provider', async () => {
+    const seen = await spawnAndReadEnv('codex-acp', {
+      PATH: process.env.PATH ?? '',
+      OPENAI_API_KEY: 'sk-runtime-own',
+      CODEX_CONFIG: JSON.stringify({ model_provider: 'my-own-gateway' })
+    })
+    expect(seen.R).toBeNull()
+  })
+
   it('routes a daemon-injected key by the pod base-URL floor when the daemon named no endpoint', async () => {
     // The reported cloud shape: issued key, base URL present only in the live pod. The request
     // must aim at the pod's gateway — composing the public endpoint here would send the issued


### PR DESCRIPTION
First genuinely fresh codex sandbox on the cloud pool failed its first turn with `RequestError: Authentication required (code=-32000)` — spawn env verified correct in the live pod (key, base URL, session-config floor all present).

Root cause, from the shipped codex-acp bundle: `authRequired()` is `accountRead().requiresOpenaiAuth && !account` — a bare `OPENAI_API_KEY` env is not an account, and on a fresh `CODEX_HOME` (no `auth.json`) codex-acp throws the -32000 back to the client unless `DEFAULT_AUTH_REQUEST` names a method it may use to answer its own authRequired. The daemon never set it. Every earlier cloud codex session happened to ride a sandbox whose PVC already carried an `auth.json`, which is why this only surfaced with the first fresh sandbox.

**Final shape, after five review rounds — three invariants:**

1. **An injected codex credential never touches the account store.** Every composed credential authenticates via codex-acp's gateway method: `DEFAULT_AUTH_REQUEST={"methodId":"gateway",…}` carrying base URL + `Authorization` header, held as an in-process provider (`model_providers["custom-gateway"]`, responses wire — wire-identical traffic), with `authRequired()` short-circuiting before `account/read`. No persisted account of any shape (tokens logins included) can outrank a launch's grant, and concurrently starting session hosts share no credential state.
2. **The layer that knows the effective endpoint composes the request.** The daemon composes it only when it holds the endpoint (issued/static base URL); an endpoint-less credential travels as the key alone and the shim composes the request. A daemon-sent request wins over the fill-in.
3. **The request's base is the final effective aim — never past it.** The shim reads the configuration after every fill-in has layered: `CODEX_CONFIG.openai_base_url` (daemon aim, agent aim, or pod floor), then a runtime-owned `OPENAI_BASE_URL`, then the public default. A runtime that selected its own `model_provider` gets no synthesized request at all — routing and auth stay runtime-owned — and an unreadable config composes nothing rather than aiming the key blind.

Also: interim mechanisms from earlier rounds (api-key account login, spawn-time `auth.json` reconcile) became unreachable and are deleted; human ChatGPT logins on disk stay untouched and inert; `openai_base_url` stays in `CODEX_CONFIG` for older adapters and resumed threads pinned to the built-in provider; non-codex runtimes untouched.

Tests: gateway request shape across daemon-aimed, pod-floor, runtime-owned (config and env), and floorless paths; custom-provider and endpoint-less-daemon paths compose nothing; daemon-sent request wins; `codexGatewayAuthRequest` table tests. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)