### PR TITLE
fix(memory): normalize frontmatter in the shared write path

### DIFF
--- a/packages/daemon/src/memory/frontmatter.ts
+++ b/packages/daemon/src/memory/frontmatter.ts
@@ -108,15 +108,23 @@ export function parseMemoryFrontmatter(text: string): ParsedMemory {
   }
 }
 
+/** Plain forms YAML resolves to something OTHER than a string — booleans, null, and
+ *  numbers in every spelling. A description of exactly `true` or `123` must keep its
+ *  quotes or it stops being text on the way back in. */
+const NON_STRING_SCALAR =
+  /^(?:true|false|yes|no|on|off|null|~|[-+]?(?:\d[\d_]*)(?:\.[\d_]*)?(?:[eE][-+]?\d+)?|[-+]?\.(?:inf|nan)|0[xXoObB][0-9a-fA-F_]+)$/i
+
 /**
- * Quote unless the value is unambiguously a plain YAML scalar. Conservative on
- * purpose: a stored description must survive any strict YAML reader, so this covers
- * every leading indicator character (`- ? : , [ ] { } # & * ! | > ' " % @ \``), a
- * `key: value` split, a trailing colon, an inline ` #` comment, and edge whitespace.
- * An ISO timestamp's interior colons are safe and stay unquoted.
+ * Quote unless the value is unambiguously a plain YAML *string* scalar. Conservative
+ * on purpose: a stored description must survive any strict YAML reader. Covers every
+ * leading indicator (`- ? : , [ ] { } # & * ! | > ' " % @ \``), a `key: value` split,
+ * a trailing colon, an inline ` #` comment, edge whitespace, and any spelling that
+ * would resolve as a boolean, null, or number. An ISO timestamp's interior colons are
+ * safe and stay unquoted.
  */
 function quoteIfNeeded(value: string): string {
-  return /^[\s\-?:,[\]{}#&*!|>'"%@`]|: |:$| #|\s$/.test(value) ? JSON.stringify(value) : value
+  const unsafe = /^[\s\-?:,[\]{}#&*!|>'"%@`]|: |:$| #|\s$/.test(value) || NON_STRING_SCALAR.test(value)
+  return unsafe ? JSON.stringify(value) : value
 }
 
 /**

--- a/packages/daemon/src/memory/frontmatter.ts
+++ b/packages/daemon/src/memory/frontmatter.ts
@@ -1,3 +1,4 @@
+import { parse as parseYaml } from 'yaml'
 /**
  * Memory file headers — a small YAML frontmatter block at the top of each topic
  * file (Claude Code's agent-memory shape, #41):
@@ -108,22 +109,37 @@ export function parseMemoryFrontmatter(text: string): ParsedMemory {
   }
 }
 
-/** Plain forms YAML resolves to something OTHER than a string — booleans, null, and
- *  numbers in every spelling. A description of exactly `true` or `123` must keep its
- *  quotes or it stops being text on the way back in. */
-const NON_STRING_SCALAR =
-  /^(?:true|false|yes|no|on|off|null|~|[-+]?(?:\d[\d_]*)(?:\.[\d_]*)?(?:[eE][-+]?\d+)?|[-+]?\.(?:inf|nan)|0[xXoObB][0-9a-fA-F_]+)$/i
+/**
+ * Whether YAML would read this plain scalar as something other than a string —
+ * booleans, null, and every numeric spelling (including leading-decimal floats like
+ * `.5e2`). Asking the parser we already depend on beats re-deriving its grammar by
+ * hand: a hand-written pattern silently drifts from it, and each gap turns a stored
+ * description into a boolean or number on the way back in.
+ */
+/** YAML 1.1 spells these as booleans; the 1.2 core schema our parser implements reads
+ *  them as plain strings. Quote them anyway — the guarantee is that the value survives
+ *  ANY strict reader, not only the one we happen to link. */
+const YAML_11_BOOLEANS = /^(?:y|n|yes|no|on|off)$/i
+
+function resolvesAsNonString(value: string): boolean {
+  if (YAML_11_BOOLEANS.test(value)) return true
+  try {
+    return typeof parseYaml(value) !== 'string'
+  } catch {
+    // Unparseable as a bare scalar ⇒ definitely not a safe plain string.
+    return true
+  }
+}
 
 /**
  * Quote unless the value is unambiguously a plain YAML *string* scalar. Conservative
  * on purpose: a stored description must survive any strict YAML reader. Covers every
  * leading indicator (`- ? : , [ ] { } # & * ! | > ' " % @ \``), a `key: value` split,
- * a trailing colon, an inline ` #` comment, edge whitespace, and any spelling that
- * would resolve as a boolean, null, or number. An ISO timestamp's interior colons are
- * safe and stay unquoted.
+ * a trailing colon, an inline ` #` comment, edge whitespace, and anything the parser
+ * would resolve as a non-string.
  */
 function quoteIfNeeded(value: string): string {
-  const unsafe = /^[\s\-?:,[\]{}#&*!|>'"%@`]|: |:$| #|\s$/.test(value) || NON_STRING_SCALAR.test(value)
+  const unsafe = /^[\s\-?:,[\]{}#&*!|>'"%@`]|: |:$| #|\s$/.test(value) || resolvesAsNonString(value)
   return unsafe ? JSON.stringify(value) : value
 }
 

--- a/packages/daemon/src/memory/frontmatter.ts
+++ b/packages/daemon/src/memory/frontmatter.ts
@@ -109,25 +109,24 @@ export function parseMemoryFrontmatter(text: string): ParsedMemory {
   }
 }
 
-/**
- * Whether YAML would read this plain scalar as something other than a string —
- * booleans, null, and every numeric spelling (including leading-decimal floats like
- * `.5e2`). Asking the parser we already depend on beats re-deriving its grammar by
- * hand: a hand-written pattern silently drifts from it, and each gap turns a stored
- * description into a boolean or number on the way back in.
- */
 /** YAML 1.1 spells these as booleans; the 1.2 core schema our parser implements reads
  *  them as plain strings. Quote them anyway — the guarantee is that the value survives
  *  ANY strict reader, not only the one we happen to link. */
 const YAML_11_BOOLEANS = /^(?:y|n|yes|no|on|off)$/i
 
-function resolvesAsNonString(value: string): boolean {
-  if (YAML_11_BOOLEANS.test(value)) return true
+/**
+ * Whether emitting this value bare would round-trip byte-for-byte. Asking the parser
+ * we already depend on beats re-deriving its grammar by hand, and comparing the VALUE
+ * rather than its type catches the cases a type check misses: a decoded escape, a
+ * folded line break, trimmed padding — each of which keeps the `string` type while
+ * silently changing the bytes, or breaks the header outright.
+ */
+function roundTripsBare(value: string): boolean {
   try {
-    return typeof parseYaml(value) !== 'string'
+    return parseYaml(value) === value
   } catch {
-    // Unparseable as a bare scalar ⇒ definitely not a safe plain string.
-    return true
+    // Unparseable as a bare scalar ⇒ definitely not safe to emit bare.
+    return false
   }
 }
 
@@ -135,12 +134,13 @@ function resolvesAsNonString(value: string): boolean {
  * Quote unless the value is unambiguously a plain YAML *string* scalar. Conservative
  * on purpose: a stored description must survive any strict YAML reader. Covers every
  * leading indicator (`- ? : , [ ] { } # & * ! | > ' " % @ \``), a `key: value` split,
- * a trailing colon, an inline ` #` comment, edge whitespace, and anything the parser
- * would resolve as a non-string.
+ * a trailing colon, an inline ` #` comment, edge whitespace, and anything that would
+ * not read back byte-for-byte as the same string.
  */
 function quoteIfNeeded(value: string): string {
-  const unsafe = /^[\s\-?:,[\]{}#&*!|>'"%@`]|: |:$| #|\s$/.test(value) || resolvesAsNonString(value)
-  return unsafe ? JSON.stringify(value) : value
+  const structural = /^[\s\-?:,[\]{}#&*!|>'"%@`]|: |:$| #|\s$/.test(value)
+  const safe = !structural && !YAML_11_BOOLEANS.test(value) && roundTripsBare(value)
+  return safe ? value : JSON.stringify(value)
 }
 
 /**

--- a/packages/daemon/src/memory/store.ts
+++ b/packages/daemon/src/memory/store.ts
@@ -49,6 +49,7 @@ import {
   memoryNameForTopic,
   memoryRefToTopic,
   parseMemoryFrontmatter,
+  normalizeMemoryHeader,
   stampMemoryHeader
 } from './frontmatter.js'
 
@@ -573,7 +574,14 @@ export async function writeMemoryFileHoldingLock(
   const topic = memoryTopicName(relPath)
   // Keep a written header truthful (`name` from the filename, fresh `modified`).
   // Headerless notes are left exactly as written — frontmatter is never forced on.
-  if (topic !== MEMORY_INDEX) content = stampMemoryHeader(topic, content, new Date().toISOString())
+  if (topic !== MEMORY_INDEX) {
+    // Normalize BEFORE stamping so every writer — a turn, distillation, a dream —
+    // stores a header a strict YAML reader accepts. Doing it here rather than at one
+    // caller means a model-written `description: ship: prod` cannot reach disk from
+    // any path. Both steps are idempotent, so re-writing a file is a no-op.
+    content = normalizeMemoryHeader(content)
+    content = stampMemoryHeader(topic, content, new Date().toISOString())
+  }
   if (Buffer.byteLength(content) > MAX_MEMORY_FILE_BYTES) {
     throw new MemoryTooLargeError(`memory file exceeds the ${MAX_MEMORY_FILE_BYTES}-byte limit`)
   }

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -443,3 +443,34 @@ describe('the reviewed index is the adopted index', () => {
     expect(liveIndex.replace(/^# .*$/m, '')).toBe(stagedIndex.replace(/^# .*$/m, ''))
   })
 })
+
+describe('every writer stores safe frontmatter', () => {
+  it('normalizes an unsafe header no matter which trigger wrote it', async () => {
+    // Normalization used to live at dream staging only, so a description reaching
+    // disk from a turn or from distillation could still be invalid YAML. It is in the
+    // shared write path now, so the guarantee holds for all three.
+    const nasty = 'ship: prod #now'
+    for (const source of ['tool', 'distill', 'dream', 'console'] as const) {
+      const f = fs()
+      await ensureMemory(f, 'bot')
+      await writeMemoryFile(f, 'topic.md', `---\ndescription: ${nasty}\n---\nbody\n`, undefined, source)
+
+      const stored = await readMemoryFile(f, 'topic.md')
+      expect(stored).toContain(`description: ${JSON.stringify(nasty)}`)
+      expect(parseMemoryFrontmatter(stored).header.description).toBe(nasty)
+    }
+  })
+
+  it('is a no-op for a header that is already safe, so rewrites do not churn', async () => {
+    const f = fs()
+    await ensureMemory(f, 'bot')
+    await writeMemoryFile(f, 'plain.md', '---\ndescription: how we ship\n---\nbody\n', undefined, 'tool')
+    const first = await readMemoryFile(f, 'plain.md')
+    expect(first).toContain('description: how we ship') // still unquoted
+
+    await writeMemoryFile(f, 'plain.md', first, undefined, 'tool')
+    const second = await readMemoryFile(f, 'plain.md')
+    // Only `modified` may differ; the description must not gain quoting or escapes.
+    expect(second).toContain('description: how we ship')
+  })
+})

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -474,3 +474,46 @@ describe('every writer stores safe frontmatter', () => {
     expect(second).toContain('description: how we ship')
   })
 })
+
+describe('values that only stay strings while quoted', () => {
+  it('keeps quotes on anything YAML would resolve as a bool, null, or number', () => {
+    // Normalization runs on EVERY write now, so dequoting one of these would turn a
+    // correctly-stored description into a boolean/number on the way back in.
+    const nonStrings = [
+      'true',
+      'False',
+      'yes',
+      'no',
+      'on',
+      'off',
+      'null',
+      '~',
+      '123',
+      '-4',
+      '1.5',
+      '1e10',
+      '.inf',
+      '.NaN',
+      '0x1f'
+    ]
+    for (const value of nonStrings) {
+      const fixed = normalizeMemoryHeader(`---\ndescription: ${JSON.stringify(value)}\n---\nbody\n`)
+      expect(fixed).toContain(`description: ${JSON.stringify(value)}`)
+      expect(parseMemoryFrontmatter(fixed).header.description).toBe(value)
+    }
+  })
+
+  it('still leaves ordinary prose unquoted', () => {
+    for (const value of ['how we ship', 'version 2 of the plan', 'notes about 123 things']) {
+      const fixed = normalizeMemoryHeader(`---\ndescription: ${value}\n---\nbody\n`)
+      expect(fixed).toContain(`description: ${value}`)
+    }
+  })
+
+  it('survives a write/read cycle for a numeric-looking description', async () => {
+    const f = fs()
+    await ensureMemory(f, 'bot')
+    await writeMemoryFile(f, 'n.md', '---\ndescription: "2026"\n---\nbody\n', undefined, 'dream')
+    expect(parseMemoryFrontmatter(await readMemoryFile(f, 'n.md')).header.description).toBe('2026')
+  })
+})

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -494,7 +494,13 @@ describe('values that only stay strings while quoted', () => {
       '1e10',
       '.inf',
       '.NaN',
-      '0x1f'
+      '0x1f',
+      // Leading-decimal floats: the branch a hand-written grammar keeps missing,
+      // which is why the parser itself is now the oracle.
+      '.5',
+      '+.5',
+      '.5e2',
+      '-.5E-2'
     ]
     for (const value of nonStrings) {
       const fixed = normalizeMemoryHeader(`---\ndescription: ${JSON.stringify(value)}\n---\nbody\n`)

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -523,3 +523,28 @@ describe('values that only stay strings while quoted', () => {
     expect(parseMemoryFrontmatter(await readMemoryFile(f, 'n.md')).header.description).toBe('2026')
   })
 })
+
+describe('values whose BYTES change when emitted bare', () => {
+  it('keeps quotes when the text would not read back identically', () => {
+    // A type check is not enough: each of these stays a `string` but comes back with
+    // different bytes — or breaks the header outright, as the newline does by turning
+    // one header line into two.
+    const changed = ['line1\nline2', 'trailing  ', '  leading', 'tab\there', 'a  b']
+    for (const value of changed) {
+      const fixed = normalizeMemoryHeader(`---\ndescription: ${JSON.stringify(value)}\n---\nbody\n`)
+      // Still exactly one description line — a decoded newline would have split it.
+      expect(fixed.match(/^description:/gm)).toHaveLength(1)
+      expect(parseMemoryFrontmatter(fixed).header.description).toBe(value)
+    }
+  })
+
+  it('survives the real write path with an embedded newline', async () => {
+    const f = fs()
+    await ensureMemory(f, 'bot')
+    const value = 'first\nsecond'
+    await writeMemoryFile(f, 'multi.md', `---\ndescription: ${JSON.stringify(value)}\n---\nbody\n`, undefined, 'dream')
+    const stored = await readMemoryFile(f, 'multi.md')
+    expect(stored.match(/^description:/gm)).toHaveLength(1)
+    expect(parseMemoryFrontmatter(stored).header.description).toBe(value)
+  })
+})


### PR DESCRIPTION
Groundwork for item 3 (dream writing its proposal through the shared tools), and a real fix on its own.

## The gap

I put `normalizeMemoryHeader` at **dream staging** in #1260. But since #1257/#1265, a turn and per-turn distillation also write model-authored headers — and neither went through it. An unsafe `description` (holding `: `, ` #`, or a leading YAML indicator) could still reach disk from those paths.

## The fix

Normalization moves into `writeMemoryFileHoldingLock`, ahead of stamping. One place decides how a value is stored and **every** writer inherits the guarantee. Both steps are idempotent, so rewriting a file doesn't churn it — an already-safe description stays unquoted.

It also deletes the staging-specific special case, which is why this comes first: once the dream writes through the tools, staging is no longer a distinct path that could carry its own protection.

## Tests

An unsafe header normalizes identically whichever source wrote it (`tool` / `distill` / `dream` / `console`), and a safe one survives a rewrite unchanged. Memory + dream + distill + channel + evaluation + write-gate suites green (8 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)