### PR TITLE
feat(daemon): shareFile — post a workspace image into the current conversation

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -258,7 +258,9 @@ the posted filename and type come from those bytes too. A GIF is refused by name
 is capped per send and per turn; failures name their rule. A headless turn, a postless
 agent-call session, and a platform that cannot host files are refused before any file is
 read. Captions are bounded, carried as one message, and have their mention syntax
-neutralized — a caption labels a file; it must not page anyone.
+neutralized — Slack/Discord control tokens, Feishu `<at>` tags, and the broadcast words; a
+bare Telegram `@username` is the one form with no inert spelling and may still notify. A
+caption labels a file; it must not page anyone.
 
 The share never seeds or re-anchors a session — the thread already has one — and it posts
 when called, so the image may appear before the streamed reply finishes. The transcript

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -243,6 +243,31 @@ best-effort edge: a target on another daemon whose call policy terminally reject
 caller can still leave a visible post, because that policy verdict is only known on the
 target's daemon after the post is made.
 
+### Sharing a produced file into the current conversation
+
+`shareFile` posts an image from the agent's workspace into the conversation the agent is
+answering — the one visible send that is not `sendMessage`'s job, since every `sendMessage`
+post lands at a channel root. The model supplies only a workspace-relative path and an
+optional plain-text caption; every coordinate comes from the trusted active turn, so the
+image lands in the thread that asked, threaded the way that platform threads (Slack
+`thread_ts`, Telegram reply placement, Discord thread channel, Feishu topic root — which is
+refused rather than repurposed when it cannot be honored).
+
+Images only — PNG, JPEG, or WEBP, decided from the file bytes, never the file name — and
+the posted filename and type come from those bytes too. A GIF is refused by name. The file
+is capped per send and per turn; failures name their rule. A headless turn, a postless
+agent-call session, and a platform that cannot host files are refused before any file is
+read. Captions are bounded, carried as one message, and have their mention syntax
+neutralized — a caption labels a file; it must not page anyone.
+
+The share never seeds or re-anchors a session — the thread already has one — and it posts
+when called, so the image may appear before the streamed reply finishes. The transcript
+records the share with its provenance (path, sniffed type, size, digest) and, when the
+bytes fit the transcript budget, the image itself, so the console renders what the agent
+shared exactly as it renders what a user uploaded. An upload the platform abandoned
+mid-flight is reported as "may have been delivered — do not retry", never as a failure a
+retry could double-post.
+
 ### Forwarding a received file
 
 A `toUser` or bare-`channel` send may carry `attachment`, naming a file **this

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -257,7 +257,13 @@ export const ConfigSchema = z.object({
       maxAttachmentBytes: z
         .number()
         .int()
-        .default(8 * 1024 * 1024)
+        .default(8 * 1024 * 1024),
+      // Hard cap (bytes) for ONE outbound file share (shareFile / sendMessage attachment).
+      // Its own knob because the two directions differ: inbound overflow degrades to a
+      // resource_link, outbound overflow is a refusal. Unset ⇒ follows maxAttachmentBytes.
+      maxOutboundFileBytes: z.number().int().positive().optional(),
+      // Total outbound file bytes ONE turn may upload. Unset ⇒ 2× the per-file cap.
+      maxOutboundFileBytesPerTurn: z.number().int().positive().optional()
     })
     .default({
       maxAgents: 32,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { basename, dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { mkdtemp } from 'node:fs/promises'
+import { mkdtemp, readFile, stat } from 'node:fs/promises'
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
 import { loadConfig, persistDaemonId, persistRelays, type FlatOverrides } from './config/load-config.js'
 import { readCliEntry, runCliUpgrade } from './lifecycle/cli-upgrade.js'
@@ -50,7 +50,7 @@ import { maskableSecrets, maskSecretsDeep } from './session/secret-mask.js'
 import { monotonicTs } from './store/monotonic-ts.js'
 import { StoreRetentionSweeper, resolveStoreRetentionSettings } from './store/retention.js'
 import { TranscriptRecorder, type TranscriptEvent } from './session/transcript-recorder.js'
-import { attachmentMention } from './session/attachment-block.js'
+import { attachmentMention, sniffImageMimeType } from './session/attachment-block.js'
 import { McpControlServer } from './mcp/control-server.js'
 import { RemoteWebchatGrantManager } from './mcp/remote-webchat-grant.js'
 import type { SetSessionTitleReq } from './mcp/ops.js'
@@ -285,11 +285,16 @@ import {
   originKindOf,
   SessionPurgeReason,
   RD_ACK_NOT_HOLDER,
-  RuntimeCommand
+  RuntimeCommand,
+  SessionImageAttachment as SessionImageAttachmentSchema,
+  WEBCHAT_IMAGE_MAX_BYTES
 } from '@agentconnect.md/protocol'
 import { z } from 'zod'
 import { isNoResponseBody } from './session/no-response.js'
 import { WorkspaceConflictError } from './cp/workspace-reader.js'
+import { createWorkspaceScope } from './cp/workspace-scope.js'
+import { canonicalWorkspacePath, WorkspaceViolationError } from './workspace/workspace-files.js'
+import type { ShareReadResult, ShareTargetResult } from './mcp/ops/share-file.js'
 import { TaskViolationError } from './cp/task-reader.js'
 import {
   createMemoryProvider,
@@ -2243,6 +2248,99 @@ export class Daemon {
         return found
           ? { bytes: Buffer.from(found.data, 'base64'), name: found.name, mimeType: found.mimeType }
           : undefined
+      },
+      // shareFile (agent-authored-attachments.md): the trusted target, the fenced read, the
+      // synchronous budget, and the provenance row. All coordinates come from the active
+      // turn — the model supplies only a workspace-relative path and a caption.
+      shareTarget: (ctx): ShareTargetResult => {
+        const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
+        const t = this.activeTurnShare.get(key)
+        if (!t) return { ok: false, reason: 'no-turn' }
+        // §3.2's two coordinate gates, checked BEFORE any file I/O: a headless turn must
+        // post nothing, and a postless A2A child has no conversation despite a live gateway.
+        if (t.headless) return { ok: false, reason: 'headless' }
+        if (t.synthetic) return { ok: false, reason: 'no-conversation' }
+        const { headless: _headless, synthetic: _synthetic, ...target } = t
+        return { ok: true, ...target }
+      },
+      readWorkspaceImage: async (ctx, rel): Promise<ShareReadResult> => {
+        // Phase 2 (pod workspaces over the workspace-fs channel) is designed, not built.
+        if (this.k8sPlane?.workspaceRootFor(ctx.agentId) !== undefined) return { ok: false, reason: 'sandboxed' }
+        const scope = createWorkspaceScope({
+          workspaces: this.workspaces,
+          agentOf: (id) => this.agents.get(id),
+          sessionOf: (id, acpSessionId) => this.store.getSessionByAcpIdForAgent(id, acpSessionId),
+          runtimeRootOf: (id) => this.k8sPlane?.workspaceRootFor(id)
+        })
+        const acpSessionId = await this.acpSessionIdForToolCall(ctx).catch(() => undefined)
+        const location = await scope.location(ctx.agentId, acpSessionId).catch(() => undefined)
+        if (!location) return { ok: false, reason: 'not-found' }
+        const cap = cfg.limits.maxOutboundFileBytes ?? cfg.limits.maxAttachmentBytes
+        let resolved: string | null
+        try {
+          resolved = await canonicalWorkspacePath(location.root, rel)
+        } catch (err) {
+          return { ok: false, reason: err instanceof WorkspaceViolationError ? 'escape' : 'not-found' }
+        }
+        if (!resolved) return { ok: false, reason: 'not-found' }
+        const info = await stat(resolved).catch(() => undefined)
+        if (!info?.isFile()) return { ok: false, reason: 'not-found' }
+        if (info.size > cap) return { ok: false, reason: 'too-large', detail: `${info.size} bytes > ${cap}-byte cap` }
+        // Single-shot (§4): one read; the sniff, the cap re-check, and the upload all
+        // consume this buffer. The re-check closes the stat→read race on a growing file.
+        const bytes = await readFile(resolved).catch(() => undefined)
+        if (!bytes) return { ok: false, reason: 'not-found' }
+        if (bytes.byteLength > cap) {
+          return { ok: false, reason: 'too-large', detail: `${bytes.byteLength} bytes > ${cap}-byte cap` }
+        }
+        const sniffed = sniffImageMimeType(bytes)
+        if (!sniffed) {
+          const head = bytes.subarray(0, 6).toString('latin1')
+          // GIF gets a refusal that NAMES it (§4) — a plausible find-me-images result whose
+          // animation sendPhoto would silently strip; deferred behind the enum widening.
+          if (head === 'GIF87a' || head === 'GIF89a') return { ok: false, reason: 'gif' }
+          return { ok: false, reason: 'not-image' }
+        }
+        // Outbound name + MIME from the SNIFFED type, never the model-supplied path (§4):
+        // Discord renders by extension alone, so `out/chart` must not land extensionless.
+        const ext = sniffed === 'image/png' ? 'png' : sniffed === 'image/jpeg' ? 'jpg' : 'webp'
+        const stem = basename(rel).replace(/\.[A-Za-z0-9]+$/, '') || 'image'
+        const sha256 = createHash('sha256').update(bytes).digest('hex')
+        return { ok: true, bytes, name: `${stem}.${ext}`, mimeType: sniffed, sha256 }
+      },
+      chargeShareBudget: (ctx, bytes) => {
+        const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
+        const perFile = cfg.limits.maxOutboundFileBytes ?? cfg.limits.maxAttachmentBytes
+        const perTurn = cfg.limits.maxOutboundFileBytesPerTurn ?? 2 * perFile
+        const used = this.shareBudgetByTurn.get(key) ?? 0
+        // Check + reserve in one synchronous step, so concurrent tool calls cannot both pass.
+        if (used + bytes > perTurn) return { ok: false }
+        this.shareBudgetByTurn.set(key, used + bytes)
+        return {
+          ok: true,
+          release: () => this.shareBudgetByTurn.set(key, Math.max(0, (this.shareBudgetByTurn.get(key) ?? 0) - bytes))
+        }
+      },
+      recordShare: async (ctx, row) => {
+        // Provenance row (§4). The bytes ride along exactly as an inbound image's do when
+        // they fit the transcript cap, so the console can render what the agent shared.
+        const image =
+          row.image && row.image.data.byteLength <= WEBCHAT_IMAGE_MAX_BYTES
+            ? SessionImageAttachmentSchema.safeParse({
+                name: row.image.name,
+                mimeType: row.image.mimeType,
+                data: row.image.data.toString('base64')
+              })
+            : undefined
+        await this.store.appendTranscript({
+          channel: transcriptChannelKey(ctx.channel, ctx.transportScope),
+          thread: ctx.thread,
+          ts: row.ts,
+          sender: ctx.agentId,
+          kind: 'text',
+          text: row.text,
+          ...(image?.success ? { attachments: [image.data] } : {})
+        })
       },
       recordOutbound: async (ctx, channel, thread, text, ts, integrationId) =>
         await this.store.appendTranscript({
@@ -9198,6 +9296,19 @@ export class Daemon {
     // §6.7 active-turn context: expose THIS turn's trusted callMeta by logical sessionKey so
     // a nested messageAgent made during the turn can auto-inherit hop/origin + reply-correlation.
     if (callMeta) this.activeTurnCallMeta.set(key, callMeta)
+    // shareFile's trusted post target (§3.1): the turn plan's coordinates plus the reply
+    // anchor Telegram places by. Installed per turn because headless-ness and the reply
+    // target are TURN facts, not session facts.
+    const shareReplyTo = this.telegramReplyTarget(entry.msg)
+    this.activeTurnShare.set(key, {
+      platform: plan.platform,
+      ...(plan.integrationId !== undefined ? { integrationId: plan.integrationId } : {}),
+      channel: plan.channel,
+      ...(plan.thread !== undefined ? { thread: plan.thread } : {}),
+      ...(shareReplyTo !== undefined ? { replyTo: shareReplyTo } : {}),
+      headless: entry.msg.headless === true,
+      synthetic: isSyntheticA2aChannel(plan.channel)
+    })
     const activeGithub = await this.githubReviews.prepareGithubTurn(entry, sessionId).catch((err) => {
       this.log.warn(`github review: turn setup failed (${formatErr(err)})`)
       return undefined
@@ -10098,6 +10209,8 @@ export class Daemon {
     // only inherit while the turn is in flight). Only clear if THIS turn owns the entry —
     // the map is keyed by sessionKey and the gate guarantees one active turn per key.
     if (callMeta) this.activeTurnCallMeta.delete(key)
+    this.activeTurnShare.delete(key)
+    this.shareBudgetByTurn.delete(key)
     const activeGithub = activeTurn.github
     const activeGithubReplyBatch = activeTurn.githubReplyBatch
     if (activeGithub && this.activeGithubTurnMeta.get(key) === activeGithub) this.activeGithubTurnMeta.delete(key)
@@ -10993,6 +11106,26 @@ export class Daemon {
    * makes is a fresh call (hopCount 0, no inherited correlation).
    */
   private activeTurnCallMeta = new Map<string, CallMeta>()
+
+  /** The active turn's trusted `shareFile` post target, by logical sessionKey — the
+   *  coordinate + per-platform anchor the tool may NOT receive from the model
+   *  (agent-authored-attachments.md §3.1), plus the two coordinate refusals (§3.2). */
+  private activeTurnShare = new Map<
+    string,
+    {
+      platform: string
+      integrationId?: string
+      channel: string
+      thread?: string
+      replyTo?: number
+      headless: boolean
+      synthetic: boolean
+    }
+  >()
+
+  /** Bytes `shareFile` has uploaded this turn, by the same key — the synchronous per-turn
+   *  reservation of agent-authored-attachments.md §5. */
+  private shareBudgetByTurn = new Map<string, number>()
 
   /**
    * Post a chronological boundary message SERIALIZED on the turn's apply chain, returning

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2273,7 +2273,12 @@ export class Daemon {
           runtimeRootOf: (id) => this.k8sPlane?.workspaceRootFor(id)
         })
         const acpSessionId = await this.acpSessionIdForToolCall(ctx).catch(() => undefined)
-        const location = await scope.location(ctx.agentId, acpSessionId).catch(() => undefined)
+        // Session-worktree first (an isolated session's files live there), then the agent
+        // root: `location(id, sessionId)` answers ONLY for git-repo agents on isolated
+        // sessions, and the default config (shared isolation, from-scratch) is the other arm.
+        const location =
+          (await scope.location(ctx.agentId, acpSessionId).catch(() => undefined)) ??
+          (await scope.location(ctx.agentId).catch(() => undefined))
         if (!location) return { ok: false, reason: 'not-found' }
         const cap = cfg.limits.maxOutboundFileBytes ?? cfg.limits.maxAttachmentBytes
         let resolved: string | null

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -12,7 +12,8 @@ import type { Agent } from '../agents/agent-schema.js'
 import { platformIntegrationConfig } from '../platforms/integration-config.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
-import { PlatformSendQueue } from '../platforms/send-queue.js'
+import { isSendQueueTimeout, PlatformSendQueue } from '../platforms/send-queue.js'
+import type { UploadAnchor, UploadFailReason, UploadOutcome } from '../mcp/ops/context.js'
 import { normalizeDiscordMessage, type DiscordMessageLike } from './normalize.js'
 import { DISCORD_APP_COMMANDS } from './app-commands.js'
 import {
@@ -119,6 +120,15 @@ const DISCORD_BOT_PERMISSIONS = (
 ) // SEND_MESSAGES_IN_THREADS
   .toString()
 
+/** Map a Discord send error to the port's typed failure vocabulary. 40005 = entity too large. */
+function classifyDiscordUploadError(err: unknown): UploadFailReason {
+  const code = (err as { code?: unknown })?.code
+  if (code === 40005) return 'too_large'
+  if (code === 50013 || code === 50001) return 'forbidden'
+  if (code === 10003 || code === 10008) return 'not_found'
+  return 'platform_error'
+}
+
 type DiscordPermissionIssue = 'missing-access' | 'missing-permissions' | 'missing-oauth-scope'
 
 type DiscordErrorLike = {
@@ -151,6 +161,8 @@ type SendPayload = {
   components?: DiscordComponents
   /** Discord carries bytes on the message itself — no separate upload call. */
   files?: { attachment: Buffer; name: string }[]
+  /** `parse: []` suppresses every ping a model-authored caption could carry. */
+  allowedMentions?: { parse: never[] }
 }
 type Sendable = Channel & {
   send: (payload: SendPayload) => Promise<Message>
@@ -523,43 +535,54 @@ export class DiscordConnection implements PlatformConnection {
     channel: string,
     file: { bytes: Buffer; name: string; mimeType?: string },
     comment?: string,
-    threadTs?: string
-  ): Promise<{ messageId?: string } | undefined> {
-    const target = this.replyTarget(channel, threadTs)
-    return this.queue.enqueue(async () => {
+    anchor?: UploadAnchor,
+    _identity?: unknown
+  ): Promise<UploadOutcome> {
+    const target = this.replyTarget(channel, anchor?.thread)
+    const task: Promise<UploadOutcome> = this.queue.enqueue(async () => {
       const ch = await this.sendableChannel(target)
       if (!ch) {
         await this.postPermissionUpdateNotice(target, ch)
-        return undefined
+        return { ok: false, reason: 'not_found' }
       }
       const chunks = comment ? chunkForDiscord(comment) : ['']
       let firstId: string | undefined
       let attached = false
       let dropped = false
+      let firstErr: unknown
       for (const chunk of chunks) {
         const payload: SendPayload = {
           ...(chunk ? { content: chunk } : {}),
-          ...(attached ? {} : { files: [{ attachment: file.bytes, name: file.name }] })
+          ...(attached ? {} : { files: [{ attachment: file.bytes, name: file.name }] }),
+          // A model-authored caption must not be able to ping — <@id>/@everyone resolve in
+          // plain content, and suppression is Discord-native rather than string surgery.
+          allowedMentions: { parse: [] }
         }
         const sent = await ch.send(payload).catch((err: Error) => {
+          firstErr = err
           this.rememberPermissionIssue(err, target)
           this.deps.log?.debug(`discord: uploadFile failed (ch=${target}): ${err.message}`)
           return null
         })
-        // Nothing posted yet ⇒ nothing landed at all, which is the `undefined` contract. A
-        // later chunk failing is a partial: the file is in the chat, so say what was lost
-        // rather than claim the send never happened.
-        if (!sent && !attached) return undefined
+        // Nothing posted yet ⇒ nothing landed at all — the `ok: false` contract. A later
+        // chunk failing is a partial: the file is in the chat, so say what was lost rather
+        // than claim the send never happened.
+        if (!sent && !attached) return { ok: false, reason: classifyDiscordUploadError(firstErr) }
         if (!sent) dropped = true
         attached = true
         if (sent && firstId === undefined) firstId = sent.id
       }
       await this.postPermissionUpdateNotice(target, ch)
       return {
+        ok: true,
         ...(firstId !== undefined ? { messageId: firstId } : {}),
         ...(dropped ? { warning: 'the file was sent, but part of its caption did not post' } : {})
       }
     })
+    return task.catch((err) => ({
+      ok: false,
+      reason: isSendQueueTimeout(err) ? 'indeterminate' : 'platform_error'
+    }))
   }
 
   /**

--- a/packages/daemon/src/evaluation/virtual-connections.ts
+++ b/packages/daemon/src/evaluation/virtual-connections.ts
@@ -403,20 +403,20 @@ export class VirtualSlackConnection implements PlatformConnection {
     channel: string,
     _file: { bytes: Buffer; name: string; mimeType?: string },
     comment?: string,
-    threadTs?: string,
+    anchor?: { thread?: string; replyTo?: number },
     options?: VirtualPostOptions
-  ): Promise<{ messageId?: string } | undefined> {
+  ): Promise<{ ok: true; messageId?: string; warning?: string }> {
     const result = await this.world.recordOutbound({
       kind: 'reply',
       platform: 'slack',
       integrationId: this.integrationId,
       channel,
-      ...(threadTs !== undefined ? { thread: threadTs } : {}),
+      ...(anchor?.thread !== undefined ? { thread: anchor.thread } : {}),
       ...(identityOf(options) ? { identity: identityOf(options)! } : {}),
       text: comment ?? ''
     })
     if (result.status !== 'delivered') throw new VirtualDeliveryRejected(result)
-    return {}
+    return { ok: true }
   }
 }
 

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -14,7 +14,8 @@ import { integrationCore, platformIntegrationConfig } from '../platforms/integra
 import type { ReplyAttributionInfo } from '../messages/attribution.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
-import { PlatformSendQueue } from '../platforms/send-queue.js'
+import { isSendQueueTimeout, PlatformSendQueue } from '../platforms/send-queue.js'
+import type { UploadAnchor, UploadFailReason, UploadOutcome } from '../mcp/ops/context.js'
 import { feishuEventToMessageLike, normalizeFeishuMessage, type FeishuRawEvent } from './normalize.js'
 import {
   buildCompletedReplyCard,
@@ -161,6 +162,14 @@ export interface FeishuApi {
   ): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean; avatarUrl?: string }>
   /** GET /open-apis/bot/v3/info — the bot's own open_id + display name. */
   getBotInfo(): Promise<{ openId?: string; name?: string }>
+}
+
+/** Map a Feishu send error to the port's typed failure vocabulary via the permission sniffer. */
+function classifyFeishuUploadError(err: unknown): UploadFailReason {
+  const issue = feishuPermissionIssueFrom(err)
+  if (issue === 'app-permissions') return 'missing_scope'
+  if (issue) return 'forbidden'
+  return 'platform_error'
 }
 
 /** Opaque turn-local reference returned after the CardKit entity is visible in chat. */
@@ -986,18 +995,27 @@ export class FeishuConnection implements PlatformConnection {
     channel: string,
     file: { bytes: Buffer; name: string; mimeType?: string },
     comment?: string,
-    threadAnchor?: string
-  ): Promise<{ messageId?: string } | undefined> {
+    anchor?: UploadAnchor,
+    _identity?: unknown
+  ): Promise<UploadOutcome> {
     if (file.mimeType && !file.mimeType.startsWith('image/')) {
       this.deps.log?.debug(`feishu: uploadFile refused ${file.name} (${file.mimeType}) — images only`)
-      return undefined
+      return { ok: false, reason: 'platform_error' }
     }
-    return this.queue.enqueue(async () => {
+    // REFUSE an anchor this platform cannot honor rather than repurpose it: `sendImage`
+    // prefix-sniffs, so an unrecognized anchor would silently become a chat-ROOT post — in
+    // topic mode a brand-new topic reported as success. A DM's anchor is its chat id.
+    const threadAnchor = anchor?.thread
+    if (threadAnchor !== undefined && !threadAnchor.startsWith('om_') && threadAnchor !== channel) {
+      this.deps.log?.debug(`feishu: uploadFile refused unhonorable anchor (ch=${channel})`)
+      return { ok: false, reason: 'not_found' }
+    }
+    const task: Promise<UploadOutcome> = this.queue.enqueue(async () => {
       try {
         const { imageKey } = await this.handle.api.uploadImage(file.bytes)
         if (!imageKey) {
           this.deps.log?.debug(`feishu: uploadFile got no image key for ${file.name}`)
-          return undefined
+          return { ok: false, reason: 'platform_error' }
         }
         let sent: { messageId?: string }
         try {
@@ -1005,31 +1023,35 @@ export class FeishuConnection implements PlatformConnection {
         } catch (err) {
           this.rememberPermissionIssue(err, channel)
           this.deps.log?.debug(`feishu: uploadFile ${file.name} → ch=${channel} failed: ${(err as Error).message}`)
-          return undefined
+          return { ok: false, reason: classifyFeishuUploadError(err) }
         }
-        const anchor = sent.messageId !== undefined ? { messageId: sent.messageId } : {}
+        const posted = { ok: true as const, ...(sent.messageId !== undefined ? { messageId: sent.messageId } : {}) }
         // A long caption is several messages, so the warning has to say whether NONE or only
         // SOME of it landed: an agent told the whole caption failed would re-send all of it and
         // duplicate the chunks that did post — the very duplication the ordering above avoids.
-        let posted = 0
+        let landed = 0
         try {
           for (const chunk of comment ? chunkForFeishu(comment) : []) {
             await this.sendChunk(channel, threadAnchor, chunk)
-            posted += 1
+            landed += 1
           }
-          return anchor
+          return posted
         } catch (err) {
           this.rememberPermissionIssue(err, channel)
           this.deps.log?.debug(`feishu: uploadFile caption failed (ch=${channel}): ${(err as Error).message}`)
-          const lost = posted > 0 ? 'part of its caption' : 'its caption'
-          return { ...anchor, warning: `the image was sent, but ${lost} did not post` }
+          const lost = landed > 0 ? 'part of its caption' : 'its caption'
+          return { ...posted, warning: `the image was sent, but ${lost} did not post` }
         }
       } catch (err) {
         this.rememberPermissionIssue(err, channel)
         this.deps.log?.debug(`feishu: uploadFile ${file.name} → ch=${channel} failed: ${(err as Error).message}`)
-        return undefined
+        return { ok: false, reason: classifyFeishuUploadError(err) }
       }
     })
+    return task.catch((err) => ({
+      ok: false,
+      reason: isSendQueueTimeout(err) ? 'indeterminate' : 'platform_error'
+    }))
   }
 
   /**

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -31,6 +31,7 @@ import {
   type MemoryOpsDeps
 } from './ops/memory.js'
 import { sendMessage, type MessagingDeps } from './ops/messaging.js'
+import { shareFile, type ShareFileDeps } from './ops/share-file.js'
 import {
   cancelOrchestration,
   getOrchestration,
@@ -100,6 +101,7 @@ export interface OpsDeps
     OrchestrationDeps,
     GithubReviewDeps,
     MemoryOpsDeps,
+    ShareFileDeps,
     PlatformReadDeps {
   /** Fail-closed turn gate checked before every daemon bridge tool. Used to make
    *  pause/cancel/loop interrupts terminal even while the runtime is still unwinding. */
@@ -122,6 +124,7 @@ export interface OpsDeps
  */
 const HANDLERS: Map<string, ToolHandler<OpsDeps>> = new Map<string, ToolHandler<OpsDeps>>([
   ['setSessionTitle', setSessionTitle],
+  ['shareFile', shareFile],
   ['viewSessionStatus', viewSessionStatus],
   ['readMemory', readMemory],
   ['writeMemory', writeMemory],

--- a/packages/daemon/src/mcp/ops/context.ts
+++ b/packages/daemon/src/mcp/ops/context.ts
@@ -37,6 +37,18 @@ export interface SendIdentity {
   }
 }
 
+/** Where inside a conversation a file post lands — see {@link MessageGateway.uploadFile}. */
+export interface UploadAnchor {
+  thread?: string
+  replyTo?: number
+}
+
+/** Why an upload posted nothing. `indeterminate` alone means "may have landed — do not retry". */
+export type UploadFailReason =
+  'missing_scope' | 'too_large' | 'not_found' | 'forbidden' | 'indeterminate' | 'platform_error'
+
+export type UploadOutcome = { ok: true; messageId?: string; warning?: string } | { ok: false; reason: UploadFailReason }
+
 export interface MessageGateway {
   /** Layer-1 `openDirectMessage`: resolve one platform user to the app's real
    *  direct-message conversation. Optional because it is a declared read port,
@@ -62,23 +74,31 @@ export interface MessageGateway {
   /** The mirror of {@link downloadFile}: put BYTES into a conversation, introduced by
    *  `comment`. Optional — only a platform that can host a file offers it.
    *
-   *  THE CONTRACT IS `undefined` ⇔ NOTHING WAS POSTED. Two platforms cannot express a
-   *  file and its caption as one message, so they send two — and an implementation must
-   *  order them so the FILE goes first. Then a failure before anything lands returns
-   *  `undefined`, and a caption lost after it reports `warning` on an otherwise successful
-   *  send. Conflating the two would tell an agent nothing was sent while its words sat in
-   *  the chat, and the retry would duplicate them.
+   *  THE CONTRACT IS `ok: false` ⇔ NOTHING WAS POSTED — except `reason: 'indeterminate'`,
+   *  the send queue abandoning a still-running upload, which means MAY HAVE LANDED and
+   *  must never be retried. Two platforms cannot express a file and its caption as one
+   *  message, so they send two — and an implementation must order them so the FILE goes
+   *  first. Then a failure before anything lands really did land nothing, and a caption
+   *  lost after it reports `warning` on an otherwise successful send. Conflating the two
+   *  would tell an agent nothing was sent while its words sat in the chat, and the retry
+   *  would duplicate them.
    *
-   *  A result carries the post anchor when the platform's file send produces one; Slack's
+   *  `anchor` places the post inside the conversation the caller is already in: `thread`
+   *  is the platform's own thread coordinate (Slack thread_ts / Discord thread channel /
+   *  Feishu om_ root — which an implementation must REFUSE rather than repurpose when it
+   *  cannot honor it), and `replyTo` is the reply-target message id on platforms that
+   *  place by reply (Telegram non-forum groups). Absent ⇒ a channel-root post.
+   *
+   *  A success carries the post anchor when the platform's file send produces one; Slack's
    *  does not (it answers with the file, no ts), so there `messageId` is absent on success
    *  and the caller degrades exactly as it does for a post that returned no id. */
   uploadFile?(
     channel: string,
     file: { bytes: Buffer; name: string; mimeType: string },
     comment?: string,
-    threadTs?: string,
+    anchor?: UploadAnchor,
     identity?: SendIdentity
-  ): Promise<{ messageId?: string; warning?: string } | undefined>
+  ): Promise<UploadOutcome>
 }
 
 /**

--- a/packages/daemon/src/mcp/ops/messaging.ts
+++ b/packages/daemon/src/mcp/ops/messaging.ts
@@ -591,13 +591,21 @@ export async function sendMessage(
     // A file share IS the message — the caption is `body`, not a second post. It anchors like
     // any other post where the platform answers with a message id; Slack's does not, and that
     // arm degrades on the path a gateway returning no id already takes. A failed share is
-    // raised rather than reported as sent: nothing reached the conversation.
+    // raised rather than reported as sent — except `indeterminate`, the queue abandoning a
+    // still-running upload, which must say "may have landed" or a retry double-posts.
     if (attachment) {
       const shared = await gw.uploadFile?.(postChannel, attachment, body, undefined, identity)
-      // `undefined` is the port's "nothing was posted" — the only case that may claim so.
-      if (!shared) {
+      if (!shared || !shared.ok) {
+        const reason = shared && !shared.ok ? shared.reason : 'platform_error'
+        if (reason === 'indeterminate') {
+          throw new Error(
+            `sendMessage: the ${platformLabel(wantPlatform)} file share for "${attachment.name}" timed out and ` +
+              'MAY still have been delivered — do NOT retry; say the send may have gone through instead.'
+          )
+        }
         throw new Error(
-          `sendMessage: ${platformLabel(wantPlatform)} rejected the file "${attachment.name}" — nothing was sent.`
+          `sendMessage: ${platformLabel(wantPlatform)} rejected the file "${attachment.name}" ` +
+            `(${reason.replace('_', ' ')}) — nothing was sent.`
         )
       }
       providerPostId = shared.messageId

--- a/packages/daemon/src/mcp/ops/share-file.ts
+++ b/packages/daemon/src/mcp/ops/share-file.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import type { SendIdentity, SessionContext } from './context.js'
+import type { SendIdentity, SessionContext, UploadFailReason } from './context.js'
 import type { GatewayDeps } from './gateway.js'
 import { parseArgs, requiredString } from './args.js'
 import { platformLabel } from '../../platforms/read-ports.js'
@@ -77,10 +77,12 @@ export interface ShareFileDeps extends GatewayDeps {
 }
 
 /** Neutralize mention syntax in a model-authored caption (docs §3): Slack/Discord control
- *  tokens and the two broadcast words. A caption labels a file; escaping costs nothing.
- *  Discord additionally suppresses pings natively (allowedMentions), so this is belt only. */
+ *  tokens, Feishu's `<at …>` tag (which pages `user_id="all"` from plain text), and the two
+ *  broadcast words. A caption labels a file; escaping costs nothing. Discord additionally
+ *  suppresses pings natively (allowedMentions). The one form with no inert spelling is a
+ *  bare Telegram `@username` — the tool description says so instead of promising it away. */
 export function escapeCaptionMentions(caption: string): string {
-  return caption.replace(/<(?=[@#!])/g, '<\u200b').replace(/@(everyone|here)\b/g, '@\u200b$1')
+  return caption.replace(/<(?=[@#!]|at[\s>])/gi, '<\u200b').replace(/@(everyone|here)\b/gi, '@\u200b$1')
 }
 
 const READ_REFUSALS: Record<Exclude<ShareReadResult, { ok: true }>['reason'], (path: string, d?: string) => string> = {
@@ -95,7 +97,7 @@ const READ_REFUSALS: Record<Exclude<ShareReadResult, { ok: true }>['reason'], (p
   'too-large': (path, detail) => `shareFile: "${path}" is over the per-file limit${detail ? ` (${detail})` : ''}.`
 }
 
-const UPLOAD_REFUSALS: Record<string, (platform: string) => string> = {
+const UPLOAD_REFUSALS: Record<Exclude<UploadFailReason, 'indeterminate'>, (platform: string) => string> = {
   missing_scope: (p) =>
     `shareFile: the ${p} integration lacks the file-upload permission — an operator has to update the app's scopes.`,
   too_large: (p) => `shareFile: ${p} rejected the file as too large.`,
@@ -170,23 +172,36 @@ export async function shareFile(
         'shareFile: the upload timed out and MAY still have been delivered — do NOT retry; say the image may have gone through instead.'
       )
     }
-    throw new Error(UPLOAD_REFUSALS[outcome.reason]!(platformLabel(target.platform)))
+    throw new Error(UPLOAD_REFUSALS[outcome.reason](platformLabel(target.platform)))
   }
 
   // Provenance (docs §4): the model-chosen path plus what was ACTUALLY published — sniffed
   // type, size, digest — and the bytes for console replay when they fit the transcript cap.
   const marker = `[shared: ${path} (${read.mimeType}, ${read.bytes.byteLength} bytes, sha256:${read.sha256.slice(0, 16)})]`
   const ts = outcome.messageId ?? `local-${deps.now()}`
-  await deps.recordShare?.(ctx, {
-    ts,
-    text: escaped ? `${escaped}\n${marker}` : marker,
-    image: { name: read.name, mimeType: read.mimeType, data: read.bytes }
-  })
+  // The image is already in the conversation past this point, so a store failure must NOT
+  // read as a failed share — a thrown error here would invite the double-posting retry the
+  // whole outcome vocabulary exists to prevent. Degrade to a notice instead.
+  const recorded = await (
+    deps.recordShare?.(ctx, {
+      ts,
+      text: escaped ? `${escaped}\n${marker}` : marker,
+      image: { name: read.name, mimeType: read.mimeType, data: read.bytes }
+    }) ?? Promise.resolve()
+  )
+    .then(() => true)
+    .catch(() => false)
 
+  const notices = [
+    ...(outcome.warning ? [`This send partly failed: ${outcome.warning}.`] : []),
+    ...(recorded
+      ? []
+      : ['The image was posted, but recording it in the transcript failed — the console may not show it.'])
+  ]
   return {
     ok: true,
     shared: { path, mimeType: read.mimeType, bytes: read.bytes.byteLength, sha256: read.sha256 },
     post: { platform: target.platform, channel: target.channel, ts },
-    ...(outcome.warning ? { notice: `This send partly failed: ${outcome.warning}.` } : {})
+    ...(notices.length ? { notice: notices.join(' ') } : {})
   }
 }

--- a/packages/daemon/src/mcp/ops/share-file.ts
+++ b/packages/daemon/src/mcp/ops/share-file.ts
@@ -1,0 +1,192 @@
+import { z } from 'zod'
+import type { SendIdentity, SessionContext } from './context.js'
+import type { GatewayDeps } from './gateway.js'
+import { parseArgs, requiredString } from './args.js'
+import { platformLabel } from '../../platforms/read-ports.js'
+
+/**
+ * `shareFile` — a produced file into the CURRENT conversation
+ * (docs/designs/agent-authored-attachments.md §3).
+ *
+ * This is the surface `sendMessage` cannot be: every visible `sendMessage` lands at a
+ * channel ROOT, while "find me some images" wants the image in the thread that asked. So
+ * this tool takes NO coordinates at all — the daemon posts into the active turn's own
+ * conversation from trusted context (the postless-wake precedent), and no new
+ * authorization question exists because the model cannot name a destination.
+ *
+ * It carries no routing semantics: no wake, no reply correlation, no session seeding —
+ * the thread already HAS the session this turn runs in, which is why the result's
+ * message id is a transcript detail here and never an anchor.
+ */
+
+/** Caption bound, refused up front: under Telegram's 1024-char native caption so every
+ *  platform carries it as ONE message, and plain text by contract. */
+export const SHARE_CAPTION_MAX = 1000
+
+const pathField = requiredString('path')
+const captionField = z
+  .string('shareFile: `caption` must be a string')
+  .max(
+    SHARE_CAPTION_MAX,
+    `shareFile: caption is limited to ${SHARE_CAPTION_MAX} characters (plain text, one message) — put the rest in your ordinary reply.`
+  )
+  .nullish()
+  .transform((value) => (value?.trim() ? value.trim() : undefined))
+
+/** Where the active turn posts: the trusted coordinates plus the per-platform anchor
+ *  ingredients (docs §3.1 — one rule, four platform shapes). */
+export interface ShareTurnTarget {
+  platform: string
+  integrationId?: string
+  channel: string
+  /** The platform thread coordinate, when the conversation has one. */
+  thread?: string
+  /** Reply-target message id on platforms that place by reply (Telegram groups). */
+  replyTo?: number
+}
+
+export type ShareTargetRefusal = 'no-turn' | 'no-conversation' | 'headless'
+export type ShareTargetResult = ({ ok: true } & ShareTurnTarget) | { ok: false; reason: ShareTargetRefusal }
+
+/** The resolved, fenced, sniffed workspace image — or why it cannot be shared. */
+export type ShareReadResult =
+  | { ok: true; bytes: Buffer; name: string; mimeType: string; sha256: string }
+  | {
+      ok: false
+      reason: 'sandboxed' | 'not-found' | 'escape' | 'not-image' | 'gif' | 'too-large'
+      /** Bound or detail the refusal names (e.g. the per-file cap). */
+      detail?: string
+    }
+
+export interface ShareFileDeps extends GatewayDeps {
+  /** The active turn's trusted post target — absent outside a live daemon. */
+  shareTarget?: (ctx: SessionContext) => ShareTargetResult
+  /** Resolve + fence + read + sniff a workspace-relative path (docs §4): single-shot read,
+   *  images only by magic bytes, name and MIME from the sniffed type. */
+  readWorkspaceImage?: (ctx: SessionContext, path: string) => Promise<ShareReadResult>
+  /** Synchronous per-turn byte reservation (docs §5) — charge before the upload, release on
+   *  failure. Synchronous so concurrent tool calls cannot race past the budget. */
+  chargeShareBudget?: (ctx: SessionContext, bytes: number) => { ok: true; release: () => void } | { ok: false }
+  /** Persist the share as the agent's own transcript row, with provenance and — when the
+   *  bytes fit the transcript cap — the bytes themselves for console replay. */
+  recordShare?: (
+    ctx: SessionContext,
+    row: { ts: string; text: string; image?: { name: string; mimeType: string; data: Buffer } }
+  ) => Promise<void>
+  now: () => number
+}
+
+/** Neutralize mention syntax in a model-authored caption (docs §3): Slack/Discord control
+ *  tokens and the two broadcast words. A caption labels a file; escaping costs nothing.
+ *  Discord additionally suppresses pings natively (allowedMentions), so this is belt only. */
+export function escapeCaptionMentions(caption: string): string {
+  return caption.replace(/<(?=[@#!])/g, '<\u200b').replace(/@(everyone|here)\b/g, '@\u200b$1')
+}
+
+const READ_REFUSALS: Record<Exclude<ShareReadResult, { ok: true }>['reason'], (path: string, d?: string) => string> = {
+  sandboxed: () =>
+    'shareFile: not yet available for sandboxed (cluster) agents — the daemon cannot reach this workspace file yet.',
+  'not-found': (path) => `shareFile: no file at "${path}" in this workspace.`,
+  escape: (path) =>
+    `shareFile: "${path}" is not a workspace-relative path — only files inside the workspace can be shared.`,
+  'not-image': (path) => `shareFile: "${path}" is not a PNG, JPEG, or WEBP image — only those can be shared.`,
+  gif: () =>
+    'shareFile: GIF is not supported yet — only PNG, JPEG, or WEBP. Convert it first; an animated GIF would lose its animation anyway.',
+  'too-large': (path, detail) => `shareFile: "${path}" is over the per-file limit${detail ? ` (${detail})` : ''}.`
+}
+
+const UPLOAD_REFUSALS: Record<string, (platform: string) => string> = {
+  missing_scope: (p) =>
+    `shareFile: the ${p} integration lacks the file-upload permission — an operator has to update the app's scopes.`,
+  too_large: (p) => `shareFile: ${p} rejected the file as too large.`,
+  not_found: (p) => `shareFile: ${p} could not place the file in this conversation.`,
+  forbidden: (p) => `shareFile: the bot may not post files in this ${p} conversation.`,
+  platform_error: (p) => `shareFile: ${p} rejected the file — nothing was sent.`
+}
+
+/** The tool handler. SECURITY: every coordinate comes from the trusted session/turn context;
+ *  the model supplies only a workspace-relative path and a caption. */
+export async function shareFile(
+  ctx: SessionContext,
+  args: Record<string, unknown>,
+  deps: ShareFileDeps
+): Promise<unknown> {
+  const path = parseArgs(pathField, args.path)
+  const caption = parseArgs(captionField, args.caption)
+
+  const target = deps.shareTarget?.(ctx)
+  if (!target) throw new Error('shareFile is not available in this environment.')
+  if (!target.ok) {
+    if (target.reason === 'headless') {
+      throw new Error('shareFile: this turn is headless — it must not post anything visible.')
+    }
+    if (target.reason === 'no-conversation') {
+      throw new Error(
+        'shareFile: this session has no platform conversation to share into (it was opened by a direct agent call).'
+      )
+    }
+    throw new Error('shareFile: no active conversation turn to share into.')
+  }
+
+  // Port-probe the platform BEFORE reading the file, so a webchat/fileless session costs no I/O.
+  const integrationId = target.integrationId ?? ctx.integrationId
+  const gw = integrationId ? deps.gatewayFor(integrationId) : undefined
+  if (!gw) throw new Error(`no live platform connection for integration ${integrationId ?? '(none)'}`)
+  if (!gw.uploadFile) {
+    throw new Error(
+      `shareFile: this conversation's platform (${platformLabel(target.platform)}) cannot host files yet.`
+    )
+  }
+
+  if (!deps.readWorkspaceImage) throw new Error('shareFile is not available in this environment.')
+  const read = await deps.readWorkspaceImage(ctx, path)
+  if (!read.ok) throw new Error(READ_REFUSALS[read.reason](path, read.detail))
+
+  const charge = deps.chargeShareBudget?.(ctx, read.bytes.byteLength) ?? { ok: true as const, release: () => {} }
+  if (!charge.ok) {
+    throw new Error("shareFile: this turn's upload budget is exhausted — stop sharing files this turn.")
+  }
+
+  const identity: SendIdentity = {
+    ...(ctx.agentName ? { username: ctx.agentName } : {}),
+    ...(ctx.iconUrl ? { icon_url: ctx.iconUrl } : {}),
+    agentAuthorId: ctx.agentId
+  }
+  const escaped = caption ? escapeCaptionMentions(caption) : undefined
+  const outcome = await gw.uploadFile(
+    target.channel,
+    { bytes: read.bytes, name: read.name, mimeType: read.mimeType },
+    escaped,
+    {
+      ...(target.thread !== undefined ? { thread: target.thread } : {}),
+      ...(target.replyTo !== undefined ? { replyTo: target.replyTo } : {})
+    },
+    identity
+  )
+  if (!outcome.ok) {
+    charge.release()
+    if (outcome.reason === 'indeterminate') {
+      throw new Error(
+        'shareFile: the upload timed out and MAY still have been delivered — do NOT retry; say the image may have gone through instead.'
+      )
+    }
+    throw new Error(UPLOAD_REFUSALS[outcome.reason]!(platformLabel(target.platform)))
+  }
+
+  // Provenance (docs §4): the model-chosen path plus what was ACTUALLY published — sniffed
+  // type, size, digest — and the bytes for console replay when they fit the transcript cap.
+  const marker = `[shared: ${path} (${read.mimeType}, ${read.bytes.byteLength} bytes, sha256:${read.sha256.slice(0, 16)})]`
+  const ts = outcome.messageId ?? `local-${deps.now()}`
+  await deps.recordShare?.(ctx, {
+    ts,
+    text: escaped ? `${escaped}\n${marker}` : marker,
+    image: { name: read.name, mimeType: read.mimeType, data: read.bytes }
+  })
+
+  return {
+    ok: true,
+    shared: { path, mimeType: read.mimeType, bytes: read.bytes.byteLength, sha256: read.sha256 },
+    post: { platform: target.platform, channel: target.channel, ts },
+    ...(outcome.warning ? { notice: `This send partly failed: ${outcome.warning}.` } : {})
+  }
+}

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -84,10 +84,10 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
     minLength: 1,
     description:
       'Optional. Forward an IMAGE this conversation received, by its name exactly as the `[attached: …]` ' +
-      'marker spells it — this is how a picture reaches another platform. Images only, and only the one ' +
-      'retained per message: a document, or a second image on the same message, is listed in the marker but ' +
-      'cannot be forwarded. The daemon posts the bytes itself with `message` as the caption; you can neither ' +
-      'attach a file you were not sent nor produce one from what you saw. The copy sent may be smaller than ' +
+      'marker spells it — this is how a RECEIVED picture reaches another platform. Images only, and only the ' +
+      'one retained per message: a document, or a second image on the same message, is listed in the marker ' +
+      'but cannot be forwarded. The daemon posts the bytes itself with `message` as the caption. To send a ' +
+      'file you PRODUCED, use `shareFile` (current conversation only). The copy sent may be smaller than ' +
       'the original.'
   }
 
@@ -261,7 +261,8 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
       'with no recipient, or the parent-session reply.\n' +
       'TO SPEAK IN THE CONVERSATION YOU ARE ALREADY IN — including to address a peer agent or a human there — do ' +
       'NOT use this tool. Write your ordinary turn reply and @-mention them in it (use `listAgents` to get an ' +
-      'agent’s exact `mention` token). That reply already goes to the right thread as you. This tool is only for ' +
+      'agent’s exact `mention` token); to put an IMAGE there, use `shareFile`. That reply already goes to the ' +
+      'right thread as you. This tool is only for ' +
       'what it cannot do: reaching a DIFFERENT conversation, a direct message, a postless agent call, or a reply ' +
       'into the parent session.\n' +
       '- toAgent — wake exactly one AgentConnect agent (id from listAgents or your own # Agent ID; never a ' +
@@ -283,8 +284,8 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
       'root without waking anyone or @-mentioning anyone; add `platform` or `integrationId` only when needed.\n' +
       '- attachment (with `toUser` or `channel`) — forward an image this conversation received: ' +
       '`{"channel":"<channel id>","attachment":"<file name>","message":"..."}`. The name is the one in the ' +
-      '`[attached: …]` marker. This is the ONLY way to put an image on another platform; describing what you saw ' +
-      'is not the same thing.\n' +
+      '`[attached: …]` marker. This is the only way a RECEIVED image reaches another platform; for an image you ' +
+      'produced, `shareFile` posts it into the current conversation.\n' +
       '- Parent session reply: `{"sessionId":"<Parent session>","message":"..."}` — relay an answer back to whoever ' +
       'asked this way, never by posting it at their channel root.\n' +
       'Every visible send lands at the channel ROOT and opens a NEW conversation of your own there. Write ' +
@@ -305,6 +306,44 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
  * file downloads by whichever platforms declare that read port
  * ({@link attachmentReadToolsFor}).
  */
+/**
+ * `shareFile` — post a workspace image into the CURRENT conversation
+ * (docs/designs/agent-authored-attachments.md §3). The one visible send that is NOT
+ * `sendMessage`'s job: every `sendMessage` post lands at a channel ROOT, while this places
+ * a file in the thread the agent is already answering. No coordinates by construction —
+ * the daemon posts from the trusted active-turn context.
+ */
+function buildShareFileTool(): ToolDescriptor {
+  return {
+    name: 'shareFile',
+    description:
+      'Post an IMAGE from your workspace into THIS conversation — the thread you are answering right now. This is ' +
+      'the only way to show someone a file you produced or downloaded: your ordinary reply is text-only, and ' +
+      '`sendMessage` posts to channel roots, never here. `path` is relative to your workspace root; put files there ' +
+      'first. Images only (PNG, JPEG, or WEBP — not GIF), decided from the file bytes, not the name. The optional ' +
+      '`caption` is plain text (max 1000 chars, mentions are neutralized); write everything else in your ordinary ' +
+      'reply. The image posts immediately, so it may appear before your streamed reply finishes. If the result says ' +
+      'the upload MAY have been delivered, do NOT retry — report that instead.',
+    inputSchema: obj(
+      {
+        path: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Workspace-relative path to the image (e.g. `out/chart.png`). Absolute paths and `..` are rejected.'
+        },
+        caption: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 1000,
+          description: 'Optional short plain-text caption posted with the image.'
+        }
+      },
+      ['path']
+    )
+  }
+}
+
 function buildReadTools(platforms: string[]): ToolDescriptor[] {
   const platform = {
     type: 'string',
@@ -656,6 +695,7 @@ export const ALL_TOOL_NAMES = [
       // platform-neutral tools — descriptors are built per-agent, but the names
       // are stable and belong in the permission auto-allow set.
       buildSendMessageTool([]),
+      buildShareFileTool(),
       ...buildReadTools([]),
       // Every platform's credentialed attachment tool, whatever this agent has:
       // the auto-allow set is about NAMES, and a name a platform can inject must
@@ -710,6 +750,10 @@ export function toolsForIntegrations(
   // Platform read helpers only make sense once the agent has at least one integration.
   if (platforms.length > 0) {
     add(buildReadTools(platforms))
+    // The current-conversation file share (docs/designs/agent-authored-attachments.md §3):
+    // platform-gated like the read tools; sessions without a file-hosting gateway get a
+    // clean refusal at call time (port probe / coordinate gates).
+    add([buildShareFileTool()])
   }
   // Per-platform CREDENTIALED attachment reads. A platform contributes its own
   // descriptor by declaring the read port (`platforms/read-ports.ts`); core does

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -321,7 +321,8 @@ function buildShareFileTool(): ToolDescriptor {
       'the only way to show someone a file you produced or downloaded: your ordinary reply is text-only, and ' +
       '`sendMessage` posts to channel roots, never here. `path` is relative to your workspace root; put files there ' +
       'first. Images only (PNG, JPEG, or WEBP — not GIF), decided from the file bytes, not the name. The optional ' +
-      '`caption` is plain text (max 1000 chars, mentions are neutralized); write everything else in your ordinary ' +
+      '`caption` is plain text (max 1000 chars; mention syntax is neutralized, though a bare Telegram @username ' +
+      'may still notify); write everything else in your ordinary ' +
       'reply. The image posts immediately, so it may appear before your streamed reply finishes. If the result says ' +
       'the upload MAY have been delivered, do NOT retry — report that instead.',
     inputSchema: obj(

--- a/packages/daemon/src/platforms/send-queue.ts
+++ b/packages/daemon/src/platforms/send-queue.ts
@@ -13,6 +13,12 @@
  * abandoned call's promise still settles in the background; the caller just sees a
  * timeout rejection (which, for a progress/plan post, the daemon treats as "no ts").
  */
+/** True for the queue's own abandonment rejection — the task KEEPS RUNNING and may still land,
+ *  so a caller must report "may have been sent", never "nothing was sent". */
+export function isSendQueueTimeout(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { sendQueueTimeout?: unknown }).sendQueueTimeout === true
+}
+
 export class PlatformSendQueue {
   private chain: Promise<unknown> = Promise.resolve()
   // -inf so the very first task never waits, regardless of the clock's origin.
@@ -48,7 +54,11 @@ export class PlatformSendQueue {
       const timer = setTimeout(() => {
         if (settled) return
         settled = true
-        reject(new Error(`PlatformSendQueue: task exceeded ${this.taskTimeoutMs}ms — abandoned`))
+        reject(
+          Object.assign(new Error(`PlatformSendQueue: task exceeded ${this.taskTimeoutMs}ms — abandoned`), {
+            sendQueueTimeout: true
+          })
+        )
       }, this.taskTimeoutMs)
       p.then(
         (v) => {

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -12,7 +12,8 @@ import { integrationCore, platformIntegrationConfig } from '../platforms/integra
 import { normalizeSlackEvent, toAttachment, type SlackFile, type SlackMessageEvent } from './normalize.js'
 import type { Attachment, NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
-import { PlatformSendQueue } from '../platforms/send-queue.js'
+import { isSendQueueTimeout, PlatformSendQueue } from '../platforms/send-queue.js'
+import type { UploadAnchor, UploadFailReason, UploadOutcome } from '../mcp/ops/context.js'
 import {
   STATUS_ACTION,
   ELICIT_ACTION_PREFIX,
@@ -500,6 +501,17 @@ const CUSTOM_USERNAME_REPROBE_MS = 5 * 60_000
 /** Per-request bound on every Slack egress call. Shared with the byte upload, which rides the
  *  same serial queue and would otherwise block all delivery on undici's 300 s defaults. */
 const SLACK_API_TIMEOUT_MS = 30_000
+
+/** Map a Slack API error to the port's typed failure vocabulary — every arm already had the
+ *  raw material (`missing_scope` payloads, stable error codes); this only names them. */
+function classifySlackUploadError(err: unknown): UploadFailReason {
+  if (missingScopesFrom(err).length > 0) return 'missing_scope'
+  const code = slackApiErrorCode(err)
+  if (code === 'message_not_found' || code === 'channel_not_found' || code === 'thread_not_found') return 'not_found'
+  if (code === 'not_in_channel' || code === 'restricted_action' || code === 'access_denied') return 'forbidden'
+  if (code === 'file_size_limit_exceeded' || code === 'too_large') return 'too_large'
+  return 'platform_error'
+}
 
 function proxyDispatcher(): ProxyAgent | undefined {
   const url = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY
@@ -1253,18 +1265,20 @@ export class SlackConnection implements PlatformConnection {
    * message here — `comment` rides as `initial_comment`, and the agent's conversational
    * identity as username/icon, exactly as {@link postChatMessage} applies it to a text post.
    *
-   * Undefined means the share FAILED and nothing is in the conversation. Success carries no
-   * `messageId`: Slack answers with the file and no ts, so a shared file is the one post kind
-   * that cannot anchor a session seed or a paired wake. `fileId` is diagnostic only.
+   * `ok: false` means the share FAILED and nothing is in the conversation, with a typed
+   * reason — `indeterminate` alone means the queue abandoned a still-running upload that may
+   * yet land. Success carries no `messageId`: Slack answers with the file and no ts, so a
+   * shared file is the one post kind that cannot anchor a session seed or a paired wake.
    */
   async uploadFile(
     channel: string,
     file: { bytes: Buffer; name: string; mimeType?: string },
     comment?: string,
-    threadTs?: string,
+    anchor?: UploadAnchor,
     options?: SlackPostOptions
-  ): Promise<{ messageId?: string; fileId?: string } | undefined> {
-    return this.queue.enqueue(async () => {
+  ): Promise<UploadOutcome> {
+    const threadTs = anchor?.thread
+    const task: Promise<UploadOutcome> = this.queue.enqueue(async () => {
       try {
         const reserved = await this.app.client.files.getUploadURLExternal({
           filename: file.name,
@@ -1274,9 +1288,10 @@ export class SlackConnection implements PlatformConnection {
         const fileId = reserved.file_id
         if (!uploadUrl || !fileId) {
           this.deps.log?.debug(`slack: uploadFile got no upload url for ${file.name}`)
-          return undefined
+          return { ok: false, reason: 'platform_error' }
         }
-        if (!(await this.putUploadBytes(uploadUrl, file))) return undefined
+        const put = await this.putUploadBytes(uploadUrl, file)
+        if (!put.ok) return put
         // Sharing is what makes the file a message; without `channel_id` it stays a private
         // upload nobody can see. `thread_ts` must be the PARENT's ts, never a reply's.
         // A CAPTION IS MRKDWN HERE, unlike every other send in this file. `postMessage` renders
@@ -1292,19 +1307,28 @@ export class SlackConnection implements PlatformConnection {
           ...(comment ? { initial_comment: comment } : {})
         }
         await this.completeUpload(share, options)
-        return { fileId }
+        return { ok: true }
       } catch (err) {
         this.rememberMissingScopes(err)
         this.deps.log?.debug(`slack: uploadFile ${file.name} → ch=${channel} failed: ${(err as Error).message}`)
-        return undefined
+        return { ok: false, reason: classifySlackUploadError(err) }
       }
     })
+    // The queue abandons a task at 30 s but the task KEEPS RUNNING — the share may still
+    // land, so this must not read as "nothing was sent" (a retry would double-post).
+    return task.catch((err) => ({
+      ok: false,
+      reason: isSendQueueTimeout(err) ? 'indeterminate' : 'platform_error'
+    }))
   }
 
   /** Step 2 of the upload: POST the bytes to the reserved URL. It is NOT a Slack API
    *  endpoint (no token, no JSON envelope), so it goes out through undici with the same
    *  proxy dispatcher the Web API client uses rather than through `this.app.client`. */
-  private async putUploadBytes(uploadUrl: string, file: { bytes: Buffer; name: string }): Promise<boolean> {
+  private async putUploadBytes(
+    uploadUrl: string,
+    file: { bytes: Buffer; name: string }
+  ): Promise<{ ok: true } | { ok: false; reason: UploadFailReason }> {
     const form = new FormData()
     form.append('file', new Blob([new Uint8Array(file.bytes)]), file.name)
     // This runs inside the serial send queue, so it carries the same bound the WebClient
@@ -1327,9 +1351,9 @@ export class SlackConnection implements PlatformConnection {
       await res.body?.cancel().catch(() => {})
       if (!res.ok) {
         this.deps.log?.debug(`slack: uploadFile byte POST for ${file.name} → HTTP ${res.status}`)
-        return false
+        return { ok: false, reason: res.status === 413 ? 'too_large' : 'platform_error' }
       }
-      return true
+      return { ok: true }
     } finally {
       // Unlike the two long-lived clients, this agent serves one request — closing it keeps
       // a proxied deployment from leaking a keep-alive socket pool per forward.

--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -3,9 +3,20 @@ import type { Agent } from '../agents/agent-schema.js'
 import { platformIntegrationConfig } from '../platforms/integration-config.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
-import { PlatformSendQueue } from '../platforms/send-queue.js'
+import { isSendQueueTimeout, PlatformSendQueue } from '../platforms/send-queue.js'
+import type { UploadAnchor, UploadFailReason, UploadOutcome } from '../mcp/ops/context.js'
 import { isTelegramMembershipServiceMessage, normalizeTelegramMessage, type TelegramMessage } from './normalize.js'
 import type { PlatformConnection } from '../platforms/contract.js'
+
+/** Map a Telegram Bot API error to the port's typed failure vocabulary, from its description. */
+function classifyTelegramUploadError(err: unknown): UploadFailReason {
+  const text = `${(err as { description?: string }).description ?? ''} ${(err as Error).message ?? ''}`
+  if (/not found|not enough rights to send|chat not found/i.test(text) && /chat|topic|thread|message/i.test(text))
+    return 'not_found'
+  if (/too (big|large)|file is too|entity too large/i.test(text)) return 'too_large'
+  if (/not enough rights|forbidden|bot was kicked|have no rights/i.test(text)) return 'forbidden'
+  return 'platform_error'
+}
 
 /** Telegram truncates a caption past this instead of rejecting it, so we never send one longer. */
 const TELEGRAM_CAPTION_LIMIT = 1024
@@ -152,12 +163,20 @@ export interface TelegramApi {
   sendPhoto(
     chatId: number | string,
     photo: InputFile,
-    opts?: { message_thread_id?: number; caption?: string }
+    opts?: {
+      message_thread_id?: number
+      caption?: string
+      reply_parameters?: { message_id: number; allow_sending_without_reply?: boolean }
+    }
   ): Promise<{ message_id: number }>
   sendDocument(
     chatId: number | string,
     document: InputFile,
-    opts?: { message_thread_id?: number; caption?: string }
+    opts?: {
+      message_thread_id?: number
+      caption?: string
+      reply_parameters?: { message_id: number; allow_sending_without_reply?: boolean }
+    }
   ): Promise<{ message_id: number }>
   answerCallbackQuery(callbackQueryId: string, opts?: { text?: string }): Promise<unknown>
   sendChatAction(chatId: number | string, action: string): Promise<unknown>
@@ -359,41 +378,54 @@ export class TelegramConnection implements PlatformConnection {
    * dimensions, over the size cap) leaves the chat untouched instead of stranding a caption
    * for an image that never arrived. It reads below the image; that is the cost.
    *
-   * Returns the FILE message's id — the post a reply to this send threads from.
+   * `anchor.replyTo` is what PLACES the post in a non-forum group — the session thread key
+   * there is deliberately non-numeric and cannot address anything — while a numeric
+   * `anchor.thread` selects a forum topic. Both apply to the file and the overflow caption
+   * alike. Returns the FILE message's id — the post a reply to this send threads from.
    */
   async uploadFile(
     channel: string,
     file: { bytes: Buffer; name: string; mimeType?: string },
     comment?: string,
-    threadTs?: string
-  ): Promise<{ messageId?: string } | undefined> {
-    const thread = threadTs != null && /^\d+$/.test(threadTs) ? Number(threadTs) : undefined
-    const threadOpt = thread !== undefined ? { message_thread_id: thread } : {}
+    anchor?: UploadAnchor,
+    _identity?: unknown
+  ): Promise<UploadOutcome> {
+    const thread = anchor?.thread != null && /^\d+$/.test(anchor.thread) ? Number(anchor.thread) : undefined
+    const placeOpt = {
+      ...(thread !== undefined ? { message_thread_id: thread } : {}),
+      ...(anchor?.replyTo !== undefined
+        ? { reply_parameters: { message_id: anchor.replyTo, allow_sending_without_reply: true } }
+        : {})
+    }
     const inCaption = comment && comment.length <= TELEGRAM_CAPTION_LIMIT ? comment : undefined
     const asOwnMessage = comment && !inCaption ? comment : undefined
-    return this.queue.enqueue(async () => {
+    const task: Promise<UploadOutcome> = this.queue.enqueue(async () => {
       let sentId: string | undefined
       try {
         const input = new InputFile(file.bytes, file.name)
-        const opts = { ...threadOpt, ...(inCaption ? { caption: inCaption } : {}) }
+        const opts = { ...placeOpt, ...(inCaption ? { caption: inCaption } : {}) }
         const res = file.mimeType?.startsWith('image/')
           ? await this.bot.api.sendPhoto(channel, input, opts)
           : await this.bot.api.sendDocument(channel, input, opts)
         sentId = res?.message_id != null ? String(res.message_id) : undefined
       } catch (err) {
         this.deps.log?.debug(`telegram: uploadFile ${file.name} → ch=${channel} failed: ${(err as Error).message}`)
-        return undefined
+        return { ok: false, reason: classifyTelegramUploadError(err) }
       }
-      const anchor = sentId !== undefined ? { messageId: sentId } : {}
-      if (!asOwnMessage) return anchor
+      const posted = { ok: true as const, ...(sentId !== undefined ? { messageId: sentId } : {}) }
+      if (!asOwnMessage) return posted
       try {
-        await this.bot.api.sendMessage(channel, asOwnMessage, threadOpt)
-        return anchor
+        await this.bot.api.sendMessage(channel, asOwnMessage, placeOpt)
+        return posted
       } catch (err) {
         this.deps.log?.debug(`telegram: uploadFile caption failed (ch=${channel}): ${(err as Error).message}`)
-        return { ...anchor, warning: 'the file was sent, but its caption was too long to attach and did not post' }
+        return { ...posted, warning: 'the file was sent, but its caption was too long to attach and did not post' }
       }
     })
+    return task.catch((err) => ({
+      ok: false,
+      reason: isSendQueueTimeout(err) ? 'indeterminate' : 'platform_error'
+    }))
   }
 
   /**

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -211,8 +211,8 @@ describe('executeTool: sendMessage (channel post)', () => {
     const bytes = Buffer.from('PNGBYTES')
     const resolved = { bytes, name: 'shot.png', mimeType: 'image/png' }
     // Slack's share answers with the file and no ts; the other three answer with a message.
-    const anchorless = () => fakeGateway({ uploadFile: vi.fn(async () => ({})) })
-    const anchoring = () => fakeGateway({ uploadFile: vi.fn(async () => ({ messageId: 'ts-999' })) })
+    const anchorless = () => fakeGateway({ uploadFile: vi.fn(async () => ({ ok: true as const })) })
+    const anchoring = () => fakeGateway({ uploadFile: vi.fn(async () => ({ ok: true as const, messageId: 'ts-999' })) })
     const resolves = () => ({
       resolveAttachment: vi.fn(async (_c: SessionContext, name: string) => (name === 'shot.png' ? resolved : undefined))
     })
@@ -259,7 +259,7 @@ describe('executeTool: sendMessage (channel post)', () => {
       // The file landed and the caption did not. Neither "sent" nor "nothing was sent" is
       // true, and only the agent can decide what to do about it inside this turn.
       const gw = fakeGateway({
-        uploadFile: vi.fn(async () => ({ messageId: 'ts-999', warning: 'its caption did not post' }))
+        uploadFile: vi.fn(async () => ({ ok: true as const, messageId: 'ts-999', warning: 'its caption did not post' }))
       })
       const { deps: d } = deps(gw)
       Object.assign(d, resolves())
@@ -275,12 +275,14 @@ describe('executeTool: sendMessage (channel post)', () => {
     it('raises a refused share instead of reporting it as sent', async () => {
       // Nothing reached the conversation, so this must not read as a delivered message —
       // a silently dropped image is the one outcome the agent cannot detect on its own.
-      const gw = fakeGateway({ uploadFile: vi.fn(async () => undefined) })
+      const gw = fakeGateway({
+        uploadFile: vi.fn(async () => ({ ok: false as const, reason: 'forbidden' as const }))
+      })
       const { deps: d, recorded } = deps(gw)
       Object.assign(d, resolves())
       await expect(
         executeTool(ctx, 'sendMessage', { channel: 'C_OTHER', attachment: 'shot.png', message: 'hi' }, d)
-      ).rejects.toThrow(/rejected the file "shot.png"/)
+      ).rejects.toThrow(/rejected the file "shot.png" \(forbidden\)/)
       expect(recorded).toEqual([])
     })
 
@@ -303,6 +305,159 @@ describe('executeTool: sendMessage (channel post)', () => {
         executeTool(ctx, 'sendMessage', { channel: 'C_OTHER', attachment: 'shot.png', message: 'hi' }, d)
       ).rejects.toThrow(/cannot post files/)
       expect(gw.postMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  // shareFile (agent-authored-attachments.md §3): the produced-file share into the CURRENT
+  // conversation — coordinate-less, fenced, budgeted, and never a session seed.
+  describe('shareFile', () => {
+    const image = {
+      ok: true as const,
+      bytes: Buffer.from('PNGBYTES'),
+      name: 'chart.png',
+      mimeType: 'image/png',
+      sha256: 'a'.repeat(64)
+    }
+    const target = {
+      ok: true as const,
+      platform: 'slack',
+      integrationId: 'int-1',
+      channel: 'C_CURRENT',
+      thread: '111.1',
+      replyTo: 41
+    }
+    function shareDeps(over: Partial<OpsDeps> = {}) {
+      const gw = fakeGateway({ uploadFile: vi.fn(async () => ({ ok: true as const, messageId: 'ts-42' })) })
+      const shares: unknown[] = []
+      const d = makeDeps({
+        gatewayFor: () => gw,
+        shareTarget: () => target,
+        readWorkspaceImage: async (_c, path) => (path === 'out/chart.png' ? image : { ok: false, reason: 'not-found' }),
+        chargeShareBudget: vi.fn(() => ({ ok: true as const, release: vi.fn() })),
+        recordShare: async (_c, row) => {
+          shares.push(row)
+        },
+        ...over
+      })
+      return { d, gw, shares }
+    }
+
+    it('posts into the active turn’s own conversation with the trusted anchor and identity', async () => {
+      const { d, gw, shares } = shareDeps()
+      const res = (await executeTool(
+        ctx,
+        'shareFile',
+        { path: 'out/chart.png', caption: 'revenue by week' },
+        d
+      )) as Record<string, unknown>
+
+      expect(gw.uploadFile).toHaveBeenCalledWith(
+        'C_CURRENT',
+        { bytes: image.bytes, name: 'chart.png', mimeType: 'image/png' },
+        'revenue by week',
+        { thread: '111.1', replyTo: 41 },
+        authorIdentity
+      )
+      expect(res).toMatchObject({
+        ok: true,
+        shared: { path: 'out/chart.png', mimeType: 'image/png', bytes: image.bytes.byteLength },
+        post: { platform: 'slack', channel: 'C_CURRENT', ts: 'ts-42' }
+      })
+      // Provenance row: caption + the [shared: …] marker, with the bytes for console replay.
+      expect(shares).toEqual([
+        expect.objectContaining({
+          ts: 'ts-42',
+          text: expect.stringContaining('[shared: out/chart.png (image/png, 8 bytes, sha256:aaaaaaaaaaaaaaaa)]'),
+          image: expect.objectContaining({ mimeType: 'image/png' })
+        })
+      ])
+    })
+
+    it('neutralizes mention syntax in the caption — it labels a file, it must not ping', async () => {
+      const { d, gw } = shareDeps()
+      await executeTool(ctx, 'shareFile', { path: 'out/chart.png', caption: 'cc <@U1> @here' }, d)
+      const caption = (gw.uploadFile as ReturnType<typeof vi.fn>).mock.calls[0]![2] as string
+      expect(caption).not.toContain('<@U1>')
+      expect(caption).not.toContain('@here')
+      expect(caption).toContain('U1')
+    })
+
+    it('refuses a headless turn — its whole point is that nothing is posted', async () => {
+      const { d, gw } = shareDeps({ shareTarget: () => ({ ok: false, reason: 'headless' }) })
+      await expect(executeTool(ctx, 'shareFile', { path: 'out/chart.png' }, d)).rejects.toThrow(/headless/)
+      expect(gw.uploadFile).not.toHaveBeenCalled()
+    })
+
+    it('refuses a postless A2A child, whose live gateway would otherwise pass the port probe', async () => {
+      const { d } = shareDeps({ shareTarget: () => ({ ok: false, reason: 'no-conversation' }) })
+      await expect(executeTool(ctx, 'shareFile', { path: 'out/chart.png' }, d)).rejects.toThrow(
+        /no platform conversation/
+      )
+    })
+
+    it('refuses before any file I/O when the platform cannot host files', async () => {
+      const reads = vi.fn(async () => image)
+      const { d } = shareDeps({ gatewayFor: () => fakeGateway(), readWorkspaceImage: reads })
+      await expect(executeTool(ctx, 'shareFile', { path: 'out/chart.png' }, d)).rejects.toThrow(/cannot host files/)
+      expect(reads).not.toHaveBeenCalled()
+    })
+
+    it('names GIF in its refusal — a plausible find-me-images result, not a generic non-image', async () => {
+      const { d } = shareDeps({ readWorkspaceImage: async () => ({ ok: false, reason: 'gif' }) })
+      await expect(executeTool(ctx, 'shareFile', { path: 'anim.gif' }, d)).rejects.toThrow(/GIF is not supported/)
+    })
+
+    it('refuses over the per-turn budget and never uploads', async () => {
+      const { d, gw } = shareDeps({ chargeShareBudget: () => ({ ok: false }) })
+      await expect(executeTool(ctx, 'shareFile', { path: 'out/chart.png' }, d)).rejects.toThrow(/upload budget/)
+      expect(gw.uploadFile).not.toHaveBeenCalled()
+    })
+
+    it('releases the budget charge when the upload is refused, and names the reason', async () => {
+      const release = vi.fn()
+      const { d } = shareDeps({
+        gatewayFor: () =>
+          fakeGateway({ uploadFile: vi.fn(async () => ({ ok: false as const, reason: 'missing_scope' as const })) }),
+        chargeShareBudget: () => ({ ok: true, release })
+      })
+      await expect(executeTool(ctx, 'shareFile', { path: 'out/chart.png' }, d)).rejects.toThrow(
+        /file-upload permission/
+      )
+      expect(release).toHaveBeenCalledOnce()
+    })
+
+    it('says MAY-have-landed on an indeterminate outcome, and forbids the retry', async () => {
+      const { d, shares } = shareDeps({
+        gatewayFor: () =>
+          fakeGateway({ uploadFile: vi.fn(async () => ({ ok: false as const, reason: 'indeterminate' as const })) })
+      })
+      await expect(executeTool(ctx, 'shareFile', { path: 'out/chart.png' }, d)).rejects.toThrow(/do NOT retry/)
+      expect(shares).toEqual([])
+    })
+
+    it('refuses an over-long caption up front, before anything is read or sent', async () => {
+      const reads = vi.fn(async () => image)
+      const { d } = shareDeps({ readWorkspaceImage: reads })
+      await expect(
+        executeTool(ctx, 'shareFile', { path: 'out/chart.png', caption: 'x'.repeat(1001) }, d)
+      ).rejects.toThrow(/1000 characters/)
+      expect(reads).not.toHaveBeenCalled()
+    })
+
+    it('surfaces a partial send (caption lost after the file) as a notice on success', async () => {
+      const { d } = shareDeps({
+        gatewayFor: () =>
+          fakeGateway({
+            uploadFile: vi.fn(async () => ({ ok: true as const, warning: 'part of its caption did not post' }))
+          })
+      })
+      const res = (await executeTool(ctx, 'shareFile', { path: 'out/chart.png', caption: 'hi' }, d)) as Record<
+        string,
+        unknown
+      >
+      expect(res).toMatchObject({ ok: true, notice: expect.stringContaining('part of its caption') })
+      // No message id came back (Slack), so the transcript ts is synthesized like sendMessage's.
+      expect(res).toMatchObject({ post: expect.objectContaining({ ts: 'local-1000' }) })
     })
   })
 

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -375,11 +375,29 @@ describe('executeTool: sendMessage (channel post)', () => {
 
     it('neutralizes mention syntax in the caption — it labels a file, it must not ping', async () => {
       const { d, gw } = shareDeps()
-      await executeTool(ctx, 'shareFile', { path: 'out/chart.png', caption: 'cc <@U1> @here' }, d)
+      await executeTool(
+        ctx,
+        'shareFile',
+        { path: 'out/chart.png', caption: 'cc <@U1> @here <at user_id="all">everyone</at>' },
+        d
+      )
       const caption = (gw.uploadFile as ReturnType<typeof vi.fn>).mock.calls[0]![2] as string
       expect(caption).not.toContain('<@U1>')
       expect(caption).not.toContain('@here')
+      expect(caption).not.toContain('<at ')
       expect(caption).toContain('U1')
+    })
+
+    it('reports a failed transcript record as a notice, never as a failed share', async () => {
+      // The image is already in the conversation; a thrown error here would invite the
+      // double-posting retry the outcome vocabulary exists to prevent.
+      const { d } = shareDeps({
+        recordShare: async () => {
+          throw new Error('store closed')
+        }
+      })
+      const res = (await executeTool(ctx, 'shareFile', { path: 'out/chart.png' }, d)) as Record<string, unknown>
+      expect(res).toMatchObject({ ok: true, notice: expect.stringContaining('transcript') })
     })
 
     it('refuses a headless turn — its whole point is that nothing is posted', async () => {

--- a/packages/daemon/test/platform-upload-file.test.ts
+++ b/packages/daemon/test/platform-upload-file.test.ts
@@ -25,30 +25,45 @@ describe('outbound file sends', () => {
       return { conn, api }
     }
 
-    it('sends an image as a photo so it previews inline, captioned and threaded', async () => {
+    it('sends an image as a photo so it previews inline, captioned, topic-threaded, and by reply', async () => {
+      // `replyTo` is what PLACES the post in a non-forum group — without it the file lands at
+      // the chat ROOT, the outcome the design's §2 exists to rule out.
       const { conn, api } = connection()
-      await expect(conn.uploadFile('-100123', png, 'from slack', '77')).resolves.toEqual({ messageId: '11' })
+      await expect(conn.uploadFile('-100123', png, 'from slack', { thread: '77', replyTo: 41 })).resolves.toEqual({
+        ok: true,
+        messageId: '11'
+      })
       expect(api.sendPhoto).toHaveBeenCalledWith('-100123', expect.anything(), {
         message_thread_id: 77,
+        reply_parameters: { message_id: 41, allow_sending_without_reply: true },
         caption: 'from slack'
       })
       expect(api.sendDocument).not.toHaveBeenCalled()
       expect(api.sendMessage).not.toHaveBeenCalled()
     })
 
+    it('ignores a non-numeric thread (the tg:/dm session keys address nothing)', async () => {
+      const { conn, api } = connection()
+      await conn.uploadFile('-100123', png, undefined, { thread: 'tg:99', replyTo: 99 })
+      expect(api.sendPhoto).toHaveBeenCalledWith('-100123', expect.anything(), {
+        reply_parameters: { message_id: 99, allow_sending_without_reply: true }
+      })
+    })
+
     it('sends anything else as a document, the only form that preserves the bytes', async () => {
       const { conn, api } = connection()
-      await expect(conn.uploadFile('-100123', zip, 'logs')).resolves.toEqual({ messageId: '12' })
+      await expect(conn.uploadFile('-100123', zip, 'logs')).resolves.toEqual({ ok: true, messageId: '12' })
       expect(api.sendDocument).toHaveBeenCalledOnce()
       expect(api.sendPhoto).not.toHaveBeenCalled()
     })
 
-    it('posts an over-cap caption as its own message, after the file', async () => {
+    it('posts an over-cap caption as its own message, after the file and with the same placement', async () => {
       const { conn, api } = connection()
       const long = 'x'.repeat(1025)
-      await conn.uploadFile('-100123', png, long)
-      expect(api.sendMessage).toHaveBeenCalledWith('-100123', long, {})
-      expect(api.sendPhoto.mock.calls[0]![2]).toEqual({})
+      await conn.uploadFile('-100123', png, long, { replyTo: 41 })
+      expect(api.sendMessage).toHaveBeenCalledWith('-100123', long, {
+        reply_parameters: { message_id: 41, allow_sending_without_reply: true }
+      })
       // File first: a photo Telegram rejects must not leave a caption standing alone.
       expect(api.sendPhoto.mock.invocationCallOrder[0]!).toBeLessThan(api.sendMessage.mock.invocationCallOrder[0]!)
     })
@@ -57,15 +72,16 @@ describe('outbound file sends', () => {
       const { conn, api } = connection()
       api.sendMessage.mockRejectedValueOnce(new Error('rate limited'))
       await expect(conn.uploadFile('-100123', png, 'x'.repeat(1025))).resolves.toEqual({
+        ok: true,
         messageId: '11',
         warning: expect.stringContaining('caption')
       })
     })
 
-    it('reports a refused send instead of throwing into the caller', async () => {
+    it('classifies a refused send instead of throwing into the caller', async () => {
       const { conn, api } = connection()
-      api.sendPhoto.mockRejectedValueOnce(new Error('chat not found'))
-      await expect(conn.uploadFile('-100123', png, 'hi')).resolves.toBeUndefined()
+      api.sendPhoto.mockRejectedValueOnce(Object.assign(new Error('Bad Request'), { description: 'chat not found' }))
+      await expect(conn.uploadFile('-100123', png, 'hi')).resolves.toEqual({ ok: false, reason: 'not_found' })
     })
   })
 
@@ -78,17 +94,20 @@ describe('outbound file sends', () => {
         sendIntervalMs: 0
       })
       let n = 0
-      const channel = { send: vi.fn(async () => ({ id: `m${++n}` })) }
+      const channel = { send: vi.fn(async (_payload: unknown) => ({ id: `m${++n}` })) }
       ;(conn as unknown as { client: unknown }).client = { channels: { fetch: async () => channel } }
       return { conn, channel }
     }
 
-    it('carries the bytes on the message itself, so the caption and file are one post', async () => {
+    it('carries the bytes on the message itself, with every ping suppressed', async () => {
+      // allowedMentions parse:[] is the platform-native half of caption-mention escaping —
+      // a model-authored caption must not be able to ping.
       const { conn, channel } = connection()
-      await expect(conn.uploadFile('C1', png, 'look at this')).resolves.toEqual({ messageId: 'm1' })
+      await expect(conn.uploadFile('C1', png, 'look at this')).resolves.toEqual({ ok: true, messageId: 'm1' })
       expect(channel.send).toHaveBeenCalledWith({
         content: 'look at this',
-        files: [{ attachment: png.bytes, name: 'shot.png' }]
+        files: [{ attachment: png.bytes, name: 'shot.png' }],
+        allowedMentions: { parse: [] }
       })
     })
 
@@ -104,15 +123,22 @@ describe('outbound file sends', () => {
       const { conn, channel } = connection()
       channel.send.mockImplementationOnce(async () => ({ id: 'm1' })).mockRejectedValueOnce(new Error('boom'))
       await expect(conn.uploadFile('C1', png, 'y'.repeat(2500))).resolves.toEqual({
+        ok: true,
         messageId: 'm1',
         warning: expect.stringContaining('caption')
       })
     })
 
-    it('reports an unreachable channel rather than claiming delivery', async () => {
+    it('classifies an unreachable channel rather than claiming delivery', async () => {
       const { conn } = connection()
       ;(conn as unknown as { client: unknown }).client = { channels: { fetch: async () => null } }
-      await expect(conn.uploadFile('C1', png, 'hi')).resolves.toBeUndefined()
+      await expect(conn.uploadFile('C1', png, 'hi')).resolves.toEqual({ ok: false, reason: 'not_found' })
+    })
+
+    it('classifies an over-limit attachment from Discord’s own error code', async () => {
+      const { conn, channel } = connection()
+      channel.send.mockRejectedValueOnce(Object.assign(new Error('Request entity too large'), { code: 40005 }))
+      await expect(conn.uploadFile('C1', png, 'hi')).resolves.toEqual({ ok: false, reason: 'too_large' })
     })
   })
 
@@ -153,24 +179,19 @@ describe('outbound file sends', () => {
     })
 
     it('sends the image before the caption, and anchors on it', async () => {
-      // Order is the whole point: the caption is a second message, so putting it first would
-      // strand it in the chat whenever the image send then failed.
       const { conn, api } = connection()
-      await expect(conn.uploadFile('oc_1', png, 'from slack')).resolves.toEqual({ messageId: 'om_img' })
+      await expect(conn.uploadFile('oc_1', png, 'from slack')).resolves.toEqual({ ok: true, messageId: 'om_img' })
       expect(api.createText).toHaveBeenCalledWith('oc_1', 'from slack')
       expect(api.createImage.mock.invocationCallOrder[0]!).toBeLessThan(api.createText.mock.invocationCallOrder[0]!)
-    })
-
-    it('anchors on the image when there is no caption at all', async () => {
-      const { conn, api } = connection()
-      await expect(conn.uploadFile('oc_1', png)).resolves.toEqual({ messageId: 'om_img' })
-      expect(api.createText).not.toHaveBeenCalled()
     })
 
     it('reports nothing-sent when the image fails, without having posted the caption', async () => {
       const { conn, api } = connection()
       api.createImage.mockRejectedValueOnce(new Error('bad key'))
-      await expect(conn.uploadFile('oc_1', png, 'from slack')).resolves.toBeUndefined()
+      await expect(conn.uploadFile('oc_1', png, 'from slack')).resolves.toEqual({
+        ok: false,
+        reason: 'platform_error'
+      })
       expect(api.createText).not.toHaveBeenCalled()
     })
 
@@ -178,20 +199,20 @@ describe('outbound file sends', () => {
       const { conn, api } = connection()
       api.createText.mockRejectedValueOnce(new Error('rate limited'))
       await expect(conn.uploadFile('oc_1', png, 'from slack')).resolves.toEqual({
+        ok: true,
         messageId: 'om_img',
         warning: 'the image was sent, but its caption did not post'
       })
     })
 
     it('says PART of the caption when earlier chunks already landed', async () => {
-      // Whole-vs-part decides whether re-sending duplicates: an agent told the whole caption
-      // failed would post the chunks that did land a second time.
       const { conn, api } = connection()
       api.createText
         .mockImplementationOnce(async () => ({ messageId: 'om_text' }))
         .mockRejectedValueOnce(new Error('rate limited'))
       const long = 'z'.repeat(6000)
       await expect(conn.uploadFile('oc_1', png, long)).resolves.toEqual({
+        ok: true,
         messageId: 'om_img',
         warning: 'the image was sent, but part of its caption did not post'
       })
@@ -199,14 +220,34 @@ describe('outbound file sends', () => {
 
     it('threads both messages off a topic anchor', async () => {
       const { conn, api } = connection()
-      await conn.uploadFile('oc_1', png, 'hi', 'om_root')
+      await conn.uploadFile('oc_1', png, 'hi', { thread: 'om_root' })
       expect(api.replyText).toHaveBeenCalledWith('om_root', 'hi')
       expect(api.replyImage).toHaveBeenCalledWith('om_root', 'img_1')
     })
 
+    it('treats a DM anchor (the chat id) as the root post it is', async () => {
+      const { conn, api } = connection()
+      await expect(conn.uploadFile('oc_1', png, undefined, { thread: 'oc_1' })).resolves.toEqual({
+        ok: true,
+        messageId: 'om_img'
+      })
+      expect(api.createImage).toHaveBeenCalledWith('oc_1', 'img_1')
+    })
+
+    it('REFUSES an anchor it cannot honor instead of silently posting at the chat root', async () => {
+      // sendImage prefix-sniffs; an unrecognized anchor (a hook turn's hookId:deliveryKey)
+      // would otherwise become a brand-new topic reported as success.
+      const { conn, api } = connection()
+      await expect(conn.uploadFile('oc_1', png, 'hi', { thread: 'hook-1:d-2' })).resolves.toEqual({
+        ok: false,
+        reason: 'not_found'
+      })
+      expect(api.uploadImage).not.toHaveBeenCalled()
+    })
+
     it('refuses a non-image, which its file endpoint cannot type honestly', async () => {
       const { conn, api } = connection()
-      await expect(conn.uploadFile('oc_1', zip, 'logs')).resolves.toBeUndefined()
+      await expect(conn.uploadFile('oc_1', zip, 'logs')).resolves.toEqual({ ok: false, reason: 'platform_error' })
       expect(api.uploadImage).not.toHaveBeenCalled()
     })
   })

--- a/packages/daemon/test/slack-upload-file.test.ts
+++ b/packages/daemon/test/slack-upload-file.test.ts
@@ -50,11 +50,17 @@ describe('SlackConnection.uploadFile', () => {
 
     const bytes = Buffer.from('PNGBYTES')
     await expect(
-      conn.uploadFile('C1', { bytes, name: 'shot.png' }, 'from telegram', '111.1', {
-        username: 'Scout',
-        icon_url: 'https://example.test/a.png'
-      })
-    ).resolves.toEqual({ fileId: 'F1' })
+      conn.uploadFile(
+        'C1',
+        { bytes, name: 'shot.png' },
+        'from telegram',
+        { thread: '111.1' },
+        {
+          username: 'Scout',
+          icon_url: 'https://example.test/a.png'
+        }
+      )
+    ).resolves.toEqual({ ok: true })
 
     expect(getUploadURLExternal).toHaveBeenCalledWith({ filename: 'shot.png', length: bytes.byteLength })
     expect(undici.fetch).toHaveBeenCalledWith(
@@ -91,7 +97,7 @@ describe('SlackConnection.uploadFile', () => {
 
     await expect(
       conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi', undefined, { username: 'Scout' })
-    ).resolves.toEqual({ fileId: 'F1' })
+    ).resolves.toEqual({ ok: true })
     expect(completeUploadExternal).toHaveBeenCalledTimes(2)
     expect(completeUploadExternal.mock.calls[1]![0]).not.toHaveProperty('username')
   })
@@ -114,17 +120,37 @@ describe('SlackConnection.uploadFile', () => {
     const completeUploadExternal = vi.fn(async () => ({ files: [] }))
     const conn = connWith({ getUploadURLExternal: async () => ({}), completeUploadExternal })
 
-    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toBeUndefined()
+    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
+      ok: false,
+      reason: 'platform_error'
+    })
     expect(completeUploadExternal).not.toHaveBeenCalled()
   })
 
-  it('reports failure instead of throwing into the send path', async () => {
+  it('classifies failures instead of throwing into the send path', async () => {
     const conn = connWith({
       getUploadURLExternal: async () => {
         throw new Error('slack down')
       },
       completeUploadExternal: async () => ({ files: [] })
     })
-    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toBeUndefined()
+    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
+      ok: false,
+      reason: 'platform_error'
+    })
+  })
+
+  it('classifies a missing files:write scope, the likeliest first-run failure', async () => {
+    // Operator-fixable, so the reason must be distinguishable from a deleted thread root.
+    const conn = connWith({
+      getUploadURLExternal: async () => {
+        throw Object.assign(new Error('missing_scope'), { data: { error: 'missing_scope', needed: 'files:write' } })
+      },
+      completeUploadExternal: async () => ({ files: [] })
+    })
+    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
+      ok: false,
+      reason: 'missing_scope'
+    })
   })
 })


### PR DESCRIPTION
## What this is

Phase 1 of [`agent-authored-attachments.md`](https://github.com/agentconnect-md/agentconnect/blob/main/docs/designs/agent-authored-attachments.md): **`shareFile`** — an agent posts an image from its workspace into **the conversation it is answering**. The case that motivated the design ("find me some images" → the images appear in that thread) had no surface at all: the ordinary reply is text-only, and every `sendMessage` post lands at a channel root.

## The tool

`shareFile({path, caption?})` — deliberately coordinate-less. The daemon posts from the trusted active-turn context (the postless-wake precedent), so the model cannot name a destination and no new authorization question exists. It posts when called, carries no routing semantics, and **never seeds or re-anchors a session** — the thread already has the one the turn runs in.

## What guards it

- **The workspace browser's own fence** (`canonicalWorkspacePath`: lexical containment + realpath re-verification), a single-shot read, and a magic-byte gate: **PNG/JPEG/WEBP only**, GIF refused **by name** (a plausible find-me-images result whose animation `sendPhoto` would silently strip). Outbound filename and MIME derive from the sniffed bytes, never the model-supplied path.
- **Two synchronous caps**: per-file (own knob, defaulting to `maxAttachmentBytes`) and per-turn, charged before the read so concurrent tool calls cannot race past the budget.
- **Three pre-I/O gates**: headless turns, postless A2A children (whose live gateway passes the port probe — the tell is the synthetic channel), and platforms without the port.
- Captions: bounded to one message, plain text, mention syntax neutralized; Discord additionally suppresses pings natively (`allowedMentions: {parse: []}`).

## The port widenings (from the design's review)

- `uploadFile` gains an **anchor** `{thread?, replyTo?}` — Telegram places by `replyTo` (without it every plain-group share lands at the chat root, the exact outcome §2 rules out), applied to the photo and the overflow caption alike; **Feishu now refuses an anchor it cannot honor** instead of silently posting a new topic.
- The port's failure is **typed**: `missing_scope | too_large | not_found | forbidden | indeterminate | platform_error`. `indeterminate` is the send queue abandoning a still-running upload — the outcome that must read "may have landed, do **not** retry", because a retry double-posts. Classification reuses material the connections already had (scope trackers, permission sniffers, stable error codes).

## Also in this change

- The transcript row carries provenance (path, sniffed type, size, digest) **plus the bytes when they fit the 160 KB transcript budget**, so the console renders the agent's chart exactly as it renders a user's upload.
- The three shipped tool-description sentences that steered agents to channel-root posts are edited (`sendMessage`'s "write your ordinary reply instead" now names `shareFile`; the "you cannot produce an attachment" claims are retracted where they stopped being true).
- `product-conventions.md` gains the user-facing section.
- Sandboxed (cluster) agents get a named deferral — their workspace is phase 2, over the workspace-fs channel the design already located.

## Testing

- `shareFile` handler: happy path (anchor + identity + provenance row), mention neutralization, all three gates, GIF-by-name, budget refusal + release-on-failure, caption bound (pre-I/O), indeterminate wording, partial-send notice, synthesized ts.
- Per-platform port: Telegram replyTo placement (photo + overflow) and non-numeric-thread handling; Discord ping suppression, chunk-split files, 40005 → `too_large`; Feishu anchor refusal, DM anchor, image-first ordering, whole-vs-part caption loss; Slack outcome shape + `missing_scope` classification.
- Workspace `typecheck`, `lint`, `format:check`, full `eval:gates` (28 files / 192 tests), and all 16 touched suites green.

Not exercised against live workspaces; the live checks the design doc lists (§9) still stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
