### PR TITLE
fix(daemon): read Control-Plane frames tolerantly, so an added field cannot brick an older daemon

### DIFF
--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -29,6 +29,7 @@ degraded operation, and fleet control.
 - **Subprotocol:** `agentconnect.v1` (sent in `Sec-WebSocket-Protocol`). The CP echoes it on accept; mismatch → close `4400`.
 - **Encoding:** UTF-8 **JSON text frames**. One protocol envelope per WS frame. Binary frames are reserved (future MsgPack negotiation) and currently rejected with close `4415`.
 - **Validation:** every payload is a **zod**-discriminated union keyed on `type`. Unknown `type` from a peer → `error` reply with `code: "UNKNOWN_FRAME"` (not a connection close — forward-compat).
+- **Unknown KEYS are forward-compat too, and asymmetrically so.** The daemon reads this socket with the tolerant reader (`decodeCpEnvelope`, over `packages/protocol/src/tolerant.ts`): every object in a CP-authored payload strips a key it does not know instead of failing the frame. That is not a nicety — the CP upgrades first, so one added optional field inside a `.strict()` object nested anywhere in `register/ok` fails the handshake, identically, on every retry, until the daemon is upgraded too. The CP reads the daemon with the strict reader (`decodeEnvelope`), where refusing an unknown key is an input check on what a peer sends in. Field-level validation — types, required fields, refinements — is identical on both sides.
 - **Size:** soft cap **256 KiB** per frame. Anything larger (e.g. a big facts blob) must be chunked or moved off-band (attachment/object-store, see §3.2). Over cap → `error` `FRAME_TOO_LARGE`.
 - **Compression:** `permessage-deflate` enabled if both sides offer it; never assumed.
 

--- a/packages/cli/src/cp/auth-probe.ts
+++ b/packages/cli/src/cp/auth-probe.ts
@@ -5,7 +5,7 @@
  * a `4401` close, a correlated `error`, a dial failure, or a timeout. It always
  * closes the socket and never leaves a connection open.
  */
-import { buildEnvelope, CP_SUBPROTOCOL, CP_WS_PATH, decodeEnvelope, encode, isFrame } from '@agentconnect.md/protocol'
+import { buildEnvelope, CP_SUBPROTOCOL, CP_WS_PATH, decodeCpEnvelope, encode, isFrame } from '@agentconnect.md/protocol'
 import { ClientTransport, type Transport } from '@agentconnect.md/connection'
 
 export interface ProbeResult {
@@ -62,7 +62,7 @@ export async function probeAuth(opts: ProbeOpts): Promise<ProbeResult> {
     )
 
     transport.onMessage((text) => {
-      const decoded = decodeEnvelope(text)
+      const decoded = decodeCpEnvelope(text)
       if (!decoded.ok) return
       const f = decoded.frame
       if (f.corr !== frame.id) return

--- a/packages/daemon/src/bootstrap-upgrade.ts
+++ b/packages/daemon/src/bootstrap-upgrade.ts
@@ -5,7 +5,7 @@ import {
   CP_SUBPROTOCOL,
   CP_WS_PATH,
   DAEMON_BOOTSTRAP_PROTOCOL_VERSION,
-  decodeEnvelope,
+  decodeCpEnvelope,
   RESERVED_RESTART_CODE
 } from '@agentconnect.md/protocol'
 import { ClientTransport, ReqRep, systemClock, type Transport } from '@agentconnect.md/connection'
@@ -107,7 +107,7 @@ export async function runBootstrapUpgrade(
   try {
     transport = await deps.connect(cp.url)
     transport.onMessage((text) => {
-      const decoded = decodeEnvelope(text)
+      const decoded = decodeCpEnvelope(text)
       if (decoded.ok && decoded.frame.corr) correlator.settle(decoded.frame)
     })
     transport.onClose(() => correlator.rejectAll(new Error('bootstrap connection closed')))

--- a/packages/daemon/src/cli/reconcile.ts
+++ b/packages/daemon/src/cli/reconcile.ts
@@ -24,7 +24,7 @@ import {
   CP_SUBPROTOCOL,
   CP_URL_ENV,
   CP_WS_PATH,
-  decodeEnvelope
+  decodeCpEnvelope
 } from '@agentconnect.md/protocol'
 import { ClientTransport, ReqRep, systemClock, type Transport } from '@agentconnect.md/connection'
 import { K8sHttp, loadInClusterConfig } from '@agentconnect.md/k8s-client'
@@ -144,7 +144,7 @@ export async function connectObserver(url: string, seams: ObserverSeams = {}): P
     })
   try {
     transport.onMessage((text) => {
-      const decoded = decodeEnvelope(text)
+      const decoded = decodeCpEnvelope(text)
       if (decoded.ok && decoded.frame.corr) correlator.settle(decoded.frame)
     })
     transport.onClose(() => correlator.rejectAll(new Error('control-plane connection closed')))

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -55,7 +55,7 @@ import type {
 } from '@agentconnect.md/protocol'
 import {
   buildEnvelope,
-  decodeEnvelope,
+  decodeCpEnvelope,
   encode,
   MAX_FRAME_BYTES,
   SESSION_LIVE_TAIL_FEATURE,
@@ -1039,7 +1039,8 @@ export class CpClient {
     // A superseded socket must not settle the current connection's correlator or
     // enter its post-register FIFO.
     if (source !== this.transport) return
-    const decoded = decodeEnvelope(text)
+    // The CP authors every frame on this socket, so read it tolerantly: a field it added must strip, not fail.
+    const decoded = decodeCpEnvelope(text)
     if (!decoded.ok) {
       const code = this.decodeErrorCode(decoded.msg)
       this.sendError(decoded.id, code, decoded.msg, false)

--- a/packages/daemon/test/cp/client-handshake.test.ts
+++ b/packages/daemon/test/cp/client-handshake.test.ts
@@ -116,6 +116,75 @@ describe('CpClient handshake', () => {
     expect(applied).toHaveLength(1)
   })
 
+  it('registers against a register/ok carrying a field this build predates', async () => {
+    // One field added to a nested spec used to fail the whole snapshot, so the handshake retried the same failure forever.
+    const t = new FakeTransport()
+    const applied: any[] = []
+    const client = new CpClient(
+      makeDeps(t, {
+        configApply: {
+          applyConfigPush() {},
+          applyReconcileSnapshot: (s) => applied.push(s),
+          upsertCron() {},
+          removeCron() {},
+          applyRouteAssign() {},
+          applyRouteUpdate() {}
+        }
+      })
+    )
+    client.start()
+    await tick()
+    const auth = t.lastSent()
+    t.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'auth/ok',
+          { daemonId: DAEMON_ID, sessionEpoch: 7, heartbeatSec: 20, serverTime: '2026-06-26T00:00:00.000Z' },
+          { corr: auth.id }
+        )
+      )
+    )
+    await tick()
+    const reg = t.lastSent()
+    t.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'register/ok',
+          {
+            routingEpoch: 3,
+            assignments: [],
+            crons: [],
+            leases: [],
+            memoryConnections: [
+              {
+                connectionId: '44444444-4444-4444-8444-444444444444',
+                revision: 1,
+                config: {},
+                secretKeys: [],
+                pin: { pluginId: 'mem0', profileMajor: 1, secretHeaders: [] },
+                transport: 'streamable-http',
+                relayUrl: 'https://relay.example.test/mcp',
+                grantKey: 'grant-1',
+                addedByANewerControlPlane: 'org-1'
+              }
+            ],
+            drop: { assignments: [], crons: [] },
+            somethingNewer: true
+          },
+          { corr: reg.id }
+        )
+      )
+    )
+    await tick()
+
+    expect(client.state).toBe('READY')
+    expect(applied).toHaveLength(1)
+    // Read tolerantly, not blindly: the unread field is stripped before the snapshot is applied.
+    expect(applied[0].memoryConnections[0].connectionId).toBe('44444444-4444-4444-8444-444444444444')
+    expect(applied[0].memoryConnections[0]).not.toHaveProperty('addedByANewerControlPlane')
+    expect(applied[0]).not.toHaveProperty('somethingNewer')
+  })
+
   it('joins a blocked reconcile snapshot on stop and never transitions that connection to READY', async () => {
     const t = new FakeTransport()
     let releaseSnapshot!: () => void

--- a/packages/protocol/src/codec.ts
+++ b/packages/protocol/src/codec.ts
@@ -1,4 +1,5 @@
 import { FRAME_SCHEMAS, type AnyFrame, type FrameType } from './index.js'
+import { tolerantSchemas } from './tolerant.js'
 import {
   MAX_FRAME_BYTES,
   buildEnvelopeRaw,
@@ -12,6 +13,12 @@ import {
  * The daemon↔CP wire codec — the `FRAME_SCHEMAS` instantiation of the generic
  * envelope codec in `wire.ts`. The relay wires (`frames/relay-*.ts`) build their
  * own instantiations over their own schema maps; the unions never mix.
+ *
+ * Two readers, one union. The CP reads a daemon with `decodeEnvelope`, where a
+ * strict payload keeps its unknown-key check on what a peer sends in. The daemon
+ * reads the CP with `decodeCpEnvelope`, which strips unknown keys instead: the CP
+ * upgrades first, and a daemon that fails `register/ok` over a field it predates
+ * cannot finish a handshake until it is upgraded too (`tolerant.ts`).
  */
 
 export { MAX_FRAME_BYTES }
@@ -21,6 +28,15 @@ export type DecodeResult = DecodeResultOf<AnyFrame>
 
 export function decodeEnvelope(text: string): DecodeResult {
   return decodeEnvelopeWith<AnyFrame>(FRAME_SCHEMAS, text)
+}
+
+// Built on first use, not at import: only a daemon-side reader pays for the rebuild.
+let cpSchemas: typeof FRAME_SCHEMAS | undefined
+
+/** Decode a CP-authored frame. Same union as `decodeEnvelope`, read tolerantly. */
+export function decodeCpEnvelope(text: string): DecodeResult {
+  cpSchemas ??= tolerantSchemas(FRAME_SCHEMAS)
+  return decodeEnvelopeWith<AnyFrame>(cpSchemas, text)
 }
 
 export function buildEnvelope<T extends FrameType>(type: T, payload: unknown, opts: BuildOpts = {}): AnyFrame {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -104,8 +104,11 @@ export function isFrame<T extends FrameType>(type: T) {
 export { isFrameType as isKnownFrameType }
 
 // ── wire codec (shared by daemon + control-plane) ──
-export { decodeEnvelope, buildEnvelope, encode, MAX_FRAME_BYTES } from './codec.js'
+export { decodeEnvelope, decodeCpEnvelope, buildEnvelope, encode, MAX_FRAME_BYTES } from './codec.js'
 export type { DecodeResult, BuildOpts, InboundControlExt } from './codec.js'
+
+// ── tolerant reading of a peer-authored payload, for a wire that needs its own reader ──
+export { tolerantReader, tolerantSchemas } from './tolerant.js'
 
 // ── which frames carry an organization (k8s-daemon-pool.md M4) ──
 export {

--- a/packages/protocol/src/tolerant.test.ts
+++ b/packages/protocol/src/tolerant.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { FRAME_SCHEMAS, type FrameType } from './frame.js'
+import { decodeCpEnvelope, decodeEnvelope } from './codec.js'
+import { isStrictObject, reachableSchemas, tolerantReader } from './tolerant.js'
+
+/**
+ * Direction-asymmetric strictness (protocol §1).
+ *
+ * The live case this pins: a `.strict()` object nested in `register/ok` — the
+ * CP-authored reconcile baseline — turned one added optional field into a
+ * permanent handshake failure on every daemon older than the CP. The CP's own
+ * reader keeps refusing an unknown key on what a daemon sends it.
+ */
+
+const ID = '11111111-1111-4111-8111-111111111111'
+const CONNECTION_ID = '44444444-4444-4444-8444-444444444444'
+const TS = '2026-08-20T00:00:00.000Z'
+
+function envelope(type: FrameType, payload: unknown) {
+  return JSON.stringify({ v: 1, id: ID, ts: TS, type, payload })
+}
+
+/** Stands in for the next field a newer CP adds; `orgId` was the live one. */
+const ADDED_LATER = 'addedByANewerControlPlane'
+
+/** One `memoryConnections` entry, plus whatever a newer CP has started sending. */
+function memoryConnection(extra: Record<string, unknown> = {}) {
+  return {
+    connectionId: CONNECTION_ID,
+    revision: 1,
+    config: { endpoint: 'https://memory.example.test' },
+    secretKeys: [],
+    pin: { pluginId: 'mem0', profileMajor: 1, secretHeaders: [] },
+    transport: 'streamable-http',
+    relayUrl: 'https://relay.example.test/mcp',
+    grantKey: 'grant-1',
+    ...extra
+  }
+}
+
+function registerOk(extra: Record<string, unknown> = {}) {
+  return {
+    routingEpoch: 3,
+    assignments: [],
+    crons: [],
+    leases: [],
+    drop: { assignments: [], crons: [] },
+    ...extra
+  }
+}
+
+describe('CP-authored frames read tolerantly on the daemon', () => {
+  it('accepts a register/ok whose memoryConnections entry carries a field this build predates', () => {
+    const text = envelope(
+      'register/ok',
+      registerOk({ memoryConnections: [memoryConnection({ [ADDED_LATER]: 'org-1' })] })
+    )
+
+    // The strict reader is the whole incident: one unknown key fails the handshake, forever.
+    const strict = decodeEnvelope(text)
+    expect(strict.ok).toBe(false)
+    if (!strict.ok) expect(strict.msg).toContain('unrecognized_keys')
+
+    const tolerant = decodeCpEnvelope(text)
+    expect(tolerant.ok).toBe(true)
+    if (tolerant.ok && tolerant.frame.type === 'register/ok') {
+      const connection = tolerant.frame.payload.memoryConnections[0]
+      expect(connection?.connectionId).toBe(CONNECTION_ID)
+      // Stripped, not carried: an unread field must not leak into daemon state.
+      expect(connection && ADDED_LATER in connection).toBe(false)
+    }
+  })
+
+  it('tolerates an added field at the top of a snapshot and inside a nested spec alike', () => {
+    const text = envelope(
+      'register/ok',
+      registerOk({
+        somethingNewer: { nested: true },
+        memoryConnections: [memoryConnection({ pin: { pluginId: 'mem0', profileMajor: 1, tier: 'gold' } })]
+      })
+    )
+    const decoded = decodeCpEnvelope(text)
+    expect(decoded.ok).toBe(true)
+    if (decoded.ok && decoded.frame.type === 'register/ok') {
+      expect('somethingNewer' in decoded.frame.payload).toBe(false)
+      expect(decoded.frame.payload.memoryConnections[0]?.pin.pluginId).toBe('mem0')
+    }
+  })
+
+  it('keeps every check that is not about unknown keys', () => {
+    // Wrong type on a known field — the reason the payload schema exists at all.
+    expect(decodeCpEnvelope(envelope('register/ok', registerOk({ routingEpoch: 'not-a-number' }))).ok).toBe(false)
+    // Missing required field.
+    expect(decodeCpEnvelope(envelope('register/ok', { assignments: [], crons: [] })).ok).toBe(false)
+    // A refinement inside a discriminated-union member: the lease must match `secretKeys`.
+    const stdio = {
+      ...memoryConnection(),
+      transport: 'stdio',
+      relayUrl: undefined,
+      grantKey: undefined,
+      commandRef: 'mem0-local',
+      secretKeys: ['API_KEY'],
+      secretLease: { values: { OTHER_KEY: 'v' } }
+    }
+    expect(decodeCpEnvelope(envelope('memoryconnection/upsert', stdio)).ok).toBe(false)
+    const matched = { ...stdio, secretLease: { values: { API_KEY: 'v' } }, addedLater: true }
+    const ok = decodeCpEnvelope(envelope('memoryconnection/upsert', matched))
+    expect(ok.ok).toBe(true)
+    if (ok.ok && ok.frame.type === 'memoryconnection/upsert') {
+      expect('addedLater' in ok.frame.payload).toBe(false)
+      expect(ok.frame.payload.transport).toBe('stdio')
+    }
+  })
+
+  it('leaves the daemon→CP direction strict — the CP still refuses an unknown key it is sent', () => {
+    const fact = {
+      connectionId: CONNECTION_ID,
+      revision: 1,
+      pluginId: 'mem0',
+      status: 'ready',
+      unexpected: 'x'
+    }
+    const decoded = decodeEnvelope(envelope('facts/memory-connections', { connections: [fact] }))
+    expect(decoded.ok).toBe(false)
+    if (!decoded.ok) expect(decoded.msg).toContain('unrecognized_keys')
+  })
+})
+
+describe('the rebuild reaches every strict object, so the next added field is inert too', () => {
+  const strictReachable = (schema: z.ZodType) => [...reachableSchemas(schema)].filter(isStrictObject)
+
+  it('finds strict objects under the strict map (the guard is testing something)', () => {
+    const found = Object.values(FRAME_SCHEMAS).flatMap((schema) => strictReachable(schema))
+    expect(found.length).toBeGreaterThan(0)
+  })
+
+  it('leaves none under the tolerant one', () => {
+    const survivors = Object.entries(FRAME_SCHEMAS).filter(
+      ([, schema]) => strictReachable(tolerantReader(schema)).length > 0
+    )
+    expect(survivors.map(([type]) => type)).toEqual([])
+  })
+
+  it('relaxes a strict object behind any container the wire can nest it in', () => {
+    const strict = z.object({ a: z.string() }).strict()
+    const nested = z.object({
+      list: z.array(strict),
+      maybe: strict.optional(),
+      fallback: z.array(strict).default([]),
+      bag: z.record(z.string(), strict),
+      either: z.union([strict, z.string()]),
+      pair: z.tuple([strict]),
+      piped: strict.pipe(z.any()),
+      later: z.lazy(() => strict)
+    })
+    const value = { a: 'x', b: 'unknown' }
+    const parsed = tolerantReader(nested).parse({
+      list: [value],
+      maybe: value,
+      bag: { k: value },
+      either: value,
+      pair: [value],
+      piped: value,
+      later: value
+    })
+    expect(parsed).toEqual({
+      list: [{ a: 'x' }],
+      maybe: { a: 'x' },
+      fallback: [],
+      bag: { k: { a: 'x' } },
+      either: { a: 'x' },
+      pair: [{ a: 'x' }],
+      piped: { a: 'x' },
+      later: { a: 'x' }
+    })
+  })
+
+  it('keeps a declared catchall, which states a key policy rather than inheriting one', () => {
+    const open = z.object({ a: z.string() }).catchall(z.unknown())
+    expect(tolerantReader(open).parse({ a: 'x', b: 2 })).toEqual({ a: 'x', b: 2 })
+  })
+
+  it('returns one rebuilt instance per schema, so decoding does not rebuild per frame', () => {
+    expect(tolerantReader(FRAME_SCHEMAS['register/ok'])).toBe(tolerantReader(FRAME_SCHEMAS['register/ok']))
+  })
+})

--- a/packages/protocol/src/tolerant.ts
+++ b/packages/protocol/src/tolerant.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod'
+
+/**
+ * Tolerant readers — the reading end of a payload its peer AUTHORS (protocol §1).
+ *
+ * A `.strict()` payload object refuses an unknown key. That is the right check
+ * on the receiving end of a REQUEST, and a liability on the receiving end of a
+ * REPLY: the writer upgrades first, so one optional field added to a CP-authored
+ * payload makes every older reader reject the WHOLE frame — and for `register/ok`
+ * that is the handshake, failing identically on every retry. `tolerantReader`
+ * rebuilds a schema with every strict object relaxed to zod's default strip, so a
+ * field the reader predates is dropped instead of fatal. Nothing else moves: a
+ * wrong type, a missing required field, and every refinement still reject.
+ */
+
+/** Structural view of a zod `_zod.def` — the child slots this rebuild traverses. */
+type SchemaDef = { type: string } & Record<string, unknown>
+
+const memo = new WeakMap<z.ZodType, z.ZodType>()
+
+/** `schema` with every strict object relaxed to strip, memoized per schema instance. */
+export function tolerantReader<T extends z.ZodType>(schema: T): T {
+  const hit = memo.get(schema)
+  if (hit) return hit as T
+  const built = rebuild(schema)
+  memo.set(schema, built)
+  return built as T
+}
+
+/** One whole wire's `type` → payload map, read tolerantly. */
+export function tolerantSchemas<M extends Record<string, z.ZodType>>(schemas: M): M {
+  return Object.fromEntries(Object.entries(schemas).map(([type, schema]) => [type, tolerantReader(schema)])) as M
+}
+
+/** Is `value` a schema (any zod type carries `_zod`)? */
+function isSchema(value: unknown): value is z.ZodType {
+  return typeof value === 'object' && value !== null && '_zod' in value
+}
+
+function defOf(schema: z.ZodType): SchemaDef {
+  return schema._zod.def as SchemaDef
+}
+
+function child(value: unknown): z.ZodType {
+  return tolerantReader(value as z.ZodType)
+}
+
+/** Clone with a patched def; zod re-derives the parser from the constructor. */
+function withDef(schema: z.ZodType, def: SchemaDef): z.ZodType {
+  return z.clone(schema, def as never)
+}
+
+/** Rebuild one schema and everything reachable under it. Cycles need `lazy`, which defers. */
+function rebuild(schema: z.ZodType): z.ZodType {
+  const def = defOf(schema)
+  switch (def.type) {
+    case 'object': {
+      const shape = Object.fromEntries(
+        Object.entries(def.shape as Record<string, z.ZodType>).map(([key, value]) => [key, child(value)])
+      )
+      // `.strict()` is a `never` catchall; a declared `.catchall(...)` is a real key policy and stays.
+      const catchall = isNeverSchema(def.catchall) ? undefined : def.catchall ? child(def.catchall) : undefined
+      return withDef(schema, { ...def, shape, catchall })
+    }
+    case 'array':
+      return withDef(schema, { ...def, element: child(def.element) })
+    // Both plain and discriminated unions; the discriminator rides along in the spread def.
+    case 'union':
+      return withDef(schema, { ...def, options: (def.options as z.ZodType[]).map(child) })
+    case 'intersection':
+      return withDef(schema, { ...def, left: child(def.left), right: child(def.right) })
+    case 'tuple':
+      return withDef(schema, {
+        ...def,
+        items: (def.items as z.ZodType[]).map(child),
+        ...(isSchema(def.rest) ? { rest: child(def.rest) } : {})
+      })
+    case 'record':
+    case 'map':
+      return withDef(schema, { ...def, keyType: child(def.keyType), valueType: child(def.valueType) })
+    case 'set':
+      return withDef(schema, { ...def, valueType: child(def.valueType) })
+    case 'optional':
+    case 'nullable':
+    case 'nonoptional':
+    case 'default':
+    case 'prefault':
+    case 'catch':
+    case 'readonly':
+    case 'promise':
+      return withDef(schema, { ...def, innerType: child(def.innerType) })
+    case 'pipe':
+      return withDef(schema, { ...def, in: child(def.in), out: child(def.out) })
+    case 'lazy':
+      return z.lazy(() => child((def.getter as () => z.ZodType)()))
+    default:
+      // A leaf (string, number, literal, enum, custom, …) carries no object to relax.
+      return schema
+  }
+}
+
+/** The `never` catchall `.strict()` installs — the one thing this rebuild removes. */
+export function isStrictObject(schema: z.ZodType): boolean {
+  const def = defOf(schema)
+  return def.type === 'object' && isNeverSchema(def.catchall)
+}
+
+function isNeverSchema(value: unknown): boolean {
+  return isSchema(value) && defOf(value).type === 'never'
+}
+
+/** Every schema reachable from `schema`, found by scanning def slots rather than by type. */
+export function reachableSchemas(schema: z.ZodType, seen = new Set<z.ZodType>()): Set<z.ZodType> {
+  if (seen.has(schema)) return seen
+  seen.add(schema)
+  for (const value of Object.values(defOf(schema))) visit(value, seen)
+  return seen
+}
+
+function visit(value: unknown, seen: Set<z.ZodType>): void {
+  if (isSchema(value)) {
+    reachableSchemas(value, seen)
+    return
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) visit(item, seen)
+    return
+  }
+  if (typeof value === 'object' && value !== null) {
+    for (const item of Object.values(value)) visit(item, seen)
+  }
+}


### PR DESCRIPTION
## The failure

A Control Plane upgraded ahead of a self-hosted daemon started sending
`memoryConnections[].orgId` inside the `register/ok` reconcile baseline (the field
arrived in #930). `MemoryConnectionSpecBase` is a `.strict()` object, so the older
daemon refused the whole reply and killed its own handshake, forever:

```
cp: connect/handshake failed: invalid correlated reply: [
  { "code": "unrecognized_keys", "keys": ["orgId"],
    "path": ["memoryConnections", 0], "message": "Invalid input" } ]
```

Retry does not help — the CP re-sends the identical snapshot every 30s. Any daemon
older than the field whose agents reference a memory connection goes the same way;
a daemon with an empty `memoryConnections` never notices, which is what made this
look like one machine rather than a class of failure.

## The fix

Split the reader by direction rather than deleting the one field:

- `packages/protocol/src/tolerant.ts` — `tolerantReader(schema)` rebuilds a schema with
  every strict object relaxed to zod's default strip, recursing through the containers
  the wire nests them in (arrays, unions, optionals, defaults, records, tuples, pipes).
  A declared `.catchall(...)` is a real key policy and survives untouched.
- `decodeCpEnvelope(text)` — the same frame union as `decodeEnvelope`, read tolerantly,
  built once on first use. The daemon (and the CLI's auth probe) now read the socket with
  it, because the CP authors every frame on it.
- The CP keeps `decodeEnvelope`. Refusing an unknown key on what a peer *sends you* is an
  input check, not a compatibility rule, so the daemon→CP direction stays strict.
- Field-level validation is identical on both sides: wrong types, missing required fields,
  and every refinement still reject.

This is the shape #1251 used for the key-server responses — tolerant replies, strict
requests — applied to the frame union.

## Why structural rather than a one-off

Nothing here mentions `orgId`, or memory connections, or any particular field: the next
optional field added to any CP→daemon payload is inert on an older daemon by construction.
A guard test walks every frame's schema tree by scanning def slots (independently of the
rebuild's own type switch) and fails if a strict object survives, so a container kind the
rebuild cannot traverse surfaces as a red test rather than as the next handshake loop.

Daemons already released still need the upgrade to benefit — this closes the hole going
forward, it does not retro-fix a running old build.

## Tests

- `packages/protocol/src/tolerant.test.ts` — a `register/ok` carrying an unknown key inside
  `memoryConnections[0]` fails the strict reader and decodes (stripped) on the tolerant one;
  the daemon→CP direction still rejects an unknown key; refinements, required fields, and
  types still reject; the guard over every frame schema; container coverage; memoization.
- `packages/daemon/test/cp/client-handshake.test.ts` — the regression: a `register/ok` with a
  field this build predates now reaches `READY` with the unread key stripped from the applied
  snapshot. Reverting the one-line reader swap turns it back into `DEGRADED`, i.e. the incident.

```
pnpm --filter @agentconnect.md/protocol test   → 23 files, 409 tests passed
pnpm --filter @agentconnect.md/daemon test     → 4272 passed; the 15 failures are pre-existing
                                                  sandbox-exec / real-runtime-CLI cases that fail
                                                  identically on main in this environment
pnpm typecheck                                 → clean
pnpm lint                                      → clean
pnpm format:check                              → clean
```
