### PR TITLE
feat(control-plane): withhold undecodable agent specs from mixed-version daemons

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -689,7 +689,13 @@ export function buildContainer(
   )
 
   // The fan-out that rides the resolver (orchestrator/agentDelivery.ts).
-  const agentDelivery = new AgentDelivery({ control: sender, specs: agentSpecs, placement: placementResolver })
+  const agentDelivery = new AgentDelivery({
+    control: sender,
+    specs: agentSpecs,
+    placement: placementResolver,
+    // §17.3 projection gate: live advertised features; unknown daemon reads fail-closed.
+    daemonFeatures: (daemonId) => connReg.get(daemonId)?.capabilities?.features
+  })
 
   // The projections that BAKE IN the serving daemon — hook rules, HTTP-bot assignment, the
   // collaboration snapshot. A duty grant or release moves who serves an agent exactly as a

--- a/packages/control-plane/src/domain/daemon-features.test.ts
+++ b/packages/control-plane/src/domain/daemon-features.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { GITLAB_COM_V1_FEATURE } from '@agentconnect.md/protocol'
+import { daemonSupportsAgent, requiredDaemonFeatures } from './daemon-features.js'
+import type { AgentRecord } from '../persistence/ports.js'
+
+const workspace = (mode: string) => ({ workspace: { mode } as AgentRecord['workspace'] })
+
+describe('§17.3 snapshot projection gate predicate', () => {
+  it('requires nothing for every storable workspace shape today', () => {
+    expect(requiredDaemonFeatures(workspace('scratch'))).toEqual([])
+    expect(requiredDaemonFeatures(workspace('github'))).toEqual([])
+  })
+
+  it('gates a gitlab-shaped workspace on gitlab-com-v1', () => {
+    expect(requiredDaemonFeatures(workspace('gitlab'))).toEqual([GITLAB_COM_V1_FEATURE])
+  })
+
+  it('fails closed: absent or feature-less advertisements support only ungated agents', () => {
+    expect(daemonSupportsAgent(workspace('github'), undefined)).toBe(true)
+    expect(daemonSupportsAgent(workspace('gitlab'), undefined)).toBe(false)
+    expect(daemonSupportsAgent(workspace('gitlab'), [])).toBe(false)
+    expect(daemonSupportsAgent(workspace('gitlab'), ['some-other-feature'])).toBe(false)
+    expect(daemonSupportsAgent(workspace('gitlab'), [GITLAB_COM_V1_FEATURE])).toBe(true)
+  })
+})

--- a/packages/control-plane/src/domain/daemon-features.ts
+++ b/packages/control-plane/src/domain/daemon-features.ts
@@ -1,0 +1,35 @@
+/**
+ * §17.3 snapshot projection gate (gitlab-com-integration.md).
+ *
+ * The daemon reads CP-authored frames tolerantly, but tolerance covers unknown
+ * KEYS only — a new union arm or enum value inside `register/ok` or
+ * `agent/upsert` makes the whole frame undecodable on a pre-GitLab daemon,
+ * killing its GitHub work too. So the CP must never project a GitLab-shaped
+ * spec (or place such an agent) onto a daemon that has not advertised
+ * `gitlab-com-v1`. This module is the one predicate every projection and
+ * placement site asks; it lands before any GitLab-shaped value can exist, so
+ * the first one to exist is born gated.
+ */
+import { GITLAB_COM_V1_FEATURE } from '@agentconnect.md/protocol'
+import type { AgentRecord } from '../persistence/ports.js'
+
+type WorkspaceShapedAgent = Pick<AgentRecord, 'workspace'>
+
+/** Features a daemon must advertise before this agent's spec can decode there. */
+export function requiredDaemonFeatures(agent: WorkspaceShapedAgent): readonly string[] {
+  // The workspace union's 'gitlab' arm arrives with the M4 daemon slice; until a
+  // row can carry it this returns [] for every agent, and the comparison stays a
+  // string so the arm lights the gate up without touching this file again.
+  return (agent.workspace.mode as string) === 'gitlab' ? [GITLAB_COM_V1_FEATURE] : []
+}
+
+/** Fail-closed: unknown/absent advertised features support only feature-free agents. */
+export function daemonSupportsAgent(
+  agent: WorkspaceShapedAgent,
+  advertisedFeatures: readonly string[] | undefined
+): boolean {
+  const required = requiredDaemonFeatures(agent)
+  if (required.length === 0) return true
+  const advertised = new Set(advertisedFeatures ?? [])
+  return required.every((feature) => advertised.has(feature))
+}

--- a/packages/control-plane/src/orchestrator/agentDelivery.test.ts
+++ b/packages/control-plane/src/orchestrator/agentDelivery.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { GITLAB_COM_V1_FEATURE } from '@agentconnect.md/protocol'
+import { AgentDelivery } from './agentDelivery.js'
+import type { AgentSpecAssembler } from './agentSpecAssembler.js'
+import type { AgentRecord } from '../persistence/ports.js'
+
+const DAEMON = 'd1111111-1111-4111-8111-111111111111'
+
+function agentWith(mode: string): AgentRecord {
+  return {
+    id: 'a1111111-1111-4111-8111-111111111111',
+    orgId: 'org-1',
+    daemonId: DAEMON,
+    workspace: { mode } as AgentRecord['workspace']
+  } as AgentRecord
+}
+
+function harness(features: readonly string[] | undefined) {
+  const sent: string[] = []
+  const delivery = new AgentDelivery({
+    control: {
+      agentUpsert: async (daemonId: string) => {
+        sent.push(daemonId)
+      },
+      agentRemove: async () => {},
+      integrationUpsert: async () => {},
+      integrationRemove: async () => {},
+      cronUpsert: async () => ({ ok: true }),
+      cronRemove: async () => ({ ok: true })
+    },
+    specs: { assemble: async () => ({ agentId: 'a' }) } as unknown as AgentSpecAssembler,
+    daemonFeatures: () => features
+  })
+  return { delivery, sent }
+}
+
+describe('AgentDelivery §17.3 projection gate', () => {
+  it('delivers ungated agents regardless of advertised features', async () => {
+    const { delivery, sent } = harness(undefined)
+    await delivery.upsert(agentWith('github'), () => {})
+    expect(sent).toEqual([DAEMON])
+  })
+
+  it('skips a target that has not advertised a gated agent required feature', async () => {
+    const { delivery, sent } = harness([])
+    await delivery.upsert(agentWith('gitlab'), () => {})
+    expect(sent).toEqual([])
+  })
+
+  it('delivers a gated agent once the target advertises the feature', async () => {
+    const { delivery, sent } = harness([GITLAB_COM_V1_FEATURE])
+    await delivery.upsert(agentWith('gitlab'), () => {})
+    expect(sent).toEqual([DAEMON])
+  })
+})

--- a/packages/control-plane/src/orchestrator/agentDelivery.ts
+++ b/packages/control-plane/src/orchestrator/agentDelivery.ts
@@ -21,6 +21,7 @@ import type { CronUpsert, IntegrationSpec } from '@agentconnect.md/protocol'
 import type { AgentSpecAssembler } from './agentSpecAssembler.js'
 import type { ControlSender } from './outbound.js'
 import { PLACEMENT_ONLY, type PlacementResolver, type ResolvableAgent } from './placementResolver.js'
+import { daemonSupportsAgent } from '../domain/daemon-features.js'
 import type { AgentRecord } from '../persistence/ports.js'
 
 export type { DutyHolderReader } from './placementResolver.js'
@@ -39,6 +40,9 @@ export class AgentDelivery {
       specs: AgentSpecAssembler
       /** Absent (tests / no pool) ⇒ placement alone, which is the pre-duty behavior. */
       placement?: PlacementResolver
+      /** Live advertised features per connected daemon (§17.3 projection gate).
+       *  Absent or unknown reads as "no features" — fail-closed for gated agents. */
+      daemonFeatures?: (daemonId: string) => readonly string[] | undefined
     }
   ) {}
 
@@ -91,7 +95,11 @@ export class AgentDelivery {
   /** Push an edited spec to every delivery target. The spec is assembled ONCE:
    *  the targets replicate the same agent, and two assemblies could disagree. */
   async upsert(agent: AgentRecord, onError: DeliveryErrorHandler): Promise<void> {
-    const targets = await this.daemonsFor(agent)
+    // §17.3 projection gate: a target that has not advertised the agent's required
+    // features is skipped rather than sent a frame it cannot decode.
+    const targets = (await this.daemonsFor(agent)).filter((daemonId) =>
+      daemonSupportsAgent(agent, this.deps.daemonFeatures?.(daemonId))
+    )
     if (targets.length === 0) return
     const spec = await this.deps.specs.assemble(agent)
     await this.fanOut(targets, onError, (daemonId) =>

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -64,6 +64,7 @@ import {
   type McpDefinitionDeps,
   type MemoryDefinitionDeps
 } from './agentDefinitions.js'
+import { daemonSupportsAgent, requiredDaemonFeatures } from '../domain/daemon-features.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
 import { AgentId as toAgentId, DaemonId as toDaemonId, IntegrationId as toIntegrationId } from '../domain/ids.js'
 import { sessionKeyStr, type SessionKey } from '../domain/sessionKey.js'
@@ -408,12 +409,25 @@ export class Placement implements ReconcileService {
     const ownedCrons = dedupeById(daemonCrons, heldCrons)
 
     const quarantinedAgentIds = new Set<string>()
+    // §17.3 snapshot projection gate: a spec this daemon cannot decode is withheld
+    // from its snapshot entirely (spec, assignments, integrations, crons) instead of
+    // shipped as a frame-fatal union value. The local replica, if any, is deliberately
+    // NOT pruned — the durable row still names this daemon until an operator moves it.
+    for (const agent of ownedAgents) {
+      if (daemonSupportsAgent(agent, req.capabilities.features)) continue
+      quarantinedAgentIds.add(agent.id)
+      this.orch?.log?.warn(
+        { agentId: agent.id, daemonId, required: requiredDaemonFeatures(agent) },
+        'withholding agent from snapshot: daemon lacks a required feature'
+      )
+    }
+    const deliverableAgents = ownedAgents.filter((a) => !quarantinedAgentIds.has(a.id))
     // Conversation gating (§14): derived per-agent from restricted visibility. This
     // is a data-plane read of the DERIVED boolean only — identities never ride the
     // wire, and the roster itself stays unfiltered (§9 graceful degradation).
     const gatedAgentIds = new Set(ownedAgents.filter((a) => a.visibility === 'restricted').map((a) => a.id))
     const [desiredAgents, assembledIntegrations] = await Promise.all([
-      this.specs.assembleAll(ownedAgents, (agent) => {
+      this.specs.assembleAll(deliverableAgents, (agent) => {
         quarantinedAgentIds.add(agent.id)
         this.orch?.log?.warn({ agentId: agent.id }, 'quarantining agent with an unsafe historical git repository')
       }),


### PR DESCRIPTION
Third [gitlab-com-integration.md](docs/designs/gitlab-com-integration.md) M0 PR, after #1361/#1362 — the §17.3 snapshot projection gate, landed before any GitLab-shaped value exists to leak.

## Why now

The daemon reads CP-authored frames tolerantly, but tolerance covers unknown keys only: a new union arm or enum value inside `register/ok` or `agent/upsert` makes the whole frame undecodable on a pre-GitLab daemon, killing its GitHub work too. The gate must therefore exist before the first GitLab-shaped workspace can be stored, so that value is born gated.

## What's in

- `domain/daemon-features.ts` — `requiredDaemonFeatures(agent)` / `daemonSupportsAgent(agent, advertised)`: the one predicate every projection site asks. A gitlab-shaped workspace requires `gitlab-com-v1`; every storable workspace today requires nothing, so current behavior is unchanged. Unknown/absent advertisements read fail-closed.
- Register reconcile: a gated agent the daemon cannot decode is withheld from its snapshot entirely — spec, assignments, integrations, and crons — with a warn log, instead of shipped as a frame-fatal value. Its existing local replica is deliberately **not** pruned: the durable row still names the daemon until an operator moves the agent or upgrades the daemon.
- `AgentDelivery.upsert`: the live fan-out skips targets that have not advertised the agent's required features, reading live features from the connection registry.
- Placement-time refusal (the "never place" half of §17.3) deliberately rides the later change that first makes a gated workspace storable — the create/edit route that admits it will carry the check.

## Tests

- Predicate units: nothing gated today, gitlab-shaped gating, fail-closed on absent/foreign advertisements.
- `AgentDelivery` units: ungated delivery unchanged; gated agent skipped without the feature and delivered with it.
- Register-path integration tests (`ws-handshake`, smoke) pass; CP unit suite 1833/1833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
