### PR TITLE
fix(console): resolve a session's pull request where the agent actually runs

### DIFF
--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -1161,11 +1161,20 @@ list; `HookRun`'s recorded review appears only as the degraded-arm fallback
      lookup resolves `null` — the degraded arm needs a PR to NAME, and identity
      that never resolved has none. The panel keeps its no-PR state for all of
      them.
-   - **Only a session worktree.** A shared checkout is the agent's primary tree
-     and its branch is no session's work; a purged session has no worktree left.
-     Both skip the daemon read entirely, as does an offline or too-old daemon —
-     so a session that can never resolve a PR spends none of the installation's
-     quota.
+   - **Two checkouts, and the shared one only for the session using it.** A
+     session worktree's branch IS that session's work. A shared-workspace agent
+     has no per-session worktree at all, and refusing to read its primary tree
+     left this tab permanently empty for every such agent — while reading it for
+     ANY session would hand an old one the newest session's pull request, whose
+     branch replaced the one that carried its work. So the primary tree is read
+     for the agent's most recently active session only, and `linkScope: shared`
+     makes the panel say the PR may carry more than this session's work. A purged
+     session, a non-checkout workspace, and no daemon serving the agent all skip
+     the daemon read entirely, so a session that can never resolve a PR spends
+     none of the installation's quota. The daemon comes from the PLACEMENT
+     (`servingDaemon`), like every workspace route: a pool- or cluster-placed
+     agent has no `agent.daemonId`, and reading that column resolved no branch at
+     all for exactly the deployments where every agent is placed that way.
    - **The ambiguity is reported, not hidden.** Several open PRs on one head are
      all equally "this session's": the lowest number wins (the first opened for
      the branch is the canonical review) and `linkAmbiguous` makes the panel say

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -906,16 +906,25 @@ export function buildContainer(
           clock,
           github,
           tokens: github.tokens,
-          readSessionBranch: async (agent, session) => {
-            if (!agent.daemonId) return null
-            const daemon = await registry.getAvailable(agent.orgId, agent.daemonId)
-            // An older daemon drops the frame silently, so the REQ would burn its retransmit budget
-            // and then read as an offline daemon — refuse first, exactly as the workspace routes do.
-            if (!daemon?.capabilities.features.includes(WORKSPACE_SESSION_READ_FEATURE)) return null
+          readSessionBranch: async (agent, session, scope) => {
+            // Through the PLACEMENT, like every workspace route (`getServingAgent`): a pool- or
+            // cluster-placed agent has no `agent.daemonId` at all, so reading that column instead
+            // resolved no branch for exactly the deployments where every agent is placed that way.
+            const daemonId = (await placementResolver.servingDaemon(agent)) ?? agent.daemonId
+            if (!daemonId) return null
+            const daemon = await registry.getAvailable(agent.orgId, daemonId)
+            if (!daemon) return null
+            // An older daemon drops an unknown frame silently, so the REQ would burn its retransmit
+            // budget and then read as an offline daemon — refuse first, exactly as the workspace
+            // routes do. Only the session-worktree read needs it; the primary checkout is the read
+            // every daemon has always answered.
+            if (scope === 'session' && !daemon.capabilities.features.includes(WORKSPACE_SESSION_READ_FEATURE)) {
+              return null
+            }
             try {
-              const status = await sender.workspaceGitStatus(agent.daemonId, {
+              const status = await sender.workspaceGitStatus(daemonId, {
                 agentId: agent.id,
-                sessionId: session.id
+                ...(scope === 'session' ? { sessionId: session.id } : {})
               })
               return status.isRepo ? (status.branch ?? null) : null
             } catch {
@@ -924,6 +933,7 @@ export function buildContainer(
               return null
             }
           },
+          latestSessionIdOfAgent: (agent) => repos.session.latestSessionIdForAgent(agent.orgId, agent.id),
           log: { warn: (obj, message) => http.log.warn(obj, message) },
           ...(opts.githubFetch ? { fetchImpl: opts.githubFetch } : {})
         })

--- a/packages/control-plane/src/github/session-pull-request-link.service.test.ts
+++ b/packages/control-plane/src/github/session-pull-request-link.service.test.ts
@@ -28,13 +28,22 @@ const SESSION = {
 
 const REPO = { repoId: 42n, repoFullName: 'acme/repo', installationId: 111n }
 
+/** Which checkout the last branch read asked about — the scope is the service's own decision. */
+const readBranchOf = (h: { readBranch: ReturnType<typeof vi.fn> }): unknown => h.readBranch.mock.calls.at(-1)?.[2]
+
 const pull = (number: number, state: string, ref = 'dev/jane/panel'): HeadPull => ({
   number,
   state,
   head: { ref }
 })
 
-function harness(opts: { pulls?: HeadPull[][]; branch?: string | null; repo?: typeof REPO | null }): {
+function harness(opts: {
+  pulls?: HeadPull[][]
+  branch?: string | null
+  repo?: typeof REPO | null
+  /** The agent's most recently active session; only the shared arm consults it. */
+  latest?: string | null
+}): {
   service: SessionPullRequestLinkService
   clock: FakeClock
   fetch: ReturnType<typeof vi.fn>
@@ -47,7 +56,9 @@ function harness(opts: { pulls?: HeadPull[][]; branch?: string | null; repo?: ty
     const next = pages.shift() ?? []
     return new Response(JSON.stringify(next), { status: 200, headers: { 'content-type': 'application/json' } })
   })
-  const readBranch = vi.fn(async () => (opts.branch === undefined ? 'dev/jane/panel' : opts.branch))
+  const readBranch = vi.fn(async (_agent: AgentRecord, _session: SessionMetaRecord, _scope: string) =>
+    opts.branch === undefined ? 'dev/jane/panel' : opts.branch
+  )
   const resolveRepo = vi.fn(async () => (opts.repo === undefined ? REPO : opts.repo))
   const service = new SessionPullRequestLinkService({
     clock,
@@ -56,6 +67,7 @@ function harness(opts: { pulls?: HeadPull[][]; branch?: string | null; repo?: ty
       mintPullRequestRead: async () => ({ token: 'ghs_test' })
     } as unknown as InstallationTokenService,
     readSessionBranch: readBranch,
+    latestSessionIdOfAgent: async () => (opts.latest === undefined ? SESSION.id : opts.latest),
     fetchImpl: fetch as unknown as FetchLike
   })
   return { service, clock, fetch, readBranch, resolveRepo }
@@ -91,27 +103,54 @@ describe('chooseHeadPull', () => {
 
 describe('SessionPullRequestLinkService', () => {
   it('resolves the branch’s pull request and asks GitHub for that head only', async () => {
-    const { service, fetch } = harness({})
+    const harnessed = harness({})
+    const { service, fetch } = harnessed
 
     expect(await service.resolve(AGENT, SESSION)).toEqual({
       ...REPO,
       pullNumber: 7,
       branch: 'dev/jane/panel',
+      scope: 'session',
       ambiguous: false
     })
+    expect(readBranchOf(harnessed)).toBe('session')
     const url = String(fetch.mock.calls[0]![0])
     expect(url).toContain('/repos/acme/repo/pulls')
     expect(url).toContain(`head=${encodeURIComponent('acme:dev/jane/panel')}`)
     expect(url).toContain('state=all')
   })
 
-  it('spends NO GitHub call for a shared checkout, a purged session, or a branchless worktree', async () => {
+  it('reads the agent’s PRIMARY checkout for a shared-workspace session, and says so', async () => {
+    // The checkout the Files and Git tabs already show such a session. Refusing it left the tab
+    // permanently empty for every shared-workspace agent; the `scope` is how the panel stays honest
+    // about the PR not being exclusively this session's.
     const shared = harness({})
-    expect(
-      await shared.service.resolve(AGENT, { ...SESSION, workspaceIsolation: 'shared' } as SessionMetaRecord)
-    ).toBeNull()
-    expect(shared.readBranch).not.toHaveBeenCalled()
 
+    const link = await shared.service.resolve(AGENT, { ...SESSION, workspaceIsolation: 'shared' } as SessionMetaRecord)
+
+    expect(link).toMatchObject({ pullNumber: 7, scope: 'shared' })
+    expect(readBranchOf(shared)).toBe('shared')
+  })
+
+  it('refuses the shared checkout for a session that is no longer the one using it', async () => {
+    // The tree has ONE branch and it moves with the agent. Handing an older session the NEWEST
+    // session's pull request — its checks, its threads — is worse than an empty tab.
+    const stale = harness({ latest: 'sess-newer' })
+
+    expect(
+      await stale.service.resolve(AGENT, { ...SESSION, workspaceIsolation: 'shared' } as SessionMetaRecord)
+    ).toBeNull()
+    expect(stale.readBranch).not.toHaveBeenCalled()
+    expect(stale.fetch).not.toHaveBeenCalled()
+  })
+
+  it('does not ask which session is current for a session worktree — its branch is its own', async () => {
+    const own = harness({ latest: 'sess-newer' })
+
+    expect((await own.service.resolve(AGENT, SESSION))?.scope).toBe('session')
+  })
+
+  it('spends NO GitHub call for a purged session or a branchless worktree', async () => {
     const purged = harness({})
     expect(
       await purged.service.resolve(AGENT, { ...SESSION, contentPurgedAt: new Date() } as SessionMetaRecord)
@@ -133,6 +172,7 @@ describe('SessionPullRequestLinkService', () => {
       github: { resolveWorkspaceRepo: async () => REPO } as unknown as GithubService,
       tokens: { mintPullRequestRead: async () => ({ token: 'ghs_test' }) } as unknown as InstallationTokenService,
       readSessionBranch: async () => 'dev/jane/panel',
+      latestSessionIdOfAgent: async () => SESSION.id,
       fetchImpl: fetch as unknown as FetchLike
     })
 

--- a/packages/control-plane/src/github/session-pull-request-link.service.ts
+++ b/packages/control-plane/src/github/session-pull-request-link.service.ts
@@ -6,6 +6,10 @@
 // Failure to establish identity is an ABSENCE, never a degraded view — the degraded arm needs a PR to
 // name, and here there is none — so every unreachable, denied or rate-limited answer reads `null` and
 // is cached as a miss rather than re-asked on the next panel mount.
+// Two checkouts can answer: a session's own worktree, whose branch IS that session's work, and — for a
+// shared-workspace agent, which has no per-session worktree — the agent's primary tree, but only for
+// the session currently using it. That second arm is what keeps the tab from being permanently empty
+// on a shared workspace without handing an old session the newest one's pull request.
 import { githubRequest, type FetchLike } from './api.js'
 import type { GithubService } from './service.js'
 import type { InstallationTokenService } from './installation-token.service.js'
@@ -25,6 +29,11 @@ export const SESSION_PR_LINK_CACHE_MAX = 512
 // bound on a branch's own history of reopened/closed PRs, not on the repository's.
 const HEAD_PULL_LIMIT = 20
 
+/** Which checkout's branch a link resolved through. `shared` is the agent's PRIMARY tree, which every
+ *  session on a shared-workspace agent works in — the same checkout the Files and Git tabs already
+ *  show for such a session, so the PR is real but is not exclusively this session's work. */
+export type SessionPullRequestLinkScope = 'session' | 'shared'
+
 /** The durable half of a branch-resolved PR — the same facts a hook run would have carried. */
 export interface SessionPullRequestLink {
   repoId: bigint
@@ -33,6 +42,8 @@ export interface SessionPullRequestLink {
   pullNumber: number
   /** The head branch this resolved through, so the panel can say what it matched on. */
   branch: string
+  /** Whose checkout that branch was read from, so the panel can say that too. */
+  scope: SessionPullRequestLinkScope
   /** true ⇒ the branch has more than one OPEN pull request and this is the first of them. */
   ambiguous: boolean
 }
@@ -72,10 +83,17 @@ export interface SessionPullRequestLinkDeps {
   clock: Clock
   github: GithubService
   tokens: InstallationTokenService
-  /** The owning daemon's read of THIS session's worktree, reduced to its checked-out branch. `null`
-   *  for everything the caller cannot read a session branch from: no live daemon, a daemon too old to
+  /** The serving daemon's read of the checkout named by `scope`, reduced to its branch. `null` for
+   *  everything the caller cannot read a branch from: no daemon serving the agent, a daemon too old to
    *  serve session worktrees, a non-repo workspace, a detached HEAD, or a failed read. */
-  readSessionBranch: (agent: AgentRecord, session: SessionMetaRecord) => Promise<string | null>
+  readSessionBranch: (
+    agent: AgentRecord,
+    session: SessionMetaRecord,
+    scope: SessionPullRequestLinkScope
+  ) => Promise<string | null>
+  /** The agent's most recently active session. Only the SHARED arm asks: one checkout has one branch,
+   *  and that branch describes the session using it now — not the ones that ran in it last week. */
+  latestSessionIdOfAgent: (agent: AgentRecord) => Promise<string | null>
   fetchImpl?: FetchLike
   baseUrl?: string
   log?: { warn?: (obj: unknown, msg: string) => void }
@@ -140,13 +158,22 @@ export class SessionPullRequestLinkService {
   }
 
   private async read(agent: AgentRecord, session: SessionMetaRecord): Promise<SessionPullRequestLink | null> {
-    // A shared checkout is the agent's PRIMARY tree, whose branch is no session's work — the same gate
-    // the console applies before it draws branch facts in this tab. A purged session has no worktree
-    // left to read either, so neither reaches the daemon.
-    if (session.workspaceIsolation !== 'session' || session.contentPurgedAt) return null
+    // A purged session's worktree is gone with its content, so there is nothing to read.
+    if (session.contentPurgedAt) return null
+    // Which checkout to ask about. A session worktree has a branch of its OWN; a shared-workspace
+    // session works in the agent's primary tree — which is exactly the checkout the Files and Git tabs
+    // beside this one already show it, so refusing to read it here left the tab permanently empty for
+    // every shared-workspace agent rather than protecting anything. It is read, and the link says
+    // which checkout answered so the panel can say the PR is not exclusively this session's.
+    const scope: SessionPullRequestLinkScope = session.workspaceIsolation === 'session' ? 'session' : 'shared'
+    // A shared tree has ONE branch, which moves with whatever the agent is doing now — so it speaks
+    // for the session using it and for no other. An older session would otherwise be handed the
+    // NEWEST session's pull request, checks and threads, which is worse than an empty tab: the branch
+    // that carried its own work is long gone from that checkout and nothing here can find it.
+    if (scope === 'shared' && (await this.deps.latestSessionIdOfAgent(agent)) !== session.id) return null
     // The branch first, deliberately: no branch ⇒ no GitHub call at all, which keeps the sessions
     // that can never resolve a PR (scratch workspaces, offline daemons) off the installation's quota.
-    const branch = await this.deps.readSessionBranch(agent, session)
+    const branch = await this.deps.readSessionBranch(agent, session, scope)
     if (!branch) return null
     const repo = await this.deps.github.resolveWorkspaceRepo(agent)
     if (!repo) return null
@@ -173,6 +200,7 @@ export class SessionPullRequestLinkService {
         installationId: repo.installationId,
         pullNumber: chosen.pullNumber,
         branch,
+        scope,
         ambiguous: chosen.ambiguous
       }
     } catch (err) {

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3272,6 +3272,9 @@ export const SessionPullRequestDto = z.object({
   linkedBy: z.enum(['run', 'head-branch']),
   // The head branch a `head-branch` link resolved through; null for a run-linked PR.
   linkBranch: z.string().nullable(),
+  // Whose checkout that branch was read from: this session's own worktree, or the agent's `shared`
+  // primary tree, where every session on the agent works and the PR is not exclusively this session's.
+  linkScope: z.enum(['session', 'shared']).nullable(),
   // true ⇒ that branch has more than one OPEN pull request and this is the first of them.
   linkAmbiguous: z.boolean()
 })

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -369,9 +369,15 @@ function toSessionPullRequestDto(
   view: PullRequestView,
   canArmAutoMerge: boolean,
   // How this PR was found. Defaulted to the run, which is the only source that existed before §12.6.
-  link: { linkedBy: 'run' | 'head-branch'; linkBranch: string | null; linkAmbiguous: boolean } = {
+  link: {
+    linkedBy: 'run' | 'head-branch'
+    linkBranch: string | null
+    linkScope: 'session' | 'shared' | null
+    linkAmbiguous: boolean
+  } = {
     linkedBy: 'run',
     linkBranch: null,
+    linkScope: null,
     linkAmbiguous: false
   }
 ): SessionPullRequestDtoT {
@@ -1108,7 +1114,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get the session’s pull request',
           description:
-            'This session’s pull request: identity (repo, number, url, head/base) plus live state (checks, current reviews, unresolved review threads) proxied from GitHub in one GraphQL read. Identity comes from the owning hook run where one exists (`linkedBy: run`, which also carries the review facts a rate-limited answer falls back on); otherwise from the session worktree’s own head branch (`linkedBy: head-branch`, `linkBranch`), so a pull request the agent opened mid-conversation is linked too — `linkAmbiguous` says the branch has more than one open pull request and this is the first of them. GitHub being rate limited, denying the installation, or unreachable is data — `degraded` names which, identity survives, and the live lists are empty — because a panel that still names its PR beats an empty one. 404 when neither source names a pull request (no run and no pull request for the branch, a shared or purged workspace, an offline daemon) or when the deployment has no GitHub App configured; the console then draws its branch state and a create action instead. Review thread bodies are user content: proxied, never stored.',
+            'This session’s pull request: identity (repo, number, url, head/base) plus live state (checks, current reviews, unresolved review threads) proxied from GitHub in one GraphQL read. Identity comes from the owning hook run where one exists (`linkedBy: run`, which also carries the review facts a rate-limited answer falls back on); otherwise from the head branch of the checkout this session works in (`linkedBy: head-branch`, `linkBranch`, `linkScope`), so a pull request the agent opened mid-conversation is linked too — `linkScope: shared` means the branch came from the agent’s primary checkout, which every session on a shared-workspace agent works in, so the pull request is real but not exclusively this session’s; `linkAmbiguous` says the branch has more than one open pull request and this is the first of them. GitHub being rate limited, denying the installation, or unreachable is data — `degraded` names which, identity survives, and the live lists are empty — because a panel that still names its PR beats an empty one. 404 when neither source names a pull request (no run and no pull request for that branch, a purged session, a workspace that is not a checkout, no daemon serving the agent) or when the deployment has no GitHub App configured; the console then draws its branch state and a create action instead. Review thread bodies are user content: proxied, never stored.',
           operationId: 'getSessionPullRequest',
           params: IdParam,
           querystring: SessionPullRequestQueryDto,
@@ -1146,7 +1152,12 @@ export function sessionRoutes(deps: HttpDeps) {
               req.query.refresh === true
             ),
             canArmBranch,
-            { linkedBy: 'head-branch', linkBranch: link.branch, linkAmbiguous: link.ambiguous }
+            {
+              linkedBy: 'head-branch',
+              linkBranch: link.branch,
+              linkScope: link.scope,
+              linkAmbiguous: link.ambiguous
+            }
           )
         }
         // The subject's own open/draft facts feed the degraded arm, so a rate-limited panel still names them.

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1319,6 +1319,10 @@ export interface SessionRepo {
    *  (no visibility predicate), safe to return to any org member: it reveals nothing
    *  about sessions the caller can't see. Drives the getting-started conversation step. */
   orgHasAny(orgId: OrgId): Promise<boolean>
+  /** The most recently active session of one agent, org-fenced. For the shared-checkout PR link: an
+   *  agent with one checkout has one branch, so that branch only speaks for the session using it now
+   *  (webchat-side-panels.md §12.6). Rides `session_meta_agent_activity_page_idx`. */
+  latestSessionIdForAgent(orgId: OrgId, agentId: AgentId): Promise<SessionId | null>
   /** One latest representative per distinct facet value after applying every
    *  other active facet. The database reduces the full history before returning
    *  this compact index to the HTTP layer. */

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -1150,6 +1150,16 @@ export class PgSessionRepo implements SessionRepo {
     return row !== null
   }
 
+  async latestSessionIdForAgent(orgId: OrgId, agentId: AgentId): Promise<SessionId | null> {
+    // Same tie-break as every session listing, so "latest" means one thing across the CP.
+    const row = await this.db.sessionMeta.findFirst({
+      where: { orgId, agentId },
+      orderBy: [{ lastActivityAt: 'desc' }, { startedAt: 'desc' }, { id: 'desc' }],
+      select: { id: true }
+    })
+    return row ? SessionId(row.id) : null
+  }
+
   async listFacets(q: SessionFacetQuery): Promise<SessionFacetIndex> {
     if (queryAgentIds(q).length === 0) return { agents: [], integrations: [], channels: [], triggers: [] }
 

--- a/packages/control-plane/test/integration/sessions.pull-request.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.pull-request.route.test.ts
@@ -13,6 +13,7 @@ import { GitCredDeniedError, type GithubService } from '../../src/github/service
 import type { InstallationTokenService } from '../../src/github/installation-token.service.js'
 import type { FetchLike } from '../../src/github/api.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
+import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { systemClock } from '../../src/domain/clock.js'
 
@@ -246,6 +247,7 @@ describe('GET /sessions/:id/pull-request', () => {
       agentReview: null,
       linkedBy: 'run',
       linkBranch: null,
+      linkScope: null,
       linkAmbiguous: false
     })
     expect(github.calls).toHaveLength(1)
@@ -581,7 +583,7 @@ describe('GET /sessions/:id/pull-request — the head-branch link', () => {
   const BRANCH = 'dev/jane/panel'
 
   // The link service as the route sees it: a scripted daemon branch read plus the `pulls` REST list.
-  function linkStub(opts: { branch?: string | null; pulls?: unknown[] } = {}) {
+  function linkStub(opts: { branch?: string | null; pulls?: unknown[]; latestSessionId?: string | null } = {}) {
     const calls: string[] = []
     const fetch: FetchLike = async (url) => {
       calls.push(String(url))
@@ -596,7 +598,16 @@ describe('GET /sessions/:id/pull-request — the head-branch link', () => {
         resolveWorkspaceRepo: async () => ({ repoId: REPO_ID, repoFullName: REPO, installationId: INSTALLATION })
       } as unknown as GithubService,
       tokens: { mintPullRequestRead: async () => ({ token: 'ghs_link' }) } as unknown as InstallationTokenService,
-      readSessionBranch: async () => (opts.branch === undefined ? BRANCH : opts.branch),
+      readSessionBranch: async (_agent, _session, scope) => {
+        calls.push(`branch:${scope}`)
+        return opts.branch === undefined ? BRANCH : opts.branch
+      },
+      // Real repo read by default, so the shared arm's "is this the session using the checkout now"
+      // question is answered by Postgres exactly as it is in production.
+      latestSessionIdOfAgent: async (agent) =>
+        opts.latestSessionId !== undefined
+          ? opts.latestSessionId
+          : new PgSessionRepo(prisma).latestSessionIdForAgent(agent.orgId, agent.id),
       fetchImpl: fetch
     })
     return { links, calls }
@@ -624,11 +635,12 @@ describe('GET /sessions/:id/pull-request — the head-branch link', () => {
       degraded: false,
       linkedBy: 'head-branch',
       linkBranch: BRANCH,
+      linkScope: 'session',
       linkAmbiguous: false
     })
     // One REST list for identity, then the same single GraphQL projection a run-linked PR spends.
-    expect(link.calls).toHaveLength(1)
-    expect(link.calls[0]).toContain(`head=${encodeURIComponent(`acme:${BRANCH}`)}`)
+    expect(link.calls.filter((call) => call.startsWith('https'))).toHaveLength(1)
+    expect(link.calls.at(-1)).toContain(`head=${encodeURIComponent(`acme:${BRANCH}`)}`)
     expect(github.calls).toHaveLength(1)
   })
 
@@ -646,6 +658,48 @@ describe('GET /sessions/:id/pull-request — the head-branch link', () => {
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
 
     expect(res.json()).toMatchObject({ pullNumber: PULL, linkAmbiguous: true, linkBranch: BRANCH })
+  })
+
+  it('links a SHARED-workspace session through the agent’s primary checkout, and says which', async () => {
+    // Every session on a shared-workspace agent works in that one checkout — the same one the Files
+    // and Git tabs show them — so the pull request on its branch is this session's to see, labelled.
+    const session = await seedAgentAndSession()
+    await prisma.sessionMeta.update({ where: { id: session }, data: { workspaceIsolation: 'shared' } })
+    const github = githubStub([graphqlOk(fullAnswer())])
+    const link = linkStub()
+    const running = app(github.view, undefined, undefined, link.links)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ pullNumber: PULL, linkedBy: 'head-branch', linkScope: 'shared' })
+    // The branch was read from the PRIMARY checkout, not from a session worktree that does not exist.
+    expect(link.calls[0]).toBe('branch:shared')
+  })
+
+  it('404s an OLDER shared-workspace session — the tree moved on and its branch is gone', async () => {
+    // Real Postgres ordering decides "the session using it now": the newer row wins, so the older
+    // session is not handed the newer one's pull request, checks and threads.
+    const older = await seedAgentAndSession()
+    await prisma.sessionMeta.update({
+      where: { id: older },
+      data: { workspaceIsolation: 'shared', lastActivityAt: new Date('2026-08-01T00:00:00Z') }
+    })
+    await seedSessionMeta(prisma, randomUUID(), AGENT, {
+      daemonId: DAEMON,
+      lastActivityAt: new Date('2026-08-20T00:00:00Z')
+    })
+    const github = githubStub([])
+    const link = linkStub()
+    const running = app(github.view, undefined, undefined, link.links)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${older}/pull-request` })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual(NOT_FOUND)
+    // Refused before the daemon read, so a stale session costs nothing at all.
+    expect(link.calls).toHaveLength(0)
+    expect(github.calls).toHaveLength(0)
   })
 
   it('still 404s when the branch has no pull request — the panel keeps its create action', async () => {
@@ -670,7 +724,7 @@ describe('GET /sessions/:id/pull-request — the head-branch link', () => {
 
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
 
-    expect(res.json()).toMatchObject({ linkedBy: 'run', linkBranch: null })
+    expect(res.json()).toMatchObject({ linkedBy: 'run', linkBranch: null, linkScope: null })
     expect(link.calls).toHaveLength(0)
   })
 

--- a/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
@@ -423,6 +423,19 @@ describe('PullRequestPanel body', () => {
     )
   })
 
+  it('says when the link came from the agent’s SHARED checkout, and stays silent for a session worktree', async () => {
+    // The PR is real either way; what differs is whose work it can contain, and the panel says so
+    // rather than letting a shared tree's branch read as this session's alone.
+    await render()
+    expect(container?.querySelector('[data-pr-link-shared]')).toBeNull()
+
+    wire.data = pr({ linkedBy: 'head-branch', linkBranch: 'main', linkScope: 'shared' })
+    await rerender({ sessionId: 'session-2' })
+    expect(container?.querySelector('[data-pr-link-shared]')?.textContent).toContain(
+      "Found through main, the branch of this agent's shared checkout"
+    )
+  })
+
   it('draws each check with its own state marker and a duration only where both ends exist', async () => {
     await render()
     const checks = Array.from(container?.querySelectorAll<HTMLElement>('[data-pr-check]') ?? [])

--- a/packages/web/src/components/console/dock/PullRequestPanel.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.tsx
@@ -605,6 +605,22 @@ export function PullRequestPanel({
         </a>
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-auto pb-2">
+        {/* A shared checkout is the agent's ONE tree, which every session on it works in — so the PR on its branch is this session's to see, but not exclusively its work. Said, not implied. */}
+        {view.linkScope === 'shared' ? (
+          <div
+            data-pr-link-shared=""
+            className="flex items-start gap-2 px-3 pt-[7px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)"
+          >
+            <Icon name="info" size={13} color="var(--text-tertiary)" className="mt-[2px] flex-none" />
+            <span>
+              {view.linkBranch
+                ? `Found through ${view.linkBranch}, the branch of this agent's shared checkout`
+                : "Found through the branch of this agent's shared checkout"}{' '}
+              — every session on this agent works in that one tree, so this pull request may carry more than this
+              session&rsquo;s work.
+            </span>
+          </div>
+        ) : null}
         {/* A branch-resolved link can be ambiguous where a run-linked one never is: the head branch is the whole identity, so several open PRs on it are all equally "this session's". The panel names the pick rather than picking silently. */}
         {view.linkAmbiguous ? (
           <div

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3347,6 +3347,8 @@ export interface SessionPullRequestDto {
   linkedBy?: 'run' | 'head-branch'
   /** The head branch a `head-branch` link resolved through; null for a run-linked PR. */
   linkBranch?: string | null
+  /** Whose checkout that branch was read from: this session's own worktree, or the agent's `shared` primary tree, where every session on the agent works. */
+  linkScope?: 'session' | 'shared' | null
   /** true ⇒ that branch has more than one OPEN pull request and this is the first of them. */
   linkAmbiguous?: boolean
 }


### PR DESCRIPTION
## Why

Follow-up to #1294, from debugging one live session on the test deployment whose PR panel was still empty — [session `349851a3`](https://test-app.agentconnect.md/agentconnect/sessions/349851a3-b4fc-4904-9912-6f0518319418), a webchat session on `cloud-test-2` that had just opened #1332.

Two independent reasons the branch fallback never fired there:

| | |
| --- | --- |
| `agent.daemonId` was NULL | that agent is pool-placed (`placementKind: set`), like every agent in that deployment. Workspace routes resolve their daemon through `placementResolver.servingDaemon` (`getServingAgent`, `agents.ts:862`); `readSessionBranch` read the column instead, so it bailed before asking anyone. The fallback could not have worked for **any** agent there, session worktree or not. |
| the session reports `workspaceIsolation: shared` | the agent has one checkout, and that tree is exactly what the Files and Git tabs already show this session. Refusing to read it left the tab permanently empty for every shared-workspace agent. |

Verified against the deployment rather than inferred: `session_meta` says `shared` for all 6 of that agent's sessions, `agent.daemonId` is null, and the sandbox pod's `/agent/repo` is checked out on `feat/web-sessions-new-session-button` — the head of #1332, opened one second after that session's last activity.

## What

**Placement, not the column.** `readSessionBranch` resolves the serving daemon exactly as the workspace routes beside it do, falling back to `agent.daemonId` only if the placement resolves nothing.

**The shared checkout is read, for one session.** One tree has one branch and it moves with the agent, so it speaks for the session using it *now*. Reading it for any session would hand an older one the newest session's PR, checks and threads — worse than an empty tab, since the branch that carried its own work is long gone from that checkout and nothing here can find it. So:

- session worktree ⇒ read it, `linkScope: 'session'` (its branch **is** that session's work);
- shared checkout ⇒ read the primary tree only for the agent's most recently active session, `linkScope: 'shared'`;
- anything else ⇒ absent, as before.

`SessionRepo.latestSessionIdForAgent` answers "the session using it now" on the existing `session_meta_agent_activity_page_idx` — no migration — and a stale session is refused *before* the daemon read, so it costs nothing at all.

**The panel says which.** `linkScope` reaches the DTO, and a `shared` link draws one line: found through *branch*, the branch of this agent's shared checkout, which every session on the agent works in — so the PR may carry more than this session's work. Only the session-worktree read keeps the `workspace-session-read-v1` feature gate; the primary checkout is a read every daemon has always answered.

For the session that started this: it *is* that agent's most recently active one, so it now links #1332 with the shared-checkout note.

## Tests

- Unit (+3, 13 total): the shared arm reads the primary checkout and reports `scope: 'shared'`; an older shared session is refused before any read; a session worktree never consults "who is current".
- Integration (+2, 21 total): a shared session links through the primary checkout (asserting the read was `branch:shared`, i.e. no session worktree was asked for), and an older shared session 404s with real Postgres ordering deciding which is current, spending neither a daemon read nor a GitHub call.
- Web (+1): the panel draws the shared-checkout note, and stays silent for a session-worktree link.

`test:unit` 1805 ✅ · `sessions.pull-request` integration 21 ✅ · web 1699 ✅ · typecheck / lint / format clean.

## Notes

§12.6 of the design doc is updated: the "only a session worktree" limit becomes the two-checkout rule with its own reasoning, plus the placement note.

Still absent by design: a session that is neither the current user of a shared tree nor has a worktree of its own. Recovering *that* needs a durable session→PR binding written when the agent opens one — the alternative #1294's §12.6 lists — not more guessing from a checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
