### PR TITLE
fix(daemon): collapse a burst of check re-requests into one review

### DIFF
--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -159,16 +159,45 @@ export function githubPullRequestLane(
   ])
 }
 
-/** Deliveries that establish a new head; a re-request only reopens the revision already current. */
+/** Deliveries that establish a new head. */
 const GITHUB_PULL_REVISION_EVENTS = new Set(['pull_request:opened', 'pull_request:synchronize'])
+
+/** Deliveries that re-run the head already current; a burst of them is one review asked for repeatedly. */
+const GITHUB_PULL_RERUN_EVENTS = new Set([
+  'pull_request:review_requested',
+  'check_run:rerequested',
+  'check_suite:rerequested',
+  'check_run:requested_action'
+])
+
+/** One lane's contest for the next generation; a re-run is `pinned` to its own head and contests that alone. */
+export interface GithubRevisionStream {
+  lane: string
+  headSha: string
+  pinned: boolean
+}
 
 export function githubPullRevisionStream(
   hook: GithubCoordinatedHook | undefined,
   coords: GithubHookCoordinates
-): string | undefined {
+): GithubRevisionStream | undefined {
   const lane = githubPullRequestLane(hook, coords)
-  if (!lane || !hook || !GITHUB_PULL_REVISION_EVENTS.has(hook.event ?? '') || !hook.github?.headSha) return undefined
-  return JSON.stringify(['revision', lane])
+  const headSha = hook?.github?.headSha
+  if (!lane || !headSha) return undefined
+  const event = hook?.event ?? ''
+  if (GITHUB_PULL_REVISION_EVENTS.has(event)) return { lane, headSha, pinned: false }
+  if (GITHUB_PULL_RERUN_EVENTS.has(event)) return { lane, headSha, pinned: true }
+  return undefined
+}
+
+/** Contenders share a lane, and share a head whenever either only re-runs its own. */
+export function githubRevisionStreamsContest(a: GithubRevisionStream, b: GithubRevisionStream): boolean {
+  return a.lane === b.lane && (!(a.pinned || b.pinned) || a.headSha === b.headSha)
+}
+
+/** A re-run means re-run: only the winner's generation is reported, so an older one is dead work. */
+export function githubRerunsCurrentHead(hook: Pick<HookDispatchContext, 'event'> | undefined): boolean {
+  return GITHUB_PULL_RERUN_EVENTS.has(hook?.event ?? '')
 }
 
 export function githubReviewBatchStream(

--- a/packages/daemon/src/github/queue-admission.ts
+++ b/packages/daemon/src/github/queue-admission.ts
@@ -13,6 +13,8 @@ import {
   githubHookCoordinates,
   githubPullRequestLane,
   githubPullRevisionStream,
+  githubRerunsCurrentHead,
+  githubRevisionStreamsContest,
   githubReviewBatchStream,
   renderGithubReviewBatchPrompt,
   GITHUB_REVIEW_BATCH_MAX_COMMENTS,
@@ -20,6 +22,7 @@ import {
   GITHUB_REVIEW_BATCH_QUIET_MS,
   type GithubQueueCandidate,
   type GithubRevisionAdmissionPlan,
+  type GithubRevisionStream,
   type GithubReviewBatch,
   type HookDispatchContext
 } from './hook-coords.js'
@@ -38,26 +41,28 @@ export function collectGithubQueueCandidates(
   return candidates
 }
 
+/** The generation stream one queue candidate belongs to, if any. */
+function candidateRevisionStream(candidate: QueueEntry): GithubRevisionStream | undefined {
+  return githubPullRevisionStream(
+    candidate.hookContext,
+    githubHookCoordinates(candidate.agentId, candidate.msg, candidate.integrationId)
+  )
+}
+
 /** Pick the newest relay-fired revision across every session key in one trusted GitHub lane. */
 export function planGithubRevisionAdmission(
   key: string,
   incoming: QueueEntry,
   candidates: readonly GithubQueueCandidate[]
 ): GithubRevisionAdmissionPlan | undefined {
-  const stream = githubPullRevisionStream(
-    incoming.hookContext,
-    githubHookCoordinates(incoming.agentId, incoming.msg, incoming.integrationId)
-  )
+  const stream = candidateRevisionStream(incoming)
   if (!stream) return undefined
   const revisions = [
-    ...candidates.filter(
-      (candidate) =>
-        !candidate.entry.cancelledReason &&
-        githubPullRevisionStream(
-          candidate.entry.hookContext,
-          githubHookCoordinates(candidate.entry.agentId, candidate.entry.msg, candidate.entry.integrationId)
-        ) === stream
-    ),
+    ...candidates.filter((candidate) => {
+      if (candidate.entry.cancelledReason) return false
+      const other = candidateRevisionStream(candidate.entry)
+      return other !== undefined && githubRevisionStreamsContest(stream, other)
+    }),
     { key, entry: incoming, state: 'incoming' as const }
   ]
   const winner = revisions.reduce((latest, candidate) =>
@@ -104,7 +109,7 @@ export interface GithubRevisionAdmissionEffects {
   terminalLosers: GithubQueueCandidate[]
   /** Losers already generating: their completion is awaited by the winner. */
   activeLosers: GithubQueueCandidate[]
-  /** Active losers reviewing a different head: only a genuinely newer revision preempts running work. */
+  /** Active losers a newer revision — or an explicit re-run of their own head — preempts. */
   preemptableActiveLosers: GithubQueueCandidate[]
   /** Lane the winner belongs to, so its own re-admission survives the interrupt. */
   winnerLane: string | undefined
@@ -119,12 +124,13 @@ export function planGithubRevisionAdmissionEffects(
   incoming: QueueEntry
 ): GithubRevisionAdmissionEffects {
   const winnerHead = plan.winner.entry.hookContext?.github?.headSha
+  const rerun = githubRerunsCurrentHead(plan.winner.entry.hookContext)
   const activeLosers = plan.superseded.filter((candidate) => candidate.state === 'active')
   return {
     terminalLosers: plan.superseded.filter((candidate) => candidate.state !== 'active'),
     activeLosers,
     preemptableActiveLosers: activeLosers.filter(
-      (candidate) => candidate.entry.hookContext?.github?.headSha !== winnerHead
+      (candidate) => rerun || candidate.entry.hookContext?.github?.headSha !== winnerHead
     ),
     winnerLane: githubPullRequestLane(
       plan.winner.entry.hookContext,

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -2389,6 +2389,107 @@ describe('Daemon rd/msg hook fires', () => {
     await restarted.stop()
   }, 15_000)
 
+  it('collapses a burst of check re-requests for one head onto the newest delivery', async () => {
+    let onUpdate!: (sid: string, update: unknown) => void
+    const releases: Array<(error?: Error) => void> = []
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-pr-rerun'),
+      modelOptions: vi.fn(() => null),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sid: string) => {
+        await new Promise<void>((resolve, reject) => releases.push((error) => (error ? reject(error) : resolve())))
+        onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'done' } })
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => releases.shift()?.(new Error('cancelled by shutdown'))),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: (_agent, cb) => {
+        onUpdate = cb
+        return host as never
+      }
+    })
+    await daemon.start()
+    ;(daemon as any).cfg.limits.shutdownDrainMs = 0
+    const cp = fakeCpClient()
+    ;(daemon as never as { cpClient: unknown }).cpClient = cp
+    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+      poster: { publish: vi.fn(async () => {}) },
+      collector: new GithubReplyCollector()
+    }))
+
+    // One head, one review: the checks page re-run button fired three deliveries in under a second.
+    const rerun = (deliveryKey: string, firedAt: string): RdMsgHook =>
+      fire({
+        sessionKey: 'acme/infra#42',
+        msgId: `${HOOK_ID}:${deliveryKey}`,
+        deliveryKey,
+        firedAt,
+        event: 'check_suite:rerequested',
+        github: {
+          repoId: '123',
+          repoFullName: 'acme/infra',
+          sourceInstallationId: '456',
+          subjectKind: 'pull_request',
+          pullNumber: 42,
+          headSha: 'a'.repeat(40),
+          baseSha: '0'.repeat(40),
+          reportSha: 'a'.repeat(40)
+        },
+        context: {
+          source: 'github',
+          event: 'check_suite',
+          action: 'rerequested',
+          repo: 'acme/infra',
+          number: 42,
+          title: 'Collapse re-request bursts',
+          senderLogin: 'alice',
+          truncated: false
+        }
+      })
+
+    await expect(
+      (daemon as any).handleRelayMsg(rerun('first', '2026-08-19T17:55:42.765Z'), () => {})
+    ).resolves.toMatchObject({ accepted: true })
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledOnce(), WAIT)
+    await expect(
+      (daemon as any).handleRelayMsg(rerun('second', '2026-08-19T17:55:42.947Z'), () => {})
+    ).resolves.toMatchObject({ accepted: true })
+    await expect(
+      (daemon as any).handleRelayMsg(rerun('third', '2026-08-19T17:55:43.456Z'), () => {})
+    ).resolves.toMatchObject({ accepted: true })
+
+    await vi.waitFor(
+      () =>
+        expect(cp.hookReports.filter((report) => report.deliveryKey !== 'third')).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ deliveryKey: 'first', status: 'failed', reason: 'superseded' }),
+            expect.objectContaining({ deliveryKey: 'second', status: 'failed', reason: 'superseded' })
+          ])
+        ),
+      WAIT
+    )
+    expect(cp.hookReports.filter((report) => report.deliveryKey !== 'third')).toHaveLength(2)
+    expect(host.cancel).toHaveBeenCalled()
+    // The preempted head leaves the gate on its own teardown, so the lane settles on one review.
+    await vi.waitFor(
+      () =>
+        expect(
+          [
+            ...((daemon as any).activeGateEntries.values() as Iterable<{ hookContext?: { deliveryKey: string } }>),
+            ...([...(daemon as any).serialQueue.values()].flat() as Array<{ hookContext?: { deliveryKey: string } }>)
+          ].map((entry) => entry.hookContext?.deliveryKey)
+        ).toEqual(['third']),
+      WAIT
+    )
+
+    await daemon.stop()
+  }, 15_000)
+
   it('keeps targeted PR revision reviews latest-wins across distinct anchor session keys', async () => {
     let onUpdate!: (sid: string, update: unknown) => void
     let sessionNumber = 0

--- a/packages/daemon/test/github-queue-admission.test.ts
+++ b/packages/daemon/test/github-queue-admission.test.ts
@@ -56,10 +56,42 @@ describe('planGithubRevisionAdmission', () => {
     expect(effects.preemptableActiveLosers).toEqual([])
   })
 
-  it('leaves a re-request out of latest-wins, since it opens no new revision', () => {
+  it('re-runs the head a re-request names, preempting the review already generating it', () => {
     const opened = entry('opened', 'pull_request:opened', HEAD_A, '2026-08-19T01:24:44.000Z')
     const rerequested = entry('rerequested', 'check_run:rerequested', HEAD_A, '2026-08-19T01:26:00.000Z')
 
-    expect(planGithubRevisionAdmission(KEY, rerequested, active(opened))).toBeUndefined()
+    const plan = planGithubRevisionAdmission(KEY, rerequested, active(opened))
+
+    expect(plan?.winner.entry).toBe(rerequested)
+    const effects = planGithubRevisionAdmissionEffects(plan!, rerequested)
+    expect(effects.incomingWins).toBe(true)
+    expect(effects.preemptableActiveLosers.map((candidate) => candidate.entry)).toEqual([opened])
+  })
+
+  it('collapses a burst of re-requests for one head onto the newest delivery', () => {
+    const first = entry('first', 'check_suite:rerequested', HEAD_A, '2026-08-19T17:55:42.765Z')
+    const second = entry('second', 'check_suite:rerequested', HEAD_A, '2026-08-19T17:55:42.947Z')
+    const third = entry('third', 'check_suite:rerequested', HEAD_A, '2026-08-19T17:55:43.456Z')
+
+    const plan = planGithubRevisionAdmission(KEY, third, [
+      { key: KEY, entry: first, state: 'active' },
+      { key: KEY, entry: second, state: 'queued' }
+    ])
+
+    expect(plan?.winner.entry).toBe(third)
+    const effects = planGithubRevisionAdmissionEffects(plan!, third)
+    expect(effects.incomingWins).toBe(true)
+    expect(effects.terminalLosers.map((candidate) => candidate.entry)).toEqual([second])
+    expect(effects.preemptableActiveLosers.map((candidate) => candidate.entry)).toEqual([first])
+  })
+
+  it('leaves the head under review alone when a re-request names a stale one', () => {
+    const pushed = entry('pushed', 'pull_request:synchronize', HEAD_B, '2026-08-19T01:28:20.000Z')
+    const rerequested = entry('rerequested', 'check_suite:rerequested', HEAD_A, '2026-08-19T01:29:00.000Z')
+
+    const plan = planGithubRevisionAdmission(KEY, rerequested, active(pushed))
+
+    expect(plan?.winner.entry).toBe(rerequested)
+    expect(plan?.superseded).toEqual([])
   })
 })


### PR DESCRIPTION
## What & why

#1274 collected three identical `REQUEST_CHANGES` reviews inside one minute. The trigger was three
`check_suite:rerequested` deliveries 0.18s and 0.51s apart on one head — a single re-run, three
delivery GUIDs, three accepted review generations.

The daemon's per-lane admission gate already collapses a burst of pushes into one review, but
`githubPullRevisionStream()` recognized only `pull_request:opened` / `synchronize`. A re-request got
no stream at all, so it contested nothing: the deliveries queued behind one another and ran three
serial review generations of the same commit, each submitting the same verdict to the PR.

Those extra generations were dead work even before they were duplicates — the projection binds to
the newest accepted run, so an older generation's report is dropped on arrival. The only thing the
duplicates changed was the PR conversation.

## What changes

- Re-run deliveries (`check_run:rerequested`, `check_suite:rerequested`, `check_run:requested_action`,
  `pull_request:review_requested`) now join their lane's revision contest, **pinned** to the head they
  name. `check_run:requested_action` is already filtered to the single `request_review` identifier
  upstream, so every event in the set means exactly "run the review again".
- Pinned means a re-run contests only candidates on that same head, so a re-run of a stale head can
  never contest — or preempt — a newer revision already under review.
- A winning re-run preempts the generation running on its own head rather than queueing behind it
  (a re-run is a request to re-run), and drops the queued ones. Both settle through the existing
  `superseded` terminal path, exactly as a superseded push does today.
- Unchanged: cross-head latest-wins for pushes, and a same-head `opened` / `synchronize` still waits
  out the running review instead of restarting it.

## Test plan

- [x] `test/github-queue-admission.test.ts` — burst collapse onto the newest delivery, re-run
      preemption of a running same-head review, and a stale-head re-run leaving the current review alone.
- [x] `test/daemon-hook.test.ts` — end to end: three `check_suite:rerequested` fires on one head yield
      two `superseded` reports and one surviving review. Both files were re-run against the
      pre-fix sources to confirm the new cases fail without the change.
- [x] `pnpm --filter @agentconnect.md/daemon typecheck`; eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
