### PR TITLE
test(daemon): deflake memory-capture budget and git not-a-repo classification tests

### DIFF
--- a/packages/daemon/test/memory-plugin-client.test.ts
+++ b/packages/daemon/test/memory-plugin-client.test.ts
@@ -124,6 +124,7 @@ interface FakeOptions {
   wrongInputTypeFor?: { tool: string; field: string }
   textOnlyFor?: string
   delayFor?: { tool: string; ms: number }
+  holdFor?: { tool: string; arrived: () => void; released: Promise<void> }
   hugeFor?: { tool: string; bytes: number }
   resultFor?: Partial<Record<string, ToolResult>>
 }
@@ -286,6 +287,10 @@ async function startFake(options: FakeOptions = {}): Promise<{
       const name = String(params.name)
       calls.push({ name, args: params.arguments })
       if (options.delayFor?.tool === name) await new Promise((resolve) => setTimeout(resolve, options.delayFor!.ms))
+      if (options.holdFor?.tool === name) {
+        options.holdFor.arrived()
+        await options.holdFor.released
+      }
       let result: ToolResult
       if (options.resultFor?.[name]) result = options.resultFor[name]!
       else if (name === MEMORY_PLUGIN_TOOL.manifest) {
@@ -677,14 +682,37 @@ describe('MemoryPluginClient conformance over remote Streamable HTTP', () => {
   })
 
   it('gives capture its own budget so a write slower than the generic call timeout still completes', async () => {
-    // Mirrors a healthy Mem0 `infer: true` capture that runs past the generic
-    // per-call budget: capture must not be bound by the recall/generic timeout.
-    const slow = await startFake({ delayFor: { tool: MEMORY_PLUGIN_TOOL.capture, ms: 120 } })
-    const client = await MemoryPluginClient.connect({ url: slow.url, callTimeoutMs: 40, captureTimeoutMs: 400 })
-    await expect(
-      client.capture({ context, operationId: 'op-slow', turn: { turnId: 'turn-slow', input: 'in', output: 'out' } })
-    ).resolves.toEqual({ state: 'completed' })
-    await client.close()
+    // Capture must not be bound by the recall/generic timeout (a healthy Mem0 `infer: true` outruns it).
+    let captureArrived!: () => void
+    let releaseCapture!: () => void
+    const arrived = new Promise<void>((resolve) => (captureArrived = resolve))
+    const released = new Promise<void>((resolve) => (releaseCapture = resolve))
+    const slow = await startFake({ holdFor: { tool: MEMORY_PLUGIN_TOOL.capture, arrived: captureArrived, released } })
+    // The reply is held while the FAKE clock runs the generic budget out — no real sleep to race CI load.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] })
+    try {
+      // Generous real-clock budgets: the connect-time conformance probe also runs under callTimeoutMs.
+      const client = await MemoryPluginClient.connect({
+        url: slow.url,
+        callTimeoutMs: 30_000,
+        captureTimeoutMs: 60_000
+      })
+      const pending = client.capture({
+        context,
+        operationId: 'op-slow',
+        turn: { turnId: 'turn-slow', input: 'in', output: 'out' }
+      })
+      pending.catch(() => undefined) // a regression rejects mid-advance; keep that handled for the assert below
+      await arrived
+      await vi.advanceTimersByTimeAsync(45_000) // past callTimeoutMs, within captureTimeoutMs
+      releaseCapture()
+      await expect(pending).resolves.toEqual({ state: 'completed' })
+      vi.useRealTimers()
+      await client.close()
+    } finally {
+      releaseCapture() // on any earlier failure, unblock the fake so afterEach can close it
+      vi.useRealTimers()
+    }
   })
 
   it('still surfaces a capture that exceeds its own budget so the outbox can mark delivery unknown', async () => {

--- a/packages/daemon/test/workspace-git-read.test.ts
+++ b/packages/daemon/test/workspace-git-read.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, renameSync, symlinkSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
@@ -25,7 +25,13 @@ const env = {
   GIT_COMMITTER_NAME: 'Ada Lovelace',
   GIT_COMMITTER_EMAIL: 'ada@example.invalid'
 }
-const git = (root: string, ...args: string[]) => execFileSync('git', ['-C', root, ...args], { env, stdio: 'ignore' })
+// No background maintenance: `git commit` detaches `maintenance run --auto` (git >= 2.47), and that
+// child's objects/maintenance.lock teardown races this file's fixture surgery and afterAll sweep.
+const git = (root: string, ...args: string[]) =>
+  execFileSync('git', ['-C', root, '-c', 'maintenance.auto=false', '-c', 'gc.auto=0', ...args], {
+    env,
+    stdio: 'ignore'
+  })
 
 let base: string
 let repo: string // a real checkout with an upstream ref and one unpushed commit
@@ -394,19 +400,19 @@ describe('createWorkspaceGit.log against a real repo', () => {
   })
 
   it('classifies a checkout git itself does not recognise as not-a-repo, not as an empty history', async () => {
-    // MEASURED, because the classification is git's and not ours: a repo whose `.git/objects` is
-    // missing OR unreadable answers `rev-parse --is-inside-work-tree` with the same
-    // "not a git repository" fatal a plain directory does. So this is not a corrupt repository the
-    // seam should report on — it is not a repository, and the preflight says so before `log` runs.
-    // The `isUnbornHead` guard still exists for the failures that DO reach it (a read timeout, a
-    // spawn failure), and those have no constructible fixture here — see the M3 follow-ups.
+    // MEASURED, because the classification is git's and not ours: a gitdir without `.git/objects`
+    // answers with the same "not a git repository" fatal a plain directory does — not a repo, said
+    // by the preflight before `log` runs. `isUnbornHead` still covers the failures that DO reach it
+    // (read timeout, spawn failure); those have no constructible fixture here — see M3 follow-ups.
     const broken = join(base, 'broken')
     mkdirSync(broken, { recursive: true })
     git(broken, 'init', '-b', 'main')
     writeFileSync(join(broken, 'a.ts'), 'x\n')
     git(broken, 'add', 'a.ts')
     git(broken, 'commit', '-m', 'seed')
-    rmSync(join(broken, '.git', 'objects'), { recursive: true, force: true })
+    // Rename, not rmSync: a recursive rm swallows ENOENT under force and once left an EMPTY objects/
+    // behind when a stray git child unlinked inside it mid-sweep — an atomic move has no partial state.
+    renameSync(join(broken, '.git', 'objects'), join(base, 'broken-objects-gone'))
 
     expect(await createWorkspaceGit(workspaces, async () => broken).log({ agentId: AGENT, limit: 20 })).toEqual({
       agentId: AGENT,


### PR DESCRIPTION
Two daemon unit tests each failed once on CI on 2026-08-22 on PRs that did not touch daemon code, then passed on rerun. Both root causes are now understood and reproduced; both tests are deterministic without any product change.

## 1. `memory-plugin-client` — "gives capture its own budget so a write slower than the generic call timeout still completes"

**CI failure** (run 32544585403, attempt 1): `MemoryPluginProtocolError: memory plugin manifest failed structured output validation` thrown from `MemoryPluginClient.probe` inside `connect()`.

**Root cause.** The test proved "capture outlives the generic budget" with real sleeps: the fake delayed capture 120 ms against `callTimeoutMs: 40` / `captureTimeoutMs: 400`. But `connect()` also runs the conformance probe — `tools/list` plus the manifest `tools/call`, two HTTP round trips — under that same 40 ms `callTimeoutMs`. On a loaded runner the probe ran out of budget before the property under test was ever exercised.

**Fix.** The fake server gains a `holdFor` gate (signals arrival, holds the reply until released). The test connects with generous real-clock budgets (`callTimeoutMs: 30_000`, `captureTimeoutMs: 60_000`), installs vitest fake timers (`setTimeout`/`clearTimeout`/`Date`), waits for the capture call to land, advances the fake clock by 45 s — past the generic budget, inside the capture budget — and only then releases the reply. The MCP SDK schedules request deadlines with global `setTimeout`, so a regression that binds capture to `callTimeoutMs` fires during the advance and fails the test (verified by temporarily re-binding capture in the client: the test fails; on the real client it passes). No wall-clock deadline remains that CI load could race; the test now runs in ~60 ms instead of ≥120 ms.

## 2. `workspace-git-read` — "classifies a checkout git itself does not recognise as not-a-repo, not as an empty history"

**CI failure** (run 32549508249, attempt 1): `git log … HEAD` → `fatal: bad object HEAD`, i.e. the seam's `isRepo` preflight answered *true* for a checkout whose `.git/objects` the test had just deleted.

**Root cause.** Since git 2.47 `git commit` detaches `git maintenance run --auto` (trace2 shows the child; with `maintenance.auto=false` it is not spawned). That child's teardown — unlinking its `objects/maintenance.lock` — races the fixture's `rmSync('.git/objects', { recursive: true, force: true })`: `std::filesystem::remove_all` hits `ENOENT` mid-sweep, `force: true` swallows it, and an **empty** `objects/` directory survives. Git's discovery only checks that `objects/` is accessible, so it recognises the checkout, and `git log` then fails on the unreadable commit — exactly the CI trace. Reproduced on Linux with git 2.55.0 (the runner's version): **135 / 1200** iterations misclassified with the old fixture sequence.

**Fix.** (a) The file's fixture `git()` helper passes `-c maintenance.auto=false -c gc.auto=0`, so fixture git never schedules background work on any git version — this also protects the file's `afterAll` sweep. (b) The broken checkout is built by **renaming** `objects/` away (atomic, no partial state) instead of recursive deletion. With both: **0 / 3000** misclassifications in the same harness.

## Verification

- Both files: 30 consecutive runs under 8 busy-loop CPU hogs, 30/30 green; `memory-plugin-client` alone another 30/30 under load.
- `workspace-git-read`: 100 additional consecutive runs, 100/100 green.
- Standalone Linux harness on git 2.55.0 / Node 24: control 135/1200 failures vs fixed 0/3000.
- `pnpm --filter @agentconnect.md/daemon typecheck`, eslint, prettier: clean.

No product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
