### PR TITLE
fix(daemon): a refused hook-reply lease is retryable, not a durable denial

### DIFF
--- a/packages/daemon/src/cp/git-credential.ts
+++ b/packages/daemon/src/cp/git-credential.ts
@@ -39,6 +39,9 @@ const HANDOUT_MIN_MS = 10 * 60 * 1000
 /** Repo-level denials are retried after this — the console-authorization lag. */
 const REPO_DENIAL_TTL_MS = 60 * 1000
 
+/** Daemon-owned GitLab writers: project-keyed, re-resolved live per call, so a refusal is never durable. */
+const GITLAB_EFFECT_PURPOSES = new Set(['gitlab_hook_reply', 'gitlab_effect'])
+
 /** The baseline scope set behind `GH_TOKEN` (P2.5 write-back): git contents plus the
  *  issue/PR scopes `gh issue comment` / `gh pr comment` need. The CP clamps
  *  every capability — the workspace repo to the agent's gitAccess, an
@@ -354,9 +357,9 @@ export class GitCredentialCache {
     } catch (e) {
       const code = (e as { code?: string }).code
       if (code === 'SCOPE_DENIED') {
-        // §14.2: an effect lease is re-resolved live on every call and hook/binding lifecycle changes
-        // never replicate an agent spec, so its refusal is never durable — the next call asks again.
-        if (payload.purpose === 'gitlab_effect') {
+        // §14.1/§14.2: these leases are re-resolved live and hook/binding lifecycle changes never
+        // replicate an agent spec, so a refusal is never durable — the next turn asks the CP again.
+        if (payload.purpose !== undefined && GITLAB_EFFECT_PURPOSES.has(payload.purpose)) {
           this.entries.delete(key)
           throw new GitCredUnavailableError((e as Error).message, false)
         }

--- a/packages/daemon/test/cp/git-credential.test.ts
+++ b/packages/daemon/test/cp/git-credential.test.ts
@@ -343,7 +343,7 @@ describe('GitCredentialCache', () => {
     })
   })
 
-  describe('gitlab effect lease (gitlab-com-integration.md 14.2)', () => {
+  describe('daemon-owned gitlab leases (gitlab-com-integration.md 14.1/14.2)', () => {
     const PROJECT = '4455667'
 
     function buildEffect(responder: (n: number, payload: { purpose?: string }) => GitCredGrant) {
@@ -402,6 +402,33 @@ describe('GitCredentialCache', () => {
       expect((await h.cache.get(AGENT, 'clone', { provider: 'gitlab', externalRepoId: PROJECT })).token).toBe('glpat_4')
     })
 
+    it('keeps a SCOPE_DENIED hook-reply lease retryable instead of durably denying the key', async () => {
+      const h = buildEffect((n) => {
+        if (n === 1) throw Object.assign(new Error('hook is not enabled'), { code: 'SCOPE_DENIED' })
+        return effectGrant(`glpat_${n}`)
+      })
+      // The note poster carries only the numeric project, so this refusal used to read as agent-level.
+      await expect(h.cache.getGitlabPostToken(AGENT, PROJECT, HOOK)).rejects.toMatchObject({ terminal: false })
+      // A re-enabled hook takes effect on the next turn, with no agent upsert in between.
+      expect((await h.cache.getGitlabPostToken(AGENT, PROJECT, HOOK)).token).toBe('glpat_2')
+      expect(h.calls()).toBe(2)
+    })
+
+    it('recovers the note poster without clearDenied, and leaves the sibling keyspaces alone', async () => {
+      const h = buildEffect((n) => {
+        if (n <= 2) throw Object.assign(new Error('hook is not enabled'), { code: 'SCOPE_DENIED' })
+        return effectGrant(`glpat_${n}`)
+      })
+      await expect(h.cache.getGitlabPostToken(AGENT, PROJECT, HOOK)).rejects.toBeInstanceOf(GitCredUnavailableError)
+      await expect(h.cache.getGitlabPostToken(AGENT, PROJECT, HOOK)).rejects.toBeInstanceOf(GitCredUnavailableError)
+      // Two refusals, two CP asks — nothing absorbed the second one locally.
+      expect(h.calls()).toBe(2)
+      expect((await h.cache.getGitlabPostToken(AGENT, PROJECT, HOOK)).token).toBe('glpat_3')
+      // The broker lease and the agent's own workspace grant were never dragged into the denial.
+      expect((await h.cache.getGitlabEffectToken(AGENT, PROJECT)).token).toBe('glpat_4')
+      expect((await h.cache.get(AGENT, 'clone', { provider: 'gitlab', externalRepoId: PROJECT })).token).toBe('glpat_5')
+    })
+
     it('leaves a workspace-keyed git SCOPE_DENIED terminal, exactly as before', async () => {
       const h = buildEffect((n, p) => {
         if (p.purpose === undefined) throw Object.assign(new Error('not placed here'), { code: 'SCOPE_DENIED' })
@@ -410,8 +437,9 @@ describe('GitCredentialCache', () => {
       await expect(h.cache.get(AGENT, 'push')).rejects.toMatchObject({ terminal: true })
       await expect(h.cache.get(AGENT, 'push')).rejects.toMatchObject({ terminal: true })
       expect(h.calls()).toBe(1) // still silenced locally — the git-purpose behavior is unchanged
-      // …and that terminal git denial does not reach the effect keyspace.
+      // …and that terminal git denial reaches neither daemon-owned writer's keyspace.
       expect((await h.cache.getGitlabEffectToken(AGENT, PROJECT)).token).toBe('glpat_2')
+      expect((await h.cache.getGitlabPostToken(AGENT, PROJECT, HOOK)).token).toBe('glpat_3')
     })
   })
 })


### PR DESCRIPTION
## What

Follow-up to the broker's denial-classification fix: the final poster's token path (purpose `gitlab_hook_reply`) had the identical bug. It sends only the numeric project identity, so a stale-hook `SCOPE_DENIED` was classified as an agent-level denial and inserted the poster key into the durable `denied` set — and since hook lifecycle changes never replicate an agent spec, nothing ever cleared it until a daemon restart or an unrelated agent update.

Both daemon-owned GitLab writer purposes (`gitlab_hook_reply`, `gitlab_effect`) now share one rule: a refusal evicts the cached entry and reports as retryable, so the next turn asks the control plane again — which re-resolves the hook, binding, and membership live. `github_hook_reply` stays out of the set deliberately: it always carries the repository name and already lands in the repo-keyed short negative cache, which is the correct shape for it. Workspace-keyed git denials remain durable, unchanged.

## Tests

Two new tests: a refused hook-reply lease is retryable and the next call re-contacts the control plane; recovery needs no `clearDenied` and leaves the sibling keyspaces (broker effect, workspace git) independent. The pre-existing durable git-denial control is extended to assert the terminal git denial reaches neither daemon-owned writer keyspace. Negative control: with the source fix stashed, exactly the two new tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
