### PR TITLE
fix(discord): request CREATE_PUBLIC_THREADS, not MANAGE_THREADS

### DIFF
--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -106,7 +106,8 @@ const DEFAULT_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024
 const CHANNEL_CAP = 200
 const PERMISSION_NOTICE_RETRY_MS = 5 * 60_000
 
-// Keep this permission set in lock-step with packages/web/src/lib/discord-invite.ts.
+// Keep this permission set in lock-step with
+// packages/web/src/components/console/platforms/discord/invite.ts.
 // It covers reactions, channel visibility, messages, embeds/files/history, and public
 // thread creation + replies. Discord permission bitfields exceed 32 bits.
 const DISCORD_BOT_PERMISSIONS = (
@@ -116,7 +117,7 @@ const DISCORD_BOT_PERMISSIONS = (
   (1n << 14n) |
   (1n << 15n) |
   (1n << 16n) |
-  (1n << 34n) |
+  (1n << 35n) |
   (1n << 38n)
 ).toString()
 

--- a/packages/daemon/test/discord-permission-notice.test.ts
+++ b/packages/daemon/test/discord-permission-notice.test.ts
@@ -56,7 +56,7 @@ describe('Discord permission update notice', () => {
     expect(url.pathname).toBe('/oauth2/authorize')
     expect(url.searchParams.get('client_id')).toBe('123456789012345678')
     expect(url.searchParams.get('scope')).toBe('bot applications.commands')
-    expect(url.searchParams.get('permissions')).toBe('292057893952')
+    expect(url.searchParams.get('permissions')).toBe('309237763136')
 
     resolveNotice({ id: 'notice-1' })
     await Promise.all([first, second])

--- a/packages/web/src/components/console/platforms/discord/invite.test.ts
+++ b/packages/web/src/components/console/platforms/discord/invite.test.ts
@@ -51,6 +51,6 @@ describe('discordBotInviteUrl', () => {
     // ADD_REACTIONS | VIEW_CHANNEL | SEND_MESSAGES | EMBED_LINKS | ATTACH_FILES |
     // READ_MESSAGE_HISTORY | CREATE_PUBLIC_THREADS | SEND_MESSAGES_IN_THREADS —
     // kept in lock-step with packages/daemon/src/discord. Too wide for 32 bits.
-    expect(url.searchParams.get('permissions')).toBe('292057893952')
+    expect(url.searchParams.get('permissions')).toBe('309237763136')
   })
 })

--- a/packages/web/src/components/console/platforms/discord/invite.ts
+++ b/packages/web/src/components/console/platforms/discord/invite.ts
@@ -20,7 +20,7 @@ const DISCORD_BOT_PERMISSIONS = (
   (1n << 14n) | // EMBED_LINKS
   (1n << 15n) | // ATTACH_FILES
   (1n << 16n) | // READ_MESSAGE_HISTORY
-  (1n << 34n) | // CREATE_PUBLIC_THREADS
+  (1n << 35n) | // CREATE_PUBLIC_THREADS (1 << 34, mistakenly used before, is MANAGE_THREADS)
   (1n << 38n)
 ) // SEND_MESSAGES_IN_THREADS
   .toString()


### PR DESCRIPTION
## The bug

Both copies of the bot-invite permission bitfield (`packages/web/.../discord/invite.ts`, `packages/daemon/src/discord/connection.ts`) label `1n << 34n` as CREATE_PUBLIC_THREADS. Per Discord's permission table, `1 << 34` is **MANAGE_THREADS** and `1 << 35` is **CREATE_PUBLIC_THREADS**.

So the invite has been requesting a moderation permission the adapter never uses, and never requesting the one its thread promotion (`createThread`) depends on. It went unnoticed because promotion works anyway wherever the server's `@everyone` role carries Discord's create-threads default.

## The fix

`1n << 34n` → `1n << 35n` in both copies (labels were already right — only the bit was wrong), plus the two tests pinning the encoded value (`292057893952` → `309237763136`), plus a stale lock-step path comment.

Existing installs keep whatever they were granted; the corrected set applies to new invites and to the permission-update notice's link — which after this fix asks for exactly the permission that repairs failed thread promotion.

## Provenance

Surfaced by the multi-lens design review behind #1326 (its open question §9.1); bit values verified against Discord's permissions documentation before changing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
