### PR TITLE
fix(control-plane): label the org gauges by id, not by slug

### DIFF
--- a/packages/control-plane/src/observability/org-metrics.test.ts
+++ b/packages/control-plane/src/observability/org-metrics.test.ts
@@ -6,7 +6,6 @@ const NOW = new Date('2026-01-01T00:00:00Z')
 
 const row = (over: Partial<OrgTelemetryRow> = {}): OrgTelemetryRow => ({
   orgId: 'org_acme',
-  orgSlug: 'acme',
   daemons: 2,
   agents: 7,
   sessionsTotal: 900,
@@ -25,14 +24,15 @@ const valueOf = (obs: ReturnType<typeof orgObservations>, metric: string, window
   obs.find((o) => o.metric === metric && o.attrs.window === window)?.value
 
 describe('orgObservations', () => {
-  it('labels every series with the org slug and splits sessions by window', () => {
+  it('labels every series with the org id and splits sessions by window', () => {
     const obs = orgObservations([row()])
     expect(valueOf(obs, 'daemons')).toBe(2)
     expect(valueOf(obs, 'agents')).toBe(7)
     expect(valueOf(obs, 'sessions', 'total')).toBe(900)
     expect(valueOf(obs, 'sessions', '30d')).toBe(120)
     expect(valueOf(obs, 'sessions', '24h')).toBe(5)
-    expect(obs.every((o) => o.attrs.org === 'acme')).toBe(true)
+    // The ID, never the slug: a slug is mutable, and a personal org's is built from its owner's name.
+    expect(obs.every((o) => o.attrs.org === 'org_acme')).toBe(true)
   })
 
   // The counts are not a hierarchy: only `total` is cumulative, so an org that has stopped using
@@ -46,17 +46,18 @@ describe('orgObservations', () => {
 
   // A series that vanishes on the way to zero is invisible on a dashboard — an org that removed
   // its last daemon would look like an org that was never there.
-  it('reports an org holding nothing, as zeros', () => {
-    const obs = orgObservations([row({ orgSlug: 'empty', daemons: 0, agents: 0, sessionsTotal: 0 })])
+  it('emits all five series for an org holding nothing, as zeros', () => {
+    const empty = row({ orgId: 'org_empty', daemons: 0, agents: 0, sessionsTotal: 0, sessions30d: 0, sessions24h: 0 })
+    const obs = orgObservations([empty])
     expect(obs).toHaveLength(5)
-    expect(obs.map((o) => o.value)).toEqual([0, 0, 0, 120, 5])
+    expect(obs.map((o) => o.value)).toEqual([0, 0, 0, 0, 0])
   })
 
   it('reports every org, so a busy one cannot be averaged away by an idle one', () => {
-    const obs = orgObservations([row(), row({ orgSlug: 'other', agents: 1 })])
+    const obs = orgObservations([row(), row({ orgId: 'org_other', agents: 1 })])
     expect(obs.filter((o) => o.metric === 'agents').map((o) => [o.attrs.org, o.value])).toEqual([
-      ['acme', 7],
-      ['other', 1]
+      ['org_acme', 7],
+      ['org_other', 1]
     ])
   })
 })

--- a/packages/control-plane/src/observability/org-metrics.ts
+++ b/packages/control-plane/src/observability/org-metrics.ts
@@ -6,17 +6,26 @@
  * whole install. Sibling of `pool-metrics.ts` in shape and in discipline — one read per collection
  * feeding every gauge, and a failed read reports NOTHING rather than zeros.
  *
- * Two things to know before reading a dashboard built on these:
+ * Three things to know before reading a dashboard built on these:
  *
  *  - `org.daemons` counts daemons the org OWNS. A pool member belongs to no org, so an org running
  *    entirely on the install-wide pool reads zero here no matter how much of it it occupies — its
  *    demand is in the `agentconnect.pool.*` / `agentconnect.duty.*` series instead.
+ *  - `org.agents` reads 1 for a brand-new org, not 0 — every org is born with the `agentconnect`
+ *    preset unless the install disables it.
  *  - `org.sessions{window="total"}` is a lifetime count over an unpruned table, so it only ever
  *    climbs. The `30d`/`24h` windows are the ones that show whether an org is still active.
  *
+ * The `org` label is the org's ID, never its slug. A slug is mutable, so labelling with it would
+ * retire a series on rename — exactly the disappearance the zeros below exist to prevent — and a
+ * personal org's slug is built from its owner's display name or email, which has no business being
+ * a label value in a metrics backend. Resolving an id to a name is the dashboard's job.
+ *
  * Every CP replica observes the same install-wide numbers, so these are fleet totals repeated per
- * pod, not per-pod shards: aggregate them with `max by (...)`, never `sum`. Series count is
- * (orgs × 5) per replica — cheap at this scale, and the thing to watch if org count ever explodes.
+ * pod, not per-pod shards: aggregate them with `max by (...)`, never `sum`. Cardinality, not the
+ * query, is the dominant cost: an activated user gets a personal org, so a signup-driven install
+ * reports closer to (users × 5) series per replica, every one of them re-reported each collection
+ * interval whether or not that org has ever held anything.
  */
 import { metrics, type BatchObservableResult, type ObservableGauge } from '@opentelemetry/api'
 import type { OrgTelemetryRow } from '../persistence/ports.js'
@@ -48,10 +57,11 @@ export interface OrgObservation {
   attrs: { org: string; window?: SessionWindow }
 }
 
-/** Rows → the series each gauge reports. Pure, so a dashboard's input is testable on its own. */
+/** Rows → the series each gauge reports, labelled by org ID. Pure, so a dashboard's input is
+ *  testable on its own. */
 export function orgObservations(rows: readonly OrgTelemetryRow[]): OrgObservation[] {
   return rows.flatMap((row): OrgObservation[] => {
-    const org = row.orgSlug
+    const org = row.orgId
     const sessions = (window: SessionWindow, value: number): OrgObservation => ({
       metric: 'sessions',
       value,
@@ -99,7 +109,8 @@ function createGauges(): Record<OrgMetricName, ObservableGauge> {
     }),
     agents: meter.createObservableGauge('agentconnect.org.agents', {
       unit: '{agent}',
-      description: 'Agents defined in the org, including inactive and unplaced ones'
+      description:
+        'Agents defined in the org, including inactive and unplaced ones. A brand-new org reads 1, not 0 — every org is born with the agentconnect preset unless the install disables it'
     }),
     sessions: meter.createObservableGauge('agentconnect.org.sessions', {
       unit: '{session}',

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3913,14 +3913,16 @@ export interface OrgRecord {
 
 /** One org's footprint, for the per-org gauges (observability/org-metrics.ts). */
 export interface OrgTelemetryRow {
+  /** What the gauge labels the series with. The slug is deliberately NOT read here: it is mutable,
+   *  and a personal org's is built from its owner's display name or email. */
   orgId: string
-  /** The org's console URL segment — what the gauge labels the series with. */
-  orgSlug: string
   /** Daemons registered to the org, any status. An install-wide pool member belongs to NO org
    *  (`daemon.orgId IS NULL`) and is counted for none of them — a pool-backed org reads zero here
    *  however much of the pool it occupies, which `duty_group` is the ledger for. */
   daemons: number
-  /** Agents defined in the org, any status — including inactive and unplaced ones. */
+  /** Agents defined in the org, any status — including inactive and unplaced ones. A brand-new org
+   *  reads 1, not 0: `provisionPresetAgents` gives every org the `agentconnect` preset at creation
+   *  unless the install sets `PRESET_AGENTS_ENABLED=false`. */
   agents: number
   /** Sessions the org has ever started. `session_meta` has no retention sweep, so this is a
    *  lifetime total that only grows; the windows below are what carry a trend. */

--- a/packages/control-plane/src/persistence/repositories/org.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org.repo.ts
@@ -193,7 +193,7 @@ export class PgOrgRepo implements OrgRepo {
         FROM "session_meta" GROUP BY "orgId"
       )
       -- Driven from "org" so an org holding nothing still reports its zeros.
-      SELECT o.id AS "orgId", o.slug AS "orgSlug",
+      SELECT o.id AS "orgId",
              COALESCE(d.n, 0)::int AS "daemons",
              COALESCE(a.n, 0)::int AS "agents",
              COALESCE(s.total, 0)::int AS "sessionsTotal",

--- a/packages/control-plane/test/repo/org-telemetry.repo.test.ts
+++ b/packages/control-plane/test/repo/org-telemetry.repo.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { PgOrgRepo } from '../../src/persistence/repositories/org.repo.js'
 import { seedAgent, seedDaemon, seedSessionMeta } from '../fixtures/seed.js'
-import { DEFAULT_ORG_SLUG } from '../../prisma/seed.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import type { OrgTelemetryRow } from '../../src/persistence/ports.js'
 
 const NOW = new Date('2026-06-01T12:00:00Z')
@@ -21,7 +21,7 @@ const DAY = 24 * HOUR
 // Preset agents would add rows this test does not control, so the repo is built without them.
 const repo = () => new PgOrgRepo(prisma, false)
 
-const bySlug = (rows: OrgTelemetryRow[], slug: string) => rows.find((r) => r.orgSlug === slug)!
+const byId = (rows: OrgTelemetryRow[], orgId: string) => rows.find((r) => r.orgId === orgId)!
 
 describe('orgTelemetry', () => {
   it('attributes daemons, agents and sessions to their own org', async () => {
@@ -38,8 +38,22 @@ describe('orgTelemetry', () => {
 
     const rows = await repo().orgTelemetry(NOW)
 
-    expect(bySlug(rows, DEFAULT_ORG_SLUG)).toMatchObject({ daemons: 1, agents: 2, sessionsTotal: 1 })
-    expect(bySlug(rows, 'other-org')).toMatchObject({ daemons: 0, agents: 1, sessionsTotal: 1 })
+    expect(byId(rows, DEFAULT_ORG_ID)).toMatchObject({ daemons: 1, agents: 2, sessionsTotal: 1 })
+    expect(byId(rows, other.id)).toMatchObject({ daemons: 0, agents: 1, sessionsTotal: 1 })
+  })
+
+  // The label has to survive a rename, and must not carry the owner's name a personal org's slug is
+  // built from — so the row is keyed by id and the slug is never read.
+  it('identifies an org by id, not by its mutable slug', async () => {
+    const org = await prisma.org.create({ data: { slug: 'before-rename' } })
+
+    const before = await repo().orgTelemetry(NOW)
+    await prisma.org.update({ where: { id: org.id }, data: { slug: 'after-rename' } })
+    const after = await repo().orgTelemetry(NOW)
+
+    expect(byId(before, org.id)).toBeDefined()
+    expect(byId(after, org.id)).toBeDefined()
+    expect(Object.keys(byId(after, org.id))).not.toContain('orgSlug')
   })
 
   // An org running entirely on the install-wide pool reads zero daemons — the member is shared by
@@ -59,25 +73,25 @@ describe('orgTelemetry', () => {
     await seedSessionMeta(prisma, 'this-month', agent, { startedAt: ago(10 * DAY) })
     await seedSessionMeta(prisma, 'ancient', agent, { startedAt: ago(90 * DAY) })
 
-    const row = bySlug(await repo().orgTelemetry(NOW), DEFAULT_ORG_SLUG)
+    const row = byId(await repo().orgTelemetry(NOW), DEFAULT_ORG_ID)
 
     // The total is cumulative over an unpruned table; the windows are how many BEGAN inside them.
     expect(row).toMatchObject({ sessionsTotal: 3, sessions30d: 2, sessions24h: 1 })
 
     // The windows move with the caller's clock, not the database's — 40 days on and only the
     // lifetime total survives, which is what makes an idle org legible on the dashboard.
-    const later = bySlug(await repo().orgTelemetry(new Date(NOW.getTime() + 40 * DAY)), DEFAULT_ORG_SLUG)
+    const later = byId(await repo().orgTelemetry(new Date(NOW.getTime() + 40 * DAY)), DEFAULT_ORG_ID)
     expect(later).toMatchObject({ sessionsTotal: 3, sessions30d: 0, sessions24h: 0 })
   })
 
   // A series that vanishes on its way to zero is invisible on a dashboard: an org that removed its
   // last daemon would look like an org that never existed.
   it('reports an org holding nothing at all, as zeros', async () => {
-    await prisma.org.create({ data: { slug: 'empty-org' } })
+    const empty = await prisma.org.create({ data: { slug: 'empty-org' } })
 
     const rows = await repo().orgTelemetry(NOW)
 
-    expect(bySlug(rows, 'empty-org')).toMatchObject({
+    expect(byId(rows, empty.id)).toMatchObject({
       daemons: 0,
       agents: 0,
       sessionsTotal: 0,


### PR DESCRIPTION
Follow-up to #1316, which merged before this review feedback landed. Four
review points, all accepted.

## The label is the org id now, not its slug

The important one. A slug is mutable (`OrgRepo.update` accepts `patch.slug`),
so a rename retires the old series and starts a new one — on a dashboard that
reads as the org vanishing, which is exactly the disappearance the "every org
reports its zeros" rule exists to prevent.

And a personal org's slug is derived from a person: `ensurePersonalOrg` builds
it with `personalOrgBase(displayName, email)` + `slugify`. The label was
therefore shipping slugified human names to the metrics backend. This
repository already goes to some trouble to keep credentials out of exported
span names; the same instinct applies to a label value.

`o.id` was already selected and never observed, so labelling with it costs
nothing, and resolving an id to a display name is the dashboard's job.
`OrgTelemetryRow.orgSlug` is removed with it — the query should not read a
column nothing may observe. A new repo test renames an org between two reads
and asserts the row is still found by id.

## Cardinality is (users x 5), not (orgs x 5)

An activated user gets a personal org, so on a signup-driven install the
series count tracks users, not organizations — and each of those orgs is
re-reported every collection interval whether or not it has ever held
anything. That, not the `session_meta` scan #1316 measured, is the dominant
cost. Not a reason to change the design (reporting the zeros is still right
for an org that had something and lost it), but the module comment now says so
where whoever configures the exporter will read it.

## A brand-new org reads 1 agent, not 0

`provisionPresetAgents` gives every org the `agentconnect` preset at creation
unless `PRESET_AGENTS_ENABLED=false`, so a fresh install shows a column of orgs
sitting at exactly 1. Documented in the port and in the metric description,
alongside the pool-member and monotonic-total caveats already recorded there.

## A unit fixture asserted an impossible row

The "org holding nothing" case overrode `sessionsTotal: 0` while inheriting
`sessions30d: 120` / `sessions24h: 5` — 120 sessions started in 30 days, none
ever. The shape assertion still held, but the values made the test read as if
it checked something it did not. It now zeroes all three and is named for what
it actually asserts: all five series emitted even at zero.

## Tests

`pnpm --filter @agentconnect.md/control-plane typecheck` clean; 6 unit and 5
integration tests pass (the integration ones against real Postgres).
