### PR TITLE
feat(web): give a daemon group and Cloud their own detail pages

### DIFF
--- a/packages/web/src/app/(app)/[slug]/daemons/groups/[id]/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/daemons/groups/[id]/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next'
+import GroupDetailView from '@/components/console/views/GroupDetailView'
+
+export const metadata: Metadata = { title: 'Daemon group · AgentConnect' }
+
+export default function Page() {
+  return <GroupDetailView />
+}

--- a/packages/web/src/components/console/FleetDetail.tsx
+++ b/packages/web/src/components/console/FleetDetail.tsx
@@ -40,13 +40,9 @@ export interface FleetRuntime {
   authRequired: boolean
 }
 
-/**
- * The runtimes a set offers, unioned over the members given (pass the serving ones).
- *
- * Version is the first non-empty one seen: the members of a set roll together, so they
- * agree, and quoting nothing is worse than quoting the release they share. `authRequired`
- * is sticky — one member whose probe was rejected is a real problem on that member.
- */
+// The runtimes a set offers, unioned over the members given (pass the serving ones). Version is
+// the first non-empty one seen — a set's members roll together, so they agree — and `authRequired`
+// is sticky, because one member whose probe was rejected is a real problem on that member.
 export function unionRuntimes(members: readonly DaemonRow[]): FleetRuntime[] {
   const byId = new Map<string, FleetRuntime>()
   for (const m of members) {
@@ -127,12 +123,9 @@ export function ResourceBar({
   )
 }
 
-/**
- * The runtimes a set offers, each disclosing its models.
- *
- * A real button, not the design's hover target: the model list is the only place a set's
- * models are readable, and a pointer is not the only input.
- */
+// The runtimes a set offers, each disclosing its models. A real button, not the design's hover
+// target: the model list is the only place a set's models are readable, and a pointer is not the
+// only input.
 export function FleetRuntimesCard({
   title,
   runtimes,

--- a/packages/web/src/components/console/FleetDetail.tsx
+++ b/packages/web/src/components/console/FleetDetail.tsx
@@ -1,0 +1,353 @@
+'use client'
+
+// The blocks a FLEET detail page is built from. Three screens in the console design read a
+// set of interchangeable daemons as one thing — the managed AgentConnect Cloud, a
+// self-hoster's own cluster (both `ClusterDetailView`) and one of the org's own groups
+// (`GroupDetailView`) — and they answer the same four questions: what does the set offer,
+// what runs on it, what does it hold, and what is true of it right now.
+//
+// So the answers live here once. A member of any of those sets is interchangeable by
+// definition, which is why every aggregate below is a union over the SERVING members: a
+// member that stopped answering can no longer offer a runtime or hold a connection.
+
+import { useState } from 'react'
+import {
+  agentLabel,
+  agentModelDisplay,
+  effectiveAgentStatus,
+  platName,
+  runtimeLabel,
+  status,
+  type Agent,
+  type DaemonRow,
+  type IntegrationRow,
+  type McpServerInfo
+} from '@/lib/data'
+import { AgentIconView, AgentMark, PlatformMark } from '@/components/marks'
+import { Icon } from '@/components/ui'
+import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
+
+/** Bar colour tracks the reading — one scale across Infra, cluster, group and daemon detail. */
+export function barColor(pct: number): string {
+  return pct >= 80 ? 'var(--status-paused)' : pct >= 60 ? 'var(--amber-500)' : 'var(--brand)'
+}
+
+/** A runtime as a whole SET offers it — the union over its serving members. */
+export interface FleetRuntime {
+  runtime: string
+  version: string
+  models: string[]
+  authRequired: boolean
+}
+
+/**
+ * The runtimes a set offers, unioned over the members given (pass the serving ones).
+ *
+ * Version is the first non-empty one seen: the members of a set roll together, so they
+ * agree, and quoting nothing is worse than quoting the release they share. `authRequired`
+ * is sticky — one member whose probe was rejected is a real problem on that member.
+ */
+export function unionRuntimes(members: readonly DaemonRow[]): FleetRuntime[] {
+  const byId = new Map<string, FleetRuntime>()
+  for (const m of members) {
+    for (const rt of m.runtimeModels) {
+      const prev = byId.get(rt.runtime)
+      if (!prev) {
+        byId.set(rt.runtime, {
+          runtime: rt.runtime,
+          version: rt.version,
+          models: [...rt.models],
+          authRequired: rt.authRequired === true
+        })
+        continue
+      }
+      if (!prev.version) prev.version = rt.version
+      for (const model of rt.models) if (!prev.models.includes(model)) prev.models.push(model)
+      prev.authRequired ||= rt.authRequired === true
+    }
+  }
+  return [...byId.values()]
+}
+
+/** The MCP servers a set offers, deduped by name over the members given. */
+export function unionMcpServers(members: readonly DaemonRow[]): McpServerInfo[] {
+  const byName = new Map<string, McpServerInfo>()
+  for (const m of members) for (const s of m.mcpServers) if (!byName.has(s.name)) byName.set(s.name, s)
+  return [...byName.values()]
+}
+
+/** One cell of a detail page's metric strip. */
+export function FleetStat({ icon, label, value, note }: { icon: string; label: string; value: string; note?: string }) {
+  return (
+    <div className="card stat">
+      <div className="statlbl">
+        <Icon name={icon} size={14} />
+        {label}
+      </div>
+      <div className="statval">{value}</div>
+      {note && <div className="mono mt-[3px] text-[11px] text-(--text-tertiary)">{note}</div>}
+    </div>
+  )
+}
+
+/** One label/value row of a Details or Routing card. */
+export function FleetFact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="row grid-cols-[1fr_auto]">
+      <span className="font-sans text-[13px] font-normal leading-normal text-(--text-tertiary)">{label}</span>
+      <span className="mono text-[12.5px]">{value}</span>
+    </div>
+  )
+}
+
+/** One labelled utilization bar (design: the fleet detail's `resources` rows). */
+export function ResourceBar({
+  label,
+  detail,
+  pct,
+  muted = false
+}: {
+  label: string
+  detail: string
+  pct: number
+  muted?: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-[6px]">
+      <div className="flex items-baseline gap-2">
+        <span className="flex-1 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+          {label}
+        </span>
+        <span className="mono text-[12.5px]">{detail}</span>
+      </div>
+      <span className="block h-[6px] overflow-hidden rounded-[3px] bg-(--surface-active)">
+        {!muted && <span className="block h-full" style={{ width: `${pct}%`, background: barColor(pct) }} />}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * The runtimes a set offers, each disclosing its models.
+ *
+ * A real button, not the design's hover target: the model list is the only place a set's
+ * models are readable, and a pointer is not the only input.
+ */
+export function FleetRuntimesCard({
+  title,
+  runtimes,
+  agents,
+  empty
+}: {
+  title: string
+  runtimes: readonly FleetRuntime[]
+  /** Agents placed on the set — a runtime's row says how many of them use it. */
+  agents: readonly Agent[]
+  empty: string
+}) {
+  const acpRegistry = useAcpRegistry()
+  // Independent disclosures — more than one runtime's models can be open at once, matching
+  // the daemon detail page's tap expansion.
+  const [open, setOpen] = useState<Set<string>>(new Set())
+  const toggle = (rid: string) =>
+    setOpen((prev) => {
+      const next = new Set(prev)
+      if (next.has(rid)) next.delete(rid)
+      else next.add(rid)
+      return next
+    })
+
+  return (
+    <div className="card mb-[18px]">
+      <div className="cardhead">
+        <span className="cardtitle">{title}</span>
+        <span className="ml-auto font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+          Open a runtime for its models
+        </span>
+      </div>
+      {runtimes.length > 0 ? (
+        runtimes.map((rt) => {
+          const meta = acpRuntime(acpRegistry, rt.runtime)
+          const label = runtimeLabel(rt.runtime, meta?.name)
+          // Id namespaces differ across daemon generations ('claude' vs 'claude-acp'),
+          // so agents match on the display family rather than the raw id.
+          const users = agents.filter((a) => a.runtime === rt.runtime || runtimeLabel(a.runtime) === label)
+          const hasModels = rt.models.length > 0
+          const shown = open.has(rt.runtime) && hasModels
+          return (
+            <div key={rt.runtime}>
+              <button
+                type="button"
+                aria-expanded={shown}
+                disabled={!hasModels}
+                onClick={() => toggle(rt.runtime)}
+                className="row grid w-full grid-cols-[1.4fr_.7fr_.9fr_.9fr_auto] gap-[14px] border-0 bg-transparent text-left enabled:cursor-pointer enabled:hover:bg-(--surface-hover)"
+              >
+                <span className="inline-flex min-w-0 items-center gap-[9px]">
+                  <span className="imark h-[22px] w-[22px]">
+                    <AgentMark model={rt.runtime} />
+                  </span>
+                  <span className="truncate font-sans text-[13px] font-semibold leading-normal">{label}</span>
+                  {rt.authRequired && (
+                    <span
+                      className="flex flex-none"
+                      title="A member's probe was rejected with 'authentication required' — sign in to the runtime on that machine."
+                    >
+                      <Icon name="triangle-alert" size={13} color="var(--amber-500)" />
+                    </span>
+                  )}
+                </span>
+                <span className="mono text-[12px] text-(--text-secondary)">
+                  {rt.version ? `v${rt.version.replace(/^v/, '')}` : '—'}
+                </span>
+                <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+                  {users.length > 0 ? `${users.length} agent${users.length === 1 ? '' : 's'}` : 'no agents'}
+                </span>
+                <span className="mono text-[12px] text-(--text-tertiary)">
+                  {rt.models.length} model{rt.models.length === 1 ? '' : 's'}
+                </span>
+                <Icon
+                  name={shown ? 'chevron-up' : 'chevron-down'}
+                  size={15}
+                  color="var(--text-tertiary)"
+                  className={hasModels ? '' : 'invisible'}
+                />
+              </button>
+              {shown && (
+                <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 py-[10px]">
+                  <div className="pb-1 font-sans text-[10px] font-semibold leading-normal tracking-[.05em] uppercase text-(--text-tertiary)">
+                    Models
+                  </div>
+                  {rt.models.map((m) => (
+                    <div key={m} className="mono truncate py-[3px] text-[11.5px]">
+                      {m}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })
+      ) : (
+        <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+          {empty}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * The agents placed on a set.
+ *
+ * No member stands in for one of them: whichever member holds a duty is interchangeable, so
+ * status comes from the placement (`effectiveAgentStatus` reads the set branch first) and the
+ * models a serving member reports name what the set can run.
+ */
+export function FleetAgentsCard({
+  title,
+  agents,
+  capabilitySource,
+  onOpen,
+  emptyTitle,
+  emptyHint
+}: {
+  title: string
+  agents: readonly Agent[]
+  /** One serving member, standing in for the set when reading what it can run. */
+  capabilitySource: DaemonRow | undefined
+  onOpen: (agentId: string) => void
+  emptyTitle: string
+  emptyHint: string
+}) {
+  return (
+    <div className="card">
+      <div className="cardhead">
+        <span className="cardtitle">{title}</span>
+      </div>
+      {agents.length > 0 ? (
+        agents.map((a) => {
+          const as = status(effectiveAgentStatus(a, undefined))
+          return (
+            <div key={a.id} className="row click grid-cols-[auto_1.6fr_1fr_auto] gap-3" onClick={() => onOpen(a.id)}>
+              <span className="av h-7 w-7 rounded-[7px]">
+                <AgentIconView icon={a.icon} runtime={a.runtime} size={28} />
+              </span>
+              <span className="min-w-0 truncate font-sans text-[13px] font-semibold leading-normal">
+                {agentLabel(a)}
+              </span>
+              <span className="min-w-0 truncate font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+                {agentModelDisplay(capabilitySource, a.runtime, a.model)}
+              </span>
+              <span className="badge" style={{ background: as.bg, color: as.text }}>
+                <span className="dot h-[6px] w-[6px]" style={{ background: as.dot }} />
+                {as.label}
+              </span>
+            </div>
+          )
+        })
+      ) : (
+        <div className="px-4 py-7 text-center">
+          <div className="font-sans text-[13px] font-medium leading-normal text-(--text-secondary)">{emptyTitle}</div>
+          <div className="mt-[3px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+            {emptyHint}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** The platform connections a set holds — an integration is held wherever its agent runs. */
+export function FleetConnectionsCard({
+  title,
+  conns,
+  empty
+}: {
+  title: string
+  conns: readonly IntegrationRow[]
+  empty: string
+}) {
+  return (
+    <div className="card">
+      <div className="cardhead">
+        <span className="cardtitle">{title}</span>
+      </div>
+      {conns.length > 0 ? (
+        conns.map((c) => {
+          const cs = status(c.status)
+          return (
+            <div key={c.id ?? c.name} className="row grid-cols-[auto_1.6fr_1fr_auto] gap-3">
+              <span className="imark h-6 w-6">
+                <PlatformMark platform={c.platform} fillPct={100} />
+              </span>
+              <span className="min-w-0">
+                <span className="block truncate font-sans text-[13px] font-semibold leading-normal">{c.name}</span>
+                <span className="mono block truncate text-[11px] text-(--text-tertiary)">
+                  {c.workspace || platName(c.platform)}
+                </span>
+              </span>
+              <span className="mono min-w-0 truncate text-[12px] text-(--text-secondary)">
+                {c.channels.length} channel{c.channels.length === 1 ? '' : 's'}
+              </span>
+              <span className="badge" style={{ background: cs.bg, color: cs.text }}>
+                <span className="dot h-[6px] w-[6px]" style={{ background: cs.dot }} />
+                {cs.label}
+              </span>
+            </div>
+          )
+        })
+      ) : (
+        <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+          {empty}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** The connections a set holds: an integration is held wherever its owning agent runs. */
+export function connsHeldBy(agents: readonly Agent[], integrations: readonly IntegrationRow[]): IntegrationRow[] {
+  const ids = new Set(agents.map((a) => a.id))
+  return integrations.filter((i) => i.agentId !== undefined && ids.has(i.agentId))
+}

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -333,7 +333,8 @@ function ShellChromeInner({ children }: { children: ReactNode }) {
   const params = useParams<{ slug?: string }>()
   const { orgPath, orgs, activeOrg, setActiveOrg } = useOrgs()
   const { openModal } = useModal()
-  const { daemons, agents, crons, allSessions, sessionAccessSnapshot, usageAccessSnapshot } = useConsoleData()
+  const { daemons, agents, crons, allSessions, memberSets, sessionAccessSnapshot, usageAccessSnapshot } =
+    useConsoleData()
   useDaemonNotifier(daemons)
   useSessionAccessNotifier({ sessionAccessSnapshot, usageAccessSnapshot, orgPath })
   // Mobile-only chrome state: which bottom sheet is open, and the full-screen search.
@@ -565,8 +566,14 @@ function ShellChromeInner({ children }: { children: ReactNode }) {
       const agent = agents.find((a) => a.id === id)
       return agent ? agentLabel(agent) : undefined
     }
-    // `cluster` is the pool's own page, not a daemon id — no member id survives a rollout.
-    if (section === 'daemons') return id === 'cluster' ? poolLabel() : daemons.find((d) => d.daemonId === id)?.name
+    if (section === 'daemons') {
+      // `cluster` is the pool's own page, not a daemon id — no member id survives a rollout —
+      // and `groups/<setId>` is a placement target rather than a machine, so neither resolves
+      // against the daemon list.
+      if (id === 'cluster') return poolLabel()
+      if (id === 'groups') return memberSets.find((g) => g.setId === seg[2])?.name
+      return daemons.find((d) => d.daemonId === id)?.name
+    }
     if (section === 'sessions') return allSessions.find((s) => s.id === id)?.title
     if (section === 'crons') return crons.find((c) => c.id === id)?.name
     return undefined

--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   agents: [] as unknown[],
   integrations: [] as unknown[],
   daemonsLoading: false,
+  balance: { data: { orgId: 'org-pool', balanceMicro: 12_340_000 } } as Record<string, unknown>,
   push: vi.fn()
 }))
 
@@ -33,7 +34,7 @@ vi.mock('@/lib/data-context', () => ({
 }))
 vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
 // Only the managed reading fetches anything (the balance); no test should reach the network for it.
-vi.mock('swr', () => ({ default: () => ({ data: { orgId: 'org-pool', balanceMicro: 12_340_000 } }) }))
+vi.mock('swr', () => ({ default: () => mocks.balance }))
 
 const ClusterDetailView = (await import('./ClusterDetailView')).default
 
@@ -114,6 +115,7 @@ beforeEach(() => {
   mocks.agents = []
   mocks.integrations = []
   mocks.daemonsLoading = false
+  mocks.balance = { data: { orgId: 'org-pool', balanceMicro: 12_340_000 } }
   mocks.push.mockClear()
   setFlags('daemon-pool')
 })
@@ -338,6 +340,19 @@ describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
     expect(html).toContain('acme-ops')
     expect(html).toContain('2 models')
     expect(html).toContain('Runtimes available')
+  })
+
+  it('lets the billing failure say which failure it was', () => {
+    // A shape mismatch throws BillingShapeError into the same slot as an unreachable service, and
+    // this console deploys ahead of the pinned billing image — so blaming the network guesses.
+    mocks.daemons = [member('p1')]
+    mocks.balance = { error: new Error('billing sent an unexpected account — the console may be out of date') }
+
+    const html = render()
+
+    expect(html).toContain('Balance unavailable')
+    expect(html).toContain('may be out of date')
+    expect(html).not.toContain('Could not reach')
   })
 
   it('says where Cloud usage is billed, and where it is not', () => {

--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -32,6 +32,8 @@ vi.mock('@/lib/data-context', () => ({
   })
 }))
 vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
+// Only the managed reading fetches anything (the balance); no test should reach the network for it.
+vi.mock('swr', () => ({ default: () => ({ data: { orgId: 'org-pool', balanceMicro: 12_340_000 } }) }))
 
 const ClusterDetailView = (await import('./ClusterDetailView')).default
 
@@ -262,5 +264,88 @@ describe('ClusterDetailView', () => {
     const html = render()
 
     expect(html).not.toContain('No cluster connected')
+  })
+})
+
+/**
+ * The SAME page on the managed install, where the pool is AgentConnect Cloud — a product the
+ * org buys rather than infrastructure it runs. Node count, host names, versions and CPU are
+ * the operator's business, so the Cloud reading drops them and answers what the org can act
+ * on instead: what runs there, what it can run, what it holds, and what it costs.
+ */
+describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
+  beforeEach(() => setFlags('daemon-pool,managed,billing'))
+
+  it('names Cloud and keeps its topology to itself', () => {
+    mocks.daemons = [member('p1'), member('p2', { status: 'offline' })]
+
+    const html = render()
+
+    expect(html).toContain('AgentConnect Cloud')
+    expect(html).toContain('Managed by AgentConnect')
+    // Everything a self-hoster is shown about their own cluster is Cloud's internals.
+    expect(html).not.toContain('nodes serving')
+    expect(html).not.toContain('Agent ceiling')
+    expect(html).not.toContain('Sandbox capacity')
+    expect(html).not.toContain('pool-member-p1')
+  })
+
+  it('quotes the prepaid balance, not an invented plan quota', () => {
+    mocks.daemons = [member('p1')]
+
+    const html = render()
+
+    expect(html).toContain('Billing')
+    expect(html).toContain('$12.34')
+    expect(html).toContain('Manage billing')
+    // A plan's included usage is not derivable from load telemetry, so no bar pretends it is.
+    expect(html).not.toContain('included')
+  })
+
+  it('offers no billing surface where the deployment has none', () => {
+    setFlags('daemon-pool,managed')
+    mocks.daemons = [member('p1')]
+
+    const html = render()
+
+    expect(html).toContain('AgentConnect Cloud')
+    expect(html).not.toContain('Manage billing')
+    expect(html).not.toContain('prepaid balance')
+  })
+
+  it('still lists the runtimes, agents and connections Cloud offers', () => {
+    mocks.daemons = [
+      member('p1', {
+        runtimeModels: [{ runtime: 'claude', version: '0.54.1', models: ['opus', 'sonnet'], acpProtocolVersion: 1 }]
+      })
+    ] as unknown[]
+    mocks.agents = [onPool('a1')]
+    mocks.integrations = [
+      {
+        id: 'i1',
+        agentId: 'a1',
+        name: 'acme-ops',
+        platform: 'slack',
+        workspace: 'acme.slack.com',
+        status: 'online',
+        channels: [{ channelId: 'C1', name: 'deploys', trigger: 'mention' }]
+      }
+    ]
+
+    const html = render()
+
+    expect(html).toContain('Agents on Cloud')
+    expect(html).toContain('acme-ops')
+    expect(html).toContain('2 models')
+    expect(html).toContain('Runtimes available')
+  })
+
+  it('says where Cloud usage is billed, and where it is not', () => {
+    mocks.daemons = [member('p1')]
+
+    const html = render()
+
+    expect(html).toContain('billed to this organization')
+    expect(html).toContain('never billed here')
   })
 })

--- a/packages/web/src/components/console/views/ClusterDetailView.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.tsx
@@ -1,112 +1,75 @@
 'use client'
 
-// Cluster detail — the self-hosted pool read as ONE thing (design: the Cloud/cluster
-// detail screen, `cd.isCluster`). A pool member is a Pod: no member id survives a
-// rollout, so opening the Infra card must not land on one machine's page and call it
-// the cluster. Everything here aggregates the serving members.
+// The pool's own detail page, in both of its readings (design: the Cloud / cluster detail
+// screen, `cd.isCloud` and `cd.isCluster`).
 //
-// The design's mint/rotate-token action and its log tail are deliberately absent: the
-// console mints no cluster credentials, and inventing a log stream would be
+// A pool member is a Pod: no member id survives a rollout, so opening the Infra entry must
+// not land on one machine's page and call it the pool. Everything here aggregates the
+// serving members.
+//
+// Which reading applies is not cosmetic — it is whose infrastructure this IS:
+//
+//   managed   → AgentConnect Cloud, a product the org buys. Node count, host names,
+//               versions and CPU are the operator's business, not the reader's, so the page
+//               shows what the org can act on: what runs there, what it can run, what it
+//               holds, and what it costs.
+//   self-host → the operator's OWN cluster. Now the topology IS theirs, so capacity and
+//               utilization are the numbers worth quoting and nothing is billed here.
+//
+// The design's mint/rotate-token action and its log tail are deliberately absent in both:
+// the console mints no pool credentials, and inventing a log stream would be
 // indistinguishable from real telemetry (same call the daemon detail page made).
 
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useRouter } from 'next/navigation'
-import {
-  agentLabel,
-  agentModelDisplay,
-  effectiveAgentStatus,
-  isPoolPlacementKind,
-  platName,
-  poolFleetStatus,
-  poolLabel,
-  runtimeLabel,
-  status,
-  type DaemonRow,
-  type McpServerInfo
-} from '@/lib/data'
+import useSWR from 'swr'
+import { isPoolPlacementKind, poolFleetStatus, poolLabel, status, type DaemonRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
+import { consoleKeys } from '@/lib/swr-keys'
+import { fetchBillingAccount, fmtMicroUsd } from '@/lib/billing-api'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { NotFound } from '@/components/console/NotFound'
-import { AgentIconView, AgentMark, LoadingState, PlatformMark } from '@/components/marks'
-import { Icon } from '@/components/ui'
+import {
+  FleetAgentsCard,
+  FleetConnectionsCard,
+  FleetFact,
+  FleetRuntimesCard,
+  FleetStat,
+  ResourceBar,
+  connsHeldBy,
+  unionMcpServers,
+  unionRuntimes
+} from '@/components/console/FleetDetail'
+import { LoadingState } from '@/components/marks'
+import { Button, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
-import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
-
-// Bar colour tracks the reading, matching the Infra list and the daemon detail page.
-function barColor(pct: number): string {
-  return pct >= 80 ? 'var(--status-paused)' : pct >= 60 ? 'var(--amber-500)' : 'var(--brand)'
-}
-
-/** A runtime as the whole cluster offers it — the union over its serving members. */
-interface ClusterRuntime {
-  runtime: string
-  version: string
-  models: string[]
-  authRequired: boolean
-}
 
 export default function ClusterDetailView() {
-  const acpRegistry = useAcpRegistry()
   const { orgPath } = useOrgs()
   const router = useRouter()
   const { daemons, agents, integrations, orgSetIds, daemonsLoading } = useConsoleData()
-  // Independent disclosures — more than one runtime's models can be open at once, matching
-  // the daemon detail page's tap expansion.
-  const [openRuntimes, setOpenRuntimes] = useState<Set<string>>(new Set())
-  const toggleRuntime = (rid: string) =>
-    setOpenRuntimes((prev) => {
-      const next = new Set(prev)
-      if (next.has(rid)) next.delete(rid)
-      else next.add(rid)
-      return next
-    })
 
   const showPool = featureFlagEnabled('daemon-pool')
+  // Whose infrastructure the pool IS decides how the page reads — see the file header.
+  const managed = featureFlagEnabled('managed')
+  // Cloud's one honest action and its one honest figure both live on the Billing page, so
+  // neither is offered where this deployment does not have one.
+  const billingOffered = managed && featureFlagEnabled('billing')
   const members = useMemo(() => (showPool ? daemons.filter((d) => d.pool) : []), [daemons, showPool])
   const serving = useMemo(() => members.filter((m) => m.status === 'online'), [members])
   // Pool agents carry the POOL sentinel, never a member id: the Pod holding the duty is
   // ephemeral, so `agentFromDto` maps a set placement to `daemon: POOL_PLACEMENT`. Matching
-  // member ids here would report an empty cluster however many agents run on it.
+  // member ids here would report an empty pool however many agents run on it.
   const hosted = useMemo(
     () => agents.filter((a) => isPoolPlacementKind(a.placementKind, a.setId, orgSetIds)),
     [agents, orgSetIds]
   )
 
-  // The runtimes the cluster offers: a member that stopped answering can no longer serve
-  // one, so the union is over the serving members only.
-  const runtimes = useMemo<ClusterRuntime[]>(() => {
-    const byId = new Map<string, ClusterRuntime>()
-    for (const m of serving) {
-      for (const rt of m.runtimeModels) {
-        const prev = byId.get(rt.runtime)
-        if (!prev) {
-          byId.set(rt.runtime, {
-            runtime: rt.runtime,
-            version: rt.version,
-            models: [...rt.models],
-            authRequired: rt.authRequired === true
-          })
-          continue
-        }
-        if (!prev.version) prev.version = rt.version
-        for (const model of rt.models) if (!prev.models.includes(model)) prev.models.push(model)
-        prev.authRequired ||= rt.authRequired === true
-      }
-    }
-    return [...byId.values()]
-  }, [serving])
-
-  const mcpServers = useMemo<McpServerInfo[]>(() => {
-    const byName = new Map<string, McpServerInfo>()
-    for (const m of serving) for (const s of m.mcpServers) if (!byName.has(s.name)) byName.set(s.name, s)
-    return [...byName.values()]
-  }, [serving])
-
-  // The connections the cluster holds: an integration is held wherever its agent runs.
-  const conns = useMemo(() => {
-    const hostedIds = new Set(hosted.map((a) => a.id))
-    return integrations.filter((i) => i.agentId !== undefined && hostedIds.has(i.agentId))
-  }, [hosted, integrations])
+  // A member that stopped answering can no longer serve a runtime or hold a connection, so
+  // both unions are over the serving members only.
+  const runtimes = useMemo(() => unionRuntimes(serving), [serving])
+  const mcpServers = useMemo(() => unionMcpServers(serving), [serving])
+  const conns = useMemo(() => connsHeldBy(hosted, integrations), [hosted, integrations])
 
   if (members.length === 0) {
     if (daemonsLoading)
@@ -119,9 +82,13 @@ export default function ClusterDetailView() {
       <div className="wrap max-w-[1240px]">
         <NotFound
           icon="server-off"
-          kind="CLUSTER"
-          title="No cluster connected"
-          pre="No pool member has registered with this control plane. Install the daemon runtime on a cluster and it appears here."
+          kind={managed ? 'CLOUD' : 'CLUSTER'}
+          title={managed ? 'Cloud is not available here' : 'No cluster connected'}
+          pre={
+            managed
+              ? 'No Cloud capacity has registered with this control plane yet. Place your agents on a daemon you connected in the meantime.'
+              : 'No pool member has registered with this control plane. Install the daemon runtime on a cluster and it appears here.'
+          }
           actionLabel="Back to daemons"
           actionHref={orgPath('/daemons')}
           searchLabel="Search daemons"
@@ -146,37 +113,26 @@ export default function ClusterDetailView() {
   const cpu = avg((m) => m.cpu)
   const mem = avg((m) => m.mem)
   const sessions = serving.reduce((sum, m) => sum + Number(m.activeSessions ?? 0), 0)
-  // The serving members roll together, so they share a release; an idle cluster has no
+  // The serving members roll together, so they share a release; an idle pool has no
   // version worth quoting rather than one belonging to a Pod that is gone.
   const version = online ? serving[0]!.version : '—'
   // One serving member stands in for the set when reading what it can run — the same
   // substitution Add-agent and Edit-agent make (edit-agent-daemon-choice.ts).
   const capabilitySource = serving[0]
-
-  const labeled = (label: string, value: string) => (
-    <div className="row grid-cols-[1fr_auto]">
-      <span className="font-sans text-[13px] font-normal leading-normal text-(--text-tertiary)">{label}</span>
-      <span className="mono text-[12.5px]">{value}</span>
-    </div>
-  )
-
-  const stat = (icon: string, label: string, value: string) => (
-    <div className="card stat">
-      <div className="statlbl">
-        <Icon name={icon} size={14} />
-        {label}
-      </div>
-      <div className="statval">{value}</div>
-    </div>
-  )
+  const models = runtimes.reduce((sum, rt) => sum + rt.models.length, 0)
 
   return (
     <div className="wrap max-w-[1240px] px-4 pt-[14px] pb-1 desktop:p-0">
-      {/* header — no action button: a self-hoster's cluster credentials are minted on the
-          cluster, never here, so there is nothing for this page to offer. */}
+      {/* header — no credential action in either reading: pool credentials are minted where
+          the pool runs, never here, so there is nothing for this page to offer. Cloud does
+          get the one action it can honestly own, which is where its usage is paid for. */}
       <div className="mb-5 flex items-start gap-4">
-        <span className="relative flex h-13 w-13 flex-none items-center justify-center rounded-lg border border-(--border-subtle) bg-(--surface-sunken)">
-          <Icon name="boxes" size={26} color={online ? 'var(--brand)' : 'var(--text-tertiary)'} />
+        <span
+          className={`relative flex h-13 w-13 flex-none items-center justify-center rounded-lg ${
+            managed ? 'bg-(--brand-soft)' : 'border border-(--border-subtle) bg-(--surface-sunken)'
+          }`}
+        >
+          <Icon name={managed ? 'cloud' : 'boxes'} size={26} color={online ? 'var(--brand)' : 'var(--text-tertiary)'} />
           <span
             className="dot absolute -right-1 -bottom-1 h-[14px] w-[14px] border-[2.5px] border-(--surface-app)"
             style={{ background: s.dot }}
@@ -191,253 +147,217 @@ export default function ClusterDetailView() {
             </span>
           </div>
           <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2">
-            <span className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-              <Icon name="server" size={14} color="var(--text-tertiary)" />
-              {online ? `${serving.length} node${serving.length === 1 ? '' : 's'} serving` : 'no nodes serving'}
-            </span>
-            <span className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-              <Icon name="tag" size={14} color="var(--text-tertiary)" />
-              <span className="mono text-[12px]">{version}</span>
-            </span>
-            <span className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-              <Icon name="layers" size={14} color="var(--text-tertiary)" />
-              Runs your agents on your own cluster
-            </span>
+            {managed ? (
+              <>
+                <MetaItem icon="cloud" text="Managed by AgentConnect" />
+                <MetaItem icon="layers" text="Runs your agents on AgentConnect's infrastructure" />
+              </>
+            ) : (
+              <>
+                <MetaItem
+                  icon="server"
+                  text={
+                    online ? `${serving.length} node${serving.length === 1 ? '' : 's'} serving` : 'no nodes serving'
+                  }
+                />
+                <MetaItem icon="tag" mono text={version} />
+                <MetaItem icon="layers" text="Runs your agents on your own cluster" />
+              </>
+            )}
           </div>
         </div>
+        {billingOffered && (
+          <Button variant="secondary" size="sm" onClick={() => router.push(orgPath('/billing'))}>
+            Manage billing
+          </Button>
+        )}
       </div>
 
       {/* metric strip */}
       <div className="mb-[18px] grid grid-cols-2 gap-[14px] desktop:grid-cols-4">
-        {stat('bot', 'Agents on cluster', String(hosted.length))}
-        {stat('server', 'Nodes serving', `${serving.length} / ${members.length}`)}
-        {stat('layers', 'Sandbox capacity', capacityLabel)}
-        {stat('activity', 'Active sessions', String(sessions))}
+        {managed ? (
+          <>
+            <FleetStat icon="bot" label="Agents on Cloud" value={String(hosted.length)} />
+            <FleetStat icon="plug" label="Connections held" value={String(conns.length)} />
+            <FleetStat icon="activity" label="Active sessions" value={String(sessions)} />
+            <FleetStat
+              icon="cpu"
+              label="Runtimes available"
+              value={String(runtimes.length)}
+              note={`${models} model${models === 1 ? '' : 's'}`}
+            />
+          </>
+        ) : (
+          <>
+            <FleetStat icon="bot" label="Agents on cluster" value={String(hosted.length)} />
+            <FleetStat icon="server" label="Nodes serving" value={`${serving.length} / ${members.length}`} />
+            <FleetStat icon="layers" label="Sandbox capacity" value={capacityLabel} />
+            <FleetStat icon="activity" label="Active sessions" value={String(sessions)} />
+          </>
+        )}
       </div>
 
-      <div className="mb-[18px] grid grid-cols-1 items-start gap-[18px] desktop:grid-cols-[1.15fr_1fr]">
-        {/* capacity + utilization, the numbers the cluster's own members report */}
-        <div className="card">
-          <div className="cardhead">
-            <span className="cardtitle">Capacity</span>
-            <span className="mono ml-auto text-[11px] text-(--text-tertiary)">across serving nodes</span>
-          </div>
-          <div className="flex flex-col gap-[14px] px-4 py-[15px]">
-            <ResourceBar
-              label="Sandbox capacity in use"
-              detail={capacityLabel}
-              pct={capacityPct}
-              // An unbounded cluster has no fraction to fill: the track stays empty rather
-              // than drawing a 0% that reads as a measurement.
-              muted={unbounded}
-            />
-            <ResourceBar label="CPU" detail={`${cpu}%`} pct={cpu} />
-            <ResourceBar label="Memory" detail={`${mem}%`} pct={mem} />
-          </div>
-        </div>
+      <div
+        className={`mb-[18px] grid grid-cols-1 items-start gap-[18px] ${
+          managed && !billingOffered ? '' : 'desktop:grid-cols-[1.15fr_1fr]'
+        }`}
+      >
+        {/* Cloud quotes what its usage costs; a cluster quotes the capacity its own members
+            report. Neither borrows the other's figure — a plan's included usage cannot be
+            derived from load telemetry, and a self-hoster is billed nothing here. */}
+        {managed ? (
+          billingOffered && <CloudBillingCard />
+        ) : (
+          <ClusterCapacityCard {...{ capacityLabel, capacityPct, unbounded, cpu, mem }} />
+        )}
 
         <div className="card">
           <div className="cardhead">
             <span className="cardtitle">Details</span>
           </div>
           <div className="py-[6px]">
-            {labeled('Nodes', `${serving.length} serving of ${members.length}`)}
-            {labeled('Status', s.label)}
-            {labeled('Version', version)}
-            {labeled('Agent ceiling', unbounded ? 'unbounded' : String(capacity))}
-            {labeled('Placement', 'pool')}
-            {labeled('MCP servers', String(mcpServers.length))}
+            {managed ? (
+              <>
+                <FleetFact label="Status" value={s.label} />
+                <FleetFact label="Operated by" value="AgentConnect" />
+                <FleetFact label="Placement" value="pool" />
+                <FleetFact label="Runtimes" value={String(runtimes.length)} />
+                <FleetFact label="MCP servers" value={String(mcpServers.length)} />
+              </>
+            ) : (
+              <>
+                <FleetFact label="Nodes" value={`${serving.length} serving of ${members.length}`} />
+                <FleetFact label="Status" value={s.label} />
+                <FleetFact label="Version" value={version} />
+                <FleetFact label="Agent ceiling" value={unbounded ? 'unbounded' : String(capacity)} />
+                <FleetFact label="Placement" value="pool" />
+                <FleetFact label="MCP servers" value={String(mcpServers.length)} />
+              </>
+            )}
           </div>
         </div>
       </div>
 
-      {/* runtimes the cluster offers */}
-      <div className="card mb-[18px]">
-        <div className="cardhead">
-          <span className="cardtitle">Runtimes</span>
-          <span className="ml-auto font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-            Open a runtime for its models
-          </span>
-        </div>
-        {runtimes.length > 0 ? (
-          runtimes.map((rt) => {
-            const meta = acpRuntime(acpRegistry, rt.runtime)
-            const label = runtimeLabel(rt.runtime, meta?.name)
-            // Id namespaces differ across daemon generations ('claude' vs 'claude-acp'),
-            // so agents match on the display family rather than the raw id.
-            const users = hosted.filter((a) => a.runtime === rt.runtime || runtimeLabel(a.runtime) === label)
-            const hasModels = rt.models.length > 0
-            const open = openRuntimes.has(rt.runtime) && hasModels
-            return (
-              <div key={rt.runtime}>
-                {/* A real button, not a hover target: the model list is the only place the
-                    cluster's models are readable, and a pointer is not the only input. */}
-                <button
-                  type="button"
-                  aria-expanded={open}
-                  disabled={!hasModels}
-                  onClick={() => toggleRuntime(rt.runtime)}
-                  className="row grid w-full grid-cols-[1.4fr_.7fr_.9fr_.9fr_auto] gap-[14px] border-0 bg-transparent text-left enabled:cursor-pointer enabled:hover:bg-(--surface-hover)"
-                >
-                  <span className="inline-flex min-w-0 items-center gap-[9px]">
-                    <span className="imark h-[22px] w-[22px]">
-                      <AgentMark model={rt.runtime} />
-                    </span>
-                    <span className="truncate font-sans text-[13px] font-semibold leading-normal">{label}</span>
-                    {rt.authRequired && (
-                      <span
-                        className="flex flex-none"
-                        title="A node's probe was rejected with 'authentication required' — sign in to the runtime on that node."
-                      >
-                        <Icon name="triangle-alert" size={13} color="var(--amber-500)" />
-                      </span>
-                    )}
-                  </span>
-                  <span className="mono text-[12px] text-(--text-secondary)">
-                    {rt.version ? `v${rt.version.replace(/^v/, '')}` : '—'}
-                  </span>
-                  <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
-                    {users.length > 0 ? `${users.length} agent${users.length === 1 ? '' : 's'}` : 'no agents'}
-                  </span>
-                  <span className="mono text-[12px] text-(--text-tertiary)">
-                    {rt.models.length} model{rt.models.length === 1 ? '' : 's'}
-                  </span>
-                  <Icon
-                    name={open ? 'chevron-up' : 'chevron-down'}
-                    size={15}
-                    color="var(--text-tertiary)"
-                    className={hasModels ? '' : 'invisible'}
-                  />
-                </button>
-                {open && (
-                  <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 py-[10px]">
-                    <div className="pb-1 font-sans text-[10px] font-semibold tracking-[.05em] uppercase leading-normal text-(--text-tertiary)">
-                      Models
-                    </div>
-                    {rt.models.map((m) => (
-                      <div key={m} className="mono truncate py-[3px] text-[11.5px]">
-                        {m}
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )
-          })
-        ) : (
-          <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-            No runtimes reported — no node has advertised its runtime profiles yet.
-          </div>
-        )}
-      </div>
+      <FleetRuntimesCard
+        title="Runtimes"
+        runtimes={runtimes}
+        agents={hosted}
+        empty={
+          managed
+            ? 'No runtimes reported — Cloud has not advertised its runtime profiles yet.'
+            : 'No runtimes reported — no node has advertised its runtime profiles yet.'
+        }
+      />
 
       <div className="grid grid-cols-1 items-start gap-[18px] desktop:grid-cols-2">
-        <div className="card">
-          <div className="cardhead">
-            <span className="cardtitle">Agents on this cluster</span>
-          </div>
-          {hosted.length > 0 ? (
-            hosted.map((a) => {
-              // No member stands for the pool's agents individually — the Pod holding a duty
-              // is ephemeral. Status comes from the placement (effectiveAgentStatus reads the
-              // pool branch first), and the models a serving member reports name the cluster's.
-              const as = status(effectiveAgentStatus(a, undefined))
-              return (
-                <div
-                  key={a.id}
-                  className="row click grid-cols-[auto_1.6fr_1fr_auto] gap-3"
-                  onClick={() => router.push(orgPath(`/agents/${a.id}`))}
-                >
-                  <span className="av h-7 w-7 rounded-[7px]">
-                    <AgentIconView icon={a.icon} runtime={a.runtime} size={28} />
-                  </span>
-                  <span className="min-w-0 truncate font-sans text-[13px] font-semibold leading-normal">
-                    {agentLabel(a)}
-                  </span>
-                  <span className="min-w-0 truncate font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
-                    {agentModelDisplay(capabilitySource, a.runtime, a.model)}
-                  </span>
-                  <span className="badge" style={{ background: as.bg, color: as.text }}>
-                    <span className="dot h-[6px] w-[6px]" style={{ background: as.dot }} />
-                    {as.label}
-                  </span>
-                </div>
-              )
-            })
-          ) : (
-            <div className="px-4 py-7 text-center">
-              <div className="font-sans text-[13px] font-medium leading-normal text-(--text-secondary)">
-                No agents run here yet
-              </div>
-              <div className="mt-[3px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                Place an agent on {poolLabel()} to start handling messages.
-              </div>
-            </div>
-          )}
-        </div>
+        <FleetAgentsCard
+          title={managed ? 'Agents on Cloud' : 'Agents on this cluster'}
+          agents={hosted}
+          capabilitySource={capabilitySource}
+          onOpen={(id) => router.push(orgPath(`/agents/${id}`))}
+          emptyTitle="No agents run here yet"
+          emptyHint={`Place an agent on ${poolLabel()} to start handling messages.`}
+        />
+        <FleetConnectionsCard
+          title="Connections held here"
+          conns={conns}
+          empty={
+            managed ? 'No integration tokens are held on Cloud.' : 'No integration tokens are held on this cluster.'
+          }
+        />
+      </div>
 
-        <div className="card">
-          <div className="cardhead">
-            <span className="cardtitle">Connections held here</span>
+      {managed && (
+        <p className="mt-[14px] max-w-[780px] font-sans text-[12px] font-normal leading-[1.6] text-(--text-tertiary) text-pretty">
+          Cloud usage is billed to this organization&rsquo;s balance. Agents on daemons you connected yourself use the
+          credentials on those machines and are never billed here.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function MetaItem({ icon, text, mono = false }: { icon: string; text: string; mono?: boolean }) {
+  return (
+    <span className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+      <Icon name={icon} size={14} color="var(--text-tertiary)" />
+      {mono ? <span className="mono text-[12px]">{text}</span> : text}
+    </span>
+  )
+}
+
+/**
+ * What Cloud costs, on the one figure the billing service will actually stand behind.
+ *
+ * NOT the design's "included usage" bar: this deployment sells prepaid credit, so there is no
+ * plan quota to fill a track with, and drawing one from load telemetry would read as a real
+ * ceiling. The balance is a settled fact, so it is what shows — and it shares SWR's cache key
+ * with the Billing page, so opening this page costs no extra request there.
+ */
+function CloudBillingCard() {
+  const { activeOrg } = useOrgs()
+  const orgId = activeOrg?.id ?? null
+  const account = useSWR(orgId ? consoleKeys.billingAccount(orgId) : null, () => fetchBillingAccount(orgId!))
+
+  return (
+    <div className="card">
+      <div className="cardhead">
+        <span className="cardtitle">Billing</span>
+        <span className="mono ml-auto text-[11px] text-(--text-tertiary)">prepaid balance</span>
+      </div>
+      <div className="px-4 py-[15px]">
+        {account.error ? (
+          <div className="flex items-start gap-2 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary)">
+            <Icon name="triangle-alert" size={15} color="var(--status-error)" />
+            Could not reach the billing service.
           </div>
-          {conns.length > 0 ? (
-            conns.map((c) => {
-              const cs = status(c.status)
-              return (
-                <div key={c.id ?? c.name} className="row grid-cols-[auto_1.6fr_1fr_auto] gap-3">
-                  <span className="imark h-6 w-6">
-                    <PlatformMark platform={c.platform} fillPct={100} />
-                  </span>
-                  <span className="min-w-0">
-                    <span className="block truncate font-sans text-[13px] font-semibold leading-normal">{c.name}</span>
-                    <span className="mono block truncate text-[11px] text-(--text-tertiary)">
-                      {c.workspace || platName(c.platform)}
-                    </span>
-                  </span>
-                  <span className="mono min-w-0 truncate text-[12px] text-(--text-secondary)">
-                    {c.channels.length} channel{c.channels.length === 1 ? '' : 's'}
-                  </span>
-                  <span className="badge" style={{ background: cs.bg, color: cs.text }}>
-                    <span className="dot h-[6px] w-[6px]" style={{ background: cs.dot }} />
-                    {cs.label}
-                  </span>
-                </div>
-              )
-            })
-          ) : (
-            <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-              No integration tokens are held on this cluster.
-            </div>
-          )}
-        </div>
+        ) : account.data ? (
+          <>
+            <div className="mono text-[22px] leading-none font-semibold">{fmtMicroUsd(account.data.balanceMicro)}</div>
+            <p className="mt-[10px] font-sans text-[12.5px] font-normal leading-[1.6] text-(--text-secondary)">
+              Sessions that run on Cloud draw down this balance. Top it up on the Billing page.
+            </p>
+          </>
+        ) : (
+          <div className="mono text-[22px] leading-none font-semibold text-(--text-tertiary)">—</div>
+        )}
       </div>
     </div>
   )
 }
 
-/** One labelled utilization bar (design: the cluster detail's `cd.resources` rows). */
-function ResourceBar({
-  label,
-  detail,
-  pct,
-  muted = false
+/** The capacity a self-hoster's own members report — the numbers only they can act on. */
+function ClusterCapacityCard({
+  capacityLabel,
+  capacityPct,
+  unbounded,
+  cpu,
+  mem
 }: {
-  label: string
-  detail: string
-  pct: number
-  muted?: boolean
+  capacityLabel: string
+  capacityPct: number
+  unbounded: boolean
+  cpu: number
+  mem: number
 }) {
   return (
-    <div className="flex flex-col gap-[6px]">
-      <div className="flex items-baseline gap-2">
-        <span className="flex-1 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-          {label}
-        </span>
-        <span className="mono text-[12.5px]">{detail}</span>
+    <div className="card">
+      <div className="cardhead">
+        <span className="cardtitle">Capacity</span>
+        <span className="mono ml-auto text-[11px] text-(--text-tertiary)">across serving nodes</span>
       </div>
-      <span className="block h-[6px] overflow-hidden rounded-[3px] bg-(--surface-active)">
-        {!muted && <span className="block h-full" style={{ width: `${pct}%`, background: barColor(pct) }} />}
-      </span>
+      <div className="flex flex-col gap-[14px] px-4 py-[15px]">
+        <ResourceBar
+          label="Sandbox capacity in use"
+          detail={capacityLabel}
+          pct={capacityPct}
+          // An unbounded cluster has no fraction to fill: the track stays empty rather
+          // than drawing a 0% that reads as a measurement.
+          muted={unbounded}
+        />
+        <ResourceBar label="CPU" detail={`${cpu}%`} pct={cpu} />
+        <ResourceBar label="Memory" detail={`${mem}%`} pct={mem} />
+      </div>
     </div>
   )
 }

--- a/packages/web/src/components/console/views/ClusterDetailView.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.tsx
@@ -286,14 +286,9 @@ function MetaItem({ icon, text, mono = false }: { icon: string; text: string; mo
   )
 }
 
-/**
- * What Cloud costs, on the one figure the billing service will actually stand behind.
- *
- * NOT the design's "included usage" bar: this deployment sells prepaid credit, so there is no
- * plan quota to fill a track with, and drawing one from load telemetry would read as a real
- * ceiling. The balance is a settled fact, so it is what shows — and it shares SWR's cache key
- * with the Billing page, so opening this page costs no extra request there.
- */
+// What Cloud costs, on the one figure billing stands behind. NOT the design's "included usage"
+// bar: this deployment sells prepaid credit, so there is no quota to fill a track with and
+// drawing one from load telemetry would read as a real ceiling. Shares the Billing page's SWR key.
 function CloudBillingCard() {
   const { activeOrg } = useOrgs()
   const orgId = activeOrg?.id ?? null
@@ -307,9 +302,12 @@ function CloudBillingCard() {
       </div>
       <div className="px-4 py-[15px]">
         {account.error ? (
+          // Not only unreachability: `assertAccount` throws BillingShapeError on an unexpected
+          // shape and lands here too — likely, since this console deploys ahead of the pinned
+          // billing image. So the label stays neutral and the service's own message says which.
           <div className="flex items-start gap-2 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary)">
             <Icon name="triangle-alert" size={15} color="var(--status-error)" />
-            Could not reach the billing service.
+            Balance unavailable — {(account.error as Error).message}
           </div>
         ) : account.data ? (
           <>

--- a/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
@@ -159,7 +159,7 @@ describe('DaemonsView pool', () => {
     expect(html).not.toContain('Delete')
   })
 
-  it('opens a serving member for the runtimes the pool offers', () => {
+  it('opens Cloud’s own page, never a member’s — no member id survives a rollout', () => {
     mocks.daemons = [member('dead', { status: 'offline' }), member('serving')]
 
     const host = document.createElement('div')
@@ -174,7 +174,7 @@ describe('DaemonsView pool', () => {
     act(() => root.unmount())
     host.remove()
 
-    expect(mocks.push).toHaveBeenCalledWith('/acme/daemons/serving')
+    expect(mocks.push).toHaveBeenCalledWith('/acme/daemons/cluster')
   })
 
   it('still shows the empty state when there is no daemon of any kind', () => {

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -201,6 +201,8 @@ const GROUP_COLS = 'grid-cols-[2.2fr_.9fr_1.9fr_.55fr_32px] gap-x-[14px]'
 
 function GroupRow({ group, daemons }: { group: MemberSetRow; daemons: DaemonRow[] }) {
   const { openModal } = useModal()
+  const { orgPath } = useOrgs()
+  const router = useRouter()
   const [menuOpen, setMenuOpen] = useState(false)
   const s = status(groupFleetStatus(group, daemons))
   const members = daemons.filter((d) => group.memberDaemonIds.includes(d.daemonId))
@@ -215,7 +217,10 @@ function GroupRow({ group, daemons }: { group: MemberSetRow; daemons: DaemonRow[
         : `${members.length} daemons · ${serving} serving`
 
   return (
-    <div className={`row click ${GROUP_COLS}`} onClick={() => openModal('group', group)}>
+    // The row opens the group's own page, not the editor: what a reader wants from a group is
+    // what runs on it and which members are serving, and renaming it is the rarer of the two.
+    // The editor stays one click away, in the row menu and on that page.
+    <div className={`row click ${GROUP_COLS}`} onClick={() => router.push(orgPath(`/daemons/groups/${group.setId}`))}>
       <div className="flex min-w-0 items-center gap-[10px]">
         <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-subtle) bg-(--surface-sunken)">
           <Icon name="layers" size={15} color={serving > 0 ? 'var(--brand)' : 'var(--text-tertiary)'} />
@@ -295,14 +300,15 @@ function PoolFleetCard({ members, hosted }: { members: DaemonRow[]; hosted: numb
   const online = serving.length > 0
   // Node count and version stay internal — the cloud pool doesn't expose its topology.
   const meta = online ? 'Managed by AgentConnect' : 'Managed by AgentConnect · not serving'
-  // Opens one member's detail for the runtimes, models and MCP servers the pool offers —
-  // a serving one, since a member that stopped answering can no longer describe itself.
-  const target = serving[0] ?? members[members.length - 1]!
+  // Opens CLOUD's own page, never a member's: no member id survives a rollout, so landing on
+  // one machine would name the pool after a Pod that is already gone. That page is where the
+  // runtimes, models and connections Cloud offers are read.
+  const open = () => router.push(orgPath('/daemons/cluster'))
 
   return (
     <div
       className="card click flex items-center gap-3 overflow-visible p-[14px] max-desktop:rounded-lg desktop:gap-[14px] desktop:px-4 desktop:py-[15px]"
-      onClick={() => router.push(orgPath(`/daemons/${target.daemonId}`))}
+      onClick={open}
     >
       <span className="relative flex h-10 w-10 flex-none items-center justify-center rounded-md bg-(--brand-soft) desktop:h-9 desktop:w-9">
         <Icon name="cloud" size={20} color={online ? 'var(--brand)' : 'var(--text-tertiary)'} />

--- a/packages/web/src/components/console/views/GroupDetailView.test.tsx
+++ b/packages/web/src/components/console/views/GroupDetailView.test.tsx
@@ -1,0 +1,316 @@
+// @vitest-environment happy-dom
+/**
+ * A daemon group has its own page because it is a placement TARGET, not a machine — and the
+ * whole risk of the page is that it starts reading like whichever member happened to answer.
+ * So these tests pin the two rules: every aggregate is over the members that are SERVING, and
+ * the group itself never borrows a member's host, version or uptime.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent, DaemonRow, MemberSetRow } from '@/lib/data'
+
+const mocks = vi.hoisted(() => ({
+  daemons: [] as unknown[],
+  agents: [] as unknown[],
+  integrations: [] as unknown[],
+  memberSets: [] as unknown[],
+  memberSetsLoading: false,
+  routeId: 'g1',
+  push: vi.fn(),
+  openModal: vi.fn()
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.push }),
+  useParams: () => ({ id: mocks.routeId })
+}))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, myRole: 'owner', orgPath: (p: string) => `/acme${p}` })
+}))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    daemons: mocks.daemons,
+    agents: mocks.agents,
+    integrations: mocks.integrations,
+    memberSets: mocks.memberSets,
+    memberSetsLoading: mocks.memberSetsLoading
+  })
+}))
+vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: mocks.openModal }) }))
+vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
+
+const GroupDetailView = (await import('./GroupDetailView')).default
+
+function daemon(id: string, over: Partial<DaemonRow> = {}): DaemonRow {
+  return {
+    daemonId: id,
+    pool: false,
+    memberSetId: null,
+    name: id,
+    version: '1.41.0',
+    latestVersion: '1.41.0',
+    releaseChannel: 'latest',
+    upgradeAvailable: false,
+    availableVersions: [],
+    lifecycleOp: null,
+    lifecycleStatus: null,
+    canManageLifecycle: true,
+    status: 'online',
+    host: `${id}.internal`,
+    cpu: 20,
+    mem: 40,
+    loadAgents: 0,
+    caps: { platforms: [], runtimes: [], acp: true, features: [] },
+    runtimeModels: [],
+    mcpServers: [],
+    activeSessions: '0',
+    conns: '8',
+    uptime: '1m',
+    createdBy: '',
+    createdAt: '',
+    lastModifiedBy: '',
+    lastModifiedAt: '',
+    sessionRetention: '7d',
+    visibility: 'org',
+    sharedWith: [],
+    canEdit: true,
+    canManageSharing: true,
+    ...over
+  } as DaemonRow
+}
+
+const group = (over: Partial<MemberSetRow> = {}): MemberSetRow => ({
+  setId: 'g1',
+  name: 'build-farm',
+  memberDaemonIds: [],
+  agentCount: 0,
+  ...over
+})
+
+/** An agent placed on the GROUP: kind `set` plus the group's own set id — never a member id,
+ *  because whichever member holds the duty is interchangeable. */
+const onGroup = (id: string, setId = 'g1', over: Partial<Agent> = {}): Agent =>
+  ({
+    id,
+    daemon: 'pool',
+    placementKind: 'set',
+    setId,
+    placementReady: true,
+    name: id,
+    status: 'online',
+    runtime: 'claude',
+    model: 'opus',
+    ...over
+  }) as Agent
+
+/** An agent PINNED to one machine — it does not move with the group and is not on it. */
+const pinned = (id: string, daemonId: string, over: Partial<Agent> = {}): Agent =>
+  ({
+    id,
+    daemon: daemonId,
+    placementKind: 'daemon',
+    setId: null,
+    name: id,
+    status: 'online',
+    runtime: 'claude',
+    model: 'opus',
+    ...over
+  }) as Agent
+
+function render(): string {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root: Root = createRoot(host)
+  act(() => {
+    root.render(<GroupDetailView />)
+  })
+  const html = host.innerHTML
+  act(() => root.unmount())
+  host.remove()
+  return html
+}
+
+const setFlags = (value: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: value }
+}
+
+beforeEach(() => {
+  mocks.daemons = []
+  mocks.agents = []
+  mocks.integrations = []
+  mocks.memberSets = []
+  mocks.memberSetsLoading = false
+  mocks.routeId = 'g1'
+  mocks.push.mockClear()
+  mocks.openModal.mockClear()
+  setFlags('daemon-groups')
+})
+
+describe('GroupDetailView', () => {
+  it('names the group and its members, and reads them as one fleet', () => {
+    mocks.memberSets = [group({ memberDaemonIds: ['d1', 'd2'] })]
+    mocks.daemons = [daemon('d1'), daemon('d2', { status: 'offline' })]
+
+    const html = render()
+
+    expect(html).toContain('build-farm')
+    expect(html).toContain('Any daemon in the group')
+    expect(html).toContain('2 daemons')
+    // Serving is what routes work, so it is what the strip counts.
+    expect(html).toContain('1 / 2')
+  })
+
+  it('is online while ANY member is serving', () => {
+    mocks.memberSets = [group({ memberDaemonIds: ['d1', 'd2'] })]
+    mocks.daemons = [daemon('d1', { status: 'offline' }), daemon('d2')]
+
+    // One serving member is what routes work, so it is what makes the group online.
+    expect(render()).toContain('1 serving of 2')
+
+    mocks.daemons = [daemon('d1', { status: 'offline' }), daemon('d2', { status: 'offline' })]
+
+    const dark = render()
+    expect(dark).toContain('0 serving of 2')
+    // Nothing on the page is green once no member answers — the group's own badge included.
+    expect(dark).not.toContain('var(--status-online)')
+  })
+
+  it('never borrows a member’s host, version or uptime for the group itself', () => {
+    mocks.memberSets = [group({ memberDaemonIds: ['d1'] })]
+    mocks.daemons = [daemon('d1', { host: 'builder.internal', version: '9.9.9', uptime: '31d' })]
+
+    const html = render()
+
+    // A group has no machine identity of its own — showing one is the bug this page avoids.
+    expect(html).not.toContain('builder.internal')
+    expect(html).not.toContain('9.9.9')
+    expect(html).not.toContain('31d')
+  })
+
+  it('counts the agents placed on the GROUP, not the ones pinned to its members', () => {
+    mocks.memberSets = [group({ memberDaemonIds: ['d1'] })]
+    mocks.daemons = [daemon('d1')]
+    mocks.agents = [onGroup('a1'), onGroup('elsewhere', 'g2'), pinned('a3', 'd1')]
+
+    const html = render()
+
+    expect(html).toContain('Agents on this group')
+    expect(html).toContain('>a1<')
+    // A group placement naming another set is not this group's.
+    expect(html).not.toContain('>elsewhere<')
+    // A pinned agent stays pinned — it is reported against its member, not the group.
+    expect(html).not.toContain('>a3<')
+  })
+
+  it('unions the runtimes over the SERVING members only', () => {
+    mocks.memberSets = [group({ memberDaemonIds: ['d1', 'd2'] })]
+    mocks.daemons = [
+      daemon('d1', {
+        runtimeModels: [{ runtime: 'claude', version: '0.54.1', models: ['opus'], acpProtocolVersion: 1 }]
+      }),
+      daemon('d2', {
+        status: 'offline',
+        runtimeModels: [{ runtime: 'codex', version: '1.0.0', models: ['gpt-5'], acpProtocolVersion: 1 }]
+      })
+    ] as unknown[]
+    mocks.agents = [onGroup('a1')]
+
+    const html = render()
+
+    expect(html).toContain('Runtimes across the group')
+    expect(html).toContain('v0.54.1')
+    // A member that stopped answering can no longer offer a runtime.
+    expect(html).not.toContain('v1.0.0')
+    expect(html).toContain('1 agent')
+  })
+
+  it('lists the connections the group’s agents hold', () => {
+    mocks.memberSets = [group({ memberDaemonIds: ['d1'] })]
+    mocks.daemons = [daemon('d1')]
+    mocks.agents = [onGroup('a1')]
+    mocks.integrations = [
+      {
+        id: 'i1',
+        agentId: 'a1',
+        name: 'acme-ops',
+        platform: 'slack',
+        workspace: 'acme.slack.com',
+        status: 'online',
+        channels: [{ channelId: 'C1', name: 'deploys', trigger: 'mention' }]
+      },
+      {
+        id: 'i2',
+        agentId: 'other',
+        name: 'not-ours',
+        platform: 'slack',
+        workspace: 'x',
+        status: 'online',
+        channels: []
+      }
+    ]
+
+    const html = render()
+
+    expect(html).toContain('acme-ops')
+    expect(html).toContain('1 channel')
+    expect(html).not.toContain('not-ours')
+  })
+
+  it('opens a member’s own page, because that is where a machine’s detail lives', () => {
+    mocks.memberSets = [group({ memberDaemonIds: ['d1'] })]
+    mocks.daemons = [daemon('d1')]
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root: Root = createRoot(host)
+    act(() => {
+      root.render(<GroupDetailView />)
+    })
+    act(() => {
+      host.querySelector<HTMLElement>('.row.click')?.click()
+    })
+    act(() => root.unmount())
+    host.remove()
+
+    expect(mocks.push).toHaveBeenCalledWith('/acme/daemons/d1')
+  })
+
+  it('says how to populate an empty group instead of showing an empty table', () => {
+    mocks.memberSets = [group()]
+
+    const html = render()
+
+    expect(html).toContain('No daemons in this group')
+    expect(html).toContain('0 / 0')
+  })
+
+  it('offers no log tail — a fabricated one is indistinguishable from telemetry', () => {
+    mocks.memberSets = [group({ memberDaemonIds: ['d1'] })]
+    mocks.daemons = [daemon('d1')]
+
+    expect(render()).not.toContain('tail · local time')
+  })
+
+  it('404s on a set id this org does not own, and waits while the list loads', () => {
+    mocks.routeId = 'nope'
+    mocks.memberSets = [group()]
+
+    expect(render()).toContain('Group not found')
+
+    mocks.memberSetsLoading = true
+
+    expect(render()).not.toContain('Group not found')
+  })
+
+  it('is not reachable where the deployment did not ask for groups', () => {
+    setFlags('')
+    mocks.memberSets = [group({ memberDaemonIds: ['d1'] })]
+    mocks.daemons = [daemon('d1')]
+
+    const html = render()
+
+    expect(html).toContain('Group not found')
+    expect(html).not.toContain('build-farm')
+  })
+})

--- a/packages/web/src/components/console/views/GroupDetailView.test.tsx
+++ b/packages/web/src/components/console/views/GroupDetailView.test.tsx
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   integrations: [] as unknown[],
   memberSets: [] as unknown[],
   memberSetsLoading: false,
+  daemonsLoading: false,
+  agentsLoading: false,
   routeId: 'g1',
   push: vi.fn(),
   openModal: vi.fn()
@@ -34,7 +36,9 @@ vi.mock('@/lib/data-context', () => ({
     agents: mocks.agents,
     integrations: mocks.integrations,
     memberSets: mocks.memberSets,
-    memberSetsLoading: mocks.memberSetsLoading
+    memberSetsLoading: mocks.memberSetsLoading,
+    daemonsLoading: mocks.daemonsLoading,
+    agentsLoading: mocks.agentsLoading
   })
 }))
 vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: mocks.openModal }) }))
@@ -141,6 +145,8 @@ beforeEach(() => {
   mocks.integrations = []
   mocks.memberSets = []
   mocks.memberSetsLoading = false
+  mocks.daemonsLoading = false
+  mocks.agentsLoading = false
   mocks.routeId = 'g1'
   mocks.push.mockClear()
   mocks.openModal.mockClear()
@@ -283,6 +289,37 @@ describe('GroupDetailView', () => {
 
     expect(html).toContain('No daemons in this group')
     expect(html).toContain('0 / 0')
+  })
+
+  it('waits for the membership rather than calling a found group empty', () => {
+    // `memberSets` is the smallest of three independent SWR keys, so a deep link resolves the
+    // group's NAME a round trip before its members. Answering there is a confident wrong answer.
+    mocks.memberSets = [group({ memberDaemonIds: ['d1'] })]
+    mocks.daemonsLoading = true
+
+    const html = render()
+
+    expect(html).not.toContain('No daemons in this group')
+    expect(html).not.toContain('0 / 0')
+
+    mocks.daemonsLoading = false
+    mocks.agentsLoading = true
+
+    expect(render()).not.toContain('No agents target this group yet')
+  })
+
+  it('names the sessions stat for what the CP actually counts', () => {
+    // activeSessions is per-DAEMON, so it includes the sessions of agents pinned to a member —
+    // the agents every other stat on the page excludes.
+    mocks.memberSets = [group({ memberDaemonIds: ['d1'] })]
+    mocks.daemons = [daemon('d1', { activeSessions: '4' })]
+    mocks.agents = [onGroup('a1'), pinned('a2', 'd1')]
+
+    const html = render()
+
+    expect(html).toContain('Sessions on members')
+    expect(html).toContain('incl. pinned agents')
+    expect(html).not.toContain('Active sessions')
   })
 
   it('offers no log tail — a fabricated one is indistinguishable from telemetry', () => {

--- a/packages/web/src/components/console/views/GroupDetailView.tsx
+++ b/packages/web/src/components/console/views/GroupDetailView.tsx
@@ -39,7 +39,8 @@ export default function GroupDetailView() {
   const { orgPath } = useOrgs()
   const { id } = useParams<{ id: string }>()
   const router = useRouter()
-  const { daemons, agents, integrations, memberSets, memberSetsLoading } = useConsoleData()
+  const { daemons, agents, agentsLoading, daemonsLoading, integrations, memberSets, memberSetsLoading } =
+    useConsoleData()
   const { openModal } = useModal()
 
   const group = useMemo(() => memberSets.find((g) => g.setId === id), [memberSets, id])
@@ -89,6 +90,17 @@ export default function GroupDetailView() {
       </div>
     )
   }
+
+  // Found, but not yet describable. `memberSets`, `daemons` and `agents` are independent SWR
+  // keys and the group's is by far the smallest payload, so a deep link resolves the NAME a round
+  // trip before the membership. Rendering there would state "0 / 0 serving · no daemons · no
+  // runtimes · no agents" as settled fact and then correct itself, which is worse than waiting.
+  if (daemonsLoading || agentsLoading)
+    return (
+      <div className="wrap max-w-[1240px]">
+        <LoadingState fill />
+      </div>
+    )
 
   const s = status(groupFleetStatus(group, daemons))
   const online = serving.length > 0
@@ -151,14 +163,19 @@ export default function GroupDetailView() {
         />
         <FleetStat icon="bot" label="Agents on group" value={String(hosted.length)} />
         <FleetStat icon="plug" label="Connections held" value={String(conns.length)} />
-        <FleetStat icon="activity" label="Active sessions" value={String(sessions)} />
+        {/* Machine-scoped, unlike its three neighbours: the CP counts active sessions per DAEMON,
+            so this includes the ones belonging to agents pinned to these members — the agents the
+            rest of the page deliberately excludes. Named for what it actually counts. */}
+        <FleetStat icon="activity" label="Sessions on members" value={String(sessions)} note="incl. pinned agents" />
       </div>
 
       <div className="mb-[18px] grid grid-cols-1 items-start gap-[18px] desktop:grid-cols-[1.15fr_1fr]">
         <div className="card">
           <div className="cardhead">
             <span className="cardtitle">Daemons in this group</span>
-            <span className="mono ml-auto text-[11px] text-(--text-tertiary)">cpu / memory · pinned</span>
+            <span className="mono ml-auto text-[11px] text-(--text-tertiary)">
+              <span className="hidden desktop:inline">cpu / memory · </span>pinned
+            </span>
           </div>
           {members.length > 0 ? (
             members.map((m) => (
@@ -258,8 +275,7 @@ function MemberRow({ m, pinned, onOpen }: { m: DaemonRow; pinned: number; onOpen
   )
 }
 
-/** A member's CPU or memory reading. Clamped: a daemon predating the cpu-normalization fix
- *  reports a raw load average, which would otherwise render as e.g. "722%". */
+/** A member's CPU or memory. Clamped — a daemon predating cpu-normalization reports a raw load average. */
 function MemberBar({ pct }: { pct: number }) {
   const shown = Math.max(0, Math.min(100, Math.round(pct)))
   return (

--- a/packages/web/src/components/console/views/GroupDetailView.tsx
+++ b/packages/web/src/components/console/views/GroupDetailView.tsx
@@ -1,0 +1,273 @@
+'use client'
+
+// One of the organization's OWN daemon groups, read as a placement target (design: the
+// group/pool detail screen, `gd.*`; daemon-groups.md §2).
+//
+// A group is not a machine and this page never lets it borrow one's telemetry: it has no
+// host, no version, no uptime and no CPU of its own, and the moment it shows those it starts
+// reading like whichever member happened to answer. What it DOES have is a membership, and
+// everything on the page is either a fact about that set or an aggregate over the members
+// that are actually serving — because a member that stopped answering can neither offer a
+// runtime nor hold a connection.
+//
+// The design's pool log tail is absent for the same reason it is absent on the cluster page:
+// inventing a log stream would be indistinguishable from real telemetry.
+
+import { useMemo } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { groupFleetStatus, isSetPlacementKind, status, type DaemonRow } from '@/lib/data'
+import { useConsoleData } from '@/lib/data-context'
+import { featureFlagEnabled } from '@/lib/feature-flags'
+import { useModal } from '@/components/console/ModalProvider'
+import { NotFound } from '@/components/console/NotFound'
+import {
+  FleetAgentsCard,
+  FleetConnectionsCard,
+  FleetFact,
+  FleetRuntimesCard,
+  FleetStat,
+  barColor,
+  connsHeldBy,
+  unionMcpServers,
+  unionRuntimes
+} from '@/components/console/FleetDetail'
+import { LoadingState } from '@/components/marks'
+import { Button, Icon } from '@/components/ui'
+import { useOrgs } from '@/lib/org-context'
+
+export default function GroupDetailView() {
+  const { orgPath } = useOrgs()
+  const { id } = useParams<{ id: string }>()
+  const router = useRouter()
+  const { daemons, agents, integrations, memberSets, memberSetsLoading } = useConsoleData()
+  const { openModal } = useModal()
+
+  const group = useMemo(() => memberSets.find((g) => g.setId === id), [memberSets, id])
+  const members = useMemo(
+    () => (group ? daemons.filter((d) => group.memberDaemonIds.includes(d.daemonId)) : []),
+    [daemons, group]
+  )
+  const serving = useMemo(() => members.filter((m) => m.status === 'online'), [members])
+  // A group placement carries the set id and no member id — whichever member holds the duty
+  // is interchangeable, so matching member ids would report an empty group however many
+  // agents are placed on it.
+  const hosted = useMemo(
+    () => (group ? agents.filter((a) => isSetPlacementKind(a.placementKind) && a.setId === group.setId) : []),
+    [agents, group]
+  )
+  const runtimes = useMemo(() => unionRuntimes(serving), [serving])
+  const mcpServers = useMemo(() => unionMcpServers(serving), [serving])
+  const conns = useMemo(() => connsHeldBy(hosted, integrations), [hosted, integrations])
+  // Agents PINNED to a member, per member. They are not the group's — a pinned agent names one
+  // machine and stays there — but they are why a member's load is what it is.
+  const pinnedByDaemon = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const a of agents) if (!isSetPlacementKind(a.placementKind)) map.set(a.daemon, (map.get(a.daemon) ?? 0) + 1)
+    return map
+  }, [agents])
+
+  // Flagged for the same reason the Infra section is: the Control Plane serves member sets
+  // either way, so this hides the console entry point, not the feature.
+  if (!featureFlagEnabled('daemon-groups') || !group) {
+    if (memberSetsLoading && featureFlagEnabled('daemon-groups'))
+      return (
+        <div className="wrap max-w-[1240px]">
+          <LoadingState fill />
+        </div>
+      )
+    return (
+      <div className="wrap max-w-[1240px]">
+        <NotFound
+          icon="server-off"
+          kind="GROUP"
+          title="Group not found"
+          pre="No daemon group with this id belongs to this organization. It may have been removed, or it belongs to another org."
+          actionLabel="Back to daemons"
+          actionHref={orgPath('/daemons')}
+          searchLabel="Search daemons"
+        />
+      </div>
+    )
+  }
+
+  const s = status(groupFleetStatus(group, daemons))
+  const online = serving.length > 0
+  const sessions = serving.reduce((sum, m) => sum + Number(m.activeSessions ?? 0), 0)
+  // One serving member stands in for the set when reading what it can run — the same
+  // substitution Add-agent and Edit-agent make (edit-agent-daemon-choice.ts).
+  const capabilitySource = serving[0]
+  // Names the members while the list still fits, because "which machines is this" is the
+  // question a group answers that a count cannot.
+  const memberList =
+    members.length === 0
+      ? 'no daemons yet'
+      : members.length <= 3
+        ? members.map((m) => m.name).join(', ')
+        : `${members.length} daemons`
+
+  return (
+    <div className="wrap max-w-[1240px] px-4 pt-[14px] pb-1 desktop:p-0">
+      <div className="mb-5 flex items-start gap-4">
+        <span className="relative flex h-13 w-13 flex-none items-center justify-center rounded-lg border border-(--border-subtle) bg-(--surface-sunken)">
+          <Icon name="layers" size={26} color={online ? 'var(--brand)' : 'var(--text-tertiary)'} />
+          <span
+            className="dot absolute -right-1 -bottom-1 h-[14px] w-[14px] border-[2.5px] border-(--surface-app)"
+            style={{ background: s.dot }}
+          />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-[10px]">
+            <h1 className="ptitle mono">{group.name}</h1>
+            <span className="badge" style={{ background: s.bg, color: s.text }}>
+              <span className="dot h-[6px] w-[6px]" style={{ background: s.dot }} />
+              {s.label}
+            </span>
+            <span className="badge bg-(--surface-active) text-(--text-secondary)">
+              {members.length} daemon{members.length === 1 ? '' : 's'}
+            </span>
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2">
+            <span className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+              <Icon name="shuffle" size={14} color="var(--text-tertiary)" />
+              Any daemon in the group
+            </span>
+            <span className="inline-flex min-w-0 items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+              <Icon name="server" size={14} color="var(--text-tertiary)" />
+              <span className="mono truncate text-[12px]">{memberList}</span>
+            </span>
+          </div>
+        </div>
+        <Button variant="secondary" size="sm" onClick={() => openModal('group', group)}>
+          Edit group
+        </Button>
+      </div>
+
+      <div className="mb-[18px] grid grid-cols-2 gap-[14px] desktop:grid-cols-4">
+        <FleetStat
+          icon="server"
+          label="Daemons serving"
+          value={`${serving.length} / ${members.length}`}
+          note={members.length === 0 ? 'no members yet' : undefined}
+        />
+        <FleetStat icon="bot" label="Agents on group" value={String(hosted.length)} />
+        <FleetStat icon="plug" label="Connections held" value={String(conns.length)} />
+        <FleetStat icon="activity" label="Active sessions" value={String(sessions)} />
+      </div>
+
+      <div className="mb-[18px] grid grid-cols-1 items-start gap-[18px] desktop:grid-cols-[1.15fr_1fr]">
+        <div className="card">
+          <div className="cardhead">
+            <span className="cardtitle">Daemons in this group</span>
+            <span className="mono ml-auto text-[11px] text-(--text-tertiary)">cpu / memory · pinned</span>
+          </div>
+          {members.length > 0 ? (
+            members.map((m) => (
+              <MemberRow
+                key={m.daemonId}
+                m={m}
+                pinned={pinnedByDaemon.get(m.daemonId) ?? 0}
+                onOpen={() => router.push(orgPath(`/daemons/${m.daemonId}`))}
+              />
+            ))
+          ) : (
+            <div className="px-4 py-7 text-center">
+              <div className="font-sans text-[13px] font-medium leading-normal text-(--text-secondary)">
+                No daemons in this group
+              </div>
+              <div className="mt-[3px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                A daemon joins from its own page — membership is admitted on the machine whose runtime authority moves.
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="card">
+          <div className="cardhead">
+            <span className="cardtitle">Routing</span>
+          </div>
+          <div className="py-[6px]">
+            <FleetFact label="Strategy" value="any member serving" />
+            <FleetFact label="Members" value={`${serving.length} serving of ${members.length}`} />
+            <FleetFact label="Status" value={s.label} />
+            <FleetFact label="Placement" value="group" />
+            <FleetFact label="Runtimes" value={String(runtimes.length)} />
+            <FleetFact label="MCP servers" value={String(mcpServers.length)} />
+          </div>
+        </div>
+      </div>
+
+      <FleetRuntimesCard
+        title="Runtimes across the group"
+        runtimes={runtimes}
+        agents={hosted}
+        empty={
+          members.length === 0
+            ? 'No runtimes — the group has no members yet.'
+            : 'No runtimes reported — no serving member has advertised its runtime profiles yet.'
+        }
+      />
+
+      <div className="grid grid-cols-1 items-start gap-[18px] desktop:grid-cols-2">
+        <FleetAgentsCard
+          title="Agents on this group"
+          agents={hosted}
+          capabilitySource={capabilitySource}
+          onOpen={(agentId) => router.push(orgPath(`/agents/${agentId}`))}
+          emptyTitle="No agents target this group yet"
+          emptyHint={`Place an agent on ${group.name} and it runs on whichever member is serving.`}
+        />
+        <FleetConnectionsCard
+          title="Connections held in the group"
+          conns={conns}
+          empty="No integration tokens are held on these daemons."
+        />
+      </div>
+
+      <p className="mt-[14px] max-w-[780px] font-sans text-[12px] font-normal leading-[1.6] text-(--text-tertiary) text-pretty">
+        An agent placed on this group keeps running when one member does not — whichever member is serving picks the
+        work up. An agent pinned to a member stays pinned there and does not move with the group.
+      </p>
+    </div>
+  )
+}
+
+/** One member of the group. Clickable, because the machine's own page is where its detail lives. */
+function MemberRow({ m, pinned, onOpen }: { m: DaemonRow; pinned: number; onOpen: () => void }) {
+  const ms = status(m.status)
+  return (
+    // Mobile drops the two load bars rather than squeezing six tracks into 375px: which member
+    // is serving is the routing fact, and its utilization is on the machine's own page anyway.
+    <div
+      className="row click grid-cols-[auto_1fr_auto_auto] gap-3 desktop:grid-cols-[auto_1.5fr_.9fr_.8fr_.8fr_auto]"
+      onClick={onOpen}
+    >
+      <span className="flex h-6 w-6 flex-none items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
+        <Icon name="server" size={13} color={m.status === 'online' ? 'var(--brand)' : 'var(--text-tertiary)'} />
+      </span>
+      <span className="mono min-w-0 truncate text-[12.5px] font-semibold text-(--text-primary)">{m.name}</span>
+      <span className="inline-flex items-center gap-[7px]">
+        <span className="dot" style={{ background: ms.dot }} />
+        <span className="font-sans text-[12px] font-medium leading-normal" style={{ color: ms.text }}>
+          {ms.label}
+        </span>
+      </span>
+      <MemberBar pct={m.cpu} />
+      <MemberBar pct={m.mem} />
+      <span className="mono text-right text-[12px] text-(--text-primary)">{pinned}</span>
+    </div>
+  )
+}
+
+/** A member's CPU or memory reading. Clamped: a daemon predating the cpu-normalization fix
+ *  reports a raw load average, which would otherwise render as e.g. "722%". */
+function MemberBar({ pct }: { pct: number }) {
+  const shown = Math.max(0, Math.min(100, Math.round(pct)))
+  return (
+    <span className="hidden min-w-0 flex-col gap-1 desktop:flex">
+      <span className="mono text-[11px] text-(--text-secondary)">{shown}%</span>
+      <span className="block h-1 overflow-hidden rounded-[2px] bg-(--surface-active)">
+        <span className="block h-full" style={{ width: `${shown}%`, background: barColor(shown) }} />
+      </span>
+    </span>
+  )
+}


### PR DESCRIPTION
Implements the two remaining Infra screens from `AgentConnect Console v2.dc.html` — the group/pool detail (`gd.*`) and the Cloud reading of the Cloud/cluster detail (`cd.isCloud`).

## Shared blocks first

The design draws Cloud, cluster and group detail as **one layout with three data bindings**, so the blocks now live once in `components/console/FleetDetail.tsx`: `unionRuntimes` / `unionMcpServers` / `connsHeldBy`, `FleetStat`, `FleetFact`, `ResourceBar`, `FleetRuntimesCard`, `FleetAgentsCard`, `FleetConnectionsCard`, `barColor`. `ClusterDetailView` was the donor and its duplicated copies are gone.

The runtime disclosure stays a real `aria-expanded` button rather than the design's hover-only popover — the model list is the only place a set's models are readable, and a pointer is not the only input.

## AgentConnect Cloud

One page, two readings, picked by the `managed` flag, because it is the same pool either way. Cloud drops what is the operator's business and not the reader's — node count, host names, versions, CPU — and answers what the org can act on: agents on Cloud, connections held, active sessions, runtimes and models available, then the runtime, agent and connection cards.

The Infra Cloud card now opens `/daemons/cluster` instead of one member's page: no member id survives a rollout, so landing on one machine named the pool after a Pod that was already gone.

**One deliberate substitution.** The design's left card is a plan's *included usage* bar. This deployment sells prepaid credit, so there is no quota to fill a track with, and deriving one from load telemetry would read as a real ceiling. Cloud quotes the real balance instead — behind the `billing` flag, on the Billing page's own SWR key so the page costs no extra request — with a **Manage billing** action and the design's own footnote about what is and is not billed there.

## Daemon group

New `GroupDetailView` at `/daemons/groups/[id]`: header (name, fleet status, member badge, "Any daemon in the group", member list, Edit group) → 4-stat strip → members table with per-member CPU/memory → Routing facts → runtimes across the group → agents and connections.

The Infra group row now navigates here; it used to open the editor, which is the rarer of the two things a reader wants from a group. The editor stays one click away, in the row menu and on the page. Shell's mobile push title resolves group names too, and the members table drops its two load bars below 769px rather than squeezing six tracks into 375px.

A group never borrows a member's host, version or uptime — it is a placement target, not a machine — and every aggregate is over the members that are actually **serving**, since one that stopped answering can neither offer a runtime nor hold a connection.

## Absent on both, on purpose

The design's mint/rotate-token action, because the console mints no pool credentials, and its log tail, because a fabricated stream is indistinguishable from real telemetry. Same call the daemon detail and cluster pages already made.

## Verification

`pnpm lint`, `pnpm format`, web `typecheck` clean. 1720 tests pass across 159 files, including 11 new `GroupDetailView` tests and 5 new managed-Cloud tests.

One existing assertion changed on purpose: `DaemonsView.pool.test.tsx` expected the Cloud card to open `/acme/daemons/serving`, and now expects `/acme/daemons/cluster`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
