### PR TITLE
refactor(daemon): give the JSON-Schema tool vocabulary a neutral home

### DIFF
--- a/packages/daemon/src/evaluation/environment.ts
+++ b/packages/daemon/src/evaluation/environment.ts
@@ -9,7 +9,7 @@
 import type { AgentAuthorshipClaim, ChannelAgentsOk, CollabRoutesSnapshot } from '@agentconnect.md/protocol'
 import { IntegrationSchema, type BindRuleConfig, type Integration } from '../agents/agent-schema.js'
 import type { ChannelAgentsRequest, SessionContext } from '../mcp/ops.js'
-import type { ToolDescriptor } from '../mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../tool-schema/descriptor.js'
 import type { VirtualPlatform, VirtualPlatformConnection } from './virtual-connections.js'
 
 /** One synthetic integration, projected into both `agent.integrations` and the

--- a/packages/daemon/src/mcp/control-server.ts
+++ b/packages/daemon/src/mcp/control-server.ts
@@ -4,7 +4,7 @@ import { mkdirSync, rmSync, chmodSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { decodeFrames, encodeFrame, type IpcRequest, type IpcResponse } from './ipc.js'
 import { executeTool, type OpsDeps, type SessionContext } from './ops.js'
-import type { ToolDescriptor } from './tool-descriptor.js'
+import type { ToolDescriptor } from '../tool-schema/descriptor.js'
 import type { Logger } from '../log.js'
 
 export interface McpControlDeps extends OpsDeps {

--- a/packages/daemon/src/mcp/ops/context.ts
+++ b/packages/daemon/src/mcp/ops/context.ts
@@ -1,6 +1,6 @@
 import type { MemoryWriteSource } from '../../memory/store.js'
 import type { MemoryScope } from '../../memory/types.js'
-import type { ToolDescriptor } from '../tool-descriptor.js'
+import type { ToolDescriptor } from '../../tool-schema/descriptor.js'
 
 /**
  * The platform-neutral slice a session's tools need. `SlackConnection` and

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -1,5 +1,5 @@
 import type { Integration } from '../agents/agent-schema.js'
-import { obj, unionOf, type ToolDescriptor } from './tool-descriptor.js'
+import { obj, unionOf, type ToolDescriptor } from '../tool-schema/descriptor.js'
 import { SESSION_TITLE_TOOL_NAME } from './session-title-tool.js'
 import { allAttachmentReadTools, attachmentReadToolsFor } from '../platforms/read-ports.js'
 import { EXTERNAL_MEMORY_TOOL_NAMES, MEMORY_TOOLS } from '../memory/tools.js'

--- a/packages/daemon/src/memory/providers/dispatching.ts
+++ b/packages/daemon/src/memory/providers/dispatching.ts
@@ -1,6 +1,6 @@
 import type { AgentMemoryBinding, CaptureReceipt, ExternalMemoryBinding, MemoryEntry } from '@agentconnect.md/protocol'
 import type { RuntimeDef } from '../../config/config-schema.js'
-import type { ToolDescriptor } from '../../mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../../tool-schema/descriptor.js'
 import { MEMORY_TOOLS } from '../tools.js'
 import type { MemoryFs, MemoryWriteSource } from '../store.js'
 import {

--- a/packages/daemon/src/memory/providers/external.ts
+++ b/packages/daemon/src/memory/providers/external.ts
@@ -5,7 +5,7 @@ import type {
   MemoryPluginOperation
 } from '@agentconnect.md/protocol'
 import { randomUUID } from 'node:crypto'
-import type { ToolDescriptor } from '../../mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../../tool-schema/descriptor.js'
 import { externalMemoryTools } from '../tools.js'
 import { MemoryConflictError, MemoryTooLargeError } from '../store.js'
 import { canonicalAgentMemoryKey } from '../keys.js'

--- a/packages/daemon/src/memory/providers/managed.ts
+++ b/packages/daemon/src/memory/providers/managed.ts
@@ -1,6 +1,6 @@
 import type { MemoryEntry } from '@agentconnect.md/protocol'
 import type { RuntimeDef } from '../../config/config-schema.js'
-import type { ToolDescriptor } from '../../mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../../tool-schema/descriptor.js'
 import { MEMORY_TOOLS } from '../tools.js'
 import {
   ensureMemory,

--- a/packages/daemon/src/memory/providers/native.ts
+++ b/packages/daemon/src/memory/providers/native.ts
@@ -1,6 +1,6 @@
 import type { MemoryEntry } from '@agentconnect.md/protocol'
 import type { RuntimeDef } from '../../config/config-schema.js'
-import type { ToolDescriptor } from '../../mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../../tool-schema/descriptor.js'
 import type { MemoryWriteSource } from '../store.js'
 import { nativeMemoryList, nativeMemoryRead, nativeMemoryWrite } from '../runtime/native.js'
 import type {

--- a/packages/daemon/src/memory/providers/none.ts
+++ b/packages/daemon/src/memory/providers/none.ts
@@ -1,6 +1,6 @@
 import type { MemoryEntry } from '@agentconnect.md/protocol'
 import type { RuntimeDef } from '../../config/config-schema.js'
-import type { ToolDescriptor } from '../../mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../../tool-schema/descriptor.js'
 import {
   MemoryProviderUnavailableError,
   type MemoryProvider,

--- a/packages/daemon/src/memory/tools.ts
+++ b/packages/daemon/src/memory/tools.ts
@@ -1,5 +1,5 @@
 import type { MemoryPluginOperation } from '@agentconnect.md/protocol'
-import { obj, type ToolDescriptor } from '../mcp/tool-descriptor.js'
+import { obj, type ToolDescriptor } from '../tool-schema/descriptor.js'
 
 /** Refusal surfaced to the model when an isolated session tries to access agent memory shared with other users. */
 export const MEMORY_ACCESS_BLOCKED =

--- a/packages/daemon/src/memory/types.ts
+++ b/packages/daemon/src/memory/types.ts
@@ -10,7 +10,7 @@ import type {
   MemoryPluginOperation
 } from '@agentconnect.md/protocol'
 import type { RuntimeDef } from '../config/config-schema.js'
-import type { ToolDescriptor } from '../mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../tool-schema/descriptor.js'
 import type { MemoryWriteSource, ManagedMemoryHistoryPage } from './store.js'
 import type { DistillationTurn } from './distill.js'
 

--- a/packages/daemon/src/platforms/read-ports.ts
+++ b/packages/daemon/src/platforms/read-ports.ts
@@ -37,7 +37,7 @@
  * names do not move. They live in their platform's own module now, which is the
  * whole point — core no longer knows that either name exists.
  */
-import type { ToolDescriptor } from '../mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../tool-schema/descriptor.js'
 import { SLACK_ATTACHMENT_TOOL } from './slack/attachments.js'
 import { TELEGRAM_ATTACHMENT_TOOL } from './telegram/attachments.js'
 

--- a/packages/daemon/src/platforms/slack/attachments.ts
+++ b/packages/daemon/src/platforms/slack/attachments.ts
@@ -11,7 +11,7 @@
  * shared resource_link points at, and what warm ACP sessions already carry in
  * their descriptor list. The injection mechanism generalized; the name did not.
  */
-import type { ToolDescriptor } from '../../mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../../tool-schema/descriptor.js'
 
 export const SLACK_ATTACHMENT_TOOL: ToolDescriptor = {
   name: 'readSlackFile',

--- a/packages/daemon/src/platforms/telegram/attachments.ts
+++ b/packages/daemon/src/platforms/telegram/attachments.ts
@@ -10,7 +10,7 @@
  *
  * THE NAME IS FROZEN — see the note on Slack's sibling module.
  */
-import type { ToolDescriptor } from '../../mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../../tool-schema/descriptor.js'
 
 export const TELEGRAM_ATTACHMENT_TOOL: ToolDescriptor = {
   name: 'readTelegramFile',

--- a/packages/daemon/src/tool-schema/descriptor.ts
+++ b/packages/daemon/src/tool-schema/descriptor.ts
@@ -1,4 +1,5 @@
-import type { JSONValue } from '@modelcontextprotocol/server'
+/** A JSON value, defined locally so this vocabulary stays a dependency-free leaf. */
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue }
 
 /** A tool descriptor in MCP's `tools/list` shape: name, model-facing description, and an argument JSON Schema. */
 export interface ToolDescriptor {
@@ -7,9 +8,9 @@ export interface ToolDescriptor {
   inputSchema: ObjectToolSchema | ObjectUnionSchema
 }
 
-export type ToolProperties = Record<string, JSONValue>
+export type ToolProperties = Record<string, JsonValue>
 
-export interface ObjectToolSchema extends Record<string, JSONValue> {
+export interface ObjectToolSchema extends Record<string, JsonValue> {
   type: 'object'
   properties: ToolProperties
   required: string[]
@@ -17,7 +18,7 @@ export interface ObjectToolSchema extends Record<string, JSONValue> {
 }
 
 /** A root object schema whose `oneOf` branches are mutually exclusive call modes (used by sendMessage). */
-export interface ObjectUnionSchema extends Record<string, JSONValue> {
+export interface ObjectUnionSchema extends Record<string, JsonValue> {
   type: 'object'
   oneOf: ObjectToolSchema[]
 }

--- a/packages/daemon/test/mcp-tool-args.test.ts
+++ b/packages/daemon/test/mcp-tool-args.test.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { SEND_MESSAGE_BRANCHES, TOOL_ARG_SCHEMAS } from '../src/mcp/ops.js'
 import { GITHUB_REVIEW_TOOLS, RETIRED_ORCHESTRATION_TOOLS, toolsForIntegrations } from '../src/mcp/tools.js'
 import { externalMemoryTools } from '../src/memory/tools.js'
-import type { ToolDescriptor } from '../src/mcp/tool-descriptor.js'
+import type { ToolDescriptor } from '../src/tool-schema/descriptor.js'
 import type { Integration } from '../src/agents/agent-schema.js'
 
 /**


### PR DESCRIPTION
## What

`src/mcp/tool-descriptor.ts` (35 lines: `ToolDescriptor`, `ObjectToolSchema`, `ObjectUnionSchema`, `obj()`, `unionOf()`) was MCP-agnostic JSON-Schema vocabulary that happened to live under `mcp/`. That made it the **single remaining edge closing the `memory` -> `mcp` direction**: `memory/tools.ts`, `memory/types.ts`, and all five memory providers imported it purely for the vocabulary.

Moved it to `src/tool-schema/descriptor.ts` — a new tiny directory holding a leaf module with **zero imports**. `JSONValue` is now defined locally (`JsonValue`) instead of imported from `@modelcontextprotocol/server`, which is what makes the leaf truly dependency-free.

**No re-export shell is left in `mcp/`** — every importer points at the real owner.

## Importers retargeted (15)

- `src/mcp/`: `tools.ts`, `control-server.ts`, `ops/context.ts`
- `src/memory/`: `tools.ts`, `types.ts`, `providers/{none,native,managed,external,dispatching}.ts`
- `src/platforms/`: `read-ports.ts`, `slack/attachments.ts`, `telegram/attachments.ts`
- `src/evaluation/environment.ts`
- `test/mcp-tool-args.test.ts`

## Verification

- `rg -a "from '\.\./+.*mcp/" src/memory/` -> **no matches**: zero imports from `src/memory/**` pointing at `src/mcp/**`.
- `pnpm typecheck` clean.
- `vitest run test/mcp-tools.test.ts test/mcp-tool-args.test.ts test/memory-provider-dispatch.test.ts test/memory.test.ts` -> 118 passed.
- `prettier --check` + `eslint` clean on touched files.

Pure move; no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)