### PR TITLE
fix(dream): adopt only a staged store the memory tools actually wrote

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -312,9 +312,11 @@ Where the runtime has no trusted system-prompt channel (today: Codex ACP),
 the policy text is prepended to the user prompt instead. That is acceptable
 because invariant 3 + staged output constrain the proposal to validated
 managed-memory content. Independently, the extraction session is **hard-gated
-on a verified read-only / plan mode** (§2) — so even on that untrusted-channel
-path a prompt injection cannot cause tool side effects during the run; a
-runtime with no non-mutating mode fails the dream. When `autoAdopt` is enabled,
+on a verified read-only / plan mode** (§2); a runtime with no non-mutating mode
+fails the dream. That gate is necessary but NOT sufficient — a real claude run
+in plan mode still wrote files through its own tools (#1302) — so the staged
+store is verified explicitly rather than trusted: staging refuses any file the
+bound memory tools did not write. When `autoAdopt` is enabled,
 a valid completed proposal is accepted on either prompt transport; the console
 warns that this skips content review.
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3975,6 +3975,7 @@ export class Daemon {
     model?: string
     stopReason: string
     usage?: StoredUsage
+    memoryTopics: string[]
   }> {
     // Defense in depth: DreamRunner is the intended caller and already checks
     // admission before creating a job. Keep the extraction seam independently
@@ -4115,6 +4116,7 @@ export class Daemon {
     model?: string
     stopReason: string
     usage?: StoredUsage
+    memoryTopics: string[]
   }> {
     const agentId = agent.id
     // Capture the transport capability from THIS host so the extraction policy
@@ -4159,7 +4161,7 @@ export class Daemon {
         ? await host.newSession(cwd, mcpServers, undefined, systemPrompt)
         : await host.newSession(cwd, mcpServers)
       ref.sessionId = sessionId
-      return await this.runDreamExtractionSession(
+      const result = await this.runDreamExtractionSession(
         host,
         agent,
         sessionId,
@@ -4169,6 +4171,9 @@ export class Daemon {
         systemPrompt,
         trusted
       )
+      // What the model actually wrote through the bound tools. Staging refuses
+      // anything else that turned up in the staged store.
+      return { ...result, memoryTopics: this.mcp.writtenMemoryTopics(mcpToken) }
     } finally {
       this.mcp.unregister(mcpToken)
     }

--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -149,6 +149,12 @@ export interface DreamStorePort {
 
 export interface DreamExtractionResult {
   output: string
+  /** Topics the extraction wrote through the BOUND memory tools. Staging refuses any
+   *  staged file missing from this list: it reached the staged store some other way
+   *  (a runtime file tool, say) and never passed the memory write path's rules.
+   *  Absent counts as none — an extraction that cannot report provenance cannot
+   *  stage files either. */
+  memoryTopics?: string[]
   /** The short-lived ACP id is retained for correlation after the runtime
    *  session itself is discarded. */
   sessionId?: string
@@ -747,10 +753,29 @@ export class DreamRunner {
       // early — produced no store proposal at all, only a parseable reply. Staging
       // it would complete an index-only store that adoption, auto-adoption above
       // all, installs over every live topic. Treat it as no proposal.
-      const stagedTopics = (await fs.readdir(join(base, MEMORY_DIRNAME))).filter(
-        (entry) => entry.kind === 'file' && entry.name !== MEMORY_INDEX && stagedPathOk(entry.name)
-      ).length
+      const stagedNames = (await fs.readdir(join(base, MEMORY_DIRNAME)))
+        .filter((entry) => entry.kind === 'file' && entry.name !== MEMORY_INDEX && stagedPathOk(entry.name))
+        .map((entry) => entry.name)
+      const stagedTopics = stagedNames.length
       const liveTopics = files.filter((file) => file.name !== MEMORY_INDEX).length
+      // A staged file the memory tools did not write skipped every rule they enforce
+      // (name, byte cap, header normalize + stamp). It means the model reached the
+      // staging directory with its own file tools, so the whole proposal is suspect.
+      const written = new Set(extracted.memoryTopics ?? [])
+      const unaccounted = stagedNames.filter((name) => !written.has(name))
+      if (unaccounted.length > 0) {
+        await this.clearStaging(agentId, dreamId)
+        await this.finish(agentId, dreamId, {
+          status: 'failed',
+          error: {
+            type: 'untrusted_staging',
+            message: `staged files did not come from the memory tools: ${unaccounted.slice(0, 5).join(', ')}`
+          },
+          ...execution,
+          usage
+        })
+        return
+      }
       if (stagedTopics === 0 && liveTopics > 0) {
         await this.clearStaging(agentId, dreamId)
         await this.finish(agentId, dreamId, {

--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -758,9 +758,10 @@ export class DreamRunner {
         .map((entry) => entry.name)
       const stagedTopics = stagedNames.length
       const liveTopics = files.filter((file) => file.name !== MEMORY_INDEX).length
-      // A staged file the memory tools did not write skipped every rule they enforce
-      // (name, byte cap, header normalize + stamp). It means the model reached the
-      // staging directory with its own file tools, so the whole proposal is suspect.
+      // Provenance is by NAME: a staged file no bound write ever produced means the
+      // model reached the staging directory some other way — its own file tools — so
+      // the whole proposal is suspect. (A topic written properly and then overwritten
+      // out of band still passes; catching that needs a per-write digest.)
       const written = new Set(extracted.memoryTopics ?? [])
       const unaccounted = stagedNames.filter((name) => !written.has(name))
       if (unaccounted.length > 0) {

--- a/packages/daemon/src/mcp/control-server.ts
+++ b/packages/daemon/src/mcp/control-server.ts
@@ -4,6 +4,7 @@ import { mkdirSync, rmSync, chmodSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { decodeFrames, encodeFrame, type IpcRequest, type IpcResponse } from './ipc.js'
 import { executeTool, type OpsDeps, type SessionContext } from './ops.js'
+import { boundWrittenTopics } from './ops/memory.js'
 import type { ToolDescriptor } from '../tool-schema/descriptor.js'
 import type { Logger } from '../log.js'
 
@@ -37,6 +38,13 @@ export class McpControlServer {
 
   unregister(token: string): void {
     this.sessions.delete(token)
+  }
+
+  /** Memory topics this session wrote through the bound memory tools. A dream checks
+   *  its staged files against this: anything else got there some other way. */
+  writtenMemoryTopics(token: string): string[] {
+    const ctx = this.sessions.get(token)
+    return ctx ? boundWrittenTopics(ctx) : []
   }
 
   async start(): Promise<void> {

--- a/packages/daemon/src/mcp/ops/memory.ts
+++ b/packages/daemon/src/mcp/ops/memory.ts
@@ -89,9 +89,16 @@ function memoryScopeFor(ctx: SessionContext, deps: MemoryOpsDeps): MemoryScope {
 /** Provenance for a write made through the shared tool surface. The ordinary
  *  conversational case is `tool`; a distillation- or dream-bound session keeps its own
  *  source so the write ledger — and dream adoption's distill-only rebase — stay honest. */
-/** Topics a bound session has already written, so `maxTopics` counts DISTINCT files
- *  rather than writes — appending to one topic repeatedly is not new content. */
+/** Topics a bound session has written, so `maxTopics` counts DISTINCT files rather than
+ *  writes — appending to one topic repeatedly is not new content. It doubles as the
+ *  provenance record a dream checks its staged store against. */
 const boundTopics = new WeakMap<SessionContext, Set<string>>()
+
+/** Every topic this bound session wrote through the tool. A staged file that is NOT
+ *  here did not come from the memory write path — see the dream's staging check. */
+export function boundWrittenTopics(ctx: SessionContext): string[] {
+  return [...(boundTopics.get(ctx) ?? [])]
+}
 
 /** Apply the binding's own limits before a write reaches the store. These carry the
  *  constraints the dream's JSON proposal format used to enforce; the store still
@@ -103,13 +110,12 @@ function enforceBindingPolicy(ctx: SessionContext, path: string): void {
   if (binding.topicPattern && !binding.topicPattern.test(name)) {
     throw new Error(`invalid memory path: "${name}" must match ${String(binding.topicPattern)}`)
   }
-  if (binding.maxTopics === undefined) return
   let seen = boundTopics.get(ctx)
   if (!seen) {
     seen = new Set()
     boundTopics.set(ctx, seen)
   }
-  if (!seen.has(name) && seen.size >= binding.maxTopics) {
+  if (binding.maxTopics !== undefined && !seen.has(name) && seen.size >= binding.maxTopics) {
     throw new Error(`memory topic limit reached (${binding.maxTopics}) for this session`)
   }
   seen.add(name)

--- a/packages/daemon/src/mcp/ops/memory.ts
+++ b/packages/daemon/src/mcp/ops/memory.ts
@@ -89,9 +89,9 @@ function memoryScopeFor(ctx: SessionContext, deps: MemoryOpsDeps): MemoryScope {
 /** Provenance for a write made through the shared tool surface. The ordinary
  *  conversational case is `tool`; a distillation- or dream-bound session keeps its own
  *  source so the write ledger — and dream adoption's distill-only rebase — stay honest. */
-/** Topics a bound session has written, so `maxTopics` counts DISTINCT files rather than
- *  writes — appending to one topic repeatedly is not new content. It doubles as the
- *  provenance record a dream checks its staged store against. */
+/** Topics a bound session has SUCCESSFULLY written, so `maxTopics` counts DISTINCT files
+ *  rather than writes — appending to one topic repeatedly is not new content. It doubles
+ *  as the provenance record a dream checks its staged store against. */
 const boundTopics = new WeakMap<SessionContext, Set<string>>()
 
 /** Every topic this bound session wrote through the tool. A staged file that is NOT
@@ -106,19 +106,29 @@ export function boundWrittenTopics(ctx: SessionContext): string[] {
 function enforceBindingPolicy(ctx: SessionContext, path: string): void {
   const binding = ctx.memoryBinding
   if (!binding) return
-  const name = path.replace(/^.*\//, '')
+  const name = topicOf(path)
   if (binding.topicPattern && !binding.topicPattern.test(name)) {
     throw new Error(`invalid memory path: "${name}" must match ${String(binding.topicPattern)}`)
   }
-  let seen = boundTopics.get(ctx)
-  if (!seen) {
-    seen = new Set()
-    boundTopics.set(ctx, seen)
-  }
-  if (binding.maxTopics !== undefined && !seen.has(name) && seen.size >= binding.maxTopics) {
+  const seen = boundTopics.get(ctx)
+  if (binding.maxTopics !== undefined && !seen?.has(name) && (seen?.size ?? 0) >= binding.maxTopics) {
     throw new Error(`memory topic limit reached (${binding.maxTopics}) for this session`)
   }
-  seen.add(name)
+}
+
+/** Record the topic only once the write is DURABLE. A refused write — a subdirectory
+ *  path, an oversized body, a bad mode pair — must not vouch for that name, or a dream
+ *  could name a topic here and then smuggle its content in some other way. It also
+ *  keeps a rejected call from consuming a `maxTopics` slot. */
+function recordBoundTopic(ctx: SessionContext, path: string): void {
+  if (!ctx.memoryBinding) return
+  const seen = boundTopics.get(ctx) ?? new Set<string>()
+  seen.add(topicOf(path))
+  boundTopics.set(ctx, seen)
+}
+
+function topicOf(path: string): string {
+  return path.replace(/^.*\//, '')
 }
 
 function writeSource(ctx: SessionContext): MemoryWriteSource {
@@ -195,10 +205,14 @@ export async function writeMemory(
           'writeMemory: `oldString` occurs multiple times — include more surrounding context to make it unique'
         )
       const updated = current.replace(oldString, newString)
-      return await deps.memory.write(scope, path, updated, undefined, writeSource(ctx))
+      const edited = await deps.memory.write(scope, path, updated, undefined, writeSource(ctx))
+      recordBoundTopic(ctx, path)
+      return edited
     }
     const full = parseArgs(requiredStringAllowEmpty('content'), content)
-    return await deps.memory.write(scope, path, full, undefined, writeSource(ctx))
+    const written = await deps.memory.write(scope, path, full, undefined, writeSource(ctx))
+    recordBoundTopic(ctx, path)
+    return written
   } catch (err) {
     toToolError(err)
   }

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -112,26 +112,28 @@ class FakeStore implements DreamStorePort {
 // the model WROTE through the memory tools, so a fake extraction has to write too.
 const PROPOSAL = JSON.stringify({ agentSkills: [], organizationKnowledge: [], organizationSkills: [] })
 
-/** Stand in for the model writing its rebuilt store through the bound memory tools. */
+/** Stand in for the model writing its rebuilt store through the bound memory tools.
+ *  Returns the topics written, which is what the daemon reports as provenance. */
 async function writeStagedProposal(
   stagedStore: {
     writeFile(path: string, content: string, opts?: unknown): Promise<unknown>
     mkdir(p: string): Promise<unknown>
   },
   files: { path: string; content: string }[] = [{ path: 'prefs.md', content: '- Uses tabs, not spaces (2026-07-24).' }]
-): Promise<void> {
+): Promise<string[]> {
   await stagedStore.mkdir('memory')
   for (const file of files) {
     const content = file.content.endsWith('\n') ? file.content : `${file.content}\n`
     await stagedStore.writeFile(join('memory', file.path), content, {})
   }
+  return files.map((file) => file.path)
 }
 
 async function setup(opts: {
   /** Files the fake model writes into the staged store; `null` writes nothing. */
   stagedFiles?: { path: string; content: string }[] | null
   /** Write the staged store exactly as the bound memory tools would, instead. */
-  stagedWrite?: (stagedStore: MemoryFs) => Promise<void>
+  stagedWrite?: (stagedStore: MemoryFs) => Promise<string[]>
   extract?: (agentId: string, systemPrompt: string, prompt: string, signal: AbortSignal) => Promise<string>
   policy?: MemoryDreamingPolicy
   cancelGraceMs?: number
@@ -159,15 +161,17 @@ async function setup(opts: {
     store,
     extract: async (agentId, systemPrompt, prompt, signal, context) => {
       prompts.push({ systemPrompt, prompt, inputDir: context.inputDir })
+      const stage = async (): Promise<string[]> => {
+        if (opts.stagedWrite) return opts.stagedWrite(context.stagedStore)
+        if (opts.stagedFiles === null) return []
+        return writeStagedProposal(context.stagedStore, opts.stagedFiles)
+      }
       if (opts.extractionResult) {
-        if (opts.stagedWrite) await opts.stagedWrite(context.stagedStore)
-        else if (opts.stagedFiles !== null) await writeStagedProposal(context.stagedStore, opts.stagedFiles)
-        return opts.extractionResult
+        const memoryTopics = await stage()
+        return { memoryTopics, ...opts.extractionResult }
       }
       const output = opts.extract ? await opts.extract(agentId, systemPrompt, prompt, signal) : PROPOSAL
-      if (opts.stagedWrite) await opts.stagedWrite(context.stagedStore)
-      else if (opts.stagedFiles !== null) await writeStagedProposal(context.stagedStore, opts.stagedFiles)
-      return { output }
+      return { output, memoryTopics: await stage() }
     },
     ...(opts.onEvent ? { onEvent: opts.onEvent } : {}),
     ...(opts.onOrganizationSuggestions ? { onOrganizationSuggestions: opts.onOrganizationSuggestions } : {}),
@@ -299,6 +303,7 @@ describe('DreamRunner pipeline', () => {
           undefined,
           'dream'
         )
+        return ['deploys.md']
       }
     })
     const started = await runner.start('a1', { trigger: 'manual' })
@@ -326,6 +331,26 @@ describe('DreamRunner pipeline', () => {
     const done = await settle(store, started.dreamId)
     expect(done.status).toBe('failed')
     expect(done.error?.type).toBe('empty_proposal')
+    expect(await runner.stagedFiles('a1', started.dreamId)).toBeNull()
+    expect(await readMemoryFile(local(dir), 'prefs.md')).toContain('uses tabs')
+  })
+
+  it('fails a dream whose staged files the memory tools never wrote (found in a live E2E)', async () => {
+    // The runtime's own file tools can reach the staging directory — it is a sibling of
+    // the dream's cwd, and a real claude run in plan mode wrote there when the MCP bridge
+    // was down. Such a file skipped the name rule, the byte cap, and header stamping, so
+    // the proposal is refused rather than reviewed.
+    const { dir, store, runner } = await setup({
+      stagedWrite: async (stagedStore) => {
+        await writeMemoryFile(stagedStore, 'smuggled.md', 'written with the runtime file tool\n', undefined, 'dream')
+        return [] // ...and reported by nobody: no bound tool call happened
+      }
+    })
+    const started = await runner.start('a1', { trigger: 'manual' })
+    const done = await settle(store, started.dreamId)
+    expect(done.status).toBe('failed')
+    expect(done.error?.type).toBe('untrusted_staging')
+    expect(done.error?.message).toContain('smuggled.md')
     expect(await runner.stagedFiles('a1', started.dreamId)).toBeNull()
     expect(await readMemoryFile(local(dir), 'prefs.md')).toContain('uses tabs')
   })
@@ -517,8 +542,8 @@ describe('DreamRunner pipeline', () => {
       operationPolicy: 'test-only',
       store,
       extract: async (_agentId, _systemPrompt, _prompt, _signal, context) => {
-        await writeStagedProposal(context.stagedStore)
-        return { output: PROPOSAL }
+        const memoryTopics = await writeStagedProposal(context.stagedStore)
+        return { output: PROPOSAL, memoryTopics }
       },
       onStaged: async (agentId, dreamId) => {
         await runner.cancel(agentId, dreamId) // cancel after staging, before completion
@@ -695,8 +720,8 @@ describe('DreamRunner adoption', () => {
       extract: async (_agentId, _systemPrompt, _prompt, _signal, context) => {
         heldDuringExtraction = holds
         // The model writes its rebuilt store through the tools, on the pod's volume.
-        await writeStagedProposal(context.stagedStore)
-        return { output: PROPOSAL }
+        const memoryTopics = await writeStagedProposal(context.stagedStore)
+        return { output: PROPOSAL, memoryTopics }
       },
       log: silent
     })

--- a/packages/daemon/test/memory-write-gate.test.ts
+++ b/packages/daemon/test/memory-write-gate.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import { executeTool, type OpsDeps, type SessionContext } from '../src/mcp/ops.js'
+import { boundWrittenTopics } from '../src/mcp/ops/memory.js'
 import { MEMORY_ACCESS_BLOCKED } from '../src/memory/tools.js'
 
 const ctx = (): SessionContext => ({
@@ -229,6 +230,32 @@ describe('a dream-bound session writing its staged store', () => {
       /topic limit reached/
     )
     expect((d.memory.write as unknown as { mock: { calls: unknown[][] } }).mock.calls).toHaveLength(3)
+  })
+
+  it('reports the topics it wrote, which is what the dream stages against', async () => {
+    const d = deps(true)
+    const ctx = dreamCtx()
+    await executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'a' }, d)
+    await executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'a2' }, d)
+    expect(boundWrittenTopics(ctx)).toEqual(['one.md'])
+  })
+
+  it('does not let a REFUSED write vouch for its topic or spend a topic slot', async () => {
+    // The store rejects the write (a subdirectory path, an oversized body). The name must
+    // not enter the provenance record, or a dream could claim a topic through the tool and
+    // then put the actual bytes there with the runtime's own file tool.
+    const d = deps(true)
+    const ctx = dreamCtx()
+    ;(d.memory.write as unknown as { mockRejectedValueOnce(e: Error): void }).mockRejectedValueOnce(
+      new Error('memory is a flat directory')
+    )
+    await expect(executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'x' }, d)).rejects.toThrow()
+    expect(boundWrittenTopics(ctx)).toEqual([])
+
+    // ...and the refusal did not consume one of the two allowed topics.
+    await executeTool(ctx, 'writeMemory', { path: 'two.md', content: 'x' }, d)
+    await executeTool(ctx, 'writeMemory', { path: 'three.md', content: 'x' }, d)
+    expect(boundWrittenTopics(ctx).sort()).toEqual(['three.md', 'two.md'])
   })
 
   it('leaves an unbound turn unconstrained', async () => {


### PR DESCRIPTION
Found by running a real daemon end to end (local root, real `claude-acp` runtime, real MCP bridge, manual dream → review → adopt).

## The bug

The first E2E run had a dead MCP bridge (the shim entry pointed at a file plain `node` cannot execute). The dream session therefore got **no memory tools** — and instead of failing, the model searched for them, gave up, listed the filesystem, found the staging directory sitting next to its cwd, and wrote the topic files with the runtime's own `Write` tool. The dream completed, review looked normal, and adoption installed a live store from content that never went through the memory write path: no topic-name rule, no byte cap, no header normalize/stamp, no `.history` row.

Two things make this worse than a one-off:

- **Plan mode does not prevent it.** The dream's hard gate verifies a non-mutating permission mode and it was applied (the model's own reasoning mentions the plan-mode reminder), yet `Write` succeeded. The same run also wrote a plan file into the host user's `~/.claude/plans/` — outside the dream's tree entirely.
- **The sandbox cannot be the answer.** Dreams must run with and without one, so the pipeline has to verify what it stages rather than assume the model could not have written it.

Before #1298 this was structurally impossible: `stage()` wiped the directory and transcribed `proposal.files`, so a model-written file was deleted. Moving the store to tool writes removed that erasure, so the check has to be explicit.

## The fix

The bound memory tools already track the distinct topics a session writes (that is how `maxTopics` counts files rather than writes). Expose that record, report it from the dream extraction, and refuse at staging any staged file that is not in it — including the case where the extraction reports nothing at all, which is exactly the dead-bridge run. `MEMORY.md` is generated by the runner and excluded.

Fail-closed by construction: `memoryTopics` absent ⇒ nothing may be staged, so a future extraction seam that forgets to report provenance cannot silently disable the check.

## Verified

- New regression test reproduces the bypass (a staged file no bound call wrote ⇒ `failed` / `untrusted_staging`, staging dropped, live store intact).
- E2E with a working bridge: turn writes land as `source: tool` with stamped headers, the dream writes through `mcp__agentconnect__writeMemory`, staging generates the index, adopt installs it with `source: dream` history rows.
- E2E with the broken bridge again: no unverified store is staged or adopted (that run failed earlier still, at proposal parse, with staging cleared).
- daemon unit suite, typecheck, lint, and `pnpm --filter @agentconnect.md/daemon build` (the bundler catches re-exported bindings that `tsc` accepts).

The plan-mode / write-outside-the-tree behaviour is a separate finding; issue to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)