### PR TITLE
feat(control-plane): per-org daemon, agent, and session gauges

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -161,6 +161,7 @@ import { relayHttpOrigin } from './orchestrator/mcpProvider.js'
 import { CollabRoutesService } from './orchestrator/collabRoutes.service.js'
 import { DutyLeaseService, DUTY_LEASE_DEFAULTS } from './orchestrator/dutyLease.js'
 import { registerPoolMetrics } from './observability/pool-metrics.js'
+import { registerOrgMetrics } from './observability/org-metrics.js'
 import { AgentDelivery } from './orchestrator/agentDelivery.js'
 import { AgentRoutingConverger } from './orchestrator/agentRouting.js'
 import { PlacementResolver, type ResolvableAgent } from './orchestrator/placementResolver.js'
@@ -742,6 +743,9 @@ export function buildContainer(
     maxMembers: DUTY_GRANT_MEMBERS_MAX,
     log: { warn: (o, m) => http.log.warn(o, m) }
   })
+  // Per-org footprint gauges (observability/org-metrics.ts) — daemons/agents/sessions per org, the
+  // "who is using this install, and how much" read the pool gauges deliberately do not answer.
+  const orgMetrics = registerOrgMetrics({ repo: repos.org, clock, log: { warn: (o, m) => http.log.warn(o, m) } })
   const agentMutations = new AgentMutationGate()
 
   // Relay roster (shared-bot-relay.md §5): computed from the durable `relay` table
@@ -1818,6 +1822,7 @@ export function buildContainer(
       relaySweeper.stop()
       dutyRecompute.stop()
       poolMetrics.stop()
+      orgMetrics.stop()
       sessionAccessWarmer.stop()
       for (const loop of backgroundLoops) loop.stop()
       visibilityPush.stop()

--- a/packages/control-plane/src/observability/org-metrics.test.ts
+++ b/packages/control-plane/src/observability/org-metrics.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { orgObservations, readOrgObservations, type OrgMetricsDeps } from './org-metrics.js'
+import type { OrgTelemetryRow } from '../persistence/ports.js'
+
+const NOW = new Date('2026-01-01T00:00:00Z')
+
+const row = (over: Partial<OrgTelemetryRow> = {}): OrgTelemetryRow => ({
+  orgId: 'org_acme',
+  orgSlug: 'acme',
+  daemons: 2,
+  agents: 7,
+  sessionsTotal: 900,
+  sessions30d: 120,
+  sessions24h: 5,
+  ...over
+})
+
+const deps = (over: Partial<OrgMetricsDeps> = {}): OrgMetricsDeps => ({
+  repo: { orgTelemetry: async () => [row()] },
+  clock: { now: () => NOW.getTime() } as OrgMetricsDeps['clock'],
+  ...over
+})
+
+const valueOf = (obs: ReturnType<typeof orgObservations>, metric: string, window?: string) =>
+  obs.find((o) => o.metric === metric && o.attrs.window === window)?.value
+
+describe('orgObservations', () => {
+  it('labels every series with the org slug and splits sessions by window', () => {
+    const obs = orgObservations([row()])
+    expect(valueOf(obs, 'daemons')).toBe(2)
+    expect(valueOf(obs, 'agents')).toBe(7)
+    expect(valueOf(obs, 'sessions', 'total')).toBe(900)
+    expect(valueOf(obs, 'sessions', '30d')).toBe(120)
+    expect(valueOf(obs, 'sessions', '24h')).toBe(5)
+    expect(obs.every((o) => o.attrs.org === 'acme')).toBe(true)
+  })
+
+  // The counts are not a hierarchy: only `total` is cumulative, so an org that has stopped using
+  // the product keeps a large total beside zero windows and must still report all three.
+  it('reports an idle org’s zero windows rather than dropping them', () => {
+    const obs = orgObservations([row({ sessions30d: 0, sessions24h: 0 })])
+    expect(valueOf(obs, 'sessions', 'total')).toBe(900)
+    expect(valueOf(obs, 'sessions', '30d')).toBe(0)
+    expect(valueOf(obs, 'sessions', '24h')).toBe(0)
+  })
+
+  // A series that vanishes on the way to zero is invisible on a dashboard — an org that removed
+  // its last daemon would look like an org that was never there.
+  it('reports an org holding nothing, as zeros', () => {
+    const obs = orgObservations([row({ orgSlug: 'empty', daemons: 0, agents: 0, sessionsTotal: 0 })])
+    expect(obs).toHaveLength(5)
+    expect(obs.map((o) => o.value)).toEqual([0, 0, 0, 120, 5])
+  })
+
+  it('reports every org, so a busy one cannot be averaged away by an idle one', () => {
+    const obs = orgObservations([row(), row({ orgSlug: 'other', agents: 1 })])
+    expect(obs.filter((o) => o.metric === 'agents').map((o) => [o.attrs.org, o.value])).toEqual([
+      ['acme', 7],
+      ['other', 1]
+    ])
+  })
+})
+
+describe('readOrgObservations', () => {
+  it('reads at the clock it was given, so the windows are the caller’s notion of now', async () => {
+    const seen: unknown[] = []
+    const obs = await readOrgObservations(
+      deps({
+        repo: {
+          orgTelemetry: async (now) => {
+            seen.push(now)
+            return [row()]
+          }
+        }
+      })
+    )
+    expect(seen).toEqual([NOW])
+    expect(valueOf(obs!, 'daemons')).toBe(2)
+  })
+
+  // The defect this exists to prevent: observing zeros on a database blip is indistinguishable
+  // from every org losing its daemons at once, which reads as a fleet-wide outage.
+  it('skips the collection entirely when the read fails', async () => {
+    const warned: unknown[] = []
+    const result = await readOrgObservations(
+      deps({
+        repo: {
+          orgTelemetry: async () => {
+            throw new Error('connection terminated')
+          }
+        },
+        log: { warn: (o) => warned.push(o) }
+      })
+    )
+    expect(result).toBeNull()
+    expect(warned).toHaveLength(1)
+  })
+})

--- a/packages/control-plane/src/observability/org-metrics.ts
+++ b/packages/control-plane/src/observability/org-metrics.ts
@@ -1,0 +1,137 @@
+/**
+ * Per-org footprint gauges — "how much of this install is each organization actually using".
+ *
+ * The CP's Postgres is the only place that can answer it: daemons, agents and sessions each carry
+ * `orgId` (session_meta's is denormalized at ingest), so one pass over three tables states the
+ * whole install. Sibling of `pool-metrics.ts` in shape and in discipline — one read per collection
+ * feeding every gauge, and a failed read reports NOTHING rather than zeros.
+ *
+ * Two things to know before reading a dashboard built on these:
+ *
+ *  - `org.daemons` counts daemons the org OWNS. A pool member belongs to no org, so an org running
+ *    entirely on the install-wide pool reads zero here no matter how much of it it occupies — its
+ *    demand is in the `agentconnect.pool.*` / `agentconnect.duty.*` series instead.
+ *  - `org.sessions{window="total"}` is a lifetime count over an unpruned table, so it only ever
+ *    climbs. The `30d`/`24h` windows are the ones that show whether an org is still active.
+ *
+ * Every CP replica observes the same install-wide numbers, so these are fleet totals repeated per
+ * pod, not per-pod shards: aggregate them with `max by (...)`, never `sum`. Series count is
+ * (orgs × 5) per replica — cheap at this scale, and the thing to watch if org count ever explodes.
+ */
+import { metrics, type BatchObservableResult, type ObservableGauge } from '@opentelemetry/api'
+import type { OrgTelemetryRow } from '../persistence/ports.js'
+import type { Clock } from '../domain/clock.js'
+
+/** The read these gauges project. */
+export interface OrgTelemetrySource {
+  orgTelemetry(now: Date): Promise<OrgTelemetryRow[]>
+}
+
+export interface OrgMetricsLog {
+  warn(obj: unknown, msg?: string): void
+}
+
+export interface OrgMetricsDeps {
+  repo: OrgTelemetrySource
+  clock: Clock
+  log?: OrgMetricsLog
+}
+
+export type OrgMetricName = 'daemons' | 'agents' | 'sessions'
+
+/** `total` is the lifetime count; the others are how many sessions STARTED in that window. */
+export type SessionWindow = 'total' | '30d' | '24h'
+
+export interface OrgObservation {
+  metric: OrgMetricName
+  value: number
+  attrs: { org: string; window?: SessionWindow }
+}
+
+/** Rows → the series each gauge reports. Pure, so a dashboard's input is testable on its own. */
+export function orgObservations(rows: readonly OrgTelemetryRow[]): OrgObservation[] {
+  return rows.flatMap((row): OrgObservation[] => {
+    const org = row.orgSlug
+    const sessions = (window: SessionWindow, value: number): OrgObservation => ({
+      metric: 'sessions',
+      value,
+      attrs: { org, window }
+    })
+    return [
+      { metric: 'daemons', value: row.daemons, attrs: { org } },
+      { metric: 'agents', value: row.agents, attrs: { org } },
+      sessions('total', row.sessionsTotal),
+      sessions('30d', row.sessions30d),
+      sessions('24h', row.sessions24h)
+    ]
+  })
+}
+
+/**
+ * One collection's worth of observations, or `null` to report nothing at all.
+ *
+ * A collection that cannot read the database must skip rather than observe zeros: a zeroed org
+ * is indistinguishable from one that just lost every daemon it had, so a database blip would
+ * read as a fleet-wide outage on the dashboard.
+ */
+export async function readOrgObservations(deps: OrgMetricsDeps): Promise<OrgObservation[] | null> {
+  try {
+    return orgObservations(await deps.repo.orgTelemetry(new Date(deps.clock.now())))
+  } catch (err) {
+    deps.log?.warn({ err }, 'org-metrics: org read failed, skipping this collection')
+    return null
+  }
+}
+
+export interface OrgMetricsHandle {
+  /** Unregister the callback. MUST run before Prisma disconnects, or a collection races shutdown. */
+  stop(): void
+}
+
+const meter = metrics.getMeter('@agentconnect.md/control-plane-org', '1.0.0')
+
+function createGauges(): Record<OrgMetricName, ObservableGauge> {
+  return {
+    daemons: meter.createObservableGauge('agentconnect.org.daemons', {
+      unit: '{daemon}',
+      description:
+        'Daemons registered to the org, any status. Install-wide pool members belong to no org and are counted for none — see agentconnect.pool.* for those'
+    }),
+    agents: meter.createObservableGauge('agentconnect.org.agents', {
+      unit: '{agent}',
+      description: 'Agents defined in the org, including inactive and unplaced ones'
+    }),
+    sessions: meter.createObservableGauge('agentconnect.org.sessions', {
+      unit: '{session}',
+      description:
+        'Sessions the org started: window="total" is the lifetime count over an unpruned table (monotonic), window="30d"/"24h" are how many began in that window'
+    })
+  }
+}
+
+/**
+ * Register the batch callback. One database read per collection interval feeds every gauge, so an
+ * org's series are one consistent snapshot rather than three independently-timed reads.
+ */
+export function registerOrgMetrics(deps: OrgMetricsDeps): OrgMetricsHandle {
+  const gauges = createGauges()
+  const observed = Object.values(gauges)
+  let stopped = false
+
+  const callback = async (result: BatchObservableResult): Promise<void> => {
+    if (stopped) return
+    const observations = await readOrgObservations(deps)
+    // Re-checked after the await: a shutdown that began mid-read must not observe against a
+    // provider that is going away, nor keep the read alive past Prisma's disconnect.
+    if (stopped || !observations) return
+    for (const o of observations) result.observe(gauges[o.metric], o.value, o.attrs)
+  }
+
+  meter.addBatchObservableCallback(callback, observed)
+  return {
+    stop() {
+      stopped = true
+      meter.removeBatchObservableCallback(callback, observed)
+    }
+  }
+}

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3911,6 +3911,26 @@ export interface OrgRecord {
   updatedAt: Date
 }
 
+/** One org's footprint, for the per-org gauges (observability/org-metrics.ts). */
+export interface OrgTelemetryRow {
+  orgId: string
+  /** The org's console URL segment — what the gauge labels the series with. */
+  orgSlug: string
+  /** Daemons registered to the org, any status. An install-wide pool member belongs to NO org
+   *  (`daemon.orgId IS NULL`) and is counted for none of them — a pool-backed org reads zero here
+   *  however much of the pool it occupies, which `duty_group` is the ledger for. */
+  daemons: number
+  /** Agents defined in the org, any status — including inactive and unplaced ones. */
+  agents: number
+  /** Sessions the org has ever started. `session_meta` has no retention sweep, so this is a
+   *  lifetime total that only grows; the windows below are what carry a trend. */
+  sessionsTotal: number
+  /** Sessions STARTED in the last 30 days / 24 hours — a rate, not an occupancy: a long-running
+   *  session is counted once, in the window it began. */
+  sessions30d: number
+  sessions24h: number
+}
+
 export interface OrgDeleteResult {
   status: 'deleted' | 'review_cleanup_pending' | 'daemons_present'
   /** Hook rules made inert by the same transaction; callers remove them from
@@ -4063,6 +4083,12 @@ export interface OrgRepo {
   /** The org's slug (its URL segment in the console), or null when the org is absent.
    *  Used to build org-scoped session deep links (`<webAppUrl>/<slug>/sessions/<id>`). */
   slugById(orgId: string): Promise<string | null>
+
+  /** Per-org daemon/agent/session counts, for the org gauges (observability/org-metrics.ts).
+   *  EVERY org is returned, including one holding nothing: a series that vanishes on the way to
+   *  zero is invisible on a dashboard, so the zeros have to be stated. `now` fixes the window
+   *  boundaries at the caller's clock rather than the database's. */
+  orgTelemetry(now: Date): Promise<OrgTelemetryRow[]>
 
   /**
    * Hard-delete an org. Cascades memberships, agents, crons, integrations,

--- a/packages/control-plane/src/persistence/repositories/org.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org.repo.ts
@@ -6,13 +6,17 @@
  */
 import type { PrismaLike } from '../prisma.js'
 import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
-import type { AgentCallPolicy, OrgRepo, OrgRecord, OrgMemberRole } from '../ports.js'
+import type { AgentCallPolicy, OrgRepo, OrgRecord, OrgMemberRole, OrgTelemetryRow } from '../ports.js'
 import type { AgentIcon } from '@agentconnect.md/protocol'
 import { OrgId } from '../../domain/ids.js'
 import { PgHookRepo } from './hook.repo.js'
 import { parseAgentIcon, randomGlyphIcon } from '../../agents/agent-icon.js'
 import { provisionPresetAgents, type PresetPoolPlacement } from '../preset-agents.js'
 import { OrgCreationLimitReached } from '../errors.js'
+
+/** The session-start windows the org gauges report beside the lifetime total. */
+const SESSION_WINDOW_30D_MS = 30 * 24 * 60 * 60 * 1000
+const SESSION_WINDOW_24H_MS = 24 * 60 * 60 * 1000
 
 export class PgOrgRepo implements OrgRepo {
   constructor(
@@ -167,6 +171,40 @@ export class PgOrgRepo implements OrgRepo {
   async slugById(orgId: string): Promise<string | null> {
     const org = await this.db.org.findUnique({ where: { id: orgId }, select: { slug: true } })
     return org?.slug ?? null
+  }
+
+  async orgTelemetry(now: Date): Promise<OrgTelemetryRow[]> {
+    const since30d = new Date(now.getTime() - SESSION_WINDOW_30D_MS)
+    const since24h = new Date(now.getTime() - SESSION_WINDOW_24H_MS)
+    // Each table is aggregated ONCE and joined, never read per org: a correlated subquery here
+    // would re-scan `session_meta` for every org, turning one cheap pass into N.
+    return this.db.$queryRaw<OrgTelemetryRow[]>(Prisma.sql`
+      WITH d AS (
+        SELECT "orgId", count(*)::int AS n FROM "daemon" WHERE "orgId" IS NOT NULL GROUP BY "orgId"
+      ),
+      a AS (
+        SELECT "orgId", count(*)::int AS n FROM "agent" GROUP BY "orgId"
+      ),
+      s AS (
+        SELECT "orgId",
+               count(*)::int AS total,
+               count(*) FILTER (WHERE "startedAt" >= ${since30d})::int AS d30,
+               count(*) FILTER (WHERE "startedAt" >= ${since24h})::int AS d24
+        FROM "session_meta" GROUP BY "orgId"
+      )
+      -- Driven from "org" so an org holding nothing still reports its zeros.
+      SELECT o.id AS "orgId", o.slug AS "orgSlug",
+             COALESCE(d.n, 0)::int AS "daemons",
+             COALESCE(a.n, 0)::int AS "agents",
+             COALESCE(s.total, 0)::int AS "sessionsTotal",
+             COALESCE(s.d30, 0)::int AS "sessions30d",
+             COALESCE(s.d24, 0)::int AS "sessions24h"
+      FROM "org" o
+      LEFT JOIN d ON d."orgId" = o.id
+      LEFT JOIN a ON a."orgId" = o.id
+      LEFT JOIN s ON s."orgId" = o.id
+      ORDER BY o.id
+    `)
   }
 
   async delete(orgId: string): ReturnType<OrgRepo['delete']> {

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -135,6 +135,8 @@ export async function seedSessionMeta(
     channel?: string
     parentSessionId?: string
     lastActivityAt?: Date
+    /** When the session BEGAN; defaults to now. What the per-org session-rate windows read. */
+    startedAt?: Date
     model?: string
     /** Owning organization; defaults to the seeded one (multi-org tests pass their own). */
     orgId?: string
@@ -149,6 +151,7 @@ export async function seedSessionMeta(
       channel: opts.channel ?? '#general',
       phase: 'start',
       lastActivityAt: opts.lastActivityAt ?? new Date(),
+      ...(opts.startedAt ? { startedAt: opts.startedAt } : {}),
       ...(opts.visibility ? { visibility: opts.visibility } : {}),
       ...(opts.ownerIdentity ? { ownerIdentity: opts.ownerIdentity } : {}),
       ...(opts.daemonId ? { daemonId: opts.daemonId } : {}),

--- a/packages/control-plane/test/repo/org-telemetry.repo.test.ts
+++ b/packages/control-plane/test/repo/org-telemetry.repo.test.ts
@@ -1,0 +1,88 @@
+/**
+ * `PgOrgRepo.orgTelemetry` — the read behind the per-org gauges
+ * (`src/observability/org-metrics.ts`).
+ *
+ * The gauges' own logic is unit-tested; what needs a real database is the query: that the three
+ * tables are attributed to the right org, that an install-wide pool member (no org) is counted for
+ * nobody, and that the session windows cut at the caller's clock rather than the database's.
+ */
+import { describe, expect, it } from 'vitest'
+import { prisma } from '../setup.db.js'
+import { PgOrgRepo } from '../../src/persistence/repositories/org.repo.js'
+import { seedAgent, seedDaemon, seedSessionMeta } from '../fixtures/seed.js'
+import { DEFAULT_ORG_SLUG } from '../../prisma/seed.js'
+import type { OrgTelemetryRow } from '../../src/persistence/ports.js'
+
+const NOW = new Date('2026-06-01T12:00:00Z')
+const ago = (ms: number) => new Date(NOW.getTime() - ms)
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+
+// Preset agents would add rows this test does not control, so the repo is built without them.
+const repo = () => new PgOrgRepo(prisma, false)
+
+const bySlug = (rows: OrgTelemetryRow[], slug: string) => rows.find((r) => r.orgSlug === slug)!
+
+describe('orgTelemetry', () => {
+  it('attributes daemons, agents and sessions to their own org', async () => {
+    const other = await prisma.org.create({ data: { slug: 'other-org' } })
+    await seedDaemon(prisma, '11111111-1111-4111-8111-111111111111')
+    await seedAgent(prisma, '22222222-2222-4222-8222-222222222222')
+    await seedAgent(prisma, '33333333-3333-4333-8333-333333333333', { name: 'second' })
+    await seedAgent(prisma, '44444444-4444-4444-8444-444444444444', { orgId: other.id, name: 'theirs' })
+    await seedSessionMeta(prisma, 's-1', '22222222-2222-4222-8222-222222222222', { startedAt: ago(2 * HOUR) })
+    await seedSessionMeta(prisma, 's-2', '44444444-4444-4444-8444-444444444444', {
+      orgId: other.id,
+      startedAt: ago(2 * HOUR)
+    })
+
+    const rows = await repo().orgTelemetry(NOW)
+
+    expect(bySlug(rows, DEFAULT_ORG_SLUG)).toMatchObject({ daemons: 1, agents: 2, sessionsTotal: 1 })
+    expect(bySlug(rows, 'other-org')).toMatchObject({ daemons: 0, agents: 1, sessionsTotal: 1 })
+  })
+
+  // An org running entirely on the install-wide pool reads zero daemons — the member is shared by
+  // every org and owned by none, so crediting it to one would overstate that org's fleet.
+  it('counts an org-less pool member for nobody', async () => {
+    await prisma.daemon.create({ data: { id: '55555555-5555-4555-8555-555555555555', orgId: null } })
+
+    const rows = await repo().orgTelemetry(NOW)
+
+    expect(rows.every((r) => r.daemons === 0)).toBe(true)
+  })
+
+  it('splits sessions by start time, at the clock it was given', async () => {
+    await seedAgent(prisma, '22222222-2222-4222-8222-222222222222')
+    const agent = '22222222-2222-4222-8222-222222222222'
+    await seedSessionMeta(prisma, 'fresh', agent, { startedAt: ago(2 * HOUR) })
+    await seedSessionMeta(prisma, 'this-month', agent, { startedAt: ago(10 * DAY) })
+    await seedSessionMeta(prisma, 'ancient', agent, { startedAt: ago(90 * DAY) })
+
+    const row = bySlug(await repo().orgTelemetry(NOW), DEFAULT_ORG_SLUG)
+
+    // The total is cumulative over an unpruned table; the windows are how many BEGAN inside them.
+    expect(row).toMatchObject({ sessionsTotal: 3, sessions30d: 2, sessions24h: 1 })
+
+    // The windows move with the caller's clock, not the database's — 40 days on and only the
+    // lifetime total survives, which is what makes an idle org legible on the dashboard.
+    const later = bySlug(await repo().orgTelemetry(new Date(NOW.getTime() + 40 * DAY)), DEFAULT_ORG_SLUG)
+    expect(later).toMatchObject({ sessionsTotal: 3, sessions30d: 0, sessions24h: 0 })
+  })
+
+  // A series that vanishes on its way to zero is invisible on a dashboard: an org that removed its
+  // last daemon would look like an org that never existed.
+  it('reports an org holding nothing at all, as zeros', async () => {
+    await prisma.org.create({ data: { slug: 'empty-org' } })
+
+    const rows = await repo().orgTelemetry(NOW)
+
+    expect(bySlug(rows, 'empty-org')).toMatchObject({
+      daemons: 0,
+      agents: 0,
+      sessionsTotal: 0,
+      sessions30d: 0,
+      sessions24h: 0
+    })
+  })
+})


### PR DESCRIPTION
## What

Three new observable gauges on the Control Plane, reporting per organization:

| Metric | Unit | Meaning |
| --- | --- | --- |
| `agentconnect.org.daemons` | `{daemon}` | Daemons the org owns, any status |
| `agentconnect.org.agents` | `{agent}` | Agents defined in the org, including inactive and unplaced ones |
| `agentconnect.org.sessions` | `{session}` | Sessions the org started, split by a `window` label |

`agentconnect.org.sessions` carries `window="total"` (the lifetime count) beside
`window="30d"` and `window="24h"` (how many *began* in that window).

## Why

The pool gauges answer "is the fleet big enough". Nothing answered the other
question an operator has — "who is using this install, and how much". Daemons,
agents and sessions each carry `orgId` (session_meta's is denormalized at
ingest), so one pass over three tables states the whole install per org, and the
CP's database is the only place that can say it without a second opinion.

## Two things a reader of these series needs to know

- **`org.daemons` counts daemons the org OWNS.** An install-wide pool member
  belongs to no org (`daemon.orgId IS NULL`) and is counted for none of them, so
  an org running entirely on the pool reads zero here however much of the pool it
  occupies. Its demand is in the existing `agentconnect.pool.*` /
  `agentconnect.duty.*` series instead.
- **`window="total"` is monotonic.** `session_meta` has no retention sweep, so
  the lifetime count only ever climbs; the `30d`/`24h` windows are what carry a
  trend.

Both are stated in the metric descriptions, not just here.

## Design

Same shape and the same discipline as `observability/pool-metrics.ts`, which
this is the sibling of:

- **One read per collection** feeds every gauge, through a batch observable
  callback, so an org's five series are one consistent snapshot rather than
  three independently-timed reads.
- **Every org reports its zeros.** A series that vanishes on the way to zero is
  invisible on a dashboard: an org that removed its last daemon would look like
  an org that never existed. The query is driven from `org` with left joins.
- **A failed read skips the collection entirely** rather than observing zeros. A
  zeroed org is indistinguishable from one that just lost every daemon it had, so
  a database blip would otherwise read as a fleet-wide outage.
- **Window boundaries come from the caller's `Clock`**, not the database's
  `now()`, which is what makes them testable.
- Each table is aggregated **once** and joined; a correlated subquery would
  re-scan `session_meta` per org, turning one cheap pass into N.

Every CP replica observes the same install-wide numbers, so these are fleet
totals repeated per pod: aggregate with `max by (...)`, never `sum`. Series
count is (orgs x 5) per replica.

## Cost

Measured against a live database (~3k session rows): the whole query is a single
~5 ms pass, all buffer hits, once per metric collection interval. The session
count is a sequential scan whose cost is linear in total rows; at roughly 100x
the data it would be worth either memoizing the read across collections or
adding a narrow `(orgId, startedAt)` index for an index-only scan. Neither is
worth doing now. With no OTel exporter configured the callback never runs at all.

## Tests

- `src/observability/org-metrics.test.ts` (unit, 6): label shape, the window
  split, an idle org keeping its non-zero total beside zero windows, an org
  holding nothing still reporting zeros, and the skip-on-read-failure path.
- `test/repo/org-telemetry.repo.test.ts` (integration, 4, real Postgres): the
  query itself — per-org attribution across the three tables, an org-less pool
  member counted for nobody, the windows cutting at the passed clock, and an
  empty org present with zeros.

`seedSessionMeta` gained an optional `startedAt` so a fixture can place a session
in a window.

Dashboards and any alerting on these series are set up separately.
