### PR TITLE
feat(daemon): shareFile reaches a pod agent's workspace

### DIFF
--- a/docs/designs/agent-authored-attachments.md
+++ b/docs/designs/agent-authored-attachments.md
@@ -1,6 +1,6 @@
 # Agent-Authored Attachments
 
-**Status:** Proposed
+**Status:** Implemented through phase 2 (§7's deferrals stand)
 
 [#1323](https://github.com/agentconnect-md/agentconnect/pull/1323) gave the daemon an
 outbound byte path: every chat platform implements `MessageGateway.uploadFile`, and

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2311,7 +2311,17 @@ export class Daemon {
           } catch (err) {
             return { ok: false, reason: err instanceof WorkspaceViolationError ? 'escape' : 'not-found' }
           }
-          const read = await placement.fs.readFileBytes(resolved, cap).catch(() => undefined)
+          // A transport failure must NOT read as absence: "the channel dropped" mid-read is
+          // not evidence the file is missing, and the agent would act on it (regenerate, or
+          // give up). ShimWorkspaceFs already folds true refusals into undefined, so anything
+          // it THROWS is the channel — answer "sandbox unreachable", which invites a retry.
+          let read: Awaited<ReturnType<typeof placement.fs.readFileBytes>> | 'channel-lost'
+          try {
+            read = await placement.fs.readFileBytes(resolved, cap)
+          } catch {
+            read = 'channel-lost'
+          }
+          if (read === 'channel-lost') return { ok: false, reason: 'sandboxed' }
           if (!read) return { ok: false, reason: 'not-found' }
           if ('tooLarge' in read) {
             return { ok: false, reason: 'too-large', detail: `${read.tooLarge} bytes > ${cap}-byte cap` }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -293,7 +293,7 @@ import { z } from 'zod'
 import { isNoResponseBody } from './session/no-response.js'
 import { WorkspaceConflictError } from './cp/workspace-reader.js'
 import { createWorkspaceScope } from './cp/workspace-scope.js'
-import { canonicalWorkspacePath, WorkspaceViolationError } from './workspace/workspace-files.js'
+import { canonicalWorkspacePath, containedWorkspacePath, WorkspaceViolationError } from './workspace/workspace-files.js'
 import type { ShareReadResult, ShareTargetResult } from './mcp/ops/share-file.js'
 import { TaskViolationError } from './cp/task-reader.js'
 import {
@@ -2264,8 +2264,6 @@ export class Daemon {
         return { ok: true, ...target }
       },
       readWorkspaceImage: async (ctx, rel): Promise<ShareReadResult> => {
-        // Phase 2 (pod workspaces over the workspace-fs channel) is designed, not built.
-        if (this.k8sPlane?.workspaceRootFor(ctx.agentId) !== undefined) return { ok: false, reason: 'sandboxed' }
         const scope = createWorkspaceScope({
           workspaces: this.workspaces,
           agentOf: (id) => this.agents.get(id),
@@ -2276,11 +2274,51 @@ export class Daemon {
         // Session-worktree first (an isolated session's files live there), then the agent
         // root: `location(id, sessionId)` answers ONLY for git-repo agents on isolated
         // sessions, and the default config (shared isolation, from-scratch) is the other arm.
+        // For a cluster agent the scope composes the root in POD coordinates.
         const location =
           (await scope.location(ctx.agentId, acpSessionId).catch(() => undefined)) ??
           (await scope.location(ctx.agentId).catch(() => undefined))
         if (!location) return { ok: false, reason: 'not-found' }
         const cap = cfg.limits.maxOutboundFileBytes ?? cfg.limits.maxAttachmentBytes
+        // Sniff + name + digest, shared by both arms: outbound name and MIME come from the
+        // SNIFFED bytes, never the model-supplied path (§4) — Discord renders by extension
+        // alone, so `out/chart` must not land extensionless.
+        const imageOf = (bytes: Buffer): ShareReadResult => {
+          const sniffed = sniffImageMimeType(bytes)
+          if (!sniffed) {
+            const head = bytes.subarray(0, 6).toString('latin1')
+            // GIF gets a refusal that NAMES it (§4) — a plausible find-me-images result whose
+            // animation sendPhoto would silently strip; deferred behind the enum widening.
+            if (head === 'GIF87a' || head === 'GIF89a') return { ok: false, reason: 'gif' }
+            return { ok: false, reason: 'not-image' }
+          }
+          const ext = sniffed === 'image/png' ? 'png' : sniffed === 'image/jpeg' ? 'jpg' : 'webp'
+          const stem = basename(rel).replace(/\.[A-Za-z0-9]+$/, '') || 'image'
+          const sha256 = createHash('sha256').update(bytes).digest('hex')
+          return { ok: true, bytes, name: `${stem}.${ext}`, mimeType: sniffed, sha256 }
+        }
+
+        // Pod arm (design §6): the workspace lives on the sandbox volume, reached over the
+        // fd-anchored workspace-fs channel. The daemon contributes the LEXICAL fence (which
+        // carries the `.git` rule the pod-side check lacks); the symlink guarantee is the
+        // pod's own fd-anchored descent — there is nothing daemon-side to realpath.
+        if (this.k8sPlane?.workspaceRootFor(ctx.agentId) !== undefined) {
+          const placement = this.k8sPlane.workspaceFsFor(ctx.agentId)
+          if (!placement) return { ok: false, reason: 'sandboxed' }
+          let resolved: string
+          try {
+            resolved = containedWorkspacePath(location.root, rel)
+          } catch (err) {
+            return { ok: false, reason: err instanceof WorkspaceViolationError ? 'escape' : 'not-found' }
+          }
+          const read = await placement.fs.readFileBytes(resolved, cap).catch(() => undefined)
+          if (!read) return { ok: false, reason: 'not-found' }
+          if ('tooLarge' in read) {
+            return { ok: false, reason: 'too-large', detail: `${read.tooLarge} bytes > ${cap}-byte cap` }
+          }
+          return imageOf(read.bytes)
+        }
+
         let resolved: string | null
         try {
           resolved = await canonicalWorkspacePath(location.root, rel)
@@ -2298,20 +2336,7 @@ export class Daemon {
         if (bytes.byteLength > cap) {
           return { ok: false, reason: 'too-large', detail: `${bytes.byteLength} bytes > ${cap}-byte cap` }
         }
-        const sniffed = sniffImageMimeType(bytes)
-        if (!sniffed) {
-          const head = bytes.subarray(0, 6).toString('latin1')
-          // GIF gets a refusal that NAMES it (§4) — a plausible find-me-images result whose
-          // animation sendPhoto would silently strip; deferred behind the enum widening.
-          if (head === 'GIF87a' || head === 'GIF89a') return { ok: false, reason: 'gif' }
-          return { ok: false, reason: 'not-image' }
-        }
-        // Outbound name + MIME from the SNIFFED type, never the model-supplied path (§4):
-        // Discord renders by extension alone, so `out/chart` must not land extensionless.
-        const ext = sniffed === 'image/png' ? 'png' : sniffed === 'image/jpeg' ? 'jpg' : 'webp'
-        const stem = basename(rel).replace(/\.[A-Za-z0-9]+$/, '') || 'image'
-        const sha256 = createHash('sha256').update(bytes).digest('hex')
-        return { ok: true, bytes, name: `${stem}.${ext}`, mimeType: sniffed, sha256 }
+        return imageOf(bytes)
       },
       chargeShareBudget: (ctx, bytes) => {
         const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)

--- a/packages/daemon/src/mcp/ops/share-file.ts
+++ b/packages/daemon/src/mcp/ops/share-file.ts
@@ -87,7 +87,7 @@ export function escapeCaptionMentions(caption: string): string {
 
 const READ_REFUSALS: Record<Exclude<ShareReadResult, { ok: true }>['reason'], (path: string, d?: string) => string> = {
   sandboxed: () =>
-    'shareFile: not yet available for sandboxed (cluster) agents — the daemon cannot reach this workspace file yet.',
+    "shareFile: this agent's sandbox is not reachable right now, so its workspace cannot be read — try again shortly.",
   'not-found': (path) => `shareFile: no file at "${path}" in this workspace.`,
   escape: (path) =>
     `shareFile: "${path}" is not a workspace-relative path — only files inside the workspace can be shared.`,

--- a/packages/daemon/src/shim/memory-fs-channel.ts
+++ b/packages/daemon/src/shim/memory-fs-channel.ts
@@ -186,6 +186,10 @@ const WRITE_CHUNK_BYTES = 128 * 1024
 /** How often a whole-file read restarts when the file changed underneath its slices. */
 const READ_RESTARTS = 3
 
+/** Raw bytes per base64 read chunk: fits `REPLY_BUDGET` after 4/3 expansion, and a multiple
+ *  of 3 so every chunk encodes pad-free (decoded per chunk regardless — belt and braces). */
+const BASE64_READ_LIMIT = Math.floor(REPLY_BUDGET / 4) * 3
+
 /** A bound shim channel that knows which agent it serves (a `ShimSession`). */
 export type ShimMemoryChannel = ShimRequester & { readonly agentId: string }
 
@@ -229,6 +233,49 @@ export class ShimMemoryFs implements MemoryFs {
 
   private run<T>(payload: MemoryFsPayload, schema: z.ZodType<T>): Promise<T> {
     return requestMemoryFs(this.channel, payload, schema, this.timeoutMs)
+  }
+
+  /**
+   * The file's BYTES, chunked over the same read op with `encoding: 'base64'`.
+   *
+   * Two things the text read does not need: the per-chunk request is sized to
+   * {@link BASE64_READ_LIMIT} raw bytes, because the POD base64-encodes exactly the
+   * requested slice with no budget fitting of its own — a `REPLY_BUDGET` request would
+   * expand 4/3 past the frame and lose the channel instead of refusing; and each chunk is
+   * DECODED separately before concatenation, because independently-encoded slices carry
+   * their own padding and their joined strings are not one valid base64 stream.
+   *
+   * `maxBytes` refuses from the FIRST reply's size — a bounded refusal, not a transfer.
+   */
+  async readFileBytes(
+    rel: string,
+    maxBytes: number
+  ): Promise<{ bytes: Buffer; size: number; mtime: string } | { tooLarge: number } | null> {
+    const read = (offset: number) =>
+      this.run(
+        { op: 'memory-read', root: this.root, rel, offset, limit: BASE64_READ_LIMIT, encoding: 'base64' },
+        ReadReplySchema
+      )
+    for (let attempt = 0; attempt < READ_RESTARTS; attempt++) {
+      const first = await read(0)
+      if (!first.exists) return null
+      if (first.size > maxBytes) return { tooLarge: first.size }
+      const parts = [Buffer.from(first.content, 'base64')]
+      let offset = first.nextOffset
+      let stale = false
+      while (offset < first.size) {
+        const next = await read(offset)
+        // A slice from a different version of the file would splice two files together: start over.
+        if (!next.exists || next.mtime !== first.mtime || next.size !== first.size || next.nextOffset <= offset) {
+          stale = true
+          break
+        }
+        parts.push(Buffer.from(next.content, 'base64'))
+        offset = next.nextOffset
+      }
+      if (!stale) return { bytes: Buffer.concat(parts), size: first.size, mtime: first.mtime }
+    }
+    throw new MemoryConflictError('the file kept changing while it was read')
   }
 
   async readFile(rel: string, encoding: MemoryFsEncoding = 'utf8'): Promise<MemoryFsFile | null> {

--- a/packages/daemon/src/shim/memory-fs-channel.ts
+++ b/packages/daemon/src/shim/memory-fs-channel.ts
@@ -245,7 +245,7 @@ export class ShimMemoryFs implements MemoryFs {
    * DECODED separately before concatenation, because independently-encoded slices carry
    * their own padding and their joined strings are not one valid base64 stream.
    *
-   * `maxBytes` refuses from the FIRST reply's size — a bounded refusal, not a transfer.
+   * `maxBytes` refuses from the FIRST reply's size — one frame, not a whole transfer.
    */
   async readFileBytes(
     rel: string,

--- a/packages/daemon/src/shim/workspace-fs-channel.ts
+++ b/packages/daemon/src/shim/workspace-fs-channel.ts
@@ -62,6 +62,17 @@ export class ShimWorkspaceFs implements WorkspaceFs {
     }
   }
 
+  async readFileBytes(path: string, maxBytes: number): Promise<{ bytes: Buffer } | { tooLarge: number } | undefined> {
+    try {
+      const read = await this.files.readFileBytes(this.rel(path), maxBytes)
+      if (read === null) return undefined
+      return 'tooLarge' in read ? { tooLarge: read.tooLarge } : { bytes: read.bytes }
+    } catch (err) {
+      if (err instanceof MemoryPathError) return undefined
+      throw err
+    }
+  }
+
   async writeFile(path: string, content: string, options: { mode?: number } = {}): Promise<void> {
     // Staged as appended chunks beside the target and published by one rename, on the pod.
     await this.files.writeFile(this.rel(path), content, options)

--- a/packages/daemon/src/workspace/workspace-fs.ts
+++ b/packages/daemon/src/workspace/workspace-fs.ts
@@ -34,6 +34,10 @@ export interface WorkspaceFs {
   /** The file's text, or undefined when it is absent or unreadable — every caller reads a marker
    *  it is willing to find missing. */
   readFile(path: string): Promise<string | undefined>
+  /** The file's BYTES, bounded: over `maxBytes` answers `{tooLarge}` without transferring, and
+   *  absent/unreadable answers undefined. The binary sibling of {@link readFile}, added for the
+   *  outbound file share (agent-authored-attachments.md §6). */
+  readFileBytes(path: string, maxBytes: number): Promise<{ bytes: Buffer } | { tooLarge: number } | undefined>
   /** Atomic: staged beside the target, then published by one rename. */
   writeFile(path: string, content: string, options?: { mode?: number }): Promise<void>
   rename(from: string, to: string): Promise<void>
@@ -87,6 +91,20 @@ export class LocalWorkspaceFs implements WorkspaceFs {
   async readFile(path: string): Promise<string | undefined> {
     try {
       return readFileSync(path, 'utf8')
+    } catch {
+      return undefined
+    }
+  }
+
+  async readFileBytes(path: string, maxBytes: number): Promise<{ bytes: Buffer } | { tooLarge: number } | undefined> {
+    try {
+      const stats = lstatSync(path)
+      if (!stats.isFile()) return undefined
+      if (stats.size > maxBytes) return { tooLarge: stats.size }
+      const bytes = readFileSync(path)
+      // Re-check on the read bytes: the stat→read race on a growing file must refuse, not overrun.
+      if (bytes.byteLength > maxBytes) return { tooLarge: bytes.byteLength }
+      return { bytes }
     } catch {
       return undefined
     }

--- a/packages/daemon/test/fixtures/pod-workspace-fs.ts
+++ b/packages/daemon/test/fixtures/pod-workspace-fs.ts
@@ -21,6 +21,13 @@ export class PodWorkspaceFs implements WorkspaceFs {
     for (const dir of seedDirs) this.dirs.add(dir)
   }
 
+  async readFileBytes(path: string, maxBytes: number): Promise<{ bytes: Buffer } | { tooLarge: number } | undefined> {
+    const content = this.files.get(path)
+    if (content === undefined) return undefined
+    const bytes = Buffer.from(content, 'utf8')
+    return bytes.byteLength > maxBytes ? { tooLarge: bytes.byteLength } : { bytes }
+  }
+
   async stat(path: string): Promise<WorkspaceFsKind> {
     if (this.links.has(path)) return 'other'
     if (this.dirs.has(path)) return 'dir'

--- a/packages/daemon/test/memory-fs.test.ts
+++ b/packages/daemon/test/memory-fs.test.ts
@@ -103,6 +103,29 @@ describe('ShimMemoryFs over the read capability (the port over a sandbox volume)
     expect(requester.frames).toContain('memory-commit')
   })
 
+  it('reads BYTES in frame-safe base64 chunks, decoded per chunk, and refuses over-cap from the first reply', async () => {
+    const { root, fs, requester } = pod()
+    // Binary, non-UTF-8, larger than one base64-safe chunk (~189 KB) — forces reassembly and
+    // would corrupt under either of the two traps: a REPLY_BUDGET-sized request (4/3 expansion
+    // over-frames the reply) or joining independently-padded base64 strings before decoding.
+    const bytes = Buffer.alloc(400_000)
+    for (let i = 0; i < bytes.length; i++) bytes[i] = i % 251
+    mkdirSync(join(root, 'ws'), { recursive: true })
+    writeFileSync(join(root, 'ws', 'chart.png'), bytes)
+
+    const read = await fs.readFileBytes('ws/chart.png', 1_000_000)
+    if (read === null || 'tooLarge' in read!) throw new Error('expected bytes')
+    expect(read.bytes.equals(bytes)).toBe(true)
+    expect(requester.frames.filter((op) => op === 'memory-read').length).toBeGreaterThan(1)
+
+    // The cap refuses from the FIRST reply's size — one frame, no transfer.
+    const before = requester.frames.length
+    expect(await fs.readFileBytes('ws/chart.png', 100_000)).toEqual({ tooLarge: 400_000 })
+    expect(requester.frames.length - before).toBe(1)
+
+    expect(await fs.readFileBytes('ws/absent.png', 1_000_000)).toBeNull()
+  })
+
   it('reassembles a file larger than one frame and stages an oversized write as chunks', async () => {
     const { fs, requester } = pod()
     const big = 'é'.repeat(300_000) // 600 KB, multi-byte, more than two reply budgets

--- a/packages/daemon/test/workspace-fs.test.ts
+++ b/packages/daemon/test/workspace-fs.test.ts
@@ -85,6 +85,18 @@ for (const { name, fs, root } of subjects()) {
       expect(await fs.readFile(join(dir, 'missing.txt'))).toBeUndefined()
     })
 
+    it('reads bytes bounded by a cap that refuses instead of transferring', async () => {
+      const dir = join(root, 'bytes')
+      await fs.mkdir(dir)
+      const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0x01, 0x02])
+      writeFileSync(join(dir, 'img.bin'), binary)
+      const read = await fs.readFileBytes(join(dir, 'img.bin'), 1024)
+      if (read === undefined || 'tooLarge' in read) throw new Error('expected bytes')
+      expect(read.bytes.equals(binary)).toBe(true)
+      expect(await fs.readFileBytes(join(dir, 'img.bin'), 4)).toEqual({ tooLarge: 8 })
+      expect(await fs.readFileBytes(join(dir, 'absent.bin'), 1024)).toBeUndefined()
+    })
+
     it('publishes a write atomically and leaves no staging file behind', async () => {
       const dir = join(root, 'write')
       await fs.mkdir(dir)


### PR DESCRIPTION
## What this is

Phase 2 of [`agent-authored-attachments.md`](https://github.com/agentconnect-md/agentconnect/blob/main/docs/designs/agent-authored-attachments.md): `shareFile` (#1330) now works for **sandboxed (cluster) agents**, whose workspace lives on the pod's volume. Phase 1 refused them with a deferral; the design's review had already located the route — the fd-anchored workspace-fs channel carries chunked base64 reads under the `read` grant every sandbox holds — so the only genuine gap was a port shape: `WorkspaceFs` typed its read as text.

## The change

**`WorkspaceFs.readFileBytes(path, maxBytes)`** — the binary sibling of `readFile`, bounded by the outbound file cap rather than by a frame: over-cap answers `{tooLarge}` from the **first** reply's size without transferring; absence answers `undefined`.

The shim implementation dodges the two traps the design review named, both daemon-side (wire and pod bundle untouched, so running pods are compatible):

- A `REPLY_BUDGET`-sized request would expand 4/3 past the frame when the pod base64-encodes exactly the requested slice — losing the channel instead of refusing. Chunks request `floor(REPLY_BUDGET/4)*3` raw bytes.
- Independently-encoded slices carry their own padding, so their **joined strings are not one valid base64 stream** — each chunk is decoded separately and the buffers concatenated, with the same mtime/size staleness restart the text read uses.

**The resolver's pod arm:** the workspace scope already composes the root in pod coordinates; the daemon contributes the **lexical** fence (which carries the `.git` rule the pod-side check lacks — the symlink guarantee is the pod's own fd-anchored descent, exactly the division §4 of the design spells out); the bytes come over the channel and feed the same sniff/name/digest tail as the local arm. The `sandboxed` refusal now means only "sandbox unreachable right now", and says so.

## Testing

- End-to-end over the **real chunk protocol** (real tree + the fd executor): a 400 KB non-UTF-8 binary that forces multi-chunk reassembly and would corrupt under either trap; the over-cap refusal proven to cost exactly one frame; absence.
- The port's bounded read on **both** implementations via the existing shared suite (Local + Shim run the same cases).
- Workspace `typecheck`, `lint`, `format:check`, full `eval:gates` (192 tests) green. `shim-workspace-files.test.ts` fails identically on a clean tree on this machine (local `sandbox-exec` environment); CI is authoritative for it.

Design doc status flipped to *Implemented through phase 2* — §7's deferrals (attachFile, GIF, webchat frame, multi-file/composition, A2A) stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
