### PR TITLE
feat(daemon): capture the runtime's advertised slash commands and serve them to the console

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3026,6 +3026,21 @@ export const LocalSkillsDto = z.object({
   skills: z.array(LocalSkillEntryDto)
 })
 
+/** One slash command the agent's runtime advertised over ACP. */
+export const RuntimeCommandDto = z.object({
+  name: z.string(),
+  description: z.string(),
+  hint: z.string().nullable()
+})
+/** `GET /agents/:id/commands` — what the agent's runtime can be asked to run. `reported` is false
+ *  until a session has advertised a list, so an empty list then means "unknown", not "none". */
+export const RuntimeCommandsDto = z.object({
+  reported: z.boolean(),
+  updatedAt: z.string().optional(),
+  sessionId: z.string().optional(),
+  commands: z.array(RuntimeCommandDto)
+})
+
 export const WorkspaceGitFileDto = z.object({
   path: z.string(),
   index: z.string(), // staged (X) status char

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -44,6 +44,7 @@ import {
   WORKSPACE_GIT_REVIEW_FEATURE,
   WORKSPACE_GIT_WRITE_FEATURE,
   TASK_LIST_FEATURE,
+  RUNTIME_COMMANDS_FEATURE,
   AGENT_WAKE_FEATURE,
   WorkspaceErrorReason,
   TaskErrorReason,
@@ -168,6 +169,7 @@ import {
   DreamSkillParam,
   DreamSkillContentDto,
   LocalSkillsDto,
+  RuntimeCommandsDto,
   StartDreamBody,
   AdoptDreamBody,
   AcceptDreamSkillBody,
@@ -2981,6 +2983,51 @@ export function agentRoutes(deps: HttpDeps) {
         }
         try {
           return await deps.control.listLocalSkills(agent.daemonId, { agentId: agent.id })
+        } catch (err) {
+          const unavailable = daemonEdgeFailure(err)
+          if (unavailable !== null) {
+            return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: unavailable })
+          }
+          throw err
+        }
+      }
+    )
+
+    // Runtime slash commands: what the agent's ACP runtime advertised it can be
+    // asked to run. Unlike skills/local this is the runtime's own answer, so it
+    // covers user/plugin skills and built-ins a workspace scan never sees.
+    r.get(
+      '/agents/:id/commands',
+      {
+        schema: {
+          tags: [Tag.Skills],
+          summary: 'List an agent’s runtime slash commands',
+          description:
+            'Proxy the slash commands the agent’s ACP runtime last advertised (`available_commands_update`) live from the owning daemon — skills, plugin skills and the harness’s own built-ins in one list, each with the runtime’s description and optional argument hint. `reported:false` means no session has advertised a list yet, so the empty list is "unknown", not "no commands". 409 when the daemon predates this read, 503 when unplaced or offline.',
+          operationId: 'listAgentRuntimeCommands',
+          params: IdParam,
+          response: { 200: RuntimeCommandsDto, 404: ErrorDto, 409: ErrorDto, 503: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const agent = await getServingAgent(req, req.params.id)
+        if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+        if (!agent.daemonId) {
+          return reply
+            .code(503)
+            .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
+        }
+        // Version skew: an older daemon drops the frame silently, so refuse before sending it.
+        const supported = await requireDaemonFeature(
+          reply,
+          agent.orgId,
+          agent.daemonId,
+          RUNTIME_COMMANDS_FEATURE,
+          'this agent version does not report its runtime commands; upgrade its daemon'
+        )
+        if (!supported) return reply
+        try {
+          return await deps.control.listRuntimeCommands(agent.daemonId, { agentId: agent.id })
         } catch (err) {
           const unavailable = daemonEdgeFailure(err)
           if (unavailable !== null) {

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -108,6 +108,8 @@ import type {
   DreamSkillReadReq,
   LocalSkillsReq,
   LocalSkillsList,
+  RuntimeCommandsReq,
+  RuntimeCommandsList,
   DreamSkillContent,
   OrganizationSuggestionReadReq,
   OrganizationSuggestionChunk,
@@ -699,6 +701,12 @@ export class ControlSender {
   async listLocalSkills(daemonId: string, req: LocalSkillsReq): Promise<LocalSkillsList> {
     const c = this.must(daemonId)
     return c.conn.request<LocalSkillsList>('skills/local', req, { epoch: c.sessionEpoch })
+  }
+
+  /** The slash commands the agent's runtime advertised over ACP — what it can be asked to run. */
+  async listRuntimeCommands(daemonId: string, req: RuntimeCommandsReq): Promise<RuntimeCommandsList> {
+    const c = this.must(daemonId)
+    return c.conn.request<RuntimeCommandsList>('runtime/commands', req, { epoch: c.sessionEpoch })
   }
 
   /** Accept one mined skill candidate — installs it for the agent (design §7). */

--- a/packages/control-plane/test/integration/agents.commands.route.test.ts
+++ b/packages/control-plane/test/integration/agents.commands.route.test.ts
@@ -1,0 +1,139 @@
+/**
+ * `GET /agents/:id/commands` — what the agent's ACP runtime advertised it can be asked to run.
+ * The CP authorizes the agent, proxies the daemon's cached advertisement and persists nothing.
+ * "No session has advertised yet" is DATA (`reported:false`), not an error — an empty list then
+ * means unknown, the same distinction `skills/local` draws with `materialized`.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { RUNTIME_COMMANDS_FEATURE, type RuntimeCommandsList, type RuntimeCommandsReq } from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { NoConnection, type ControlSender } from '../../src/orchestrator/outbound.js'
+import type { DaemonLiveness } from '../../src/ports.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const DAEMON = 'd5d5d5d5-dddd-4ddd-8ddd-dddddddddddd'
+const AGENT = 'a5a5a5a5-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const CAPABILITIES = { platforms: ['slack'], runtimes: ['claude'], acp: true, features: [RUNTIME_COMMANDS_FEATURE] }
+const LIVE: DaemonLiveness = {
+  get: (id) => (id === DAEMON ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined)
+}
+
+const opened: HttpApp[] = []
+afterEach(async () => {
+  await Promise.all(opened.splice(0).map((app) => app.close()))
+})
+
+/** The one read seam under test, recording every forwarded REQ. */
+class CommandsSpy {
+  calls: Array<{ daemonId: string; req: RuntimeCommandsReq }> = []
+  /** Set to answer as a daemon that has seen no advertisement for this agent yet. */
+  unreported = false
+  /** Set to make the next read fail the way a daemon `error` frame would. */
+  failure: Error | null = null
+
+  async listRuntimeCommands(daemonId: string, req: RuntimeCommandsReq): Promise<RuntimeCommandsList> {
+    this.calls.push({ daemonId, req })
+    if (this.failure) throw this.failure
+    if (this.unreported) return { reported: false, commands: [] }
+    return {
+      reported: true,
+      updatedAt: '2026-08-20T10:00:00.000Z',
+      sessionId: 'acp-1',
+      commands: [
+        { name: 'code-review', description: 'Review the current diff (project)', hint: '[pr-number]' },
+        { name: 'superpowers:brainstorming', description: 'Explore intent first (user)', hint: null }
+      ]
+    }
+  }
+}
+
+function app(control: CommandsSpy, userId?: string): HttpApp {
+  const running = buildHttpApp(
+    prisma,
+    userId ? { DEFAULT_OWNER_ID: userId } : undefined,
+    LIVE,
+    control as unknown as ControlSender
+  )
+  opened.push(running)
+  return running
+}
+
+async function seedCommandAgent(features: string[] = CAPABILITIES.features): Promise<void> {
+  await seedDaemon(prisma, DAEMON, { capabilities: { ...CAPABILITIES, features } })
+  await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+}
+
+describe('GET /agents/:id/commands', () => {
+  it('proxies the runtime’s advertisement, hint and all', async () => {
+    await seedCommandAgent()
+    const control = new CommandsSpy()
+
+    const res = await app(control).app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/commands` })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({
+      reported: true,
+      updatedAt: '2026-08-20T10:00:00.000Z',
+      sessionId: 'acp-1',
+      commands: [
+        { name: 'code-review', description: 'Review the current diff (project)', hint: '[pr-number]' },
+        { name: 'superpowers:brainstorming', description: 'Explore intent first (user)', hint: null }
+      ]
+    })
+    expect(control.calls).toEqual([{ daemonId: DAEMON, req: { agentId: AGENT } }])
+  })
+
+  it('passes "nothing advertised yet" through as data, not as an error', async () => {
+    await seedCommandAgent()
+    const control = new CommandsSpy()
+    control.unreported = true
+
+    const res = await app(control).app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/commands` })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ reported: false, commands: [] })
+  })
+
+  it('reads an unknown and a foreign org’s agent as absent, without touching the wire', async () => {
+    await seedCommandAgent()
+    const control = new CommandsSpy()
+
+    const res = await app(control).app.inject({ method: 'GET', url: `${ORG}/agents/${randomUUID()}/commands` })
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toMatchObject({ message: 'agent not found' })
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('answers an unplaced agent 503 without touching the wire', async () => {
+    await seedDaemon(prisma, DAEMON, { capabilities: CAPABILITIES })
+    await seedAgent(prisma, AGENT) // no daemonId
+    const control = new CommandsSpy()
+
+    const res = await app(control).app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/commands` })
+    expect(res.statusCode).toBe(503)
+    expect(res.json()).toMatchObject({ message: 'agent has no live daemon' })
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('refuses a daemon that predates this read instead of sending a frame it would drop', async () => {
+    await seedCommandAgent([]) // capable of everything else, command-blind
+    const control = new CommandsSpy()
+
+    const res = await app(control).app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/commands` })
+    expect(res.statusCode).toBe(409)
+    expect(res.json()).toMatchObject({ code: 'DAEMON_FEATURE_MISSING' })
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('answers 503 when the owning daemon is unreachable', async () => {
+    await seedCommandAgent()
+    const control = new CommandsSpy()
+    control.failure = new NoConnection(DAEMON)
+
+    const res = await app(control).app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/commands` })
+    expect(res.statusCode).toBe(503)
+    expect(res.json()).toMatchObject({ message: 'owning daemon is offline' })
+  })
+})

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -1074,6 +1074,13 @@ export class AcpHost {
     return this.live.has(sessionId)
   }
 
+  /** True while a session/load is in flight — the session is this host's, but `live` does not hold it
+   *  yet. A caller identifying "is this session mine" from an update must accept this window too, or
+   *  it depends on whether the adapter emits before or after the load response. */
+  isLoadingSession(sessionId: string): boolean {
+    return this.loadingSessions.has(sessionId)
+  }
+
   /** Force the next exact-session turn through session/load/new so a rotated
    * session-scoped MCP descriptor is installed before another prompt. */
   forgetSession(sessionId: string): void {

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -49,9 +49,15 @@ export const APPROVALS_REVIEWER_CATEGORY = '_approvals_reviewer'
 
 /** A session/load may replay the historical conversation stream. Keep that off
  *  platform transports, but preserve latest-wins metadata needed to converge the
- *  local/CP session projection after a restart. */
+ *  local/CP session projection after a restart. The command list is one of those:
+ *  the adapter advertises it after the replay, and it is the only advertisement a
+ *  resumed session ever makes. */
 export function shouldForwardUpdateDuringLoad(update: SessionUpdate): boolean {
-  return update.sessionUpdate === 'session_info_update' || update.sessionUpdate === 'usage_update'
+  return (
+    update.sessionUpdate === 'session_info_update' ||
+    update.sessionUpdate === 'usage_update' ||
+    update.sessionUpdate === 'available_commands_update'
+  )
 }
 
 /** A runtime's advertised model selector, distilled from ACP session config options. */

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -275,6 +275,7 @@ export class CpClient {
       memoryReader: deps.memoryReader,
       dreamReader: deps.dreamReader,
       localSkillsReader: deps.localSkillsReader,
+      runtimeCommandsReader: deps.runtimeCommandsReader,
       gitMessagePasses: new GitMessagePasses(),
       noteLeasesGranted: (groupIds) => this.noteLeasesGranted(groupIds),
       forgetLeaseDeadlines: (groupIds) => this.forgetLeaseDeadlines(groupIds),

--- a/packages/daemon/src/cp/control/registry.ts
+++ b/packages/daemon/src/cp/control/registry.ts
@@ -60,7 +60,7 @@ import {
   sessionVisibilitySnapshot,
   type SessionControlDeps
 } from './session.js'
-import { skillsLocal, type SkillsControlDeps } from './skills.js'
+import { runtimeCommands, skillsLocal, type SkillsControlDeps } from './skills.js'
 import { taskList, type TaskControlDeps } from './task.js'
 import {
   workspaceDelete,
@@ -177,6 +177,7 @@ export const CONTROL_HANDLERS: Map<string, ControlHandler<ControlDeps>> = new Ma
   ['memory/dream/skill/accept', dreamSkillAccept],
   ['memory/dream/skill/dismiss', dreamSkillDismiss],
   ['skills/local', skillsLocal],
+  ['runtime/commands', runtimeCommands],
   ['knowledge/suggestion/read', knowledgeSuggestionRead],
   ['knowledge/suggestion/review', knowledgeSuggestionReview]
 ])

--- a/packages/daemon/src/cp/control/skills.ts
+++ b/packages/daemon/src/cp/control/skills.ts
@@ -1,10 +1,13 @@
-import type { AnyFrame, LocalSkillsReq } from '@agentconnect.md/protocol'
+import type { AnyFrame, LocalSkillsReq, RuntimeCommandsReq } from '@agentconnect.md/protocol'
 import type { LocalSkillsReader } from '../local-skills-reader.js'
+import type { RuntimeCommandsReader } from '../runtime-commands-reader.js'
 import type { ControlHandler } from './context.js'
 
 export interface SkillsControlDeps {
   /** Read-only inventory of the skills an agent's workspace can load (skills/local). */
   localSkillsReader: LocalSkillsReader
+  /** The slash commands the agent's runtime advertised over ACP (runtime/commands). */
+  runtimeCommandsReader: RuntimeCommandsReader
 }
 
 export const skillsLocal: ControlHandler<SkillsControlDeps> = (frame: AnyFrame, deps, wire) => {
@@ -14,5 +17,15 @@ export const skillsLocal: ControlHandler<SkillsControlDeps> = (frame: AnyFrame, 
     .catch((err) => {
       wire.log.warn(`cp: skills/local failed: ${(err as Error)?.message}`)
       wire.sendError(frame.id, 'INTERNAL', 'skills/local failed', false)
+    })
+}
+
+export const runtimeCommands: ControlHandler<SkillsControlDeps> = (frame: AnyFrame, deps, wire) => {
+  deps.runtimeCommandsReader
+    .list(frame.payload as RuntimeCommandsReq)
+    .then((list) => wire.reply(frame, 'runtime/commands/list', list))
+    .catch((err) => {
+      wire.log.warn(`cp: runtime/commands failed: ${(err as Error)?.message}`)
+      wire.sendError(frame.id, 'INTERNAL', 'runtime/commands failed', false)
     })
 }

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -26,6 +26,8 @@ import { createAgentWaker } from './agent-wake.js'
 import { createMemoryReader, type AgentMemoryAdminResolver } from './memory-reader.js'
 import { createDreamReader } from './dream-reader.js'
 import { createLocalSkillsReader } from './local-skills-reader.js'
+import { createRuntimeCommandsReader } from './runtime-commands-reader.js'
+import type { RuntimeCommandsCache } from '../runtimes/runtime-commands.js'
 import type { CpAgentRegistry } from './cp-agent-registry.js'
 import type { CpIntegrationRegistry } from './cp-integration-registry.js'
 import type { CpCronRegistry } from './cp-cron.js'
@@ -127,6 +129,7 @@ export interface CpClientSeamHost {
   k8sPlane(): K8sRuntimePlane | undefined
   memory(): AgentMemoryAdminResolver
   dreamRunner(): DreamRunner
+  runtimeCommands(): RuntimeCommandsCache
   memoryFsFor(agentId: string): MemoryFs | undefined
   gitCommitIdentity(): GitCommitIdentity | undefined
   sessionThreadUrl(session: SessionRecord): string | undefined
@@ -343,6 +346,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       join(host.daemonRoot(), 'skill-installs'),
       (id) => host.k8sPlane()?.workspaceFilesFor(id)
     ),
+    runtimeCommandsReader: createRuntimeCommandsReader(host.runtimeCommands(), (id) => host.agents().has(id)),
     // webchat is no longer a CP control-WS integration (milestone A4) — it rides the
     // relay's rd/* wire, wired through RelayManager.onRelayMsg.
     clock: systemClock,

--- a/packages/daemon/src/cp/runtime-commands-reader.ts
+++ b/packages/daemon/src/cp/runtime-commands-reader.ts
@@ -1,0 +1,23 @@
+// CP-facing read of an agent's advertised slash commands (`runtime/commands`). Pure cache read: the
+// list is pushed by the runtime, so unlike `skills/local` this never touches a filesystem and
+// answers the same way for a local and a cluster agent.
+
+import type { RuntimeCommandsList, RuntimeCommandsReq } from '@agentconnect.md/protocol'
+import type { RuntimeCommandsCache } from '../runtimes/runtime-commands.js'
+
+export interface RuntimeCommandsReader {
+  list(req: RuntimeCommandsReq): Promise<RuntimeCommandsList>
+}
+
+export function createRuntimeCommandsReader(
+  commands: RuntimeCommandsCache,
+  knowsAgent: (agentId: string) => boolean
+): RuntimeCommandsReader {
+  return {
+    // An agent this daemon does not run reads as "nothing advertised yet" rather than as another
+    // agent's cache entry surviving a move.
+    async list(req) {
+      return knowsAgent(req.agentId) ? commands.get(req.agentId) : { reported: false, commands: [] }
+    }
+  }
+}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11205,11 +11205,16 @@ export class Daemon {
       return
     }
     // Recorded before the pending-turn gate below, because an advertisement arrives outside a turn.
-    // Only the agent's OWN host describes the agent's workspace: a dream/distill host is a separate
-    // AcpHost over its own cwd, and it advertises right after its session/new — before its collector
-    // is registered above. Identifying this host positively is what makes that ordering-proof.
+    // A dream host is a separate AcpHost that never enters `hosts`, and it advertises right after
+    // ITS session/new — before the collector returns above exist — so identifying the agent's own
+    // host positively is what makes the exclusion ordering-proof. `isLoadingSession` covers the
+    // session/load window, where the session is this host's but `live` does not hold it yet.
+    // KNOWN GAP: distillation and the commit-message pass run on the agent's OWN host over a temp
+    // dir, so their advertisement is recorded and the list loses the agent's project skills until
+    // the next ordinary session/new replaces it (#1310 review, follow-up).
     if (isAvailableCommandsUpdate(update)) {
-      if (this.hosts.get(agentId)?.hasSession(sessionId)) {
+      const host = this.hosts.get(agentId)
+      if (host?.hasSession(sessionId) || host?.isLoadingSession(sessionId)) {
         this.runtimeCommands.record(agentId, sessionId, update, this.clock.now())
       }
       return

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -192,6 +192,7 @@ import {
   selectGithubReviewBatchLeader
 } from './github/queue-admission.js'
 import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from './runtimes/registry.js'
+import { isAvailableCommandsUpdate, RuntimeCommandsCache } from './runtimes/runtime-commands.js'
 import { installedRuntimeCatalog, installedRuntimes, resolveCommandPath } from './runtimes/probe.js'
 import { startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.js'
 import { declaredRuntimeCatalog, loadK8sRuntimeTable, type K8sRuntimeAcpSnapshot } from './runtimes/k8s-runtimes.js'
@@ -252,6 +253,7 @@ import {
   MAX_TASK_DETAIL,
   MAX_TASK_LIST_TASKS,
   TASK_LIST_FEATURE,
+  RUNTIME_COMMANDS_FEATURE,
   AGENT_WAKE_FEATURE,
   WORKSPACE_GIT_MESSAGE_FEATURE,
   WORKSPACE_GIT_REVIEW_FEATURE,
@@ -1019,6 +1021,8 @@ export class Daemon {
   private readonly observedChannelsSync: ObservedChannelsSync
   private readonly webchatTransport: WebchatTransport
   private readonly webchatMcpRevocations: WebchatMcpRevocations
+  // What each agent's runtime last advertised it can be asked to run (ACP available_commands_update).
+  private readonly runtimeCommands = new RuntimeCommandsCache()
   // In-conversation command execution (commands/handlers.ts), behind the delegates below.
   private readonly commands: CommandHandlers
   // §7.3 force-cancel backstops, keyed by (agentId, acpSessionId); cleared at turn end.
@@ -2687,6 +2691,7 @@ export class Daemon {
       this.dreamScheduler.unregister(id)
       this.gitCreds.remove(id)
       this.gitCredServer?.revoke(id)
+      this.runtimeCommands.forget(id)
       // Use the one generation-safe teardown path: it evicts the host synchronously,
       // publishes hostStopping, and fences every older startup/retry generation.
       await this.stopHost(id)
@@ -3410,6 +3415,7 @@ export class Daemon {
       WORKSPACE_SESSION_READ_FEATURE,
       WORKSPACE_REPO_SCOPE_FEATURE,
       TASK_LIST_FEATURE,
+      RUNTIME_COMMANDS_FEATURE,
       // Only a cluster daemon has a sandbox to wake; elsewhere the CP answers `unsupported` unsent.
       ...(this.k8s ? [AGENT_WAKE_FEATURE] : []),
       WORKSPACE_GIT_MESSAGE_FEATURE,
@@ -11194,6 +11200,12 @@ export class Daemon {
       }
       return
     }
+    // Past the extraction/quarantine returns (a dream host's list describes its own cwd, not the
+    // agent's workspace) and before the pending-turn gate: an advertisement arrives outside a turn.
+    if (isAvailableCommandsUpdate(update)) {
+      this.runtimeCommands.record(agentId, sessionId, update, this.clock.now())
+      return
+    }
     const p = this.pending.get(pendingTurnKey(agentId, sessionId))
     this.evalHooks.emit({
       type: 'acp.update',
@@ -14123,6 +14135,7 @@ export class Daemon {
       k8sPlane: () => this.k8sPlane,
       memory: () => this.memory,
       dreamRunner: () => this.dreamRunner(),
+      runtimeCommands: () => this.runtimeCommands,
       memoryFsFor: (agentId) => this.memoryFsFor(agentId),
       gitCommitIdentity: () => this.gitCommitIdentity,
       sessionThreadUrl: (session) => this.sessionThreadUrl(session),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2756,6 +2756,10 @@ export class Daemon {
         const wasDraining = this.drainingAgents.has(a.id)
         this.drainingAgents.add(a.id)
         await this.interruptAgentTurns(a.id, 'stop')
+        // The advertised command list belongs to the runtime and workspace being torn down — both
+        // are in hostSpawnSig, so a runtime switch would otherwise keep serving the old harness's
+        // commands until some later session/new replaced them.
+        this.runtimeCommands.forget(a.id)
         if (workspaceNeedsColdRecovery) {
           this.gitCreds.remove(a.id)
           this.gitCredServer?.revoke(a.id)
@@ -11200,10 +11204,14 @@ export class Daemon {
       }
       return
     }
-    // Past the extraction/quarantine returns (a dream host's list describes its own cwd, not the
-    // agent's workspace) and before the pending-turn gate: an advertisement arrives outside a turn.
+    // Recorded before the pending-turn gate below, because an advertisement arrives outside a turn.
+    // Only the agent's OWN host describes the agent's workspace: a dream/distill host is a separate
+    // AcpHost over its own cwd, and it advertises right after its session/new — before its collector
+    // is registered above. Identifying this host positively is what makes that ordering-proof.
     if (isAvailableCommandsUpdate(update)) {
-      this.runtimeCommands.record(agentId, sessionId, update, this.clock.now())
+      if (this.hosts.get(agentId)?.hasSession(sessionId)) {
+        this.runtimeCommands.record(agentId, sessionId, update, this.clock.now())
+      }
       return
     }
     const p = this.pending.get(pendingTurnKey(agentId, sessionId))

--- a/packages/daemon/src/runtimes/runtime-commands.ts
+++ b/packages/daemon/src/runtimes/runtime-commands.ts
@@ -1,0 +1,86 @@
+// The last slash-command list each agent's runtime advertised over ACP `available_commands_update`
+// (agentclientprotocol.com/protocol/v1/slash-commands) — the runtime's own answer to what it can be
+// asked to run, including for a cluster agent whose workspace no local scan can reach.
+
+import type { RuntimeCommand, RuntimeCommandsList } from '@agentconnect.md/protocol'
+
+// Names/descriptions are workspace-controlled (a repo's SKILL.md), and the reply rides a control
+// frame the receiver rejects over 256 KiB — bound both.
+const MAX_COMMANDS = 512
+const MAX_NAME_CHARS = 256
+const MAX_DESCRIPTION_CHARS = 512
+const MAX_HINT_CHARS = 256
+const MAX_TOTAL_BYTES = 200 * 1024
+
+interface AdvertisedCommands {
+  sessionId: string
+  updatedAt: string
+  commands: RuntimeCommand[]
+}
+
+/** True for the ACP update this cache is built from. */
+export function isAvailableCommandsUpdate(update: unknown): boolean {
+  return (update as { sessionUpdate?: unknown } | undefined)?.sessionUpdate === 'available_commands_update'
+}
+
+function text(value: unknown, limit: number): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed ? trimmed.slice(0, limit) : null
+}
+
+/** One advertisement in wire shape: unnamed/duplicate entries dropped, caps enforced, never merged. */
+export function normalizeAvailableCommands(update: unknown): RuntimeCommand[] {
+  const raw = (update as { availableCommands?: unknown } | undefined)?.availableCommands
+  if (!Array.isArray(raw)) return []
+  const commands: RuntimeCommand[] = []
+  const seen = new Set<string>()
+  let bytes = 0
+  for (const entry of raw) {
+    if (commands.length >= MAX_COMMANDS) break
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+    const row = entry as { name?: unknown; description?: unknown; input?: unknown }
+    const name = text(row.name, MAX_NAME_CHARS)
+    if (!name || seen.has(name)) continue
+    const input = row.input as { hint?: unknown } | null | undefined
+    const command: RuntimeCommand = {
+      name,
+      description: text(row.description, MAX_DESCRIPTION_CHARS) ?? '',
+      hint: input && typeof input === 'object' ? text(input.hint, MAX_HINT_CHARS) : null
+    }
+    bytes += Buffer.byteLength(JSON.stringify(command)) + 1
+    if (bytes > MAX_TOTAL_BYTES) break
+    seen.add(name)
+    commands.push(command)
+  }
+  return commands
+}
+
+export class RuntimeCommandsCache {
+  // Latest-wins per agent, not per session: a session-worktree list still beats none once it ends.
+  private readonly byAgent = new Map<string, AdvertisedCommands>()
+
+  record(agentId: string, sessionId: string, update: unknown, at: number): void {
+    if (!isAvailableCommandsUpdate(update)) return
+    this.byAgent.set(agentId, {
+      sessionId,
+      updatedAt: new Date(at).toISOString(),
+      commands: normalizeAvailableCommands(update)
+    })
+  }
+
+  get(agentId: string): RuntimeCommandsList {
+    const entry = this.byAgent.get(agentId)
+    if (!entry) return { reported: false, commands: [] }
+    return {
+      reported: true,
+      updatedAt: entry.updatedAt,
+      sessionId: entry.sessionId,
+      commands: entry.commands
+    }
+  }
+
+  forget(agentId: string): void {
+    this.byAgent.delete(agentId)
+  }
+}

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -163,6 +163,11 @@ describe('AcpHost session/load update filtering', () => {
   it('allows only latest-wins metadata through during load', () => {
     expect(shouldForwardUpdateDuringLoad({ sessionUpdate: 'session_info_update', title: 'Restored' })).toBe(true)
     expect(shouldForwardUpdateDuringLoad({ sessionUpdate: 'usage_update', used: 1, size: 10 } as any)).toBe(true)
+    // The adapter advertises the command list AFTER a load's replay — the only one a resumed
+    // session makes, so dropping it would leave the console blind until the next new session.
+    expect(shouldForwardUpdateDuringLoad({ sessionUpdate: 'available_commands_update', availableCommands: [] })).toBe(
+      true
+    )
     expect(
       shouldForwardUpdateDuringLoad({
         sessionUpdate: 'agent_message_chunk',

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -5,6 +5,8 @@ import { WorkspaceConflictError, WorkspaceViolationError } from '../../src/cp/wo
 import { MemorySandboxUnavailableError } from '../../src/cp/memory-reader.js'
 import { TaskViolationError } from '../../src/cp/task-reader.js'
 import { AgentWakeViolationError } from '../../src/cp/agent-wake.js'
+import { createRuntimeCommandsReader } from '../../src/cp/runtime-commands-reader.js'
+import { RuntimeCommandsCache } from '../../src/runtimes/runtime-commands.js'
 import { FakeTransport } from './fake-transport.js'
 import { FakeClock } from './fake-clock.js'
 
@@ -935,6 +937,45 @@ describe('CpClient dispatch', () => {
     expect(rep.corr).toBe(f.id)
     expect(rep.payload.tasks[0].state).toBe('running')
     expect(rep.payload.tracked).toBe(true)
+  })
+
+  it('replies runtime/commands/list from what the runtime advertised over ACP', async () => {
+    const commands = new RuntimeCommandsCache()
+    commands.record(
+      'a1',
+      'acp-1',
+      {
+        sessionUpdate: 'available_commands_update',
+        availableCommands: [{ name: 'code-review', description: 'Review the diff', input: { hint: '[pr]' } }]
+      },
+      Date.parse('2026-06-26T00:00:00.000Z')
+    )
+    const { t } = await readyClient({
+      runtimeCommandsReader: createRuntimeCommandsReader(commands, (id) => id === 'a1')
+    })
+    const f = JSON.parse(frame('runtime/commands', { agentId: 'a1' }, { epoch: 5 }))
+    t.pushInbound(JSON.stringify(f))
+    await tick()
+    const rep = JSON.parse(t.sent[0]!)
+    expect(rep.type).toBe('runtime/commands/list')
+    expect(rep.corr).toBe(f.id)
+    expect(rep.payload).toEqual({
+      reported: true,
+      updatedAt: '2026-06-26T00:00:00.000Z',
+      sessionId: 'acp-1',
+      commands: [{ name: 'code-review', description: 'Review the diff', hint: '[pr]' }]
+    })
+  })
+
+  it('replies runtime/commands/list with reported:false before any advertisement', async () => {
+    const { t } = await readyClient({
+      runtimeCommandsReader: createRuntimeCommandsReader(new RuntimeCommandsCache(), () => true)
+    })
+    t.pushInbound(frame('runtime/commands', { agentId: 'a1' }, { epoch: 5 }))
+    await tick()
+    const rep = JSON.parse(t.sent[0]!)
+    expect(rep.type).toBe('runtime/commands/list')
+    expect(rep.payload).toEqual({ reported: false, commands: [] })
   })
 
   it('maps an unknown-agent task violation to BAD_PAYLOAD with its reason', async () => {

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { Daemon } from '../src/daemon.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import { createRuntimeCommandsReader } from '../src/cp/runtime-commands-reader.js'
 import {
   isAvailableCommandsUpdate,
@@ -105,5 +107,29 @@ describe('runtime command advertisements', () => {
 
     expect((await reader.list({ agentId: 'mine' })).commands).toHaveLength(3)
     expect(await reader.list({ agentId: 'moved' })).toEqual({ reported: false, commands: [] })
+  })
+})
+
+describe('the daemon records only its own host’s advertisement', () => {
+  // A dream or distillation host is a separate AcpHost over its own cwd, and it advertises right
+  // after ITS session/new — before its extraction collector is registered, so the collector guard
+  // alone would let that list through and describe the agent with commands it does not have.
+  it('ignores a session the agent’s host does not own, and takes one it does', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const host = daemon as unknown as {
+      hosts: Map<string, { hasSession(id: string): boolean }>
+      onAcpUpdate(agentId: string, sessionId: string, update: unknown): Promise<void>
+      runtimeCommands: RuntimeCommandsCache
+    }
+    host.hosts.set('agent-1', { hasSession: (id) => id === 'own-session' })
+
+    await host.onAcpUpdate('agent-1', 'dream-session', advertisement)
+    expect(host.runtimeCommands.get('agent-1')).toEqual({ reported: false, commands: [] })
+
+    await host.onAcpUpdate('agent-1', 'own-session', advertisement)
+    const reported = host.runtimeCommands.get('agent-1')
+    expect(reported.reported).toBe(true)
+    expect(reported.sessionId).toBe('own-session')
+    expect(reported.commands.map((c) => c.name)).toEqual(['code-review', 'superpowers:brainstorming', 'model'])
   })
 })

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { createRuntimeCommandsReader } from '../src/cp/runtime-commands-reader.js'
+import {
+  isAvailableCommandsUpdate,
+  normalizeAvailableCommands,
+  RuntimeCommandsCache
+} from '../src/runtimes/runtime-commands.js'
+
+// One advertisement as claude-agent-acp emits it right after session/new: a workspace skill, a
+// plugin skill, a built-in, and an argument hint.
+const advertisement = {
+  sessionUpdate: 'available_commands_update',
+  availableCommands: [
+    { name: 'code-review', description: 'Review the current diff (project)', input: { hint: '[pr-number]' } },
+    { name: 'superpowers:brainstorming', description: 'Explore intent before implementing (user)', input: null },
+    { name: 'model', description: 'Set the model for this session' }
+  ]
+}
+
+describe('runtime command advertisements', () => {
+  it('recognizes only the ACP available-commands update', () => {
+    expect(isAvailableCommandsUpdate(advertisement)).toBe(true)
+    expect(isAvailableCommandsUpdate({ sessionUpdate: 'usage_update' })).toBe(false)
+    expect(isAvailableCommandsUpdate(undefined)).toBe(false)
+  })
+
+  it('normalizes names, descriptions and argument hints', () => {
+    expect(normalizeAvailableCommands(advertisement)).toEqual([
+      { name: 'code-review', description: 'Review the current diff (project)', hint: '[pr-number]' },
+      { name: 'superpowers:brainstorming', description: 'Explore intent before implementing (user)', hint: null },
+      { name: 'model', description: 'Set the model for this session', hint: null }
+    ])
+  })
+
+  it('drops unnamed and duplicate entries rather than surfacing them', () => {
+    const commands = normalizeAvailableCommands({
+      sessionUpdate: 'available_commands_update',
+      availableCommands: [
+        { name: 'deploy', description: 'first' },
+        { name: '  ', description: 'unnamed' },
+        { name: 'deploy', description: 'duplicate' },
+        'not-an-object',
+        { description: 'no name at all' }
+      ]
+    })
+    expect(commands).toEqual([{ name: 'deploy', description: 'first', hint: null }])
+  })
+
+  it('bounds a hostile advertisement so the reply still fits a control frame', () => {
+    const commands = normalizeAvailableCommands({
+      sessionUpdate: 'available_commands_update',
+      availableCommands: Array.from({ length: 4096 }, (_, i) => ({
+        name: `cmd-${i}`.padEnd(512, 'x'),
+        description: 'd'.repeat(4096),
+        input: { hint: 'h'.repeat(4096) }
+      }))
+    })
+    expect(commands.length).toBeLessThan(4096)
+    expect(Buffer.byteLength(JSON.stringify(commands))).toBeLessThanOrEqual(200 * 1024)
+    for (const command of commands) {
+      expect(command.name.length).toBeLessThanOrEqual(256)
+      expect(command.description.length).toBeLessThanOrEqual(512)
+      expect(command.hint?.length).toBeLessThanOrEqual(256)
+    }
+  })
+
+  it('reports nothing until a session advertises, then replaces the whole list', () => {
+    const cache = new RuntimeCommandsCache()
+    expect(cache.get('a')).toEqual({ reported: false, commands: [] })
+
+    cache.record('a', 'acp-1', advertisement, Date.parse('2026-08-20T00:00:00.000Z'))
+    const first = cache.get('a')
+    expect(first.reported).toBe(true)
+    expect(first.sessionId).toBe('acp-1')
+    expect(first.updatedAt).toBe('2026-08-20T00:00:00.000Z')
+    expect(first.commands.map((c) => c.name)).toEqual(['code-review', 'superpowers:brainstorming', 'model'])
+
+    // A later advertisement REPLACES rather than merges — the runtime always sends its whole list.
+    cache.record(
+      'a',
+      'acp-2',
+      { sessionUpdate: 'available_commands_update', availableCommands: [{ name: 'deploy', description: 'Ship' }] },
+      Date.parse('2026-08-20T01:00:00.000Z')
+    )
+    expect(cache.get('a').commands.map((c) => c.name)).toEqual(['deploy'])
+    expect(cache.get('a').sessionId).toBe('acp-2')
+  })
+
+  it('ignores an update that is not an advertisement, and forgets a removed agent', () => {
+    const cache = new RuntimeCommandsCache()
+    cache.record('a', 'acp-1', { sessionUpdate: 'usage_update', used: 1 }, 0)
+    expect(cache.get('a').reported).toBe(false)
+
+    cache.record('a', 'acp-1', advertisement, 0)
+    expect(cache.get('a').reported).toBe(true)
+    cache.forget('a')
+    expect(cache.get('a')).toEqual({ reported: false, commands: [] })
+  })
+
+  it('answers for an agent this daemon runs, and reports nothing for one it does not', async () => {
+    const cache = new RuntimeCommandsCache()
+    cache.record('mine', 'acp-1', advertisement, 0)
+    cache.record('moved', 'acp-2', advertisement, 0)
+    const reader = createRuntimeCommandsReader(cache, (id) => id === 'mine')
+
+    expect((await reader.list({ agentId: 'mine' })).commands).toHaveLength(3)
+    expect(await reader.list({ agentId: 'moved' })).toEqual({ reported: false, commands: [] })
+  })
+})

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -121,7 +121,10 @@ describe('the daemon records only its own host’s advertisement', () => {
       onAcpUpdate(agentId: string, sessionId: string, update: unknown): Promise<void>
       runtimeCommands: RuntimeCommandsCache
     }
-    host.hosts.set('agent-1', { hasSession: (id) => id === 'own-session' })
+    host.hosts.set('agent-1', {
+      hasSession: (id) => id === 'own-session',
+      isLoadingSession: (id) => id === 'resuming-session'
+    })
 
     await host.onAcpUpdate('agent-1', 'dream-session', advertisement)
     expect(host.runtimeCommands.get('agent-1')).toEqual({ reported: false, commands: [] })
@@ -131,5 +134,21 @@ describe('the daemon records only its own host’s advertisement', () => {
     expect(reported.reported).toBe(true)
     expect(reported.sessionId).toBe('own-session')
     expect(reported.commands.map((c) => c.name)).toEqual(['code-review', 'superpowers:brainstorming', 'model'])
+  })
+
+  // claude-agent-acp advertises AFTER the session/load response, so `live` already holds the session
+  // by then — but that is one adapter's ordering, and the guard must not depend on it. A session the
+  // host is still loading is this host's session.
+  it('takes an advertisement that arrives while a session/load is still in flight', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const host = daemon as unknown as {
+      hosts: Map<string, { hasSession(id: string): boolean; isLoadingSession(id: string): boolean }>
+      onAcpUpdate(agentId: string, sessionId: string, update: unknown): Promise<void>
+      runtimeCommands: RuntimeCommandsCache
+    }
+    host.hosts.set('agent-1', { hasSession: () => false, isLoadingSession: (id) => id === 'resuming' })
+
+    await host.onAcpUpdate('agent-1', 'resuming', advertisement)
+    expect(host.runtimeCommands.get('agent-1').sessionId).toBe('resuming')
   })
 })

--- a/packages/protocol/src/consts.ts
+++ b/packages/protocol/src/consts.ts
@@ -87,6 +87,11 @@ export const WORKSPACE_GIT_MESSAGE_FEATURE = 'workspace-git-message-v1'
  * hides the Tasks tab on a daemon without it rather than showing a tab that can never answer. */
 export const TASK_LIST_FEATURE = 'task-list-v1'
 
+/** Daemon serves `runtime/commands` — the slash commands an agent's ACP runtime advertised it can be
+ * asked to run. Checked before sending: an older daemon ignores an unknown frame silently, so the REQ
+ * would burn its retransmit budget and then read as an offline daemon. */
+export const RUNTIME_COMMANDS_FEATURE = 'runtime-commands-v1'
+
 /** Daemon serves `agent/wake` — the console's "start this agent's sandbox" for a Files/Memory read.
  * Advertised only by a daemon that runs agents in cluster sandboxes: on any other daemon there is
  * nothing to wake, and the CP answers `unsupported` without sending a frame it would ignore. */

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -139,6 +139,7 @@ import {
   DreamSkillContent
 } from './frames/memory.js'
 import { LocalSkillsReq, LocalSkillsList } from './frames/skill.js'
+import { RuntimeCommandsReq, RuntimeCommandsList } from './frames/runtime-command.js'
 import {
   KnowledgeSearchReq,
   KnowledgeSearchOk,
@@ -403,6 +404,8 @@ export const FRAME_SCHEMAS = {
   'memory/dream/skill/dismiss/ok': DreamState,
   'skills/local': LocalSkillsReq,
   'skills/local/list': LocalSkillsList,
+  'runtime/commands': RuntimeCommandsReq,
+  'runtime/commands/list': RuntimeCommandsList,
   // ── organization knowledge + managed skills ──
   'knowledge/search': KnowledgeSearchReq,
   'knowledge/search/ok': KnowledgeSearchOk,
@@ -640,6 +643,8 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('memory/dream/skill/dismiss/ok', FRAME_SCHEMAS['memory/dream/skill/dismiss/ok']),
   frame('skills/local', FRAME_SCHEMAS['skills/local']),
   frame('skills/local/list', FRAME_SCHEMAS['skills/local/list']),
+  frame('runtime/commands', FRAME_SCHEMAS['runtime/commands']),
+  frame('runtime/commands/list', FRAME_SCHEMAS['runtime/commands/list']),
   frame('knowledge/search', FRAME_SCHEMAS['knowledge/search']),
   frame('knowledge/list', FRAME_SCHEMAS['knowledge/list']),
   frame('knowledge/list/ok', FRAME_SCHEMAS['knowledge/list/ok']),

--- a/packages/protocol/src/frames/runtime-command.ts
+++ b/packages/protocol/src/frames/runtime-command.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+// The slash commands an agent's ACP runtime advertises (`available_commands_update`) — skills,
+// plugin skills and the harness's own built-ins arrive as one list, so this is what the runtime
+// can actually be asked to run rather than what a workspace scan guesses (`skills/local`).
+
+export const RuntimeCommand = z
+  .object({
+    /** Name as typed after `/` — e.g. `code-review`, `superpowers:brainstorming`, `mcp:srv:cmd`. */
+    name: z.string(),
+    /** The runtime's own description; empty when it advertised none. */
+    description: z.string(),
+    /** ACP `input.hint` — an argument hint, or null when the command takes no argument. */
+    hint: z.string().nullable()
+  })
+  .strict()
+export type RuntimeCommand = z.infer<typeof RuntimeCommand>
+
+/** CP → daemon: what can this agent's runtime be asked to run? */
+export const RuntimeCommandsReq = z.object({ agentId: z.string().min(1) }).strict()
+export type RuntimeCommandsReq = z.infer<typeof RuntimeCommandsReq>
+
+/** daemon → CP: the last advertised list. `reported:false` means no session has advertised one
+ *  yet, so the empty list is "unknown", not "no commands". */
+export const RuntimeCommandsList = z
+  .object({
+    reported: z.boolean(),
+    /** When that advertisement arrived; the list survives the host stopping, so it can be stale. */
+    updatedAt: z.string().optional(),
+    /** The ACP session it came from — a worktree-isolated session can advertise its own set. */
+    sessionId: z.string().optional(),
+    commands: z.array(RuntimeCommand)
+  })
+  .strict()
+export type RuntimeCommandsList = z.infer<typeof RuntimeCommandsList>

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -32,6 +32,7 @@ export {
   ORGANIZATION_KNOWLEDGE_FEATURE,
   ORGANIZATION_SUGGESTION_REVIEW_FEATURE,
   RESERVED_RESTART_CODE,
+  RUNTIME_COMMANDS_FEATURE,
   K8S_SUPERVISOR,
   AGENT_EXISTS_FEATURE,
   SESSION_LIVE_TAIL_FEATURE,
@@ -67,6 +68,7 @@ export * from './frames/integration.js'
 export * from './frames/mcpserver.js'
 export * from './frames/memory-connection.js'
 export * from './frames/skill.js'
+export * from './frames/runtime-command.js'
 export * from './frames/gitcred.js'
 export * from './frames/secrets.js'
 export * from './frames/session.js'


### PR DESCRIPTION
Groundwork for a `/` command picker in the webchat composer. Landing the read seam on its own because it stands up without any UI: it also lets the Tools & Skills tab eventually show what the runtime *actually* exposes instead of what we guess by scanning directories.

## What

ACP already standardizes this ([spec](https://agentclientprotocol.com/protocol/v1/slash-commands)): the agent advertises `available_commands_update` with `{ name, description, input.hint }`, and the client invokes a command as plain `/name arg` text in the prompt — no structured field. `claude-agent-acp` sends the list right after `session/new` and replaces it wholesale on every later advertisement.

The daemon has been receiving that notification and dropping it. This captures it per agent and serves it as one CP read:

- `runtime/commands` → `runtime/commands/list` (protocol)
- `RuntimeCommandsCache` on the daemon, latest-wins per agent
- `GET /agents/:id/commands` (CP), pure proxy, persists nothing

## Why not just use `skills/local`

`skills/local` scans `.claude/skills` / `.agents/skills`. The runtime's own list is strictly better: it includes user-level skills, plugin skills (`superpowers:brainstorming`), built-ins and argument hints; it reflects what the harness actually resolved rather than our re-parse of frontmatter; it differs per runtime; and it answers for a cluster agent whose workspace sits on a pod volume that no local scan can reach.

Verified against the real adapter — a probe client driving `@agentclientprotocol/claude-agent-acp@0.70.0` returned 101 commands, including a workspace `SKILL.md` written for the test, and sending `/that-skill-name` as prompt text ran it.

## The session/load fix

`shouldForwardUpdateDuringLoad` only allowed `session_info_update` and `usage_update` through. But the adapter sends the advertisement **after** a load's history replay, and that is the only advertisement a resumed session ever makes — so without this, every restarted daemon would stay blind until its next new session. Same rationale as the existing entries: latest-wins metadata needed to converge after a restart, not replayed conversation.

## Version skew

Gated on `runtime-commands-v1` and checked before the frame is sent (409 `DAEMON_FEATURE_MISSING`). An older daemon silently ignores an unknown control frame, so an ungated read would burn the REQ's full retransmit budget and then surface as "daemon offline". `skills/local` skipped this gate; this one doesn't.

## Bounds

Names and descriptions come from repo-controlled `SKILL.md` frontmatter and the reply rides a 256 KiB control frame, so the normalizer caps command count, per-field length and total bytes, and drops unnamed/duplicate entries. The real 101-command payload normalizes to 24.5 KiB.

## Tests

- `runtime-commands.test.ts` — normalization, dedup, the hostile-advertisement bound, cache replace-not-merge, per-agent forget, and the reader refusing an agent this daemon doesn't run
- `client-dispatch.test.ts` — two cases over the real frame path (envelope → codec → control registry → handler → reply)
- `agents.commands.route.test.ts` — real Postgres + Fastify: 200 proxy, `reported:false` as data, 404, 409 on version skew, 503 unplaced, 503 offline
- `acp-host.test.ts` — the load-filter passthrough

Regression: daemon affected subset 36 files / 519 tests green, CP unit 161 files / 1792 tests green. The daemon full run has 14 failures in `shim-*` / `workspace-git-runner-seam` and the `acp-matrix` real-runtime cases — confirmed identical with this change stashed, so pre-existing.

## Not in this PR

The composer `/` picker, and a design-doc section on the two data sources (`skills/local` has no design entry either; worth adding one that covers both rather than one for this alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
