### PR TITLE
fix(control-plane): host a session continuation on any daemon that serves its content

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1484,6 +1484,7 @@ export function buildContainer(
       daemons: connReg,
       conversations: repos.webchatConversation,
       sessions: repos.session,
+      memberSets: repos.memberSet,
       orgs: repos.org,
       remoteMcp: webchatRemoteMcp,
       placement: placementResolver

--- a/packages/control-plane/src/domain/session-content.ts
+++ b/packages/control-plane/src/domain/session-content.ts
@@ -47,3 +47,8 @@ export function sessionContentReaders(sources: SessionContentSources): string[] 
     ])
   ]
 }
+
+/** May `daemonId` serve this session's content — the recorder itself, or a holder of the store it wrote to? */
+export function servesSessionContent(sources: SessionContentSources, daemonId: string): boolean {
+  return sessionContentReaders(sources).includes(daemonId)
+}

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -20,8 +20,9 @@ import { AgentId, HookId, OrgId, SessionId } from '../../domain/ids.js'
 import { orgOf, ctxOf, denyNonOwner } from '../rbac.js'
 import { decodeConversationKey, encodeConversationKey } from '../conversation-key.js'
 import { canChangeSessionVisibility, canContinueSession, canView, canViewSession } from '../../authorization/policy.js'
-import { originKindOf, WEBCHAT_SESSION_CONTINUATION_FEATURE } from '@agentconnect.md/protocol'
+import { originKindOf } from '@agentconnect.md/protocol'
 import { makeSessionAccessResolver } from '../session-access.js'
+import { resolveContinuationHost } from '../session-continuation.js'
 import { Tag } from '../plugins/openapi.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { ConnectionClosed } from '../../ws/registry.js'
@@ -814,18 +815,8 @@ export function sessionRoutes(deps: HttpDeps) {
           }
           if (s.contentPurgedAt) return 'content_purged' as const
           if (originKindOf(s.platform ?? '') !== 'chat') return 'unsupported_platform' as const
-          if (!s.daemonId || owningAgent.daemonId !== s.daemonId) return 'agent_moved' as const
-          const daemon = deps.daemonConns.get(s.daemonId)
-          if (daemon?.state !== 'READY') return 'daemon_offline' as const
-          if (!daemon.capabilities?.features?.includes(WEBCHAT_SESSION_CONTINUATION_FEATURE)) {
-            return 'unavailable' as const
-          }
-          if (!deps.config.PUBLIC_RELAY_URL) return 'unavailable' as const
-          const alive = await deps.repos.relay.listAlive(new Date(Date.now() - (deps.config.RELAY_STALE_MS ?? 45_000)))
-          if (alive.length === 0 || alive.some((r) => !r.features.includes(WEBCHAT_SESSION_CONTINUATION_FEATURE))) {
-            return 'unavailable' as const
-          }
-          return null
+          const host = await resolveContinuationHost(deps, s, owningAgent)
+          return host.ok ? null : host.reason
         })()
         const siblings = siblingCandidates.filter((candidate) => candidate.id !== s.id)
         const related = [...(parent ? [parent] : []), ...siblings, ...children]

--- a/packages/control-plane/src/http/routes/webchat-token.ts
+++ b/packages/control-plane/src/http/routes/webchat-token.ts
@@ -14,17 +14,14 @@
 import type { FastifyInstance } from 'fastify'
 import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
-import {
-  originKindOf,
-  WEBCHAT_MULTI_AGENT_FEATURE,
-  WEBCHAT_SESSION_CONTINUATION_FEATURE
-} from '@agentconnect.md/protocol'
+import { originKindOf, WEBCHAT_MULTI_AGENT_FEATURE } from '@agentconnect.md/protocol'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import { AgentId, SessionId, type OrgId } from '../../domain/ids.js'
 import type { ResolvableAgent } from '../../orchestrator/placementResolver.js'
 import { canContinueSession, canView } from '../../authorization/policy.js'
 import { makeSessionAccessResolver } from '../session-access.js'
+import { resolveContinuationHost } from '../session-continuation.js'
 import { ctxOf, orgOf } from '../rbac.js'
 import { ErrorDto } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
@@ -163,7 +160,7 @@ export function webchatTokenRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Mint a session-continuation webchat token',
           description:
-            'Mints a short-lived token the browser presents to the relay pool to continue an existing chat-origin session from the console composer. Requires continuation authorization, un-purged content, the owning agent still placed on the session daemon, and continuation-capable daemon and relay pool.',
+            'Mints a short-lived token the browser presents to the relay pool to continue an existing chat-origin session from the console composer. Requires continuation authorization, un-purged content, a daemon that can still serve the session content (its recorder, or a live member of the shared store it was written to), and continuation-capable daemon and relay pool.',
           operationId: 'mintWebchatSessionToken',
           params: z.object({ orgId: z.string(), sessionId: z.string() }),
           response: { 200: WebchatTokenDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto, 503: ErrorDto }
@@ -200,17 +197,16 @@ export function webchatTokenRoutes(deps: HttpDeps) {
         if (originKindOf(s.platform ?? '') !== 'chat') return refuse(409, 'only chat sessions can be continued')
         const agent = await deps.repos.agent.get(orgOf(req), s.agentId)
         if (!agent || !canView(agent, ctx)) return refuse(404, 'session not found')
-        if (!s.daemonId || agent.daemonId !== s.daemonId) return refuse(409, 'the agent moved since this session ran')
-        const daemon = deps.daemonConns.get(s.daemonId)
-        if (daemon?.state !== 'READY') return refuse(409, 'the session host is offline')
-        if (!daemon.capabilities?.features?.includes(WEBCHAT_SESSION_CONTINUATION_FEATURE)) {
-          return refuse(409, 'session continuation is not available yet')
-        }
-        // Fail-closed rollout: EVERY live relay behind the public pool must
-        // preserve targetSessionId; one old member keeps the feature off.
-        const alive = await deps.repos.relay.listAlive(new Date(Date.now() - (deps.config.RELAY_STALE_MS ?? 45_000)))
-        if (alive.length === 0 || alive.some((r) => !r.features.includes(WEBCHAT_SESSION_CONTINUATION_FEATURE))) {
-          return refuse(409, 'session continuation is not available yet')
+        const host = await resolveContinuationHost(deps, s, agent)
+        if (!host.ok) {
+          return refuse(
+            409,
+            host.reason === 'agent_moved'
+              ? 'the agent moved since this session ran'
+              : host.reason === 'daemon_offline'
+                ? 'the session host is offline'
+                : 'session continuation is not available yet'
+          )
         }
         const userId = req.principal!.userId
         const { conversationId } = await deps.repos.webchatConversation.upsertSessionTargeted(

--- a/packages/control-plane/src/http/session-continuation.ts
+++ b/packages/control-plane/src/http/session-continuation.ts
@@ -1,0 +1,38 @@
+import { WEBCHAT_SESSION_CONTINUATION_FEATURE } from '@agentconnect.md/protocol'
+import { servesSessionContent } from '../domain/session-content.js'
+import type { ResolvableAgent } from '../orchestrator/placementResolver.js'
+import type { HttpDeps } from './deps.js'
+
+/** Why no daemon can host a session continuation right now — the detail view's reason vocabulary. */
+export type ContinuationHostRefusal = 'agent_moved' | 'daemon_offline' | 'unavailable'
+
+export type ContinuationHost = { ok: true; daemonId: string } | { ok: false; reason: ContinuationHostRefusal }
+
+/** The ONE answer to "which daemon continues this session" — the detail projection (`canContinue`) and the session-target mint both read it, so they cannot disagree. The daemon a turn reaches (`dispatchDaemon`) must be the recorder or a holder of the shared store the rows went to (`domain/session-content.ts`); keying on `session.daemonId` alone read as "agent moved" for every pooled agent once its recorder pod rolled. */
+export async function resolveContinuationHost(
+  deps: Pick<HttpDeps, 'placementResolver' | 'daemonConns' | 'repos' | 'config'>,
+  session: { daemonId: string | null; contentSetId: string | null },
+  agent: ResolvableAgent
+): Promise<ContinuationHost> {
+  const daemonId = await deps.placementResolver.dispatchDaemon(agent)
+  // A machine placement always names its daemon; only a set with no live member resolves to nobody.
+  if (!daemonId) return { ok: false, reason: 'daemon_offline' }
+  const sharedStoreMembers = session.contentSetId
+    ? await deps.repos.memberSet.sharedStoreMemberIdsOf(session.contentSetId)
+    : []
+  if (!servesSessionContent({ recordedDaemonId: session.daemonId, sharedStoreMembers }, daemonId)) {
+    return { ok: false, reason: 'agent_moved' }
+  }
+  const daemon = deps.daemonConns.get(daemonId)
+  if (daemon?.state !== 'READY') return { ok: false, reason: 'daemon_offline' }
+  if (!daemon.capabilities?.features?.includes(WEBCHAT_SESSION_CONTINUATION_FEATURE)) {
+    return { ok: false, reason: 'unavailable' }
+  }
+  if (!deps.config.PUBLIC_RELAY_URL) return { ok: false, reason: 'unavailable' }
+  // Fail-closed rollout: EVERY live relay behind the public pool must preserve targetSessionId.
+  const alive = await deps.repos.relay.listAlive(new Date(Date.now() - (deps.config.RELAY_STALE_MS ?? 45_000)))
+  if (alive.length === 0 || alive.some((r) => !r.features.includes(WEBCHAT_SESSION_CONTINUATION_FEATURE))) {
+    return { ok: false, reason: 'unavailable' }
+  }
+  return { ok: true, daemonId }
+}

--- a/packages/control-plane/src/registry/webchatVerification.ts
+++ b/packages/control-plane/src/registry/webchatVerification.ts
@@ -7,6 +7,7 @@ import {
   type RegisterReq
 } from '@agentconnect.md/protocol'
 import { AgentId, OrgId, SessionId } from '../domain/ids.js'
+import { servesSessionContent } from '../domain/session-content.js'
 import type { PlacementResolver, ResolvableAgent } from '../orchestrator/placementResolver.js'
 import type { WebchatRemoteMcpService } from './webchatRemoteMcpService.js'
 import type { WebchatTokenService } from './webchatToken.js'
@@ -32,11 +33,14 @@ export interface WebchatVerificationDeps {
       agentId: string
       platform: string | null
       daemonId: string | null
+      contentSetId: string | null
       visibility: string
       ownerIdentity: string | null
       contentPurgedAt: Date | null
     } | null>
   }
+  /** Who else holds the shared store a session was written to (`domain/session-content.ts`). */
+  memberSets: { sharedStoreMemberIdsOf(setId: string): Promise<string[]> }
   orgs: { roleOf(orgId: string, userId: string): Promise<string | null> }
   remoteMcp: Pick<WebchatRemoteMcpService, 'establish'>
   /** Resolves the daemon a webchat turn should reach — the holder, or any live member that can
@@ -57,8 +61,9 @@ export interface WebchatVerificationDeps {
  * A SESSION-TARGETED conversation (non-null `targetSessionId`) re-checks the
  * continuation gates on every dial: the target session must exist un-purged and
  * chat-origin, the signed user must still hold a non-viewer role (private
- * sessions: console ownership), and the owner agent must still be placed on the
- * session's content-owning daemon with the continuation capability. Any drift
+ * sessions: console ownership), and the owner agent's dispatch daemon must still
+ * serve the session's content (its recorder, or a holder of the shared store it
+ * was written to) with the continuation capability. Any drift
  * fails the token instead of degrading into a fresh webchat session. The full
  * provider-identity expansion ran at mint (≤ token TTL ago); verify re-checks
  * with the console identity, which fails closed for platform-identity owners.
@@ -112,9 +117,11 @@ export function createWebchatTokenVerifier(deps: WebchatVerificationDeps): (toke
       ) {
         return { ok: false, reason: 'continuation unavailable' }
       }
-      // Content ownership is daemon-local: the agent must still be on the
-      // session's recorded daemon, and that daemon continuation-capable.
-      if (session.daemonId === null || session.daemonId !== agentDaemonId) {
+      // The dispatch daemon must still reach the content: the recorder, or a holder of the shared store it wrote to.
+      const sharedStoreMembers = session.contentSetId
+        ? await deps.memberSets.sharedStoreMemberIdsOf(session.contentSetId)
+        : []
+      if (!servesSessionContent({ recordedDaemonId: session.daemonId, sharedStoreMembers }, agentDaemonId)) {
         return { ok: false, reason: 'continuation unavailable' }
       }
       if (!daemon.capabilities?.features.includes(WEBCHAT_SESSION_CONTINUATION_FEATURE)) {

--- a/packages/control-plane/src/ws/relay-connection.test.ts
+++ b/packages/control-plane/src/ws/relay-connection.test.ts
@@ -1,4 +1,5 @@
-import { PLACEMENT_ONLY } from '../orchestrator/placementResolver.js'
+import { PLACEMENT_ONLY, PlacementResolver } from '../orchestrator/placementResolver.js'
+import { systemClock } from '../domain/clock.js'
 import { describe, it, expect, vi } from 'vitest'
 import {
   buildRelayCpFrame,
@@ -182,7 +183,7 @@ function buildWebchatVerifier(
      *  pre-participant single-agent shape). */
     participants?: Awaited<ReturnType<WebchatVerificationDeps['conversations']['participants']>>
     /** Per-agent lookups for roster MEMBERS (the primary keeps the defaults). */
-    agentById?: Record<string, { orgId: string; daemonId: string | null } | null>
+    agentById?: Record<string, Awaited<ReturnType<WebchatVerificationDeps['agents']['getUnscoped']>>>
     /** Per-daemon connection state for member placements. */
     daemonById?: Record<string, { state: string; features?: string[] }>
     establish?: WebchatVerificationDeps['remoteMcp']['establish']
@@ -191,6 +192,10 @@ function buildWebchatVerifier(
     conversationRow?: { targetSessionId: string | null } | null
     /** Target session row for the continuation branch. */
     sessionById?: Record<string, Awaited<ReturnType<WebchatVerificationDeps['sessions']['getUnscoped']>>>
+    /** Members of a shared-store set, by set id (default: none). */
+    sharedStoreMembersBySet?: Record<string, string[]>
+    /** The placement resolver (default: placement alone — no duty ledger, no live members). */
+    placement?: WebchatVerificationDeps['placement']
     /** Signed user's role in the org (default collaborator). */
     role?: string | null
   } = {}
@@ -210,6 +215,8 @@ function buildWebchatVerifier(
     if (over.agentById && id in over.agentById) return over.agentById[id] ?? null
     return {
       orgId: 'org-1',
+      placementKind: 'daemon' as const,
+      setId: null,
       daemonId: over.daemonId === undefined ? WEBCHAT_DAEMON_ID : over.daemonId
     }
   })
@@ -254,8 +261,9 @@ function buildWebchatVerifier(
         target: async () => (over.conversationRow === undefined ? { targetSessionId: null } : over.conversationRow)
       },
       sessions: { getUnscoped: async (id) => over.sessionById?.[id] ?? null },
+      memberSets: { sharedStoreMemberIdsOf: async (setId) => over.sharedStoreMembersBySet?.[setId] ?? [] },
       orgs: { roleOf: async () => (over.role === undefined ? 'collaborator' : over.role) },
-      placement: PLACEMENT_ONLY,
+      placement: over.placement ?? PLACEMENT_ONLY,
       remoteMcp: { establish }
     })
   }
@@ -790,7 +798,9 @@ describe('webchat verification multi-agent roster (webchat-multi-agents.md §6.2
   it('returns the roster primary-first with member placements and suppresses remote-MCP', async () => {
     const h = buildWebchatVerifier({
       participants: ROSTER,
-      agentById: { [MEMBER_AGENT_ID]: { orgId: 'org-1', daemonId: MEMBER_DAEMON_ID } },
+      agentById: {
+        [MEMBER_AGENT_ID]: { orgId: 'org-1', placementKind: 'daemon', setId: null, daemonId: MEMBER_DAEMON_ID }
+      },
       daemonById: { [MEMBER_DAEMON_ID]: { state: 'READY' } }
     })
 
@@ -811,7 +821,9 @@ describe('webchat verification multi-agent roster (webchat-multi-agents.md §6.2
   it('lists a member WITHOUT a placement when its daemon is not READY', async () => {
     const h = buildWebchatVerifier({
       participants: ROSTER,
-      agentById: { [MEMBER_AGENT_ID]: { orgId: 'org-1', daemonId: MEMBER_DAEMON_ID } },
+      agentById: {
+        [MEMBER_AGENT_ID]: { orgId: 'org-1', placementKind: 'daemon', setId: null, daemonId: MEMBER_DAEMON_ID }
+      },
       daemonById: { [MEMBER_DAEMON_ID]: { state: 'DEGRADED' } }
     })
 
@@ -827,7 +839,9 @@ describe('webchat verification multi-agent roster (webchat-multi-agents.md §6.2
   it('lists a cross-org or vanished member WITHOUT a placement (fail-closed targeting)', async () => {
     const h = buildWebchatVerifier({
       participants: ROSTER,
-      agentById: { [MEMBER_AGENT_ID]: { orgId: 'org-OTHER', daemonId: MEMBER_DAEMON_ID } },
+      agentById: {
+        [MEMBER_AGENT_ID]: { orgId: 'org-OTHER', placementKind: 'daemon', setId: null, daemonId: MEMBER_DAEMON_ID }
+      },
       daemonById: { [MEMBER_DAEMON_ID]: { state: 'READY' } }
     })
 
@@ -862,6 +876,7 @@ describe('webchat verification — session-targeted continuation (webchat-cross-
       agentId: string
       platform: string | null
       daemonId: string | null
+      contentSetId: string | null
       visibility: string
       ownerIdentity: string | null
       contentPurgedAt: Date | null
@@ -871,6 +886,7 @@ describe('webchat verification — session-targeted continuation (webchat-cross-
     agentId: WEBCHAT_AGENT_ID,
     platform: 'slack',
     daemonId: WEBCHAT_DAEMON_ID,
+    contentSetId: null,
     visibility: 'org',
     ownerIdentity: null,
     contentPurgedAt: null,
@@ -963,5 +979,39 @@ describe('webchat verification — session-targeted continuation (webchat-cross-
     await expect(targeted({}, { daemonFeatures: [WEBCHAT_REMOTE_MCP_FEATURE] }).verifier('t')).resolves.toMatchObject({
       ok: false
     })
+  })
+
+  // A pool member is replaced on every rollout: the recorder is gone (or SetNulled), yet every live
+  // member reads the shared store it wrote to — so the dispatch member continues the session.
+  it('continues through any live pool member when the content sits in the shared store', async () => {
+    const POOL_SET = 'pool-set-1'
+    const RECORDER = '11111111-1111-4111-8111-111111111111'
+    const SUCCESSOR = '22222222-2222-4222-8222-222222222222'
+    const pooled = (session: Parameters<typeof targetSession>[0], members: string[]) =>
+      targeted(session, {
+        agentById: { [WEBCHAT_AGENT_ID]: { orgId: 'org-1', placementKind: 'set', setId: POOL_SET, daemonId: null } },
+        placement: new PlacementResolver({ clock: systemClock, liveMembers: async () => [SUCCESSOR] }),
+        sharedStoreMembersBySet: { [POOL_SET]: members },
+        daemonById: { [SUCCESSOR]: { state: 'READY', features: CONTINUATION_FEATURES } }
+      })
+    // Recorder rolled away; its row may even be reaped (daemonId SetNulled).
+    await expect(
+      pooled({ daemonId: RECORDER, contentSetId: POOL_SET }, [SUCCESSOR]).verifier('t')
+    ).resolves.toMatchObject({
+      ok: true,
+      targetSessionId: TARGET_SESSION_ID,
+      participants: [{ agentId: WEBCHAT_AGENT_ID, daemonId: SUCCESSOR }]
+    })
+    await expect(pooled({ daemonId: null, contentSetId: POOL_SET }, [SUCCESSOR]).verifier('t')).resolves.toMatchObject({
+      ok: true
+    })
+    // Recorded on a private store before the agent joined the pool: no member holds those rows.
+    await expect(pooled({ daemonId: RECORDER, contentSetId: null }, [SUCCESSOR]).verifier('t')).resolves.toMatchObject({
+      ok: false
+    })
+    // The dispatch member is not a holder of that store.
+    await expect(
+      pooled({ daemonId: RECORDER, contentSetId: POOL_SET }, [RECORDER]).verifier('t')
+    ).resolves.toMatchObject({ ok: false })
   })
 })

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -125,6 +125,8 @@ export async function seedSessionMeta(
     visibility?: 'org' | 'private'
     ownerIdentity?: string
     daemonId?: string
+    /** The shared-store set the rows went to (a pool-recorded session); absent ⇒ private store. */
+    contentSetId?: string
     platform?: string
     channel?: string
     parentSessionId?: string
@@ -146,6 +148,7 @@ export async function seedSessionMeta(
       ...(opts.visibility ? { visibility: opts.visibility } : {}),
       ...(opts.ownerIdentity ? { ownerIdentity: opts.ownerIdentity } : {}),
       ...(opts.daemonId ? { daemonId: opts.daemonId } : {}),
+      ...(opts.contentSetId ? { contentSetId: opts.contentSetId } : {}),
       ...(opts.parentSessionId ? { parentSessionId: opts.parentSessionId } : {}),
       ...(opts.model ? { model: opts.model } : {})
     }

--- a/packages/control-plane/test/integration/relay-gateway.test.ts
+++ b/packages/control-plane/test/integration/relay-gateway.test.ts
@@ -26,6 +26,7 @@ import {
 } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { seedAgent, seedDutyGroup, seedSessionMeta } from '../fixtures/seed.js'
+import { joinPool } from '../fakes/member-set.js'
 import { buildApp, type App } from '../../src/app.js'
 import { AppConfigSchema, type AppConfig } from '../../src/config/env.js'
 import { systemClock } from '../../src/domain/clock.js'
@@ -1053,6 +1054,36 @@ describe('webchat session-continuation mint + verify', () => {
     await prisma.agent.update({ where: { id: AGENT }, data: { daemonId: DAEMON } })
 
     capable.close()
+    daemonWs.close()
+  })
+
+  // A pool member is replaced on every rollout and reaped once silent, which SetNulls the
+  // `daemonId` it recorded — but the rows live in the store its peers share, and the duty holder
+  // reads them like it wrote them. Keying the gate on the recorder alone read as "agent moved".
+  it('continues a pool-recorded session through the live duty holder once the recorder is gone', async () => {
+    const { app, base } = await start({ PUBLIC_RELAY_URL: RELAY_URL })
+    const daemonWs = await connectDaemonReady(base, CONTINUATION)
+    const { ws: relayWs } = await openRelay(base, 'pod-cont-3', 'wss://pod-cont-3.example.test', CONTINUATION)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    const setId = await joinPool(prisma, DAEMON)
+    await prisma.agent.update({ where: { id: AGENT }, data: { placementKind: 'set', setId, daemonId: null } })
+    await seedDutyGroup(prisma, randomUUID(), DAEMON, [AGENT])
+    await seedSessionMeta(prisma, SESSION_ID, AGENT, { platform: 'slack', channel: 'C123', contentSetId: setId })
+
+    expect((await mintSessionToken(app, SESSION_ID)).statusCode).toBe(200)
+    const detail = await app.http.inject({
+      method: 'GET',
+      url: `/api/v1/orgs/${DEFAULT_ORG_ID}/sessions/${SESSION_ID}`
+    })
+    expect(detail.json()).toMatchObject({ canContinue: true, continuationUnavailableReason: null })
+
+    // Recorded on a private store before the agent joined the pool: no live member holds those rows.
+    await prisma.sessionMeta.update({ where: { id: SESSION_ID }, data: { contentSetId: null } })
+    expect((await mintSessionToken(app, SESSION_ID)).statusCode).toBe(409)
+    const moved = await app.http.inject({ method: 'GET', url: `/api/v1/orgs/${DEFAULT_ORG_ID}/sessions/${SESSION_ID}` })
+    expect(moved.json()).toMatchObject({ canContinue: false, continuationUnavailableReason: 'agent_moved' })
+
+    relayWs.close()
     daemonWs.close()
   })
 


### PR DESCRIPTION
## What

Sibling of #1263, on the control-plane side: the **integration-origin session continuation** (console composer → Slack/Discord/… session) was refused for every **pool-placed** agent — `canContinue: false / agent_moved` on the detail, 409 *"the agent moved since this session ran"* on the mint — as soon as the recorder pod was gone, even while the pool was healthy.

## Why

Three gates required `agent.daemonId === session.daemonId`:

- `routes/sessions.ts` — detail `continuationUnavailableReason`
- `routes/webchat-token.ts` — `POST /sessions/:id/webchat/token`
- `registry/webchatVerification.ts` — the relay-facing verifier's targeted branch

A pool agent has no `daemonId` (its holder is a ledger answer), and the recorder pod is replaced on every rollout and reaped once silent (which SetNulls the session's column). Content eligibility is a property of the **store** (`domain/session-content.ts`), not of the recorder — the same rule the transcript reader already follows.

## How

- `domain/session-content.ts`: `servesSessionContent(sources, daemonId)` — recorder, or a holder of the shared store the rows went to.
- New `http/session-continuation.ts` → `resolveContinuationHost(deps, session, agent)`: `dispatchDaemon(agent)` → content predicate → READY → continuation feature → relay-pool feature gate. Both HTTP gates read it, so the detail reason and the mint refusal cannot drift.
- Verifier: same predicate via a new `memberSets.sharedStoreMemberIdsOf` port (wired in `container.ts`).
- `daemon` placements are unchanged: the one machine must still be the recorder.

## Tests

- Unit (`relay-connection.test.ts`): pool agent — rolled recorder / reaped recorder → continues through the live member; private-store recording → refused; dispatch member outside the store → refused.
- Integration (`relay-gateway.test.ts`): pool-recorded session with no recorder row → mint 200 + detail `canContinue: true`; clear `contentSetId` → 409 + `agent_moved`.
- CP unit suite 161 files / 1792 tests; integration `relay-gateway`, `session-metadata`, `sessions.history`, `session-visibility` (102 tests) green; typecheck / eslint / prettier clean.

Independent of #1263 (no shared files); together they close the pool-placement gap for both webchat resume and integration-session continuation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
