### PR TITLE
refactor(daemon): own the runtime facts/probe cluster in a RuntimeFactsRegistry

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -76,10 +76,9 @@ import { configureWorkspaceGitOrigins } from './workspace/git-origin-policy.js'
 import { buildMcpServers } from './mcp/inject.js'
 import { resolveAgentMcpServers, RESERVED_MCP_SERVER_NAME } from './mcp/resolve-servers.js'
 import { toolsForIntegrations, GITHUB_REVIEW_TOOLS, KNOWLEDGE_TOOLS } from './mcp/tools.js'
-import { MEMORY_TOOL_NAMES } from './memory/tools.js'
+import { MEMORY_TOOL_NAMES, MEMORY_TOOLS } from './memory/tools.js'
 import { isSessionTitleToolCall } from './mcp/session-title-tool.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT, readOnlyExtractionMode } from './memory/distill.js'
-import { MEMORY_TOOLS } from './memory/tools.js'
 import {
   DREAM_MODEL_READABLE_CREDENTIALS_REASON,
   DreamRunner,
@@ -197,17 +196,14 @@ import { startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.
 import { declaredRuntimeCatalog, loadK8sRuntimeTable, type K8sRuntimeAcpSnapshot } from './runtimes/k8s-runtimes.js'
 import { ensureNodeBinOnPath } from './runtimes/exec-path.js'
 import {
-  probeAllRuntimes,
   isAuthRequiredError,
   sweepStaleProbeRoots,
   type ProbeOptions,
   type RuntimeProbeResult
 } from './runtimes/runtime-prober.js'
-import { ModelCatalogService, catalogFingerprint } from './runtimes/model-catalog.js'
+import { ModelCatalogService } from './runtimes/model-catalog.js'
 import { makeModelEnumerator } from './runtimes/model-enumerator.js'
 import { defaultProbeHostFactory } from './acp/probe-host-factory.js'
-import { capsFromConfigOptions, augmentEffortOptions } from './runtimes/config-caps.js'
-import { isClaudeRuntimeDef } from './runtime-defs/claude-runtime.js'
 import { runtimeHomePath } from './runtimes/runtime-home.js'
 import {
   applyCodexSessionFloor,
@@ -222,7 +218,7 @@ import {
 import { KeyServerClient, type KeyGrant } from './key-server/client.js'
 import { internalSessionKey, ModelSessionHostPool, type ModelSessionHostPoolHost } from './key-server/session-hosts.js'
 import { CuratedRuntimeAdmission } from './runtimes/curated-admission.js'
-import { runtimeSandboxReadRoots } from './launch/compose.js'
+import { RuntimeFactsRegistry, PROBE_TTL_MS, type RuntimeFactsHost } from './runtimes/facts-registry.js'
 import { assembleRuntimeLaunch } from './launch/assemble.js'
 import { resolveTrustedExecutable, trustedRuntimeReadRoots } from './runtimes/read-roots.js'
 import { nodeExecArgvModuleEntries } from './runtimes/node-exec-argv.js'
@@ -344,10 +340,7 @@ import type {
   RegisterReq,
   RelayRosterEntry,
   CronReport,
-  FactsRuntimeProfile,
   FactsMcpServer,
-  McpTransportCapabilities,
-  RuntimeModelCatalog,
   IntegrationChannel,
   Drain,
   DrainProgress,
@@ -877,40 +870,9 @@ export class Daemon {
   // runtimeProfiles() reports — ACP protocol version, the adapter's own version, MCP transports —
   // stay empty and the published snapshot describes nothing.
   private k8sDeclaredAcp: Record<string, K8sRuntimeAcpSnapshot> = {}
-  private runtimeNames: Record<string, string> = {} // registry id -> display name (for CP reporting)
-  private runtimeVersions: Record<string, string> = {} // registry id -> version (for the facts/daemon-runtimes snapshot)
-  // Models learned by actively probing each runtime (registry id -> model ids).
-  // Empty/absent until the post-connect probe sweep completes; feeds runtimeProfiles().
-  private runtimeModels = new Map<string, string[]>()
-  // ACP protocol version each runtime negotiated at its last probe; feeds runtimeProfiles().
-  private runtimeAcpVersions = new Map<string, number>()
-  // The agent's self-reported version (`agentInfo.version` from `initialize`) learned
-  // at the last probe — the ACTUAL running adapter release (e.g. claude-agent-acp
-  // 0.59.0). Preferred over the registry's declared version in runtimeProfileFor().
-  private runtimeProbedVersions = new Map<string, string>()
-  // MCP transports each runtime advertised at its last probe; feeds runtimeProfiles()
-  // and gates which configured http/sse servers attach at session/new (absent ⇒ not
-  // probed yet ⇒ assume stdio-only but attach optimistically — see resolve-servers.ts).
-  private runtimeMcpCaps = new Map<string, McpTransportCapabilities>()
-  // Provenance of runtimeModels entries: 'cached' = hydrated from the local
-  // catalog cache at boot (a live probe has not confirmed it this process) —
-  // the activation model gate treats it as permissive; 'probed' = live result.
-  private runtimeModelsSource = new Map<string, 'cached' | 'probed'>()
-  // Runtimes whose last probe was rejected with the ACP auth-required error
-  // (-32000): installed but needing an interactive login on this host. Feeds the
-  // console's per-runtime login warning; cleared on any successful probe.
-  private runtimeAuthRequired = new Set<string>()
-  // Same signal observed on a LIVE turn (dispatch): kept separate from the
-  // probe-derived set because a successful probe must not clear it —
-  // claude-agent-acp initializes, opens sessions, and enumerates models fine
-  // while logged out and only rejects the live prompt with -32000, so the probe
-  // sweep is blind to its login state. Cleared by the next successful turn.
-  private runtimeAuthRequiredLive = new Set<string>()
-  // Report-shape model catalogs (last-good CAPABILITY knowledge, augmented for
-  // reporting). Deliberately independent of the fail-to-empty rule that wipes
-  // runtimeModels (ADVERTISEMENT): a probe failure empties the offered list but
-  // keeps the catalog, so the CP's capability data survives transient timeouts.
-  private runtimeCatalogs = new Map<string, RuntimeModelCatalog>()
+  // Per-runtime facts (names, versions, models, ACP/MCP caps, login state, catalogs),
+  // the probe sweep that learns them, and the `facts/daemon-runtimes` snapshot.
+  private runtimeFacts!: RuntimeFactsRegistry
   private modelCatalogSvc?: ModelCatalogService
   // Daemon-local MCP definitions; CP definitions are overlaid per organization at use sites.
   private mcpServerDefs: Record<string, import('./config/config-schema.js').McpServerDef> = {}
@@ -920,11 +882,6 @@ export class Daemon {
   private memoryConnections?: CpMemoryConnectionRegistry
   /** Durable reply-after-delivery capture pump. Bodies remain in LocalStore. */
   private memoryOutbox?: MemoryCaptureOutbox
-  private probing = false // a probe sweep is in flight (dedup concurrent onReady fires)
-  private ordinaryProbePending = false // a CP-ready sweep arrived behind a local curated sweep
-  private curatedProbePending = false // a local TTL sweep arrived behind another sweep
-  private lastProbeAtMs = 0 // when ordinary runtimes were last swept; gates re-probe on reconnect
-  private runtimeProbeTimer?: TimerHandle
   private cpClient?: CpClient
   private remoteWebchatGrants?: RemoteWebchatGrantManager
   private managedSkillCache?: ManagedSkillCache
@@ -1161,8 +1118,9 @@ export class Daemon {
     this.githubReviews = new GithubReviewOrchestrator(this.githubReviewHost())
     this.curatedRuntimeAdmission = new CuratedRuntimeAdmission({
       now: () => this.clock.now(),
-      ttlMs: Daemon.PROBE_TTL_MS
+      ttlMs: PROBE_TTL_MS
     })
+    this.runtimeFacts = new RuntimeFactsRegistry(this.runtimeFactsHost())
     this.requestExit = opts.requestExit ?? ((code) => process.exit(code))
     this.fleetUpgrade = new FleetUpgradeCoordinator({
       log: () => this.log,
@@ -1726,12 +1684,7 @@ export class Daemon {
     const { runtimes: installed, entries: installedEntries } = installedCatalog
     this.runtimeCatalog = installedCatalog
     this.refreshAdmittedRuntimes()
-    this.runtimeNames = Object.fromEntries(
-      Object.entries(installedEntries).map(([id, entry]) => [id, entry.name || id])
-    )
-    this.runtimeVersions = Object.fromEntries(
-      Object.entries(installedEntries).map(([id, entry]) => [id, entry.version])
-    )
+    this.runtimeFacts.setInstalled(installedEntries)
     this.log.info(`runtimes ready: ${Object.keys(this.runtimes).join(', ') || '(none)'}`)
     const pendingCurated = Object.keys(installed).filter((id) => installedEntries[id]?.source === 'curated')
     if (pendingCurated.length) this.log.info(`runtimes pending ACP admission: ${pendingCurated.join(', ')}`)
@@ -1808,10 +1761,10 @@ export class Daemon {
     // Model-catalog cache: synchronous last-good hydrate BEFORE the CP client
     // starts, so the register-time facts snapshot already carries models + the
     // capability matrix instead of blanking the CP until the sweep completes.
-    await this.hydrateRuntimeCatalogCache()
+    await this.runtimeFacts.hydrateFromCache()
     // The image's declared models are the fresher truth than any cached row, and stay
     // `cached` provenance: no live probe confirmed them, so model gates remain permissive.
-    this.applyK8sDeclaredFacts()
+    this.runtimeFacts.applyDeclaredFacts(this.k8sDeclaredModels, this.k8sDeclaredAcp)
     // Started HERE, not when the plane comes up: the probe projects onto the resolved catalog, and
     // that is only assembled further down start(). Kicking it off earlier meant it returned
     // immediately every time — a probe that never ran, and a daemon that silently advertised
@@ -1837,9 +1790,9 @@ export class Daemon {
         mcpSocketPath: mcpSocketPath(root)
       }),
       onUpdated: async (runtimeId) => {
-        await this.rebuildRuntimeCatalog(runtimeId)
+        await this.runtimeFacts.rebuildCatalog(runtimeId)
         this.cpClient?.emitDaemonRuntimes?.(
-          this.admittedRuntimeIds().map((id) => this.runtimeProfileFor(id)),
+          this.admittedRuntimeIds().map((id) => this.runtimeFacts.profileFor(id)),
           this.mcpServerFactsFromDefs()
         )
       }
@@ -2235,7 +2188,7 @@ export class Daemon {
           ...resolveAgentMcpServers({
             enabled: agent.mcpServers,
             defs: this.mcpDefsForAgent(agent.id),
-            caps: this.runtimeMcpCaps.get(agent.runtime),
+            caps: this.runtimeFacts.mcpCapabilities(agent.runtime),
             ...(this.agentRunsInSandbox(agent)
               ? {
                   resolveStdioCommand: (command: string, entries: { name: string; value: string }[]) =>
@@ -2351,7 +2304,7 @@ export class Daemon {
     if (this.dreamOperationsAllowed()) await this.dreamRunner().initialize()
     // Curated admission belongs to local runtime resolution, not CP readiness.
     // Start it even when the control plane is disabled or still unreachable.
-    void this.probeRuntimesAndEmit(false).finally(() => this.armRuntimeProbeRefresh())
+    void this.runtimeFacts.probeAndEmit(false).finally(() => this.runtimeFacts.armProbeRefresh())
     if (!this.k8s) startControlPlane(root)
     this.armIdleSweep()
     this.armStoreRetentionSweep()
@@ -5209,7 +5162,7 @@ export class Daemon {
   /** Apply the Agent's configured runtime policy to one live session. Callers that
    *  fence a pending prompt await this; reconciliation fans it out in the background. */
   private async applyConfiguredRuntimeSettings(agent: LoadedAgent, host: AcpHost, sessionId: string): Promise<void> {
-    const catalog = this.runtimeCatalogs.get(agent.runtime)
+    const catalog = this.runtimeFacts.modelCatalog(agent.runtime)
     // A fresh ACP session may advertise its baseline as the literal `default`.
     // Catalog metadata intentionally keeps defaultModel concrete, so fall back to
     // that selectable entry when the Agent leaves its model unpinned.
@@ -6129,7 +6082,7 @@ export class Daemon {
       activeGithubReplyBatch: (key) => this.activeGithubReplyBatchMeta.get(key),
       agentLink: (agentId) => this.agentLink(agentId),
       sessionLink: (acpSessionId, source) => this.sessionLink(acpSessionId, source),
-      runtimeNames: () => this.runtimeNames,
+      runtimeNames: () => this.runtimeFacts.runtimeNames(),
       hostForStoredSession: async (agentId, acpSessionId) =>
         await this.modelSessions.hostForStoredSession(agentId, acpSessionId)
     }
@@ -9039,7 +8992,7 @@ export class Daemon {
       : undefined
     const configuredPermissionMode =
       runtimeAgent?.permissionMode ??
-      this.runtimeCatalogs.get(runtimeAgent?.runtime ?? agent.runtime)?.defaultPermissionMode
+      this.runtimeFacts.modelCatalog(runtimeAgent?.runtime ?? agent.runtime)?.defaultPermissionMode
     const effectivePermissionPreset =
       permissionPresetOverride ??
       (configuredPermissionMode
@@ -9260,7 +9213,7 @@ export class Daemon {
 
       // A completed prompt proves the runtime's credentials work — drop any
       // login-required mark (no-op emit unless the flag actually flips).
-      this.noteRuntimeAuthFromTurn(agent.runtime, false)
+      this.runtimeFacts.noteAuthFromTurn(agent.runtime, false)
       if (p.outputSuppressed) {
         evaluation.finishEvaluation('turn.cancelled', { reason: p.outputSuppressed })
         if (p.outputSuppressed === 'loop protection') settlement.finalPhase = 'problem'
@@ -9707,7 +9660,7 @@ export class Daemon {
     // classification catches the expired/revoked-credential family that
     // adapters surface as -32603 internal errors with auth wording.
     if (isAuthRequiredError(err) || turnFailureCode(err) === HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED)
-      this.noteRuntimeAuthFromTurn(agent.runtime, true)
+      this.runtimeFacts.noteAuthFromTurn(agent.runtime, true)
     if (p.outputSuppressed) {
       evaluation.finishEvaluation('turn.cancelled', { reason: p.outputSuppressed })
       if (p.outputSuppressed === 'loop protection') settlement.finalPhase = 'problem'
@@ -9991,7 +9944,7 @@ export class Daemon {
     return {
       botName: agent.name,
       botUrl: this.agentLink(entry.agentId),
-      runtime: this.runtimeNames[agent.runtime] ?? agent.runtime,
+      runtime: this.runtimeFacts.runtimeNames()[agent.runtime] ?? agent.runtime,
       model: (await this.buildStatusInfo(p)).model ?? turnModel ?? 'default',
       sessionUrl: this.sessionLink(sessionId, this.sessionLinkSource(plan.platform, plan.integrationId)),
       ...(plan.hopLimitNotice ? { notice: plan.hopLimitNotice } : {})
@@ -10490,9 +10443,9 @@ export class Daemon {
     // explicit lack of a selector authoritative; only fall back when the host does not
     // currently own this session.
     const modelSessionIsLive = acpSessionId !== undefined && host?.hasSession?.(acpSessionId) === true
-    const runtimeModels = agent ? this.runtimeModels.get(agent.runtime) : undefined
+    const runtimeModels = agent ? this.runtimeFacts.offeredModels(agent.runtime) : undefined
     const models = model?.models ?? (!modelSessionIsLive ? runtimeModels : undefined)
-    const runtimeDefaultModel = agent ? this.runtimeCatalogs.get(agent.runtime)?.defaultModel : undefined
+    const runtimeDefaultModel = agent ? this.runtimeFacts.modelCatalog(agent.runtime)?.defaultModel : undefined
     const fallbackModel =
       !modelSessionIsLive && models?.length
         ? runtimeDefaultModel && models.includes(runtimeDefaultModel)
@@ -13510,15 +13463,15 @@ export class Daemon {
 
   private activationCapabilityError(agent: LoadedAgent): string | undefined {
     const model = agent.runtimeOverrides?.model
-    const offeredModels = this.runtimeModels.get(agent.runtime) ?? []
+    const offeredModels = this.runtimeFacts.offeredModels(agent.runtime) ?? []
     // A cache-hydrated list is not live knowledge: enforcing it would reject
     // models added while this daemon was down (fail-open like the empty list;
     // the gate turns strict once the first real probe lands).
-    const offeredIsLive = this.runtimeModelsSource.get(agent.runtime) !== 'cached'
+    const offeredIsLive = this.runtimeFacts.offeredModelsAreLive(agent.runtime)
     if (model && offeredIsLive && offeredModels.length > 0 && !offeredModels.includes(model)) {
       return `model "${model}" is not offered by runtime "${agent.runtime}"`
     }
-    const caps = this.runtimeMcpCaps.get(agent.runtime)
+    const caps = this.runtimeFacts.mcpCapabilities(agent.runtime)
     for (const name of agent.mcpServers) {
       if (name === RESERVED_MCP_SERVER_NAME) return `MCP server name "${name}" is reserved`
       const def = this.mcpDefsForAgent(agent.id)[name]
@@ -13941,8 +13894,8 @@ export class Daemon {
       registrationFeatures: () => this.registrationFeatures(),
       admittedRuntimeIds: () => this.admittedRuntimeIds(),
       reportedRuntimeIds: () => this.reportedRuntimeIds(),
-      runtimeNames: () => this.runtimeNames,
-      runtimeProfileFor: (id) => this.runtimeProfileFor(id),
+      runtimeNames: () => this.runtimeFacts.runtimeNames(),
+      runtimeProfileFor: (id) => this.runtimeFacts.profileFor(id),
       mcpServerFactsFromDefs: () => this.mcpServerFactsFromDefs(),
       cpLocalState: () => this.cpLocalState(),
       metrics: () => this.metrics,
@@ -13951,7 +13904,7 @@ export class Daemon {
       bootstrapUpgradeCapable: () => this.bootstrapUpgradeCapable(),
       runBootstrapFleetUpgrade: (targetVersion) => this.fleetUpgrade.runBootstrapFleetUpgrade(targetVersion),
       readiness: () => this.readiness,
-      probeRuntimesAndEmit: () => this.probeRuntimesAndEmit(),
+      probeRuntimesAndEmit: () => this.runtimeFacts.probeAndEmit(),
       syncOrganizationSuggestions: () => this.syncOrganizationSuggestions(),
       memoryConnections: () => this.memoryConnections,
       replayHookTerminalReports: () => this.replayHookTerminalReports(),
@@ -14396,54 +14349,31 @@ export class Daemon {
     return initialRegistry
   }
 
-  /** Build the current profile entry for a runtime (one element of the
-   *  `facts/daemon-runtimes` snapshot), folding in any models learned by the
-   *  probe sweep. */
-  private runtimeProfileFor(id: string): FactsRuntimeProfile {
+  /** The outward calls the runtime facts/probe cluster makes — see RuntimeFactsRegistry. */
+  private runtimeFactsHost(): RuntimeFactsHost {
     return {
-      runtime: id,
-      // Prefer the probed adapter version (the actual running release, learned at the
-      // last probe's `initialize`) over the registry's declared version; fall back to
-      // the declared version when a runtime hasn't been probed / reported none.
-      version: this.runtimeProbedVersions.get(id) || this.runtimeVersions[id] || '',
-      models: this.runtimeModels.get(id) ?? [],
-      acpSupport: 'full',
-      acpProtocolVersion: this.runtimeAcpVersions.get(id),
-      toolCalling: true,
-      mcpCapabilities: this.runtimeMcpCaps.get(id),
-      modelsSource: this.runtimeModelsSource.get(id),
-      // Capability matrix rides every frame it exists for — including probe-failure
-      // rounds where models[] empties (advertisement ≠ capability knowledge).
-      modelCatalog: this.runtimeCatalogs.get(id),
-      ...(this.runtimeAuthRequired.has(id) || this.runtimeAuthRequiredLive.has(id) ? { authRequired: true } : {})
-    }
-  }
-
-  /** Fold a live turn's auth outcome into the facts state. A turn rejected with
-   *  ACP -32000 marks the agent's runtime login-required; a completed turn is
-   *  the definitive "logged in" signal and clears both the live mark and any
-   *  stale probe-derived one (the user logged in between sweeps). Re-emits the
-   *  facts snapshot only when the reported flag actually flips. Called from the
-   *  dispatch hot path (right after prompt / inside its failure handler), so
-   *  the telemetry emit is best-effort like emitStoredUsageReport — it must
-   *  never affect message delivery. */
-  private noteRuntimeAuthFromTurn(runtimeId: string, authRequired: boolean): void {
-    let changed: boolean
-    if (authRequired) {
-      changed = !this.runtimeAuthRequiredLive.has(runtimeId) && !this.runtimeAuthRequired.has(runtimeId)
-      this.runtimeAuthRequiredLive.add(runtimeId)
-    } else {
-      changed = this.runtimeAuthRequiredLive.delete(runtimeId)
-      if (this.runtimeAuthRequired.delete(runtimeId)) changed = true
-    }
-    if (!changed) return
-    try {
-      this.cpClient?.emitDaemonRuntimes?.(
-        this.reportedRuntimeIds().map((id) => this.runtimeProfileFor(id)),
-        this.mcpServerFactsFromDefs()
-      )
-    } catch (err) {
-      this.log.debug(`runtime auth facts emit failed (${runtimeId}): ${(err as Error).message}`)
+      log: () => this.log,
+      clock: () => this.clock,
+      store: () => this.store,
+      draining: () => this.draining,
+      catalog: () => this.runtimeCatalog,
+      admittedRuntimes: () => this.runtimes,
+      refreshAdmitted: () => this.refreshAdmittedRuntimes(),
+      reportedRuntimeIds: () => this.reportedRuntimeIds(),
+      curatedAdmission: () => this.curatedRuntimeAdmission,
+      emitDaemonRuntimes: (profiles, mcpServers) => this.cpClient?.emitDaemonRuntimes?.(profiles, mcpServers),
+      updateCapabilities: () => this.cpClient?.updateCapabilities?.(),
+      mcpServerFacts: () => this.mcpServerFactsFromDefs(),
+      noteCatalogProbe: (input) => void this.modelCatalogSvc?.noteProbe(input),
+      launch: () => ({
+        k8s: this.k8s,
+        fakeHosts: this.opts.hostFactory !== undefined,
+        ...(this.opts.probeRuntimes ? { probe: this.opts.probeRuntimes } : {}),
+        ...(this.sandboxMechanism ? { sandboxMechanism: this.sandboxMechanism } : {}),
+        daemonRoot: this.root,
+        agentsRoot: this.cfg.agentsDir,
+        isolateAccountApps: this.cfg.security.isolateAccountApps
+      })
     }
   }
 
@@ -14453,23 +14383,6 @@ export class Daemon {
    * served cache-first from `<root>/acp_registry.json` in an image). Replaces host
    * executable discovery, which can only ever answer "nothing" in a daemon pod.
    */
-  /** Fold the declared/probed snapshot into the SAME maps runtimeProfiles() reads, so a probed
-   *  fact and a locally probed one are indistinguishable downstream. */
-  private applyK8sDeclaredFacts(): void {
-    for (const [runtimeId, models] of Object.entries(this.k8sDeclaredModels)) {
-      this.runtimeModels.set(runtimeId, [...models])
-      this.runtimeModelsSource.set(runtimeId, 'cached')
-    }
-    for (const [runtimeId, snapshot] of Object.entries(this.k8sDeclaredAcp)) {
-      if (snapshot.protocolVersion !== undefined) this.runtimeAcpVersions.set(runtimeId, snapshot.protocolVersion)
-      const mcp = snapshot.capabilities?.mcpCapabilities
-      if (mcp && typeof mcp === 'object') {
-        const caps = mcp as { http?: unknown; sse?: unknown }
-        this.runtimeMcpCaps.set(runtimeId, { http: caps.http === true, sse: caps.sse === true })
-      }
-    }
-  }
-
   private declaredPoolCatalog(root: string, resolved: ResolvedRuntimeCatalog): ResolvedRuntimeCatalog {
     // Kept for a file-supplied table (an override, or a daemon started before its first probe
     // returns). The authoritative answer comes from the sandbox itself — see probeK8sRuntimes.
@@ -14506,12 +14419,8 @@ export class Daemon {
       // The profile reports these, and they come from the catalog entry rather than the table —
       // so without this refresh the version the image just told us about would be reported as the
       // registry's, or as an empty string.
-      for (const [id, entry] of Object.entries(catalog.entries)) {
-        this.runtimeNames[id] = entry.name
-        if (entry.version) this.runtimeVersions[id] = entry.version
-        this.runtimeProbedVersions.set(id, entry.version || (this.runtimeProbedVersions.get(id) ?? ''))
-      }
-      this.applyK8sDeclaredFacts()
+      this.runtimeFacts.noteImageCatalog(catalog.entries)
+      this.runtimeFacts.applyDeclaredFacts(this.k8sDeclaredModels, this.k8sDeclaredAcp)
       // The half of readiness only this call can settle: before it the member advertises nothing
       // and the CP would assign it nothing, so it is not servable however healthy it looks.
       this.k8sRuntimeProbed = true
@@ -14519,10 +14428,7 @@ export class Daemon {
       this.log.info(
         `runtimes ready (probed): ${table.runtimes.map((entry) => `${entry.id}@${entry.version}`).join(', ') || '(none)'}`
       )
-      this.cpClient?.emitDaemonRuntimes?.(
-        this.reportedRuntimeIds().map((id) => this.runtimeProfileFor(id)),
-        this.mcpServerFactsFromDefs()
-      )
+      this.runtimeFacts.emitFacts()
     } catch (err) {
       // Advertising nothing is the honest outcome: the Control Plane then assigns no agent, which
       // is better than assigning one to a daemon that cannot launch it.
@@ -14596,60 +14502,6 @@ export class Daemon {
     return declared.catalog
   }
 
-  /** Synchronously pre-fill the in-memory runtime maps from the SQLite last-good
-   *  catalog cache (design runtime-model-catalog.md §4): the register-time facts
-   *  snapshot then carries cached models + matrix instead of an empty REPLACE
-   *  that would wipe the CP's learned state until the sweep completes. Rows for
-   *  runtimes not in the installed catalog are ignored (kept on disk — the
-   *  runtime may only be temporarily unresolved); rows older than 30 days are
-   *  garbage-collected. The store reads only this member's rows, so a member can
-   *  never boot advertising models a peer's image runs and its own does not. */
-  private async hydrateRuntimeCatalogCache(): Promise<void> {
-    try {
-      for (const meta of await this.store.listRuntimeCatalogMetas()) {
-        if (!this.runtimeCatalog.entries[meta.runtimeId]) continue
-        await this.rebuildRuntimeCatalog(meta.runtimeId)
-        const cachedModels = (await this.store.listRuntimeModelCaps(meta.runtimeId)).map((r) => r.modelId)
-        if (cachedModels.length > 0 && (this.runtimeModels.get(meta.runtimeId) ?? []).length === 0) {
-          this.runtimeModels.set(meta.runtimeId, cachedModels)
-          this.runtimeModelsSource.set(meta.runtimeId, 'cached')
-        }
-      }
-    } catch (err) {
-      this.log.warn(`catalog: cache hydrate failed: ${formatErr(err)}`)
-    }
-  }
-
-  /** Rebuild one runtime's report-shape catalog from the cache: raw stored caps
-   *  plus daemon-side synthetic effort levels (Claude max/ultracode) so the
-   *  console vocabulary always matches the live-session pickers. */
-  private async rebuildRuntimeCatalog(id: string): Promise<void> {
-    const meta = await this.store.getRuntimeCatalogMeta(id)
-    if (!meta) {
-      this.runtimeCatalogs.delete(id)
-      return
-    }
-    const rt = this.runtimeCatalog.entries[id]?.runtime
-    const claude = rt ? isClaudeRuntimeDef(rt) : false
-    const models = (await this.store.listRuntimeModelCaps(id)).map((r) => ({
-      id: r.modelId,
-      ...(r.caps.name ? { name: r.caps.name } : {}),
-      ...(r.caps.efforts !== undefined
-        ? { efforts: claude ? augmentEffortOptions(r.caps.efforts) : r.caps.efforts }
-        : {}),
-      ...(r.caps.defaultEffort ? { defaultEffort: r.caps.defaultEffort } : {}),
-      ...(r.caps.fastMode !== undefined ? { fastMode: r.caps.fastMode } : {})
-    }))
-    this.runtimeCatalogs.set(id, {
-      models: models.slice(0, 128),
-      ...(meta.defaultModel ? { defaultModel: meta.defaultModel } : {}),
-      ...(meta.permissionModes ? { permissionModes: meta.permissionModes } : {}),
-      ...(meta.defaultPermissionMode ? { defaultPermissionMode: meta.defaultPermissionMode } : {}),
-      source: meta.source,
-      observedAt: new Date(meta.observedAt).toISOString()
-    })
-  }
-
   private refreshAdmittedRuntimes(): void {
     this.runtimes = this.curatedRuntimeAdmission.filterCatalog(this.runtimeCatalog).runtimes
   }
@@ -14673,283 +14525,6 @@ export class Daemon {
     ]
   }
 
-  /** The `facts/daemon-runtimes` snapshot for the currently reported runtime set. */
-  private emitDaemonRuntimeFacts(): void {
-    this.cpClient?.emitDaemonRuntimes?.(
-      this.reportedRuntimeIds().map((id) => this.runtimeProfileFor(id)),
-      this.mcpServerFactsFromDefs()
-    )
-  }
-
-  /** How long a completed probe sweep stays fresh — reconnects within this window
-   *  re-emit the cached profiles instead of re-spawning every agent. */
-  private static readonly PROBE_TTL_MS = 5 * 60_000
-
-  /** Admission freshness must not depend on CP reconnects: a CP-disabled or
-   * continuously connected daemon rechecks curated winners on the same TTL. */
-  private armRuntimeProbeRefresh(): void {
-    if (this.draining || this.runtimeProbeTimer !== undefined) return
-    if (!Object.values(this.runtimeCatalog.entries).some((entry) => entry.source === 'curated')) return
-    this.runtimeProbeTimer = this.clock.setTimeout(() => {
-      this.runtimeProbeTimer = undefined
-      if (this.draining) return
-      void this.probeRuntimesAndEmit(false).finally(() => this.armRuntimeProbeRefresh())
-    }, Daemon.PROBE_TTL_MS)
-  }
-
-  /**
-   * Probe every installed runtime in the background (launch → initialize →
-   * session/new → read models → tear down), then emit one `facts/daemon-runtimes`
-   * snapshot once the sweep completes so the CP replaces its runtime list. The
-   * daemon-configured MCP-server list rides the same frame, derived from config
-   * (no probing — see `mcpServerFactsFromDefs`).
-   *
-   * Triggered on each CP (re)connect. Deduped while in flight; skipped (with a
-   * cached re-emit) when the last sweep is still fresh, so a reconnect storm can't
-   * spawn a fleet of agent subprocesses. Never throws — probing is best-effort and
-   * must not affect the CP connection.
-   */
-  private async probeRuntimesAndEmit(includeOrdinary = true): Promise<void> {
-    // --k8s has no runtime to launch on this host: profiles come from the image's
-    // declared table. Still emit them, because this is also the CP (re)connect path
-    // that (re)asserts the runtime list. Unconditional — unlike the fake-host guard
-    // below, an injected prober must not re-enable local spawning in this mode.
-    if (this.k8s) {
-      this.emitDaemonRuntimeFacts()
-      return
-    }
-    // With a hostFactory (unit tests use fake in-memory hosts) we don't spawn real
-    // subprocesses unless a probe seam is injected.
-    if (this.opts.hostFactory && !this.opts.probeRuntimes) return
-    // Runtime probes are ACP children under the same UID. Sandbox-optional
-    // principle (#36): probe sandboxed when a mechanism exists (launchFor below
-    // sets runInSandbox from `this.sandboxMechanism`), but still probe UNSANDBOXED
-    // when none is available — otherwise curated runtimes are never admitted and
-    // their agents cannot run on a no-sandbox host. The explicit operator
-    // `security.requireSandbox` already refused boot without a mechanism.
-    if (this.probing) {
-      if (includeOrdinary) this.ordinaryProbePending = true
-      else this.curatedProbePending = true
-      return
-    }
-
-    const fresh = this.lastProbeAtMs > 0 && this.clock.now() - this.lastProbeAtMs < Daemon.PROBE_TTL_MS
-    const curatedCandidates = this.curatedRuntimeAdmission.probeCandidates(this.runtimeCatalog)
-    if (fresh && Object.keys(curatedCandidates).length === 0) {
-      // Recent results still valid — just re-assert the snapshot to the (new) connection.
-      this.emitDaemonRuntimeFacts()
-      return
-    }
-
-    const ordinaryRuntimes =
-      !includeOrdinary || fresh
-        ? {}
-        : Object.fromEntries(
-            Object.entries(this.runtimeCatalog.entries)
-              .filter(([, entry]) => entry.source !== 'curated')
-              .map(([id, entry]) => [id, entry.runtime])
-          )
-    const probeCount = Object.keys(ordinaryRuntimes).length + Object.keys(curatedCandidates).length
-    if (probeCount === 0) return
-
-    this.probing = true
-    const probeIds = [...Object.keys(ordinaryRuntimes), ...Object.keys(curatedCandidates)]
-    this.log.info(`probe: sweeping ${probeCount} runtime(s): ${probeIds.join(', ') || '(none)'}`)
-    try {
-      const probe = this.opts.probeRuntimes ?? probeAllRuntimes
-      const probeHostFactory = defaultProbeHostFactory({
-        log: this.log,
-        isolateAccountApps: this.cfg.security.isolateAccountApps
-      })
-      // Apply and report every result the moment it lands. A package-launcher
-      // runtime building its install tree takes minutes on first use, and holding
-      // the whole sweep for it also held back the runtimes that answered in
-      // seconds. `facts/daemon-runtimes` is idempotent REPLACE fenced by `seq`
-      // (design runtime-model-catalog.md §6), so per-result frames converge.
-      const applied = new Set<string>()
-      const onResult = async (result: RuntimeProbeResult): Promise<void> => {
-        if (applied.has(result.runtime)) return
-        applied.add(result.runtime)
-        await this.applyProbeResult(result)
-        this.emitDaemonRuntimeFacts()
-      }
-      const batches: Array<Promise<RuntimeProbeResult[]>> = []
-      if (Object.keys(ordinaryRuntimes).length > 0) {
-        batches.push(
-          probe(ordinaryRuntimes, {
-            log: this.log,
-            hostFactory: probeHostFactory,
-            onResult,
-            launchFor: (id, runtime, scopeDir, cwd) =>
-              prepareRuntimeLaunch({
-                runtimeId: id,
-                runtime,
-                scopeDir,
-                cwd,
-                runInSandbox: this.sandboxMechanism !== undefined,
-                daemonRoot: this.root,
-                agentsRoot: this.cfg.agentsDir,
-                trustedRuntimeReadRoots:
-                  this.sandboxMechanism !== undefined
-                    ? runtimeSandboxReadRoots(runtime, process.env).readRoots
-                    : undefined,
-                explicitEnv: Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value])),
-                sandboxMechanism: this.sandboxMechanism,
-                hostPackageCache: true
-              })
-          })
-        )
-      }
-      if (Object.keys(curatedCandidates).length > 0) {
-        batches.push(
-          probe(curatedCandidates, {
-            curated: true,
-            log: this.log,
-            hostFactory: probeHostFactory,
-            onResult,
-            runInSandbox: this.sandboxMechanism !== undefined,
-            daemonRoot: this.root,
-            agentsRoot: this.cfg.agentsDir,
-            sandboxMechanism: this.sandboxMechanism,
-            mcpSocketPath: mcpSocketPath(this.root),
-            hostEnv: process.env
-          })
-        )
-      }
-      const results = (await Promise.all(batches)).flat()
-      // An injected prober (tests) may not drive the incremental callback.
-      for (const result of results) await onResult(result)
-      if (Object.keys(ordinaryRuntimes).length > 0) this.lastProbeAtMs = this.clock.now()
-      const okCount = results.filter((r) => r.ok).length
-      this.log.info(`probe: sweep complete — ${okCount}/${results.length} runtime(s) reachable`)
-      // Admission freshness is measured from the END of the sweep that observed it,
-      // because armRuntimeProbeRefresh() only starts the next one from here. Stamping
-      // each result when it landed would expire a runtime that answered in seconds one
-      // whole slow-launcher install before its next probe — unlaunchable, and pruned
-      // from the snapshot — so restamp the batch now that every result is in.
-      const reportedBefore = this.reportedRuntimeIds().join(' ')
-      for (const result of results) {
-        if (this.runtimeCatalog.entries[result.runtime]?.source === 'curated') {
-          this.curatedRuntimeAdmission.record(result)
-        }
-      }
-      this.refreshAdmittedRuntimes()
-      // Each result already emitted the REPLACE snapshot that prunes vanished ids, so
-      // the CP is owed one only when the sweep produced none, or when restamping
-      // brought a runtime back that had expired mid-sweep.
-      if (applied.size === 0 || this.reportedRuntimeIds().join(' ') !== reportedBefore) {
-        this.emitDaemonRuntimeFacts()
-      }
-      // Probe results can change runtime-derived registration capabilities, and
-      // register ran before this sweep — re-announce if the set moved.
-      this.cpClient?.updateCapabilities?.()
-    } catch (err) {
-      this.log.warn(`probe: sweep failed: ${formatErr(err)}`)
-    } finally {
-      this.probing = false
-      if (this.ordinaryProbePending || this.curatedProbePending) {
-        const includePendingOrdinary = this.ordinaryProbePending
-        this.ordinaryProbePending = false
-        this.curatedProbePending = false
-        void this.probeRuntimesAndEmit(includePendingOrdinary)
-      }
-    }
-  }
-
-  /** Fold one probe result into admission, advertised models/caps and the model
-   *  catalog. Called per result so a slow runtime delays only itself. */
-  private async applyProbeResult(r: RuntimeProbeResult): Promise<void> {
-    if (this.runtimeCatalog.entries[r.runtime]?.source === 'curated') this.curatedRuntimeAdmission.record(r)
-    this.refreshAdmittedRuntimes()
-    // Successful probes (including empty selectors) and auth failures are
-    // authoritative. Preserve a non-empty cache-hydrated list across other
-    // startup probe failures: disposable probe homes can fail while established
-    // agent homes remain usable. Cached provenance keeps model gates permissive
-    // until a later successful probe supplies live knowledge.
-    const keepCachedAdvertisement =
-      !r.ok &&
-      !r.authRequired &&
-      this.runtimeModelsSource.get(r.runtime) === 'cached' &&
-      (this.runtimeModels.get(r.runtime)?.length ?? 0) > 0
-    if (!keepCachedAdvertisement) {
-      this.runtimeModels.set(r.runtime, r.ok ? r.models : [])
-      this.runtimeModelsSource.set(r.runtime, 'probed')
-    }
-    if (r.ok && r.acpProtocolVersion !== undefined) this.runtimeAcpVersions.set(r.runtime, r.acpProtocolVersion)
-    else this.runtimeAcpVersions.delete(r.runtime)
-    if (r.ok && r.probedVersion) this.runtimeProbedVersions.set(r.runtime, r.probedVersion)
-    else this.runtimeProbedVersions.delete(r.runtime)
-    // Same overwrite rule: an unreachable runtime falls back to "not probed"
-    // (⇒ session resolution turns optimistic again rather than trusting stale caps).
-    if (r.ok && r.mcpCapabilities) this.runtimeMcpCaps.set(r.runtime, r.mcpCapabilities)
-    else this.runtimeMcpCaps.delete(r.runtime)
-    // Login state is live knowledge from this probe only: set on an ACP
-    // auth-required rejection, cleared on success or any OTHER failure kind
-    // (a timeout says nothing about credentials).
-    if (!r.ok && r.authRequired) this.runtimeAuthRequired.add(r.runtime)
-    else this.runtimeAuthRequired.delete(r.runtime)
-    await this.seedCatalogFromProbe(r)
-  }
-
-  /** Phase 1 of catalog discovery (design runtime-model-catalog.md §3.3): the probe
-   *  session's config options are already in hand — seed the cache with the default
-   *  model's caps + runtime-level permission modes, then let the discovery gate decide
-   *  whether a full phase-2 discovery is due. A failed probe deliberately skips this:
-   *  the last-good catalog is never cleared. */
-  private async seedCatalogFromProbe(r: RuntimeProbeResult): Promise<void> {
-    if (!r.ok) return
-    const entry = this.runtimeCatalog.entries[r.runtime]
-    if (!entry || this.runtimes[r.runtime] === undefined) return // curated candidates pre-admission stay out
-    try {
-      const fp = catalogFingerprint(r.runtime, r.probedVersion, entry.runtime)
-      if (r.configOptions) {
-        const caps = capsFromConfigOptions(r.configOptions)
-        const existing = await this.store.getRuntimeCatalogMeta(r.runtime)
-        // Phase 1 must not flip a driver-built catalog back to 'acp'.
-        const source = existing && existing.fingerprint === fp ? existing.source : 'acp'
-        // The probe session sits on `currentModel` — which may be the literal
-        // "default" a runtime advertises. Seed that model's caps under its real
-        // id (so selecting "default" shows the runtime's own effort/fast), but
-        // keep meta.defaultModel to a CONCRETE resolved id (never "default") —
-        // it feeds the console's preselection + "Default (…)" hint, and a
-        // native driver may still overwrite it with a concrete default.
-        const seedModel = caps.currentModel
-        const defaultModel = seedModel && seedModel !== 'default' ? seedModel : undefined
-        await this.store.recordRuntimeCatalogMeta({
-          runtimeId: r.runtime,
-          fingerprint: fp,
-          source,
-          ...(defaultModel ? { defaultModel } : {}),
-          ...(caps.permissionModes ? { permissionModes: caps.permissionModes } : {}),
-          ...(caps.currentPermissionMode ? { defaultPermissionMode: caps.currentPermissionMode } : {}),
-          observedAt: this.clock.now()
-        })
-        if (seedModel) {
-          await this.store.upsertRuntimeModelCap({
-            runtimeId: r.runtime,
-            modelId: seedModel,
-            fingerprint: fp,
-            caps: {
-              efforts: caps.efforts,
-              ...(caps.defaultEffort ? { defaultEffort: caps.defaultEffort } : {}),
-              fastMode: caps.fastMode
-            },
-            observedAt: this.clock.now()
-          })
-        }
-        await this.rebuildRuntimeCatalog(r.runtime)
-      }
-      this.modelCatalogSvc?.noteProbe({
-        runtimeId: r.runtime,
-        rt: entry.runtime,
-        probedVersion: r.probedVersion,
-        models: r.models
-      })
-    } catch (err) {
-      this.log.warn(`catalog: phase-1 seed for ${r.runtime} failed: ${formatErr(err)}`)
-    }
-  }
-
   /** Daemon-configured MCP servers as `{name, transport}` for `facts/daemon-runtimes`,
    *  derived from the effective def set (config + CP-pushed). The daemon does NOT
    *  connect to the servers — metadata only, for the console's server list. */
@@ -14967,7 +14542,7 @@ export class Daemon {
    * converges with the new provider set.
    */
   private onMcpDefsChanged(): void {
-    this.emitDaemonRuntimeFacts()
+    this.runtimeFacts.emitFacts()
   }
 
   private externalMemoryAdmission(agentId: string): { assertReady(connectionId: string): void } {
@@ -15033,10 +14608,7 @@ export class Daemon {
       this.clock.clearTimeout(this.storeRetentionTimer)
       this.storeRetentionTimer = undefined
     }
-    if (this.runtimeProbeTimer !== undefined) {
-      this.clock.clearTimeout(this.runtimeProbeTimer)
-      this.runtimeProbeTimer = undefined
-    }
+    this.runtimeFacts.dispose()
     this.dutyCoordinator.dispose()
     for (const t of this.bgWakeTimers) this.clock.clearTimeout(t)
     this.bgWakeTimers.clear()

--- a/packages/daemon/src/runtimes/facts-registry.ts
+++ b/packages/daemon/src/runtimes/facts-registry.ts
@@ -1,0 +1,567 @@
+import type { Clock, TimerHandle } from '@agentconnect.md/connection'
+import type {
+  FactsMcpServer,
+  FactsRuntimeProfile,
+  McpTransportCapabilities,
+  RuntimeModelCatalog
+} from '@agentconnect.md/protocol'
+import type { Logger } from '../log.js'
+import type { RuntimeDef } from '../config/config-schema.js'
+import type { SandboxMechanism } from '../acp/sandbox.js'
+import type { LocalStore } from '../store/local-store.js'
+import type { ResolvedRuntimeCatalog } from './registry.js'
+import type { CuratedRuntimeAdmission } from './curated-admission.js'
+import type { K8sRuntimeAcpSnapshot } from './k8s-runtimes.js'
+import { probeAllRuntimes, type ProbeOptions, type RuntimeProbeResult } from './runtime-prober.js'
+import { defaultProbeHostFactory } from '../acp/probe-host-factory.js'
+import { prepareRuntimeLaunch } from '../launch/prepare.js'
+import { runtimeSandboxReadRoots } from '../launch/compose.js'
+import { capsFromConfigOptions, augmentEffortOptions } from './config-caps.js'
+import { isClaudeRuntimeDef } from '../runtime-defs/claude-runtime.js'
+import { catalogFingerprint } from './model-catalog.js'
+import { mcpSocketPath } from '../paths.js'
+import { formatErr } from '../daemon/text.js'
+
+/** How long a completed probe sweep stays fresh — reconnects within this window
+ *  re-emit the cached profiles instead of re-spawning every agent. Also the TTL
+ *  curated admission measures a winner's freshness on. */
+export const PROBE_TTL_MS = 5 * 60_000
+
+/** The store rows the registry reads/writes — the last-good catalog cache. */
+export type RuntimeFactsStore = Pick<
+  LocalStore,
+  | 'listRuntimeCatalogMetas'
+  | 'listRuntimeModelCaps'
+  | 'getRuntimeCatalogMeta'
+  | 'recordRuntimeCatalogMeta'
+  | 'upsertRuntimeModelCap'
+>
+
+/** How a sweep spawns: the injected seam, sandbox posture, and the roots a probe launch composes. */
+export interface RuntimeProbeLaunchContext {
+  /** `--k8s` runs no local probe — facts come from the image's declared table. */
+  k8s: boolean
+  /** Unit tests drive fake in-memory hosts; without an injected prober, don't spawn. */
+  fakeHosts: boolean
+  probe?: (runtimes: Record<string, RuntimeDef>, opts: ProbeOptions) => Promise<RuntimeProbeResult[]>
+  sandboxMechanism?: SandboxMechanism
+  daemonRoot: string
+  agentsRoot: string | undefined
+  isolateAccountApps: boolean
+}
+
+/** The genuinely outward calls the facts cluster makes: logging/clock, the catalog cache,
+ *  the admitted-runtime view it projects over, CP egress, and how a probe launches. */
+export interface RuntimeFactsHost {
+  log(): Logger
+  clock(): Clock
+  store(): RuntimeFactsStore
+  draining(): boolean
+  catalog(): ResolvedRuntimeCatalog
+  admittedRuntimes(): Record<string, RuntimeDef>
+  refreshAdmitted(): void
+  reportedRuntimeIds(): string[]
+  curatedAdmission(): CuratedRuntimeAdmission
+  emitDaemonRuntimes(profiles: FactsRuntimeProfile[], mcpServers: FactsMcpServer[]): void
+  updateCapabilities(): void
+  mcpServerFacts(): FactsMcpServer[]
+  noteCatalogProbe(input: { runtimeId: string; rt: RuntimeDef; probedVersion?: string; models: string[] }): void
+  launch(): RuntimeProbeLaunchContext
+}
+
+/**
+ * Everything the daemon knows about the runtimes it can run: the per-runtime facts
+ * (names, versions, models, ACP/MCP capabilities, login state, model catalogs), the
+ * probe sweep that learns them, and the `facts/daemon-runtimes` snapshot it emits.
+ *
+ * One owner means one answer: `profileFor` is the single projection every
+ * consumer reads, and a probed fact, a k8s-declared fact and a cache-hydrated one are
+ * indistinguishable downstream because they all land in these maps.
+ */
+export class RuntimeFactsRegistry {
+  private names: Record<string, string> = {} // registry id -> display name (for CP reporting)
+  private versions: Record<string, string> = {} // registry id -> version (for the facts/daemon-runtimes snapshot)
+  // Models learned by actively probing each runtime (registry id -> model ids).
+  // Empty/absent until the post-connect probe sweep completes; feeds runtimeProfiles().
+  private models = new Map<string, string[]>()
+  // ACP protocol version each runtime negotiated at its last probe; feeds runtimeProfiles().
+  private acpVersions = new Map<string, number>()
+  // The agent's self-reported version (`agentInfo.version` from `initialize`) learned
+  // at the last probe — the ACTUAL running adapter release (e.g. claude-agent-acp
+  // 0.59.0). Preferred over the registry's declared version in profileFor().
+  private probedVersions = new Map<string, string>()
+  // MCP transports each runtime advertised at its last probe; feeds runtimeProfiles()
+  // and gates which configured http/sse servers attach at session/new (absent ⇒ not
+  // probed yet ⇒ assume stdio-only but attach optimistically — see resolve-servers.ts).
+  private mcpCaps = new Map<string, McpTransportCapabilities>()
+  // Provenance of `models` entries: 'cached' = hydrated from the local catalog cache
+  // at boot (a live probe has not confirmed it this process) — the activation model
+  // gate treats it as permissive; 'probed' = live result.
+  private modelsSource = new Map<string, 'cached' | 'probed'>()
+  // Runtimes whose last probe was rejected with the ACP auth-required error
+  // (-32000): installed but needing an interactive login on this host. Feeds the
+  // console's per-runtime login warning; cleared on any successful probe.
+  private authRequired = new Set<string>()
+  // Same signal observed on a LIVE turn (dispatch): kept separate from the
+  // probe-derived set because a successful probe must not clear it —
+  // claude-agent-acp initializes, opens sessions, and enumerates models fine
+  // while logged out and only rejects the live prompt with -32000, so the probe
+  // sweep is blind to its login state. Cleared by the next successful turn.
+  private authRequiredLive = new Set<string>()
+  // Report-shape model catalogs (last-good CAPABILITY knowledge, augmented for
+  // reporting). Deliberately independent of the fail-to-empty rule that wipes
+  // `models` (ADVERTISEMENT): a probe failure empties the offered list but keeps
+  // the catalog, so the CP's capability data survives transient timeouts.
+  private catalogs = new Map<string, RuntimeModelCatalog>()
+  private probing = false // a probe sweep is in flight (dedup concurrent onReady fires)
+  private ordinaryProbePending = false // a CP-ready sweep arrived behind a local curated sweep
+  private curatedProbePending = false // a local TTL sweep arrived behind another sweep
+  private lastProbeAtMs = 0 // when ordinary runtimes were last swept; gates re-probe on reconnect
+  private probeTimer?: TimerHandle
+
+  constructor(private readonly host: RuntimeFactsHost) {}
+
+  /** Seed the declared name/version tables from the installed catalog (start-up). */
+  setInstalled(entries: ResolvedRuntimeCatalog['entries']): void {
+    this.names = Object.fromEntries(Object.entries(entries).map(([id, entry]) => [id, entry.name || id]))
+    this.versions = Object.fromEntries(Object.entries(entries).map(([id, entry]) => [id, entry.version]))
+  }
+
+  runtimeNames(): Record<string, string> {
+    return this.names
+  }
+
+  offeredModels(runtimeId: string): string[] | undefined {
+    return this.models.get(runtimeId)
+  }
+
+  /** Whether the offered list for a runtime is live probe knowledge (cache-hydrated is not). */
+  offeredModelsAreLive(runtimeId: string): boolean {
+    return this.modelsSource.get(runtimeId) !== 'cached'
+  }
+
+  mcpCapabilities(runtimeId: string): McpTransportCapabilities | undefined {
+    return this.mcpCaps.get(runtimeId)
+  }
+
+  modelCatalog(runtimeId: string): RuntimeModelCatalog | undefined {
+    return this.catalogs.get(runtimeId)
+  }
+
+  /** Build the current profile entry for a runtime (one element of the
+   *  `facts/daemon-runtimes` snapshot), folding in any models learned by the
+   *  probe sweep. */
+  profileFor(id: string): FactsRuntimeProfile {
+    return {
+      runtime: id,
+      // Prefer the probed adapter version (the actual running release, learned at the
+      // last probe's `initialize`) over the registry's declared version; fall back to
+      // the declared version when a runtime hasn't been probed / reported none.
+      version: this.probedVersions.get(id) || this.versions[id] || '',
+      models: this.models.get(id) ?? [],
+      acpSupport: 'full',
+      acpProtocolVersion: this.acpVersions.get(id),
+      toolCalling: true,
+      mcpCapabilities: this.mcpCaps.get(id),
+      modelsSource: this.modelsSource.get(id),
+      // Capability matrix rides every frame it exists for — including probe-failure
+      // rounds where models[] empties (advertisement ≠ capability knowledge).
+      modelCatalog: this.catalogs.get(id),
+      ...(this.authRequired.has(id) || this.authRequiredLive.has(id) ? { authRequired: true } : {})
+    }
+  }
+
+  /** The `facts/daemon-runtimes` snapshot for the currently reported runtime set. */
+  emitFacts(): void {
+    this.host.emitDaemonRuntimes(
+      this.host.reportedRuntimeIds().map((id) => this.profileFor(id)),
+      this.host.mcpServerFacts()
+    )
+  }
+
+  /** Fold a live turn's auth outcome into the facts state. A turn rejected with
+   *  ACP -32000 marks the agent's runtime login-required; a completed turn is
+   *  the definitive "logged in" signal and clears both the live mark and any
+   *  stale probe-derived one (the user logged in between sweeps). Re-emits the
+   *  facts snapshot only when the reported flag actually flips. Called from the
+   *  dispatch hot path (right after prompt / inside its failure handler), so
+   *  the telemetry emit is best-effort like emitStoredUsageReport — it must
+   *  never affect message delivery. */
+  noteAuthFromTurn(runtimeId: string, authRequired: boolean): void {
+    let changed: boolean
+    if (authRequired) {
+      changed = !this.authRequiredLive.has(runtimeId) && !this.authRequired.has(runtimeId)
+      this.authRequiredLive.add(runtimeId)
+    } else {
+      changed = this.authRequiredLive.delete(runtimeId)
+      if (this.authRequired.delete(runtimeId)) changed = true
+    }
+    if (!changed) return
+    try {
+      this.emitFacts()
+    } catch (err) {
+      this.host.log().debug(`runtime auth facts emit failed (${runtimeId}): ${(err as Error).message}`)
+    }
+  }
+
+  /** Fold the declared/probed k8s snapshot into the SAME maps the profiles read, so a
+   *  declared fact and a locally probed one are indistinguishable downstream. */
+  applyDeclaredFacts(
+    declaredModels: Record<string, string[]>,
+    declaredAcp: Record<string, K8sRuntimeAcpSnapshot>
+  ): void {
+    for (const [runtimeId, models] of Object.entries(declaredModels)) {
+      this.models.set(runtimeId, [...models])
+      this.modelsSource.set(runtimeId, 'cached')
+    }
+    for (const [runtimeId, snapshot] of Object.entries(declaredAcp)) {
+      if (snapshot.protocolVersion !== undefined) this.acpVersions.set(runtimeId, snapshot.protocolVersion)
+      const mcp = snapshot.capabilities?.mcpCapabilities
+      if (mcp && typeof mcp === 'object') {
+        const caps = mcp as { http?: unknown; sse?: unknown }
+        this.mcpCaps.set(runtimeId, { http: caps.http === true, sse: caps.sse === true })
+      }
+    }
+  }
+
+  /** The image's own probe answered: its catalog entries carry the versions the profile
+   *  reports, which the declared table never does. */
+  noteImageCatalog(entries: ResolvedRuntimeCatalog['entries']): void {
+    for (const [id, entry] of Object.entries(entries)) {
+      this.names[id] = entry.name
+      if (entry.version) this.versions[id] = entry.version
+      this.probedVersions.set(id, entry.version || (this.probedVersions.get(id) ?? ''))
+    }
+  }
+
+  /** Synchronously pre-fill the in-memory runtime maps from the SQLite last-good
+   *  catalog cache (design runtime-model-catalog.md §4): the register-time facts
+   *  snapshot then carries cached models + matrix instead of an empty REPLACE
+   *  that would wipe the CP's learned state until the sweep completes. Rows for
+   *  runtimes not in the installed catalog are ignored (kept on disk — the
+   *  runtime may only be temporarily unresolved); rows older than 30 days are
+   *  garbage-collected. The store reads only this member's rows, so a member can
+   *  never boot advertising models a peer's image runs and its own does not. */
+  async hydrateFromCache(): Promise<void> {
+    try {
+      for (const meta of await this.host.store().listRuntimeCatalogMetas()) {
+        if (!this.host.catalog().entries[meta.runtimeId]) continue
+        await this.rebuildCatalog(meta.runtimeId)
+        const cachedModels = (await this.host.store().listRuntimeModelCaps(meta.runtimeId)).map((r) => r.modelId)
+        if (cachedModels.length > 0 && (this.models.get(meta.runtimeId) ?? []).length === 0) {
+          this.models.set(meta.runtimeId, cachedModels)
+          this.modelsSource.set(meta.runtimeId, 'cached')
+        }
+      }
+    } catch (err) {
+      this.host.log().warn(`catalog: cache hydrate failed: ${formatErr(err)}`)
+    }
+  }
+
+  /** Rebuild one runtime's report-shape catalog from the cache: raw stored caps
+   *  plus daemon-side synthetic effort levels (Claude max/ultracode) so the
+   *  console vocabulary always matches the live-session pickers. */
+  async rebuildCatalog(id: string): Promise<void> {
+    const meta = await this.host.store().getRuntimeCatalogMeta(id)
+    if (!meta) {
+      this.catalogs.delete(id)
+      return
+    }
+    const rt = this.host.catalog().entries[id]?.runtime
+    const claude = rt ? isClaudeRuntimeDef(rt) : false
+    const models = (await this.host.store().listRuntimeModelCaps(id)).map((r) => ({
+      id: r.modelId,
+      ...(r.caps.name ? { name: r.caps.name } : {}),
+      ...(r.caps.efforts !== undefined
+        ? { efforts: claude ? augmentEffortOptions(r.caps.efforts) : r.caps.efforts }
+        : {}),
+      ...(r.caps.defaultEffort ? { defaultEffort: r.caps.defaultEffort } : {}),
+      ...(r.caps.fastMode !== undefined ? { fastMode: r.caps.fastMode } : {})
+    }))
+    this.catalogs.set(id, {
+      models: models.slice(0, 128),
+      ...(meta.defaultModel ? { defaultModel: meta.defaultModel } : {}),
+      ...(meta.permissionModes ? { permissionModes: meta.permissionModes } : {}),
+      ...(meta.defaultPermissionMode ? { defaultPermissionMode: meta.defaultPermissionMode } : {}),
+      source: meta.source,
+      observedAt: new Date(meta.observedAt).toISOString()
+    })
+  }
+
+  /** Admission freshness must not depend on CP reconnects: a CP-disabled or
+   * continuously connected daemon rechecks curated winners on the same TTL. */
+  armProbeRefresh(): void {
+    if (this.host.draining() || this.probeTimer !== undefined) return
+    if (!Object.values(this.host.catalog().entries).some((entry) => entry.source === 'curated')) return
+    this.probeTimer = this.host.clock().setTimeout(() => {
+      this.probeTimer = undefined
+      if (this.host.draining()) return
+      void this.probeAndEmit(false).finally(() => this.armProbeRefresh())
+    }, PROBE_TTL_MS)
+  }
+
+  /** Drop the recurring curated re-probe timer so it cannot hold the process open. */
+  dispose(): void {
+    if (this.probeTimer !== undefined) {
+      this.host.clock().clearTimeout(this.probeTimer)
+      this.probeTimer = undefined
+    }
+  }
+
+  /**
+   * Probe every installed runtime in the background (launch → initialize →
+   * session/new → read models → tear down), then emit one `facts/daemon-runtimes`
+   * snapshot once the sweep completes so the CP replaces its runtime list. The
+   * daemon-configured MCP-server list rides the same frame, derived from config
+   * (no probing — see the host's `mcpServerFacts`).
+   *
+   * Triggered on each CP (re)connect. Deduped while in flight; skipped (with a
+   * cached re-emit) when the last sweep is still fresh, so a reconnect storm can't
+   * spawn a fleet of agent subprocesses. Never throws — probing is best-effort and
+   * must not affect the CP connection.
+   */
+  async probeAndEmit(includeOrdinary = true): Promise<void> {
+    const launch = this.host.launch()
+    // --k8s has no runtime to launch on this host: profiles come from the image's
+    // declared table. Still emit them, because this is also the CP (re)connect path
+    // that (re)asserts the runtime list. Unconditional — unlike the fake-host guard
+    // below, an injected prober must not re-enable local spawning in this mode.
+    if (launch.k8s) {
+      this.emitFacts()
+      return
+    }
+    // With a hostFactory (unit tests use fake in-memory hosts) we don't spawn real
+    // subprocesses unless a probe seam is injected.
+    if (launch.fakeHosts && !launch.probe) return
+    // Runtime probes are ACP children under the same UID. Sandbox-optional
+    // principle (#36): probe sandboxed when a mechanism exists (launchFor below
+    // sets runInSandbox from the sandbox mechanism), but still probe UNSANDBOXED
+    // when none is available — otherwise curated runtimes are never admitted and
+    // their agents cannot run on a no-sandbox host. The explicit operator
+    // `security.requireSandbox` already refused boot without a mechanism.
+    if (this.probing) {
+      if (includeOrdinary) this.ordinaryProbePending = true
+      else this.curatedProbePending = true
+      return
+    }
+
+    const log = this.host.log()
+    const catalog = this.host.catalog()
+    const fresh = this.lastProbeAtMs > 0 && this.host.clock().now() - this.lastProbeAtMs < PROBE_TTL_MS
+    const curatedCandidates = this.host.curatedAdmission().probeCandidates(catalog)
+    if (fresh && Object.keys(curatedCandidates).length === 0) {
+      // Recent results still valid — just re-assert the snapshot to the (new) connection.
+      this.emitFacts()
+      return
+    }
+
+    const ordinaryRuntimes =
+      !includeOrdinary || fresh
+        ? {}
+        : Object.fromEntries(
+            Object.entries(catalog.entries)
+              .filter(([, entry]) => entry.source !== 'curated')
+              .map(([id, entry]) => [id, entry.runtime])
+          )
+    const probeCount = Object.keys(ordinaryRuntimes).length + Object.keys(curatedCandidates).length
+    if (probeCount === 0) return
+
+    this.probing = true
+    const probeIds = [...Object.keys(ordinaryRuntimes), ...Object.keys(curatedCandidates)]
+    log.info(`probe: sweeping ${probeCount} runtime(s): ${probeIds.join(', ') || '(none)'}`)
+    try {
+      const probe = launch.probe ?? probeAllRuntimes
+      const probeHostFactory = defaultProbeHostFactory({
+        log,
+        isolateAccountApps: launch.isolateAccountApps
+      })
+      // Apply and report every result the moment it lands. A package-launcher
+      // runtime building its install tree takes minutes on first use, and holding
+      // the whole sweep for it also held back the runtimes that answered in
+      // seconds. `facts/daemon-runtimes` is idempotent REPLACE fenced by `seq`
+      // (design runtime-model-catalog.md §6), so per-result frames converge.
+      const applied = new Set<string>()
+      const onResult = async (result: RuntimeProbeResult): Promise<void> => {
+        if (applied.has(result.runtime)) return
+        applied.add(result.runtime)
+        await this.applyProbeResult(result)
+        this.emitFacts()
+      }
+      const batches: Array<Promise<RuntimeProbeResult[]>> = []
+      if (Object.keys(ordinaryRuntimes).length > 0) {
+        batches.push(
+          probe(ordinaryRuntimes, {
+            log,
+            hostFactory: probeHostFactory,
+            onResult,
+            launchFor: (id, runtime, scopeDir, cwd) =>
+              prepareRuntimeLaunch({
+                runtimeId: id,
+                runtime,
+                scopeDir,
+                cwd,
+                runInSandbox: launch.sandboxMechanism !== undefined,
+                daemonRoot: launch.daemonRoot,
+                agentsRoot: launch.agentsRoot,
+                trustedRuntimeReadRoots:
+                  launch.sandboxMechanism !== undefined
+                    ? runtimeSandboxReadRoots(runtime, process.env).readRoots
+                    : undefined,
+                explicitEnv: Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value])),
+                sandboxMechanism: launch.sandboxMechanism,
+                hostPackageCache: true
+              })
+          })
+        )
+      }
+      if (Object.keys(curatedCandidates).length > 0) {
+        batches.push(
+          probe(curatedCandidates, {
+            curated: true,
+            log,
+            hostFactory: probeHostFactory,
+            onResult,
+            runInSandbox: launch.sandboxMechanism !== undefined,
+            daemonRoot: launch.daemonRoot,
+            agentsRoot: launch.agentsRoot,
+            sandboxMechanism: launch.sandboxMechanism,
+            mcpSocketPath: mcpSocketPath(launch.daemonRoot),
+            hostEnv: process.env
+          })
+        )
+      }
+      const results = (await Promise.all(batches)).flat()
+      // An injected prober (tests) may not drive the incremental callback.
+      for (const result of results) await onResult(result)
+      if (Object.keys(ordinaryRuntimes).length > 0) this.lastProbeAtMs = this.host.clock().now()
+      const okCount = results.filter((r) => r.ok).length
+      log.info(`probe: sweep complete — ${okCount}/${results.length} runtime(s) reachable`)
+      // Admission freshness is measured from the END of the sweep that observed it,
+      // because armProbeRefresh() only starts the next one from here. Stamping
+      // each result when it landed would expire a runtime that answered in seconds one
+      // whole slow-launcher install before its next probe — unlaunchable, and pruned
+      // from the snapshot — so restamp the batch now that every result is in.
+      const reportedBefore = this.host.reportedRuntimeIds().join(' ')
+      for (const result of results) {
+        if (this.host.catalog().entries[result.runtime]?.source === 'curated') {
+          this.host.curatedAdmission().record(result)
+        }
+      }
+      this.host.refreshAdmitted()
+      // Each result already emitted the REPLACE snapshot that prunes vanished ids, so
+      // the CP is owed one only when the sweep produced none, or when restamping
+      // brought a runtime back that had expired mid-sweep.
+      if (applied.size === 0 || this.host.reportedRuntimeIds().join(' ') !== reportedBefore) {
+        this.emitFacts()
+      }
+      // Probe results can change runtime-derived registration capabilities, and
+      // register ran before this sweep — re-announce if the set moved.
+      this.host.updateCapabilities()
+    } catch (err) {
+      log.warn(`probe: sweep failed: ${formatErr(err)}`)
+    } finally {
+      this.probing = false
+      if (this.ordinaryProbePending || this.curatedProbePending) {
+        const includePendingOrdinary = this.ordinaryProbePending
+        this.ordinaryProbePending = false
+        this.curatedProbePending = false
+        void this.probeAndEmit(includePendingOrdinary)
+      }
+    }
+  }
+
+  /** Fold one probe result into admission, advertised models/caps and the model
+   *  catalog. Called per result so a slow runtime delays only itself. */
+  private async applyProbeResult(r: RuntimeProbeResult): Promise<void> {
+    if (this.host.catalog().entries[r.runtime]?.source === 'curated') this.host.curatedAdmission().record(r)
+    this.host.refreshAdmitted()
+    // Successful probes (including empty selectors) and auth failures are
+    // authoritative. Preserve a non-empty cache-hydrated list across other
+    // startup probe failures: disposable probe homes can fail while established
+    // agent homes remain usable. Cached provenance keeps model gates permissive
+    // until a later successful probe supplies live knowledge.
+    const keepCachedAdvertisement =
+      !r.ok &&
+      !r.authRequired &&
+      this.modelsSource.get(r.runtime) === 'cached' &&
+      (this.models.get(r.runtime)?.length ?? 0) > 0
+    if (!keepCachedAdvertisement) {
+      this.models.set(r.runtime, r.ok ? r.models : [])
+      this.modelsSource.set(r.runtime, 'probed')
+    }
+    if (r.ok && r.acpProtocolVersion !== undefined) this.acpVersions.set(r.runtime, r.acpProtocolVersion)
+    else this.acpVersions.delete(r.runtime)
+    if (r.ok && r.probedVersion) this.probedVersions.set(r.runtime, r.probedVersion)
+    else this.probedVersions.delete(r.runtime)
+    // Same overwrite rule: an unreachable runtime falls back to "not probed"
+    // (⇒ session resolution turns optimistic again rather than trusting stale caps).
+    if (r.ok && r.mcpCapabilities) this.mcpCaps.set(r.runtime, r.mcpCapabilities)
+    else this.mcpCaps.delete(r.runtime)
+    // Login state is live knowledge from this probe only: set on an ACP
+    // auth-required rejection, cleared on success or any OTHER failure kind
+    // (a timeout says nothing about credentials).
+    if (!r.ok && r.authRequired) this.authRequired.add(r.runtime)
+    else this.authRequired.delete(r.runtime)
+    await this.seedCatalogFromProbe(r)
+  }
+
+  /** Phase 1 of catalog discovery (design runtime-model-catalog.md §3.3): the probe
+   *  session's config options are already in hand — seed the cache with the default
+   *  model's caps + runtime-level permission modes, then let the discovery gate decide
+   *  whether a full phase-2 discovery is due. A failed probe deliberately skips this:
+   *  the last-good catalog is never cleared. */
+  private async seedCatalogFromProbe(r: RuntimeProbeResult): Promise<void> {
+    if (!r.ok) return
+    const entry = this.host.catalog().entries[r.runtime]
+    if (!entry || this.host.admittedRuntimes()[r.runtime] === undefined) return // curated candidates pre-admission stay out
+    const store = this.host.store()
+    try {
+      const fp = catalogFingerprint(r.runtime, r.probedVersion, entry.runtime)
+      if (r.configOptions) {
+        const caps = capsFromConfigOptions(r.configOptions)
+        const existing = await store.getRuntimeCatalogMeta(r.runtime)
+        // Phase 1 must not flip a driver-built catalog back to 'acp'.
+        const source = existing && existing.fingerprint === fp ? existing.source : 'acp'
+        // The probe session sits on `currentModel` — which may be the literal
+        // "default" a runtime advertises. Seed that model's caps under its real
+        // id (so selecting "default" shows the runtime's own effort/fast), but
+        // keep meta.defaultModel to a CONCRETE resolved id (never "default") —
+        // it feeds the console's preselection + "Default (…)" hint, and a
+        // native driver may still overwrite it with a concrete default.
+        const seedModel = caps.currentModel
+        const defaultModel = seedModel && seedModel !== 'default' ? seedModel : undefined
+        await store.recordRuntimeCatalogMeta({
+          runtimeId: r.runtime,
+          fingerprint: fp,
+          source,
+          ...(defaultModel ? { defaultModel } : {}),
+          ...(caps.permissionModes ? { permissionModes: caps.permissionModes } : {}),
+          ...(caps.currentPermissionMode ? { defaultPermissionMode: caps.currentPermissionMode } : {}),
+          observedAt: this.host.clock().now()
+        })
+        if (seedModel) {
+          await store.upsertRuntimeModelCap({
+            runtimeId: r.runtime,
+            modelId: seedModel,
+            fingerprint: fp,
+            caps: {
+              efforts: caps.efforts,
+              ...(caps.defaultEffort ? { defaultEffort: caps.defaultEffort } : {}),
+              fastMode: caps.fastMode
+            },
+            observedAt: this.host.clock().now()
+          })
+        }
+        await this.rebuildCatalog(r.runtime)
+      }
+      this.host.noteCatalogProbe({
+        runtimeId: r.runtime,
+        rt: entry.runtime,
+        probedVersion: r.probedVersion,
+        models: r.models
+      })
+    } catch (err) {
+      this.host.log().warn(`catalog: phase-1 seed for ${r.runtime} failed: ${formatErr(err)}`)
+    }
+  }
+}

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -823,7 +823,7 @@ describe('Daemon CP agent → memory + reconcile', () => {
 
     await seam(daemon).applyAgentDetach({ agentId: 'ghost', moveId: MOVE_ID_3 })
     ;(daemon as any).cpMcpDefs.upsert('org-a', 'remote', { transport: 'http', url: 'https://mcp.invalid' })
-    ;(daemon as any).runtimeMcpCaps.set('claude', { http: false, sse: false })
+    ;(daemon as any).runtimeFacts.mcpCaps.set('claude', { http: false, sse: false })
     await expect(
       seam(daemon).applyAgentActivate({
         agentId: 'ghost',
@@ -838,7 +838,7 @@ describe('Daemon CP agent → memory + reconcile', () => {
     })
 
     await seam(daemon).applyAgentDetach({ agentId: 'ghost', moveId: MOVE_ID_4 })
-    ;(daemon as any).runtimeModels.set('claude', ['supported-model'])
+    ;(daemon as any).runtimeFacts.models.set('claude', ['supported-model'])
     await expect(
       seam(daemon).applyAgentActivate({
         agentId: 'ghost',

--- a/packages/daemon/test/curated-runtime-daemon.test.ts
+++ b/packages/daemon/test/curated-runtime-daemon.test.ts
@@ -33,7 +33,7 @@ function catalog(): ResolvedRuntimeCatalog {
 
 async function waitForProbe(daemon: Daemon, probe: ReturnType<typeof vi.fn>): Promise<void> {
   await vi.waitFor(() => expect(probe).toHaveBeenCalled(), WAIT)
-  await vi.waitFor(() => expect((daemon as any).probing).toBe(false), WAIT)
+  await vi.waitFor(() => expect((daemon as any).runtimeFacts.probing).toBe(false), WAIT)
 }
 
 describe('daemon curated runtime admission', () => {
@@ -66,7 +66,7 @@ describe('daemon curated runtime admission', () => {
         expect(probe.mock.calls.some(([, options]) => options.curated === true)).toBe(true)
 
         const calls = probe.mock.calls.length
-        await (daemon as any).probeRuntimesAndEmit(false)
+        await (daemon as any).runtimeFacts.probeAndEmit(false)
         expect(probe).toHaveBeenCalledTimes(calls)
       } finally {
         await daemon.stop()
@@ -129,7 +129,7 @@ describe('daemon curated runtime admission', () => {
       )
       // …but the facts snapshot reports it so the console can show the warning.
       expect((daemon as any).reportedRuntimeIds().sort()).toEqual(['explicit', 'hermes-agent'])
-      expect((daemon as any).runtimeProfileFor('hermes-agent')).toMatchObject({
+      expect((daemon as any).runtimeFacts.profileFor('hermes-agent')).toMatchObject({
         runtime: 'hermes-agent',
         models: [],
         authRequired: true
@@ -143,7 +143,7 @@ describe('daemon curated runtime admission', () => {
         },
         stop: vi.fn(async () => {})
       }
-      await (daemon as any).probeRuntimesAndEmit(true)
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
       expect(emitted.length).toBeGreaterThan(0)
       const last = emitted[emitted.length - 1]!
       expect(last.find((p) => p.runtime === 'hermes-agent')?.authRequired).toBe(true)
@@ -177,23 +177,23 @@ describe('daemon curated runtime admission', () => {
       }
 
       // Live signal: a real turn on 'explicit' rejected with ACP -32000.
-      ;(daemon as any).noteRuntimeAuthFromTurn('explicit', true)
+      ;(daemon as any).runtimeFacts.noteAuthFromTurn('explicit', true)
       expect(emitted.length).toBe(1)
       expect(emitted[0]!.find((p) => p.runtime === 'explicit')?.authRequired).toBe(true)
       // Re-marking without a state flip does not re-emit.
-      ;(daemon as any).noteRuntimeAuthFromTurn('explicit', true)
+      ;(daemon as any).runtimeFacts.noteAuthFromTurn('explicit', true)
       expect(emitted.length).toBe(1)
 
       // A fresh all-OK sweep must NOT clear the live mark: claude-style adapters
       // probe fine (initialize + session/new succeed) while logged out.
-      ;(daemon as any).lastProbeAtMs = 0
-      await (daemon as any).probeRuntimesAndEmit(true)
+      ;(daemon as any).runtimeFacts.lastProbeAtMs = 0
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
       const afterSweep = emitted[emitted.length - 1]!
       expect(afterSweep.find((p) => p.runtime === 'explicit')?.authRequired).toBe(true)
 
       // The next successful turn clears it and emits the flip.
       const beforeClear = emitted.length
-      ;(daemon as any).noteRuntimeAuthFromTurn('explicit', false)
+      ;(daemon as any).runtimeFacts.noteAuthFromTurn('explicit', false)
       expect(emitted.length).toBe(beforeClear + 1)
       expect(emitted[emitted.length - 1]!.find((p) => p.runtime === 'explicit')?.authRequired).toBeUndefined()
     } finally {
@@ -236,17 +236,17 @@ describe('daemon curated runtime admission', () => {
         stop: vi.fn(async () => {})
       }
       // Re-arm a full sweep whose curated probe blocks until released.
-      ;(daemon as any).lastProbeAtMs = 0
+      ;(daemon as any).runtimeFacts.lastProbeAtMs = 0
       ;(daemon as any).curatedRuntimeAdmission = new CuratedRuntimeAdmission()
       ;(daemon as any).refreshAdmittedRuntimes()
       gate = new Promise<void>((resolve) => {
         releaseCurated = resolve
       })
-      const sweep = (daemon as any).probeRuntimesAndEmit(true)
+      const sweep = (daemon as any).runtimeFacts.probeAndEmit(true)
 
       // The fast runtime is reported while the curated probe is still in flight.
       await vi.waitFor(() => expect(emitted.at(-1)).toContain('explicit'), WAIT)
-      expect((daemon as any).probing).toBe(true)
+      expect((daemon as any).runtimeFacts.probing).toBe(true)
       expect(emitted.at(-1)).not.toContain('hermes-agent')
 
       releaseCurated()
@@ -288,7 +288,7 @@ describe('daemon curated runtime admission', () => {
         stop: vi.fn(async () => {})
       }
 
-      await (daemon as any).probeRuntimesAndEmit(true)
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
 
       expect(probe).toHaveBeenCalled()
       expect(Object.keys((daemon as any).runtimes).sort()).toEqual(['explicit', 'hermes-agent'])
@@ -297,7 +297,7 @@ describe('daemon curated runtime admission', () => {
       expect(emitted.at(-1)).toContain('hermes-agent')
     } finally {
       ;(daemon as any).draining = true
-      const timer = (daemon as any).runtimeProbeTimer
+      const timer = (daemon as any).runtimeFacts.probeTimer
       if (timer !== undefined) clock.clearTimeout(timer)
     }
   }, 15_000)
@@ -318,16 +318,16 @@ describe('daemon curated runtime admission', () => {
       ;(daemon as any).root = '/tmp/curated-admission-test'
       ;(daemon as any).runtimeCatalog = catalog()
       ;(daemon as any).refreshAdmittedRuntimes()
-      ;(daemon as any).armRuntimeProbeRefresh()
+      ;(daemon as any).runtimeFacts.armProbeRefresh()
 
       clock.advance(5 * 60_000)
       await vi.waitFor(() => expect(probe).toHaveBeenCalled(), WAIT)
-      await vi.waitFor(() => expect((daemon as any).probing).toBe(false), WAIT)
+      await vi.waitFor(() => expect((daemon as any).runtimeFacts.probing).toBe(false), WAIT)
       expect(Object.keys((daemon as any).runtimes).sort()).toEqual(['explicit', 'hermes-agent'])
       expect(Object.keys(probe.mock.calls[0]![0])).toEqual(['hermes-agent'])
     } finally {
       ;(daemon as any).draining = true
-      const timer = (daemon as any).runtimeProbeTimer
+      const timer = (daemon as any).runtimeFacts.probeTimer
       if (timer !== undefined) clock.clearTimeout(timer)
     }
   }, 15_000)
@@ -339,9 +339,9 @@ describe('daemon curated runtime admission', () => {
       runtimes: { explicit: catalog().runtimes.explicit }
     }
 
-    ;(daemon as any).armRuntimeProbeRefresh()
+    ;(daemon as any).runtimeFacts.armProbeRefresh()
 
-    expect((daemon as any).runtimeProbeTimer).toBeUndefined()
+    expect((daemon as any).runtimeFacts.probeTimer).toBeUndefined()
   })
 
   it('queues the ordinary CP-ready sweep behind an in-flight curated sweep', async () => {
@@ -359,9 +359,9 @@ describe('daemon curated runtime admission', () => {
     ;(daemon as any).runtimeCatalog = catalog()
     ;(daemon as any).refreshAdmittedRuntimes()
 
-    const curated = (daemon as any).probeRuntimesAndEmit(false)
+    const curated = (daemon as any).runtimeFacts.probeAndEmit(false)
     await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(1), WAIT)
-    await (daemon as any).probeRuntimesAndEmit(true)
+    await (daemon as any).runtimeFacts.probeAndEmit(true)
     releaseFirst()
     await curated
 

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -2271,7 +2271,7 @@ describe('Slack interactive status bar', () => {
     // daemon-wide probe result still carries the runtime's model choices.
     host.hasSession.mockReturnValue(false)
     ;(host.modelOptions as any).mockReturnValue(null)
-    ;(daemon as any).runtimeModels.set('claude', ['default', 'opus[1m]', 'sonnet', 'haiku'])
+    ;(daemon as any).runtimeFacts.models.set('claude', ['default', 'opus[1m]', 'sonnet', 'haiku'])
 
     const fallback = (await (daemon as any).statusInfoForKey(key)).info
     expect(fallback.model).toBe('default')

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -138,7 +138,7 @@ describe('Daemon rd/msg hook fires', () => {
       hostFactory: factory
     })
     await daemon.start()
-    ;(daemon as any).runtimeNames.claude = 'Claude Code'
+    ;(daemon as any).runtimeFacts.names.claude = 'Claude Code'
     await (daemon as any).ensureHostAsync(AGENT_ID)
 
     expect(await (daemon as any).githubReviews.githubCommentAttribution(AGENT_ID, 'acp-hook-1')).toMatchObject({

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -181,7 +181,7 @@ describe('daemon --k8s mode', () => {
       expect(Object.keys((k8sDaemon as any).runtimes)).toEqual(['claude'])
       // Never launches a runtime locally to learn this — the table is the source.
       expect(probe).not.toHaveBeenCalled()
-      const profile = (k8sDaemon as any).runtimeProfileFor('claude')
+      const profile = (k8sDaemon as any).runtimeFacts.profileFor('claude')
       expect(profile.models).toEqual(['sonnet'])
       // Declared, not probed: model gates must stay permissive on this provenance.
       expect(profile.modelsSource).toBe('cached')

--- a/packages/daemon/test/daemon-runtime-auth.test.ts
+++ b/packages/daemon/test/daemon-runtime-auth.test.ts
@@ -121,30 +121,30 @@ describe('live-turn runtime auth signal', () => {
     try {
       // An ordinary turn failure is NOT an auth signal — no mark, no emit.
       await expect((daemon as any).dispatch('bot-a', dm('100', 'q1'), 'int-a')).rejects.toThrow('runtime exploded')
-      expect((daemon as any).runtimeProfileFor('claude').authRequired).toBeUndefined()
+      expect((daemon as any).runtimeFacts.profileFor('claude').authRequired).toBeUndefined()
       expect(emitted.length).toBe(0)
 
       // ACP -32000 marks the agent's runtime and re-emits the facts snapshot.
       await expect((daemon as any).dispatch('bot-a', dm('200', 'q2'), 'int-a')).rejects.toMatchObject({
         code: -32000
       })
-      expect((daemon as any).runtimeProfileFor('claude')).toMatchObject({ authRequired: true })
+      expect((daemon as any).runtimeFacts.profileFor('claude')).toMatchObject({ authRequired: true })
       expect(emitted.length).toBe(1)
       expect(emitted[0]!.find((p) => p.runtime === 'claude')?.authRequired).toBe(true)
 
       // The next successful turn proves credentials work — mark cleared, flip emitted.
       await (daemon as any).dispatch('bot-a', dm('300', 'q3'), 'int-a')
-      expect((daemon as any).runtimeProfileFor('claude').authRequired).toBeUndefined()
+      expect((daemon as any).runtimeFacts.profileFor('claude').authRequired).toBeUndefined()
       expect(emitted.length).toBe(2)
       expect(emitted[1]!.find((p) => p.runtime === 'claude')?.authRequired).toBeUndefined()
 
       // The expired-credential family (-32603 + auth wording) marks it too.
       await expect((daemon as any).dispatch('bot-a', dm('400', 'q4'), 'int-a')).rejects.toThrow(/OAuth session expired/)
-      expect((daemon as any).runtimeProfileFor('claude')).toMatchObject({ authRequired: true })
+      expect((daemon as any).runtimeFacts.profileFor('claude')).toMatchObject({ authRequired: true })
       expect(emitted.length).toBe(3)
 
       await (daemon as any).dispatch('bot-a', dm('500', 'q5'), 'int-a')
-      expect((daemon as any).runtimeProfileFor('claude').authRequired).toBeUndefined()
+      expect((daemon as any).runtimeFacts.profileFor('claude').authRequired).toBeUndefined()
       expect(emitted.length).toBe(4)
     } finally {
       await daemon.stop()
@@ -182,10 +182,10 @@ describe('live-turn runtime auth signal', () => {
       await expect((daemon as any).dispatch('bot-a', dm('100', 'q1'), 'int-a')).rejects.toMatchObject({
         code: -32000
       })
-      expect((daemon as any).runtimeProfileFor('claude')).toMatchObject({ authRequired: true })
+      expect((daemon as any).runtimeFacts.profileFor('claude')).toMatchObject({ authRequired: true })
       // The successful turn still completes and clears the mark.
       await (daemon as any).dispatch('bot-a', dm('200', 'q2'), 'int-a')
-      expect((daemon as any).runtimeProfileFor('claude').authRequired).toBeUndefined()
+      expect((daemon as any).runtimeFacts.profileFor('claude').authRequired).toBeUndefined()
     } finally {
       await daemon.stop()
     }

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -375,7 +375,7 @@ describe('Daemon transcript records the agent reply', () => {
       hostFactory: factory
     })
     await daemon.start()
-    ;(daemon as any).runtimeNames.claude = 'Claude Code'
+    ;(daemon as any).runtimeFacts.names.claude = 'Claude Code'
     ;(daemon as any).agents.get('bot-a').displayName = 'Repo Bot'
     const conn = makeRoutable(daemon)
 

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -836,7 +836,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     })
     const daemon = new Daemon({ root, hostFactory: factory })
     await daemon.start()
-    ;(daemon as any).runtimeCatalogs.set('claude', {
+    ;(daemon as any).runtimeFacts.catalogs.set('claude', {
       models: [
         {
           id: 'default',

--- a/packages/daemon/test/model-catalog-daemon.test.ts
+++ b/packages/daemon/test/model-catalog-daemon.test.ts
@@ -75,7 +75,7 @@ async function seedCache(
  *  register-time `facts/daemon-runtimes` snapshot (cp/client.ts sends it at READY). */
 function firstSnapshot(daemon: Daemon): FactsRuntimeProfile[] {
   const d = daemon as any
-  return d.admittedRuntimeIds().map((id: string) => d.runtimeProfileFor(id))
+  return d.admittedRuntimeIds().map((id: string) => d.runtimeFacts.profileFor(id))
 }
 
 /** Capture post-sweep `facts/daemon-runtimes` emissions via the injected-cpClient
@@ -162,8 +162,8 @@ describe('daemon model-catalog cache hydrate', () => {
       })
       // The uninstalled runtime is absent from memory but retained on disk
       // (it may only be temporarily unresolved).
-      expect((daemon as any).runtimeModels.has('ghost')).toBe(false)
-      expect((daemon as any).runtimeCatalogs.has('ghost')).toBe(false)
+      expect((daemon as any).runtimeFacts.models.has('ghost')).toBe(false)
+      expect((daemon as any).runtimeFacts.catalogs.has('ghost')).toBe(false)
       expect(await ((daemon as any).store as LocalStore).getRuntimeCatalogMeta('ghost')).toBeDefined()
     } finally {
       await daemon.stop()
@@ -213,12 +213,12 @@ describe('daemon activation gate provenance rule', () => {
       await daemon.start()
       // Hydrated advertisement is non-empty but cached ⇒ NOT live knowledge: a
       // model added while the daemon was down must not be rejected at startup.
-      expect((daemon as any).runtimeModels.get('fake')).toEqual(['m-old'])
+      expect((daemon as any).runtimeFacts.models.get('fake')).toEqual(['m-old'])
       expect((daemon as any).activationCapabilityError(agent)).toBeUndefined()
 
       stubCatalogSvc(daemon)
       const emitted = captureEmits(daemon)
-      await (daemon as any).probeRuntimesAndEmit(true)
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
 
       // The sweep flips provenance cached→probed in the emitted snapshot...
       expect(emitted).toHaveLength(1)
@@ -250,7 +250,7 @@ describe('daemon last-good advertisement fallback', () => {
       const noteProbe = stubCatalogSvc(daemon)
       const emitted = captureEmits(daemon)
 
-      await (daemon as any).probeRuntimesAndEmit(true)
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
       expect(probe).toHaveBeenCalledTimes(1)
       const failed = emitted[0]![0]!
       // A disposable refresh can fail while established runtime homes remain
@@ -269,7 +269,7 @@ describe('daemon last-good advertisement fallback', () => {
       // no phase-2 rediscovery involved (the catalog service stub can't run one).
       clock.advance(6 * 60_000) // past the 5-minute probe TTL
       results = [{ runtime: 'fake', ok: true, models: ['m-a', 'm-b'] }]
-      await (daemon as any).probeRuntimesAndEmit(true)
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
       expect(probe).toHaveBeenCalledTimes(2)
       const restored = emitted[1]![0]!
       expect(restored.models).toEqual(['m-a', 'm-b'])
@@ -298,7 +298,7 @@ describe('daemon auth-required probe fold', () => {
       stubCatalogSvc(daemon)
       const emitted = captureEmits(daemon)
 
-      await (daemon as any).probeRuntimesAndEmit(true)
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
       // Authentication rejection is authoritative and clears even a warm cache.
       expect(emitted[0]![0]).toMatchObject({
         runtime: 'fake',
@@ -311,7 +311,7 @@ describe('daemon auth-required probe fold', () => {
       // entirely (absent ⇒ ok, matching older-daemon semantics).
       clock.advance(6 * 60_000) // past the 5-minute probe TTL
       results = [{ runtime: 'fake', ok: true, models: ['m-a'] }]
-      await (daemon as any).probeRuntimesAndEmit(true)
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
       expect(emitted[1]![0]!.runtime).toBe('fake')
       expect(emitted[1]![0]!.authRequired).toBeUndefined()
     } finally {
@@ -331,7 +331,7 @@ describe('daemon auth-required probe fold', () => {
       await daemon.start()
       stubCatalogSvc(daemon)
       const emitted = captureEmits(daemon)
-      await (daemon as any).probeRuntimesAndEmit(true)
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
       expect(emitted[0]![0]!.authRequired).toBeUndefined()
       // With no last-good cache, there is nothing to preserve.
       expect(emitted[0]![0]).toMatchObject({ models: [], modelsSource: 'probed' })
@@ -412,7 +412,7 @@ describe('daemon sweep phase-1 catalog seeding', () => {
         await daemon.start()
         const noteProbe = stubCatalogSvc(daemon)
         const emitted = captureEmits(daemon)
-        await (daemon as any).probeRuntimesAndEmit(true)
+        await (daemon as any).runtimeFacts.probeAndEmit(true)
 
         // Store: phase-1 meta (fingerprint, resolved default model, permission
         // modes) with the discovery gate left OPEN (complete=false)...
@@ -491,7 +491,7 @@ describe('daemon sweep phase-1 catalog seeding', () => {
     try {
       await daemon.start()
       stubCatalogSvc(daemon)
-      await (daemon as any).probeRuntimesAndEmit(true)
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
       const store = (daemon as any).store as LocalStore
       // meta.defaultModel is never the literal "default" (feeds the concrete
       // preselection/hint) — but the caps row IS seeded under "default" so


### PR DESCRIPTION
## What

`daemon.ts` held **15 unhomed fields** covering everything the daemon knows about the runtimes it can run, plus ~550 lines of methods that read them. This moves the **fields together with the methods** into a new `src/runtimes/facts-registry.ts`.

Fields moved (all 15): `runtimeNames`, `runtimeVersions`, `runtimeModels`, `runtimeAcpVersions`, `runtimeProbedVersions`, `runtimeMcpCaps`, `runtimeModelsSource`, `runtimeAuthRequired`, `runtimeAuthRequiredLive`, `runtimeCatalogs`, `probing`, `ordinaryProbePending`, `curatedProbePending`, `lastProbeAtMs`, `runtimeProbeTimer`.

Methods moved: `runtimeProfileFor` → `profileFor`, `emitDaemonRuntimeFacts` → `emitFacts`, `noteRuntimeAuthFromTurn` → `noteAuthFromTurn`, `applyK8sDeclaredFacts` → `applyDeclaredFacts(models, acp)`, `hydrateRuntimeCatalogCache` → `hydrateFromCache`, `rebuildRuntimeCatalog` → `rebuildCatalog`, `armRuntimeProbeRefresh` → `armProbeRefresh`, `probeRuntimesAndEmit` → `probeAndEmit`, `applyProbeResult`, `seedCatalogFromProbe`. Plus two new seams that replace inline field writes on Daemon: `setInstalled(entries)` (start-up name/version tables) and `noteImageCatalog(entries)` (the k8s image-probe version refresh). `dispose()` drops the recurring curated re-probe timer and is wired into `stop()`. `Daemon.PROBE_TTL_MS` becomes an exported `PROBE_TTL_MS`, imported by the curated-admission construction.

## Host

One narrow grouped host, `RuntimeFactsHost`, for the genuinely outward calls: `log`/`clock`, the catalog-cache store rows (`RuntimeFactsStore` = a 5-method `Pick<LocalStore, …>`), the admitted/reported runtime view it projects over (`catalog`, `admittedRuntimes`, `refreshAdmitted`, `reportedRuntimeIds`, `curatedAdmission`), CP egress (`emitDaemonRuntimes`, `updateCapabilities`, `mcpServerFacts`), the model-catalog service note, and one `launch()` context describing how a probe spawns (k8s flag, fake-host/injected-prober seams, sandbox mechanism, roots).

Admission (`this.runtimes`, `refreshAdmittedRuntimes`, `admittedRuntimeIds`, `reportedRuntimeIds`) deliberately stays on Daemon: it touches none of the 15 fields and `this.runtimes` is read across launch gating — it is a separate cluster, reached here through the host.

## Placement

`src/runtimes/facts-registry.ts`, not daemon-adjacent — no cycle. Its only non-`runtimes/` imports are ones `runtimes/*` already takes (`../acp/*`, `../launch/*`, `../store/local-store.js`, `../paths.js`, `../log.js`, `../config/config-schema.js`) plus `../daemon/text.js` for `formatErr`, which is a zero-import leaf util.

## No shells

No same-name delegate wrappers were left on `Daemon`. Callers hold `this.runtimeFacts` directly: `start()`, the model-catalog service's `onUpdated`, `probeK8sRuntimes`, `buildAcpHost` MCP caps, activation gating, the status/model projections, `cp-client-deps`' `runtimeProfileFor`/`probeRuntimesAndEmit` members, `onMcpDefsChanged`, and `stop()`. Test pokes/spies were retargeted to the real owner — `(daemon as any).runtimeFacts.<name>` — across 9 test files.

Emission ordering is untouched: results are still applied and emitted the moment each lands (#1153).

## Verification

- `pnpm typecheck` (daemon) clean
- `vitest run test/model-catalog-daemon.test.ts test/daemon-runtime-auth.test.ts test/runtime-prober.test.ts test/curated-runtime-daemon.test.ts` — 56 passed
- `vitest run test/daemon-k8s-mode.test.ts test/daemon-webchat.test.ts test/daemon-transcript.test.ts test/daemon-hook.test.ts test/cp/cp-agent-reconcile.test.ts` — passed
- `test/daemon-smoke.test.ts` — 38/39; the one failure (`GIT_CONFIG_KEY_0` in `buildAcpHost` env) reproduces identically on unmodified `origin/main`
- prettier + eslint clean on every touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)