### PR TITLE
fix(webchat): record the author's stable principal as the transcript sender, not their display name

### DIFF
--- a/packages/control-plane/src/domain/session-visibility.ts
+++ b/packages/control-plane/src/domain/session-visibility.ts
@@ -35,7 +35,7 @@ export interface SessionClassificationInput {
   conversationKind?: SessionConversationKind
   /** Durable tenant scope for the IM identity tuple (§2); absent ⇒ no IM owner. */
   transportScope?: string
-  /** Platform sender id (webchat reports an unstable email — never used as a key). */
+  /** Platform sender id — never used as a key here; webchat owns its own `webchatOwnerUserId`. */
   triggeredBy?: string
   /** Present ⇒ an A2A child: it inherits from its parent under a row lock (§4.5). */
   parentSessionId?: string

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -436,7 +436,7 @@ import {
   type TurnSettlement
 } from './daemon/turn-types.js'
 import { UUID_RE, type WebchatSink, type WebchatTurnContext } from './webchat/types.js'
-import { WebchatTransport, type WebchatHost } from './webchat/transport.js'
+import { webchatAuthorOf, WebchatTransport, type WebchatHost } from './webchat/transport.js'
 import { WebchatMcpRevocations, type WebchatMcpRevocationHost } from './webchat/mcp-revocations.js'
 import * as webchatTurnOutput from './webchat/turn-output.js'
 import {
@@ -6374,7 +6374,7 @@ export class Daemon {
               msg.chatId,
               msg.targetSessionId,
               op.text,
-              op.user ?? 'webchat',
+              webchatAuthorOf(op),
               sink,
               op.turnId
             )
@@ -6401,7 +6401,7 @@ export class Daemon {
           msg.agentId,
           msg.chatId,
           op.text,
-          op.user ?? 'webchat',
+          webchatAuthorOf(op),
           sink,
           op.turnId,
           op.attachments,

--- a/packages/daemon/src/webchat/transport.ts
+++ b/packages/daemon/src/webchat/transport.ts
@@ -43,6 +43,23 @@ import {
   type WebchatTurnStream
 } from './types.js'
 
+/** Who authored a webchat turn. `id` is the caller's STABLE control-plane principal and is
+ *  what the durable transcript row records, so renaming a profile never re-identifies past
+ *  rows; `name` is the mutable display handle for the author line, the branch a session
+ *  worktree is cut under, and the console mirror. */
+export interface WebchatAuthor {
+  id: string
+  name: string
+}
+
+/** The author a webchat `turn` op names. A relay older than the stable-principal claim sends
+ *  only the display handle; falling back to it keeps that relay working, at the cost of the
+ *  handle-shaped sender this pairing exists to remove. */
+export function webchatAuthorOf(op: { user?: string; userId?: string }): WebchatAuthor {
+  const name = op.user ?? 'webchat'
+  return { id: op.userId ?? name, name }
+}
+
 /** Any platform connection a continuation mirror can post through. */
 export type WebchatReplyConnection = SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection
 
@@ -117,6 +134,20 @@ export class WebchatTransport {
     for (const [streamKey, stream] of this.webchatStreams) this.removeWebchatStream(streamKey, stream)
   }
 
+  /** Cache the author's display handle under their stable principal, so session read-back
+   *  (`senderName`), the permission card's requester line, and a session worktree's branch
+   *  label all resolve a name from a row that stores only the id. Best-effort, like every
+   *  other name-cache write: a failed write costs a label, never a turn. Skipped when the
+   *  two are the same string — an older relay sent no principal to key on. */
+  private async rememberAuthorName(author: WebchatAuthor): Promise<void> {
+    if (!author.name || author.id === author.name) return
+    try {
+      await this.host.store().setDisplayName(author.id, author.name, Date.now())
+    } catch (err) {
+      this.host.debug(`webchat: author name cache write failed: ${formatErr(err)}`)
+    }
+  }
+
   /**
    * Dispatch one webchat turn onto the named agent and return the ack — transport-neutral:
    * the reply stream flows to `sink`. A webchat turn is a REAL session (recorded to the
@@ -127,7 +158,7 @@ export class WebchatTransport {
     agentId: string,
     chatId: string,
     text: string,
-    user: string,
+    author: WebchatAuthor,
     sink: WebchatSink,
     requestedTurnId?: string,
     inlineImages?: WebchatImageAttachment[],
@@ -169,6 +200,7 @@ export class WebchatTransport {
       this.host.info(`webchat: agent "${result.agentId}" is draining — rejecting turn`)
       return { accepted: false, turnId, reason: 'draining' }
     }
+    await this.rememberAuthorName(author)
     // platform:'webchat', channel:conversationId, no thread (the wire SessionKey omits
     // it — §5), source:'user'. The trigger is a direct address (dm-equivalent) — webchat
     // always targets one agent. msgId is stable per-conversation (NOT per-turn) so every
@@ -181,7 +213,7 @@ export class WebchatTransport {
       source: 'user',
       platform: 'webchat',
       channel: chatId,
-      sender: { id: user, isBot: false },
+      sender: { id: author.id, isBot: false, name: author.name },
       text,
       // Structured composer mentions (agent ids). This agent seeing ITSELF in
       // the list is the explicit-address fact (`trigger:'mention'` below); the
@@ -253,7 +285,7 @@ export class WebchatTransport {
         `webchat:${chatId}`,
         String(post.at),
         {
-          sender: user,
+          sender: author.id,
           recipient: result.agentId,
           // The canonical identity must ride the ADMISSION write too — without
           // it the probe falls back to (sender, text) and a distinct same-ms
@@ -293,7 +325,7 @@ export class WebchatTransport {
     chatId: string,
     targetSessionId: string,
     text: string,
-    user: string,
+    author: WebchatAuthor,
     sink: WebchatSink,
     requestedTurnId?: string
   ): Promise<WebchatAck> {
@@ -312,6 +344,7 @@ export class WebchatTransport {
     if (!integrationId || !conn) return { accepted: false, turnId, reason: 'integration_offline' }
     const botUserId =
       this.host.botUserIds()[integrationId] ?? this.host.resolveCpAgent(agentId, local.platform)?.botUserId
+    await this.rememberAuthorName(author)
     const msg: NormalizedMessage = {
       msgId: `webchat-cont:${chatId}:${turnId}`,
       traceId: turnId,
@@ -322,7 +355,7 @@ export class WebchatTransport {
       ...(local.transportScope ? { transportScope: local.transportScope } : {}),
       // Ordered as NEW content in the origin session (the replyToSession rule).
       transcriptTs: monotonicTs(),
-      sender: { id: user, isBot: false },
+      sender: { id: author.id, isBot: false, name: author.name },
       text,
       mentionedBots: botUserId ? [botUserId] : [],
       isDm: local.conversationKind === 'dm',
@@ -371,7 +404,7 @@ export class WebchatTransport {
       return { accepted: false, turnId, reason: admission.reason === 'draining' ? 'draining' : 'busy' }
     }
     // Admission owns a serial-queue slot before mirroring and waits for its result before execution.
-    const mirrorText = `[${user} via console] ${text}`
+    const mirrorText = `[${author.name} via console] ${text}`
     // The mirror takes the SAME two-step shape an ordinary agent reply does:
     // an attributed body post, then a finalizing chat.update stamping the
     // trusted routing claim (author = the target agent, root depth, unaddressed
@@ -417,7 +450,9 @@ export class WebchatTransport {
       if (!finalized)
         this.host.warn(`webchat continuation: mirror finalization failed for ${local.key} (peers unrouted)`)
     }
-    this.host.info(`webchat continuation: ${user} → session ${local.key} (conversation ${chatId}, turn ${turnId})`)
+    this.host.info(
+      `webchat continuation: ${author.name} → session ${local.key} (conversation ${chatId}, turn ${turnId})`
+    )
     return { accepted: true, turnId }
   }
 
@@ -699,7 +734,14 @@ export class WebchatTransport {
     if (contextPost.author.kind === 'agent' && contextPost.author.agentId === agentId) return undefined
     if (!contextPost.text.trim() && !contextPost.attachments?.length) return undefined
     const sender =
-      contextPost.author.kind === 'agent' ? contextPost.author.agentId : (contextPost.author.user ?? 'webchat')
+      contextPost.author.kind === 'agent'
+        ? contextPost.author.agentId
+        : (contextPost.author.userId ?? contextPost.author.user ?? 'webchat')
+    // Same display-name cache the targeted turn writes, so a fanned-out copy the
+    // recipient recorded FIRST still labels its author by name on read-back.
+    if (contextPost.author.kind === 'user' && contextPost.author.userId && contextPost.author.user) {
+      await this.rememberAuthorName({ id: contextPost.author.userId, name: contextPost.author.user })
+    }
     // The canonical origin-minted ts. A re-fanned identical copy dedups in place
     // (the recipient tag still records the delivery for THIS agent when the text
     // row was already written by a co-hosted participant's turn); a foreign post

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -129,7 +129,7 @@ describe('Daemon interrupt safety gates', () => {
         AGENT_ID,
         CONV_1,
         'first',
-        'alice',
+        { id: 'alice', name: 'alice' },
         stream.sink
       )
       await vi.waitFor(() => expect(host.setSessionModel).toHaveBeenCalled(), WAIT)
@@ -178,7 +178,7 @@ describe('Daemon interrupt safety gates', () => {
         AGENT_ID,
         CONV_1,
         'first',
-        'alice',
+        { id: 'alice', name: 'alice' },
         stream.sink
       )
       expect(first.accepted).toBe(true)
@@ -193,7 +193,7 @@ describe('Daemon interrupt safety gates', () => {
         AGENT_ID,
         CONV_2,
         'too early',
-        'alice',
+        { id: 'alice', name: 'alice' },
         stream.sink
       )
       expect(tooEarly).toMatchObject({ accepted: false, reason: 'busy' })
@@ -206,7 +206,7 @@ describe('Daemon interrupt safety gates', () => {
         AGENT_ID,
         CONV_2,
         'fresh',
-        'alice',
+        { id: 'alice', name: 'alice' },
         stream.sink
       )
       expect(fresh.accepted).toBe(true)
@@ -338,7 +338,7 @@ describe('Daemon interrupt safety gates', () => {
         AGENT_ID,
         CONV_1,
         'cold',
-        'alice',
+        { id: 'alice', name: 'alice' },
         stream.sink
       )
       expect(ack.accepted).toBe(true)
@@ -401,7 +401,7 @@ describe('Daemon interrupt safety gates', () => {
       AGENT_ID,
       CONV_1,
       'cold memory',
-      'alice',
+      { id: 'alice', name: 'alice' },
       stream.sink
     )
     await vi.waitFor(() => expect(standingContext).toHaveBeenCalled(), WAIT)
@@ -449,7 +449,7 @@ describe('Daemon interrupt safety gates', () => {
         AGENT_ID,
         CONV_1,
         'cold',
-        'alice',
+        { id: 'alice', name: 'alice' },
         stream.sink
       )
       expect(ack.accepted).toBe(true)
@@ -465,7 +465,7 @@ describe('Daemon interrupt safety gates', () => {
         AGENT_ID,
         CONV_2,
         'must stay blocked',
-        'alice',
+        { id: 'alice', name: 'alice' },
         stream.sink
       )
       expect(retry).toMatchObject({ accepted: false, reason: 'busy' })
@@ -510,7 +510,7 @@ describe('Daemon interrupt safety gates', () => {
           AGENT_ID,
           CONV_1,
           'cold',
-          'alice',
+          { id: 'alice', name: 'alice' },
           stream.sink
         )
         expect(ack.accepted).toBe(true)
@@ -936,7 +936,7 @@ describe('Daemon interrupt safety gates', () => {
       AGENT_ID,
       CONV_1,
       'cold shutdown',
-      'alice',
+      { id: 'alice', name: 'alice' },
       stream.sink
     )
     await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)

--- a/packages/daemon/test/daemon-webchat-continuation.test.ts
+++ b/packages/daemon/test/daemon-webchat-continuation.test.ts
@@ -234,6 +234,34 @@ describe('webchat multi-agent continuation (#549 parity)', () => {
     await daemon.stop()
   }, 15_000)
 
+  // The fan-out leg of the #912 regression: a user turn targeted at one participant
+  // reaches the rest as a `context` post, and that copy wrote the author's DISPLAY NAME
+  // as the transcript sender too. Both writers must agree on the stable principal, or a
+  // peer's copy of one post identifies its author differently from the target's copy.
+  it("records a user context post under the author's principal, and caches their handle", async () => {
+    const { factory } = scriptedHosts({ [P1]: () => NO_RESPONSE })
+    const daemon = new Daemon({ root: scaffold([P1]), hostFactory: factory })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+    seedCallPolicy(daemon, [P1, P2])
+    const post: WebchatPost = {
+      ...userPost('a peer sees this', 2_000, '00000009-0000-4000-8000-000000000009'),
+      author: { kind: 'user', user: 'Ada Lovelace', userId: 'user-1' }
+    }
+    await (daemon as any).handleRelayMsg(rd({ op: 'context', post }, { msgId: 'c-1' }), () => {})
+    await settle()
+
+    const rows = (await (daemon as any).store.transcriptSince(
+      transcriptChannelKey(CONV, undefined),
+      `webchat:${CONV}`,
+      null
+    )) as { sender: string; text: string }[]
+    expect(rows.map((r) => r.text)).toEqual(['a peer sees this'])
+    expect(rows[0]!.sender).toBe('user-1')
+    expect((await (daemon as any).store.getDisplayNames(['user-1'])).get('user-1')).toBe('Ada Lovelace')
+    await daemon.stop()
+  }, 15_000)
+
   it('the author never self-activates: a context frame mis-addressed to the author is dropped', async () => {
     const { factory, prompts } = scriptedHosts({ [P1]: () => 'should never run' })
     const daemon = new Daemon({ root: scaffold([P1]), hostFactory: factory })

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -590,7 +590,13 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     ;(daemon as any).cpClient = cp
 
     // Run one full turn so a session row (with acpSessionId) exists for the conversation.
-    await (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
+    await (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'go',
+      { id: 'webchat', name: 'webchat' },
+      cp.sink
+    )
     await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
 
     const key = (daemon as any).webchatTransport.webchatSessionKey(CONV, AGENT_ID)
@@ -619,7 +625,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
         AGENT_ID,
         CONV,
         'go',
-        'webchat',
+        { id: 'webchat', name: 'webchat' },
         cp.sink,
         undefined,
         undefined,
@@ -702,7 +708,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       AGENT_ID,
       CONV,
       'go',
-      'webchat',
+      { id: 'webchat', name: 'webchat' },
       cp.sink,
       undefined,
       undefined,
@@ -762,7 +768,13 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     ;(daemon as any).cpClient = cp
 
     // Finish a turn first: Pending is gone, but the ACP session remains warm.
-    await (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'first', 'webchat', cp.sink)
+    await (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'first',
+      { id: 'webchat', name: 'webchat' },
+      cp.sink
+    )
     await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
     expect((daemon as any).pending.size).toBe(0)
     expect(host.newSession).toHaveBeenCalledTimes(1)
@@ -798,7 +810,13 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     expect(await (daemon as any).store.getFastModeOverride(key)).toBeUndefined()
 
     // The next turn reuses that same restored session while chat changes remain locked.
-    await (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'second', 'webchat', cp.sink)
+    await (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'second',
+      { id: 'webchat', name: 'webchat' },
+      cp.sink
+    )
     await vi.waitFor(() => expect(cp.dones).toHaveLength(2), WAIT)
     expect(host.newSession).toHaveBeenCalledTimes(1)
     expect((daemon as any).agents.get(AGENT_ID).allowRuntimeChangesInChat).toBe(false)
@@ -834,7 +852,13 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     const cp = fakeCpClient()
     ;(daemon as any).cpClient = cp
 
-    await (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'first', 'webchat', cp.sink)
+    await (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'first',
+      { id: 'webchat', name: 'webchat' },
+      cp.sink
+    )
     await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
     expect((daemon as any).pending.size).toBe(0)
 
@@ -859,7 +883,13 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       expect(host.setSessionFastMode).toHaveBeenCalledWith('acp-wc-1', false)
     }, WAIT)
 
-    await (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'second', 'webchat', cp.sink)
+    await (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'second',
+      { id: 'webchat', name: 'webchat' },
+      cp.sink
+    )
     await vi.waitFor(() => expect(cp.dones).toHaveLength(2), WAIT)
     expect(host.newSession).toHaveBeenCalledTimes(1)
     await daemon.stop()
@@ -886,7 +916,13 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     const cp = fakeCpClient()
     ;(daemon as any).cpClient = cp
 
-    await (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
+    await (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'go',
+      { id: 'webchat', name: 'webchat' },
+      cp.sink
+    )
     await vi.waitFor(
       () =>
         expect([...(daemon as any).pending.values()].some((p: any) => p.webchat?.conversationId === CONV)).toBe(true),
@@ -927,7 +963,13 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     await daemon.start()
     const cp = fakeCpClient()
 
-    const ack = await (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
+    const ack = await (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'go',
+      { id: 'webchat', name: 'webchat' },
+      cp.sink
+    )
     expect(ack.accepted).toBe(true)
     await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
     expect((daemon as any).pending.size).toBe(0)
@@ -1082,7 +1124,13 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     const cp = fakeCpClient()
     ;(daemon as any).cpClient = cp
 
-    const ack = await (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink)
+    const ack = await (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'go',
+      { id: 'webchat', name: 'webchat' },
+      cp.sink
+    )
 
     expect(ack).toMatchObject({ accepted: false, reason: 'paused' })
     expect(host.prompt).not.toHaveBeenCalled()
@@ -1110,13 +1158,25 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     const cp = fakeCpClient()
 
     const accepted = [
-      await (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, 'head', 'webchat', cp.sink)
+      await (daemon as any).webchatTransport.dispatchWebchatTurn(
+        AGENT_ID,
+        CONV,
+        'head',
+        { id: 'webchat', name: 'webchat' },
+        cp.sink
+      )
     ]
     await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1), WAIT)
 
     for (let n = 1; n <= 10; n++) {
       accepted.push(
-        await (daemon as any).webchatTransport.dispatchWebchatTurn(AGENT_ID, CONV, `queued-${n}`, 'webchat', cp.sink)
+        await (daemon as any).webchatTransport.dispatchWebchatTurn(
+          AGENT_ID,
+          CONV,
+          `queued-${n}`,
+          { id: 'webchat', name: 'webchat' },
+          cp.sink
+        )
       )
     }
     expect(accepted.every((ack) => ack.accepted)).toBe(true)
@@ -1130,7 +1190,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       AGENT_ID,
       CONV,
       'queue-full',
-      'webchat',
+      { id: 'webchat', name: 'webchat' },
       cp.sink
     )
     expect(rejected).toMatchObject({ accepted: false, reason: 'busy' })
@@ -1179,6 +1239,68 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     }[]
     const botText = rows.filter((r) => r.sender === AGENT_ID && r.kind === 'text').map((r) => r.text)
     expect(botText).toContain('the reply')
+    await daemon.stop()
+  }, 15_000)
+
+  // #912 regression: the token's `user` claim became the profile's display NAME, and the
+  // daemon stamped it as the transcript sender — so a re-read row identified the author by
+  // a mutable label the console could not match against /me, and the viewer's own messages
+  // came back as a stranger's. The row must record the stable principal instead.
+  it('records the stable principal as the transcript sender and caches the handle as a name', async () => {
+    const { factory } = streamingHost([text('ok')])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    const cp = fakeCpClient()
+    ;(daemon as any).cpClient = cp
+
+    await (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'ask',
+      { id: 'user-1', name: 'Ada Lovelace' },
+      cp.sink
+    )
+    // The ack returns before the dispatch commits, so poll for the durable row.
+    await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
+
+    const rows = (await (daemon as any).store.threadTranscript(CONV, `webchat:${CONV}`)) as {
+      sender: string
+      kind: string
+    }[]
+    const humanSenders = rows.filter((r) => r.kind === 'text' && r.sender !== AGENT_ID).map((r) => r.sender)
+    expect(humanSenders.length).toBeGreaterThan(0)
+    expect(new Set(humanSenders)).toEqual(new Set(['user-1']))
+    // The handle is not lost — it moves to the name cache the session reader projects as
+    // `senderName`, and that `initiatorLabel` reads for a session worktree's branch.
+    expect((await (daemon as any).store.getDisplayNames(['user-1'])).get('user-1')).toBe('Ada Lovelace')
+    await daemon.stop()
+  }, 15_000)
+
+  // An older relay sends no principal. The turn must still work, and must not write a
+  // pointless self-referential name-cache row for the handle it fell back to.
+  it('falls back to the display handle when a pre-principal relay sends no id', async () => {
+    const { factory } = streamingHost([text('ok')])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    const cp = fakeCpClient()
+    ;(daemon as any).cpClient = cp
+
+    const ack = await (daemon as any).webchatTransport.dispatchWebchatTurn(
+      AGENT_ID,
+      CONV,
+      'ask',
+      { id: 'Ada Lovelace', name: 'Ada Lovelace' },
+      cp.sink
+    )
+    expect(ack.accepted).toBe(true)
+    await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
+
+    const rows = (await (daemon as any).store.threadTranscript(CONV, `webchat:${CONV}`)) as {
+      sender: string
+      kind: string
+    }[]
+    expect(rows.some((r) => r.kind === 'text' && r.sender === 'Ada Lovelace')).toBe(true)
+    expect((await (daemon as any).store.getDisplayNames(['Ada Lovelace'])).size).toBe(0)
     await daemon.stop()
   }, 15_000)
 

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -132,7 +132,13 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
   z.object({
     op: z.literal('turn'),
     text: z.string(),
+    // The author's mutable display handle — the transcript author line and the name a
+    // session worktree's branch is cut under.
     user: z.string().optional(),
+    // The author's STABLE CP principal, which is what the daemon records as the
+    // transcript sender so a display-name change never re-identifies past rows.
+    // Absent on frames from an older relay; the daemon then falls back to `user`.
+    userId: z.string().optional(),
     // New browsers allocate this before sending so a pre-ack reconnect can name
     // the exact turn. Optional for older clients; the daemon allocates a fallback.
     turnId: z.string().uuid().optional(),

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -73,7 +73,9 @@ export const WebchatPost = z.object({
   postId: z.string().uuid(),
   conversationId: z.string().uuid(),
   author: z.discriminatedUnion('kind', [
-    z.object({ kind: z.literal('user'), user: z.string().optional() }),
+    // `userId` is the stable CP principal and is what a recipient records as the
+    // transcript sender; `user` is the mutable display handle for the author line.
+    z.object({ kind: z.literal('user'), user: z.string().optional(), userId: z.string().optional() }),
     z.object({
       kind: z.literal('agent'),
       agentId: z.string().uuid(),

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -122,6 +122,14 @@ describe('parseBrowserFrame', () => {
     })
     expect(parseBrowserFrame({ text: '', attachments: [{ ...attachment, data: 'invalid' }] }, USER)).toBeNull()
   })
+  it("carries the verified stable principal beside the display handle, never the browser's", () => {
+    expect(parseBrowserFrame({ text: 'hi', userId: 'spoofed' }, USER, 'user-1')).toEqual({
+      op: { op: 'turn', text: 'hi', user: USER, userId: 'user-1' }
+    })
+    // A CP that returns no principal leaves the claim off entirely, rather than
+    // inventing one from the handle — the daemon owns that fallback.
+    expect(parseBrowserFrame({ text: 'hi' }, USER)).toEqual({ op: { op: 'turn', text: 'hi', user: USER } })
+  })
   it('maps the session-control envelopes', () => {
     expect(parseBrowserFrame({ type: 'resume', turnId: AGENT, generation: 3, afterIndex: 4 }, USER)).toEqual({
       op: {

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -86,6 +86,9 @@ export interface RelayBrowserConnDeps {
   participants: BrowserConnParticipant[]
   /** Display handle for the transcript author line (from the verified token). */
   user: string
+  /** The author's stable CP principal (from the same verdict). Recipients record it as
+   *  the transcript sender, so `user` staying mutable costs nothing. */
+  userId?: string
   /** Session-targeted continuation: the CP-verified target ACP session id from
    *  the verdict, stamped verbatim onto every rd/msg. Never browser input. */
   targetSessionId?: string
@@ -121,7 +124,7 @@ function uuidArray(value: unknown, max: number): string[] | undefined {
 }
 
 /** Parse a browser envelope into a webchat op (+ targeting), or null if unrecognized. */
-export function parseBrowserFrame(msg: unknown, user: string): ParsedBrowserOp | null {
+export function parseBrowserFrame(msg: unknown, user: string, userId?: string): ParsedBrowserOp | null {
   if (typeof msg !== 'object' || msg === null) return null
   const m = msg as Record<string, unknown>
   // A bare message envelope (no type) or {type:'message', ...} is a turn.
@@ -131,6 +134,7 @@ export function parseBrowserFrame(msg: unknown, user: string): ParsedBrowserOp |
       op: 'turn',
       text: typeof m.text === 'string' ? m.text : '',
       user,
+      ...(userId ? { userId } : {}),
       ...(m.turnId !== undefined ? { turnId: m.turnId } : {}),
       ...(mentions ? { mentions } : {}),
       ...(m.attachments !== undefined ? { attachments: m.attachments } : {}),
@@ -266,7 +270,7 @@ export class RelayBrowserConnection implements ChatSink {
       this.send({ type: 'error', message: 'invalid frame' })
       return
     }
-    const op = parseBrowserFrame(parsed, this.deps.user)
+    const op = parseBrowserFrame(parsed, this.deps.user, this.deps.userId)
     if (!op) {
       this.send({ type: 'error', message: 'unrecognized frame' })
       return
@@ -311,7 +315,7 @@ export class RelayBrowserConnection implements ChatSink {
     const contextPost: WebchatPost = {
       postId: post.postId,
       conversationId: this.deps.chatId,
-      author: { kind: 'user', user: this.deps.user },
+      author: { kind: 'user', user: this.deps.user, ...(this.deps.userId ? { userId: this.deps.userId } : {}) },
       text: op.text,
       at: post.at,
       ...(op.attachments?.length ? { attachments: op.attachments } : {})

--- a/packages/relay/src/relay-browser-server.test.ts
+++ b/packages/relay/src/relay-browser-server.test.ts
@@ -241,6 +241,43 @@ describe('createRelayBrowserServer (browser webchat edge)', () => {
     ws.close()
   })
 
+  it("forwards the CP-verified stable principal to the daemon, never the browser's claim", async () => {
+    const verified: RcVerifyResult = {
+      ok: true,
+      agentId: AGENT,
+      daemonId: DAEMON,
+      user: 'Ada Lovelace',
+      userId: 'user-1',
+      conversationId: RESUME
+    }
+    const { base, sent } = await start({ verify: async () => verified })
+    const ws = await dial(base, '?token=good')
+    await nextFrame(ws, 'ready')
+
+    ws.send(JSON.stringify({ text: 'hi', userId: 'spoofed', user: 'spoofed' }))
+    await nextFrame(ws, 'ack')
+
+    expect(sent[0]?.payload).toMatchObject({ op: 'turn', user: 'Ada Lovelace', userId: 'user-1' })
+    ws.close()
+  })
+
+  it('omits the principal claim entirely when the CP verdict carries none', async () => {
+    const { base, sent } = await start({
+      verify: async () =>
+        ({ ok: true, agentId: AGENT, daemonId: DAEMON, user: 'Ada Lovelace', conversationId: RESUME }) as RcVerifyResult
+    })
+    const ws = await dial(base, '?token=good')
+    await nextFrame(ws, 'ready')
+
+    ws.send(JSON.stringify({ text: 'hi' }))
+    await nextFrame(ws, 'ack')
+
+    // Absent, not synthesized from the handle — the daemon owns that fallback.
+    expect(sent[0]?.payload).toMatchObject({ op: 'turn', user: 'Ada Lovelace' })
+    expect(sent[0]?.payload).not.toHaveProperty('userId')
+    ws.close()
+  })
+
   it('captures an immutable copy of verified server state for the browser connection', async () => {
     const verifiedEntitlement = { ...ENTITLEMENT }
     const verified: RcVerifyResult = {

--- a/packages/relay/src/relay-browser-server.ts
+++ b/packages/relay/src/relay-browser-server.ts
@@ -103,6 +103,9 @@ export function createRelayBrowserServer(app: FastifyInstance, deps: RelayBrowse
           agentId,
           participants,
           user,
+          // The stable principal travels beside the display handle: the daemon keys the
+          // durable transcript row on it, so a later profile rename cannot orphan old rows.
+          ...(result.userId ? { userId: result.userId } : {}),
           // Session-targeted continuation: verdict-only, never browser input.
           ...(result.targetSessionId ? { targetSessionId: result.targetSessionId } : {}),
           ...(result.remoteMcp ? { remoteMcp: result.remoteMcp } : {}),

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2280,6 +2280,16 @@ export default function SessionDetailView() {
       pictures.set(member.userId, member.picture)
       if (member.email) pictures.set(member.email, member.picture)
     }
+    // Last resort, for webchat rows written while the sender was the author's DISPLAY NAME
+    // rather than their CP principal: key by that name too, so those sessions still show a
+    // photo. Strictly after the identity keys — a name is not an identity, and two members
+    // sharing one would otherwise hand the second member's photo to the first's rows, so
+    // the first writer wins and nothing here ever gates access.
+    for (const member of members) {
+      if (!member.picture) continue
+      const label = memberDisplayName(member)
+      if (!pictures.has(label)) pictures.set(label, member.picture)
+    }
     return pictures
   }, [members])
   const attributedAgentIdBySender = useMemo(

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -2187,17 +2187,26 @@ export function speaker(handle: string, name?: string): Speaker {
 }
 
 /** Is `sender` the signed-in viewer? Live Playground steps use the canonical local
- *  `@you` marker before a durable webchat sender id exists. Persisted webchat rows use
- *  the CP principal — the user's email in an OIDC deployment, the devAuth owner id
- *  locally — which is the same identity `/me` returns. Slack/Telegram/Discord senders
- *  are platform ids and never match. `me` is typed structurally to avoid an api ↔ data
- *  import cycle. */
+ *  `@you` marker before a durable webchat sender id exists. Persisted webchat rows record
+ *  the CP principal (`userId`); rows written between #912 and the fix that restored the
+ *  principal instead hold the viewer's DISPLAY NAME, so that is accepted as a last resort
+ *  to keep those sessions readable. Slack/Telegram/Discord senders are platform ids and
+ *  never match any of the three. `me` is typed structurally to avoid an api ↔ data import
+ *  cycle.
+ *
+ *  The display-name arm is deliberately last: a name is not an identity, so two members
+ *  sharing one — or a member renaming themselves to another's name — would read that
+ *  person's old rows as "You". Never reorder it ahead of the id/email match, and never
+ *  extend it to an authorization decision; this is a presentation-only affordance for
+ *  rows already written with the wrong key. */
 export function isSelfSender(
   sender: string | null | undefined,
-  me: { userId: string; email: string | null } | null | undefined
+  me: { userId: string; email: string | null; name?: string | null } | null | undefined
 ): boolean {
   if (sender === '@you') return true
-  return !!sender && !!me && (sender === me.userId || (!!me.email && sender === me.email))
+  if (!sender || !me) return false
+  if (sender === me.userId || (!!me.email && sender === me.email)) return true
+  return !!me.name && sender === me.name
 }
 
 // playground suggested prompts (the canned-reply mock is gone — replies now

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -244,11 +244,40 @@ describe('sessionSenderLabel', () => {
     expect(sessionSenderLabel('member-id', 'member-id', agents, members, me)).toBe('Ada')
     expect(sessionSenderLabel('me', 'me', agents, members, me)).toBe('You')
   })
+
+  it('labels the viewer "You" on a legacy webchat row keyed by their display name', () => {
+    const agents = new Map([['agent-id', 'Release agent']])
+    const members = new Map([['member-id', 'Ada']])
+    const me = { userId: 'me', email: 'me@example.test', name: 'Phil Z' }
+
+    // The row a pre-fix daemon wrote records the handle, not the principal.
+    expect(sessionSenderLabel('Phil Z', 'Phil Z', agents, members, me)).toBe('You')
+    // Another member's row still resolves through the directory, never to "You".
+    expect(sessionSenderLabel('member-id', 'member-id', agents, members, me)).toBe('Ada')
+  })
 })
 
 describe('isSelfSender', () => {
   it('recognizes the live Playground viewer marker before /me is available', () => {
     expect(isSelfSender('@you', null)).toBe(true)
+  })
+
+  it('matches the CP principal a webchat row records, and the email an older row used', () => {
+    const me = { userId: 'user-1', email: 'ada@example.test', name: 'Ada Lovelace' }
+
+    expect(isSelfSender('user-1', me)).toBe(true)
+    expect(isSelfSender('ada@example.test', me)).toBe(true)
+    expect(isSelfSender('U0SLACK', me)).toBe(false)
+    expect(isSelfSender('other-user', me)).toBe(false)
+  })
+
+  it('falls back to the display name, for rows written before the principal was carried', () => {
+    const me = { userId: 'user-1', email: 'ada@example.test', name: 'Ada Lovelace' }
+
+    expect(isSelfSender('Ada Lovelace', me)).toBe(true)
+    // A viewer with no display name must not match on a null/absent name.
+    expect(isSelfSender('Ada Lovelace', { userId: 'user-1', email: 'ada@example.test', name: null })).toBe(false)
+    expect(isSelfSender('Ada Lovelace', { userId: 'user-1', email: 'ada@example.test' })).toBe(false)
   })
 })
 

--- a/packages/web/src/lib/session-trigger.ts
+++ b/packages/web/src/lib/session-trigger.ts
@@ -96,7 +96,7 @@ export function sessionSenderLabel(
   fallback: string | undefined,
   agentNames: ReadonlyMap<string, string>,
   memberNames: ReadonlyMap<string, string>,
-  me: { userId: string; email: string | null } | null | undefined
+  me: { userId: string; email: string | null; name?: string | null } | null | undefined
 ): string {
   if (!sender) return fallback ?? '—'
   if (isSelfSender(sender, me)) return 'You'


### PR DESCRIPTION
## The bug

Re-entering a webchat session in the console, the signed-in user's own messages
render with generated initials instead of their profile photo, and the author
line shows their name instead of "You". The avatar menu shows the real photo, so
it is not a profile problem. Live typing looks correct — only the persisted
transcript path is wrong.

## Why

A persisted webchat row identified its author by the webchat token's `user`
claim. #912 changed that claim from the sign-in address to the profile's display
name, so a session worktree's branch would read `dev/jane-doe/…` rather than
`dev/jane-example-com/…`. That goal is right, but the same string was also the
durable transcript sender — and a display name is not an identity, so the
console's self-check (`sender === me.userId || sender === me.email`) stopped
matching, and every lookup keyed on identity missed with it:

- `isSelfSender` returned false, so the row lost both "You" and the viewer photo;
- the member picture directory (keyed by userId/email) missed, so the avatar fell
  through to initials;
- `sessionSenderLabel` fell through to the raw sender.

The CP already resolves the stable principal — `rc/verify` returns `userId` and
`user` — but the relay forwarded only the handle and dropped the id.

## The fix

Carry the principal the whole way and record it:

- **protocol** — the webchat `turn` op and `WebchatPost`'s user author gain an
  optional `userId` beside `user`.
- **relay** — forwards `result.userId` from the verify verdict onto the browser
  connection, the turn frame, and the multi-agent context post. Browser-supplied
  claims are ignored, as before.
- **daemon** — records `userId` as the transcript sender (targeted turns,
  continuation turns, and fanned-out context posts) and keeps the handle in
  `sender.name`. It also caches the handle under the id in the display-name
  store, so `senderName`, the permission card's requester line, and
  `initiatorLabel` still resolve a human name from a row that stores only an id
  — which is what keeps #912's branch naming intact. Verified that nothing
  authorization-shaped keys off this sender: webchat session visibility uses the
  CP's own conversation owner, and command admission never reads the sender id.
- An older relay sends no `userId`; the daemon falls back to the handle exactly
  as today.

Rows already written hold the display name and cannot be repaired in place, so
the console repairs them at render time — strictly as a last resort after the id
and email match:

- `isSelfSender` also compares the viewer's own display name;
- the member picture directory is additionally keyed by member display name.

Both carry the collision caveat in-code: a name is not an identity, two members
sharing one resolve to whichever is indexed first, and neither path gates
access. The stale doc comment on `isSelfSender` (and the CP's
`SessionClassificationInput.triggeredBy`) is corrected.

`sessionSenderLabel` / the Sessions list ("triggered by") had the same symptom
for the viewer's own sessions and is fixed by the same `isSelfSender` change;
other members' rows already resolved correctly through the fallback chain, so
they needed nothing.

## Deliberate consequence

The agent's own view of a webchat turn — the `[sender] text` trigger line and
replayed context rows — now shows the id rather than the name. That is already
what Slack, Discord and Feishu senders render as; webchat was the outlier.
Resolving display names in the agent prompt would be a cross-platform change to
shared rendering (it also affects Telegram) and is deliberately left out of this
fix.

## Tests

- `relay-browser-server` — forwards the verified principal, never the browser's
  claim; omits it entirely when the CP verdict carries none.
- `relay-browser-connection` — `parseBrowserFrame` carries the principal.
- `daemon-webchat` — the transcript row records the principal and the handle
  lands in the name cache; a pre-principal relay still works and writes no
  self-referential cache row.
- `daemon-webchat-continuation` — the multi-agent context copy agrees with the
  targeted copy on the principal.
- `session-trigger` — `isSelfSender` across principal / email / display-name
  rows, and `sessionSenderLabel` on a legacy name-keyed row.

`pnpm lint`, `pnpm format:check` and `pnpm typecheck` are clean (the two
`import-x/no-duplicates` warnings in `daemon.ts` predate this branch). Full
protocol / relay / web / control-plane-unit suites pass; the daemon suite passes
except for sandbox and live-ACP-matrix files that fail identically on `main` in
this environment.
