### PR TITLE
feat(control-plane): rotate gitlab project credentials ahead of expiry

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -26,6 +26,7 @@ import { resolveGitlabAppConfig } from './gitlab/config.js'
 import type { FetchLike as GitlabFetchLike } from './gitlab/api.js'
 import { GitlabOauthService } from './gitlab/oauth.service.js'
 import { GitlabProvisioner } from './gitlab/provisioner.js'
+import { GitlabCredentialRotator } from './gitlab/rotator.js'
 import { resolveSlackPlatformAppConfig } from './config/slack-platform.js'
 import { resolveFeishuPlatformApps } from './config/feishu-platform.js'
 import type { FetchLike } from './github/api.js'
@@ -965,6 +966,14 @@ export function buildContainer(
         })
       }
     : undefined
+  // §7.4 PAT-rotation sweep; armed only by startBackground().
+  const gitlabRotator = gitlab
+    ? new GitlabCredentialRotator({
+        provisioner: gitlab.provisioner,
+        clock,
+        log: { warn: (obj, msg) => http.log.warn(obj, msg) }
+      })
+    : undefined
 
   // The console PR panel's read projection — long-lived so its short TTL cache actually absorbs mounts.
   const pullRequestView = github ? new PullRequestViewService(github.tokens, clock, opts.githubFetch) : undefined
@@ -1885,6 +1894,7 @@ export function buildContainer(
       webchatMcpOperationReaper.start()
       githubRunReporter?.start()
       hookRedeliveryReconciler?.start()
+      gitlabRotator?.start()
       for (const reaper of pendingInstallReapers) reaper.start()
       relaySweeper.start()
       dutyRecompute.start()
@@ -1901,6 +1911,7 @@ export function buildContainer(
       const webchatMcpOperationSettled = webchatMcpOperationReaper.stopAndSettle()
       githubRunReporter?.stop()
       hookRedeliveryReconciler?.stop()
+      gitlabRotator?.stop()
       installationDoorbell?.stop()
       for (const reaper of pendingInstallReapers) reaper.stop()
       relaySweeper.stop()

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -475,7 +475,20 @@ export class GitlabProvisioner {
           continue
         }
         const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
-        const previousTokenId = credential.externalTokenId
+        // Revalidate UNDER the lease: the worklist is a pre-lease snapshot, so a
+        // peer sweep may have rotated this row already. A changed generation or
+        // a no-longer-due expiry skips; the reloaded predecessor (never the
+        // snapshot's) is what gets revoked — revoking the snapshot's id here
+        // would strand the peer's freshly minted token untracked.
+        const current = await this.deps.credentials.get(credential.bindingId, credential.purpose)
+        if (
+          !current ||
+          current.generation !== credential.generation ||
+          current.providerExpiresAt.getTime() >= this.deps.clock.now() + horizonMs
+        ) {
+          continue
+        }
+        const previousTokenId = current.externalTokenId
         const serviceAccountUserId = binding.serviceAccountUserId
         await this.mintCredential(orgId, binding, token, root.id, serviceAccountUserId, credential.purpose, owner)
         await gitlabRevokeServiceAccountToken(
@@ -490,15 +503,22 @@ export class GitlabProvisioner {
             'gitlab rotation could not revoke the previous token (it still expires on schedule)'
           )
         })
+        // A rotation-owned degradation heals on the first successful rotation:
+        // nothing else clears it, and repair should not be the only way out.
+        if (binding.state === 'admin_degraded' && binding.stateReason?.startsWith('rotation_')) {
+          await this.deps.bindings.update(orgId, binding.id, { state: 'ready', stateReason: null })
+        }
       } catch (e) {
         // The Console warns while administration is unavailable; runtime keeps
         // working until the existing credential expires (§7.4).
         failedBindings.add(binding.id)
+        // Every rotation-set reason is rotation_-prefixed: that namespace is
+        // exactly what a later successful sweep may clear.
         const reason =
           e instanceof GitlabClaimFenceLost
-            ? 'claim_fence_lost'
+            ? 'rotation_claim_fence_lost'
             : e instanceof GitlabTokenPolicyViolation
-              ? 'out_of_policy_token'
+              ? 'rotation_out_of_policy_token'
               : e instanceof GitlabApiError
                 ? `rotation_gitlab_${e.status || 'unreachable'}`
                 : 'rotation_admin_unavailable'

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -432,6 +432,85 @@ export class GitlabProvisioner {
   }
 
   /**
+   * §7.4 rotation: create the replacement BEFORE revoking the old PAT — GitLab's
+   * rotate-in-place invalidates immediately, so the overlap lives on our side.
+   * The replacement rides the same validation + atomic commit as first mint,
+   * under the same exclusive run lease as provision (§10.2) — a live peer
+   * refuses and the next sweep retries. Only after commit is the previous
+   * provider token revoked (best-effort: it carries a finite expiry anyway).
+   */
+  async rotateDueCredentials(horizonMs: number): Promise<void> {
+    const due = await this.deps.credentials.listExpiring(new Date(this.deps.clock.now() + horizonMs))
+    const failedBindings = new Set<string>()
+    for (const { credential, orgId } of due) {
+      if (failedBindings.has(credential.bindingId)) continue
+      const binding = await this.deps.bindings.get(orgId, credential.bindingId)
+      if (!binding || binding.state === 'cleanup_pending') continue
+      if (!binding.installerConnectionId) {
+        failedBindings.add(binding.id)
+        await this.degrade(orgId, binding.id, 'admin_degraded', 'rotation_admin_unavailable')
+        continue
+      }
+      const owner = randomBytes(9).toString('base64url')
+      const nowMs = this.deps.clock.now()
+      const acquired = await this.deps.bindings.markProviderMutationStarted(
+        orgId,
+        binding.id,
+        binding.projectId,
+        owner,
+        new Date(nowMs + PROVISION_LEASE_MS),
+        new Date(nowMs)
+      )
+      if (!acquired) continue
+      try {
+        const token = await this.deps.oauth.withAccessToken(orgId, binding.installerConnectionId)
+        const project = (await gitlabProject(
+          token,
+          binding.projectId,
+          this.deps.fetchImpl
+        )) as GitlabProjectWithNamespace | null
+        if (!project?.namespace || binding.serviceAccountUserId === null) {
+          failedBindings.add(binding.id)
+          await this.degrade(orgId, binding.id, 'admin_degraded', 'rotation_identity_missing')
+          continue
+        }
+        const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
+        const previousTokenId = credential.externalTokenId
+        const serviceAccountUserId = binding.serviceAccountUserId
+        await this.mintCredential(orgId, binding, token, root.id, serviceAccountUserId, credential.purpose, owner)
+        await gitlabRevokeServiceAccountToken(
+          token,
+          root.id,
+          serviceAccountUserId,
+          previousTokenId,
+          this.deps.fetchImpl
+        ).catch(() => {
+          this.deps.log?.warn(
+            { bindingId: binding.id, purpose: credential.purpose },
+            'gitlab rotation could not revoke the previous token (it still expires on schedule)'
+          )
+        })
+      } catch (e) {
+        // The Console warns while administration is unavailable; runtime keeps
+        // working until the existing credential expires (§7.4).
+        failedBindings.add(binding.id)
+        const reason =
+          e instanceof GitlabClaimFenceLost
+            ? 'claim_fence_lost'
+            : e instanceof GitlabTokenPolicyViolation
+              ? 'out_of_policy_token'
+              : e instanceof GitlabApiError
+                ? `rotation_gitlab_${e.status || 'unreachable'}`
+                : 'rotation_admin_unavailable'
+        this.deps.log?.warn({ bindingId: binding.id, reason }, 'gitlab credential rotation failed')
+        await this.degrade(orgId, binding.id, 'admin_degraded', reason)
+      } finally {
+        await this.deps.bindings.endProviderMutation(orgId, binding.id, binding.projectId, owner).catch(() => {})
+      }
+    }
+  }
+
+  /**
    * §19.4 disconnect: local authority off first (epoch bump), then external
    * cleanup — webhook, PAT revocations, service account. Complete cleanup
    * removes the binding and releases the deployment-global claim; anything

--- a/packages/control-plane/src/gitlab/rotator.ts
+++ b/packages/control-plane/src/gitlab/rotator.ts
@@ -1,0 +1,48 @@
+/**
+ * Background PAT-rotation loop (gitlab-com-integration.md §7.4): sweeps
+ * credentials approaching their provider expiry and rotates each through the
+ * provisioner's create-before-revoke path. Built in the graph, armed only by
+ * `startBackground()` — never in tests, which drive `rotateDueCredentials`
+ * directly.
+ */
+import type { Clock, TimerHandle } from '../domain/clock.js'
+import type { GitlabProvisioner } from './provisioner.js'
+
+/** Rotate while this much lifetime remains — two weeks of admin-outage slack. */
+export const ROTATION_HORIZON_MS = 14 * 24 * 60 * 60 * 1000
+const FIRST_SWEEP_DELAY_MS = 5 * 60 * 1000
+const SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000
+
+export class GitlabCredentialRotator {
+  private timer: TimerHandle | null = null
+  private stopped = false
+
+  constructor(
+    private readonly deps: {
+      provisioner: GitlabProvisioner
+      clock: Clock
+      log?: { warn(obj: object, msg: string): void }
+    }
+  ) {}
+
+  start(): void {
+    this.stopped = false
+    this.arm(FIRST_SWEEP_DELAY_MS)
+  }
+
+  stop(): void {
+    this.stopped = true
+    if (this.timer !== null) this.deps.clock.clearTimeout(this.timer)
+    this.timer = null
+  }
+
+  private arm(delayMs: number): void {
+    if (this.stopped) return
+    this.timer = this.deps.clock.setTimeout(() => {
+      void this.deps.provisioner
+        .rotateDueCredentials(ROTATION_HORIZON_MS)
+        .catch((err) => this.deps.log?.warn({ err }, 'gitlab credential rotation sweep failed'))
+        .finally(() => this.arm(SWEEP_INTERVAL_MS))
+    }, delayMs)
+  }
+}

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3209,6 +3209,8 @@ export interface GitlabProjectCredentialRepo {
   }): Promise<GitlabProjectCredentialRecord>
   get(bindingId: string, purpose: GitlabCredentialPurpose): Promise<GitlabProjectCredentialRecord | null>
   listForBinding(bindingId: string): Promise<GitlabProjectCredentialRecord[]>
+  /** Rotation worklist (§7.4): credentials whose provider expiry is before the horizon. */
+  listExpiring(before: Date): Promise<Array<{ credential: GitlabProjectCredentialRecord; orgId: string }>>
   remove(bindingId: string, purpose: GitlabCredentialPurpose): Promise<void>
 }
 

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -544,6 +544,15 @@ export class PgGitlabProjectCredentialRepo implements GitlabProjectCredentialRep
     return rows.map((r) => this.toRecord(r))
   }
 
+  async listExpiring(before: Date): Promise<Array<{ credential: GitlabProjectCredentialRecord; orgId: string }>> {
+    const rows = await this.prisma.gitlabProjectCredential.findMany({
+      orderBy: { providerExpiresAt: 'asc' },
+      where: { providerExpiresAt: { lt: before } },
+      include: { binding: { select: { orgId: true } } }
+    })
+    return rows.map((row) => ({ credential: this.toRecord(row), orgId: row.binding.orgId }))
+  }
+
   async remove(bindingId: string, purpose: GitlabCredentialPurpose): Promise<void> {
     await this.prisma.gitlabProjectCredential.deleteMany({ where: { bindingId, purpose } })
   }

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -301,6 +301,86 @@ describe('GitlabProvisioner (§10.2)', () => {
     expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(0)
   })
 
+  it('rotates near-expiry credentials create-before-revoke; far ones untouched (§7.4)', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const creds = new PgGitlabProjectCredentialRepo(prisma)
+    const store = new PgGitlabProjectCredentialSecretStore(prisma, cipher)
+    const before = (await creds.get(h.binding.id, 'read'))!
+    const sealedBefore = await store.get(DEFAULT_ORG_ID, before.id)
+    // Only the read credential nears expiry; the other two stay far out.
+    await prisma.gitlabProjectCredential.update({
+      where: { id: before.id },
+      data: { providerExpiresAt: new Date(Date.now() + 3 * 86_400_000) }
+    })
+    await h.provisioner.rotateDueCredentials(14 * 86_400_000)
+    const after = (await creds.get(h.binding.id, 'read'))!
+    expect(after.generation).toBe(before.generation + 1n)
+    expect(after.externalTokenId).not.toBe(before.externalTokenId)
+    expect(await store.get(DEFAULT_ORG_ID, after.id)).not.toBe(sealedBefore)
+    // Create-before-revoke: the OLD provider token is revoked, the new one is not.
+    expect(h.fake.tokens.get(Number(before.externalTokenId))!.revoked).toBe(true)
+    expect(h.fake.tokens.get(Number(after.externalTokenId))!.revoked).toBe(false)
+    // The far-from-expiry credentials were not touched.
+    expect((await creds.get(h.binding.id, 'effect'))!.generation).toBe(1n)
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('ready')
+    // The run lease was released.
+    expect(
+      await h.bindings.markProviderMutationStarted(
+        DEFAULT_ORG_ID,
+        h.binding.id,
+        PROJECT,
+        'follow-up',
+        new Date(Date.now() + 600_000),
+        new Date()
+      )
+    ).toBe(true)
+  })
+
+  it('rotation without a working admin connection degrades and keeps the old credential (§7.4)', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const creds = new PgGitlabProjectCredentialRepo(prisma)
+    const before = (await creds.get(h.binding.id, 'read'))!
+    await prisma.gitlabProjectCredential.update({
+      where: { id: before.id },
+      data: { providerExpiresAt: new Date(Date.now() + 3 * 86_400_000) }
+    })
+    // The admin connection loses its pair (e.g. revoked): rotation cannot run.
+    await prisma.gitlabConnectionSecret.deleteMany({})
+    await h.provisioner.rotateDueCredentials(14 * 86_400_000)
+    const binding = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
+    expect(binding.state).toBe('admin_degraded')
+    // The existing credential is untouched — runtime continues until it expires.
+    expect((await creds.get(h.binding.id, 'read'))!.externalTokenId).toBe(before.externalTokenId)
+    expect(h.fake.tokens.get(Number(before.externalTokenId))!.revoked).toBe(false)
+  })
+
+  it('a live foreign run lease defers rotation to the next sweep (§10.2)', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const creds = new PgGitlabProjectCredentialRepo(prisma)
+    const before = (await creds.get(h.binding.id, 'read'))!
+    await prisma.gitlabProjectCredential.update({
+      where: { id: before.id },
+      data: { providerExpiresAt: new Date(Date.now() + 3 * 86_400_000) }
+    })
+    expect(
+      await h.bindings.markProviderMutationStarted(
+        DEFAULT_ORG_ID,
+        h.binding.id,
+        PROJECT,
+        'foreign-run',
+        new Date(Date.now() + 600_000),
+        new Date()
+      )
+    ).toBe(true)
+    await h.provisioner.rotateDueCredentials(14 * 86_400_000)
+    // Untouched and NOT degraded — the holder is presumed alive.
+    expect((await creds.get(h.binding.id, 'read'))!.externalTokenId).toBe(before.externalTokenId)
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('ready')
+  })
+
   it('incomplete cleanup keeps cleanup_pending and RETAINS the claim (§19.4)', async () => {
     const h = await harness({ failTokenRevoke: true })
     await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -75,7 +75,7 @@ async function harness(options: FakeGitlabOptions = {}, webhookEvents: GitlabWeb
     projectPath: 'example-group/example-project',
     installerConnectionId: connection.id
   })
-  return { fake, bindings, provisioner, binding }
+  return { fake, bindings, oauth, provisioner, binding }
 }
 
 describe('GitlabProvisioner (§10.2)', () => {
@@ -354,6 +354,63 @@ describe('GitlabProvisioner (§10.2)', () => {
     // The existing credential is untouched — runtime continues until it expires.
     expect((await creds.get(h.binding.id, 'read'))!.externalTokenId).toBe(before.externalTokenId)
     expect(h.fake.tokens.get(Number(before.externalTokenId))!.revoked).toBe(false)
+  })
+
+  it('revalidates the worklist under the lease: a peer-rotated credential is skipped untouched', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const creds = new PgGitlabProjectCredentialRepo(prisma)
+    const before = (await creds.get(h.binding.id, 'read'))!
+    // A stale pre-lease snapshot: generation 0 with a near expiry, while the
+    // DB row (a peer's committed rotation) is already current and far out.
+    const stale = {
+      credential: {
+        ...before,
+        generation: before.generation - 1n,
+        providerExpiresAt: new Date(Date.now() + 3 * 86_400_000)
+      },
+      orgId: DEFAULT_ORG_ID
+    }
+    const proxied = new GitlabProvisioner({
+      oauth: h.oauth,
+      bindings: h.bindings,
+      credentials: Object.assign(Object.create(creds), { listExpiring: async () => [stale] }),
+      credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, cipher),
+      webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
+      catalog: new PgCodeHostRepositoryRepo(prisma),
+      cipher,
+      clock: systemClock,
+      publicRelayUrl: 'https://relay.example.test',
+      desiredWebhookEvents: async () => null,
+      fetchImpl: h.fake.fetch()
+    })
+    const tokensBefore = h.fake.tokens.size
+    await proxied.rotateDueCredentials(14 * 86_400_000)
+    // Nothing minted, nothing revoked — the peer's current token stays tracked.
+    expect(h.fake.tokens.size).toBe(tokensBefore)
+    expect(h.fake.tokens.get(Number(before.externalTokenId))!.revoked).toBe(false)
+    expect((await creds.get(h.binding.id, 'read'))!.generation).toBe(before.generation)
+  })
+
+  it('a successful rotation heals a rotation-owned degradation', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const creds = new PgGitlabProjectCredentialRepo(prisma)
+    const before = (await creds.get(h.binding.id, 'read'))!
+    await prisma.gitlabProjectCredential.update({
+      where: { id: before.id },
+      data: { providerExpiresAt: new Date(Date.now() + 3 * 86_400_000) }
+    })
+    // A previous sweep's transient failure left the rotation-owned mark.
+    await prisma.gitlabProjectBinding.update({
+      where: { id: h.binding.id },
+      data: { state: 'admin_degraded', stateReason: 'rotation_gitlab_503' }
+    })
+    await h.provisioner.rotateDueCredentials(14 * 86_400_000)
+    const binding = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
+    expect(binding.state).toBe('ready')
+    expect(binding.stateReason).toBeNull()
+    expect((await creds.get(h.binding.id, 'read'))!.generation).toBe(before.generation + 1n)
   })
 
   it('a live foreign run lease defers rotation to the next sweep (§10.2)', async () => {


### PR DESCRIPTION
The M2 tail from [gitlab-com-integration.md](docs/designs/gitlab-com-integration.md) §7.4, after #1366: the PAT-rotation sweep.

## Create-before-revoke, under the run lease

GitLab's rotate-in-place API invalidates the old token immediately, so the overlap lives on our side: `rotateDueCredentials` mints the replacement through the SAME path as first mint — §7.3 fail-closed validation, then #1365's atomic commit (metadata + sealed value + the credential-epoch purge fence in one transaction) — and only then revokes the previous provider token by id (best-effort: it carries a finite expiry either way).

Each due binding first CAS-acquires the §10.2 exclusive run lease (`markProviderMutationStarted`, released in `finally`), so rotation can never interleave with a provisioning or cleanup run: a live foreign lease simply defers that binding to the next sweep, with no state overwrite.

## Degradation, not interruption (§7.4)

A rotation that cannot run — admin connection gone, identity missing, provider refusal, out-of-policy replacement — marks the binding `admin_degraded` with a specific reason for the console, and touches nothing else: the existing credential keeps working until its provider expiry.

## The loop

`GitlabCredentialRotator`: 14-day horizon, 6-hour sweep, first sweep 5 minutes after boot; built in the graph, armed only by `startBackground()` — tests drive `rotateDueCredentials` directly.

## Tests

Three new saga-suite cases: near-expiry rotation (generation advance, old token revoked, new one live, far credentials untouched, lease released), admin-unavailable degradation keeping the old credential, and a live foreign lease deferring untouched. Full CP: unit 1844/1844, integration suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
