### PR TITLE
feat(daemon): render and update the GitLab run projection note in place

### DIFF
--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -26,6 +26,8 @@ import type {
   GithubReviewAuthorized,
   GithubReviewResultReport,
   GithubReviewResultOk,
+  CodeHostNoteResult,
+  CodeHostNoteResultOk,
   GitCredRequest,
   GitCredGrant,
   ChannelAgentsReq,
@@ -70,6 +72,7 @@ import {
 import { ReqRep, WireError, type Clock, type TimerHandle, type Transport } from '@agentconnect.md/connection'
 import type { AgentControlDeps } from './control/agent.js'
 import type { ControlWire } from './control/context.js'
+import type { CodeHostControlDeps } from './control/codehost.js'
 import type { DreamControlDeps } from './control/dream.js'
 import type { MemoryControlDeps } from './control/memory.js'
 import { CONTROL_HANDLERS, type ControlDeps } from './control/registry.js'
@@ -122,6 +125,7 @@ export interface CpClientDeps
     SessionControlDeps,
     SkillsControlDeps,
     TaskControlDeps,
+    CodeHostControlDeps,
     WorkspaceReadDeps {
   url: string
   /** The CP API key. Absent on an in-cluster daemon, which presents
@@ -277,6 +281,7 @@ export class CpClient {
       localSkillsReader: deps.localSkillsReader,
       runtimeCommandsReader: deps.runtimeCommandsReader,
       gitMessagePasses: new GitMessagePasses(),
+      codeHostNoteProjection: deps.codeHostNoteProjection,
       noteLeasesGranted: (groupIds) => this.noteLeasesGranted(groupIds),
       forgetLeaseDeadlines: (groupIds) => this.forgetLeaseDeadlines(groupIds),
       onDutyRenewed: (leaseMs) => this.onDutyRenewed(leaseMs),
@@ -781,6 +786,16 @@ export class CpClient {
       throw new WireError('INTERNAL', `expected github/review-result/ok, got ${rep.type}`, false)
     }
     return rep.payload as GithubReviewResultOk
+  }
+
+  /** The observed outcome of ONE desired run projection generation (gitlab-com-integration.md §16). */
+  async reportCodeHostNoteResult(payload: CodeHostNoteResult, orgId?: string): Promise<CodeHostNoteResultOk> {
+    this.requireReady('codehost/note-result')
+    const rep = await this.request('codehost/note-result', payload, orgId)
+    if (rep.type !== 'codehost/note-result/ok') {
+      throw new WireError('INTERNAL', `expected codehost/note-result/ok, got ${rep.type}`, false)
+    }
+    return rep.payload as CodeHostNoteResultOk
   }
 
   async issueWebchatMcpGrant(payload: WebchatMcpGrantIssue, orgId?: string): Promise<WebchatMcpGrantIssued> {

--- a/packages/daemon/src/cp/control/codehost.ts
+++ b/packages/daemon/src/cp/control/codehost.ts
@@ -1,0 +1,21 @@
+import type { AnyFrame, CodeHostNoteDesired } from '@agentconnect.md/protocol'
+import type { ControlHandler } from './context.js'
+
+export interface CodeHostControlDeps {
+  /** Converge one desired run projection (gitlab-com-integration.md §16); absent on a daemon with no writer. */
+  codeHostNoteProjection?: (desired: CodeHostNoteDesired, orgId?: string) => Promise<void>
+}
+
+/**
+ * `codehost/note-desired` (C→D EVT): the Control Plane's desired projection generation.
+ *
+ * Uncorrelated by design — the authoritative answer is the daemon's own `codehost/note-result`
+ * frame, not a transport ack, so this hands the frame to the writer and returns.
+ */
+export const codeHostNoteDesired: ControlHandler<CodeHostControlDeps> = (frame: AnyFrame, deps, wire) => {
+  if (!deps.codeHostNoteProjection) {
+    wire.log.debug('cp: ignoring codehost/note-desired — this daemon has no projection writer')
+    return
+  }
+  void deps.codeHostNoteProjection(frame.payload as CodeHostNoteDesired, frame.orgId)
+}

--- a/packages/daemon/src/cp/control/registry.ts
+++ b/packages/daemon/src/cp/control/registry.ts
@@ -10,6 +10,7 @@ import {
   agentWake,
   type AgentControlDeps
 } from './agent.js'
+import { codeHostNoteDesired, type CodeHostControlDeps } from './codehost.js'
 import { configPush, type ConfigApplyDeps } from './config.js'
 import type { ControlHandler } from './context.js'
 import { cronRemove, cronRun, cronUpsert } from './cron.js'
@@ -89,6 +90,7 @@ import {
 export interface ControlDeps
   extends
     AgentControlDeps,
+    CodeHostControlDeps,
     ConfigApplyDeps,
     DaemonOpsDeps,
     DreamControlDeps,
@@ -179,5 +181,6 @@ export const CONTROL_HANDLERS: Map<string, ControlHandler<ControlDeps>> = new Ma
   ['skills/local', skillsLocal],
   ['runtime/commands', runtimeCommands],
   ['knowledge/suggestion/read', knowledgeSuggestionRead],
-  ['knowledge/suggestion/review', knowledgeSuggestionReview]
+  ['knowledge/suggestion/review', knowledgeSuggestionReview],
+  ['codehost/note-desired', codeHostNoteDesired]
 ])

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -48,6 +48,7 @@ import type { SystemMetrics } from '../metrics/system-metrics.js'
 import type { ReadinessGate } from '../readiness.js'
 import type { MemoryFs } from '../memory/store.js'
 import type { DreamRunner } from '../dream/runner.js'
+import type { CodeHostNoteProjector } from '../gitlab/note-projection.js'
 
 /** The credentials, identity and logging this connection is built from, plus its single-point writes. */
 export interface CpClientConnectionHost {
@@ -107,6 +108,8 @@ export interface CpClientReadyHost {
   webchatMcpRevocations(): WebchatMcpRevocations
   drainSessionPurges(): Promise<void>
   effectiveAgents(): LoadedAgent[]
+  /** The §16 run-projection writer: the CP dispatch target and the interrupted-write reconciler. */
+  noteProjector(): CodeHostNoteProjector
 }
 
 /** Tenant lookups for agent-scoped frames, plus the duty seam the heartbeat carries. */
@@ -249,6 +252,9 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       // Replay remote MCP revocations that could not reach the CP (revokes
       // queued while disconnected or left over from a previous process).
       void host.webchatMcpRevocations().drainWebchatMcpRevocations()
+      // ...and every §16 projection write this daemon started but never settled. Each is reconciled
+      // by the hidden marker before the merge request is touched again, never by replaying the write.
+      void host.noteProjector().reconcilePending()
       // ...and the retention-GC receipts (#485). A sweep that ran while the CP
       // was unreachable (or before it advertised the feature) left the deleted
       // sessions' metadata rows unmarked; this is the only side that still knows.
@@ -319,6 +325,8 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
     // A pure projection of the in-memory lease — no I/O, no runtime, and nothing it can do to a
     // reclaim decision, so it needs neither of the workspace coordinators.
     taskReader: { list: async (req) => host.listBackgroundTasks(req) },
+    // §16 desired projection generations, converged by the only GitLab Notes writer for this surface.
+    codeHostNoteProjection: (desired, orgId) => host.noteProjector().apply(desired, orgId),
     // The console's "start this agent's sandbox": duty claim + channel bind, no host — the same
     // condition the file reader serves on, reached without a turn. Local daemons have no plane.
     agentWake: createAgentWaker({

--- a/packages/daemon/src/cp/git-credential.ts
+++ b/packages/daemon/src/cp/git-credential.ts
@@ -87,6 +87,8 @@ interface Entry {
   repoFullName: string
   /** §13.1 authorization level as the CP echoed it — 'comment' rides an effect lease only. */
   access: GitCredGrant['access']
+  /** The purge fence the CP minted this grant under; absent when the CP echoed none. */
+  credentialEpoch?: string
   /** Monotonic deadline (ms on the injected monotonic clock). */
   expiresAtMono: number
 }
@@ -414,6 +416,7 @@ export class GitCredentialCache {
       token: grant.token,
       repoFullName: grant.repoFullName,
       access: grant.access,
+      ...(grant.credentialEpoch !== undefined ? { credentialEpoch: grant.credentialEpoch } : {}),
       expiresAtMono: this.monoNow() + grant.ttlSec * 1000
     }
     this.entries.set(key, entry)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -56,6 +56,7 @@ import { RemoteWebchatGrantManager } from './mcp/remote-webchat-grant.js'
 import type { CodeHostEffectReq, SetSessionTitleReq } from './mcp/ops.js'
 import { GitCredentialCache } from './cp/git-credential.js'
 import { GitlabBroker } from './gitlab/broker.js'
+import { CodeHostNoteProjector } from './gitlab/note-projection.js'
 import {
   CONFIG_FILE_CONVENTIONS,
   cleanupConfigFiles,
@@ -253,6 +254,7 @@ import {
   WEBCHAT_MULTI_AGENT_FEATURE,
   WEBCHAT_REMOTE_MCP_FEATURE,
   WEBCHAT_SESSION_CONTINUATION_FEATURE,
+  CODEHOST_NOTE_PROJECTION_V1_FEATURE,
   GITLAB_COM_V1_FEATURE,
   encodeSharedSlackStatusTarget,
   HOOK_REPORT_REASON_AGENT_HANDOVER,
@@ -640,6 +642,8 @@ export class Daemon {
   private gitCreds!: GitCredentialCache
   /** §14.2 structured mutation broker — allowlisted GitLab effects run under a daemon-held lease. */
   private gitlabBroker?: GitlabBroker
+  /** §16 run projection — the only writer of the service-account status note for a merge-request head. */
+  private noteProjector!: CodeHostNoteProjector
   /** Public commit attribution selected by the CP deployment's GitHub App. */
   private gitCommitIdentity?: GitCommitIdentity
   private gitCredServer?: GitCredServer
@@ -1686,6 +1690,29 @@ export class Daemon {
         return { token: entry.token, access: entry.access }
       },
       invalidateLease: (target, token) => this.gitCreds.invalidateGitlabEffect(target.agentId, target.projectId, token)
+    })
+    // §16: the same hook-authorized effect lease, on a writer the model never sees or influences.
+    this.noteProjector = new CodeHostNoteProjector({
+      daemonId: () => this.cfg.daemonId,
+      store: {
+        getNoteProjection: (key) => this.store.getNoteProjection(key),
+        beginNoteProjectionWrite: (row, now) => this.store.beginNoteProjectionWrite(row, now),
+        settleNoteProjectionWrite: (key, marker, noteId, now) =>
+          this.store.settleNoteProjectionWrite(key, marker, noteId, now),
+        listInFlightNoteProjections: () => this.store.listInFlightNoteProjections()
+      },
+      lease: async (target) => {
+        const entry = await this.gitCreds.getGitlabEffectToken(target.agentId, target.projectId, target.hookId)
+        return { token: entry.token, access: entry.access }
+      },
+      invalidateLease: (target, token) => this.gitCreds.invalidateGitlabEffect(target.agentId, target.projectId, token),
+      report: async (result, orgId) => {
+        const client = this.cpClient
+        if (!client) throw new Error('control plane is not connected')
+        await client.reportCodeHostNoteResult(result, orgId)
+      },
+      log: { warn: (m: string) => this.log.warn(m) },
+      now: () => this.clock.now()
     })
     this.gitCredServer = new GitCredServer(this.gitCreds, gitcredSocketPath(root), {
       log: {
@@ -3728,7 +3755,10 @@ export class Daemon {
       // built-in preset; turn-time dispatch rechecks the replicated marker.
       ...(this.remoteWebchatGrants ? [WEBCHAT_REMOTE_MCP_FEATURE] : []),
       // The CP withholds gitlab-workspace specs and gitlab hook assignments until this is advertised.
-      GITLAB_COM_V1_FEATURE
+      GITLAB_COM_V1_FEATURE,
+      // §16: this daemon renders and updates the run-projection note. The CP leaves the desired
+      // generation pending rather than opening a second provider egress path without this bit.
+      CODEHOST_NOTE_PROJECTION_V1_FEATURE
     ]
   }
 
@@ -14607,6 +14637,7 @@ export class Daemon {
       webchatMcpRevocations: () => this.webchatMcpRevocations,
       drainSessionPurges: () => this.drainSessionPurges(),
       effectiveAgents: () => this.effectiveAgents(),
+      noteProjector: () => this.noteProjector,
       cpAgents: () => this.cpAgents,
       cpIntegrations: () => this.cpIntegrations,
       cpCrons: () => this.cpCrons,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1695,12 +1695,13 @@ export class Daemon {
     this.noteProjector = new CodeHostNoteProjector({
       daemonId: () => this.cfg.daemonId,
       store: {
-        getNoteProjection: (key) => this.store.getNoteProjection(key),
+        getNoteProjection: (daemonId, key) => this.store.getNoteProjection(daemonId, key),
         beginNoteProjectionWrite: (row, now) => this.store.beginNoteProjectionWrite(row, now),
         recordNoteProjectionOutcome: (row, outcome, code, now) =>
           this.store.recordNoteProjectionOutcome(row, outcome, code, now),
-        markNoteProjectionReported: (key, marker, now) => this.store.markNoteProjectionReported(key, marker, now),
-        listUnsettledNoteProjections: () => this.store.listUnsettledNoteProjections()
+        markNoteProjectionReported: (daemonId, key, marker, now) =>
+          this.store.markNoteProjectionReported(daemonId, key, marker, now),
+        listUnsettledNoteProjections: (daemonId) => this.store.listUnsettledNoteProjections(daemonId)
       },
       lease: async (target) => {
         const entry = await this.gitCreds.getGitlabEffectToken(target.agentId, target.projectId, target.hookId)
@@ -15650,6 +15651,8 @@ export class Daemon {
     // so server.close() isn't left waiting on a live bridge connection.
     await Promise.resolve(this.mcp?.stop()).catch((e) => errors.push(e))
     this.gitCredServer?.stop()
+    // The projection resweep runs on its own clock, so it must be disarmed before the store closes.
+    this.noteProjector?.stop()
     if (this.dataPlane) await this.dataPlane.close().catch((e) => errors.push(e))
     else await this.store?.close()
     if (errors.length) throw new AggregateError(errors, 'stop: partial failure')

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1697,13 +1697,19 @@ export class Daemon {
       store: {
         getNoteProjection: (key) => this.store.getNoteProjection(key),
         beginNoteProjectionWrite: (row, now) => this.store.beginNoteProjectionWrite(row, now),
-        settleNoteProjectionWrite: (key, marker, noteId, now) =>
-          this.store.settleNoteProjectionWrite(key, marker, noteId, now),
-        listInFlightNoteProjections: () => this.store.listInFlightNoteProjections()
+        recordNoteProjectionOutcome: (row, outcome, code, now) =>
+          this.store.recordNoteProjectionOutcome(row, outcome, code, now),
+        markNoteProjectionReported: (key, marker, now) => this.store.markNoteProjectionReported(key, marker, now),
+        listUnsettledNoteProjections: () => this.store.listUnsettledNoteProjections()
       },
       lease: async (target) => {
         const entry = await this.gitCreds.getGitlabEffectToken(target.agentId, target.projectId, target.hookId)
-        return { token: entry.token, access: entry.access }
+        // The grant's purge epoch travels with it: the writer refuses a fence the grant does not match.
+        return {
+          token: entry.token,
+          access: entry.access,
+          ...(entry.credentialEpoch !== undefined ? { credentialEpoch: entry.credentialEpoch } : {})
+        }
       },
       invalidateLease: (target, token) => this.gitCreds.invalidateGitlabEffect(target.agentId, target.projectId, token),
       report: async (result, orgId) => {

--- a/packages/daemon/src/gitlab/note-projection.ts
+++ b/packages/daemon/src/gitlab/note-projection.ts
@@ -90,7 +90,15 @@ export function renderProjectionNote(desired: CodeHostNoteDesired): string {
   return lines.join('\n')
 }
 
-export type NoteProjectionPhase = 'in_flight' | 'settled'
+/**
+ * `in_flight` — a mutation was started and its outcome is not yet definite.
+ * `settled_unreported` — the outcome is definite but the control plane has not acknowledged it.
+ * `settled` — the control plane holds the result; nothing is owed.
+ */
+export type NoteProjectionPhase = 'in_flight' | 'settled_unreported' | 'settled'
+
+/** The definite outcomes a stored row can replay; `ambiguous` is never definite, so never stored. */
+export type NoteProjectionOutcome = 'written' | 'skipped' | 'failed'
 
 /** The durable local write ledger row: written BEFORE any mutation, settled after a definite one. */
 export interface NoteProjectionRow {
@@ -111,23 +119,29 @@ export interface NoteProjectionRow {
   noteId?: string
   credentialEpoch: string
   phase: NoteProjectionPhase
+  /** Set with `settled_unreported`: the outcome and code the replay re-sends verbatim. */
+  outcome?: NoteProjectionOutcome
+  code?: string
 }
 
 export interface NoteProjectionStore {
   getNoteProjection(projectionKey: string): Promise<NoteProjectionRow | undefined>
   beginNoteProjectionWrite(row: NoteProjectionRow, now: number): Promise<void>
-  settleNoteProjectionWrite(
-    projectionKey: string,
-    writeMarker: string,
-    noteId: string | undefined,
+  recordNoteProjectionOutcome(
+    row: NoteProjectionRow,
+    outcome: NoteProjectionOutcome,
+    code: string | undefined,
     now: number
   ): Promise<void>
-  listInFlightNoteProjections(): Promise<NoteProjectionRow[]>
+  markNoteProjectionReported(projectionKey: string, writeMarker: string, now: number): Promise<void>
+  listUnsettledNoteProjections(): Promise<NoteProjectionRow[]>
 }
 
 export interface NoteProjectionLease {
   token: string
   access: BrokerCapability
+  /** The purge fence the grant was minted under; a mismatch against the desired fence never writes. */
+  credentialEpoch?: string
 }
 
 export interface CodeHostNoteProjectorDeps {
@@ -138,7 +152,8 @@ export interface CodeHostNoteProjectorDeps {
   lease: (input: { agentId: string; projectId: string; hookId: string }) => Promise<NoteProjectionLease>
   /** Drop a lease GitLab just rejected (401/403) so the single retry re-mints. */
   invalidateLease?: (input: { agentId: string; projectId: string }, token: string) => void
-  /** Deliver `codehost/note-result` to the Control Plane; may reject when the CP is unreachable. */
+  /** Deliver `codehost/note-result` to the Control Plane; may reject when the CP is unreachable. A
+   *  rejection carrying `retryable: false` is a permanent answer and stops the replay. */
   report: (result: CodeHostNoteResult, orgId?: string) => Promise<void>
   log: { warn: (message: string) => void }
   now?: () => number
@@ -147,9 +162,12 @@ export interface CodeHostNoteProjectorDeps {
   requestTimeoutMs?: number
 }
 
-/** A definite provider answer, an ambiguous one, or a deterministic no-effect refusal. */
+/** A definite provider answer, an ambiguous one, or a no-effect refusal this writer owns. */
 type WriteOutcome =
-  { kind: 'written'; noteId: string } | { kind: 'failed'; code: string } | { kind: 'ambiguous'; code: string }
+  | { kind: 'written'; noteId: string }
+  | { kind: 'failed'; code: string }
+  | { kind: 'skipped'; code: string }
+  | { kind: 'ambiguous'; code: string }
 
 /** One bounded provider call's answer; a timeout or transport error is unavailable, not a status. */
 type ProviderAnswer = { kind: 'answered'; status: number; body: string } | { kind: 'unavailable'; code: string }
@@ -166,14 +184,16 @@ export class CodeHostNoteProjector {
   }
 
   /**
-   * Startup / reconnect sweep over writes this daemon started but never settled (§16): every one is
+   * Startup / reconnect sweep over everything this daemon still owes (§16). An `in_flight` row is
    * reconciled by LISTING the merge request's notes and matching the hidden marker before the note
-   * is touched again, so an interrupted create can never become a second note for the same head.
+   * is touched again, so an interrupted create can never become a second note for the same head. A
+   * `settled_unreported` row already has its definite outcome and only replays the result, so a
+   * dropped `codehost/note-result` cannot leave the control plane's write mutex held forever.
    */
   async reconcilePending(): Promise<void> {
     let rows: NoteProjectionRow[]
     try {
-      rows = await this.deps.store.listInFlightNoteProjections()
+      rows = await this.deps.store.listUnsettledNoteProjections()
     } catch (err) {
       this.warn(`note projection: pending write scan failed (${String(err)})`)
       return
@@ -196,16 +216,24 @@ export class CodeHostNoteProjector {
 
   private async converge(desired: CodeHostNoteDesired, orgId?: string): Promise<void> {
     const fence = this.fenceFailure(desired)
-    if (fence) return await this.send(refusal(desired, fence.outcome, fence.code, this.now()), orgId)
+    // A refusal this daemon does not own leaves no local row: there is nothing here to replay.
+    if (fence) {
+      await this.send(refusal(desired, fence.outcome, fence.code, this.now()), orgId)
+      return
+    }
     let stored: NoteProjectionRow | undefined
     try {
       stored = await this.deps.store.getNoteProjection(desired.projectionKey)
     } catch (err) {
       this.warn(`note projection: ledger read failed for ${desired.projectionKey} (${String(err)})`)
-      return await this.send(refusal(desired, 'failed', 'ledger_unavailable', this.now()), orgId)
+      await this.send(refusal(desired, 'failed', 'ledger_unavailable', this.now()), orgId)
+      return
     }
     const ledger = this.ledgerFailure(desired, stored)
-    if (ledger) return await this.send(refusal(desired, 'skipped', ledger, this.now()), orgId)
+    if (ledger) {
+      await this.send(refusal(desired, 'skipped', ledger, this.now()), orgId)
+      return
+    }
 
     // The recorded note wins over the frame's hint only when the frame carries none; both are the
     // same observed identity, and an unreadable one is treated as unknown so the marker decides.
@@ -231,15 +259,35 @@ export class CodeHostNoteProjector {
     // An earlier write of this projection never reached a definite outcome, so the note's identity
     // is recovered from the provider before this generation may touch the merge request at all.
     const outcome = await this.write(row, stored?.phase === 'in_flight', true)
-    await this.send(settled(row, outcome, this.now()), orgId)
+    await this.deliver(row, outcome, orgId)
   }
 
-  /** Finish an interrupted write from the ledger row alone: reconcile by marker, then converge. */
+  /** Finish what the ledger row still owes: reconcile an interrupted write, or replay its result. */
   private async settlePending(row: NoteProjectionRow): Promise<void> {
+    if (row.phase === 'settled_unreported') return await this.deliver(row, storedOutcome(row), row.orgId)
     const outcome = await this.write(row, true, false)
     // Still fail-closed on this writer: the row stays in flight and the next sweep reconciles again.
-    if (outcome.kind === 'ambiguous') return
-    await this.send(settled(row, outcome, this.now()), row.orgId)
+    if (outcome.kind === 'ambiguous') {
+      await this.send(settled(row, outcome, this.now()), row.orgId)
+      return
+    }
+    await this.deliver(row, outcome, row.orgId)
+  }
+
+  /** Send one definite result and stop replaying it only once the control plane has taken it. */
+  private async deliver(row: NoteProjectionRow, outcome: WriteOutcome, orgId?: string): Promise<void> {
+    // An ambiguous outcome keeps its in-flight row, which the sweep reconciles; nothing to retire.
+    if (outcome.kind === 'ambiguous') {
+      await this.send(settled(row, outcome, this.now()), orgId)
+      return
+    }
+    if (!(await this.send(settled(row, outcome, this.now()), orgId))) return
+    try {
+      await this.deps.store.markNoteProjectionReported(row.projectionKey, row.writeMarker, this.now())
+    } catch (err) {
+      // Harmless: the row simply replays an identical result, which the control plane answers once.
+      this.warn(`note projection: ledger ack failed for ${row.projectionKey} (${String(err)})`)
+    }
   }
 
   /** Placement, credential and renderability fences — all of them refuse BEFORE any provider call. */
@@ -267,7 +315,9 @@ export class CodeHostNoteProjector {
     )
       return 'projection_key_conflict'
     if (BigInt(stored.credentialEpoch) > BigInt(desired.credentialEpoch)) return 'stale_credential_epoch'
-    if (stored.phase === 'settled' && BigInt(stored.generation) > BigInt(desired.generation)) return 'stale_generation'
+    // Any phase but in-flight means the stored generation reached a definite outcome and outranks an older one.
+    if (stored.phase !== 'in_flight' && BigInt(stored.generation) > BigInt(desired.generation))
+      return 'stale_generation'
     return undefined
   }
 
@@ -276,15 +326,9 @@ export class CodeHostNoteProjector {
    * write marker, then create once or update the SAME note in place.
    */
   private async write(row: NoteProjectionRow, reconcile: boolean, persist: boolean): Promise<WriteOutcome> {
-    let lease: NoteProjectionLease
-    try {
-      lease = await this.deps.lease({ agentId: row.agentId, projectId: row.projectId, hookId: row.hookId })
-    } catch {
-      // A refused effect lease is its own outcome: nothing was ever sent to GitLab.
-      return { kind: 'failed', code: 'token_unavailable' }
-    }
-    if (CAPABILITY_RANK[lease.access] < CAPABILITY_RANK[REQUIRED_CAPABILITY])
-      return { kind: 'failed', code: 'insufficient_authority' }
+    const minted = await this.mint(row)
+    if (minted.kind !== 'lease') return await this.persistOutcome(row, minted, row.noteId)
+    const lease = minted.lease
 
     let noteId = row.noteId
     if (reconcile) {
@@ -305,17 +349,49 @@ export class CodeHostNoteProjector {
     const outcome = await this.mutate(row, noteId, lease)
     // An ambiguous mutation keeps its in-flight row: only reconciliation, never a replay, may follow.
     if (outcome.kind === 'ambiguous') return outcome
+    return await this.persistOutcome(row, outcome, noteId)
+  }
+
+  /** A definite outcome becomes durable BEFORE it is reported, so a dropped report is replayable. */
+  private async persistOutcome(
+    row: NoteProjectionRow,
+    outcome: WriteOutcome,
+    noteId: string | undefined
+  ): Promise<WriteOutcome> {
+    if (outcome.kind === 'ambiguous') return outcome
+    const settledNoteId = outcome.kind === 'written' ? outcome.noteId : noteId
     try {
-      await this.deps.store.settleNoteProjectionWrite(
-        row.projectionKey,
-        row.writeMarker,
-        outcome.kind === 'written' ? outcome.noteId : noteId,
+      await this.deps.store.recordNoteProjectionOutcome(
+        { ...row, ...(settledNoteId ? { noteId: settledNoteId } : {}) },
+        outcome.kind,
+        outcome.kind === 'written' ? undefined : outcome.code,
         this.now()
       )
     } catch (err) {
-      this.warn(`note projection: ledger settle failed for ${row.projectionKey} (${String(err)})`)
+      this.warn(`note projection: outcome persist failed for ${row.projectionKey} (${String(err)})`)
     }
     return outcome
+  }
+
+  /**
+   * Mint the hook-authorized effect lease and check every authority fence it must satisfy: the §13.1
+   * clamp, and the credential epoch the desired generation was fenced on. A grant minted under an
+   * older or newer purge epoch is stale authority and may not write.
+   */
+  private async mint(
+    row: NoteProjectionRow
+  ): Promise<{ kind: 'lease'; lease: NoteProjectionLease } | { kind: 'failed' | 'skipped'; code: string }> {
+    let lease: NoteProjectionLease
+    try {
+      lease = await this.deps.lease({ agentId: row.agentId, projectId: row.projectId, hookId: row.hookId })
+    } catch {
+      // A refused effect lease is its own outcome: nothing was ever sent to GitLab.
+      return { kind: 'failed', code: 'token_unavailable' }
+    }
+    if (CAPABILITY_RANK[lease.access] < CAPABILITY_RANK[REQUIRED_CAPABILITY])
+      return { kind: 'failed', code: 'insufficient_authority' }
+    if (lease.credentialEpoch !== row.credentialEpoch) return { kind: 'skipped', code: 'stale_credential_epoch' }
+    return { kind: 'lease', lease }
   }
 
   /** One retry only, and only after a definite auth rejection or a 404 proving the note is gone. */
@@ -333,20 +409,23 @@ export class CodeHostNoteProjector {
       if (res.kind === 'unavailable') return { kind: 'ambiguous', code: res.code }
       if (res.status >= 200 && res.status < 300) {
         const id = noteIdOf(idFromBody(res.body))
-        // The note exists; a missing id only loses the deep link and must never re-run the write.
-        return id ? { kind: 'written', noteId: id } : { kind: 'failed', code: 'note_id_unreadable' }
+        if (id) return { kind: 'written', noteId: id }
+        // An update already knows the note it edited, so an unreadable body loses nothing. A create
+        // does not: GitLab accepted it, so the note exists at an id only the marker can recover.
+        return target === undefined
+          ? { kind: 'ambiguous', code: 'create_id_unreadable' }
+          : { kind: 'written', noteId: target }
       }
+      // A 5xx never proves the mutation had no effect — on either attempt, so this precedes the guard.
+      if (res.status >= 500) return { kind: 'ambiguous', code: `http_${res.status}` }
       if (attempt === 1) return { kind: 'failed', code: `http_${res.status}` }
       if (res.status === 401 || res.status === 403) {
         if (!this.deps.invalidateLease) return { kind: 'failed', code: `http_${res.status}` }
         this.deps.invalidateLease({ agentId: row.agentId, projectId: row.projectId }, current.token)
-        try {
-          current = await this.deps.lease({ agentId: row.agentId, projectId: row.projectId, hookId: row.hookId })
-        } catch {
-          return { kind: 'failed', code: 'token_unavailable' }
-        }
-        if (CAPABILITY_RANK[current.access] < CAPABILITY_RANK[REQUIRED_CAPABILITY])
-          return { kind: 'failed', code: 'insufficient_authority' }
+        // The re-minted grant re-runs every authority fence: a refresh may cross a credential purge.
+        const minted = await this.mint(row)
+        if (minted.kind !== 'lease') return minted
+        current = minted.lease
         continue
       }
       // The recorded note is gone: reconcile by marker once more rather than assume a fresh create.
@@ -357,8 +436,6 @@ export class CodeHostNoteProjector {
         target = found.noteId
         continue
       }
-      // A 5xx answer does not prove the mutation had no effect, so it stays fail-closed here.
-      if (res.status >= 500) return { kind: 'ambiguous', code: `http_${res.status}` }
       return { kind: 'failed', code: `http_${res.status}` }
     }
     return { kind: 'failed', code: 'write_failed' }
@@ -423,12 +500,16 @@ export class CodeHostNoteProjector {
     }
   }
 
-  private async send(result: CodeHostNoteResult, orgId?: string): Promise<void> {
+  /** True once the control plane has definitively taken the result — acked, or permanently refused. */
+  private async send(result: CodeHostNoteResult, orgId?: string): Promise<boolean> {
     try {
       await this.deps.report(result, orgId)
+      return true
     } catch (err) {
-      // The ledger row already records the truth; a lost result is re-derivable, never a second write.
       this.warn(`note projection: result report failed for ${result.projectionId} (${String(err)})`)
+      // A non-retryable refusal means the control plane already moved past this generation: replaying
+      // it forever would only leak a row. Anything else is a delivery failure the sweep retries.
+      return (err as { retryable?: unknown })?.retryable === false
     }
   }
 
@@ -470,6 +551,13 @@ function settled(row: NoteProjectionRow, outcome: WriteOutcome, now: number): Co
     ...(outcome.kind === 'written' ? { noteId: outcome.noteId, observedState: row.state } : { code: outcome.code }),
     observedAt: new Date(now).toISOString()
   }
+}
+
+/** Rebuild an unreported outcome from its row. A `written` row without an id cannot claim one. */
+function storedOutcome(row: NoteProjectionRow): WriteOutcome {
+  if (row.outcome === 'written' && row.noteId) return { kind: 'written', noteId: row.noteId }
+  if (row.outcome === 'skipped') return { kind: 'skipped', code: row.code ?? 'skipped' }
+  return { kind: 'failed', code: row.code ?? 'note_id_unreadable' }
 }
 
 function noteIdOf(value: string | undefined): string | undefined {

--- a/packages/daemon/src/gitlab/note-projection.ts
+++ b/packages/daemon/src/gitlab/note-projection.ts
@@ -3,6 +3,7 @@
 // generations, reconciled by a hidden marker before any retry, reported back as identity + outcome.
 // The note carries fixed control fields only: never agent output, review text, issue/MR text, or logs.
 import type { CodeHostNoteDesired, CodeHostNoteResult, CodeHostNoteState } from '@agentconnect.md/protocol'
+import type { PosterScheduler } from '../github/poster.js'
 import { parseGitlabJson, type BrokerCapability } from './broker.js'
 
 /** The fixed §16 lifecycle labels; the note shows one of these and nothing else as its heading. */
@@ -35,6 +36,9 @@ const SHORT_SHA_CHARS = 8
 const LIST_PAGE_SIZE = 100
 const MAX_LIST_PAGES = 5
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+/** Unsettled rows retry on the projector's own clock: a healthy control socket never triggers a sweep. */
+const DEFAULT_RESWEEP_BASE_MS = 30_000
+const DEFAULT_RESWEEP_CAP_MS = 300_000
 const DEFAULT_BASE_URL = 'https://gitlab.com/api/v4'
 /** The projection is a comment-class effect, so the hook-authorized lease must clamp at least here. */
 const REQUIRED_CAPABILITY: BrokerCapability = 'comment'
@@ -118,6 +122,8 @@ export interface NoteProjectionRow {
   body: string
   noteId?: string
   credentialEpoch: string
+  /** The stable daemon identity that owns this write — the one the placement fence names. */
+  daemonId: string
   phase: NoteProjectionPhase
   /** Set with `settled_unreported`: the outcome and code the replay re-sends verbatim. */
   outcome?: NoteProjectionOutcome
@@ -125,7 +131,7 @@ export interface NoteProjectionRow {
 }
 
 export interface NoteProjectionStore {
-  getNoteProjection(projectionKey: string): Promise<NoteProjectionRow | undefined>
+  getNoteProjection(daemonId: string, projectionKey: string): Promise<NoteProjectionRow | undefined>
   beginNoteProjectionWrite(row: NoteProjectionRow, now: number): Promise<void>
   recordNoteProjectionOutcome(
     row: NoteProjectionRow,
@@ -133,8 +139,9 @@ export interface NoteProjectionStore {
     code: string | undefined,
     now: number
   ): Promise<void>
-  markNoteProjectionReported(projectionKey: string, writeMarker: string, now: number): Promise<void>
-  listUnsettledNoteProjections(): Promise<NoteProjectionRow[]>
+  markNoteProjectionReported(daemonId: string, projectionKey: string, writeMarker: string, now: number): Promise<void>
+  /** Scoped to the stable daemon identity, so a restart recovers its own rows and no peer's. */
+  listUnsettledNoteProjections(daemonId: string): Promise<NoteProjectionRow[]>
 }
 
 export interface NoteProjectionLease {
@@ -157,6 +164,10 @@ export interface CodeHostNoteProjectorDeps {
   report: (result: CodeHostNoteResult, orgId?: string) => Promise<void>
   log: { warn: (message: string) => void }
   now?: () => number
+  /** Timer seam for the self-scheduled resweep; tests drive it, production uses real timers. */
+  scheduler?: PosterScheduler
+  resweepBaseMs?: number
+  resweepCapMs?: number
   baseUrl?: string
   fetchImpl?: typeof fetch
   requestTimeoutMs?: number
@@ -175,8 +186,26 @@ type ProviderAnswer = { kind: 'answered'; status: number; body: string } | { kin
 export class CodeHostNoteProjector {
   /** One mutation at a time per projection key: two generations must never race the same note. */
   private readonly chains = new Map<string, Promise<void>>()
+  private readonly sched: PosterScheduler
+  private resweepHandle?: unknown
+  /** Consecutive sweeps that still left work behind; resets to zero the moment nothing is owed. */
+  private resweepAttempt = 0
+  private sweeping = false
+  private stopped = false
 
-  constructor(private readonly deps: CodeHostNoteProjectorDeps) {}
+  constructor(private readonly deps: CodeHostNoteProjectorDeps) {
+    this.sched = deps.scheduler ?? {
+      now: () => Date.now(),
+      setTimeout: (fn, ms) => setTimeout(fn, ms),
+      clearTimeout: (h) => clearTimeout(h as NodeJS.Timeout)
+    }
+  }
+
+  /** Drop the pending resweep so a shutting-down daemon leaves no timer behind. */
+  stop(): void {
+    this.stopped = true
+    this.disarm()
+  }
 
   /** Converge one desired generation and report exactly one result. Never rejects. */
   apply(desired: CodeHostNoteDesired, orgId?: string): Promise<void> {
@@ -191,14 +220,68 @@ export class CodeHostNoteProjector {
    * dropped `codehost/note-result` cannot leave the control plane's write mutex held forever.
    */
   async reconcilePending(): Promise<void> {
+    if (this.sweeping) return
+    this.sweeping = true
+    try {
+      const remaining = await this.sweepOnce()
+      // Keep the projector's own clock running while anything is owed, and go quiet the moment
+      // nothing is: an unreachable provider must not depend on a control-plane reconnect to retry.
+      if (remaining === undefined) return
+      if (remaining > 0) this.arm()
+      else this.disarm()
+    } finally {
+      this.sweeping = false
+    }
+  }
+
+  /** One pass over what this daemon identity owes; the count still unsettled after it, or undefined. */
+  private async sweepOnce(): Promise<number | undefined> {
+    const daemonId = this.deps.daemonId()
+    // Before the control plane adopts an id there is no identity to recover rows under; retry later.
+    if (!daemonId) return 0
     let rows: NoteProjectionRow[]
     try {
-      rows = await this.deps.store.listUnsettledNoteProjections()
+      rows = await this.deps.store.listUnsettledNoteProjections(daemonId)
     } catch (err) {
       this.warn(`note projection: pending write scan failed (${String(err)})`)
-      return
+      return undefined
     }
+    if (rows.length === 0) return 0
     for (const row of rows) await this.serialize(row.projectionKey, () => this.settlePending(row))
+    try {
+      return (await this.deps.store.listUnsettledNoteProjections(daemonId)).length
+    } catch {
+      // The pass ran; an unreadable follow-up count just keeps the backoff armed.
+      return rows.length
+    }
+  }
+
+  /** Arm the next resweep on exponential backoff, capped. An armed timer is never restarted early. */
+  private arm(): void {
+    if (this.stopped || this.resweepHandle !== undefined) return
+    const base = this.deps.resweepBaseMs ?? DEFAULT_RESWEEP_BASE_MS
+    const cap = this.deps.resweepCapMs ?? DEFAULT_RESWEEP_CAP_MS
+    const delay = Math.min(base * 2 ** Math.min(this.resweepAttempt, 16), cap)
+    this.resweepAttempt += 1
+    try {
+      this.resweepHandle = this.sched.setTimeout(() => {
+        this.resweepHandle = undefined
+        void this.reconcilePending()
+      }, delay)
+    } catch (err) {
+      this.warn(`note projection: resweep scheduling failed (${String(err)})`)
+    }
+  }
+
+  private disarm(): void {
+    this.resweepAttempt = 0
+    if (this.resweepHandle === undefined) return
+    try {
+      this.sched.clearTimeout(this.resweepHandle)
+    } catch {
+      // A failed clear only leaves a sweep that finds nothing to do.
+    }
+    this.resweepHandle = undefined
   }
 
   private serialize(key: string, run: () => Promise<void>): Promise<void> {
@@ -217,13 +300,14 @@ export class CodeHostNoteProjector {
   private async converge(desired: CodeHostNoteDesired, orgId?: string): Promise<void> {
     const fence = this.fenceFailure(desired)
     // A refusal this daemon does not own leaves no local row: there is nothing here to replay.
-    if (fence) {
+    if (fence.kind === 'refused') {
       await this.send(refusal(desired, fence.outcome, fence.code, this.now()), orgId)
       return
     }
+    const daemonId = fence.daemonId
     let stored: NoteProjectionRow | undefined
     try {
-      stored = await this.deps.store.getNoteProjection(desired.projectionKey)
+      stored = await this.deps.store.getNoteProjection(daemonId, desired.projectionKey)
     } catch (err) {
       this.warn(`note projection: ledger read failed for ${desired.projectionKey} (${String(err)})`)
       await this.send(refusal(desired, 'failed', 'ledger_unavailable', this.now()), orgId)
@@ -254,6 +338,7 @@ export class CodeHostNoteProjector {
       body: renderProjectionNote(desired),
       ...(noteId ? { noteId } : {}),
       credentialEpoch: desired.credentialEpoch,
+      daemonId,
       phase: 'in_flight'
     }
     // An earlier write of this projection never reached a definite outcome, so the note's identity
@@ -276,14 +361,20 @@ export class CodeHostNoteProjector {
 
   /** Send one definite result and stop replaying it only once the control plane has taken it. */
   private async deliver(row: NoteProjectionRow, outcome: WriteOutcome, orgId?: string): Promise<void> {
-    // An ambiguous outcome keeps its in-flight row, which the sweep reconciles; nothing to retire.
+    // An ambiguous outcome keeps its in-flight row: arm the resweep that will reconcile it, because
+    // a provider timeout says nothing about the control socket that would otherwise be the trigger.
     if (outcome.kind === 'ambiguous') {
       await this.send(settled(row, outcome, this.now()), orgId)
+      this.arm()
       return
     }
-    if (!(await this.send(settled(row, outcome, this.now()), orgId))) return
+    if (!(await this.send(settled(row, outcome, this.now()), orgId))) {
+      // The outcome is durable but unreported; the sweep replays it until the control plane takes it.
+      this.arm()
+      return
+    }
     try {
-      await this.deps.store.markNoteProjectionReported(row.projectionKey, row.writeMarker, this.now())
+      await this.deps.store.markNoteProjectionReported(row.daemonId, row.projectionKey, row.writeMarker, this.now())
     } catch (err) {
       // Harmless: the row simply replays an identical result, which the control plane answers once.
       this.warn(`note projection: ledger ack failed for ${row.projectionKey} (${String(err)})`)
@@ -291,17 +382,19 @@ export class CodeHostNoteProjector {
   }
 
   /** Placement, credential and renderability fences — all of them refuse BEFORE any provider call. */
-  private fenceFailure(desired: CodeHostNoteDesired): { outcome: 'skipped' | 'failed'; code: string } | undefined {
-    if (desired.provider !== 'gitlab') return { outcome: 'skipped', code: 'provider_unsupported' }
+  private fenceFailure(
+    desired: CodeHostNoteDesired
+  ): { kind: 'owned'; daemonId: string } | { kind: 'refused'; outcome: 'skipped' | 'failed'; code: string } {
+    const refused = (outcome: 'skipped' | 'failed', code: string) => ({ kind: 'refused', outcome, code }) as const
+    if (desired.provider !== 'gitlab') return refused('skipped', 'provider_unsupported')
     const daemonId = this.deps.daemonId()
     // No adopted id yet, or a fence naming another member: this daemon is not the writer.
-    if (!daemonId || desired.snapshot.dispatchDaemonId !== daemonId)
-      return { outcome: 'skipped', code: 'not_dispatch_owner' }
+    if (!daemonId || desired.snapshot.dispatchDaemonId !== daemonId) return refused('skipped', 'not_dispatch_owner')
     const leaseUntil = Date.parse(desired.leaseUntil)
-    if (!Number.isFinite(leaseUntil) || leaseUntil <= this.now()) return { outcome: 'skipped', code: 'lease_expired' }
-    if (!PROJECTION_KEY.test(desired.projectionKey)) return { outcome: 'failed', code: 'invalid_projection_key' }
-    if (!DECIMAL_ID.test(desired.projectId)) return { outcome: 'failed', code: 'invalid_project_id' }
-    return undefined
+    if (!Number.isFinite(leaseUntil) || leaseUntil <= this.now()) return refused('skipped', 'lease_expired')
+    if (!PROJECTION_KEY.test(desired.projectionKey)) return refused('failed', 'invalid_projection_key')
+    if (!DECIMAL_ID.test(desired.projectId)) return refused('failed', 'invalid_project_id')
+    return { kind: 'owned', daemonId }
   }
 
   /** What the durable ledger already knows refuses a frame the local record has moved past. */

--- a/packages/daemon/src/gitlab/note-projection.ts
+++ b/packages/daemon/src/gitlab/note-projection.ts
@@ -190,6 +190,8 @@ export class CodeHostNoteProjector {
   private resweepHandle?: unknown
   /** Consecutive sweeps that still left work behind; resets to zero the moment nothing is owed. */
   private resweepAttempt = 0
+  /** Monotonic count of arm REQUESTS, so a zero-work disarm can tell whether it raced new work. */
+  private armGeneration = 0
   private sweeping = false
   private stopped = false
 
@@ -204,7 +206,7 @@ export class CodeHostNoteProjector {
   /** Drop the pending resweep so a shutting-down daemon leaves no timer behind. */
   stop(): void {
     this.stopped = true
-    this.disarm()
+    this.clearTimer()
   }
 
   /** Converge one desired generation and report exactly one result. Never rejects. */
@@ -222,13 +224,15 @@ export class CodeHostNoteProjector {
   async reconcilePending(): Promise<void> {
     if (this.sweeping) return
     this.sweeping = true
+    // Read BEFORE the scan: work that arms after this point owns the timer, not this sweep.
+    const armedThrough = this.armGeneration
     try {
       const remaining = await this.sweepOnce()
       // Keep the projector's own clock running while anything is owed, and go quiet the moment
       // nothing is: an unreachable provider must not depend on a control-plane reconnect to retry.
-      if (remaining === undefined) return
-      if (remaining > 0) this.arm()
-      else this.disarm()
+      // A scan that did not answer proves nothing, so it continues the chain rather than ending it.
+      if (remaining === undefined || remaining > 0) this.arm()
+      else this.disarm(armedThrough)
     } finally {
       this.sweeping = false
     }
@@ -258,7 +262,11 @@ export class CodeHostNoteProjector {
 
   /** Arm the next resweep on exponential backoff, capped. An armed timer is never restarted early. */
   private arm(): void {
-    if (this.stopped || this.resweepHandle !== undefined) return
+    if (this.stopped) return
+    // EVERY arm request advances the generation, including one an armed timer already covers: a
+    // concurrent zero-work sweep decides by this counter whether the timer is still its to clear.
+    this.armGeneration += 1
+    if (this.resweepHandle !== undefined) return
     const base = this.deps.resweepBaseMs ?? DEFAULT_RESWEEP_BASE_MS
     const cap = this.deps.resweepCapMs ?? DEFAULT_RESWEEP_CAP_MS
     const delay = Math.min(base * 2 ** Math.min(this.resweepAttempt, 16), cap)
@@ -273,8 +281,14 @@ export class CodeHostNoteProjector {
     }
   }
 
-  private disarm(): void {
+  /** Go quiet — but only if nothing armed after the sweep that decided there was no work left. */
+  private disarm(armedThrough: number): void {
+    if (this.armGeneration !== armedThrough) return
     this.resweepAttempt = 0
+    this.clearTimer()
+  }
+
+  private clearTimer(): void {
     if (this.resweepHandle === undefined) return
     try {
       this.sched.clearTimeout(this.resweepHandle)

--- a/packages/daemon/src/gitlab/note-projection.ts
+++ b/packages/daemon/src/gitlab/note-projection.ts
@@ -1,0 +1,493 @@
+// Informational run projection (gitlab-com-integration.md §16): the daemon is the ONLY GitLab Notes
+// writer for this surface — one service-account note per merge-request head, updated in place across
+// generations, reconciled by a hidden marker before any retry, reported back as identity + outcome.
+// The note carries fixed control fields only: never agent output, review text, issue/MR text, or logs.
+import type { CodeHostNoteDesired, CodeHostNoteResult, CodeHostNoteState } from '@agentconnect.md/protocol'
+import { parseGitlabJson, type BrokerCapability } from './broker.js'
+
+/** The fixed §16 lifecycle labels; the note shows one of these and nothing else as its heading. */
+const STATE_LABEL: Record<CodeHostNoteState, string> = {
+  queued: 'Queued',
+  running: 'Running',
+  completed: 'Completed',
+  failed: 'Failed',
+  skipped: 'Skipped',
+  superseded: 'Superseded',
+  interrupted: 'Interrupted'
+}
+
+/** §16.1: the only authorized ways to open a new generation, named on a note that ended early. */
+const RE_REQUEST_SENTENCE =
+  'To run again, re-request a review from the project service account, mention the agent explicitly, or use "Run again" in the AgentConnect Console.'
+
+/** The hidden stable marker a note is reconciled by; identical across every generation of one head. */
+const MARKER_PREFIX = 'agentconnect-projection:'
+/** The key is a Control-Plane-issued opaque id; anything outside this charset cannot enter a comment. */
+const PROJECTION_KEY = /^[A-Za-z0-9_.:-]{1,200}$/
+const REASON_CODE = /^[a-z0-9_:-]{1,100}$/
+/** Console links are ordinary authenticated http(s) URLs — never a scheme that could execute. */
+const CONSOLE_URL = /^https?:\/\/[^\s()<>"']{1,500}$/
+const NON_HEX = /[^0-9a-fA-F]/g
+const DECIMAL_ID = /^[1-9]\d*$/
+const MAX_AGENT_NAME_CHARS = 200
+const SHORT_SHA_CHARS = 8
+/** Bounded reconciliation scan: enough to find our own note on a busy merge request, never unbounded. */
+const LIST_PAGE_SIZE = 100
+const MAX_LIST_PAGES = 5
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+const DEFAULT_BASE_URL = 'https://gitlab.com/api/v4'
+/** The projection is a comment-class effect, so the hook-authorized lease must clamp at least here. */
+const REQUIRED_CAPABILITY: BrokerCapability = 'comment'
+const CAPABILITY_RANK: Record<BrokerCapability, number> = { read: 0, comment: 1, write: 2 }
+
+export function projectionMarker(projectionKey: string): string {
+  return `<!-- ${MARKER_PREFIX}${projectionKey} -->`
+}
+
+/** Collapse to one safe display line: no newline, no Markdown structure, no HTML-comment escape. */
+function plain(value: string, max: number): string {
+  return value
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max)
+    .replace(/[\\`*_[\]<>|]/g, (c) => `\\${c}`)
+}
+
+/** Re-emit a frame timestamp from its parsed value, so only a real instant ever reaches the body. */
+function stamp(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const at = Date.parse(value)
+  return Number.isFinite(at) ? new Date(at).toISOString() : undefined
+}
+
+function shortSha(headSha: string): string | undefined {
+  const hex = headSha.replace(NON_HEX, '').slice(0, SHORT_SHA_CHARS)
+  return hex.length > 0 ? hex : undefined
+}
+
+/**
+ * The FIXED template. Its only inputs are the frame's control fields — state, agent display name,
+ * revision abbreviation, timestamps, normalized reason, Console link, and the hidden marker. No
+ * other field of the frame, and nothing from any other source, may reach this string.
+ */
+export function renderProjectionNote(desired: CodeHostNoteDesired): string {
+  const lines = [projectionMarker(desired.projectionKey), `**AgentConnect run — ${STATE_LABEL[desired.state]}**`, '']
+  lines.push(`- Agent: ${plain(desired.agentName, MAX_AGENT_NAME_CHARS)}`)
+  const revision = shortSha(desired.headSha)
+  if (revision) lines.push(`- Revision: \`${revision}\``)
+  if (desired.reason && REASON_CODE.test(desired.reason)) lines.push(`- Reason: \`${desired.reason}\``)
+  const queued = stamp(desired.queuedAt)
+  if (queued) lines.push(`- Queued: ${queued}`)
+  const started = stamp(desired.startedAt)
+  if (started) lines.push(`- Started: ${started}`)
+  const completed = stamp(desired.completedAt)
+  if (completed) lines.push(`- Completed: ${completed}`)
+  const updated = stamp(desired.desiredAt)
+  if (updated) lines.push(`- Updated: ${updated}`)
+  if (desired.consoleUrl && CONSOLE_URL.test(desired.consoleUrl))
+    lines.push('', `[View this run in the Console](${desired.consoleUrl})`)
+  if (desired.state === 'superseded' || desired.state === 'interrupted') lines.push('', RE_REQUEST_SENTENCE)
+  return lines.join('\n')
+}
+
+export type NoteProjectionPhase = 'in_flight' | 'settled'
+
+/** The durable local write ledger row: written BEFORE any mutation, settled after a definite one. */
+export interface NoteProjectionRow {
+  projectionKey: string
+  projectionId: string
+  hookId: string
+  agentId: string
+  orgId?: string
+  provider: string
+  projectId: string
+  mergeRequestIid: number
+  headSha: string
+  generation: string
+  writeMarker: string
+  state: CodeHostNoteState
+  /** The rendered body of this generation, so a reconciled write needs no re-render. */
+  body: string
+  noteId?: string
+  credentialEpoch: string
+  phase: NoteProjectionPhase
+}
+
+export interface NoteProjectionStore {
+  getNoteProjection(projectionKey: string): Promise<NoteProjectionRow | undefined>
+  beginNoteProjectionWrite(row: NoteProjectionRow, now: number): Promise<void>
+  settleNoteProjectionWrite(
+    projectionKey: string,
+    writeMarker: string,
+    noteId: string | undefined,
+    now: number
+  ): Promise<void>
+  listInFlightNoteProjections(): Promise<NoteProjectionRow[]>
+}
+
+export interface NoteProjectionLease {
+  token: string
+  access: BrokerCapability
+}
+
+export interface CodeHostNoteProjectorDeps {
+  /** This daemon's adopted id — the frame's placement fence is checked against it, never assumed. */
+  daemonId: () => string | undefined
+  store: NoteProjectionStore
+  /** Hook-authorized effect lease (purpose `gitlab_effect`); the token never leaves this writer. */
+  lease: (input: { agentId: string; projectId: string; hookId: string }) => Promise<NoteProjectionLease>
+  /** Drop a lease GitLab just rejected (401/403) so the single retry re-mints. */
+  invalidateLease?: (input: { agentId: string; projectId: string }, token: string) => void
+  /** Deliver `codehost/note-result` to the Control Plane; may reject when the CP is unreachable. */
+  report: (result: CodeHostNoteResult, orgId?: string) => Promise<void>
+  log: { warn: (message: string) => void }
+  now?: () => number
+  baseUrl?: string
+  fetchImpl?: typeof fetch
+  requestTimeoutMs?: number
+}
+
+/** A definite provider answer, an ambiguous one, or a deterministic no-effect refusal. */
+type WriteOutcome =
+  { kind: 'written'; noteId: string } | { kind: 'failed'; code: string } | { kind: 'ambiguous'; code: string }
+
+/** One bounded provider call's answer; a timeout or transport error is unavailable, not a status. */
+type ProviderAnswer = { kind: 'answered'; status: number; body: string } | { kind: 'unavailable'; code: string }
+
+export class CodeHostNoteProjector {
+  /** One mutation at a time per projection key: two generations must never race the same note. */
+  private readonly chains = new Map<string, Promise<void>>()
+
+  constructor(private readonly deps: CodeHostNoteProjectorDeps) {}
+
+  /** Converge one desired generation and report exactly one result. Never rejects. */
+  apply(desired: CodeHostNoteDesired, orgId?: string): Promise<void> {
+    return this.serialize(desired.projectionKey, () => this.converge(desired, orgId))
+  }
+
+  /**
+   * Startup / reconnect sweep over writes this daemon started but never settled (§16): every one is
+   * reconciled by LISTING the merge request's notes and matching the hidden marker before the note
+   * is touched again, so an interrupted create can never become a second note for the same head.
+   */
+  async reconcilePending(): Promise<void> {
+    let rows: NoteProjectionRow[]
+    try {
+      rows = await this.deps.store.listInFlightNoteProjections()
+    } catch (err) {
+      this.warn(`note projection: pending write scan failed (${String(err)})`)
+      return
+    }
+    for (const row of rows) await this.serialize(row.projectionKey, () => this.settlePending(row))
+  }
+
+  private serialize(key: string, run: () => Promise<void>): Promise<void> {
+    const next = (this.chains.get(key) ?? Promise.resolve()).then(run, run)
+    this.chains.set(key, next)
+    void next.finally(() => {
+      if (this.chains.get(key) === next) this.chains.delete(key)
+    })
+    return next
+  }
+
+  private now(): number {
+    return this.deps.now?.() ?? Date.now()
+  }
+
+  private async converge(desired: CodeHostNoteDesired, orgId?: string): Promise<void> {
+    const fence = this.fenceFailure(desired)
+    if (fence) return await this.send(refusal(desired, fence.outcome, fence.code, this.now()), orgId)
+    let stored: NoteProjectionRow | undefined
+    try {
+      stored = await this.deps.store.getNoteProjection(desired.projectionKey)
+    } catch (err) {
+      this.warn(`note projection: ledger read failed for ${desired.projectionKey} (${String(err)})`)
+      return await this.send(refusal(desired, 'failed', 'ledger_unavailable', this.now()), orgId)
+    }
+    const ledger = this.ledgerFailure(desired, stored)
+    if (ledger) return await this.send(refusal(desired, 'skipped', ledger, this.now()), orgId)
+
+    // The recorded note wins over the frame's hint only when the frame carries none; both are the
+    // same observed identity, and an unreadable one is treated as unknown so the marker decides.
+    const noteId = noteIdOf(desired.noteId) ?? noteIdOf(stored?.noteId)
+    const row: NoteProjectionRow = {
+      projectionKey: desired.projectionKey,
+      projectionId: desired.projectionId,
+      hookId: desired.hookId,
+      agentId: desired.agentId,
+      ...(orgId ? { orgId } : {}),
+      provider: desired.provider,
+      projectId: desired.projectId,
+      mergeRequestIid: desired.mergeRequestIid,
+      headSha: desired.headSha,
+      generation: desired.generation,
+      writeMarker: desired.writeMarker,
+      state: desired.state,
+      body: renderProjectionNote(desired),
+      ...(noteId ? { noteId } : {}),
+      credentialEpoch: desired.credentialEpoch,
+      phase: 'in_flight'
+    }
+    // An earlier write of this projection never reached a definite outcome, so the note's identity
+    // is recovered from the provider before this generation may touch the merge request at all.
+    const outcome = await this.write(row, stored?.phase === 'in_flight', true)
+    await this.send(settled(row, outcome, this.now()), orgId)
+  }
+
+  /** Finish an interrupted write from the ledger row alone: reconcile by marker, then converge. */
+  private async settlePending(row: NoteProjectionRow): Promise<void> {
+    const outcome = await this.write(row, true, false)
+    // Still fail-closed on this writer: the row stays in flight and the next sweep reconciles again.
+    if (outcome.kind === 'ambiguous') return
+    await this.send(settled(row, outcome, this.now()), row.orgId)
+  }
+
+  /** Placement, credential and renderability fences — all of them refuse BEFORE any provider call. */
+  private fenceFailure(desired: CodeHostNoteDesired): { outcome: 'skipped' | 'failed'; code: string } | undefined {
+    if (desired.provider !== 'gitlab') return { outcome: 'skipped', code: 'provider_unsupported' }
+    const daemonId = this.deps.daemonId()
+    // No adopted id yet, or a fence naming another member: this daemon is not the writer.
+    if (!daemonId || desired.snapshot.dispatchDaemonId !== daemonId)
+      return { outcome: 'skipped', code: 'not_dispatch_owner' }
+    const leaseUntil = Date.parse(desired.leaseUntil)
+    if (!Number.isFinite(leaseUntil) || leaseUntil <= this.now()) return { outcome: 'skipped', code: 'lease_expired' }
+    if (!PROJECTION_KEY.test(desired.projectionKey)) return { outcome: 'failed', code: 'invalid_projection_key' }
+    if (!DECIMAL_ID.test(desired.projectId)) return { outcome: 'failed', code: 'invalid_project_id' }
+    return undefined
+  }
+
+  /** What the durable ledger already knows refuses a frame the local record has moved past. */
+  private ledgerFailure(desired: CodeHostNoteDesired, stored: NoteProjectionRow | undefined): string | undefined {
+    if (!stored) return undefined
+    if (
+      stored.hookId !== desired.hookId ||
+      stored.projectId !== desired.projectId ||
+      stored.mergeRequestIid !== desired.mergeRequestIid ||
+      stored.headSha !== desired.headSha
+    )
+      return 'projection_key_conflict'
+    if (BigInt(stored.credentialEpoch) > BigInt(desired.credentialEpoch)) return 'stale_credential_epoch'
+    if (stored.phase === 'settled' && BigInt(stored.generation) > BigInt(desired.generation)) return 'stale_generation'
+    return undefined
+  }
+
+  /**
+   * The single provider mutation: adopt the note by marker when reconciliation is owed, persist the
+   * write marker, then create once or update the SAME note in place.
+   */
+  private async write(row: NoteProjectionRow, reconcile: boolean, persist: boolean): Promise<WriteOutcome> {
+    let lease: NoteProjectionLease
+    try {
+      lease = await this.deps.lease({ agentId: row.agentId, projectId: row.projectId, hookId: row.hookId })
+    } catch {
+      // A refused effect lease is its own outcome: nothing was ever sent to GitLab.
+      return { kind: 'failed', code: 'token_unavailable' }
+    }
+    if (CAPABILITY_RANK[lease.access] < CAPABILITY_RANK[REQUIRED_CAPABILITY])
+      return { kind: 'failed', code: 'insufficient_authority' }
+
+    let noteId = row.noteId
+    if (reconcile) {
+      const found = await this.findByMarker(row, lease.token)
+      // A list that did not answer cannot authorize a write: retrying blind is how a head gets two notes.
+      if (found.kind === 'unavailable') return { kind: 'ambiguous', code: 'reconcile_unavailable' }
+      noteId = found.noteId
+    }
+    if (persist) {
+      try {
+        await this.deps.store.beginNoteProjectionWrite({ ...row, ...(noteId ? { noteId } : {}) }, this.now())
+      } catch (err) {
+        this.warn(`note projection: write marker persist failed for ${row.projectionKey} (${String(err)})`)
+        return { kind: 'failed', code: 'ledger_unavailable' }
+      }
+    }
+
+    const outcome = await this.mutate(row, noteId, lease)
+    // An ambiguous mutation keeps its in-flight row: only reconciliation, never a replay, may follow.
+    if (outcome.kind === 'ambiguous') return outcome
+    try {
+      await this.deps.store.settleNoteProjectionWrite(
+        row.projectionKey,
+        row.writeMarker,
+        outcome.kind === 'written' ? outcome.noteId : noteId,
+        this.now()
+      )
+    } catch (err) {
+      this.warn(`note projection: ledger settle failed for ${row.projectionKey} (${String(err)})`)
+    }
+    return outcome
+  }
+
+  /** One retry only, and only after a definite auth rejection or a 404 proving the note is gone. */
+  private async mutate(
+    row: NoteProjectionRow,
+    noteId: string | undefined,
+    lease: NoteProjectionLease
+  ): Promise<WriteOutcome> {
+    let current = lease
+    let target = noteId
+    let readopted = false
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const path = target === undefined ? this.notesPath(row) : `${this.notesPath(row)}/${encodeURIComponent(target)}`
+      const res = await this.call(target === undefined ? 'POST' : 'PUT', path, current.token, { body: row.body })
+      if (res.kind === 'unavailable') return { kind: 'ambiguous', code: res.code }
+      if (res.status >= 200 && res.status < 300) {
+        const id = noteIdOf(idFromBody(res.body))
+        // The note exists; a missing id only loses the deep link and must never re-run the write.
+        return id ? { kind: 'written', noteId: id } : { kind: 'failed', code: 'note_id_unreadable' }
+      }
+      if (attempt === 1) return { kind: 'failed', code: `http_${res.status}` }
+      if (res.status === 401 || res.status === 403) {
+        if (!this.deps.invalidateLease) return { kind: 'failed', code: `http_${res.status}` }
+        this.deps.invalidateLease({ agentId: row.agentId, projectId: row.projectId }, current.token)
+        try {
+          current = await this.deps.lease({ agentId: row.agentId, projectId: row.projectId, hookId: row.hookId })
+        } catch {
+          return { kind: 'failed', code: 'token_unavailable' }
+        }
+        if (CAPABILITY_RANK[current.access] < CAPABILITY_RANK[REQUIRED_CAPABILITY])
+          return { kind: 'failed', code: 'insufficient_authority' }
+        continue
+      }
+      // The recorded note is gone: reconcile by marker once more rather than assume a fresh create.
+      if (res.status === 404 && target !== undefined && !readopted) {
+        const found = await this.findByMarker(row, current.token)
+        if (found.kind === 'unavailable') return { kind: 'ambiguous', code: 'reconcile_unavailable' }
+        readopted = true
+        target = found.noteId
+        continue
+      }
+      // A 5xx answer does not prove the mutation had no effect, so it stays fail-closed here.
+      if (res.status >= 500) return { kind: 'ambiguous', code: `http_${res.status}` }
+      return { kind: 'failed', code: `http_${res.status}` }
+    }
+    return { kind: 'failed', code: 'write_failed' }
+  }
+
+  /** The §16 reconciliation read: the note this projection owns, identified only by its hidden marker. */
+  private async findByMarker(
+    row: NoteProjectionRow,
+    token: string
+  ): Promise<{ kind: 'resolved'; noteId?: string } | { kind: 'unavailable' }> {
+    const marker = projectionMarker(row.projectionKey)
+    for (let page = 1; page <= MAX_LIST_PAGES; page += 1) {
+      const res = await this.call('GET', `${this.notesPath(row)}?per_page=${LIST_PAGE_SIZE}&page=${page}`, token)
+      if (res.kind === 'unavailable' || res.status < 200 || res.status >= 300) return { kind: 'unavailable' }
+      let notes: unknown
+      try {
+        notes = parseGitlabJson(res.body)
+      } catch {
+        return { kind: 'unavailable' }
+      }
+      if (!Array.isArray(notes)) return { kind: 'unavailable' }
+      for (const raw of notes) {
+        const note = (typeof raw === 'object' && raw !== null ? raw : {}) as { id?: unknown; body?: unknown }
+        if (typeof note.body !== 'string' || !note.body.includes(marker)) continue
+        const id = noteIdOf(rawId(note.id))
+        if (id) return { kind: 'resolved', noteId: id }
+      }
+      if (notes.length < LIST_PAGE_SIZE) break
+    }
+    return { kind: 'resolved' }
+  }
+
+  private notesPath(row: NoteProjectionRow): string {
+    return `/projects/${encodeURIComponent(row.projectId)}/merge_requests/${row.mergeRequestIid}/notes`
+  }
+
+  /** One bounded provider call. A timeout or transport error is UNAVAILABLE, never a no-effect answer. */
+  private async call(
+    method: 'GET' | 'POST' | 'PUT',
+    path: string,
+    token: string,
+    payload?: Record<string, unknown>
+  ): Promise<ProviderAnswer> {
+    const doFetch = this.deps.fetchImpl ?? fetch
+    const abort = new AbortController()
+    const timer = setTimeout(() => abort.abort(), this.deps.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS)
+    try {
+      const res = await doFetch(`${this.deps.baseUrl ?? DEFAULT_BASE_URL}${path}`, {
+        method,
+        headers: {
+          'private-token': token,
+          ...(payload !== undefined ? { 'content-type': 'application/json' } : {})
+        },
+        signal: abort.signal,
+        ...(payload !== undefined ? { body: JSON.stringify(payload) } : {})
+      })
+      return { kind: 'answered', status: res.status, body: await res.text() }
+    } catch {
+      return { kind: 'unavailable', code: 'request_unresolved' }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  private async send(result: CodeHostNoteResult, orgId?: string): Promise<void> {
+    try {
+      await this.deps.report(result, orgId)
+    } catch (err) {
+      // The ledger row already records the truth; a lost result is re-derivable, never a second write.
+      this.warn(`note projection: result report failed for ${result.projectionId} (${String(err)})`)
+    }
+  }
+
+  private warn(message: string): void {
+    try {
+      this.deps.log.warn(message)
+    } catch {
+      // A broken logger must not break this writer's no-throw boundary.
+    }
+  }
+}
+
+/** A refusal that never reached GitLab; the Control Plane releases or keeps its mutex on the outcome. */
+function refusal(
+  desired: CodeHostNoteDesired,
+  outcome: 'skipped' | 'failed',
+  code: string,
+  now: number
+): CodeHostNoteResult {
+  return {
+    projectionId: desired.projectionId,
+    hookId: desired.hookId,
+    generation: desired.generation,
+    writeMarker: desired.writeMarker,
+    outcome,
+    code,
+    observedAt: new Date(now).toISOString()
+  }
+}
+
+/** The observed outcome of one started mutation, echoed by the generation and marker it was fenced on. */
+function settled(row: NoteProjectionRow, outcome: WriteOutcome, now: number): CodeHostNoteResult {
+  return {
+    projectionId: row.projectionId,
+    hookId: row.hookId,
+    generation: row.generation,
+    writeMarker: row.writeMarker,
+    outcome: outcome.kind,
+    ...(outcome.kind === 'written' ? { noteId: outcome.noteId, observedState: row.state } : { code: outcome.code }),
+    observedAt: new Date(now).toISOString()
+  }
+}
+
+function noteIdOf(value: string | undefined): string | undefined {
+  return value !== undefined && DECIMAL_ID.test(value) ? value : undefined
+}
+
+function rawId(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' && Number.isSafeInteger(value)) return String(value)
+  return undefined
+}
+
+/** Note ids exceed the safe-integer range; quote them before parsing, as the poster does. */
+function idFromBody(raw: string): string | undefined {
+  try {
+    return rawId((parseGitlabJson(raw) as { id?: unknown })?.id)
+  } catch {
+    // An unreadable body is handled by the caller as a missing id.
+    return undefined
+  }
+}

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -663,6 +663,7 @@ interface CodeHostNoteProjectionRow {
   outcome: string | null
   code: string | null
   updatedAt: number
+  daemonId: string
   ownerId: string | null
 }
 
@@ -687,6 +688,7 @@ function toNoteProjectionRow(row: CodeHostNoteProjectionRow): NoteProjectionRow 
     body: row.body,
     ...(row.noteId ? { noteId: row.noteId } : {}),
     credentialEpoch: row.credentialEpoch,
+    daemonId: row.daemonId,
     // An unknown phase reads as fully settled: it can neither be rewritten nor replayed.
     phase: NOTE_PROJECTION_PHASES.find((p) => p === row.phase) ?? 'settled',
     ...(outcome ? { outcome } : {}),
@@ -697,10 +699,11 @@ function toNoteProjectionRow(row: CodeHostNoteProjectionRow): NoteProjectionRow 
 /** One upsert for both projection phases: the row is identical, only the phase and outcome differ. */
 const NOTE_PROJECTION_UPSERT = `INSERT INTO code_host_note_projection
    (projectionKey, projectionId, hookId, agentId, orgId, provider, projectId, mergeRequestIid, headSha,
-    generation, writeMarker, state, body, noteId, credentialEpoch, phase, outcome, code, updatedAt, ownerId)
+    generation, writeMarker, state, body, noteId, credentialEpoch, phase, outcome, code, updatedAt,
+    daemonId, ownerId)
  VALUES (@projectionKey, @projectionId, @hookId, @agentId, @orgId, @provider, @projectId, @mergeRequestIid,
     @headSha, @generation, @writeMarker, @state, @body, @noteId, @credentialEpoch, @phase, @outcome, @code,
-    @now, @ownerId)
+    @now, @daemonId, @ownerId)
  ON CONFLICT (projectionKey) DO UPDATE SET
    projectionId = excluded.projectionId, hookId = excluded.hookId, agentId = excluded.agentId,
    orgId = excluded.orgId, provider = excluded.provider, projectId = excluded.projectId,
@@ -708,7 +711,7 @@ const NOTE_PROJECTION_UPSERT = `INSERT INTO code_host_note_projection
    generation = excluded.generation, writeMarker = excluded.writeMarker, state = excluded.state,
    body = excluded.body, noteId = excluded.noteId, credentialEpoch = excluded.credentialEpoch,
    phase = excluded.phase, outcome = excluded.outcome, code = excluded.code,
-   updatedAt = excluded.updatedAt, ownerId = excluded.ownerId`
+   updatedAt = excluded.updatedAt, daemonId = excluded.daemonId, ownerId = excluded.ownerId`
 
 function noteProjectionParams(row: NoteProjectionRow, now: number, ownerId: string | null): SqlParams {
   return {
@@ -728,6 +731,7 @@ function noteProjectionParams(row: NoteProjectionRow, now: number, ownerId: stri
     noteId: row.noteId ?? null,
     credentialEpoch: row.credentialEpoch,
     now,
+    daemonId: row.daemonId,
     ownerId
   }
 }
@@ -1491,10 +1495,14 @@ export class LocalStore {
         outcome TEXT,                     -- the definite outcome awaiting acknowledgement
         code TEXT,                        -- its normalized reason code
         updatedAt INTEGER NOT NULL,
-        ownerId TEXT                      -- daemon incarnation that started the write; NULL on an exclusively owned store
+        -- The STABLE daemon identity the control plane dispatches to, not a process incarnation: a
+        -- restarted daemon must find its own unfinished writes, and the control plane keeps an
+        -- ambiguous marker on that identity, so no peer is ever dispatched to finish them.
+        daemonId TEXT NOT NULL,
+        ownerId TEXT                      -- process incarnation that started the write; informational only
       );
       CREATE INDEX IF NOT EXISTS code_host_note_projection_pending
-        ON code_host_note_projection (phase, updatedAt);
+        ON code_host_note_projection (daemonId, phase, updatedAt);
     `)
     // Stamped only once the CREATE block above has actually emitted that schema, so
     // a store that failed halfway through creation is not left claiming to be current.
@@ -5212,11 +5220,12 @@ export class LocalStore {
       .run({ conversationId, authorityId, authorityGeneration, nextAttemptAt, now })
   }
 
-  /** The §16 projection this daemon last wrote for a merge-request head, or nothing yet. */
-  async getNoteProjection(projectionKey: string): Promise<NoteProjectionRow | undefined> {
+  /** The §16 projection THIS daemon identity last wrote for a merge-request head, or nothing yet.
+   *  Scoped by the stable daemon id on every store: a pool peer's row is not this daemon's to read. */
+  async getNoteProjection(daemonId: string, projectionKey: string): Promise<NoteProjectionRow | undefined> {
     const row = (await this.db
-      .prepare('SELECT * FROM code_host_note_projection WHERE projectionKey = ?')
-      .get(projectionKey)) as CodeHostNoteProjectionRow | undefined
+      .prepare('SELECT * FROM code_host_note_projection WHERE projectionKey = @projectionKey AND daemonId = @daemonId')
+      .get({ projectionKey, daemonId })) as CodeHostNoteProjectionRow | undefined
     return row ? toNoteProjectionRow(row) : undefined
   }
 
@@ -5243,26 +5252,37 @@ export class LocalStore {
   }
 
   /** The control plane acknowledged the result: only then does the row stop being replayed. */
-  async markNoteProjectionReported(projectionKey: string, writeMarker: string, now: number): Promise<void> {
+  async markNoteProjectionReported(
+    daemonId: string,
+    projectionKey: string,
+    writeMarker: string,
+    now: number
+  ): Promise<void> {
     await this.db
       .prepare(
         `UPDATE code_host_note_projection
          SET phase = 'settled', updatedAt = @now
-         WHERE projectionKey = @projectionKey AND writeMarker = @writeMarker AND phase = 'settled_unreported'`
+         WHERE projectionKey = @projectionKey AND daemonId = @daemonId AND writeMarker = @writeMarker
+           AND phase = 'settled_unreported'`
       )
-      .run({ projectionKey, writeMarker, now })
+      .run({ projectionKey, daemonId, writeMarker, now })
   }
 
-  /** Writes THIS incarnation started and has not carried to a reported outcome: reconcile or replay. */
-  async listUnsettledNoteProjections(limit = 100): Promise<NoteProjectionRow[]> {
-    const owned = this.shared ? ' AND ownerId = @ownerId' : ''
+  /**
+   * Writes THIS DAEMON IDENTITY has not carried to a reported outcome: reconcile or replay.
+   *
+   * Keyed by the stable daemon id, never the process incarnation, because a restart is exactly when
+   * recovery is owed — and the control plane keeps an ambiguous write marker on that same identity,
+   * so a row no restarted daemon could see would never be settled by anyone.
+   */
+  async listUnsettledNoteProjections(daemonId: string, limit = 100): Promise<NoteProjectionRow[]> {
     const rows = (await this.db
       .prepare(
         `SELECT * FROM code_host_note_projection
-         WHERE phase IN ('in_flight', 'settled_unreported')${owned}
+         WHERE daemonId = @daemonId AND phase IN ('in_flight', 'settled_unreported')
          ORDER BY updatedAt ASC LIMIT @limit`
       )
-      .all({ limit, ...(this.shared ? { ownerId: this.ownerId! } : {}) })) as unknown as CodeHostNoteProjectionRow[]
+      .all({ daemonId, limit })) as unknown as CodeHostNoteProjectionRow[]
     return rows.map(toNoteProjectionRow)
   }
 

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -9,6 +9,7 @@ import {
   type QuotedMessage,
   type SessionImageAttachment
 } from '@agentconnect.md/protocol'
+import type { NoteProjectionRow } from '../gitlab/note-projection.js'
 import { SESSION_TITLE_TOOL_TITLES } from '../mcp/session-title-tool.js'
 import type { ScheduleRun } from '../scheduler/scheduler.js'
 import { AsyncMutex } from './async-mutex.js'
@@ -639,6 +640,49 @@ export interface WebchatMcpGrantLedgerRow {
   updatedAt: number
   /** The daemon incarnation answerable for this row; NULL on an exclusively owned store. */
   ownerId: string | null
+}
+
+/** The stored §16 run-projection write marker, as the column types present it. */
+interface CodeHostNoteProjectionRow {
+  projectionKey: string
+  projectionId: string
+  hookId: string
+  agentId: string
+  orgId: string | null
+  provider: string
+  projectId: string
+  mergeRequestIid: number
+  headSha: string
+  generation: string
+  writeMarker: string
+  state: string
+  body: string
+  noteId: string | null
+  credentialEpoch: string
+  phase: string
+  updatedAt: number
+  ownerId: string | null
+}
+
+function toNoteProjectionRow(row: CodeHostNoteProjectionRow): NoteProjectionRow {
+  return {
+    projectionKey: row.projectionKey,
+    projectionId: row.projectionId,
+    hookId: row.hookId,
+    agentId: row.agentId,
+    ...(row.orgId ? { orgId: row.orgId } : {}),
+    provider: row.provider,
+    projectId: row.projectId,
+    mergeRequestIid: row.mergeRequestIid,
+    headSha: row.headSha,
+    generation: row.generation,
+    writeMarker: row.writeMarker,
+    state: row.state as NoteProjectionRow['state'],
+    body: row.body,
+    ...(row.noteId ? { noteId: row.noteId } : {}),
+    credentialEpoch: row.credentialEpoch,
+    phase: row.phase === 'in_flight' ? 'in_flight' : 'settled'
+  }
 }
 
 /** §3.4/§6.8 main-agent orchestration record (daemon-local). `status` is the
@@ -1375,6 +1419,31 @@ export class LocalStore {
         agentId TEXT PRIMARY KEY,
         generation INTEGER NOT NULL
       );
+      -- gitlab-com-integration.md §16 run projection: the write marker this daemon persists BEFORE
+      -- every provider mutation. An 'in_flight' row surviving a restart is reconciled by listing the
+      -- merge request's notes and matching the hidden marker, never by replaying the write.
+      CREATE TABLE IF NOT EXISTS code_host_note_projection (
+        projectionKey TEXT PRIMARY KEY,
+        projectionId TEXT NOT NULL,
+        hookId TEXT NOT NULL,
+        agentId TEXT NOT NULL,
+        orgId TEXT,
+        provider TEXT NOT NULL,
+        projectId TEXT NOT NULL,
+        mergeRequestIid INTEGER NOT NULL,
+        headSha TEXT NOT NULL,
+        generation TEXT NOT NULL,
+        writeMarker TEXT NOT NULL,
+        state TEXT NOT NULL,
+        body TEXT NOT NULL,
+        noteId TEXT,
+        credentialEpoch TEXT NOT NULL,
+        phase TEXT NOT NULL CHECK (phase IN ('in_flight', 'settled')),
+        updatedAt INTEGER NOT NULL,
+        ownerId TEXT                      -- daemon incarnation that started the write; NULL on an exclusively owned store
+      );
+      CREATE INDEX IF NOT EXISTS code_host_note_projection_pending
+        ON code_host_note_projection (phase, updatedAt);
     `)
     // Stamped only once the CREATE block above has actually emitted that schema, so
     // a store that failed halfway through creation is not left claiming to be current.
@@ -5090,6 +5159,81 @@ export class LocalStore {
            AND authorityGeneration = @authorityGeneration AND state = 'revoking'`
       )
       .run({ conversationId, authorityId, authorityGeneration, nextAttemptAt, now })
+  }
+
+  /** The §16 projection this daemon last wrote for a merge-request head, or nothing yet. */
+  async getNoteProjection(projectionKey: string): Promise<NoteProjectionRow | undefined> {
+    const row = (await this.db
+      .prepare('SELECT * FROM code_host_note_projection WHERE projectionKey = ?')
+      .get(projectionKey)) as CodeHostNoteProjectionRow | undefined
+    return row ? toNoteProjectionRow(row) : undefined
+  }
+
+  /** Record the write marker BEFORE the provider mutation, so an interrupted write is reconcilable. */
+  async beginNoteProjectionWrite(row: NoteProjectionRow, now: number): Promise<void> {
+    await this.db
+      .prepare(
+        `INSERT INTO code_host_note_projection
+           (projectionKey, projectionId, hookId, agentId, orgId, provider, projectId, mergeRequestIid, headSha,
+            generation, writeMarker, state, body, noteId, credentialEpoch, phase, updatedAt, ownerId)
+         VALUES (@projectionKey, @projectionId, @hookId, @agentId, @orgId, @provider, @projectId, @mergeRequestIid,
+            @headSha, @generation, @writeMarker, @state, @body, @noteId, @credentialEpoch, 'in_flight', @now, @ownerId)
+         ON CONFLICT (projectionKey) DO UPDATE SET
+           projectionId = excluded.projectionId, hookId = excluded.hookId, agentId = excluded.agentId,
+           orgId = excluded.orgId, provider = excluded.provider, projectId = excluded.projectId,
+           mergeRequestIid = excluded.mergeRequestIid, headSha = excluded.headSha,
+           generation = excluded.generation, writeMarker = excluded.writeMarker, state = excluded.state,
+           body = excluded.body, noteId = excluded.noteId, credentialEpoch = excluded.credentialEpoch,
+           phase = 'in_flight', updatedAt = excluded.updatedAt, ownerId = excluded.ownerId`
+      )
+      .run({
+        projectionKey: row.projectionKey,
+        projectionId: row.projectionId,
+        hookId: row.hookId,
+        agentId: row.agentId,
+        orgId: row.orgId ?? null,
+        provider: row.provider,
+        projectId: row.projectId,
+        mergeRequestIid: row.mergeRequestIid,
+        headSha: row.headSha,
+        generation: row.generation,
+        writeMarker: row.writeMarker,
+        state: row.state,
+        body: row.body,
+        noteId: row.noteId ?? null,
+        credentialEpoch: row.credentialEpoch,
+        now,
+        ownerId: this.ownerId ?? null
+      })
+  }
+
+  /** Settle the write that marker opened, recording the observed note identity. Exact-marker fenced. */
+  async settleNoteProjectionWrite(
+    projectionKey: string,
+    writeMarker: string,
+    noteId: string | undefined,
+    now: number
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE code_host_note_projection
+         SET phase = 'settled', noteId = COALESCE(@noteId, noteId), updatedAt = @now
+         WHERE projectionKey = @projectionKey AND writeMarker = @writeMarker`
+      )
+      .run({ projectionKey, writeMarker, noteId: noteId ?? null, now })
+  }
+
+  /** Writes THIS incarnation started and never settled — the only rows a reconciliation may touch. */
+  async listInFlightNoteProjections(limit = 100): Promise<NoteProjectionRow[]> {
+    const owned = this.shared ? ' AND ownerId = @ownerId' : ''
+    const rows = (await this.db
+      .prepare(
+        `SELECT * FROM code_host_note_projection
+         WHERE phase = 'in_flight'${owned}
+         ORDER BY updatedAt ASC LIMIT @limit`
+      )
+      .all({ limit, ...(this.shared ? { ownerId: this.ownerId! } : {}) })) as unknown as CodeHostNoteProjectionRow[]
+    return rows.map(toNoteProjectionRow)
   }
 
   /** Record one turn admission against a conversation-wide fixed window. A trusted

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -9,7 +9,7 @@ import {
   type QuotedMessage,
   type SessionImageAttachment
 } from '@agentconnect.md/protocol'
-import type { NoteProjectionRow } from '../gitlab/note-projection.js'
+import type { NoteProjectionOutcome, NoteProjectionPhase, NoteProjectionRow } from '../gitlab/note-projection.js'
 import { SESSION_TITLE_TOOL_TITLES } from '../mcp/session-title-tool.js'
 import type { ScheduleRun } from '../scheduler/scheduler.js'
 import { AsyncMutex } from './async-mutex.js'
@@ -660,11 +660,17 @@ interface CodeHostNoteProjectionRow {
   noteId: string | null
   credentialEpoch: string
   phase: string
+  outcome: string | null
+  code: string | null
   updatedAt: number
   ownerId: string | null
 }
 
+const NOTE_PROJECTION_PHASES: readonly NoteProjectionPhase[] = ['in_flight', 'settled_unreported', 'settled']
+const NOTE_PROJECTION_OUTCOMES: readonly NoteProjectionOutcome[] = ['written', 'skipped', 'failed']
+
 function toNoteProjectionRow(row: CodeHostNoteProjectionRow): NoteProjectionRow {
+  const outcome = NOTE_PROJECTION_OUTCOMES.find((o) => o === row.outcome)
   return {
     projectionKey: row.projectionKey,
     projectionId: row.projectionId,
@@ -681,7 +687,48 @@ function toNoteProjectionRow(row: CodeHostNoteProjectionRow): NoteProjectionRow 
     body: row.body,
     ...(row.noteId ? { noteId: row.noteId } : {}),
     credentialEpoch: row.credentialEpoch,
-    phase: row.phase === 'in_flight' ? 'in_flight' : 'settled'
+    // An unknown phase reads as fully settled: it can neither be rewritten nor replayed.
+    phase: NOTE_PROJECTION_PHASES.find((p) => p === row.phase) ?? 'settled',
+    ...(outcome ? { outcome } : {}),
+    ...(row.code ? { code: row.code } : {})
+  }
+}
+
+/** One upsert for both projection phases: the row is identical, only the phase and outcome differ. */
+const NOTE_PROJECTION_UPSERT = `INSERT INTO code_host_note_projection
+   (projectionKey, projectionId, hookId, agentId, orgId, provider, projectId, mergeRequestIid, headSha,
+    generation, writeMarker, state, body, noteId, credentialEpoch, phase, outcome, code, updatedAt, ownerId)
+ VALUES (@projectionKey, @projectionId, @hookId, @agentId, @orgId, @provider, @projectId, @mergeRequestIid,
+    @headSha, @generation, @writeMarker, @state, @body, @noteId, @credentialEpoch, @phase, @outcome, @code,
+    @now, @ownerId)
+ ON CONFLICT (projectionKey) DO UPDATE SET
+   projectionId = excluded.projectionId, hookId = excluded.hookId, agentId = excluded.agentId,
+   orgId = excluded.orgId, provider = excluded.provider, projectId = excluded.projectId,
+   mergeRequestIid = excluded.mergeRequestIid, headSha = excluded.headSha,
+   generation = excluded.generation, writeMarker = excluded.writeMarker, state = excluded.state,
+   body = excluded.body, noteId = excluded.noteId, credentialEpoch = excluded.credentialEpoch,
+   phase = excluded.phase, outcome = excluded.outcome, code = excluded.code,
+   updatedAt = excluded.updatedAt, ownerId = excluded.ownerId`
+
+function noteProjectionParams(row: NoteProjectionRow, now: number, ownerId: string | null): SqlParams {
+  return {
+    projectionKey: row.projectionKey,
+    projectionId: row.projectionId,
+    hookId: row.hookId,
+    agentId: row.agentId,
+    orgId: row.orgId ?? null,
+    provider: row.provider,
+    projectId: row.projectId,
+    mergeRequestIid: row.mergeRequestIid,
+    headSha: row.headSha,
+    generation: row.generation,
+    writeMarker: row.writeMarker,
+    state: row.state,
+    body: row.body,
+    noteId: row.noteId ?? null,
+    credentialEpoch: row.credentialEpoch,
+    now,
+    ownerId
   }
 }
 
@@ -1421,7 +1468,9 @@ export class LocalStore {
       );
       -- gitlab-com-integration.md §16 run projection: the write marker this daemon persists BEFORE
       -- every provider mutation. An 'in_flight' row surviving a restart is reconciled by listing the
-      -- merge request's notes and matching the hidden marker, never by replaying the write.
+      -- merge request's notes and matching the hidden marker, never by replaying the write. A
+      -- 'settled_unreported' row holds a definite outcome the control plane has not acknowledged yet:
+      -- it is replayed until acked, so a dropped result cannot wedge the control plane's write mutex.
       CREATE TABLE IF NOT EXISTS code_host_note_projection (
         projectionKey TEXT PRIMARY KEY,
         projectionId TEXT NOT NULL,
@@ -1438,7 +1487,9 @@ export class LocalStore {
         body TEXT NOT NULL,
         noteId TEXT,
         credentialEpoch TEXT NOT NULL,
-        phase TEXT NOT NULL CHECK (phase IN ('in_flight', 'settled')),
+        phase TEXT NOT NULL CHECK (phase IN ('in_flight', 'settled_unreported', 'settled')),
+        outcome TEXT,                     -- the definite outcome awaiting acknowledgement
+        code TEXT,                        -- its normalized reason code
         updatedAt INTEGER NOT NULL,
         ownerId TEXT                      -- daemon incarnation that started the write; NULL on an exclusively owned store
       );
@@ -5172,64 +5223,43 @@ export class LocalStore {
   /** Record the write marker BEFORE the provider mutation, so an interrupted write is reconcilable. */
   async beginNoteProjectionWrite(row: NoteProjectionRow, now: number): Promise<void> {
     await this.db
-      .prepare(
-        `INSERT INTO code_host_note_projection
-           (projectionKey, projectionId, hookId, agentId, orgId, provider, projectId, mergeRequestIid, headSha,
-            generation, writeMarker, state, body, noteId, credentialEpoch, phase, updatedAt, ownerId)
-         VALUES (@projectionKey, @projectionId, @hookId, @agentId, @orgId, @provider, @projectId, @mergeRequestIid,
-            @headSha, @generation, @writeMarker, @state, @body, @noteId, @credentialEpoch, 'in_flight', @now, @ownerId)
-         ON CONFLICT (projectionKey) DO UPDATE SET
-           projectionId = excluded.projectionId, hookId = excluded.hookId, agentId = excluded.agentId,
-           orgId = excluded.orgId, provider = excluded.provider, projectId = excluded.projectId,
-           mergeRequestIid = excluded.mergeRequestIid, headSha = excluded.headSha,
-           generation = excluded.generation, writeMarker = excluded.writeMarker, state = excluded.state,
-           body = excluded.body, noteId = excluded.noteId, credentialEpoch = excluded.credentialEpoch,
-           phase = 'in_flight', updatedAt = excluded.updatedAt, ownerId = excluded.ownerId`
-      )
-      .run({
-        projectionKey: row.projectionKey,
-        projectionId: row.projectionId,
-        hookId: row.hookId,
-        agentId: row.agentId,
-        orgId: row.orgId ?? null,
-        provider: row.provider,
-        projectId: row.projectId,
-        mergeRequestIid: row.mergeRequestIid,
-        headSha: row.headSha,
-        generation: row.generation,
-        writeMarker: row.writeMarker,
-        state: row.state,
-        body: row.body,
-        noteId: row.noteId ?? null,
-        credentialEpoch: row.credentialEpoch,
-        now,
-        ownerId: this.ownerId ?? null
-      })
+      .prepare(NOTE_PROJECTION_UPSERT)
+      .run({ ...noteProjectionParams(row, now, this.ownerId ?? null), phase: 'in_flight', outcome: null, code: null })
   }
 
-  /** Settle the write that marker opened, recording the observed note identity. Exact-marker fenced. */
-  async settleNoteProjectionWrite(
-    projectionKey: string,
-    writeMarker: string,
-    noteId: string | undefined,
+  /** Persist a definite outcome as UNREPORTED: it is replayed until the control plane acknowledges it. */
+  async recordNoteProjectionOutcome(
+    row: NoteProjectionRow,
+    outcome: NoteProjectionOutcome,
+    code: string | undefined,
     now: number
   ): Promise<void> {
+    await this.db.prepare(NOTE_PROJECTION_UPSERT).run({
+      ...noteProjectionParams(row, now, this.ownerId ?? null),
+      phase: 'settled_unreported',
+      outcome,
+      code: code ?? null
+    })
+  }
+
+  /** The control plane acknowledged the result: only then does the row stop being replayed. */
+  async markNoteProjectionReported(projectionKey: string, writeMarker: string, now: number): Promise<void> {
     await this.db
       .prepare(
         `UPDATE code_host_note_projection
-         SET phase = 'settled', noteId = COALESCE(@noteId, noteId), updatedAt = @now
-         WHERE projectionKey = @projectionKey AND writeMarker = @writeMarker`
+         SET phase = 'settled', updatedAt = @now
+         WHERE projectionKey = @projectionKey AND writeMarker = @writeMarker AND phase = 'settled_unreported'`
       )
-      .run({ projectionKey, writeMarker, noteId: noteId ?? null, now })
+      .run({ projectionKey, writeMarker, now })
   }
 
-  /** Writes THIS incarnation started and never settled — the only rows a reconciliation may touch. */
-  async listInFlightNoteProjections(limit = 100): Promise<NoteProjectionRow[]> {
+  /** Writes THIS incarnation started and has not carried to a reported outcome: reconcile or replay. */
+  async listUnsettledNoteProjections(limit = 100): Promise<NoteProjectionRow[]> {
     const owned = this.shared ? ' AND ownerId = @ownerId' : ''
     const rows = (await this.db
       .prepare(
         `SELECT * FROM code_host_note_projection
-         WHERE phase = 'in_flight'${owned}
+         WHERE phase IN ('in_flight', 'settled_unreported')${owned}
          ORDER BY updatedAt ASC LIMIT @limit`
       )
       .all({ limit, ...(this.shared ? { ownerId: this.ownerId! } : {}) })) as unknown as CodeHostNoteProjectionRow[]

--- a/packages/daemon/test/codehost-note-projection.test.ts
+++ b/packages/daemon/test/codehost-note-projection.test.ts
@@ -161,6 +161,10 @@ function projector(
     /** A store other than the per-test one — the shared-store restart cases open their own. */
     store?: LocalStore
     scheduler?: ReturnType<typeof fakeScheduler>
+    /** Make the unsettled-row scan throw this many times before it starts answering. */
+    scanFailures?: number
+    /** Runs inside the FIRST scan, after it read the rows — the interleave the arm fence guards. */
+    onFirstScan?: () => Promise<void>
   } = {}
 ) {
   const results: Array<{ result: CodeHostNoteResult; orgId?: string }> = []
@@ -170,6 +174,8 @@ function projector(
   const clock = over.scheduler ?? fakeScheduler()
   let mint = 0
   let rejections = over.reportRejections ?? 0
+  let scanFailures = over.scanFailures ?? 0
+  let firstScan = over.onFirstScan
   const projector = new CodeHostNoteProjector({
     daemonId: () => over.daemonId ?? DAEMON,
     store: {
@@ -178,7 +184,17 @@ function projector(
       recordNoteProjectionOutcome: (row, outcome, code, now) => db.recordNoteProjectionOutcome(row, outcome, code, now),
       markNoteProjectionReported: (daemonId, key, marker, now) =>
         db.markNoteProjectionReported(daemonId, key, marker, now),
-      listUnsettledNoteProjections: (daemonId) => db.listUnsettledNoteProjections(daemonId)
+      listUnsettledNoteProjections: async (daemonId) => {
+        if (scanFailures > 0) {
+          scanFailures -= 1
+          throw new Error('ledger scan unavailable')
+        }
+        const rows = await db.listUnsettledNoteProjections(daemonId)
+        const hook = firstScan
+        firstScan = undefined
+        await hook?.()
+        return rows
+      }
     },
     lease: async () => {
       if (over.leaseThrows) throw new Error('effect lease refused')
@@ -639,6 +655,106 @@ describe('recovery scheduling and ownership (round-3 review)', () => {
     await second.close()
     await first.close()
     rmSync(poolRoot, { recursive: true, force: true })
+  })
+})
+
+describe('resweep scheduling edges (round-4 review)', () => {
+  it('continues the backoff when a fired sweep cannot read the ledger at all', async () => {
+    const listed = JSON.stringify([{ id: 12345, body: projectionMarker(PROJECTION) }])
+    const { fetchImpl, calls } = fakeFetch([
+      { throws: true },
+      { status: 200, body: listed },
+      { status: 200, body: '{"id":12345}' }
+    ])
+    // The scan fails once, on the sweep the first armed timer fires.
+    const { projector: p, results, clock } = projector(fetchImpl, { scanFailures: 1 })
+    await p.apply(desiredFrame())
+    expect(clock.delays()).toEqual([RESWEEP_BASE_MS])
+
+    clock.fire()
+    // An unreadable ledger proves nothing about the durable work, so the chain must not end here.
+    await vi.waitFor(() => expect(clock.delays()).toEqual([RESWEEP_BASE_MS, 60_000]))
+    expect(clock.armed()).toBe(1)
+    expect(calls).toHaveLength(1)
+
+    clock.fire()
+    await vi.waitFor(() => expect(results).toHaveLength(2))
+    expect(calls.map((c) => c.method)).toEqual(['POST', 'GET', 'PUT'])
+    expect(results[1]!.result).toMatchObject({ outcome: 'written', noteId: '12345' })
+    expect(await store.getNoteProjection(DAEMON, PROJECTION)).toMatchObject({ phase: 'settled' })
+    expect(clock.armed()).toBe(0)
+  })
+
+  it('never lets a zero-work disarm clear a timer that concurrent new work just armed', async () => {
+    const listed = JSON.stringify([{ id: 12345, body: projectionMarker(PROJECTION) }])
+    const { fetchImpl, calls } = fakeFetch([
+      { throws: true },
+      { status: 200, body: listed },
+      { status: 200, body: '{"id":12345}' }
+    ])
+    // A box, because the hook must reach the projector the same call is still constructing.
+    const box: { projector?: CodeHostNoteProjector } = {}
+    const started = projector(fetchImpl, {
+      // The interleave: the sweep has already read an EMPTY ledger when new work arms the timer.
+      onFirstScan: async () => {
+        await box.projector!.apply(desiredFrame())
+      }
+    })
+    box.projector = started.projector
+
+    await started.projector.reconcilePending()
+
+    // The sweep decided there was nothing to do, but that decision predates the row now on disk.
+    expect(started.results[0]!.result).toMatchObject({ outcome: 'ambiguous' })
+    expect(started.clock.armed()).toBe(1)
+    expect(await store.getNoteProjection(DAEMON, PROJECTION)).toMatchObject({ phase: 'in_flight' })
+
+    started.clock.fire()
+    await vi.waitFor(() => expect(started.results).toHaveLength(2))
+    expect(calls.map((c) => c.method)).toEqual(['POST', 'GET', 'PUT'])
+    expect(started.results[1]!.result).toMatchObject({ outcome: 'written', noteId: '12345' })
+    expect(started.clock.armed()).toBe(0)
+  })
+
+  it('fences the disarm even when the racing work reused an ALREADY armed timer', async () => {
+    const listed = JSON.stringify([{ id: 700, body: projectionMarker(PROJECTION_B) }])
+    const { fetchImpl, calls } = fakeFetch([
+      { throws: true },
+      { throws: true },
+      { status: 200, body: listed },
+      { status: 200, body: '{"id":700}' }
+    ])
+    const box: { projector?: CodeHostNoteProjector } = {}
+    const started = projector(fetchImpl, {
+      onFirstScan: async () => {
+        // Arms while a timer is already pending, so arm() takes its early-return path.
+        await box.projector!.apply(
+          desiredFrame({ projectionId: PROJECTION_B, projectionKey: PROJECTION_B, writeMarker: MARKER_B })
+        )
+      }
+    })
+    box.projector = started.projector
+
+    await started.projector.apply(desiredFrame())
+    expect(started.clock.delays()).toEqual([RESWEEP_BASE_MS])
+
+    // Retire the first row out of band: the next scan reads an empty ledger with the timer still up.
+    const first = (await store.getNoteProjection(DAEMON, PROJECTION))!
+    await store.recordNoteProjectionOutcome(first, 'written', undefined, NOW)
+    await store.markNoteProjectionReported(DAEMON, PROJECTION, MARKER_A, NOW)
+
+    await started.projector.reconcilePending()
+
+    // No second timer was scheduled — this is the reused-timer path — and it survived the disarm.
+    expect(started.clock.delays()).toEqual([RESWEEP_BASE_MS])
+    expect(started.clock.armed()).toBe(1)
+    expect(await store.getNoteProjection(DAEMON, PROJECTION_B)).toMatchObject({ phase: 'in_flight' })
+
+    started.clock.fire()
+    await vi.waitFor(() => expect(started.results).toHaveLength(3))
+    expect(calls.map((c) => c.method)).toEqual(['POST', 'POST', 'GET', 'PUT'])
+    expect(started.results[2]!.result).toMatchObject({ outcome: 'written', noteId: '700' })
+    expect(started.clock.armed()).toBe(0)
   })
 })
 

--- a/packages/daemon/test/codehost-note-projection.test.ts
+++ b/packages/daemon/test/codehost-note-projection.test.ts
@@ -12,14 +12,18 @@ import {
   type CodeHostNoteState
 } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
+import { DatabaseSync } from 'node:sqlite'
 import { CodeHostNoteProjector, projectionMarker, renderProjectionNote } from '../src/gitlab/note-projection.js'
+import type { PosterScheduler } from '../src/github/poster.js'
 import { LocalStore } from '../src/store/local-store.js'
+import { SqliteAsyncDatabase } from '../src/store/sqlite-async-database.js'
 import { statePath } from '../src/paths.js'
 
 const DAEMON = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd1'
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const HOOK = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'
 const PROJECTION = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1'
+const PROJECTION_B = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc2'
 const MARKER_A = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeee1'
 const MARKER_B = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeee2'
 const PROJECT = '4455667'
@@ -28,6 +32,8 @@ const HEAD = 'abc123def4567890abc123def4567890abc123de'
 const NOW = Date.parse('2026-08-22T10:00:00.000Z')
 /** The credential purge fence the desired frame and the effect grant must agree on. */
 const EPOCH = '3'
+const RESWEEP_BASE_MS = 30_000
+const RESWEEP_CAP_MS = 120_000
 
 function desiredFrame(over: Partial<CodeHostNoteDesired> = {}): CodeHostNoteDesired {
   return {
@@ -59,6 +65,37 @@ function desiredFrame(over: Partial<CodeHostNoteDesired> = {}): CodeHostNoteDesi
     credentialEpoch: '3',
     leaseUntil: '2026-08-22T10:02:00.000Z',
     ...over
+  }
+}
+
+/** A hand-driven timer seam: the resweep is armed on it and fired only when a test says so. */
+function fakeScheduler() {
+  let nextId = 1
+  const pending = new Map<number, { fn: () => void; at: number }>()
+  const delays: number[] = []
+  const sched: PosterScheduler = {
+    now: () => NOW,
+    setTimeout: (fn, ms) => {
+      const id = nextId++
+      delays.push(ms)
+      pending.set(id, { fn, at: ms })
+      return id
+    },
+    clearTimeout: (handle) => {
+      pending.delete(handle as number)
+    }
+  }
+  return {
+    sched,
+    delays: () => [...delays],
+    armed: () => pending.size,
+    /** Fire the single armed timer, as the event loop would. */
+    fire: () => {
+      const [id, entry] = [...pending.entries()][0] ?? []
+      if (id === undefined || !entry) throw new Error('no resweep is armed')
+      pending.delete(id)
+      entry.fn()
+    }
   }
 }
 
@@ -121,22 +158,27 @@ function projector(
     /** Reject this many reports before the fake control plane starts accepting them. */
     reportRejections?: number
     reportRetryable?: boolean
+    /** A store other than the per-test one — the shared-store restart cases open their own. */
+    store?: LocalStore
+    scheduler?: ReturnType<typeof fakeScheduler>
   } = {}
 ) {
   const results: Array<{ result: CodeHostNoteResult; orgId?: string }> = []
   const invalidated: string[] = []
   const tokens = over.leaseTokens ?? ['glpat-1', 'glpat-2']
+  const db = over.store ?? store
+  const clock = over.scheduler ?? fakeScheduler()
   let mint = 0
   let rejections = over.reportRejections ?? 0
   const projector = new CodeHostNoteProjector({
     daemonId: () => over.daemonId ?? DAEMON,
     store: {
-      getNoteProjection: (key) => store.getNoteProjection(key),
-      beginNoteProjectionWrite: (row, now) => store.beginNoteProjectionWrite(row, now),
-      recordNoteProjectionOutcome: (row, outcome, code, now) =>
-        store.recordNoteProjectionOutcome(row, outcome, code, now),
-      markNoteProjectionReported: (key, marker, now) => store.markNoteProjectionReported(key, marker, now),
-      listUnsettledNoteProjections: () => store.listUnsettledNoteProjections()
+      getNoteProjection: (daemonId, key) => db.getNoteProjection(daemonId, key),
+      beginNoteProjectionWrite: (row, now) => db.beginNoteProjectionWrite(row, now),
+      recordNoteProjectionOutcome: (row, outcome, code, now) => db.recordNoteProjectionOutcome(row, outcome, code, now),
+      markNoteProjectionReported: (daemonId, key, marker, now) =>
+        db.markNoteProjectionReported(daemonId, key, marker, now),
+      listUnsettledNoteProjections: (daemonId) => db.listUnsettledNoteProjections(daemonId)
     },
     lease: async () => {
       if (over.leaseThrows) throw new Error('effect lease refused')
@@ -156,10 +198,13 @@ function projector(
     },
     log: { warn: () => undefined },
     now: () => NOW,
+    scheduler: clock.sched,
+    resweepBaseMs: RESWEEP_BASE_MS,
+    resweepCapMs: RESWEEP_CAP_MS,
     baseUrl: 'https://gitlab.example.test/api/v4',
     fetchImpl
   })
-  return { projector, results, invalidated, mints: () => mint }
+  return { projector, results, invalidated, clock, mints: () => mint }
 }
 
 describe('the run-projection note (gitlab-com-integration.md §16)', () => {
@@ -187,7 +232,7 @@ describe('the run-projection note (gitlab-com-integration.md §16)', () => {
         orgId: 'org-1'
       }
     ])
-    const row = await store.getNoteProjection(PROJECTION)
+    const row = await store.getNoteProjection(DAEMON, PROJECTION)
     expect(row?.phase).toBe('settled')
     expect(row?.noteId).toBe('12345')
   })
@@ -221,7 +266,7 @@ describe('the run-projection note (gitlab-com-integration.md §16)', () => {
     await p.apply(desiredFrame())
 
     expect(results[0]!.result.noteId).toBe(bigId)
-    expect((await store.getNoteProjection(PROJECTION))?.noteId).toBe(bigId)
+    expect((await store.getNoteProjection(DAEMON, PROJECTION))?.noteId).toBe(bigId)
   })
 
   it('reports ambiguous and keeps the row in flight when the request never resolved', async () => {
@@ -233,7 +278,7 @@ describe('the run-projection note (gitlab-com-integration.md §16)', () => {
     expect(calls).toHaveLength(1)
     expect(results[0]!.result).toMatchObject({ outcome: 'ambiguous', code: 'request_unresolved' })
     expect(results[0]!.result.noteId).toBeUndefined()
-    const row = await store.getNoteProjection(PROJECTION)
+    const row = await store.getNoteProjection(DAEMON, PROJECTION)
     expect(row?.phase).toBe('in_flight')
     expect(row?.writeMarker).toBe(MARKER_A)
   })
@@ -241,7 +286,7 @@ describe('the run-projection note (gitlab-com-integration.md §16)', () => {
   it('reconciles an interrupted write by LISTING the notes and adopting the marker match', async () => {
     const interrupted = fakeFetch([{ throws: true }])
     await projector(interrupted.fetchImpl).projector.apply(desiredFrame())
-    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('in_flight')
+    expect((await store.getNoteProjection(DAEMON, PROJECTION))?.phase).toBe('in_flight')
 
     // A fresh process opens the same store and finds the write marker the crash left behind.
     const listed = JSON.stringify([
@@ -258,7 +303,7 @@ describe('the run-projection note (gitlab-com-integration.md §16)', () => {
     expect(restarted.calls.map((c) => c.method)).toEqual(['GET', 'PUT'])
     expect(restarted.calls[1]!.url.endsWith('/notes/12345')).toBe(true)
     expect(b.results[0]!.result).toMatchObject({ outcome: 'written', noteId: '12345', observedState: 'queued' })
-    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('settled')
+    expect((await store.getNoteProjection(DAEMON, PROJECTION))?.phase).toBe('settled')
   })
 
   it('creates exactly once when reconciliation finds no marker — the interrupted write had no effect', async () => {
@@ -284,7 +329,7 @@ describe('the run-projection note (gitlab-com-integration.md §16)', () => {
     expect(calls).toHaveLength(0)
     expect(mints()).toBe(0)
     expect(results[0]!.result).toMatchObject({ outcome: 'skipped', code: 'not_dispatch_owner' })
-    expect(await store.getNoteProjection(PROJECTION)).toBeUndefined()
+    expect(await store.getNoteProjection(DAEMON, PROJECTION)).toBeUndefined()
   })
 
   it('skips without any provider call when the write lease has already expired', async () => {
@@ -352,7 +397,7 @@ describe('authority and outcome fences (round-2 review)', () => {
     expect(calls).toHaveLength(0)
     expect(results[0]!.result).toMatchObject({ outcome: 'skipped', code: 'stale_credential_epoch' })
     // Stale authority must not leave a claim on the note either.
-    expect((await store.getNoteProjection(PROJECTION))?.noteId).toBeUndefined()
+    expect((await store.getNoteProjection(DAEMON, PROJECTION))?.noteId).toBeUndefined()
   })
 
   it('re-checks the epoch after the auth refresh, so a purge mid-write stops the retry', async () => {
@@ -381,7 +426,7 @@ describe('authority and outcome fences (round-2 review)', () => {
     await a.projector.apply(desiredFrame())
 
     expect(a.results[0]!.result).toMatchObject({ outcome: 'ambiguous', code: 'create_id_unreadable' })
-    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('in_flight')
+    expect((await store.getNoteProjection(DAEMON, PROJECTION))?.phase).toBe('in_flight')
 
     const listed = JSON.stringify([{ id: 777, body: `${projectionMarker(PROJECTION)}\n**AgentConnect run**` }])
     const recovered = fakeFetch([
@@ -416,7 +461,7 @@ describe('authority and outcome fences (round-2 review)', () => {
     expect(calls).toHaveLength(2)
     // The refreshed POST may well have created the note, so only reconciliation may decide.
     expect(results[0]!.result).toMatchObject({ outcome: 'ambiguous', code: 'http_500' })
-    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('in_flight')
+    expect((await store.getNoteProjection(DAEMON, PROJECTION))?.phase).toBe('in_flight')
   })
 
   it('keeps an answered 4xx on the retried attempt deterministic — the negative control', async () => {
@@ -426,7 +471,7 @@ describe('authority and outcome fences (round-2 review)', () => {
 
     expect(results[0]!.result).toMatchObject({ outcome: 'failed', code: 'http_422' })
     // Definite: the outcome was persisted, reported, and acknowledged in one pass.
-    expect(await store.getNoteProjection(PROJECTION)).toMatchObject({ phase: 'settled', outcome: 'failed' })
+    expect(await store.getNoteProjection(DAEMON, PROJECTION)).toMatchObject({ phase: 'settled', outcome: 'failed' })
   })
 
   it('replays a dropped result until the control plane takes it, exactly once in effect', async () => {
@@ -436,7 +481,7 @@ describe('authority and outcome fences (round-2 review)', () => {
 
     // The note exists and the outcome is durable, but the control plane never heard it.
     expect(a.results).toHaveLength(0)
-    const pending = await store.getNoteProjection(PROJECTION)
+    const pending = await store.getNoteProjection(DAEMON, PROJECTION)
     expect(pending).toMatchObject({ phase: 'settled_unreported', outcome: 'written', noteId: '12345' })
 
     const replay = fakeFetch([])
@@ -453,7 +498,7 @@ describe('authority and outcome fences (round-2 review)', () => {
       noteId: '12345',
       observedState: 'queued'
     })
-    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('settled')
+    expect((await store.getNoteProjection(DAEMON, PROJECTION))?.phase).toBe('settled')
 
     // Acknowledged means retired: a later sweep re-sends nothing.
     const after = projector(fakeFetch([]).fetchImpl)
@@ -465,14 +510,135 @@ describe('authority and outcome fences (round-2 review)', () => {
     const wrote = fakeFetch([{ status: 201, body: '{"id":12345}' }])
     const a = projector(wrote.fetchImpl, { reportRejections: 1 })
     await a.projector.apply(desiredFrame())
-    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('settled_unreported')
+    expect((await store.getNoteProjection(DAEMON, PROJECTION))?.phase).toBe('settled_unreported')
 
     const refused = projector(fakeFetch([]).fetchImpl, { reportRejections: 1, reportRetryable: false })
     await refused.projector.reconcilePending()
 
     // The control plane already moved past this generation; the row must not keep asking.
     expect(refused.results).toHaveLength(0)
-    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('settled')
+    expect((await store.getNoteProjection(DAEMON, PROJECTION))?.phase).toBe('settled')
+  })
+})
+
+/** Answers by METHOD rather than call order, so a multi-row sweep is not order-sensitive. */
+function markerFetch(projectionKeys: string[]) {
+  const calls: Call[] = []
+  const listed = JSON.stringify(projectionKeys.map((key, i) => ({ id: 900 + i, body: projectionMarker(key) })))
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET'
+    calls.push({ method, url: String(url) })
+    if (method === 'GET') return new Response(listed, { status: 200 })
+    return new Response('{"id":900}', { status: 200 })
+  }) as typeof fetch
+  return { fetchImpl, calls }
+}
+
+/** One shared-store handle, as a pool member (or a restarted one) opens it. */
+async function sharedStore(path: string, ownerId: string): Promise<LocalStore> {
+  return await LocalStore.open({
+    database: SqliteAsyncDatabase.adopt(new DatabaseSync(path)),
+    shared: true,
+    ownerId,
+    orgForAgent: () => 'org-1'
+  })
+}
+
+describe('recovery scheduling and ownership (round-3 review)', () => {
+  it('reconciles an ambiguous write on its own backoff, with no control-plane reconnect', async () => {
+    const listed = JSON.stringify([{ id: 12345, body: projectionMarker(PROJECTION) }])
+    const { fetchImpl, calls } = fakeFetch([
+      { throws: true },
+      { status: 200, body: listed },
+      { status: 200, body: '{"id":12345}' }
+    ])
+    const { projector: p, results, clock } = projector(fetchImpl)
+    await p.apply(desiredFrame())
+
+    expect(results[0]!.result).toMatchObject({ outcome: 'ambiguous' })
+    // The provider timed out while the control socket stayed healthy, so the writer arms its own retry.
+    expect(clock.armed()).toBe(1)
+    expect(clock.delays()).toEqual([RESWEEP_BASE_MS])
+
+    clock.fire()
+    await vi.waitFor(() => expect(results).toHaveLength(2))
+
+    expect(calls.map((c) => c.method)).toEqual(['POST', 'GET', 'PUT'])
+    expect(results[1]!.result).toMatchObject({ outcome: 'written', noteId: '12345' })
+    expect(await store.getNoteProjection(DAEMON, PROJECTION)).toMatchObject({ phase: 'settled' })
+    // Nothing is owed any more, so the writer goes quiet instead of polling forever.
+    expect(clock.armed()).toBe(0)
+  })
+
+  it('backs off exponentially to a cap while work remains, then stops once it settles', async () => {
+    const listed = JSON.stringify([{ id: 12345, body: projectionMarker(PROJECTION) }])
+    const { fetchImpl } = fakeFetch([
+      { throws: true },
+      { status: 500 },
+      { status: 500 },
+      { status: 500 },
+      { status: 200, body: listed },
+      { status: 200, body: '{"id":12345}' }
+    ])
+    const { projector: p, results, clock } = projector(fetchImpl)
+    await p.apply(desiredFrame())
+
+    for (let sweep = 0; sweep < 3; sweep += 1) {
+      const before = results.length
+      clock.fire()
+      await vi.waitFor(() => expect(results.length).toBeGreaterThan(before))
+    }
+    // 30s, 60s, then pinned at the 120s cap — a wedged projection never becomes a hot loop.
+    expect(clock.delays()).toEqual([RESWEEP_BASE_MS, 60_000, RESWEEP_CAP_MS, RESWEEP_CAP_MS])
+
+    clock.fire()
+    await vi.waitFor(() => expect(results).toHaveLength(5))
+    expect(results[4]!.result).toMatchObject({ outcome: 'written', noteId: '12345' })
+    expect(clock.armed()).toBe(0)
+  })
+
+  it('recovers a previous incarnation’s rows on a shared store, and only its own daemon’s', async () => {
+    const poolRoot = mkdtempSync(join(tmpdir(), 'note-projection-pool-'))
+    const path = statePath(poolRoot)
+    await (await LocalStore.open(path)).close()
+    const first = await sharedStore(path, 'incarnation-1')
+
+    // One write left in flight, and one whose definite outcome the control plane never acknowledged.
+    const stalled = projector(fakeFetch([{ throws: true }]).fetchImpl, { store: first })
+    await stalled.projector.apply(desiredFrame())
+    const unreported = projector(fakeFetch([{ status: 201, body: '{"id":901}' }]).fetchImpl, {
+      store: first,
+      reportRejections: 1
+    })
+    await unreported.projector.apply(desiredFrame({ projectionId: PROJECTION_B, projectionKey: PROJECTION_B }))
+    expect(await first.getNoteProjection(DAEMON, PROJECTION)).toMatchObject({ phase: 'in_flight' })
+    expect(await first.getNoteProjection(DAEMON, PROJECTION_B)).toMatchObject({ phase: 'settled_unreported' })
+
+    // A RESTART: same daemon identity, a brand-new process incarnation over the same database.
+    const second = await sharedStore(path, 'incarnation-2')
+
+    // The negative control runs first, while both rows are still owed: a pool peer sees neither.
+    const peerFetch = markerFetch([PROJECTION])
+    const peer = projector(peerFetch.fetchImpl, { store: second, daemonId: 'peer-daemon-id' })
+    await peer.projector.reconcilePending()
+    expect(peer.results).toHaveLength(0)
+    expect(peerFetch.calls).toHaveLength(0)
+    expect(peer.clock.armed()).toBe(0)
+
+    const recovery = markerFetch([PROJECTION, PROJECTION_B])
+    const restarted = projector(recovery.fetchImpl, { store: second })
+    await restarted.projector.reconcilePending()
+
+    // Both rows are this daemon identity's to finish, whatever process started them.
+    expect(restarted.results).toHaveLength(2)
+    expect(restarted.results.map((r) => r.result.outcome)).toEqual(['written', 'written'])
+    expect(await second.getNoteProjection(DAEMON, PROJECTION)).toMatchObject({ phase: 'settled' })
+    expect(await second.getNoteProjection(DAEMON, PROJECTION_B)).toMatchObject({ phase: 'settled', noteId: '901' })
+    expect(restarted.clock.armed()).toBe(0)
+
+    await second.close()
+    await first.close()
+    rmSync(poolRoot, { recursive: true, force: true })
   })
 })
 

--- a/packages/daemon/test/codehost-note-projection.test.ts
+++ b/packages/daemon/test/codehost-note-projection.test.ts
@@ -1,0 +1,401 @@
+// Informational run projection writer (gitlab-com-integration.md §16): one service-account note per
+// merge-request head, created once, updated in place, reconciled by the hidden marker, never replayed.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  CODEHOST_NOTE_PROJECTION_V1_FEATURE,
+  GITLAB_COM_V1_FEATURE,
+  type CodeHostNoteDesired,
+  type CodeHostNoteResult,
+  type CodeHostNoteState
+} from '@agentconnect.md/protocol'
+import { Daemon } from '../src/daemon.js'
+import { CodeHostNoteProjector, projectionMarker, renderProjectionNote } from '../src/gitlab/note-projection.js'
+import { LocalStore } from '../src/store/local-store.js'
+import { statePath } from '../src/paths.js'
+
+const DAEMON = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd1'
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const HOOK = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'
+const PROJECTION = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1'
+const MARKER_A = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeee1'
+const MARKER_B = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeee2'
+const PROJECT = '4455667'
+const IID = 77
+const HEAD = 'abc123def4567890abc123def4567890abc123de'
+const NOW = Date.parse('2026-08-22T10:00:00.000Z')
+
+function desiredFrame(over: Partial<CodeHostNoteDesired> = {}): CodeHostNoteDesired {
+  return {
+    projectionId: PROJECTION,
+    provider: 'gitlab',
+    hookId: HOOK,
+    agentId: AGENT,
+    agentName: 'Reviewer',
+    deliveryKey: 'delivery-1',
+    generation: '1',
+    projectionEpoch: '1',
+    projectionKey: PROJECTION,
+    writeMarker: MARKER_A,
+    projectId: PROJECT,
+    projectPath: 'example-group/example-project',
+    mergeRequestIid: IID,
+    headSha: HEAD,
+    state: 'queued',
+    queuedAt: '2026-08-22T09:59:00.000Z',
+    desiredAt: '2026-08-22T10:00:00.000Z',
+    snapshot: {
+      configRevision: '4',
+      dispatchRevision: '9',
+      dispatchDaemonId: DAEMON,
+      reviewPolicy: 'off',
+      reportingMode: 'off',
+      gateMode: 'informational'
+    },
+    credentialEpoch: '3',
+    leaseUntil: '2026-08-22T10:02:00.000Z',
+    ...over
+  }
+}
+
+interface Call {
+  method: string
+  url: string
+  body?: string
+}
+
+/** `answers` is consumed per call; anything past the end is a 200 with an empty note object. */
+function fakeFetch(answers: Array<{ status?: number; body?: string; throws?: boolean }>) {
+  const calls: Call[] = []
+  let n = 0
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const answer = answers[n] ?? {}
+    n += 1
+    calls.push({
+      method: init?.method ?? 'GET',
+      url: String(url),
+      ...(init?.body === undefined ? {} : { body: JSON.parse(String(init.body)).body as string })
+    })
+    if (answer.throws) throw new Error('socket hang up')
+    return new Response(answer.body ?? '{"id":12345}', { status: answer.status ?? 200 })
+  }) as typeof fetch
+  return { fetchImpl, calls }
+}
+
+let root: string
+let store: LocalStore
+
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), 'note-projection-'))
+  store = await LocalStore.open(statePath(root))
+})
+
+afterEach(async () => {
+  await store.close()
+  rmSync(root, { recursive: true, force: true })
+})
+
+function projector(
+  fetchImpl: typeof fetch,
+  over: {
+    access?: 'read' | 'comment' | 'write'
+    leaseTokens?: string[]
+    leaseThrows?: boolean
+    daemonId?: string
+  } = {}
+) {
+  const results: Array<{ result: CodeHostNoteResult; orgId?: string }> = []
+  const invalidated: string[] = []
+  const tokens = over.leaseTokens ?? ['glpat-1', 'glpat-2']
+  let mint = 0
+  const projector = new CodeHostNoteProjector({
+    daemonId: () => over.daemonId ?? DAEMON,
+    store: {
+      getNoteProjection: (key) => store.getNoteProjection(key),
+      beginNoteProjectionWrite: (row, now) => store.beginNoteProjectionWrite(row, now),
+      settleNoteProjectionWrite: (key, marker, noteId, now) =>
+        store.settleNoteProjectionWrite(key, marker, noteId, now),
+      listInFlightNoteProjections: () => store.listInFlightNoteProjections()
+    },
+    lease: async () => {
+      if (over.leaseThrows) throw new Error('effect lease refused')
+      const token = tokens[Math.min(mint, tokens.length - 1)]!
+      mint += 1
+      return { token, access: over.access ?? 'comment' }
+    },
+    invalidateLease: (_target, token) => invalidated.push(token),
+    report: async (result, orgId) => {
+      results.push({ result, ...(orgId ? { orgId } : {}) })
+    },
+    log: { warn: () => undefined },
+    now: () => NOW,
+    baseUrl: 'https://gitlab.example.test/api/v4',
+    fetchImpl
+  })
+  return { projector, results, invalidated, mints: () => mint }
+}
+
+describe('the run-projection note (gitlab-com-integration.md §16)', () => {
+  it('creates one note carrying the hidden marker on the first generation', async () => {
+    const { fetchImpl, calls } = fakeFetch([{ status: 201, body: '{"id":12345}' }])
+    const { projector: p, results } = projector(fetchImpl)
+    await p.apply(desiredFrame(), 'org-1')
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.method).toBe('POST')
+    expect(calls[0]!.url).toBe(`https://gitlab.example.test/api/v4/projects/${PROJECT}/merge_requests/${IID}/notes`)
+    expect(calls[0]!.body).toContain(projectionMarker(PROJECTION))
+    expect(results).toEqual([
+      {
+        result: {
+          projectionId: PROJECTION,
+          hookId: HOOK,
+          generation: '1',
+          writeMarker: MARKER_A,
+          outcome: 'written',
+          noteId: '12345',
+          observedState: 'queued',
+          observedAt: '2026-08-22T10:00:00.000Z'
+        },
+        orgId: 'org-1'
+      }
+    ])
+    const row = await store.getNoteProjection(PROJECTION)
+    expect(row?.phase).toBe('settled')
+    expect(row?.noteId).toBe('12345')
+  })
+
+  it('updates the SAME note in place on the next generation — never a second note per head', async () => {
+    const first = fakeFetch([{ status: 201, body: '{"id":12345}' }])
+    const a = projector(first.fetchImpl)
+    await a.projector.apply(desiredFrame())
+
+    const second = fakeFetch([{ status: 200, body: '{"id":12345}' }])
+    const b = projector(second.fetchImpl)
+    await b.projector.apply(desiredFrame({ generation: '2', writeMarker: MARKER_B, state: 'completed' }))
+
+    expect(second.calls).toHaveLength(1)
+    expect(second.calls[0]!.method).toBe('PUT')
+    expect(second.calls[0]!.url.endsWith(`/merge_requests/${IID}/notes/12345`)).toBe(true)
+    expect(second.calls[0]!.body).toContain(projectionMarker(PROJECTION))
+    expect(b.results[0]!.result).toMatchObject({
+      generation: '2',
+      writeMarker: MARKER_B,
+      outcome: 'written',
+      noteId: '12345',
+      observedState: 'completed'
+    })
+  })
+
+  it('preserves a note id beyond the safe-integer range', async () => {
+    const bigId = '9007199254740993123'
+    const { fetchImpl } = fakeFetch([{ status: 201, body: `{"id":${bigId}}` }])
+    const { projector: p, results } = projector(fetchImpl)
+    await p.apply(desiredFrame())
+
+    expect(results[0]!.result.noteId).toBe(bigId)
+    expect((await store.getNoteProjection(PROJECTION))?.noteId).toBe(bigId)
+  })
+
+  it('reports ambiguous and keeps the row in flight when the request never resolved', async () => {
+    const { fetchImpl, calls } = fakeFetch([{ throws: true }])
+    const { projector: p, results } = projector(fetchImpl)
+    await p.apply(desiredFrame())
+
+    // No blind retry: a started mutation with an unknown outcome stays fail-closed on this writer.
+    expect(calls).toHaveLength(1)
+    expect(results[0]!.result).toMatchObject({ outcome: 'ambiguous', code: 'request_unresolved' })
+    expect(results[0]!.result.noteId).toBeUndefined()
+    const row = await store.getNoteProjection(PROJECTION)
+    expect(row?.phase).toBe('in_flight')
+    expect(row?.writeMarker).toBe(MARKER_A)
+  })
+
+  it('reconciles an interrupted write by LISTING the notes and adopting the marker match', async () => {
+    const interrupted = fakeFetch([{ throws: true }])
+    await projector(interrupted.fetchImpl).projector.apply(desiredFrame())
+    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('in_flight')
+
+    // A fresh process opens the same store and finds the write marker the crash left behind.
+    const listed = JSON.stringify([
+      { id: 999, body: 'someone else commented' },
+      { id: 12345, body: `${projectionMarker(PROJECTION)}\n**AgentConnect run — Queued**` }
+    ])
+    const restarted = fakeFetch([
+      { status: 200, body: listed },
+      { status: 200, body: '{"id":12345}' }
+    ])
+    const b = projector(restarted.fetchImpl)
+    await b.projector.reconcilePending()
+
+    expect(restarted.calls.map((c) => c.method)).toEqual(['GET', 'PUT'])
+    expect(restarted.calls[1]!.url.endsWith('/notes/12345')).toBe(true)
+    expect(b.results[0]!.result).toMatchObject({ outcome: 'written', noteId: '12345', observedState: 'queued' })
+    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('settled')
+  })
+
+  it('creates exactly once when reconciliation finds no marker — the interrupted write had no effect', async () => {
+    const interrupted = fakeFetch([{ throws: true }])
+    await projector(interrupted.fetchImpl).projector.apply(desiredFrame())
+
+    const restarted = fakeFetch([
+      { status: 200, body: '[{"id":999,"body":"unrelated"}]' },
+      { status: 201, body: '{"id":54321}' }
+    ])
+    const b = projector(restarted.fetchImpl)
+    await b.projector.reconcilePending()
+
+    expect(restarted.calls.map((c) => c.method)).toEqual(['GET', 'POST'])
+    expect(b.results[0]!.result).toMatchObject({ outcome: 'written', noteId: '54321' })
+  })
+
+  it('skips without any provider call when the placement fence names another daemon', async () => {
+    const { fetchImpl, calls } = fakeFetch([])
+    const { projector: p, results, mints } = projector(fetchImpl, { daemonId: 'another-daemon' })
+    await p.apply(desiredFrame())
+
+    expect(calls).toHaveLength(0)
+    expect(mints()).toBe(0)
+    expect(results[0]!.result).toMatchObject({ outcome: 'skipped', code: 'not_dispatch_owner' })
+    expect(await store.getNoteProjection(PROJECTION)).toBeUndefined()
+  })
+
+  it('skips without any provider call when the write lease has already expired', async () => {
+    const { fetchImpl, calls } = fakeFetch([])
+    const { projector: p, results } = projector(fetchImpl)
+    await p.apply(desiredFrame({ leaseUntil: '2026-08-22T09:59:00.000Z' }))
+
+    expect(calls).toHaveLength(0)
+    expect(results[0]!.result).toMatchObject({ outcome: 'skipped', code: 'lease_expired' })
+  })
+
+  it('refreshes the effect lease exactly once after a definite auth rejection, then retries', async () => {
+    const { fetchImpl, calls } = fakeFetch([{ status: 401 }, { status: 201, body: '{"id":12345}' }])
+    const { projector: p, results, invalidated, mints } = projector(fetchImpl)
+    await p.apply(desiredFrame())
+
+    expect(calls.map((c) => c.method)).toEqual(['POST', 'POST'])
+    expect(invalidated).toEqual(['glpat-1'])
+    expect(mints()).toBe(2)
+    expect(results[0]!.result).toMatchObject({ outcome: 'written', noteId: '12345' })
+  })
+
+  it('fails deterministically after a second auth rejection instead of writing again', async () => {
+    const { fetchImpl, calls } = fakeFetch([{ status: 403 }, { status: 403 }])
+    const { projector: p, results } = projector(fetchImpl)
+    await p.apply(desiredFrame())
+
+    expect(calls).toHaveLength(2)
+    expect(results[0]!.result).toMatchObject({ outcome: 'failed', code: 'http_403' })
+  })
+
+  it('fails without a provider call when the effect lease is refused or clamped below comment', async () => {
+    const refused = fakeFetch([])
+    const a = projector(refused.fetchImpl, { leaseThrows: true })
+    await a.projector.apply(desiredFrame())
+    expect(refused.calls).toHaveLength(0)
+    expect(a.results[0]!.result).toMatchObject({ outcome: 'failed', code: 'token_unavailable' })
+
+    const clamped = fakeFetch([])
+    const b = projector(clamped.fetchImpl, { access: 'read' })
+    await b.projector.apply(desiredFrame({ writeMarker: MARKER_B, generation: '2' }))
+    expect(clamped.calls).toHaveLength(0)
+    expect(b.results[0]!.result).toMatchObject({ outcome: 'failed', code: 'insufficient_authority' })
+  })
+
+  it('refuses a frame whose natural key contradicts the projection key the ledger already holds', async () => {
+    const first = fakeFetch([{ status: 201, body: '{"id":12345}' }])
+    await projector(first.fetchImpl).projector.apply(desiredFrame())
+
+    const second = fakeFetch([])
+    const b = projector(second.fetchImpl)
+    await b.projector.apply(desiredFrame({ generation: '2', writeMarker: MARKER_B, headSha: 'f'.repeat(40) }))
+
+    expect(second.calls).toHaveLength(0)
+    expect(b.results[0]!.result).toMatchObject({ outcome: 'skipped', code: 'projection_key_conflict' })
+  })
+})
+
+describe('the run-projection template', () => {
+  it('names the three authorized re-request paths on a superseded or interrupted note', () => {
+    for (const state of ['superseded', 'interrupted'] as CodeHostNoteState[]) {
+      const body = renderProjectionNote(desiredFrame({ state }))
+      expect(body).toContain('re-request a review from the project service account')
+      expect(body).toContain('mention the agent explicitly')
+      expect(body).toContain('"Run again" in the AgentConnect Console')
+    }
+    // A live generation carries no re-request sentence — nothing has ended yet.
+    expect(renderProjectionNote(desiredFrame({ state: 'running' }))).not.toContain('To run again')
+  })
+
+  it('renders the fixed control fields and the stable marker, and nothing else', () => {
+    const body = renderProjectionNote(
+      desiredFrame({
+        state: 'completed',
+        reason: 'agent_handover',
+        startedAt: '2026-08-22T09:59:30.000Z',
+        completedAt: '2026-08-22T10:00:00.000Z',
+        consoleUrl: 'https://console.example.test/example-org/sessions/s-1?source=gitlab'
+      })
+    )
+    expect(body).toContain(projectionMarker(PROJECTION))
+    expect(body).toContain('**AgentConnect run — Completed**')
+    expect(body).toContain('- Agent: Reviewer')
+    expect(body).toContain('- Revision: `abc123de`')
+    expect(body).toContain('- Reason: `agent_handover`')
+    expect(body).toContain('- Queued: 2026-08-22T09:59:00.000Z')
+    expect(body).toContain('- Started: 2026-08-22T09:59:30.000Z')
+    expect(body).toContain('- Completed: 2026-08-22T10:00:00.000Z')
+    expect(body).toContain(
+      '[View this run in the Console](https://console.example.test/example-org/sessions/s-1?source=gitlab)'
+    )
+    // The abbreviation only: a full revision would make the note a diff-adjacent artifact.
+    expect(body).not.toContain(HEAD)
+  })
+
+  it('lets no field outside the template reach the body, and no display name break out of it', () => {
+    const smuggled = 'SMUGGLED-PAYLOAD'
+    const body = renderProjectionNote(
+      desiredFrame({
+        agentName: `Rev\niewer <script> [x](y) --> ${smuggled.toLowerCase()}`,
+        projectPath: smuggled,
+        deliveryKey: smuggled,
+        projectionId: PROJECTION,
+        consoleUrl: `javascript:alert(1)//${smuggled}` as string
+      })
+    )
+    expect(body).not.toContain(smuggled)
+    // The display name is one escaped line: it can neither close the marker nor open Markdown structure.
+    expect(body.split('\n').filter((line) => line.startsWith('- Agent: '))).toHaveLength(1)
+    expect(body.indexOf('-->')).toBe(
+      body.indexOf(projectionMarker(PROJECTION)) + projectionMarker(PROJECTION).length - 3
+    )
+    // A non-http(s) link is not a Console link, so it never becomes one.
+    expect(body).not.toContain('javascript:')
+  })
+})
+
+describe('feature negotiation (§17.3)', () => {
+  it('advertises codehost-note-projection-v1 so the Control Plane starts sending desired frames', async () => {
+    const daemonRoot = mkdtempSync(join(tmpdir(), 'note-projection-feature-'))
+    writeFileSync(
+      join(daemonRoot, 'config.json'),
+      JSON.stringify({ version: 1, controlPlane: { enabled: false }, runtimes: {} })
+    )
+    mkdirSync(join(daemonRoot, 'agents'), { recursive: true })
+    const daemon = new Daemon({
+      root: daemonRoot,
+      hostFactory: () => ({ start: vi.fn(async () => {}), stop: vi.fn(async () => {}) }) as never
+    })
+    await daemon.start()
+    const features = (daemon as never as Record<string, () => string[]>).registrationFeatures()
+    await daemon.stop().catch(() => undefined)
+    rmSync(daemonRoot, { recursive: true, force: true })
+
+    expect(features).toContain(CODEHOST_NOTE_PROJECTION_V1_FEATURE)
+    // The projection rides the GitLab surface, so the older bit stays advertised beside it.
+    expect(features).toContain(GITLAB_COM_V1_FEATURE)
+  }, 20_000)
+})

--- a/packages/daemon/test/codehost-note-projection.test.ts
+++ b/packages/daemon/test/codehost-note-projection.test.ts
@@ -26,6 +26,8 @@ const PROJECT = '4455667'
 const IID = 77
 const HEAD = 'abc123def4567890abc123def4567890abc123de'
 const NOW = Date.parse('2026-08-22T10:00:00.000Z')
+/** The credential purge fence the desired frame and the effect grant must agree on. */
+const EPOCH = '3'
 
 function desiredFrame(over: Partial<CodeHostNoteDesired> = {}): CodeHostNoteDesired {
   return {
@@ -97,6 +99,16 @@ afterEach(async () => {
   rmSync(root, { recursive: true, force: true })
 })
 
+/** A control-plane answer to `codehost/note-result`, as the correlator surfaces it. */
+class FakeWireError extends Error {
+  constructor(
+    message: string,
+    readonly retryable: boolean
+  ) {
+    super(message)
+  }
+}
+
 function projector(
   fetchImpl: typeof fetch,
   over: {
@@ -104,29 +116,42 @@ function projector(
     leaseTokens?: string[]
     leaseThrows?: boolean
     daemonId?: string
+    /** Per-mint credential epoch; the default matches the desired frame's fence. */
+    leaseEpochs?: (string | undefined)[]
+    /** Reject this many reports before the fake control plane starts accepting them. */
+    reportRejections?: number
+    reportRetryable?: boolean
   } = {}
 ) {
   const results: Array<{ result: CodeHostNoteResult; orgId?: string }> = []
   const invalidated: string[] = []
   const tokens = over.leaseTokens ?? ['glpat-1', 'glpat-2']
   let mint = 0
+  let rejections = over.reportRejections ?? 0
   const projector = new CodeHostNoteProjector({
     daemonId: () => over.daemonId ?? DAEMON,
     store: {
       getNoteProjection: (key) => store.getNoteProjection(key),
       beginNoteProjectionWrite: (row, now) => store.beginNoteProjectionWrite(row, now),
-      settleNoteProjectionWrite: (key, marker, noteId, now) =>
-        store.settleNoteProjectionWrite(key, marker, noteId, now),
-      listInFlightNoteProjections: () => store.listInFlightNoteProjections()
+      recordNoteProjectionOutcome: (row, outcome, code, now) =>
+        store.recordNoteProjectionOutcome(row, outcome, code, now),
+      markNoteProjectionReported: (key, marker, now) => store.markNoteProjectionReported(key, marker, now),
+      listUnsettledNoteProjections: () => store.listUnsettledNoteProjections()
     },
     lease: async () => {
       if (over.leaseThrows) throw new Error('effect lease refused')
       const token = tokens[Math.min(mint, tokens.length - 1)]!
+      const epochs = over.leaseEpochs ?? [EPOCH]
+      const credentialEpoch = epochs[Math.min(mint, epochs.length - 1)]
       mint += 1
-      return { token, access: over.access ?? 'comment' }
+      return { token, access: over.access ?? 'comment', ...(credentialEpoch ? { credentialEpoch } : {}) }
     },
     invalidateLease: (_target, token) => invalidated.push(token),
     report: async (result, orgId) => {
+      if (rejections > 0) {
+        rejections -= 1
+        throw new FakeWireError('control plane unreachable', over.reportRetryable ?? true)
+      }
       results.push({ result, ...(orgId ? { orgId } : {}) })
     },
     log: { warn: () => undefined },
@@ -315,6 +340,139 @@ describe('the run-projection note (gitlab-com-integration.md §16)', () => {
 
     expect(second.calls).toHaveLength(0)
     expect(b.results[0]!.result).toMatchObject({ outcome: 'skipped', code: 'projection_key_conflict' })
+  })
+})
+
+describe('authority and outcome fences (round-2 review)', () => {
+  it('never mutates when the effect grant was minted under a different credential epoch', async () => {
+    const { fetchImpl, calls } = fakeFetch([])
+    const { projector: p, results } = projector(fetchImpl, { leaseEpochs: ['2'] })
+    await p.apply(desiredFrame())
+
+    expect(calls).toHaveLength(0)
+    expect(results[0]!.result).toMatchObject({ outcome: 'skipped', code: 'stale_credential_epoch' })
+    // Stale authority must not leave a claim on the note either.
+    expect((await store.getNoteProjection(PROJECTION))?.noteId).toBeUndefined()
+  })
+
+  it('re-checks the epoch after the auth refresh, so a purge mid-write stops the retry', async () => {
+    const { fetchImpl, calls } = fakeFetch([{ status: 401 }, { status: 201, body: '{"id":12345}' }])
+    const { projector: p, results, invalidated } = projector(fetchImpl, { leaseEpochs: [EPOCH, '4'] })
+    await p.apply(desiredFrame())
+
+    expect(invalidated).toEqual(['glpat-1'])
+    // The refreshed grant crossed a purge, so the second write never leaves the daemon.
+    expect(calls).toHaveLength(1)
+    expect(results[0]!.result).toMatchObject({ outcome: 'skipped', code: 'stale_credential_epoch' })
+  })
+
+  it('still writes when the refreshed grant carries the same epoch — the negative control', async () => {
+    const { fetchImpl, calls } = fakeFetch([{ status: 401 }, { status: 201, body: '{"id":12345}' }])
+    const { projector: p, results } = projector(fetchImpl, { leaseEpochs: [EPOCH, EPOCH] })
+    await p.apply(desiredFrame())
+
+    expect(calls).toHaveLength(2)
+    expect(results[0]!.result).toMatchObject({ outcome: 'written', noteId: '12345' })
+  })
+
+  it('treats an accepted create whose id is unreadable as ambiguous, then recovers it by marker', async () => {
+    const created = fakeFetch([{ status: 201, body: 'not json at all' }])
+    const a = projector(created.fetchImpl)
+    await a.projector.apply(desiredFrame())
+
+    expect(a.results[0]!.result).toMatchObject({ outcome: 'ambiguous', code: 'create_id_unreadable' })
+    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('in_flight')
+
+    const listed = JSON.stringify([{ id: 777, body: `${projectionMarker(PROJECTION)}\n**AgentConnect run**` }])
+    const recovered = fakeFetch([
+      { status: 200, body: listed },
+      { status: 200, body: '{"id":777}' }
+    ])
+    const b = projector(recovered.fetchImpl)
+    await b.projector.reconcilePending()
+
+    // Reconciliation adopts the note GitLab really created; a redispatch would have posted a second one.
+    expect(recovered.calls.map((c) => c.method)).toEqual(['GET', 'PUT'])
+    expect(b.results[0]!.result).toMatchObject({ outcome: 'written', noteId: '777' })
+  })
+
+  it('keeps an update deterministic when its response is unreadable — the target id is already known', async () => {
+    const first = fakeFetch([{ status: 201, body: '{"id":12345}' }])
+    await projector(first.fetchImpl).projector.apply(desiredFrame())
+
+    const second = fakeFetch([{ status: 200, body: 'not json at all' }])
+    const b = projector(second.fetchImpl)
+    await b.projector.apply(desiredFrame({ generation: '2', writeMarker: MARKER_B, state: 'completed' }))
+
+    expect(second.calls.map((c) => c.method)).toEqual(['PUT'])
+    expect(b.results[0]!.result).toMatchObject({ outcome: 'written', noteId: '12345', observedState: 'completed' })
+  })
+
+  it('reports ambiguous for a 5xx on the retried attempt, not a deterministic failure', async () => {
+    const { fetchImpl, calls } = fakeFetch([{ status: 401 }, { status: 500 }])
+    const { projector: p, results } = projector(fetchImpl)
+    await p.apply(desiredFrame())
+
+    expect(calls).toHaveLength(2)
+    // The refreshed POST may well have created the note, so only reconciliation may decide.
+    expect(results[0]!.result).toMatchObject({ outcome: 'ambiguous', code: 'http_500' })
+    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('in_flight')
+  })
+
+  it('keeps an answered 4xx on the retried attempt deterministic — the negative control', async () => {
+    const { fetchImpl } = fakeFetch([{ status: 401 }, { status: 422 }])
+    const { projector: p, results } = projector(fetchImpl)
+    await p.apply(desiredFrame())
+
+    expect(results[0]!.result).toMatchObject({ outcome: 'failed', code: 'http_422' })
+    // Definite: the outcome was persisted, reported, and acknowledged in one pass.
+    expect(await store.getNoteProjection(PROJECTION)).toMatchObject({ phase: 'settled', outcome: 'failed' })
+  })
+
+  it('replays a dropped result until the control plane takes it, exactly once in effect', async () => {
+    const wrote = fakeFetch([{ status: 201, body: '{"id":12345}' }])
+    const a = projector(wrote.fetchImpl, { reportRejections: 1 })
+    await a.projector.apply(desiredFrame())
+
+    // The note exists and the outcome is durable, but the control plane never heard it.
+    expect(a.results).toHaveLength(0)
+    const pending = await store.getNoteProjection(PROJECTION)
+    expect(pending).toMatchObject({ phase: 'settled_unreported', outcome: 'written', noteId: '12345' })
+
+    const replay = fakeFetch([])
+    const b = projector(replay.fetchImpl)
+    await b.projector.reconcilePending()
+
+    // A replay touches no provider — the outcome is already definite.
+    expect(replay.calls).toHaveLength(0)
+    expect(b.results).toHaveLength(1)
+    expect(b.results[0]!.result).toMatchObject({
+      generation: '1',
+      writeMarker: MARKER_A,
+      outcome: 'written',
+      noteId: '12345',
+      observedState: 'queued'
+    })
+    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('settled')
+
+    // Acknowledged means retired: a later sweep re-sends nothing.
+    const after = projector(fakeFetch([]).fetchImpl)
+    await after.projector.reconcilePending()
+    expect(after.results).toHaveLength(0)
+  })
+
+  it('retires an unreported row the control plane permanently refuses instead of replaying forever', async () => {
+    const wrote = fakeFetch([{ status: 201, body: '{"id":12345}' }])
+    const a = projector(wrote.fetchImpl, { reportRejections: 1 })
+    await a.projector.apply(desiredFrame())
+    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('settled_unreported')
+
+    const refused = projector(fakeFetch([]).fetchImpl, { reportRejections: 1, reportRetryable: false })
+    await refused.projector.reconcilePending()
+
+    // The control plane already moved past this generation; the row must not keep asking.
+    expect(refused.results).toHaveLength(0)
+    expect((await store.getNoteProjection(PROJECTION))?.phase).toBe('settled')
   })
 })
 


### PR DESCRIPTION
## What

The daemon half of the section 16 informational run projection, stacked on #1380 (the Control-Plane ledger). The daemon is the only GitLab Notes API writer for this surface: it renders the fixed control fields into one service-account note per merge-request head, updates that note in place across generations, and reports only the observed note identity and outcome. Daemons now advertise `codehost-note-projection-v1`.

- **Writer** (`gitlab/note-projection.ts`): fence check → effect lease → optional marker reconciliation → durable write marker → exactly one create or in-place update → exactly one `codehost/note-result`. Serialized per projection key; never rejects — every path, including skipped and failed, reports one result so the ledger settles.
- **Render**: a hidden stable marker, state label, agent display name, short revision, normalized reason, timestamps, an optional console link (validated scheme), and — for superseded/interrupted — one sentence naming the three authorized re-request paths. Nothing else can reach the body: a negative test pins that project path, delivery key, snapshot, and full SHA never appear.
- **Reconciliation**: the local ledger row goes `in_flight` before any provider mutation; an interrupted write (restart), the control-plane ready sweep, and a definite 404 on the recorded note id all list the merge request's notes and adopt by marker before writing. A list that does not answer yields `ambiguous`, never a write. Transport failure and 5xx classify as `ambiguous` (a 5xx on POST may already have created the note); 401/403 re-mints the lease once; other 4xx fail with a normalized code.
- The feature is advertised in the register capability list only — the projection never crosses the relay, so `rd/hello` is untouched.

## Tests

New `codehost-note-projection.test.ts` (16 tests on a real local store, fake fetch, fake control plane): create with marker, in-place update, big-int ids, ambiguous timeout without retry, restart-reconcile-adopt with no duplicate POST, wrong owner / expired lease with zero HTTP, single 401 refresh, refused lease, the re-request sentence, the exact template field set, and the smuggled-string negative. Hook, poster, broker, relay-client, store, and cp suites green; typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
