### PR TITLE
fix(control-plane): show gateway-metered usage to console viewers

### DIFF
--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -378,7 +378,11 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // lets billing ask for gateway spend alone through the console's own route.
     const sourceScope = (alias: string) =>
       source ? Prisma.sql`AND ${Prisma.raw(`${alias}."source"`)} = ${source}::"UsageSource"` : Prisma.empty
-    const sessionScope = sessionViewerSql(sessionViewer)
+    // A gateway-metered row's sessionId (a hash minted for the model credential) matches no
+    // session_meta, so the viewer predicate's equality arms would silently drop it; an unlinked
+    // row has no per-session content to protect, so it falls back to agent visibility alone.
+    const viewerScope = sessionViewerSql(sessionViewer)
+    const sessionScope = viewerScope ? Prisma.sql`(s."id" IS NULL OR ${viewerScope})` : null
 
     // EVERY figure in this answer comes from the spend timeline inside `[from, to)`,
     // diffed against each session's last checkpoint before the window. Tokens too, not

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -728,6 +728,39 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     }
   })
 
+  it('keeps a gateway row whose sessionId matches no session_meta (hashed credential id)', async () => {
+    await seedAgent(prisma, AGENT_A)
+    const repo = new PgSessionUsageRepo(prisma)
+    const at = new Date(Date.now() - 60_000)
+    // The hub reports the model credential's hashed session id — no session_meta row exists
+    // for it, so the row must fall back to agent visibility instead of being filtered out.
+    await repo.record({
+      agentId: AgentId(AGENT_A),
+      sessionId: 'a'.repeat(64),
+      source: 'gateway',
+      lastActivityAt: at,
+      usage: { totalTokens: 100, costAmount: '12.75', costCurrency: 'USD' }
+    })
+
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as {
+        totals: { sessions: number; totalTokens: number; costAmount: string; costCurrency: string | null }
+        sources: { source: string; costAmount: string }[]
+      }
+      expect(body.totals.sessions).toBe(1)
+      expect(body.totals.totalTokens).toBe(100)
+      expect(body.totals.costAmount).toBe('12.75')
+      // The currency read shares the viewer predicate, so it must see the unlinked row too.
+      expect(body.totals.costCurrency).toBe('USD')
+      expect(body.sources).toEqual([expect.objectContaining({ source: 'gateway', costAmount: '12.75' })])
+    } finally {
+      await close()
+    }
+  })
+
   it('keeps a session that spent in the window but reported again after it', async () => {
     await seedAgent(prisma, AGENT_A)
     const repo = new PgSessionUsageRepo(prisma)


### PR DESCRIPTION
## What changed

A gateway usage report's `sessionId` is the model credential's **hashed** session id (`sha256(sessionKey)`, minted in `key-server/session-hosts.ts`), so it matches no `session_meta` row. The `/usage` aggregate LEFT JOINs `session_meta` and applies the session viewer predicate, whose arms are all equalities on `s.*` columns — a NULL-joined row failed every arm, so **every gateway spend row was silently dropped from viewer-scoped answers**. Billing's no-viewer service read saw the spend; the console never did (observed live on test: hub flushes accepted with 204, billing sweep applied, console `sources` showing only `daemon`).

Fix: an unlinked spend row has no per-session content to protect, so it falls back to agent visibility alone — the viewer predicate is wrapped in `(s."id" IS NULL OR …)` at both use sites (the spend aggregate and the currency read).

## Why

With the test environment's chain flip (`daemonPool.usageReporting: false`, hub reporter as the single writer), all new usage arrives via the gateway ingress — which the console could not display at all, contradicting the design (`usage-reporting-and-billing.md` §2: the console shows gateway and daemon usage side by side via the `sources` breakdown).

## Review notes

- The service-read path (billing) is untouched: it passes no viewer, so it never hit the predicate.
- Regression test added: a gateway spend row with no `session_meta` is visible to a human viewer, including the currency label (`test/integration/usage.route.test.ts`).
- Full `test:int` suite (1497 tests) and typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)