### PR TITLE
feat(web): cancel the in-flight transcript fetch on session switch (AbortSignal)

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1756,8 +1756,8 @@ export default function SessionDetailView() {
     tailReady,
     transcriptSessionId,
     conversationOffline,
-    conversationHasEarlier,
-    conversationPagingEarlier,
+    hasEarlier,
+    pagingEarlier,
     conversationLoadedKey,
     loadEarlier: loadEarlierConversation,
     refreshTail,
@@ -3860,14 +3860,14 @@ export default function SessionDetailView() {
                 </div>
               )}
 
-              {conversationKey && conversationHasEarlier && (
+              {hasEarlier && (
                 <div className="flex items-center justify-center pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
                   <button
                     className="lnk text-[12px]"
                     onClick={() => void loadEarlierConversation()}
-                    disabled={conversationPagingEarlier}
+                    disabled={pagingEarlier}
                   >
-                    {conversationPagingEarlier ? 'Loading earlier activity…' : 'Load earlier activity'}
+                    {pagingEarlier ? 'Loading earlier activity…' : 'Load earlier activity'}
                   </button>
                 </div>
               )}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2262,6 +2262,7 @@ export default function SessionDetailView() {
   const visibleMsgPaging = wantTranscript && transcriptMatchesSession && msgPaging
   const visibleMsgErr = wantTranscript && transcriptMatchesSession ? msgErr : null
   const visibleTailReady = wantTranscript && transcriptMatchesSession && tailReady
+  const visibleHasEarlier = wantTranscript && transcriptMatchesSession && hasEarlier
   const agentNameById = useMemo(() => new Map(agents.map((a) => [a.id, agentLabel(a)])), [agents])
   const memberNameByIdentity = useMemo(() => {
     const names = new Map<string, string>()
@@ -3278,15 +3279,21 @@ export default function SessionDetailView() {
     focusedLiveActivityStats.lastMs,
     pgBusy && headerFocusAgentId === session.agentId && durationFirst != null ? nowMs : null
   )
-  const displayDuration =
-    durationFirst != null && durationLast != null
+  // With older history unloaded the transcript is only the newest page, so a transcript-derived
+  // Duration/Tool-calls would describe ~50 rows and CLIMB on every "Load earlier" — show `—` instead
+  // of a wrong, growing number until the whole session is loaded (the DTO carries no session total).
+  const displayDuration = visibleHasEarlier
+    ? '—'
+    : durationFirst != null && durationLast != null
       ? fmtTranscriptDuration(durationLast - durationFirst)
       : (focusedSession?.duration ?? '—')
-  const displayToolCount = focusedTranscriptStats
-    ? fmtCountCompact(focusedTranscriptStats.toolCalls + focusedLiveActivityStats.toolCalls)
-    : focusedLiveActivityStats.toolCalls > 0 || isPg
-      ? fmtCountCompact(focusedLiveActivityStats.toolCalls)
-      : (focusedSession?.toolCount ?? '—')
+  const displayToolCount = visibleHasEarlier
+    ? '—'
+    : focusedTranscriptStats
+      ? fmtCountCompact(focusedTranscriptStats.toolCalls + focusedLiveActivityStats.toolCalls)
+      : focusedLiveActivityStats.toolCalls > 0 || isPg
+        ? fmtCountCompact(focusedLiveActivityStats.toolCalls)
+        : (focusedSession?.toolCount ?? '—')
 
   // Token-usage breakdown for the detail card — only the fields the runtime reported.
   const u = focusedSession?.usage
@@ -3860,7 +3867,7 @@ export default function SessionDetailView() {
                 </div>
               )}
 
-              {hasEarlier && (
+              {visibleHasEarlier && (
                 <div className="flex items-center justify-center pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
                   <button
                     className="lnk text-[12px]"

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1342,8 +1342,8 @@ async function authenticatedFetch(
   return retried
 }
 
-async function apiGet<T>(path: string): Promise<T> {
-  const res = await authenticatedFetch(path, { cache: 'no-store' })
+async function apiGet<T>(path: string, init?: Omit<RequestInit, 'headers'>): Promise<T> {
+  const res = await authenticatedFetch(path, { cache: 'no-store', ...init })
   // Parse the denial body like the write helpers do: reads carry machine-readable
   // `code`s too (e.g. DAEMON_FEATURE_MISSING on a capability-gated route), and a
   // status-only ApiError silently drops them.
@@ -2348,12 +2348,15 @@ export function putSessionExternalAccess(
 // SessionMeta. Content ownership stays pinned there when the agent moves.
 export async function fetchSessionMessages(
   sessionId: string,
-  options: { cursor?: string; after?: string; limit?: number } = {}
+  options: { cursor?: string; after?: string; limit?: number; signal?: AbortSignal } = {}
 ): Promise<SessionHistoryDto> {
   const q = new URLSearchParams({ limit: String(options.limit ?? 50) })
   if (options.cursor) q.set('cursor', options.cursor)
   if (options.after) q.set('after', options.after)
-  return apiGet<SessionHistoryDto>(`${orgBase()}/sessions/${encodeURIComponent(sessionId)}/messages?${q.toString()}`)
+  return apiGet<SessionHistoryDto>(
+    `${orgBase()}/sessions/${encodeURIComponent(sessionId)}/messages?${q.toString()}`,
+    options.signal ? { signal: options.signal } : undefined
+  )
 }
 
 // One frame-budgeted byte slice of a tool call's FULL ToolBody JSON (mirrors the

--- a/packages/web/src/lib/use-session-transcript.ts
+++ b/packages/web/src/lib/use-session-transcript.ts
@@ -80,8 +80,8 @@ export interface UseSessionTranscriptResult {
   tailReady: boolean
   transcriptSessionId: string | null
   conversationOffline: number
-  conversationHasEarlier: boolean
-  conversationPagingEarlier: boolean
+  hasEarlier: boolean
+  pagingEarlier: boolean
   conversationLoadedKey: string | null
   loadEarlier: () => Promise<void>
   refreshTail: () => Promise<void>
@@ -128,8 +128,12 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
   // Owning member agent of a merged-conversation row — a background-task wake from a peer member
   // must render as THAT agent's work, not the representative's.
   const conversationSourceAgentByMessageRef = useRef(new WeakMap<SessionMessageDto, string>())
-  const [conversationHasEarlier, setConversationHasEarlier] = useState(false)
-  const [conversationPagingEarlier, setConversationPagingEarlier] = useState(false)
+  // "Load earlier" state, unified across single-session and merged-conversation mode.
+  const [hasEarlier, setHasEarlier] = useState(false)
+  const [pagingEarlier, setPagingEarlier] = useState(false)
+  // Single-session strictly-older cursor; conversation mode uses the per-source `older` map on
+  // conversationSourcesRef instead.
+  const olderCursorRef = useRef<string | null>(null)
   // Which conversation key the CURRENT fan-out state belongs to — the focus effect's readiness
   // signal. Null while a (new) key is loading, so a key-to-key navigation in the persistent layout
   // can never act on the previous conversation's leftover msgs/cursors.
@@ -173,10 +177,9 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     setMsgErr(null)
     setMsgs(null)
     setMsgPaging(false)
-    // Pull the WHOLE history, not just the newest frame-budgeted page: render the first (newest)
-    // page immediately, then keep paging strictly older via nextCursor, prepending each page.
-    // Bounded so a pathological session can't keep the proxy busy forever.
-    const MAX_PAGES = 40
+    olderCursorRef.current = null
+    // Load only the NEWEST page; older history comes in on demand via loadEarlier (a "Load earlier
+    // activity" button), so a long session no longer walks its whole backlog at open.
     if (conversationKey) {
       // Merged conversation (merged-conversation-view.md §4/§6): pull every member's history through
       // the SAME bounded per-session reads, then render mergeConversation() over the union. A member
@@ -194,7 +197,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
           sources.map(async (src) => {
             try {
               // Newest window only — one page per member (C3 §5.2). Older history loads on demand via
-              // the per-source cursors below, capping a cold open at N requests instead of N × MAX_PAGES.
+              // the per-source cursors below, so a cold open is one request per member.
               const page = await fetchSessionMessages(src.sessionId, {})
               if (!active) return
               cursors.set(src.sessionId, page.liveCursor ?? null)
@@ -207,7 +210,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
         )
         if (!active) return
         conversationSourcesRef.current = { rows: rowsBySession, cursors, older }
-        setConversationHasEarlier([...older.values()].some((cursor) => cursor !== null))
+        setHasEarlier([...older.values()].some((cursor) => cursor !== null))
         setConversationLoadedKey(conversationKey)
         setConversationOffline(failed)
         // Exact post matching uses every participant row; fuzzy prompt matching stays representative-only.
@@ -242,32 +245,17 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
       }
     }
     ;(async () => {
-      let all: SessionMessageDto[] = []
-      let cursor: string | undefined
-      let liveCursor: string | null = null
-      for (let i = 0; i < MAX_PAGES; i++) {
-        const page = await fetchSessionMessages(sid, { ...(cursor ? { cursor } : {}) })
-        if (!active) return
-        if (i === 0) liveCursor = page.liveCursor ?? null
-        all = [...page.messages, ...all]
-        setMsgs(all)
-        setMsgLoading(false)
-        if (!page.nextCursor) {
-          setMsgPaging(false)
-          liveCursorRef.current = liveCursor
-          tailReadyRef.current = true
-          setTailReady(true)
-          if (!sessionBusyRef.current) reconcileLiveSteps(sid, all, aid)
-          return
-        }
-        cursor = page.nextCursor
-        setMsgPaging(true)
-      }
+      const page = await fetchSessionMessages(sid, {})
+      if (!active) return
+      olderCursorRef.current = page.nextCursor ?? null
+      setHasEarlier(page.nextCursor != null)
+      liveCursorRef.current = page.liveCursor ?? null
+      setMsgs(page.messages)
+      setMsgLoading(false)
       setMsgPaging(false)
-      liveCursorRef.current = liveCursor
       tailReadyRef.current = true
       setTailReady(true)
-      if (!sessionBusyRef.current) reconcileLiveSteps(sid, all, aid)
+      if (!sessionBusyRef.current) reconcileLiveSteps(sid, page.messages, aid)
     })().catch((e) => {
       if (!active) return
       setMsgErr(e instanceof Error ? e.message : String(e))
@@ -388,13 +376,29 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     return run
   }, [wantTranscript, sid, aid, sessionPlatform, reconcileLiveSteps, conversationKey])
 
-  // C3 §5.2 cross-source "load earlier": one strictly-older page per member that still has history,
-  // prepended per source, then re-merged.
+  // "Load earlier": one strictly-older page, prepended. Single-session pages `sid` off its own
+  // cursor; conversation mode (C3 §5.2) pages one older page per member and re-merges the union.
   const loadEarlier = useCallback(async (): Promise<void> => {
-    if (!conversationKey || conversationPagingEarlier) return
+    if (pagingEarlier) return
+    if (!conversationKey) {
+      const cursor = olderCursorRef.current
+      if (!sid || !cursor) return
+      setPagingEarlier(true)
+      try {
+        const page = await fetchSessionMessages(sid, { cursor })
+        setMsgs((current) => [...page.messages, ...(current ?? [])])
+        olderCursorRef.current = page.nextCursor ?? null
+        setHasEarlier(page.nextCursor != null)
+      } catch {
+        // Keep the window; the button stays for a retry.
+      } finally {
+        setPagingEarlier(false)
+      }
+      return
+    }
     const sources = conversationMembersRef.current ?? []
     const state = conversationSourcesRef.current
-    setConversationPagingEarlier(true)
+    setPagingEarlier(true)
     try {
       await Promise.all(
         sources.map(async (src) => {
@@ -419,11 +423,11 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
           conversationSourceAgentByMessageRef.current
         )
       )
-      setConversationHasEarlier([...state.older.values()].some((cursor) => cursor !== null))
+      setHasEarlier([...state.older.values()].some((cursor) => cursor !== null))
     } finally {
-      setConversationPagingEarlier(false)
+      setPagingEarlier(false)
     }
-  }, [conversationKey, conversationPagingEarlier])
+  }, [conversationKey, pagingEarlier, sid])
 
   return {
     msgs,
@@ -433,8 +437,8 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     tailReady,
     transcriptSessionId,
     conversationOffline,
-    conversationHasEarlier,
-    conversationPagingEarlier,
+    hasEarlier,
+    pagingEarlier,
     conversationLoadedKey,
     loadEarlier,
     refreshTail,

--- a/packages/web/src/lib/use-session-transcript.ts
+++ b/packages/web/src/lib/use-session-transcript.ts
@@ -177,6 +177,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     setMsgErr(null)
     setMsgs(null)
     setMsgPaging(false)
+    setHasEarlier(false)
     olderCursorRef.current = null
     // Load only the NEWEST page; older history comes in on demand via loadEarlier (a "Load earlier
     // activity" button), so a long session no longer walks its whole backlog at open.
@@ -386,6 +387,10 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
       setPagingEarlier(true)
       try {
         const page = await fetchSessionMessages(sid, { cursor })
+        // Fence on the session: a navigation before this resolves would otherwise splice these rows
+        // into the NEW session and re-point its cursor at the old one (tailSessionRef tracks the open
+        // session, like refreshTail's guard).
+        if (tailSessionRef.current !== sid) return
         setMsgs((current) => [...page.messages, ...(current ?? [])])
         olderCursorRef.current = page.nextCursor ?? null
         setHasEarlier(page.nextCursor != null)

--- a/packages/web/src/lib/use-session-transcript.ts
+++ b/packages/web/src/lib/use-session-transcript.ts
@@ -391,7 +391,11 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
         // into the NEW session and re-point its cursor at the old one (tailSessionRef tracks the open
         // session, like refreshTail's guard).
         if (tailSessionRef.current !== sid) return
-        setMsgs((current) => [...page.messages, ...(current ?? [])])
+        // Upsert, not concat: a Slack warm-thread backfill can make this older read overlap rows the
+        // tail already added, so a raw prepend would duplicate them (and their React keys).
+        setMsgs((current) =>
+          mergeSessionMessages(current ?? [], page.messages, platformTranscriptOrdering(sessionPlatform))
+        )
         olderCursorRef.current = page.nextCursor ?? null
         setHasEarlier(page.nextCursor != null)
       } catch {
@@ -432,7 +436,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     } finally {
       setPagingEarlier(false)
     }
-  }, [conversationKey, pagingEarlier, sid])
+  }, [conversationKey, pagingEarlier, sid, sessionPlatform])
 
   return {
     msgs,

--- a/packages/web/src/lib/use-session-transcript.ts
+++ b/packages/web/src/lib/use-session-transcript.ts
@@ -165,7 +165,10 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
 
   useEffect(() => {
     if (!wantTranscript || !sid || !aid) return
+    // `active` ignores late results; `ac` cancels the in-flight request itself on a session switch or
+    // unmount, so a superseded fan-out stops occupying the CP proxy instead of running to completion.
     let active = true
+    const ac = new AbortController()
     setTranscriptSessionId(sid)
     tailSessionRef.current = sid
     tailReadyRef.current = false
@@ -199,7 +202,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
             try {
               // Newest window only — one page per member (C3 §5.2). Older history loads on demand via
               // the per-source cursors below, so a cold open is one request per member.
-              const page = await fetchSessionMessages(src.sessionId, {})
+              const page = await fetchSessionMessages(src.sessionId, { signal: ac.signal })
               if (!active) return
               cursors.set(src.sessionId, page.liveCursor ?? null)
               older.set(src.sessionId, page.nextCursor ?? null)
@@ -239,6 +242,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
       })
       return () => {
         active = false
+        ac.abort()
         if (tailSessionRef.current === sid) {
           tailSessionRef.current = null
           tailReadyRef.current = false
@@ -246,7 +250,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
       }
     }
     ;(async () => {
-      const page = await fetchSessionMessages(sid, {})
+      const page = await fetchSessionMessages(sid, { signal: ac.signal })
       if (!active) return
       olderCursorRef.current = page.nextCursor ?? null
       setHasEarlier(page.nextCursor != null)
@@ -265,6 +269,7 @@ export function useSessionTranscript(input: UseSessionTranscriptInput): UseSessi
     })
     return () => {
       active = false
+      ac.abort()
       if (tailSessionRef.current === sid) {
         tailSessionRef.current = null
         tailReadyRef.current = false


### PR DESCRIPTION
## Managed cancellation for the transcript fetch — follow-up to #1327

> **Stacked on #1341 → #1342.** This PR shows three commits; the first two are those PRs. **Review the top commit**, `feat(web): cancel the in-flight transcript fetch…`. It collapses to just that commit once the stack merges.

Addresses the "unmanaged async in the effect" concern raised on the extraction: the initial-load effect discarded a superseded fetch's *result* (via the `active` flag) but never cancelled the *request*, so a fast session switch left the fan-out running to completion on the CP proxy.

### Change
- `apiGet(path, init?)` and `fetchSessionMessages(sessionId, { …, signal? })` now accept an optional `AbortSignal` — both **additive**, no existing caller changes. `authenticatedFetch`'s `init` is already `Omit<RequestInit, 'headers'>`, so the signal flows to both the initial fetch and the token-refresh retry.
- `useSessionTranscript`'s initial-load effect drives an `AbortController` and `ac.abort()`s it on cleanup (both the single-session and conversation-fan-out branches).

### Why keep the `active` flag too
`active` and the abort are complementary: the abort cancels the network; `active` still ignores late results. In the fan-out, an aborted per-source read is swallowed as non-offline and `Promise.all` still resolves, so the post-`await` `if (!active) return` is what prevents a partial `setState`. Because cleanup sets `active = false` *and* aborts, an `AbortError` never reaches a `setState` — the guard bails first (no spurious error notice).

### Scope
The tail refresh keeps its existing `tailSessionRef` guard; giving it its own `AbortController` is a separate change (noted, not done here).

### Verification
`tsc`, `eslint`, `prettier` clean. `apiGet`/`fetchSessionMessages` changes are optional params, so the whole app still type-checks. The `happy-dom` viewer suite can't run in my Node 26 sandbox (env, same as #1341/#1342); CI runs it on Node 24.

Part of #1327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
