### PR TITLE
feat(daemon): structured GitLab mutation broker behind the effect lease

### DIFF
--- a/packages/daemon/src/cp/git-credential.ts
+++ b/packages/daemon/src/cp/git-credential.ts
@@ -354,6 +354,12 @@ export class GitCredentialCache {
     } catch (e) {
       const code = (e as { code?: string }).code
       if (code === 'SCOPE_DENIED') {
+        // §14.2: an effect lease is re-resolved live on every call and hook/binding lifecycle changes
+        // never replicate an agent spec, so its refusal is never durable — the next call asks again.
+        if (payload.purpose === 'gitlab_effect') {
+          this.entries.delete(key)
+          throw new GitCredUnavailableError((e as Error).message, false)
+        }
         if (payload.repoFullName !== undefined) {
           // Repo-keyed: negative-cache and retry in a minute — the operator may
           // be authorizing the repo in the console right now.

--- a/packages/daemon/src/cp/git-credential.ts
+++ b/packages/daemon/src/cp/git-credential.ts
@@ -64,6 +64,9 @@ const POST_KEY = (agentId: string, repo: string): string => `post\u0000${agentId
 /** Cache key for the gitlab note poster's effect token (§14.1) — its own keyspace. */
 const GITLAB_POST_KEY = (agentId: string, projectId: string): string => `postglab\u0000${agentId}\u0000${projectId}`
 
+/** Cache key for the structured broker's effect lease (§14.2) — a third keyspace, per (agent, project). */
+const GITLAB_EFFECT_KEY = (agentId: string, projectId: string): string => `fxglab\u0000${agentId}\u0000${projectId}`
+
 export class GitCredUnavailableError extends Error {
   constructor(
     message: string,
@@ -92,7 +95,7 @@ export interface GitCredentialCacheDeps {
     reason?: 'clone' | 'fetch' | 'pull' | 'push' | 'helper'
     capabilities?: GitCredCapability[]
     repoFullName?: string
-    purpose?: 'github_hook_reply' | 'gitlab_hook_reply'
+    purpose?: 'github_hook_reply' | 'gitlab_hook_reply' | 'gitlab_effect'
     hookId?: string
     forceRefresh?: boolean
     provider?: 'gitlab'
@@ -108,6 +111,9 @@ export interface GitCredentialCacheDeps {
    *  gitcred-provider-v2 — an older CP would strip the field and answer a
    *  GitHub workspace grant for the wrong provider. */
   providerV2Supported?: () => boolean
+  /** §17.3 negotiation: `purpose: 'gitlab_effect'` is a NEW ENUM VALUE, so naming it to an
+   *  older CP is frame-fatal rather than silently stripped — ask only after gitlab-effect-v1. */
+  gitlabEffectSupported?: () => boolean
   /** Monotonic ms; injectable for tests. */
   monoNow?: () => number
 }
@@ -217,9 +223,45 @@ export class GitCredentialCache {
     return entry
   }
 
+  /** The structured broker's effect lease (§14.2): the never-agent-visible effect PAT, authorized by the
+   *  agent's GitLab workspace binding or the NAMED enabled hook, carrying the §13.1 clamp it enforces. */
+  async getGitlabEffectToken(agentId: string, projectId: string, hookId?: string): Promise<Entry> {
+    if (this.deps.providerV2Supported?.() !== true) {
+      throw new GitCredUnavailableError(
+        'the control plane is too old for gitlab credentials (gitcred-provider-v2 not advertised)',
+        false
+      )
+    }
+    if (this.deps.gitlabEffectSupported?.() !== true) {
+      throw new GitCredUnavailableError('the control plane does not support GitLab effect leases yet', false)
+    }
+    const key = GITLAB_EFFECT_KEY(agentId, projectId)
+    const forceRefresh = this.refreshPosts.has(key)
+    const entry = await this.getKeyed(key, agentId, {
+      agentId,
+      reason: 'helper',
+      provider: 'gitlab',
+      externalRepoId: projectId,
+      purpose: 'gitlab_effect',
+      ...(hookId !== undefined ? { hookId } : {}),
+      ...(forceRefresh ? { forceRefresh: true } : {})
+    })
+    if (forceRefresh) this.refreshPosts.delete(key)
+    return entry
+  }
+
   /** Drop the cached gitlab note token after GitLab rejects it. */
   invalidateGitlabPost(agentId: string, projectId: string, presentedToken?: string): void {
-    const key = GITLAB_POST_KEY(agentId, projectId)
+    this.dropCached(GITLAB_POST_KEY(agentId, projectId), presentedToken)
+  }
+
+  /** Drop the cached broker effect lease after GitLab rejects it, so the single retry re-mints. */
+  invalidateGitlabEffect(agentId: string, projectId: string, presentedToken?: string): void {
+    this.dropCached(GITLAB_EFFECT_KEY(agentId, projectId), presentedToken)
+  }
+
+  /** Evict one daemon-owned writer's cached token and force its next mint past the CP cache. */
+  private dropCached(key: string, presentedToken?: string): void {
     const entry = this.entries.get(key)
     if (!entry) return
     if (presentedToken !== undefined && entry.token !== presentedToken) return
@@ -230,12 +272,7 @@ export class GitCredentialCache {
   /** Drop the cached GithubPoster token after GitHub rejects it. Matching the
    *  presented token avoids deleting a newer grant that won a concurrent race. */
   invalidatePost(agentId: string, repo: string, presentedToken?: string): void {
-    const key = POST_KEY(agentId, repo)
-    const entry = this.entries.get(key)
-    if (!entry) return
-    if (presentedToken !== undefined && entry.token !== presentedToken) return
-    this.entries.delete(key)
-    this.refreshPosts.add(key)
+    this.dropCached(POST_KEY(agentId, repo), presentedToken)
   }
 
   private async getKeyed(

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -53,8 +53,9 @@ import { TranscriptRecorder, type TranscriptEvent } from './session/transcript-r
 import { attachmentMention, sniffImageMimeType } from './session/attachment-block.js'
 import { McpControlServer } from './mcp/control-server.js'
 import { RemoteWebchatGrantManager } from './mcp/remote-webchat-grant.js'
-import type { SetSessionTitleReq } from './mcp/ops.js'
+import type { CodeHostEffectReq, SetSessionTitleReq } from './mcp/ops.js'
 import { GitCredentialCache } from './cp/git-credential.js'
+import { GitlabBroker } from './gitlab/broker.js'
 import {
   CONFIG_FILE_CONVENTIONS,
   cleanupConfigFiles,
@@ -76,7 +77,7 @@ import {
 import { configureWorkspaceGitOrigins } from './workspace/git-origin-policy.js'
 import { buildMcpServers, buildSandboxMcpServers, type McpStdioServer } from './mcp/inject.js'
 import { resolveAgentMcpServers, RESERVED_MCP_SERVER_NAME } from './mcp/resolve-servers.js'
-import { toolsForIntegrations, GITHUB_REVIEW_TOOLS, KNOWLEDGE_TOOLS } from './mcp/tools.js'
+import { toolsForIntegrations, CODE_HOST_EFFECT_TOOLS, GITHUB_REVIEW_TOOLS, KNOWLEDGE_TOOLS } from './mcp/tools.js'
 import { MEMORY_TOOL_NAMES, MEMORY_TOOLS } from './memory/tools.js'
 import { DREAM_TOPIC_RE, MAX_DREAM_FILES } from './dream/dreamer.js'
 import { isSessionTitleToolCall } from './mcp/session-title-tool.js'
@@ -263,6 +264,7 @@ import {
   K8S_SUPERVISOR,
   AGENT_CONFIG_REVISION_FEATURE,
   DAEMON_BOOTSTRAP_UPGRADE_FEATURE,
+  GITLAB_EFFECT_V1_FEATURE,
   ORGANIZATION_KNOWLEDGE_FEATURE,
   ORGANIZATION_SUGGESTION_REVIEW_FEATURE,
   SESSION_VISIBILITY_FEATURE,
@@ -636,6 +638,8 @@ export class Daemon {
   /** Lazily-built dream-job engine (docs/designs/memory-dreaming.md §4). */
   private dreamRunnerInstance?: DreamRunner
   private gitCreds!: GitCredentialCache
+  /** §14.2 structured mutation broker — allowlisted GitLab effects run under a daemon-held lease. */
+  private gitlabBroker?: GitlabBroker
   /** Public commit attribution selected by the CP deployment's GitHub App. */
   private gitCommitIdentity?: GitCommitIdentity
   private gitCredServer?: GitCredServer
@@ -1672,7 +1676,16 @@ export class Daemon {
       },
       log: { warn: (m: string) => this.log.warn(m) },
       actionsSupported: () => this.cpClient?.supportsServerFeature?.('gitcred-actions-v1') ?? false,
-      providerV2Supported: () => this.cpClient?.supportsServerFeature?.('gitcred-provider-v2') ?? false
+      providerV2Supported: () => this.cpClient?.supportsServerFeature?.('gitcred-provider-v2') ?? false,
+      gitlabEffectSupported: () => this.cpClient?.supportsServerFeature?.(GITLAB_EFFECT_V1_FEATURE) ?? false
+    })
+    // §14.2: the broker holds the effect lease; the agent environment never sees the token.
+    this.gitlabBroker = new GitlabBroker({
+      lease: async (target) => {
+        const entry = await this.gitCreds.getGitlabEffectToken(target.agentId, target.projectId, target.hookId)
+        return { token: entry.token, access: entry.access }
+      },
+      invalidateLease: (target, token) => this.gitCreds.invalidateGitlabEffect(target.agentId, target.projectId, token)
     })
     this.gitCredServer = new GitCredServer(this.gitCreds, gitcredSocketPath(root), {
       log: {
@@ -2266,6 +2279,7 @@ export class Daemon {
       cancelOrchestration: (req) => Promise.resolve(this.collab.cancelOrchestrationForOwner(req)),
       submitGithubReview: (req) => this.githubReviews.submitGithubReview(req),
       replyGithubReviewThreads: (req) => this.githubReviews.replyGithubReviewThreads(req),
+      codeHostEffect: (req) => this.runCodeHostEffect(req),
       memory: this.memory,
       // Every session may READ shared agent memory; only a non-isolated session
       // may WRITE it, so a private DM/A2A turn can use existing memory but cannot
@@ -2521,6 +2535,8 @@ export class Daemon {
         // outlive many hook deliveries. The call resolves the CURRENT daemon-
         // private turn and fails closed everywhere else.
         tools = [...tools, ...GITHUB_REVIEW_TOOLS]
+        // §14.2 broker: only a session with a GitLab target carries it, and the clamped lease still authorizes.
+        if (this.gitlabWorkspaceProject(agent.id) !== undefined) tools = [...tools, ...CODE_HOST_EFFECT_TOOLS]
         // Replace the legacy managed descriptors with this provider's stable core
         // tools. An external plugin's raw MCP tools never enter the ACP session.
         tools = tools.filter((t) => !MEMORY_TOOL_NAMES.has(t.name))
@@ -6538,6 +6554,31 @@ export class Daemon {
     return !this.dutyCoordinator.dutyEnforced() || this.duties.holdsAgent(agentId)
   }
 
+  /** §14.2: resolve this turn's trusted GitLab target, then run exactly one allowlisted operation. */
+  private async runCodeHostEffect(req: CodeHostEffectReq): Promise<unknown> {
+    const broker = this.gitlabBroker
+    if (!broker) throw new Error('code-host effects are unavailable on this daemon')
+    const key = sessionKey(req.platform, req.channel, req.thread, req.agentId, req.transportScope)
+    const target = this.codeHostEffectTarget(req.agentId, key)
+    if (!target) throw new Error('this session has no GitLab project to act on')
+    return await broker.execute({ ...target, agentId: req.agentId, sessionKey: key }, req.operation)
+  }
+
+  /** The hook-dispatched turn's trusted project first (§13.1), else the agent's GitLab workspace project. */
+  private codeHostEffectTarget(agentId: string, key: string): { projectId: string; hookId?: string } | undefined {
+    const hook = this.activeTurnCodeHost.get(key)
+    if (hook && hook.agentId === agentId) return { projectId: hook.projectId, hookId: hook.hookId }
+    const projectId = this.gitlabWorkspaceProject(agentId)
+    return projectId === undefined ? undefined : { projectId }
+  }
+
+  /** The agent's managed GitLab workspace project from the REPLICATED SPEC — never a tool argument. */
+  private gitlabWorkspaceProject(agentId: string): string | undefined {
+    const agent = this.agents.get(agentId)
+    if (!agent || this.workspaces.managedCredentialProvider(agent) !== 'gitlab') return undefined
+    return agent.workspace.mode === 'git-repo' ? agent.workspace.gitlabProjectId : undefined
+  }
+
   /** Everything the GitHub hook-dispatch and formal-review seam reaches back for. */
   private githubReviewHost(): GithubReviewHost {
     return {
@@ -9436,6 +9477,12 @@ export class Daemon {
       headless: entry.msg.headless === true,
       synthetic: isSyntheticA2aChannel(plan.channel)
     })
+    // §14.2: a hook-dispatched turn pins the broker to the delivery's own signature-verified project.
+    const hookContext = entry.hookContext
+    if (hookContext?.gitlab) {
+      const target = { agentId, projectId: hookContext.gitlab.projectId, hookId: hookContext.hookId }
+      this.activeTurnCodeHost.set(key, target)
+    }
     const activeGithub = await this.githubReviews.prepareGithubTurn(entry, sessionId).catch((err) => {
       this.log.warn(`github review: turn setup failed (${formatErr(err)})`)
       return undefined
@@ -10338,6 +10385,7 @@ export class Daemon {
     if (callMeta) this.activeTurnCallMeta.delete(key)
     this.activeTurnShare.delete(key)
     this.shareBudgetByTurn.delete(key)
+    this.activeTurnCodeHost.delete(key)
     const activeGithub = activeTurn.github
     const activeGithubReplyBatch = activeTurn.githubReplyBatch
     if (activeGithub && this.activeGithubTurnMeta.get(key) === activeGithub) this.activeGithubTurnMeta.delete(key)
@@ -11277,6 +11325,9 @@ export class Daemon {
   /** Bytes `shareFile` has uploaded this turn, by the same key — the synchronous per-turn
    *  reservation of agent-authored-attachments.md §5. */
   private shareBudgetByTurn = new Map<string, number>()
+
+  /** The hook-dispatched turn's trusted GitLab project by sessionKey — the §14.2 broker target, never model input. */
+  private activeTurnCodeHost = new Map<string, { agentId: string; projectId: string; hookId: string }>()
 
   /**
    * Post a chronological boundary message SERIALIZED on the turn's apply chain, returning

--- a/packages/daemon/src/gitlab/broker.ts
+++ b/packages/daemon/src/gitlab/broker.ts
@@ -269,11 +269,15 @@ function limited(limit: number | undefined): string {
   return String(Math.min(Math.max(limit ?? MAX_LIST_ITEMS, 1), MAX_LIST_ITEMS))
 }
 
-/** Draft state is a title prefix in GitLab, so the bounded `draft` flag normalizes the title. */
+/** Every draft marker GitLab recognizes, case-insensitively: `Draft:`, `[Draft]`, `(Draft)` and the legacy WIP forms. */
+const DRAFT_MARKER = /^\s*(?:\[\s*(?:draft|wip)\s*\]|\(\s*(?:draft|wip)\s*\)|(?:draft|wip)\s*:)\s*/i
+
+/** Draft state is a title prefix in GitLab, so the bounded `draft` flag normalizes the title both ways. */
 function draftTitle(title: string, draft: boolean | undefined): string {
   if (draft === undefined) return title
-  const bare = title.replace(/^\s*(draft:\s*|wip:\s*)+/i, '').trim()
-  return draft ? `Draft: ${bare}` : bare
+  let bare = title
+  while (DRAFT_MARKER.test(bare)) bare = bare.replace(DRAFT_MARKER, '')
+  return (draft ? `Draft: ${bare.trim()}` : bare).trim()
 }
 
 export class GitlabBroker {

--- a/packages/daemon/src/gitlab/broker.ts
+++ b/packages/daemon/src/gitlab/broker.ts
@@ -1,0 +1,539 @@
+// GitLab structured mutation broker (gitlab-com-integration.md §14.2): the allowlisted
+// non-review effects an agent may ask the daemon to perform under an effect lease.
+// The token never enters the agent environment and the project is never model input.
+import type { GitCredGrant } from '@agentconnect.md/protocol'
+
+/** §13.1 authorization levels, ordered — an operation's class is checked against the CLAMPED grant. */
+export type BrokerCapability = GitCredGrant['access']
+
+const CAPABILITY_RANK: Record<BrokerCapability, number> = { read: 0, comment: 1, write: 2 }
+
+/** One allowlisted endpoint: an exact method, an exact path template, and the capability it costs. */
+export interface BrokerEndpoint {
+  method: 'GET' | 'POST' | 'PUT'
+  capability: BrokerCapability
+  path: string
+}
+
+/** THE allowlist: every call renders one of these templates — no arbitrary path, GraphQL, or raw body. */
+export const GITLAB_BROKER_ENDPOINTS = {
+  'comment.create': { method: 'POST', capability: 'comment', path: '/projects/:project/:subject/:iid/notes' },
+  'comment.update': { method: 'PUT', capability: 'comment', path: '/projects/:project/:subject/:iid/notes/:noteId' },
+  'discussion.list': { method: 'GET', capability: 'read', path: '/projects/:project/:subject/:iid/discussions' },
+  'discussion.get': {
+    method: 'GET',
+    capability: 'read',
+    path: '/projects/:project/:subject/:iid/discussions/:discussionId'
+  },
+  'discussion.reply': {
+    method: 'POST',
+    capability: 'comment',
+    path: '/projects/:project/:subject/:iid/discussions/:discussionId/notes'
+  },
+  'mergeRequest.create': { method: 'POST', capability: 'write', path: '/projects/:project/merge_requests' },
+  'mergeRequest.update': { method: 'PUT', capability: 'write', path: '/projects/:project/merge_requests/:iid' },
+  'pipeline.list': { method: 'GET', capability: 'read', path: '/projects/:project/pipelines' },
+  'pipeline.get': { method: 'GET', capability: 'read', path: '/projects/:project/pipelines/:pipelineId' },
+  'pipeline.jobs': { method: 'GET', capability: 'read', path: '/projects/:project/pipelines/:pipelineId/jobs' },
+  'job.get': { method: 'GET', capability: 'read', path: '/projects/:project/jobs/:jobId' },
+  'pipeline.retry': { method: 'POST', capability: 'write', path: '/projects/:project/pipelines/:pipelineId/retry' },
+  'pipeline.cancel': { method: 'POST', capability: 'write', path: '/projects/:project/pipelines/:pipelineId/cancel' },
+  'job.retry': { method: 'POST', capability: 'write', path: '/projects/:project/jobs/:jobId/retry' },
+  'job.cancel': { method: 'POST', capability: 'write', path: '/projects/:project/jobs/:jobId/cancel' }
+} as const satisfies Record<string, BrokerEndpoint>
+
+export type BrokerEndpointId = keyof typeof GITLAB_BROKER_ENDPOINTS
+
+/** The product subject vocabulary the tools speak, mapped to its GitLab path segment. */
+export type BrokerSubject = 'issue' | 'merge_request'
+const SUBJECT_SEGMENT: Record<BrokerSubject, string> = { issue: 'issues', merge_request: 'merge_requests' }
+
+/** Bounded pipeline states the inspect operation may filter on. */
+export const BROKER_PIPELINE_STATUSES = [
+  'created',
+  'waiting_for_resource',
+  'preparing',
+  'pending',
+  'running',
+  'success',
+  'failed',
+  'canceled',
+  'skipped',
+  'manual',
+  'scheduled'
+] as const
+
+/** The §14.2 operation set, exactly. Every member resolves to one allowlisted endpoint. */
+export type GitlabBrokerOperation =
+  | { kind: 'createComment'; subject: BrokerSubject; iid: number; body: string }
+  | { kind: 'updateComment'; subject: BrokerSubject; iid: number; noteId: string; body: string }
+  | { kind: 'readDiscussions'; subject: BrokerSubject; iid: number; discussionId?: string; limit?: number }
+  | { kind: 'replyDiscussion'; subject: BrokerSubject; iid: number; discussionId: string; body: string }
+  | {
+      kind: 'createMergeRequest'
+      sourceBranch: string
+      targetBranch: string
+      title: string
+      description?: string
+      draft?: boolean
+    }
+  | {
+      kind: 'updateMergeRequest'
+      iid: number
+      title?: string
+      description?: string
+      targetBranch?: string
+      draft?: boolean
+    }
+  | {
+      kind: 'inspectPipelines'
+      scope: 'pipelines' | 'pipeline' | 'pipeline_jobs' | 'job'
+      pipelineId?: string
+      jobId?: string
+      ref?: string
+      status?: (typeof BROKER_PIPELINE_STATUSES)[number]
+      limit?: number
+    }
+  | {
+      kind: 'controlPipeline'
+      action: 'retry_pipeline' | 'cancel_pipeline' | 'retry_job' | 'cancel_job'
+      pipelineId?: string
+      jobId?: string
+    }
+
+/** The trusted target: agent, project, and hook are daemon-held coordinates, never tool arguments. */
+export interface GitlabBrokerTarget {
+  agentId: string
+  /** Numeric project id (decimal string) — the hook's trusted metadata or the agent's workspace project. */
+  projectId: string
+  /** Present when a hook-dispatched turn authorizes the lease (§13.1). */
+  hookId?: string
+  /** Logical session key — the single-writer ledger for `updateComment` is scoped to it. */
+  sessionKey: string
+}
+
+export interface GitlabBrokerLease {
+  token: string
+  /** The clamp the CP echoed in the grant; every operation is refused above it. */
+  access: BrokerCapability
+}
+
+export interface GitlabBrokerDeps {
+  /** Action-time effect lease (purpose `gitlab_effect`); refuses when the CP lacks the feature. */
+  lease: (target: GitlabBrokerTarget) => Promise<GitlabBrokerLease>
+  /** Drop a cached lease GitLab just rejected (401/403) so the single retry re-mints. */
+  invalidateLease?: (target: GitlabBrokerTarget, token: string) => void
+  baseUrl?: string
+  fetchImpl?: typeof fetch
+}
+
+/** Bounds on what one broker answer may carry back into the model's context. */
+const MAX_NOTE_BODY_CHARS = 4000
+const MAX_DISCUSSION_NOTES = 50
+const MAX_LIST_ITEMS = 20
+const MAX_ERROR_CHARS = 200
+/** Ledger bounds: a long-lived daemon must not accumulate note ids for every session it ever ran. */
+const MAX_LEDGER_SESSIONS = 500
+const MAX_LEDGER_NOTES = 200
+
+const DECIMAL_ID = /^[1-9]\d*$/
+/** GitLab discussion ids are hex digests. */
+const DISCUSSION_ID = /^[0-9a-f]{6,64}$/
+/** A conservative branch shape — enough for real refs, never a traversal or a query injection. */
+const BRANCH_NAME = /^[\w.\-/]{1,255}$/
+
+/** GitLab ids exceed the safe-integer range; quote them before parsing, as the poster does. */
+export function parseGitlabJson(raw: string): unknown {
+  return JSON.parse(raw.replace(/"((?:[a-z][a-z0-9_]*_)?id)"\s*:\s*(\d{15,})/g, '"$1":"$2"'))
+}
+
+/** A big-int-safe id as a decimal string; undefined when the value is not one. */
+function idOf(value: unknown): string | undefined {
+  if (typeof value === 'string' && DECIMAL_ID.test(value)) return value
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return String(value)
+  return undefined
+}
+
+function str(value: unknown, max = 500): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value.slice(0, max) : undefined
+}
+
+function int(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) ? value : undefined
+}
+
+function bool(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+}
+
+/** Drop undefined members so a bounded result never carries empty keys into the model's context. */
+function compact<T extends Record<string, unknown>>(value: T): Partial<T> {
+  return Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined)) as Partial<T>
+}
+
+function noteResult(raw: unknown): Record<string, unknown> {
+  const note = record(raw)
+  return compact({
+    id: idOf(note.id),
+    body: str(note.body, MAX_NOTE_BODY_CHARS),
+    author: str(record(note.author).username, 100),
+    system: bool(note.system),
+    resolved: bool(note.resolved),
+    createdAt: str(note.created_at, 40),
+    updatedAt: str(note.updated_at, 40)
+  })
+}
+
+function discussionResult(raw: unknown): Record<string, unknown> {
+  const discussion = record(raw)
+  const notes = Array.isArray(discussion.notes) ? discussion.notes.slice(0, MAX_DISCUSSION_NOTES) : []
+  return compact({
+    id: str(discussion.id, 64),
+    individualNote: bool(discussion.individual_note),
+    notes: notes.map(noteResult)
+  })
+}
+
+function mergeRequestResult(raw: unknown): Record<string, unknown> {
+  const mr = record(raw)
+  return compact({
+    id: idOf(mr.id),
+    iid: int(mr.iid),
+    projectId: idOf(mr.project_id),
+    title: str(mr.title, 500),
+    state: str(mr.state, 40),
+    draft: bool(mr.draft) ?? bool(mr.work_in_progress),
+    sourceBranch: str(mr.source_branch, 255),
+    targetBranch: str(mr.target_branch, 255),
+    webUrl: str(mr.web_url, 500),
+    createdAt: str(mr.created_at, 40),
+    updatedAt: str(mr.updated_at, 40)
+  })
+}
+
+function pipelineResult(raw: unknown): Record<string, unknown> {
+  const pipeline = record(raw)
+  return compact({
+    id: idOf(pipeline.id),
+    iid: int(pipeline.iid),
+    projectId: idOf(pipeline.project_id),
+    status: str(pipeline.status, 40),
+    source: str(pipeline.source, 40),
+    ref: str(pipeline.ref, 255),
+    sha: str(pipeline.sha, 64),
+    webUrl: str(pipeline.web_url, 500),
+    createdAt: str(pipeline.created_at, 40),
+    updatedAt: str(pipeline.updated_at, 40)
+  })
+}
+
+function jobResult(raw: unknown): Record<string, unknown> {
+  const job = record(raw)
+  return compact({
+    id: idOf(job.id),
+    name: str(job.name, 255),
+    stage: str(job.stage, 255),
+    status: str(job.status, 40),
+    ref: str(job.ref, 255),
+    allowFailure: bool(job.allow_failure),
+    pipelineId: idOf(record(job.pipeline).id),
+    webUrl: str(job.web_url, 500),
+    createdAt: str(job.created_at, 40),
+    startedAt: str(job.started_at, 40),
+    finishedAt: str(job.finished_at, 40)
+  })
+}
+
+/** One resolved call: the allowlisted endpoint, its rendered path params, and the bounded payload. */
+interface BrokerPlan {
+  endpoint: BrokerEndpointId
+  params: Record<string, string>
+  query?: Record<string, string>
+  body?: Record<string, unknown>
+  /** Project the GitLab response onto bounded structured data. */
+  shape: (parsed: unknown) => unknown
+  /** Remember the created note id so `updateComment` keeps the single-writer discipline. */
+  recordsNote?: boolean
+}
+
+function requireDecimal(value: string, label: string): string {
+  if (!DECIMAL_ID.test(value)) throw new Error(`${label} must be a positive decimal id`)
+  return value
+}
+
+function limited(limit: number | undefined): string {
+  return String(Math.min(Math.max(limit ?? MAX_LIST_ITEMS, 1), MAX_LIST_ITEMS))
+}
+
+/** Draft state is a title prefix in GitLab, so the bounded `draft` flag normalizes the title. */
+function draftTitle(title: string, draft: boolean | undefined): string {
+  if (draft === undefined) return title
+  const bare = title.replace(/^\s*(draft:\s*|wip:\s*)+/i, '').trim()
+  return draft ? `Draft: ${bare}` : bare
+}
+
+export class GitlabBroker {
+  /** Note ids this broker authored, by session key — `updateComment` may touch nothing else. */
+  private readonly authored = new Map<string, Set<string>>()
+
+  constructor(private readonly deps: GitlabBrokerDeps) {}
+
+  async execute(target: GitlabBrokerTarget, op: GitlabBrokerOperation): Promise<unknown> {
+    const plan = this.plan(target, op)
+    const endpoint = GITLAB_BROKER_ENDPOINTS[plan.endpoint]
+    const lease = await this.deps.lease(target)
+    this.enforce(lease, endpoint)
+    const parsed = await this.call(target, plan, endpoint, lease)
+    if (plan.recordsNote) this.remember(target.sessionKey, idOf(record(parsed).id))
+    return plan.shape(parsed)
+  }
+
+  /** §13.1: the clamp the CP echoed decides, not the tool the model happened to call. */
+  private enforce(lease: GitlabBrokerLease, endpoint: BrokerEndpoint): void {
+    if (CAPABILITY_RANK[lease.access] >= CAPABILITY_RANK[endpoint.capability]) return
+    throw new Error(
+      `this operation needs ${endpoint.capability} authority on the GitLab project, but the current authorization grants ${lease.access}`
+    )
+  }
+
+  private plan(target: GitlabBrokerTarget, op: GitlabBrokerOperation): BrokerPlan {
+    const project = requireDecimal(target.projectId, 'project id')
+    switch (op.kind) {
+      case 'createComment':
+        return {
+          endpoint: 'comment.create',
+          params: { project, subject: SUBJECT_SEGMENT[op.subject], iid: String(op.iid) },
+          body: { body: op.body },
+          shape: (parsed) => ({ note: noteResult(parsed) }),
+          recordsNote: true
+        }
+      case 'updateComment': {
+        const noteId = requireDecimal(op.noteId, 'noteId')
+        if (!this.authored.get(target.sessionKey)?.has(noteId)) {
+          throw new Error('only a comment this session created through the broker can be updated')
+        }
+        return {
+          endpoint: 'comment.update',
+          params: { project, subject: SUBJECT_SEGMENT[op.subject], iid: String(op.iid), noteId },
+          body: { body: op.body },
+          shape: (parsed) => ({ note: noteResult(parsed) })
+        }
+      }
+      case 'readDiscussions': {
+        const base = { project, subject: SUBJECT_SEGMENT[op.subject], iid: String(op.iid) }
+        if (op.discussionId === undefined) {
+          return {
+            endpoint: 'discussion.list',
+            params: base,
+            query: { per_page: limited(op.limit) },
+            shape: (parsed) => ({
+              discussions: (Array.isArray(parsed) ? parsed.slice(0, MAX_LIST_ITEMS) : []).map(discussionResult)
+            })
+          }
+        }
+        return {
+          endpoint: 'discussion.get',
+          params: { ...base, discussionId: discussionId(op.discussionId) },
+          shape: (parsed) => ({ discussion: discussionResult(parsed) })
+        }
+      }
+      case 'replyDiscussion':
+        return {
+          endpoint: 'discussion.reply',
+          params: {
+            project,
+            subject: SUBJECT_SEGMENT[op.subject],
+            iid: String(op.iid),
+            discussionId: discussionId(op.discussionId)
+          },
+          body: { body: op.body },
+          shape: (parsed) => ({ note: noteResult(parsed) }),
+          recordsNote: true
+        }
+      case 'createMergeRequest':
+        return {
+          endpoint: 'mergeRequest.create',
+          params: { project },
+          body: compact({
+            source_branch: branch(op.sourceBranch, 'sourceBranch'),
+            target_branch: branch(op.targetBranch, 'targetBranch'),
+            title: draftTitle(op.title, op.draft),
+            description: op.description
+          }),
+          shape: (parsed) => ({ mergeRequest: mergeRequestResult(parsed) })
+        }
+      case 'updateMergeRequest':
+        return {
+          endpoint: 'mergeRequest.update',
+          params: { project, iid: String(op.iid) },
+          body: compact({
+            ...(op.title !== undefined ? { title: draftTitle(op.title, op.draft) } : {}),
+            description: op.description,
+            target_branch: op.targetBranch === undefined ? undefined : branch(op.targetBranch, 'targetBranch')
+          }),
+          shape: (parsed) => ({ mergeRequest: mergeRequestResult(parsed) })
+        }
+      case 'inspectPipelines':
+        return planInspect(project, op)
+      case 'controlPipeline':
+        return planControl(project, op)
+    }
+  }
+
+  /** Issue the allowlisted request; retry once, and only after a definite auth rejection. */
+  private async call(
+    target: GitlabBrokerTarget,
+    plan: BrokerPlan,
+    endpoint: BrokerEndpoint,
+    lease: GitlabBrokerLease
+  ): Promise<unknown> {
+    const doFetch = this.deps.fetchImpl ?? fetch
+    const search = new URLSearchParams(plan.query ?? {}).toString()
+    const path = renderPath(endpoint.path, plan.params)
+    const url = `${this.deps.baseUrl ?? 'https://gitlab.com/api/v4'}${path}${search ? `?${search}` : ''}`
+    let current = lease
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const res = await doFetch(url, {
+        method: endpoint.method,
+        headers: {
+          'private-token': current.token,
+          ...(plan.body !== undefined ? { 'content-type': 'application/json' } : {})
+        },
+        ...(plan.body !== undefined ? { body: JSON.stringify(plan.body) } : {})
+      })
+      if (res.ok) {
+        const raw = await res.text()
+        try {
+          return parseGitlabJson(raw)
+        } catch {
+          throw new Error(`GitLab returned an unreadable ${endpoint.method} response`)
+        }
+      }
+      const authRejected = res.status === 401 || res.status === 403
+      const detail = await failureDetail(res)
+      if (attempt === 1 || !authRejected || !this.deps.invalidateLease) {
+        throw new Error(`GitLab ${endpoint.method} failed with ${res.status}${detail}`)
+      }
+      this.deps.invalidateLease(target, current.token)
+      current = await this.deps.lease(target)
+      this.enforce(current, endpoint)
+    }
+    throw new Error(`GitLab ${endpoint.method} failed`)
+  }
+
+  private remember(sessionKey: string, noteId: string | undefined): void {
+    if (!noteId) return
+    let notes = this.authored.get(sessionKey)
+    if (!notes) {
+      if (this.authored.size >= MAX_LEDGER_SESSIONS) {
+        const oldest = this.authored.keys().next().value
+        if (oldest !== undefined) this.authored.delete(oldest)
+      }
+      notes = new Set<string>()
+      this.authored.set(sessionKey, notes)
+    }
+    if (notes.size >= MAX_LEDGER_NOTES) {
+      const oldest = notes.values().next().value
+      if (oldest !== undefined) notes.delete(oldest)
+    }
+    notes.add(noteId)
+  }
+}
+
+function planInspect(project: string, op: Extract<GitlabBrokerOperation, { kind: 'inspectPipelines' }>): BrokerPlan {
+  if (op.scope === 'pipelines') {
+    return {
+      endpoint: 'pipeline.list',
+      params: { project },
+      query: {
+        per_page: limited(op.limit),
+        ...(op.ref !== undefined ? { ref: branch(op.ref, 'ref') } : {}),
+        ...(op.status !== undefined ? { status: op.status } : {})
+      },
+      shape: (parsed) => ({
+        pipelines: (Array.isArray(parsed) ? parsed.slice(0, MAX_LIST_ITEMS) : []).map(pipelineResult)
+      })
+    }
+  }
+  if (op.scope === 'job') {
+    return {
+      endpoint: 'job.get',
+      params: { project, jobId: requireArg(op.jobId, 'jobId', op.scope) },
+      shape: (parsed) => ({ job: jobResult(parsed) })
+    }
+  }
+  const pipelineId = requireArg(op.pipelineId, 'pipelineId', op.scope)
+  if (op.scope === 'pipeline') {
+    return {
+      endpoint: 'pipeline.get',
+      params: { project, pipelineId },
+      shape: (parsed) => ({ pipeline: pipelineResult(parsed) })
+    }
+  }
+  return {
+    endpoint: 'pipeline.jobs',
+    params: { project, pipelineId },
+    query: { per_page: limited(op.limit) },
+    shape: (parsed) => ({ jobs: (Array.isArray(parsed) ? parsed.slice(0, MAX_LIST_ITEMS) : []).map(jobResult) })
+  }
+}
+
+function planControl(project: string, op: Extract<GitlabBrokerOperation, { kind: 'controlPipeline' }>): BrokerPlan {
+  if (op.action === 'retry_job' || op.action === 'cancel_job') {
+    return {
+      endpoint: op.action === 'retry_job' ? 'job.retry' : 'job.cancel',
+      params: { project, jobId: requireArg(op.jobId, 'jobId', op.action) },
+      shape: (parsed) => ({ job: jobResult(parsed) })
+    }
+  }
+  return {
+    endpoint: op.action === 'retry_pipeline' ? 'pipeline.retry' : 'pipeline.cancel',
+    params: { project, pipelineId: requireArg(op.pipelineId, 'pipelineId', op.action) },
+    shape: (parsed) => ({ pipeline: pipelineResult(parsed) })
+  }
+}
+
+function discussionId(value: string): string {
+  if (!DISCUSSION_ID.test(value)) throw new Error('discussionId must be a GitLab discussion id')
+  return value
+}
+
+function branch(value: string, label: string): string {
+  if (!BRANCH_NAME.test(value)) throw new Error(`${label} must be a branch name`)
+  return value
+}
+
+function requireArg(value: string | undefined, label: string, scope: string): string {
+  if (value === undefined) throw new Error(`${label} is required for ${scope}`)
+  return requireDecimal(value, label)
+}
+
+/** Fill an allowlisted template; an unresolved placeholder is a bug, never a passthrough path. */
+function renderPath(template: string, params: Record<string, string>): string {
+  return template
+    .split('/')
+    .map((segment) => {
+      if (!segment.startsWith(':')) return segment
+      const value = params[segment.slice(1)]
+      if (value === undefined) throw new Error(`broker path parameter ${segment.slice(1)} is missing`)
+      return encodeURIComponent(value)
+    })
+    .join('/')
+}
+
+/** A bounded, single-line hint from GitLab's error body — never the request or the token. */
+async function failureDetail(res: Response): Promise<string> {
+  try {
+    const raw = await res.text()
+    const parsed = JSON.parse(raw) as { message?: unknown; error?: unknown }
+    const message = typeof parsed.message === 'string' ? parsed.message : parsed.error
+    if (typeof message !== 'string' || !message.trim()) return ''
+    return `: ${message.replace(/\s+/g, ' ').slice(0, MAX_ERROR_CHARS)}`
+  } catch {
+    return ''
+  }
+}

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -48,6 +48,25 @@ import {
   type GithubReviewDeps
 } from './ops/github.js'
 import {
+  controlCodeHostPipeline,
+  CONTROL_CODE_HOST_PIPELINE_ARGS,
+  createCodeHostComment,
+  CREATE_CODE_HOST_COMMENT_ARGS,
+  createCodeHostMergeRequest,
+  CREATE_CODE_HOST_MERGE_REQUEST_ARGS,
+  inspectCodeHostPipelines,
+  INSPECT_CODE_HOST_PIPELINES_ARGS,
+  readCodeHostDiscussions,
+  READ_CODE_HOST_DISCUSSIONS_ARGS,
+  replyCodeHostDiscussion,
+  REPLY_CODE_HOST_DISCUSSION_ARGS,
+  updateCodeHostComment,
+  UPDATE_CODE_HOST_COMMENT_ARGS,
+  updateCodeHostMergeRequest,
+  UPDATE_CODE_HOST_MERGE_REQUEST_ARGS,
+  type CodeHostEffectDeps
+} from './ops/code-host.js'
+import {
   getCurrentChannel,
   getUserProfile,
   GET_USER_PROFILE_ARGS,
@@ -76,6 +95,7 @@ export type {
   ReplyGithubReviewThreadsResult,
   SubmitGithubReviewReq
 } from './ops/github.js'
+export type { CodeHostEffectReq } from './ops/code-host.js'
 export { SEND_MESSAGE_BRANCHES } from './ops/messaging.js'
 export type { MessageAgentReq, MessageAgentResult, ReplyToSessionReq, ReplyToSessionResult } from './ops/messaging.js'
 export type {
@@ -100,6 +120,7 @@ export interface OpsDeps
     KnowledgeDeps,
     OrchestrationDeps,
     GithubReviewDeps,
+    CodeHostEffectDeps,
     MemoryOpsDeps,
     ShareFileDeps,
     PlatformReadDeps {
@@ -145,6 +166,14 @@ const HANDLERS: Map<string, ToolHandler<OpsDeps>> = new Map<string, ToolHandler<
   ['cancelOrchestration', cancelOrchestration],
   ['submitGithubReview', submitGithubReview],
   ['replyGithubReviewThreads', replyGithubReviewThreads],
+  ['createCodeHostComment', createCodeHostComment],
+  ['updateCodeHostComment', updateCodeHostComment],
+  ['readCodeHostDiscussions', readCodeHostDiscussions],
+  ['replyCodeHostDiscussion', replyCodeHostDiscussion],
+  ['createCodeHostMergeRequest', createCodeHostMergeRequest],
+  ['updateCodeHostMergeRequest', updateCodeHostMergeRequest],
+  ['inspectCodeHostPipelines', inspectCodeHostPipelines],
+  ['controlCodeHostPipeline', controlCodeHostPipeline],
   ['listKnownUsers', listKnownUsers],
   ['listChannels', listChannels],
   ['listChannelMembers', listChannelMembers],
@@ -178,6 +207,14 @@ export const TOOL_ARG_SCHEMAS: Map<string, ZodType> = new Map<string, ZodType>([
   ['cancelOrchestration', ORCHESTRATION_OWNER_ARGS],
   ['submitGithubReview', SUBMIT_GITHUB_REVIEW_ARGS],
   ['replyGithubReviewThreads', REPLY_GITHUB_REVIEW_THREADS_ARGS],
+  ['createCodeHostComment', CREATE_CODE_HOST_COMMENT_ARGS],
+  ['updateCodeHostComment', UPDATE_CODE_HOST_COMMENT_ARGS],
+  ['readCodeHostDiscussions', READ_CODE_HOST_DISCUSSIONS_ARGS],
+  ['replyCodeHostDiscussion', REPLY_CODE_HOST_DISCUSSION_ARGS],
+  ['createCodeHostMergeRequest', CREATE_CODE_HOST_MERGE_REQUEST_ARGS],
+  ['updateCodeHostMergeRequest', UPDATE_CODE_HOST_MERGE_REQUEST_ARGS],
+  ['inspectCodeHostPipelines', INSPECT_CODE_HOST_PIPELINES_ARGS],
+  ['controlCodeHostPipeline', CONTROL_CODE_HOST_PIPELINE_ARGS],
   ['listKnownUsers', LIST_KNOWN_USERS_ARGS],
   ['listChannels', LIST_CHANNELS_ARGS],
   ['listChannelMembers', LIST_CHANNEL_MEMBERS_ARGS],

--- a/packages/daemon/src/mcp/ops/args.ts
+++ b/packages/daemon/src/mcp/ops/args.ts
@@ -59,6 +59,14 @@ export function optionalBoundedInt(key: string, min: number, max: number) {
     .transform((value) => value ?? undefined)
 }
 
+/** An optional boolean; `null` reads as absent, like every other optional here. */
+export function optionalBoolean(key: string) {
+  return z
+    .boolean(`argument ${key} must be a boolean`)
+    .nullish()
+    .transform((value) => value ?? undefined)
+}
+
 /** An optional plain JSON object (never an array). */
 export function optionalObject(key: string) {
   const message = `argument ${key} must be an object`

--- a/packages/daemon/src/mcp/ops/code-host.ts
+++ b/packages/daemon/src/mcp/ops/code-host.ts
@@ -1,0 +1,188 @@
+// The provider-neutral code-host effect tools (gitlab-com-integration.md §14.2), GitLab-backed today.
+// Every handler validates bounded arguments and hands the daemon a discriminated operation; the
+// target project and the effect token stay daemon-private.
+import { z } from 'zod'
+import type { SessionContext } from './context.js'
+import {
+  optionalBoolean,
+  optionalBoundedInt,
+  optionalEnum,
+  optionalString,
+  parseArgs,
+  requiredEnum,
+  requiredPositiveInt,
+  requiredString
+} from './args.js'
+import { BROKER_PIPELINE_STATUSES, type GitlabBrokerOperation } from '../../gitlab/broker.js'
+
+const SUBJECTS = ['issue', 'merge_request'] as const
+const INSPECT_SCOPES = ['pipelines', 'pipeline', 'pipeline_jobs', 'job'] as const
+const PIPELINE_ACTIONS = ['retry_pipeline', 'cancel_pipeline', 'retry_job', 'cancel_job'] as const
+
+/** A decimal external id (note, pipeline, job) — the only shape an allowlisted path accepts. */
+function requiredDecimalId(key: string) {
+  return requiredString(key).regex(/^[1-9]\d*$/, `argument ${key} must be a positive decimal string`)
+}
+
+function optionalDecimalId(key: string) {
+  return requiredDecimalId(key)
+    .nullish()
+    .transform((value) => value ?? undefined)
+}
+
+const subject = requiredEnum('subject', SUBJECTS)
+const iid = requiredPositiveInt('iid')
+
+export const CREATE_CODE_HOST_COMMENT_ARGS = z.object({ subject, iid, body: requiredString('body') })
+
+export const UPDATE_CODE_HOST_COMMENT_ARGS = z.object({
+  subject,
+  iid,
+  noteId: requiredDecimalId('noteId'),
+  body: requiredString('body')
+})
+
+export const READ_CODE_HOST_DISCUSSIONS_ARGS = z.object({
+  subject,
+  iid,
+  discussionId: optionalString('discussionId'),
+  limit: optionalBoundedInt('limit', 1, 20)
+})
+
+export const REPLY_CODE_HOST_DISCUSSION_ARGS = z.object({
+  subject,
+  iid,
+  discussionId: requiredString('discussionId'),
+  body: requiredString('body')
+})
+
+export const CREATE_CODE_HOST_MERGE_REQUEST_ARGS = z.object({
+  sourceBranch: requiredString('sourceBranch'),
+  targetBranch: requiredString('targetBranch'),
+  title: requiredString('title'),
+  description: optionalString('description'),
+  draft: optionalBoolean('draft')
+})
+
+export const UPDATE_CODE_HOST_MERGE_REQUEST_ARGS = z.object({
+  iid,
+  title: optionalString('title'),
+  description: optionalString('description'),
+  targetBranch: optionalString('targetBranch'),
+  draft: optionalBoolean('draft')
+})
+
+export const INSPECT_CODE_HOST_PIPELINES_ARGS = z.object({
+  scope: requiredEnum('scope', INSPECT_SCOPES),
+  pipelineId: optionalDecimalId('pipelineId'),
+  jobId: optionalDecimalId('jobId'),
+  ref: optionalString('ref'),
+  status: optionalEnum('status', BROKER_PIPELINE_STATUSES),
+  limit: optionalBoundedInt('limit', 1, 20)
+})
+
+export const CONTROL_CODE_HOST_PIPELINE_ARGS = z.object({
+  action: requiredEnum('action', PIPELINE_ACTIONS),
+  pipelineId: optionalDecimalId('pipelineId'),
+  jobId: optionalDecimalId('jobId')
+})
+
+/** One brokered effect with its caller identity filled from the trusted MCP SessionContext. */
+export interface CodeHostEffectReq {
+  agentId: string
+  platform: string
+  channel: string
+  thread: string
+  transportScope?: string
+  operation: GitlabBrokerOperation
+}
+
+/** The broker seam. Optional: an ordinary daemon carries the descriptors but fails closed. */
+export interface CodeHostEffectDeps {
+  /** Resolve the trusted project, mint the action-time effect lease, and run one allowlisted call. */
+  codeHostEffect?: (req: CodeHostEffectReq) => Promise<unknown>
+}
+
+function run(ctx: SessionContext, deps: CodeHostEffectDeps, operation: GitlabBrokerOperation): Promise<unknown> {
+  if (!deps.codeHostEffect) throw new Error('code-host effects are unavailable on this daemon')
+  return deps.codeHostEffect({
+    agentId: ctx.agentId,
+    platform: ctx.platform,
+    channel: ctx.channel,
+    thread: ctx.thread,
+    ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
+    operation
+  })
+}
+
+export function createCodeHostComment(
+  ctx: SessionContext,
+  args: Record<string, unknown>,
+  deps: CodeHostEffectDeps
+): Promise<unknown> {
+  return run(ctx, deps, { kind: 'createComment', ...parseArgs(CREATE_CODE_HOST_COMMENT_ARGS, args) })
+}
+
+export function updateCodeHostComment(
+  ctx: SessionContext,
+  args: Record<string, unknown>,
+  deps: CodeHostEffectDeps
+): Promise<unknown> {
+  return run(ctx, deps, { kind: 'updateComment', ...parseArgs(UPDATE_CODE_HOST_COMMENT_ARGS, args) })
+}
+
+export function readCodeHostDiscussions(
+  ctx: SessionContext,
+  args: Record<string, unknown>,
+  deps: CodeHostEffectDeps
+): Promise<unknown> {
+  return run(ctx, deps, { kind: 'readDiscussions', ...parseArgs(READ_CODE_HOST_DISCUSSIONS_ARGS, args) })
+}
+
+export function replyCodeHostDiscussion(
+  ctx: SessionContext,
+  args: Record<string, unknown>,
+  deps: CodeHostEffectDeps
+): Promise<unknown> {
+  return run(ctx, deps, { kind: 'replyDiscussion', ...parseArgs(REPLY_CODE_HOST_DISCUSSION_ARGS, args) })
+}
+
+export function createCodeHostMergeRequest(
+  ctx: SessionContext,
+  args: Record<string, unknown>,
+  deps: CodeHostEffectDeps
+): Promise<unknown> {
+  return run(ctx, deps, { kind: 'createMergeRequest', ...parseArgs(CREATE_CODE_HOST_MERGE_REQUEST_ARGS, args) })
+}
+
+export function updateCodeHostMergeRequest(
+  ctx: SessionContext,
+  args: Record<string, unknown>,
+  deps: CodeHostEffectDeps
+): Promise<unknown> {
+  const parsed = parseArgs(UPDATE_CODE_HOST_MERGE_REQUEST_ARGS, args)
+  // Draft state is carried by the title on GitLab, so it can only move together with one.
+  if (parsed.draft !== undefined && parsed.title === undefined) {
+    throw new Error('argument draft also requires title, because draft state is carried by the merge-request title')
+  }
+  if (parsed.title === undefined && parsed.description === undefined && parsed.targetBranch === undefined) {
+    throw new Error('supply at least one of title, description, or targetBranch')
+  }
+  return run(ctx, deps, { kind: 'updateMergeRequest', ...parsed })
+}
+
+export function inspectCodeHostPipelines(
+  ctx: SessionContext,
+  args: Record<string, unknown>,
+  deps: CodeHostEffectDeps
+): Promise<unknown> {
+  return run(ctx, deps, { kind: 'inspectPipelines', ...parseArgs(INSPECT_CODE_HOST_PIPELINES_ARGS, args) })
+}
+
+export function controlCodeHostPipeline(
+  ctx: SessionContext,
+  args: Record<string, unknown>,
+  deps: CodeHostEffectDeps
+): Promise<unknown> {
+  return run(ctx, deps, { kind: 'controlPipeline', ...parseArgs(CONTROL_CODE_HOST_PIPELINE_ARGS, args) })
+}

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -3,6 +3,7 @@ import { obj, unionOf, type ToolDescriptor } from '../tool-schema/descriptor.js'
 import { SESSION_TITLE_TOOL_NAME } from './session-title-tool.js'
 import { allAttachmentReadTools, attachmentReadToolsFor } from '../platforms/read-ports.js'
 import { EXTERNAL_MEMORY_TOOL_NAMES, MEMORY_TOOLS } from '../memory/tools.js'
+import { BROKER_PIPELINE_STATUSES } from '../gitlab/broker.js'
 
 /**
  * Session metadata fallback tools. Opt-in via `toolsForIntegrations`'s
@@ -689,6 +690,164 @@ export const GITHUB_REVIEW_TOOLS: ToolDescriptor[] = [
   }
 ]
 
+/**
+ * The provider-neutral code-host effect surface (gitlab-com-integration.md §14.2),
+ * GitLab-backed today. Each tool maps to ONE allowlisted endpoint and method; the
+ * project is resolved from trusted daemon state and the effect token never enters
+ * the agent environment. Availability is not authorization: every call is refused
+ * below its clamped capability, and read/comment/write are the §13.1 classes.
+ */
+export const CODE_HOST_EFFECT_TOOLS: ToolDescriptor[] = [
+  {
+    name: 'createCodeHostComment',
+    description:
+      'Post one comment on an issue or merge request in the code-host project this session is bound to. The project ' +
+      'is fixed by trusted session state and cannot be selected here. Requires comment authority. Returns the ' +
+      'created comment id, which is the only id `updateCodeHostComment` will accept later in this session.',
+    inputSchema: obj(
+      {
+        subject: {
+          type: 'string',
+          enum: ['issue', 'merge_request'],
+          description: 'Which subject family to comment on.'
+        },
+        iid: { type: 'integer', minimum: 1, description: 'The subject’s project-scoped number (IID).' },
+        body: { type: 'string', minLength: 1, description: 'Complete Markdown comment body.' }
+      },
+      ['subject', 'iid', 'body']
+    )
+  },
+  {
+    name: 'updateCodeHostComment',
+    description:
+      'Rewrite a comment THIS session created through the broker. Any other comment is refused, so the single ' +
+      'author of a brokered comment stays its only editor. Requires comment authority.',
+    inputSchema: obj(
+      {
+        subject: { type: 'string', enum: ['issue', 'merge_request'] },
+        iid: { type: 'integer', minimum: 1, description: 'The subject’s project-scoped number (IID).' },
+        noteId: {
+          type: 'string',
+          pattern: '^[1-9][0-9]*$',
+          description: 'The comment id returned by an earlier createCodeHostComment or replyCodeHostDiscussion call.'
+        },
+        body: { type: 'string', minLength: 1, description: 'The complete replacement body.' }
+      },
+      ['subject', 'iid', 'noteId', 'body']
+    )
+  },
+  {
+    name: 'readCodeHostDiscussions',
+    description:
+      'Read the discussion threads on an issue or merge request. Omit `discussionId` for a bounded list of the ' +
+      'subject’s threads, or supply one to read that single thread. Read-only, so a read-level authorization is enough.',
+    inputSchema: obj(
+      {
+        subject: { type: 'string', enum: ['issue', 'merge_request'] },
+        iid: { type: 'integer', minimum: 1, description: 'The subject’s project-scoped number (IID).' },
+        discussionId: { type: 'string', description: 'Read exactly this thread; omit to list the subject’s threads.' },
+        limit: { type: 'integer', minimum: 1, maximum: 20, description: 'Maximum threads to list (default 20).' }
+      },
+      ['subject', 'iid']
+    )
+  },
+  {
+    name: 'replyCodeHostDiscussion',
+    description:
+      'Add one reply to an existing discussion thread on an issue or merge request. Use this instead of a new ' +
+      'top-level comment when answering in place. Requires comment authority.',
+    inputSchema: obj(
+      {
+        subject: { type: 'string', enum: ['issue', 'merge_request'] },
+        iid: { type: 'integer', minimum: 1, description: 'The subject’s project-scoped number (IID).' },
+        discussionId: { type: 'string', description: 'The thread id from readCodeHostDiscussions.' },
+        body: { type: 'string', minLength: 1, description: 'Complete Markdown reply body.' }
+      },
+      ['subject', 'iid', 'discussionId', 'body']
+    )
+  },
+  {
+    name: 'createCodeHostMergeRequest',
+    description:
+      'Open a merge request in this session’s project from an already-pushed branch. Only the fields below are ' +
+      'settable — there is no arbitrary payload. Requires write authority.',
+    inputSchema: obj(
+      {
+        sourceBranch: { type: 'string', minLength: 1, description: 'The branch holding the changes (already pushed).' },
+        targetBranch: { type: 'string', minLength: 1, description: 'The branch to merge into.' },
+        title: { type: 'string', minLength: 1, description: 'Merge-request title.' },
+        description: { type: 'string', description: 'Merge-request description in Markdown.' },
+        draft: { type: 'boolean', description: 'Open it as a draft (marks the title accordingly).' }
+      },
+      ['sourceBranch', 'targetBranch', 'title']
+    )
+  },
+  {
+    name: 'updateCodeHostMergeRequest',
+    description:
+      'Edit an existing merge request’s title, description, target branch, or draft state. Supply at least one of ' +
+      'them; everything else is left untouched. Requires write authority.',
+    inputSchema: obj(
+      {
+        iid: { type: 'integer', minimum: 1, description: 'The merge request’s project-scoped number (IID).' },
+        title: { type: 'string', description: 'Replacement title.' },
+        description: { type: 'string', description: 'Replacement description in Markdown.' },
+        targetBranch: { type: 'string', description: 'Retarget the merge request at this branch.' },
+        draft: { type: 'boolean', description: 'Set or clear draft state (requires `title` to re-mark it).' }
+      },
+      ['iid']
+    )
+  },
+  {
+    name: 'inspectCodeHostPipelines',
+    description:
+      'Inspect CI in this session’s project: list recent pipelines, read one pipeline, list a pipeline’s jobs, or ' +
+      'read one job. Read-only, so a read-level authorization is enough. Results are bounded.',
+    inputSchema: obj(
+      {
+        scope: {
+          type: 'string',
+          enum: ['pipelines', 'pipeline', 'pipeline_jobs', 'job'],
+          description:
+            '`pipelines` lists recent pipelines; `pipeline` and `pipeline_jobs` need `pipelineId`; `job` needs `jobId`.'
+        },
+        pipelineId: {
+          type: 'string',
+          pattern: '^[1-9][0-9]*$',
+          description: 'Required for `pipeline`/`pipeline_jobs`.'
+        },
+        jobId: { type: 'string', pattern: '^[1-9][0-9]*$', description: 'Required for `job`.' },
+        ref: { type: 'string', description: 'Only for `pipelines`: filter by branch or tag.' },
+        status: {
+          type: 'string',
+          enum: [...BROKER_PIPELINE_STATUSES],
+          description: 'Only for `pipelines`: filter by pipeline status.'
+        },
+        limit: { type: 'integer', minimum: 1, maximum: 20, description: 'Maximum entries to list (default 20).' }
+      },
+      ['scope']
+    )
+  },
+  {
+    name: 'controlCodeHostPipeline',
+    description:
+      'Retry or cancel a pipeline or a single job in this session’s project. Requires write authority; nothing else ' +
+      'about the pipeline can be changed here.',
+    inputSchema: obj(
+      {
+        action: {
+          type: 'string',
+          enum: ['retry_pipeline', 'cancel_pipeline', 'retry_job', 'cancel_job'],
+          description: 'Pipeline actions need `pipelineId`; job actions need `jobId`.'
+        },
+        pipelineId: { type: 'string', pattern: '^[1-9][0-9]*$', description: 'Required for the pipeline actions.' },
+        jobId: { type: 'string', pattern: '^[1-9][0-9]*$', description: 'Required for the job actions.' }
+      },
+      ['action']
+    )
+  }
+]
+
 export const ALL_TOOL_NAMES = [
   ...new Set(
     [
@@ -709,7 +868,8 @@ export const ALL_TOOL_NAMES = [
       // reserved (no evaluation tool may shadow it) and auto-allowed (a session warm with
       // the old descriptor, or an in-flight orchestration, must not start hitting approval).
       ...RETIRED_ORCHESTRATION_TOOLS,
-      ...GITHUB_REVIEW_TOOLS
+      ...GITHUB_REVIEW_TOOLS,
+      ...CODE_HOST_EFFECT_TOOLS
     ]
       .map((t) => t.name)
       // External-memory record tools: only their names are core knowledge here, the descriptors live in memory/.

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -320,7 +320,7 @@ function gitlabReplyHint(c: HookContext, gitlab: GitlabHookMetadata): string {
   if (gitlab.target.kind === 'push') return ''
   return [
     '',
-    `Return one self-contained final answer for ${gitlabSubjectRef(c, gitlab)}. The daemon posts it back to that GitLab thread automatically as one note and exclusively owns the reply. Do NOT create, update, or delete GitLab notes through \`glab\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitLab access is READ-only inspection.`
+    `Return one self-contained final answer for ${gitlabSubjectRef(c, gitlab)}. The daemon posts it back to that GitLab thread automatically as one note and exclusively owns the reply. Do NOT create, update, or delete GitLab notes through \`glab\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Any other effect — a separate comment, a discussion reply, a merge request, a pipeline action — goes through the structured code-host tools when you have them; every other GitLab access is READ-only inspection.`
   ].join('\n')
 }
 

--- a/packages/daemon/test/cp/git-credential.test.ts
+++ b/packages/daemon/test/cp/git-credential.test.ts
@@ -342,4 +342,76 @@ describe('GitCredentialCache', () => {
       expect((await h.cache.get(AGENT, 'helper', { repo: 'other-org/tools' })).token).toBe('ghs_2')
     })
   })
+
+  describe('gitlab effect lease (gitlab-com-integration.md 14.2)', () => {
+    const PROJECT = '4455667'
+
+    function buildEffect(responder: (n: number, payload: { purpose?: string }) => GitCredGrant) {
+      let calls = 0
+      let mono = 0
+      const cache = new GitCredentialCache({
+        request: async (p) => {
+          calls += 1
+          return responder(calls, p)
+        },
+        log: { warn: () => {} },
+        providerV2Supported: () => true,
+        gitlabEffectSupported: () => true,
+        monoNow: () => mono
+      })
+      return { cache, calls: () => calls, advance: (ms: number) => (mono += ms) }
+    }
+
+    function effectGrant(token: string): GitCredGrant {
+      return {
+        username: 'project_4455667_bot',
+        token,
+        ttlSec: 3540,
+        expiresAt: '2026-07-06T13:00:00.000Z',
+        repoFullName: 'example-group/example-project',
+        access: 'comment',
+        provider: 'gitlab',
+        externalRepoId: PROJECT
+      }
+    }
+
+    it('keeps a SCOPE_DENIED effect lease retryable instead of durably denying the key', async () => {
+      const h = buildEffect((n) => {
+        if (n === 1) throw Object.assign(new Error('hook is not enabled'), { code: 'SCOPE_DENIED' })
+        return effectGrant(`glpat_${n}`)
+      })
+      // A stale hook refusal is NOT terminal: hook lifecycle never replicates an agent spec,
+      // so a durable denial here could only be cleared by a restart or an unrelated upsert.
+      await expect(h.cache.getGitlabEffectToken(AGENT, PROJECT, HOOK)).rejects.toMatchObject({ terminal: false })
+      // The very next call re-contacts the CP, which re-resolves the hook live.
+      expect((await h.cache.getGitlabEffectToken(AGENT, PROJECT, HOOK)).token).toBe('glpat_2')
+      expect(h.calls()).toBe(2)
+    })
+
+    it('does not need clearDenied to recover, and never silences the agent workspace key', async () => {
+      const h = buildEffect((n) => {
+        if (n <= 2) throw Object.assign(new Error('hook is not enabled'), { code: 'SCOPE_DENIED' })
+        return effectGrant(`glpat_${n}`)
+      })
+      await expect(h.cache.getGitlabEffectToken(AGENT, PROJECT)).rejects.toBeInstanceOf(GitCredUnavailableError)
+      await expect(h.cache.getGitlabEffectToken(AGENT, PROJECT)).rejects.toBeInstanceOf(GitCredUnavailableError)
+      // Two refusals, two CP asks — no local negative cache absorbed the second one.
+      expect(h.calls()).toBe(2)
+      expect((await h.cache.getGitlabEffectToken(AGENT, PROJECT)).token).toBe('glpat_3')
+      // And the agent's own workspace grant was never dragged into the denial.
+      expect((await h.cache.get(AGENT, 'clone', { provider: 'gitlab', externalRepoId: PROJECT })).token).toBe('glpat_4')
+    })
+
+    it('leaves a workspace-keyed git SCOPE_DENIED terminal, exactly as before', async () => {
+      const h = buildEffect((n, p) => {
+        if (p.purpose === undefined) throw Object.assign(new Error('not placed here'), { code: 'SCOPE_DENIED' })
+        return effectGrant(`glpat_${n}`)
+      })
+      await expect(h.cache.get(AGENT, 'push')).rejects.toMatchObject({ terminal: true })
+      await expect(h.cache.get(AGENT, 'push')).rejects.toMatchObject({ terminal: true })
+      expect(h.calls()).toBe(1) // still silenced locally — the git-purpose behavior is unchanged
+      // …and that terminal git denial does not reach the effect keyspace.
+      expect((await h.cache.getGitlabEffectToken(AGENT, PROJECT)).token).toBe('glpat_2')
+    })
+  })
 })

--- a/packages/daemon/test/gitlab-broker.test.ts
+++ b/packages/daemon/test/gitlab-broker.test.ts
@@ -1,0 +1,648 @@
+// GitLab structured mutation broker (gitlab-com-integration.md §14.2): allowlisted endpoints,
+// clamped capabilities, a daemon-held effect lease, and bounded structured results.
+import { describe, it, expect, vi } from 'vitest'
+import {
+  GitlabBroker,
+  GITLAB_BROKER_ENDPOINTS,
+  type BrokerCapability,
+  type GitlabBrokerOperation,
+  type GitlabBrokerTarget
+} from '../src/gitlab/broker.js'
+import { GitCredentialCache, GitCredUnavailableError } from '../src/cp/git-credential.js'
+import { executeTool, type OpsDeps, type SessionContext } from '../src/mcp/ops.js'
+
+const BASE = 'https://gitlab.example.test/api/v4'
+const PROJECT = '4455667'
+const TARGET: GitlabBrokerTarget = { agentId: 'agent-1', projectId: PROJECT, sessionKey: 'session-1' }
+
+interface Call {
+  method: string
+  url: string
+  token: string
+  contentType?: string
+  body?: unknown
+}
+
+/** `statuses` is the per-attempt response status; anything omitted succeeds with the queued body. */
+function fakeFetch(opts: { statuses?: number[]; bodies?: string[]; body?: string } = {}) {
+  const calls: Call[] = []
+  let n = 0
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const index = n
+    n += 1
+    const headers = (init?.headers ?? {}) as Record<string, string>
+    calls.push({
+      method: init?.method ?? 'GET',
+      url: String(url),
+      token: headers['private-token'] ?? '',
+      ...(headers['content-type'] !== undefined ? { contentType: headers['content-type'] } : {}),
+      ...(init?.body === undefined ? {} : { body: JSON.parse(String(init.body)) })
+    })
+    const status = opts.statuses?.[index]
+    if (status !== undefined && status >= 400) return new Response('{"message":"403 Forbidden"}', { status })
+    return new Response(opts.bodies?.[index] ?? opts.body ?? '{"id":9001}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    })
+  }) as typeof fetch
+  return { fetchImpl, calls }
+}
+
+function broker(
+  fetchImpl: typeof fetch,
+  opts: { access?: BrokerCapability; tokens?: string[]; invalidate?: (token: string) => void } = {}
+) {
+  const tokens = opts.tokens ?? ['glpat-effect']
+  let minted = 0
+  const instance = new GitlabBroker({
+    lease: async () => ({ token: tokens[Math.min(minted++, tokens.length - 1)]!, access: opts.access ?? 'write' }),
+    invalidateLease: (_target, token) => opts.invalidate?.(token),
+    baseUrl: BASE,
+    fetchImpl
+  })
+  return { instance, minted: () => minted }
+}
+
+async function run(
+  op: GitlabBrokerOperation,
+  opts: Parameters<typeof broker>[1] = {},
+  fetchOpts: Parameters<typeof fakeFetch>[0] = {}
+) {
+  const { fetchImpl, calls } = fakeFetch(fetchOpts)
+  const { instance } = broker(fetchImpl, opts)
+  const result = await instance.execute(TARGET, op)
+  return { result, calls }
+}
+
+describe('the allowlist is the whole surface', () => {
+  it('declares only bounded methods and templated paths', () => {
+    for (const [id, endpoint] of Object.entries(GITLAB_BROKER_ENDPOINTS)) {
+      expect(['GET', 'POST', 'PUT'], id).toContain(endpoint.method)
+      expect(endpoint.path.startsWith('/projects/:project'), id).toBe(true)
+      expect(endpoint.path, id).not.toContain('?')
+    }
+  })
+
+  it('classifies every endpoint into a read, comment, or write capability', () => {
+    const byCapability = (capability: BrokerCapability) =>
+      Object.entries(GITLAB_BROKER_ENDPOINTS)
+        .filter(([, endpoint]) => endpoint.capability === capability)
+        .map(([id]) => id)
+        .sort()
+    expect(byCapability('read')).toEqual([
+      'discussion.get',
+      'discussion.list',
+      'job.get',
+      'pipeline.get',
+      'pipeline.jobs',
+      'pipeline.list'
+    ])
+    expect(byCapability('comment')).toEqual(['comment.create', 'comment.update', 'discussion.reply'])
+    expect(byCapability('write')).toEqual([
+      'job.cancel',
+      'job.retry',
+      'mergeRequest.create',
+      'mergeRequest.update',
+      'pipeline.cancel',
+      'pipeline.retry'
+    ])
+  })
+})
+
+describe('each operation calls exactly one allowlisted endpoint', () => {
+  it('creates an issue comment', async () => {
+    const { calls } = await run({ kind: 'createComment', subject: 'issue', iid: 12, body: 'hello' })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      method: 'POST',
+      url: `${BASE}/projects/4455667/issues/12/notes`,
+      token: 'glpat-effect',
+      contentType: 'application/json',
+      body: { body: 'hello' }
+    })
+  })
+
+  it('creates a merge-request comment on the merge-request path', async () => {
+    const { calls } = await run({ kind: 'createComment', subject: 'merge_request', iid: 77, body: 'hi' })
+    expect(calls[0]?.url).toBe(`${BASE}/projects/4455667/merge_requests/77/notes`)
+  })
+
+  it('lists discussions with a bounded page size', async () => {
+    const { calls } = await run(
+      { kind: 'readDiscussions', subject: 'merge_request', iid: 77, limit: 500 },
+      {},
+      { body: '[]' }
+    )
+    expect(calls[0]).toMatchObject({
+      method: 'GET',
+      url: `${BASE}/projects/4455667/merge_requests/77/discussions?per_page=20`
+    })
+    expect(calls[0]?.contentType).toBeUndefined()
+  })
+
+  it('reads one discussion by id', async () => {
+    const { calls } = await run(
+      { kind: 'readDiscussions', subject: 'merge_request', iid: 77, discussionId: 'a1b2c3d4e5f6' },
+      {},
+      { body: '{"id":"a1b2c3d4e5f6","notes":[]}' }
+    )
+    expect(calls[0]?.url).toBe(`${BASE}/projects/4455667/merge_requests/77/discussions/a1b2c3d4e5f6`)
+  })
+
+  it('replies into one discussion', async () => {
+    const { calls } = await run({
+      kind: 'replyDiscussion',
+      subject: 'merge_request',
+      iid: 77,
+      discussionId: 'a1b2c3d4e5f6',
+      body: 'answered'
+    })
+    expect(calls[0]).toMatchObject({
+      method: 'POST',
+      url: `${BASE}/projects/4455667/merge_requests/77/discussions/a1b2c3d4e5f6/notes`,
+      body: { body: 'answered' }
+    })
+  })
+
+  it('creates a merge request from bounded fields only', async () => {
+    const { calls } = await run({
+      kind: 'createMergeRequest',
+      sourceBranch: 'feature/x',
+      targetBranch: 'main',
+      title: 'Add x',
+      description: 'why',
+      draft: true
+    })
+    expect(calls[0]).toMatchObject({
+      method: 'POST',
+      url: `${BASE}/projects/4455667/merge_requests`,
+      body: { source_branch: 'feature/x', target_branch: 'main', title: 'Draft: Add x', description: 'why' }
+    })
+  })
+
+  it('updates a merge request and clears the draft marker', async () => {
+    const { calls } = await run({
+      kind: 'updateMergeRequest',
+      iid: 77,
+      title: 'Draft: Add x',
+      targetBranch: 'release',
+      draft: false
+    })
+    expect(calls[0]).toMatchObject({
+      method: 'PUT',
+      url: `${BASE}/projects/4455667/merge_requests/77`,
+      body: { title: 'Add x', target_branch: 'release' }
+    })
+  })
+
+  it('inspects pipelines, one pipeline, its jobs, and one job', async () => {
+    const list = await run(
+      { kind: 'inspectPipelines', scope: 'pipelines', ref: 'main', status: 'failed' },
+      {},
+      { body: '[]' }
+    )
+    expect(list.calls[0]?.url).toBe(`${BASE}/projects/4455667/pipelines?per_page=20&ref=main&status=failed`)
+
+    const one = await run({ kind: 'inspectPipelines', scope: 'pipeline', pipelineId: '31' })
+    expect(one.calls[0]).toMatchObject({ method: 'GET', url: `${BASE}/projects/4455667/pipelines/31` })
+
+    const jobs = await run({ kind: 'inspectPipelines', scope: 'pipeline_jobs', pipelineId: '31' }, {}, { body: '[]' })
+    expect(jobs.calls[0]?.url).toBe(`${BASE}/projects/4455667/pipelines/31/jobs?per_page=20`)
+
+    const job = await run({ kind: 'inspectPipelines', scope: 'job', jobId: '99' })
+    expect(job.calls[0]?.url).toBe(`${BASE}/projects/4455667/jobs/99`)
+  })
+
+  it('retries and cancels pipelines and jobs', async () => {
+    const cases: [GitlabBrokerOperation, string][] = [
+      [
+        { kind: 'controlPipeline', action: 'retry_pipeline', pipelineId: '31' },
+        `${BASE}/projects/4455667/pipelines/31/retry`
+      ],
+      [
+        { kind: 'controlPipeline', action: 'cancel_pipeline', pipelineId: '31' },
+        `${BASE}/projects/4455667/pipelines/31/cancel`
+      ],
+      [{ kind: 'controlPipeline', action: 'retry_job', jobId: '99' }, `${BASE}/projects/4455667/jobs/99/retry`],
+      [{ kind: 'controlPipeline', action: 'cancel_job', jobId: '99' }, `${BASE}/projects/4455667/jobs/99/cancel`]
+    ]
+    for (const [op, url] of cases) {
+      const { calls } = await run(op)
+      expect(calls[0]).toMatchObject({ method: 'POST', url })
+    }
+  })
+})
+
+describe('capability classes are enforced against the clamped grant', () => {
+  const comment: GitlabBrokerOperation = { kind: 'createComment', subject: 'issue', iid: 12, body: 'hi' }
+  const write: GitlabBrokerOperation = { kind: 'controlPipeline', action: 'retry_pipeline', pipelineId: '31' }
+  const read: GitlabBrokerOperation = { kind: 'inspectPipelines', scope: 'pipeline', pipelineId: '31' }
+
+  it('lets a read clamp read but refuses comment and write', async () => {
+    await expect(run(read, { access: 'read' })).resolves.toBeDefined()
+    await expect(run(comment, { access: 'read' })).rejects.toThrow(
+      /needs comment authority on the GitLab project, but the current authorization grants read/
+    )
+    await expect(run(write, { access: 'read' })).rejects.toThrow(/needs write authority/)
+  })
+
+  it('lets a comment clamp comment but refuses write', async () => {
+    await expect(run(comment, { access: 'comment' })).resolves.toBeDefined()
+    await expect(run(write, { access: 'comment' })).rejects.toThrow(
+      /needs write authority on the GitLab project, but the current authorization grants comment/
+    )
+  })
+
+  it('lets a write clamp do everything', async () => {
+    await expect(run(read, { access: 'write' })).resolves.toBeDefined()
+    await expect(run(comment, { access: 'write' })).resolves.toBeDefined()
+    await expect(run(write, { access: 'write' })).resolves.toBeDefined()
+  })
+
+  it('refuses before reaching GitLab at all', async () => {
+    const { fetchImpl, calls } = fakeFetch()
+    const { instance } = broker(fetchImpl, { access: 'read' })
+    await expect(instance.execute(TARGET, comment)).rejects.toThrow(/needs comment authority/)
+    expect(calls).toEqual([])
+  })
+})
+
+describe('lease invalidation and retry', () => {
+  it('re-mints once after a definite auth rejection and replays with the new token', async () => {
+    const invalidate = vi.fn()
+    const { fetchImpl, calls } = fakeFetch({ statuses: [401] })
+    const { instance } = broker(fetchImpl, { tokens: ['glpat-stale', 'glpat-fresh'], invalidate })
+    await instance.execute(TARGET, { kind: 'createComment', subject: 'issue', iid: 12, body: 'hi' })
+    expect(invalidate).toHaveBeenCalledWith('glpat-stale')
+    expect(calls.map((call) => call.token)).toEqual(['glpat-stale', 'glpat-fresh'])
+  })
+
+  it('gives up after the second rejection instead of looping', async () => {
+    const { fetchImpl, calls } = fakeFetch({ statuses: [403, 403] })
+    const { instance } = broker(fetchImpl, { tokens: ['glpat-stale', 'glpat-fresh'] })
+    await expect(
+      instance.execute(TARGET, { kind: 'createComment', subject: 'issue', iid: 12, body: 'hi' })
+    ).rejects.toThrow(/GitLab POST failed with 403: 403 Forbidden/)
+    expect(calls).toHaveLength(2)
+  })
+
+  it('does not retry a non-auth failure', async () => {
+    const { fetchImpl, calls } = fakeFetch({ statuses: [404] })
+    const { instance } = broker(fetchImpl)
+    await expect(
+      instance.execute(TARGET, { kind: 'inspectPipelines', scope: 'pipeline', pipelineId: '31' })
+    ).rejects.toThrow(/GitLab GET failed with 404/)
+    expect(calls).toHaveLength(1)
+  })
+})
+
+describe('bounded structured results', () => {
+  it('preserves ids beyond the safe-integer range as strings', async () => {
+    const { result } = await run(
+      { kind: 'createComment', subject: 'issue', iid: 12, body: 'hi' },
+      {},
+      { body: '{"id":9007199254740993123,"project_id":4455667123456789012,"created_at":"2026-01-02T03:04:05Z"}' }
+    )
+    expect(result).toMatchObject({ note: { id: '9007199254740993123', createdAt: '2026-01-02T03:04:05Z' } })
+  })
+
+  it('reports the merge request as ids, state, and link only', async () => {
+    const { result } = await run(
+      { kind: 'updateMergeRequest', iid: 77, title: 'Add x' },
+      {},
+      {
+        body: JSON.stringify({
+          id: 5,
+          iid: 77,
+          project_id: 4455667,
+          title: 'Add x',
+          state: 'opened',
+          draft: false,
+          source_branch: 'feature/x',
+          target_branch: 'main',
+          web_url: 'https://gitlab.example.test/example-group/example-project/-/merge_requests/77',
+          secret_note: 'dropped'
+        })
+      }
+    )
+    expect(result).toEqual({
+      mergeRequest: {
+        id: '5',
+        iid: 77,
+        projectId: '4455667',
+        title: 'Add x',
+        state: 'opened',
+        draft: false,
+        sourceBranch: 'feature/x',
+        targetBranch: 'main',
+        webUrl: 'https://gitlab.example.test/example-group/example-project/-/merge_requests/77'
+      }
+    })
+  })
+
+  it('caps a listed page at the bounded item count', async () => {
+    const pipelines = Array.from({ length: 50 }, (_, index) => ({ id: index + 1, status: 'success' }))
+    const { result } = await run(
+      { kind: 'inspectPipelines', scope: 'pipelines' },
+      {},
+      { body: JSON.stringify(pipelines) }
+    )
+    expect((result as { pipelines: unknown[] }).pipelines).toHaveLength(20)
+  })
+})
+
+describe('single-writer discipline for comment updates', () => {
+  const create: GitlabBrokerOperation = { kind: 'createComment', subject: 'issue', iid: 12, body: 'first' }
+  const update: GitlabBrokerOperation = {
+    kind: 'updateComment',
+    subject: 'issue',
+    iid: 12,
+    noteId: '9001',
+    body: 'second'
+  }
+
+  it('refuses a comment this session did not author', async () => {
+    const { fetchImpl, calls } = fakeFetch()
+    const { instance } = broker(fetchImpl)
+    await expect(instance.execute(TARGET, update)).rejects.toThrow(
+      'only a comment this session created through the broker can be updated'
+    )
+    expect(calls).toEqual([])
+  })
+
+  it('accepts a comment the broker created in this session', async () => {
+    const { fetchImpl, calls } = fakeFetch()
+    const { instance } = broker(fetchImpl)
+    await instance.execute(TARGET, create)
+    await instance.execute(TARGET, update)
+    expect(calls[1]).toMatchObject({
+      method: 'PUT',
+      url: `${BASE}/projects/4455667/issues/12/notes/9001`,
+      body: { body: 'second' }
+    })
+  })
+
+  it('does not carry authorship across sessions', async () => {
+    const { fetchImpl } = fakeFetch()
+    const { instance } = broker(fetchImpl)
+    await instance.execute(TARGET, create)
+    await expect(instance.execute({ ...TARGET, sessionKey: 'session-2' }, update)).rejects.toThrow(
+      'only a comment this session created through the broker can be updated'
+    )
+  })
+})
+
+describe('trusted path parameters', () => {
+  it('refuses a non-numeric project id rather than composing a path from it', async () => {
+    const { fetchImpl, calls } = fakeFetch()
+    const { instance } = broker(fetchImpl)
+    await expect(
+      instance.execute(
+        { ...TARGET, projectId: 'example-group/example-project' },
+        { kind: 'createComment', subject: 'issue', iid: 12, body: 'hi' }
+      )
+    ).rejects.toThrow('project id must be a positive decimal id')
+    expect(calls).toEqual([])
+  })
+
+  it('refuses a discussion id that is not a GitLab digest', async () => {
+    const { fetchImpl } = fakeFetch()
+    const { instance } = broker(fetchImpl)
+    await expect(
+      instance.execute(TARGET, {
+        kind: 'replyDiscussion',
+        subject: 'merge_request',
+        iid: 77,
+        discussionId: '../../projects/1',
+        body: 'x'
+      })
+    ).rejects.toThrow('discussionId must be a GitLab discussion id')
+  })
+
+  it('refuses a branch name that is not a branch name', async () => {
+    const { fetchImpl } = fakeFetch()
+    const { instance } = broker(fetchImpl)
+    await expect(
+      instance.execute(TARGET, {
+        kind: 'createMergeRequest',
+        sourceBranch: 'feature/x',
+        targetBranch: 'main?private_token=leak',
+        title: 'Add x'
+      })
+    ).rejects.toThrow('targetBranch must be a branch name')
+  })
+
+  it('requires the id its scope needs', async () => {
+    const { fetchImpl } = fakeFetch()
+    const { instance } = broker(fetchImpl)
+    await expect(instance.execute(TARGET, { kind: 'inspectPipelines', scope: 'pipeline' })).rejects.toThrow(
+      'pipelineId is required for pipeline'
+    )
+    await expect(instance.execute(TARGET, { kind: 'controlPipeline', action: 'retry_job' })).rejects.toThrow(
+      'jobId is required for retry_job'
+    )
+  })
+})
+
+describe('effect leases are gated on the control plane feature', () => {
+  function cache(features: { providerV2?: boolean; gitlabEffect?: boolean }) {
+    const request = vi.fn(async () => {
+      throw new Error('the control plane must never be asked before the gate passes')
+    })
+    return {
+      request,
+      instance: new GitCredentialCache({
+        request: request as never,
+        log: { warn: () => {} },
+        providerV2Supported: () => features.providerV2 === true,
+        gitlabEffectSupported: () => features.gitlabEffect === true
+      })
+    }
+  }
+
+  it('refuses with a clear message when the control plane lacks gitlab-effect-v1', async () => {
+    const { instance, request } = cache({ providerV2: true })
+    await expect(instance.getGitlabEffectToken('agent-1', PROJECT)).rejects.toThrow(
+      'the control plane does not support GitLab effect leases yet'
+    )
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('still requires the provider-qualified v2 wire', async () => {
+    const { instance } = cache({ gitlabEffect: true })
+    await expect(instance.getGitlabEffectToken('agent-1', PROJECT)).rejects.toBeInstanceOf(GitCredUnavailableError)
+  })
+
+  it('names purpose gitlab_effect with the trusted project once both features are advertised', async () => {
+    const request = vi.fn(async () => ({
+      username: 'project_4455667_bot',
+      token: 'glpat-effect',
+      ttlSec: 3600,
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      repoFullName: 'example-group/example-project',
+      access: 'comment' as const,
+      provider: 'gitlab' as const,
+      externalRepoId: PROJECT
+    }))
+    const instance = new GitCredentialCache({
+      request,
+      log: { warn: () => {} },
+      providerV2Supported: () => true,
+      gitlabEffectSupported: () => true
+    })
+    const entry = await instance.getGitlabEffectToken('agent-1', PROJECT, 'hook-1')
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'agent-1',
+        provider: 'gitlab',
+        externalRepoId: PROJECT,
+        purpose: 'gitlab_effect',
+        hookId: 'hook-1'
+      })
+    )
+    expect(entry.access).toBe('comment')
+  })
+
+  it('keeps the broker lease in its own keyspace, so invalidating it leaves the poster token alone', async () => {
+    const grant = (token: string) => ({
+      username: 'project_4455667_bot',
+      token,
+      ttlSec: 3600,
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      repoFullName: 'example-group/example-project',
+      access: 'comment' as const,
+      provider: 'gitlab' as const,
+      externalRepoId: PROJECT
+    })
+    let minted = 0
+    const instance = new GitCredentialCache({
+      request: async () => grant(`glpat-${++minted}`),
+      log: { warn: () => {} },
+      providerV2Supported: () => true,
+      gitlabEffectSupported: () => true
+    })
+    const post = await instance.getGitlabPostToken('agent-1', PROJECT, 'hook-1')
+    const effect = await instance.getGitlabEffectToken('agent-1', PROJECT)
+    expect(post.token).not.toBe(effect.token)
+    instance.invalidateGitlabEffect('agent-1', PROJECT, effect.token)
+    expect((await instance.getGitlabPostToken('agent-1', PROJECT, 'hook-1')).token).toBe(post.token)
+    expect((await instance.getGitlabEffectToken('agent-1', PROJECT)).token).not.toBe(effect.token)
+  })
+})
+
+describe('the MCP surface validates arguments before the broker sees them', () => {
+  const ctx: SessionContext = {
+    agentId: 'agent-1',
+    platform: 'gitlab',
+    isDm: false,
+    channel: 'hook-1',
+    thread: 'thread-1',
+    tools: []
+  }
+
+  function deps(codeHostEffect?: OpsDeps['codeHostEffect']): OpsDeps {
+    return {
+      ...(codeHostEffect ? { codeHostEffect } : {}),
+      gatewayFor: () => undefined
+    } as unknown as OpsDeps
+  }
+
+  it('hands the daemon a discriminated operation, never a project', async () => {
+    const codeHostEffect = vi.fn(async () => ({ note: { id: '1' } }))
+    await executeTool(
+      ctx,
+      'createCodeHostComment',
+      { subject: 'merge_request', iid: 77, body: 'hi' },
+      deps(codeHostEffect)
+    )
+    expect(codeHostEffect).toHaveBeenCalledWith({
+      agentId: 'agent-1',
+      platform: 'gitlab',
+      channel: 'hook-1',
+      thread: 'thread-1',
+      operation: { kind: 'createComment', subject: 'merge_request', iid: 77, body: 'hi' }
+    })
+  })
+
+  it('ignores a project supplied as an argument', async () => {
+    const codeHostEffect = vi.fn(async () => ({}))
+    await executeTool(
+      ctx,
+      'createCodeHostComment',
+      { subject: 'issue', iid: 12, body: 'hi', projectId: '1', project: 'example-group/example-project' },
+      deps(codeHostEffect)
+    )
+    expect(codeHostEffect.mock.calls[0]?.[0].operation).toEqual({
+      kind: 'createComment',
+      subject: 'issue',
+      iid: 12,
+      body: 'hi'
+    })
+  })
+
+  it('rejects an out-of-vocabulary subject and a non-positive iid', async () => {
+    await expect(
+      executeTool(
+        ctx,
+        'createCodeHostComment',
+        { subject: 'snippet', iid: 1, body: 'hi' },
+        deps(async () => ({}))
+      )
+    ).rejects.toThrow('argument subject must be one of: issue, merge_request')
+    await expect(
+      executeTool(
+        ctx,
+        'createCodeHostComment',
+        { subject: 'issue', iid: 0, body: 'hi' },
+        deps(async () => ({}))
+      )
+    ).rejects.toThrow('argument iid must be a positive integer')
+  })
+
+  it('rejects a note id that is not a positive decimal string', async () => {
+    await expect(
+      executeTool(
+        ctx,
+        'updateCodeHostComment',
+        { subject: 'issue', iid: 12, noteId: '../9001', body: 'x' },
+        deps(async () => ({}))
+      )
+    ).rejects.toThrow('argument noteId must be a positive decimal string')
+  })
+
+  it('requires a field to change on a merge-request update, and a title to move draft state', async () => {
+    await expect(
+      executeTool(
+        ctx,
+        'updateCodeHostMergeRequest',
+        { iid: 77 },
+        deps(async () => ({}))
+      )
+    ).rejects.toThrow('supply at least one of title, description, or targetBranch')
+    await expect(
+      executeTool(
+        ctx,
+        'updateCodeHostMergeRequest',
+        { iid: 77, description: 'x', draft: true },
+        deps(async () => ({}))
+      )
+    ).rejects.toThrow('argument draft also requires title')
+  })
+
+  it('rejects an unknown pipeline action', async () => {
+    await expect(
+      executeTool(
+        ctx,
+        'controlCodeHostPipeline',
+        { action: 'delete_pipeline' },
+        deps(async () => ({}))
+      )
+    ).rejects.toThrow('argument action must be one of: retry_pipeline, cancel_pipeline, retry_job, cancel_job')
+  })
+
+  it('fails closed on a daemon with no broker wired', async () => {
+    await expect(executeTool(ctx, 'inspectCodeHostPipelines', { scope: 'pipelines' }, deps())).rejects.toThrow(
+      'code-host effects are unavailable on this daemon'
+    )
+  })
+})

--- a/packages/daemon/test/gitlab-broker.test.ts
+++ b/packages/daemon/test/gitlab-broker.test.ts
@@ -233,6 +233,60 @@ describe('each operation calls exactly one allowlisted endpoint', () => {
   })
 })
 
+describe('draft markers normalize in both directions', () => {
+  // GitLab carries draft state in the title, and recognizes each of these prefixes.
+  const MARKED = [
+    'Draft: Add x',
+    '[Draft] Add x',
+    '(Draft) Add x',
+    'draft: Add x',
+    '[draft] Add x',
+    'WIP: Add x',
+    '[WIP] Add x',
+    '(WIP) Add x'
+  ]
+
+  it.each(MARKED)('clears %s on a merge-request update', async (title) => {
+    const { calls } = await run({ kind: 'updateMergeRequest', iid: 77, title, draft: false })
+    expect((calls[0]?.body as { title: string }).title).toBe('Add x')
+  })
+
+  it.each(MARKED)('re-marks %s exactly once when a merge request is created as a draft', async (title) => {
+    const { calls } = await run({
+      kind: 'createMergeRequest',
+      sourceBranch: 'feature/x',
+      targetBranch: 'main',
+      title,
+      draft: true
+    })
+    expect((calls[0]?.body as { title: string }).title).toBe('Draft: Add x')
+  })
+
+  it.each(MARKED)('re-marks %s exactly once on a merge-request update', async (title) => {
+    const { calls } = await run({ kind: 'updateMergeRequest', iid: 77, title, draft: true })
+    expect((calls[0]?.body as { title: string }).title).toBe('Draft: Add x')
+  })
+
+  it('marks an unmarked title and clears a title that carries several markers', async () => {
+    const marked = await run({
+      kind: 'createMergeRequest',
+      sourceBranch: 'feature/x',
+      targetBranch: 'main',
+      title: 'Add x',
+      draft: true
+    })
+    expect((marked.calls[0]?.body as { title: string }).title).toBe('Draft: Add x')
+
+    const cleared = await run({ kind: 'updateMergeRequest', iid: 77, title: 'Draft: [WIP] Add x', draft: false })
+    expect((cleared.calls[0]?.body as { title: string }).title).toBe('Add x')
+  })
+
+  it('leaves the title untouched when the flag is absent', async () => {
+    const { calls } = await run({ kind: 'updateMergeRequest', iid: 77, title: '[Draft] Add x' })
+    expect((calls[0]?.body as { title: string }).title).toBe('[Draft] Add x')
+  })
+})
+
 describe('capability classes are enforced against the clamped grant', () => {
   const comment: GitlabBrokerOperation = { kind: 'createComment', subject: 'issue', iid: 12, body: 'hi' }
   const write: GitlabBrokerOperation = { kind: 'controlPipeline', action: 'retry_pipeline', pipelineId: '31' }

--- a/packages/daemon/test/mcp-tool-args.test.ts
+++ b/packages/daemon/test/mcp-tool-args.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import { SEND_MESSAGE_BRANCHES, TOOL_ARG_SCHEMAS } from '../src/mcp/ops.js'
-import { GITHUB_REVIEW_TOOLS, RETIRED_ORCHESTRATION_TOOLS, toolsForIntegrations } from '../src/mcp/tools.js'
+import {
+  CODE_HOST_EFFECT_TOOLS,
+  GITHUB_REVIEW_TOOLS,
+  RETIRED_ORCHESTRATION_TOOLS,
+  toolsForIntegrations
+} from '../src/mcp/tools.js'
 import { externalMemoryTools } from '../src/memory/tools.js'
 import type { ToolDescriptor } from '../src/tool-schema/descriptor.js'
 import type { Integration } from '../src/agents/agent-schema.js'
@@ -31,7 +36,8 @@ const advertised: ToolDescriptor[] = [
   ...toolsForIntegrations([slackInt, telegramInt], { sessionTitle: true, organizationKnowledge: true }),
   ...externalMemoryTools(ALL_CAPABILITIES),
   ...RETIRED_ORCHESTRATION_TOOLS,
-  ...GITHUB_REVIEW_TOOLS
+  ...GITHUB_REVIEW_TOOLS,
+  ...CODE_HOST_EFFECT_TOOLS
 ]
 
 interface ObjectSchemaView {


### PR DESCRIPTION
## What

The daemon half of the design's structured mutation broker (gitlab-com-integration.md section 14.2): agent-visible structured tools that perform a bounded set of GitLab operations through a daemon-held effect lease. The token never enters the agent environment; the target project is never model input.

- Eight `…CodeHost…` tools covering exactly the section 14.2 list — comment create/update, discussion read/reply, merge-request create/update, pipeline/job inspection, pipeline/job retry/cancel. The neutral naming follows the design's `submitCodeReview` promotion signal (section 15) and the code-host seam vocabulary (section 6.5); GitLab is the first implementer behind it.
- One allowlist table (15 entries, `{method, capability, path}`): every path template starts at `/projects/:project`, placeholders fill only from trusted coordinates or validated decimal/enum/hex arguments, and rendering throws on an unfilled placeholder. No arbitrary path, no GraphQL, no raw body, no token exposure.
- Capability classes ranked `read < comment < write`, enforced against the clamped `access` echoed in the effect grant (#1376) before any GitLab request; refusals are model-visible and name the missing class.
- Trusted target: the hook turn's verified project metadata via a per-turn map, else the agent's replicated GitLab workspace project. Tools inject only for sessions whose agent has a managed GitLab workspace.
- The effect lease requires both `gitcred-provider-v2` and `gitlab-effect-v1` server features before naming `purpose: gitlab_effect`; it lives in its own cache keyspace, evicts on 401/403 with one retry, like the final poster's token.
- `updateCodeHostComment` accepts only note ids the broker itself created in the same session key, preserving the single-writer discipline; results are bounded projections with big-int ids preserved as strings.

## Tests

New `gitlab-broker.test.ts` (39 tests): exact URL/method/header per operation, capability refusals per clamp level, feature-gate refusal, token eviction + single retry, placeholder/argument validation, big-int id preservation, own-note update fence. Full daemon gate suite (10 files / 368 tests), typecheck, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
