### PR TITLE
feat(web): gitlab workspace and hook configuration behind the gitlab flag

### DIFF
--- a/packages/control-plane/src/http/routes/sessions.code-host-facets.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.code-host-facets.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Session integration facets across the two code hosts.
+ *
+ * A hook session's `platform` is the literal 'hook' for every kind, so the facet
+ * has to be PROMOTED from the hook definition's kind. GitHub was promoted and
+ * GitLab was not, which left GitLab activity indistinguishable from generic
+ * webhook activity in both the facet list and the filter that reads it. These
+ * tests pin the promotion, the filter vocabulary, and the per-host hook-id
+ * resolution the repository predicate is given.
+ */
+import Fastify, { type FastifyInstance } from 'fastify'
+import { describe, expect, it, vi } from 'vitest'
+import type { HttpDeps } from '../deps.js'
+import { installZod } from '../plugins/zod.js'
+import { sessionRoutes } from './sessions.js'
+
+const ORG_ID = 'org-1'
+const AGENT_ID = 'agent-1'
+const GITHUB_HOOK = '11111111-1111-4111-8111-111111111111'
+const GITLAB_HOOK = '22222222-2222-4222-8222-222222222222'
+const WEBHOOK = '33333333-3333-4333-8333-333333333333'
+
+const at = new Date('2026-08-22T00:00:00Z')
+
+function hookSession(hookId: string, id: string) {
+  return {
+    id,
+    agentId: AGENT_ID,
+    platform: 'hook',
+    channel: hookId,
+    thread: null,
+    triggeredBy: `hook:${hookId}`,
+    channelName: null,
+    triggeredByName: null,
+    lastActivityAt: at,
+    startedAt: at
+  }
+}
+
+const facetIndex = {
+  agents: [AGENT_ID],
+  integrations: [
+    hookSession(GITHUB_HOOK, 'sess-github'),
+    hookSession(GITLAB_HOOK, 'sess-gitlab'),
+    hookSession(WEBHOOK, 'sess-webhook')
+  ],
+  channels: [],
+  triggers: [
+    hookSession(GITHUB_HOOK, 'sess-github'),
+    hookSession(GITLAB_HOOK, 'sess-gitlab'),
+    hookSession(WEBHOOK, 'sess-webhook')
+  ]
+}
+
+const hookRows = [
+  { id: GITHUB_HOOK, agentId: AGENT_ID, kind: 'github', name: 'owner/repo', repoId: 123n },
+  { id: GITLAB_HOOK, agentId: AGENT_ID, kind: 'gitlab', name: 'acme/platform', repoId: 4210n },
+  { id: WEBHOOK, agentId: AGENT_ID, kind: 'webhook', name: 'acme/build', repoId: null }
+]
+
+function fakeDeps() {
+  const listFacets = vi.fn(async () => facetIndex)
+  const listPage = vi.fn(async () => ({ sessions: [], total: 0, hasMore: false }))
+  const listIdsForOrgKind = vi.fn(async (_orgId: string, kind: string) =>
+    hookRows.filter((hook) => hook.kind === kind).map((hook) => hook.id)
+  )
+  const deps = {
+    repos: {
+      agent: { list: vi.fn(async () => [{ id: AGENT_ID, name: 'build-agent', orgId: ORG_ID }]) },
+      session: {
+        listFacets,
+        listPage,
+        listConversationPage: vi.fn(async () => ({ conversations: [], total: 0, hasMore: false })),
+        orgHasAny: vi.fn(async () => true),
+        listExternalScopes: vi.fn(async () => []),
+        getExternalScopes: vi.fn(async () => []),
+        getExternalAccessPolicy: vi.fn(async () => null)
+      },
+      hook: {
+        getMany: vi.fn(async (_orgId: string, ids: string[]) => hookRows.filter((hook) => ids.includes(hook.id))),
+        listIdsForOrgKind,
+        listForOrgKind: vi.fn(async (_orgId: string, kind: string) => hookRows.filter((hook) => hook.kind === kind))
+      }
+    },
+    clock: { now: () => Date.now() }
+  } as unknown as HttpDeps
+  return { deps, listFacets, listPage, listIdsForOrgKind }
+}
+
+async function app(deps: HttpDeps): Promise<FastifyInstance> {
+  const instance = Fastify()
+  installZod(instance)
+  instance.addHook('onRequest', async (req) => {
+    req.principal = { userId: 'user-1' }
+    req.orgCtx = { orgId: ORG_ID, role: 'collaborator', userId: 'user-1' } as never
+  })
+  await instance.register(sessionRoutes(deps))
+  return instance
+}
+
+describe('session integration facets across code hosts', () => {
+  it('promotes each code host out of the generic hook bucket', async () => {
+    const { deps } = fakeDeps()
+    const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions/facets' })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as {
+      integrations: string[]
+      triggers: Array<{ value: string; integration: string; hookKind: string | null; githubRepoId: string | null }>
+    }
+    expect([...body.integrations].sort()).toEqual(['github', 'gitlab', 'hook'])
+    expect(body.triggers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: `hook:${GITLAB_HOOK}`, integration: 'gitlab', hookKind: 'gitlab' }),
+        expect.objectContaining({ value: `hook:${GITHUB_HOOK}`, integration: 'github', hookKind: 'github' }),
+        expect.objectContaining({ value: `hook:${WEBHOOK}`, integration: 'hook', hookKind: 'webhook' })
+      ])
+    )
+    // The numeric repository id is GitHub's own filter key; GitLab carries none.
+    expect(body.triggers.find((t) => t.hookKind === 'gitlab')?.githubRepoId).toBeNull()
+  })
+
+  it('accepts gitlab as a filter value and hands the repository its own hook ids', async () => {
+    const { deps, listPage } = fakeDeps()
+    const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions?view=flat&integration=gitlab' })
+
+    expect(res.statusCode).toBe(200)
+    expect(listPage.mock.calls[0]?.[0]).toMatchObject({ integration: 'gitlab', gitlabHookIds: [GITLAB_HOOK] })
+    // GitHub's ids are irrelevant to a gitlab filter, so they are never read.
+    expect(listPage.mock.calls[0]?.[0]).not.toHaveProperty('githubHookIds')
+  })
+
+  it('gives the generic hook filter both hosts to exclude', async () => {
+    const { deps, listPage } = fakeDeps()
+    const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions?view=flat&integration=hook' })
+
+    expect(res.statusCode).toBe(200)
+    expect(listPage.mock.calls[0]?.[0]).toMatchObject({
+      integration: 'hook',
+      githubHookIds: [GITHUB_HOOK],
+      gitlabHookIds: [GITLAB_HOOK]
+    })
+  })
+
+  it('resolves no code-host definitions for a filter that needs none', async () => {
+    const { deps, listIdsForOrgKind } = fakeDeps()
+    const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions?view=flat&integration=slack' })
+
+    expect(res.statusCode).toBe(200)
+    expect(listIdsForOrgKind).not.toHaveBeenCalled()
+  })
+})

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -60,7 +60,9 @@ const SessionFilterQueryDto = z.object({
   // parser hands repeated keys over as an array.
   agentId: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
   platform: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'dream']).optional(),
-  integration: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'github', 'dream']).optional(),
+  integration: z
+    .enum(['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'github', 'gitlab', 'dream'])
+    .optional(),
   channel: z.string().optional(),
   triggeredBy: z.string().optional(),
   githubRepoId: z
@@ -103,25 +105,31 @@ function requestedAgentIds(query: z.infer<typeof SessionFilterQueryDto>): string
 const HOOK_TRIGGER_PREFIX = 'hook:'
 const HookIdString = z.string().uuid()
 
-async function githubHookFilters(
+/** Which code-host hook definitions this request has to resolve. A repository
+ *  filter is GitHub-only (the numeric repo id is GitHub's); otherwise each host's
+ *  ids are read when the facet projection classifies everything, when that host is
+ *  the requested integration, or when `hook` needs to exclude it. */
+async function codeHostHookFilters(
   deps: HttpDeps,
   orgId: OrgId,
   query: z.infer<typeof SessionFilterQueryDto>,
   classifyAll: boolean
-): Promise<{ githubHookIds: HookId[]; repoHookIds?: HookId[] }> {
+): Promise<{ githubHookIds: HookId[]; gitlabHookIds: HookId[]; repoHookIds?: HookId[] }> {
   if (query.githubRepoId) {
     const githubHooks = await deps.repos.hook.listForOrgKind(orgId, 'github')
     return {
       githubHookIds: githubHooks.map((hook) => hook.id),
+      gitlabHookIds: [],
       repoHookIds: githubHooks.filter((hook) => hook.repoId?.toString() === query.githubRepoId).map((hook) => hook.id)
     }
   }
-  return {
-    githubHookIds:
-      classifyAll || query.integration === 'github' || query.integration === 'hook'
-        ? await deps.repos.hook.listIdsForOrgKind(orgId, 'github')
-        : []
-  }
+  const wanted = (kind: 'github' | 'gitlab') =>
+    classifyAll || query.integration === kind || query.integration === 'hook'
+  const [githubHookIds, gitlabHookIds] = await Promise.all([
+    wanted('github') ? deps.repos.hook.listIdsForOrgKind(orgId, 'github') : Promise.resolve([]),
+    wanted('gitlab') ? deps.repos.hook.listIdsForOrgKind(orgId, 'gitlab') : Promise.resolve([])
+  ])
+  return { githubHookIds, gitlabHookIds }
 }
 
 function hookIdForSession(s: HookSessionRow): string | null {
@@ -201,9 +209,13 @@ function decodeSessionCursor(raw: string): SessionCursor | null {
   }
 }
 
+/** A hook session's integration facet. Both code hosts are promoted out of the
+ *  generic hook bucket so each gets a first-class entry the console can filter by;
+ *  the value matches the client's own `sessionPlatform` classification. */
 function sessionIntegration(s: HookSessionRow, hook: HookSessionMetadata | undefined): string {
   const platform = s.platform ?? 'slack'
-  return platform === 'hook' && hook?.kind === 'github' ? 'github' : platform
+  if (platform !== 'hook') return platform
+  return hook?.kind === 'github' || hook?.kind === 'gitlab' ? hook.kind : platform
 }
 
 function sessionDisplayMetadata(
@@ -585,7 +597,12 @@ export function sessionRoutes(deps: HttpDeps) {
         if (requested.some((id) => !new Set<string>(orgAgentIds).has(id))) {
           return { agents: [], agentNames: {}, integrations: [], channels: [], triggers: [] }
         }
-        const { githubHookIds, repoHookIds } = await githubHookFilters(deps, orgOf(req), req.query, true)
+        const { githubHookIds, gitlabHookIds, repoHookIds } = await codeHostHookFilters(
+          deps,
+          orgOf(req),
+          req.query,
+          true
+        )
         // A multi-agent request narrows to the qualifying CONVERSATIONS and then
         // reads facets off every member row the caller can see, rather than only
         // the selected agents' rows: a facet answers "what else can I narrow by",
@@ -599,6 +616,7 @@ export function sessionRoutes(deps: HttpDeps) {
           ...(req.query.channel ? { channel: req.query.channel } : {}),
           ...(req.query.triggeredBy ? { triggeredBy: req.query.triggeredBy } : {}),
           githubHookIds,
+          gitlabHookIds,
           ...(repoHookIds ? { hookTriggerIds: repoHookIds } : {})
         }
         // Each facet drops its own active filter, so its external-audience
@@ -669,9 +687,14 @@ export function sessionRoutes(deps: HttpDeps) {
           }
         }
 
-        // GitHub is a semantic subtype of hook sessions. Resolve definitions only
-        // when integration classification or a repository-wide trigger filter needs them.
-        const { githubHookIds, repoHookIds } = await githubHookFilters(deps, orgOf(req), req.query, false)
+        // Each code host is a semantic subtype of hook sessions. Resolve definitions
+        // only when integration classification or a repository-wide trigger filter needs them.
+        const { githubHookIds, gitlabHookIds, repoHookIds } = await codeHostHookFilters(
+          deps,
+          orgOf(req),
+          req.query,
+          false
+        )
         // Two or more selected agents ask for the threads they SHARE. The rows stay
         // scoped to those agents (`agentIds`), so `?agentId=a` keeps returning
         // exactly what it always did. Every branch below reads this one binding —
@@ -692,6 +715,7 @@ export function sessionRoutes(deps: HttpDeps) {
           ...(req.query.channel ? { channel: req.query.channel } : {}),
           ...(req.query.triggeredBy ? { triggeredBy: req.query.triggeredBy } : {}),
           ...(githubHookIds.length > 0 ? { githubHookIds } : {}),
+          ...(gitlabHookIds.length > 0 ? { gitlabHookIds } : {}),
           ...(repoHookIds ? { hookTriggerIds: repoHookIds } : {}),
           ...(cursor ? { cursor } : {}),
           limit: req.query.limit,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1199,9 +1199,12 @@ export interface SessionQuery {
 }
 
 export interface SessionFilterQuery extends SessionQuery {
-  integration?: Platform | 'github'
+  integration?: Platform | 'github' | 'gitlab'
   triggeredBy?: string
+  /** Code-host hook ids, per host: each one is promoted out of the generic hook
+   *  bucket into its own integration, and `integration: 'hook'` excludes them all. */
   githubHookIds?: HookId[]
+  gitlabHookIds?: HookId[]
   hookTriggerIds?: HookId[]
   /** Agents whose sessions count as conversation MEMBERS, when the caller may see
    *  more than the filter returns. Absent ⇒ `agentIds`, i.e. membership and row

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -221,29 +221,38 @@ function hookTriggerSql(hookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
   `
 }
 
-function githubHookSql(githubHookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
-  return Prisma.sql`${a}."platform" = 'hook' AND ${hookTriggerSql(githubHookIds, a)}`
+/** One code host's hook sessions — the same predicate for either host, told apart
+ *  only by which hook ids it is given. */
+function codeHostHookSql(hookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
+  return Prisma.sql`${a}."platform" = 'hook' AND ${hookTriggerSql(hookIds, a)}`
 }
 
-function genericHookSql(githubHookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
-  if (githubHookIds.length === 0) return Prisma.sql`${a}."platform" = 'hook'`
-  const triggers = githubHookIds.map((id) => `${HOOK_TRIGGER_PREFIX}${id}`)
+/** Hook sessions that belong to NO code host — every promoted id is excluded here,
+ *  or a GitLab session would be counted twice: once as gitlab, once as a webhook. */
+function genericHookSql(codeHostHookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
+  if (codeHostHookIds.length === 0) return Prisma.sql`${a}."platform" = 'hook'`
+  const triggers = codeHostHookIds.map((id) => `${HOOK_TRIGGER_PREFIX}${id}`)
   return Prisma.sql`
     ${a}."platform" = 'hook'
     AND (${a}."triggeredBy" IS NULL OR ${a}."triggeredBy" NOT IN (${Prisma.join(triggers)}))
     AND (
       (${a}."triggeredBy" LIKE ${`${HOOK_TRIGGER_PREFIX}%`} AND ${a}."triggeredBy" <> ${HOOK_TRIGGER_PREFIX})
       OR ${a}."channel" IS NULL
-      OR ${a}."channel" NOT IN (${Prisma.join(githubHookIds)})
+      OR ${a}."channel" NOT IN (${Prisma.join(codeHostHookIds)})
     )
   `
 }
 
+/** Every promoted code-host hook id, in one list, for the generic-hook exclusion. */
+function codeHostHookIds(q: Pick<SessionFilterQuery, 'githubHookIds' | 'gitlabHookIds'>): string[] {
+  return [...(q.githubHookIds ?? []), ...(q.gitlabHookIds ?? [])]
+}
+
 function integrationSql(q: SessionFilterQuery, a: Prisma.Sql = S): Prisma.Sql | null {
   if (!q.integration) return null
-  const githubHookIds = q.githubHookIds ?? []
-  if (q.integration === 'github') return githubHookSql(githubHookIds, a)
-  if (q.integration === 'hook') return genericHookSql(githubHookIds, a)
+  if (q.integration === 'github') return codeHostHookSql(q.githubHookIds ?? [], a)
+  if (q.integration === 'gitlab') return codeHostHookSql(q.gitlabHookIds ?? [], a)
+  if (q.integration === 'hook') return genericHookSql(codeHostHookIds(q), a)
   return platformSql(q.integration, a)
 }
 
@@ -306,11 +315,15 @@ function pageWhereSql(
   return Prisma.sql`WHERE ${Prisma.join(filters, ' AND ')}`
 }
 
-function integrationFacetSql(githubHookIds: string[]): Prisma.Sql {
-  if (githubHookIds.length === 0) return Prisma.sql`COALESCE(s."platform", 'slack')`
+function integrationFacetSql(githubHookIds: string[], gitlabHookIds: string[]): Prisma.Sql {
+  if (githubHookIds.length === 0 && gitlabHookIds.length === 0) return Prisma.sql`COALESCE(s."platform", 'slack')`
+  const arms = [
+    ...(githubHookIds.length > 0 ? [Prisma.sql`WHEN ${codeHostHookSql(githubHookIds)} THEN 'github'`] : []),
+    ...(gitlabHookIds.length > 0 ? [Prisma.sql`WHEN ${codeHostHookSql(gitlabHookIds)} THEN 'gitlab'`] : [])
+  ]
   return Prisma.sql`
     CASE
-      WHEN ${githubHookSql(githubHookIds)} THEN 'github'
+      ${Prisma.join(arms, ' ')}
       WHEN s."platform" IS NULL THEN 'slack'
       ELSE s."platform"
     END
@@ -1178,7 +1191,7 @@ export class PgSessionRepo implements SessionRepo {
     delete triggerQuery.triggeredBy
     delete triggerQuery.hookTriggerIds
 
-    const integrationFacet = integrationFacetSql(q.githubHookIds ?? [])
+    const integrationFacet = integrationFacetSql(q.githubHookIds ?? [], q.gitlabHookIds ?? [])
     const [agents, integrations, channels, triggers] = await Promise.all([
       this.db.$queryRaw<SessionAgentFacetDbRow[]>(Prisma.sql`
         SELECT DISTINCT s."agentId"

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -489,6 +489,97 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     )
   })
 
+  it('gives gitlab hook sessions their own integration facet and filter', async () => {
+    // GitLab rows carry platform 'hook' like every other hook session, so without the
+    // per-host promotion they were counted as generic webhooks — and the webhook filter
+    // returned them, mixing two unrelated sources under one entry.
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    const webhookId = randomUUID()
+    await prisma.hookDef.create({
+      data: {
+        id: webhookId,
+        orgId: DEFAULT_ORG_ID,
+        agentId: AGENT,
+        kind: 'webhook',
+        name: 'acme/build',
+        sessionMode: 'perDelivery',
+        urlToken: `whk_${randomUUID().replace(/-/g, '')}`,
+        targetPlatform: 'slack'
+      }
+    })
+    const gitlabId = randomUUID()
+    await prisma.hookDef.create({
+      data: {
+        id: gitlabId,
+        orgId: DEFAULT_ORG_ID,
+        agentId: AGENT,
+        kind: 'gitlab',
+        name: 'acme/platform',
+        sessionMode: 'perThread',
+        repoId: 4210n,
+        repoFullName: 'acme/platform',
+        events: ['merge_request:*'],
+        targetPlatform: 'slack'
+      }
+    })
+    running = buildHttpApp(prisma)
+
+    await reportSession({
+      sessionId: 'acp-webhook-gl',
+      agentId: AGENT,
+      phase: 'start',
+      platform: 'hook',
+      channel: webhookId,
+      thread: 'delivery-1',
+      title: 'Reply with a one-line hello',
+      triggeredBy: `hook:${webhookId}`,
+      ts: '2026-08-22T00:00:00.000Z'
+    })
+    await reportSession({
+      sessionId: 'acp-gitlab-1',
+      agentId: AGENT,
+      phase: 'start',
+      platform: 'hook',
+      channel: gitlabId,
+      title: 'Answer the merge request',
+      triggeredBy: `hook:${gitlabId}`,
+      channelName: 'acme/platform',
+      triggeredByName: 'acme/platform',
+      ts: '2026-08-22T00:00:00.000Z'
+    })
+
+    const facets = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/facets` })
+    expect(facets.statusCode).toBe(200)
+    const facetBody = facets.json() as {
+      integrations: string[]
+      triggers: Array<{ value: string; integration: string; hookKind: string | null }>
+    }
+    expect([...facetBody.integrations].sort()).toEqual(['gitlab', 'hook'])
+    expect(facetBody.triggers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: `hook:${gitlabId}`, integration: 'gitlab', hookKind: 'gitlab' }),
+        expect.objectContaining({ value: `hook:${webhookId}`, integration: 'hook', hookKind: 'webhook' })
+      ])
+    )
+
+    const gitlabOnly = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?view=flat&integration=gitlab`
+    })
+    expect(gitlabOnly.statusCode).toBe(200)
+    expect((gitlabOnly.json() as { sessions: Array<{ sessionId: string }> }).sessions.map((s) => s.sessionId)).toEqual([
+      'acp-gitlab-1'
+    ])
+    expect((gitlabOnly.json() as { total: number }).total).toBe(1)
+
+    const genericOnly = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&integration=hook` })
+    expect(genericOnly.statusCode).toBe(200)
+    expect((genericOnly.json() as { sessions: Array<{ sessionId: string }> }).sessions.map((s) => s.sessionId)).toEqual(
+      ['acp-webhook-gl']
+    )
+  })
+
   it('serves the multi-agent webchat roster on the detail route; single-agent stays null', async () => {
     // An adopted/refreshed webchat session has no relay socket to deliver the
     // verified roster — the composer/header read it from this DTO field instead.

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { Button, Icon } from '@/components/ui'
 import { GitlabMark, LoadingState } from '@/components/marks'
 import { useOrgs } from '@/lib/org-context'
+import { GITLAB_PROJECT_STATE } from '@/lib/gitlab-projects'
 import {
   createGitlabProject,
   deleteGitlabProject,
@@ -19,18 +20,8 @@ import {
   startGitlabOauth,
   type GitlabConnectionDto,
   type GitlabProjectBindingDto,
-  type GitlabProjectBindingState,
   type GitlabProjectDto
 } from '@/lib/api'
-
-// The user-facing word for each lifecycle state: it names the broken half, not the internal state id.
-const PROJECT_STATE: Record<GitlabProjectBindingState, { label: string; badge: string }> = {
-  provisioning: { label: 'setting up', badge: 'bg-(--status-info-soft) text-(--status-info)' },
-  ready: { label: 'ready', badge: 'bg-(--status-online-soft) text-(--status-online)' },
-  admin_degraded: { label: 'setup incomplete', badge: 'bg-(--status-paused-soft) text-(--amber-500)' },
-  runtime_degraded: { label: 'bot access degraded', badge: 'bg-(--status-paused-soft) text-(--amber-500)' },
-  cleanup_pending: { label: 'removal incomplete', badge: 'bg-(--status-error-soft) text-(--status-error)' }
-}
 
 // The CP records a machine category in `stateReason`; these are the ones a user can act on, in GitLab
 // vocabulary. Every rotation_* variant collapses to one line — the tail (rotation_gitlab_<status>) is open-ended.
@@ -281,7 +272,9 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
           >
             <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
               <span className="mono min-w-0 truncate text-[12.5px]">{p.projectPath}</span>
-              <span className={`badge ${PROJECT_STATE[p.state].badge}`}>{PROJECT_STATE[p.state].label}</span>
+              <span className={`badge ${GITLAB_PROJECT_STATE[p.state].badge}`}>
+                {GITLAB_PROJECT_STATE[p.state].label}
+              </span>
               {p.serviceAccountUsername && (
                 <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
                   bot @{p.serviceAccountUsername}

--- a/packages/web/src/components/console/IntegrationMarks.tsx
+++ b/packages/web/src/components/console/IntegrationMarks.tsx
@@ -1,6 +1,11 @@
-import { GithubMark, PlatformMark } from '@/components/marks'
+import { GithubMark, GitlabMark, PlatformMark } from '@/components/marks'
+import type { HookKind } from '@/lib/api'
 
-type HookKind = 'webhook' | 'github'
+const HOOK_KIND_TITLE: Record<HookKind, string> = {
+  github: 'GitHub events',
+  gitlab: 'GitLab events',
+  webhook: 'Inbound webhook'
+}
 
 interface IntegrationMarkSource {
   id?: string
@@ -36,11 +41,15 @@ export function IntegrationMarks({
           <span
             key={kind}
             className={`imark h-[21px] w-[21px] ${visibleIntegrations.length + index === 0 ? '' : 'imark-overlap -ml-[7px]'}`}
-            title={kind === 'github' ? 'GitHub events' : 'Inbound webhook'}
+            title={HOOK_KIND_TITLE[kind]}
           >
             {kind === 'github' ? (
               <span className="flex h-[13px] w-[13px] items-center justify-center">
                 <GithubMark fillPct={90} />
+              </span>
+            ) : kind === 'gitlab' ? (
+              <span className="flex h-[13px] w-[13px] items-center justify-center">
+                <GitlabMark fillPct={90} />
               </span>
             ) : (
               // The brand-pink webhook mark, not a white glyph on an inverted plate:

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -21,6 +21,7 @@ import {
 } from 'react'
 import {
   agentLabel,
+  isGitWorkspace,
   selectedPermissionPreset,
   type Agent,
   type Session,
@@ -1127,7 +1128,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const openPlayground = useCallback(
     (da: Agent, members?: Agent[], options?: { worktree?: boolean }): string => {
       const id = newPlaygroundSessionId(da.id)
-      if (da.workspace?.mode === 'github') {
+      if (da.workspace && isGitWorkspace(da.workspace)) {
         stagedWorktree.current.set(id, options?.worktree ?? da.workspace.worktree === true)
       }
       // The roster is fixed at creation (webchat-multi-agents.md §3.1): the

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -25,7 +25,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
-import { GithubMark, LoadingState } from '@/components/marks'
+import { GithubMark, GitlabMark, LoadingState } from '@/components/marks'
 import { Icon } from '@/components/ui'
 import { isPoolPlacementKind, type Agent, type WorkspaceStatusInfo } from '@/lib/data'
 import { creatorLabel, fetchAgentRepos } from '@/lib/api'
@@ -33,8 +33,9 @@ import { useOrgs } from '@/lib/org-context'
 import { useProfile } from '@/lib/profile'
 import { consoleKeys } from '@/lib/swr-keys'
 import { useConsoleData } from '@/lib/data-context'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import EditWorkspaceModal from '@/components/console/modals/EditWorkspaceModal'
-import { REPOSITORY_ACCESS_BADGE } from '@/components/console/WorkspaceFormFields'
+import { REPOSITORY_ACCESS_BADGE, type WorkspaceMode } from '@/components/console/WorkspaceFormFields'
 
 /**
  * The live half of the Source row. The card itself only knows the agent's
@@ -83,7 +84,7 @@ export function WorkspaceCard({
   // Non-null ⇒ the unified workspace editor is open. The authorization
   // shortcut starts it directly in its additional-repository subview.
   const [editState, setEditState] = useState<{
-    mode: 'scratch' | 'github'
+    mode: WorkspaceMode
     authorizeRepository?: true
   } | null>(null)
 
@@ -106,7 +107,10 @@ export function WorkspaceCard({
     router.replace(`${pathname}${sp.size ? `?${sp}` : ''}`, { scroll: false })
   }, [searchParams, agent.canEdit, pathname, router])
 
+  const gitlabOffered = featureFlagEnabled('gitlab')
   const isGithub = ws.mode === 'github'
+  const isGitlab = ws.mode === 'gitlab'
+  const isGit = ws.mode !== 'scratch'
   const isGithubApp = ws.mode === 'github' && !!ws.installationId
   const reposKey = consoleKeys.agentRepos(activeOrg?.id, agent.id)
   const {
@@ -125,16 +129,22 @@ export function WorkspaceCard({
   // A manual checkout has no App installation to mint a write token from, so its
   // effective workspace access is read regardless of the stored preference.
   const workspaceAccess =
-    ws.mode === 'github' ? (ws.installationId ? (ws.gitAccess ?? 'write') : ('read' as const)) : null
-  const remoteLabel = header?.remoteLabel ?? 'GitHub'
+    ws.mode === 'github'
+      ? ws.installationId
+        ? (ws.gitAccess ?? 'write')
+        : ('read' as const)
+      : ws.mode === 'gitlab'
+        ? (ws.gitAccess ?? 'write')
+        : null
+  const remoteLabel = header?.remoteLabel ?? (isGitlab ? 'GitLab' : 'GitHub')
 
   // The segment is the conversion entry point; picking the mode the agent is
   // already on is a no-op (the pencil edits the current source's settings).
-  const pickMode = (next: 'scratch' | 'github') => {
+  const pickMode = (next: WorkspaceMode) => {
     if (!canEdit || next === ws.mode) return
     setEditState({ mode: next })
   }
-  const segClass = (mode: 'scratch' | 'github') =>
+  const segClass = (mode: WorkspaceMode) =>
     mode === ws.mode ? (canEdit ? SEG_ON : SEG_ON_LOCKED) : canEdit ? SEG_OFF : SEG_OFF_LOCKED
 
   return (
@@ -152,11 +162,21 @@ export function WorkspaceCard({
             <Icon name="git-branch" size={12} />
             GitHub repo
           </button>
+          {gitlabOffered && (
+            <button
+              className={segClass('gitlab')}
+              onClick={() => pickMode('gitlab')}
+              title={isGitlab ? 'The workspace is a GitLab clone' : 'Convert this workspace to a GitLab project'}
+            >
+              <Icon name="git-branch" size={12} />
+              GitLab project
+            </button>
+          )}
           <button
             className={segClass('scratch')}
             onClick={() => pickMode('scratch')}
             title={
-              isGithub ? 'Convert this workspace to an empty scratch directory' : 'The workspace is a scratch directory'
+              isGit ? 'Convert this workspace to an empty scratch directory' : 'The workspace is a scratch directory'
             }
           >
             <Icon name="folder" size={12} />
@@ -166,15 +186,15 @@ export function WorkspaceCard({
 
         <span className="mx-[2px] h-[18px] w-px flex-none bg-(--border-subtle)" />
 
-        {isGithub ? (
+        {isGit ? (
           <span className="flex h-5 w-5 flex-none items-center justify-center">
-            <GithubMark color="var(--text-secondary)" />
+            {isGitlab ? <GitlabMark color="var(--text-secondary)" /> : <GithubMark color="var(--text-secondary)" />}
           </span>
         ) : (
           <Icon name="folder" size={16} color="var(--text-tertiary)" />
         )}
         <span className="mono min-w-0 truncate text-[13px] font-semibold text-(--text-primary)">
-          {ws.mode === 'github' ? ws.repo : 'Scratch workspace'}
+          {ws.mode === 'scratch' ? 'Scratch workspace' : ws.repo}
         </span>
         {/* Effective workspace access stays visible next to the repository
             (product-conventions.md §Workspace navigation and repository access) —
@@ -197,7 +217,7 @@ export function WorkspaceCard({
             <span className="text-(--brand-soft-text)">{header.commit.sha}</span> · {header.commit.time}
           </span>
         )}
-        {isGithub && header?.onPull && (
+        {isGit && header?.onPull && (
           <button
             className={`iconbtn h-6 w-6 flex-none ${header.pulling ? 'pointer-events-none opacity-50' : ''}`}
             title="Fast-forward pull from the remote"
@@ -206,7 +226,7 @@ export function WorkspaceCard({
             <Icon name="refresh-cw" size={13} />
           </button>
         )}
-        {isGithub && header?.repoUrl && (
+        {isGit && header?.repoUrl && (
           <a
             className="iconbtn flex h-6 w-6 flex-none items-center justify-center no-underline"
             title={`View on ${remoteLabel}`}

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -241,6 +241,52 @@ describe('workspaceReadModelKey', () => {
       workspaceReadModelKey(github, undefined, 'example-co/shared-library')
     )
   })
+
+  // Every gitlab workspace used to fall through to the `:scratch` arm, so switching
+  // project — or converting scratch → GitLab — reused the previous checkout's tree.
+  describe('gitlab workspaces', () => {
+    const gitlabAt = (over: Record<string, unknown>) =>
+      workspaceReadModelKey({
+        id: 'agent-a',
+        workdir: '/ws/agent-a',
+        workspace: {
+          mode: 'gitlab',
+          projectId: '4210',
+          repo: 'acme/platform',
+          branch: 'main',
+          agentDir: '/',
+          ...over
+        }
+      } as unknown as Pick<Agent, 'id' | 'workspace' | 'workdir'>)
+
+    it('separates two projects, and a project from scratch', () => {
+      expect(gitlabAt({ projectId: '4211', repo: 'acme/runtime' })).not.toBe(gitlabAt({}))
+      expect(gitlabAt({})).not.toBe(
+        workspaceReadModelKey({
+          id: 'agent-a',
+          workdir: '/ws/agent-a',
+          workspace: { mode: 'scratch' }
+        } as unknown as Pick<Agent, 'id' | 'workspace' | 'workdir'>)
+      )
+    })
+
+    it('separates a renamed project from a genuinely different one', () => {
+      // The path moved but the project did not: same checkout, so the same key.
+      expect(gitlabAt({ repo: 'acme-group/platform' })).toBe(gitlabAt({}))
+      expect(gitlabAt({ projectId: '99' })).not.toBe(gitlabAt({}))
+    })
+
+    it.each([
+      ['branch', { branch: 'next' }],
+      ['working subdirectory', { agentDir: '/services/api' }]
+    ])('changes when the %s changes', (_label, over) => {
+      expect(gitlabAt(over)).not.toBe(gitlabAt({}))
+    })
+
+    it('never collides with a GitHub workspace of the same path', () => {
+      expect(gitlabAt({ repo: 'acme/infra', projectId: 'acme/infra' })).not.toBe(workspaceReadModelKey(github))
+    })
+  })
 })
 
 const REPO_GRANTS = [

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -22,7 +22,7 @@ import { useIsMobile } from '@/lib/use-is-mobile'
 import { escapeHtml, highlight, linkifyHtml, loadHljs } from '@/lib/highlight'
 import { resolveWorkspaceMarkdownLink } from '@/components/console/workspace-links'
 import type { WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
-import type { Agent } from '@/lib/data'
+import { isGitWorkspace, type Agent } from '@/lib/data'
 import type { MarkdownLinkResolution } from '@/components/console/MarkdownView'
 import {
   FileBrowserBreadcrumb,
@@ -76,8 +76,8 @@ const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
  * rather than reuse it. Since the workspace editor now lives in the card above
  * the browser — same tab, same mounted tree — reuse would leave the refreshed
  * source card sitting on top of files that belong to the workspace it replaced,
- * and a GitHub → scratch conversion would additionally flip `canEdit` to true
- * over that stale GitHub preview. Pass this as the instance's React `key`.
+ * and a git → scratch conversion would additionally flip `canEdit` to true
+ * over that stale preview. Pass this as the instance's React `key`.
  */
 export function workspaceReadModelKey(
   agent: Pick<Agent, 'id' | 'workspace' | 'workdir'>,
@@ -88,7 +88,10 @@ export function workspaceReadModelKey(
   // The repo scope is part of the identity for the same reason the session is: the cached tree,
   // preview and git status belong to ONE root, and switching roots must remount rather than reuse.
   const at = `${agent.id}:${agent.workdir}:${sessionId ?? 'primary'}:${repo ?? 'workspace'}`
-  return ws.mode === 'github' ? `${at}:github:${ws.repo}@${ws.branch}:${ws.agentDir}` : `${at}:scratch`
+  if (!isGitWorkspace(ws)) return `${at}:scratch`
+  // Each host names its checkout its own way — GitLab by rename-stable project id, GitHub by owner/repo.
+  const source = ws.mode === 'gitlab' ? `gitlab:${ws.projectId ?? ws.repo}` : `github:${ws.repo}`
+  return `${at}:${source}@${ws.branch}:${ws.agentDir}`
 }
 
 // Parse a full git remote address (https or ssh) into a display label ("org/repo")

--- a/packages/web/src/components/console/WorkspaceFormFields.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.test.tsx
@@ -14,6 +14,11 @@ import {
 let root: Root | undefined
 let container: HTMLDivElement | undefined
 
+const setFlags = (value?: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
+    value === undefined ? {} : { FEATURE_FLAGS: value }
+}
+
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
 async function render(element: ReactNode) {
@@ -24,6 +29,7 @@ async function render(element: ReactNode) {
 }
 
 afterEach(async () => {
+  setFlags()
   if (root) await act(async () => root?.unmount())
   container?.remove()
   root = undefined
@@ -53,6 +59,22 @@ describe('WorkspaceFormFields', () => {
 
     await act(async () => buttons[1]?.click())
     expect(onChange).toHaveBeenCalledWith('github')
+  })
+
+  it('offers the GitLab source only where the flag is on', async () => {
+    const onChange = vi.fn()
+    setFlags('gitlab')
+    await render(<WorkspaceModeField value="scratch" onChange={onChange} />)
+
+    const buttons = Array.from(container?.querySelectorAll('button') ?? [])
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      'From scratchFresh empty directory.',
+      'From GitHubClone a repo on a branch.',
+      'From GitLabClone a project on a branch.'
+    ])
+
+    await act(async () => buttons[2]?.click())
+    expect(onChange).toHaveBeenCalledWith('gitlab')
   })
 
   it('returns the shared repository access vocabulary', async () => {

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { KeyboardEvent, ReactNode } from 'react'
-import { GithubMark } from '@/components/marks'
+import { GithubMark, GitlabMark } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
-import type { RepoAccess } from '@/lib/api'
+import { featureFlagEnabled } from '@/lib/feature-flags'
+import { GITLAB_PROJECT_STATE, gitlabProjectSelectable } from '@/lib/gitlab-projects'
+import type { GitlabProjectBindingDto, RepoAccess } from '@/lib/api'
 
-export type WorkspaceMode = 'scratch' | 'github'
+export type WorkspaceMode = 'scratch' | 'github' | 'gitlab'
 export type WorkspaceRepoAccess = 'read' | 'write'
 type RepositoryMenuStyle = { left: number; top: number; width: number; maxHeight: number }
 
@@ -31,6 +33,7 @@ export function WorkspaceModeField({
   label?: string
 }) {
   const fieldClassName = className ? `fld ${className}` : 'fld'
+  const gitlab = featureFlagEnabled('gitlab')
   const radio = (selected: boolean) => (
     <span
       className={
@@ -51,7 +54,11 @@ export function WorkspaceModeField({
   return (
     <div className={fieldClassName}>
       <span className="fldlbl">{label}</span>
-      <div className="grid grid-cols-1 gap-[10px] desktop:grid-cols-2">
+      <div
+        className={
+          gitlab ? 'grid grid-cols-1 gap-[10px] desktop:grid-cols-3' : 'grid grid-cols-1 gap-[10px] desktop:grid-cols-2'
+        }
+      >
         <button
           type="button"
           className={value === 'scratch' ? 'ptile on items-start text-left' : 'ptile items-start text-left'}
@@ -82,6 +89,22 @@ export function WorkspaceModeField({
           </span>
           {radio(value === 'github')}
         </button>
+        {gitlab && (
+          <button
+            type="button"
+            className={value === 'gitlab' ? 'ptile on items-start text-left' : 'ptile items-start text-left'}
+            onClick={() => onChange('gitlab')}
+          >
+            {tileIcon(<GitlabMark color="var(--text-primary)" />)}
+            <span className="min-w-0 flex-1">
+              <span className="block font-sans text-[13px] font-semibold leading-normal">From GitLab</span>
+              <span className="mt-[2px] block truncate font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                Clone a project on a branch.
+              </span>
+            </span>
+            {radio(value === 'gitlab')}
+          </button>
+        )}
       </div>
     </div>
   )
@@ -175,22 +198,10 @@ export function GithubPrivateReposNotice({ profileHref }: { profileHref: string 
   )
 }
 
-export function GithubRepositoryField({
-  value,
-  icon = 'lock',
-  badge,
-  loading,
-  open,
-  query,
-  onToggle,
-  onClose,
-  onQueryChange,
-  onSearchKeyDown,
-  error,
-  onRetry,
-  children,
-  note
-}: {
+/** What a caller supplies to either code-host picker; the words come from the wrapper. */
+export interface RepositoryPickerProps {
+  /** Overrides the wrapper's field label where a surface needs another noun. */
+  label?: string
   value: string
   icon?: 'lock' | 'book-marked'
   badge?: string
@@ -205,7 +216,39 @@ export function GithubRepositoryField({
   onRetry?: () => void
   children: ReactNode
   note?: ReactNode
-}) {
+}
+
+interface RepositoryPickerWords {
+  label: string
+  mark: ReactNode
+  emptyLabel: string
+  loadingLabel: string
+  searchPlaceholder: string
+}
+
+/** The provider-neutral picker chrome — trigger, portalled menu, search box and
+ *  error row. Each code host supplies its own words and mark through a wrapper. */
+function RepositoryPickerField({
+  label,
+  mark,
+  emptyLabel,
+  loadingLabel,
+  searchPlaceholder,
+  value,
+  icon = 'lock',
+  badge,
+  loading,
+  open,
+  query,
+  onToggle,
+  onClose,
+  onQueryChange,
+  onSearchKeyDown,
+  error,
+  onRetry,
+  children,
+  note
+}: Omit<RepositoryPickerProps, 'label'> & RepositoryPickerWords) {
   const triggerRef = useRef<HTMLDivElement>(null)
   const [menuStyle, setMenuStyle] = useState<RepositoryMenuStyle | null>(null)
 
@@ -234,7 +277,7 @@ export function GithubRepositoryField({
 
   return (
     <div className="fld relative min-w-0">
-      <span className="fldlbl">GitHub repository</span>
+      <span className="fldlbl">{label}</span>
       <div ref={triggerRef} className="inp min-w-0 cursor-pointer gap-2" title={value || undefined} onClick={onToggle}>
         <span className="inline-flex min-w-0 flex-1 items-center gap-[7px]">
           {value ? (
@@ -254,12 +297,8 @@ export function GithubRepositoryField({
             </>
           ) : (
             <>
-              <span className="imark h-4 w-4 flex-none border-0 bg-transparent">
-                <GithubMark color="var(--text-secondary)" />
-              </span>
-              <span className="truncate text-(--text-tertiary)">
-                {loading ? 'Loading repositories…' : 'Pick a repository'}
-              </span>
+              <span className="imark h-4 w-4 flex-none border-0 bg-transparent">{mark}</span>
+              <span className="truncate text-(--text-tertiary)">{loading ? loadingLabel : emptyLabel}</span>
             </>
           )}
         </span>
@@ -276,7 +315,7 @@ export function GithubRepositoryField({
                 value={query}
                 onChange={(event) => onQueryChange(event.target.value)}
                 onKeyDown={onSearchKeyDown}
-                placeholder="Search or type owner/repo…"
+                placeholder={searchPlaceholder}
                 autoFocus
               />
               {error && (
@@ -295,6 +334,96 @@ export function GithubRepositoryField({
           document.body
         )}
       {note}
+    </div>
+  )
+}
+
+export function GithubRepositoryField(props: RepositoryPickerProps) {
+  return (
+    <RepositoryPickerField
+      {...props}
+      label={props.label ?? 'GitHub repository'}
+      mark={<GithubMark color="var(--text-secondary)" />}
+      emptyLabel="Pick a repository"
+      loadingLabel="Loading repositories…"
+      searchPlaceholder="Search or type owner/repo…"
+    />
+  )
+}
+
+export function GitlabProjectField(props: RepositoryPickerProps) {
+  return (
+    <RepositoryPickerField
+      {...props}
+      label={props.label ?? 'GitLab project'}
+      mark={<GitlabMark color="var(--text-secondary)" />}
+      emptyLabel="Pick a project"
+      loadingLabel="Loading projects…"
+      searchPlaceholder="Search your added projects…"
+    />
+  )
+}
+
+/** One added project. Transient states are listed and disabled, not hidden — a project
+ *  the user just added reads as on its way rather than mysteriously absent. */
+export function GitlabProjectOption({
+  project,
+  selected = false,
+  onSelect
+}: {
+  project: GitlabProjectBindingDto
+  selected?: boolean
+  onSelect: () => void
+}) {
+  const selectable = gitlabProjectSelectable(project.state)
+  const state = GITLAB_PROJECT_STATE[project.state]
+  return (
+    <button
+      type="button"
+      className={
+        selectable
+          ? 'fopt min-h-[46px] items-center gap-3 px-2 py-2'
+          : 'fopt min-h-[46px] cursor-not-allowed items-center gap-3 px-2 py-2 opacity-60'
+      }
+      title={project.projectPath}
+      aria-disabled={!selectable}
+      disabled={!selectable}
+      onClick={() => selectable && onSelect()}
+    >
+      <span className="flex h-4 w-4 flex-none items-center justify-center">
+        <GitlabMark color="var(--text-tertiary)" />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col items-start gap-[2px] overflow-hidden">
+        <span
+          className="block w-full min-w-0 truncate font-mono text-[12.5px] font-semibold leading-normal text-(--text-primary)"
+          title={project.projectPath}
+        >
+          {project.projectPath}
+        </span>
+        <span className="block w-full min-w-0 truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+          {project.defaultBranch ? `default branch ${project.defaultBranch}` : 'no default branch reported'}
+        </span>
+      </span>
+      {project.state !== 'ready' && <span className={`badge flex-none ${state.badge}`}>{state.label}</span>}
+      {selected && <Icon name="check" size={17} color="var(--brand)" />}
+    </button>
+  )
+}
+
+/** Nothing to pick yet: projects come from the organization's GitLab connection. */
+export function GitlabNoProjectsNotice({ integrationsHref }: { integrationsHref: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">
+      <span className="mt-[1px] flex h-[14px] w-[14px] flex-none items-center justify-center">
+        <GitlabMark color="var(--text-tertiary)" fillPct={100} />
+      </span>
+      <span>
+        No GitLab projects have been added yet. Connect GitLab and add a project under{' '}
+        <a className="lnk font-medium" href={integrationsHref}>
+          Integrations
+        </a>
+        , then pick it here.
+      </span>
     </div>
   )
 }
@@ -342,20 +471,17 @@ export function GithubRepositoryOption({
   )
 }
 
-const ACCESS_OPTIONS: Array<{
+function accessOptions(writeDescription: string): Array<{
   value: WorkspaceRepoAccess
   icon: 'eye' | 'git-branch'
   label: string
   description: string
-}> = [
-  { value: 'read', icon: 'eye', label: 'Read only', description: 'Clone & read files only' },
-  {
-    value: 'write',
-    icon: 'git-branch',
-    label: 'Read & write',
-    description: 'Push, open PRs & run GitHub Actions'
-  }
-]
+}> {
+  return [
+    { value: 'read', icon: 'eye', label: 'Read only', description: 'Clone & read files only' },
+    { value: 'write', icon: 'git-branch', label: 'Read & write', description: writeDescription }
+  ]
+}
 
 export function RepositoryAccessField({
   repositorySelected,
@@ -363,6 +489,9 @@ export function RepositoryAccessField({
   open,
   readOnly = false,
   readOnlyNote,
+  label = 'Repository access',
+  unselectedLabel = 'Select repository first',
+  writeDescription = 'Push, open PRs & run GitHub Actions',
   onToggle,
   onClose,
   onChange
@@ -372,20 +501,25 @@ export function RepositoryAccessField({
   open: boolean
   readOnly?: boolean
   readOnlyNote?: ReactNode
+  label?: string
+  unselectedLabel?: string
+  /** What read & write buys on this code host — the only provider-specific word here. */
+  writeDescription?: string
   onToggle: () => void
   onClose: () => void
   onChange: (value: WorkspaceRepoAccess) => void
 }) {
-  const selected = ACCESS_OPTIONS.find((option) => option.value === value)!
+  const options = accessOptions(writeDescription)
+  const selected = options.find((option) => option.value === value)!
   return (
     <div className="fld relative min-w-0">
-      <span className="fldlbl">Repository access</span>
+      <span className="fldlbl">{label}</span>
       {!repositorySelected ? (
         <div className="inp min-w-0 cursor-not-allowed pl-[10px] opacity-70" aria-disabled="true">
           <span className="inline-flex min-w-0 flex-1 items-center gap-[7px]">
             <Icon name="book-marked" size={16} color="var(--text-tertiary)" className="flex-none" />
             <span className="truncate font-sans text-[13px] font-medium leading-normal text-(--text-tertiary)">
-              Select repository first
+              {unselectedLabel}
             </span>
           </span>
         </div>
@@ -409,7 +543,7 @@ export function RepositoryAccessField({
             <>
               <div className="fscrim" onClick={onClose} />
               <div className="fmenu left-0 right-0 z-40 min-w-0 rounded-lg p-2 shadow-(--shadow-xl)">
-                {ACCESS_OPTIONS.map((option) => (
+                {options.map((option) => (
                   <button
                     key={option.value}
                     type="button"
@@ -445,6 +579,8 @@ export function WorkspaceBranchField({
   defaultBranch,
   open,
   query,
+  unselectedLabel = 'Pick repository first',
+  defaultBranchLabel = 'GitHub default branch',
   onToggle,
   onClose,
   onQueryChange,
@@ -456,6 +592,8 @@ export function WorkspaceBranchField({
   defaultBranch?: string
   open: boolean
   query: string
+  unselectedLabel?: string
+  defaultBranchLabel?: string
   onToggle: () => void
   onClose: () => void
   onQueryChange: (value: string) => void
@@ -472,7 +610,7 @@ export function WorkspaceBranchField({
           <span className="inline-flex min-w-0 flex-1 items-center gap-[7px]">
             <Icon name="git-branch" size={16} color="var(--text-tertiary)" className="flex-none" />
             <span className="truncate font-sans text-[13px] font-medium leading-normal text-(--text-tertiary)">
-              Pick repository first
+              {unselectedLabel}
             </span>
           </span>
         </div>
@@ -488,7 +626,7 @@ export function WorkspaceBranchField({
                     : 'truncate font-sans text-[13px] font-medium leading-normal text-(--text-tertiary)'
                 }
               >
-                {value || 'GitHub default branch'}
+                {value || defaultBranchLabel}
               </span>
             </span>
             <Icon name="chevron-down" size={15} color="var(--text-tertiary)" />

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -43,13 +43,15 @@ import {
   fetchGithubInstallUrl,
   fetchGithubRepoRoster,
   fetchGithubRepoAccess,
+  fetchGitlabProjects,
   invalidateGithubRepoRosterCache,
   type AgentWorkspaceDto,
   type GithubInstallationDto,
   type GithubRepoAccess,
-  type GithubRepoDto
+  type GithubRepoDto,
+  type GitlabProjectBindingDto
 } from '@/lib/api'
-import { GithubMark } from '@/components/marks'
+import { GithubMark, LoadingState } from '@/components/marks'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
 import { DaemonSelect, type DaemonSelectOption } from '@/components/console/DaemonSelect'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
@@ -83,14 +85,19 @@ import {
   GithubPrivateReposNotice,
   GithubRepositoryField,
   GithubRepositoryOption,
+  GitlabNoProjectsNotice,
+  GitlabProjectField,
+  GitlabProjectOption,
   RepositoryAccessField,
   WorktreeField,
   WorkingSubdirectoryField,
   WorkspaceBranchField,
-  WorkspaceModeField
+  WorkspaceModeField,
+  type WorkspaceMode
 } from '@/components/console/WorkspaceFormFields'
+import { gitlabProjectSelectable, matchGitlabProjects } from '@/lib/gitlab-projects'
 
-type WsMode = 'scratch' | 'github'
+type WsMode = WorkspaceMode
 type RepoCheckState = 'idle' | 'checking' | 'missing' | 'found'
 
 // The dialog is a single scrolling form with a section rail beside it: every
@@ -265,6 +272,15 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const [ghPublicExactRepo, setGhPublicExactRepo] = useState<GithubRepoDto | null>(null)
   const [ghExactRepoState, setGhExactRepoState] = useState<RepoCheckState>('idle')
   const [ghManualPublicRepo, setGhManualPublicRepo] = useState<GithubRepoDto | null>(null)
+  // GitLab path: the organization's added projects, picked by their numeric id.
+  // Null while the list is still loading; the picker never adds a project itself.
+  const [glProjects, setGlProjects] = useState<GitlabProjectBindingDto[] | null>(null)
+  const [glProjectsError, setGlProjectsError] = useState<string | null>(null)
+  const [glProject, setGlProject] = useState('')
+  const [glOpen, setGlOpen] = useState(false)
+  const [glQ, setGlQ] = useState('')
+  const [glAccessOpen, setGlAccessOpen] = useState(false)
+  const [glPush, setGlPush] = useState(true)
   const [sharing, setSharing] = useState<SharingValue>({ visibility: 'org', sharedWith: [] })
   // The org default seeds both directions; this form can still override either one.
   const [callPolicy, setCallPolicy] = useState<AgentCallPolicy>(defaultAgentVisibility)
@@ -482,6 +498,25 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   }, [])
 
   const usingPicker = wsMode === 'github' && ghEnabled === true && ghInstalls.length > 0
+
+  // Only the GitLab pane asks for projects, so a deployment without the flag
+  // never issues the request — the mode tile it would come from is not offered.
+  useEffect(() => {
+    if (wsMode !== 'gitlab' || glProjects !== null) return
+    let alive = true
+    setGlProjectsError(null)
+    fetchGitlabProjects().then(
+      (bindings) => alive && setGlProjects(bindings),
+      (e) => alive && setGlProjectsError(e instanceof Error ? e.message : String(e))
+    )
+    return () => {
+      alive = false
+    }
+  }, [glProjects, wsMode])
+
+  const glSelectable = (glProjects ?? []).filter((project) => gitlabProjectSelectable(project.state))
+  const glNoProjects = wsMode === 'gitlab' && glProjects !== null && glSelectable.length === 0
+  const glPicked = (glProjects ?? []).find((project) => project.projectId === glProject)
 
   // Installations loaded or refreshed → merge repository pages as they arrive.
   // GitHub has no server-side search here, so the dropdown filters locally.
@@ -794,6 +829,10 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
       setErr('Pick a GitHub repository, or switch to “From scratch”.')
       return
     }
+    if (wsMode === 'gitlab' && !glProject) {
+      setErr('Pick a GitLab project, or switch to “From scratch”.')
+      return
+    }
     if (memoryProvider === 'external' && !externalMemory.connectionId) {
       setErr('Select an external-memory connection, or choose another memory backend.')
       return
@@ -805,7 +844,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     const envRecord = envRecordFromRows(envRows)
     const secretsRecord = secretsRecordFromRows(secretRows)
     let normalizedAgentDir: string | undefined
-    if (wsMode === 'github') {
+    if (wsMode !== 'scratch') {
       try {
         normalizedAgentDir = normalizeAgentDir(agentDir)
       } catch (e) {
@@ -816,33 +855,42 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     setBusy(true)
     setErr(null)
     const workspace: AgentWorkspaceDto =
-      wsMode === 'github'
-        ? usingPicker
-          ? picked
-            ? {
-                mode: 'github',
-                worktree,
-                gitRepo: picked.fullName, // owner/repo — the CP normalizes to the full address
-                ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
-                ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {}),
-                installationId: picked.installationId,
-                gitAccess: ghPush ? ('write' as const) : ('read' as const)
-              }
+      wsMode === 'gitlab'
+        ? {
+            mode: 'gitlab',
+            worktree,
+            projectId: glProject,
+            ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
+            ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {}),
+            gitAccess: glPush ? ('write' as const) : ('read' as const)
+          }
+        : wsMode === 'github'
+          ? usingPicker
+            ? picked
+              ? {
+                  mode: 'github',
+                  worktree,
+                  gitRepo: picked.fullName, // owner/repo — the CP normalizes to the full address
+                  ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
+                  ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {}),
+                  installationId: picked.installationId,
+                  gitAccess: ghPush ? ('write' as const) : ('read' as const)
+                }
+              : {
+                  mode: 'github',
+                  worktree,
+                  gitRepo: publicRepo ?? ghRepo.trim(),
+                  ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
+                  ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {})
+                }
             : {
                 mode: 'github',
                 worktree,
-                gitRepo: publicRepo ?? ghRepo.trim(),
+                gitRepo: repo.trim(),
                 ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
                 ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {})
               }
-          : {
-              mode: 'github',
-              worktree,
-              gitRepo: repo.trim(),
-              ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
-              ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {})
-            }
-        : { mode: 'scratch' }
+          : { mode: 'scratch' }
     try {
       await createAgent({
         name: slug,
@@ -921,9 +969,11 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const manageGithubAccess = installGithubApp
 
   const modeHint =
-    wsMode === 'github'
-      ? 'The repo is cloned onto the machine; the agent runs from the directory you pick.'
-      : 'We create a fresh working directory on the daemon — nothing is cloned.'
+    wsMode === 'gitlab'
+      ? 'The project is cloned onto the machine; the agent runs from the directory you pick.'
+      : wsMode === 'github'
+        ? 'The repo is cloned onto the machine; the agent runs from the directory you pick.'
+        : 'We create a fresh working directory on the daemon — nothing is cloned.'
 
   // What still blocks Create, per section — an amber dot on the rail item plus,
   // in the footer, the first one you have to go fix. These mirror `submit`'s
@@ -945,6 +995,8 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   else if (usingPicker && ghDenied) blockers.workspace = 'no access to this repository'
   else if (usingPicker && !picked && !publicRepo) blockers.workspace = 'pick a repository'
   else if (wsMode === 'github' && !usingPicker && !repo.trim()) blockers.workspace = 'add a repository'
+  else if (wsMode === 'gitlab' && glNoProjects) blockers.workspace = 'no GitLab projects added'
+  else if (wsMode === 'gitlab' && !glProject) blockers.workspace = 'pick a project'
   if (envSecretError) blockers.secrets = envSecretError
   if (memoryProvider === 'external' && !externalMemory.connectionId) blockers.memory = 'select a connection'
   const firstBlocker = SECTIONS.find((s) => blockers[s.id])
@@ -1419,6 +1471,89 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                   </div>
                 </>
               )}
+
+              {wsMode === 'gitlab' &&
+                (glProjectsError ? (
+                  <div className="font-sans text-[12px] font-normal leading-[1.5] text-(--status-error) desktop:col-span-2">
+                    Couldn&rsquo;t load your GitLab projects — {glProjectsError}
+                  </div>
+                ) : glProjects === null ? (
+                  <div className="desktop:col-span-2">
+                    <LoadingState size={20} padding={16} />
+                  </div>
+                ) : glNoProjects ? (
+                  <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} />
+                ) : (
+                  <div className="grid grid-cols-1 gap-[14px] desktop:col-span-2 desktop:grid-cols-2 desktop:gap-x-7">
+                    <GitlabProjectField
+                      value={glPicked?.projectPath ?? ''}
+                      icon="book-marked"
+                      loading={false}
+                      open={glOpen}
+                      query={glQ}
+                      onToggle={() => {
+                        setGlQ('')
+                        setGlAccessOpen(false)
+                        setGlOpen((value) => !value)
+                      }}
+                      onClose={() => setGlOpen(false)}
+                      onQueryChange={setGlQ}
+                    >
+                      {matchGitlabProjects(glProjects, glQ).map((project) => (
+                        <GitlabProjectOption
+                          key={project.id}
+                          project={project}
+                          selected={glProject === project.projectId}
+                          onSelect={() => {
+                            setGlProject(project.projectId)
+                            setGlOpen(false)
+                            setBranch(project.defaultBranch ?? '')
+                            setErr(null)
+                          }}
+                        />
+                      ))}
+                      {matchGitlabProjects(glProjects, glQ).length === 0 && (
+                        <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>
+                      )}
+                    </GitlabProjectField>
+
+                    <RepositoryAccessField
+                      repositorySelected={!!glProject}
+                      label="Project access"
+                      unselectedLabel="Select project first"
+                      writeDescription="Push, open merge requests & run pipelines"
+                      value={glPush ? 'write' : 'read'}
+                      open={glAccessOpen}
+                      onToggle={() => {
+                        setGlOpen(false)
+                        setGlAccessOpen((value) => !value)
+                      }}
+                      onClose={() => setGlAccessOpen(false)}
+                      onChange={(value) => {
+                        setGlPush(value === 'write')
+                        setGlAccessOpen(false)
+                      }}
+                    />
+
+                    <div className="grid grid-cols-1 gap-[14px] desktop:col-span-2 desktop:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_96px] desktop:gap-x-[14px]">
+                      <WorkspaceBranchField
+                        repositorySelected={!!glProject}
+                        unselectedLabel="Pick project first"
+                        defaultBranchLabel="GitLab default branch"
+                        value={branch}
+                        branches={null}
+                        open={false}
+                        query=""
+                        onToggle={() => undefined}
+                        onClose={() => undefined}
+                        onQueryChange={() => undefined}
+                        onChange={setBranch}
+                      />
+                      <WorkingSubdirectoryField value={agentDir} onChange={setAgentDir} />
+                      <WorktreeField checked={worktree} onChange={setWorktree} />
+                    </div>
+                  </div>
+                ))}
             </div>
             <div className="mt-2 flex items-center gap-[6px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
               <Icon name="corner-down-right" size={13} />

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment happy-dom
+/**
+ * The GitLab trigger kind in the Add-integration wizard. Two things are worth a
+ * regression test: the tile is absent — and the project list unrequested — while
+ * the flag is off, and the create body carries exactly the stored vocabulary the
+ * CP validates (`family:*` patterns, note families, labels, mention-only) keyed
+ * by the project's numeric id rather than its renameable path.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Agent } from '@/lib/data'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const mocks = vi.hoisted(() => ({
+  createGitlabHook: vi.fn(async () => ({ id: 'hook-1', agentId: 'agent-a', kind: 'gitlab' })),
+  fetchGitlabProjects: vi.fn()
+}))
+
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, orgPath: (path: string) => `/acme${path}` })
+}))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    bots: [],
+    daemons: [],
+    daemonsLoading: false,
+    createIntegration: vi.fn(),
+    createHook: vi.fn(),
+    createGithubHook: vi.fn(),
+    createGitlabHook: mocks.createGitlabHook,
+    refresh: vi.fn(),
+    updateAgent: vi.fn()
+  })
+}))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchAgentHooks: vi.fn(async () => []),
+  fetchAgentRepos: vi.fn(async () => []),
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
+  fetchGithubInstallUrl: vi.fn(async () => null),
+  fetchGithubRepoRoster: vi.fn(async () => ({ repos: [], privateReposHidden: false, failed: false })),
+  syncGithubInstallations: vi.fn(async () => []),
+  fetchGitlabProjects: mocks.fetchGitlabProjects
+}))
+
+const AddIntegrationModal = (await import('./AddIntegrationModal')).default
+
+const agent = {
+  id: 'agent-a',
+  name: 'build-agent',
+  daemon: 'daemon-1',
+  canEdit: true,
+  workspace: { mode: 'scratch' }
+} as unknown as Agent
+
+const setFlags = (value?: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
+    value === undefined ? {} : { FEATURE_FLAGS: value }
+}
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+async function render() {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(<AddIntegrationModal agent={agent} onClose={() => undefined} />)
+  })
+}
+
+const tileNamed = (label: string) =>
+  Array.from(document.querySelectorAll<HTMLDivElement>('.ptile')).find((tile) => tile.textContent === label)
+const clickText = (text: string) =>
+  Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.includes(text))
+const checkbox = (label: string) => document.querySelector<HTMLInputElement>(`input[aria-label="${label}"]`)
+// React tracks the DOM value itself, so a plain assignment is invisible to onChange.
+function typeInto(input: HTMLInputElement, value: string) {
+  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(input, value)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+afterEach(async () => {
+  setFlags()
+  if (root) await act(async () => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  mocks.createGitlabHook.mockClear()
+  mocks.fetchGitlabProjects.mockReset()
+})
+
+describe('AddIntegrationModal, GitLab trigger', () => {
+  it('offers no GitLab tile and asks for no projects while the flag is off', async () => {
+    setFlags()
+    mocks.fetchGitlabProjects.mockResolvedValue([])
+    await render()
+
+    expect(tileNamed('GitHub')).toBeDefined()
+    expect(tileNamed('GitLab')).toBeUndefined()
+    expect(mocks.fetchGitlabProjects).not.toHaveBeenCalled()
+  })
+
+  it('creates a gitlab hook from the chosen families, labels and mention mode', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([
+      {
+        id: 'binding-1',
+        projectId: '4210',
+        projectPath: 'acme/platform',
+        defaultBranch: 'main',
+        state: 'ready',
+        stateReason: null,
+        serviceAccountUsername: 'project_4210_bot',
+        webhookInstalled: true,
+        credentialEpoch: '1',
+        createdAt: '2026-08-01T00:00:00.000Z'
+      }
+    ])
+    await render()
+    await act(async () => tileNamed('GitLab')?.click())
+    await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
+    await act(async () => clickText('acme/platform')?.click())
+
+    // Merge requests ride the default; add issues and drop the issue note family.
+    await act(async () => document.querySelector<HTMLDivElement>('[data-gitlab-family="issues"]')?.click())
+    await act(async () => checkbox('Comments in issues')?.click())
+    await act(async () =>
+      typeInto(document.querySelector<HTMLInputElement>('input[aria-label="Label filter"]')!, 'needs-review, agent')
+    )
+    await act(async () => checkbox('Mention only')?.click())
+
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGitlabHook).toHaveBeenCalledWith({
+      agentId: 'agent-a',
+      name: 'acme/platform',
+      projectId: '4210',
+      events: ['issues:*', 'merge_request:*'],
+      commentFamilies: ['merge_request'],
+      labelFilter: ['needs-review', 'agent'],
+      mentionOnly: true
+    })
+  })
+
+  it('points at the connection surface when no project has been added', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([])
+    await render()
+    await act(async () => tileNamed('GitLab')?.click())
+
+    expect(document.body.textContent).toContain('No GitLab projects have been added yet')
+    expect(document.querySelector('a[href="/acme/integrations"]')).not.toBeNull()
+  })
+})

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -15,7 +15,8 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
 const mocks = vi.hoisted(() => ({
   createGitlabHook: vi.fn(async () => ({ id: 'hook-1', agentId: 'agent-a', kind: 'gitlab' })),
-  fetchGitlabProjects: vi.fn()
+  fetchGitlabProjects: vi.fn(),
+  daemons: [] as unknown[]
 }))
 
 vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
@@ -25,7 +26,7 @@ vi.mock('@/lib/org-context', () => ({
 vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({
     bots: [],
-    daemons: [],
+    daemons: mocks.daemons,
     daemonsLoading: false,
     createIntegration: vi.fn(),
     createHook: vi.fn(),
@@ -92,6 +93,7 @@ afterEach(async () => {
   host = undefined
   mocks.createGitlabHook.mockClear()
   mocks.fetchGitlabProjects.mockReset()
+  mocks.daemons = []
 })
 
 describe('AddIntegrationModal, GitLab trigger', () => {
@@ -145,6 +147,21 @@ describe('AddIntegrationModal, GitLab trigger', () => {
       labelFilter: ['needs-review', 'agent'],
       mentionOnly: true
     })
+  })
+
+  it('keeps the GitLab tile enabled on a placed daemon that advertises no such adapter', async () => {
+    // GitLab is a relay-backed trigger kind, not a chat platform: the owning daemon's
+    // adapter list has no say over it. Naming only webhook and github in that set left
+    // this tile — and the agent page's empty-state twin — disabled for a placed agent.
+    setFlags('gitlab')
+    mocks.daemons = [{ daemonId: 'daemon-1', caps: { platforms: ['slack'] } }]
+    mocks.fetchGitlabProjects.mockResolvedValue([])
+    await render()
+
+    expect(tileNamed('GitLab')?.getAttribute('aria-disabled')).toBe('false')
+    expect(tileNamed('GitHub')?.getAttribute('aria-disabled')).toBe('false')
+    // Control: a chat platform the daemon does not advertise stays disabled.
+    expect(tileNamed('Discord')?.getAttribute('aria-disabled')).toBe('true')
   })
 
   it('points at the connection surface when no project has been added', async () => {

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -38,7 +38,7 @@ import {
   type IdentityChromeView
 } from '@/components/console/platforms/publish'
 import { platformRegistry, platformSupportsSharing } from '@/components/console/platforms/registry'
-import { BOT_PLATFORMS, offeredPlatforms } from '@/components/console/platforms/host-projections'
+import { BOT_PLATFORMS, isCoreTriggerKind, offeredPlatforms } from '@/components/console/platforms/host-projections'
 import { agentLabel, MOCK_MODE, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
@@ -405,10 +405,7 @@ export default function AddIntegrationModal({
   // webhook + github are relay/CP-backed triggers — always available, never
   // gated by the daemon's adapter capabilities.
   const isPlatformAvailable = (candidate: Platform) =>
-    candidate === 'webhook' ||
-    candidate === 'github' ||
-    candidate === 'gitlab' ||
-    supportedBotPlatforms.some((supported) => supported.key === candidate)
+    isCoreTriggerKind(candidate) || supportedBotPlatforms.some((supported) => supported.key === candidate)
   const selectedBotPlatformSupported = isPlatformAvailable(platform)
 
   const platformTiles = offeredPlatforms()

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -11,10 +11,16 @@ import {
 } from 'react'
 import useSWR from 'swr'
 import LarkFeishuSwitcher, { type LarkFeishuTarget } from '@/components/LarkFeishuSwitcher'
-import { AgentIconView, GithubMark, PlatformMark } from '@/components/marks'
+import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { GithubReviewSettings } from '@/components/console/GithubReviewSettings'
-import { GithubPrivateReposNotice, REPOSITORY_ACCESS_BADGE } from '@/components/console/WorkspaceFormFields'
+import {
+  GithubPrivateReposNotice,
+  GitlabNoProjectsNotice,
+  GitlabProjectField,
+  GitlabProjectOption,
+  REPOSITORY_ACCESS_BADGE
+} from '@/components/console/WorkspaceFormFields'
 import type {
   WebWizardTransport,
   WizardFooterState,
@@ -32,7 +38,7 @@ import {
   type IdentityChromeView
 } from '@/components/console/platforms/publish'
 import { platformRegistry, platformSupportsSharing } from '@/components/console/platforms/registry'
-import { BOT_PLATFORMS, PLATFORMS } from '@/components/console/platforms/host-projections'
+import { BOT_PLATFORMS, offeredPlatforms } from '@/components/console/platforms/host-projections'
 import { agentLabel, MOCK_MODE, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
@@ -46,12 +52,15 @@ import {
   fetchGithubInstallations,
   fetchGithubInstallUrl,
   fetchGithubRepoRoster,
+  fetchGitlabProjects,
   invalidateGithubRepoRosterCache,
   syncGithubInstallations,
   updateAgentRepo,
   type CreatedHookDto,
   type GithubInstallationDto,
   type GithubRepoDto,
+  type GitlabCommentFamily,
+  type GitlabProjectBindingDto,
   type RepoAccess
 } from '@/lib/api'
 import EditWorkspaceModal from './EditWorkspaceModal'
@@ -66,6 +75,15 @@ import {
   type GhFamily,
   type GhTriggerMode
 } from '@/lib/github-events'
+import {
+  GL_COMMENT_FAMILIES,
+  GL_DEFAULT_FAMILIES,
+  GL_FAMILIES,
+  eventsForGitlabFamilies,
+  parseLabelFilter,
+  type GlFamily
+} from '@/lib/gitlab-events'
+import { gitlabProjectSelectable, matchGitlabProjects } from '@/lib/gitlab-projects'
 import {
   effectiveRepoAccess,
   hasChecksWritePermission,
@@ -203,8 +221,17 @@ export default function AddIntegrationModal({
   initialFeishuRegion?: FeishuRegion
   onClose: () => void
 }) {
-  const { createIntegration, bots, createHook, createGithubHook, daemons, daemonsLoading, refresh, updateAgent } =
-    useConsoleData()
+  const {
+    createIntegration,
+    bots,
+    createHook,
+    createGithubHook,
+    createGitlabHook,
+    daemons,
+    daemonsLoading,
+    refresh,
+    updateAgent
+  } = useConsoleData()
   const { me } = useProfile()
   const [platform, setPlatform] = useState<Platform>(initialPlatform ?? 'slack')
   // Lark/Feishu gateway: new installs default to international Lark. Host state
@@ -315,6 +342,18 @@ export default function AddIntegrationModal({
       (ghReportingMode === 'check' &&
         (!hasChecksWritePermission(ghSelectedInstallation) || !hasPullRequestsReadPermission(ghSelectedInstallation))))
 
+  // GitLab path: the organization's added projects, one hook per project. The
+  // wizard never adds a project — that stays on the connection card.
+  const [glProjects, setGlProjects] = useState<GitlabProjectBindingDto[] | null>(null)
+  const [glProjectsError, setGlProjectsError] = useState<string | null>(null)
+  const [glProject, setGlProject] = useState<string | null>(null)
+  const [glOpen, setGlOpen] = useState(false)
+  const [glQ, setGlQ] = useState('')
+  const [glFams, setGlFams] = useState<Set<GlFamily>>(new Set(GL_DEFAULT_FAMILIES))
+  const [glComments, setGlComments] = useState<Set<GitlabCommentFamily>>(new Set(['issues', 'merge_request']))
+  const [glLabels, setGlLabels] = useState('')
+  const [glMentionOnly, setGlMentionOnly] = useState(false)
+
   // Reusing a bot is an advanced path; every platform opens on the create flow
   // until the user explicitly chooses an existing identity.
   const [modePick, setModePick] = useState<'existing' | 'create' | null>(null)
@@ -368,10 +407,13 @@ export default function AddIntegrationModal({
   const isPlatformAvailable = (candidate: Platform) =>
     candidate === 'webhook' ||
     candidate === 'github' ||
+    candidate === 'gitlab' ||
     supportedBotPlatforms.some((supported) => supported.key === candidate)
   const selectedBotPlatformSupported = isPlatformAvailable(platform)
 
-  // The active platform module — undefined for the two core trigger sections.
+  const platformTiles = offeredPlatforms()
+
+  // The active platform module — undefined for the core trigger sections.
   const activeModule = platformRegistry.get(platform)
   const wizard = activeModule?.wizard
   // §5 `regions` is manifest data the web module deliberately does not carry
@@ -704,6 +746,24 @@ export default function AddIntegrationModal({
     })
   }
 
+  const toggleGlFam = (fam: GlFamily) => {
+    setGlFams((prev) => {
+      const next = new Set(prev)
+      if (next.has(fam)) next.delete(fam)
+      else next.add(fam)
+      return next
+    })
+  }
+
+  const toggleGlComment = (fam: GitlabCommentFamily) => {
+    setGlComments((prev) => {
+      const next = new Set(prev)
+      if (next.has(fam)) next.delete(fam)
+      else next.add(fam)
+      return next
+    })
+  }
+
   const authorizeSelectedRepo = async () => {
     if (!ghRepoPick || ghAccessSaving) return
     if (ghSelectedIsWorkspace) {
@@ -736,6 +796,62 @@ export default function AddIntegrationModal({
       setErr(e instanceof Error ? e.message : String(e))
     } finally {
       setGhAccessSaving(false)
+    }
+  }
+
+  // Only the GitLab pane asks for projects; the flag already decides whether the
+  // tile that reaches this pane exists at all.
+  useEffect(() => {
+    if (platform !== 'gitlab' || glProjects !== null) return
+    let alive = true
+    setGlProjectsError(null)
+    fetchGitlabProjects().then(
+      (bindings) => alive && setGlProjects(bindings),
+      (e) => alive && setGlProjectsError(e instanceof Error ? e.message : String(e))
+    )
+    return () => {
+      alive = false
+    }
+  }, [glProjects, platform])
+
+  const glSelectable = (glProjects ?? []).filter((project) => gitlabProjectSelectable(project.state))
+  const glNoProjects = glProjects !== null && glSelectable.length === 0
+  const glPicked = (glProjects ?? []).find((project) => project.projectId === glProject)
+  // One hook per (agent, project) — the CP 409s a second one, so the picker says so first.
+  const glWatchedProjects = useMemo(
+    () =>
+      new Set((agentHooksData ?? []).filter((h) => h.kind === 'gitlab' && h.repoId).map((h) => h.repoId!.toString())),
+    [agentHooksData]
+  )
+  const glAlreadyWatched = !!glProject && glWatchedProjects.has(glProject)
+
+  // One subscription = one hook row on this agent, named after the project.
+  const submitGitlab = async () => {
+    if (busyRef.current || !glProject || glFams.size === 0) return
+    if (glAlreadyWatched) {
+      setErr(
+        `This agent already watches ${glPicked?.projectPath ?? 'this project'} — edit its events on the agent page instead.`
+      )
+      return
+    }
+    busyRef.current = true
+    setSaving(true)
+    setErr(null)
+    try {
+      await createGitlabHook({
+        agentId: agent.id,
+        name: glPicked?.projectPath ?? glProject,
+        projectId: glProject,
+        events: eventsForGitlabFamilies(glFams),
+        commentFamilies: [...glComments],
+        labelFilter: parseLabelFilter(glLabels),
+        mentionOnly: glMentionOnly
+      })
+      onClose()
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+      setSaving(false)
+      busyRef.current = false
     }
   }
 
@@ -837,19 +953,26 @@ export default function AddIntegrationModal({
             enabled: !!ghRepoPick && !ghRepoAlreadyWatched && ghFams.size > 0 && !ghReviewSettingsBlocked,
             hidden: false
           }
-        : mode === 'existing'
+        : platform === 'gitlab'
           ? {
-              label: 'Connect & authorize',
-              act: () => void submitReuse(),
-              enabled: selectedBotId !== null,
+              label: 'Connect',
+              act: () => void submitGitlab(),
+              enabled: !!glProject && !glAlreadyWatched && glFams.size > 0,
               hidden: false
             }
-          : {
-              label: footerView?.label ?? 'Connect & authorize',
-              act: () => footerRef.current?.onSubmit(),
-              enabled: footerView?.enabled === true,
-              hidden: footerView?.hidden === true
-            }
+          : mode === 'existing'
+            ? {
+                label: 'Connect & authorize',
+                act: () => void submitReuse(),
+                enabled: selectedBotId !== null,
+                hidden: false
+              }
+            : {
+                label: footerView?.label ?? 'Connect & authorize',
+                act: () => footerRef.current?.onSubmit(),
+                enabled: footerView?.enabled === true,
+                hidden: footerView?.hidden === true
+              }
 
   return (
     <>
@@ -886,8 +1009,16 @@ export default function AddIntegrationModal({
           </div>
         )}
         <div className="fldlbl mb-2">Platform</div>
-        <div className="mb-[18px] grid grid-cols-2 gap-[10px] desktop:grid-cols-6">
-          {PLATFORMS.map((candidate) => {
+        {/* One column per offered tile — complete literal strings, so the flagged
+            GitLab tile widens the row instead of wrapping a lone tile below it. */}
+        <div
+          className={
+            platformTiles.length > 6
+              ? 'mb-[18px] grid grid-cols-2 gap-[10px] desktop:grid-cols-7'
+              : 'mb-[18px] grid grid-cols-2 gap-[10px] desktop:grid-cols-6'
+          }
+        >
+          {platformTiles.map((candidate) => {
             const available = isPlatformAvailable(candidate.key)
             const on = available && platform === candidate.key
             return (
@@ -1512,6 +1643,149 @@ export default function AddIntegrationModal({
             )}
           </>
         )}
+        {platform === 'gitlab' && (
+          <>
+            {glProjectsError ? (
+              <div className="mb-4 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
+                Couldn&rsquo;t load your GitLab projects — {glProjectsError}
+              </div>
+            ) : glProjects === null ? (
+              <LoadingState size={20} padding={16} />
+            ) : glNoProjects ? (
+              <div className="mb-4">
+                <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} />
+              </div>
+            ) : (
+              <>
+                <div className="mb-4">
+                  <GitlabProjectField
+                    value={glPicked?.projectPath ?? ''}
+                    icon="book-marked"
+                    loading={false}
+                    open={glOpen}
+                    query={glQ}
+                    onToggle={() => {
+                      setGlQ('')
+                      setGlOpen((value) => !value)
+                    }}
+                    onClose={() => setGlOpen(false)}
+                    onQueryChange={setGlQ}
+                    error={
+                      glAlreadyWatched
+                        ? `This agent already watches ${glPicked?.projectPath ?? 'this project'}.`
+                        : undefined
+                    }
+                  >
+                    {matchGitlabProjects(glProjects, glQ).map((project) => (
+                      <GitlabProjectOption
+                        key={project.id}
+                        project={project}
+                        selected={glProject === project.projectId}
+                        onSelect={() => {
+                          setGlProject(project.projectId)
+                          setGlOpen(false)
+                          setErr(null)
+                        }}
+                      />
+                    ))}
+                    {matchGitlabProjects(glProjects, glQ).length === 0 && (
+                      <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>
+                    )}
+                  </GitlabProjectField>
+                </div>
+                <div className="fldlbl mb-2">Listen for</div>
+                <div className="mb-4 grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-3">
+                  {GL_FAMILIES.map((r) => {
+                    const on = glFams.has(r.fam)
+                    return (
+                      <div
+                        key={r.fam}
+                        data-gitlab-family={r.fam}
+                        className={`flex min-w-0 cursor-pointer items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
+                          on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'
+                        }`}
+                        onClick={() => toggleGlFam(r.fam)}
+                      >
+                        <Icon
+                          name={r.icon}
+                          size={16}
+                          color={on ? 'var(--brand)' : 'var(--text-tertiary)'}
+                          className="mt-[1px] flex-none"
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="block font-sans text-[12.5px] font-semibold leading-normal">{r.label}</span>
+                          <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                            {r.desc}
+                          </span>
+                        </span>
+                        <span
+                          className={`mt-[1px] flex h-[18px] w-[18px] flex-none items-center justify-center rounded-[5px] border-[1.5px] ${
+                            on ? 'border-(--brand) bg-(--brand)' : 'border-(--border-default) bg-(--surface-card)'
+                          }`}
+                        >
+                          {on && <Icon name="check" size={12} color="#fff" />}
+                        </span>
+                      </div>
+                    )
+                  })}
+                </div>
+                <div className="fldlbl mb-2">Also run on comments in</div>
+                <div className="mb-4 grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-2">
+                  {GL_COMMENT_FAMILIES.map((r) => {
+                    const on = glComments.has(r.fam)
+                    return (
+                      <label
+                        key={r.fam}
+                        className={`flex min-w-0 cursor-pointer items-center gap-2.5 rounded-[9px] border px-3 py-[10px] ${
+                          on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          className="flex-none accent-(--brand)"
+                          checked={on}
+                          aria-label={`Comments in ${r.label.toLowerCase()}`}
+                          onChange={() => toggleGlComment(r.fam)}
+                        />
+                        <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                          {r.label}
+                        </span>
+                      </label>
+                    )
+                  })}
+                </div>
+                <div className="fld mb-4">
+                  <span className="fldlbl">Only these labels (optional)</span>
+                  <input
+                    className="inp mn"
+                    placeholder="needs-review, agent"
+                    value={glLabels}
+                    onChange={(e) => setGlLabels(e.target.value)}
+                    aria-label="Label filter"
+                  />
+                  <span className="mt-[6px] block font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-tertiary)">
+                    Comma separated. Empty means every issue and merge request.
+                  </span>
+                </div>
+                <label className="mb-4 flex cursor-pointer items-start gap-2.5 rounded-[9px] border border-(--border-default) bg-(--surface-card) px-3 py-[10px]">
+                  <input
+                    type="checkbox"
+                    className="mt-[2px] flex-none accent-(--brand)"
+                    checked={glMentionOnly}
+                    aria-label="Mention only"
+                    onChange={(e) => setGlMentionOnly(e.target.checked)}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-sans text-[12.5px] font-semibold leading-normal">Mention only</span>
+                    <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                      Run only when the text mentions @{agent.name}.
+                    </span>
+                  </span>
+                </label>
+              </>
+            )}
+          </>
+        )}
         {wizard && !identityHidden && (
           <div className="mb-2 flex items-center justify-between gap-3">
             <div className="fldlbl">Bot identity</div>
@@ -1644,7 +1918,9 @@ export default function AddIntegrationModal({
               ? 'Each POST becomes a session, routed to this agent by the endpoint path. Retries are de-duplicated by the X-AC-Delivery-Key header (auto-assigned when absent).'
               : platform === 'github'
                 ? 'Matching events run the agent in a session and reply on the same PR, issue or commit thread.'
-                : wizard?.inviteHint(region)}
+                : platform === 'gitlab'
+                  ? 'Matching events run the agent in a session and reply on the same issue, merge request or push thread.'
+                  : wizard?.inviteHint(region)}
           </span>
         </div>
         {shareToggleAvailable && !identityHidden && (

--- a/packages/web/src/components/console/modals/DeleteHookModal.tsx
+++ b/packages/web/src/components/console/modals/DeleteHookModal.tsx
@@ -7,8 +7,9 @@ import { Button, Icon } from '@/components/ui'
 
 // Confirm-delete a trigger. The CP drops the row and the relay pool drops its
 // rule — a webhook's inbound URL stops accepting deliveries immediately (senders
-// get a uniform 404); a github subscription stops matching that repo's events.
+// get a uniform 404); a github subscription stops matching that repo's events;
 // Past runs and their sessions survive. The list re-pulls via the data context.
+// a gitlab subscription stops matching that project's events.
 // An ARRAY target = the GitHub group card's header unplug: disconnect GitHub by
 // removing every repo subscription of this agent in one confirm.
 export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | HookDto[]; onClose: () => void }) {
@@ -19,6 +20,7 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
   const group = Array.isArray(hook)
   const first = hooks[0]!
   const isGithub = group || first.kind === 'github'
+  const isGitlab = !group && first.kind === 'gitlab'
 
   const onDelete = async () => {
     if (busy) return
@@ -37,10 +39,16 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
     <>
       <div className="modalhead">
         <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
-          <Icon name={isGithub ? 'folder-git-2' : 'webhook'} size={16} color="var(--status-error)" />
+          <Icon name={isGithub || isGitlab ? 'folder-git-2' : 'webhook'} size={16} color="var(--status-error)" />
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">
-          {group ? 'Disconnect GitHub' : isGithub ? 'Remove repository' : 'Delete webhook'}
+          {group
+            ? 'Disconnect GitHub'
+            : isGithub
+              ? 'Remove repository'
+              : isGitlab
+                ? 'Remove project'
+                : 'Delete webhook'}
         </span>
         <button className="iconbtn" onClick={onClose}>
           <Icon name="x" size={16} />
@@ -61,6 +69,12 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
             <>
               <span className="mono text-(--text-primary)">{first.repoFullName ?? first.name}</span>&#32;stops
               triggering this agent — its GitHub events are ignored from now on. Past runs and their sessions stay.
+            </>
+          ) : isGitlab ? (
+            <>
+              <span className="mono text-(--text-primary)">{first.repoFullName ?? first.name}</span>&#32;stops
+              triggering this agent — its GitLab events are ignored from now on. The project itself, its bot and its
+              webhook are untouched. Past runs and their sessions stay.
             </>
           ) : (
             <>

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment happy-dom
+/**
+ * The GitLab workspace choice is a standing switch: with the flag off the mode
+ * tile must not exist AND the project list must never be requested, because a
+ * deployment without a GitLab application does not serve that route. With it on,
+ * the picker offers the organization's added projects — every state except the
+ * transient ones — and the save sends the numeric project id, never the path.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Agent } from '@/lib/data'
+
+const mocks = vi.hoisted(() => ({
+  fetchGitlabProjects: vi.fn(),
+  setAgentWorkspace: vi.fn(async () => ({}) as Agent)
+}))
+
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (path: string) => `/acme${path}` }) }))
+vi.mock('@/lib/data-context', () => ({ useConsoleData: () => ({ orgSetIds: new Set<string>() }) }))
+vi.mock('@/components/console/modals/AddAgentRepoModal', () => ({ default: () => <div /> }))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchAgentRepos: vi.fn(async () => []),
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
+  fetchGithubInstallUrl: vi.fn(async () => null),
+  fetchGitlabProjects: mocks.fetchGitlabProjects,
+  setAgentWorkspace: mocks.setAgentWorkspace
+}))
+
+const EditWorkspaceModal = (await import('./EditWorkspaceModal')).default
+
+const binding = (over: Record<string, unknown>) => ({
+  id: `binding-${over.projectId}`,
+  projectPath: 'acme/platform',
+  defaultBranch: 'main',
+  state: 'ready',
+  stateReason: null,
+  serviceAccountUsername: 'project_1_bot',
+  webhookInstalled: true,
+  credentialEpoch: '1',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  ...over
+})
+
+const agent = {
+  id: 'agent-a',
+  name: 'build-agent',
+  canEdit: true,
+  workspace: { mode: 'scratch' }
+} as unknown as Agent
+
+const setFlags = (value?: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
+    value === undefined ? {} : { FEATURE_FLAGS: value }
+}
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+async function render() {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(
+      <EditWorkspaceModal agent={agent} authorized={[]} onClose={() => undefined} onChanged={() => undefined} />
+    )
+  })
+}
+
+const buttonsNamed = (text: string) =>
+  Array.from(document.querySelectorAll('button')).filter((button) => button.textContent?.includes(text))
+
+afterEach(async () => {
+  setFlags()
+  if (root) await act(async () => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  mocks.fetchGitlabProjects.mockReset()
+  mocks.setAgentWorkspace.mockClear()
+})
+
+describe('EditWorkspaceModal, GitLab workspace', () => {
+  it('offers no GitLab source and asks for no projects while the flag is off', async () => {
+    setFlags()
+    mocks.fetchGitlabProjects.mockResolvedValue([binding({ projectId: '1' })])
+    await render()
+
+    expect(document.body.textContent).not.toContain('From GitLab')
+    expect(mocks.fetchGitlabProjects).not.toHaveBeenCalled()
+  })
+
+  it('lists the added projects and disables the ones still setting up', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([
+      binding({ projectId: '1', projectPath: 'acme/platform', state: 'ready' }),
+      binding({ projectId: '2', projectPath: 'acme/runtime', state: 'runtime_degraded' }),
+      binding({ projectId: '3', projectPath: 'acme/fresh', state: 'provisioning' })
+    ])
+    await render()
+    await act(async () => buttonsNamed('From GitLab')[0]?.click())
+    await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
+
+    const options = Array.from(document.querySelectorAll('button')).filter((button) =>
+      button.textContent?.includes('acme/')
+    )
+    expect(options.map((option) => option.textContent?.includes('acme/platform'))).toContain(true)
+    expect(options.find((option) => option.textContent?.includes('acme/fresh'))?.disabled).toBe(true)
+    expect(options.find((option) => option.textContent?.includes('acme/runtime'))?.disabled).toBe(false)
+    expect(document.body.textContent).toContain('bot access degraded')
+  })
+
+  it('saves the picked project by its numeric id', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([binding({ projectId: '4210', projectPath: 'acme/platform' })])
+    await render()
+    await act(async () => buttonsNamed('From GitLab')[0]?.click())
+    await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
+    const option = Array.from(document.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('acme/platform')
+    )
+    await act(async () => option?.click())
+    await act(async () => buttonsNamed('Replace workspace')[0]?.click())
+
+    expect(mocks.setAgentWorkspace).toHaveBeenCalledWith('agent-a', {
+      mode: 'gitlab',
+      worktree: true,
+      projectId: '4210',
+      gitBranch: 'main',
+      gitAccess: 'write'
+    })
+  })
+
+  it('points at the connection surface when no project has been added', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([])
+    await render()
+    await act(async () => buttonsNamed('From GitLab')[0]?.click())
+
+    expect(document.body.textContent).toContain('No GitLab projects have been added yet')
+    expect(document.querySelector('a[href="/acme/integrations"]')).not.toBeNull()
+  })
+})

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -6,11 +6,13 @@
 // rejects edits that conflict with enabled GitHub review or Check actions.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { GithubMark } from '@/components/marks'
+import { GithubMark, LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { agentLabel, isPoolPlacementKind, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
+import { featureFlagEnabled } from '@/lib/feature-flags'
+import { gitlabProjectSelectable, matchGitlabProjects } from '@/lib/gitlab-projects'
 import {
   ApiError,
   deleteAgentRepo,
@@ -20,12 +22,14 @@ import {
   fetchGithubInstallUrl,
   fetchGithubRepoRoster,
   fetchGithubRepoAccess,
+  fetchGitlabProjects,
   invalidateGithubRepoRosterCache,
   syncGithubInstallations,
   type AgentRepoAuthDto,
   type GithubInstallationDto,
   type GithubRepoAccess,
   type GithubRepoDto,
+  type GitlabProjectBindingDto,
   type RepoAccess
 } from '@/lib/api'
 import { agentDirInputValue, normalizeAgentDir } from '@/lib/repo-subdir'
@@ -35,12 +39,16 @@ import {
   GithubPrivateReposNotice,
   GithubRepositoryField,
   GithubRepositoryOption,
+  GitlabNoProjectsNotice,
+  GitlabProjectField,
+  GitlabProjectOption,
   RepositoryAccessField,
   REPOSITORY_ACCESS_BADGE,
   WorktreeField,
   WorkingSubdirectoryField,
   WorkspaceBranchField,
-  WorkspaceModeField
+  WorkspaceModeField,
+  type WorkspaceMode
 } from '@/components/console/WorkspaceFormFields'
 import AddAgentRepoModal from '@/components/console/modals/AddAgentRepoModal'
 
@@ -64,7 +72,7 @@ export default function EditWorkspaceModal({
   authorized: AgentRepoAuthDto[]
   /** Preselected mode — the workspace card's Source segment opens the editor
    *  already switched to the mode the user picked. Defaults to the current one. */
-  initialMode?: 'scratch' | 'github'
+  initialMode?: WorkspaceMode
   /** Open directly at the additional-repository step for contextual shortcuts. */
   initialRepositoryAuthorization?: InitialRepositoryAuthorization
   /** Keep the caller's shared repository cache synchronized after add/revoke. */
@@ -79,9 +87,16 @@ export default function EditWorkspaceModal({
   // Pool placements do not materialize secondary roots yet, so they keep the authorization-only wording.
   const poolPlaced = isPoolPlacementKind(agent.placementKind, agent.setId, orgSetIds)
   const githubWorkspace = agent.workspace.mode === 'github' ? agent.workspace : null
-  const currentWrite = githubWorkspace ? !!githubWorkspace.installationId && githubWorkspace.gitAccess !== 'read' : null
-  const currentAgentDir = agentDirInputValue(githubWorkspace?.agentDir)
-  const [mode, setMode] = useState<'scratch' | 'github'>(initialMode ?? agent.workspace.mode)
+  const gitlabWorkspace = agent.workspace.mode === 'gitlab' ? agent.workspace : null
+  const gitWorkspace = githubWorkspace ?? gitlabWorkspace
+  const currentWrite = githubWorkspace
+    ? !!githubWorkspace.installationId && githubWorkspace.gitAccess !== 'read'
+    : gitlabWorkspace
+      ? gitlabWorkspace.gitAccess !== 'read'
+      : null
+  const currentAgentDir = agentDirInputValue(gitWorkspace?.agentDir)
+  const gitlabOffered = featureFlagEnabled('gitlab')
+  const [mode, setMode] = useState<WorkspaceMode>(initialMode ?? agent.workspace.mode)
   const [gh, setGh] = useState<{ enabled: boolean; installations: GithubInstallationDto[] } | null>(null)
   const [ghSyncing, setGhSyncing] = useState(false)
   const [repos, setRepos] = useState<Array<GithubRepoDto & { installationId: string }> | null>(null)
@@ -92,12 +107,18 @@ export default function EditWorkspaceModal({
   const [pickOpen, setPickOpen] = useState(false)
   const [accessOpen, setAccessOpen] = useState(false)
   const [q, setQ] = useState('')
-  const [branch, setBranch] = useState(githubWorkspace?.branch ?? '')
+  const [branch, setBranch] = useState(gitWorkspace?.branch ?? '')
   const [branches, setBranches] = useState<string[] | null>(null)
   const [branchOpen, setBranchOpen] = useState(false)
   const [branchQ, setBranchQ] = useState('')
   const [agentDir, setAgentDir] = useState(currentAgentDir)
-  const [worktree, setWorktree] = useState(githubWorkspace ? githubWorkspace.worktree === true : true)
+  const [worktree, setWorktree] = useState(gitWorkspace ? gitWorkspace.worktree === true : true)
+  // The organization's added GitLab projects; null while the list is still loading.
+  const [glProjects, setGlProjects] = useState<GitlabProjectBindingDto[] | null>(null)
+  const [glProjectsError, setGlProjectsError] = useState<string | null>(null)
+  const [glPick, setGlPick] = useState(gitlabWorkspace?.projectId ?? '')
+  const [glPickOpen, setGlPickOpen] = useState(false)
+  const [glQ, setGlQ] = useState('')
   const [write, setWrite] = useState(currentWrite ?? (authorized[0] ? authorized[0].access === 'write' : true))
   const [authorizations, setAuthorizations] = useState(authorized)
   const [repositoryEditor, setRepositoryEditor] = useState<{
@@ -171,6 +192,21 @@ export default function EditWorkspaceModal({
       ctrl.abort()
     }
   }, [gh, repositoryEditor, reposNonce])
+
+  // Added projects only — the picker never installs one, so the connection card
+  // stays the single place a project joins the organization.
+  useEffect(() => {
+    if (repositoryEditor !== null || !gitlabOffered || mode !== 'gitlab' || glProjects !== null) return
+    let alive = true
+    setGlProjectsError(null)
+    fetchGitlabProjects().then(
+      (bindings) => alive && setGlProjects(bindings),
+      (e) => alive && setGlProjectsError(e instanceof Error ? e.message : String(e))
+    )
+    return () => {
+      alive = false
+    }
+  }, [gitlabOffered, glProjects, mode, repositoryEditor])
 
   const openGhInstall = async () => {
     const url = await fetchGithubInstallUrl().catch(() => null)
@@ -268,16 +304,23 @@ export default function EditWorkspaceModal({
   }
 
   const noInstall = mode === 'github' && gh !== null && (!gh.enabled || gh.installations.length === 0)
-  const accessChanged = githubWorkspace !== null && write !== currentWrite
+  const glSelectable = (glProjects ?? []).filter((project) => gitlabProjectSelectable(project.state))
+  const noProjects = mode === 'gitlab' && glProjects !== null && glSelectable.length === 0
+  const glPicked = (glProjects ?? []).find((project) => project.projectId === glPick)
+  // Falls back to the stored path so the current project reads correctly before the list lands.
+  const glPickLabel =
+    glPicked?.projectPath ?? (glPick && glPick === gitlabWorkspace?.projectId ? gitlabWorkspace.repo : '')
+  const accessChanged = gitWorkspace !== null && write !== currentWrite
   const installationChanged =
     githubWorkspace !== null && pickInstallationId !== null && githubWorkspace.installationId !== pickInstallationId
   const repoChanged =
-    mode === 'github' && (githubWorkspace === null || pick.toLowerCase() !== githubWorkspace.repo.toLowerCase())
-  const branchChanged =
-    mode === 'github' && githubWorkspace !== null && branch.trim() !== (githubWorkspace.branch ?? '')
+    mode === 'github'
+      ? githubWorkspace === null || pick.toLowerCase() !== githubWorkspace.repo.toLowerCase()
+      : mode === 'gitlab' && (gitlabWorkspace === null || glPick !== gitlabWorkspace.projectId)
+  const branchChanged = mode === agent.workspace.mode && gitWorkspace !== null && branch.trim() !== gitWorkspace.branch
   const agentDirChanged =
-    mode === 'github' && githubWorkspace !== null && (normalizedAgentDir ?? '') !== currentAgentDir
-  const worktreeChanged = mode === 'github' && githubWorkspace !== null && worktree !== !!githubWorkspace.worktree
+    mode === agent.workspace.mode && gitWorkspace !== null && (normalizedAgentDir ?? '') !== currentAgentDir
+  const worktreeChanged = mode === agent.workspace.mode && gitWorkspace !== null && worktree !== !!gitWorkspace.worktree
   const destructiveChange = mode !== agent.workspace.mode || repoChanged || branchChanged
   const changed =
     mode !== agent.workspace.mode ||
@@ -288,10 +331,15 @@ export default function EditWorkspaceModal({
         agentDirChanged ||
         worktreeChanged ||
         accessChanged ||
-        installationChanged))
+        installationChanged)) ||
+    (mode === 'gitlab' &&
+      (gitlabWorkspace === null || repoChanged || branchChanged || agentDirChanged || worktreeChanged || accessChanged))
   const canSubmit =
     changed &&
-    (mode === 'scratch' || (!!pick && !uncovered && !probeDenies && agentDirError === null && !!pickInstallationId))
+    (mode === 'scratch' ||
+      (mode === 'gitlab'
+        ? !!glPick && agentDirError === null
+        : !!pick && !uncovered && !probeDenies && agentDirError === null && !!pickInstallationId))
 
   const selectRepo = (fullName: string) => {
     const selected = repos?.find((repo) => repo.fullName.toLowerCase() === fullName.toLowerCase())
@@ -306,6 +354,15 @@ export default function EditWorkspaceModal({
     setErr(null)
   }
 
+  const selectProject = (project: GitlabProjectBindingDto) => {
+    setGlPick(project.projectId)
+    setGlPickOpen(false)
+    setAccessOpen(false)
+    setBranch(project.defaultBranch ?? '')
+    setAgentDir('')
+    setErr(null)
+  }
+
   const submit = async () => {
     if (busyRef.current || !canSubmit) return
     busyRef.current = true
@@ -317,14 +374,23 @@ export default function EditWorkspaceModal({
         agent.id,
         mode === 'scratch'
           ? { mode: 'scratch' }
-          : {
-              mode: 'github',
-              worktree,
-              repoFullName: pick,
-              ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
-              ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {}),
-              gitAccess: write ? 'write' : 'read'
-            }
+          : mode === 'gitlab'
+            ? {
+                mode: 'gitlab',
+                worktree,
+                projectId: glPick,
+                ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
+                ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {}),
+                gitAccess: write ? 'write' : 'read'
+              }
+            : {
+                mode: 'github',
+                worktree,
+                repoFullName: pick,
+                ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
+                ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {}),
+                gitAccess: write ? 'write' : 'read'
+              }
       )
       onChanged()
     } catch (error) {
@@ -415,6 +481,7 @@ export default function EditWorkspaceModal({
               setPickOpen(false)
               setAccessOpen(false)
               setBranchOpen(false)
+              setGlPickOpen(false)
               setErr(null)
             }}
           />
@@ -434,6 +501,98 @@ export default function EditWorkspaceModal({
             </span>
           </div>
 
+          {mode === 'gitlab' && (
+            <div className="mb-4 grid grid-cols-1 gap-[14px] desktop:grid-cols-2 desktop:gap-x-7">
+              {glProjectsError ? (
+                <div className="font-sans text-[12px] font-normal leading-[1.5] text-(--status-error) desktop:col-span-2">
+                  Couldn&rsquo;t load your GitLab projects — {glProjectsError}
+                </div>
+              ) : glProjects === null ? (
+                <div className="desktop:col-span-2">
+                  <LoadingState size={20} padding={16} />
+                </div>
+              ) : noProjects ? (
+                <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} />
+              ) : (
+                <>
+                  <GitlabProjectField
+                    value={glPickLabel}
+                    icon="book-marked"
+                    loading={false}
+                    open={glPickOpen}
+                    query={glQ}
+                    onToggle={() => {
+                      setGlQ('')
+                      setAccessOpen(false)
+                      setGlPickOpen((value) => !value)
+                    }}
+                    onClose={() => setGlPickOpen(false)}
+                    onQueryChange={setGlQ}
+                  >
+                    {matchGitlabProjects(glProjects, glQ).map((project) => (
+                      <GitlabProjectOption
+                        key={project.id}
+                        project={project}
+                        selected={glPick === project.projectId}
+                        onSelect={() => selectProject(project)}
+                      />
+                    ))}
+                    {matchGitlabProjects(glProjects, glQ).length === 0 && (
+                      <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>
+                    )}
+                  </GitlabProjectField>
+
+                  <RepositoryAccessField
+                    repositorySelected={!!glPick}
+                    label="Project access"
+                    unselectedLabel="Select project first"
+                    writeDescription="Push, open merge requests & run pipelines"
+                    value={write ? 'write' : 'read'}
+                    open={accessOpen}
+                    onToggle={() => {
+                      setGlPickOpen(false)
+                      setAccessOpen((value) => !value)
+                    }}
+                    onClose={() => setAccessOpen(false)}
+                    onChange={(value) => {
+                      setWrite(value === 'write')
+                      setAccessOpen(false)
+                      setErr(null)
+                    }}
+                  />
+
+                  <div className="grid grid-cols-1 gap-[14px] desktop:col-span-2 desktop:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_96px] desktop:gap-x-[14px]">
+                    <WorkspaceBranchField
+                      repositorySelected={!!glPick}
+                      unselectedLabel="Pick project first"
+                      defaultBranchLabel="GitLab default branch"
+                      value={branch}
+                      branches={null}
+                      open={false}
+                      query=""
+                      onToggle={() => {}}
+                      onClose={() => {}}
+                      onQueryChange={() => {}}
+                      onChange={(value) => {
+                        setBranch(value)
+                        setErr(null)
+                      }}
+                    />
+
+                    <WorkingSubdirectoryField
+                      value={agentDir}
+                      error={agentDirError}
+                      onChange={(value) => {
+                        setAgentDir(value)
+                        setErr(null)
+                      }}
+                    />
+                    <WorktreeField checked={worktree} onChange={setWorktree} />
+                  </div>
+                </>
+              )}
+            </div>
+          )}
           {mode === 'github' &&
             (gh === null ? (
               <div className="mb-4 flex items-center gap-[10px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
@@ -689,8 +848,8 @@ export default function EditWorkspaceModal({
           </Button>
           <Button
             onClick={() => void submit()}
-            disabled={!canSubmit || saving || noInstall}
-            className={!canSubmit || saving || noInstall ? 'pointer-events-none opacity-50' : undefined}
+            disabled={!canSubmit || saving || noInstall || noProjects}
+            className={!canSubmit || saving || noInstall || noProjects ? 'pointer-events-none opacity-50' : undefined}
           >
             {saving ? 'Saving…' : destructiveChange ? 'Replace workspace' : 'Save'}
           </Button>

--- a/packages/web/src/components/console/platforms/host-projections.ts
+++ b/packages/web/src/components/console/platforms/host-projections.ts
@@ -3,6 +3,7 @@
 
 import { larkFeishuBrand, type LarkFeishuTarget } from '@/components/LarkFeishuSwitcher'
 import type { BotDto } from '@/lib/api'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import { platformLabel } from '@/lib/platform-labels'
 import { platformRegistry } from './registry'
 
@@ -21,8 +22,8 @@ import { platformRegistry } from './registry'
  *    (`lib/platform-labels.ts`), never re-spelled here. §5's `displayName` is
  *    manifest data shared with the daemon/relay/CP and deliberately NOT a
  *    web-module member (contract D2);
- *  - the two **core trigger kinds** (`webhook`, `github`) are not platform
- *    modules at all — picking either mints an inbound hook rather than a bot
+ *  - the **core trigger kinds** (`webhook`, `github`, `gitlab`) are not platform
+ *    modules at all — picking one mints an inbound hook rather than a bot
  *    identity — so the chassis lists them itself;
  *  - the **region axis** ({@link BOT_PLATFORM_TABS}), for the same D2 reason.
  *
@@ -55,13 +56,22 @@ export function platformTiles(ids: readonly string[]): PlatformTile[] {
  */
 export const BOT_PLATFORMS: readonly PlatformTile[] = platformTiles(platformRegistry.ids())
 
-/** Every picker choice: the chat platforms plus the two core trigger kinds.
- *  Neither trigger is gated by daemon adapters — both live on the relay pool. */
+/** Every picker choice: the chat platforms plus the core trigger kinds. None of
+ *  the triggers is gated by daemon adapters — all live on the relay pool. The
+ *  GitLab tile is additionally gated on its feature flag at the call site. */
 export const PLATFORMS: readonly PlatformTile[] = [
   ...BOT_PLATFORMS,
   { key: 'webhook', label: 'Webhook' },
-  { key: 'github', label: 'GitHub' }
+  { key: 'github', label: 'GitHub' },
+  { key: 'gitlab', label: 'GitLab' }
 ]
+
+/** The picker choices this deployment actually offers — {@link PLATFORMS} minus
+ *  the tiles a feature flag holds back. Every picker reads this, so a flagged
+ *  trigger kind can never appear on one surface and not the other. */
+export function offeredPlatforms(): readonly PlatformTile[] {
+  return PLATFORMS.filter((tile) => tile.key !== 'gitlab' || featureFlagEnabled('gitlab'))
+}
 
 /**
  * One-liners for the agent page's empty-integrations tiles, keyed by picker
@@ -75,6 +85,7 @@ export const INTEGRATION_BLURB: Record<string, string> = {
   discord: 'Reply in servers',
   feishu: 'Reply in groups & chats',
   github: 'React to issues & PRs',
+  gitlab: 'React to issues & MRs',
   webhook: 'Trigger by posting a URL'
 }
 

--- a/packages/web/src/components/console/platforms/host-projections.ts
+++ b/packages/web/src/components/console/platforms/host-projections.ts
@@ -66,6 +66,14 @@ export const PLATFORMS: readonly PlatformTile[] = [
   { key: 'gitlab', label: 'GitLab' }
 ]
 
+/** The core trigger kinds — every picker choice that is NOT a registry platform.
+ *  Derived from the two lists rather than restated, so adding a trigger kind above
+ *  is still one edit. These ride the relay pool, so no daemon's chat-adapter
+ *  capabilities gate them; every picker must treat them as always available. */
+export function isCoreTriggerKind(key: string): boolean {
+  return !BOT_PLATFORMS.some((tile) => tile.key === key) && PLATFORMS.some((tile) => tile.key === key)
+}
+
 /** The picker choices this deployment actually offers — {@link PLATFORMS} minus
  *  the tiles a feature flag holds back. Every picker reads this, so a flagged
  *  trigger kind can never appear on one surface and not the other. */

--- a/packages/web/src/components/console/platforms/platform-set.test.tsx
+++ b/packages/web/src/components/console/platforms/platform-set.test.tsx
@@ -32,9 +32,9 @@ import { botCardCopy, platformRegistry } from './registry'
  */
 const ALIASES = ['lark']
 
-/** Not a module and never will be: picking either mints an inbound trigger, not
- *  a bot identity (contract, registry doc). The picker still offers them. */
-const CORE_TRIGGER_KINDS = ['webhook', 'github']
+/** Not modules and never will be: picking one mints an inbound trigger, not a
+ *  bot identity (contract, registry doc). The picker still offers them. */
+const CORE_TRIGGER_KINDS = ['webhook', 'github', 'gitlab']
 
 describe('platform set', () => {
   it('gives every registered module a mark and a label', () => {
@@ -61,9 +61,9 @@ describe('platform set', () => {
     }
   })
 
-  it('offers exactly the registered platforms as picker tiles, plus the two core triggers', () => {
-    // The tile SET is the registry's, in registry order; the two trigger kinds
-    // are appended by the chassis because they are not modules.
+  it('offers exactly the registered platforms as picker tiles, plus the core triggers', () => {
+    // The tile SET is the registry's, in registry order; the trigger kinds are
+    // appended by the chassis because they are not modules.
     expect(BOT_PLATFORMS.map((tile) => tile.key)).toEqual([...platformRegistry.ids()])
     expect(PLATFORMS.map((tile) => tile.key)).toEqual([...platformRegistry.ids(), ...CORE_TRIGGER_KINDS])
   })

--- a/packages/web/src/components/console/platforms/platform-set.test.tsx
+++ b/packages/web/src/components/console/platforms/platform-set.test.tsx
@@ -9,6 +9,8 @@ import {
   INTEGRATION_BLURB,
   PLATFORMS,
   botMatchesPlatformTab,
+  isCoreTriggerKind,
+  offeredPlatforms,
   platformTiles
 } from './host-projections'
 import { PLATFORM_MARK_IDS, platformMark } from './marks'
@@ -78,6 +80,33 @@ describe('platform set', () => {
       expect(INTEGRATION_BLURB[tile.key], tile.key).toBeTruthy()
     }
     expect(Object.keys(INTEGRATION_BLURB).sort()).toEqual([...platformRegistry.ids(), ...CORE_TRIGGER_KINDS].sort())
+  })
+
+  it('treats exactly the non-module choices as relay-backed trigger kinds', () => {
+    // Both pickers gate a chat platform on the owning daemon's advertised adapters
+    // and must NEVER gate a trigger kind that way — GitLab's empty-state tile
+    // rendered disabled for a normally placed agent while this set named only two.
+    expect(PLATFORMS.map((tile) => tile.key).filter(isCoreTriggerKind)).toEqual(CORE_TRIGGER_KINDS)
+    for (const id of platformRegistry.ids()) expect(isCoreTriggerKind(id), id).toBe(false)
+    expect(isCoreTriggerKind('zulip')).toBe(false)
+  })
+
+  it('offers the flagged GitLab tile only where its flag is on', () => {
+    const flags = (value?: string) => {
+      ;(globalThis as { window?: { __AC_ENV?: Record<string, string> } }).window = {
+        __AC_ENV: value === undefined ? {} : { FEATURE_FLAGS: value }
+      }
+    }
+    try {
+      flags()
+      expect(offeredPlatforms().map((tile) => tile.key)).not.toContain('gitlab')
+      flags('gitlab')
+      expect(offeredPlatforms().map((tile) => tile.key)).toContain('gitlab')
+      // Still a trigger kind, so nothing about the daemon can disable its tile.
+      expect(isCoreTriggerKind('gitlab')).toBe(true)
+    } finally {
+      delete (globalThis as { window?: unknown }).window
+    }
   })
 
   it('passes an id no module claims straight through the tile projection', () => {

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -14,6 +14,7 @@ import {
   effortField,
   enrichSessionWithAgent,
   flattenFiles,
+  isGitWorkspace,
   isPoolPlacementKind,
   MOCK_MODE,
   MOCK_PREFIX,
@@ -67,7 +68,7 @@ import LarkFeishuSwitcher from '@/components/LarkFeishuSwitcher'
 import { AgentMark, GithubMark, GitlabMark, LoadingState, PlatformMark } from '@/components/marks'
 import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import type { Platform } from '@/components/console/modals/AddIntegrationModal'
-import { INTEGRATION_BLURB, offeredPlatforms } from '@/components/console/platforms/host-projections'
+import { INTEGRATION_BLURB, isCoreTriggerKind, offeredPlatforms } from '@/components/console/platforms/host-projections'
 import { GL_FAMILIES, eventsForGitlabFamilies, gitlabFamCovered, type GlFamily } from '@/lib/gitlab-events'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
 import { BuiltinBadge } from '@/components/console/BuiltinBadge'
@@ -480,14 +481,14 @@ export default function AgentDetailView() {
   const ws = da.workspace
   // Demo agents have no daemon to read git state from, so the workspace card's
   // live half comes straight from their static mock workspace instead.
-  const mockWorkspaceHeader: WorkspaceHeaderInfo =
-    ws.mode === 'github'
-      ? {
-          status: workspaceStatus(ws),
-          ...(ws.commitMsg ? { commit: { sha: ws.commit, time: ws.commitTime, title: ws.commitMsg } } : {}),
-          repoUrl: ws.repoUrl ?? `https://github.com/${ws.repo}`
-        }
-      : { status: workspaceStatus(ws) }
+  const mockWorkspaceHeader: WorkspaceHeaderInfo = isGitWorkspace(ws)
+    ? {
+        status: workspaceStatus(ws),
+        ...(ws.commitMsg ? { commit: { sha: ws.commit, time: ws.commitTime, title: ws.commitMsg } } : {}),
+        repoUrl: ws.repoUrl ?? `https://${ws.mode === 'gitlab' ? 'gitlab.com' : 'github.com'}/${ws.repo}`,
+        remoteLabel: ws.mode === 'gitlab' ? 'GitLab' : 'GitHub'
+      }
+    : { status: workspaceStatus(ws) }
   // Counts walk the whole mock tree (files are nested under folder children).
   const allFiles = flattenFiles(ws.files)
   const changedFiles = allFiles.filter((f) => f.tag).length
@@ -509,11 +510,7 @@ export default function AgentDetailView() {
   // Slack" card / the funnel mint CP-side rows whose delivery converges at
   // placement; the modal + server gate what genuinely needs a daemon.
   const integrationPlatformAvailable = (key: Platform) =>
-    key === 'webhook' ||
-    key === 'github' ||
-    daemonsLoading ||
-    !owningDaemon ||
-    owningDaemon.caps.platforms.includes(key)
+    isCoreTriggerKind(key) || daemonsLoading || !owningDaemon || owningDaemon.caps.platforms.includes(key)
   // Effective (intersection) peer sets for the read-only Access summary.
   const inboundEffectiveIds = agentReach.incomingByAgentId.get(da.id) ?? []
   const outboundEffectiveIds = agentReach.outgoingByAgentId.get(da.id) ?? []
@@ -1822,13 +1819,13 @@ export default function AgentDetailView() {
               {...(selectedWorktreeSessionId ? { sessionId: selectedWorktreeSessionId } : {})}
               {...(selectedRepo ? { repo: selectedRepo } : {})}
               repoOptions={workspaceRepoOptions}
-              {...(da.workspace.mode === 'github' ? { primaryRepoLabel: da.workspace.repo } : {})}
+              {...(isGitWorkspace(da.workspace) ? { primaryRepoLabel: da.workspace.repo } : {})}
               onRepoChange={selectRepoScope}
               workdir={da.workdir}
               canEdit={selectedWorktreeSessionId === null && da.workspace.mode === 'scratch' && da.canEdit}
               sandboxed={isPoolPlacementKind(da.placementKind)}
               renderWorkspacePicker={(primaryBranch) =>
-                da.workspace.mode === 'github' ? (
+                isGitWorkspace(da.workspace) ? (
                   <WorkspaceScopePicker
                     primaryBranch={primaryBranch ?? da.workspace.branch}
                     sessions={workspaceSessions}
@@ -1858,7 +1855,7 @@ export default function AgentDetailView() {
             <FileBrowserShell
               title="Files"
               headerEnd={
-                ws.mode === 'github' ? (
+                isGitWorkspace(ws) ? (
                   <div className="flex w-1/4 min-w-0 flex-none items-center gap-2 max-desktop:w-[min(210px,56vw)]">
                     <WorkspaceScopePicker
                       primaryBranch={ws.branch}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -32,8 +32,10 @@ import {
   fetchSessionDetail,
   sessionFromDetailDto,
   updateGithubHook,
+  updateGitlabHook,
   uploadAgentIcon,
   type GithubInstallationDto,
+  type GitlabCommentFamily,
   type HookDto,
   type HookRunDto
 } from '@/lib/api'
@@ -62,10 +64,11 @@ import { LocalSkillsList } from '@/components/console/LocalSkillsList'
 import { GithubReviewSettings } from '@/components/console/GithubReviewSettings'
 import { VisibilityValue } from '@/components/console/VisibilityField'
 import LarkFeishuSwitcher from '@/components/LarkFeishuSwitcher'
-import { AgentMark, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
+import { AgentMark, GithubMark, GitlabMark, LoadingState, PlatformMark } from '@/components/marks'
 import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import type { Platform } from '@/components/console/modals/AddIntegrationModal'
-import { INTEGRATION_BLURB, PLATFORMS } from '@/components/console/platforms/host-projections'
+import { INTEGRATION_BLURB, offeredPlatforms } from '@/components/console/platforms/host-projections'
+import { GL_FAMILIES, eventsForGitlabFamilies, gitlabFamCovered, type GlFamily } from '@/lib/gitlab-events'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
 import { BuiltinBadge } from '@/components/console/BuiltinBadge'
 import { NotFound } from '@/components/console/NotFound'
@@ -79,6 +82,7 @@ import {
   GH_TRIGGER_MODES,
   GH_TRIGGER_PILL,
   commentFamiliesForFamilies,
+  githubCommentFamilies,
   eventsForFamilies,
   famCovered,
   githubHookNeedsNormalization,
@@ -209,10 +213,11 @@ export default function AgentDetailView() {
   })
   const agentHooks = agentHooksData ?? []
   const hooksLoadError = agentHooksData === undefined && hooksError
-  // GitHub subscriptions render as ONE "GitHub" group with a row per watched
-  // repo (design); webhooks stay flat rows.
-  const webhookHooks = agentHooks.filter((h) => h.kind !== 'github')
+  // Each code host renders as ONE group with a row per watched repository or
+  // project (design); webhooks stay flat rows.
+  const webhookHooks = agentHooks.filter((h) => h.kind === 'webhook')
   const githubHooks = agentHooks.filter((h) => h.kind === 'github')
+  const gitlabHooks = agentHooks.filter((h) => h.kind === 'gitlab')
   const githubInstallationsKey =
     activeOrg && githubHooks.length > 0 ? (['github-review-installations', activeOrg.id] as const) : null
   const { data: githubInstallationsData } = useSWR<GithubInstallationDto[]>(githubInstallationsKey, () =>
@@ -329,7 +334,7 @@ export default function AgentDetailView() {
         enabled: reviewSettingsHook.enabled,
         repoFullName: reviewSettingsHook.repoFullName,
         events: reviewSettingsHook.events,
-        commentFamilies: reviewSettingsHook.commentFamilies,
+        commentFamilies: githubCommentFamilies(reviewSettingsHook.commentFamilies),
         labelFilter: reviewSettingsHook.labelFilter,
         mentionOnly: reviewSettingsHook.mentionOnly,
         reviewPolicy: reviewSettingsDraft.reviewPolicy,
@@ -367,6 +372,35 @@ export default function AgentDetailView() {
         reviewPolicy: h.reviewPolicy,
         reportingMode: h.reportingMode,
         gateMode: 'informational'
+      })
+      void mutateHooks((rows) => rows?.map((r) => (r.id === h.id ? updated : r)), { revalidate: false })
+    } catch {
+      /* controls stay as they were — the next refresh interval reconciles */
+    } finally {
+      setHookBusy(null)
+    }
+  }
+  // The GitLab counterpart: subject families only, no cadence axis and no review
+  // knobs — the M6 review slice adds those, and the row must not imply them yet.
+  const toggleGitlabHookFam = async (h: HookDto, fam: GlFamily) => {
+    if (hookBusy || !h.agentId || !h.repoId) return
+    const families = GL_FAMILIES.map((f) => f.fam).filter((f) =>
+      f === fam ? !gitlabFamCovered(h.events, f) : gitlabFamCovered(h.events, f)
+    )
+    if (families.length === 0) return // at least one family must stay subscribed
+    setHookBusy(h.id)
+    try {
+      const updated = await updateGitlabHook(h.id, {
+        agentId: h.agentId,
+        name: h.name,
+        enabled: h.enabled,
+        projectId: h.repoId,
+        events: eventsForGitlabFamilies(families),
+        commentFamilies: h.commentFamilies.filter(
+          (family): family is GitlabCommentFamily => family === 'issues' || family === 'merge_request'
+        ),
+        labelFilter: h.labelFilter,
+        mentionOnly: h.mentionOnly
       })
       void mutateHooks((rows) => rows?.map((r) => (r.id === h.id ? updated : r)), { revalidate: false })
     } catch {
@@ -1329,6 +1363,34 @@ export default function AgentDetailView() {
                       </button>
                     </div>
                   ))}
+                  {gitlabHooks.map((h, i) => (
+                    <div
+                      key={h.id}
+                      className={`flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3 ${
+                        agentInts.length + webhookHooks.length + githubHooks.length + i > 0 ? 'border-t' : ''
+                      }`}
+                    >
+                      <span className="flex h-9 w-9 flex-none items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
+                        <span className="flex h-[18px] w-[18px] items-center justify-center">
+                          <PlatformMark platform="gitlab" fillPct={100} />
+                        </span>
+                      </span>
+                      <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
+                        <span className="mono min-w-0 truncate text-[13px] font-semibold">
+                          {h.repoFullName ?? h.name}
+                        </span>
+                        <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                          {GL_FAMILIES.filter((f) => gitlabFamCovered(h.events, f.fam))
+                            .map((f) => f.pill)
+                            .join(' · ') || 'no events'}
+                          {h.mentionOnly ? ' · @-mention only' : ''}
+                        </span>
+                      </span>
+                      <span className="inline-flex flex-none items-center gap-[5px] rounded-full bg-(--surface-active) px-[10px] py-[3px] font-sans text-[12px] font-semibold leading-normal text-(--text-tertiary)">
+                        GitLab
+                      </span>
+                    </div>
+                  ))}
                 </div>
                 <div className="hidden flex-col gap-3 px-4 py-[14px] desktop:flex">
                   {agentInts.map((g, i) => (
@@ -1563,6 +1625,102 @@ export default function AgentDetailView() {
                       </div>
                     </div>
                   )}
+                  {/* GitLab group — the same one-card shape as GitHub, minus the
+                      review and Check controls the M6 slice has not landed yet. */}
+                  {gitlabHooks.length > 0 && (
+                    <div className="overflow-hidden rounded-[9px] border border-(--border-subtle)">
+                      <div className="flex items-center gap-3 px-[14px] py-3">
+                        <span className="flex h-[34px] w-[34px] flex-none items-center justify-center">
+                          <span className="flex h-[26px] w-[26px] items-center justify-center">
+                            <GitlabMark fillPct={100} />
+                          </span>
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="font-sans text-[13.5px] font-semibold leading-normal">GitLab</span>
+                            <span className="badge bg-(--brand-soft) text-(--brand-soft-text)">
+                              <span className="dot h-[6px] w-[6px] bg-(--status-online)" />
+                              connected
+                            </span>
+                          </div>
+                          <div className="mono mt-[3px] text-[11.5px] font-normal text-(--text-tertiary)">
+                            gitlab.com
+                          </div>
+                        </div>
+                      </div>
+                      <div className="border-t border-(--border-subtle) bg-(--surface-app)">
+                        {gitlabHooks.map((h) => (
+                          <div key={h.id} className="border-b border-(--border-subtle)">
+                            <div className="flex flex-wrap items-center gap-x-2 gap-y-[6px] px-[14px] py-[9px]">
+                              <Icon name="folder-git-2" size={14} color="var(--text-tertiary)" className="flex-none" />
+                              <span className="mono min-w-[90px] flex-1 truncate text-[12px] text-(--text-primary)">
+                                {h.repoFullName ?? h.name}
+                              </span>
+                              {h.mentionOnly && (
+                                <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">
+                                  @-mention only
+                                </span>
+                              )}
+                              <div className="ml-auto inline-flex flex-none gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) p-[2px]">
+                                {GL_FAMILIES.map((f) => {
+                                  const on = gitlabFamCovered(h.events, f.fam)
+                                  return (
+                                    <button
+                                      key={f.fam}
+                                      onClick={() => void toggleGitlabHookFam(h, f.fam)}
+                                      disabled={hookBusy === h.id}
+                                      title={on ? `Stop listening for ${f.label}` : `Listen for ${f.label}`}
+                                      className={`cursor-pointer rounded-[7px] border-0 px-[9px] py-[3px] font-sans text-[11.5px] leading-normal ${
+                                        on
+                                          ? 'bg-(--surface-card) font-semibold text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]'
+                                          : 'bg-transparent font-normal text-(--text-tertiary)'
+                                      } ${hookBusy === h.id ? 'opacity-60' : ''}`}
+                                    >
+                                      {f.pill}
+                                    </button>
+                                  )
+                                })}
+                              </div>
+                              <span className="inline-flex flex-none gap-[2px]">
+                                <button
+                                  className="iconbtn h-[26px] w-[26px] flex-none"
+                                  title="Recent deliveries"
+                                  onClick={() => setHookRunsFor(hookRunsFor === h.id ? null : h.id)}
+                                >
+                                  <Icon name={hookRunsFor === h.id ? 'chevron-up' : 'history'} size={13} />
+                                </button>
+                                <button
+                                  className="iconbtn h-[26px] w-[26px] flex-none"
+                                  title="Remove project"
+                                  onClick={() => openModal('deleteHook', h)}
+                                >
+                                  <Icon name="x" size={13} />
+                                </button>
+                              </span>
+                            </div>
+                            {hookRunsFor === h.id && (
+                              <HookRunsPanel hookId={h.id} sessionHref={(sid) => orgPath(`/sessions/${sid}`)} />
+                            )}
+                          </div>
+                        ))}
+                        <div className="px-[14px] py-2">
+                          {/* Straight to the GitLab pane — this button adds a project, not a bot. */}
+                          <button
+                            className="lnk text-[12px]"
+                            onClick={() => openModal('integration', da, { platform: 'gitlab' })}
+                          >
+                            <Icon name="plus" size={13} />
+                            Add project
+                          </button>
+                        </div>
+                        <div className="flex items-center gap-[7px] px-[14px] pt-0 pb-2 font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                          <Icon name="info" size={12} className="flex-none" />
+                          Pick which projects to watch and which events run the agent — it replies on the same issue,
+                          merge request or push thread.
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </div>
               </>
             ) : hooksLoadError ? (
@@ -1587,7 +1745,7 @@ export default function AgentDetailView() {
                 {/* Identical grid to the Add-integration modal's platform picker —
                     same list, order, tile size and disabled treatment. */}
                 <div className="mt-4 grid grid-cols-2 gap-[10px] desktop:flex desktop:flex-wrap desktop:justify-center">
-                  {PLATFORMS.map((p) => {
+                  {offeredPlatforms().map((p) => {
                     const available = integrationPlatformAvailable(p.key)
                     return (
                       <div

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -16,7 +16,7 @@ import { amountToNumber } from '@/lib/amount'
 import { useConsoleData } from '@/lib/data-context'
 import { IntegrationMarks } from '@/components/console/IntegrationMarks'
 import { useModal } from '@/components/console/ModalProvider'
-import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
+import { AgentIconView, GithubMark, GitlabMark, LoadingState, PlatformMark } from '@/components/marks'
 import { BuiltinBadge } from '@/components/console/BuiltinBadge'
 import { RestrictedLock } from '@/components/console/VisibilityField'
 import { Avatar, Button, Icon } from '@/components/ui'
@@ -436,6 +436,8 @@ export default function AgentsView() {
                     <span className="flex h-4 w-4 flex-none items-center justify-center">
                       {(a.hookKinds ?? []).includes('github') ? (
                         <GithubMark />
+                      ) : (a.hookKinds ?? []).includes('gitlab') ? (
+                        <GitlabMark />
                       ) : (
                         <Icon name="webhook" size={14} color="var(--text-secondary)" />
                       )}

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -7,6 +7,7 @@ import {
   agentLabel,
   agentModelDisplay,
   effectiveAgentStatus,
+  isGitWorkspace,
   runtimeLabel,
   status,
   type Agent
@@ -100,7 +101,7 @@ export default function AgentsView() {
   // Creator names remain available to sorting and assistive text; rows show only avatars.
   const memberById = useMemo(() => new Map(members.map((m) => [m.userId, m])), [members])
   const creatorText = (a: Agent) => creatorLabel(a.createdBy || null, me)
-  const repoText = (a: Agent) => (a.workspace.mode === 'github' ? a.repo : 'scratch')
+  const repoText = (a: Agent) => (isGitWorkspace(a.workspace) ? a.repo : 'scratch')
   const onlineCount = agents.filter(
     (a) =>
       effectiveAgentStatus(
@@ -563,9 +564,13 @@ export default function AgentsView() {
             const agentInts = integrations.filter((i) => i.agentId === a.id)
             const hookKinds = a.hookKinds ?? []
             const totalIntegrations = agentInts.length + hookKinds.length
-            const repoIcon =
-              a.workspace.mode === 'github' ? (a.workspace.installationId ? 'lock' : 'book-marked') : 'folder'
-            const repoLabel = a.workspace.mode === 'github' ? a.repo : 'scratch'
+            // Only a GitHub App checkout can promise privacy, so every other clone takes the neutral repo glyph.
+            const repoIcon = !isGitWorkspace(a.workspace)
+              ? 'folder'
+              : a.workspace.mode === 'github' && a.workspace.installationId
+                ? 'lock'
+                : 'book-marked'
+            const repoLabel = isGitWorkspace(a.workspace) ? a.repo : 'scratch'
             return (
               <Link
                 key={a.id}

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -39,6 +39,7 @@ import {
   modelCapability,
   effortChoicesFor,
   displayedEffort,
+  isGitWorkspace,
   resolveEffortForModel,
   permissionModeChoicesFor,
   permissionModePresets,
@@ -210,8 +211,8 @@ export default function HomeView() {
   const [menu, setMenu] = useState<'agent' | 'model' | 'effort' | 'permission' | 'add' | 'attach' | null>(null)
   const [runtime, setRuntime] = useState<{ model?: string; effort?: string; permissionPreset?: string }>({})
   const [worktreeOverride, setWorktreeOverride] = useState<boolean>()
-  const githubWorkspace = agent?.workspace?.mode === 'github' ? agent.workspace : undefined
-  const defaultWorktree = githubWorkspace?.worktree === true
+  const gitWorkspace = agent?.workspace && isGitWorkspace(agent.workspace) ? agent.workspace : undefined
+  const defaultWorktree = gitWorkspace?.worktree === true
   const worktree = worktreeOverride ?? defaultWorktree
 
   // Overrides are per-agent; drop them when the agent changes so the new agent's
@@ -312,7 +313,7 @@ export default function HomeView() {
     const text = input.trim()
     if ((!text && !image) || imagePreparing || mention.joining) return
     if (!agent || !canSend) return // offline / unsigned-in agents can't take a session
-    const id = openPlayground(agent, members, !multi && githubWorkspace ? { worktree } : undefined)
+    const id = openPlayground(agent, members, !multi && gitWorkspace ? { worktree } : undefined)
     // Stage the EFFECTIVE (displayed) runtime before the turn — not just explicit
     // overrides — so the session runs exactly what the composer showed. stageRuntimeChange
     // is a synchronous ref write, so pgSend's payload picks it up (PlaygroundProvider).
@@ -683,7 +684,7 @@ export default function HomeView() {
                     onChange={(v) => setRuntime((r) => ({ ...r, permissionPreset: v }))}
                   />
                 )}
-                {!multi && githubWorkspace && (
+                {!multi && gitWorkspace && (
                   <label className={`${CHIP} min-w-0 cursor-pointer`}>
                     <input
                       type="checkbox"

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -25,6 +25,7 @@ import {
   MOCK_MODE,
   MOCK_PREFIX,
   permissionModeLabel,
+  isGitWorkspace,
   pgPrompts,
   POOL_PLACEMENT,
   platName,
@@ -2609,7 +2610,8 @@ export default function SessionDetailView() {
   const attachmentsEnabled = !isContinuable
   const pgQueue = getPgQueue(session.id)
   const hasSessionWorktree =
-    focusedAgent?.workspace.mode === 'github' &&
+    !!focusedAgent &&
+    isGitWorkspace(focusedAgent.workspace) &&
     (focusedSessionDetail?.workspaceIsolation ?? focusedSession?.workspaceIsolation) === 'session' &&
     !(focusedSessionDetail?.contentPurgedAt ?? focusedSession?.contentPurgedAt)
   const workspaceHref =
@@ -2618,7 +2620,7 @@ export default function SessionDetailView() {
           hasSessionWorktree && headerFocusSessionId ? `&worktree=${encodeURIComponent(headerFocusSessionId)}` : ''
         }`
       : null
-  const workspaceIcon = focusedAgent?.workspace.mode === 'github' ? 'git-branch' : 'folder'
+  const workspaceIcon = focusedAgent && isGitWorkspace(focusedAgent.workspace) ? 'git-branch' : 'folder'
   const focusedAgentLabel = focusedAgent ? agentLabel(focusedAgent) : (headerFocusOption?.label ?? 'agent')
   const workspaceTitle = hasSessionWorktree
     ? `Open ${focusedAgentLabel}’s session worktree`
@@ -2729,9 +2731,13 @@ export default function SessionDetailView() {
   const pgWorktree =
     worktreeSelections[session.id] ??
     getPgWorktree(session.id) ??
-    (owner?.workspace?.mode === 'github' && owner.workspace.worktree === true)
+    (!!owner?.workspace && isGitWorkspace(owner.workspace) && owner.workspace.worktree === true)
   const canChooseWorktree =
-    isPg && !multiLive && owner?.workspace?.mode === 'github' && !session.steps.some((step) => step.kind === 'msg')
+    isPg &&
+    !multiLive &&
+    !!owner?.workspace &&
+    isGitWorkspace(owner.workspace) &&
+    !session.steps.some((step) => step.kind === 'msg')
   const addAgentOptions = isPg
     ? agents
         .filter((a) => !liveRoster.some((p) => p.agentId === a.id))

--- a/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
@@ -15,6 +15,8 @@ const wire = vi.hoisted(() => ({
   listCalls: [] as Array<{ path: string; sessionId?: string }>,
   /** Whether the open session has a worktree of its own; a shared workspace must never be asked for one. */
   isolation: 'session' as 'session' | 'shared',
+  /** Which code host backs the checkout. Both are git, so both have session worktrees. */
+  workspaceMode: 'github' as 'github' | 'gitlab',
   /** The Git tab's two reads. A from-scratch workspace by default, so every case that predates the tab sees what it saw. */
   git: { isRepo: false } as unknown,
   log: { isRepo: false, commits: [], truncated: false, tracking: null } as unknown,
@@ -181,7 +183,7 @@ const session: Session = {
 
 vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({
-    agents: [agent],
+    agents: [{ ...agent, workspace: { ...agent.workspace, mode: wire.workspaceMode } }],
     allSessions: [
       {
         ...session,
@@ -306,6 +308,7 @@ beforeEach(() => {
   wire.fileCalls = []
   wire.listCalls = []
   wire.isolation = 'session'
+  wire.workspaceMode = 'github'
   wire.git = { isRepo: false }
   wire.log = { isRepo: false, commits: [], truncated: false, tracking: null }
   wire.diffCalls = []
@@ -485,6 +488,15 @@ describe('the collapsed-band overlay', () => {
 
 describe('the workspace scope both surfaces read', () => {
   it('reads this session\u2019s own worktree when it has one', async () => {
+    nav.search = 'file=src%2Fnotes.md'
+    await render()
+    expect(wire.fileCalls.at(-1)).toEqual({ path: 'src/notes.md', sessionId: 'session-1' })
+    expect(wire.listCalls[0]).toEqual({ path: '', sessionId: 'session-1' })
+  })
+
+  it('reads a GitLab checkout\u2019s own worktree too \u2014 the gate is git, not one host', async () => {
+    // The gate used to name GitHub, so a GitLab worktree session silently read the agent's PRIMARY checkout.
+    wire.workspaceMode = 'gitlab'
     nav.search = 'file=src%2Fnotes.md'
     await render()
     expect(wire.fileCalls.at(-1)).toEqual({ path: 'src/notes.md', sessionId: 'session-1' })

--- a/packages/web/src/components/console/views/SessionsView.gitlab.test.tsx
+++ b/packages/web/src/components/console/views/SessionsView.gitlab.test.tsx
@@ -16,7 +16,12 @@ import type { Session } from '@/lib/data'
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
-const mocks = vi.hoisted(() => ({ replace: vi.fn(), sessions: [] as unknown[], triggers: [] as unknown[] }))
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  sessions: [] as unknown[],
+  triggers: [] as unknown[],
+  integrations: ['hook'] as string[]
+}))
 
 vi.mock('next/link', () => ({
   default: ({ children, className }: { children: React.ReactNode; className?: string }) => (
@@ -59,7 +64,7 @@ vi.mock('@/lib/use-session-facets', () => ({
     data: {
       agentIds: [],
       agentNames: {},
-      integrations: ['hook'],
+      integrations: mocks.integrations,
       channels: [],
       triggers: mocks.triggers
     }
@@ -108,14 +113,14 @@ async function render() {
   })
 }
 
-/** Open the trigger dropdown — the filter row's selects share one class, so find it by its search box. */
-async function openTriggerMenu() {
+/** Open one filter dropdown — the row's selects share a class, so find it by its search box. */
+async function openFilterMenu(noun: string) {
   for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>('.selbtn'))) {
     await act(async () => button.click())
-    if (document.querySelector('input[aria-label="Filter triggers"]')) return
+    if (document.querySelector(`input[aria-label="Filter ${noun}"]`)) return
     await act(async () => button.click())
   }
-  throw new Error('trigger filter never opened')
+  throw new Error(`${noun} filter never opened`)
 }
 
 afterEach(async () => {
@@ -125,6 +130,7 @@ afterEach(async () => {
   host = undefined
   mocks.sessions = []
   mocks.triggers = []
+  mocks.integrations = ['hook']
   mocks.replace.mockClear()
 })
 
@@ -139,13 +145,32 @@ describe('SessionsView, GitLab triggers', () => {
     expect(document.body.textContent).toContain('acme/platform')
   })
 
+  it('offers GitLab as its own integration, separate from generic webhooks', async () => {
+    // The server-side facet is a first-class `gitlab` entry now; before that these
+    // sessions were counted under `hook` and read as "Webhook" in this menu.
+    mocks.sessions = [gitlabSession]
+    mocks.integrations = ['gitlab', 'hook']
+    await render()
+    await openFilterMenu('integrations')
+
+    const options = Array.from(document.querySelectorAll<HTMLButtonElement>('.fmenu button'))
+    const gitlab = options.find((option) => option.textContent?.includes('GitLab'))
+    expect(gitlab).toBeDefined()
+    // Negative control: the entry must be its own, not folded into the webhook one.
+    expect(options.filter((option) => option.textContent?.trim() === 'Webhook')).toHaveLength(1)
+    expect(gitlab!.querySelector('[data-platform-mark="gitlab"]')).not.toBeNull()
+
+    await act(async () => gitlab!.click())
+    expect(mocks.replace).toHaveBeenCalledWith('/acme/sessions?integration=gitlab')
+  })
+
   it('offers a GitLab trigger group and filters to the chosen subscription', async () => {
     mocks.sessions = [gitlabSession]
     mocks.triggers = [
       { value: 'hook:gl-1', integration: 'hook', name: 'acme/platform', hookKind: 'gitlab', githubRepoId: null }
     ]
     await render()
-    await openTriggerMenu()
+    await openFilterMenu('triggers')
 
     const headers = Array.from(document.querySelectorAll('.fhdr')).map((node) => node.textContent)
     expect(headers).toContain('GitLab')

--- a/packages/web/src/components/console/views/SessionsView.gitlab.test.tsx
+++ b/packages/web/src/components/console/views/SessionsView.gitlab.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+/**
+ * A GitLab-triggered session is a CODE-HOST session, not a generic webhook.
+ *
+ * The CP has always been able to answer `hookKind: 'gitlab'`; the console typed the
+ * field as `webhook | github`, so those rows folded into the webhook rendering and
+ * fell out of the trigger filter entirely — `sessionTriggerKind` returned a value
+ * no `switch` arm collected, so the facet was silently dropped. These tests pin
+ * both halves: the row renders under the GitLab mark, and the trigger menu offers
+ * a GitLab group that filters to it.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Session } from '@/lib/data'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const mocks = vi.hoisted(() => ({ replace: vi.fn(), sessions: [] as unknown[], triggers: [] as unknown[] }))
+
+vi.mock('next/link', () => ({
+  default: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <a className={className}>{children}</a>
+  )
+}))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+  useSearchParams: () => new URLSearchParams()
+}))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, orgPath: (path: string) => `/acme${path}` })
+}))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/components/console/PlaygroundProvider', () => ({ usePlayground: () => ({ pgSessionList: [] }) }))
+vi.mock('@/components/console/Shell', () => ({ useMobileFilterSlot: () => ({ register: () => undefined }) }))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    agents: [],
+    allSessions: [],
+    crons: [],
+    members: [],
+    sessionFacets: { agentIds: [], agentNames: {}, integrations: [], channels: [], triggers: [] }
+  })
+}))
+vi.mock('@/lib/use-session-list', () => ({
+  useSessionList: () => ({
+    sessions: mocks.sessions,
+    total: mocks.sessions.length,
+    nextCursor: null,
+    loadingMore: false,
+    loadMore: () => undefined,
+    isLoading: false,
+    isValidating: false
+  }),
+  sessionFilterAgentKey: () => ''
+}))
+vi.mock('@/lib/use-session-facets', () => ({
+  useSessionFacets: () => ({
+    data: {
+      agentIds: [],
+      agentNames: {},
+      integrations: ['hook'],
+      channels: [],
+      triggers: mocks.triggers
+    }
+  })
+}))
+// Real marks would all render as anonymous <svg> paths; these stubs name which one ran.
+vi.mock('@/components/marks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/components/marks')>()),
+  AgentIconView: () => <span />,
+  GithubMark: () => <span data-mark="github" />,
+  GitlabMark: () => <span data-mark="gitlab" />,
+  PlatformMark: ({ platform }: { platform: string }) => <span data-platform-mark={platform} />
+}))
+
+const SessionsView = (await import('./SessionsView')).default
+
+const gitlabSession = {
+  id: 'sess-1',
+  agentId: 'agent-a',
+  agentName: 'build-agent',
+  title: 'Fix the failing pipeline',
+  status: 'done',
+  statusLabel: 'done',
+  time: '2m',
+  lastActivityAt: '2026-08-22T09:00:00.000Z',
+  platform: 'hook',
+  channel: 'acme/platform',
+  hookKind: 'gitlab',
+  triggeredBy: 'hook:gl-1',
+  user: 'acme/platform',
+  runtime: 'claude',
+  model: 'default',
+  cost: '$0.00',
+  tokens: '0'
+} as unknown as Session
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+async function render() {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(<SessionsView />)
+  })
+}
+
+/** Open the trigger dropdown — the filter row's selects share one class, so find it by its search box. */
+async function openTriggerMenu() {
+  for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>('.selbtn'))) {
+    await act(async () => button.click())
+    if (document.querySelector('input[aria-label="Filter triggers"]')) return
+    await act(async () => button.click())
+  }
+  throw new Error('trigger filter never opened')
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  mocks.sessions = []
+  mocks.triggers = []
+  mocks.replace.mockClear()
+})
+
+describe('SessionsView, GitLab triggers', () => {
+  it('renders a gitlab-hook session under the GitLab mark, not the generic webhook one', async () => {
+    mocks.sessions = [gitlabSession]
+    await render()
+
+    expect(document.querySelector('[data-platform-mark="gitlab"]')).not.toBeNull()
+    // Negative control: before the fix this row folded to the raw 'hook' platform.
+    expect(document.querySelector('[data-platform-mark="hook"]')).toBeNull()
+    expect(document.body.textContent).toContain('acme/platform')
+  })
+
+  it('offers a GitLab trigger group and filters to the chosen subscription', async () => {
+    mocks.sessions = [gitlabSession]
+    mocks.triggers = [
+      { value: 'hook:gl-1', integration: 'hook', name: 'acme/platform', hookKind: 'gitlab', githubRepoId: null }
+    ]
+    await render()
+    await openTriggerMenu()
+
+    const headers = Array.from(document.querySelectorAll('.fhdr')).map((node) => node.textContent)
+    expect(headers).toContain('GitLab')
+    // Negative control: a gitlab facet must not be collected as a plain webhook.
+    const webhookGroup = Array.from(document.querySelectorAll('.fhdr')).find((n) => n.textContent === 'Webhooks')
+    expect(webhookGroup).toBeUndefined()
+
+    const gitlabGroup = Array.from(document.querySelectorAll('.fhdr')).find(
+      (n) => n.textContent === 'GitLab'
+    )!.parentElement!
+    expect(gitlabGroup.querySelector('[data-mark="gitlab"]')).not.toBeNull()
+
+    const option = Array.from(gitlabGroup.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('acme/platform')
+    )!
+    await act(async () => option.click())
+    expect(mocks.replace).toHaveBeenCalledWith('/acme/sessions?trigger=hook%3Agl-1')
+  })
+})

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -25,7 +25,8 @@ import {
   githubRepoIdFromSessionTriggerFilter,
   sessionSenderLabel,
   sessionTriggerFilterValue,
-  sessionTriggerKind
+  sessionTriggerKind,
+  type SessionTriggerKind
 } from '@/lib/session-trigger'
 import { useConsoleData } from '@/lib/data-context'
 import { useSessionFacets } from '@/lib/use-session-facets'
@@ -34,7 +35,7 @@ import { isFlatSessionView, sessionListSearchParams } from '@/lib/session-list-v
 import { useProfile } from '@/lib/profile'
 import { usePlayground } from '@/components/console/PlaygroundProvider'
 import { useMobileFilterSlot } from '@/components/console/Shell'
-import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
+import { AgentIconView, GithubMark, GitlabMark, LoadingState, PlatformMark } from '@/components/marks'
 import { RestrictedLock } from '@/components/console/VisibilityField'
 import { Avatar, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
@@ -280,10 +281,11 @@ export default function SessionsView() {
   }
   // Triggerers are keyed by raw triggeredBy id so same-named entries stay distinct.
   // Agent ids resolve only through the caller-visible agent roster; hook sessions use
-  // their CP-enriched source kind to keep GitHub distinct from generic webhooks.
+  // their CP-enriched source kind to keep each code host distinct from generic webhooks.
   const triggerAgentSet = new Map<string, Agent>()
   const peopleSet = new Map<string, { label: string; platform: string; member?: MemberDto }>()
   const githubSet = new Map<string, string>()
+  const gitlabSet = new Map<string, string>()
   const webhookSet = new Map<string, string>()
   const cronSet = new Map<string, string>()
   for (const [triggeredBy, source] of triggerSources) {
@@ -296,6 +298,11 @@ export default function SessionsView() {
       }
       case 'github':
         if (!githubSet.has(source.filterValue)) githubSet.set(source.filterValue, label)
+        break
+      // No per-project collapse: the CP indexes a numeric repo id for GitHub only,
+      // so a GitLab subscription filters by its own trigger value like a webhook.
+      case 'gitlab':
+        gitlabSet.set(triggeredBy, label)
         break
       case 'webhook':
         webhookSet.set(triggeredBy, label)
@@ -427,6 +434,18 @@ export default function SessionsView() {
       )
     }))
     .sort(byLabel)
+  const triggerGitlab: FilterOption[] = [...gitlabSet]
+    .map(([v, label]) => ({
+      v,
+      label,
+      kind: 'gitlab' as const,
+      face: (
+        <span className="flex h-[15px] w-[15px] items-center justify-center">
+          <GitlabMark color="var(--text-tertiary)" />
+        </span>
+      )
+    }))
+    .sort(byLabel)
   const triggerWebhooks: FilterOption[] = [...webhookSet]
     .map(([v, label]) => ({ v, label, kind: 'webhook' as const, face: catFace('webhook') }))
     .sort(byLabel)
@@ -437,6 +456,7 @@ export default function SessionsView() {
     { label: 'Agents', options: triggerAgents },
     { label: 'People', options: triggerPeople },
     { label: 'GitHub', options: triggerGithub },
+    { label: 'GitLab', options: triggerGitlab },
     { label: 'Webhooks', options: triggerWebhooks },
     { label: 'Schedules', options: triggerScheds }
   ]
@@ -445,6 +465,7 @@ export default function SessionsView() {
     ...triggerAgents,
     ...triggerPeople,
     ...triggerGithub,
+    ...triggerGitlab,
     ...triggerWebhooks,
     ...triggerScheds
   ]
@@ -813,7 +834,8 @@ type FilterOption = {
   // left/right). Defaults to `face`; channels override it to the platform mark
   // (their desktop `face` is the `#` glyph, but the pill wants the platform).
   pillFace?: ReactNode
-  kind?: 'agent' | 'person' | 'github' | 'webhook' | 'schedule'
+  /** The trigger category this option came from — one vocabulary with `sessionTriggerKind`. */
+  kind?: SessionTriggerKind
 }
 type FilterGroup = { label: string; options: FilterOption[] }
 

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -230,8 +230,8 @@ export function GitlabMark({ color = 'currentColor', fillPct = 60 }: { color?: s
 }
 
 /**
- * A mark for one integration surface. The CORE kinds (github / webhook / schedule
- * / memory dream / playground+webchat) are the host's own; the four chat platforms
+ * A mark for one integration surface. The CORE kinds (github / gitlab / webhook /
+ * schedule / memory dream / playground+webchat) are the host's own; the chat platforms
  * come from their modules (§10 {@link WebPlatformModule.Mark}) through the light
  * `platforms/marks` lookup — see the note there on why this is not a read through
  * `platformRegistry`.
@@ -255,6 +255,10 @@ export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fil
   const sq = squareMarkBox(fillPct)
   if (x.includes('github')) {
     return <SiGithub style={sq} color="currentColor" aria-hidden />
+  }
+  // The other code host, capped the same way: the tanuki is a full-bleed glyph too.
+  if (x.includes('gitlab')) {
+    return <SiGitlab style={sq} color="currentColor" aria-hidden />
   }
   if (x.includes('hook')) {
     return <IconifyIcon icon={webhooksLogoFillIcon} style={s} color="var(--brand)" aria-hidden />

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -414,7 +414,7 @@ export interface SessionDto {
   externalProvider?: string | null
   externalResolution?: 'pending' | 'settled' | 'invalid' | null
   triggeredBy: string | null
-  hookKind?: 'webhook' | 'github' | null
+  hookKind?: HookKind | null
   // Daemon-resolved display names; null until the daemon has resolved them.
   channelName: string | null
   triggeredByName: string | null
@@ -457,7 +457,7 @@ export interface SessionFacetsDto {
     value: string
     integration: string
     name: string | null
-    hookKind: 'webhook' | 'github' | null
+    hookKind: HookKind | null
     githubRepoId: string | null
   }>
 }
@@ -524,7 +524,7 @@ export interface SessionFacets {
     value: string
     name?: string
     platform: string
-    hookKind?: 'webhook' | 'github'
+    hookKind?: HookKind
     githubRepoId?: string
   }>
 }
@@ -565,7 +565,7 @@ export interface SessionDetailDto {
   usage: SessionUsageDto | null
   triggeredBy: string | null
   /** Stable source kind for hook-backed sessions. Absent on older Control Planes. */
-  hookKind?: 'webhook' | 'github' | null
+  hookKind?: HookKind | null
   channelName: string | null
   triggeredByName: string | null
   threadUrl: string | null
@@ -1869,8 +1869,8 @@ export function agentFromDto(d: AgentDto): Agent {
     daemon: placementValueOf(d) ?? PLACEHOLDER,
     ...(d.daemonName ? { daemonName: d.daemonName } : {}),
     region: PLACEHOLDER,
-    repo: ws.mode === 'github' ? ws.repo : PLACEHOLDER,
-    workdir: ws.mode === 'github' ? ws.agentDir : PLACEHOLDER,
+    repo: ws.mode !== 'scratch' ? ws.repo : PLACEHOLDER,
+    workdir: ws.mode !== 'scratch' ? ws.agentDir : PLACEHOLDER,
     // A paused agent reads as "paused" regardless of placement — pause is a deliberate
     // operator state, orthogonal to online/offline. Gives the "Paused" filter tab meaning.
     status: d.pause ? 'paused' : toStatusKey(d.status),

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -253,6 +253,17 @@ export type AgentWorkspaceDto =
       installationId?: string
       gitAccess?: 'read' | 'write'
     }
+  | {
+      // A managed GitLab project binding. `projectId` is what a caller sends; the
+      // clone address comes back derived from the binding and is never supplied.
+      mode: 'gitlab'
+      worktree?: boolean
+      projectId?: string
+      gitRepo?: string
+      gitBranch?: string
+      agentDir?: string
+      gitAccess?: 'read' | 'write'
+    }
 
 export interface ExternalMemoryRecallPolicy {
   mode: 'auto' | 'tool-only'
@@ -343,7 +354,7 @@ export interface AgentDto {
   runInSandbox: boolean // #642: persisted per-agent Run in sandbox preference
   sandboxSupported: boolean // #642: whether the placed daemon can provide an OS sandbox
   sandboxRequired: boolean // #642: whether daemon policy forces the effective value on
-  hookKinds: ('webhook' | 'github')[] // distinct kinds of enabled inbound triggers (list-view marks)
+  hookKinds: HookKind[] // distinct kinds of enabled inbound triggers (list-view marks)
 }
 
 /** The `PUT /{agents,daemons,crons}/:id/sharing` request body. */
@@ -968,6 +979,16 @@ export type SetAgentWorkspaceInput =
       worktree?: boolean
       repoFullName: string
       /** Absent lets the server use GitHub's current default branch. */
+      gitBranch?: string
+      agentDir?: string
+      gitAccess: 'read' | 'write'
+    }
+  | {
+      mode: 'gitlab'
+      worktree?: boolean
+      /** Numeric GitLab project id of a managed binding in this organization. */
+      projectId: string
+      /** Absent lets the server use the project's current default branch. */
       gitBranch?: string
       agentDir?: string
       gitAccess: 'read' | 'write'
@@ -1711,6 +1732,26 @@ export function repoWebUrl(gitRepo: string): string | undefined {
 // The CP does not surface git state (commit/pull/dirty/files), so those render
 // as placeholders / empty until a daemon read model exists.
 function workspaceFromDto(w: AgentWorkspaceDto, workspaceRepoId?: string | null): Workspace {
+  if (w.mode === 'gitlab') {
+    // The clone address is the binding's, so the namespaced path is what it labels.
+    const gitRepo = w.gitRepo ?? ''
+    return {
+      mode: 'gitlab',
+      worktree: w.worktree === true,
+      ...((w.projectId ?? workspaceRepoId) ? { projectId: (w.projectId ?? workspaceRepoId)! } : {}),
+      repo: repoLabel(gitRepo),
+      ...(repoWebUrl(gitRepo) ? { repoUrl: repoWebUrl(gitRepo) } : {}),
+      ...(w.gitAccess ? { gitAccess: w.gitAccess } : {}),
+      branch: w.gitBranch || 'main',
+      agentDir: w.agentDir || '/',
+      lastPull: PLACEHOLDER,
+      commit: PLACEHOLDER,
+      commitMsg: '',
+      commitTime: '',
+      clean: true,
+      files: []
+    }
+  }
   if (w.mode === 'github') {
     return {
       mode: 'github',
@@ -3782,7 +3823,12 @@ export async function deleteIntegration(id: string): Promise<void> {
 
 // A hook definition row. `url` is the full public ingress URL (relay-pool based),
 // a capability URL the CP surfaces only to callers with edit rights.
+export type HookKind = 'webhook' | 'github' | 'gitlab'
 export type GithubCommentFamily = 'issues' | 'pull_request'
+/** GitLab's own note families — the merge-request counterpart of a pull request. */
+export type GitlabCommentFamily = 'issues' | 'merge_request'
+/** The stored union across code hosts; each row carries only its own host's subset. */
+export type HookCommentFamily = GithubCommentFamily | GitlabCommentFamily
 export type HookReviewPolicy = 'off' | 'comment' | 'request_changes' | 'full'
 // R2a intentionally exposes informational Checks only. `status` is R3.
 export type HookReportingMode = 'off' | 'check'
@@ -3792,17 +3838,17 @@ export type HookGateMode = 'informational'
 export interface HookDto {
   id: string
   agentId: string | null // null ⇒ orphaned by agent delete (inert)
-  kind: 'webhook' | 'github'
+  kind: HookKind
   name: string
   sessionMode: 'perDelivery' | 'perThread' | 'shared'
   enabled: boolean
   url: string | null
   hmacConfigured: boolean
-  // ── github kind ── repo + subscription (empty/null on webhook kind)
-  repoId?: string | null
-  repoFullName: string | null // canonical owner/repo as GitHub cases it
-  events: string[] // 'issues:*' / 'issue_comment:created' / …
-  commentFamilies: GithubCommentFamily[] // thread kinds whose replies may fire this hook
+  // ── code-host kinds ── repo/project + subscription (empty/null on webhook kind)
+  repoId?: string | null // GitHub numeric repo id, or the GitLab numeric project id
+  repoFullName: string | null // owner/repo as GitHub cases it, or the GitLab project path
+  events: string[] // 'issues:*' / 'issue_comment:created' / 'merge_request:*' / …
+  commentFamilies: HookCommentFamily[] // thread kinds whose replies may fire this hook
   labelFilter: string[]
   mentionOnly: boolean // P3: authored event text must @-mention the agent or App
   configRevision: string // BigInt JSON/wire form; CP-owned, monotonic
@@ -3857,6 +3903,19 @@ export interface CreateGithubHookInput {
   gateMode?: HookGateMode
 }
 
+// gitlab kind: the project must already be a managed binding in the org — the CP
+// validates the numeric id against its own row and derives the path from it.
+export interface CreateGitlabHookInput {
+  agentId: string
+  name: string
+  enabled?: boolean
+  projectId: string // numeric GitLab project id
+  events: string[] // 'issues:*' / 'merge_request:*' / 'push:*' — at least one
+  commentFamilies?: GitlabCommentFamily[]
+  labelFilter?: string[]
+  mentionOnly?: boolean
+}
+
 // A hook is subordinate to its agent (like an Integration), so there is no
 // org-wide hook list — you fetch ONE agent's hooks, gated server-side by that
 // agent's visibility (404 for an agent you can't see).
@@ -3885,6 +3944,19 @@ export async function createGithubHook(input: CreateGithubHookInput): Promise<Cr
 // The body re-sends the full github block — PUT is whole-definition.
 export async function updateGithubHook(id: string, input: CreateGithubHookInput): Promise<HookDto> {
   return apiPut<HookDto>(`${orgBase()}/hooks/${encodeURIComponent(id)}`, { kind: 'github', ...input })
+}
+
+// GitLab subscription — no URL, no secret: the managed project webhook signs its
+// own deliveries. Events ride through the relay, one session per issue/MR thread.
+export async function createGitlabHook(input: CreateGitlabHookInput): Promise<CreatedHookDto> {
+  const hook = await apiPost<CreatedHookDto>(`${orgBase()}/hooks`, { kind: 'gitlab', ...input })
+  track('hook_created', { org_id: apiOrgId, agent_id: hook.agentId, hook_kind: hook.kind, hook_id: hook.id })
+  return hook
+}
+
+// Update a gitlab hook's subscription. Whole-definition PUT, like the github one.
+export async function updateGitlabHook(id: string, input: CreateGitlabHookInput): Promise<HookDto> {
+  return apiPut<HookDto>(`${orgBase()}/hooks/${encodeURIComponent(id)}`, { kind: 'gitlab', ...input })
 }
 
 export async function deleteHook(id: string): Promise<void> {

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -43,6 +43,7 @@ import {
   fetchIntegrations,
   createHook as apiCreateHook,
   createGithubHook as apiCreateGithubHook,
+  createGitlabHook as apiCreateGitlabHook,
   deleteHook as apiDeleteHook,
   fetchBots,
   deleteBot as apiDeleteBot,
@@ -112,6 +113,7 @@ import {
   type CreatedHookDto,
   type CreateHookInput,
   type CreateGithubHookInput,
+  type CreateGitlabHookInput,
   type BotDto,
   type UpsertCronInput,
   type CronDto,
@@ -231,6 +233,9 @@ interface ConsoleData {
   /** Create a GitHub subscription hook (no URL/secret — events ride the relay),
    *  then invalidate its agent's hook cache. */
   createGithubHook: (input: CreateGithubHookInput) => Promise<CreatedHookDto>
+  /** Create a GitLab subscription hook against a managed project binding, then
+   *  invalidate its agent's hook cache. */
+  createGitlabHook: (input: CreateGitlabHookInput) => Promise<CreatedHookDto>
   /** Delete a hook (its ingress URL dies with it), then invalidate its agent's hook cache. */
   deleteHook: (id: string, agentId?: string | null) => Promise<void>
   /** Per-conversation trigger choice (PATCH), applied to the local row on success. */
@@ -1167,6 +1172,18 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     [mutateCache, orgKey]
   )
 
+  // GitLab subscription — the CP validates the numeric project id against the
+  // organization's own managed binding before it writes anything.
+  const createGitlabHook = useCallback(
+    async (input: CreateGitlabHookInput): Promise<CreatedHookDto> => {
+      const created = await apiCreateGitlabHook(input)
+      const hooksKey = consoleKeys.agentHooks(orgKey, input.agentId)
+      if (hooksKey) settleInBackground(mutateCache(hooksKey))
+      return created
+    },
+    [mutateCache, orgKey]
+  )
+
   const deleteHook = useCallback(
     async (id: string, agentId?: string | null) => {
       await apiDeleteHook(id)
@@ -1586,6 +1603,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       deleteIntegration,
       createHook,
       createGithubHook,
+      createGitlabHook,
       deleteHook,
       deleteBot,
       setChannelTrigger,
@@ -1666,6 +1684,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       deleteIntegration,
       createHook,
       createGithubHook,
+      createGitlabHook,
       deleteHook,
       deleteBot,
       setChannelTrigger,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -348,7 +348,18 @@ export interface ScratchWorkspace {
   files: WorkspaceFile[]
 }
 
-export type Workspace = GithubWorkspace | GitlabWorkspace | ScratchWorkspace
+/** A workspace backed by a git checkout, on either code host. */
+export type GitWorkspace = GithubWorkspace | GitlabWorkspace
+
+export type Workspace = GitWorkspace | ScratchWorkspace
+
+/** Whether the workspace is a clone rather than an empty directory. Everything that
+ *  reads a checkout — the files view, session worktrees, branch scope — keys off this
+ *  rather than off one code host's name, which is how GitLab workspaces used to read
+ *  as scratch. Host-specific facts (App installations, repo grants) still ask by mode. */
+export function isGitWorkspace(ws: Pick<Workspace, 'mode'>): ws is GitWorkspace {
+  return ws.mode !== 'scratch'
+}
 
 export interface WorkspaceStatusInfo {
   dot: string
@@ -447,9 +458,10 @@ export interface Agent {
   /** Display name projected with the Agent; available even when the daemon itself is not visible. */
   daemonName?: string
   region: string
-  /** Convenience mirror of the workspace for list views: github repo, else '—'. */
+  /** Convenience mirror of the workspace for list views: the cloned repository or
+   *  project path on either code host, else '—'. */
   repo: string
-  /** On-disk working dir (github agentDir or the scratch path). */
+  /** On-disk working dir (the checkout's agentDir, or the scratch path). */
   workdir: string
   status: StatusKey
   tokens: string
@@ -1070,7 +1082,7 @@ export interface Session {
    *  fire. Lets the Sessions list link a run back to its schedule. */
   triggeredBy?: string
   /** Stable source kind for a `hook:<id>` trigger, enriched by the Control Plane. */
-  hookKind?: 'webhook' | 'github'
+  hookKind?: HookKind
   /** Session-level visibility (lock badge / detail toggle). Absent on mock and
    *  pre-feature CP rows — treated as 'org', matching the server-side backfill. */
   visibility?: 'private' | 'org' | 'external'
@@ -2130,8 +2142,8 @@ export const MEMBERS: Member[] = [
  * A platform's display name.
  *
  * The CORE kinds are matched by SUBSTRING because their ids are synthesized in
- * several places (`sessionPlatform` folds playground→webchat and hook+github→
- * github; `sessionChannelDisplay` mints `schedule`); order is load-bearing, since
+ * several places (`sessionPlatform` folds playground→webchat and hook+code-host→
+ * that host; `sessionChannelDisplay` mints `schedule`); order is load-bearing, since
  * `hook` must be tested before `web` or `webhook` would read as "Playground".
  * The four CHAT platforms are an exact-id lookup into the one shared label table
  * (`lib/platform-labels.ts`) — their ids come off the wire, where the vocabulary
@@ -2141,6 +2153,7 @@ export function platName(p: string): string {
   const x = (p || '').toLowerCase()
   if (x.includes('sched')) return 'Schedule'
   if (x.includes('github')) return 'GitHub'
+  if (x.includes('gitlab')) return 'GitLab'
   if (x.includes('dream')) return 'Memory dream'
   if (x.includes('hook')) return 'Webhook'
   // 'playground' (live sandbox) and 'webchat' (its persisted CP session) are the same
@@ -2155,11 +2168,13 @@ export function platName(p: string): string {
   return p.charAt(0).toUpperCase() + p.slice(1)
 }
 
-/** A session's display integration. GitHub is a hook source rather than a
- * routing Platform, so the CP supplies its stable hook kind explicitly. */
-export function sessionPlatform(s: { platform: string; hookKind?: 'webhook' | 'github' }): string {
+/** A session's display integration. The code hosts are hook sources rather than
+ * routing Platforms, so the CP supplies the stable hook kind explicitly — without
+ * it a GitLab session would render as a generic webhook. */
+export function sessionPlatform(s: { platform: string; hookKind?: HookKind }): string {
   if (s.platform === 'playground') return 'webchat'
-  return s.platform === 'hook' && s.hookKind === 'github' ? 'github' : s.platform
+  if (s.platform !== 'hook') return s.platform
+  return s.hookKind === 'github' || s.hookKind === 'gitlab' ? s.hookKind : s.platform
 }
 
 /** Channel-cell identity (mark + label) for a session row. A headless schedule
@@ -2168,7 +2183,7 @@ export function sessionPlatform(s: { platform: string; hookKind?: 'webhook' | 'g
  * schedule mark instead of a raw uuid with a Slack icon. `cronName` looks up
  * the schedule (the crons list may still be loading → short-id fallback). */
 export function sessionChannelDisplay(
-  s: { platform: string; channel: string; hookKind?: 'webhook' | 'github' },
+  s: { platform: string; channel: string; hookKind?: HookKind },
   cronName: (id: string) => string | null | undefined
 ): { platform: string; label: string } {
   if (s.channel.startsWith('cron:')) {
@@ -2186,7 +2201,7 @@ export function sessionChannelFilterValue(s: {
   platform: string
   channel: string
   channelId?: string
-  hookKind?: 'webhook' | 'github'
+  hookKind?: HookKind
 }): string {
   return sessionPlatform(s) === 'webchat' ? PLAYGROUND_CHANNEL_FILTER : (s.channelId ?? s.channel)
 }

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -2,7 +2,7 @@
 // Ported from the AgentConnect design (static demo content for the console UI).
 
 import type { AgentIcon } from '@/lib/agent-icon'
-import type { DaemonSessionRetention, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
+import type { DaemonSessionRetention, HookKind, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { platformLabel } from '@/lib/platform-labels'
 import { randomUuid } from '@/lib/random-uuid'
@@ -334,6 +334,13 @@ export interface GithubWorkspace {
   files: WorkspaceFile[]
 }
 
+/** A managed GitLab project checkout — the same git shape, keyed by project id. */
+export interface GitlabWorkspace extends Omit<GithubWorkspace, 'mode' | 'repoId' | 'installationId'> {
+  mode: 'gitlab'
+  /** Numeric GitLab project id — rename-stable, unlike the namespaced path. */
+  projectId?: string
+}
+
 export interface ScratchWorkspace {
   mode: 'scratch'
   created: string
@@ -341,7 +348,7 @@ export interface ScratchWorkspace {
   files: WorkspaceFile[]
 }
 
-export type Workspace = GithubWorkspace | ScratchWorkspace
+export type Workspace = GithubWorkspace | GitlabWorkspace | ScratchWorkspace
 
 export interface WorkspaceStatusInfo {
   dot: string
@@ -479,7 +486,7 @@ export interface Agent {
   sandboxRequired: boolean
   integrations: Integration[]
   /** Distinct kinds of enabled inbound triggers (hooks) — list-view marks. */
-  hookKinds?: ('webhook' | 'github')[]
+  hookKinds?: HookKind[]
   workspace: Workspace
 }
 

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -1,4 +1,4 @@
-import type { GithubCommentFamily } from './api'
+import type { GithubCommentFamily, HookCommentFamily } from './api'
 
 /**
  * GitHub subscription event model shared by the Add-integration form and the
@@ -94,6 +94,11 @@ export const GH_DEFAULT_TRIGGER_MODE: GhTriggerMode = 'every'
 /** The comment subscription that rides updated/mention-only modes for thread families. */
 export const THREAD_COMMENT_EVENT = 'issue_comment:created'
 
+/** Narrow a stored cross-host comment scope to the GitHub families a github hook may carry. */
+export function githubCommentFamilies(families: readonly HookCommentFamily[]): GithubCommentFamily[] {
+  return families.filter((family): family is GithubCommentFamily => family === 'issues' || family === 'pull_request')
+}
+
 /** Derive the explicit comment scope from the selected issue/PR families. */
 export function commentFamiliesForFamilies(fams: Iterable<GhFamily>): GithubCommentFamily[] {
   return [...fams].filter((fam): fam is GithubCommentFamily => fam === 'issues' || fam === 'pull_request')
@@ -126,7 +131,7 @@ export function triggerModeOf(h: { events: string[]; mentionOnly: boolean }): Gh
  *  same-cadence selection normalize them instead of returning early. */
 export function githubHookNeedsNormalization(h: {
   events: string[]
-  commentFamilies: GithubCommentFamily[]
+  commentFamilies: readonly HookCommentFamily[]
   mentionOnly: boolean
 }): boolean {
   const families = GH_FAMILIES.map((family) => family.fam).filter((family) => famCovered(h.events, family))
@@ -141,6 +146,6 @@ export function githubHookNeedsNormalization(h: {
   }
   return (
     !sameMembers(h.events, eventsForFamilies(families, mode)) ||
-    !sameMembers(h.commentFamilies, commentFamiliesForFamilies(families))
+    !sameMembers(githubCommentFamilies(h.commentFamilies), commentFamiliesForFamilies(families))
   )
 }

--- a/packages/web/src/lib/github-review-settings.ts
+++ b/packages/web/src/lib/github-review-settings.ts
@@ -129,7 +129,7 @@ interface WorkspaceRepoMatchInput {
   repoId?: string | null
   repoFullName: string | null | undefined
   workspace: {
-    mode: 'github' | 'scratch'
+    mode: 'github' | 'gitlab' | 'scratch'
     repoId?: string
     repo?: string
     installationId?: string
@@ -158,7 +158,7 @@ export function effectiveRepoAccess(input: {
   repoId?: string | null
   repoFullName: string | null | undefined
   workspace: {
-    mode: 'github' | 'scratch'
+    mode: 'github' | 'gitlab' | 'scratch'
     repoId?: string
     repo?: string
     installationId?: string

--- a/packages/web/src/lib/gitlab-events.ts
+++ b/packages/web/src/lib/gitlab-events.ts
@@ -1,0 +1,60 @@
+/**
+ * GitLab subscription vocabulary, the counterpart of `github-events.ts`.
+ *
+ * The console works in SUBJECT families (issues / merge requests / pushes) and,
+ * independently, in NOTE families — which conversations a reply may fire the
+ * agent from. Both are stored plainly: a subject family becomes a `family:*`
+ * pattern, a note family stays in `commentFamilies`, and `mentionOnly` narrows
+ * every one of them to authored text that @-mentions the agent.
+ *
+ * The wire accepts finer `family:action` patterns; these helpers never emit one.
+ */
+
+import type { GitlabCommentFamily } from './api'
+
+export type GlFamily = 'issues' | 'merge_request' | 'push'
+
+export const GL_FAMILIES: { fam: GlFamily; pill: string; icon: string; label: string; desc: string }[] = [
+  { fam: 'issues', pill: 'Issues', icon: 'circle-dot', label: 'Issues', desc: 'opened, updated, labelled' },
+  {
+    fam: 'merge_request',
+    pill: 'MRs',
+    icon: 'git-pull-request',
+    label: 'Merge requests',
+    desc: 'opened, updated, merged'
+  },
+  { fam: 'push', pill: 'Pushes', icon: 'git-commit-horizontal', label: 'Pushes', desc: 'commits pushed to a branch' }
+]
+
+/** The note families a reply can arrive on — pushes carry no conversation. */
+export const GL_COMMENT_FAMILIES: { fam: GitlabCommentFamily; label: string }[] = [
+  { fam: 'issues', label: 'Issues' },
+  { fam: 'merge_request', label: 'Merge requests' }
+]
+
+/** The default create-form selection: merge requests only. */
+export const GL_DEFAULT_FAMILIES: readonly GlFamily[] = ['merge_request']
+
+/** Compile the console's family choice into stored event patterns, in display
+ *  order — a hook's stored events must not depend on the order boxes were ticked. */
+export function eventsForGitlabFamilies(families: Iterable<GlFamily>): string[] {
+  const picked = new Set(families)
+  return GL_FAMILIES.filter((family) => picked.has(family.fam)).map((family) => `${family.fam}:*`)
+}
+
+/** Whether a hook's stored events cover a family (any action pattern counts). */
+export function gitlabFamCovered(events: readonly string[], family: GlFamily): boolean {
+  return events.some((event) => event.startsWith(`${family}:`))
+}
+
+/** Split a comma or whitespace separated label filter into the stored array. */
+export function parseLabelFilter(input: string): string[] {
+  return [
+    ...new Set(
+      input
+        .split(',')
+        .map((label) => label.trim())
+        .filter(Boolean)
+    )
+  ]
+}

--- a/packages/web/src/lib/gitlab-projects.ts
+++ b/packages/web/src/lib/gitlab-projects.ts
@@ -1,0 +1,34 @@
+/**
+ * How the console words a managed GitLab project binding, shared by the
+ * Connections card and the pickers that pick one (a workspace, a hook).
+ *
+ * The vocabulary names the broken half in GitLab terms, never the internal
+ * state id, and the selectability rule is the one product answer: a project is
+ * pickable once it exists on GitLab, even when its setup finished only partly.
+ * Setup and removal are transient — offering either would attach an agent to a
+ * project that is about to change underneath it.
+ */
+
+import type { GitlabProjectBindingDto, GitlabProjectBindingState } from './api'
+
+export const GITLAB_PROJECT_STATE: Record<GitlabProjectBindingState, { label: string; badge: string }> = {
+  provisioning: { label: 'setting up', badge: 'bg-(--status-info-soft) text-(--status-info)' },
+  ready: { label: 'ready', badge: 'bg-(--status-online-soft) text-(--status-online)' },
+  admin_degraded: { label: 'setup incomplete', badge: 'bg-(--status-paused-soft) text-(--amber-500)' },
+  runtime_degraded: { label: 'bot access degraded', badge: 'bg-(--status-paused-soft) text-(--amber-500)' },
+  cleanup_pending: { label: 'removal incomplete', badge: 'bg-(--status-error-soft) text-(--status-error)' }
+}
+
+/** Whether a binding may be attached to an agent workspace or a hook. */
+export function gitlabProjectSelectable(state: GitlabProjectBindingState): boolean {
+  return state === 'ready' || state === 'admin_degraded' || state === 'runtime_degraded'
+}
+
+/** Filter a project list by the picker's search box — path substring, case-insensitive. */
+export function matchGitlabProjects(
+  projects: readonly GitlabProjectBindingDto[],
+  query: string
+): GitlabProjectBindingDto[] {
+  const wanted = query.trim().toLowerCase()
+  return projects.filter((project) => !wanted || project.projectPath.toLowerCase().includes(wanted))
+}

--- a/packages/web/src/lib/session-trigger.ts
+++ b/packages/web/src/lib/session-trigger.ts
@@ -1,6 +1,7 @@
 import { isSelfSender } from './data'
+import type { HookKind } from './api'
 
-export type SessionTriggerKind = 'agent' | 'person' | 'github' | 'webhook' | 'schedule'
+export type SessionTriggerKind = 'agent' | 'person' | 'github' | 'gitlab' | 'webhook' | 'schedule'
 
 type IdLookup = { has(id: string): boolean }
 const GITHUB_REPO_TRIGGER_PREFIX = 'github-repo:'
@@ -64,9 +65,11 @@ export function sessionTranscriptAgentIds(
   return authors
 }
 
+/** GitHub subscriptions collapse per repository — the CP indexes their numeric repo id.
+ *  Every other trigger, GitLab included, filters by its own raw `hook:<id>` value. */
 export function sessionTriggerFilterValue(trigger: {
   value: string
-  hookKind?: 'webhook' | 'github'
+  hookKind?: HookKind
   githubRepoId?: string
 }): string {
   return trigger.hookKind === 'github' && trigger.githubRepoId
@@ -81,7 +84,7 @@ export function githubRepoIdFromSessionTriggerFilter(value: string): string | un
 }
 
 export function sessionTriggerKind(
-  session: { triggeredBy?: string; hookKind?: 'webhook' | 'github' },
+  session: { triggeredBy?: string; hookKind?: HookKind },
   agentIds: IdLookup
 ): SessionTriggerKind | null {
   const trigger = session.triggeredBy


### PR DESCRIPTION
The second console slice of [gitlab-com-integration.md](docs/designs/gitlab-com-integration.md) §18.1, after #1373 — everything still behind the `gitlab` feature flag.

## Workspace picker

The agent workspace form (create AND edit) gains a GitLab project mode: a bound-projects picker fed by the organization's bindings (degraded projects stay selectable, provisioning/cleanup rows are disabled with their state), plus the same branch / working-subdirectory / access / worktree controls the GitHub form has, submitting `{ mode: 'gitlab', projectId, … }` by the rename-stable numeric id. The picker chrome was extracted from the GitHub repository field into one shared component, so both providers are thin word-supplying wrappers and no existing call site changed. An org with no bindings gets an empty-state pointing at the GitLab card in Integrations.

## Hook configuration

The integration picker gains a flag-gated GitLab tile: bound-project picker, Issues/Merge requests/Pushes event families, comment families, label filter, and mention-only — reusing the GitHub form's family/cadence tiles. Bodies follow the REST contract exactly (`kind: 'gitlab'`, pattern strings, families); review/reporting knobs are deliberately absent until the review slice. Hook lists and marks render the gitlab kind as a first-class trigger.

## Pre-existing gaps this surfaced (fixed here)

The console's read models predated the gitlab kind: `HookDto.kind`/`commentFamilies` and `Agent.hookKinds` were github/webhook-only unions although the CP already serves gitlab values; a gitlab workspace fell through the DTO mapping and rendered as "Scratch workspace" everywhere; and the agent detail view's two-way hook grouping would have drawn gitlab rows with a webhook glyph and a null URL. All four are corrected, with the platform-set drift test taught that gitlab is a core trigger kind like github rather than a platform module.

## Tests

Eight new tests across the workspace form, edit modal, and integration modal: flag-off renders nothing and issues no project request on either surface; bound-project selectability matrix; workspace save by numeric id; the exact hook create body; empty-states. Web suite 1812/1812; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
