### PR TITLE
refactor(dream): stage into a real memory store, not a bare output dir

### DIFF
--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -232,6 +232,19 @@ const LAST_SUCCESSFUL_DREAM_SCAN = 50
 const MAX_AUTO_SESSION_WINDOW = 100
 const DREAMS_DIRNAME = 'memory-dreams'
 const BACKUPS_DIRNAME = 'memory-backups'
+/** A dream stages into a real memory store (`<dream>/memory/`), so every store helper
+ *  — listing, index generation, the memory tools — works on it unchanged. Dreams
+ *  staged before that lived in `output/`; those keep resolving for review and adoption. */
+const LEGACY_STAGED_DIRNAME = 'output'
+
+/** The staged store for a dream: the current layout when present, else the legacy one. */
+async function resolveStagedDir(fs: MemoryFs, base: string): Promise<string> {
+  const current = join(base, MEMORY_DIRNAME)
+  if ((await fs.readdir(current)).length > 0) return current
+  const legacy = join(base, LEGACY_STAGED_DIRNAME)
+  return (await fs.readdir(legacy)).length > 0 ? legacy : current
+}
+
 /** Staged file names are the validator's own outputs; anything else is a violation. */
 const STAGED_NAME_RE = /^[a-z0-9][a-z0-9-]{0,62}\.md$/
 
@@ -712,7 +725,8 @@ export class DreamRunner {
       // stage() is several awaited writes; a cancel can land while it runs.
       // Cancel-wins: honor it, drop the partial output, don't flip to completed.
       if ((await this.deps.store.getDream(agentId, dreamId))?.status !== 'running') {
-        await fs.rm(join(base, 'output')).catch(() => {})
+        await fs.rm(join(base, MEMORY_DIRNAME)).catch(() => {})
+        await fs.rm(join(base, LEGACY_STAGED_DIRNAME)).catch(() => {})
         return
       }
       await this.finish(agentId, dreamId, {
@@ -795,8 +809,9 @@ export class DreamRunner {
   }
 
   private async stage(fs: MemoryFs, base: string, proposal: DreamProposal): Promise<DreamOrganizationSuggestionInfo[]> {
-    const out = join(base, 'output')
+    const out = join(base, MEMORY_DIRNAME)
     await fs.rm(out)
+    await fs.rm(join(base, LEGACY_STAGED_DIRNAME))
     await fs.mkdir(out)
     const staged: MemoryIndexEntry[] = []
     for (const file of proposal.files) {
@@ -1013,7 +1028,7 @@ export class DreamRunner {
       if (dream.status !== 'completed') throw new DreamStateError(`cannot adopt a ${dream.status} dream`)
       if (this.active.has(agentId)) throw new DreamStateError('a dream is in flight for this agent; wait or cancel it')
 
-      const out = join(this.dreamDir(agentId, dreamId), 'output')
+      const out = await resolveStagedDir(fs, this.dreamDir(agentId, dreamId))
       const stagedNames = (await fs.readdir(out))
         .filter((entry) => entry.kind === 'file' && stagedPathOk(entry.name))
         .map((entry) => entry.name)
@@ -1344,7 +1359,7 @@ export class DreamRunner {
       (dream.skills ?? []).some((skill) => skill.state === 'proposed') ||
       (dream.organizationSuggestions ?? []).some((suggestion) => suggestion.state === 'proposed')
     if (pending) {
-      for (const part of ['input', 'output']) await fs.rm(join(base, part))
+      for (const part of ['input', MEMORY_DIRNAME, LEGACY_STAGED_DIRNAME]) await fs.rm(join(base, part))
     } else {
       await fs.rm(base)
     }
@@ -1574,7 +1589,7 @@ export class DreamRunner {
   async stagedFiles(agentId: string, dreamId: string): Promise<{ name: string; size: number; mtime: string }[] | null> {
     this.assertStagedContentAllowed()
     await this.getDream(agentId, dreamId)
-    const out = join(this.dreamDir(agentId, dreamId), 'output')
+    const out = await resolveStagedDir(this.fsFor(agentId), this.dreamDir(agentId, dreamId))
     // A staged store always carries its index, so no entries means no staging (absent is data).
     const staged = (await this.fsFor(agentId).readdir(out)).filter(
       (entry) => entry.kind === 'file' && stagedPathOk(entry.name)
@@ -1597,7 +1612,8 @@ export class DreamRunner {
     this.assertStagedContentAllowed()
     await this.getDream(agentId, dreamId)
     if (!stagedPathOk(path)) throw new DreamViolationError('staged memory paths are plain kebab-case .md names')
-    const file = await this.fsFor(agentId).readFile(join(this.dreamDir(agentId, dreamId), 'output', path))
+    const stagedDir = await resolveStagedDir(this.fsFor(agentId), this.dreamDir(agentId, dreamId))
+    const file = await this.fsFor(agentId).readFile(join(stagedDir, path))
     return file ? { content: file.content, mtime: file.mtime } : null
   }
 
@@ -1609,7 +1625,7 @@ export class DreamRunner {
     this.assertStagedContentAllowed()
     await this.getDream(agentId, dreamId)
     const fs = this.fsFor(agentId)
-    const out = join(this.dreamDir(agentId, dreamId), 'output')
+    const out = await resolveStagedDir(fs, this.dreamDir(agentId, dreamId))
     const names = (await fs.readdir(out))
       .filter((entry) => entry.kind === 'file' && stagedPathOk(entry.name))
       .map((entry) => entry.name)

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, readdir, stat, utimes, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, utimes, writeFile } from 'node:fs/promises'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -742,7 +742,8 @@ describe('DreamRunner adoption', () => {
     // Seed a live keep.md byte-identical to what the dream staged, and backdate
     // every current file so "fresh" is unambiguous. Adopt with force since this
     // live edit intentionally drifts from the dream's start snapshot.
-    const out = join(dir, 'memory-dreams', started.dreamId, 'output')
+    // A dream stages into a real memory store now, so its files live under `memory/`.
+    const out = join(dir, 'memory-dreams', started.dreamId, 'memory')
     const stagedKeep = await readFile(join(out, 'keep.md'), 'utf8')
     await writeMemoryFile(local(dir), 'keep.md', stagedKeep, undefined, 'tool')
     const OLD = new Date('2020-01-01T00:00:00.000Z')
@@ -764,7 +765,8 @@ describe('DreamRunner adoption', () => {
     await settle(store, started.dreamId)
 
     // The review token is the digest of the exact staged output the user reviewed.
-    const out = join(dir, 'memory-dreams', started.dreamId, 'output')
+    // A dream stages into a real memory store now, so its files live under `memory/`.
+    const out = join(dir, 'memory-dreams', started.dreamId, 'memory')
     const names = await readdir(out)
     const stagedFiles = await Promise.all(
       names.map(async (name) => ({ name, content: await readFile(join(out, name), 'utf8') }))
@@ -1191,6 +1193,32 @@ describe('DreamRunner crash recovery', () => {
     await runner.reclaimDreams(['a1'])
     expect(store.dreams.get('drm-peer')?.status).toBe('completed')
     expect(failures).toEqual(['drm-peer'])
+  })
+
+  it('still reviews and adopts a dream staged under the legacy output/ layout', async () => {
+    // Dreams staged before the store-shaped layout keep their files in `output/`.
+    // They must stay reviewable and adoptable rather than reading as unstaged.
+    const { dir, store, runner } = await setup({})
+    const started = await runner.start('a1', { trigger: 'manual' })
+    await settle(store, started.dreamId)
+
+    // Rewrite this dream the old way: same bytes, legacy directory.
+    const base = join(dir, 'memory-dreams', started.dreamId)
+    const current = join(base, 'memory')
+    const legacy = join(base, 'output')
+    await mkdir(legacy, { recursive: true })
+    for (const name of await readdir(current)) {
+      await writeFile(join(legacy, name), await readFile(join(current, name), 'utf8'))
+    }
+    await rm(current, { recursive: true, force: true })
+
+    const staged = await runner.stagedFiles('a1', started.dreamId)
+    expect(staged?.some((f) => f.name === 'prefs.md')).toBe(true)
+    expect((await runner.stagedRead('a1', started.dreamId, 'prefs.md'))?.content).toContain('2026-07-24')
+
+    const adopted = await runner.adopt('a1', started.dreamId, false)
+    expect(adopted.status).toBe('adopted')
+    expect(await readMemoryFile(local(dir), 'prefs.md')).toContain('2026-07-24')
   })
 
   it('sweeps reconciled superseded staging while preserving proposed skills', async () => {


### PR DESCRIPTION
Layout prerequisite for item 3 (the dream writing its proposal through the shared memory tools). Landing it separately because it touches the adoption path and the review-token digest — those should move under the existing tests, not alongside a behaviour change.

## What

A dream staged into `<dream>/output/`, a flat directory only the dream code understood. It now stages into `<dream>/memory/`, so **the staged proposal is a real memory store**: `listMemory`, index generation, and (next) the memory tools all work on it unchanged, instead of the dream carrying a parallel implementation of each.

## Compatibility

Dreams staged before this keep working. One `resolveStagedDir` helper prefers the current layout and falls back to `output/` when only that is populated, so an in-flight proposal stays reviewable and adoptable. Sweeps and cancels clear both.

## Tests

The whole dream suite (71) passes against the new layout, plus a new case that rewrites a staged dream into the legacy directory and asserts staged listing, staged read, and adoption all still work — that fallback is the risky part of this change, so it's covered directly rather than by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)