### PR TITLE
feat(memory): let a binding pin an explicit store and its own limits

### DIFF
--- a/packages/daemon/src/mcp/ops/context.ts
+++ b/packages/daemon/src/mcp/ops/context.ts
@@ -103,8 +103,15 @@ export interface SessionContext {
     source: MemoryWriteSource
     /** The store to act on. A synthetic session (distillation) has no real channel
      *  coordinates, so it pins the ORIGINATING conversation's scope here — otherwise a
-     *  channel-scoped agent would distill into the wrong folder. */
+     *  channel-scoped agent would distill into the wrong folder. A dream pins its
+     *  STAGED store the same way. */
     scope?: MemoryScope
+    /** Constrain topic filenames beyond the store's own path rules. A dream keeps the
+     *  lowercase-kebab shape its proposal format always enforced. */
+    topicPattern?: RegExp
+    /** Cap distinct topics this session may create, mirroring the bound the proposal
+     *  format used to apply. Absent ⇒ uncapped, as for an ordinary turn. */
+    maxTopics?: number
   }
   /** Snapshot of the agent's integrations (id + platform) at session/new. Lets the
    *  platform-neutral `sendMessage` tool route to ANY connected platform,

--- a/packages/daemon/src/mcp/ops/memory.ts
+++ b/packages/daemon/src/mcp/ops/memory.ts
@@ -89,6 +89,32 @@ function memoryScopeFor(ctx: SessionContext, deps: MemoryOpsDeps): MemoryScope {
 /** Provenance for a write made through the shared tool surface. The ordinary
  *  conversational case is `tool`; a distillation- or dream-bound session keeps its own
  *  source so the write ledger — and dream adoption's distill-only rebase — stay honest. */
+/** Topics a bound session has already written, so `maxTopics` counts DISTINCT files
+ *  rather than writes — appending to one topic repeatedly is not new content. */
+const boundTopics = new WeakMap<SessionContext, Set<string>>()
+
+/** Apply the binding's own limits before a write reaches the store. These carry the
+ *  constraints the dream's JSON proposal format used to enforce; the store still
+ *  applies path containment and the byte cap underneath. */
+function enforceBindingPolicy(ctx: SessionContext, path: string): void {
+  const binding = ctx.memoryBinding
+  if (!binding) return
+  const name = path.replace(/^.*\//, '')
+  if (binding.topicPattern && !binding.topicPattern.test(name)) {
+    throw new Error(`invalid memory path: "${name}" must match ${String(binding.topicPattern)}`)
+  }
+  if (binding.maxTopics === undefined) return
+  let seen = boundTopics.get(ctx)
+  if (!seen) {
+    seen = new Set()
+    boundTopics.set(ctx, seen)
+  }
+  if (!seen.has(name) && seen.size >= binding.maxTopics) {
+    throw new Error(`memory topic limit reached (${binding.maxTopics}) for this session`)
+  }
+  seen.add(name)
+}
+
 function writeSource(ctx: SessionContext): MemoryWriteSource {
   return ctx.memoryBinding?.source ?? 'tool'
 }
@@ -139,6 +165,7 @@ export async function writeMemory(
     // must be an explicit `newString: ""`).
     const parsed = parseArgs(WRITE_MEMORY_ARGS, args)
     const path = parsed.path ?? 'MEMORY.md'
+    enforceBindingPolicy(ctx, path)
     const { oldString, newString, content } = parsed
     const editMode = oldString !== undefined || newString !== undefined
     if (editMode) {

--- a/packages/daemon/src/memory/providers/managed.ts
+++ b/packages/daemon/src/memory/providers/managed.ts
@@ -63,6 +63,7 @@ export class ManagedMemoryProvider implements MemoryProvider {
    *  agent base. All WRITES (tools + distillation) target this so a channel's
    *  content never lands in another channel or the shared base (#653). */
   private activeRoot(scope: MemoryScope): MemoryFs {
+    if (scope.root) return scope.root
     const base = this.rootFor(scope.agentId)
     return scope.channelKey ? channelMemoryRoot(base, scope.channelKey) : base
   }
@@ -71,6 +72,9 @@ export class ManagedMemoryProvider implements MemoryProvider {
    *  scoped so the channel layer shadows the shared base per file; `[base]`
    *  otherwise. */
   private readRoots(scope: MemoryScope): MemoryFs[] {
+    // An explicit store stands alone: a dream's staged proposal must not read through
+    // to the live store, or a reviewer would see files the proposal does not contain.
+    if (scope.root) return [scope.root]
     const base = this.rootFor(scope.agentId)
     return scope.channelKey ? [channelMemoryRoot(base, scope.channelKey), base] : [base]
   }

--- a/packages/daemon/src/memory/types.ts
+++ b/packages/daemon/src/memory/types.ts
@@ -1,3 +1,4 @@
+import type { MemoryFs } from './fs.js'
 /** The L0 memory contract: the `MemoryProvider` port plus its scope, result, admin-surface
  *  and error types. Implementations and factories live in `provider.ts`, which re-exports
  *  everything here so existing importers stay unchanged. */
@@ -26,6 +27,10 @@ export type MemoryProviderKind = 'none' | 'native' | 'managed' | 'external'
  *  `userId`/`sessionId` are reserved for later providers. */
 export interface MemoryScope {
   agentId: string
+  /** Act on exactly this store instead of resolving one from the agent + channel.
+   *  A dream binds its STAGED store here, so the same memory tools serve it without
+   *  the provider needing to know what a dream is. */
+  root?: MemoryFs
   /** A filesystem-safe per-channel folder name (channel + transport scope), set by
    *  the daemon only for channel-scoped agents. Absent ⇒ agent-level store. */
   channelKey?: string

--- a/packages/daemon/test/memory-write-gate.test.ts
+++ b/packages/daemon/test/memory-write-gate.test.ts
@@ -185,3 +185,55 @@ describe('the distillation binding is its own authorization', () => {
     expect((calls[1]![0] as { channelKey?: string }).channelKey).toBe('chan-B')
   })
 })
+
+describe('a dream-bound session writing its staged store', () => {
+  const dreamCtx = (over: Partial<SessionContext['memoryBinding']> = {}): SessionContext => ({
+    agentId: 'bot-a',
+    platform: 'dream',
+    channel: 'memory',
+    thread: 'drm-1',
+    isDm: false,
+    tools: [],
+    memoryBinding: {
+      source: 'dream',
+      scope: { agentId: 'bot-a', root: { key: 'staged' } as never },
+      topicPattern: /^[a-z0-9][a-z0-9-]{0,62}\.md$/,
+      maxTopics: 2,
+      ...over
+    }
+  })
+
+  it('writes to the pinned staged store, recorded as `dream`', async () => {
+    const d = deps(true)
+    await executeTool(dreamCtx(), 'writeMemory', { path: 'deploys.md', content: '- x' }, d)
+    const [scope, , , , source] = (d.memory.write as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]!
+    expect((scope as { root?: unknown }).root).toEqual({ key: 'staged' })
+    expect(source).toBe('dream')
+  })
+
+  it('keeps the lowercase-kebab filename rule the proposal format used to enforce', async () => {
+    const d = deps(true)
+    await expect(executeTool(dreamCtx(), 'writeMemory', { path: 'Bad_Name.md', content: 'x' }, d)).rejects.toThrow(
+      /invalid memory path/
+    )
+    expect(d.memory.write).not.toHaveBeenCalled()
+  })
+
+  it('caps DISTINCT topics, while letting one topic be rewritten freely', async () => {
+    const d = deps(true)
+    const ctx = dreamCtx()
+    await executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'a' }, d)
+    await executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'a2' }, d) // same topic, fine
+    await executeTool(ctx, 'writeMemory', { path: 'two.md', content: 'b' }, d)
+    await expect(executeTool(ctx, 'writeMemory', { path: 'three.md', content: 'c' }, d)).rejects.toThrow(
+      /topic limit reached/
+    )
+    expect((d.memory.write as unknown as { mock: { calls: unknown[][] } }).mock.calls).toHaveLength(3)
+  })
+
+  it('leaves an unbound turn unconstrained', async () => {
+    const d = deps(true)
+    await executeTool(ctx(), 'writeMemory', { path: 'Any_Name.md', content: 'x' }, d)
+    expect(d.memory.write).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
The last mechanism needed before the dream can write its proposal through the shared memory tools. Split out so it lands under its own tests rather than inside the flow change.

## What

- **`MemoryScope.root`** pins an explicit store instead of resolving one from agent + channel. The managed provider honours it for reads and writes, and an explicit store **stands alone** — a staged proposal must not read through to the live store, or a reviewer would see files the proposal doesn't contain.
- **A binding may carry `topicPattern` and `maxTopics`.** These are exactly the two constraints the dream's JSON proposal format enforced that nothing else does: the lowercase-kebab filename shape, and a bound on how many topics one run may create. `maxTopics` counts **distinct** topics, so rewriting one file repeatedly stays free — the bound is on new content, not on writes.

Path containment and the byte cap already live in the store and are untouched, and the review token is computed from staged files on disk, so neither depends on the proposal carrying `files`.

An unbound session — an ordinary turn — is unconstrained by any of this.

## Tests

A dream-bound write lands in the pinned store recorded as `dream`; a non-kebab name is refused *before* reaching the store; the distinct-topic cap holds while repeated writes to one topic don't count against it; an ordinary turn is unaffected.

## Next

The flow change itself: create the staged store before extraction, bind these tools to it, and drop `files` from the proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)