### PR TITLE
feat(observability): log why a webchat stream did not come back

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6375,6 +6375,12 @@ export class Daemon {
           op.afterIndex,
           sink
         )
+        // The one place that knows WHY a browser's stream did not come back — keep it in the log.
+        if (!resumed.accepted) {
+          this.log.info(
+            `webchat: resume of turn ${op.turnId} (gen ${op.generation}, after ${op.afterIndex}) for agent ${msg.agentId} in ${msg.chatId} refused: ${resumed.reason ?? 'unspecified'}`
+          )
+        }
         return {
           msgId: msg.msgId,
           accepted: resumed.accepted,

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -314,6 +314,26 @@ describe('RelayBrowserConnection', () => {
     })
   })
 
+  // A stream that "never came back" is diagnosed from these lines alone: who joined/left the
+  // conversation (with the close code), and which daemon refused a resume, and why.
+  it('logs the browser join/leave and every refused resume with the daemon and reason', async () => {
+    const turnId = '22222222-2222-4222-8222-222222222222'
+    const lines: string[] = []
+    const log: Logger = { debug: () => {}, info: (m) => lines.push(m), warn: (m) => lines.push(m), error: () => {} }
+    const { conn, transport } = build({
+      log,
+      ack: { msgId: 'resume-1', accepted: false, reason: 'stream_not_found' }
+    })
+    expect(lines[0]).toMatch(new RegExp(`browser joined conversation ${CHAT} \\(1 participant`))
+    transport.feed({ type: 'resume', turnId, generation: 4, afterIndex: 7 })
+    await tick()
+    expect(lines.at(-1)).toBe(
+      `webchat: resume ${turnId} for ${AGENT} in ${CHAT} refused by ${DAEMON}: stream_not_found`
+    )
+    conn['onClose'](1006, '')
+    expect(lines.at(-1)).toBe(`webchat: browser left conversation ${CHAT} (close 1006)`)
+  })
+
   it('translates an rd/chat output/done back to {type:output}/{type:done}', () => {
     const { conn, transport } = build()
     const outputPayload = { conversationId: CHAT, turnId: AGENT, index: 0, status: { model: 'claude' } }

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -221,6 +221,10 @@ export class RelayBrowserConnection implements ChatSink {
 
   start(): void {
     this.deps.register(this.deps.chatId, this)
+    this.deps.log.info(
+      `webchat: browser joined conversation ${this.deps.chatId} (${this.byAgentId.size} participant(s)` +
+        `${this.deps.targetSessionId ? `, continuing session ${this.deps.targetSessionId}` : ''})`
+    )
     // The client correlates its session on this frame (matches the old gateway).
     // `participants` is the verified roster, primary first.
     this.send({
@@ -233,7 +237,7 @@ export class RelayBrowserConnection implements ChatSink {
       }))
     })
     this.transport.onMessage((t) => this.onText(t))
-    this.transport.onClose(() => this.onClose())
+    this.transport.onClose((code, reason) => this.onClose(code, reason))
   }
 
   /** A reply chunk arrived from the daemon (routed here by chatId) → forward to the browser. */
@@ -363,6 +367,7 @@ export class RelayBrowserConnection implements ChatSink {
           }
         })
       } else if (kind === 'resume') {
+        this.deps.log.warn(`webchat: resume for ${agentId} in ${this.deps.chatId} has no live daemon to reach`)
         this.send({ type: 'resumed', ack: { accepted: false, agentId, reason: 'no_agent' } })
       }
       return
@@ -402,6 +407,12 @@ export class RelayBrowserConnection implements ChatSink {
         agentId,
         ...(ack.reason ? { reason: ack.reason } : {})
       }
+      // A refusal is the whole story of a stream that "never came back" — name it, and who refused.
+      if (!ack.accepted && (op.op === 'turn' || op.op === 'resume')) {
+        this.deps.log.info(
+          `webchat: ${op.op} ${op.turnId ?? '?'} for ${agentId} in ${this.deps.chatId} refused by ${daemonId}: ${ack.reason ?? 'unspecified'}`
+        )
+      }
       if (kind === 'turn') {
         this.send({ type: 'ack', ack: browserAck })
       } else if (kind === 'resume') {
@@ -432,8 +443,12 @@ export class RelayBrowserConnection implements ChatSink {
     this.transport.send(JSON.stringify(obj))
   }
 
-  private onClose(): void {
+  private onClose(code?: number, reason?: string): void {
     this.closed = true
+    // The close code is the one fact a "my stream never came back" report needs and nothing else records.
+    this.deps.log.info(
+      `webchat: browser left conversation ${this.deps.chatId} (close ${code ?? '?'}${reason ? ` ${reason}` : ''})`
+    )
     this.deps.unregister(this.deps.chatId, this)
     // Best-effort: tell every participant's daemon that the browser conversation closed.
     for (const p of this.byAgentId.values()) {


### PR DESCRIPTION
## What

Last of the set with #1263 / #1266 / #1267. When a browser's reply stream drops mid-turn and the resume is refused, nothing today says why: the relay logs neither the browser socket open/close (nor its close code) nor the daemon's resume verdict, and the daemon logs the verdict nowhere either. The incident behind these PRs had to be reconstructed from CP access-log timestamps and the daemon's replay-window source.

## How

**relay** (`relay-browser-connection.ts`)
- `webchat: browser joined conversation <id> (N participant(s)[, continuing session <acp id>])`
- `webchat: browser left conversation <id> (close <code> [reason])` — `ServerTransport.onClose` already carried code+reason; the connection just dropped them.
- `webchat: <turn|resume> <turnId> for <agent> in <conversation> refused by <daemon>: <reason>` for every daemon refusal.
- `warn` when a `resume` has no live daemon to reach at all.

**daemon** (`daemon.ts` `case 'resume'`)
- `webchat: resume of turn <id> (gen N, after M) for agent <a> in <conv> refused: <reason>`.

Ids only — no bodies, tokens, or remote addresses (relay log seam, design §14). Volume: one line per browser connect/disconnect and per refusal.

## Tests

`relay-browser-connection.test.ts`: join/leave lines (with close code) and the refused-resume line with daemon + reason. Relay suite 26 files / 503 tests; daemon `daemon-webchat.test.ts` 39 green; relay `tsc` (with freshly built workspace deps) clean; eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
