### PR TITLE
feat(sandbox): give the runtime image curl, python3, and a compiler

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -5,7 +5,8 @@
 #
 # Deliberately a different image from docker/Dockerfile's service targets. Those run the
 # published daemon and control-plane packages; this one runs half-trusted agent code, so it
-# carries the opposite bias: the shim and nothing the shim does not need.
+# carries the opposite bias: the shim, plus the baseline build toolchain a coding agent needs, and
+# nothing else.
 #
 #   docker build -f docker/runtime-sandbox.Dockerfile -t runtime-sandbox .
 #
@@ -95,11 +96,16 @@ ARG OPENCODE_VERSION=1.18.16
 ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.9
 
 # git and ca-certificates are load-bearing — the workspace surface runs git IN here over the
-# shim's exec channel. openssh-client is for ssh remotes; tini is PID 1. Nothing else: every
-# additional binary is one more thing half-trusted code can reach.
+# shim's exec channel. openssh-client is for ssh remotes; tini is PID 1.
+# curl, python3 (+venv/pip) and build-essential are the baseline toolchain an agent needs to build and
+# run the workspace it was given; without them a routine `pip install` or native-module build just fails.
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y ca-certificates git openssh-client tini \
+  && apt-get install --no-install-recommends -y \
+    ca-certificates git openssh-client tini \
+    build-essential curl pkg-config python3 python3-dev python3-pip python3-venv \
   && rm -rf /var/lib/apt/lists/*
+# `python` as well as `python3` — plenty of tooling still spawns the unsuffixed name.
+RUN ln -sf /usr/bin/python3 /usr/local/bin/python
 
 # Installed globally so the shim resolves a real executable on PATH. `--k8s` deliberately
 # refuses package-launcher (npx/uvx) entries: fetching a runtime at spawn time would mean the


### PR DESCRIPTION
## Why

The runtime sandbox shipped `git`, `openssh-client` and `tini` and nothing else, on the principle that every extra binary is reach for half-trusted code. In practice that was cutting into the agent's actual job: a `pip install`, a native-module build, or a plain `curl` inside the workspace just failed — and the failure read as a broken workspace rather than a missing toolchain.

## What

`docker/runtime-sandbox.Dockerfile`, one apt layer:

- `curl`, `build-essential`
- `python3` + `python3-pip` + `python3-venv` + `python3-dev`, and `pkg-config`
- `python` symlinked to `python3` — plenty of tooling still spawns the unsuffixed name

`python3-venv` because Debian's python3 is externally-managed and refuses `pip install` without one; `python3-dev` + `pkg-config` because that is what native extensions look for.

The file header no longer claims "the shim and nothing the shim does not need" — it now says the shim plus the baseline build toolchain, because that is what the image is.

## Trade-off

This widens the executable surface a sandbox escape lands on: with egress, `curl | sh` and local compilation are both in hand. Deliberate — flagging it rather than burying it. If we'd rather not pay for the compiler by default, `build-essential` is the piece to move behind a build arg.

Cost: base layer goes 247 MB → 693 MB uncompressed, nearly all of it `build-essential`.

## Verification

Built the apt layer standalone on arm64: curl 7.88.1, Python 3.11.2, gcc 12.2.0, GNU Make 4.3, git 2.39.5, pkg-config 1.8.1, `python3 -m venv` OK. The full image build (four ACP runtimes + the runtime-table probe) was not run locally — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)