### PR TITLE
feat(dream): write the proposal through the shared memory tools

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -258,8 +258,11 @@ interface DreamRecord {
    human reviews is byte-for-byte the one adoption installs. Parse the returned
    JSON (§5) for the review queue only — skills and organization suggestions,
    validated per §7 — and stage candidates to
-   `memory-dreams/<dreamId>/skills/<name>/`. A parse failure ⇒ `failed`, and the
-   staging of a run that never completes is dropped.
+   `memory-dreams/<dreamId>/skills/<name>/`. A parse failure ⇒ `failed`, and so
+   does a run that wrote no topic file while the live store had some: the store
+   is what the model wrote, so writing nothing is no proposal at all, not an
+   empty one — completing it would let adoption install an index-only store over
+   a live one. The staging of a run that never completes is dropped.
 5. **Finish.** Mark `completed`; emit `memory.dream.completed` on the
    evaluation-events channel (alongside the existing `memory.capture.*`
    events). If `autoAdopt` is set, run §6 adoption for the store — never for

--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -79,11 +79,12 @@ inputs        │  snapshot of <agent-root>/memory/   (read-only)        │
               │            │                                           │
               │            ▼                                           │
 executor      │  isolated ACP session on the agent's runtime           │
-              │  (dream pipeline prompt; model returns proposals as    │
-              │   validated JSON — the model never writes files)       │
+              │  (dream pipeline prompt; the model WRITES the rebuilt  │
+              │   store through the memory tools, bound to the staged  │
+              │   store, and returns review proposals as JSON)         │
               │            │                                           │
               │            ▼                                           │
-outputs       │  memory-dreams/<dreamId>/output/    (staged store)     │
+outputs       │  memory-dreams/<dreamId>/memory/    (staged store)     │
               │  memory-dreams/<dreamId>/skills/    (staged skills §7) │
               └────────────┬───────────────────────────────────────────┘
                            ▼
@@ -99,11 +100,12 @@ Three invariants:
    timestamped backup and moves the staged tree into place, appending a
    `dream-adopt` event to `.history`. The backup is retained until the next
    successful adoption.
-3. **The model proposes; the daemon disposes.** The runtime returns the
-   proposed store as structured JSON. The daemon validates every entry (topic
-   filename regex, per-file and index size caps, no dotfiles, no path
-   traversal) and performs all filesystem writes itself. `.history` is never
-   part of the proposal — it is carried over verbatim and appended to.
+3. **The model proposes; the daemon disposes.** The model's writes reach disk
+   only through the daemon's own memory tools, bound to the staged store: the
+   same path validation, topic-name rule, and byte caps a turn gets, plus the
+   dream's own bounded file count. The daemon still performs every filesystem
+   write itself and generates the index. `.history` is never part of the
+   proposal — it is carried over verbatim and appended to.
 
 Invariant 3 bounds only what the dream _output_ can do: a bad proposal can
 change only the managed-memory store, and only after staging and validation.
@@ -111,7 +113,7 @@ Auto-accept deliberately skips a human content-quality check, as its console
 warning makes clear. The invariant says nothing about what the _extraction run
 itself_ can do — the mined transcript is attacker-controlled, so
 a prompt injection could drive the runtime's native shell/file/network tools
-before the model ever emits JSON, and staged-output review cannot undo those
+during the run, and staged-output review cannot undo those
 side effects. The executor therefore separates two independent gates:
 
 - **Side effects during the run — HARD gate (fail closed).** The extraction
@@ -246,14 +248,18 @@ interface DreamRecord {
    permission mode when the runtime offers one, dream system prompt (§5),
    snapshot + transcripts as untrusted prompt data. Collect the streamed text
    exactly as distillation does.
-4. **Validate & stage.** Parse the returned JSON
-   (`{"files":[...], "index":"...", "skills":[...]}`, §5) with the distiller's
-   hardening style: topic regex `^[a-z0-9][a-z0-9-]{0,62}\.md$`, per-file
-   clamp, index clamp to the 25 KB injection cap, bounded file count; skill
-   entries validated per §7. Write the store proposal to
-   `memory-dreams/<dreamId>/output/` and skill candidates to
-   `memory-dreams/<dreamId>/skills/<name>/`. A parse/validation failure ⇒
-   `failed`, with the partial staging left in place for inspection.
+4. **Validate & stage.** The store proposal is already on disk: the extraction
+   session's `writeMemory`/`readMemory` are bound to `memory-dreams/<dreamId>/`
+   as their store, so every topic file went through the same write path a turn
+   uses (header normalize + stamp, byte cap, `.history`) — the binding also
+   carries the two limits the old JSON format enforced, the topic regex
+   `^[a-z0-9][a-z0-9-]{0,62}\.md$` and the bounded file count. Staging then
+   generates the index from those files' `description` headers, so the index a
+   human reviews is byte-for-byte the one adoption installs. Parse the returned
+   JSON (§5) for the review queue only — skills and organization suggestions,
+   validated per §7 — and stage candidates to
+   `memory-dreams/<dreamId>/skills/<name>/`. A parse failure ⇒ `failed`, and the
+   staging of a run that never completes is dropped.
 5. **Finish.** Mark `completed`; emit `memory.dream.completed` on the
    evaluation-events channel (alongside the existing `memory.capture.*`
    events). If `autoAdopt` is set, run §6 adoption for the store — never for
@@ -273,24 +279,28 @@ with the same injection posture and a five-phase pipeline:
   transcripts for corrections, preference shifts, decisions, and recurring
   patterns → **consolidate**: merge duplicates, keep the _latest_ value where
   entries contradict, convert relative dates to absolute, drop transient task
-  progress and secrets → **prune & index**: rebuild the index with one line
-  per topic, under the injection cap, demoting verbose entries into topic
-  files → (when skill mining is enabled) **extract procedures**: identify
+  progress and secrets → **prune**: give every topic a strong `description`
+  header (the index is generated from those), demoting verbose entries into
+  topic files → (when skill mining is enabled) **extract procedures**: identify
   workflows the agent performed repeatedly or re-derived across sessions and
   express each as a candidate skill (§7) — only procedures grounded in at
   least two distinct sessions, never one-off task steps.
 - Unlike distillation, rewriting and deleting are **allowed** — that is the
-  point — but only inside the returned proposal.
+  point — but only inside the staged store, never in the live one.
 - Existing topic boundaries, filenames, and byte-identical content are
   preserved by default. Small wording, formatting, ordering, or consistency
   edits do not justify renaming a topic. A rename, merge, or split is proposed
   only when a material content change makes the existing structure misleading;
   equally faithful proposals prefer the smallest diff.
-- Output is JSON only:
-  `{"files":[{"path":"topic.md","content":"..."}], "index":"...",
-"skills":[{"name":"...","description":"...","skill":"<SKILL.md body>",
-"scripts":[{"path":"...","content":"..."}]}]}` — `skills` present only when
-  mining is enabled.
+- The rebuilt store is WRITTEN, not returned: one `writeMemory` call per topic
+  file, into a staging area that starts empty and replaces the live store on
+  adoption — so a file the model does not write is how it prunes, and an
+  unchanged file is copied byte-for-byte. `MEMORY.md` is generated, never
+  written by the model.
+- The JSON reply carries only the review queue:
+  `{"agentSkills":[{"name":"...","description":"...","skill":"<SKILL.md body>",
+"scripts":[{"path":"...","content":"..."}]}],"organizationKnowledge":[],
+"organizationSkills":[]}` — skills present only when mining is enabled.
 - The operator's `instructions` string is appended to the system prompt (it is
   operator-, not model- or user-supplied — same trust class as the rest of the
   prompt).
@@ -316,7 +326,7 @@ warns that this skips content review.
    changed while the dream ran — rerun or force). This mirrors the `ifMatch`
    optimistic-concurrency style of `writeMemoryFile`.
 3. Atomically: rename `memory/` → `memory-backups/<ts>-pre-<dreamId>/`; move
-   staged `output/` into place as `memory/`; carry `.history` over and append
+   the staged store into place as `memory/`; carry `.history` over and append
    one `dream-adopt` line (`source: 'dream'`, dreamId, backup path).
 4. Mark the record `adopted`. Every other `completed` store proposal for the
    agent is no longer based on the live store, so remove its store staging and

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -77,6 +77,7 @@ import { buildMcpServers, buildSandboxMcpServers, type McpStdioServer } from './
 import { resolveAgentMcpServers, RESERVED_MCP_SERVER_NAME } from './mcp/resolve-servers.js'
 import { toolsForIntegrations, GITHUB_REVIEW_TOOLS, KNOWLEDGE_TOOLS } from './mcp/tools.js'
 import { MEMORY_TOOL_NAMES, MEMORY_TOOLS } from './memory/tools.js'
+import { DREAM_TOPIC_RE, MAX_DREAM_FILES } from './dream/dreamer.js'
 import { isSessionTitleToolCall } from './mcp/session-title-tool.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT, readOnlyExtractionMode } from './memory/distill.js'
 import {
@@ -479,6 +480,16 @@ export type {
   DaemonEvaluationTurnInput,
   DaemonEvaluationTurnResult
 } from './daemon/evaluation-types.js'
+
+/** What the dream runner hands the extraction: where its inputs are materialized and
+ *  which staged store its memory tools write into. */
+type DreamExtractionContext = {
+  dreamId: string
+  trigger: 'manual' | 'schedule' | 'auto'
+  sessionIds: string[]
+  inputDir: string
+  stagedStore: MemoryFs
+}
 
 /** Identity of a desired Feishu connection: appId + gateway region + ingress mode — a region or mode change on the same appId yields a distinct connection for reuse-matching, mapping-eviction, and the in-flight guard. */
 /** The session-control selectors driven by `/models` `/effort` `/permission` + their tappable cards — single-char codes keep the inline-button `callback_data` (≤64 bytes) compact as `<code>:<optionIndex>`. */
@@ -3956,7 +3967,7 @@ export class Daemon {
     systemPrompt: string,
     prompt: string,
     signal: AbortSignal,
-    context: { dreamId: string; trigger: 'manual' | 'schedule' | 'auto'; sessionIds: string[]; inputDir: string }
+    context: DreamExtractionContext
   ): Promise<{
     output: string
     sessionId: string
@@ -4093,7 +4104,7 @@ export class Daemon {
     systemPrompt: string,
     prompt: string,
     signal: AbortSignal,
-    context: { dreamId: string; trigger: 'manual' | 'schedule' | 'auto'; sessionIds: string[]; inputDir: string },
+    context: DreamExtractionContext,
     // Written back once the ACP session exists so the caller's teardown can
     // reclaim this session's quarantine tombstone after the host is stopped.
     ref: { sessionId?: string }
@@ -4125,13 +4136,22 @@ export class Daemon {
     // prompt. Read-only, org-scoped from the trusted agentId in this context.
     // The token is unregistered in finally so a leaked token cannot outlive the
     // one-off dream host.
+    // The dream writes its proposal through the SAME memory tools an agent uses,
+    // bound to the dream's staged store rather than the live one (#41). The two
+    // constraints its old JSON format enforced ride along on the binding.
     const mcpToken = this.mcp.register({
       agentId,
       platform: 'dream',
       isDm: false,
       channel: 'memory',
       thread: context.dreamId,
-      tools: KNOWLEDGE_TOOLS
+      tools: [...KNOWLEDGE_TOOLS, ...MEMORY_TOOLS],
+      memoryBinding: {
+        source: 'dream',
+        scope: { agentId, root: context.stagedStore },
+        topicPattern: DREAM_TOPIC_RE,
+        maxTopics: MAX_DREAM_FILES
+      }
     })
     const mcpServers = this.mcpToolServerSpec(mcpToken)
     try {
@@ -4163,7 +4183,7 @@ export class Daemon {
     sessionId: string,
     prompt: string,
     signal: AbortSignal,
-    context: { dreamId: string; trigger: 'manual' | 'schedule' | 'auto'; sessionIds: string[]; inputDir: string },
+    context: DreamExtractionContext,
     systemPrompt: string,
     trusted: boolean
   ): Promise<{

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4133,7 +4133,7 @@ export class Daemon {
     // Give the dream on-demand tools to browse existing org knowledge/skills
     // (findKnowledge / listKnowledge / listOrgSkills) so it can choose update
     // over duplicate-create — instead of pre-stuffing that context into the
-    // prompt. Read-only, org-scoped from the trusted agentId in this context.
+    // prompt. Those reads are org-scoped from the trusted agentId in this context.
     // The token is unregistered in finally so a leaked token cannot outlive the
     // one-off dream host.
     // The dream writes its proposal through the SAME memory tools an agent uses,

--- a/packages/daemon/src/dream/dreamer.ts
+++ b/packages/daemon/src/dream/dreamer.ts
@@ -100,9 +100,7 @@ export interface DreamExplorationPromptInput {
   dismissedSkills?: string[]
 }
 
-/** Same topic-name discipline as the distiller: lowercase kebab-case .md files. */
-/** The filename shape a dream's topics must take. Enforced on the memory-tool
- *  binding now that the proposal no longer carries file entries to validate. */
+/** Same topic discipline as the distiller, enforced on the dream's memory-tool binding. */
 export const DREAM_TOPIC_RE = /^[a-z0-9][a-z0-9-]{0,62}\.md$/
 
 /** Bounded proposal: a store rebuild, not a dump. */
@@ -158,7 +156,7 @@ Rules:
 ${MEMORY_FORMAT_GUIDANCE}
 
 - Never include credentials, tokens, or other secrets.
-- Return JSON only with four explicit categories:
+- Return JSON only with three explicit categories:
   {"agentSkills":[],"organizationKnowledge":[],"organizationSkills":[]}.
 - WRITE the rebuilt store with \`writeMemory\`, one call per topic file. Your JSON reply carries ONLY the review-queue proposals above — the memory itself is what you wrote.
 - Those writes land in an EMPTY staging area that REPLACES the live store if a human adopts it: write every file you are keeping, copying an unchanged one byte-for-byte from the snapshot. A file you never write is deleted — that is how you prune.

--- a/packages/daemon/src/dream/dreamer.ts
+++ b/packages/daemon/src/dream/dreamer.ts
@@ -2,7 +2,6 @@ import { createHash } from 'node:crypto'
 import { posix } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import { MAX_ORGANIZATION_SUGGESTION_BODY_BYTES, type SkillBundleTextFile } from '@agentconnect.md/protocol'
-import { MEMORY_INDEX, MAX_MEMORY_FILE_BYTES } from '../memory/store.js'
 import { MEMORY_FORMAT_GUIDANCE } from '../memory/frontmatter.js'
 
 /**
@@ -72,7 +71,6 @@ export interface TrustedOrganizationSkillTarget {
 }
 
 export interface DreamProposal {
-  files: DreamProposalFile[]
   /** Empty unless the agent enabled `mineSkills` AND the model proposed some. */
   skills: DreamProposalSkill[]
   organizationKnowledge: DreamOrganizationKnowledgeProposal[]
@@ -103,7 +101,9 @@ export interface DreamExplorationPromptInput {
 }
 
 /** Same topic-name discipline as the distiller: lowercase kebab-case .md files. */
-const TOPIC_RE = /^[a-z0-9][a-z0-9-]{0,62}\.md$/
+/** The filename shape a dream's topics must take. Enforced on the memory-tool
+ *  binding now that the proposal no longer carries file entries to validate. */
+export const DREAM_TOPIC_RE = /^[a-z0-9][a-z0-9-]{0,62}\.md$/
 
 /** Bounded proposal: a store rebuild, not a dump. */
 export const MAX_DREAM_FILES = 64
@@ -159,8 +159,12 @@ ${MEMORY_FORMAT_GUIDANCE}
 
 - Never include credentials, tokens, or other secrets.
 - Return JSON only with four explicit categories:
-  {"agentMemory":{"files":[{"path":"topic.md","content":"full file text"}]},"agentSkills":[],"organizationKnowledge":[],"organizationSkills":[]}.
+  {"agentSkills":[],"organizationKnowledge":[],"organizationSkills":[]}.
+- WRITE the rebuilt store with \`writeMemory\`, one call per topic file. Your JSON reply carries ONLY the review-queue proposals above — the memory itself is what you wrote.
+- Those writes land in an EMPTY staging area that REPLACES the live store if a human adopts it: write every file you are keeping, copying an unchanged one byte-for-byte from the snapshot. A file you never write is deleted — that is how you prune.
+- \`readMemory\` reads back what you have staged so far, never the live store. The existing store is the snapshot in your working directory; read it with your file tools.
 - Do NOT write MEMORY.md. The index is generated from your files' \`description\` headers, so a good description is what makes a memory findable — that is where the effort belongs.
+- Topic filenames must be lowercase kebab-case \`.md\`; a write that is not will be refused.
 - organizationKnowledge entries are owner-review proposals in exactly this shape: {"operation":"create|update","targetId":"uuid only for update","targetRevision":1,"title":"...","summary":"...","tags":["..."],"content":"Markdown","sessionIds":["..."]}. The citation property is named "sessionIds" (never "groundedSessionIds").
 - Propose organization knowledge only when it is reusable across multiple agents or represents a durable organization-wide convention. Agent-specific facts stay in agentMemory.
 - Before proposing organization knowledge, check what already exists with the listKnowledge / findKnowledge tools. If an existing entry covers the same subject, propose an "update" to its exact id/revision (never a near-duplicate "create").
@@ -310,48 +314,20 @@ function parseDreamJson(text: string): unknown | undefined {
 }
 
 /**
- * Parse and harden the model's proposal. Returns null when the text carries no
- * usable JSON proposal (the dream then fails; partial staging is never written
- * from an unparseable reply). Individual entries are dropped, not repaired:
- * bad topic names, oversized bodies, duplicate paths, and index entries are
- * filtered the same way the distiller filters memories.
+ * Parse and harden the model's review-queue proposals — skills and organization
+ * suggestions. Returns null when the text carries no usable JSON (the dream then
+ * fails and its staging is dropped). Ungrounded or malformed entries are dropped,
+ * never repaired. The memory store itself is not parsed from here: the model wrote
+ * it through the memory tools, which enforce naming and size on the way in.
  */
 export function parseDreamProposal(text: string, minedSessionIds: readonly string[] = []): DreamProposal | null {
   const value = parseDreamJson(text)
   if (value === undefined) return null
   const envelope = value as Record<string, unknown>
-  const memory =
-    envelope.agentMemory && typeof envelope.agentMemory === 'object'
-      ? (envelope.agentMemory as Record<string, unknown>)
-      : envelope
-  if (!Array.isArray(memory.files)) return null
-
-  const seen = new Set<string>([MEMORY_INDEX])
-  const files: DreamProposalFile[] = []
-  for (const row of memory.files) {
-    const file = row as DreamProposalFile
-    if (
-      typeof file?.path !== 'string' ||
-      typeof file?.content !== 'string' ||
-      !TOPIC_RE.test(file.path) ||
-      seen.has(file.path) ||
-      !file.content.trim()
-    ) {
-      continue
-    }
-    seen.add(file.path)
-    // Reserve one byte for the trailing newline so the final string is ≤ the
-    // writer's byte cap, and clamp on a code-point boundary so the cut never
-    // decodes to a replacement char that would push it back over the cap.
-    const content = clampToBytesOnBoundary(file.content.trim(), MAX_MEMORY_FILE_BYTES - 1) + '\n'
-    files.push({ path: file.path, content })
-    if (files.length >= MAX_DREAM_FILES) break
-  }
-
-  // No index is read from the model: staging generates MEMORY.md from these files'
-  // descriptions, exactly as adoption will, so what a reviewer sees is what installs.
+  // Neither files nor an index come back in JSON any more: the model writes its topic
+  // files into the staged store through the memory tools, and staging renders the
+  // index from them. The envelope now carries only the review-queue proposals.
   return {
-    files,
     skills: parseDreamSkills(envelope.agentSkills ?? envelope.skills, minedSessionIds),
     organizationKnowledge: parseOrganizationKnowledge(envelope.organizationKnowledge, minedSessionIds),
     organizationSkills: parseOrganizationSkills(envelope.organizationSkills, minedSessionIds)

--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -20,7 +20,7 @@ import {
   OrganizationSuggestionContentBody,
   organizationSuggestionCanonical
 } from '@agentconnect.md/protocol'
-import { memoryNameForTopic, normalizeMemoryHeader, parseMemoryFrontmatter } from '../memory/frontmatter.js'
+import { memoryNameForTopic, parseMemoryFrontmatter } from '../memory/frontmatter.js'
 import {
   MEMORY_INDEX,
   renderMemoryIndex,
@@ -195,7 +195,16 @@ export interface DreamRunnerDeps {
     systemPrompt: string,
     prompt: string,
     signal: AbortSignal,
-    context: { dreamId: string; trigger: DreamTrigger; sessionIds: string[]; inputDir: string }
+    context: {
+      dreamId: string
+      trigger: DreamTrigger
+      sessionIds: string[]
+      inputDir: string
+      /** The dream's STAGED memory store. The extraction session binds the shared
+       *  memory tools to it, so the model writes its proposal the same way an agent
+       *  writes memory — the daemon no longer transcribes files out of JSON. */
+      stagedStore: MemoryFs
+    }
   ): Promise<DreamExtractionResult>
   /** Metadata-only lifecycle tap. Observer failures are contained by the
    *  runner and can never change the job outcome. */
@@ -681,12 +690,29 @@ export class DreamRunner {
 
       // The dream's cwd is its input dir in the coordinates of the filesystem that holds it: this
       // disk for a local agent, the pod's volume for a cluster agent — where its host runs.
-      const extracted = await this.extractWithBackstop(dream, prompt, signal, join(fs.root, inputDir), mineSkills)
+      // The staged store must exist BEFORE extraction: the model writes into it
+      // through the memory tools rather than returning file contents to transcribe.
+      const stagedStore = fs.subdir(base)
+      await fs.rm(join(base, MEMORY_DIRNAME))
+      await fs.rm(join(base, LEGACY_STAGED_DIRNAME))
+      await fs.mkdir(join(base, MEMORY_DIRNAME))
+      const extracted = await this.extractWithBackstop(
+        dream,
+        prompt,
+        signal,
+        join(fs.root, inputDir),
+        stagedStore,
+        mineSkills
+      )
 
       // A cancel that landed mid-extraction wins: drop the output unstaged. This
       // also covers the backstop firing (extraction ignored the cancel and never
       // settled within the grace window) — the reservation is released either way.
-      if ((await this.deps.store.getDream(agentId, dreamId))?.status !== 'running' || extracted.abandoned) return
+      // The model writes as it goes, so whatever it already wrote is dropped too.
+      if ((await this.deps.store.getDream(agentId, dreamId))?.status !== 'running' || extracted.abandoned) {
+        await this.clearStaging(agentId, dreamId)
+        return
+      }
       const output = extracted.output
       const execution = {
         ...(extracted.sessionId ? { executionSessionId: extracted.sessionId } : {}),
@@ -706,6 +732,7 @@ export class DreamRunner {
         sources.map((s) => s.sessionId)
       )
       if (!proposal) {
+        await this.clearStaging(agentId, dreamId)
         await this.finish(agentId, dreamId, {
           status: 'failed',
           error: { type: 'unparseable_proposal', message: 'the dream reply carried no valid store proposal' },
@@ -725,10 +752,12 @@ export class DreamRunner {
       // stage() is several awaited writes; a cancel can land while it runs.
       // Cancel-wins: honor it, drop the partial output, don't flip to completed.
       if ((await this.deps.store.getDream(agentId, dreamId))?.status !== 'running') {
-        await fs.rm(join(base, MEMORY_DIRNAME)).catch(() => {})
-        await fs.rm(join(base, LEGACY_STAGED_DIRNAME)).catch(() => {})
+        await this.clearStaging(agentId, dreamId)
         return
       }
+      // Count before completing: every await after the status flip widens the
+      // window where the job reads completed but the reservation is still held.
+      const stagedCount = (await fs.readdir(join(base, MEMORY_DIRNAME))).filter((e) => e.kind === 'file').length
       await this.finish(agentId, dreamId, {
         status: 'completed',
         ...execution,
@@ -751,7 +780,7 @@ export class DreamRunner {
           `dream ${dreamId}: suggestion inventory sync deferred (${err instanceof Error ? err.name : 'unknown'})`
         )
       })
-      this.deps.log.info(`dream ${dreamId} completed for agent ${agentId} (${proposal.files.length + 1} staged files)`)
+      this.deps.log.info(`dream ${dreamId} completed for agent ${agentId} (${stagedCount} staged files)`)
     } catch (err) {
       this.deps.log.warn(`dream ${dreamId} failed for agent ${agentId}: ${err instanceof Error ? err.name : 'unknown'}`)
       // Fail BOTH pending and running dreams terminally — a failure before the
@@ -760,11 +789,25 @@ export class DreamRunner {
       // status is preserved, not overwritten).
       const status = (await this.deps.store.getDream(agentId, dreamId))?.status
       if (status === 'running' || status === 'pending') {
+        // Whatever the model already wrote belongs to a run that never completed.
+        await this.clearStaging(agentId, dreamId)
         await this.finish(agentId, dreamId, {
           status: 'failed',
           error: { type: 'pipeline_error', message: err instanceof Error ? err.message : 'unknown error' }
         })
       }
+    }
+  }
+
+  /** Drop every staged byte of a run that will never complete — both layouts, best effort. */
+  private async clearStaging(agentId: string, dreamId: string): Promise<void> {
+    try {
+      const fs = this.fsFor(agentId)
+      const base = this.dreamDir(agentId, dreamId)
+      await fs.rm(join(base, MEMORY_DIRNAME))
+      await fs.rm(join(base, LEGACY_STAGED_DIRNAME))
+    } catch {
+      // The home may already be unreachable; the dream dir is swept with the record.
     }
   }
 
@@ -782,6 +825,7 @@ export class DreamRunner {
     prompt: string,
     signal: AbortSignal,
     inputDir: string,
+    stagedStore: MemoryFs,
     mineSkills = false
   ): Promise<({ abandoned: false } & DreamExtractionResult) | { abandoned: true; output: '' }> {
     const graceMs = this.deps.cancelGraceMs ?? 30_000
@@ -790,7 +834,8 @@ export class DreamRunner {
         dreamId: dream.dreamId,
         trigger: dream.trigger,
         sessionIds: dream.sessionIds,
-        inputDir
+        inputDir,
+        stagedStore
       })
       .then((result) => ({ abandoned: false as const, ...result }))
     let timer: ReturnType<typeof setTimeout> | undefined
@@ -809,30 +854,22 @@ export class DreamRunner {
   }
 
   private async stage(fs: MemoryFs, base: string, proposal: DreamProposal): Promise<DreamOrganizationSuggestionInfo[]> {
+    // The model already wrote its topic files into the staged store through the memory
+    // tools, so staging no longer transcribes them — it reads back what landed and
+    // renders the index the same way adoption will.
     const out = join(base, MEMORY_DIRNAME)
-    await fs.rm(out)
-    await fs.rm(join(base, LEGACY_STAGED_DIRNAME))
-    await fs.mkdir(out)
     const staged: MemoryIndexEntry[] = []
-    for (const file of proposal.files) {
-      // parseDreamProposal already enforced TOPIC_RE — belt and suspenders here
-      // because these names become filesystem paths.
-      if (!stagedPathOk(file.path)) continue
-      // The dream writes frontmatter as free text, so re-render its known scalars through
-      // the shared quoting rule before staging — a description holding `: ` or ` #` would
-      // otherwise be invalid YAML, and auto-adopt would make that malformed topic live.
-      const content = normalizeMemoryHeader(file.content)
-      await fs.writeFile(join(out, file.path), content)
-      const { header } = parseMemoryFrontmatter(content)
+    for (const entry of await fs.readdir(out)) {
+      if (entry.kind !== 'file' || entry.name === MEMORY_INDEX || !stagedPathOk(entry.name)) continue
+      const raw = await fs.readFile(join(out, entry.name))
+      if (raw === null) continue
+      const { header } = parseMemoryFrontmatter(raw.content)
       staged.push({
-        topic: file.path,
-        name: header.name || memoryNameForTopic(file.path),
+        topic: entry.name,
+        name: header.name || memoryNameForTopic(entry.name),
         description: header.description ?? ''
       })
     }
-    // Generate the staged index the same way adoption will, rather than staging the
-    // model's hand-written one: otherwise the index a human reviews is not the index
-    // that ends up installed.
     await fs.writeFile(join(out, MEMORY_INDEX), renderMemoryIndex(staged))
     await this.stageSkills(fs, base, proposal)
     return this.stageOrganizationSuggestions(fs, base, proposal)

--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -742,6 +742,29 @@ export class DreamRunner {
         return
       }
 
+      // The store is what the model WROTE, so an extraction that never called
+      // `writeMemory` — a broken tool surface, refused writes, a turn that ended
+      // early — produced no store proposal at all, only a parseable reply. Staging
+      // it would complete an index-only store that adoption, auto-adoption above
+      // all, installs over every live topic. Treat it as no proposal.
+      const stagedTopics = (await fs.readdir(join(base, MEMORY_DIRNAME))).filter(
+        (entry) => entry.kind === 'file' && entry.name !== MEMORY_INDEX && stagedPathOk(entry.name)
+      ).length
+      const liveTopics = files.filter((file) => file.name !== MEMORY_INDEX).length
+      if (stagedTopics === 0 && liveTopics > 0) {
+        await this.clearStaging(agentId, dreamId)
+        await this.finish(agentId, dreamId, {
+          status: 'failed',
+          error: {
+            type: 'empty_proposal',
+            message: `the dream wrote no memory files; refusing a rebuild that would delete ${liveTopics} existing topic(s)`
+          },
+          ...execution,
+          usage
+        })
+        return
+      }
+
       if (!mineSkills) {
         proposal.skills = []
         proposal.organizationSkills = []
@@ -755,9 +778,6 @@ export class DreamRunner {
         await this.clearStaging(agentId, dreamId)
         return
       }
-      // Count before completing: every await after the status flip widens the
-      // window where the job reads completed but the reservation is still held.
-      const stagedCount = (await fs.readdir(join(base, MEMORY_DIRNAME))).filter((e) => e.kind === 'file').length
       await this.finish(agentId, dreamId, {
         status: 'completed',
         ...execution,
@@ -780,7 +800,7 @@ export class DreamRunner {
           `dream ${dreamId}: suggestion inventory sync deferred (${err instanceof Error ? err.name : 'unknown'})`
         )
       })
-      this.deps.log.info(`dream ${dreamId} completed for agent ${agentId} (${stagedCount} staged files)`)
+      this.deps.log.info(`dream ${dreamId} completed for agent ${agentId} (${stagedTopics} staged topics)`)
     } catch (err) {
       this.deps.log.warn(`dream ${dreamId} failed for agent ${agentId}: ${err instanceof Error ? err.name : 'unknown'}`)
       // Fail BOTH pending and running dreams terminally — a failure before the

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -108,12 +108,30 @@ class FakeStore implements DreamStorePort {
   }
 }
 
-const PROPOSAL = JSON.stringify({
-  index: '# Memory\n- [prefs](prefs.md)',
-  files: [{ path: 'prefs.md', content: '- Uses tabs, not spaces (2026-07-24).' }]
-})
+// The JSON reply now carries only review-queue proposals; the store itself is what
+// the model WROTE through the memory tools, so a fake extraction has to write too.
+const PROPOSAL = JSON.stringify({ agentSkills: [], organizationKnowledge: [], organizationSkills: [] })
+
+/** Stand in for the model writing its rebuilt store through the bound memory tools. */
+async function writeStagedProposal(
+  stagedStore: {
+    writeFile(path: string, content: string, opts?: unknown): Promise<unknown>
+    mkdir(p: string): Promise<unknown>
+  },
+  files: { path: string; content: string }[] = [{ path: 'prefs.md', content: '- Uses tabs, not spaces (2026-07-24).' }]
+): Promise<void> {
+  await stagedStore.mkdir('memory')
+  for (const file of files) {
+    const content = file.content.endsWith('\n') ? file.content : `${file.content}\n`
+    await stagedStore.writeFile(join('memory', file.path), content, {})
+  }
+}
 
 async function setup(opts: {
+  /** Files the fake model writes into the staged store; `null` writes nothing. */
+  stagedFiles?: { path: string; content: string }[] | null
+  /** Write the staged store exactly as the bound memory tools would, instead. */
+  stagedWrite?: (stagedStore: MemoryFs) => Promise<void>
   extract?: (agentId: string, systemPrompt: string, prompt: string, signal: AbortSignal) => Promise<string>
   policy?: MemoryDreamingPolicy
   cancelGraceMs?: number
@@ -141,8 +159,14 @@ async function setup(opts: {
     store,
     extract: async (agentId, systemPrompt, prompt, signal, context) => {
       prompts.push({ systemPrompt, prompt, inputDir: context.inputDir })
-      if (opts.extractionResult) return opts.extractionResult
+      if (opts.extractionResult) {
+        if (opts.stagedWrite) await opts.stagedWrite(context.stagedStore)
+        else if (opts.stagedFiles !== null) await writeStagedProposal(context.stagedStore, opts.stagedFiles)
+        return opts.extractionResult
+      }
       const output = opts.extract ? await opts.extract(agentId, systemPrompt, prompt, signal) : PROPOSAL
+      if (opts.stagedWrite) await opts.stagedWrite(context.stagedStore)
+      else if (opts.stagedFiles !== null) await writeStagedProposal(context.stagedStore, opts.stagedFiles)
       return { output }
     },
     ...(opts.onEvent ? { onEvent: opts.onEvent } : {}),
@@ -260,6 +284,37 @@ describe('DreamRunner pipeline', () => {
     expect(staged?.map((f) => f.name)).toEqual(['MEMORY.md', 'prefs.md'])
     const read = await runner.stagedRead('a1', started.dreamId, 'prefs.md')
     expect(read?.content).toContain('2026-07-24')
+  })
+
+  it('stages what the model wrote through the shared write path, indexed by its own headers', async () => {
+    // The composed contract: a dream writes with the memory tools bound to its staged
+    // store, so the same normalize/stamp/index-regen a turn gets applies there — and a
+    // topic the model never rewrote is simply gone, because staging replaces the store.
+    const { dir, store, runner } = await setup({
+      stagedWrite: async (stagedStore) => {
+        await writeMemoryFile(
+          stagedStore,
+          'deploys.md',
+          '---\ndescription: how we ship\n---\n\n- ship from main\n',
+          undefined,
+          'dream'
+        )
+      }
+    })
+    const started = await runner.start('a1', { trigger: 'manual' })
+    await settle(store, started.dreamId)
+
+    const staged = await runner.stagedFiles('a1', started.dreamId)
+    expect(staged?.map((f) => f.name)).toEqual(['MEMORY.md', 'deploys.md'])
+    const stagedIndex = await runner.stagedRead('a1', started.dreamId, MEMORY_INDEX)
+    expect(stagedIndex?.content).toContain('- [deploys](deploys.md) — how we ship')
+
+    await runner.adopt('a1', started.dreamId, false)
+    const adopted = await readMemoryFile(local(dir), 'deploys.md')
+    expect(adopted).toContain('name: deploys') // stamped on the way in, not at adoption
+    expect(adopted).toMatch(/modified: \d{4}-/)
+    expect(await readMemoryFile(local(dir), MEMORY_INDEX)).toBe(stagedIndex?.content)
+    expect(await readMemoryFile(local(dir), 'prefs.md')).toBe('')
   })
 
   it('mines every session the agent participated in, without a capture-visibility filter (#36)', async () => {
@@ -603,8 +658,10 @@ describe('DreamRunner adoption', () => {
       dreamingPolicyFor: () => ({ enabled: true, autoAdopt: true }),
       operationPolicy: 'test-only',
       store,
-      extract: async () => {
+      extract: async (_agentId, _systemPrompt, _prompt, _signal, context) => {
         heldDuringExtraction = holds
+        // The model writes its rebuilt store through the tools, on the pod's volume.
+        await writeStagedProposal(context.stagedStore)
         return { output: PROPOSAL }
       },
       log: silent
@@ -727,14 +784,10 @@ describe('DreamRunner adoption', () => {
     // file would show the adoption time. Only files whose content actually
     // changed should get a fresh updated-time.
     const { dir, store, runner } = await setup({
-      extract: async () =>
-        JSON.stringify({
-          index: '# Memory\n- [keep](keep.md)\n- [prefs](prefs.md)',
-          files: [
-            { path: 'keep.md', content: 'unchanged body' },
-            { path: 'prefs.md', content: 'changed by the dream' }
-          ]
-        })
+      stagedFiles: [
+        { path: 'keep.md', content: 'unchanged body' },
+        { path: 'prefs.md', content: 'changed by the dream' }
+      ]
     })
     const started = await runner.start('a1', { trigger: 'manual' })
     await settle(store, started.dreamId)
@@ -797,14 +850,12 @@ describe('DreamRunner adoption', () => {
   })
 
   it('records the exact add, update, and delete set with live before snapshots', async () => {
-    const proposal = JSON.stringify({
-      index: '# Memory\n- [prefs](prefs.md)\n- [fresh](fresh.md)',
-      files: [
+    const { dir, store, runner } = await setup({
+      stagedFiles: [
         { path: 'prefs.md', content: '- consolidated preference' },
         { path: 'fresh.md', content: '- newly learned fact' }
       ]
     })
-    const { dir, store, runner } = await setup({ extract: async () => proposal })
     await writeMemoryFile(local(dir), 'obsolete.md', '- no longer relevant\n', undefined, 'tool')
     const started = await runner.start('a1', { trigger: 'manual' })
     await settle(store, started.dreamId)
@@ -1024,10 +1075,7 @@ describe('DreamRunner adoption', () => {
     // A proposal that is already at capacity plus one distilled line must not
     // adopt an over-limit store the ordinary write path could never produce.
     const atCap = '- ' + 'x'.repeat(MAX_MEMORY_FILE_BYTES - 4)
-    const { dir, store, runner } = await setup({
-      extract: async () =>
-        JSON.stringify({ index: '# Memory\n- [prefs](prefs.md)', files: [{ path: 'prefs.md', content: atCap }] })
-    })
+    const { dir, store, runner } = await setup({ stagedFiles: [{ path: 'prefs.md', content: atCap }] })
     const started = await runner.start('a1', { trigger: 'manual' })
     await settle(store, started.dreamId)
 

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -317,6 +317,37 @@ describe('DreamRunner pipeline', () => {
     expect(await readMemoryFile(local(dir), 'prefs.md')).toBe('')
   })
 
+  it('fails a dream that wrote no memory rather than staging a store that deletes every topic', async () => {
+    // The store is what the model wrote, so a parseable reply with zero writes is not
+    // an empty proposal — it is no proposal. Completing it would hand auto-adopt an
+    // index-only store to install over the live one.
+    const { dir, store, runner } = await setup({ stagedFiles: null })
+    const started = await runner.start('a1', { trigger: 'manual' })
+    const done = await settle(store, started.dreamId)
+    expect(done.status).toBe('failed')
+    expect(done.error?.type).toBe('empty_proposal')
+    expect(await runner.stagedFiles('a1', started.dreamId)).toBeNull()
+    expect(await readMemoryFile(local(dir), 'prefs.md')).toContain('uses tabs')
+  })
+
+  it('still completes an empty rebuild when the live store had nothing to lose', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'ac-dream-'))
+    const fs = local(dir)
+    await ensureMemory(fs, 'bot')
+    const store = new FakeStore()
+    const runner = new DreamRunner({
+      agentDirByAgent: (id) => (id === 'a1' ? dir : undefined),
+      memoryFsFor: (id) => (id === 'a1' ? fs : undefined),
+      dreamingPolicyFor: () => ({ enabled: true }),
+      operationPolicy: 'test-only',
+      store,
+      extract: async () => ({ output: PROPOSAL }),
+      log: silent
+    })
+    const started = await runner.start('a1', { trigger: 'manual' })
+    expect((await settle(store, started.dreamId)).status).toBe('completed')
+  })
+
   it('mines every session the agent participated in, without a capture-visibility filter (#36)', async () => {
     // A dream distills all of the agent's own sessions — including DM / webchat /
     // external (GitHub) / A2A ones that the per-turn capture gate marks private.
@@ -485,7 +516,10 @@ describe('DreamRunner pipeline', () => {
       dreamingPolicyFor: () => ({ enabled: true }),
       operationPolicy: 'test-only',
       store,
-      extract: async () => ({ output: PROPOSAL }),
+      extract: async (_agentId, _systemPrompt, _prompt, _signal, context) => {
+        await writeStagedProposal(context.stagedStore)
+        return { output: PROPOSAL }
+      },
       onStaged: async (agentId, dreamId) => {
         await runner.cancel(agentId, dreamId) // cancel after staging, before completion
       },

--- a/packages/daemon/test/memory-dreamer.test.ts
+++ b/packages/daemon/test/memory-dreamer.test.ts
@@ -8,7 +8,6 @@ import {
   parseDreamProposal,
   parseOrganizationSkills,
   storeDigest,
-  MAX_DREAM_FILES,
   MAX_DREAM_SKILLS,
   MAX_SKILL_BODY_BYTES,
   MAX_SKILL_SCRIPTS,
@@ -96,16 +95,21 @@ describe('dream exploration prompt + materialized inputs', () => {
 })
 
 describe('dream proposal parsing', () => {
+  // The reply now carries only the review queue — the store the dream rebuilt was
+  // written through the memory tools while it ran, not returned as JSON.
   const good = JSON.stringify({
-    index: '# Memory\n- [prefs](prefs.md)',
-    files: [{ path: 'prefs.md', content: '- Uses tabs, not spaces.' }]
+    agentSkills: [],
+    organizationKnowledge: [
+      { operation: 'create', title: 'Deploy runbook', content: 'Ship from main.', sessionIds: ['sess-a'] }
+    ],
+    organizationSkills: []
   })
 
   it('parses a fenced or bare JSON proposal', () => {
     for (const text of [good, `Here you go:\n\`\`\`json\n${good}\n\`\`\``]) {
-      const proposal = parseDreamProposal(text)
-      expect(proposal?.files).toHaveLength(1)
-      expect(proposal?.files[0]).toMatchObject({ path: 'prefs.md' })
+      const proposal = parseDreamProposal(text, ['sess-a'])
+      expect(proposal?.organizationKnowledge).toHaveLength(1)
+      expect(proposal?.organizationKnowledge[0]).toMatchObject({ title: 'Deploy runbook' })
     }
   })
 
@@ -146,60 +150,17 @@ describe('dream proposal parsing', () => {
   })
 
   it('parses a fenced proposal that trails prose after the JSON', () => {
-    const proposal = parseDreamProposal(`\`\`\`json\n${good}\n\`\`\`\n\nThat covers it — nothing else stood out.`)
-    expect(proposal?.files).toHaveLength(1)
+    const proposal = parseDreamProposal(`\`\`\`json\n${good}\n\`\`\`\n\nThat covers it — nothing else stood out.`, [
+      'sess-a'
+    ])
+    expect(proposal?.organizationKnowledge).toHaveLength(1)
   })
 
-  it('returns null only for unparseable replies — an absent index is now expected', () => {
+  it('returns null only for unparseable replies — an empty review queue is expected', () => {
     expect(parseDreamProposal('no json at all')).toBeNull()
-    // An empty store is valid and adoptable — staging renders an index for it.
-    expect(parseDreamProposal(JSON.stringify({ files: [] }))?.files).toEqual([])
-    // A proposal with files and no index is valid now: staging generates the index.
-    expect(parseDreamProposal(JSON.stringify({ files: [{ path: 'topic.md', content: 'x' }] }))?.files).toHaveLength(1)
-  })
-
-  it('drops traversal paths, bad names, duplicates, and the index masquerading as a file', () => {
-    const proposal = parseDreamProposal(
-      JSON.stringify({
-        index: '# Memory',
-        files: [
-          { path: '../escape.md', content: 'x' },
-          { path: 'Bad Name.md', content: 'x' },
-          { path: '.history', content: 'x' },
-          { path: 'MEMORY.md', content: 'shadow index' },
-          { path: 'ok.md', content: 'first' },
-          { path: 'ok.md', content: 'dupe' },
-          { path: 'also-ok.md', content: '' }
-        ]
-      })
-    )
-    expect(proposal?.files.map((f) => f.path)).toEqual(['ok.md'])
-  })
-
-  it('caps the number of proposed files', () => {
-    const proposal = parseDreamProposal(
-      JSON.stringify({
-        index: '# Memory',
-        files: Array.from({ length: 100 }, (_, i) => ({ path: `topic-${i}.md`, content: 'x' }))
-      })
-    )
-    expect(proposal?.files).toHaveLength(MAX_DREAM_FILES)
-  })
-
-  it('keeps oversized content adoptable: final bytes never exceed the writer cap', () => {
-    // A multibyte body larger than the cap: the trailing-newline reservation and
-    // the code-point-boundary clamp must keep the stored string within
-    // MAX_MEMORY_FILE_BYTES (256000), so writeMemoryFile can never reject it.
-    const proposal = parseDreamProposal(
-      JSON.stringify({
-        index: '#'.repeat(30_000), // over the 25k index cap
-        files: [{ path: 'big.md', content: '€'.repeat(200_000) }] // 3 bytes each ⇒ ~600kB
-      })
-    )
-    expect(proposal).not.toBeNull()
-    expect(Buffer.byteLength(proposal!.files[0]!.content)).toBeLessThanOrEqual(256_000)
-    // No replacement character introduced by a mid-codepoint cut.
-    expect(proposal!.files[0]!.content).not.toContain('�')
+    // A dream that only rewrote memory proposes nothing for review, and that is valid:
+    // the staged store it wrote through the tools is what gets adopted.
+    expect(parseDreamProposal('{}')?.skills).toEqual([])
   })
 })
 
@@ -290,8 +251,7 @@ describe('structured organization proposals', () => {
       })
 
     const proposal = parseDreamProposal(reply, ['sess-1', 'sess-2'])
-    // The model no longer supplies an index at all; staging renders one.
-    expect(proposal?.files).toEqual([])
+    // The model supplies neither files nor an index: it wrote the store as it went.
     expect(proposal?.organizationKnowledge).toMatchObject([{ sessionIds: ['sess-1'] }])
     expect(proposal?.organizationSkills).toMatchObject([
       { title: 'incident-rollback', sessionIds: ['sess-1', 'sess-2'] }


### PR DESCRIPTION
Third and last item of the memory-write unification (after #1287 / #1295): the dream now writes its rebuilt store the same way an agent writes memory.

## What changed

The dream used to return `{"agentMemory":{"index":"…","files":[…]}}` and the runner transcribed those files onto disk. That made it the one writer bypassing the shared write path — no header normalize/stamp, its own copy of the topic-name/dedupe/cap validation, and an index the model hand-wrote (so review showed something adoption did not install).

Now the extraction session registers `MEMORY_TOOLS` with a `memoryBinding` pinned to the dream's staged store, so `writeMemory` lands in `memory-dreams/<dreamId>/memory/` through `writeMemoryFileHoldingLock`: normalize → stamp → byte cap → `.history` → index regen, in the staged tree, never the live one.

- The staged store is created **before** extraction (the model needs somewhere to write) and dropped on every path that will not complete — cancel, the abandon backstop, an unparseable reply, a pipeline failure — so a partial rebuild is never reviewable.
- The binding carries the two constraints the JSON format enforced: the lowercase-kebab topic rule (`DREAM_TOPIC_RE`) and the 64-file cap (`MAX_DREAM_FILES`, counted as DISTINCT topics so one file can be rewritten freely). Path safety and the 256 KB cap were already in the tool path.
- `stage()` no longer transcribes: it reads back what landed and renders the index from those files' `description` headers, which is byte-for-byte what adoption installs.
- `DreamProposal.files` / `.index` are gone; the reply carries only the review queue (skills, organization suggestions).
- The prompt now states the replace semantics explicitly: the staging starts empty and replaces the live store, so a file the model does not write is how it prunes, and `readMemory` reads back its own staging (the live snapshot stays in the working directory).

## Tests

- `dream-runner.test.ts`: the fake extraction now writes through `context.stagedStore` — that IS the new contract. New composed-path test writes via the real `writeMemoryFile` and asserts the staged index, the stamped header after adoption, and that an unwritten topic is pruned.
- `memory-dreamer.test.ts`: parse tests re-pointed at the review queue; the traversal/bad-name/duplicate/cap/oversize cases now live on the binding (`memory-write-gate.test.ts`).
- Full daemon suite green apart from the known env-dependent files (`shim-*`, `acp-matrix`, `workspace-git-runner-seam`, `mcp-bridge-e2e` — the last needs a `tsx` this sandbox lacks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)