### PR TITLE
feat(daemon): translate a typed /skill into the instruction its runtime acts on

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3030,7 +3030,9 @@ export const LocalSkillsDto = z.object({
 export const RuntimeCommandDto = z.object({
   name: z.string(),
   description: z.string(),
-  hint: z.string().nullable()
+  hint: z.string().nullable(),
+  /** Record-time skill classification (see protocol RuntimeCommand.skill); absent on older daemons. */
+  skill: z.boolean().optional()
 })
 /** `GET /agents/:id/commands` — what the agent's runtime can be asked to run. `reported` is false
  *  until a session has advertised a list, so an empty list then means "unknown", not "none". */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2268,6 +2268,8 @@ export class Daemon {
       // single preparation rather than starting a warm preparation afterward.
       isHostRunning: (agentId) => this.readyHosts.has(agentId),
       agentById: (id) => this.agents.get(id),
+      // Skill-invocation translation reads what the runtime itself advertised (runtime-commands.ts).
+      advertisedCommandsFor: (agentId) => this.runtimeCommands.get(agentId).commands,
       prepareWorkspace: (agent, expectedWarmHost, request) =>
         this.prepareAgentWorkspace(agent, expectedWarmHost, request),
       // Cluster agents resolve to POD coordinates — the local resolver would hand back the

--- a/packages/daemon/src/runtimes/runtime-commands.ts
+++ b/packages/daemon/src/runtimes/runtime-commands.ts
@@ -2,7 +2,7 @@
 // (agentclientprotocol.com/protocol/v1/slash-commands) — the runtime's own answer to what it can be
 // asked to run, including for a cluster agent whose workspace no local scan can reach.
 
-import type { RuntimeCommand, RuntimeCommandsList } from '@agentconnect.md/protocol'
+import { isSkillCommand, type RuntimeCommand, type RuntimeCommandsList } from '@agentconnect.md/protocol'
 
 // Names/descriptions are workspace-controlled (a repo's SKILL.md), and the reply rides a control
 // frame the receiver rejects over 256 KiB — bound both.
@@ -46,7 +46,10 @@ export function normalizeAvailableCommands(update: unknown): RuntimeCommand[] {
     const command: RuntimeCommand = {
       name,
       description: text(row.description, MAX_DESCRIPTION_CHARS) ?? '',
-      hint: input && typeof input === 'object' ? text(input.hint, MAX_HINT_CHARS) : null
+      hint: input && typeof input === 'object' ? text(input.hint, MAX_HINT_CHARS) : null,
+      // From the RAW description — the claude skill marker is its SUFFIX, which the cap above
+      // removes for long descriptions, and this bit must not change with the display length.
+      skill: isSkillCommand({ name, description: typeof row.description === 'string' ? row.description : '' })
     }
     bytes += Buffer.byteLength(JSON.stringify(command)) + 1
     if (bytes > MAX_TOTAL_BYTES) break

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -21,6 +21,8 @@ import { backfillThreadHistory } from './turn/thread-backfill.js'
 import { RecallObserver, runTurnRecall, type MemoryRecallLifecycleEvent } from './turn/memory-recall.js'
 import { openRuntimeSession } from './turn/runtime-session.js'
 import { ingestInboundTranscript } from './turn/transcript-ingest.js'
+import { matchSkillInvocation, renderSkillInvocation } from './skill-invocation.js'
+import type { RuntimeCommand } from '@agentconnect.md/protocol'
 
 // The recall lifecycle contract lives with the collaborator that emits it; re-exported
 // here because SessionManagerDeps is the seam production wires its observer through.
@@ -204,6 +206,9 @@ export class SessionManager {
       /** Daemon-observed reply-source sidecar for context rows. Standalone/test
        * callers omit it and preserve the historical transcript-only behavior. */
       quoteForContextEvent?: (event: TranscriptEntry, replayed: readonly TranscriptEntry[]) => string | undefined
+      /** The agent runtime's advertised slash commands, for skill-invocation translation
+       *  (skill-invocation.ts). Absent (tests / chat CLI) ⇒ no translation. */
+      advertisedCommandsFor?: (agentId: string) => readonly RuntimeCommand[]
       /** The agent's own Slack bot user id on an integration (auth.test-resolved).
        *  Surfaced as the `Slack identity` line of the `# Agent` block: platform
        *  mentions are opaque `<@U…>` tokens, and without this binding the model
@@ -737,7 +742,14 @@ export class SessionManager {
         // no idea WHO is speaking and must guess from ambient account context. Synthetic
         // (cron/hook) triggers stay bare, and an agent delivery already names its caller in the
         // forwarded text (`From <caller>: …` from prepareAgentDelivery).
-        blocks.push({ type: 'text', text: msg.source === 'user' ? `[${msg.sender.id}] ${msg.text}` : msg.text })
+        // A typed `/skill` is translated into the instruction shape the runtime acts on; the
+        // transcript keeps the user's own words — prompt ≠ transcript is this seam's contract.
+        const invocation =
+          msg.source === 'user' && this.deps.advertisedCommandsFor
+            ? matchSkillInvocation(msg.text, this.deps.advertisedCommandsFor(agentId))
+            : null
+        const triggerText = invocation ? renderSkillInvocation(invocation) : msg.text
+        blocks.push({ type: 'text', text: msg.source === 'user' ? `[${msg.sender.id}] ${triggerText}` : msg.text })
         contextEvents = [...context.map((entry) => ({ ts: entry.ts, text: entry.text })), { ts, text: msg.text }]
       }
       rec.lastDeliveredTs = plan.deliveredThrough ?? ts

--- a/packages/daemon/src/session/skill-invocation.ts
+++ b/packages/daemon/src/session/skill-invocation.ts
@@ -28,11 +28,17 @@ export function matchSkillInvocation(text: string, commands: readonly RuntimeCom
   if (!PREFIXES.some((prefix) => trimmed.startsWith(prefix))) return null
   const body = trimmed.slice(1)
   const space = body.search(/\s/)
-  const token = space === -1 ? body : body.slice(0, space)
+  const token = (space === -1 ? body : body.slice(0, space)).toLowerCase()
   if (!token) return null
-  // Exact advertised name, or the `$`-stripped form a hand-typed `/name` produces on codex.
-  const command = commands.find((entry) => entry.name === token || entry.name === `$${token}`)
-  if (!command || !isSkillCommand(command)) return null
+  // Skills first, so a same-named built-in (codex's `review` vs a `$review` skill) cannot shadow
+  // the one entry that is actually invocable. Case-insensitive like codex's own parse; the `skill`
+  // bit is record-time truth, with the heuristic only as the pre-field fallback.
+  const skills = commands.filter((entry) => entry.skill ?? isSkillCommand(entry))
+  const command = skills.find((entry) => {
+    const name = entry.name.toLowerCase()
+    return name === token || name === `$${token}`
+  })
+  if (!command) return null
   return { name: command.name, args: space === -1 ? '' : body.slice(space + 1).trim() }
 }
 

--- a/packages/daemon/src/session/skill-invocation.ts
+++ b/packages/daemon/src/session/skill-invocation.ts
@@ -1,0 +1,44 @@
+// Turn a typed `/skill args` (or the Slack alias `!skill args`) into an instruction the runtime
+// reliably acts on. Delivering the literal token does NOT invoke it: the daemon's `[sender]` prompt
+// envelope displaces it from the position each adapter's command detection requires — measured
+// 2026-08-20 against claude-agent-acp 0.70.0 (command must be the LAST text block, at offset 0) and
+// codex-acp (single-block `prompt[0]`, or its `$name` token expanded anywhere inline). The one
+// shape that survives the envelope on BOTH is a plain-text instruction naming the advertised
+// command: Claude model-dispatches the named skill; codex core expands the `$name` inline.
+//
+// Only SKILLS translate (`isSkillCommand`) — a harness built-in like `/compact` cannot be
+// dispatched by prose, so translating it would replace a no-op with a misfire. Anything that does
+// not match the agent's advertised table verbatim passes through untouched, so `/Users/pc/x is
+// broken` never changes.
+import { isSkillCommand, type RuntimeCommand } from '@agentconnect.md/protocol'
+
+export interface SkillInvocation {
+  /** The ADVERTISED name — `code-review` on claude, `$code-review` on codex. */
+  name: string
+  args: string
+}
+
+/** The typed prefixes; `!` is the Slack alias (Slack swallows `/`), accepted everywhere like
+ *  parseCommand's. Control words never reach this seam — parseCommand intercepts them upstream. */
+const PREFIXES = ['/', '!']
+
+/** Match a human turn against the agent's advertised commands. `null` ⇒ deliver unchanged. */
+export function matchSkillInvocation(text: string, commands: readonly RuntimeCommand[]): SkillInvocation | null {
+  const trimmed = text.trimStart()
+  if (!PREFIXES.some((prefix) => trimmed.startsWith(prefix))) return null
+  const body = trimmed.slice(1)
+  const space = body.search(/\s/)
+  const token = space === -1 ? body : body.slice(0, space)
+  if (!token) return null
+  // Exact advertised name, or the `$`-stripped form a hand-typed `/name` produces on codex.
+  const command = commands.find((entry) => entry.name === token || entry.name === `$${token}`)
+  if (!command || !isSkillCommand(command)) return null
+  return { name: command.name, args: space === -1 ? '' : body.slice(space + 1).trim() }
+}
+
+/** The instruction the model sees in place of the raw token. Template validated by probe on both
+ *  runtimes (see module header); keep the literal `/name` — codex's inline expansion needs the
+ *  advertised token present, and Claude's dispatch is anchored by it. */
+export function renderSkillInvocation(invocation: SkillInvocation): string {
+  return `Run the command /${invocation.name}${invocation.args ? ` ${invocation.args}` : ''}`
+}

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -963,7 +963,7 @@ describe('CpClient dispatch', () => {
       reported: true,
       updatedAt: '2026-06-26T00:00:00.000Z',
       sessionId: 'acp-1',
-      commands: [{ name: 'code-review', description: 'Review the diff', hint: '[pr]' }]
+      commands: [{ name: 'code-review', description: 'Review the diff', hint: '[pr]', skill: false }]
     })
   })
 

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -29,12 +29,29 @@ describe('runtime command advertisements', () => {
     expect(isAvailableCommandsUpdate(undefined)).toBe(false)
   })
 
-  it('normalizes names, descriptions and argument hints', () => {
+  it('normalizes names, descriptions and argument hints, classifying skills at record time', () => {
     expect(normalizeAvailableCommands(advertisement)).toEqual([
-      { name: 'code-review', description: 'Review the current diff (project)', hint: '[pr-number]' },
-      { name: 'superpowers:brainstorming', description: 'Explore intent before implementing (user)', hint: null },
-      { name: 'model', description: 'Set the model for this session', hint: null }
+      { name: 'code-review', description: 'Review the current diff (project)', hint: '[pr-number]', skill: true },
+      {
+        name: 'superpowers:brainstorming',
+        description: 'Explore intent before implementing (user)',
+        hint: null,
+        skill: true
+      },
+      { name: 'model', description: 'Set the model for this session', hint: null, skill: false }
     ])
+  })
+
+  it('keeps the skill bit when the description cap eats the claude marker', () => {
+    // The `(user)` suffix sits past the 512-char display cap — classification reads the RAW text.
+    const long = `${'x'.repeat(600)} (user)`
+    const [command] = normalizeAvailableCommands({
+      sessionUpdate: 'available_commands_update',
+      availableCommands: [{ name: 'agentconnect-setup', description: long, input: null }]
+    })
+    expect(command!.description.length).toBeLessThanOrEqual(512)
+    expect(command!.description.endsWith('(user)')).toBe(false)
+    expect(command!.skill).toBe(true)
   })
 
   it('drops unnamed and duplicate entries rather than surfacing them', () => {
@@ -48,7 +65,7 @@ describe('runtime command advertisements', () => {
         { description: 'no name at all' }
       ]
     })
-    expect(commands).toEqual([{ name: 'deploy', description: 'first', hint: null }])
+    expect(commands).toEqual([{ name: 'deploy', description: 'first', hint: null, skill: false }])
   })
 
   it('bounds a hostile advertisement so the reply still fits a control frame', () => {

--- a/packages/daemon/test/skill-invocation-dispatch.test.ts
+++ b/packages/daemon/test/skill-invocation-dispatch.test.ts
@@ -1,0 +1,115 @@
+// End-to-end through the real daemon: a typed `/skill` reaches the runtime as the probe-validated
+// instruction, gated on what THIS agent's runtime advertised — while the transcript, and every
+// non-command message, keep the user's own words. This is the seam the #1312 review caught missing:
+// the picker's UI was right and the wire wasn't, so this test crosses that exact boundary.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Daemon } from '../src/daemon.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-daemon-skillinv-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      features: { turnFinalContextRefresh: false },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  const adir = join(root, 'agents', 'bot-a')
+  mkdirSync(adir, { recursive: true })
+  writeFileSync(
+    join(adir, 'agent.json'),
+    JSON.stringify({
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+      integrations: [],
+      output: { mode: 'medium' }
+    })
+  )
+  return root
+}
+
+const roots: string[] = []
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function msg(text: string, n: number) {
+  return {
+    msgId: `slack:C1:${n}`,
+    traceId: String(n),
+    source: 'user' as const,
+    platform: 'slack' as const,
+    channel: 'C1',
+    thread: `slack:C1:${n}`,
+    sender: { id: 'U123', isBot: false },
+    text,
+    mentionedBots: ['bot-a'],
+    isDm: true,
+    trigger: 'dm' as const
+  }
+}
+
+describe('skill-invocation translation through dispatch', () => {
+  it('translates a typed /skill for the prompt only, and only when advertised', async () => {
+    const root = scaffold()
+    roots.push(root)
+    const prompts: string[][] = []
+    const fakeHost = {
+      __started: true,
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-1'),
+      hasSession: (id: string) => id === 'acp-1',
+      prompt: vi.fn(async (_sid: string, blocks: any[]) => {
+        prompts.push(blocks.map((b) => String(b.text ?? '')))
+        return 'end_turn'
+      }),
+      cancel: vi.fn(),
+      stop: vi.fn()
+    }
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost as any })
+    await daemon.start()
+    try {
+      // Before any advertisement the table is empty, so a typed /name is ordinary text.
+      await (daemon as any).dispatch('bot-a', msg('/code-review 42', 1))
+      expect(prompts[0]!.join('\n')).toContain('[U123] /code-review 42')
+
+      // The runtime advertises — the same wire the real adapter uses (#1310's capture).
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-1', {
+        sessionUpdate: 'available_commands_update',
+        availableCommands: [
+          { name: 'code-review', description: 'Review the current diff (project)', input: { hint: '[pr]' } },
+          { name: 'model', description: 'Set the AI model for Claude Code', input: null }
+        ]
+      })
+
+      // Now the same message is delivered as the instruction — sender envelope intact.
+      await (daemon as any).dispatch('bot-a', msg('/code-review 42', 2))
+      const translated = prompts[1]!.join('\n')
+      expect(translated).toContain('[U123] Run the command /code-review 42')
+      expect(translated).not.toContain('[U123] /code-review 42')
+
+      // A built-in never translates; unknown names and paths never translate.
+      await (daemon as any).dispatch('bot-a', msg('/model haiku', 3))
+      expect(prompts[2]!.join('\n')).toContain('[U123] /model haiku')
+      await (daemon as any).dispatch('bot-a', msg('/Users/pc/x is broken', 4))
+      expect(prompts[3]!.join('\n')).toContain('[U123] /Users/pc/x is broken')
+
+      // The transcript kept the user's words, not the instruction (prompt ≠ transcript).
+      const store = (daemon as any).store
+      const rows = await store.transcriptSince('slack:C1', 'slack:C1:2', null, 'bot-a')
+      const all = rows.map((r: { text?: string }) => r.text ?? '').join('\n')
+      expect(all).not.toContain('Run the command')
+    } finally {
+      await daemon.stop()
+    }
+  }, 20_000)
+})

--- a/packages/daemon/test/skill-invocation.test.ts
+++ b/packages/daemon/test/skill-invocation.test.ts
@@ -45,6 +45,23 @@ describe('matchSkillInvocation', () => {
     expect(matchSkillInvocation('/$code-review', CODEX_TABLE)).toEqual({ name: '$code-review', args: '' })
   })
 
+  it('lets a skill win over a same-named built-in, whatever the advertisement order', () => {
+    const table = [
+      { name: 'review', description: 'Review my current changes', hint: null },
+      { name: '$review', description: 'Team review skill', hint: null }
+    ]
+    expect(matchSkillInvocation('/review now', table)).toEqual({ name: '$review', args: 'now' })
+  })
+
+  it('matches case-insensitively, like codex’s own parse', () => {
+    expect(matchSkillInvocation('/Code-Review 1', CLAUDE_TABLE)).toEqual({ name: 'code-review', args: '1' })
+  })
+
+  it('trusts the record-time skill bit over the truncated description', () => {
+    const truncated = [{ name: 'agentconnect-setup', description: 'x'.repeat(512), hint: null, skill: true }]
+    expect(matchSkillInvocation('/agentconnect-setup', truncated)).toEqual({ name: 'agentconnect-setup', args: '' })
+  })
+
   it('never translates a built-in — prose cannot dispatch one', () => {
     expect(matchSkillInvocation('/model haiku', CLAUDE_TABLE)).toBeNull()
     expect(matchSkillInvocation('/compact', CLAUDE_TABLE)).toBeNull()

--- a/packages/daemon/test/skill-invocation.test.ts
+++ b/packages/daemon/test/skill-invocation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { isSkillCommand } from '@agentconnect.md/protocol'
+import { matchSkillInvocation, renderSkillInvocation } from '../src/session/skill-invocation.js'
+
+// Shapes taken from real advertisements captured 2026-08-20: claude-agent-acp 0.70.0 marks skill
+// scope as a description suffix; codex-acp advertises skills as `$name`; both list built-ins bare.
+const CLAUDE_TABLE = [
+  { name: 'code-review', description: 'Review the current diff … (user)', hint: '[pr-number]' },
+  { name: 'zz-probe', description: 'Probe skill for tests. (project)', hint: null },
+  { name: 'superpowers:brainstorming', description: '(superpowers) You MUST use this…', hint: null },
+  { name: 'mcp:docs:search', description: 'Search the docs prompt', hint: null },
+  { name: 'model', description: 'Set the AI model for Claude Code', hint: '<model>' },
+  { name: 'compact', description: 'Clear conversation history but keep a summary', hint: null }
+]
+const CODEX_TABLE = [
+  { name: '$code-review', description: 'Review the current diff', hint: null },
+  { name: 'review', description: 'Review my current changes', hint: null },
+  { name: 'compact', description: 'Summarize to free context', hint: null }
+]
+
+describe('isSkillCommand', () => {
+  it('recognizes each adapter’s skill markers and nothing else', () => {
+    expect(CLAUDE_TABLE.filter(isSkillCommand).map((c) => c.name)).toEqual([
+      'code-review',
+      'zz-probe',
+      'superpowers:brainstorming'
+    ])
+    expect(CODEX_TABLE.filter(isSkillCommand).map((c) => c.name)).toEqual(['$code-review'])
+  })
+})
+
+describe('matchSkillInvocation', () => {
+  it('matches a typed /skill with and without arguments', () => {
+    expect(matchSkillInvocation('/code-review 1234', CLAUDE_TABLE)).toEqual({ name: 'code-review', args: '1234' })
+    expect(matchSkillInvocation('/zz-probe', CLAUDE_TABLE)).toEqual({ name: 'zz-probe', args: '' })
+    expect(matchSkillInvocation('  /code-review  x ', CLAUDE_TABLE)).toEqual({ name: 'code-review', args: 'x' })
+  })
+
+  it('accepts the Slack `!` alias', () => {
+    expect(matchSkillInvocation('!code-review 1234', CLAUDE_TABLE)).toEqual({ name: 'code-review', args: '1234' })
+  })
+
+  it('resolves a hand-typed bare name to codex’s advertised `$name`', () => {
+    expect(matchSkillInvocation('/code-review 1', CODEX_TABLE)).toEqual({ name: '$code-review', args: '1' })
+    expect(matchSkillInvocation('/$code-review', CODEX_TABLE)).toEqual({ name: '$code-review', args: '' })
+  })
+
+  it('never translates a built-in — prose cannot dispatch one', () => {
+    expect(matchSkillInvocation('/model haiku', CLAUDE_TABLE)).toBeNull()
+    expect(matchSkillInvocation('/compact', CLAUDE_TABLE)).toBeNull()
+    expect(matchSkillInvocation('/review', CODEX_TABLE)).toBeNull()
+    expect(matchSkillInvocation('/mcp:docs:search q', CLAUDE_TABLE)).toBeNull()
+  })
+
+  it('leaves ordinary text alone: paths, dates, unknown names, mid-sentence slashes', () => {
+    expect(matchSkillInvocation('/Users/pc/x is broken', CLAUDE_TABLE)).toBeNull()
+    expect(matchSkillInvocation('/2026 goals', CLAUDE_TABLE)).toBeNull()
+    expect(matchSkillInvocation('/no-such-skill', CLAUDE_TABLE)).toBeNull()
+    expect(matchSkillInvocation('run /code-review please', CLAUDE_TABLE)).toBeNull()
+    expect(matchSkillInvocation('/', CLAUDE_TABLE)).toBeNull()
+    expect(matchSkillInvocation('hello there', CLAUDE_TABLE)).toBeNull()
+  })
+})
+
+describe('renderSkillInvocation', () => {
+  // The template is probe-validated on both runtimes (module header) — codex needs the literal
+  // advertised token present for inline expansion, so `$name` keeps its `$`.
+  it('renders the probe-validated instruction, advertised name verbatim', () => {
+    expect(renderSkillInvocation({ name: 'code-review', args: '1234' })).toBe('Run the command /code-review 1234')
+    expect(renderSkillInvocation({ name: 'code-review', args: '' })).toBe('Run the command /code-review')
+    expect(renderSkillInvocation({ name: '$code-review', args: 'x' })).toBe('Run the command /$code-review x')
+  })
+})

--- a/packages/protocol/src/frames/runtime-command.ts
+++ b/packages/protocol/src/frames/runtime-command.ts
@@ -33,3 +33,16 @@ export const RuntimeCommandsList = z
   })
   .strict()
 export type RuntimeCommandsList = z.infer<typeof RuntimeCommandsList>
+
+/** Whether an advertised command is a SKILL — content loaded on request — rather than a harness
+ *  built-in. Only skills are dispatchable through a plain-text instruction, so the daemon's
+ *  invocation translation and the console's pickers both gate on this. The markers are each
+ *  adapter's own convention: codex advertises skills as `$name`; claude-agent-acp suffixes the
+ *  SKILL.md scope onto the description (`(user)` / `(project)`) and names plugin skills
+ *  `plugin:skill`; `mcp:`-prefixed names are MCP prompts, not skills. */
+export function isSkillCommand(command: Pick<RuntimeCommand, 'name' | 'description'>): boolean {
+  if (command.name.startsWith('$')) return true
+  if (command.name.startsWith('mcp:')) return false
+  if (command.name.includes(':')) return true
+  return /\((?:user|project)\)$/.test(command.description.trimEnd())
+}

--- a/packages/protocol/src/frames/runtime-command.ts
+++ b/packages/protocol/src/frames/runtime-command.ts
@@ -11,7 +11,12 @@ export const RuntimeCommand = z
     /** The runtime's own description; empty when it advertised none. */
     description: z.string(),
     /** ACP `input.hint` — an argument hint, or null when the command takes no argument. */
-    hint: z.string().nullable()
+    hint: z.string().nullable(),
+    /** Classified from the RAW advertisement at record time (`isSkillCommand`), BEFORE the
+     *  description is capped — the claude marker is a description suffix, so classifying after
+     *  truncation silently demotes any skill with a long description. Absent on daemons that
+     *  predate the field; readers fall back to the heuristic then. */
+    skill: z.boolean().optional()
   })
   .strict()
 export type RuntimeCommand = z.infer<typeof RuntimeCommand>


### PR DESCRIPTION
The invocation half of the `/` skill picker — the piece whose absence blocked #1312 ("the text this picker inserts can't reach the runtime as a command invocation"). #1312 stays draft until this lands; its UI then revives on top.

## The problem, measured

The daemon wraps every human turn as `[sender] text`. Command detection in both adapters is position-sensitive, and the envelope displaces the token:

| prompt shape | claude-agent-acp 0.70.0 | codex-acp |
| --- | --- | --- |
| single block, command alone | expands | expands |
| single block, `[sender] /cmd` | falls to model dispatch | expands |
| two blocks, command last | expands | ignored |
| two blocks, command first | ignored | — |

The rules are opposite (Claude anchors on the **last** block, codex on a **single** block), so delivering the literal token in a turn that also carries the sender envelope or replayed thread context cannot work on both. An earlier plan — strip the envelope and context on command turns — died on that table plus its own cost (it contradicts session-concept §2.1 and risks the delivery cursor).

## What this does instead

Translate at prompt assembly. A human trigger whose first token (after `/`, or the Slack alias `!` — Slack swallows `/` entirely) names a command the agent's runtime advertised, and which `isSkillCommand` classifies as a **skill**, is delivered as:

```
[sender] Run the command /name args
```

Envelope intact, context intact, cursor untouched. The template keeps the literal advertised token because both runtimes anchor on it: codex core expands its `$name` inline anywhere in prose (measured), and Claude model-dispatches the named skill (measured, including against a skill whose description says "never use this on your own initiative" — where occasional refusal is the model exercising judgment, arguably correctly).

**Skills only.** A harness built-in like `/compact` or `/model` cannot be dispatched by prose; translating it would replace a no-op with a misfire. `isSkillCommand` (protocol, shared with the future picker) reads each adapter's own marker: codex's `$` prefix, claude's `(user)`/`(project)` description suffix and `plugin:skill` names, with `mcp:` excluded.

**Gated on the advertisement (#1310).** No advertised table, no translation — `/Users/pc/x is broken` and `/2026 goals` never change, and a runtime that never advertises keeps byte-identical behavior. The read seam is now also the write path's authority.

**Transcript keeps the user's words.** Prompt ≠ transcript is this seam's existing contract — the envelope and context headers already live here and never appear in the transcript either.

## Template validation

Per the prompt-changes discipline: probe-validated on both runtimes before wiring — codex with and without args (core expansion, `$` name preserved as `/$name`), Claude 3/3 dispatch on a normally-described skill (one output refusal was the probe's own "token" wording tripping a safety heuristic; the skill loaded every time). Not a statistical eval; it is two runtimes, both mechanisms, both arg shapes, plus an adversarial case.

## Tests

- `skill-invocation.test.ts` — classifier against real advertisement shapes from both adapters; matcher (aliases, `$` resolution, built-in refusal, paths/dates/mid-sentence); renderer
- `skill-invocation-dispatch.test.ts` — end-to-end through a real daemon: unadvertised `/name` passes through; after an `available_commands_update` arrives on the live wire the same message delivers translated with the envelope intact; built-ins and paths never translate; the transcript never contains the instruction

Regression: smoke / message-agent / commands / webchat / turn-output / duty-replay / runtime-commands suites green (294 tests), protocol 409 green, both typechecks clean.

## Not in this PR

The picker revival (#1312, next), IM-native command registration (Discord/Telegram, later), and `!skills` discovery on Slack (later — adding a word to `parseCommand` drags the Discord app-command lockstep with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
