### PR TITLE
fix(daemon): persist the advertised command list, and stop leaking the scope marker

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -284,8 +284,10 @@ import {
   manifestFor,
   originKindOf,
   SessionPurgeReason,
-  RD_ACK_NOT_HOLDER
+  RD_ACK_NOT_HOLDER,
+  RuntimeCommand
 } from '@agentconnect.md/protocol'
+import { z } from 'zod'
 import { isNoResponseBody } from './session/no-response.js'
 import { WorkspaceConflictError } from './cp/workspace-reader.js'
 import { TaskViolationError } from './cp/task-reader.js'
@@ -2055,6 +2057,9 @@ export class Daemon {
     for (const a of this.effectiveAgents()) {
       this.agents.set(a.id, a)
       this.prefetchClone(a)
+      // Same reason as the clone: the picker's command list must survive a restart, and this
+      // path never goes through reconcile's toStart.
+      void this.hydrateRuntimeCommands(a.id)
     }
   }
 
@@ -2714,6 +2719,7 @@ export class Daemon {
       this.gitCreds.remove(id)
       this.gitCredServer?.revoke(id)
       this.runtimeCommands.forget(id)
+      void this.store.deleteRuntimeCommands(id).catch(() => undefined)
       // Use the one generation-safe teardown path: it evicts the host synchronously,
       // publishes hostStopping, and fences every older startup/retry generation.
       await this.stopHost(id)
@@ -2782,6 +2788,7 @@ export class Daemon {
         // are in hostSpawnSig, so a runtime switch would otherwise keep serving the old harness's
         // commands until some later session/new replaced them.
         this.runtimeCommands.forget(a.id)
+        void this.store.deleteRuntimeCommands(a.id).catch(() => undefined)
         if (workspaceNeedsColdRecovery) {
           this.gitCreds.remove(a.id)
           this.gitCredServer?.revoke(a.id)
@@ -2829,6 +2836,9 @@ export class Daemon {
       // New agent: warm its git-repo checkout in the background now (e.g. on daemon
       // start every agent is a toStart), so the repo is cloned ahead of the first message.
       this.prefetchClone(a as LoadedAgent)
+      // And the picker's command list, from the persisted last advertisement — a restart
+      // must not read as "this agent has never run" until a session happens to start.
+      void this.hydrateRuntimeCommands(a.id)
       await this.syncAgentSchedules(a)
     }
     // Reconcile exactly once from the final live roster. The close phase is strict:
@@ -8486,6 +8496,19 @@ export class Daemon {
     )
   }
 
+  /** Seed the in-memory command cache from the persisted advertisement; a live one always wins. */
+  private async hydrateRuntimeCommands(agentId: string): Promise<void> {
+    try {
+      const row = await this.store.getRuntimeCommands(agentId)
+      if (!row) return
+      const parsed = z.array(RuntimeCommand).safeParse(JSON.parse(row.payload))
+      if (!parsed.success) return
+      this.runtimeCommands.seed(agentId, { sessionId: row.sessionId, updatedAt: row.updatedAt, commands: parsed.data })
+    } catch {
+      // Corrupt or unreadable persisted copy — the next live advertisement rewrites it.
+    }
+  }
+
   private withWorkspaceFileWrite<T>(agentId: string, write: () => Promise<T>): Promise<T> {
     // Admission into the shared mutation tail is synchronous: a preparation or
     // second publication accepted in the next call stack can only run after this
@@ -11253,7 +11276,18 @@ export class Daemon {
       const host = this.hosts.get(agentId)
       const owned = host?.hasSession(sessionId) || host?.isLoadingSession(sessionId)
       if (owned && !this.internalPassSessions.has(extractionKey)) {
-        this.runtimeCommands.record(agentId, sessionId, update, this.clock.now())
+        const entry = this.runtimeCommands.record(agentId, sessionId, update, this.clock.now())
+        // Persisted so a restart/upgrade serves the last-known list instead of "nothing yet".
+        // `store` is absent only in bare test harnesses constructed without start().
+        if (entry && this.store) {
+          void this.store
+            .setRuntimeCommands(agentId, {
+              sessionId: entry.sessionId,
+              updatedAt: entry.updatedAt,
+              payload: JSON.stringify(entry.commands)
+            })
+            .catch((err) => this.log.debug(`runtime-commands persist failed for ${agentId}: ${formatErr(err)}`))
+        }
       }
       return
     }

--- a/packages/daemon/src/runtimes/runtime-commands.ts
+++ b/packages/daemon/src/runtimes/runtime-commands.ts
@@ -12,7 +12,7 @@ const MAX_DESCRIPTION_CHARS = 512
 const MAX_HINT_CHARS = 256
 const MAX_TOTAL_BYTES = 200 * 1024
 
-interface AdvertisedCommands {
+export interface AdvertisedCommands {
   sessionId: string
   updatedAt: string
   commands: RuntimeCommand[]
@@ -43,13 +43,17 @@ export function normalizeAvailableCommands(update: unknown): RuntimeCommand[] {
     const name = text(row.name, MAX_NAME_CHARS)
     if (!name || seen.has(name)) continue
     const input = row.input as { hint?: unknown } | null | undefined
+    const rawDescription = typeof row.description === 'string' ? row.description : ''
+    // Classify from the RAW description — the claude skill marker is its SUFFIX, which both the
+    // display cap and the strip below would otherwise destroy before the bit is derived.
+    const skill = isSkillCommand({ name, description: rawDescription })
+    // The scope marker is adapter bookkeeping, not prose: once the bit is derived, showing
+    // "… (project)" to a user is a leak, so it never enters the stored description.
     const command: RuntimeCommand = {
       name,
-      description: text(row.description, MAX_DESCRIPTION_CHARS) ?? '',
+      description: text(rawDescription.replace(/\s*\((?:user|project)\)\s*$/, ''), MAX_DESCRIPTION_CHARS) ?? '',
       hint: input && typeof input === 'object' ? text(input.hint, MAX_HINT_CHARS) : null,
-      // From the RAW description — the claude skill marker is its SUFFIX, which the cap above
-      // removes for long descriptions, and this bit must not change with the display length.
-      skill: isSkillCommand({ name, description: typeof row.description === 'string' ? row.description : '' })
+      skill
     }
     bytes += Buffer.byteLength(JSON.stringify(command)) + 1
     if (bytes > MAX_TOTAL_BYTES) break
@@ -110,13 +114,22 @@ export class RuntimeCommandsCache {
   // Latest-wins per agent, not per session: a session-worktree list still beats none once it ends.
   private readonly byAgent = new Map<string, AdvertisedCommands>()
 
-  record(agentId: string, sessionId: string, update: unknown, at: number): void {
-    if (!isAvailableCommandsUpdate(update)) return
-    this.byAgent.set(agentId, {
+  record(agentId: string, sessionId: string, update: unknown, at: number): AdvertisedCommands | null {
+    if (!isAvailableCommandsUpdate(update)) return null
+    const entry: AdvertisedCommands = {
       sessionId,
       updatedAt: new Date(at).toISOString(),
       commands: normalizeAvailableCommands(update)
-    })
+    }
+    this.byAgent.set(agentId, entry)
+    return entry
+  }
+
+  /** Hydrate one agent from the persisted copy — a LIVE advertisement always wins, so this only
+   *  fills an absent slot (daemon restart/upgrade must not blind the picker until the next
+   *  session happens to start). */
+  seed(agentId: string, entry: AdvertisedCommands): void {
+    if (!this.byAgent.has(agentId)) this.byAgent.set(agentId, entry)
   }
 
   get(agentId: string): RuntimeCommandsList {

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1297,6 +1297,15 @@ export class LocalStore {
       -- can tell "never fully discovered" from "last-good on file".
       -- ownerId leads both keys (#1039): the cache describes an image, so on a store every
       -- pool member shares, two rollout generations would re-probe and prune each other.
+      -- The last slash-command list each agent's runtime advertised (ACP
+      -- available_commands_update), so a daemon restart/upgrade does not blind the
+      -- console's skill picker until the next session happens to start.
+      CREATE TABLE IF NOT EXISTS runtime_commands (
+        agentId TEXT PRIMARY KEY,
+        sessionId TEXT NOT NULL,
+        updatedAt TEXT NOT NULL,          -- ISO timestamp of the advertisement
+        payload TEXT NOT NULL             -- JSON RuntimeCommand[]
+      );
       CREATE TABLE IF NOT EXISTS runtime_catalog_meta (
         ownerId TEXT NOT NULL DEFAULT '', -- the owning member; '' is the single-daemon store
         runtimeId TEXT NOT NULL,
@@ -4280,6 +4289,29 @@ export class LocalStore {
   }
 
   /** Whether an integration's first channel snapshot has been baselined (seeded). */
+  /** Persist one agent's advertised slash-command list (latest-wins, whole list). */
+  async setRuntimeCommands(agentId: string, row: { sessionId: string; updatedAt: string; payload: string }) {
+    await this.db
+      .prepare(
+        `INSERT INTO runtime_commands (agentId, sessionId, updatedAt, payload) VALUES (?, ?, ?, ?)
+         ON CONFLICT(agentId) DO UPDATE SET sessionId=excluded.sessionId, updatedAt=excluded.updatedAt, payload=excluded.payload`
+      )
+      .run(agentId, row.sessionId, row.updatedAt, row.payload)
+  }
+
+  async getRuntimeCommands(
+    agentId: string
+  ): Promise<{ sessionId: string; updatedAt: string; payload: string } | undefined> {
+    const row = (await this.db
+      .prepare('SELECT sessionId, updatedAt, payload FROM runtime_commands WHERE agentId = ?')
+      .get(agentId)) as { sessionId: string; updatedAt: string; payload: string } | undefined
+    return row ?? undefined
+  }
+
+  async deleteRuntimeCommands(agentId: string): Promise<void> {
+    await this.db.prepare('DELETE FROM runtime_commands WHERE agentId = ?').run(agentId)
+  }
+
   async isChannelIntroSeeded(integrationId: string): Promise<boolean> {
     return (
       (await this.db.prepare('SELECT 1 FROM channel_intro_seed WHERE integrationId = ?').get(integrationId)) !==

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -31,15 +31,18 @@ describe('runtime command advertisements', () => {
 
   it('normalizes names, descriptions and argument hints, classifying skills at record time', () => {
     expect(normalizeAvailableCommands(advertisement)).toEqual([
-      { name: 'code-review', description: 'Review the current diff (project)', hint: '[pr-number]', skill: true },
-      {
-        name: 'superpowers:brainstorming',
-        description: 'Explore intent before implementing (user)',
-        hint: null,
-        skill: true
-      },
+      { name: 'code-review', description: 'Review the current diff', hint: '[pr-number]', skill: true },
+      { name: 'superpowers:brainstorming', description: 'Explore intent before implementing', hint: null, skill: true },
       { name: 'model', description: 'Set the model for this session', hint: null, skill: false }
     ])
+  })
+
+  it('strips the scope marker from the stored description — adapter bookkeeping, not prose', () => {
+    const [command] = normalizeAvailableCommands({
+      sessionUpdate: 'available_commands_update',
+      availableCommands: [{ name: 'deploy', description: 'Ship the release. (project)', input: null }]
+    })
+    expect(command).toEqual({ name: 'deploy', description: 'Ship the release.', hint: null, skill: true })
   })
 
   it('keeps the skill bit when the description cap eats the claude marker', () => {

--- a/packages/daemon/test/skill-invocation-dispatch.test.ts
+++ b/packages/daemon/test/skill-invocation-dispatch.test.ts
@@ -111,5 +111,33 @@ describe('skill-invocation translation through dispatch', () => {
     } finally {
       await daemon.stop()
     }
-  }, 20_000)
+
+    // Restart onto the same root: the advertisement must survive the process — a daemon
+    // upgrade or restart must not read as "this agent has never run" until a session starts.
+    const prompts2: string[][] = []
+    const fakeHost2 = {
+      __started: true,
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-2'),
+      hasSession: (id: string) => id === 'acp-2',
+      prompt: vi.fn(async (_sid: string, blocks: any[]) => {
+        prompts2.push(blocks.map((b) => String(b.text ?? '')))
+        return 'end_turn'
+      }),
+      cancel: vi.fn(),
+      stop: vi.fn()
+    }
+    const restarted = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => fakeHost2 as any })
+    await restarted.start()
+    try {
+      await vi.waitFor(() => {
+        expect((restarted as any).runtimeCommands.get('bot-a').reported).toBe(true)
+      })
+      // And the seeded table still drives translation, before any new advertisement.
+      await (restarted as any).dispatch('bot-a', msg('/code-review 7', 5))
+      expect(prompts2[0]!.join('\n')).toContain('[U123] Run the command /code-review 7')
+    } finally {
+      await restarted.stop()
+    }
+  }, 30_000)
 })

--- a/packages/web/src/components/console/CommandMenu.tsx
+++ b/packages/web/src/components/console/CommandMenu.tsx
@@ -99,7 +99,7 @@ export function CommandMenu({
           >
             {gap.agentName || 'One agent'}
             {gap.reason === 'unreported'
-              ? ' hasn’t run yet — skills appear after its first session'
+              ? ' hasn’t reported its skills yet — they appear after its next session starts'
               : ' is unreachable'}
           </div>
         ))}

--- a/packages/web/src/components/console/useCommandAutocomplete.test.tsx
+++ b/packages/web/src/components/console/useCommandAutocomplete.test.tsx
@@ -162,7 +162,7 @@ describe('CommandMenu', () => {
       )
     )
     const text = container.textContent ?? ''
-    expect(text).toContain('review-bot hasn’t run yet')
+    expect(text).toContain('review-bot hasn’t reported its skills yet')
     expect(text).toContain('refactor-bot is unreachable')
   })
 


### PR DESCRIPTION
Two field reports from the first real use of the `/` picker on the test deployment.

## "review-bot hasn't run yet" — for an agent that reviewed PRs all day

The command cache was process-memory only. The restart that **deployed** the capture code also guaranteed every agent read as never-having-run until its next session — and every future daemon restart or upgrade would repeat that. Requiring the user to send a message first just to *see* what an agent can do is backwards.

- The advertisement now persists in the LocalStore (`runtime_commands`, latest-wins per agent, plain `CREATE TABLE IF NOT EXISTS` per the schema conventions).
- Both roster-load paths reseed the cache (the initial local load and reconcile's `toStart` — the first one matters: a no-CP daemon never runs `toStart` on boot, which the new restart test caught).
- A live advertisement always beats the seed; both forget paths (removal, host respawn) delete the row so a runtime switch cannot resurrect a stale list.
- The dispatch test now stops the daemon, starts a second one on the same root, and proves the seeded table both answers `reported:true` and still drives `/skill` translation before any new advertisement.

A truly never-run agent still needs one session — that information doesn't exist anywhere — and the gap copy now says so honestly: *"hasn't reported its skills yet — they appear after its next session starts"*.

## "(project)" in the description pane

claude-agent-acp's scope marker, which is classification bookkeeping (#1322 derives the `skill` bit from it), not prose. Stripped at record time, after the bit is derived from the raw text, so no display surface ever sees it.

## Tests

Round-trip restart test as above; normalize tests for the strip (including the marker-past-the-cap case keeping `skill:true`); web copy assertion updated. Affected daemon suites 209 green, web 163 files / 1779 green, both typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
