### PR TITLE
[WIP] feat(web): virtualize the webchat transcript via a VirtualTranscript component

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,6 +33,7 @@
     "@opentelemetry/resources": "^2.10.0",
     "@opentelemetry/sdk-trace-web": "^2.10.0",
     "@opentelemetry/semantic-conventions": "^1.43.0",
+    "@tanstack/react-virtual": "^3.14.10",
     "croner": "^10.0.1",
     "cronstrue": "^3.24.0",
     "highlight.js": "^11.11.1",

--- a/packages/web/src/components/console/VirtualTranscript.tsx
+++ b/packages/web/src/components/console/VirtualTranscript.tsx
@@ -12,7 +12,6 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -83,14 +82,6 @@ export function VirtualTranscript<T extends { key?: string }>({
     scrollMargin
   })
 
-  useLayoutEffect(() => {
-    const root = rootRef.current
-    const scroll = scrollRef.current
-    if (!root || !scroll) return
-    const offset = root.getBoundingClientRect().top - scroll.getBoundingClientRect().top + scroll.scrollTop
-    setScrollMargin((prev) => (Math.abs(prev - offset) > 0.5 ? offset : prev))
-  }, [turns.length, virtualize])
-
   // The latest props in refs, so the effects below don't re-run on every parent render — the parent
   // passes fresh callback identities and a fresh `turns` array each time, and an effect that re-ran
   // on those would re-arm the follow constantly and trap the reader at the bottom.
@@ -100,24 +91,31 @@ export function VirtualTranscript<T extends { key?: string }>({
   onLoadOlderRef.current = onLoadOlder
   const hasOlderRef = useRef(hasOlder)
   hasOlderRef.current = hasOlder
-  const virtualizeRef = useRef(virtualize)
-  virtualizeRef.current = virtualize
-  const countRef = useRef(turns.length)
-  countRef.current = turns.length
-  const virtualizerRef = useRef(rowVirtualizer)
-  virtualizerRef.current = rowVirtualizer
+  // Where the last pin landed, so onScroll can swallow the pin's own (delayed) scroll event.
+  const pinnedTop = useRef<number | null>(null)
 
   const reportAtBottom = useCallback((atBottom: boolean) => onAtBottomRef.current?.(atBottom), [])
 
   const pinToBottom = useCallback(() => {
     const el = scrollRef.current
     if (!el) return
-    // The virtualizer keeps an accurate end while rows are still estimated; the plain path clamps.
-    if (virtualizeRef.current && countRef.current > 0) {
-      virtualizerRef.current.scrollToIndex(countRef.current - 1, { align: 'end' })
-    } else {
-      el.scrollTop = el.scrollHeight
-    }
+    // Scroll the PANE to its true bottom, not the last turn's: the typing dots, the flex-1 spacer
+    // and the sticky composer follow the turn list, so aligning the last turn would leave the newest
+    // reply under the composer and read as "not at the bottom".
+    el.scrollTop = el.scrollHeight
+    // Read back (the browser clamps) so onScroll can recognise this pin's echo by position.
+    pinnedTop.current = el.scrollTop
+  }, [])
+
+  // The list is offset from the scrollport by whatever sits above it (a "load earlier" row, the
+  // paging spinner, an offline/purge notice); the virtualizer needs that offset or every row is
+  // mispositioned. Remeasured on every content change (below), not just when the turn COUNT changes.
+  const measureScrollMargin = useCallback(() => {
+    const root = rootRef.current
+    const el = scrollRef.current
+    if (!root || !el) return
+    const offset = root.getBoundingClientRect().top - el.getBoundingClientRect().top + el.scrollTop
+    setScrollMargin((prev) => (Math.abs(prev - offset) > 0.5 ? offset : prev))
   }, [])
 
   // Arm the follow ONLY when the session/conversation changes — never on an ordinary re-render, or
@@ -129,14 +127,22 @@ export function VirtualTranscript<T extends { key?: string }>({
     reportAtBottom(true)
   }, [resetKey, reportAtBottom])
 
-  // Follow ACTUAL growth, not every render: a ResizeObserver on the growing content fires only when
-  // it really grows (a streamed step, a merged row), and only re-pins while the reader is still at
-  // the bottom. `onScroll` latches that, and drives the reverse-infinite-scroll load. Re-attached
-  // only on a session switch or a plain↔virtual flip (the root element changes) — not per render.
+  // Follow ACTUAL growth, not every render. A ResizeObserver on the scroller's inner wrapper fires
+  // whenever anything in the pane grows or shrinks — a streamed step, a merged row, a notice
+  // appearing above the list — so it doubles as the trigger to re-pin (while the reader is at the
+  // bottom) and to remeasure `scrollMargin`. `onScroll` latches whether the reader is still at the
+  // bottom and drives the reverse-infinite-scroll load. Re-attached only on a session switch or a
+  // plain↔virtual flip, not per render.
   useEffect(() => {
     const el = scrollRef.current
     if (!el) return
     const onScroll = () => {
+      // Swallow the echo of our own pin: it dispatches a scroll event delivered LATER, by which time
+      // a streamed row may already have grown the content, so measuring it would read "far from the
+      // bottom" and drop the follow one beat after arming it. Matched by position (events coalesce).
+      const echo = pinnedTop.current !== null && el.scrollTop === pinnedTop.current
+      pinnedTop.current = null
+      if (echo) return
       follow.current = nearBottom(el)
       reportAtBottom(follow.current)
       if (hasOlderRef.current && onLoadOlderRef.current && !loadingOlder.current && el.scrollTop <= NEAR_TOP) {
@@ -154,15 +160,19 @@ export function VirtualTranscript<T extends { key?: string }>({
     }
     el.addEventListener('scroll', onScroll, { passive: true })
     const grow = new ResizeObserver(() => {
+      measureScrollMargin()
       if (follow.current) pinToBottom()
       reportAtBottom(nearBottom(el))
     })
-    if (rootRef.current) grow.observe(rootRef.current)
+    // Observe the scroller's inner wrapper (always present, unlike the turn list which is absent for
+    // an empty transcript), so the follow survives the empty→first-render transition.
+    const content = el.firstElementChild
+    if (content) grow.observe(content)
     return () => {
       el.removeEventListener('scroll', onScroll)
       grow.disconnect()
     }
-  }, [resetKey, virtualize, pinToBottom, reportAtBottom])
+  }, [resetKey, virtualize, pinToBottom, reportAtBottom, measureScrollMargin])
 
   useImperativeHandle(
     handleRef,
@@ -175,6 +185,10 @@ export function VirtualTranscript<T extends { key?: string }>({
     }),
     [pinToBottom, reportAtBottom]
   )
+
+  // Nothing to render when empty — return null rather than an empty wrapper, whose parent `gap-4` +
+  // `max-desktop:pb-3` would otherwise leave dead space above the mobile empty state / prompts.
+  if (turns.length === 0) return null
 
   if (!virtualize) {
     return (

--- a/packages/web/src/components/console/VirtualTranscript.tsx
+++ b/packages/web/src/components/console/VirtualTranscript.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+// The webchat transcript's turn list, with deepseek-harness-style windowing. It renders the turns
+// SessionDetailView builds — plainly for short chats, virtualized with `@tanstack/react-virtual`
+// once they pass the threshold — and owns the follow-to-bottom behaviour that used to live in
+// `useStickToBottom`. SessionDetailView keeps the per-turn JSX (passed as `renderTurn`), the scroll
+// pane element (this finds it as the `[data-transcript-scroll]` ancestor), and the composer.
+
+import { useVirtualizer } from '@tanstack/react-virtual'
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type Ref
+} from 'react'
+import { shouldVirtualizeTranscript } from '@/lib/transcript-virtual'
+
+/** Distance from the bottom (px) that still counts as "reading the newest" — a couple of rows of
+ *  slack so a nudge of the wheel doesn't drop the follow. Mirrors the old STICK_SLACK. */
+const FOLLOW_SLACK = 80
+/** Scroll within this of the top and we ask for the previous page (reverse infinite scroll). */
+const NEAR_TOP = 240
+/** Extra rows rendered beyond the viewport, so a fast scroll doesn't flash blank. */
+const OVERSCAN = 6
+
+export interface VirtualTranscriptHandle {
+  /** Re-arm the follow and jump to the newest turn — the send path and the jump button call this. */
+  scrollToBottom(): void
+}
+
+function nearBottom(el: HTMLElement): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < FOLLOW_SLACK
+}
+
+export function VirtualTranscript<T extends { key?: string }>({
+  turns,
+  estimate,
+  renderTurn,
+  resetKey,
+  hasOlder = false,
+  onLoadOlder,
+  onAtBottomChange,
+  handleRef
+}: {
+  turns: readonly T[]
+  /** First-paint height guess for one turn; measurement refines it once the row mounts. */
+  estimate: (turn: T) => number
+  /** The per-turn JSX, kept in SessionDetailView so its closures stay put. */
+  renderTurn: (turn: T, index: number) => ReactNode
+  /** Re-arms the follow when the open session/conversation changes. */
+  resetKey: string | null
+  hasOlder?: boolean
+  onLoadOlder?: () => void
+  /** Reports whether the reader has scrolled up out of a scrollable transcript (drives the button). */
+  onAtBottomChange?: (atBottom: boolean) => void
+  handleRef?: Ref<VirtualTranscriptHandle>
+}) {
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const scrollRef = useRef<HTMLElement | null>(null)
+  // Latched on scroll, never read at growth time: new content has already pushed the bottom away,
+  // so a measurement then would always read "not at the bottom" and the follow would never fire.
+  const follow = useRef(true)
+  const loadingOlder = useRef(false)
+
+  const virtualize = shouldVirtualizeTranscript(turns.length)
+  // The turn list is not at the top of the scroller — a "load earlier" row and empty-state notices
+  // can sit above it — so the virtualizer needs the offset from the scrollport to the list start,
+  // or every row is mispositioned by that gap. Measured below and kept fresh as content shifts.
+  const [scrollMargin, setScrollMargin] = useState(0)
+
+  const rowVirtualizer = useVirtualizer({
+    count: virtualize ? turns.length : 0,
+    enabled: virtualize,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (index) => estimate(turns[index]!),
+    getItemKey: (index) => turns[index]?.key ?? index,
+    overscan: OVERSCAN,
+    scrollMargin
+  })
+
+  useLayoutEffect(() => {
+    const root = rootRef.current
+    const scroll = scrollRef.current
+    if (!root || !scroll) return
+    const offset = root.getBoundingClientRect().top - scroll.getBoundingClientRect().top + scroll.scrollTop
+    setScrollMargin((prev) => (Math.abs(prev - offset) > 0.5 ? offset : prev))
+  }, [turns.length, virtualize])
+
+  const pinToBottom = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    // The virtualizer keeps an accurate end while rows are still estimated; the plain path just
+    // clamps to the bottom.
+    if (virtualize && turns.length > 0) rowVirtualizer.scrollToIndex(turns.length - 1, { align: 'end' })
+    else el.scrollTop = el.scrollHeight
+  }, [virtualize, turns.length, rowVirtualizer])
+
+  // Resolve the scroll pane once mounted; re-arm the follow for the newly-opened session.
+  useEffect(() => {
+    scrollRef.current = rootRef.current?.closest<HTMLElement>('[data-transcript-scroll]') ?? null
+    follow.current = true
+    // The view mounts before the turns land, so an empty pane reads as at-the-bottom and the first
+    // history render lands at the newest turn — which is what makes the follow reachable at all.
+    onAtBottomChange?.(true)
+  }, [resetKey, onAtBottomChange])
+
+  // Follow the growing transcript, but ONLY while the reader is already at the bottom.
+  useEffect(() => {
+    if (follow.current) pinToBottom()
+    // The button follows the same latch: away = the reader scrolled up out of a scrollable list.
+    const el = scrollRef.current
+    onAtBottomChange?.(el ? nearBottom(el) : true)
+  }, [turns, pinToBottom, onAtBottomChange])
+
+  const onScroll = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    follow.current = nearBottom(el)
+    onAtBottomChange?.(follow.current)
+    if (hasOlder && onLoadOlder && !loadingOlder.current && el.scrollTop <= NEAR_TOP) {
+      loadingOlder.current = true
+      // Preserve the viewport across the prepend: the caller grows the list at the top, so hold the
+      // distance-from-bottom and restore it after the new rows land.
+      const anchorFromBottom = el.scrollHeight - el.scrollTop
+      Promise.resolve(onLoadOlder()).finally(() => {
+        requestAnimationFrame(() => {
+          const pane = scrollRef.current
+          if (pane) pane.scrollTop = pane.scrollHeight - anchorFromBottom
+          loadingOlder.current = false
+        })
+      })
+    }
+  }, [hasOlder, onLoadOlder, onAtBottomChange])
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [onScroll])
+
+  useImperativeHandle(
+    handleRef,
+    () => ({
+      scrollToBottom() {
+        follow.current = true
+        pinToBottom()
+        onAtBottomChange?.(true)
+      }
+    }),
+    [pinToBottom, onAtBottomChange]
+  )
+
+  if (!virtualize) {
+    return (
+      <div ref={rootRef} className="flex flex-col gap-4 max-desktop:pb-3 desktop:gap-[15px]">
+        {turns.map((turn, index) => (
+          <Fragment key={turn.key ?? index}>{renderTurn(turn, index)}</Fragment>
+        ))}
+      </div>
+    )
+  }
+
+  const items = rowVirtualizer.getVirtualItems()
+  return (
+    <div ref={rootRef} style={{ height: rowVirtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
+      {items.map((item) => (
+        <div
+          key={item.key}
+          data-index={item.index}
+          ref={rowVirtualizer.measureElement}
+          className="max-desktop:pb-3"
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            // `item.start` is scrollport-relative; the container starts `scrollMargin` down from it.
+            transform: `translateY(${item.start - scrollMargin}px)`
+          }}
+        >
+          {renderTurn(turns[item.index]!, item.index)}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/VirtualTranscript.tsx
+++ b/packages/web/src/components/console/VirtualTranscript.tsx
@@ -91,58 +91,78 @@ export function VirtualTranscript<T extends { key?: string }>({
     setScrollMargin((prev) => (Math.abs(prev - offset) > 0.5 ? offset : prev))
   }, [turns.length, virtualize])
 
+  // The latest props in refs, so the effects below don't re-run on every parent render — the parent
+  // passes fresh callback identities and a fresh `turns` array each time, and an effect that re-ran
+  // on those would re-arm the follow constantly and trap the reader at the bottom.
+  const onAtBottomRef = useRef(onAtBottomChange)
+  onAtBottomRef.current = onAtBottomChange
+  const onLoadOlderRef = useRef(onLoadOlder)
+  onLoadOlderRef.current = onLoadOlder
+  const hasOlderRef = useRef(hasOlder)
+  hasOlderRef.current = hasOlder
+  const virtualizeRef = useRef(virtualize)
+  virtualizeRef.current = virtualize
+  const countRef = useRef(turns.length)
+  countRef.current = turns.length
+  const virtualizerRef = useRef(rowVirtualizer)
+  virtualizerRef.current = rowVirtualizer
+
+  const reportAtBottom = useCallback((atBottom: boolean) => onAtBottomRef.current?.(atBottom), [])
+
   const pinToBottom = useCallback(() => {
     const el = scrollRef.current
     if (!el) return
-    // The virtualizer keeps an accurate end while rows are still estimated; the plain path just
-    // clamps to the bottom.
-    if (virtualize && turns.length > 0) rowVirtualizer.scrollToIndex(turns.length - 1, { align: 'end' })
-    else el.scrollTop = el.scrollHeight
-  }, [virtualize, turns.length, rowVirtualizer])
+    // The virtualizer keeps an accurate end while rows are still estimated; the plain path clamps.
+    if (virtualizeRef.current && countRef.current > 0) {
+      virtualizerRef.current.scrollToIndex(countRef.current - 1, { align: 'end' })
+    } else {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [])
 
-  // Resolve the scroll pane once mounted; re-arm the follow for the newly-opened session.
+  // Arm the follow ONLY when the session/conversation changes — never on an ordinary re-render, or
+  // the reader is yanked back to the bottom the moment they scroll up. The view mounts before the
+  // turns land, so an empty pane reads as at-the-bottom and the first history render lands newest.
   useEffect(() => {
     scrollRef.current = rootRef.current?.closest<HTMLElement>('[data-transcript-scroll]') ?? null
     follow.current = true
-    // The view mounts before the turns land, so an empty pane reads as at-the-bottom and the first
-    // history render lands at the newest turn — which is what makes the follow reachable at all.
-    onAtBottomChange?.(true)
-  }, [resetKey, onAtBottomChange])
+    reportAtBottom(true)
+  }, [resetKey, reportAtBottom])
 
-  // Follow the growing transcript, but ONLY while the reader is already at the bottom.
+  // Follow ACTUAL growth, not every render: a ResizeObserver on the growing content fires only when
+  // it really grows (a streamed step, a merged row), and only re-pins while the reader is still at
+  // the bottom. `onScroll` latches that, and drives the reverse-infinite-scroll load. Re-attached
+  // only on a session switch or a plain↔virtual flip (the root element changes) — not per render.
   useEffect(() => {
-    if (follow.current) pinToBottom()
-    // The button follows the same latch: away = the reader scrolled up out of a scrollable list.
-    const el = scrollRef.current
-    onAtBottomChange?.(el ? nearBottom(el) : true)
-  }, [turns, pinToBottom, onAtBottomChange])
-
-  const onScroll = useCallback(() => {
     const el = scrollRef.current
     if (!el) return
-    follow.current = nearBottom(el)
-    onAtBottomChange?.(follow.current)
-    if (hasOlder && onLoadOlder && !loadingOlder.current && el.scrollTop <= NEAR_TOP) {
-      loadingOlder.current = true
-      // Preserve the viewport across the prepend: the caller grows the list at the top, so hold the
-      // distance-from-bottom and restore it after the new rows land.
-      const anchorFromBottom = el.scrollHeight - el.scrollTop
-      Promise.resolve(onLoadOlder()).finally(() => {
-        requestAnimationFrame(() => {
-          const pane = scrollRef.current
-          if (pane) pane.scrollTop = pane.scrollHeight - anchorFromBottom
-          loadingOlder.current = false
+    const onScroll = () => {
+      follow.current = nearBottom(el)
+      reportAtBottom(follow.current)
+      if (hasOlderRef.current && onLoadOlderRef.current && !loadingOlder.current && el.scrollTop <= NEAR_TOP) {
+        loadingOlder.current = true
+        // Hold the distance-from-bottom across the prepend and restore it after the new rows land.
+        const anchorFromBottom = el.scrollHeight - el.scrollTop
+        Promise.resolve(onLoadOlderRef.current()).finally(() => {
+          requestAnimationFrame(() => {
+            const pane = scrollRef.current
+            if (pane) pane.scrollTop = pane.scrollHeight - anchorFromBottom
+            loadingOlder.current = false
+          })
         })
-      })
+      }
     }
-  }, [hasOlder, onLoadOlder, onAtBottomChange])
-
-  useEffect(() => {
-    const el = scrollRef.current
-    if (!el) return
     el.addEventListener('scroll', onScroll, { passive: true })
-    return () => el.removeEventListener('scroll', onScroll)
-  }, [onScroll])
+    const grow = new ResizeObserver(() => {
+      if (follow.current) pinToBottom()
+      reportAtBottom(nearBottom(el))
+    })
+    if (rootRef.current) grow.observe(rootRef.current)
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      grow.disconnect()
+    }
+  }, [resetKey, virtualize, pinToBottom, reportAtBottom])
 
   useImperativeHandle(
     handleRef,
@@ -150,10 +170,10 @@ export function VirtualTranscript<T extends { key?: string }>({
       scrollToBottom() {
         follow.current = true
         pinToBottom()
-        onAtBottomChange?.(true)
+        reportAtBottom(true)
       }
     }),
-    [pinToBottom, onAtBottomChange]
+    [pinToBottom, reportAtBottom]
   )
 
   if (!virtualize) {

--- a/packages/web/src/components/console/VirtualTranscript.tsx
+++ b/packages/web/src/components/console/VirtualTranscript.tsx
@@ -72,6 +72,18 @@ export function VirtualTranscript<T extends { key?: string }>({
   // or every row is mispositioned by that gap. Measured below and kept fresh as content shifts.
   const [scrollMargin, setScrollMargin] = useState(0)
 
+  // Resolve the scroll pane via a callback ref, NOT an effect keyed on `resetKey`: for a real CP
+  // session `resetKey` is already final at mount, so an effect would never re-run when the turns
+  // land (the empty→first-render flip) and the pane would stay unresolved forever. A callback ref
+  // fires whenever the root mounts — including that flip — so the lookup is independent of resetKey.
+  const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null)
+  const setRoot = useCallback((node: HTMLDivElement | null) => {
+    rootRef.current = node
+    const pane = node?.closest<HTMLElement>('[data-transcript-scroll]') ?? null
+    scrollRef.current = pane
+    setScrollEl(pane)
+  }, [])
+
   const rowVirtualizer = useVirtualizer({
     count: virtualize ? turns.length : 0,
     enabled: virtualize,
@@ -102,9 +114,12 @@ export function VirtualTranscript<T extends { key?: string }>({
     // Scroll the PANE to its true bottom, not the last turn's: the typing dots, the flex-1 spacer
     // and the sticky composer follow the turn list, so aligning the last turn would leave the newest
     // reply under the composer and read as "not at the bottom".
+    const before = el.scrollTop
     el.scrollTop = el.scrollHeight
-    // Read back (the browser clamps) so onScroll can recognise this pin's echo by position.
-    pinnedTop.current = el.scrollTop
+    // Record the landing (browser-clamped) so onScroll can swallow this pin's echo by position — but
+    // only if the pin actually moved: an already-at-bottom pin dispatches no scroll event, so arming
+    // the latch here would instead eat the reader's next real scroll that happens to land here.
+    pinnedTop.current = el.scrollTop === before ? null : el.scrollTop
   }, [])
 
   // The list is offset from the scrollport by whatever sits above it (a "load earlier" row, the
@@ -113,7 +128,10 @@ export function VirtualTranscript<T extends { key?: string }>({
   const measureScrollMargin = useCallback(() => {
     const root = rootRef.current
     const el = scrollRef.current
-    if (!root || !el) return
+    // `offsetParent === null` means the list is display:none — opening a file conceals the transcript
+    // while the observed wrapper stays visible (hosting the viewer), so the ResizeObserver still fires.
+    // Measuring then reads all-zero rects and latches a large NEGATIVE margin; skip until it's back.
+    if (!root || !el || root.offsetParent === null) return
     const offset = root.getBoundingClientRect().top - el.getBoundingClientRect().top + el.scrollTop
     setScrollMargin((prev) => (Math.abs(prev - offset) > 0.5 ? offset : prev))
   }, [])
@@ -122,7 +140,6 @@ export function VirtualTranscript<T extends { key?: string }>({
   // the reader is yanked back to the bottom the moment they scroll up. The view mounts before the
   // turns land, so an empty pane reads as at-the-bottom and the first history render lands newest.
   useEffect(() => {
-    scrollRef.current = rootRef.current?.closest<HTMLElement>('[data-transcript-scroll]') ?? null
     follow.current = true
     reportAtBottom(true)
   }, [resetKey, reportAtBottom])
@@ -134,7 +151,7 @@ export function VirtualTranscript<T extends { key?: string }>({
   // bottom and drives the reverse-infinite-scroll load. Re-attached only on a session switch or a
   // plain↔virtual flip, not per render.
   useEffect(() => {
-    const el = scrollRef.current
+    const el = scrollEl
     if (!el) return
     const onScroll = () => {
       // Swallow the echo of our own pin: it dispatches a scroll event delivered LATER, by which time
@@ -172,7 +189,7 @@ export function VirtualTranscript<T extends { key?: string }>({
       el.removeEventListener('scroll', onScroll)
       grow.disconnect()
     }
-  }, [resetKey, virtualize, pinToBottom, reportAtBottom, measureScrollMargin])
+  }, [scrollEl, virtualize, pinToBottom, reportAtBottom, measureScrollMargin])
 
   useImperativeHandle(
     handleRef,
@@ -192,7 +209,7 @@ export function VirtualTranscript<T extends { key?: string }>({
 
   if (!virtualize) {
     return (
-      <div ref={rootRef} className="flex flex-col gap-4 max-desktop:pb-3 desktop:gap-[15px]">
+      <div ref={setRoot} className="flex flex-col gap-4 max-desktop:pb-3 desktop:gap-[15px]">
         {turns.map((turn, index) => (
           <Fragment key={turn.key ?? index}>{renderTurn(turn, index)}</Fragment>
         ))}
@@ -202,7 +219,7 @@ export function VirtualTranscript<T extends { key?: string }>({
 
   const items = rowVirtualizer.getVirtualItems()
   return (
-    <div ref={rootRef} style={{ height: rowVirtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
+    <div ref={setRoot} style={{ height: rowVirtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
       {items.map((item) => (
         <div
           key={item.key}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -81,7 +81,8 @@ import {
 } from '@/lib/session-trigger'
 import { platformTranscriptOrdering } from '@/components/console/platforms/registry'
 import { mergeSessionMessages } from '@/lib/session-transcript'
-import { useStickToBottom } from '@/lib/stick-to-bottom'
+import { VirtualTranscript, type VirtualTranscriptHandle } from '@/components/console/VirtualTranscript'
+import { estimateTurnSize } from '@/lib/transcript-virtual'
 import { socialLoginProviders } from '@/lib/social-login-providers'
 import { isAuthConfigured } from '@/lib/auth'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
@@ -2590,10 +2591,12 @@ export default function SessionDetailView() {
     void refreshTranscriptTail()
   }, [visibleTailReady, sessionBusy, sessionActivityVersion, sessionStreamGeneration, refreshTranscriptTail])
 
-  // Everything above only APPENDS rows; nothing ever moved the viewport, so a
-  // live session's newest output landed below the fold. Follow it — but only for
-  // a reader who is already at the bottom (see lib/stick-to-bottom).
-  const { pin: stickToBottom, awayFromBottom } = useStickToBottom(conversationKey ?? sid ?? null)
+  // The transcript's follow-to-bottom + jump-button state now live in <VirtualTranscript>; this
+  // just holds a handle to it. `stickToBottom` (re-arm + jump) is called from the send path and the
+  // jump button; `awayFromBottom` (the reader scrolled up out of a scrollable transcript) shows it.
+  const transcriptRef = useRef<VirtualTranscriptHandle>(null)
+  const [awayFromBottom, setAwayFromBottom] = useState(false)
+  const stickToBottom = useCallback(() => transcriptRef.current?.scrollToBottom(), [])
 
   useEffect(() => {
     if (!session || (session.platform !== 'playground' && session.platform !== 'webchat') || !sessionBusy) return
@@ -4138,246 +4141,247 @@ export default function SessionDetailView() {
           the composer stops short of. (Longhand `pb-*` always sorts after shorthand
           `p-*`, so the cancel wins — STYLE.md §8.) */}
               <div className="flex flex-1 flex-col gap-4 p-3 max-desktop:pb-0 desktop:gap-0 desktop:p-0">
-                {turns.length > 0 && (
-                  <div className="flex flex-col gap-4 max-desktop:pb-3 desktop:gap-[15px]">
-                    {turns.map((turn, ti) => (
-                      // The turn's clock time is its own centred line above the message —
-                      // a shared separator for both sides, instead of a label-row tail
-                      // that never lines up with the bubble edge on either side.
-                      <div key={turn.key} className="flex flex-col gap-[5px]">
-                        {turn.time && (
-                          <div className="mono text-center text-[11px] leading-normal text-(--text-tertiary)">
-                            {turn.time}
-                          </div>
-                        )}
-                        {turn.kind === 'user' ? (
-                          // 2b: user turns are right-aligned brand-soft bubbles. A sender label
-                          // sits above the bubble only when it isn't you (platform user / cron).
-                          <div className="group/turn flex items-start justify-end gap-[9px]">
-                            <div className="relative flex min-w-0 max-w-[86%] flex-col items-end gap-[3px]">
-                              {showsSenderLabel(turn) && (
-                                <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
-                                  {turn.isCron && turn.cronId ? (
-                                    <Link className="lnk text-inherit" href={orgPath(`/crons/${turn.cronId}`)}>
-                                      {turn.sp.name}
-                                    </Link>
-                                  ) : (
-                                    <span>{turn.sp.name}</span>
-                                  )}
-                                </span>
-                              )}
-                              <div className={SELF_BUBBLE}>
-                                {turn.image && (
-                                  <img
-                                    src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
-                                    alt={turn.image.name}
-                                    className={`max-h-[360px] max-w-full rounded-md object-contain ${turn.text ? 'mb-[10px]' : ''}`}
-                                  />
+                <VirtualTranscript
+                  turns={turns}
+                  estimate={estimateTurnSize}
+                  resetKey={conversationKey ?? sid ?? null}
+                  onAtBottomChange={(atBottom) => setAwayFromBottom(!atBottom)}
+                  handleRef={transcriptRef}
+                  renderTurn={(turn, ti) => (
+                    // The turn's clock time is its own centred line above the message —
+                    // a shared separator for both sides, instead of a label-row tail
+                    // that never lines up with the bubble edge on either side.
+                    <div key={turn.key} className="flex flex-col gap-[5px]">
+                      {turn.time && (
+                        <div className="mono text-center text-[11px] leading-normal text-(--text-tertiary)">
+                          {turn.time}
+                        </div>
+                      )}
+                      {turn.kind === 'user' ? (
+                        // 2b: user turns are right-aligned brand-soft bubbles. A sender label
+                        // sits above the bubble only when it isn't you (platform user / cron).
+                        <div className="group/turn flex items-start justify-end gap-[9px]">
+                          <div className="relative flex min-w-0 max-w-[86%] flex-col items-end gap-[3px]">
+                            {showsSenderLabel(turn) && (
+                              <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
+                                {turn.isCron && turn.cronId ? (
+                                  <Link className="lnk text-inherit" href={orgPath(`/crons/${turn.cronId}`)}>
+                                    {turn.sp.name}
+                                  </Link>
+                                ) : (
+                                  <span>{turn.sp.name}</span>
                                 )}
-                                {turn.text && <MessageText text={turn.text} platform={turn.platform} />}
-                              </div>
-                              {/* Sent bubbles are complete by definition — the copy affordance
+                              </span>
+                            )}
+                            <div className={SELF_BUBBLE}>
+                              {turn.image && (
+                                <img
+                                  src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
+                                  alt={turn.image.name}
+                                  className={`max-h-[360px] max-w-full rounded-md object-contain ${turn.text ? 'mb-[10px]' : ''}`}
+                                />
+                              )}
+                              {turn.text && <MessageText text={turn.text} platform={turn.platform} />}
+                            </div>
+                            {/* Sent bubbles are complete by definition — the copy affordance
                         (hover-revealed, right-aligned under the bubble) always mounts.
                         Absolutely positioned into the inter-turn gap so revealing it
                         never changes the row's height. */}
-                              {turn.text && (
-                                <span className="absolute right-0 top-full">
-                                  <CopyTurnButton text={turn.text} />
-                                </span>
-                              )}
-                            </div>
-                            <ParticipantAvatar
-                              agent={turn.agent}
-                              avatarUrl={turn.avatarUrl}
-                              avatarInitials={turn.avatarInitials}
-                              platformMark={usesIntegrationAvatar ? sessionIntegration : undefined}
-                              sp={turn.sp}
-                              isCron={turn.isCron}
-                              // Optically centre the 26px mark on the bubble's FIRST LINE, not
-                              // on the bubble's top edge: 9px of padding plus half of a 21px
-                              // line puts that centre 19.5px down, while a top-aligned mark
-                              // centres at 13px — the 6px it looked too high by. A labelled row
-                              // keeps the mark level with its label instead, like the bot side.
-                              className={showsSenderLabel(turn) ? '' : 'mt-[6px]'}
-                            />
+                            {turn.text && (
+                              <span className="absolute right-0 top-full">
+                                <CopyTurnButton text={turn.text} />
+                              </span>
+                            )}
                           </div>
-                        ) : (
-                          (() => {
-                            // 2b: the spoken answer (MSG/DONE) is plain text; the agent's work
-                            // (reasoning / plan / tool / edit) collapses behind a per-turn toggle.
-                            const textSteps = turn.steps.filter((s) => !WORK_LANES.has(s.lane))
-                            const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
-                            // Reasoning steps / tool commands / edited FILES (distinct paths across
-                            // EDIT rows, since one EDIT row can touch several files).
-                            const { thinkCount, toolCount, editCount } = workCounts(workSteps)
-                            const summary = workSummary(thinkCount, toolCount, editCount)
-                            // Is this turn still streaming? A multi-agent live webchat runs
-                            // several reply lanes at once, so a TAGGED turn asks its own lane
-                            // (an earlier still-active participant must not show the copy
-                            // affordance or lose its live line just because a later turn renders
-                            // below it). Lane-less/single-agent streams keep the trailing-turn
-                            // fallback. statusLabel carries the RAW session state — the
-                            // active-turn predicate lives (and is tested) in session-work.ts.
-                            const turnInFlight = sessionTurnInFlight(pgBusy, session.statusLabel)
-                            const busyLanes = turnInFlight ? getBusyLaneAgentIds(session.id) : []
-                            // The lane only says WHICH AGENT is busy — restrict the match to that
-                            // agent's LAST turn so its finished history stays non-streaming.
-                            const streaming =
-                              turnInFlight &&
-                              (turn.agentId && busyLanes.length > 0
-                                ? busyLanes.includes(turn.agentId) && lastBotTurnIndexByAgent.get(turn.agentId) === ti
-                                : ti === turns.length - 1)
-                            const openWork = workPanelOpen(workOverride.get(turn.key ?? ''))
-                            // Is the WORK itself still running? `streaming` alone is turn-level —
-                            // it stays true while the spoken answer streams AFTER the last tool
-                            // finished, which must not keep the live line alive. ACP tool calls
-                            // can also run in PARALLEL, each update replacing its original row
-                            // in place (keyed by toolCallId) — so "the newest row is finished"
-                            // does not mean the work is: any non-terminal tool row keeps the
-                            // work running, and the LATEST such row is what the toggle line
-                            // reports. With no active tool, a trailing unfinished work step
-                            // still counts (THINK rows carry no status and run until
-                            // superseded); a trailing text step means the agent moved on to its
-                            // answer.
-                            const stepDone = (st?: FmtStep) =>
-                              ['completed', 'failed'].includes((st?.msg?.toolStatus ?? '').toLowerCase())
-                            const activeTool = [...workSteps]
-                              .reverse()
-                              .find((st) => st.msg?.toolCallId && !stepDone(st))
-                            const lastStep = turn.steps[turn.steps.length - 1]
-                            const tailRunning = !!lastStep && WORK_LANES.has(lastStep.lane) && !stepDone(lastStep)
-                            const liveStep = activeTool ?? (tailRunning ? lastStep : undefined)
-                            const workRunning = streaming && liveStep !== undefined
-                            // While work runs, the toggle line also carries what is running RIGHT
-                            // NOW — the live step's first line (tool rows keep the command in
-                            // `code`) — so a collapsed panel still shows live progress.
-                            // trimStart skips the blank lines reasoning text can open with; a
-                            // reasoning line also drops its markdown markers (same as the row title).
-                            const liveRaw =
-                              workRunning && liveStep
-                                ? (liveStep.text || liveStep.code)?.trimStart().split('\n', 1)[0]?.trim()
-                                : undefined
-                            const liveLine = liveRaw && liveStep?.text ? stripMdMarkers(liveRaw) : liveRaw
-                            // Step identity for the fade-in key: two consecutive steps can show
-                            // the SAME first line, and a keyed-by-text span would keep its DOM
-                            // node and never replay the animation.
-                            const liveKey =
-                              liveStep && liveLine
-                                ? `${liveStep.msg?.toolCallId ?? turn.steps.indexOf(liveStep)}:${liveLine}`
-                                : undefined
-                            // Keyed by agent id where there is one so the colour survives a
-                            // rename; a mock/playground row without an id falls back to the
-                            // display name, which is stable for as long as the row is.
-                            const turnTone = agentToneColor(turn.agentId || turn.agentName)
-                            // What the bubble-level copy button copies: the spoken answer.
-                            const answerText = textSteps
-                              .map((st) => st.text)
-                              .filter(Boolean)
-                              .join('\n\n')
-                            return (
-                              <div
-                                key={`${session.id}:${ti}`}
-                                className="group/turn flex items-start gap-2 desktop:gap-[10px]"
-                              >
-                                <span className="av h-[26px] w-[26px] flex-none rounded-md">
-                                  <AgentIconView
-                                    icon={((turn.agentId ? agentById.get(turn.agentId) : owner) ?? owner)?.icon}
-                                    runtime={
-                                      (turn.agentId ? agentById.get(turn.agentId)?.runtime : undefined) ??
-                                      (agentRuntime || turn.model)
-                                    }
-                                    size={26}
-                                  />
-                                </span>
-                                <div className="min-w-0 flex-1" style={{ '--agent-accent': turnTone } as CSSProperties}>
-                                  <div className="mb-[5px] flex items-center gap-[7px]">
-                                    <span className={AGENT_NAME}>{turn.agentName}</span>
-                                  </div>
-                                  {/* One bubble per text step: a turn that answers in two chunks
+                          <ParticipantAvatar
+                            agent={turn.agent}
+                            avatarUrl={turn.avatarUrl}
+                            avatarInitials={turn.avatarInitials}
+                            platformMark={usesIntegrationAvatar ? sessionIntegration : undefined}
+                            sp={turn.sp}
+                            isCron={turn.isCron}
+                            // Optically centre the 26px mark on the bubble's FIRST LINE, not
+                            // on the bubble's top edge: 9px of padding plus half of a 21px
+                            // line puts that centre 19.5px down, while a top-aligned mark
+                            // centres at 13px — the 6px it looked too high by. A labelled row
+                            // keeps the mark level with its label instead, like the bot side.
+                            className={showsSenderLabel(turn) ? '' : 'mt-[6px]'}
+                          />
+                        </div>
+                      ) : (
+                        (() => {
+                          // 2b: the spoken answer (MSG/DONE) is plain text; the agent's work
+                          // (reasoning / plan / tool / edit) collapses behind a per-turn toggle.
+                          const textSteps = turn.steps.filter((s) => !WORK_LANES.has(s.lane))
+                          const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
+                          // Reasoning steps / tool commands / edited FILES (distinct paths across
+                          // EDIT rows, since one EDIT row can touch several files).
+                          const { thinkCount, toolCount, editCount } = workCounts(workSteps)
+                          const summary = workSummary(thinkCount, toolCount, editCount)
+                          // Is this turn still streaming? A multi-agent live webchat runs
+                          // several reply lanes at once, so a TAGGED turn asks its own lane
+                          // (an earlier still-active participant must not show the copy
+                          // affordance or lose its live line just because a later turn renders
+                          // below it). Lane-less/single-agent streams keep the trailing-turn
+                          // fallback. statusLabel carries the RAW session state — the
+                          // active-turn predicate lives (and is tested) in session-work.ts.
+                          const turnInFlight = sessionTurnInFlight(pgBusy, session.statusLabel)
+                          const busyLanes = turnInFlight ? getBusyLaneAgentIds(session.id) : []
+                          // The lane only says WHICH AGENT is busy — restrict the match to that
+                          // agent's LAST turn so its finished history stays non-streaming.
+                          const streaming =
+                            turnInFlight &&
+                            (turn.agentId && busyLanes.length > 0
+                              ? busyLanes.includes(turn.agentId) && lastBotTurnIndexByAgent.get(turn.agentId) === ti
+                              : ti === turns.length - 1)
+                          const openWork = workPanelOpen(workOverride.get(turn.key ?? ''))
+                          // Is the WORK itself still running? `streaming` alone is turn-level —
+                          // it stays true while the spoken answer streams AFTER the last tool
+                          // finished, which must not keep the live line alive. ACP tool calls
+                          // can also run in PARALLEL, each update replacing its original row
+                          // in place (keyed by toolCallId) — so "the newest row is finished"
+                          // does not mean the work is: any non-terminal tool row keeps the
+                          // work running, and the LATEST such row is what the toggle line
+                          // reports. With no active tool, a trailing unfinished work step
+                          // still counts (THINK rows carry no status and run until
+                          // superseded); a trailing text step means the agent moved on to its
+                          // answer.
+                          const stepDone = (st?: FmtStep) =>
+                            ['completed', 'failed'].includes((st?.msg?.toolStatus ?? '').toLowerCase())
+                          const activeTool = [...workSteps].reverse().find((st) => st.msg?.toolCallId && !stepDone(st))
+                          const lastStep = turn.steps[turn.steps.length - 1]
+                          const tailRunning = !!lastStep && WORK_LANES.has(lastStep.lane) && !stepDone(lastStep)
+                          const liveStep = activeTool ?? (tailRunning ? lastStep : undefined)
+                          const workRunning = streaming && liveStep !== undefined
+                          // While work runs, the toggle line also carries what is running RIGHT
+                          // NOW — the live step's first line (tool rows keep the command in
+                          // `code`) — so a collapsed panel still shows live progress.
+                          // trimStart skips the blank lines reasoning text can open with; a
+                          // reasoning line also drops its markdown markers (same as the row title).
+                          const liveRaw =
+                            workRunning && liveStep
+                              ? (liveStep.text || liveStep.code)?.trimStart().split('\n', 1)[0]?.trim()
+                              : undefined
+                          const liveLine = liveRaw && liveStep?.text ? stripMdMarkers(liveRaw) : liveRaw
+                          // Step identity for the fade-in key: two consecutive steps can show
+                          // the SAME first line, and a keyed-by-text span would keep its DOM
+                          // node and never replay the animation.
+                          const liveKey =
+                            liveStep && liveLine
+                              ? `${liveStep.msg?.toolCallId ?? turn.steps.indexOf(liveStep)}:${liveLine}`
+                              : undefined
+                          // Keyed by agent id where there is one so the colour survives a
+                          // rename; a mock/playground row without an id falls back to the
+                          // display name, which is stable for as long as the row is.
+                          const turnTone = agentToneColor(turn.agentId || turn.agentName)
+                          // What the bubble-level copy button copies: the spoken answer.
+                          const answerText = textSteps
+                            .map((st) => st.text)
+                            .filter(Boolean)
+                            .join('\n\n')
+                          return (
+                            <div
+                              key={`${session.id}:${ti}`}
+                              className="group/turn flex items-start gap-2 desktop:gap-[10px]"
+                            >
+                              <span className="av h-[26px] w-[26px] flex-none rounded-md">
+                                <AgentIconView
+                                  icon={((turn.agentId ? agentById.get(turn.agentId) : owner) ?? owner)?.icon}
+                                  runtime={
+                                    (turn.agentId ? agentById.get(turn.agentId)?.runtime : undefined) ??
+                                    (agentRuntime || turn.model)
+                                  }
+                                  size={26}
+                                />
+                              </span>
+                              <div className="min-w-0 flex-1" style={{ '--agent-accent': turnTone } as CSSProperties}>
+                                <div className="mb-[5px] flex items-center gap-[7px]">
+                                  <span className={AGENT_NAME}>{turn.agentName}</span>
+                                </div>
+                                {/* One bubble per text step: a turn that answers in two chunks
                             arrives as two delivered messages, so one wrapper around the set
                             would merge messages the platform kept apart. */}
-                                  {textSteps.map((st, si) => (
-                                    <div key={si} className={`${AGENT_BUBBLE} ${si > 0 ? 'mt-2' : ''}`}>
-                                      {st.image && (
-                                        <img
-                                          src={`data:${st.image.mimeType};base64,${st.image.data}`}
-                                          alt={st.image.name}
-                                          className={`max-h-[360px] max-w-full rounded-md object-contain ${st.text ? 'mb-[10px]' : ''}`}
-                                        />
-                                      )}
-                                      {st.text && (
-                                        <div className="whitespace-pre-wrap">
-                                          <MessageText text={st.text} platform={st.platform} />
-                                        </div>
-                                      )}
-                                      <StepExtras step={st} sessionId={toolSid} />
-                                    </div>
-                                  ))}
-                                  {workSteps.length > 0 && (
-                                    <>
-                                      {/* One row: the work toggle, with the bubble's copy button at
-                                the line's end — mounted only once the turn has finished. */}
-                                      <div className="mt-2 flex min-w-0 items-center gap-[6px]">
-                                        <button
-                                          type="button"
-                                          onClick={() => toggleWork(turn.key ?? '', openWork)}
-                                          className="inline-flex min-w-0 items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
-                                          title={openWork ? 'Hide the agent’s work' : 'Show the agent’s work'}
-                                        >
-                                          <Icon
-                                            name={openWork ? 'chevron-down' : 'chevron-right'}
-                                            size={13}
-                                            color="var(--text-tertiary)"
-                                          />
-                                          <span className="flex-none">{summary || 'Details'}</span>
-                                          {liveLine && (
-                                            // Keyed by step identity + content: a new step (or a new
-                                            // first line within one) remounts the span, replaying the
-                                            // ac-rise fade-in (honors reduced-motion in globals.css).
-                                            <span key={liveKey} className="work-live min-w-0 truncate">
-                                              · {liveLine}
-                                            </span>
-                                          )}
-                                        </button>
-                                        {!streaming && answerText && <CopyTurnButton text={answerText} />}
+                                {textSteps.map((st, si) => (
+                                  <div key={si} className={`${AGENT_BUBBLE} ${si > 0 ? 'mt-2' : ''}`}>
+                                    {st.image && (
+                                      <img
+                                        src={`data:${st.image.mimeType};base64,${st.image.data}`}
+                                        alt={st.image.name}
+                                        className={`max-h-[360px] max-w-full rounded-md object-contain ${st.text ? 'mb-[10px]' : ''}`}
+                                      />
+                                    )}
+                                    {st.text && (
+                                      <div className="whitespace-pre-wrap">
+                                        <MessageText text={st.text} platform={st.platform} />
                                       </div>
-                                      {openWork && (
-                                        <div className="mt-2 overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
-                                          {/* All work steps show, streaming or not — a live turn's
-                                    panel grows as steps arrive so the whole run is visible. */}
-                                          {workSteps.map((st, si) => (
-                                            <WorkStepRow
-                                              // Keyed by tool identity where there is one, so an
-                                              // open row survives re-renders as new steps stream
-                                              // in. Steps without a tool id (THINK rows) fall back
-                                              // to the index; within one agent's turn a toolCallId
-                                              // appears once.
-                                              key={st.msg?.toolCallId ?? `i:${si}`}
-                                              step={st}
-                                              sessionId={toolSid}
-                                              divider={si > 0}
-                                            />
-                                          ))}
-                                        </div>
-                                      )}
-                                    </>
-                                  )}
-                                  {/* A turn with no work has no toggle row — the finished
-                            bubble's copy button gets its own line instead. */}
-                                  {workSteps.length === 0 && !streaming && answerText && (
-                                    <div className="mt-2 flex">
-                                      <CopyTurnButton text={answerText} />
+                                    )}
+                                    <StepExtras step={st} sessionId={toolSid} />
+                                  </div>
+                                ))}
+                                {workSteps.length > 0 && (
+                                  <>
+                                    {/* One row: the work toggle, with the bubble's copy button at
+                                the line's end — mounted only once the turn has finished. */}
+                                    <div className="mt-2 flex min-w-0 items-center gap-[6px]">
+                                      <button
+                                        type="button"
+                                        onClick={() => toggleWork(turn.key ?? '', openWork)}
+                                        className="inline-flex min-w-0 items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
+                                        title={openWork ? 'Hide the agent’s work' : 'Show the agent’s work'}
+                                      >
+                                        <Icon
+                                          name={openWork ? 'chevron-down' : 'chevron-right'}
+                                          size={13}
+                                          color="var(--text-tertiary)"
+                                        />
+                                        <span className="flex-none">{summary || 'Details'}</span>
+                                        {liveLine && (
+                                          // Keyed by step identity + content: a new step (or a new
+                                          // first line within one) remounts the span, replaying the
+                                          // ac-rise fade-in (honors reduced-motion in globals.css).
+                                          <span key={liveKey} className="work-live min-w-0 truncate">
+                                            · {liveLine}
+                                          </span>
+                                        )}
+                                      </button>
+                                      {!streaming && answerText && <CopyTurnButton text={answerText} />}
                                     </div>
-                                  )}
-                                </div>
+                                    {openWork && (
+                                      <div className="mt-2 overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
+                                        {/* All work steps show, streaming or not — a live turn's
+                                    panel grows as steps arrive so the whole run is visible. */}
+                                        {workSteps.map((st, si) => (
+                                          <WorkStepRow
+                                            // Keyed by tool identity where there is one, so an
+                                            // open row survives re-renders as new steps stream
+                                            // in. Steps without a tool id (THINK rows) fall back
+                                            // to the index; within one agent's turn a toolCallId
+                                            // appears once.
+                                            key={st.msg?.toolCallId ?? `i:${si}`}
+                                            step={st}
+                                            sessionId={toolSid}
+                                            divider={si > 0}
+                                          />
+                                        ))}
+                                      </div>
+                                    )}
+                                  </>
+                                )}
+                                {/* A turn with no work has no toggle row — the finished
+                            bubble's copy button gets its own line instead. */}
+                                {workSteps.length === 0 && !streaming && answerText && (
+                                  <div className="mt-2 flex">
+                                    <CopyTurnButton text={answerText} />
+                                  </div>
+                                )}
                               </div>
-                            )
-                          })()
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
+                            </div>
+                          )
+                        })()
+                      )}
+                    </div>
+                  )}
+                />
 
                 {/* LIVE INDICATOR — mobile-only trailing bot avatar + blue-dot note while a
             platform run is live. (A live playground/webchat surface uses the

--- a/packages/web/src/lib/transcript-virtual.test.ts
+++ b/packages/web/src/lib/transcript-virtual.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { estimateTurnSize, shouldVirtualizeTranscript, VIRTUALIZE_THRESHOLD } from './transcript-virtual'
+
+describe('shouldVirtualizeTranscript', () => {
+  it('leaves short transcripts on the plain path and virtualizes long ones', () => {
+    expect(shouldVirtualizeTranscript(VIRTUALIZE_THRESHOLD)).toBe(false)
+    expect(shouldVirtualizeTranscript(VIRTUALIZE_THRESHOLD + 1)).toBe(true)
+    expect(shouldVirtualizeTranscript(0)).toBe(false)
+  })
+})
+
+describe('estimateTurnSize', () => {
+  it('gives a positive height for both kinds and grows a bot turn with its steps', () => {
+    const user = estimateTurnSize({ kind: 'user', text: 'hi' })
+    const oneStep = estimateTurnSize({ kind: 'bot', steps: [{ text: 'ok' }] })
+    const manySteps = estimateTurnSize({
+      kind: 'bot',
+      steps: [{ text: 'plan' }, { text: 'tool' }, { text: 'done' }]
+    })
+    expect(user).toBeGreaterThan(0)
+    expect(oneStep).toBeGreaterThan(0)
+    expect(manySteps).toBeGreaterThan(oneStep)
+  })
+
+  it('adds height for a long message and for an image', () => {
+    const short = estimateTurnSize({ kind: 'user', text: 'x' })
+    const long = estimateTurnSize({ kind: 'user', text: 'x'.repeat(500) })
+    const withImage = estimateTurnSize({ kind: 'user', text: 'x', image: {} })
+    expect(long).toBeGreaterThan(short)
+    expect(withImage).toBeGreaterThan(short)
+  })
+
+  it('never returns a zero-height bot turn even with no steps', () => {
+    expect(estimateTurnSize({ kind: 'bot', steps: [] })).toBeGreaterThan(0)
+  })
+})

--- a/packages/web/src/lib/transcript-virtual.ts
+++ b/packages/web/src/lib/transcript-virtual.ts
@@ -1,0 +1,47 @@
+// Pure inputs for virtualizing the webchat transcript (deepseek-harness style): a length
+// threshold below which plain rendering wins, and a per-turn size ESTIMATE. The estimate only
+// seeds the virtualizer's initial scroll math — `measureElement` replaces it with the real height
+// once a row mounts — so it just needs to be a sane first guess, not exact.
+
+/** Turn counts at or below this render plainly (no virtualization): short chats don't pay the DOM
+ *  cost, and the plain path keeps the existing `useStickToBottom` follow untouched. */
+export const VIRTUALIZE_THRESHOLD = 60
+
+/** Whether a transcript of `turnCount` turns is worth virtualizing. */
+export function shouldVirtualizeTranscript(turnCount: number): boolean {
+  return turnCount > VIRTUALIZE_THRESHOLD
+}
+
+/** The minimal turn shape the estimate reads — a structural subset of the view's `Turn`. */
+export interface EstimableTurn {
+  kind: 'user' | 'bot'
+  text?: string
+  image?: unknown
+  steps?: readonly { text?: string; code?: string }[]
+}
+
+const BASE_ROW = 44 // the turn's time line + vertical gaps
+const USER_BASE = 40 // one right-aligned bubble
+const BOT_STEP = 56 // one agent step (a bubble / tool row / collapsed work line)
+const IMAGE = 220 // an attached image, before it decodes
+const CHARS_PER_LINE = 64
+const LINE = 20
+
+function textHeight(text: string | undefined): number {
+  if (!text) return 0
+  return Math.ceil(text.length / CHARS_PER_LINE) * LINE
+}
+
+/** A rough first-paint height for one turn, refined by measurement on mount. User turns are one
+ *  bubble; bot turns grow with their step count and the text they carry. */
+export function estimateTurnSize(turn: EstimableTurn): number {
+  if (turn.kind === 'user') {
+    return BASE_ROW + USER_BASE + textHeight(turn.text) + (turn.image ? IMAGE : 0)
+  }
+  const steps = turn.steps ?? []
+  const stepsHeight = steps.reduce(
+    (sum, step) => sum + BOT_STEP + textHeight(step.text) + (step.code ? textHeight(step.code) : 0),
+    0
+  )
+  return BASE_ROW + Math.max(BOT_STEP, stepsHeight)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,7 +254,7 @@ importers:
         version: 10.0.0
       prisma:
         specifier: ^7.9.0
-        version: 7.9.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(better-sqlite3@11.10.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        version: 7.9.0(@types/react-dom@19.2.4(@types/react@19.2.17))(@types/react@19.2.17)(better-sqlite3@11.10.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       testcontainers:
         specifier: ^12.0.4
         version: 12.0.4
@@ -613,10 +613,10 @@ importers:
         version: link:../protocol
       '@iconify-icons/logos':
         specifier: ^1.2.36
-        version: 1.2.36
+        version: 1.2.37
       '@iconify-icons/ph':
         specifier: ^1.2.5
-        version: 1.2.5
+        version: 1.2.6
       '@iconify/react':
         specifier: ^6.0.2
         version: 6.0.2(react@19.2.8)
@@ -650,6 +650,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.43.0
         version: 1.43.0
+      '@tanstack/react-virtual':
+        specifier: ^3.14.10
+        version: 3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       croner:
         specifier: ^10.0.1
         version: 10.0.1
@@ -658,7 +661,7 @@ importers:
         version: 3.24.0
       highlight.js:
         specifier: ^11.11.1
-        version: 11.11.1
+        version: 11.12.0
       lucide-react:
         specifier: ^1.26.0
         version: 1.26.0(react@19.2.8)
@@ -707,7 +710,7 @@ importers:
         version: 19.2.17
       '@types/react-dom':
         specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
+        version: 19.2.4(@types/react@19.2.17)
       happy-dom:
         specifier: ^20.11.1
         version: 20.11.1
@@ -1439,11 +1442,11 @@ packages:
     resolution: {integrity: sha512-JUxFuACcKhDC+shavgyLEFjWiSsBjI+tjIBvLrzcHywh0HqTT0m+whe2kL3isPheBzrduSMfovwypbSuKwCp+g==}
     engines: {node: '>=20.0.0'}
 
-  '@iconify-icons/logos@1.2.36':
-    resolution: {integrity: sha512-VzF299ubR4SKCZzLJoAawxeSjszJV1Q6y+4chCIPQuAafqfjtDjZxagZxL3ILKCsRLNN/z3zmCOOAL83tC8kLw==}
+  '@iconify-icons/logos@1.2.37':
+    resolution: {integrity: sha512-AAh0X+3wDATSzSV1NWOI+G9K2WTTVU+BsCkcQ2gDwZ1MHbRg+d+VmGfXcpFuqCm2/9prUJwVA6moAswQ9MoNzQ==}
 
-  '@iconify-icons/ph@1.2.5':
-    resolution: {integrity: sha512-Ox2VkJDoFowrf0e74LlLUuLMiN73PsCN28MUx9wCQfyZAFrL8ntfBnMpzukfi/0vN9qpJKAiKYZ3dQ5JjBqt/A==}
+  '@iconify-icons/ph@1.2.6':
+    resolution: {integrity: sha512-UDxq7IcdkafYV49vkvBRRHNiWjlNXXm9vLUOTtzHSu2+qnyK99xwoF7psZwM+6ATdGBabhi87VpFUTGso0FrdA==}
 
   '@iconify/react@6.0.2':
     resolution: {integrity: sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg==}
@@ -3376,6 +3379,15 @@ packages:
   '@tailwindcss/postcss@4.3.3':
     resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
+  '@tanstack/react-virtual@3.14.10':
+    resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.8':
+    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
+
   '@testcontainers/postgresql@12.0.4':
     resolution: {integrity: sha512-a/pLU6j5lpKKAlUTPwqweqMGhOSjgTSb6HBX69TOrXn32ifU37nnQDmNFTj8ddOAw+BQL9oTRkeOxVbZkqhgZA==}
 
@@ -3524,8 +3536,8 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
     peerDependencies:
       '@types/react': ^19.2.0
 
@@ -5653,7 +5665,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -5751,8 +5763,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  highlight.js@11.11.1:
-    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+  highlight.js@11.12.0:
+    resolution: {integrity: sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==}
     engines: {node: '>=12.0.0'}
 
   hono@4.12.32:
@@ -9895,11 +9907,11 @@ snapshots:
       - supports-color
     optional: true
 
-  '@iconify-icons/logos@1.2.36':
+  '@iconify-icons/logos@1.2.37':
     dependencies:
       '@iconify/types': 2.0.0
 
-  '@iconify-icons/ph@1.2.5':
+  '@iconify-icons/ph@1.2.6':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -11165,9 +11177,9 @@ snapshots:
       env-paths: 3.0.0
       proper-lockfile: 4.1.2
 
-  '@prisma/studio-core@0.33.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@prisma/studio-core@0.33.0(@types/react-dom@19.2.4(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react': 19.2.17
       '@visx/curve': 4.0.1-alpha.0
       '@visx/event': 4.0.1-alpha.0
@@ -11216,14 +11228,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.4(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react-dom': 19.2.4(@types/react@19.2.17)
 
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.17)(react@19.2.8)':
     dependencies:
@@ -11232,16 +11244,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.4(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react-dom': 19.2.4(@types/react@19.2.17)
 
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.17)(react@19.2.8)':
     dependencies:
@@ -11828,6 +11840,14 @@ snapshots:
       postcss: 8.5.25
       tailwindcss: 4.3.3
 
+  '@tanstack/react-virtual@3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.8
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  '@tanstack/virtual-core@3.17.8': {}
+
   '@testcontainers/postgresql@12.0.4':
     dependencies:
       testcontainers: 12.0.4
@@ -12003,7 +12023,7 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
-  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+  '@types/react-dom@19.2.4(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
 
@@ -14286,7 +14306,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  highlight.js@11.11.1: {}
+  highlight.js@11.12.0: {}
 
   hono@4.12.32: {}
 
@@ -14376,7 +14396,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.18.0(debug@4.3.4))
+      retry-axios: 2.6.0(axios@1.18.0)
       tough-cookie: 4.1.3
     transitivePeerDependencies:
       - supports-color
@@ -16071,12 +16091,12 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(better-sqlite3@11.10.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3):
+  prisma@7.9.0(@types/react-dom@19.2.4(@types/react@19.2.17))(@types/react@19.2.17)(better-sqlite3@11.10.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3):
     dependencies:
       '@prisma/config': 7.9.0
       '@prisma/dev': 0.24.14(typescript@6.0.3)
       '@prisma/engines': 7.9.0
-      '@prisma/studio-core': 0.33.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@prisma/studio-core': 0.33.0(@types/react-dom@19.2.4(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       mysql2: 3.15.3
       postgres: 3.4.7
     optionalDependencies:
@@ -16608,7 +16628,7 @@ snapshots:
 
   ret@0.5.0: {}
 
-  retry-axios@2.6.0(axios@1.18.0(debug@4.3.4)):
+  retry-axios@2.6.0(axios@1.18.0):
     dependencies:
       axios: 1.18.0(debug@4.3.4)
     optional: true


### PR DESCRIPTION
## What & why

deepseek-harness-style virtual scrolling for the webchat transcript, extracted into a dedicated
component so `SessionDetailView` stops owning the scroll machinery.

**`<VirtualTranscript>`** (`components/console/VirtualTranscript.tsx`) owns the whole scroll concern:
- **≤60 turns → plain render** (unchanged behaviour); **>60 → `@tanstack/react-virtual` windowing**
  — only the visible turns in the DOM, dynamic `measureElement` heights, and a `scrollMargin` so the
  rows sit right below the "load earlier" row.
- **Follow-to-bottom** (the old `useStickToBottom` logic, folded in and fixed) driven by a
  `ResizeObserver` on actual growth — armed only on a session switch, so scrolling up *sticks* — plus
  reverse-infinite-scroll prepend anchoring.
- Exposes `scrollToBottom()` (jump button + send re-arm) and `onAtBottomChange` (drives the button).

The per-turn JSX stays in `SessionDetailView` via a `renderTurn` render prop (no dep threading); the
component finds the scroll pane as its `[data-transcript-scroll]` ancestor. `useStickToBottom` is no
longer used by the view.

`transcript-virtual.ts` holds the pure bits: the length threshold and a per-turn size estimate
(unit-tested).

## Notes for reviewers

- The `SessionDetailView` churn is mostly the `turns.map` block becoming `<VirtualTranscript … />`
  and the `useStickToBottom` → handle swap.
- The composer stays `sticky bottom-0` inside the pane for now (it sits *after* the virtualized turn
  range, so it coexists); pulling it out to a fixed footer is optional follow-up.
- `lib/stick-to-bottom.ts` is now dead and can be removed in a cleanup pass.

## Test plan

- [x] `tsc --noEmit` — 0 errors; eslint + prettier clean.
- [x] `next build` — compiles; unit tests for `transcript-virtual`.
- [x] Deployed to a live box; verified follow / jump / streaming and that scroll-up sticks.
- [ ] Reviewer: exercise a >60-turn session for the windowed path (smooth scroll, DOM holds a
      window, no jumps); short sessions unchanged.

## Follow-ups (deferred)

- Wire `onLoadOlder` so paging back doesn't jump (component already supports it).
- Composer-out to a fixed footer; remove dead `stick-to-bottom.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
