### PR TITLE
fix(web): hug the caret when the skill picker opens upward

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -17,7 +17,13 @@
       "import": "./dist/slack-app-manifest.js",
       "default": "./dist/slack-app-manifest.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./runtime-command": {
+      "development": "./src/frames/runtime-command.ts",
+      "types": "./dist/frames/runtime-command.d.ts",
+      "import": "./dist/frames/runtime-command.js",
+      "default": "./dist/frames/runtime-command.js"
+    }
   },
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/web/src/components/console/CommandMenu.tsx
+++ b/packages/web/src/components/console/CommandMenu.tsx
@@ -49,8 +49,15 @@ export function CommandMenu({
   // Clamp like MentionMenu: near a narrow composer's right edge `left` would otherwise push the
   // whole popover past it. Clamped against the list alone — the pane is desktop-only and fixed.
   const left = Math.min(Math.max(0, coords.left - 4), Math.max(0, coords.elWidth - LIST_WIDTH))
+  // Anchored by whichever edge faces the caret: opening upward, the wrapper's BOTTOM is the fixed
+  // edge, so the cards must bottom-align — top-aligning there leaves the shorter card (usually the
+  // list, the primary surface) floating high above the composer while only the taller pane touches
+  // it. Downward, the top edge faces the caret and top-alignment is correct.
   return (
-    <div style={{ ...position, left }} className="absolute z-50 flex items-start gap-1">
+    <div
+      style={{ ...position, left }}
+      className={`absolute z-50 flex gap-1 ${coords.openUpward ? 'items-end' : 'items-start'}`}
+    >
       <div
         role="listbox"
         aria-label="Run a command"

--- a/packages/web/src/components/console/runtime-command-menu.ts
+++ b/packages/web/src/components/console/runtime-command-menu.ts
@@ -8,7 +8,9 @@
 // offering it would put a dead entry in the menu. This also supersedes the old console-owned-name
 // filter: `model` / `effort` / `permission` are built-ins, so the same gate removes them.
 
-import { isSkillCommand } from '@agentconnect.md/protocol'
+// The bundler-facing LEAF, like `/slack-app-manifest`: the protocol root pulls the whole wire
+// index (codec and friends), which the web dev bundler cannot resolve from source.
+import { isSkillCommand } from '@agentconnect.md/protocol/runtime-command'
 
 /** One skill offered in the picker, carrying the agent it belongs to. */
 export interface CommandCandidate {

--- a/packages/web/src/components/console/useCommandAutocomplete.test.tsx
+++ b/packages/web/src/components/console/useCommandAutocomplete.test.tsx
@@ -166,6 +166,37 @@ describe('CommandMenu', () => {
     expect(text).toContain('refactor-bot is unreachable')
   })
 
+  it('bottom-aligns the cards when opening upward, so the list hugs the caret', () => {
+    // Opening upward anchors the wrapper's BOTTOM edge; top-aligning there left the shorter list
+    // card floating high above the composer while only the taller pane touched it (field report).
+    for (const [openUpward, expected] of [
+      [true, 'items-end'],
+      [false, 'items-start']
+    ] as const) {
+      container = document.createElement('div')
+      document.body.appendChild(container)
+      root = createRoot(container)
+      act(() =>
+        root!.render(
+          <CommandMenu
+            options={[command('a', 'Alice', 'tdd')]}
+            activeIndex={0}
+            coords={{ ...coords, openUpward }}
+            iconOf={() => undefined}
+            showOwner={false}
+            onHover={() => {}}
+            onPick={() => {}}
+          />
+        )
+      )
+      expect(container.firstElementChild?.className).toContain(expected)
+      act(() => root!.unmount())
+      container.remove()
+      root = null
+      container = null
+    }
+  })
+
   it('renders nothing without a caret anchor, so a closed picker leaves no artifact', () => {
     container = document.createElement('div')
     document.body.appendChild(container)

--- a/packages/web/src/components/console/useRuntimeCommands.ts
+++ b/packages/web/src/components/console/useRuntimeCommands.ts
@@ -8,8 +8,36 @@ import { useMemo } from 'react'
 import useSWR from 'swr'
 import { useOrgs } from '@/lib/org-context'
 import { consoleKeys } from '@/lib/swr-keys'
-import { fetchAgentRuntimeCommands } from '@/lib/api'
+import { fetchAgentRuntimeCommands, type RuntimeCommandsDto } from '@/lib/api'
+import { MOCK_MODE } from '@/lib/data'
 import { offerableCommands, type CommandCandidate } from '@/components/console/runtime-command-menu'
+
+// Demo advertisement for mock mode, mirroring real adapter shapes (claude suffix-classified names,
+// a codex `$` name, argument hints) so the picker is demoable and its layout visually testable.
+const MOCK_COMMANDS: RuntimeCommandsDto = {
+  reported: true,
+  commands: [
+    {
+      name: 'deploy-checklist',
+      description: 'Walk the release checklist: build, canary, dashboards, rollout gates.',
+      hint: '[service]',
+      skill: true
+    },
+    {
+      name: 'code-review',
+      description: 'Review the current diff against the team conventions and open questions.',
+      hint: '[pr-number]',
+      skill: true
+    },
+    {
+      name: '$rollback',
+      description: 'Roll the named service back to the last good build.',
+      hint: '<service>',
+      skill: true
+    },
+    { name: 'triage', description: 'Sort the incoming issues by severity and route them.', hint: null, skill: true }
+  ]
+}
 
 /** Why one participant contributes nothing, so the picker can say so instead of going blank. */
 export type RuntimeCommandsGap = 'unreported' | 'unavailable'
@@ -34,6 +62,9 @@ export function useRuntimeCommands(
   // allSettled, not all: one offline daemon or one daemon too old to answer must not blank the whole
   // menu — that participant becomes a gap and the rest still list.
   const { data, isLoading } = useSWR(key, async () => {
+    if (MOCK_MODE) {
+      return ids.map((agentId) => ({ agentId, result: { status: 'fulfilled', value: MOCK_COMMANDS } as const }))
+    }
     const settled = await Promise.allSettled(ids.map((id) => fetchAgentRuntimeCommands(id)))
     return ids.map((agentId, index) => ({ agentId, result: settled[index]! }))
   })


### PR DESCRIPTION
Field report with screenshot: with the composer at the bottom of the viewport, the skill picker's list card floated ~250px above the composer while the description pane touched it.

## Cause

Opening upward anchors the popover wrapper's **bottom** edge (`bottom: elHeight - caretTop + 4`), but the two cards inside were `items-start` — top-aligned. The wrapper's height is the taller card's (the description pane), so the pane's bottom sat correctly against the caret line while the shorter list card hung from the shared top edge, leaving the gap exactly where the primary surface should hug the composer.

## Fix

Bottom-align the cards when opening upward (`items-end`), keep top-alignment downward — whichever edge faces the caret is the shared one. One-class conditional, pinned by a render test on both branches.

## Verified in the browser this time

All three shapes eyeballed at real widths — downward (tall viewport), upward (short viewport), and gaps-only — before/after. That verification needed two enabling changes that ride along:

- **Mock-mode demo advertisement** in `useRuntimeCommands` (claude-suffix names, a codex `$` name, hints), following the existing `MOCK_MODE` pattern — the picker is now demoable and visually testable without a live daemon.
- **A bundler-facing protocol leaf** `@agentconnect.md/protocol/runtime-command` (exactly like `/slack-app-manifest`): the web dev server cannot resolve the protocol ROOT from source (`development` condition → `src/index.ts` → `./codec.js` fails under turbopack), which `next build` never caught because production resolves `dist`. Web was the first root importer; it now uses the leaf, and dev works again.

Web suite 163 files / 1780 green, typecheck and `next build` clean.
