### PR TITLE
docs(session): sessionId and acpSessionId are one session's two names, each with its own scope

### DIFF
--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -62,6 +62,38 @@ sessionId                                                // Stable opaque addres
   also the value shown on the `Session` line of the `# Agent` block in section
   2.3. A model treats it as opaque.
 
+**`sessionId` and `acpSessionId` are two NAMES for one session, each used in its
+own scope — never two concepts, and never interchangeable words for the same
+scope.** Which name is correct is decided by who is being addressed:
+
+- **`sessionId`** is the session's identity everywhere OUTSIDE the ACP hop: the
+  wire to the control plane, the console and its deep links, `sendMessage`
+  targets, the `# Agent` block, and the model-credential claims the gateway
+  verifies. It must exist BEFORE the runtime does — a credential is minted to
+  start the runtime, so an identity that only appears afterwards cannot be in it.
+- **`acpSessionId`** is the identity the RUNTIME knows the session by, and it is
+  needed in both directions on that hop: the daemon keys `session/prompt`,
+  `session/cancel` and `session/set_config_option` by it, and the runtime keys
+  every `session/update`, permission and elicitation notification by it. The
+  daemon can never discard it.
+
+The two normally hold the SAME value: the daemon mints the id when the session
+slot is first resolved — before any credential is issued — and proposes it to
+the runtime on `session/new`, which a cooperating adapter adopts. A runtime that
+insists on its own id does not break the doctrine: the daemon then stores both,
+uses `acpSessionId` for the ACP hop alone, and keeps answering the rest of the
+world with `sessionId`. Translation happens at that one boundary and nowhere
+else.
+
+What this rules out, in both directions:
+
+- Reporting the ACP id (or anything derived from `sessionKey`, such as a hash of
+  it) as the outward identity. `sessionKey` carries platform coordinates —
+  channel and thread — which must not leave the daemon, and the ACP id does not
+  exist early enough to be minted into a credential.
+- Sending the outward id to the runtime as if it were the ACP id when the
+  runtime did not adopt it.
+
 The session's `platform` is where the owner agent receives and sends. It may
 differ from a target platform operated on by one message. See
 [case 3 in section 7.4](#74-case-3-send-from-telegram-to-a-slack-channel-without-mentioning-another-agent).

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -175,6 +175,12 @@ export class ModelSessionHostPool {
     return await this.keyServer.issue({
       orgId,
       agentId: agent.id,
+      // DOCTRINE DEBT (session-concept.md §1.1): this should be the session's outward
+      // `sessionId`, and it is neither — the ACP id does not exist yet when a credential is
+      // minted, so this hashes the slot key instead. The hash is stable and hides the platform
+      // coordinates `sessionKey` carries, but nothing outside the daemon can resolve it back to
+      // a session, so gateway-metered spend lands under an identity the console cannot match.
+      // Fixed by minting the outward id here, before issuance, and proposing it on session/new.
       sessionId: createHash('sha256').update(sessionKey).digest('hex'),
       provider: target.provider,
       ttlSeconds: DEFAULT_MODEL_KEY_TTL_SECONDS

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -38,7 +38,7 @@ export type SessionUsage = z.infer<typeof SessionUsage>
 
 /** One row in the session list (metadata + console metrics; NOT the transcript). */
 export const SessionListItem = z.object({
-  sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+  sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
   // The stable ACP session id that spawned this session through sendMessage.
   // Absent for root sessions. This is lineage metadata only, never a body.
   parentSessionId: z.string().optional(),
@@ -131,7 +131,7 @@ export const SessionHistoryReq = z
     // Optional only for rolling compatibility with an older CP. A current CP always
     // sends the authorized owner and the daemon re-checks the session binding.
     agentId: z.string().uuid().optional(),
-    sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+    sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
     cursor: z.string().optional(), // opaque; omit ⇒ newest page
     // Monotonic daemon-local transcript revision. Mutually exclusive with the
     // backward-pagination cursor; used by an open console view to pull inserts
@@ -150,7 +150,7 @@ export type SessionHistoryReq = z.infer<typeof SessionHistoryReq>
 
 /** D→C REP (corr = the req id): a page of messages + the cursor for the next page. */
 export const SessionHistoryPage = z.object({
-  sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+  sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
   messages: z.array(SessionMessage), // chronological oldest→newest within the page (seq breaks equal-time ties)
   nextCursor: z.string().optional(), // absent ⇒ no older messages
   // Optional for rolling compatibility. `liveCursor` is the next `after`
@@ -264,7 +264,7 @@ export type ChildSessionStatusProbe = z.infer<typeof ChildSessionStatusProbe>
  * and out-of-order application safe on the daemon.
  */
 export const SessionVisibilityPush = z.object({
-  sessionId: z.string().min(1), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+  sessionId: z.string().min(1), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
   // The session's owning agent. ACP session ids are runtime-local, so on a pool's
   // shared store the id alone names a gate every org could claim. Optional for
   // rolling upgrades: an older CP omits it and the daemon attributes the push to


### PR DESCRIPTION
Raised while tracing why gateway-metered spend cannot be matched to a session in the console: the access log carries a 64-hex value where the session's id should be.

`session-concept.md` §1.1 already listed all three identifiers, but the sentence binding them was ambiguous enough that the implementation read it as *"the outward id IS the ACP id"* — and the protocol's own comments hardened that reading into a contract: `// opaque ACP session id (agent-assigned; NOT a wire UUID)`, which is the opposite of what the section intends.

**The doctrine, now stated so neither direction can drift again:**

- **`sessionId`** — the identity everywhere OUTSIDE the ACP hop: the control-plane wire, the console and its deep links, `sendMessage` targets, the `# Agent` block, and the credential claims the gateway verifies. It must exist BEFORE the runtime, because a credential is minted in order to start that runtime.
- **`acpSessionId`** — what the runtime knows the session by, needed in BOTH directions on that hop (`session/prompt` and `session/cancel` are keyed by it; every `session/update`, permission and elicitation notification carries it). The daemon can never discard it.
- They normally hold the **same value**: the daemon mints the id when the slot resolves and proposes it on `session/new`; a cooperating adapter adopts it. A runtime that insists on its own does not break the doctrine — the daemon stores both, uses the ACP id for that one hop, and answers the rest of the world with `sessionId`.

The section also now names what it rules out: reporting the ACP id, or anything derived from `sessionKey` (a hash included), as the outward identity — `sessionKey` carries platform coordinates that must not leave the daemon, and the ACP id does not exist early enough to be minted into a credential.

**Docs-only, deliberately.** The debt is recorded where it lives — the key-server call that hashes the slot key — and the protocol comments now state the doctrine *and* that the daemon still fills the field from the ACP id today, rather than claiming a state the code has not reached. Making the code match is the follow-up: mint the outward id before issuance, propose it on `session/new`, keep the ACP id for its hop, and translate at that single boundary.

Typecheck clean for protocol and daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)