### PR TITLE
feat(web): offer the runtime's commands from the composer, with what each one does

### DIFF
--- a/packages/web/src/components/console/CommandMenu.tsx
+++ b/packages/web/src/components/console/CommandMenu.tsx
@@ -47,7 +47,7 @@ export function CommandMenu({
     ? { bottom: coords.elHeight - coords.top + 4 }
     : { top: coords.top + coords.height + 4 }
   // Clamp like MentionMenu: near a narrow composer's right edge `left` would otherwise push the
-  // whole popover past it. The detail pane collapses first, so clamp against the list alone.
+  // whole popover past it. Clamped against the list alone — the pane is desktop-only and fixed.
   const left = Math.min(Math.max(0, coords.left - 4), Math.max(0, coords.elWidth - LIST_WIDTH))
   return (
     <div style={{ ...position, left }} className="absolute z-50 flex items-start gap-1">
@@ -82,8 +82,9 @@ export function CommandMenu({
               )}
               <span className="min-w-0 flex-1 text-left">
                 <span className="mono block truncate text-[12px]">/{option.name}</span>
-                {option.description && (
+                {(option.description || showOwner) && (
                   <span className="block truncate font-sans text-[11px] leading-normal font-normal text-(--text-tertiary) desktop:hidden">
+                    {showOwner ? `${option.agentName} · ` : ''}
                     {option.description}
                   </span>
                 )}

--- a/packages/web/src/components/console/CommandMenu.tsx
+++ b/packages/web/src/components/console/CommandMenu.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+// The `/command` picker's floating list. Like MentionMenu it owns no focus — the textarea keeps it
+// and drives `activeIndex` through useCommandAutocomplete.handleKeyDown.
+//
+// The pane beside the list is the point of this menu: ACP makes `description` a REQUIRED field on
+// every advertised command, and a name alone ("/tdd", "/handoff") does not say what running it
+// does. Zed's ACP picker drops the description and its users ask for it back
+// (zed-industries/zed discussion #49085), so the data is there and the affordance is the gap.
+
+import { AgentIconView } from '@/components/marks'
+import type { AgentIcon } from '@/lib/agent-icon'
+import type { CommandCandidate } from '@/components/console/runtime-command-menu'
+import type { RuntimeCommandsGap } from '@/components/console/useRuntimeCommands'
+import { COMMAND_MENU_MAX_HEIGHT } from '@/components/console/useCommandAutocomplete'
+import type { MentionCoords } from '@/components/console/useMentionAutocomplete'
+
+const LIST_WIDTH = 240
+const DETAIL_WIDTH = 260
+
+export function CommandMenu({
+  options,
+  activeIndex,
+  coords,
+  /** Icons by agentId — a multi-participant conversation marks whose command each row is. */
+  iconOf,
+  gaps,
+  /** Whether to show the owning agent at all (a one-agent conversation has nothing to disambiguate). */
+  showOwner,
+  onHover,
+  onPick
+}: {
+  options: readonly CommandCandidate[]
+  activeIndex: number
+  coords: MentionCoords | null
+  iconOf: (agentId: string) => { icon: AgentIcon | null | undefined; runtime: string } | undefined
+  showOwner: boolean
+  /** Participants that contributed nothing, and why — a partial roster reads as partial, not empty. */
+  gaps?: ReadonlyArray<{ agentId: string; agentName: string; reason: RuntimeCommandsGap }>
+  onHover: (index: number) => void
+  onPick: (option: CommandCandidate) => void
+}) {
+  // Render for gaps alone too: a roster whose every participant is a gap must say so, not vanish.
+  if ((options.length === 0 && (gaps?.length ?? 0) === 0) || !coords) return null
+  const active = options[activeIndex]
+  const position = coords.openUpward
+    ? { bottom: coords.elHeight - coords.top + 4 }
+    : { top: coords.top + coords.height + 4 }
+  // Clamp like MentionMenu: near a narrow composer's right edge `left` would otherwise push the
+  // whole popover past it. The detail pane collapses first, so clamp against the list alone.
+  const left = Math.min(Math.max(0, coords.left - 4), Math.max(0, coords.elWidth - LIST_WIDTH))
+  return (
+    <div style={{ ...position, left }} className="absolute z-50 flex items-start gap-1">
+      <div
+        role="listbox"
+        aria-label="Run a command"
+        style={{ maxHeight: COMMAND_MENU_MAX_HEIGHT }}
+        className="w-[240px] flex-none overflow-y-auto rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
+      >
+        {options.map((option, index) => {
+          const owner = iconOf(option.agentId)
+          return (
+            <button
+              key={`${option.agentId}:${option.name}`}
+              type="button"
+              role="option"
+              aria-selected={index === activeIndex}
+              className={`fopt min-h-8 w-full gap-2 rounded-md px-2 py-[5px] text-[12px] ${
+                index === activeIndex ? 'bg-(--surface-hover)' : ''
+              }`}
+              onMouseEnter={() => onHover(index)}
+              onMouseDown={(event) => {
+                // preventDefault keeps focus in the textarea so pick() can restore the caret.
+                event.preventDefault()
+                onPick(option)
+              }}
+            >
+              {showOwner && owner && (
+                <span className="av h-[18px] w-[18px] flex-none rounded-xs">
+                  <AgentIconView icon={owner.icon} runtime={owner.runtime} size={18} />
+                </span>
+              )}
+              <span className="min-w-0 flex-1 text-left">
+                <span className="mono block truncate text-[12px]">/{option.name}</span>
+                {option.description && (
+                  <span className="block truncate font-sans text-[11px] leading-normal font-normal text-(--text-tertiary) desktop:hidden">
+                    {option.description}
+                  </span>
+                )}
+              </span>
+            </button>
+          )
+        })}
+        {(gaps ?? []).map((gap) => (
+          <div
+            key={gap.agentId}
+            className="border-t border-(--border-subtle) px-2 py-[5px] font-sans text-[11px] leading-normal font-normal text-(--text-tertiary)"
+          >
+            {gap.agentName || 'One agent'}
+            {gap.reason === 'unreported'
+              ? ' hasn’t run yet — skills appear after its first session'
+              : ' is unreachable'}
+          </div>
+        ))}
+      </div>
+      {active && (
+        <div
+          style={{ maxHeight: COMMAND_MENU_MAX_HEIGHT, width: DETAIL_WIDTH }}
+          className="hidden flex-none overflow-y-auto rounded-[9px] border border-(--border-default) bg-(--surface-card) p-3 shadow-(--shadow-lg) desktop:block"
+        >
+          <div className="mono text-[12px] break-all text-(--text-primary)">/{active.name}</div>
+          {active.hint && (
+            <div className="mono mt-[3px] text-[11px] break-all text-(--text-tertiary)">{active.hint}</div>
+          )}
+          <p className="mt-2 font-sans text-[12px] leading-[1.5] font-normal text-(--text-secondary)">
+            {active.description || 'This command has no description.'}
+          </p>
+          {showOwner && (
+            <div className="mt-2 border-t border-(--border-subtle) pt-2 font-sans text-[11px] font-normal text-(--text-tertiary)">
+              Runs on {active.agentName}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -40,6 +40,7 @@ import {
 import { useOrgs } from '@/lib/org-context'
 import { randomUuid } from '@/lib/random-uuid'
 import { resolveRoster, typedMentionIds, wireMentions } from '@/lib/conversation-addressing'
+import { leadingCommandToken } from '@/components/console/runtime-command-menu'
 import { sessionAfterModelSelection } from '@/lib/session-runtime-controls'
 import { reconcilePersistedLiveSteps } from '@/lib/session-transcript'
 import {
@@ -103,7 +104,11 @@ interface PlaygroundData {
     participants?: Array<{ agentId: string; name: string; primary?: boolean }>,
     /** Overrides the staged composer image — for callers (Home) that mint the
      *  session id in the same tick, before setPgImage state could land. */
-    image?: SessionImage
+    image?: SessionImage,
+    /** A `/` pick's owner. Honored only while the picked token still LEADS the outgoing text and
+     *  the owner is a participant — then it joins `mentions[]`, narrowing the turn to the one
+     *  agent whose runtime has the skill instead of waking the roster to decline. */
+    commandPick?: { agentId: string; name: string }
   ) => boolean
   /** Mark `id` (a CP session id) as a session-targeted continuation: the socket
    *  mints through the session-target token route and the daemon dispatches
@@ -154,6 +159,8 @@ export interface QueuedTurn {
   agentId: string
   conversationId?: string
   participants?: Array<{ agentId: string; name: string; primary?: boolean }>
+  /** A `/` pick's owner, revalidated at dispatch — see sendTurn. */
+  commandPick?: { agentId: string; name: string }
 }
 
 // Synthetic playground session ids start with `pg_`; real CP session ids do not.
@@ -1244,7 +1251,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       text: string,
       image: SessionImage | undefined,
       conversationId?: string,
-      knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>
+      knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>,
+      commandPick?: { agentId: string; name: string }
     ): void => {
       const requestedTurnId = randomUuid()
       pushStep(id, { kind: 'msg', who: '@you', turnId: requestedTurnId, text, ...(image ? { image } : {}) })
@@ -1276,7 +1284,15 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       if (!session && knownParticipants && knownParticipants.length > 1 && !rosterNames.current.has(id)) {
         rosterNames.current.set(id, new Map(knownParticipants.map((p) => [p.agentId, p.name])))
       }
-      const mentions = typedMentionIds(roster, text)
+      const typed = typedMentionIds(roster, text)
+      const commandTarget =
+        commandPick &&
+        roster.some((p) => p.agentId === commandPick.agentId) &&
+        leadingCommandToken(text) === commandPick.name &&
+        !typed.includes(commandPick.agentId)
+          ? [commandPick.agentId]
+          : []
+      const mentions = [...typed, ...commandTarget]
       const targets = roster.length > 1 ? (mentions.length ? mentions : roster.map((p) => p.agentId)) : [agentForId]
       // Membership is a standing mention — a bare multi-agent send materializes it as
       // the whole roster in structured `mentions` (see wireMentions), the same wire
@@ -1352,7 +1368,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       textArg?: string,
       conversationId?: string,
       knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>,
-      imageArg?: SessionImage
+      imageArg?: SessionImage,
+      commandPick?: { agentId: string; name: string }
     ) => {
       const text = String(textArg ?? pgDrafts.current[id] ?? '').trim()
       const image = imageArg ?? pgImageBy[id]
@@ -1368,6 +1385,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           text,
           ...(image ? { image } : {}),
           agentId: agentForId,
+          ...(commandPick ? { commandPick } : {}),
           ...(conversationId ? { conversationId } : {}),
           ...(knownParticipants ? { participants: knownParticipants } : {})
         }
@@ -1375,7 +1393,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         setPgQueueBy((cur) => ({ ...cur, [id]: [...(cur[id] ?? NO_QUEUE), queued] }))
         return true
       }
-      sendTurn(id, agentForId, text, image, conversationId, knownParticipants)
+      sendTurn(id, agentForId, text, image, conversationId, knownParticipants, commandPick)
       return true
     },
     [pgImageBy, sendTurn, setPgImage, setPgInput]
@@ -1395,7 +1413,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       dispatchedQueueIds.current.add(next.queueId)
       pgQueueRef.current[id] = (pgQueueRef.current[id] ?? NO_QUEUE).filter((q) => q.queueId !== next.queueId)
       setPgQueueBy((cur) => ({ ...cur, [id]: (cur[id] ?? NO_QUEUE).filter((q) => q.queueId !== next.queueId) }))
-      sendTurn(id, next.agentId, next.text, next.image, next.conversationId, next.participants)
+      sendTurn(id, next.agentId, next.text, next.image, next.conversationId, next.participants, next.commandPick)
     }
   }, [pgQueueBy, pgBusyBy, sendTurn])
 

--- a/packages/web/src/components/console/runtime-command-menu.test.ts
+++ b/packages/web/src/components/console/runtime-command-menu.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { commandQueryAt } from '@/lib/conversation-addressing'
+import {
+  commandInsertion,
+  leadingCommandToken,
+  matchCommands,
+  offerableCommands,
+  type CommandCandidate
+} from '@/components/console/runtime-command-menu'
+
+const AGENT_A = { agentId: 'a', agentName: 'Alice' }
+const AGENT_B = { agentId: 'b', agentName: 'Bob' }
+const candidate = (agent: typeof AGENT_A, name: string): CommandCandidate => ({
+  ...agent,
+  name,
+  description: `${name} does a thing`,
+  hint: null
+})
+
+describe('commandQueryAt', () => {
+  it('opens on a leading slash and narrows on what follows', () => {
+    expect(commandQueryAt('/', 1)).toEqual({ start: 0, query: '' })
+    expect(commandQueryAt('/rev', 4)).toEqual({ start: 0, query: 'rev' })
+    expect(commandQueryAt('  /rev', 6)).toEqual({ start: 2, query: 'rev' })
+  })
+
+  it('opens after mentions, since picking a command may have inserted one', () => {
+    expect(commandQueryAt('@Bob /rev', 9)).toEqual({ start: 5, query: 'rev' })
+    expect(commandQueryAt('@Alice @Bob /co', 15)).toEqual({ start: 12, query: 'co' })
+  })
+
+  it('leaves an ordinary slash alone — a command is the prompt’s leading token', () => {
+    expect(commandQueryAt('look at src/index.ts', 20)).toBeNull()
+    expect(commandQueryAt('see https://example.test/x', 26)).toBeNull()
+    expect(commandQueryAt('do this /then', 13)).toBeNull()
+    // A space ends the query: the picker narrows on the command word only.
+    expect(commandQueryAt('/review this pr', 15)).toBeNull()
+  })
+})
+
+describe('offerableCommands', () => {
+  it('offers only skills — built-ins (console-owned ones included) cannot be dispatched', () => {
+    const offered = offerableCommands(AGENT_A, [
+      { name: 'code-review', description: 'Review the diff (project)', hint: '[pr]' },
+      { name: '$refactor', description: 'Restructure safely', hint: null },
+      { name: 'superpowers:brainstorming', description: '(superpowers) Explore intent', hint: null },
+      { name: 'model', description: 'Set the AI model for Claude Code', hint: '<model>' },
+      { name: 'compact', description: 'Clear conversation history', hint: null },
+      { name: 'mcp:docs:search', description: 'Search the docs', hint: null }
+    ])
+    expect(offered.map((c) => c.name)).toEqual(['code-review', '$refactor', 'superpowers:brainstorming'])
+    expect(offered[0]).toMatchObject({ agentId: 'a', agentName: 'Alice', hint: '[pr]' })
+  })
+
+  it('trusts the daemon’s record-time skill bit over the (possibly truncated) description', () => {
+    const offered = offerableCommands(AGENT_A, [
+      // Long description whose `(user)` marker was eaten by the daemon's display cap.
+      { name: 'agentconnect-setup', description: 'x'.repeat(512), hint: null, skill: true },
+      // And the inverse: the bit outranks a suffix that would have matched.
+      { name: 'weird', description: 'looks like (user)', hint: null, skill: false }
+    ])
+    expect(offered.map((c) => c.name)).toEqual(['agentconnect-setup'])
+  })
+})
+
+describe('matchCommands', () => {
+  it('ranks a prefix match above a substring one', () => {
+    const all = [candidate(AGENT_A, 'code-review'), candidate(AGENT_A, 'review'), candidate(AGENT_A, 'tdd')]
+    expect(matchCommands(all, 're', 8).map((c) => c.name)).toEqual(['review', 'code-review'])
+  })
+
+  it('keeps the same name from two agents — they are different commands', () => {
+    const all = [candidate(AGENT_A, 'code-review'), candidate(AGENT_B, 'code-review')]
+    const matched = matchCommands(all, 'code', 8)
+    expect(matched).toHaveLength(2)
+    expect(matched.map((c) => c.agentId).sort()).toEqual(['a', 'b'])
+  })
+
+  it('reaches a codex `$name` from a bare typed query', () => {
+    const all = [candidate(AGENT_A, '$code-review'), candidate(AGENT_A, 'tdd')]
+    expect(matchCommands(all, 'code', 8).map((c) => c.name)).toEqual(['$code-review'])
+  })
+
+  it('offers everything on an empty query, bounded by the limit', () => {
+    const all = Array.from({ length: 40 }, (_, i) => candidate(AGENT_A, `cmd-${i}`))
+    expect(matchCommands(all, '', 8)).toHaveLength(8)
+  })
+})
+
+describe('commandInsertion', () => {
+  it('replaces the typed token verbatim and leaves the caret ready for an argument', () => {
+    const next = commandInsertion({ text: '/co', anchorStart: 0, spanEnd: 3, command: { name: 'code-review' } })
+    expect(next.text).toBe('/code-review ')
+    expect(next.caret).toBe(next.text.length)
+  })
+
+  // The owner is addressed structurally (the pick rides mentions[]) — an inline `@Name` would
+  // displace the command from the leading position the daemon's translation gate matches on.
+  it('never writes a mention into the draft', () => {
+    const next = commandInsertion({ text: '/co', anchorStart: 0, spanEnd: 3, command: { name: 'code-review' } })
+    expect(next.text).not.toContain('@')
+  })
+
+  it('keeps the advertised `$` name and any text typed after the token', () => {
+    const next = commandInsertion({
+      text: '/co the release',
+      anchorStart: 0,
+      spanEnd: 3,
+      command: { name: '$code-review' }
+    })
+    expect(next.text).toBe('/$code-review  the release')
+    expect(next.caret).toBe('/$code-review '.length)
+  })
+})
+
+describe('leadingCommandToken', () => {
+  it('reads the token a draft leads with, tolerating whitespace and complete mentions', () => {
+    expect(leadingCommandToken('/code-review 42')).toBe('code-review')
+    expect(leadingCommandToken('  /$refactor')).toBe('$refactor')
+    expect(leadingCommandToken('@Bob /tdd now')).toBe('tdd')
+  })
+
+  it('reads nothing from a draft the command no longer leads', () => {
+    expect(leadingCommandToken('run /code-review')).toBeNull()
+    expect(leadingCommandToken('@Bob the log is in /tmp')).toBeNull()
+    expect(leadingCommandToken('hello')).toBeNull()
+  })
+})

--- a/packages/web/src/components/console/runtime-command-menu.test.ts
+++ b/packages/web/src/components/console/runtime-command-menu.test.ts
@@ -24,9 +24,11 @@ describe('commandQueryAt', () => {
     expect(commandQueryAt('  /rev', 6)).toEqual({ start: 2, query: 'rev' })
   })
 
-  it('opens after mentions, since picking a command may have inserted one', () => {
-    expect(commandQueryAt('@Bob /rev', 9)).toEqual({ start: 5, query: 'rev' })
-    expect(commandQueryAt('@Alice @Bob /co', 15)).toEqual({ start: 12, query: 'co' })
+  it('does NOT open after a mention — the daemon never translates that draft', () => {
+    // Owner addressing is structural (the pick rides mentions[]), so a leading @mention has no
+    // command meaning; offering the picker on it would re-create the UI-yes/wire-no split.
+    expect(commandQueryAt('@Bob /rev', 9)).toBeNull()
+    expect(commandQueryAt('@Alice @Bob /co', 15)).toBeNull()
   })
 
   it('leaves an ordinary slash alone — a command is the prompt’s leading token', () => {
@@ -114,14 +116,15 @@ describe('commandInsertion', () => {
 })
 
 describe('leadingCommandToken', () => {
-  it('reads the token a draft leads with, tolerating whitespace and complete mentions', () => {
+  it('reads the token a draft leads with, tolerating whitespace only', () => {
     expect(leadingCommandToken('/code-review 42')).toBe('code-review')
     expect(leadingCommandToken('  /$refactor')).toBe('$refactor')
-    expect(leadingCommandToken('@Bob /tdd now')).toBe('tdd')
   })
 
-  it('reads nothing from a draft the command no longer leads', () => {
+  it('reads nothing from a draft the command no longer leads — mentions included', () => {
     expect(leadingCommandToken('run /code-review')).toBeNull()
+    // Matches the daemon gate exactly: a leading mention defeats translation, so it defeats this.
+    expect(leadingCommandToken('@Bob /tdd now')).toBeNull()
     expect(leadingCommandToken('@Bob the log is in /tmp')).toBeNull()
     expect(leadingCommandToken('hello')).toBeNull()
   })

--- a/packages/web/src/components/console/runtime-command-menu.ts
+++ b/packages/web/src/components/console/runtime-command-menu.ts
@@ -1,0 +1,88 @@
+// The `/` skill picker's pure logic: which of the runtime's advertised commands the composer
+// offers, how a query narrows them, and what picking one writes into the draft. Kept out of the
+// hook so the multi-agent rules — the ones Claude Code and Zed never have to make — are testable
+// on their own.
+//
+// SKILLS only (`isSkillCommand`): the daemon's invocation translation dispatches skills through a
+// plain-text instruction, and a harness built-in like `/compact` cannot be dispatched that way —
+// offering it would put a dead entry in the menu. This also supersedes the old console-owned-name
+// filter: `model` / `effort` / `permission` are built-ins, so the same gate removes them.
+
+import { isSkillCommand } from '@agentconnect.md/protocol'
+
+/** One skill offered in the picker, carrying the agent it belongs to. */
+export interface CommandCandidate {
+  agentId: string
+  agentName: string
+  name: string
+  description: string
+  /** ACP `input.hint` — an argument hint, or null when the command takes none. */
+  hint: string | null
+}
+
+/** The skills the picker may offer for one agent. */
+export function offerableCommands(
+  agent: { agentId: string; agentName: string },
+  commands: ReadonlyArray<{ name: string; description: string; hint: string | null; skill?: boolean }>
+): CommandCandidate[] {
+  // The daemon's record-time bit is the truth (it saw the description before the display cap);
+  // the heuristic only covers a daemon that predates the field.
+  return commands
+    .filter((command) => command.skill ?? isSkillCommand(command))
+    .map(({ skill: _skill, ...command }) => ({ ...agent, ...command }))
+}
+
+/**
+ * Narrow the offered commands to a typed query. A prefix match outranks a substring one — typing
+ * "re" should reach `review` before `code-review` — and the name is never deduplicated across
+ * agents: two participants can both expose `code-review`, and they are different commands.
+ */
+export function matchCommands(
+  candidates: readonly CommandCandidate[],
+  query: string,
+  limit: number
+): CommandCandidate[] {
+  const q = query.trim().toLowerCase()
+  const scored: Array<{ candidate: CommandCandidate; rank: number }> = []
+  for (const candidate of candidates) {
+    // codex advertises skills as `$name`; typing `/code` must still reach `$code-review`.
+    const name = candidate.name.toLowerCase().replace(/^\$/, '')
+    const bare = q.replace(/^\$/, '')
+    if (!bare) scored.push({ candidate, rank: 1 })
+    else if (name.startsWith(bare)) scored.push({ candidate, rank: 0 })
+    else if (name.includes(bare)) scored.push({ candidate, rank: 1 })
+  }
+  return scored
+    .sort((a, b) => a.rank - b.rank || a.candidate.name.localeCompare(b.candidate.name))
+    .slice(0, limit)
+    .map((entry) => entry.candidate)
+}
+
+/**
+ * What picking `command` writes into the draft: the token is replaced by the ADVERTISED `/name `
+ * verbatim (`/$code-review` on codex) with a trailing space for an argument. Nothing else — the
+ * owner is addressed STRUCTURALLY (the pick's target rides the send's `mentions[]`), never as
+ * `@Name` text: an inline mention would displace the command from the leading position the
+ * daemon's translation gate matches on, which is exactly how the first cut of this picker died
+ * in review.
+ */
+export function commandInsertion(input: {
+  text: string
+  /** Index of the triggering `/`. */
+  anchorStart: number
+  /** End of the `/token` being replaced. */
+  spanEnd: number
+  command: Pick<CommandCandidate, 'name'>
+}): { text: string; caret: number } {
+  const inserted = `/${input.command.name} `
+  const head = input.text.slice(0, input.anchorStart)
+  const tail = input.text.slice(input.spanEnd)
+  return { text: head + inserted + tail, caret: head.length + inserted.length }
+}
+
+/** The `/token` a draft leads with (after whitespace and complete @mentions), for validating a
+ *  stored pick at send time — the pick only narrows the turn while its token still leads. */
+export function leadingCommandToken(text: string): string | null {
+  const match = /^\s*(?:@\S+\s+)*\/(\S+)/.exec(text)
+  return match ? match[1]! : null
+}

--- a/packages/web/src/components/console/runtime-command-menu.ts
+++ b/packages/web/src/components/console/runtime-command-menu.ts
@@ -80,9 +80,10 @@ export function commandInsertion(input: {
   return { text: head + inserted + tail, caret: head.length + inserted.length }
 }
 
-/** The `/token` a draft leads with (after whitespace and complete @mentions), for validating a
- *  stored pick at send time — the pick only narrows the turn while its token still leads. */
+/** The `/token` a draft leads with (after whitespace ONLY — the daemon's gate trims and demands
+ *  the prefix, and this must agree with it exactly), for validating a stored pick at send time:
+ *  the pick only narrows the turn while its token still leads. */
 export function leadingCommandToken(text: string): string | null {
-  const match = /^\s*(?:@\S+\s+)*\/(\S+)/.exec(text)
+  const match = /^\s*\/(\S+)/.exec(text)
   return match ? match[1]! : null
 }

--- a/packages/web/src/components/console/useCommandAutocomplete.test.tsx
+++ b/packages/web/src/components/console/useCommandAutocomplete.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment happy-dom
+import { act, useRef, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useCommandAutocomplete } from './useCommandAutocomplete'
+import { CommandMenu } from './CommandMenu'
+import type { CommandCandidate } from './runtime-command-menu'
+
+const command = (agentId: string, agentName: string, name: string): CommandCandidate => ({
+  agentId,
+  agentName,
+  name,
+  description: `${name} description`,
+  hint: null
+})
+const ROSTER = [command('a', 'Alice', 'code-review'), command('b', 'Bob', 'code-review'), command('a', 'Alice', 'tdd')]
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  if (root) act(() => root!.unmount())
+  container?.remove()
+  root = null
+  container = null
+})
+
+function mountHarness(candidates: CommandCandidate[], onPicked?: (t: { agentId: string; name: string }) => void) {
+  let api!: ReturnType<typeof useCommandAutocomplete>
+  let setDraft!: (v: string) => void
+  let getValue!: () => string
+
+  function Harness() {
+    const [value, setValue] = useState('')
+    const ref = useRef<HTMLTextAreaElement>(null)
+    api = useCommandAutocomplete({ ref, value, setValue, candidates, onPicked })
+    setDraft = setValue
+    getValue = () => value
+    return <textarea ref={ref} value={value} readOnly />
+  }
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root!.render(<Harness />))
+  return { api: () => api, setDraft: (v: string) => setDraft(v), getValue: () => getValue() }
+}
+
+/** Type `text` into the harness the way the composer's onChange does. */
+function type(h: ReturnType<typeof mountHarness>, text: string) {
+  act(() => {
+    h.setDraft(text)
+    h.api().sync(text, text.length)
+  })
+}
+
+describe('useCommandAutocomplete', () => {
+  it('opens on a leading slash and narrows as the name is typed', () => {
+    const h = mountHarness(ROSTER)
+    type(h, '/')
+    expect(h.api().open).toBe(true)
+    expect(h.api().matches).toHaveLength(3)
+
+    type(h, '/tdd')
+    expect(h.api().matches.map((c) => c.name)).toEqual(['tdd'])
+  })
+
+  it('stays shut for an ordinary slash in the middle of a sentence', () => {
+    const h = mountHarness(ROSTER)
+    type(h, 'open src/index.ts')
+    expect(h.api().open).toBe(false)
+  })
+
+  it('writes the command into the draft and leaves room for an argument', () => {
+    const h = mountHarness(ROSTER)
+    type(h, '/tdd')
+    act(() => h.api().pick(h.api().matches[0]!))
+    expect(h.getValue()).toBe('/tdd ')
+    expect(h.api().open).toBe(false)
+  })
+
+  it('names the owner through onPicked instead of writing a mention into the draft', () => {
+    const picks: Array<{ agentId: string; name: string }> = []
+    const h = mountHarness(ROSTER, (t) => picks.push(t))
+    type(h, '/code')
+    // Two participants expose `code-review`; picking Bob's must reach Bob, not the whole roster.
+    const bobs = h.api().matches.find((c) => c.agentId === 'b')!
+    act(() => h.api().pick(bobs))
+    expect(h.getValue()).toBe('/code-review ')
+    expect(picks).toEqual([{ agentId: 'b', agentName: 'Bob', name: 'code-review' }])
+  })
+
+  it('still opens after a hand-typed mention', () => {
+    const h = mountHarness(ROSTER)
+    type(h, '@Bob /td')
+    expect(h.api().matches.map((c) => c.name)).toEqual(['tdd'])
+    act(() => h.api().pick(h.api().matches[0]!))
+    expect(h.getValue()).toBe('@Bob /tdd ')
+  })
+
+  it('does not open mid-sentence after a mention — the reviewed regression', () => {
+    const h = mountHarness(ROSTER)
+    type(h, '@Bob the log is in /tmp')
+    expect(h.api().open).toBe(false)
+  })
+
+  it('closes when the draft moves out from under the anchor', () => {
+    const h = mountHarness(ROSTER)
+    type(h, '/td')
+    expect(h.api().open).toBe(true)
+    act(() => h.setDraft('')) // a queued send clearing the composer
+    expect(h.api().open).toBe(false)
+  })
+})
+
+describe('CommandMenu', () => {
+  const coords = { top: 0, left: 0, height: 18, elHeight: 56, elWidth: 400, openUpward: false }
+
+  it('lists the commands and explains the highlighted one', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() =>
+      root!.render(
+        <CommandMenu
+          options={[{ ...command('a', 'Alice', 'code-review'), hint: '[pr-number]' }, command('b', 'Bob', 'tdd')]}
+          activeIndex={0}
+          coords={coords}
+          iconOf={() => ({ icon: null, runtime: 'claude-acp' })}
+          showOwner
+          onHover={() => {}}
+          onPick={() => {}}
+        />
+      )
+    )
+    const text = container.textContent ?? ''
+    expect(text).toContain('/code-review')
+    expect(text).toContain('/tdd')
+    // The pane the picker exists for: the ACP-required description, its argument hint, and — in a
+    // multi-agent conversation — whose runtime would run it.
+    expect(text).toContain('code-review description')
+    // Pane-only content: the hint and the owner line render for the ACTIVE row alone. (Each row
+    // also carries its own description now — that is the mobile inline fallback, not a leak.)
+    expect(text).toContain('[pr-number]')
+    expect(text).toContain('Runs on Alice')
+    expect(text).not.toContain('Runs on Bob')
+  })
+
+  it('says why a participant contributed nothing instead of vanishing', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() =>
+      root!.render(
+        <CommandMenu
+          options={[]}
+          activeIndex={0}
+          coords={coords}
+          iconOf={() => undefined}
+          showOwner
+          gaps={[
+            { agentId: 'a', agentName: 'review-bot', reason: 'unreported' },
+            { agentId: 'b', agentName: 'refactor-bot', reason: 'unavailable' }
+          ]}
+          onHover={() => {}}
+          onPick={() => {}}
+        />
+      )
+    )
+    const text = container.textContent ?? ''
+    expect(text).toContain('review-bot hasn’t run yet')
+    expect(text).toContain('refactor-bot is unreachable')
+  })
+
+  it('renders nothing without a caret anchor, so a closed picker leaves no artifact', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() =>
+      root!.render(
+        <CommandMenu
+          options={[command('a', 'Alice', 'tdd')]}
+          activeIndex={0}
+          coords={null}
+          iconOf={() => undefined}
+          showOwner={false}
+          onHover={() => {}}
+          onPick={() => {}}
+        />
+      )
+    )
+    expect(container.textContent).toBe('')
+  })
+})

--- a/packages/web/src/components/console/useCommandAutocomplete.test.tsx
+++ b/packages/web/src/components/console/useCommandAutocomplete.test.tsx
@@ -90,16 +90,10 @@ describe('useCommandAutocomplete', () => {
     expect(picks).toEqual([{ agentId: 'b', agentName: 'Bob', name: 'code-review' }])
   })
 
-  it('still opens after a hand-typed mention', () => {
+  it('does not open after a mention — the daemon never translates that draft', () => {
     const h = mountHarness(ROSTER)
     type(h, '@Bob /td')
-    expect(h.api().matches.map((c) => c.name)).toEqual(['tdd'])
-    act(() => h.api().pick(h.api().matches[0]!))
-    expect(h.getValue()).toBe('@Bob /tdd ')
-  })
-
-  it('does not open mid-sentence after a mention — the reviewed regression', () => {
-    const h = mountHarness(ROSTER)
+    expect(h.api().open).toBe(false)
     type(h, '@Bob the log is in /tmp')
     expect(h.api().open).toBe(false)
   })

--- a/packages/web/src/components/console/useCommandAutocomplete.ts
+++ b/packages/web/src/components/console/useCommandAutocomplete.ts
@@ -1,0 +1,112 @@
+'use client'
+
+// Composer `/skill` picker. A sibling of useMentionAutocomplete rather than a mode of it: the two
+// share the caret anchoring and the key contract, but a mention resolves a RECIPIENT (and may join
+// the conversation, with a rollback) while a command resolves one agent's runtime capability. What
+// they must share is the textarea's onKeyDown — the caller offers this one first, and only one can
+// be open at a time because the trigger rules do not overlap.
+//
+// A pick writes ONLY the `/name ` token; the owner is addressed structurally via `onPicked` (the
+// caller merges it into the send's `mentions[]`). Inline `@Name` text would displace the command
+// from the leading position the daemon's translation matches on.
+
+import { useEffect, useMemo, useState, type KeyboardEvent, type RefObject } from 'react'
+import { commandQueryAt, tokenSpanEnd } from '@/lib/conversation-addressing'
+import { caretCoordinates } from '@/components/console/caret-coordinates'
+import { commandInsertion, matchCommands, type CommandCandidate } from '@/components/console/runtime-command-menu'
+import type { MentionCoords } from '@/components/console/useMentionAutocomplete'
+
+/** Mirrors CommandMenu's `max-h` — the worst-case height used to decide whether the list fits below. */
+export const COMMAND_MENU_MAX_HEIGHT = 280
+const MAX_MATCHES = 8
+
+export function useCommandAutocomplete(params: {
+  ref: RefObject<HTMLTextAreaElement | null>
+  value: string
+  setValue: (v: string) => void
+  candidates: readonly CommandCandidate[]
+  /** A pick names its owner — the caller validates the token still leads at send time and merges
+   *  the owner into `mentions[]`, narrowing the turn to the agent that can actually run it. */
+  onPicked?: (target: { agentId: string; agentName: string; name: string }) => void
+}) {
+  const { ref, value, setValue, candidates, onPicked } = params
+  const [anchor, setAnchor] = useState<{ start: number; query: string } | null>(null)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [coords, setCoords] = useState<MentionCoords | null>(null)
+
+  const matches = useMemo(
+    () => (anchor ? matchCommands(candidates, anchor.query, MAX_MATCHES) : []),
+    [anchor, candidates]
+  )
+  const open = matches.length > 0
+
+  /** Call from the textarea's onChange AND onSelect — see useMentionAutocomplete for why both. */
+  const sync = (nextValue: string, caret: number) => {
+    const next = commandQueryAt(nextValue, caret)
+    setAnchor(next)
+    setActiveIndex(0)
+    const el = ref.current
+    if (!next || !el) {
+      setCoords(null)
+      return
+    }
+    const c = caretCoordinates(el, next.start)
+    const belowY = el.getBoundingClientRect().top + c.top + c.height
+    const openUpward = window.innerHeight - belowY < COMMAND_MENU_MAX_HEIGHT + 8
+    setCoords({ ...c, elHeight: el.offsetHeight, elWidth: el.offsetWidth, openUpward })
+  }
+
+  const close = () => {
+    setAnchor(null)
+    setCoords(null)
+  }
+
+  // The draft can move without going through `sync` (a queued send clearing it, a session switch).
+  useEffect(() => {
+    if (anchor && value[anchor.start] !== '/') close()
+  }, [value, anchor])
+
+  const pick = (candidate: CommandCandidate) => {
+    if (!anchor) return
+    const el = ref.current
+    const next = commandInsertion({
+      text: value,
+      anchorStart: anchor.start,
+      spanEnd: tokenSpanEnd(value, anchor.start),
+      command: candidate
+    })
+    setValue(next.text)
+    close()
+    onPicked?.({ agentId: candidate.agentId, agentName: candidate.agentName, name: candidate.name })
+    requestAnimationFrame(() => {
+      el?.focus()
+      el?.setSelectionRange(next.caret, next.caret)
+    })
+  }
+
+  /** Call from onKeyDown BEFORE the mention picker's and before Enter-sends. */
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+    if (!open || event.nativeEvent.isComposing) return false
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const step = event.key === 'ArrowDown' ? 1 : -1
+      setActiveIndex((i) => (i + step + matches.length) % matches.length)
+      return true
+    }
+    if (event.key === 'Enter' || event.key === 'Tab') {
+      const candidate = matches[activeIndex]
+      if (!candidate) return false
+      event.preventDefault()
+      pick(candidate)
+      return true
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      close()
+      return true
+    }
+    return false
+  }
+
+  return { open, matches, activeIndex, setActiveIndex, coords, sync, handleKeyDown, pick, close }
+}

--- a/packages/web/src/components/console/useRuntimeCommands.ts
+++ b/packages/web/src/components/console/useRuntimeCommands.ts
@@ -1,0 +1,59 @@
+'use client'
+
+// The `/` picker's candidate pool: what every participant's runtime advertised it can be asked to
+// run. Fetched when the conversation opens rather than on the keystroke — each read is a CP → daemon
+// round trip, and a roster of five would otherwise fire five of them the moment `/` is pressed.
+
+import { useMemo } from 'react'
+import useSWR from 'swr'
+import { useOrgs } from '@/lib/org-context'
+import { consoleKeys } from '@/lib/swr-keys'
+import { fetchAgentRuntimeCommands } from '@/lib/api'
+import { offerableCommands, type CommandCandidate } from '@/components/console/runtime-command-menu'
+
+/** Why one participant contributes nothing, so the picker can say so instead of going blank. */
+export type RuntimeCommandsGap = 'unreported' | 'unavailable'
+
+export interface RosterCommands {
+  candidates: CommandCandidate[]
+  /** Participants that answered with nothing, and why. */
+  gaps: Array<{ agentId: string; agentName: string; reason: RuntimeCommandsGap }>
+  loading: boolean
+}
+
+export function useRuntimeCommands(
+  roster: ReadonlyArray<{ agentId: string; name: string }>,
+  enabled: boolean
+): RosterCommands {
+  const { activeOrg } = useOrgs()
+  // Sorted + joined so the key is stable across re-renders that reorder the roster.
+  const ids = useMemo(() => roster.map((p) => p.agentId).sort(), [roster])
+  const names = useMemo(() => new Map(roster.map((p) => [p.agentId, p.name])), [roster])
+  const key = enabled && ids.length > 0 ? consoleKeys.agentRuntimeCommands(activeOrg?.id, ids.join(',')) : null
+
+  // allSettled, not all: one offline daemon or one daemon too old to answer must not blank the whole
+  // menu — that participant becomes a gap and the rest still list.
+  const { data, isLoading } = useSWR(key, async () => {
+    const settled = await Promise.allSettled(ids.map((id) => fetchAgentRuntimeCommands(id)))
+    return ids.map((agentId, index) => ({ agentId, result: settled[index]! }))
+  })
+
+  return useMemo(() => {
+    const candidates: CommandCandidate[] = []
+    const gaps: RosterCommands['gaps'] = []
+    for (const row of data ?? []) {
+      const agentName = names.get(row.agentId) ?? ''
+      if (row.result.status === 'rejected') {
+        gaps.push({ agentId: row.agentId, agentName, reason: 'unavailable' })
+        continue
+      }
+      const value = row.result.value
+      if (!value.reported) {
+        gaps.push({ agentId: row.agentId, agentName, reason: 'unreported' })
+        continue
+      }
+      candidates.push(...offerableCommands({ agentId: row.agentId, agentName }, value.commands))
+    }
+    return { candidates, gaps, loading: isLoading }
+  }, [data, isLoading, names])
+}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -89,6 +89,10 @@ import { ContextWindowIndicator } from '@/components/console/ContextWindowIndica
 import { ComposerMenu } from '@/components/console/ComposerMenu'
 import { MentionMenu, type MentionOption } from '@/components/console/MentionMenu'
 import { useMentionAutocomplete } from '@/components/console/useMentionAutocomplete'
+import { CommandMenu } from '@/components/console/CommandMenu'
+import { useCommandAutocomplete } from '@/components/console/useCommandAutocomplete'
+import { useRuntimeCommands } from '@/components/console/useRuntimeCommands'
+import type { AgentIcon } from '@/lib/agent-icon'
 import {
   WORK_LANES,
   sessionTurnInFlight,
@@ -218,6 +222,9 @@ function useHeaderPopover() {
   return { open, setPresence, closeTap, toggleTap, reset }
 }
 
+/** Stable identity for a composer with no participants to ask — keeps useRuntimeCommands' memo still. */
+const EMPTY_ROSTER: ReadonlyArray<{ agentId: string; name: string }> = []
+
 // The composer's textarea, isolated so a keystroke re-renders ONLY this node:
 // the draft lives outside the playground context (usePgDraft subscription), and
 // SessionDetailView rebuilds the whole transcript on every render — routing
@@ -229,7 +236,9 @@ function ComposerTextarea({
   onImageFile,
   mentionCandidates,
   onPickMention,
-  onMentionJoiningChange
+  onMentionJoiningChange,
+  onCommandPick,
+  commands
 }: {
   sessionId: string
   placeholder: string
@@ -240,6 +249,14 @@ function ComposerTextarea({
   /** Mirrors `mention.joining` up to the parent so the (separately isolated)
    *  Send button can disable itself too — see the effect below. */
   onMentionJoiningChange: (joining: boolean) => void
+  /** A pick names its owner; the parent validates it at send time and merges it into mentions[]. */
+  onCommandPick?: (target: { agentId: string; name: string }) => void
+  /** The `/` picker's participants, absent when the conversation has no live runtime to ask. */
+  commands?: {
+    roster: ReadonlyArray<{ agentId: string; name: string }>
+    iconOf: (agentId: string) => { icon: AgentIcon | null | undefined; runtime: string } | undefined
+    multi: boolean
+  }
 }) {
   const draft = usePgDraft(sessionId)
   const { setPgInput } = usePlayground()
@@ -255,6 +272,20 @@ function ComposerTextarea({
     onPick: onPickMention
   })
   useEffect(() => onMentionJoiningChange(mention.joining), [mention.joining, onMentionJoiningChange])
+  // Fetched HERE rather than in the view body: the picker's pool must be read with a hook, and the
+  // view returns early above this point. The composer mounts with the conversation, so the read is
+  // still a mount-time prefetch rather than a keystroke-time one.
+  const runtimeCommands = useRuntimeCommands(commands?.roster ?? EMPTY_ROSTER, !!commands)
+  // `/skill` picker. Offered BEFORE the mention picker on every key, and their triggers cannot
+  // both be live (a command is the draft's leading token; a mention is not). The pick's owner
+  // travels structurally through onCommandPick — never as inline `@Name` text.
+  const command = useCommandAutocomplete({
+    ref: textareaRef,
+    value: draft,
+    setValue: (v) => setPgInput(sessionId, v),
+    candidates: runtimeCommands.candidates,
+    onPicked: onCommandPick
+  })
   return (
     <div className="relative">
       <textarea
@@ -264,13 +295,17 @@ function ComposerTextarea({
         value={draft}
         onChange={(e) => {
           setPgInput(sessionId, e.target.value)
-          mention.sync(e.target.value, e.target.selectionStart ?? e.target.value.length)
+          const caret = e.target.selectionStart ?? e.target.value.length
+          mention.sync(e.target.value, caret)
+          command.sync(e.target.value, caret)
         }}
         onSelect={(e) => {
           // Re-derives the anchor on every caret move, not just typing — see
           // the Home composer's identical handler for why.
           const el = e.currentTarget
-          mention.sync(el.value, el.selectionStart ?? el.value.length)
+          const caret = el.selectionStart ?? el.value.length
+          mention.sync(el.value, caret)
+          command.sync(el.value, caret)
         }}
         onPaste={(event) => {
           if (!onImageFile) return
@@ -280,6 +315,7 @@ function ComposerTextarea({
           onImageFile(image)
         }}
         onKeyDown={(e) => {
+          if (command.handleKeyDown(e)) return
           if (mention.handleKeyDown(e)) return
           // Enter sends — but NOT while an IME is composing (that Enter
           // just confirms the candidate), while a mention join is still in
@@ -297,6 +333,18 @@ function ComposerTextarea({
         onHover={mention.setActiveIndex}
         onPick={mention.pick}
       />
+      {commands && (
+        <CommandMenu
+          options={command.matches}
+          activeIndex={command.activeIndex}
+          coords={command.coords}
+          iconOf={commands.iconOf}
+          showOwner={commands.multi}
+          gaps={runtimeCommands.gaps}
+          onHover={command.setActiveIndex}
+          onPick={command.pick}
+        />
+      )}
     </div>
   )
 }
@@ -1620,6 +1668,8 @@ export default function SessionDetailView() {
   // join is still in flight, so the separately-isolated Send button can
   // disable itself for the same reason ComposerTextarea holds off Enter-send.
   const [mentionJoining, setMentionJoining] = useState(false)
+  // The last `/` pick, if any — consumed (and cleared) by the next send; see onPgSend.
+  const commandPickRef = useRef<{ agentId: string; name: string } | null>(null)
   const [runtimeSelections, setRuntimeSelections] = useState<
     Record<string, { model?: string; effort?: string; permissionPreset?: string; fast?: boolean }>
   >({})
@@ -2943,6 +2993,11 @@ export default function SessionDetailView() {
   const onPgSend = (text?: string): boolean => {
     if (imagePreparing || mentionJoining || (isContinuable && pgImage !== undefined)) return false
     setImageError(null)
+    // The `/` pick's owner. Validation happens in pgSend against the OUTGOING draft (this parent
+    // deliberately does not subscribe to it) — the pick narrows the turn only while its token
+    // still leads and the owner is still a participant.
+    const pick = commandPickRef.current
+    commandPickRef.current = null
     // A continuation socket mints through the session-target route (§6.5).
     if (isContinuable) markSessionTarget(session.id)
     // Pass the fetched roster: an adopted webchat session has no provider-side
@@ -2955,7 +3010,9 @@ export default function SessionDetailView() {
       session.agentId ?? '',
       text,
       isWebchat ? session.channelId : undefined,
-      isWebchat ? liveRoster : undefined
+      isWebchat ? liveRoster : undefined,
+      undefined,
+      pick ?? undefined
     )
     // Writing ends reading: someone who scrolled up through history and then
     // sends must not have their own message — or the reply to it — land
@@ -3031,6 +3088,18 @@ export default function SessionDetailView() {
           return a ? [{ id: a.id, name: p.name, icon: a.icon, runtime: a.runtime, inRoster: true }] : []
         })
       : []
+  // The `/` picker's participants. Every live participant contributes its OWN runtime's commands,
+  // so a name can legitimately appear twice; picking one addresses its agent (see commandInsertion).
+  const commandParticipants = isLive
+    ? {
+        roster: liveRoster.map((p) => ({ agentId: p.agentId, name: p.name })),
+        iconOf: (agentId: string) => {
+          const agent = agentById.get(agentId)
+          return agent ? { icon: agent.icon, runtime: agent.runtime } : undefined
+        },
+        multi: multiLive
+      }
+    : undefined
   // Returns the join's promise (not fire-and-forget): pgAddAgent awaits the
   // HTTP request before the roster reflects the new participant, and the
   // composer holds Enter-send off until it settles — sending against the OLD
@@ -4578,6 +4647,10 @@ export default function SessionDetailView() {
                           mentionCandidates={mentionCandidates}
                           onPickMention={onPickMention}
                           onMentionJoiningChange={setMentionJoining}
+                          onCommandPick={(target) => {
+                            commandPickRef.current = target
+                          }}
+                          commands={commandParticipants}
                         />
                         <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
                           {attachmentsEnabled && (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2471,6 +2471,34 @@ export async function fetchAgentLocalSkills(agentId: string): Promise<LocalSkill
   return apiGet<LocalSkillsDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/skills/local`)
 }
 
+// ── runtime slash commands ──────────────────────────────────────────────────
+// One command the agent's ACP runtime advertised it can be asked to run
+// (GET /agents/:id/commands) — skills, plugin skills and the harness's own
+// built-ins arrive in one list, so this is what the runtime actually exposes
+// rather than what a workspace scan finds.
+export interface RuntimeCommandDto {
+  name: string
+  description: string
+  /** Argument hint, or null when the command takes no argument. */
+  hint: string | null
+  /** Record-time skill classification (daemon-side, pre-truncation); absent on older daemons. */
+  skill?: boolean
+}
+
+// `reported:false` means no session has advertised a list yet, so an empty list
+// then means "unknown", not "no commands". Proxied live from the owning daemon;
+// 409 when the daemon predates this read, 503 when it is offline.
+export interface RuntimeCommandsDto {
+  reported: boolean
+  updatedAt?: string
+  sessionId?: string
+  commands: RuntimeCommandDto[]
+}
+
+export async function fetchAgentRuntimeCommands(agentId: string): Promise<RuntimeCommandsDto> {
+  return apiGet<RuntimeCommandsDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/commands`)
+}
+
 // One slice of a workspace file (GET /agents/:id/workspace/file), proxied live
 // from the owning daemon like the listing — file bytes never touch the CP store.
 // 503 when the daemon is offline / the agent is unplaced.

--- a/packages/web/src/lib/conversation-addressing.ts
+++ b/packages/web/src/lib/conversation-addressing.ts
@@ -118,9 +118,32 @@ export function mentionQueryAt(text: string, caret: number): { start: number; qu
  *  as stray text instead of being consumed by the inserted name.
  */
 export function mentionSpanEnd(text: string, start: number): number {
+  return tokenSpanEnd(text, start)
+}
+
+/** The run of non-space characters a trigger token occupies, from its sigil at `start`. Shared with
+ *  the `/` command picker, which replaces its whole token for the same reason. */
+export function tokenSpanEnd(text: string, start: number): number {
   let end = start + 1
   while (end < text.length && !/\s/.test(text[end]!)) end++
   return end
+}
+
+/** The `/command` being typed at `caret`, if any (composer command picker).
+ *
+ *  Unlike a mention, a command is the prompt's own leading token — ACP invokes one as the prompt
+ *  text `/name arg` — so only whitespace and @mentions may precede it. That also keeps the two
+ *  pickers from competing: `/` mid-sentence is ordinary text, as is a path or a URL. */
+export function commandQueryAt(text: string, caret: number): { start: number; query: string } | null {
+  const upto = text.slice(0, caret)
+  const at = upto.lastIndexOf('/')
+  if (at === -1) return null
+  const query = upto.slice(at + 1)
+  if (/\s/.test(query)) return null
+  // Strictly whitespace and COMPLETE @mention tokens before the `/` — `(?:@.*\s)?` also matched
+  // "@Bob the log is in /tmp" and opened the picker mid-sentence, turning Enter into an insert.
+  if (!/^\s*(?:@\S+\s+)*$/.test(upto.slice(0, at))) return null
+  return { start: at, query }
 }
 
 /** Where a `/sessions/:id` deep link goes when its session turns out to belong

--- a/packages/web/src/lib/conversation-addressing.ts
+++ b/packages/web/src/lib/conversation-addressing.ts
@@ -132,17 +132,18 @@ export function tokenSpanEnd(text: string, start: number): number {
 /** The `/command` being typed at `caret`, if any (composer command picker).
  *
  *  Unlike a mention, a command is the prompt's own leading token — ACP invokes one as the prompt
- *  text `/name arg` — so only whitespace and @mentions may precede it. That also keeps the two
- *  pickers from competing: `/` mid-sentence is ordinary text, as is a path or a URL. */
+ *  text `/name arg` — so ONLY whitespace may precede it, exactly matching the daemon's
+ *  translation gate (`matchSkillInvocation` trims and demands the prefix). A leading @mention
+ *  used to be tolerated here, but the daemon never translates that draft, so offering the picker
+ *  on it manufactured the very UI-says-yes/wire-says-no split this feature exists to close;
+ *  owner addressing is structural now, so the allowance had no remaining purpose. */
 export function commandQueryAt(text: string, caret: number): { start: number; query: string } | null {
   const upto = text.slice(0, caret)
   const at = upto.lastIndexOf('/')
   if (at === -1) return null
   const query = upto.slice(at + 1)
   if (/\s/.test(query)) return null
-  // Strictly whitespace and COMPLETE @mention tokens before the `/` — `(?:@.*\s)?` also matched
-  // "@Bob the log is in /tmp" and opened the picker mid-sentence, turning Enter into an insert.
-  if (!/^\s*(?:@\S+\s+)*$/.test(upto.slice(0, at))) return null
+  if (!/^\s*$/.test(upto.slice(0, at))) return null
   return { start: at, query }
 }
 

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -18,6 +18,8 @@ export const consoleKeys = {
   memberSets: (orgId: string | null | undefined) => consoleKey(orgId, 'member-sets'),
   agentLocalSkills: (orgId: string | null | undefined, agentId: string) =>
     consoleKey(orgId, 'agent-local-skills', agentId),
+  agentRuntimeCommands: (orgId: string | null | undefined, agentId: string) =>
+    consoleKey(orgId, 'agent-runtime-commands', agentId),
   managedSkills: (orgId: string | null | undefined, includeArchived: boolean) =>
     consoleKey(orgId, 'managed-skills', includeArchived ? 'include-archived' : 'active'),
   organizationEnvironment: (orgId: string | null | undefined) => consoleKey(orgId, 'organization-environment'),


### PR DESCRIPTION
**Stacked on #1322** (the daemon's skill-invocation translation) — the piece whose absence blocked the first cut of this PR. Retargets to `main` when it merges; staying **draft** until then.

## What

Typing `/` in a live conversation opens a picker over the **skills** every participant's runtime advertised, with a pane explaining what the highlighted one does. ACP makes `description` required; Zed's picker drops it and its users ask for it back ([#49085](https://github.com/zed-industries/zed/discussions/49085)).

Skills only, not every advertised command: a harness built-in like `/compact` cannot be dispatched through the translation seam, so offering it would put a dead entry in the menu. The daemon's record-time `skill` bit (#1322) gates both the menu and the translation — one truth for both ends. This also supersedes the old console-owned-name filter: `model`/`effort`/`permission` are built-ins, so the same gate removes them.

## What changed against the reviewed first cut

Every blocking and non-blocking finding from the previous review round:

- **Invocation is real now.** The daemon translates the leading `/name` into the probe-validated instruction (#1322), so the picker's insert actually dispatches on both claude and codex.
- **Owner addressing is structural.** A pick writes ONLY the advertised `/name ` token; the owner rides `mentions[]` (ComposerTextarea → `commandPickRef` → `pgSend` → `sendTurn`, queued sends included), honored only while the picked token still **leads** the outgoing draft and the owner is still a participant. Inline `@Name` text would displace the command from the position the daemon's gate matches on — the exact failure the review predicted.
- **The trigger regex is tight.** Only whitespace and complete mentions before the `/`; `@Bob the log is in /tmp` no longer opens the picker mid-sentence.
- **Gaps are rendered.** A participant that hasn't run yet ("skills appear after its first session") or whose daemon is unreachable is a labeled row; a menu of only gaps still opens instead of vanishing.
- **Mobile shows descriptions.** Each row carries its description inline where the desktop side pane doesn't render.
- **codex names work end to end**: `$code-review` matches a typed `/code`, displays verbatim, inserts verbatim, and the daemon resolves either form.

## Tests

`runtime-command-menu.test.ts` (15) and `useCommandAutocomplete.test.tsx` (10) — trigger rule, skills-only offering, bit-over-heuristic, `$` matching, structural pick contract, gaps rendering, the reviewed mid-sentence regression. Web suite 163 files / 1780 green, `next build` clean.

## Still not verified in a live browser

Same caveat as before, same reason (needs a live agent with an ACP session). The difference this round: the invocation path itself is probe-validated end-to-end at the daemon seam (#1322), so what remains unverified is layout at real widths, not behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
