### PR TITLE
fix(relay): log the two silent drops on the GitHub reviewer-request path

### DIFF
--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -1059,7 +1059,13 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
           // transient CP/GitHub failures all fail closed.
           deps.log.warn(`github ingress: authz failed ${representative.hookId}:${deliveryKey}: ${String(err)}`)
         }
-        if (!allowed && onDenied === 'skip') return
+        // A silent skip is indistinguishable from "GitHub never delivered it" without this line.
+        if (!allowed && onDenied === 'skip') {
+          deps.log.info(
+            `github ingress: authz denied ${representative.hookId}:${deliveryKey} (${ctx.eventAction} actor ${actors.senderLogin})`
+          )
+          return
+        }
 
         // Authorization waited on at least two remote calls. Re-read the table so a
         // remove/reconfigure/reassignment during that window cannot dispatch
@@ -1082,6 +1088,12 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
       const matched = candidates
         .map((rule) => ({ rule, verdict: githubRuleVerdict(rule, ctx) }))
         .filter((candidate) => candidate.verdict !== 'no-match')
+      // A native reviewer request is an explicit maintainer action; a drop always deserves a line.
+      if (ctx.eventAction === 'pull_request:review_requested' && matched.length === 0) {
+        deps.log.info(
+          `github ingress: reviewer request matched no rule ${deliveryKey} (reviewer ${ctx.requestedReviewerLogin ?? 'none'} github:${repoId}#${thread})`
+        )
+      }
       if (
         ctx.event === 'issues' ||
         (ctx.event === 'pull_request' && ctx.eventAction !== 'pull_request:review_requested')


### PR DESCRIPTION
## Why

GitHub's native reviewer control is wired as an explicit maintainer trigger: `pull_request:review_requested` bypasses the cadence, label, and mention filters and the third-party write boundary, subject only to a live write-permission check on whoever clicked.

Today, when that path produces nothing, we cannot tell why. Three outcomes are observationally identical:

1. GitHub never delivered the event.
2. It was delivered and `githubRuleVerdict` returned `no-match`.
3. It was delivered, matched, and the write-permission check denied it — `authorizeAndDispatch` returns through the `onDenied === 'skip'` branch.

None of the three writes a log line or a run row, and the file has no debug logging at all. Diagnosing a reported "the button did nothing" therefore means paging through the App's own delivery log to rule out (1) before our own code can even be suspected.

## What

Two info lines, no behavior change:

- An unmatched `pull_request:review_requested` logs the delivery key, the requested reviewer login, and the repository/thread — enough to say whether the reviewer login failed the App-bot check or the rule set no longer covers pull requests.
- A denied authorization logs the hook, the delivery key, the event action, and the actor. This branch is shared with the comment paths, so it also answers "why did the bot ignore my comment" for an actor without write access.

## Verification

`pnpm --filter @agentconnect.md/relay typecheck`, `test` (506 passed), eslint and prettier on the touched file.
