### PR TITLE
fix(console): render Markdown frontmatter as a table, like GitHub

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -894,6 +894,14 @@ and `Add file`, `Edit`, and `Delete` actions on the right. New-file naming happe
 in that breadcrumb; completed slash-separated directory names become breadcrumb
 segments. The preview pane does not repeat the file name, path, or workspace label.
 
+A Markdown preview renders a leading YAML frontmatter block as a keyed table above
+the document, the way GitHub does — a memory topic file, a `SKILL.md`, and a
+knowledge body all open with one, and CommonMark would otherwise read it as a
+thematic break plus a setext heading. A sequence renders as a row of cells and a
+nested mapping as its own table. A block that is not a readable mapping is hidden
+rather than shown as prose, and the document body still renders; the raw text stays
+visible through the preview's Code toggle. Editing always shows the file verbatim.
+
 The managed and native Memory file browser uses the same shared inline file editor,
 breadcrumb naming field, and header actions as Workspace. It must not introduce a
 separate prompt or modal flow for adding or editing files; only the persistence API

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -46,15 +46,19 @@
     "react-markdown": "^10.1.0",
     "recharts": "^3.10.1",
     "remark-breaks": "^4.0.0",
+    "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
-    "swr": "^2.4.2"
+    "swr": "^2.4.2",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",
+    "@types/hast": "^3.0.4",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "happy-dom": "^20.11.1",
+    "mdast-util-to-hast": "^13.2.1",
     "postcss": "^8.5.24",
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.3",

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -2639,6 +2639,15 @@
   .md-body tr:nth-child(2n) td {
     background: var(--surface-app);
   }
+  /* YAML frontmatter, rendered as a keyed table above the body (GitHub's shape).
+   The key column is centered and unwrapped; nested tables sit flush in their cell. */
+  .md-body .md-frontmatter th {
+    text-align: center;
+    white-space: nowrap;
+  }
+  .md-body .md-frontmatter table {
+    margin: 0;
+  }
   .md-body hr {
     height: 1px;
     border: 0;

--- a/packages/web/src/components/console/MarkdownView.test.tsx
+++ b/packages/web/src/components/console/MarkdownView.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+
+// Frontmatter rendering, driven through the REAL react-markdown pipeline: the bug was
+// that `---\nkey: value\n---` came out as one giant setext heading, which only shows up
+// once remark actually parses the document.
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import MarkdownView from './MarkdownView'
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+function render(content: string): HTMLDivElement {
+  act(() => root.render(<MarkdownView content={content} />))
+  return host
+}
+
+describe('MarkdownView frontmatter', () => {
+  it('renders a memory header as a keyed table, not a heading', () => {
+    const out = render('---\nname: deploys\ndescription: how we ship\n---\n\nDeploy only from main.\n')
+    const table = out.querySelector('table.md-frontmatter')
+    expect(table).not.toBeNull()
+    expect([...table!.querySelectorAll('th')].map((th) => th.textContent)).toEqual(['name', 'description'])
+    expect([...table!.querySelectorAll('tr > td')].map((td) => td.textContent)).toEqual(['deploys', 'how we ship'])
+    // The regression: the header used to become an <h2> and the body followed it.
+    expect(out.querySelector('h1, h2')).toBeNull()
+    expect(out.textContent).toContain('Deploy only from main.')
+  })
+
+  it('nests a sequence as a row of cells and a mapping as its own table', () => {
+    const out = render(
+      '---\ntitle: ACP\nread_when:\n  - Setting up IDE integrations\n  - Debugging session routing\nmetadata:\n  type: reference\n---\nbody\n'
+    )
+    const rows = [...out.querySelectorAll('table.md-frontmatter > tbody > tr')]
+    expect(rows.map((row) => row.querySelector('th')?.textContent)).toEqual(['title', 'read_when', 'metadata'])
+    const listCells = [...rows[1]!.querySelectorAll('table td')]
+    expect(listCells.map((td) => td.textContent)).toEqual(['Setting up IDE integrations', 'Debugging session routing'])
+    const nested = rows[2]!.querySelector('table')
+    expect(nested?.querySelector('th')?.textContent).toBe('type')
+    expect(nested?.querySelector('td')?.textContent).toBe('reference')
+  })
+
+  it('keeps quoted scalars intact and does not print YAML syntax', () => {
+    const out = render('---\ndescription: "ship: only from main"\nmodified: 2026-08-20T05:48:55.191Z\n---\nbody\n')
+    expect(out.querySelector('table.md-frontmatter')?.textContent).toContain('ship: only from main')
+    expect(out.textContent).not.toContain('"ship')
+  })
+
+  it('drops an unreadable block instead of rendering it as prose', () => {
+    // Invalid YAML, and a scalar or sequence where a mapping belongs: metadata the
+    // viewer cannot key is hidden, but the document body still renders.
+    for (const header of ['description: ship: prod', 'just text', '- one\n- two']) {
+      const out = render(`---\n${header}\n---\n\nthe body\n`)
+      expect(out.querySelector('table')).toBeNull()
+      expect(out.textContent).toContain('the body')
+      expect(out.textContent).not.toContain('just text')
+    }
+  })
+
+  it('leaves a mid-document thematic break alone', () => {
+    const out = render('# Title\n\n---\n\nnot a header\n')
+    expect(out.querySelector('table')).toBeNull()
+    expect(out.querySelector('hr')).not.toBeNull()
+    expect(out.querySelector('h1')?.textContent).toBe('Title')
+  })
+})

--- a/packages/web/src/components/console/MarkdownView.tsx
+++ b/packages/web/src/components/console/MarkdownView.tsx
@@ -4,6 +4,10 @@
 // Split into its own module so react-markdown + remark-gfm are loaded lazily (via
 // next/dynamic) and never ship in the main console bundle.
 //
+// Frontmatter is handled the way GitHub does it — `remark-frontmatter` keeps the
+// `---` block out of the prose rules and it renders as a keyed table (see
+// `frontmatter.ts`), instead of turning the whole header into a setext heading.
+//
 // Safety: react-markdown escapes raw HTML and sanitizes URLs by default, so
 // untrusted agent-authored files can't inject scripts. A caller may opt in to
 // resolving a link as an in-app action or marking it unavailable; every unresolved
@@ -11,6 +15,8 @@
 
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import remarkFrontmatter from 'remark-frontmatter'
+import { frontmatterTableHandler } from '@/components/console/frontmatter'
 
 export type MarkdownLinkResolution = { kind: 'action'; onActivate: () => void } | { kind: 'blocked' }
 
@@ -24,7 +30,8 @@ export default function MarkdownView({
   return (
     <div className="md-body">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkFrontmatter]}
+        remarkRehypeOptions={{ handlers: { yaml: frontmatterTableHandler } }}
         components={{
           a: ({ children, node: _node, href, title, ...props }) => {
             const resolved = href !== undefined ? resolveLink?.(href) : undefined

--- a/packages/web/src/components/console/frontmatter.ts
+++ b/packages/web/src/components/console/frontmatter.ts
@@ -1,0 +1,69 @@
+// YAML frontmatter in a Markdown preview, rendered the way GitHub renders it: a
+// keyed table above the document instead of the setext heading CommonMark would
+// otherwise make of `---\nkey: value\n---`.
+//
+// The pieces are off the shelf — `remark-frontmatter` recognizes the block (so it
+// never reaches the paragraph/heading rules) and `yaml` reads it. Only the table
+// shape below is ours, because GitHub's renderer is not published as a plugin.
+
+import { parse as parseYaml } from 'yaml'
+import type { Element, ElementContent } from 'hast'
+import type { Handler } from 'mdast-util-to-hast'
+
+function element(tagName: string, children: ElementContent[]): Element {
+  return { type: 'element', tagName, properties: {}, children }
+}
+
+function text(value: string): ElementContent {
+  return { type: 'text', value }
+}
+
+/** One value. A sequence becomes a row of cells and a mapping a keyed table — nesting
+ *  a table inside a cell is why this builds hast rather than an mdast table node. */
+function valueContent(value: unknown): ElementContent[] {
+  if (value === null || value === undefined) return []
+  if (value instanceof Date) return [text(value.toISOString())]
+  if (Array.isArray(value)) {
+    if (value.length === 0) return []
+    const cells = value.map((item) => element('td', valueContent(item)))
+    return [element('table', [element('tbody', [element('tr', cells)])])]
+  }
+  if (typeof value === 'object') {
+    const rows = mappingRows(value as Record<string, unknown>)
+    return rows.length > 0 ? [element('table', [element('tbody', rows)])] : []
+  }
+  return [text(String(value))]
+}
+
+function mappingRows(mapping: Record<string, unknown>): Element[] {
+  return Object.entries(mapping).map(([key, value]) => {
+    const th: Element = { type: 'element', tagName: 'th', properties: { scope: 'row' }, children: [text(key)] }
+    return element('tr', [th, element('td', valueContent(value))])
+  })
+}
+
+/**
+ * mdast-to-hast handler for the `yaml` node `remark-frontmatter` produces.
+ *
+ * Anything that is not a mapping — invalid YAML, a bare scalar, a sequence — returns
+ * `undefined`, which drops the node from the output. The block is metadata, so hiding
+ * an unreadable one beats rendering it as prose that was never meant to be read.
+ */
+export const frontmatterTableHandler: Handler = (_state, node) => {
+  const raw = typeof (node as { value?: unknown }).value === 'string' ? (node as { value: string }).value : ''
+  let parsed: unknown
+  try {
+    parsed = parseYaml(raw)
+  } catch {
+    return undefined
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
+  const rows = mappingRows(parsed as Record<string, unknown>)
+  if (rows.length === 0) return undefined
+  return {
+    type: 'element',
+    tagName: 'table',
+    properties: { className: ['md-frontmatter'] },
+    children: [element('tbody', rows)]
+  }
+}

--- a/packages/web/src/components/console/frontmatter.ts
+++ b/packages/web/src/components/console/frontmatter.ts
@@ -22,7 +22,6 @@ function text(value: string): ElementContent {
  *  a table inside a cell is why this builds hast rather than an mdast table node. */
 function valueContent(value: unknown): ElementContent[] {
   if (value === null || value === undefined) return []
-  if (value instanceof Date) return [text(value.toISOString())]
   if (Array.isArray(value)) {
     if (value.length === 0) return []
     const cells = value.map((item) => element('td', valueContent(item)))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -689,16 +689,25 @@ importers:
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
+      remark-frontmatter:
+        specifier: ^5.0.0
+        version: 5.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
       swr:
         specifier: ^2.4.2
         version: 2.4.2(react@19.2.8)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.5
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -711,6 +720,9 @@ importers:
       happy-dom:
         specifier: ^20.11.1
         version: 20.11.1
+      mdast-util-to-hast:
+        specifier: ^13.2.1
+        version: 13.2.1
       postcss:
         specifier: ^8.5.24
         version: 8.5.25
@@ -5411,6 +5423,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -5513,6 +5528,10 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -6480,6 +6499,9 @@ packages:
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
@@ -6546,6 +6568,9 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -7672,6 +7697,9 @@ packages:
 
   remark-breaks@4.0.0:
     resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -13847,6 +13875,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -13958,6 +13990,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  format@0.2.2: {}
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -14986,6 +15020,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -15150,6 +15195,13 @@ snapshots:
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
@@ -16542,6 +16594,15 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-newline-to-break: 2.0.0
       unified: 11.0.5
+
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
Reported by @pchsu: memory files render badly in the console because of their YAML header.

## The bug

Confirmed against the real pipeline — `---\nname: deploys\ndescription: how we ship\n---` came out as:

```html
<hr>
<h2>name: deploys
description: how we ship</h2>
```

CommonMark has no frontmatter: the opening `---` is a thematic break and the closing one is a setext underline, so the whole header became one heading. Memory topic files, `SKILL.md`, and knowledge bodies all open this way.

## The fix

Off-the-shelf where a library exists, ours only for the shape GitHub renders:

- **`remark-frontmatter`** (remarkjs, YAML only by default) recognizes the block so it never reaches the paragraph/heading rules — no hand-rolled fence regex, and a mid-document `---` stays a thematic break.
- **`yaml`** reads it, same parser the daemon writes memory headers with.
- A **mdast-to-hast handler** (`remarkRehypeOptions.handlers.yaml`) turns it into the keyed table: scalar → text, sequence → a row of cells, mapping → its own nested table. No published plugin does this — GitHub's renderer isn't one — and mdast tables can't nest, which is why the handler emits hast. Everything is a text node, so nothing new is injectable.

A block that isn't a readable mapping (invalid YAML, a bare scalar, a sequence) is dropped rather than rendered as prose it was never meant to be; the document body always renders.

One component, so this covers the memory viewer, the workspace file browser, and knowledge bodies. Raw editing is untouched.

## Verified

`MarkdownView.test.tsx` drives the real react-markdown pipeline: keyed table + no heading for a memory header, nested sequence/mapping, a quoted scalar with a colon (`"ship: only from main"`) surviving intact, unreadable blocks dropped with the body preserved, and a mid-document `---` still an `<hr>`. Full web suite (1709), typecheck, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)