### PR TITLE
style(daemon): one-line the comments the dial budget added

### DIFF
--- a/packages/daemon/src/shim/dialer.ts
+++ b/packages/daemon/src/shim/dialer.ts
@@ -24,12 +24,7 @@ export type ShimDialPhase = 'startup' | 'reconnect'
 /** Startup pacing: the pod was created moments ago, so a refusal means "not listening yet" and is met in ~100ms. */
 export const STARTUP_DIAL_BACKOFF: BackoffOpts = { baseMs: 100 }
 
-/** First startup attempt's opening-handshake budget; each later one doubles it, up to the caller's own.
- *  The pacing above assumes a failure is a REFUSAL and costs nothing, which is true of a listener still
- *  coming up and false of a dropped packet — a policy or route that has not converged swallows the SYN,
- *  and the transport's own 10s handshake timeout is then the whole cost of learning that. Reaching the
- *  ~100ms retry at all means bounding the attempt well under it; doubling keeps a genuinely slow-but-live
- *  handshake from being retried forever. */
+/** First startup handshake's budget, doubling after it: a dropped SYN reaches the pacing above, not the 10s default. */
 export const STARTUP_HANDSHAKE_TIMEOUT_MS = 1_000
 
 export interface ShimDialerDeps {
@@ -191,8 +186,7 @@ export class ShimDialer {
   private dialAndBind(
     dial: SupervisedDial,
     timeoutMs: number,
-    /** This attempt's opening-handshake budget; absent ⇒ the transport's own default. Bounds ONLY the
-     *  handshake: once the socket is open the path is proven and binding keeps the full budget below. */
+    /** This attempt's handshake budget, absent ⇒ the transport's default; binding keeps the full one either way. */
     handshakeTimeoutMs?: number
   ): Promise<{ connection: ShimConnection; closed: Promise<{ code: number; reason: string }> }> {
     const boundedMs = Math.max(1, timeoutMs)

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -392,8 +392,7 @@ describe('shim dial startup budget', () => {
       backoff: () => new Backoff({ baseMs: 10, jitter: () => 0 }),
       dial: async (_url, opts) => {
         handshakes.push(opts.handshakeTimeoutMs)
-        // What an unconverged network path actually produces: no refusal, just the transport
-        // giving up on an opening handshake nobody was ever going to answer.
+        // What an unconverged network path produces: no refusal, just a handshake nobody answers.
         if (attempts++ < failFirst) throw new Error('Opening handshake has timed out')
         return healthyTransport()
       },
@@ -404,17 +403,14 @@ describe('shim dial startup budget', () => {
   }
 
   it('bounds every pre-bind handshake and doubles it, rather than paying the transport default', async () => {
-    // A dropped SYN gives no refusal, so an unbounded attempt costs the transport's full 10s
-    // handshake timeout and the ~100ms startup pacing never gets to run. Bounding the attempt is
-    // what makes the retry the cheap thing it was written to be.
+    // Unbounded, a dropped SYN costs the transport's full 10s and the ~100ms startup pacing never runs.
     const clock = new VirtualClock()
     const handshakes: Array<number | undefined> = []
     const dialer = dialerRecordingHandshakes(clock, 2, handshakes)
 
     const connection = await runVirtual(clock, dialer.connect(SCRIPTED_ENDPOINT, record(), 60_000))
     expect(connection.binding.agentId).toBe('agent-a')
-    // Doubling, not a fixed floor: a handshake that is genuinely slow rather than dropped must
-    // still be allowed to finish instead of being retried out of existence.
+    // Doubling, not a fixed floor: a slow-but-live handshake must still be allowed to finish.
     expect(handshakes).toEqual([1_000, 2_000, 4_000])
   })
 


### PR DESCRIPTION
## Why

Review feedback on #1275 asked for this, and #1275 merged before the fix reached it: CLAUDE.md asks for one-line comments, and the block I put beside `STARTUP_HANDSHAKE_TIMEOUT_MS` was six lines of incident narrative.

Tightened to the invariant only — starts at 1s, doubles, so a dropped SYN reaches the ~100ms pacing instead of the transport's 10s default. The narrative lives in #1275's description, which is where it belongs. Same pass one-lined the `dialAndBind` parameter doc and three comments in the test.

No behaviour change: comments only.

## Tests

`test/shim-handshake.test.ts` → 32 passed. eslint and prettier clean.
