### PR TITLE
feat(web): wire the cluster page's Credits card to live billing and usage data

### DIFF
--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -399,11 +399,13 @@ describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
     mocks.agents = [onPool('a1')]
     mocks.usage = { data: usageOverPool(), error: new Error('fetch failed') }
     mocks.topUps = { data: [credit(4, 20_000_000)], error: new Error('fetch failed') }
+    mocks.balance = { data: { orgId: 'org-pool', balanceMicro: 38_740_000 }, error: new Error('fetch failed') }
 
     const html = render()
 
     expect(html).toContain('$8.00')
     expect(html).toContain('$20.00')
+    expect(html).toContain('$38.74')
     expect(html).not.toContain('unavailable')
   })
 

--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   integrations: [] as unknown[],
   daemonsLoading: false,
   balance: { data: { orgId: 'org-pool', balanceMicro: 38_740_000 } } as Record<string, unknown>,
+  usage: {} as Record<string, unknown>,
+  topUps: {} as Record<string, unknown>,
   push: vi.fn()
 }))
 
@@ -33,8 +35,17 @@ vi.mock('@/lib/data-context', () => ({
   })
 }))
 vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
-// The Credits card's Balance is live; nothing else on the page fetches.
-vi.mock('swr', () => ({ default: () => mocks.balance }))
+// The Credits card is the page's only fetcher, and it reads three independent sources, so
+// the stub answers per KEY — one shared response would hide a card that wired the wrong one.
+vi.mock('swr', () => ({
+  default: (key: unknown) => {
+    const resource = Array.isArray(key) ? key[2] : null
+    if (resource === 'billing-account') return mocks.balance
+    if (resource === 'usage') return mocks.usage
+    if (resource === 'billing-top-ups') return mocks.topUps
+    return {}
+  }
+}))
 
 const ClusterDetailView = (await import('./ClusterDetailView')).default
 
@@ -93,6 +104,35 @@ const onPool = (id: string, over: Partial<Agent> = {}): Agent =>
     ...over
   }) as Agent
 
+/** A 30-day spend series where only SOME of the cost is the pool's — the other agent is the
+ *  whole point: a card that summed the org's total would pass against a single-agent series. */
+function usageOverPool(pool: Record<number, string> = { 3: '1.50', 10: '4.00', 29: '2.50' }) {
+  return {
+    from: '',
+    to: '',
+    totals: { sessions: 0, totalTokens: 0, costAmount: '0', costCurrency: 'USD' },
+    agents: [],
+    models: [],
+    sources: [],
+    series: {
+      bucket: 'day' as const,
+      points: Array.from({ length: 30 }, (_, day) => ({
+        start: new Date(Date.UTC(2026, 6, 22 + day)).toISOString(),
+        costAmount: '9.99',
+        byAgent: { ...(pool[day] ? { a1: pool[day] } : {}), 'not-on-pool': '7.00' }
+      }))
+    }
+  }
+}
+
+const credit = (day: number, amountMicro: number) => ({
+  type: 'credit' as const,
+  id: `c${day}`,
+  kind: 'purchase' as const,
+  amountMicro,
+  at: new Date(Date.UTC(2026, 6, 22 + day, 9)).toISOString()
+})
+
 function render(): string {
   const host = document.createElement('div')
   document.body.appendChild(host)
@@ -116,6 +156,8 @@ beforeEach(() => {
   mocks.integrations = []
   mocks.daemonsLoading = false
   mocks.balance = { data: { orgId: 'org-pool', balanceMicro: 38_740_000 } }
+  mocks.usage = { data: usageOverPool() }
+  mocks.topUps = { data: [] }
   mocks.push.mockClear()
   setFlags('daemon-pool')
 })
@@ -292,35 +334,81 @@ describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
     expect(html).not.toContain('pool-member-p1')
   })
 
-  it('shows the REAL balance and chips only the figures it cannot serve', () => {
-    // A fabricated balance beside a "Manage billing" link to the real one reads as headroom the
-    // org has, so the one figure billing can already answer is live and the rest are marked.
+  it('bills the org for what ran on the POOL, not for what the org spent', () => {
+    // The footnote right below this card promises agents on your own daemons are never billed
+    // here, so the spend is the `byAgent` split filtered to the pool — never the bucket total.
     mocks.daemons = [member('p1')]
+    mocks.agents = [onPool('a1')]
 
     const html = render()
 
     expect(html).toContain('Credits')
+    expect(html).toContain('$8.00')
+    // 30 buckets × $7.00 belonging to an agent that does not run here.
+    expect(html).not.toContain('$218.00')
+    expect(html).not.toContain('$210.00')
+  })
+
+  it('shows the REAL balance beside them', () => {
+    mocks.daemons = [member('p1')]
+    mocks.agents = [onPool('a1')]
+
+    const html = render()
+
     expect(html).toContain('$38.74')
-    expect(html).toContain('sample')
     expect(html).toContain('Manage billing')
-    // Decoration, not a figure a reader could act on.
-    expect(html).toContain('aria-hidden')
     // A plan's included usage is not derivable from load telemetry, so no bar pretends it is.
     expect(html).not.toContain('included')
   })
 
-  it('keeps the sample total and the sample bars consistent with each other', () => {
-    // They come from ONE series once wired, so the placeholder satisfies that invariant already.
+  it('sums the credit rows that fall inside the window', () => {
     mocks.daemons = [member('p1')]
+    mocks.agents = [onPool('a1')]
+    mocks.topUps = { data: [credit(4, 20_000_000), credit(25, 30_000_000)] }
 
-    // 146,600 cents across the 30 bars.
-    expect(render()).toContain('$1,466.00')
+    const html = render()
+
+    expect(html).toContain('$50.00')
+    expect(html).toContain('2 top-ups')
   })
 
-  it('lets the balance failure say which failure it was', () => {
+  it("holds the chart's footprint while the first load is in flight", () => {
+    // A card that collapsed to its figures and grew a chart underneath would shove the page
+    // down the moment the series lands.
+    mocks.daemons = [member('p1')]
+    mocks.agents = [onPool('a1')]
+    mocks.usage = { isLoading: true }
+    mocks.topUps = { isLoading: true }
+    mocks.balance = { isLoading: true }
+
+    const html = render()
+
+    expect(html).toContain('animate-pulse')
+    expect(html).toContain('min-h-[140px]')
+    // Nothing is claimed while it loads — not even a zero.
+    expect(html).not.toContain('$0.00')
+  })
+
+  it('refuses to quote a spend it cannot scope to the pool', () => {
+    // A CP predating the `byAgent` split can only answer for the whole org, and answering with
+    // that number is the one thing this card must not do.
+    mocks.daemons = [member('p1')]
+    mocks.agents = [onPool('a1')]
+    mocks.usage = { data: { ...usageOverPool(), series: { bucket: 'day', points: [] } } }
+
+    const html = render()
+
+    expect(html).toContain('unavailable')
+    expect(html).toContain('does not split spend per agent')
+    // The balance is a different source and still answers.
+    expect(html).toContain('$38.74')
+  })
+
+  it('lets each figure fail on its own', () => {
     // A shape mismatch throws BillingShapeError into the same slot as an unreachable service, and
     // this console deploys ahead of the pinned billing image — so blaming the network guesses.
     mocks.daemons = [member('p1')]
+    mocks.agents = [onPool('a1')]
     mocks.balance = { error: new Error('billing sent an unexpected account — the console may be out of date') }
 
     const html = render()
@@ -328,21 +416,8 @@ describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
     expect(html).toContain('unavailable')
     expect(html).toContain('may be out of date')
     expect(html).not.toContain('Could not reach')
-  })
-
-  it('dates the axis relatively, so it cannot go stale', () => {
-    mocks.daemons = [member('p1')]
-
-    const html = render()
-
-    expect(html).toContain('30 days ago')
-    expect(html).toContain('today')
-  })
-
-  it('never generates the placeholder series, so it cannot read as live data', () => {
-    mocks.daemons = [member('p1')]
-
-    expect(render()).toBe(render())
+    // A failed balance is not a failed spend: the CP's figure still renders.
+    expect(html).toContain('$8.00')
   })
 
   it('offers no billing surface where the deployment has none', () => {

--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -378,6 +378,49 @@ describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
     expect(html).toContain('2 top-ups')
   })
 
+  it('claims nothing while placement is still loading, even with the series in hand', () => {
+    // `hosted` is empty while agents load — and group-placed agents classify as pool-placed
+    // while the set ids load — so a figure rendered now would be a confident wrong number.
+    mocks.daemons = [member('p1')]
+    mocks.agents = [onPool('a1')]
+    mocks.agentsLoading = true
+
+    const html = render()
+
+    expect(html).toContain('animate-pulse')
+    expect(html).not.toContain('$8.00')
+    expect(html).not.toContain('$0.00 / day')
+  })
+
+  it('keeps the stale figure through a failed revalidation instead of contradicting the chart', () => {
+    // SWR retains `data` when a revalidation fails; the chart below still draws that series,
+    // so the header must not flip to "unavailable" beside it.
+    mocks.daemons = [member('p1')]
+    mocks.agents = [onPool('a1')]
+    mocks.usage = { data: usageOverPool(), error: new Error('fetch failed') }
+    mocks.topUps = { data: [credit(4, 20_000_000)], error: new Error('fetch failed') }
+
+    const html = render()
+
+    expect(html).toContain('$8.00')
+    expect(html).toContain('$20.00')
+    expect(html).not.toContain('unavailable')
+  })
+
+  it('keeps a negative credit in the net total but out of the chart and the count', () => {
+    // Stacked on a positive spend base, a negative segment draws downward over the brand bar —
+    // and it is not a "top-up", so the note counts only the positive rows the chart marks.
+    mocks.daemons = [member('p1')]
+    mocks.agents = [onPool('a1')]
+    mocks.topUps = { data: [credit(4, 20_000_000), { ...credit(25, -5_000_000), kind: 'adjustment' as const }] }
+
+    const html = render()
+
+    expect(html).toContain('$15.00')
+    expect(html).toContain('1 top-up')
+    expect(html).not.toContain('2 top-ups')
+  })
+
   it("holds the chart's footprint while the first load is in flight", () => {
     // A card that collapsed to its figures and grew a chart underneath would shove the page
     // down the moment the series lands.

--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   agents: [] as unknown[],
   integrations: [] as unknown[],
   daemonsLoading: false,
+  agentsLoading: false,
+  memberSetsLoading: false,
   balance: { data: { orgId: 'org-pool', balanceMicro: 38_740_000 } } as Record<string, unknown>,
   usage: {} as Record<string, unknown>,
   topUps: {} as Record<string, unknown>,
@@ -31,6 +33,8 @@ vi.mock('@/lib/data-context', () => ({
     daemons: mocks.daemons,
     daemonsLoading: mocks.daemonsLoading,
     agents: mocks.agents,
+    agentsLoading: mocks.agentsLoading,
+    memberSetsLoading: mocks.memberSetsLoading,
     integrations: mocks.integrations
   })
 }))
@@ -155,6 +159,8 @@ beforeEach(() => {
   mocks.agents = []
   mocks.integrations = []
   mocks.daemonsLoading = false
+  mocks.agentsLoading = false
+  mocks.memberSetsLoading = false
   mocks.balance = { data: { orgId: 'org-pool', balanceMicro: 38_740_000 } }
   mocks.usage = { data: usageOverPool() }
   mocks.topUps = { data: [] }
@@ -394,7 +400,10 @@ describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
     // that number is the one thing this card must not do.
     mocks.daemons = [member('p1')]
     mocks.agents = [onPool('a1')]
-    mocks.usage = { data: { ...usageOverPool(), series: { bucket: 'day', points: [] } } }
+    // The split absent on every point — the shape an older CP actually sends (a current CP
+    // never returns an empty series; its bucket count is floored at 1).
+    const noSplit = usageOverPool().series.points.map(({ byAgent: _, ...p }) => p)
+    mocks.usage = { data: { ...usageOverPool(), series: { bucket: 'day' as const, points: noSplit } } }
 
     const html = render()
 

--- a/packages/web/src/components/console/views/ClusterDetailView.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.tsx
@@ -57,7 +57,8 @@ import { useOrgs } from '@/lib/org-context'
 export default function ClusterDetailView() {
   const { orgPath } = useOrgs()
   const router = useRouter()
-  const { daemons, agents, integrations, orgSetIds, daemonsLoading } = useConsoleData()
+  const { daemons, agents, integrations, orgSetIds, daemonsLoading, agentsLoading, memberSetsLoading } =
+    useConsoleData()
 
   const showPool = featureFlagEnabled('daemon-pool')
   // Whose infrastructure the pool IS decides how the page reads — see the file header.
@@ -216,7 +217,7 @@ export default function ClusterDetailView() {
             report. Neither borrows the other's figure — a plan's included usage cannot be
             derived from load telemetry, and a self-hoster is billed nothing here. */}
         {managed ? (
-          billingOffered && <CloudCreditsCard hosted={hosted} />
+          billingOffered && <CloudCreditsCard hosted={hosted} placementLoading={agentsLoading || memberSetsLoading} />
         ) : (
           <ClusterCapacityCard {...{ capacityLabel, capacityPct, unbounded, cpu, mem }} />
         )}
@@ -307,6 +308,11 @@ function MetaItem({ icon, text, mono = false }: { icon: string; text: string; mo
 // agents can be summed out of it and nothing else is counted. A CP predating that split can
 // only answer for the whole org, so the card reports the figure as unavailable rather than
 // quoting a number this page has just promised it is not.
+//
+// One approximation remains, and it is the axis the rollup does not have: placement is
+// CURRENT-state while the series is historical, so an agent moved onto the pool brings its
+// whole 30 days along (spend it incurred on a self-connected daemon), and one moved off drops
+// its real Cloud spend. Exact scoping needs a placement dimension in the CP's rollup.
 const CREDITS_WINDOW_DAYS = 30
 const DAY_MS = 24 * 60 * 60 * 1000
 // Two series, one shared axis: both are USD, and a second axis scaled to make a $0.40 day
@@ -339,7 +345,7 @@ async function fetchTopUps(orgId: string, sinceMs: number): Promise<BillingCredi
   return credits
 }
 
-function CloudCreditsCard({ hosted }: { hosted: readonly Agent[] }) {
+function CloudCreditsCard({ hosted, placementLoading }: { hosted: readonly Agent[]; placementLoading: boolean }) {
   const { activeOrg } = useOrgs()
   const orgId = activeOrg?.id ?? null
   // Same `billingAccount` key the Billing page reads, so the two pages cannot disagree.
@@ -357,18 +363,30 @@ function CloudCreditsCard({ hosted }: { hosted: readonly Agent[] }) {
     ? points.map((p) => sumAmounts(Object.entries(p.byAgent ?? {}).flatMap(([id, c]) => (poolIds.has(id) ? [c] : []))))
     : []
   const spent = sumAmounts(daily)
-  const days = daily.length || CREDITS_WINDOW_DAYS
-  const spendError = usage.error
-    ? (usage.error as Error).message
-    : usage.data && !scoped
-      ? 'this control plane does not split spend per agent, so the Cloud-only figure cannot be separated from the org total'
-      : undefined
+  // The spend figure needs BOTH sides settled: the series, and the placement that scopes it.
+  // `hosted` is empty while agents load, and worse, group-placed agents classify as pool-placed
+  // while `orgSetIds` is empty — either would render a confident wrong figure for a round trip.
+  const spendLoading = usage.isLoading || placementLoading
+  // An error is the figure's state only while there is nothing to show: SWR keeps `data` across
+  // a failed revalidation, and flipping the header to "unavailable" beside a chart still drawn
+  // from that same retained series would have the card disagree with itself.
+  const spendError =
+    usage.error && !usage.data
+      ? (usage.error as Error).message
+      : usage.data && !scoped
+        ? 'this control plane does not split spend per agent, so the Cloud-only figure cannot be separated from the org total'
+        : undefined
 
   const credits = topUps.data ?? []
+  // The NET of the credit side — a negative adjustment subtracts, which is what the balance
+  // does with it too.
   const toppedUpMicro = credits.reduce((sum, c) => sum + c.amountMicro, 0)
   // A top-up lands on the bucket it posted into: the last one that started at or before it.
+  // Negative credits stay out of the chart: stacked on a positive spend base, a negative
+  // segment draws DOWNWARD over the brand bar — they are in the net total above instead.
   const topUpByDay = new Map<number, number>()
   for (const c of credits) {
+    if (c.amountMicro <= 0) continue
     const at = Date.parse(c.at)
     for (let i = points.length - 1; i >= 0; i--) {
       if (Date.parse(points[i]!.start) <= at) {
@@ -431,17 +449,24 @@ function CloudCreditsCard({ hosted }: { hosted: readonly Agent[] }) {
           label={`Topped up · ${CREDITS_WINDOW_DAYS}d`}
           value={topUps.data ? fmtMicroUsd(toppedUpMicro) : '—'}
           note={topUps.data ? `${credits.length} top-up${credits.length === 1 ? '' : 's'}` : ' '}
-          error={topUps.error ? (topUps.error as Error).message : undefined}
+          error={topUps.error && !topUps.data ? (topUps.error as Error).message : undefined}
           loading={topUps.isLoading}
         />
         <span className="w-px flex-none self-stretch bg-(--border-subtle)" />
         <Figure
           label={`Spent · ${CREDITS_WINDOW_DAYS}d`}
           value={scoped ? fmtDecimalUsd(spent) : '—'}
-          note={scoped ? `avg ${fmtMicroUsd(Math.round((amountToNumber(spent) / days) * 1_000_000))} / day` : ' '}
+          // Divided by the labelled window, not `daily.length`: the CP floors the window's
+          // start to a local day boundary, so a 30-day span is 31 buckets whenever "now" is
+          // not midnight, and the edge two are partial days.
+          note={
+            scoped
+              ? `avg ${fmtMicroUsd(Math.round((amountToNumber(spent) / CREDITS_WINDOW_DAYS) * 1_000_000))} / day`
+              : ' '
+          }
           error={spendError}
           valueClass="text-[20px] text-(--brand) desktop:text-[24px]"
-          loading={usage.isLoading}
+          loading={spendLoading}
         />
         <Figure
           className="ml-auto flex-none text-right"
@@ -450,7 +475,7 @@ function CloudCreditsCard({ hosted }: { hosted: readonly Agent[] }) {
           // Not only unreachability: `assertAccount` throws BillingShapeError on an unexpected
           // shape and lands here too — likely, since this console deploys ahead of the pinned
           // billing image. So the label stays neutral and the service's own message says which.
-          error={account.error ? (account.error as Error).message : undefined}
+          error={account.error && !account.data ? (account.error as Error).message : undefined}
           valueClass="text-[18px]"
           loading={account.isLoading}
           note="USD"
@@ -465,9 +490,9 @@ function CloudCreditsCard({ hosted }: { hosted: readonly Agent[] }) {
           $50 top-up would be the misleading chart. `minPointSize` keeps the small side
           readable — a pixel floor under any nonzero value, and 0 for a day with none, so an
           idle day still draws nothing. */}
-      {(usage.isLoading || chartData.length > 0) && (
+      {(spendLoading || chartData.length > 0) && (
         <>
-          {usage.isLoading ? (
+          {spendLoading ? (
             <SpendSkeleton />
           ) : (
             <div className={`min-h-[140px] flex-1 px-[6px] pb-[6px] text-(--text-tertiary) ${SEG_FILL} ${SERIES_FILL}`}>

--- a/packages/web/src/components/console/views/ClusterDetailView.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.tsx
@@ -23,10 +23,20 @@
 import { useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import useSWR from 'swr'
-import { isPoolPlacementKind, poolFleetStatus, poolLabel, status, type DaemonRow } from '@/lib/data'
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
+import { isPoolPlacementKind, poolFleetStatus, poolLabel, status, type Agent, type DaemonRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { consoleKeys } from '@/lib/swr-keys'
-import { fetchBillingAccount, fmtMicroUsd } from '@/lib/billing-api'
+import { fetchUsage } from '@/lib/api'
+import { amountToNumber, sumAmounts } from '@/lib/amount'
+import { SEG_FILL, bucketLabel, tickInterval } from '@/lib/spend-chart'
+import {
+  fetchBillingAccount,
+  fetchBillingTransactions,
+  fmtDecimalUsd,
+  fmtMicroUsd,
+  type BillingCredit
+} from '@/lib/billing-api'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { NotFound } from '@/components/console/NotFound'
 import {
@@ -198,7 +208,7 @@ export default function ClusterDetailView() {
       </div>
 
       <div
-        className={`mb-[18px] grid grid-cols-1 items-start gap-[18px] ${
+        className={`mb-[18px] grid grid-cols-1 gap-[18px] ${
           managed && !billingOffered ? '' : 'desktop:grid-cols-[1.15fr_1fr]'
         }`}
       >
@@ -206,7 +216,7 @@ export default function ClusterDetailView() {
             report. Neither borrows the other's figure — a plan's included usage cannot be
             derived from load telemetry, and a self-hoster is billed nothing here. */}
         {managed ? (
-          billingOffered && <CloudCreditsCard />
+          billingOffered && <CloudCreditsCard hosted={hosted} />
         ) : (
           <ClusterCapacityCard {...{ capacityLabel, capacityPct, unbounded, cpu, mem }} />
         )}
@@ -286,152 +296,296 @@ function MetaItem({ icon, text, mono = false }: { icon: string; text: string; mo
   )
 }
 
-// The BALANCE here is live. The 30-day figures and the chart are sample data, and the card says
-// so — the two are separated because the balance endpoint already works today, and a fabricated
-// balance beside a "Manage billing" link to the real one would read as headroom the org has.
+// Every figure here is live, and the two halves of "credits" come from two services because
+// that is where they live: the balance and the top-ups are the billing service's ledger, the
+// daily spend is the CP's usage rollup.
 //
-// What is missing is the daily series: the billing service's debits carry a `period` of
-// `YYYY-MM`, so they are MONTHLY aggregates and no per-day spend can be recovered from them.
-// So the card's shape ships and those numbers wait. Wiring them is a mechanical swap:
+// The spend is NOT read off the billing debits, and scope is the whole reason. A debit's
+// `period` is `YYYY-MM`, so it is a monthly aggregate of the org's ENTIRE usage — quoting it
+// here would contradict this page's own footnote about agents on daemons you connected
+// yourself. `fetchUsage('d30')` buckets cost per day with a `byAgent` split, so the pool's
+// agents can be summed out of it and nothing else is counted. A CP predating that split can
+// only answer for the whole org, so the card reports the figure as unavailable rather than
+// quoting a number this page has just promised it is not.
+const CREDITS_WINDOW_DAYS = 30
+const DAY_MS = 24 * 60 * 60 * 1000
+// Two series, one shared axis: both are USD, and a second axis scaled to make a $0.40 day
+// look like a $50 top-up would be the misleading chart. SVG `fill` can't take a `var()`
+// attribute, so the hues are descendant rules on the wrapper — the trick `SEG_FILL` uses.
+const SERIES_FILL = '[&_.bar-spend_path]:fill-(--brand) [&_.bar-topup_path]:fill-(--green-500)'
+// The window goes to the service as `from`, so a long ledger costs one page here instead of
+// however many it takes to walk back 30 days. The client-side cut stays: a billing image that
+// predates the parameter ignores it and answers with everything, and this console deploys
+// ahead of that image — summing what came back would then quote the wrong figure, silently.
 //
-//   TOPPED UP · 30D  → the credit rows in the transaction feed, summed over the window
-//   SPENT · 30D      → needs a DAILY spend series the service does not expose yet
-//   the bars         → the same daily series, with credits placed on the day they posted
-//
-// Scope matters when that lands: the spend has to cover only what ran on Cloud, or the card
-// contradicts this page's own footnote about agents on daemons you connected yourself. The usage
-// API is the likely source — `fetchUsage('d30')` already buckets cost per day with a `byAgent`
-// split, which is what makes the Cloud-only scoping possible.
-const SAMPLE_TOPPED_UP_MICRO = 1_800_000_000
-// Daily spend in cents. Fixed, never generated: a random walk would redraw on every render and
-// read as live data.
-const SAMPLE_SPEND = [
-  3_780, 4_240, 3_960, 4_680, 5_120, 3_540, 2_980, 4_320, 5_040, 5_480, 6_120, 5_260, 4_880, 3_240, 2_760, 5_180, 5_720,
-  6_040, 6_680, 5_840, 4_620, 3_880, 3_420, 5_560, 6_240, 6_920, 5_380, 4_740, 5_020, 5_960
-]
-const SAMPLE_TOP_UP_DAYS = new Set([4, 14, 25])
-const MICRO_PER_CENT = 10_000
-// Derived, not stated: the total and the bars come from ONE series once this is wired, so the
-// placeholder has to satisfy that invariant too — otherwise whoever wires it has no reference to
-// check their work against.
-const SAMPLE_SPENT_MICRO = SAMPLE_SPEND.reduce((sum, cents) => sum + cents, 0) * MICRO_PER_CENT
+// The page cap is a runaway guard, not a policy: an org that tops up more times than this in
+// 30 days under-reports rather than paging its whole ledger for one total.
+const TOPUP_MAX_PAGES = 10
 
-function CloudCreditsCard() {
+async function fetchTopUps(orgId: string, sinceMs: number): Promise<BillingCredit[]> {
+  const from = new Date(sinceMs).toISOString()
+  const credits: BillingCredit[] = []
+  let cursor: string | undefined
+  for (let page = 0; page < TOPUP_MAX_PAGES; page++) {
+    const { items, nextCursor } = await fetchBillingTransactions(orgId, cursor, { from })
+    // Rows are newest-first, so the window ends at the first row older than it. An unparseable
+    // `at` compares false and stays — a row this side cannot date must not silently truncate
+    // the ones behind it.
+    const older = items.findIndex((t) => Date.parse(t.at) < sinceMs)
+    for (const row of older < 0 ? items : items.slice(0, older)) if (row.type === 'credit') credits.push(row)
+    if (older >= 0 || !nextCursor) break
+    cursor = nextCursor
+  }
+  return credits
+}
+
+function CloudCreditsCard({ hosted }: { hosted: readonly Agent[] }) {
   const { activeOrg } = useOrgs()
   const orgId = activeOrg?.id ?? null
-  const account = useSWR(orgId ? consoleKeys.billingAccount(orgId) : null, () => fetchBillingAccount(orgId!))
-  const peak = Math.max(...SAMPLE_SPEND)
+  // Same `billingAccount` key the Billing page reads, so the two pages cannot disagree.
+  const account = useSWR(consoleKeys.billingAccount(orgId), () => fetchBillingAccount(orgId!))
+  const usage = useSWR(consoleKeys.usage(orgId, 'd30'), () => fetchUsage('d30', orgId!))
+  const topUps = useSWR(consoleKeys.billingTopUps(orgId), () =>
+    fetchTopUps(orgId!, Date.now() - CREDITS_WINDOW_DAYS * DAY_MS)
+  )
+
+  const points = usage.data?.series?.points ?? []
+  const poolIds = new Set(hosted.map((a) => a.id))
+  // `byAgent` is optional on the wire; without it there is no Cloud-only figure to quote.
+  const scoped = points.some((p) => p.byAgent)
+  const daily = scoped
+    ? points.map((p) => sumAmounts(Object.entries(p.byAgent ?? {}).flatMap(([id, c]) => (poolIds.has(id) ? [c] : []))))
+    : []
+  const spent = sumAmounts(daily)
+  const days = daily.length || CREDITS_WINDOW_DAYS
+  const spendError = usage.error
+    ? (usage.error as Error).message
+    : usage.data && !scoped
+      ? 'this control plane does not split spend per agent, so the Cloud-only figure cannot be separated from the org total'
+      : undefined
+
+  const credits = topUps.data ?? []
+  const toppedUpMicro = credits.reduce((sum, c) => sum + c.amountMicro, 0)
+  // A top-up lands on the bucket it posted into: the last one that started at or before it.
+  const topUpByDay = new Map<number, number>()
+  for (const c of credits) {
+    const at = Date.parse(c.at)
+    for (let i = points.length - 1; i >= 0; i--) {
+      if (Date.parse(points[i]!.start) <= at) {
+        topUpByDay.set(i, (topUpByDay.get(i) ?? 0) + c.amountMicro)
+        break
+      }
+    }
+  }
+
+  // One recharts row per bucket. `spend` is geometry, so the amount becomes a number here and
+  // nowhere else; the exact string is what `spent` above was summed from.
+  const bucket = usage.data?.series?.bucket ?? 'day'
+  const chartData = daily.map((amount, day) => ({
+    label: bucketLabel(points[day]!.start, bucket),
+    spend: amountToNumber(amount),
+    topUp: (topUpByDay.get(day) ?? 0) / 1_000_000
+  }))
+
+  // Pixel floor for a nonzero segment, so a cent beside a $50 top-up is still visible — and 0
+  // for a segment with nothing, so it draws nothing. The callback reads the row's own field:
+  // in a stack, recharts hands it the segment's cumulative TOP, so a zero top-up capping a
+  // nonzero spend would otherwise inherit the spend's "nonzero" and get floored into a green
+  // cap on a day nothing was topped up.
+  const minBar = (key: 'spend' | 'topUp') => (_: number | null | undefined, index: number) =>
+    (chartData[index]?.[key] ?? 0) > 0 ? 3 : 0
+
+  type TipRow = { payload: (typeof chartData)[number] }
+  const Tip = ({ active, payload }: { active?: boolean; payload?: TipRow[] }) => {
+    const row = active ? payload?.[0]?.payload : undefined
+    if (!row) return null
+    return (
+      <div className="rounded-md border border-(--border-subtle) bg-(--surface-card) px-2.5 py-2 shadow-(--shadow-md)">
+        <div className="mono text-[11px] font-semibold text-(--text-primary)">{row.label}</div>
+        <div className="mt-1 flex items-center gap-[6px] font-sans text-[11px] leading-normal text-(--text-secondary)">
+          <span className="h-[9px] w-[9px] flex-none rounded-[2px] bg-(--brand)" />
+          spent <span className="mono text-(--text-primary)">{fmtMicroUsd(Math.round(row.spend * 1_000_000))}</span>
+        </div>
+        {row.topUp > 0 && (
+          <div className="mt-1 flex items-center gap-[6px] font-sans text-[11px] leading-normal text-(--text-secondary)">
+            <span className="h-[9px] w-[9px] flex-none rounded-[2px] bg-(--green-500)" />
+            topped up{' '}
+            <span className="mono text-(--text-primary)">{fmtMicroUsd(Math.round(row.topUp * 1_000_000))}</span>
+          </div>
+        )}
+      </div>
+    )
+  }
 
   return (
-    <div className="card">
+    // `min-w-0`: recharts measures this box, and a grid item's auto min-width would otherwise
+    // let the plot widen its own column.
+    <div className="card flex min-w-0 flex-col">
       <div className="cardhead">
         <span className="cardtitle">Credits</span>
-        <span className="mono ml-auto text-[11px] text-(--text-tertiary)">last 30 days</span>
+        <span className="mono ml-auto text-[11px] text-(--text-tertiary)">last {CREDITS_WINDOW_DAYS} days</span>
       </div>
 
       <div className="flex flex-wrap items-start gap-x-4 gap-y-3 px-4 pt-[15px] pb-[13px] desktop:gap-x-5">
-        <div className="min-w-0">
-          <div className="eyebrow flex items-center gap-[6px]">
-            Topped up · 30d
-            <SampleChip />
-          </div>
-          <div className="mono mt-[6px] text-[20px] leading-none font-semibold tracking-[-.02em] desktop:text-[24px]">
-            {fmtMicroUsd(SAMPLE_TOPPED_UP_MICRO)}
-          </div>
-          <div className="mt-[7px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-            {SAMPLE_TOP_UP_DAYS.size} top-ups
-          </div>
-        </div>
+        <Figure
+          label={`Topped up · ${CREDITS_WINDOW_DAYS}d`}
+          value={topUps.data ? fmtMicroUsd(toppedUpMicro) : '—'}
+          note={topUps.data ? `${credits.length} top-up${credits.length === 1 ? '' : 's'}` : ' '}
+          error={topUps.error ? (topUps.error as Error).message : undefined}
+          loading={topUps.isLoading}
+        />
         <span className="w-px flex-none self-stretch bg-(--border-subtle)" />
-        <div className="min-w-0">
-          <div className="eyebrow flex items-center gap-[6px]">
-            Spent · 30d
-            <SampleChip />
-          </div>
-          <div className="mono mt-[6px] text-[20px] leading-none font-semibold tracking-[-.02em] text-(--brand) desktop:text-[24px]">
-            {fmtMicroUsd(SAMPLE_SPENT_MICRO)}
-          </div>
-          <div className="mt-[7px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-            avg {fmtMicroUsd(Math.round(SAMPLE_SPENT_MICRO / SAMPLE_SPEND.length))} / day
-          </div>
-        </div>
-        {/* The one live figure, and the reason the others are chipped: this is the same
-            `billingAccount` key the Billing page reads, so the two pages cannot disagree. */}
-        <div className="ml-auto flex-none text-right">
-          <div className="eyebrow">Balance</div>
-          {account.error ? (
-            // Not only unreachability: `assertAccount` throws BillingShapeError on an unexpected
-            // shape and lands here too — likely, since this console deploys ahead of the pinned
-            // billing image. So the label stays neutral and the service's own message says which.
-            <div
-              className="mt-[6px] inline-flex items-center gap-[6px] font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)"
-              title={(account.error as Error).message}
-            >
-              <Icon name="triangle-alert" size={14} color="var(--status-error)" />
-              unavailable
-            </div>
+        <Figure
+          label={`Spent · ${CREDITS_WINDOW_DAYS}d`}
+          value={scoped ? fmtDecimalUsd(spent) : '—'}
+          note={scoped ? `avg ${fmtMicroUsd(Math.round((amountToNumber(spent) / days) * 1_000_000))} / day` : ' '}
+          error={spendError}
+          valueClass="text-[20px] text-(--brand) desktop:text-[24px]"
+          loading={usage.isLoading}
+        />
+        <Figure
+          className="ml-auto flex-none text-right"
+          label="Balance"
+          value={account.data ? fmtMicroUsd(account.data.balanceMicro) : '—'}
+          // Not only unreachability: `assertAccount` throws BillingShapeError on an unexpected
+          // shape and lands here too — likely, since this console deploys ahead of the pinned
+          // billing image. So the label stays neutral and the service's own message says which.
+          error={account.error ? (account.error as Error).message : undefined}
+          valueClass="text-[18px]"
+          loading={account.isLoading}
+          note="USD"
+        />
+      </div>
+
+      {/* Two series on one shared axis, STACKED rather than grouped: a grouped pair reserves
+          half of every day's band for a top-up, on all 30 days, and top-ups happen on three of
+          them — so both bars end up half-width for nothing. Stacked, a day is one full-width
+          bar, which is the design's proportion, and a day with no top-up is simply all spend.
+          One axis on purpose: both are USD, and a second axis scaled so a $0.40 day matched a
+          $50 top-up would be the misleading chart. `minPointSize` keeps the small side
+          readable — a pixel floor under any nonzero value, and 0 for a day with none, so an
+          idle day still draws nothing. */}
+      {(usage.isLoading || chartData.length > 0) && (
+        <>
+          {usage.isLoading ? (
+            <SpendSkeleton />
           ) : (
-            <div className="mono mt-[6px] text-[18px] leading-none font-semibold">
-              {account.data ? fmtMicroUsd(account.data.balanceMicro) : '—'}
+            <div className={`min-h-[140px] flex-1 px-[6px] pb-[6px] text-(--text-tertiary) ${SEG_FILL} ${SERIES_FILL}`}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: 8 }} barCategoryGap="12%">
+                  <XAxis
+                    dataKey="label"
+                    interval={tickInterval(chartData.length)}
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={6}
+                    tick={{ fill: 'currentColor', fontSize: 10.5 }}
+                    className="mono"
+                  />
+                  <Tooltip content={<Tip />} cursor={{ fill: 'var(--surface-hover)' }} />
+                  {/* Spend on the baseline, the top-up capping it — and the radius on both, so
+                      whichever segment ends up on top of a given day is the rounded one. */}
+                  <Bar
+                    dataKey="spend"
+                    name="daily spend"
+                    className="bar-spend"
+                    stackId="day"
+                    radius={[3, 3, 0, 0]}
+                    minPointSize={minBar('spend')}
+                  />
+                  <Bar
+                    dataKey="topUp"
+                    name="top-up"
+                    className="bar-topup"
+                    stackId="day"
+                    radius={[3, 3, 0, 0]}
+                    minPointSize={minBar('topUp')}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
             </div>
           )}
-        </div>
-      </div>
 
-      {/* Decoration until the series is real, so it is aria-hidden rather than announced as a
-          figure a reader could act on. Every bar is spend: a top-up is a tick UNDER the axis, not
-          a recoloured bar, because a green bar whose HEIGHT is that day's spend reads as the
-          top-up's amount — and this shape is what gets wired. */}
-      <div aria-hidden className="px-4">
-        <div className="flex h-[96px] items-end gap-[3px]">
-          {SAMPLE_SPEND.map((cents, day) => (
-            <span
-              key={day}
-              className="min-w-0 flex-1 rounded-t-[2px] bg-(--brand)"
-              style={{ height: `${Math.max(6, Math.round((cents / peak) * 100))}%` }}
-            />
-          ))}
-        </div>
-        <div className="mt-[3px] flex gap-[3px] border-t border-(--border-subtle) pt-[3px]">
-          {SAMPLE_SPEND.map((_, day) => (
-            <span
-              key={day}
-              className="h-[3px] min-w-0 flex-1 rounded-[1px]"
-              style={{ background: SAMPLE_TOP_UP_DAYS.has(day) ? 'var(--green-500)' : 'transparent' }}
-            />
-          ))}
-        </div>
-      </div>
-
-      {/* Relative, not dated: "Jul 21 / Aug 20" would be right today and wrong tomorrow, and a
-          reader who reads the chip as covering the figures need not extend it to the axis. */}
-      <div className="flex items-center gap-3 px-4 pt-[9px] pb-[13px]">
-        <span className="mono text-[11px] text-(--text-tertiary)">30 days ago</span>
-        <span className="mx-auto flex items-center gap-3">
-          <span className="inline-flex items-center gap-[6px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-            <span className="dot h-[7px] w-[7px] bg-(--brand)" />
-            daily spend
-          </span>
-          <span className="inline-flex items-center gap-[6px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-            <span className="h-[3px] w-[10px] rounded-[1px] bg-(--green-500)" />
-            top-up day
-          </span>
-        </span>
-        <span className="mono text-[11px] text-(--text-tertiary)">today</span>
-      </div>
+          <div className="flex items-center justify-center gap-3 px-4 pb-[13px]">
+            <span className="inline-flex items-center gap-[6px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+              <span className="h-[9px] w-[9px] rounded-[2px] bg-(--brand)" />
+              daily spend
+            </span>
+            <span className="inline-flex items-center gap-[6px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+              <span className="h-[9px] w-[9px] rounded-[2px] bg-(--green-500)" />
+              top-up
+            </span>
+          </div>
+        </>
+      )}
     </div>
   )
 }
 
-/** Marks one figure as sample data. Per-figure, because the Balance beside them is live. */
-function SampleChip() {
+/** First-load stand-in for the chart: the same 140px body, so data landing shifts nothing.
+ *  Heights are a fixed pattern, never random — a random walk redraws on every render. */
+function SpendSkeleton() {
   return (
-    <span
-      className="badge bg-(--surface-active) text-(--text-tertiary)"
-      title="Sample data — billing cannot serve a daily spend series yet"
-    >
-      sample
-    </span>
+    <div className="flex min-h-[140px] flex-1 animate-pulse items-end gap-[3px] px-[14px] pt-3 pb-[26px]">
+      {Array.from({ length: CREDITS_WINDOW_DAYS }, (_, i) => (
+        <span
+          key={i}
+          className="min-w-0 max-w-[22px] flex-1 rounded-t-[3px] bg-(--surface-active)"
+          style={{ height: `${24 + ((i * 23 + 13) % 60)}%` }}
+        />
+      ))}
+    </div>
+  )
+}
+
+/** One figure in the Credits header. Each has its own source, so each fails on its own: a
+ *  dash where a request failed would read as zero, which is a number the org could act on. */
+function Figure({
+  label,
+  value,
+  note,
+  error,
+  loading = false,
+  valueClass = 'text-[20px] desktop:text-[24px]',
+  className = ''
+}: {
+  label: string
+  value: string
+  note?: string
+  error?: string
+  loading?: boolean
+  valueClass?: string
+  className?: string
+}) {
+  return (
+    <div className={`min-w-0 ${className}`}>
+      <div className="eyebrow">{label}</div>
+      {loading ? (
+        <>
+          <span className="mt-[6px] inline-block h-[22px] w-24 animate-pulse rounded-md bg-(--surface-active)" />
+          <div className="mt-[9px]">
+            <span className="inline-block h-[10px] w-16 animate-pulse rounded-full bg-(--surface-active)" />
+          </div>
+        </>
+      ) : error ? (
+        <div
+          className="mt-[6px] inline-flex items-center gap-[6px] font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)"
+          title={error}
+        >
+          <Icon name="triangle-alert" size={14} color="var(--status-error)" />
+          unavailable
+        </div>
+      ) : (
+        <>
+          <div className={`mono mt-[6px] leading-none font-semibold tracking-[-.02em] ${valueClass}`}>{value}</div>
+          {note && (
+            <div className="mt-[7px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+              {note}
+            </div>
+          )}
+        </>
+      )}
+    </div>
   )
 }
 

--- a/packages/web/src/components/console/views/ClusterDetailView.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.tsx
@@ -381,6 +381,9 @@ function CloudCreditsCard({ hosted, placementLoading }: { hosted: readonly Agent
   // The NET of the credit side — a negative adjustment subtracts, which is what the balance
   // does with it too.
   const toppedUpMicro = credits.reduce((sum, c) => sum + c.amountMicro, 0)
+  // The note counts what the word means and the chart marks — the positive rows. A negative
+  // adjustment stays in the net value above but is not a "top-up" and draws no bar.
+  const topUpCount = credits.filter((c) => c.amountMicro > 0).length
   // A top-up lands on the bucket it posted into: the last one that started at or before it.
   // Negative credits stay out of the chart: stacked on a positive spend base, a negative
   // segment draws DOWNWARD over the brand bar — they are in the net total above instead.
@@ -448,7 +451,7 @@ function CloudCreditsCard({ hosted, placementLoading }: { hosted: readonly Agent
         <Figure
           label={`Topped up · ${CREDITS_WINDOW_DAYS}d`}
           value={topUps.data ? fmtMicroUsd(toppedUpMicro) : '—'}
-          note={topUps.data ? `${credits.length} top-up${credits.length === 1 ? '' : 's'}` : ' '}
+          note={topUps.data ? `${topUpCount} top-up${topUpCount === 1 ? '' : 's'}` : ' '}
           error={topUps.error && !topUps.data ? (topUps.error as Error).message : undefined}
           loading={topUps.isLoading}
         />

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import useSWR from 'swr'
 import { Bar, BarChart, Legend, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
+import { SEG_FILL, bucketLabel, tickInterval } from '@/lib/spend-chart'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { fetchUsage, fmtCost, fmtCountCompact as fmtCompact, type UsageRange } from '@/lib/api'
 import { amountToNumber, sumAmounts } from '@/lib/amount'
@@ -28,32 +29,6 @@ const MOBILE_RANGES: { key: UsageRange; label: string }[] = [
   { key: 'd30', label: '30 days' }
 ]
 
-// SVG `fill` can't take a `var()` presentation attribute, so the stacked-bar hues
-// are applied as descendant CSS rules on the chart wrapper (a real declaration
-// out-ranks recharts' own `fill` attribute) — that keeps the bars theme-reactive
-// with no JS reading computed styles. Literal strings so Tailwind can see them.
-const SEG_FILL = [
-  '[&_.seg-0_path]:fill-(--chart-1)',
-  '[&_.seg-1_path]:fill-(--chart-2)',
-  '[&_.seg-2_path]:fill-(--chart-3)',
-  '[&_.seg-3_path]:fill-(--chart-4)',
-  '[&_.seg-4_path]:fill-(--chart-5)',
-  '[&_.seg-5_path]:fill-(--chart-6)',
-  '[&_.seg-6_path]:fill-(--chart-other)',
-  '[&_.seg-flat_path]:fill-(--brand)',
-  // recharts' accessibility layer makes the chart surface focusable, so clicking a
-  // bar leaves a UA focus ring around the whole plot. Drop the default outline but
-  // keep a themed one for :focus-visible, so keyboard users still see where focus is.
-  '[&_.recharts-wrapper]:outline-none',
-  '[&_.recharts-surface]:outline-none',
-  '[&_.recharts-wrapper:focus-visible]:outline-2',
-  '[&_.recharts-wrapper:focus-visible]:outline-offset-2',
-  '[&_.recharts-wrapper:focus-visible]:outline-(--border-focus)',
-  '[&_.recharts-surface:focus-visible]:outline-2',
-  '[&_.recharts-surface:focus-visible]:outline-offset-2',
-  '[&_.recharts-surface:focus-visible]:outline-(--border-focus)'
-].join(' ')
-
 const GRID = 'grid-cols-[2fr_1fr_1fr_1fr_1.4fr]'
 
 // How the usage table is broken down. Runtime is derived from the per-agent
@@ -65,16 +40,6 @@ const GROUPS: { key: GroupBy; label: string }[] = [
   { key: 'runtime', label: 'By runtime' },
   { key: 'model', label: 'By model' }
 ]
-
-// Buckets are aligned to the viewer's local day/hour (the CP flooring uses the
-// tz offset we send), so `start` is the UTC instant of a local boundary — label
-// it in local time to read as that local date/hour.
-function bucketLabel(iso: string, bucket: 'hour' | 'day'): string {
-  const d = new Date(iso)
-  return bucket === 'hour'
-    ? `${String(d.getHours()).padStart(2, '0')}:00`
-    : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-}
 
 export default function UsageView() {
   const { orgPath, activeOrg, orgs, loading: orgLoading, error: orgError } = useOrgs()
@@ -317,7 +282,6 @@ export default function UsageView() {
       {data?.series &&
         (() => {
           const pts = data.series.points
-          const labelEvery = Math.max(1, Math.ceil(pts.length / 8))
           const unit = (currency ?? 'USD').toUpperCase()
           // Full IANA zone name (e.g. "Asia/Shanghai") — the buckets are aligned to
           // this zone, so tell the viewer. Client-only: the chart never renders on
@@ -472,7 +436,7 @@ export default function UsageView() {
                   <BarChart data={chartData} margin={{ top: 0, right: 8, bottom: 0, left: 8 }} barCategoryGap="18%">
                     <XAxis
                       dataKey="label"
-                      interval={labelEvery - 1}
+                      interval={tickInterval(pts.length)}
                       tickLine={false}
                       axisLine={false}
                       tickMargin={6}

--- a/packages/web/src/lib/billing-api.test.ts
+++ b/packages/web/src/lib/billing-api.test.ts
@@ -3,12 +3,13 @@
 // hypothetical. These checks pin the one property that makes the copy tolerable:
 // a response that does not match is REFUSED at the boundary, so the page shows
 // its error card instead of rendering `$NaN` where a balance belongs.
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   assertAccount,
   assertPurchase,
   assertPurchaseCreated,
   assertTransactionsPage,
+  fetchBillingTransactions,
   fmtDecimalUsd,
   BillingShapeError,
   fmtMicroUsd
@@ -194,5 +195,58 @@ describe('fmtDecimalUsd', () => {
   it('keeps the sign outside the symbol, matching fmtMicroUsd', () => {
     expect(fmtDecimalUsd('-0.5')).toBe('-$0.50')
     expect(fmtDecimalUsd('-0.001234')).toBe('-$0.001234')
+  })
+})
+
+// Auth is not what these check; stub it so `request` builds a URL instead of a token.
+vi.mock('@/lib/auth', () => ({
+  getToken: async () => null,
+  getUser: async () => null,
+  getIdTokenRaw: async () => null
+}))
+
+describe('fetchBillingTransactions', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  const urls: string[] = []
+  const stub = () => {
+    urls.length = 0
+    vi.stubEnv('BILLING_URL', 'https://billing.test')
+    vi.stubGlobal('fetch', async (url: string) => {
+      urls.push(url)
+      return { ok: true, json: async () => ({ items: [], nextCursor: null }) }
+    })
+  }
+
+  it('sends the window as the service names it, so the filter runs in SQL', async () => {
+    // A misspelled parameter is invisible from the console: the service ignores what it does
+    // not know, the caller's own cut still trims the rows, and the page stays correct while
+    // paging the whole ledger to get there.
+    stub()
+
+    await fetchBillingTransactions('org1', undefined, { from: '2026-07-21T00:00:00.000Z' })
+
+    expect(urls[0]).toBe('https://billing.test/api/v1/orgs/org1/billing/transactions?from=2026-07-21T00%3A00%3A00.000Z')
+  })
+
+  it('carries the cursor and both ends together', async () => {
+    stub()
+
+    await fetchBillingTransactions('org1', 'c1', { from: '2026-07-21T00:00:00.000Z', to: '2026-08-20T00:00:00.000Z' })
+
+    expect(urls[0]).toContain('cursor=c1')
+    expect(urls[0]).toContain('from=2026-07-21')
+    expect(urls[0]).toContain('to=2026-08-20')
+  })
+
+  it('asks for no window at all when it has none, rather than an empty one', async () => {
+    stub()
+
+    await fetchBillingTransactions('org1')
+
+    expect(urls[0]).toBe('https://billing.test/api/v1/orgs/org1/billing/transactions')
   })
 })

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -254,8 +254,22 @@ export async function fetchBillingAccount(orgId: string): Promise<BillingAccount
   return body
 }
 
-export async function fetchBillingTransactions(orgId: string, cursor?: string): Promise<BillingTransactionsPage> {
-  const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''
+/** `window` narrows the feed to a half-open `[from, to)` on the row's own instant, the same
+ *  shape the CP's usage query takes; both ends are optional and an omitted one is open.
+ *
+ *  It is a REQUEST, not a guarantee: a billing image that predates the parameters ignores
+ *  them and answers with the whole ledger, and this console routinely runs ahead of that
+ *  image. A caller that needs the window to hold must still check `at` on the rows it keeps. */
+export async function fetchBillingTransactions(
+  orgId: string,
+  cursor?: string,
+  window?: { from?: string; to?: string }
+): Promise<BillingTransactionsPage> {
+  const params = new URLSearchParams()
+  if (cursor) params.set('cursor', cursor)
+  if (window?.from) params.set('from', window.from)
+  if (window?.to) params.set('to', window.to)
+  const query = params.size > 0 ? `?${params}` : ''
   const body = await request<unknown>(`${orgPath(orgId)}/transactions${query}`)
   assertTransactionsPage(body)
   // Normalised here so the tolerance stops at this boundary: a service that predates the

--- a/packages/web/src/lib/spend-chart.ts
+++ b/packages/web/src/lib/spend-chart.ts
@@ -1,0 +1,41 @@
+// Shared recharts config for the console's two spend charts (Usage's "Spend over time" and
+// the Cluster page's Credits card), so a hue or a bucket label is defined once.
+
+// SVG `fill` can't take a `var()` presentation attribute, so the bar hues are applied as
+// descendant CSS rules on the chart wrapper (a real declaration out-ranks recharts' own `fill`
+// attribute) — that keeps the bars theme-reactive with no JS reading computed styles. Literal
+// strings so Tailwind can see them.
+export const SEG_FILL = [
+  '[&_.seg-0_path]:fill-(--chart-1)',
+  '[&_.seg-1_path]:fill-(--chart-2)',
+  '[&_.seg-2_path]:fill-(--chart-3)',
+  '[&_.seg-3_path]:fill-(--chart-4)',
+  '[&_.seg-4_path]:fill-(--chart-5)',
+  '[&_.seg-5_path]:fill-(--chart-6)',
+  '[&_.seg-6_path]:fill-(--chart-other)',
+  '[&_.seg-flat_path]:fill-(--brand)',
+  // recharts' accessibility layer makes the chart surface focusable, so clicking a bar leaves a
+  // UA focus ring around the whole plot. Drop the default outline but keep a themed one for
+  // :focus-visible, so keyboard users still see where focus is.
+  '[&_.recharts-wrapper]:outline-none',
+  '[&_.recharts-surface]:outline-none',
+  '[&_.recharts-wrapper:focus-visible]:outline-2',
+  '[&_.recharts-wrapper:focus-visible]:outline-offset-2',
+  '[&_.recharts-wrapper:focus-visible]:outline-(--border-focus)',
+  '[&_.recharts-surface:focus-visible]:outline-2',
+  '[&_.recharts-surface:focus-visible]:outline-offset-2',
+  '[&_.recharts-surface:focus-visible]:outline-(--border-focus)'
+].join(' ')
+
+// Buckets are aligned to the viewer's local day/hour (the CP flooring uses the tz offset we
+// send), so `start` is the UTC instant of a local boundary — label it in local time to read as
+// that local date/hour.
+export function bucketLabel(iso: string, bucket: 'hour' | 'day'): string {
+  const d = new Date(iso)
+  return bucket === 'hour'
+    ? `${String(d.getHours()).padStart(2, '0')}:00`
+    : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+/** Label every Nth tick, so a 30-bucket axis does not print 30 dates. */
+export const tickInterval = (buckets: number) => Math.max(1, Math.ceil(buckets / 8)) - 1

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -44,6 +44,9 @@ export const consoleKeys = {
    *  are org-scoped like everything else here, so they key the same way. */
   billingAccount: (orgId: string | null | undefined) => consoleKey(orgId, 'billing-account'),
   billingTransactions: (orgId: string | null | undefined) => consoleKey(orgId, 'billing-transactions'),
+  /** The credit rows of the last 30 days — paged out of the same feed, so it keys apart
+   *  from the first page `billingTransactions` serves the Billing table. */
+  billingTopUps: (orgId: string | null | undefined) => consoleKey(orgId, 'billing-top-ups'),
   sessions: (
     orgId: string | null | undefined,
     cursor: string,


### PR DESCRIPTION
## What

The Cloud reading of the cluster detail page shipped its Credits card with a sample 30-day series (chipped "sample") and only a live balance. This wires every figure to live data and redraws the chart on recharts.

- **Balance** — unchanged: the billing service's `account`, on the same SWR key the Billing page reads.
- **Topped up · 30d** — the credit rows of the last 30 days, paged out of the billing transaction feed. The window goes to the service as the new `from` parameter (billing-side change, paired PR in the extensions repo), and a client-side cut is kept because this console routinely deploys ahead of the pinned billing image — an older service ignores the parameter and answers with the whole ledger.
- **Spent · 30d + chart** — the CP's `fetchUsage('d30')` daily series, summing the `byAgent` split over **the pool's agents only**. Scope is the point: billing debits are `YYYY-MM` aggregates of the org's entire usage, and quoting them here would contradict the page's own footnote that agents on self-connected daemons are never billed here. A CP that predates `byAgent` gets "unavailable", never the org total.
- The three figures load and fail independently: first-load skeletons (same footprint as the loaded card, no layout shift), per-figure error states carrying the service's own message.

## Chart

recharts, matching the Usage page — the shared config (`SEG_FILL`, `bucketLabel`, `tickInterval`) moved to `lib/spend-chart.ts` and both views consume it. Two stacked series on one shared USD axis: spend on the baseline, that day's top-up capping it. Grouped bars were tried and rejected (they halve every day's band for a series present on ~3 of 30 days). One deliberate deviation from the design mock: a top-up is its own green segment, not a recolour of the spend bar, so a bar's height never presents a top-up's amount as spend.

One recharts subtlety worth knowing: in a stack, `minPointSize` receives the segment's cumulative top, not its own delta — the pixel floor reads the row's own field by index, or zero-top-up days grow a green cap.

## Reviewer notes

- Pairs with the billing service's `from`/`to` window on `GET .../transactions` (extensions repo). Safe to merge in either order: an older billing image ignores the parameter and the client-side cut keeps the figure correct.
- `consoleKeys.billingTopUps` is a new SWR key, separate from the Billing page's first-page `billingTransactions` cache.
- Tests: the card's suite now stubs SWR per key and pins the scoping invariant (a series where most spend belongs to a non-pool agent must not leak into the total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)