### PR TITLE
fix(daemon): stop handing a cluster runtime an MCP bridge that lives on the daemon's filesystem

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1536,7 +1536,7 @@ export class Daemon {
           // workspace is the one case today: its git reaches the credential helper over a unix
           // socket that, without a tunnel, exists only on the daemon's own filesystem. MCP is
           // deliberately absent — the in-pod bridge that would dial it is not in the image yet, so
-          // a listener for it would be a socket nobody can use.
+          // a listener for it would be a socket nobody can use — `mcpBridgeRunnable` withholds the spec too.
           tunnelsFor: (agentId) =>
             this.agents.get(agentId)?.workspace.gitCredential === 'github-app' ? ['gitcred'] : [],
           tunnelSocketPath: (tunnel) => (tunnel === 'gitcred' ? gitcredSocketPath(root) : undefined),
@@ -1566,6 +1566,11 @@ export class Daemon {
       // in-place conversion has no pod-side implementation of its rollback contract.
       this.workspaces.setSandboxMode(true)
       this.log.info('k8s: execution plane ready — daemon-to-sandbox shim dialing enabled')
+      // Once at boot rather than per session: it is a property of the image this pool runs.
+      this.log.warn(
+        'mcp: cluster agents get no AgentConnect tool server — the runtime image ships no in-pod bridge, ' +
+          'so agent tools, memory distillation and dream knowledge browsing are unavailable to them'
+      )
     }
     // Sandbox-optional principle (#36): skills are NOT force-sandboxed fleet-wide.
     // A skill runs sandboxed only when its agent does (agentRunsInSandbox), so the
@@ -2218,7 +2223,8 @@ export class Daemon {
         // Falling back to agent.integrations[0] can send a title/message through the
         // wrong bot when one agent has multiple integrations. A memory-only session
         // still registers with no integration so its universal tools work.
-        if (tools.length > 0) {
+        // No bridge to spawn ⇒ no token either: a live credential nothing can ever present.
+        if (tools.length > 0 && this.mcpBridgeRunnable()) {
           const token = this.mcp.register({
             agentId: agent.id,
             platform,
@@ -2775,6 +2781,12 @@ export class Daemon {
     // agent runs (and installs/uses skills) unsandboxed, and the daemon never
     // fails closed on a host with no OS sandbox.
     return effectiveRunInSandbox(this.cfg.security.requireSandbox, agent.runInSandbox, this.sandboxMechanism)
+  }
+
+  // False in --k8s: `buildMcpServers` names a bridge entry and control socket on THIS filesystem,
+  // and the sandbox image ships neither — the pod's runtime restarted a missing module instead.
+  private mcpBridgeRunnable(): boolean {
+    return !this.k8sPlane
   }
 
   private async runAgentWorkspacePreparation(agent: Agent, request?: PrepareSessionWorkspaceRequest): Promise<string> {
@@ -3811,11 +3823,14 @@ export class Daemon {
         })
         this.releaseMemoryExtractionToken(cacheKey)
         this.memoryExtractionTokens.set(cacheKey, mcpToken)
-        const mcpServers = buildMcpServers({
-          socketPath: mcpSocketPath(this.root),
-          token: mcpToken,
-          cliEntry: daemonEntryForShims(this.root)
-        })
+        // Tool-less in --k8s: the extraction already wrote nothing behind a bridge the pod could not start.
+        const mcpServers = this.mcpBridgeRunnable()
+          ? buildMcpServers({
+              socketPath: mcpSocketPath(this.root),
+              token: mcpToken,
+              cliEntry: daemonEntryForShims(this.root)
+            })
+          : []
         sessionId = trusted
           ? await host.newSession(cwd, mcpServers, undefined, MEMORY_DISTILLATION_SYSTEM_PROMPT)
           : await host.newSession(cwd, mcpServers)
@@ -4209,11 +4224,14 @@ export class Daemon {
       thread: context.dreamId,
       tools: KNOWLEDGE_TOOLS
     })
-    const mcpServers = buildMcpServers({
-      socketPath: mcpSocketPath(this.root),
-      token: mcpToken,
-      cliEntry: daemonEntryForShims(this.root)
-    })
+    // Tool-less in --k8s for the same reason: no knowledge browsing, rather than an unspawnable spec.
+    const mcpServers = this.mcpBridgeRunnable()
+      ? buildMcpServers({
+          socketPath: mcpSocketPath(this.root),
+          token: mcpToken,
+          cliEntry: daemonEntryForShims(this.root)
+        })
+      : []
     try {
       const sessionId = trusted
         ? await host.newSession(cwd, mcpServers, undefined, systemPrompt)

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -502,4 +502,39 @@ describe('daemon --k8s mode', () => {
       await k8sDaemon.stop()
     }
   })
+
+  // Sent to a pod, the daemon-path bridge spec became a MODULE_NOT_FOUND restart loop in its log.
+  it('injects no AgentConnect MCP server, because the sandbox image ships no bridge to spawn', async () => {
+    const k8sDaemon = daemon({ root: root({ declared: { runtimes: [{ id: 'claude' }] } }), k8s: true })
+    try {
+      await k8sDaemon.start()
+      expect(mcpServersFor(k8sDaemon)).toEqual([])
+    } finally {
+      await k8sDaemon.stop()
+    }
+  })
+
+  it('still injects the bridge outside k8s, where the runtime shares this filesystem', async () => {
+    const local = daemon({ root: root(), k8s: false })
+    try {
+      await local.start()
+      const servers = mcpServersFor(local)
+      expect(servers).toHaveLength(1)
+      expect(servers[0]!.args).toContain('mcp-bridge')
+    } finally {
+      await local.stop()
+    }
+  })
 })
+
+/** The session seam that decides an agent's MCP servers, asked about an ordinary agent. */
+function mcpServersFor(instance: Daemon): { args: string[] }[] {
+  const agent = { id: 'a1', name: 'a1', runtime: 'claude', integrations: [], mcpServers: [] }
+  return (instance as any).sessions.deps.mcpServersFor({
+    agent,
+    platform: 'slack',
+    channel: 'C1',
+    thread: '1',
+    isDm: false
+  })
+}


### PR DESCRIPTION
## The symptom

Every claimed runtime sandbox pod logged a crash loop moments after `shim: bound`:

```
Error: Cannot find module '/app/packages/daemon/dist/index.js'
code: 'MODULE_NOT_FOUND'
```

Eleven stack traces on an exponential backoff (0.65s → 30s), then silence. Nothing on
the daemon side said anything at all.

## What was actually happening

`mcpServersFor` built the AgentConnect stdio MCP server unconditionally, so a `--k8s`
session carried **this daemon's own** `cliEntry` and control-socket path into the sandbox
pod through ACP `session/new`. The runtime there dutifully spawned it, the module is not
in the runtime image, and the runtime's own MCP client retried on a backoff loop.

The path's shape is what identifies the source. `sandboxProviderLauncher()` — the obvious
suspect — passes the bare `process.argv[1]`, which in the daemon container is the
*relative* `dist/index.js`. Only `buildMcpServers()` runs it through `realpathSync`, which
is what produces the absolute path in the error. The SRT provider is not involved at all:
`--k8s` sets `sandboxProbe` to `undefined` on purpose (the pod is the isolation boundary),
and `createRemoteRuntime` never forwards `request.sandbox` to the shim.

## The fix

The runtime image ships the shim, the credential helper and the gh token entry, and no
bridge. `tunnelsFor` already withholds the matching `mcp` tunnel for exactly that reason,
with a comment saying so. This withholds the other half.

`mcpBridgeRunnable()` gates the three injection points — ordinary session, memory
distillation, dream — and the ordinary path no longer registers a bridge token either,
since nothing can ever present it. The plane now says once at boot that cluster agents
have no tool server, rather than leaving it to be discovered as a crash loop in a pod log.

## What a reviewer should know

**Behaviour is unchanged.** A bridge that could never start provided no tools either, so
cluster agents have had no AgentConnect tool surface — agent tools, memory distillation,
dream knowledge browsing — all along. This PR removes the noise and states the gap; it
does not close it. Ordinary chat is unaffected: replies travel over ACP `session/update`
and never touch the bridge.

Closing the gap properly means a fourth shim bundle, an image entry, opening the `mcp`
tunnel, rewriting the spec into pod coordinates, and probing for the bridge so images
already deployed keep working. That is a feature on top of this, and it is in progress
separately — expect this gate and the boot warning to come back out when it lands.

## Verification

- Two differential rows in `daemon-k8s-mode.test.ts`: `k8s: true` injects no server,
  `k8s: false` still injects one containing `mcp-bridge`. The rows differ only by that flag.
- Reproduced live in a cluster environment before the change and traced end to end —
  pod `shim: bound`, then the owning daemon's `acp:` line 1.4s before the first trace.
- Daemon typecheck and repo format clean; 65/65 across `daemon-k8s-mode`, `mcp-inject`
  and `daemon-smoke`.
- The full daemon suite has 15 pre-existing failures in 5 files (`acp-matrix`, `shim-*`,
  `workspace-git-runner-seam`). None of them import `daemon.ts`, and they fail identically
  on a clean tree — they are macOS/live-provider environmental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
