### PR TITLE
feat(control-plane): GitLab provisioning saga and external cleanup (M2b)

### DIFF
--- a/packages/control-plane/prisma/migrations/20260902000000_gitlab_claim_mutation_fence/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260902000000_gitlab_claim_mutation_fence/migration.sql
@@ -1,0 +1,42 @@
+-- §10.2 review follow-up: the claim guard must not read "all external ids are
+-- null" as "no provider mutation ever began" — a crash between an external
+-- create and its local id write would then let a binding/org deletion release
+-- the claim over live provider state. The saga now durably flips the claim out
+-- of `provisioning` BEFORE its first provider write; the guard keys on that.
+CREATE OR REPLACE FUNCTION gitlab_binding_claim_guard() RETURNS trigger AS $$
+DECLARE
+    claim_state text;
+    token_ids bigint[];
+    mutated boolean;
+BEGIN
+    SELECT "state" INTO claim_state
+      FROM "code_host_repository_claim"
+     WHERE "provider" = 'gitlab' AND "externalId" = OLD."projectId" AND "bindingRef" = OLD."id";
+    IF claim_state IS NULL THEN
+        RETURN OLD;
+    END IF;
+    SELECT array_agg("externalTokenId") INTO token_ids
+      FROM "gitlab_project_credential" WHERE "bindingId" = OLD."id";
+    mutated := claim_state <> 'provisioning'
+        OR OLD."serviceAccountUserId" IS NOT NULL
+        OR OLD."webhookId" IS NOT NULL
+        OR token_ids IS NOT NULL;
+    IF mutated THEN
+        UPDATE "code_host_repository_claim"
+           SET "bindingRef" = NULL,
+               "state" = 'cleanup_pending',
+               "tombstone" = jsonb_build_object(
+                   'projectId', OLD."projectId"::text,
+                   'projectPath', OLD."projectPath",
+                   'serviceAccountUserId', OLD."serviceAccountUserId"::text,
+                   'webhookId', OLD."webhookId"::text,
+                   'externalTokenIds', to_jsonb(COALESCE(token_ids, ARRAY[]::bigint[]))
+               )
+         WHERE "provider" = 'gitlab' AND "externalId" = OLD."projectId" AND "bindingRef" = OLD."id";
+    ELSE
+        DELETE FROM "code_host_repository_claim"
+         WHERE "provider" = 'gitlab' AND "externalId" = OLD."projectId" AND "bindingRef" = OLD."id";
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/control-plane/prisma/migrations/20260902000000_gitlab_claim_mutation_fence/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260902000000_gitlab_claim_mutation_fence/migration.sql
@@ -45,4 +45,5 @@ $$ LANGUAGE plpgsql;
 -- RESERVES the claim before any provider write; cleanup may not begin while the
 -- reservation is held, and a held fence cannot be re-acquired by cleanup racing
 -- the check-to-write window.
-ALTER TABLE "code_host_repository_claim" ADD COLUMN "opInFlight" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "code_host_repository_claim" ADD COLUMN "opOwner" TEXT;
+ALTER TABLE "code_host_repository_claim" ADD COLUMN "opLeaseUntil" TIMESTAMPTZ(6);

--- a/packages/control-plane/prisma/migrations/20260902000000_gitlab_claim_mutation_fence/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260902000000_gitlab_claim_mutation_fence/migration.sql
@@ -40,3 +40,9 @@ BEGIN
     RETURN OLD;
 END;
 $$ LANGUAGE plpgsql;
+
+-- §10.2 mutual exclusion between provisioning and cleanup: a provisioning run
+-- RESERVES the claim before any provider write; cleanup may not begin while the
+-- reservation is held, and a held fence cannot be re-acquired by cleanup racing
+-- the check-to-write window.
+ALTER TABLE "code_host_repository_claim" ADD COLUMN "opInFlight" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -957,6 +957,9 @@ model CodeHostRepositoryClaim {
   // Metadata-only cleanup facts (external ids, never secrets) preserved when the
   // owning binding disappears before external cleanup completed (§10.2/§19.4).
   tombstone  Json?
+  // §10.2 mutual exclusion: true while a provisioning run may write to the
+  // provider. beginCleanup refuses while set; the same owner's next run resets it.
+  opInFlight Boolean  @default(false)
   createdAt  DateTime @default(now()) @db.Timestamptz(6)
   updatedAt  DateTime @updatedAt @db.Timestamptz(6)
 

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -957,9 +957,11 @@ model CodeHostRepositoryClaim {
   // Metadata-only cleanup facts (external ids, never secrets) preserved when the
   // owning binding disappears before external cleanup completed (§10.2/§19.4).
   tombstone  Json?
-  // §10.2 mutual exclusion: true while a provisioning run may write to the
-  // provider. beginCleanup refuses while set; the same owner's next run resets it.
-  opInFlight Boolean  @default(false)
+  // §10.2 mutual exclusion: an EXCLUSIVE run-owned provisioning lease. Acquired
+  // CAS-style before any provider write; cleanup refuses while it is live; only
+  // the owning run releases it, and only expiry lets another run reclaim.
+  opOwner      String?
+  opLeaseUntil DateTime? @db.Timestamptz(6)
   createdAt  DateTime @default(now()) @db.Timestamptz(6)
   updatedAt  DateTime @updatedAt @db.Timestamptz(6)
 

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -25,6 +25,7 @@ import { resolveGithubAppConfig } from './github/config.js'
 import { resolveGitlabAppConfig } from './gitlab/config.js'
 import type { FetchLike as GitlabFetchLike } from './gitlab/api.js'
 import { GitlabOauthService } from './gitlab/oauth.service.js'
+import { GitlabProvisioner } from './gitlab/provisioner.js'
 import { resolveSlackPlatformAppConfig } from './config/slack-platform.js'
 import { resolveFeishuPlatformApps } from './config/feishu-platform.js'
 import type { FetchLike } from './github/api.js'
@@ -95,6 +96,9 @@ import {
   PgGitlabConnectionRepo,
   PgGitlabProjectBindingRepo,
   PgGitlabConnectionSecretStore,
+  PgGitlabProjectCredentialRepo,
+  PgGitlabProjectCredentialSecretStore,
+  PgGitlabWebhookSecretStore,
   PgGitlabOauthStateStore,
   PgSocialIdentityMutationGate,
   PgCronRepo,
@@ -925,24 +929,42 @@ export function buildContainer(
     throw new Error('GITLAB_CLIENT_ID/SECRET are set but PUBLIC_CP_URL is not — set it or unset both')
   }
   const gitlabWebAppUrl = resolveWebAppUrl(config)
-  const gitlab =
+  const gitlabOauthService =
     gitlabAppCfg && config.PUBLIC_CP_URL
-      ? {
+      ? new GitlabOauthService({
+          cfg: gitlabAppCfg,
+          connections: repos.gitlabConnection,
+          secrets: new PgGitlabConnectionSecretStore(prisma, secretCipher),
+          states: repos.gitlabOauthState,
+          cipher: secretCipher,
+          clock,
+          publicCpUrl: config.PUBLIC_CP_URL,
+          ...(gitlabWebAppUrl ? { webAppUrl: gitlabWebAppUrl } : {}),
           ...(opts.gitlabFetch ? { fetchImpl: opts.gitlabFetch } : {}),
-          oauth: new GitlabOauthService({
-            cfg: gitlabAppCfg,
-            connections: repos.gitlabConnection,
-            secrets: new PgGitlabConnectionSecretStore(prisma, secretCipher),
-            states: repos.gitlabOauthState,
-            cipher: secretCipher,
-            clock,
-            publicCpUrl: config.PUBLIC_CP_URL,
-            ...(gitlabWebAppUrl ? { webAppUrl: gitlabWebAppUrl } : {}),
-            ...(opts.gitlabFetch ? { fetchImpl: opts.gitlabFetch } : {}),
-            log: { warn: (obj, msg) => http.log.warn(obj, msg) }
-          })
-        }
+          log: { warn: (obj, msg) => http.log.warn(obj, msg) }
+        })
       : undefined
+  const gitlab = gitlabOauthService
+    ? {
+        ...(opts.gitlabFetch ? { fetchImpl: opts.gitlabFetch } : {}),
+        oauth: gitlabOauthService,
+        provisioner: new GitlabProvisioner({
+          oauth: gitlabOauthService,
+          bindings: repos.gitlabProjectBinding,
+          credentials: new PgGitlabProjectCredentialRepo(prisma),
+          credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, secretCipher),
+          webhookSecrets: new PgGitlabWebhookSecretStore(prisma, secretCipher),
+          catalog: repos.codeHostRepository,
+          cipher: secretCipher,
+          clock,
+          ...(config.PUBLIC_RELAY_URL ? { publicRelayUrl: config.PUBLIC_RELAY_URL } : {}),
+          // No GitLab hook kind exists yet (M3): no binding wants a webhook.
+          desiredWebhookEvents: async () => null,
+          ...(opts.gitlabFetch ? { fetchImpl: opts.gitlabFetch } : {}),
+          log: { warn: (obj, msg) => http.log.warn(obj, msg) }
+        })
+      }
+    : undefined
 
   // The console PR panel's read projection — long-lived so its short TTL cache actually absorbs mounts.
   const pullRequestView = github ? new PullRequestViewService(github.tokens, clock, opts.githubFetch) : undefined

--- a/packages/control-plane/src/gitlab/api.ts
+++ b/packages/control-plane/src/gitlab/api.ts
@@ -415,20 +415,33 @@ export async function gitlabCreateServiceAccountToken(
   )
 }
 
-/** List the account's PATs (marker recovery); values are never returned here. */
+/** List the account's PATs (marker recovery); values are never returned here.
+ *  Group-scoped on purpose: the installer OAuth identity is not an instance
+ *  admin on GitLab.com and can manage ONLY the group's service-account tokens. */
 export async function gitlabListServiceAccountTokens(
   accessToken: string,
+  groupId: number,
   serviceAccountUserId: bigint,
   fetchImpl?: FetchLike
 ): Promise<GitlabPatGrant[]> {
-  return gitlabRequest<GitlabPatGrant[]>(`/personal_access_tokens?user_id=${serviceAccountUserId}&per_page=100`, {
-    auth: accessToken,
-    fetchImpl
-  })
+  return gitlabRequest<GitlabPatGrant[]>(
+    `/groups/${groupId}/service_accounts/${serviceAccountUserId}/personal_access_tokens?per_page=100`,
+    { auth: accessToken, fetchImpl }
+  )
 }
 
-export async function gitlabRevokeToken(accessToken: string, tokenId: bigint, fetchImpl?: FetchLike): Promise<void> {
-  await gitlabRequest<void>(`/personal_access_tokens/${tokenId}`, { method: 'DELETE', auth: accessToken, fetchImpl })
+/** Revoke one service-account PAT through the group endpoint (same reason as above). */
+export async function gitlabRevokeServiceAccountToken(
+  accessToken: string,
+  groupId: number,
+  serviceAccountUserId: bigint,
+  tokenId: bigint,
+  fetchImpl?: FetchLike
+): Promise<void> {
+  await gitlabRequest<void>(
+    `/groups/${groupId}/service_accounts/${serviceAccountUserId}/personal_access_tokens/${tokenId}`,
+    { method: 'DELETE', auth: accessToken, fetchImpl }
+  )
 }
 
 export interface GitlabWebhook {
@@ -452,7 +465,9 @@ export async function gitlabCreateWebhook(
   return gitlabRequest<GitlabWebhook>(`/projects/${projectId}/hooks`, {
     method: 'POST',
     auth: accessToken,
-    body: { url: input.url, token: input.signingToken, enable_ssl_verification: true, ...input.events },
+    // `signing_token` is the whsec HMAC key producing `webhook-signature`;
+    // `token` would configure the legacy X-Gitlab-Token header instead (§11.1).
+    body: { url: input.url, signing_token: input.signingToken, enable_ssl_verification: true, ...input.events },
     fetchImpl
   })
 }
@@ -467,7 +482,7 @@ export async function gitlabUpdateWebhook(
   return gitlabRequest<GitlabWebhook>(`/projects/${projectId}/hooks/${webhookId}`, {
     method: 'PUT',
     auth: accessToken,
-    body: { url: input.url, token: input.signingToken, enable_ssl_verification: true, ...input.events },
+    body: { url: input.url, signing_token: input.signingToken, enable_ssl_verification: true, ...input.events },
     fetchImpl
   })
 }

--- a/packages/control-plane/src/gitlab/api.ts
+++ b/packages/control-plane/src/gitlab/api.ts
@@ -487,6 +487,15 @@ export async function gitlabUpdateWebhook(
   })
 }
 
+/** The project's webhooks — crash-left create reconciliation (exact-URL adoption). */
+export async function gitlabListWebhooks(
+  accessToken: string,
+  projectId: bigint,
+  fetchImpl?: FetchLike
+): Promise<GitlabWebhook[]> {
+  return gitlabRequest<GitlabWebhook[]>(`/projects/${projectId}/hooks?per_page=100`, { auth: accessToken, fetchImpl })
+}
+
 export async function gitlabDeleteWebhook(
   accessToken: string,
   projectId: bigint,

--- a/packages/control-plane/src/gitlab/api.ts
+++ b/packages/control-plane/src/gitlab/api.ts
@@ -266,3 +266,236 @@ export function membershipSatisfies(
   }
   return true
 }
+
+// ── administration surface for the provisioning saga (§10.2, §7.2–§7.4, §11.1) ──
+
+export interface GitlabNamespaceRef {
+  id: number
+  parent_id: number | null
+  kind: string // 'group' | 'user'
+  full_path: string
+}
+
+/** Project namespace facts ride the project payload. */
+export interface GitlabProjectWithNamespace extends GitlabProjectSummary {
+  namespace?: GitlabNamespaceRef
+}
+
+/** Walk to the ROOT namespace (service accounts hang off the top-level group).
+ *  A personal (`user`) namespace has no service accounts — the caller reports it. */
+export async function gitlabRootNamespace(
+  accessToken: string,
+  start: GitlabNamespaceRef,
+  fetchImpl?: FetchLike
+): Promise<GitlabNamespaceRef> {
+  let current = start
+  for (let depth = 0; depth < 20 && current.parent_id !== null; depth++) {
+    current = await gitlabRequest<GitlabNamespaceRef>(`/namespaces/${current.parent_id}`, {
+      auth: accessToken,
+      fetchImpl
+    })
+  }
+  return current
+}
+
+export interface GitlabServiceAccount {
+  id: number
+  username: string
+  name: string
+}
+
+/** The binding's deterministic, non-secret service-account marker (§10.2). */
+export function gitlabServiceAccountUsername(projectId: bigint): string {
+  return `agentconnect-p${projectId}`
+}
+
+/** Find the marked account among the top-level group's service accounts. */
+export async function gitlabFindServiceAccount(
+  accessToken: string,
+  groupId: number,
+  username: string,
+  fetchImpl?: FetchLike
+): Promise<GitlabServiceAccount | null> {
+  const accounts = await gitlabRequest<GitlabServiceAccount[]>(`/groups/${groupId}/service_accounts?per_page=100`, {
+    auth: accessToken,
+    fetchImpl
+  })
+  return accounts.find((account) => account.username === username) ?? null
+}
+
+export async function gitlabCreateServiceAccount(
+  accessToken: string,
+  groupId: number,
+  input: { username: string; name: string },
+  fetchImpl?: FetchLike
+): Promise<GitlabServiceAccount> {
+  return gitlabRequest<GitlabServiceAccount>(`/groups/${groupId}/service_accounts`, {
+    method: 'POST',
+    auth: accessToken,
+    body: { username: input.username, name: input.name },
+    fetchImpl
+  })
+}
+
+export async function gitlabDeleteServiceAccount(
+  accessToken: string,
+  groupId: number,
+  userId: bigint,
+  fetchImpl?: FetchLike
+): Promise<void> {
+  await gitlabRequest<void>(`/groups/${groupId}/service_accounts/${userId}`, {
+    method: 'DELETE',
+    auth: accessToken,
+    fetchImpl
+  })
+}
+
+export interface GitlabMember {
+  id: number
+  access_level: number
+  state: string
+}
+
+/** Ensure the service account is a Developer member (§7.2): add, or raise a lower
+ *  direct membership to exactly Developer. Never raises beyond it. */
+export async function gitlabEnsureDeveloperMember(
+  accessToken: string,
+  projectId: bigint,
+  userId: bigint,
+  fetchImpl?: FetchLike
+): Promise<void> {
+  try {
+    await gitlabRequest<GitlabMember>(`/projects/${projectId}/members`, {
+      method: 'POST',
+      auth: accessToken,
+      body: { user_id: Number(userId), access_level: GITLAB_ACCESS_DEVELOPER },
+      fetchImpl
+    })
+    return
+  } catch (e) {
+    // 409: already a member — verify the effective level below.
+    if (!(e instanceof GitlabApiError) || (e.status !== 409 && e.status !== 400)) throw e
+  }
+  const membership = await gitlabEffectiveMembership(accessToken, projectId, userId, fetchImpl)
+  if (membershipSatisfies(membership, GITLAB_ACCESS_DEVELOPER, Date.now())) return
+  await gitlabRequest<GitlabMember>(`/projects/${projectId}/members/${userId}`, {
+    method: 'PUT',
+    auth: accessToken,
+    body: { access_level: GITLAB_ACCESS_DEVELOPER },
+    fetchImpl
+  })
+}
+
+export interface GitlabPatGrant {
+  id: number
+  name: string
+  scopes: string[]
+  active: boolean
+  revoked?: boolean
+  expires_at: string | null
+  token?: string // present ONLY on create/rotate responses — never log
+  user_id?: number
+}
+
+export async function gitlabCreateServiceAccountToken(
+  accessToken: string,
+  groupId: number,
+  serviceAccountUserId: bigint,
+  input: { name: string; scopes: string[]; expiresAt: string },
+  fetchImpl?: FetchLike
+): Promise<GitlabPatGrant> {
+  return gitlabRequest<GitlabPatGrant>(
+    `/groups/${groupId}/service_accounts/${serviceAccountUserId}/personal_access_tokens`,
+    {
+      method: 'POST',
+      auth: accessToken,
+      body: { name: input.name, scopes: input.scopes, expires_at: input.expiresAt },
+      fetchImpl
+    }
+  )
+}
+
+/** List the account's PATs (marker recovery); values are never returned here. */
+export async function gitlabListServiceAccountTokens(
+  accessToken: string,
+  serviceAccountUserId: bigint,
+  fetchImpl?: FetchLike
+): Promise<GitlabPatGrant[]> {
+  return gitlabRequest<GitlabPatGrant[]>(`/personal_access_tokens?user_id=${serviceAccountUserId}&per_page=100`, {
+    auth: accessToken,
+    fetchImpl
+  })
+}
+
+export async function gitlabRevokeToken(accessToken: string, tokenId: bigint, fetchImpl?: FetchLike): Promise<void> {
+  await gitlabRequest<void>(`/personal_access_tokens/${tokenId}`, { method: 'DELETE', auth: accessToken, fetchImpl })
+}
+
+export interface GitlabWebhook {
+  id: number
+  url: string
+}
+
+export interface GitlabWebhookEvents {
+  push_events: boolean
+  issues_events: boolean
+  merge_requests_events: boolean
+  note_events: boolean
+}
+
+export async function gitlabCreateWebhook(
+  accessToken: string,
+  projectId: bigint,
+  input: { url: string; signingToken: string; events: GitlabWebhookEvents },
+  fetchImpl?: FetchLike
+): Promise<GitlabWebhook> {
+  return gitlabRequest<GitlabWebhook>(`/projects/${projectId}/hooks`, {
+    method: 'POST',
+    auth: accessToken,
+    body: { url: input.url, token: input.signingToken, enable_ssl_verification: true, ...input.events },
+    fetchImpl
+  })
+}
+
+export async function gitlabUpdateWebhook(
+  accessToken: string,
+  projectId: bigint,
+  webhookId: bigint,
+  input: { url: string; signingToken: string; events: GitlabWebhookEvents },
+  fetchImpl?: FetchLike
+): Promise<GitlabWebhook> {
+  return gitlabRequest<GitlabWebhook>(`/projects/${projectId}/hooks/${webhookId}`, {
+    method: 'PUT',
+    auth: accessToken,
+    body: { url: input.url, token: input.signingToken, enable_ssl_verification: true, ...input.events },
+    fetchImpl
+  })
+}
+
+export async function gitlabDeleteWebhook(
+  accessToken: string,
+  projectId: bigint,
+  webhookId: bigint,
+  fetchImpl?: FetchLike
+): Promise<void> {
+  await gitlabRequest<void>(`/projects/${projectId}/hooks/${webhookId}`, {
+    method: 'DELETE',
+    auth: accessToken,
+    fetchImpl
+  })
+}
+
+/** Fire one provider test delivery at a newly created or repaired webhook (§10.2 step 7). */
+export async function gitlabTestWebhook(
+  accessToken: string,
+  projectId: bigint,
+  webhookId: bigint,
+  trigger: 'push_events' | 'issues_events' | 'merge_requests_events' | 'note_events',
+  fetchImpl?: FetchLike
+): Promise<void> {
+  await gitlabRequest<void>(`/projects/${projectId}/hooks/${webhookId}/test/${trigger}`, {
+    method: 'POST',
+    auth: accessToken,
+    fetchImpl
+  })
+}

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -45,7 +45,7 @@ import {
   gitlabEnsureDeveloperMember,
   gitlabFindServiceAccount,
   gitlabProject,
-  gitlabRevokeToken,
+  gitlabRevokeServiceAccountToken,
   gitlabRootNamespace,
   gitlabServiceAccountUsername,
   gitlabTestWebhook,
@@ -164,6 +164,11 @@ export class GitlabProvisioner {
     // Service accounts hang off a top-level GROUP; a personal namespace has none (§5).
     if (root.kind !== 'group') return { state: 'admin_degraded', reason: 'personal_namespace_unsupported' }
 
+    // §10.2 fence, durable BEFORE the first provider write: from here on, a
+    // disappearing binding must tombstone the claim, never release it — even if
+    // the crash lands before any external id is recorded locally.
+    await this.deps.bindings.markProviderMutationStarted(orgId, binding.id, binding.projectId)
+
     // 2–3. Find-or-create the marked service account; ensure Developer membership.
     const username = gitlabServiceAccountUsername(binding.projectId)
     let account = await gitlabFindServiceAccount(token, root.id, username, fetchImpl)
@@ -245,7 +250,13 @@ export class GitlabProvisioner {
       // Out-of-policy token: revoke by id immediately and fail closed. An
       // id-less response is recorded as restricted cleanup debt.
       if (typeof grant.id === 'number') {
-        await gitlabRevokeToken(token, BigInt(grant.id), this.deps.fetchImpl).catch(() => {
+        await gitlabRevokeServiceAccountToken(
+          token,
+          groupId,
+          serviceAccountUserId,
+          BigInt(grant.id),
+          this.deps.fetchImpl
+        ).catch(() => {
           this.deps.log?.warn(
             { bindingId: binding.id, purpose, tokenId: grant.id },
             'gitlab out-of-policy token revocation is unconfirmed (restricted cleanup debt)'
@@ -333,22 +344,33 @@ export class GitlabProvisioner {
       if (binding.webhookId !== null) {
         await gitlabDeleteWebhook(token, binding.projectId, binding.webhookId, this.deps.fetchImpl).catch(swallow404)
       }
-      for (const credential of await this.deps.credentials.listForBinding(bindingId)) {
-        await gitlabRevokeToken(token, credential.externalTokenId, this.deps.fetchImpl).catch(swallow404)
-      }
-      if (binding.serviceAccountUserId !== null) {
+      const credentials = await this.deps.credentials.listForBinding(bindingId)
+      if (credentials.length > 0 || binding.serviceAccountUserId !== null) {
+        // Token revocation and account deletion are group-scoped operations: the
+        // installer OAuth identity manages only the group's service accounts.
         const project = (await gitlabProject(
           token,
           binding.projectId,
           this.deps.fetchImpl
         )) as GitlabProjectWithNamespace | null
-        if (project?.namespace) {
-          const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
-          if (root.kind === 'group') {
-            await gitlabDeleteServiceAccount(token, root.id, binding.serviceAccountUserId, this.deps.fetchImpl).catch(
-              swallow404
-            )
+        if (!project?.namespace) {
+          throw new GitlabApiError('project namespace unavailable for cleanup', 0, 'INTERNAL', true)
+        }
+        const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
+        if (root.kind !== 'group') throw new GitlabApiError('root group unavailable for cleanup', 0, 'INTERNAL', false)
+        if (binding.serviceAccountUserId !== null) {
+          for (const credential of credentials) {
+            await gitlabRevokeServiceAccountToken(
+              token,
+              root.id,
+              binding.serviceAccountUserId,
+              credential.externalTokenId,
+              this.deps.fetchImpl
+            ).catch(swallow404)
           }
+          await gitlabDeleteServiceAccount(token, root.id, binding.serviceAccountUserId, this.deps.fetchImpl).catch(
+            swallow404
+          )
         }
       }
     } catch (e) {

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -46,6 +46,7 @@ import {
   gitlabFindServiceAccount,
   gitlabProject,
   gitlabListServiceAccountTokens,
+  gitlabListWebhooks,
   gitlabRevokeServiceAccountToken,
   gitlabRootNamespace,
   gitlabServiceAccountUsername,
@@ -183,13 +184,15 @@ export class GitlabProvisioner {
     return { state, reason }
   }
 
-  private fenceHeld(orgId: string, binding: GitlabProjectBindingRecord, owner: string): Promise<boolean> {
-    return this.deps.bindings.claimFenceHeld(
+  private renewLease(orgId: string, binding: GitlabProjectBindingRecord, owner: string): Promise<boolean> {
+    // Atomic owner-matched extension: liveness check and renewal are one write,
+    // with fresh validity covering the provider request that follows.
+    return this.deps.bindings.renewProviderLease(
       orgId,
       binding.id,
       binding.projectId,
       owner,
-      new Date(this.deps.clock.now())
+      new Date(this.deps.clock.now() + PROVISION_LEASE_MS)
     )
   }
 
@@ -224,8 +227,8 @@ export class GitlabProvisioner {
     const username = gitlabServiceAccountUsername(binding.projectId)
     let account = await gitlabFindServiceAccount(token, root.id, username, fetchImpl)
     if (!account) {
-      // §10.2 per-step belt: the run must still own a live lease.
-      if (!(await this.fenceHeld(orgId, binding, owner))) {
+      // §10.2 per-step atomic renewal: the run must still own the lease.
+      if (!(await this.renewLease(orgId, binding, owner))) {
         return { state: 'admin_degraded', reason: 'claim_fence_lost' }
       }
       try {
@@ -285,8 +288,8 @@ export class GitlabProvisioner {
   ): Promise<void> {
     const scopes = PURPOSE_SCOPES[purpose]
     const expiresAt = expiresAtDate(this.deps.clock.now())
-    // §10.2 per-step belt under the lease.
-    if (!(await this.fenceHeld(orgId, binding, owner))) throw new GitlabClaimFenceLost()
+    // §10.2 per-step atomic renewal under the lease.
+    if (!(await this.renewLease(orgId, binding, owner))) throw new GitlabClaimFenceLost()
     // Ambiguous-create recovery (§10.2): a marked token we did not record has a
     // lost plaintext — revoke it before minting, sparing the recorded one
     // (rotation's create-before-revoke overlap shares the name deliberately).
@@ -366,30 +369,50 @@ export class GitlabProvisioner {
     if (!this.deps.publicRelayUrl) {
       return { state: 'admin_degraded', reason: 'relay_url_unconfigured' }
     }
-    // §10.2 per-step belt before the webhook create/update.
-    if (!(await this.fenceHeld(orgId, binding, owner))) {
+    // §10.2 per-step atomic renewal before the webhook create/update: the lease
+    // is extended so it cannot expire while the provider request is in flight.
+    if (!(await this.renewLease(orgId, binding, owner))) {
       return { state: 'admin_degraded', reason: 'claim_fence_lost' }
     }
     const url = `${this.deps.publicRelayUrl.replace(/\/$/, '')}/webhooks/gitlab`
     const signingToken = `whsec_${randomBytes(32).toString('base64')}`
-    const fresh = binding.webhookId === null
+    // Seal the signing intent BEFORE any provider call: a crash after the
+    // create still leaves us the key the created hook carries.
+    await this.deps.webhookSecrets.put(orgId, binding.id, signingToken)
+    let fresh = binding.webhookId === null
     let webhookId: bigint
     if (fresh) {
-      const created = await gitlabCreateWebhook(
-        token,
-        binding.projectId,
-        { url, signingToken, events },
-        this.deps.fetchImpl
+      // Crash-left create reconciliation: an existing hook at OUR exact managed
+      // URL for this project is ours (the URL is this deployment's endpoint) —
+      // re-key it in place instead of creating a duplicate. A merely similar
+      // URL never matches (§10.3).
+      const existing = (await gitlabListWebhooks(token, binding.projectId, this.deps.fetchImpl)).find(
+        (hook) => hook.url === url
       )
-      webhookId = BigInt(created.id)
+      if (existing) {
+        webhookId = BigInt(existing.id)
+        await gitlabUpdateWebhook(
+          token,
+          binding.projectId,
+          webhookId,
+          { url, signingToken, events },
+          this.deps.fetchImpl
+        )
+        fresh = false
+      } else {
+        const created = await gitlabCreateWebhook(
+          token,
+          binding.projectId,
+          { url, signingToken, events },
+          this.deps.fetchImpl
+        )
+        webhookId = BigInt(created.id)
+      }
     } else {
       // Ownership = stored id + marker URL (§10.3); never adopt by URL alone.
       webhookId = binding.webhookId!
       await gitlabUpdateWebhook(token, binding.projectId, webhookId, { url, signingToken, events }, this.deps.fetchImpl)
     }
-    // Seal BEFORE recording the webhook as converged: a crash between leaves a
-    // webhook we own and re-key on the next convergence, never a key we lost.
-    await this.deps.webhookSecrets.put(orgId, binding.id, signingToken)
     await this.deps.bindings.update(orgId, binding.id, {
       webhookId,
       desiredEventsHash: JSON.stringify(events)
@@ -433,6 +456,16 @@ export class GitlabProvisioner {
       const token = await this.deps.oauth.withAccessToken(orgId, binding.installerConnectionId)
       if (binding.webhookId !== null) {
         await gitlabDeleteWebhook(token, binding.projectId, binding.webhookId, this.deps.fetchImpl).catch(swallow404)
+      } else if (this.deps.publicRelayUrl) {
+        // A crash-left create may exist without a recorded id: our exact managed
+        // URL identifies it (the URL is this deployment's endpoint), so cleanup
+        // retires it rather than orphaning it.
+        const url = `${this.deps.publicRelayUrl.replace(/\/$/, '')}/webhooks/gitlab`
+        for (const hook of await gitlabListWebhooks(token, binding.projectId, this.deps.fetchImpl)) {
+          if (hook.url === url) {
+            await gitlabDeleteWebhook(token, binding.projectId, BigInt(hook.id), this.deps.fetchImpl).catch(swallow404)
+          }
+        }
       }
       const credentials = await this.deps.credentials.listForBinding(bindingId)
       if (credentials.length > 0 || binding.serviceAccountUserId !== null) {

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -468,33 +468,44 @@ export class GitlabProvisioner {
         }
       }
       const credentials = await this.deps.credentials.listForBinding(bindingId)
-      if (credentials.length > 0 || binding.serviceAccountUserId !== null) {
-        // Token revocation and account deletion are group-scoped operations: the
-        // installer OAuth identity manages only the group's service accounts.
-        const project = (await gitlabProject(
+      // Local ids are NOT proof of external absence: a crash between the
+      // service-account create and its id write leaves both empty while the
+      // marked account exists. Cleanup therefore always resolves the root group
+      // and reconciles the deterministic marker before the claim may release.
+      const project = (await gitlabProject(
+        token,
+        binding.projectId,
+        this.deps.fetchImpl
+      )) as GitlabProjectWithNamespace | null
+      if (!project?.namespace) {
+        throw new GitlabApiError('project namespace unavailable for cleanup', 0, 'INTERNAL', true)
+      }
+      const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
+      if (root.kind === 'group') {
+        const marked = await gitlabFindServiceAccount(
           token,
-          binding.projectId,
+          root.id,
+          gitlabServiceAccountUsername(binding.projectId),
           this.deps.fetchImpl
-        )) as GitlabProjectWithNamespace | null
-        if (!project?.namespace) {
-          throw new GitlabApiError('project namespace unavailable for cleanup', 0, 'INTERNAL', true)
-        }
-        const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
-        if (root.kind !== 'group') throw new GitlabApiError('root group unavailable for cleanup', 0, 'INTERNAL', false)
-        if (binding.serviceAccountUserId !== null) {
+        )
+        const accountUserId = binding.serviceAccountUserId ?? (marked ? BigInt(marked.id) : null)
+        if (accountUserId !== null) {
+          // Recorded tokens are revoked individually (belt); deleting the
+          // account then invalidates anything a crash left unrecorded.
           for (const credential of credentials) {
             await gitlabRevokeServiceAccountToken(
               token,
               root.id,
-              binding.serviceAccountUserId,
+              accountUserId,
               credential.externalTokenId,
               this.deps.fetchImpl
             ).catch(swallow404)
           }
-          await gitlabDeleteServiceAccount(token, root.id, binding.serviceAccountUserId, this.deps.fetchImpl).catch(
-            swallow404
-          )
+          await gitlabDeleteServiceAccount(token, root.id, accountUserId, this.deps.fetchImpl).catch(swallow404)
         }
+      } else if (binding.serviceAccountUserId !== null || credentials.length > 0) {
+        // Provider facts exist but their group is unreachable: never release.
+        throw new GitlabApiError('root group unavailable for cleanup', 0, 'INTERNAL', false)
       }
     } catch (e) {
       const reason = e instanceof GitlabApiError ? `gitlab_${e.status || 'unreachable'}` : 'cleanup_failed'

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -57,6 +57,9 @@ import {
 } from './api.js'
 import type { GitlabOauthService } from './oauth.service.js'
 
+/** The exclusive provisioning lease a run holds across its provider writes. */
+export const PROVISION_LEASE_MS = 10 * 60 * 1000
+
 /** §7.3 v1 policy: every PAT is created with exactly this lifetime. */
 export const PAT_LIFETIME_DAYS = 90
 
@@ -82,7 +85,12 @@ export class GitlabTokenPolicyViolation extends Error {
   }
 }
 
-export type ProvisionOutcome = { state: 'ready' } | { state: 'admin_degraded' | 'runtime_degraded'; reason: string }
+export type ProvisionOutcome =
+  | { state: 'ready' }
+  | { state: 'admin_degraded' | 'runtime_degraded'; reason: string }
+  // A live peer owns the claim (provisioning or cleanup in progress): nothing
+  // was written and no binding state was overwritten; the caller observes.
+  | { state: 'busy'; reason: string }
 
 export interface GitlabProvisionerDeps {
   oauth: GitlabOauthService
@@ -120,12 +128,30 @@ export class GitlabProvisioner {
     if (!binding.installerConnectionId) {
       return this.degrade(orgId, bindingId, 'admin_degraded', 'no_admin_connection')
     }
+    // The run's exclusive lease identity (§10.2): CAS-acquired before any
+    // provider write; a live foreign lease refuses, so runs never overlap.
+    const owner = randomBytes(9).toString('base64url')
+    const nowMs = this.deps.clock.now()
+    if (
+      !(await this.deps.bindings.markProviderMutationStarted(
+        orgId,
+        bindingId,
+        binding.projectId,
+        owner,
+        new Date(nowMs + PROVISION_LEASE_MS),
+        new Date(nowMs)
+      ))
+    ) {
+      // Held by a live peer, or the claim is gone/detached/in-cleanup: no
+      // provider writes, and no state overwrite of whatever is in progress.
+      return { state: 'busy', reason: 'provisioning_or_cleanup_in_progress' }
+    }
     try {
       const token = await this.deps.oauth.withAccessToken(orgId, binding.installerConnectionId)
-      const outcome = await this.converge(orgId, binding, token)
+      const outcome = await this.converge(orgId, binding, token, owner)
       if (outcome.state === 'ready') {
         await this.deps.bindings.update(orgId, bindingId, { state: 'ready', stateReason: null })
-      } else {
+      } else if (outcome.state !== 'busy') {
         await this.deps.bindings.update(orgId, bindingId, { state: outcome.state, stateReason: outcome.reason })
       }
       return outcome
@@ -141,9 +167,9 @@ export class GitlabProvisioner {
       this.deps.log?.warn({ bindingId, reason }, 'gitlab provisioning failed')
       return this.degrade(orgId, bindingId, 'admin_degraded', reason)
     } finally {
-      // Release the reservation whatever happened: every external resource is
-      // deterministically marked, so the next same-owner run reconciles it.
-      await this.deps.bindings.endProviderMutation(orgId, bindingId, binding.projectId).catch(() => {})
+      // Release THIS run's lease whatever happened: every external resource is
+      // deterministically marked, so the next run reconciles it.
+      await this.deps.bindings.endProviderMutation(orgId, bindingId, binding.projectId, owner).catch(() => {})
     }
   }
 
@@ -157,7 +183,22 @@ export class GitlabProvisioner {
     return { state, reason }
   }
 
-  private async converge(orgId: string, binding: GitlabProjectBindingRecord, token: string): Promise<ProvisionOutcome> {
+  private fenceHeld(orgId: string, binding: GitlabProjectBindingRecord, owner: string): Promise<boolean> {
+    return this.deps.bindings.claimFenceHeld(
+      orgId,
+      binding.id,
+      binding.projectId,
+      owner,
+      new Date(this.deps.clock.now())
+    )
+  }
+
+  private async converge(
+    orgId: string,
+    binding: GitlabProjectBindingRecord,
+    token: string,
+    owner: string
+  ): Promise<ProvisionOutcome> {
     const { fetchImpl } = this.deps
     // 1. Refresh the mutable facts by numeric id (rename-proof, §10.2 step 1).
     const project = (await gitlabProject(token, binding.projectId, fetchImpl)) as GitlabProjectWithNamespace | null
@@ -179,20 +220,12 @@ export class GitlabProvisioner {
     // Service accounts hang off a top-level GROUP; a personal namespace has none (§5).
     if (root.kind !== 'group') return { state: 'admin_degraded', reason: 'personal_namespace_unsupported' }
 
-    // §10.2 fence, durable BEFORE the first provider write: from here on, a
-    // disappearing binding must tombstone the claim, never release it — even if
-    // the crash lands before any external id is recorded locally. Losing the
-    // fence (claim gone, detached, or entering cleanup) forbids provider writes.
-    if (!(await this.deps.bindings.markProviderMutationStarted(orgId, binding.id, binding.projectId))) {
-      return { state: 'admin_degraded', reason: 'claim_fence_lost' }
-    }
-
     // 2–3. Find-or-create the marked service account; ensure Developer membership.
     const username = gitlabServiceAccountUsername(binding.projectId)
     let account = await gitlabFindServiceAccount(token, root.id, username, fetchImpl)
     if (!account) {
-      // §10.2 per-step check: never create against the provider once cleanup began.
-      if (!(await this.deps.bindings.claimFenceHeld(orgId, binding.id, binding.projectId))) {
+      // §10.2 per-step belt: the run must still own a live lease.
+      if (!(await this.fenceHeld(orgId, binding, owner))) {
         return { state: 'admin_degraded', reason: 'claim_fence_lost' }
       }
       try {
@@ -229,13 +262,13 @@ export class GitlabProvisioner {
         existing.providerExpiresAt.getTime() > this.deps.clock.now() &&
         (await this.deps.credentialSecrets.get(orgId, existing.id)) !== null
       if (stillValid) continue
-      await this.mintCredential(orgId, binding, token, root.id, accountUserId, purpose)
+      await this.mintCredential(orgId, binding, token, root.id, accountUserId, purpose, owner)
     }
 
     // 6–7. The managed webhook, only when an enabled hook wants events (§10.3).
     const events = await this.deps.desiredWebhookEvents(orgId, binding.projectId)
     if (events) {
-      const outcome = await this.convergeWebhook(orgId, binding, token, events)
+      const outcome = await this.convergeWebhook(orgId, binding, token, events, owner)
       if (outcome) return outcome
     }
     return { state: 'ready' }
@@ -247,14 +280,13 @@ export class GitlabProvisioner {
     token: string,
     groupId: number,
     serviceAccountUserId: bigint,
-    purpose: GitlabCredentialPurpose
+    purpose: GitlabCredentialPurpose,
+    owner: string
   ): Promise<void> {
     const scopes = PURPOSE_SCOPES[purpose]
     const expiresAt = expiresAtDate(this.deps.clock.now())
-    // §10.2 per-step belt under the reservation.
-    if (!(await this.deps.bindings.claimFenceHeld(orgId, binding.id, binding.projectId))) {
-      throw new GitlabClaimFenceLost()
-    }
+    // §10.2 per-step belt under the lease.
+    if (!(await this.fenceHeld(orgId, binding, owner))) throw new GitlabClaimFenceLost()
     // Ambiguous-create recovery (§10.2): a marked token we did not record has a
     // lost plaintext — revoke it before minting, sparing the recorded one
     // (rotation's create-before-revoke overlap shares the name deliberately).
@@ -328,13 +360,14 @@ export class GitlabProvisioner {
     orgId: string,
     binding: GitlabProjectBindingRecord,
     token: string,
-    events: GitlabWebhookEvents
+    events: GitlabWebhookEvents,
+    owner: string
   ): Promise<ProvisionOutcome | null> {
     if (!this.deps.publicRelayUrl) {
       return { state: 'admin_degraded', reason: 'relay_url_unconfigured' }
     }
-    // §10.2 per-step check before the webhook create/update.
-    if (!(await this.deps.bindings.claimFenceHeld(orgId, binding.id, binding.projectId))) {
+    // §10.2 per-step belt before the webhook create/update.
+    if (!(await this.fenceHeld(orgId, binding, owner))) {
       return { state: 'admin_degraded', reason: 'claim_fence_lost' }
     }
     const url = `${this.deps.publicRelayUrl.replace(/\/$/, '')}/webhooks/gitlab`
@@ -382,8 +415,10 @@ export class GitlabProvisioner {
     const binding = await this.deps.bindings.get(orgId, bindingId)
     if (!binding) return { removed: false, reason: 'binding_missing' }
     // Mutual exclusion with provision/repair (§10.2): cleanup may not begin
-    // while a provisioning reservation is held — the caller retries later.
-    if (!(await this.deps.bindings.beginCleanup(orgId, bindingId, binding.projectId))) {
+    // while a LIVE provisioning lease is held — the caller retries later.
+    if (
+      !(await this.deps.bindings.beginCleanup(orgId, bindingId, binding.projectId, new Date(this.deps.clock.now())))
+    ) {
       return { removed: false, reason: 'provisioning_in_progress' }
     }
     await this.deps.bindings.bumpCredentialEpoch(orgId, bindingId)

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -65,6 +65,14 @@ const PURPOSE_SCOPES: Record<GitlabCredentialPurpose, string[]> = {
   effect: ['api']
 }
 
+/** §10.2: the claim fence was lost mid-run (cleanup or takeover won). */
+export class GitlabClaimFenceLost extends Error {
+  constructor() {
+    super('the deployment-global project claim fence was lost')
+    this.name = 'GitlabClaimFenceLost'
+  }
+}
+
 /** §7.3: the provider returned a token outside the requested policy. */
 export class GitlabTokenPolicyViolation extends Error {
   constructor(readonly purpose: GitlabCredentialPurpose) {
@@ -122,11 +130,13 @@ export class GitlabProvisioner {
       return outcome
     } catch (e) {
       const reason =
-        e instanceof GitlabTokenPolicyViolation
-          ? 'out_of_policy_token'
-          : e instanceof GitlabApiError
-            ? `gitlab_${e.status || 'unreachable'}`
-            : 'admin_unavailable'
+        e instanceof GitlabClaimFenceLost
+          ? 'claim_fence_lost'
+          : e instanceof GitlabTokenPolicyViolation
+            ? 'out_of_policy_token'
+            : e instanceof GitlabApiError
+              ? `gitlab_${e.status || 'unreachable'}`
+              : 'admin_unavailable'
       this.deps.log?.warn({ bindingId, reason }, 'gitlab provisioning failed')
       return this.degrade(orgId, bindingId, 'admin_degraded', reason)
     }
@@ -166,13 +176,20 @@ export class GitlabProvisioner {
 
     // §10.2 fence, durable BEFORE the first provider write: from here on, a
     // disappearing binding must tombstone the claim, never release it — even if
-    // the crash lands before any external id is recorded locally.
-    await this.deps.bindings.markProviderMutationStarted(orgId, binding.id, binding.projectId)
+    // the crash lands before any external id is recorded locally. Losing the
+    // fence (claim gone, detached, or entering cleanup) forbids provider writes.
+    if (!(await this.deps.bindings.markProviderMutationStarted(orgId, binding.id, binding.projectId))) {
+      return { state: 'admin_degraded', reason: 'claim_fence_lost' }
+    }
 
     // 2–3. Find-or-create the marked service account; ensure Developer membership.
     const username = gitlabServiceAccountUsername(binding.projectId)
     let account = await gitlabFindServiceAccount(token, root.id, username, fetchImpl)
     if (!account) {
+      // §10.2 per-step check: never create against the provider once cleanup began.
+      if (!(await this.deps.bindings.claimFenceHeld(orgId, binding.id, binding.projectId))) {
+        return { state: 'admin_degraded', reason: 'claim_fence_lost' }
+      }
       try {
         account = await gitlabCreateServiceAccount(
           token,
@@ -229,6 +246,10 @@ export class GitlabProvisioner {
   ): Promise<void> {
     const scopes = PURPOSE_SCOPES[purpose]
     const expiresAt = expiresAtDate(this.deps.clock.now())
+    // §10.2 per-step check before every provider create.
+    if (!(await this.deps.bindings.claimFenceHeld(orgId, binding.id, binding.projectId))) {
+      throw new GitlabClaimFenceLost()
+    }
     const grant = await gitlabCreateServiceAccountToken(
       token,
       groupId,
@@ -287,6 +308,10 @@ export class GitlabProvisioner {
     if (!this.deps.publicRelayUrl) {
       return { state: 'admin_degraded', reason: 'relay_url_unconfigured' }
     }
+    // §10.2 per-step check before the webhook create/update.
+    if (!(await this.deps.bindings.claimFenceHeld(orgId, binding.id, binding.projectId))) {
+      return { state: 'admin_degraded', reason: 'claim_fence_lost' }
+    }
     const url = `${this.deps.publicRelayUrl.replace(/\/$/, '')}/webhooks/gitlab`
     const signingToken = `whsec_${randomBytes(32).toString('base64')}`
     const fresh = binding.webhookId === null
@@ -331,6 +356,10 @@ export class GitlabProvisioner {
   async disconnect(orgId: string, bindingId: string): Promise<{ removed: boolean; reason?: string }> {
     const binding = await this.deps.bindings.get(orgId, bindingId)
     if (!binding) return { removed: false, reason: 'binding_missing' }
+    // Mutual exclusion with provision/repair (§10.2): entering cleanup flips the
+    // claim out of `active`, so a concurrent run loses its fence before its
+    // next provider write. Local authority goes with it.
+    await this.deps.bindings.beginCleanup(orgId, bindingId, binding.projectId)
     await this.deps.bindings.bumpCredentialEpoch(orgId, bindingId)
     if (!binding.installerConnectionId) {
       await this.deps.bindings.update(orgId, bindingId, {

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -45,6 +45,7 @@ import {
   gitlabEnsureDeveloperMember,
   gitlabFindServiceAccount,
   gitlabProject,
+  gitlabListServiceAccountTokens,
   gitlabRevokeServiceAccountToken,
   gitlabRootNamespace,
   gitlabServiceAccountUsername,
@@ -139,6 +140,10 @@ export class GitlabProvisioner {
               : 'admin_unavailable'
       this.deps.log?.warn({ bindingId, reason }, 'gitlab provisioning failed')
       return this.degrade(orgId, bindingId, 'admin_degraded', reason)
+    } finally {
+      // Release the reservation whatever happened: every external resource is
+      // deterministically marked, so the next same-owner run reconciles it.
+      await this.deps.bindings.endProviderMutation(orgId, bindingId, binding.projectId).catch(() => {})
     }
   }
 
@@ -246,9 +251,29 @@ export class GitlabProvisioner {
   ): Promise<void> {
     const scopes = PURPOSE_SCOPES[purpose]
     const expiresAt = expiresAtDate(this.deps.clock.now())
-    // §10.2 per-step check before every provider create.
+    // §10.2 per-step belt under the reservation.
     if (!(await this.deps.bindings.claimFenceHeld(orgId, binding.id, binding.projectId))) {
       throw new GitlabClaimFenceLost()
+    }
+    // Ambiguous-create recovery (§10.2): a marked token we did not record has a
+    // lost plaintext — revoke it before minting, sparing the recorded one
+    // (rotation's create-before-revoke overlap shares the name deliberately).
+    const recorded = await this.deps.credentials.get(binding.id, purpose)
+    const name = patName(binding.projectId, purpose)
+    const strays = (
+      await gitlabListServiceAccountTokens(token, groupId, serviceAccountUserId, this.deps.fetchImpl)
+    ).filter((t) => t.name === name && t.active !== false && t.revoked !== true)
+    for (const stray of strays) {
+      if (recorded && BigInt(stray.id) === recorded.externalTokenId) continue
+      await gitlabRevokeServiceAccountToken(
+        token,
+        groupId,
+        serviceAccountUserId,
+        BigInt(stray.id),
+        this.deps.fetchImpl
+      ).catch(() =>
+        this.deps.log?.warn({ bindingId: binding.id, purpose }, 'gitlab stray token revocation is unconfirmed')
+      )
     }
     const grant = await gitlabCreateServiceAccountToken(
       token,
@@ -356,10 +381,11 @@ export class GitlabProvisioner {
   async disconnect(orgId: string, bindingId: string): Promise<{ removed: boolean; reason?: string }> {
     const binding = await this.deps.bindings.get(orgId, bindingId)
     if (!binding) return { removed: false, reason: 'binding_missing' }
-    // Mutual exclusion with provision/repair (§10.2): entering cleanup flips the
-    // claim out of `active`, so a concurrent run loses its fence before its
-    // next provider write. Local authority goes with it.
-    await this.deps.bindings.beginCleanup(orgId, bindingId, binding.projectId)
+    // Mutual exclusion with provision/repair (§10.2): cleanup may not begin
+    // while a provisioning reservation is held — the caller retries later.
+    if (!(await this.deps.bindings.beginCleanup(orgId, bindingId, binding.projectId))) {
+      return { removed: false, reason: 'provisioning_in_progress' }
+    }
     await this.deps.bindings.bumpCredentialEpoch(orgId, bindingId)
     if (!binding.installerConnectionId) {
       await this.deps.bindings.update(orgId, bindingId, {

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -310,6 +310,9 @@ export class GitlabProvisioner {
         this.deps.log?.warn({ bindingId: binding.id, purpose }, 'gitlab stray token revocation is unconfirmed')
       )
     }
+    // Renew again right before the create: the stray sweep above may have
+    // spent a chunk of the lease on sequential provider calls.
+    if (!(await this.renewLease(orgId, binding, owner))) throw new GitlabClaimFenceLost()
     const grant = await gitlabCreateServiceAccountToken(
       token,
       groupId,
@@ -482,14 +485,15 @@ export class GitlabProvisioner {
       }
       const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
       if (root.kind === 'group') {
-        const marked = await gitlabFindServiceAccount(
-          token,
-          root.id,
-          gitlabServiceAccountUsername(binding.projectId),
-          this.deps.fetchImpl
-        )
-        const accountUserId = binding.serviceAccountUserId ?? (marked ? BigInt(marked.id) : null)
-        if (accountUserId !== null) {
+        const username = gitlabServiceAccountUsername(binding.projectId)
+        const marked = await gitlabFindServiceAccount(token, root.id, username, this.deps.fetchImpl)
+        // The UNION of the recorded id and the marker result: a stale recorded
+        // account and a crash-left marked replacement can be two distinct
+        // accounts, and both must be gone before the claim may release.
+        const candidates = new Set<bigint>()
+        if (binding.serviceAccountUserId !== null) candidates.add(binding.serviceAccountUserId)
+        if (marked) candidates.add(BigInt(marked.id))
+        for (const accountUserId of candidates) {
           // Recorded tokens are revoked individually (belt); deleting the
           // account then invalidates anything a crash left unrecorded.
           for (const credential of credentials) {
@@ -502,6 +506,10 @@ export class GitlabProvisioner {
             ).catch(swallow404)
           }
           await gitlabDeleteServiceAccount(token, root.id, accountUserId, this.deps.fetchImpl).catch(swallow404)
+        }
+        // Release only on positive evidence: the deterministic marker is absent.
+        if (await gitlabFindServiceAccount(token, root.id, username, this.deps.fetchImpl)) {
+          throw new GitlabApiError('marked service account still present after cleanup', 0, 'INTERNAL', true)
         }
       } else if (binding.serviceAccountUserId !== null || credentials.length > 0) {
         // Provider facts exist but their group is unreachable: never release.

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -1,0 +1,375 @@
+/**
+ * GitLab project provisioning saga + external cleanup (gitlab-com-integration.md
+ * §10.2, §7.2–§7.4, §11.1, §19.4).
+ *
+ * Desired-state convergence, resumable at every step: refresh the project by
+ * numeric id, find-or-create the deterministically marked Project Service
+ * Account under the ROOT group, ensure Developer membership, create or recover
+ * the three purpose-separated PATs with an explicit 90-day expiry, and — when
+ * at least one enabled GitLab hook wants events — install and test the managed
+ * webhook with a fresh whsec signing key.
+ *
+ * Fail-closed rules carried from the design:
+ * - a returned PAT is sealed only after its identity, scopes, active flag, and
+ *   EXACT requested expiry validate; anything else is revoked by id at once and
+ *   the step fails (§7.3);
+ * - external names carry the stable binding marker; foreign accounts, tokens,
+ *   and webhooks are never adopted by name alone — webhook ownership needs BOTH
+ *   the stored id and the marker URL (§10.3);
+ * - cleanup that cannot be completed leaves `cleanup_pending` and RETAINS the
+ *   deployment-global claim; elapsed time never releases it (§10.2, §19.4).
+ *
+ * NEVER log token material or upstream token responses.
+ */
+import { randomBytes } from 'node:crypto'
+import { OrgId } from '../domain/ids.js'
+import type { SecretCipher } from '../secrets/cipher.js'
+import { orgScope } from '../secrets/scope.js'
+import type { Clock } from '../domain/clock.js'
+import type {
+  CodeHostRepositoryRepo,
+  GitlabCredentialPurpose,
+  GitlabProjectBindingRecord,
+  GitlabProjectBindingRepo,
+  GitlabProjectCredentialRepo,
+  GitlabProjectCredentialSecretStore,
+  GitlabWebhookSecretStore
+} from '../persistence/ports.js'
+import {
+  GitlabApiError,
+  gitlabCreateServiceAccount,
+  gitlabCreateServiceAccountToken,
+  gitlabCreateWebhook,
+  gitlabDeleteServiceAccount,
+  gitlabDeleteWebhook,
+  gitlabEnsureDeveloperMember,
+  gitlabFindServiceAccount,
+  gitlabProject,
+  gitlabRevokeToken,
+  gitlabRootNamespace,
+  gitlabServiceAccountUsername,
+  gitlabTestWebhook,
+  gitlabUpdateWebhook,
+  type FetchLike,
+  type GitlabProjectWithNamespace,
+  type GitlabWebhookEvents
+} from './api.js'
+import type { GitlabOauthService } from './oauth.service.js'
+
+/** §7.3 v1 policy: every PAT is created with exactly this lifetime. */
+export const PAT_LIFETIME_DAYS = 90
+
+const PURPOSE_SCOPES: Record<GitlabCredentialPurpose, string[]> = {
+  read: ['read_api', 'read_repository'],
+  git_write: ['write_repository'],
+  effect: ['api']
+}
+
+/** §7.3: the provider returned a token outside the requested policy. */
+export class GitlabTokenPolicyViolation extends Error {
+  constructor(readonly purpose: GitlabCredentialPurpose) {
+    super(`gitlab returned an out-of-policy ${purpose} token`)
+    this.name = 'GitlabTokenPolicyViolation'
+  }
+}
+
+export type ProvisionOutcome = { state: 'ready' } | { state: 'admin_degraded' | 'runtime_degraded'; reason: string }
+
+export interface GitlabProvisionerDeps {
+  oauth: GitlabOauthService
+  bindings: GitlabProjectBindingRepo
+  credentials: GitlabProjectCredentialRepo
+  credentialSecrets: GitlabProjectCredentialSecretStore
+  webhookSecrets: GitlabWebhookSecretStore
+  catalog: CodeHostRepositoryRepo
+  cipher: SecretCipher
+  clock: Clock
+  /** Public relay origin the managed webhook URL derives from; absent ⇒ the
+   *  webhook step reports a configuration reason instead of guessing. */
+  publicRelayUrl?: string
+  /** The enabled-hook event union for a project; null ⇒ no webhook wanted (§10.3). */
+  desiredWebhookEvents: (orgId: string, projectId: bigint) => Promise<GitlabWebhookEvents | null>
+  fetchImpl?: FetchLike
+  log?: { warn(obj: object, msg: string): void }
+}
+
+function expiresAtDate(nowMs: number): string {
+  return new Date(nowMs + PAT_LIFETIME_DAYS * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+}
+
+function patName(projectId: bigint, purpose: GitlabCredentialPurpose): string {
+  return `${gitlabServiceAccountUsername(projectId)}-${purpose.replace('_', '-')}`
+}
+
+export class GitlabProvisioner {
+  constructor(private readonly deps: GitlabProvisionerDeps) {}
+
+  /** Converge one binding to ready; persists the outcome state on the binding. */
+  async provision(orgId: string, bindingId: string): Promise<ProvisionOutcome> {
+    const binding = await this.deps.bindings.get(orgId, bindingId)
+    if (!binding) return { state: 'admin_degraded', reason: 'binding_missing' }
+    if (!binding.installerConnectionId) {
+      return this.degrade(orgId, bindingId, 'admin_degraded', 'no_admin_connection')
+    }
+    try {
+      const token = await this.deps.oauth.withAccessToken(orgId, binding.installerConnectionId)
+      const outcome = await this.converge(orgId, binding, token)
+      if (outcome.state === 'ready') {
+        await this.deps.bindings.update(orgId, bindingId, { state: 'ready', stateReason: null })
+      } else {
+        await this.deps.bindings.update(orgId, bindingId, { state: outcome.state, stateReason: outcome.reason })
+      }
+      return outcome
+    } catch (e) {
+      const reason =
+        e instanceof GitlabTokenPolicyViolation
+          ? 'out_of_policy_token'
+          : e instanceof GitlabApiError
+            ? `gitlab_${e.status || 'unreachable'}`
+            : 'admin_unavailable'
+      this.deps.log?.warn({ bindingId, reason }, 'gitlab provisioning failed')
+      return this.degrade(orgId, bindingId, 'admin_degraded', reason)
+    }
+  }
+
+  private async degrade(
+    orgId: string,
+    bindingId: string,
+    state: 'admin_degraded' | 'runtime_degraded',
+    reason: string
+  ): Promise<ProvisionOutcome> {
+    await this.deps.bindings.update(orgId, bindingId, { state, stateReason: reason })
+    return { state, reason }
+  }
+
+  private async converge(orgId: string, binding: GitlabProjectBindingRecord, token: string): Promise<ProvisionOutcome> {
+    const { fetchImpl } = this.deps
+    // 1. Refresh the mutable facts by numeric id (rename-proof, §10.2 step 1).
+    const project = (await gitlabProject(token, binding.projectId, fetchImpl)) as GitlabProjectWithNamespace | null
+    if (!project) return { state: 'admin_degraded', reason: 'project_not_accessible' }
+    await this.deps.bindings.update(orgId, binding.id, {
+      projectPath: project.path_with_namespace,
+      defaultBranch: project.default_branch ?? null
+    })
+    await this.deps.catalog.upsert({
+      orgId,
+      provider: 'gitlab',
+      externalId: binding.projectId,
+      displayPath: project.path_with_namespace,
+      ...(project.http_url_to_repo ? { cloneUrl: project.http_url_to_repo } : {}),
+      ...(project.default_branch ? { defaultBranch: project.default_branch } : {})
+    })
+    if (!project.namespace) return { state: 'admin_degraded', reason: 'project_namespace_unknown' }
+    const root = await gitlabRootNamespace(token, project.namespace, fetchImpl)
+    // Service accounts hang off a top-level GROUP; a personal namespace has none (§5).
+    if (root.kind !== 'group') return { state: 'admin_degraded', reason: 'personal_namespace_unsupported' }
+
+    // 2–3. Find-or-create the marked service account; ensure Developer membership.
+    const username = gitlabServiceAccountUsername(binding.projectId)
+    let account = await gitlabFindServiceAccount(token, root.id, username, fetchImpl)
+    if (!account) {
+      try {
+        account = await gitlabCreateServiceAccount(
+          token,
+          root.id,
+          { username, name: `AgentConnect (${project.path_with_namespace})` },
+          fetchImpl
+        )
+      } catch (e) {
+        // Ambiguous create (§10.2): list by the deterministic marker before failing.
+        account = await gitlabFindServiceAccount(token, root.id, username, fetchImpl)
+        if (!account) {
+          if (e instanceof GitlabApiError && e.status === 403) {
+            // Owner identity verification or the Free quota — a human prerequisite (§5).
+            return { state: 'admin_degraded', reason: 'service_account_create_forbidden' }
+          }
+          throw e
+        }
+      }
+    }
+    const accountUserId = BigInt(account.id)
+    await gitlabEnsureDeveloperMember(token, binding.projectId, accountUserId, fetchImpl)
+    await this.deps.bindings.update(orgId, binding.id, {
+      serviceAccountUserId: accountUserId,
+      serviceAccountUsername: account.username
+    })
+
+    // 4–5. The three purpose-separated PATs, each with the explicit finite expiry.
+    for (const purpose of ['read', 'git_write', 'effect'] as const) {
+      const existing = await this.deps.credentials.get(binding.id, purpose)
+      const stillValid =
+        existing &&
+        existing.providerExpiresAt.getTime() > this.deps.clock.now() &&
+        (await this.deps.credentialSecrets.get(orgId, existing.id)) !== null
+      if (stillValid) continue
+      await this.mintCredential(orgId, binding, token, root.id, accountUserId, purpose)
+    }
+
+    // 6–7. The managed webhook, only when an enabled hook wants events (§10.3).
+    const events = await this.deps.desiredWebhookEvents(orgId, binding.projectId)
+    if (events) {
+      const outcome = await this.convergeWebhook(orgId, binding, token, events)
+      if (outcome) return outcome
+    }
+    return { state: 'ready' }
+  }
+
+  private async mintCredential(
+    orgId: string,
+    binding: GitlabProjectBindingRecord,
+    token: string,
+    groupId: number,
+    serviceAccountUserId: bigint,
+    purpose: GitlabCredentialPurpose
+  ): Promise<void> {
+    const scopes = PURPOSE_SCOPES[purpose]
+    const expiresAt = expiresAtDate(this.deps.clock.now())
+    const grant = await gitlabCreateServiceAccountToken(
+      token,
+      groupId,
+      serviceAccountUserId,
+      { name: patName(binding.projectId, purpose), scopes, expiresAt },
+      this.deps.fetchImpl
+    )
+    // §7.3 validation before sealing: identity, scopes, active, EXACT expiry.
+    const valid =
+      typeof grant.token === 'string' &&
+      grant.token.length > 0 &&
+      grant.active !== false &&
+      grant.revoked !== true &&
+      grant.expires_at === expiresAt &&
+      (grant.user_id === undefined || BigInt(grant.user_id) === serviceAccountUserId) &&
+      scopes.every((scope) => grant.scopes?.includes(scope)) &&
+      grant.scopes?.length === scopes.length
+    if (!valid) {
+      // Out-of-policy token: revoke by id immediately and fail closed. An
+      // id-less response is recorded as restricted cleanup debt.
+      if (typeof grant.id === 'number') {
+        await gitlabRevokeToken(token, BigInt(grant.id), this.deps.fetchImpl).catch(() => {
+          this.deps.log?.warn(
+            { bindingId: binding.id, purpose, tokenId: grant.id },
+            'gitlab out-of-policy token revocation is unconfirmed (restricted cleanup debt)'
+          )
+        })
+      } else {
+        this.deps.log?.warn({ bindingId: binding.id, purpose }, 'gitlab returned an out-of-policy token without an id')
+      }
+      throw new GitlabTokenPolicyViolation(purpose)
+    }
+    // Seal first; metadata, sealed value, and the epoch fence commit atomically.
+    await this.deps.credentials.commitRotation({
+      bindingId: binding.id,
+      purpose,
+      externalTokenId: BigInt(grant.id),
+      scopes,
+      providerExpiresAt: new Date(`${expiresAt}T00:00:00.000Z`),
+      sealedToken: await this.deps.cipher.seal(grant.token!, orgScope(OrgId(orgId)))
+    })
+  }
+
+  private async convergeWebhook(
+    orgId: string,
+    binding: GitlabProjectBindingRecord,
+    token: string,
+    events: GitlabWebhookEvents
+  ): Promise<ProvisionOutcome | null> {
+    if (!this.deps.publicRelayUrl) {
+      return { state: 'admin_degraded', reason: 'relay_url_unconfigured' }
+    }
+    const url = `${this.deps.publicRelayUrl.replace(/\/$/, '')}/webhooks/gitlab`
+    const signingToken = `whsec_${randomBytes(32).toString('base64')}`
+    const fresh = binding.webhookId === null
+    let webhookId: bigint
+    if (fresh) {
+      const created = await gitlabCreateWebhook(
+        token,
+        binding.projectId,
+        { url, signingToken, events },
+        this.deps.fetchImpl
+      )
+      webhookId = BigInt(created.id)
+    } else {
+      // Ownership = stored id + marker URL (§10.3); never adopt by URL alone.
+      webhookId = binding.webhookId!
+      await gitlabUpdateWebhook(token, binding.projectId, webhookId, { url, signingToken, events }, this.deps.fetchImpl)
+    }
+    // Seal BEFORE recording the webhook as converged: a crash between leaves a
+    // webhook we own and re-key on the next convergence, never a key we lost.
+    await this.deps.webhookSecrets.put(orgId, binding.id, signingToken)
+    await this.deps.bindings.update(orgId, binding.id, {
+      webhookId,
+      desiredEventsHash: JSON.stringify(events)
+    })
+    if (fresh) {
+      await gitlabTestWebhook(token, binding.projectId, webhookId, 'push_events', this.deps.fetchImpl).catch((e) => {
+        this.deps.log?.warn(
+          { bindingId: binding.id, status: e instanceof GitlabApiError ? e.status : undefined },
+          'gitlab webhook test delivery failed'
+        )
+      })
+    }
+    return null
+  }
+
+  /**
+   * §19.4 disconnect: local authority off first (epoch bump), then external
+   * cleanup — webhook, PAT revocations, service account. Complete cleanup
+   * removes the binding and releases the deployment-global claim; anything
+   * ambiguous keeps `cleanup_pending` and RETAINS the claim.
+   */
+  async disconnect(orgId: string, bindingId: string): Promise<{ removed: boolean; reason?: string }> {
+    const binding = await this.deps.bindings.get(orgId, bindingId)
+    if (!binding) return { removed: false, reason: 'binding_missing' }
+    await this.deps.bindings.bumpCredentialEpoch(orgId, bindingId)
+    if (!binding.installerConnectionId) {
+      await this.deps.bindings.update(orgId, bindingId, {
+        state: 'cleanup_pending',
+        stateReason: 'no_admin_connection'
+      })
+      return { removed: false, reason: 'no_admin_connection' }
+    }
+    try {
+      const token = await this.deps.oauth.withAccessToken(orgId, binding.installerConnectionId)
+      if (binding.webhookId !== null) {
+        await gitlabDeleteWebhook(token, binding.projectId, binding.webhookId, this.deps.fetchImpl).catch(swallow404)
+      }
+      for (const credential of await this.deps.credentials.listForBinding(bindingId)) {
+        await gitlabRevokeToken(token, credential.externalTokenId, this.deps.fetchImpl).catch(swallow404)
+      }
+      if (binding.serviceAccountUserId !== null) {
+        const project = (await gitlabProject(
+          token,
+          binding.projectId,
+          this.deps.fetchImpl
+        )) as GitlabProjectWithNamespace | null
+        if (project?.namespace) {
+          const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
+          if (root.kind === 'group') {
+            await gitlabDeleteServiceAccount(token, root.id, binding.serviceAccountUserId, this.deps.fetchImpl).catch(
+              swallow404
+            )
+          }
+        }
+      }
+    } catch (e) {
+      const reason = e instanceof GitlabApiError ? `gitlab_${e.status || 'unreachable'}` : 'cleanup_failed'
+      await this.deps.bindings.update(orgId, bindingId, { state: 'cleanup_pending', stateReason: reason })
+      return { removed: false, reason }
+    }
+    // Verified-complete external cleanup: the local rows and the claim go together.
+    await this.deps.bindings.removeWithClaim(orgId, bindingId, binding.projectId)
+    return { removed: true }
+  }
+}
+
+/** A definitively absent external resource IS cleaned up; anything else rethrows. */
+function swallow404(e: unknown): void {
+  if (e instanceof GitlabApiError && e.code === 'NOT_FOUND') return
+  throw e
+}
+
+/** The sealed webhook signing key is relay material; this module never returns it. */
+export type { GitlabWebhookEvents }
+export const GITLAB_WEBHOOK_PATH = '/webhooks/gitlab'
+/** Test-facing alias for the deterministic marker (kept beside its consumer). */
+export { gitlabServiceAccountUsername as gitlabServiceAccountUsernameForTests }

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -59,6 +59,7 @@ import type { OAuthService } from '../registry/oauthService.js'
 import type { GithubService } from '../github/service.js'
 import type { GitlabOauthService } from '../gitlab/oauth.service.js'
 import type { FetchLike as GitlabFetchLike } from '../gitlab/api.js'
+import type { GitlabProvisioner } from '../gitlab/provisioner.js'
 import type { PullRequestViewService } from '../github/pull-request-view.service.js'
 import type { SessionPullRequestLinkService } from '../github/session-pull-request-link.service.js'
 import type { GithubUserAuthzService } from '../github/user-authz.js'
@@ -376,7 +377,7 @@ export interface HttpDeps {
   github?: GithubService
   /** GitLab.com OAuth surface (gitlab-com-integration.md §9); absent ⇒ routes 404.
    *  `fetchImpl` is the injectable gitlab.com edge the admin routes share with the service. */
-  gitlab?: { oauth: GitlabOauthService; fetchImpl?: GitlabFetchLike }
+  gitlab?: { oauth: GitlabOauthService; provisioner: GitlabProvisioner; fetchImpl?: GitlabFetchLike }
   /** The PR panel's read projection; absent like {@link github} ⇒ the route 404s, hiding the tab. */
   pullRequestView?: PullRequestViewService
   /** The panel's second identity source: the PR a session's own head branch has, for the sessions no

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -267,7 +267,11 @@ export function gitlabRoutes(deps: HttpDeps) {
             ...(project.http_url_to_repo ? { cloneUrl: project.http_url_to_repo } : {}),
             installerConnectionId: connection.id
           })
-          return bindingToDto(binding)
+          // The §10.2 saga converges the external resources; the binding records
+          // the outcome state either way and repair re-runs it.
+          await gitlab.provisioner.provision(orgId, binding.id)
+          const converged = await deps.repos.gitlabProjectBinding.get(orgId, binding.id)
+          return bindingToDto(converged ?? binding)
         } catch (e) {
           if (e instanceof GitlabProjectClaimConflict) {
             // The deployment-global claim (§7.2): one managing organization per
@@ -283,6 +287,68 @@ export function gitlabRoutes(deps: HttpDeps) {
           }
           throw e
         }
+      }
+    )
+
+    r.post(
+      '/gitlab/projects/:id/repair',
+      {
+        schema: {
+          tags: [Tag.GitLab],
+          summary: 'Repair a managed GitLab project',
+          description:
+            'Re-runs the §10.2 provisioning convergence: refresh identity, service account, credentials, and the managed webhook.',
+          operationId: 'repairGitlabProject',
+          params: IdParam,
+          response: { 200: GitlabProjectBindingDto, 403: ErrorDto, 404: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return
+        const orgId = orgOf(req)
+        if (!(await deps.repos.gitlabProjectBinding.get(orgId, req.params.id))) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab project not found' })
+        }
+        await gitlab.provisioner.provision(orgId, req.params.id)
+        const binding = await deps.repos.gitlabProjectBinding.get(orgId, req.params.id)
+        if (!binding) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab project not found' })
+        }
+        return bindingToDto(binding)
+      }
+    )
+
+    r.delete(
+      '/gitlab/projects/:id',
+      {
+        schema: {
+          tags: [Tag.GitLab],
+          summary: 'Disconnect a managed GitLab project',
+          description:
+            'Disables local authority, then removes the managed webhook, revokes the managed tokens, and deletes the Project Service Account (§19.4). Incomplete external cleanup leaves the binding cleanup_pending and keeps the deployment-global claim.',
+          operationId: 'deleteGitlabProject',
+          params: IdParam,
+          response: {
+            200: z.object({
+              removed: z.boolean(),
+              state: GitlabProjectBindingDto.shape.state.optional(),
+              stateReason: z.string().nullable().optional()
+            }),
+            403: ErrorDto,
+            404: ErrorDto
+          }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return
+        const orgId = orgOf(req)
+        if (!(await deps.repos.gitlabProjectBinding.get(orgId, req.params.id))) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab project not found' })
+        }
+        const outcome = await gitlab.provisioner.disconnect(orgId, req.params.id)
+        if (outcome.removed) return { removed: true }
+        const binding = await deps.repos.gitlabProjectBinding.get(orgId, req.params.id)
+        return { removed: false, state: binding?.state, stateReason: binding?.stateReason ?? outcome.reason ?? null }
       }
     )
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3156,6 +3156,10 @@ export interface GitlabProjectBindingRepo {
   ): Promise<GitlabProjectBindingRecord | null>
   /** Purge fence: every rotation/revocation/disconnect bumps it (§7.4/§19.4). */
   bumpCredentialEpoch(orgId: string, bindingId: string): Promise<bigint | null>
+  /** §10.2 durable fence, written BEFORE the first provider write: flips the
+   *  attached claim out of `provisioning`, so the claim guard can never read a
+   *  crash between an external create and its local id write as "unmutated". */
+  markProviderMutationStarted(orgId: string, bindingId: string, projectId: bigint): Promise<void>
   /** Verified-complete cleanup only (§10.2/§19.4): the binding, its cascaded
    *  local rows, and the deployment-global claim are removed in ONE
    *  transaction. Anything short of verified cleanup keeps both. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3157,9 +3157,15 @@ export interface GitlabProjectBindingRepo {
   /** Purge fence: every rotation/revocation/disconnect bumps it (§7.4/§19.4). */
   bumpCredentialEpoch(orgId: string, bindingId: string): Promise<bigint | null>
   /** §10.2 durable fence, written BEFORE the first provider write: flips the
-   *  attached claim out of `provisioning`, so the claim guard can never read a
-   *  crash between an external create and its local id write as "unmutated". */
-  markProviderMutationStarted(orgId: string, bindingId: string, projectId: bigint): Promise<void>
+   *  attached claim out of `provisioning`. False ⇒ the claim is gone, detached,
+   *  or already in cleanup — the caller must NOT touch the provider. */
+  markProviderMutationStarted(orgId: string, bindingId: string, projectId: bigint): Promise<boolean>
+  /** Per-step §10.2 check before EVERY provider create: the claim is still
+   *  attached to this binding and still `active` (not entering cleanup). */
+  claimFenceHeld(orgId: string, bindingId: string, projectId: bigint): Promise<boolean>
+  /** Cleanup entry: flips the attached claim to `cleanup_pending` so any
+   *  concurrent provision/repair loses its fence before its next provider write. */
+  beginCleanup(orgId: string, bindingId: string, projectId: bigint): Promise<void>
   /** Verified-complete cleanup only (§10.2/§19.4): the binding, its cascaded
    *  local rows, and the deployment-global claim are removed in ONE
    *  transaction. Anything short of verified cleanup keeps both. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3156,6 +3156,10 @@ export interface GitlabProjectBindingRepo {
   ): Promise<GitlabProjectBindingRecord | null>
   /** Purge fence: every rotation/revocation/disconnect bumps it (§7.4/§19.4). */
   bumpCredentialEpoch(orgId: string, bindingId: string): Promise<bigint | null>
+  /** Verified-complete cleanup only (§10.2/§19.4): the binding, its cascaded
+   *  local rows, and the deployment-global claim are removed in ONE
+   *  transaction. Anything short of verified cleanup keeps both. */
+  removeWithClaim(orgId: string, bindingId: string, projectId: bigint): Promise<boolean>
 }
 
 export type GitlabCredentialPurpose = 'read' | 'git_write' | 'effect'

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3156,18 +3156,25 @@ export interface GitlabProjectBindingRepo {
   ): Promise<GitlabProjectBindingRecord | null>
   /** Purge fence: every rotation/revocation/disconnect bumps it (§7.4/§19.4). */
   bumpCredentialEpoch(orgId: string, bindingId: string): Promise<bigint | null>
-  /** §10.2 RESERVATION, durable before the first provider write: flips the
-   *  attached claim out of `provisioning` and holds the in-flight reservation
-   *  cleanup must respect. False ⇒ gone/detached/in-cleanup: NO provider writes. */
-  markProviderMutationStarted(orgId: string, bindingId: string, projectId: bigint): Promise<boolean>
-  /** Releases the reservation once the run's provider writes have settled. */
-  endProviderMutation(orgId: string, bindingId: string, projectId: bigint): Promise<void>
-  /** Per-step belt under the reservation: attached and still `active`. */
-  claimFenceHeld(orgId: string, bindingId: string, projectId: bigint): Promise<boolean>
-  /** Cleanup entry — MUTUALLY EXCLUSIVE with the reservation: false while a
-   *  provisioning run holds it (cleanup retries later); flips the attached
-   *  claim to `cleanup_pending` so a late marker/fence check refuses. */
-  beginCleanup(orgId: string, bindingId: string, projectId: bigint): Promise<boolean>
+  /** §10.2 EXCLUSIVE run-owned provisioning lease, CAS-acquired before the
+   *  first provider write: free, same-owner, or expired only — a live foreign
+   *  lease refuses, so two runs can never both write. False also when the claim
+   *  is gone, detached, or in cleanup. */
+  markProviderMutationStarted(
+    orgId: string,
+    bindingId: string,
+    projectId: bigint,
+    owner: string,
+    until: Date,
+    now: Date
+  ): Promise<boolean>
+  /** Releases ONLY the owning run's lease. */
+  endProviderMutation(orgId: string, bindingId: string, projectId: bigint, owner: string): Promise<void>
+  /** Per-step belt under the lease: attached, `active`, owned by this run, unexpired. */
+  claimFenceHeld(orgId: string, bindingId: string, projectId: bigint, owner: string, now: Date): Promise<boolean>
+  /** Cleanup entry — mutually exclusive with a LIVE lease: false while one is
+   *  held (cleanup retries later); flips the attached claim to `cleanup_pending`. */
+  beginCleanup(orgId: string, bindingId: string, projectId: bigint, now: Date): Promise<boolean>
   /** Verified-complete cleanup only (§10.2/§19.4): the binding, its cascaded
    *  local rows, and the deployment-global claim are removed in ONE
    *  transaction. Anything short of verified cleanup keeps both. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3170,8 +3170,10 @@ export interface GitlabProjectBindingRepo {
   ): Promise<boolean>
   /** Releases ONLY the owning run's lease. */
   endProviderMutation(orgId: string, bindingId: string, projectId: bigint, owner: string): Promise<void>
-  /** Per-step belt under the lease: attached, `active`, owned by this run, unexpired. */
-  claimFenceHeld(orgId: string, bindingId: string, projectId: bigint, owner: string, now: Date): Promise<boolean>
+  /** Per-step ATOMIC renewal before every provider mutation: still attached,
+   *  `active`, and owned by this run — and the lease is extended so it cannot
+   *  expire while the provider request is in flight. */
+  renewProviderLease(orgId: string, bindingId: string, projectId: bigint, owner: string, until: Date): Promise<boolean>
   /** Cleanup entry — mutually exclusive with a LIVE lease: false while one is
    *  held (cleanup retries later); flips the attached claim to `cleanup_pending`. */
   beginCleanup(orgId: string, bindingId: string, projectId: bigint, now: Date): Promise<boolean>

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3156,16 +3156,18 @@ export interface GitlabProjectBindingRepo {
   ): Promise<GitlabProjectBindingRecord | null>
   /** Purge fence: every rotation/revocation/disconnect bumps it (§7.4/§19.4). */
   bumpCredentialEpoch(orgId: string, bindingId: string): Promise<bigint | null>
-  /** §10.2 durable fence, written BEFORE the first provider write: flips the
-   *  attached claim out of `provisioning`. False ⇒ the claim is gone, detached,
-   *  or already in cleanup — the caller must NOT touch the provider. */
+  /** §10.2 RESERVATION, durable before the first provider write: flips the
+   *  attached claim out of `provisioning` and holds the in-flight reservation
+   *  cleanup must respect. False ⇒ gone/detached/in-cleanup: NO provider writes. */
   markProviderMutationStarted(orgId: string, bindingId: string, projectId: bigint): Promise<boolean>
-  /** Per-step §10.2 check before EVERY provider create: the claim is still
-   *  attached to this binding and still `active` (not entering cleanup). */
+  /** Releases the reservation once the run's provider writes have settled. */
+  endProviderMutation(orgId: string, bindingId: string, projectId: bigint): Promise<void>
+  /** Per-step belt under the reservation: attached and still `active`. */
   claimFenceHeld(orgId: string, bindingId: string, projectId: bigint): Promise<boolean>
-  /** Cleanup entry: flips the attached claim to `cleanup_pending` so any
-   *  concurrent provision/repair loses its fence before its next provider write. */
-  beginCleanup(orgId: string, bindingId: string, projectId: bigint): Promise<void>
+  /** Cleanup entry — MUTUALLY EXCLUSIVE with the reservation: false while a
+   *  provisioning run holds it (cleanup retries later); flips the attached
+   *  claim to `cleanup_pending` so a late marker/fence check refuses. */
+  beginCleanup(orgId: string, bindingId: string, projectId: bigint): Promise<boolean>
   /** Verified-complete cleanup only (§10.2/§19.4): the binding, its cascaded
    *  local rows, and the deployment-global claim are removed in ONE
    *  transaction. Anything short of verified cleanup keeps both. */

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -377,6 +377,9 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
   async markProviderMutationStarted(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {
     // Idempotent for reruns (`active` stays `active`); false the moment the
     // claim is gone, detached, or entering cleanup — the fence is REQUIRED.
+    // The RESERVATION: durable before any provider write, and the mutual-
+    // exclusion edge — beginCleanup refuses while it is held. Idempotent for
+    // the same owner (a crashed run's stale reservation is re-acquired here).
     const res = await this.prisma.codeHostRepositoryClaim.updateMany({
       where: {
         provider: 'gitlab',
@@ -385,9 +388,16 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
         bindingRef: bindingId,
         state: { in: ['provisioning', 'active'] }
       },
-      data: { state: 'active' }
+      data: { state: 'active', opInFlight: true }
     })
     return res.count === 1
+  }
+
+  async endProviderMutation(orgId: string, bindingId: string, projectId: bigint): Promise<void> {
+    await this.prisma.codeHostRepositoryClaim.updateMany({
+      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId },
+      data: { opInFlight: false }
+    })
   }
 
   async claimFenceHeld(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {
@@ -397,11 +407,19 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
     return held === 1
   }
 
-  async beginCleanup(orgId: string, bindingId: string, projectId: bigint): Promise<void> {
-    await this.prisma.codeHostRepositoryClaim.updateMany({
-      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId },
+  async beginCleanup(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {
+    // Refused while a provisioning reservation is held: cleanup must WAIT, so
+    // there is no window between a fence check and its provider write. When no
+    // claim row is attached at all (already tombstoned), cleanup may proceed.
+    const attached = await this.prisma.codeHostRepositoryClaim.count({
+      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId }
+    })
+    if (attached === 0) return true
+    const res = await this.prisma.codeHostRepositoryClaim.updateMany({
+      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId, opInFlight: false },
       data: { state: 'cleanup_pending' }
     })
+    return res.count === 1
   }
 
   async removeWithClaim(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -406,25 +406,29 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
     })
   }
 
-  async claimFenceHeld(
+  async renewProviderLease(
     orgId: string,
     bindingId: string,
     projectId: bigint,
     owner: string,
-    now: Date
+    until: Date
   ): Promise<boolean> {
-    const held = await this.prisma.codeHostRepositoryClaim.count({
+    // Owner-matched atomic extension: renewal and the liveness check are one
+    // write, so the lease cannot lapse between a check and its provider call.
+    // Owner match alone suffices — an expired-but-unreclaimed lease renews,
+    // a reclaimed one has a different owner and refuses.
+    const res = await this.prisma.codeHostRepositoryClaim.updateMany({
       where: {
         provider: 'gitlab',
         externalId: projectId,
         orgId,
         bindingRef: bindingId,
         state: 'active',
-        opOwner: owner,
-        opLeaseUntil: { gte: now }
-      }
+        opOwner: owner
+      },
+      data: { opLeaseUntil: until }
     })
-    return held === 1
+    return res.count === 1
   }
 
   async beginCleanup(orgId: string, bindingId: string, projectId: bigint, now: Date): Promise<boolean> {

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -374,12 +374,33 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
     return this.get(orgId, bindingId)
   }
 
-  async markProviderMutationStarted(orgId: string, bindingId: string, projectId: bigint): Promise<void> {
-    // Idempotent: only the first provisioning run flips it; `active` then means
-    // "provider state may exist" for the rest of the claim's life.
-    await this.prisma.codeHostRepositoryClaim.updateMany({
-      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId, state: 'provisioning' },
+  async markProviderMutationStarted(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {
+    // Idempotent for reruns (`active` stays `active`); false the moment the
+    // claim is gone, detached, or entering cleanup — the fence is REQUIRED.
+    const res = await this.prisma.codeHostRepositoryClaim.updateMany({
+      where: {
+        provider: 'gitlab',
+        externalId: projectId,
+        orgId,
+        bindingRef: bindingId,
+        state: { in: ['provisioning', 'active'] }
+      },
       data: { state: 'active' }
+    })
+    return res.count === 1
+  }
+
+  async claimFenceHeld(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {
+    const held = await this.prisma.codeHostRepositoryClaim.count({
+      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId, state: 'active' }
+    })
+    return held === 1
+  }
+
+  async beginCleanup(orgId: string, bindingId: string, projectId: bigint): Promise<void> {
+    await this.prisma.codeHostRepositoryClaim.updateMany({
+      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId },
+      data: { state: 'cleanup_pending' }
     })
   }
 

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -374,6 +374,21 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
     return this.get(orgId, bindingId)
   }
 
+  async removeWithClaim(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {
+    // Claim FIRST: the binding-delete trigger preserves any still-attached claim
+    // as cleanup_pending, which is exactly wrong here — this path is only taken
+    // after verified-complete external cleanup, so the claim releases with it.
+    return this.prisma.$transaction(async (tx) => {
+      const owned = await tx.gitlabProjectBinding.count({ where: { id: bindingId, orgId } })
+      if (owned !== 1) return false
+      await tx.codeHostRepositoryClaim.deleteMany({
+        where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId }
+      })
+      await tx.gitlabProjectBinding.deleteMany({ where: { id: bindingId, orgId } })
+      return true
+    })
+  }
+
   async bumpCredentialEpoch(orgId: string, bindingId: string): Promise<bigint | null> {
     const res = await this.prisma.gitlabProjectBinding.updateMany({
       where: { id: bindingId, orgId },

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -374,41 +374,61 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
     return this.get(orgId, bindingId)
   }
 
-  async markProviderMutationStarted(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {
-    // Idempotent for reruns (`active` stays `active`); false the moment the
-    // claim is gone, detached, or entering cleanup — the fence is REQUIRED.
-    // The RESERVATION: durable before any provider write, and the mutual-
-    // exclusion edge — beginCleanup refuses while it is held. Idempotent for
-    // the same owner (a crashed run's stale reservation is re-acquired here).
+  async markProviderMutationStarted(
+    orgId: string,
+    bindingId: string,
+    projectId: bigint,
+    owner: string,
+    until: Date,
+    now: Date
+  ): Promise<boolean> {
+    // EXCLUSIVE run-owned lease, CAS-acquired: free, same-owner, or expired —
+    // never a live foreign lease, so two runs can never both hold the fence.
     const res = await this.prisma.codeHostRepositoryClaim.updateMany({
       where: {
         provider: 'gitlab',
         externalId: projectId,
         orgId,
         bindingRef: bindingId,
-        state: { in: ['provisioning', 'active'] }
+        state: { in: ['provisioning', 'active'] },
+        OR: [{ opOwner: null }, { opOwner: owner }, { opLeaseUntil: { lt: now } }]
       },
-      data: { state: 'active', opInFlight: true }
+      data: { state: 'active', opOwner: owner, opLeaseUntil: until }
     })
     return res.count === 1
   }
 
-  async endProviderMutation(orgId: string, bindingId: string, projectId: bigint): Promise<void> {
+  async endProviderMutation(orgId: string, bindingId: string, projectId: bigint, owner: string): Promise<void> {
+    // Only the owning run releases; a finished run can never clear a peer's lease.
     await this.prisma.codeHostRepositoryClaim.updateMany({
-      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId },
-      data: { opInFlight: false }
+      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId, opOwner: owner },
+      data: { opOwner: null, opLeaseUntil: null }
     })
   }
 
-  async claimFenceHeld(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {
+  async claimFenceHeld(
+    orgId: string,
+    bindingId: string,
+    projectId: bigint,
+    owner: string,
+    now: Date
+  ): Promise<boolean> {
     const held = await this.prisma.codeHostRepositoryClaim.count({
-      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId, state: 'active' }
+      where: {
+        provider: 'gitlab',
+        externalId: projectId,
+        orgId,
+        bindingRef: bindingId,
+        state: 'active',
+        opOwner: owner,
+        opLeaseUntil: { gte: now }
+      }
     })
     return held === 1
   }
 
-  async beginCleanup(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {
-    // Refused while a provisioning reservation is held: cleanup must WAIT, so
+  async beginCleanup(orgId: string, bindingId: string, projectId: bigint, now: Date): Promise<boolean> {
+    // Refused while a LIVE provisioning lease is held: cleanup must wait, so
     // there is no window between a fence check and its provider write. When no
     // claim row is attached at all (already tombstoned), cleanup may proceed.
     const attached = await this.prisma.codeHostRepositoryClaim.count({
@@ -416,8 +436,14 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
     })
     if (attached === 0) return true
     const res = await this.prisma.codeHostRepositoryClaim.updateMany({
-      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId, opInFlight: false },
-      data: { state: 'cleanup_pending' }
+      where: {
+        provider: 'gitlab',
+        externalId: projectId,
+        orgId,
+        bindingRef: bindingId,
+        OR: [{ opOwner: null }, { opLeaseUntil: { lt: now } }]
+      },
+      data: { state: 'cleanup_pending', opOwner: null, opLeaseUntil: null }
     })
     return res.count === 1
   }

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -374,6 +374,15 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
     return this.get(orgId, bindingId)
   }
 
+  async markProviderMutationStarted(orgId: string, bindingId: string, projectId: bigint): Promise<void> {
+    // Idempotent: only the first provisioning run flips it; `active` then means
+    // "provider state may exist" for the rest of the claim's life.
+    await this.prisma.codeHostRepositoryClaim.updateMany({
+      where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId, state: 'provisioning' },
+      data: { state: 'active' }
+    })
+  }
+
   async removeWithClaim(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {
     // Claim FIRST: the binding-delete trigger preserves any still-attached claim
     // as cleanup_pending, which is exactly wrong here — this path is only taken

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -1,0 +1,209 @@
+/**
+ * Stateful fake gitlab.com edge for integration tests — the `FetchLike` twin of
+ * the recording GitHub stubs (M2 test infrastructure). Serves OAuth token
+ * exchange, the current user, project reads/search, effective membership, and
+ * the §10.2 administration surface (service accounts, PATs, webhooks) with
+ * scriptable failures. Grows with the milestones; the real-GitLab.com contract
+ * suite stays §23's job.
+ */
+import type { FetchLike } from '../../src/gitlab/api.js'
+
+export interface FakeGitlabOptions {
+  projectId?: number
+  path?: string
+  accessLevel?: number
+  namespaceKind?: 'group' | 'user'
+  /** Refuse service-account creation (Owner verification / Free quota, §5). */
+  refuseServiceAccountCreate?: boolean
+  /** Return this expires_at instead of echoing the request (out-of-policy). */
+  patExpiryOverride?: string | null
+  /** Fail PAT revocations with a 500 (ambiguous cleanup). */
+  failTokenRevoke?: boolean
+}
+
+export class FakeGitlab {
+  readonly opts: Required<Pick<FakeGitlabOptions, 'projectId' | 'path' | 'accessLevel' | 'namespaceKind'>> &
+    FakeGitlabOptions
+  serviceAccounts: { id: number; username: string; name: string }[] = []
+  tokens = new Map<number, { name: string; scopes: string[]; expires_at: string; revoked: boolean; user_id: number }>()
+  webhooks = new Map<number, { url: string; token: string; events: Record<string, boolean>; tested: number }>()
+  members = new Map<number, number>() // userId → access_level
+  deletedServiceAccounts: number[] = []
+  private nextId = 5000
+
+  constructor(options: FakeGitlabOptions = {}) {
+    this.opts = {
+      projectId: options.projectId ?? 4455667,
+      path: options.path ?? 'example-group/example-project',
+      accessLevel: options.accessLevel ?? 50,
+      namespaceKind: options.namespaceKind ?? 'group',
+      ...options
+    }
+  }
+
+  fetch(): FetchLike {
+    return async (url, init) => {
+      const method = init?.method ?? 'GET'
+      const body = typeof init?.body === 'string' ? init.body : ''
+      const json = (): Record<string, unknown> => {
+        try {
+          return JSON.parse(body) as Record<string, unknown>
+        } catch {
+          return {}
+        }
+      }
+
+      if (url.endsWith('/oauth/token')) {
+        return Response.json({
+          access_token: 'at-1',
+          refresh_token: 'rt-1',
+          expires_in: 7200,
+          created_at: Math.floor(Date.now() / 1000),
+          scope: 'api'
+        })
+      }
+      if (url.endsWith('/oauth/revoke')) return Response.json({})
+      if (url.endsWith('/api/v4/user')) return Response.json({ id: 4242, username: 'example-admin' })
+
+      if (/\/api\/v4\/projects\/\d+\/members\/all\/\d+$/.test(url)) {
+        const userId = Number(/members\/all\/(\d+)$/.exec(url)![1])
+        const direct = this.members.get(userId)
+        const level = direct ?? (userId === 4242 ? this.opts.accessLevel : null)
+        if (level === null) return Response.json({ message: 'Not Found' }, { status: 404 })
+        return Response.json({ access_level: level, state: 'active', expires_at: null })
+      }
+      if (/\/api\/v4\/projects\/\d+\/members$/.test(url) && method === 'POST') {
+        const payload = json()
+        this.members.set(Number(payload.user_id), Number(payload.access_level))
+        return Response.json({ id: payload.user_id, access_level: payload.access_level, state: 'active' })
+      }
+      if (/\/api\/v4\/projects\/\d+\/members\/\d+$/.test(url) && method === 'PUT') {
+        const userId = Number(/members\/(\d+)$/.exec(url)![1])
+        this.members.set(userId, Number(json().access_level))
+        return Response.json({ id: userId, access_level: json().access_level, state: 'active' })
+      }
+
+      if (/\/api\/v4\/projects\/\d+\/hooks$/.test(url) && method === 'POST') {
+        const id = ++this.nextId
+        const payload = json()
+        this.webhooks.set(id, {
+          url: String(payload.url),
+          token: String(payload.token),
+          events: payload as Record<string, boolean>,
+          tested: 0
+        })
+        return Response.json({ id, url: payload.url })
+      }
+      if (/\/api\/v4\/projects\/\d+\/hooks\/\d+\/test\/\w+$/.test(url) && method === 'POST') {
+        const id = Number(/hooks\/(\d+)\/test/.exec(url)![1])
+        const hook = this.webhooks.get(id)
+        if (!hook) return Response.json({ message: 'Not Found' }, { status: 404 })
+        hook.tested += 1
+        return Response.json({})
+      }
+      if (/\/api\/v4\/projects\/\d+\/hooks\/\d+$/.test(url)) {
+        const id = Number(/hooks\/(\d+)$/.exec(url)![1])
+        if (method === 'DELETE') {
+          if (!this.webhooks.delete(id)) return Response.json({ message: 'Not Found' }, { status: 404 })
+          return Response.json({})
+        }
+        if (method === 'PUT') {
+          const payload = json()
+          this.webhooks.set(id, {
+            url: String(payload.url),
+            token: String(payload.token),
+            events: payload as Record<string, boolean>,
+            tested: this.webhooks.get(id)?.tested ?? 0
+          })
+          return Response.json({ id, url: payload.url })
+        }
+      }
+
+      if (/\/api\/v4\/projects\/\d+$/.test(url)) {
+        const id = Number(/projects\/(\d+)$/.exec(url)![1])
+        return Response.json({
+          id,
+          path_with_namespace: this.opts.path,
+          default_branch: 'main',
+          http_url_to_repo: `https://gitlab.com/${this.opts.path}.git`,
+          namespace: {
+            id: 900,
+            parent_id: null,
+            kind: this.opts.namespaceKind,
+            full_path: this.opts.path.split('/')[0]!
+          }
+        })
+      }
+      if (url.includes('/api/v4/projects?')) {
+        return Response.json([
+          {
+            id: this.opts.projectId,
+            path_with_namespace: this.opts.path,
+            default_branch: 'main',
+            last_activity_at: '2026-08-20T00:00:00.000Z'
+          }
+        ])
+      }
+
+      if (/\/api\/v4\/groups\/\d+\/service_accounts\?/.test(url)) {
+        return Response.json(this.serviceAccounts)
+      }
+      if (/\/api\/v4\/groups\/\d+\/service_accounts$/.test(url) && method === 'POST') {
+        if (this.opts.refuseServiceAccountCreate) {
+          return Response.json({ message: 'forbidden' }, { status: 403 })
+        }
+        const payload = json()
+        const account = { id: ++this.nextId, username: String(payload.username), name: String(payload.name) }
+        this.serviceAccounts.push(account)
+        return Response.json(account, { status: 201 })
+      }
+      if (/\/api\/v4\/groups\/\d+\/service_accounts\/\d+$/.test(url) && method === 'DELETE') {
+        const id = Number(/service_accounts\/(\d+)$/.exec(url)![1])
+        this.deletedServiceAccounts.push(id)
+        this.serviceAccounts = this.serviceAccounts.filter((account) => account.id !== id)
+        return Response.json({})
+      }
+      if (/\/api\/v4\/groups\/\d+\/service_accounts\/\d+\/personal_access_tokens$/.test(url) && method === 'POST') {
+        const userId = Number(/service_accounts\/(\d+)\//.exec(url)![1])
+        const payload = json()
+        const id = ++this.nextId
+        const expires = this.opts.patExpiryOverride !== undefined ? this.opts.patExpiryOverride : payload.expires_at
+        this.tokens.set(id, {
+          name: String(payload.name),
+          scopes: payload.scopes as string[],
+          expires_at: String(expires),
+          revoked: false,
+          user_id: userId
+        })
+        return Response.json(
+          {
+            id,
+            name: payload.name,
+            scopes: payload.scopes,
+            active: true,
+            revoked: false,
+            expires_at: expires,
+            user_id: userId,
+            token: `glpat-${id}`
+          },
+          { status: 201 }
+        )
+      }
+      if (/\/api\/v4\/personal_access_tokens\?/.test(url)) {
+        return Response.json([...this.tokens.entries()].map(([id, t]) => ({ id, ...t, active: !t.revoked })))
+      }
+      if (/\/api\/v4\/personal_access_tokens\/\d+$/.test(url) && method === 'DELETE') {
+        if (this.opts.failTokenRevoke) return Response.json({ message: 'error' }, { status: 500 })
+        const id = Number(/personal_access_tokens\/(\d+)$/.exec(url)![1])
+        const token = this.tokens.get(id)
+        if (!token) return Response.json({ message: 'Not Found' }, { status: 404 })
+        token.revoked = true
+        return new Response(null, { status: 204 })
+      }
+      if (/\/api\/v4\/namespaces\/\d+$/.test(url)) {
+        return Response.json({ id: 900, parent_id: null, kind: this.opts.namespaceKind, full_path: 'example-group' })
+      }
+      throw new Error(`fake gitlab: unexpected ${method} ${url}`)
+    }
+  }
+}

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -88,7 +88,7 @@ export class FakeGitlab {
         const payload = json()
         this.webhooks.set(id, {
           url: String(payload.url),
-          token: String(payload.token),
+          token: String(payload.signing_token),
           events: payload as Record<string, boolean>,
           tested: 0
         })
@@ -111,7 +111,7 @@ export class FakeGitlab {
           const payload = json()
           this.webhooks.set(id, {
             url: String(payload.url),
-            token: String(payload.token),
+            token: String(payload.signing_token),
             events: payload as Record<string, boolean>,
             tested: this.webhooks.get(id)?.tested ?? 0
           })
@@ -189,14 +189,24 @@ export class FakeGitlab {
           { status: 201 }
         )
       }
-      if (/\/api\/v4\/personal_access_tokens\?/.test(url)) {
-        return Response.json([...this.tokens.entries()].map(([id, t]) => ({ id, ...t, active: !t.revoked })))
+      if (/\/api\/v4\/groups\/\d+\/service_accounts\/\d+\/personal_access_tokens\?/.test(url)) {
+        const userId = Number(/service_accounts\/(\d+)\//.exec(url)![1])
+        return Response.json(
+          [...this.tokens.entries()]
+            .filter(([, t]) => t.user_id === userId)
+            .map(([id, t]) => ({ id, ...t, active: !t.revoked }))
+        )
       }
-      if (/\/api\/v4\/personal_access_tokens\/\d+$/.test(url) && method === 'DELETE') {
+      if (
+        /\/api\/v4\/groups\/\d+\/service_accounts\/\d+\/personal_access_tokens\/\d+$/.test(url) &&
+        method === 'DELETE'
+      ) {
         if (this.opts.failTokenRevoke) return Response.json({ message: 'error' }, { status: 500 })
+        const userId = Number(/service_accounts\/(\d+)\//.exec(url)![1])
         const id = Number(/personal_access_tokens\/(\d+)$/.exec(url)![1])
         const token = this.tokens.get(id)
-        if (!token) return Response.json({ message: 'Not Found' }, { status: 404 })
+        // Group-scoped authority: only the owning service account's tokens resolve.
+        if (!token || token.user_id !== userId) return Response.json({ message: 'Not Found' }, { status: 404 })
         token.revoked = true
         return new Response(null, { status: 204 })
       }

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -83,6 +83,9 @@ export class FakeGitlab {
         return Response.json({ id: userId, access_level: json().access_level, state: 'active' })
       }
 
+      if (/\/api\/v4\/projects\/\d+\/hooks\?/.test(url) && method === 'GET') {
+        return Response.json([...this.webhooks.entries()].map(([id, hook]) => ({ id, url: hook.url })))
+      }
       if (/\/api\/v4\/projects\/\d+\/hooks$/.test(url) && method === 'POST') {
         const id = ++this.nextId
         const payload = json()

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -284,6 +284,23 @@ describe('GitlabProvisioner (§10.2)', () => {
     expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(0)
   })
 
+  it('disconnect retires BOTH a stale recorded id and a crash-left marked replacement', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    // Recovery sequence: recorded account A was removed externally; a repair
+    // created marker-matching replacement B and crashed before persisting it.
+    const bindingRow = await prisma.gitlabProjectBinding.findUniqueOrThrow({ where: { id: h.binding.id } })
+    const recordedId = Number(bindingRow.serviceAccountUserId)
+    h.fake.serviceAccounts = h.fake.serviceAccounts.filter((account) => account.id !== recordedId)
+    h.fake.serviceAccounts.push({ id: 99999, username: 'agentconnect-p4455667', name: 'AgentConnect (replacement)' })
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({ removed: true })
+    // The union was reconciled: the marked replacement is gone too, and the
+    // claim released only after the marker read came back absent.
+    expect(h.fake.serviceAccounts).toHaveLength(0)
+    expect(h.fake.deletedServiceAccounts).toContain(99999)
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(0)
+  })
+
   it('incomplete cleanup keeps cleanup_pending and RETAINS the claim (§19.4)', async () => {
     const h = await harness({ failTokenRevoke: true })
     await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -173,15 +173,44 @@ describe('GitlabProvisioner (§10.2)', () => {
     expect(h.fake.tokens.size).toBe(0)
   })
 
-  it('the fence methods disagree deterministically with cleanup ordering', async () => {
+  it('the reservation is mutually exclusive with cleanup, in both orders', async () => {
     const h = await harness()
-    // Fence held after marking; lost the moment cleanup begins.
+    // Reservation held: cleanup must wait — no check-to-write window exists.
     expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(true)
+    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(false)
     expect(await h.bindings.claimFenceHeld(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(true)
-    await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT)
+    // Released: cleanup wins, and a late marker/fence check refuses.
+    await h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT)
+    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(true)
     expect(await h.bindings.claimFenceHeld(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(false)
-    // And cleanup-first refuses a late marker too.
     expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(false)
+  })
+
+  it('disconnect during a held reservation is refused, then succeeds after release', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(true)
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      removed: false,
+      reason: 'provisioning_in_progress'
+    })
+    await h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT)
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({ removed: true })
+  })
+
+  it('an unrecorded marked token (crash after create) is revoked before re-minting (§10.2)', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const creds = new PgGitlabProjectCredentialRepo(prisma)
+    const before = (await creds.get(h.binding.id, 'read'))!
+    // Simulate the crash: the provider token exists but our record is gone.
+    await prisma.gitlabProjectCredential.delete({ where: { id: before.id } })
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    // The stray was revoked; a fresh token took its place.
+    expect(h.fake.tokens.get(Number(before.externalTokenId))!.revoked).toBe(true)
+    const after = (await creds.get(h.binding.id, 'read'))!
+    expect(after.externalTokenId).not.toBe(before.externalTokenId)
+    expect(h.fake.tokens.get(Number(after.externalTokenId))!.revoked).toBe(false)
   })
 
   it('incomplete cleanup keeps cleanup_pending and RETAINS the claim (§19.4)', async () => {

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -268,6 +268,22 @@ describe('GitlabProvisioner (§10.2)', () => {
     expect(h.fake.tokens.get(Number(after.externalTokenId))!.revoked).toBe(false)
   })
 
+  it('disconnect reconciles a marked service account even when no local id was recorded', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    // Simulate the crash: the account exists at GitLab, the local facts do not.
+    await prisma.gitlabProjectCredential.deleteMany({})
+    await prisma.gitlabProjectBinding.update({
+      where: { id: h.binding.id },
+      data: { serviceAccountUserId: null, serviceAccountUsername: null, webhookId: null }
+    })
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({ removed: true })
+    // The marker-found account was deleted before the claim released.
+    expect(h.fake.deletedServiceAccounts).toHaveLength(1)
+    expect(h.fake.serviceAccounts).toHaveLength(0)
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(0)
+  })
+
   it('incomplete cleanup keeps cleanup_pending and RETAINS the claim (§19.4)', async () => {
     const h = await harness({ failTokenRevoke: true })
     await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -190,11 +190,11 @@ describe('GitlabProvisioner (§10.2)', () => {
     // Cleanup must wait while the lease is live; a foreign release does nothing.
     expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT, now)).toBe(false)
     await h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'B')
-    expect(await h.bindings.claimFenceHeld(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A', now)).toBe(true)
+    expect(await h.bindings.renewProviderLease(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A', until)).toBe(true)
     // Only the owner's release frees it; then cleanup wins and late checks refuse.
     await h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A')
     expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT, now)).toBe(true)
-    expect(await h.bindings.claimFenceHeld(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A', now)).toBe(false)
+    expect(await h.bindings.renewProviderLease(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A', until)).toBe(false)
     expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A', until, now)).toBe(
       false
     )

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -165,36 +165,91 @@ describe('GitlabProvisioner (§10.2)', () => {
   it('provision loses to a concurrent cleanup: no provider write after the fence flips (§10.2)', async () => {
     const h = await harness()
     // Cleanup entered first: the fence is gone before provision's first write.
-    await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT)
+    await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT, new Date())
     const outcome = await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
-    expect(outcome).toEqual({ state: 'admin_degraded', reason: 'claim_fence_lost' })
+    expect(outcome).toEqual({ state: 'busy', reason: 'provisioning_or_cleanup_in_progress' })
     // Nothing was created against the provider.
     expect(h.fake.serviceAccounts).toHaveLength(0)
     expect(h.fake.tokens.size).toBe(0)
   })
 
-  it('the reservation is mutually exclusive with cleanup, in both orders', async () => {
+  it('the lease is exclusive, run-owned, and mutually exclusive with cleanup', async () => {
     const h = await harness()
-    // Reservation held: cleanup must wait — no check-to-write window exists.
-    expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(true)
-    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(false)
-    expect(await h.bindings.claimFenceHeld(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(true)
-    // Released: cleanup wins, and a late marker/fence check refuses.
-    await h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT)
-    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(true)
-    expect(await h.bindings.claimFenceHeld(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(false)
-    expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(false)
+    const now = new Date()
+    const until = new Date(Date.now() + 600_000)
+    // Acquired by A: a live foreign acquire (B) refuses; same-owner re-acquire holds.
+    expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A', until, now)).toBe(
+      true
+    )
+    expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'B', until, now)).toBe(
+      false
+    )
+    expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A', until, now)).toBe(
+      true
+    )
+    // Cleanup must wait while the lease is live; a foreign release does nothing.
+    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT, now)).toBe(false)
+    await h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'B')
+    expect(await h.bindings.claimFenceHeld(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A', now)).toBe(true)
+    // Only the owner's release frees it; then cleanup wins and late checks refuse.
+    await h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A')
+    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT, now)).toBe(true)
+    expect(await h.bindings.claimFenceHeld(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A', now)).toBe(false)
+    expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'A', until, now)).toBe(
+      false
+    )
   })
 
-  it('disconnect during a held reservation is refused, then succeeds after release', async () => {
+  it('an expired lease is reclaimable by a new run and by cleanup (crash recovery)', async () => {
+    const h = await harness()
+    const now = new Date()
+    const expired = new Date(Date.now() - 1_000)
+    expect(
+      await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'dead', expired, now)
+    ).toBe(true)
+    // The dead run's lease no longer blocks either successor.
+    expect(
+      await h.bindings.markProviderMutationStarted(
+        DEFAULT_ORG_ID,
+        h.binding.id,
+        PROJECT,
+        'next',
+        new Date(Date.now() + 600_000),
+        now
+      )
+    ).toBe(true)
+    await h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'next')
+    expect(
+      await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'dead2', expired, now)
+    ).toBe(true)
+    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT, now)).toBe(true)
+  })
+
+  it('two concurrent provisions: exactly one runs, the other observes busy', async () => {
+    const h = await harness()
+    const [a, b] = await Promise.all([
+      h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id),
+      h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    ])
+    const states = [a.state, b.state].sort()
+    expect(states).toEqual(['busy', 'ready'])
+    // Exactly one set of provider resources was created.
+    expect(h.fake.serviceAccounts).toHaveLength(1)
+    expect(h.fake.tokens.size).toBe(3)
+  })
+
+  it('disconnect during a held lease is refused, then succeeds after release', async () => {
     const h = await harness()
     await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
-    expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(true)
+    const until = new Date(Date.now() + 600_000)
+    expect(
+      await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'live', until, new Date())
+    ).toBe(true)
     expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({
       removed: false,
       reason: 'provisioning_in_progress'
     })
-    await h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT)
+    await h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'live')
     expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({ removed: true })
   })
 

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Provisioning saga + external cleanup (gitlab-com-integration.md §10.2, §7.3,
+ * §11.1, §19.4) against real Postgres and the stateful fake gitlab.com edge:
+ * service-account convergence, purpose-separated PATs with policy validation,
+ * the managed webhook, and claim-preserving disconnect.
+ */
+import { describe, expect, it } from 'vitest'
+import { prisma } from '../setup.db.js'
+import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
+import { FakeGitlab, type FakeGitlabOptions } from '../fakes/gitlab-api.js'
+import { GitlabOauthService } from '../../src/gitlab/oauth.service.js'
+import { GitlabProvisioner, gitlabServiceAccountUsernameForTests } from '../../src/gitlab/provisioner.js'
+import {
+  PgGitlabConnectionRepo,
+  PgGitlabConnectionSecretStore,
+  PgGitlabOauthStateStore,
+  PgGitlabProjectBindingRepo,
+  PgGitlabProjectCredentialRepo,
+  PgGitlabProjectCredentialSecretStore,
+  PgGitlabWebhookSecretStore
+} from '../../src/persistence/repositories/gitlab.repo.js'
+import { PgCodeHostRepositoryRepo } from '../../src/persistence/repositories/code-host-repository.repo.js'
+import { makeSecretCipher } from '../../src/secrets/cipher.js'
+import { systemClock } from '../../src/domain/clock.js'
+import type { GitlabWebhookEvents } from '../../src/gitlab/api.js'
+
+const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
+const PROJECT = 4455667n
+const EVENTS: GitlabWebhookEvents = {
+  push_events: true,
+  issues_events: true,
+  merge_requests_events: true,
+  note_events: false
+}
+
+async function harness(options: FakeGitlabOptions = {}, webhookEvents: GitlabWebhookEvents | null = null) {
+  const fake = new FakeGitlab(options)
+  const connections = new PgGitlabConnectionRepo(prisma)
+  const bindings = new PgGitlabProjectBindingRepo(prisma)
+  const oauth = new GitlabOauthService({
+    cfg: { clientId: 'client-1', clientSecret: 'secret-1' },
+    connections,
+    secrets: new PgGitlabConnectionSecretStore(prisma, cipher),
+    states: new PgGitlabOauthStateStore(prisma),
+    cipher,
+    clock: systemClock,
+    publicCpUrl: 'https://api.example.test',
+    fetchImpl: fake.fetch()
+  })
+  const provisioner = new GitlabProvisioner({
+    oauth,
+    bindings,
+    credentials: new PgGitlabProjectCredentialRepo(prisma),
+    credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, cipher),
+    webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
+    catalog: new PgCodeHostRepositoryRepo(prisma),
+    cipher,
+    clock: systemClock,
+    publicRelayUrl: 'https://relay.example.test',
+    desiredWebhookEvents: async () => webhookEvents,
+    fetchImpl: fake.fetch()
+  })
+  const connection = await connections.upsertOnCallback({
+    orgId: DEFAULT_ORG_ID,
+    userId: DEFAULT_OWNER_ID,
+    gitlabUserId: 4242n,
+    gitlabUsername: 'example-admin',
+    scopes: ['api'],
+    accessExpiresAt: new Date(Date.now() + 3600_000),
+    sealedPair: { accessToken: 'at-1', refreshToken: 'rt-1' }
+  })
+  const binding = await bindings.createWithClaim({
+    orgId: DEFAULT_ORG_ID,
+    projectId: PROJECT,
+    projectPath: 'example-group/example-project',
+    installerConnectionId: connection.id
+  })
+  return { fake, bindings, provisioner, binding }
+}
+
+describe('GitlabProvisioner (§10.2)', () => {
+  it('converges to ready: marked service account, Developer member, three sealed PATs', async () => {
+    const h = await harness()
+    const outcome = await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    expect(outcome).toEqual({ state: 'ready' })
+
+    const binding = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
+    expect(binding.state).toBe('ready')
+    expect(binding.serviceAccountUsername).toBe(gitlabServiceAccountUsernameForTests(PROJECT))
+    expect(binding.credentialEpoch).toBe(h.binding.credentialEpoch + 3n)
+    // Developer, never higher (§7.2).
+    expect(h.fake.members.get(Number(binding.serviceAccountUserId))).toBe(30)
+
+    const creds = new PgGitlabProjectCredentialRepo(prisma)
+    const store = new PgGitlabProjectCredentialSecretStore(prisma, cipher)
+    const rows = await creds.listForBinding(h.binding.id)
+    expect(rows.map((row) => row.purpose).sort()).toEqual(['effect', 'git_write', 'read'])
+    for (const row of rows) {
+      expect(await store.get(DEFAULT_ORG_ID, row.id)).toMatch(/^glpat-/)
+      // §7.3: explicit finite expiry, ~90 days out.
+      const days = (row.providerExpiresAt.getTime() - Date.now()) / 86_400_000
+      expect(days).toBeGreaterThan(88)
+      expect(days).toBeLessThan(91)
+    }
+
+    // Idempotent: a second run reuses everything and mints nothing new.
+    const tokenCount = h.fake.tokens.size
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    expect(h.fake.tokens.size).toBe(tokenCount)
+  })
+
+  it('reports the human prerequisite when service-account creation is forbidden, and repairs later', async () => {
+    const h = await harness({ refuseServiceAccountCreate: true })
+    const outcome = await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    expect(outcome).toEqual({ state: 'admin_degraded', reason: 'service_account_create_forbidden' })
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('admin_degraded')
+
+    h.fake.opts.refuseServiceAccountCreate = false
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+  })
+
+  it('revokes an out-of-policy token and fails closed (§7.3)', async () => {
+    const h = await harness({ patExpiryOverride: null })
+    const outcome = await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    expect(outcome).toEqual({ state: 'admin_degraded', reason: 'out_of_policy_token' })
+    // The returned token was revoked by id, and nothing was sealed.
+    expect([...h.fake.tokens.values()].every((token) => token.revoked)).toBe(true)
+    expect(await prisma.gitlabProjectCredential.count({ where: { bindingId: h.binding.id } })).toBe(0)
+  })
+
+  it('refuses a personal namespace (§5)', async () => {
+    const h = await harness({ namespaceKind: 'user' })
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      state: 'admin_degraded',
+      reason: 'personal_namespace_unsupported'
+    })
+  })
+
+  it('installs, keys, and tests the managed webhook when hooks want events (§11.1)', async () => {
+    const h = await harness({}, EVENTS)
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    const binding = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
+    expect(binding.webhookId).not.toBeNull()
+    const hook = h.fake.webhooks.get(Number(binding.webhookId))!
+    expect(hook.url).toBe('https://relay.example.test/webhooks/gitlab')
+    expect(hook.token.startsWith('whsec_')).toBe(true)
+    expect(hook.events.issues_events).toBe(true)
+    expect(hook.tested).toBe(1)
+    const sealed = await new PgGitlabWebhookSecretStore(prisma, cipher).get(DEFAULT_ORG_ID, h.binding.id)
+    expect(sealed).toBe(hook.token)
+  })
+
+  it('disconnect retires webhook, tokens, and the service account, then releases the claim (§19.4)', async () => {
+    const h = await harness({}, EVENTS)
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const outcome = await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)
+    expect(outcome).toEqual({ removed: true })
+    expect(await prisma.gitlabProjectBinding.count()).toBe(0)
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(0)
+    expect(h.fake.webhooks.size).toBe(0)
+    expect([...h.fake.tokens.values()].every((token) => token.revoked)).toBe(true)
+    expect(h.fake.deletedServiceAccounts).toHaveLength(1)
+  })
+
+  it('incomplete cleanup keeps cleanup_pending and RETAINS the claim (§19.4)', async () => {
+    const h = await harness({ failTokenRevoke: true })
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const outcome = await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)
+    expect(outcome.removed).toBe(false)
+    const binding = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
+    expect(binding.state).toBe('cleanup_pending')
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(1)
+  })
+})

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -162,6 +162,28 @@ describe('GitlabProvisioner (§10.2)', () => {
     expect(h.fake.deletedServiceAccounts).toHaveLength(1)
   })
 
+  it('provision loses to a concurrent cleanup: no provider write after the fence flips (§10.2)', async () => {
+    const h = await harness()
+    // Cleanup entered first: the fence is gone before provision's first write.
+    await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT)
+    const outcome = await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    expect(outcome).toEqual({ state: 'admin_degraded', reason: 'claim_fence_lost' })
+    // Nothing was created against the provider.
+    expect(h.fake.serviceAccounts).toHaveLength(0)
+    expect(h.fake.tokens.size).toBe(0)
+  })
+
+  it('the fence methods disagree deterministically with cleanup ordering', async () => {
+    const h = await harness()
+    // Fence held after marking; lost the moment cleanup begins.
+    expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(true)
+    expect(await h.bindings.claimFenceHeld(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(true)
+    await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT)
+    expect(await h.bindings.claimFenceHeld(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(false)
+    // And cleanup-first refuses a late marker too.
+    expect(await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT)).toBe(false)
+  })
+
   it('incomplete cleanup keeps cleanup_pending and RETAINS the claim (§19.4)', async () => {
     const h = await harness({ failTokenRevoke: true })
     await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)

--- a/packages/control-plane/test/integration/gitlab.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab.route.test.ts
@@ -8,12 +8,18 @@ import { prisma } from '../setup.db.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { GitlabOauthService } from '../../src/gitlab/oauth.service.js'
-import type { FetchLike } from '../../src/gitlab/api.js'
 import {
   PgGitlabConnectionRepo,
   PgGitlabConnectionSecretStore,
-  PgGitlabOauthStateStore
+  PgGitlabOauthStateStore,
+  PgGitlabProjectBindingRepo,
+  PgGitlabProjectCredentialRepo,
+  PgGitlabProjectCredentialSecretStore,
+  PgGitlabWebhookSecretStore
 } from '../../src/persistence/repositories/gitlab.repo.js'
+import { PgCodeHostRepositoryRepo } from '../../src/persistence/repositories/code-host-repository.repo.js'
+import { GitlabProvisioner } from '../../src/gitlab/provisioner.js'
+import { FakeGitlab, type FakeGitlabOptions } from '../fakes/gitlab-api.js'
 import { makeSecretCipher } from '../../src/secrets/cipher.js'
 import { systemClock } from '../../src/domain/clock.js'
 
@@ -22,52 +28,14 @@ const PUBLIC_CP = 'https://api.example.test'
 
 const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
 
-function gitlabFetch(script: { accessLevel?: number } = {}): FetchLike {
-  return async (url) => {
-    if (/\/api\/v4\/projects\/\d+\/members\/all\/\d+$/.test(url)) {
-      return Response.json({ access_level: script.accessLevel ?? 50, state: 'active', expires_at: null })
-    }
-    if (/\/api\/v4\/projects\/\d+$/.test(url)) {
-      const id = Number(/projects\/(\d+)$/.exec(url)![1])
-      return Response.json({
-        id,
-        path_with_namespace: 'example-group/example-project',
-        default_branch: 'main',
-        http_url_to_repo: 'https://gitlab.com/example-group/example-project.git'
-      })
-    }
-    if (url.includes('/api/v4/projects?')) {
-      return Response.json([
-        {
-          id: 4455667,
-          path_with_namespace: 'example-group/example-project',
-          default_branch: 'main',
-          last_activity_at: '2026-08-20T00:00:00.000Z'
-        }
-      ])
-    }
-    if (url.endsWith('/oauth/token')) {
-      return Response.json({
-        access_token: 'at-1',
-        refresh_token: 'rt-1',
-        expires_in: 7200,
-        created_at: Math.floor(Date.now() / 1000),
-        scope: 'api'
-      })
-    }
-    if (url.endsWith('/user')) return Response.json({ id: 4242, username: 'example-admin' })
-    if (url.endsWith('/oauth/revoke')) return Response.json({})
-    throw new Error(`unexpected gitlab call: ${url}`)
-  }
-}
-
 let running: HttpApp | undefined
 afterEach(async () => {
   await running?.close()
   running = undefined
 })
 
-function gitlabApp(script: { accessLevel?: number } = {}): HttpApp {
+function gitlabApp(options: FakeGitlabOptions = {}): HttpApp {
+  const fake = new FakeGitlab(options)
   const oauth = new GitlabOauthService({
     cfg: { clientId: 'client-1', clientSecret: 'secret-1' },
     connections: new PgGitlabConnectionRepo(prisma),
@@ -77,10 +45,23 @@ function gitlabApp(script: { accessLevel?: number } = {}): HttpApp {
     clock: systemClock,
     publicCpUrl: PUBLIC_CP,
     webAppUrl: 'https://console.example.test',
-    fetchImpl: gitlabFetch(script)
+    fetchImpl: fake.fetch()
+  })
+  const provisioner = new GitlabProvisioner({
+    oauth,
+    bindings: new PgGitlabProjectBindingRepo(prisma),
+    credentials: new PgGitlabProjectCredentialRepo(prisma),
+    credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, cipher),
+    webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
+    catalog: new PgCodeHostRepositoryRepo(prisma),
+    cipher,
+    clock: systemClock,
+    publicRelayUrl: 'https://relay.example.test',
+    desiredWebhookEvents: async () => null,
+    fetchImpl: fake.fetch()
   })
   running = buildHttpApp(prisma, { PUBLIC_CP_URL: PUBLIC_CP }, undefined, undefined, {
-    gitlab: { oauth, fetchImpl: gitlabFetch(script) }
+    gitlab: { oauth, provisioner, fetchImpl: fake.fetch() }
   })
   return running
 }
@@ -210,7 +191,8 @@ describe('gitlab oauth routes', () => {
     expect(res.json()).toMatchObject({
       projectId: '4455667',
       projectPath: 'example-group/example-project',
-      state: 'provisioning',
+      state: 'ready',
+      serviceAccountUsername: 'agentconnect-p4455667',
       webhookInstalled: false
     })
     // The claim and the provider-qualified catalog row were acquired atomically.

--- a/packages/control-plane/test/repo/gitlab-binding.repo.test.ts
+++ b/packages/control-plane/test/repo/gitlab-binding.repo.test.ts
@@ -146,6 +146,21 @@ describe('credential + webhook secret stores (§7.3)', () => {
     })
   })
 
+  it('a crash before any external id lands still tombstones once mutation was marked (§10.2)', async () => {
+    // The saga durably flips the claim out of `provisioning` BEFORE its first
+    // provider write; a binding that dies with all-null external ids must then
+    // tombstone, never release.
+    const orgC = await otherOrg()
+    const bound = await bindings().createWithClaim(await withConnection(orgC))
+    await bindings().markProviderMutationStarted(orgC, bound.id, PROJECT)
+    await prisma.org.delete({ where: { id: orgC } })
+    const claim = await prisma.codeHostRepositoryClaim.findUniqueOrThrow({
+      where: { provider_externalId: { provider: 'gitlab', externalId: PROJECT } }
+    })
+    expect(claim.state).toBe('cleanup_pending')
+    expect(claim.bindingRef).toBeNull()
+  })
+
   it('seals the webhook signing key behind its store, org-fenced', async () => {
     const binding = await bindings().createWithClaim(await withConnection(DEFAULT_ORG_ID))
     const store = new PgGitlabWebhookSecretStore(prisma, cipher)

--- a/packages/control-plane/test/repo/gitlab-binding.repo.test.ts
+++ b/packages/control-plane/test/repo/gitlab-binding.repo.test.ts
@@ -152,7 +152,14 @@ describe('credential + webhook secret stores (§7.3)', () => {
     // tombstone, never release.
     const orgC = await otherOrg()
     const bound = await bindings().createWithClaim(await withConnection(orgC))
-    await bindings().markProviderMutationStarted(orgC, bound.id, PROJECT)
+    await bindings().markProviderMutationStarted(
+      orgC,
+      bound.id,
+      PROJECT,
+      'crashed-run',
+      new Date(Date.now() + 600_000),
+      new Date()
+    )
     await prisma.org.delete({ where: { id: orgC } })
     const claim = await prisma.codeHostRepositoryClaim.findUniqueOrThrow({
       where: { provider_externalId: { provider: 'gitlab', externalId: PROJECT } }


### PR DESCRIPTION
The second half of [gitlab-com-integration.md](docs/designs/gitlab-com-integration.md) §22 **M2**, after #1365: the §10.2 provisioning saga, §7.2–§7.4 credential policy, the §11.1 managed webhook, and §19.4 removal. Routes stay console-hidden.

## The saga (§10.2)

`GitlabProvisioner.provision` converges one binding, resumable at every step:

1. refresh the project by numeric id (rename-proof) and the provider-qualified catalog row;
2. walk to the ROOT namespace — service accounts hang off the top-level group, and a personal namespace is a reported human prerequisite (`personal_namespace_unsupported`, §5), never a fallback to a regular user;
3. find-or-create the deterministically marked Project Service Account (`agentconnect-p<projectId>`); an ambiguous create re-lists by the marker before failing, and a 403 (Owner identity verification / Free quota) degrades with `service_account_create_forbidden`;
4. ensure exactly Developer membership — add, or raise a lower direct membership to 30; never higher (§7.2);
5. mint the three purpose-separated PATs (`read` / `git_write` / `effect`, §7.3) with an explicit 90-day `expires_at`.

**§7.3 fail-closed validation**: a returned token seals only after its identity, scopes, active flag, and EXACT requested expiry validate. Anything else is revoked by id on the spot (an id-less response is logged as restricted cleanup debt) and the run degrades with `out_of_policy_token`. Sealing rides #1365's atomic rotation commit, so metadata, sealed value, and the credential-epoch purge fence land together.

## The managed webhook (§11.1)

Installed only when an enabled hook wants events (the union input is wired to "none" until the M3 hook kind exists, so no webhook is created today): fresh `whsec_` signing key sealed **before** the webhook facts are recorded, SSL verification always on, and one provider test delivery on fresh installs. Ownership stays id+marker (§10.3).

## Removal (§19.4)

`disconnect` turns local authority off first (credential-epoch bump), then deletes the managed webhook, revokes the managed PATs, and deletes the service account — 404s count as already-clean. Verified-complete cleanup removes the binding and releases the deployment-global claim in one claim-first transaction (ordering matters: the binding-delete trigger from #1365 otherwise preserves the claim as `cleanup_pending`). Any failure keeps `cleanup_pending` and **retains the claim**.

## Routes & test infrastructure

- `POST /gitlab/projects` now runs the saga to its outcome state; `POST /gitlab/projects/:id/repair` re-runs it; `DELETE /gitlab/projects/:id` drives the cleanup flow.
- `test/fakes/gitlab-api.ts`: a stateful fake gitlab.com edge (projects, membership, service accounts, PATs, webhooks, scriptable failures) now shared by the oauth, binding, and saga suites. The real-GitLab.com contract suite remains §23's later job.

## Tests

Saga suite (7): happy convergence + idempotent re-run, forbidden-create repair, out-of-policy revoke-and-fail, personal namespace, webhook install/key/test, verified disconnect releasing the claim, ambiguous cleanup retaining it. Full gitlab set 29/29; CP unit suite 1844/1844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
