### PR TITLE
fix(daemon): the key server's scheme and credential are the deployment's to choose

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -136,7 +136,7 @@ The daemon does not implement these, but interacts with them through the section
 | `--max-agents <n>`               | `limits.maxAgents`             | Capacity reported to CP + local hard limit.                                                                                                        |
 | `--require-sandbox`              | `security.requireSandbox=true` | Require every agent to run in the Linux SRT sandbox; refuse daemon startup on unsupported or failed hosts.                                         |
 | `--k8s`                          | n/a (mode switch)              | Run runtimes in cluster sandbox pods instead of on this host; see section 2.6 for what that changes.                                               |
-| `--key-server <url>`             | `KEY_SERVER`                   | Cloud-only HTTPS service for session-scoped model credentials; see [key-server.md](key-server.md).                                                 |
+| `--key-server <url>`             | `KEY_SERVER`                   | Cloud-only service for session-scoped model credentials, http or https as the deployment chooses; see [key-server.md](key-server.md).              |
 | `--key-server-token-path <path>` | `KEY_SERVER_TOKEN_PATH`        | File re-read as the key-server bearer token on every request.                                                                                      |
 | `--dry-run`                      | n/a                            | Load and validate all configuration and print the reconcile plan without opening connections/processes.                                            |
 

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -73,8 +73,7 @@ the daemon does not have — a runtime switches models mid-session.
 Cloud daemons accept `--key-server <url>` — **http or https, the deployment's choice**: the bearer
 is a projected ServiceAccount token, and a daemon that already reaches its control plane over an
 in-cluster `ws://` gains nothing from one hop being stricter than the boundary it sits in. A
-deployment that terminates TLS on this hop simply configures an https address. Also accepted:
-`--key-server-token-path <path>`, and
+deployment that terminates TLS on this hop simply configures an https address. Beside it they accept
 `--key-server-token-path <path>`. The equivalent deployment environment names are
 `KEY_SERVER` and `KEY_SERVER_TOKEN_PATH`; explicit CLI values win. A token path
 without a server does nothing and says so, as does a server without a token — that one sends every

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -128,15 +128,13 @@ neither completes the other:
   neither, whatever credential the runtime environment already carries.
 - **the base URL** is deployment topology — which gateway this install's runtimes talk
   to — so it always comes from the daemon's own configuration, key server or not. The
-  contract no longer defines a `baseUrl`; responses parse tolerantly, so an issuer
-  still sending the retired field (or adding one later) is stripped, never rejected.
+  contract defines no `baseUrl`, and an issuer that sends one is stripped rather than
+  rejected (responses parse tolerantly).
 
-The earlier rule was the opposite: the response pair was atomic, so a key server that
-fronted a gateway had to name it and one that did not had to stay silent. That made
-every issuer restate a fact it does not own — the address is the same for every session
-the install ever runs, and it is already written down where the gateway is deployed.
-Restating it invites the two copies to disagree, and the disagreement surfaces as a
-runtime aimed somewhere the deployment never put a gateway.
+An issuer naming the address would be restating a fact it does not own: the address is
+the same for every session the install ever runs, and it is already written down where
+the gateway is deployed. Two copies of it invite disagreement, and the disagreement
+surfaces as a runtime aimed somewhere the deployment never put a gateway.
 
 What remains beneath both is the runtime's own environment, including the pod's
 `AC_*_BASE_URL` floor the shim fills in: a daemon with no base URL configured for a

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -78,9 +78,11 @@ deployment that terminates TLS on this hop simply configures an https address. A
 `--key-server-token-path <path>`. The equivalent deployment environment names are
 `KEY_SERVER` and `KEY_SERVER_TOKEN_PATH`; explicit CLI values win. A token path
 without a server does nothing and says so, as does a server without a token — that one sends every
-request with no `Authorization` header at all, which a server that reviews its callers refuses; neither option requires `--k8s`, because where a runtime
-runs and where its key comes from are different questions — the launch path applies a minted
-credential to whatever environment it is building, cluster sandbox or local child alike.
+request with no `Authorization` header at all, which a server that reviews its callers refuses. Both
+are warnings rather than refusals: a key server may be configured to trust its callers by network
+position, and that is its operator's call to make. A key server itself does require `--k8s`, because
+the credential it mints is only usable with the `*_MODEL_BASE_URL` pair that aims it at this
+install's gateway, and that pair is cloud-mode configuration.
 
 The bearer file is read for every IssueKey and RevokeKey request. The kubelet or
 another credential agent can therefore rotate the file without restarting the daemon.

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -77,7 +77,9 @@ deployment that terminates TLS on this hop simply configures an https address. A
 `--key-server-token-path <path>`, and
 `--key-server-token-path <path>`. The equivalent deployment environment names are
 `KEY_SERVER` and `KEY_SERVER_TOKEN_PATH`; explicit CLI values win. A token path
-without a server is rejected, and these options are rejected outside `--k8s`.
+without a server does nothing and says so; neither option requires `--k8s`, because where a runtime
+runs and where its key comes from are different questions — the launch path applies a minted
+credential to whatever environment it is building, cluster sandbox or local child alike.
 
 The bearer file is read for every IssueKey and RevokeKey request. The kubelet or
 another credential agent can therefore rotate the file without restarting the daemon.

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -77,7 +77,8 @@ deployment that terminates TLS on this hop simply configures an https address. A
 `--key-server-token-path <path>`, and
 `--key-server-token-path <path>`. The equivalent deployment environment names are
 `KEY_SERVER` and `KEY_SERVER_TOKEN_PATH`; explicit CLI values win. A token path
-without a server does nothing and says so; neither option requires `--k8s`, because where a runtime
+without a server does nothing and says so, as does a server without a token — that one sends every
+request with no `Authorization` header at all, which a server that reviews its callers refuses; neither option requires `--k8s`, because where a runtime
 runs and where its key comes from are different questions — the launch path applies a minted
 credential to whatever environment it is building, cluster sandbox or local child alike.
 

--- a/docs/designs/key-server.md
+++ b/docs/designs/key-server.md
@@ -70,7 +70,11 @@ the daemon does not have — a runtime switches models mid-session.
 
 ### 2.1 Daemon configuration
 
-Cloud daemons accept `--key-server <https-url>` and
+Cloud daemons accept `--key-server <url>` — **http or https, the deployment's choice**: the bearer
+is a projected ServiceAccount token, and a daemon that already reaches its control plane over an
+in-cluster `ws://` gains nothing from one hop being stricter than the boundary it sits in. A
+deployment that terminates TLS on this hop simply configures an https address. Also accepted:
+`--key-server-token-path <path>`, and
 `--key-server-token-path <path>`. The equivalent deployment environment names are
 `KEY_SERVER` and `KEY_SERVER_TOKEN_PATH`; explicit CLI values win. A token path
 without a server is rejected, and these options are rejected outside `--k8s`.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1153,7 +1153,6 @@ export class Daemon {
     this.clock = opts.clock ?? systemClock
     const modelKeyNow = opts.clock ? () => this.clock.now() : () => performance.timeOrigin + performance.now()
     this.modelSessions = new ModelSessionHostPool(this.modelSessionPoolHost(), {
-      k8s: this.k8s,
       address: opts.keyServer?.trim() || process.env.KEY_SERVER?.trim(),
       tokenPath: opts.keyServerTokenPath?.trim() || process.env.KEY_SERVER_TOKEN_PATH?.trim(),
       ...(opts.keyServerClient ? { client: opts.keyServerClient } : {}),
@@ -3486,7 +3485,10 @@ export class Daemon {
         // A dream host materializes nothing: it has no cleanup path and needs none of these secrets.
         ...(excludeAgentToolCredentials ? {} : { configFileDir: agent.dir }),
         finalizeLaunchEnv: (launchEnv) => {
-          if (!this.k8s || !target) return
+          // Not gated on `--k8s`: a minted credential belongs in whatever environment this is
+          // building, cluster sandbox or local child alike. The two branches below are inert
+          // outside a cloud daemon anyway — both maps are populated only there.
+          if (!target) return
           if (opts.modelCredential) applyModelCredential(target, launchEnv, opts.modelCredential.credential)
           else {
             const configured = this.modelSessions.staticCredential(target.runtime)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1160,8 +1160,12 @@ export class Daemon {
     })
     // Base URLs are deployment topology and always come from here, key server or not; an issuer
     // supplies the key alone.
-    this.modelSessions.staticModelCredentials = this.k8s ? configuredModelCredentials(process.env) : undefined
-    this.codexSessionFloor = this.k8s ? configuredCodexSessionFloor(process.env) : undefined
+    // Read regardless of `--k8s`, because these are deployment configuration and both are absent
+    // unless a deployment sets them. It also completes the key server outside cloud mode: a minted
+    // credential carries the KEY, and the endpoint it is minted for comes from this pair — gated on
+    // the flag, a non-cloud daemon would aim a gateway credential at the provider's own address.
+    this.modelSessions.staticModelCredentials = configuredModelCredentials(process.env)
+    this.codexSessionFloor = configuredCodexSessionFloor(process.env)
     this.evalHooks = new DaemonEvaluationHooks(this.evaluationHost(), opts.evaluation)
     this.sessionMetadataOutbox = new SessionMetadataOutbox(this.sessionMetadataHost())
     this.observedChannelsSync = new ObservedChannelsSync(this.observedChannelsSyncHost())

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1153,6 +1153,7 @@ export class Daemon {
     this.clock = opts.clock ?? systemClock
     const modelKeyNow = opts.clock ? () => this.clock.now() : () => performance.timeOrigin + performance.now()
     this.modelSessions = new ModelSessionHostPool(this.modelSessionPoolHost(), {
+      k8s: this.k8s,
       address: opts.keyServer?.trim() || process.env.KEY_SERVER?.trim(),
       tokenPath: opts.keyServerTokenPath?.trim() || process.env.KEY_SERVER_TOKEN_PATH?.trim(),
       ...(opts.keyServerClient ? { client: opts.keyServerClient } : {}),
@@ -1160,12 +1161,8 @@ export class Daemon {
     })
     // Base URLs are deployment topology and always come from here, key server or not; an issuer
     // supplies the key alone.
-    // Read regardless of `--k8s`, because these are deployment configuration and both are absent
-    // unless a deployment sets them. It also completes the key server outside cloud mode: a minted
-    // credential carries the KEY, and the endpoint it is minted for comes from this pair — gated on
-    // the flag, a non-cloud daemon would aim a gateway credential at the provider's own address.
-    this.modelSessions.staticModelCredentials = configuredModelCredentials(process.env)
-    this.codexSessionFloor = configuredCodexSessionFloor(process.env)
+    this.modelSessions.staticModelCredentials = this.k8s ? configuredModelCredentials(process.env) : undefined
+    this.codexSessionFloor = this.k8s ? configuredCodexSessionFloor(process.env) : undefined
     this.evalHooks = new DaemonEvaluationHooks(this.evaluationHost(), opts.evaluation)
     this.sessionMetadataOutbox = new SessionMetadataOutbox(this.sessionMetadataHost())
     this.observedChannelsSync = new ObservedChannelsSync(this.observedChannelsSyncHost())
@@ -3489,10 +3486,7 @@ export class Daemon {
         // A dream host materializes nothing: it has no cleanup path and needs none of these secrets.
         ...(excludeAgentToolCredentials ? {} : { configFileDir: agent.dir }),
         finalizeLaunchEnv: (launchEnv) => {
-          // Not gated on `--k8s`: a minted credential belongs in whatever environment this is
-          // building, cluster sandbox or local child alike. The two branches below are inert
-          // outside a cloud daemon anyway — both maps are populated only there.
-          if (!target) return
+          if (!this.k8s || !target) return
           if (opts.modelCredential) applyModelCredential(target, launchEnv, opts.modelCredential.credential)
           else {
             const configured = this.modelSessions.staticCredential(target.runtime)

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -59,7 +59,7 @@ program
   .option('--max-agents <n>', 'max agents this daemon advertises / enforces')
   .option('--require-sandbox', 'require the Linux SRT sandbox for every agent or refuse daemon startup')
   .option('--k8s', 'run runtimes in cluster sandbox pods instead of on this host (no probing, no local runtimes)')
-  .option('--key-server <url>', 'HTTPS endpoint for session-scoped model credentials')
+  .option('--key-server <url>', 'http(s) endpoint for session-scoped model credentials')
   .option('--key-server-token-path <path>', 'file containing the key-server bearer token')
   .option('--dry-run', 'load + validate config and print the reconcile plan, then exit')
   .option('--agent <name>', 'select a single agent by id (run/chat)')

--- a/packages/daemon/src/key-server/client.ts
+++ b/packages/daemon/src/key-server/client.ts
@@ -44,7 +44,16 @@ export class KeyServerClient {
     } = {}
   ) {
     this.baseUrl = new URL(address)
-    if (this.baseUrl.protocol !== 'https:') throw new Error('key-server must use https')
+    // http and https both, because the SCHEME is the deployment's decision and not this client's.
+    // The bearer this sends is a projected ServiceAccount token, and every other credential this
+    // process carries already crosses the same cluster in the clear — the control-plane socket is
+    // `ws://` in-cluster and carries a token of the same kind. Refusing http here made one hop
+    // stricter than the boundary it lives in, which bought nothing and forced a private CA (and a
+    // certificate, and its rotation) on the one service dialled directly rather than through the
+    // edge. A deployment that terminates TLS itself simply configures an https address.
+    if (this.baseUrl.protocol !== 'https:' && this.baseUrl.protocol !== 'http:') {
+      throw new Error(`key-server address must be http or https, got ${this.baseUrl.protocol}`)
+    }
     if (this.baseUrl.username || this.baseUrl.password) throw new Error('key-server URL must not contain credentials')
   }
 

--- a/packages/daemon/src/key-server/client.ts
+++ b/packages/daemon/src/key-server/client.ts
@@ -44,13 +44,10 @@ export class KeyServerClient {
     } = {}
   ) {
     this.baseUrl = new URL(address)
-    // http and https both, because the SCHEME is the deployment's decision and not this client's.
-    // The bearer this sends is a projected ServiceAccount token, and every other credential this
-    // process carries already crosses the same cluster in the clear — the control-plane socket is
-    // `ws://` in-cluster and carries a token of the same kind. Refusing http here made one hop
-    // stricter than the boundary it lives in, which bought nothing and forced a private CA (and a
-    // certificate, and its rotation) on the one service dialled directly rather than through the
-    // edge. A deployment that terminates TLS itself simply configures an https address.
+    // The scheme is the deployment's decision, not this client's: the bearer is a projected
+    // ServiceAccount token, and the same process already carries one over an in-cluster `ws://`
+    // socket to the control plane. Refusing http made one hop stricter than the boundary it lives
+    // in, at the price of a private CA on the one service dialled directly rather than via the edge.
     if (this.baseUrl.protocol !== 'https:' && this.baseUrl.protocol !== 'http:') {
       throw new Error(`key-server address must be http or https, got ${this.baseUrl.protocol}`)
     }

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -54,9 +54,9 @@ export interface ModelSessionHostPoolOptions {
 }
 
 /** True for an http address whose host is not obviously inside the cluster — a Service name (with
- *  or without its namespace/`.svc` suffix), the local node, or the cluster domain. Deliberately a
- *  shape test rather than a resolver: this runs at construction, and a warning that needed DNS
- *  would be a startup dependency. */
+ *  or without its namespace/`.svc` suffix), the local node, the cluster domain, or a private
+ *  network. Deliberately a shape test rather than a resolver: this runs at construction, and a
+ *  warning that needed DNS would be a startup dependency. */
 export function offClusterPlaintext(address: string): boolean {
   let url: URL
   try {
@@ -66,7 +66,22 @@ export function offClusterPlaintext(address: string): boolean {
   }
   if (url.protocol !== 'http:') return false
   const host = url.hostname
-  if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return false
+  if (host === 'localhost') return false
+  // IPv6 literals arrive bracketed; classifying one by shape is more than this warning is worth.
+  if (host.startsWith('[')) return false
+  const octets = host.split('.')
+  if (octets.length === 4 && octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) < 256)) {
+    const [a, b = 0] = octets.map(Number)
+    // Loopback, RFC1918, and the CGNAT range CNIs hand pod and Service IPs out of are this cluster
+    // or the network it sits on; any other literal is an address on the open internet.
+    const internal =
+      a === 127 ||
+      a === 10 ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 100 && b >= 64 && b <= 127)
+    return !internal
+  }
   // `.local` covers the default cluster domain (`…svc.cluster.local`) as well as an mDNS name,
   // which is a LAN rather than the internet and not what this warning is about.
   if (host.endsWith('.svc') || host.endsWith('.local')) return false
@@ -97,11 +112,9 @@ export class ModelSessionHostPool {
         'key-server-token-path is set with no key-server address: no credential will be requested and the token file is unused'
       )
     }
-    // The mirror image, and the more expensive mistake: with no token source the client sends the
-    // request with NO Authorization header at all — silently. A server that reviews its callers
-    // answers 401 to every mint, so every new session fails and the only evidence is per-session.
-    // Still a warning and not a refusal: a key server may be configured to trust its callers by
-    // network position, and that is its operator's call to make rather than this client's.
+    // The mirror image, and the more expensive one: with no token source every mint goes out with
+    // no Authorization header at all, and a server that reviews its callers 401s each one. Still a
+    // warning — a key server may trust its callers by network position, which is its operator's call.
     if (opts.address && !opts.tokenPath && !opts.client) {
       this.log.warn(
         `key-server ${opts.address} is configured with no key-server-token-path: requests will carry no credential, which a server that reviews its callers refuses`
@@ -110,10 +123,8 @@ export class ModelSessionHostPool {
     this.keyServer =
       opts.client ??
       (opts.address ? new KeyServerClient(opts.address, { tokenPath: opts.tokenPath, now: opts.now }) : undefined)
-    // The scheme is the deployment's to choose, so plaintext is not refused — but plaintext to an
-    // address that is NOT plainly in-cluster sends this daemon's bearer token across whatever lies
-    // between, which is the one case worth saying out loud. Said once, at construction, because it
-    // is a configuration fact rather than a per-request one.
+    // Plaintext is not refused, but plaintext to an address that is not plainly in-cluster sends
+    // this daemon's bearer across whatever lies between — said once here, being a config fact.
     if (opts.address && offClusterPlaintext(opts.address)) {
       this.log.warn(
         `key-server ${opts.address} is plaintext and does not look in-cluster: the bearer token will cross the network in the clear`

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -42,7 +42,6 @@ export interface ModelSessionHostPoolHost {
 }
 
 export interface ModelSessionHostPoolOptions {
-  k8s: boolean
   address?: string
   tokenPath?: string
   client?: KeyServerClient
@@ -81,10 +80,16 @@ export class ModelSessionHostPool {
     private readonly host: ModelSessionHostPoolHost,
     private readonly opts: ModelSessionHostPoolOptions
   ) {
-    if ((opts.address || opts.client) && !opts.k8s) {
-      throw new Error('key-server is supported only by cloud daemons running with --k8s')
+    // No `--k8s` requirement: a key server is a credential SOURCE, and where a runtime runs is a
+    // different question from where its key comes from. The launch path applies a minted credential
+    // to whatever environment it is building, cluster sandbox or local child alike.
+    // A token path with no server is a configuration that does nothing — say so and carry on, rather
+    // than refusing to start a daemon whose every other agent is fine.
+    if (opts.tokenPath && !opts.address && !opts.client) {
+      this.log.warn(
+        'key-server-token-path is set with no key-server address: no credential will be requested and the token file is unused'
+      )
     }
-    if (opts.tokenPath && !opts.address && !opts.client) throw new Error('key-server-token-path requires key-server')
     this.keyServer =
       opts.client ??
       (opts.address ? new KeyServerClient(opts.address, { tokenPath: opts.tokenPath, now: opts.now }) : undefined)
@@ -266,7 +271,7 @@ export class ModelSessionHostPool {
   boundTarget(sessionKey: string, agentId: string): ModelProviderTarget | undefined {
     const credentialHost = this.entries.get(sessionKey)
     if (credentialHost) return credentialHost.target
-    if (this.keyServer || !this.opts.k8s || !this.staticModelCredentials) return undefined
+    if (this.keyServer || !this.staticModelCredentials) return undefined
     const agent = this.host.agent(agentId)
     const runtime = agent ? this.host.runtime(agent.runtime) : undefined
     const target = agent && runtime ? modelProviderTarget(agent, runtime) : undefined

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -51,6 +51,26 @@ export interface ModelSessionHostPoolOptions {
 
 /** Owns the per-session model-credential state machine: the key-server handle, the issued grants,
  *  and the confined hosts started against them. */
+/** True for an http address whose host is not obviously inside the cluster — a Service name (with
+ *  or without its namespace/`.svc` suffix), the local node, or the cluster domain. Deliberately a
+ *  shape test rather than a resolver: this runs at construction, and a warning that needed DNS
+ *  would be a startup dependency. */
+export function offClusterPlaintext(address: string): boolean {
+  let url: URL
+  try {
+    url = new URL(address)
+  } catch {
+    return false
+  }
+  if (url.protocol !== 'http:') return false
+  const host = url.hostname
+  if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return false
+  if (host.endsWith('.svc') || host.endsWith('.svc.cluster.local') || host.endsWith('.local')) return false
+  // A bare label (`my-service`) or `service.namespace` is in-cluster addressing; a public name has
+  // a registrable domain, which needs at least three labels here (`a.b.c`) not to be one of those.
+  return host.split('.').length > 2
+}
+
 export class ModelSessionHostPool {
   private readonly entries = new Map<string, ModelSessionHost>()
   readonly keyServer?: KeyServerClient
@@ -68,6 +88,15 @@ export class ModelSessionHostPool {
     this.keyServer =
       opts.client ??
       (opts.address ? new KeyServerClient(opts.address, { tokenPath: opts.tokenPath, now: opts.now }) : undefined)
+    // The scheme is the deployment's to choose, so plaintext is not refused — but plaintext to an
+    // address that is NOT plainly in-cluster sends this daemon's bearer token across whatever lies
+    // between, which is the one case worth saying out loud. Said once, at construction, because it
+    // is a configuration fact rather than a per-request one.
+    if (opts.address && offClusterPlaintext(opts.address)) {
+      this.log.warn(
+        `key-server ${opts.address} is plaintext and does not look in-cluster: the bearer token will cross the network in the clear`
+      )
+    }
   }
 
   private get log(): Logger {

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -41,10 +41,12 @@ export interface ModelSessionHostPoolHost {
   cleanupAgentConfigFiles(agentId: string): void
 }
 
-/** No `--k8s` field, deliberately: a key server is a credential SOURCE, and where a runtime runs is
- *  a different question from where its key comes from. The launch path applies a minted credential
- *  to whatever environment it is building, cluster sandbox or local child alike. */
 export interface ModelSessionHostPoolOptions {
+  /** Cloud mode. A key server is refused without it — not because minting needs a cluster, but
+   *  because the credential it mints is only usable with the `*_MODEL_BASE_URL` pair that aims it
+   *  at this install's gateway, and that pair is cloud-mode configuration. A key minted for a
+   *  gateway and sent to the provider's own address is a 401 with no hint as to why. */
+  k8s: boolean
   address?: string
   tokenPath?: string
   client?: KeyServerClient
@@ -85,6 +87,9 @@ export class ModelSessionHostPool {
     private readonly host: ModelSessionHostPoolHost,
     private readonly opts: ModelSessionHostPoolOptions
   ) {
+    if ((opts.address || opts.client) && !opts.k8s) {
+      throw new Error('key-server is supported only by cloud daemons running with --k8s')
+    }
     // A token path with no server is a configuration that does nothing — say so and carry on, rather
     // than refusing to start a daemon whose every other agent is fine.
     if (opts.tokenPath && !opts.address && !opts.client) {
@@ -284,7 +289,7 @@ export class ModelSessionHostPool {
   boundTarget(sessionKey: string, agentId: string): ModelProviderTarget | undefined {
     const credentialHost = this.entries.get(sessionKey)
     if (credentialHost) return credentialHost.target
-    if (this.keyServer || !this.staticModelCredentials) return undefined
+    if (this.keyServer || !this.opts.k8s || !this.staticModelCredentials) return undefined
     const agent = this.host.agent(agentId)
     const runtime = agent ? this.host.runtime(agent.runtime) : undefined
     const target = agent && runtime ? modelProviderTarget(agent, runtime) : undefined

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -90,6 +90,16 @@ export class ModelSessionHostPool {
         'key-server-token-path is set with no key-server address: no credential will be requested and the token file is unused'
       )
     }
+    // The mirror image, and the more expensive mistake: with no token source the client sends the
+    // request with NO Authorization header at all — silently. A server that reviews its callers
+    // answers 401 to every mint, so every new session fails and the only evidence is per-session.
+    // Still a warning and not a refusal: a key server may be configured to trust its callers by
+    // network position, and that is its operator's call to make rather than this client's.
+    if (opts.address && !opts.tokenPath && !opts.client) {
+      this.log.warn(
+        `key-server ${opts.address} is configured with no key-server-token-path: requests will carry no credential, which a server that reviews its callers refuses`
+      )
+    }
     this.keyServer =
       opts.client ??
       (opts.address ? new KeyServerClient(opts.address, { tokenPath: opts.tokenPath, now: opts.now }) : undefined)

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -145,7 +145,8 @@ export class ModelSessionHostPool {
     return this.staticModelCredentials?.[runtime]
   }
 
-  /** The deployment's base for a target, the only source of one — an IssueKey `baseUrl` is not read. */
+  /** The deployment's base for a target, and the only source of one: the contract defines no
+   *  `baseUrl`, and an issuer that sends one is stripped rather than read. */
   staticBaseUrl(target: ModelProviderTarget): { baseUrl?: string } {
     const baseUrl = this.staticModelCredentials?.[target.runtime]?.baseUrl
     return baseUrl ? { baseUrl } : {}

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -41,6 +41,9 @@ export interface ModelSessionHostPoolHost {
   cleanupAgentConfigFiles(agentId: string): void
 }
 
+/** No `--k8s` field, deliberately: a key server is a credential SOURCE, and where a runtime runs is
+ *  a different question from where its key comes from. The launch path applies a minted credential
+ *  to whatever environment it is building, cluster sandbox or local child alike. */
 export interface ModelSessionHostPoolOptions {
   address?: string
   tokenPath?: string
@@ -48,8 +51,6 @@ export interface ModelSessionHostPoolOptions {
   now: () => number
 }
 
-/** Owns the per-session model-credential state machine: the key-server handle, the issued grants,
- *  and the confined hosts started against them. */
 /** True for an http address whose host is not obviously inside the cluster — a Service name (with
  *  or without its namespace/`.svc` suffix), the local node, or the cluster domain. Deliberately a
  *  shape test rather than a resolver: this runs at construction, and a warning that needed DNS
@@ -64,12 +65,16 @@ export function offClusterPlaintext(address: string): boolean {
   if (url.protocol !== 'http:') return false
   const host = url.hostname
   if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return false
-  if (host.endsWith('.svc') || host.endsWith('.svc.cluster.local') || host.endsWith('.local')) return false
+  // `.local` covers the default cluster domain (`…svc.cluster.local`) as well as an mDNS name,
+  // which is a LAN rather than the internet and not what this warning is about.
+  if (host.endsWith('.svc') || host.endsWith('.local')) return false
   // A bare label (`my-service`) or `service.namespace` is in-cluster addressing; a public name has
   // a registrable domain, which needs at least three labels here (`a.b.c`) not to be one of those.
   return host.split('.').length > 2
 }
 
+/** Owns the per-session model-credential state machine: the key-server handle, the issued grants,
+ *  and the confined hosts started against them. */
 export class ModelSessionHostPool {
   private readonly entries = new Map<string, ModelSessionHost>()
   readonly keyServer?: KeyServerClient
@@ -80,9 +85,6 @@ export class ModelSessionHostPool {
     private readonly host: ModelSessionHostPoolHost,
     private readonly opts: ModelSessionHostPoolOptions
   ) {
-    // No `--k8s` requirement: a key server is a credential SOURCE, and where a runtime runs is a
-    // different question from where its key comes from. The launch path applies a minted credential
-    // to whatever environment it is building, cluster sandbox or local child alike.
     // A token path with no server is a configuration that does nothing — say so and carry on, rather
     // than refusing to start a daemon whose every other agent is fine.
     if (opts.tokenPath && !opts.address && !opts.client) {

--- a/packages/daemon/test/key-server-client.test.ts
+++ b/packages/daemon/test/key-server-client.test.ts
@@ -86,8 +86,14 @@ describe('KeyServerClient', () => {
     expect(fetch.mock.calls[1]?.[1]?.body).toBe(JSON.stringify({ keyId: 'key-1' }))
   })
 
-  it('requires HTTPS and rejects credentials in the address', () => {
-    expect(() => new KeyServerClient('http://keys.example')).toThrow(/https/)
+  it("takes either scheme — that is the deployment's call — and rejects credentials in the address", () => {
+    // http is not a downgrade this client gets to veto: the bearer it sends is a projected
+    // ServiceAccount token, and the same process already carries one over an in-cluster `ws://`
+    // socket to the control plane. Refusing it here made one hop stricter than its boundary and
+    // forced a private CA onto the one service dialled directly instead of through the edge.
+    expect(() => new KeyServerClient('http://keys.example')).not.toThrow()
+    expect(() => new KeyServerClient('https://keys.example')).not.toThrow()
+    expect(() => new KeyServerClient('ftp://keys.example')).toThrow(/http or https/)
     expect(() => new KeyServerClient('https://user:pass@keys.example')).toThrow(/must not contain credentials/)
   })
 

--- a/packages/daemon/test/key-server-client.test.ts
+++ b/packages/daemon/test/key-server-client.test.ts
@@ -87,10 +87,8 @@ describe('KeyServerClient', () => {
   })
 
   it("takes either scheme — that is the deployment's call — and rejects credentials in the address", () => {
-    // http is not a downgrade this client gets to veto: the bearer it sends is a projected
-    // ServiceAccount token, and the same process already carries one over an in-cluster `ws://`
-    // socket to the control plane. Refusing it here made one hop stricter than its boundary and
-    // forced a private CA onto the one service dialled directly instead of through the edge.
+    // http is not a downgrade this client gets to veto: the bearer is a projected ServiceAccount
+    // token, and the same process already carries one over an in-cluster `ws://` socket to the CP.
     expect(() => new KeyServerClient('http://keys.example')).not.toThrow()
     expect(() => new KeyServerClient('https://keys.example')).not.toThrow()
     expect(() => new KeyServerClient('ftp://keys.example')).toThrow(/http or https/)

--- a/packages/daemon/test/model-key-session.test.ts
+++ b/packages/daemon/test/model-key-session.test.ts
@@ -22,12 +22,13 @@ function harness(grants: Array<Record<string, unknown>>) {
 const agent = { id: 'agent-a', runtime: 'claude' }
 
 describe('daemon model-key session lifecycle', () => {
-  it('takes key-server configuration outside cloud mode, and does not refuse a lone token path', () => {
-    // Where a runtime RUNS and where its key comes FROM are different questions: the launch path
-    // applies a minted credential to whatever environment it is building. And a token path with no
-    // server is a configuration that does nothing — worth a warning, not a refusal to start a
-    // daemon whose every other agent is fine.
-    expect(() => new Daemon({ keyServerClient: {} as never })).not.toThrow()
+  it('refuses a key server outside cloud mode, and never demands a token path', () => {
+    // A minted key is only usable with the `*_MODEL_BASE_URL` pair that aims it at this install's
+    // gateway, and that pair is cloud-mode configuration — so a non-cloud key server is refused.
+    // Its credential is a separate question: with or without a token path, both directions are a
+    // warning rather than a refusal to start a daemon whose every other agent is fine.
+    expect(() => new Daemon({ keyServerClient: {} as never })).toThrow(/--k8s/)
+    expect(() => new Daemon({ k8s: true, keyServerClient: {} as never })).not.toThrow()
     expect(() => new Daemon({ k8s: true, keyServerTokenPath: '/token' })).not.toThrow()
     expect(() => new Daemon({ keyServerTokenPath: '/token' })).not.toThrow()
   })

--- a/packages/daemon/test/model-key-session.test.ts
+++ b/packages/daemon/test/model-key-session.test.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 import { FakeClock } from '@agentconnect.md/connection'
 import { Daemon } from '../src/daemon.js'
+import { offClusterPlaintext } from '../src/key-server/session-hosts.js'
 
 function harness(grants: Array<Record<string, unknown>>) {
   const clock = new FakeClock(1_000)
@@ -271,5 +272,34 @@ describe('daemon model-key session lifecycle', () => {
     await released
     expect(h.firstHost.stop).toHaveBeenCalledOnce()
     expect(h.revoke).toHaveBeenCalledWith('key-1')
+  })
+})
+
+describe('the plaintext key-server warning', () => {
+  it('says nothing for TLS, and nothing for the in-cluster shapes a deployment actually writes', () => {
+    // The scheme is the deployment's to choose, so this is a warning about ONE case — a bearer
+    // crossing something that is not obviously the cluster — not a rule about schemes.
+    for (const address of [
+      'https://keys.example.com',
+      'https://hub.agentconnect-test.svc:8080',
+      'http://test-agentconnect-aigw-hub:8080',
+      'http://test-agentconnect-aigw-hub.agentconnect-test:8080',
+      'http://test-agentconnect-aigw-hub.agentconnect-test.svc:8080',
+      'http://test-agentconnect-aigw-hub.agentconnect-test.svc.cluster.local:8080',
+      'http://localhost:8080',
+      'http://127.0.0.1:8080'
+    ]) {
+      expect(offClusterPlaintext(address), address).toBe(false)
+    }
+  })
+
+  it('warns for plaintext to a name that is not cluster-shaped', () => {
+    for (const address of ['http://keys.example.com', 'http://keys.example.com:8080', 'http://a.b.c']) {
+      expect(offClusterPlaintext(address), address).toBe(true)
+    }
+  })
+
+  it('says nothing about an address it cannot parse — the client already refuses that', () => {
+    expect(offClusterPlaintext('not a url')).toBe(false)
   })
 })

--- a/packages/daemon/test/model-key-session.test.ts
+++ b/packages/daemon/test/model-key-session.test.ts
@@ -293,14 +293,25 @@ describe('the plaintext key-server warning', () => {
       'http://test-agentconnect-aigw-hub.agentconnect-test.svc:8080',
       'http://test-agentconnect-aigw-hub.agentconnect-test.svc.cluster.local:8080',
       'http://localhost:8080',
-      'http://127.0.0.1:8080'
+      'http://127.0.0.1:8080',
+      'http://[::1]:8080',
+      'http://10.96.3.4:8080',
+      'http://172.20.0.5:8080',
+      'http://192.168.1.9:8080',
+      'http://100.72.4.1:8080'
     ]) {
       expect(offClusterPlaintext(address), address).toBe(false)
     }
   })
 
   it('warns for plaintext to a name that is not cluster-shaped', () => {
-    for (const address of ['http://keys.example.com', 'http://keys.example.com:8080', 'http://a.b.c']) {
+    for (const address of [
+      'http://keys.example.com',
+      'http://keys.example.com:8080',
+      'http://a.b.c',
+      'http://203.0.113.5:8080',
+      'http://172.32.0.5:8080'
+    ]) {
       expect(offClusterPlaintext(address), address).toBe(true)
     }
   })

--- a/packages/daemon/test/model-key-session.test.ts
+++ b/packages/daemon/test/model-key-session.test.ts
@@ -22,9 +22,14 @@ function harness(grants: Array<Record<string, unknown>>) {
 const agent = { id: 'agent-a', runtime: 'claude' }
 
 describe('daemon model-key session lifecycle', () => {
-  it('accepts key-server configuration only in cloud mode', () => {
-    expect(() => new Daemon({ keyServerClient: {} as never })).toThrow(/only by cloud daemons/)
-    expect(() => new Daemon({ k8s: true, keyServerTokenPath: '/token' })).toThrow(/requires key-server/)
+  it('takes key-server configuration outside cloud mode, and does not refuse a lone token path', () => {
+    // Where a runtime RUNS and where its key comes FROM are different questions: the launch path
+    // applies a minted credential to whatever environment it is building. And a token path with no
+    // server is a configuration that does nothing — worth a warning, not a refusal to start a
+    // daemon whose every other agent is fine.
+    expect(() => new Daemon({ keyServerClient: {} as never })).not.toThrow()
+    expect(() => new Daemon({ k8s: true, keyServerTokenPath: '/token' })).not.toThrow()
+    expect(() => new Daemon({ keyServerTokenPath: '/token' })).not.toThrow()
   })
 
   it('issues once per logical session, caches the host, and revokes on release', async () => {

--- a/packages/protocol/src/key-server.ts
+++ b/packages/protocol/src/key-server.ts
@@ -46,9 +46,9 @@ export const IssueKeyRequest = z
 export type IssueKeyRequest = z.infer<typeof IssueKeyRequest>
 
 // Responses parse tolerantly (unknown fields stripped, not rejected), unlike the `.strict()`
-// requests: the daemon reads many issuers it does not ship with, so a field an issuer still
-// sends (the retired `baseUrl`) or adds later must not fail every issuance. Base URLs are
-// deployment topology and come only from the daemon's own configuration.
+// requests: the daemon reads issuers it does not ship with, so a field one adds later must not
+// fail every issuance. A base URL is not among the fields it may usefully add — that is
+// deployment topology and comes only from the daemon's own configuration.
 export const IssueKeyResponse = z
   .object({
     // Opaque handle for RevokeKey and audit; the key value never travels again. It names


### PR DESCRIPTION
`--key-server` refused anything but `https:`, and demanded a token path beside it. Both are
deployment decisions, and the first one blocks the plaintext in-cluster hop the test install
actually runs — the daemon and the hub sit in the same namespace, like every other link in
this stack (daemon↔CP, billing↔CP).

**Scheme.** `http:` and `https:` are both accepted; anything else is still refused, as is a
URL carrying credentials. Plaintext to an address that is *not* obviously in-cluster gets a
warning, because that is a bearer token on the open network. In-cluster here means `.svc`,
`.local`, localhost, a bare one- or two-label name, or a private-range literal (loopback,
RFC1918, and the CGNAT range CNIs allocate pod and Service IPs from) — a shape test, not a
resolver, so a warning never becomes a DNS dependency at startup.

**Credential.** A key server with no `--key-server-token-path` now warns instead of refusing.
The client sends the mint request with no `Authorization` header at all, which a server that
reviews its callers answers 401 to — but a key server may equally be configured to trust its
callers by network position, and that is its operator's call. The mirror image, a token path
with no server, warns too: it is a configuration that does nothing, and it should not stop a
daemon whose every other agent is fine.

**Not relaxed: `--k8s`.** A minted credential is only usable together with the
`*_MODEL_BASE_URL` pair that aims it at this install's gateway, and that pair is cloud-mode
configuration. Aimed at the provider's own address the key is a 401 with no hint as to why —
so the requirement stays, and now records what it is protecting rather than reading as an
arbitrary flag check.

Docs follow the code, including dropping the archaeology about a base URL the contract no
longer defines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)