### PR TITLE
fix(web): show an agent's org MCP servers when its placement resolves no daemon

### DIFF
--- a/packages/web/src/components/console/AgentToolsCard.test.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DaemonRow } from '@/lib/data'
+
+const mocks = vi.hoisted(() => ({
+  mcpProviders: [
+    { name: 'grafana', visibility: 'org' },
+    { name: 'linear', visibility: 'org' }
+  ] as unknown[]
+}))
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    updateAgent: vi.fn(async () => undefined),
+    mcpProviders: mocks.mcpProviders,
+    connectorsEnabled: false
+  })
+}))
+vi.mock('@/lib/api', () => ({
+  fetchAgentDto: vi.fn(async () => ({ mcpServers: [] })),
+  fetchConnectorCatalog: vi.fn(async () => ({ providers: [] })),
+  repoLabel: (r: unknown) => String(r),
+  repoWebUrl: () => undefined
+}))
+vi.mock('@/components/marks', () => ({ GithubMark: () => null }))
+
+import { AgentToolsCard } from './AgentToolsCard'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let host: HTMLDivElement | undefined
+let root: Root | undefined
+
+async function render(daemon: DaemonRow | undefined): Promise<string> {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root!.render(<AgentToolsCard agentId="a1" runtime="claude" daemon={daemon} canEdit />)
+  })
+  return host.textContent ?? ''
+}
+
+afterEach(() => {
+  act(() => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+})
+
+describe('AgentToolsCard', () => {
+  // A pool- or group-placed agent carries a placement sentinel instead of a member id, so the
+  // console resolves no owning daemon for it. Gating the whole candidate list on that lookup hid
+  // every org-registry server such an agent could attach — and those are http-proxied, so they
+  // never needed a daemon in the first place.
+  it('lists the org registry servers for an agent with no resolved daemon', async () => {
+    const text = await render(undefined)
+    expect(text).toContain('grafana')
+    expect(text).toContain('linear')
+  })
+
+  it('unions the daemon-reported servers with the registry when a daemon does resolve', async () => {
+    const daemon = {
+      mcpServers: [{ name: 'daemon-local', transport: 'stdio' }],
+      runtimeModels: []
+    } as unknown as DaemonRow
+    const text = await render(daemon)
+    expect(text).toContain('daemon-local')
+    expect(text).toContain('grafana')
+  })
+
+  it('still shows the empty state when the org registry is empty too', async () => {
+    const saved = mocks.mcpProviders
+    mocks.mcpProviders = []
+    try {
+      expect(await render(undefined)).toContain('No MCP servers available to this agent.')
+    } finally {
+      mocks.mcpProviders = saved
+    }
+  })
+})

--- a/packages/web/src/components/console/AgentToolsCard.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.tsx
@@ -25,8 +25,9 @@ import { Icon, Toggle } from '@/components/ui'
  * (they can't be turned back on here); this is the only place to clear a stale
  * name now that the create/edit picker is gone.
  *
- * Daemons are live-only, so a mock agent (or one whose daemon is out of the fleet)
- * has no reported servers and renders the empty state.
+ * Daemons are live-only, so an agent with no resolved daemon — a mock one, one
+ * out of the fleet, or one placed on a pool or a group rather than a member —
+ * contributes no daemon-reported servers. The org registry still does.
  */
 export function AgentToolsCard({
   agentId,
@@ -58,13 +59,10 @@ export function AgentToolsCard({
     const service = serviceByName.get(name)
     return service ? iconByService.get(service) : undefined
   }
-  // A demo agent has no live daemon, so mock mode falls back to the org registry
-  // alone — enough to render the tiles with no CP running.
-  const candidates = daemon
-    ? mcpCandidates(daemon.mcpServers, registryNames)
-    : MOCK_MODE
-      ? mcpCandidates([], registryNames)
-      : []
+  // The registry half is org-scoped and http-proxied, so it does NOT depend on resolving an
+  // owning daemon: a pool- or group-placed agent carries a placement sentinel rather than a
+  // member id, and gating the whole list on that lookup hid every org server it could attach.
+  const candidates = mcpCandidates(daemon?.mcpServers ?? [], registryNames)
   const caps = daemon ? mcpCapsFor(daemon.runtimeModels, runtime) : null
   const servers = mcpServersForRuntime(candidates, caps)
   // The persisted allow-list, once the raw spec loads; null ⇒ not loaded yet.
@@ -118,7 +116,7 @@ export function AgentToolsCard({
   const candidateNames = new Set(candidates.map((c) => c.name))
   const unknown = (enabled ?? []).filter((n) => !eligibleNames.has(n))
   const unknownMeta = (n: string) =>
-    candidateNames.has(n) ? 'Not supported by this runtime' : 'Not reported by this daemon'
+    candidateNames.has(n) ? 'Not supported by this runtime' : 'Not available to this agent'
 
   // One MCP tile — the same ToolTile the registry card renders, with the enable toggle
   // in place of its edit/delete action. Eligible servers toggle freely; an ineligible
@@ -158,7 +156,7 @@ export function AgentToolsCard({
       ) : (
         <div className="flex items-center gap-2 px-4 py-[13px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) desktop:py-3">
           <Icon name="plug" size={14} />
-          No MCP servers on this daemon&apos;s runtime.
+          No MCP servers available to this agent.
         </div>
       )}
       {err && (


### PR DESCRIPTION
## The bug

An agent's Tools card renders no MCP servers at all when the console cannot resolve an
owning daemon row for it — and for a **pool- or group-placed agent it never can**, because
such an agent carries a placement sentinel (`placementValueOf` → `POOL_PLACEMENT` or a group
value) instead of a member id, so `daemons.find(d => d.daemonId === da.daemon)` is always
`undefined`.

The card then took this branch:

```ts
const candidates = daemon
  ? mcpCandidates(daemon.mcpServers, registryNames)   // daemon-reported ∪ org registry
  : MOCK_MODE
    ? mcpCandidates([], registryNames)
    : []                                              // ← registryNames thrown away
```

So every org-registry server such an agent could attach was hidden, and the card claimed
there were none. The transport gate was never the blocker — `mcpTransportSupported` passes
everything when `caps` is null, which is exactly the no-daemon case.

## The fix

The daemon half of the union genuinely needs the daemon: those names are whatever that
member reports. The registry half never did — its entries are org-scoped and http-proxied,
and nothing about them is a property of the machine an agent happens to run on.

```ts
const candidates = mcpCandidates(daemon?.mcpServers ?? [], registryNames)
```

Every case that worked before is unchanged: a resolved daemon still unions both halves, and
mock mode still gets the registry alone (it was already passing `[]` there).

## Two labels came with it

Both named a daemon at a moment the console has none, and both became reachable for pool
agents only because the card now renders for them at all:

- empty state: "No MCP servers on this daemon's runtime." → "No MCP servers available to this agent."
- stale saved name: "Not reported by this daemon" → "Not available to this agent"

## Verification

`AgentToolsCard.test.tsx` is new — the repo had no test for this component. Three rows:
no-daemon lists the registry, a resolved daemon still unions both halves, and a genuinely
empty registry still shows the empty state. I checked the first one fails against the old
expression and passes against the new one, so it pins the actual regression rather than
just the current behaviour.

Web typecheck, lint and format clean; full web suite 1679/1679.

Not verified in a browser: the fix is only observable against a real Control Plane with a
pool-placed agent and a non-empty org registry, and mock mode already took the registry
path this change preserves — so a local preview would render identically either way. The
component test covers what a preview could not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
