### PR TITLE
feat(daemon): ship the tool-server bridge in the runtime image so cluster agents get their tools

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -124,7 +124,13 @@ COPY --from=shim-builder --chown=0:0 /build/packages/daemon/dist/shim/git-creden
 # The gh wrapper's token fetch, a third disjoint bundle for the same reason: the wrapper spawns it once per `gh`.
 # Path must match SANDBOX_GH_TOKEN_ENTRY in packages/daemon/src/shim/sandbox-paths.ts.
 COPY --from=shim-builder --chown=0:0 /build/packages/daemon/dist/shim/gh-token.js /opt/agentconnect/shim/gh-token.js
-RUN chmod 0444 /opt/agentconnect/shim/index.js /opt/agentconnect/shim/git-credential.js /opt/agentconnect/shim/gh-token.js \
+# The AgentConnect tool server, a fourth disjoint bundle: the agent's harness spawns it once per session from the
+# spec the daemon sends, and it reaches the daemon over the `mcp` tunnel rather than this image's filesystem.
+# Path must match SANDBOX_MCP_BRIDGE_ENTRY in packages/daemon/src/shim/sandbox-paths.ts — the daemon puts this path
+# in the spec, so a rename here is a runtime that retries a missing module until it gives up.
+COPY --from=shim-builder --chown=0:0 /build/packages/daemon/dist/shim/mcp-bridge.js /opt/agentconnect/shim/mcp-bridge.js
+RUN chmod 0444 /opt/agentconnect/shim/index.js /opt/agentconnect/shim/git-credential.js \
+  /opt/agentconnect/shim/gh-token.js /opt/agentconnect/shim/mcp-bridge.js \
   && chmod 0555 /opt/agentconnect/shim
 
 # The executable git runs as its credential helper. A wrapper because git needs something

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -66,8 +66,22 @@ it holds no policy — every decision stays in the daemon.
 The tunnel names a **closed set** of daemon-side servers (`gitcred`, `mcp`) at paths the
 runtime image fixes. `gh`'s token helper is not among them because it shares `gitcred.sock`
 with the credential helper: a second name would be a second in-pod path onto one server.
-`mcp` is declared but not yet opened — the in-pod bridge that would dial it is not in the
-image, so a listener for it would be a socket nothing can use.
+`mcp` is served for every pod agent, because any session may carry tools and the listener belongs
+to the pod's lifetime; the `mcpServers` spec that dials it is decided per session instead.
+
+That spec is in **pod coordinates**, and the launch half of it is reported by the image rather
+than assembled here: the runtime probe answers with the interpreter and the bridge bundle (a
+fourth single-file shim artifact, spawned by the agent's harness once per session), and the daemon
+copies both into `mcpServers` beside the tunnel's in-pod socket. Even `node` by name would be an
+assumption about a filesystem and a PATH the daemon cannot see. An image built before the bridge
+reports neither and gets no tool server at all, which is the honest outcome: the daemon's own
+bridge path sent into a pod is not a degraded spec but an unspawnable one, and a runtime handed it
+retried a missing module on a backoff for the life of the session.
+
+The `mcp` stream is also the one tunnel with no idle deadline. A credential stream is one request
+and its reply, so silence means no answer is coming; the bridge holds a single connection for the
+life of an ACP session and is idle between tool calls, and ending that is the agent losing its
+tools mid-session. Its bound is the channel: a lost or superseded one stops every stream.
 
 **The shim listens; the daemon dials the ready pod's IP.** The Sandbox status already reports
 the backing pod's addresses, so no per-sandbox Service is required. The sandbox

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -73,7 +73,7 @@ import {
   sessionGitPolicyEnv
 } from './workspace/git-injection.js'
 import { configureWorkspaceGitOrigins } from './workspace/git-origin-policy.js'
-import { buildMcpServers } from './mcp/inject.js'
+import { buildMcpServers, buildSandboxMcpServers, type McpStdioServer } from './mcp/inject.js'
 import { resolveAgentMcpServers, RESERVED_MCP_SERVER_NAME } from './mcp/resolve-servers.js'
 import { toolsForIntegrations, GITHUB_REVIEW_TOOLS, KNOWLEDGE_TOOLS } from './mcp/tools.js'
 import { MEMORY_TOOL_NAMES, MEMORY_TOOLS } from './memory/tools.js'
@@ -873,6 +873,9 @@ export class Daemon {
   // runtimeProfiles() reports — ACP protocol version, the adapter's own version, MCP transports —
   // stay empty and the published snapshot describes nothing.
   private k8sDeclaredAcp: Record<string, K8sRuntimeAcpSnapshot> = {}
+  // How the probed image launches its in-pod MCP bridge; undefined until the probe answers, and on
+  // an image built before it shipped one. Set only from a live probe — see probeK8sRuntimes.
+  private k8sMcpBridge?: { command: string; args: string[] }
   // Per-runtime facts (names, versions, models, ACP/MCP caps, login state, catalogs),
   // the probe sweep that learns them, and the `facts/daemon-runtimes` snapshot.
   private runtimeFacts!: RuntimeFactsRegistry
@@ -1464,7 +1467,7 @@ export class Daemon {
     await this.hydrateCpRouting()
     this.buildCpRegistries()
     await this.startMcpControlServer(root, cfg)
-    this.buildSessionRuntime(root, cfg)
+    this.buildSessionRuntime(cfg)
     this.buildSchedulers()
     const startControlPlane = await this.connectControlPlane(root)
     await this.openPlatformConnections(agents)
@@ -1550,14 +1553,19 @@ export class Daemon {
           // member shares — a per-process counter restarts at 1 and the agent's pod refuses it.
           generations: this.dataPlane!.store,
           orgForAgent: (agentId) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
-          // Which sockets this agent's pod needs, and where this daemon serves them. A GitHub-App
-          // workspace is the one case today: its git reaches the credential helper over a unix
-          // socket that, without a tunnel, exists only on the daemon's own filesystem. MCP is
-          // deliberately absent — the in-pod bridge that would dial it is not in the image yet, so
-          // a listener for it would be a socket nobody can use.
-          tunnelsFor: (agentId) =>
-            this.agents.get(agentId)?.workspace.gitCredential === 'github-app' ? ['gitcred'] : [],
-          tunnelSocketPath: (tunnel) => (tunnel === 'gitcred' ? gitcredSocketPath(root) : undefined),
+          // Which sockets this agent's pod needs, and where this daemon serves them — both are on
+          // the daemon's own filesystem, so without a tunnel they exist nowhere the pod can reach.
+          // `mcp` is served for every pod agent because any session may carry tools and the
+          // listener belongs to the pod's lifetime, while the spec that dials it is decided per
+          // session; a GitHub-App workspace adds the credential helper its git asks for.
+          // An id this daemon holds no agent for gets neither: the member's own runtime probe is
+          // the case, and its channel is granted `probe` alone, so asking would only be refused.
+          tunnelsFor: (agentId) => {
+            const agent = this.agents.get(agentId)
+            if (!agent) return []
+            return agent.workspace.gitCredential === 'github-app' ? ['mcp', 'gitcred'] : ['mcp']
+          },
+          tunnelSocketPath: (tunnel) => (tunnel === 'gitcred' ? gitcredSocketPath(root) : mcpSocketPath(root)),
           // A bound sandbox is a reachable memory tree: drain any managed capture that waited for it.
           onSandboxBound: () => this.memoryOutbox?.wake(),
           log: {
@@ -2200,9 +2208,7 @@ export class Daemon {
   }
 
   /** Phase 24 — the turn-context coordinator and the session manager, which registers bridge tokens against the MCP server above. */
-  private buildSessionRuntime(root: string, cfg: Config): void {
-    const cliEntry = daemonEntryForShims(root)
-
+  private buildSessionRuntime(cfg: Config): void {
     this.threadContext = new ThreadContextCoordinator(this.store, (error) =>
       this.log.warn(`turn context snapshot degraded to observed-only (${formatErr(error)})`)
     )
@@ -2296,7 +2302,8 @@ export class Daemon {
         // Falling back to agent.integrations[0] can send a title/message through the
         // wrong bot when one agent has multiple integrations. A memory-only session
         // still registers with no integration so its universal tools work.
-        if (tools.length > 0) {
+        // No reachable bridge ⇒ no token either: a live credential nothing can present.
+        if (tools.length > 0 && this.mcpToolServerReachable()) {
           const token = this.mcp.register({
             agentId: agent.id,
             platform,
@@ -2314,7 +2321,7 @@ export class Daemon {
             agentName: agent.displayName?.trim() || agent.name,
             ...(agent.iconUrl ? { iconUrl: agent.iconUrl } : {})
           })
-          servers.push(...buildMcpServers({ socketPath: mcpSocketPath(root), token, cliEntry }))
+          servers.push(...this.mcpToolServerSpec(token))
         }
         servers.push(
           ...resolveAgentMcpServers({
@@ -2879,6 +2886,29 @@ export class Daemon {
     // agent runs (and installs/uses skills) unsandboxed, and the daemon never
     // fails closed on a host with no OS sandbox.
     return effectiveRunInSandbox(this.cfg.security.requireSandbox, agent.runInSandbox, this.sandboxMechanism)
+  }
+
+  /**
+   * Whether a bridge spawned for this daemon's tools can reach it at all.
+   *
+   * Always, where the runtime shares this filesystem. In `--k8s` only once the image has said it
+   * ships the in-pod bridge: an older one ships none, and a spec it cannot spawn is worse than no
+   * tools — its harness retries the missing module on a backoff for the life of the session.
+   */
+  private mcpToolServerReachable(): boolean {
+    return !this.k8sPlane || this.k8sMcpBridge !== undefined
+  }
+
+  /** That tool server's `session/new` spec, in the coordinates of wherever the runtime runs. */
+  private mcpToolServerSpec(token: string): McpStdioServer[] {
+    if (!this.k8sPlane) {
+      return buildMcpServers({
+        socketPath: mcpSocketPath(this.root),
+        token,
+        cliEntry: daemonEntryForShims(this.root)
+      })
+    }
+    return this.k8sMcpBridge ? buildSandboxMcpServers({ bridge: this.k8sMcpBridge, token }) : []
   }
 
   private async runAgentWorkspacePreparation(agent: Agent, request?: PrepareSessionWorkspaceRequest): Promise<string> {
@@ -3709,11 +3739,7 @@ export class Daemon {
         })
         this.releaseMemoryExtractionToken(cacheKey)
         this.memoryExtractionTokens.set(cacheKey, mcpToken)
-        const mcpServers = buildMcpServers({
-          socketPath: mcpSocketPath(this.root),
-          token: mcpToken,
-          cliEntry: daemonEntryForShims(this.root)
-        })
+        const mcpServers = this.mcpToolServerSpec(mcpToken)
         sessionId = trusted
           ? await host.newSession(cwd, mcpServers, undefined, MEMORY_DISTILLATION_SYSTEM_PROMPT)
           : await host.newSession(cwd, mcpServers)
@@ -4107,11 +4133,7 @@ export class Daemon {
       thread: context.dreamId,
       tools: KNOWLEDGE_TOOLS
     })
-    const mcpServers = buildMcpServers({
-      socketPath: mcpSocketPath(this.root),
-      token: mcpToken,
-      cliEntry: daemonEntryForShims(this.root)
-    })
+    const mcpServers = this.mcpToolServerSpec(mcpToken)
     try {
       const sessionId = trusted
         ? await host.newSession(cwd, mcpServers, undefined, systemPrompt)
@@ -14572,6 +14594,16 @@ export class Daemon {
     try {
       this.log.info('runtimes: probing a sandbox for the runtimes this image provides')
       const table = await plane.probeRuntimes()
+      // The image's answer about its own filesystem, which is the only place this can be known:
+      // the tool-server spec is copied from it verbatim, and a spec assembled here instead gave
+      // the pod's runtime a module to retry forever. Absent means an image from before the bridge
+      // shipped — no tools rather than a server that cannot start.
+      this.k8sMcpBridge = table.mcpBridge
+      if (!table.mcpBridge) {
+        this.log.warn(
+          'mcp: this runtime image ships no in-pod tool bridge — cluster agents get no agent tools, memory distillation or knowledge browsing until it is updated'
+        )
+      }
       const catalog = this.projectDeclaredRuntimes(resolved, table)
       this.runtimeCatalog = catalog
       // The profile reports these, and they come from the catalog entry rather than the table —

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -167,7 +167,7 @@ program
   .option('--lazy-tools', 'resolve tools/list dynamically for a private delegated broker')
   .action(async (opts: { lazyTools?: boolean }) => {
     const { runBridge } = await import('./mcp/bridge.js')
-    await runBridge({ lazyTools: opts.lazyTools === true })
+    await runBridge({ lazyTools: opts.lazyTools === true, version: DAEMON_VERSION })
   })
 
 // Service lifecycle (up/down/restart/status/install-service/uninstall-service)

--- a/packages/daemon/src/mcp/bridge.ts
+++ b/packages/daemon/src/mcp/bridge.ts
@@ -3,7 +3,6 @@ import { Server } from '@modelcontextprotocol/server'
 import { StdioServerTransport } from '@modelcontextprotocol/server/stdio'
 import { decodeFrames, encodeFrame, type IpcListToolsResult, type IpcResponse } from './ipc.js'
 import type { McpContentResult } from './ops.js'
-import { DAEMON_VERSION } from '../version.js'
 
 type IpcCall = { op: 'attach' } | { op: 'listTools' } | { op: 'callTool'; name: string; args: Record<string, unknown> }
 
@@ -65,11 +64,13 @@ class IpcClient {
 }
 
 /**
- * Entry point for `agentconnect mcp-bridge`: a stdio MCP server that relays
- * `tools/list` and `tools/call` to the running daemon over its control socket.
- * The agent harness spawns this per session; the daemon does the real work.
+ * The stdio MCP server that relays `tools/list` and `tools/call` to the running
+ * daemon over its control socket. The agent harness spawns it per session; the
+ * daemon does the real work. Two entries reach it: the daemon's hidden
+ * `mcp-bridge` subcommand where the runtime shares this filesystem, and the
+ * runtime image's own bundle where it does not (src/shim/mcp-bridge.ts).
  */
-export async function runBridge(opts: { lazyTools?: boolean } = {}): Promise<void> {
+export async function runBridge(opts: { lazyTools?: boolean; version?: string } = {}): Promise<void> {
   const endpoint = process.env.AC_MCP_ENDPOINT
   const token = process.env.AC_MCP_TOKEN
   if (!endpoint || !token) {
@@ -99,7 +100,9 @@ export async function runBridge(opts: { lazyTools?: boolean } = {}): Promise<voi
     }
   }
 
-  const server = new Server({ name: 'agentconnect', version: DAEMON_VERSION }, { capabilities: { tools: {} } })
+  // Stated by the entry rather than read from a package.json: the in-sandbox bundle is copied into
+  // the runtime image on its own, and a manifest beside it would change how node reads every .js there.
+  const server = new Server({ name: 'agentconnect', version: opts.version ?? '0.0.0' }, { capabilities: { tools: {} } })
   server.setRequestHandler('tools/list', async () => {
     if (tools) return { tools }
     const res = (await ipc.request({ op: 'listTools' })) as IpcListToolsResult

--- a/packages/daemon/src/mcp/inject.ts
+++ b/packages/daemon/src/mcp/inject.ts
@@ -1,6 +1,7 @@
 import { RESERVED_MCP_SERVER_NAME } from '@agentconnect.md/protocol'
 import { existsSync, realpathSync } from 'node:fs'
 import { canonicalNodeExecArgv } from '../runtimes/node-exec-argv.js'
+import { SANDBOX_TUNNEL_PATHS } from '../shim/sandbox-paths.js'
 
 /** The stdio MCP-server spec we hand to ACP's `session/new` (`McpServerStdio`). */
 export interface McpStdioServer {
@@ -35,6 +36,33 @@ export function buildMcpServers(opts: {
       args: [...canonicalNodeExecArgv(), cliEntry, 'mcp-bridge', ...(opts.lazyTools ? ['--lazy-tools'] : [])],
       env: [
         { name: 'AC_MCP_ENDPOINT', value: opts.socketPath },
+        { name: 'AC_MCP_TOKEN', value: opts.token }
+      ]
+    }
+  ]
+}
+
+/**
+ * The same bridge for a runtime that lives in a SANDBOX POD, in that pod's coordinates.
+ *
+ * Nothing of this daemon's filesystem survives the trip. The launch is the one the image reported
+ * for itself — interpreter included, so nothing here depends on what the harness leaves on the
+ * pod's PATH — and the endpoint is the `mcp` tunnel's in-pod socket, which the shim serves and
+ * proxies back to this daemon's control server. Sending the daemon-side pair instead is not a
+ * degraded spec but an unspawnable one: the pod's runtime retried a module it has no filesystem
+ * for until it gave up, and the agent lost every AgentConnect tool without saying so.
+ */
+export function buildSandboxMcpServers(opts: {
+  bridge: { command: string; args: string[] }
+  token: string
+}): McpStdioServer[] {
+  return [
+    {
+      name: RESERVED_MCP_SERVER_NAME,
+      command: opts.bridge.command,
+      args: [...opts.bridge.args],
+      env: [
+        { name: 'AC_MCP_ENDPOINT', value: SANDBOX_TUNNEL_PATHS.mcp },
         { name: 'AC_MCP_TOKEN', value: opts.token }
       ]
     }

--- a/packages/daemon/src/runtimes/k8s-runtimes.ts
+++ b/packages/daemon/src/runtimes/k8s-runtimes.ts
@@ -46,7 +46,24 @@ const K8sRuntimeEntrySchema = z.object({
   acp: K8sRuntimeAcpSchema.optional()
 })
 
-export const K8sRuntimeTableSchema = z.object({ runtimes: z.array(K8sRuntimeEntrySchema).min(1) })
+export const K8sRuntimeTableSchema = z.object({
+  runtimes: z.array(K8sRuntimeEntrySchema).min(1),
+  /**
+   * How to launch the in-pod MCP bridge, stated by the image: the interpreter it runs and the
+   * bundle it ships. Absent on an image built before the bridge shipped.
+   *
+   * Both halves rather than the path alone, and read from a live PROBE only. The daemon copies
+   * this into the `mcpServers` spec verbatim for a runtime it cannot see, so every part of it has
+   * to come from the filesystem that will run it — a command resolved anywhere else, even one as
+   * ordinary as `node`, is an assumption about a machine the daemon is not on. Hence absolute, and
+   * `catch` rather than a parse error: a bad value costs one tool surface and must not also cost
+   * the member the runtime table the same answer carries.
+   */
+  mcpBridge: z
+    .object({ command: z.string().min(1).startsWith('/'), args: z.array(z.string().min(1)).max(8) })
+    .optional()
+    .catch(undefined)
+})
 
 export type K8sRuntimeTable = z.infer<typeof K8sRuntimeTableSchema>
 export type K8sRuntimeEntry = z.infer<typeof K8sRuntimeEntrySchema>

--- a/packages/daemon/src/shim/exec-handler.ts
+++ b/packages/daemon/src/shim/exec-handler.ts
@@ -1,8 +1,9 @@
 import { execFile } from 'node:child_process'
 import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
-import { realpathSync } from 'node:fs'
+import { existsSync, realpathSync } from 'node:fs'
 import { isAbsolute, normalize, resolve, sep } from 'node:path'
 import { applyFileSinkPayload } from './file-sink.js'
+import { SANDBOX_MCP_BRIDGE_ENTRY } from './sandbox-paths.js'
 import { GitExecPayloadSchema, type GitExecResult } from './git-exec.js'
 import type { ShimCapability } from './protocol.js'
 import { applyWorkspaceFilesPayload } from './workspace-files-channel.js'
@@ -193,7 +194,7 @@ export function createExecHandler(
 }
 
 /**
- * Ask this image which runtimes it provides.
+ * Ask this image what it provides: the runtimes, and the in-pod MCP bridge beside them.
  *
  * Runs the generator rather than reading the table it wrote at build time: the two agree by
  * construction, but a live answer cannot go stale against the image the way a copy in a ConfigMap
@@ -217,7 +218,15 @@ async function probeRuntimes(deps: ExecHandlerDeps, abort?: AbortSignal): Promis
           return
         }
         try {
-          resolvePromise(JSON.parse(String(stdout)))
+          const table = JSON.parse(String(stdout)) as Record<string, unknown>
+          // Consulted here rather than assumed there: whether this image ships the bridge, and
+          // which interpreter runs it, are facts of THIS filesystem — and an older image, whose
+          // probe simply reports neither, is the version skew the daemon has to read rather than
+          // guess. `process.execPath` because the daemon must not have to trust the pod's PATH.
+          const bridge = existsSync(SANDBOX_MCP_BRIDGE_ENTRY)
+            ? { mcpBridge: { command: process.execPath, args: [SANDBOX_MCP_BRIDGE_ENTRY] } }
+            : {}
+          resolvePromise({ ...table, ...bridge })
         } catch (err) {
           reject(new ExecRefusedError(`runtime probe produced invalid JSON: ${(err as Error).message}`))
         }

--- a/packages/daemon/src/shim/mcp-bridge.ts
+++ b/packages/daemon/src/shim/mcp-bridge.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * The in-sandbox AgentConnect tool server. Lives at a fixed path in the runtime image
+ * (`/opt/agentconnect/shim/mcp-bridge.js`), root-owned and read-only like the shim, and is spawned
+ * by the agent's own harness from the `mcpServers` spec the daemon sends at `session/new`.
+ *
+ * Its own entry for the reason the credential helper is one: the harness spawns it per session, the
+ * image copies ONE file per bundle, and two entries whose graphs are disjoint stay two single files
+ * where a shared module would make rolldown emit a chunk nothing copies.
+ *
+ * It holds no policy and knows no tools. The endpoint it dials is the `mcp` tunnel's in-pod socket
+ * and the token is the daemon's own per-session capability; every tool it serves is resolved on the
+ * far side, exactly as for a runtime that shares the daemon's filesystem.
+ */
+import { runBridge } from '../mcp/bridge.js'
+
+// No version to state: this bundle ships alone, and a package.json placed beside it to read one
+// from would change how node interprets every .js in that directory.
+runBridge({ lazyTools: process.argv.slice(2).includes('--lazy-tools') }).catch((err: unknown) => {
+  process.stderr.write(`agentconnect: mcp-bridge failed: ${(err as Error).message}\n`)
+  process.exit(1)
+})

--- a/packages/daemon/src/shim/sandbox-paths.ts
+++ b/packages/daemon/src/shim/sandbox-paths.ts
@@ -14,6 +14,10 @@ export const SANDBOX_GIT_CREDENTIAL_HELPER = '/opt/agentconnect/bin/git-credenti
 /** The gh wrapper's token fetch in the pod — the in-sandbox twin of the daemon's hidden `gh-token` subcommand. */
 export const SANDBOX_GH_TOKEN_ENTRY = '/opt/agentconnect/shim/gh-token.js'
 
+/** The AgentConnect tool server the agent's harness spawns in the pod, reached over the `mcp` tunnel.
+ *  Reported to the daemon by the probe rather than assumed: an image built before it ships none. */
+export const SANDBOX_MCP_BRIDGE_ENTRY = '/opt/agentconnect/shim/mcp-bridge.js'
+
 /** The ONLY image directory prepended to the runtime's PATH: the gh wrapper and nothing else. */
 // Its own dir rather than reusing bin/ or shim/: those hold the credential helper and the runtime-table
 // generator, and neither should become a command an agent can run by name.

--- a/packages/daemon/src/shim/tunnel-proxy.ts
+++ b/packages/daemon/src/shim/tunnel-proxy.ts
@@ -2,9 +2,17 @@ import { createConnection, type Socket } from 'node:net'
 import type { ShimCapability, ShimEvent } from './protocol.js'
 import { MAX_TUNNEL_CHUNK_BYTES, TunnelListeningSchema, type TunnelName } from './tunnel.js'
 
-/** A connection reached its deadline without the daemon-side server answering. Bounded because a
- *  stream nobody closes holds one of the pod's few tunnel slots. */
-const STREAM_IDLE_MS = 5 * 60_000
+/**
+ * How long a stream may stay silent before this side ends it, per tunnel — `null` for none.
+ *
+ * `gitcred` carries one request and its reply, so silence past a few minutes means no answer is
+ * coming and the stream is holding one of the pod's few slots for nothing. `mcp` is the opposite
+ * shape: the harness spawns one bridge per ACP session and it stays connected, idle between tool
+ * calls, so the same deadline would take the agent's tool surface away a few quiet minutes into
+ * every session. Its bound is the channel instead — a lost or superseded one stops every stream,
+ * and the pod dies with its sandbox.
+ */
+const STREAM_IDLE_MS: Readonly<Record<TunnelName, number | null>> = { gitcred: 5 * 60_000, mcp: null }
 
 /** This side's own ceiling on concurrent streams per agent. The shim enforces one too; that one
  *  protects the pod, and this one protects the daemon from a shim that does not. */
@@ -41,7 +49,7 @@ export interface TunnelProxyDeps {
  * filesystem.
  */
 export class TunnelProxy {
-  private readonly streams = new Map<string, { socket: Socket; timer: NodeJS.Timeout; inFlight: number }>()
+  private readonly streams = new Map<string, { socket: Socket; timer?: NodeJS.Timeout; inFlight: number }>()
   private readonly listening = new Set<TunnelName>()
   private readonly onEvent = (event: ShimEvent): void => this.accept(event)
   private readonly onAttach = (): void => this.dropUnaccountedStreams()
@@ -148,7 +156,7 @@ export class TunnelProxy {
     // somebody else's and not an error.
     if (!entry) return
     if (event.event.kind === 'chunk') {
-      entry.timer.refresh()
+      entry.timer?.refresh()
       entry.socket.write(Buffer.from(event.event.data, 'base64'))
       return
     }
@@ -171,13 +179,14 @@ export class TunnelProxy {
       this.refuse(streamId, `could not reach the ${tunnel} socket: ${(err as Error).message}`)
       return
     }
-    const timer = setTimeout(() => this.close(streamId, `idle for ${STREAM_IDLE_MS}ms`), STREAM_IDLE_MS)
-    timer.unref?.()
-    this.streams.set(streamId, { socket, timer, inFlight: 0 })
+    const idleMs = STREAM_IDLE_MS[tunnel]
+    const timer = idleMs === null ? undefined : setTimeout(() => this.close(streamId, `idle for ${idleMs}ms`), idleMs)
+    timer?.unref?.()
+    this.streams.set(streamId, { socket, ...(timer ? { timer } : {}), inFlight: 0 })
     socket.on('data', (data: Buffer) => {
       const entry = this.streams.get(streamId)
       if (!entry) return
-      entry.timer.refresh()
+      entry.timer?.refresh()
       for (let offset = 0; offset < data.length; offset += MAX_TUNNEL_CHUNK_BYTES) {
         const slice = data.subarray(offset, offset + MAX_TUNNEL_CHUNK_BYTES)
         void this.deliver(streamId, { op: 'data', streamId, chunk: slice.toString('base64') })
@@ -204,7 +213,7 @@ export class TunnelProxy {
     const entry = this.streams.get(streamId)
     if (!entry) return false
     this.streams.delete(streamId)
-    clearTimeout(entry.timer)
+    if (entry.timer) clearTimeout(entry.timer)
     entry.socket.destroy()
     return true
   }

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -6,7 +6,8 @@ import { AGENT_WAKE_FEATURE, DAEMON_BOOTSTRAP_UPGRADE_FEATURE } from '@agentconn
 import { Daemon } from '../src/daemon.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 import { LocalStore } from '../src/store/local-store.js'
-import { statePath } from '../src/paths.js'
+import { mcpSocketPath, statePath } from '../src/paths.js'
+import { SANDBOX_TUNNEL_PATHS } from '../src/shim/sandbox-paths.js'
 
 /** The behavior matrix for `--k8s`: each assertion here is one row of the mode
  *  contract, so k8s and self-hosted behavior cannot drift apart unnoticed. */
@@ -59,6 +60,8 @@ function daemon(opts: {
   dataPlane?: boolean
   openDataPlane?: ReturnType<typeof vi.fn>
   startControlPlane?: ReturnType<typeof vi.fn>
+  /** Receives the options the mode hands the plane — the rows about what it asks the pod to serve. */
+  onPlaneStart?: (options: any) => void
 }): Daemon {
   return new Daemon({
     root: opts.root,
@@ -86,8 +89,9 @@ function daemon(opts: {
                     close: async () => {}
                   }) as never
               }),
-          startK8sPlane: async () =>
-            ({
+          startK8sPlane: async (options: any) => {
+            opts.onPlaneStart?.(options)
+            return {
               driver: { claimName: (id: string) => `agent-${id}` } as never,
               listener: { listeningPort: () => 0 } as never,
               gitRunnerFor: () => undefined,
@@ -96,7 +100,8 @@ function daemon(opts: {
               discardAgent: async () => {},
               stop: async () => {},
               ...opts.plane
-            }) as never
+            } as never
+          }
         }
       : {}),
     ...(opts.openDataPlane ? { openDataPlane: opts.openDataPlane as never } : {}),
@@ -483,6 +488,84 @@ describe('daemon --k8s mode', () => {
     }
   })
 
+  // A daemon-path bridge spec sent to a pod is not a degraded tool surface but an unspawnable one:
+  // the runtime retried `/app/.../dist/index.js` on a backoff until it gave up, and the agent had no
+  // AgentConnect tools at all. The spec has to name what the IMAGE reports shipping.
+  it('injects the image’s own MCP bridge, in pod coordinates, once the probe reports one', async () => {
+    const BRIDGE = { command: '/usr/local/bin/node', args: ['/opt/agentconnect/shim/mcp-bridge.js'] }
+    let settle!: (table: unknown) => void
+    const k8sDaemon = daemon({
+      root: root({ declared: { runtimes: [{ id: 'claude' }] } }),
+      k8s: true,
+      plane: { probeRuntimes: () => new Promise((resolve) => (settle = resolve)) }
+    })
+    try {
+      await k8sDaemon.start()
+      settle({ runtimes: [{ id: 'claude', version: '1.2.3' }], mcpBridge: BRIDGE })
+      await vi.waitFor(() => expect(mcpServersFor(k8sDaemon)).toHaveLength(1))
+      const [server] = mcpServersFor(k8sDaemon)
+      // The image's own interpreter and entry, verbatim: anything resolved on this host — the
+      // daemon's node, its CLI entry, even a bare `node` trusting the pod's PATH — names something
+      // the runtime may not have.
+      expect(server).toMatchObject({ command: BRIDGE.command, args: BRIDGE.args })
+      // And the endpoint is the tunnel's in-pod socket, which the shim serves back to this daemon.
+      expect(server!.env).toContainEqual({ name: 'AC_MCP_ENDPOINT', value: SANDBOX_TUNNEL_PATHS.mcp })
+    } finally {
+      await k8sDaemon.stop()
+    }
+  })
+
+  it('withholds the tool server from an image that reports no bridge, rather than a spec it cannot spawn', async () => {
+    let settle!: (table: unknown) => void
+    const k8sDaemon = daemon({
+      root: root({ declared: { runtimes: [{ id: 'claude' }] } }),
+      k8s: true,
+      plane: { probeRuntimes: () => new Promise((resolve) => (settle = resolve)) }
+    })
+    try {
+      await k8sDaemon.start()
+      // An image built before the bridge shipped: it says nothing, and silence is the answer.
+      settle({ runtimes: [{ id: 'claude', version: '1.2.3' }] })
+      await vi.waitFor(() => expect((k8sDaemon as any).k8sRuntimeProbed).toBe(true))
+      expect(mcpServersFor(k8sDaemon)).toEqual([])
+    } finally {
+      await k8sDaemon.stop()
+    }
+  })
+
+  it('still injects this daemon’s own bridge outside k8s, where the runtime shares its filesystem', async () => {
+    const local = daemon({ root: root(), k8s: false })
+    try {
+      await local.start()
+      const servers = mcpServersFor(local)
+      expect(servers).toHaveLength(1)
+      expect(servers[0]!.args).toContain('mcp-bridge')
+    } finally {
+      await local.stop()
+    }
+  })
+
+  it('asks every pod to serve the mcp socket, and the credential socket only where git needs one', async () => {
+    let planeOptions!: any
+    const rootDir = root({ declared: { runtimes: [{ id: 'claude' }] } })
+    const k8sDaemon = daemon({ root: rootDir, k8s: true, onPlaneStart: (options) => (planeOptions = options) })
+    try {
+      await k8sDaemon.start()
+      // Every pod agent: any session may carry tools, and the listener belongs to the pod's
+      // lifetime while the spec that dials it is decided per session.
+      ;(k8sDaemon as any).agents.set('plain', { id: 'plain', workspace: {} })
+      expect(planeOptions.tunnelsFor('plain')).toEqual(['mcp'])
+      expect(planeOptions.tunnelSocketPath('mcp')).toBe(mcpSocketPath(rootDir))
+      ;(k8sDaemon as any).agents.set('gh', { id: 'gh', workspace: { gitCredential: 'github-app' } })
+      expect(planeOptions.tunnelsFor('gh')).toEqual(['mcp', 'gitcred'])
+      // And nothing for the member's own runtime probe, whose channel is granted `probe` alone —
+      // asking it to serve a socket would be refused, and the refusal logged, on every boot.
+      expect(planeOptions.tunnelsFor('ac-runtime-probe-0f0f0f0f')).toEqual([])
+    } finally {
+      await k8sDaemon.stop()
+    }
+  })
+
   it('deletes a removed agent’s sandbox, which is what takes its workspace volume with it', async () => {
     const discarded: string[] = []
     const k8sDaemon = daemon({
@@ -503,3 +586,17 @@ describe('daemon --k8s mode', () => {
     }
   })
 })
+
+/** The session seam that decides an agent's MCP servers, asked about an ordinary agent. */
+function mcpServersFor(
+  instance: Daemon
+): { command: string; args: string[]; env: { name: string; value: string }[] }[] {
+  const agent = { id: 'a1', name: 'a1', runtime: 'claude', integrations: [], mcpServers: [] }
+  return (instance as any).sessions.deps.mcpServersFor({
+    agent,
+    platform: 'slack',
+    channel: 'C1',
+    thread: '1',
+    isDm: false
+  })
+}

--- a/packages/daemon/test/k8s-runtimes.test.ts
+++ b/packages/daemon/test/k8s-runtimes.test.ts
@@ -38,6 +38,22 @@ function catalog(): ResolvedRuntimeCatalog {
 }
 
 describe('k8s runtime table', () => {
+  it('takes the probed MCP bridge launch, and drops a malformed one without losing the runtimes', () => {
+    const mcpBridge = { command: '/usr/local/bin/node', args: ['/opt/agentconnect/shim/mcp-bridge.js'] }
+    const shipped = K8sRuntimeTableSchema.parse({ runtimes: [{ id: 'claude' }], mcpBridge })
+    expect(shipped.mcpBridge).toEqual(mcpBridge)
+    // The daemon hands this to the pod's runtime to spawn, so a command that is not an absolute
+    // path in that image is refused — but refusing it must not fail the parse: the same answer
+    // carries the runtimes this member advertises, and losing those takes the member out of
+    // service over a tool surface.
+    const odd = K8sRuntimeTableSchema.parse({
+      runtimes: [{ id: 'claude' }],
+      mcpBridge: { command: 'node', args: ['mcp-bridge.js'] }
+    })
+    expect(odd.mcpBridge).toBeUndefined()
+    expect(odd.runtimes).toHaveLength(1)
+  })
+
   it('defaults under the daemon root and honors the env override', () => {
     const dir = root()
     expect(k8sRuntimesPath(dir, {})).toBe(join(dir, 'k8s-runtimes.json'))

--- a/packages/daemon/test/mcp-inject.test.ts
+++ b/packages/daemon/test/mcp-inject.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { buildMcpServers } from '../src/mcp/inject.js'
+import { buildMcpServers, buildSandboxMcpServers } from '../src/mcp/inject.js'
+import { SANDBOX_TUNNEL_PATHS } from '../src/shim/sandbox-paths.js'
 
 describe('buildMcpServers', () => {
   it('builds a single stdio server that re-invokes this CLI with mcp-bridge', () => {
@@ -36,5 +37,22 @@ describe('buildMcpServers', () => {
       { name: 'AC_MCP_ENDPOINT', value: '/private' },
       { name: 'AC_MCP_TOKEN', value: 'private-token' }
     ])
+  })
+})
+
+describe('buildSandboxMcpServers', () => {
+  it('names the image’s own bridge and the tunnel socket, never a path on this daemon', () => {
+    const bridge = { command: '/usr/local/bin/node', args: ['/opt/agentconnect/shim/mcp-bridge.js'] }
+    const [server] = buildSandboxMcpServers({ bridge, token: 'tok-1' })
+    expect(server!.name).toBe('agentconnect')
+    // Not process.execPath and not the daemon's CLI entry: both name files the pod does not have,
+    // and a runtime handed them retries a missing module instead of serving tools.
+    expect(server!.command).toBe(bridge.command)
+    expect(server!.args).toEqual(bridge.args)
+    expect(server!.env).toEqual([
+      { name: 'AC_MCP_ENDPOINT', value: SANDBOX_TUNNEL_PATHS.mcp },
+      { name: 'AC_MCP_TOKEN', value: 'tok-1' }
+    ])
+    expect(server!.args).not.toContain('tok-1')
   })
 })

--- a/packages/daemon/test/shim-tunnel.test.ts
+++ b/packages/daemon/test/shim-tunnel.test.ts
@@ -213,7 +213,7 @@ function proxyUnderTest(options: { stall?: (payload: unknown) => boolean } = {})
       offAttach: () => undefined,
       onLost: () => undefined
     },
-    socketPathFor: (tunnel) => (tunnel === 'gitcred' ? '/daemon/gitcred.sock' : undefined),
+    socketPathFor: (tunnel) => (tunnel === 'gitcred' ? '/daemon/gitcred.sock' : '/daemon/mcp.sock'),
     dial: (path) => {
       dialled.push(path)
       const socket = new Socket()
@@ -417,6 +417,32 @@ describe('the shim tunnel', () => {
     expect(proxy.dialled).toEqual(['/daemon/gitcred.sock'])
     expect(proxy.instance.streamCount()).toBe(1)
     expect(proxy.sent.at(-1)).toEqual(expect.objectContaining({ op: 'close', streamId }))
+  })
+
+  it('keeps an mcp stream through an idle window that ends a gitcred one', async () => {
+    // The two tunnels have opposite shapes, so one deadline cannot fit both. A credential stream is
+    // one request and its reply, and silence past a few minutes means no answer is coming. The
+    // harness's MCP bridge holds ONE connection for the life of an ACP session and is idle between
+    // tool calls — ending that is the agent quietly losing its tools mid-session.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const proxy = proxyUnderTest()
+      await proxy.instance.ensure('gitcred')
+      await proxy.instance.ensure('mcp')
+      const credential = randomUUID()
+      const bridge = randomUUID()
+      proxy.announce({ kind: 'connect', tunnel: 'gitcred' }, credential)
+      proxy.announce({ kind: 'connect', tunnel: 'mcp' }, bridge)
+      expect(proxy.instance.streamCount()).toBe(2)
+
+      vi.advanceTimersByTime(10 * 60_000)
+
+      expect(proxy.instance.streamCount()).toBe(1)
+      expect(proxy.sent).toContainEqual(expect.objectContaining({ op: 'close', streamId: credential }))
+      expect(proxy.sent).not.toContainEqual(expect.objectContaining({ op: 'close', streamId: bridge }))
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('refuses tunnel data for a stream the pod never opened', async () => {

--- a/packages/daemon/tsdown.shim.config.ts
+++ b/packages/daemon/tsdown.shim.config.ts
@@ -23,14 +23,16 @@ const shared = {
   clean: false
 }
 
-// THREE builds rather than one build with three entries, and the difference is load-bearing: several
+// FOUR builds rather than one build with four entries, and the difference is load-bearing: several
 // entries in a single build make rolldown hoist anything they share into a chunk, and the image
 // copies each artifact as a single file — so that chunk would be a further file nothing copies and
 // the helper would fail at startup on a missing module. Independent builds cannot share one. It
-// also keeps each graph honest: git spawns the credential helper once per operation and the gh
-// wrapper spawns the token entry once per `gh`, and neither has any use for the channel's WebSocket client.
+// also keeps each graph honest: git spawns the credential helper once per operation, the gh
+// wrapper spawns the token entry once per `gh`, and the agent's harness spawns the MCP bridge once
+// per session — none of the three has any use for the channel's WebSocket client.
 export default defineConfig([
   { ...shared, entry: { index: 'src/shim/index.ts' } },
   { ...shared, entry: { 'git-credential': 'src/shim/git-credential.ts' } },
-  { ...shared, entry: { 'gh-token': 'src/shim/gh-token.ts' } }
+  { ...shared, entry: { 'gh-token': 'src/shim/gh-token.ts' } },
+  { ...shared, entry: { 'mcp-bridge': 'src/shim/mcp-bridge.ts' } }
 ])

--- a/scripts/verify-runtime-image.mjs
+++ b/scripts/verify-runtime-image.mjs
@@ -52,6 +52,10 @@ const CREDENTIAL_HELPER_PATH = '/opt/agentconnect/bin/git-credential'
 /** Must match SANDBOX_GH_WRAPPER_DIR in packages/daemon/src/shim/sandbox-paths.ts: the shim prepends exactly
  *  this directory to the runtime's PATH, so a rename here silently drops every per-repo gh token. */
 const GH_WRAPPER_PATH = '/opt/agentconnect/pathbin/gh'
+/** Must match SANDBOX_MCP_BRIDGE_ENTRY in packages/daemon/src/shim/sandbox-paths.ts: the shim reports this
+ *  path to the daemon, which copies it into the `mcpServers` spec — so a bundle missing here is a runtime
+ *  retrying a module that is not there, which is how an agent silently lost its AgentConnect tools. */
+const MCP_BRIDGE_PATH = '/opt/agentconnect/shim/mcp-bridge.js'
 const TABLE_PATH = '/opt/agentconnect/runtime/k8s-runtimes.json'
 
 // The runtime is the untrusted party in this image, so root would hand it the whole filesystem.
@@ -140,18 +144,48 @@ check('the credential helper runs and fails loudly with no daemon socket', () =>
   return 'exits 1 with an actionable message'
 })
 
-// The shim is built with everything inlined so this image installs no node_modules for it. A
-// require of anything but a node: builtin means the bundle is depending on a tree that is absent.
-check('the shim bundle is self-contained', () => {
+// The agent's harness spawns this per session from a spec the daemon builds around THIS path, and
+// it inherits the shim's threat model: one the runtime can rewrite is one it can replace with a
+// tool server that answers the daemon's tool calls however it likes.
+check('the MCP bridge is present and root-owned', () => {
+  const owner = inImage(`stat -c '%U:%G %a' ${MCP_BRIDGE_PATH}`)
+  if (!owner.startsWith('root:root')) throw new Error(`mcp bridge is not root-owned (${owner})`)
+  const mode = owner.split(' ')[1]
+  if (/[2367]$/.test(mode) || /^.[2367]/.test(mode)) throw new Error(`mcp bridge is group/other writable (${mode})`)
+  const refused = inImage(`(echo x >> ${MCP_BRIDGE_PATH} && echo WRITABLE) || echo refused`)
+  if (refused !== 'refused') throw new Error('the runtime user can modify the mcp bridge')
+  return owner
+})
+
+// It has to LOAD before it can fail: a bundle that reads a file the image does not ship dies on
+// import, and to the harness that is indistinguishable from a missing module — the failure this
+// whole path exists to remove. Reaching "could not reach daemon" proves the module ran.
+check('the MCP bridge starts and fails loudly with no daemon socket', () => {
+  const out = inImage(
+    `AC_MCP_ENDPOINT=/nonexistent/mcp.sock AC_MCP_TOKEN=probe ` +
+      `sh -c 'node ${MCP_BRIDGE_PATH} </dev/null; echo "exit=$?"' 2>&1`
+  )
+  if (!/mcp-bridge: could not reach daemon/.test(out)) throw new Error(`bridge did not run to its own error: ${out}`)
+  if (!out.includes('exit=1')) throw new Error(`bridge did not exit 1 without a socket: ${out}`)
+  return 'exits 1 with an actionable message'
+})
+
+// The bundles are built with everything inlined so this image installs no node_modules for them. A
+// require of anything but a node: builtin means a bundle is depending on a tree that is absent.
+check('the shim bundles are self-contained', () => {
   // Same specifier shapes the daemon package's own assert-self-contained step looks for, run
-  // against the artifact that actually shipped. The local build being clean says nothing about
+  // against the artifacts that actually shipped. The local build being clean says nothing about
   // the image: an earlier version of this Dockerfile ran tsdown without building the workspace
   // deps, and produced a bundle that imported them externally — which the image cannot resolve.
-  const specs = inImage(
-    `grep -oE '\\b(from|import)[[:space:]]*\\(?[[:space:]]*"[^"]+"' ${SHIM_PATH} | ` +
-      `grep -oE '"[^"]+"' | tr -d '"' | sort -u | grep -v '^node:' || true`
-  )
-  if (specs) throw new Error(`shim references non-builtin modules: ${specs.split('\n').join(', ')}`)
+  const external = []
+  for (const path of [SHIM_PATH, MCP_BRIDGE_PATH]) {
+    const specs = inImage(
+      `grep -oE '\\b(from|import)[[:space:]]*\\(?[[:space:]]*"[^"]+"' ${path} | ` +
+        `grep -oE '"[^"]+"' | tr -d '"' | sort -u | grep -v '^node:' || true`
+    )
+    if (specs) external.push(`${path}: ${specs.split('\n').join(', ')}`)
+  }
+  if (external.length > 0) throw new Error(`bundles reference non-builtin modules — ${external.join('; ')}`)
   return 'node: builtins only'
 })
 


### PR DESCRIPTION
## The gap

A `--k8s` runtime receives its `mcpServers` at `session/new`, and that spec named this daemon's
own bridge entry and control socket — a file and a unix socket that exist only on the daemon's
filesystem. The pod's runtime spawned them anyway and retried the missing module on a backoff, so
a **cluster agent silently had no AgentConnect tools at all**: no agent tools, no memory
distillation, no dream knowledge browsing. Ordinary chat is unaffected (it never touches the
bridge), which is why this looked healthy.

## What this does

- **The image ships the bridge.** A fourth single-file shim bundle from a new thin entry
  (`src/shim/mcp-bridge.ts`), built separately like the credential helper and the gh token entry
  so rolldown emits no shared chunk the image would never copy, and COPY'd root-owned/read-only
  beside the others at `SANDBOX_MCP_BRIDGE_ENTRY`.
- **The `mcp` tunnel is opened.** Served for every pod agent, because any session may carry tools
  and the listener belongs to the pod's lifetime, while the spec that dials it stays a per-session
  decision — so the two cannot race. An id this daemon holds no agent for gets nothing: the
  member's own runtime probe is that case, and its channel is granted `probe` alone.
- **The spec is in pod coordinates.** One `Daemon.mcpToolServerSpec()` now answers for all three
  injection points (ordinary session, memory distillation, dream), choosing the sandbox spec or
  the daemon-local one by where the runtime actually runs.
- **Skew is read, not assumed.** The shim's probe — the existing reader-first channel — now
  reports how *this* image launches the bridge, interpreter included, and the daemon copies that
  pair verbatim. An image built before the bridge reports neither and gets no tool server and no
  minted token, which is what it can actually run.

## Two bugs the change dragged in with it, both fixed here

- `mcp/bridge.ts` imported `version.ts`, which reads `../package.json` at module load. Bundled
  alone into the image that is an ENOENT at import — indistinguishable to the harness from the
  missing module this PR exists to remove — and a manifest placed beside it would change how node
  interprets every `.js` in that directory. Each entry states its version instead.
- The tunnel's five-minute idle deadline would have killed the bridge mid-session. A credential
  stream is one request and its reply; the bridge holds one connection for the life of an ACP
  session and is silent between tool calls. `STREAM_IDLE_MS` is now per tunnel — `mcp` is bounded
  by the channel, which stops every stream when it is lost or superseded.

## Notes for review

- **Why not `command: 'node'`** — the MCP server is spawned by the agent's harness, not by the
  shim, so PATH inheritance is the harness's choice. Reporting the interpreter removes the guess;
  a clean-env spawn would otherwise reproduce the exact failure class being fixed.
- **A malformed probe answer costs the tool surface only** (`.catch(undefined)` on the field) —
  never the runtime table the same answer carries, which is what the member's servability rests on.
- **Not addressed:** `MAX_TUNNEL_STREAMS = 32` now also covers MCP, one stream per live ACP
  session. A very busy agent could have a new session's bridge refused; degradation is logged and
  chat is unaffected, but raising that cap is a separate judgement.

## Verification

`typecheck` clean workspace-wide; `lint` / `format:check` clean. 62 tests green across the five
touched suites, including new rows for: the pod-coordinate spec once the probe reports a bridge,
withholding it when the probe reports none, the unchanged local path, which tunnels each agent
gets, and the mcp stream surviving an idle window that ends a gitcred one (verified to fail
without the fix). The rest of the daemon suite fails identically with these changes stashed
(pre-existing macOS sandbox/realpath failures plus the real-runtime matrix).

The image itself was **not built or verified locally** (no Docker in this environment), so the
Dockerfile change and the three new `scripts/verify-runtime-image.mjs` checks — bridge present and
root-owned, bridge *starts* and fails loudly with no daemon socket, both bundles self-contained —
are unexecuted here and need CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
