### PR TITLE
feat(daemon): give a session an outward id of its own, minted before its runtime

### DIFF
--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -94,6 +94,15 @@ transcript page, a workspace read, a webchat delivery target. A daemon that rece
 its slot by the outward id (falling back to the ACP id, which is what a pre-v12 session was
 reported under) and works internally in ACP terms from there.
 
+LINEAGE is outward for the same reason, and it is the case where the ACP id fails hardest: an
+`originSessionId`, a `lineageReplyTo`, a `sendMessage` SessionTarget and a reported
+`parentSessionId` all name a session to someone who is not its runtime — another agent, another
+daemon, the CP. A lineage link written in the runtime's name matches nothing on the other side:
+the control plane keys its session rows by the outward id, so a child reporting an ACP-named
+parent is a child whose parent "does not exist" — no console lineage, and no visibility to
+inherit (session-visibility.md §5.1). The `Session` and `Parent session` lines of the `# Agent`
+block are the same id, which is what makes them usable as a SessionTarget at all.
+
 What this rules out, in both directions:
 
 - Reporting the ACP id (or anything derived from `sessionKey`, such as a hash of

--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -62,6 +62,38 @@ sessionId                                                // Stable opaque addres
   also the value shown on the `Session` line of the `# Agent` block in section
   2.3. A model treats it as opaque.
 
+**`sessionId` and `acpSessionId` are two NAMES for one session, each used in its
+own scope — never two concepts, and never interchangeable words for the same
+scope.** Which name is correct is decided by who is being addressed:
+
+- **`sessionId`** is the session's identity everywhere OUTSIDE the ACP hop: the
+  wire to the control plane, the console and its deep links, `sendMessage`
+  targets, the `# Agent` block, and the model-credential claims the gateway
+  verifies. It must exist BEFORE the runtime does — a credential is minted to
+  start the runtime, so an identity that only appears afterwards cannot be in it.
+- **`acpSessionId`** is the identity the RUNTIME knows the session by, and it is
+  needed in both directions on that hop: the daemon keys `session/prompt`,
+  `session/cancel` and `session/set_config_option` by it, and the runtime keys
+  every `session/update`, permission and elicitation notification by it. The
+  daemon can never discard it.
+
+The two normally hold the SAME value: the daemon mints the id when the session
+slot is first resolved — before any credential is issued — and proposes it to
+the runtime on `session/new`, which a cooperating adapter adopts. A runtime that
+insists on its own id does not break the doctrine: the daemon then stores both,
+uses `acpSessionId` for the ACP hop alone, and keeps answering the rest of the
+world with `sessionId`. Translation happens at that one boundary and nowhere
+else.
+
+What this rules out, in both directions:
+
+- Reporting the ACP id (or anything derived from `sessionKey`, such as a hash of
+  it) as the outward identity. `sessionKey` carries platform coordinates —
+  channel and thread — which must not leave the daemon, and the ACP id does not
+  exist early enough to be minted into a credential.
+- Sending the outward id to the runtime as if it were the ACP id when the
+  runtime did not adopt it.
+
 The session's `platform` is where the owner agent receives and sends. It may
 differ from a target platform operated on by one message. See
 [case 3 in section 7.4](#74-case-3-send-from-telegram-to-a-slack-channel-without-mentioning-another-agent).

--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -77,13 +77,22 @@ scope.** Which name is correct is decided by who is being addressed:
   every `session/update`, permission and elicitation notification by it. The
   daemon can never discard it.
 
-The two normally hold the SAME value: the daemon mints the id when the session
-slot is first resolved — before any credential is issued — and proposes it to
-the runtime on `session/new`, which a cooperating adapter adopts. A runtime that
-insists on its own id does not break the doctrine: the daemon then stores both,
-uses `acpSessionId` for the ACP hop alone, and keeps answering the rest of the
-world with `sessionId`. Translation happens at that one boundary and nowhere
+The daemon mints the outward id when the session slot is first resolved — before
+any credential is issued, so a credential can carry it. Where a runtime adopts
+the id proposed on `session/new`, the two hold the same value; our adapters do
+not propose it yet, so today they normally differ, and a runtime is always free
+to insist on its own id. That does not break the doctrine: the daemon stores
+both, uses `acpSessionId` for the ACP hop alone, and keeps answering the rest of
+the world with `sessionId`. Translation happens at that one boundary and nowhere
 else.
+
+The field name is the contract, and it is readable from the frame alone: a field named
+`acpSessionId` carries the runtime's id, because what it addresses lives on that hop and dies
+with it — an ACP lease, a `session/update` stream. A field named `sessionId` carries the outward
+one, whoever is asking: session metadata, usage, a purge receipt, a credential's claims, a
+transcript page, a workspace read, a webchat delivery target. A daemon that receives one resolves
+its slot by the outward id (falling back to the ACP id, which is what a pre-v12 session was
+reported under) and works internally in ACP terms from there.
 
 What this rules out, in both directions:
 

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -829,12 +829,19 @@ export class AcpHost {
    *  session) rides the Claude `_meta.systemPrompt` append — standing context, never a
    *  user turn (see #398). `additionalDirectories` expands the runtime workspace
    *  without changing the configured working-subdirectory `cwd`. */
+  /**
+   * @param announce Called with the runtime's brand-new id at the raw `session/new` response —
+   *   BEFORE the session becomes reachable. Anything the daemon must know before an update can
+   *   arrive belongs here: `live.add()` makes the session ownable, and the configuration round
+   *   trips that follow are awaited, so a runtime may advertise from inside this call.
+   */
   async newSession(
     cwd: string,
     mcpServers: McpServer[] = [],
     effortOverride?: string,
     systemAppend?: string,
-    additionalDirectories: string[] = []
+    additionalDirectories: string[] = [],
+    announce?: (sessionId: string) => Promise<void> | void
   ): Promise<string> {
     const _meta = claudeSessionMeta(
       effortOverride ?? this.opts.configPrefs?.reasoningEffort,
@@ -852,6 +859,7 @@ export class AcpHost {
       mcpServers,
       ...(_meta ? { _meta } : {})
     })
+    await announce?.(res.sessionId)
     this.live.add(res.sessionId)
     const configOptions = await this.applySessionConfig(res.sessionId, res.configOptions)
     this.refreshOptionCaches(configOptions)

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -834,6 +834,8 @@ export class AcpHost {
    *   BEFORE the session becomes reachable. Anything the daemon must know before an update can
    *   arrive belongs here: `live.add()` makes the session ownable, and the configuration round
    *   trips that follow are awaited, so a runtime may advertise from inside this call.
+   *   SYNCHRONOUS on purpose: a runtime can emit the instant it has answered, and anything awaited
+   *   here would widen the response-to-ownership gap into a window where that update is dropped.
    */
   async newSession(
     cwd: string,
@@ -841,7 +843,7 @@ export class AcpHost {
     effortOverride?: string,
     systemAppend?: string,
     additionalDirectories: string[] = [],
-    announce?: (sessionId: string) => Promise<void> | void
+    announce?: (sessionId: string) => void
   ): Promise<string> {
     const _meta = claudeSessionMeta(
       effortOverride ?? this.opts.configPrefs?.reasoningEffort,
@@ -859,7 +861,7 @@ export class AcpHost {
       mcpServers,
       ...(_meta ? { _meta } : {})
     })
-    await announce?.(res.sessionId)
+    announce?.(res.sessionId)
     this.live.add(res.sessionId)
     const configOptions = await this.applySessionConfig(res.sessionId, res.configOptions)
     this.refreshOptionCaches(configOptions)

--- a/packages/daemon/src/collab/coordinator.ts
+++ b/packages/daemon/src/collab/coordinator.ts
@@ -397,10 +397,16 @@ export class CollabCoordinator {
     const sourceHopCount = inbound?.hopCount ?? 0
     // session-concept §5.3: capture the CALLER's own session as the woken child's origin, so
     // the child can reply into it via `sendMessage`'s SessionTarget (across thread/platform/
-    // daemon). originSessionId is the caller session's stable acpSessionId (mid-turn, so it is
-    // already minted); originCoords are its landing coords for cross-daemon reply routing.
-    const originSessionId = (await this.host.store().getSession(callerKey))?.acpSessionId ?? undefined
-    const externalOrigin = await this.host.externalOriginForSession(req.callerAgentId, originSessionId)
+    // daemon). The lineage id is the caller's OUTWARD one (§1.1) — an ACP id names a session
+    // only inside its own runtime, and this one travels to another agent, another daemon and
+    // the CP. originCoords are its landing coords for cross-daemon reply routing.
+    const callerSession = await this.host.store().getSession(callerKey)
+    const originSessionId = callerSession
+      ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId)
+      : undefined
+    // These two read the caller's LOCAL rows, which are keyed by the runtime's id.
+    const callerAcpSessionId = callerSession?.acpSessionId ?? undefined
+    const externalOrigin = await this.host.externalOriginForSession(req.callerAgentId, callerAcpSessionId)
     const originCoordPlatform = platform
     const originCoords: CallMeta['originCoords'] = {
       platform: originCoordPlatform,
@@ -477,6 +483,7 @@ export class CollabCoordinator {
           sourceHopCount,
           correlationId,
           ...(originSessionId !== undefined ? { originSessionId } : {}),
+          ...(callerAcpSessionId !== undefined ? { originAcpSessionId: callerAcpSessionId } : {}),
           originCoords,
           ...(externalOrigin ? { externalOrigin } : {})
         }
@@ -528,7 +535,7 @@ export class CollabCoordinator {
       // §5.1: seal the child's capture gate when the waking session is private.
       // Tighten-only — see CallMeta.parentPrivate.
       ...(originSessionId !== undefined &&
-      (await this.host.store().isCaptureExcluded(req.callerAgentId, originSessionId))
+      (await this.host.store().isCaptureExcluded(req.callerAgentId, callerAcpSessionId))
         ? { parentPrivate: true }
         : {})
     }
@@ -791,8 +798,13 @@ export class CollabCoordinator {
     // Hand the origin owner a turn whose origin points back at the REPLIER's session, so the
     // origin could reply again (symmetric lineage). callFrom = the replier.
     const replyCoordPlatform = platform
-    const replierSessionId = callerRec?.acpSessionId ?? undefined
-    const externalOrigin = await this.host.externalOriginForSession(req.callerAgentId, replierSessionId)
+    // Symmetric lineage: what we hand the origin is the REPLIER's outward id (§1.1), while the
+    // replier's own local rows stay keyed by the runtime's.
+    const replierAcpSessionId = callerRec?.acpSessionId ?? undefined
+    const replierSessionId = callerRec
+      ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId)
+      : undefined
+    const externalOrigin = await this.host.externalOriginForSession(req.callerAgentId, replierAcpSessionId)
     const replyOriginCoords: CallMeta['originCoords'] = {
       platform: replyCoordPlatform,
       channel: req.callerChannel,
@@ -809,7 +821,7 @@ export class CollabCoordinator {
       // §5.1: seal the child's capture gate when the waking session is private.
       // Tighten-only — see CallMeta.parentPrivate.
       ...(replierSessionId !== undefined &&
-      (await this.host.store().isCaptureExcluded(req.callerAgentId, replierSessionId))
+      (await this.host.store().isCaptureExcluded(req.callerAgentId, replierAcpSessionId))
         ? { parentPrivate: true }
         : {})
     }
@@ -818,7 +830,7 @@ export class CollabCoordinator {
     // per-session serial gate (satisfies §5.3 concurrency vs. a running origin turn). Not
     // local ⇒ the origin is on another daemon; route over the relay using the origin coords
     // carried on the inbound turn (the relay has no sessionId→daemon registry).
-    const local = await this.host.store().getSessionByAcpId(req.sessionId)
+    const local = await this.host.store().getSessionByOutwardId(req.sessionId)
     if (local) {
       const originOwner = local.agentId
       const originPlatform = local.platform
@@ -942,6 +954,7 @@ export class CollabCoordinator {
         sourceHopCount: inbound.hopCount,
         ...(correlationId !== undefined ? { correlationId } : {}),
         ...(replierSessionId !== undefined ? { originSessionId: replierSessionId } : {}),
+        ...(replierAcpSessionId !== undefined ? { originAcpSessionId: replierAcpSessionId } : {}),
         originCoords: replyOriginCoords,
         ...(externalOrigin ? { externalOrigin } : {}),
         // §5.3: this is a REPLY into the validated origin session, not a wake — the
@@ -991,7 +1004,11 @@ export class CollabCoordinator {
       req.callerAgentId,
       req.callerTransportScope
     )
-    const callerSessionId = (await this.host.store().getSession(callerKey))?.acpSessionId ?? undefined
+    // The caller names ITSELF the way lineage does — outwardly (§1.1) — because that is what the
+    // durable parent link, the admission link and the CP's ownership check are all written in.
+    const callerSessionId = (await this.host.store().getSession(callerKey))
+      ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId)
+      : undefined
     // A caller with no session id of its own has no lineage to check against — refuse rather than
     // fall through to a link lookup that could match an `undefined` parent.
     if (!callerSessionId) return null
@@ -1157,7 +1174,7 @@ export class CollabCoordinator {
       throw new Error(
         'the status of a session on another daemon is unavailable while the control plane is disconnected'
       )
-    const parentAgentId = (await this.host.store().getSessionByAcpId(parentSessionId))?.agentId
+    const parentAgentId = (await this.host.store().getSessionByOutwardId(parentSessionId))?.agentId
     const orgId = parentAgentId ? this.host.cpAgents()?.orgForAgent(parentAgentId) : undefined
     const res = await client.childSessionStatus({ parentSessionId, childSessionId, childAgentId }, orgId)
     if (res.reason === 'offline') {
@@ -1275,7 +1292,7 @@ export class CollabCoordinator {
     const inbound = this.host.activeTurnCallMeta().get(key)
     const parentSessionId =
       inbound?.originSessionId ?? (await this.host.store().getSession(key))?.originSessionId ?? undefined
-    const parent = parentSessionId ? await this.host.store().getSessionByAcpId(parentSessionId) : undefined
+    const parent = parentSessionId ? await this.host.store().getSessionByOutwardId(parentSessionId) : undefined
     // A LOCAL parent's row records its transport scope, so its identity is exact.
     if (parentSessionId && parent && isForkOf(parent.platform, parent.channel, parent.thread, parent.transportScope)) {
       return { kind: 'parent', sessionId: parentSessionId }
@@ -1348,8 +1365,12 @@ export class CollabCoordinator {
       this.host.log().info(`channel-root session: hop limit reached for agent "${req.agentId}" — not spawning`)
       return false
     }
-    const originSessionId = (await this.host.store().getSession(originKey))?.acpSessionId ?? undefined
-    const externalOrigin = await this.host.externalOriginForSession(req.agentId, originSessionId)
+    const originRec = await this.host.store().getSession(originKey)
+    const originAcpSessionId = originRec?.acpSessionId ?? undefined
+    const originSessionId = originRec
+      ? await this.host.store().ensureOutwardSessionId(originKey, req.agentId)
+      : undefined
+    const externalOrigin = await this.host.externalOriginForSession(req.agentId, originAcpSessionId)
     const originCoordPlatform = originPlatform
     const deliveryId = randomUUID()
     const callMeta: CallMeta = {
@@ -1366,7 +1387,7 @@ export class CollabCoordinator {
       },
       // §5.1: seal the child's capture gate when the waking session is private.
       // Tighten-only — see CallMeta.parentPrivate.
-      ...(originSessionId && (await this.host.store().isCaptureExcluded(req.agentId, originSessionId))
+      ...(originSessionId && (await this.host.store().isCaptureExcluded(req.agentId, originAcpSessionId))
         ? { parentPrivate: true }
         : {})
     }
@@ -1426,12 +1447,15 @@ export class CollabCoordinator {
       targetSession: string
       sourceHopCount: number
       correlationId?: string
-      /** §5.3: the caller's origin session, forwarded so the remote child can reply back. */
+      /** §5.3: the caller's origin session, forwarded so the remote child can reply back — its
+       *  OUTWARD id (§1.1), since it travels to another daemon. */
       originSessionId?: string
+      /** The same session's runtime-local id, for the gates this daemon keys by it. */
+      originAcpSessionId?: string
       originCoords?: CallMeta['originCoords']
       externalOrigin?: CallMeta['externalOrigin']
-      /** §5.3 lineage reply: the EXISTING target session (acpSessionId) this delivery
-       *  replies into — the target dispatches into it instead of coordinate keying. */
+      /** §5.3 lineage reply: the EXISTING target session this delivery replies into, by its
+       *  outward id — the target dispatches into it instead of coordinate keying. */
       lineageReplyTo?: string
       /** send-message-routing-rework.md §8.3. Marks the delivery as a parent-session reply
        *  so the target dispatches it into `lineageReplyTo` instead of coordinate keying.
@@ -1451,9 +1475,12 @@ export class CollabCoordinator {
       const ack = await sendAgentMsgUntilReady(
         {
           claimedFromAgentId: req.callerAgentId,
-          // Tighten-only privacy hint for the remote child's capture gate (§5.1).
+          // Tighten-only privacy hint for the remote child's capture gate (§5.1). The gate is
+          // keyed by the runtime's id, so read it from the caller's own slot — `originSessionId`
+          // is the lineage id, which is outward (§1.1).
           ...(ctx.originSessionId !== undefined &&
-          (await this.host.store().isCaptureExcluded(req.callerAgentId, ctx.originSessionId))
+          ctx.originAcpSessionId !== undefined &&
+          (await this.host.store().isCaptureExcluded(req.callerAgentId, ctx.originAcpSessionId))
             ? { parentPrivate: true }
             : {}),
           toAgentId: req.toAgentId,

--- a/packages/daemon/src/collab/coordinator.ts
+++ b/packages/daemon/src/collab/coordinator.ts
@@ -402,7 +402,7 @@ export class CollabCoordinator {
     // the CP. originCoords are its landing coords for cross-daemon reply routing.
     const callerSession = await this.host.store().getSession(callerKey)
     const originSessionId = callerSession
-      ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId)
+      ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId, this.host.clock().now())
       : undefined
     // These two read the caller's LOCAL rows, which are keyed by the runtime's id.
     const callerAcpSessionId = callerSession?.acpSessionId ?? undefined
@@ -802,7 +802,7 @@ export class CollabCoordinator {
     // replier's own local rows stay keyed by the runtime's.
     const replierAcpSessionId = callerRec?.acpSessionId ?? undefined
     const replierSessionId = callerRec
-      ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId)
+      ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId, this.host.clock().now())
       : undefined
     const externalOrigin = await this.host.externalOriginForSession(req.callerAgentId, replierAcpSessionId)
     const replyOriginCoords: CallMeta['originCoords'] = {
@@ -1007,7 +1007,7 @@ export class CollabCoordinator {
     // The caller names ITSELF the way lineage does — outwardly (§1.1) — because that is what the
     // durable parent link, the admission link and the CP's ownership check are all written in.
     const callerSessionId = (await this.host.store().getSession(callerKey))
-      ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId)
+      ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId, this.host.clock().now())
       : undefined
     // A caller with no session id of its own has no lineage to check against — refuse rather than
     // fall through to a link lookup that could match an `undefined` parent.
@@ -1368,7 +1368,7 @@ export class CollabCoordinator {
     const originRec = await this.host.store().getSession(originKey)
     const originAcpSessionId = originRec?.acpSessionId ?? undefined
     const originSessionId = originRec
-      ? await this.host.store().ensureOutwardSessionId(originKey, req.agentId)
+      ? await this.host.store().ensureOutwardSessionId(originKey, req.agentId, this.host.clock().now())
       : undefined
     const externalOrigin = await this.host.externalOriginForSession(req.agentId, originAcpSessionId)
     const originCoordPlatform = originPlatform

--- a/packages/daemon/src/commands/handlers.ts
+++ b/packages/daemon/src/commands/handlers.ts
@@ -71,7 +71,9 @@ export interface CommandHost {
   /** `!queue` admission through the unified per-sessionKey gate — it decides run-now vs enqueue. */
   dispatchQueueCommand(agentId: string, msg: NormalizedMessage, integrationId: string): Promise<void>
   replyConnFor(agentId: string, integrationId?: string): PlatformConnection | undefined
-  sessionLink(acpSessionId: string, source?: string): string
+  /** Takes the session's OUTWARD id (session-concept.md §1.1), which {@link outwardSessionId} resolves. */
+  sessionLink(sessionId: string, source?: string): string
+  outwardSessionId(agentId: string, acpSessionId: string): Promise<string | undefined>
   sessionLinkSource(platform: string, integrationId?: string): string | undefined
   /** Thread affinity for the routing ladder a command reuses. */
   threadOwner(channel: string, thread: string, transportScope?: string | null): Promise<string | null>
@@ -669,8 +671,10 @@ export class CommandHandlers {
       return true
     }
     const info = this.host.statusInfoFrom(target.agentId, key, acpSessionId ?? undefined)
-    const link = acpSessionId
-      ? this.host.sessionLink(acpSessionId, this.host.sessionLinkSource(msg.platform, target.integrationId))
+    // The View link goes to the console, which knows this session by its outward id (§1.1).
+    const outward = acpSessionId ? await this.host.outwardSessionId(target.agentId, acpSessionId) : undefined
+    const link = outward
+      ? this.host.sessionLink(outward, this.host.sessionLinkSource(msg.platform, target.integrationId))
       : undefined
     // Presentation is the platform's (§7.4): HTML chrome + View link on Telegram,
     // markdown + a real link button on Discord, plain text + a 🔗 line on Feishu,

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -841,13 +841,16 @@ export async function applySessionVisibility(
   host: ConfigApplyCoreHost,
   p: SessionVisibilityPush
 ): Promise<'applied' | 'superseded'> {
-  // A CP too old to name the agent leaves only the runtime-local ACP id: use the
-  // sole local holder, and where there is none leave the gate closed (still ACKed).
+  // A CP too old to name the agent leaves only the id: use the sole local holder, and where
+  // there is none leave the gate closed (still ACKed).
   const agentId = p.agentId ?? (await host.store().soleAgentForAcpSession(p.sessionId))
   if (!agentId) return 'superseded'
+  // The push names the session outwardly; the gate is keyed by the runtime's id.
+  const slot = await host.store().getSessionByOutwardId(p.sessionId, agentId)
+  const acpSessionId = slot?.acpSessionId ?? p.sessionId
   return host
     .store()
-    .applyCpCaptureGate(agentId, p.sessionId, p.sharedMemoryExcluded ?? p.visibility === 'private', p.visibilityRev)
+    .applyCpCaptureGate(agentId, acpSessionId, p.sharedMemoryExcluded ?? p.visibility === 'private', p.visibilityRev)
 }
 
 /** Wire the handlers into the seam — member order mirrors the `ConfigApply` contract. */

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -693,17 +693,21 @@ export async function listAgentPermissionRequests(
 ): Promise<AgentPermissionRequestPage> {
   return {
     agentId,
-    requests: (await host.store().listPermissionRequests(agentId, limit)).map((request) => ({
-      id: request.id,
-      agentId: request.agentId,
-      sessionId: request.sessionId,
-      createdAt: new Date(request.createdAt).toISOString(),
-      requesterId: request.requesterId,
-      requesterName: request.requesterName,
-      command: request.command,
-      status: request.status,
-      resolvedAt: request.resolvedAt === null ? null : new Date(request.resolvedAt).toISOString()
-    }))
+    requests: await Promise.all(
+      (await host.store().listPermissionRequests(agentId, limit)).map(async (request) => ({
+        id: request.id,
+        agentId: request.agentId,
+        // The console scopes approvals to the session it is showing, by the id it routed on —
+        // the outward one (§1.1). The row is keyed by the runtime's, so it translates here.
+        sessionId: await outwardSessionId(host, request.agentId, request.sessionId),
+        createdAt: new Date(request.createdAt).toISOString(),
+        requesterId: request.requesterId,
+        requesterName: request.requesterName,
+        command: request.command,
+        status: request.status,
+        resolvedAt: request.resolvedAt === null ? null : new Date(request.resolvedAt).toISOString()
+      }))
+    )
   }
 }
 
@@ -837,6 +841,13 @@ export function applyAgentStop(host: ConfigApplyGateHost & ConfigApplyRuntimeHos
 // settlements and cascades); the daemon only enforces the resulting
 // capture gate. Ordering is by the CP's durable revision, so retransmits
 // and out-of-order delivery are safe.
+/** How the CONSOLE names the session an ACP id belongs to (session-concept.md §1.1). Falls back
+ *  to the id it was given, which is what a pre-v12 session was reported under. */
+async function outwardSessionId(host: ConfigApplyCoreHost, agentId: string, acpSessionId: string): Promise<string> {
+  const slot = await host.store().getSessionByAcpIdForAgent(agentId, acpSessionId)
+  return slot ? await host.store().ensureOutwardSessionId(slot.key, agentId, host.clock().now()) : acpSessionId
+}
+
 export async function applySessionVisibility(
   host: ConfigApplyCoreHost,
   p: SessionVisibilityPush

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -153,12 +153,6 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
   // Which root a console request addresses and where it IS — the sandbox pod's volume under --k8s.
   // ONE resolver for the file reader and the git seam: the directory the console browses and the one
   // it commits are the same directory, and describing them two different ways broke both panels.
-  // One translation for every CP-facing read in this file that holds only the runtime's id.
-  const outwardSessionId = async (agentId: string, acpSessionId: string): Promise<string> => {
-    const slot = await host.store().getSessionByAcpIdForAgent(agentId, acpSessionId)
-    return slot ? await host.store().ensureOutwardSessionId(slot.key, agentId, systemClock.now()) : acpSessionId
-  }
-
   const workspaceScope = createWorkspaceScope({
     workspaces: host.workspaces(),
     agentOf: (id) => host.agents().get(id),
@@ -343,7 +337,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       log: host.log()
     }),
     memoryReader: createMemoryReader((id) => host.memoryFsFor(id), host.memory()),
-    dreamReader: createDreamReader(host.dreamRunner(), outwardSessionId),
+    dreamReader: createDreamReader(host.dreamRunner()),
     localSkillsReader: createLocalSkillsReader(
       host.workspaces(),
       // The workspace root in EXECUTION coordinates, like the file reader's: the skill roots the
@@ -352,11 +346,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       join(host.daemonRoot(), 'skill-installs'),
       (id) => host.k8sPlane()?.workspaceFilesFor(id)
     ),
-    runtimeCommandsReader: createRuntimeCommandsReader(
-      host.runtimeCommands(),
-      (id) => host.agents().has(id),
-      outwardSessionId
-    ),
+    runtimeCommandsReader: createRuntimeCommandsReader(host.runtimeCommands(), (id) => host.agents().has(id)),
     // webchat is no longer a CP control-WS integration (milestone A4) — it rides the
     // relay's rd/* wire, wired through RelayManager.onRelayMsg.
     clock: systemClock,

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -156,7 +156,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
   const workspaceScope = createWorkspaceScope({
     workspaces: host.workspaces(),
     agentOf: (id) => host.agents().get(id),
-    sessionOf: (id, acpSessionId) => host.store().getSessionByAcpIdForAgent(id, acpSessionId),
+    sessionOf: (id, sessionId) => host.store().getSessionByOutwardId(sessionId, id),
     runtimeRootOf: (id) => host.k8sPlane()?.workspaceRootFor(id)
   })
 

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -134,7 +134,7 @@ export interface CpClientSeamHost {
   gitCommitIdentity(): GitCommitIdentity | undefined
   sessionThreadUrl(session: SessionRecord): string | undefined
   childSessionStatusProbe(probe: ChildSessionStatusProbe): Promise<ChildSessionStatus>
-  listBackgroundTasks(req: TaskListReq): TaskList
+  listBackgroundTasks(req: TaskListReq): Promise<TaskList>
   withWorkspaceFileWrite<T>(agentId: string, write: () => Promise<T>): Promise<T>
   withWorkspaceIndexWrite<T>(agentId: string, write: () => Promise<T>): Promise<T>
   runCommitMessagePass: CommitMessagePass
@@ -153,6 +153,12 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
   // Which root a console request addresses and where it IS — the sandbox pod's volume under --k8s.
   // ONE resolver for the file reader and the git seam: the directory the console browses and the one
   // it commits are the same directory, and describing them two different ways broke both panels.
+  // One translation for every CP-facing read in this file that holds only the runtime's id.
+  const outwardSessionId = async (agentId: string, acpSessionId: string): Promise<string> => {
+    const slot = await host.store().getSessionByAcpIdForAgent(agentId, acpSessionId)
+    return slot ? await host.store().ensureOutwardSessionId(slot.key, agentId, systemClock.now()) : acpSessionId
+  }
+
   const workspaceScope = createWorkspaceScope({
     workspaces: host.workspaces(),
     agentOf: (id) => host.agents().get(id),
@@ -337,7 +343,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       log: host.log()
     }),
     memoryReader: createMemoryReader((id) => host.memoryFsFor(id), host.memory()),
-    dreamReader: createDreamReader(host.dreamRunner()),
+    dreamReader: createDreamReader(host.dreamRunner(), outwardSessionId),
     localSkillsReader: createLocalSkillsReader(
       host.workspaces(),
       // The workspace root in EXECUTION coordinates, like the file reader's: the skill roots the
@@ -346,7 +352,11 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       join(host.daemonRoot(), 'skill-installs'),
       (id) => host.k8sPlane()?.workspaceFilesFor(id)
     ),
-    runtimeCommandsReader: createRuntimeCommandsReader(host.runtimeCommands(), (id) => host.agents().has(id)),
+    runtimeCommandsReader: createRuntimeCommandsReader(
+      host.runtimeCommands(),
+      (id) => host.agents().has(id),
+      outwardSessionId
+    ),
     // webchat is no longer a CP control-WS integration (milestone A4) — it rides the
     // relay's rd/* wire, wired through RelayManager.onRelayMsg.
     clock: systemClock,

--- a/packages/daemon/src/cp/dream-reader.ts
+++ b/packages/daemon/src/cp/dream-reader.ts
@@ -6,7 +6,6 @@
  * (UTF-8 boundary + encoded-frame budget). Never log staged contents.
  */
 import type {
-  DreamInfo,
   DreamStartReq,
   DreamCancelReq,
   DreamListReq,
@@ -30,9 +29,6 @@ import type {
 import { fitToBudget, utf8Boundary } from '../wire-slice.js'
 import type { DreamRunner } from '../dream/runner.js'
 
-/** Resolves the OUTWARD id of the session an ACP id names (session-concept.md §1.1). */
-export type OutwardSessionIds = (agentId: string, acpSessionId: string) => Promise<string>
-
 export interface DreamReader {
   start(req: DreamStartReq): Promise<DreamState>
   cancel(req: DreamCancelReq): Promise<DreamState>
@@ -51,60 +47,41 @@ export interface DreamReader {
   organizationSuggestionReview(req: OrganizationSuggestionReviewReq): Promise<Ack>
 }
 
-export function createDreamReader(runner: DreamRunner, outward: OutwardSessionIds): DreamReader {
-  // A dream names sessions to the console — the execution session it deep-links as "Open session",
-  // and the sources it distilled — so both cross as outward ids (session-concept.md §1.1) even
-  // though the runner stores what the runtime called them.
-  const named = async (dream: DreamInfo): Promise<DreamInfo> => {
-    const executionSessionId = dream.executionSessionId
-      ? await outward(dream.agentId, dream.executionSessionId)
-      : undefined
-    return {
-      ...dream,
-      sessionIds: await Promise.all(dream.sessionIds.map(async (id) => await outward(dream.agentId, id))),
-      ...(executionSessionId ? { executionSessionId } : {})
-    }
-  }
-  const allNamed = async (dreams: DreamInfo[]): Promise<DreamInfo[]> =>
-    await Promise.all(dreams.map(async (dream) => await named(dream)))
+export function createDreamReader(runner: DreamRunner): DreamReader {
   return {
     async start(req) {
       return {
-        dream: await named(
-          await runner.start(req.agentId, {
-            trigger: req.trigger,
-            ...(req.sessionWindow !== undefined ? { sessionWindow: req.sessionWindow } : {}),
-            ...(req.instructions !== undefined ? { instructions: req.instructions } : {})
-          })
-        )
+        dream: await runner.start(req.agentId, {
+          trigger: req.trigger,
+          ...(req.sessionWindow !== undefined ? { sessionWindow: req.sessionWindow } : {}),
+          ...(req.instructions !== undefined ? { instructions: req.instructions } : {})
+        })
       }
     },
 
     async cancel(req) {
-      return { dream: await named(await runner.cancel(req.agentId, req.dreamId)) }
+      return { dream: await runner.cancel(req.agentId, req.dreamId) }
     },
 
     async list(req) {
       return {
         agentId: req.agentId,
-        dreams: await allNamed(
-          req.pendingSkills
-            ? await runner.listPendingSkills(req.agentId, req.limit)
-            : await runner.list(req.agentId, req.limit)
-        )
+        dreams: req.pendingSkills
+          ? await runner.listPendingSkills(req.agentId, req.limit)
+          : await runner.list(req.agentId, req.limit)
       }
     },
 
     async get(req) {
-      return { dream: await named(await runner.get(req.agentId, req.dreamId)) }
+      return { dream: await runner.get(req.agentId, req.dreamId) }
     },
 
     async adopt(req) {
-      return { dream: await named(await runner.adopt(req.agentId, req.dreamId, req.force, req.reviewToken)) }
+      return { dream: await runner.adopt(req.agentId, req.dreamId, req.force, req.reviewToken) }
     },
 
     async discard(req) {
-      return { dream: await named(await runner.discard(req.agentId, req.dreamId)) }
+      return { dream: await runner.discard(req.agentId, req.dreamId) }
     },
 
     async files(req) {

--- a/packages/daemon/src/cp/dream-reader.ts
+++ b/packages/daemon/src/cp/dream-reader.ts
@@ -6,6 +6,7 @@
  * (UTF-8 boundary + encoded-frame budget). Never log staged contents.
  */
 import type {
+  DreamInfo,
   DreamStartReq,
   DreamCancelReq,
   DreamListReq,
@@ -29,6 +30,9 @@ import type {
 import { fitToBudget, utf8Boundary } from '../wire-slice.js'
 import type { DreamRunner } from '../dream/runner.js'
 
+/** Resolves the OUTWARD id of the session an ACP id names (session-concept.md §1.1). */
+export type OutwardSessionIds = (agentId: string, acpSessionId: string) => Promise<string>
+
 export interface DreamReader {
   start(req: DreamStartReq): Promise<DreamState>
   cancel(req: DreamCancelReq): Promise<DreamState>
@@ -47,41 +51,60 @@ export interface DreamReader {
   organizationSuggestionReview(req: OrganizationSuggestionReviewReq): Promise<Ack>
 }
 
-export function createDreamReader(runner: DreamRunner): DreamReader {
+export function createDreamReader(runner: DreamRunner, outward: OutwardSessionIds): DreamReader {
+  // A dream names sessions to the console — the execution session it deep-links as "Open session",
+  // and the sources it distilled — so both cross as outward ids (session-concept.md §1.1) even
+  // though the runner stores what the runtime called them.
+  const named = async (dream: DreamInfo): Promise<DreamInfo> => {
+    const executionSessionId = dream.executionSessionId
+      ? await outward(dream.agentId, dream.executionSessionId)
+      : undefined
+    return {
+      ...dream,
+      sessionIds: await Promise.all(dream.sessionIds.map(async (id) => await outward(dream.agentId, id))),
+      ...(executionSessionId ? { executionSessionId } : {})
+    }
+  }
+  const allNamed = async (dreams: DreamInfo[]): Promise<DreamInfo[]> =>
+    await Promise.all(dreams.map(async (dream) => await named(dream)))
   return {
     async start(req) {
       return {
-        dream: await runner.start(req.agentId, {
-          trigger: req.trigger,
-          ...(req.sessionWindow !== undefined ? { sessionWindow: req.sessionWindow } : {}),
-          ...(req.instructions !== undefined ? { instructions: req.instructions } : {})
-        })
+        dream: await named(
+          await runner.start(req.agentId, {
+            trigger: req.trigger,
+            ...(req.sessionWindow !== undefined ? { sessionWindow: req.sessionWindow } : {}),
+            ...(req.instructions !== undefined ? { instructions: req.instructions } : {})
+          })
+        )
       }
     },
 
     async cancel(req) {
-      return { dream: await runner.cancel(req.agentId, req.dreamId) }
+      return { dream: await named(await runner.cancel(req.agentId, req.dreamId)) }
     },
 
     async list(req) {
       return {
         agentId: req.agentId,
-        dreams: req.pendingSkills
-          ? await runner.listPendingSkills(req.agentId, req.limit)
-          : await runner.list(req.agentId, req.limit)
+        dreams: await allNamed(
+          req.pendingSkills
+            ? await runner.listPendingSkills(req.agentId, req.limit)
+            : await runner.list(req.agentId, req.limit)
+        )
       }
     },
 
     async get(req) {
-      return { dream: await runner.get(req.agentId, req.dreamId) }
+      return { dream: await named(await runner.get(req.agentId, req.dreamId)) }
     },
 
     async adopt(req) {
-      return { dream: await runner.adopt(req.agentId, req.dreamId, req.force, req.reviewToken) }
+      return { dream: await named(await runner.adopt(req.agentId, req.dreamId, req.force, req.reviewToken)) }
     },
 
     async discard(req) {
-      return { dream: await runner.discard(req.agentId, req.dreamId) }
+      return { dream: await named(await runner.discard(req.agentId, req.dreamId)) }
     },
 
     async files(req) {

--- a/packages/daemon/src/cp/runtime-commands-reader.ts
+++ b/packages/daemon/src/cp/runtime-commands-reader.ts
@@ -11,19 +11,14 @@ export interface RuntimeCommandsReader {
 
 export function createRuntimeCommandsReader(
   commands: RuntimeCommandsCache,
-  knowsAgent: (agentId: string) => boolean,
-  outward: (agentId: string, acpSessionId: string) => Promise<string>
+  knowsAgent: (agentId: string) => boolean
 ): RuntimeCommandsReader {
   return {
     // An agent this daemon does not run reads as "nothing advertised yet" rather than as another
-    // agent's cache entry surviving a move.
+    // agent's cache entry surviving a move. The advertising session is already named outwardly —
+    // recorded that way (session-concept.md §1.1), because the row outlives the session.
     async list(req) {
-      if (!knowsAgent(req.agentId)) return { reported: false, commands: [] }
-      const entry = commands.get(req.agentId)
-      // The cache remembers which runtime session advertised the set; the frame names that session
-      // the way everyone outside the ACP hop does (session-concept.md §1.1).
-      if (entry.sessionId === undefined) return entry
-      return { ...entry, sessionId: await outward(req.agentId, entry.sessionId) }
+      return knowsAgent(req.agentId) ? commands.get(req.agentId) : { reported: false, commands: [] }
     }
   }
 }

--- a/packages/daemon/src/cp/runtime-commands-reader.ts
+++ b/packages/daemon/src/cp/runtime-commands-reader.ts
@@ -11,13 +11,19 @@ export interface RuntimeCommandsReader {
 
 export function createRuntimeCommandsReader(
   commands: RuntimeCommandsCache,
-  knowsAgent: (agentId: string) => boolean
+  knowsAgent: (agentId: string) => boolean,
+  outward: (agentId: string, acpSessionId: string) => Promise<string>
 ): RuntimeCommandsReader {
   return {
     // An agent this daemon does not run reads as "nothing advertised yet" rather than as another
     // agent's cache entry surviving a move.
     async list(req) {
-      return knowsAgent(req.agentId) ? commands.get(req.agentId) : { reported: false, commands: [] }
+      if (!knowsAgent(req.agentId)) return { reported: false, commands: [] }
+      const entry = commands.get(req.agentId)
+      // The cache remembers which runtime session advertised the set; the frame names that session
+      // the way everyone outside the ACP hop does (session-concept.md §1.1).
+      if (entry.sessionId === undefined) return entry
+      return { ...entry, sessionId: await outward(req.agentId, entry.sessionId) }
     }
   }
 }

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -265,7 +265,10 @@ export function createSessionReader(
         // for legacy rows without moving platform branches into this reader.
         const threadUrl = r.threadUrl ?? threadUrlFor?.(r)
         return {
-          sessionId: r.acpSessionId!, // listSessions filters out null acpSessionId
+          // The console addresses what it is shown, and the CP stores the row under this id
+          // (session-concept.md §1.1). A row from before the column answers with its ACP id,
+          // which is exactly what such a session was reported under.
+          sessionId: r.sessionId ?? r.acpSessionId!,
           ...(r.originSessionId ? { parentSessionId: r.originSessionId } : {}),
           // store `platform` is a free string; the daemon only ever writes a valid Platform.
           sessionKey: { platform: r.platform as Platform, channel: r.channel, thread: r.thread },

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -144,10 +144,11 @@ function parseUsage(raw: string | null): SessionUsage | undefined {
   }
 }
 
-/** Current CPs send the authorized owner. The unscoped branch preserves rolling
- * compatibility only while a newly upgraded daemon is still connected to an old CP. */
+/** The console addresses a session by its OUTWARD id (session-concept.md §1.1), so that is what
+ *  a read resolves. Current CPs send the authorized owner; the unscoped branch preserves rolling
+ *  compatibility only while a newly upgraded daemon is still connected to an old CP. */
 async function sessionForRead(store: LocalStore, agentId: string | undefined, sessionId: string) {
-  return agentId ? await store.getSessionByAcpIdForAgent(agentId, sessionId) : await store.getSessionByAcpId(sessionId)
+  return await store.getSessionByOutwardId(sessionId, agentId)
 }
 
 /** Rough character budget to trim a free-form value to when shrinking a preview. A

--- a/packages/daemon/src/cp/workspace-scope.ts
+++ b/packages/daemon/src/cp/workspace-scope.ts
@@ -27,7 +27,8 @@ export interface WorkspaceScopeSession {
 export interface WorkspaceScopeDeps {
   workspaces: WorkspaceManager
   agentOf: (agentId: string) => Agent | undefined
-  sessionOf: (agentId: string, acpSessionId: string) => Promise<WorkspaceScopeSession | undefined>
+  /** Resolve a slot from the id the console addresses it by — its outward one (session-concept.md §1.1). */
+  sessionOf: (agentId: string, sessionId: string) => Promise<WorkspaceScopeSession | undefined>
   /** The sandbox volume root a cluster agent's workspace lives on; undefined for a local daemon. */
   runtimeRootOf: (agentId: string) => string | undefined
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12947,9 +12947,13 @@ export class Daemon {
    *  ones fencing the host; then the retained settled ones (newest end first). Only an unknown
    *  agent is an error — no lease answers `tracked:false`, which is a different statement from
    *  "no background tasks" and the console says so. */
-  private listBackgroundTasks(req: TaskListReq): TaskList {
+  private async listBackgroundTasks(req: TaskListReq): Promise<TaskList> {
     if (!this.agents.has(req.agentId)) throw new TaskViolationError(`unknown agent "${req.agentId}"`, 'unknown-agent')
-    const lease = this.sdkLease.get(sdkLeaseKey(req.agentId, req.sessionId))
+    // The console names the session outwardly (§1.1); the lease it wants is keyed by the runtime's
+    // id, so this read is where the two meet. An unresolvable id is passed through, which is what
+    // a pre-v12 session was reported under.
+    const slot = await this.store.getSessionByOutwardId(req.sessionId, req.agentId)
+    const lease = this.sdkLease.get(sdkLeaseKey(req.agentId, slot?.acpSessionId ?? req.sessionId))
     const iso = (ms: number) => new Date(ms).toISOString()
     // Model-authored, so bounded here rather than trusted; the row survives, the tail does not.
     const described = (description: string | undefined) =>

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6372,7 +6372,7 @@ export class Daemon {
     // policy above still apply. A missing session NAKs `not_found`, mirroring the
     // local replyToSession contract — SessionTarget never creates a session.
     if (msg.lineageReplyTo !== undefined) {
-      const origin = await this.store.getSessionByAcpIdForAgent(msg.toAgentId, msg.lineageReplyTo)
+      const origin = await this.store.getSessionByOutwardId(msg.lineageReplyTo, msg.toAgentId)
       if (!origin) return record(nak('not_found'))
       // Reply transport from the SESSION's own scope (mirrors replyToSession's local branch).
       const replyIntegrationId = this.integrationIdForSessionTransport(

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1275,10 +1275,7 @@ export class Daemon {
       },
       replyConnFor: (agentId, integrationId) => this.replyConnFor(agentId, integrationId),
       sessionLink: (sessionId, source) => this.sessionLink(sessionId, source),
-      outwardSessionId: async (agentId, acpSessionId) => {
-        const slot = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
-        return slot ? await this.store.ensureOutwardSessionId(slot.key, agentId, this.clock.now()) : undefined
-      },
+      outwardSessionId: (agentId, acpSessionId) => this.outwardSessionIdForAcp(agentId, acpSessionId),
       sessionLinkSource: (platform, integrationId) => this.sessionLinkSource(platform, integrationId),
       threadOwner: async (channel, thread, transportScope) =>
         await this.sessions.threadOwner(channel, thread, transportScope),
@@ -6625,10 +6622,7 @@ export class Daemon {
       activeGithubReplyBatch: (key) => this.activeGithubReplyBatchMeta.get(key),
       agentLink: (agentId) => this.agentLink(agentId),
       sessionLink: (sessionId, source) => this.sessionLink(sessionId, source),
-      outwardSessionId: async (agentId, acpSessionId) => {
-        const slot = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
-        return slot ? await this.store.ensureOutwardSessionId(slot.key, agentId, this.clock.now()) : undefined
-      },
+      outwardSessionId: (agentId, acpSessionId) => this.outwardSessionIdForAcp(agentId, acpSessionId),
       runtimeNames: () => this.runtimeFacts.runtimeNames(),
       hostForStoredSession: async (agentId, acpSessionId) =>
         await this.modelSessions.hostForStoredSession(agentId, acpSessionId)
@@ -7821,12 +7815,19 @@ export class Daemon {
     owner?: HookCompletionOwner
   ): Promise<void> {
     if (owner?.hookTerminalReceipt) return
+    // Every caller here holds the runtime's session id; the CP files the run against
+    // `session_meta.id` and deep-links the console from it, which is the outward one (§1.1).
+    // Translating at this one boundary is what keeps a later caller from getting it wrong.
+    const attributed =
+      extra.sessionId === undefined
+        ? extra
+        : { ...extra, sessionId: (await this.outwardSessionIdForAcp(hook.agentId, extra.sessionId)) ?? extra.sessionId }
     // Interrupt reasons are local vocabulary, but the CP turns THIS one into maintainer-facing
     // Check text, so it crosses as the shared normalized code rather than the internal word.
     const report = this.buildHookReport(
       hook,
       status,
-      extra.reason === 'handover' ? { ...extra, reason: HOOK_REPORT_REASON_AGENT_HANDOVER } : extra
+      attributed.reason === 'handover' ? { ...attributed, reason: HOOK_REPORT_REASON_AGENT_HANDOVER } : attributed
     )
     let reportInboxId: string | undefined
     if (owner?.inboxId) {
@@ -8186,7 +8187,8 @@ export class Daemon {
       admissionWait?: Promise<boolean>
       /** Delay observed-inbound persistence until admissionWait succeeds. */
       deferObservedInbound?: boolean
-      /** Best-effort notification once the ACP session exists, before prompt. */
+      /** Best-effort notification once the session exists, before prompt. Carries its OUTWARD
+       *  id (session-concept.md §1.1) — every consumer of this reports it onward. */
       onSessionReady?: (sessionId: string) => void
     },
     githubReply?: GithubReplyTarget,
@@ -9403,7 +9405,9 @@ export class Daemon {
       await this.observedChannelsSync.refreshObservedChannels()
     }
     try {
-      onSessionReady?.(sessionId)
+      // The one consumer is the CP's cron report, a console deep link — so the callback is
+      // handed the session's outward id (§1.1), not the runtime's.
+      onSessionReady?.((await this.outwardSessionIdForAcp(agentId, sessionId)) ?? sessionId)
     } catch (err) {
       this.log.warn(`dispatch: session-ready notification failed (${formatErr(err)})`)
     }
@@ -10987,6 +10991,13 @@ export class Daemon {
     const orgSeg = this.cpOrgSlug ? `/${encodeURIComponent(this.cpOrgSlug)}` : ''
     const link = `${this.webAppBase()}${orgSeg}/sessions/${encodeURIComponent(sessionId)}`
     return source ? `${link}?source=${source}` : link
+  }
+
+  /** The OUTWARD id of the session an ACP id names (session-concept.md §1.1) — for the reporting
+   *  boundaries that hold only the runtime's. Undefined when this daemon has no such session. */
+  private async outwardSessionIdForAcp(agentId: string, acpSessionId: string): Promise<string | undefined> {
+    const slot = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+    return slot ? await this.store.ensureOutwardSessionId(slot.key, agentId, this.clock.now()) : undefined
   }
 
   /** The console deep link to an agent: `<base>/<orgSlug>/agents/<agentId>`. Same
@@ -14899,6 +14910,8 @@ export class Daemon {
     report()
     let readySessionId: string | undefined
     try {
+      // A cron run is a console deep link on the CP side, so every id it reports is the outward
+      // one (§1.1). The ready callback already delivers that; `fireTrigger`'s return is the ACP id.
       const sessionId = await this.fireTrigger(
         agentId,
         msg,
@@ -14916,7 +14929,7 @@ export class Daemon {
         report({
           status: 'success',
           durationMs: Math.max(0, this.clock.now() - firedAt),
-          sessionId
+          sessionId: (await this.outwardSessionIdForAcp(agentId, sessionId)) ?? sessionId
         })
     } catch (err) {
       report({

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2326,7 +2326,7 @@ export class Daemon {
         const scope = createWorkspaceScope({
           workspaces: this.workspaces,
           agentOf: (id) => this.agents.get(id),
-          sessionOf: (id, acpSessionId) => this.store.getSessionByAcpIdForAgent(id, acpSessionId),
+          sessionOf: (id, sessionId) => this.store.getSessionByOutwardId(sessionId, id),
           runtimeRootOf: (id) => this.k8sPlane?.workspaceRootFor(id)
         })
         const acpSessionId = await this.acpSessionIdForToolCall(ctx).catch(() => undefined)
@@ -3761,6 +3761,7 @@ export class Daemon {
       orgForAgent: (agentId) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
       modelOverride: async (sessionKey) => await this.store.getModelOverride(sessionKey),
       acpSessionId: async (sessionKey) => (await this.store.getSession(sessionKey))?.acpSessionId,
+      outwardSessionId: async (sessionKey, agentId) => await this.store.ensureOutwardSessionId(sessionKey, agentId),
       sessionKeyForAcpId: async (agentId, acpSessionId) =>
         (await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId))?.key,
       sessionSdkQuiescent: (agentId, acpSessionId) => this.sessionSdkQuiescent(agentId, acpSessionId),
@@ -11414,9 +11415,12 @@ export class Daemon {
     const usage = await this.store.getUsage(key)
     if (Object.keys(usage).length === 0) return
     const observedModel = await this.store.getObservedModel(key)
+    // The wire carries the outward id (§1.1) — the same one the gateway's metered rows carry, so
+    // both sources of a session's spend land on one row instead of two.
+    const outwardSessionId = await this.store.ensureOutwardSessionId(key, agentId)
     try {
       this.cpClient?.emitUsageReport({
-        sessionId,
+        sessionId: outwardSessionId,
         agentId,
         platform,
         channel,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1274,7 +1274,11 @@ export class Daemon {
         await this.dispatch(agentId, msg, integrationId, undefined, undefined, { isQueueCmd: true })
       },
       replyConnFor: (agentId, integrationId) => this.replyConnFor(agentId, integrationId),
-      sessionLink: (acpSessionId, source) => this.sessionLink(acpSessionId, source),
+      sessionLink: (sessionId, source) => this.sessionLink(sessionId, source),
+      outwardSessionId: async (agentId, acpSessionId) => {
+        const slot = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+        return slot ? await this.store.ensureOutwardSessionId(slot.key, agentId, this.clock.now()) : undefined
+      },
       sessionLinkSource: (platform, integrationId) => this.sessionLinkSource(platform, integrationId),
       threadOwner: async (channel, thread, transportScope) =>
         await this.sessions.threadOwner(channel, thread, transportScope),
@@ -3761,7 +3765,8 @@ export class Daemon {
       orgForAgent: (agentId) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
       modelOverride: async (sessionKey) => await this.store.getModelOverride(sessionKey),
       acpSessionId: async (sessionKey) => (await this.store.getSession(sessionKey))?.acpSessionId,
-      outwardSessionId: async (sessionKey, agentId) => await this.store.ensureOutwardSessionId(sessionKey, agentId),
+      outwardSessionId: async (sessionKey, agentId) =>
+        await this.store.ensureOutwardSessionId(sessionKey, agentId, this.clock.now()),
       sessionKeyForAcpId: async (agentId, acpSessionId) =>
         (await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId))?.key,
       sessionSdkQuiescent: (agentId, acpSessionId) => this.sessionSdkQuiescent(agentId, acpSessionId),
@@ -6619,7 +6624,11 @@ export class Daemon {
       activeGithubTurn: (key) => this.activeGithubTurnMeta.get(key),
       activeGithubReplyBatch: (key) => this.activeGithubReplyBatchMeta.get(key),
       agentLink: (agentId) => this.agentLink(agentId),
-      sessionLink: (acpSessionId, source) => this.sessionLink(acpSessionId, source),
+      sessionLink: (sessionId, source) => this.sessionLink(sessionId, source),
+      outwardSessionId: async (agentId, acpSessionId) => {
+        const slot = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+        return slot ? await this.store.ensureOutwardSessionId(slot.key, agentId, this.clock.now()) : undefined
+      },
       runtimeNames: () => this.runtimeFacts.runtimeNames(),
       hostForStoredSession: async (agentId, acpSessionId) =>
         await this.modelSessions.hostForStoredSession(agentId, acpSessionId)
@@ -9070,7 +9079,14 @@ export class Daemon {
     const pendingWebchat = webchat
       ? Object.assign(webchat, { index: 0, replyText: '', heldText: '', messageEmitted: false })
       : undefined
-    const p = this.buildPending(run, { conv, rec, sessionId, webchat: pendingWebchat })
+    // Resolved once for the turn: the console addresses this session by its outward id (§1.1),
+    // and most of the turn's link/status producers are synchronous.
+    const outwardSessionId = await this.store.ensureOutwardSessionId(
+      run.plan.sessionKey,
+      run.entry.agentId,
+      this.clock.now()
+    )
+    const p = this.buildPending(run, { conv, rec, sessionId, outwardSessionId, webchat: pendingWebchat })
     const activeTurn = await this.installActiveTurnContext(run, sessionId)
     const settlement: TurnSettlement = { finalPhase: 'end', propagatingTurnError: false }
     let turnModel: string | undefined
@@ -9396,11 +9412,17 @@ export class Daemon {
   /** Build this turn's live record from its plan and register it as the session's Pending turn. */
   private buildPending(
     run: TurnRun,
-    turn: { conv: DaemonConverger; rec: TranscriptRecorder; sessionId: string; webchat: Pending['webchat'] }
+    turn: {
+      conv: DaemonConverger
+      rec: TranscriptRecorder
+      sessionId: string
+      outwardSessionId: string
+      webchat: Pending['webchat']
+    }
   ): Pending {
     const { entry, plan } = run
     const { agentId, callMeta, githubReply } = entry
-    const { conv, rec, sessionId } = turn
+    const { conv, rec, sessionId, outwardSessionId } = turn
     let resolveDone!: () => void
     const done = new Promise<void>((r) => (resolveDone = r))
     if (!entry.selectedHost) {
@@ -9432,6 +9454,7 @@ export class Daemon {
       builtinSystemToolCallIds: new Set(),
       hiddenSessionTitleToolCallIds: new Set(),
       acpSessionId: sessionId,
+      outwardSessionId,
       ...(entry.selectedHost ? { selectedHost: entry.selectedHost } : {}),
       turnState: plan.turnSurface.initialTurnState(plan.turnCtx),
       conn: run.replyConn,
@@ -10088,7 +10111,7 @@ export class Daemon {
   ): Promise<void> {
     if (p.webchat && !p.webchat.continuation) return
     const { plan } = run
-    const link = plan.showFooter ? this.sessionLink(sessionId) : undefined
+    const link = plan.showFooter ? this.sessionLink(p.outwardSessionId) : undefined
     const finalAttributionInfo = plan.showFooter ? await currentAttributionInfo() : undefined
     // A runtime may only publish its final session-scoped model during prompt.
     // Refresh before enqueueing the final body so any not-yet-sent section is born
@@ -10534,7 +10557,7 @@ export class Daemon {
       botUrl: this.agentLink(entry.agentId),
       runtime: this.runtimeFacts.runtimeNames()[agent.runtime] ?? agent.runtime,
       model: (await this.buildStatusInfo(p)).model ?? turnModel ?? 'default',
-      sessionUrl: this.sessionLink(sessionId, this.sessionLinkSource(plan.platform, plan.integrationId)),
+      sessionUrl: this.sessionLink(p.outwardSessionId, this.sessionLinkSource(plan.platform, plan.integrationId)),
       ...(plan.hopLimitNotice ? { notice: plan.hopLimitNotice } : {})
     }
   }
@@ -10930,7 +10953,7 @@ export class Daemon {
         recordReplySegment: (turn, text) => this.recordReplySegment(turn as Pending, text),
         appendTranscript: async (row) => await this.store.appendTranscript(row),
         sessionUrl: (turn) =>
-          this.sessionLink(turn.acpSessionId, this.sessionLinkSource(turn.plan.platform, turn.plan.integrationId))
+          this.sessionLink(turn.outwardSessionId, this.sessionLinkSource(turn.plan.platform, turn.plan.integrationId))
       },
       p,
       turnState<FeishuTurnState>(p),
@@ -10958,9 +10981,11 @@ export class Daemon {
    *  (`DEFAULT_WEB_APP_URL`). The console is org-scoped, so the org slug is inserted when
    *  known; without it the link falls back to `<base>/sessions/<id>`. Provider-rendered
    *  links carry a presentation-only source hint for the generic 404 profile-linking action. */
-  private sessionLink(acpSessionId: string, source?: string): string {
+  /** The console deep link to a session. Takes its OUTWARD id (session-concept.md §1.1) — the
+   *  console resolves what the CP stored, and the CP stores this one. */
+  private sessionLink(sessionId: string, source?: string): string {
     const orgSeg = this.cpOrgSlug ? `/${encodeURIComponent(this.cpOrgSlug)}` : ''
-    const link = `${this.webAppBase()}${orgSeg}/sessions/${encodeURIComponent(acpSessionId)}`
+    const link = `${this.webAppBase()}${orgSeg}/sessions/${encodeURIComponent(sessionId)}`
     return source ? `${link}?source=${source}` : link
   }
 
@@ -11020,6 +11045,9 @@ export class Daemon {
   ): Promise<StatusBarInfo> {
     const agent = this.agents.get(agentId)
     const usage = await this.store.getUsage(sessionKey)
+    const outwardSessionId = acpSessionId
+      ? await this.store.ensureOutwardSessionId(sessionKey, agentId, this.clock.now())
+      : undefined
     // `?.()` guards a host stub without the method (test fakes); real AcpHosts always have it.
     const host = acpSessionId
       ? await this.modelSessions.hostForStoredSession(agentId, acpSessionId)
@@ -11099,7 +11127,8 @@ export class Daemon {
           }
         : {}),
       ...(allowRuntimeChangesInChat && fast ? { fastModeAvailable: true } : {}),
-      ...(acpSessionId ? { sessionId: acpSessionId } : {})
+      // The console deep-links from this, so it is the session's outward id (§1.1), not the hop's.
+      ...(outwardSessionId ? { sessionId: outwardSessionId } : {})
     }
   }
 
@@ -11127,7 +11156,8 @@ export class Daemon {
       ...(iconUrl ? { iconUrl } : {}),
       ...(sessionTitle ? { sessionTitle } : {})
     }
-    const link = rec.acpSessionId ? this.sessionLink(rec.acpSessionId, 'slack') : undefined
+    const outward = rec.sessionId ?? rec.acpSessionId
+    const link = outward ? this.sessionLink(outward, 'slack') : undefined
     const pending = [...this.pending.values()].find((turn) => turn.plan.sessionKey === sessionKey)
     const cancellable = pending?.chrome.statusCancellable ?? this.inflight.has(sessionKey)
     return { info, identity, ...(link ? { link } : {}), cancellable }
@@ -11191,7 +11221,7 @@ export class Daemon {
       // runtimes only advertise the model after the first prompt). It fills in via edits
       // as usage_update / turn-end land.
       p.chrome.lastStatusBar = key
-      const link = this.sessionLink(p.acpSessionId, 'slack')
+      const link = this.sessionLink(p.outwardSessionId, 'slack')
       const sessionTarget = this.httpSlackSessionTarget(p)
       const shared =
         sessionTarget && p.plan.integrationId
@@ -11417,7 +11447,7 @@ export class Daemon {
     const observedModel = await this.store.getObservedModel(key)
     // The wire carries the outward id (§1.1) — the same one the gateway's metered rows carry, so
     // both sources of a session's spend land on one row instead of two.
-    const outwardSessionId = await this.store.ensureOutwardSessionId(key, agentId)
+    const outwardSessionId = await this.store.ensureOutwardSessionId(key, agentId, this.clock.now())
     try {
       this.cpClient?.emitUsageReport({
         sessionId: outwardSessionId,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2463,7 +2463,7 @@ export class Daemon {
     )
 
     this.sessions = new SessionManager({
-      bindOutwardSessionId: (agentId, key, acpSessionId) => this.bindOutwardSessionId(agentId, key, acpSessionId),
+      prepareOutwardBinding: (agentId, key) => this.prepareOutwardBinding(agentId, key),
       // THIS daemon's plane. Omitting it hands the manager a local-mode one, and
       // `additionalWorkspaceDirectories` would then `realpathSync` a `--k8s` workspace's pod-side
       // cwd against this filesystem — failing session create/load before the runtime call.
@@ -11021,14 +11021,16 @@ export class Daemon {
    *  Dropped once the row can answer for itself; bounded so an aborted open cannot accumulate. */
   private readonly openingOutwardSessionIds = new Map<string, string>()
 
-  /** Called by the opener the instant `newSession()` returns — the outward id is already minted
-   *  (the credential that started this runtime carries it), so this only records the pairing. */
-  private async bindOutwardSessionId(agentId: string, key: string, acpSessionId: string): Promise<void> {
-    if (this.openingOutwardSessionIds.size >= 2000) this.openingOutwardSessionIds.clear()
-    this.openingOutwardSessionIds.set(
-      pendingTurnKey(agentId, acpSessionId),
-      await this.store.ensureOutwardSessionId(key, agentId, this.clock.now())
-    )
+  /** Mint the slot's outward id BEFORE the runtime is asked for a session, and hand back the
+   *  binder its raw response calls. The binder is synchronous by contract: it runs in the instant
+   *  between the runtime answering and its session becoming reachable, and an update that lands
+   *  while it awaited anything would be dropped for want of an owner. */
+  private async prepareOutwardBinding(agentId: string, key: string): Promise<(acpSessionId: string) => void> {
+    const outward = await this.store.ensureOutwardSessionId(key, agentId, this.clock.now())
+    return (acpSessionId) => {
+      if (this.openingOutwardSessionIds.size >= 2000) this.openingOutwardSessionIds.clear()
+      this.openingOutwardSessionIds.set(pendingTurnKey(agentId, acpSessionId), outward)
+    }
   }
 
   /** The console deep link to an agent: `<base>/<orgSlug>/agents/<agentId>`. Same

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2463,6 +2463,7 @@ export class Daemon {
     )
 
     this.sessions = new SessionManager({
+      bindOutwardSessionId: (agentId, key, acpSessionId) => this.bindOutwardSessionId(agentId, key, acpSessionId),
       // THIS daemon's plane. Omitting it hands the manager a local-mode one, and
       // `additionalWorkspaceDirectories` would then `realpathSync` a `--k8s` workspace's pod-side
       // cwd against this filesystem — failing session create/load before the runtime call.
@@ -10997,12 +10998,37 @@ export class Daemon {
   }
 
   /** The OUTWARD id of the session an ACP id names (session-concept.md §1.1) — for the reporting
-   *  boundaries that hold only the runtime's. Undefined when this daemon has no such session. */
+   *  boundaries that hold only the runtime's. Undefined when this daemon has no such session.
+   *
+   *  The in-flight bindings answer first, and they are why an early report cannot fall back to the
+   *  hop's id: `newSession()` returns a live session that can stream updates before the row
+   *  carrying the mapping is written, and one of those updates (an `available_commands_update`)
+   *  is persisted durably. */
   private async outwardSessionIdForAcp(agentId: string, acpSessionId: string): Promise<string | undefined> {
     // `store` is absent only in bare test harnesses constructed without start() — the same guard
     // the advertisement's own persist makes one line later.
     const slot = await this.store?.getSessionByAcpIdForAgent(agentId, acpSessionId)
-    return slot ? await this.store.ensureOutwardSessionId(slot.key, agentId, this.clock.now()) : undefined
+    const turnKey = pendingTurnKey(agentId, acpSessionId)
+    // Once the row can answer, it is the authority and the binding has done its job.
+    if (slot) {
+      this.openingOutwardSessionIds.delete(turnKey)
+      return await this.store.ensureOutwardSessionId(slot.key, agentId, this.clock.now())
+    }
+    return this.openingOutwardSessionIds.get(turnKey)
+  }
+
+  /** Slots whose runtime session exists but whose row does not yet, by {@link pendingTurnKey}.
+   *  Dropped once the row can answer for itself; bounded so an aborted open cannot accumulate. */
+  private readonly openingOutwardSessionIds = new Map<string, string>()
+
+  /** Called by the opener the instant `newSession()` returns — the outward id is already minted
+   *  (the credential that started this runtime carries it), so this only records the pairing. */
+  private async bindOutwardSessionId(agentId: string, key: string, acpSessionId: string): Promise<void> {
+    if (this.openingOutwardSessionIds.size >= 2000) this.openingOutwardSessionIds.clear()
+    this.openingOutwardSessionIds.set(
+      pendingTurnKey(agentId, acpSessionId),
+      await this.store.ensureOutwardSessionId(key, agentId, this.clock.now())
+    )
   }
 
   /** The console deep link to an agent: `<base>/<orgSlug>/agents/<agentId>`. Same

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4535,7 +4535,9 @@ export class Daemon {
     if (dream) {
       await this.store.updateDream({
         ...dream,
-        executionSessionId: sessionId,
+        // Stored outwardly (§1.1), not resolved at read time: the dream outlives its session, and
+        // a record whose identity changes when the session is purged is worse than no link.
+        executionSessionId: await this.store.ensureOutwardSessionId(executionKey, agentId, this.clock.now()),
         runtime: agent.runtime,
         ...(model ? { model } : {})
       })
@@ -4754,7 +4756,7 @@ export class Daemon {
     })
 
     if (!dream.executionSessionId || event.type === 'memory.dream.started') return
-    const rec = await this.store.getSessionByAcpIdForAgent(dream.agentId, dream.executionSessionId)
+    const rec = await this.store.getSessionByOutwardId(dream.executionSessionId, dream.agentId)
     if (!rec) return
     const message: Partial<Record<DreamLifecycleEvent['type'], string>> = {
       'memory.dream.completed': 'Dream completed. The staged memory is ready for review.',
@@ -4776,7 +4778,8 @@ export class Daemon {
     }
     await this.store.setSessionState(rec.key, 'idle', this.clock.now())
     await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({
-      sessionId: dream.executionSessionId,
+      // The outbox takes the ACP hop's id and translates; the dream row holds the outward one.
+      sessionId: rec.acpSessionId ?? dream.executionSessionId,
       agentId: dream.agentId,
       phase: event.type === 'memory.dream.failed' ? 'problem' : 'end',
       platform: 'dream',
@@ -10996,7 +10999,9 @@ export class Daemon {
   /** The OUTWARD id of the session an ACP id names (session-concept.md §1.1) — for the reporting
    *  boundaries that hold only the runtime's. Undefined when this daemon has no such session. */
   private async outwardSessionIdForAcp(agentId: string, acpSessionId: string): Promise<string | undefined> {
-    const slot = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+    // `store` is absent only in bare test harnesses constructed without start() — the same guard
+    // the advertisement's own persist makes one line later.
+    const slot = await this.store?.getSessionByAcpIdForAgent(agentId, acpSessionId)
     return slot ? await this.store.ensureOutwardSessionId(slot.key, agentId, this.clock.now()) : undefined
   }
 
@@ -11667,7 +11672,14 @@ export class Daemon {
       const host = this.hosts.get(agentId)
       const owned = host?.hasSession(sessionId) || host?.isLoadingSession(sessionId)
       if (owned && !this.internalPassSessions.has(extractionKey)) {
-        const entry = this.runtimeCommands.record(agentId, sessionId, update, this.clock.now())
+        // Recorded under the session's OUTWARD id (§1.1): the row survives the session, so a name
+        // resolved later would change once retention drops the mapping.
+        const entry = this.runtimeCommands.record(
+          agentId,
+          (await this.outwardSessionIdForAcp(agentId, sessionId)) ?? sessionId,
+          update,
+          this.clock.now()
+        )
         // Persisted so a restart/upgrade serves the last-known list instead of "nothing yet".
         // `store` is absent only in bare test harnesses constructed without start().
         if (entry && this.store) {

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -511,9 +511,12 @@ export interface Pending {
    *  session metadata, but housekeeping must not appear in platform/webchat output
    *  or the persisted user-visible activity log. */
   hiddenSessionTitleToolCallIds: Set<string>
-  /** The live ACP session id for this turn (part of the `this.pending` map key) — surfaced
-   *  in the status bar so the console can deep-link to the session detail page. */
+  /** The live ACP session id for this turn (part of the `this.pending` map key). */
   acpSessionId: string
+  /** The same session's OUTWARD id (session-concept.md §1.1) — what the console knows it by, so
+   *  every deep link and status payload this turn produces addresses a row the CP actually has.
+   *  Stamped once here because most of those producers are synchronous. */
+  outwardSessionId: string
   /** The exact host selected for this turn, including its full cleanup boundary. */
   selectedHost?: SelectedTurnHost
   /** Once an operator pause or loop trip targets this turn, no subsequent ACP update

--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -128,6 +128,10 @@ export interface DreamStorePort {
   supersededDreams(): Promise<DreamInfo[]>
   /** Dreams still carrying a proposed organization suggestion, newest first. */
   organizationSuggestionDreams(limit: number): Promise<DreamInfo[]>
+  /** The two reads that name a session OUTWARDLY (session-concept.md §1.1), for the durable
+   *  records a dream leaves behind — they outlive the session they point at. */
+  getSessionByAcpIdForAgent(agentId: string, acpSessionId: string): Promise<{ key: string } | undefined>
+  ensureOutwardSessionId(key: string, agentId?: string): Promise<string>
   /** Newest-first addressable sessions for the agent (transcript sources). */
   dreamSessionSources(
     agentId: string,
@@ -720,8 +724,16 @@ export class DreamRunner {
         return
       }
       const output = extracted.output
+      // Named outwardly here too (§1.1) — the extraction hands back the runtime's id, and this row
+      // outlives the session it points at.
+      const executionSlot = extracted.sessionId
+        ? await this.deps.store.getSessionByAcpIdForAgent(agentId, extracted.sessionId)
+        : undefined
+      const executionSessionId = executionSlot
+        ? await this.deps.store.ensureOutwardSessionId(executionSlot.key, agentId)
+        : extracted.sessionId
       const execution = {
-        ...(extracted.sessionId ? { executionSessionId: extracted.sessionId } : {}),
+        ...(executionSessionId ? { executionSessionId } : {}),
         ...(extracted.runtime ? { runtime: extracted.runtime } : {}),
         ...(extracted.model ? { model: extracted.model } : {}),
         ...(extracted.stopReason ? { stopReason: extracted.stopReason } : {})

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -135,7 +135,9 @@ export interface GithubReviewHost {
   activeGithubTurn(key: string): ActiveGithubTurnMeta | undefined
   activeGithubReplyBatch(key: string): ActiveGithubReplyBatchMeta | undefined
   agentLink(agentId: string): string
-  sessionLink(acpSessionId: string, source?: string): string
+  /** Takes the session's OUTWARD id (session-concept.md §1.1), which {@link outwardSessionId} resolves. */
+  sessionLink(sessionId: string, source?: string): string
+  outwardSessionId(agentId: string, acpSessionId: string): Promise<string | undefined>
   runtimeNames(): Record<string, string>
   hostForStoredSession(agentId: string, acpSessionId: string): Promise<AcpHost | undefined>
 }
@@ -977,6 +979,8 @@ export class GithubReviewOrchestrator {
   async githubCommentAttribution(agentId: string, sessionId: string): Promise<GithubCommentAttribution> {
     const agent = this.agents.get(agentId)
     const runtime = agent?.runtime
+    // The footer links the console, which knows this session by its outward id (§1.1).
+    const outward = await this.host.outwardSessionId(agentId, sessionId)
     return {
       agentName: agent?.displayName?.trim() || agent?.name || agentId,
       agentUrl: this.host.agentLink(agentId),
@@ -985,7 +989,7 @@ export class GithubReviewOrchestrator {
         (await this.host.hostForStoredSession(agentId, sessionId))?.modelOptions?.(sessionId)?.current ??
         agent?.runtimeOverrides?.model ??
         'default',
-      sessionUrl: this.host.sessionLink(sessionId, 'github'),
+      sessionUrl: this.host.sessionLink(outward ?? sessionId, 'github'),
       // Same CP-resolved public avatar Slack uses for icon_url; GitHub renders it
       // inline ahead of the footer sentence.
       ...(agent?.iconUrl ? { iconUrl: agent.iconUrl } : {})

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -621,7 +621,9 @@ export class GithubReviewOrchestrator {
       hookId: hook.hookId,
       agentId: hook.agentId,
       deliveryKey: hook.deliveryKey,
-      sessionId,
+      // The CP files the run against `session_meta.id` and deep-links the console from it, so
+      // this is the session's outward id (§1.1) — the caller holds the ACP hop's.
+      sessionId: (await this.host.outwardSessionId(hook.agentId, sessionId)) ?? sessionId,
       ...(hook.event ? { event: hook.event } : {}),
       github: { ...trusted, reportSha: trusted.reportSha ?? trusted.headSha },
       ...snapshot

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -175,6 +175,12 @@ export class ModelSessionHostPool {
     return await this.keyServer.issue({
       orgId,
       agentId: agent.id,
+      // DOCTRINE DEBT (session-concept.md §1.1): this should be the session's outward
+      // `sessionId`, and it is neither — the ACP id does not exist yet when a credential is
+      // minted, so this hashes the slot key instead. The hash is stable and hides the platform
+      // coordinates `sessionKey` carries, but nothing outside the daemon can resolve it back to
+      // a session, so gateway-metered spend lands under an identity the console cannot match.
+      // Fixed by minting the outward id here, before issuance, and proposing it on session/new.
       sessionId: createHash('sha256').update(sessionKey).digest('hex'),
       provider: target.provider,
       ttlSeconds: DEFAULT_MODEL_KEY_TTL_SECONDS

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto'
 import type { AcpHost } from '../acp/acp-host.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import type { RuntimeDef } from '../config/config-schema.js'
@@ -30,6 +29,8 @@ export interface ModelSessionHostPoolHost {
   orgForAgent(agentId: string): string | undefined
   modelOverride(sessionKey: string): Promise<string | undefined>
   acpSessionId(sessionKey: string): Promise<string | null | undefined>
+  /** The slot's OUTWARD session id, minted on first ask — see session-concept.md §1.1. */
+  outwardSessionId(sessionKey: string, agentId: string): Promise<string>
   sessionKeyForAcpId(agentId: string, acpSessionId: string): Promise<string | undefined>
   sessionSdkQuiescent(agentId: string, acpSessionId: string | null | undefined): boolean
   releaseSdkLease(agentId: string, acpSessionId: string): void
@@ -172,16 +173,13 @@ export class ModelSessionHostPool {
     const orgId = this.host.orgForAgent(agent.id)
     if (!orgId) throw new Error(`cannot resolve organization for agent ${agent.id}`)
     if (!this.keyServer) throw new Error('key-server is not configured')
+    // Minted here if this is the slot's first credential — which is why the outward id cannot be
+    // the ACP one: this call starts the runtime, so the runtime's id does not exist yet (§1.1).
+    const sessionId = await this.host.outwardSessionId(sessionKey, agent.id)
     return await this.keyServer.issue({
       orgId,
       agentId: agent.id,
-      // DOCTRINE DEBT (session-concept.md §1.1): this should be the session's outward
-      // `sessionId`, and it is neither — the ACP id does not exist yet when a credential is
-      // minted, so this hashes the slot key instead. The hash is stable and hides the platform
-      // coordinates `sessionKey` carries, but nothing outside the daemon can resolve it back to
-      // a session, so gateway-metered spend lands under an identity the console cannot match.
-      // Fixed by minting the outward id here, before issuance, and proposing it on session/new.
-      sessionId: createHash('sha256').update(sessionKey).digest('hex'),
+      sessionId,
       provider: target.provider,
       ttlSeconds: DEFAULT_MODEL_KEY_TTL_SECONDS
     })

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -166,9 +166,9 @@ export class SessionManager {
   constructor(
     private deps: {
       store: LocalStore
-      /** Bind a runtime session id to its slot's outward id (§1.1) the moment `newSession()` returns,
-       *  before the row exists — see the opener's `bindOutwardSessionId`. */
-      bindOutwardSessionId?: (agentId: string, key: string, acpSessionId: string) => Promise<void>
+      /** Mint a slot's outward id (§1.1) and hand back the synchronous binder the runtime's raw
+       *  `session/new` response calls — see the opener's `prepareOutwardBinding`. */
+      prepareOutwardBinding?: (agentId: string, key: string) => Promise<(acpSessionId: string) => void>
       hostFor: (agentId: string) => Promise<AcpHost>
       /** Whether the runtime initialize handshake completed. A cold hostFor may
        * own preparation itself when resolvePreparedWorkspace is also supplied. */
@@ -594,7 +594,9 @@ export class SessionManager {
           : {})
       },
       store: this.deps.store,
-      bindOutwardSessionId: (acpSessionId) => this.deps.bindOutwardSessionId?.(agentId, key, acpSessionId),
+      ...(this.deps.prepareOutwardBinding
+        ? { prepareOutwardBinding: () => this.deps.prepareOutwardBinding!(agentId, key) }
+        : {}),
       ...(options.preparedWorkspaceCwd !== undefined ? { preparedWorkspaceCwd: options.preparedWorkspaceCwd } : {}),
       ...(preparedCwd !== undefined ? { preparedCwd } : {}),
       ...(expectedWarmHost !== undefined ? { expectedWarmHost } : {}),

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -166,6 +166,9 @@ export class SessionManager {
   constructor(
     private deps: {
       store: LocalStore
+      /** Bind a runtime session id to its slot's outward id (§1.1) the moment `newSession()` returns,
+       *  before the row exists — see the opener's `bindOutwardSessionId`. */
+      bindOutwardSessionId?: (agentId: string, key: string, acpSessionId: string) => Promise<void>
       hostFor: (agentId: string) => Promise<AcpHost>
       /** Whether the runtime initialize handshake completed. A cold hostFor may
        * own preparation itself when resolvePreparedWorkspace is also supplied. */
@@ -591,6 +594,7 @@ export class SessionManager {
           : {})
       },
       store: this.deps.store,
+      bindOutwardSessionId: (acpSessionId) => this.deps.bindOutwardSessionId?.(agentId, key, acpSessionId),
       ...(options.preparedWorkspaceCwd !== undefined ? { preparedWorkspaceCwd: options.preparedWorkspaceCwd } : {}),
       ...(preparedCwd !== undefined ? { preparedCwd } : {}),
       ...(expectedWarmHost !== undefined ? { expectedWarmHost } : {}),

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -553,7 +553,7 @@ export class SessionManager {
           slackSelfId:
             msg.platform === 'slack' && integrationId ? this.deps.slackBotUserIdFor?.(integrationId) : undefined,
           thread,
-          acpSessionId: rec?.acpSessionId,
+          sessionId: rec?.sessionId,
           parentSessionId: effectiveOriginSessionId,
           envSecretNames: secretNames.filter((n) => !fileSecretNames.has(n)),
           fileSecrets: fileSecrets.map((m) => ({ sourceVar: m.sourceVar, pointerVar: m.convention.pointerVar })),

--- a/packages/daemon/src/session/turn/runtime-session.ts
+++ b/packages/daemon/src/session/turn/runtime-session.ts
@@ -56,13 +56,14 @@ export interface OpenRuntimeSessionInput {
   metaContext?: () => Promise<string | undefined>
   resumeSystemContext?: () => Promise<string | undefined>
   usesMeta: boolean
-  /** Bind the runtime's brand-new session id to this slot's OUTWARD one (session-concept.md §1.1)
-   *  at the raw `session/new` response, before the session is reachable. The host makes it live
-   *  and then awaits its configuration round trips, and the row lands later still, so a runtime
-   *  that advertises from inside that window would otherwise be reported under the hop's id —
-   *  durably, with nothing to repair it. Runs on every create path; a resumed session keeps the
-   *  id its row already carries. */
-  bindOutwardSessionId?: (acpSessionId: string) => Promise<void> | void
+  /** Mint this slot's OUTWARD id (session-concept.md §1.1) and hand back the binder that pairs the
+   *  runtime's id with it. Awaited BEFORE `session/new` is issued, so the binder itself is
+   *  synchronous: the host makes the session live and then awaits its configuration round trips,
+   *  and the row lands later still, so a runtime advertising from inside that window would
+   *  otherwise be reported under the hop's id — durably, with nothing to repair it. Anything
+   *  awaited at the response instead would widen the gap where such an update is dropped
+   *  outright. Runs on every create path; a resumed session keeps the id its row carries. */
+  prepareOutwardBinding?: () => Promise<(acpSessionId: string) => void>
   signal?: AbortSignal
   abortable: <T>(start: () => PromiseLike<T> | T, signal?: AbortSignal) => Promise<T>
   interrupted: (signal: AbortSignal) => Error
@@ -116,14 +117,12 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
     fallbackMcpServers?: McpServer[]
   ): Promise<string> => {
     const additionalDirectories = await input.workspaceDirectories(cwd)
+    const bindOutward = await input.prepareOutwardBinding?.()
     while (true) {
       const selected = await sessionStartEffort()
       const create = (servers: McpServer[]) =>
         abortable(
-          () =>
-            host.newSession(cwd, servers, selected.value, systemAppend, additionalDirectories, (acpSessionId) =>
-              input.bindOutwardSessionId?.(acpSessionId)
-            ),
+          () => host.newSession(cwd, servers, selected.value, systemAppend, additionalDirectories, bindOutward),
           signal
         )
       const sessionId = await withAdditionalMcpFallback(

--- a/packages/daemon/src/session/turn/runtime-session.ts
+++ b/packages/daemon/src/session/turn/runtime-session.ts
@@ -56,6 +56,12 @@ export interface OpenRuntimeSessionInput {
   metaContext?: () => Promise<string | undefined>
   resumeSystemContext?: () => Promise<string | undefined>
   usesMeta: boolean
+  /** Bind the runtime's brand-new session id to this slot's OUTWARD one (session-concept.md §1.1)
+   *  the instant it exists. `newSession()` makes the ACP session live — and able to stream updates
+   *  — before the row that would carry the mapping is written, so anything reported in that window
+   *  could otherwise only name the hop. Called for a created session; a resumed one already has
+   *  its row. */
+  bindOutwardSessionId?: (acpSessionId: string) => Promise<void> | void
   signal?: AbortSignal
   abortable: <T>(start: () => PromiseLike<T> | T, signal?: AbortSignal) => Promise<T>
   interrupted: (signal: AbortSignal) => Error
@@ -164,6 +170,7 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
       input.additionalMcpServers?.length ? ordinaryMcpServers : undefined
     )
     created = true
+    await input.bindOutwardSessionId?.(acpSessionId)
     rec = {
       key: identity.key,
       agentId: identity.agentId,

--- a/packages/daemon/src/session/turn/runtime-session.ts
+++ b/packages/daemon/src/session/turn/runtime-session.ts
@@ -57,10 +57,11 @@ export interface OpenRuntimeSessionInput {
   resumeSystemContext?: () => Promise<string | undefined>
   usesMeta: boolean
   /** Bind the runtime's brand-new session id to this slot's OUTWARD one (session-concept.md §1.1)
-   *  the instant it exists. `newSession()` makes the ACP session live — and able to stream updates
-   *  — before the row that would carry the mapping is written, so anything reported in that window
-   *  could otherwise only name the hop. Called for a created session; a resumed one already has
-   *  its row. */
+   *  at the raw `session/new` response, before the session is reachable. The host makes it live
+   *  and then awaits its configuration round trips, and the row lands later still, so a runtime
+   *  that advertises from inside that window would otherwise be reported under the hop's id —
+   *  durably, with nothing to repair it. Runs on every create path; a resumed session keeps the
+   *  id its row already carries. */
   bindOutwardSessionId?: (acpSessionId: string) => Promise<void> | void
   signal?: AbortSignal
   abortable: <T>(start: () => PromiseLike<T> | T, signal?: AbortSignal) => Promise<T>
@@ -118,7 +119,13 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
     while (true) {
       const selected = await sessionStartEffort()
       const create = (servers: McpServer[]) =>
-        abortable(() => host.newSession(cwd, servers, selected.value, systemAppend, additionalDirectories), signal)
+        abortable(
+          () =>
+            host.newSession(cwd, servers, selected.value, systemAppend, additionalDirectories, (acpSessionId) =>
+              input.bindOutwardSessionId?.(acpSessionId)
+            ),
+          signal
+        )
       const sessionId = await withAdditionalMcpFallback(
         () => create(mcpServers),
         fallbackMcpServers ? () => create(fallbackMcpServers) : undefined
@@ -170,7 +177,6 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
       input.additionalMcpServers?.length ? ordinaryMcpServers : undefined
     )
     created = true
-    await input.bindOutwardSessionId?.(acpSessionId)
     rec = {
       key: identity.key,
       agentId: identity.agentId,

--- a/packages/daemon/src/session/turn/standing-context.ts
+++ b/packages/daemon/src/session/turn/standing-context.ts
@@ -57,7 +57,7 @@ export type StandingContextInput = {
   slackSelfId?: string
   thread: string
   /** This session's own ACP id, once minted (absent on the turn that mints it). */
-  acpSessionId?: string | null
+  sessionId?: string | null
   /** The parent session to reply into, when this session was woken by another. */
   parentSessionId?: string | null
   /** Key NAMES (never values) of the agent's write-only env secrets. */
@@ -140,13 +140,12 @@ function buildAgentMeta(input: StandingContextInput): string {
     // Best-effort and async, so it can be absent for a brand-new channel until resolution
     // catches up — then the id line alone stands.
     ...(input.channelName ? [`- Channel name: ${input.channelName}`] : []),
-    // session-concept §2.3: standing locator lines. `Thread` is this session's thread
-    // segment; `Session` is its own stable id (only once minted — a brand-new session
-    // mints its acpSessionId AFTER this block is composed, so it appears from the next
-    // turn / on resume); `Parent session` appears ONLY when this session has a parent
-    // (woken by another session's `sendMessage`) and is the SessionTarget to reply into.
+    // session-concept §2.3: standing locator lines. `Thread` is this session's thread segment;
+    // `Session` is its own OUTWARD id (§1.1), minted when the slot resolves, so it is there from
+    // the first turn; `Parent session` appears ONLY when this session has a parent (woken by
+    // another session's `sendMessage`) and is the SessionTarget to reply into.
     `- Thread: ${input.thread}`,
-    ...(input.acpSessionId ? [`- Session: ${input.acpSessionId}`] : []),
+    ...(input.sessionId ? [`- Session: ${input.sessionId}`] : []),
     ...(input.parentSessionId ? [`- Parent session: ${input.parentSessionId}`] : []),
     ...(input.agentDescription ? ['', input.agentDescription] : []),
     // Key NAMES (never values) of the agent's write-only secrets. The values are merged into

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1486,6 +1486,13 @@ export class LocalStore {
    * dream / memory / commit work under `internal:*` keys — leaves nothing behind that looks like
    * one. Idempotent without depending on a driver's `changes`, since a pool's members share one
    * store: each step is a no-op for the loser and the final read settles who won.
+   *
+   * THE SESSION ROW WINS. A full insert can land between the first read and the stage — its own
+   * id already generated, since the stage it would have adopted did not exist yet — and the
+   * adopting UPDATE below then finds nothing to fill. Answering with the stage there would split
+   * one session's identity in two: the credential under one name, its metadata and usage under
+   * another, which is the very failure this column exists to end. So the row is re-read after the
+   * UPDATE, and where it disagrees the stage is settled onto it.
    */
   async ensureOutwardSessionId(key: string, agentId?: string, now = Date.now()): Promise<string> {
     const onSession = (
@@ -1503,6 +1510,14 @@ export class LocalStore {
     if (!minted) throw new Error(`could not mint an outward session id for ${key}`)
     // A session row written before this column existed adopts the mint rather than a second name.
     await this.db.prepare('UPDATE sessions SET sessionId = ? WHERE key = ? AND sessionId IS NULL').run(minted, key)
+    const settled = (
+      (await this.db.prepare('SELECT sessionId FROM sessions WHERE key = ?').get(key)) as
+        { sessionId: string | null } | undefined
+    )?.sessionId
+    if (settled && settled !== minted) {
+      await this.db.prepare('UPDATE session_outward_ids SET sessionId = ? WHERE key = ?').run(settled, key)
+      return settled
+    }
     return minted
   }
 

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type { SQLInputValue } from 'node:sqlite'
 import { chmodSync, mkdirSync, statSync } from 'node:fs'
 import { dirname } from 'node:path'
@@ -199,7 +200,11 @@ export interface SessionRecord {
   thread: string
   /** Opaque physical-bot scope for transcript/session lookup isolation. */
   transportScope?: string | null
+  /** What the RUNTIME knows this session by, used on the ACP hop alone (§1.1). Null until it exists. */
   acpSessionId: string | null
+  /** The session's OUTWARD identity (§1.1), minted when the slot resolves — so it exists before
+   *  the runtime does. Null only on a pre-v12 row that had no ACP id to backfill from. */
+  sessionId?: string | null
   // §7.3 session lifecycle. `prompting` ⇒ a turn is in flight; `cancelling` ⇒
   // a `!stop` was issued and we're awaiting the agent (with a force backstop);
   // `resuming` ⇒ re-attaching a persisted session after a restart/host eviction;
@@ -729,7 +734,7 @@ function restrictPath(path: string, mode: number): void {
  * change that edits a `CREATE TABLE` below, and append the matching step to
  * {@link SCHEMA_MIGRATIONS}.
  */
-const SCHEMA_VERSION = 11
+const SCHEMA_VERSION = 12
 
 /**
  * Ordered in-place upgrades for a store created by an EARLIER daemon.
@@ -847,7 +852,14 @@ const SCHEMA_MIGRATIONS: ((db: StoreTx, store: { shared: boolean }) => Promise<v
       DROP TABLE transcript_recipient;
       ALTER TABLE transcript_recipient_orged RENAME TO transcript_recipient;
     `)
-  }
+  },
+  // The outward id (§1.1), split from the ACP hop's. Existing sessions are backfilled with the id
+  // they already answer to, so nothing the CP or the console knows changes name.
+  async (db) =>
+    await db.exec(`
+      ALTER TABLE sessions ADD COLUMN sessionId TEXT;
+      UPDATE sessions SET sessionId = acpSessionId WHERE acpSessionId IS NOT NULL;
+    `)
 ]
 
 export class LocalStore {
@@ -938,7 +950,7 @@ export class LocalStore {
     await this.db.exec(`
       CREATE TABLE IF NOT EXISTS sessions (
         key TEXT PRIMARY KEY, agentId TEXT, platform TEXT, channel TEXT, thread TEXT,
-        transportScope TEXT, acpSessionId TEXT, state TEXT, lastDeliveredTs TEXT, updatedAt INTEGER,
+        transportScope TEXT, acpSessionId TEXT, sessionId TEXT, state TEXT, lastDeliveredTs TEXT, updatedAt INTEGER,
         usage TEXT, muted INTEGER, triggeredBy TEXT, title TEXT, threadUrl TEXT, modelOverride TEXT,
         observedModel TEXT, observedModelSet INTEGER NOT NULL DEFAULT 0,
         effortOverride TEXT, permissionModeOverride TEXT, fastModeOverride INTEGER,
@@ -1448,6 +1460,33 @@ export class LocalStore {
     return (await this.db.prepare('SELECT * FROM sessions WHERE key = ?').get(key)) as SessionRecord | undefined
   }
 
+  /**
+   * The slot's OUTWARD session id (§1.1), minted on first ask and stable for the slot's life.
+   * Asked before a credential is issued — earlier than the runtime, so earlier than any ACP id.
+   *
+   * Idempotent without depending on a driver's `changes`: a pool's members share one store and
+   * two of them can reach this for one slot at the same instant, so each step is a no-op for the
+   * loser and the final read settles who won. `upsertSession` keeps an existing id, so the
+   * skeleton row a first mint may create survives the turn that writes the session proper.
+   */
+  async ensureOutwardSessionId(key: string, agentId?: string): Promise<string> {
+    const read = async (): Promise<string | undefined> =>
+      (
+        (await this.db.prepare('SELECT sessionId FROM sessions WHERE key = ?').get(key)) as
+          { sessionId: string | null } | undefined
+      )?.sessionId ?? undefined
+    const existing = await read()
+    if (existing) return existing
+    const minted = randomUUID()
+    // The row may not exist yet: a brand-new session mints its credential before the turn writes
+    // the session. Carry the agent so even that momentary row is attributable.
+    await this.db
+      .prepare('INSERT OR IGNORE INTO sessions (key, agentId, sessionId, updatedAt) VALUES (?, ?, ?, ?)')
+      .run(key, agentId ?? null, minted, Date.now())
+    await this.db.prepare('UPDATE sessions SET sessionId = ? WHERE key = ? AND sessionId IS NULL').run(minted, key)
+    return (await read()) ?? minted
+  }
+
   async createPermissionRequest(record: PermissionRequestRecord): Promise<void> {
     await this.db
       .prepare(
@@ -1681,6 +1720,17 @@ export class LocalStore {
     return (await this.db
       .prepare('SELECT * FROM sessions WHERE agentId = ? AND acpSessionId = ?')
       .get(agentId, acpSessionId)) as SessionRecord | undefined
+  }
+
+  /** Resolve a slot from the id the OUTSIDE world addresses it by (session-concept.md §1.1).
+   *  Falls back to the ACP id so a caller still holding the runtime's name — and a control
+   *  plane that recorded one before the outward column existed — still lands on the session. */
+  async getSessionByOutwardId(sessionId: string, agentId?: string): Promise<SessionRecord | undefined> {
+    const scope = agentId === undefined ? '' : ' AND agentId = @agentId'
+    const params = { sessionId, ...(agentId === undefined ? {} : { agentId }) }
+    return ((await this.db.prepare(`SELECT * FROM sessions WHERE sessionId = @sessionId${scope}`).get(params)) ??
+      (await this.db.prepare(`SELECT * FROM sessions WHERE acpSessionId = @sessionId${scope}`).get(params))) as
+      SessionRecord | undefined
   }
 
   /**
@@ -1976,16 +2026,17 @@ export class LocalStore {
     await this.db
       .prepare(
         `INSERT INTO sessions
-           (key, agentId, platform, channel, thread, transportScope, acpSessionId, state, lastDeliveredTs, updatedAt, muted, triggeredBy, threadUrl, memoryProvider, workspaceIsolation, originSessionId, needsParentReply,
+           (key, sessionId, agentId, platform, channel, thread, transportScope, acpSessionId, state, lastDeliveredTs, updatedAt, muted, triggeredBy, threadUrl, memoryProvider, workspaceIsolation, originSessionId, needsParentReply,
             externalProvider, externalRealmKey, externalResourceKind, externalResourceKey, externalIntegrationId,
             externalOriginJson, sourceBindingKind)
          VALUES
-           (@key, @agentId, @platform, @channel, @thread, @transportScope, @acpSessionId, @state, @lastDeliveredTs, @updatedAt,
+           (@key, @sessionId, @agentId, @platform, @channel, @thread, @transportScope, @acpSessionId, @state, @lastDeliveredTs, @updatedAt,
             CASE WHEN EXISTS (SELECT 1 FROM session_mutes WHERE key = @key) THEN 1 ELSE NULL END,
             @triggeredBy, @threadUrl, @memoryProvider, @workspaceIsolation, @originSessionId, @needsParentReply,
             @externalProvider, @externalRealmKey, @externalResourceKind, @externalResourceKey, @externalIntegrationId,
             @externalOriginJson, @sourceBindingKind)
          ON CONFLICT(key) DO UPDATE SET
+           sessionId=COALESCE(sessions.sessionId, excluded.sessionId),
            acpSessionId=excluded.acpSessionId, state=excluded.state,
            lastDeliveredTs=excluded.lastDeliveredTs, updatedAt=excluded.updatedAt,
            transportScope=excluded.transportScope,
@@ -2020,6 +2071,7 @@ export class LocalStore {
       )
       .run({
         key: rec.key,
+        sessionId: rec.sessionId ?? randomUUID(),
         agentId: rec.agentId,
         platform: rec.platform,
         channel: rec.channel,
@@ -2127,10 +2179,13 @@ export class LocalStore {
 
   /** The one agent holding this ACP id locally, or undefined when none or several
    *  do — how a push from a CP too old to name the agent is attributed. */
-  async soleAgentForAcpSession(acpSessionId: string): Promise<string | undefined> {
+  async soleAgentForAcpSession(sessionId: string): Promise<string | undefined> {
     const rows = (await this.db
-      .prepare('SELECT DISTINCT agentId FROM sessions WHERE acpSessionId = ? AND agentId IS NOT NULL LIMIT 2')
-      .all(acpSessionId)) as { agentId: string }[]
+      .prepare(
+        `SELECT DISTINCT agentId FROM sessions
+         WHERE (sessionId = @sessionId OR acpSessionId = @sessionId) AND agentId IS NOT NULL LIMIT 2`
+      )
+      .all({ sessionId })) as { agentId: string }[]
     return rows.length === 1 ? rows[0]!.agentId : undefined
   }
 
@@ -2642,17 +2697,20 @@ export class LocalStore {
       // fact "this session's content is gone" must not be able to exist without
       // the report that carries it, in either direction. Only a session that bound
       // an ACP id was ever reported to the CP, so only that one has a row to mark.
+      // How the CONTROL PLANE knows this session (§1.1): the id its receipt marks and its outbox
+      // row is keyed by. A pre-v12 row answers with its ACP id, which is what it was reported under.
+      const outward = rec.sessionId ?? rec.acpSessionId
       // OR IGNORE keeps the FIRST stamp if a still-unacked receipt is somehow
       // re-created for the same id — the console should show when the content
       // actually went away, not when the daemon last retried.
       if (purge && rec.acpSessionId) {
-        // Stamped to the deleting member on a shared store: its drain owns the receipt.
+        // Stamped to the deleting member on a shared store: its drain owns it.
         await tx
           .prepare(
             `INSERT OR IGNORE INTO session_purges (agentId, sessionId, reason, purgedAt, ownerId, claimedAt)
              VALUES (?, ?, ?, ?, ?, ?)`
           )
-          .run(rec.agentId, rec.acpSessionId, purge.reason, purge.at, purge.ownerId ?? null, purge.at)
+          .run(rec.agentId, outward, purge.reason, purge.at, purge.ownerId ?? null, purge.at)
       }
       await tx.prepare('DELETE FROM sessions WHERE key = ?').run(key)
       await tx.prepare('DELETE FROM session_mutes WHERE key = ?').run(key)
@@ -2663,7 +2721,7 @@ export class LocalStore {
         // obsolete snapshot; an existing CP row is handled by session_purges.
         await tx
           .prepare('DELETE FROM session_metadata_outbox WHERE agentId = ? AND sessionId = ?')
-          .run(rec.agentId, rec.acpSessionId)
+          .run(rec.agentId, outward)
         await tx
           .prepare('DELETE FROM session_gates WHERE agentId = ? AND acpSessionId = ?')
           .run(rec.agentId, rec.acpSessionId)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -3370,7 +3370,11 @@ export class LocalStore {
   > {
     const rows = (await this.db
       .prepare(
-        `SELECT acpSessionId AS sessionId, channel, thread, transportScope, updatedAt FROM sessions
+        // Outward ids (§1.1): these become the citations the model grounds a skill candidate in,
+        // and from there the dream's durable, CP-visible provenance. A pre-v12 row answers with
+        // its ACP id, which is what that session was reported under.
+        `SELECT COALESCE(sessionId, acpSessionId) AS sessionId, channel, thread, transportScope, updatedAt
+         FROM sessions
          WHERE agentId = ? AND acpSessionId IS NOT NULL AND platform <> 'dream'
          ORDER BY updatedAt DESC LIMIT ?`
       )

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -859,6 +859,12 @@ const SCHEMA_MIGRATIONS: ((db: StoreTx, store: { shared: boolean }) => Promise<v
     await db.exec(`
       ALTER TABLE sessions ADD COLUMN sessionId TEXT;
       UPDATE sessions SET sessionId = acpSessionId WHERE acpSessionId IS NOT NULL;
+      CREATE TABLE IF NOT EXISTS session_outward_ids (
+        key TEXT PRIMARY KEY,
+        agentId TEXT,
+        sessionId TEXT NOT NULL,
+        mintedAt INTEGER NOT NULL
+      );
     `)
 ]
 
@@ -1010,6 +1016,16 @@ export class LocalStore {
         ON session_metadata_outbox (queuedAt);
       CREATE INDEX IF NOT EXISTS session_metadata_outbox_attempt
         ON session_metadata_outbox (nextAttemptAt, queuedAt);
+      -- Outward session ids minted BEFORE their session row exists — a credential is issued to
+      -- start the runtime, and the turn writes the session only once it dispatches (§1.1). The
+      -- insert adopts the mint, so this table holds only what has not become a session yet: an
+      -- in-flight slot, or an internal:* key (dream / memory / commit) that never will.
+      CREATE TABLE IF NOT EXISTS session_outward_ids (
+        key TEXT PRIMARY KEY,
+        agentId TEXT,
+        sessionId TEXT NOT NULL,
+        mintedAt INTEGER NOT NULL
+      );
       -- Retention-GC receipts (#485): sessions this daemon has already deleted
       -- locally, still owed to the CP as an event/session-purged report. Durable
       -- because the local row is GONE — unlike every other D→C report, an
@@ -1462,29 +1478,32 @@ export class LocalStore {
 
   /**
    * The slot's OUTWARD session id (§1.1), minted on first ask and stable for the slot's life.
-   * Asked before a credential is issued — earlier than the runtime, so earlier than any ACP id.
+   * Asked before a credential is issued — earlier than the runtime, so earlier than any ACP id,
+   * and usually earlier than the session ROW, which the turn writes only once it dispatches.
    *
-   * Idempotent without depending on a driver's `changes`: a pool's members share one store and
-   * two of them can reach this for one slot at the same instant, so each step is a no-op for the
-   * loser and the final read settles who won. `upsertSession` keeps an existing id, so the
-   * skeleton row a first mint may create survives the turn that writes the session proper.
+   * A mint therefore lands in `session_outward_ids`, never in a half-built `sessions` row: the
+   * turn's own insert adopts it, and a key that never becomes a session — the pool also runs
+   * dream / memory / commit work under `internal:*` keys — leaves nothing behind that looks like
+   * one. Idempotent without depending on a driver's `changes`, since a pool's members share one
+   * store: each step is a no-op for the loser and the final read settles who won.
    */
-  async ensureOutwardSessionId(key: string, agentId?: string): Promise<string> {
-    const read = async (): Promise<string | undefined> =>
-      (
-        (await this.db.prepare('SELECT sessionId FROM sessions WHERE key = ?').get(key)) as
-          { sessionId: string | null } | undefined
-      )?.sessionId ?? undefined
-    const existing = await read()
-    if (existing) return existing
-    const minted = randomUUID()
-    // The row may not exist yet: a brand-new session mints its credential before the turn writes
-    // the session. Carry the agent so even that momentary row is attributable.
+  async ensureOutwardSessionId(key: string, agentId?: string, now = Date.now()): Promise<string> {
+    const onSession = (
+      (await this.db.prepare('SELECT sessionId FROM sessions WHERE key = ?').get(key)) as
+        { sessionId: string | null } | undefined
+    )?.sessionId
+    if (onSession) return onSession
     await this.db
-      .prepare('INSERT OR IGNORE INTO sessions (key, agentId, sessionId, updatedAt) VALUES (?, ?, ?, ?)')
-      .run(key, agentId ?? null, minted, Date.now())
+      .prepare('INSERT OR IGNORE INTO session_outward_ids (key, agentId, sessionId, mintedAt) VALUES (?, ?, ?, ?)')
+      .run(key, agentId ?? null, randomUUID(), now)
+    const minted = (
+      (await this.db.prepare('SELECT sessionId FROM session_outward_ids WHERE key = ?').get(key)) as
+        { sessionId: string } | undefined
+    )?.sessionId
+    if (!minted) throw new Error(`could not mint an outward session id for ${key}`)
+    // A session row written before this column existed adopts the mint rather than a second name.
     await this.db.prepare('UPDATE sessions SET sessionId = ? WHERE key = ? AND sessionId IS NULL').run(minted, key)
-    return (await read()) ?? minted
+    return minted
   }
 
   async createPermissionRequest(record: PermissionRequestRecord): Promise<void> {
@@ -1786,15 +1805,17 @@ export class LocalStore {
 
   /** Addressable session ids whose authorized transcript scope may have changed. */
   async sessionIdsForTranscript(agentId: string, channel: string, thread: string): Promise<string[]> {
+    // Outward ids (§1.1): the only consumer is the CP's transcript-activity signal, and the CP
+    // invalidates by the id it filed the session under. A pre-v12 row answers with its ACP id.
     const rows = (await this.db
       .prepare(
-        `SELECT DISTINCT acpSessionId, channel, transportScope FROM sessions
+        `SELECT DISTINCT COALESCE(sessionId, acpSessionId) AS sessionId, channel, transportScope FROM sessions
          WHERE agentId = ? AND thread = ? AND acpSessionId IS NOT NULL`
       )
-      .all(agentId, thread)) as { acpSessionId: string; channel: string; transportScope: string | null }[]
+      .all(agentId, thread)) as { sessionId: string; channel: string; transportScope: string | null }[]
     return rows
       .filter((row) => transcriptChannelKey(row.channel, row.transportScope) === channel)
-      .map((row) => row.acpSessionId)
+      .map((row) => row.sessionId)
   }
 
   async currentTranscriptRevision(agentId?: string, orgId?: string): Promise<number> {
@@ -2030,13 +2051,20 @@ export class LocalStore {
             externalProvider, externalRealmKey, externalResourceKind, externalResourceKey, externalIntegrationId,
             externalOriginJson, sourceBindingKind)
          VALUES
-           (@key, @sessionId, @agentId, @platform, @channel, @thread, @transportScope, @acpSessionId, @state, @lastDeliveredTs, @updatedAt,
+           (@key, COALESCE((SELECT sessionId FROM session_outward_ids WHERE key = @key), @sessionId), @agentId, @platform, @channel, @thread, @transportScope, @acpSessionId, @state, @lastDeliveredTs, @updatedAt,
             CASE WHEN EXISTS (SELECT 1 FROM session_mutes WHERE key = @key) THEN 1 ELSE NULL END,
             @triggeredBy, @threadUrl, @memoryProvider, @workspaceIsolation, @originSessionId, @needsParentReply,
             @externalProvider, @externalRealmKey, @externalResourceKind, @externalResourceKey, @externalIntegrationId,
             @externalOriginJson, @sourceBindingKind)
          ON CONFLICT(key) DO UPDATE SET
            sessionId=COALESCE(sessions.sessionId, excluded.sessionId),
+           -- The key's own components. A row this daemon minted an outward id into before the
+           -- session existed (ensureOutwardSessionId) carries none of them, and they are immutable
+           -- once written, so COALESCE hydrates that skeleton exactly once and never rewrites a
+           -- real row. Without this the session could not be read back from its own coordinates.
+           platform=COALESCE(sessions.platform, excluded.platform),
+           channel=COALESCE(sessions.channel, excluded.channel),
+           thread=COALESCE(sessions.thread, excluded.thread),
            acpSessionId=excluded.acpSessionId, state=excluded.state,
            lastDeliveredTs=excluded.lastDeliveredTs, updatedAt=excluded.updatedAt,
            transportScope=excluded.transportScope,
@@ -2713,6 +2741,9 @@ export class LocalStore {
           .run(rec.agentId, outward, purge.reason, purge.at, purge.ownerId ?? null, purge.at)
       }
       await tx.prepare('DELETE FROM sessions WHERE key = ?').run(key)
+      // Its identity goes with it: the receipt just reported this id as purged, so the next
+      // session on the same slot must be a new one, not this one's name reused.
+      await tx.prepare('DELETE FROM session_outward_ids WHERE key = ?').run(key)
       await tx.prepare('DELETE FROM session_mutes WHERE key = ?').run(key)
       await tx.prepare('DELETE FROM inbox WHERE sessionKey = ? AND terminalReport IS NULL').run(key)
       if (rec.acpSessionId) {

--- a/packages/daemon/src/store/retention.ts
+++ b/packages/daemon/src/store/retention.ts
@@ -88,6 +88,18 @@ export const STORE_RETENTION_RULES: readonly StoreRetentionRule[] = [
     horizonMs: DEFAULT_STORE_HORIZON_MS
   },
   {
+    // An outward id minted before its session row exists (§1.1). The turn's insert adopts it and
+    // `deleteSession` drops it, so what ages out here is a slot whose turn never dispatched, or an
+    // `internal:*` key — dream / memory / commit work that never becomes a session at all. Aging
+    // one out is safe: the session, if it exists, answers with its own column first.
+    id: 'outward-id',
+    table: 'session_outward_ids',
+    key: ['key'],
+    clock: 'mintedAt',
+    agentColumn: 'agentId',
+    horizonMs: DEFAULT_STORE_HORIZON_MS
+  },
+  {
     id: 'session-metadata',
     table: 'session_metadata_outbox',
     key: ['agentId', 'sessionId'],

--- a/packages/daemon/src/store/session-metadata-outbox.ts
+++ b/packages/daemon/src/store/session-metadata-outbox.ts
@@ -99,13 +99,15 @@ export class SessionMetadataOutbox {
     // live send still depends on a constructed client.
     if (!cpClient && !this.host.controlPlaneConfigured()) return
     const now = new Date(this.host.clock().now()).toISOString()
-    const row = await this.sessionListProjection(input.sessionId, input.agentId)
-    const key = row?.sessionKey
-    // Callers hold the ACP hop's id; the wire carries the session's outward one (session-concept.md §1.1).
+    // Callers hold the ACP hop's id; the wire carries the session's outward one (§1.1).
     const slot = await store.getSessionByAcpIdForAgent(input.agentId, input.sessionId)
     // An unresolvable slot keeps the id it was given — the same thing a pre-v12 daemon would have sent.
     const outwardSessionId =
-      slot?.sessionId ?? (slot ? await store.ensureOutwardSessionId(slot.key, input.agentId) : input.sessionId)
+      slot?.sessionId ??
+      (slot ? await store.ensureOutwardSessionId(slot.key, input.agentId, this.host.clock().now()) : input.sessionId)
+    // The projection speaks the same outward language the wire does, so it is looked up that way.
+    const row = await this.sessionListProjection(outwardSessionId, input.agentId)
+    const key = row?.sessionKey
     const event: EventSession = {
       sessionId: outwardSessionId,
       agentId: input.agentId,

--- a/packages/daemon/src/store/session-metadata-outbox.ts
+++ b/packages/daemon/src/store/session-metadata-outbox.ts
@@ -101,13 +101,18 @@ export class SessionMetadataOutbox {
     const now = new Date(this.host.clock().now()).toISOString()
     const row = await this.sessionListProjection(input.sessionId, input.agentId)
     const key = row?.sessionKey
+    // Callers hold the ACP hop's id; the wire carries the session's outward one (session-concept.md §1.1).
+    const slot = await store.getSessionByAcpIdForAgent(input.agentId, input.sessionId)
+    // An unresolvable slot keeps the id it was given — the same thing a pre-v12 daemon would have sent.
+    const outwardSessionId =
+      slot?.sessionId ?? (slot ? await store.ensureOutwardSessionId(slot.key, input.agentId) : input.sessionId)
     const event: EventSession = {
-      sessionId: input.sessionId,
+      sessionId: outwardSessionId,
       agentId: input.agentId,
       phase: input.phase,
       platform: key?.platform ?? input.platform,
       channel: key?.channel ?? input.channel,
-      link: this.host.sessionLink(input.sessionId),
+      link: this.host.sessionLink(outwardSessionId),
       lastActivityAt: row?.lastActivityAt ?? now,
       ts: now
     }
@@ -203,7 +208,9 @@ export class SessionMetadataOutbox {
       pending =
         (await store.saveSessionMetadataSnapshot(
           input.agentId,
-          input.sessionId,
+          // The obligation belongs to the SESSION, so the row is keyed by its outward id — a
+          // rebuilt ACP hop updates the same pending snapshot instead of opening a second one.
+          outwardSessionId,
           JSON.stringify(snapshot),
           input.phase !== 'plan',
           this.host.clock().now(),

--- a/packages/daemon/src/webchat/transport.ts
+++ b/packages/daemon/src/webchat/transport.ts
@@ -345,10 +345,10 @@ export class WebchatTransport {
       if (startFailure) return { accepted: false, turnId, reason: 'start_failed', detail: startFailure }
       return { accepted: false, turnId, reason: 'no_agent' }
     }
-    // ACP ids are runtime-owned: resolve agent-scoped, and use ONLY the local
-    // row's coordinates. A miss means the CP verdict is stale (retention GC /
-    // metadata replacement) — fail closed.
-    const local = await this.host.store().getSessionByAcpIdForAgent(agentId, targetSessionId)
+    // The console names the target session outwardly (session-concept.md §1.1). Resolve
+    // agent-scoped, and use ONLY the local row's coordinates. A miss means the CP verdict is
+    // stale (retention GC / metadata replacement) — fail closed.
+    const local = await this.host.store().getSessionByOutwardId(targetSessionId, agentId)
     if (!local || originKindOf(local.platform) !== 'chat') return { accepted: false, turnId, reason: 'not_found' }
     if (this.host.paused(agentId)) return { accepted: false, turnId, reason: 'paused' }
     if (this.host.safetyDraining(agentId)) return { accepted: false, turnId, reason: 'busy' }

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -35,6 +35,24 @@ describe('AcpHost (against a fake ACP agent)', () => {
     await host.stop()
   }, 15_000)
 
+  // A runtime can advertise from inside `newSession()`: the host makes the session ownable and
+  // then awaits its configuration round trips. Whatever the daemon needs in order to name that
+  // session must therefore be handed over at the RAW response, before it is reachable.
+  it('announces a new session id before the session becomes reachable', async () => {
+    const host = new AcpHost({ command: process.execPath, args: [fakeAgent], env: [] }, { onUpdate: () => {} })
+    await host.start()
+    let reachableWhenAnnounced: boolean | undefined
+    let announced: string | undefined
+    const sessionId = await host.newSession('/tmp', [], undefined, undefined, [], (id) => {
+      announced = id
+      reachableWhenAnnounced = host.hasSession(id)
+    })
+    expect(announced).toBe(sessionId)
+    expect(reachableWhenAnnounced).toBe(false)
+    expect(host.hasSession(sessionId)).toBe(true)
+    await host.stop()
+  }, 15_000)
+
   it('applies and switches the composite Auto permission preset through independent selectors', async () => {
     const host = new AcpHost(
       { command: process.execPath, args: [fakeAgent], env: [] },

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -951,7 +951,11 @@ describe('CpClient dispatch', () => {
       Date.parse('2026-06-26T00:00:00.000Z')
     )
     const { t } = await readyClient({
-      runtimeCommandsReader: createRuntimeCommandsReader(commands, (id) => id === 'a1')
+      runtimeCommandsReader: createRuntimeCommandsReader(
+        commands,
+        (id) => id === 'a1',
+        async (_a, acp) => acp
+      )
     })
     const f = JSON.parse(frame('runtime/commands', { agentId: 'a1' }, { epoch: 5 }))
     t.pushInbound(JSON.stringify(f))
@@ -969,7 +973,11 @@ describe('CpClient dispatch', () => {
 
   it('replies runtime/commands/list with reported:false before any advertisement', async () => {
     const { t } = await readyClient({
-      runtimeCommandsReader: createRuntimeCommandsReader(new RuntimeCommandsCache(), () => true)
+      runtimeCommandsReader: createRuntimeCommandsReader(
+        new RuntimeCommandsCache(),
+        () => true,
+        async (_a, acp) => acp
+      )
     })
     t.pushInbound(frame('runtime/commands', { agentId: 'a1' }, { epoch: 5 }))
     await tick()

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -936,6 +936,8 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
         channel: 'C1',
         thread: '1720000000.000100',
         acpSessionId: 'acp-parent-1',
+        // Lineage travels by the OUTWARD id (session-concept.md §1.1), so seed one that differs.
+        sessionId: 'sid-parent-1',
         state: 'idle',
         lastDeliveredTs: null,
         updatedAt: Date.now()
@@ -945,7 +947,7 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
       expect(calls).toHaveLength(1)
       expect(calls[0]!.callMeta).toMatchObject({
         callFrom: 'bot-a',
-        originSessionId: 'acp-parent-1',
+        originSessionId: 'sid-parent-1',
         needsReply: true
       })
       expect(await (daemon as any).store.getActivation(pairingKey(daemon))).toMatchObject({

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1480,7 +1480,10 @@ describe('Slack interactive status bar', () => {
     const section = blocks.find((b) => b.type === 'section')!
     expect(blocks).toHaveLength(1)
     expect(section.text!.text).toContain('opus-4.8')
-    expect(section.text!.text).toContain('<http://localhost:3000/sessions/acp-1?source=slack|View Session>')
+    // The deep link names the session outwardly (session-concept.md §1.1), not the runtime's id.
+    const outward = (await (daemon as any).store.getSessionByAcpId('acp-1'))!.sessionId
+    expect(outward).not.toBe('acp-1')
+    expect(section.text!.text).toContain(`<http://localhost:3000/sessions/${outward}?source=slack|View Session>`)
     expect(section.accessory.action_id).toBe('ac_more')
     await daemon.stop()
   }, 15_000)
@@ -2200,7 +2203,8 @@ describe('Slack interactive status bar', () => {
     await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
     // The connection queries statusInfoForKey to build the modal; it resolves the deep link.
     const data = await (daemon as any).statusInfoForKey(SESSION_KEY)
-    expect(data.link).toBe('https://console.example.com/sessions/acp-1?source=slack')
+    const outward = (await (daemon as any).store.getSessionByAcpId('acp-1'))!.sessionId
+    expect(data.link).toBe(`https://console.example.com/sessions/${outward}?source=slack`)
     expect(data.info.models).toEqual(['opus-4.8', 'sonnet-5'])
     expect(data.identity).toMatchObject({
       name: AGENT_IDENTITY.displayName,

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -7,6 +7,12 @@ import { Daemon } from '../src/daemon.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT } from '../src/memory/distill.js'
 import { EvaluationEventCollector } from '../src/evaluation/index.js'
 
+// The outward `sessionId` a frame carries for the slot behind an ACP hop id (session-concept.md §1.1).
+const outwardId = async (daemon: any, acpSessionId: string): Promise<string> => {
+  const slot = await daemon.store.getSessionByAcpId(acpSessionId)
+  return slot!.sessionId ?? (await daemon.store.ensureOutwardSessionId(slot!.key, slot!.agentId ?? undefined))
+}
+
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
 // Give every poll in this file the same generous budget instead.
@@ -279,7 +285,7 @@ describe('Daemon evaluation surface', () => {
     // the teardown window is covered by the ignore-cancel test below.
     expect((daemon as any).memoryExtractionQuarantines.size).toBe(0)
     expect(usageReports.at(-1)).toMatchObject({
-      sessionId: 'dream-session-1',
+      sessionId: await outwardId(daemon, 'dream-session-1'),
       agentId: AGENT_ID,
       platform: 'dream',
       channel: 'memory'

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -229,8 +229,12 @@ describe('Daemon evaluation surface', () => {
       expect(dream?.status).toBe('adopted')
     }, WAIT)
 
+    // The dream row names its execution session outwardly (§1.1), stored at write time so the
+    // record keeps one identity after the session itself is purged.
+    const outwardExecution = (await (daemon as any).store.getSessionByAcpId('dream-session-1'))!.sessionId
+    expect(outwardExecution).not.toBe('dream-session-1')
     expect(dream).toMatchObject({
-      executionSessionId: 'dream-session-1',
+      executionSessionId: outwardExecution,
       runtime: 'test',
       model: 'test-model',
       stopReason: 'end_turn',
@@ -298,7 +302,8 @@ describe('Daemon evaluation surface', () => {
     })
     expect(collector.events().at(-1)).toMatchObject({
       type: 'memory.dream.skill_accepted',
-      sessionId: 'dream-session-1',
+      // The evaluation event carries the dream's own record, which names its session outwardly.
+      sessionId: outwardExecution,
       data: { dreamId: started.dreamId, skillName: 'deploy-staging' }
     })
     const reviewedHistory = (await (daemon as any).store.threadTranscript('memory', started.dreamId))

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -186,12 +186,16 @@ describe('Daemon rd/msg hook fires', () => {
     expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
 
     await vi.waitFor(() => expect(cp.hookReports.length).toBe(1), WAIT)
+    // The CP files this run against `session_meta.id` and deep-links the console from it, so the
+    // report names the session outwardly (session-concept.md §1.1), never the runtime's id.
+    const outward = (await (daemon as any).store.getSessionByAcpId('acp-hook-1'))!.sessionId
+    expect(outward).not.toBe('acp-hook-1')
     expect(cp.hookReports[0]).toMatchObject({
       hookId: HOOK_ID,
       agentId: AGENT_ID,
       deliveryKey: 'd-1',
       status: 'success',
-      sessionId: 'acp-hook-1'
+      sessionId: outward
     })
     expect(cp.hookReports[0]!.durationMs).toBeGreaterThanOrEqual(0)
     // Exactly one turn ran through the shared engine.
@@ -532,7 +536,7 @@ describe('Daemon rd/msg hook fires', () => {
         hookId: HOOK_ID,
         deliveryKey: 'd-1',
         status: 'failed',
-        sessionId: 'acp-hook-1',
+        sessionId: (await (daemon as any).store.getSessionByAcpId('acp-hook-1'))!.sessionId,
         reason
       })
       await daemon.stop()
@@ -1427,7 +1431,7 @@ describe('Daemon rd/msg hook fires', () => {
         hookId: HOOK_ID,
         deliveryKey: 'd-1',
         status: 'success',
-        sessionId: `acp-${event}`
+        sessionId: (await (daemon as any).store.getSessionByAcpId(`acp-${event}`))!.sessionId
       })
 
       await daemon.stop()

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -987,12 +987,16 @@ describe('Daemon session lifecycle (#118)', () => {
     await vi.waitFor(() => expect(blocked.host.prompt).toHaveBeenCalledWith('acp-1', expect.any(Array)), WAIT)
     expect(emitCronReport).toHaveBeenCalledTimes(2)
     expect(emitCronReport.mock.calls[0]![0]).not.toHaveProperty('sessionId')
-    expect(emitCronReport.mock.calls[1]![0]).toMatchObject({ sessionId: 'acp-1' })
+    // A cron run is a console deep link on the CP side, so it is reported under the session's
+    // outward id (session-concept.md §1.1) — the same one on the ready report and the close.
+    const outward = (await (daemon as any).store.getSessionByAcpId('acp-1'))!.sessionId
+    expect(outward).not.toBe('acp-1')
+    expect(emitCronReport.mock.calls[1]![0]).toMatchObject({ sessionId: outward })
     expect(emitCronReport.mock.calls[1]![0]).not.toHaveProperty('status')
 
     blocked.release()
     await run
-    expect(emitCronReport.mock.calls[2]![0]).toMatchObject({ status: 'success', sessionId: 'acp-1' })
+    expect(emitCronReport.mock.calls[2]![0]).toMatchObject({ status: 'success', sessionId: outward })
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -1898,7 +1898,14 @@ describe('Daemon idle sweep — background-task lease', () => {
   it('projects the lease for task/list — running, done, and a failure refined by a later edge', async () => {
     const clock = new FakeClock()
     const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
-    const list = () => (daemon as any).listBackgroundTasks({ agentId: 'bot-a', sessionId: 'acp-1' })
+    const list = async () => await (daemon as any).listBackgroundTasks({ agentId: 'bot-a', sessionId: 'acp-1' })
+    // The console asks by the id it routed on — the outward one (session-concept.md §1.1) — and
+    // must get the same lease back, since the lease itself is keyed by the runtime's id.
+    const outwardList = async () =>
+      await (daemon as any).listBackgroundTasks({
+        agentId: 'bot-a',
+        sessionId: (await (daemon as any).store.getSessionByAcpId('acp-1'))!.sessionId
+      })
 
     await (daemon as any).onSdkLifecycle(
       'bot-a',
@@ -1915,22 +1922,23 @@ describe('Daemon idle sweep — background-task lease', () => {
     // Live rows, newest start first. The internal subagent is CARRIED, not filtered at the source:
     // it fences reclaim exactly like a real task, so hiding it here would make the panel and the
     // thing deferring reclaim disagree. Consumers filter at render.
-    expect(list().tasks.map((t: any) => [t.id, t.state, t.subagent])).toEqual([
+    expect((await list()).tasks.map((t: any) => [t.id, t.state, t.subagent])).toEqual([
       ['t2', 'running', true],
       ['t1', 'running', false]
     ])
-    expect(list().tracked).toBe(true)
-    expect(list().truncated).toBe(false)
-    expect(list().tasks[1].description).toBe('Sleep 15')
-    expect(list().tasks[1].startedAt).toBe(new Date(0).toISOString()) // the task_started edge's arrival
-    expect(list().tasks[1].endedAt).toBeUndefined() // a live task has not ended
-    expect(list().tasks[0].description).toBeUndefined() // the runtime omitted it
+    expect((await list()).tracked).toBe(true)
+    expect((await outwardList()).tasks.map((t: any) => t.id)).toEqual((await list()).tasks.map((t: any) => t.id))
+    expect((await list()).truncated).toBe(false)
+    expect((await list()).tasks[1].description).toBe('Sleep 15')
+    expect((await list()).tasks[1].startedAt).toBe(new Date(0).toISOString()) // the task_started edge's arrival
+    expect((await list()).tasks[1].endedAt).toBeUndefined() // a live task has not ended
+    expect((await list()).tasks[0].description).toBeUndefined() // the runtime omitted it
 
     // The snapshot settles both and carries NO status, which is the common case — so `done` means
     // "settled without a reported failure", and `detail` stays absent rather than claiming success.
     clock.advance(1000)
     await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('background_tasks_changed', { tasks: [] }))
-    expect(list().tasks.map((t: any) => [t.id, t.state, t.endedAt, t.detail])).toEqual([
+    expect((await list()).tasks.map((t: any) => [t.id, t.state, t.endedAt, t.detail])).toEqual([
       ['t1', 'done', new Date(2000).toISOString(), undefined],
       ['t2', 'done', new Date(2000).toISOString(), undefined]
     ])
@@ -1942,7 +1950,7 @@ describe('Daemon idle sweep — background-task lease', () => {
       'acp-1',
       evt('task_updated', { task_id: 't1', patch: { status: 'failed' } })
     )
-    const refined = list().tasks.find((t: any) => t.id === 't1')
+    const refined = (await list()).tasks.find((t: any) => t.id === 't1')
     expect([refined.state, refined.detail]).toEqual(['failed', 'failed'])
     expect((daemon as any).sdkLease.get(LEASE_KEY).tasks.size).toBe(0)
     expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(false) // t1's own wake, not the record
@@ -1953,7 +1961,7 @@ describe('Daemon idle sweep — background-task lease', () => {
   it('bounds the retained history and the page, and neither bound touches the liveness set', async () => {
     const clock = new FakeClock()
     const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
-    const list = () => (daemon as any).listBackgroundTasks({ agentId: 'bot-a', sessionId: 'acp-1' })
+    const list = async () => await (daemon as any).listBackgroundTasks({ agentId: 'bot-a', sessionId: 'acp-1' })
     // Subagent tasks, so the sweep of settles below neither announces nor wakes — they are retained
     // and counted as live exactly like any other task, which is the point.
     const ids = Array.from({ length: MAX_TASK_LIST_TASKS + 1 }, (_unused, i) => `t${i}`)
@@ -1966,17 +1974,17 @@ describe('Daemon idle sweep — background-task lease', () => {
       )
     }
     expect((daemon as any).sdkLease.get(LEASE_KEY).tasks.size).toBe(MAX_TASK_LIST_TASKS + 1)
-    expect(list().tasks).toHaveLength(MAX_TASK_LIST_TASKS)
-    expect(list().truncated).toBe(true)
+    expect((await list()).tasks).toHaveLength(MAX_TASK_LIST_TASKS)
+    expect((await list()).truncated).toBe(true)
 
     // All settle on one snapshot. Retention keeps the newest MAX_SETTLED_TASKS_PER_SESSION (20) and
     // the liveness set empties completely — the cap evicts history, never a live task.
     await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('background_tasks_changed', { tasks: [] }))
     expect((daemon as any).sdkLease.get(LEASE_KEY).tasks.size).toBe(0)
-    expect(list().tasks).toHaveLength(20)
-    expect(list().truncated).toBe(false)
-    expect(list().tasks.map((t: any) => t.id)).not.toContain('t0') // oldest settle evicted first
-    expect(list().tasks.every((t: any) => t.state === 'done' && t.subagent)).toBe(true)
+    expect((await list()).tasks).toHaveLength(20)
+    expect((await list()).truncated).toBe(false)
+    expect((await list()).tasks.map((t: any) => t.id)).not.toContain('t0') // oldest settle evicted first
+    expect((await list()).tasks.every((t: any) => t.state === 'done' && t.subagent)).toBe(true)
     expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(true) // 20 retained rows, still quiescent
 
     await daemon.stop()
@@ -1988,14 +1996,14 @@ describe('Daemon idle sweep — background-task lease', () => {
 
     // No lease is NOT "no background tasks": a non-Claude runtime and an adapter without the
     // lifecycle extension both land here, and the console says so rather than claiming idleness.
-    expect((daemon as any).listBackgroundTasks({ agentId: 'bot-a', sessionId: 'acp-9' })).toEqual({
+    expect(await (daemon as any).listBackgroundTasks({ agentId: 'bot-a', sessionId: 'acp-9' })).toEqual({
       agentId: 'bot-a',
       sessionId: 'acp-9',
       tracked: false,
       tasks: [],
       truncated: false
     })
-    expect(() => (daemon as any).listBackgroundTasks({ agentId: 'nope', sessionId: 'acp-1' })).toThrow(
+    await expect((daemon as any).listBackgroundTasks({ agentId: 'nope', sessionId: 'acp-1' })).rejects.toThrow(
       TaskViolationError
     )
 

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -2151,7 +2151,12 @@ describe('Daemon session retention GC (#485)', () => {
     await (daemon as any).sweepSessionRetention()
   }
 
-  const seedSession = async (daemon: Daemon, key: string, state: 'idle' | 'prompting' | 'closed', updatedAt: number) =>
+  const seedSession = async (
+    daemon: Daemon,
+    key: string,
+    state: 'idle' | 'prompting' | 'closed',
+    updatedAt: number
+  ): Promise<string> => {
     await (daemon as any).store.upsertSession({
       key,
       agentId: 'bot-a',
@@ -2163,6 +2168,8 @@ describe('Daemon session retention GC (#485)', () => {
       lastDeliveredTs: null,
       updatedAt
     })
+    return (await (daemon as any).store.getSession(key))!.sessionId!
+  }
 
   it('the idle sweep deletes expired sessions but spares live turns and gate-owned keys', async () => {
     const clock = new FakeClock()
@@ -2223,21 +2230,20 @@ describe('Daemon session retention GC (#485)', () => {
     const emitSessionPurged = vi.fn(async () => 'acknowledged' as const)
     ;(daemon as any).cpClient = { emitSessionPurged, state: 'READY', stop: vi.fn(async () => {}) }
 
-    await seedSession(daemon, 'expired-a', 'closed', 0)
-    await seedSession(daemon, 'expired-b', 'idle', 0)
+    const expiredA = await seedSession(daemon, 'expired-a', 'closed', 0)
+    const expiredB = await seedSession(daemon, 'expired-b', 'idle', 0)
     clock.advance(8 * 24 * 3_600_000)
     await sweepRetention(daemon)
     await vi.waitFor(() => expect(emitSessionPurged).toHaveBeenCalledOnce(), WAIT)
 
-    // One frame per agent, carrying the ACP session ids — the only session
-    // identity the CP knows.
+    // One frame per agent, carrying the sessions' outward ids — the identity the CP knows.
     expect(emitSessionPurged.mock.calls[0]![0]).toMatchObject({
       agentId: 'bot-a',
       reason: 'retention'
     })
-    expect(emitSessionPurged.mock.calls[0]![0].sessionIds.sort()).toEqual(['acp-expired-a', 'acp-expired-b'])
-    // ACKed ⇒ the durable receipts are released.
-    expect(await (daemon as any).store.listSessionPurges(10, 0)).toEqual([])
+    expect([...emitSessionPurged.mock.calls[0]![0].sessionIds].sort()).toEqual([expiredA, expiredB].sort())
+    // ACKed ⇒ the durable receipts are released, which the drain does after the report returns.
+    await vi.waitFor(async () => expect(await (daemon as any).store.listSessionPurges(10, 0)).toEqual([]), WAIT)
 
     await daemon.stop()
   }, 15_000)
@@ -2259,11 +2265,11 @@ describe('Daemon session retention GC (#485)', () => {
     // agent + reason + timestamp for all the sessions it carries, so a row may
     // never ride in a frame that would mislabel when (or by whom) it was purged.
     await store.deleteSession('x', { reason: 'retention', at: 1_000 }) // absent row — no receipt
-    await seedSession(daemon, 'sweep-1a', 'closed', 0)
-    await seedSession(daemon, 'sweep-1b', 'closed', 0)
+    const sweep1a = await seedSession(daemon, 'sweep-1a', 'closed', 0)
+    const sweep1b = await seedSession(daemon, 'sweep-1b', 'closed', 0)
     await store.deleteSession('sweep-1a', { reason: 'retention', at: 1_000 })
     await store.deleteSession('sweep-1b', { reason: 'retention', at: 1_000 })
-    await seedSession(daemon, 'sweep-2', 'closed', 0)
+    const sweep2 = await seedSession(daemon, 'sweep-2', 'closed', 0)
     await store.deleteSession('sweep-2', { reason: 'retention', at: 2_000 })
 
     await (daemon as any).drainSessionPurges()
@@ -2272,9 +2278,9 @@ describe('Daemon session retention GC (#485)', () => {
     const frames = emitSessionPurged.mock.calls
       .map((call) => call[0])
       .sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts))
-    expect(frames[0]!.sessionIds.sort()).toEqual(['acp-sweep-1a', 'acp-sweep-1b'])
+    expect([...frames[0]!.sessionIds].sort()).toEqual([sweep1a, sweep1b].sort())
     expect(frames[0]!.ts).toBe(new Date(1_000).toISOString())
-    expect(frames[1]!.sessionIds).toEqual(['acp-sweep-2'])
+    expect(frames[1]!.sessionIds).toEqual([sweep2])
     expect(frames[1]!.ts).toBe(new Date(2_000).toISOString())
     expect(await store.listSessionPurges(10, 0)).toEqual([])
 
@@ -2322,13 +2328,13 @@ describe('Daemon session retention GC (#485)', () => {
       stop: vi.fn()
     }
 
-    await seedSession(daemon, 'expired-a', 'closed', 0)
+    const expiredA = await seedSession(daemon, 'expired-a', 'closed', 0)
     clock.advance(8 * 24 * 3_600_000)
     await sweepRetention(daemon)
     await (daemon as any).drainSessionPurges()
 
     expect(await (daemon as any).store.listSessionPurges(10, 0)).toMatchObject([
-      { agentId: 'bot-a', sessionId: 'acp-expired-a', reason: 'retention' }
+      { agentId: 'bot-a', sessionId: expiredA, reason: 'retention' }
     ])
 
     // ...and a reporting failure is equally non-destructive.

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -171,7 +171,7 @@ describe('messageAgent: same-daemon delivery', () => {
     await daemon.stop()
   })
 
-  it('stamps the caller session’s acpSessionId as the woken child’s originSessionId', async () => {
+  it('stamps the caller session’s OUTWARD id as the woken child’s originSessionId', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon, calls, call } = await bootWithDispatchSpy(root)
     // Seed the caller's own session record (mid-turn its acpSessionId is already minted),
@@ -184,6 +184,7 @@ describe('messageAgent: same-daemon delivery', () => {
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -193,7 +194,10 @@ describe('messageAgent: same-daemon delivery', () => {
     expect(res.delivered).toBe(true)
     expect(calls[0]!.callMeta).toMatchObject({
       callFrom: 'bot-a',
-      originSessionId: 'acp-parent-1',
+      // NOT 'acp-parent-1': the control plane keys its session rows by the outward id, so a
+      // lineage link written in the runtime's name would point at a parent no row matches —
+      // which is also how a child inherits its parent's visibility (session-visibility.md §5.1).
+      originSessionId: 'sid-parent-1',
       originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
     })
     await daemon.stop()
@@ -210,6 +214,7 @@ describe('messageAgent: same-daemon delivery', () => {
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -290,6 +295,7 @@ describe('messageAgent: same-daemon delivery', () => {
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -318,7 +324,7 @@ describe('messageAgent: same-daemon delivery', () => {
       },
       callMeta: {
         callFrom: 'bot-a',
-        originSessionId: 'acp-parent-1',
+        originSessionId: 'sid-parent-1',
         originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
       }
     })
@@ -809,13 +815,14 @@ describe('messageAgent: cross-daemon routing (P2, source side)', () => {
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now()
     })
 
     await call(baseReq({ toAgentId: 'bot-b', needsReply: true }))
-    expect(sent[0]).toMatchObject({ originSessionId: 'acp-parent-1', needsReply: true })
+    expect(sent[0]).toMatchObject({ originSessionId: 'sid-parent-1', needsReply: true })
     await daemon.stop()
   })
 
@@ -1089,6 +1096,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
       channel: 'memory',
       thread: 'dream-1',
       acpSessionId: 'acp-dream-origin',
+      sessionId: 'sid-dream-origin',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1096,7 +1104,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     const ack = await (daemon as any).handleRelayAgentMsg(
       fwd({
         coords: { platform: 'dream', channel: 'memory', thread: 'dream-1' },
-        lineageReplyTo: 'acp-dream-origin',
+        lineageReplyTo: 'sid-dream-origin',
         deliveryId: 'd-reply-1'
       })
     )
@@ -1128,6 +1136,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
       channel: CONV,
       thread: `webchat:${CONV}`,
       acpSessionId: 'acp-webchat-origin',
+      sessionId: 'sid-webchat-origin',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1138,7 +1147,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     const ack = await (daemon as any).handleRelayAgentMsg(
       fwd({
         coords: { platform: 'webchat', channel: CONV },
-        lineageReplyTo: 'acp-webchat-origin',
+        lineageReplyTo: 'sid-webchat-origin',
         deliveryId: 'd-reply-2'
       })
     )
@@ -1173,6 +1182,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
       channel: 'memory',
       thread: 'dream-1',
       acpSessionId: 'acp-dream-origin',
+      sessionId: 'sid-dream-origin',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1180,7 +1190,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     const ack = await (daemon as any).handleRelayAgentMsg(
       fwd({
         coords: { platform: 'dream', channel: 'memory', thread: 'dream-1' },
-        lineageReplyTo: 'acp-dream-origin',
+        lineageReplyTo: 'sid-dream-origin',
         deliveryKind: 'session-reply',
         deliveryId: 'd-reply-headless'
       })
@@ -1205,6 +1215,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
       channel: 'C9',
       thread: '900.9',
       acpSessionId: 'acp-shared',
+      sessionId: 'sid-shared',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1217,12 +1228,13 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
       channel: 'memory',
       thread: 'dream-2',
       acpSessionId: 'acp-shared',
+      sessionId: 'sid-shared',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
     })
     const ack = await (daemon as any).handleRelayAgentMsg(
-      fwd({ coords: { platform: 'dream', channel: 'memory' }, lineageReplyTo: 'acp-shared', deliveryId: 'd-coll' })
+      fwd({ coords: { platform: 'dream', channel: 'memory' }, lineageReplyTo: 'sid-shared', deliveryId: 'd-coll' })
     )
     expect(ack).toMatchObject({ delivered: true, childSessionId: originKey })
     expect(calls).toHaveLength(1)
@@ -1247,6 +1259,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
       channel: 'C_EXECS',
       thread: '900.1',
       acpSessionId: 'acp-execs-origin',
+      sessionId: 'sid-execs-origin',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1260,7 +1273,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     const reply = await (daemon as any).handleRelayAgentMsg(
       fwd({
         coords: { platform: 'slack', channel: 'C_EXECS', thread: '900.1' },
-        lineageReplyTo: 'acp-execs-origin',
+        lineageReplyTo: 'sid-execs-origin',
         deliveryId: 'd-reply-2'
       })
     )
@@ -1275,7 +1288,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     const { daemon, calls } = await bootWithDispatchSpy(root)
     withSnapshot(daemon)
     const missing = await (daemon as any).handleRelayAgentMsg(
-      fwd({ coords: { platform: 'dream', channel: 'memory' }, lineageReplyTo: 'acp-nope', deliveryId: 'd-r1' })
+      fwd({ coords: { platform: 'dream', channel: 'memory' }, lineageReplyTo: 'sid-nope', deliveryId: 'd-r1' })
     )
     expect(missing).toMatchObject({ delivered: false, reason: 'not_found' })
     // A session owned by ANOTHER agent is refused the same way (ownership half of the check).
@@ -1286,12 +1299,13 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
       channel: 'memory',
       thread: 'dream-9',
       acpSessionId: 'acp-foreign',
+      sessionId: 'sid-foreign',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
     })
     const foreign = await (daemon as any).handleRelayAgentMsg(
-      fwd({ coords: { platform: 'dream', channel: 'memory' }, lineageReplyTo: 'acp-foreign', deliveryId: 'd-r2' })
+      fwd({ coords: { platform: 'dream', channel: 'memory' }, lineageReplyTo: 'sid-foreign', deliveryId: 'd-r2' })
     )
     expect(foreign).toMatchObject({ delivered: false, reason: 'not_found' })
     expect(calls).toHaveLength(0)
@@ -1316,10 +1330,10 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     const { daemon, calls } = await bootWithDispatchSpy(root)
     withSnapshot(daemon)
     const ack = await (daemon as any).handleRelayAgentMsg(
-      fwd({ originSessionId: 'acp-remote-parent', needsReply: true })
+      fwd({ originSessionId: 'sid-remote-parent', needsReply: true })
     )
     expect(ack.delivered).toBe(true)
-    expect(calls[0]!.callMeta).toMatchObject({ originSessionId: 'acp-remote-parent', needsReply: true })
+    expect(calls[0]!.callMeta).toMatchObject({ originSessionId: 'sid-remote-parent', needsReply: true })
     // The obligation is metadata — it never enters the delivered text.
     expect(calls[0]!.msg.text).not.toMatch(/needsReply|report back/i)
     await daemon.stop()
@@ -1644,7 +1658,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
     platform: 'slack',
     callerChannel: 'C2',
     callerThread: '200.1',
-    sessionId: 'acp-parent-1',
+    sessionId: 'sid-parent-1',
     text: 'result: done',
     ...over
   })
@@ -1666,7 +1680,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd1',
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
     })
     const res = await (daemon as any).collab.replyToSession(replyReq({ sessionId: 'some-other-session' }))
@@ -1686,6 +1700,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1698,10 +1713,11 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       channel: 'C2',
       thread: '200.1',
       acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now(),
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       needsParentReply: 1
     })
     armTurn(daemon, callerKey, {
@@ -1709,7 +1725,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       hopCount: 1,
       deliveryId: 'd1',
       correlationId: 'orch-1',
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
     })
 
@@ -1761,6 +1777,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       channel: CONV,
       thread: `webchat:${CONV}`,
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1773,17 +1790,18 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       channel: 'C2',
       thread: '200.1',
       acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now(),
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       needsParentReply: 1
     })
     armTurn(daemon, callerKey, {
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd1',
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       originCoords: { platform: 'webchat', channel: CONV }
     })
     const sendWebchatPost = vi.fn()
@@ -1818,6 +1836,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       channel: SYNTHETIC,
       thread: `webchat:${SYNTHETIC}`,
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1830,17 +1849,18 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       channel: 'C2',
       thread: '200.1',
       acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now(),
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       needsParentReply: 1
     })
     armTurn(daemon, callerKey, {
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd1',
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       originCoords: { platform: 'webchat', channel: SYNTHETIC }
     })
 
@@ -1861,6 +1881,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1873,17 +1894,18 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       channel: 'C2',
       thread: '200.1',
       acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now(),
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       needsParentReply: 1
     })
     armTurn(daemon, callerKey, {
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd1',
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
     })
     ;(daemon as any).dispatch = vi.fn(
@@ -1938,6 +1960,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       thread: 'dream-1',
       transportScope: scope,
       acpSessionId: 'acp-parent-dream',
+      sessionId: 'sid-parent-dream',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1947,10 +1970,10 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd1',
-      originSessionId: 'acp-parent-dream',
+      originSessionId: 'sid-parent-dream',
       originCoords: { platform: 'dream', channel: 'a2a:bot-x', thread: 'dream-1' }
     })
-    const res = await (daemon as any).collab.replyToSession(replyReq({ sessionId: 'acp-parent-dream' }))
+    const res = await (daemon as any).collab.replyToSession(replyReq({ sessionId: 'sid-parent-dream' }))
     expect(res.delivered).toBe(true)
     expect(res.targetSession).toBe(dreamKey)
     expect(calls).toHaveLength(1)
@@ -1987,6 +2010,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       thread: 'dream-2',
       transportScope: scope,
       acpSessionId: 'acp-parent-dream-tg',
+      sessionId: 'sid-parent-dream-tg',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -1996,10 +2020,10 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd2',
-      originSessionId: 'acp-parent-dream-tg',
+      originSessionId: 'sid-parent-dream-tg',
       originCoords: { platform: 'dream', channel: 'a2a:bot-x', thread: 'dream-2' }
     })
-    const res = await (daemon as any).collab.replyToSession(replyReq({ sessionId: 'acp-parent-dream-tg' }))
+    const res = await (daemon as any).collab.replyToSession(replyReq({ sessionId: 'sid-parent-dream-tg' }))
     expect(res.delivered).toBe(true)
     expect(res.targetSession).toBe(dreamKey)
     expect(calls).toHaveLength(1)
@@ -2028,17 +2052,17 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd1',
-      originSessionId: 'acp-remote-dream',
+      originSessionId: 'sid-remote-dream',
       originCoords: { platform: 'dream', channel: 'memory', thread: 'dream-1' }
     })
-    const res = await (daemon as any).collab.replyToSession(replyReq({ sessionId: 'acp-remote-dream' }))
+    const res = await (daemon as any).collab.replyToSession(replyReq({ sessionId: 'sid-remote-dream' }))
     expect(res.delivered).toBe(true)
     expect(res.targetSession).toBe('dream:memory:dream-1:bot-a')
     expect(sent).toHaveLength(1)
     expect(sent[0]).toMatchObject({
       toAgentId: 'bot-a',
       coords: { platform: 'dream', channel: 'memory', thread: 'dream-1' },
-      lineageReplyTo: 'acp-remote-dream'
+      lineageReplyTo: 'sid-remote-dream'
     })
     await daemon.stop()
   })
@@ -2056,6 +2080,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -2068,10 +2093,11 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       channel: 'C2',
       thread: '200.1',
       acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now(),
-      originSessionId: 'acp-parent-1'
+      originSessionId: 'sid-parent-1'
     })
     // NO armTurn: activeTurnCallMeta is empty for the caller (a human-triggered follow-up turn).
     const res = await (daemon as any).collab.replyToSession(replyReq())
@@ -2095,7 +2121,7 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd1',
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
     })
     // No local row for `acp-parent-1` ⇒ the origin lives on another daemon.
@@ -2133,6 +2159,7 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-origin-1',
+      sessionId: 'sid-origin-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -2163,7 +2190,7 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
       callFrom: 'bot-a',
       hopCount: 1,
       initializeOnly: true,
-      originSessionId: 'acp-origin-1',
+      originSessionId: 'sid-origin-1',
       originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
     })
     await daemon.stop()
@@ -2189,11 +2216,10 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
     })
 
     await vi.waitFor(async () => {
-      expect(await (daemon as any).store.getSession(targetKey)).toMatchObject({
-        acpSessionId: 'acp-1',
-        state: 'idle',
-        lastDeliveredTs: null
-      })
+      const created = await (daemon as any).store.getSession(targetKey)
+      expect(created).toMatchObject({ acpSessionId: 'acp-1', state: 'idle', lastDeliveredTs: null })
+      // The daemon mints the outward id itself, and it is never the runtime's (§1.1).
+      expect(created.sessionId).toMatch(/^[0-9a-f-]{36}$/)
     }, WAIT)
     expect(host.newSession).toHaveBeenCalledOnce()
     expect(host.prompt).not.toHaveBeenCalled()
@@ -2246,6 +2272,7 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
       channel: '-100999',
       thread: 'tg:52',
       acpSessionId: 'acp-tg-origin',
+      sessionId: 'sid-tg-origin',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -2271,7 +2298,7 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
     expect(callMeta).toMatchObject({
       callFrom: 'bot-a',
       hopCount: 1,
-      originSessionId: 'acp-tg-origin',
+      originSessionId: 'sid-tg-origin',
       originCoords: { platform: 'telegram', channel: '-100999', thread: 'tg:52' }
     })
     await daemon.stop()
@@ -2345,7 +2372,8 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       platform: 'telegram',
       channel: '-100123',
       thread: 'tg:170',
-      acpSessionId: 'acp-parent-1'
+      acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1'
     })
     await seed(daemon, {
       key: sessionKey('slack', 'C2', '200.1', 'bot-b'),
@@ -2354,10 +2382,11 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       channel: 'C2',
       thread: '200.1',
       acpSessionId: 'acp-child-1',
-      originSessionId: 'acp-parent-1'
+      sessionId: 'sid-child-1',
+      originSessionId: 'sid-parent-1'
     })
 
-    expect(await ask(daemon)).toEqual({ kind: 'parent', sessionId: 'acp-parent-1' })
+    expect(await ask(daemon)).toEqual({ kind: 'parent', sessionId: 'sid-parent-1' })
     // A post somewhere else is an ordinary new topic, not a fork.
     expect(await ask(daemon, { targetChannel: '-100999' })).toBeUndefined()
     // The caller's OWN conversation, which its turn reply already reaches.
@@ -2377,7 +2406,8 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       platform: 'telegram',
       channel: '-100123',
       thread: 'tg:170',
-      acpSessionId: 'acp-parent-1'
+      acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1'
     })
     await seed(daemon, {
       key: sessionKey('feishu', 'oc_42', 'om_1', 'bot-b'),
@@ -2386,12 +2416,13 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       channel: 'oc_42',
       thread: 'om_1',
       acpSessionId: 'acp-child-feishu',
-      originSessionId: 'acp-parent-1'
+      sessionId: 'sid-child-feishu',
+      originSessionId: 'sid-parent-1'
     })
 
     expect(await ask(daemon, { platform: 'feishu', callerChannel: 'oc_42', callerThread: 'om_1' })).toEqual({
       kind: 'parent',
-      sessionId: 'acp-parent-1'
+      sessionId: 'sid-parent-1'
     })
     await daemon.stop()
   })
@@ -2410,7 +2441,8 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       channel: '-100123',
       thread: 'tg:170',
       transportScope: 'scope-bot-1',
-      acpSessionId: 'acp-parent-scoped'
+      acpSessionId: 'acp-parent-scoped',
+      sessionId: 'sid-parent-scoped'
     })
     await seed(daemon, {
       key: sessionKey('slack', 'C2', '200.1', 'bot-b'),
@@ -2419,7 +2451,8 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       channel: 'C2',
       thread: '200.1',
       acpSessionId: 'acp-child-1',
-      originSessionId: 'acp-parent-scoped'
+      sessionId: 'sid-child-1',
+      originSessionId: 'sid-parent-scoped'
     })
     expect(await ask(daemon)).toBeUndefined()
 
@@ -2431,7 +2464,8 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       platform: 'telegram',
       channel: '-100123',
       thread: 'tg:171',
-      acpSessionId: 'acp-parent-unscoped'
+      acpSessionId: 'acp-parent-unscoped',
+      sessionId: 'sid-parent-unscoped'
     })
     await (daemon as any).store.upsertSession({
       key: sessionKey('slack', 'C3', '300.1', 'bot-b'),
@@ -2440,14 +2474,15 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       channel: 'C3',
       thread: '300.1',
       acpSessionId: 'acp-child-2',
+      sessionId: 'sid-child-2',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: Date.now(),
-      originSessionId: 'acp-parent-unscoped'
+      originSessionId: 'sid-parent-unscoped'
     })
     expect(await ask(daemon, { callerChannel: 'C3', callerThread: '300.1' })).toEqual({
       kind: 'parent',
-      sessionId: 'acp-parent-unscoped'
+      sessionId: 'sid-parent-unscoped'
     })
     await daemon.stop()
   })
@@ -2462,7 +2497,8 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       platform: 'slack',
       channel: 'C2',
       thread: '200.1',
-      acpSessionId: 'acp-child-1'
+      acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1'
     })
     // Woken over the relay: the parent session lives on another daemon, so `getSessionByAcpId`
     // finds nothing and only the trusted wake carries its coords. Requiring a row here made the
@@ -2471,10 +2507,10 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd1',
-      originSessionId: 'acp-remote-parent',
+      originSessionId: 'sid-remote-parent',
       originCoords: { platform: 'telegram', channel: '-100123', thread: 'tg:9' }
     })
-    expect(await ask(daemon)).toEqual({ kind: 'parent', sessionId: 'acp-remote-parent' })
+    expect(await ask(daemon)).toEqual({ kind: 'parent', sessionId: 'sid-remote-parent' })
     // Still only for the conversation it actually names.
     expect(await ask(daemon, { targetChannel: '-100999' })).toBeUndefined()
     // Matching is coordinates-only here BY DESIGN — the remote scope is credential-derived and
@@ -2483,7 +2519,7 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
     // entirely on the cross-daemon escalation path.
     expect(await ask(daemon, { targetIntegrationId: 'int-tg-1' })).toEqual({
       kind: 'parent',
-      sessionId: 'acp-remote-parent'
+      sessionId: 'sid-remote-parent'
     })
     await daemon.stop()
   })
@@ -2518,6 +2554,7 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
         channel: 'C2',
         thread: '200.1',
         acpSessionId: 'acp-child-1',
+        sessionId: 'sid-child-1',
         originSessionId: parentId
       })
 
@@ -2548,7 +2585,8 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       platform: 'slack',
       channel: 'C2',
       thread: '200.1',
-      acpSessionId: 'acp-child-1'
+      acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1'
     })
     // No parent link anywhere ⇒ a post into an unrelated channel relates to nothing.
     expect(await ask(daemon)).toBeUndefined()
@@ -2560,16 +2598,17 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       platform: 'telegram',
       channel: '-100999',
       thread: 'tg:9',
-      acpSessionId: 'acp-parent-2'
+      acpSessionId: 'acp-parent-2',
+      sessionId: 'sid-parent-2'
     })
     ;(daemon as any).activeTurnCallMeta.set(callerKey, {
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd1',
-      originSessionId: 'acp-parent-2',
+      originSessionId: 'sid-parent-2',
       originCoords: { platform: 'telegram', channel: '-100999', thread: 'tg:9' }
     })
-    expect(await ask(daemon, { targetChannel: '-100999' })).toEqual({ kind: 'parent', sessionId: 'acp-parent-2' })
+    expect(await ask(daemon, { targetChannel: '-100999' })).toEqual({ kind: 'parent', sessionId: 'sid-parent-2' })
     await daemon.stop()
   })
 })
@@ -2621,7 +2660,11 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
   it('reports a child woken by this session, keyed by the childSessionId sendMessage returned', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon, call } = await bootWithDispatchSpy(root)
-    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1', state: 'prompting' })
+    await seedSession(daemon, PARENT_KEY, {
+      acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
+      state: 'prompting'
+    })
 
     const res = await call(baseReq({ needsReply: true }))
     expect(res.delivered).toBe(true)
@@ -2652,8 +2695,13 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
   ])('collapses state=$state + outcome=$outcome to $status', async ({ state, outcome, status }) => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
-    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1' })
-    await seedSession(daemon, CHILD_KEY, { acpSessionId: 'acp-child-1', state, originSessionId: 'acp-parent-1' })
+    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1', sessionId: 'sid-parent-1' })
+    await seedSession(daemon, CHILD_KEY, {
+      acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
+      state,
+      originSessionId: 'sid-parent-1'
+    })
     if (outcome) await (daemon as any).store.setSessionTurnOutcome(CHILD_KEY, outcome, 2_000)
 
     expect(await ask(daemon, CHILD_KEY)).toMatchObject({ agentId: 'bot-b', status, state })
@@ -2665,8 +2713,12 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
   it('refuses the child’s ACP session id — only the returned logical key is addressable', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
-    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1' })
-    await seedSession(daemon, CHILD_KEY, { acpSessionId: 'acp-child-1', originSessionId: 'acp-parent-1' })
+    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1', sessionId: 'sid-parent-1' })
+    await seedSession(daemon, CHILD_KEY, {
+      acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
+      originSessionId: 'sid-parent-1'
+    })
     await (daemon as any).store.setSessionTurnOutcome(CHILD_KEY, 'done', 2_000)
 
     expect((await ask(daemon, CHILD_KEY))?.status).toBe('done')
@@ -2679,8 +2731,16 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
   it('reports in-progress for a re-wake of an already-finished child, not its old outcome', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon, call } = await bootWithDispatchSpy(root)
-    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1', state: 'prompting' })
-    await seedSession(daemon, CHILD_KEY, { acpSessionId: 'acp-child-1', originSessionId: 'acp-parent-1' })
+    await seedSession(daemon, PARENT_KEY, {
+      acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
+      state: 'prompting'
+    })
+    await seedSession(daemon, CHILD_KEY, {
+      acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
+      originSessionId: 'sid-parent-1'
+    })
     await (daemon as any).store.setSessionTurnOutcome(CHILD_KEY, 'done', 2_000)
     // Before the re-wake the parent legitimately sees the finished first delegation.
     expect((await ask(daemon, CHILD_KEY))?.status).toBe('done')
@@ -2696,8 +2756,12 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
   it('refuses a session this caller did not start (a sibling with a different parent)', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
-    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1' })
-    await seedSession(daemon, CHILD_KEY, { acpSessionId: 'acp-child-1', originSessionId: 'acp-someone-else' })
+    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1', sessionId: 'sid-parent-1' })
+    await seedSession(daemon, CHILD_KEY, {
+      acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
+      originSessionId: 'sid-someone-else'
+    })
 
     expect(await ask(daemon, CHILD_KEY)).toBeNull()
     await daemon.stop()
@@ -2706,8 +2770,8 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
   it('refuses a root session with no parent at all', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
-    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1' })
-    await seedSession(daemon, CHILD_KEY, { acpSessionId: 'acp-child-1' })
+    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1', sessionId: 'sid-parent-1' })
+    await seedSession(daemon, CHILD_KEY, { acpSessionId: 'acp-child-1', sessionId: 'sid-child-1' })
 
     expect(await ask(daemon, CHILD_KEY)).toBeNull()
     await daemon.stop()
@@ -2716,7 +2780,7 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
   it('refuses the caller’s OWN session — a session is not its own child', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
-    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1' })
+    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1', sessionId: 'sid-parent-1' })
 
     expect(await ask(daemon, PARENT_KEY)).toBeNull()
     expect(await ask(daemon, 'acp-parent-1')).toBeNull()
@@ -2726,11 +2790,15 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
   it('refuses an unknown session id, and a known child asked for by a DIFFERENT session', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
-    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1' })
-    await seedSession(daemon, CHILD_KEY, { acpSessionId: 'acp-child-1', originSessionId: 'acp-parent-1' })
+    await seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1', sessionId: 'sid-parent-1' })
+    await seedSession(daemon, CHILD_KEY, {
+      acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
+      originSessionId: 'sid-parent-1'
+    })
     // bot-b's own session in another thread: a real session, but not this child's parent.
     const otherKey = sessionKey('slack', 'C1', '999.9', 'bot-b')
-    await seedSession(daemon, otherKey, { acpSessionId: 'acp-other-1' })
+    await seedSession(daemon, otherKey, { acpSessionId: 'acp-other-1', sessionId: 'sid-other-1' })
 
     expect(await ask(daemon, 'no-such-session')).toBeNull()
     expect(await ask(daemon, CHILD_KEY, { agentId: 'bot-b', channel: 'C1', thread: '999.9' })).toBeNull()
@@ -2752,11 +2820,16 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
       thread: '100.1',
       transportScope: 'bot-scope-1',
       acpSessionId: 'acp-parent-scoped',
+      sessionId: 'sid-parent-scoped',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1_000
     })
-    await seedSession(daemon, CHILD_KEY, { acpSessionId: 'acp-child-1', originSessionId: 'acp-parent-scoped' })
+    await seedSession(daemon, CHILD_KEY, {
+      acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
+      originSessionId: 'sid-parent-scoped'
+    })
     await (daemon as any).store.setSessionTurnOutcome(CHILD_KEY, 'done', 2_000)
 
     const caller = { agentId: 'bot-a', channel: 'C1', thread: '100.1', transportScope: 'bot-scope-1' }
@@ -2770,7 +2843,7 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
     // A child whose parent link is absent must not match an absent caller session id.
-    await seedSession(daemon, CHILD_KEY, { acpSessionId: 'acp-child-1' })
+    await seedSession(daemon, CHILD_KEY, { acpSessionId: 'acp-child-1', sessionId: 'sid-child-1' })
 
     expect(await ask(daemon, CHILD_KEY)).toBeNull()
     await daemon.stop()
@@ -2793,6 +2866,7 @@ describe('viewSessionStatus: cross-daemon children', () => {
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: 1_000
@@ -2841,7 +2915,7 @@ describe('viewSessionStatus: cross-daemon children', () => {
     })
     // The CP needs the child AGENT to resolve placement — it must not parse the composite key.
     expect(asks[0]).toEqual({
-      parentSessionId: 'acp-parent-1',
+      parentSessionId: 'sid-parent-1',
       childSessionId: res.targetSession,
       childAgentId: 'bot-b'
     })
@@ -2909,6 +2983,7 @@ describe('viewSessionStatus: cross-daemon children', () => {
       channel: 'C1',
       thread: '777.7',
       acpSessionId: 'acp-other',
+      sessionId: 'sid-other',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1_000
@@ -2941,6 +3016,7 @@ describe('viewSessionStatus: remote child handle identity', () => {
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: 1_000
@@ -3035,7 +3111,7 @@ describe('handleRelayAgentMsg: admission handle + pre-row probe window', () => {
       coords: { platform: 'slack', channel: 'C1', thread: '100.1' },
       hopCount: 1,
       deliveryId: 'd-canon-1',
-      originSessionId: 'acp-remote-parent'
+      originSessionId: 'sid-remote-parent'
     })
     expect(ack.delivered).toBe(true)
     // dispatch is stubbed, so no row exists yet — the ACK handle plus the admission link are all
@@ -3044,7 +3120,7 @@ describe('handleRelayAgentMsg: admission handle + pre-row probe window', () => {
     expect(await (daemon as any).store.getSession(ack.childSessionId)).toBeUndefined()
     expect(
       await (daemon as any).collab.childSessionStatusProbe({
-        parentSessionId: 'acp-remote-parent',
+        parentSessionId: 'sid-remote-parent',
         childSessionId: ack.childSessionId
       })
     ).toEqual({
@@ -3059,7 +3135,7 @@ describe('handleRelayAgentMsg: admission handle + pre-row probe window', () => {
     // …and only to the parent that actually woke it.
     expect(
       await (daemon as any).collab.childSessionStatusProbe({
-        parentSessionId: 'acp-someone-else',
+        parentSessionId: 'sid-someone-else',
         childSessionId: ack.childSessionId
       })
     ).toEqual({ found: false })
@@ -3079,6 +3155,7 @@ describe('childSessionStatusProbe: owning-daemon authorization', () => {
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1_000,
@@ -3088,12 +3165,12 @@ describe('childSessionStatusProbe: owning-daemon authorization', () => {
   it('answers with the collapsed status when the child’s origin matches the claimed parent', async () => {
     const root = scaffold([{ id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
-    await seedChild(daemon, { originSessionId: 'acp-remote-parent' })
+    await seedChild(daemon, { originSessionId: 'sid-remote-parent' })
     await (daemon as any).store.setSessionTurnOutcome(CHILD_KEY, 'failed', 2_000)
 
     expect(
       await (daemon as any).collab.childSessionStatusProbe({
-        parentSessionId: 'acp-remote-parent',
+        parentSessionId: 'sid-remote-parent',
         childSessionId: CHILD_KEY
       })
     ).toMatchObject({ found: true, agentId: 'bot-b', status: 'failed', state: 'idle' })
@@ -3103,7 +3180,7 @@ describe('childSessionStatusProbe: owning-daemon authorization', () => {
   it('refuses a mismatched parent, a parentless child, and an unknown session — all as found:false', async () => {
     const root = scaffold([{ id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
-    await seedChild(daemon, { originSessionId: 'acp-remote-parent' })
+    await seedChild(daemon, { originSessionId: 'sid-remote-parent' })
 
     const probe = async (parentSessionId: string, childSessionId = CHILD_KEY) =>
       await (daemon as any).collab.childSessionStatusProbe({ parentSessionId, childSessionId })
@@ -3121,6 +3198,7 @@ describe('childSessionStatusProbe: owning-daemon authorization', () => {
       channel: 'C1',
       thread: '555.5',
       acpSessionId: 'acp-root-1',
+      sessionId: 'sid-root-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1_000
@@ -3144,10 +3222,11 @@ describe('viewSessionStatus: a reused child is readable by the current waking pa
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1_000,
-      originSessionId: 'acp-parent-a'
+      originSessionId: 'sid-parent-a'
     })
     await (daemon as any).store.setSessionTurnOutcome(CHILD, 'done', 2_000)
     // Parent C (a different session) now wakes it and receives the handle.
@@ -3159,6 +3238,7 @@ describe('viewSessionStatus: a reused child is readable by the current waking pa
       channel: 'C1',
       thread: '300.3',
       acpSessionId: 'acp-parent-c',
+      sessionId: 'sid-parent-c',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: 1_000
@@ -3180,17 +3260,17 @@ describe('viewSessionStatus: a reused child is readable by the current waking pa
     expect((await askAs('bot-c', '300.3'))?.status).toBe('in-progress')
     // …and the owning-side probe agrees, so a cross-daemon C sees the same.
     expect(
-      (await (daemon as any).collab.childSessionStatusProbe({ parentSessionId: 'acp-parent-c', childSessionId: CHILD }))
+      (await (daemon as any).collab.childSessionStatusProbe({ parentSessionId: 'sid-parent-c', childSessionId: CHILD }))
         .found
     ).toBe(true)
     // The durable first parent A keeps its access too.
     expect(
-      (await (daemon as any).collab.childSessionStatusProbe({ parentSessionId: 'acp-parent-a', childSessionId: CHILD }))
+      (await (daemon as any).collab.childSessionStatusProbe({ parentSessionId: 'sid-parent-a', childSessionId: CHILD }))
         .found
     ).toBe(true)
     // An unrelated session still cannot read it.
     expect(
-      (await (daemon as any).collab.childSessionStatusProbe({ parentSessionId: 'acp-stranger', childSessionId: CHILD }))
+      (await (daemon as any).collab.childSessionStatusProbe({ parentSessionId: 'sid-stranger', childSessionId: CHILD }))
         .found
     ).toBe(false)
     await daemon.stop()
@@ -3209,13 +3289,14 @@ describe('messageAgent: needsReply report-back directive', () => {
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-parent-1',
+      sessionId: 'sid-parent-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now()
     })
 
     await call(baseReq({ needsReply: true }))
-    expect(calls[0]!.callMeta).toMatchObject({ originSessionId: 'acp-parent-1', needsReply: true })
+    expect(calls[0]!.callMeta).toMatchObject({ originSessionId: 'sid-parent-1', needsReply: true })
     // The obligation is metadata; the delivered text is untouched.
     expect(calls[0]!.msg.text).not.toMatch(/needsReply|report back/i)
     await daemon.stop()
@@ -3241,6 +3322,7 @@ describe('messageAgent: needsReply report-back directive', () => {
       channel: 'C1',
       thread: '100.1',
       acpSessionId: 'acp-child-1',
+      sessionId: 'sid-child-1',
       state: 'prompting',
       lastDeliveredTs: null,
       updatedAt: Date.now()
@@ -3250,7 +3332,7 @@ describe('messageAgent: needsReply report-back directive', () => {
       callFrom: 'bot-a',
       hopCount: 1,
       deliveryId: 'd1',
-      originSessionId: 'acp-parent-1',
+      originSessionId: 'sid-parent-1',
       needsReply: true,
       originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
     })

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -3,6 +3,11 @@ import type { CreateElicitationRequest, RequestPermissionRequest } from '@agentc
 import { Daemon, noneSuppressedApprovalSurface, isBuiltinSystemTool, isBuiltinSystemToolCall } from '../src/daemon.js'
 import { ALL_TOOL_NAMES } from '../src/mcp/tools.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { LocalStore } from '../src/store/local-store.js'
+import { listAgentPermissionRequests } from '../src/cp/config-apply-handlers.js'
 
 /**
  * Auto-approve policy for the daemon's OWN built-in MCP tools (UX fix): a human should
@@ -351,5 +356,43 @@ describe('built-in MCP approvals use one policy on both ACP paths', () => {
     await expect(
       (daemon as any).permissions.onAcpElicit('agent-1', 's1', elicitation('uncorrelated', { mode: 'url' }))
     ).resolves.toBeUndefined()
+  })
+})
+
+describe('the approval list names its session the way the console asked for it', () => {
+  it('reports the outward id, so the console can scope approvals to the session it is showing', async () => {
+    const store = await LocalStore.open(join(mkdtempSync(join(tmpdir(), 'ac-approvals-')), 'local.sqlite'))
+    const key = ['slack', 'C1', '100.1', 'bot-a'].join('\u001f')
+    await store.upsertSession({
+      key,
+      agentId: 'bot-a',
+      platform: 'slack',
+      channel: 'C1',
+      thread: '100.1',
+      acpSessionId: 'acp-1',
+      state: 'prompting',
+      lastDeliveredTs: null,
+      updatedAt: 1
+    })
+    const outward = (await store.getSession(key))!.sessionId!
+    expect(outward).not.toBe('acp-1')
+    // The row itself is keyed by the runtime's id — the permission arrives over ACP.
+    await store.createPermissionRequest({
+      id: 'p1',
+      agentId: 'bot-a',
+      sessionId: 'acp-1',
+      createdAt: 100,
+      requesterId: null,
+      requesterName: null,
+      command: 'rm -rf /tmp/x',
+      status: 'pending',
+      resolvedAt: null
+    })
+
+    const host = { store: () => store, clock: () => ({ now: () => 1_000 }) } as never
+    const page = await listAgentPermissionRequests(host, { agentId: 'bot-a', limit: 10 })
+    // The console routes on the outward id, so filtering by it must find this request.
+    expect(page.requests.map((r) => r.sessionId)).toEqual([outward])
+    await store.close()
   })
 })

--- a/packages/daemon/test/daemon-session-sweeps-pool.test.ts
+++ b/packages/daemon/test/daemon-session-sweeps-pool.test.ts
@@ -105,7 +105,7 @@ const seedSession = async (
   agentId: string,
   state: 'idle' | 'closed',
   updatedAt: number
-) =>
+): Promise<string> => {
   await store.upsertSession({
     key,
     agentId,
@@ -117,6 +117,9 @@ const seedSession = async (
     lastDeliveredTs: null,
     updatedAt
   })
+  // The outward id the session's purge receipt will be addressed by (session-concept.md §1.1).
+  return (await store.getSession(key))!.sessionId!
+}
 
 /** A's in-memory background-task lease for one of its sessions: live work the TTL sweep must respect. */
 function leaseLiveTask(inner: any, agentId: string, acpSessionId: string): void {
@@ -208,10 +211,10 @@ describe('session sweeps on a daemon pool are holder-only (#1032)', () => {
 
     // A's sweep purged two of A's sessions and one legacy, unowned receipt sits alongside;
     // B's own receipt is the youngest, so a drain that returned on the foreign group would never reach it.
-    await seedSession(shared, 'a-1', AGENT_A, 'closed', 0)
-    await seedSession(shared, 'a-2', AGENT_A, 'closed', 0)
-    await seedSession(shared, 'a-legacy', AGENT_A, 'closed', 0)
-    await seedSession(shared, 'b-1', AGENT_B, 'closed', 0)
+    const a1 = await seedSession(shared, 'a-1', AGENT_A, 'closed', 0)
+    const a2 = await seedSession(shared, 'a-2', AGENT_A, 'closed', 0)
+    const aLegacy = await seedSession(shared, 'a-legacy', AGENT_A, 'closed', 0)
+    const b1 = await seedSession(shared, 'b-1', AGENT_B, 'closed', 0)
     await shared.deleteSession('a-1', { reason: 'retention', at: 1_000, ownerId: 'daemon-a' })
     await shared.deleteSession('a-2', { reason: 'retention', at: 1_000, ownerId: 'daemon-a' })
     await shared.deleteSession('a-legacy', { reason: 'retention', at: 1_500 })
@@ -221,14 +224,14 @@ describe('session sweeps on a daemon pool are holder-only (#1032)', () => {
 
     await b.inner.drainSessionPurges()
     expect(b.emitSessionPurged).toHaveBeenCalledOnce()
-    expect(b.emitSessionPurged.mock.calls[0]![0]).toMatchObject({ agentId: AGENT_B, sessionIds: ['acp-b-1'] })
+    expect(b.emitSessionPurged.mock.calls[0]![0]).toMatchObject({ agentId: AGENT_B, sessionIds: [b1] })
     // A's live rows and the unowned row for A's agent are left for A: nothing was destroyed.
-    expect((await owed()).sort()).toEqual(['acp-a-1', 'acp-a-2', 'acp-a-legacy'])
+    expect((await owed()).sort()).toEqual([a1, a2, aLegacy].sort())
 
     await a.inner.drainSessionPurges()
     const frames = a.emitSessionPurged.mock.calls.map((call: any[]) => call[0])
     expect(frames.map((frame: any) => frame.agentId)).toEqual([AGENT_A, AGENT_A])
-    expect(frames.flatMap((frame: any) => frame.sessionIds).sort()).toEqual(['acp-a-1', 'acp-a-2', 'acp-a-legacy'])
+    expect(frames.flatMap((frame: any) => [...frame.sessionIds]).sort()).toEqual([a1, a2, aLegacy].sort())
     expect(await owed()).toEqual([])
     await stop()
     for (const local of locals) await local.close()
@@ -290,7 +293,7 @@ describe('session sweeps on a daemon pool are holder-only (#1032)', () => {
     })
     const shared: LocalStore = b.inner.store
     // The prior holder purged this session and died before its receipt was ACKed.
-    await seedSession(shared, 'left', AGENT_A, 'closed', 0)
+    const left = await seedSession(shared, 'left', AGENT_A, 'closed', 0)
     await shared.deleteSession('left', { reason: 'retention', at: 1_000, ownerId: 'daemon-a' })
     await advance(b, 1_000 + 2 * 60_000 + 1)
 
@@ -300,7 +303,7 @@ describe('session sweeps on a daemon pool are holder-only (#1032)', () => {
     // The grant lands: the receipt is this member's to report now, and it is reported exactly once.
     b.inner.dutyCoordinator.settleDutyChange(b.inner.duties.applyGrant([grant(GROUP_A, AGENT_A)]))
     await vi.waitFor(() => expect(b.emitSessionPurged).toHaveBeenCalledOnce())
-    expect(b.emitSessionPurged.mock.calls[0]![0]).toMatchObject({ agentId: AGENT_A, sessionIds: ['acp-left'] })
+    expect(b.emitSessionPurged.mock.calls[0]![0]).toMatchObject({ agentId: AGENT_A, sessionIds: [left] })
     await b.inner.drainSessionPurges()
     expect(b.emitSessionPurged).toHaveBeenCalledOnce()
     expect(await shared.listSessionPurges(10, b.clock.now(), 'daemon-b', [AGENT_A])).toEqual([])

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -8,6 +8,12 @@ import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../src/cp/gitcred-ser
 import { FakeClock } from './cp/fake-clock.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
+// The outward `sessionId` a frame carries for the slot behind an ACP hop id (session-concept.md §1.1).
+const outwardId = async (daemon: any, acpSessionId: string): Promise<string> => {
+  const slot = await daemon.store.getSessionByAcpId(acpSessionId)
+  return slot!.sessionId ?? (await daemon.store.ensureOutwardSessionId(slot!.key, slot!.agentId ?? undefined))
+}
+
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
 // Give every poll in this file the same generous budget instead.
@@ -456,13 +462,13 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     // The warm turn's start snapshot is what flips the console's work panel open:
     // it must carry the ACTIVE raw state, on the same session row.
     expect(emitEventSession.mock.calls[2]![0]).toMatchObject({
-      sessionId: 'acp-sess-1',
+      sessionId: await outwardId(daemon, 'acp-sess-1'),
       phase: 'start',
       status: 'prompting'
     })
     const start = emitEventSession.mock.calls[0]![0]
     expect(start).toMatchObject({
-      sessionId: 'acp-sess-1',
+      sessionId: await outwardId(daemon, 'acp-sess-1'),
       agentId: 'bot-a',
       phase: 'start',
       platform: 'slack',
@@ -485,13 +491,13 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     expect(start.model).toBeUndefined()
     expect(start.effort).toBeUndefined()
     expect(start.fastMode).toBeUndefined()
-    expect(start.link).toContain('/sessions/acp-sess-1')
+    expect(start.link).toContain(`/sessions/${await outwardId(daemon, 'acp-sess-1')}`)
     expect(typeof start.lastActivityAt).toBe('string')
     expect(typeof start.ts).toBe('string')
     expect(start.launchId).toBeUndefined() // Slack/Discord path — no CP launch fence
     const firstFinal = emitEventSession.mock.calls[1]![0]
     expect(firstFinal).toMatchObject({
-      sessionId: 'acp-sess-1',
+      sessionId: await outwardId(daemon, 'acp-sess-1'),
       phase: 'end',
       status: 'idle',
       title: 'first',
@@ -499,7 +505,12 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       observedModel: 'claude-sonnet-4-5'
     })
     const final = emitEventSession.mock.calls[3]![0]
-    expect(final).toMatchObject({ sessionId: 'acp-sess-1', phase: 'end', status: 'idle', observedModel: null })
+    expect(final).toMatchObject({
+      sessionId: await outwardId(daemon, 'acp-sess-1'),
+      phase: 'end',
+      status: 'idle',
+      observedModel: null
+    })
     expect(final.model).toBeUndefined()
     expect(emitUsageReport.mock.calls.map(([report]) => report.observedModel)).toEqual(['claude-sonnet-4-5', null])
     await daemon.stop()
@@ -570,7 +581,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
 
       expect(replayed).toHaveBeenCalledTimes(1)
       expect(replayed.mock.calls[0]![0]).toMatchObject({
-        sessionId,
+        sessionId: await outwardId(restored, sessionId),
         agentId,
         phase: 'end',
         platform: 'slack',
@@ -716,13 +727,13 @@ describe('Daemon (no Slack, injected ACP host)', () => {
 
     expect(emitEventSession.mock.calls.map(([payload]) => payload.phase)).toEqual(['start', 'plan', 'end'])
     expect(emitEventSession.mock.calls[1]![0]).toMatchObject({
-      sessionId: 'acp-title-1',
+      sessionId: await outwardId(daemon, 'acp-title-1'),
       phase: 'plan',
       title: 'Runtime summary',
       status: 'prompting'
     })
     expect(emitEventSession.mock.calls[2]![0]).toMatchObject({
-      sessionId: 'acp-title-1',
+      sessionId: await outwardId(daemon, 'acp-title-1'),
       phase: 'end',
       title: 'Runtime summary',
       status: 'idle'
@@ -788,7 +799,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     expect(emitEventSession.mock.calls.map(([payload]) => payload.phase)).toEqual(['start', 'end'])
     // The session keeps its first-message fallback title instead of the echo.
     expect(emitEventSession.mock.calls[1]![0]).toMatchObject({
-      sessionId: 'acp-title-echo',
+      sessionId: await outwardId(daemon, 'acp-title-echo'),
       phase: 'end',
       title: 'first fallback',
       status: 'idle'
@@ -952,7 +963,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     expect(connA.setTitle).not.toHaveBeenCalled()
     expect((await (daemon as any).store.getSessionByAcpId('acp-title-late'))?.title).toBe('Fix session titles')
     expect(emitEventSession.mock.calls.at(-1)?.[0]).toMatchObject({
-      sessionId: 'acp-title-late',
+      sessionId: await outwardId(daemon, 'acp-title-late'),
       phase: 'plan',
       title: 'Fix session titles'
     })
@@ -1264,7 +1275,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
 
     const refresh = emitEventSession.mock.calls.at(-1)![0]
     expect(refresh).toMatchObject({
-      sessionId: 'acp-name-1',
+      sessionId: await outwardId(daemon, 'acp-name-1'),
       phase: 'plan',
       title: 'need names',
       status: 'idle',

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -138,13 +138,22 @@ async function activity(daemon: Daemon): Promise<{ kind: string; sender: string;
   }))
 }
 
+// The footer deep-links the console, which knows the session by its OUTWARD id (§1.1) — a
+// minted UUID, not the runtime's `acp-1`. Matched loosely on that segment alone: the exact value
+// belongs to the store, and daemon-message-agent covers what it must be.
+const SESSION_URL = /https:\/\/app\.example\.com\/sessions\/[0-9a-f-]{36}\?source=slack/
+
 function classicFooter(botName = 'bot-a', runtime = 'claude', model = 'default') {
   return {
     type: 'context',
     elements: [
       {
         type: 'mrkdwn',
-        text: `sent by <https://app.example.com/agents/bot-a|${botName}> (${runtime} · ${model}) · <https://app.example.com/sessions/acp-1?source=slack|open in session>`
+        text: expect.stringMatching(
+          new RegExp(
+            `^sent by <https://app\\.example\\.com/agents/bot-a\\|${botName}> \\(${runtime} · ${model}\\) · <${SESSION_URL.source}\\|open in session>$`
+          )
+        )
       }
     ]
   }

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -392,11 +392,15 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     // Turn start: model + sessionId (no usage folded yet). Runtime controls are hidden while
     // chat-side changes are disabled. Then usage_update adds context+cost. Turn end: token
     // totals fold in. Deduped ⇒ exactly these three snapshots.
+    // The console deep-links from this, so it is the session's OUTWARD id (§1.1) — minted by the
+    // daemon, never the runtime's `acp-wc-1`.
+    const outward = (await (daemon as any).store.getSessionByAcpId('acp-wc-1'))!.sessionId
+    expect(outward).not.toBe('acp-wc-1')
     const base = {
       model: 'opus-4.8',
       permissionMode: 'default',
       permissionModes: [],
-      sessionId: 'acp-wc-1'
+      sessionId: outward
     }
     const ctx = { contextUsed: 120_000, contextSize: 200_000, costAmount: 0.18, costCurrency: 'USD' }
     expect(statuses).toEqual([base, { ...base, ...ctx }, { ...base, ...ctx, totalTokens: 45_200 }])

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -86,6 +86,14 @@ class FakeStore implements DreamStorePort {
       (d) => agentIds.includes(d.agentId) && (d.status === 'pending' || d.status === 'running')
     )
   }
+  // A dream's durable records name their sessions outwardly (§1.1): the fake keeps the mapping
+  // explicit so a regression that stores the runtime's id instead is visible in the assertions.
+  async getSessionByAcpIdForAgent(_agentId: string, acpSessionId: string): Promise<{ key: string } | undefined> {
+    return { key: `key-of-${acpSessionId}` }
+  }
+  async ensureOutwardSessionId(key: string): Promise<string> {
+    return key.replace(/^key-of-/, 'sid-of-')
+  }
   async completedDreams(agentId: string): Promise<DreamInfo[]> {
     return [...this.dreams.values()].filter((d) => d.agentId === agentId && d.status === 'completed')
   }
@@ -420,7 +428,7 @@ describe('DreamRunner pipeline', () => {
 
     expect(done).toMatchObject({
       status: 'completed',
-      executionSessionId: 'dream-session-1',
+      executionSessionId: 'sid-of-dream-session-1',
       runtime: 'codex',
       model: 'gpt-5.6',
       stopReason: 'end_turn',
@@ -435,7 +443,7 @@ describe('DreamRunner pipeline', () => {
     expect(done.usage?.inputBytes).toBeGreaterThan(0)
     expect(done.usage?.outputBytes).toBeGreaterThan(0)
     expect(events.map((event) => event.type)).toEqual(['memory.dream.started', 'memory.dream.completed'])
-    expect(events[1]?.dream.executionSessionId).toBe('dream-session-1')
+    expect(events[1]?.dream.executionSessionId).toBe('sid-of-dream-session-1')
   })
 
   it('rejects a second dream while one is in flight and when dreaming is disabled', async () => {
@@ -1545,7 +1553,7 @@ describe('DreamRunner store persistence', () => {
       trigger: 'manual',
       sessionIds: ['s1'],
       snapshotDigest: 'sha256:abc',
-      executionSessionId: 'dream-session-1',
+      executionSessionId: 'sid-of-dream-session-1',
       runtime: 'codex',
       model: 'gpt-5.6',
       stopReason: 'end_turn',
@@ -1561,7 +1569,7 @@ describe('DreamRunner store persistence', () => {
     }
     await store.insertDream(dream)
     expect(await store.getDream('a1', 'drm-store-1')).toMatchObject({
-      executionSessionId: 'dream-session-1',
+      executionSessionId: 'sid-of-dream-session-1',
       runtime: 'codex',
       model: 'gpt-5.6',
       stopReason: 'end_turn',

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -776,6 +776,37 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     await s.close()
   })
 
+  it('settles on the session row when a full insert lands mid-mint', async () => {
+    const s = await store()
+    // The interleaving the staging table makes possible: the mint reads no session, the turn's
+    // own insert commits with an id of its own (the stage it would have adopted did not exist
+    // yet), and only then does the mint stage its. Answering with the stage would split one
+    // session's identity — credential under one name, metadata and usage under another.
+    const reads: string[] = []
+    const realGet = (s as any).db.prepare.bind((s as any).db)
+    ;(s as any).db.prepare = (sql: string) => {
+      const stmt = realGet(sql)
+      if (!sql.startsWith('SELECT sessionId FROM sessions')) return stmt
+      return {
+        ...stmt,
+        get: async (...args: unknown[]) => {
+          const row = await stmt.get(...args)
+          reads.push(sql)
+          // Exactly once, between the mint's first read and its stage, the turn writes the row.
+          if (reads.length === 1) await seed(s, 'k1', 'bot-a', 'acp-1', 100)
+          return row
+        }
+      }
+    }
+    const minted = await s.ensureOutwardSessionId('k1', 'bot-a')
+    ;(s as any).db.prepare = realGet
+    const row = (await s.getSession('k1'))!.sessionId
+    expect(minted).toBe(row)
+    // ...and the stage is settled onto it, so the next ask cannot revive the losing name.
+    expect(await s.ensureOutwardSessionId('k1', 'bot-a')).toBe(row)
+    await s.close()
+  })
+
   it('a purged slot does not hand its identity to the next session on the same key', async () => {
     const s = await store()
     await seed(s, 'k1', 'bot-a', 'acp-1', 100)

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -101,6 +101,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN ownerId')
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN claimedAt')
     dropTranscriptOrg(old)
+    old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
     old.exec('PRAGMA user_version = 1')
     old.close()
 
@@ -128,7 +129,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     expect(cronColumns).toContain('definition')
     // Purge receipts are leased per pool member (#1032).
     expect(purgeColumns).toEqual(expect.arrayContaining(['ownerId', 'claimedAt']))
-    expect(userVersion(path)).toBe(11)
+    expect(userVersion(path)).toBe(12)
   })
 
   it.skipIf(pg)('never persists the CP routing map on a shared store, and still does on an owned one', async () => {
@@ -175,6 +176,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN ownerId')
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN claimedAt')
     dropTranscriptOrg(old)
+    old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
     old.exec('PRAGMA user_version = 5')
     old.close()
 
@@ -190,7 +192,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     expect(await upgraded.isCaptureExcluded('bot-c', 'acp-2')).toBe(true)
     await upgraded.close()
 
-    expect(userVersion(path)).toBe(11)
+    expect(userVersion(path)).toBe(12)
   })
 
   it('re-keys the runtime catalog cache on its owning member when upgrading a v7 store', async () => {
@@ -219,6 +221,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN ownerId')
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN claimedAt')
     dropTranscriptOrg(old)
+    old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
     old.exec('PRAGMA user_version = 7')
     old.close()
 
@@ -240,7 +243,30 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
         .map((column) => column.name)
     expect(primaryKey(metaColumns)).toEqual(['ownerId', 'runtimeId'])
     expect(primaryKey(capColumns)).toEqual(['ownerId', 'runtimeId', 'modelId'])
-    expect(userVersion(path)).toBe(11)
+    expect(userVersion(path)).toBe(12)
+  })
+
+  it('backfills a v11 store with the outward id its sessions were already reported under', async () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-schema-v11-')), 'local.sqlite')
+    await (await LocalStore.open(path)).close()
+    const old = new DatabaseSync(path)
+    old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
+    old.exec(`INSERT INTO sessions (key, agentId, platform, channel, thread, acpSessionId, state, updatedAt)
+      VALUES ('k1', 'bot-a', 'slack', 'C1', 'T1', 'acp-1', 'idle', 100)`)
+    // A session that never launched has no id to inherit — it gets one when it next needs one.
+    old.exec(`INSERT INTO sessions (key, agentId, platform, channel, thread, acpSessionId, state, updatedAt)
+      VALUES ('k2', 'bot-a', 'slack', 'C1', 'T2', NULL, 'idle', 100)`)
+    old.exec('PRAGMA user_version = 11')
+    old.close()
+
+    const upgraded = await LocalStore.open(path)
+    // The control plane already knows this session by its ACP id: renaming it would orphan the row.
+    expect((await upgraded.getSession('k1'))?.sessionId).toBe('acp-1')
+    expect((await upgraded.getSessionByOutwardId('acp-1'))?.key).toBe('k1')
+    expect((await upgraded.getSession('k2'))?.sessionId).toBeNull()
+    expect(await upgraded.ensureOutwardSessionId('k2', 'bot-a')).toMatch(/^[0-9a-f-]{36}$/)
+    await upgraded.close()
+    expect(userVersion(path)).toBe(12)
   })
 
   it('refuses a store written by a newer daemon WITHOUT touching it first', async () => {
@@ -706,6 +732,40 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     expect((await s.getSessionByAcpIdForAgent('bot-a', 'shared-acp-id'))?.key).toBe('k1')
     expect((await s.getSessionByAcpIdForAgent('bot-b', 'shared-acp-id'))?.key).toBe('k2')
     expect(await s.getSessionByAcpIdForAgent('bot-c', 'shared-acp-id')).toBeUndefined()
+    await s.close()
+  })
+
+  it('mints one outward id per slot, before the session row and across every later upsert', async () => {
+    const s = await store()
+    // A credential is issued before the turn writes the session, so the id must exist first.
+    const minted = await s.ensureOutwardSessionId('k1', 'bot-a')
+    expect(minted).toMatch(/^[0-9a-f-]{36}$/)
+    expect(await s.ensureOutwardSessionId('k1', 'bot-a')).toBe(minted)
+    await seed(s, 'k1', 'bot-a', 'acp-1', 100)
+    // The session proper landing on the skeleton row keeps the id the credential already carries.
+    expect((await s.getSession('k1'))?.sessionId).toBe(minted)
+    await seed(s, 'k1', 'bot-a', 'acp-rebuilt', 200)
+    // A rebuilt ACP hop is a new runtime instance of the SAME session: outward id unchanged.
+    expect((await s.getSession('k1'))?.sessionId).toBe(minted)
+    // A slot the daemon never issued a credential for gets its id from the upsert itself.
+    await seed(s, 'k2', 'bot-a', 'acp-2', 100)
+    const other = (await s.getSession('k2'))!.sessionId
+    expect(other).toMatch(/^[0-9a-f-]{36}$/)
+    expect(other).not.toBe(minted)
+    await s.close()
+  })
+
+  it('getSessionByOutwardId resolves the outward id, and falls back to the ACP one', async () => {
+    const s = await store()
+    await seed(s, 'k1', 'bot-a', 'acp-1', 100)
+    const outward = (await s.getSession('k1'))!.sessionId!
+    expect((await s.getSessionByOutwardId(outward))?.key).toBe('k1')
+    expect((await s.getSessionByOutwardId(outward, 'bot-a'))?.key).toBe('k1')
+    // Scoped to the agent that owns it, so a peer cannot read another org's session.
+    expect(await s.getSessionByOutwardId(outward, 'bot-b')).toBeUndefined()
+    // A caller still holding the runtime's name — or a CP row written before v12 — still lands.
+    expect((await s.getSessionByOutwardId('acp-1'))?.key).toBe('k1')
+    expect(await s.getSessionByOutwardId('nope')).toBeUndefined()
     await s.close()
   })
 
@@ -1381,26 +1441,41 @@ describe('LocalStore session retention GC (#485)', () => {
     // is no metadata row to mark and no receipt to keep.
     await seed(s, 'unbound', 'closed', 100, null)
 
+    // The receipt addresses the session by its outward id, not the ACP hop's.
+    const outward = (await s.getSession('gone'))!.sessionId!
     await s.deleteSession('gone', { reason: 'retention', at: 1_700 })
     await s.deleteSession('unbound', { reason: 'retention', at: 1_800 })
 
     expect(await s.listSessionPurges(10, 0)).toEqual([
-      { agentId: 'bot-a', sessionId: 'acp-gone', reason: 'retention', purgedAt: 1_700 }
+      { agentId: 'bot-a', sessionId: outward, reason: 'retention', purgedAt: 1_700 }
     ])
     await s.close()
   })
 
   it('a purge receipt survives until acknowledged, and only for the reported agent', async () => {
     const s = await store()
-    await seed(s, 'a', 'closed', 100)
+    // Both rows carry the SAME outward id — the shape a v11 store leaves behind, where the
+    // backfill took each session's runtime-local ACP id. The ACK fence is the agent, not the id.
+    await s.upsertSession({
+      key: 'a',
+      agentId: 'bot-a',
+      platform: 'slack',
+      channel: 'C1',
+      thread: 'a',
+      acpSessionId: 'acp-a',
+      sessionId: 'acp-a',
+      state: 'closed',
+      lastDeliveredTs: null,
+      updatedAt: 100
+    })
     await s.upsertSession({
       key: 'b',
       agentId: 'bot-b',
       platform: 'slack',
       channel: 'C1',
       thread: 'b',
-      // ACP ids are runtime-local: two agents can each have purged an `acp-1`.
       acpSessionId: 'acp-a',
+      sessionId: 'acp-a',
       state: 'closed',
       lastDeliveredTs: null,
       updatedAt: 100
@@ -1899,7 +1974,7 @@ describe('LocalStore recovery scope on a shared store (daemon pool)', () => {
   // member exactly like the hook-completion outbox — a peer's live row is never
   // offered, claimed, or released by anyone but its owner.
   const LEASE_MS = 2 * 60 * 1_000
-  const purged = async (s: LocalStore, key: string, agentId: string, ownerId: string, at: number) => {
+  const purged = async (s: LocalStore, key: string, agentId: string, ownerId: string, at: number): Promise<string> => {
     await s.upsertSession({
       key,
       agentId,
@@ -1911,7 +1986,9 @@ describe('LocalStore recovery scope on a shared store (daemon pool)', () => {
       lastDeliveredTs: null,
       updatedAt: 0
     })
+    const outward = (await s.getSession(key))!.sessionId!
     expect(await s.deleteSession(key, { reason: 'retention', at, ownerId })).toBe(true)
+    return outward
   }
   const ids = (rows: { sessionId: string }[]) => rows.map((row) => row.sessionId)
 
@@ -1919,19 +1996,19 @@ describe('LocalStore recovery scope on a shared store (daemon pool)', () => {
     const path = sharedPath()
     const a = await member(path, 'store-a')
     const b = await member(path, 'store-b')
-    await purged(a, 'from-a', 'agent-a', 'daemon-a', 1_000)
-    await purged(b, 'from-b', 'agent-b', 'daemon-b', 1_000)
+    const fromA = await purged(a, 'from-a', 'agent-a', 'daemon-a', 1_000)
+    const fromB = await purged(b, 'from-b', 'agent-b', 'daemon-b', 1_000)
 
-    expect(ids(await a.listSessionPurges(10, 1500, 'daemon-a', ['agent-a']))).toEqual(['acp-from-a'])
+    expect(ids(await a.listSessionPurges(10, 1500, 'daemon-a', ['agent-a']))).toEqual([fromA])
     // B serves both agents and still may not touch A's row: A's claim is live.
-    expect(ids(await b.listSessionPurges(10, 1500, 'daemon-b', ['agent-a', 'agent-b']))).toEqual(['acp-from-b'])
-    expect(await b.claimSessionPurges('agent-a', ['acp-from-a'], 'daemon-b', 1_500)).toEqual([])
+    expect(ids(await b.listSessionPurges(10, 1500, 'daemon-b', ['agent-a', 'agent-b']))).toEqual([fromB])
+    expect(await b.claimSessionPurges('agent-a', [fromA], 'daemon-b', 1_500)).toEqual([])
     // Nor release it: the ACK fence is the claim holder.
-    await b.acknowledgeSessionPurges('agent-a', ['acp-from-a'], 'daemon-b')
-    expect(ids(await a.listSessionPurges(10, 1500, 'daemon-a', []))).toEqual(['acp-from-a'])
+    await b.acknowledgeSessionPurges('agent-a', [fromA], 'daemon-b')
+    expect(ids(await a.listSessionPurges(10, 1500, 'daemon-a', []))).toEqual([fromA])
     // The owner renews and settles its own row.
-    expect(await a.claimSessionPurges('agent-a', ['acp-from-a'], 'daemon-a', 1_500)).toEqual(['acp-from-a'])
-    await a.acknowledgeSessionPurges('agent-a', ['acp-from-a'], 'daemon-a')
+    expect(await a.claimSessionPurges('agent-a', [fromA], 'daemon-a', 1_500)).toEqual([fromA])
+    await a.acknowledgeSessionPurges('agent-a', [fromA], 'daemon-a')
     expect(await a.listSessionPurges(10, 1_500, 'daemon-a', [])).toEqual([])
     await a.close()
     await b.close()
@@ -1941,16 +2018,16 @@ describe('LocalStore recovery scope on a shared store (daemon pool)', () => {
     const path = sharedPath()
     const a = await member(path, 'store-a')
     const b = await member(path, 'store-b')
-    await purged(a, 'from-a', 'agent-a', 'daemon-a', 1_000)
+    const fromA = await purged(a, 'from-a', 'agent-a', 'daemon-a', 1_000)
     const lapsed = 1_000 + LEASE_MS + 1
 
     // Still not B's to take while B does not serve the agent.
     expect(await b.listSessionPurges(10, lapsed, 'daemon-b', ['agent-b'])).toEqual([])
-    expect(ids(await b.listSessionPurges(10, lapsed, 'daemon-b', ['agent-a']))).toEqual(['acp-from-a'])
-    expect(await b.claimSessionPurges('agent-a', ['acp-from-a'], 'daemon-b', lapsed)).toEqual(['acp-from-a'])
+    expect(ids(await b.listSessionPurges(10, lapsed, 'daemon-b', ['agent-a']))).toEqual([fromA])
+    expect(await b.claimSessionPurges('agent-a', [fromA], 'daemon-b', lapsed)).toEqual([fromA])
     // The takeover is exclusive: the dead owner's id no longer holds the row.
     expect(await a.listSessionPurges(10, lapsed, 'daemon-a', [])).toEqual([])
-    expect(await a.claimSessionPurges('agent-a', ['acp-from-a'], 'daemon-a', lapsed)).toEqual([])
+    expect(await a.claimSessionPurges('agent-a', [fromA], 'daemon-a', lapsed)).toEqual([])
     await a.close()
     await b.close()
   })
@@ -1968,10 +2045,11 @@ describe('LocalStore recovery scope on a shared store (daemon pool)', () => {
       lastDeliveredTs: null,
       updatedAt: 0
     })
+    const outward = (await s.getSession('k'))!.sessionId!
     await s.deleteSession('k', { reason: 'retention', at: 1_000 })
-    expect(ids(await s.listSessionPurges(10, 1500, 'daemon-a', []))).toEqual(['acp-k'])
-    expect(await s.claimSessionPurges('agent-1', ['acp-k'], undefined, 1_500)).toEqual(['acp-k'])
-    await s.acknowledgeSessionPurges('agent-1', ['acp-k'])
+    expect(ids(await s.listSessionPurges(10, 1500, 'daemon-a', []))).toEqual([outward])
+    expect(await s.claimSessionPurges('agent-1', [outward], undefined, 1_500)).toEqual([outward])
+    await s.acknowledgeSessionPurges('agent-1', [outward])
     expect(await s.listSessionPurges(10, 1_500)).toEqual([])
     await s.close()
   })
@@ -2276,6 +2354,7 @@ describe.skipIf(pg)('transcript org migration from a v10 store', () => {
     old.exec(`INSERT INTO transcript (channel, thread, ts, sender, kind, text, recipient, eventTimeUs, revision)
       VALUES ('C1', 'T1', '1', 'U', 'text', 'kept', 'agent-a', 1000000, 1)`)
     old.exec("INSERT INTO transcript_recipient (channel, thread, ts, agentId) VALUES ('C1', 'T1', '1', 'agent-b')")
+    old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
     old.exec('PRAGMA user_version = 10')
     old.close()
     return path

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -755,6 +755,38 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     await s.close()
   })
 
+  it('a pre-session mint stages itself, leaving no half-built session behind', async () => {
+    const s = await store()
+    // The pool also issues credentials for keys that never become sessions at all.
+    const internal = await s.ensureOutwardSessionId('internal:memory:bot-a', 'bot-a')
+    expect(await s.getSession('internal:memory:bot-a')).toBeUndefined()
+    expect(await s.listSessions()).toEqual([])
+    expect(await s.ensureOutwardSessionId('internal:memory:bot-a', 'bot-a')).toBe(internal)
+
+    // A real slot mints the same way, and the turn's own insert adopts it — coordinates and all.
+    const minted = await s.ensureOutwardSessionId('k1', 'bot-a')
+    expect(await s.getSession('k1')).toBeUndefined()
+    await seed(s, 'k1', 'bot-a', 'acp-1', 100)
+    expect(await s.getSession('k1')).toMatchObject({
+      sessionId: minted,
+      platform: 'slack',
+      channel: 'C1',
+      thread: 'k1'
+    })
+    await s.close()
+  })
+
+  it('a purged slot does not hand its identity to the next session on the same key', async () => {
+    const s = await store()
+    await seed(s, 'k1', 'bot-a', 'acp-1', 100)
+    const first = (await s.getSession('k1'))!.sessionId
+    expect(await s.deleteSession('k1', { reason: 'retention', at: 1_000 })).toBe(true)
+    // The receipt just reported `first` as purged; reusing it would resurrect a dead row upstream.
+    await seed(s, 'k1', 'bot-a', 'acp-2', 200)
+    expect((await s.getSession('k1'))!.sessionId).not.toBe(first)
+    await s.close()
+  })
+
   it('getSessionByOutwardId resolves the outward id, and falls back to the ACP one', async () => {
     const s = await store()
     await seed(s, 'k1', 'bot-a', 'acp-1', 100)

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -438,8 +438,12 @@ describe('LocalStore', () => {
       updatedAt: 2
     })
 
+    // A source is named the way the dream will report it — outwardly (§1.1), since the citation
+    // becomes durable provenance the console reads back.
+    const outward = (await s.getSession(sessionKey('slack', 'C1', 'T1', 'bot-a')))!.sessionId
+    expect(outward).not.toBe('source-session')
     expect(await s.dreamSessionSources('bot-a', 20)).toEqual([
-      { sessionId: 'source-session', channel: 'C1', thread: 'T1', updatedAt: 1 }
+      { sessionId: outward, channel: 'C1', thread: 'T1', updatedAt: 1 }
     ])
     await s.close()
   })
@@ -815,6 +819,23 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     // The receipt just reported `first` as purged; reusing it would resurrect a dead row upstream.
     await seed(s, 'k1', 'bot-a', 'acp-2', 200)
     expect((await s.getSession('k1'))!.sessionId).not.toBe(first)
+    await s.close()
+  })
+
+  it('a record that outlives its session keeps the name it was written with', async () => {
+    const s = await store()
+    await seed(s, 'k1', 'bot-a', 'acp-1', 100)
+    const outward = (await s.getSession('k1'))!.sessionId!
+    // What a durable record (a dream, an advertisement) stores at write time.
+    const written = (await s.dreamSessionSources('bot-a', 10))[0]!.sessionId
+    expect(written).toBe(outward)
+
+    // Retention takes the session AND the staging row with it, so nothing can map acp → outward
+    // any more. A record that had resolved at READ time would answer with a different id from
+    // here on; one written with the outward name does not change.
+    expect(await s.deleteSession('k1', { reason: 'retention', at: 1_000 })).toBe(true)
+    expect(await s.getSessionByOutwardId(outward)).toBeUndefined()
+    expect(written).toBe(outward)
     await s.close()
   })
 

--- a/packages/daemon/test/model-key-session.test.ts
+++ b/packages/daemon/test/model-key-session.test.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 import { FakeClock } from '@agentconnect.md/connection'
 import { Daemon } from '../src/daemon.js'
@@ -14,7 +13,12 @@ function harness(grants: Array<Record<string, unknown>>) {
   const starts = vi.fn().mockResolvedValueOnce(firstHost).mockResolvedValueOnce(secondHost)
   ;(daemon as any).runtimes = { claude: { command: 'claude-agent-acp', args: [], env: [] } }
   ;(daemon as any).cpAgents = { orgForAgent: () => 'org-a' }
-  ;(daemon as any).store = { getSession: () => undefined, getModelOverride: () => undefined }
+  ;(daemon as any).store = {
+    getSession: () => undefined,
+    getModelOverride: () => undefined,
+    // The credential names the session by its outward id, minted here on first use.
+    ensureOutwardSessionId: async (key: string) => `outward-of-${key}`
+  }
   ;(daemon as any).startModelSessionRuntime = starts
   return { clock, daemon: daemon as any, issue, revoke, starts, firstHost, secondHost }
 }
@@ -44,7 +48,7 @@ describe('daemon model-key session lifecycle', () => {
     expect(h.issue).toHaveBeenCalledWith({
       orgId: 'org-a',
       agentId: 'agent-a',
-      sessionId: createHash('sha256').update('slack:C:T:agent-a').digest('hex'),
+      sessionId: 'outward-of-slack:C:T:agent-a',
       provider: 'anthropic',
       ttlSeconds: 3_600
     })

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -161,35 +161,70 @@ describe('the daemon records only its own host’s advertisement', () => {
     expect(reported.commands.map((c) => c.name)).toEqual(['code-review', 'superpowers:brainstorming', 'model'])
   })
 
-  // `newSession()` returns a session that can already stream updates, and the row that maps it to
-  // its slot is written only after that returns. An advertisement in THAT window is still recorded
-  // durably, so it must not fall back to the hop's id — nothing would repair it later.
-  it('names an advertisement that arrives before the session row exists', async () => {
+  // Production ordering, not a hand-driven one: the fake runtime advertises from INSIDE
+  // `newSession()`, in the window where the host has the id but has not returned it — the daemon
+  // has no row and, before the binding moved to the raw response, nothing to resolve through.
+  it('names an advertisement the runtime makes from inside session creation', async () => {
     const root = scaffold(['agent-1'])
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: null })
-    await daemon.start()
-    const host = daemon as unknown as {
-      hosts: Map<string, { hasSession(id: string): boolean; isLoadingSession(id: string): boolean }>
+    const advertise: { run: () => Promise<void> } = { run: async () => {} }
+    const acpSessionId = 'fresh-acp'
+    const hostFactory = (): unknown => {
+      const host = {
+        start: async () => {},
+        stop: async () => {},
+        hasSession: (id: string) => id === acpSessionId,
+        isLoadingSession: () => false,
+        newSession: async (
+          _cwd: string,
+          _servers: unknown,
+          _effort: unknown,
+          _append: unknown,
+          _dirs: unknown,
+          announce?: (id: string) => Promise<void> | void
+        ) => {
+          await announce?.(acpSessionId)
+          // Where `applySessionConfig()`'s awaited round trips would be.
+          await advertise.run()
+          return acpSessionId
+        },
+        prompt: async () => ({ stopReason: 'end_turn' })
+      }
+      return host
+    }
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      sandboxMechanism: null,
+      hostFactory: hostFactory as never
+    })
+    const inner = daemon as unknown as {
       onAcpUpdate(agentId: string, sessionId: string, update: unknown): Promise<void>
       runtimeCommands: RuntimeCommandsCache
       store: LocalStore
-      bindOutwardSessionId(agentId: string, key: string, acpSessionId: string): Promise<void>
     }
-    host.hosts.set('agent-1', {
-      hasSession: (id) => id === 'fresh-acp',
-      isLoadingSession: () => false,
-      stop: async () => {}
-    } as never)
-    const key = ['slack', 'C1', '100.1', 'agent-1'].join('\u001f')
+    advertise.run = async () => {
+      // No row yet — this is precisely the reported window.
+      expect(await inner.store.getSessionByAcpId(acpSessionId)).toBeUndefined()
+      await inner.onAcpUpdate('agent-1', acpSessionId, advertisement)
+    }
+    await daemon.start()
 
-    // What the opener does the instant the runtime hands back its id — before any upsert.
-    await host.bindOutwardSessionId('agent-1', key, 'fresh-acp')
-    expect(await host.store.getSessionByAcpId('fresh-acp')).toBeUndefined()
+    await (daemon as any).dispatch('agent-1', {
+      msgId: 'slack:C1:100.1',
+      traceId: 't1',
+      source: 'user',
+      platform: 'slack',
+      channel: 'C1',
+      thread: '100.1',
+      sender: { id: 'U1', isBot: false },
+      text: 'hi',
+      mentionedBots: [],
+      isDm: true
+    })
 
-    await host.onAcpUpdate('agent-1', 'fresh-acp', advertisement)
-    const outward = await host.store.ensureOutwardSessionId(key, 'agent-1')
-    expect(host.runtimeCommands.get('agent-1').sessionId).toBe(outward)
-    expect(outward).not.toBe('fresh-acp')
+    const recorded = inner.runtimeCommands.get('agent-1').sessionId
+    expect(recorded).not.toBe(acpSessionId)
+    expect(recorded).toBe((await inner.store.getSessionByAcpId(acpSessionId))!.sessionId)
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -169,10 +169,13 @@ describe('the daemon records only its own host’s advertisement', () => {
     const advertise: { run: () => Promise<void> } = { run: async () => {} }
     const acpSessionId = 'fresh-acp'
     const hostFactory = (): unknown => {
+      // Ownership follows the real host: false until `newSession()` has announced and made the
+      // session live, so an advertisement in that window would be DROPPED, not merely misnamed.
+      let live = false
       const host = {
         start: async () => {},
         stop: async () => {},
-        hasSession: (id: string) => id === acpSessionId,
+        hasSession: (id: string) => live && id === acpSessionId,
         isLoadingSession: () => false,
         newSession: async (
           _cwd: string,
@@ -180,9 +183,10 @@ describe('the daemon records only its own host’s advertisement', () => {
           _effort: unknown,
           _append: unknown,
           _dirs: unknown,
-          announce?: (id: string) => Promise<void> | void
+          announce?: (id: string) => void
         ) => {
-          await announce?.(acpSessionId)
+          announce?.(acpSessionId)
+          live = true
           // Where `applySessionConfig()`'s awaited round trips would be.
           await advertise.run()
           return acpSessionId

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -126,9 +126,17 @@ describe('runtime command advertisements', () => {
     const cache = new RuntimeCommandsCache()
     cache.record('mine', 'acp-1', advertisement, 0)
     cache.record('moved', 'acp-2', advertisement, 0)
-    const reader = createRuntimeCommandsReader(cache, (id) => id === 'mine')
+    // The advertising session crosses by its outward id (session-concept.md §1.1); the cache
+    // remembers the runtime's, so the reader translates.
+    const reader = createRuntimeCommandsReader(
+      cache,
+      (id) => id === 'mine',
+      async (_a, acp) => `sid-of-${acp}`
+    )
 
-    expect((await reader.list({ agentId: 'mine' })).commands).toHaveLength(3)
+    const mine = await reader.list({ agentId: 'mine' })
+    expect(mine.commands).toHaveLength(3)
+    expect(mine.sessionId).toBe('sid-of-acp-1')
     expect(await reader.list({ agentId: 'moved' })).toEqual({ reported: false, commands: [] })
   })
 })

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { Daemon } from '../src/daemon.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { scaffold } from './webchat-continuation-fixture.js'
+import type { LocalStore } from '../src/store/local-store.js'
 import { createRuntimeCommandsReader } from '../src/cp/runtime-commands-reader.js'
 import { pendingTurnKey } from '../src/daemon/turn-types.js'
 import {
@@ -158,6 +160,38 @@ describe('the daemon records only its own host’s advertisement', () => {
     expect(reported.sessionId).toBe('own-session')
     expect(reported.commands.map((c) => c.name)).toEqual(['code-review', 'superpowers:brainstorming', 'model'])
   })
+
+  // `newSession()` returns a session that can already stream updates, and the row that maps it to
+  // its slot is written only after that returns. An advertisement in THAT window is still recorded
+  // durably, so it must not fall back to the hop's id — nothing would repair it later.
+  it('names an advertisement that arrives before the session row exists', async () => {
+    const root = scaffold(['agent-1'])
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: null })
+    await daemon.start()
+    const host = daemon as unknown as {
+      hosts: Map<string, { hasSession(id: string): boolean; isLoadingSession(id: string): boolean }>
+      onAcpUpdate(agentId: string, sessionId: string, update: unknown): Promise<void>
+      runtimeCommands: RuntimeCommandsCache
+      store: LocalStore
+      bindOutwardSessionId(agentId: string, key: string, acpSessionId: string): Promise<void>
+    }
+    host.hosts.set('agent-1', {
+      hasSession: (id) => id === 'fresh-acp',
+      isLoadingSession: () => false,
+      stop: async () => {}
+    } as never)
+    const key = ['slack', 'C1', '100.1', 'agent-1'].join('\u001f')
+
+    // What the opener does the instant the runtime hands back its id — before any upsert.
+    await host.bindOutwardSessionId('agent-1', key, 'fresh-acp')
+    expect(await host.store.getSessionByAcpId('fresh-acp')).toBeUndefined()
+
+    await host.onAcpUpdate('agent-1', 'fresh-acp', advertisement)
+    const outward = await host.store.ensureOutwardSessionId(key, 'agent-1')
+    expect(host.runtimeCommands.get('agent-1').sessionId).toBe(outward)
+    expect(outward).not.toBe('fresh-acp')
+    await daemon.stop()
+  }, 15_000)
 
   // claude-agent-acp advertises AFTER the session/load response, so `live` already holds the session
   // by then — but that is one adapter's ordering, and the guard must not depend on it. A session the

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -126,17 +126,9 @@ describe('runtime command advertisements', () => {
     const cache = new RuntimeCommandsCache()
     cache.record('mine', 'acp-1', advertisement, 0)
     cache.record('moved', 'acp-2', advertisement, 0)
-    // The advertising session crosses by its outward id (session-concept.md §1.1); the cache
-    // remembers the runtime's, so the reader translates.
-    const reader = createRuntimeCommandsReader(
-      cache,
-      (id) => id === 'mine',
-      async (_a, acp) => `sid-of-${acp}`
-    )
+    const reader = createRuntimeCommandsReader(cache, (id) => id === 'mine')
 
-    const mine = await reader.list({ agentId: 'mine' })
-    expect(mine.commands).toHaveLength(3)
-    expect(mine.sessionId).toBe('sid-of-acp-1')
+    expect((await reader.list({ agentId: 'mine' })).commands).toHaveLength(3)
     expect(await reader.list({ agentId: 'moved' })).toEqual({ reported: false, commands: [] })
   })
 })

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -158,7 +158,15 @@ describe('SessionManager', () => {
 
     await sm.handle('bot-a', msg({ ts: '100.3', thread: '100.3', text: 'update production' }))
 
-    expect(host.newSession).toHaveBeenCalledWith(realpathSync(cwd), [], undefined, undefined, [realpathSync(repoRoot)])
+    // The trailing argument is the outward-id announce hook (session-concept.md §1.1).
+    expect(host.newSession).toHaveBeenCalledWith(
+      realpathSync(cwd),
+      [],
+      undefined,
+      undefined,
+      [realpathSync(repoRoot)],
+      expect.any(Function)
+    )
     await (await store).close()
   })
 
@@ -1402,7 +1410,14 @@ describe('SessionManager', () => {
     expect(host2.loadSession).toHaveBeenCalledTimes(1)
     expect(host2.loadSession.mock.calls[0]?.[3]).toBe('ultracode')
     expect(host2.discardSession).toHaveBeenCalledWith('acp-1')
-    expect(host2.newSession).toHaveBeenCalledWith(expect.any(String), [], undefined, undefined, [])
+    expect(host2.newSession).toHaveBeenCalledWith(
+      expect.any(String),
+      [],
+      undefined,
+      undefined,
+      [],
+      expect.any(Function)
+    )
     await (await store).close()
   })
 

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -158,14 +158,15 @@ describe('SessionManager', () => {
 
     await sm.handle('bot-a', msg({ ts: '100.3', thread: '100.3', text: 'update production' }))
 
-    // The trailing argument is the outward-id announce hook (session-concept.md §1.1).
+    // The trailing argument is the outward-id binder (session-concept.md §1.1); this harness
+    // wires no `prepareOutwardBinding`, so the opener has none to pass on.
     expect(host.newSession).toHaveBeenCalledWith(
       realpathSync(cwd),
       [],
       undefined,
       undefined,
       [realpathSync(repoRoot)],
-      expect.any(Function)
+      undefined
     )
     await (await store).close()
   })
@@ -1410,14 +1411,7 @@ describe('SessionManager', () => {
     expect(host2.loadSession).toHaveBeenCalledTimes(1)
     expect(host2.loadSession.mock.calls[0]?.[3]).toBe('ultracode')
     expect(host2.discardSession).toHaveBeenCalledWith('acp-1')
-    expect(host2.newSession).toHaveBeenCalledWith(
-      expect.any(String),
-      [],
-      undefined,
-      undefined,
-      [],
-      expect.any(Function)
-    )
+    expect(host2.newSession).toHaveBeenCalledWith(expect.any(String), [], undefined, undefined, [], undefined)
     await (await store).close()
   })
 

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -772,9 +772,11 @@ describe('SessionManager', () => {
     expect(appendArg).toContain('- Source: telegram')
     expect(appendArg).toContain('# Choosing whether to respond')
     expect(appendArg).toContain('AC_NO_RESPONSE')
-    // On a resume the session record already carries its acpSessionId (minted on the
-    // first turn), so the `- Session` locator line is present now.
-    expect(appendArg).toContain('- Session: acp-1')
+    // The locator line names the session OUTWARDLY (session-concept.md §1.1), never the runtime's
+    // id — and that one exists from the slot's first resolution, so it is there on every turn.
+    const outward = (await store.getSession(sessionKey('telegram', 'C1', '100.1', 'bot-a')))!.sessionId
+    expect(outward).not.toBe('acp-1')
+    expect(appendArg).toContain(`- Session: ${outward}`)
     await (await store).close()
   })
 

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -27,6 +27,7 @@ async function seedHistorySession(
     channel,
     thread,
     acpSessionId: 'acp-1',
+    sessionId: 'sid-1',
     state: 'idle',
     lastDeliveredTs: null,
     updatedAt: 1
@@ -81,6 +82,7 @@ describe('SessionReader', () => {
       thread: 'dm',
       transportScope: 'telegram:bot-b',
       acpSessionId: 'acp-scoped',
+      sessionId: 'sid-scoped',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1
@@ -122,11 +124,12 @@ describe('SessionReader', () => {
       channel: 'C1',
       thread: 'T1',
       acpSessionId: 'acp-1',
+      sessionId: 'sid-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1,
       triggeredBy: 'U1',
-      originSessionId: 'acp-parent'
+      originSessionId: 'sid-parent'
     })
     await s.upsertSession({
       key: sessionKey('slack', 'C2', 'T2', AGENT),
@@ -135,6 +138,7 @@ describe('SessionReader', () => {
       channel: 'C2',
       thread: 'T2',
       acpSessionId: 'acp-2',
+      sessionId: 'sid-2',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 2
@@ -146,15 +150,15 @@ describe('SessionReader', () => {
     const reader = createSessionReader(s)
     const { sessions } = await reader.list({})
     const byId = new Map(sessions.map((x) => [x.sessionId, x]))
-    expect(byId.get('acp-1')).toMatchObject({
-      parentSessionId: 'acp-parent',
+    expect(byId.get('sid-1')).toMatchObject({
+      parentSessionId: 'sid-parent',
       title: 'Roll back the deploy',
       channelName: 'deploys',
       triggeredBy: 'U1',
       triggeredByName: 'Dana Reyes'
     })
     // No cached names / no triggeredBy / no title → optional fields simply absent, ids intact.
-    const bare = byId.get('acp-2')!
+    const bare = byId.get('sid-2')!
     expect(bare.sessionKey.channel).toBe('C2')
     expect(bare.title).toBeUndefined()
     expect(bare.channelName).toBeUndefined()
@@ -173,6 +177,7 @@ describe('SessionReader', () => {
       channel: 'conv-1',
       thread: 'webchat:conv-1',
       acpSessionId: 'acp-wc',
+      sessionId: 'sid-wc',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 3,
@@ -204,6 +209,7 @@ describe('SessionReader', () => {
       channel: 'C9',
       thread: 'T9',
       acpSessionId: 'acp-titled',
+      sessionId: 'sid-titled',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 4
@@ -220,9 +226,9 @@ describe('SessionReader', () => {
 
     const byId = new Map((await createSessionReader(s).list({})).sessions.map((x) => [x.sessionId, x]))
     // Untitled webchat session ⇒ named from its first user message (never the agent reply).
-    expect(byId.get('acp-wc')!.title).toBe("what's your model?")
+    expect(byId.get('sid-wc')!.title).toBe("what's your model?")
     // Runtime title wins over the first-message fallback.
-    expect(byId.get('acp-titled')!.title).toBe('Runtime summary')
+    expect(byId.get('sid-titled')!.title).toBe('Runtime summary')
     await s.close()
   })
 
@@ -235,6 +241,7 @@ describe('SessionReader', () => {
       channel: 'C1',
       thread: 'T1',
       acpSessionId: 'acp-1',
+      sessionId: 'sid-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1
@@ -250,7 +257,7 @@ describe('SessionReader', () => {
     })
     await s.setDisplayName('U1', 'Dana Reyes', 1)
 
-    const title = (await createSessionReader(s).list({})).sessions.find((x) => x.sessionId === 'acp-1')!.title!
+    const title = (await createSessionReader(s).list({})).sessions.find((x) => x.sessionId === 'sid-1')!.title!
     expect(title.startsWith('@Dana Reyes ')).toBe(true) // leading mention rewritten to @name
     expect(title.endsWith('…')).toBe(true) // long body truncated with an ellipsis
     expect(title).not.toContain('second line') // only the first line is used
@@ -267,6 +274,7 @@ describe('SessionReader', () => {
       channel: 'C1',
       thread: '1710799200.123456',
       acpSessionId: 'acp-slack',
+      sessionId: 'sid-slack',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 2
@@ -279,6 +287,7 @@ describe('SessionReader', () => {
       channel: 'chat1',
       thread: 'T1',
       acpSessionId: 'acp-tg',
+      sessionId: 'sid-tg',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1
@@ -291,6 +300,7 @@ describe('SessionReader', () => {
       thread: '42',
       threadUrl: 'https://github.com/acme/infra/issues/42',
       acpSessionId: 'acp-github',
+      sessionId: 'sid-github',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 3
@@ -301,19 +311,19 @@ describe('SessionReader', () => {
       sessionThreadUrlFor(session, { workspaceUrl: 'https://acme.slack.com/' })
     )
     const byId = new Map((await withUrl.list({})).sessions.map((x) => [x.sessionId, x]))
-    expect(byId.get('acp-slack')!.threadUrl).toBe('https://acme.slack.com/archives/C1/p1710799200123456')
-    expect(byId.get('acp-tg')!.threadUrl).toBeUndefined()
-    expect(byId.get('acp-github')!.threadUrl).toBe('https://github.com/acme/infra/issues/42')
+    expect(byId.get('sid-slack')!.threadUrl).toBe('https://acme.slack.com/archives/C1/p1710799200123456')
+    expect(byId.get('sid-tg')!.threadUrl).toBeUndefined()
+    expect(byId.get('sid-github')!.threadUrl).toBe('https://github.com/acme/infra/issues/42')
 
     // No resolver leaves only the persisted links available.
     expect(
-      (await createSessionReader(s).list({})).sessions.find((x) => x.sessionId === 'acp-slack')!.threadUrl
+      (await createSessionReader(s).list({})).sessions.find((x) => x.sessionId === 'sid-slack')!.threadUrl
     ).toBeUndefined()
-    expect((await createSessionReader(s).list({})).sessions.find((x) => x.sessionId === 'acp-github')!.threadUrl).toBe(
+    expect((await createSessionReader(s).list({})).sessions.find((x) => x.sessionId === 'sid-github')!.threadUrl).toBe(
       'https://github.com/acme/infra/issues/42'
     )
     expect(
-      (await createSessionReader(s, () => undefined).list({})).sessions.find((x) => x.sessionId === 'acp-slack')!
+      (await createSessionReader(s, () => undefined).list({})).sessions.find((x) => x.sessionId === 'sid-slack')!
         .threadUrl
     ).toBeUndefined()
     await s.close()
@@ -331,6 +341,7 @@ describe('SessionReader', () => {
       thread: 'T1',
       transportScope,
       acpSessionId: 'acp-1',
+      sessionId: 'sid-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1
@@ -489,6 +500,7 @@ describe('SessionReader', () => {
       channel: 'C1',
       thread: 'T1',
       acpSessionId: 'acp-peer',
+      sessionId: 'sid-peer',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1
@@ -551,6 +563,7 @@ describe('SessionReader', () => {
       channel: 'C1',
       thread: 'T1',
       acpSessionId: 'acp-1',
+      sessionId: 'sid-1',
       state: 'idle',
       lastDeliveredTs: null,
       updatedAt: 1

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -50,6 +50,27 @@ describe('SessionReader', () => {
     await s.close()
   })
 
+  it('reads a session under the OUTWARD id the control plane knows it by', async () => {
+    const s = await store()
+    await seedHistorySession(s)
+    const key = sessionKey('slack', 'C1', 'T1', AGENT)
+    const outward = (await s.getSession(key))!.sessionId!
+    // The id the console holds came from this daemon's own metadata frame, and it is not the
+    // runtime's (session-concept.md §1.1) — a read that only knew ACP ids would answer empty.
+    expect(outward).not.toBe('acp-1')
+    const reader = await createSessionReader(s, undefined, {
+      transcriptPageForAgentByEventTime: async () => ({ rows: [], hasMore: false, cursor: 5 }),
+      transcriptPageForAgent: async () => ({ rows: [], hasMore: false, cursor: 5 }),
+      transcriptTailForAgent: async () => ({ rows: [], hasMore: false, cursor: 5 }),
+      currentTranscriptRevision: async () => 5,
+      getToolBodyForAgent: async () => undefined
+    } as never)
+    expect((await reader.history({ agentId: AGENT, sessionId: outward, limit: 20 })).liveCursor).toBe('5')
+    // A pre-v12 session was reported under its ACP id, so that still resolves.
+    expect((await reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 20 })).liveCursor).toBe('5')
+    await s.close()
+  })
+
   it('reads only the transcript namespace persisted on the session', async () => {
     const s = await store()
     await s.upsertSession({

--- a/packages/daemon/test/store-concurrency.test.ts
+++ b/packages/daemon/test/store-concurrency.test.ts
@@ -92,6 +92,8 @@ describe('LocalStore under interleaved turns', () => {
     const keys = [1, 2, 3, 4, 5, 6].map((n) => sessionKey('slack', 'C1', `T-tx-${n}`, 'bot-a'))
     for (const [index, key] of keys.entries()) await seedSession(s, key, 'bot-a', `acp-tx-${index}`)
 
+    const deletedOutwardIds = await Promise.all(keys.slice(3).map(async (key) => (await s.getSession(key))!.sessionId!))
+
     // Mutes and deletes, each a BEGIN…COMMIT block, all in flight against one store.
     await Promise.all([
       ...keys.slice(0, 3).map((key) => s.setSessionMuted(key, true)),
@@ -109,7 +111,9 @@ describe('LocalStore under interleaved turns', () => {
       expect(await s.isSessionMuted(key)).toBe(false)
     }
     const purged = await s.listSessionPurges(10, 1_500, 'daemon-a', ['bot-a'])
-    expect(purged.map((row) => row.sessionId).sort()).toEqual(['acp-tx-3', 'acp-tx-4', 'acp-tx-5'])
+    // Receipts name their sessions the outward way (session-concept.md §1.1), so compare against
+    // the ids the store minted for the three deleted slots.
+    expect(purged.map((row) => row.sessionId).sort()).toEqual(deletedOutwardIds.sort())
     await s.close()
   })
 

--- a/packages/daemon/test/store-retention.test.ts
+++ b/packages/daemon/test/store-retention.test.ts
@@ -63,6 +63,9 @@ async function seedEveryTable(s: LocalStore, agentId: string, tag: string, at: n
     updatedAt: at
   })
   await s.deleteSession(tag, { reason: 'retention', at, ownerId: owner })
+  // An outward id minted for a key that never becomes a session — the pool's internal dream /
+  // memory / commit work, which is exactly what this table's rule ages out.
+  await s.ensureOutwardSessionId(`internal:memory:${tag}`, agentId, at)
   // Written after the delete: `deleteSession` drops the session's own outbox snapshot with it.
   await s.saveSessionMetadataSnapshot(agentId, `acp-${tag}`, '{"phase":"end"}', true, at, owner)
   await s.recordWebchatMcpGrant({
@@ -175,6 +178,7 @@ describe('store retention rule table', () => {
     expect(summary!.byRule).toMatchObject({
       'hook-report': 1,
       'session-metadata': 1,
+      'outward-id': 1,
       'webchat-grant': 1,
       'memory-capture': 1,
       activation: 1,
@@ -182,8 +186,8 @@ describe('store retention rule table', () => {
       'catalog-meta': 0,
       'catalog-models': 0
     })
-    expect(summary).toMatchObject({ horizon: 5, agentGone: 0, deleted: 5, failed: 0 })
-    expect(logs.at(-1)).toContain('collected=5 deleted=5')
+    expect(summary).toMatchObject({ horizon: 6, agentGone: 0, deleted: 6, failed: 0 })
+    expect(logs.at(-1)).toContain('collected=6 deleted=6')
     expect(await remaining(s, 'hook-report')).toBe(0)
     expect(await remaining(s, 'session-purge')).toBe(1)
 
@@ -304,7 +308,7 @@ describe('store retention rule table', () => {
     const summary = await instance.sweep()
 
     expect(cp.asked).toEqual([[LIVE, GONE]])
-    expect(summary).toMatchObject({ agentGone: 5, horizon: 0, deleted: 5, failed: 0 })
+    expect(summary).toMatchObject({ agentGone: 6, horizon: 0, deleted: 6, failed: 0 })
     // Only the rules that name an agent; the agent-free ones are untouched by this proof.
     expect(summary!.byRule).toMatchObject({
       'hook-report': 1,
@@ -327,7 +331,7 @@ describe('store retention rule table', () => {
     const { instance, logs } = sweeper(b, AT + 1_000, { liveAgents: fakeCp().liveAgents })
     const summary = await instance.sweep()
 
-    expect(summary).toMatchObject({ agentGone: 5, collected: 5, deleted: 0 })
+    expect(summary).toMatchObject({ agentGone: 6, collected: 6, deleted: 0 })
     expect(logs.at(-1)).toContain('(orphan dry run)')
     expect(await remaining(b, 'hook-report')).toBe(1)
     await a.close()
@@ -342,7 +346,7 @@ describe('store retention rule table', () => {
     expect(fresh).toMatchObject({ agentGone: 0, collected: 0 })
 
     const aged = await sweeper(s, AT + DEFAULT_STORE_HORIZON_MS).instance.sweep()
-    expect(aged).toMatchObject({ agentGone: 0, horizon: 5, deleted: 5 })
+    expect(aged).toMatchObject({ agentGone: 0, horizon: 6, deleted: 6 })
     await s.close()
   })
 
@@ -444,7 +448,7 @@ describe('store retention rule table', () => {
     const { instance } = sweeper(s, AT + 30 * DAY)
     const summary = await instance.sweepAgeOnly()
 
-    expect(summary).toMatchObject({ agentGone: 0, horizon: 8, deleted: 8, failed: 0 })
+    expect(summary).toMatchObject({ agentGone: 0, horizon: 9, deleted: 9, failed: 0 })
     expect(await remaining(s, 'catalog-meta')).toBe(0)
     await s.close()
   })

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -555,8 +555,9 @@ export type AgentScopeDenied = z.infer<typeof AgentScopeDenied>
 export const AgentPermissionRequestRecord = z.object({
   id: z.string().uuid(),
   agentId: z.string().uuid(),
-  // Optional for rolling compatibility with daemons that predate session-scoped
-  // approval rendering. Current daemons always report the owning ACP session id.
+  // The owning session, by its outward id (session-concept.md §1.1) — the console scopes
+  // approvals to the session it is showing, by the id it routed on. Optional for rolling
+  // compatibility with daemons that predate session-scoped approval rendering.
   sessionId: z.string().min(1).optional(),
   createdAt: z.string().datetime(),
   requesterId: z.string().nullable(),

--- a/packages/protocol/src/frames/cron.ts
+++ b/packages/protocol/src/frames/cron.ts
@@ -71,8 +71,8 @@ export const CronReport = z.object({
   // Terminal outcome fields (absent on fire/session progress reports).
   status: CronRunStatus.optional(),
   durationMs: z.number().int().nonnegative().optional(), // fire → turn end
-  // Sent once the ACP session exists, then repeated on completion.
-  sessionId: z.string().optional(), // ACP session the run prompted (console deep-link)
+  // Sent once the session exists, then repeated on completion.
+  sessionId: z.string().optional(), // the session the run prompted, by its outward id (§1.1)
   reason: z.string().optional() // short failure text (status "failed")
 })
 export type CronReport = z.infer<typeof CronReport>

--- a/packages/protocol/src/frames/hook.ts
+++ b/packages/protocol/src/frames/hook.ts
@@ -249,7 +249,7 @@ export const HookReport = z
     gitlab: GitlabHookMetadata.optional(),
     status: z.enum(['success', 'failed']),
     durationMs: z.number().int().nonnegative().optional(), // dispatch → turn end
-    sessionId: z.string().optional(), // ACP session the run prompted (console deep-link)
+    sessionId: z.string().optional(), // the session the run prompted, by its outward id (§1.1)
     reason: z.string().optional(), // short failure text (status "failed")
     // A submitted result is repeated here as recovery if the immediate
     // github/review-result request was lost. No review/comment body crosses CP.
@@ -303,7 +303,7 @@ export const HookStart = z
     hookId: z.string().uuid(),
     agentId: z.string().uuid(),
     deliveryKey: z.string().min(1),
-    sessionId: z.string().min(1).optional(), // ACP session already created for this turn (rolling-compatible)
+    sessionId: z.string().min(1).optional(), // the turn's session by its outward id (§1.1); rolling-compatible
     event: z.string().min(1).optional(),
     // Provider one-of: exactly one member carries the trusted subject metadata.
     // `github` was required pre-GitLab, so every existing sender stays valid.

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -146,7 +146,7 @@ export const RcVerifyResult = z.object({
   // always includes the primary. Absent ⇒ single-agent conversation on an older CP.
   participants: z.array(RcWebchatParticipant).max(16).optional(),
   // Session-targeted continuation (webchat-cross-integration-continuation.md):
-  // the CP-selected target ACP session id. The relay copies it verbatim onto
+  // the CP-selected target session, by its outward id (§1.1). The relay copies it verbatim onto
   // every rd/msg for this conversation; it never originates in the browser and
   // is deliberately the only cross-system coordinate on the wire — every local
   // coordinate comes from the daemon's own session row.

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -206,7 +206,7 @@ export const RdMsgWebchat = z.object({
   sessionKey: z.string().min(1),
   msgId: z.string().min(1), // relay-minted idempotency key (unique per op)
   chatId: z.string().uuid(), // == conversationId (SessionKey.channel for 'webchat')
-  // Session-targeted continuation: the CP-verified target ACP session id,
+  // Session-targeted continuation: the CP-verified target session by its outward id (§1.1),
   // copied verbatim from the rc/verify verdict. Absent ⇒ today's behavior
   // (conversation-derived webchat session). Never originates in the browser.
   targetSessionId: z.string().min(1).optional(),

--- a/packages/protocol/src/frames/runtime-command.ts
+++ b/packages/protocol/src/frames/runtime-command.ts
@@ -32,7 +32,7 @@ export const RuntimeCommandsList = z
     reported: z.boolean(),
     /** When that advertisement arrived; the list survives the host stopping, so it can be stale. */
     updatedAt: z.string().optional(),
-    /** The ACP session it came from — a worktree-isolated session can advertise its own set. */
+    /** The session it came from, by its outward id (§1.1) — a worktree-isolated session can advertise its own set. */
     sessionId: z.string().optional(),
     commands: z.array(RuntimeCommand)
   })

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -38,7 +38,7 @@ export type SessionUsage = z.infer<typeof SessionUsage>
 
 /** One row in the session list (metadata + console metrics; NOT the transcript). */
 export const SessionListItem = z.object({
-  sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+  sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
   // The stable ACP session id that spawned this session through sendMessage.
   // Absent for root sessions. This is lineage metadata only, never a body.
   parentSessionId: z.string().optional(),
@@ -131,7 +131,7 @@ export const SessionHistoryReq = z
     // Optional only for rolling compatibility with an older CP. A current CP always
     // sends the authorized owner and the daemon re-checks the session binding.
     agentId: z.string().uuid().optional(),
-    sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+    sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
     cursor: z.string().optional(), // opaque; omit ⇒ newest page
     // Monotonic daemon-local transcript revision. Mutually exclusive with the
     // backward-pagination cursor; used by an open console view to pull inserts
@@ -150,7 +150,7 @@ export type SessionHistoryReq = z.infer<typeof SessionHistoryReq>
 
 /** D→C REP (corr = the req id): a page of messages + the cursor for the next page. */
 export const SessionHistoryPage = z.object({
-  sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+  sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
   messages: z.array(SessionMessage), // chronological oldest→newest within the page (seq breaks equal-time ties)
   nextCursor: z.string().optional(), // absent ⇒ no older messages
   // Optional for rolling compatibility. `liveCursor` is the next `after`
@@ -264,7 +264,7 @@ export type ChildSessionStatusProbe = z.infer<typeof ChildSessionStatusProbe>
  * and out-of-order application safe on the daemon.
  */
 export const SessionVisibilityPush = z.object({
-  sessionId: z.string().min(1), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+  sessionId: z.string().min(1), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
   // The session's owning agent. ACP session ids are runtime-local, so on a pool's
   // shared store the id alone names a gate every org could claim. Optional for
   // rolling upgrades: an older CP omits it and the daemon attributes the push to

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -38,7 +38,7 @@ export type SessionUsage = z.infer<typeof SessionUsage>
 
 /** One row in the session list (metadata + console metrics; NOT the transcript). */
 export const SessionListItem = z.object({
-  sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
+  sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1) — never the ACP hop's id
   // The stable ACP session id that spawned this session through sendMessage.
   // Absent for root sessions. This is lineage metadata only, never a body.
   parentSessionId: z.string().optional(),
@@ -131,7 +131,7 @@ export const SessionHistoryReq = z
     // Optional only for rolling compatibility with an older CP. A current CP always
     // sends the authorized owner and the daemon re-checks the session binding.
     agentId: z.string().uuid().optional(),
-    sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
+    sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1) — never the ACP hop's id
     cursor: z.string().optional(), // opaque; omit ⇒ newest page
     // Monotonic daemon-local transcript revision. Mutually exclusive with the
     // backward-pagination cursor; used by an open console view to pull inserts
@@ -150,7 +150,7 @@ export type SessionHistoryReq = z.infer<typeof SessionHistoryReq>
 
 /** D→C REP (corr = the req id): a page of messages + the cursor for the next page. */
 export const SessionHistoryPage = z.object({
-  sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
+  sessionId: z.string(), // the session's opaque outward identity (session-concept.md §1.1) — never the ACP hop's id
   messages: z.array(SessionMessage), // chronological oldest→newest within the page (seq breaks equal-time ties)
   nextCursor: z.string().optional(), // absent ⇒ no older messages
   // Optional for rolling compatibility. `liveCursor` is the next `after`
@@ -264,7 +264,7 @@ export type ChildSessionStatusProbe = z.infer<typeof ChildSessionStatusProbe>
  * and out-of-order application safe on the daemon.
  */
 export const SessionVisibilityPush = z.object({
-  sessionId: z.string().min(1), // the session's opaque outward identity (session-concept.md §1.1); the daemon still fills it from the ACP hop's id today
+  sessionId: z.string().min(1), // the session's opaque outward identity (session-concept.md §1.1) — never the ACP hop's id
   // The session's owning agent. ACP session ids are runtime-local, so on a pool's
   // shared store the id alone names a gate every org could claim. Optional for
   // rolling upgrades: an older CP omits it and the daemon attributes the push to

--- a/packages/protocol/src/frames/task.ts
+++ b/packages/protocol/src/frames/task.ts
@@ -7,7 +7,7 @@ import { z } from 'zod'
  * in the owning daemon's in-memory background-task lease, pulled live and proxied, never
  * persisted (body-locality — webchat-side-panels.md §2).
  *
- * Scoped per (agent, ACP session) because the lease already is: ACP session ids are
+ * Scoped per (agent, session) because the lease already is: ACP session ids are
  * runtime-local, so two agents can each expose an `acp-1`
  * (background-task-aware-reclaim.md §3).
  *
@@ -56,10 +56,11 @@ export const MAX_TASK_DETAIL = 200
 export const TaskState = z.enum(['running', 'done', 'failed'])
 export type TaskState = z.infer<typeof TaskState>
 
-/** C→D REQ: the background tasks of ONE ACP session of one agent. */
+/** C→D REQ: the background tasks of ONE session of one agent. */
 export const TaskListReq = z.object({
   agentId: z.string().min(1), // local agent id (NOT a wire UUID)
-  /** ACP session id — the lease's own scope, so this is required rather than optional. */
+  /** The session's outward id (§1.1) — the console asks by what it routed on, and the daemon
+   *  resolves the runtime-scoped lease behind it. Required: a lease has no meaning without one. */
   sessionId: z.string().min(1)
 })
 export type TaskListReq = z.infer<typeof TaskListReq>

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -77,7 +77,7 @@ export type ExternalSessionOrigin = z.infer<typeof ExternalSessionOrigin>
 
 /** Converged session lifecycle milestone — protocol §7.2. NOT the message stream. */
 export const EventSession = z.object({
-  sessionId: z.string(), // ACP session id (agent-assigned; a free string, NOT a wire UUID — matches usage/report)
+  sessionId: z.string(), // the session's outward identity (session-concept.md §1.1), never the ACP hop's
   // Stable ACP session id of the session that spawned this one. Absent for roots.
   // Stored as metadata so the console can navigate the session family.
   parentSessionId: z.string().optional(),
@@ -187,9 +187,9 @@ export const SessionPurged = z.object({
   // agent is placed on the reporting daemon, the same trust boundary as
   // `event/session`. A sweep spanning several agents sends several frames.
   agentId: z.string().uuid(),
-  // ACP session ids (agent-assigned strings, NOT wire UUIDs). Batched because a
-  // single sweep commonly expires many sessions at once; capped well under the
-  // frame budget so the daemon chunks instead of overflowing the wire.
+  // The purged sessions' outward ids (§1.1) — the rows these receipts mark over there. Batched
+  // because a single sweep commonly expires many sessions at once; capped well under the frame
+  // budget so the daemon chunks instead of overflowing the wire.
   sessionIds: z.array(z.string().min(1)).min(1).max(200),
   reason: SessionPurgeReason,
   ts: z.string().datetime()
@@ -211,7 +211,7 @@ export type ReportedSessionUsage = z.infer<typeof ReportedSessionUsage>
  * by `sessionId`: re-sending the same snapshot is a no-op upsert on the CP.
  */
 export const UsageReport = z.object({
-  sessionId: z.string(), // ACP session id (agent-assigned; NOT a wire UUID)
+  sessionId: z.string(), // the session's outward identity (§1.1) — the same id the gateway meters under
   agentId: z.string().uuid(),
   platform: z.string().optional(), // denormalized sessionKey echo for dashboard filters
   channel: z.string().optional(),

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -165,7 +165,7 @@ export const WebchatStatus = z.object({
   // config option only appears once a fast-capable model is selected). Absent/false ⇒
   // no fast toggle shown.
   fastModeAvailable: z.boolean().optional(),
-  // The daemon's session id (== acpSessionId) for this conversation, so the console can
+  // This conversation's session, by its outward id (session-concept.md §1.1), so the console can
   // deep-link to the session detail page. Absent until the session is created.
   sessionId: z.string().optional()
 })


### PR DESCRIPTION
Supersedes #1351 — that PR's doc commit is the first commit here, so doctrine and implementation land together.

## The problem

`session-concept.md` §1.1 says a session has two names for two scopes: `acpSessionId` for the ACP hop, `sessionId` for everyone else. The code had one name — whatever the ACP hop called it — and that name **cannot** be the outward one, because the moment it is first needed is `issueKey`: the model credential that STARTS the runtime, before any ACP id exists.

So `issueKey` sent `sha256(sessionKey)` instead. Stable, and opaque enough to keep platform coordinates out of the gateway, but resolvable by nothing outside the daemon — so every gateway-metered request landed under an identity the console could not match to the session that spent it. That is why per-session gateway spend reads as unattributed.

## What changes

**The store mints it.** `sessions` gains a `sessionId` column (schema v12). `upsertSession` mints one when the slot is created; `ensureOutwardSessionId(key, agentId)` mints earlier for the credential path, where the slot exists before the session row does. A rebuilt ACP hop overwrites `acpSessionId` and leaves `sessionId` alone — same session, new runtime instance.

**Outbound**, every frame naming the SESSION carries it: metadata snapshots (and the outbox row keyed by them, so a rebuilt hop updates one pending snapshot instead of opening a second), usage reports, purge receipts, and the credential's `session` claim.

**Inbound**, the boundary translates back: transcript/tool-body reads, the visibility push, workspace scope, and webchat delivery targets resolve by the outward id and fall back to the ACP id.

**Lineage too** (second commit). A child's `originSessionId` was the parent's ACP id, and that is what the child re-emits as `parentSessionId` — which the CP joins against `session_meta."id"`, the outward id. Left alone, the first commit would have broken that join for every new session: no console lineage, and a child that can never inherit its parent's visibility, so it stays private + unowned with a settlement that never settles (session-visibility.md §5.1). The same value is also a capability that travels to another agent and often another daemon — `sendMessage`'s SessionTarget, i.e. the `Session` / `Parent session` lines of the `# Agent` block — and an ACP id names a session only inside its own runtime. So `originSessionId`, `lineageReplyTo`, the durable parent link, the ids `viewSessionStatus` authorizes on, and both locator lines are now outward.

**What stays keyed by the runtime's id** is what lives on that hop: the capture gate, the SDK lease, pending-turn keys, a session's external origin, and every frame whose field is *named* `acpSessionId`. Those reads now take the ACP id explicitly instead of inheriting whatever the lineage variable held. §1.1 states both rules so they are readable from a frame alone.

## Compatibility

The v12 migration backfills `sessionId = acpSessionId` for every existing session, so nothing the control plane or the console already knows changes name, and receipts written on either side of the upgrade land on the same row. Inbound resolution falls back to the ACP id, so a wake from a daemon that has not upgraded still lands. The reverse — this daemon sending an outward id to a peer too old to resolve it — NAKs `not_found` for lineage replies until that peer upgrades; a pre-v12 session is unaffected either way, since its backfilled outward id IS its ACP id.

§1.1 also no longer claims the two ids normally agree: our adapters do not propose the outward id on `session/new` yet, so today they normally differ. Making them converge is the remaining follow-up.

## Tests

New: mint-once-per-slot (before the row, across upserts, across a rebuilt hop); `getSessionByOutwardId` resolution and ACP fallback; the v11→v12 backfill; a reader round-trip proving a session reads back under the id the daemon reported it by, and still under its ACP id.

Updated: every purge-receipt, metadata-frame, credential-claim and lineage assertion now names the outward id. A2A tests seed an outward id that deliberately DIFFERS from the ACP one, so a regression that leaks the runtime's name fails loudly instead of passing on a coincidence. One update was a latent bug in the test itself — it sorted the drain's own `sessionIds` array in place while the drain was still iterating it to ACK; ACP ids happened to be pre-sorted, so it never showed until the ids became UUIDs.

Full daemon suite is green apart from the 14 shim/worktree failures that also fail on `main` in this environment.