### PR TITLE
fix(daemon): inject the Claude model credential into the x-api-key slot

### DIFF
--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -141,6 +141,9 @@ The cloud daemon's static pair is `MODEL_TOKEN` plus optional `MODEL_BASE_URL`, 
 per-runtime pair that replaces it whole: `ANTHROPIC_MODEL_TOKEN`/`ANTHROPIC_MODEL_BASE_URL`
 for Claude, `OPENAI_MODEL_*` for Codex, `DEEPSEEK_MODEL_*` for the DeepSeek Harness.
 OpenCode has no pair of its own — it picks a provider per model and takes the shared one.
+`*_MODEL_TOKEN` names an opaque deployment credential, not a header choice: despite the
+word "token" it is unrelated to `ANTHROPIC_AUTH_TOKEN`, and Claude's injection slot is
+`ANTHROPIC_API_KEY` (see the table below).
 
 One deployment gateway is still one address; the runtimes just do not agree on where their
 base ends. Claude Code appends `/v1/messages` to its base, while Codex appends `/responses`

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -152,7 +152,7 @@ must be an HTTP(S) URL. Each pair is translated at runtime launch:
 
 | Runtime  | Token                                                                                    | Base URL                                                                                                                             |
 | -------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| Claude   | `ANTHROPIC_AUTH_TOKEN`                                                                   | `ANTHROPIC_BASE_URL`                                                                                                                 |
+| Claude   | `ANTHROPIC_API_KEY` (`ANTHROPIC_AUTH_TOKEN` is cleared — one credential per launch)      | `ANTHROPIC_BASE_URL`                                                                                                                 |
 | Codex    | `OPENAI_API_KEY`                                                                         | `CODEX_CONFIG` → `model_provider = "openai"` and `model_providers.openai.base_url`; `OPENAI_BASE_URL` is also set for older adapters |
 | OpenCode | `OPENCODE_CONFIG_CONTENT` → selected provider `options.apiKey` using `{env:MODEL_TOKEN}` | selected provider `options.baseURL`                                                                                                  |
 | DeepSeek | `DEEPSEEK_API_KEY`                                                                       | `DEEPSEEK_BASE_URL`                                                                                                                  |

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -67,8 +67,10 @@ export function applyModelCredential(
   credential: ModelCredential
 ): void {
   if (target.runtime === 'claude') {
-    env.ANTHROPIC_AUTH_TOKEN = credential.key
-    delete env.ANTHROPIC_API_KEY
+    // The x-api-key slot, matching the other runtimes' same-slot shape: the sandbox shim's
+    // per-variable AC_CLAUDE_API_KEY fill-in stays blocked, so exactly one credential travels.
+    env.ANTHROPIC_API_KEY = credential.key
+    delete env.ANTHROPIC_AUTH_TOKEN
     if (credential.baseUrl) env.ANTHROPIC_BASE_URL = credential.baseUrl
     return
   }

--- a/packages/daemon/test/model-provider-config.test.ts
+++ b/packages/daemon/test/model-provider-config.test.ts
@@ -47,14 +47,16 @@ describe('modelProviderTarget', () => {
 })
 
 describe('applyModelCredential', () => {
-  it('uses Claude gateway bearer-token variables', () => {
-    const env = { ANTHROPIC_API_KEY: 'old' }
+  it('writes the Claude key slot and clears any bearer-token variable', () => {
+    // Both stale variables present: exactly one credential may survive, in the x-api-key slot —
+    // the same slot the sandbox shim's AC_CLAUDE_API_KEY fill-in targets, so it stays blocked.
+    const env = { ANTHROPIC_API_KEY: 'old', ANTHROPIC_AUTH_TOKEN: 'old-bearer' }
     applyModelCredential({ provider: 'anthropic', runtime: 'claude' }, env, {
       key: 'issued',
       baseUrl: 'https://gateway.example/anthropic'
     })
     expect(env).toEqual({
-      ANTHROPIC_AUTH_TOKEN: 'issued',
+      ANTHROPIC_API_KEY: 'issued',
       ANTHROPIC_BASE_URL: 'https://gateway.example/anthropic'
     })
   })


### PR DESCRIPTION
## What

`applyModelCredential`'s Claude branch now writes `ANTHROPIC_API_KEY` (clearing `ANTHROPIC_AUTH_TOKEN`) instead of the reverse.

## Why

The daemon wrote `ANTHROPIC_AUTH_TOKEN`, but the sandbox shim's per-variable fill-in (`AC_CLAUDE_API_KEY → ANTHROPIC_API_KEY`, `acp-runner.ts`) targets a *different* variable name, so the slot looked empty and the pod-floor placeholder key rode along beside the daemon-issued credential. The Anthropic SDK sends both auth headers when both variables are set (`X-Api-Key` + `Authorization: Bearer`) — there is no configuration in which two credentials is the intended state.

Harmless today (both values are the same placeholder and nothing verifies them), but it would break on the JWT flip: the gateway's SecurityPolicy lists `x-api-key` first for the Anthropic dialect, and a non-JWT placeholder there 401s a request whose `Authorization` header carries a perfectly valid hub-minted token.

Writing the same slot the fill-in targets restores the same-slot shape codex and deepseek already have — the occupied variable blocks the fill-in naturally, so exactly one credential travels, with no shim change and no runtime-image coordination needed.

## Changes

- `packages/daemon/src/runtimes/model-provider-config.ts` — flip the Claude credential slot
- `packages/daemon/test/model-provider-config.test.ts` — assert both stale variables collapse to the single `ANTHROPIC_API_KEY` slot
- `docs/designs/key-server.md` — injection-variable table updated to match, plus a note that `*_MODEL_TOKEN` names an opaque deployment credential (despite the word "token", it is unrelated to `ANTHROPIC_AUTH_TOKEN`)

## Behavior change to note

A deployment whose static pair (`ANTHROPIC_MODEL_TOKEN` / `MODEL_TOKEN`) aims Claude at a gateway that accepts **only** `Authorization: Bearer` will move to `x-api-key` and stop authenticating after this change — the 401 will look like a gateway problem, not a daemon one. Point such a gateway's policy at `x-api-key` (or accept both headers, as this repo's reference JWT policy does).

## Verification

- `model-provider-config` 20/20, plus `shim-provider-env` / `runtime-launch` / `sandbox` / `acp-config` all green; daemon typecheck passes
- No interactive approval gate can bite: the pod floor has been populating `ANTHROPIC_API_KEY` on every sandboxed launch already, so Claude Code demonstrably runs with this variable set in exactly this configuration
- `@anthropic-ai/sdk` emits the `X-Api-Key` header only when `apiKey` is set, so requests now carry exactly one auth header
- `test/shim-provider-env.test.ts` already asserts a daemon-authored `ANTHROPIC_API_KEY` blocks the pod fill-in — the exact mechanism this fix leans on

🤖 Generated with [Claude Code](https://claude.com/claude-code)