### PR TITLE
refactor(daemon): split the Pending bag into plan + chrome/reply/approval/signals

### DIFF
--- a/packages/daemon/src/collab/coordinator.ts
+++ b/packages/daemon/src/collab/coordinator.ts
@@ -348,7 +348,7 @@ export class CollabCoordinator {
         type,
         agentId: req.callerAgentId,
         ...(caller?.acpSessionId ? { sessionId: caller.acpSessionId } : {}),
-        ...(pending?.evaluationTurnId ? { turnId: pending.evaluationTurnId } : {}),
+        ...(pending?.plan.evaluationTurnId ? { turnId: pending.plan.evaluationTurnId } : {}),
         platform,
         channel: req.channel,
         data: {
@@ -684,7 +684,7 @@ export class CollabCoordinator {
     agentId: string,
     msg: NormalizedMessage,
     callMeta: CallMeta | undefined,
-    p: { replyText: string; outputSuppressed?: string | undefined }
+    p: { reply: { text: string }; outputSuppressed?: string | undefined }
   ): Promise<void> {
     if (this.host.draining()) return
     if (!callMeta?.needsReply || callMeta.originSessionId === undefined) return
@@ -700,7 +700,7 @@ export class CollabCoordinator {
     const sessionId = (await this.host.store().getSession(childKey))?.acpSessionId ?? undefined
     const lease = sessionId !== undefined ? this.host.sdkLease().get(sdkLeaseKey(agentId, sessionId)) : undefined
     if (lease !== undefined && (lease.tasks.size > 0 || lease.armedWakes > 0)) return
-    const finalOutput = p.replyText.trim()
+    const finalOutput = p.reply.text.trim()
     const text =
       finalOutput && !isNoResponseBody(finalOutput)
         ? `[inferred reply] The delegated session finished its turn without sending its report ` +

--- a/packages/daemon/src/commands/handlers.ts
+++ b/packages/daemon/src/commands/handlers.ts
@@ -607,7 +607,7 @@ export class CommandHandlers {
         (entry) => entry.cancelledReason === 'loop protection' && loopGuardScope(entry.msg) === scope
       ) ||
       [...this.host.pending().values()].some((pending) => {
-        return pending.outputSuppressed === 'loop protection' && pending.loopGuardScope === scope
+        return pending.outputSuppressed === 'loop protection' && pending.plan.loopGuardScope === scope
       })
     if (stillStopping) {
       reply('Loop protection is still stopping the previous turn. Try `!resume` again in a moment.')

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -367,7 +367,7 @@ import type {
 } from '@agentconnect.md/protocol'
 import { formatErr } from './daemon/text.js'
 import { isBuiltinSystemToolCall } from './daemon/tool-classification.js'
-import { buildTurnPlan } from './daemon/turn-plan.js'
+import { buildTurnPlan, type TurnPlan } from './daemon/turn-plan.js'
 import { turnEvaluationReporter, type TurnEvaluationReporter } from './daemon/turn-evaluation.js'
 import {
   isTrustedHumanTurn,
@@ -3056,7 +3056,7 @@ export class Daemon {
    * SessionManager call, so abort those callers immediately, stop every selected
    * cell, and wait for their uncancellable workspace I/O before returning. */
   private async quiesceAgentWorkspaceAuthority(agentId: string): Promise<void> {
-    const selected = [...this.pending.values()].filter((turn) => turn.agentId === agentId)
+    const selected = [...this.pending.values()].filter((turn) => turn.plan.agentId === agentId)
     await this.interruptAgentTurns(agentId, 'stop')
     for (const entry of this.activeGateEntries.values()) {
       if (entry.agentId !== agentId) continue
@@ -6428,8 +6428,8 @@ export class Daemon {
     const recentlyActive =
       (await this.store.activeSessionCountSince(msg.channel, thread, sinceTs, msg.transportScope)) > 0
     const inFlightAgent = [...this.pending.values()].find(
-      (p) => p.transcriptChannel === transcriptChannel && p.statusThread === thread
-    )?.agentId
+      (p) => p.plan.transcriptChannel === transcriptChannel && p.plan.statusThread === thread
+    )?.plan.agentId
     const initializingAgent = [...this.activeGateEntries.values()].find((entry) => {
       const coords = transcriptCoords(entry.msg)
       return (
@@ -6549,20 +6549,20 @@ export class Daemon {
     // NOTE for the second adapter: the checkpoint below is minted in Slack's ts
     // format; when another platform implements the port, checkpoint minting moves
     // into it.
-    if (!offersReadPort(this.replyConnFor(pending.agentId, pending.integrationId), 'getThreadReplies')) {
+    if (!offersReadPort(this.replyConnFor(pending.plan.agentId, pending.plan.integrationId), 'getThreadReplies')) {
       return undefined
     }
     return async () => {
       const checkpoint = slackTsForWallClock(this.clock.now())
       const readState = { truncated: false }
       const history = await this.fetchThreadHistory(
-        pending.agentId,
-        pending.channel,
-        pending.statusThread,
+        pending.plan.agentId,
+        pending.plan.channel,
+        pending.plan.statusThread,
         checkpoint,
         providerCheckpoint,
         true,
-        pending.integrationId,
+        pending.plan.integrationId,
         readState
       )
       return {
@@ -6572,8 +6572,8 @@ export class Daemon {
         // the completeness label exposes the remaining provider-side gap.
         completeness: readState.truncated ? 'observed-only' : 'authoritative',
         events: history.map((event) => ({
-          channel: pending.transcriptChannel,
-          thread: pending.statusThread,
+          channel: pending.plan.transcriptChannel,
+          thread: pending.plan.statusThread,
           ts: event.ts,
           sender: event.sender,
           kind: 'text' as const,
@@ -6593,26 +6593,26 @@ export class Daemon {
     const startedAt = this.clock.now()
     const snapshot = includeProviderSnapshot ? this.finalThreadSnapshot(pending, providerCheckpoint) : undefined
     const refresh = await this.threadContext.refresh({
-      agentId: pending.agentId,
-      transcriptChannel: pending.transcriptChannel,
-      thread: pending.statusThread,
+      agentId: pending.plan.agentId,
+      transcriptChannel: pending.plan.transcriptChannel,
+      thread: pending.plan.statusThread,
       afterRevision,
       // Pairwise a2a threads are shared storage but private conversations:
       // scope the refresh to this agent's own rows (#967).
-      ...(isSyntheticA2aChannel(pending.transcriptChannel) ? { scopeReadsToAgent: true } : {}),
+      ...(isSyntheticA2aChannel(pending.plan.transcriptChannel) ? { scopeReadsToAgent: true } : {}),
       ...(providerCheckpoint ? { providerCheckpoint } : {}),
       ...(snapshot ? { snapshot } : {})
     })
     const phase = includeProviderSnapshot ? 'final' : 'start'
     defaultTurnOutputMetrics.refresh({
-      platform: pending.platform,
+      platform: pending.plan.platform,
       phase,
       completeness: refresh.completeness,
       result: refresh.snapshotFailed ? 'degraded' : 'ok',
       durationMs: Math.max(0, this.clock.now() - startedAt)
     })
     defaultTurnOutputMetrics.events(
-      pending.platform,
+      pending.plan.platform,
       refresh.completeness === 'authoritative' ? 'provider' : 'observed',
       refresh.events.length
     )
@@ -6620,23 +6620,23 @@ export class Daemon {
   }
 
   private async localInvalidatingEvents(pending: Pending, afterRevision: number): Promise<TranscriptRow[]> {
-    const rows = isSyntheticA2aChannel(pending.transcriptChannel)
+    const rows = isSyntheticA2aChannel(pending.plan.transcriptChannel)
       ? // Pairwise a2a threads: only this agent's own rows may invalidate its
         // turn — a sibling's private delivery is not its context (#967).
         await this.store.transcriptSinceRevisionForAgent(
-          pending.transcriptChannel,
-          pending.statusThread,
+          pending.plan.transcriptChannel,
+          pending.plan.statusThread,
           afterRevision,
-          pending.agentId
+          pending.plan.agentId
         )
       : await this.store.transcriptSinceRevision(
-          pending.transcriptChannel,
-          pending.statusThread,
+          pending.plan.transcriptChannel,
+          pending.plan.statusThread,
           afterRevision,
-          pending.agentId
+          pending.plan.agentId
         )
     return rows
-      .filter((row) => row.kind === 'text' && row.sender !== pending.agentId)
+      .filter((row) => row.kind === 'text' && row.sender !== pending.plan.agentId)
       .sort((a, b) => a.eventTimeUs - b.eventTimeUs || a.seq - b.seq)
   }
 
@@ -6653,7 +6653,7 @@ export class Daemon {
    *  as coalesced instead of queueing it. Returns false when nothing absorbed this message. */
   private async coalesceLateAdmission(key: string, entry: QueueEntry): Promise<boolean> {
     if (!this.claimAbsorbedContext(key, transcriptCoords(entry.msg).ts)) return false
-    const sessionId = [...this.pending.values()].find((p) => p.sessionKey === key)?.acpSessionId
+    const sessionId = [...this.pending.values()].find((p) => p.plan.sessionKey === key)?.acpSessionId
     await this.coalesceEntryIntoTurn(entry, sessionId ?? null)
     defaultTurnOutputMetrics.queueCoalesced(entry.msg.platform, 1)
     this.log.info(`turn context: coalesced 1 late activation into ${key}`)
@@ -6913,15 +6913,15 @@ export class Daemon {
   /** Move only the accepted generation through the existing renderer. This call and
    * the first enqueue performed by the caller form the local answer commit point. */
   private acceptStagedAttempt(pending: Pending): void {
-    pending.replyText = pending.attemptReplyText
-    for (const update of pending.attemptAnswerUpdates) {
+    pending.reply.text = pending.reply.attemptText
+    for (const update of pending.reply.attemptAnswerUpdates) {
       for (const action of pending.conv.onUpdate(update)) this.enqueueApply(pending, action)
     }
   }
 
   private discardStagedAttempt(pending: Pending): void {
-    pending.attemptReplyText = ''
-    pending.attemptAnswerUpdates = []
+    pending.reply.attemptText = ''
+    pending.reply.attemptAnswerUpdates = []
   }
 
   // ── §4.3/§6.9 per-sessionKey serial admission gate ────────────────────────────
@@ -7110,7 +7110,7 @@ export class Daemon {
       raceDeadline: (work, ms) => this.raceDeadline(work, ms),
       sleepUntil: (at) => this.sleepUntil(at),
       activeDispatchCount: (agentId) => this.activeDispatchesByAgent.get(agentId)?.size ?? 0,
-      pendingTurnAgentIds: () => [...this.pending.values()].map((p) => p.agentId),
+      pendingTurnAgentIds: () => [...this.pending.values()].map((p) => p.plan.agentId),
       activeGateAgentIds: () => [...this.activeGateEntries.values()].map((entry) => entry.agentId),
       dreamInFlight: (agentId) => this.dreamRunnerInstance?.inFlight(agentId) === true
     }
@@ -7673,8 +7673,8 @@ export class Daemon {
       targets.set(key, { agentId: entry.agentId })
     }
     for (const pending of this.pending.values()) {
-      if (pending.loopGuardScope === scope) {
-        targets.set(pending.sessionKey, { agentId: pending.agentId, acpSessionId: pending.acpSessionId })
+      if (pending.plan.loopGuardScope === scope) {
+        targets.set(pending.plan.sessionKey, { agentId: pending.plan.agentId, acpSessionId: pending.acpSessionId })
       }
     }
     for (const [key, queued] of this.serialQueue) {
@@ -8475,7 +8475,7 @@ export class Daemon {
     // and Pending.done views until both are empty, then it is safe to stop.
     while (true) {
       const leases = [...(this.activeReplyConnectionUses.get(conn) ?? [])]
-      const pending = [...this.pending.values()].filter((turn) => turn.conn === conn).map((turn) => turn.done)
+      const pending = [...this.pending.values()].filter((turn) => turn.conn === conn).map((turn) => turn.signals.done)
       if (leases.length === 0 && pending.length === 0) return
       await Promise.all([...leases, ...pending])
     }
@@ -9024,8 +9024,8 @@ export class Daemon {
     run: TurnRun,
     turn: { conv: DaemonConverger; rec: TranscriptRecorder; sessionId: string; webchat: Pending['webchat'] }
   ): Pending {
-    const { entry, key, plan } = run
-    const { agentId, msg, integrationId, callMeta, githubReply } = entry
+    const { entry, plan } = run
+    const { agentId, callMeta, githubReply } = entry
     const { conv, rec, sessionId } = turn
     let resolveDone!: () => void
     const done = new Promise<void>((r) => (resolveDone = r))
@@ -9034,57 +9034,33 @@ export class Daemon {
       if (ordinaryHost) entry.selectedHost = this.selectedOrdinaryTurnHost(agentId, ordinaryHost)
     }
     const p: Pending = {
+      plan,
       entry,
       conv,
       rec,
-      replyText: '',
-      attemptReplyText: '',
-      attemptAnswerUpdates: [],
-      stageAnswer: plan.stageAnswer,
-      webchatRefresh: plan.webchatRefresh,
+      chrome: { statusCancellable: true },
+      reply: {
+        text: '',
+        attemptText: '',
+        attemptAnswerUpdates: [],
+        // One id for this turn's complete logical response (§5.1), minted before any
+        // output can be produced so every physical section of it agrees.
+        responseId: randomUUID()
+      },
+      approval: { waitMs: 0, depth: 0 },
+      signals: {
+        done,
+        resolveDone,
+        applyChain: Promise.resolve(),
+        usageReportSent: false,
+        runtimeCostReported: false
+      },
       builtinSystemToolCallIds: new Set(),
       hiddenSessionTitleToolCallIds: new Set(),
-      // One id for this turn's complete logical response (§5.1), minted before any
-      // output can be produced so every physical section of it agrees.
-      responseId: randomUUID(),
-      // §4.1: the author's OWN turn depth, stamped on every body it posts so the next
-      // routing edge advances from it. A human/root turn carries none and is depth 0; the
-      // model can neither read nor set this.
-      sourceHopCount: plan.sourceHopCount,
-      // §5.3: compound shared-bot addresses a split must never cut in half.
-      protectedAddresses: plan.protectedAddresses,
-      agentId,
-      agentName: plan.agentName,
-      requesterId: plan.requesterId,
-      ...(integrationId !== undefined ? { integrationId } : {}),
-      ...(plan.iconUrl ? { iconUrl: plan.iconUrl } : {}),
-      platform: msg.platform,
-      isDm: msg.isDm,
-      loopGuardScope: plan.loopGuardScope,
-      sessionKey: key,
       acpSessionId: sessionId,
       ...(entry.selectedHost ? { selectedHost: entry.selectedHost } : {}),
-      channel: msg.channel,
-      transcriptChannel: plan.transcriptChannel,
-      thread: msg.thread,
       turnState: plan.turnSurface.initialTurnState(plan.turnCtx),
-      statusThread: plan.statusThread,
       conn: run.replyConn,
-      // Snapshot alongside `conn`: true only when `none` removed THIS turn's Slack permission
-      // card surface (not Telegram/Discord/Feishu, webchat, or headless). Frozen for the turn
-      // so a mid-turn mode flip can't desync the permission policy from the already-cleared
-      // connection (auto-allow regression).
-      approvalSurfaceSuppressed: plan.approvalSurfaceSuppressed,
-      approvalWaitMs: 0,
-      approvalWaitDepth: 0,
-      runtimeCostReported: false,
-      usageReportSent: false,
-      evaluationTurnId: plan.evaluationTurnId,
-      showStatusBar: plan.showStatusBar,
-      statusCancellable: true,
-      applyChain: Promise.resolve(),
-      done,
-      resolveDone,
       ...(callMeta ? { callMeta } : {}),
       ...(turn.webchat ? { webchat: turn.webchat } : {}),
       ...(plan.githubTurnEligible && githubReply
@@ -9279,9 +9255,9 @@ export class Daemon {
     let finalCaptureInput = handled.captureInput ?? msg.text
     let baseRevision =
       handled.contextRevision ??
-      (await this.store.threadTranscriptRevision(p.transcriptChannel, p.statusThread, p.agentId))
+      (await this.store.threadTranscriptRevision(p.plan.transcriptChannel, p.plan.statusThread, p.plan.agentId))
     let providerCheckpoint = handled.providerCheckpoint
-    if (p.stageAnswer || p.webchatRefresh) {
+    if (p.plan.stageAnswer || p.plan.webchatRefresh) {
       // Queue entries remain untouched until every gate above has succeeded.
       const initialRefresh = await this.refreshTurnContext(p, baseRevision, providerCheckpoint, false)
       // Webchat: a co-hosted participant's recipient-delivery bump can re-surface
@@ -9290,7 +9266,7 @@ export class Daemon {
       // A row an earlier prompt for this session already carried is not new context — the
       // async store lets a fence re-read it, and replaying it would prompt it twice.
       const initialEvents = (
-        p.webchatRefresh
+        p.plan.webchatRefresh
           ? initialRefresh.events.filter((event) => msg.transcriptTs === undefined || event.ts !== msg.transcriptTs)
           : initialRefresh.events
       ).filter((event) => !this.absorbedContext(key, event))
@@ -9310,7 +9286,11 @@ export class Daemon {
         finalCaptureInput = recallQueryFromBlocks([{ type: 'text', text: finalCaptureInput }, ...deltaBlocks])
       }
       await this.coalesceQueuedContext(key, sessionId, representedEventTs)
-      baseRevision = await this.store.threadTranscriptRevision(p.transcriptChannel, p.statusThread, p.agentId)
+      baseRevision = await this.store.threadTranscriptRevision(
+        p.plan.transcriptChannel,
+        p.plan.statusThread,
+        p.plan.agentId
+      )
       providerCheckpoint = initialRefresh.providerCheckpoint ?? providerCheckpoint
     }
     return { promptBlocks, finalCaptureInput, baseRevision, providerCheckpoint }
@@ -9379,7 +9359,7 @@ export class Daemon {
     const codexUsageIsPerPrompt = plan.codexUsageIsPerPrompt
 
     while (true) {
-      if (p.stageAnswer) this.discardStagedAttempt(p)
+      if (p.plan.stageAnswer) this.discardStagedAttempt(p)
 
       // Start-fence linearization: no await occurs between queue coalescing above
       // (or the prior regeneration decision) and initiating this ACP request.
@@ -9424,7 +9404,7 @@ export class Daemon {
             cachedReadTokens: (evaluationUsage?.cachedReadTokens ?? 0) + (usage.cachedReadTokens ?? 0),
             cachedWriteTokens: (evaluationUsage?.cachedWriteTokens ?? 0) + (usage.cachedWriteTokens ?? 0)
           }
-          if (!p.runtimeCostReported) {
+          if (!p.signals.runtimeCostReported) {
             const estimate = estimateOpenAiTurnCost(turnModel, counts)
             if (estimate.ok) {
               if (!(await this.store.addCost(key, estimate.amount, estimate.currency))) {
@@ -9442,7 +9422,7 @@ export class Daemon {
         }
       }
 
-      if (!p.stageAnswer && !p.webchatRefresh) break
+      if (!p.plan.stageAnswer && !p.plan.webchatRefresh) break
 
       const refresh = await this.refreshTurnContext(p, baseRevision, providerCheckpoint, true)
       providerCheckpoint = refresh.providerCheckpoint ?? providerCheckpoint
@@ -9466,23 +9446,27 @@ export class Daemon {
         // the shared trigger row's revision (recipient-delivery write), which
         // would re-surface this agent's OWN trigger as a "new" message. The
         // trigger's canonical ts is carried on the message — exclude it.
-        .filter((event) => !p.webchatRefresh || msg.transcriptTs === undefined || event.ts !== msg.transcriptTs)
+        .filter((event) => !p.plan.webchatRefresh || msg.transcriptTs === undefined || event.ts !== msg.transcriptTs)
         // A row an earlier prompt for this session already carried is not new context: the
         // async store lets a later write bump its revision and re-surface it here.
         .filter((event) => !this.absorbedContext(key, event))
         .sort((a, b) => a.eventTimeUs - b.eventTimeUs || a.seq - b.seq)
-      const finalRevision = await this.store.threadTranscriptRevision(p.transcriptChannel, p.statusThread, p.agentId)
+      const finalRevision = await this.store.threadTranscriptRevision(
+        p.plan.transcriptChannel,
+        p.plan.statusThread,
+        p.plan.agentId
+      )
 
       if (invalidatingEvents.length === 0) {
-        if (p.stageAnswer) this.acceptStagedAttempt(p)
-        if (generation > 0) defaultTurnOutputMetrics.regeneration(p.platform, 'accepted')
+        if (p.plan.stageAnswer) this.acceptStagedAttempt(p)
+        if (generation > 0) defaultTurnOutputMetrics.regeneration(p.plan.platform, 'accepted')
         defaultTurnOutputMetrics.generations(generation + 1)
         baseRevision = finalRevision
         break
       }
 
       this.discardStagedAttempt(p)
-      if (p.webchatRefresh && p.webchat) {
+      if (p.plan.webchatRefresh && p.webchat) {
         // The canonical post — and post-turn memory / turn.completed.output —
         // must carry only the accepted generation. Webchat chunks accumulate
         // into BOTH buffers (the stream is never staged), so clear both — and
@@ -9490,7 +9474,7 @@ export class Daemon {
         p.webchat.replyText = ''
         p.webchat.heldText = ''
         p.webchat.messageEmitted = false
-        p.replyText = ''
+        p.reply.text = ''
       }
       this.evalHooks.emit({
         type: 'turn.context_changed',
@@ -9512,13 +9496,13 @@ export class Daemon {
       const regenerationElapsedMs =
         regenerationStartedAt === undefined
           ? 0
-          : this.clock.now() - regenerationStartedAt - Math.max(0, p.approvalWaitMs - regenerationApprovalWaitBaseline)
+          : this.clock.now() - regenerationStartedAt - Math.max(0, p.approval.waitMs - regenerationApprovalWaitBaseline)
       const retryAvailable =
         generation < MAX_TURN_CONTEXT_REGENERATIONS &&
         (regenerationStartedAt === undefined || regenerationElapsedMs < MAX_TURN_CONTEXT_REGENERATION_MS)
       if (!retryAvailable) {
         defaultTurnOutputMetrics.candidateDiscarded('context_churn')
-        defaultTurnOutputMetrics.contextChurnExhausted(p.platform)
+        defaultTurnOutputMetrics.contextChurnExhausted(p.plan.platform)
         defaultTurnOutputMetrics.generations(generation + 1)
         evaluation.finishEvaluation('turn.cancelled', { reason: 'context_churn', generations: generation + 1 })
         if (p.webchat) {
@@ -9561,7 +9545,7 @@ export class Daemon {
       // The browser supersession marker fires HERE — after the budget check —
       // so it is only ever followed by a real replacement generation, never by
       // the context-churn terminal (§5.4: "the replacement streams next").
-      if (p.webchatRefresh && p.webchat && !p.webchat.doneSent) {
+      if (p.plan.webchatRefresh && p.webchat && !p.webchat.doneSent) {
         p.webchat.sink.output({
           conversationId: p.webchat.conversationId,
           turnId: p.webchat.turnId,
@@ -9571,7 +9555,11 @@ export class Daemon {
       }
       defaultTurnOutputMetrics.candidateDiscarded('context_changed')
       await this.coalesceQueuedContext(key, sessionId, eventTs)
-      baseRevision = await this.store.threadTranscriptRevision(p.transcriptChannel, p.statusThread, p.agentId)
+      baseRevision = await this.store.threadTranscriptRevision(
+        p.plan.transcriptChannel,
+        p.plan.statusThread,
+        p.plan.agentId
+      )
       generation += 1
       promptBlocks = [
         {
@@ -9584,9 +9572,9 @@ export class Daemon {
       // generation (including approval waits) must never consume the first retry.
       if (regenerationStartedAt === undefined) {
         regenerationStartedAt = this.clock.now()
-        regenerationApprovalWaitBaseline = p.approvalWaitMs
+        regenerationApprovalWaitBaseline = p.approval.waitMs
       }
-      defaultTurnOutputMetrics.regeneration(p.platform, 'started')
+      defaultTurnOutputMetrics.regeneration(p.plan.platform, 'started')
       this.evalHooks.emit({
         type: 'turn.regeneration_started',
         agentId,
@@ -9613,7 +9601,7 @@ export class Daemon {
     // historical dashboard. Fire-and-forget; no-op if the CP is down. Wrapped so
     // a transport hiccup can never abort the turn before the final reply flush.
     await this.emitStoredUsageReport(sessionId, entry.agentId, plan.platform, plan.channel, key)
-    p.usageReportSent = true
+    p.signals.usageReportSent = true
     // turn finished: stop any pending idle-flush, then drain the final actions
     // (remaining body + status clear + optional Web App detail link). A webchat
     // turn skips the Slack renderer entirely — its reply already streamed through
@@ -9638,7 +9626,7 @@ export class Daemon {
       // agent): drop the held stream text — nothing was ever streamed — and
       // commit no canonical post or transcript reply row.
       p.webchat.heldText = ''
-      p.replyText = ''
+      p.reply.text = ''
     } else if (trimmedWebchatReply) {
       // A real reply that never diverged from the sentinel prefix mid-stream
       // (shorter than the sentinel) is still held — release it before commit.
@@ -9654,7 +9642,7 @@ export class Daemon {
         const replyPostId = randomUUID()
         const replyTs = await webchatTurnOutput.appendWebchatTextRow(
           this.store,
-          p.transcriptChannel,
+          p.plan.transcriptChannel,
           plan.statusThread,
           monotonicTs(),
           {
@@ -9676,7 +9664,7 @@ export class Daemon {
           post: {
             postId: replyPostId,
             conversationId: p.webchat.conversationId,
-            author: { kind: 'agent', agentId, hopCount: p.sourceHopCount },
+            author: { kind: 'agent', agentId, hopCount: p.plan.sourceHopCount },
             text: p.webchat.replyText,
             at: Number(replyTs)
           },
@@ -9751,7 +9739,7 @@ export class Daemon {
     // The turn is over, so nothing more will supersede a coalesced tool body: make the last
     // state of every streamed tool call durable now rather than on the buffer's own timer.
     await this.store.flushToolCallWrites()
-    await p.applyChain
+    await p.signals.applyChain
     // Every section has now been delivered, so the complete logical response exists and
     // exactly one of its messages can be marked final (§5.5). Must run AFTER applyChain:
     // before it, the message being closed might not be the last one posted.
@@ -9759,7 +9747,7 @@ export class Daemon {
     // §7.3 `closeResponse`: exact lookup, so a webchat / hook / dream turn rendering
     // through the core surface does not inherit its platform's closure, and a platform
     // that cannot amend a sent message simply registers none.
-    await this.turnSurfaces.exact(p.platform)?.closeResponse?.(p)
+    await this.turnSurfaces.exact(p.plan.platform)?.closeResponse?.(p)
     // Continuation `done` fires only now, behind the platform apply/finalization
     // boundary, so both sinks settle as ONE ordered turn: the console cannot admit
     // a next turn (whose mirror posts immediately) ahead of this reply's flush.
@@ -9781,14 +9769,14 @@ export class Daemon {
       sessionId,
       p.webchat?.turnId ?? handled.turnId ?? stableTurnId(agentId, msg),
       finalCaptureInput,
-      p.replyText,
+      p.reply.text,
       agent.memory,
       memoryCaptureTarget,
       plan.evaluationTurnId
     )
     evaluation.finishEvaluation('turn.completed', {
       ...(stopReason ? { stopReason } : {}),
-      output: p.replyText,
+      output: p.reply.text,
       ...(usage
         ? {
             usage: {
@@ -9885,7 +9873,7 @@ export class Daemon {
         const partialPostId = randomUUID()
         const replyTs = await webchatTurnOutput.appendWebchatTextRow(
           this.store,
-          p.transcriptChannel,
+          p.plan.transcriptChannel,
           plan.statusThread,
           monotonicTs(),
           {
@@ -9944,7 +9932,7 @@ export class Daemon {
       }
       this.clearTurnActivity(run) // clear "is thinking…"
       try {
-        await p.applyChain
+        await p.signals.applyChain
       } finally {
         // Continuation closes the browser stream only after the platform failure
         // actions drain (or terminally fail) — never before, so the sinks stay ordered.
@@ -9983,12 +9971,12 @@ export class Daemon {
     // Remove Cancel run before releasing the Slack transport. Suppressed turns still
     // allow this one terminal chrome update; ordinary queued output remains blocked.
     await this.settleStatusBar(p)
-    await p.applyChain.catch(() => {})
+    await p.signals.applyChain.catch(() => {})
     // Platform turn settlement (§7.3 teardown hook): cleanup the ordinary final
     // action may have bypassed on failure/suppression — Slack retries stale
     // footer removals. Exact lookup: a webchat/hook turn rendering through the
     // core surface must not inherit its platform's teardown.
-    await this.turnSurfaces.exact(p.platform)?.onSettle?.(p)
+    await this.turnSurfaces.exact(p.plan.platform)?.onSettle?.(p)
     // The reply transport is no longer used after the final apply chain / failure
     // notice. Release before local metadata cleanup so even a cleanup exception
     // cannot strand the connection lease forever.
@@ -10081,7 +10069,7 @@ export class Daemon {
         channel: msg.channel,
         thread: plan.statusThread
       })
-      p.resolveDone()
+      p.signals.resolveDone()
     } else if (!settlement.propagatingTurnError) {
       // Success/cancel has no original error for runLoop to fail-stop on. Use
       // the internal sentinel only in that case; a real prompt error must leave
@@ -10201,7 +10189,7 @@ export class Daemon {
     }
     const live = acpSessionId
       ? this.pending.get(pendingTurnKey(agentId, acpSessionId))
-      : [...this.pending.values()].find((pending) => pending.sessionKey === key)
+      : [...this.pending.values()].find((pending) => pending.plan.sessionKey === key)
     const liveSessionId = acpSessionId ?? live?.acpSessionId
     if (live) {
       await this.settleStatusBar(live)
@@ -10209,8 +10197,8 @@ export class Daemon {
       this.clearIdle(live)
       // Platform suppression teardown (§7.3): Feishu stops its stream timer and
       // cancels the CardKit entity. Exact lookup — no core fallback.
-      this.turnSurfaces.exact(live.platform)?.onSuppress?.(live)
-      this.showActivity(live.conn, live.channel, live.statusThread, '')
+      this.turnSurfaces.exact(live.plan.platform)?.onSuppress?.(live)
+      this.showActivity(live.conn, live.plan.channel, live.plan.statusThread, '')
       if (live.webchat && !live.webchat.doneSent) {
         live.webchat.doneSent = true
         live.webchat.sink.done({
@@ -10278,7 +10266,7 @@ export class Daemon {
       targets.set(key, undefined)
     }
     for (const p of this.pending.values()) {
-      if (p.agentId === agentId) targets.set(p.sessionKey, p.acpSessionId)
+      if (p.plan.agentId === agentId) targets.set(p.plan.sessionKey, p.acpSessionId)
     }
     for (const [key, queued] of this.serialQueue) {
       if (queued.some((entry) => entry.agentId === agentId) && !targets.has(key)) {
@@ -10377,13 +10365,12 @@ export class Daemon {
 
   /** Opaque routing target attached to daemon-rendered interactive Slack blocks when
    * inbound actions belong to the relay instead of this process's Socket Mode edge. */
-  private httpSlackSessionTarget(p: Pick<Pending, 'agentId' | 'integrationId' | 'sessionKey'>): string | undefined {
-    return p.integrationId && this.isHttpSlackIntegration(p.agentId, p.integrationId)
-      ? encodeSharedSlackStatusTarget({
-          agentId: p.agentId,
-          integrationId: p.integrationId,
-          sessionKey: p.sessionKey
-        })
+  private httpSlackSessionTarget(p: {
+    plan: Pick<TurnPlan, 'agentId' | 'integrationId' | 'sessionKey'>
+  }): string | undefined {
+    const { agentId, integrationId, sessionKey } = p.plan
+    return integrationId && this.isHttpSlackIntegration(agentId, integrationId)
+      ? encodeSharedSlackStatusTarget({ agentId, integrationId, sessionKey })
       : undefined
   }
 
@@ -10393,10 +10380,10 @@ export class Daemon {
    * dedup collisions. Platform-agnostic; runs even headless (no conn). */
   private async recordReplySegment(p: Pending, text: string): Promise<void> {
     await this.store.appendTranscript({
-      channel: p.transcriptChannel,
-      thread: p.statusThread,
+      channel: p.plan.transcriptChannel,
+      thread: p.plan.statusThread,
       ts: monotonicTs(),
-      sender: p.agentId,
+      sender: p.plan.agentId,
       kind: 'text',
       text
     })
@@ -10413,26 +10400,27 @@ export class Daemon {
    */
   private async closeSlackResponse(p: Pending): Promise<void> {
     if (!p.conn) return
-    const orgId = this.cpCollab.orgForAgent(p.agentId)
+    const orgId = this.cpCollab.orgForAgent(p.plan.agentId)
     const recipients = orgId
-      ? resolveSlackMentionedAgents(p.replyText, this.cpCollab.mentionDirectory(orgId, p.platform, p.channel)).filter(
-          (id) => id !== p.agentId
-        )
+      ? resolveSlackMentionedAgents(
+          p.reply.text,
+          this.cpCollab.mentionDirectory(orgId, p.plan.platform, p.plan.channel)
+        ).filter((id) => id !== p.plan.agentId)
       : []
     // Whether the answer addressed ANYONE is read from the complete reply text, not
     // from the final section: §2.3 makes any address binding, and the splitter may
     // have put the only mention in section one. Without this the same answer would
     // wake a peer or not depending on where the cut landed.
-    const addressedAnyone = slackTextAddressesAnyone(p.replyText)
+    const addressedAnyone = slackTextAddressesAnyone(p.reply.text)
     // What this response RESOLVED to, at the one place the author still knows it.
     // Everything downstream (relay arbitration, the target's ladder) sees only the
     // outcome, so without this a response that addressed a peer but resolved to no
     // agent — a stale or unpopulated mention directory — is indistinguishable from
     // one that addressed nobody, on either side of the wire.
-    const mentionDir = orgId ? this.cpCollab.mentionDirectory(orgId, p.platform, p.channel) : []
+    const mentionDir = orgId ? this.cpCollab.mentionDirectory(orgId, p.plan.platform, p.plan.channel) : []
     this.log.debug(
-      `slack: finalizing response ${p.responseId} for "${p.agentId}" — recipients=[${recipients.join(',')}] ` +
-        `addressedAnyone=${addressedAnyone} text=${JSON.stringify(p.replyText.slice(0, 120))} ` +
+      `slack: finalizing response ${p.reply.responseId} for "${p.plan.agentId}" — recipients=[${recipients.join(',')}] ` +
+        `addressedAnyone=${addressedAnyone} text=${JSON.stringify(p.reply.text.slice(0, 120))} ` +
         `directory=[${mentionDir
           .map((e) => `${e.agentId.slice(0, 8)}:${e.botUserId ?? 'NO-BOT-USER-ID'}${e.botShared ? '(shared)' : ''}`)
           .join(' ')}]`
@@ -10522,7 +10510,7 @@ export class Daemon {
         recordReplySegment: (turn, text) => this.recordReplySegment(turn as Pending, text),
         appendTranscript: async (row) => await this.store.appendTranscript(row),
         sessionUrl: (turn) =>
-          this.sessionLink(turn.acpSessionId, this.sessionLinkSource(turn.platform, turn.integrationId))
+          this.sessionLink(turn.acpSessionId, this.sessionLinkSource(turn.plan.platform, turn.plan.integrationId))
       },
       p,
       turnState<FeishuTurnState>(p),
@@ -10697,7 +10685,7 @@ export class Daemon {
 
   /** Per-turn status snapshot for the live in-thread line + webchat status payload (no breakdown). */
   private buildStatusInfo(p: Pending): Promise<StatusBarInfo> {
-    return this.statusInfoFrom(p.agentId, p.sessionKey, p.acpSessionId)
+    return this.statusInfoFrom(p.plan.agentId, p.plan.sessionKey, p.acpSessionId)
   }
 
   /** Agent identity + status snapshot (WITH the full token breakdown) + deep link for a
@@ -10720,16 +10708,16 @@ export class Daemon {
       ...(sessionTitle ? { sessionTitle } : {})
     }
     const link = rec.acpSessionId ? this.sessionLink(rec.acpSessionId, 'slack') : undefined
-    const pending = [...this.pending.values()].find((turn) => turn.sessionKey === sessionKey)
-    const cancellable = pending?.statusCancellable ?? this.inflight.has(sessionKey)
+    const pending = [...this.pending.values()].find((turn) => turn.plan.sessionKey === sessionKey)
+    const cancellable = pending?.chrome.statusCancellable ?? this.inflight.has(sessionKey)
     return { info, identity, ...(link ? { link } : {}), cancellable }
   }
 
   /** Settle the persistent Slack status row without reviving suppressed turn output. */
   private async settleStatusBar(p: Pending): Promise<void> {
-    const emitted = p.lastStatusBar !== undefined
-    p.statusCancellable = false
-    if (turnChromeFor(p.platform).statusSurface === 'turn-bar' && emitted) await this.emitStatusBar(p, true)
+    const emitted = p.chrome.lastStatusBar !== undefined
+    p.chrome.statusCancellable = false
+    if (turnChromeFor(p.plan.platform).statusSurface === 'turn-bar' && emitted) await this.emitStatusBar(p, true)
   }
 
   /** Emit/refresh the session's status bar (model / context / tokens / cost). Called at
@@ -10742,23 +10730,23 @@ export class Daemon {
    *  applyAction (no connection), which is fine. */
   private async emitStatusBar(p: Pending, allowWhenSuppressed = false): Promise<void> {
     if (p.outputSuppressed && !allowWhenSuppressed) return
-    const statusSurface = turnChromeFor(p.platform).statusSurface
-    if (statusSurface === 'turn-bar' && !p.showStatusBar) {
+    const statusSurface = turnChromeFor(p.plan.platform).statusSurface
+    if (statusSurface === 'turn-bar' && !p.plan.showStatusBar) {
       const key = 'status-bar:hidden'
-      if (key === p.lastStatusBar) return
-      p.lastStatusBar = key
+      if (key === p.chrome.lastStatusBar) return
+      p.chrome.lastStatusBar = key
       this.enqueueApply(p, { kind: 'clear-status-bar' }, { allowWhenSuppressed })
       return
     }
     const info = await this.buildStatusInfo(p)
-    const key = JSON.stringify([info, statusSurface === 'turn-bar' ? p.statusCancellable : null])
-    if (key === p.lastStatusBar) return // unchanged since the last emit — no-op
+    const key = JSON.stringify([info, statusSurface === 'turn-bar' ? p.chrome.statusCancellable : null])
+    if (key === p.chrome.lastStatusBar) return // unchanged since the last emit — no-op
     if (p.webchat) {
       // Webchat: skip a truly-empty frame (nothing for the web bar to show); the model /
       // usage lands on a later call. `sessionId` is always present, so exclude it.
       const hasContent = Object.entries(info).some(([k, v]) => k !== 'sessionId' && v !== undefined)
       if (hasContent) {
-        p.lastStatusBar = key
+        p.chrome.lastStatusBar = key
         const wc = p.webchat
         wc.sink.output({
           conversationId: wc.conversationId,
@@ -10776,20 +10764,20 @@ export class Daemon {
       // Record the dedup key so the shared bookkeeping stays consistent, but emit
       // nothing. The absent declaration (webchat handled above; hook/dream/
       // headless) falls through to the legacy default arm below.
-      p.lastStatusBar = key
+      p.chrome.lastStatusBar = key
     } else {
       // Slack: ensure/refresh the status bar from turn START unconditionally — it must be
       // visible as soon as the turn begins, even before the model/usage is known (some
       // runtimes only advertise the model after the first prompt). It fills in via edits
       // as usage_update / turn-end land.
-      p.lastStatusBar = key
+      p.chrome.lastStatusBar = key
       const link = this.sessionLink(p.acpSessionId, 'slack')
       const sessionTarget = this.httpSlackSessionTarget(p)
       const shared =
-        sessionTarget && p.integrationId
+        sessionTarget && p.plan.integrationId
           ? {
               sessionTarget,
-              shareable: this.isShareableSlackIntegration(p.agentId, p.integrationId)
+              shareable: this.isShareableSlackIntegration(p.plan.agentId, p.plan.integrationId)
             }
           : undefined
       this.enqueueApply(
@@ -10797,7 +10785,7 @@ export class Daemon {
         {
           kind: 'status-bar',
           text: renderStatusBar(info),
-          blocks: buildStatusBlocks(info, p.sessionKey, link, shared, p.statusCancellable)
+          blocks: buildStatusBlocks(info, p.plan.sessionKey, link, shared, p.chrome.statusCancellable)
         },
         { allowWhenSuppressed }
       )
@@ -10833,12 +10821,12 @@ export class Daemon {
     opts: { allowWhenSuppressed?: boolean } = {}
   ): void {
     if (p.outputSuppressed && !opts.allowWhenSuppressed) return
-    p.applyChain = p.applyChain.then(() => {
+    p.signals.applyChain = p.signals.applyChain.then(() => {
       // Check again at execution time: actions queued before an interrupt must not
       // publish later after a backed-up transport queue drains.
       if (p.outputSuppressed && !opts.allowWhenSuppressed) return
       return this.turnSurfaces
-        .for(p.platform)
+        .for(p.plan.platform)
         .apply(p, action)
         .catch((err) => this.log.error(`apply failed: ${formatErr(err)}`))
     })
@@ -10849,8 +10837,8 @@ export class Daemon {
   private armIdle(p: Pending): void {
     this.clearIdle(p)
     if (!p.conv.hasBuffered()) return
-    p.idleTimer = setTimeout(() => {
-      p.idleTimer = undefined
+    p.signals.idleTimer = setTimeout(() => {
+      p.signals.idleTimer = undefined
       for (const action of p.conv.flushBuffered()) this.enqueueApply(p, action)
     }, IDLE_FLUSH_MS)
   }
@@ -10880,8 +10868,8 @@ export class Daemon {
   }
 
   private clearIdle(p: Pending): void {
-    if (p.idleTimer) clearTimeout(p.idleTimer)
-    p.idleTimer = undefined
+    if (p.signals.idleTimer) clearTimeout(p.signals.idleTimer)
+    p.signals.idleTimer = undefined
   }
 
   /** In-flight rendering state keyed by (agentId, ACP sessionId). */
@@ -10915,7 +10903,7 @@ export class Daemon {
   ): Promise<T | undefined> {
     const conn = p.conn as SlackConnection
     let result: T | undefined
-    const step = p.applyChain.then(async () => {
+    const step = p.signals.applyChain.then(async () => {
       result = await post(conn)
       if (result !== undefined && LIVE_CHROME_BOUNDARY_MESSAGE_TYPES.has(messageType)) {
         this.markInPlaceChromeForReanchor(p)
@@ -10923,7 +10911,7 @@ export class Daemon {
     })
     // Keep the chain alive for later actions (the reanchor, the post-answer stream) even if
     // this post throws — mirrors enqueueApply's per-step error isolation.
-    p.applyChain = step.catch(() => {})
+    p.signals.applyChain = step.catch(() => {})
     await step
     return result
   }
@@ -10951,17 +10939,17 @@ export class Daemon {
    * reset directly. Slack-only.
    */
   private reanchorInPlaceChrome(p: Pending): void {
-    p.applyChain = p.applyChain.then(() => this.markInPlaceChromeForReanchor(p))
+    p.signals.applyChain = p.signals.applyChain.then(() => this.markInPlaceChromeForReanchor(p))
   }
 
   private markInPlaceChromeForReanchor(p: Pending): void {
-    p.liveReplyReanchor = true
-    p.progressTs = undefined
-    p.progressAttempted = false
-    p.planTs = undefined
-    p.planAttempted = false
-    p.reasoningTs = undefined
-    p.reasoningAttempted = false
+    p.chrome.liveReplyReanchor = true
+    p.chrome.progressTs = undefined
+    p.chrome.progressAttempted = false
+    p.chrome.planTs = undefined
+    p.chrome.planAttempted = false
+    p.chrome.reasoningTs = undefined
+    p.chrome.reasoningAttempted = false
   }
 
   /** Copy-on-write mask of an agent's write-only secret values over any JSON-ish
@@ -11101,13 +11089,13 @@ export class Daemon {
     await this.persistSessionTitle(rec, req.title)
 
     const p = this.pending.get(pendingTurnKey(rec.agentId, rec.acpSessionId))
-    if (p && p.sessionKey === key && !p.outputSuppressed) {
+    if (p && p.plan.sessionKey === key && !p.outputSuppressed) {
       if (p.webchat) {
         webchatTurnOutput.emitWebchatUpdate(p.webchat, { sessionUpdate: 'session_info_update', title: req.title })
       }
-      if (turnChromeFor(p.platform).dmSessionTitle && p.isDm && p.conn) {
+      if (turnChromeFor(p.plan.platform).dmSessionTitle && p.plan.isDm && p.conn) {
         this.enqueueApply(p, { kind: 'set-title', text: req.title })
-        await p.applyChain
+        await p.signals.applyChain
         return
       }
     }
@@ -11186,9 +11174,9 @@ export class Daemon {
       type: 'acp.update',
       agentId,
       sessionId,
-      ...(p?.evaluationTurnId ? { turnId: p.evaluationTurnId } : {}),
-      ...(p?.platform ? { platform: p.platform } : {}),
-      ...(p?.channel ? { channel: p.channel } : {}),
+      ...(p?.plan.evaluationTurnId ? { turnId: p.plan.evaluationTurnId } : {}),
+      ...(p?.plan.platform ? { platform: p.plan.platform } : {}),
+      ...(p?.plan.channel ? { channel: p.plan.channel } : {}),
       data: { update }
     })
     if (p?.outputSuppressed) return
@@ -11216,9 +11204,9 @@ export class Daemon {
     // reported, rather than being silently lost.
     if (update?.sessionUpdate === 'usage_update') {
       const rec = p ? undefined : detachedRec
-      const key = p?.sessionKey ?? rec?.key
+      const key = p?.plan.sessionKey ?? rec?.key
       if (key) {
-        if (p && update.cost?.amount !== undefined) p.runtimeCostReported = true
+        if (p && update.cost?.amount !== undefined) p.signals.runtimeCostReported = true
         await this.store.setUsageSnapshot(key, {
           contextUsed: update.used,
           contextSize: update.size,
@@ -11232,8 +11220,8 @@ export class Daemon {
           // prompt() may already have returned and emitted the normal CP report while
           // output is still draining. In that window Pending still exists, so send a
           // latest-wins correction instead of waiting for another turn.
-          if (p.usageReportSent) {
-            await this.emitStoredUsageReport(sessionId, p.agentId, p.platform, p.channel, key, true)
+          if (p.signals.usageReportSent) {
+            await this.emitStoredUsageReport(sessionId, p.plan.agentId, p.plan.platform, p.plan.channel, key, true)
           }
         } else if (rec) {
           // The normal report happens at turn end. A notification after that point
@@ -11247,7 +11235,7 @@ export class Daemon {
     // renames and some adapters can notify out of turn. ACP semantics: string ⇒ set,
     // null ⇒ clear, absent ⇒ no change.
     if (update?.sessionUpdate === 'session_info_update' && update.title !== undefined) {
-      const rec = p ? await this.store.getSession(p.sessionKey) : detachedRec
+      const rec = p ? await this.store.getSession(p.plan.sessionKey) : detachedRec
       // The callback is agent-bound, but ACP session ids are runtime-controlled. Match
       // both before touching another logical session if two adapters reuse an id.
       if (rec?.agentId === agentId && rec.acpSessionId === sessionId) {
@@ -11256,7 +11244,7 @@ export class Daemon {
         // the runtime's title verbatim (apart from surrounding whitespace); do not
         // invent one from the first-message fallback used by the console session list.
         const slackTitle = typeof update.title === 'string' ? update.title.trim() : ''
-        if (p && turnChromeFor(p.platform).dmSessionTitle && p.isDm && slackTitle) {
+        if (p && turnChromeFor(p.plan.platform).dmSessionTitle && p.plan.isDm && slackTitle) {
           this.enqueueApply(p, { kind: 'set-title', text: slackTitle })
         } else if (!p && slackTitle) {
           const binding = this.sessionDeliveryBindings.get(rec.key)
@@ -11268,11 +11256,11 @@ export class Daemon {
     const isAnswerChunk = update?.sessionUpdate === 'agent_message_chunk' && update.content?.type === 'text'
     if (isAnswerChunk) {
       const text = String(update.content.text ?? '')
-      if (p.stageAnswer) {
-        p.attemptReplyText += text
-        p.attemptAnswerUpdates.push(update)
+      if (p.plan.stageAnswer) {
+        p.reply.attemptText += text
+        p.reply.attemptAnswerUpdates.push(update)
       } else {
-        p.replyText += text
+        p.reply.text += text
       }
     }
     // `setSessionTitle` is daemon housekeeping, not conversational activity. Codex
@@ -11298,13 +11286,14 @@ export class Daemon {
     // full activity log below, so a webchat session reads back like any other.
     // A continuation turn drives BOTH: the browser sink and the platform renderer (§5.2).
     if (p.webchat) webchatTurnOutput.emitWebchatUpdate(p.webchat, update)
-    if ((!p.webchat || p.webchat.continuation) && !isHeadlessGithubFinal && !(p.stageAnswer && isAnswerChunk)) {
+    if ((!p.webchat || p.webchat.continuation) && !isHeadlessGithubFinal && !(p.plan.stageAnswer && isAnswerChunk)) {
       for (const action of p.conv.onUpdate(update)) this.enqueueApply(p, action)
       this.armIdle(p)
       this.armFeishuStream(p)
     }
     // Full activity log (tool/reasoning), recorded regardless of output mode.
-    for (const ev of p.rec.onUpdate(update)) await this.recordEvent(p.agentId, p.transcriptChannel, p.statusThread, ev)
+    for (const ev of p.rec.onUpdate(update))
+      await this.recordEvent(p.plan.agentId, p.plan.transcriptChannel, p.plan.statusThread, ev)
   }
 
   /** Persist one internal activity event (tool/reasoning). Ordered by row `seq`, so its
@@ -12709,7 +12698,7 @@ export class Daemon {
       this.drainingAgents.has(rec.agentId) ||
       this.inflight.has(rec.key) ||
       this.activeDispatchDoneByKey.has(rec.key) ||
-      [...this.pending.values()].some((p) => p.sessionKey === rec.key) ||
+      [...this.pending.values()].some((p) => p.plan.sessionKey === rec.key) ||
       (await this.store.sessionHasPendingInboxRows(rec.key)) ||
       !this.sessionSdkQuiescent(rec.agentId, rec.acpSessionId)
     )
@@ -12855,7 +12844,7 @@ export class Daemon {
   private async agentWorkspaceActive(agentId: string): Promise<boolean> {
     if (!this.servesAgent(agentId) || this.workspaceMutationBusy(agentId)) return true
     for (const entry of this.activeGateEntries.values()) if (entry.agentId === agentId) return true
-    for (const turn of this.pending.values()) if (turn.agentId === agentId) return true
+    for (const turn of this.pending.values()) if (turn.plan.agentId === agentId) return true
     return await this.store.agentHasPendingInboxRows(agentId)
   }
 
@@ -13127,7 +13116,7 @@ export class Daemon {
     for (const [agentId, entry] of this.hostConfigFiles) {
       if (!entry.materialized || !entry.childEnv) continue
       if (this.drainingAgents.has(agentId)) continue // stopHost will remove them
-      if ([...this.pending.values()].some((p) => p.agentId === agentId)) continue
+      if ([...this.pending.values()].some((p) => p.plan.agentId === agentId)) continue
       const last = Math.max((await this.store.agentLastActivityTs(agentId)) ?? 0, this.hostStartedAt.get(agentId) ?? 0)
       if (now - last <= configFilesIdle) continue
       // The lease also covers the settle→followup gap of a background task: a
@@ -13155,7 +13144,7 @@ export class Daemon {
       // be assembling memory/context or preparing its workspace before that;
       // reclaiming its host here would detach a live initialization generation.
       if ((this.activeDispatchesByAgent.get(agentId)?.size ?? 0) > 0) continue
-      if ([...this.pending.values()].some((p) => p.agentId === agentId)) continue
+      if ([...this.pending.values()].some((p) => p.plan.agentId === agentId)) continue
       // A just-started host that hasn't served a turn yet has no recorded activity
       // (`agentLastActivityTs` unset ⇒ 0 ⇒ idle≈now), so without this it would be
       // reclaimed on the very next sweep — including WHILE it is still mid-startup
@@ -13209,7 +13198,7 @@ export class Daemon {
       // beneath a runtime that is merely between turns.
       if (this.hosts.has(agentId) || this.modelSessions.hasStartedHostForAgent(agentId)) continue
       if ((this.activeDispatchesByAgent.get(agentId)?.size ?? 0) > 0) continue
-      if ([...this.pending.values()].some((p) => p.agentId === agentId)) continue
+      if ([...this.pending.values()].some((p) => p.plan.agentId === agentId)) continue
       // Shared-store activity, floored at when this member took the launch: a full window, not epoch-idle.
       const last = Math.max((await this.store.agentLastActivityTs(agentId)) ?? 0, since)
       if (now - last <= ttl) continue
@@ -13305,10 +13294,12 @@ export class Daemon {
   ): Promise<{ matched: SessionKey[]; drained: SessionKey[]; targets: Pending[] }> {
     const match = (p: Pending): boolean => {
       if (scope.kind === 'daemon') return true
-      if (scope.kind === 'agent') return p.agentId === scope.agentId
+      if (scope.kind === 'agent') return p.plan.agentId === scope.agentId
       const k = scope.sessionKey
       return (
-        p.platform === k.platform && p.channel === k.channel && (k.thread === undefined || p.statusThread === k.thread)
+        p.plan.platform === k.platform &&
+        p.plan.channel === k.channel &&
+        (k.thread === undefined || p.plan.statusThread === k.thread)
       )
     }
     if (scope.kind === 'daemon') this.draining = true
@@ -13327,7 +13318,7 @@ export class Daemon {
     let remaining = targets.length
     const work = Promise.all(
       targets.map(([, p]) =>
-        p.done.then(() => {
+        p.signals.done.then(() => {
           const sk = pendingSessionKey(p)
           drained.set(keyOf(sk), sk)
           remaining--
@@ -13341,7 +13332,7 @@ export class Daemon {
       for (const p of this.pending.values()) {
         if (!match(p)) continue
         this.log.warn(`drain[${scope.kind}]: cancelling straggler turn (session ${p.acpSessionId})`)
-        await (p.selectedHost?.host ?? this.hosts.get(p.agentId))?.cancel(p.acpSessionId).catch(() => {})
+        await (p.selectedHost?.host ?? this.hosts.get(p.plan.agentId))?.cancel(p.acpSessionId).catch(() => {})
       }
     }
     return { matched: [...matched.values()], drained: [...drained.values()], targets: targets.map(([, p]) => p) }
@@ -13690,7 +13681,7 @@ export class Daemon {
   private async drainForShutdown(deadlineMs = this.shutdownDrainBudgetMs()): Promise<void> {
     this.draining = true
     const active = [...new Set([...this.activeDispatchesByAgent.values()].flatMap((runs) => [...runs]))]
-    const pendingKeys = new Set([...this.pending.values()].map((p) => p.sessionKey))
+    const pendingKeys = new Set([...this.pending.values()].map((p) => p.plan.sessionKey))
     const coldAgents = new Set<string>()
     // A pre-Pending dispatch has no p.done for the old shutdown drain to observe.
     // Latch + abort its whole SessionManager initialization path immediately, retaining
@@ -13728,11 +13719,11 @@ export class Daemon {
         for (const p of this.pending.values()) {
           p.outputSuppressed ??= 'shutdown'
           this.clearIdle(p)
-          this.turnSurfaces.exact(p.platform)?.onSuppress?.(p)
-          await this.permissions.releaseElicits(p.agentId, p.acpSessionId)
-          await this.permissions.releaseChatPermissions(p.agentId, p.acpSessionId)
-          await this.permissions.releaseEditorPermissions(p.agentId, p.acpSessionId)
-          void (p.selectedHost?.host ?? this.hosts.get(p.agentId))?.cancel(p.acpSessionId).catch(() => {})
+          this.turnSurfaces.exact(p.plan.platform)?.onSuppress?.(p)
+          await this.permissions.releaseElicits(p.plan.agentId, p.acpSessionId)
+          await this.permissions.releaseChatPermissions(p.plan.agentId, p.acpSessionId)
+          await this.permissions.releaseEditorPermissions(p.plan.agentId, p.acpSessionId)
+          void (p.selectedHost?.host ?? this.hosts.get(p.plan.agentId))?.cancel(p.acpSessionId).catch(() => {})
         }
         const forceStops = [...forceAgents].filter((id) => !coldAgents.has(id)).map(stopFailClosed)
         // stopHost is the hard deadline backstop, but closing the store underneath an

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -5,6 +5,7 @@ import type { TurnPlan } from './turn-plan.js'
 import type { TurnEvaluationReporter } from './turn-evaluation.js'
 import type { KeyGrant } from '../key-server/client.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
+import type { ApprovalWait } from '../permissions/coordinator.js'
 import type { GithubTurnState } from '../platforms/github/turn-output.js'
 import type { ModelProviderTarget } from '../runtimes/model-provider-config.js'
 import type { TranscriptRecorder } from '../session/transcript-recorder.js'
@@ -398,8 +399,102 @@ export function turnState<S extends object>(p: Pending): S {
   return (p.turnState ??= {} as S) as S
 }
 
-/** Per-in-flight-turn rendering state, keyed by ACP sessionId in `this.pending`. */
+/** The in-place platform chrome anchors a turn edits rather than re-posts. Each `*Ts` is the
+ *  message id of a single row, and its `*Attempted` sibling records that the first post was
+ *  tried so a failed post cannot spam a duplicate on the next action. */
+export interface TurnChromeCursors {
+  /** ts of the single in-place "main progress" message, once posted (medium/high). */
+  progressTs?: string
+  /** Whether the progress message's first post was attempted. */
+  progressAttempted?: boolean
+  /** ts of the single in-place plan-summary message, once posted (medium/high). */
+  planTs?: string
+  planAttempted?: boolean
+  /** ts of the single in-place reasoning "context block" message, once posted (high). */
+  reasoningTs?: string
+  reasoningAttempted?: boolean
+  /** ts of the single in-place agent reply message (minimal mode's `live-reply`), once posted. */
+  liveReplyTs?: string
+  liveReplyAttempted?: boolean
+  /** Text last written to the live-reply message — skip a chat.update when unchanged. */
+  liveReplyText?: string
+  /** Set after an interactive card that needs a human answer (permission / elicitation) is
+   *  posted: the current live reply is now ABOVE that card, so the NEXT live-reply action
+   *  starts a FRESH reply BELOW the card (leaving the old one frozen above) instead of
+   *  editing the one above in place. Consumed lazily by the next live-reply so an empty tail
+   *  keeps the old message (and its settled footer). */
+  liveReplyReanchor?: boolean
+  /** ts of the session's interactive status-bar message, once known. Persisted in the
+   *  session row so later turns update the first line instead of posting duplicates. */
+  statusBarTs?: string
+  statusBarAttempted?: boolean
+  /** Dedup key for the last status snapshot + cancel availability emitted this turn, so
+   *  a `usage_update` that changes nothing observable skips a redundant edit. */
+  lastStatusBar?: string
+  /** Whether the Slack status controls may still interrupt this turn. Cleared as soon as
+   *  cancellation starts or terminal cleanup begins, then included in the dedup key so
+   *  the persisted status row drops its stale Cancel run option. */
+  statusCancellable: boolean
+}
+
+/** What one turn has said so far: the raw stream, the generation-local attempt held behind
+ *  the context fence, and the pointers to what is actually posted. */
+export interface ReplyAccumulator {
+  /** Complete raw assistant text, used only as input to opt-in memory distillation. */
+  text: string
+  /** IM answer text is generation-local until the final context fence accepts it. */
+  attemptText: string
+  /** Answer-bearing ACP updates withheld from the platform converger until commit. */
+  attemptAnswerUpdates: any[]
+  /** Current successfully-delivered agent reply message. `footerKey` records which footer
+   *  it owns; progress/tool/reasoning chrome never replaces this pointer. */
+  lastReply?: { ts: string; text: string; footerKey?: string }
+  /** The LAST agent-authored conversational message posted this turn, with the exact
+   *  text it currently shows — the message turn finalization re-stamps as
+   *  `delivery_state: 'final'` (§5.5). The text is carried because chat.update REPLACES
+   *  content, so closing the response means re-sending what is already displayed.
+   *  Undefined when the turn posted no conversational body (chrome-only, `none` mode, or
+   *  a headless turn): there is then no response event to close. */
+  lastResponse?: { ts: string; text: string }
+  /** send-message-routing-rework.md §5.1: the id of the ONE complete logical response
+   *  this turn produces. Every physical message of a long answer carries it, so a peer
+   *  deduplicates on (responseId, target agent) and activates exactly once even when the
+   *  answer was split across several Slack messages. Minted per turn, never per post. */
+  responseId: string
+}
+
+/** The turn's completion machinery: what settles it, what defers it, and the once-only
+ *  latches that keep its terminal reporting from firing twice. */
+export interface TurnSignals {
+  /** Resolves when this turn leaves `pending` (success or failure) — drain awaits it. */
+  done: Promise<void>
+  /** Settles `done`; called once from dispatch's finally. */
+  resolveDone: () => void
+  /** Pending idle-flush timer (§9.1). */
+  idleTimer?: NodeJS.Timeout
+  /** Serializes applyAction so in-place edits don't race on the chrome cursors. */
+  applyChain: Promise<void>
+  /** True once the normal turn-end usage/report has been emitted. */
+  usageReportSent: boolean
+  /** Whether this turn received an ACP-native cost. When true, it wins and the
+   *  public-pricing fallback must not add another amount for the same turn. */
+  runtimeCostReported: boolean
+}
+
+/** Per-in-flight-turn rendering state, keyed by ACP sessionId in `this.pending`.
+ *
+ *  Everything a turn DECIDED before it ran lives on the readonly `plan` and is read
+ *  through it; the mutable rest is grouped by who writes it — platform chrome cursors,
+ *  reply accumulation, the approval-wait meter (permissions/), and completion signals. */
 export interface Pending {
+  /** The pure decisions this turn was planned with — its identity, coordinates, output
+   *  mode, and surface. Readonly by construction: nothing here is turn state. */
+  readonly plan: TurnPlan
+  chrome: TurnChromeCursors
+  reply: ReplyAccumulator
+  /** Explicit human-approval wait meter (permissions/coordinator owns every write). */
+  approval: ApprovalWait
+  signals: TurnSignals
   /** Admitted-turn lifecycle owner. Backstops and finalization share its cleanup
    * failure latch so one rejected stop cannot be logged or fenced twice. */
   entry: QueueEntry
@@ -409,22 +504,6 @@ export interface Pending {
   /** Captures the full activity log (tool/reasoning) from the raw ACP stream,
    *  independent of output mode. Text/result rows are recorded at send time. */
   rec: TranscriptRecorder
-  /** Complete raw assistant text, used only as input to opt-in memory distillation. */
-  replyText: string
-  /** IM answer text is generation-local until the final context fence accepts it. */
-  attemptReplyText: string
-  /** Answer-bearing ACP updates withheld from the platform converger until commit. */
-  attemptAnswerUpdates: any[]
-  /** Interactive IM platforms use staged answer delivery; webchat/hooks keep their
-   * existing transport-specific contracts and remain outside the initial rollout. */
-  stageAnswer: boolean
-  /** Turn-final context refresh for webchat conversations (webchat-multi-agents.md
-   * §5.4): the browser stream stays LIVE (no answer staging) — only the canonical
-   * post commit (reply record + rd/webchat-post) is fenced. Invalidation comes
-   * from conversation posts other participants produced (relay `context` ops
-   * recorded into the shared transcript); a single-agent conversation receives
-   * none, so the check is inert there. */
-  webchatRefresh: boolean
   /** Tool-call ids structurally identified as this daemon's own MCP tools. Approval
    *  requests may carry only this opaque id, regardless of which ACP path is used. */
   builtinSystemToolCallIds: Set<string>
@@ -432,27 +511,6 @@ export interface Pending {
    *  session metadata, but housekeeping must not appear in platform/webchat output
    *  or the persisted user-visible activity log. */
   hiddenSessionTitleToolCallIds: Set<string>
-  /** Agent that owns this turn — the sender stamped on its recorded reply rows. */
-  agentId: string
-  /** Human-readable AgentConnect agent name captured for this turn's Slack channel authorship. */
-  agentName: string
-  /** Trusted sender id for the message that started this turn. Approval audit rows use
-   *  this actor, not the session's historical first trigger. */
-  requesterId?: string
-  /** Exact integration that owns the reply path. HTTP Slack turns encode it into the
-   *  status controls so the relay can route each button to the right owner. */
-  integrationId?: string
-  /** Public avatar URL for this turn's Slack channel messages (icon_url), if the CP resolved one. */
-  iconUrl?: string
-  /** Source platform (for building the protocol SessionKey on drain release). */
-  platform: string
-  /** Whether the source conversation is a direct message. Slack thread titles are
-   *  valid only for Agents-feature app threads, which live in the app DM. */
-  isDm: boolean
-  /** Durable loop-breaker scope captured from the original event shape. */
-  loopGuardScope: string
-  /** Local session key (platform:channel:thread:agentId[:transportScope]) — for state writes. */
-  sessionKey: string
   /** The live ACP session id for this turn (part of the `this.pending` map key) — surfaced
    *  in the status bar so the console can deep-link to the session detail page. */
   acpSessionId: string
@@ -461,13 +519,6 @@ export interface Pending {
   /** Once an operator pause or loop trip targets this turn, no subsequent ACP update
    *  or queued renderer action may publish output, even if the gate is later reset. */
   outputSuppressed?: TurnInterruptReason
-  channel: string
-  /** Internal transcript namespace for this physical bot connection. */
-  transcriptChannel: string
-  /** thread_ts for body posts (undefined for a top-level message). */
-  thread?: string
-  /** thread_ts for the assistant status bar (always set; falls back to msgId). */
-  statusThread: string
   /** P3 outbound: the final-answer selector + completed comment on the triggering
    *  GitHub issue/PR. Commentary stays transcript-local; final is awaited at turn end.
    *  For a headless hook, explicit final chunks are withheld from OutputConverger and
@@ -478,99 +529,9 @@ export interface Pending {
    *  read only by that surface (see {@link turnState}). Core carries the slot and
    *  never inspects it — the reason platform-shaped fields stopped accreting here. */
   turnState?: unknown
-  /** True when `none` output mode removed this turn's interactive permission surface — see
-   *  {@link noneSuppressedApprovalSurface}. Snapshotted at dispatch ALONGSIDE `conn`; the
-   *  permission policy still queues the request for an Agent editor, but never exposes a
-   *  chat-side approval card. Frozen for the turn, so a mid-turn `none → low` change can't
-   *  desync it from the connection it was derived from. */
-  approvalSurfaceSuppressed: boolean
-  /** Union of explicit human-approval wait intervals for this turn. Regeneration
-   * budgets subtract these intervals while retaining runtime/tool work time. */
-  approvalWaitMs: number
-  approvalWaitDepth: number
-  approvalWaitStartedAt?: number
-  /** ts of the single in-place "main progress" message, once posted (medium/high). */
-  progressTs?: string
-  /** Whether the progress message's first post was attempted (so a failed initial
-   *  post does not spam a duplicate on the next progress action). */
-  progressAttempted?: boolean
-  /** ts of the single in-place plan-summary message, once posted (medium/high). */
-  planTs?: string
-  /** Whether the plan message's first post was attempted (see progressAttempted). */
-  planAttempted?: boolean
-  /** ts of the single in-place reasoning "context block" message, once posted (high). */
-  reasoningTs?: string
-  /** Whether the reasoning message's first post was attempted (see progressAttempted). */
-  reasoningAttempted?: boolean
-  /** Telegram: the id and exact sent text of the LAST body message posted this turn, so a
-   *  turn-end `continue-hint` action can append the continue-the-topic line to it in place
-   *  (the body may have been flushed long before the turn ended). */
-  /** ts of the single in-place agent reply message (minimal mode's `live-reply`), once posted. */
-  liveReplyTs?: string
-  /** Whether the live-reply's first post was attempted (see progressAttempted). */
-  liveReplyAttempted?: boolean
-  /** Text last written to the live-reply message — skip a chat.update when unchanged. */
-  liveReplyText?: string
-  /** Set after an interactive card that needs a human answer (permission / elicitation) is
-   *  posted: the current live reply is now ABOVE that card, so the NEXT live-reply action
-   *  starts a FRESH reply BELOW the card (leaving the old one frozen above) instead of
-   *  editing the one above in place. Consumed lazily by the next live-reply so an empty tail
-   *  keeps the old message (and its settled footer). */
-  liveReplyReanchor?: boolean
   /** Linked footer prepared before the runtime starts streaming. Every reply section is
    *  initially posted with these trailing blocks so Slack can suppress unfurls. */
   attribution?: { blocks: unknown[]; key: string }
-  /** Current successfully-delivered agent reply message. `footerKey` records which footer
-   *  it owns; progress/tool/reasoning chrome never replaces this pointer. */
-  lastReply?: { ts: string; text: string; footerKey?: string }
-  /** send-message-routing-rework.md §5.1: the id of the ONE complete logical response
-   *  this turn produces. Every physical message of a long answer carries it, so a peer
-   *  deduplicates on (responseId, target agent) and activates exactly once even when the
-   *  answer was split across several Slack messages. Minted per turn, never per post. */
-  responseId: string
-  /** The LAST agent-authored conversational message posted this turn, with the exact
-   *  text it currently shows — the message turn finalization re-stamps as
-   *  `delivery_state: 'final'` (§5.5). The text is carried because chat.update REPLACES
-   *  content, so closing the response means re-sending what is already displayed.
-   *  Undefined when the turn posted no conversational body (chrome-only, `none` mode, or
-   *  a headless turn): there is then no response event to close. */
-  lastResponse?: { ts: string; text: string }
-  /** send-message-routing-rework.md §4.1: this turn's own trusted depth, stamped on every
-   *  body it posts so the NEXT routing edge advances from it. A human/root turn is 0. */
-  sourceHopCount: number
-  /** §5.3: compound shared-bot addresses this conversation can contain, which the
-   *  splitter must never cut in half. Empty off Slack, or with no collaboration snapshot. */
-  protectedAddresses: readonly string[]
-  /** ts of the session's interactive status-bar message, once known. Persisted in the
-   *  session row so later turns update the first line instead of posting duplicates. */
-  statusBarTs?: string
-  /** Agent-level Slack status-row preference, snapshotted for this turn alongside output
-   *  mode/footer settings so a hot config edit takes effect cleanly on the next turn. */
-  showStatusBar: boolean
-  /** Whether the status bar's first post was attempted (see progressAttempted). */
-  statusBarAttempted?: boolean
-  /** Dedup key for the last status snapshot + cancel availability emitted this turn, so
-   *  a `usage_update` that changes nothing observable skips a redundant edit. */
-  lastStatusBar?: string
-  /** Whether the Slack status controls may still interrupt this turn. Cleared as soon as
-   *  cancellation starts or terminal cleanup begins, then included in the dedup key so
-   *  the persisted status row drops its stale Cancel run option. */
-  statusCancellable: boolean
-  /** Whether this turn received an ACP-native cost. When true, it wins and the
-   *  public-pricing fallback must not add another amount for the same turn. */
-  runtimeCostReported: boolean
-  /** True once the normal turn-end usage/report has been emitted. */
-  usageReportSent: boolean
-  /** Stable semantic turn id used by evaluation events (never shown to the model). */
-  evaluationTurnId: string
-  /** Pending idle-flush timer (§9.1). */
-  idleTimer?: NodeJS.Timeout
-  /** Serializes applyAction so in-place edits don't race on progressTs/planTs/reasoningTs. */
-  applyChain: Promise<void>
-  /** Resolves when this turn leaves `pending` (success or failure) — drain awaits it. */
-  done: Promise<void>
-  /** Settles `done`; called once from dispatch's finally. */
-  resolveDone: () => void
   /**
    * DAEMON-PRIVATE trusted call metadata for an agent→agent turn (design §3.3a/§6.6/§6.7).
    * Present iff this turn was started by `messageAgent`. Holds the AUTHORITATIVE caller
@@ -615,8 +576,9 @@ export interface SessionDeliveryBinding {
  *  a channel-root message), NOT `statusThread` (which falls back to msgId): the CP
  *  keys assignments by `thread ?? "-"`, so reporting the msgId would miss the match. */
 export function pendingSessionKey(p: Pending): SessionKey {
-  const platform = p.platform as SessionKey['platform']
-  return p.thread !== undefined ? { platform, channel: p.channel, thread: p.thread } : { platform, channel: p.channel }
+  const { platform: rawPlatform, channel, thread } = p.plan
+  const platform = rawPlatform as SessionKey['platform']
+  return thread !== undefined ? { platform, channel, thread } : { platform, channel }
 }
 
 /** One shutdown duty drain: its bound, its counters, and the grants that landed after the latch. */

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -36,6 +36,15 @@ import {
 } from '../daemon/tool-classification.js'
 import { pendingTurnKey, type DaemonRenderAction, type Pending } from '../daemon/turn-types.js'
 
+/** The union of a turn's explicit human-approval waits, measured here and nowhere else.
+ *  Regeneration budgets subtract it while retaining runtime/tool work time; `depth` counts
+ *  overlapping requests so the union is measured once, and `startedAt` marks the open interval. */
+export interface ApprovalWait {
+  waitMs: number
+  depth: number
+  startedAt?: number
+}
+
 /** Process-wide daemon state the permission path reads. */
 export interface PermissionCoreHost {
   log(): Logger
@@ -57,7 +66,7 @@ export interface PermissionSurfaceHost {
     p: Pending,
     post: (conn: SlackConnection) => Promise<string | undefined>
   ): Promise<string | undefined>
-  httpSlackSessionTarget(p: Pick<Pending, 'agentId' | 'integrationId' | 'sessionKey'>): string | undefined
+  httpSlackSessionTarget(p: Pick<Pending, 'plan'>): string | undefined
   maskAgentSecrets<T>(agentId: string, payload: T): T
   logSessionAction(verb: string, sessionKey: string, actor?: InteractionActor): void
 }
@@ -136,7 +145,7 @@ export class PermissionCoordinator {
   ): Promise<void> {
     const store = this.host.store()
     const session = await store.getSessionByAcpIdForAgent(agentId, sessionId)
-    const requesterId = p.requesterId ?? session?.triggeredBy ?? null
+    const requesterId = p.plan.requesterId ?? session?.triggeredBy ?? null
     const requesterName = requesterId ? ((await store.getDisplayNames([requesterId])).get(requesterId) ?? null) : null
     await store.createPermissionRequest({
       id,
@@ -168,7 +177,7 @@ export class PermissionCoordinator {
     } catch (err) {
       // The durable editor request is authoritative. A best-effort chat notice
       // must never discard the live resolver or silently fall back to auto-allow.
-      this.host.log().warn(`permission request notice failed for "${p.sessionKey}": ${formatErr(err)}`)
+      this.host.log().warn(`permission request notice failed for "${p.plan.sessionKey}": ${formatErr(err)}`)
     }
   }
 
@@ -191,17 +200,16 @@ export class PermissionCoordinator {
   /** Exclude only explicit human decision latency from regeneration wall time.
    * A depth counter measures the union of overlapping approval intervals. */
   private async trackHumanApprovalWait<T>(p: Pending, result: Promise<T>): Promise<T> {
-    p.approvalWaitDepth ??= 0
-    p.approvalWaitMs ??= 0
-    if (p.approvalWaitDepth === 0) p.approvalWaitStartedAt = this.host.clock().now()
-    p.approvalWaitDepth += 1
+    const a = p.approval
+    if (a.depth === 0) a.startedAt = this.host.clock().now()
+    a.depth += 1
     try {
       return await result
     } finally {
-      p.approvalWaitDepth = Math.max(0, p.approvalWaitDepth - 1)
-      if (p.approvalWaitDepth === 0 && p.approvalWaitStartedAt !== undefined) {
-        p.approvalWaitMs += Math.max(0, this.host.clock().now() - p.approvalWaitStartedAt)
-        delete p.approvalWaitStartedAt
+      a.depth = Math.max(0, a.depth - 1)
+      if (a.depth === 0 && a.startedAt !== undefined) {
+        a.waitMs += Math.max(0, this.host.clock().now() - a.startedAt)
+        delete a.startedAt
       }
     }
   }
@@ -292,7 +300,7 @@ export class PermissionCoordinator {
       params,
       evaluationParams,
       conn,
-      channel: p.channel,
+      channel: p.plan.channel,
       resolve: resolveResult
     })
     const recorded = this.noteEditorPermissionRequest(
@@ -317,8 +325,8 @@ export class PermissionCoordinator {
     const blocks = buildPermissionCard(requestId, params, this.host.httpSlackSessionTarget(p))
     const fallback = `Permission requested: ${params.toolCall?.title ?? 'a tool call'}`
     const ts = await this.host.postCardSerialized(p, (slack) =>
-      slack.postBlocks(p.channel, blocks, fallback, p.statusThread, {
-        ...(slackPostOptions(p) ?? {}),
+      slack.postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
+        ...(slackPostOptions(p.plan) ?? {}),
         chrome: true
       })
     )
@@ -327,7 +335,7 @@ export class PermissionCoordinator {
       if (ts) {
         void conn
           .updateBlocks(
-            p.channel,
+            p.plan.channel,
             ts,
             buildPermissionResolvedCard(params, 'Cancelled', undefined),
             'Permission cancelled',
@@ -579,7 +587,7 @@ export class PermissionCoordinator {
     const context = {
       agentId,
       sessionId,
-      ...(pending?.evaluationTurnId ? { turnId: pending.evaluationTurnId } : {})
+      ...(pending?.plan.evaluationTurnId ? { turnId: pending.plan.evaluationTurnId } : {})
     }
     const toolCallId = typeof params.toolCall?.toolCallId === 'string' ? params.toolCall.toolCallId : undefined
     if (event.kind === 'requested') {
@@ -666,7 +674,7 @@ export class PermissionCoordinator {
           type: 'permission.auto_allowed',
           agentId,
           sessionId,
-          ...(p?.evaluationTurnId ? { turnId: p.evaluationTurnId } : {}),
+          ...(p?.plan.evaluationTurnId ? { turnId: p.plan.evaluationTurnId } : {}),
           data: { reason: 'agentconnect_system_tool', optionId: allow.optionId }
         })
         return { outcome: { outcome: 'selected', optionId: allow.optionId } }
@@ -680,9 +688,9 @@ export class PermissionCoordinator {
     }
     const chatApprovalEnabled =
       this.host.agents().get(agentId)?.allowRuntimeChangesInChat === true &&
-      turnChromeFor(p.platform).chatInputCards === true &&
+      turnChromeFor(p.plan.platform).chatInputCards === true &&
       p.conn instanceof SlackConnection &&
-      !p.approvalSurfaceSuppressed &&
+      !p.plan.approvalSurfaceSuppressed &&
       params.options.length > 0
     if (chatApprovalEnabled) {
       return await this.awaitChatPermission(agentId, sessionId, params, evaluationParams, p)
@@ -718,15 +726,15 @@ export class PermissionCoordinator {
     if (isApproval) {
       const chatApprovalEnabled =
         this.host.agents().get(agentId)?.allowRuntimeChangesInChat === true &&
-        turnChromeFor(p.platform).chatInputCards === true &&
+        turnChromeFor(p.plan.platform).chatInputCards === true &&
         p.conn instanceof SlackConnection &&
-        !p.approvalSurfaceSuppressed
+        !p.plan.approvalSurfaceSuppressed
       if (!chatApprovalEnabled) return await this.awaitEditorElicitation(agentId, sessionId, params, p)
     }
     // A `none` Slack turn has no generic human-input card to answer this request.
-    if (p.approvalSurfaceSuppressed) return { action: 'cancel' }
+    if (p.plan.approvalSurfaceSuppressed) return { action: 'cancel' }
     const conn = p.conn
-    if (!turnChromeFor(p.platform).chatInputCards || !(conn instanceof SlackConnection)) return undefined
+    if (!turnChromeFor(p.plan.platform).chatInputCards || !(conn instanceof SlackConnection)) return undefined
     const target = elicitTarget(params)
     if (!target) return undefined
     const requestId = isApproval ? randomUUID() : `elicit-${++this.elicitSeq}`
@@ -743,7 +751,7 @@ export class PermissionCoordinator {
       kind: target.kind,
       approval: isApproval,
       conn,
-      channel: p.channel,
+      channel: p.plan.channel,
       resolve: resolveResult
     })
     if (isApproval) {
@@ -767,8 +775,8 @@ export class PermissionCoordinator {
       if (!this.pendingElicits.has(requestId)) return await result
     }
     const ts = await this.host.postCardSerialized(p, (sc) =>
-      sc.postBlocks(p.channel, blocks, fallback, p.statusThread, {
-        ...(slackPostOptions(p) ?? {}),
+      sc.postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
+        ...(slackPostOptions(p.plan) ?? {}),
         chrome: true
       })
     )
@@ -776,7 +784,13 @@ export class PermissionCoordinator {
     if (!live) {
       if (ts)
         void conn
-          .updateBlocks(p.channel, ts, buildElicitationResolvedCard(params, ':hourglass: Cancelled'), 'Cancelled', true)
+          .updateBlocks(
+            p.plan.channel,
+            ts,
+            buildElicitationResolvedCard(params, ':hourglass: Cancelled'),
+            'Cancelled',
+            true
+          )
           .catch(() => {})
       return await result
     }

--- a/packages/daemon/src/platforms/discord/turn-output.ts
+++ b/packages/daemon/src/platforms/discord/turn-output.ts
@@ -20,23 +20,27 @@ import type { DiscordAction } from '../../discord/render.js'
  *  nothing more. `Pending` satisfies this structurally. */
 export interface DiscordTurn {
   conn?: unknown
-  channel: string
-  thread?: string
-  statusThread: string
-  transcriptChannel: string
-  agentId: string
-  sessionKey: string
-  progressTs?: string
-  progressAttempted?: boolean
-  planTs?: string
-  planAttempted?: boolean
-  reasoningTs?: string
-  reasoningAttempted?: boolean
-  statusBarTs?: string
-  statusBarAttempted?: boolean
-  liveReplyTs?: string
-  liveReplyText?: string
-  liveReplyAttempted?: boolean
+  plan: {
+    channel: string
+    thread?: string
+    statusThread: string
+    transcriptChannel: string
+    agentId: string
+    sessionKey: string
+  }
+  chrome: {
+    progressTs?: string
+    progressAttempted?: boolean
+    planTs?: string
+    planAttempted?: boolean
+    reasoningTs?: string
+    reasoningAttempted?: boolean
+    statusBarTs?: string
+    statusBarAttempted?: boolean
+    liveReplyTs?: string
+    liveReplyText?: string
+    liveReplyAttempted?: boolean
+  }
 }
 
 /** The host capabilities this applier needs — the same two Telegram's does. */
@@ -71,15 +75,15 @@ export async function applyDiscordAction<TTurn extends DiscordTurn>(
   if (!conn) return
   switch (action.kind) {
     case 'typing':
-      await conn.sendChatAction(turn.channel, turn.thread)
+      await conn.sendChatAction(turn.plan.channel, turn.plan.thread)
       return
     case 'post': {
-      const id = await conn.postMessage(turn.channel, action.text, turn.thread)
+      const id = await conn.postMessage(turn.plan.channel, action.text, turn.plan.thread)
       await host.appendTranscript({
-        channel: turn.transcriptChannel,
-        thread: turn.statusThread,
+        channel: turn.plan.transcriptChannel,
+        thread: turn.plan.statusThread,
         ts: id ?? `local-${Date.now()}`,
-        sender: turn.agentId,
+        sender: turn.plan.agentId,
         kind: 'text',
         text: action.text
       })
@@ -88,13 +92,15 @@ export async function applyDiscordAction<TTurn extends DiscordTurn>(
     case 'live-reply': {
       // minimal mode's single agent reply: send once then edit in place as the turn
       // streams. Skip an update when unchanged; not recorded (the `recordOnly` posts do).
-      if (turn.liveReplyText === action.text) return
-      turn.liveReplyText = action.text
-      if (turn.liveReplyTs)
-        await conn.updateMessage(turn.channel, turn.liveReplyTs, action.text, { threadTs: turn.thread })
-      else if (!turn.liveReplyAttempted) {
-        turn.liveReplyAttempted = true
-        turn.liveReplyTs = await conn.postMessage(turn.channel, action.text, turn.thread)
+      if (turn.chrome.liveReplyText === action.text) return
+      turn.chrome.liveReplyText = action.text
+      if (turn.chrome.liveReplyTs)
+        await conn.updateMessage(turn.plan.channel, turn.chrome.liveReplyTs, action.text, {
+          threadTs: turn.plan.thread
+        })
+      else if (!turn.chrome.liveReplyAttempted) {
+        turn.chrome.liveReplyAttempted = true
+        turn.chrome.liveReplyTs = await conn.postMessage(turn.plan.channel, action.text, turn.plan.thread)
       }
       return
     }
@@ -102,45 +108,48 @@ export async function applyDiscordAction<TTurn extends DiscordTurn>(
     case 'tool-output':
       // Posted to the channel but NOT recorded — the done footer is chrome, and tool
       // output is captured independently by the recorder.
-      await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      await conn.postChrome(turn.plan.channel, action.text, { threadTs: turn.plan.thread })
       return
     case 'progress':
-      if (turn.progressTs)
-        await conn.updateMessage(turn.channel, turn.progressTs, action.text, { threadTs: turn.thread })
-      else if (!turn.progressAttempted) {
-        turn.progressAttempted = true
-        turn.progressTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      if (turn.chrome.progressTs)
+        await conn.updateMessage(turn.plan.channel, turn.chrome.progressTs, action.text, { threadTs: turn.plan.thread })
+      else if (!turn.chrome.progressAttempted) {
+        turn.chrome.progressAttempted = true
+        turn.chrome.progressTs = await conn.postChrome(turn.plan.channel, action.text, { threadTs: turn.plan.thread })
       }
       return
     case 'plan':
-      if (turn.planTs) await conn.updateMessage(turn.channel, turn.planTs, action.text, { threadTs: turn.thread })
-      else if (!turn.planAttempted) {
-        turn.planAttempted = true
-        turn.planTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      if (turn.chrome.planTs)
+        await conn.updateMessage(turn.plan.channel, turn.chrome.planTs, action.text, { threadTs: turn.plan.thread })
+      else if (!turn.chrome.planAttempted) {
+        turn.chrome.planAttempted = true
+        turn.chrome.planTs = await conn.postChrome(turn.plan.channel, action.text, { threadTs: turn.plan.thread })
       }
       return
     case 'reasoning':
-      if (turn.reasoningTs)
-        await conn.updateMessage(turn.channel, turn.reasoningTs, action.text, { threadTs: turn.thread })
-      else if (!turn.reasoningAttempted) {
-        turn.reasoningAttempted = true
-        turn.reasoningTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      if (turn.chrome.reasoningTs)
+        await conn.updateMessage(turn.plan.channel, turn.chrome.reasoningTs, action.text, {
+          threadTs: turn.plan.thread
+        })
+      else if (!turn.chrome.reasoningAttempted) {
+        turn.chrome.reasoningAttempted = true
+        turn.chrome.reasoningTs = await conn.postChrome(turn.plan.channel, action.text, { threadTs: turn.plan.thread })
       }
       return
     case 'status-bar':
       // Per-turn status line + button row: post once (registering the message →
       // sessionKey so its button interactions resolve), then edit in place.
-      if (turn.statusBarTs)
-        await conn.updateMessage(turn.channel, turn.statusBarTs, action.text, {
-          threadTs: turn.thread,
+      if (turn.chrome.statusBarTs)
+        await conn.updateMessage(turn.plan.channel, turn.chrome.statusBarTs, action.text, {
+          threadTs: turn.plan.thread,
           keyboard: action.keyboard
         })
-      else if (!turn.statusBarAttempted) {
-        turn.statusBarAttempted = true
-        turn.statusBarTs = await conn.postChrome(turn.channel, action.text, {
-          threadTs: turn.thread,
+      else if (!turn.chrome.statusBarAttempted) {
+        turn.chrome.statusBarAttempted = true
+        turn.chrome.statusBarTs = await conn.postChrome(turn.plan.channel, action.text, {
+          threadTs: turn.plan.thread,
           keyboard: action.keyboard,
-          sessionKey: turn.sessionKey
+          sessionKey: turn.plan.sessionKey
         })
       }
       return

--- a/packages/daemon/src/platforms/feishu/turn-output.ts
+++ b/packages/daemon/src/platforms/feishu/turn-output.ts
@@ -32,21 +32,25 @@ export interface FeishuTurnState {
 /** The core turn, as Feishu's applier sees it. `Pending` satisfies it structurally. */
 export interface FeishuTurn {
   conn?: unknown
-  channel: string
-  thread?: string
-  statusThread: string
-  transcriptChannel: string
-  agentId: string
-  sessionKey: string
   acpSessionId: string
-  platform: string
-  integrationId?: string
-  progressTs?: string
-  progressAttempted?: boolean
-  planTs?: string
-  planAttempted?: boolean
-  reasoningTs?: string
-  reasoningAttempted?: boolean
+  plan: {
+    channel: string
+    thread?: string
+    statusThread: string
+    transcriptChannel: string
+    agentId: string
+    sessionKey: string
+    platform: string
+    integrationId?: string
+  }
+  chrome: {
+    progressTs?: string
+    progressAttempted?: boolean
+    planTs?: string
+    planAttempted?: boolean
+    reasoningTs?: string
+    reasoningAttempted?: boolean
+  }
 }
 
 /** The host capabilities this applier needs: the two every platform needs, plus
@@ -86,41 +90,41 @@ export async function applyFeishuAction<TTurn extends FeishuTurn>(
     case 'card-start':
       if (state.cardAttempted) return
       state.cardAttempted = true
-      state.card = await conn.startStreamingCard(turn.channel, turn.thread, {
-        sessionKey: turn.sessionKey,
+      state.card = await conn.startStreamingCard(turn.plan.channel, turn.plan.thread, {
+        sessionKey: turn.plan.sessionKey,
         sessionUrl: host.sessionUrl(turn),
-        ...(turn.integrationId
-          ? { target: { v: 1, agentId: turn.agentId, integrationId: turn.integrationId } as const }
+        ...(turn.plan.integrationId
+          ? { target: { v: 1, agentId: turn.plan.agentId, integrationId: turn.plan.integrationId } as const }
           : {})
       })
       return
     case 'card-stream':
-      if (state.card) await conn.updateStreamingCard(turn.channel, state.card, action.text)
+      if (state.card) await conn.updateStreamingCard(turn.plan.channel, state.card, action.text)
       return
     case 'card-final': {
       if (state.card) {
-        const delivered = await conn.finishStreamingCard(turn.channel, state.card, action.text, action.attribution)
+        const delivered = await conn.finishStreamingCard(turn.plan.channel, state.card, action.text, action.attribution)
         if (delivered) return
         // A final CardKit update failure must not lose the answer. Remove the stale
         // partial card where possible, then fall back to ordinary text.
-        await conn.cancelStreamingCard(turn.channel, state.card)
+        await conn.cancelStreamingCard(turn.plan.channel, state.card)
       }
-      await conn.postMessage(turn.channel, action.text, turn.thread)
+      await conn.postMessage(turn.plan.channel, action.text, turn.plan.thread)
       return
     }
     case 'card-cancel':
-      if (state.card) await conn.cancelStreamingCard(turn.channel, state.card)
+      if (state.card) await conn.cancelStreamingCard(turn.plan.channel, state.card)
       return
     case 'typing':
-      await conn.sendChatAction(turn.channel)
+      await conn.sendChatAction(turn.plan.channel)
       return
     case 'post': {
-      const id = await conn.postMessage(turn.channel, action.text, turn.thread)
+      const id = await conn.postMessage(turn.plan.channel, action.text, turn.plan.thread)
       await host.appendTranscript({
-        channel: turn.transcriptChannel,
-        thread: turn.statusThread,
+        channel: turn.plan.transcriptChannel,
+        thread: turn.plan.statusThread,
         ts: id ?? `local-${Date.now()}`,
-        sender: turn.agentId,
+        sender: turn.plan.agentId,
         kind: 'text',
         text: action.text
       })
@@ -130,27 +134,27 @@ export async function applyFeishuAction<TTurn extends FeishuTurn>(
     case 'tool-output':
       // Posted to the chat but NOT recorded — the done footer is chrome, and tool
       // output is captured independently by the recorder.
-      await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      await conn.postChrome(turn.plan.channel, action.text, { threadTs: turn.plan.thread })
       return
     case 'progress':
-      if (turn.progressTs) await conn.updateMessage(turn.channel, turn.progressTs, action.text)
-      else if (!turn.progressAttempted) {
-        turn.progressAttempted = true
-        turn.progressTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      if (turn.chrome.progressTs) await conn.updateMessage(turn.plan.channel, turn.chrome.progressTs, action.text)
+      else if (!turn.chrome.progressAttempted) {
+        turn.chrome.progressAttempted = true
+        turn.chrome.progressTs = await conn.postChrome(turn.plan.channel, action.text, { threadTs: turn.plan.thread })
       }
       return
     case 'plan':
-      if (turn.planTs) await conn.updateMessage(turn.channel, turn.planTs, action.text)
-      else if (!turn.planAttempted) {
-        turn.planAttempted = true
-        turn.planTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      if (turn.chrome.planTs) await conn.updateMessage(turn.plan.channel, turn.chrome.planTs, action.text)
+      else if (!turn.chrome.planAttempted) {
+        turn.chrome.planAttempted = true
+        turn.chrome.planTs = await conn.postChrome(turn.plan.channel, action.text, { threadTs: turn.plan.thread })
       }
       return
     case 'reasoning':
-      if (turn.reasoningTs) await conn.updateMessage(turn.channel, turn.reasoningTs, action.text)
-      else if (!turn.reasoningAttempted) {
-        turn.reasoningAttempted = true
-        turn.reasoningTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      if (turn.chrome.reasoningTs) await conn.updateMessage(turn.plan.channel, turn.chrome.reasoningTs, action.text)
+      else if (!turn.chrome.reasoningAttempted) {
+        turn.chrome.reasoningAttempted = true
+        turn.chrome.reasoningTs = await conn.postChrome(turn.plan.channel, action.text, { threadTs: turn.plan.thread })
       }
       return
   }

--- a/packages/daemon/src/platforms/github/turn-output.ts
+++ b/packages/daemon/src/platforms/github/turn-output.ts
@@ -62,10 +62,12 @@ export interface GithubTurnState {
  *  structurally — a far smaller footprint than the chat surfaces need, because
  *  GitHub owns no anchors on the turn record. */
 export interface GithubTurn {
-  statusThread: string
-  transcriptChannel: string
-  agentId: string
-  platform: string
+  plan: {
+    statusThread: string
+    transcriptChannel: string
+    agentId: string
+    platform: string
+  }
 }
 
 /** The host capabilities this surface needs.
@@ -96,11 +98,11 @@ export interface GithubTurnHost {
  *  reach a platform before `publish()` makes the single public POST — so its
  *  transcript row is owed at turn end instead. */
 export function isGithubFinalChunk(
-  turn: Pick<GithubTurn, 'platform'>,
+  turn: { plan: Pick<GithubTurn['plan'], 'platform'> },
   update: { sessionUpdate?: unknown; _meta?: { codex?: { phase?: unknown } } } | undefined
 ): boolean {
   return (
-    turn.platform === 'hook' &&
+    turn.plan.platform === 'hook' &&
     update?.sessionUpdate === 'agent_message_chunk' &&
     update?._meta?.codex?.phase === 'final_answer'
   )
@@ -133,10 +135,10 @@ export async function finalizeGithubTurn<TTurn extends GithubTurn>(
   const final = !opts.suppressed && opts.atEnd ? state.collector.finalText(true) : undefined
   if (state.deferredFinalTranscript && final?.trim()) {
     await host.appendTranscript({
-      channel: turn.transcriptChannel,
-      thread: turn.statusThread,
+      channel: turn.plan.transcriptChannel,
+      thread: turn.plan.statusThread,
       ts: host.monotonicTs(),
-      sender: turn.agentId,
+      sender: turn.plan.agentId,
       kind: 'text',
       text: final
     })

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -24,14 +24,15 @@
  *    dependency points core → platform, which is the direction the design wants.
  *
  * WHAT DID NOT MOVE. `liveReplyTs` / `progressTs` / `statusBarTs` / `lastReply` /
- * `attribution` and their `*Attempted` flags stay on the core turn record.
- * They LOOK like Slack state, and eventually most of them belong in the opaque
- * slot beside `staleReplyFooters` — but core reads them today from suppression,
- * re-anchoring, and human-input paths (`attribution` alone has 30+ readers). The
- * structural `SlackTurn` view below names that surface exactly, which is what
- * makes the follow-up a mechanical field migration instead of an archaeology
- * project. Moving them here in the same change would be the §16 failure mode:
- * relocating a body while silently redefining what it may reach.
+ * `attribution` and their `*Attempted` flags stay on the core turn record — now
+ * clustered there as `chrome` and `reply`. They LOOK like Slack state, and
+ * eventually most of them belong in the opaque slot beside `staleReplyFooters` —
+ * but core reads them today from suppression, re-anchoring, and human-input paths
+ * (`attribution` alone has 30+ readers). The structural `SlackTurn` view below
+ * names that surface exactly, which is what makes the follow-up a mechanical
+ * field migration instead of an archaeology project. Moving them here in the same
+ * change would be the §16 failure mode: relocating a body while silently
+ * redefining what it may reach.
  *
  * WEBCHAT / HOOK / DREAM still render through this applier — it is the registry's
  * CORE surface, not merely Slack's (§12). The `platform !== 'slack'` guards in the
@@ -58,6 +59,45 @@ export interface SlackTurnState {
  *  follow-up, not as the port Slack wants. */
 export interface SlackTurn {
   conn?: unknown
+  /** The turn's readonly decisions — its coordinates and identity. */
+  plan: SlackTurnPlan
+  /** The in-place message anchors this applier edits rather than re-posts. */
+  chrome: {
+    liveReplyTs?: string
+    liveReplyText?: string
+    liveReplyAttempted?: boolean
+    liveReplyReanchor?: boolean
+    progressTs?: string
+    progressAttempted?: boolean
+    planTs?: string
+    planAttempted?: boolean
+    reasoningTs?: string
+    reasoningAttempted?: boolean
+    statusBarTs?: string
+    statusBarAttempted?: boolean
+  }
+  /** What the turn has posted so far, and the id of the logical response it belongs to. */
+  reply: {
+    /** The message currently owning the footer. */
+    lastReply?: { ts: string; text: string; footerKey?: string }
+    /** send-message-routing-rework.md §5.1: the ONE logical response this turn produces.
+     *  Every physical message of a long answer carries it, so a peer deduplicates on
+     *  (responseId, target agent) and activates exactly once. */
+    responseId?: string
+    /** The LAST agent-authored body posted this turn, with the text it currently shows —
+     *  what finalization re-stamps as `delivery_state: 'final'` (§5.5). The text is carried
+     *  because chat.update REPLACES content, so closing the response means re-sending what
+     *  is already displayed. */
+    lastResponse?: { ts: string; text: string }
+  }
+  /** The turn's finalized attribution footer, and a key identifying its content so
+   *  a re-post can tell "same footer" from "footer changed". */
+  attribution?: { blocks: unknown[]; key: string }
+}
+
+/** The planned facts Slack's applier reads. The option builders take this alone, so a
+ *  non-turn caller (a failure notice) can supply the same four fields without a turn. */
+export interface SlackTurnPlan {
   channel: string
   thread?: string
   statusThread: string
@@ -68,32 +108,6 @@ export interface SlackTurn {
   sessionKey: string
   platform: string
   isDm: boolean
-  /** The turn's finalized attribution footer, and a key identifying its content so
-   *  a re-post can tell "same footer" from "footer changed". */
-  attribution?: { blocks: unknown[]; key: string }
-  /** The message currently owning the footer. */
-  lastReply?: { ts: string; text: string; footerKey?: string }
-  liveReplyTs?: string
-  liveReplyText?: string
-  liveReplyAttempted?: boolean
-  liveReplyReanchor?: boolean
-  progressTs?: string
-  progressAttempted?: boolean
-  planTs?: string
-  planAttempted?: boolean
-  reasoningTs?: string
-  reasoningAttempted?: boolean
-  statusBarTs?: string
-  statusBarAttempted?: boolean
-  /** send-message-routing-rework.md §5.1: the ONE logical response this turn produces.
-   *  Every physical message of a long answer carries it, so a peer deduplicates on
-   *  (responseId, target agent) and activates exactly once. */
-  responseId?: string
-  /** The LAST agent-authored body posted this turn, with the text it currently shows —
-   *  what finalization re-stamps as `delivery_state: 'final'` (§5.5). The text is carried
-   *  because chat.update REPLACES content, so closing the response means re-sending what
-   *  is already displayed. */
-  lastResponse?: { ts: string; text: string }
   /** The author's own trusted turn depth (§4.1). A human/root turn is 0; each routing
    *  edge adds one. Read-only here — the model can neither set nor reset it. */
   sourceHopCount?: number
@@ -132,7 +146,7 @@ export interface SlackTurnHost<TTurn> {
  *  only in channels. A DM is already a one-to-one surface, so overriding the
  *  author there would replace the bot's own identity for no gain. */
 export function slackPostOptions(
-  p: Pick<SlackTurn, 'platform' | 'isDm' | 'agentName' | 'iconUrl'>
+  p: Pick<SlackTurnPlan, 'platform' | 'isDm' | 'agentName' | 'iconUrl'>
 ): SlackPostOptions | undefined {
   if (p.platform !== 'slack' || p.isDm) return undefined
   return { username: p.agentName, ...(p.iconUrl ? { icon_url: p.iconUrl } : {}) }
@@ -142,7 +156,7 @@ export function slackPostOptions(
  *  conversational authorship because status/chrome rows must retain their chrome
  *  metadata marker instead of masquerading as transcript messages. */
 export function slackAgentIdentityOptions(
-  p: Pick<SlackTurn, 'platform' | 'agentName' | 'iconUrl'>
+  p: Pick<SlackTurnPlan, 'platform' | 'agentName' | 'iconUrl'>
 ): SlackPostOptions | undefined {
   if (p.platform !== 'slack') return undefined
   return { username: p.agentName, ...(p.iconUrl ? { icon_url: p.iconUrl } : {}) }
@@ -152,8 +166,8 @@ export function slackAgentIdentityOptions(
  *  Peer daemons use it during thread backfill, so shared/custom bot ids never replace
  *  the Agent's name and icon in the Console transcript. */
 export function slackAgentPostOptions(
-  p: Pick<SlackTurn, 'platform' | 'agentId' | 'agentName' | 'iconUrl'> &
-    Partial<Pick<SlackTurn, 'responseId' | 'sourceHopCount'>>
+  p: Pick<SlackTurnPlan, 'platform' | 'agentId' | 'agentName' | 'iconUrl'> &
+    Partial<Pick<SlackTurnPlan, 'sourceHopCount'>> & { responseId?: string }
 ): SlackPostOptions | undefined {
   const identity = slackAgentIdentityOptions(p)
   if (!identity) return undefined
@@ -219,21 +233,21 @@ export async function finalizeSlackResponse(
   addressedAnyone: boolean,
   debug: (message: string) => void
 ): Promise<void> {
-  const body = p.lastResponse
-  if (p.platform !== 'slack' || !body || !p.responseId) return
+  const body = p.reply.lastResponse
+  if (p.plan.platform !== 'slack' || !body || !p.reply.responseId) return
   // Duck-typed adaptor/test connections implement only the subset they need. Closing the
   // response is additive metadata, not delivery — a connection that cannot do it must not
   // fail the turn whose answer was already delivered.
   if (typeof conn.finalizeResponse !== 'function') return
   // Re-supply exactly what the message already shows: chat.update REPLACES content, and
   // the footer belongs to this message only while `lastReply` still points at it.
-  const ownsFooter = p.lastReply?.ts === body.ts && p.lastReply.footerKey !== undefined
+  const ownsFooter = p.reply.lastReply?.ts === body.ts && p.reply.lastReply.footerKey !== undefined
   const blocks = [{ type: 'markdown', text: body.text }, ...(ownsFooter && p.attribution ? p.attribution.blocks : [])]
   try {
-    await conn.finalizeResponse(p.channel, body.ts, blocks, body.text, p.agentId, {
-      responseId: p.responseId,
+    await conn.finalizeResponse(p.plan.channel, body.ts, blocks, body.text, p.plan.agentId, {
+      responseId: p.reply.responseId,
       deliveryState: 'final',
-      hopCount: p.sourceHopCount ?? 0,
+      hopCount: p.plan.sourceHopCount ?? 0,
       mentionedAgentIds,
       ...(addressedAnyone ? { addressedAnyone } : {})
     })
@@ -261,12 +275,12 @@ export async function clearStaleSlackReplyFooters<TTurn extends SlackTurn>(
   for (const reply of new Map(pending.map((item) => [item.ts, item])).values()) {
     try {
       const updated = await conn.updateBlocks(
-        p.channel,
+        p.plan.channel,
         reply.ts,
         [{ type: 'markdown', text: reply.text }],
         undefined,
         false,
-        p.agentId
+        p.plan.agentId
       )
       if (updated === false) failed.push(reply)
     } catch (err) {
@@ -298,10 +312,14 @@ async function findExistingSlackStatusBarTs(conn: SlackConnection, p: SlackTurn)
   if (!getThreadReplies) return undefined
   const own = new Set([conn.botId, conn.botUserId].filter(Boolean))
   if (own.size === 0) return undefined
-  const replies = await getThreadReplies.call(conn, p.channel, p.statusThread)
+  const replies = await getThreadReplies.call(conn, p.plan.channel, p.plan.statusThread)
   return replies.find(
     (m) =>
-      m.isBot && own.has(m.sender) && m.chrome && m.chromeOwnerAgentId === p.agentId && isSlackStatusBarText(m.text)
+      m.isBot &&
+      own.has(m.sender) &&
+      m.chrome &&
+      m.chromeOwnerAgentId === p.plan.agentId &&
+      isSlackStatusBarText(m.text)
   )?.ts
 }
 
@@ -316,15 +334,15 @@ async function postSlackReply<TTurn extends SlackTurn>(
   text: string,
   trackReply = true
 ): Promise<string | undefined> {
-  const previous = trackReply ? p.lastReply : undefined
+  const previous = trackReply ? p.reply.lastReply : undefined
   const attribution = trackReply ? p.attribution : undefined
-  const agentPostOptions = slackAgentPostOptions(p)
+  const agentPostOptions = slackAgentPostOptions({ ...p.plan, responseId: p.reply.responseId })
   const options = attribution ? { ...agentPostOptions, trailingBlocks: attribution.blocks } : agentPostOptions
-  const ts = await conn.postMessage(p.channel, text, p.thread, options as SlackPostOptions | undefined)
+  const ts = await conn.postMessage(p.plan.channel, text, p.plan.thread, options as SlackPostOptions | undefined)
   // Remember the newest conversational body so finalization knows which message closes
   // the response (§5.5). Tracked for every agent-authored body, including `attributed:
   // false` sections: "last posted" is a fact about ordering, not about footer ownership.
-  if (ts) p.lastResponse = { ts, text }
+  if (ts) p.reply.lastResponse = { ts, text }
   if (ts && trackReply) {
     if (attribution)
       await clearStaleSlackReplyFooters(
@@ -334,7 +352,7 @@ async function postSlackReply<TTurn extends SlackTurn>(
         state,
         previous?.footerKey ? [{ ts: previous.ts, text: previous.text }] : []
       )
-    p.lastReply = {
+    p.reply.lastReply = {
       ts,
       text,
       ...(attribution ? { footerKey: attribution.key } : {})
@@ -347,30 +365,30 @@ async function postSlackReply<TTurn extends SlackTurn>(
  *  footer-key transition after Slack accepts the edit so finalization can retry a failed
  *  metadata refresh. */
 async function updateSlackLiveReply(conn: SlackConnection, p: SlackTurn, text: string): Promise<void> {
-  if (!p.liveReplyTs) return
+  if (!p.chrome.liveReplyTs) return
   // minimal mode edits ONE message as the answer streams, so the text finalization must
   // re-send is the latest edit, not the text this message was born with (§5.5).
-  if (p.lastResponse?.ts === p.liveReplyTs) p.lastResponse.text = text
+  if (p.reply.lastResponse?.ts === p.chrome.liveReplyTs) p.reply.lastResponse.text = text
   const attribution = p.attribution
   if (!attribution) {
-    await conn.updateMessage(p.channel, p.liveReplyTs, text, false, p.agentId)
-    if (p.lastReply?.ts === p.liveReplyTs) {
-      p.lastReply.text = text
-      delete p.lastReply.footerKey
+    await conn.updateMessage(p.plan.channel, p.chrome.liveReplyTs, text, false, p.plan.agentId)
+    if (p.reply.lastReply?.ts === p.chrome.liveReplyTs) {
+      p.reply.lastReply.text = text
+      delete p.reply.lastReply.footerKey
     }
     return
   }
   const updated = await conn.updateBlocks(
-    p.channel,
-    p.liveReplyTs,
+    p.plan.channel,
+    p.chrome.liveReplyTs,
     [{ type: 'markdown', text }, ...attribution.blocks],
     text,
     false,
-    p.agentId
+    p.plan.agentId
   )
-  if (updated !== false && p.lastReply?.ts === p.liveReplyTs) {
-    p.lastReply.text = text
-    p.lastReply.footerKey = attribution.key
+  if (updated !== false && p.reply.lastReply?.ts === p.chrome.liveReplyTs) {
+    p.reply.lastReply.text = text
+    p.reply.lastReply.footerKey = attribution.key
   }
 }
 
@@ -398,34 +416,34 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     // still be readable in the session transcript.
     if (action.kind === 'post') {
       await host.appendTranscript({
-        channel: p.transcriptChannel,
-        thread: p.statusThread,
+        channel: p.plan.transcriptChannel,
+        thread: p.plan.statusThread,
         ts: host.monotonicTs(),
-        sender: p.agentId,
+        sender: p.plan.agentId,
         kind: 'text',
         text: action.text
       })
     }
     return
   }
-  const postOptions = slackPostOptions(p)
-  const statusBarPostOptions = slackAgentIdentityOptions(p)
+  const postOptions = slackPostOptions(p.plan)
+  const statusBarPostOptions = slackAgentIdentityOptions(p.plan)
   // Chrome variant of the post options: marks status/progress/plan/reasoning/notice/card
   // messages so a peer daemon's thread backfill skips them (they are not conversation).
   const chromeOptions: SlackPostOptions = { ...(postOptions ?? {}), chrome: true }
   switch (action.kind) {
     case 'set-status':
-      if (p.statusThread)
+      if (p.plan.statusThread)
         await conn.setStatus(
-          p.channel,
-          p.statusThread,
+          p.plan.channel,
+          p.plan.statusThread,
           action.text,
           action.loadingMessages,
-          slackStatusOptions(p.platform, p.agentName, p.iconUrl)
+          slackStatusOptions(p.plan.platform, p.plan.agentName, p.plan.iconUrl)
         )
       return
     case 'set-title':
-      if (p.statusThread) await conn.setTitle(p.channel, p.statusThread, action.text)
+      if (p.plan.statusThread) await conn.setTitle(p.plan.channel, p.plan.statusThread, action.text)
       return
     case 'post': {
       const trackReply = action.attributed !== false
@@ -434,10 +452,10 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       // strip the footer from this turn's previous section and move the pointer.
       const ts = await postSlackReply(host, conn, p, state, action.text, trackReply)
       await host.appendTranscript({
-        channel: p.transcriptChannel,
-        thread: p.statusThread,
+        channel: p.plan.transcriptChannel,
+        thread: p.plan.statusThread,
         ts: ts ?? `local-${Date.now()}`,
-        sender: p.agentId,
+        sender: p.plan.agentId,
         kind: 'text',
         text: action.text
       })
@@ -447,7 +465,7 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     case 'tool-output':
       // Both post to the thread but are NOT recorded into the transcript — notices are
       // system chrome, and tool output is captured independently by the recorder.
-      await conn.postMessage(p.channel, action.text, p.thread, chromeOptions)
+      await conn.postMessage(p.plan.channel, action.text, p.plan.thread, chromeOptions)
       return
     case 'attribution':
       // Final metadata normally matches the footer already included in the initial post.
@@ -456,22 +474,22 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       p.attribution = { blocks: action.blocks, key: JSON.stringify(action.blocks) }
       if (action.standalone) {
         if (
-          p.liveReplyTs &&
-          p.liveReplyText !== undefined &&
-          p.lastReply?.ts === p.liveReplyTs &&
-          p.lastReply.footerKey !== p.attribution.key
+          p.chrome.liveReplyTs &&
+          p.chrome.liveReplyText !== undefined &&
+          p.reply.lastReply?.ts === p.chrome.liveReplyTs &&
+          p.reply.lastReply.footerKey !== p.attribution.key
         ) {
           const updated = await conn.updateBlocks(
-            p.channel,
-            p.liveReplyTs,
-            [{ type: 'markdown', text: p.liveReplyText }, ...action.blocks],
-            p.liveReplyText,
+            p.plan.channel,
+            p.chrome.liveReplyTs,
+            [{ type: 'markdown', text: p.chrome.liveReplyText }, ...action.blocks],
+            p.chrome.liveReplyText,
             false,
-            p.agentId
+            p.plan.agentId
           )
           if (updated !== false) {
-            p.lastReply.text = p.liveReplyText
-            p.lastReply.footerKey = p.attribution.key
+            p.reply.lastReply.text = p.chrome.liveReplyText
+            p.reply.lastReply.footerKey = p.attribution.key
           }
         }
       } else {
@@ -482,47 +500,47 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       // Post the single progress message exactly once; thereafter edit it in
       // place. If the first post rejects or returns no ts, we mark it attempted
       // and skip subsequent edits rather than posting a duplicate message.
-      if (p.progressTs) await conn.updateMessage(p.channel, p.progressTs, action.text, true)
-      else if (!p.progressAttempted) {
-        p.progressAttempted = true
-        p.progressTs = await conn.postMessage(p.channel, action.text, p.thread, chromeOptions)
+      if (p.chrome.progressTs) await conn.updateMessage(p.plan.channel, p.chrome.progressTs, action.text, true)
+      else if (!p.chrome.progressAttempted) {
+        p.chrome.progressAttempted = true
+        p.chrome.progressTs = await conn.postMessage(p.plan.channel, action.text, p.plan.thread, chromeOptions)
       }
       return
     case 'plan':
-      if (p.planTs) await conn.updateMessage(p.channel, p.planTs, action.text, true)
-      else if (!p.planAttempted) {
-        p.planAttempted = true
-        p.planTs = await conn.postMessage(p.channel, action.text, p.thread, chromeOptions)
+      if (p.chrome.planTs) await conn.updateMessage(p.plan.channel, p.chrome.planTs, action.text, true)
+      else if (!p.chrome.planAttempted) {
+        p.chrome.planAttempted = true
+        p.chrome.planTs = await conn.postMessage(p.plan.channel, action.text, p.plan.thread, chromeOptions)
       }
       return
     case 'reasoning':
       // The single in-place reasoning block (high mode): post once, then edit — same
       // post-once/edit-thereafter contract as `progress`. Not recorded into the
       // transcript; the TranscriptRecorder captures reasoning rows independently.
-      if (p.reasoningTs) await conn.updateMessage(p.channel, p.reasoningTs, action.text, true)
-      else if (!p.reasoningAttempted) {
-        p.reasoningAttempted = true
-        p.reasoningTs = await conn.postMessage(p.channel, action.text, p.thread, chromeOptions)
+      if (p.chrome.reasoningTs) await conn.updateMessage(p.plan.channel, p.chrome.reasoningTs, action.text, true)
+      else if (!p.chrome.reasoningAttempted) {
+        p.chrome.reasoningAttempted = true
+        p.chrome.reasoningTs = await conn.postMessage(p.plan.channel, action.text, p.plan.thread, chromeOptions)
       }
       return
     case 'live-reply': {
       // minimal mode's single agent reply: post once with its attribution footer, then
       // update body + footer together as the turn streams. Skip an update when the text
       // is unchanged; the paired `recordOnly` posts carry the transcript content.
-      if (p.liveReplyReanchor) {
+      if (p.chrome.liveReplyReanchor) {
         // A human-input card was posted above this reply; start a FRESH reply below it so
         // the post-answer stream reads after the question (the old reply stays frozen above).
-        p.liveReplyReanchor = false
-        p.liveReplyTs = undefined
-        p.liveReplyAttempted = false
-        p.liveReplyText = undefined
+        p.chrome.liveReplyReanchor = false
+        p.chrome.liveReplyTs = undefined
+        p.chrome.liveReplyAttempted = false
+        p.chrome.liveReplyText = undefined
       }
-      if (p.liveReplyText === action.text) return
-      p.liveReplyText = action.text
-      if (p.liveReplyTs) await updateSlackLiveReply(conn, p, action.text)
-      else if (!p.liveReplyAttempted) {
-        p.liveReplyAttempted = true
-        p.liveReplyTs = await postSlackReply(host, conn, p, state, action.text)
+      if (p.chrome.liveReplyText === action.text) return
+      p.chrome.liveReplyText = action.text
+      if (p.chrome.liveReplyTs) await updateSlackLiveReply(conn, p, action.text)
+      else if (!p.chrome.liveReplyAttempted) {
+        p.chrome.liveReplyAttempted = true
+        p.chrome.liveReplyTs = await postSlackReply(host, conn, p, state, action.text)
       }
       return
     }
@@ -532,42 +550,42 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       // minimal mode never drops the tail of a long final answer. Every successful next
       // section is born with the footer before the prior section loses it, keeping the
       // footer anchored to the last delivered response throughout the handoff.
-      const sections = splitIntoSections(action.text, undefined, p.protectedAddresses)
+      const sections = splitIntoSections(action.text, undefined, p.plan.protectedAddresses)
       const [first, ...rest] = sections
       if (!first) return
-      if (p.liveReplyReanchor) {
-        p.liveReplyReanchor = false
-        p.liveReplyTs = undefined
-        p.liveReplyAttempted = false
-        p.liveReplyText = undefined
+      if (p.chrome.liveReplyReanchor) {
+        p.chrome.liveReplyReanchor = false
+        p.chrome.liveReplyTs = undefined
+        p.chrome.liveReplyAttempted = false
+        p.chrome.liveReplyText = undefined
       }
-      if (p.liveReplyText !== first) {
-        p.liveReplyText = first
-        if (p.liveReplyTs) await updateSlackLiveReply(conn, p, first)
-        else if (!p.liveReplyAttempted) {
-          p.liveReplyAttempted = true
-          p.liveReplyTs = await postSlackReply(host, conn, p, state, first)
+      if (p.chrome.liveReplyText !== first) {
+        p.chrome.liveReplyText = first
+        if (p.chrome.liveReplyTs) await updateSlackLiveReply(conn, p, first)
+        else if (!p.chrome.liveReplyAttempted) {
+          p.chrome.liveReplyAttempted = true
+          p.chrome.liveReplyTs = await postSlackReply(host, conn, p, state, first)
         }
       }
       for (const section of rest) {
         const ts = await postSlackReply(host, conn, p, state, section)
         if (ts) {
-          p.liveReplyTs = ts
-          p.liveReplyText = section
+          p.chrome.liveReplyTs = ts
+          p.chrome.liveReplyText = section
         }
       }
       return
     }
     case 'clear-status-bar': {
-      const ts = p.statusBarTs ?? (await host.getStatusBarTs(p.sessionKey))
+      const ts = p.chrome.statusBarTs ?? (await host.getStatusBarTs(p.plan.sessionKey))
       if (!ts) return
-      p.statusBarTs = ts
-      const deleted = await conn.deleteMessage(p.channel, ts)
+      p.chrome.statusBarTs = ts
+      const deleted = await conn.deleteMessage(p.plan.channel, ts)
       // Duck-typed test connections historically return void; only an explicit false
       // means Slack rejected the cleanup and the persisted ts should be retried later.
       if (deleted !== false) {
-        p.statusBarTs = undefined
-        await host.clearStatusBarTs(p.sessionKey)
+        p.chrome.statusBarTs = undefined
+        await host.clearStatusBarTs(p.plan.sessionKey)
       }
       return
     }
@@ -575,17 +593,25 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       // Session-scoped interactive status line: the first post's ts is stored on the
       // session, and every later turn updates that topmost line in place. Serialized by
       // applyChain; not recorded into the transcript (live chrome).
-      let ts = p.statusBarTs ?? (await host.getStatusBarTs(p.sessionKey))
-      if (!ts && !p.statusBarAttempted) {
+      let ts = p.chrome.statusBarTs ?? (await host.getStatusBarTs(p.plan.sessionKey))
+      if (!ts && !p.chrome.statusBarAttempted) {
         ts = await findExistingSlackStatusBarTs(conn, p)
         if (ts) {
-          p.statusBarTs = ts
-          await host.setStatusBarTs(p.sessionKey, ts)
+          p.chrome.statusBarTs = ts
+          await host.setStatusBarTs(p.plan.sessionKey, ts)
         }
       }
       if (ts) {
-        p.statusBarTs = ts
-        const updated = await conn.updateBlocks(p.channel, ts, action.blocks, action.text, true, undefined, p.agentId)
+        p.chrome.statusBarTs = ts
+        const updated = await conn.updateBlocks(
+          p.plan.channel,
+          ts,
+          action.blocks,
+          action.text,
+          true,
+          undefined,
+          p.plan.agentId
+        )
         // Duck-typed test connections historically return void; only an explicit
         // false means Slack rejected the edit — typically cant_update_message on a
         // bar another Slack app authored (a foreign ts persisted by the
@@ -594,21 +620,21 @@ export async function applySlackAction<TTurn extends SlackTurn>(
         // of hammering an uneditable message on every usage tick. A transient
         // failure costs at most one duplicate bar; a foreign ts never heals.
         if (updated === false) {
-          p.statusBarTs = undefined
-          await host.clearStatusBarTs(p.sessionKey)
+          p.chrome.statusBarTs = undefined
+          await host.clearStatusBarTs(p.plan.sessionKey)
         }
-      } else if (!p.statusBarAttempted) {
-        p.statusBarAttempted = true
+      } else if (!p.chrome.statusBarAttempted) {
+        p.chrome.statusBarAttempted = true
         // The session status line represents the selected agent, so keep its author
         // identity aligned with the native loading state and the eventual reply.
-        const posted = await conn.postBlocks(p.channel, action.blocks, action.text, p.thread, {
+        const posted = await conn.postBlocks(p.plan.channel, action.blocks, action.text, p.plan.thread, {
           ...(statusBarPostOptions ?? {}),
           chrome: true,
-          chromeOwnerAgentId: p.agentId
+          chromeOwnerAgentId: p.plan.agentId
         })
         if (posted) {
-          p.statusBarTs = posted
-          await host.setStatusBarTs(p.sessionKey, posted)
+          p.chrome.statusBarTs = posted
+          await host.setStatusBarTs(p.plan.sessionKey, posted)
         }
       }
       return

--- a/packages/daemon/src/platforms/telegram/turn-output.ts
+++ b/packages/daemon/src/platforms/telegram/turn-output.ts
@@ -37,20 +37,24 @@ export interface TelegramTurnState {
  *  nothing more. `Pending` satisfies this structurally. */
 export interface TelegramTurn {
   conn?: unknown
-  channel: string
-  thread?: string
-  statusThread: string
-  transcriptChannel: string
-  agentId: string
-  progressTs?: string
-  progressAttempted?: boolean
-  planTs?: string
-  planAttempted?: boolean
-  reasoningTs?: string
-  reasoningAttempted?: boolean
-  liveReplyTs?: string
-  liveReplyText?: string
-  liveReplyAttempted?: boolean
+  plan: {
+    channel: string
+    thread?: string
+    statusThread: string
+    transcriptChannel: string
+    agentId: string
+  }
+  chrome: {
+    progressTs?: string
+    progressAttempted?: boolean
+    planTs?: string
+    planAttempted?: boolean
+    reasoningTs?: string
+    reasoningAttempted?: boolean
+    liveReplyTs?: string
+    liveReplyText?: string
+    liveReplyAttempted?: boolean
+  }
 }
 
 /** The host capabilities this applier needs. Two — both about recording what was
@@ -89,20 +93,20 @@ export async function applyTelegramAction<TTurn extends TelegramTurn>(
   if (!conn) return
   switch (action.kind) {
     case 'typing':
-      await conn.sendChatAction(turn.channel)
+      await conn.sendChatAction(turn.plan.channel)
       return
     case 'post': {
       // The continue-the-topic hint is chrome: sent with the reply (so it lands on the very
       // message users are told to reply to) but kept out of the recorded text below.
       const sent = action.hint ? `${action.text}\n\n${action.hint}` : action.text
-      const id = await conn.postMessage(turn.channel, sent, turn.thread, { replyTo: state.replyTo })
+      const id = await conn.postMessage(turn.plan.channel, sent, turn.plan.thread, { replyTo: state.replyTo })
       // Remember the newest body message so a turn-end `continue-hint` can annotate it.
       if (id) state.lastBody = { id, text: sent }
       await host.appendTranscript({
-        channel: turn.transcriptChannel,
-        thread: turn.statusThread,
+        channel: turn.plan.transcriptChannel,
+        thread: turn.plan.statusThread,
         ts: id ?? `local-${Date.now()}`,
-        sender: turn.agentId,
+        sender: turn.plan.agentId,
         kind: 'text',
         text: action.text
       })
@@ -118,18 +122,18 @@ export async function applyTelegramAction<TTurn extends TelegramTurn>(
       const sent = `${last.text}\n\n${action.hint}`
       if (sent.length > TELEGRAM_MESSAGE_LIMIT) return
       state.lastBody = { id: last.id, text: sent }
-      await conn.updateMessage(turn.channel, last.id, sent)
+      await conn.updateMessage(turn.plan.channel, last.id, sent)
       return
     }
     case 'live-reply': {
       // minimal mode's single agent reply: send once (plain text) then edit in place as the
       // turn streams. Skip an update when unchanged; not recorded (the `recordOnly` posts do).
-      if (turn.liveReplyText === action.text) return
-      turn.liveReplyText = action.text
-      if (turn.liveReplyTs) await conn.updateMessage(turn.channel, turn.liveReplyTs, action.text)
-      else if (!turn.liveReplyAttempted) {
-        turn.liveReplyAttempted = true
-        turn.liveReplyTs = await conn.postMessage(turn.channel, action.text, turn.thread, {
+      if (turn.chrome.liveReplyText === action.text) return
+      turn.chrome.liveReplyText = action.text
+      if (turn.chrome.liveReplyTs) await conn.updateMessage(turn.plan.channel, turn.chrome.liveReplyTs, action.text)
+      else if (!turn.chrome.liveReplyAttempted) {
+        turn.chrome.liveReplyAttempted = true
+        turn.chrome.liveReplyTs = await conn.postMessage(turn.plan.channel, action.text, turn.plan.thread, {
           replyTo: state.replyTo
         })
       }
@@ -139,43 +143,48 @@ export async function applyTelegramAction<TTurn extends TelegramTurn>(
     case 'tool-output':
       // Posted to the chat but NOT recorded — the done footer is chrome, and tool
       // output is captured independently by the recorder.
-      await conn.postChrome(turn.channel, action.text, {
+      await conn.postChrome(turn.plan.channel, action.text, {
         parseMode: action.parseMode,
-        threadTs: turn.thread,
+        threadTs: turn.plan.thread,
         replyTo: state.replyTo
       })
       return
     case 'progress':
-      if (turn.progressTs)
-        await conn.updateMessage(turn.channel, turn.progressTs, action.text, { parseMode: action.parseMode })
-      else if (!turn.progressAttempted) {
-        turn.progressAttempted = true
-        turn.progressTs = await conn.postChrome(turn.channel, action.text, {
+      if (turn.chrome.progressTs)
+        await conn.updateMessage(turn.plan.channel, turn.chrome.progressTs, action.text, {
+          parseMode: action.parseMode
+        })
+      else if (!turn.chrome.progressAttempted) {
+        turn.chrome.progressAttempted = true
+        turn.chrome.progressTs = await conn.postChrome(turn.plan.channel, action.text, {
           parseMode: action.parseMode,
-          threadTs: turn.thread,
+          threadTs: turn.plan.thread,
           replyTo: state.replyTo
         })
       }
       return
     case 'plan':
-      if (turn.planTs) await conn.updateMessage(turn.channel, turn.planTs, action.text, { parseMode: action.parseMode })
-      else if (!turn.planAttempted) {
-        turn.planAttempted = true
-        turn.planTs = await conn.postChrome(turn.channel, action.text, {
+      if (turn.chrome.planTs)
+        await conn.updateMessage(turn.plan.channel, turn.chrome.planTs, action.text, { parseMode: action.parseMode })
+      else if (!turn.chrome.planAttempted) {
+        turn.chrome.planAttempted = true
+        turn.chrome.planTs = await conn.postChrome(turn.plan.channel, action.text, {
           parseMode: action.parseMode,
-          threadTs: turn.thread,
+          threadTs: turn.plan.thread,
           replyTo: state.replyTo
         })
       }
       return
     case 'reasoning':
-      if (turn.reasoningTs)
-        await conn.updateMessage(turn.channel, turn.reasoningTs, action.text, { parseMode: action.parseMode })
-      else if (!turn.reasoningAttempted) {
-        turn.reasoningAttempted = true
-        turn.reasoningTs = await conn.postChrome(turn.channel, action.text, {
+      if (turn.chrome.reasoningTs)
+        await conn.updateMessage(turn.plan.channel, turn.chrome.reasoningTs, action.text, {
+          parseMode: action.parseMode
+        })
+      else if (!turn.chrome.reasoningAttempted) {
+        turn.chrome.reasoningAttempted = true
+        turn.chrome.reasoningTs = await conn.postChrome(turn.plan.channel, action.text, {
           parseMode: action.parseMode,
-          threadTs: turn.thread,
+          threadTs: turn.plan.thread,
           replyTo: state.replyTo
         })
       }

--- a/packages/daemon/src/webchat/transport.ts
+++ b/packages/daemon/src/webchat/transport.ts
@@ -686,9 +686,9 @@ export class WebchatTransport {
       convId === conversationId && (agentId === undefined || a === agentId)
     const interrupted = new Set<string>()
     for (const p of this.host.pending().values()) {
-      if (matches(p.agentId, p.webchat?.conversationId) && !interrupted.has(p.sessionKey)) {
-        interrupted.add(p.sessionKey)
-        await this.host.interruptTurn(p.agentId, p.sessionKey, 'cancel', p.acpSessionId)
+      if (matches(p.plan.agentId, p.webchat?.conversationId) && !interrupted.has(p.plan.sessionKey)) {
+        interrupted.add(p.plan.sessionKey)
+        await this.host.interruptTurn(p.plan.agentId, p.plan.sessionKey, 'cancel', p.acpSessionId)
       }
     }
     // Cold accepted head: it owns the logical gate but has not reached Pending yet.

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -38,7 +38,7 @@ const LOOP_SCOPE = `slack:C1:dm:${TRANSPORT_SCOPE}`
 
 function hasPending(daemon: Daemon, acpSessionId: string): boolean {
   return [...(daemon as any).pending.values()].some(
-    (pending: any) => pending.agentId === 'bot-a' && pending.acpSessionId === acpSessionId
+    (pending: any) => pending.plan.agentId === 'bot-a' && pending.acpSessionId === acpSessionId
   )
 }
 
@@ -1498,30 +1498,27 @@ describe('Slack interactive status bar', () => {
     const clearStatusBarTs = vi.fn()
     ;(daemon as any).store = { getStatusBarTs, clearStatusBarTs }
     const pending: any = {
-      platform: 'slack',
-      showStatusBar: false,
-      statusBarTs: 'sb1',
-      sessionKey: SESSION_KEY,
-      channel: 'C1',
+      plan: { platform: 'slack', showStatusBar: false, sessionKey: SESSION_KEY, channel: 'C1' },
+      chrome: { statusBarTs: 'sb1' },
       conn,
-      applyChain: Promise.resolve()
+      signals: { applyChain: Promise.resolve() }
     }
 
     ;(daemon as any).emitStatusBar(pending)
-    await pending.applyChain
+    await pending.signals.applyChain
     expect(conn.deleteMessage).toHaveBeenCalledWith('C1', 'sb1')
-    expect(pending.statusBarTs).toBeUndefined()
+    expect(pending.chrome.statusBarTs).toBeUndefined()
     expect(clearStatusBarTs).toHaveBeenCalledWith(SESSION_KEY)
 
     ;(daemon as any).emitStatusBar(pending)
-    await pending.applyChain
+    await pending.signals.applyChain
     expect(conn.deleteMessage).toHaveBeenCalledTimes(1)
 
     // Never adopt an unowned legacy row for deletion: a shared Slack thread may contain
     // another Agent's status bar.
-    const unowned = { ...pending, statusBarTs: undefined, lastStatusBar: undefined, applyChain: Promise.resolve() }
+    const unowned = { ...pending, chrome: {}, signals: { applyChain: Promise.resolve() } }
     ;(daemon as any).emitStatusBar(unowned)
-    await unowned.applyChain
+    await unowned.signals.applyChain
     expect(conn.getThreadReplies).not.toHaveBeenCalled()
     expect(conn.deleteMessage).toHaveBeenCalledTimes(1)
   }, 15_000)
@@ -1540,13 +1537,13 @@ describe('Slack interactive status bar', () => {
     const t1 = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
     await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1), WAIT)
     const p = [...(daemon as any).pending.values()][0]
-    expect(p.statusBarTs).toBe('sb1')
+    expect(p.chrome.statusBarTs).toBe('sb1')
 
     // A permission / elicitation card is posted mid-turn (its handler calls this). Other
     // live output re-anchors below the card, but the session header must remain at sb1.
     ;(daemon as any).reanchorInPlaceChrome(p)
-    await p.applyChain
-    p.lastStatusBar = undefined // mimic a usage update that changes the visible header
+    await p.signals.applyChain
+    p.chrome.lastStatusBar = undefined // mimic a usage update that changes the visible header
     ;(daemon as any).emitStatusBar(p)
     await vi.waitFor(
       () =>
@@ -1561,8 +1558,8 @@ describe('Slack interactive status bar', () => {
         ),
       WAIT
     )
-    expect(p.statusBarTs).toBe('sb1')
-    expect(await (daemon as any).store.getStatusBarTs(p.sessionKey)).toBe('sb1')
+    expect(p.chrome.statusBarTs).toBe('sb1')
+    expect(await (daemon as any).store.getStatusBarTs(p.plan.sessionKey)).toBe('sb1')
     expect(conn.postBlocks).toHaveBeenCalledTimes(1)
     expect(conn.deleteMessage).not.toHaveBeenCalled()
 

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -19,7 +19,7 @@ const CONV_2 = '22222222-2222-4222-8222-222222222222'
 
 function hasPending(daemon: Daemon, acpSessionId: string): boolean {
   return [...(daemon as any).pending.values()].some(
-    (pending: any) => pending.agentId === AGENT_ID && pending.acpSessionId === acpSessionId
+    (pending: any) => pending.plan.agentId === AGENT_ID && pending.acpSessionId === acpSessionId
   )
 }
 

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -165,7 +165,7 @@ function wakeFenceHeld(daemon: Daemon): boolean {
 
 function pendingFor(daemon: Daemon, acpSessionId: string): any {
   return [...(daemon as any).pending.values()].find(
-    (pending: any) => pending.agentId === 'bot-a' && pending.acpSessionId === acpSessionId
+    (pending: any) => pending.plan.agentId === 'bot-a' && pending.acpSessionId === acpSessionId
   )
 }
 
@@ -1002,7 +1002,7 @@ describe('Daemon session lifecycle (#118)', () => {
     await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined(), WAIT)
     const pending = pendingFor(daemon, 'acp-1')
     let releaseApply!: () => void
-    pending.applyChain = new Promise<void>((resolve) => (releaseApply = resolve))
+    pending.signals.applyChain = new Promise<void>((resolve) => (releaseApply = resolve))
     ;(daemon as any).enqueueApply(pending, { kind: 'post', text: 'must not post' })
 
     writePause(root, true)

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -113,16 +113,22 @@ function installPending(daemon: Daemon): {
     resolvePermissionRequest: vi.fn(() => true)
   }
   const pending = {
+    plan: {
+      platform: 'hook',
+      agentId: 'agent-1',
+      requesterId: 'turn-user',
+      channel: 'test',
+      statusThread: 'test',
+      approvalSurfaceSuppressed: false
+    },
+    chrome: {},
+    reply: { text: '', attemptText: '', attemptAnswerUpdates: [] },
+    signals: { applyChain: Promise.resolve() },
+    approval: { waitMs: 0, depth: 0 },
     builtinSystemToolCallIds: new Set<string>(),
     hiddenSessionTitleToolCallIds: new Set<string>(),
-    replyText: '',
-    platform: 'hook',
     conv: { onUpdate: () => [], hasBuffered: () => false },
-    rec: { onUpdate: () => [] },
-    agentId: 'agent-1',
-    requesterId: 'turn-user',
-    channel: 'test',
-    statusThread: 'test'
+    rec: { onUpdate: () => [] }
   }
   ;(daemon as any).pending.set(JSON.stringify(['agent-1', 's1']), pending)
   return pending
@@ -132,7 +138,7 @@ describe('an approval publishes its resolver before the durable write', () => {
   it('a cancellation during createPermissionRequest leaves no orphaned wait or pending row', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending = installPending(daemon) as Record<string, unknown>
-    pending.approvalSurfaceSuppressed = true
+    pending.plan.approvalSurfaceSuppressed = true
 
     // Hold the durable write open so the cancellation sweep lands inside it — the window the
     // async store opened, which the synchronous path never had.
@@ -205,7 +211,7 @@ describe('built-in MCP approvals use one policy on both ACP paths', () => {
   it('queues non-system requests for an Agent editor even when `none` hides the chat surface', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending = installPending(daemon) as Record<string, unknown>
-    pending.approvalSurfaceSuppressed = true
+    pending.plan.approvalSurfaceSuppressed = true
 
     const permissionResult = (daemon as any).permissions.onAcpPermission(
       'agent-1',
@@ -268,8 +274,8 @@ describe('built-in MCP approvals use one policy on both ACP paths', () => {
     for (const platform of ['telegram', 'discord', 'feishu', 'webchat']) {
       const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
       const pending = installPending(daemon) as Record<string, unknown>
-      pending.platform = platform
-      pending.approvalSurfaceSuppressed = false
+      pending.plan.platform = platform
+      pending.plan.approvalSurfaceSuppressed = false
 
       const result = (daemon as any).permissions.onAcpPermission('agent-1', 's1', req({ title: 'Bash' }))
       await vi.waitFor(() => expect((daemon as any).permissions.pendingEditorPermissions.size).toBe(1))

--- a/packages/daemon/test/daemon-platform-authorship.test.ts
+++ b/packages/daemon/test/daemon-platform-authorship.test.ts
@@ -282,13 +282,12 @@ describe('response closure is a turn-output surface member (audit F19, site 7)',
     const daemon = await boot(['bot-a', 'bot-b'])
     const finalizeResponse = vi.fn(async () => true)
     const turn = {
-      platform: 'slack',
-      agentId: 'bot-a',
-      channel: 'C1',
-      replyText: 'done <@UBOTB>',
-      responseId: 'r-1',
-      sourceHopCount: 1,
-      lastResponse: { ts: '1720000000.000300', text: 'done <@UBOTB>' },
+      plan: { platform: 'slack', agentId: 'bot-a', channel: 'C1', sourceHopCount: 1 },
+      reply: {
+        text: 'done <@UBOTB>',
+        responseId: 'r-1',
+        lastResponse: { ts: '1720000000.000300', text: 'done <@UBOTB>' }
+      },
       conn: { finalizeResponse }
     }
     await (daemon as any).turnSurfaces.exact('slack').closeResponse(turn)

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -596,7 +596,7 @@ describe('Daemon transcript records the agent reply', () => {
         // FRESH reply BELOW it — not edit reply-1 in place above the question.
         const p = [...(daemon as any).pending.values()][0]
         ;(daemon as any).reanchorInPlaceChrome(p)
-        await p.applyChain
+        await p.signals.applyChain
         onUpdate(sid, text('second part'))
         onUpdate(sid, tool('t2', 'Read two'))
         await vi.waitFor(
@@ -671,7 +671,7 @@ describe('Daemon transcript records the agent reply', () => {
       })
     }
     // A pre-card chrome send is already queued on the chain but has not flushed yet.
-    const p: any = { conn, applyChain: chromeSent.then(() => void order.push('chrome')) }
+    const p: any = { conn, chrome: {}, signals: { applyChain: chromeSent.then(() => void order.push('chrome')) } }
 
     const cardPromise = (daemon as any).postCardSerialized(p, (sc: any) => sc.postBlocks())
     // Give microtasks a chance: the card still must NOT post while the queued chrome is pending.

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -714,15 +714,18 @@ describe('continue-the-topic hint delivery', () => {
       sendChatAction: vi.fn(async () => {})
     }
     const p = {
-      agentId: 'bot-a',
-      channel: '-100',
-      transcriptChannel: '-100',
-      statusThread: 'tg:100',
-      thread: 'tg:100',
+      plan: {
+        agentId: 'bot-a',
+        channel: '-100',
+        transcriptChannel: '-100',
+        statusThread: 'tg:100',
+        thread: 'tg:100',
+        approvalSurfaceSuppressed: false
+      },
+      chrome: {},
       // §7.3: Telegram's per-turn state lives in the opaque slot, seeded by its
       // output surface at dispatch (here, by hand).
       turnState: { replyTo: 100 } as { replyTo?: number; lastBody?: { id: string; text: string } },
-      approvalSurfaceSuppressed: false,
       conn
     }
     return { conn, p, apply: (a: unknown) => (daemon as any).applyTelegramAction(p, a) }

--- a/packages/daemon/test/turn-output-workflow.test.ts
+++ b/packages/daemon/test/turn-output-workflow.test.ts
@@ -81,7 +81,7 @@ function connect(daemon: Daemon, overrides: Record<string, unknown> = {}) {
 describe('TurnOutputWorkflow', () => {
   it('offers a final-fence provider snapshot only where the Layer-1 thread-history port exists', async () => {
     // The gate is the read port (`getThreadReplies`), asked by name — not a
-    // `pending.platform !== 'slack'` test and not a `Partial<SlackConnection>`
+    // `pending.plan.platform !== 'slack'` test and not a `Partial<SlackConnection>`
     // cast that only looks like one. A connection without the port contributes
     // no provider snapshot and the fence falls back to daemon-observed rows.
     const daemon = new Daemon({
@@ -99,12 +99,14 @@ describe('TurnOutputWorkflow', () => {
     })
     await daemon.start()
     const pending = {
-      agentId: 'bot-a',
-      integrationId: 'int-a',
-      channel: 'C1',
-      statusThread: 'T1',
-      transcriptChannel: transcriptChannelKey('C1', undefined),
-      platform: 'slack'
+      plan: {
+        agentId: 'bot-a',
+        integrationId: 'int-a',
+        channel: 'C1',
+        statusThread: 'T1',
+        transcriptChannel: transcriptChannelKey('C1', undefined),
+        platform: 'slack'
+      }
     }
 
     connect(daemon)
@@ -115,9 +117,11 @@ describe('TurnOutputWorkflow', () => {
 
     // Port presence, not platform identity: a NON-Slack pending whose connection
     // answers the port still gets a snapshot, and a Slack one that doesn't, doesn't.
-    expect(typeof (daemon as any).finalThreadSnapshot({ ...pending, platform: 'telegram' })).toBe('function')
+    expect(typeof (daemon as any).finalThreadSnapshot({ plan: { ...pending.plan, platform: 'telegram' } })).toBe(
+      'function'
+    )
     connect(daemon)
-    expect((daemon as any).finalThreadSnapshot({ ...pending, platform: 'telegram' })).toBeUndefined()
+    expect((daemon as any).finalThreadSnapshot({ plan: { ...pending.plan, platform: 'telegram' } })).toBeUndefined()
 
     // No connection at all is the same fail-closed answer.
     ;(daemon as any).connByIntegration.delete('int-a')


### PR DESCRIPTION
## What

`src/daemon/turn-types.ts`'s `Pending` had grown to **63 mutable fields** mixing four unrelated lifetimes. This splits it along ownership lines:

```ts
interface Pending {
  readonly plan: TurnPlan          // was ~20 copied-in duplicate fields
  chrome: TurnChromeCursors        // in-place platform anchors
  reply: ReplyAccumulator          // what the turn has said / posted
  approval: ApprovalWait           // permissions/ owns every write
  signals: TurnSignals             // completion machinery
  …irreducible identity/context (entry, conv, rec, acpSessionId, conn,
    turnState, attribution, github, callMeta, webchat, …)
}
```

### (a) plan duplicates — REMOVED, not moved
`buildPending` used to copy 20 plan fields onto the turn record: `sessionKey`, `agentId`, `agentName`, `iconUrl`, `platform`, `isDm`, `channel`, `thread`, `statusThread`, `transcriptChannel`, `integrationId`, `requesterId`, `evaluationTurnId`, `showStatusBar`, `approvalSurfaceSuppressed`, `protectedAddresses`, `stageAnswer`, `webchatRefresh`, `loopGuardScope`, `sourceHopCount`.

Every reader now goes through `p.plan.X`. **Verified first that no production writer mutates any of them** (`rg` for assignment forms across `src/`), which is what makes this behaviour-preserving rather than a newly asserted invariant. The only mutators were three test pokes, retargeted onto the real owner (`pending.plan.approvalSurfaceSuppressed`, `pending.plan.platform`).

### (b) chrome cursors → `TurnChromeCursors`
`progressTs/Attempted`, `planTs/Attempted`, `reasoningTs/Attempted`, `liveReplyTs/Attempted/Text/Reanchor`, `statusBarTs/Attempted`, `lastStatusBar`, `statusCancellable`. (`showStatusBar` is a plan fact and went to `plan`, not here.)

### (c) reply accumulation → `ReplyAccumulator`
`replyText`→`reply.text`, `attemptReplyText`→`reply.attemptText`, `attemptAnswerUpdates`, `lastReply`, `lastResponse`, `responseId`.

### (d) approval wait → `ApprovalWait`, owned by `permissions/`
The type is **declared in `permissions/coordinator.ts`**, the only writer; `turn-types.ts` imports it. `approvalWaitMs/Depth/StartedAt` → `approval.waitMs/depth/startedAt`. `approvalSurfaceSuppressed` did **not** join the cluster: it is a frozen plan decision (`buildTurnPlan` computes it) with no mutator, so it lives on `plan` and permissions reads `p.plan.approvalSurfaceSuppressed`.

### (e) completion signals → `TurnSignals`
`done`, `resolveDone`, `idleTimer`, `applyChain`, `usageReportSent`, `runtimeCostReported`.

## The platform seam

The per-platform structural turn views are views **on `Pending`**, so they nest identically — `SlackTurn`, `TelegramTurn`, `DiscordTurn`, `FeishuTurn`, `GithubTurn` each grew a `plan` (and, where relevant, `chrome` / `reply`) member. `Pending` still satisfies every one structurally, and each seam still names exactly the fields that platform may reach.

Slack's four option builders now take the **plan subset** (`SlackTurnPlan`) instead of a turn: they are pure functions of those four/six fields, and one caller (the turn-failure notice in `daemon.ts`) is not a turn at all. Turn callers pass `p.plan`; `slackAgentPostOptions` takes `{ ...p.plan, responseId: p.reply.responseId }`.

## No shells

No same-name delegate shells were kept. Callers hold the new clusters directly.

## Behaviour

Zero behaviour change by construction:
- plan-duplicated fields were provably never written, so read-through is identity;
- the webchat alias object is untouched — still the same `Object.assign`-shared instance held by `QueueEntry` (`doneSent` sharing intact);
- `pendingSessionKey` still reads the real `thread` (not `statusThread`), now off `plan`.

The bulk of the ~230 call-site rewrites was applied **from tsc's own error positions** rather than by textual search-and-replace, so no `p.channel` belonging to some other object could be caught by accident.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean.
- `prettier --check` + `eslint` on all touched files — clean.
- Targeted vitest: `daemon-smoke`, `daemon-serial-gate`, `turn-output-seam`, `daemon-webchat`, `daemon-hook`, `daemon-permission-autoallow`, `attribution`, `turn-plan`, `daemon-interrupt-safety`, plus the suites whose fixtures build turn records by hand (`turn-output-workflow`, `telegram-threading`, `daemon-commands`, `daemon-transcript`, `daemon-lifecycle`) and the surrounding output/GitHub/webchat suites — all green.
- The one `daemon-smoke` failure seen locally (`hands a scratch workspace with App credentials the same gitcred capability a clone gets`) reproduces identically on unmodified `main`; it is a sandbox/gitcred baseline failure, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)