### PR TITLE
feat(daemon): post gitlab final answers as the project service account

### DIFF
--- a/packages/control-plane/src/gitlab/gitcred.service.ts
+++ b/packages/control-plane/src/gitlab/gitcred.service.ts
@@ -10,6 +10,8 @@ import type {
 
 /** Local lease ceiling — the daemon refreshes hourly even though the PAT lives ~90 days. */
 const LEASE_MAX_SEC = 3600
+/** Effect leases are action-time (§14.1): enough for one post + one auth retry. */
+const EFFECT_LEASE_MAX_SEC = 900
 /** Clock-skew shave, mirroring the GitHub grant discipline. */
 const SKEW_SEC = 60
 
@@ -29,6 +31,55 @@ export interface GitlabGitcredDeps {
  */
 export class GitlabGitcredService {
   constructor(private readonly deps: GitlabGitcredDeps) {}
+
+  /** §14.1 effect lease: the binding's effect PAT for the note poster, authorized by the enabled hook, not the workspace gitAccess. */
+  async grantForHookReply(orgId: string, projectId: bigint): Promise<GitCredGrant> {
+    const binding = await this.deps.bindings.byProject(orgId, projectId)
+    if (!binding || binding.state === 'cleanup_pending') {
+      throw new GitCredDeniedError(
+        'the project is not a managed GitLab binding in this organization',
+        'SCOPE_DENIED',
+        false
+      )
+    }
+    if (binding.state === 'runtime_degraded') {
+      throw new GitCredDeniedError('the project binding is runtime-degraded — repair it', 'LEASE_DENIED', true)
+    }
+    if (binding.serviceAccountUsername === null || binding.serviceAccountUserId === null) {
+      throw new GitCredDeniedError('the project binding has no service account yet — repair it', 'LEASE_DENIED', true)
+    }
+    const credential = await this.deps.credentials.get(binding.id, 'effect')
+    if (!credential) {
+      throw new GitCredDeniedError('the project binding has no effect credential — repair it', 'LEASE_DENIED', true)
+    }
+    const token = await this.deps.credentialSecrets.get(orgId, credential.id)
+    if (!token) {
+      throw new GitCredDeniedError('the project credential is sealed away — repair the binding', 'LEASE_DENIED', true)
+    }
+    const nowMs = this.deps.clock.now()
+    const providerRemainingSec = Math.floor((credential.providerExpiresAt.getTime() - nowMs) / 1000) - SKEW_SEC
+    const ttlSec = Math.min(EFFECT_LEASE_MAX_SEC, providerRemainingSec)
+    if (ttlSec <= 0) {
+      throw new GitCredDeniedError(
+        'the project credential has expired — rotation or repair must run',
+        'LEASE_DENIED',
+        true
+      )
+    }
+    return {
+      username: binding.serviceAccountUsername,
+      token,
+      ttlSec,
+      expiresAt: new Date(nowMs + ttlSec * 1000).toISOString(),
+      repoFullName: binding.projectPath,
+      // The wire access field describes CONTENTS capability — 'read' is the conservative label, as for the GitHub hook-reply grant.
+      access: 'read',
+      provider: 'gitlab',
+      externalRepoId: projectId.toString(),
+      credentialEpoch: binding.credentialEpoch.toString(),
+      providerExpiresAt: credential.providerExpiresAt.toISOString()
+    }
+  }
 
   async grantForAgent(
     agent: AgentRecord,

--- a/packages/control-plane/src/ws/handlers/gitcred.test.ts
+++ b/packages/control-plane/src/ws/handlers/gitcred.test.ts
@@ -203,6 +203,113 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
     )
   })
 
+  it('routes a gitlab_hook_reply to the effect grant, gated by the enabled gitlab hook (§14.1)', async () => {
+    const grantForHookReply = vi.fn(async () => ({
+      username: 'agentconnect-p4455667',
+      token: 'glpat-effect',
+      ttlSec: 900,
+      expiresAt: '2026-07-11T00:15:00.000Z',
+      repoFullName: 'example-group/example-project',
+      access: 'read' as const,
+      provider: 'gitlab',
+      externalRepoId: '4455667',
+      credentialEpoch: '3',
+      providerExpiresAt: '2026-10-01T00:00:00.000Z'
+    }))
+    const grantForAgent = vi.fn()
+    const deps = {
+      agent: { get: async () => PLACED_AGENT },
+      hook: { get: async () => ({ agentId: AGENT_ID, kind: 'gitlab', enabled: true, repoId: 4455667n }) },
+      github: {},
+      gitlabGitcred: { grantForAgent, grantForHookReply }
+    } as unknown as DaemonWsDeps
+    const conn = fakeConn()
+    const frame = gitcredFrame({
+      provider: 'gitlab',
+      purpose: 'gitlab_hook_reply',
+      hookId: HOOK_ID,
+      externalRepoId: '4455667'
+    })
+
+    await handleGitCredRequest(frame, conn, deps)
+
+    // The workspace clamp is bypassed: the hook, not gitAccess, is the authority.
+    expect(grantForHookReply).toHaveBeenCalledWith(ORG_ID, 4455667n)
+    expect(grantForAgent).not.toHaveBeenCalled()
+    expect(conn.replyTo).toHaveBeenCalledWith(
+      frame,
+      'gitcred/grant',
+      expect.objectContaining({ provider: 'gitlab', access: 'read', ttlSec: 900 })
+    )
+    expect(conn.sendError).not.toHaveBeenCalled()
+  })
+
+  it('denies a gitlab_hook_reply whose hook is disabled, foreign, wrong-kind, or on another project', async () => {
+    const grantForHookReply = vi.fn()
+    const frame = gitcredFrame({
+      provider: 'gitlab',
+      purpose: 'gitlab_hook_reply',
+      hookId: HOOK_ID,
+      externalRepoId: '4455667'
+    })
+    const enabledGitlab = { agentId: AGENT_ID, kind: 'gitlab', enabled: true, repoId: 4455667n }
+    const cases = [
+      { ...enabledGitlab, enabled: false },
+      { ...enabledGitlab, kind: 'github' },
+      { ...enabledGitlab, repoId: 999n },
+      { ...enabledGitlab, agentId: 'e0e0e0e0-eeee-4eee-8eee-eeeeeeeeeeee' },
+      null
+    ]
+
+    for (const hook of cases) {
+      const conn = fakeConn()
+      const deps = {
+        agent: { get: async () => PLACED_AGENT },
+        hook: { get: async () => hook },
+        github: {},
+        gitlabGitcred: { grantForHookReply }
+      } as unknown as DaemonWsDeps
+
+      await handleGitCredRequest(frame, conn, deps)
+
+      expect(conn.sendError).toHaveBeenCalledWith(
+        frame.id,
+        'SCOPE_DENIED',
+        'hook is not an enabled gitlab hook of this agent on that project',
+        false
+      )
+      expect(conn.replyTo).not.toHaveBeenCalled()
+    }
+    expect(grantForHookReply).not.toHaveBeenCalled()
+  })
+
+  it('denies a gitlab_hook_reply that names no hook or no project before reaching the store', async () => {
+    const grantForHookReply = vi.fn()
+    const get = vi.fn()
+    const deps = {
+      agent: { get: async () => PLACED_AGENT },
+      hook: { get },
+      github: {},
+      gitlabGitcred: { grantForHookReply }
+    } as unknown as DaemonWsDeps
+
+    for (const payload of [{ hookId: HOOK_ID }, { externalRepoId: '4455667' }, {}]) {
+      const conn = fakeConn()
+      const frame = gitcredFrame({ provider: 'gitlab', purpose: 'gitlab_hook_reply', ...payload })
+
+      await handleGitCredRequest(frame, conn, deps)
+
+      expect(conn.sendError).toHaveBeenCalledWith(
+        frame.id,
+        'SCOPE_DENIED',
+        'gitlab hook reply credentials require a hook and a project',
+        false
+      )
+    }
+    expect(get).not.toHaveBeenCalled()
+    expect(grantForHookReply).not.toHaveBeenCalled()
+  })
+
   it('fails a gitlab request closed when the seam is absent, and refuses unknown providers per-value', async () => {
     const deps = { agent: { get: async () => PLACED_AGENT }, github: {} } as unknown as DaemonWsDeps
     const conn = fakeConn()

--- a/packages/control-plane/src/ws/handlers/gitcred.ts
+++ b/packages/control-plane/src/ws/handlers/gitcred.ts
@@ -70,8 +70,33 @@ export const handleGitCredRequest: Handler = async (frame, conn, deps) => {
 
   try {
     if (gitlabRequest) {
-      // The binding's PAT under the workspace access clamp (§13.1). No hook
-      // purpose here — the M5 poster gets its own gated path.
+      if (purpose === 'gitlab_hook_reply') {
+        // §14.1: the daemon-owned note poster — its authority is the ENABLED gitlab hook itself, not the workspace clamp.
+        if (hookId === undefined || externalRepoId === undefined) {
+          conn.sendError(frame.id, 'SCOPE_DENIED', 'gitlab hook reply credentials require a hook and a project', false)
+          return
+        }
+        const hook = await deps.hook.get(orgId, HookId(hookId))
+        if (
+          !hook ||
+          hook.agentId !== AgentId(agentId) ||
+          hook.kind !== 'gitlab' ||
+          !hook.enabled ||
+          hook.repoId !== BigInt(externalRepoId)
+        ) {
+          conn.sendError(
+            frame.id,
+            'SCOPE_DENIED',
+            'hook is not an enabled gitlab hook of this agent on that project',
+            false
+          )
+          return
+        }
+        const grant = await deps.gitlabGitcred!.grantForHookReply(orgId, hook.repoId)
+        conn.replyTo(frame, 'gitcred/grant', grant)
+        return
+      }
+      // The binding's PAT under the workspace access clamp (§13.1).
       const grant = await deps.gitlabGitcred!.grantForAgent(
         agent,
         externalRepoId !== undefined ? BigInt(externalRepoId) : undefined,

--- a/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
@@ -14,6 +14,7 @@ import { GitlabProvisioner } from '../../src/gitlab/provisioner.js'
 import { GitlabGitcredService } from '../../src/gitlab/gitcred.service.js'
 import { GitCredDeniedError } from '../../src/github/service.js'
 import {
+  PgAgentRepo,
   PgCodeHostRepositoryRepo,
   PgGitlabConnectionRepo,
   PgGitlabConnectionSecretStore,
@@ -28,7 +29,6 @@ import { makeSecretCipher } from '../../src/secrets/cipher.js'
 import { systemClock } from '../../src/domain/clock.js'
 import { seedDaemon } from '../fixtures/seed.js'
 import type { DaemonLiveness } from '../../src/ports.js'
-import { PgAgentRepo } from '../../src/persistence/index.js'
 import { OrgId } from '../../src/domain/ids.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -368,5 +368,31 @@ describe('gitcred v2 GitLab grants (§13.1/§17.1)', () => {
       data: { providerExpiresAt: new Date(Date.now() - 1000) }
     })
     await expect(service.grantForAgent(gitlabAgent())).rejects.toThrowError(GitCredDeniedError)
+  })
+
+  it('grantForHookReply serves the effect PAT on a short action-time lease (§14.1)', async () => {
+    const h = await harness()
+    const service = credService(h.bindings)
+    const creds = new PgGitlabProjectCredentialRepo(prisma)
+    const store = new PgGitlabProjectCredentialSecretStore(prisma, cipher)
+
+    const grant = await service.grantForHookReply(DEFAULT_ORG_ID, PROJECT)
+
+    const effect = (await creds.get(h.binding.id, 'effect'))!
+    expect(grant.token).toBe(await store.get(DEFAULT_ORG_ID, effect.id))
+    // Never a workspace PAT: the reply carries api effect scope, not contents.
+    expect(grant.token).not.toBe(await store.get(DEFAULT_ORG_ID, (await creds.get(h.binding.id, 'read'))!.id))
+    expect(grant.token).not.toBe(await store.get(DEFAULT_ORG_ID, (await creds.get(h.binding.id, 'git_write'))!.id))
+    expect(grant.access).toBe('read')
+    expect(grant.provider).toBe('gitlab')
+    expect(grant.username).toBe(`agentconnect-p${PROJECT}`)
+    expect(grant.externalRepoId).toBe(PROJECT.toString())
+    expect(grant.repoFullName).toBe('example-group/example-project')
+    // Action-time, not the hourly workspace lease.
+    expect(grant.ttlSec).toBeGreaterThan(0)
+    expect(grant.ttlSec).toBeLessThanOrEqual(900)
+
+    await prisma.gitlabProjectBinding.update({ where: { id: h.binding.id }, data: { state: 'runtime_degraded' } })
+    await expect(service.grantForHookReply(DEFAULT_ORG_ID, PROJECT)).rejects.toThrowError(GitCredDeniedError)
   })
 })

--- a/packages/daemon/src/cp/git-credential.ts
+++ b/packages/daemon/src/cp/git-credential.ts
@@ -330,6 +330,8 @@ export class GitCredentialCache {
         this.entries.delete(key)
         throw new GitCredUnavailableError((e as Error).message, true)
       }
+      // 19.3: LEASE_DENIED is an authoritative refusal of new effects, not an outage — evict so no revoked token keeps serving.
+      if (code === 'LEASE_DENIED') this.entries.delete(key)
       throw new GitCredUnavailableError((e as Error).message, false)
     }
     // Old-CP mismatch guard (multi-repo design §Protocol Changes): a CP that predates

--- a/packages/daemon/src/cp/git-credential.ts
+++ b/packages/daemon/src/cp/git-credential.ts
@@ -61,6 +61,9 @@ const keyOf = (agentId: string, plane: CachePlane, repo?: string, provider?: 'gi
  *  it gets its own keyspace). One per (agent, repo). */
 const POST_KEY = (agentId: string, repo: string): string => `post\u0000${agentId}\u0000${repo.toLowerCase()}`
 
+/** Cache key for the gitlab note poster's effect token (§14.1) — its own keyspace. */
+const GITLAB_POST_KEY = (agentId: string, projectId: string): string => `postglab\u0000${agentId}\u0000${projectId}`
+
 export class GitCredUnavailableError extends Error {
   constructor(
     message: string,
@@ -88,7 +91,7 @@ export interface GitCredentialCacheDeps {
     reason?: 'clone' | 'fetch' | 'pull' | 'push' | 'helper'
     capabilities?: GitCredCapability[]
     repoFullName?: string
-    purpose?: 'github_hook_reply'
+    purpose?: 'github_hook_reply' | 'gitlab_hook_reply'
     hookId?: string
     forceRefresh?: boolean
     provider?: 'gitlab'
@@ -188,6 +191,39 @@ export class GitCredentialCache {
     })
     if (forceRefresh) this.refreshPosts.delete(key)
     return entry
+  }
+
+  /** The GitlabPoster's note token (§14.1): the binding's effect PAT, gated CP-side by the enabled gitlab hook. */
+  async getGitlabPostToken(agentId: string, projectId: string, hookId: string): Promise<Entry> {
+    if (this.deps.providerV2Supported?.() !== true) {
+      throw new GitCredUnavailableError(
+        'the control plane is too old for gitlab credentials (gitcred-provider-v2 not advertised)',
+        false
+      )
+    }
+    const key = GITLAB_POST_KEY(agentId, projectId)
+    const forceRefresh = this.refreshPosts.has(key)
+    const entry = await this.getKeyed(key, agentId, {
+      agentId,
+      reason: 'helper',
+      provider: 'gitlab',
+      externalRepoId: projectId,
+      purpose: 'gitlab_hook_reply',
+      hookId,
+      ...(forceRefresh ? { forceRefresh: true } : {})
+    })
+    if (forceRefresh) this.refreshPosts.delete(key)
+    return entry
+  }
+
+  /** Drop the cached gitlab note token after GitLab rejects it. */
+  invalidateGitlabPost(agentId: string, projectId: string, presentedToken?: string): void {
+    const key = GITLAB_POST_KEY(agentId, projectId)
+    const entry = this.entries.get(key)
+    if (!entry) return
+    if (presentedToken !== undefined && entry.token !== presentedToken) return
+    this.entries.delete(key)
+    this.refreshPosts.add(key)
   }
 
   /** Drop the cached GithubPoster token after GitHub rejects it. Matching the

--- a/packages/daemon/src/cp/relay-client.ts
+++ b/packages/daemon/src/cp/relay-client.ts
@@ -25,7 +25,8 @@ import {
   type RdAgentMsgFwd,
   type RdAgentMsgAck,
   type RdChatEvent,
-  type RdWebchatPost
+  type RdWebchatPost,
+  GITLAB_COM_V1_FEATURE
 } from '@agentconnect.md/protocol'
 import { Backoff, ReqRep, WireError, type Clock, type TimerHandle, type Transport } from '@agentconnect.md/connection'
 import type { Logger } from '../log.js'
@@ -43,7 +44,9 @@ const CLOSE_AUTH_FAILED = 4401
 const DAEMON_RD_CAPABILITIES: readonly string[] = [
   RD_HEADLESS_AGENT_DELIVERY_V1,
   RD_AGENT_IMPLICIT_ROUTING_V1,
-  RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2
+  RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2,
+  // The relay gates gitlab rd/msg dispatch on this capability.
+  GITLAB_COM_V1_FEATURE
 ]
 
 export type RelayClientState = 'CONNECTING' | 'HELLO' | 'READY' | 'CLOSED' | 'DEGRADED'

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -413,6 +413,7 @@ import {
   githubPullRequestLane,
   githubReviewResultForCompletion,
   githubThreadWorktreeCleanup,
+  hookOutcomeFailure,
   MAX_HOOK_REPORT_INFLIGHT,
   type ActiveGithubReplyBatchMeta,
   type ActiveGithubTurnMeta,
@@ -9066,7 +9067,7 @@ export class Daemon {
     // Turn finished cleanly. Draining the next queued message for this sessionKey is
     // runLoop's job (it holds ownership across turns) — NOT here. On a throw, the catch
     // above rethrows and runLoop applies fail-stop (§6.9 #378).
-    await this.completeHookOutcome(entry, sessionId)
+    await this.completeHookOutcome(entry, sessionId, p)
     return sessionId
   }
 
@@ -10427,23 +10428,17 @@ export class Daemon {
   }
 
   /** Report the terminal hook outcome of a cleanly finished turn, failing it when a sealed
-   *  GitHub review batch did not publish every reply. */
-  private async completeHookOutcome(entry: QueueEntry, sessionId: string): Promise<void> {
+   *  GitHub review batch did not publish every reply, or when the promised note never landed. */
+  private async completeHookOutcome(entry: QueueEntry, sessionId: string, p: Pending): Promise<void> {
     const hookContext = entry.hookContext
     if (!hookContext) return
-    const batch = hookContext.githubReviewBatch
-    const batchFailure =
-      batch && batch.items.length > 1
-        ? batch.items.some((item) => item.publishState === 'in_flight')
-          ? 'review_batch_publish_ambiguous'
-          : batch.items.some((item) => item.publishState !== 'settled')
-            ? 'review_batch_replies_missing'
-            : undefined
-        : undefined
+    // The gitlab poster only records a failure for a non-empty final it actually attempted (14.1).
+    const notePublishFailure = entry.githubReply?.provider === 'gitlab' ? p.github?.poster.failure : undefined
+    const failure = hookOutcomeFailure(hookContext.githubReviewBatch, notePublishFailure)
     await this.emitHookCompletion(
       hookContext,
-      batchFailure ? 'failed' : 'success',
-      { sessionId, ...(batchFailure ? { reason: batchFailure } : {}) },
+      failure ? 'failed' : 'success',
+      { sessionId, ...(failure ? { reason: failure } : {}) },
       entry
     )
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -422,6 +422,7 @@ import {
   type GithubRevisionAdmissionPlan,
   type HookCompletionOwner,
   type HookDispatchContext,
+  type NotePublishFailure,
   type SessionWorktreeCleanupResult
 } from './github/hook-coords.js'
 import {
@@ -10364,7 +10365,7 @@ export class Daemon {
         {
           appendTranscript: async (row) => await this.store.appendTranscript(row),
           monotonicTs: () => monotonicTs(),
-          beginPublish: async () => {
+          beginPublish: async (hasFinal) => {
             try {
               // A replay of `in_flight` suppresses another comment. If this write
               // cannot be made durable, fail closed and do not perform the POST.
@@ -10372,6 +10373,11 @@ export class Daemon {
               return true
             } catch (err) {
               this.log.warn(`github poster: durability barrier failed; final publish skipped (${formatErr(err)})`)
+              // A body was owed and the poster is never reached — a lost publication, not a silent skip.
+              if (hasFinal && this.markNotePublishFailure(entry, 'publish_barrier_failed')) {
+                // The barrier write just failed, so this one may too; the live completion still reads memory.
+                await this.persistHookState(entry)
+              }
               return false
             }
           },
@@ -10380,6 +10386,9 @@ export class Daemon {
               if ('provider' in published) hookContext.publishedOutput = published
               else hookContext.publishedComment = published
             }
+            // Stamped BEFORE the settled write so one durable record carries both — a crash
+            // between them cannot replay into a successful report with no note.
+            this.markNotePublishFailure(entry, p.github?.poster.failure)
             await this.persistHookState(entry, 'settled')
           },
           warn: (message) => this.log.warn(message)
@@ -10427,13 +10436,23 @@ export class Daemon {
     }
   }
 
+  /** Stamp this turn's normalized note outcome on the durable hook context (14.1) so settlement
+   *  carries it; gitlab reply targets only. Returns whether anything was recorded. */
+  private markNotePublishFailure(entry: QueueEntry, code: NotePublishFailure | undefined): boolean {
+    if (!code || !entry.hookContext || entry.githubReply?.provider !== 'gitlab') return false
+    entry.hookContext.notePublishFailure = code
+    return true
+  }
+
   /** Report the terminal hook outcome of a cleanly finished turn, failing it when a sealed
    *  GitHub review batch did not publish every reply, or when the promised note never landed. */
   private async completeHookOutcome(entry: QueueEntry, sessionId: string, p: Pending): Promise<void> {
     const hookContext = entry.hookContext
     if (!hookContext) return
-    // The gitlab poster only records a failure for a non-empty final it actually attempted (14.1).
-    const notePublishFailure = entry.githubReply?.provider === 'gitlab' ? p.github?.poster.failure : undefined
+    // The PERSISTED outcome is authoritative — it is the only one a replayed row still has.
+    const notePublishFailure =
+      hookContext.notePublishFailure ??
+      (entry.githubReply?.provider === 'gitlab' ? p.github?.poster.failure : undefined)
     const failure = hookOutcomeFailure(hookContext.githubReviewBatch, notePublishFailure)
     await this.emitHookCompletion(
       hookContext,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10387,8 +10387,10 @@ export class Daemon {
               else hookContext.publishedComment = published
             }
             // Stamped BEFORE the settled write so one durable record carries both — a crash
-            // between them cannot replay into a successful report with no note.
-            this.markNotePublishFailure(entry, p.github?.poster.failure)
+            // between them cannot replay into a successful report with no note. A barrier refusal
+            // leaves the row retryable, so a note that DID land must erase that marker here.
+            if (published) this.clearNotePublishFailure(entry)
+            else this.markNotePublishFailure(entry, p.github?.poster.failure)
             await this.persistHookState(entry, 'settled')
           },
           warn: (message) => this.log.warn(message)
@@ -10444,15 +10446,22 @@ export class Daemon {
     return true
   }
 
+  /** Erase a marker a retryable earlier attempt left behind — the note this turn published exists. */
+  private clearNotePublishFailure(entry: QueueEntry): void {
+    if (entry.hookContext) delete entry.hookContext.notePublishFailure
+  }
+
   /** Report the terminal hook outcome of a cleanly finished turn, failing it when a sealed
    *  GitHub review batch did not publish every reply, or when the promised note never landed. */
   private async completeHookOutcome(entry: QueueEntry, sessionId: string, p: Pending): Promise<void> {
     const hookContext = entry.hookContext
     if (!hookContext) return
-    // The PERSISTED outcome is authoritative — it is the only one a replayed row still has.
-    const notePublishFailure =
-      hookContext.notePublishFailure ??
-      (entry.githubReply?.provider === 'gitlab' ? p.github?.poster.failure : undefined)
+    // The PERSISTED outcome is authoritative — it is the only one a replayed row still has. A proven
+    // note identity outranks any marker: the publication happened, whatever an earlier attempt recorded.
+    const notePublishFailure = hookContext.publishedOutput
+      ? undefined
+      : (hookContext.notePublishFailure ??
+        (entry.githubReply?.provider === 'gitlab' ? p.github?.poster.failure : undefined))
     const failure = hookOutcomeFailure(hookContext.githubReviewBatch, notePublishFailure)
     await this.emitHookCompletion(
       hookContext,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -252,6 +252,7 @@ import {
   WEBCHAT_MULTI_AGENT_FEATURE,
   WEBCHAT_REMOTE_MCP_FEATURE,
   WEBCHAT_SESSION_CONTINUATION_FEATURE,
+  GITLAB_COM_V1_FEATURE,
   encodeSharedSlackStatusTarget,
   HOOK_REPORT_REASON_AGENT_HANDOVER,
   HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED,
@@ -3707,7 +3708,9 @@ export class Daemon {
       // a runtime artifact, capability probe, or sandbox policy. The CP remains
       // authoritative for deciding whether a conversation belongs to the
       // built-in preset; turn-time dispatch rechecks the replicated marker.
-      ...(this.remoteWebchatGrants ? [WEBCHAT_REMOTE_MCP_FEATURE] : [])
+      ...(this.remoteWebchatGrants ? [WEBCHAT_REMOTE_MCP_FEATURE] : []),
+      // The CP withholds gitlab-workspace specs and gitlab hook assignments until this is advertised.
+      GITLAB_COM_V1_FEATURE
     ]
   }
 
@@ -6546,6 +6549,9 @@ export class Daemon {
       getSession: async (key) => await this.store.getSession(key),
       displayNames: async (ids) => await this.store.getDisplayNames(ids),
       getPostToken: (agentId, repo, hookId) => this.gitCreds.getPostToken(agentId, repo, hookId),
+      getGitlabPostToken: (agentId, projectId, hookId) => this.gitCreds.getGitlabPostToken(agentId, projectId, hookId),
+      invalidateGitlabPost: (agentId, projectId, token) =>
+        this.gitCreds.invalidateGitlabPost(agentId, projectId, token),
       invalidatePost: (agentId, repo, presentedToken) => this.gitCreds.invalidatePost(agentId, repo, presentedToken),
       paused: (agentId) => this.paused(agentId),
       draining: (agentId) => this.draining || this.drainingAgents.has(agentId),
@@ -7737,7 +7743,8 @@ export class Daemon {
       durationMs: Number.isFinite(start) ? Math.max(0, this.clock.now() - start) : 0,
       ...extra,
       ...(review ? { reviewAttemptId: review.attemptId, reviewResult: review.result } : {}),
-      ...(hook.publishedComment ? { publishedComment: hook.publishedComment } : {})
+      ...(hook.publishedComment ? { publishedComment: hook.publishedComment } : {}),
+      ...(hook.publishedOutput ? { publishedOutput: hook.publishedOutput } : {})
     }
   }
 
@@ -10367,8 +10374,11 @@ export class Daemon {
               return false
             }
           },
-          endPublish: async (publishedComment) => {
-            if (publishedComment && hookContext) hookContext.publishedComment = publishedComment
+          endPublish: async (published) => {
+            if (published && hookContext) {
+              if ('provider' in published) hookContext.publishedOutput = published
+              else hookContext.publishedComment = published
+            }
             await this.persistHookState(entry, 'settled')
           },
           warn: (message) => this.log.warn(message)

--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -13,6 +13,7 @@ import type { GithubReviewEffect, GithubReviewEvent, GithubReviewTarget, GithubR
 import type { SessionWorktreeRemoval } from '../workspace/workspace-manager.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { QueueEntry } from '../daemon/turn-types.js'
+import type { GitlabPublishFailure } from '../gitlab/poster.js'
 
 export function hookSnapshot(msg: RdMsgHook): HookConfigSnapshot | undefined {
   if (
@@ -85,6 +86,18 @@ export interface GithubReviewBatch {
   updatedAt: number
   sealed?: boolean
   items: GithubReviewBatchItem[]
+}
+
+/** Terminal hook reason for a cleanly finished turn, undefined ⇒ success: an unfinished multi-reply review batch, else a final the poster could not publish (14.1 — a silently absent note must never read as a successful run). */
+export function hookOutcomeFailure(
+  batch: GithubReviewBatch | undefined,
+  notePublishFailure: GitlabPublishFailure | undefined
+): string | undefined {
+  if (batch && batch.items.length > 1) {
+    if (batch.items.some((item) => item.publishState === 'in_flight')) return 'review_batch_publish_ambiguous'
+    if (batch.items.some((item) => item.publishState !== 'settled')) return 'review_batch_replies_missing'
+  }
+  return notePublishFailure ? `note_publish_failed:${notePublishFailure}` : undefined
 }
 
 /** Durable daemon-private hook identity; coalesced prompt excerpts stay local and HookReport omits them. */

--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -88,16 +88,33 @@ export interface GithubReviewBatch {
   items: GithubReviewBatchItem[]
 }
 
-/** Terminal hook reason for a cleanly finished turn, undefined ⇒ success: an unfinished multi-reply review batch, else a final the poster could not publish (14.1 — a silently absent note must never read as a successful run). */
+/** Bounded normalized note outcomes on the durable hook context (14.1); `publish_barrier_failed` is core's own — the poster was never reached. */
+export type NotePublishFailure = GitlabPublishFailure | 'publish_barrier_failed'
+
+const NOTE_PUBLISH_FAILURES = new Set<string>([
+  'publish_timeout',
+  'auth_rejected',
+  'token_unavailable',
+  'post_failed',
+  'publish_barrier_failed'
+] satisfies NotePublishFailure[])
+
+/** Clamp a note outcome that round-tripped through the durable row's JSON back onto the bounded set. */
+function notePublishFailureOf(value: unknown): NotePublishFailure | undefined {
+  return typeof value === 'string' && NOTE_PUBLISH_FAILURES.has(value) ? (value as NotePublishFailure) : undefined
+}
+
+/** Terminal hook reason for a cleanly finished turn, undefined ⇒ success: an unfinished multi-reply review batch, else a final that never became a note (14.1 — a silently absent note must never read as a successful run). */
 export function hookOutcomeFailure(
   batch: GithubReviewBatch | undefined,
-  notePublishFailure: GitlabPublishFailure | undefined
+  notePublishFailure: unknown
 ): string | undefined {
   if (batch && batch.items.length > 1) {
     if (batch.items.some((item) => item.publishState === 'in_flight')) return 'review_batch_publish_ambiguous'
     if (batch.items.some((item) => item.publishState !== 'settled')) return 'review_batch_replies_missing'
   }
-  return notePublishFailure ? `note_publish_failed:${notePublishFailure}` : undefined
+  const code = notePublishFailureOf(notePublishFailure)
+  return code ? `note_publish_failed:${code}` : undefined
 }
 
 /** Durable daemon-private hook identity; coalesced prompt excerpts stay local and HookReport omits them. */
@@ -126,6 +143,8 @@ export interface HookDispatchContext {
   publishedComment?: GithubPublishedComment
   /** Provider-neutral twin (§14.1): e.g. the GitLab note id this turn published. */
   publishedOutput?: PublishedHookOutput
+  /** Its twin for an absent note — persisted WITH settlement so a replay cannot report success (§14.1). */
+  notePublishFailure?: NotePublishFailure
 }
 
 export type GithubThreadWorktreeCleanup = 'pull_request_merged' | 'issue_closed' | 'issue_deleted'

--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -2,6 +2,7 @@ import type {
   GithubHookMetadata,
   GitlabHookMetadata,
   GithubPublishedComment,
+  PublishedHookOutput,
   GithubReviewAuthorized,
   HookConfigSnapshot,
   HookReport,
@@ -58,6 +59,9 @@ export function foreignHookDispatch(report: HookReport, daemonId?: string): bool
 
 export interface GithubReplyTarget {
   hookId: string
+  /** Provider discriminator: absent ⇒ github; 'gitlab' sets `repo` = numeric project id and `number` = the subject IID (§14.1). */
+  provider?: 'gitlab'
+  subjectKind?: 'issue' | 'merge_request'
   repo: string
   number: number
   /** The review-comment delivery that triggered this turn (diagnostic identity). */
@@ -107,6 +111,8 @@ export interface HookDispatchContext {
   reviewReportResult?: HookReviewResult
   /** Exact body-free identity of the fallback comment published for this turn. */
   publishedComment?: GithubPublishedComment
+  /** Provider-neutral twin (§14.1): e.g. the GitLab note id this turn published. */
+  publishedOutput?: PublishedHookOutput
 }
 
 export type GithubThreadWorktreeCleanup = 'pull_request_merged' | 'issue_closed' | 'issue_deleted'

--- a/packages/daemon/src/github/poster.ts
+++ b/packages/daemon/src/github/poster.ts
@@ -332,7 +332,7 @@ function safePrefix(text: string, maxChars: number): string {
 }
 
 /** Fit a reply prefix into `budget`, closing a fence before marker/footer chrome. */
-function truncatedMarkdownPrefix(text: string, budget: number): string {
+export function truncatedMarkdownPrefix(text: string, budget: number): string {
   let contentBudget = Math.max(0, budget)
   for (;;) {
     const prefix = safePrefix(text, contentBudget)

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -53,6 +53,7 @@ import type { WebchatTurnContext } from '../webchat/types.js'
 import { initiatorLabel } from '../workspace/session-branch.js'
 import type { PrepareSessionWorkspaceRequest } from '../workspace/workspace-manager.js'
 import { GithubFinalPoster, GithubReplyCollector, type GithubCommentAttribution } from './poster.js'
+import { GitlabFinalPoster } from '../gitlab/poster.js'
 import { GithubReviewClient, type GithubReviewEffect } from './review.js'
 
 /** Dispatch options this seam needs; a subset of the daemon's own. */
@@ -75,6 +76,9 @@ export interface GithubReviewHost {
   getSession(key: string): Promise<SessionRecord | undefined>
   displayNames(ids: string[]): Promise<Map<string, string>>
   getPostToken(agentId: string, repo: string, hookId: string): Promise<{ token: string }>
+  /** §14.1 effect lease: the binding's effect PAT gated by the enabled gitlab hook. */
+  getGitlabPostToken(agentId: string, projectId: string, hookId: string): Promise<{ token: string }>
+  invalidateGitlabPost(agentId: string, projectId: string, presentedToken?: string): void
   invalidatePost(agentId: string, repo: string, presentedToken?: string): void
   paused(agentId: string): boolean
   draining(agentId: string): boolean
@@ -272,8 +276,20 @@ export class GithubReviewOrchestrator {
     // Inline coordinates and their PR target are one body-free trusted unit.
     // A mixed-version frame without that unit keeps the rolling-compatible
     // ordinary issue/PR comment path derived from HookContext.
+    // GitLab (§14.1) rides the same pipe: repo = numeric project id, number = IID; pushes have no thread and stay silent.
+    const gitlabReply =
+      c?.source === 'gitlab' && msg.gitlab && msg.gitlab.target.kind !== 'push'
+        ? {
+            hookId: msg.hookId,
+            provider: 'gitlab' as const,
+            subjectKind: msg.gitlab.target.kind,
+            repo: msg.gitlab.projectId,
+            number: msg.gitlab.target.iid
+          }
+        : undefined
     const githubReply =
       trustedInlineTarget ??
+      gitlabReply ??
       (c?.source === 'github' && c.repo && c.number !== undefined
         ? { hookId: msg.hookId, repo: c.repo, number: c.number }
         : undefined)
@@ -902,13 +918,15 @@ export class GithubReviewOrchestrator {
       const published = await this.makeGithubReply(req.agentId, item.reply, active.sessionId).poster.publish(
         supplied.get(root)!
       )
-      if (published) item.publishedComment = published
+      // Batch replies are a GitHub-only surface (inline review threads) — narrow away the gitlab arm of the shared poster union.
+      const comment = published && !('provider' in published) ? published : undefined
+      if (comment) item.publishedComment = comment
       item.publishState = 'settled'
       await this.host.persistHookState(active.entry, undefined, true)
       results.push({
         threadRootCommentId: root,
-        state: published ? 'published' : 'settled',
-        ...(published ? { commentId: published.commentId } : {})
+        state: comment ? 'published' : 'settled',
+        ...(comment ? { commentId: comment.commentId } : {})
       })
     }
     return { replies: results }
@@ -921,7 +939,24 @@ export class GithubReviewOrchestrator {
     agentId: string,
     ref: GithubReplyTarget,
     sessionId: string
-  ): { poster: GithubFinalPoster; collector: GithubReplyCollector } {
+  ): { poster: GithubFinalPoster | GitlabFinalPoster; collector: GithubReplyCollector } {
+    if (ref.provider === 'gitlab') {
+      return {
+        collector: new GithubReplyCollector(),
+        poster: new GitlabFinalPoster(
+          {
+            token: async () => (await this.host.getGitlabPostToken(agentId, ref.repo, ref.hookId)).token,
+            invalidateToken: (token) => this.host.invalidateGitlabPost(agentId, ref.repo, token),
+            log: { warn: (m: string) => this.log.warn(m) }
+          },
+          ref.repo,
+          ref.subjectKind ?? 'issue',
+          ref.number,
+          () =>
+            this.agents.get(agentId)?.output.showFooter ? this.githubCommentAttribution(agentId, sessionId) : undefined
+        )
+      }
+    }
     return {
       collector: new GithubReplyCollector(),
       poster: new GithubFinalPoster(

--- a/packages/daemon/src/gitlab/poster.ts
+++ b/packages/daemon/src/gitlab/poster.ts
@@ -14,6 +14,9 @@ const MAX_NOTE_CHARS = 65536
 const TRUNCATION_MARKER = '\n\n…(truncated)'
 const DEFAULT_FINALIZE_TIMEOUT_MS = 60_000
 
+/** Bounded normalized reasons the promised note is absent (14.1) — the hook completion reports exactly one. */
+export type GitlabPublishFailure = 'publish_timeout' | 'auth_rejected' | 'token_unavailable' | 'post_failed'
+
 export interface GitlabFinalPosterDeps {
   /** Action-time effect lease: the binding's effect PAT via purpose gitlab_hook_reply. */
   token: () => Promise<string>
@@ -28,6 +31,7 @@ export interface GitlabFinalPosterDeps {
 
 export class GitlabFinalPoster {
   private abandoned = false
+  private failureCode?: GitlabPublishFailure
   private publishPromise?: Promise<PublishedHookOutput | undefined>
   private readonly abort = new AbortController()
   private readonly sched: PosterScheduler
@@ -47,6 +51,11 @@ export class GitlabFinalPoster {
       clearTimeout: (h) => clearTimeout(h as NodeJS.Timeout)
     }
     this.finalizeTimeoutMs = deps.finalizeTimeoutMs ?? DEFAULT_FINALIZE_TIMEOUT_MS
+  }
+
+  /** Why this turn's note is missing; undefined when it published or the final was legitimately empty. */
+  get failure(): GitlabPublishFailure | undefined {
+    return this.failureCode
   }
 
   /** Publish the completed turn's final body exactly once; never rejects. */
@@ -78,6 +87,7 @@ export class GitlabFinalPoster {
       })
       return await Promise.race([this.post(finalBody, deadlineAt), deadline])
     } catch (err) {
+      this.fail('post_failed')
       if (!this.abandoned) this.safeWarn(`gitlab poster: create failed on ${this.target()} (${String(err)})`)
       return undefined
     } finally {
@@ -98,7 +108,14 @@ export class GitlabFinalPoster {
     const family = this.subjectKind === 'issue' ? 'issues' : 'merge_requests'
     const notePath = `/projects/${this.projectId}/${family}/${this.iid}/notes`
     for (let attempt = 0; attempt < 2; attempt += 1) {
-      const token = await this.deps.token()
+      let token: string
+      try {
+        token = await this.deps.token()
+      } catch (err) {
+        // A refused effect lease is its own outcome: nothing was ever sent to GitLab.
+        this.fail('token_unavailable')
+        throw err
+      }
       if (this.abandoned) return
       if (this.sched.now() >= deadlineAt) {
         this.abandonTimedOut()
@@ -136,11 +153,16 @@ export class GitlabFinalPoster {
       } catch {
         // Best-effort resource cleanup only.
       }
-      const refreshable = attempt === 0 && (res.status === 401 || res.status === 403) && this.deps.invalidateToken
-      if (!refreshable) throw new Error(`GitLab POST ${res.status}`)
+      const authRejected = res.status === 401 || res.status === 403
+      const refreshable = attempt === 0 && authRejected && this.deps.invalidateToken
+      if (!refreshable) {
+        this.fail(authRejected ? 'auth_rejected' : 'post_failed')
+        throw new Error(`GitLab POST ${res.status}`)
+      }
       try {
         this.deps.invalidateToken!(token)
       } catch {
+        this.fail('auth_rejected')
         throw new Error(`GitLab POST ${res.status}`)
       }
     }
@@ -164,9 +186,15 @@ export class GitlabFinalPoster {
     }
   }
 
+  /** First cause wins: a deadline that aborted an in-flight POST must not be relabelled by its abort error. */
+  private fail(code: GitlabPublishFailure): void {
+    this.failureCode ??= code
+  }
+
   private abandon(): boolean {
     if (this.abandoned) return false
     this.abandoned = true
+    this.fail('publish_timeout')
     this.abort.abort()
     return true
   }

--- a/packages/daemon/src/gitlab/poster.ts
+++ b/packages/daemon/src/gitlab/poster.ts
@@ -1,0 +1,178 @@
+// GitLab final-answer poster (gitlab-com-integration.md 14.1): one note per completed turn as the project service account.
+// Single-writer contract — never commentary or a second write after ambiguity; retry once only after a definite auth rejection.
+import type { PublishedHookOutput } from '@agentconnect.md/protocol'
+import {
+  appendGithubMarkdownChrome,
+  githubAttributionFooter,
+  truncatedMarkdownPrefix,
+  type GithubCommentAttributionSource,
+  type PosterScheduler
+} from '../github/poster.js'
+
+/** GitLab notes accept ~1 MB; keep the GitHub cap — nobody reads more. */
+const MAX_NOTE_CHARS = 65536
+const TRUNCATION_MARKER = '\n\n…(truncated)'
+const DEFAULT_FINALIZE_TIMEOUT_MS = 60_000
+
+export interface GitlabFinalPosterDeps {
+  /** Action-time effect lease: the binding's effect PAT via purpose gitlab_hook_reply. */
+  token: () => Promise<string>
+  /** Drop a cached token GitLab just rejected (401/403) so the retry re-mints. */
+  invalidateToken?: (token: string) => void
+  log: { warn: (message: string) => void }
+  baseUrl?: string
+  fetchImpl?: typeof fetch
+  scheduler?: PosterScheduler
+  finalizeTimeoutMs?: number
+}
+
+export class GitlabFinalPoster {
+  private abandoned = false
+  private publishPromise?: Promise<PublishedHookOutput | undefined>
+  private readonly abort = new AbortController()
+  private readonly sched: PosterScheduler
+  private readonly finalizeTimeoutMs: number
+
+  constructor(
+    private readonly deps: GitlabFinalPosterDeps,
+    /** Numeric project id (decimal string) — the rename-stable API target. */
+    private readonly projectId: string,
+    private readonly subjectKind: 'issue' | 'merge_request',
+    private readonly iid: number,
+    private readonly attribution?: GithubCommentAttributionSource
+  ) {
+    this.sched = deps.scheduler ?? {
+      now: () => Date.now(),
+      setTimeout: (fn, ms) => setTimeout(fn, ms),
+      clearTimeout: (h) => clearTimeout(h as NodeJS.Timeout)
+    }
+    this.finalizeTimeoutMs = deps.finalizeTimeoutMs ?? DEFAULT_FINALIZE_TIMEOUT_MS
+  }
+
+  /** Publish the completed turn's final body exactly once; never rejects. */
+  publish(finalBody?: string): Promise<PublishedHookOutput | undefined> {
+    if (!this.publishPromise) this.publishPromise = this.publishOnce(finalBody)
+    return this.publishPromise
+  }
+
+  private target(): string {
+    return `gitlab:${this.projectId} ${this.subjectKind === 'issue' ? '#' : '!'}${this.iid}`
+  }
+
+  private async publishOnce(finalBody?: string): Promise<PublishedHookOutput | undefined> {
+    if (!finalBody?.trim()) return
+    let deadlineHandle: unknown
+    try {
+      const deadlineAt = this.sched.now() + this.finalizeTimeoutMs
+      const deadline = new Promise<undefined>((resolve) => {
+        try {
+          deadlineHandle = this.sched.setTimeout(() => {
+            this.abandonTimedOut()
+            resolve(undefined)
+          }, this.finalizeTimeoutMs)
+        } catch (err) {
+          this.abandon()
+          this.safeWarn(`gitlab poster: publish deadline failed on ${this.target()} (${String(err)})`)
+          resolve(undefined)
+        }
+      })
+      return await Promise.race([this.post(finalBody, deadlineAt), deadline])
+    } catch (err) {
+      if (!this.abandoned) this.safeWarn(`gitlab poster: create failed on ${this.target()} (${String(err)})`)
+      return undefined
+    } finally {
+      if (deadlineHandle !== undefined) {
+        try {
+          this.sched.clearTimeout(deadlineHandle)
+        } catch {
+          // Preserve publish()'s no-throw boundary.
+        }
+      }
+    }
+  }
+
+  private async post(text: string, deadlineAt: number): Promise<PublishedHookOutput | undefined> {
+    const attribution = typeof this.attribution === 'function' ? await this.attribution() : this.attribution
+    const body = this.render(text, githubAttributionFooter(attribution))
+    const doFetch = this.deps.fetchImpl ?? fetch
+    const family = this.subjectKind === 'issue' ? 'issues' : 'merge_requests'
+    const notePath = `/projects/${this.projectId}/${family}/${this.iid}/notes`
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const token = await this.deps.token()
+      if (this.abandoned) return
+      if (this.sched.now() >= deadlineAt) {
+        this.abandonTimedOut()
+        return
+      }
+      const res = await doFetch(`${this.deps.baseUrl ?? 'https://gitlab.com/api/v4'}${notePath}`, {
+        method: 'POST',
+        headers: {
+          'private-token': token,
+          'content-type': 'application/json'
+        },
+        signal: this.abort.signal,
+        body: JSON.stringify({ body })
+      })
+      if (res.ok) {
+        // Note ids are control metadata only; preserve ids beyond the safe-integer range.
+        let noteId: string | undefined
+        try {
+          const raw = await res.text()
+          const parsed = JSON.parse(raw.replace(/"id"\s*:\s*(\d{15,})/g, '"id":"$1"')) as { id?: unknown }
+          const rawId = parsed?.id
+          if (typeof rawId === 'string' && /^[1-9]\d*$/.test(rawId)) noteId = rawId
+          if (typeof rawId === 'number' && Number.isSafeInteger(rawId) && rawId > 0) noteId = String(rawId)
+        } catch {
+          // The note exists — a missing id only loses the deep link, it must not retry the public write.
+        }
+        if (!noteId) {
+          this.safeWarn(`gitlab poster: created note has no usable id on ${this.target()}`)
+          return undefined
+        }
+        return { provider: 'gitlab', kind: 'note', externalId: noteId }
+      }
+      try {
+        await res.body?.cancel()
+      } catch {
+        // Best-effort resource cleanup only.
+      }
+      const refreshable = attempt === 0 && (res.status === 401 || res.status === 403) && this.deps.invalidateToken
+      if (!refreshable) throw new Error(`GitLab POST ${res.status}`)
+      try {
+        this.deps.invalidateToken!(token)
+      } catch {
+        throw new Error(`GitLab POST ${res.status}`)
+      }
+    }
+  }
+
+  private render(text: string, footer: string): string {
+    if (text.length + footer.length <= MAX_NOTE_CHARS) {
+      const rendered = appendGithubMarkdownChrome(text, footer)
+      if (rendered.length <= MAX_NOTE_CHARS) return rendered
+    }
+    const suffix = TRUNCATION_MARKER + footer
+    const bodyBudget = Math.max(0, MAX_NOTE_CHARS - suffix.length)
+    return `${truncatedMarkdownPrefix(text, bodyBudget)}${suffix}`
+  }
+
+  private safeWarn(message: string): void {
+    try {
+      this.deps.log.warn(message)
+    } catch {
+      // A broken logger must not break the poster's failure-degrading boundary.
+    }
+  }
+
+  private abandon(): boolean {
+    if (this.abandoned) return false
+    this.abandoned = true
+    this.abort.abort()
+    return true
+  }
+
+  private abandonTimedOut(): void {
+    if (!this.abandon()) return
+    this.safeWarn(`gitlab poster: final publish timed out on ${this.target()}`)
+  }
+}

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -315,12 +315,20 @@ function buildGithubHookText(
   )
 }
 
-/** The gitlab-kind turn text: a trusted metadata header + the FENCED excerpt.
- *  No posting promise rides here yet — the daemon-owned GitLab reply surface is
- *  the M5 slice; until then the final reply stays in the session transcript. */
+/** The daemon-owned GitLab reply promise (§14.1) — issue/MR subjects only; a push has no thread to answer. */
+function gitlabReplyHint(c: HookContext, gitlab: GitlabHookMetadata): string {
+  if (gitlab.target.kind === 'push') return ''
+  return [
+    '',
+    `Return one self-contained final answer for ${gitlabSubjectRef(c, gitlab)}. The daemon posts it back to that GitLab thread automatically as one note and exclusively owns the reply. Do NOT create, update, or delete GitLab notes through \`glab\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitLab access is READ-only inspection.`
+  ].join('\n')
+}
+
+/** The gitlab-kind turn text: a trusted metadata header + the FENCED excerpt + the reply promise. */
 function buildGitlabHookText(c: HookContext, gitlab: GitlabHookMetadata): string {
   const event = c.action ? `${c.event}:${c.action}` : (c.event ?? 'event')
   const target = gitlab.target
+  const tail = gitlabReplyHint(c, gitlab)
   const head = [
     `GitLab ${event} — ${gitlabSubjectRef(c, gitlab)}${c.title ? ` "${c.title}"` : ''}`,
     `From: ${c.senderLogin ?? 'unknown'}${c.labels?.length ? ` · labels: ${c.labels.join(', ')}` : ''}`,
@@ -329,15 +337,17 @@ function buildGitlabHookText(c: HookContext, gitlab: GitlabHookMetadata): string
     ...(target.kind === 'push' ? [`Ref: ${target.ref}`] : []),
     ...(c.htmlUrl ? [c.htmlUrl] : [])
   ].join('\n')
-  if (!c.bodyExcerpt) return head
-  return [
-    head,
-    '',
-    UNTRUSTED_CONTENT_BEGIN_GITLAB,
-    neutralizeDelimiters(c.bodyExcerpt),
-    UNTRUSTED_CONTENT_END,
-    ...(c.truncated ? ['(body truncated — pull the full thread yourself through the authorized read path)'] : [])
-  ].join('\n')
+  if (!c.bodyExcerpt) return head + tail
+  return (
+    [
+      head,
+      '',
+      UNTRUSTED_CONTENT_BEGIN_GITLAB,
+      neutralizeDelimiters(c.bodyExcerpt),
+      UNTRUSTED_CONTENT_END,
+      ...(c.truncated ? ['(body truncated — pull the full thread yourself through the authorized read path)'] : [])
+    ].join('\n') + tail
+  )
 }
 
 /** The turn text: the caller's payload-borne message (+ leftover fields as context). */

--- a/packages/daemon/src/platforms/github/turn-output.ts
+++ b/packages/daemon/src/platforms/github/turn-output.ts
@@ -43,6 +43,7 @@
  */
 import type { GithubPublishedComment, PublishedHookOutput } from '@agentconnect.md/protocol'
 import type { GithubReplyCollector } from '../../github/poster.js'
+import type { GitlabPublishFailure } from '../../gitlab/poster.js'
 
 /** GitHub's per-turn state (§7.3). Held in the turn's final-surface slot, which
  *  core stores opaquely and never reads. */
@@ -50,6 +51,8 @@ export interface GithubTurnState {
   /** Publishes the one comment — structurally the GitHub poster or its GitLab twin (§14.1), tokened and attributed at publish time. */
   poster: {
     publish(finalBody?: string): Promise<GithubPublishedComment | PublishedHookOutput | undefined>
+    /** Normalized reason the one note is absent (GitLab §14.1); GitHub's poster reports none. */
+    readonly failure?: GitlabPublishFailure
   }
   /** Accumulates ACP updates and selects the single logical final answer. */
   collector: GithubReplyCollector

--- a/packages/daemon/src/platforms/github/turn-output.ts
+++ b/packages/daemon/src/platforms/github/turn-output.ts
@@ -41,15 +41,16 @@
  * human, so the ordinary final must be suppressed) is decided by core from hook
  * state and passed in as one boolean — the surface never inspects hook context.
  */
-import type { GithubPublishedComment } from '@agentconnect.md/protocol'
-import type { GithubFinalPoster, GithubReplyCollector } from '../../github/poster.js'
+import type { GithubPublishedComment, PublishedHookOutput } from '@agentconnect.md/protocol'
+import type { GithubReplyCollector } from '../../github/poster.js'
 
 /** GitHub's per-turn state (§7.3). Held in the turn's final-surface slot, which
  *  core stores opaquely and never reads. */
 export interface GithubTurnState {
-  /** Publishes the one comment. Tokened per turn via the repo-targeted gitcred
-   *  mint; resolves its attribution at publish time. */
-  poster: GithubFinalPoster
+  /** Publishes the one comment — structurally the GitHub poster or its GitLab twin (§14.1), tokened and attributed at publish time. */
+  poster: {
+    publish(finalBody?: string): Promise<GithubPublishedComment | PublishedHookOutput | undefined>
+  }
   /** Accumulates ACP updates and selects the single logical final answer. */
   collector: GithubReplyCollector
   /** Set when the runtime's explicit final chunk was withheld from the core
@@ -89,7 +90,7 @@ export interface GithubTurnHost {
    *  be made durable, and the caller must NOT perform the public POST. */
   beginPublish(): boolean | Promise<boolean>
   /** Record the durable `settled` state and any exact public comment identity. */
-  endPublish(publishedComment?: GithubPublishedComment): void | Promise<void>
+  endPublish(publishedComment?: GithubPublishedComment | PublishedHookOutput): void | Promise<void>
   warn(message: string): void
 }
 

--- a/packages/daemon/src/platforms/github/turn-output.ts
+++ b/packages/daemon/src/platforms/github/turn-output.ts
@@ -90,8 +90,10 @@ export interface GithubTurnHost {
   /** Monotonic transcript timestamp — core owns ordering across surfaces. */
   monotonicTs(): string
   /** Record the durable `in_flight` barrier. `false` means the write could not
-   *  be made durable, and the caller must NOT perform the public POST. */
-  beginPublish(): boolean | Promise<boolean>
+   *  be made durable, and the caller must NOT perform the public POST. `hasFinal`
+   *  says whether a body was actually owed, so core can tell a lost publication
+   *  from a barrier failure on a turn that had nothing to say. */
+  beginPublish(hasFinal: boolean): boolean | Promise<boolean>
   /** Record the durable `settled` state and any exact public comment identity. */
   endPublish(publishedComment?: GithubPublishedComment | PublishedHookOutput): void | Promise<void>
   warn(message: string): void
@@ -151,7 +153,7 @@ export async function finalizeGithubTurn<TTurn extends GithubTurn>(
   // With no formal effect (or a proved not_submitted effect), the ordinary final
   // remains the fallback. A replay of `in_flight` suppresses another comment; if
   // that write cannot be made durable, fail closed and skip the POST entirely.
-  if (!(await host.beginPublish())) return
+  if (!(await host.beginPublish(!!final?.trim()))) return
   // publish() is time-bounded and degrading — a failure here must not strand the
   // turn, so it is logged and the hook still settles.
   const publishedComment = await state.poster.publish(final).catch((err) => {

--- a/packages/daemon/test/cp/git-credential.test.ts
+++ b/packages/daemon/test/cp/git-credential.test.ts
@@ -93,6 +93,21 @@ describe('GitCredentialCache', () => {
     expect((await h.cache.get(AGENT, 'push')).token).toBe('ghs_2')
   })
 
+  it('evicts the cached token on an authoritative LEASE_DENIED instead of riding it (19.3)', async () => {
+    const h = build((n) => {
+      if (n === 2) throw Object.assign(new Error('binding stopped new effects'), { code: 'LEASE_DENIED' })
+      return grant(`ghs_${n}`, 3540)
+    })
+    expect((await h.cache.get(AGENT, 'clone')).token).toBe('ghs_1')
+    h.advance(50 * 60 * 1000) // below the handout threshold → refresh, and the CP refuses
+
+    // Unlike the INTERNAL outage above, the caller must fail NOW rather than keep the revoked grant.
+    await expect(h.cache.get(AGENT, 'push')).rejects.toMatchObject({ terminal: false })
+    // Neither terminal nor negative-cached: a repaired binding serves on the very next ask.
+    expect((await h.cache.get(AGENT, 'push')).token).toBe('ghs_3')
+    expect(h.calls()).toBe(3)
+  })
+
   it('invalidates only when the presented password matches (stale erase races)', async () => {
     const h = build((n) => grant(`ghs_${n}`, 3540))
     await h.cache.get(AGENT, 'clone')

--- a/packages/daemon/test/cp/gitlab-gitcred.test.ts
+++ b/packages/daemon/test/cp/gitlab-gitcred.test.ts
@@ -12,11 +12,13 @@ import { projectFromPath, repoFromPath } from '../../src/gitcred/helper.js'
 import { initGitInjection, managedCredentialHostOf, sessionGitConfig } from '../../src/workspace/git-injection.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const HOOK = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
 type Payload = { provider?: string; requestedAccess?: string }
 
 function build(opts: { v2?: boolean; respond: (payload: Payload, n: number) => GitCredGrant }) {
   let calls = 0
+  let mono = 0
   const seen: Payload[] = []
   const cache = new GitCredentialCache({
     request: async (payload) => {
@@ -25,10 +27,10 @@ function build(opts: { v2?: boolean; respond: (payload: Payload, n: number) => G
       return opts.respond(payload, calls)
     },
     log: { warn: () => {} },
-    monoNow: () => 0,
+    monoNow: () => mono,
     providerV2Supported: () => opts.v2 === true
   })
-  return { cache, seen, calls: () => calls }
+  return { cache, seen, calls: () => calls, advance: (ms: number) => (mono += ms) }
 }
 
 const gitlabGrant: GitCredGrant = {
@@ -88,6 +90,25 @@ describe('GitCredentialCache — gitlab provider (§17.1)', () => {
     h.cache.invalidate(AGENT, 'glpat-1', { provider: 'gitlab' })
     await h.cache.get(AGENT, 'clone', { provider: 'gitlab', externalRepoId: '4455667' })
     expect(h.calls()).toBe(3) // eviction forced a fresh CP ask
+  })
+})
+
+describe('gitlab note token under an authoritative denial (19.3)', () => {
+  it('a LEASE_DENIED refresh evicts the minted PAT: the poster fails now and re-asks next turn', async () => {
+    const h = build({
+      v2: true,
+      respond: (_payload, n) => {
+        if (n === 2) throw Object.assign(new Error('runtime_degraded'), { code: 'LEASE_DENIED' })
+        return { ...gitlabGrant, token: `glpat-${n}` }
+      }
+    })
+    expect((await h.cache.getGitlabPostToken(AGENT, '4455667', HOOK)).token).toBe('glpat-1')
+    h.advance(50 * 60 * 1000) // below the handout threshold → refresh, and the binding refuses
+
+    await expect(h.cache.getGitlabPostToken(AGENT, '4455667', HOOK)).rejects.toThrow(GitCredUnavailableError)
+    // The revoked grant is gone rather than served for the rest of its lease.
+    expect((await h.cache.getGitlabPostToken(AGENT, '4455667', HOOK)).token).toBe('glpat-3')
+    expect(h.calls()).toBe(3)
   })
 })
 

--- a/packages/daemon/test/cp/relay-client.test.ts
+++ b/packages/daemon/test/cp/relay-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
   buildRelayDaemonFrame,
+  GITLAB_COM_V1_FEATURE,
   RD_HEADLESS_AGENT_DELIVERY_V1,
   RD_AGENT_IMPLICIT_ROUTING_V1,
   RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2,
@@ -108,7 +109,12 @@ describe('RelayClient (daemon → one relay)', () => {
     expect(t.lastReq('rd/hello')!.payload).toEqual({
       apiKey: 'daemon-key',
       daemonId: DAEMON_ID,
-      capabilities: [RD_HEADLESS_AGENT_DELIVERY_V1, RD_AGENT_IMPLICIT_ROUTING_V1, RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2]
+      capabilities: [
+        RD_HEADLESS_AGENT_DELIVERY_V1,
+        RD_AGENT_IMPLICIT_ROUTING_V1,
+        RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2,
+        GITLAB_COM_V1_FEATURE
+      ]
     })
     expect(client.state).toBe('READY')
     expect(client.isReady()).toBe(true)

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -325,6 +325,69 @@ describe('Daemon rd/msg hook fires', () => {
     15_000
   )
 
+  it('clears a stale barrier marker when the retry publishes: no row carries both a note and a failure', async () => {
+    const root = scaffold()
+    const seed = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
+    await seed.start()
+    const replayFire = gitlabFire()
+    const replayMessage = buildHookMessage(replayFire, 'trace-gitlab-barrier-retry')
+    // The barrier refused BEFORE any POST, so the row stays retryable — with a marker already on it.
+    const replayHook = {
+      hookId: HOOK_ID,
+      agentId: AGENT_ID,
+      deliveryKey: 'd-1',
+      firedAt: replayFire.firedAt,
+      event: replayFire.event,
+      gitlab: replayFire.gitlab,
+      githubReply: {
+        hookId: HOOK_ID,
+        provider: 'gitlab',
+        subjectKind: 'merge_request',
+        repo: GITLAB_PROJECT,
+        number: 42
+      },
+      notePublishFailure: 'publish_barrier_failed'
+    }
+    expect(
+      await (seed as any).store.appendInbox({
+        id: replayMessage.msgId,
+        sessionKey: `hook:gitlab:${GITLAB_PROJECT}:42:${AGENT_ID}`,
+        agentId: AGENT_ID,
+        msg: JSON.stringify(replayMessage),
+        hookContext: JSON.stringify(replayHook),
+        posterPublishState: 'not_started',
+        loopGuardCounted: 1,
+        enqueuedAt: '1'
+      })
+    ).toBe(true)
+    await seed.stop()
+
+    const restarted = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
+    const cp = fakeCpClient()
+    ;(restarted as never as { cpClient: unknown }).cpClient = cp
+    const poster = { publish: vi.fn(async () => ({ provider: 'gitlab', kind: 'note', externalId: '9001' })) }
+    ;(restarted as any).githubReviews.makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+    const settled: Array<string | undefined> = []
+    const realPersist = (restarted as any).persistHookState.bind(restarted)
+    ;(restarted as any).persistHookState = async (entry: any, state: any, required: any) => {
+      if (state === 'settled') settled.push(entry.hookContext?.notePublishFailure)
+      return realPersist(entry, state, required)
+    }
+
+    await restarted.start()
+
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
+    expect(poster.publish).toHaveBeenCalledWith('done!')
+    expect(cp.hookReports[0]).toMatchObject({
+      status: 'success',
+      publishedOutput: { provider: 'gitlab', kind: 'note', externalId: '9001' }
+    })
+    expect(cp.hookReports[0]!.reason).toBeUndefined()
+    // The settled write dropped the marker, so a later replay cannot resurrect it either.
+    expect(settled).toEqual([undefined])
+    await restarted.stop()
+  }, 20_000)
+
   it('re-derives the failed completion from the persisted outcome after a restart', async () => {
     const root = scaffold()
     const seed = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -286,6 +286,123 @@ describe('Daemon rd/msg hook fires', () => {
     15_000
   )
 
+  it.each([
+    {
+      name: 'a failed publish carries its code into the settled write',
+      failure: 'post_failed',
+      expected: 'post_failed'
+    },
+    { name: 'a published note leaves the durable record clean', failure: undefined, expected: undefined }
+  ])(
+    'persists the note outcome with settlement: $name',
+    async ({ failure, expected }) => {
+      const { factory } = streamingHost()
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
+      await daemon.start()
+      const cp = fakeCpClient()
+      ;(daemon as never as { cpClient: unknown }).cpClient = cp
+      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+        poster: {
+          publish: vi.fn(async () => (failure ? undefined : { provider: 'gitlab', kind: 'note', externalId: '9001' })),
+          ...(failure ? { failure } : {})
+        },
+        collector: new GithubReplyCollector()
+      }))
+      // Capture what the 'settled' write actually serializes — the reason must ride that same record.
+      const settled: Array<string | undefined> = []
+      const realPersist = (daemon as any).persistHookState.bind(daemon)
+      ;(daemon as any).persistHookState = async (entry: any, state: any, required: any) => {
+        if (state === 'settled') settled.push(entry.hookContext?.notePublishFailure)
+        return realPersist(entry, state, required)
+      }
+
+      await (daemon as any).handleRelayMsg(gitlabFire(), () => {})
+
+      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
+      expect(settled).toEqual([expected])
+      await daemon.stop()
+    },
+    15_000
+  )
+
+  it('re-derives the failed completion from the persisted outcome after a restart', async () => {
+    const root = scaffold()
+    const seed = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
+    await seed.start()
+    const replayFire = gitlabFire()
+    const replayMessage = buildHookMessage(replayFire, 'trace-gitlab-replay')
+    // The crash window: `settled` and the reason were made durable, the completion was not sent.
+    const replayHook = {
+      hookId: HOOK_ID,
+      agentId: AGENT_ID,
+      deliveryKey: 'd-1',
+      firedAt: replayFire.firedAt,
+      event: replayFire.event,
+      gitlab: replayFire.gitlab,
+      githubReply: {
+        hookId: HOOK_ID,
+        provider: 'gitlab',
+        subjectKind: 'merge_request',
+        repo: GITLAB_PROJECT,
+        number: 42
+      },
+      notePublishFailure: 'post_failed'
+    }
+    expect(
+      await (seed as any).store.appendInbox({
+        id: replayMessage.msgId,
+        sessionKey: `hook:gitlab:${GITLAB_PROJECT}:42:${AGENT_ID}`,
+        agentId: AGENT_ID,
+        msg: JSON.stringify(replayMessage),
+        hookContext: JSON.stringify(replayHook),
+        posterPublishState: 'settled',
+        loopGuardCounted: 1,
+        enqueuedAt: '1'
+      })
+    ).toBe(true)
+    await seed.stop()
+
+    const restarted = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
+    const cp = fakeCpClient()
+    ;(restarted as never as { cpClient: unknown }).cpClient = cp
+    const makeGithubReply = vi.fn(() => ({ poster: { publish: vi.fn() }, collector: new GithubReplyCollector() }))
+    ;(restarted as any).githubReviews.makeGithubReply = makeGithubReply
+
+    await restarted.start()
+
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
+    expect(cp.hookReports[0]).toMatchObject({ status: 'failed', reason: 'note_publish_failed:post_failed' })
+    // A settled row builds no poster at all, so the reason can only have come from the durable record.
+    expect(makeGithubReply).not.toHaveBeenCalled()
+    await restarted.stop()
+  }, 20_000)
+
+  it('records publish_barrier_failed and never reaches the poster when the durable barrier write fails', async () => {
+    const { factory } = streamingHost()
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    const cp = fakeCpClient()
+    ;(daemon as never as { cpClient: unknown }).cpClient = cp
+    const poster = { publish: vi.fn(async () => undefined) }
+    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+    const realPersist = (daemon as any).persistHookState.bind(daemon)
+    ;(daemon as any).persistHookState = async (entry: any, state: any, required: any) => {
+      if (state === 'in_flight') throw new Error('durable inbox row is missing')
+      return realPersist(entry, state, required)
+    }
+
+    await (daemon as any).handleRelayMsg(gitlabFire(), () => {})
+
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
+    expect(cp.hookReports[0]).toMatchObject({
+      status: 'failed',
+      reason: 'note_publish_failed:publish_barrier_failed'
+    })
+    // Fail-closed is preserved: the barrier never opened, so no public write was attempted.
+    expect(poster.publish).not.toHaveBeenCalled()
+    await daemon.stop()
+  }, 15_000)
+
   it('still reports success when the gitlab note published — the poster reports no failure', async () => {
     const { factory } = streamingHost()
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -128,6 +128,30 @@ const fire = (over: Partial<RdMsgHook> = {}): RdMsgHook => ({
   ...over
 })
 
+const GITLAB_PROJECT = '4455667'
+
+/** A gitlab MR delivery — `githubReply` rides the same pipe with repo = project id, number = IID (14.1). */
+const gitlabFire = (): RdMsgHook =>
+  fire({
+    sessionKey: `gitlab:${GITLAB_PROJECT}:merge_request:42`,
+    event: 'merge_request:opened',
+    gitlab: {
+      projectId: GITLAB_PROJECT,
+      projectPath: 'example-group/example-project',
+      target: { kind: 'merge_request', iid: 42 }
+    },
+    context: {
+      source: 'gitlab',
+      event: 'merge_request',
+      action: 'opened',
+      repo: 'example-group/example-project',
+      number: 42,
+      title: 'fix the primary',
+      htmlUrl: 'https://gitlab.com/example-group/example-project/-/merge_requests/42',
+      truncated: false
+    }
+  })
+
 describe('Daemon rd/msg hook fires', () => {
   it('uses the display agent, runtime, and session model in GitHub attribution', async () => {
     const { factory, host } = streamingHost()
@@ -231,6 +255,53 @@ describe('Daemon rd/msg hook fires', () => {
       sourceInstallationId: '456',
       repoFullName: 'agentconnect-md/agentconnect'
     })
+    await daemon.stop()
+  }, 15_000)
+
+  // gitlab-com-integration.md 14.1/19.3: a note the poster could not publish must fail the run.
+  it.each([
+    { name: 'a refused effect lease', failure: 'token_unavailable' },
+    { name: 'an exhausted auth retry', failure: 'auth_rejected' },
+    { name: 'an abandoned publish', failure: 'publish_timeout' }
+  ])(
+    'fails the hook run when the gitlab note publish reports $name',
+    async ({ failure }) => {
+      const { factory } = streamingHost()
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
+      await daemon.start()
+      const cp = fakeCpClient()
+      ;(daemon as never as { cpClient: unknown }).cpClient = cp
+      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+        poster: { publish: vi.fn(async () => undefined), failure },
+        collector: new GithubReplyCollector()
+      }))
+
+      const ack = await (daemon as any).handleRelayMsg(gitlabFire(), () => {})
+
+      expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
+      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
+      expect(cp.hookReports[0]).toMatchObject({ status: 'failed', reason: `note_publish_failed:${failure}` })
+      await daemon.stop()
+    },
+    15_000
+  )
+
+  it('still reports success when the gitlab note published — the poster reports no failure', async () => {
+    const { factory } = streamingHost()
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    const cp = fakeCpClient()
+    ;(daemon as never as { cpClient: unknown }).cpClient = cp
+    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+      poster: { publish: vi.fn(async () => ({ provider: 'gitlab', kind: 'note', externalId: '9001' })) },
+      collector: new GithubReplyCollector()
+    }))
+
+    await (daemon as any).handleRelayMsg(gitlabFire(), () => {})
+
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
+    expect(cp.hookReports[0]).toMatchObject({ status: 'success' })
+    expect(cp.hookReports[0]!.reason).toBeUndefined()
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/gitlab-hook-message.test.ts
+++ b/packages/daemon/test/gitlab-hook-message.test.ts
@@ -96,8 +96,36 @@ describe('gitlab hook normalization (§12.3)', () => {
     expect(text).toContain(UNTRUSTED_CONTENT_BEGIN_GITLAB)
     expect(text).toContain(UNTRUSTED_CONTENT_END)
     expect(text.indexOf(UNTRUSTED_CONTENT_BEGIN_GITLAB)).toBeLessThan(text.indexOf('the primary is unreachable'))
-    // No posting promise before the M5 output surface exists.
-    expect(text).not.toContain('posts')
+    // §14.1: the daemon-owned reply promise rides AFTER the untrusted fence.
+    expect(text).toContain('The daemon posts it back to that GitLab thread automatically as one note')
+    expect(text).toContain('Do NOT create, update, or delete GitLab notes')
+    expect(text.indexOf(UNTRUSTED_CONTENT_END)).toBeLessThan(text.indexOf('The daemon posts it back'))
+  })
+
+  it('promises the daemon-owned note for issue and MR subjects but never for a push', () => {
+    const mr = fire({
+      sessionKey: `gitlab:${PROJECT}:merge_request:77`,
+      gitlab: {
+        projectId: PROJECT,
+        projectPath: 'example-group/example-project',
+        target: { kind: 'merge_request', iid: 77 }
+      },
+      context: { source: 'gitlab', event: 'merge_request', action: 'opened', number: 77, truncated: false }
+    })
+    expect(buildHookText(mr)).toContain('Return one self-contained final answer for example-group/example-project!77')
+    const push = fire({
+      sessionKey: `gitlab:${PROJECT}:push:refs/heads/main`,
+      gitlab: {
+        projectId: PROJECT,
+        projectPath: 'example-group/example-project',
+        target: { kind: 'push', ref: 'refs/heads/main' }
+      },
+      context: { source: 'gitlab', event: 'push', truncated: false, bodyExcerpt: 'two commits' }
+    })
+    const pushText = buildHookText(push)
+    expect(pushText).toContain('Ref: refs/heads/main')
+    expect(pushText).not.toContain('The daemon posts it back')
+    expect(pushText).not.toContain('Return one self-contained final answer')
   })
 
   it('renders MR references with ! and surfaces revision facts on the trusted header', () => {

--- a/packages/daemon/test/gitlab-poster.test.ts
+++ b/packages/daemon/test/gitlab-poster.test.ts
@@ -6,7 +6,7 @@ import type { PosterScheduler } from '../src/github/poster.js'
 const PROJECT = '4455667'
 
 /** A hand-driven clock so the publish deadline never depends on wall time. */
-function fakeScheduler() {
+function fakeScheduler(opts: { fireDeadline?: boolean } = {}) {
   const now = 0
   let nextId = 1
   const pending = new Map<number, { fn: () => void; at: number }>()
@@ -15,6 +15,7 @@ function fakeScheduler() {
     setTimeout: (fn, ms) => {
       const id = nextId++
       pending.set(id, { fn, at: now + ms })
+      if (opts.fireDeadline) fn()
       return id
     },
     clearTimeout: (handle) => {
@@ -60,6 +61,7 @@ function poster(
     fetchImpl: typeof fetch
     token?: () => Promise<string>
     invalidateToken?: (token: string) => void
+    fireDeadline?: boolean
   },
   subject: 'issue' | 'merge_request' = 'merge_request',
   iid = 77
@@ -70,7 +72,7 @@ function poster(
       ...(deps.invalidateToken ? { invalidateToken: deps.invalidateToken } : {}),
       log,
       fetchImpl: deps.fetchImpl,
-      scheduler: fakeScheduler().sched
+      scheduler: fakeScheduler({ ...(deps.fireDeadline ? { fireDeadline: true } : {}) }).sched
     },
     PROJECT,
     subject,
@@ -91,6 +93,7 @@ describe('GitlabFinalPoster (§14.1)', () => {
     expect(calls[0]!.url).toBe(`https://gitlab.com/api/v4/projects/${PROJECT}/merge_requests/77/notes`)
     expect(calls[0]!.headers['private-token']).toBe('glpat-effect')
     expect(calls[0]!.body).toContain('the primary is back')
+    expect(p.failure).toBeUndefined()
   })
 
   it('is a single-publish barrier: a second publish returns the same promise without a second POST', async () => {
@@ -114,15 +117,20 @@ describe('GitlabFinalPoster (§14.1)', () => {
     expect(published).toEqual({ provider: 'gitlab', kind: 'note', externalId: '9007199254740993123' })
   })
 
-  it('never posts an empty or whitespace-only final', async () => {
+  it('never posts an empty or whitespace-only final, and that is a no-op rather than a failure', async () => {
     const empty = fakeFetch()
     const blank = fakeFetch()
+    const nothing = poster({ fetchImpl: empty.fetchImpl })
+    const whitespace = poster({ fetchImpl: blank.fetchImpl })
+    const absent = poster({ fetchImpl: empty.fetchImpl })
 
-    expect(await poster({ fetchImpl: empty.fetchImpl }).publish('')).toBeUndefined()
-    expect(await poster({ fetchImpl: blank.fetchImpl }).publish('   \n\t ')).toBeUndefined()
-    expect(await poster({ fetchImpl: empty.fetchImpl }).publish(undefined)).toBeUndefined()
+    expect(await nothing.publish('')).toBeUndefined()
+    expect(await whitespace.publish('   \n\t ')).toBeUndefined()
+    expect(await absent.publish(undefined)).toBeUndefined()
     expect(empty.calls).toHaveLength(0)
     expect(blank.calls).toHaveLength(0)
+    // Nothing was owed, so nothing is missing — the hook run must still complete successfully.
+    expect([nothing.failure, whitespace.failure, absent.failure]).toEqual([undefined, undefined, undefined])
   })
 
   it('retries exactly once with a fresh token after a definite auth rejection', async () => {
@@ -130,45 +138,86 @@ describe('GitlabFinalPoster (§14.1)', () => {
     const invalidated: string[] = []
     let minted = 0
 
-    const published = await poster({
+    const retried = poster({
       fetchImpl,
       token: async () => `glpat-${(minted += 1)}`,
       invalidateToken: (token) => invalidated.push(token)
-    }).publish('answer')
+    })
+    const published = await retried.publish('answer')
 
     expect(published).toEqual({ provider: 'gitlab', kind: 'note', externalId: '12345' })
     expect(invalidated).toEqual(['glpat-1'])
     expect(calls).toHaveLength(2)
     expect(calls[0]!.headers['private-token']).toBe('glpat-1')
     expect(calls[1]!.headers['private-token']).toBe('glpat-2')
+    expect(retried.failure).toBeUndefined()
   })
 
   it('gives up after a second auth rejection rather than looping', async () => {
     const { fetchImpl, calls } = fakeFetch({ statuses: [401, 403] })
     const invalidated: string[] = []
 
-    const published = await poster({
-      fetchImpl,
-      invalidateToken: (token) => invalidated.push(token)
-    }).publish('answer')
+    const p = poster({ fetchImpl, invalidateToken: (token) => invalidated.push(token) })
+    const published = await p.publish('answer')
 
     expect(published).toBeUndefined()
     expect(calls).toHaveLength(2)
     expect(invalidated).toHaveLength(1)
+    expect(p.failure).toBe('auth_rejected')
   })
 
   it('does not retry a server error — an ambiguous write must never double-post', async () => {
     const { fetchImpl, calls } = fakeFetch({ statuses: [500] })
     const invalidated: string[] = []
 
-    const published = await poster({
-      fetchImpl,
-      invalidateToken: (token) => invalidated.push(token)
-    }).publish('answer')
+    const p = poster({ fetchImpl, invalidateToken: (token) => invalidated.push(token) })
+    const published = await p.publish('answer')
 
     expect(published).toBeUndefined()
     expect(calls).toHaveLength(1)
     expect(invalidated).toHaveLength(0)
+    expect(p.failure).toBe('post_failed')
+  })
+
+  it('reports token_unavailable when the effect lease is refused — nothing was ever sent', async () => {
+    const { fetchImpl, calls } = fakeFetch()
+    const p = poster({
+      fetchImpl,
+      token: async () => {
+        throw new Error('LEASE_DENIED')
+      }
+    })
+
+    expect(await p.publish('answer')).toBeUndefined()
+    expect(calls).toHaveLength(0)
+    expect(p.failure).toBe('token_unavailable')
+  })
+
+  it('reports post_failed when the POST itself throws', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('ECONNRESET')
+    }) as unknown as typeof fetch
+    const p = poster({ fetchImpl })
+
+    expect(await p.publish('answer')).toBeUndefined()
+    expect(p.failure).toBe('post_failed')
+  })
+
+  it('reports publish_timeout when the deadline abandons the publish', async () => {
+    const { fetchImpl, calls } = fakeFetch()
+    const p = poster({ fetchImpl, fireDeadline: true })
+
+    expect(await p.publish('answer')).toBeUndefined()
+    expect(calls).toHaveLength(0)
+    expect(p.failure).toBe('publish_timeout')
+  })
+
+  it('classifies a 403 with no token invalidator as auth_rejected, not as a generic post failure', async () => {
+    const { fetchImpl } = fakeFetch({ statuses: [403] })
+    const p = poster({ fetchImpl })
+
+    expect(await p.publish('answer')).toBeUndefined()
+    expect(p.failure).toBe('auth_rejected')
   })
 
   it('posts an issue subject on the issues note path', async () => {

--- a/packages/daemon/test/gitlab-poster.test.ts
+++ b/packages/daemon/test/gitlab-poster.test.ts
@@ -1,0 +1,182 @@
+// GitLab final-answer poster (gitlab-com-integration.md 14.1): one note per completed turn, single-publish, auth-retry once.
+import { describe, it, expect, vi } from 'vitest'
+import { GitlabFinalPoster } from '../src/gitlab/poster.js'
+import type { PosterScheduler } from '../src/github/poster.js'
+
+const PROJECT = '4455667'
+
+/** A hand-driven clock so the publish deadline never depends on wall time. */
+function fakeScheduler() {
+  const now = 0
+  let nextId = 1
+  const pending = new Map<number, { fn: () => void; at: number }>()
+  const sched: PosterScheduler = {
+    now: () => now,
+    setTimeout: (fn, ms) => {
+      const id = nextId++
+      pending.set(id, { fn, at: now + ms })
+      return id
+    },
+    clearTimeout: (handle) => {
+      pending.delete(handle as number)
+    }
+  }
+  return { sched }
+}
+
+interface Call {
+  method: string
+  url: string
+  headers: Record<string, string>
+  body: string
+}
+
+/** `statuses` is the per-attempt response status; anything omitted succeeds with `okBody`. */
+function fakeFetch(opts: { statuses?: number[]; okBody?: string } = {}) {
+  const calls: Call[] = []
+  let n = 0
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const status = opts.statuses?.[n]
+    n += 1
+    calls.push({
+      method: init?.method ?? 'GET',
+      url: String(url),
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: JSON.parse(String(init?.body)).body
+    })
+    if (status !== undefined && status >= 400) return new Response('', { status })
+    return new Response(opts.okBody ?? '{"id":12345,"noteable_iid":77}', {
+      status: 201,
+      headers: { 'content-type': 'application/json' }
+    })
+  }) as typeof fetch
+  return { fetchImpl, calls }
+}
+
+const log = { warn: vi.fn() }
+
+function poster(
+  deps: {
+    fetchImpl: typeof fetch
+    token?: () => Promise<string>
+    invalidateToken?: (token: string) => void
+  },
+  subject: 'issue' | 'merge_request' = 'merge_request',
+  iid = 77
+) {
+  return new GitlabFinalPoster(
+    {
+      token: deps.token ?? (async () => 'glpat-effect'),
+      ...(deps.invalidateToken ? { invalidateToken: deps.invalidateToken } : {}),
+      log,
+      fetchImpl: deps.fetchImpl,
+      scheduler: fakeScheduler().sched
+    },
+    PROJECT,
+    subject,
+    iid
+  )
+}
+
+describe('GitlabFinalPoster (§14.1)', () => {
+  it('posts one MR note with the private-token header and reports the provider-neutral identity', async () => {
+    const { fetchImpl, calls } = fakeFetch()
+    const p = poster({ fetchImpl })
+
+    const published = await p.publish('the primary is back')
+
+    expect(published).toEqual({ provider: 'gitlab', kind: 'note', externalId: '12345' })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.method).toBe('POST')
+    expect(calls[0]!.url).toBe(`https://gitlab.com/api/v4/projects/${PROJECT}/merge_requests/77/notes`)
+    expect(calls[0]!.headers['private-token']).toBe('glpat-effect')
+    expect(calls[0]!.body).toContain('the primary is back')
+  })
+
+  it('is a single-publish barrier: a second publish returns the same promise without a second POST', async () => {
+    const { fetchImpl, calls } = fakeFetch()
+    const p = poster({ fetchImpl })
+
+    const first = p.publish('answer')
+    const second = p.publish('a different answer')
+
+    expect(second).toBe(first)
+    expect(await first).toEqual({ provider: 'gitlab', kind: 'note', externalId: '12345' })
+    expect(await second).toEqual(await first)
+    expect(calls).toHaveLength(1)
+  })
+
+  it('preserves a note id beyond the safe-integer range as a string', async () => {
+    const { fetchImpl } = fakeFetch({ okBody: '{"id":9007199254740993123,"noteable_iid":77}' })
+
+    const published = await poster({ fetchImpl }).publish('answer')
+
+    expect(published).toEqual({ provider: 'gitlab', kind: 'note', externalId: '9007199254740993123' })
+  })
+
+  it('never posts an empty or whitespace-only final', async () => {
+    const empty = fakeFetch()
+    const blank = fakeFetch()
+
+    expect(await poster({ fetchImpl: empty.fetchImpl }).publish('')).toBeUndefined()
+    expect(await poster({ fetchImpl: blank.fetchImpl }).publish('   \n\t ')).toBeUndefined()
+    expect(await poster({ fetchImpl: empty.fetchImpl }).publish(undefined)).toBeUndefined()
+    expect(empty.calls).toHaveLength(0)
+    expect(blank.calls).toHaveLength(0)
+  })
+
+  it('retries exactly once with a fresh token after a definite auth rejection', async () => {
+    const { fetchImpl, calls } = fakeFetch({ statuses: [401] })
+    const invalidated: string[] = []
+    let minted = 0
+
+    const published = await poster({
+      fetchImpl,
+      token: async () => `glpat-${(minted += 1)}`,
+      invalidateToken: (token) => invalidated.push(token)
+    }).publish('answer')
+
+    expect(published).toEqual({ provider: 'gitlab', kind: 'note', externalId: '12345' })
+    expect(invalidated).toEqual(['glpat-1'])
+    expect(calls).toHaveLength(2)
+    expect(calls[0]!.headers['private-token']).toBe('glpat-1')
+    expect(calls[1]!.headers['private-token']).toBe('glpat-2')
+  })
+
+  it('gives up after a second auth rejection rather than looping', async () => {
+    const { fetchImpl, calls } = fakeFetch({ statuses: [401, 403] })
+    const invalidated: string[] = []
+
+    const published = await poster({
+      fetchImpl,
+      invalidateToken: (token) => invalidated.push(token)
+    }).publish('answer')
+
+    expect(published).toBeUndefined()
+    expect(calls).toHaveLength(2)
+    expect(invalidated).toHaveLength(1)
+  })
+
+  it('does not retry a server error — an ambiguous write must never double-post', async () => {
+    const { fetchImpl, calls } = fakeFetch({ statuses: [500] })
+    const invalidated: string[] = []
+
+    const published = await poster({
+      fetchImpl,
+      invalidateToken: (token) => invalidated.push(token)
+    }).publish('answer')
+
+    expect(published).toBeUndefined()
+    expect(calls).toHaveLength(1)
+    expect(invalidated).toHaveLength(0)
+  })
+
+  it('posts an issue subject on the issues note path', async () => {
+    const { fetchImpl, calls } = fakeFetch()
+
+    const published = await poster({ fetchImpl }, 'issue', 42).publish('answer')
+
+    expect(published).toEqual({ provider: 'gitlab', kind: 'note', externalId: '12345' })
+    expect(calls[0]!.url).toBe(`https://gitlab.com/api/v4/projects/${PROJECT}/issues/42/notes`)
+  })
+})

--- a/packages/protocol/src/frames/gitcred.ts
+++ b/packages/protocol/src/frames/gitcred.ts
@@ -56,7 +56,8 @@ export const GitCredRequest = z.object({
   // the one final comment for an enabled GitHub hook turn. Marking that purpose
   // explicitly lets the CP apply the hook authorization instead of incorrectly
   // clamping the comment token to the workspace contents gitAccess.
-  purpose: z.literal('github_hook_reply').optional(),
+  // gitlab_hook_reply is the §14.1 twin: the note poster's effect lease, gated by an enabled gitlab hook.
+  purpose: z.enum(['github_hook_reply', 'gitlab_hook_reply']).optional(),
   // Trusted hook identity copied from the relay-delivered rd/msg. Required by
   // the CP for purpose=github_hook_reply so authorization stays rename-safe on
   // HookDef.repoId instead of comparing mutable owner/repo display names.


### PR DESCRIPTION
The first daemon-output slice of [gitlab-com-integration.md](docs/designs/gitlab-com-integration.md) §22 **M5** (§14.1), after #1372 — and the switch-on: with this PR the daemon advertises `gitlab-com-v1`, so GitLab hooks, workspaces, credentials, and replies are live end to end.

## The GitLab final poster (§14.1)

The second implementer of the turn-final surface, riding the exact GitHub discipline: collect in memory, publish ONE note per completed turn on the triggering issue or merge request, never commentary or a second write after ambiguity, one retry only after a definite 401/403 plus token invalidation, a bounded finalize deadline, and note ids preserved beyond the safe-integer range. The shared durable single-publish barrier (`posterPublishState` recorded around the public POST) covers it unchanged — a daemon restart cannot replay an in-flight reply. The published identity reports as the provider-neutral `publishedOutput` (`{provider, kind: 'note', externalId}`) on `hook/report`; the body never leaves the daemon.

The reply pipe is generalized structurally rather than duplicated: the reply target carries an optional provider discriminator (numeric project id + IID), the turn-output surface's poster type is the publish shape both posters satisfy, and the GitHub-only batch path narrows explicitly.

## The effect lease

A new `gitcred` purpose `gitlab_hook_reply` (negotiated under `gitcred-provider-v2`): the CP serves the binding's **effect** PAT gated by the ENABLED gitlab hook itself — hook kind, owning agent, and numeric project all fence the mint — so a read workspace still delivers the one reply its hook promised. The token never enters the agent environment and the local lease is capped at 15 minutes; `runtime_degraded` bindings refuse with a retryable denial, per §19.3.

## Prompt + advertisement

The gitlab turn prompt now promises the daemon-owned reply for issue/MR subjects (push stays silent) and forbids CLI/API note writes that would race it. The daemon advertises `gitlab-com-v1` to the control plane (register) and the relay pool (rd/hello) — every wire contract the feature gates (workspace spec arm, hook dispatch + session-key recompute, provider credentials, the reply) is implemented at this point. The §16 status-note projection and formal reviews stay behind their own feature strings.

## Tests

Poster suite (8): single-publish idempotence, issue vs MR paths, big-int ids, empty-final skip, auth-retry-once, give-up-after-second-rejection. Handler units (+3, incl. a table-driven denial matrix over five hook shapes and a never-reaches-the-store guard); grant integration (+1: effect PAT, 15-minute cap, runtime-degraded denial). Full gates: workspace typecheck, protocol 418, CP unit 1852 / integration 1564, daemon targeted suites, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
