### PR TITLE
fix(web): read the transactions table in local time and link its receipts

### DIFF
--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -33,9 +33,11 @@ import { LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 
 // `.row` is a bare grid — the column template is the caller's, as a full literal.
-// Design columns: direction chip · description · amount · posted. Mobile scrolls the
-// card sideways (globals' `.card:has(.row)`), so one fixed template serves both.
-const TX_GRID = 'grid-cols-[34px_minmax(0,1fr)_132px_168px] gap-2'
+// Design columns: direction chip · description · amount · spacer · posted.
+// Every track but the description is a fixed width: each `.row` is its own grid, so an
+// `auto` track sizes per-row and pulls the header out of line with the body below it.
+// Mobile scrolls the card sideways (globals' `.card:has(.row)`), so one template serves both.
+const TX_GRID = 'grid-cols-[34px_minmax(0,1fr)_132px_24px_190px] gap-2'
 
 const KIND_LABEL: Record<string, string> = {
   purchase: 'Credit purchase',
@@ -51,10 +53,20 @@ const STATE_PILL: Record<NonNullable<BillingAccount['state']>, { label: string; 
   unknown: { label: 'Unconfirmed', color: 'var(--status-info)' }
 }
 
-/** Design's Posted (UTC) column: `YYYY-MM-DD HH:mm`. */
-function fmtPostedUtc(iso: string): string {
+// Design's Posted column, `YYYY-MM-DD HH:mm` in the viewer's own timezone. sv-SE is the
+// locale whose short form already is that shape, so no manual part assembly.
+const LOCAL_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
+function fmtPostedLocal(iso: string): string {
   const d = new Date(iso)
-  return Number.isNaN(d.getTime()) ? iso : d.toISOString().slice(0, 16).replace('T', ' ')
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleString('sv-SE', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit'
+      })
 }
 
 const PRESETS_USD = [10, 50, 100]
@@ -636,7 +648,7 @@ export default function BillingView() {
                 <div className="mt-5 flex gap-[26px] border-t border-(--border-subtle) pt-4">
                   <div>
                     <div className="eyebrow">Last deduction</div>
-                    <div className="mono mt-[5px] text-[13px]">{lastDebit ? fmtPostedUtc(lastDebit.at) : '—'}</div>
+                    <div className="mono mt-[5px] text-[13px]">{lastDebit ? fmtPostedLocal(lastDebit.at) : '—'}</div>
                   </div>
                   <div>
                     <div className="eyebrow">Alert threshold</div>
@@ -699,7 +711,10 @@ export default function BillingView() {
                   <span />
                   <span>Description</span>
                   <span className="text-right">Amount</span>
-                  <span>Posted (UTC)</span>
+                  <span />
+                  <span className="truncate" title={LOCAL_TZ}>
+                    Posted ({LOCAL_TZ})
+                  </span>
                 </div>
                 {txItems.map((t) => {
                   const credit = t.type === 'credit'
@@ -730,6 +745,17 @@ export default function BillingView() {
                         >
                           {credit ? t.kind : 'usage'}
                         </span>
+                        {credit && t.receiptUrl && (
+                          <a
+                            className="inline-flex flex-none items-center gap-0.5 font-sans text-[12px] font-medium text-(--text-brand) hover:underline"
+                            href={t.receiptUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Receipt
+                            <Icon name="arrow-up-right" size={11} />
+                          </a>
+                        )}
                       </span>
                       {/* A debit is recorded as a positive amount that was taken away, so the
                           sign belongs here. The rounded figure carries the exact wire string
@@ -748,7 +774,8 @@ export default function BillingView() {
                           </span>
                         </span>
                       )}
-                      <span className="mono text-[12px] text-(--text-secondary)">{fmtPostedUtc(t.at)}</span>
+                      <span />
+                      <span className="mono text-[12px] text-(--text-secondary)">{fmtPostedLocal(t.at)}</span>
                     </div>
                   )
                 })}

--- a/packages/web/src/lib/billing-api.test.ts
+++ b/packages/web/src/lib/billing-api.test.ts
@@ -249,4 +249,33 @@ describe('fetchBillingTransactions', () => {
 
     expect(urls[0]).toBe('https://billing.test/api/v1/orgs/org1/billing/transactions')
   })
+
+  it('keeps an https receipt and drops anything else, so no row can render a hostile href', async () => {
+    vi.stubEnv('BILLING_URL', 'https://billing.test')
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            id: 'c1',
+            kind: 'purchase',
+            amountMicro: 50_000_000,
+            at: tx.at,
+            receiptUrl: 'https://pay.stripe.com/receipts/x'
+          },
+          { id: 'c2', kind: 'purchase', amountMicro: 50_000_000, at: tx.at, receiptUrl: 'javascript:alert(1)' },
+          { id: 'c3', kind: 'purchase', amountMicro: 50_000_000, at: tx.at }
+        ],
+        nextCursor: null
+      })
+    }))
+
+    const page = await fetchBillingTransactions('org1')
+
+    expect(page.items.map((t) => (t.type === 'credit' ? t.receiptUrl : undefined))).toEqual([
+      'https://pay.stripe.com/receipts/x',
+      null,
+      null
+    ])
+  })
 })

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -60,6 +60,10 @@ export interface BillingCredit {
   amountMicro: number
   /** ISO 8601 instant. */
   at: string
+  // Stripe-hosted receipt, on a `purchase` row only, and optional for the same reason
+  // `type` is: a service that predates it omits it, and the console runs ahead of that
+  // image. Absent or null ⇒ the row renders with no receipt link, never a broken one.
+  receiptUrl?: string | null
 }
 
 export interface BillingDebit {
@@ -211,6 +215,9 @@ export function assertTransactionsPage(
       // this build has not heard of renders with its raw value as the label, and
       // refusing the whole page over one unknown label would be the worse failure.
       if (typeof t.kind !== 'string') throw new BillingShapeError('transaction')
+      // A non-string, non-null receipt is a shape error; ABSENT is the older contract.
+      if (!(t.receiptUrl === undefined || t.receiptUrl === null || typeof t.receiptUrl === 'string'))
+        throw new BillingShapeError('transaction')
     } else if (t.type === 'debit') {
       // A string, and never coerced to a number here — the exact value is what the
       // service sent, and only the display rounds it.
@@ -277,8 +284,12 @@ export async function fetchBillingTransactions(
   // switch on it without knowing that history.
   // Keyed on `debit` rather than on the absence of `type`, so the credit arm is stamped
   // the same way whether the service sent it or not.
+  // The receipt is dropped unless it is `https:` — it becomes an `href`, and a payload
+  // that reached this line is remote input, so nothing else may become a link.
   const items: BillingTransaction[] = body.items.map((row) =>
-    row.type === 'debit' ? row : { ...row, type: 'credit' as const }
+    row.type === 'debit'
+      ? row
+      : { ...row, type: 'credit' as const, receiptUrl: row.receiptUrl?.startsWith('https://') ? row.receiptUrl : null }
   )
   return { items, nextCursor: body.nextCursor }
 }


### PR DESCRIPTION
Three things about the Billing → Transactions table, all of them what the row already implied but did not deliver.

## Posted was UTC, silently

The column was formatted with `toISOString()`, so every instant read as UTC while the reader sat in their own zone — nothing on the row said so except a `(UTC)` in the header, which is the kind of label a reader skips. It now formats in the viewer's own timezone, and the header names which one:

```
POSTED (ASIA/SINGAPORE)
2026-08-21 15:15
```

`sv-SE` is the locale whose short form already *is* `YYYY-MM-DD HH:mm`, so the shape the design asked for costs no manual part assembly. The balance card's "Last deduction" follows the same formatter.

The timezone is the IANA name rather than an abbreviation on purpose: `timeZoneName: 'short'` degrades to `GMT+8` in much of the world, which tells the reader less than the zone they are actually in.

## Amount and Posted were flush against each other

A 24px spacer track separates them. Every track but the description is a **fixed** width deliberately — each `.row` is its own grid, so an `auto` track sizes per-row, and the header (a long zone name) then computes a different width than the body rows beneath it, which drags `1fr` and every column after it out of line. An overlong zone name truncates in the header with the full value as its `title`.

## A credit purchase now links to its Stripe receipt

The row already had everything needed to find one, one join away — see the paired service change below.

Two deliberate choices on this side:

- **`receiptUrl` is read as optional**, for the same reason `type` is. A billing image that predates the field omits it, and the console rides the application train while the billing image is pinned and synced by hand — so a console carrying a new mirror routinely runs against the previous service. A row with no receipt simply renders without the link.
- **It is dropped unless it is `https:`.** It becomes an `href`, and the payload it arrived in is remote input, so the check lives at that boundary in `fetchBillingTransactions` — no component downstream can render anything else.

## Paired service change

The wire field comes from a separate change in the **extensions** repository (`packages/billing`), which needs its own PR:

- `TransactionView` / `TransactionsDto` credit arm gains `receiptUrl: string | null`
- the history query resolves it with one correlated subselect — `credit_ledger."sourceRef"` **is** the Stripe Checkout Session id (`purchaseRepo.fulfillPaid` writes it as such), and `purchase_intent."stripeCheckoutSessionId"` is unique and already stores the receipt. No new table, column, or migration.

Merge order does not matter: this PR is safe against the current billing image, and the service change is additive.

## Verification

- `pnpm --filter @agentconnect.md/web test` — 1796 pass; one new test covers the https boundary (kept / `javascript:` dropped / absent → null)
- `pnpm --filter @agentconnect.md/web typecheck`, prettier, eslint clean
- the service-side SQL was run against a real `postgres:16-alpine` with the migrations applied, since `packages/billing` is a unit-only Vitest project: settled purchase → receipt, purchase whose receipt has not landed → null, promo (`sourceRef = 'signup-bonus'`) → null, usage debit → null
- **not** verified in a browser: `localhost:3000` is behind sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)