### PR TITLE
ci: fetch the sandbox packages from upstream instead of the runner's mirror

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -232,13 +232,20 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Generate Prisma client
         run: pnpm -r prisma:generate
-      # This is the only apt on the critical path, and a runner's mirror can black-hole a fetch
-      # for hours; the acquire timeouts fail one over in seconds and the step cap bounds the rest.
+      # The only apt on the critical path. A runner's regional mirror can black-hole a fetch for
+      # hours, and the acquire timeouts below do NOT rescue that: apt falls through to upstream,
+      # but per index file, so the step cap expires before the fallbacks finish. Drop the mirror
+      # list to upstream first and the timeouts go back to covering the ordinary case.
       - name: Install and enable the Linux kernel sandbox
         timeout-minutes: 5
         env:
           APT_OPTS: -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 -o Acquire::Retries=2
         run: |
+          # One package set on one job: reaching upstream directly is not a bandwidth decision.
+          # An `if` and not `[ … ] &&`, which under this shell's -e fails the step when absent.
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            echo 'https://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt >/dev/null
+          fi
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y --no-install-recommends bubblewrap ripgrep socat
           # Ubuntu 24.04 runners restrict unprivileged userns via AppArmor; bwrap (so the SRT sandbox) needs them.


### PR DESCRIPTION
## What is failing

`Sandbox (Linux)` dies in `Install and enable the Linux kernel sandbox`, before it has installed anything:

```
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
...
Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
##[error]The action 'Install and enable the Linux kernel sandbox' has timed out after 5 minutes.
```

Three consecutive runs across two pull requests today, each burning the whole five-minute cap. In the same minute as the first one, the same job passed on another PR — a runner that drew a working mirror.

## Why the existing guard does not catch it

The step's comment says the acquire timeouts "fail one over in seconds". They do not. When the regional mirror black-holes, apt *does* fall through to upstream — but it pays the timeout **per index file**, and there are enough of them (`noble`, `-updates`, `-backports`, `-security`, times several component lists) that the cap expires partway through the fallbacks.

So the timeouts bound each fetch and the cap bounds the step, and between them nothing bounds the *sum*. There is no retry either, so drawing a bad mirror is an unconditional red check on a change that never touched anything related.

## The fix

Rewrite the runner's mirror list to upstream before `apt-get update`, removing the first hop rather than trying to survive it. The timeouts stay and go back to covering what they were written for — a slow fetch, not a dead one.

One package set on one job, so this is not a bandwidth decision.

Guarded with `if [ -f … ]` rather than `[ -f … ] &&`: these `run:` blocks execute under `bash -e`, where a trailing false test would fail the step on any image that has no mirror list.

## Verification

Workflow parses; `prettier --check` clean. The real proof is this PR's own `Sandbox (Linux)` run — it exercises the changed step.
