### PR TITLE
feat(web): bound the single-session transcript load with on-demand paging

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1756,8 +1756,8 @@ export default function SessionDetailView() {
     tailReady,
     transcriptSessionId,
     conversationOffline,
-    conversationHasEarlier,
-    conversationPagingEarlier,
+    hasEarlier,
+    pagingEarlier,
     conversationLoadedKey,
     loadEarlier: loadEarlierConversation,
     refreshTail,
@@ -3860,14 +3860,14 @@ export default function SessionDetailView() {
                 </div>
               )}
 
-              {conversationKey && conversationHasEarlier && (
+              {hasEarlier && (
                 <div className="flex items-center justify-center pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
                   <button
                     className="lnk text-[12px]"
                     onClick={() => void loadEarlierConversation()}
-                    disabled={conversationPagingEarlier}
+                    disabled={pagingEarlier}
                   >
-                    {conversationPagingEarlier ? 'Loading earlier activity…' : 'Load earlier activity'}
+                    {pagingEarlier ? 'Loading earlier activity…' : 'Load earlier activity'}
                   </button>
                 </div>
               )}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2262,6 +2262,7 @@ export default function SessionDetailView() {
   const visibleMsgPaging = wantTranscript && transcriptMatchesSession && msgPaging
   const visibleMsgErr = wantTranscript && transcriptMatchesSession ? msgErr : null
   const visibleTailReady = wantTranscript && transcriptMatchesSession && tailReady
+  const visibleHasEarlier = wantTranscript && transcriptMatchesSession && hasEarlier
   const agentNameById = useMemo(() => new Map(agents.map((a) => [a.id, agentLabel(a)])), [agents])
   const memberNameByIdentity = useMemo(() => {
     const names = new Map<string, string>()
@@ -3278,15 +3279,21 @@ export default function SessionDetailView() {
     focusedLiveActivityStats.lastMs,
     pgBusy && headerFocusAgentId === session.agentId && durationFirst != null ? nowMs : null
   )
-  const displayDuration =
-    durationFirst != null && durationLast != null
+  // With older history unloaded the transcript is only the newest page, so a transcript-derived
+  // Duration/Tool-calls would describe ~50 rows and CLIMB on every "Load earlier" — show `—` instead
+  // of a wrong, growing number until the whole session is loaded (the DTO carries no session total).
+  const displayDuration = visibleHasEarlier
+    ? '—'
+    : durationFirst != null && durationLast != null
       ? fmtTranscriptDuration(durationLast - durationFirst)
       : (focusedSession?.duration ?? '—')
-  const displayToolCount = focusedTranscriptStats
-    ? fmtCountCompact(focusedTranscriptStats.toolCalls + focusedLiveActivityStats.toolCalls)
-    : focusedLiveActivityStats.toolCalls > 0 || isPg
-      ? fmtCountCompact(focusedLiveActivityStats.toolCalls)
-      : (focusedSession?.toolCount ?? '—')
+  const displayToolCount = visibleHasEarlier
+    ? '—'
+    : focusedTranscriptStats
+      ? fmtCountCompact(focusedTranscriptStats.toolCalls + focusedLiveActivityStats.toolCalls)
+      : focusedLiveActivityStats.toolCalls > 0 || isPg
+        ? fmtCountCompact(focusedLiveActivityStats.toolCalls)
+        : (focusedSession?.toolCount ?? '—')
 
   // Token-usage breakdown for the detail card — only the fields the runtime reported.
   const u = focusedSession?.usage
@@ -3860,7 +3867,7 @@ export default function SessionDetailView() {
                 </div>
               )}
 
-              {hasEarlier && (
+              {visibleHasEarlier && (
                 <div className="flex items-center justify-center pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
                   <button
                     className="lnk text-[12px]"

--- a/packages/web/src/lib/use-session-transcript.ts
+++ b/packages/web/src/lib/use-session-transcript.ts
@@ -80,8 +80,8 @@ export interface UseSessionTranscriptResult {
   tailReady: boolean
   transcriptSessionId: string | null
   conversationOffline: number
-  conversationHasEarlier: boolean
-  conversationPagingEarlier: boolean
+  hasEarlier: boolean
+  pagingEarlier: boolean
   conversationLoadedKey: string | null
   loadEarlier: () => Promise<void>
   refreshTail: () => Promise<void>
@@ -128,8 +128,12 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
   // Owning member agent of a merged-conversation row — a background-task wake from a peer member
   // must render as THAT agent's work, not the representative's.
   const conversationSourceAgentByMessageRef = useRef(new WeakMap<SessionMessageDto, string>())
-  const [conversationHasEarlier, setConversationHasEarlier] = useState(false)
-  const [conversationPagingEarlier, setConversationPagingEarlier] = useState(false)
+  // "Load earlier" state, unified across single-session and merged-conversation mode.
+  const [hasEarlier, setHasEarlier] = useState(false)
+  const [pagingEarlier, setPagingEarlier] = useState(false)
+  // Single-session strictly-older cursor; conversation mode uses the per-source `older` map on
+  // conversationSourcesRef instead.
+  const olderCursorRef = useRef<string | null>(null)
   // Which conversation key the CURRENT fan-out state belongs to — the focus effect's readiness
   // signal. Null while a (new) key is loading, so a key-to-key navigation in the persistent layout
   // can never act on the previous conversation's leftover msgs/cursors.
@@ -173,10 +177,9 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     setMsgErr(null)
     setMsgs(null)
     setMsgPaging(false)
-    // Pull the WHOLE history, not just the newest frame-budgeted page: render the first (newest)
-    // page immediately, then keep paging strictly older via nextCursor, prepending each page.
-    // Bounded so a pathological session can't keep the proxy busy forever.
-    const MAX_PAGES = 40
+    olderCursorRef.current = null
+    // Load only the NEWEST page; older history comes in on demand via loadEarlier (a "Load earlier
+    // activity" button), so a long session no longer walks its whole backlog at open.
     if (conversationKey) {
       // Merged conversation (merged-conversation-view.md §4/§6): pull every member's history through
       // the SAME bounded per-session reads, then render mergeConversation() over the union. A member
@@ -194,7 +197,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
           sources.map(async (src) => {
             try {
               // Newest window only — one page per member (C3 §5.2). Older history loads on demand via
-              // the per-source cursors below, capping a cold open at N requests instead of N × MAX_PAGES.
+              // the per-source cursors below, so a cold open is one request per member.
               const page = await fetchSessionMessages(src.sessionId, {})
               if (!active) return
               cursors.set(src.sessionId, page.liveCursor ?? null)
@@ -207,7 +210,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
         )
         if (!active) return
         conversationSourcesRef.current = { rows: rowsBySession, cursors, older }
-        setConversationHasEarlier([...older.values()].some((cursor) => cursor !== null))
+        setHasEarlier([...older.values()].some((cursor) => cursor !== null))
         setConversationLoadedKey(conversationKey)
         setConversationOffline(failed)
         // Exact post matching uses every participant row; fuzzy prompt matching stays representative-only.
@@ -242,32 +245,17 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
       }
     }
     ;(async () => {
-      let all: SessionMessageDto[] = []
-      let cursor: string | undefined
-      let liveCursor: string | null = null
-      for (let i = 0; i < MAX_PAGES; i++) {
-        const page = await fetchSessionMessages(sid, { ...(cursor ? { cursor } : {}) })
-        if (!active) return
-        if (i === 0) liveCursor = page.liveCursor ?? null
-        all = [...page.messages, ...all]
-        setMsgs(all)
-        setMsgLoading(false)
-        if (!page.nextCursor) {
-          setMsgPaging(false)
-          liveCursorRef.current = liveCursor
-          tailReadyRef.current = true
-          setTailReady(true)
-          if (!sessionBusyRef.current) reconcileLiveSteps(sid, all, aid)
-          return
-        }
-        cursor = page.nextCursor
-        setMsgPaging(true)
-      }
+      const page = await fetchSessionMessages(sid, {})
+      if (!active) return
+      olderCursorRef.current = page.nextCursor ?? null
+      setHasEarlier(page.nextCursor != null)
+      liveCursorRef.current = page.liveCursor ?? null
+      setMsgs(page.messages)
+      setMsgLoading(false)
       setMsgPaging(false)
-      liveCursorRef.current = liveCursor
       tailReadyRef.current = true
       setTailReady(true)
-      if (!sessionBusyRef.current) reconcileLiveSteps(sid, all, aid)
+      if (!sessionBusyRef.current) reconcileLiveSteps(sid, page.messages, aid)
     })().catch((e) => {
       if (!active) return
       setMsgErr(e instanceof Error ? e.message : String(e))
@@ -388,13 +376,29 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     return run
   }, [wantTranscript, sid, aid, sessionPlatform, reconcileLiveSteps, conversationKey])
 
-  // C3 §5.2 cross-source "load earlier": one strictly-older page per member that still has history,
-  // prepended per source, then re-merged.
+  // "Load earlier": one strictly-older page, prepended. Single-session pages `sid` off its own
+  // cursor; conversation mode (C3 §5.2) pages one older page per member and re-merges the union.
   const loadEarlier = useCallback(async (): Promise<void> => {
-    if (!conversationKey || conversationPagingEarlier) return
+    if (pagingEarlier) return
+    if (!conversationKey) {
+      const cursor = olderCursorRef.current
+      if (!sid || !cursor) return
+      setPagingEarlier(true)
+      try {
+        const page = await fetchSessionMessages(sid, { cursor })
+        setMsgs((current) => [...page.messages, ...(current ?? [])])
+        olderCursorRef.current = page.nextCursor ?? null
+        setHasEarlier(page.nextCursor != null)
+      } catch {
+        // Keep the window; the button stays for a retry.
+      } finally {
+        setPagingEarlier(false)
+      }
+      return
+    }
     const sources = conversationMembersRef.current ?? []
     const state = conversationSourcesRef.current
-    setConversationPagingEarlier(true)
+    setPagingEarlier(true)
     try {
       await Promise.all(
         sources.map(async (src) => {
@@ -419,11 +423,11 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
           conversationSourceAgentByMessageRef.current
         )
       )
-      setConversationHasEarlier([...state.older.values()].some((cursor) => cursor !== null))
+      setHasEarlier([...state.older.values()].some((cursor) => cursor !== null))
     } finally {
-      setConversationPagingEarlier(false)
+      setPagingEarlier(false)
     }
-  }, [conversationKey, conversationPagingEarlier])
+  }, [conversationKey, pagingEarlier, sid])
 
   return {
     msgs,
@@ -433,8 +437,8 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     tailReady,
     transcriptSessionId,
     conversationOffline,
-    conversationHasEarlier,
-    conversationPagingEarlier,
+    hasEarlier,
+    pagingEarlier,
     conversationLoadedKey,
     loadEarlier,
     refreshTail,

--- a/packages/web/src/lib/use-session-transcript.ts
+++ b/packages/web/src/lib/use-session-transcript.ts
@@ -177,6 +177,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     setMsgErr(null)
     setMsgs(null)
     setMsgPaging(false)
+    setHasEarlier(false)
     olderCursorRef.current = null
     // Load only the NEWEST page; older history comes in on demand via loadEarlier (a "Load earlier
     // activity" button), so a long session no longer walks its whole backlog at open.
@@ -386,6 +387,10 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
       setPagingEarlier(true)
       try {
         const page = await fetchSessionMessages(sid, { cursor })
+        // Fence on the session: a navigation before this resolves would otherwise splice these rows
+        // into the NEW session and re-point its cursor at the old one (tailSessionRef tracks the open
+        // session, like refreshTail's guard).
+        if (tailSessionRef.current !== sid) return
         setMsgs((current) => [...page.messages, ...(current ?? [])])
         olderCursorRef.current = page.nextCursor ?? null
         setHasEarlier(page.nextCursor != null)

--- a/packages/web/src/lib/use-session-transcript.ts
+++ b/packages/web/src/lib/use-session-transcript.ts
@@ -391,7 +391,11 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
         // into the NEW session and re-point its cursor at the old one (tailSessionRef tracks the open
         // session, like refreshTail's guard).
         if (tailSessionRef.current !== sid) return
-        setMsgs((current) => [...page.messages, ...(current ?? [])])
+        // Upsert, not concat: a Slack warm-thread backfill can make this older read overlap rows the
+        // tail already added, so a raw prepend would duplicate them (and their React keys).
+        setMsgs((current) =>
+          mergeSessionMessages(current ?? [], page.messages, platformTranscriptOrdering(sessionPlatform))
+        )
         olderCursorRef.current = page.nextCursor ?? null
         setHasEarlier(page.nextCursor != null)
       } catch {
@@ -432,7 +436,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     } finally {
       setPagingEarlier(false)
     }
-  }, [conversationKey, pagingEarlier, sid])
+  }, [conversationKey, pagingEarlier, sid, sessionPlatform])
 
   return {
     msgs,


### PR DESCRIPTION
## Phase 2 of #1327 — bound the eager transcript load

> **Stacked on #1341.** This PR shows two commits; the first (`refactor: extract useSessionTranscript`) is #1341. **Review the second commit**, `feat(web): bound the single-session transcript load…`. Once #1341 merges, this diff collapses to just that commit.

### The change
On `main`, opening a single session eagerly walks up to `MAX_PAGES = 40` × `limit = 50` = **~2,000 messages** of backlog and renders all of it. This PR makes a single-session open load **only the newest page**, and surfaces older history on demand through the **"Load earlier activity" button** the merged-conversation path already uses — now ungated from conversation mode so single sessions get it too.

`useSessionTranscript` unifies the paging surface:
- `hasEarlier` / `pagingEarlier` (replacing the conversation-only `conversationHasEarlier` / `conversationPagingEarlier`)
- a mode-aware `loadEarlier`: single session pages `sid` off its own strictly-older cursor and prepends; conversation mode keeps the per-member fan-out (one older page per member, re-merged)

### Notes
- `msgPaging` (the old initial-load walk spinner) is now vestigial — always false. Left wired to keep this diff focused; prunable in a follow-up.
- No virtualization is added — see #1327 for why an AI-chat transcript (bounded, paged, variable-height, streaming, copyable) is the profile the mainstream deliberately does *not* virtualize. `main` never virtualized, so there is no jump-to-top regression to chase here; this is a load/scalability win.
- Phase 3 (prepend-stable scroll — anchor-restore on "Load earlier", optional DeepSeek-style observed-top ledger) is optional follow-up; the load-bounding win lands here.

### Verification
- `tsc`, `eslint`, `prettier` — clean
- `session-transcript` unit tests pass (9/9)
- Runtime paging (one-page first paint, button pages older, live tail still appends) to be exercised in review/staging. The `happy-dom` viewer suite can't run in my sandbox's Node 26 (env, not this change — same as #1341); CI runs it on Node 24.

Part of #1327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
