### PR TITLE
fix(control-plane): let a settled review projection leave the reporter's queue

### DIFF
--- a/packages/control-plane/src/github/run-reporter.test.ts
+++ b/packages/control-plane/src/github/run-reporter.test.ts
@@ -536,6 +536,7 @@ describe('GithubRunReporter', () => {
       advancePendingReviewProjection: vi.fn(async () => null),
       retryProjectionWrite: vi.fn(async () => true),
       blockProjection: vi.fn(async () => true),
+      settleReviewProjection: vi.fn(async () => true),
       getReviewProjection: vi.fn(async () => ({ ...p, observedState: p.desiredState, nextAttemptAt: null })),
       refreshReviewProjectionTarget: vi.fn(async () => true),
       synchronizeReviewSubjects: vi.fn(async () => true),
@@ -950,7 +951,7 @@ describe('GithubRunReporter', () => {
   ] as const)('publishes a Request review action for every active terminal %s Check', async (desiredState, title) => {
     const p = projection({
       desiredState,
-      observedState: desiredState,
+      observedState: 'in_progress',
       checkRunId: '90071992547409931'
     })
     const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
@@ -1424,7 +1425,7 @@ describe('GithubRunReporter', () => {
 
   it('retries the canonical desired state after an authorization block is woken', async () => {
     const p = projection({
-      desiredState: 'queued',
+      desiredState: 'in_progress',
       observedState: 'queued',
       checkRunId: '90071992547409931',
       lastErrorCode: 'repo_authorization',
@@ -1434,7 +1435,7 @@ describe('GithubRunReporter', () => {
       Response.json({
         id: p.checkRunId,
         external_id: p.externalId,
-        status: 'queued',
+        status: 'in_progress',
         conclusion: null,
         output: { summary: JSON.parse(String(init?.body)).output.summary }
       })
@@ -1446,8 +1447,46 @@ describe('GithubRunReporter', () => {
     expect(fetchImpl).toHaveBeenCalledOnce()
     expect(fetchImpl.mock.calls[0]![1]?.method).toBe('PATCH')
     expect(hooks.completeProjectionWrite).toHaveBeenCalledWith(
-      expect.objectContaining({ projectionId: p.id, observedState: 'queued' })
+      expect.objectContaining({ projectionId: p.id, observedState: 'in_progress' })
     )
+  })
+
+  it('settles a projection GitHub already agrees with instead of re-publishing it', async () => {
+    // The claim is a bounded FIFO over everything whose due time has passed, so a row that
+    // never leaves it both re-writes a settled Check and holds up the rows behind it. Observed
+    // live: 3027 of 3680 due rows had nothing to publish, and a genuinely pending one sat
+    // behind 3671 of them.
+    const p = projection({
+      desiredState: 'success',
+      observedState: 'success',
+      checkRunId: '90071992547409931',
+      subjectSyncGeneration: 1n
+    })
+    const fetchImpl = vi.fn(async () => Response.json({}))
+    const { reporter, hooks } = worker(p, fetchImpl)
+
+    await reporter.tick()
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(hooks.beginProjectionWrite).not.toHaveBeenCalled()
+    expect(hooks.settleReviewProjection).toHaveBeenCalledWith(p.id, p.generation, expect.any(String))
+  })
+
+  it('still publishes when a newer intent is queued behind the state GitHub shows', async () => {
+    const p = projection({
+      desiredState: 'success',
+      observedState: 'success',
+      checkRunId: '90071992547409931',
+      pendingIntent: JSON.stringify({ desiredState: 'failure', generation: '2' })
+    })
+    const { reporter, hooks } = worker(
+      p,
+      vi.fn(async () => Response.json({}))
+    )
+
+    await reporter.tick()
+
+    expect(hooks.settleReviewProjection).not.toHaveBeenCalled()
   })
 
   it('retains the durable mutex after an ambiguous POST and does not complete', async () => {

--- a/packages/control-plane/src/github/run-reporter.ts
+++ b/packages/control-plane/src/github/run-reporter.ts
@@ -300,6 +300,7 @@ export interface GithubRunReporterDeps {
     | 'advancePendingReviewProjection'
     | 'retryProjectionWrite'
     | 'blockProjection'
+    | 'settleReviewProjection'
     | 'getReviewProjection'
     | 'listReviewSubjects'
     | 'synchronizeReviewSubjects'
@@ -471,6 +472,20 @@ export class GithubRunReporter {
       projection.pendingIntent !== null
     ) {
       await this.advancePending(projection)
+      return
+    }
+    // Settled: GitHub already shows the desired state, no write is in flight, and no newer
+    // intent is queued. Everything below this point mints a token and writes a Check, so a row
+    // that reaches it with nothing to say re-publishes what is already there. Leave the due set
+    // instead — the claim is a bounded FIFO, and rows that never leave it starve the real work
+    // behind them.
+    if (
+      projection.observedState === projection.desiredState &&
+      projection.writePhase === null &&
+      projection.writeMarker === null &&
+      projection.pendingIntent === null
+    ) {
+      await this.deps.hooks.settleReviewProjection(projection.id, projection.generation, this.workerId)
       return
     }
     const settledAssociationError =

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2636,6 +2636,9 @@ export interface HookRepo {
     errorCode: string,
     keepWriteMutex?: boolean
   ): Promise<boolean>
+  /** Release a projection that has nothing left to publish, clearing its due time so the
+   *  bounded claim stops returning it. Any later work re-arms `nextAttemptAt`. */
+  settleReviewProjection(projectionId: string, generation: bigint, leaseOwner: string): Promise<boolean>
   /** Permanently tombstone every durable Check owned by one agent/repository
    * grant before that grant is revoked. The reporter may subsequently use only
    * its cleanup capability; delayed HookRun repair must never revive the row. */

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -2901,6 +2901,30 @@ export class PgHookRepo implements HookRepo {
     })
   }
 
+  /** Nothing left to publish: drop the row out of the due set instead of leaving it to be
+   *  claimed, re-written, and claimed again. Not a failure, so `lastErrorCode` clears too. */
+  async settleReviewProjection(projectionId: string, generation: bigint, leaseOwner: string): Promise<boolean> {
+    return this.transaction(async (tx) => {
+      const current = await this.lockReviewProjectionById(tx, projectionId)
+      if (!current || current.generation !== generation || current.leaseOwner !== leaseOwner) return false
+      // Re-read under the row lock: a converge that landed while this worker held the lease has
+      // already re-armed the row, and clearing its due time would strand the new intent.
+      if (
+        current.desiredState !== current.observedState ||
+        current.pendingIntent !== null ||
+        current.writePhase !== null ||
+        current.writeMarker !== null
+      ) {
+        return false
+      }
+      const changed = await tx.hookReviewProjection.updateMany({
+        where: { id: projectionId, generation, leaseOwner },
+        data: { nextAttemptAt: null, leaseOwner: null, leaseUntil: null, lastErrorCode: null, attempts: 0 }
+      })
+      return changed.count === 1
+    })
+  }
+
   async blockProjection(
     projectionId: string,
     generation: bigint,


### PR DESCRIPTION
## What

A review projection whose Check already shows the desired state now leaves the reporter's due set instead of being claimed, re-published, and claimed again.

## Why

`claimDueReviewProjections` takes the 25 oldest rows whose `nextAttemptAt` has passed, ordered by that timestamp. Nothing ever removed a row from that set. And `process()` had no early return for "already correct": a row with `observedState === desiredState`, no `writePhase`/`writeMarker`, and no `pendingIntent` fell past every guard, minted a token, and PATCHed a Check that needed no change — leaving the row exactly as due as before.

Both consequences were observed on a live deployment:

| | |
|---|---|
| rows due | **3680** |
| of those, nothing to publish (`desiredState == observedState`) | **3027** |
| rows queued ahead of one genuinely pending projection | **3671** |
| its state | `desiredState=success`, `observedState=in_progress`, `attempts=0` |

`attempts=0` is the tell: that projection was never attempted, not attempted and failed. Its review had finished and approved minutes earlier and the control plane already knew the Check should be green — it simply never reached the front of the queue. On the pull request, the check sat at "Analyzing this revision" indefinitely. A second pull request was reported with the identical shape while this fix was being written.

One paused agent contributed 2366 projections of its own to that queue (see the companion change that keeps a paused agent's hooks out of the relay pool), but the accumulation is structural: nothing bounded this set for any agent.

## How

`process()` settles a row it has nothing to say about — clear `nextAttemptAt`, release the lease, drop the stale `lastErrorCode`. Leaving the due set is not the same as being forgotten: every path that creates work (`afterAccepted`, `afterStart`, `afterReviewResult`, `afterReport`, the reaper, `repair`) re-arms `nextAttemptAt` already.

`settleReviewProjection` re-reads the row under its lock and refuses if the state moved, so a converge that landed while the worker held the lease is never silently discarded.

## Reviewer notes

- **Behavior change worth confirming:** a converged projection is no longer re-published. Three tests encoded the old shape by constructing rows with `observedState === desiredState` and asserting a PATCH; their fixtures now describe rows with actual work (`observedState: 'in_progress'`), which is what the production path produces. If any of those re-writes was load-bearing for a reason I did not find, this is where to say so.
- **Not fixed here:** 3671 of the due rows shared a due timestamp to the millisecond, so something re-arms projections in bulk and I did not track down what. Worth finding, but it is no longer harmful — each row now settles once, cheaply, and leaves.
- The backlog drains itself. Each stale row costs one small transaction on its next claim instead of a GitHub write, so the queue empties in cycles rather than staying permanently full. No migration or manual cleanup.
- No claim-side predicate: Prisma cannot compare two columns in `where`, so filtering `desiredState <> observedState` at claim time would mean dropping to raw SQL. Settling at the source fixes the same bug without it.

## Tests

`run-reporter.test.ts` — a settled row performs no fetch, begins no write, and calls `settleReviewProjection`; a row with a queued `pendingIntent` behind the same observed state still publishes. Three existing fixtures updated as described. Control-plane unit suite 1825 passed, typecheck, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
