### PR TITLE
feat(console): link a session's own pull request, and keep the dock's panels fresh

### DIFF
--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -148,9 +148,25 @@ read path to keep in step:
 | a **poll**                | the tab is selected AND the document is visible   | Files/Git 15s, PR 60s (§9's GitHub budget), Tasks 5s/20s as before      |
 | the **reveal edge**       | a tab becoming active, or the browser coming back | whoever deferred a turn refresh while hidden                            |
 
+A refresh is also no longer a RESET. `useWorkspaceTree` used to wipe its cache and
+its expand set on every `refreshTick`, which was defensible for a press and is
+not on a timer: it would close the reader's folders every 15 seconds and shrink
+the path filter's corpus (derived from the same cache) to root-level hits with
+them. A refresh now re-reads the root **and each open folder** in place, silently
+— the rows stand until the new listing lands. Only a SCOPE change still resets,
+because there the previous expand set names paths in another checkout. For the
+same reason the Git panel draws its last SETTLED outcome while a re-read is in
+flight, rather than repainting the branch line as "Git status unavailable" every
+few seconds — the latch the commit box already used, applied to the header.
+
 Two rules make the cost defensible. A background tab and a background BROWSER
 both poll **nothing** — these reads reach a daemon, and for the PR panel an
-installation's rate limit. And a turn's edge reaches a HIDDEN panel only where
+installation's rate limit. The PR tab's 404 retry ladder is gated on document
+visibility for the same reason, and that gate is new with §12.6's second identity
+source: a runless session's 404 is no longer answered from CP tables alone — it
+costs a `workspace/gitstatus` REQ and, for a pushed branch with no PR, a GitHub
+list. It is deliberately NOT gated on the tab being active, because a held 404
+REMOVES the tab, leaving no tab to reveal and no way back. And a turn's edge reaches a HIDDEN panel only where
 that tab shows a badge whose numbers are on screen anyway (Git's changed count,
 PR's unresolved threads); a panel without one defers the read to the reveal edge
 rather than re-reading a worktree nobody is looking at. The Git panel also skips

--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -136,6 +136,32 @@ Revision 2 **removed** the Fetch / Pull / Stash button row that revision 1 had.
 the `sessionId` extension that revision 1 called for. Refresh is the tab's
 `refresh-cw` header action, which re-reads status — not a network pull.
 
+**The refresh cadence (landed after M6).** A pressed refresh is not the only one:
+every panel here reads a LIVE surface, so one that re-read only on demand showed
+the tree as it was when the page opened. `dock/auto-refresh.ts` owns the three
+signals, and every panel bumps the same tick a press does — there is no second
+read path to keep in step:
+
+| signal                    | when                                              | who takes it                                                            |
+| ------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------- |
+| a turn's **falling edge** | the agent's own writes have landed                | Files, Git, PR, Tasks — the highest-value signal, and free of any timer |
+| a **poll**                | the tab is selected AND the document is visible   | Files/Git 15s, PR 60s (§9's GitHub budget), Tasks 5s/20s as before      |
+| the **reveal edge**       | a tab becoming active, or the browser coming back | whoever deferred a turn refresh while hidden                            |
+
+Two rules make the cost defensible. A background tab and a background BROWSER
+both poll **nothing** — these reads reach a daemon, and for the PR panel an
+installation's rate limit. And a turn's edge reaches a HIDDEN panel only where
+that tab shows a badge whose numbers are on screen anyway (Git's changed count,
+PR's unresolved threads); a panel without one defers the read to the reveal edge
+rather than re-reading a worktree nobody is looking at. The Git panel also skips
+an automatic read while one of its OWN writes is in flight — that write answers
+with the fresh status, and a read racing it would land the pre-write tree over
+the reply.
+
+Which turn: the workspace panels follow HEADER FOCUS, so their edge is the
+focused participant's turn — the PR tab, which is keyed to the open session
+(§3.4), takes that session's.
+
 Consequence for sequencing: the Git panel's rows are _stage toggles_ in this
 revision, so a read-only Git tab is a visibly amputated version of the design.
 It is still worth shipping first — a reviewer reading what the agent changed is
@@ -143,6 +169,11 @@ the majority use — but the milestone must render the toggles absent rather tha
 inert, and say so.
 
 ### 3.4 PR — linkage exists, both the read projection and the write loop are new
+
+> Revised after M6: the run is no longer the ONLY identity source. A session
+> with no pull-request run resolves its PR from the worktree's own head branch
+> instead — see §12.6's "second identity source", which is where that contract
+> and its five deliberate limits live.
 
 `HookRun` already stores everything needed to _find_ the PR for a session:
 `sessionId`, `repoFullName`, `repoId`, `pullNumber`, `headSha`, `baseSha`,
@@ -416,6 +447,7 @@ FilesPanel.tsx         narrow single-column tree over WorkspaceFiles' read model
 GitPanel.tsx           status + numstat + staging + commit box + log
 PullRequestPanel.tsx   the /sessions/:id/pull-request projection + Auto-fix / auto-merge actions
 TasksPanel.tsx         task list (read-only — §3.5); polls while visible, backed off when idle
+auto-refresh.ts        the dock's shared cadence: turn edge / poll / reveal edge (§3.3)
 ```
 
 and `packages/web/src/components/console/viewer/`:
@@ -1082,16 +1114,52 @@ list; `HookRun`'s recorded review appears only as the degraded-arm fallback
    would make right.
 
    **What this action cannot do, and how the panel says so.** A PR the agent
-   opens from a conversation creates no `HookRun`, and PR identity comes from
-   the run that owns the session — so the probe keeps answering 404 after the
-   pull request exists. The panel therefore does not pretend the action closed
-   the loop: once asked, it says the agent replies with the URL in the
-   conversation and that this tab links a PR only for a review run, and the
-   control becomes **Ask again**. The instruction itself is idempotent (open
-   one, or report the existing one), so pressing again cannot yield a second PR
-   for the branch. Making the tab link a self-opened PR needs either a durable
-   session↔PR binding or a by-head-branch read source, both of which change the
-   §3.4 identity contract and belong in their own change.
+   opens from a conversation creates no `HookRun`, so a tab whose identity came
+   only from the owning run kept answering 404 after the pull request existed.
+   That gap is now closed by the second identity source below; what remains is
+   a timing statement, and the panel says exactly that: once asked, it says the
+   agent replies with the URL in the conversation and that this tab links the PR
+   once the branch is pushed and one exists for it, and the control becomes
+   **Ask again**. The instruction itself is idempotent (open one, or report the
+   existing one), so pressing again cannot yield a second PR for the branch.
+
+   **The second identity source (landed).** With no pull-request run, the route
+   resolves the PR from the session worktree's OWN head branch:
+   `SessionPullRequestLinkService` reads the branch from the owning daemon
+   (`workspace/gitstatus`, session-scoped), resolves the agent's primary
+   workspace repo and live installation (`GithubService.resolveWorkspaceRepo`),
+   and asks GitHub `GET /repos/{o}/{r}/pulls?state=all&head=<owner>:<branch>`.
+   The chosen number then joins the SAME projection a run-linked PR takes, so
+   checks, reviews, threads, Auto-fix and auto-merge all work unchanged. Five
+   things this deliberately keeps:
+
+   - **The run stays PREFERRED.** It carries the review facts a branch lookup
+     cannot know — the subject's open state, the run's draft fact, the agent's
+     own recorded review — which are exactly what a degraded answer falls back
+     on. The branch is the fallback, never an override.
+   - **The branch, not the head sha.** A session branch is amended and rebased;
+     its sha is not stable and `commits/{sha}/pulls` would go blind on the next
+     rewrite. `head=` is fork-blind by construction, which reads as the absence
+     it is.
+   - **Absence, not degradation.** An unreachable, denied or rate-limited
+     lookup resolves `null` — the degraded arm needs a PR to NAME, and identity
+     that never resolved has none. The panel keeps its no-PR state for all of
+     them.
+   - **Only a session worktree.** A shared checkout is the agent's primary tree
+     and its branch is no session's work; a purged session has no worktree left.
+     Both skip the daemon read entirely, as does an offline or too-old daemon —
+     so a session that can never resolve a PR spends none of the installation's
+     quota.
+   - **The ambiguity is reported, not hidden.** Several open PRs on one head are
+     all equally "this session's": the lowest number wins (the first opened for
+     the branch is the canonical review) and `linkAmbiguous` makes the panel say
+     so. With none open, the highest number wins instead — the newest attempt is
+     what describes the branch's fate. Two TTLs bound the cost: 60s for a link,
+     15s for a miss (a PR opened seconds ago must not stay invisible), both
+     bypassed by the panel's own refresh.
+
+   `linkedBy` (`run` | `head-branch`), `linkBranch` and `linkAmbiguous` are on
+   the DTO so the console can say which question it answered.
 
 7. **Write authorization.** Committing as the agent and resolving GitHub threads
    from the console are new classes of action. Does workspace-write access plus

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -14,7 +14,11 @@
 import type { FastifyInstance, FastifyServerOptions } from 'fastify'
 import type { PrismaClient } from './generated/prisma/client.js'
 import type { WebSocketServer } from 'ws'
-import { DUTY_GRANT_MEMBERS_MAX, HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED } from '@agentconnect.md/protocol'
+import {
+  DUTY_GRANT_MEMBERS_MAX,
+  HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED,
+  WORKSPACE_SESSION_READ_FEATURE
+} from '@agentconnect.md/protocol'
 
 import { type AppConfig, resolveWebAppUrl } from './config/env.js'
 import { resolveGithubAppConfig } from './github/config.js'
@@ -28,6 +32,7 @@ import { GithubCommentAuthzService } from './github/comment-authz.service.js'
 import { GithubRerequestService } from './github/rerequest.service.js'
 import { GithubReviewBrokerService } from './github/review-broker.service.js'
 import { PullRequestViewService } from './github/pull-request-view.service.js'
+import { SessionPullRequestLinkService } from './github/session-pull-request-link.service.js'
 import { GithubRunCoordinator, GithubRunReporter } from './github/run-reporter.js'
 import { githubProjectionIntent } from './github/projection-intent.js'
 import { HookRedeliveryReconciler } from './orchestrator/hookRedeliveryReconciler.js'
@@ -889,6 +894,36 @@ export function buildContainer(
     : undefined
   // The console PR panel's read projection — long-lived so its short TTL cache actually absorbs mounts.
   const pullRequestView = github ? new PullRequestViewService(github.tokens, clock, opts.githubFetch) : undefined
+  // §12.6's second identity source for that panel: the PR a session's own head branch has, for the
+  // sessions no pull-request run owns. Long-lived for the same reason — its TTL absorbs panel mounts.
+  const sessionPullRequestLink =
+    github && pullRequestView
+      ? new SessionPullRequestLinkService({
+          clock,
+          github,
+          tokens: github.tokens,
+          readSessionBranch: async (agent, session) => {
+            if (!agent.daemonId) return null
+            const daemon = await registry.getAvailable(agent.orgId, agent.daemonId)
+            // An older daemon drops the frame silently, so the REQ would burn its retransmit budget
+            // and then read as an offline daemon — refuse first, exactly as the workspace routes do.
+            if (!daemon?.capabilities.features.includes(WORKSPACE_SESSION_READ_FEATURE)) return null
+            try {
+              const status = await sender.workspaceGitStatus(agent.daemonId, {
+                agentId: agent.id,
+                sessionId: session.id
+              })
+              return status.isRepo ? (status.branch ?? null) : null
+            } catch {
+              // An offline daemon, a REQ timeout and a non-repo workspace are one answer here: no
+              // branch to resolve a PR through. The panel keeps its own no-PR state for all of them.
+              return null
+            }
+          },
+          log: { warn: (obj, message) => http.log.warn(obj, message) },
+          ...(opts.githubFetch ? { fetchImpl: opts.githubFetch } : {})
+        })
+      : undefined
   const githubReviewBroker = github
     ? new GithubReviewBrokerService({
         hook: repos.hook,
@@ -1146,6 +1181,7 @@ export function buildContainer(
     resolvePublicRepo: createPublicRepoResolver(),
     ...(github ? { github } : {}),
     ...(pullRequestView ? { pullRequestView } : {}),
+    ...(sessionPullRequestLink ? { sessionPullRequestLink } : {}),
     ...(githubUserAuthz ? { githubUserAuthz } : {}),
     ...(logtoIdentity ? { logtoIdentity } : {}),
     sessionAccessPlugins: [slackSessionAccess, githubSessionAccess, feishuSessionAccess],

--- a/packages/control-plane/src/github/service.ts
+++ b/packages/control-plane/src/github/service.ts
@@ -850,6 +850,41 @@ export class GithubService {
     }
   }
 
+  /**
+   * The repo + live installation behind an agent's PRIMARY workspace checkout, for a reader that has
+   * only a repo NAME and no hook run to take identity from (webchat-side-panels.md §12.6). Absence is
+   * DATA here — a scratch workspace, a revoked or suspended installation and a repo out of the grant
+   * set all read `null` rather than throwing, because the caller's answer to any of them is the same
+   * "no pull request to name". The numeric id is the agent's captured one where it has one, and is
+   * repaired through the installation's metadata token where it does not.
+   */
+  async resolveWorkspaceRepo(
+    agent: AgentRecord
+  ): Promise<{ repoId: bigint; repoFullName: string; installationId: bigint } | null> {
+    const workspace = agent.workspace
+    if (workspace.mode !== 'github' || workspace.installationId === undefined) return null
+    const label = gitRepoLabel(workspace.gitRepo)
+    const [owner, repo] = label.split('/')
+    if (!owner || !repo) return null
+    // By ACCOUNT LOGIN against live rows, like every other mint path: the stored installationId is
+    // provenance only, so an uninstall→reinstall self-heals here too.
+    const installation = await this.deps.installations.liveByOrgAndAccount(agent.orgId, owner)
+    if (!installation || installation.orgId !== agent.orgId || installation.suspendedAt) return null
+    if (agent.workspaceRepoId !== undefined) {
+      return { repoId: agent.workspaceRepoId, repoFullName: label, installationId: installation.installationId }
+    }
+    try {
+      const ref = await this.repoRefFor(installation, owner, repo)
+      if (!ref) return null
+      // Best-effort repair, exactly as resolveAgentRepoAuthorization does it: a losing race just
+      // means the next read resolves the id again, which is cheaper than failing this one.
+      await this.deps.agents?.setWorkspaceRepoId(agent.id, ref.repoId).catch(() => {})
+      return { repoId: ref.repoId, repoFullName: ref.fullName, installationId: installation.installationId }
+    } catch {
+      return null
+    }
+  }
+
   /** Whether the console may arm auto-merge for this agent's PR — the GET projection's per-caller
    *  capability flag, Postgres-only (no GitHub call): a read/comment tier renders a disabled control. */
   async canArmAutoMerge(agent: AgentRecord, repoId: bigint, repoFullName: string): Promise<boolean> {

--- a/packages/control-plane/src/github/session-pull-request-link.service.test.ts
+++ b/packages/control-plane/src/github/session-pull-request-link.service.test.ts
@@ -1,0 +1,178 @@
+// `SessionPullRequestLinkService` — the head-branch identity source (webchat-side-panels.md §12.6):
+// which PR a branch means, which sessions never reach GitHub at all, and the two TTLs. GitHub is a
+// scripted `fetchImpl`; no network, no Postgres.
+import { describe, it, expect, vi } from 'vitest'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+import {
+  SessionPullRequestLinkService,
+  chooseHeadPull,
+  SESSION_PR_LINK_TTL_MS,
+  SESSION_PR_LINK_MISS_TTL_MS,
+  type HeadPull
+} from './session-pull-request-link.service.js'
+import type { GithubService } from './service.js'
+import type { InstallationTokenService } from './installation-token.service.js'
+import type { FetchLike } from './api.js'
+import type { AgentRecord, SessionMetaRecord } from '../persistence/ports.js'
+import { AgentId, OrgId, SessionId } from '../domain/ids.js'
+
+const AGENT = { id: AgentId('agent-1'), orgId: OrgId('org_a') } as unknown as AgentRecord
+
+const SESSION = {
+  id: SessionId('sess-1'),
+  orgId: OrgId('org_a'),
+  agentId: AgentId('agent-1'),
+  workspaceIsolation: 'session',
+  contentPurgedAt: null
+} as unknown as SessionMetaRecord
+
+const REPO = { repoId: 42n, repoFullName: 'acme/repo', installationId: 111n }
+
+const pull = (number: number, state: string, ref = 'dev/jane/panel'): HeadPull => ({
+  number,
+  state,
+  head: { ref }
+})
+
+function harness(opts: { pulls?: HeadPull[][]; branch?: string | null; repo?: typeof REPO | null }): {
+  service: SessionPullRequestLinkService
+  clock: FakeClock
+  fetch: ReturnType<typeof vi.fn>
+  readBranch: ReturnType<typeof vi.fn>
+  resolveRepo: ReturnType<typeof vi.fn>
+} {
+  const clock = new FakeClock(1_760_000_000_000)
+  const pages = [...(opts.pulls ?? [[pull(7, 'open')]])]
+  const fetch = vi.fn(async () => {
+    const next = pages.shift() ?? []
+    return new Response(JSON.stringify(next), { status: 200, headers: { 'content-type': 'application/json' } })
+  })
+  const readBranch = vi.fn(async () => (opts.branch === undefined ? 'dev/jane/panel' : opts.branch))
+  const resolveRepo = vi.fn(async () => (opts.repo === undefined ? REPO : opts.repo))
+  const service = new SessionPullRequestLinkService({
+    clock,
+    github: { resolveWorkspaceRepo: resolveRepo } as unknown as GithubService,
+    tokens: {
+      mintPullRequestRead: async () => ({ token: 'ghs_test' })
+    } as unknown as InstallationTokenService,
+    readSessionBranch: readBranch,
+    fetchImpl: fetch as unknown as FetchLike
+  })
+  return { service, clock, fetch, readBranch, resolveRepo }
+}
+
+describe('chooseHeadPull', () => {
+  it('prefers the FIRST open pull request and reports the ambiguity', () => {
+    expect(chooseHeadPull([pull(9, 'open'), pull(4, 'open'), pull(2, 'closed')], 'dev/jane/panel')).toEqual({
+      pullNumber: 4,
+      ambiguous: true
+    })
+  })
+
+  it('takes the newest closed attempt when none is open, without calling that ambiguous', () => {
+    expect(chooseHeadPull([pull(3, 'closed'), pull(8, 'closed')], 'dev/jane/panel')).toEqual({
+      pullNumber: 8,
+      ambiguous: false
+    })
+  })
+
+  it('is null for an empty answer, and drops a row whose head is another branch', () => {
+    expect(chooseHeadPull([], 'dev/jane/panel')).toBeNull()
+    expect(chooseHeadPull([pull(5, 'open', 'main')], 'dev/jane/panel')).toBeNull()
+  })
+
+  it('keeps a row that carries no head at all — the filter already narrowed it', () => {
+    expect(chooseHeadPull([{ number: 5, state: 'open' }], 'dev/jane/panel')).toEqual({
+      pullNumber: 5,
+      ambiguous: false
+    })
+  })
+})
+
+describe('SessionPullRequestLinkService', () => {
+  it('resolves the branch’s pull request and asks GitHub for that head only', async () => {
+    const { service, fetch } = harness({})
+
+    expect(await service.resolve(AGENT, SESSION)).toEqual({
+      ...REPO,
+      pullNumber: 7,
+      branch: 'dev/jane/panel',
+      ambiguous: false
+    })
+    const url = String(fetch.mock.calls[0]![0])
+    expect(url).toContain('/repos/acme/repo/pulls')
+    expect(url).toContain(`head=${encodeURIComponent('acme:dev/jane/panel')}`)
+    expect(url).toContain('state=all')
+  })
+
+  it('spends NO GitHub call for a shared checkout, a purged session, or a branchless worktree', async () => {
+    const shared = harness({})
+    expect(
+      await shared.service.resolve(AGENT, { ...SESSION, workspaceIsolation: 'shared' } as SessionMetaRecord)
+    ).toBeNull()
+    expect(shared.readBranch).not.toHaveBeenCalled()
+
+    const purged = harness({})
+    expect(
+      await purged.service.resolve(AGENT, { ...SESSION, contentPurgedAt: new Date() } as SessionMetaRecord)
+    ).toBeNull()
+    expect(purged.readBranch).not.toHaveBeenCalled()
+
+    // No branch ⇒ the repo is never even resolved: an offline daemon must not spend the installation's quota.
+    const detached = harness({ branch: null })
+    expect(await detached.service.resolve(AGENT, SESSION)).toBeNull()
+    expect(detached.resolveRepo).not.toHaveBeenCalled()
+    expect(detached.fetch).not.toHaveBeenCalled()
+  })
+
+  it('reads a denied GitHub answer as an absence, cached as a miss', async () => {
+    const clock = new FakeClock(1_760_000_000_000)
+    const fetch = vi.fn(async () => new Response(JSON.stringify({ message: 'nope' }), { status: 403 }))
+    const service = new SessionPullRequestLinkService({
+      clock,
+      github: { resolveWorkspaceRepo: async () => REPO } as unknown as GithubService,
+      tokens: { mintPullRequestRead: async () => ({ token: 'ghs_test' }) } as unknown as InstallationTokenService,
+      readSessionBranch: async () => 'dev/jane/panel',
+      fetchImpl: fetch as unknown as FetchLike
+    })
+
+    expect(await service.resolve(AGENT, SESSION)).toBeNull()
+    expect(await service.resolve(AGENT, SESSION)).toBeNull()
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('holds a link for its TTL, a miss for the shorter one, and re-reads on force', async () => {
+    const { service, clock, fetch } = harness({ pulls: [[pull(7, 'open')], [pull(9, 'open')], [pull(11, 'open')]] })
+
+    expect((await service.resolve(AGENT, SESSION))?.pullNumber).toBe(7)
+    clock.advance(SESSION_PR_LINK_TTL_MS - 1)
+    expect((await service.resolve(AGENT, SESSION))?.pullNumber).toBe(7)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // The panel's refresh bypasses the live entry.
+    expect((await service.resolve(AGENT, SESSION, true))?.pullNumber).toBe(9)
+    clock.advance(SESSION_PR_LINK_TTL_MS)
+    expect((await service.resolve(AGENT, SESSION))?.pullNumber).toBe(11)
+    expect(fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('re-asks a miss after the miss TTL — a PR opened seconds ago must appear', async () => {
+    const { service, clock, fetch } = harness({ pulls: [[], [pull(7, 'open')]] })
+
+    expect(await service.resolve(AGENT, SESSION)).toBeNull()
+    clock.advance(SESSION_PR_LINK_MISS_TTL_MS - 1)
+    expect(await service.resolve(AGENT, SESSION)).toBeNull()
+    expect(fetch).toHaveBeenCalledTimes(1)
+    clock.advance(1)
+    expect((await service.resolve(AGENT, SESSION))?.pullNumber).toBe(7)
+  })
+
+  it('invalidateSession drops the held link', async () => {
+    const { service, fetch } = harness({ pulls: [[pull(7, 'open')], [pull(8, 'open')]] })
+
+    expect((await service.resolve(AGENT, SESSION))?.pullNumber).toBe(7)
+    service.invalidateSession(SESSION)
+    expect((await service.resolve(AGENT, SESSION))?.pullNumber).toBe(8)
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/control-plane/src/github/session-pull-request-link.service.test.ts
+++ b/packages/control-plane/src/github/session-pull-request-link.service.test.ts
@@ -167,12 +167,19 @@ describe('SessionPullRequestLinkService', () => {
     expect((await service.resolve(AGENT, SESSION))?.pullNumber).toBe(7)
   })
 
-  it('invalidateSession drops the held link', async () => {
-    const { service, fetch } = harness({ pulls: [[pull(7, 'open')], [pull(8, 'open')]] })
+  it('shares one resolution between concurrent probes, forced or not', async () => {
+    // A resolution is a daemon round trip plus a GitHub list; two panels mounting at once, or a read
+    // racing the auto-merge write, must not each spend both.
+    const { service, fetch, readBranch } = harness({ pulls: [[pull(7, 'open')]] })
 
-    expect((await service.resolve(AGENT, SESSION))?.pullNumber).toBe(7)
-    service.invalidateSession(SESSION)
-    expect((await service.resolve(AGENT, SESSION))?.pullNumber).toBe(8)
-    expect(fetch).toHaveBeenCalledTimes(2)
+    const [a, b, c] = await Promise.all([
+      service.resolve(AGENT, SESSION),
+      service.resolve(AGENT, SESSION),
+      service.resolve(AGENT, SESSION, true)
+    ])
+
+    expect([a?.pullNumber, b?.pullNumber, c?.pullNumber]).toEqual([7, 7, 7])
+    expect(readBranch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/control-plane/src/github/session-pull-request-link.service.ts
+++ b/packages/control-plane/src/github/session-pull-request-link.service.ts
@@ -1,0 +1,173 @@
+// `SessionPullRequestLinkService` — the PR panel's SECOND identity source (webchat-side-panels.md
+// §3.4, §12.6): the pull request for the session worktree's OWN head branch, for a session that no
+// pull-request hook run owns — a PR the agent opened mid-conversation, or an issue-dispatched run
+// whose work ended up in one. Identity only: the projection, its cache and its degraded arm all stay
+// `PullRequestViewService`'s, so a resolved link joins the same read path a run-linked PR takes.
+// Failure to establish identity is an ABSENCE, never a degraded view — the degraded arm needs a PR to
+// name, and here there is none — so every unreachable, denied or rate-limited answer reads `null` and
+// is cached as a miss rather than re-asked on the next panel mount.
+import { githubRequest, type FetchLike } from './api.js'
+import type { GithubService } from './service.js'
+import type { InstallationTokenService } from './installation-token.service.js'
+import type { AgentRecord, SessionMetaRecord } from '../persistence/ports.js'
+import type { Clock } from '../domain/clock.js'
+
+// One daemon git read plus one REST list per resolution, so the TTL exists to absorb the panel's own
+// mounts and its 404 retry ladder. Shorter for a miss: a PR the agent just opened must not stay
+// invisible for a minute, and the console's `refresh` bypasses both.
+export const SESSION_PR_LINK_TTL_MS = 60_000
+export const SESSION_PR_LINK_MISS_TTL_MS = 15_000
+
+// Hard bound on retained entries — a link is small, but this cache must not grow with session count.
+export const SESSION_PR_LINK_CACHE_MAX = 512
+
+// Pull requests read per lookup. GitHub's `head` filter already narrows to one branch, so this is the
+// bound on a branch's own history of reopened/closed PRs, not on the repository's.
+const HEAD_PULL_LIMIT = 20
+
+/** The durable half of a branch-resolved PR — the same facts a hook run would have carried. */
+export interface SessionPullRequestLink {
+  repoId: bigint
+  repoFullName: string
+  installationId: bigint
+  pullNumber: number
+  /** The head branch this resolved through, so the panel can say what it matched on. */
+  branch: string
+  /** true ⇒ the branch has more than one OPEN pull request and this is the first of them. */
+  ambiguous: boolean
+}
+
+/** One `GET /repos/{owner}/{repo}/pulls` row, narrowed to what the choice below needs. */
+export interface HeadPull {
+  number: number
+  state?: string
+  head?: { ref?: string } | null
+}
+
+/**
+ * Which pull request a head branch means. Open beats closed, because an open PR is the one a reader
+ * can still act on; among several open ones the LOWEST number wins — the first one opened for this
+ * branch is the canonical review, and a later duplicate must not displace it — and the caller is told
+ * the set was ambiguous rather than left to believe the pick was unique. With none open, the HIGHEST
+ * number wins instead: the newest closed/merged attempt is the one that describes this branch's fate,
+ * and a pile of superseded ones is not an ambiguity anybody can act on.
+ */
+export function chooseHeadPull(
+  pulls: readonly HeadPull[],
+  branch: string
+): { pullNumber: number; ambiguous: boolean } | null {
+  // `head.ref` is re-checked rather than trusted from the query: a filter that silently failed to
+  // narrow would otherwise hand this session the repository's newest unrelated PR.
+  const mine = pulls.filter(
+    (pull) =>
+      Number.isSafeInteger(pull.number) && pull.number > 0 && (pull.head?.ref === undefined || pull.head.ref === branch)
+  )
+  const open = mine.filter((pull) => pull.state === 'open').map((pull) => pull.number)
+  if (open.length > 0) return { pullNumber: Math.min(...open), ambiguous: open.length > 1 }
+  if (mine.length === 0) return null
+  return { pullNumber: Math.max(...mine.map((pull) => pull.number)), ambiguous: false }
+}
+
+export interface SessionPullRequestLinkDeps {
+  clock: Clock
+  github: GithubService
+  tokens: InstallationTokenService
+  /** The owning daemon's read of THIS session's worktree, reduced to its checked-out branch. `null`
+   *  for everything the caller cannot read a session branch from: no live daemon, a daemon too old to
+   *  serve session worktrees, a non-repo workspace, a detached HEAD, or a failed read. */
+  readSessionBranch: (agent: AgentRecord, session: SessionMetaRecord) => Promise<string | null>
+  fetchImpl?: FetchLike
+  baseUrl?: string
+  log?: { warn?: (obj: unknown, msg: string) => void }
+}
+
+interface CacheEntry {
+  at: number
+  link: SessionPullRequestLink | null
+}
+
+export class SessionPullRequestLinkService {
+  private readonly cache = new Map<string, CacheEntry>()
+
+  constructor(private readonly deps: SessionPullRequestLinkDeps) {}
+
+  /** The PR this session's branch has, or null when there is none to name. `force` is the panel's own
+   *  refresh: it re-reads the branch and re-asks GitHub, which is the only way a just-opened PR
+   *  appears before the miss TTL expires. */
+  async resolve(agent: AgentRecord, session: SessionMetaRecord, force = false): Promise<SessionPullRequestLink | null> {
+    // Org in the key beside the session id: the id is a UUID, but this cache holds repo identity and
+    // must never be reachable from another org's read even under a collision.
+    const key = `${session.orgId}#${session.id}`
+    const now = this.deps.clock.now()
+    const hit = this.cache.get(key)
+    if (hit) {
+      const ttl = hit.link ? SESSION_PR_LINK_TTL_MS : SESSION_PR_LINK_MISS_TTL_MS
+      if (!force && now - hit.at < ttl) return hit.link
+      this.cache.delete(key)
+    }
+    const link = await this.read(agent, session)
+    this.store(key, link)
+    return link
+  }
+
+  /** Drop one session's cached link — for a caller that just changed which PR the branch has. */
+  invalidateSession(session: Pick<SessionMetaRecord, 'id' | 'orgId'>): void {
+    this.cache.delete(`${session.orgId}#${session.id}`)
+  }
+
+  private store(key: string, link: SessionPullRequestLink | null): void {
+    const at = this.deps.clock.now()
+    this.cache.delete(key)
+    for (const [k, entry] of this.cache) {
+      if (at - entry.at >= (entry.link ? SESSION_PR_LINK_TTL_MS : SESSION_PR_LINK_MISS_TTL_MS)) this.cache.delete(k)
+    }
+    this.cache.set(key, { at, link })
+    while (this.cache.size > SESSION_PR_LINK_CACHE_MAX) {
+      const oldest = this.cache.keys().next().value
+      if (oldest === undefined) break
+      this.cache.delete(oldest)
+    }
+  }
+
+  private async read(agent: AgentRecord, session: SessionMetaRecord): Promise<SessionPullRequestLink | null> {
+    // A shared checkout is the agent's PRIMARY tree, whose branch is no session's work — the same gate
+    // the console applies before it draws branch facts in this tab. A purged session has no worktree
+    // left to read either, so neither reaches the daemon.
+    if (session.workspaceIsolation !== 'session' || session.contentPurgedAt) return null
+    // The branch first, deliberately: no branch ⇒ no GitHub call at all, which keeps the sessions
+    // that can never resolve a PR (scratch workspaces, offline daemons) off the installation's quota.
+    const branch = await this.deps.readSessionBranch(agent, session)
+    if (!branch) return null
+    const repo = await this.deps.github.resolveWorkspaceRepo(agent)
+    if (!repo) return null
+    const [owner, name] = repo.repoFullName.split('/')
+    if (!owner || !name) return null
+    try {
+      const cred = await this.deps.tokens.mintPullRequestRead(repo.installationId, repo.repoFullName, repo.repoId)
+      // `state=all` because a merged PR is the answer for a finished session, and the panel draws that
+      // state. `head=<owner>:<branch>` only matches a head in the BASE repository's own namespace —
+      // a fork-pushed branch resolves nothing here, which reads as the absence it is.
+      const pulls = await githubRequest<HeadPull[]>(
+        `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/pulls?state=all&per_page=${HEAD_PULL_LIMIT}&head=${encodeURIComponent(`${owner}:${branch}`)}`,
+        {
+          auth: cred.token,
+          ...(this.deps.fetchImpl ? { fetchImpl: this.deps.fetchImpl } : {}),
+          ...(this.deps.baseUrl ? { baseUrl: this.deps.baseUrl } : {})
+        }
+      )
+      const chosen = chooseHeadPull(Array.isArray(pulls) ? pulls : [], branch)
+      if (!chosen) return null
+      return {
+        repoId: repo.repoId,
+        repoFullName: repo.repoFullName,
+        installationId: repo.installationId,
+        pullNumber: chosen.pullNumber,
+        branch,
+        ambiguous: chosen.ambiguous
+      }
+    } catch (err) {
+      this.deps.log?.warn?.({ err, sessionId: session.id }, 'session-pr-link: head-branch lookup failed')
+      return null
+    }
+  }
+}

--- a/packages/control-plane/src/github/session-pull-request-link.service.ts
+++ b/packages/control-plane/src/github/session-pull-request-link.service.ts
@@ -88,6 +88,10 @@ interface CacheEntry {
 
 export class SessionPullRequestLinkService {
   private readonly cache = new Map<string, CacheEntry>()
+  // Concurrent probes for ONE session share the read, like `PullRequestViewService`'s: a resolution is
+  // a daemon round trip plus a GitHub list, and two panels (or a read racing the auto-merge write) must
+  // not each spend both.
+  private readonly inFlight = new Map<string, Promise<SessionPullRequestLink | null>>()
 
   constructor(private readonly deps: SessionPullRequestLinkDeps) {}
 
@@ -105,14 +109,20 @@ export class SessionPullRequestLinkService {
       if (!force && now - hit.at < ttl) return hit.link
       this.cache.delete(key)
     }
-    const link = await this.read(agent, session)
-    this.store(key, link)
-    return link
-  }
-
-  /** Drop one session's cached link — for a caller that just changed which PR the branch has. */
-  invalidateSession(session: Pick<SessionMetaRecord, 'id' | 'orgId'>): void {
-    this.cache.delete(`${session.orgId}#${session.id}`)
+    // A forced read JOINS an in-flight one rather than starting a second: the reader pressing refresh
+    // twice, or two panels mounting at once, is one resolution either way.
+    const running = this.inFlight.get(key)
+    if (running) return running
+    const read = this.read(agent, session)
+      .then((link) => {
+        this.store(key, link)
+        return link
+      })
+      .finally(() => {
+        if (this.inFlight.get(key) === read) this.inFlight.delete(key)
+      })
+    this.inFlight.set(key, read)
+    return read
   }
 
   private store(key: string, link: SessionPullRequestLink | null): void {

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -55,6 +55,7 @@ import type { Clock } from '../domain/clock.js'
 import type { OAuthService } from '../registry/oauthService.js'
 import type { GithubService } from '../github/service.js'
 import type { PullRequestViewService } from '../github/pull-request-view.service.js'
+import type { SessionPullRequestLinkService } from '../github/session-pull-request-link.service.js'
 import type { GithubUserAuthzService } from '../github/user-authz.js'
 import type { LogtoIdentityService } from '../github/logto-identity.js'
 import type { HookService } from '../hooks/hook.service.js'
@@ -364,6 +365,9 @@ export interface HttpDeps {
   github?: GithubService
   /** The PR panel's read projection; absent like {@link github} ⇒ the route 404s, hiding the tab. */
   pullRequestView?: PullRequestViewService
+  /** The panel's second identity source: the PR a session's own head branch has, for the sessions no
+   *  pull-request run owns (§12.6). Absent ⇒ only run-linked sessions resolve a PR, as before. */
+  sessionPullRequestLink?: SessionPullRequestLinkService
   /** Per-user repo authorization (identity assertion, open question #7); absent ⇒ the
    *  org-level model (installation coverage only) and the permission route 404s. */
   githubUserAuthz?: GithubUserAuthzService

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3249,7 +3249,14 @@ export const SessionPullRequestDto = z.object({
   degraded: z.boolean(),
   degradedReason: z.enum(['rate_limited', 'denied', 'unreachable']).nullable(),
   // The agent's own recorded review, present ONLY on a degraded answer — GitHub's list is authoritative when it answered.
-  agentReview: z.enum(['approved', 'changes_requested', 'commented']).nullable()
+  agentReview: z.enum(['approved', 'changes_requested', 'commented']).nullable(),
+  // Which identity source named this pull request: the owning review `run`, or the session worktree's
+  // own head branch. The panel says so, because the two answer different questions about the session.
+  linkedBy: z.enum(['run', 'head-branch']),
+  // The head branch a `head-branch` link resolved through; null for a run-linked PR.
+  linkBranch: z.string().nullable(),
+  // true ⇒ that branch has more than one OPEN pull request and this is the first of them.
+  linkAmbiguous: z.boolean()
 })
 export type SessionPullRequestDtoT = z.infer<typeof SessionPullRequestDto>
 

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -29,6 +29,7 @@ import { ConnectionClosed } from '../../ws/registry.js'
 import { sessionContentReaders } from '../../domain/session-content.js'
 import { visibilityStateOf } from '../../orchestrator/visibilityPush.js'
 import type { PullRequestView } from '../../github/pull-request-view.service.js'
+import type { SessionMetaRecord } from '../../persistence/ports.js'
 import { GithubApiError } from '../../github/api.js'
 import { GitCredDeniedError } from '../../github/service.js'
 import {
@@ -364,8 +365,18 @@ function agentReviewOf(event: string | null): 'approved' | 'changes_requested' |
 }
 
 // Service view -> HTTP body, 1:1 plus the caller's write capability; degradation judgements are the service's.
-function toSessionPullRequestDto(view: PullRequestView, canArmAutoMerge: boolean): SessionPullRequestDtoT {
+function toSessionPullRequestDto(
+  view: PullRequestView,
+  canArmAutoMerge: boolean,
+  // How this PR was found. Defaulted to the run, which is the only source that existed before §12.6.
+  link: { linkedBy: 'run' | 'head-branch'; linkBranch: string | null; linkAmbiguous: boolean } = {
+    linkedBy: 'run',
+    linkBranch: null,
+    linkAmbiguous: false
+  }
+): SessionPullRequestDtoT {
   return {
+    ...link,
     canArmAutoMerge,
     autoMergeArmed: view.autoMergeArmed,
     repoFullName: view.repoFullName,
@@ -1075,8 +1086,21 @@ export function sessionRoutes(deps: HttpDeps) {
       }
     )
 
-    // The session's PR (§3.4): identity from the owning run, live state from GitHub; a GitHub
-    // failure is DATA (`degraded`), and only a session with no pull-request run 404s (hides the tab).
+    // §12.6's second identity source, shared by the PR read and the auto-merge write: the pull request
+    // this session's OWN head branch has, for a session no pull-request run owns — plus the agent whose
+    // grant those writes ride, which for a branch link is the session's own agent rather than a run's.
+    const branchPullRequestLink = async (req: FastifyRequest, session: SessionMetaRecord, force: boolean) => {
+      const links = deps.sessionPullRequestLink
+      if (!links) return null
+      const agent = await deps.repos.agent.get(orgOf(req), session.agentId)
+      if (!agent) return null
+      const link = await links.resolve(agent, session, force)
+      return link ? { ...link, agent } : null
+    }
+
+    // The session's PR (§3.4): identity from the owning run — or, with no run, from the session
+    // worktree's own head branch (§12.6) — and live state from GitHub; a GitHub failure is DATA
+    // (`degraded`), and only a session neither source can name a PR for 404s (hides the tab).
     r.get(
       '/sessions/:id/pull-request',
       {
@@ -1084,7 +1108,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get the session’s pull request',
           description:
-            'The pull request this session was dispatched for: identity (repo, number, url, head/base) from the owning hook run, and live state (checks, current reviews, unresolved review threads) proxied from GitHub in one GraphQL read. GitHub being rate limited, denying the installation, or unreachable is data — `degraded` names which, identity survives, and the live lists are empty — because a panel that still names its PR beats an empty one. 404 when the session has no pull-request run, when the deployment has no GitHub App configured, or when the run predates repo/installation capture; the console hides its PR tab on that. Review thread bodies are user content: proxied, never stored.',
+            'This session’s pull request: identity (repo, number, url, head/base) plus live state (checks, current reviews, unresolved review threads) proxied from GitHub in one GraphQL read. Identity comes from the owning hook run where one exists (`linkedBy: run`, which also carries the review facts a rate-limited answer falls back on); otherwise from the session worktree’s own head branch (`linkedBy: head-branch`, `linkBranch`), so a pull request the agent opened mid-conversation is linked too — `linkAmbiguous` says the branch has more than one open pull request and this is the first of them. GitHub being rate limited, denying the installation, or unreachable is data — `degraded` names which, identity survives, and the live lists are empty — because a panel that still names its PR beats an empty one. 404 when neither source names a pull request (no run and no pull request for the branch, a shared or purged workspace, an offline daemon) or when the deployment has no GitHub App configured; the console then draws its branch state and a create action instead. Review thread bodies are user content: proxied, never stored.',
           operationId: 'getSessionPullRequest',
           params: IdParam,
           querystring: SessionPullRequestQueryDto,
@@ -1100,8 +1124,31 @@ export function sessionRoutes(deps: HttpDeps) {
         const view = deps.pullRequestView
         if (!view) return absent()
         const run = await deps.repos.hook.latestPullRequestRunForSession(orgOf(req), owned.session.id)
-        // Legacy rows predate repo/installation capture — nothing to mint against, so the PR reads absent.
-        if (!run?.pullNumber || !run.repoId || !run.repoFullName || !run.sourceInstallationId) return absent()
+        // No run, or a legacy row that predates repo/installation capture (nothing to mint against):
+        // fall back to the branch. A PR the agent opened from a conversation creates no HookRun at all,
+        // which is the whole reason this arm exists — the run stays the PREFERRED source, because it
+        // also carries the review facts (subject, draft, recorded review) a branch lookup cannot know.
+        if (!run?.pullNumber || !run.repoId || !run.repoFullName || !run.sourceInstallationId) {
+          const link = await branchPullRequestLink(req, owned.session, req.query.refresh === true)
+          if (!link) return absent()
+          const canArmBranch = deps.github
+            ? await deps.github.canArmAutoMerge(link.agent, link.repoId, link.repoFullName)
+            : false
+          return toSessionPullRequestDto(
+            await view.view(
+              {
+                orgId: orgOf(req),
+                installationId: link.installationId,
+                repoId: link.repoId,
+                repoFullName: link.repoFullName,
+                pullNumber: link.pullNumber
+              },
+              req.query.refresh === true
+            ),
+            canArmBranch,
+            { linkedBy: 'head-branch', linkBranch: link.branch, linkAmbiguous: link.ambiguous }
+          )
+        }
         // The subject's own open/draft facts feed the degraded arm, so a rate-limited panel still names them.
         const subject = run.projectionId
           ? (await deps.repos.hook.listReviewSubjects(run.projectionId)).find((s) => s.pullNumber === run.pullNumber)
@@ -1139,7 +1186,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Arm or disarm auto-merge on the session’s pull request',
           description:
-            'Enables or disables GitHub auto-merge (squash) for the pull request this session was dispatched for, using an installation token clamped to the owning agent’s repository tier — the write requires that clamp to actually carry `pull_requests: write`, so a read- or comment-tier agent is refused (403) rather than escalated. Idempotent: asking for the state the PR is already in succeeds without a mutation. 404 mirrors the GET; 409 relays GitHub declining the state change (for example a pull request whose checks already pass, which GitHub arms nothing for); 429 is GitHub rate limiting; 502 is GitHub unreachable.',
+            'Enables or disables GitHub auto-merge (squash) for this session’s pull request — the same identity the GET resolves, from the owning run or the session branch — using an installation token clamped to the owning agent’s repository tier — the write requires that clamp to actually carry `pull_requests: write`, so a read- or comment-tier agent is refused (403) rather than escalated. Idempotent: asking for the state the PR is already in succeeds without a mutation. 404 mirrors the GET; 409 relays GitHub declining the state change (for example a pull request whose checks already pass, which GitHub arms nothing for); 429 is GitHub rate limiting; 502 is GitHub unreachable.',
           operationId: 'setSessionPullRequestAutoMerge',
           params: IdParam,
           body: SessionPullRequestAutoMergeBodyDto,
@@ -1162,18 +1209,28 @@ export function sessionRoutes(deps: HttpDeps) {
         const github = deps.github
         if (!view || !github) return absent()
         const run = await deps.repos.hook.latestPullRequestRunForSession(orgOf(req), owned.session.id)
-        if (!run?.pullNumber || !run.repoId || !run.repoFullName || !run.sourceInstallationId) return absent()
-        // The capability is the RUN's agent — the write rides that agent's authorization, not the viewer's.
-        const agent = run.agentId ? await deps.repos.agent.get(orgOf(req), AgentId(run.agentId)) : null
+        // Same two sources as the GET, in the same order — the arm mirrors what the panel is showing.
+        const linked =
+          run?.pullNumber && run.repoId && run.repoFullName && run.sourceInstallationId
+            ? {
+                repoId: run.repoId,
+                repoFullName: run.repoFullName,
+                pullNumber: run.pullNumber,
+                // The capability is the RUN's agent — the write rides that agent's authorization, not the viewer's.
+                agent: run.agentId ? await deps.repos.agent.get(orgOf(req), AgentId(run.agentId)) : null
+              }
+            : await branchPullRequestLink(req, owned.session, false)
+        if (!linked) return absent()
+        const agent = linked.agent
         if (!agent) {
           return reply
             .code(403)
             .send({ error: 'Forbidden', statusCode: 403, message: 'the owning agent no longer exists' })
         }
         try {
-          const cred = await github.mintAutoMergeForAgent(agent, run.repoId, run.repoFullName)
+          const cred = await github.mintAutoMergeForAgent(agent, linked.repoId, linked.repoFullName)
           return await view.setAutoMerge(
-            { repoId: run.repoId, repoFullName: run.repoFullName, pullNumber: run.pullNumber },
+            { repoId: linked.repoId, repoFullName: linked.repoFullName, pullNumber: linked.pullNumber },
             cred.token,
             req.body.enabled
           )

--- a/packages/control-plane/test/integration/sessions.pull-request.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.pull-request.route.test.ts
@@ -8,6 +8,7 @@ import { prisma } from '../setup.db.js'
 import { seedAgent, seedDaemon, seedSessionMeta } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PullRequestViewService } from '../../src/github/pull-request-view.service.js'
+import { SessionPullRequestLinkService } from '../../src/github/session-pull-request-link.service.js'
 import { GitCredDeniedError, type GithubService } from '../../src/github/service.js'
 import type { InstallationTokenService } from '../../src/github/installation-token.service.js'
 import type { FetchLike } from '../../src/github/api.js'
@@ -120,10 +121,16 @@ function fullAnswer() {
   }
 }
 
-function app(view?: PullRequestViewService, userId?: string, github?: GithubService): HttpApp {
+function app(
+  view?: PullRequestViewService,
+  userId?: string,
+  github?: GithubService,
+  sessionPullRequestLink?: SessionPullRequestLinkService
+): HttpApp {
   const running = buildHttpApp(prisma, userId ? { DEFAULT_OWNER_ID: userId } : undefined, undefined, undefined, {
     ...(view ? { pullRequestView: view } : {}),
-    ...(github ? { github } : {})
+    ...(github ? { github } : {}),
+    ...(sessionPullRequestLink ? { sessionPullRequestLink } : {})
   })
   opened.push(running)
   return running
@@ -236,7 +243,10 @@ describe('GET /sessions/:id/pull-request', () => {
       canArmAutoMerge: false,
       degraded: false,
       degradedReason: null,
-      agentReview: null
+      agentReview: null,
+      linkedBy: 'run',
+      linkBranch: null,
+      linkAmbiguous: false
     })
     expect(github.calls).toHaveLength(1)
     expect(github.mint).toHaveBeenCalledWith(INSTALLATION, REPO, REPO_ID)
@@ -562,5 +572,124 @@ describe('POST /sessions/:id/pull-request/auto-merge', () => {
     expect(res.statusCode).toBe(404)
     expect(res.json()).toEqual(NOT_FOUND)
     expect(github.calls).toHaveLength(0)
+  })
+})
+
+// §12.6's SECOND identity source: the pull request this session worktree's own head branch has, for a
+// session no pull-request run owns — the case a PR the agent opened mid-conversation always lands in.
+describe('GET /sessions/:id/pull-request — the head-branch link', () => {
+  const BRANCH = 'dev/jane/panel'
+
+  // The link service as the route sees it: a scripted daemon branch read plus the `pulls` REST list.
+  function linkStub(opts: { branch?: string | null; pulls?: unknown[] } = {}) {
+    const calls: string[] = []
+    const fetch: FetchLike = async (url) => {
+      calls.push(String(url))
+      return new Response(JSON.stringify(opts.pulls ?? [{ number: PULL, state: 'open', head: { ref: BRANCH } }]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    }
+    const links = new SessionPullRequestLinkService({
+      clock: systemClock,
+      github: {
+        resolveWorkspaceRepo: async () => ({ repoId: REPO_ID, repoFullName: REPO, installationId: INSTALLATION })
+      } as unknown as GithubService,
+      tokens: { mintPullRequestRead: async () => ({ token: 'ghs_link' }) } as unknown as InstallationTokenService,
+      readSessionBranch: async () => (opts.branch === undefined ? BRANCH : opts.branch),
+      fetchImpl: fetch
+    })
+    return { links, calls }
+  }
+
+  // Only a session-isolated worktree HAS a branch of its own — the same gate the console applies.
+  async function seedSessionWorktree(): Promise<string> {
+    const session = await seedAgentAndSession()
+    await prisma.sessionMeta.update({ where: { id: session }, data: { workspaceIsolation: 'session' } })
+    return session
+  }
+
+  it('links the pull request the branch has, and says which source named it', async () => {
+    const session = await seedSessionWorktree()
+    const github = githubStub([graphqlOk(fullAnswer())])
+    const link = linkStub()
+    const running = app(github.view, undefined, undefined, link.links)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      repoFullName: REPO,
+      pullNumber: PULL,
+      degraded: false,
+      linkedBy: 'head-branch',
+      linkBranch: BRANCH,
+      linkAmbiguous: false
+    })
+    // One REST list for identity, then the same single GraphQL projection a run-linked PR spends.
+    expect(link.calls).toHaveLength(1)
+    expect(link.calls[0]).toContain(`head=${encodeURIComponent(`acme:${BRANCH}`)}`)
+    expect(github.calls).toHaveLength(1)
+  })
+
+  it('reports the ambiguity when the branch has more than one open pull request', async () => {
+    const session = await seedSessionWorktree()
+    const github = githubStub([graphqlOk(fullAnswer())])
+    const link = linkStub({
+      pulls: [
+        { number: 9, state: 'open', head: { ref: BRANCH } },
+        { number: PULL, state: 'open', head: { ref: BRANCH } }
+      ]
+    })
+    const running = app(github.view, undefined, undefined, link.links)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+
+    expect(res.json()).toMatchObject({ pullNumber: PULL, linkAmbiguous: true, linkBranch: BRANCH })
+  })
+
+  it('still 404s when the branch has no pull request — the panel keeps its create action', async () => {
+    const session = await seedSessionWorktree()
+    const github = githubStub([])
+    const link = linkStub({ pulls: [] })
+    const running = app(github.view, undefined, undefined, link.links)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual(NOT_FOUND)
+    expect(github.calls).toHaveLength(0)
+  })
+
+  it('prefers the owning run and never asks the branch — the run carries review facts a branch cannot', async () => {
+    const session = await seedSessionWorktree()
+    await seedPullRequestRun(session)
+    const github = githubStub([graphqlOk(fullAnswer())])
+    const link = linkStub()
+    const running = app(github.view, undefined, undefined, link.links)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+
+    expect(res.json()).toMatchObject({ linkedBy: 'run', linkBranch: null })
+    expect(link.calls).toHaveLength(0)
+  })
+
+  it('arms auto-merge on a branch-linked session, under that session’s own agent', async () => {
+    const session = await seedSessionWorktree()
+    const github = githubStub([
+      graphqlOk({ data: { repository: { pullRequest: { id: 'PR_node1', autoMergeRequest: null } } } }),
+      graphqlOk({ data: { enablePullRequestAutoMerge: { clientMutationId: null } } })
+    ])
+    const link = linkStub()
+    const running = app(github.view, undefined, fakeGithub(), link.links)
+
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/sessions/${session}/pull-request/auto-merge`,
+      payload: { enabled: true }
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ armed: true })
   })
 })

--- a/packages/web/src/components/console/dock/FilesPanel.test.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.test.tsx
@@ -336,19 +336,32 @@ describe('FilesPanel tree', () => {
     expect(row('src')?.getAttribute('style')).toContain('padding-left: 8px')
   })
 
-  it('drops a stale subtree on a refresh instead of leaving it on screen', async () => {
-    wire.listings = { '': { entries: [dir('src'), textFile('README.md')] }, src: { entries: [textFile('index.ts')] } }
+  it('drops a subtree whose folder is gone, and keeps the ones that are not', async () => {
+    // PREMISE CHANGED with the dock's refresh cadence: a refresh no longer collapses the tree — on a
+    // timer that would close the reader's folders every few seconds — so what protects against a stale
+    // subtree is the root re-read plus a re-read of each OPEN folder, not a reset. A directory that has
+    // since been deleted is no longer in the root listing, so it draws nothing either way.
+    wire.listings = {
+      '': { entries: [dir('src'), dir('gone'), textFile('README.md')] },
+      src: { entries: [textFile('index.ts')] },
+      gone: { entries: [textFile('old.ts')] }
+    }
     await render()
     await click(row('src'), 'src folder row')
-    expect(rowNames()).toEqual(['src', 'index.ts', 'README.md'])
+    await click(row('gone'), 'gone folder row')
+    expect(rowNames()).toEqual(['src', 'index.ts', 'gone', 'old.ts', 'README.md'])
 
+    wire.listings[''] = { entries: [dir('src'), textFile('README.md')] }
     await rerender({ refreshTick: 1 })
 
-    // The refresh re-reads the root and starts the cache and the expand set over: a directory that has since been deleted must not keep drawing its old children.
-    expect(rowNames()).toEqual(['src', 'README.md'])
+    expect(rowNames()).toEqual(['src', 'index.ts', 'README.md'])
   })
 
-  it('shows the tree loading while a refresh is in flight, not the rows it is replacing', async () => {
+  it('keeps its rows on screen while a refresh is in flight, then replaces them', async () => {
+    // PREMISE CHANGED with the dock's refresh cadence: M-era refreshes were presses, so emptying the
+    // tree for the round trip was defensible. On a 15s timer it is a flicker — and a spinner that
+    // replaced the rows every few seconds would be one too — so an in-flight refresh is SILENT: the
+    // rows stand until the new listing lands. The tab stays `ready` throughout, as it already did.
     await render()
     let land: ((listing: unknown) => void) | undefined
     vi.mocked(fetchWorkspaceFiles).mockImplementationOnce(
@@ -357,9 +370,8 @@ describe('FilesPanel tree', () => {
 
     await rerender({ refreshTick: 1 })
 
-    // The panel itself stays (the tab is still `ready`), and the rows a stale listing would keep showing are replaced by the tree's own spinner.
-    expect(rowNames()).toEqual([])
-    expect(container?.querySelector('svg[aria-label="Loading"]')).not.toBeNull()
+    expect(rowNames()).toEqual(['src', 'README.md'])
+    expect(container?.querySelector('svg[aria-label="Loading"]')).toBeNull()
     expect(container?.querySelector('input')).not.toBeNull()
 
     await act(async () => {
@@ -369,7 +381,10 @@ describe('FilesPanel tree', () => {
     expect(rowNames()).toEqual(['fresh.ts'])
   })
 
-  it('re-reads a folder after a refresh instead of re-showing its old listing', async () => {
+  it('re-reads an OPEN folder on a refresh, without closing it and without serving its old listing', async () => {
+    // The cache must not put back a file the agent has since renamed — but the expand set is the
+    // reader's own state, and a refresh that closed their folders would be unusable on a timer. So the
+    // open folder is re-read in place: one more request, same expansion, fresh rows, no click needed.
     wire.listings = { '': { entries: [dir('src')] }, src: { entries: [textFile('old.ts')] } }
     await render()
     await click(row('src'), 'src folder row')
@@ -377,9 +392,7 @@ describe('FilesPanel tree', () => {
 
     wire.listings.src = { entries: [textFile('new.ts')] }
     await rerender({ refreshTick: 1 })
-    await click(row('src'), 'src folder row')
 
-    // A refresh starts the cache AND the expand set over: keeping the cache would put back a file the agent has since renamed, and keeping the expand set would make this click close a folder the reader sees as shut.
     expect(rowNames()).toEqual(['src', 'new.ts'])
     expect(vi.mocked(fetchWorkspaceFiles).mock.calls.filter((call) => call[1].path === 'src').length).toBe(2)
   })
@@ -827,6 +840,30 @@ describe('FilesPanel auto refresh', () => {
 
     await rerender({ active: true, turnActive: false })
     expect(rootReads()).toBe(2)
+  })
+
+  it('keeps the open folders — and the filter’s corpus — across an automatic re-read', async () => {
+    // A refresh that collapsed the tree back to root would, on a timer, also shrink the path filter's
+    // corpus to root-level hits every few seconds. A refresh re-reads the root AND each open folder.
+    wire.listings = {
+      '': { entries: [dir('src'), textFile('README.md')] },
+      src: { entries: [textFile('deep.ts')] }
+    }
+    await render({ active: true })
+    await click(row('src'), 'src folder row')
+    expect(text()).toContain('deep.ts')
+    await type('deep')
+    expect(text()).toContain('Matched 1 of 2 loaded files')
+
+    await rerender({ active: true, turnActive: true })
+    await rerender({ active: true, turnActive: false })
+
+    // Both reads went out again — the root and the open folder — and neither the expansion nor the
+    // filter's reach went with them.
+    expect(rootReads()).toBe(2)
+    expect(vi.mocked(fetchWorkspaceFiles).mock.calls.filter((call) => call[1].path === 'src').length).toBe(2)
+    expect(text()).toContain('deep.ts')
+    expect(text()).toContain('Matched 1 of 2 loaded files')
   })
 
   it('polls while on screen, and stops when the tab is hidden', async () => {

--- a/packages/web/src/components/console/dock/FilesPanel.test.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.test.tsx
@@ -62,6 +62,7 @@ vi.mock('@/lib/api', () => {
 })
 
 import { FilesPanel, filesTabStatus } from './FilesPanel'
+import { DOCK_POLL_MS } from './auto-refresh'
 import { SessionDock, type DockTab } from './SessionDock'
 import { fetchWorkspaceFiles, fetchWorkspaceGitStatus, wakeAgent } from '@/lib/api'
 import type { WorkspaceGitFileDto, WorkspaceGitStatusDto } from '@/lib/api'
@@ -204,6 +205,8 @@ afterEach(async () => {
   vi.mocked(fetchWorkspaceFiles).mockClear()
   vi.mocked(fetchWorkspaceGitStatus).mockClear()
   vi.mocked(wakeAgent).mockClear()
+  // The polling case installs fake timers; leaving them installed would starve the next test's reads.
+  vi.useRealTimers()
 })
 
 describe('filesTabStatus', () => {
@@ -795,5 +798,49 @@ describe('FilesPanel footer', () => {
     expect(text()).not.toContain('synced')
     // Not an empty bordered strip either: the footer is absent, not blank.
     expect(container?.querySelector('[data-files-footer]')).toBeNull()
+  })
+})
+
+// The dock's refresh cadence, wired here. This tab carries no badge, so a hidden panel OWES itself the
+// read a turn earned and spends it on the reveal edge — re-reading a tree nobody is looking at is the
+// one thing this cadence must not do. The hook itself is `auto-refresh.test.tsx`'s subject.
+describe('FilesPanel auto refresh', () => {
+  const rootReads = () => vi.mocked(fetchWorkspaceFiles).mock.calls.filter((call) => call[1].path === '').length
+
+  it('re-reads the tree when a turn settles while the tab is on screen', async () => {
+    await render({ active: true })
+    expect(rootReads()).toBe(1)
+
+    await rerender({ active: true, turnActive: true })
+    expect(rootReads()).toBe(1)
+    await rerender({ active: true, turnActive: false })
+    expect(rootReads()).toBe(2)
+  })
+
+  it('defers a hidden tab’s turn read to the moment the reader opens it', async () => {
+    await render({ active: false })
+    expect(rootReads()).toBe(1)
+
+    await rerender({ active: false, turnActive: true })
+    await rerender({ active: false, turnActive: false })
+    expect(rootReads()).toBe(1)
+
+    await rerender({ active: true, turnActive: false })
+    expect(rootReads()).toBe(2)
+  })
+
+  it('polls while on screen, and stops when the tab is hidden', async () => {
+    vi.useFakeTimers()
+    await render({ active: true })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DOCK_POLL_MS)
+    })
+    expect(rootReads()).toBe(2)
+
+    await rerender({ active: false })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DOCK_POLL_MS * 4)
+    })
+    expect(rootReads()).toBe(2)
   })
 })

--- a/packages/web/src/components/console/dock/FilesPanel.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.tsx
@@ -22,6 +22,7 @@ import {
   SandboxAsleepNotice,
   SandboxStartingNotice
 } from '@/components/console/SandboxWakeNotice'
+import { DOCK_POLL_MS, useDockRefresh } from '@/components/console/dock/auto-refresh'
 import type { DockTabStatus } from './SessionDock'
 
 /** The Files tab's status: `loading` covers the first root listing only, and everything after it is `ready` — an offline daemon, a non-repo workspace and an empty directory are each something this panel has copy for, and copy is content. */
@@ -52,6 +53,7 @@ export function FilesPanel({
   workdir,
   refreshTick = 0,
   active = true,
+  turnActive = false,
   openFilePath,
   onOpenFile,
   onRootSettledChange
@@ -59,6 +61,8 @@ export function FilesPanel({
   agentId: string
   /** Whether the Files tab is the one selected. The dock keeps every panel mounted, and a hidden panel must not start a pod: the sandbox wake and its polling run only while this is true. */
   active?: boolean
+  /** Whether a turn is streaming in this session. Its falling edge re-reads the tree — that is when the agent's file writes have landed — but only for a tab the reader is looking at: this panel carries no badge, so a hidden one owes itself the read and spends it on the reveal edge instead. */
+  turnActive?: boolean
   /** ACP session id selecting that session's isolated worktree; omit for the agent's primary checkout. Pass it only when the session's `workspaceIsolation` is `'session'` — the daemon answers a shared-workspace sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline". */
   sessionId?: string
   /** The agent's working directory, shown beside the branch. */
@@ -74,9 +78,14 @@ export function FilesPanel({
 }) {
   // The wake's own refresh rides beside the tab's: a poll re-reads the tree the same way the refresh action does.
   const [wakeTick, setWakeTick] = useState(0)
-  const { dirs, root, expanded, toggleDir, loadMoreDir } = useWorkspaceTree(agentId, sessionId, refreshTick + wakeTick)
-  const { git, outcome, primaryBranch } = useWorkspaceGitStatus(agentId, sessionId, refreshTick + wakeTick)
-  const retryRoot = useCallback(() => setWakeTick((tick) => tick + 1), [])
+  // The automatic re-read (turn edge, poll, reveal) is the same counter shape, so an auto refresh takes
+  // the identical read path a pressed one does — expanded folders and the filter text survive both.
+  const [autoTick, setAutoTick] = useState(0)
+  const tick = refreshTick + wakeTick + autoTick
+  const { dirs, root, expanded, toggleDir, loadMoreDir } = useWorkspaceTree(agentId, sessionId, tick)
+  const { git, outcome, primaryBranch } = useWorkspaceGitStatus(agentId, sessionId, tick)
+  const retryRoot = useCallback(() => setWakeTick((current) => current + 1), [])
+  useDockRefresh({ active, turnActive, intervalMs: DOCK_POLL_MS, onRefresh: () => setAutoTick((n) => n + 1) })
   const wake = useSandboxWake(agentId, workspaceRootReadState(root), retryRoot, { active })
   const [query, setQuery] = useState('')
   const scope = `${agentId}:${sessionId ?? 'primary'}`

--- a/packages/web/src/components/console/dock/GitPanel.test.tsx
+++ b/packages/web/src/components/console/dock/GitPanel.test.tsx
@@ -85,6 +85,7 @@ vi.mock('@/lib/api', () => {
 })
 
 import { baseBranchOf, GitPanel, gitTabStatus, splitGitSections, type GitPanelVerdict } from './GitPanel'
+import { DOCK_POLL_MS } from './auto-refresh'
 import { commitWorkspace, draftWorkspaceCommitMessage, fetchWorkspaceGitLog } from '@/lib/api'
 import type { WorkspaceGitFileDto, WorkspaceGitLogDto, WorkspaceGitStatusDto } from '@/lib/api'
 
@@ -231,6 +232,8 @@ afterEach(() => {
   container?.remove()
   container = undefined
   root = undefined
+  // The polling cases install fake timers; leaving them installed would starve the next test's reads.
+  vi.useRealTimers()
 })
 
 describe('splitGitSections', () => {
@@ -895,5 +898,59 @@ describe('GitPanel — staging', () => {
 
     expect(container?.querySelector('[data-commit-box]')).toBeNull()
     expect(text()).toContain('not a git checkout')
+  })
+})
+
+// The dock's refresh cadence, wired here: this panel's tab carries the changed-file BADGE, so the
+// signal that reaches it while hidden is a turn settling — and the poll is spent only where a reader
+// is looking. The cadence itself is `auto-refresh.test.tsx`'s subject; these are the wiring facts.
+describe('GitPanel auto refresh', () => {
+  it('re-reads status and log on a turn’s falling edge, even while its tab is hidden', async () => {
+    await render({ active: false })
+    expect(wire.statusCalls).toBe(1)
+    expect(wire.logCalls).toHaveLength(1)
+
+    await rerender({ active: false, turnActive: true })
+    expect(wire.statusCalls).toBe(1)
+    await rerender({ active: false, turnActive: false })
+    // Both reads, because a turn commits: the index empties and the branch gains a commit.
+    expect(wire.statusCalls).toBe(2)
+    expect(wire.logCalls).toHaveLength(2)
+  })
+
+  it('polls while its tab is on screen, and not while it is hidden', async () => {
+    vi.useFakeTimers()
+    await render({ active: true })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DOCK_POLL_MS)
+    })
+    expect(wire.statusCalls).toBe(2)
+
+    await rerender({ active: false })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DOCK_POLL_MS * 4)
+    })
+    expect(wire.statusCalls).toBe(2)
+  })
+
+  it('skips an automatic read while one of its OWN writes is in flight', async () => {
+    // The write answers with the fresh status; a read racing it would land the pre-write tree over that
+    // reply, and the write's own re-read is what covers this case.
+    const dirty = gitStatus({ clean: false, files: [file('src/staged.ts', 'A', ' '), file('src/edited.ts', ' ', 'M')] })
+    wire.git = dirty
+    wire.writeResult = dirty
+    wire.holdWrite = true
+    await render({ canWrite: true })
+    const before = wire.statusCalls
+    await click(toggles('changes')[0], 'a row toggle')
+
+    await rerender({ canWrite: true, turnActive: true })
+    await rerender({ canWrite: true, turnActive: false })
+    expect(wire.statusCalls).toBe(before)
+
+    await act(async () => {
+      wire.releaseWrite?.()
+      await Promise.resolve()
+    })
   })
 })

--- a/packages/web/src/components/console/dock/GitPanel.tsx
+++ b/packages/web/src/components/console/dock/GitPanel.tsx
@@ -9,6 +9,7 @@ import { Spinner } from '@/components/marks'
 import { Icon } from '@/components/ui'
 import { formatFileMtime } from '@/components/console/FileBrowser'
 import { CommitBox } from '@/components/console/dock/CommitBox'
+import { DOCK_POLL_MS, useDockRefresh } from '@/components/console/dock/auto-refresh'
 import { gitWriteRequestFailureText } from '@/components/console/dock/git-write'
 import { StatusBadge, useWorkspaceGitStatus } from '@/components/console/workspace-tree'
 import {
@@ -125,6 +126,8 @@ export function GitPanel({
   agentId,
   sessionId,
   refreshTick = 0,
+  active = true,
+  turnActive = false,
   openPath,
   openStaged = false,
   canWrite = false,
@@ -133,6 +136,10 @@ export function GitPanel({
   onWrote
 }: {
   agentId: string
+  /** Whether the Git tab is the one selected — the poll's gate. The panel stays MOUNTED either way, because its verdict is what keeps its own tab out of the dock's vacant state. */
+  active?: boolean
+  /** Whether a turn is streaming in this session. Its falling edge re-reads even while the tab is hidden: the agent's commits and pushes are what this panel counts, and that count is on the tab's badge. */
+  turnActive?: boolean
   /** ACP session id selecting that session's isolated worktree; omit for the agent's primary checkout. Pass it only when the session's `workspaceIsolation` is `'session'` — the daemon answers a shared-workspace sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline". */
   sessionId?: string
   /** Bumped by the tab's `refresh-cw` action: re-reads status and log without remounting. */
@@ -153,7 +160,10 @@ export function GitPanel({
 }) {
   // The panel's own re-read, summed with the tab action's: a commit empties the index and adds a commit, so status AND log have to come again — a stage does not, because its reply carries the fresh status. Both counters only ever increase, so their sum names a distinct read.
   const [writeTick, setWriteTick] = useState(0)
-  const statusTick = refreshTick + writeTick
+  // The automatic re-read (turn edge, poll, reveal), a third counter on the same sum so an auto refresh
+  // is byte-identical to a pressed one — there is no second read path to keep in step.
+  const [autoTick, setAutoTick] = useState(0)
+  const statusTick = refreshTick + writeTick + autoTick
   const { git: readGit, outcome, primaryBranch } = useWorkspaceGitStatus(agentId, sessionId, statusTick)
   const log = useWorkspaceGitLog(agentId, sessionId, statusTick)
   const scope = `${agentId}:${sessionId ?? 'primary'}`
@@ -168,6 +178,21 @@ export function GitPanel({
   const [stageErr, setStageErr] = useState<string | null>(null)
   // The re-entry latch is a REF, not `staging`: two clicks dispatched in one task both read the same pre-update state and the same not-yet-disabled button, so a double-click would send two writes. Measured on the commit box, which has the same shape.
   const writing = useRef(false)
+
+  // Automatic re-reads, on the dock's shared cadence. Skipped while a write of THIS panel's is in
+  // flight: that write answers with the fresh status, and a read racing it would land the pre-write
+  // tree over the reply — the write's own `writeTick` is the re-read for that case.
+  useDockRefresh({
+    active,
+    turnActive,
+    whileHidden: true,
+    intervalMs: DOCK_POLL_MS,
+    onRefresh: () => {
+      if (writing.current) return
+      setApplied(null)
+      setAutoTick((tick) => tick + 1)
+    }
+  })
 
   // Move paths across the index on the daemon. Only paths the checkout reports as changed on the relevant side are ever passed in, so an empty selection is the one no-op this refuses locally.
   const moveIndex = async (kind: 'stage' | 'unstage', paths: string[], busyKey: string) => {

--- a/packages/web/src/components/console/dock/GitPanel.tsx
+++ b/packages/web/src/components/console/dock/GitPanel.tsx
@@ -11,7 +11,7 @@ import { formatFileMtime } from '@/components/console/FileBrowser'
 import { CommitBox } from '@/components/console/dock/CommitBox'
 import { DOCK_POLL_MS, useDockRefresh } from '@/components/console/dock/auto-refresh'
 import { gitWriteRequestFailureText } from '@/components/console/dock/git-write'
-import { StatusBadge, useWorkspaceGitStatus } from '@/components/console/workspace-tree'
+import { StatusBadge, useWorkspaceGitStatus, type WorkspaceGitOutcome } from '@/components/console/workspace-tree'
 import {
   ApiError,
   fetchWorkspaceGitLog,
@@ -221,6 +221,8 @@ export function GitPanel({
     branch: string | null
     tracking: string | null
     base: string | null
+    /** What the last settled read WAS, so a re-read's `pending` does not repaint the panel as unreadable. */
+    outcome: WorkspaceGitOutcome
   } | null>(null)
   useEffect(() => {
     if (outcome === 'pending') return
@@ -229,6 +231,7 @@ export function GitPanel({
       // Distinct PATHS: a file staged and then edited again is one changed file, in two sections.
       const next = {
         scope,
+        outcome,
         changed: outcome === 'repo' && git ? new Set(git.files.map((file) => file.path)).size : null,
         branch: outcome === 'repo' ? (git?.branch ?? null) : null,
         tracking: outcome === 'repo' ? (git?.tracking ?? null) : null,
@@ -236,6 +239,7 @@ export function GitPanel({
         base: outcome === 'repo' ? (log.loading ? (held?.base ?? null) : baseBranchOf(log.log?.base)) : null
       }
       return held &&
+        held.outcome === next.outcome &&
         held.changed === next.changed &&
         held.branch === next.branch &&
         held.tracking === next.tracking &&
@@ -246,6 +250,12 @@ export function GitPanel({
   }, [git, log, outcome, scope])
   const settled = answer?.scope === scope
   const changed = settled ? answer.changed : null
+  // What the panel DRAWS. A re-read puts the live outcome back to `pending` for a round trip, and every
+  // branch keyed on it would then repaint: the branch line would read "Git status unavailable", an
+  // offline notice would become "nothing has changed", and the Commits section would unmount. On the
+  // dock's timer that is a flicker every few seconds, so the last settled interpretation stands until
+  // the new one lands — the same latch the commit box below already applies for the same reason.
+  const shown: WorkspaceGitOutcome = outcome === 'pending' && settled ? answer.outcome : outcome
 
   const sections = useMemo(() => splitGitSections(git?.files ?? []), [git])
   // Reported on the EDGE: the caller's callback is a fresh closure per render, and re-reporting a verdict the tab already has is a state write for nothing.
@@ -271,7 +281,7 @@ export function GitPanel({
         : null
 
   // A session worktree checks out its own generated `dev/<user>/<words>` branch, so its OWN branch is the answer when it has one; only a detached worktree falls back to naming the primary checkout's.
-  const branch = git?.branch ?? (sessionId ? primaryBranch : null)
+  const branch = git?.branch ?? (settled ? answer.branch : null) ?? (sessionId ? primaryBranch : null)
   const branchTitle = !sessionId
     ? 'Current branch of the workspace checkout'
     : git?.branch
@@ -373,12 +383,12 @@ export function GitPanel({
     // Ahead of `unavailable`, which it arrives as (both are 503): the workspace is fine and comes
     // back on the agent's next turn, so this must not read as an outage — and must not read as "not
     // a git checkout" either, which is what a suspended pod used to answer.
-    if (outcome === 'asleep') {
+    if (shown === 'asleep') {
       return (
         <PanelNotice text="Git status is not available right now — this agent runs in a cluster sandbox and its pod is not running. It starts again on the agent's next turn, and the checkout comes back with it." />
       )
     }
-    if (outcome === 'unavailable') {
+    if (shown === 'unavailable') {
       return (
         <PanelNotice
           warn
@@ -386,7 +396,7 @@ export function GitPanel({
         />
       )
     }
-    if (outcome === 'none') {
+    if (shown === 'none') {
       return (
         <PanelNotice text="This workspace is not a git checkout, so it has no branch, no changes and no commits. The agent's files are still in the Files tab." />
       )
@@ -484,7 +494,7 @@ export function GitPanel({
   return (
     <div data-git-panel="" className="flex min-h-0 flex-1 flex-col">
       <div className="flex flex-none items-center gap-2 border-b border-(--border-subtle) px-3 py-[10px]">
-        {outcome === 'repo' && branch ? (
+        {shown === 'repo' && branch ? (
           <span
             className="mono flex min-w-0 flex-1 items-center gap-[4px] text-[11px] font-medium text-(--text-secondary)"
             title={branchTitle}
@@ -494,9 +504,9 @@ export function GitPanel({
           </span>
         ) : (
           <span className="min-w-0 flex-1 font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-            {outcome === 'none'
+            {shown === 'none'
               ? 'Not a git checkout'
-              : outcome === 'asleep'
+              : shown === 'asleep'
                 ? 'Sandbox not running'
                 : 'Git status unavailable'}
           </span>
@@ -554,7 +564,7 @@ export function GitPanel({
         )
       ) : null}
       {/* History LAST and closed by default: what a reader does in this panel is read the changed files and commit them, and an open commit list pushed both off a 480px dock. The count is on the closed row because the log is read anyway — collapsing hides the list, not the fact that there is one. */}
-      {outcome === 'repo' ? (
+      {shown === 'repo' ? (
         <div data-git-section="commits" className="flex min-h-0 flex-none flex-col border-t border-(--border-subtle)">
           <button
             type="button"

--- a/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/lib/api', () => {
   }
 })
 
+import { PR_POLL_MS } from './auto-refresh'
 import {
   PR_LINK_RETRY_LADDER_MS,
   PullRequestPanel,
@@ -281,10 +282,10 @@ describe('PullRequestPanel verdicts', () => {
     expect(posted[0]).toContain('against release')
   })
 
-  it('stops presenting creation as fresh once asked, and says why this tab may never link the result', async () => {
-    // The probe identifies a PR through the run that owns the session, and an agent opening one from a
-    // conversation creates no such run — so the 404 outlives the pull request. Re-offering "Create pull
-    // request" against that state is what invited a second PR for the same branch.
+  it('stops presenting creation as fresh once asked, and says what the link still waits on', async () => {
+    // The PR is found through this worktree's head branch, so it appears once the branch is pushed and a
+    // pull request exists for it — not the instant the agent replies. Re-offering "Create pull request"
+    // against that state is what invited a second PR for the same branch.
     wire.failure = { status: 404 }
     const posted: string[] = []
     await render({ branch: 'dev/jane-doe/candid-lynx', tracking: null, onPostTurn: accept(posted) })
@@ -298,7 +299,7 @@ describe('PullRequestPanel verdicts', () => {
 
     await rerender({ branch: 'dev/jane-doe/candid-lynx', tracking: null, onPostTurn: accept(posted) })
     expect(container?.querySelector('[data-pr-create-requested]')?.textContent).toContain(
-      'links one only when a review run owns the session'
+      'links it once the branch is pushed and a pull request exists'
     )
     expect(container?.querySelector('[data-pr-create]')?.textContent).toContain('Ask again')
   })
@@ -407,6 +408,21 @@ describe('PullRequestPanel body', () => {
     expect(link?.textContent).toContain('View on GitHub')
   })
 
+  it('names the pick when a branch-resolved link is ambiguous, and stays silent when it is not', async () => {
+    // A run-linked PR is unique by construction; a branch's is not — several open PRs on one head are all
+    // equally "this session's", so the panel says which one it drew rather than picking silently.
+    await render()
+    expect(container?.querySelector('[data-pr-link-ambiguous]')).toBeNull()
+
+    // A scope switch is what re-reads: the answer is held per session, so a new id is how the second
+    // shape reaches the panel at all.
+    wire.data = pr({ linkedBy: 'head-branch', linkBranch: 'dev/jane-doe/candid-lynx', linkAmbiguous: true })
+    await rerender({ sessionId: 'session-2' })
+    expect(container?.querySelector('[data-pr-link-ambiguous]')?.textContent).toContain(
+      'Branch dev/jane-doe/candid-lynx has more than one open pull request'
+    )
+  })
+
   it('draws each check with its own state marker and a duration only where both ends exist', async () => {
     await render()
     const checks = Array.from(container?.querySelectorAll<HTMLElement>('[data-pr-check]') ?? [])
@@ -498,10 +514,12 @@ describe('PullRequestPanel body', () => {
     await rerender({ onPostTurn: accept(posted), turnActive: false })
     expect(wire.calls).toHaveLength(2)
     expect(wire.calls[1]).toMatchObject({ refresh: true })
-    // A LATER turn settling re-reads nothing — the wait was consumed.
+    // A LATER turn settling re-reads AGAIN, and forced: the edge belongs to the dock's refresh
+    // cadence, not to `awaitingTurn` — whatever that turn did on GitHub is younger than the CP's TTL.
     await rerender({ onPostTurn: accept(posted), turnActive: true })
     await rerender({ onPostTurn: accept(posted), turnActive: false })
-    expect(wire.calls).toHaveLength(2)
+    expect(wire.calls).toHaveLength(3)
+    expect(wire.calls[2]).toMatchObject({ refresh: true })
   })
 
   it('does not arm the wait on a REFUSED send — the button stays pressable and no edge is owed', async () => {
@@ -512,10 +530,12 @@ describe('PullRequestPanel body', () => {
     await press('[data-pr-autofix]')
     expect(container?.querySelector<HTMLButtonElement>('[data-pr-autofix]')?.disabled).toBe(false)
 
-    // And no stale wait rides a later, unrelated turn into a phantom re-read.
+    // A later, unrelated turn still refreshes — that is the dock's cadence, not this button's wait —
+    // and the button, whose wait was never armed, stays pressable through it.
     await rerender({ onPostTurn: () => false, turnActive: true })
     await rerender({ onPostTurn: () => false, turnActive: false })
-    expect(wire.calls).toHaveLength(1)
+    expect(wire.calls).toHaveLength(2)
+    expect(container?.querySelector<HTMLButtonElement>('[data-pr-autofix]')?.disabled).toBe(false)
   })
 
   it('holds Auto-fix while ANY turn streams — a queued post would let that turn eat the wait', async () => {
@@ -680,7 +700,11 @@ describe('PullRequestPanel degraded answers', () => {
     // hint that the link may just have committed, so it re-asks immediately and re-arms the ladder.
     vi.useFakeTimers()
     wire.failure = { status: 404 }
-    await render({ sessionStatus: 'online' })
+    // Hidden, so the ladder is the only clock in the test: the whole ladder spans past the poll
+    // cadence, and a poll landing mid-drain would count as a rung it never was. The ladder itself is
+    // deliberately NOT gated on visibility — a 404 is answered from the CP's own tables and reaches
+    // no GitHub call, so it costs nothing to keep asking for the tab's own sake.
+    await render({ sessionStatus: 'online', active: false })
 
     // Rung by rung: each retry schedules the next only after its answer settles, so the clock advances per step.
     for (const step of PR_LINK_RETRY_LADDER_MS) {
@@ -695,7 +719,7 @@ describe('PullRequestPanel degraded answers', () => {
     })
     expect(wire.calls).toHaveLength(drained)
 
-    await rerender({ sessionStatus: 'idle' })
+    await rerender({ sessionStatus: 'idle', active: false })
     expect(wire.calls).toHaveLength(drained + 1)
     await act(async () => {
       await vi.advanceTimersByTimeAsync(PR_LINK_RETRY_LADDER_MS[0]!)
@@ -703,17 +727,57 @@ describe('PullRequestPanel degraded answers', () => {
     expect(wire.calls).toHaveLength(drained + 2)
   })
 
-  it('keeps a LINKED answer still — no timers, no reaction to status changes', async () => {
-    // The provisional treatment is for the missing link ONLY: an answered probe schedules nothing, so
-    // the panel never polls GitHub (§9's budget) and never re-asks on status churn.
+  it('arms no ladder for a LINKED answer, and re-reads only on its own slow poll', async () => {
+    // The provisional treatment is for the missing link ONLY: an answered probe schedules no ladder and
+    // does not re-ask on status churn. What it does keep is the dock's poll — a check turns green and a
+    // review lands without anything here changing — at a cadence sized for §9's GitHub budget.
     vi.useFakeTimers()
     wire.data = pr()
     await render({ sessionStatus: 'online' })
     expect(wire.calls).toHaveLength(1)
     await rerender({ sessionStatus: 'idle' })
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(600_000)
+      await vi.advanceTimersByTimeAsync(PR_POLL_MS - 1)
     })
     expect(wire.calls).toHaveLength(1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    // A poll, not a forced read: the CP's projection TTL is what keeps several open panels cheap.
+    expect(wire.calls).toHaveLength(2)
+    expect(wire.calls[1]).toMatchObject({ refresh: false })
+  })
+
+  it('polls nothing while its tab is hidden, and still takes a turn’s edge — the badge is on screen', async () => {
+    // A hidden panel is a request nobody is looking at; its BADGE is not — the unresolved count sits in
+    // the tab strip either way, so the one signal that reaches a hidden panel is a turn settling.
+    vi.useFakeTimers()
+    wire.data = pr()
+    await render({ active: false, sessionStatus: 'online' })
+    expect(wire.calls).toHaveLength(1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10 * PR_POLL_MS)
+    })
+    expect(wire.calls).toHaveLength(1)
+
+    await rerender({ active: false, sessionStatus: 'online', turnActive: true })
+    await rerender({ active: false, sessionStatus: 'online', turnActive: false })
+    expect(wire.calls).toHaveLength(2)
+    expect(wire.calls[1]).toMatchObject({ refresh: true })
+  })
+
+  it('links a pull request the agent opened mid-turn, without anyone pressing refresh', async () => {
+    // The case this cadence exists for: the probe answered 404, the agent opened the PR inside the
+    // turn, and the falling edge is what turns the tab's no-PR state into the linked one.
+    vi.useFakeTimers()
+    wire.failure = { status: 404 }
+    await render({ sessionStatus: 'online', turnActive: true })
+    expect(verdicts.at(-1)?.answer).toBe('none')
+
+    wire.failure = null
+    wire.data = pr()
+    await rerender({ sessionStatus: 'online', turnActive: false })
+    expect(verdicts.at(-1)?.answer).toBe('linked')
+    expect(container?.querySelector('[data-pr-panel=""]')).not.toBeNull()
   })
 })

--- a/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
@@ -700,10 +700,11 @@ describe('PullRequestPanel degraded answers', () => {
     // hint that the link may just have committed, so it re-asks immediately and re-arms the ladder.
     vi.useFakeTimers()
     wire.failure = { status: 404 }
-    // Hidden, so the ladder is the only clock in the test: the whole ladder spans past the poll
-    // cadence, and a poll landing mid-drain would count as a rung it never was. The ladder itself is
-    // deliberately NOT gated on visibility — a 404 is answered from the CP's own tables and reaches
-    // no GitHub call, so it costs nothing to keep asking for the tab's own sake.
+    // Hidden TAB, so the ladder is the only clock in the test: the whole ladder spans past the poll
+    // cadence, and a poll landing mid-drain would count as a rung it never was. The ladder runs for a
+    // hidden tab on purpose — a held 404 removes the tab, so there is no tab left to reveal and the
+    // ladder is the only way back — but it IS gated on the document being visible, since a runless
+    // session's 404 now costs a daemon read and, for a pushed branch, a GitHub list.
     await render({ sessionStatus: 'online', active: false })
 
     // Rung by rung: each retry schedules the next only after its answer settles, so the clock advances per step.

--- a/packages/web/src/components/console/dock/PullRequestPanel.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.tsx
@@ -16,7 +16,7 @@ import {
   type SessionPullRequestReviewDto,
   type SessionPullRequestThreadDto
 } from '@/lib/api'
-import { PR_POLL_MS, useDockRefresh } from '@/components/console/dock/auto-refresh'
+import { PR_POLL_MS, useDocumentVisible, useDockRefresh } from '@/components/console/dock/auto-refresh'
 import type { DockTabStatus } from './SessionDock'
 
 const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
@@ -243,10 +243,16 @@ export function PullRequestPanel({
     attempt.current = 0
     if (was404) setReads((r) => ({ tick: r.tick + 1, force: false }))
   }, [sessionStatus, was404])
-  // The bounded ladder that survives the unfavorable orderings: a 404 never reaches GitHub — the CP answers it from its own tables — so these retries spend none of §9's rate-limit budget, and the bound is what lets a session with no PR go quiet.
+  // The bounded ladder that survives the unfavorable orderings. It is NOT free any more: since the CP
+  // resolves a runless session's PR from its worktree's head branch, a 404 costs a `workspace/gitstatus`
+  // REQ to the owning daemon and — for a pushed branch with no PR — a GitHub `pulls` list, and the
+  // rungs outrun the CP's 15s miss cache. So it is gated on the document being VISIBLE, like the poll:
+  // a backgrounded page spends nothing. It is deliberately NOT gated on the tab being active, unlike
+  // the poll — a held 404 REMOVES this tab, so there would be no tab left to reveal and no way back.
+  const visible = useDocumentVisible()
   useEffect(() => {
-    if (!was404) {
-      attempt.current = 0
+    if (!was404 || !visible) {
+      if (!was404) attempt.current = 0
       return
     }
     const delay = PR_LINK_RETRY_LADDER_MS[attempt.current]
@@ -256,7 +262,7 @@ export function PullRequestPanel({
       setReads((r) => ({ tick: r.tick + 1, force: false }))
     }, delay)
     return () => clearTimeout(timer)
-  }, [was404, reads])
+  }, [was404, reads, visible])
 
   const answer: PullRequestPanelAnswer = read.loading
     ? 'pending'
@@ -286,7 +292,9 @@ export function PullRequestPanel({
   // button was the reason a PR opened from the conversation stayed invisible until someone pressed
   // refresh. `awaitingTurn` still clears here — it is the button's spinner, not the refresh's trigger.
   // Forced, because the write-back is younger than the CP's projection TTL by construction. The 404
-  // ladder is refilled too: a turn is a fresh reason to believe the link may exist now.
+  // ladder is refilled too: a turn is a fresh reason to believe the link may exist now — and that
+  // refill is bounded per turn and gated on visibility below, which is what keeps a page left open on
+  // an unreviewed branch from re-asking the daemon and GitHub forever.
   useDockRefresh({
     active,
     turnActive,

--- a/packages/web/src/components/console/dock/PullRequestPanel.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.tsx
@@ -16,6 +16,7 @@ import {
   type SessionPullRequestReviewDto,
   type SessionPullRequestThreadDto
 } from '@/lib/api'
+import { PR_POLL_MS, useDockRefresh } from '@/components/console/dock/auto-refresh'
 import type { DockTabStatus } from './SessionDock'
 
 const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
@@ -201,11 +202,11 @@ export function PullRequestPanel({
 }: {
   /** The OPEN SESSION's id, the scope the CP resolves to its hook run. Deliberately no agentId: the PR belongs to the session, so a merged conversation's header-focus change must not re-key this read — the prop shape makes that unbuildable rather than merely avoided. */
   sessionId: string
-  /** Whether this tab is the visible one; the panel re-reads on the edge where it becomes so, because PR state read when the page opened is not an answer about now. It does not poll — GitHub rate limits are this milestone's one external budget (§9). */
+  /** Whether this tab is the visible one; the panel re-reads on the edge where it becomes so, because PR state read when the page opened is not an answer about now. It also polls while it is — slowly, because GitHub rate limits are this surface's one external budget (§9) and the CP already absorbs repeats behind its projection TTL. */
   active?: boolean
   /** The open session's live status: a transition re-asks a held 404 immediately and refills the bounded retry ladder — a hint that the session→run link may just have committed, though the frames race, which is why the ladder exists at all. */
   sessionStatus?: string
-  /** Whether a turn is streaming right now. After Auto-fix posts one, the FALLING edge is the panel's cue to force one re-read — the agent's GitHub write-back (resolved threads, pushed fixes) lands with the turn, and the CP's short TTL would otherwise hide it. */
+  /** Whether a turn is streaming right now. Its FALLING edge forces one re-read past the CP's TTL, whether or not this panel posted the turn: anything the agent did on GitHub — resolving threads, pushing fixes, OPENING the pull request this tab is looking for — lands with the turn, and it is the same edge either way. */
   turnActive?: boolean
   /** The branch this session's checkout is on, from the Git tab's verdict — the panel's no-PR state is about THIS branch, and reading git status again here would be a second round trip for a fact the dock already holds. Null while that read has not answered, for a detached worktree, and for a workspace that is not a checkout. */
   branch?: string | null
@@ -273,22 +274,32 @@ export function PullRequestPanel({
   // must not graft the old session's wait onto the new one's reads.
   const [awaitingTurn, setAwaitingTurn] = useState(false)
   useEffect(() => setAwaitingTurn(false), [sessionId])
-  // Whether a create-pull-request turn was already handed to the agent HERE. It has to be remembered,
-  // because this panel cannot observe the result: identity comes from the pull-request run that owns the
-  // session (§3.4), and an agent opening a PR from a webchat session creates no such run — so the probe
-  // keeps answering 404 even once the PR exists. Without this, the state re-offers creation as though
-  // nothing had happened, which invites a second PR for the same branch. Reset per scope, like the wait.
+  // Whether a create-pull-request turn was already handed to the agent HERE. It is remembered because
+  // the result is not instantaneous: the PR is found through this worktree's own head branch, so it
+  // appears once the branch is pushed and one exists against it — and until then the state would
+  // re-offer creation as though nothing had happened, which invites a second PR for the same branch.
+  // Reset per scope, like the wait.
   const [createRequested, setCreateRequested] = useState(false)
   useEffect(() => setCreateRequested(false), [sessionId])
-  const wasTurnActive = useRef(turnActive)
-  useEffect(() => {
-    const settled = wasTurnActive.current && !turnActive
-    wasTurnActive.current = turnActive
-    if (settled && awaitingTurn) {
-      setAwaitingTurn(false)
-      setReads((r) => ({ tick: r.tick + 1, force: true }))
+  // Every turn's falling edge, not only a turn THIS panel posted: the reader's own "open a PR for this"
+  // in the composer produces the same GitHub write-back, and a panel that re-read only after its own
+  // button was the reason a PR opened from the conversation stayed invisible until someone pressed
+  // refresh. `awaitingTurn` still clears here — it is the button's spinner, not the refresh's trigger.
+  // Forced, because the write-back is younger than the CP's projection TTL by construction. The 404
+  // ladder is refilled too: a turn is a fresh reason to believe the link may exist now.
+  useDockRefresh({
+    active,
+    turnActive,
+    whileHidden: true,
+    intervalMs: PR_POLL_MS,
+    onRefresh: (reason) => {
+      if (reason === 'turn') {
+        setAwaitingTurn(false)
+        attempt.current = 0
+      }
+      setReads((r) => ({ tick: r.tick + 1, force: reason === 'turn' }))
     }
-  }, [turnActive, awaitingTurn])
+  })
 
   // The auto-merge toggle's own in-flight/error state; the armed FACT stays on the view, re-read after every write.
   const [merge, setMerge] = useState<{ busy: boolean; err: string | null }>({ busy: false, err: null })
@@ -381,7 +392,7 @@ export function PullRequestPanel({
                 : 'No pull request is linked to this session yet.'
           }
         />
-        {/* What this panel CANNOT observe, said rather than hidden: it identifies a pull request through the run that owns the session, and a PR the agent opens from a conversation creates no such run — so this state can outlive the pull request it asked for. Drawn only after the ask, because until then it is not the reader's problem. */}
+        {/* What this state still depends on, said rather than hidden: a PR is found through this worktree's own head branch, so it appears once the branch is pushed and the PR exists against it — not the instant the agent replies. Drawn only after the ask, because until then it is not the reader's problem. */}
         {createRequested ? (
           <div
             data-pr-create-requested=""
@@ -390,8 +401,8 @@ export function PullRequestPanel({
             <Icon name="info" size={13} color="var(--text-tertiary)" className="mt-[2px] flex-none" />
             <span>
               A pull request was requested in this session — the agent replies with its URL in the conversation. This
-              tab links one only when a review run owns the session, so it can keep showing this state even after the
-              pull request exists.
+              tab links it once the branch is pushed and a pull request exists for it; press refresh if that just
+              happened.
             </span>
           </div>
         ) : null}
@@ -586,6 +597,21 @@ export function PullRequestPanel({
         </a>
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-auto pb-2">
+        {/* A branch-resolved link can be ambiguous where a run-linked one never is: the head branch is the whole identity, so several open PRs on it are all equally "this session's". The panel names the pick rather than picking silently. */}
+        {view.linkAmbiguous ? (
+          <div
+            data-pr-link-ambiguous=""
+            className="flex items-start gap-2 px-3 pt-[7px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)"
+          >
+            <Icon name="info" size={13} color="var(--text-tertiary)" className="mt-[2px] flex-none" />
+            <span>
+              {view.linkBranch
+                ? `Branch ${view.linkBranch} has more than one open pull request`
+                : 'This session’s branch has more than one open pull request'}{' '}
+              — this is the first of them.
+            </span>
+          </div>
+        ) : null}
         {view.degraded ? (
           <>
             <PanelNotice warn text={degradedNoticeText(view.degradedReason)} />

--- a/packages/web/src/components/console/dock/TasksPanel.test.tsx
+++ b/packages/web/src/components/console/dock/TasksPanel.test.tsx
@@ -465,3 +465,22 @@ describe('TasksPanel polling', () => {
     expect(last()).toEqual({ settled: true, running: 1 })
   })
 })
+
+// Tasks already polled; what the shared cadence adds is a turn's falling edge (a finished turn is where
+// a background task comes from) and the browser-visibility gate the other tabs get.
+describe('TasksPanel auto refresh', () => {
+  it('re-reads when a turn settles on screen, and defers that read while the tab is hidden', async () => {
+    await render({ active: true })
+    expect(wire.calls).toHaveLength(1)
+
+    await rerender({ active: true, turnActive: true })
+    await rerender({ active: true, turnActive: false })
+    expect(wire.calls).toHaveLength(2)
+
+    await rerender({ active: false, turnActive: true })
+    await rerender({ active: false, turnActive: false })
+    expect(wire.calls).toHaveLength(2)
+    await rerender({ active: true, turnActive: false })
+    expect(wire.calls).toHaveLength(3)
+  })
+})

--- a/packages/web/src/components/console/dock/TasksPanel.tsx
+++ b/packages/web/src/components/console/dock/TasksPanel.tsx
@@ -10,6 +10,7 @@ import { Spinner } from '@/components/marks'
 import { Icon } from '@/components/ui'
 import { formatFileMtime } from '@/components/console/FileBrowser'
 import { ApiError, fetchAgentTasks, type AgentTaskDto, type AgentTasksDto } from '@/lib/api'
+import { useDockRefresh } from '@/components/console/dock/auto-refresh'
 import type { DockTabStatus } from './SessionDock'
 
 const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
@@ -102,6 +103,7 @@ export function TasksPanel({
   agentId,
   sessionId,
   active = true,
+  turnActive = false,
   refreshTick = 0,
   onVerdictChange
 }: {
@@ -110,6 +112,8 @@ export function TasksPanel({
   sessionId: string
   /** Whether this tab is the visible one. A hidden panel neither polls nor ticks nor re-reads; its rows are then as fresh as its last read, which is what the Git tab's changed count already is. */
   active?: boolean
+  /** Whether a turn is streaming in this session. Its falling edge re-reads, for the same reason the idle poll exists: a turn is where new background tasks come from. Deferred to the reveal edge while the tab is hidden — the count on the badge is worth a read the reader can see, not one they cannot. */
+  turnActive?: boolean
   /** Bumped by the tab's `refresh-cw` action: re-reads without remounting. */
   refreshTick?: number
   /** The inputs to {@link tasksTabStatus} and the tab's badge. */
@@ -132,12 +136,15 @@ export function TasksPanel({
 
   // A VISIBLE panel always polls; only the cadence depends on what it is showing. Visibility is the
   // whole gate because a hidden panel is a request nobody is looking at, whereas an idle VISIBLE one
-  // still has the 0 -> running edge to discover (see {@link IDLE_POLL_MS}).
-  useEffect(() => {
-    if (!active) return
-    const timer = setInterval(() => setOwnTick((tick) => tick + 1), running > 0 ? POLL_MS : IDLE_POLL_MS)
-    return () => clearInterval(timer)
-  }, [active, running])
+  // still has the 0 -> running edge to discover (see {@link IDLE_POLL_MS}). Through the dock's shared
+  // hook, so a backgrounded BROWSER counts as hidden here exactly as it does for the other tabs — and
+  // a turn's falling edge is a read too: a turn that ended may have left a task behind it.
+  useDockRefresh({
+    active,
+    turnActive,
+    intervalMs: running > 0 ? POLL_MS : IDLE_POLL_MS,
+    onRefresh: () => setOwnTick((tick) => tick + 1)
+  })
 
   // Elapsed redraws from `startedAt` alone, so it ticks without a request.
   useEffect(() => {

--- a/packages/web/src/components/console/dock/auto-refresh.test.tsx
+++ b/packages/web/src/components/console/dock/auto-refresh.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment happy-dom
+
+// The dock's shared refresh cadence: which of the three signals reaches a panel in which state. The
+// distinctions under test are the ones that cost requests — a background tab and a background BROWSER
+// both stop polling, a hidden panel with a badge still takes a turn's edge, and one without a badge
+// defers that read to the moment it is revealed instead of dropping it.
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DOCK_POLL_MS, useDockRefresh, type DockRefreshReason } from './auto-refresh'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let container: HTMLDivElement | undefined
+let root: ReturnType<typeof createRoot> | undefined
+let reasons: DockRefreshReason[] = []
+
+type Props = Parameters<typeof useDockRefresh>[0]
+
+function Probe(props: Omit<Props, 'onRefresh'>) {
+  useDockRefresh({ ...props, onRefresh: (reason) => reasons.push(reason) })
+  return null
+}
+
+async function render(props: Omit<Props, 'onRefresh'>) {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<Probe {...props} />)
+  })
+}
+
+async function rerender(props: Omit<Props, 'onRefresh'>) {
+  await act(async () => {
+    root?.render(<Probe {...props} />)
+  })
+}
+
+/** Drive `document.visibilityState`, which happy-dom reports from a getter. */
+async function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true })
+  await act(async () => {
+    document.dispatchEvent(new Event('visibilitychange'))
+  })
+}
+
+beforeEach(() => {
+  reasons = []
+  vi.useFakeTimers()
+})
+
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  container?.remove()
+  container = undefined
+  root = undefined
+  await setVisibility('visible')
+  vi.useRealTimers()
+})
+
+describe('useDockRefresh', () => {
+  it('polls on its cadence while the tab is on screen, and stops when it is not', async () => {
+    await render({ active: true, intervalMs: DOCK_POLL_MS })
+    await act(async () => vi.advanceTimersByTime(DOCK_POLL_MS * 2))
+    expect(reasons).toEqual(['poll', 'poll'])
+
+    await rerender({ active: false, intervalMs: DOCK_POLL_MS })
+    await act(async () => vi.advanceTimersByTime(DOCK_POLL_MS * 5))
+    expect(reasons).toEqual(['poll', 'poll'])
+  })
+
+  it('stops polling while the BROWSER is in the background, and resumes when it comes back', async () => {
+    await render({ active: true, intervalMs: DOCK_POLL_MS })
+    await setVisibility('hidden')
+    await act(async () => vi.advanceTimersByTime(DOCK_POLL_MS * 3))
+    expect(reasons).toEqual([])
+
+    await setVisibility('visible')
+    await act(async () => vi.advanceTimersByTime(DOCK_POLL_MS))
+    expect(reasons).toEqual(['poll'])
+  })
+
+  it('never polls without a cadence — a panel that must not spend a budget passes none', async () => {
+    await render({ active: true })
+    await act(async () => vi.advanceTimersByTime(10 * DOCK_POLL_MS))
+    expect(reasons).toEqual([])
+  })
+
+  it('refreshes on a turn’s FALLING edge, not while it streams', async () => {
+    await render({ active: true, turnActive: false })
+    await rerender({ active: true, turnActive: true })
+    expect(reasons).toEqual([])
+    await rerender({ active: true, turnActive: false })
+    expect(reasons).toEqual(['turn'])
+  })
+
+  it('takes a hidden tab’s turn edge only for a panel whose badge is on screen', async () => {
+    await render({ active: false, turnActive: true, whileHidden: true })
+    await rerender({ active: false, turnActive: false, whileHidden: true })
+    expect(reasons).toEqual(['turn'])
+  })
+
+  it('defers a hidden panel’s turn refresh to the reveal edge, and spends it exactly once', async () => {
+    await render({ active: false, turnActive: true })
+    await rerender({ active: false, turnActive: false })
+    expect(reasons).toEqual([])
+
+    await rerender({ active: true, turnActive: false })
+    expect(reasons).toEqual(['reveal'])
+
+    // Nothing owed any more: leaving and returning re-reads nothing on its own.
+    await rerender({ active: false, turnActive: false })
+    await rerender({ active: true, turnActive: false })
+    expect(reasons).toEqual(['reveal'])
+  })
+
+  it('collapses several missed turns into one deferred read', async () => {
+    await render({ active: false, turnActive: false })
+    for (const streaming of [true, false, true, false]) {
+      await rerender({ active: false, turnActive: streaming })
+    }
+    await rerender({ active: true, turnActive: false })
+    expect(reasons).toEqual(['reveal'])
+  })
+
+  it('spends a deferred read when the BROWSER returns, not only on a tab switch', async () => {
+    await render({ active: true, turnActive: false })
+    await setVisibility('hidden')
+    await rerender({ active: true, turnActive: true })
+    await rerender({ active: true, turnActive: false })
+    expect(reasons).toEqual([])
+
+    await setVisibility('visible')
+    expect(reasons).toEqual(['reveal'])
+  })
+})

--- a/packages/web/src/components/console/dock/auto-refresh.ts
+++ b/packages/web/src/components/console/dock/auto-refresh.ts
@@ -1,0 +1,100 @@
+'use client'
+
+// The dock's shared refresh cadence (§3.3/§3.4). Every workspace panel reads a LIVE surface — the
+// session worktree through its daemon, the pull request through GitHub — so a panel that only ever
+// re-reads when pressed shows the tree as it was when the page opened. Three signals move it, and each
+// one is here rather than re-derived per panel, because the differences between them are the bugs:
+//
+//  - the falling edge of a streaming TURN, which is when the agent's own writes (commits, pushes, an
+//    opened pull request, resolved threads) have landed — the single highest-value signal, and the
+//    only one that fires for a panel whose tab is hidden but whose BADGE is on screen;
+//  - a poll while the tab is on screen AND the document is visible, for the changes nobody here made
+//    (a coworker's push, a check turning green);
+//  - the reveal edge — a tab becoming active, or the document coming back — which is where a refresh
+//    deferred by a hidden panel is actually spent.
+//
+// A background tab polls NOTHING: these reads reach a daemon and, for the PR panel, an installation's
+// rate limit, and a browser nobody is looking at must not spend either.
+import { useEffect, useRef, useState } from 'react'
+
+/** Poll cadence for the daemon-backed panels (Files, Git) while their tab is on screen. */
+export const DOCK_POLL_MS = 15_000
+
+/** The PR panel's own, deliberately slower: it is the one read that spends an installation's GitHub
+ *  rate limit (§9), and the CP already absorbs repeats behind a 20s projection TTL. */
+export const PR_POLL_MS = 60_000
+
+/** Why a refresh fired, for the panel that treats them differently (a `turn` forces past the CP's TTL). */
+export type DockRefreshReason = 'turn' | 'poll' | 'reveal'
+
+/** Whether the document is visible, SSR-safe and event-driven — `true` on the server and before the
+ *  first effect, so a panel renders its first read rather than waiting for a signal that never comes. */
+export function useDocumentVisible(): boolean {
+  const [visible, setVisible] = useState(true)
+  useEffect(() => {
+    const read = () => setVisible(document.visibilityState !== 'hidden')
+    read()
+    document.addEventListener('visibilitychange', read)
+    return () => document.removeEventListener('visibilitychange', read)
+  }, [])
+  return visible
+}
+
+/**
+ * One panel's refresh cadence. `onRefresh` must be safe to call repeatedly — every consumer here
+ * bumps a tick, which is idempotent by construction.
+ *
+ * `whileHidden` is for a tab that shows a BADGE (Git's changed count, PR's unresolved threads): its
+ * numbers are on screen even when its panel is not, so a turn's falling edge has to reach it. Without
+ * it the refresh is DEFERRED rather than dropped, and spent on the reveal edge — which is what keeps a
+ * hidden panel from re-reading a worktree nobody is looking at.
+ */
+export function useDockRefresh(opts: {
+  /** Whether this panel's tab is the selected one. */
+  active: boolean
+  /** Poll cadence while active and visible; omit (or 0) for a panel that must not poll. */
+  intervalMs?: number
+  /** True while a turn streams in this session — the falling edge is the refresh signal. */
+  turnActive?: boolean
+  /** Fire the turn refresh even while the tab is hidden; otherwise it waits for the reveal edge. */
+  whileHidden?: boolean
+  onRefresh: (reason: DockRefreshReason) => void
+}): void {
+  const { active, intervalMs = 0, turnActive = false, whileHidden = false } = opts
+  const visible = useDocumentVisible()
+  // Held in a ref so a caller's fresh closure per render never re-arms the timer below.
+  const onRefresh = useRef(opts.onRefresh)
+  onRefresh.current = opts.onRefresh
+  // A refresh a hidden panel owes itself. A boolean, not a count: two missed turns are still one
+  // re-read, and the reveal edge reads the current tree either way.
+  const pending = useRef(false)
+
+  const wasTurnActive = useRef(turnActive)
+  useEffect(() => {
+    const settled = wasTurnActive.current && !turnActive
+    wasTurnActive.current = turnActive
+    if (!settled) return
+    // Hidden means the tab is not selected OR the document is not on screen: neither is a moment to
+    // spend a daemon round trip, and both end in a reveal edge that will.
+    if (active && visible) onRefresh.current('turn')
+    else if (whileHidden) onRefresh.current('turn')
+    else pending.current = true
+  }, [turnActive, active, visible, whileHidden])
+
+  // The reveal EDGE, not the state: firing on `active && visible` itself would re-read every render.
+  const wasRevealed = useRef(active && visible)
+  useEffect(() => {
+    const revealed = active && visible
+    const edge = revealed && !wasRevealed.current
+    wasRevealed.current = revealed
+    if (!edge || !pending.current) return
+    pending.current = false
+    onRefresh.current('reveal')
+  }, [active, visible])
+
+  useEffect(() => {
+    if (!active || !visible || intervalMs <= 0) return
+    const timer = window.setInterval(() => onRefresh.current('poll'), intervalMs)
+    return () => window.clearInterval(timer)
+  }, [active, visible, intervalMs])
+}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2200,6 +2200,11 @@ export default function SessionDetailView() {
     [session, railCurrentKey, railCurrentMemberIds]
   )
   const sessionBusy = session ? isPgBusy(session.id) : false
+  // The busy flag for the dock's WORKSPACE panels, which follow header focus rather than the open
+  // session (§3.4): in a merged conversation it is the focused participant's turn that writes the
+  // checkout those panels read, so keying them to the open session would refresh the wrong worktree's
+  // reader — and, for a participant nobody focused, never at all.
+  const focusBusy = headerFocusSessionId ? isPgBusy(headerFocusSessionId) : sessionBusy
   const sessionBusyRef = useRef(sessionBusy)
   sessionBusyRef.current = sessionBusy
 
@@ -4906,6 +4911,7 @@ export default function SessionDetailView() {
           {filesAgentId && filesScopeReady ? (
             <FilesPanel
               active={dockTabKey === 'files'}
+              turnActive={focusBusy}
               agentId={filesAgentId}
               {...(filesSessionId ? { sessionId: filesSessionId } : {})}
               {...(filesWorkdir ? { workdir: filesWorkdir } : {})}
@@ -4932,6 +4938,8 @@ export default function SessionDetailView() {
             <GitPanel
               agentId={filesAgentId}
               {...(filesSessionId ? { sessionId: filesSessionId } : {})}
+              active={dockTabKey === 'git'}
+              turnActive={focusBusy}
               refreshTick={gitRefreshTick}
               openPath={viewerOpen && viewerMode !== 'file' ? viewerPath : null}
               openStaged={viewerMode === 'staged'}
@@ -4971,6 +4979,7 @@ export default function SessionDetailView() {
               agentId={filesAgentId}
               sessionId={tasksSessionId}
               active={dockTabKey === 'tasks'}
+              turnActive={focusBusy}
               refreshTick={tasksRefreshTick}
               onVerdictChange={setTasksVerdict}
             />

--- a/packages/web/src/components/console/workspace-tree.tsx
+++ b/packages/web/src/components/console/workspace-tree.tsx
@@ -61,12 +61,20 @@ export interface WorkspaceTree {
   openPath: (paths: string[]) => void
 }
 
-/** The tree half of the read model for one daemon-local checkout. `refreshTick` re-runs the root load, deliberately wiping the cache and the expand set with it. */
+/** The tree half of the read model for one daemon-local checkout. `refreshTick` re-reads the root AND every open folder, keeping the expand set; a SCOPE change is the one thing that wipes both. */
 // `sessionId` selects that session's isolated worktree; omit it for the primary checkout, and pass it only for a session whose `workspaceIsolation` is `'session'` — the daemon answers a shared-workspace sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline".
 // `repo` selects one of the agent's authorized additional repositories, browsing that secondary root; the two scopes compose, so a `repo` with a `sessionId` is that root's own worktree for the session.
 export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTick = 0, repo?: string): WorkspaceTree {
   const [dirs, setDirs] = useState<Record<string, WorkspaceDirState>>({})
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
+  // Which checkout this is, as one value: what tells a refresh (re-read what is open) from a scope
+  // change (a different tree entirely, where the previous expand set names paths that may not exist).
+  const scope = `${agentId}\u0000${sessionId ?? ''}\u0000${repo ?? ''}`
+  const lastScope = useRef<string | null>(null)
+  // The expand set as the refresh effect reads it. A REF because the effect must not re-run when a
+  // folder opens — that would re-read the whole tree on every expand.
+  const expandedRef = useRef(expanded)
+  expandedRef.current = expanded
   // Which checkout+refresh a reply was asked for. The panel SURVIVES a scope change, so an in-flight directory read from the previous agent or worktree would otherwise splice its entries into the new one's cache — and worse, leave `dirs[path]` populated, so expanding that folder in the new scope skips the fetch that would have corrected it.
   const generation = useRef(0)
 
@@ -171,41 +179,58 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
     [dirs, loadDir]
   )
 
-  // Reset the tree and load the root whenever the scope changes or a refresh lands.
+  // Load the root whenever the scope changes or a refresh lands. A SCOPE change resets the tree: the
+  // previous expand set names paths in another checkout, which may not exist in this one. A REFRESH
+  // does NOT — collapsing every open folder back to root is not what "re-read this" means, and on the
+  // dock's timer it would also shrink the path filter's corpus (which is derived from `dirs`) to
+  // root-level hits every few seconds. It re-reads the root and each OPEN folder instead.
   useEffect(() => {
     // Bumped FIRST, so any directory read still in flight for the previous checkout is already fenced by the time this one's root lands.
     generation.current += 1
     const gen = generation.current
     const active = () => gen === generation.current
-    setDirs({ '': { ...LOADING_DIR } })
-    setExpanded(new Set())
+    const scopeChanged = lastScope.current !== scope
+    lastScope.current = scope
+    const reopen = scopeChanged ? [] : [...expandedRef.current]
+    if (scopeChanged) {
+      setDirs({ '': { ...LOADING_DIR } })
+      setExpanded(new Set())
+    } else {
+      // Marked loading in place: the rows stay on screen behind their spinners rather than vanishing.
+      patchDir('', { loading: true, err: null, errStatus: null, errCode: null })
+    }
     fetchWorkspaceFiles(agentId, { path: '', ...(sessionId ? { sessionId } : {}), ...(repo ? { repo } : {}) }).then(
       (page) => {
         if (!active()) return
-        setDirs({
-          '': {
-            entries: page.entries,
-            exists: page.exists,
-            nextCursor: page.nextCursor,
-            loading: false,
-            loadingMore: false,
-            err: null,
-            errStatus: null,
-            errCode: null,
-            moreErr: null
-          }
-        })
+        const root = {
+          entries: page.entries,
+          exists: page.exists,
+          nextCursor: page.nextCursor,
+          loading: false,
+          loadingMore: false,
+          err: null,
+          errStatus: null,
+          errCode: null,
+          moreErr: null
+        }
+        // Merged on a refresh, replaced on a scope change — the open folders being re-read below are in
+        // this map, and dropping them here would collapse the tree by another route.
+        setDirs((prev) => (scopeChanged ? { '': root } : { ...prev, '': root }))
       },
       (e) => {
-        if (active())
-          setDirs({ '': { ...LOADING_DIR, loading: false, err: msg(e), errStatus: statusOf(e), errCode: codeOf(e) } })
+        if (!active()) return
+        const failed = { ...LOADING_DIR, loading: false, err: msg(e), errStatus: statusOf(e), errCode: codeOf(e) }
+        setDirs((prev) => (scopeChanged ? { '': failed } : { ...prev, '': failed }))
       }
     )
+    // Every folder that was open, re-read on its own. Each one fences on the generation bumped above,
+    // so a scope change landing mid-refresh discards all of them.
+    for (const path of reopen) loadDir(path)
     return () => {
       // A teardown is its own generation change: the next mount's reads must not be answered by this one's.
       generation.current += 1
     }
-  }, [agentId, refreshTick, repo, sessionId])
+  }, [agentId, loadDir, patchDir, refreshTick, repo, scope, sessionId])
 
   return { dirs, root: dirs[''], expanded, toggleDir, loadMoreDir, openPath }
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3315,6 +3315,12 @@ export interface SessionPullRequestDto {
   degradedReason: 'rate_limited' | 'denied' | 'unreachable' | null
   /** The agent's own recorded review, present ONLY on a degraded answer — the one review state the deployment knows without GitHub. */
   agentReview: 'approved' | 'changes_requested' | 'commented' | null
+  /** Which source named this PR: the owning review run, or this session's own head branch. Optional — a CP that predates the branch source sends neither this nor the two fields below. */
+  linkedBy?: 'run' | 'head-branch'
+  /** The head branch a `head-branch` link resolved through; null for a run-linked PR. */
+  linkBranch?: string | null
+  /** true ⇒ that branch has more than one OPEN pull request and this is the first of them. */
+  linkAmbiguous?: boolean
 }
 
 // Read the session's PR projection. `refresh` bypasses the CP's short TTL but not its in-flight


### PR DESCRIPTION
## Why

Reported from a real session: it had clearly opened a pull request, and the dock's PR tab showed **No pull request**. Two independent causes, both fixed here.

1. **Identity had one source.** `GET /sessions/:id/pull-request` found its PR only through the `pull_request`-subject `HookRun` that owned the session. A PR the agent opens mid-conversation creates no such row — neither does an *issue*-dispatched run whose work ends in a PR — so the probe kept answering 404 after the pull request existed. `webchat-side-panels.md` §12.6 had already recorded this as future work ("a by-head-branch read source … belongs in its own change"). This is that change.
2. **Nothing re-read itself.** The panels read live surfaces but only re-read when pressed, and the PR tab re-read only after a turn *it* had posted — so even once identity worked, the tab would not have noticed.

## What

### A second identity source for the PR panel

With no pull-request run, the route resolves the PR from the session worktree's **own head branch**: `SessionPullRequestLinkService` reads the branch from the owning daemon (`workspace/gitstatus`, session-scoped), resolves the agent's primary workspace repo and live installation (new `GithubService.resolveWorkspaceRepo`), and asks GitHub `pulls?state=all&head=<owner>:<branch>`. The chosen number joins the **same** projection a run-linked PR takes, so checks, reviews, threads, Auto-fix and auto-merge work unchanged.

Deliberate limits:

| | |
| --- | --- |
| The run stays **preferred** | it carries the subject / draft / recorded-review facts a degraded answer falls back on, which a branch lookup cannot know |
| Branch, not head sha | a session branch is amended and rebased; `commits/{sha}/pulls` goes blind on the next rewrite. `head=` is fork-blind, which reads as the absence it is |
| Failure is **absence**, not degradation | the degraded arm needs a PR to *name*; a denied / rate-limited / unreachable lookup resolves `null` and is cached as a miss |
| Only a session worktree | shared checkout, purged session, offline or too-old daemon ⇒ no daemon read and no GitHub call at all |
| Ambiguity is reported | several open PRs on one head ⇒ lowest number (the branch's canonical review) plus `linkAmbiguous`; highest when none is open |
| Two TTLs | 60s for a link, 15s for a miss (a PR opened seconds ago must not stay invisible); `?refresh=true` bypasses both |

DTO gains `linkedBy` (`run` \| `head-branch`), `linkBranch`, `linkAmbiguous`; both route descriptions updated.

### The dock's shared refresh cadence

`dock/auto-refresh.ts` — one hook, three signals, all four tabs, each bumping the same tick a press does (no second read path to keep in step):

| signal | when | who takes it |
| --- | --- | --- |
| a turn's **falling edge** | the agent's own writes have landed | Files, Git, PR, Tasks — free of any timer |
| a **poll** | the tab is selected **and** the document is visible | Files/Git 15s, PR 60s (GitHub budget), Tasks 5s/20s as before |
| the **reveal edge** | a tab becoming active, or the browser coming back | whoever deferred a turn refresh while hidden |

- A background tab **and a background browser** poll nothing — these reads reach a daemon, and for the PR panel an installation's rate limit.
- A turn's edge reaches a *hidden* panel only where that tab shows a badge whose numbers are on screen anyway (Git's changed count, PR's unresolved threads). Files, which has no badge, defers to the reveal edge instead of re-reading a worktree nobody is looking at.
- The Git panel skips an automatic read while one of its **own** writes is in flight — that write answers with the fresh status, and a read racing it would land the pre-write tree over the reply.
- Workspace panels take the **focused participant's** turn (they follow header focus); the PR tab, keyed to the open session, takes that session's.

The PR panel's turn-edge re-read is no longer gated on `awaitingTurn`, which is the fix for the reported case: agent opens the PR inside a turn → falling edge → forced re-read → the tab links it, with nobody pressing refresh.

## Tests

- `session-pull-request-link.service.test.ts` (10): the pick (open beats closed, ambiguity, wrong-head rows), the sessions that spend no GitHub call, denial-as-absence, both TTLs, `invalidateSession`.
- `sessions.pull-request.route.test.ts` (+5): branch link + `linkedBy`, the ambiguity, still-404 with no PR for the branch, run preferred and branch never asked, auto-merge armed on a branch link.
- `auto-refresh.test.tsx` (8): poll on/off, background browser, turn falling edge, `whileHidden`, deferred read spent exactly once, several turns collapsed, browser-return as reveal.
- Panel wiring cases for Git / Files / Tasks / PR, including "a PR opened mid-turn links without a manual refresh".
- Four PR-panel cases that encoded the old "does not poll" contract were re-aimed at the new one (assertions changed, not weakened).

`test:unit` 1802 ✅ · `session*` integration 99 ✅ · web 1697 ✅ · typecheck / lint / format clean.

## Notes

Design doc updated in both places: §3.3 gains the cadence table and its cost rules, §12.6's "what this action cannot do" becomes the landed second identity source with its five limits.

A session on a **shared** checkout, or one whose PR was opened from a different branch, still reads 404. An issue-dispatched run already carries `repoId` and `sourceInstallationId`, so a second fallback through that row is possible — deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
