### PR TITLE
fix(daemon): bound the shim dial's opening handshake while it is still starting up

### DIFF
--- a/packages/daemon/src/shim/dialer.ts
+++ b/packages/daemon/src/shim/dialer.ts
@@ -24,11 +24,22 @@ export type ShimDialPhase = 'startup' | 'reconnect'
 /** Startup pacing: the pod was created moments ago, so a refusal means "not listening yet" and is met in ~100ms. */
 export const STARTUP_DIAL_BACKOFF: BackoffOpts = { baseMs: 100 }
 
+/** First startup attempt's opening-handshake budget; each later one doubles it, up to the caller's own.
+ *  The pacing above assumes a failure is a REFUSAL and costs nothing, which is true of a listener still
+ *  coming up and false of a dropped packet — a policy or route that has not converged swallows the SYN,
+ *  and the transport's own 10s handshake timeout is then the whole cost of learning that. Reaching the
+ *  ~100ms retry at all means bounding the attempt well under it; doubling keeps a genuinely slow-but-live
+ *  handshake from being retried forever. */
+export const STARTUP_HANDSHAKE_TIMEOUT_MS = 1_000
+
 export interface ShimDialerDeps {
   verifier: PodIdentityVerifier
   now?: () => number
   clock?: Clock
-  dial?: (url: string, opts: { subprotocol: string; path: string }) => Promise<ShimTransport>
+  dial?: (
+    url: string,
+    opts: { subprotocol: string; path: string; handshakeTimeoutMs?: number }
+  ) => Promise<ShimTransport>
   /** Per-phase backoff factory. Injected so tests dial and reconnect in milliseconds. */
   backoff?: (phase: ShimDialPhase) => Backoff
   credentialTtlMs?: number
@@ -129,9 +140,13 @@ export class ShimDialer {
     const startup = this.deps.backoff?.('startup') ?? new Backoff(STARTUP_DIAL_BACKOFF)
     const reconnect = this.deps.backoff?.('reconnect') ?? new Backoff()
     let everBound = false
+    let startupAttempt = 0
     while (!dial.stopped) {
       try {
-        const { connection, closed } = await this.dialAndBind(dial, timeoutMs)
+        const handshakeMs = everBound
+          ? undefined
+          : Math.min(STARTUP_HANDSHAKE_TIMEOUT_MS * 2 ** startupAttempt++, timeoutMs)
+        const { connection, closed } = await this.dialAndBind(dial, timeoutMs, handshakeMs)
         if (dial.stopped) {
           connection.close('dial no longer current')
           return
@@ -175,7 +190,10 @@ export class ShimDialer {
 
   private dialAndBind(
     dial: SupervisedDial,
-    timeoutMs: number
+    timeoutMs: number,
+    /** This attempt's opening-handshake budget; absent ⇒ the transport's own default. Bounds ONLY the
+     *  handshake: once the socket is open the path is proven and binding keeps the full budget below. */
+    handshakeTimeoutMs?: number
   ): Promise<{ connection: ShimConnection; closed: Promise<{ code: number; reason: string }> }> {
     const boundedMs = Math.max(1, timeoutMs)
     let transport: ShimTransport | undefined
@@ -191,7 +209,8 @@ export class ShimDialer {
     const attempt = (async () => {
       transport = await (this.deps.dial ?? defaultDial)(dial.endpoint, {
         subprotocol: SHIM_SUBPROTOCOL,
-        path: SHIM_WS_PATH
+        path: SHIM_WS_PATH,
+        ...(handshakeTimeoutMs === undefined ? {} : { handshakeTimeoutMs })
       })
       if (timedOut || dial.stopped) {
         transport.close(4408, timedOut ? 'binding timeout' : 'dial no longer current')
@@ -411,6 +430,9 @@ export class ShimDialer {
   }
 }
 
-function defaultDial(url: string, opts: { subprotocol: string; path: string }): Promise<ShimTransport> {
+function defaultDial(
+  url: string,
+  opts: { subprotocol: string; path: string; handshakeTimeoutMs?: number }
+): Promise<ShimTransport> {
   return ClientTransport.dial(url, opts) as Promise<ShimTransport>
 }

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -368,6 +368,66 @@ describe('shim handshake', () => {
   })
 })
 
+describe('shim dial startup budget', () => {
+  /** A shim that answers the daemon's hello, once a dial finally gets a socket. */
+  function healthyTransport(): ShimTransport {
+    let deliver: (text: string) => void = () => {}
+    return {
+      send: (text) => {
+        if (parseShimFrame(text)?.type === 'shim/hello')
+          queueMicrotask(() => deliver(JSON.stringify({ type: 'shim/identity', token: 'projected-token' })))
+      },
+      onMessage: (cb) => (deliver = cb),
+      onClose: () => {},
+      close: () => {}
+    }
+  }
+
+  function dialerRecordingHandshakes(clock: VirtualClock, failFirst: number, handshakes: Array<number | undefined>) {
+    let attempts = 0
+    const dialer = new ShimDialer({
+      verifier: verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' }),
+      clock,
+      now: () => clock.now(),
+      backoff: () => new Backoff({ baseMs: 10, jitter: () => 0 }),
+      dial: async (_url, opts) => {
+        handshakes.push(opts.handshakeTimeoutMs)
+        // What an unconverged network path actually produces: no refusal, just the transport
+        // giving up on an opening handshake nobody was ever going to answer.
+        if (attempts++ < failFirst) throw new Error('Opening handshake has timed out')
+        return healthyTransport()
+      },
+      log: { info: () => {}, warn: () => {} }
+    })
+    dialers.push(dialer)
+    return dialer
+  }
+
+  it('bounds every pre-bind handshake and doubles it, rather than paying the transport default', async () => {
+    // A dropped SYN gives no refusal, so an unbounded attempt costs the transport's full 10s
+    // handshake timeout and the ~100ms startup pacing never gets to run. Bounding the attempt is
+    // what makes the retry the cheap thing it was written to be.
+    const clock = new VirtualClock()
+    const handshakes: Array<number | undefined> = []
+    const dialer = dialerRecordingHandshakes(clock, 2, handshakes)
+
+    const connection = await runVirtual(clock, dialer.connect(SCRIPTED_ENDPOINT, record(), 60_000))
+    expect(connection.binding.agentId).toBe('agent-a')
+    // Doubling, not a fixed floor: a handshake that is genuinely slow rather than dropped must
+    // still be allowed to finish instead of being retried out of existence.
+    expect(handshakes).toEqual([1_000, 2_000, 4_000])
+  })
+
+  it('never bounds an attempt above the budget its caller gave', async () => {
+    const clock = new VirtualClock()
+    const handshakes: Array<number | undefined> = []
+    const dialer = dialerRecordingHandshakes(clock, 0, handshakes)
+
+    await runVirtual(clock, dialer.connect(SCRIPTED_ENDPOINT, record(), 250))
+    expect(handshakes).toEqual([250])
+  })
+})
+
 describe('workspace root reporting', () => {
   async function boundWith(workspaceRoot?: string): Promise<{ workspaceRoot?: string }> {
     const clock = new VirtualClock()


### PR DESCRIPTION
## The bug

`ShimDialer`'s startup backoff is paced at ~100ms, and its comment says why: the pod was created moments ago, so a failure means "not listening yet" — a refusal, which costs nothing.

A **dropped** SYN costs the opposite. Nothing refuses, nothing answers, and the attempt runs all the way to the transport's 10s handshake timeout. The ~100ms pacing never gets a chance to run.

That is what happens whenever something swallows the packet instead of refusing it — a network policy or a route the cluster has not converged on yet. Observed on a cluster-execution pool: the claim binds a warm sandbox in 26ms, and the member then spends 13–28 seconds failing to reach a shim that has been listening since the pod started an hour earlier. One or two full 10s timeouts, then a retry that connects in 1ms.

## The fix

Bound the opening handshake while nothing has bound yet: 1s on the first attempt, doubling after that, capped by the caller's own budget.

- **Doubling, not a fixed floor** — a handshake that is genuinely slow rather than dropped must still be allowed to finish instead of being retried out of existence.
- **Only the handshake.** Once a socket has opened the path is proven, so binding keeps the full budget.
- **Only before the first bind.** A later reconnect keeps the transport's default.
- The overall deadline is unchanged, so nothing gives up sooner than it did.

Effect on the case above: a dropped path costs ~1s before the retry instead of ~10s, and the retry cadence the code already had starts working.

## Tests

Two added to `shim-handshake.test.ts`, both failing before this change (the recorded value was `undefined` — the transport default):

- the pre-bind handshakes are `[1000, 2000, 4000]` across two dropped attempts and a third that binds;
- an attempt is never bounded above the budget its caller gave.

`test/shim-handshake.test.ts test/shim-tunnel.test.ts test/shim-dial-in.test.ts test/k8s-runtime-plane.test.ts test/k8s-driver.test.ts test/cluster-cold-start.test.ts` → 120 passed.

## Note

This is the cheap half. The dropped-packet window itself is a deployment-side matter and is being fixed there; this makes the daemon stop paying ten seconds to discover it, wherever it comes from.
