### PR TITLE
feat(control-plane): keep a paused agent's hooks out of the relay pool

### DIFF
--- a/packages/control-plane/src/hooks/hook.service.test.ts
+++ b/packages/control-plane/src/hooks/hook.service.test.ts
@@ -75,13 +75,19 @@ function make(
     installations?: GithubInstallationRecord[]
     appSlug?: string
     hooks?: Partial<HookRepo>
+    pause?: boolean | null
   } = {}
 ) {
   const agents: HookAgentReads = {
     getUnscoped: vi.fn(async () =>
       opts.daemonId === null
         ? null
-        : ({ id: AGENT, name: 'review-agent', daemonId: opts.daemonId ?? DAEMON } as AgentRecord)
+        : ({
+            id: AGENT,
+            name: 'review-agent',
+            daemonId: opts.daemonId ?? DAEMON,
+            ...(opts.pause !== undefined ? { pause: opts.pause } : {})
+          } as AgentRecord)
     )
   }
   const secrets = { get: vi.fn(async () => opts.secret ?? null) } as unknown as HookSecretStore
@@ -141,6 +147,23 @@ describe('HookService.compile', () => {
 
   it('returns null for a tokenless webhook hook', async () => {
     expect(await make().svc.compile(hook({ urlToken: null }))).toBeNull()
+  })
+
+  it('keeps a paused agent out of the pool, and converges the rule to a removal', async () => {
+    const { svc, assigns, removes } = make({ pause: true })
+
+    expect(await svc.compile(hook())).toBeNull()
+    await svc.broadcast(hook())
+    expect(assigns).toEqual([])
+    expect(removes).toEqual([HOOK])
+  })
+
+  it('compiles again once the agent resumes', async () => {
+    const { svc, assigns, removes } = make({ pause: false })
+
+    await svc.broadcast(hook())
+    expect(removes).toEqual([])
+    expect(assigns).toHaveLength(1)
   })
 
   const ghHook = (over: Partial<HookRecord> = {}) =>

--- a/packages/control-plane/src/hooks/hook.service.ts
+++ b/packages/control-plane/src/hooks/hook.service.ts
@@ -60,12 +60,16 @@ export class HookService {
 
   /**
    * HookDef → relay rule, or null when it must not be in the pool (disabled,
-   * legacy orphaned, unplaced, missing kind columns, or — github kind — no
-   * valid installation left to attribute events with).
+   * legacy orphaned, paused, unplaced, missing kind columns, or — github kind —
+   * no valid installation left to attribute events with).
    */
   async compile(hook: HookRecord): Promise<RcHookAssign | null> {
     if (!hook.enabled || !hook.agentId) return null
     const agent = await this.agents.getUnscoped(hook.agentId)
+    // A paused agent rejects every fire at the daemon, so a rule left in the pool buys only a
+    // dispatch that dies and, for a github hook, a Check that reports nothing anyone can act on.
+    // Pause leaves the pool the same way an unplaced agent does, and resuming re-assigns it.
+    if (agent?.pause === true) return null
     // The relay needs one member to address; for a pool agent that is the current duty holder,
     // since placement names none. Nothing serving it ⇒ the rule leaves the relay pool, exactly as
     // an unplaced agent's does.

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -2173,6 +2173,11 @@ export function agentRoutes(deps: HttpDeps) {
           }
           await pushExternalMemoryBeforeAgent(agent)
           await replicateUpsert(agent)
+          // Pause decides whether this agent's hooks belong in the relay pool at all, so a toggle
+          // needs the rule convergence a placement change gets — nothing else recomputes it.
+          if ((existing.pause === true) !== (agent.pause === true)) {
+            await deps.hooks.rebroadcastForAgent(AgentId(agent.id))
+          }
           if (req.body.icon !== undefined) void syncAgentBotIcons(deps, agent, app.log)
           await removeUnusedExternalMemoryAfterAgent(existing, agent)
           // Provision/drop MCP proxy defs for an enable-list change with the placement


### PR DESCRIPTION
## What

A paused agent's hooks no longer compile into a relay rule, so a pause stops the delivery at the source instead of at the daemon.

## Why

Pausing already stopped the work — the daemon rejects every fire with `rejected:paused`. What it did not stop was everything leading up to that rejection. The rule stayed in the pool, so each event still travelled relay → daemon to buy a rejection, and for a github hook the accepted delivery also opened a review projection. That projection publishes a Check.

The result is a Check on every pull request revision, from an agent that is switched off, whose title tells the reader nothing they can act on. Measured on one deployment: an agent paused twelve days earlier had **2366 review projections**, **1273** of them settled as `skipped` — one per revision the repository saw while it did nothing. Anyone reading that check reasonably concludes the integration is broken rather than paused.

The load is real too. Those settled rows sit in the reporter's due set, and the worker was observed leasing them in batches while genuine work waited.

## How

`HookService.compile()` returns `null` for a paused agent. That is the pool-exit the service already models for every hook that must not dispatch — disabled, orphaned, unplaced, or with no valid installation left to attribute events — so `broadcast()` converges to `rc/hook-remove` with no new mechanism, `replayTo` skips it on relay reconnect, and resuming compiles and re-assigns.

The PATCH handler re-converges an agent's rules when `pause` flips. Nothing else did: routing convergence runs on placement and duty changes, and a pause is neither, so without this the rule table would only catch up on the next unrelated placement event.

## Reviewer notes

- **The delivery record changes shape.** Today a paused agent leaves one `rejected:paused` run per event; now it leaves none, because nothing is dispatched. That is the intent — the console's Recent deliveries stops filling with rejections — but if you would rather keep an audit trail of suppressed triggers, this is the decision to push back on, and it is easier to change now than later.
- Scope is every hook kind, not just github, which matches what the daemon already did with them. Cron is daemon-local and unaffected.
- Existing published Checks from before the change are left alone. They are settled rows on old revisions; nothing rewrites history here.

## Tests

`hook.service.test.ts` — a paused agent compiles to `null` and converges to a removal; a resumed one compiles and assigns. Control-plane unit suite 1825 passed, typecheck, eslint, and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
