### PR TITLE
fix(daemon): read a spend limit as an exhausted quota, not a generic failure

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -212,8 +212,10 @@ const PROVIDER_QUOTA_CODES = new Set([
 ])
 
 const PROVIDER_QUOTA_MESSAGES = [
-  /\b(?:you(?:'|’)ve|you have) hit your (?:[a-z]+ )?usage limit\b/i,
-  /\busage limit (?:has been )?(?:reached|exceeded)\b/i,
+  // A spend limit is a quota, not a transient rate limit, however the provider phrases the
+  // possessive in between: "You've hit your org's monthly spend limit".
+  /\b(?:you(?:'|’)ve|you have) hit your\b[\s\S]{0,60}\b(?:usage|spend) limit\b/i,
+  /\b(?:usage|spend) limit (?:has been )?(?:reached|exceeded)\b/i,
   /\b(?:you(?:'|’)ve|you have) hit your limit\b[\s\S]{0,120}\bresets?\b/i,
   /\b(?:credit|credits) balance (?:is )?(?:too low|depleted|exhausted)\b/i,
   /\b(?:insufficient|not enough|no) (?:api )?credits?(?: (?:remaining|available))?\b/i,

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -541,6 +541,22 @@ describe('turnFailureCode (normalized non-actionable provider failures)', () => 
     {
       name: 'provider credit exhaustion text',
       error: { error: { message: 'Credit balance is too low to access the Anthropic API' } }
+    },
+    {
+      // Observed live 2026-08-21: every review turn on the org died in under a second, and this
+      // wording reached neither the quota codes nor the usage-limit patterns, so the Check said
+      // only "Review could not be completed" while the real cause sat in the daemon log.
+      name: 'Claude org spend limit text',
+      error: Object.assign(
+        new Error(
+          "Internal error: You've hit your org's monthly spend limit · run /usage-credits to ask your admin for a higher limit"
+        ),
+        { code: -32603, data: { errorKind: 'rate_limit' } }
+      )
+    },
+    {
+      name: 'spend limit reached text',
+      error: { data: { message: 'Your monthly spend limit has been reached.' } }
     }
   ])('classifies $name as provider_quota_exhausted', ({ error }) => {
     expect(turnFailureCode(error)).toBe('provider_quota_exhausted')
@@ -570,6 +586,8 @@ describe('turnFailureCode (normalized non-actionable provider failures)', () => 
   it.each([
     new Error('spawn claude ENOENT'),
     { code: 'rate_limit_error', message: 'Rate limit exceeded; retry in 20 seconds' },
+    // An adapter's `rate_limit` error kind is transient on its own: only the message promotes.
+    { message: 'Rate limit exceeded; retry in 20 seconds', data: { errorKind: 'rate_limit' } },
     { data: { error: { type: 'overloaded_error', message: 'Service temporarily overloaded' } } },
     Object.assign(new Error('Authentication required'), { data: { message: 'Please sign in again' } })
   ])('keeps non-quota failures as turn_failed', (error) => {


### PR DESCRIPTION
## What

Classify a provider "spend limit" refusal as `provider_quota_exhausted` instead of the catch-all `turn_failed`.

## Why

Observed live on 2026-08-21: every review turn for one agent died in under a second for roughly two and a half hours. The daemon log carried the reason verbatim —

```
RequestError: Internal error: You've hit your org's monthly spend limit ·
run /usage-credits to ask your admin for a higher limit
(code=-32603) data={"errorKind":"rate_limit"}
```

— but `turnFailureCode()` matched none of it:

- `PROVIDER_QUOTA_CODES` sees no quota code (`-32603` is generic, and `rate_limit` is deliberately excluded so an ordinary transient rate limit is not mistaken for an empty balance).
- `PROVIDER_QUOTA_MESSAGES` allowed exactly one lowercase word between "hit your" and "usage limit", so `your org's monthly spend limit` missed on both the possessive and the noun.

So the run reported `turn_failed`, and every reader downstream lost the only useful fact: the GitHub Check said "Review could not be completed", the console's delivery list said `turn_failed`, and the real sentence existed nowhere outside the daemon's journal. It read as a broken trigger rather than an empty balance, which is exactly how it was reported.

## How

Widen the two usage-limit patterns to cover spending and to tolerate a possessive between the verb and the noun. Nothing else moves.

Classification stays message-driven on purpose. The payload does carry a structured `errorKind: "rate_limit"`, but so does an ordinary retryable rate limit, so promoting on the kind would misclassify transient throttling as an exhausted quota. A test pins that the kind alone still resolves to `turn_failed`.

## Reviewer notes

- This only changes the reason string. The Check title stays deliberately vague: `hookSkippedCheckLabel` returns `null` for both `provider_quota_exhausted` and `provider_auth_required`, so a public pull request never displays an organization's billing state. What improves is the console — the integration's Recent deliveries panel renders the reason, so it now reads `provider_quota_exhausted` instead of `turn_failed`.
- The gap is generic to the seam: an adapter can phrase an exhausted balance any way it likes, and every phrasing that misses lands in the same silent bucket. Worth revisiting if a third phrasing shows up.

## Tests

`packages/daemon/test/acp-host.test.ts` — the observed message and a `spend limit has been reached` variant added to the quota table; the `errorKind: "rate_limit"` shape added to the non-quota table. 49 passed in that file, daemon typecheck, eslint, and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
