### PR TITLE
fix(daemon): ignore the command list a daemon-internal pass advertises

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -192,7 +192,12 @@ import {
   selectGithubReviewBatchLeader
 } from './github/queue-admission.js'
 import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from './runtimes/registry.js'
-import { isAvailableCommandsUpdate, RuntimeCommandsCache } from './runtimes/runtime-commands.js'
+import {
+  internalPassSlot,
+  InternalPassSessions,
+  isAvailableCommandsUpdate,
+  RuntimeCommandsCache
+} from './runtimes/runtime-commands.js'
 import { installedRuntimeCatalog, installedRuntimes, resolveCommandPath } from './runtimes/probe.js'
 import { startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.js'
 import { declaredRuntimeCatalog, loadK8sRuntimeTable, type K8sRuntimeAcpSnapshot } from './runtimes/k8s-runtimes.js'
@@ -1023,6 +1028,8 @@ export class Daemon {
   private readonly webchatMcpRevocations: WebchatMcpRevocations
   // What each agent's runtime last advertised it can be asked to run (ACP available_commands_update).
   private readonly runtimeCommands = new RuntimeCommandsCache()
+  // The ACP sessions this daemon opened for its own passes, whose advertisement describes a temp dir.
+  private readonly internalPassSessions = new InternalPassSessions()
   // In-conversation command execution (commands/handlers.ts), behind the delegates below.
   private readonly commands: CommandHandlers
   // §7.3 force-cancel backstops, keyed by (agentId, acpSessionId); cleared at turn end.
@@ -3764,8 +3771,13 @@ export class Daemon {
         sessionId = trusted
           ? await host.newSession(cwd, mcpServers, undefined, MEMORY_DISTILLATION_SYSTEM_PROMPT)
           : await host.newSession(cwd, mcpServers)
+        // Synchronous on purpose: the runtime advertises its commands on a timer right after this
+        // resolves, and a registration behind one more await loses that race (#1310 review).
+        const passKey = pendingTurnKey(agentId, sessionId)
+        this.internalPassSessions.add(internalPassSlot.distill(cacheKey), passKey)
         if (!(await host.setSessionPermissionMode(sessionId, readOnlyMode))) {
           host.discardSession(sessionId)
+          this.internalPassSessions.delete(passKey)
           this.memoryExtractionUnavailable.add(host)
           throw new Error('runtime lacks a verified read-only memory-extraction mode')
         }
@@ -3868,6 +3880,8 @@ export class Daemon {
         ? await host.newSession(cwd, [], undefined, systemPrompt)
         : await host.newSession(cwd, [])
       const key = pendingTurnKey(agentId, sessionId)
+      // Synchronous on purpose: see the distillation pass — the advertisement is already on a timer.
+      this.internalPassSessions.add(internalPassSlot.commit(agentId), key)
       try {
         if (!(await host.setSessionPermissionMode(sessionId, readOnlyMode))) {
           throw new Error('runtime rejected the read-only/plan mode')
@@ -3909,6 +3923,7 @@ export class Daemon {
         }
       } finally {
         host.discardSession(sessionId)
+        this.internalPassSessions.delete(key)
         if (modelSessionKey) {
           await this.modelSessions.release(modelSessionKey)
           this.memoryExtractionQuarantines.delete(key)
@@ -4171,6 +4186,9 @@ export class Daemon {
         ? await host.newSession(cwd, mcpServers, undefined, systemPrompt)
         : await host.newSession(cwd, mcpServers)
       ref.sessionId = sessionId
+      // Redundant while the dream owns a dedicated host the gate already excludes, but it keeps one
+      // rule: every session the daemon opens for itself is registered, synchronously, right here.
+      this.internalPassSessions.add(internalPassSlot.dream(agentId), pendingTurnKey(agentId, sessionId))
       const result = await this.runDreamExtractionSession(
         host,
         agent,
@@ -4400,6 +4418,7 @@ export class Daemon {
         ...(extractionMode ? { permissionMode: extractionMode } : {})
       })
       host.discardSession(sessionId)
+      this.internalPassSessions.delete(pendingTurnKey(agentId, sessionId))
     }
   }
 
@@ -11205,16 +11224,16 @@ export class Daemon {
       return
     }
     // Recorded before the pending-turn gate below, because an advertisement arrives outside a turn.
-    // A dream host is a separate AcpHost that never enters `hosts`, and it advertises right after
-    // ITS session/new — before the collector returns above exist — so identifying the agent's own
-    // host positively is what makes the exclusion ordering-proof. `isLoadingSession` covers the
-    // session/load window, where the session is this host's but `live` does not hold it yet.
-    // KNOWN GAP: distillation and the commit-message pass run on the agent's OWN host over a temp
-    // dir, so their advertisement is recorded and the list loses the agent's project skills until
-    // the next ordinary session/new replaces it (#1310 review, follow-up).
+    // It lands right after the session/new that caused it — before the collector returns above exist
+    // — so both guards are ordering-proof by construction rather than by arrival time. The host must
+    // own the session: a dream's dedicated AcpHost never enters `hosts`, and `isLoadingSession`
+    // covers the session/load window, where the session is this host's but `live` does not hold it
+    // yet. And the session must not be one this daemon opened for a pass of its OWN: those run on
+    // the agent's warm host over a temp dir, whose list is missing its project skills (#1310 review).
     if (isAvailableCommandsUpdate(update)) {
       const host = this.hosts.get(agentId)
-      if (host?.hasSession(sessionId) || host?.isLoadingSession(sessionId)) {
+      const owned = host?.hasSession(sessionId) || host?.isLoadingSession(sessionId)
+      if (owned && !this.internalPassSessions.has(extractionKey)) {
         this.runtimeCommands.record(agentId, sessionId, update, this.clock.now())
       }
       return

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3803,6 +3803,10 @@ export class Daemon {
         if (this.memoryExtractionSessions.get(cacheKey) === sessionId) {
           this.memoryExtractionSessions.delete(cacheKey)
           this.releaseMemoryExtractionToken(cacheKey)
+          // Uncached means abandoned: leaving it in `live` leaks an ACP session on the warm host,
+          // and its temp-dir list would be recorded the moment a later pass took this slot.
+          host.discardSession(sessionId)
+          this.internalPassSessions.delete(key)
         }
         throw err
       } finally {
@@ -3881,7 +3885,7 @@ export class Daemon {
         : await host.newSession(cwd, [])
       const key = pendingTurnKey(agentId, sessionId)
       // Synchronous on purpose: see the distillation pass — the advertisement is already on a timer.
-      this.internalPassSessions.add(internalPassSlot.commit(agentId), key)
+      this.internalPassSessions.add(internalPassSlot.commit(agentId, sessionId), key)
       try {
         if (!(await host.setSessionPermissionMode(sessionId, readOnlyMode))) {
           throw new Error('runtime rejected the read-only/plan mode')

--- a/packages/daemon/src/runtimes/runtime-commands.ts
+++ b/packages/daemon/src/runtimes/runtime-commands.ts
@@ -56,6 +56,47 @@ export function normalizeAvailableCommands(update: unknown): RuntimeCommand[] {
   return commands
 }
 
+/** The slot an internal pass parks its ACP session in. One live session per slot, so registering
+ *  the next one retires the slot's previous session and the registry cannot grow with uptime. */
+export const internalPassSlot = {
+  /** Keyed by the distillation cache key (agent + memory scope), whose session is cached and reused. */
+  distill: (cacheKey: string) => `distill:${cacheKey}`,
+  commit: (agentId: string) => `commit:${agentId}`,
+  dream: (agentId: string) => `dream:${agentId}`
+}
+
+/** The ACP sessions the daemon opens for its OWN passes — distillation, the commit-message wand, a
+ *  dream — over a throwaway temp dir. Their advertisement is missing the agent's project skills, and
+ *  the two that run on the agent's own warm host are indistinguishable there by session ownership.
+ *  Register SYNCHRONOUSLY in the continuation right after `newSession` resolves: the adapter
+ *  advertises on a timer, so a registration behind one more await loses the race (#1310 review). */
+export class InternalPassSessions {
+  private readonly bySlot = new Map<string, string>()
+  private readonly slotOf = new Map<string, string>()
+
+  add(slot: string, sessionKey: string): void {
+    const prior = this.bySlot.get(slot)
+    if (prior !== undefined && prior !== sessionKey) this.slotOf.delete(prior)
+    this.bySlot.set(slot, sessionKey)
+    this.slotOf.set(sessionKey, slot)
+  }
+
+  has(sessionKey: string): boolean {
+    return this.slotOf.has(sessionKey)
+  }
+
+  delete(sessionKey: string): void {
+    const slot = this.slotOf.get(sessionKey)
+    if (slot === undefined) return
+    this.slotOf.delete(sessionKey)
+    if (this.bySlot.get(slot) === sessionKey) this.bySlot.delete(slot)
+  }
+
+  get size(): number {
+    return this.slotOf.size
+  }
+}
+
 export class RuntimeCommandsCache {
   // Latest-wins per agent, not per session: a session-worktree list still beats none once it ends.
   private readonly byAgent = new Map<string, AdvertisedCommands>()

--- a/packages/daemon/src/runtimes/runtime-commands.ts
+++ b/packages/daemon/src/runtimes/runtime-commands.ts
@@ -57,11 +57,17 @@ export function normalizeAvailableCommands(update: unknown): RuntimeCommand[] {
 }
 
 /** The slot an internal pass parks its ACP session in. One live session per slot, so registering
- *  the next one retires the slot's previous session and the registry cannot grow with uptime. */
+ *  the next one retires the slot's previous session and the registry cannot grow with uptime.
+ *  A pass that DISCARDS its session takes a slot per session instead — it deletes its own entry, so
+ *  it needs no retirement, and retiring one press while a concurrent one is still live would re-open
+ *  the gap the registry exists to close. */
 export const internalPassSlot = {
-  /** Keyed by the distillation cache key (agent + memory scope), whose session is cached and reused. */
+  /** The distillation session is cached and reused per memory scope, and has no discard site. */
   distill: (cacheKey: string) => `distill:${cacheKey}`,
-  commit: (agentId: string) => `commit:${agentId}`,
+  /** Two presses on one agent can overlap — the console disables its own button, two tabs do not. */
+  commit: (agentId: string, sessionId: string) => `commit:${agentId}:${sessionId}`,
+  /** Per agent, not per dream: a dream can fail before the discard in its own finally, and its
+   *  dedicated host keeps it out of the gate whether or not this entry is current. */
   dream: (agentId: string) => `dream:${agentId}`
 }
 

--- a/packages/daemon/test/daemon-commit-message-pass.test.ts
+++ b/packages/daemon/test/daemon-commit-message-pass.test.ts
@@ -12,6 +12,13 @@ import { Daemon } from '../src/daemon.js'
 const AGENT = 'bot-a'
 const roots: string[] = []
 
+// What claude-agent-acp advertises for the pass's empty temp cwd: user and plugin skills survive a
+// cwd change, the agent's project skills do not.
+const ADVERTISEMENT = {
+  sessionUpdate: 'available_commands_update',
+  availableCommands: [{ name: 'superpowers:brainstorming', description: 'Explore intent (user)' }]
+}
+
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
@@ -66,6 +73,8 @@ function stubHost(
     stopReason?: string
     /** A runtime that answers only when it is canceled — i.e. one that honours `session/cancel`. */
     awaitCancel?: boolean
+    /** A runtime that advertises its slash commands the way a real adapter does — see below. */
+    advertise?: boolean
   } = {}
 ): { host: HostStub; factory: ReturnType<typeof vi.fn> } {
   let seq = 0
@@ -73,8 +82,27 @@ function stubHost(
   const host: HostStub = {
     usesMetaSystemPrompt: () => opts.trusted ?? false,
     permissionModeOptions: () => ({ modes: opts.modes ?? ['read-only'] }),
-    setSessionPermissionMode: vi.fn(async () => opts.modeAccepted ?? true),
-    newSession: vi.fn(async () => `sess-${++seq}`),
+    setSessionPermissionMode: vi.fn(async () => {
+      // A real `session/set_mode` is a round-trip, not a microtask. Deferring it by a macrotask is
+      // what lets the advertisement below overtake anything registered after this await.
+      if (opts.advertise) await new Promise((resolve) => setTimeout(resolve, 0))
+      return opts.modeAccepted ?? true
+    }),
+    newSession: vi.fn(async () => {
+      const id = `sess-${++seq}`
+      // claude-agent-acp advertises its commands on a timer right after the session/new response —
+      // outside any turn, and before the pass registers its collector.
+      if (opts.advertise) {
+        setTimeout(() => {
+          ;(daemon as never as { onAcpUpdate(a: string, s: string, u: unknown): void }).onAcpUpdate(
+            AGENT,
+            id,
+            ADVERTISEMENT
+          )
+        }, 0)
+      }
+      return id
+    }),
     prompt: vi.fn(async (sessionId: string) => {
       for (const text of opts.chunks ?? []) {
         // Exactly the path a real adapter takes, so the collector interception is what is under test.
@@ -173,6 +201,23 @@ describe('runCommitMessagePass — a fresh isolated session on the warm host', (
       // A second press replaces it rather than adding one, so presses cannot accumulate entries.
       await pass(daemon)
       expect([...inner.memoryExtractionQuarantines.keys()]).toEqual([JSON.stringify([AGENT, 'sess-2'])])
+    })
+  }, 20_000)
+
+  it('keeps its throwaway cwd out of the command list the console reports for the agent', async () => {
+    // The pass's session belongs to the agent's warm host, so host ownership alone would take this
+    // advertisement and truncate the agent's `/` picker to the skills a temp dir has (#1310 review).
+    await withDaemon({ advertise: true, chunks: ['fix: quiet'] }, async (daemon, host) => {
+      const inner = daemon as never as Record<string, any>
+      await pass(daemon)
+      expect(host.newSession).toHaveBeenCalledTimes(1)
+      expect(inner.runtimeCommands.get(AGENT)).toEqual({ reported: false, commands: [] })
+      // …and the pass leaves no entry behind, because the session it registered is discarded.
+      expect(inner.internalPassSessions.size).toBe(0)
+
+      // An ordinary chat session on that same host still reports.
+      await inner.onAcpUpdate(AGENT, 'chat-1', ADVERTISEMENT)
+      expect(inner.runtimeCommands.get(AGENT).sessionId).toBe('chat-1')
     })
   }, 20_000)
 

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -602,18 +602,20 @@ describe('Daemon evaluation surface', () => {
 
 describe('managed memory auto-distillation runtime support (#653)', () => {
   // A fake host whose distillation session emits the given JSON as its answer.
-  function distillHost(opts: { usesMetaSystemPrompt: boolean; modes?: string[] }) {
+  function distillHost(opts: { usesMetaSystemPrompt: boolean; modes?: string[]; promptFails?: boolean }) {
     let onUpdate!: (sessionId: string, update: unknown) => void
+    const discarded = new Set<string>()
     const host = {
       start: vi.fn(async () => {}),
       newSession: vi.fn(async () => 'distill-session-1'),
-      hasSession: vi.fn(() => true),
+      hasSession: vi.fn((id: string) => !discarded.has(id)),
       usesMetaSystemPrompt: vi.fn(() => opts.usesMetaSystemPrompt),
       modelOptions: vi.fn(() => ({ current: 'test-model', models: ['test-model'] })),
       permissionModeOptions: vi.fn(() => ({ modes: opts.modes ?? ['read-only'] })),
       setSessionPermissionMode: vi.fn(async () => true),
-      discardSession: vi.fn(),
+      discardSession: vi.fn((id: string) => void discarded.add(id)),
       prompt: vi.fn(async (sessionId: string) => {
+        if (opts.promptFails) throw new Error('runtime exploded')
         onUpdate(sessionId, {
           sessionUpdate: 'agent_message_chunk',
           content: { type: 'text', text: '{"memories":[]}' }
@@ -661,6 +663,19 @@ describe('managed memory auto-distillation runtime support (#653)', () => {
     )
     // Trusted: the prompt carries only the turn data, not the inline policy.
     expect(host.prompt.mock.calls[0][1][0].text).toBe('DISTILL THIS')
+    await daemon.stop()
+  }, 15_000)
+
+  it('abandons the session of a failed pass instead of leaving it live on the warm host', async () => {
+    const { host, daemon } = distillHost({ usesMetaSystemPrompt: false, promptFails: true })
+    await daemon.start()
+    await expect((daemon as any).runMemoryExtraction(AGENT_ID, 'DISTILL THIS')).rejects.toThrow('runtime exploded')
+    // Dropping the session from the cache is not enough: it stays in the host's `live` set, where it
+    // is an orphaned ACP session and — once a later pass takes its registry slot — a `hasSession`
+    // that would let its temp-dir command list be read as the agent's.
+    expect(host.discardSession).toHaveBeenCalledWith('distill-session-1')
+    expect(host.hasSession('distill-session-1')).toBe(false)
+    expect((daemon as any).internalPassSessions.size).toBe(0)
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -181,18 +181,17 @@ describe('the daemon records only its own host’s advertisement', () => {
 describe('the sessions the daemon opened for its own passes', () => {
   it('retires a slot’s previous session, so the registry cannot grow with uptime', () => {
     const sessions = new InternalPassSessions()
-    sessions.add(internalPassSlot.commit('a'), 'key-1')
+    // Distillation's session is cached per memory scope and has no discard site, so the next
+    // session for that scope is what retires it.
+    sessions.add(internalPassSlot.distill('a'), 'key-1')
     expect(sessions.has('key-1')).toBe(true)
-
-    // A commit-message session is created and discarded per press, so the next press's session
-    // replaces the one before it even if nothing deleted it.
-    sessions.add(internalPassSlot.commit('a'), 'key-2')
+    sessions.add(internalPassSlot.distill('a'), 'key-2')
     expect(sessions.has('key-1')).toBe(false)
     expect(sessions.has('key-2')).toBe(true)
 
-    // A distillation session is cached and reused, and lives in its own slot alongside.
-    sessions.add(internalPassSlot.distill('a'), 'key-3')
-    sessions.add(internalPassSlot.distill('a'), 'key-3')
+    // A dream keeps its own slot alongside, and re-adding a session is idempotent.
+    sessions.add(internalPassSlot.dream('a'), 'key-3')
+    sessions.add(internalPassSlot.dream('a'), 'key-3')
     expect(sessions.size).toBe(2)
 
     sessions.delete('key-2')
@@ -200,5 +199,21 @@ describe('the sessions the daemon opened for its own passes', () => {
     expect(sessions.has('key-2')).toBe(false)
     expect(sessions.has('key-3')).toBe(true)
     expect(sessions.size).toBe(1)
+  })
+
+  // Nothing serializes the wand daemon-side: the console disables its own button while a press is in
+  // flight, but two tabs or two repo panels on one agent do overlap. Retiring the first press while
+  // its session is still live would re-open the gap for exactly that press's advertisement.
+  it('keeps both of two overlapping commit presses excluded', () => {
+    const sessions = new InternalPassSessions()
+    sessions.add(internalPassSlot.commit('a', 'sess-1'), 'key-1')
+    sessions.add(internalPassSlot.commit('a', 'sess-2'), 'key-2')
+    expect(sessions.has('key-1')).toBe(true)
+    expect(sessions.has('key-2')).toBe(true)
+
+    // Each press deletes its own entry when it discards its session, so nothing accumulates.
+    sessions.delete('key-1')
+    sessions.delete('key-2')
+    expect(sessions.size).toBe(0)
   })
 })

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -167,7 +167,8 @@ describe('the daemon records only its own host’s advertisement', () => {
       runtimeCommands: RuntimeCommandsCache
     }
     inner.hosts.set('agent-1', { hasSession: () => true, isLoadingSession: () => false })
-    inner.internalPassSessions.add(internalPassSlot.commit('agent-1'), pendingTurnKey('agent-1', 'commit-session'))
+    const passKey = pendingTurnKey('agent-1', 'commit-session')
+    inner.internalPassSessions.add(internalPassSlot.commit('agent-1', 'commit-session'), passKey)
 
     await inner.onAcpUpdate('agent-1', 'commit-session', advertisement)
     expect(inner.runtimeCommands.get('agent-1')).toEqual({ reported: false, commands: [] })

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 import { Daemon } from '../src/daemon.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import { createRuntimeCommandsReader } from '../src/cp/runtime-commands-reader.js'
+import { pendingTurnKey } from '../src/daemon/turn-types.js'
 import {
+  internalPassSlot,
+  InternalPassSessions,
   isAvailableCommandsUpdate,
   normalizeAvailableCommands,
   RuntimeCommandsCache
@@ -150,5 +153,52 @@ describe('the daemon records only its own host’s advertisement', () => {
 
     await host.onAcpUpdate('agent-1', 'resuming', advertisement)
     expect(host.runtimeCommands.get('agent-1').sessionId).toBe('resuming')
+  })
+
+  // Distillation and the commit-message wand open their session on the agent's OWN host over a
+  // throwaway temp dir, so ownership says yes and only the daemon's own registry can tell that list
+  // (user + plugin skills, no project skills) from a real one.
+  it('ignores the temp-dir advertisement from a session it opened for a pass of its own', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const inner = daemon as unknown as {
+      hosts: Map<string, { hasSession(id: string): boolean; isLoadingSession(id: string): boolean }>
+      internalPassSessions: InternalPassSessions
+      onAcpUpdate(agentId: string, sessionId: string, update: unknown): Promise<void>
+      runtimeCommands: RuntimeCommandsCache
+    }
+    inner.hosts.set('agent-1', { hasSession: () => true, isLoadingSession: () => false })
+    inner.internalPassSessions.add(internalPassSlot.commit('agent-1'), pendingTurnKey('agent-1', 'commit-session'))
+
+    await inner.onAcpUpdate('agent-1', 'commit-session', advertisement)
+    expect(inner.runtimeCommands.get('agent-1')).toEqual({ reported: false, commands: [] })
+
+    // Per session, not per host: the agent's ordinary chat session on that same host still reports.
+    await inner.onAcpUpdate('agent-1', 'chat-session', advertisement)
+    expect(inner.runtimeCommands.get('agent-1').sessionId).toBe('chat-session')
+  })
+})
+
+describe('the sessions the daemon opened for its own passes', () => {
+  it('retires a slot’s previous session, so the registry cannot grow with uptime', () => {
+    const sessions = new InternalPassSessions()
+    sessions.add(internalPassSlot.commit('a'), 'key-1')
+    expect(sessions.has('key-1')).toBe(true)
+
+    // A commit-message session is created and discarded per press, so the next press's session
+    // replaces the one before it even if nothing deleted it.
+    sessions.add(internalPassSlot.commit('a'), 'key-2')
+    expect(sessions.has('key-1')).toBe(false)
+    expect(sessions.has('key-2')).toBe(true)
+
+    // A distillation session is cached and reused, and lives in its own slot alongside.
+    sessions.add(internalPassSlot.distill('a'), 'key-3')
+    sessions.add(internalPassSlot.distill('a'), 'key-3')
+    expect(sessions.size).toBe(2)
+
+    sessions.delete('key-2')
+    sessions.delete('key-2')
+    expect(sessions.has('key-2')).toBe(false)
+    expect(sessions.has('key-3')).toBe(true)
+    expect(sessions.size).toBe(1)
   })
 })


### PR DESCRIPTION
## The gap

The `available_commands_update` gate identifies the agent's own host positively, which excludes a dream's dedicated `AcpHost` — but not the two passes that run on the agent's **own** host:

- **distillation** (`runMemoryExtraction`) falls back to `ensureHostAsync(agentId)` wherever `modelSessions.enabled` is false — everywhere except a cloud daemon with a key server — and opens its session with `cwd = mkdtemp(.../agentconnect-memory-distill-*)`;
- **the commit-message wand** does the same with `.../agentconnect-commit-message-*`.

Both sessions land in the host's `live` set, so `hasSession` is true and the runtime's advertisement for a directory with no project in it is recorded as the agent's list with `reported: true`. User-level and plugin skills survive (they are not cwd-dependent); the agent's **project** skills disappear until an ordinary `session/new` happens to replace them. The consumer is the webchat `/` picker (`useRuntimeCommands.ts` + `CommandMenu.tsx`), where a truncated list reads as authoritative rather than as stale. The gate carried a `KNOWN GAP` comment marking this; that comment is now retired by code.

## The fix

The daemon tracks the sessions it opens for its own passes and excludes them at the gate.

**Registration is synchronous** — the statement immediately after each `await host.newSession(...)` resolves, with no await in between. The adapter emits the advertisement on a `setTimeout(0)` after the session/new response and `ndJsonStream` dispatches one message per microtask, so a registration placed behind one more await loses the race. That is exactly how the earlier collector-based exclusion failed (#1310 review).

**The key is the slot that owns the session**, and which slot depends on the pass's lifetime:

- **distillation** is keyed per memory scope (its cache key). Its session is cached and reused across passes and has no discard site, so the next session for that scope is what retires it — that is what keeps the registry from growing with uptime.
- **a commit press** is keyed per session. It discards its session and deletes its own entry, so it needs no retirement — and retiring one press while a concurrent press is still live would re-open the gap, since a press's advertisement arrives before any collector or quarantine tombstone exists for it. The console disables its own wand button while a press is in flight; two tabs or two repo panels on one agent do not.
- **a dream** is keyed per agent. It can fail before the discard in its own `finally`, so a per-session key would leak an entry per failed dream — and its dedicated host keeps it out of the gate whether or not the entry is current. It is registered at all only so the rule is one rule; the comment says it is redundant so nobody reads it as load-bearing.

Two smaller things fall out of the same review: a distillation pass whose prompt throws now **discards** its session where it drops it from the cache, instead of leaving an orphaned ACP session in the host's `live` set for the rest of that host's life; and the `distillHost` test double's `hasSession` now honours `discardSession`.

## Tests

Every new test is red before its fix, verified by reverting.

- `runtime-commands.test.ts` — the gate ignores a registered session on a host that owns it, while an ordinary session on that same host still reports (per session, not per host). Two registry tests pin the slot semantics: distillation's session is retired by the next one, and two overlapping presses each keep their exclusion.
- `daemon-commit-message-pass.test.ts` — runs the **real** `runCommitMessagePass` against the stub host, which advertises on a timer after session/new and answers `session/set_mode` on a macrotask (a real set_mode is a round-trip, not a microtask). That makes it a genuine ordering test: moving the registration one await later turns it red again.
- `daemon-evaluation.test.ts` — a distillation pass whose prompt throws discards its session and leaves no registry entry.

Full daemon suite: 275 files pass. The 5 failing files (`shim-*`, `workspace-git-runner-seam`, `acp-matrix`) fail identically on a clean tree — sandbox/shim environment and real-model access, unrelated to this change; CI's Sandbox (Linux) job covers the shim suites and is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)