### PR TITLE
feat(setup): administer the deployment GitLab OAuth application

### DIFF
--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -34,6 +34,12 @@
       "import": "./dist/github/setup-api.js",
       "default": "./dist/github/setup-api.js"
     },
+    "./gitlab-config": {
+      "development": "./src/gitlab/config.ts",
+      "types": "./dist/gitlab/config.d.ts",
+      "import": "./dist/gitlab/config.js",
+      "default": "./dist/gitlab/config.js"
+    },
     "./slack-config-api": {
       "development": "./src/http/slack-config-api.ts",
       "types": "./dist/http/slack-config-api.d.ts",

--- a/packages/setup/README.md
+++ b/packages/setup/README.md
@@ -1,9 +1,9 @@
 # `@agentconnect.md/setup`
 
 Browser-based Setup Server for AgentConnect self-hosting. It configures Logto,
-GitHub, Slack, Google, Feishu, and Lark through one authenticated local operator
-surface. Provider identities and write-only credentials are stored in the
-deployment database; the UI never returns stored secret values.
+GitHub, GitLab, Slack, Google, Feishu, and Lark through one authenticated local
+operator surface. Provider identities and write-only credentials are stored in
+the deployment database; the UI never returns stored secret values.
 
 This package has no command-line setup interface. Provider creation, match
 checks, edits, secret replacement, and clearing a provider configuration all
@@ -54,8 +54,8 @@ AGENTCONNECT_PUBLIC_CP_URL=https://gateway.example.test/cp
 AGENTCONNECT_PUBLIC_RELAY_URL=https://gateway.example.test/relay
 ```
 
-Setup shows these values at the top because GitHub and Slack manifests
-derive their callbacks from them. Change the environment and restart Setup
+Setup shows these values at the top because GitHub and Slack manifests, and the
+GitLab redirect URI, derive their callbacks from them. Change the environment and restart Setup
 Server before applying updated provider settings.
 
 ## Configuration ownership

--- a/packages/setup/src/deployment-config-client.ts
+++ b/packages/setup/src/deployment-config-client.ts
@@ -68,6 +68,30 @@ export function githubDeploymentPut(
   })
 }
 
+export interface GitlabDeploymentCredentials {
+  clientId: string
+  /** Omitted keeps the sealed secret; GitLab shows it only once at registration. */
+  clientSecret?: string
+}
+
+/** Null clears the application. GitLab OAuth applications are registered by hand (§18.3). */
+export function gitlabDeploymentPut(
+  current: CurrentDeploymentConfig,
+  application: GitlabDeploymentCredentials | null
+): DeploymentConfigPut {
+  if (application && !application.clientSecret && current.values.gitlab?.clientId !== application.clientId) {
+    throw new Error('the GitLab OAuth application secret is required for a new application id')
+  }
+  const secret = application ? application.clientSecret : null
+  return DeploymentConfigPutSchema.parse({
+    values: {
+      ...current.values,
+      gitlab: application ? { clientId: application.clientId } : null
+    },
+    ...(secret === undefined ? {} : { secrets: { 'gitlab.clientSecret': secret } })
+  })
+}
+
 export interface LogtoGithubConnectorCredentials {
   appId: string
   slug: string

--- a/packages/setup/src/gitlab-app.ts
+++ b/packages/setup/src/gitlab-app.ts
@@ -1,0 +1,22 @@
+import { GITLAB_OAUTH_CALLBACK_PATH } from '@agentconnect.md/control-plane/gitlab-config'
+import type { ProviderAppConfig } from './provider-app.js'
+
+/** Exactly the scope set the Control Plane asks GitLab for (gitlab-com-integration.md §9.1). */
+export const GITLAB_OAUTH_SCOPES = ['api'] as const
+
+export interface GitlabConfiguredUrls {
+  callbackUrl: string
+  scopes: string[]
+}
+
+/** GitLab has no OAuth-application creation API, so setup only publishes what to register by hand. */
+export function gitlabConfiguredUrls(config: ProviderAppConfig): GitlabConfiguredUrls {
+  const controlPlane = config.services.controlPlane
+  if (!controlPlane || new URL(controlPlane).protocol !== 'https:') {
+    throw new Error('the GitLab OAuth application requires a saved HTTPS Control Plane public URL')
+  }
+  return {
+    callbackUrl: `${controlPlane.replace(/\/$/, '')}${GITLAB_OAUTH_CALLBACK_PATH}`,
+    scopes: [...GITLAB_OAUTH_SCOPES]
+  }
+}

--- a/packages/setup/src/server/html.ts
+++ b/packages/setup/src/server/html.ts
@@ -139,6 +139,7 @@ export const SETUP_HTML = String.raw`<!doctype html>
       <a href="#startup-section">Startup</a>
       <a href="#logto-section">Logto</a>
       <a href="#github-section">GitHub</a>
+      <a href="#gitlab-section">GitLab</a>
       <a href="#slack-section">Slack</a>
       <a href="#google-section">Google</a>
       <a href="#feishu-section">Feishu</a>
@@ -239,6 +240,28 @@ export const SETUP_HTML = String.raw`<!doctype html>
           <button id="clear-github" class="danger" hidden>Clear configuration</button>
           <a id="github-settings" class="button" target="_blank" rel="noopener" hidden>Open GitHub settings</a>
         </div>
+      </section>
+
+      <section id="gitlab-section" class="panel setup-section" aria-labelledby="gitlab-heading">
+        <div class="provider-head">
+          <div><h3 id="gitlab-heading">GitLab</h3><p class="muted">OAuth application used to administer GitLab.com projects.</p></div>
+          <span id="gitlab-match" class="badge">Not configured</span>
+        </div>
+        <dl class="credentials">
+          <dt>Application ID</dt><dd class="value-line"><code id="gitlab-client-id">Not configured</code><button class="edit-configuration" data-provider="gitlab">Edit</button></dd>
+          <dt>Secret</dt><dd class="secret-line"><span id="gitlab-client-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="gitlab.clientSecret" data-secret-display="gitlab-client-secret-display">Edit</button></dd>
+        </dl>
+        <p id="gitlab-status" class="muted"></p>
+        <div id="gitlab-drift" class="notice" hidden></div>
+        <p>Redirect URI:</p><ul id="gitlab-callbacks" class="uris"></ul>
+        <p>Scopes:</p><ul id="gitlab-scopes" class="uris"></ul>
+        <p class="muted">GitLab does not expose OAuth application creation through an API. In User settings &rarr; Applications, or a group's Settings &rarr; Applications, add an application whose redirect URI is exactly the value above, keep Confidential selected, grant the scopes above, then save the generated Application ID and Secret here. GitLab shows the secret only once.</p>
+        <div class="row"><a class="button" href="https://gitlab.com/-/user_settings/applications" target="_blank" rel="noopener">Open GitLab applications</a></div>
+        <div id="gitlab-config-controls" class="subsection">
+          <label class="field">Application ID<input id="gitlab-id" autocomplete="off"></label>
+          <label id="gitlab-initial-secret-field" class="field">Secret<input id="gitlab-secret" type="password" autocomplete="new-password" placeholder="Required when the Application ID changes"></label>
+        </div>
+        <div class="row"><button id="save-gitlab">Save GitLab application</button><button id="cancel-gitlab-configuration" hidden>Cancel</button><button id="clear-gitlab" class="danger" hidden>Clear configuration</button></div>
       </section>
 
       <section id="slack-section" class="panel setup-section" aria-labelledby="slack-heading">
@@ -554,7 +577,7 @@ export const SETUP_HTML = String.raw`<!doctype html>
       currentStatus = status;
       const byKey = new Map((status.secrets || []).map((item) => [item.key, item]));
       const values = status.values;
-      const expected = status.providerExpectations || { github: null, slack: null, google: { origins: [], redirects: [] } };
+      const expected = status.providerExpectations || { github: null, gitlab: null, slack: null, google: { origins: [], redirects: [] } };
       renderStartupEnvironment();
 
       const logto = values.logto;
@@ -606,6 +629,30 @@ export const SETUP_HTML = String.raw`<!doctype html>
       el('check-github').hidden = !github;
       if (github) showDiff('github-drift', githubDrift, 'Expected URLs changed since App creation');
       else el('github-drift').hidden = true;
+
+      const gitlab = values.gitlab;
+      const gitlabSecret = configured(byKey, 'gitlab.clientSecret');
+      const expectedGitlab = expected.gitlab;
+      renderUriList('gitlab-callbacks', expectedGitlab ? [expectedGitlab.callbackUrl] : []);
+      renderUriList('gitlab-scopes', expectedGitlab ? expectedGitlab.scopes : []);
+      text('gitlab-client-id', gitlab && gitlab.clientId);
+      secretText('gitlab-client-secret-display', byKey, 'gitlab.clientSecret', Boolean(gitlab));
+      showIdentityEditors('gitlab', Boolean(gitlab));
+      el('gitlab-id').value = gitlab ? gitlab.clientId : '';
+      el('gitlab-status').textContent = gitlab
+        ? gitlab.clientId + ' is configured.'
+        : expectedGitlab
+          ? 'Register the OAuth application on GitLab.com, then save its Application ID and Secret here.'
+          : 'Publishing the redirect URI needs an HTTPS API public URL.';
+      showDiff('gitlab-drift', gitlab && !expectedGitlab
+        ? [{ field: 'Startup public URLs', current: 'Unavailable', expected: 'An HTTPS API URL' }]
+        : []);
+      match('gitlab-match', gitlab && gitlabSecret ? 'warn' : '', !gitlab ? 'Not configured' : !gitlabSecret ? 'Missing secret' : "Can't verify automatically");
+      el('gitlab-initial-secret-field').hidden = Boolean(gitlab) && gitlabSecret;
+      el('gitlab-config-controls').hidden = Boolean(gitlab);
+      el('save-gitlab').hidden = Boolean(gitlab);
+      el('cancel-gitlab-configuration').hidden = true;
+      el('clear-gitlab').hidden = !gitlab;
 
       const slack = values.slack;
       text('slack-app-id', slack && slack.appId);
@@ -747,6 +794,16 @@ export const SETUP_HTML = String.raw`<!doctype html>
         el('slack-edit-controls').hidden = false;
         el('clear-slack').hidden = true;
         el('slack-edit-app-id').focus();
+      } else if (provider === 'gitlab') {
+        if (!values.gitlab) return;
+        el('gitlab-id').value = values.gitlab.clientId;
+        el('gitlab-secret').value = '';
+        el('gitlab-config-controls').hidden = false;
+        el('gitlab-initial-secret-field').hidden = false;
+        el('save-gitlab').hidden = false;
+        el('cancel-gitlab-configuration').hidden = false;
+        el('clear-gitlab').hidden = true;
+        el('gitlab-id').focus();
       } else if (provider === 'google') {
         const google = values.logto && values.logto.googleConnector;
         if (!google) return;
@@ -894,7 +951,7 @@ export const SETUP_HTML = String.raw`<!doctype html>
 
     async function clearProvider(provider) {
       if (!currentStatus) throw new Error('Deployment configuration is not loaded');
-      const label = provider === 'github' ? 'GitHub' : provider === 'slack' ? 'Slack' : provider === 'google' ? 'Google' : provider === 'feishu' ? 'Feishu' : 'Lark';
+      const label = provider === 'github' ? 'GitHub' : provider === 'gitlab' ? 'GitLab' : provider === 'slack' ? 'Slack' : provider === 'google' ? 'Google' : provider === 'feishu' ? 'Feishu' : 'Lark';
       if (!window.confirm('Clear the saved ' + label + ' configuration and secrets?')) return;
       const values = currentStatus.values;
       let next = values;
@@ -914,6 +971,9 @@ export const SETUP_HTML = String.raw`<!doctype html>
           'github.webhookSecret': null,
           ...(connectorReused ? { 'logto.githubConnectorClientSecret': null } : {})
         };
+      } else if (provider === 'gitlab') {
+        next = { ...values, gitlab: null };
+        secrets = { 'gitlab.clientSecret': null };
       } else if (provider === 'slack') {
         const logto = values.logto
           ? {
@@ -1165,6 +1225,22 @@ export const SETUP_HTML = String.raw`<!doctype html>
       el(region + '-login-status').textContent = result.message;
       el(region + '-login-status').className = result.status === 'pass' ? 'ok' : result.status === 'fail' ? 'warn' : 'muted';
       message(result.message || (label + ' credential check completed.'), result.status === 'fail');
+    }
+
+    async function saveGitlab() {
+      const clientSecret = el('gitlab-secret').value;
+      await json(await fetch(api + '/configure/gitlab', {
+        method: 'POST', headers: { 'content-type': 'application/json', ...bearer() },
+        body: JSON.stringify({
+          application: {
+            clientId: requiredInput('gitlab-id', 'the GitLab Application ID'),
+            ...(clientSecret ? { clientSecret } : {})
+          }
+        })
+      }));
+      el('gitlab-secret').value = '';
+      await load();
+      message('GitLab OAuth application saved. Restart AgentConnect to apply it.');
     }
 
     async function saveGoogle() {
@@ -1434,6 +1510,9 @@ export const SETUP_HTML = String.raw`<!doctype html>
     el('cancel-slack-configuration').onclick = cancelConfigurationEdit;
     el('clear-slack').onclick = () => clearProvider('slack').catch((error) => message(error.message, true));
     el('check-slack').onclick = () => checkSlack().catch((error) => message(error.message, true));
+    el('save-gitlab').onclick = () => saveGitlab().catch((error) => message(error.message, true));
+    el('cancel-gitlab-configuration').onclick = cancelConfigurationEdit;
+    el('clear-gitlab').onclick = () => clearProvider('gitlab').catch((error) => message(error.message, true));
     el('save-google').onclick = () => saveGoogle().catch((error) => message(error.message, true));
     el('cancel-google-configuration').onclick = cancelConfigurationEdit;
     el('clear-google').onclick = () => clearProvider('google').catch((error) => message(error.message, true));

--- a/packages/setup/src/server/index.ts
+++ b/packages/setup/src/server/index.ts
@@ -32,6 +32,7 @@ import { loadDeploymentEnvironment } from '../deployment-environment.js'
 import { LOGTO_GITHUB_CONNECTOR_ID, LOGTO_GOOGLE_CONNECTOR_ID, LOGTO_SLACK_CONNECTOR_ID } from '../logto-connectors.js'
 import {
   githubDeploymentPut,
+  gitlabDeploymentPut,
   localAuthLogtoPut,
   logtoGoogleConnectorPut,
   logtoGithubConnectorPut,
@@ -44,6 +45,7 @@ import {
   githubConfiguredUrls,
   githubManifestRegistrationUrl
 } from '../github-app.js'
+import { gitlabConfiguredUrls } from '../gitlab-app.js'
 import {
   auditSlackManifest,
   buildSlackDeploymentManifest,
@@ -110,6 +112,15 @@ const CreateSlackBody = z.strictObject({
   name: z.string().trim().min(1).max(80),
   configToken: z.string().trim().min(1).max(10_000),
   connectLogto: z.boolean().optional().default(false)
+})
+
+const ConfigureGitlabBody = z.strictObject({
+  application: z
+    .strictObject({
+      clientId: z.string().trim().min(1).max(500),
+      clientSecret: z.string().min(1).max(10_000).optional()
+    })
+    .nullable()
 })
 
 const ConfigureGoogleBody = z.strictObject({
@@ -504,8 +515,15 @@ export function buildSetupServer(deps: SetupServerDeps, options: SetupServerOpti
     } catch {
       // Slack requires HTTPS startup URLs; the UI keeps creation/check disabled.
     }
+    let gitlab: ReturnType<typeof gitlabConfiguredUrls> | null = null
+    try {
+      gitlab = gitlabConfiguredUrls(providerAppConfig(localAuthBootstrap.services))
+    } catch {
+      // GitLab needs an HTTPS Control Plane URL before its redirect URI is publishable.
+    }
     return {
       github,
+      gitlab,
       slack,
       google: values.logto?.browser
         ? {
@@ -839,6 +857,23 @@ export function buildSetupServer(deps: SetupServerDeps, options: SetupServerOpti
       return { revision: saved.revision, restartRequired: true as const }
     })
   )
+
+  app.post('/api/v1/configure/gitlab', { preHandler: requireConfigurationAccess }, async (request, reply) => {
+    const parsed = ConfigureGitlabBody.safeParse(request.body)
+    if (!parsed.success) return problem(reply, 400, 'a valid GitLab OAuth application id is required')
+    return serializeMutation(async () => {
+      const current = await deps.store.getAdmin()
+      if (!current) return problem(reply, 409, 'save deployment settings before configuring GitLab')
+      let put: ReturnType<typeof gitlabDeploymentPut>
+      try {
+        put = gitlabDeploymentPut(current, parsed.data.application)
+      } catch (error) {
+        return problem(reply, 400, error instanceof Error ? error.message : 'invalid GitLab OAuth application')
+      }
+      const saved = await deps.store.replace({ expectedRevision: current.revision, ...put })
+      return { revision: saved.revision, restartRequired: true as const }
+    })
+  })
 
   app.post('/api/v1/configure/google', { preHandler: requireConfigurationAccess }, async (request, reply) => {
     const parsed = ConfigureGoogleBody.safeParse(request.body)

--- a/packages/setup/test/deployment-config-client.test.ts
+++ b/packages/setup/test/deployment-config-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1 } from '@agentconnect.md/control-plane/deployment-config-store'
-import { localAuthLogtoPut } from '../src/deployment-config-client.js'
+import { gitlabDeploymentPut, localAuthLogtoPut } from '../src/deployment-config-client.js'
 
 describe('localAuthLogtoPut', () => {
   it('stores an explicit Logto Management API resource', () => {
@@ -14,5 +14,32 @@ describe('localAuthLogtoPut', () => {
     )
 
     expect(result.values.logto?.managementResource).toBe('https://tenant-id.logto.app/api')
+  })
+})
+
+describe('gitlabDeploymentPut', () => {
+  const current = { values: DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1 }
+
+  it('stores the application id as configuration and the secret as a write-only entry', () => {
+    const result = gitlabDeploymentPut(current, { clientId: 'application-id', clientSecret: 'application-secret' })
+
+    expect(result.values.gitlab).toEqual({ clientId: 'application-id' })
+    expect(result.secrets).toEqual({ 'gitlab.clientSecret': 'application-secret' })
+    expect(JSON.stringify(result.values)).not.toContain('application-secret')
+  })
+
+  it('requires a secret for a new application id and keeps the sealed one otherwise', () => {
+    expect(() => gitlabDeploymentPut(current, { clientId: 'application-id' })).toThrow(/secret is required/)
+
+    const saved = { values: { ...DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1, gitlab: { clientId: 'application-id' } } }
+    expect(gitlabDeploymentPut(saved, { clientId: 'application-id' }).secrets).toBeUndefined()
+  })
+
+  it('clears the application and its secret together', () => {
+    const saved = { values: { ...DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1, gitlab: { clientId: 'application-id' } } }
+    const result = gitlabDeploymentPut(saved, null)
+
+    expect(result.values.gitlab).toBeNull()
+    expect(result.secrets).toEqual({ 'gitlab.clientSecret': null })
   })
 })

--- a/packages/setup/test/provider-base-paths.test.ts
+++ b/packages/setup/test/provider-base-paths.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { loadDeploymentEnvironment } from '../src/deployment-environment.js'
 import { buildGithubAppManifest, githubConfiguredUrls } from '../src/github-app.js'
+import { gitlabConfiguredUrls } from '../src/gitlab-app.js'
 import { buildSlackDeploymentManifest, slackConfiguredUrls } from '../src/slack-app.js'
 
 const PREFIXED_ENVIRONMENT = {
@@ -75,5 +76,15 @@ describe('provider service base paths', () => {
       webhookUrl: 'https://gateway.example.test/relay/webhooks/github',
       webhookActive: true
     })
+  })
+
+  it('publishes the GitLab redirect URI beneath the Control Plane prefix with the requested scopes', () => {
+    const config = { services: loadDeploymentEnvironment(PREFIXED_ENVIRONMENT).services }
+
+    expect(gitlabConfiguredUrls(config)).toEqual({
+      callbackUrl: 'https://gateway.example.test/cp/v1/gitlab/oauth/callback',
+      scopes: ['api']
+    })
+    expect(() => gitlabConfiguredUrls({ services: { controlPlane: 'http://localhost:8080' } })).toThrow(/HTTPS/)
   })
 })


### PR DESCRIPTION
## What

The Setup Server administration surface for the deployment's GitLab OAuth application (gitlab-com-integration.md section 18.3). The Control Plane already projects `values.gitlab.clientId` + the sealed `gitlab.clientSecret` from the typed deployment document, but nothing could write them — GitHub and Slack have cards, GitLab had none.

- A GitLab provider card following the guided-manual shape (GitLab has no application-creation API): step-by-step registration instructions, the exact callback URL to register, the scope list, an Application ID / Secret form, Edit, and Clear.
- The callback URL derives from the public CP URL plus `GITLAB_OAUTH_CALLBACK_PATH` imported from the Control Plane via a new packaging-only `./gitlab-config` subpath export (mirroring the existing manifest/app-api subpaths), so an ingress path prefix is preserved and the path is never duplicated. The scope list mirrors what the OAuth service actually requests (`api`).
- The secret is write-only end to end: sealed through the existing cipher path, redacted in every status read, and the pure document mutation refuses a new application id without a secret, keeps the sealed value on an unchanged id, and clears value + secret together.
- HTTPS is required before the card publishes a callback URL, matching the GitHub and Slack cards.

## Tests

Four new setup tests over the document mutation and rendered states (24 passing total); typecheck, lint, format, and the self-contained-bundle build assertion all clean. The rendered page was additionally driven against a stub API: unconfigured/configured states, masked secret, edit repopulation, save payload shape, and clear semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
