### PR TITLE
feat(webchat): let a conversation be continued by the session's visibility, not only its owner

### DIFF
--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -383,7 +383,9 @@ session read policy; the merge renders what comes back:
   conversation resumes through the existing conversation-token mint, which
   already requires _all_ participants viewable. A caller with partial view
   gets a read-only merged page with the standard error on send.
-- The webchat per-conversation privacy model (owner-private by default) and
+- The webchat per-conversation privacy model (private by default; the owner
+  may make a session org-visible, which also lets other non-viewer members
+  continue the conversation) and
   Slack's org-visible default both pass through untouched — the merged page is
   as visible as its most visible member session, because that is literally
   what it fetches.

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -446,8 +446,12 @@ rules remain in
 
 A webchat browser presents a short-lived CP-minted token. For a new
 conversation, CP allocates its id and persists only the ownership tuple
-`(conversationId, userId, agentId, orgId)`. A resume mint succeeds only when
-that tuple matches the authenticated caller; unknown and foreign ids fail
+`(conversationId, userId, agentId, orgId)`. A resume mint succeeds for the
+owner of that tuple, and for any other non-viewer member whom the
+`session.continue` policy admits to every session the conversation currently
+stands on (an org-visible session is continuable by the organization; a
+private one stays its owner's, and a conversation with no turn yet has no
+session to judge, so it is the owner's alone); unknown and foreign ids fail
 closed. The token carries the authorized conversation id, and the relay uses
 that token-bound value rather than trusting the browser query. It then resolves
 the agent's current daemon placement and bridges browser turns and daemon

--- a/docs/designs/webchat-preset-agentconnect-mcp.md
+++ b/docs/designs/webchat-preset-agentconnect-mcp.md
@@ -587,8 +587,13 @@ tools are unavailable.
 
 ### 10.2 Resume
 
-Resume succeeds only for the same authenticated owner, organization, agent, and
-conversation. The CP keeps the current logical authority generation, while the
+Resume succeeds for the conversation owner, and for any other non-viewer
+member the `session.continue` policy admits to every session the conversation
+currently stands on (org-visible sessions; private ones stay owner-only). The
+delegated admin MCP is owner-only regardless: the authority resolver fences the
+token's user against the conversation owner, so a non-owner's turns run without
+the `agentconnect-admin` entitlement. The CP keeps the current logical authority
+generation for the owner, while the
 daemon completes a fresh revision-fenced grant activation because stored hashes
 cannot be re-delivered when the daemon no longer retains the active credential.
 An ordinary browser reconnect does not itself rotate the credential: all tabs share

--- a/packages/control-plane/src/http/routes/webchat-token.ts
+++ b/packages/control-plane/src/http/routes/webchat-token.ts
@@ -98,9 +98,11 @@ export function webchatTokenRoutes(deps: HttpDeps) {
     }
 
     /** Who may RESUME a conversation: its owner always; anyone else under the same `session.continue` policy an
-     *  integration-origin session gets — every participant's current session visible to them and a non-viewer
-     *  role, private sessions owner-only. Before the first turn there is no session to judge, so it is the owner's.
-     *  Unknown and foreign ids read as null, exactly like a refusal. */
+     *  integration-origin session gets — EVERY participant's current session visible to them and a non-viewer
+     *  role, private sessions owner-only. A participant with no session yet (before the first turn, or a peer a
+     *  targeted turn skipped) has nothing to judge, and the socket would let the caller target it into a session
+     *  that is default-private to the owner — so any missing slot keeps the conversation the owner's. Unknown
+     *  and foreign ids read as null, exactly like a refusal. */
     const resumableBy = async (
       req: Parameters<typeof ctxOf>[0] & { principal?: { userId: string } },
       conversationId: string
@@ -109,8 +111,9 @@ export function webchatTokenRoutes(deps: HttpDeps) {
       if (!binding) return null
       const resumable = { primaryAgentId: binding.primaryAgentId }
       if (binding.ownerUserId === req.principal!.userId) return resumable
-      if (binding.currentSessionIds.length === 0) return null
-      const sessions = await Promise.all(binding.currentSessionIds.map((id) => deps.repos.session.get(orgOf(req), id)))
+      const ids = binding.currentSessionIds.filter((id): id is SessionId => id !== null)
+      if (ids.length === 0 || ids.length !== binding.currentSessionIds.length) return null
+      const sessions = await Promise.all(ids.map((id) => deps.repos.session.get(orgOf(req), id)))
       const rows = sessions.filter((s) => s !== null)
       if (rows.length !== sessions.length) return null
       const access = await sessionAccess.forSessions(req, rows)

--- a/packages/control-plane/src/http/routes/webchat-token.ts
+++ b/packages/control-plane/src/http/routes/webchat-token.ts
@@ -97,6 +97,27 @@ export function webchatTokenRoutes(deps: HttpDeps) {
       return true
     }
 
+    /** Who may RESUME a conversation: its owner always; anyone else under the same `session.continue` policy an
+     *  integration-origin session gets — every participant's current session visible to them and a non-viewer
+     *  role, private sessions owner-only. Before the first turn there is no session to judge, so it is the owner's.
+     *  Unknown and foreign ids read as null, exactly like a refusal. */
+    const resumableBy = async (
+      req: Parameters<typeof ctxOf>[0] & { principal?: { userId: string } },
+      conversationId: string
+    ): Promise<{ primaryAgentId: AgentId } | null> => {
+      const binding = await deps.repos.webchatConversation.resumeBinding(conversationId, orgOf(req))
+      if (!binding) return null
+      const resumable = { primaryAgentId: binding.primaryAgentId }
+      if (binding.ownerUserId === req.principal!.userId) return resumable
+      if (binding.currentSessionIds.length === 0) return null
+      const sessions = await Promise.all(binding.currentSessionIds.map((id) => deps.repos.session.get(orgOf(req), id)))
+      const rows = sessions.filter((s) => s !== null)
+      if (rows.length !== sessions.length) return null
+      const access = await sessionAccess.forSessions(req, rows)
+      const ctx = ctxOf(req)
+      return rows.every((s) => canContinueSession(s, ctx, access.identitySet, access.externalAccess)) ? resumable : null
+    }
+
     r.post(
       '/agents/:agentId/webchat/token',
       {
@@ -105,7 +126,7 @@ export function webchatTokenRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'Mint a webchat token',
           description:
-            'Mints a short-lived token the browser presents to the relay pool to start or resume a playground webchat session with this agent. A resume is allowed only for a conversation already owned by the authenticated user.',
+            'Mints a short-lived token the browser presents to the relay pool to start or resume a playground webchat session with this agent. A resume is allowed for the conversation owner, and for any non-viewer member who may continue every session it currently stands on (org-visible sessions; private ones stay owner-only).',
           operationId: 'mintWebchatToken',
           params: Params,
           body: Body,
@@ -128,8 +149,10 @@ export function webchatTokenRoutes(deps: HttpDeps) {
         const conversationId = req.body.conversationId?.toLowerCase() ?? randomUUID()
         const binding = { conversationId, userId, agentId: agent.id, orgId: agent.orgId }
         if (req.body.conversationId) {
+          // The asserted agent must be the conversation's primary on this per-agent path.
+          const resumable = await resumableBy(req, conversationId)
           if (
-            !(await deps.repos.webchatConversation.owns(binding)) ||
+            resumable?.primaryAgentId !== agent.id ||
             !(await allParticipantsViewable(conversationId, agent.orgId, ctxOf(req)))
           ) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'conversation not found' })
@@ -237,7 +260,7 @@ export function webchatTokenRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'Mint a conversation webchat token',
           description:
-            'Mints a short-lived token the browser presents to the relay pool. Pass `agentIds` (first entry is the primary) to create a conversation — the roster is fixed at creation — or `conversationId` to resume one owned by the authenticated user. Creating with more than one agent requires every selected agent to be placed on a daemon that supports multi-agent webchat.',
+            'Mints a short-lived token the browser presents to the relay pool. Pass `agentIds` (first entry is the primary) to create a conversation — the roster is fixed at creation — or `conversationId` to resume one — as its owner, or as any non-viewer member who may continue every session it currently stands on (org-visible sessions; private ones stay owner-only). Creating with more than one agent requires every selected agent to be placed on a daemon that supports multi-agent webchat.',
           operationId: 'mintWebchatConversationToken',
           params: ConversationParams,
           body: ConversationBody,
@@ -256,14 +279,14 @@ export function webchatTokenRoutes(deps: HttpDeps) {
 
         if (req.body.conversationId) {
           const conversationId = req.body.conversationId.toLowerCase()
-          const owned = await deps.repos.webchatConversation.ownedBy(conversationId, orgId, userId)
-          if (!owned) {
+          const resumable = await resumableBy(req, conversationId)
+          if (!resumable) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'conversation not found' })
           }
           // EVERY participant must still be viewable — the minted token exposes
           // and targets the full roster, so losing access to one restricted
           // member revokes resume for the whole conversation.
-          const primary = await deps.repos.agent.get(orgOf(req), owned.primaryAgentId)
+          const primary = await deps.repos.agent.get(orgOf(req), resumable.primaryAgentId)
           if (
             !primary ||
             primary.orgId !== orgId ||

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1443,8 +1443,9 @@ export interface WebchatParticipant {
 export interface WebchatResumeBinding {
   primaryAgentId: AgentId
   ownerUserId: string
-  /** Every participant's current session (the conversation's own pointer on a pre-roster row); empty before the first turn. */
-  currentSessionIds: SessionId[]
+  /** One slot per roster participant — null until that participant has a session (a partial roster is normal: a
+   *  targeted turn or a refused delivery leaves peers unmaterialized); the conversation's own pointer on a pre-roster row. */
+  currentSessionIds: Array<SessionId | null>
 }
 
 export interface WebchatConversationRepo {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1439,6 +1439,14 @@ export interface WebchatParticipant {
   role: 'primary' | 'member'
 }
 
+/** What a resume mint authorizes against: the owner, and the sessions the conversation currently stands on. */
+export interface WebchatResumeBinding {
+  primaryAgentId: AgentId
+  ownerUserId: string
+  /** Every participant's current session (the conversation's own pointer on a pre-roster row); empty before the first turn. */
+  currentSessionIds: SessionId[]
+}
+
 export interface WebchatConversationRepo {
   /** Register a server-allocated conversation before its first relay dial.
    *  `binding.agentId` is the PRIMARY; `memberAgentIds` are the remaining
@@ -1468,6 +1476,10 @@ export interface WebchatConversationRepo {
   /** Owner check for the conversation-scoped mint path: returns the primary
    *  agent when (conversationId, orgId, userId) matches, else null. */
   ownedBy(conversationId: string, orgId: OrgId, userId: string): Promise<{ primaryAgentId: AgentId } | null>
+  /** The resume-authorization subject of a conversation (null = unknown/foreign): its owner plus the
+   *  current session of every participant, which the `session.continue` policy is applied to for
+   *  anyone who is not the owner. */
+  resumeBinding(conversationId: string, orgId: OrgId): Promise<WebchatResumeBinding | null>
   /** Session-targeted continuation (webchat-cross-integration-continuation.md
    *  §6.2): find-or-create the caller's ONE conversation adopting
    *  `targetSessionId` — concurrent mints converge on the

--- a/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.ts
@@ -9,8 +9,13 @@
 import { randomUUID } from 'node:crypto'
 import type { PrismaClient, Prisma } from '../../generated/prisma/client.js'
 import type { PrismaLike } from '../prisma.js'
-import type { WebchatConversationBinding, WebchatConversationRepo, WebchatParticipant } from '../ports.js'
-import { AgentId, type OrgId } from '../../domain/ids.js'
+import type {
+  WebchatConversationBinding,
+  WebchatConversationRepo,
+  WebchatParticipant,
+  WebchatResumeBinding
+} from '../ports.js'
+import { AgentId, SessionId, type OrgId } from '../../domain/ids.js'
 
 /** CP-minted webchat conversation ids are UUIDs. Daemon-local A2A children can
  * retain `platform: webchat` while using an `a2a:<caller>` channel; repository
@@ -122,6 +127,28 @@ export class PgWebchatConversationRepo implements WebchatConversationRepo {
       select: { id: true }
     })
     return row !== null
+  }
+
+  async resumeBinding(conversationId: string, orgId: OrgId): Promise<WebchatResumeBinding | null> {
+    if (!UUID_RE.test(conversationId)) return null
+    const row = await this.db.webchatConversation.findFirst({
+      where: { id: conversationId, orgId },
+      select: {
+        agentId: true,
+        userId: true,
+        currentSessionId: true,
+        participants: { select: { currentSessionId: true } }
+      }
+    })
+    if (!row) return null
+    // Every participant's own pointer, with the conversation's as the pre-roster fallback.
+    const sessionIds = row.participants.map((p) => p.currentSessionId).filter((id): id is string => id !== null)
+    if (sessionIds.length === 0 && row.currentSessionId) sessionIds.push(row.currentSessionId)
+    return {
+      primaryAgentId: AgentId(row.agentId),
+      ownerUserId: row.userId,
+      currentSessionIds: [...new Set(sessionIds)].map((id) => SessionId(id))
+    }
   }
 
   async ownedBy(conversationId: string, orgId: OrgId, userId: string): Promise<{ primaryAgentId: AgentId } | null> {

--- a/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.ts
@@ -141,14 +141,13 @@ export class PgWebchatConversationRepo implements WebchatConversationRepo {
       }
     })
     if (!row) return null
-    // Every participant's own pointer, with the conversation's as the pre-roster fallback.
-    const sessionIds = row.participants.map((p) => p.currentSessionId).filter((id): id is string => id !== null)
-    if (sessionIds.length === 0 && row.currentSessionId) sessionIds.push(row.currentSessionId)
-    return {
-      primaryAgentId: AgentId(row.agentId),
-      ownerUserId: row.userId,
-      currentSessionIds: [...new Set(sessionIds)].map((id) => SessionId(id))
-    }
+    // One slot per roster participant, null where that participant has not materialized a session
+    // yet (a partial roster is a normal state); the conversation's own pointer only on a pre-roster row.
+    const currentSessionIds =
+      row.participants.length > 0
+        ? row.participants.map((p) => (p.currentSessionId === null ? null : SessionId(p.currentSessionId)))
+        : [row.currentSessionId === null ? null : SessionId(row.currentSessionId)]
+    return { primaryAgentId: AgentId(row.agentId), ownerUserId: row.userId, currentSessionIds }
   }
 
   async ownedBy(conversationId: string, orgId: OrgId, userId: string): Promise<{ primaryAgentId: AgentId } | null> {

--- a/packages/control-plane/test/integration/relay-gateway.test.ts
+++ b/packages/control-plane/test/integration/relay-gateway.test.ts
@@ -191,6 +191,15 @@ function mintWebchatToken(app: App, agentId: string, body: Record<string, unknow
   })
 }
 
+/** POST the conversation-scoped mint route as the devAuth owner (org-scoped). */
+function mintConversationToken(app: App, body: Record<string, unknown>) {
+  return app.http.inject({
+    method: 'POST',
+    url: `/api/v1/orgs/${DEFAULT_ORG_ID}/webchat/conversations/token`,
+    payload: body
+  })
+}
+
 async function verifyWebchat(
   base: string,
   token: string,
@@ -455,7 +464,7 @@ describe('relay control gateway — rc/* handshake over agentconnect.rc.v1', () 
     expect(body.conversationId).toMatch(/^[0-9a-f-]{36}$/) // a fresh conversation id
   })
 
-  it('POST …/webchat/token resumes only a conversation bound to the caller', async () => {
+  it('POST …/webchat/token resumes the caller’s own conversation; unknown ids and another member’s turnless one are 404', async () => {
     const { app } = await start({ PUBLIC_RELAY_URL: RELAY_URL })
     await seedAgent(prisma, AGENT)
     const fresh = await mintWebchatToken(app, AGENT)
@@ -467,6 +476,7 @@ describe('relay control gateway — rc/* handshake over agentconnect.rc.v1', () 
 
     expect((await mintWebchatToken(app, AGENT, { conversationId: randomUUID() })).statusCode).toBe(404)
 
+    // Another member's conversation that has not had a turn yet stands on no session: owner-only.
     const otherUserId = 'usr_webchat_victim'
     await prisma.user.create({ data: { id: otherUserId, email: 'webchat-victim@example.test' } })
     await prisma.membership.create({ data: { orgId: DEFAULT_ORG_ID, userId: otherUserId, role: 'collaborator' } })
@@ -475,6 +485,50 @@ describe('relay control gateway — rc/* handshake over agentconnect.rc.v1', () 
       data: { id: otherConversationId, orgId: DEFAULT_ORG_ID, agentId: AGENT, userId: otherUserId }
     })
     expect((await mintWebchatToken(app, AGENT, { conversationId: otherConversationId })).statusCode).toBe(404)
+  })
+
+  // Resume follows the session's visibility, exactly like an integration-origin continuation
+  // (policy `session.continue`): a conversation whose current session its owner made org-visible
+  // is every non-viewer member's to continue; a private one stays the owner's.
+  it('resumes another member’s conversation by the visibility of the session it stands on', async () => {
+    const { app } = await start({ PUBLIC_RELAY_URL: RELAY_URL })
+    await seedAgent(prisma, AGENT)
+    const otherUserId = 'usr_webchat_sharer'
+    await prisma.user.create({ data: { id: otherUserId, email: 'webchat-sharer@example.test' } })
+    await prisma.membership.create({ data: { orgId: DEFAULT_ORG_ID, userId: otherUserId, role: 'collaborator' } })
+    const seedConversation = async (visibility: 'org' | 'private'): Promise<string> => {
+      const conversationId = randomUUID()
+      const sessionId = `acp-${visibility}-${conversationId.slice(0, 8)}`
+      await prisma.webchatConversation.create({
+        data: { id: conversationId, orgId: DEFAULT_ORG_ID, agentId: AGENT, userId: otherUserId }
+      })
+      await seedSessionMeta(prisma, sessionId, AGENT, {
+        platform: 'webchat',
+        channel: conversationId,
+        visibility,
+        ownerIdentity: `user:${otherUserId}`
+      })
+      await prisma.webchatConversation.update({ where: { id: conversationId }, data: { currentSessionId: sessionId } })
+      await prisma.webchatConversationAgent.create({
+        data: {
+          conversationId,
+          agentId: AGENT,
+          role: 'primary',
+          ord: 0,
+          addedByUserId: otherUserId,
+          currentSessionId: sessionId
+        }
+      })
+      return conversationId
+    }
+    const shared = await seedConversation('org')
+    const kept = await seedConversation('private')
+
+    // Both mint paths agree: the per-agent legacy route and the conversation-scoped one.
+    expect((await mintWebchatToken(app, AGENT, { conversationId: shared })).statusCode).toBe(200)
+    expect((await mintConversationToken(app, { conversationId: shared })).statusCode).toBe(200)
+    expect((await mintWebchatToken(app, AGENT, { conversationId: kept })).statusCode).toBe(404)
+    expect((await mintConversationToken(app, { conversationId: kept })).statusCode).toBe(404)
   })
 
   it('POST …/webchat/token → 503 when no relay pool is configured (PUBLIC_RELAY_URL unset)', async () => {

--- a/packages/control-plane/test/integration/relay-gateway.test.ts
+++ b/packages/control-plane/test/integration/relay-gateway.test.ts
@@ -529,6 +529,31 @@ describe('relay control gateway — rc/* handshake over agentconnect.rc.v1', () 
     expect((await mintConversationToken(app, { conversationId: shared })).statusCode).toBe(200)
     expect((await mintWebchatToken(app, AGENT, { conversationId: kept })).statusCode).toBe(404)
     expect((await mintConversationToken(app, { conversationId: kept })).statusCode).toBe(404)
+
+    // A multi-agent roster is judged as a WHOLE. A peer with no session yet (a targeted turn skipped it,
+    // or its delivery was refused) has nothing visible to judge, and the minted socket could target it
+    // into a session that is default-private to the owner — so the conversation stays the owner's until
+    // every participant stands on a session the caller may continue.
+    await seedAgent(prisma, AGENT_B)
+    await prisma.webchatConversationAgent.create({
+      data: { conversationId: shared, agentId: AGENT_B, role: 'member', ord: 1, addedByUserId: otherUserId }
+    })
+    expect((await mintConversationToken(app, { conversationId: shared })).statusCode).toBe(404)
+    const peerSession = `acp-peer-${shared.slice(0, 8)}`
+    await seedSessionMeta(prisma, peerSession, AGENT_B, {
+      platform: 'webchat',
+      channel: shared,
+      visibility: 'org',
+      ownerIdentity: `user:${otherUserId}`
+    })
+    await prisma.webchatConversationAgent.update({
+      where: { conversationId_agentId: { conversationId: shared, agentId: AGENT_B } },
+      data: { currentSessionId: peerSession }
+    })
+    expect((await mintConversationToken(app, { conversationId: shared })).statusCode).toBe(200)
+    // …and one private peer session is enough to keep it the owner's.
+    await prisma.sessionMeta.update({ where: { id: peerSession }, data: { visibility: 'private' } })
+    expect((await mintConversationToken(app, { conversationId: shared })).statusCode).toBe(404)
   })
 
   it('POST …/webchat/token → 503 when no relay pool is configured (PUBLIC_RELAY_URL unset)', async () => {

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -1315,6 +1315,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           // A 409 from the conversation mint names the exact blocker (an agent's
           // daemon lacking multi-agent webchat support) — surface it verbatim.
           const conflict = err instanceof ApiError && err.status === 409 ? err.message : undefined
+          // A 404 on a RESUME is the CP refusing this account the conversation (private to its owner, or a roster member out of view) — not an unreachable agent.
+          const notYours = Boolean(conversationId) && err instanceof ApiError && err.status === 404
           pushStep(id, {
             kind: 'done',
             turnId: requestedTurnId,
@@ -1322,7 +1324,9 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               ? '⚠️ Webchat relay not configured — set PUBLIC_RELAY_URL on the control plane.'
               : conflict
                 ? `⚠️ ${conflict}`
-                : '⚠️ Could not reach the agent.'
+                : notYours
+                  ? '⚠️ You can’t continue this conversation — it is private to the person who started it, or includes an agent you can’t view.'
+                  : '⚠️ Could not reach the agent.'
           })
           pendingTurnFrames.current.delete(id)
           dropLanes(id)


### PR DESCRIPTION
## What

A webchat conversation can now be continued by any non-viewer org member **when the session it stands on is org-visible**; a private session stays its owner's. Same rule integration-origin sessions already follow (`session.continue`, #932).

Observed on test: the owner (`jupiterv2.10@…`) had made session `f1b192c8…` org-visible, a colleague opened it, the composer was live, and the send died with *"⚠️ Could not reach the agent."* — the mint's 404, because both mint routes required `conversation.userId === caller` since #43.

## Why owner-only was never the intent

#43 (2026-07-24) bound conversations to users to close a real hijack: the relay trusted the browser's `conversation_id` as the session key, so anyone who could mint for the agent could inject into another user's conversation. The user binding at mint was the fix's side effect and later got written down as an invariant (§10.2 of the admin-MCP design). The hijack fence — token carries the CP-authorized conversation id, relay never trusts the query — is independent of *who* may mint, and is untouched here.

## How

- `WebchatConversationRepo.resumeBinding(conversationId, orgId)` → owner + every participant's current session (pre-roster fallback to the conversation's own pointer).
- `webchat-token.ts` `resumableBy(req, conversationId)`: owner → yes; else every current session must exist, be viewable, and pass `canContinueSession` (non-viewer; private ⇒ owner-only). No turn yet ⇒ owner only. Both mint routes (`/agents/:id/webchat/token` resume, `/webchat/conversations/token` resume) read it; the legacy route still requires the asserted agent to be the primary; `allParticipantsViewable` still applies.
- Delegated admin MCP stays owner-only with **no change**: `webchatMcpAuthority.resolveLiveWebchatMcpAuthority` already fences `owner === token.userId`, so a non-owner's turns simply carry no `agentconnect-admin` entitlement. (Docs §10.2 now say so explicitly.)
- web: a 404 on a *resume* renders *"You can't continue this conversation — it is private to the person who started it, or includes an agent you can't view."* instead of "Could not reach the agent".
- Docs: `shared-bot-relay.md`, `webchat-preset-agentconnect-mcp.md` §10.2, `merged-conversation-view.md`.

## Tests

- Integration (`relay-gateway.test.ts`): another member's conversation standing on an **org** session → 200 on both mint paths; on a **private** session → 404 on both; a turnless conversation of another member → 404 (kept from #43); unknown/foreign ids → 404 (kept).
- CP unit 161 files / 1792; integration `relay-gateway` + `session-conversations` + `tenant-isolation` (106) green; web typecheck + `PlaygroundSend` suite green; eslint/prettier clean.

Product decision confirmed by @zfy0701: org-visible ⇒ everyone can interact; private ⇒ owner only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
