### PR TITLE
fix(control-plane): release an organization's agent claims when the organization is deleted

### DIFF
--- a/packages/control-plane/src/http/routes/orgs.ts
+++ b/packages/control-plane/src/http/routes/orgs.ts
@@ -28,6 +28,7 @@ import { Tag } from '../plugins/openapi.js'
 import { resolveOrgIconUrl, type IconUrlBases } from '../../agents/agent-icon.js'
 import { OrgDto, OrgListDto, CreateOrgBody, UpdateOrgBody, ErrorDto, type OrgDtoT } from '../dto/index.js'
 import { OrgCreationLimitReached } from '../../persistence/errors.js'
+import { NoConnection } from '../../orchestrator/outbound.js'
 
 function toDto(o: OrgRecord, deps: HttpDeps): OrgDtoT {
   const bases: IconUrlBases = {
@@ -243,6 +244,11 @@ export function orgScopedRoutes(deps: HttpDeps) {
             message: 'the organization still has daemons — remove them first'
           })
         }
+        // Resolved BEFORE the cascade and sent after it: the duty ledger cascades from the org, so
+        // once the delete lands there is nothing left to say which pool member serves these agents.
+        // Without this an agent placed on a pool keeps its sandbox claim — and the pod and workspace
+        // volume the claim owns — with no row left anywhere to reap it from.
+        const announceRemovals = await deps.agentDelivery.planRemoval(await deps.repos.agent.list(orgId), orgId)
         const deleted = await deps.repos.org.delete(req.orgCtx!.orgId)
         for (const hookId of deleted.removedHookIds) deps.hooks.remove(hookId)
         if (deleted.status === 'daemons_present') {
@@ -260,6 +266,15 @@ export function orgScopedRoutes(deps: HttpDeps) {
             message: 'GitHub Check cleanup is pending — retry organization deletion after cleanup converges'
           })
         }
+        // Best-effort, like the agent delete's own removal push: the rows are gone either way, and a
+        // member that missed this drops the agents on its next register roster.
+        await announceRemovals((err, daemonId) => {
+          if (err instanceof NoConnection) {
+            app.log.debug({ orgId, daemonId }, 'agent/remove skipped on org delete: daemon offline')
+          } else {
+            app.log.warn({ err, orgId, daemonId }, 'agent/remove failed on org delete (backstop: reconnect roster)')
+          }
+        })
         return reply.code(204).send(null)
       }
     )

--- a/packages/control-plane/src/orchestrator/agentDelivery.ts
+++ b/packages/control-plane/src/orchestrator/agentDelivery.ts
@@ -66,6 +66,28 @@ export class AgentDelivery {
     return [...targets]
   }
 
+  /**
+   * Removal of every agent an organization owns, for the one caller whose delete takes the
+   * delivery set with it: `DutyGroup` cascades from `Org`, so after the cascade the ledger that
+   * names a pool member holding these agents no longer exists and {@link remove}'s "delete first,
+   * resolve after" order — the order that makes a single deleted agent's holder still findable —
+   * would resolve nothing at all. Resolve here, and hand back the send so the caller fires it once
+   * its own delete has committed rather than announcing a removal that may still be refused.
+   */
+  async planRemoval(
+    agents: readonly ResolvableAgent[],
+    orgId: string
+  ): Promise<(onError: DeliveryErrorHandler) => Promise<void>> {
+    const planned = await Promise.all(
+      agents.map(async (agent) => ({ agentId: agent.id, targets: await this.daemonsFor(agent) }))
+    )
+    return async (onError) => {
+      for (const { agentId, targets } of planned) {
+        await this.fanOut(targets, onError, (daemonId) => this.deps.control.agentRemove(daemonId, { agentId }, orgId))
+      }
+    }
+  }
+
   /** Push an edited spec to every delivery target. The spec is assembled ONCE:
    *  the targets replicate the same agent, and two assemblies could disagree. */
   async upsert(agent: AgentRecord, onError: DeliveryErrorHandler): Promise<void> {

--- a/packages/control-plane/test/integration/orgs.route.test.ts
+++ b/packages/control-plane/test/integration/orgs.route.test.ts
@@ -12,6 +12,8 @@ import { prisma } from '../setup.db.js'
 import { buildHttpApp } from '../fakes/build-http.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
+import { seedDutyGroup } from '../fixtures/seed.js'
+import type { ControlSender } from '../../src/orchestrator/outbound.js'
 import { Prisma } from '../../src/generated/prisma/client.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 
@@ -361,6 +363,59 @@ describe('DELETE /orgs/:orgId', () => {
       expect((await app.inject({ method: 'DELETE', url: `/api/v1/orgs/${created.id}` })).statusCode).toBe(204)
       expect(await prisma.org.findUnique({ where: { id: created.id } })).toBeNull()
       expect(await prisma.daemon.findUnique({ where: { id: poolMember.id } })).not.toBeNull()
+    } finally {
+      await close()
+    }
+  })
+
+  it('tells the pool member holding the org\u2019s agents that they are gone', async () => {
+    // Nothing else can: DutyGroup cascades from Org, so the moment the delete lands there is no
+    // row left saying which member serves these agents. A member never told keeps their sandbox
+    // claims \u2014 and the pods and workspace volumes those claims own \u2014 for good. Per-agent
+    // DELETE sends this already; an org's built-in agent cannot be deleted that way at all.
+    const poolMember = await new PgDaemonRepo(prisma).resolvePoolClusterIdentity(
+      'system:serviceaccount:agentconnect:ac-cloud-daemon',
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    )
+    const removes: Array<{ daemonId: string; agentId: string }> = []
+    const control = {
+      agentUpsert: async () => {},
+      agentRemove: async (daemonId: string, r: { agentId: string }) => void removes.push({ daemonId, ...r })
+    } as unknown as ControlSender
+    const { app, close } = buildHttpApp(prisma, undefined, undefined, control)
+    try {
+      const created = (await (
+        await app.inject({ method: 'POST', url: '/api/v1/orgs', payload: { name: 'Doomed', slug: 'doomed' } })
+      ).json()) as OrgBody
+      const agentId = '77777777-7777-4777-8777-777777777777'
+      await prisma.agent.create({
+        data: { id: agentId, orgId: created.id, name: 'pool-agent', runtime: 'claude', placementKind: 'set' }
+      })
+      await seedDutyGroup(prisma, '66666666-6666-4666-8666-666666666666', poolMember.id, [agentId], {
+        orgId: created.id
+      })
+
+      expect((await app.inject({ method: 'DELETE', url: `/api/v1/orgs/${created.id}` })).statusCode).toBe(204)
+      expect(removes).toEqual([{ daemonId: poolMember.id, agentId }])
+    } finally {
+      await close()
+    }
+  })
+
+  it('announces nothing when the deletion is refused', async () => {
+    // The rows are still there, so a member told to drop them would stop serving a LIVE org.
+    await prisma.daemon.create({
+      data: { id: 'ffffffff-ffff-4fff-8fff-ffffffffffff', orgId: DEFAULT_ORG_ID, sessionEpoch: 1n, status: 'ready' }
+    })
+    const removes: string[] = []
+    const control = {
+      agentUpsert: async () => {},
+      agentRemove: async (_d: string, r: { agentId: string }) => void removes.push(r.agentId)
+    } as unknown as ControlSender
+    const { app, close } = buildHttpApp(prisma, undefined, undefined, control)
+    try {
+      expect((await app.inject({ method: 'DELETE', url: ORG })).statusCode).toBe(409)
+      expect(removes).toEqual([])
     } finally {
       await close()
     }


### PR DESCRIPTION
## The bug

Deleting an organization cascaded its rows and told nobody.

Per-agent `DELETE /agents/:id` has always pushed `agent/remove` so the serving daemon drops the agent. On a pool member that push is what deletes the agent's sandbox claim — and the pod and the workspace volume the claim owns. `DELETE /orgs/:orgId` had no equivalent: it went straight to the cascade.

So every organization removed stranded one running sandbox per agent, with no row left anywhere to reap it from. Two such pods were found running on a live pool, both belonging to organizations that no longer existed.

An organization's **built-in agent** turns this from likely into certain: deletion of it is refused on the per-agent route by design, so the organization cascade is the only path by which it ever goes away — and that was exactly the path with no release.

## Why it needs a new method rather than a loop over `remove`

`AgentDelivery.remove` deliberately resolves the delivery set *after* the row is gone; its comment says so, and it works because duty membership has no foreign key to the agent, so a deleted agent's holder is still findable.

That inverts here. `DutyGroup` cascades from `Org`, so the ledger naming the pool member disappears **with** the agents and there is nothing left to resolve.

`planRemoval` reads the set first and returns the send. The route fires it only once the delete has committed — a refused delete (daemons present, Check cleanup pending) must not tell anyone to stop serving an organization that still exists.

Best-effort like every other replicate site: the rows are gone either way, and a member that missed the frame drops the agents from its next `register/ok` roster.

## Tests

Two added to `orgs.route.test.ts`, both failing before this change:

- an org whose agent is held by a pool member via a duty lease → `DELETE` sends exactly one `agent/remove`, to that member, for that agent;
- a `DELETE` refused with 409 (org still has daemons) sends nothing at all.

`pnpm --filter @agentconnect.md/control-plane test:int` → 98 files, 1471 tests, all passing.

## Relationship to the sweep

The orphan reconciler stays the backstop it was designed to be rather than the mechanism. It still collects anything that slips past — a member offline at delete time reconverges from its roster, and the sweep catches whatever neither path reached.
