### PR TITLE
feat(relay): verify and route GitLab project webhooks

### DIFF
--- a/packages/protocol/src/frames/hook.ts
+++ b/packages/protocol/src/frames/hook.ts
@@ -190,7 +190,7 @@ export type PublishedHookOutput = z.infer<typeof PublishedHookOutput>
  * (P2) are untrusted third-party content the daemon fences in the prompt.
  */
 export const HookContext = z.object({
-  source: z.enum(['webhook', 'github']),
+  source: z.enum(['webhook', 'github', 'gitlab']),
   // ── github (P2) ──
   event: z.string().optional(), // 'issues' | 'pull_request' | 'issue_comment'
   action: z.string().optional(), // 'opened' | 'synchronize' | 'created' | …

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -9,7 +9,7 @@ import {
 import { frameSchema } from '../envelope.js'
 import { ErrorFrame } from './error.js'
 import { WebchatDone, WebchatImageAttachment, WebchatOutput, WebchatPost } from './webchat.js'
-import { GithubHookMetadata, HookContext, OptionalHookConfigSnapshot } from './hook.js'
+import { GitlabHookMetadata, GithubHookMetadata, HookContext, OptionalHookConfigSnapshot } from './hook.js'
 import { CronTarget } from './cron.js'
 import { Platform } from './route.js'
 import { WebchatRemoteMcpEntitlement } from './remote-mcp.js'
@@ -408,6 +408,10 @@ export const RdMsgHook = z.object({
   // Signature-verified, rule-fenced metadata. Kept outside HookContext because
   // the latter contains model-visible, attacker-authored excerpts.
   github: GithubHookMetadata.optional(),
+  // GitLab counterpart (gitlab-com-integration.md §12.3): the daemon's trusted
+  // normalization discriminator. Optional member — an older daemon never sees
+  // it (dispatch is gated on the daemon advertising gitlab-com-v1).
+  gitlab: GitlabHookMetadata.optional(),
   context: HookContext.optional(), // trimmed envelope; message extraction/fencing happens on the daemon
   target: CronTarget.optional() // output anchoring; absent ⇒ headless
 })

--- a/packages/relay/src/hooks/gitlab-ingress.test.ts
+++ b/packages/relay/src/hooks/gitlab-ingress.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import { createHmac, randomBytes } from 'node:crypto'
+import { FakeClock } from '@agentconnect.md/connection'
+import {
+  GITLAB_COM_V1_FEATURE,
+  HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED,
+  type RcCodeHostMembershipAuthz,
+  type RcHookAssign,
+  type RcRunReport,
+  type RdAck,
+  type RdMsg,
+  type RdMsgHook
+} from '@agentconnect.md/protocol'
+import { HookTable } from './hook-table.js'
+import { HookRateLimiter } from './rate-limit.js'
+import { registerGitlabIngress, gitlabRuleVerdict, normalizeGitlabEvent } from './gitlab-ingress.js'
+
+const HOOK = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const HOOK_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const AGENT = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const DAEMON = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const PROJECT = 4455667
+const SA_USER = 9042
+const KEY = randomBytes(32)
+const TOKEN = `whsec_${KEY.toString('base64')}`
+
+const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+function rule(
+  overrides: Partial<RcHookAssign> = {},
+  gitlab: Partial<NonNullable<RcHookAssign['gitlab']>> = {}
+): RcHookAssign {
+  return {
+    hookId: HOOK,
+    kind: 'gitlab',
+    agentId: AGENT,
+    daemonId: DAEMON,
+    configRevision: '3',
+    dispatchRevision: '5',
+    dispatchDaemonId: DAEMON,
+    reviewPolicy: 'off',
+    reportingMode: 'off',
+    gateMode: 'informational',
+    sessionMode: 'perThread',
+    gitlab: {
+      projectId: String(PROJECT),
+      projectPath: 'example-group/example-project',
+      sessionKeyPrefix: `gitlab:${PROJECT}`,
+      events: ['issues:opened'],
+      labelFilter: [],
+      mentionOnly: false,
+      serviceAccountUserId: String(SA_USER),
+      serviceAccountUsername: `agentconnect-p${PROJECT}`,
+      signingToken: TOKEN,
+      ...gitlab
+    },
+    ...overrides
+  }
+}
+
+function issuePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    object_kind: 'issue',
+    user: { id: 7001, username: 'alice', avatar_url: 'https://gitlab.com/a.png' },
+    project: { id: PROJECT, path_with_namespace: 'example-group/example-project' },
+    object_attributes: {
+      iid: 42,
+      title: 'db down',
+      description: 'the primary is unreachable',
+      action: 'open',
+      author_id: 7001,
+      url: 'https://gitlab.com/example-group/example-project/-/issues/42',
+      ...((overrides.object_attributes as Record<string, unknown> | undefined) ?? {})
+    },
+    labels: [{ title: 'bug' }],
+    ...Object.fromEntries(Object.entries(overrides).filter(([k]) => k !== 'object_attributes'))
+  }
+}
+
+function mrPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    object_kind: 'merge_request',
+    user: { id: 7001, username: 'alice' },
+    project: { id: PROJECT, path_with_namespace: 'example-group/example-project' },
+    object_attributes: {
+      iid: 77,
+      title: 'tighten retry',
+      description: 'please review',
+      action: 'open',
+      author_id: 7001,
+      source_project_id: PROJECT,
+      target_project_id: PROJECT,
+      last_commit: { id: 'a'.repeat(40) },
+      draft: false,
+      url: 'https://gitlab.com/example-group/example-project/-/merge_requests/77',
+      ...((overrides.object_attributes as Record<string, unknown> | undefined) ?? {})
+    },
+    ...Object.fromEntries(Object.entries(overrides).filter(([k]) => k !== 'object_attributes'))
+  }
+}
+
+function notePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    object_kind: 'note',
+    user: { id: 7001, username: 'alice' },
+    project: { id: PROJECT, path_with_namespace: 'example-group/example-project' },
+    object_attributes: {
+      note: 'what is the rollout plan?',
+      noteable_type: 'Issue',
+      url: 'https://gitlab.com/example-group/example-project/-/issues/42#note_1',
+      ...((overrides.object_attributes as Record<string, unknown> | undefined) ?? {})
+    },
+    issue: { iid: 42, title: 'db down', labels: [{ title: 'bug' }], author_id: 7002 },
+    ...Object.fromEntries(Object.entries(overrides).filter(([k]) => k !== 'object_attributes'))
+  }
+}
+
+interface Harness {
+  app: FastifyInstance
+  table: HookTable
+  clock: FakeClock
+  sent: RdMsg[]
+  reports: RcRunReport[]
+  authzRequests: RcCodeHostMembershipAuthz[]
+  authzResult: boolean | ((request: RcCodeHostMembershipAuthz) => boolean | Promise<boolean>)
+  ack: RdAck
+  offline: boolean
+  gitlabSupported: boolean
+}
+
+function makeHarness(): Harness {
+  const clock = new FakeClock()
+  const h: Partial<Harness> & Pick<Harness, 'sent' | 'reports' | 'authzRequests'> = {
+    sent: [],
+    reports: [],
+    authzRequests: [],
+    authzResult: true,
+    ack: { msgId: 'x', accepted: true },
+    offline: false,
+    gitlabSupported: true
+  }
+  const app = Fastify()
+  const table = new HookTable()
+  registerGitlabIngress(app, {
+    table,
+    daemons: () => ({
+      get: () => {
+        if (h.offline) return undefined
+        return {
+          supports: (capability: string) => (capability === GITLAB_COM_V1_FEATURE ? h.gitlabSupported === true : true),
+          sendMsg: async (msg: RdMsg) => {
+            h.sent.push(msg)
+            return h.ack!
+          }
+        } as never
+      }
+    }),
+    report: (r) => h.reports.push(r),
+    authorizeMembership: async (request) => {
+      h.authzRequests.push(request)
+      return typeof h.authzResult === 'function' ? h.authzResult(request) : h.authzResult!
+    },
+    authzLimiter: new HookRateLimiter(clock, { capacity: 20, refillPerSec: 0 }),
+    limiter: new HookRateLimiter(clock, { capacity: 5, refillPerSec: 0 }),
+    clock,
+    log
+  })
+  h.app = app
+  h.table = table
+  h.clock = clock
+  return h as Harness
+}
+
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0))
+}
+
+function post(h: Harness, payload: Record<string, unknown>, overrides: Record<string, string | undefined> = {}) {
+  const body = JSON.stringify(payload)
+  const ts = String(Math.floor(h.clock.now() / 1000))
+  const id = overrides['webhook-id'] ?? 'msg_delivery_1'
+  const signature =
+    overrides['webhook-signature'] ?? `v1,${createHmac('sha256', KEY).update(`${id}.${ts}.${body}`).digest('base64')}`
+  return h.app.inject({
+    method: 'POST',
+    url: '/webhooks/gitlab',
+    headers: {
+      'content-type': 'application/json',
+      'webhook-id': id,
+      'webhook-timestamp': overrides['webhook-timestamp'] ?? ts,
+      'webhook-signature': signature
+    },
+    payload: body
+  })
+}
+
+describe('gitlab ingress', () => {
+  let h: Harness
+  beforeEach(() => {
+    h = makeHarness()
+  })
+  afterEach(async () => {
+    await h.app.close()
+  })
+
+  it('verified issue open → membership authz → dispatch with the §12.3 key and trusted metadata', async () => {
+    h.table.upsert(rule())
+    const res = await post(h, issuePayload())
+    expect(res.statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toEqual([
+      expect.objectContaining({
+        provider: 'gitlab',
+        repoExternalId: String(PROJECT),
+        actorExternalId: '7001',
+        configRevision: '3',
+        dispatchRevision: '5'
+      })
+    ])
+    expect(h.sent).toHaveLength(1)
+    const msg = h.sent[0] as RdMsgHook
+    expect(msg.sessionKey).toBe(`gitlab:${PROJECT}:issue:42`)
+    expect(msg.msgId).toBe(`${HOOK}:msg_delivery_1`)
+    expect(msg.event).toBe('issues:opened')
+    expect(msg.gitlab).toEqual({
+      projectId: String(PROJECT),
+      projectPath: 'example-group/example-project',
+      target: { kind: 'issue', iid: 42 }
+    })
+    expect(msg.context?.source).toBe('gitlab')
+    expect(msg.context?.bodyExcerpt).toBe('the primary is unreachable')
+    expect(h.reports.map((r) => r.status)).toEqual(['accepted'])
+  })
+
+  it('uniform 404: bad signature, stale timestamp, unknown project, malformed body, missing headers', async () => {
+    h.table.upsert(rule())
+    const bad = await post(h, issuePayload(), { 'webhook-signature': `v1,${'x'.repeat(43)}=` })
+    expect(bad.statusCode).toBe(404)
+    const stale = await post(h, issuePayload(), { 'webhook-timestamp': '100' })
+    expect(stale.statusCode).toBe(404)
+    const unknown = await post(h, issuePayload({ project: { id: 999 } }))
+    expect(unknown.statusCode).toBe(404)
+    const malformed = await h.app.inject({
+      method: 'POST',
+      url: '/webhooks/gitlab',
+      headers: { 'content-type': 'application/json' },
+      payload: 'not-json'
+    })
+    expect(malformed.statusCode).toBe(404)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+  })
+
+  it('membership denial skips silently for issues; nothing reaches the daemon', async () => {
+    h.authzResult = false
+    h.table.upsert(rule())
+    expect((await post(h, issuePayload())).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    expect(h.reports).toHaveLength(0)
+  })
+
+  it('a denied MR revision leaves the durable review-request-required row (§12.2)', async () => {
+    h.authzResult = false
+    h.table.upsert(rule({}, { events: ['merge_request:*'] }))
+    const external = mrPayload({
+      object_attributes: { author_id: 7999, source_project_id: 12345 },
+      user: { id: 7999, username: 'mallory' }
+    })
+    expect((await post(h, external)).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    expect(h.reports).toEqual([
+      expect.objectContaining({ status: 'failed', reason: HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED })
+    ])
+  })
+
+  it('§12.1: service-account-authored events are vetoed, except its own same-project MR revision', async () => {
+    h.table.upsert(rule({}, { events: ['issues:opened', 'merge_request:*'] }))
+    const saIssue = issuePayload({ user: { id: SA_USER, username: `agentconnect-p${PROJECT}` } })
+    expect((await post(h, saIssue)).statusCode).toBe(202)
+    const saNote = notePayload({ user: { id: SA_USER, username: `agentconnect-p${PROJECT}` } })
+    expect((await post(h, saNote)).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+
+    // The internal CI lane: same-project revision authored by the SA is
+    // TRUSTED — no membership call, straight to dispatch.
+    const internal = mrPayload({
+      object_attributes: { action: 'update', oldrev: 'c'.repeat(40), author_id: SA_USER },
+      user: { id: SA_USER, username: `agentconnect-p${PROJECT}` }
+    })
+    expect((await post(h, internal)).statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toHaveLength(0)
+    expect(h.sent).toHaveLength(1)
+    expect((h.sent[0] as RdMsgHook).event).toBe('merge_request:synchronize')
+  })
+
+  it('assigning the service account as reviewer is the explicit start path', async () => {
+    h.table.upsert(rule({}, { events: ['merge_request:opened'] }))
+    const assigned = mrPayload({
+      object_attributes: { action: 'update' },
+      changes: { reviewers: { previous: [], current: [{ id: SA_USER }] } }
+    })
+    expect((await post(h, assigned)).statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toHaveLength(1)
+    // The assigning ACTOR is authorized, not the MR author.
+    expect(h.authzRequests[0]?.actorExternalId).toBe('7001')
+    expect(h.sent).toHaveLength(1)
+    const msg = h.sent[0] as RdMsgHook
+    expect(msg.event).toBe('merge_request:review_requested')
+    expect(msg.gitlab?.target).toMatchObject({ kind: 'merge_request', iid: 77, explicitReviewRequest: true })
+  })
+
+  it('push is relay-trusted, matches only push:*, and keys the session by ref', async () => {
+    h.table.upsert(rule({}, { events: ['push:*'] }))
+    h.table.upsert(rule({ hookId: HOOK_B }, { events: ['issues:opened'] }))
+    const push = {
+      object_kind: 'push',
+      ref: 'refs/heads/main',
+      user_id: 7001,
+      user_username: 'alice',
+      project: { id: PROJECT, path_with_namespace: 'example-group/example-project' },
+      project_id: PROJECT,
+      commits: [{ message: 'fix: retry' }]
+    }
+    expect((await post(h, push)).statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toHaveLength(0)
+    expect(h.sent).toHaveLength(1)
+    const msg = h.sent[0] as RdMsgHook
+    expect(msg.hookId).toBe(HOOK)
+    expect(msg.sessionKey).toBe(`gitlab:${PROJECT}:push:refs/heads/main`)
+    expect(msg.gitlab?.target).toEqual({ kind: 'push', ref: 'refs/heads/main' })
+  })
+
+  it('merged MRs and closed issues fan out as maintenance cleanup, bypassing the actor gate', async () => {
+    h.authzResult = false // the gate would deny — cleanup must not care
+    h.table.upsert(rule({}, { events: ['merge_request:*'] }))
+    const merged = mrPayload({ object_attributes: { action: 'merge', state: 'merged' } })
+    expect((await post(h, merged)).statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toHaveLength(0)
+    expect(h.sent).toHaveLength(1)
+    expect((h.sent[0] as RdMsgHook).event).toBe('merge_request:merged')
+    expect((h.sent[0] as RdMsgHook).sessionKey).toBe(`gitlab:${PROJECT}:merge_request:77`)
+  })
+
+  it('comment families scope notes; a summon narrows the fan-out to the mentioned agent', async () => {
+    h.table.upsert(rule({}, { commentFamilies: ['issues'], agentName: 'oncall' }))
+    h.table.upsert(rule({ hookId: HOOK_B, agentId: 'ffffffff-ffff-4fff-8fff-ffffffffffff' }, { agentName: 'deploy' }))
+    // HOOK matches via its selected family; HOOK_B has no families and no summon.
+    expect((await post(h, notePayload())).statusCode).toBe(202)
+    await flush()
+    expect(h.sent.map((m) => (m as RdMsgHook).hookId)).toEqual([HOOK])
+
+    h.sent.length = 0
+    h.authzRequests.length = 0
+    // An @mention of one agent name narrows a would-be fan-out.
+    const mention = notePayload({ object_attributes: { note: '@oncall please look' } })
+    expect((await post(h, mention, { 'webhook-id': 'msg_delivery_2' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent.map((m) => (m as RdMsgHook).hookId)).toEqual([HOOK])
+    // The summoned path authorizes the commenter only.
+    expect(h.authzRequests[0]?.subjectAuthorExternalId).toBeUndefined()
+  })
+
+  it('an unmentioned continuation also fences the subject author (§12.2)', async () => {
+    h.table.upsert(rule({}, { commentFamilies: ['issues'] }))
+    expect((await post(h, notePayload())).statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toEqual([
+      expect.objectContaining({ actorExternalId: '7001', subjectAuthorExternalId: '7002' })
+    ])
+  })
+
+  it('mention-only rules stay silent without a summon', async () => {
+    h.table.upsert(rule({}, { mentionOnly: true, commentFamilies: ['issues'], agentName: 'oncall' }))
+    expect((await post(h, notePayload())).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    const summoned = notePayload({ object_attributes: { note: `@agentconnect-p${PROJECT} plan?` } })
+    expect((await post(h, summoned, { 'webhook-id': 'msg_delivery_2' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(1)
+  })
+
+  it('a daemon without gitlab-com-v1 fails the dispatch closed', async () => {
+    h.gitlabSupported = false
+    h.table.upsert(rule({}, { events: ['push:*'] }))
+    const push = {
+      object_kind: 'push',
+      ref: 'refs/heads/main',
+      user_id: 7001,
+      project: { id: PROJECT, path_with_namespace: 'example-group/example-project' }
+    }
+    expect((await post(h, push)).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    expect(h.reports).toEqual([expect.objectContaining({ status: 'failed', reason: 'rejected:unsupported' })])
+  })
+
+  it('lifecycle noise never fires: edits, reopens, unmerged closes, draft toggles', async () => {
+    h.table.upsert(rule({}, { events: ['issues:*', 'merge_request:*'] }))
+    expect(normalizeGitlabEvent(issuePayload({ object_attributes: { action: 'update' } }) as never)).toBeUndefined()
+    expect(normalizeGitlabEvent(issuePayload({ object_attributes: { action: 'reopen' } }) as never)).toBeUndefined()
+    expect(normalizeGitlabEvent(mrPayload({ object_attributes: { action: 'close' } }) as never)).toBeUndefined()
+    expect(
+      normalizeGitlabEvent(
+        mrPayload({
+          object_attributes: { action: 'update' },
+          changes: { draft: { previous: true, current: false } }
+        }) as never
+      )
+    ).toBeUndefined()
+    // System notes are never turns.
+    expect(normalizeGitlabEvent(notePayload({ object_attributes: { system: true } }) as never)).toBeUndefined()
+  })
+
+  it('verdict is pure: label filter and event patterns gate before authz', async () => {
+    const ctx = normalizeGitlabEvent(issuePayload() as never)!
+    expect(gitlabRuleVerdict(rule({}, { labelFilter: ['bug'] }), ctx)).toBe('needs-authz')
+    expect(gitlabRuleVerdict(rule({}, { labelFilter: ['ops'] }), ctx)).toBe('no-match')
+    expect(gitlabRuleVerdict(rule({}, { events: ['merge_request:*'] }), ctx)).toBe('no-match')
+    expect(gitlabRuleVerdict(rule({ kind: 'github' }), ctx)).toBe('no-match')
+  })
+})

--- a/packages/relay/src/hooks/gitlab-ingress.test.ts
+++ b/packages/relay/src/hooks/gitlab-ingress.test.ts
@@ -301,14 +301,16 @@ describe('gitlab ingress', () => {
   it('assigning the service account as reviewer is the explicit start path', async () => {
     h.table.upsert(rule({}, { events: ['merge_request:opened'] }))
     const assigned = mrPayload({
-      object_attributes: { action: 'update' },
+      object_attributes: { action: 'update', author_id: 7999 },
+      user: { id: 7005, username: 'maintainer' },
       changes: { reviewers: { previous: [], current: [{ id: SA_USER }] } }
     })
     expect((await post(h, assigned)).statusCode).toBe(202)
     await flush()
     expect(h.authzRequests).toHaveLength(1)
-    // The assigning ACTOR is authorized, not the MR author.
-    expect(h.authzRequests[0]?.actorExternalId).toBe('7001')
+    // The ASSIGNING actor is authorized — never the (untrusted) MR author.
+    expect(h.authzRequests[0]?.actorExternalId).toBe('7005')
+    expect(h.authzRequests[0]?.subjectAuthorExternalId).toBeUndefined()
     expect(h.sent).toHaveLength(1)
     const msg = h.sent[0] as RdMsgHook
     expect(msg.event).toBe('merge_request:review_requested')
@@ -416,8 +418,38 @@ describe('gitlab ingress', () => {
         }) as never
       )
     ).toBeUndefined()
-    // System notes are never turns.
+    // System notes are never turns, and neither are comment EDITS (§12 veto):
+    // a Note Hook update arrives with a fresh webhook-id and must not open a
+    // duplicate turn. An absent action keeps meaning creation.
     expect(normalizeGitlabEvent(notePayload({ object_attributes: { system: true } }) as never)).toBeUndefined()
+    expect(normalizeGitlabEvent(notePayload({ object_attributes: { action: 'update' } }) as never)).toBeUndefined()
+    expect(normalizeGitlabEvent(notePayload({ object_attributes: { action: 'create' } }) as never)).toBeDefined()
+    expect(normalizeGitlabEvent(notePayload() as never)).toBeDefined()
+  })
+
+  it('a native reviewer RE-request (same reviewer, re_requested flag) is a start path too', async () => {
+    h.table.upsert(rule({}, { events: ['merge_request:opened'] }))
+    const rerequested = mrPayload({
+      object_attributes: { action: 'update', author_id: 7999 },
+      user: { id: 7005, username: 'maintainer' },
+      changes: {
+        reviewers: { previous: [{ id: SA_USER }], current: [{ id: SA_USER, re_requested: true }] }
+      }
+    })
+    expect((await post(h, rerequested)).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(1)
+    expect((h.sent[0] as RdMsgHook).event).toBe('merge_request:review_requested')
+    // An unchanged reviewer set WITHOUT the flag (e.g. a submitted-review state
+    // change) stays inert.
+    h.sent.length = 0
+    const inert = mrPayload({
+      object_attributes: { action: 'update', author_id: 7999 },
+      changes: { reviewers: { previous: [{ id: SA_USER }], current: [{ id: SA_USER }] } }
+    })
+    expect((await post(h, inert, { 'webhook-id': 'msg_delivery_2' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
   })
 
   it('verdict is pure: label filter and event patterns gate before authz', async () => {

--- a/packages/relay/src/hooks/gitlab-ingress.ts
+++ b/packages/relay/src/hooks/gitlab-ingress.ts
@@ -81,7 +81,10 @@ interface GitlabPayload {
   labels?: Array<{ title?: string }>
   changes?: {
     labels?: { previous?: unknown[]; current?: unknown[] }
-    reviewers?: { previous?: Array<{ id?: number }>; current?: Array<{ id?: number }> }
+    reviewers?: {
+      previous?: Array<{ id?: number }>
+      current?: Array<{ id?: number; re_requested?: boolean }>
+    }
     draft?: { previous?: boolean; current?: boolean }
     work_in_progress?: { previous?: boolean; current?: boolean }
   }
@@ -202,10 +205,16 @@ export function normalizeGitlabEvent(payload: GitlabPayload): GitlabMatchCtx | u
         return {
           ...base,
           eventAction: 'merge_request:review_requested',
+          // A request is a NEWLY ADDED reviewer, or a native re-request — which
+          // keeps the reviewer in both arrays and flags the current entry with
+          // `re_requested: true`. Ordinary submitted-review state changes carry
+          // neither and stay inert.
           serviceAccountReviewerRequested: (serviceAccountUserId) =>
             currentReviewers.some(
               (reviewer) =>
-                reviewer.id !== undefined && String(reviewer.id) === serviceAccountUserId && !previous.has(reviewer.id)
+                reviewer.id !== undefined &&
+                String(reviewer.id) === serviceAccountUserId &&
+                (!previous.has(reviewer.id) || reviewer.re_requested === true)
             )
         }
       }
@@ -217,6 +226,10 @@ export function normalizeGitlabEvent(payload: GitlabPayload): GitlabMatchCtx | u
   }
   if (kind === 'note') {
     if (!attrs || attrs.system === true) return undefined
+    // §12 edit veto: GitLab Note Hooks also fire on comment EDITS with
+    // action 'update' and a fresh webhook-id — never a new turn. Absent action
+    // (legacy payloads) keeps meaning creation.
+    if (attrs.action !== undefined && attrs.action !== 'create') return undefined
     const subject = payload.issue ?? payload.merge_request
     const family = payload.issue ? ('issues' as const) : payload.merge_request ? ('merge_request' as const) : undefined
     if (!subject || subject.iid === undefined || !family) return undefined
@@ -560,8 +573,15 @@ export function registerGitlabIngress(app: FastifyInstance, deps: GitlabIngressD
       // revision event leaves a durable, actionable run row instead.
       const isLifecycle = ctx.family === 'issues' || ctx.family === 'merge_request'
       // Lifecycle events authorize the subject author; comments authorize the
-      // commenter, plus the subject author on unmentioned thread continuation.
-      const actorId = isLifecycle ? (ctx.subjectAuthorId ?? ctx.actorId) : ctx.actorId
+      // commenter. A reviewer request/re-request instead authorizes the
+      // ASSIGNING actor — the MR author is deliberately untrusted on the
+      // explicit external start path (§12.2).
+      const actorId =
+        ctx.eventAction === 'merge_request:review_requested'
+          ? ctx.actorId
+          : isLifecycle
+            ? (ctx.subjectAuthorId ?? ctx.actorId)
+            : ctx.actorId
       // Only a denied MR REVISION leaves the durable actionable row (§12.2) —
       // the same two events GitHub treats as first-review material.
       const onDenied: 'skip' | 'request-review' =

--- a/packages/relay/src/hooks/gitlab-ingress.ts
+++ b/packages/relay/src/hooks/gitlab-ingress.ts
@@ -1,0 +1,669 @@
+/**
+ * GitLab ingress — `POST /webhooks/gitlab`, the relay's project-webhook
+ * endpoint (gitlab-com-integration.md §11.2, §12). Verification is per-rule:
+ * the compiled rule carries the project's `whsec_` signing token inline, so the
+ * bounded first parse only extracts the numeric project id, the Standard
+ * Webhooks signature is checked against the matching rules' token, and only
+ * then is the payload trusted as filter input. Uniform 404 for invalid
+ * signatures, stale timestamps, unknown projects, and malformed bodies — no
+ * connected-project oracle. Verified unmatched deliveries answer 202.
+ *
+ * The payload is NEVER logged; rules carry secret material.
+ */
+import type { FastifyInstance, FastifyReply } from 'fastify'
+import type { Clock } from '@agentconnect.md/connection'
+import {
+  HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED,
+  type GitlabHookMetadata,
+  type GitlabHookTarget,
+  type HookContext,
+  type RcCodeHostMembershipAuthz,
+  type RcHookAssign,
+  type RcRunReport,
+  type RdMsgHook
+} from '@agentconnect.md/protocol'
+import type { RelayDaemonServer } from '../relay-daemon-server.js'
+import type { HookTable } from './hook-table.js'
+import type { HookRateLimiter } from './rate-limit.js'
+import { dispatchHookFire } from './ingress.js'
+import { hookSnapshotForDelivery } from './hook-snapshot.js'
+import { mentionsGithubHandle, truncateUtf8, GITHUB_BODY_EXCERPT_MAX } from './github-ingress.js'
+import { verifyStandardWebhook } from './standard-webhooks.js'
+import type { Logger } from '../log.js'
+
+/** Raw-body cap (§11.2: 1 MiB). */
+export const GITLAB_BODY_LIMIT = 1024 * 1024
+
+export interface GitlabIngressDeps {
+  table: HookTable
+  /** Late-bound: the rd/* server exists only after `listen()` (routes register before). */
+  daemons: () => Pick<RelayDaemonServer, 'get'> | undefined
+  /** Emit one delivery-stage `rc/run-report` EVT to the CP (fire-and-forget). */
+  report: (report: RcRunReport) => void
+  /** §12.2 live effective-membership gate — metadata only, resolved by the CP. */
+  authorizeMembership: (request: RcCodeHostMembershipAuthz) => Promise<boolean>
+  /** Dedicated upstream-call budget, shared by every hook on one project. */
+  authzLimiter: HookRateLimiter
+  limiter: HookRateLimiter
+  clock: Clock
+  log: Logger
+}
+
+/** The slice of a GitLab webhook payload the matcher/envelope reads. Everything
+ *  here is UNTRUSTED except as filter input; authorization is the signature
+ *  plus the CP's live membership resolution (§12.2). */
+interface GitlabPayload {
+  object_kind?: string
+  event_type?: string
+  user?: { id?: number; username?: string; name?: string; avatar_url?: string }
+  project?: { id?: number; path_with_namespace?: string; web_url?: string }
+  project_id?: number
+  object_attributes?: {
+    iid?: number
+    title?: string
+    description?: string | null
+    note?: string
+    noteable_type?: string
+    system?: boolean
+    position?: unknown
+    action?: string
+    state?: string
+    oldrev?: string
+    url?: string
+    author_id?: number
+    source_project_id?: number
+    target_project_id?: number
+    last_commit?: { id?: string }
+    draft?: boolean
+    work_in_progress?: boolean
+    labels?: Array<{ title?: string }>
+  }
+  labels?: Array<{ title?: string }>
+  changes?: {
+    labels?: { previous?: unknown[]; current?: unknown[] }
+    reviewers?: { previous?: Array<{ id?: number }>; current?: Array<{ id?: number }> }
+    draft?: { previous?: boolean; current?: boolean }
+    work_in_progress?: { previous?: boolean; current?: boolean }
+  }
+  issue?: { iid?: number; title?: string; labels?: Array<{ title?: string }>; author_id?: number }
+  merge_request?: {
+    iid?: number
+    title?: string
+    labels?: Array<{ title?: string }>
+    author_id?: number
+    source_project_id?: number
+    target_project_id?: number
+    last_commit?: { id?: string }
+    draft?: boolean
+    work_in_progress?: boolean
+  }
+  // Push Hook
+  ref?: string
+  checkout_sha?: string | null
+  user_id?: number
+  user_username?: string
+  commits?: Array<{ message?: string | null }>
+}
+
+/** One delivery's normalized facts (extracted once; pure filter input). */
+export interface GitlabMatchCtx {
+  /** Normalized `family:action` (or bare `push`) — the stored-pattern universe. */
+  eventAction: string
+  family: 'issues' | 'merge_request' | 'push' | 'note'
+  /** Comment deliveries: the subject family the note hangs off. */
+  commentSubjectFamily?: 'issues' | 'merge_request'
+  actorId?: string
+  subjectAuthorId?: string
+  labels: string[]
+  mentionText: string | undefined
+  /** MR facts (loop prevention + §12.2 external gate + metadata). */
+  sourceProjectId?: string
+  targetProjectId?: string
+  /** §12.2 explicit start path: the SA was just assigned as reviewer. */
+  serviceAccountReviewerRequested?: (serviceAccountUserId: string) => boolean
+  /** True when GitLab marked the note as system-generated. */
+  systemNote?: boolean
+  hasDiffPosition?: boolean
+  iid?: number
+  ref?: string
+}
+
+/** Lifecycle deliveries that close a GitLab thread's daemon-owned workspace
+ *  (§12): merged MRs and closed issues; an unmerged closed MR may reopen. */
+function gitlabThreadWorktreeCleanupEvent(payload: GitlabPayload): string | undefined {
+  const attrs = payload.object_attributes
+  if (!attrs) return undefined
+  if (payload.object_kind === 'issue' && attrs.action === 'close') return 'issues:closed'
+  if (payload.object_kind === 'merge_request' && attrs.action === 'merge') return 'merge_request:merged'
+  return undefined
+}
+
+/** Normalize one verified payload to the stored-pattern event universe, or
+ *  undefined when the delivery is lifecycle noise (§12 vetoes). Exported for
+ *  unit tests. */
+export function normalizeGitlabEvent(payload: GitlabPayload): GitlabMatchCtx | undefined {
+  const attrs = payload.object_attributes
+  const kind = payload.object_kind
+  if (kind === 'push') {
+    if (!payload.ref) return undefined
+    return {
+      eventAction: 'push',
+      family: 'push',
+      ...(payload.user_id !== undefined ? { actorId: String(payload.user_id) } : {}),
+      labels: [],
+      mentionText:
+        (payload.commits ?? [])
+          .map((commit) => commit.message)
+          .filter(Boolean)
+          .join('\n') || undefined,
+      ref: payload.ref
+    }
+  }
+  if (kind === 'issue') {
+    if (!attrs || attrs.iid === undefined) return undefined
+    const labels = (payload.labels ?? attrs.labels ?? []).map((label) => label.title ?? '').filter(Boolean)
+    const base = {
+      family: 'issues' as const,
+      ...(payload.user?.id !== undefined ? { actorId: String(payload.user.id) } : {}),
+      ...(attrs.author_id !== undefined ? { subjectAuthorId: String(attrs.author_id) } : {}),
+      labels,
+      mentionText: attrs.description ?? undefined,
+      iid: attrs.iid
+    }
+    if (attrs.action === 'open') return { ...base, eventAction: 'issues:opened' }
+    // Label changes are the one substantive `update`; edit/close/reopen are
+    // lifecycle noise (close fires separately as maintenance cleanup).
+    if (attrs.action === 'update' && payload.changes?.labels) return { ...base, eventAction: 'issues:labeled' }
+    return undefined
+  }
+  if (kind === 'merge_request') {
+    if (!attrs || attrs.iid === undefined) return undefined
+    const labels = (payload.labels ?? attrs.labels ?? []).map((label) => label.title ?? '').filter(Boolean)
+    const base = {
+      family: 'merge_request' as const,
+      ...(payload.user?.id !== undefined ? { actorId: String(payload.user.id) } : {}),
+      ...(attrs.author_id !== undefined ? { subjectAuthorId: String(attrs.author_id) } : {}),
+      labels,
+      mentionText: attrs.description ?? undefined,
+      ...(attrs.source_project_id !== undefined ? { sourceProjectId: String(attrs.source_project_id) } : {}),
+      ...(attrs.target_project_id !== undefined ? { targetProjectId: String(attrs.target_project_id) } : {}),
+      iid: attrs.iid
+    }
+    if (attrs.action === 'open') return { ...base, eventAction: 'merge_request:opened' }
+    if (attrs.action === 'update') {
+      // Draft/ready toggles are lifecycle noise even when they ride an update.
+      if (payload.changes?.draft || payload.changes?.work_in_progress) return undefined
+      // New source commits normalize to the existing revision event.
+      if (attrs.oldrev) return { ...base, eventAction: 'merge_request:synchronize' }
+      if (payload.changes?.labels) return { ...base, eventAction: 'merge_request:labeled' }
+      const currentReviewers = payload.changes?.reviewers?.current
+      if (currentReviewers) {
+        const previous = new Set((payload.changes?.reviewers?.previous ?? []).map((reviewer) => reviewer.id))
+        return {
+          ...base,
+          eventAction: 'merge_request:review_requested',
+          serviceAccountReviewerRequested: (serviceAccountUserId) =>
+            currentReviewers.some(
+              (reviewer) =>
+                reviewer.id !== undefined && String(reviewer.id) === serviceAccountUserId && !previous.has(reviewer.id)
+            )
+        }
+      }
+      return undefined
+    }
+    // close (unmerged), reopen, approve/unapprove, merge → not new turns here
+    // (merge fires separately as maintenance cleanup).
+    return undefined
+  }
+  if (kind === 'note') {
+    if (!attrs || attrs.system === true) return undefined
+    const subject = payload.issue ?? payload.merge_request
+    const family = payload.issue ? ('issues' as const) : payload.merge_request ? ('merge_request' as const) : undefined
+    if (!subject || subject.iid === undefined || !family) return undefined
+    return {
+      eventAction: 'note:created',
+      family: 'note',
+      commentSubjectFamily: family,
+      ...(payload.user?.id !== undefined ? { actorId: String(payload.user.id) } : {}),
+      ...(subject.author_id !== undefined ? { subjectAuthorId: String(subject.author_id) } : {}),
+      labels: (subject.labels ?? []).map((label) => label.title ?? '').filter(Boolean),
+      mentionText: attrs.note ?? undefined,
+      ...(payload.merge_request?.source_project_id !== undefined
+        ? { sourceProjectId: String(payload.merge_request.source_project_id) }
+        : {}),
+      ...(payload.merge_request?.target_project_id !== undefined
+        ? { targetProjectId: String(payload.merge_request.target_project_id) }
+        : {}),
+      systemNote: false,
+      hasDiffPosition: attrs.position != null,
+      iid: subject.iid
+    }
+  }
+  return undefined
+}
+
+function gitlabRuleIsSummoned(rule: RcHookAssign, ctx: GitlabMatchCtx): boolean {
+  return (
+    mentionsGithubHandle(ctx.mentionText, rule.gitlab?.serviceAccountUsername) ||
+    mentionsGithubHandle(ctx.mentionText, rule.gitlab?.agentName)
+  )
+}
+
+/** Explicit agent handles narrow a project fan-out; the service-account handle
+ *  is the broadcast form (the GitLab analog of the App slug). */
+export function gitlabMentionCandidates(rules: RcHookAssign[], body: string | undefined): RcHookAssign[] {
+  if (rules.some((rule) => mentionsGithubHandle(body, rule.gitlab?.serviceAccountUsername))) return rules
+  const targeted = new Set(
+    rules.filter((rule) => mentionsGithubHandle(body, rule.gitlab?.agentName)).map((rule) => rule.agentId)
+  )
+  return targeted.size === 0 ? rules : rules.filter((rule) => targeted.has(rule.agentId))
+}
+
+export type GitlabRuleVerdict = 'no-match' | 'trusted' | 'needs-authz'
+
+/** The §12.1 internal lane: a same-project MR revision authored by the managed
+ *  service account still enters review; everything else it authors is vetoed. */
+function isInternalServiceAccountRevision(rule: RcHookAssign, ctx: GitlabMatchCtx): boolean {
+  return (
+    (ctx.eventAction === 'merge_request:opened' || ctx.eventAction === 'merge_request:synchronize') &&
+    ctx.subjectAuthorId !== undefined &&
+    ctx.subjectAuthorId === rule.gitlab?.serviceAccountUserId &&
+    ctx.sourceProjectId !== undefined &&
+    ctx.sourceProjectId === ctx.targetProjectId
+  )
+}
+
+/**
+ * One rule's verdict for one verified delivery (pure; exported for unit tests).
+ * Order: loop-prevention veto → reviewer-request path → cadence/additive summon
+ * match → comment scope → mention-only gate → labels → live-authz classification.
+ */
+export function gitlabRuleVerdict(rule: RcHookAssign, ctx: GitlabMatchCtx): GitlabRuleVerdict {
+  if (rule.kind !== 'gitlab' || !rule.gitlab) return 'no-match'
+  // §12.1: events authored BY the managed service account never re-trigger,
+  // except its own same-project MR revisions (the internal CI lane). Notes it
+  // authors are always rejected (the note author IS the actor).
+  const actorIsServiceAccount = ctx.actorId !== undefined && ctx.actorId === rule.gitlab.serviceAccountUserId
+  if (actorIsServiceAccount && !isInternalServiceAccountRevision(rule, ctx)) return 'no-match'
+  if (ctx.family === 'note' && actorIsServiceAccount) return 'no-match'
+  // §12.2 explicit start path: assigning the SA as reviewer bypasses cadence,
+  // label, and mention filters — but only for this rule's SA, and only after
+  // the live membership gate authorizes the assigning actor.
+  if (ctx.eventAction === 'merge_request:review_requested') {
+    const supportsMr =
+      rule.gitlab.events.some((event) => event.startsWith('merge_request:')) ||
+      (rule.gitlab.commentFamilies ?? []).includes('merge_request')
+    return ctx.serviceAccountReviewerRequested?.(rule.gitlab.serviceAccountUserId) && supportsMr
+      ? 'needs-authz'
+      : 'no-match'
+  }
+  const action = ctx.eventAction.includes(':') ? ctx.eventAction.slice(ctx.eventAction.indexOf(':')) : ''
+  const matchesPattern = (family: string): boolean =>
+    (action !== '' && rule.gitlab!.events.includes(`${family}${action}`)) || rule.gitlab!.events.includes(`${family}:*`)
+  const summoned = gitlabRuleIsSummoned(rule, ctx)
+  let eventMatched: boolean
+  if (ctx.family === 'note') {
+    // Comments are scoped by the console-selected families; a summon in a
+    // created-cadence thread family fires additively (§12).
+    const families = rule.gitlab.commentFamilies ?? []
+    const familySelected = ctx.commentSubjectFamily !== undefined && families.includes(ctx.commentSubjectFamily)
+    const createdCadenceSummon =
+      summoned &&
+      ctx.commentSubjectFamily !== undefined &&
+      rule.gitlab.events.includes(`${ctx.commentSubjectFamily}:opened`)
+    eventMatched = familySelected || createdCadenceSummon
+  } else {
+    const createdCadenceSummon =
+      summoned &&
+      (ctx.family === 'issues' || ctx.family === 'merge_request') &&
+      rule.gitlab.events.includes(`${ctx.family}:opened`)
+    eventMatched = matchesPattern(ctx.family) || createdCadenceSummon
+  }
+  if (!eventMatched) return 'no-match'
+  if (rule.gitlab.mentionOnly && !summoned) return 'no-match'
+  if (rule.gitlab.labelFilter.length > 0 && !ctx.labels.some((label) => rule.gitlab!.labelFilter.includes(label)))
+    return 'no-match'
+  // §12.2: pushes and the SA's own same-project revisions stay relay-trusted;
+  // every issue/MR lifecycle event and comment resolves live membership.
+  if (ctx.family === 'push') return 'trusted'
+  if (isInternalServiceAccountRevision(rule, ctx) && actorIsServiceAccount) return 'trusted'
+  return 'needs-authz'
+}
+
+/** The §12.3 rename-stable session key: exact subject discriminator, positive
+ *  IID (or the payload's canonical ref) — never a display path or delivery id. */
+export function gitlabSessionKey(rule: RcHookAssign, target: GitlabHookTarget): string {
+  const prefix = rule.gitlab!.sessionKeyPrefix
+  return target.kind === 'push' ? `${prefix}:push:${target.ref}` : `${prefix}:${target.kind}:${target.iid}`
+}
+
+/** The signed-payload subject → the trusted `RdMsgHook.gitlab` discriminator.
+ *  Undefined identity is rejected before any dispatch — never substituted. */
+export function buildTrustedGitlabMetadata(
+  payload: GitlabPayload,
+  ctx: GitlabMatchCtx,
+  rule: RcHookAssign
+): GitlabHookMetadata | undefined {
+  const gitlab = rule.gitlab
+  if (!gitlab) return undefined
+  const projectId = payload.project?.id ?? payload.project_id
+  if (projectId === undefined || String(projectId) !== gitlab.projectId) return undefined
+  let target: GitlabHookTarget
+  if (ctx.family === 'push') {
+    if (!ctx.ref) return undefined
+    target = { kind: 'push', ref: ctx.ref }
+  } else if (ctx.family === 'issues' || ctx.commentSubjectFamily === 'issues') {
+    if (ctx.iid === undefined || ctx.iid <= 0) return undefined
+    target = { kind: 'issue', iid: ctx.iid }
+  } else {
+    if (ctx.iid === undefined || ctx.iid <= 0) return undefined
+    const mr = payload.object_attributes?.iid === ctx.iid ? payload.object_attributes : payload.merge_request
+    const headSha = mr?.last_commit?.id
+    const draft = mr?.draft ?? mr?.work_in_progress
+    target = {
+      kind: 'merge_request',
+      iid: ctx.iid,
+      ...(ctx.sourceProjectId !== undefined ? { sourceProjectId: ctx.sourceProjectId } : {}),
+      ...(headSha ? { headSha } : {}),
+      ...(draft !== undefined ? { isDraft: draft } : {}),
+      ...(ctx.eventAction === 'merge_request:review_requested' ? { explicitReviewRequest: true } : {})
+    }
+  }
+  return {
+    projectId: gitlab.projectId,
+    projectPath: payload.project?.path_with_namespace ?? gitlab.projectPath,
+    target
+  }
+}
+
+/** The trimmed model-visible envelope shared by the delivery's fan-out. */
+export function buildGitlabContext(payload: GitlabPayload, ctx: GitlabMatchCtx): HookContext {
+  const attrs = payload.object_attributes
+  const subject = payload.issue ?? payload.merge_request
+  const title = attrs?.title ?? subject?.title
+  const bodySource = attrs?.note ?? attrs?.description ?? ctx.mentionText ?? ''
+  const excerpt = truncateUtf8(bodySource, GITHUB_BODY_EXCERPT_MAX)
+  const flatTitle = title ? title.replace(/\s+/g, ' ').trim() : undefined
+  return {
+    source: 'gitlab',
+    event: ctx.family === 'note' ? 'note' : ctx.family,
+    ...(ctx.eventAction.includes(':') ? { action: ctx.eventAction.slice(ctx.eventAction.indexOf(':') + 1) } : {}),
+    ...(payload.project?.path_with_namespace ? { repo: payload.project.path_with_namespace } : {}),
+    ...(ctx.iid !== undefined ? { number: ctx.iid } : {}),
+    ...(flatTitle ? { title: flatTitle.length > 200 ? `${flatTitle.slice(0, 199)}…` : flatTitle } : {}),
+    ...((payload.user?.username ?? payload.user_username)
+      ? { senderLogin: payload.user?.username ?? payload.user_username }
+      : {}),
+    ...(payload.user?.avatar_url ? { senderAvatarUrl: payload.user.avatar_url } : {}),
+    ...(ctx.labels.length > 0 ? { labels: ctx.labels } : {}),
+    ...(attrs?.url ? { htmlUrl: attrs.url } : {}),
+    ...(excerpt.text ? { bodyExcerpt: excerpt.text } : {}),
+    truncated: excerpt.truncated
+  }
+}
+
+function headerString(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function notFound(reply: FastifyReply): FastifyReply {
+  return reply.code(404).send({ error: 'Not Found', statusCode: 404 })
+}
+
+export function registerGitlabIngress(app: FastifyInstance, deps: GitlabIngressDeps): void {
+  // Own plugin scope: the buffer content parser (raw bytes for the signature)
+  // must not leak onto the relay's other JSON surfaces.
+  void app.register(async (scope) => {
+    scope.addContentTypeParser(
+      'application/json',
+      { parseAs: 'buffer', bodyLimit: GITLAB_BODY_LIMIT },
+      (_req, body, done) => done(null, body)
+    )
+
+    scope.post('/webhooks/gitlab', { bodyLimit: GITLAB_BODY_LIMIT }, async (req, reply) => {
+      const raw = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0)
+      // §11.2 order: bounded parse for the project id FIRST, then the rules'
+      // signing token verifies the delivery, and only then is anything matched.
+      let payload: GitlabPayload
+      try {
+        payload = JSON.parse(raw.toString('utf8')) as GitlabPayload
+      } catch {
+        return notFound(reply)
+      }
+      const projectId = payload.project?.id ?? payload.project_id
+      if (projectId === undefined || !Number.isSafeInteger(projectId)) return notFound(reply)
+      const rules = deps.table.getByGitlabProject(String(projectId))
+      if (rules.length === 0) return notFound(reply)
+
+      const webhookId = headerString(req.headers['webhook-id'])
+      const webhookTimestamp = headerString(req.headers['webhook-timestamp'])
+      const signature = headerString(req.headers['webhook-signature'])
+      if (!webhookId || !webhookTimestamp || !signature) return notFound(reply)
+      // Every rule on one project carries the binding's key; accept any match
+      // so a mid-rotation mixed table cannot drop deliveries.
+      const nowMs = deps.clock.now()
+      const verified = rules.some(
+        (rule) =>
+          rule.gitlab &&
+          verifyStandardWebhook(rule.gitlab.signingToken, webhookId, webhookTimestamp, raw, signature, nowMs)
+      )
+      if (!verified) return notFound(reply)
+
+      const deliveryKey = webhookId.slice(0, 200)
+      const firedAt = new Date(nowMs).toISOString()
+
+      const cleanupEvent = gitlabThreadWorktreeCleanupEvent(payload)
+      const cleanupIid = payload.object_attributes?.iid
+      if (cleanupEvent && cleanupIid !== undefined && cleanupIid > 0) {
+        // Maintenance cleanup (§12): relay-authored, never a model turn, and it
+        // bypasses the actor gate — a low-role closer must not leak a worktree.
+        const kind = cleanupEvent.startsWith('issues') ? ('issue' as const) : ('merge_request' as const)
+        for (const rule of rules) {
+          if (rule.kind !== 'gitlab' || !rule.gitlab) continue
+          const gitlab: GitlabHookMetadata = {
+            projectId: rule.gitlab.projectId,
+            projectPath: payload.project?.path_with_namespace ?? rule.gitlab.projectPath,
+            target: { kind, iid: cleanupIid }
+          }
+          const msg: RdMsgHook = {
+            source: 'hook',
+            agentId: rule.agentId,
+            sessionKey: gitlabSessionKey(rule, gitlab.target),
+            msgId: `${rule.hookId}:${deliveryKey}`,
+            hookId: rule.hookId,
+            deliveryKey,
+            firedAt,
+            ...hookSnapshotForDelivery(rule),
+            event: cleanupEvent,
+            gitlab,
+            context: buildGitlabContext(payload, {
+              eventAction: cleanupEvent,
+              family: kind === 'issue' ? 'issues' : 'merge_request',
+              labels: [],
+              mentionText: undefined,
+              iid: cleanupIid
+            }),
+            ...(rule.target ? { target: rule.target } : {})
+          }
+          void dispatchHookFire(
+            { table: deps.table, daemons: deps.daemons, report: deps.report, clock: deps.clock, log: deps.log },
+            rule,
+            msg
+          )
+        }
+        return reply.code(202).send({ deliveryKey })
+      }
+
+      const ctx = normalizeGitlabEvent(payload)
+      if (!ctx) return reply.code(202).send({ deliveryKey })
+      const context = buildGitlabContext(payload, ctx)
+
+      const dispatchRule = (rule: RcHookAssign): void => {
+        if (!deps.limiter.allow(rule.hookId)) {
+          deps.log.info(`gitlab ingress: rate-limited ${rule.hookId}:${deliveryKey} (${ctx.eventAction})`)
+          return
+        }
+        const gitlab = buildTrustedGitlabMetadata(payload, ctx, rule)
+        if (!gitlab) {
+          deps.log.info(`gitlab ingress: rejected incomplete identity ${rule.hookId}:${deliveryKey}`)
+          return
+        }
+        const msg: RdMsgHook = {
+          source: 'hook',
+          agentId: rule.agentId,
+          sessionKey: gitlabSessionKey(rule, gitlab.target),
+          msgId: `${rule.hookId}:${deliveryKey}`,
+          hookId: rule.hookId,
+          deliveryKey,
+          firedAt,
+          ...hookSnapshotForDelivery(rule),
+          event: ctx.eventAction,
+          gitlab,
+          context,
+          ...(rule.target ? { target: rule.target } : {})
+        }
+        void dispatchHookFire(
+          { table: deps.table, daemons: deps.daemons, report: deps.report, clock: deps.clock, log: deps.log },
+          rule,
+          msg
+        )
+        deps.log.info(`gitlab ingress: queued ${rule.hookId}:${deliveryKey} (${ctx.eventAction} ${msg.sessionKey})`)
+      }
+
+      const reportReviewRequestRequired = (rule: RcHookAssign): void => {
+        const gitlab = buildTrustedGitlabMetadata(payload, ctx, rule)
+        deps.report({
+          hookId: rule.hookId,
+          deliveryKey,
+          firedAt,
+          agentId: rule.agentId,
+          daemonId: rule.daemonId,
+          ...hookSnapshotForDelivery(rule),
+          event: ctx.eventAction,
+          ...(gitlab ? { gitlab } : {}),
+          status: 'failed',
+          reason: HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED
+        })
+      }
+
+      const candidates =
+        ctx.eventAction === 'merge_request:review_requested' ? rules : gitlabMentionCandidates(rules, ctx.mentionText)
+      const matched = candidates
+        .map((rule) => ({ rule, verdict: gitlabRuleVerdict(rule, ctx) }))
+        .filter((candidate) => candidate.verdict !== 'no-match')
+      for (const { rule, verdict } of matched) if (verdict === 'trusted') dispatchRule(rule)
+      const needsAuthz = matched.filter((candidate) => candidate.verdict === 'needs-authz').map(({ rule }) => rule)
+      if (needsAuthz.length === 0) return reply.code(202).send({ deliveryKey })
+
+      // §12.2: one live membership decision fences the complete fan-out. An MR
+      // from an untrusted author does not start automatically — a denied
+      // revision event leaves a durable, actionable run row instead.
+      const isLifecycle = ctx.family === 'issues' || ctx.family === 'merge_request'
+      // Lifecycle events authorize the subject author; comments authorize the
+      // commenter, plus the subject author on unmentioned thread continuation.
+      const actorId = isLifecycle ? (ctx.subjectAuthorId ?? ctx.actorId) : ctx.actorId
+      // Only a denied MR REVISION leaves the durable actionable row (§12.2) —
+      // the same two events GitHub treats as first-review material.
+      const onDenied: 'skip' | 'request-review' =
+        ctx.eventAction === 'merge_request:opened' || ctx.eventAction === 'merge_request:synchronize'
+          ? 'request-review'
+          : 'skip'
+
+      const authorizeAndDispatch = async (fanout: RcHookAssign[], requireSubjectAuthor: boolean): Promise<void> => {
+        const representative = fanout[0]
+        if (!representative?.gitlab) return
+        if (
+          !actorId ||
+          (requireSubjectAuthor && !ctx.subjectAuthorId) ||
+          fanout.some(
+            (rule) => !rule.gitlab || rule.configRevision === undefined || rule.dispatchRevision === undefined
+          )
+        ) {
+          deps.log.info(`gitlab ingress: authz metadata incomplete ${representative.hookId}:${deliveryKey}`)
+          if (onDenied === 'request-review') for (const rule of fanout) reportReviewRequestRequired(rule)
+          return
+        }
+        if (!deps.authzLimiter.allow(representative.gitlab.projectId)) {
+          deps.log.info(`gitlab ingress: authz rate-limited ${representative.hookId}:${deliveryKey}`)
+          return
+        }
+        const request: RcCodeHostMembershipAuthz = {
+          hookId: representative.hookId,
+          provider: 'gitlab',
+          repoExternalId: representative.gitlab.projectId,
+          actorExternalId: actorId,
+          ...(requireSubjectAuthor && ctx.subjectAuthorId && ctx.subjectAuthorId !== actorId
+            ? { subjectAuthorExternalId: ctx.subjectAuthorId }
+            : {}),
+          configRevision: representative.configRevision!,
+          dispatchRevision: representative.dispatchRevision!,
+          ...(fanout.length > 1
+            ? {
+                siblingFences: fanout.slice(1).map((rule) => ({
+                  hookId: rule.hookId,
+                  configRevision: rule.configRevision!,
+                  dispatchRevision: rule.dispatchRevision!
+                }))
+              }
+            : {})
+        }
+        let allowed = false
+        try {
+          allowed = await deps.authorizeMembership(request)
+        } catch (err) {
+          // Rolling upgrade against an older CP (UNKNOWN_FRAME), timeout, and
+          // transient failures all fail closed (§12.2).
+          deps.log.warn(`gitlab ingress: authz failed ${representative.hookId}:${deliveryKey}: ${String(err)}`)
+        }
+        if (!allowed) {
+          deps.log.info(
+            `gitlab ingress: authz denied ${representative.hookId}:${deliveryKey} (${ctx.eventAction} actor ${actorId})`
+          )
+          if (onDenied === 'request-review') for (const rule of fanout) reportReviewRequestRequired(rule)
+          return
+        }
+        // The membership wait crossed a remote boundary: re-read every rule and
+        // re-run the verdict so a remove/reconfigure/retarget in that window
+        // cannot dispatch a stale capture.
+        for (const rule of fanout) {
+          const current = deps.table.getByHookId(rule.hookId)
+          if (
+            !current ||
+            current.kind !== 'gitlab' ||
+            !current.gitlab ||
+            current.gitlab.projectId !== rule.gitlab!.projectId ||
+            current.configRevision !== rule.configRevision ||
+            current.dispatchRevision !== rule.dispatchRevision ||
+            current.agentId !== rule.agentId ||
+            gitlabRuleVerdict(current, ctx) !== 'needs-authz'
+          ) {
+            deps.log.info(`gitlab ingress: authz rule changed ${rule.hookId}:${deliveryKey}`)
+            continue
+          }
+          dispatchRule(current)
+        }
+      }
+
+      // Comments on an unmentioned thread continuation also require the subject
+      // author's membership (§12.2); a summoning comment authorizes only the
+      // commenter.
+      if (ctx.family === 'note') {
+        const summonedRules = needsAuthz.filter((rule) => gitlabRuleIsSummoned(rule, ctx))
+        const unsummoned = needsAuthz.filter((rule) => !gitlabRuleIsSummoned(rule, ctx))
+        if (summonedRules.length > 0)
+          void authorizeAndDispatch(summonedRules, false).catch((err) => {
+            deps.log.warn(`gitlab ingress: authz task failed ${deliveryKey}: ${String(err)}`)
+          })
+        if (unsummoned.length > 0)
+          void authorizeAndDispatch(unsummoned, true).catch((err) => {
+            deps.log.warn(`gitlab ingress: authz task failed ${deliveryKey}: ${String(err)}`)
+          })
+      } else {
+        void authorizeAndDispatch(needsAuthz, false).catch((err) => {
+          deps.log.warn(`gitlab ingress: authz task failed ${deliveryKey}: ${String(err)}`)
+        })
+      }
+      return reply.code(202).send({ deliveryKey })
+    })
+  })
+}

--- a/packages/relay/src/hooks/hook-table.ts
+++ b/packages/relay/src/hooks/hook-table.ts
@@ -16,6 +16,8 @@ export class HookTable {
   private byToken = new Map<string, RcHookAssign>()
   /** repoId → hookId → rule (fan-out: several hooks may watch one repo). */
   private byRepoId = new Map<string, Map<string, RcHookAssign>>()
+  /** GitLab projectId → hookId → rule (same fan-out shape as byRepoId). */
+  private byProjectId = new Map<string, Map<string, RcHookAssign>>()
 
   upsert(rule: RcHookAssign): void {
     // Re-index: if the hook's token/repo changed (or the kind did), drop the old key.
@@ -25,6 +27,9 @@ export class HookTable {
     }
     if (prior?.github && prior.github.repoId !== rule.github?.repoId) {
       this.dropFromRepoIndex(prior)
+    }
+    if (prior?.gitlab && prior.gitlab.projectId !== rule.gitlab?.projectId) {
+      this.dropFromProjectIndex(prior)
     }
     this.byHookId.set(rule.hookId, rule)
     if (rule.kind === 'webhook' && rule.webhook) this.byToken.set(rule.webhook.urlToken, rule)
@@ -36,6 +41,14 @@ export class HookTable {
       }
       bucket.set(rule.hookId, rule)
     }
+    if (rule.kind === 'gitlab' && rule.gitlab) {
+      let bucket = this.byProjectId.get(rule.gitlab.projectId)
+      if (!bucket) {
+        bucket = new Map()
+        this.byProjectId.set(rule.gitlab.projectId, bucket)
+      }
+      bucket.set(rule.hookId, rule)
+    }
   }
 
   remove(hookId: string): void {
@@ -44,6 +57,7 @@ export class HookTable {
     this.byHookId.delete(hookId)
     if (rule.webhook) this.byToken.delete(rule.webhook.urlToken)
     if (rule.github) this.dropFromRepoIndex(rule)
+    if (rule.gitlab) this.dropFromProjectIndex(rule)
   }
 
   /** The generic-ingress lookup: URL token → rule (undefined = uniform 404). */
@@ -63,6 +77,12 @@ export class HookTable {
     return bucket ? [...bucket.values()] : []
   }
 
+  /** The GitLab-ingress lookup: numeric project id (as string) → every watching rule. */
+  getByGitlabProject(projectId: string): RcHookAssign[] {
+    const bucket = this.byProjectId.get(projectId)
+    return bucket ? [...bucket.values()] : []
+  }
+
   size(): number {
     return this.byHookId.size
   }
@@ -73,5 +93,13 @@ export class HookTable {
     if (!bucket) return
     bucket.delete(rule.hookId)
     if (bucket.size === 0) this.byRepoId.delete(rule.github.repoId)
+  }
+
+  private dropFromProjectIndex(rule: RcHookAssign): void {
+    if (!rule.gitlab) return
+    const bucket = this.byProjectId.get(rule.gitlab.projectId)
+    if (!bucket) return
+    bucket.delete(rule.hookId)
+    if (bucket.size === 0) this.byProjectId.delete(rule.gitlab.projectId)
   }
 }

--- a/packages/relay/src/hooks/ingress.ts
+++ b/packages/relay/src/hooks/ingress.ts
@@ -23,6 +23,7 @@ import { isDeepStrictEqual } from 'node:util'
 import type { FastifyInstance, FastifyReply } from 'fastify'
 import type { Clock } from '@agentconnect.md/connection'
 import {
+  GITLAB_COM_V1_FEATURE,
   HOOK_DELIVERY_REASON_DISPATCH_TIMEOUT,
   HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
   RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2,
@@ -150,7 +151,8 @@ function reportBase(rule: RcHookAssign, msg: RdMsgHook): Omit<RcRunReport, 'stat
     daemonId: rule.daemonId,
     ...hookSnapshotForDelivery(rule),
     ...(msg.event ? { event: msg.event } : {}),
-    ...(msg.github ? { github: msg.github } : {})
+    ...(msg.github ? { github: msg.github } : {}),
+    ...(msg.gitlab ? { gitlab: msg.gitlab } : {})
   }
 }
 
@@ -194,6 +196,14 @@ export async function dispatchHookFire(
       // daemon would run them as model prompts, so fail closed until the target
       // explicitly advertises maintenance-only handling.
       if (requiresGithubThreadWorktreeCleanup(dispatchMsg) && !conn.supports(RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2)) {
+        deps.report({ ...base, status: 'failed', reason: 'rejected:unsupported' })
+        resolve()
+        return
+      }
+      // A GitLab turn's session-key/normalization contract is the daemon's
+      // gitlab-com-v1 capability (§12.3): an older daemon would fall back to
+      // generic parsing and mis-scope the thread, so fail closed instead.
+      if (dispatchMsg.gitlab && !conn.supports(GITLAB_COM_V1_FEATURE)) {
         deps.report({ ...base, status: 'failed', reason: 'rejected:unsupported' })
         resolve()
         return

--- a/packages/relay/src/hooks/standard-webhooks.test.ts
+++ b/packages/relay/src/hooks/standard-webhooks.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { createHmac, randomBytes } from 'node:crypto'
+import { verifyStandardWebhook, STANDARD_WEBHOOK_TOLERANCE_MS } from './standard-webhooks.js'
+
+const KEY = randomBytes(32)
+const TOKEN = `whsec_${KEY.toString('base64')}`
+const NOW = 1_760_000_000_000
+const TS = String(Math.floor(NOW / 1000))
+const BODY = Buffer.from('{"object_kind":"issue"}')
+
+const sign = (id: string, ts: string, body: Buffer, key = KEY) =>
+  `v1,${createHmac('sha256', key).update(`${id}.${ts}.`).update(body).digest('base64')}`
+
+describe('verifyStandardWebhook (§11.2)', () => {
+  it('accepts a valid v1 signature, including one inside a space-separated list', () => {
+    expect(verifyStandardWebhook(TOKEN, 'msg_1', TS, BODY, sign('msg_1', TS, BODY), NOW)).toBe(true)
+    const list = `v1,${'A'.repeat(43)}= ${sign('msg_1', TS, BODY)} v2,${'B'.repeat(43)}=`
+    expect(verifyStandardWebhook(TOKEN, 'msg_1', TS, BODY, list, NOW)).toBe(true)
+  })
+
+  it('rejects a wrong key, wrong id, tampered body, and non-v1 entries', () => {
+    expect(verifyStandardWebhook(TOKEN, 'msg_1', TS, BODY, sign('msg_1', TS, BODY, randomBytes(32)), NOW)).toBe(false)
+    expect(verifyStandardWebhook(TOKEN, 'msg_2', TS, BODY, sign('msg_1', TS, BODY), NOW)).toBe(false)
+    expect(verifyStandardWebhook(TOKEN, 'msg_1', TS, Buffer.from('{}'), sign('msg_1', TS, BODY), NOW)).toBe(false)
+    const sig = sign('msg_1', TS, BODY).replace('v1,', 'v2,')
+    expect(verifyStandardWebhook(TOKEN, 'msg_1', TS, BODY, sig, NOW)).toBe(false)
+  })
+
+  it('rejects timestamps outside the replay window and malformed tokens', () => {
+    const staleSeconds = Math.floor((NOW - STANDARD_WEBHOOK_TOLERANCE_MS - 1000) / 1000)
+    const stale = String(staleSeconds)
+    expect(verifyStandardWebhook(TOKEN, 'msg_1', stale, BODY, sign('msg_1', stale, BODY), NOW)).toBe(false)
+    expect(verifyStandardWebhook(TOKEN, 'msg_1', 'soon', BODY, sign('msg_1', 'soon', BODY), NOW)).toBe(false)
+    expect(verifyStandardWebhook('plain-secret', 'msg_1', TS, BODY, sign('msg_1', TS, BODY), NOW)).toBe(false)
+    expect(verifyStandardWebhook('whsec_', 'msg_1', TS, BODY, sign('msg_1', TS, BODY), NOW)).toBe(false)
+  })
+})

--- a/packages/relay/src/hooks/standard-webhooks.ts
+++ b/packages/relay/src/hooks/standard-webhooks.ts
@@ -1,0 +1,45 @@
+/**
+ * Standard Webhooks verification (gitlab-com-integration.md §11.2): the signed
+ * content is `"{webhook-id}.{webhook-timestamp}.{raw-body}"`, the key is the
+ * base64 payload of the `whsec_` signing token, and the signature header is a
+ * space-separated list of `v1,<base64>` entries — any timing-safe match
+ * accepts. Timestamps outside the replay window reject before any HMAC work.
+ */
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+/** §11.2 replay window: reject webhook-timestamp drift beyond this. */
+export const STANDARD_WEBHOOK_TOLERANCE_MS = 5 * 60 * 1000
+
+export function verifyStandardWebhook(
+  signingToken: string,
+  webhookId: string,
+  webhookTimestamp: string,
+  rawBody: Buffer,
+  signatureHeader: string,
+  nowMs: number
+): boolean {
+  if (!signingToken.startsWith('whsec_')) return false
+  const seconds = Number(webhookTimestamp)
+  if (!Number.isSafeInteger(seconds)) return false
+  if (Math.abs(nowMs - seconds * 1000) > STANDARD_WEBHOOK_TOLERANCE_MS) return false
+  let key: Buffer
+  try {
+    key = Buffer.from(signingToken.slice('whsec_'.length), 'base64')
+  } catch {
+    return false
+  }
+  if (key.length === 0) return false
+  const expected = createHmac('sha256', key).update(`${webhookId}.${webhookTimestamp}.`).update(rawBody).digest()
+  for (const entry of signatureHeader.split(' ')) {
+    const [version, sig] = entry.split(',', 2)
+    if (version !== 'v1' || !sig) continue
+    let candidate: Buffer
+    try {
+      candidate = Buffer.from(sig, 'base64')
+    } catch {
+      continue
+    }
+    if (candidate.length === expected.length && timingSafeEqual(candidate, expected)) return true
+  }
+  return false
+}

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -27,6 +27,7 @@ import { HookTable } from './hooks/hook-table.js'
 import { HookRateLimiter } from './hooks/rate-limit.js'
 import { registerHookIngress } from './hooks/ingress.js'
 import { registerGithubIngress } from './hooks/github-ingress.js'
+import { registerGitlabIngress } from './hooks/gitlab-ingress.js'
 import { McpBindingTable } from './mcp/binding-table.js'
 import { registerMcpProxy, registerMemoryPluginProxy } from './mcp/proxy.js'
 import { MemoryConnectionBindingTable } from './memory/binding-table.js'
@@ -246,6 +247,20 @@ async function main(): Promise<void> {
     clock: systemClock,
     log,
     webhookSecret: () => deploymentConfig.githubWebhookSecret
+  })
+
+  // GitLab project webhooks (gitlab-com-integration.md §11.2): rule-carried
+  // signing tokens, live membership through the CP, same shared run limiter.
+  const gitlabAuthzLimiter = new HookRateLimiter(systemClock, { capacity: 10, refillPerSec: 0.25 })
+  registerGitlabIngress(server, {
+    table: hookTable,
+    daemons: () => held.rdServer,
+    report: (r) => client.emitRunReport(r),
+    authorizeMembership: (request) => client.authorizeCodeHostMembership(request),
+    authzLimiter: gitlabAuthzLimiter,
+    limiter,
+    clock: systemClock,
+    log
   })
 
   // MCP reverse proxy (ALL /mcp/:providerId) — resolves a grant to its upstream, SSRF-guards

--- a/packages/relay/src/relay-cp-client.test.ts
+++ b/packages/relay/src/relay-cp-client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   buildRelayCpFrame,
   RELAY_CP_SUBPROTOCOL,
+  GITLAB_COM_V1_FEATURE,
   WEBCHAT_SESSION_CONTINUATION_FEATURE,
   type RelayCpFrame
 } from '@agentconnect.md/protocol'
@@ -177,7 +178,7 @@ describe('RelayCpClient', () => {
     expect(reg.payload).toEqual({
       name: 'relay-0',
       daemonUrl: 'wss://relay-0.example',
-      features: [WEBCHAT_SESSION_CONTINUATION_FEATURE]
+      features: [WEBCHAT_SESSION_CONTINUATION_FEATURE, GITLAB_COM_V1_FEATURE]
     })
 
     expect(client.state).toBe('READY')

--- a/packages/relay/src/relay-cp-client.ts
+++ b/packages/relay/src/relay-cp-client.ts
@@ -15,6 +15,7 @@
 import {
   buildRelayCpFrame,
   decodeRelayCpFrame,
+  GITLAB_COM_V1_FEATURE,
   WEBCHAT_SESSION_CONTINUATION_FEATURE,
   type RelayCpFrame,
   type RcAuthOk,
@@ -22,6 +23,7 @@ import {
   type RcRegistered,
   type RcVerify,
   type RcVerifyResult,
+  type RcCodeHostMembershipAuthz,
   type RcGithubCommentAuthz,
   type RcGithubRerequest,
   type RcGithubRerequestResult,
@@ -272,6 +274,19 @@ export class RelayCpClient {
    * request is never retransmitted on the same connection (GitHub deliveries are
    * already deduplicated by delivery id), only re-issued once after a reconnect.
    */
+  /** §12.2 live effective-membership gate — the provider-neutral successor to
+   * the GitHub comment authz REQ. Fail-closed at the caller on any error. */
+  async authorizeCodeHostMembership(request: RcCodeHostMembershipAuthz): Promise<boolean> {
+    const rep = await this.authorizationRequest(
+      () => buildRelayCpFrame('rc/codehost-membership-authz', request),
+      'rc/codehost-membership-authz'
+    )
+    if (rep.type !== 'rc/codehost-membership-authz/ok') {
+      throw new WireError('INTERNAL', `expected rc/codehost-membership-authz/ok, got ${rep.type}`, false)
+    }
+    return rep.payload.allowed
+  }
+
   async authorizeGithubComment(request: RcGithubCommentAuthz): Promise<boolean> {
     const rep = await this.authorizationRequest(
       () => buildRelayCpFrame('rc/github-comment-authz', request),
@@ -506,7 +521,9 @@ export class RelayCpClient {
         daemonUrl: this.deps.daemonUrl,
         // This relay preserves RdMsgWebchat.targetSessionId end to end; the CP
         // gates session-targeted mints on every live relay advertising it.
-        features: [WEBCHAT_SESSION_CONTINUATION_FEATURE]
+        // gitlab-com-v1: this relay verifies and routes GitLab project
+        // webhooks, so the CP may send it gitlab-kind compiled rules (§17.3).
+        features: [WEBCHAT_SESSION_CONTINUATION_FEATURE, GITLAB_COM_V1_FEATURE]
       })
     )
     this.relayId = (registered.payload as RcRegistered).relayId


### PR DESCRIPTION
The relay half of [gitlab-com-integration.md](docs/designs/gitlab-com-integration.md) §22 **M3**, after #1367. The daemon half (M4) follows.

## `POST /webhooks/gitlab` (§11.2)

Verification is per-rule — the compiled rule carries the project's `whsec_` signing token inline, so the order is: bounded parse for the numeric project id only → rule lookup by project → Standard Webhooks verification (`{webhook-id}.{webhook-timestamp}.{raw-body}`, base64 key, any timing-safe `v1` match from the space-separated list, 5-minute replay window) → only then is the payload trusted as filter input. Invalid signatures, stale timestamps, unknown projects, and malformed bodies share one uniform 404; verified unmatched deliveries answer 202. `webhook-id` is the delivery key; the daemon inbox and the CP's unique HookRun row absorb provider retries.

## Event mapping and the gate table (§12)

`issues:opened`/`:labeled`, `merge_request:opened`/`:synchronize` (oldrev)/`:labeled`, `push`, and `note:created` scoped by the console-selected comment families; edits, reopens, unmerged closes, draft/ready toggles, and system notes are vetoed. Merged MRs and closed issues fan out as the relay-authored maintenance-cleanup family — never a model turn, and deliberately bypassing the actor gate so a low-role closer cannot leak a session worktree.

- **§12.1 loop prevention**: events authored by the managed service account never re-trigger, except its own same-project MR revisions (the internal CI lane, relay-trusted); notes it authors are always rejected.
- **§12.2 live membership**: every issue/MR lifecycle event and comment resolves through `rc/codehost-membership-authz` (fail-closed on error/UNKNOWN_FRAME; one decision fences the fan-out with sibling fences; rules re-read + re-judged after the remote wait). Unmentioned thread continuation fences the subject author too; a denied MR revision leaves the durable review-request-required run row. Assigning the service account as reviewer is the explicit start path and authorizes the assigning actor.
- **§12.3 session keys**: `gitlab:<projectId>:{issue|merge_request}:<iid>` / `…:push:<ref>` — recomputable, rename-stable, never built from display paths or delivery ids.

## Rolling compatibility (§17.3)

`RdMsgHook` gains the optional trusted `gitlab` discriminator and `HookContext.source` learns `'gitlab'`; dispatch fails closed (`rejected:unsupported`) unless the daemon connection advertises `gitlab-com-v1`, and the relay now advertises the feature on register so the CP will send it gitlab rules.

The GitHub ingress' dispatch loop, config-snapshot normalization, rate limiting, and mention/truncation helpers are shared rather than re-extracted into a forced common skeleton: the two providers' verification models differ structurally (App-level secret vs rule-carried key), so the seam stays at the pure helpers plus `dispatchHookFire`.

## Tests

Ingress suite (14): verification matrix, gate/veto table, loop-prevention lanes, reviewer-request path, membership fencing, cleanup fan-out, daemon-capability fail-closed, mention narrowing. Standard Webhooks units (3). Relay suite 523/523; workspace typecheck/lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
