### PR TITLE
fix(web): let a session scope speak about the session's own worktree

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -937,9 +937,13 @@ Workspace link immediately before Details. For an unpurged session-scoped GitHub
 checkout, it opens that session's worktree; for a shared GitHub checkout or Scratch,
 it opens the Agent's primary workspace. Its git or folder icon reflects that source.
 A session worktree is browse-only in the console: file editing and pull remain actions
-on the primary workspace. When a selected session's worktree has been cleaned up, the
-browser says that it will be recreated from the repository when the agent next works in
-that session; it must not present the missing worktree as a new workspace with no files.
+on the primary workspace. When a selected session has no worktree, the browser says so
+without naming a cause — a worktree that was cleaned up and one the session never had
+are the same answer from this surface — and it must not present the missing worktree as
+a new workspace with no files. That sentence belongs to the session whichever repository
+is selected: a session-scoped read of an authorized additional repository addresses that
+root's worktree for this session, so it may never answer with the Agent-scoped copy about
+a repository the Agent materializes on its next session.
 
 The checkout control occupies about one quarter of the Workspace file browser
 header, opposite the current file breadcrumb. Its primary choice is named with

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -413,7 +413,7 @@ it('scopes file and git reads to the selected session worktree', async () => {
   expect(container?.textContent).not.toContain('Add file')
 })
 
-it('explains when a selected session workspace has been cleaned up', async () => {
+it('explains a selected session that has no checkout, without inventing why', async () => {
   workspace.exists = false
   container = document.createElement('div')
   document.body.append(container)
@@ -431,9 +431,19 @@ it('explains when a selected session workspace has been cleaned up', async () =>
     await Promise.resolve()
   })
 
-  expect(container.textContent).toContain("This session's workspace has been cleaned up")
-  expect(container.textContent).toContain('it will be recreated from the repository')
+  expect(container.textContent).toContain('No checkout for this session')
+  expect(container.textContent).toContain('may not have one of its own')
   expect(container.textContent).not.toContain('The workspace has no files yet')
+})
+
+it('speaks about the SESSION, not the agent, when a session scope selects an additional repository', async () => {
+  // Both selectors ride the same read, and the repository sentence is the AGENT's: told to a reader
+  // looking at one finished session's worktree it promises a checkout no later session will produce.
+  workspace.exists = false
+  await renderRepoScoped({ repo: 'acme/infra', sessionId: 'session-a' })
+
+  expect(container?.textContent).toContain('No checkout for this session')
+  expect(container?.textContent).not.toContain('materialized on the agent’s next session')
 })
 
 it('keeps an inline new-file draft across the desktop-to-mobile breakpoint', async () => {

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -442,7 +442,8 @@ it('speaks about the SESSION, not the agent, when a session scope selects an add
   workspace.exists = false
   await renderRepoScoped({ repo: 'acme/infra', sessionId: 'session-a' })
 
-  expect(container?.textContent).toContain('No checkout for this session')
+  // Named, because with a root selected the missing worktree is THAT root's.
+  expect(container?.textContent).toContain('No checkout of acme/infra for this session')
   expect(container?.textContent).not.toContain('materialized on the agent’s next session')
 })
 

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -38,6 +38,7 @@ import {
   type FileBrowserEditorDraft
 } from '@/components/console/FileBrowser'
 import {
+  SESSION_WORKTREE_ABSENT_NOTICE,
   StatusBadge,
   useWorkspaceGitStatus,
   useWorkspaceTree,
@@ -701,10 +702,11 @@ export function WorkspaceFiles({
         {!editor && root && !root.loading && !root.err && !root.exists && (
           <EmptyNote
             text={
-              repo
-                ? 'Not checked out yet — this repository is materialized on the agent’s next session.'
-                : sessionId
-                  ? "This session's workspace has been cleaned up — it will be recreated from the repository when the agent next works in this session."
+              // The SESSION scope answers first for every root: the repository sentence below is about the AGENT's checkout, and offering it to a reader looking at one session's worktree promises a materialization that session will never see.
+              sessionId
+                ? SESSION_WORKTREE_ABSENT_NOTICE
+                : repo
+                  ? 'Not checked out yet — this repository is materialized on the agent’s next session.'
                   : 'The workspace has no files yet — the agent creates them as it works.'
             }
           />

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -38,7 +38,7 @@ import {
   type FileBrowserEditorDraft
 } from '@/components/console/FileBrowser'
 import {
-  SESSION_WORKTREE_ABSENT_NOTICE,
+  sessionWorktreeAbsentNotice,
   StatusBadge,
   useWorkspaceGitStatus,
   useWorkspaceTree,
@@ -704,7 +704,7 @@ export function WorkspaceFiles({
             text={
               // The SESSION scope answers first for every root: the repository sentence below is about the AGENT's checkout, and offering it to a reader looking at one session's worktree promises a materialization that session will never see.
               sessionId
-                ? SESSION_WORKTREE_ABSENT_NOTICE
+                ? sessionWorktreeAbsentNotice(repo)
                 : repo
                   ? 'Not checked out yet — this repository is materialized on the agent’s next session.'
                   : 'The workspace has no files yet — the agent creates them as it works.'

--- a/packages/web/src/components/console/dock/FilesPanel.test.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.test.tsx
@@ -740,11 +740,12 @@ describe('FilesPanel degraded states', () => {
     expect(text()).not.toContain('may be offline')
   })
 
-  it('explains a cleaned-up worktree that the listing reports as missing', async () => {
+  it('explains a listing that reports the session worktree missing, without inventing why', async () => {
     wire.listings = { '': { entries: [], exists: false } }
     await render()
 
-    expect(text()).toContain('will be recreated from the repository')
+    expect(text()).toContain('No checkout for this session')
+    expect(text()).toContain('may not have one of its own')
   })
 
   it('explains a primary workspace that has no files yet', async () => {

--- a/packages/web/src/components/console/dock/FilesPanel.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.tsx
@@ -9,6 +9,7 @@ import { Icon } from '@/components/ui'
 import { FileBrowserRow, formatFileMtime, formatFileSize } from '@/components/console/FileBrowser'
 import {
   SANDBOX_ASLEEP_CODE,
+  SESSION_WORKTREE_ABSENT_NOTICE,
   StatusBadge,
   useWorkspaceGitStatus,
   useWorkspaceTree,
@@ -215,7 +216,7 @@ export function FilesPanel({
         <PanelNotice
           text={
             sessionId
-              ? "This session's workspace has been cleaned up — it will be recreated from the repository when the agent next works in this session."
+              ? SESSION_WORKTREE_ABSENT_NOTICE
               : 'The workspace has no files yet — the agent creates them as it works.'
           }
         />

--- a/packages/web/src/components/console/dock/FilesPanel.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.tsx
@@ -9,7 +9,7 @@ import { Icon } from '@/components/ui'
 import { FileBrowserRow, formatFileMtime, formatFileSize } from '@/components/console/FileBrowser'
 import {
   SANDBOX_ASLEEP_CODE,
-  SESSION_WORKTREE_ABSENT_NOTICE,
+  sessionWorktreeAbsentNotice,
   StatusBadge,
   useWorkspaceGitStatus,
   useWorkspaceTree,
@@ -216,7 +216,7 @@ export function FilesPanel({
         <PanelNotice
           text={
             sessionId
-              ? SESSION_WORKTREE_ABSENT_NOTICE
+              ? sessionWorktreeAbsentNotice()
               : 'The workspace has no files yet — the agent creates them as it works.'
           }
         />

--- a/packages/web/src/components/console/workspace-tree.tsx
+++ b/packages/web/src/components/console/workspace-tree.tsx
@@ -245,7 +245,7 @@ export const SANDBOX_ASLEEP_CODE = 'WORKSPACE_SANDBOX_UNAVAILABLE'
 // `repo` names the SELECTED root, because with one chosen the missing worktree is that root's and a bare "its worktree" reads as the session's primary one.
 export function sessionWorktreeAbsentNotice(repo?: string): string {
   const of = repo ? ` of ${repo}` : ''
-  return `No checkout${of} for this session — its worktree may have been cleaned up, or this session may not have one${repo ? ' of this repository' : ' of its own'}.`
+  return `No checkout${of} for this session — its worktree may have been cleaned up, or this session may not have one${repo ? ' for this repository' : ' of its own'}.`
 }
 
 /** Whether a failed workspace read was the sandbox being asleep rather than anything being wrong. */

--- a/packages/web/src/components/console/workspace-tree.tsx
+++ b/packages/web/src/components/console/workspace-tree.tsx
@@ -242,8 +242,11 @@ export type WorkspaceGitOutcome = 'pending' | 'repo' | 'none' | 'asleep' | 'unav
 export const SANDBOX_ASLEEP_CODE = 'WORKSPACE_SANDBOX_UNAVAILABLE'
 
 /** What both file surfaces say when a read SUCCEEDS and reports a session-scoped root that is not there. Named no cause on purpose: a worktree the daemon reclaimed and one this session was never given are the same answer from here, and the sentence this replaced asserted the first and promised a recreation the second never gets. */
-export const SESSION_WORKTREE_ABSENT_NOTICE =
-  'No checkout for this session — its worktree may have been cleaned up, or this session may not have one of its own.'
+// `repo` names the SELECTED root, because with one chosen the missing worktree is that root's and a bare "its worktree" reads as the session's primary one.
+export function sessionWorktreeAbsentNotice(repo?: string): string {
+  const of = repo ? ` of ${repo}` : ''
+  return `No checkout${of} for this session — its worktree may have been cleaned up, or this session may not have one${repo ? ' of this repository' : ' of its own'}.`
+}
 
 /** Whether a failed workspace read was the sandbox being asleep rather than anything being wrong. */
 export function isSandboxAsleep(err: unknown): boolean {

--- a/packages/web/src/components/console/workspace-tree.tsx
+++ b/packages/web/src/components/console/workspace-tree.tsx
@@ -241,6 +241,10 @@ export type WorkspaceGitOutcome = 'pending' | 'repo' | 'none' | 'asleep' | 'unav
 /** The CP's code for "this agent's sandbox is not running". A 503 like an offline daemon — the code is the only thing that separates the two, and a plain 503 keeps the offline story. */
 export const SANDBOX_ASLEEP_CODE = 'WORKSPACE_SANDBOX_UNAVAILABLE'
 
+/** What both file surfaces say when a read SUCCEEDS and reports a session-scoped root that is not there. Named no cause on purpose: a worktree the daemon reclaimed and one this session was never given are the same answer from here, and the sentence this replaced asserted the first and promised a recreation the second never gets. */
+export const SESSION_WORKTREE_ABSENT_NOTICE =
+  'No checkout for this session — its worktree may have been cleaned up, or this session may not have one of its own.'
+
 /** Whether a failed workspace read was the sandbox being asleep rather than anything being wrong. */
 export function isSandboxAsleep(err: unknown): boolean {
   return err instanceof ApiError && err.code === SANDBOX_ASLEEP_CODE


### PR DESCRIPTION
## Two selectors, one empty state, wrong order

The file browser's empty state asked about `repo` before `sessionId`:

```tsx
repo
  ? 'Not checked out yet — this repository is materialized on the agent’s next session.'
  : sessionId
    ? "This session's workspace has been cleaned up — …"
    : 'The workspace has no files yet — …'
```

The two selectors compose — a `repo` with a `sessionId` is that root's own worktree for that session — so choosing an additional repository while the scope was a session worktree always drew the **agent's** sentence. Told to someone looking at one finished session, "this repository is materialized on the agent's next session" promises a checkout that session will never see. The session scope answers first now, for every root.

## The session's own copy stopped naming a cause

A worktree the daemon reclaimed and one the session was never given are the same answer from here: a successful read that reports the root is not there. The old sentence asserted the first ("has been cleaned up") and promised a recreation the second never gets.

Both file surfaces now share one sentence, in the hedged voice the 404 notice beside it already uses:

> No checkout for this session — its worktree may have been cleaned up, or this session may not have one of its own.

The dock's Files panel carried a copy-pasted duplicate of the old sentence, so it moves to the shared constant with the agent page — the two cannot drift apart now.

## Tests

A new case pins the combination that was broken (a session scope with an additional repository selected): restoring the old branch order fails it. The two existing empty-state cases follow the new copy, and the dock's equivalent follows it too. Full web suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
