### PR TITLE
test(control-plane): synchronise the mid-flight snapshot race properly

### DIFF
--- a/packages/control-plane/test/integration/usage-report-ingress.test.ts
+++ b/packages/control-plane/test/integration/usage-report-ingress.test.ts
@@ -9,7 +9,7 @@
  * cannot double-count, a report for a vanished agent cannot wedge the batch, and a late
  * report writes its own checkpoint without rolling the snapshot back.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { USAGE_COLLECTOR_SA_NAME } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { buildHttpApp } from '../fakes/build-http.js'
@@ -23,6 +23,25 @@ const POD_UID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 const AGENT_A = '11111111-1111-4111-8111-111111111111'
 const GONE = '99999999-9999-4999-8999-999999999999'
 const URL = '/api/v1/internal/usage/reports'
+
+/** Wait until a backend is genuinely queued on a `session_spend` row lock — the interleaving the
+ *  race below is written for. Sleeping a fixed guess instead runs a DIFFERENT interleaving whenever
+ *  the runner is slower than the guess, and the split the test names then goes uncovered. */
+async function awaitCheckpointLockWaiter(): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const rows = await prisma.$queryRaw<Array<{ waiting: number }>>`
+        SELECT count(*)::int AS "waiting"
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND cardinality(pg_blocking_pids(pid)) > 0
+          AND query ILIKE '%session_spend%'
+      `
+      expect(rows[0]?.waiting ?? 0).toBeGreaterThanOrEqual(1)
+    },
+    { timeout: 20_000, interval: 10 }
+  )
+}
 
 function report(sessionId: string, agentId: string, costAmount: string, at: Date) {
   return {
@@ -456,17 +475,26 @@ describe('the shared store semantics both adapters get', () => {
     // waited. Two autocommit statements publish the snapshot mid-flight; one
     // transaction cannot. This is the split the fences alone could not prevent.
     let release!: () => void
+    let markLocked!: () => void
     const held = new Promise<void>((resolve) => (release = resolve))
+    const locked = new Promise<void>((resolve) => (markLocked = resolve))
     const holding = prisma.$transaction(
       async (tx) => {
         await tx.$queryRaw`SELECT 1 FROM "session_spend"
           WHERE "agentId" = ${AGENT_A}::uuid AND "sessionId" = 'gated' FOR UPDATE`
+        markLocked()
         await held
       },
       { timeout: 20_000 }
     )
+    // Report only once the lock is PROVABLY held (racing `holding` so a failure there surfaces
+    // instead of hanging): started earlier, the report runs to completion unblocked and the read
+    // below sees its 999 without any mid-flight publish having happened.
+    await Promise.race([locked, holding])
     const writing = write(999, '9')
-    await new Promise((resolve) => setTimeout(resolve, 300))
+    // Parked on the checkpoint row ⇒ its snapshot statement has already run, so this read is
+    // exactly the mid-flight instant — no sleep long enough to guess at.
+    await awaitCheckpointLockWaiter()
     const midFlight = await snapshotTokens()
     release()
     await holding


### PR DESCRIPTION
## The flake

`usage-report-ingress.test.ts` — "does not publish the snapshot before the checkpoint has landed" — failed in CI with `expected 999 to be 10`, while the same suite passed on the branch's previous commit. A race in the test, not a regression.

The test proves one report cannot publish its first statement's snapshot while its second statement waits on a `session_spend` row lock. It set that up by:

1. starting a transaction that takes `SELECT ... FOR UPDATE` and then parks — without waiting for anything that confirms the lock was actually taken,
2. immediately starting the competing write,
3. sleeping 300ms and reading the snapshot.

If the holder had not reached its `FOR UPDATE` yet — plausible on a loaded runner, since the transaction still has to acquire a connection and `BEGIN` — the write was never blocked, ran to completion inside the sleep, and the "mid-flight" read saw its `999`. The assertion failed with the invariant intact, and the interleaving the test is named for went uncovered on exactly the runs slow enough to change it.

## The fix

Test-side only; the store's behaviour is untouched.

- The holding callback signals **after** `FOR UPDATE` returns, and the write starts after that signal — raced against the transaction itself, so a failure inside it surfaces instead of hanging until the vitest timeout.
- The 300ms sleep is gone. In its place, a wait until the writer is genuinely queued on the row lock (`pg_blocking_pids`, scoped to `current_database()`). Being parked there is also the proof its snapshot statement has already run, so the read is the mid-flight instant by construction rather than by timing. This is the pattern the other row-lock races in this suite already use.

No neighbouring case in the file has the same shape — this is the only one that started a competitor against an unconfirmed lock.

## Verification

Reproduced the CI failure deterministically by delaying the holder 500ms before its `FOR UPDATE`, then ran both arrangements against it:

| holder delayed 500ms | mid-flight read |
| --- | --- |
| old synchronisation | `999` — the CI failure |
| new synchronisation | `10` |

- The file passes 13/13 consecutive runs, four of them with the machine saturated.
- Full `test:int` suite green: 101 files, 1489 tests.
- The file's runtime drops from ~1.4s to ~1.0s, since the wait resolves in ~10ms instead of always costing 300ms.

Unrelated to the PR that surfaced it; kept to its own change.
