### PR TITLE
feat(control-plane): compile and serve gitlab hooks to feature-advertising relays

### DIFF
--- a/packages/control-plane/prisma/migrations/20260903000000_gitlab_hook_kind/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260903000000_gitlab_hook_kind/migration.sql
@@ -1,0 +1,4 @@
+-- GitLab code-host hooks (gitlab-com-integration.md §8.3): the provider
+-- discriminator joins the enum; common cadence/label/session/review fields are
+-- reused as-is, and GitLab-only state stays on gitlab_project_binding.
+ALTER TYPE "HookKind" ADD VALUE IF NOT EXISTS 'gitlab';

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1655,6 +1655,7 @@ model CronRun {
 enum HookKind {
   webhook // generic inbound webhook (POST /webhooks/in/:token on the relay)
   github // GitHub event subscription (P2)
+  gitlab // GitLab.com event subscription (gitlab-com-integration.md §8.3)
 }
 
 enum HookSessionMode {

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -970,6 +970,16 @@ export function buildContainer(
           // §11.1: the union every enabled gitlab hook on the project wants.
           desiredWebhookEvents: async (orgId, projectId) =>
             unionGitlabWebhookEvents(await repos.hook.listForOrgKind(OrgId(orgId), 'gitlab'), projectId),
+          // Rules embed binding/webhook facts — recompile the project's hooks
+          // after every run that may have changed them (assign or remove).
+          onConverged: (orgId, projectId) => {
+            void repos.hook
+              .listForOrgKind(OrgId(orgId), 'gitlab')
+              .then(async (rows) => {
+                for (const row of rows) if (row.repoId === projectId) await hookService.broadcast(row)
+              })
+              .catch((err) => http.log.warn({ err }, 'gitlab hook rebroadcast failed'))
+          },
           ...(opts.gitlabFetch ? { fetchImpl: opts.gitlabFetch } : {}),
           log: { warn: (obj, msg) => http.log.warn(obj, msg) }
         })

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -27,6 +27,8 @@ import type { FetchLike as GitlabFetchLike } from './gitlab/api.js'
 import { GitlabOauthService } from './gitlab/oauth.service.js'
 import { GitlabProvisioner } from './gitlab/provisioner.js'
 import { GitlabCredentialRotator } from './gitlab/rotator.js'
+import { GitlabMembershipAuthzService } from './gitlab/membership-authz.service.js'
+import { unionGitlabWebhookEvents } from './gitlab/webhook-events.js'
 import { resolveSlackPlatformAppConfig } from './config/slack-platform.js'
 import { resolveFeishuPlatformApps } from './config/feishu-platform.js'
 import type { FetchLike } from './github/api.js'
@@ -147,7 +149,7 @@ import { WebchatMcpGrantTokenCodec } from './registry/webchatMcpGrantToken.js'
 import { OrgInviteLinkCodec } from './registry/orgInviteLink.js'
 import { OrgInviteLinkService } from './registry/orgInviteLinkService.js'
 import { WaitlistService } from './registry/waitlistService.js'
-import { AgentId, DaemonId, HookId, type OrgId } from './domain/ids.js'
+import { AgentId, DaemonId, HookId, OrgId } from './domain/ids.js'
 import { HookService } from './hooks/hook.service.js'
 import { RelayAuthService } from './registry/relayAuthService.js'
 import { DaemonRegistryService } from './registry/registryService.js'
@@ -667,6 +669,10 @@ export function buildContainer(
   // Hook compiler/converger (webhook-triggers-and-github-events.md): CRUD routes
   // broadcast through it, and a (re)registering relay gets the full-set replay.
   // The installation repo feeds the github-kind compile (installationIds gate).
+  // GitLab OAuth app config resolves here (not at the service block below) so the
+  // hook compiler can receive its gitlab-kind sources; absent ⇒ gitlab hooks never compile.
+  const gitlabAppCfg = resolveGitlabAppConfig(config)
+  const gitlabWebhookSecretStore = gitlabAppCfg ? new PgGitlabWebhookSecretStore(prisma, secretCipher) : undefined
   const hookService = new HookService(
     repos.hook,
     repos.hookSecret,
@@ -674,7 +680,10 @@ export function buildContainer(
     relayControl,
     placementResolver,
     githubAppCfg ? repos.githubInstallation : undefined,
-    githubAppCfg?.slug
+    githubAppCfg?.slug,
+    undefined,
+    gitlabAppCfg ? repos.gitlabProjectBinding : undefined,
+    gitlabWebhookSecretStore
   )
 
   // The single fencing site (allocates seq, stamps epoch/launchId on C→D frames).
@@ -924,7 +933,6 @@ export function buildContainer(
   // GitLab.com OAuth administration (opt-in, gitlab-com-integration.md §9):
   // assembled only when GITLAB_CLIENT_ID/SECRET are configured AND the public
   // origin is known (the begin/callback URLs derive from it); absent ⇒ routes 404.
-  const gitlabAppCfg = resolveGitlabAppConfig(config)
   if (gitlabAppCfg && !config.PUBLIC_CP_URL) {
     // A deploy mistake, not a mode: the begin/callback URLs derive from the public origin.
     throw new Error('GITLAB_CLIENT_ID/SECRET are set but PUBLIC_CP_URL is not — set it or unset both')
@@ -954,13 +962,14 @@ export function buildContainer(
           bindings: repos.gitlabProjectBinding,
           credentials: new PgGitlabProjectCredentialRepo(prisma),
           credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, secretCipher),
-          webhookSecrets: new PgGitlabWebhookSecretStore(prisma, secretCipher),
+          webhookSecrets: gitlabWebhookSecretStore!,
           catalog: repos.codeHostRepository,
           cipher: secretCipher,
           clock,
           ...(config.PUBLIC_RELAY_URL ? { publicRelayUrl: config.PUBLIC_RELAY_URL } : {}),
-          // No GitLab hook kind exists yet (M3): no binding wants a webhook.
-          desiredWebhookEvents: async () => null,
+          // §11.1: the union every enabled gitlab hook on the project wants.
+          desiredWebhookEvents: async (orgId, projectId) =>
+            unionGitlabWebhookEvents(await repos.hook.listForOrgKind(OrgId(orgId), 'gitlab'), projectId),
           ...(opts.gitlabFetch ? { fetchImpl: opts.gitlabFetch } : {}),
           log: { warn: (obj, msg) => http.log.warn(obj, msg) }
         })
@@ -972,6 +981,19 @@ export function buildContainer(
         provisioner: gitlab.provisioner,
         clock,
         log: { warn: (obj, msg) => http.log.warn(obj, msg) }
+      })
+    : undefined
+
+  // The GitLab arm of rc/codehost-membership-authz (§12.2): live effective
+  // membership through the binding's read PAT. Absent configuration fails closed.
+  const gitlabMembershipAuthz = gitlab
+    ? new GitlabMembershipAuthzService({
+        hooks: repos.hook,
+        bindings: repos.gitlabProjectBinding,
+        credentials: new PgGitlabProjectCredentialRepo(prisma),
+        credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, secretCipher),
+        clock,
+        ...(opts.gitlabFetch ? { fetchImpl: opts.gitlabFetch } : {})
       })
     : undefined
 
@@ -1639,6 +1661,7 @@ export function buildContainer(
     // Missing GitHub configuration fails closed.
     authorizeGithubComment: async (req) => (githubCommentAuthz ? githubCommentAuthz.allowed(req) : false),
     authorizeGithubRerequest: async (req) => (githubRerequest ? githubRerequest.resolve(req) : { allowed: false }),
+    authorizeCodeHostMembership: async (req) => (gitlabMembershipAuthz ? gitlabMembershipAuthz.allowed(req) : false),
     // A relay just (re)registered — refresh every daemon's roster, (re)assign every
     // HTTP bots' ingress + routes (§5, idempotent), AND replay the compiled hook
     // rules to the fresh connection (its table is a memory copy). All fire-and-forget,

--- a/packages/control-plane/src/gitlab/membership-authz.service.ts
+++ b/packages/control-plane/src/gitlab/membership-authz.service.ts
@@ -1,0 +1,138 @@
+import type { RcCodeHostMembershipAuthz } from '@agentconnect.md/protocol'
+import type { Clock } from '../domain/clock.js'
+import { HookId } from '../domain/ids.js'
+import type {
+  GitlabProjectBindingRepo,
+  GitlabProjectCredentialRepo,
+  GitlabProjectCredentialSecretStore,
+  HookRecord,
+  HookRepo
+} from '../persistence/ports.js'
+import { GITLAB_ACCESS_DEVELOPER, gitlabEffectiveMembership, membershipSatisfies, type FetchLike } from './api.js'
+
+export interface GitlabMembershipAuthzDeps {
+  hooks: Pick<HookRepo, 'getManyUnscoped'>
+  bindings: Pick<GitlabProjectBindingRepo, 'byProject'>
+  credentials: Pick<GitlabProjectCredentialRepo, 'get'>
+  credentialSecrets: Pick<GitlabProjectCredentialSecretStore, 'get'>
+  clock: Clock
+  fetchImpl?: FetchLike
+  /** Test override; production stays below the relay's 5 second correlator. */
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 4_000
+
+/**
+ * The GitLab arm of `rc/codehost-membership-authz` (gitlab-com-integration.md
+ * §12.2): re-resolve every relevant actor's live effective membership with the
+ * binding's read PAT — never webhook-carried relationship labels. Local
+ * metadata mismatches deny before any GitLab request; operational failures and
+ * the bounded overall timeout propagate so the wire handler can distinguish
+ * them from a definitive denial.
+ */
+export class GitlabMembershipAuthzService {
+  constructor(private readonly deps: GitlabMembershipAuthzDeps) {}
+
+  async allowed(req: RcCodeHostMembershipAuthz): Promise<boolean> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error('GitLab membership authorization timed out')), this.timeoutMs)
+    })
+    try {
+      // Promise.race installs handlers on both inputs, so a late failure from
+      // the abandoned lookup cannot become unhandled.
+      return await Promise.race([this.resolve(req), timeout])
+    } finally {
+      if (timer !== undefined) clearTimeout(timer)
+    }
+  }
+
+  private get timeoutMs(): number {
+    return this.deps.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  }
+
+  private async resolve(req: RcCodeHostMembershipAuthz): Promise<boolean> {
+    // Provider fail-per-value (§17.2): this service answers only for gitlab.
+    if (req.provider !== 'gitlab') return false
+    const projectId = BigInt(req.repoExternalId)
+    const fences = [
+      { hookId: req.hookId, configRevision: req.configRevision, dispatchRevision: req.dispatchRevision },
+      ...(req.siblingFences ?? [])
+    ]
+    if (new Set(fences.map((fence) => fence.hookId)).size !== fences.length) return false
+
+    const hooks = await this.deps.hooks.getManyUnscoped(fences.map((fence) => HookId(fence.hookId)))
+    const currentById = new Map<string, HookRecord>(hooks.map((hook) => [hook.id, hook]))
+    const authorized = fences.map((fence) => {
+      const hook = currentById.get(fence.hookId) ?? null
+      return this.matchesAuthorizedHook(hook, projectId, fence) ? hook : null
+    })
+    const authorizedHooks = authorized.filter((hook): hook is HookRecord => hook !== null)
+    if (authorizedHooks.length !== fences.length) return false
+    const first = authorizedHooks[0]
+    if (!first) return false
+    if (authorizedHooks.some((candidate) => candidate.orgId !== first.orgId)) return false
+
+    // The compiled rule's backing binding must still be live and still own the
+    // project; cleanup or a missing service account invalidates the rule.
+    const binding = await this.deps.bindings.byProject(first.orgId, projectId)
+    if (!binding || binding.state === 'cleanup_pending' || binding.state === 'provisioning') return false
+    if (binding.serviceAccountUserId === null) return false
+
+    // Loop/self-summon guard (§12.1 belt): the managed service account holds
+    // Developer, but its own identity must never authorize a trigger.
+    const actorIds = [
+      ...new Set([req.actorExternalId, ...(req.subjectAuthorExternalId ? [req.subjectAuthorExternalId] : [])])
+    ].map((id) => BigInt(id))
+    if (actorIds.some((id) => id === binding.serviceAccountUserId)) return false
+
+    const credential = await this.deps.credentials.get(binding.id, 'read')
+    if (!credential) return false
+    const token = await this.deps.credentialSecrets.get(binding.orgId, credential.id)
+    if (!token) return false
+
+    const nowMs = this.deps.clock.now()
+    const memberships = await Promise.all(
+      actorIds.map((id) => gitlabEffectiveMembership(token, projectId, id, this.deps.fetchImpl))
+    )
+    if (memberships.some((membership) => !membershipSatisfies(membership, GITLAB_ACCESS_DEVELOPER, nowMs))) {
+      return false
+    }
+
+    // The GitLab calls above can take seconds. Re-read immediately before the
+    // allow verdict so a concurrent disable, retarget, or reassignment cannot
+    // authorize any fan-out sibling whose durable snapshot is no longer current.
+    const refreshed = await this.deps.hooks.getManyUnscoped(fences.map((fence) => HookId(fence.hookId)))
+    const refreshedById = new Map<string, HookRecord>(refreshed.map((candidate) => [candidate.id, candidate]))
+    return fences.every((fence, index) => {
+      const expected = authorizedHooks[index]
+      return (
+        expected !== undefined &&
+        this.matchesAuthorizedHook(refreshedById.get(fence.hookId) ?? null, projectId, fence, {
+          orgId: expected.orgId,
+          agentId: expected.agentId
+        })
+      )
+    })
+  }
+
+  private matchesAuthorizedHook(
+    hook: HookRecord | null,
+    projectId: bigint,
+    fence: Pick<RcCodeHostMembershipAuthz, 'hookId' | 'configRevision' | 'dispatchRevision'>,
+    expected?: Pick<HookRecord, 'orgId' | 'agentId'>
+  ): hook is HookRecord {
+    return (
+      hook !== null &&
+      hook.enabled &&
+      hook.kind === 'gitlab' &&
+      hook.agentId !== null &&
+      hook.id === fence.hookId &&
+      hook.repoId === projectId &&
+      hook.configRevision === BigInt(fence.configRevision) &&
+      hook.dispatchRevision === BigInt(fence.dispatchRevision) &&
+      (expected === undefined || (hook.orgId === expected.orgId && hook.agentId === expected.agentId))
+    )
+  }
+}

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -273,31 +273,49 @@ export class GitlabProvisioner {
       await this.mintCredential(orgId, binding, token, root.id, accountUserId, purpose, owner)
     }
 
-    // 6–7. The managed webhook, converged to the union CURRENT at run end and
-    // re-checked until stable: a hook write landing mid-run finds this run's
-    // lease live and its own kick backs off, so THIS run must not finish on a
-    // union it read before that write.
+    // 6–7. The managed webhook, converged against PROVIDER truth to the union
+    // CURRENT at run end. Each pass re-lists the project's webhooks first: a
+    // crash between a provider delete and the local clear, or a provider-side
+    // deletion, leaves a recorded id that no longer exists — local columns are
+    // never proof. Re-checked until stable because a hook write landing mid-run
+    // finds this run's lease live and its own kick backs off.
+    let applied: string | null = null
     for (let pass = 0; pass < 3; pass++) {
-      const fresh = (await this.deps.bindings.get(orgId, binding.id)) ?? binding
       const events = await this.deps.desiredWebhookEvents(orgId, binding.projectId)
-      const installed = fresh.webhookId === null ? null : fresh.desiredEventsHash
-      if ((events ? JSON.stringify(events) : null) === installed) break
+      const want = events ? JSON.stringify(events) : 'none'
+      if (applied === want) break
+      const fresh = (await this.deps.bindings.get(orgId, binding.id)) ?? binding
+      if (!(await this.renewLease(orgId, fresh, owner))) {
+        return { state: 'admin_degraded', reason: 'claim_fence_lost' }
+      }
+      const hooks = await gitlabListWebhooks(token, binding.projectId, this.deps.fetchImpl)
+      const recordedExists = fresh.webhookId !== null && hooks.some((hook) => BigInt(hook.id) === fresh.webhookId)
+      if (!recordedExists && fresh.webhookId !== null) {
+        // The recorded webhook is gone at the provider: forget it so the
+        // converge below re-adopts by exact URL or creates, never PUTs a 404 id.
+        await this.deps.bindings.update(orgId, binding.id, { webhookId: null, desiredEventsHash: null })
+      }
       if (events) {
-        const outcome = await this.convergeWebhook(orgId, fresh, token, events, owner)
+        const effective = recordedExists ? fresh : { ...fresh, webhookId: null }
+        const outcome = await this.convergeWebhook(orgId, effective, token, events, owner)
         if (outcome) return outcome
       } else {
         // §11.1's inverse: no enabled hook wants ingress any more, so the managed
-        // webhook (ours by recorded id) and its sealed key go. Same per-step lease
-        // discipline as the install path; a 404 counts as already-clean.
-        if (!(await this.renewLease(orgId, fresh, owner))) {
-          return { state: 'admin_degraded', reason: 'claim_fence_lost' }
-        }
-        if (fresh.webhookId !== null) {
-          await gitlabDeleteWebhook(token, binding.projectId, fresh.webhookId, this.deps.fetchImpl).catch(swallow404)
+        // webhook — the recorded id AND any crash-left hook at our exact managed
+        // URL — and its sealed key go. A 404 counts as already-clean.
+        const url = this.deps.publicRelayUrl
+          ? `${this.deps.publicRelayUrl.replace(/\/$/, '')}/webhooks/gitlab`
+          : undefined
+        for (const hook of hooks) {
+          const ours =
+            (recordedExists && BigInt(hook.id) === fresh.webhookId) || (url !== undefined && hook.url === url)
+          if (!ours) continue
+          await gitlabDeleteWebhook(token, binding.projectId, BigInt(hook.id), this.deps.fetchImpl).catch(swallow404)
         }
         await this.deps.webhookSecrets.delete(orgId, binding.id)
         await this.deps.bindings.update(orgId, binding.id, { webhookId: null, desiredEventsHash: null })
       }
+      applied = want
     }
     return { state: 'ready' }
   }

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -273,6 +273,16 @@ export class GitlabProvisioner {
     if (events) {
       const outcome = await this.convergeWebhook(orgId, binding, token, events, owner)
       if (outcome) return outcome
+    } else if (binding.webhookId !== null) {
+      // §11.1's inverse: no enabled hook wants ingress any more, so the managed
+      // webhook (ours by recorded id) and its sealed key go. Same per-step lease
+      // discipline as the install path; a 404 counts as already-clean.
+      if (!(await this.renewLease(orgId, binding, owner))) {
+        return { state: 'admin_degraded', reason: 'claim_fence_lost' }
+      }
+      await gitlabDeleteWebhook(token, binding.projectId, binding.webhookId, this.deps.fetchImpl).catch(swallow404)
+      await this.deps.webhookSecrets.delete(orgId, binding.id)
+      await this.deps.bindings.update(orgId, binding.id, { webhookId: null })
     }
     return { state: 'ready' }
   }

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -107,6 +107,10 @@ export interface GitlabProvisionerDeps {
   publicRelayUrl?: string
   /** The enabled-hook event union for a project; null ⇒ no webhook wanted (§10.3). */
   desiredWebhookEvents: (orgId: string, projectId: bigint) => Promise<GitlabWebhookEvents | null>
+  /** Fired after any run that may have changed binding/webhook facts — the
+   *  container rebroadcasts the project's compiled hook rules (assign or
+   *  remove) so relays never keep a rule built from stale facts. */
+  onConverged?: (orgId: string, projectId: bigint) => void
   fetchImpl?: FetchLike
   log?: { warn(obj: object, msg: string): void }
 }
@@ -155,6 +159,7 @@ export class GitlabProvisioner {
       } else if (outcome.state !== 'busy') {
         await this.deps.bindings.update(orgId, bindingId, { state: outcome.state, stateReason: outcome.reason })
       }
+      this.deps.onConverged?.(orgId, binding.projectId)
       return outcome
     } catch (e) {
       const reason =
@@ -268,21 +273,31 @@ export class GitlabProvisioner {
       await this.mintCredential(orgId, binding, token, root.id, accountUserId, purpose, owner)
     }
 
-    // 6–7. The managed webhook, only when an enabled hook wants events (§10.3).
-    const events = await this.deps.desiredWebhookEvents(orgId, binding.projectId)
-    if (events) {
-      const outcome = await this.convergeWebhook(orgId, binding, token, events, owner)
-      if (outcome) return outcome
-    } else if (binding.webhookId !== null) {
-      // §11.1's inverse: no enabled hook wants ingress any more, so the managed
-      // webhook (ours by recorded id) and its sealed key go. Same per-step lease
-      // discipline as the install path; a 404 counts as already-clean.
-      if (!(await this.renewLease(orgId, binding, owner))) {
-        return { state: 'admin_degraded', reason: 'claim_fence_lost' }
+    // 6–7. The managed webhook, converged to the union CURRENT at run end and
+    // re-checked until stable: a hook write landing mid-run finds this run's
+    // lease live and its own kick backs off, so THIS run must not finish on a
+    // union it read before that write.
+    for (let pass = 0; pass < 3; pass++) {
+      const fresh = (await this.deps.bindings.get(orgId, binding.id)) ?? binding
+      const events = await this.deps.desiredWebhookEvents(orgId, binding.projectId)
+      const installed = fresh.webhookId === null ? null : fresh.desiredEventsHash
+      if ((events ? JSON.stringify(events) : null) === installed) break
+      if (events) {
+        const outcome = await this.convergeWebhook(orgId, fresh, token, events, owner)
+        if (outcome) return outcome
+      } else {
+        // §11.1's inverse: no enabled hook wants ingress any more, so the managed
+        // webhook (ours by recorded id) and its sealed key go. Same per-step lease
+        // discipline as the install path; a 404 counts as already-clean.
+        if (!(await this.renewLease(orgId, fresh, owner))) {
+          return { state: 'admin_degraded', reason: 'claim_fence_lost' }
+        }
+        if (fresh.webhookId !== null) {
+          await gitlabDeleteWebhook(token, binding.projectId, fresh.webhookId, this.deps.fetchImpl).catch(swallow404)
+        }
+        await this.deps.webhookSecrets.delete(orgId, binding.id)
+        await this.deps.bindings.update(orgId, binding.id, { webhookId: null, desiredEventsHash: null })
       }
-      await gitlabDeleteWebhook(token, binding.projectId, binding.webhookId, this.deps.fetchImpl).catch(swallow404)
-      await this.deps.webhookSecrets.delete(orgId, binding.id)
-      await this.deps.bindings.update(orgId, binding.id, { webhookId: null })
     }
     return { state: 'ready' }
   }
@@ -388,10 +403,16 @@ export class GitlabProvisioner {
       return { state: 'admin_degraded', reason: 'claim_fence_lost' }
     }
     const url = `${this.deps.publicRelayUrl.replace(/\/$/, '')}/webhooks/gitlab`
-    const signingToken = `whsec_${randomBytes(32).toString('base64')}`
-    // Seal the signing intent BEFORE any provider call: a crash after the
-    // create still leaves us the key the created hook carries.
-    await this.deps.webhookSecrets.put(orgId, binding.id, signingToken)
+    // The signing key is STABLE across converges — compiled rules carry it
+    // inline, so a fresh key per run would strand every live rule until a
+    // rebroadcast. Generate only when absent, sealing the intent BEFORE any
+    // provider call: a crash after the create still leaves us the created
+    // hook's key.
+    let signingToken = await this.deps.webhookSecrets.get(orgId, binding.id)
+    if (!signingToken) {
+      signingToken = `whsec_${randomBytes(32).toString('base64')}`
+      await this.deps.webhookSecrets.put(orgId, binding.id, signingToken)
+    }
     let fresh = binding.webhookId === null
     let webhookId: bigint
     if (fresh) {
@@ -557,6 +578,9 @@ export class GitlabProvisioner {
       return { removed: false, reason: 'provisioning_in_progress' }
     }
     await this.deps.bindings.bumpCredentialEpoch(orgId, bindingId)
+    // The binding just left the servable states — pull the project's compiled
+    // rules off the relay pool now, not when cleanup eventually completes.
+    this.deps.onConverged?.(orgId, binding.projectId)
     if (!binding.installerConnectionId) {
       await this.deps.bindings.update(orgId, bindingId, {
         state: 'cleanup_pending',

--- a/packages/control-plane/src/gitlab/webhook-events.test.ts
+++ b/packages/control-plane/src/gitlab/webhook-events.test.ts
@@ -1,0 +1,49 @@
+/** §11.1 desired-events union: the managed webhook subscribes to exactly what
+ *  the enabled gitlab hooks on the project need, comments over-subscribed. */
+import { describe, expect, it } from 'vitest'
+import { unionGitlabWebhookEvents } from './webhook-events.js'
+
+const PROJECT = 4455667n
+const hook = (over: Partial<Parameters<typeof unionGitlabWebhookEvents>[0][number]> = {}) => ({
+  enabled: true,
+  kind: 'gitlab' as const,
+  repoId: PROJECT,
+  events: ['issues:*'],
+  commentFamilies: [],
+  ...over
+})
+
+describe('unionGitlabWebhookEvents', () => {
+  it('returns null when no enabled gitlab hook targets the project', () => {
+    expect(unionGitlabWebhookEvents([], PROJECT)).toBeNull()
+    expect(unionGitlabWebhookEvents([hook({ enabled: false })], PROJECT)).toBeNull()
+    expect(unionGitlabWebhookEvents([hook({ kind: 'github' })], PROJECT)).toBeNull()
+    expect(unionGitlabWebhookEvents([hook({ repoId: 1n })], PROJECT)).toBeNull()
+  })
+
+  it('unions event families across hooks', () => {
+    const events = unionGitlabWebhookEvents(
+      [hook(), hook({ events: ['merge_request:opened'] }), hook({ events: ['push:*'] })],
+      PROJECT
+    )
+    expect(events).toEqual({
+      push_events: true,
+      issues_events: true,
+      merge_requests_events: true,
+      note_events: true
+    })
+  })
+
+  it('thread-bearing triggers and comment families subscribe notes; a push-only hook does not', () => {
+    expect(unionGitlabWebhookEvents([hook({ events: ['push:*'] })], PROJECT)?.note_events).toBe(false)
+    expect(
+      unionGitlabWebhookEvents([hook({ events: ['push:*'], commentFamilies: ['merge_request'] })], PROJECT)?.note_events
+    ).toBe(true)
+    expect(unionGitlabWebhookEvents([hook({ events: ['merge_request:*'] })], PROJECT)).toMatchObject({
+      merge_requests_events: true,
+      note_events: true,
+      issues_events: false,
+      push_events: false
+    })
+  })
+})

--- a/packages/control-plane/src/gitlab/webhook-events.ts
+++ b/packages/control-plane/src/gitlab/webhook-events.ts
@@ -1,0 +1,35 @@
+import type { HookRecord } from '../persistence/ports.js'
+import type { GitlabWebhookEvents } from './api.js'
+
+/**
+ * The §11.1 desired-events input: the union every enabled gitlab hook on one
+ * project wants from the managed webhook. Null means no hook wants ingress, so
+ * the saga removes (or never installs) the webhook. Comment (`note`) events are
+ * over-subscribed deliberately: threads opened by issue/MR triggers continue
+ * through comments, so under-subscribing them would strand every per-thread
+ * session; the relay filters what a rule did not ask for.
+ */
+export function unionGitlabWebhookEvents(
+  hooks: Pick<HookRecord, 'enabled' | 'kind' | 'repoId' | 'events' | 'commentFamilies'>[],
+  projectId: bigint
+): GitlabWebhookEvents | null {
+  const relevant = hooks.filter((hook) => hook.enabled && hook.kind === 'gitlab' && hook.repoId === projectId)
+  if (relevant.length === 0) return null
+  const events: GitlabWebhookEvents = {
+    push_events: false,
+    issues_events: false,
+    merge_requests_events: false,
+    note_events: false
+  }
+  for (const hook of relevant) {
+    for (const pattern of hook.events) {
+      if (pattern.startsWith('issues:')) events.issues_events = true
+      else if (pattern.startsWith('merge_request:')) events.merge_requests_events = true
+      else if (pattern.startsWith('push:')) events.push_events = true
+    }
+    if (events.issues_events || events.merge_requests_events || hook.commentFamilies.length > 0) {
+      events.note_events = true
+    }
+  }
+  return events
+}

--- a/packages/control-plane/src/hooks/hook.service.ts
+++ b/packages/control-plane/src/hooks/hook.service.ts
@@ -16,11 +16,13 @@
  * holds is always dispatchable. Compiled rules carry the hook's hmacSecret:
  * NEVER log.
  */
-import type { RcHookAssign } from '@agentconnect.md/protocol'
+import { GITLAB_COM_V1_FEATURE, type RcHookAssign } from '@agentconnect.md/protocol'
 import type { AgentId, OrgId } from '../domain/ids.js'
 import type {
   AgentRecord,
   GithubInstallationRepo,
+  GitlabProjectBindingRepo,
+  GitlabWebhookSecretStore,
   HookRecord,
   HookRepo,
   HookSecretStore
@@ -55,7 +57,12 @@ export class HookService {
      *  broadcast mention handle (P3). The agent record supplies the targeted
      *  handle. */
     private readonly appSlug?: string,
-    private readonly log?: HookServiceLog
+    private readonly log?: HookServiceLog,
+    /** gitlab-kind compile sources (gitlab-com-integration.md §11.3): the org's
+     *  managed bindings and the sealed signing keys. Absent ⇒ gitlab hooks never
+     *  compile (deployment without the GitLab OAuth app). */
+    private readonly gitlabBindings?: Pick<GitlabProjectBindingRepo, 'byProject'>,
+    private readonly gitlabWebhookSecrets?: GitlabWebhookSecretStore
   ) {}
 
   /**
@@ -120,6 +127,43 @@ export class HookService {
         }
       }
     }
+    if (hook.kind === 'gitlab') {
+      // gitlab (§11.3): the rule carries the binding's runtime identity and the
+      // inline signing token. A binding without a working ingress (no webhook,
+      // no signing key, no service account, or entering cleanup) must leave the
+      // pool — a rule the relay holds is always verifiable and dispatchable.
+      if (hook.repoId === null || !this.gitlabBindings || !this.gitlabWebhookSecrets) return null
+      const binding = await this.gitlabBindings.byProject(hook.orgId, hook.repoId)
+      if (!binding || binding.state === 'cleanup_pending') return null
+      if (binding.serviceAccountUserId === null || !binding.serviceAccountUsername || binding.webhookId === null) {
+        return null
+      }
+      const signingToken = await this.gitlabWebhookSecrets.get(hook.orgId, binding.id)
+      if (!signingToken) return null
+      return {
+        ...base,
+        kind: 'gitlab',
+        gitlab: {
+          projectId: hook.repoId.toString(),
+          projectPath: binding.projectPath,
+          sessionKeyPrefix: hook.githubSessionKey ?? `gitlab:${hook.repoId}`,
+          events: hook.events,
+          ...(hook.commentFamilies.length > 0
+            ? {
+                commentFamilies: hook.commentFamilies.filter(
+                  (family): family is 'issues' | 'merge_request' => family !== 'pull_request'
+                )
+              }
+            : {}),
+          labelFilter: hook.labelFilter,
+          mentionOnly: hook.mentionOnly,
+          agentName: agent.name,
+          serviceAccountUserId: binding.serviceAccountUserId.toString(),
+          serviceAccountUsername: binding.serviceAccountUsername,
+          signingToken
+        }
+      }
+    }
     // github (P2): the rule carries the org's VALID installation ids — the
     // relay's runtime attribution gate. Suspended/revoked installations are
     // excluded; an empty set means no event could ever prove attribution, so
@@ -137,7 +181,14 @@ export class HookService {
         events: hook.events,
         // Empty is the published API's legacy repo-wide comment behavior; omit
         // the optional wire field so older persisted rows keep that meaning.
-        ...(hook.commentFamilies.length > 0 ? { commentFamilies: hook.commentFamilies } : {}),
+        // The filter is a type proof: a github row only ever stores its own vocabulary.
+        ...(hook.commentFamilies.length > 0
+          ? {
+              commentFamilies: hook.commentFamilies.filter(
+                (family): family is 'issues' | 'pull_request' => family !== 'merge_request'
+              )
+            }
+          : {}),
         labelFilter: hook.labelFilter,
         // P3: the App slug broadcasts to every matching rule; the immutable
         // agent slug targets this rule. Thread actors also pass live maintainer auth.
@@ -190,6 +241,8 @@ export class HookService {
     for (const hook of await this.hooks.listEnabled()) {
       try {
         const rule = await this.compile(hook)
+        // The §17.3 negotiation gate, per channel (mirrors RelayControlSender).
+        if (rule?.kind === 'gitlab' && !ch.features?.includes(GITLAB_COM_V1_FEATURE)) continue
         if (rule) ch.send('rc/hook-assign', rule)
       } catch (err) {
         this.log?.warn({ hookId: hook.id, err }, 'hook replay: compile/send failed — skipped')

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -773,7 +773,7 @@ export const AgentDto = z.object({
   // Distinct kinds of ENABLED inbound triggers (hooks) on this agent — the list
   // view's integrations cell renders a mark per kind (github repo subscriptions,
   // generic webhooks) without an org-wide hook list existing anywhere.
-  hookKinds: z.array(z.enum(['webhook', 'github']))
+  hookKinds: z.array(z.enum(['webhook', 'github', 'gitlab']))
 })
 export const AgentListDto = z.array(AgentDto)
 
@@ -2362,7 +2362,29 @@ export const CreateGithubHookBody = HookBodyBase.extend({
   gateMode: HookGateModeEnum.default('informational')
 })
 
-export const CreateHookBody = z.discriminatedUnion('kind', [CreateWebhookHookBody, CreateGithubHookBody])
+/** GitLab family:action patterns (§12): the three subscribed families only. */
+export const GitlabHookEventPattern = /^(issues|merge_request|push):([a-z_]+|\*)$/
+export const GitlabCommentFamily = z.enum(['issues', 'merge_request'])
+
+export const CreateGitlabHookBody = HookBodyBase.extend({
+  kind: z.literal('gitlab'),
+  // perThread by definition, like github (one issue/MR continues one session).
+  // The project must already be a managed binding in this organization; the
+  // numeric id is validated against it server-side (never trusted for facts).
+  projectId: z.string().regex(/^[1-9]\d*$/),
+  events: z.array(z.string().regex(GitlabHookEventPattern)).min(1).max(20),
+  // Note events for the selected subject families (§12); empty = no comments.
+  commentFamilies: z.array(GitlabCommentFamily).max(2).default([]),
+  labelFilter: z.array(z.string().trim().min(1).max(100)).max(20).default([]),
+  mentionOnly: z.boolean().default(false)
+  // No review/reporting knobs yet: the M6 review slice adds them; rows default off.
+})
+
+export const CreateHookBody = z.discriminatedUnion('kind', [
+  CreateWebhookHookBody,
+  CreateGithubHookBody,
+  CreateGitlabHookBody
+])
 
 // PUT: `kind` discriminates the body but STAYS OPTIONAL for webhook updates —
 // the P1-published contract had no `kind` on PUT, and a versioned surface must
@@ -2374,6 +2396,11 @@ export const CreateHookBody = z.discriminatedUnion('kind', [CreateWebhookHookBod
 // secret rotation is a delete/re-create. The github repo IS re-targetable
 // (repoId re-resolved).
 export const UpdateHookBody = z.union([
+  CreateGitlabHookBody.extend({
+    enabled: z.boolean().optional(),
+    commentFamilies: z.array(GitlabCommentFamily).max(2).optional(),
+    mentionOnly: z.boolean().optional()
+  }),
   // mentionOnly OPTIONAL on update (unlike create's default-false): a pre-P3
   // client echoing a hook back must not silently downgrade mention mode — the
   // route falls back to the stored value when the key is absent.
@@ -2399,7 +2426,7 @@ export const HookDto = z.object({
   id: z.string(),
   orgId: z.string(),
   agentId: z.string().nullable(), // null ⇒ legacy inert row
-  kind: z.enum(['webhook', 'github']),
+  kind: z.enum(['webhook', 'github', 'gitlab']),
   name: z.string(),
   sessionMode: HookSessionModeEnum,
   enabled: z.boolean(),
@@ -2414,7 +2441,8 @@ export const HookDto = z.object({
   repoId: z.string().nullable(), // rename-proof GitHub numeric id; null for webhook kind
   repoFullName: z.string().nullable(),
   events: z.array(z.string()),
-  commentFamilies: GithubCommentFamilies,
+  // The stored union across code hosts; each row carries its own host's subset.
+  commentFamilies: z.array(z.enum(['issues', 'pull_request', 'merge_request'])),
   labelFilter: z.array(z.string()),
   mentionOnly: z.boolean(),
   configRevision: z.string(),
@@ -2492,7 +2520,7 @@ export const SessionDto = z.object({
   triggeredBy: z.string().nullable(),
   // Stable source kind for hook-triggered sessions. null for non-hook or a
   // deleted/legacy hook whose definition can no longer be resolved.
-  hookKind: z.enum(['webhook', 'github']).nullable(),
+  hookKind: z.enum(['webhook', 'github', 'gitlab']).nullable(),
   // Daemon-resolved display names (pure passthrough — the raw ids above stay
   // canonical; null when the daemon hasn't resolved them).
   channelName: z.string().nullable(),
@@ -2544,7 +2572,7 @@ export const SessionFacetsDto = z.object({
       value: z.string(),
       integration: z.string(),
       name: z.string().nullable(),
-      hookKind: z.enum(['webhook', 'github']).nullable(),
+      hookKind: z.enum(['webhook', 'github', 'gitlab']).nullable(),
       githubRepoId: z.string().nullable()
     })
   )
@@ -2628,7 +2656,7 @@ export const SessionDetailDto = z.object({
   lastActivityAt: z.string(),
   usage: SessionUsageDto.nullable(),
   triggeredBy: z.string().nullable(),
-  hookKind: z.enum(['webhook', 'github']).nullable(),
+  hookKind: z.enum(['webhook', 'github', 'gitlab']).nullable(),
   channelName: z.string().nullable(),
   triggeredByName: z.string().nullable(),
   threadUrl: z.string().nullable(),

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -41,8 +41,7 @@ import {
   GitlabProjectPageDto,
   IdParam
 } from '../dto/index.js'
-import type { GitlabProjectBindingRecord } from '../../persistence/ports.js'
-import type { GitlabConnectionRecord } from '../../persistence/ports.js'
+import type { GitlabConnectionRecord, GitlabProjectBindingRecord } from '../../persistence/ports.js'
 
 function toDto(r: GitlabConnectionRecord) {
   return {

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -113,6 +113,32 @@ export function hookRoutes(deps: HttpDeps) {
       void deps.hooks.broadcast(hook).catch((err) => app.log.warn({ hookId: hook.id, err }, 'hook broadcast failed'))
     }
 
+    // gitlab-kind writes also (re)converge the managed project webhook (§11.1):
+    // the saga recomputes the desired event union and updates/installs/removes
+    // it. Fire-and-forget for the same reason as the relay push above.
+    const convergeGitlabWebhook = (orgId: OrgId, hook: HookRecord): void => {
+      const gitlab = deps.gitlab
+      const projectId = hook.repoId
+      if (!gitlab || projectId === null) return
+      void deps.repos.gitlabProjectBinding
+        .byProject(orgId, projectId)
+        .then(async (binding) => {
+          if (!binding) return
+          // Back-to-back writes contend on the saga's run lease: a `busy` loser
+          // would silently drop this union change, so retry briefly.
+          let outcome = await gitlab.provisioner.provision(orgId, binding.id)
+          for (let attempt = 0; outcome.state === 'busy' && attempt < 5; attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 1_000))
+            outcome = await gitlab.provisioner.provision(orgId, binding.id)
+          }
+          // The compiled rule embeds the webhook + signing facts the saga just
+          // converged — re-push it (deleted hooks read null and stay removed).
+          const fresh = await deps.repos.hook.get(orgId, hook.id)
+          if (fresh) converge(fresh)
+        })
+        .catch((err) => app.log.warn({ projectId: projectId.toString(), err }, 'gitlab webhook converge failed'))
+    }
+
     // The repository repeats the workspace-access invariant under its shared
     // transaction fence. Surface a concurrent loser as the same 409 as the
     // route's fast preflight instead of leaking it as a generic 500.
@@ -353,40 +379,73 @@ export function hookRoutes(deps: HttpDeps) {
                 urlToken: `whk_${randomBytes(16).toString('hex')}`,
                 hmacSecret: req.body.hmac ? `whsec_${randomBytes(32).toString('hex')}` : null
               }
-            : await (async () => {
-                const repo = await resolveGithubRepo(orgId, (req.body as { repoFullName: string }).repoFullName)
-                if (!repo.ok) return repo
-                // One subscription per (agent, repo): edit the existing hook's
-                // events instead of stacking duplicates that would double-fire.
-                const dup = (await deps.repos.hook.listForAgent(agent.id)).some(
-                  (h) => h.kind === 'github' && h.repoId === repo.repoId
-                )
-                if (dup) {
-                  return {
-                    ok: false as const,
-                    status: 409 as const,
-                    message: `this agent already watches ${repo.repoFullName}`
+            : req.body.kind === 'gitlab'
+              ? await (async () => {
+                  // The project must already be a managed binding (§8.3): a hook
+                  // never creates a grant or a binding, and the numeric id is
+                  // validated against the org's own row — never trusted for facts.
+                  const projectId = BigInt((req.body as { projectId: string }).projectId)
+                  const binding = deps.gitlab ? await deps.repos.gitlabProjectBinding.byProject(orgId, projectId) : null
+                  if (!binding || binding.state === 'cleanup_pending') {
+                    return {
+                      ok: false as const,
+                      status: 409 as const,
+                      message: 'the project is not a managed GitLab binding in this organization'
+                    }
                   }
-                }
-                const authz = await watchRepoAuthorized(agent, repo.repoId, repo.repoFullName)
-                if (!authz.ok) return authz
-                const configError = await validateGithubEffects(agent, repo.repoId, repo.repoFullName, {
-                  reviewPolicy: req.body.kind === 'github' ? req.body.reviewPolicy : 'off',
-                  reportingMode: req.body.kind === 'github' ? req.body.reportingMode : 'off',
-                  gateMode: req.body.kind === 'github' ? req.body.gateMode : 'informational'
-                })
-                if (configError) {
-                  return { ok: false as const, ...configError }
-                }
-                return {
-                  // github is perThread by definition — the same issue/PR
-                  // continues one session (design decision 7).
-                  sessionMode: 'perThread' as const,
-                  repoId: repo.repoId,
-                  repoFullName: repo.repoFullName,
-                  hmacSecret: null
-                }
-              })()
+                  const dup = (await deps.repos.hook.listForAgent(agent.id)).some(
+                    (h) => h.kind === 'gitlab' && h.repoId === projectId
+                  )
+                  if (dup) {
+                    return {
+                      ok: false as const,
+                      status: 409 as const,
+                      message: `this agent already watches ${binding.projectPath}`
+                    }
+                  }
+                  return {
+                    // gitlab is perThread by definition, like github (§12.3).
+                    sessionMode: 'perThread' as const,
+                    repoId: projectId,
+                    repoFullName: binding.projectPath,
+                    githubSessionKey: `gitlab:${projectId}`,
+                    hmacSecret: null
+                  }
+                })()
+              : await (async () => {
+                  const repo = await resolveGithubRepo(orgId, (req.body as { repoFullName: string }).repoFullName)
+                  if (!repo.ok) return repo
+                  // One subscription per (agent, repo): edit the existing hook's
+                  // events instead of stacking duplicates that would double-fire.
+                  const dup = (await deps.repos.hook.listForAgent(agent.id)).some(
+                    (h) => h.kind === 'github' && h.repoId === repo.repoId
+                  )
+                  if (dup) {
+                    return {
+                      ok: false as const,
+                      status: 409 as const,
+                      message: `this agent already watches ${repo.repoFullName}`
+                    }
+                  }
+                  const authz = await watchRepoAuthorized(agent, repo.repoId, repo.repoFullName)
+                  if (!authz.ok) return authz
+                  const configError = await validateGithubEffects(agent, repo.repoId, repo.repoFullName, {
+                    reviewPolicy: req.body.kind === 'github' ? req.body.reviewPolicy : 'off',
+                    reportingMode: req.body.kind === 'github' ? req.body.reportingMode : 'off',
+                    gateMode: req.body.kind === 'github' ? req.body.gateMode : 'informational'
+                  })
+                  if (configError) {
+                    return { ok: false as const, ...configError }
+                  }
+                  return {
+                    // github is perThread by definition — the same issue/PR
+                    // continues one session (design decision 7).
+                    sessionMode: 'perThread' as const,
+                    repoId: repo.repoId,
+                    repoFullName: repo.repoFullName,
+                    hmacSecret: null
+                  }
+                })()
         if ('status' in kindFields) {
           const { status, message } = kindFields
           return reply.code(status).send({ error: ERROR_NAMES[status], statusCode: status, message })
@@ -409,6 +468,15 @@ export function hookRoutes(deps: HttpDeps) {
                 reviewPolicy: req.body.reviewPolicy,
                 reportingMode: req.body.reportingMode,
                 gateMode: req.body.gateMode
+              }
+            : {}),
+          ...(req.body.kind === 'gitlab'
+            ? {
+                events: req.body.events,
+                commentFamilies: req.body.commentFamilies,
+                labelFilter: req.body.labelFilter,
+                mentionOnly: req.body.mentionOnly
+                // Review/reporting stay at their off defaults until the M6 slice.
               }
             : {}),
           targetPlatform: target.targetPlatform,
@@ -441,6 +509,7 @@ export function hookRoutes(deps: HttpDeps) {
         // Re-read so hmacConfigured reflects the secret written above.
         const fresh = (await deps.repos.hook.get(orgId, hookId)) ?? hook
         converge(fresh)
+        if (fresh.kind === 'gitlab') convergeGitlabWebhook(orgId, fresh)
         return { ...toDto(fresh, deps.config.PUBLIC_RELAY_URL), hmacSecret }
       }
     )
@@ -642,6 +711,35 @@ export function hookRoutes(deps: HttpDeps) {
             mentionOnly: req.body.mentionOnly ?? existing.mentionOnly,
             ...effectConfig
           }
+        } else if (req.body.kind === 'gitlab') {
+          const projectId = BigInt(req.body.projectId)
+          const binding = deps.gitlab ? await deps.repos.gitlabProjectBinding.byProject(orgId, projectId) : null
+          if (!binding || binding.state === 'cleanup_pending') {
+            return reply.code(409).send({
+              error: ERROR_NAMES[409],
+              statusCode: 409,
+              message: 'the project is not a managed GitLab binding in this organization'
+            })
+          }
+          const dup = (await deps.repos.hook.listForAgent(agent.id)).some(
+            (h) => h.id !== existing.id && h.kind === 'gitlab' && h.repoId === projectId
+          )
+          if (dup) {
+            return reply.code(409).send({
+              error: ERROR_NAMES[409],
+              statusCode: 409,
+              message: `this agent already watches ${binding.projectPath}`
+            })
+          }
+          kindFields = {
+            sessionMode: 'perThread',
+            repoId: projectId,
+            repoFullName: binding.projectPath,
+            events: req.body.events,
+            commentFamilies: req.body.commentFamilies ?? existing.commentFamilies,
+            labelFilter: req.body.labelFilter,
+            mentionOnly: req.body.mentionOnly ?? existing.mentionOnly
+          }
         } else {
           kindFields = { sessionMode: req.body.sessionMode }
         }
@@ -677,6 +775,7 @@ export function hookRoutes(deps: HttpDeps) {
           })
           .catch(() => {})
         converge(hook)
+        if (hook.kind === 'gitlab') convergeGitlabWebhook(orgOf(req), hook)
         return toDto(hook, deps.config.PUBLIC_RELAY_URL)
       }
     )
@@ -714,6 +813,7 @@ export function hookRoutes(deps: HttpDeps) {
           })
           .catch(() => {})
         deps.hooks.remove(existing.id)
+        if (existing.kind === 'gitlab') convergeGitlabWebhook(orgOf(req), existing)
         return reply.code(204).send(null)
       }
     )

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -115,26 +115,26 @@ export function hookRoutes(deps: HttpDeps) {
 
     // gitlab-kind writes also (re)converge the managed project webhook (§11.1):
     // the saga recomputes the desired event union and updates/installs/removes
-    // it. Fire-and-forget for the same reason as the relay push above.
-    const convergeGitlabWebhook = (orgId: OrgId, hook: HookRecord): void => {
+    // it, then its onConverged rebroadcasts the project's compiled rules.
+    // `busy` means a peer run holds the §10.2 lease — that run re-checks the
+    // union at ITS end, but only for writes that landed before its final read,
+    // so this writer must outwait the lease rather than drop the change.
+    const convergeGitlabWebhook = (orgId: OrgId, projectId: bigint | null): void => {
       const gitlab = deps.gitlab
-      const projectId = hook.repoId
       if (!gitlab || projectId === null) return
       void deps.repos.gitlabProjectBinding
         .byProject(orgId, projectId)
         .then(async (binding) => {
           if (!binding) return
-          // Back-to-back writes contend on the saga's run lease: a `busy` loser
-          // would silently drop this union change, so retry briefly.
           let outcome = await gitlab.provisioner.provision(orgId, binding.id)
-          for (let attempt = 0; outcome.state === 'busy' && attempt < 5; attempt++) {
-            await new Promise((resolve) => setTimeout(resolve, 1_000))
+          // 8s × 90 outlasts a full 10-minute peer lease plus slack.
+          for (let attempt = 0; outcome.state === 'busy' && attempt < 90; attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 8_000))
             outcome = await gitlab.provisioner.provision(orgId, binding.id)
           }
-          // The compiled rule embeds the webhook + signing facts the saga just
-          // converged — re-push it (deleted hooks read null and stay removed).
-          const fresh = await deps.repos.hook.get(orgId, hook.id)
-          if (fresh) converge(fresh)
+          if (outcome.state === 'busy') {
+            app.log.warn({ projectId: projectId.toString() }, 'gitlab webhook converge still busy — gave up')
+          }
         })
         .catch((err) => app.log.warn({ projectId: projectId.toString(), err }, 'gitlab webhook converge failed'))
     }
@@ -509,7 +509,7 @@ export function hookRoutes(deps: HttpDeps) {
         // Re-read so hmacConfigured reflects the secret written above.
         const fresh = (await deps.repos.hook.get(orgId, hookId)) ?? hook
         converge(fresh)
-        if (fresh.kind === 'gitlab') convergeGitlabWebhook(orgId, fresh)
+        if (fresh.kind === 'gitlab') convergeGitlabWebhook(orgId, fresh.repoId)
         return { ...toDto(fresh, deps.config.PUBLIC_RELAY_URL), hmacSecret }
       }
     )
@@ -775,7 +775,14 @@ export function hookRoutes(deps: HttpDeps) {
           })
           .catch(() => {})
         converge(hook)
-        if (hook.kind === 'gitlab') convergeGitlabWebhook(orgOf(req), hook)
+        if (hook.kind === 'gitlab') {
+          convergeGitlabWebhook(orgOf(req), hook.repoId)
+          // A retarget moved this hook off `existing.repoId`: the source
+          // binding's union shrank too, so converge BOTH distinct projects.
+          if (existing.repoId !== null && existing.repoId !== hook.repoId) {
+            convergeGitlabWebhook(orgOf(req), existing.repoId)
+          }
+        }
         return toDto(hook, deps.config.PUBLIC_RELAY_URL)
       }
     )
@@ -813,7 +820,7 @@ export function hookRoutes(deps: HttpDeps) {
           })
           .catch(() => {})
         deps.hooks.remove(existing.id)
-        if (existing.kind === 'gitlab') convergeGitlabWebhook(orgOf(req), existing)
+        if (existing.kind === 'gitlab') convergeGitlabWebhook(orgOf(req), existing.repoId)
         return reply.code(204).send(null)
       }
     )

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -127,9 +127,11 @@ export function hookRoutes(deps: HttpDeps) {
         .then(async (binding) => {
           if (!binding) return
           let outcome = await gitlab.provisioner.provision(orgId, binding.id)
-          // 8s × 90 outlasts a full 10-minute peer lease plus slack.
-          for (let attempt = 0; outcome.state === 'busy' && attempt < 90; attempt++) {
-            await new Promise((resolve) => setTimeout(resolve, 8_000))
+          // Exponential backoff capped at 8s; ~92 attempts outlast a full
+          // 10-minute peer lease plus slack, while back-to-back writes (the
+          // common case: the peer run finishes in seconds) converge fast.
+          for (let attempt = 0; outcome.state === 'busy' && attempt < 92; attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, Math.min(8_000, 1_000 * 2 ** attempt)))
             outcome = await gitlab.provisioner.provision(orgId, binding.id)
           }
           if (outcome.state === 'busy') {

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -86,7 +86,7 @@ type SessionFacetIndex = Awaited<ReturnType<HttpDeps['repos']['session']['listFa
 type HookSessionRow = Pick<SessionPageRow, 'agentId' | 'platform' | 'channel' | 'triggeredBy'>
 type HookSessionMetadata = {
   agentId: string | null
-  kind: 'webhook' | 'github'
+  kind: 'webhook' | 'github' | 'gitlab'
   name: string
   repoId: bigint | null
 }
@@ -238,7 +238,7 @@ function sessionFacets(
       value: string
       integration: string
       name: string | null
-      hookKind: 'webhook' | 'github' | null
+      hookKind: 'webhook' | 'github' | 'gitlab' | null
       githubRepoId: string | null
     }
   >()

--- a/packages/control-plane/src/orchestrator/relayControl.ts
+++ b/packages/control-plane/src/orchestrator/relayControl.ts
@@ -19,6 +19,7 @@ import type {
   RcMemoryConnectionAssign,
   RcMemoryConnectionUnassign
 } from '@agentconnect.md/protocol'
+import { GITLAB_COM_V1_FEATURE } from '@agentconnect.md/protocol'
 import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 
 export class RelayControlSender {
@@ -35,9 +36,14 @@ export class RelayControlSender {
   }
 
   /** Upsert one compiled hook rule on every connected relay (the frame is NEVER
-   *  logged — it carries the hook's hmacSecret). */
+   *  logged — it carries the hook's hmacSecret). A gitlab rule goes only to
+   *  relays advertising the feature: the widened `kind` is frame-fatal on an
+   *  older relay's decoder (§17.3), so gating here IS the negotiation. */
   hookAssign(rule: RcHookAssign): void {
-    this.broadcast((ch) => ch.send('rc/hook-assign', rule))
+    this.broadcast((ch) => {
+      if (rule.kind === 'gitlab' && !ch.features?.includes(GITLAB_COM_V1_FEATURE)) return
+      ch.send('rc/hook-assign', rule)
+    })
   }
 
   /** Drop one hook rule pool-wide (hook disabled / deleted / agent unplaced). */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2066,9 +2066,11 @@ export interface CronRepo {
 //   HookDef rows into rc/hook-assign rules; event payloads never land here.
 // ───────────────────────────────────────────────────────────────────────────
 
-export type HookKind = 'webhook' | 'github'
+export type HookKind = 'webhook' | 'github' | 'gitlab'
 export type HookSessionMode = 'perDelivery' | 'perThread' | 'shared'
 export type GithubCommentFamily = 'issues' | 'pull_request'
+/** The stored comment-family vocabulary across code hosts; rows carry one host's subset. */
+export type HookCommentFamily = GithubCommentFamily | 'merge_request'
 export type HookReviewPolicy = 'off' | 'comment' | 'request_changes' | 'full'
 export type HookReportingMode = 'off' | 'check' | 'status'
 export type HookGateMode = 'informational' | 'required'
@@ -2099,7 +2101,7 @@ export interface UpsertHookInput {
   repoFullName?: string
   events?: string[]
   /** Empty preserves the published API's legacy repo-wide issue_comment semantics. */
-  commentFamilies?: GithubCommentFamily[]
+  commentFamilies?: HookCommentFamily[]
   labelFilter?: string[]
   mentionOnly?: boolean
   reviewPolicy?: HookReviewPolicy
@@ -2135,7 +2137,7 @@ export interface HookRecord {
   githubSessionKey?: string | null
   events: string[]
   /** Empty = legacy repo-wide comments; non-empty scopes comments to these subjects. */
-  commentFamilies: GithubCommentFamily[]
+  commentFamilies: HookCommentFamily[]
   labelFilter: string[]
   mentionOnly: boolean
   configRevision: bigint

--- a/packages/control-plane/src/ws/relay-connection.ts
+++ b/packages/control-plane/src/ws/relay-connection.ts
@@ -17,6 +17,7 @@
 import type {
   RcAuth,
   RcDeploymentConfig,
+  RcCodeHostMembershipAuthz,
   RcGithubCommentAuthz,
   RcGithubRerequest,
   RcGithubRerequestResult,
@@ -108,11 +109,15 @@ export interface RelayConnDeps {
   /** Resolve an App-owned informational Check Run rerequest to one current hook
    *  delivery. Operational failures become a retryable correlated error. */
   authorizeGithubRerequest: (req: RcGithubRerequest) => Promise<RcGithubRerequestResult>
+  /** Provider-neutral live membership re-check (gitlab-com-integration.md §12.2).
+   *  A thrown store/provider error becomes a retryable correlated error. */
+  authorizeCodeHostMembership: (req: RcCodeHostMembershipAuthz) => Promise<boolean>
 }
 
 export class RelayConnection implements RelayChannel {
   state: RelayState = 'AUTHENTICATING'
   relayId = ''
+  features: readonly string[] = []
 
   constructor(
     private readonly transport: Transport,
@@ -158,6 +163,9 @@ export class RelayConnection implements RelayChannel {
           return
         case 'rc/github-comment-authz':
           await this.handleGithubCommentAuthz(frame, frame.payload)
+          return
+        case 'rc/codehost-membership-authz':
+          await this.handleCodeHostMembershipAuthz(frame, frame.payload)
           return
         case 'rc/github-rerequest':
           await this.handleGithubRerequest(frame, frame.payload)
@@ -211,6 +219,7 @@ export class RelayConnection implements RelayChannel {
           type === 'rc/heartbeat' ||
           type === 'rc/verify' ||
           type === 'rc/github-comment-authz' ||
+          type === 'rc/codehost-membership-authz' ||
           type === 'rc/github-rerequest' ||
           type === 'rc/run-report' ||
           type === 'rc/set-channel-agent' ||
@@ -256,6 +265,7 @@ export class RelayConnection implements RelayChannel {
     // dead connection. Bail: the durable row is harmless (the sweeper ages it out).
     if (this.state === 'CLOSED') return
     this.relayId = row.id
+    this.features = req.features
     // Supersede a stale connection for the same relayId (a restarted pod reclaims its
     // id by name), then register THIS socket so the CP can push rc/daemon-revoke to it.
     const prev = this.deps.relayReg.get(row.id)
@@ -380,6 +390,19 @@ export class RelayConnection implements RelayChannel {
       return
     }
     this.reply(frame, 'rc/github-comment-authz/ok', { allowed })
+  }
+
+  private async handleCodeHostMembershipAuthz(frame: RelayCpFrame, req: RcCodeHostMembershipAuthz): Promise<void> {
+    // Same discipline as the GitHub arm: definitive denials stay distinct from
+    // transient failures; the relay fails closed on both.
+    let allowed: boolean
+    try {
+      allowed = await this.deps.authorizeCodeHostMembership(req)
+    } catch {
+      this.sendError(frame.id, 'INTERNAL', 'code host membership authorization failed', true)
+      return
+    }
+    this.reply(frame, 'rc/codehost-membership-authz/ok', { allowed })
   }
 
   private async handleGithubRerequest(frame: RelayCpFrame, req: RcGithubRerequest): Promise<void> {

--- a/packages/control-plane/src/ws/relay-registry.ts
+++ b/packages/control-plane/src/ws/relay-registry.ts
@@ -14,6 +14,8 @@ import type { z } from 'zod'
 /** The minimal channel the registry / revoke-sender holds — no `ws` knowledge. */
 export interface RelayChannel {
   readonly relayId: string
+  /** The features this relay advertised on register (rc/register.features). */
+  readonly features?: readonly string[]
   /** Fire-and-forget C→R EVT (e.g. `rc/daemon-revoke`). */
   send<T extends RelayCpFrameType>(type: T, payload: z.input<(typeof RELAY_CP_SCHEMAS)[T]>): void
   close(code: number, reason: string): void

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -35,6 +35,7 @@ import {
   PgCodeHostRepositoryRepo,
   PgGitlabConnectionRepo,
   PgGitlabProjectBindingRepo,
+  PgGitlabWebhookSecretStore,
   PgOrgRepo,
   PgOrgInviteLinkRepo,
   PgWaitlistRepo,
@@ -475,6 +476,7 @@ export function buildHttpApp(
     agentMutations: new AgentMutationGate(),
     sessionOwners: connReg,
     // The installations repo feeds the github-kind compile — same graph as prod.
+    // gitlab-kind compile sources appear exactly when the test wires a gitlab seam.
     hooks: new HookService(
       hookRepo,
       hookSecretStore,
@@ -482,7 +484,10 @@ export function buildHttpApp(
       relayControl,
       placementResolver,
       githubInstallationRepo,
-      'agentconnect-test'
+      'agentconnect-test',
+      undefined,
+      depsOverrides?.gitlab ? new PgGitlabProjectBindingRepo(prisma) : undefined,
+      depsOverrides?.gitlab ? new PgGitlabWebhookSecretStore(prisma, cipher) : undefined
     ),
     auth: new DaemonAuthService(
       codec,

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -26,7 +26,10 @@ export class FakeGitlab {
     FakeGitlabOptions
   serviceAccounts: { id: number; username: string; name: string }[] = []
   tokens = new Map<number, { name: string; scopes: string[]; expires_at: string; revoked: boolean; user_id: number }>()
-  webhooks = new Map<number, { url: string; token: string; events: Record<string, boolean>; tested: number }>()
+  webhooks = new Map<
+    number,
+    { projectId: number; url: string; token: string; events: Record<string, boolean>; tested: number }
+  >()
   members = new Map<number, number>() // userId → access_level
   deletedServiceAccounts: number[] = []
   private nextId = 5000
@@ -84,12 +87,20 @@ export class FakeGitlab {
       }
 
       if (/\/api\/v4\/projects\/\d+\/hooks\?/.test(url) && method === 'GET') {
-        return Response.json([...this.webhooks.entries()].map(([id, hook]) => ({ id, url: hook.url })))
+        const projectId = Number(/projects\/(\d+)\//.exec(url)![1])
+        // Real GitLab scopes the listing to the addressed project.
+        return Response.json(
+          [...this.webhooks.entries()]
+            .filter(([, hook]) => hook.projectId === projectId)
+            .map(([id, hook]) => ({ id, url: hook.url }))
+        )
       }
       if (/\/api\/v4\/projects\/\d+\/hooks$/.test(url) && method === 'POST') {
+        const projectId = Number(/projects\/(\d+)\//.exec(url)![1])
         const id = ++this.nextId
         const payload = json()
         this.webhooks.set(id, {
+          projectId,
           url: String(payload.url),
           token: String(payload.signing_token),
           events: payload as Record<string, boolean>,
@@ -105,14 +116,20 @@ export class FakeGitlab {
         return Response.json({})
       }
       if (/\/api\/v4\/projects\/\d+\/hooks\/\d+$/.test(url)) {
+        const projectId = Number(/projects\/(\d+)\//.exec(url)![1])
         const id = Number(/hooks\/(\d+)$/.exec(url)![1])
+        // Project-scoped authority: another project's hook id resolves 404.
+        if (this.webhooks.get(id)?.projectId !== projectId) {
+          return Response.json({ message: 'Not Found' }, { status: 404 })
+        }
         if (method === 'DELETE') {
-          if (!this.webhooks.delete(id)) return Response.json({ message: 'Not Found' }, { status: 404 })
+          this.webhooks.delete(id)
           return Response.json({})
         }
         if (method === 'PUT') {
           const payload = json()
           this.webhooks.set(id, {
+            projectId,
             url: String(payload.url),
             token: String(payload.signing_token),
             events: payload as Record<string, boolean>,

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -289,6 +289,22 @@ describe('gitlab hooks — binding lifecycle rebroadcast (§11.1/§11.3 round 2)
     )
   })
 
+  it('a provider-side webhook loss is healed on the next converge — local columns are not proof', async () => {
+    const h = await harness()
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(created.statusCode).toBe(200)
+    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 15_000 })
+    const staleId = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.webhookId!
+    // Provider-side deletion (or a crash between the delete and the local
+    // clear): the recorded id and desiredEventsHash both survive locally.
+    h.fake.webhooks.clear()
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    expect(h.fake.webhooks.size).toBe(1)
+    const healed = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.webhookId!
+    expect(healed).not.toBe(staleId)
+    expect([...h.fake.webhooks.keys()][0]).toBe(Number(healed))
+  })
+
   it('repair rebroadcasts the project rules with the STABLE signing key', async () => {
     const h = await harness()
     const glab = channel([GITLAB_COM_V1_FEATURE])

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -68,9 +68,17 @@ async function harness(options: FakeGitlabOptions = {}) {
     cipher,
     clock: systemClock,
     publicRelayUrl: RELAY_URL,
-    // The production union (container wiring): the enabled gitlab hook set.
+    // The production union + rebroadcast (container wiring): the enabled
+    // gitlab hook set, recompiled through the app's HookService after runs.
     desiredWebhookEvents: async (orgId, projectId) =>
       unionGitlabWebhookEvents(await hookRepo.listForOrgKind(OrgId(orgId), 'gitlab'), projectId),
+    onConverged: (orgId, projectId) => {
+      const app = running
+      if (!app) return
+      void hookRepo.listForOrgKind(OrgId(orgId), 'gitlab').then(async (rows) => {
+        for (const row of rows) if (row.repoId === projectId) await app.deps.hooks.broadcast(row)
+      })
+    },
     fetchImpl: fake.fetch()
   })
   running = buildHttpApp(
@@ -242,6 +250,75 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
       },
       { timeout: 15_000 }
     )
+  })
+})
+
+describe('gitlab hooks — binding lifecycle rebroadcast (§11.1/§11.3 round 2)', () => {
+  it("retargeting the last hook A→B uninstalls A's webhook and installs B's", async () => {
+    const h = await harness()
+    // A second managed binding (the fake serves any project id it is asked for).
+    const OTHER = 999n
+    const connection = await prisma.gitlabConnection.findFirstOrThrow({ where: { orgId: DEFAULT_ORG_ID } })
+    const other = await h.bindings.createWithClaim({
+      orgId: DEFAULT_ORG_ID,
+      projectId: OTHER,
+      projectPath: 'example-group/other-project',
+      installerConnectionId: connection.id
+    })
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, other.id)).toEqual({ state: 'ready' })
+
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(created.statusCode).toBe(200)
+    const hookId = (created.json() as { id: string }).id
+    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 15_000 })
+
+    const moved = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/hooks/${hookId}`,
+      payload: glBody(h.agentId, { projectId: OTHER.toString() })
+    })
+    expect(moved.statusCode).toBe(200)
+    // BOTH bindings converge: A's webhook and key retire, B's install.
+    await vi.waitFor(
+      async () => {
+        expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))?.webhookId).toBeNull()
+        expect((await h.bindings.get(DEFAULT_ORG_ID, other.id))?.webhookId).not.toBeNull()
+        expect(h.fake.webhooks.size).toBe(1)
+      },
+      { timeout: 15_000 }
+    )
+  })
+
+  it('repair rebroadcasts the project rules with the STABLE signing key', async () => {
+    const h = await harness()
+    const glab = channel([GITLAB_COM_V1_FEATURE])
+    h.a.relayReg.add(glab.ch)
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(created.statusCode).toBe(200)
+    let firstToken = ''
+    await vi.waitFor(
+      () => {
+        const assigns = glab.sent.filter((frame) => frame.type === 'rc/hook-assign')
+        expect(assigns.length).toBeGreaterThan(0)
+        firstToken = (assigns.at(-1)!.payload as RcHookAssign).gitlab!.signingToken
+      },
+      { timeout: 15_000 }
+    )
+
+    glab.sent.length = 0
+    const repair = await h.a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${h.binding.id}/repair` })
+    expect(repair.statusCode).toBe(200)
+    // The saga's onConverged re-pushes the compiled rule; the key is reused,
+    // never rotated, so live rules stay verifiable across repairs.
+    await vi.waitFor(
+      () => {
+        const assigns = glab.sent.filter((frame) => frame.type === 'rc/hook-assign')
+        expect(assigns.length).toBeGreaterThan(0)
+        expect((assigns.at(-1)!.payload as RcHookAssign).gitlab!.signingToken).toBe(firstToken)
+      },
+      { timeout: 15_000 }
+    )
+    expect([...h.fake.webhooks.values()][0]!.token).toBe(firstToken)
   })
 })
 

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -158,7 +158,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect(dto.kind).toBe('gitlab')
 
     // The converge kick installs the webhook (§11.1) with the hook's union…
-    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 15_000 })
+    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 20_000 })
     const webhook = [...h.fake.webhooks.values()][0]!
     expect(webhook.url).toBe(`${RELAY_URL}/webhooks/gitlab`)
     expect(webhook.events['issues_events']).toBe(true)
@@ -179,7 +179,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
         expect(rule.gitlab?.signingToken).toBe(webhook.token)
         expect(rule.gitlab?.events).toEqual(['issues:*', 'merge_request:opened'])
       },
-      { timeout: 15_000 }
+      { timeout: 20_000 }
     )
     expect(legacy.sent.filter((frame) => frame.type === 'rc/hook-assign')).toHaveLength(0)
   })
@@ -206,7 +206,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     h.a.relayReg.add(glab.ch)
     const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
     const hookId = (created.json() as { id: string }).id
-    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 15_000 })
+    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 20_000 })
 
     const res = await h.a.app.inject({ method: 'DELETE', url: `${ORG}/hooks/${hookId}` })
     expect(res.statusCode).toBe(204)
@@ -217,7 +217,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
         // The binding record trails the provider delete inside the same kick.
         expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))?.webhookId).toBeNull()
       },
-      { timeout: 15_000 }
+      { timeout: 20_000 }
     )
   })
 
@@ -248,7 +248,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
         expect(webhook.events['push_events']).toBe(true)
         expect(webhook.events['issues_events']).toBeFalsy()
       },
-      { timeout: 15_000 }
+      { timeout: 20_000 }
     )
   })
 })
@@ -270,7 +270,7 @@ describe('gitlab hooks — binding lifecycle rebroadcast (§11.1/§11.3 round 2)
     const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
     expect(created.statusCode).toBe(200)
     const hookId = (created.json() as { id: string }).id
-    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 15_000 })
+    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 20_000 })
 
     const moved = await h.a.app.inject({
       method: 'PUT',
@@ -285,7 +285,7 @@ describe('gitlab hooks — binding lifecycle rebroadcast (§11.1/§11.3 round 2)
         expect((await h.bindings.get(DEFAULT_ORG_ID, other.id))?.webhookId).not.toBeNull()
         expect(h.fake.webhooks.size).toBe(1)
       },
-      { timeout: 15_000 }
+      { timeout: 20_000 }
     )
   })
 
@@ -293,12 +293,16 @@ describe('gitlab hooks — binding lifecycle rebroadcast (§11.1/§11.3 round 2)
     const h = await harness()
     const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
     expect(created.statusCode).toBe(200)
-    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 15_000 })
+    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 20_000 })
     const staleId = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.webhookId!
     // Provider-side deletion (or a crash between the delete and the local
     // clear): the recorded id and desiredEventsHash both survive locally.
     h.fake.webhooks.clear()
-    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    // The create kick's saga may still hold the run lease — retry through it.
+    await vi.waitFor(
+      async () => expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' }),
+      { timeout: 20_000 }
+    )
     expect(h.fake.webhooks.size).toBe(1)
     const healed = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.webhookId!
     expect(healed).not.toBe(staleId)
@@ -318,7 +322,7 @@ describe('gitlab hooks — binding lifecycle rebroadcast (§11.1/§11.3 round 2)
         expect(assigns.length).toBeGreaterThan(0)
         firstToken = (assigns.at(-1)!.payload as RcHookAssign).gitlab!.signingToken
       },
-      { timeout: 15_000 }
+      { timeout: 20_000 }
     )
 
     glab.sent.length = 0
@@ -332,7 +336,7 @@ describe('gitlab hooks — binding lifecycle rebroadcast (§11.1/§11.3 round 2)
         expect(assigns.length).toBeGreaterThan(0)
         expect((assigns.at(-1)!.payload as RcHookAssign).gitlab!.signingToken).toBe(firstToken)
       },
-      { timeout: 15_000 }
+      { timeout: 20_000 }
     )
     expect([...h.fake.webhooks.values()][0]!.token).toBe(firstToken)
   })

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -1,0 +1,286 @@
+/**
+ * gitlab-kind hooks (gitlab-com-integration.md M3 CP half): the create/update/
+ * delete routes fenced on a managed binding (§8.3), rule compile + the §17.3
+ * feature-gated broadcast (§11.3), the managed-webhook converge kick and its
+ * inverse (§11.1), and rc/codehost-membership-authz resolution (§12.2).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
+import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { FakeGitlab, type FakeGitlabOptions } from '../fakes/gitlab-api.js'
+import { GitlabOauthService } from '../../src/gitlab/oauth.service.js'
+import { GitlabProvisioner } from '../../src/gitlab/provisioner.js'
+import { GitlabMembershipAuthzService } from '../../src/gitlab/membership-authz.service.js'
+import { unionGitlabWebhookEvents } from '../../src/gitlab/webhook-events.js'
+import {
+  PgCodeHostRepositoryRepo,
+  PgGitlabConnectionRepo,
+  PgGitlabConnectionSecretStore,
+  PgGitlabOauthStateStore,
+  PgGitlabProjectBindingRepo,
+  PgGitlabProjectCredentialRepo,
+  PgGitlabProjectCredentialSecretStore,
+  PgGitlabWebhookSecretStore,
+  PgHookRepo
+} from '../../src/persistence/index.js'
+import { makeSecretCipher } from '../../src/secrets/cipher.js'
+import { systemClock } from '../../src/domain/clock.js'
+import { HookId, OrgId } from '../../src/domain/ids.js'
+import { GITLAB_COM_V1_FEATURE, type RcHookAssign } from '@agentconnect.md/protocol'
+import type { RelayChannel } from '../../src/ws/relay-registry.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const PROJECT = 4455667n
+const RELAY_URL = 'https://relay.example.test'
+const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
+
+let running: HttpApp | undefined
+afterEach(async () => {
+  await running?.close()
+  running = undefined
+})
+
+async function harness(options: FakeGitlabOptions = {}) {
+  const fake = new FakeGitlab(options)
+  const hookRepo = new PgHookRepo(prisma)
+  const bindings = new PgGitlabProjectBindingRepo(prisma)
+  const connections = new PgGitlabConnectionRepo(prisma)
+  const oauth = new GitlabOauthService({
+    cfg: { clientId: 'client-1', clientSecret: 'secret-1' },
+    connections,
+    secrets: new PgGitlabConnectionSecretStore(prisma, cipher),
+    states: new PgGitlabOauthStateStore(prisma),
+    cipher,
+    clock: systemClock,
+    publicCpUrl: 'https://api.example.test',
+    fetchImpl: fake.fetch()
+  })
+  const provisioner = new GitlabProvisioner({
+    oauth,
+    bindings,
+    credentials: new PgGitlabProjectCredentialRepo(prisma),
+    credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, cipher),
+    webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
+    catalog: new PgCodeHostRepositoryRepo(prisma),
+    cipher,
+    clock: systemClock,
+    publicRelayUrl: RELAY_URL,
+    // The production union (container wiring): the enabled gitlab hook set.
+    desiredWebhookEvents: async (orgId, projectId) =>
+      unionGitlabWebhookEvents(await hookRepo.listForOrgKind(OrgId(orgId), 'gitlab'), projectId),
+    fetchImpl: fake.fetch()
+  })
+  running = buildHttpApp(
+    prisma,
+    { PUBLIC_CP_URL: 'https://api.example.test', PUBLIC_RELAY_URL: RELAY_URL },
+    undefined,
+    undefined,
+    { gitlab: { oauth, provisioner, fetchImpl: fake.fetch() } }
+  )
+  // A live relay row so the ingress gate passes.
+  await prisma.relay.create({
+    data: {
+      id: randomUUID(),
+      name: `relay-${randomUUID().slice(0, 8)}`,
+      daemonUrl: 'wss://relay-0',
+      lastSeenAt: new Date()
+    }
+  })
+  // A ready managed binding for the fake's default project.
+  const connection = await connections.upsertOnCallback({
+    orgId: DEFAULT_ORG_ID,
+    userId: DEFAULT_OWNER_ID,
+    gitlabUserId: 4242n,
+    gitlabUsername: 'example-admin',
+    scopes: ['api'],
+    accessExpiresAt: new Date(Date.now() + 3600_000),
+    sealedPair: { accessToken: 'at-1', refreshToken: 'rt-1' }
+  })
+  const binding = await bindings.createWithClaim({
+    orgId: DEFAULT_ORG_ID,
+    projectId: PROJECT,
+    projectPath: 'example-group/example-project',
+    installerConnectionId: connection.id
+  })
+  expect(await provisioner.provision(DEFAULT_ORG_ID, binding.id)).toEqual({ state: 'ready' })
+  const daemonId = randomUUID()
+  await seedDaemon(prisma, daemonId)
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, { daemonId })
+  return { fake, a: running, hookRepo, bindings, provisioner, binding, agentId }
+}
+
+function channel(features?: string[]) {
+  const sent: Array<{ type: string; payload: unknown }> = []
+  const ch = {
+    relayId: `r-${randomUUID().slice(0, 8)}`,
+    ...(features ? { features } : {}),
+    send: (type: string, payload: unknown) => {
+      sent.push({ type, payload })
+    },
+    close() {}
+  } as unknown as RelayChannel
+  return { ch, sent }
+}
+
+const glBody = (agentId: string, over: Record<string, unknown> = {}) => ({
+  agentId,
+  kind: 'gitlab',
+  name: 'gl-hook',
+  projectId: PROJECT.toString(),
+  events: ['issues:*', 'merge_request:opened'],
+  commentFamilies: ['issues', 'merge_request'],
+  ...over
+})
+
+describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.3)', () => {
+  it('create compiles a rule for feature-advertising relays only, and installs the managed webhook', async () => {
+    const h = await harness()
+    const glab = channel([GITLAB_COM_V1_FEATURE])
+    const legacy = channel()
+    h.a.relayReg.add(glab.ch)
+    h.a.relayReg.add(legacy.ch)
+
+    const res = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(res.statusCode).toBe(200)
+    const dto = res.json() as { id: string; kind: string; url: string | null }
+    expect(dto.kind).toBe('gitlab')
+
+    // The converge kick installs the webhook (§11.1) with the hook's union…
+    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1))
+    const webhook = [...h.fake.webhooks.values()][0]!
+    expect(webhook.url).toBe(`${RELAY_URL}/webhooks/gitlab`)
+    expect(webhook.events['issues_events']).toBe(true)
+    expect(webhook.events['merge_requests_events']).toBe(true)
+    expect(webhook.events['note_events']).toBe(true)
+    expect(webhook.events['push_events']).toBeFalsy()
+
+    // …then re-broadcasts the now-complete rule, only to relays advertising the feature (§17.3).
+    await vi.waitFor(() => {
+      const assigns = glab.sent.filter((frame) => frame.type === 'rc/hook-assign')
+      expect(assigns.length).toBeGreaterThan(0)
+      const rule = assigns.at(-1)!.payload as RcHookAssign
+      expect(rule.kind).toBe('gitlab')
+      expect(rule.gitlab?.projectId).toBe(PROJECT.toString())
+      expect(rule.gitlab?.sessionKeyPrefix).toBe(`gitlab:${PROJECT}`)
+      expect(rule.gitlab?.serviceAccountUsername).toBe(`agentconnect-p${PROJECT}`)
+      expect(rule.gitlab?.signingToken).toBe(webhook.token)
+      expect(rule.gitlab?.events).toEqual(['issues:*', 'merge_request:opened'])
+    })
+    expect(legacy.sent.filter((frame) => frame.type === 'rc/hook-assign')).toHaveLength(0)
+  })
+
+  it('create is fenced on a managed binding; a second hook on the same project+agent is a 409', async () => {
+    const h = await harness()
+    const unbound = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: glBody(h.agentId, { projectId: '999' })
+    })
+    expect(unbound.statusCode).toBe(409)
+
+    expect((await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })).statusCode).toBe(
+      200
+    )
+    const dup = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(dup.statusCode).toBe(409)
+  })
+
+  it('delete drops the rule and uninstalls the webhook once no hook wants events (§11.1 inverse)', async () => {
+    const h = await harness()
+    const glab = channel([GITLAB_COM_V1_FEATURE])
+    h.a.relayReg.add(glab.ch)
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    const hookId = (created.json() as { id: string }).id
+    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1))
+
+    const res = await h.a.app.inject({ method: 'DELETE', url: `${ORG}/hooks/${hookId}` })
+    expect(res.statusCode).toBe(204)
+    await vi.waitFor(() => {
+      expect(glab.sent.some((frame) => frame.type === 'rc/hook-remove')).toBe(true)
+      expect(h.fake.webhooks.size).toBe(0)
+    })
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))?.webhookId).toBeNull()
+  })
+
+  it('update re-fences the project against the org bindings', async () => {
+    const h = await harness()
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    const hookId = (created.json() as { id: string }).id
+
+    const retarget = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/hooks/${hookId}`,
+      payload: glBody(h.agentId, { projectId: '999' })
+    })
+    expect(retarget.statusCode).toBe(409)
+
+    const ok = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/hooks/${hookId}`,
+      payload: glBody(h.agentId, { events: ['push:*'], commentFamilies: [] })
+    })
+    expect(ok.statusCode).toBe(200)
+    const row = (await h.hookRepo.get(OrgId(DEFAULT_ORG_ID), HookId(hookId)))!
+    expect(row.events).toEqual(['push:*'])
+    // The saga converges the webhook down to the new union.
+    await vi.waitFor(() => {
+      const webhook = [...h.fake.webhooks.values()][0]!
+      expect(webhook.events['push_events']).toBe(true)
+      expect(webhook.events['issues_events']).toBeFalsy()
+    })
+  })
+})
+
+describe('rc/codehost-membership-authz (§12.2)', () => {
+  async function authzHarness() {
+    const h = await harness()
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(created.statusCode).toBe(200)
+    const hookRow = (await h.hookRepo.get(OrgId(DEFAULT_ORG_ID), HookId((created.json() as { id: string }).id)))!
+    const service = new GitlabMembershipAuthzService({
+      hooks: h.hookRepo,
+      bindings: h.bindings,
+      credentials: new PgGitlabProjectCredentialRepo(prisma),
+      credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, cipher),
+      clock: systemClock,
+      fetchImpl: h.fake.fetch()
+    })
+    const base = {
+      hookId: hookRow.id,
+      provider: 'gitlab',
+      repoExternalId: PROJECT.toString(),
+      actorExternalId: '7001',
+      configRevision: hookRow.configRevision.toString(),
+      dispatchRevision: hookRow.dispatchRevision.toString()
+    }
+    return { h, hookRow, service, base }
+  }
+
+  it('allows a live Developer, denies below-bar, unknown, and expired-fence actors', async () => {
+    const { h, service, base } = await authzHarness()
+    h.fake.members.set(7001, 30)
+    h.fake.members.set(7002, 20)
+    expect(await service.allowed(base)).toBe(true)
+    expect(await service.allowed({ ...base, actorExternalId: '7002' })).toBe(false)
+    expect(await service.allowed({ ...base, actorExternalId: '7999' })).toBe(false)
+    // Unmentioned thread continuation: the subject author must ALSO hold the bar.
+    expect(await service.allowed({ ...base, subjectAuthorExternalId: '7002' })).toBe(false)
+    expect(await service.allowed({ ...base, subjectAuthorExternalId: '7001' })).toBe(true)
+  })
+
+  it('never authorizes the managed service account, a stale fence, a foreign provider, or a disabled hook', async () => {
+    const { h, hookRow, service, base } = await authzHarness()
+    h.fake.members.set(7001, 30)
+    // The SA holds Developer by §7.2, but its identity must not summon (§12.1 belt).
+    const saId = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.serviceAccountUserId!.toString()
+    expect(await service.allowed({ ...base, actorExternalId: saId })).toBe(false)
+    expect(await service.allowed({ ...base, configRevision: (hookRow.configRevision + 1n).toString() })).toBe(false)
+    expect(await service.allowed({ ...base, provider: 'github' })).toBe(false)
+    await prisma.hookDef.update({ where: { id: hookRow.id }, data: { enabled: false } })
+    expect(await service.allowed(base)).toBe(false)
+  })
+})

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -150,7 +150,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect(dto.kind).toBe('gitlab')
 
     // The converge kick installs the webhook (§11.1) with the hook's union…
-    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1))
+    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 15_000 })
     const webhook = [...h.fake.webhooks.values()][0]!
     expect(webhook.url).toBe(`${RELAY_URL}/webhooks/gitlab`)
     expect(webhook.events['issues_events']).toBe(true)
@@ -159,17 +159,20 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect(webhook.events['push_events']).toBeFalsy()
 
     // …then re-broadcasts the now-complete rule, only to relays advertising the feature (§17.3).
-    await vi.waitFor(() => {
-      const assigns = glab.sent.filter((frame) => frame.type === 'rc/hook-assign')
-      expect(assigns.length).toBeGreaterThan(0)
-      const rule = assigns.at(-1)!.payload as RcHookAssign
-      expect(rule.kind).toBe('gitlab')
-      expect(rule.gitlab?.projectId).toBe(PROJECT.toString())
-      expect(rule.gitlab?.sessionKeyPrefix).toBe(`gitlab:${PROJECT}`)
-      expect(rule.gitlab?.serviceAccountUsername).toBe(`agentconnect-p${PROJECT}`)
-      expect(rule.gitlab?.signingToken).toBe(webhook.token)
-      expect(rule.gitlab?.events).toEqual(['issues:*', 'merge_request:opened'])
-    })
+    await vi.waitFor(
+      () => {
+        const assigns = glab.sent.filter((frame) => frame.type === 'rc/hook-assign')
+        expect(assigns.length).toBeGreaterThan(0)
+        const rule = assigns.at(-1)!.payload as RcHookAssign
+        expect(rule.kind).toBe('gitlab')
+        expect(rule.gitlab?.projectId).toBe(PROJECT.toString())
+        expect(rule.gitlab?.sessionKeyPrefix).toBe(`gitlab:${PROJECT}`)
+        expect(rule.gitlab?.serviceAccountUsername).toBe(`agentconnect-p${PROJECT}`)
+        expect(rule.gitlab?.signingToken).toBe(webhook.token)
+        expect(rule.gitlab?.events).toEqual(['issues:*', 'merge_request:opened'])
+      },
+      { timeout: 15_000 }
+    )
     expect(legacy.sent.filter((frame) => frame.type === 'rc/hook-assign')).toHaveLength(0)
   })
 
@@ -195,15 +198,19 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     h.a.relayReg.add(glab.ch)
     const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
     const hookId = (created.json() as { id: string }).id
-    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1))
+    await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 15_000 })
 
     const res = await h.a.app.inject({ method: 'DELETE', url: `${ORG}/hooks/${hookId}` })
     expect(res.statusCode).toBe(204)
-    await vi.waitFor(() => {
-      expect(glab.sent.some((frame) => frame.type === 'rc/hook-remove')).toBe(true)
-      expect(h.fake.webhooks.size).toBe(0)
-    })
-    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))?.webhookId).toBeNull()
+    await vi.waitFor(
+      async () => {
+        expect(glab.sent.some((frame) => frame.type === 'rc/hook-remove')).toBe(true)
+        expect(h.fake.webhooks.size).toBe(0)
+        // The binding record trails the provider delete inside the same kick.
+        expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))?.webhookId).toBeNull()
+      },
+      { timeout: 15_000 }
+    )
   })
 
   it('update re-fences the project against the org bindings', async () => {
@@ -227,11 +234,14 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     const row = (await h.hookRepo.get(OrgId(DEFAULT_ORG_ID), HookId(hookId)))!
     expect(row.events).toEqual(['push:*'])
     // The saga converges the webhook down to the new union.
-    await vi.waitFor(() => {
-      const webhook = [...h.fake.webhooks.values()][0]!
-      expect(webhook.events['push_events']).toBe(true)
-      expect(webhook.events['issues_events']).toBeFalsy()
-    })
+    await vi.waitFor(
+      () => {
+        const webhook = [...h.fake.webhooks.values()][0]!
+        expect(webhook.events['push_events']).toBe(true)
+        expect(webhook.events['issues_events']).toBeFalsy()
+      },
+      { timeout: 15_000 }
+    )
   })
 })
 

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -5,7 +5,7 @@ import { BindMatch, IntegrationChannel } from './integration.js'
 import { CronTarget } from './cron.js'
 import { Platform } from './route.js'
 import { CollabRoutesSnapshot } from './collab.js'
-import { GithubHookMetadata, HookBigIntString, OptionalHookConfigSnapshot } from './hook.js'
+import { GithubHookMetadata, GitlabHookMetadata, HookBigIntString, OptionalHookConfigSnapshot } from './hook.js'
 import { WebchatRemoteMcpEntitlement } from './remote-mcp.js'
 import { buildEnvelopeRaw, decodeEnvelopeWith, type BuildOpts, type DecodeResultOf } from '../wire.js'
 
@@ -311,7 +311,7 @@ export type RcGithubRerequestResult = z.infer<typeof RcGithubRerequestResult>
 export const RcHookAssign = z
   .object({
     hookId: z.string().uuid(),
-    kind: z.enum(['webhook', 'github']),
+    kind: z.enum(['webhook', 'github', 'gitlab']),
     agentId: z.string().uuid(),
     daemonId: z.string().uuid(), // the agent's CURRENT placement; re-sent on moves
     // R1/R2a rolling fields. Partial/absent remains decodable, but the relay
@@ -357,6 +357,27 @@ export const RcHookAssign = z
         // The org's valid installation ids (BigInt as string) — the runtime
         // attribution gate: an event fires only if payload.installation.id ∈ set.
         installationIds: z.array(z.string())
+      })
+      .optional(),
+    // kind=gitlab (gitlab-com-integration.md §11.3) — required for that kind.
+    // The signing token rides inline exactly as the generic webhook's HMAC
+    // secret does; the rule is NEVER logged.
+    gitlab: z
+      .object({
+        projectId: z.string().regex(/^[1-9]\d*$/), // numeric project id — the match key
+        projectPath: z.string().min(1), // display/logs only; never matched on
+        sessionKeyPrefix: z.string().min(1), // rename-stable per-thread namespace: gitlab:<projectId>
+        events: z.array(z.string()), // 'issues:*' / 'merge_request:*' / 'push:*' …
+        labelFilter: z.array(z.string()),
+        commentFamilies: z.array(z.enum(['issues', 'merge_request'])).optional(),
+        mentionOnly: z.boolean(),
+        agentName: z.string().optional(),
+        // The binding's runtime identity: loop prevention (§12.1) and the
+        // mention/reviewer targets.
+        serviceAccountUserId: z.string().regex(/^[1-9]\d*$/),
+        serviceAccountUsername: z.string().min(1),
+        // whsec_ Standard Webhooks signing key for §11.2 verification.
+        signingToken: z.string().min(1)
       })
       .optional()
   })
@@ -421,6 +442,7 @@ export const RcRunReport = z
     ...OptionalHookConfigSnapshot.shape,
     event: z.string().min(1).optional(), // 'issues:opened' etc (github); absent for webhook kind
     github: GithubHookMetadata.optional(),
+    gitlab: GitlabHookMetadata.optional(),
     status: z.enum(['accepted', 'failed']),
     reason: z.string().optional() // delivery-stage reason; use isRetryableHookDeliveryReason before redelivery
   })


### PR DESCRIPTION
The CP half of [gitlab-com-integration.md](docs/designs/gitlab-com-integration.md) §22 **M3**, after #1366. The relay half (ingress plugin + Standard Webhooks verification) follows separately.

## The `gitlab` hook kind

- Migration: `ALTER TYPE "HookKind" ADD VALUE 'gitlab'`; `HookCommentFamily` widens with `merge_request`.
- **Routes** (§8.3): create/update arms fenced on a managed binding in the organization (never trusting the numeric id for facts), duplicate-per-agent 409, `perThread` by definition with the rename-stable `gitlab:<projectId>` session namespace. Review/reporting knobs stay off until the M6 slice.
- **Compile** (§11.3): the rule carries the binding's runtime identity (service-account id/username for §12.1 loop prevention and mention targets) and the inline `whsec_` signing token, exactly as the generic webhook's HMAC secret rides. A binding without a working ingress (no webhook, no key, no service account, or entering cleanup) leaves the pool.

## §17.3 rolling compatibility

`rc/hook-assign` gitlab rules reach only relays that advertised `gitlab-com-v1` on register — gated per channel in the broadcast sender AND the register replay, so an older relay's strict decoder never sees the new kind. `RelayChannel.features` records the advertised set (absent = none).

## The managed webhook's event union (§11.1)

`desiredWebhookEvents` is now real: the union of what every enabled gitlab hook on the project needs (`note_events` deliberately over-subscribed for thread continuation; the relay filters). Hook create/update/delete kick the §10.2 saga to converge the webhook — including the inverse: when no hook wants events any more, the webhook and its sealed key are removed. Two write-path races are handled: a `busy` saga lease is retried briefly so a union change is never silently dropped, and the compiled rule is re-broadcast after the saga lands (the rule embeds webhook facts that did not exist at persist time).

## `rc/codehost-membership-authz` (§12.2)

The provider-neutral successor to the GitHub comment-authz REQ, answered for `gitlab`: same fence discipline (fan-out sibling fences, config/dispatch revision match, re-read before the allow verdict), then live *effective* membership (`/members/all/:id`) for the actor — and the subject author on unmentioned continuation — at Developer or above through the binding's read PAT, fail-closed. The managed service account's own identity never authorizes a trigger.

## Tests

New suite (6): feature-gated compile + webhook install, binding fences, delete uninstall, update re-union, and the two membership-authz matrices. Union unit tests (3). Full CP: unit 1847/1847, integration 1542/1542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
