### PR TITLE
feat(daemon): provider-aware managed git credentials and the glab wrapper

### DIFF
--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -215,6 +215,12 @@ export const AgentSchema = z.object({
     // clone/fetch/push authenticate via the local credential helper backed by
     // CP-minted short-lived installation tokens — nothing durable on this host.
     gitCredential: z.enum(['github-app', 'gitlab']).optional(),
+    // gitlab mode: the v2 rename-stable numeric project id (gitlab-com-integration.md
+    // §17.1) — the identity the credential consumer verifies against every grant echo.
+    gitlabProjectId: z
+      .string()
+      .regex(/^[1-9]\d*$/)
+      .optional(),
     // The agent's additional-repository allowlist, replicated from the CP
     // (multi-repository-workspaces.md decision 2). A later phase materializes these
     // as secondary workspace roots; nothing reads the list yet. `repoId` is GitHub's

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -214,7 +214,7 @@ export const AgentSchema = z.object({
     // Remote-git credential mode. Absent ⇒ anonymous (public repos). 'github-app' ⇒
     // clone/fetch/push authenticate via the local credential helper backed by
     // CP-minted short-lived installation tokens — nothing durable on this host.
-    gitCredential: z.enum(['github-app']).optional(),
+    gitCredential: z.enum(['github-app', 'gitlab']).optional(),
     // The agent's additional-repository allowlist, replicated from the CP
     // (multi-repository-workspaces.md decision 2). A later phase materializes these
     // as secondary workspace roots; nothing reads the list yet. `repoId` is GitHub's

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -872,9 +872,16 @@ export function applySpecFields(
     }
     // Credential mode is CP-derived config and also applies to scratch
     // workspaces with explicit repo grants. Mirror it exactly, including clear.
-    if (ws.mode === 'gitlab') existing.gitCredential = 'gitlab'
-    else if (ws.gitCredential !== undefined) existing.gitCredential = ws.gitCredential
-    else delete existing.gitCredential
+    if (ws.mode === 'gitlab') {
+      existing.gitCredential = 'gitlab'
+      // The rename-stable identity rides the spec (§17.1); the grant consumer
+      // verifies every echo against it.
+      existing.gitlabProjectId = ws.projectId
+    } else {
+      if (ws.gitCredential !== undefined) existing.gitCredential = ws.gitCredential
+      else delete existing.gitCredential
+      delete existing.gitlabProjectId
+    }
     // The CP is the authority on the additional-repository allowlist and always ships
     // the full set, so mirror it exactly — [] must replicate as a cleared list.
     existing.additionalRepos = ws.additionalRepos

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -840,10 +840,10 @@ export function applySpecFields(
     // clears a previously replicated cwd rather than preserving a stale local value.
     delete existing.agentDir
     if (ws.mode === 'gitlab') {
-      // §17.3: the CP never sends this arm unless the daemon advertised
-      // gitlab-com-v1 (the M5 slice). Decoding it stays total so a compile-time
-      // union widening cannot strand register; managed credentials arrive with
-      // the credential slice, so until then the URL is treated like any remote.
+      // The managed-GitLab workspace (gitlab-com-integration.md §13): the local
+      // credential marker routes clone/pull/session git through the daemon
+      // helper with provider 'gitlab'. The CP only sends this arm to a daemon
+      // that advertised gitlab-com-v1 (§17.3).
       existing.gitRepo = normalizeGitCloneUrl(redactGitUrlSecrets(ws.gitRepo))
       existing.gitBranch = ws.branch
       if (ws.agentDir !== undefined) existing.agentDir = ws.agentDir
@@ -872,7 +872,8 @@ export function applySpecFields(
     }
     // Credential mode is CP-derived config and also applies to scratch
     // workspaces with explicit repo grants. Mirror it exactly, including clear.
-    if (ws.mode !== 'gitlab' && ws.gitCredential !== undefined) existing.gitCredential = ws.gitCredential
+    if (ws.mode === 'gitlab') existing.gitCredential = 'gitlab'
+    else if (ws.gitCredential !== undefined) existing.gitCredential = ws.gitCredential
     else delete existing.gitCredential
     // The CP is the authority on the additional-repository allowlist and always ships
     // the full set, so mirror it exactly — [] must replicate as a cleared list.

--- a/packages/daemon/src/cli/glab-token.ts
+++ b/packages/daemon/src/cli/glab-token.ts
@@ -1,0 +1,10 @@
+// `agentconnect-daemon glab-token <agentId> -- <glab argv…>` — the DAEMON-side entry of the glab
+// wrapper's token fetch (gitlab-com-integration.md §13.3). Nothing but socket selection lives here;
+// the fetch, target resolution and exit-code contract are `gitcred/glab-token-client.ts`.
+import { emitGlabToken } from '../gitcred/glab-token-client.js'
+import { gitcredSocketFrom } from '../cp/gitcred-server.js'
+import { resolveRoot } from '../paths.js'
+
+export async function runGlabToken(agentId: string, glabArgv: readonly string[]): Promise<void> {
+  await emitGlabToken(agentId, glabArgv, gitcredSocketFrom(process.env, resolveRoot()))
+}

--- a/packages/daemon/src/cp/git-credential.ts
+++ b/packages/daemon/src/cp/git-credential.ts
@@ -92,6 +92,7 @@ export interface GitCredentialCacheDeps {
     hookId?: string
     forceRefresh?: boolean
     provider?: 'gitlab'
+    externalRepoId?: string
     requestedAccess?: 'read' | 'write'
   }) => Promise<GitCredGrant>
   log: { warn: (msg: string) => void }
@@ -135,7 +136,13 @@ export class GitCredentialCache {
   async get(
     agentId: string,
     reason: 'clone' | 'fetch' | 'pull' | 'push' | 'helper',
-    opts: { plane?: CredPlane; repo?: string; provider?: 'gitlab'; requestedAccess?: 'read' | 'write' } = {}
+    opts: {
+      plane?: CredPlane
+      repo?: string
+      provider?: 'gitlab'
+      externalRepoId?: string
+      requestedAccess?: 'read' | 'write'
+    } = {}
   ): Promise<Entry> {
     const plane = opts.plane ?? 'git'
     if (opts.provider === 'gitlab' && this.deps.providerV2Supported?.() !== true) {
@@ -154,6 +161,7 @@ export class GitCredentialCache {
         : {}),
       ...(opts.repo !== undefined ? { repoFullName: opts.repo } : {}),
       ...(opts.provider !== undefined ? { provider: opts.provider } : {}),
+      ...(opts.externalRepoId !== undefined ? { externalRepoId: opts.externalRepoId } : {}),
       ...(opts.requestedAccess !== undefined ? { requestedAccess: opts.requestedAccess } : {})
     })
   }
@@ -242,10 +250,14 @@ export class GitCredentialCache {
    * fresh grant from being wiped by a stale erase. `repo` routes the erase to
    * the same key the `get` used; absent ⇒ the workspace git-plane entry.
    */
-  invalidate(agentId: string, presentedPassword?: string, opts: { plane?: CredPlane; repo?: string } = {}): void {
+  invalidate(
+    agentId: string,
+    presentedPassword?: string,
+    opts: { plane?: CredPlane; repo?: string; provider?: 'gitlab' } = {}
+  ): void {
     const plane = opts.plane ?? 'git'
     const cachePlane = plane === 'gh' && this.deps.actionsSupported?.() === true ? 'gh-actions' : plane
-    const key = keyOf(agentId, cachePlane, opts.repo)
+    const key = keyOf(agentId, cachePlane, opts.repo, opts.provider)
     const entry = this.entries.get(key)
     if (!entry) return
     if (presentedPassword !== undefined && entry.token !== presentedPassword) return
@@ -301,6 +313,14 @@ export class GitCredentialCache {
     if (payload.provider !== undefined && grant.provider !== payload.provider) {
       throw new GitCredUnavailableError(
         `control plane answered provider ${grant.provider ?? 'github'} for a ${payload.provider} request`,
+        false
+      )
+    }
+    // …and a mismatched numeric identity is a wrong-project credential: local
+    // replica and CP record disagree — fail, never serve.
+    if (payload.externalRepoId !== undefined && grant.externalRepoId !== payload.externalRepoId) {
+      throw new GitCredUnavailableError(
+        `control plane answered project ${grant.externalRepoId ?? 'unknown'} for project ${payload.externalRepoId}`,
         false
       )
     }

--- a/packages/daemon/src/cp/git-credential.ts
+++ b/packages/daemon/src/cp/git-credential.ts
@@ -48,13 +48,13 @@ const GH_TOKEN_CAPABILITIES: readonly GitCredCapability[] = ['contents', 'issues
 
 /** The credential plane: 'git' = contents-only (the credential helper), 'gh' =
  *  the widened GH_TOKEN set. Distinct capability sets are distinct tokens. */
-export type CredPlane = 'git' | 'gh'
+export type CredPlane = 'git' | 'gh' | 'glab'
 type CachePlane = CredPlane | 'gh-actions'
 
 /** Cache key — NUL-joined so no owner/repo string can collide across fields
  *  (the GH_KEY precedent). */
-const keyOf = (agentId: string, plane: CachePlane, repo?: string): string =>
-  `${plane}\u0000${agentId}\u0000${repo?.toLowerCase() ?? ''}`
+const keyOf = (agentId: string, plane: CachePlane, repo?: string, provider?: 'gitlab'): string =>
+  `${plane}\u0000${agentId}\u0000${repo?.toLowerCase() ?? ''}\u0000${provider ?? ''}`
 
 /** Cache key for a repo-targeted COMMENT token (the GithubPoster's — issues/PR
  *  only, no contents requested; its capability set differs from both planes so
@@ -91,12 +91,18 @@ export interface GitCredentialCacheDeps {
     purpose?: 'github_hook_reply'
     hookId?: string
     forceRefresh?: boolean
+    provider?: 'gitlab'
+    requestedAccess?: 'read' | 'write'
   }) => Promise<GitCredGrant>
   log: { warn: (msg: string) => void }
   /** Rolling-upgrade gate: old CPs reject the new enum value, so request Actions
    *  only after register/ok advertises support. The cache key changes with this
    *  value so reconnecting to an upgraded CP mints a fresh widened grant. */
   actionsSupported?: () => boolean
+  /** §17.1 negotiation: a provider may be named only after register/ok carries
+   *  gitcred-provider-v2 — an older CP would strip the field and answer a
+   *  GitHub workspace grant for the wrong provider. */
+  providerV2Supported?: () => boolean
   /** Monotonic ms; injectable for tests. */
   monoNow?: () => number
 }
@@ -129,18 +135,26 @@ export class GitCredentialCache {
   async get(
     agentId: string,
     reason: 'clone' | 'fetch' | 'pull' | 'push' | 'helper',
-    opts: { plane?: CredPlane; repo?: string } = {}
+    opts: { plane?: CredPlane; repo?: string; provider?: 'gitlab'; requestedAccess?: 'read' | 'write' } = {}
   ): Promise<Entry> {
     const plane = opts.plane ?? 'git'
+    if (opts.provider === 'gitlab' && this.deps.providerV2Supported?.() !== true) {
+      throw new GitCredUnavailableError(
+        'the control plane is too old for gitlab credentials (gitcred-provider-v2 not advertised)',
+        false
+      )
+    }
     const withActions = plane === 'gh' && this.deps.actionsSupported?.() === true
     const cachePlane = withActions ? 'gh-actions' : plane
-    return this.getKeyed(keyOf(agentId, cachePlane, opts.repo), agentId, {
+    return this.getKeyed(keyOf(agentId, cachePlane, opts.repo, opts.provider), agentId, {
       agentId,
       reason,
-      ...(plane === 'gh'
+      ...(plane === 'gh' && opts.provider === undefined
         ? { capabilities: [...GH_TOKEN_CAPABILITIES, ...(withActions ? (['actions'] as const) : [])] }
         : {}),
-      ...(opts.repo !== undefined ? { repoFullName: opts.repo } : {})
+      ...(opts.repo !== undefined ? { repoFullName: opts.repo } : {}),
+      ...(opts.provider !== undefined ? { provider: opts.provider } : {}),
+      ...(opts.requestedAccess !== undefined ? { requestedAccess: opts.requestedAccess } : {})
     })
   }
 
@@ -279,6 +293,14 @@ export class GitCredentialCache {
     if (payload.repoFullName !== undefined && grant.repoFullName.toLowerCase() !== payload.repoFullName.toLowerCase()) {
       throw new GitCredUnavailableError(
         `control plane is too old for per-repo credentials (asked ${payload.repoFullName}, got ${grant.repoFullName})`,
+        false
+      )
+    }
+    // v2 echo verification (§17.1): a stripped provider means an older CP
+    // answered a GitHub workspace grant — never serve it for another provider.
+    if (payload.provider !== undefined && grant.provider !== payload.provider) {
+      throw new GitCredUnavailableError(
+        `control plane answered provider ${grant.provider ?? 'github'} for a ${payload.provider} request`,
         false
       )
     }

--- a/packages/daemon/src/cp/gitcred-server.ts
+++ b/packages/daemon/src/cp/gitcred-server.ts
@@ -64,6 +64,9 @@ interface GitCredIpcRequest {
   repoFullName?: string
   /** 'gh' ⇒ the widened GH_TOKEN capability set; absent/'git' ⇒ contents-only. */
   plane?: string
+  /** Host-derived hint from the helper ('gitlab' when git asked for gitlab.com).
+   *  ROUTING ONLY: the daemon's own replicated spec decides the real provider. */
+  provider?: string
 }
 
 export interface GitCredServerDeps {
@@ -72,6 +75,9 @@ export interface GitCredServerDeps {
    *  lets a helper request that names the workspace repo share the repo-less
    *  cache key with pre-warm/spawn instead of splitting the cache. */
   workspaceRepoOf?: (agentId: string) => string | undefined
+  /** The agent's managed credential provider from its REPLICATED SPEC — never
+   *  the helper's claim (§13.2). Absent/undefined ⇒ github (the v1 behavior). */
+  providerOf?: (agentId: string) => 'github' | 'gitlab' | undefined
 }
 
 export class GitCredServer {
@@ -79,6 +85,7 @@ export class GitCredServer {
   private readonly capabilities = new Map<string, string>()
   private readonly log: GitCredServerDeps['log']
   private readonly workspaceRepoOf?: (agentId: string) => string | undefined
+  private readonly providerOf?: (agentId: string) => 'github' | 'gitlab' | undefined
 
   constructor(
     private readonly cache: GitCredentialCache,
@@ -87,6 +94,7 @@ export class GitCredServer {
   ) {
     this.log = deps.log
     if (deps.workspaceRepoOf) this.workspaceRepoOf = deps.workspaceRepoOf
+    if (deps.providerOf) this.providerOf = deps.providerOf
   }
 
   start(): void {
@@ -160,7 +168,7 @@ export class GitCredServer {
       this.audit('rejected', req?.agentId, req?.plane === 'gh' ? 'gh' : 'git', req?.repoFullName, true)
       return reply({ ok: false, error: 'local credential capability required' })
     }
-    const plane: CredPlane = req.plane === 'gh' ? 'gh' : 'git'
+    const plane: CredPlane = req.plane === 'gh' ? 'gh' : req.plane === 'glab' ? 'glab' : 'git'
     // Workspace normalization: a request naming the workspace repo folds onto
     // the repo-less key (one cache entry with pre-warm/spawn; and old CPs that
     // strip the wire field keep serving the workspace unchanged).
@@ -179,8 +187,26 @@ export class GitCredServer {
     if (req.op !== 'get') {
       return reply({ ok: false, error: 'unsupported op' })
     }
+    // The SPEC decides the provider; a helper whose host hint disagrees is
+    // asking for another host's credential and gets a clean denial (§13.2).
+    const provider = this.providerOf?.(req.agentId) ?? 'github'
+    if (req.provider !== undefined && req.provider !== provider) {
+      this.audit('denied', req.agentId, plane, repo)
+      return reply({ ok: false, error: `this workspace has no managed ${req.provider} credential` })
+    }
+    if (plane === 'glab' && provider !== 'gitlab') {
+      this.audit('denied', req.agentId, plane, repo)
+      return reply({ ok: false, error: 'glab credentials require a managed GitLab workspace' })
+    }
     try {
-      const cred = await this.cache.get(req.agentId, 'helper', { plane, ...(repo !== undefined ? { repo } : {}) })
+      const cred = await this.cache.get(req.agentId, 'helper', {
+        plane,
+        ...(repo !== undefined ? { repo } : {}),
+        ...(provider === 'gitlab' ? { provider: 'gitlab' as const } : {}),
+        // §13.3: the CLI wrapper is read-only BY DESIGN — a mutating glab
+        // command never receives effect authority and fails at GitLab.
+        ...(plane === 'glab' ? { requestedAccess: 'read' as const } : {})
+      })
       this.audit('served', req.agentId, plane, repo ?? cred.repoFullName)
       return reply({ ok: true, username: cred.username, password: cred.token, repoFullName: cred.repoFullName })
     } catch (e) {

--- a/packages/daemon/src/cp/gitcred-server.ts
+++ b/packages/daemon/src/cp/gitcred-server.ts
@@ -78,6 +78,9 @@ export interface GitCredServerDeps {
   /** The agent's managed credential provider from its REPLICATED SPEC — never
    *  the helper's claim (§13.2). Absent/undefined ⇒ github (the v1 behavior). */
   providerOf?: (agentId: string) => 'github' | 'gitlab' | undefined
+  /** The gitlab workspace's numeric project id from the REPLICATED SPEC — the
+   *  §17.1 request identity the grant echo is verified against. */
+  projectIdOf?: (agentId: string) => string | undefined
 }
 
 export class GitCredServer {
@@ -86,6 +89,7 @@ export class GitCredServer {
   private readonly log: GitCredServerDeps['log']
   private readonly workspaceRepoOf?: (agentId: string) => string | undefined
   private readonly providerOf?: (agentId: string) => 'github' | 'gitlab' | undefined
+  private readonly projectIdOf?: (agentId: string) => string | undefined
 
   constructor(
     private readonly cache: GitCredentialCache,
@@ -95,6 +99,7 @@ export class GitCredServer {
     this.log = deps.log
     if (deps.workspaceRepoOf) this.workspaceRepoOf = deps.workspaceRepoOf
     if (deps.providerOf) this.providerOf = deps.providerOf
+    if (deps.projectIdOf) this.projectIdOf = deps.projectIdOf
   }
 
   start(): void {
@@ -178,9 +183,15 @@ export class GitCredServer {
       if (workspace && workspace.toLowerCase() === repo.toLowerCase()) repo = undefined
     }
     if (req.op === 'erase') {
-      // Git presents the rejected credential — GitHub revokes instantly on
-      // uninstall/suspend, and this is how the daemon cache learns.
-      this.cache.invalidate(req.agentId, req.password, { plane, ...(repo !== undefined ? { repo } : {}) })
+      // Git presents the rejected credential — the provider revokes instantly on
+      // uninstall/suspend/rotation, and this is how the daemon cache learns. The
+      // SPEC-derived provider keys the entry, exactly as the get stored it.
+      const eraseProvider = this.providerOf?.(req.agentId) ?? 'github'
+      this.cache.invalidate(req.agentId, req.password, {
+        plane,
+        ...(repo !== undefined ? { repo } : {}),
+        ...(eraseProvider === 'gitlab' ? { provider: 'gitlab' as const } : {})
+      })
       this.audit('erased', req.agentId, plane, repo)
       return reply({ ok: true })
     }
@@ -199,10 +210,14 @@ export class GitCredServer {
       return reply({ ok: false, error: 'glab credentials require a managed GitLab workspace' })
     }
     try {
+      const projectId = provider === 'gitlab' ? this.projectIdOf?.(req.agentId) : undefined
       const cred = await this.cache.get(req.agentId, 'helper', {
         plane,
         ...(repo !== undefined ? { repo } : {}),
         ...(provider === 'gitlab' ? { provider: 'gitlab' as const } : {}),
+        // §17.1: the workspace ask names the rename-stable numeric identity so
+        // the consumer can reject a wrong-project grant echo.
+        ...(projectId !== undefined && repo === undefined ? { externalRepoId: projectId } : {}),
         // §13.3: the CLI wrapper is read-only BY DESIGN — a mutating glab
         // command never receives effect authority and fails at GitLab.
         ...(plane === 'glab' ? { requestedAccess: 'read' as const } : {})

--- a/packages/daemon/src/cp/glab-shim.ts
+++ b/packages/daemon/src/cp/glab-shim.ts
@@ -1,0 +1,95 @@
+// The `glab` wrapper text (gitlab-com-integration.md §13.3), the gh wrapper's GitLab twin.
+// glab reads a STATIC GITLAB_TOKEN fixed at spawn and has no credential-helper hook, so the wrapper
+// goes first on PATH. Thin on purpose: locate the real glab, forward the whole argv to the token
+// command, exec glab with what it printed. Which project that token names is decided by
+// `cp/glab-target.ts` on the Node side — sh must not parse glab argv. A user-supplied GITLAB_TOKEN
+// always wins (the documented GH_TOKEN pass-through precedent), and when no token can be served the
+// wrapper runs the real glab untouched. Secret-free (paths + agent id only).
+import { chmodSync, existsSync, mkdirSync, realpathSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+
+/** Single-quote a value for sh, escaping any quote it carries. */
+const q = (v: string) => `'${v.replaceAll("'", "'\\''")}'`
+
+export interface GlabWrapperSpec {
+  /** The wrapper's own directory, skipped while it locates the real glab. */
+  selfDir: string
+  /** Command line printing a fresh READ token for THIS invocation; receives the agent's glab argv as `"$@"`. */
+  tokenCommand: string
+}
+
+/** The wrapper script itself — ONE generator, so no second copy can drift. */
+export function renderGlabWrapper({ selfDir, tokenCommand }: GlabWrapperSpec): string {
+  return `#!/bin/sh
+# agentconnect glab wrapper — generated, never edited; NO secrets.
+# Per-invocation read-only GITLAB_TOKEN over the daemon's credential channel (gitlab-com-integration.md §13.3).
+
+SELF_DIR=${q(selfDir)}
+
+# The real glab: first one on PATH outside our own bin dir.
+REAL_GLAB=""
+_OLDIFS=$IFS; IFS=:
+for _d in $PATH; do
+  [ "$_d" = "$SELF_DIR" ] && continue
+  if [ -x "$_d/glab" ]; then REAL_GLAB="$_d/glab"; break; fi
+done
+IFS=$_OLDIFS
+if [ -z "$REAL_GLAB" ]; then
+  echo "agentconnect: glab is not installed on this machine" >&2
+  exit 127
+fi
+
+# A user-configured GITLAB_TOKEN always wins.
+if [ -n "$GITLAB_TOKEN" ]; then
+  exec "$REAL_GLAB" "$@"
+fi
+if [ -z "$AC_AGENT_ID" ]; then
+  exec "$REAL_GLAB" "$@"
+fi
+
+# Fresh READ token from the daemon; stderr passes through so the agent can read
+# WHY a project was refused. Exit 2 = "not ours" (non-gitlab host) — run the
+# real glab untouched.
+_TOKEN=$(${tokenCommand})
+_RC=$?
+if [ "$_RC" -eq 2 ]; then
+  exec "$REAL_GLAB" "$@"
+fi
+if [ -n "$_TOKEN" ]; then
+  GITLAB_TOKEN="$_TOKEN" exec "$REAL_GLAB" "$@"
+fi
+# Daemon couldn't serve one — let glab use any of its own configured auth.
+exec "$REAL_GLAB" "$@"
+`
+}
+
+export function glabShimDir(root: string): string {
+  return join(root, 'run', 'bin')
+}
+
+/** (Re)write `run/bin/glab` and return the bin dir to prepend to agent PATHs. */
+export function writeGlabShim(root: string, cliEntry: string): string {
+  const dir = glabShimDir(root)
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  try {
+    chmodSync(dir, 0o700) // defeat a loose umask; best-effort on non-POSIX
+  } catch {
+    /* best-effort */
+  }
+  const executableEntry = existsSync(cliEntry) ? realpathSync(cliEntry) : cliEntry
+  // Dev daemons run under tsx with a .ts argv[1] — route through the tsx CLI
+  // (the git-credential shim precedent).
+  const argv = [q(realpathSync(process.execPath))]
+  if (executableEntry.endsWith('.ts')) {
+    const req = createRequire(import.meta.url)
+    argv.push(q(req.resolve('tsx/cli')))
+  }
+  argv.push(q(executableEntry))
+  const body = renderGlabWrapper({
+    selfDir: dir,
+    tokenCommand: `AGENTCONNECT_ROOT=${q(root)} ${argv.join(' ')} glab-token "$AC_AGENT_ID" -- "$@"`
+  })
+  writeFileSync(join(dir, 'glab'), body, { mode: 0o755 })
+  return dir
+}

--- a/packages/daemon/src/cp/glab-target.ts
+++ b/packages/daemon/src/cp/glab-target.ts
@@ -1,0 +1,73 @@
+/**
+ * Target-project resolution for the `glab` wrapper (gitlab-com-integration.md
+ * §13.3): explicit `-R/--repo` argument, then the `GITLAB_REPO` environment,
+ * then the cwd origin remote — provider-defined precedence, resolved on the
+ * Node side so sh never parses argv. gitlab.com only: any other host defers
+ * (exit 2 — the wrapper runs the real glab untouched), matching the gh
+ * wrapper's non-github deferral.
+ */
+
+function nonEmpty(value?: string): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+/** `-R x`, `--repo x`, `-R=x`, `--repo=x` — the LAST one wins, like glab. */
+function flagRepo(argv: readonly string[]): string | undefined {
+  let found: string | undefined
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!
+    if (arg === '--') break
+    if (arg === '-R' || arg === '--repo') {
+      const next = argv[i + 1]
+      if (next && !next.startsWith('-')) found = next
+    } else if (arg.startsWith('-R=')) found = arg.slice(3)
+    else if (arg.startsWith('--repo=')) found = arg.slice(7)
+  }
+  return nonEmpty(found)
+}
+
+/**
+ * Normalize a raw project candidate. glab accepts `group/…/project` full paths,
+ * `HOST/group/…/project`, and full/scp URLs for `-R`/`GITLAB_REPO`; the cwd
+ * fallback hands us whatever `git remote get-url origin` prints. Unparseable ⇒
+ * workspace token (project undefined); a non-gitlab.com host ⇒ defer.
+ */
+export function normalizeProjectArg(raw?: string): { project?: string; defer?: boolean } {
+  const s = raw?.trim()
+  if (!s) return {}
+  // Bare namespaced path (no scheme, no scp colon) — arbitrary subgroup depth.
+  if (/^[^/\s:@]+(\/[^/\s:@]+)+$/.test(s)) {
+    const segs = s.replace(/\.git$/i, '').split('/')
+    // `gitlab.com/group/project` — the HOST/path form.
+    if (segs[0]!.toLowerCase() === 'gitlab.com') {
+      return segs.length >= 3 ? { project: segs.slice(1).join('/').toLowerCase() } : {}
+    }
+    if (segs[0]!.includes('.')) return { defer: true } // some other HOST/path form
+    return { project: segs.join('/').toLowerCase() }
+  }
+  const host = /^[a-z][a-z0-9+.-]*:\/\/(?:[^/@]+@)?([^/:]+)/i.exec(s)?.[1] ?? /^[\w.-]+@([\w.-]+):/.exec(s)?.[1]
+  if (host) {
+    if (host.toLowerCase() !== 'gitlab.com') return { defer: true }
+    const path = s
+      .replace(/^[a-z][a-z0-9+.-]*:\/\/(?:[^/@]+@)?[^/]+\//i, '')
+      .replace(/^[\w.-]+@[\w.-]+:/, '')
+      .replace(/\.git$/i, '')
+      .replace(/\/+$/, '')
+    return path.includes('/') ? { project: path.toLowerCase() } : {}
+  }
+  return {}
+}
+
+export function resolveGlabTargetProject(
+  argv: readonly string[],
+  env: { GITLAB_REPO?: string; GITLAB_HOST?: string },
+  cwdOrigin: () => string | undefined
+): { project?: string; defer?: boolean } {
+  // An explicit non-gitlab.com GITLAB_HOST retargets the whole CLI — ours only
+  // answers for gitlab.com, so everything defers to the real glab.
+  const host = nonEmpty(env.GITLAB_HOST)
+  if (host && host.toLowerCase() !== 'gitlab.com') return { defer: true }
+  const candidate = flagRepo(argv) ?? nonEmpty(env.GITLAB_REPO) ?? cwdOrigin()
+  return normalizeProjectArg(candidate)
+}

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -58,6 +58,7 @@ import {
 import {
   assertSafeWorkspaceGitConfig,
   gitCommitIdentityEnv,
+  managedCredentialHostOf,
   pullWorkspaceRef,
   workspaceGitLocalEnv,
   workspaceGitRemoteTarget
@@ -289,7 +290,10 @@ export function createWorkspaceGit(
     try {
       currentOrigin = safeExplicitOrigin(await git.raw(['remote', 'get-url', 'origin']))
       if (!target) throw new Error('workspace target is unavailable')
-      expectedOrigin = authorizeWorkspaceGitUrl(target.githubApp ? normalizeGithubRepoUrl(target.repo) : target.repo)
+      // Canonicalization follows the PROVIDER HOST, never the managed flag: a github grant is tied
+      // to exactly owner/repo, while a gitlab project keeps its full subgroup namespace.
+      const github = target.githubApp && managedCredentialHostOf(target.repo) !== 'gitlab.com'
+      expectedOrigin = authorizeWorkspaceGitUrl(github ? normalizeGithubRepoUrl(target.repo) : target.repo)
     } catch {
       return undefined
     }

--- a/packages/daemon/src/cp/workspace-scope.ts
+++ b/packages/daemon/src/cp/workspace-scope.ts
@@ -118,15 +118,21 @@ export function createWorkspaceScope(deps: WorkspaceScopeDeps): WorkspaceScope {
         return root ? { repo: root.cloneUrl, branch: root.branch, githubApp: true } : undefined
       }
       const workspace = agent.workspace
+      // The flag's name is historical: it means MANAGED credential, gitlab as much as github-app.
       return workspace.mode === 'git-repo' && workspace.gitRepo
-        ? { repo: workspace.gitRepo, branch: workspace.gitBranch, githubApp: workspace.gitCredential === 'github-app' }
+        ? {
+            repo: workspace.gitRepo,
+            branch: workspace.gitBranch,
+            githubApp: deps.workspaces.usesManagedCredential(agent)
+          }
         : undefined
     },
     usesGithubApp: (agentId, repo) => {
-      const workspace = deps.agentOf(agentId)?.workspace
+      const agent = deps.agentOf(agentId)
       // Rows exist only for App-covered repositories, so a secondary root always rides the helper.
-      if (repo !== undefined) return workspace !== undefined
-      return workspace?.mode === 'git-repo' && workspace.gitCredential === 'github-app'
+      if (repo !== undefined) return agent !== undefined
+      // Same historical name, same meaning: either managed provider rides the daemon helper.
+      return agent !== undefined && deps.workspaces.usesManagedCredential(agent)
     }
   }
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -62,6 +62,7 @@ import {
   materializeConfigFiles
 } from './shim/config-file-env.js'
 import { writeGhShim } from './cp/gh-shim.js'
+import { writeGlabShim } from './cp/glab-shim.js'
 import { GitCredServer, gitcredShimPath, gitcredSocketPath, writeGitcredShim } from './cp/gitcred-server.js'
 import {
   daemonGitCredentialTarget,
@@ -638,6 +639,7 @@ export class Daemon {
   /** run/bin with the gh wrapper (multi-repo #457) — prepended to github-app
    *  agents' PATH at host spawn; unset ⇒ shim write failed, spawn without it. */
   private ghBinDir?: string
+  private glabBinDir?: string
   /** Spawn-time config warnings per agent (config-file secrets: pointer-var
    *  conflicts, write failures) — flushed into the next dispatched session. */
   private pendingSpawnNotices = new Map<string, string[]>()
@@ -1555,6 +1557,13 @@ export class Daemon {
     })
     this.cfg = cfg
     configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
+    // §13.2 readiness: an explicit operator policy stays authoritative — but say
+    // plainly when it excludes managed GitLab rather than silently widening it.
+    if (!cfg.security.workspaceGitAllowedOrigins.some((origin) => origin.toLowerCase() === 'https://gitlab.com')) {
+      this.log.warn(
+        'workspace policy: workspaceGitAllowedOrigins excludes https://gitlab.com — managed GitLab workspaces will refuse to clone on this daemon'
+      )
+    }
     return { root, cfg }
   }
 
@@ -1659,7 +1668,8 @@ export class Daemon {
         return client.requestGitCred(payload)
       },
       log: { warn: (m: string) => this.log.warn(m) },
-      actionsSupported: () => this.cpClient?.supportsServerFeature?.('gitcred-actions-v1') ?? false
+      actionsSupported: () => this.cpClient?.supportsServerFeature?.('gitcred-actions-v1') ?? false,
+      providerV2Supported: () => this.cpClient?.supportsServerFeature?.('gitcred-provider-v2') ?? false
     })
     this.gitCredServer = new GitCredServer(this.gitCreds, gitcredSocketPath(root), {
       log: {
@@ -1672,6 +1682,11 @@ export class Daemon {
         const ws = this.agents.get(agentId)?.workspace
         if (ws?.mode !== 'git-repo' || !ws.gitRepo) return undefined
         return gitRepoLabel(ws.gitRepo) ?? undefined
+      },
+      // The REPLICATED SPEC decides the provider — never the helper's host hint.
+      providerOf: (agentId: string) => {
+        const agent = this.agents.get(agentId)
+        return agent ? this.workspaces.managedCredentialProvider(agent) : undefined
       }
     })
     const daemonCredentialTarget = daemonGitCredentialTarget({
@@ -1686,7 +1701,10 @@ export class Daemon {
         this.k8sPlane?.runsInSandbox(agentId) ? sandboxGitCredentialTarget() : daemonCredentialTarget,
       capabilityFor: (agentId) => this.gitCredServer!.capabilityFor(agentId),
       preWarm: async (agentId, reason) => {
-        await this.gitCreds.get(agentId, reason)
+        const agent = this.agents.get(agentId)
+        const provider = agent ? this.workspaces.managedCredentialProvider(agent) : undefined
+        if (provider === 'gitlab') await this.gitCreds.get(agentId, reason, { provider: 'gitlab' })
+        else await this.gitCreds.get(agentId, reason)
       }
     })
     try {
@@ -1696,6 +1714,13 @@ export class Daemon {
       this.ghBinDir = writeGhShim(root, daemonEntryForShims(root))
     } catch (err) {
       this.log.warn(`gitcred: gh wrapper shim write failed — spawning agents without it (${formatErr(err)})`)
+    }
+    try {
+      // glab wrapper (§13.3) — read-only tokens for gitlab workspaces; same
+      // regenerate-per-boot, never-block-startup discipline as gh.
+      this.glabBinDir = writeGlabShim(root, daemonEntryForShims(root))
+    } catch (err) {
+      this.log.warn(`gitcred: glab wrapper shim write failed — spawning agents without it (${formatErr(err)})`)
     }
     this.gitCredServer.start()
     probeGitVersion((m) => this.log.warn(m))
@@ -3054,7 +3079,8 @@ export class Daemon {
     agent: LoadedAgent,
     runtime: RuntimeDef,
     launchEnv: Record<string, string>,
-    githubAppCredentials: boolean
+    githubAppCredentials: boolean,
+    gitlabCredentials: boolean
   ): string[] {
     const configuredMcp = agent.mcpServers.flatMap((name) => {
       const definition = this.mcpDefsForAgent(agent.id)[name]
@@ -3069,6 +3095,15 @@ export class Daemon {
       if (launchEnv.GIT_CONFIG_GLOBAL) paths.push(launchEnv.GIT_CONFIG_GLOBAL)
       const gh = resolveCommandPath('gh', process.env)
       if (gh) executableCommands.push(gh)
+    }
+    if (gitlabCredentials) {
+      // The gitlab twin: same helper socket/shim, the glab wrapper dir, and the
+      // real glab binary for the OS sandbox's read allowlist (§13.3).
+      paths.push(gitcredSocketPath(this.root), gitcredShimPath(this.root))
+      if (this.glabBinDir) paths.push(this.glabBinDir)
+      if (launchEnv.GIT_CONFIG_GLOBAL) paths.push(launchEnv.GIT_CONFIG_GLOBAL)
+      const glab = resolveCommandPath('glab', process.env)
+      if (glab) executableCommands.push(glab)
     }
     return trustedRuntimeReadRoots({
       runtime,
@@ -3380,6 +3415,9 @@ export class Daemon {
     // A GitHub workspace uses this channel for its implicit repo; scratch uses
     // it only for explicitly authorized repos named by git/gh.
     const githubAppCredentials = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'github-app'
+    const gitlabCredentials = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'gitlab'
+    const managedCredentials = githubAppCredentials || gitlabCredentials
+    const managedCredentialHost = gitlabCredentials ? ('gitlab.com' as const) : ('github.com' as const)
     // The Git session policy runs for every configured repository, not only
     // GitHub review: repository hooks/fsmonitor stay disabled without rewriting
     // checkout config. sessionGitEnv additionally supplies GitHub App identity.
@@ -3399,8 +3437,8 @@ export class Daemon {
     // is re-materialized on every spawn, because a resumed Sandbox is a new pod with an empty tmpfs.
     // The daemon-local write (sessionGitEnv) would land the file on this daemon's disk instead.
     const sandboxSessionGit =
-      this.k8sPlane && githubAppCredentials
-        ? sessionGitConfig(agent.id, this.gitCommitIdentity, sandboxGitCredentialTarget())
+      this.k8sPlane && managedCredentials
+        ? sessionGitConfig(agent.id, this.gitCommitIdentity, sandboxGitCredentialTarget(), managedCredentialHost)
         : undefined
     const env: Record<string, string> = {
       ...baseEnv,
@@ -3411,8 +3449,8 @@ export class Daemon {
       ...memoryProviderFor(memoryAgent, runtime, baseEnv, this.externalMemoryAdmission(agent.id)).runtimeEnv(),
       // App identity rides with the CREDENTIAL mode, not the workspace mode: a scratch workspace with
       // authorized repositories needs the capability for its git and gh exactly like a clone does.
-      ...(githubAppCredentials
-        ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, this.gitCommitIdentity))
+      ...(managedCredentials
+        ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, this.gitCommitIdentity, managedCredentialHost))
         : agent.workspace.mode === 'git-repo'
           ? sessionGitPolicyEnv()
           : {})
@@ -3457,6 +3495,11 @@ export class Daemon {
       env.AC_AGENT_ID = agent.id
       shimDirs.add(this.ghBinDir)
     }
+    if (gitlabCredentials && this.glabBinDir && !this.k8sPlane) {
+      // glab wrapper (§13.3): read-only project tokens for the managed workspace.
+      env.AC_AGENT_ID = agent.id
+      shimDirs.add(this.glabBinDir)
+    }
     if (shimDirs.size > 0) {
       env.PATH = `${[...shimDirs].join(':')}:${env.PATH ?? process.env.PATH ?? ''}`
     }
@@ -3496,7 +3539,8 @@ export class Daemon {
           if (this.codexSessionFloor) applyCodexSessionFloor(target, launchEnv, this.codexSessionFloor)
         },
         runtimeReadRoots: runInSandbox
-          ? (launchEnv) => this.sandboxRuntimeReadRoots(agent, runtime, launchEnv, githubAppCredentials)
+          ? (launchEnv) =>
+              this.sandboxRuntimeReadRoots(agent, runtime, launchEnv, githubAppCredentials, gitlabCredentials)
           : undefined,
         trustedWorkspaceWriteRoots: runInSandbox ? this.workspaces.trustedWorkspaceWriteRoots(agent) : undefined,
         sandboxMechanism: this.sandboxMechanism,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1687,6 +1687,10 @@ export class Daemon {
       providerOf: (agentId: string) => {
         const agent = this.agents.get(agentId)
         return agent ? this.workspaces.managedCredentialProvider(agent) : undefined
+      },
+      projectIdOf: (agentId: string) => {
+        const ws = this.agents.get(agentId)?.workspace
+        return ws?.mode === 'git-repo' ? ws.gitlabProjectId : undefined
       }
     })
     const daemonCredentialTarget = daemonGitCredentialTarget({
@@ -1703,8 +1707,13 @@ export class Daemon {
       preWarm: async (agentId, reason) => {
         const agent = this.agents.get(agentId)
         const provider = agent ? this.workspaces.managedCredentialProvider(agent) : undefined
-        if (provider === 'gitlab') await this.gitCreds.get(agentId, reason, { provider: 'gitlab' })
-        else await this.gitCreds.get(agentId, reason)
+        if (provider === 'gitlab') {
+          const projectId = agent?.workspace.mode === 'git-repo' ? agent.workspace.gitlabProjectId : undefined
+          await this.gitCreds.get(agentId, reason, {
+            provider: 'gitlab',
+            ...(projectId !== undefined ? { externalRepoId: projectId } : {})
+          })
+        } else await this.gitCreds.get(agentId, reason)
       }
     })
     try {
@@ -3545,7 +3554,9 @@ export class Daemon {
         trustedWorkspaceWriteRoots: runInSandbox ? this.workspaces.trustedWorkspaceWriteRoots(agent) : undefined,
         sandboxMechanism: this.sandboxMechanism,
         mcpSocketPath: mcpSocketPath(this.root),
-        allowModelToolUnixSockets: githubAppCredentials,
+        // Inner tool sandboxes must CONNECT to the daemon socket for either
+        // managed provider — read permission on the path alone is insufficient.
+        allowModelToolUnixSockets: managedCredentials,
         // The pod is the isolation boundary AND a different filesystem, so this daemon's env
         // must not travel with the launch.
         ...(this.k8s ? { k8s: true as const } : {})

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1616,13 +1616,13 @@ export class Daemon {
           // the daemon's own filesystem, so without a tunnel they exist nowhere the pod can reach.
           // `mcp` is served for every pod agent because any session may carry tools and the
           // listener belongs to the pod's lifetime, while the spec that dials it is decided per
-          // session; a GitHub-App workspace adds the credential helper its git asks for.
+          // session; a managed-credential workspace — github-app or gitlab — adds the helper socket.
           // An id this daemon holds no agent for gets neither: the member's own runtime probe is
           // the case, and its channel is granted `probe` alone, so asking would only be refused.
           tunnelsFor: (agentId) => {
             const agent = this.agents.get(agentId)
             if (!agent) return []
-            return agent.workspace.gitCredential === 'github-app' ? ['mcp', 'gitcred'] : ['mcp']
+            return this.workspaces.usesManagedCredential(agent) ? ['mcp', 'gitcred'] : ['mcp']
           },
           tunnelSocketPath: (tunnel) => (tunnel === 'gitcred' ? gitcredSocketPath(root) : mcpSocketPath(root)),
           // A bound sandbox is a reachable memory tree: drain any managed capture that waited for it.

--- a/packages/daemon/src/gitcred/glab-token-client.ts
+++ b/packages/daemon/src/gitcred/glab-token-client.ts
@@ -1,0 +1,80 @@
+// The glab wrapper's token fetch (gitlab-com-integration.md §13.3), independent of WHERE it runs.
+// Resolves the TARGET project with the pure `cp/glab-target.ts` resolver, then proxies gitcred with
+// `plane: 'glab'` — the daemon serves the binding's READ credential only, so a mutating glab command
+// never receives effect authority and fails at GitLab. Exit codes are the wrapper's contract:
+// 0 = token on stdout, 1 = refused/unreachable (reason on stderr), 2 = "not ours" (non-gitlab host).
+import { execFileSync } from 'node:child_process'
+import { createConnection } from 'node:net'
+import { resolveGlabTargetProject } from '../cp/glab-target.js'
+import { GITCRED_CAPABILITY_ENV } from './env.js'
+
+/** Fetch the read token for this glab invocation and print it — nothing else ever reaches stdout. */
+export async function emitGlabToken(agentId: string, glabArgv: readonly string[], socketPath: string): Promise<void> {
+  const target = resolveGlabTargetProject(glabArgv, process.env, cwdOriginRemote)
+  if (target.defer) {
+    process.exitCode = 2
+    return
+  }
+
+  const res = await ipc(socketPath, {
+    op: 'get',
+    agentId,
+    capability: process.env[GITCRED_CAPABILITY_ENV],
+    plane: 'glab',
+    provider: 'gitlab',
+    repoFullName: target.project
+  })
+  if (!res.ok || !res.password) {
+    process.stderr.write(
+      `agentconnect: no glab credentials for agent ${agentId}${target.project ? ` on ${target.project}` : ''}: ${res.error ?? 'unknown error'}\n`
+    )
+    process.exitCode = 1
+    return
+  }
+  process.stdout.write(res.password)
+}
+
+/** The last-resort target: the origin remote of the directory the agent ran glab in. */
+function cwdOriginRemote(): string | undefined {
+  try {
+    const out = execFileSync('git', ['remote', 'get-url', 'origin'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+    return out.trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
+interface IpcReply {
+  ok: boolean
+  password?: string
+  error?: string
+}
+
+function ipc(path: string, msg: unknown): Promise<IpcReply> {
+  return new Promise((resolve) => {
+    const sock = createConnection(path)
+    let buf = ''
+    const fail = (error: string) => resolve({ ok: false, error })
+    sock.setTimeout(15_000, () => {
+      sock.destroy()
+      fail('daemon did not answer in time')
+    })
+    sock.on('connect', () => sock.write(JSON.stringify(msg) + '\n'))
+    sock.on('data', (c) => {
+      buf += c.toString('utf8')
+      const nl = buf.indexOf('\n')
+      if (nl === -1) return
+      sock.destroy()
+      try {
+        resolve(JSON.parse(buf.slice(0, nl)) as IpcReply)
+      } catch {
+        fail('malformed daemon reply')
+      }
+    })
+    sock.on('error', (e) => fail(`cannot reach the daemon socket at ${path}: ${e.message}`))
+  })
+}

--- a/packages/daemon/src/gitcred/helper.ts
+++ b/packages/daemon/src/gitcred/helper.ts
@@ -52,7 +52,11 @@ export async function runGitCredential(action: string, agentId: string, socketPa
   agentId = effectiveAgentId(agentId)
 
   const input = parseStdin(await readStdin())
-  const repo = input.path !== undefined ? repoFromPath(input.path) : undefined
+  const host = input.host?.toLowerCase()
+  // gitlab.com paths keep their FULL namespaced depth (subgroups, §13.2);
+  // github stays at owner/repo.
+  const gitlab = host === 'gitlab.com'
+  const repo = input.path !== undefined ? (gitlab ? projectFromPath(input.path) : repoFromPath(input.path)) : undefined
 
   if (action === 'erase') {
     // Route the invalidation to the same (agent, repo) key the get used.
@@ -61,13 +65,14 @@ export async function runGitCredential(action: string, agentId: string, socketPa
       agentId,
       capability: process.env[GITCRED_CAPABILITY_ENV],
       password: input.password,
-      repoFullName: repo
+      repoFullName: repo,
+      ...(gitlab ? { provider: 'gitlab' } : {})
     }).catch(() => undefined) // best-effort
     return
   }
   if (action !== 'get') return // unknown actions are ignored per the helper contract
 
-  if (input.host !== undefined && input.host.toLowerCase() !== 'github.com') {
+  if (host !== undefined && host !== 'github.com' && host !== 'gitlab.com') {
     // Not ours — stay silent so git can try other helpers / fail cleanly.
     return
   }
@@ -76,7 +81,8 @@ export async function runGitCredential(action: string, agentId: string, socketPa
     op: 'get',
     agentId,
     capability: process.env[GITCRED_CAPABILITY_ENV],
-    repoFullName: repo
+    repoFullName: repo,
+    ...(gitlab ? { provider: 'gitlab' } : {})
   })
   if (!res.ok || !res.username || !res.password) {
     process.stderr.write(
@@ -106,6 +112,16 @@ function normalizeRepoPath(p: string): string {
     .replace(/^\/+/, '')
     .replace(/\.git$/i, '')
     .toLowerCase()
+}
+
+/** The full namespaced GitLab project path from git's credential `path` —
+ *  arbitrary subgroup depth, tolerating a leading slash, a `.git` suffix, and
+ *  LFS-ish subpaths (`group/sub/project.git/info/lfs`). */
+export function projectFromPath(p: string): string | undefined {
+  const cleaned = p.replace(/^\/+/, '')
+  const gitSuffix = cleaned.search(/\.git(?:\/|$)/i)
+  const path = (gitSuffix >= 0 ? cleaned.slice(0, gitSuffix) : cleaned).replace(/\/+$/, '')
+  return path.includes('/') ? path.toLowerCase() : undefined
 }
 
 /** "owner/repo" from git's credential `path` — tolerates a leading slash, a

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -210,6 +210,20 @@ program
     await runGhToken(agentId, ghArgs)
   })
 
+// glab token fetch (gitlab-com-integration.md §13.3): the gh-token twin —
+// invoked BY the run/bin/glab wrapper once per invocation. Prints ONLY the
+// READ token on stdout; exit 2 = non-gitlab target (wrapper runs real glab).
+program
+  .command('glab-token', { hidden: true })
+  .description('Fetch a read-only GITLAB_TOKEN from the local daemon (glab wrapper backend)')
+  .argument('<agentId>', 'agent whose credentials to serve')
+  .argument('[glabArgs...]', "the agent's glab argv, forwarded verbatim after `--`")
+  .allowUnknownOption()
+  .action(async (agentId: string, glabArgs: string[]) => {
+    const { runGlabToken } = await import('./cli/glab-token.js')
+    await runGlabToken(agentId, glabArgs)
+  })
+
 // Agent business config (identity, status, bindings) is owned by the Control
 // Plane or by hand-editing agent.json — the daemon only reconciles what it finds
 // on disk (docs §4/§5). So the CLI exposes a read-only `list`, not local CRUD.

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -256,7 +256,9 @@ export function workspaceGitRemoteTarget(
   const remote = `agentconnect-${randomUUID()}`
   const pairs = [
     ...workspaceGitConfigPairs(normalized),
-    ...(credentialAgentId ? credentialConfigPairs(credentialAgentId) : []),
+    ...(credentialAgentId
+      ? credentialConfigPairs(credentialAgentId, managedCredentialHostOf(normalized) ?? 'github.com')
+      : []),
     // Never an empty value first: Git reads it as the first fetch URL and fails before the authorized target.
     [`remote.${remote}.url`, normalized] as const,
     [`remote.${remote}.proxy`, ''] as const
@@ -328,6 +330,20 @@ export async function pullWorkspaceRef(git: GitRunner, remote: string, branch: s
   await git.raw(['check-ref-format', '--branch', branch])
   const refspec = `+refs/heads/${branch}:refs/remotes/origin/${branch}`
   return git.pull(remote, refspec, ['--ff-only', '--no-recurse-submodules'])
+}
+
+/** The managed-credential hosts the helper may answer for (§13.2: exact origins). */
+export type ManagedCredentialHost = 'github.com' | 'gitlab.com'
+
+/** Which managed host a workspace repository URL belongs to; undefined ⇒ neither. */
+export function managedCredentialHostOf(repository: string | undefined): ManagedCredentialHost | undefined {
+  if (!repository) return undefined
+  try {
+    const host = new URL(normalizeGitCloneUrl(repository)).host.toLowerCase()
+    return host === 'github.com' ? 'github.com' : host === 'gitlab.com' ? 'gitlab.com' : undefined
+  } catch {
+    return undefined
+  }
 }
 
 /**
@@ -424,12 +440,14 @@ function quotedHelper(agentId: string, target: GitCredentialTarget = targetOf(ag
   return `!'${helper.replaceAll("'", "'\\''")}' ${agentId}`
 }
 
-/** The three github.com-scoped config pairs both channels share. */
-function credentialConfigPairs(agentId: string): Array<[string, string]> {
+/** The three host-scoped config pairs both channels share. The host defaults to
+ *  github.com; a gitlab workspace pins gitlab.com instead (§13.2) — never both,
+ *  so a non-gitlab agent keeps whatever machine gitlab credentials exist. */
+function credentialConfigPairs(agentId: string, host: ManagedCredentialHost = 'github.com'): Array<[string, string]> {
   return [
-    ['credential.https://github.com.helper', ''], // reset: machine helpers must never answer for github.com
-    ['credential.https://github.com.helper', quotedHelper(agentId)],
-    ['credential.https://github.com.useHttpPath', 'true'] // git strips `path` otherwise — the helper wants it
+    [`credential.https://${host}.helper`, ''], // reset: machine helpers must never answer for this host
+    [`credential.https://${host}.helper`, quotedHelper(agentId)],
+    [`credential.https://${host}.useHttpPath`, 'true'] // git strips `path` otherwise — the helper wants it
   ]
 }
 
@@ -439,7 +457,10 @@ function credentialConfigPairs(agentId: string): Array<[string, string]> {
  * child environment (v3.36 verified), a bare object would strip PATH/HOME.
  */
 export function cloneGitEnv(agentId: string, repository?: string): Record<string, string> {
-  const pairs = [...workspaceGitConfigPairs(repository), ...credentialConfigPairs(agentId)]
+  const pairs = [
+    ...workspaceGitConfigPairs(repository),
+    ...credentialConfigPairs(agentId, managedCredentialHostOf(repository) ?? 'github.com')
+  ]
   const env: Record<string, string> = {
     ...gitCredentialEnv(agentId),
     GIT_TERMINAL_PROMPT: '0',
@@ -462,15 +483,16 @@ export function sessionGitConfig(
   commitIdentity?: GitCommitIdentity,
   // Explicit for a spawn that KNOWS where the runtime will run (a --k8s launch always lands in the
   // pod), so the env cannot depend on whether the shim channel happens to be attached right now.
-  target: GitCredentialTarget = targetOf(agentId)
+  target: GitCredentialTarget = targetOf(agentId),
+  host: ManagedCredentialHost = 'github.com'
 ): { path: string; content: string; env: Record<string, string> } {
   const file = join(target.configDir, `${agentId}.gitconfig`)
   const lines = [
     '# agentconnect session git config — regenerated on agent start; NO secrets.',
-    '# Keeps non-identity host config, then pins github.com credentials to the daemon helper.',
+    `# Keeps non-identity host config, then pins ${host} credentials to the daemon helper.`,
     ...(target.hostConfig ? ['[include]', `\tpath = ${target.hostConfig}`] : []),
-    '[credential "https://github.com"]',
-    '\thelper = ', // reset the accumulated helper list for github.com
+    `[credential "https://${host}"]`,
+    '\thelper = ', // reset the accumulated helper list for this host
     `\thelper = ${quotedHelper(agentId, target)}`,
     '\tuseHttpPath = true',
     ''
@@ -496,11 +518,15 @@ export function sessionGitConfig(
  * Refuses a sandbox target rather than writing one: this is a synchronous local write, and the
  * caller that owns a pod's files is the async materialization path.
  */
-export function sessionGitEnv(agentId: string, commitIdentity?: GitCommitIdentity): Record<string, string> {
+export function sessionGitEnv(
+  agentId: string,
+  commitIdentity?: GitCommitIdentity,
+  host: ManagedCredentialHost = 'github.com'
+): Record<string, string> {
   if (targetOf(agentId).kind !== 'daemon') {
     throw new Error(`agent ${agentId} runs its git in a sandbox — materialize its gitconfig instead of writing it`)
   }
-  const { path: file, content, env } = sessionGitConfig(agentId, commitIdentity)
+  const { path: file, content, env } = sessionGitConfig(agentId, commitIdentity, targetOf(agentId), host)
   mkdirSync(dirname(file), { recursive: true, mode: 0o700 })
   writeFileSync(file, content, { mode: 0o644 })
   return env
@@ -520,13 +546,17 @@ export function gitCommitIdentityEnv(identity: GitCommitIdentity): Record<string
 }
 
 /** Post-clone: pin the repo-local helper so agent-run git in the checkout works. */
-export async function writeRepoHelperConfig(runner: GitRunner, agentId: string): Promise<void> {
+export async function writeRepoHelperConfig(
+  runner: GitRunner,
+  agentId: string,
+  host: ManagedCredentialHost = 'github.com'
+): Promise<void> {
   const git = runner.withEnv(workspaceGitLocalEnv())
   // `--replace-all` on the first write resets any stale helper list from a
   // previous agent generation; addConfig(append=true) accumulates the rest.
-  await git.raw(['config', '--replace-all', 'credential.https://github.com.helper', ''])
-  await git.raw(['config', '--add', 'credential.https://github.com.helper', quotedHelper(agentId)])
-  await git.raw(['config', 'credential.https://github.com.useHttpPath', 'true'])
+  await git.raw(['config', '--replace-all', `credential.https://${host}.helper`, ''])
+  await git.raw(['config', '--add', `credential.https://${host}.helper`, quotedHelper(agentId)])
+  await git.raw(['config', `credential.https://${host}.useHttpPath`, 'true'])
 }
 
 /** Pre-warm hook for workspace-manager (no-op until initialized). */

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -33,7 +33,8 @@ import {
   workspaceGitEnvBase,
   workspaceGitLocalEnv,
   workspaceGitRemoteTarget,
-  writeRepoHelperConfig
+  writeRepoHelperConfig,
+  managedCredentialHostOf
 } from './git-injection.js'
 import { LocalGitRunner, type GitRunner } from './git-runner.js'
 import { localWorkspaceFs, type WorkspaceFs, type WorkspacePlacement } from './workspace-fs.js'
@@ -268,6 +269,18 @@ export class WorkspaceManager {
     return agent.workspace.mode === 'git-repo' && agent.workspace.gitCredential === 'github-app'
   }
 
+  /** Which managed credential backs this workspace's remote git; undefined ⇒ anonymous. */
+  managedCredentialProvider(agent: Agent): 'github' | 'gitlab' | undefined {
+    if (agent.workspace.mode !== 'git-repo') return undefined
+    if (agent.workspace.gitCredential === 'github-app') return 'github'
+    if (agent.workspace.gitCredential === 'gitlab') return 'gitlab'
+    return undefined
+  }
+
+  usesManagedCredential(agent: Agent): boolean {
+    return this.managedCredentialProvider(agent) !== undefined
+  }
+
   gitRepoOf(agent: Agent): string {
     if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) {
       throw new Error(`workspace clone: agent "${agent.id}" has git-repo mode but no gitRepo configured`)
@@ -292,7 +305,9 @@ export class WorkspaceManager {
       branch: agent.workspace.gitBranch,
       path: mount === undefined ? agent.workspace.path : this.clusterWorkspaceCheckout(agent, mount),
       worktreesPath: this.worktreesPathAt(agent, mount),
-      githubApp: this.usesGithubApp(agent)
+      // The MANAGED-credential flag (name is historical): a gitlab workspace
+      // rides the same helper pin/pre-warm/clone-env paths, host-derived.
+      githubApp: this.usesManagedCredential(agent)
     }
   }
 
@@ -988,7 +1003,11 @@ export class WorkspaceManager {
       // The CP follows repository renames by numeric repo id. Repoint the existing
       // checkout instead of treating that canonical URL refresh as a new workspace.
       await this.convergeWorkspaceOrigin(agent, cwd)
-      await writeRepoHelperConfig(this.runnerFor(agent.id, cwd), agent.id).catch(() => undefined)
+      await writeRepoHelperConfig(
+        this.runnerFor(agent.id, cwd),
+        agent.id,
+        managedCredentialHostOf(root.cloneUrl) ?? 'github.com'
+      ).catch(() => undefined)
     } else {
       // Historical anonymous checkouts may still have credential-bearing or
       // disallowed origins even after their CP row has been sanitized.
@@ -1748,7 +1767,7 @@ export class WorkspaceManager {
     // Validated at the execution boundary, exactly as the local path does: a hand-edited agent.json
     // must not turn daemon-managed git into a local-path or remote-helper launcher.
     const repository = this.gitRepoOf(agent)
-    const githubApp = this.usesGithubApp(agent)
+    const githubApp = this.usesManagedCredential(agent)
 
     // Whether the volume can be PROVEN to hold what the marker would claim. A fresh clone can, by
     // construction (`--branch` at clone time). An existing one has to be interrogated.
@@ -1765,7 +1784,11 @@ export class WorkspaceManager {
       // `.git/config`, whose agent id goes stale when an agent is recreated over a surviving volume.
       await this.convergeOriginInPlace(agent, checkout)
       if (githubApp) {
-        await writeRepoHelperConfig(this.runnerFor(agent.id, checkout), agent.id).catch(() => undefined)
+        await writeRepoHelperConfig(
+          this.runnerFor(agent.id, checkout),
+          agent.id,
+          managedCredentialHostOf(repository) ?? 'github.com'
+        ).catch(() => undefined)
       }
     }
 
@@ -1908,7 +1931,7 @@ export class WorkspaceManager {
   }
 
   async cloneInSandbox(agent: Agent, root: string, repository: string, checkout: string): Promise<void> {
-    const githubApp = this.usesGithubApp(agent)
+    const githubApp = this.usesManagedCredential(agent)
     if (githubApp) await preWarmGitCred(agent.id, 'clone')
     const env = githubApp
       ? { ...workspaceGitEnvBase(repository), ...cloneGitEnv(agent.id, repository) }
@@ -1923,7 +1946,13 @@ export class WorkspaceManager {
       await this.clearSandboxPath(agent.id, checkout)
       throw err
     }
-    if (githubApp) await writeRepoHelperConfig(this.runnerFor(agent.id, checkout), agent.id)
+    if (githubApp) {
+      await writeRepoHelperConfig(
+        this.runnerFor(agent.id, checkout),
+        agent.id,
+        managedCredentialHostOf(repository) ?? 'github.com'
+      )
+    }
   }
 
   resolvePreparedWorkspaceCwd(agent: Agent): string {
@@ -2225,7 +2254,13 @@ export class WorkspaceManager {
       // Pin the repo-local helper so AGENT-run git in this checkout authenticates
       // through the daemon too — the "no credentials on the machine, but the agent
       // can still push" half of the design.
-      if (githubApp) await writeRepoHelperConfig(this.runnerFor(agentId, cwd), agentId)
+      if (githubApp) {
+        await writeRepoHelperConfig(
+          this.runnerFor(agentId, cwd),
+          agentId,
+          managedCredentialHostOf(cloneUrl) ?? 'github.com'
+        )
+      }
     })().finally(() => {
       this.cloneInFlight.delete(key)
     })

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -723,6 +723,22 @@ export class WorkspaceManager {
     }
   }
 
+  /** A managed root's origin must stay on ITS provider host, derived from the
+   *  authorized clone URL (github.com unless the root is a gitlab.com one). */
+  isTrustedManagedOrigin(input: string, cloneUrl: string): boolean {
+    const host = managedCredentialHostOf(cloneUrl) ?? 'github.com'
+    const raw = input.trim()
+    if (raw.includes('\\')) return false
+    const scp = /^[\w.-]+@([\w.-]+):/.exec(raw)
+    if (scp) return scp[1]!.toLowerCase() === host
+    if (!/^(?:https|ssh):\/\//i.test(raw)) return false
+    try {
+      return new URL(normalizeGitCloneUrl(redactGitUrlSecrets(raw))).hostname.toLowerCase() === host
+    } catch {
+      return false
+    }
+  }
+
   isTrustedGithubOrigin(input: string): boolean {
     const raw = input.trim()
     if (raw.includes('\\')) return false
@@ -809,7 +825,9 @@ export class WorkspaceManager {
       if (root.githubApp) throw new UntrustedGithubWorkspaceOriginError({ cause })
       return
     }
-    if (root.githubApp && !this.isTrustedGithubOrigin(current)) {
+    // Managed roots trust exactly their provider's host: a gitlab root's
+    // origin must be gitlab.com, a github one github.com (§13.2).
+    if (root.githubApp && !this.isTrustedManagedOrigin(current, root.cloneUrl)) {
       throw new UntrustedGithubWorkspaceOriginError()
     }
     const normalizedCurrent = normalizeGitUrl(current)

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -24,7 +24,11 @@ describe('loadConfig', () => {
     expect(cfg.version).toBe(1)
     expect(cfg.runtimes.claude.command).toBe('npx')
     expect(cfg.security.isolateAccountApps).toBe(true)
-    expect(cfg.security.workspaceGitAllowedOrigins).toEqual(['https://github.com', 'ssh://github.com'])
+    expect(cfg.security.workspaceGitAllowedOrigins).toEqual([
+      'https://github.com',
+      'ssh://github.com',
+      'https://gitlab.com'
+    ])
     expect(cfg.features.turnFinalContextRefresh).toBe(true)
     expect(cfg.limits.maxAgents).toBe(32)
     expect(cfg.agentsDir).toContain('agents')

--- a/packages/daemon/test/cp/gitlab-gitcred.test.ts
+++ b/packages/daemon/test/cp/gitlab-gitcred.test.ts
@@ -75,6 +75,20 @@ describe('GitCredentialCache — gitlab provider (§17.1)', () => {
     const h = build({ v2: true, respond: () => githubGrant })
     await expect(h.cache.get(AGENT, 'clone', { provider: 'gitlab' })).rejects.toThrow(/provider github/)
   })
+
+  it('rejects a wrong-project numeric echo (§17.1) and evicts by the provider-qualified key on erase', async () => {
+    const h = build({ v2: true, respond: () => gitlabGrant })
+    await expect(h.cache.get(AGENT, 'clone', { provider: 'gitlab', externalRepoId: '999' })).rejects.toThrow(
+      /project 4455667 for project 999/
+    )
+
+    // Erase must hit the SAME provider-qualified key the get stored under.
+    const cached = await h.cache.get(AGENT, 'clone', { provider: 'gitlab', externalRepoId: '4455667' })
+    expect(cached.token).toBe('glpat-1')
+    h.cache.invalidate(AGENT, 'glpat-1', { provider: 'gitlab' })
+    await h.cache.get(AGENT, 'clone', { provider: 'gitlab', externalRepoId: '4455667' })
+    expect(h.calls()).toBe(3) // eviction forced a fresh CP ask
+  })
 })
 
 describe('helper path parsing (§13.2)', () => {
@@ -84,6 +98,20 @@ describe('helper path parsing (§13.2)', () => {
     expect(projectFromPath('Group/Project.git/info/lfs')).toBe('group/project')
     expect(projectFromPath('just-a-name')).toBeUndefined()
     expect(repoFromPath('owner/repo.git/info/lfs')).toBe('owner/repo')
+  })
+})
+
+describe('managed origin convergence trust (round 2)', () => {
+  it('a managed root trusts exactly ITS provider host', async () => {
+    const { WorkspaceManager } = await import('../../src/workspace/workspace-manager.js')
+    const wm = new WorkspaceManager()
+    const gitlabRoot = 'https://gitlab.com/example-group/example-project'
+    expect(wm.isTrustedManagedOrigin('https://gitlab.com/example-group/example-project.git', gitlabRoot)).toBe(true)
+    expect(wm.isTrustedManagedOrigin('git@gitlab.com:example-group/example-project.git', gitlabRoot)).toBe(true)
+    expect(wm.isTrustedManagedOrigin('https://github.com/acme/infra.git', gitlabRoot)).toBe(false)
+    const githubRoot = 'https://github.com/acme/infra'
+    expect(wm.isTrustedManagedOrigin('https://github.com/acme/infra.git', githubRoot)).toBe(true)
+    expect(wm.isTrustedManagedOrigin('https://gitlab.com/g/p.git', githubRoot)).toBe(false)
   })
 })
 

--- a/packages/daemon/test/cp/gitlab-gitcred.test.ts
+++ b/packages/daemon/test/cp/gitlab-gitcred.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Provider-aware git credentials, daemon side (gitlab-com-integration.md
+ * §13.2/§17.1): the cache keys gitlab grants apart, gates the provider on the
+ * CP's gitcred-provider-v2 advertisement, and rejects a stripped or mismatched
+ * provider echo; the helper parses full-depth gitlab paths; the injection
+ * module pins exactly one managed host per workspace.
+ */
+import { describe, it, expect } from 'vitest'
+import type { GitCredGrant } from '@agentconnect.md/protocol'
+import { GitCredentialCache, GitCredUnavailableError } from '../../src/cp/git-credential.js'
+import { projectFromPath, repoFromPath } from '../../src/gitcred/helper.js'
+import { initGitInjection, managedCredentialHostOf, sessionGitConfig } from '../../src/workspace/git-injection.js'
+
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+type Payload = { provider?: string; requestedAccess?: string }
+
+function build(opts: { v2?: boolean; respond: (payload: Payload, n: number) => GitCredGrant }) {
+  let calls = 0
+  const seen: Payload[] = []
+  const cache = new GitCredentialCache({
+    request: async (payload) => {
+      calls += 1
+      seen.push(payload)
+      return opts.respond(payload, calls)
+    },
+    log: { warn: () => {} },
+    monoNow: () => 0,
+    providerV2Supported: () => opts.v2 === true
+  })
+  return { cache, seen, calls: () => calls }
+}
+
+const gitlabGrant: GitCredGrant = {
+  username: 'agentconnect-p4455667',
+  token: 'glpat-1',
+  ttlSec: 3600,
+  expiresAt: '2026-08-22T01:00:00.000Z',
+  repoFullName: 'example-group/example-project',
+  access: 'write',
+  provider: 'gitlab',
+  externalRepoId: '4455667',
+  credentialEpoch: '3',
+  providerExpiresAt: '2026-11-20T00:00:00.000Z'
+}
+
+const githubGrant: GitCredGrant = {
+  username: 'x-access-token',
+  token: 'ghs_1',
+  ttlSec: 3540,
+  expiresAt: '2026-08-22T01:00:00.000Z',
+  repoFullName: 'acme/infra',
+  access: 'write'
+}
+
+describe('GitCredentialCache — gitlab provider (§17.1)', () => {
+  it('keys gitlab apart from github and forwards provider + requestedAccess', async () => {
+    const h = build({ v2: true, respond: (payload) => (payload.provider === 'gitlab' ? gitlabGrant : githubGrant) })
+    const gitlab = await h.cache.get(AGENT, 'clone', { provider: 'gitlab', requestedAccess: 'read' })
+    expect(gitlab.username).toBe('agentconnect-p4455667')
+    const github = await h.cache.get(AGENT, 'clone')
+    expect(github.username).toBe('x-access-token')
+    expect(h.calls()).toBe(2) // distinct cache keys, no cross-provider reuse
+    expect(h.seen[0]).toMatchObject({ provider: 'gitlab', requestedAccess: 'read' })
+    expect(h.seen[1]?.provider).toBeUndefined()
+  })
+
+  it('refuses to name a provider before the CP advertises gitcred-provider-v2', async () => {
+    const h = build({ v2: false, respond: () => gitlabGrant })
+    await expect(h.cache.get(AGENT, 'clone', { provider: 'gitlab' })).rejects.toThrow(GitCredUnavailableError)
+    expect(h.calls()).toBe(0) // never even asked — the frame would be misread
+  })
+
+  it('rejects a stripped provider echo: an old CP answered the wrong workspace grant', async () => {
+    const h = build({ v2: true, respond: () => githubGrant })
+    await expect(h.cache.get(AGENT, 'clone', { provider: 'gitlab' })).rejects.toThrow(/provider github/)
+  })
+})
+
+describe('helper path parsing (§13.2)', () => {
+  it('preserves full gitlab subgroup depth; github stays owner/repo', () => {
+    expect(projectFromPath('group/sub/deeper/project.git')).toBe('group/sub/deeper/project')
+    expect(projectFromPath('/group/project')).toBe('group/project')
+    expect(projectFromPath('Group/Project.git/info/lfs')).toBe('group/project')
+    expect(projectFromPath('just-a-name')).toBeUndefined()
+    expect(repoFromPath('owner/repo.git/info/lfs')).toBe('owner/repo')
+  })
+})
+
+describe('injection host selection (§13.2)', () => {
+  const target = { kind: 'daemon' as const, helper: '/x/helper', configDir: '/x/cfg' }
+  initGitInjection({
+    targetFor: () => target,
+    preWarm: async () => {},
+    capabilityFor: () => 'cap-test'
+  })
+
+  it('derives the managed host from the workspace URL, exactly one per workspace', () => {
+    expect(managedCredentialHostOf('https://gitlab.com/example-group/example-project')).toBe('gitlab.com')
+    expect(managedCredentialHostOf('https://github.com/acme/infra')).toBe('github.com')
+    expect(managedCredentialHostOf('https://code.example.test/x/y')).toBeUndefined()
+    expect(managedCredentialHostOf(undefined)).toBeUndefined()
+  })
+
+  it('pins the session gitconfig to the workspace host only', () => {
+    const gitlab = sessionGitConfig(AGENT, undefined, target, 'gitlab.com')
+    expect(gitlab.content).toContain('[credential "https://gitlab.com"]')
+    expect(gitlab.content).not.toContain('github.com')
+    const github = sessionGitConfig(AGENT, undefined, target)
+    expect(github.content).toContain('[credential "https://github.com"]')
+    expect(github.content).not.toContain('gitlab.com')
+  })
+})
+
+describe('glab target resolution (§13.3)', () => {
+  it('resolves -R/--repo, GITLAB_REPO, then the cwd origin, at full subgroup depth', async () => {
+    const { resolveGlabTargetProject } = await import('../../src/cp/glab-target.js')
+    const none = () => undefined
+    expect(resolveGlabTargetProject(['mr', 'view', '-R', 'group/sub/proj'], {}, none)).toEqual({
+      project: 'group/sub/proj'
+    })
+    expect(resolveGlabTargetProject(['issue', 'list', '--repo=Group/Proj'], {}, none)).toEqual({
+      project: 'group/proj'
+    })
+    expect(resolveGlabTargetProject([], { GITLAB_REPO: 'group/env-proj' }, none)).toEqual({
+      project: 'group/env-proj'
+    })
+    expect(resolveGlabTargetProject([], {}, () => 'https://gitlab.com/example-group/example-project.git')).toEqual({
+      project: 'example-group/example-project'
+    })
+    expect(resolveGlabTargetProject([], {}, () => 'git@gitlab.com:group/sub/proj.git')).toEqual({
+      project: 'group/sub/proj'
+    })
+  })
+
+  it('defers non-gitlab.com hosts to the real glab (exit-2 contract)', async () => {
+    const { resolveGlabTargetProject, normalizeProjectArg } = await import('../../src/cp/glab-target.js')
+    expect(normalizeProjectArg('https://code.example.test/g/p')).toEqual({ defer: true })
+    expect(normalizeProjectArg('git.example.test/g/p')).toEqual({ defer: true })
+    expect(normalizeProjectArg('gitlab.com/group/proj')).toEqual({ project: 'group/proj' })
+    expect(resolveGlabTargetProject([], { GITLAB_HOST: 'gitlab.example.test' }, () => 'group/p')).toEqual({
+      defer: true
+    })
+    // Unparseable ⇒ the workspace ask (project undefined, no defer).
+    expect(resolveGlabTargetProject([], {}, () => undefined)).toEqual({})
+  })
+})

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -800,8 +800,11 @@ describe('daemon --k8s mode', () => {
       ;(k8sDaemon as any).agents.set('plain', { id: 'plain', workspace: {} })
       expect(planeOptions.tunnelsFor('plain')).toEqual(['mcp'])
       expect(planeOptions.tunnelSocketPath('mcp')).toBe(mcpSocketPath(rootDir))
-      ;(k8sDaemon as any).agents.set('gh', { id: 'gh', workspace: { gitCredential: 'github-app' } })
+      ;(k8sDaemon as any).agents.set('gh', { id: 'gh', workspace: { mode: 'git-repo', gitCredential: 'github-app' } })
       expect(planeOptions.tunnelsFor('gh')).toEqual(['mcp', 'gitcred'])
+      // A managed GitLab pod needs the same socket: its clone/pull and the agent's git/glab ask for one.
+      ;(k8sDaemon as any).agents.set('gl', { id: 'gl', workspace: { mode: 'git-repo', gitCredential: 'gitlab' } })
+      expect(planeOptions.tunnelsFor('gl')).toEqual(['mcp', 'gitcred'])
       // And nothing for the member's own runtime probe, whose channel is granted `probe` alone —
       // asking it to serve a socket would be refused, and the refusal logged, on every boot.
       expect(planeOptions.tunnelsFor('ac-runtime-probe-0f0f0f0f')).toEqual([])

--- a/packages/daemon/test/git-origin-policy.test.ts
+++ b/packages/daemon/test/git-origin-policy.test.ts
@@ -6,7 +6,14 @@ afterEach(() => configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGI
 
 describe('workspace Git origin policy', () => {
   it('denies an unconfigured host at the daemon boundary', () => {
-    expect(() => authorizeWorkspaceGitUrl('https://gitlab.com/acme/repo.git')).toThrow(
+    expect(() => authorizeWorkspaceGitUrl('https://code.example.test/acme/repo.git')).toThrow(
+      'git clone origin is not allowed'
+    )
+    // §13.2: managed GitLab is HTTPS-only and part of the default policy now.
+    expect(authorizeWorkspaceGitUrl('https://gitlab.com/example-group/example-project.git')).toBe(
+      'https://gitlab.com/example-group/example-project.git'
+    )
+    expect(() => authorizeWorkspaceGitUrl('ssh://git@gitlab.com/example-group/example-project.git')).toThrow(
       'git clone origin is not allowed'
     )
   })

--- a/packages/daemon/test/skill-git-source.test.ts
+++ b/packages/daemon/test/skill-git-source.test.ts
@@ -179,7 +179,7 @@ describe('Git skill source policy boundary', () => {
 
   it('rejects disallowed hosts, private addresses, and custom ports', () => {
     for (const source of [
-      'https://gitlab.com/acme/skills.git',
+      'https://code.example.test/acme/skills.git',
       'https://127.0.0.1/acme/skills.git',
       'https://github.com:8443/acme/skills.git',
       'ssh://git@github.com:2222/acme/skills.git'
@@ -189,7 +189,13 @@ describe('Git skill source policy boundary', () => {
   })
 
   it('honors an operator-authorized exact non-default origin', () => {
-    configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS, 'https://gitlab.com'])
+    configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS, 'https://git.example.test'])
+    expect(parseGitSkillSource(entry('https://git.example.test/acme/skills.git')).cloneUrl).toBe(
+      'https://git.example.test/acme/skills.git'
+    )
+    // §13.2: gitlab.com is a DEFAULT origin now — skill sources may name it
+    // without operator opt-in (credentialed acquisition stays GitHub-only).
+    configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS])
     expect(parseGitSkillSource(entry('https://gitlab.com/acme/skills.git')).cloneUrl).toBe(
       'https://gitlab.com/acme/skills.git'
     )
@@ -200,12 +206,22 @@ describe('Git skill source policy boundary', () => {
     const destination = join(root, 'acquired')
     try {
       await expect(
-        acquireGitSkillSource(entry('https://gitlab.com/acme/skills.git'), {
+        acquireGitSkillSource(entry('https://code.example.test/acme/skills.git'), {
           destination,
           agentId: 'agent-1',
           useGitCredential: true
         })
       ).rejects.toThrow(/origin is not allowed/i)
+      expect(existsSync(destination)).toBe(false)
+      // A default-allowed gitlab origin still refuses the CREDENTIALED path,
+      // which remains canonical-GitHub-only, before any directory or Git work.
+      await expect(
+        acquireGitSkillSource(entry('https://gitlab.com/acme/skills.git'), {
+          destination,
+          agentId: 'agent-1',
+          useGitCredential: true
+        })
+      ).rejects.toThrow(/canonical GitHub/i)
       expect(existsSync(destination)).toBe(false)
     } finally {
       await rm(root, { recursive: true, force: true })

--- a/packages/daemon/test/workspace-repo-scope.test.ts
+++ b/packages/daemon/test/workspace-repo-scope.test.ts
@@ -253,6 +253,61 @@ describe('a secondary root is App-covered whatever the primary workspace is', ()
   })
 })
 
+describe('the console git scope keys on the MANAGED credential, not the github-app value', () => {
+  it('rides the helper for a gitlab primary, whose target host the remote builder derives from the URL', async () => {
+    const gitlab = AgentSchema.parse({
+      id: 'bot-gitlab',
+      name: 'bot-gitlab',
+      status: 'active',
+      runtime: 'claude',
+      workspace: {
+        mode: 'git-repo',
+        path: join(base, 'agents', 'bot-gitlab', 'workspace'),
+        gitRepo: 'https://gitlab.com/example-group/example-project',
+        gitCredential: 'gitlab',
+        gitlabProjectId: '4455667'
+      },
+      integrations: [],
+      output: { mode: 'low' }
+    })
+    const gitlabScope = createWorkspaceScope({
+      workspaces,
+      agentOf: (id) => (id === 'bot-gitlab' ? gitlab : undefined),
+      sessionOf: async () => undefined,
+      runtimeRootOf: () => undefined
+    })
+    await expect(gitlabScope.target('bot-gitlab')).resolves.toMatchObject({
+      repo: 'https://gitlab.com/example-group/example-project',
+      githubApp: true
+    })
+    expect(gitlabScope.usesGithubApp('bot-gitlab')).toBe(true)
+  })
+
+  it('leaves an anonymous git-repo primary off the helper, so the flag still means something', async () => {
+    const anon = AgentSchema.parse({
+      id: 'bot-anon',
+      name: 'bot-anon',
+      status: 'active',
+      runtime: 'claude',
+      workspace: {
+        mode: 'git-repo',
+        path: join(base, 'agents', 'bot-anon', 'workspace'),
+        gitRepo: 'https://gitlab.com/example-group/public-project'
+      },
+      integrations: [],
+      output: { mode: 'low' }
+    })
+    const anonScope = createWorkspaceScope({
+      workspaces,
+      agentOf: (id) => (id === 'bot-anon' ? anon : undefined),
+      sessionOf: async () => undefined,
+      runtimeRootOf: () => undefined
+    })
+    await expect(anonScope.target('bot-anon')).resolves.toMatchObject({ githubApp: false })
+    expect(anonScope.usesGithubApp('bot-anon')).toBe(false)
+  })
+})
+
 describe('a cluster daemon addresses a secondary root on the pod volume', () => {
   const POD_ROOT = '/agent'
   const POD_SECONDARY = `${POD_ROOT}/repos/${AUTHORIZED}`

--- a/packages/daemon/test/workspace-repo-scope.test.ts
+++ b/packages/daemon/test/workspace-repo-scope.test.ts
@@ -254,6 +254,43 @@ describe('a secondary root is App-covered whatever the primary workspace is', ()
 })
 
 describe('the console git scope keys on the MANAGED credential, not the github-app value', () => {
+  // A real checkout whose `origin` IS the managed URL, with `origin/main` already at HEAD: a push
+  // then settles on the ahead-0 shortcut, which is reached only when authorizedTarget answered AND
+  // its origin equals the checkout's own — so it pins the authorized URL without any network.
+  const checkoutOn = (name: string, origin: string): string => {
+    const dir = join(base, 'agents', name, 'workspace')
+    mkdirSync(dir, { recursive: true })
+    git(dir, 'init', '-b', 'main')
+    writeFileSync(join(dir, 'README.md'), 'the managed primary\n')
+    git(dir, 'add', '-A')
+    git(dir, 'commit', '-m', 'feat: the managed primary')
+    git(dir, 'remote', 'add', 'origin', origin)
+    git(dir, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
+    git(dir, 'branch', '--set-upstream-to=origin/main', 'main')
+    return dir
+  }
+
+  const managed = (id: string, path: string, gitRepo: string, gitCredential: 'github-app' | 'gitlab'): Agent =>
+    AgentSchema.parse({
+      id,
+      name: id,
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'git-repo', path, gitRepo, gitCredential },
+      integrations: [],
+      output: { mode: 'low' }
+    })
+
+  const seamOn = (agentRow: Agent) => {
+    const managedScope = createWorkspaceScope({
+      workspaces,
+      agentOf: (id) => (id === agentRow.id ? agentRow : undefined),
+      sessionOf: async () => undefined,
+      runtimeRootOf: () => undefined
+    })
+    return createWorkspaceGit(workspaces, managedScope.gitRoot, () => undefined, managedScope.target)
+  }
+
   it('rides the helper for a gitlab primary, whose target host the remote builder derives from the URL', async () => {
     const gitlab = AgentSchema.parse({
       id: 'bot-gitlab',
@@ -305,6 +342,22 @@ describe('the console git scope keys on the MANAGED credential, not the github-a
     })
     await expect(anonScope.target('bot-anon')).resolves.toMatchObject({ githubApp: false })
     expect(anonScope.usesGithubApp('bot-anon')).toBe(false)
+  })
+
+  it('authorizes a gitlab SUBGROUP primary at its configured URL, which github canonicalization throws on', async () => {
+    // Three path segments: `normalizeGithubRepoUrl` demands exactly owner/repo and throws here, which
+    // used to refuse every console pull and push on a managed GitLab primary as an unsafe remote.
+    const origin = 'https://gitlab.com/example-group/sub/example-project'
+    const row = managed('bot-gitlab-push', checkoutOn('bot-gitlab-push', origin), origin, 'gitlab')
+    expect(await seamOn(row).push({ agentId: row.id })).toMatchObject({ isRepo: true, ok: true, ahead: 0 })
+  })
+
+  it('still collapses a github-app primary onto its canonical owner/repo origin', async () => {
+    // A host-shifted configured URL: collapsing it is what keeps the App grant's authority pinned to
+    // github.com, so the provider split must not cost github that canonicalization.
+    const dir = checkoutOn('bot-github-push', 'https://github.com/acme/canonical')
+    const row = managed('bot-github-push', dir, 'https://code.example.test/acme/canonical', 'github-app')
+    expect(await seamOn(row).push({ agentId: row.id })).toMatchObject({ isRepo: true, ok: true, ahead: 0 })
   })
 })
 

--- a/packages/protocol/src/git-url.test.ts
+++ b/packages/protocol/src/git-url.test.ts
@@ -169,8 +169,14 @@ describe('workspace git origin policy', () => {
       normalizeAllowedWorkspaceGitUrl('git@github.com:acme/infra.git', DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
     ).toBe('git@github.com:acme/infra.git')
 
+    // §13.2: https://gitlab.com is a DEFAULT origin now (HTTPS only) — ssh
+    // gitlab and lookalike/port-widened hosts still refuse.
+    expect(
+      normalizeAllowedWorkspaceGitUrl('https://gitlab.com/group/repo', DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
+    ).toBe('https://gitlab.com/group/repo')
     for (const url of [
-      'https://gitlab.com/group/repo',
+      'ssh://git@gitlab.com/group/repo',
+      'https://gitlab.com.evil.example/group/repo',
       'https://github.com.evil.example/acme/infra',
       'https://github.com:8443/acme/infra',
       'ssh://git@github.com:2222/acme/infra'

--- a/packages/protocol/src/git-url.ts
+++ b/packages/protocol/src/git-url.ts
@@ -19,7 +19,13 @@ const CONTROL_RE = /[\u0000-\u001f\u007f]/
 
 /** Conservative daemon default. Operators may explicitly add exact origins
  * for GitLab, Bitbucket, or self-managed Git services. */
-export const DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS = ['https://github.com', 'ssh://github.com'] as const
+// gitlab-com-integration.md §13.2: managed GitLab workspaces are HTTPS-only and
+// exactly this origin. An operator-supplied allowlist stays authoritative.
+export const DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS = [
+  'https://github.com',
+  'ssh://github.com',
+  'https://gitlab.com'
+] as const
 
 /**
  * Hard cap on an untrusted repo reference. Real clone addresses are far under


### PR DESCRIPTION
The daemon consumer half of [gitlab-com-integration.md](docs/designs/gitlab-com-integration.md) §22 **M4** (§13.2/§13.3/§17.1), after #1371's server half.

## Provider-aware credential chain (§13.2)

- **Helper**: accepts `gitlab.com` alongside `github.com`; gitlab paths keep their FULL namespaced depth (arbitrary subgroups), github stays `owner/repo`. Other hosts stay silent for git's fallback chain.
- **Daemon socket server**: the provider comes from the agent's REPLICATED SPEC — never the helper's host hint; a cross-host ask gets a clean denial.
- **Cache**: gitlab grants key apart from github's; a provider may be named only after the CP advertises `gitcred-provider-v2` in `register/ok` (an older CP would strip the field and answer the wrong workspace grant — a stripped/mismatched provider echo is rejected, per the §17.1 consumer contract).
- **Injection**: all three channels — clone-time `GIT_CONFIG_*`, the session gitconfig, and the repo-local helper — pin exactly ONE managed host derived from the workspace URL. Deliberate consequence: a non-gitlab agent's session no longer touches `credential.https://gitlab.com`, so operator machine credentials for personal gitlab use keep working; a gitlab agent's session resets them and routes through the daemon, exactly like the github precedent.
- The `gitlab` workspace arm maps onto the local `git-repo` mode with a `gitlab` credential marker; prepare/prefetch/pull/repin all ride the existing managed paths, host-derived. `https://gitlab.com` joins the default origin allowlist (HTTPS only — no ssh arm), an explicit operator `workspaceGitAllowedOrigins` stays authoritative, and boot warns plainly when that policy excludes GitLab rather than silently widening it.

## The `glab` wrapper (§13.3)

`run/bin/glab` mirrors the gh wrapper: locate the real binary, resolve the target project on the Node side (`-R/--repo` → `GITLAB_REPO` → cwd origin; full subgroup depth; a non-gitlab host or foreign `GITLAB_HOST` defers with the exit-2 contract), fetch a per-invocation token over the daemon socket, exec the real glab. **Deliberately stricter than gh**: the daemon serves the binding's READ credential only (`requestedAccess: 'read'` — the CP clamps), so mutating glab commands never receive effect authority and fail at GitLab; supported mutations arrive with the M5 broker. A user-supplied `GITLAB_TOKEN` always wins, matching the `GH_TOKEN` pass-through. The OS-sandbox read roots gain the gitlab twin (helper socket/shim, wrapper dir, real glab).

## Tests

New suite (8): cache provider keying/negotiation/echo-rejection, helper subgroup parsing, one-host-per-workspace injection pinning, glab target precedence + deferral. Origin-policy and config default assertions updated for the new allowlist entry. Targeted daemon suites green (551); workspace typecheck/lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
