### PR TITLE
fix(daemon): key skill ownership by the real directory, not the harness name

### DIFF
--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -473,8 +473,13 @@ node <bundled skills@1.5.21 bin> add <absoluteSnapshot> \
   hashes a canonical `{path, mode, size, sha256}` manifest for each bundle.
 - One atomic daemon-owned ledger keyed by canonical cwd records the owning agent
   ID even for an empty skill set, plus the plan fingerprint, exact CLI version,
-  source identity, CLI-derived roots, and file manifests. The unchanged fast path
-  re-hashes every owned live tree; existence alone is insufficient.
+  source identity, CLI-derived roots, and file manifests. A CLI-derived root is
+  canonicalized through contained workspace-local aliases before it is compared or
+  recorded, so one directory has one owner no matter which harness named it — a
+  repository that exposes `.agents/skills` as a link to `.claude/skills` gets a
+  renamed receipt on a runtime switch, not a second installation over the first.
+  The unchanged fast path re-hashes every owned live tree; existence alone is
+  insufficient.
 - An external SQLite lease serializes every process that can mutate the same
   canonical workspace. `BEGIN IMMEDIATE` protects the workspace key,
   owner-PID/token, and optional detached-helper process-group ID. A live owner or
@@ -495,7 +500,10 @@ node <bundled skills@1.5.21 bin> add <absoluteSnapshot> \
   or receipt-bound tree. Before that authority exists it may remove only
   content-free crash shapes: an empty target directory, or an empty target that
   contains only the expected empty marker. Any other partial tree fails closed.
-  Unowned/manual destinations are never overwritten or adopted.
+  Unowned/manual destinations are never overwritten or adopted. A candidate whose
+  destination is unowned is skipped and reported as a conflict rather than failing
+  the workspace: leaving that path untouched is what the refusal wanted, and one
+  foreign directory must not cost the agent its other skills or its host startup.
 - A source/CLI failure clears previously owned content and starts without managed
   skills. A refused stale removal, corrupt journal, or failed rollback blocks the
   workspace so disabled executable instructions cannot remain silently active.

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -295,7 +295,8 @@ async function installSkillsLocked(
         candidates: [],
         gitResolutions: retainedGitResolutions,
         legacyOwned: legacyState.owned,
-        lockHeld: true
+        lockHeld: true,
+        warn: opts.warn
       })
       result.removed.push(...reconciled.removed)
       return result
@@ -447,11 +448,15 @@ async function installSkillsLocked(
       candidates,
       gitResolutions: nextGitResolutions,
       legacyOwned: legacyState.owned,
-      lockHeld: true
+      lockHeld: true,
+      warn: opts.warn
     })
     result.installed.push(...reconciled.installed)
     result.removed.push(...reconciled.removed)
     result.skipped = reconciled.skipped
+    for (const conflict of reconciled.conflicts) {
+      result.errors.push({ source: conflict, error: 'destination is not owned by this daemon ledger; skill skipped' })
+    }
     return result
   } catch (error) {
     if (error instanceof SkillLedgerSafetyError) throw error
@@ -478,7 +483,8 @@ async function installSkillsLocked(
         candidates: [],
         gitResolutions: retainedGitResolutions,
         legacyOwned: legacyState.owned,
-        lockHeld: true
+        lockHeld: true,
+        warn: opts.warn
       })
       result.removed.push(...cleared.removed)
       return result

--- a/packages/daemon/src/skills/skill-install-ledger.ts
+++ b/packages/daemon/src/skills/skill-install-ledger.ts
@@ -514,7 +514,8 @@ async function reconcileSkillBundlesLocked(
       agentId: options.agentId,
       runtime: options.runtime,
       cliVersion: options.cliVersion,
-      fingerprint: options.fingerprint,
+      // A skipped conflict leaves the plan unmet, so keep the fingerprint non-matching and let the next preparation retry once the path is clear.
+      fingerprint: conflicts.length > 0 ? `conflicts:${randomUUID()}` : options.fingerprint,
       owned,
       gitResolutions,
       cleanup: { operations, prior }

--- a/packages/daemon/src/skills/skill-install-ledger.ts
+++ b/packages/daemon/src/skills/skill-install-ledger.ts
@@ -4,7 +4,7 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { under } from '../fs/contained-path.js'
 import { inspectLocalSkillSource } from './skill-source-snapshot.js'
-import { runSkillWorkspaceMutation } from './skill-workspace-mutator.js'
+import { canonicalSkillMutationRoot, runSkillWorkspaceMutation } from './skill-workspace-mutator.js'
 import { withSkillMutationHelperLease, type SkillMutationHelperLease } from './skill-workspace-lock-lease.js'
 
 // An applying/cleanup journal can contain two complete receipt sets: up to 64
@@ -123,12 +123,16 @@ export interface ReconcileSkillBundlesOptions {
   legacyOwned?: string[]
   /** The caller already holds `withSkillWorkspaceLock` across acquisition. */
   lockHeld?: boolean
+  /** Reports a bundle skipped because its destination is not this ledger's to write. */
+  warn?: (message: string) => void
 }
 
 export interface ReconcileSkillBundlesResult {
   installed: string[]
   removed: string[]
   skipped: 'unchanged' | null
+  /** Destinations left untouched because they are not owned by this ledger. */
+  conflicts: string[]
 }
 
 export class SkillLedgerSafetyError extends Error {
@@ -305,6 +309,48 @@ export async function recoverSkillLedger(
   }
 }
 
+// Two harnesses name one root differently (.agents/skills vs .claude/skills, commonly symlinked), so key ownership by the real directory.
+async function canonicalizeRelativeRoot(cwd: string, relativeRoot: string): Promise<string> {
+  try {
+    const canonical = await canonicalSkillMutationRoot(cwd, relativeRoot)
+    if (canonical === relativeRoot) return relativeRoot
+    validateRelativeRoot(canonical)
+    return canonical
+  } catch {
+    // An alias that escapes the workspace is still refused where it is written, so keeping the original defers to that check.
+    return relativeRoot
+  }
+}
+
+async function canonicalizeCandidates(
+  cwd: string,
+  candidates: CandidateSkillBundle[]
+): Promise<CandidateSkillBundle[]> {
+  const resolved: CandidateSkillBundle[] = []
+  for (const candidate of candidates) {
+    resolved.push({ ...candidate, relativeRoot: await canonicalizeRelativeRoot(cwd, candidate.relativeRoot) })
+  }
+  return resolved
+}
+
+async function canonicalizeOwned(cwd: string, owned: OwnedSkillBundle[]): Promise<OwnedSkillBundle[]> {
+  const resolved: OwnedSkillBundle[] = []
+  for (const entry of owned) {
+    resolved.push({ ...entry, relativeRoot: await canonicalizeRelativeRoot(cwd, entry.relativeRoot) })
+  }
+  return resolved
+}
+
+async function destinationOccupied(cwd: string, relativeRoot: string): Promise<boolean> {
+  try {
+    await fsp.lstat(join(cwd, ...relativeRoot.split('/')))
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
+}
+
 export async function reconcileSkillBundles(
   options: ReconcileSkillBundlesOptions
 ): Promise<ReconcileSkillBundlesResult> {
@@ -329,34 +375,41 @@ async function reconcileSkillBundlesLocked(
       ledger.fingerprint === options.fingerprint &&
       (await installedBundlesIntact(options.cwd, ledger.owned, location.workspaceIdentity))
     ) {
-      return { installed: [], removed: [], skipped: 'unchanged' }
+      return { installed: [], removed: [], skipped: 'unchanged', conflicts: [] }
     }
 
-    const candidates = dedupeCandidates(options.candidates)
+    const deduped = dedupeCandidates(await canonicalizeCandidates(options.cwd, options.candidates))
     const gitResolutions = validateGitResolutions(options.gitResolutions ?? [])
-    for (const candidate of candidates) {
+    for (const candidate of deduped) {
       validateCandidate(candidate)
       if (!(await bundleIdentity(candidate.sourceDir, candidate))) {
         throw safety(`candidate skill receipt does not match ${candidate.relativeRoot}`)
       }
     }
 
-    const prior = ledger?.owned ?? []
+    // Canonicalize the recorded set too: a ledger written under another harness names the same directory by its other root.
+    const prior = await canonicalizeOwned(options.cwd, ledger?.owned ?? [])
     const priorByPath = new Map(prior.map((entry) => [entry.relativeRoot, entry]))
-    const legacyHints = new Set(options.legacyOwned ?? [])
-    for (const candidate of candidates) {
-      if (priorByPath.has(candidate.relativeRoot)) continue
-      const target = join(options.cwd, ...candidate.relativeRoot.split('/'))
-      try {
-        await fsp.lstat(target)
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
-        throw error
+    const legacyHints = new Set<string>()
+    for (const hint of options.legacyOwned ?? []) {
+      legacyHints.add(await canonicalizeRelativeRoot(options.cwd, hint))
+    }
+    const conflicts: string[] = []
+    const candidates: CandidateSkillBundle[] = []
+    for (const candidate of deduped) {
+      if (
+        priorByPath.has(candidate.relativeRoot) ||
+        !(await destinationOccupied(options.cwd, candidate.relativeRoot))
+      ) {
+        candidates.push(candidate)
+        continue
       }
       const detail = legacyHints.has(candidate.relativeRoot)
         ? 'legacy workspace marker is not trusted; remove or migrate it explicitly'
         : 'the path is not owned by this daemon ledger'
-      throw safety(`refusing to overwrite unowned skill ${candidate.relativeRoot}: ${detail}`)
+      // Skipping leaves the path untouched, which is what refusing wanted; one foreign bundle must not stop every other skill.
+      conflicts.push(candidate.relativeRoot)
+      options.warn?.(`skills: skipped unowned skill ${candidate.relativeRoot}: ${detail}`)
     }
 
     const paths = [
@@ -478,7 +531,8 @@ async function reconcileSkillBundlesLocked(
     return {
       installed: candidates.map((entry) => entry.relativeRoot),
       removed: prior.map((entry) => entry.relativeRoot),
-      skipped: null
+      skipped: null,
+      conflicts
     }
   } catch (error) {
     if (recoveryLedger && location) {

--- a/packages/daemon/test/unified-skills.test.ts
+++ b/packages/daemon/test/unified-skills.test.ts
@@ -122,9 +122,86 @@ describe.skipIf(!hasBwrap)('unified isolated skill installation', () => {
     })
 
     expect(result.errors).toEqual([])
-    expect(result.installed).toEqual(['.agents/skills/audit'])
+    // Ownership is reported by the real directory, not by whichever root the harness named.
+    expect(result.installed).toEqual(['.claude/skills/audit'])
     expect(await readFile(join(cwd, '.claude/skills/audit/SKILL.md'), 'utf8')).toContain('# audit')
   })
+
+  it('keeps an aliased skill root owned across a harness switch', async () => {
+    const sourceDir = await writeSkill(sources, 'aliased', 'v1')
+    const localSkills: LocalSkillSource[] = [{ kind: 'dream', key: 'dream:aliased', name: 'aliased', sourceDir }]
+    await mkdir(join(cwd, '.claude/skills'), { recursive: true })
+    await mkdir(join(cwd, '.agents'))
+    await symlink('../.claude/skills', join(cwd, '.agents/skills'))
+    // Claude names the root .claude/skills; Codex names that same directory .agents/skills.
+    const cli = fakeCli((agentId) => (agentId === 'claude-code' ? '.claude' : '.agents'))
+
+    const first = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, {
+      stateDir,
+      localSkills,
+      runCli: cli.run
+    })
+    expect(first.errors).toEqual([])
+    expect(existsSync(join(cwd, '.claude/skills/aliased/SKILL.md'))).toBe(true)
+
+    const switched = await installSkills({ id: 'a1', runtime: 'codex', skills: [] }, cwd, {
+      stateDir,
+      localSkills,
+      runCli: cli.run
+    })
+
+    // The switch must not read its own bundle as a foreign path, and both harnesses must agree on the real directory.
+    expect(switched.errors).toEqual([])
+    expect(switched.installed).toEqual(['.claude/skills/aliased'])
+    // Surviving bytes are the proof it was not installed under one root and then removed under the other.
+    expect(await readFile(join(cwd, '.claude/skills/aliased/SKILL.md'), 'utf8')).toContain('# v1')
+  }, 120_000)
+
+  it('skips a foreign bundle at one destination instead of failing the whole install', async () => {
+    const takenDir = await writeSkill(sources, 'taken', 'ours')
+    const freshDir = await writeSkill(sources, 'fresh', 'fresh')
+    const cli = fakeCli(() => '.runtime')
+    await mkdir(join(cwd, '.runtime/skills/taken'), { recursive: true })
+    await writeFile(join(cwd, '.runtime/skills/taken/SKILL.md'), 'not ours')
+    const warnings: string[] = []
+
+    const result = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, {
+      stateDir,
+      localSkills: [
+        { kind: 'dream', key: 'dream:taken', name: 'taken', sourceDir: takenDir },
+        { kind: 'dream', key: 'dream:fresh', name: 'fresh', sourceDir: freshDir }
+      ],
+      runCli: cli.run,
+      warn: (message) => warnings.push(message)
+    })
+
+    expect(result.errors).toEqual([
+      { source: '.runtime/skills/taken', error: 'destination is not owned by this daemon ledger; skill skipped' }
+    ])
+    expect(warnings.some((message) => message.includes('skipped unowned skill .runtime/skills/taken'))).toBe(true)
+    // The foreign bytes stay untouched, and one conflict does not cost the agent its other skills.
+    expect(await readFile(join(cwd, '.runtime/skills/taken/SKILL.md'), 'utf8')).toBe('not ours')
+    expect(existsSync(join(cwd, '.runtime/skills/fresh/SKILL.md'))).toBe(true)
+  }, 120_000)
+
+  it('refuses a skill-root alias that resolves outside the workspace', async () => {
+    const sourceDir = await writeSkill(sources, 'escape', 'escape')
+    const outside = join(root, 'outside')
+    await mkdir(outside, { recursive: true })
+    await mkdir(join(cwd, '.agents'))
+    await symlink(outside, join(cwd, '.agents/skills'))
+    const cli = fakeCli(() => '.agents')
+
+    // Containment is the security boundary, so an escaping alias fails closed rather than degrading to a skip.
+    await expect(
+      installSkills({ id: 'a1', runtime: 'codex-acp', skills: [] }, cwd, {
+        stateDir,
+        localSkills: [{ kind: 'dream', key: 'dream:escape', name: 'escape', sourceDir }],
+        runCli: cli.run
+      })
+    ).rejects.toThrow(/resolves outside workspace|mutation was refused|could not be restored/)
+    expect(existsSync(join(outside, 'escape'))).toBe(false)
+  }, 120_000)
 
   it.each([
     ['direct skills root', ''],

--- a/packages/daemon/test/unified-skills.test.ts
+++ b/packages/daemon/test/unified-skills.test.ts
@@ -182,6 +182,30 @@ describe.skipIf(!hasBwrap)('unified isolated skill installation', () => {
     // The foreign bytes stay untouched, and one conflict does not cost the agent its other skills.
     expect(await readFile(join(cwd, '.runtime/skills/taken/SKILL.md'), 'utf8')).toBe('not ours')
     expect(existsSync(join(cwd, '.runtime/skills/fresh/SKILL.md'))).toBe(true)
+
+    // An unmet plan must not be recorded as satisfied: the conflict has to keep being reported and retried.
+    const repeated = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, {
+      stateDir,
+      localSkills: [
+        { kind: 'dream', key: 'dream:taken', name: 'taken', sourceDir: takenDir },
+        { kind: 'dream', key: 'dream:fresh', name: 'fresh', sourceDir: freshDir }
+      ],
+      runCli: cli.run
+    })
+    expect(repeated.skipped).toBeNull()
+    expect(repeated.errors).toHaveLength(1)
+
+    await rm(join(cwd, '.runtime/skills/taken'), { recursive: true })
+    const cleared = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, {
+      stateDir,
+      localSkills: [
+        { kind: 'dream', key: 'dream:taken', name: 'taken', sourceDir: takenDir },
+        { kind: 'dream', key: 'dream:fresh', name: 'fresh', sourceDir: freshDir }
+      ],
+      runCli: cli.run
+    })
+    expect(cleared.errors).toEqual([])
+    expect(await readFile(join(cwd, '.runtime/skills/taken/SKILL.md'), 'utf8')).toContain('# ours')
   }, 120_000)
 
   it('refuses a skill-root alias that resolves outside the workspace', async () => {


### PR DESCRIPTION
## What broke

Switching an agent's runtime between harnesses could permanently stop that agent from starting. Every delivery failed within seconds with:

```
Agent failed to respond: refusing to overwrite unowned skill .agents/skills/<name>:
the path is not owned by this daemon ledger
```

It never recovered on its own, and it left no daemon log line — the only trace was in the session transcript.

## Why

A CLI-derived skill root is whatever the pinned skills CLI picks for the runtime, so the path string changes with the harness: `.claude/skills/<name>` under one, `.agents/skills/<name>` under another. A repository may legitimately expose one as a symlink to the other so repo-committed skills are visible to every harness.

`allow contained skill root aliases` (#796) taught the **mutation** layer to resolve that alias, but the install ledger still keyed ownership on the literal relative path. So after a runtime switch:

1. the ledger owned the directory under its old name;
2. the new candidate named the same directory under the new name;
3. `priorByPath` missed, `lstat` followed the symlink and found the bundle the daemon had written itself;
4. it refused — **fatally**, aborting agent startup rather than just that one skill.

Because the leftover bundle is untracked, no `git` operation would ever clear it, so the failure latched.

## What changed

Canonicalize the CLI-derived root through the existing `canonicalSkillMutationRoot` before it is compared or recorded — on candidates, on the recorded set, and on legacy hints.

- Canonicalizing the **recorded set** is what lets an existing ledger migrate instead of colliding on the first run after upgrade. Doing only the candidates would break every workspace on the release that ships it.
- With both sides naming one directory, a runtime switch **renames the receipt** instead of installing under the new root and then removing the old one — which resolves to the same directory and would have deleted the bundle just written.
- A root whose canonical form is not a valid receipt path keeps its original value, so an alias pointing somewhere unexpected degrades to today's behavior instead of hard-failing.

An unowned destination also stops being fatal: that one candidate is skipped, returned in a new `conflicts` field, and reported through the existing `warn` sink the workspace manager already routes to the daemon log. Skipping leaves the path untouched, which is what the refusal wanted — the difference is that one foreign directory no longer costs an agent its other skills or its startup.

Containment is unchanged. An alias resolving outside the workspace still fails closed at the write layer, and unowned content is still never adopted — the invariant in `shared-skills.md` §6.3 holds.

## Reviewer notes

- `ReconcileSkillBundlesResult` gains `conflicts: string[]`; `ReconcileSkillBundlesOptions` gains `warn?`. Both are daemon-internal.
- `installed` / `removed` now report the canonical root. One existing expectation changed from `.agents/skills/audit` to `.claude/skills/audit` — same directory, reported by its real path.
- A skipped bundle now surfaces as a `result.errors` entry rather than a thrown `SkillLedgerSafetyError`. Other safety errors are untouched and still block host startup, per the contract documented at the `installSkills` call site.
- `docs/designs/shared-skills.md` §6.3 and the ownership bullet updated to match.

## Tests

Three new cases in `unified-skills.test.ts`: an aliased root surviving a harness switch, a foreign bundle at one destination being skipped without costing the other skill, and an escaping alias still failing closed.

These suites are gated on `bwrap`, so they self-skip on macOS. Verified on an x86_64 Linux host with bubblewrap 0.9.0 and unprivileged userns enabled:

- `unified-skills.test.ts` — 27/27
- `skill-install-ledger.test.ts` — 7/7
- `skill-workspace-mutator.test.ts` — 3/3

Pre-existing security coverage still passes, including `refuses a workspace-planted parent symlink without touching the outside canary`, `does not inherit deletion authority when a workspace path is recreated`, and `removes the old CLI-derived root on a harness switch and preserves unowned skills`.

`pnpm typecheck`, `pnpm lint`, and `pnpm format:check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)