### PR TITLE
fix(control-plane): resolve the collab snapshot's channel half through placement

### DIFF
--- a/docs/designs/agent-collaboration-implementation.md
+++ b/docs/designs/agent-collaboration-implementation.md
@@ -232,9 +232,19 @@ allowedCallerAgentIds, outboundPolicy, allowedTargetAgentIds, name?, displayName
     `botAppId`). This is the authorization input. The channel-keyed structure
     _structurally cannot_ express an integration-less agent: such an agent appears
     in no `channels[]` entry at all, so "which agents exist in this org" — exactly
-    the input channel-free authorization needs — is unanswerable from it. Unplaced
-    agents (`daemonId` null) are dropped from both parts: with no owning daemon
-    there is nothing to route to.
+    the input channel-free authorization needs — is unanswerable from it.
+  - **Who serves an agent is resolved ONCE, for both parts.** `daemonId` in either
+    part is the answer `PlacementResolver.resolveDirectory` gives — placement for a
+    machine-placed agent, the live duty holder for a `set` (pool) one — never
+    `Agent.daemonId` re-read per part. That column is null for a pool agent BY
+    DESIGN, so deriving routability from it inside `channels[]` dropped every pool
+    agent from its own channels while `agents[]` listed it; the daemon's
+    `coordsDecision` reads the channel half, so such an agent was refused as a
+    non-member of a channel it is in and its peer wakes came back `not_allowed`
+    whatever its call policy said. An agent nothing serves is dropped from both
+    parts. A pool agent with an UNCONFIRMED grant is PENDING: `agents[]` carries it
+    without a `daemonId` so a wake gets the retryable `not_ready`, and `channels[]`
+    — which has no daemon-less entry — omits it until the hold is confirmed.
   - Relay resolves `toAgentId` to its owning `daemonId` from `agents[]`, then gets the connection through `relay-daemon-server.get(daemonId)`.
   - `CollabRoutesSnapshot` travels to relay through `rc/collab-routes` and to
     daemons through `register/ok` plus `collaboration/routes`.

--- a/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
@@ -173,6 +173,42 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
     expect(snap.agents.find((a) => a.agentId === AGENT_1)?.displayName).toBe('Deploy Bot')
   })
 
+  // A `set` (pool) agent's `Agent.daemonId` is null BY DESIGN — its holder lives in the duty
+  // ledger, which is what the resolved directory carries. Reading the placement column instead
+  // dropped such an agent from its OWN channels while agents[] listed it, and the daemon's
+  // `coordsDecision` then refused every peer wake it made from that channel as a non-member.
+  it('places a pool agent in its channels from the resolved directory, not the null placement column', () => {
+    const snap = buildCollabSnapshot(
+      DEFAULT_ORG_ID,
+      [
+        rec({ agentId: AGENT_1, daemonId: DAEMON_1, botUserId: 'U09SHARED', name: 'machine-placed' }),
+        // Pool-placed: no machine on the row, and a live member holds it.
+        rec({ agentId: AGENT_2, daemonId: null, botUserId: 'U09SHARED', name: 'pool-placed' })
+      ],
+      1,
+      [orgAgent({ agentId: AGENT_1, daemonId: DAEMON_1 }), orgAgent({ agentId: AGENT_2, daemonId: DAEMON_2 })]
+    )
+    expect(CollabRoutesSnapshot.parse(snap)).toEqual(snap)
+    const byAgent = new Map(snap.channels[0]!.agents.map((a) => [a.agentId, a]))
+    // The membership `coordsDecision` reads — both halves now agree on who serves AGENT_2.
+    expect([...byAgent.keys()].sort()).toEqual([AGENT_1, AGENT_2].sort())
+    expect(byAgent.get(AGENT_2)).toMatchObject({ daemonId: DAEMON_2, name: 'pool-placed' })
+    // Mention sharing counts it too: it was invisible to that derivation for the same reason.
+    expect(byAgent.get(AGENT_1)).toMatchObject({ botShared: true })
+    expect(byAgent.get(AGENT_2)).toMatchObject({ botShared: true })
+  })
+
+  it('still drops a PENDING pool agent from channels[] — that half carries no daemon-less entry', () => {
+    // The wire contract keeps pending entries to the flat directory, so a wake at an
+    // unconfirmed grant gets the retryable `not_ready` from there rather than a channel row
+    // naming a daemon that would refuse it.
+    const snap = buildCollabSnapshot(DEFAULT_ORG_ID, [rec({ agentId: AGENT_2, daemonId: null })], 1, [
+      orgAgent({ agentId: AGENT_2, daemonId: null })
+    ])
+    expect(snap.channels).toHaveLength(0)
+    expect(snap.agents.map((a) => a.agentId)).toEqual([AGENT_2])
+  })
+
   // The resolver already dropped what nothing serves; a null daemon here is a PENDING pool
   // agent, carried without a daemon so a wake gets the retryable `not_ready` (#987).
   it('carries a pending (daemon-less) directory row without a daemonId', () => {

--- a/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
@@ -173,10 +173,8 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
     expect(snap.agents.find((a) => a.agentId === AGENT_1)?.displayName).toBe('Deploy Bot')
   })
 
-  // A `set` (pool) agent's `Agent.daemonId` is null BY DESIGN — its holder lives in the duty
-  // ledger, which is what the resolved directory carries. Reading the placement column instead
-  // dropped such an agent from its OWN channels while agents[] listed it, and the daemon's
-  // `coordsDecision` then refused every peer wake it made from that channel as a non-member.
+  // A `set` (pool) agent's `Agent.daemonId` is null by design; only the resolved directory names
+  // its holder (agent-collaboration-implementation.md §"Collaboration-routing snapshot").
   it('places a pool agent in its channels from the resolved directory, not the null placement column', () => {
     const snap = buildCollabSnapshot(
       DEFAULT_ORG_ID,

--- a/packages/control-plane/src/orchestrator/collabSnapshot.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.ts
@@ -1,12 +1,14 @@
 /**
  * `buildCollabSnapshot` — assemble the bot-AGNOSTIC collaboration routing snapshot
  * (agent-collaboration §2.3/§6.2) from an org's channel placements. Groups the flat
- * placement records into per-channel `CollabChannelRoute`s, dropping unplaced agents
- * (no daemonId ⇒ not routable), plus the FLAT org-scoped `agents[]` directory built
- * from the RESOLVED `orgAgents` (`PlacementResolver.resolveDirectory`) — the only
- * carrier for an agent that has no IM integration and so appears in no channel at all,
- * and the only list that may carry a PENDING (daemon-less) entry. Bodiless
- * routing/policy metadata only.
+ * placement records into per-channel `CollabChannelRoute`s, dropping the agents nothing
+ * serves, plus the FLAT org-scoped `agents[]` directory built from the RESOLVED
+ * `orgAgents` (`PlacementResolver.resolveDirectory`) — the only carrier for an agent that
+ * has no IM integration and so appears in no channel at all, and the only list that may
+ * carry a PENDING (daemon-less) entry. Bodiless routing/policy metadata only.
+ *
+ * ONE resolution, both halves: "who serves this agent right now" comes from the resolved
+ * `orgAgents` and the channel half reads that answer instead of re-deriving it.
  *
  * The SAME snapshot is shipped to the relay (`rc/collab-routes`, full org) and to a
  * daemon (`register/ok.collabRoutes` / `collaboration/routes` EVT). The daemon copy is
@@ -31,6 +33,18 @@ export function buildCollabSnapshot(
   generation: number,
   orgAgents: OrgAgentRecord[]
 ): CollabRoutesSnapshot {
+  // Who serves this placement's agent: the resolved directory's answer, never the column re-read.
+  // `ChannelPlacementRecord.daemonId` is `Agent.daemonId`, null for a `set` agent BY DESIGN — a
+  // pool agent names no machine and its holder lives in the duty ledger. Reading it here dropped
+  // every pool agent from its OWN channels while the resolver-backed `agents[]` listed it, and
+  // `coordsDecision` reads the channel half — so the agent was refused as a non-member of a
+  // channel it is in and its peer wakes came back `not_allowed` whatever its call policy said.
+  // A row the directory does not cover keeps its column: same placed-agent population, so that is
+  // only a caller passing no directory, which then gets exactly the pre-resolver behavior.
+  const servingByAgent = new Map<string, string | null>(orgAgents.map((a) => [a.agentId, a.daemonId]))
+  const servingDaemonOf = (p: ChannelPlacementRecord): string | null =>
+    servingByAgent.has(p.agentId) ? (servingByAgent.get(p.agentId) ?? null) : p.daemonId
+
   // Sharing is an observed property of ONE conversation, not the bot's `shareable`
   // capacity setting. A bot may be shareable while only one agent is present here;
   // conversely duplicate legacy bot rows may expose the same member id. Count the
@@ -38,7 +52,7 @@ export function buildCollabSnapshot(
   // truthful compatibility flag.
   const agentsByMentionIdentity = new Map<string, Set<string>>()
   for (const p of placements) {
-    if (!p.daemonId || !p.botUserId) continue
+    if (!servingDaemonOf(p) || !p.botUserId) continue
     const key = `${p.platform}\u0000${p.channelId}\u0000${p.botUserId}`
     const agents = agentsByMentionIdentity.get(key) ?? new Set<string>()
     agents.add(p.agentId)
@@ -48,7 +62,9 @@ export function buildCollabSnapshot(
   // (platform, channelId) → CollabChannelRoute
   const byChannel = new Map<string, CollabChannelRoute>()
   for (const p of placements) {
-    if (!p.daemonId) continue // unplaced agent — not routable
+    // Nothing serves it (unplaced, or an unconfirmed pool grant) — channels[] holds no pending row.
+    const daemonId = servingDaemonOf(p)
+    if (!daemonId) continue
     const key = `${p.platform} ${p.channelId}`
     let route = byChannel.get(key)
     if (!route) {
@@ -57,7 +73,7 @@ export function buildCollabSnapshot(
     }
     route.agents.push({
       agentId: p.agentId,
-      daemonId: p.daemonId,
+      daemonId,
       integrationId: p.integrationId,
       ...(p.botAppId !== undefined ? { botAppId: p.botAppId } : {}),
       // §8.5 mention-address inputs. Channel-keyed on purpose: an address is only

--- a/packages/control-plane/src/orchestrator/collabSnapshot.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.ts
@@ -33,14 +33,9 @@ export function buildCollabSnapshot(
   generation: number,
   orgAgents: OrgAgentRecord[]
 ): CollabRoutesSnapshot {
-  // Who serves this placement's agent: the resolved directory's answer, never the column re-read.
-  // `ChannelPlacementRecord.daemonId` is `Agent.daemonId`, null for a `set` agent BY DESIGN — a
-  // pool agent names no machine and its holder lives in the duty ledger. Reading it here dropped
-  // every pool agent from its OWN channels while the resolver-backed `agents[]` listed it, and
-  // `coordsDecision` reads the channel half — so the agent was refused as a non-member of a
-  // channel it is in and its peer wakes came back `not_allowed` whatever its call policy said.
-  // A row the directory does not cover keeps its column: same placed-agent population, so that is
-  // only a caller passing no directory, which then gets exactly the pre-resolver behavior.
+  // Who serves this agent: the resolved directory's answer, never `Agent.daemonId` re-read — that
+  // column is null for a `set` agent by design (agent-collaboration-implementation.md §snapshot).
+  // A row the directory does not cover keeps its column, i.e. a caller passing no directory.
   const servingByAgent = new Map<string, string | null>(orgAgents.map((a) => [a.agentId, a.daemonId]))
   const servingDaemonOf = (p: ChannelPlacementRecord): string | null =>
     servingByAgent.has(p.agentId) ? (servingByAgent.get(p.agentId) ?? null) : p.daemonId

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3572,8 +3572,9 @@ export interface ChannelPlacementRecord {
   platform: Platform
   channelId: string
   agentId: AgentId
-  /** Owning daemon (may be null if the agent is not yet placed — such rows are
-   *  dropped from the routable snapshot). */
+  /** `Agent.daemonId` verbatim — a MACHINE placement, null for a `set` (pool) one, which names
+   *  a member set instead. Not the routing answer: `buildCollabSnapshot` takes that from the
+   *  resolved directory, because only the duty ledger knows which member holds a pool agent. */
   daemonId: string | null
   integrationId: IntegrationId
   /** Public platform app identity used to recognize messages from another

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -92,21 +92,25 @@ export async function seedAgent(
 }
 
 /** A held duty group covering `agentIds`. The lease is live by default — an
- *  expired one is how a test states "this member no longer serves it". */
+ *  expired one is how a test states "this member no longer serves it".
+ *  `confirmed` is the hold the member reported in its digest: unconfirmed (the default) is a
+ *  lease, not a route, so only a confirmed one makes the agent addressable. */
 export async function seedDutyGroup(
   prisma: PrismaClient,
   groupId: string,
   holder: string,
   agentIds: string[],
-  opts: { expiresAt?: Date; term?: bigint; orgId?: string } = {}
+  opts: { expiresAt?: Date; term?: bigint; orgId?: string; confirmed?: boolean } = {}
 ): Promise<void> {
   const orgId = opts.orgId ?? DEFAULT_ORG_ID
+  const term = opts.term ?? 1n
   await prisma.dutyGroup.create({
     data: {
       id: groupId,
       orgId,
       holder,
-      term: opts.term ?? 1n,
+      term,
+      ...(opts.confirmed ? { confirmedTerm: term, confirmedHolder: holder } : {}),
       expiresAt: opts.expiresAt ?? new Date(Date.now() + 120_000)
     }
   })

--- a/packages/control-plane/test/integration/collab-routes-pool-placement.test.ts
+++ b/packages/control-plane/test/integration/collab-routes-pool-placement.test.ts
@@ -1,20 +1,16 @@
 /**
  * The collaboration snapshot for a POOL agent — `channels[]` against the real query.
  *
- * `channelPlacements` carries `Agent.daemonId`, which a `set` placement leaves null, and the
- * snapshot builder used to read routability off that column. So a pool agent vanished from its own
- * channels while the resolver-backed `agents[]` listed it: `admits()` said yes, `coordsDecision`
- * said the caller is not in the channel, and every peer wake it made from an IM channel came back
- * `not_allowed` whatever its call policy said. Both halves now read one resolved answer.
- *
- * Unit coverage pins the builder (`orchestrator/collabSnapshot.test.ts`); this pins the seam that
- * actually broke — the real placement query plus the duty ledger behind it.
+ * Why both halves must resolve placement through one answer, and what a pool agent's missing
+ * channel row did to its wakes: agent-collaboration-implementation.md §"Collaboration-routing
+ * snapshot". Unit coverage pins the builder (`orchestrator/collabSnapshot.test.ts`); this pins the
+ * seam that actually broke — the real placement query plus the duty ledger behind it.
  */
 import { describe, expect, it } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon } from '../fixtures/seed.js'
-import { joinPool, poolSetId } from '../fakes/member-set.js'
+import { seedDutyGroup } from '../fixtures/seed.js'
+import { poolSetId, seedPoolMember } from '../fakes/member-set.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { PgIntegrationRepo } from '../../src/persistence/repositories/integration.repo.js'
 import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
@@ -28,30 +24,6 @@ const HOLDER = 'c1c1c1c1-cccc-4ccc-8ccc-cccccccccc01'
 const CHANNEL = 'C0POOLAGENT'
 
 const placement = () => new PlacementResolver({ duties: new PgDutyGroupRepo(prisma), clock: systemClock })
-
-/** An install-wide pool member: an org-less daemon row enrolled in the org-less set. */
-async function poolMember(daemonId: string): Promise<void> {
-  await seedDaemon(prisma, daemonId)
-  await prisma.daemon.update({ where: { id: daemonId }, data: { orgId: null } })
-  await joinPool(prisma, daemonId)
-}
-
-/** A live duty lease. CONFIRMED (reported in the member's digest) is what makes it routable; an
- *  unconfirmed grant is a lease, not a route — the PENDING state below. */
-async function grantDuty(holder: string, agentId: string, confirmed = true): Promise<void> {
-  const groupId = randomUUID()
-  await prisma.dutyGroup.create({
-    data: {
-      id: groupId,
-      orgId: DEFAULT_ORG_ID,
-      holder,
-      term: 1n,
-      ...(confirmed ? { confirmedTerm: 1n, confirmedHolder: holder } : {}),
-      expiresAt: new Date(Date.now() + 600_000)
-    }
-  })
-  await prisma.dutyGroupMember.create({ data: { kind: 'agent', refId: agentId, groupId, orgId: DEFAULT_ORG_ID } })
-}
 
 /** A pool-placed active agent reachable in one Slack channel — `daemonId` null by placement. */
 async function pooledSlackAgent(): Promise<string> {
@@ -104,14 +76,13 @@ async function snapshot(): Promise<ReturnType<typeof buildCollabSnapshot>> {
 
 describe('collaboration snapshot: pool placement', () => {
   it('lists a pool agent in its channel, named at the member that holds it', async () => {
-    await poolMember(HOLDER)
+    await seedPoolMember(prisma, HOLDER)
     const agentId = await pooledSlackAgent()
-    await grantDuty(HOLDER, agentId)
+    await seedDutyGroup(prisma, randomUUID(), HOLDER, [agentId], { confirmed: true })
 
     const snap = await snapshot()
     const channel = snap.channels.find((c) => c.channelId === CHANNEL)
-    // The membership the daemon's `coordsDecision` reads: absent here, the agent's own wakes
-    // from this channel are refused as a non-member's.
+    // The membership the daemon's `coordsDecision` reads — absent here, its own wakes are refused.
     expect(channel?.agents.map((a) => a.agentId)).toEqual([agentId])
     expect(channel?.agents[0]).toMatchObject({ daemonId: HOLDER })
     // And the two halves agree about who serves it.
@@ -119,11 +90,10 @@ describe('collaboration snapshot: pool placement', () => {
   })
 
   it('keeps a PENDING pool agent out of channels[] while the flat directory carries it', async () => {
-    await poolMember(HOLDER)
+    await seedPoolMember(prisma, HOLDER)
     const agentId = await pooledSlackAgent()
-    // Granted but not yet confirmed: the member has to receive its bundle before it serves, so
-    // naming it in a channel would address a wake at a daemon that refuses it.
-    await grantDuty(HOLDER, agentId, false)
+    // Granted, not yet confirmed: a lease is not a route until the member reports the hold.
+    await seedDutyGroup(prisma, randomUUID(), HOLDER, [agentId])
 
     const snap = await snapshot()
     expect(snap.channels.find((c) => c.channelId === CHANNEL)).toBeUndefined()

--- a/packages/control-plane/test/integration/collab-routes-pool-placement.test.ts
+++ b/packages/control-plane/test/integration/collab-routes-pool-placement.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The collaboration snapshot for a POOL agent — `channels[]` against the real query.
+ *
+ * `channelPlacements` carries `Agent.daemonId`, which a `set` placement leaves null, and the
+ * snapshot builder used to read routability off that column. So a pool agent vanished from its own
+ * channels while the resolver-backed `agents[]` listed it: `admits()` said yes, `coordsDecision`
+ * said the caller is not in the channel, and every peer wake it made from an IM channel came back
+ * `not_allowed` whatever its call policy said. Both halves now read one resolved answer.
+ *
+ * Unit coverage pins the builder (`orchestrator/collabSnapshot.test.ts`); this pins the seam that
+ * actually broke — the real placement query plus the duty ledger behind it.
+ */
+import { describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { seedDaemon } from '../fixtures/seed.js'
+import { joinPool, poolSetId } from '../fakes/member-set.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgIntegrationRepo } from '../../src/persistence/repositories/integration.repo.js'
+import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
+import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
+import { buildCollabSnapshot } from '../../src/orchestrator/collabSnapshot.js'
+import { OrgId } from '../../src/domain/ids.js'
+import { systemClock } from '../../src/domain/clock.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const HOLDER = 'c1c1c1c1-cccc-4ccc-8ccc-cccccccccc01'
+const CHANNEL = 'C0POOLAGENT'
+
+const placement = () => new PlacementResolver({ duties: new PgDutyGroupRepo(prisma), clock: systemClock })
+
+/** An install-wide pool member: an org-less daemon row enrolled in the org-less set. */
+async function poolMember(daemonId: string): Promise<void> {
+  await seedDaemon(prisma, daemonId)
+  await prisma.daemon.update({ where: { id: daemonId }, data: { orgId: null } })
+  await joinPool(prisma, daemonId)
+}
+
+/** A live duty lease. CONFIRMED (reported in the member's digest) is what makes it routable; an
+ *  unconfirmed grant is a lease, not a route — the PENDING state below. */
+async function grantDuty(holder: string, agentId: string, confirmed = true): Promise<void> {
+  const groupId = randomUUID()
+  await prisma.dutyGroup.create({
+    data: {
+      id: groupId,
+      orgId: DEFAULT_ORG_ID,
+      holder,
+      term: 1n,
+      ...(confirmed ? { confirmedTerm: 1n, confirmedHolder: holder } : {}),
+      expiresAt: new Date(Date.now() + 600_000)
+    }
+  })
+  await prisma.dutyGroupMember.create({ data: { kind: 'agent', refId: agentId, groupId, orgId: DEFAULT_ORG_ID } })
+}
+
+/** A pool-placed active agent reachable in one Slack channel — `daemonId` null by placement. */
+async function pooledSlackAgent(): Promise<string> {
+  const agentId = randomUUID()
+  await prisma.agent.create({
+    data: {
+      id: agentId,
+      orgId: DEFAULT_ORG_ID,
+      name: `pooled-${agentId.slice(0, 8)}`,
+      runtime: 'claude',
+      status: 'active',
+      placementKind: 'set',
+      setId: await poolSetId(prisma)
+    }
+  })
+  const botId = randomUUID()
+  const integrationId = randomUUID()
+  await prisma.bot.create({
+    data: { id: botId, orgId: DEFAULT_ORG_ID, platform: 'slack', name: 'pool-bot', botUserId: 'U0POOLBOT' }
+  })
+  await prisma.integration.create({
+    data: {
+      id: integrationId,
+      orgId: DEFAULT_ORG_ID,
+      agentId,
+      botId,
+      platform: 'slack',
+      name: 'pool-bot',
+      status: 'active'
+    }
+  })
+  await prisma.integrationChannel.create({
+    data: { integrationId, channelId: CHANNEL, name: 'ai-playground' }
+  })
+  return agentId
+}
+
+/** The snapshot exactly as both producers build it: the raw placements plus the resolved directory. */
+async function snapshot(): Promise<ReturnType<typeof buildCollabSnapshot>> {
+  const orgId = OrgId(DEFAULT_ORG_ID)
+  const integrations = new PgIntegrationRepo(prisma)
+  const agents = new PgAgentRepo(prisma)
+  return buildCollabSnapshot(
+    orgId,
+    await integrations.channelPlacements(orgId),
+    1,
+    await placement().resolveDirectory(await agents.orgDirectory(orgId))
+  )
+}
+
+describe('collaboration snapshot: pool placement', () => {
+  it('lists a pool agent in its channel, named at the member that holds it', async () => {
+    await poolMember(HOLDER)
+    const agentId = await pooledSlackAgent()
+    await grantDuty(HOLDER, agentId)
+
+    const snap = await snapshot()
+    const channel = snap.channels.find((c) => c.channelId === CHANNEL)
+    // The membership the daemon's `coordsDecision` reads: absent here, the agent's own wakes
+    // from this channel are refused as a non-member's.
+    expect(channel?.agents.map((a) => a.agentId)).toEqual([agentId])
+    expect(channel?.agents[0]).toMatchObject({ daemonId: HOLDER })
+    // And the two halves agree about who serves it.
+    expect(snap.agents.find((a) => a.agentId === agentId)).toMatchObject({ daemonId: HOLDER })
+  })
+
+  it('keeps a PENDING pool agent out of channels[] while the flat directory carries it', async () => {
+    await poolMember(HOLDER)
+    const agentId = await pooledSlackAgent()
+    // Granted but not yet confirmed: the member has to receive its bundle before it serves, so
+    // naming it in a channel would address a wake at a daemon that refuses it.
+    await grantDuty(HOLDER, agentId, false)
+
+    const snap = await snapshot()
+    expect(snap.channels.find((c) => c.channelId === CHANNEL)).toBeUndefined()
+    // channels[] carries no daemon-less entry, so the retryable `not_ready` comes from here.
+    const pending = snap.agents.find((a) => a.agentId === agentId)
+    expect(pending).toBeDefined()
+    expect(pending).not.toHaveProperty('daemonId')
+  })
+})


### PR DESCRIPTION
## The bug

A **pool-placed** (`placementKind: 'set'`) agent cannot wake a peer from any IM channel. Every visible signal says it should work:

- `listAgents` returns the peer — that reads the CP's live DB, not the snapshot.
- `CpCollabRoutes.admits(caller, target)` allows the call — that reads the snapshot's **flat** half.
- The wake still comes back `not_allowed`, with both sides on `callPolicy: 'all'` / `outboundPolicy: 'all'`.

Found on `test-app` (a `--k8s` pool deployment): agent `cloud-test-2` in Slack `#ai-playground`, both policies `all`, target fully open, retried after a pool rollout. `integration_channel` has both agents in the channel. Still refused.

## Why

The collaboration snapshot has two halves and only one of them resolved placement.

| half | source | a pool agent |
| --- | --- | --- |
| `agents[]` | `PlacementResolver.resolveDirectory(orgDirectory)` | present, named at its duty holder |
| `channels[]` | `channelPlacements()` → `daemonId: agent.daemonId` (raw column) | **dropped** |

`Agent.daemonId` is NULL for a `set` placement **by design** — a pool agent names no machine, its holder lives in the duty ledger. `buildCollabSnapshot` treated that null as "unplaced ⇒ not routable" (a rule written before pool placement existed) and dropped the row. So a pool agent vanished from its own channels while the flat directory listed it, and the two halves disagreed about who serves one agent.

The daemon's `coordsDecision` reads the channel half:

```ts
for (const members of sharing ?? []) {
  if (members.size === 0) continue
  known = true
  if (members.has(callerAgentId)) return { verdict: 'asserted' }
}
if (known) return { verdict: 'reject' }
```

`#ai-playground` is KNOWN — its machine-placed members are in the snapshot — and the caller is not among them, so a known coordinate the caller is not a member of is a reject. That lands in `localWakeDecision` as `not_allowed`, one guard past the policy checks it looks like it came from.

## The fix

Both halves now read **one** resolved answer, so they cannot disagree. The channel entry takes its `daemonId` from the resolved directory and keeps the row's own column only where the directory does not cover it (a caller passing no directory — exactly the pre-resolver behavior).

Preserved deliberately:

- what nothing serves is still dropped;
- a **PENDING** pool agent (granted, not yet confirmed) still stays out of `channels[]`, which carries no daemon-less entry, rather than being addressed at a member that would refuse it.

  **Correction** (thanks @agentconnect-md-test — [thread](https://github.com/agentconnect-md/agentconnect/pull/1296#discussion_r3818546790)): that only buys the retryable `not_ready` when the pending agent is the **target**, which is where the relay resolves from `agents[]`. As the **caller** it is still refused terminally: its own daemon runs `coordsDecision` first (`coordinator.ts:290`), finds it absent from `channels[]` in a channel that is `known` from its other members, and returns `not_allowed` before any cross-daemon route is attempted. So this PR narrows the reported symptom from *permanent* to *one grant-plus-install beat*, and does not eliminate it. Closing that window cheaply — a `not_ready`-shaped rejection when `cpCollab.agent(caller)?.daemonId` is absent, ahead of the coords check, no wire change — belongs with the diagnosability work below, not here.

Fixing it inside `buildCollabSnapshot` covers **both** producers: the `collaboration/routes` hot push (`CollabRoutesService.build`) and the `register/ok` reconnect baseline (`placement.ts`) already pass the resolved directory alongside the raw placements.

## Notes for review

- **Relay:** it resolves wake targets from `agents[]` (channel rows are only the old-CP fallback), so this changes no target resolution — it corrects the channel-**membership** view its own `coordsDecision` twin applies.
- **Mention addressing:** the same drop hid pool agents from `mentionDirectory`/`mentionAddress` and from the `botShared` derivation. Both are channel-keyed off these rows, so they are fixed by the same change; the unit test asserts the `botShared` half.
- **Scope:** the deeper question — whether channel MEMBERSHIP should depend on routability at all, given it is a fact about integrations — is left alone. Answering it means changing the wire type (`CollabAgentPlacement.daemonId` is required) and the relay; this keeps the contract and makes the two halves agree.
- A second, independent gap this incident surfaced is **not** in this PR: `localWakeDecision`'s four `not_allowed` branches are indistinguishable, `McpControlServer` logs nothing, and `sendMessage` hands the model a bare `reason` with no `message`. Diagnosing this required reading the database; the model meanwhile invented "try another channel", which can never work since the policy check is channel-free. Filed separately.

## Verification

- `collabSnapshot.test.ts` — new: a pool agent appears in its channel named at its holder (incl. `botShared`); a PENDING one stays out. **Verified to fail without the fix.**
- `test/integration/collab-routes-pool-placement.test.ts` — new: the same two cases through the REAL `channelPlacements` query + `PgDutyGroupRepo` + resolver, which is the seam that actually broke. The first case is **verified to fail without the fix**.
- Full CP suite green: unit 161 files / 1794 tests; integration 99 files / 1473 tests (real Postgres). `typecheck`, `lint`, `format:check` clean.
- Not verified in-cluster: the deployment fix has not been rolled out yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
