### PR TITLE
feat(dream): generate the staged index, and stop asking the model for one

### DIFF
--- a/packages/daemon/src/dream/dreamer.ts
+++ b/packages/daemon/src/dream/dreamer.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import { posix } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import { MAX_ORGANIZATION_SUGGESTION_BODY_BYTES, type SkillBundleTextFile } from '@agentconnect.md/protocol'
-import { MEMORY_INDEX, MAX_INDEX_INJECT_BYTES, MAX_MEMORY_FILE_BYTES } from '../memory/store.js'
+import { MEMORY_INDEX, MAX_MEMORY_FILE_BYTES } from '../memory/store.js'
 import { MEMORY_FORMAT_GUIDANCE } from '../memory/frontmatter.js'
 
 /**
@@ -73,7 +73,6 @@ export interface TrustedOrganizationSkillTarget {
 
 export interface DreamProposal {
   files: DreamProposalFile[]
-  index: string
   /** Empty unless the agent enabled `mineSkills` AND the model proposed some. */
   skills: DreamProposalSkill[]
   organizationKnowledge: DreamOrganizationKnowledgeProposal[]
@@ -145,7 +144,7 @@ Rebuild the memory store in four phases:
 1. Orient: read the existing store; understand its topics and index.
 2. Gather signal: mine the transcripts for corrections, preference shifts, decisions, and recurring patterns.
 3. Consolidate: merge duplicates; where entries contradict, keep the latest value; convert relative dates to absolute dates; drop transient task progress, pleasantries, and secrets.
-4. Prune and index: give every topic file a good \`description\` header — the index is GENERATED from those, so a weak description is what makes a memory unfindable later; demote verbose entries into topic files.
+4. Prune: give every topic file a good \`description\` header — the index is GENERATED from those, so a weak description is what makes a memory unfindable later; demote verbose entries into topic files.
 
 Rules:
 - Unlike per-turn distillation, you MAY rewrite, merge, and delete entries — but only inside the returned proposal.
@@ -160,15 +159,14 @@ ${MEMORY_FORMAT_GUIDANCE}
 
 - Never include credentials, tokens, or other secrets.
 - Return JSON only with four explicit categories:
-  {"agentMemory":{"index":"<full MEMORY.md text>","files":[{"path":"topic.md","content":"full file text"}]},"agentSkills":[],"organizationKnowledge":[],"organizationSkills":[]}.
-- agentMemory.index is always the complete, non-empty MEMORY.md text. It is a review preview: once adopted, the index is regenerated from the topic descriptions, so spend your effort on those rather than on index prose. When there are no persistent agent memories, return "# Memory\n\n_No persistent memories yet._\n" rather than an empty string.
+  {"agentMemory":{"files":[{"path":"topic.md","content":"full file text"}]},"agentSkills":[],"organizationKnowledge":[],"organizationSkills":[]}.
+- Do NOT write MEMORY.md. The index is generated from your files' \`description\` headers, so a good description is what makes a memory findable — that is where the effort belongs.
 - organizationKnowledge entries are owner-review proposals in exactly this shape: {"operation":"create|update","targetId":"uuid only for update","targetRevision":1,"title":"...","summary":"...","tags":["..."],"content":"Markdown","sessionIds":["..."]}. The citation property is named "sessionIds" (never "groundedSessionIds").
 - Propose organization knowledge only when it is reusable across multiple agents or represents a durable organization-wide convention. Agent-specific facts stay in agentMemory.
 - Before proposing organization knowledge, check what already exists with the listKnowledge / findKnowledge tools. If an existing entry covers the same subject, propose an "update" to its exact id/revision (never a near-duplicate "create").
 - PRIVACY: transcripts may include private or one-to-one exchanges (DMs, webchat, external, or A2A). Agent memory is shared with everyone who can use this agent, and organization knowledge is shared more widely still — a later session with a DIFFERENT person can read what you write. So NEVER record a specific person's private or personal conversation content, nor anything attributable to one person's private exchange, in agentMemory OR organizationKnowledge. Distill only general, durable, non-personal operating knowledge: how this agent works, stable preferences, conventions, and reusable procedures — never one individual's private/personal exchange.
 - Cite organization knowledge in at least one mined session. Use only session ids taken from a session file's "session:" header line.
 - Return organizationSkills as [] unless the additional extract-procedures phase below is present.
-- The index must reference only files present in "files".
 - Return the smallest faithful store, not the largest possible one.`
 
 /** Appended only when the agent enabled `mineSkills`, so executable procedure
@@ -326,7 +324,7 @@ export function parseDreamProposal(text: string, minedSessionIds: readonly strin
     envelope.agentMemory && typeof envelope.agentMemory === 'object'
       ? (envelope.agentMemory as Record<string, unknown>)
       : envelope
-  if (typeof memory.index !== 'string' || !Array.isArray(memory.files)) return null
+  if (!Array.isArray(memory.files)) return null
 
   const seen = new Set<string>([MEMORY_INDEX])
   const files: DreamProposalFile[] = []
@@ -350,19 +348,10 @@ export function parseDreamProposal(text: string, minedSessionIds: readonly strin
     if (files.length >= MAX_DREAM_FILES) break
   }
 
-  const rawIndex = memory.index.trim()
-  // A brand-new managed store legitimately has no index yet. Models commonly
-  // represent that as an empty string even when they produced valid independent
-  // organization proposals. Keep a blank store adoptable with a daemon-owned,
-  // deterministic sentinel, but never paper over a blank index when topic files
-  // exist (that would orphan substantive memory content on auto-adopt).
-  if (!rawIndex && files.length > 0) return null
-  const index = rawIndex
-    ? clampToBytesOnBoundary(rawIndex, MAX_INDEX_INJECT_BYTES - 1)
-    : '# Memory\n\n_No persistent memories yet._'
+  // No index is read from the model: staging generates MEMORY.md from these files'
+  // descriptions, exactly as adoption will, so what a reviewer sees is what installs.
   return {
     files,
-    index: index + '\n',
     skills: parseDreamSkills(envelope.agentSkills ?? envelope.skills, minedSessionIds),
     organizationKnowledge: parseOrganizationKnowledge(envelope.organizationKnowledge, minedSessionIds),
     organizationSkills: parseOrganizationSkills(envelope.organizationSkills, minedSessionIds)

--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -20,10 +20,12 @@ import {
   OrganizationSuggestionContentBody,
   organizationSuggestionCanonical
 } from '@agentconnect.md/protocol'
-import { normalizeMemoryHeader } from '../memory/frontmatter.js'
+import { memoryNameForTopic, normalizeMemoryHeader, parseMemoryFrontmatter } from '../memory/frontmatter.js'
 import {
   MEMORY_INDEX,
+  renderMemoryIndex,
   regenerateMemoryIndexHoldingLock,
+  type MemoryIndexEntry,
   MEMORY_HISTORY_FILENAME,
   MAX_INDEX_INJECT_BYTES,
   MAX_MEMORY_FILE_BYTES,
@@ -796,7 +798,7 @@ export class DreamRunner {
     const out = join(base, 'output')
     await fs.rm(out)
     await fs.mkdir(out)
-    await fs.writeFile(join(out, MEMORY_INDEX), proposal.index)
+    const staged: MemoryIndexEntry[] = []
     for (const file of proposal.files) {
       // parseDreamProposal already enforced TOPIC_RE — belt and suspenders here
       // because these names become filesystem paths.
@@ -804,8 +806,19 @@ export class DreamRunner {
       // The dream writes frontmatter as free text, so re-render its known scalars through
       // the shared quoting rule before staging — a description holding `: ` or ` #` would
       // otherwise be invalid YAML, and auto-adopt would make that malformed topic live.
-      await fs.writeFile(join(out, file.path), normalizeMemoryHeader(file.content))
+      const content = normalizeMemoryHeader(file.content)
+      await fs.writeFile(join(out, file.path), content)
+      const { header } = parseMemoryFrontmatter(content)
+      staged.push({
+        topic: file.path,
+        name: header.name || memoryNameForTopic(file.path),
+        description: header.description ?? ''
+      })
     }
+    // Generate the staged index the same way adoption will, rather than staging the
+    // model's hand-written one: otherwise the index a human reviews is not the index
+    // that ends up installed.
+    await fs.writeFile(join(out, MEMORY_INDEX), renderMemoryIndex(staged))
     await this.stageSkills(fs, base, proposal)
     return this.stageOrganizationSuggestions(fs, base, proposal)
   }

--- a/packages/daemon/src/memory/store.ts
+++ b/packages/daemon/src/memory/store.ts
@@ -639,7 +639,12 @@ export function renderMemoryIndex(entries: MemoryIndexEntry[], heading = '# Memo
   const lines: string[] = []
   let budget = MAX_MEMORY_FILE_BYTES - Buffer.byteLength(prefix) - Buffer.byteLength(INDEX_OVERFLOW_NOTICE) - 1
   let dropped = 0
-  for (const entry of [...entries].sort((a, b) => a.name.localeCompare(b.name))) {
+  // Tie-break on the topic filename, which is unique within a store: two entries can
+  // share a display `name`, and staging feeds proposal order while live regeneration
+  // feeds directory order — without this the reviewed index would not be byte-stable
+  // through adoption, which is the whole point of sharing this renderer.
+  const ordered = [...entries].sort((a, b) => a.name.localeCompare(b.name) || a.topic.localeCompare(b.topic))
+  for (const entry of ordered) {
     const line = `- [${entry.name}](${entry.topic})${entry.description ? ` — ${entry.description}` : ''}`
     const cost = Buffer.byteLength(line) + 1
     if (cost > budget) {

--- a/packages/daemon/src/memory/store.ts
+++ b/packages/daemon/src/memory/store.ts
@@ -620,6 +620,38 @@ const GENERATED_INDEX_MARKER = "<!-- generated from each topic's `description` h
  * to generate from, and a legacy hand-written index is left untouched. The previous
  * index is recorded in `.history` by the caller's own write path, and here on replace.
  */
+/** One topic as the index sees it. */
+export interface MemoryIndexEntry {
+  topic: string
+  name: string
+  description: string
+}
+
+/**
+ * Render `MEMORY.md` from the topic descriptions. Pure, so the live store and a
+ * dream's STAGED store produce byte-identical indexes — a reviewer then sees exactly
+ * the index adoption will install, instead of a hand-written one that gets replaced.
+ * Entries are budgeted against the managed file bound and the overflow is stated
+ * in-file rather than silently dropped.
+ */
+export function renderMemoryIndex(entries: MemoryIndexEntry[], heading = '# Memory'): string {
+  const prefix = `${heading}\n\n${GENERATED_INDEX_MARKER}\n\n`
+  const lines: string[] = []
+  let budget = MAX_MEMORY_FILE_BYTES - Buffer.byteLength(prefix) - Buffer.byteLength(INDEX_OVERFLOW_NOTICE) - 1
+  let dropped = 0
+  for (const entry of [...entries].sort((a, b) => a.name.localeCompare(b.name))) {
+    const line = `- [${entry.name}](${entry.topic})${entry.description ? ` — ${entry.description}` : ''}`
+    const cost = Buffer.byteLength(line) + 1
+    if (cost > budget) {
+      dropped++
+      continue
+    }
+    budget -= cost
+    lines.push(line)
+  }
+  return `${prefix}${lines.join('\n')}\n${dropped > 0 ? INDEX_OVERFLOW_NOTICE : ''}`
+}
+
 export async function regenerateMemoryIndexHoldingLock(
   fs: MemoryFs,
   source: MemoryWriteSource,
@@ -647,22 +679,7 @@ export async function regenerateMemoryIndexHoldingLock(
   if (!owned && !opts.force && !entries.some((entry) => entry.description)) return
 
   const heading = /^#[ \t]+.*$/m.exec(current?.content ?? '')?.[0] ?? '# Memory'
-  const prefix = `${heading}\n\n${GENERATED_INDEX_MARKER}\n\n`
-  const lines: string[] = []
-  let budget = MAX_MEMORY_FILE_BYTES - Buffer.byteLength(prefix) - Buffer.byteLength(INDEX_OVERFLOW_NOTICE) - 1
-  let dropped = 0
-  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    const line = `- [${entry.name}](${entry.topic})${entry.description ? ` — ${entry.description}` : ''}`
-    const cost = Buffer.byteLength(line) + 1
-    // The generated file is subject to the same managed bound as any other write.
-    if (cost > budget) {
-      dropped++
-      continue
-    }
-    budget -= cost
-    lines.push(line)
-  }
-  const next = `${prefix}${lines.join('\n')}\n${dropped > 0 ? INDEX_OVERFLOW_NOTICE : ''}`
+  const next = renderMemoryIndex(entries, heading)
   if (current?.content === next) return
 
   const st = await fs.writeFile(`${MEMORY_DIRNAME}/${MEMORY_INDEX}`, next, {})

--- a/packages/daemon/test/memory-dreamer.test.ts
+++ b/packages/daemon/test/memory-dreamer.test.ts
@@ -106,7 +106,6 @@ describe('dream proposal parsing', () => {
       const proposal = parseDreamProposal(text)
       expect(proposal?.files).toHaveLength(1)
       expect(proposal?.files[0]).toMatchObject({ path: 'prefs.md' })
-      expect(proposal?.index.startsWith('# Memory')).toBe(true)
     }
   })
 
@@ -149,16 +148,14 @@ describe('dream proposal parsing', () => {
   it('parses a fenced proposal that trails prose after the JSON', () => {
     const proposal = parseDreamProposal(`\`\`\`json\n${good}\n\`\`\`\n\nThat covers it — nothing else stood out.`)
     expect(proposal?.files).toHaveLength(1)
-    expect(proposal?.index.startsWith('# Memory')).toBe(true)
   })
 
-  it('returns null for unparseable or index-less replies, but normalizes a genuinely empty store', () => {
+  it('returns null only for unparseable replies — an absent index is now expected', () => {
     expect(parseDreamProposal('no json at all')).toBeNull()
-    expect(parseDreamProposal('{"files": []}')).toBeNull()
-    expect(parseDreamProposal(JSON.stringify({ index: '   ', files: [] }))?.index).toBe(
-      '# Memory\n\n_No persistent memories yet._\n'
-    )
-    expect(parseDreamProposal(JSON.stringify({ index: '   ', files: [{ path: 'topic.md', content: 'x' }] }))).toBeNull()
+    // An empty store is valid and adoptable — staging renders an index for it.
+    expect(parseDreamProposal(JSON.stringify({ files: [] }))?.files).toEqual([])
+    // A proposal with files and no index is valid now: staging generates the index.
+    expect(parseDreamProposal(JSON.stringify({ files: [{ path: 'topic.md', content: 'x' }] }))?.files).toHaveLength(1)
   })
 
   it('drops traversal paths, bad names, duplicates, and the index masquerading as a file', () => {
@@ -201,10 +198,8 @@ describe('dream proposal parsing', () => {
     )
     expect(proposal).not.toBeNull()
     expect(Buffer.byteLength(proposal!.files[0]!.content)).toBeLessThanOrEqual(256_000)
-    expect(Buffer.byteLength(proposal!.index)).toBeLessThanOrEqual(25_000)
     // No replacement character introduced by a mid-codepoint cut.
     expect(proposal!.files[0]!.content).not.toContain('�')
-    expect(proposal!.index).not.toContain('�')
   })
 })
 
@@ -295,7 +290,8 @@ describe('structured organization proposals', () => {
       })
 
     const proposal = parseDreamProposal(reply, ['sess-1', 'sess-2'])
-    expect(proposal?.index).toBe('# Memory\n\n_No persistent memories yet._\n')
+    // The model no longer supplies an index at all; staging renders one.
+    expect(proposal?.files).toEqual([])
     expect(proposal?.organizationKnowledge).toMatchObject([{ sessionIds: ['sess-1'] }])
     expect(proposal?.organizationSkills).toMatchObject([
       { title: 'incident-rollback', sessionIds: ['sess-1', 'sess-2'] }
@@ -551,7 +547,8 @@ describe('mined skill candidates', () => {
     expect(dreamSystemPrompt(true)).toContain('complete Agent Skills file tree')
     expect(dreamSystemPrompt(true)).toContain('listOrgSkills')
     expect(dreamSystemPrompt(true)).toContain('never "groundedSessionIds"')
-    expect(dreamSystemPrompt(true)).toContain('agentMemory.index is always the complete, non-empty MEMORY.md text')
+    // The policy now tells it NOT to write the index — descriptions drive it.
+    expect(dreamSystemPrompt(true)).toContain('Do NOT write MEMORY.md')
     expect(dreamSystemPrompt(true).startsWith(MEMORY_DREAM_SYSTEM_PROMPT)).toBe(true)
   })
 })

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -403,6 +403,18 @@ describe('one format text, every trigger', () => {
 })
 
 describe('the reviewed index is the adopted index', () => {
+  it('is byte-stable when two topics share a display name, whatever order they arrive in', () => {
+    // `name` comes from the header and need not be unique; staging feeds proposal
+    // order while live regeneration feeds directory order. Without a filename
+    // tie-breaker the reviewed index would differ from the adopted one.
+    const a = { topic: 'a-notes.md', name: 'notes', description: 'from a' }
+    const b = { topic: 'b-notes.md', name: 'notes', description: 'from b' }
+    expect(renderMemoryIndex([a, b])).toBe(renderMemoryIndex([b, a]))
+    expect(renderMemoryIndex([b, a]).indexOf('a-notes.md')).toBeLessThan(
+      renderMemoryIndex([b, a]).indexOf('b-notes.md')
+    )
+  })
+
   it('renders staged and live indexes identically from the same descriptions', async () => {
     // A dream used to stage a hand-written MEMORY.md while adoption regenerated one,
     // so a reviewer could approve an index that never installed. Both sides now go

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -24,6 +24,7 @@ import {
   memoryNeighbors,
   readMemoryFile,
   regenerateMemoryIndexHoldingLock,
+  renderMemoryIndex,
   writeMemoryFile,
   memoryChannelKey
 } from '../src/memory/store.js'
@@ -398,5 +399,35 @@ describe('one format text, every trigger', () => {
     expect(MEMORY_DISTILLATION_SYSTEM_PROMPT).toContain(MEMORY_FORMAT_GUIDANCE)
     expect(dreamSystemPrompt(false)).toContain(MEMORY_FORMAT_GUIDANCE)
     expect(dreamSystemPrompt(true)).toContain(MEMORY_FORMAT_GUIDANCE)
+  })
+})
+
+describe('the reviewed index is the adopted index', () => {
+  it('renders staged and live indexes identically from the same descriptions', async () => {
+    // A dream used to stage a hand-written MEMORY.md while adoption regenerated one,
+    // so a reviewer could approve an index that never installed. Both sides now go
+    // through the same renderer.
+    const entries = [
+      { topic: 'zeta.md', name: 'zeta', description: 'last one' },
+      { topic: 'alpha.md', name: 'alpha', description: 'first one' }
+    ]
+    const stagedIndex = renderMemoryIndex(entries)
+
+    // Build the same store for real and let the live path generate its index.
+    const f = fs()
+    await ensureMemory(f, 'bot')
+    for (const e of entries) {
+      await writeMemoryFile(f, e.topic, `---\ndescription: ${e.description}\n---\nbody\n`, undefined, 'dream')
+    }
+    const liveIndex = await readMemoryFile(f, 'MEMORY.md')
+
+    // Same entries, same order, same marker — only the heading differs, since the
+    // live store keeps the agent's own `# bot memory` title.
+    for (const line of ['- [alpha](alpha.md) — first one', '- [zeta](zeta.md) — last one']) {
+      expect(stagedIndex).toContain(line)
+      expect(liveIndex).toContain(line)
+    }
+    expect(stagedIndex.indexOf('alpha')).toBeLessThan(stagedIndex.indexOf('zeta'))
+    expect(liveIndex.replace(/^# .*$/m, '')).toBe(stagedIndex.replace(/^# .*$/m, ''))
   })
 })


### PR DESCRIPTION
Items 1 and 2 of the three @pchsu approved. Item 3 (dream writing the staged root through the shared memory tools) is separate and follows.

## The bug this fixes

A reviewer could approve an index that never installed. The staged `MEMORY.md` was **written by the model**, while adoption **regenerates** it from the topic descriptions (#1256) — same store, two different indexes: the one you read and the one you get.

Staging now renders `MEMORY.md` through the same code adoption uses, so review shows exactly what lands. `renderMemoryIndex` is extracted as a pure function shared by both paths, which also gives staging the managed size bound and in-file overflow notice for free.

## And the model stops writing one

With the index derived, `agentMemory.index` is gone from the proposal type, the parser, and the prompt's JSON shape; the policy now says plainly **not** to write `MEMORY.md`, because a good `description` is what makes a memory findable. That also drops a large redundant blob from every dream's output.

## Correction on scope

I'd told @pchsu twice that retiring this field would "change the contract across protocol/CP/web." **That was wrong**, and checking it is what surfaced the review-vs-adopt bug above. `index` was a daemon-internal interface plus a line in the model's JSON convention — it appears nowhere in protocol, CP, or web, because the console reviews staged **files**. Nothing outside the daemon changes here.

## Tests

Staged and live indexes render identically from the same descriptions; an absent index is now valid (including an empty store); the policy instructs the model not to write one. Memory + dream + evaluation + channel + write-gate suites green (8 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)