### PR TITLE
fix(ci): compare the runtime table on what the image pins, not byte for byte

### DIFF
--- a/scripts/runtime-table-diff.mjs
+++ b/scripts/runtime-table-diff.mjs
@@ -1,0 +1,114 @@
+// Compares the runtime table baked into the runtime-sandbox image against a fresh probe of that same image.
+// The image pins what a runtime IS: its id, version, executable, and the ACP snapshot it answers initialize with.
+// It does not pin a config option's `values` — that roster is fetched upstream at probe time and moves on its own.
+// A cache-hit build ships a table as old as the cached layer, so byte equality failed on drift the image never caused.
+
+/** Rendered for one failure line: the point is which field moved, not a dump of both tables. */
+function render(value) {
+  const text = JSON.stringify(value ?? null)
+  return text.length > 120 ? `${text.slice(0, 119)}…` : text
+}
+
+/** Set math over ids and option values, which are strings in every table this generator writes. */
+const keyOf = (value) => (typeof value === 'string' ? value : JSON.stringify(value ?? null))
+
+function only(present, absent) {
+  const other = new Set(absent.map(keyOf))
+  return [...new Set(present.map(keyOf))].filter((item) => !other.has(item)).sort()
+}
+
+const listOrNone = (items) => (items.length > 0 ? items.join(', ') : 'none')
+
+const isPlain = (value) => value !== null && typeof value === 'object' && !Array.isArray(value)
+
+const omit = (value, key) =>
+  isPlain(value) ? Object.fromEntries(Object.entries(value).filter(([name]) => name !== key)) : value
+
+/** Exact comparison of everything under `path`, so a field the generator adds later is pinned without being listed. */
+function deepDiff(path, published, probed, failures) {
+  if (isPlain(published) && isPlain(probed)) {
+    for (const key of [...new Set([...Object.keys(published), ...Object.keys(probed)])].sort()) {
+      deepDiff(`${path}.${key}`, published[key], probed[key], failures)
+    }
+    return
+  }
+  if (Array.isArray(published) && Array.isArray(probed) && published.length === probed.length) {
+    published.forEach((item, index) => deepDiff(`${path}[${index}]`, item, probed[index], failures))
+    return
+  }
+  if (JSON.stringify(published ?? null) !== JSON.stringify(probed ?? null)) {
+    failures.push(`${path}: published ${render(published)}, probed ${render(probed)}`)
+  }
+}
+
+/** Option ids, categories and types are the image's; the values inside one are upstream's and only warn. */
+function diffConfigOptions(prefix, published, probed, failures, warnings) {
+  const publishedOptions = Array.isArray(published) ? published : []
+  const probedOptions = Array.isArray(probed) ? probed : []
+  const dropped = only(
+    publishedOptions.map((option) => option?.id),
+    probedOptions.map((option) => option?.id)
+  )
+  const gained = only(
+    probedOptions.map((option) => option?.id),
+    publishedOptions.map((option) => option?.id)
+  )
+  if (dropped.length > 0 || gained.length > 0) {
+    failures.push(
+      `${prefix}.acp.configOptions: published only ${listOrNone(dropped)}, probed only ${listOrNone(gained)}`
+    )
+  }
+  const probedById = new Map(probedOptions.map((option) => [keyOf(option?.id), option]))
+  for (const option of publishedOptions) {
+    const fresh = probedById.get(keyOf(option?.id))
+    if (!fresh) continue
+    const path = `${prefix}.acp.configOptions[${option.id}]`
+    deepDiff(path, omit(option, 'values'), omit(fresh, 'values'), failures)
+    if (!Array.isArray(option.values) || !Array.isArray(fresh.values)) {
+      deepDiff(`${path}.values`, option.values, fresh.values, failures)
+      continue
+    }
+    const removed = only(option.values, fresh.values)
+    const added = only(fresh.values, option.values)
+    if (removed.length > 0 || added.length > 0) {
+      warnings.push(`${path}.values drifted upstream — added ${listOrNone(added)}, removed ${listOrNone(removed)}`)
+    }
+  }
+}
+
+/** Failures mean the table lies about what this image runs; warnings mean only an upstream roster moved. */
+export function diffRuntimeTables(published, probed) {
+  const failures = []
+  const warnings = []
+  const publishedRuntimes = published?.runtimes
+  const probedRuntimes = probed?.runtimes
+  if (!Array.isArray(publishedRuntimes) || !Array.isArray(probedRuntimes)) {
+    failures.push(`runtimes: published ${render(publishedRuntimes)}, probed ${render(probedRuntimes)}`)
+    return { failures, warnings }
+  }
+  deepDiff('table', omit(published, 'runtimes'), omit(probed, 'runtimes'), failures)
+  const dropped = only(
+    publishedRuntimes.map((entry) => entry?.id),
+    probedRuntimes.map((entry) => entry?.id)
+  )
+  const gained = only(
+    probedRuntimes.map((entry) => entry?.id),
+    publishedRuntimes.map((entry) => entry?.id)
+  )
+  if (dropped.length > 0 || gained.length > 0) {
+    failures.push(`runtime ids: published only ${listOrNone(dropped)}, probed only ${listOrNone(gained)}`)
+  }
+  const probedById = new Map(probedRuntimes.map((entry) => [keyOf(entry?.id), entry]))
+  for (const entry of publishedRuntimes) {
+    const fresh = probedById.get(keyOf(entry?.id))
+    if (!fresh) continue
+    deepDiff(
+      entry.id,
+      { ...entry, acp: omit(entry.acp, 'configOptions') },
+      { ...fresh, acp: omit(fresh.acp, 'configOptions') },
+      failures
+    )
+    diffConfigOptions(entry.id, entry.acp?.configOptions, fresh.acp?.configOptions, failures, warnings)
+  }
+  return { failures, warnings }
+}

--- a/scripts/runtime-table-diff.test.mjs
+++ b/scripts/runtime-table-diff.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { diffRuntimeTables } from './runtime-table-diff.mjs'
+
+// Shaped like the real k8s-runtimes.json: two runtimes, one authenticated and one not, each with the
+// model option whose value roster the image cannot pin.
+const baseline = () => ({
+  runtimes: [
+    {
+      id: 'claude-acp',
+      version: '1.4.2',
+      command: 'claude-agent-acp',
+      args: [],
+      acp: {
+        agentName: 'claude-code',
+        authMethods: ['claude-login'],
+        capabilities: { loadSession: true, promptCapabilities: { image: true } },
+        configOptions: [{ category: 'model', id: 'model', type: 'select', values: ['opus', 'sonnet'] }],
+        modes: ['acceptEdits', 'default'],
+        protocolVersion: 1,
+        sessionProbe: 'ok'
+      }
+    },
+    {
+      id: 'opencode',
+      version: '0.15.7',
+      command: 'opencode',
+      args: ['acp'],
+      acp: {
+        agentName: 'opencode',
+        authMethods: [],
+        capabilities: { loadSession: false },
+        configOptions: [
+          { category: 'model', id: 'model', type: 'select', values: ['hy3-free', 'nemotron-3.5-lightning-free'] },
+          { category: 'permission', id: 'permission', type: 'select', values: ['ask', 'edit'] }
+        ],
+        modes: [],
+        protocolVersion: 1,
+        sessionProbe: 'auth-required'
+      }
+    }
+  ]
+})
+
+const withOpencode = (mutate) => {
+  const table = baseline()
+  mutate(table.runtimes.find((entry) => entry.id === 'opencode'))
+  return table
+}
+
+test('two probes of the same image agree', () => {
+  assert.deepEqual(diffRuntimeTables(baseline(), baseline()), { failures: [], warnings: [] })
+})
+
+// The v1.41.0 release failure: a cache-hit build shipped a table hours older than the probe, and the
+// only difference was a free-model roster opencode fetches upstream.
+test('a value roster that moved upstream warns and does not fail', () => {
+  const probed = withOpencode((runtime) => {
+    runtime.acp.configOptions[0].values = ['ling-3.0-tiny-free', 'longcat-2.0-free', 'north-mini-code-free']
+  })
+  const { failures, warnings } = diffRuntimeTables(baseline(), probed)
+  assert.deepEqual(failures, [])
+  assert.equal(warnings.length, 1)
+  assert.match(warnings[0], /^opencode\.acp\.configOptions\[model\]\.values drifted upstream/)
+  assert.match(warnings[0], /added ling-3\.0-tiny-free, longcat-2\.0-free, north-mini-code-free/)
+  assert.match(warnings[0], /removed hy3-free, nemotron-3\.5-lightning-free/)
+})
+
+test('every field the image pins still fails the build, naming the field and both values', () => {
+  const cases = [
+    [
+      'version',
+      (runtime) => (runtime.version = '0.16.0'),
+      /^opencode\.version: published "0\.15\.7", probed "0\.16\.0"$/
+    ],
+    ['command', (runtime) => (runtime.command = 'opencode-next'), /^opencode\.command: /],
+    ['args', (runtime) => (runtime.args = ['acp', '--json']), /^opencode\.args: published \["acp"\]/],
+    [
+      'protocolVersion',
+      (runtime) => (runtime.acp.protocolVersion = 2),
+      /^opencode\.acp\.protocolVersion: published 1, probed 2$/
+    ],
+    ['agentName', (runtime) => (runtime.acp.agentName = 'opencode-acp'), /^opencode\.acp\.agentName: /],
+    ['authMethods', (runtime) => (runtime.acp.authMethods = ['api-key']), /^opencode\.acp\.authMethods: /],
+    [
+      'capabilities',
+      (runtime) => (runtime.acp.capabilities.loadSession = true),
+      /^opencode\.acp\.capabilities\.loadSession: published false, probed true$/
+    ],
+    ['modes', (runtime) => (runtime.acp.modes = ['default']), /^opencode\.acp\.modes: /],
+    [
+      'sessionProbe',
+      (runtime) => (runtime.acp.sessionProbe = 'ok'),
+      /^opencode\.acp\.sessionProbe: published "auth-required", probed "ok"$/
+    ],
+    [
+      'option category',
+      (runtime) => (runtime.acp.configOptions[0].category = 'models'),
+      /^opencode\.acp\.configOptions\[model\]\.category: published "model", probed "models"$/
+    ],
+    [
+      'option type',
+      (runtime) => (runtime.acp.configOptions[0].type = 'string'),
+      /^opencode\.acp\.configOptions\[model\]\.type: /
+    ],
+    [
+      'option roster',
+      (runtime) => runtime.acp.configOptions.pop(),
+      /^opencode\.acp\.configOptions: published only permission, probed only none$/
+    ]
+  ]
+  for (const [name, mutate, expected] of cases) {
+    const { failures, warnings } = diffRuntimeTables(baseline(), withOpencode(mutate))
+    assert.equal(failures.length, 1, `${name} produced ${failures.length} failures: ${failures.join('; ')}`)
+    assert.match(failures[0], expected)
+    assert.deepEqual(warnings, [])
+  }
+})
+
+test('a runtime that appears or disappears fails', () => {
+  const shorter = baseline()
+  shorter.runtimes.pop()
+  assert.deepEqual(diffRuntimeTables(baseline(), shorter).failures, [
+    'runtime ids: published only opencode, probed only none'
+  ])
+  assert.deepEqual(diffRuntimeTables(shorter, baseline()).failures, [
+    'runtime ids: published only none, probed only opencode'
+  ])
+})
+
+// The generator's own output is the contract, so a shape that is not it must fail rather than be diffed.
+test('a table with no runtimes array fails instead of passing empty', () => {
+  const { failures } = diffRuntimeTables({}, baseline())
+  assert.equal(failures.length, 1)
+  assert.match(failures[0], /^runtimes: published null, probed \[/)
+})
+
+// A field the generator adds later is pinned without this module listing it.
+test('an unlisted field is compared exactly', () => {
+  const probed = withOpencode((runtime) => (runtime.acp.slashCommands = ['/init']))
+  const { failures } = diffRuntimeTables(baseline(), probed)
+  assert.deepEqual(failures, ['opencode.acp.slashCommands: published null, probed ["/init"]'])
+})

--- a/scripts/verify-runtime-image.mjs
+++ b/scripts/verify-runtime-image.mjs
@@ -15,6 +15,8 @@
  */
 import { execFileSync } from 'node:child_process'
 
+import { diffRuntimeTables } from './runtime-table-diff.mjs'
+
 const image = process.argv[2]
 if (!image) {
   process.stderr.write('usage: verify-runtime-image.mjs <image>\n')
@@ -23,6 +25,7 @@ if (!image) {
 
 const failures = []
 const notes = []
+const warnings = []
 
 function check(name, fn) {
   try {
@@ -199,10 +202,8 @@ check('carries no service-account token of its own', () => {
   return 'none'
 })
 
-// The acceptance criterion: the published table must match what the runtimes report AT
-// INITIALIZE — not what a manifest or a `--version` string says. So it is checked by re-running
-// the same generator in the built image and diffing: a table that merely agrees with its own
-// source would prove only that the generator ran once.
+// Re-probed in the built image rather than checked against its own source: that proves only that the generator ran.
+// Compared on what the image pins, not byte for byte: an option's value roster comes from upstream and drifts alone.
 check('the published runtime table matches a fresh ACP probe of this image', () => {
   const published = inImage(`cat ${TABLE_PATH}`)
   const fresh = execFileSync(
@@ -222,11 +223,12 @@ check('the published runtime table matches a fresh ACP probe of this image', () 
       throw new Error(`${entry.id} publishes no ACP capabilities`)
     }
   }
-  if (published !== fresh) {
-    // Deliberately shows the ids rather than the whole diff: the point is which runtime drifted.
-    const before = JSON.parse(published).runtimes.map((r) => `${r.id}@${r.version}`)
-    const after = JSON.parse(fresh).runtimes.map((r) => `${r.id}@${r.version}`)
-    throw new Error(`the shipped table differs from a fresh probe (published ${before}, probed ${after})`)
+  const { failures: drift, warnings: rosters } = diffRuntimeTables(table, JSON.parse(fresh))
+  // Reported, never fatal: the image cannot pin these, and failing on them fails a build that changed nothing.
+  for (const roster of rosters) warnings.push(`  ! ${roster}`)
+  if (drift.length > 0) {
+    // Field by field, because the previous id@version list printed two identical strings for the drift it caught.
+    throw new Error(`the shipped table differs from a fresh probe — ${drift.join('; ')}`)
   }
   return table.runtimes.map((entry) => `${entry.id}@${entry.version} acp/${entry.acp.protocolVersion}`).join(' ')
 })
@@ -259,7 +261,7 @@ check('the workspace root is owned by the runtime user', () => {
   return owner
 })
 
-process.stdout.write(`runtime-sandbox image checks (${image})\n${[...notes, ...failures].join('\n')}\n`)
+process.stdout.write(`runtime-sandbox image checks (${image})\n${[...notes, ...warnings, ...failures].join('\n')}\n`)
 if (failures.length > 0) {
   process.stderr.write(`\n${failures.length} check(s) failed\n`)
   process.exit(1)


### PR DESCRIPTION
## What broke

The v1.41.0 stable build failed `scripts/verify-runtime-image.mjs` on "the published runtime table matches a fresh ACP probe of this image", and the failure printed two identical `id@version` lists — the drift was invisible in the message.

The only real difference between the shipped table and the fresh probe was opencode's free-model roster, `acp.configOptions[model].values`. Every other field, including every runtime's `version`, was identical.

That roster is not a property of the image. Probing the same image hours after its build yields a different list, and it does so identically with `--network none`, so this is upstream content the runtime resolves at probe time, not a network flake.

Why it only bites sometimes: when the image is genuinely rebuilt, the table-generating layer re-runs and the baked table is minutes old, so it matches. When the build is a full BuildKit cache hit (`RUN ... generate-runtime-table.mjs ... CACHED`), the baked table is as old as that cached layer — hours or days — while the verify-time probe is fresh. The failing run's two builds produced the identical ImageID, so the image itself was fine.

## What the check guarantees now

`scripts/runtime-table-diff.mjs` compares the two tables field by field instead of byte for byte.

Still a hard failure, because the image pins it:

- the set of runtime ids, and each runtime's `version`, `command`, `args`
- the ACP snapshot: `protocolVersion`, `agentName`, `authMethods`, `capabilities`, `modes`, `sessionProbe`
- each config option's `id`, `category` and `type`, and the set of option ids
- anything the generator adds later — the comparison is exact everywhere except the one lenient field, so a new key is pinned without being listed

A failure now names the runtime, the field and both values (`opencode.acp.protocolVersion: published 1, probed 2`) rather than a version list, and does not dump either document.

A difference confined to a config option's `values` no longer fails the build. It is reported as a warning line in the step output naming the runtime, the option and what was added or removed.

## Tests

`scripts/runtime-table-diff.test.mjs` (`node --test`, the style the other `scripts/*.test.mjs` use, run by `pnpm test:unit` in CI): identical tables agree; the v1.41.0 case warns and does not fail; each pinned field fails with the field and both values; a runtime or a whole config option appearing or disappearing fails; a table with no `runtimes` array fails rather than passing empty; an unlisted field is compared exactly.
