### PR TITLE
feat(daemon): formal GitLab merge-request reviews behind codehost-review-v1

### DIFF
--- a/packages/daemon/src/codehost/review-adapter.ts
+++ b/packages/daemon/src/codehost/review-adapter.ts
@@ -1,0 +1,94 @@
+/**
+ * The daemon's formal-review contract member (gitlab-com-integration.md §6.5, §15).
+ *
+ * `submitCodeReview` is provider-routed: core computes the logical session key and
+ * hands the call to whichever registered adapter owns that key's active review
+ * turn. No provider name is compared outside a registry entry, so adding a code
+ * host is registering one more adapter — GitHub's is the existing review
+ * orchestrator, GitLab's is the §15 thirteen-step adapter.
+ */
+import type { CodeHostProvider } from '@agentconnect.md/protocol'
+import { sessionKey } from '../store/local-store.js'
+
+export type CodeReviewEvent = 'COMMENT' | 'REQUEST_CHANGES' | 'APPROVE'
+export type CodeReviewVerdict = 'pass' | 'fail' | 'neutral'
+
+export interface CodeReviewInlineComment {
+  path: string
+  body: string
+  line: number
+  side: 'LEFT' | 'RIGHT'
+  startLine?: number
+  startSide?: 'LEFT' | 'RIGHT'
+}
+
+/** The §15 common input schema — unchanged from `submitGithubReview`. */
+export interface CodeReviewInput {
+  event: CodeReviewEvent
+  verdict: CodeReviewVerdict
+  body: string
+  comments?: CodeReviewInlineComment[]
+}
+
+/** One review request with its caller identity filled from the trusted MCP SessionContext. */
+export interface SubmitCodeReviewReq extends CodeReviewInput {
+  agentId: string
+  platform: string
+  channel: string
+  thread: string
+  transportScope?: string
+}
+
+/** One provider's publication steps behind the seam. */
+export interface CodeHostReviewAdapter {
+  readonly provider: CodeHostProvider
+  /** True only when THIS provider owns the active review turn for that logical session key. */
+  owns(key: string, agentId: string): boolean
+  submit(key: string, req: SubmitCodeReviewReq): Promise<unknown>
+}
+
+export const NO_ACTIVE_REVIEW_TURN =
+  'a formal code review is only available during an authorized active pull/merge request hook turn'
+
+/** `REQUEST_CHANGES` requires `fail` and `APPROVE` requires `pass` (§15). */
+export function codeReviewVerdictMatches(event: CodeReviewEvent, verdict: CodeReviewVerdict): boolean {
+  if (event === 'APPROVE') return verdict === 'pass'
+  if (event === 'REQUEST_CHANGES') return verdict === 'fail'
+  return true
+}
+
+/** Shared pre-effect validation: an incompatible pair or an unusable body never reaches a provider. */
+export function validateCodeReviewInput(input: CodeReviewInput): string | undefined {
+  if (!codeReviewVerdictMatches(input.event, input.verdict)) {
+    return input.event === 'APPROVE' ? 'APPROVE requires verdict=pass' : 'REQUEST_CHANGES requires verdict=fail'
+  }
+  if (!input.body.trim()) return `${input.event} requires a non-empty body`
+  for (const [index, comment] of (input.comments ?? []).entries()) {
+    if (!comment.path.trim()) return `comments[${index}].path is required`
+    if (!comment.body.trim()) return `comments[${index}].body is required`
+    if (!Number.isInteger(comment.line) || comment.line <= 0) return `comments[${index}].line must be positive`
+    if (comment.startLine !== undefined) {
+      if (!Number.isInteger(comment.startLine) || comment.startLine <= 0 || comment.startLine > comment.line) {
+        return `comments[${index}].startLine must be positive and no greater than line`
+      }
+      if (!comment.startSide) return `comments[${index}].startSide is required with startLine`
+    }
+  }
+  return undefined
+}
+
+/** The one dispatch point core knows; registration order is resolution order. */
+export class CodeHostReviewRouter {
+  private readonly adapters: CodeHostReviewAdapter[] = []
+
+  register(adapter: CodeHostReviewAdapter): void {
+    this.adapters.push(adapter)
+  }
+
+  submit(req: SubmitCodeReviewReq): Promise<unknown> {
+    const key = sessionKey(req.platform, req.channel, req.thread, req.agentId, req.transportScope)
+    const adapter = this.adapters.find((candidate) => candidate.owns(key, req.agentId))
+    if (!adapter) return Promise.reject(new Error(NO_ACTIVE_REVIEW_TURN))
+    return adapter.submit(key, req)
+  }
+}

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -28,6 +28,14 @@ import type {
   GithubReviewResultOk,
   CodeHostNoteResult,
   CodeHostNoteResultOk,
+  CodeHostReviewAuthorize,
+  CodeHostReviewAuthorized,
+  CodeHostReviewLeaseRenew,
+  CodeHostReviewLeaseRenewed,
+  CodeHostReviewOpAccepted,
+  CodeHostReviewOpRequest,
+  CodeHostReviewResultOk,
+  CodeHostReviewResultReport,
   GitCredRequest,
   GitCredGrant,
   ChannelAgentsReq,
@@ -796,6 +804,57 @@ export class CpClient {
       throw new WireError('INTERNAL', `expected codehost/note-result/ok, got ${rep.type}`, false)
     }
     return rep.payload as CodeHostNoteResultOk
+  }
+
+  /**
+   * The provider-neutral formal-review surface (gitlab-com-integration.md §15).
+   * `codehost/review-authz` acquires the durable publication lease and its fence;
+   * the ledger, renewal, and terminal result ride the three frames below. Review
+   * bodies never travel on any of them.
+   */
+  async authorizeCodeHostReview(payload: CodeHostReviewAuthorize, orgId?: string): Promise<CodeHostReviewAuthorized> {
+    this.requireReady('codehost/review-authz')
+    const rep = await this.request('codehost/review-authz', payload, orgId)
+    if (rep.type !== 'codehost/review-authz/result') {
+      throw new WireError('INTERNAL', `expected codehost/review-authz/result, got ${rep.type}`, false)
+    }
+    return rep.payload as CodeHostReviewAuthorized
+  }
+
+  /** One step of the §15.1 single-use operation ledger. */
+  async operateCodeHostReview(payload: CodeHostReviewOpRequest, orgId?: string): Promise<CodeHostReviewOpAccepted> {
+    this.requireReady('codehost/review-op')
+    const rep = await this.request('codehost/review-op', payload, orgId)
+    if (rep.type !== 'codehost/review-op/ok') {
+      throw new WireError('INTERNAL', `expected codehost/review-op/ok, got ${rep.type}`, false)
+    }
+    return rep.payload as CodeHostReviewOpAccepted
+  }
+
+  /** Owner-only publication-lease extension; expiry alone never transfers authority. */
+  async renewCodeHostReviewLease(
+    payload: CodeHostReviewLeaseRenew,
+    orgId?: string
+  ): Promise<CodeHostReviewLeaseRenewed> {
+    this.requireReady('codehost/review-lease-renew')
+    const rep = await this.request('codehost/review-lease-renew', payload, orgId)
+    if (rep.type !== 'codehost/review-lease-renew/ok') {
+      throw new WireError('INTERNAL', `expected codehost/review-lease-renew/ok, got ${rep.type}`, false)
+    }
+    return rep.payload as CodeHostReviewLeaseRenewed
+  }
+
+  /** The body-free terminal classification; it is also what releases or locks the lease. */
+  async reportCodeHostReviewResult(
+    payload: CodeHostReviewResultReport,
+    orgId?: string
+  ): Promise<CodeHostReviewResultOk> {
+    this.requireReady('codehost/review-result')
+    const rep = await this.request('codehost/review-result', payload, orgId)
+    if (rep.type !== 'codehost/review-result/ok') {
+      throw new WireError('INTERNAL', `expected codehost/review-result/ok, got ${rep.type}`, false)
+    }
+    return rep.payload as CodeHostReviewResultOk
   }
 
   async issueWebchatMcpGrant(payload: WebchatMcpGrantIssue, orgId?: string): Promise<WebchatMcpGrantIssued> {

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -110,6 +110,8 @@ export interface CpClientReadyHost {
   effectiveAgents(): LoadedAgent[]
   /** The §16 run-projection writer: the CP dispatch target and the interrupted-write reconciler. */
   noteProjector(): CodeHostNoteProjector
+  /** The §15 review adapter, for the control-plane frames a finished attempt still owes. */
+  gitlabReviews(): { reconcilePending(): Promise<void> }
 }
 
 /** Tenant lookups for agent-scoped frames, plus the duty seam the heartbeat carries. */
@@ -255,6 +257,9 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       // ...and every §16 projection write this daemon started but never settled. Each is reconciled
       // by the hidden marker before the merge request is touched again, never by replaying the write.
       void host.noteProjector().reconcilePending()
+      // ...and every §15 settle/result frame a review attempt still owes. Both are idempotent
+      // REQs, so replaying one the CP already took is a no-op; not replaying wedges its ledger.
+      void host.gitlabReviews().reconcilePending()
       // ...and the retention-GC receipts (#485). A sweep that ran while the CP
       // was unreachable (or before it advertised the feature) left the deleted
       // sessions' metadata rows unmarked; this is the only side that still knows.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto'
+import { createHash, randomBytes, randomUUID } from 'node:crypto'
 import { basename, dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { mkdtemp, readFile, stat } from 'node:fs/promises'
@@ -415,7 +415,7 @@ import {
 import {
   foreignHookDispatch,
   githubDeletedHookEvent,
-  githubFallbackAllowed,
+  hookOutputFallbackAllowed,
   githubHookCoordinates,
   githubPullRequestLane,
   githubReviewResultForCompletion,
@@ -6643,6 +6643,22 @@ export class Daemon {
         }
       },
       orgForAgent: (agentId) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
+      daemonId: () => this.cfg.daemonId,
+      store: {
+        recordReviewIntent: (row, now) => this.store.recordReviewIntent(row, now),
+        clearReviewIntent: (intentId) => this.store.clearReviewIntent(intentId),
+        listReviewIntents: (daemonId) => this.store.listReviewIntents(daemonId)
+      },
+      // Restart-stable, so a same-attempt recovery can still verify the drafts it authored.
+      markerKey: async () =>
+        Buffer.from(
+          await this.store.getOrCreateDaemonSecret(
+            'gitlab-review-marker-key',
+            () => randomBytes(32).toString('base64'),
+            this.clock.now()
+          ),
+          'base64'
+        ),
       token: async (turn) =>
         (await this.gitCreds.getGitlabEffectToken(turn.agentId, turn.projectId, turn.hookId)).token,
       invalidateToken: (turn, token) => this.gitCreds.invalidateGitlabEffect(turn.agentId, turn.projectId, token),
@@ -9567,7 +9583,10 @@ export class Daemon {
     })
     if (activeGithub) this.activeGithubTurnMeta.set(key, activeGithub)
     // §15: no hook/start barrier — the accepted delivery report already carries the fence review authz checks.
-    const gitlabReview = this.gitlabReviews.openTurn(key, hookContext, sessionId, this.cfg.daemonId)
+    const gitlabReview = this.gitlabReviews.openTurn(key, hookContext, sessionId, {
+      ...(this.cfg.daemonId ? { daemonId: this.cfg.daemonId } : {}),
+      persist: (required) => this.persistHookState(entry, undefined, required)
+    })
     const activeGithubReplyBatch = plan.githubReplyBatchActive ? { entry, sessionId, called: false } : undefined
     if (activeGithubReplyBatch) this.activeGithubReplyBatchMeta.set(key, activeGithubReplyBatch)
     return {
@@ -10478,9 +10497,10 @@ export class Daemon {
     if (activeGithubReplyBatch && this.activeGithubReplyBatchMeta.get(key) === activeGithubReplyBatch) {
       this.activeGithubReplyBatchMeta.delete(key)
     }
-    // Anything other than no attempt or a correlated definite no-effect
-    // result is fail-closed: GitHub may already own the public response.
-    const formalReviewOwnsResponse = githubReply !== undefined && !githubFallbackAllowed(hookContext)
+    // Anything other than no attempt or a correlated definite no-effect result is
+    // fail-closed: the code host may already own the public response. Both providers'
+    // durable attempt records are consulted, so a GitLab review blocks the note too.
+    const formalReviewOwnsResponse = githubReply !== undefined && !hookOutputFallbackAllowed(hookContext)
     if (formalReviewOwnsResponse) {
       try {
         await this.persistHookState(entry, 'settled', true)
@@ -14694,6 +14714,7 @@ export class Daemon {
       drainSessionPurges: () => this.drainSessionPurges(),
       effectiveAgents: () => this.effectiveAgents(),
       noteProjector: () => this.noteProjector,
+      gitlabReviews: () => this.gitlabReviews,
       cpAgents: () => this.cpAgents,
       cpIntegrations: () => this.cpIntegrations,
       cpCrons: () => this.cpCrons,
@@ -15702,6 +15723,7 @@ export class Daemon {
     this.gitCredServer?.stop()
     // The projection resweep runs on its own clock, so it must be disarmed before the store closes.
     this.noteProjector?.stop()
+    this.gitlabReviews?.stop()
     if (this.dataPlane) await this.dataPlane.close().catch((e) => errors.push(e))
     else await this.store?.close()
     if (errors.length) throw new AggregateError(errors, 'stop: partial failure')

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -184,6 +184,8 @@ import {
 import { DreamScheduler } from './scheduler/dream-scheduler.js'
 import { finalizeGithubTurn, isGithubFinalChunk, onGithubUpdate } from './platforms/github/turn-output.js'
 import { GithubReviewOrchestrator, type GithubReviewHost } from './github/review-orchestrator.js'
+import { CodeHostReviewRouter } from './codehost/review-adapter.js'
+import { GitlabReviewAdapter, type GitlabReviewAdapterDeps, type GitlabReviewTurn } from './gitlab/review-adapter.js'
 import {
   collectGithubQueueCandidates,
   combineCoordinationWaits,
@@ -255,6 +257,7 @@ import {
   WEBCHAT_REMOTE_MCP_FEATURE,
   WEBCHAT_SESSION_CONTINUATION_FEATURE,
   CODEHOST_NOTE_PROJECTION_V1_FEATURE,
+  CODEHOST_REVIEW_V1_FEATURE,
   GITLAB_COM_V1_FEATURE,
   encodeSharedSlackStatusTarget,
   HOOK_REPORT_REASON_AGENT_HANDOVER,
@@ -962,6 +965,9 @@ export class Daemon {
   private readonly activeGithubTurnMeta = new Map<string, ActiveGithubTurnMeta>()
   private readonly activeGithubReplyBatchMeta = new Map<string, ActiveGithubReplyBatchMeta>()
   private readonly githubReviews: GithubReviewOrchestrator
+  /** §15 GitLab formal-review adapter and the provider-routing seam both live behind this. */
+  private readonly gitlabReviews: GitlabReviewAdapter
+  private readonly codeReviews = new CodeHostReviewRouter()
   // ── lifecycle (§2.5/§5.3/§7.2/§7.3) ──
   private clock: Clock
   private requestExit: (code: number) => void
@@ -1184,6 +1190,9 @@ export class Daemon {
     this.webchatMcpRevocations = new WebchatMcpRevocations(this.webchatMcpRevocationHost())
     this.commands = new CommandHandlers(this.commandHost())
     this.githubReviews = new GithubReviewOrchestrator(this.githubReviewHost())
+    this.gitlabReviews = new GitlabReviewAdapter(this.gitlabReviewDeps())
+    this.codeReviews.register(this.githubReviews.reviewAdapter)
+    this.codeReviews.register(this.gitlabReviews)
     this.curatedRuntimeAdmission = new CuratedRuntimeAdmission({
       now: () => this.clock.now(),
       ttlMs: PROBE_TTL_MS
@@ -2311,7 +2320,7 @@ export class Daemon {
       startOrchestration: (req) => this.collab.startOrchestration(req),
       getOrchestration: (req) => Promise.resolve(this.collab.getOrchestrationForOwner(req)),
       cancelOrchestration: (req) => Promise.resolve(this.collab.cancelOrchestrationForOwner(req)),
-      submitGithubReview: (req) => this.githubReviews.submitGithubReview(req),
+      submitCodeReview: (req) => this.codeReviews.submit(req),
       replyGithubReviewThreads: (req) => this.githubReviews.replyGithubReviewThreads(req),
       codeHostEffect: (req) => this.runCodeHostEffect(req),
       memory: this.memory,
@@ -3765,7 +3774,9 @@ export class Daemon {
       GITLAB_COM_V1_FEATURE,
       // §16: this daemon renders and updates the run-projection note. The CP leaves the desired
       // generation pending rather than opening a second provider egress path without this bit.
-      CODEHOST_NOTE_PROJECTION_V1_FEATURE
+      CODEHOST_NOTE_PROJECTION_V1_FEATURE,
+      // The provider-routed formal-review surface: `submitCodeReview` plus the §15 GitLab adapter.
+      CODEHOST_REVIEW_V1_FEATURE
     ]
   }
 
@@ -6617,6 +6628,32 @@ export class Daemon {
   }
 
   /** Everything the GitHub hook-dispatch and formal-review seam reaches back for. */
+  /** §15 GitLab review adapter deps: the CP lease surface plus the never-agent-visible effect PAT. */
+  private gitlabReviewDeps(): GitlabReviewAdapterDeps {
+    return {
+      cp: () => {
+        const client = this.cpClient
+        if (!client) return undefined
+        return {
+          supportsReview: () => client.supportsServerFeature?.(CODEHOST_REVIEW_V1_FEATURE) === true,
+          authorize: (payload, orgId) => client.authorizeCodeHostReview(payload, orgId),
+          operate: (payload, orgId) => client.operateCodeHostReview(payload, orgId),
+          renew: (payload, orgId) => client.renewCodeHostReviewLease(payload, orgId),
+          report: (payload, orgId) => client.reportCodeHostReviewResult(payload, orgId)
+        }
+      },
+      orgForAgent: (agentId) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
+      token: async (turn) =>
+        (await this.gitCreds.getGitlabEffectToken(turn.agentId, turn.projectId, turn.hookId)).token,
+      invalidateToken: (turn, token) => this.gitCreds.invalidateGitlabEffect(turn.agentId, turn.projectId, token),
+      attribution: async (turn) =>
+        this.agents.get(turn.agentId)?.output.showFooter
+          ? await this.githubReviews.githubCommentAttribution(turn.agentId, turn.sessionId)
+          : undefined,
+      log: { warn: (message: string) => this.log.warn(message) }
+    }
+  }
+
   private githubReviewHost(): GithubReviewHost {
     return {
       log: () => this.log,
@@ -9491,7 +9528,11 @@ export class Daemon {
   private async installActiveTurnContext(
     run: TurnRun,
     sessionId: string
-  ): Promise<{ github?: ActiveGithubTurnMeta; githubReplyBatch?: ActiveGithubReplyBatchMeta }> {
+  ): Promise<{
+    github?: ActiveGithubTurnMeta
+    githubReplyBatch?: ActiveGithubReplyBatchMeta
+    gitlabReview?: GitlabReviewTurn
+  }> {
     const { entry, key, plan } = run
     const { agentId, callMeta } = entry
     // session/new|load may emit title/usage metadata before the local row exists.
@@ -9525,10 +9566,13 @@ export class Daemon {
       return undefined
     })
     if (activeGithub) this.activeGithubTurnMeta.set(key, activeGithub)
+    // §15: no hook/start barrier — the accepted delivery report already carries the fence review authz checks.
+    const gitlabReview = this.gitlabReviews.openTurn(key, hookContext, sessionId, this.cfg.daemonId)
     const activeGithubReplyBatch = plan.githubReplyBatchActive ? { entry, sessionId, called: false } : undefined
     if (activeGithubReplyBatch) this.activeGithubReplyBatchMeta.set(key, activeGithubReplyBatch)
     return {
       ...(activeGithub ? { github: activeGithub } : {}),
+      ...(gitlabReview ? { gitlabReview } : {}),
       ...(activeGithubReplyBatch ? { githubReplyBatch: activeGithubReplyBatch } : {})
     }
   }
@@ -10389,7 +10433,11 @@ export class Daemon {
     sessionId: string,
     settlement: TurnSettlement,
     releaseReplyConn: () => void,
-    activeTurn: { github?: ActiveGithubTurnMeta; githubReplyBatch?: ActiveGithubReplyBatchMeta }
+    activeTurn: {
+      github?: ActiveGithubTurnMeta
+      githubReplyBatch?: ActiveGithubReplyBatchMeta
+      gitlabReview?: GitlabReviewTurn
+    }
   ): Promise<void> {
     const { entry, key, plan } = run
     const { agentId, msg, callMeta, githubReply, hookContext } = entry
@@ -10426,6 +10474,7 @@ export class Daemon {
     const activeGithub = activeTurn.github
     const activeGithubReplyBatch = activeTurn.githubReplyBatch
     if (activeGithub && this.activeGithubTurnMeta.get(key) === activeGithub) this.activeGithubTurnMeta.delete(key)
+    if (activeTurn.gitlabReview) this.gitlabReviews.closeTurn(key, activeTurn.gitlabReview)
     if (activeGithubReplyBatch && this.activeGithubReplyBatchMeta.get(key) === activeGithubReplyBatch) {
       this.activeGithubReplyBatchMeta.delete(key)
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9587,6 +9587,13 @@ export class Daemon {
       ...(this.cfg.daemonId ? { daemonId: this.cfg.daemonId } : {}),
       persist: (required) => this.persistHookState(entry, undefined, required)
     })
+    // A replayed delivery may still owe the control plane frames a previous incarnation
+    // recorded; the ones needing no provider evidence are handed back before the turn runs.
+    if (gitlabReview) {
+      await this.gitlabReviews
+        .recoverTurn(gitlabReview)
+        .catch((err) => this.log.warn(`gitlab review: turn recovery deferred (${formatErr(err)})`))
+    }
     const activeGithubReplyBatch = plan.githubReplyBatchActive ? { entry, sessionId, called: false } : undefined
     if (activeGithubReplyBatch) this.activeGithubReplyBatchMeta.set(key, activeGithubReplyBatch)
     return {

--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -1,5 +1,6 @@
 import {
   codeHostReviewPublicEffect,
+  type CodeHostReviewExternalRef,
   type CodeHostReviewOpKind,
   type CodeHostReviewState,
   type HookReviewEvent,
@@ -166,19 +167,32 @@ export interface CodeReviewAttempt {
   verdict: HookReviewVerdict
   headSha: string
   state?: CodeHostReviewState
+  /** The publication lease's fence, so an owed ledger frame stays derivable after a restart. */
+  fence?: string
+  /** Published objects this attempt named; replayed verbatim with a reconstructed result. */
+  externalIds?: CodeHostReviewExternalRef[]
+  /** The classification exists but the control plane has not taken it yet (§15.1). */
+  resultOwed?: boolean
   /** Next operation-ledger ordinal per kind — monotonic, so a replay never reuses a spent coordinate. */
   ordinals?: Record<string, number>
   /** Operations whose one outbound request was permitted but not yet settled (§15.1). */
   operations?: CodeReviewOperation[]
 }
 
-/** The coordinates of ONE permitted provider request, written before it is sent. */
+/**
+ * The coordinates of ONE permitted provider request, written before it is sent.
+ *
+ * `phase` is the LOCAL view of the control plane's record: `issued` means the start
+ * transition had not been acknowledged, so a replay returns the permit unused rather
+ * than settling a record no request was ever permitted under.
+ */
 export interface CodeReviewOperation {
   recordId: string
   startToken: string
   kind: CodeHostReviewOpKind
   ordinal: number
   target: string
+  phase: 'issued' | 'started'
   /** Draft ordinal for a `draft_create`, so its marker can identify the effect on replay. */
   draftOrdinal?: number
 }

--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -1,5 +1,6 @@
 import {
   codeHostReviewPublicEffect,
+  type CodeHostReviewOpKind,
   type CodeHostReviewState,
   type HookReviewEvent,
   type HookReviewVerdict,
@@ -165,6 +166,21 @@ export interface CodeReviewAttempt {
   verdict: HookReviewVerdict
   headSha: string
   state?: CodeHostReviewState
+  /** Next operation-ledger ordinal per kind — monotonic, so a replay never reuses a spent coordinate. */
+  ordinals?: Record<string, number>
+  /** Operations whose one outbound request was permitted but not yet settled (§15.1). */
+  operations?: CodeReviewOperation[]
+}
+
+/** The coordinates of ONE permitted provider request, written before it is sent. */
+export interface CodeReviewOperation {
+  recordId: string
+  startToken: string
+  kind: CodeHostReviewOpKind
+  ordinal: number
+  target: string
+  /** Draft ordinal for a `draft_create`, so its marker can identify the effect on replay. */
+  draftOrdinal?: number
 }
 
 /** §15.2 single-writer gate: only a PROVEN no-effect attempt leaves the ordinary reply available. */

--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -1,13 +1,17 @@
-import type {
-  GithubHookMetadata,
-  GitlabHookMetadata,
-  GithubPublishedComment,
-  PublishedHookOutput,
-  GithubReviewAuthorized,
-  HookConfigSnapshot,
-  HookReport,
-  HookReviewResult,
-  RdMsgHook
+import {
+  codeHostReviewPublicEffect,
+  type CodeHostReviewState,
+  type HookReviewEvent,
+  type HookReviewVerdict,
+  type GithubHookMetadata,
+  type GitlabHookMetadata,
+  type GithubPublishedComment,
+  type PublishedHookOutput,
+  type GithubReviewAuthorized,
+  type HookConfigSnapshot,
+  type HookReport,
+  type HookReviewResult,
+  type RdMsgHook
 } from '@agentconnect.md/protocol'
 import type { GithubReviewEffect, GithubReviewEvent, GithubReviewTarget, GithubReviewVerdict } from './review.js'
 import type { SessionWorktreeRemoval } from '../workspace/workspace-manager.js'
@@ -143,8 +147,37 @@ export interface HookDispatchContext {
   publishedComment?: GithubPublishedComment
   /** Provider-neutral twin (§14.1): e.g. the GitLab note id this turn published. */
   publishedOutput?: PublishedHookOutput
+  /** The provider-neutral formal-review attempt (§15) — durable, so a replay cannot resurrect the fallback. */
+  codeReview?: CodeReviewAttempt
   /** Its twin for an absent note — persisted WITH settlement so a replay cannot report success (§14.1). */
   notePublishFailure?: NotePublishFailure
+}
+
+/**
+ * One reserved formal-review attempt, written to the durable hook row BEFORE the
+ * first provider operation (§15). `state` appears only once the attempt is durably
+ * classified; its absence means the effect is unknown and the ordinary reply is
+ * blocked, exactly as an uncorrelated GitHub attempt is.
+ */
+export interface CodeReviewAttempt {
+  attemptId: string
+  event: HookReviewEvent
+  verdict: HookReviewVerdict
+  headSha: string
+  state?: CodeHostReviewState
+}
+
+/** §15.2 single-writer gate: only a PROVEN no-effect attempt leaves the ordinary reply available. */
+export function codeHostReviewFallbackAllowed(hook: HookDispatchContext | undefined): boolean {
+  const attempt = hook?.codeReview
+  if (!attempt) return true
+  return attempt.state !== undefined && codeHostReviewPublicEffect(attempt.state) === 'absent'
+}
+
+/** THE gate the turn-final surface asks: may the daemon still publish its ordinary reply?
+ *  Either provider's unresolved formal attempt is enough to answer no. */
+export function hookOutputFallbackAllowed(hook: HookDispatchContext | undefined): boolean {
+  return githubFallbackAllowed(hook) && codeHostReviewFallbackAllowed(hook)
 }
 
 export type GithubThreadWorktreeCleanup = 'pull_request_merged' | 'issue_closed' | 'issue_deleted'

--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -2,6 +2,7 @@ import {
   codeHostReviewPublicEffect,
   type CodeHostReviewExternalRef,
   type CodeHostReviewOpKind,
+  type CodeHostReviewOpOutcome,
   type CodeHostReviewState,
   type HookReviewEvent,
   type HookReviewVerdict,
@@ -193,6 +194,9 @@ export interface CodeReviewOperation {
   ordinal: number
   target: string
   phase: 'issued' | 'started'
+  /** The settle this operation owes, kept here when its frame could not be made durable —
+   *  a restart replays it from these coordinates alone, with no provider evidence. */
+  outcome?: CodeHostReviewOpOutcome
   /** Draft ordinal for a `draft_create`, so its marker can identify the effect on replay. */
   draftOrdinal?: number
 }

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -25,6 +25,7 @@ import type { Logger } from '../log.js'
 import { buildHookMessage, githubOpensReviewGeneration, hookAnchorText } from '../messages/hook-message.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { ReplyGithubReviewThreadsReq, ReplyGithubReviewThreadsResult, SubmitGithubReviewReq } from '../mcp/ops.js'
+import type { CodeHostReviewAdapter } from '../codehost/review-adapter.js'
 import { sessionKey, type SessionRecord } from '../store/local-store.js'
 import { formatErr, formatErrWithCauses } from '../daemon/text.js'
 import {
@@ -142,6 +143,14 @@ export interface GithubReviewHost {
 
 export class GithubReviewOrchestrator {
   readonly githubReviewClient = new GithubReviewClient()
+
+  /** The §6.5 code-host review adapter, GitHub side — extracted so GitLab can implement
+   *  the same member instead of core branching on a provider name. */
+  readonly reviewAdapter: CodeHostReviewAdapter = {
+    provider: 'github',
+    owns: (key, agentId) => this.host.activeGithubTurn(key)?.hook.agentId === agentId,
+    submit: (_key, req) => this.submitGithubReview(req)
+  }
 
   constructor(private readonly host: GithubReviewHost) {}
 

--- a/packages/daemon/src/gitlab/review-adapter.ts
+++ b/packages/daemon/src/gitlab/review-adapter.ts
@@ -491,6 +491,11 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       externalIds: [],
       ...(reviewerBefore ? { reviewerBefore } : {})
     }
+    // The fence rides the durable record so an owed ledger frame stays derivable after a restart.
+    if (turn.hook.codeReview) {
+      turn.hook.codeReview.fence = attempt.fence
+      await turn.persist(true)
+    }
     // The leased publishing identity must be the account this effect token speaks as.
     if (authorized.lease.serviceAccountUserId !== serviceAccountUserId) {
       return this.settle(cp, attempt, 'not_submitted')
@@ -582,44 +587,55 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       const marker = attempt.signer.read(draft.note, attempt.turn.expectedHeadSha)
       if (marker?.attemptId === attempt.attemptId.toLowerCase()) marked.set(marker.ordinal, draft.id)
     }
+    const outstanding: CodeReviewOperation[] = []
     for (const op of pending) {
-      if (op.kind === 'bulk_publish' || op.kind === 'approval') continue
-      await this.settleOperation(cp, attempt, op.recordId, this.classifyDraftOperation(op, marked, attempt))
-      await this.clearOperation(attempt, op.recordId)
+      // A permit whose start was never acknowledged had no request: return it unused.
+      if (op.phase === 'issued' && (await this.returnUnused(cp, attempt, op)) !== 'started') continue
+      if (op.kind === 'bulk_publish' || op.kind === 'approval') {
+        outstanding.push(op)
+        continue
+      }
+      const owed = await this.settleOperation(
+        cp,
+        attempt,
+        op.recordId,
+        this.classifyDraftOperation(op, marked, attempt)
+      )
+      if (owed) await this.clearOperation(attempt, op.recordId)
     }
-    const publish = pending.find((op) => op.kind === 'bulk_publish')
-    const approval = pending.find((op) => op.kind === 'approval')
+    const publish = outstanding.find((op) => op.kind === 'bulk_publish')
+    const approval = outstanding.find((op) => op.kind === 'approval')
     if (!publish && !approval) return undefined
 
     // Only positive provider evidence can classify a permitted publication.
     const note = await this.findSummaryNote(attempt).catch(() => undefined)
     if (publish) {
       if (!note) {
-        await this.settleOperation(cp, attempt, publish.recordId, {
+        const owed = await this.settleOperation(cp, attempt, publish.recordId, {
           kind: 'ambiguous',
           code: 'publish_unreconciled'
         })
-        await this.clearOperation(attempt, publish.recordId)
+        if (owed) await this.clearOperation(attempt, publish.recordId)
         return await this.settle(cp, attempt, 'ambiguous_locked')
       }
-      await this.settleOperation(cp, attempt, publish.recordId, {
+      const owed = await this.settleOperation(cp, attempt, publish.recordId, {
         kind: 'deterministic',
         status: 201,
         externalId: note
       })
-      await this.clearOperation(attempt, publish.recordId)
+      if (owed) await this.clearOperation(attempt, publish.recordId)
     }
     if (note) attempt.externalIds.push({ kind: 'note', externalId: note })
     if (approval) {
       const readback = await this.get(attempt, this.mrPath(attempt.turn, '/approvals')).catch(() => undefined)
       const approved = this.approvalReadback(readback, attempt)
       const approvalId = idOf(record(readback).id)
-      await this.settleOperation(cp, attempt, approval.recordId, {
+      const owed = await this.settleOperation(cp, attempt, approval.recordId, {
         kind: 'deterministic',
         status: approved ? 201 : 422,
         ...(approved && approvalId ? { externalId: approvalId } : {})
       })
-      await this.clearOperation(attempt, approval.recordId)
+      if (owed) await this.clearOperation(attempt, approval.recordId)
       if (approved && approvalId) attempt.externalIds.push({ kind: 'approval', externalId: approvalId })
       return await this.settle(cp, attempt, approved ? 'submitted' : 'approval_not_recorded')
     }
@@ -634,6 +650,81 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       )
     }
     return await this.settle(cp, attempt, 'review_state_not_recorded')
+  }
+
+  /**
+   * Hand back a permit no request ever started (§15.1's second transfer condition).
+   *
+   * `returned` — acknowledged, so the coordinates are gone. `started` — the control plane
+   * had already recorded the start, so the local phase raced behind it and the caller must
+   * classify by provider evidence instead. `deferred` — nothing was decided, so the
+   * coordinates stay exactly as they are.
+   */
+  private async returnUnused(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt,
+    op: CodeReviewOperation
+  ): Promise<'returned' | 'started' | 'deferred'> {
+    try {
+      await cp.operate(
+        { op: 'return-unused', attemptId: attempt.attemptId, fence: attempt.fence, recordId: op.recordId },
+        attempt.orgId
+      )
+      await this.clearOperation(attempt, op.recordId)
+      return 'returned'
+    } catch (err) {
+      // A permanent refusal means the record moved on without this daemon; evidence decides.
+      if ((err as { retryable?: unknown }).retryable === false) return 'started'
+      this.warn(`gitlab review: unused permit return deferred (${err instanceof Error ? err.message : err})`)
+      return 'deferred'
+    }
+  }
+
+  /**
+   * Rebuild the frames a restart can owe WITHOUT provider evidence: an unstarted permit is
+   * returned, and a classified attempt whose result never became durable is re-owed. An
+   * operation that did start needs a marker read, so it waits for the turn's own replay.
+   */
+  async recoverTurn(turn: GitlabReviewTurn): Promise<void> {
+    const attemptRecord = turn.hook.codeReview
+    const cp = this.deps.cp()
+    if (!attemptRecord || !cp || !cp.supportsReview()) return
+    const fence = attemptRecord.fence
+    const orgId = this.deps.orgForAgent(turn.agentId)
+    if (fence) {
+      for (const op of [...(attemptRecord.operations ?? [])]) {
+        if (op.phase !== 'issued') continue
+        await this.returnUnused(
+          cp,
+          { turn, attemptId: attemptRecord.attemptId, fence, ...(orgId ? { orgId } : {}) } as Attempt,
+          op
+        )
+      }
+    }
+    if (!attemptRecord.resultOwed || !attemptRecord.state) return
+    const safe = await this.owe(cp, {
+      intentId: `${attemptRecord.attemptId}:result`,
+      daemonId: this.deps.daemonId() ?? '',
+      attemptId: attemptRecord.attemptId,
+      ...(orgId ? { orgId } : {}),
+      kind: 'result',
+      frame: JSON.stringify({
+        hookId: turn.hookId,
+        deliveryKey: turn.deliveryKey,
+        attemptId: attemptRecord.attemptId,
+        snapshot: turn.snapshot,
+        provider: 'gitlab',
+        projectId: turn.projectId,
+        mergeRequestIid: turn.mergeRequestIid,
+        event: attemptRecord.event,
+        verdict: attemptRecord.verdict,
+        headSha: attemptRecord.headSha,
+        state: attemptRecord.state,
+        ...(attemptRecord.externalIds?.length ? { externalIds: attemptRecord.externalIds } : {})
+      } satisfies CodeHostReviewResultReport),
+      attempts: 0
+    })
+    if (safe) await this.clearResultOwed(turn)
   }
 
   /** A draft create is proven by its marker; a draft delete is proven by the absence it asked for. */
@@ -663,6 +754,14 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     if (!attemptRecord) return
     attemptRecord.ordinals = Object.fromEntries(attempt.ordinals)
     attemptRecord.operations = [...(attemptRecord.operations ?? []).filter((e) => e.recordId !== op.recordId), op]
+    await attempt.turn.persist(true)
+  }
+
+  /** Flip the local phase once the control plane acknowledged the start transition. */
+  private async markOperationStarted(attempt: Attempt, recordId: string): Promise<void> {
+    const op = attempt.turn.hook.codeReview?.operations?.find((entry) => entry.recordId === recordId)
+    if (!op || op.phase === 'started') return
+    op.phase = 'started'
     await attempt.turn.persist(true)
   }
 
@@ -988,28 +1087,34 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
         kind,
         ordinal,
         target,
+        phase: 'issued',
         ...(draftOrdinal !== undefined ? { draftOrdinal } : {})
       })
       await this.startOperation(cp, attempt, issued.recordId, startToken)
+      // Only now may a replay assume a request was permitted under this record.
+      await this.markOperationStarted(attempt, issued.recordId)
       let result: SendResult
       try {
         result = await this.send(method, target, undefined, body, attempt.token)
       } catch (err) {
         if (err instanceof AmbiguousSend) {
-          await this.settleOperation(cp, attempt, issued.recordId, { kind: 'ambiguous', code: err.code })
-          await this.clearOperation(attempt, issued.recordId)
+          const owed = await this.settleOperation(cp, attempt, issued.recordId, {
+            kind: 'ambiguous',
+            code: err.code
+          })
+          if (owed) await this.clearOperation(attempt, issued.recordId)
           return { kind: 'ambiguous', recordId: issued.recordId }
         }
         throw err
       }
       const authRejected = result.status === 401 || result.status === 403
       const externalId = idOf(record(result.parsed).id)
-      await this.settleOperation(cp, attempt, issued.recordId, {
+      const owed = await this.settleOperation(cp, attempt, issued.recordId, {
         kind: 'deterministic',
         status: result.status,
         ...(externalId ? { externalId } : {})
       })
-      await this.clearOperation(attempt, issued.recordId)
+      if (owed) await this.clearOperation(attempt, issued.recordId)
       if (result.status < 300) {
         return { kind: 'sent', status: result.status, parsed: result.parsed, recordId: issued.recordId }
       }
@@ -1044,14 +1149,15 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     throw last instanceof Error ? last : new Error('the control plane refused to start the review operation')
   }
 
-  /** The settle is owed durably first: a lost ack must never strand a started record. */
+  /** The settle is owed durably first: a lost ack must never strand a started record.
+   *  Returns whether the operation's own coordinates may now be forgotten. */
   private async settleOperation(
     cp: GitlabReviewControlPlane,
     attempt: Attempt,
     recordId: string,
     outcome: CodeHostReviewOpOutcome
-  ): Promise<void> {
-    await this.owe(cp, {
+  ): Promise<boolean> {
+    return await this.owe(cp, {
       intentId: `${attempt.attemptId}:op:${recordId}`,
       daemonId: this.deps.daemonId() ?? '',
       attemptId: attempt.attemptId,
@@ -1077,8 +1183,9 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     const externalIds = codeHostReviewPublicEffect(state) === 'absent' ? [] : attempt.externalIds
     // The durable single-writer gate first: only a PROVEN no-effect attempt may be followed
     // by the ordinary note, and a replay must read the same verdict this turn reached (§15.2).
-    await this.recordOutcome(attempt.turn, state)
-    await this.owe(cp, {
+    // The same record is the result frame's upstream entry, so it also marks it owed.
+    await this.recordOutcome(attempt.turn, state, externalIds, true)
+    const safe = await this.owe(cp, {
       intentId: `${attempt.attemptId}:result`,
       daemonId: this.deps.daemonId() ?? '',
       attemptId: attempt.attemptId,
@@ -1100,6 +1207,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       } satisfies CodeHostReviewResultReport),
       attempts: 0
     })
+    if (safe) await this.clearResultOwed(attempt.turn)
     return {
       provider: 'gitlab',
       state,
@@ -1134,7 +1242,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
               : ''
     // No lease was granted, so nothing is owed to the control plane — but the durable
     // gate still has to learn whether the ordinary note may follow this attempt.
-    await this.recordOutcome(turn, state)
+    await this.recordOutcome(turn, state, [], false)
     return {
       provider: 'gitlab',
       state,
@@ -1145,15 +1253,32 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   }
 
   /** Stamp the durable attempt with its classification; the in-memory copy guards this process. */
-  private async recordOutcome(turn: GitlabReviewTurn, state: CodeHostReviewState): Promise<void> {
-    if (!turn.hook.codeReview) return
-    turn.hook.codeReview.state = state
+  private async recordOutcome(
+    turn: GitlabReviewTurn,
+    state: CodeHostReviewState,
+    externalIds: CodeHostReviewExternalRef[],
+    owed: boolean
+  ): Promise<void> {
+    const attemptRecord = turn.hook.codeReview
+    if (!attemptRecord) return
+    attemptRecord.state = state
+    if (owed) attemptRecord.resultOwed = true
+    else delete attemptRecord.resultOwed
+    if (externalIds.length) attemptRecord.externalIds = externalIds
+    else delete attemptRecord.externalIds
     try {
       await turn.persist(true)
     } catch (err) {
       // A stateless durable attempt reads as unknown, which blocks the fallback — the safe direction.
       this.warn(`gitlab review: outcome persistence deferred (${err instanceof Error ? err.message : err})`)
     }
+  }
+
+  /** The result frame is durable or acknowledged, so the attempt no longer owes it. */
+  private async clearResultOwed(turn: GitlabReviewTurn): Promise<void> {
+    if (!turn.hook.codeReview?.resultOwed) return
+    delete turn.hook.codeReview.resultOwed
+    await turn.persist().catch(() => undefined)
   }
 
   /**
@@ -1163,13 +1288,22 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
    * are idempotent REQs, so replaying one the control plane already took is a no-op. A
    * permanently refused frame is dropped rather than replayed forever (§15.1).
    */
-  private async owe(cp: GitlabReviewControlPlane, row: ReviewIntentRow): Promise<void> {
-    // Relying on replay requires the row to EXIST: a frame whose durable write failed is
-    // kept in memory and its write retried on the same backoff, never warned away.
-    if (!(await this.persistIntent(row))) this.unwritten.set(row.intentId, row)
+  /**
+   * Owe one control-plane frame. Returns whether the chain may move on: true once the
+   * frame is durably recorded OR the control plane has answered it. While it is false the
+   * caller must KEEP its own upstream record, because that record is the only thing a
+   * restart could rebuild this frame from (§15.1).
+   */
+  private async owe(cp: GitlabReviewControlPlane, row: ReviewIntentRow): Promise<boolean> {
+    const durable = await this.persistIntent(row)
+    if (!durable) this.unwritten.set(row.intentId, row)
     const answer = await this.deliver(cp, row)
-    if (answer === 'retry') this.arm()
-    else await this.forget(row.intentId)
+    if (answer === 'retry') {
+      this.arm()
+      return durable
+    }
+    await this.forget(row.intentId)
+    return true
   }
 
   /** Bounded local-write retry; false means the row is only in memory for now. */
@@ -1248,6 +1382,8 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     const seen = new Set<string>()
     let outstanding = 0
     let unreadable = false
+    // Hitting the cap proves nothing about what is left, so the sweep stays armed.
+    let capped = true
     for (let page = 0; page < MAX_SWEEP_PAGES; page += 1) {
       let rows: ReviewIntentRow[]
       try {
@@ -1258,7 +1394,10 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
         break
       }
       const fresh = rows.filter((row) => !seen.has(row.intentId))
-      if (fresh.length === 0) break
+      if (fresh.length === 0) {
+        capped = false
+        break
+      }
       for (const row of fresh) {
         seen.add(row.intentId)
         outstanding += await this.replay(cp, row)
@@ -1271,7 +1410,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       await this.persistIntent(row)
       outstanding += await this.replay(cp, row)
     }
-    return unreadable ? undefined : outstanding
+    return unreadable || capped ? undefined : outstanding
   }
 
   /** Deliver one owed frame; 1 when it is still owed afterwards, 0 when it is finished with. */

--- a/packages/daemon/src/gitlab/review-adapter.ts
+++ b/packages/daemon/src/gitlab/review-adapter.ts
@@ -757,9 +757,9 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     }
     const draftId = op.target.split('/').at(-1) ?? ''
     const present = [...marked.values()].includes(draftId)
-    return present
-      ? { kind: 'deterministic', status: 422, code: 'draft_present' }
-      : { kind: 'deterministic', status: 204 }
+    if (present) return { kind: 'deterministic', status: 422, code: 'draft_present' }
+    // Naming the target is what upgrades a record this delete may have left ambiguous.
+    return { kind: 'deterministic', status: 204, ...(idOf(draftId) ? { externalId: draftId } : {}) }
   }
 
   /** RECORD-FIRST: the coordinates of the one permitted request, before it is permitted. */
@@ -821,7 +821,10 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     // A 404 is the same proven absence the delete was asking for.
     if (outcome.kind === 'rejected') return outcome.status === 404
     const remaining = await this.listDraftIds(attempt).catch(() => undefined)
-    return remaining !== undefined && !remaining.has(draftId)
+    if (remaining === undefined || remaining.has(draftId)) return false
+    // Read-after-ambiguous-delete proved the absence, so the record is upgraded, not left ambiguous.
+    await this.upgradeAmbiguous(cp, attempt, outcome.recordId, draftId, 204)
+    return true
   }
 
   private async deleteAttemptDrafts(cp: GitlabReviewControlPlane, attempt: Attempt): Promise<void> {
@@ -873,6 +876,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
         // A draft is not a public effect: re-read by marker instead of retrying the POST.
         const recovered = await this.findDraftByOrdinal(attempt, draft.ordinal)
         if (!recovered) return this.settle(cp, attempt, 'review_reconciliation_required')
+        await this.upgradeAmbiguous(cp, attempt, outcome.recordId, recovered, 201)
         attempt.drafts.set(draft.ordinal, recovered)
         continue
       }
@@ -943,11 +947,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       const note = await this.findSummaryNote(attempt).catch(() => undefined)
       if (note) {
         attempt.externalIds.push({ kind: 'note', externalId: note })
-        await this.settleAndClear(cp, attempt, outcome.recordId, {
-          kind: 'deterministic',
-          status: 201,
-          externalId: note
-        })
+        await this.upgradeAmbiguous(cp, attempt, outcome.recordId, note, 201)
         return 'published'
       }
       if (this.now() >= deadline) break
@@ -1028,22 +1028,21 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       sha: attempt.turn.expectedHeadSha
     })
     if (outcome.kind === 'rejected') return 'approval_not_recorded'
-    const approvalId = facts.numericId
     if (outcome.kind === 'sent' && this.approvalReadback(outcome.parsed, attempt)) {
+      const approvalId = facts.numericId ?? idOf(record(outcome.parsed).id)
       if (approvalId) attempt.externalIds.push({ kind: 'approval', externalId: approvalId })
       return 'submitted'
     }
     // Ambiguous or unconvincing: one read-only readback decides, and nothing retries.
     const readback = await this.get(attempt, this.mrPath(attempt.turn, '/approvals')).catch(() => undefined)
     if (!this.approvalReadback(readback, attempt)) return 'approval_not_recorded'
+    // An upgrade must name an object, so the readback's own id backs up the merge request's.
+    const approvalId = facts.numericId ?? idOf(record(readback).id)
     if (approvalId) attempt.externalIds.push({ kind: 'approval', externalId: approvalId })
     if (outcome.kind === 'ambiguous') {
+      if (!approvalId) return 'approval_not_recorded'
       // Positive identification of an ambiguous request, per §15.1's fourth condition.
-      await this.settleAndClear(cp, attempt, outcome.recordId, {
-        kind: 'deterministic',
-        status: 201,
-        ...(approvalId ? { externalId: approvalId } : {})
-      })
+      await this.upgradeAmbiguous(cp, attempt, outcome.recordId, approvalId, 201)
     }
     return 'submitted'
   }
@@ -1112,7 +1111,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
         result = await this.send(method, target, undefined, body, attempt.token)
       } catch (err) {
         if (err instanceof AmbiguousSend) {
-          await this.settleAndClear(cp, attempt, issued.recordId, { kind: 'ambiguous', code: err.code })
+          await this.settleAndClear(cp, attempt, issued.recordId, { kind: 'ambiguous', code: err.code }, true)
           return { kind: 'ambiguous', recordId: issued.recordId }
         }
         throw err
@@ -1214,11 +1213,29 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     cp: GitlabReviewControlPlane,
     attempt: Attempt,
     recordId: string,
-    outcome: CodeHostReviewOpOutcome
+    outcome: CodeHostReviewOpOutcome,
+    // An `ambiguous` record stays non-terminal until an upgrade names its object, so its
+    // coordinates are kept as the replay source for exactly that upgrade (§15.1).
+    retain = false
   ): Promise<void> {
     const disposition = await this.settleOperation(cp, attempt, recordId, outcome)
-    if (disposition === 'safe') await this.clearOperation(attempt, recordId)
+    if (disposition === 'safe' && !retain) await this.clearOperation(attempt, recordId)
     if (disposition === 'blocked') attempt.settleBlocked = true
+  }
+
+  /**
+   * Upgrade a positively identified ambiguous record to `settled` by naming the provider
+   * object. The control plane keeps an ambiguous record non-terminal until exactly this
+   * frame arrives, and retains the publication lease while one remains.
+   */
+  private async upgradeAmbiguous(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt,
+    recordId: string,
+    externalId: string,
+    status: number
+  ): Promise<void> {
+    await this.settleAndClear(cp, attempt, recordId, { kind: 'deterministic', status, externalId })
   }
 
   /** Record the terminal classification, releasing (or locking) the publication lease. */

--- a/packages/daemon/src/gitlab/review-adapter.ts
+++ b/packages/daemon/src/gitlab/review-adapter.ts
@@ -174,6 +174,17 @@ const OUTCOME_SENTENCE: Record<CodeHostReviewState, string> = {
     'Pending review drafts on this merge request could not be reconciled, so no review was published and this merge request stays fail-closed.'
 }
 
+/** What a settle left behind: nothing, replayable coordinates, or no replay source at all. */
+type SettleDisposition = 'safe' | 'replayable' | 'blocked'
+
+/** The terminal result is withheld until every unsafe settle has a durable replay source. */
+class ResultWithheld extends Error {
+  constructor() {
+    super('the formal review outcome could not be made durable yet; the daemon will retry before reporting it')
+    this.name = 'ResultWithheld'
+  }
+}
+
 class AmbiguousSend extends Error {
   constructor(readonly code: string) {
     super(`GitLab review request outcome is unknown (${code})`)
@@ -211,6 +222,14 @@ interface Session {
   token: string
 }
 
+/** What a ledger frame needs to name itself — an in-flight attempt or a recovered record. */
+interface LeaseRef {
+  turn: GitlabReviewTurn
+  attemptId: string
+  fence: string
+  orgId?: string
+}
+
 /** Everything one attempt carries between steps. */
 interface Attempt extends Session {
   req: SubmitCodeReviewReq
@@ -225,6 +244,8 @@ interface Attempt extends Session {
   drafts: Map<number, string>
   externalIds: CodeHostReviewExternalRef[]
   reviewerBefore?: ReviewerRecord
+  /** A settle this attempt owes has no durable replay source yet, so no result may be reported. */
+  settleBlocked?: boolean
 }
 
 function record(value: unknown): Record<string, unknown> {
@@ -394,7 +415,8 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       turn.state = codeHostReviewPublicEffect(outcome.state) === 'absent' ? 'idle' : 'done'
       return outcome
     } catch (err) {
-      turn.state = 'done'
+      // A withheld result leaves the turn open and the attempt pre-terminal, by design.
+      turn.state = err instanceof ResultWithheld ? 'idle' : 'done'
       throw err
     }
   }
@@ -595,13 +617,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
         outstanding.push(op)
         continue
       }
-      const owed = await this.settleOperation(
-        cp,
-        attempt,
-        op.recordId,
-        this.classifyDraftOperation(op, marked, attempt)
-      )
-      if (owed) await this.clearOperation(attempt, op.recordId)
+      await this.settleAndClear(cp, attempt, op.recordId, this.classifyDraftOperation(op, marked, attempt))
     }
     const publish = outstanding.find((op) => op.kind === 'bulk_publish')
     const approval = outstanding.find((op) => op.kind === 'approval')
@@ -611,31 +627,25 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     const note = await this.findSummaryNote(attempt).catch(() => undefined)
     if (publish) {
       if (!note) {
-        const owed = await this.settleOperation(cp, attempt, publish.recordId, {
-          kind: 'ambiguous',
-          code: 'publish_unreconciled'
-        })
-        if (owed) await this.clearOperation(attempt, publish.recordId)
+        await this.settleAndClear(cp, attempt, publish.recordId, { kind: 'ambiguous', code: 'publish_unreconciled' })
         return await this.settle(cp, attempt, 'ambiguous_locked')
       }
-      const owed = await this.settleOperation(cp, attempt, publish.recordId, {
+      await this.settleAndClear(cp, attempt, publish.recordId, {
         kind: 'deterministic',
         status: 201,
         externalId: note
       })
-      if (owed) await this.clearOperation(attempt, publish.recordId)
     }
     if (note) attempt.externalIds.push({ kind: 'note', externalId: note })
     if (approval) {
       const readback = await this.get(attempt, this.mrPath(attempt.turn, '/approvals')).catch(() => undefined)
       const approved = this.approvalReadback(readback, attempt)
       const approvalId = idOf(record(readback).id)
-      const owed = await this.settleOperation(cp, attempt, approval.recordId, {
+      await this.settleAndClear(cp, attempt, approval.recordId, {
         kind: 'deterministic',
         status: approved ? 201 : 422,
         ...(approved && approvalId ? { externalId: approvalId } : {})
       })
-      if (owed) await this.clearOperation(attempt, approval.recordId)
       if (approved && approvalId) attempt.externalIds.push({ kind: 'approval', externalId: approvalId })
       return await this.settle(cp, attempt, approved ? 'submitted' : 'approval_not_recorded')
     }
@@ -662,15 +672,15 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
    */
   private async returnUnused(
     cp: GitlabReviewControlPlane,
-    attempt: Attempt,
+    ref: LeaseRef,
     op: CodeReviewOperation
   ): Promise<'returned' | 'started' | 'deferred'> {
     try {
       await cp.operate(
-        { op: 'return-unused', attemptId: attempt.attemptId, fence: attempt.fence, recordId: op.recordId },
-        attempt.orgId
+        { op: 'return-unused', attemptId: ref.attemptId, fence: ref.fence, recordId: op.recordId },
+        ref.orgId
       )
-      await this.clearOperation(attempt, op.recordId)
+      await this.clearOperation(ref, op.recordId)
       return 'returned'
     } catch (err) {
       // A permanent refusal means the record moved on without this daemon; evidence decides.
@@ -692,13 +702,17 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     const fence = attemptRecord.fence
     const orgId = this.deps.orgForAgent(turn.agentId)
     if (fence) {
+      const ref: LeaseRef = { turn, attemptId: attemptRecord.attemptId, fence, ...(orgId ? { orgId } : {}) }
       for (const op of [...(attemptRecord.operations ?? [])]) {
-        if (op.phase !== 'issued') continue
-        await this.returnUnused(
-          cp,
-          { turn, attemptId: attemptRecord.attemptId, fence, ...(orgId ? { orgId } : {}) } as Attempt,
-          op
-        )
+        // An unstarted permit is handed back; a started one replays the outcome parked on it.
+        if (op.phase === 'issued') {
+          await this.returnUnused(cp, ref, op)
+          continue
+        }
+        if (!op.outcome) continue
+        if (await this.owe(cp, this.settleIntent(ref, op.recordId, op.outcome))) {
+          await this.clearOperation(ref, op.recordId)
+        }
       }
     }
     if (!attemptRecord.resultOwed || !attemptRecord.state) return
@@ -766,11 +780,11 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   }
 
   /** Settled, so the coordinates are no longer owed. A lost removal costs one idempotent re-settle. */
-  private async clearOperation(attempt: Attempt, recordId: string): Promise<void> {
-    const attemptRecord = attempt.turn.hook.codeReview
+  private async clearOperation(ref: LeaseRef, recordId: string): Promise<void> {
+    const attemptRecord = ref.turn.hook.codeReview
     if (!attemptRecord?.operations) return
     attemptRecord.operations = attemptRecord.operations.filter((op) => op.recordId !== recordId)
-    await attempt.turn.persist().catch(() => undefined)
+    await ref.turn.persist().catch(() => undefined)
   }
 
   /** §15.1 orphan recovery, run while holding the lease and before any create. */
@@ -929,7 +943,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       const note = await this.findSummaryNote(attempt).catch(() => undefined)
       if (note) {
         attempt.externalIds.push({ kind: 'note', externalId: note })
-        await this.settleOperation(cp, attempt, outcome.recordId, {
+        await this.settleAndClear(cp, attempt, outcome.recordId, {
           kind: 'deterministic',
           status: 201,
           externalId: note
@@ -1025,7 +1039,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     if (approvalId) attempt.externalIds.push({ kind: 'approval', externalId: approvalId })
     if (outcome.kind === 'ambiguous') {
       // Positive identification of an ambiguous request, per §15.1's fourth condition.
-      await this.settleOperation(cp, attempt, outcome.recordId, {
+      await this.settleAndClear(cp, attempt, outcome.recordId, {
         kind: 'deterministic',
         status: 201,
         ...(approvalId ? { externalId: approvalId } : {})
@@ -1098,23 +1112,18 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
         result = await this.send(method, target, undefined, body, attempt.token)
       } catch (err) {
         if (err instanceof AmbiguousSend) {
-          const owed = await this.settleOperation(cp, attempt, issued.recordId, {
-            kind: 'ambiguous',
-            code: err.code
-          })
-          if (owed) await this.clearOperation(attempt, issued.recordId)
+          await this.settleAndClear(cp, attempt, issued.recordId, { kind: 'ambiguous', code: err.code })
           return { kind: 'ambiguous', recordId: issued.recordId }
         }
         throw err
       }
       const authRejected = result.status === 401 || result.status === 403
       const externalId = idOf(record(result.parsed).id)
-      const owed = await this.settleOperation(cp, attempt, issued.recordId, {
+      await this.settleAndClear(cp, attempt, issued.recordId, {
         kind: 'deterministic',
         status: result.status,
         ...(externalId ? { externalId } : {})
       })
-      if (owed) await this.clearOperation(attempt, issued.recordId)
       if (result.status < 300) {
         return { kind: 'sent', status: result.status, parsed: result.parsed, recordId: issued.recordId }
       }
@@ -1153,25 +1162,63 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
    *  Returns whether the operation's own coordinates may now be forgotten. */
   private async settleOperation(
     cp: GitlabReviewControlPlane,
-    attempt: Attempt,
+    ref: LeaseRef,
     recordId: string,
     outcome: CodeHostReviewOpOutcome
-  ): Promise<boolean> {
-    return await this.owe(cp, {
-      intentId: `${attempt.attemptId}:op:${recordId}`,
+  ): Promise<SettleDisposition> {
+    const safe = await this.owe(cp, this.settleIntent(ref, recordId, outcome))
+    if (safe) return 'safe'
+    // Neither written nor acknowledged: the coordinates become the replay source instead.
+    return (await this.persistSettleOutcome(ref, recordId, outcome)) ? 'replayable' : 'blocked'
+  }
+
+  /** The one settle frame, built the same way whether it is owed now or replayed later. */
+  private settleIntent(ref: LeaseRef, recordId: string, outcome: CodeHostReviewOpOutcome): ReviewIntentRow {
+    return {
+      intentId: `${ref.attemptId}:op:${recordId}`,
       daemonId: this.deps.daemonId() ?? '',
-      attemptId: attempt.attemptId,
-      ...(attempt.orgId ? { orgId: attempt.orgId } : {}),
+      attemptId: ref.attemptId,
+      ...(ref.orgId ? { orgId: ref.orgId } : {}),
       kind: 'operation',
       frame: JSON.stringify({
         op: 'settle',
-        attemptId: attempt.attemptId,
-        fence: attempt.fence,
+        attemptId: ref.attemptId,
+        fence: ref.fence,
         recordId,
         outcome
       } satisfies CodeHostReviewOpRequest),
       attempts: 0
-    })
+    }
+  }
+
+  /** Park the exact outcome on the surviving coordinates so a restart can replay it blind. */
+  private async persistSettleOutcome(
+    ref: LeaseRef,
+    recordId: string,
+    outcome: CodeHostReviewOpOutcome
+  ): Promise<boolean> {
+    const op = ref.turn.hook.codeReview?.operations?.find((entry) => entry.recordId === recordId)
+    if (!op) return false
+    op.outcome = outcome
+    try {
+      await ref.turn.persist(true)
+      return true
+    } catch (err) {
+      this.warn(`gitlab review: settle outcome could not be parked (${err instanceof Error ? err.message : err})`)
+      return false
+    }
+  }
+
+  /** Owe the settle, then forget the coordinates only once something can replay it. */
+  private async settleAndClear(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt,
+    recordId: string,
+    outcome: CodeHostReviewOpOutcome
+  ): Promise<void> {
+    const disposition = await this.settleOperation(cp, attempt, recordId, outcome)
+    if (disposition === 'safe') await this.clearOperation(attempt, recordId)
+    if (disposition === 'blocked') attempt.settleBlocked = true
   }
 
   /** Record the terminal classification, releasing (or locking) the publication lease. */
@@ -1181,6 +1228,12 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     state: CodeHostReviewState
   ): Promise<GitlabReviewOutcome> {
     const externalIds = codeHostReviewPublicEffect(state) === 'absent' ? [] : attempt.externalIds
+    // No terminal result while a started operation has no durable replay source: the control
+    // plane would record the outcome and keep the lease on a record nothing can settle (§15.1).
+    if (attempt.settleBlocked) {
+      this.arm()
+      throw new ResultWithheld()
+    }
     // The durable single-writer gate first: only a PROVEN no-effect attempt may be followed
     // by the ordinary note, and a replay must read the same verdict this turn reached (§15.2).
     // The same record is the result frame's upstream entry, so it also marks it owed.

--- a/packages/daemon/src/gitlab/review-adapter.ts
+++ b/packages/daemon/src/gitlab/review-adapter.ts
@@ -1,0 +1,977 @@
+/**
+ * The GitLab formal merge-request review adapter (gitlab-com-integration.md §15).
+ *
+ * One attempt per active turn, under the Control Plane's durable publication
+ * lease: reconcile before create, marker-signed drafts created under single-use
+ * operation records, head and reviewer state re-verified around ONE bulk publish,
+ * tier-aware postcondition classification, and an approval fenced on the exact
+ * head. Every ambiguous effect fails closed — no republish, no ordinary fallback.
+ *
+ * The target project, merge-request IID, and head come from daemon-private
+ * active-turn state; they are never tool input. Review bodies never reach the
+ * Control Plane: the result frame carries ids and one normalized state only.
+ */
+import { randomUUID } from 'node:crypto'
+import {
+  codeHostReviewPublicEffect,
+  type CodeHostReviewAuthorize,
+  type CodeHostReviewAuthorized,
+  type CodeHostReviewExternalRef,
+  type CodeHostReviewLeaseRenew,
+  type CodeHostReviewLeaseRenewed,
+  type CodeHostReviewOpAccepted,
+  type CodeHostReviewOpKind,
+  type CodeHostReviewOpMethod,
+  type CodeHostReviewOpRequest,
+  type CodeHostReviewOpOutcome,
+  type CodeHostReviewResultOk,
+  type CodeHostReviewResultReport,
+  type CodeHostReviewState,
+  type HookConfigSnapshot
+} from '@agentconnect.md/protocol'
+import {
+  validateCodeReviewInput,
+  type CodeHostReviewAdapter,
+  type CodeReviewEvent,
+  type CodeReviewVerdict,
+  type SubmitCodeReviewReq
+} from '../codehost/review-adapter.js'
+import { reviewPolicyAllows, type HookDispatchContext } from '../github/hook-coords.js'
+import { appendGithubMarkdownChrome, githubAttributionFooter, type GithubCommentAttribution } from '../github/poster.js'
+import { parseGitlabJson } from './broker.js'
+import { ReviewMarkerSigner } from './review-marker.js'
+
+/** One authorized merge-request review turn; every field is trusted daemon state. */
+export interface GitlabReviewTurn {
+  hookId: string
+  agentId: string
+  deliveryKey: string
+  snapshot: HookConfigSnapshot
+  /** Numeric project id (decimal string) — the rename-stable match key. */
+  projectId: string
+  projectPath: string
+  mergeRequestIid: number
+  expectedHeadSha: string
+  expectedBaseSha?: string
+  sessionId: string
+  /** §15 step 1: one review attempt per turn, reserved synchronously. */
+  state: 'idle' | 'submitting' | 'done'
+}
+
+/** The narrow Control-Plane surface this adapter needs (§15.1 lease + operation ledger). */
+export interface GitlabReviewControlPlane {
+  /** The CP advertises `codehost-review-v1`; without it the adapter refuses before any effect. */
+  supportsReview(): boolean
+  authorize(payload: CodeHostReviewAuthorize, orgId?: string): Promise<CodeHostReviewAuthorized>
+  operate(payload: CodeHostReviewOpRequest, orgId?: string): Promise<CodeHostReviewOpAccepted>
+  renew(payload: CodeHostReviewLeaseRenew, orgId?: string): Promise<CodeHostReviewLeaseRenewed>
+  report(payload: CodeHostReviewResultReport, orgId?: string): Promise<CodeHostReviewResultOk>
+}
+
+export interface GitlabReviewAdapterDeps {
+  cp: () => GitlabReviewControlPlane | undefined
+  orgForAgent: (agentId: string) => string | undefined
+  /** §14.1 effect lease: the binding's effect PAT; it never enters the agent environment. */
+  token: (turn: GitlabReviewTurn) => Promise<string>
+  invalidateToken: (turn: GitlabReviewTurn, token: string) => void
+  attribution?: (turn: GitlabReviewTurn) => Promise<GithubCommentAttribution | undefined>
+  log: { warn: (message: string) => void }
+  baseUrl?: string
+  fetchImpl?: typeof fetch
+  /** Daemon-local marker key; see the trust model on {@link ReviewMarkerSigner}. */
+  markerKey?: Buffer
+  newAttemptId?: () => string
+  newStartToken?: () => string
+  now?: () => number
+  sleep?: (ms: number) => Promise<void>
+  /** §15.2 bounded observation window for an ambiguous bulk publish. */
+  ambiguousWindowMs?: number
+  /** §15.2/§15 step 13 bounded wait for `detailed_merge_status` to leave its unstable values. */
+  mergeStatusWindowMs?: number
+  pollIntervalMs?: number
+}
+
+/** The model-visible outcome: one normalized state plus a plain-English sentence. */
+export interface GitlabReviewOutcome {
+  provider: 'gitlab'
+  state: CodeHostReviewState
+  event: CodeReviewEvent
+  verdict: CodeReviewVerdict
+  message: string
+  externalIds?: CodeHostReviewExternalRef[]
+}
+
+const DEFAULT_BASE_URL = 'https://gitlab.com/api/v4'
+const DEFAULT_TIMEOUT_MS = 20_000
+const DEFAULT_AMBIGUOUS_WINDOW_MS = 30_000
+const DEFAULT_MERGE_STATUS_WINDOW_MS = 30_000
+const DEFAULT_POLL_INTERVAL_MS = 2_000
+const MAX_NOTE_PAGES = 10
+const NOTES_PER_PAGE = 100
+const MAX_DRAFTS = 100
+
+/** Merge-status values that mean "GitLab has not finished computing"; never read a verdict from them. */
+const UNSTABLE_MERGE_STATUS = new Set(['checking', 'approvals_syncing', 'unchecked', 'preparing'])
+
+/** One English sentence per normalized state, so the tool result mirrors §15.2 exactly. */
+const OUTCOME_SENTENCE: Record<CodeHostReviewState, string> = {
+  submitted: 'The formal review was published on the merge request.',
+  not_submitted: 'No review was published; nothing was changed on the merge request.',
+  ambiguous_locked:
+    'GitLab did not confirm the publication and no review marker became visible, so this merge request is locked against further automated review attempts and no fallback comment was posted.',
+  approval_not_recorded:
+    'The review comments were published but the approval was not recorded; do not re-run the approval automatically.',
+  review_state_not_recorded:
+    'The review was published but GitLab did not report the resulting reviewer state, so the recorded state is unknown.',
+  review_state_changed_unexpectedly:
+    'The review was published but the reviewer state changed unexpectedly, so the recorded state is unknown.',
+  requested_changes_block_observed:
+    'The review was published and the merge request is currently blocked by a change request.',
+  requested_changes_state_ambiguous:
+    'The review was published but GitLab did not confirm the requested-changes state, so it may or may not be blocking.',
+  reviewer_assignment_required:
+    'REQUEST_CHANGES needs the project service account to be a current reviewer; ask a user to request a review through GitLab, or record the finding with COMMENT and verdict fail.',
+  review_reconciliation_required:
+    'Pending review drafts on this merge request could not be reconciled, so no review was published and this merge request stays fail-closed.'
+}
+
+class AmbiguousSend extends Error {
+  constructor(readonly code: string) {
+    super(`GitLab review request outcome is unknown (${code})`)
+    this.name = 'AmbiguousSend'
+  }
+}
+
+interface SendResult {
+  status: number
+  parsed: unknown
+}
+
+interface DraftNote {
+  id: string
+  note: string
+}
+
+interface ReviewerRecord {
+  userId: string
+  state?: string
+}
+
+interface MergeRequestFacts {
+  headSha: string
+  baseSha?: string
+  startSha?: string
+  state?: string
+  detailedMergeStatus?: string
+  numericId?: string
+}
+
+/** The turn plus its live effect token; the token is re-minted in place on a refresh. */
+interface Session {
+  turn: GitlabReviewTurn
+  token: string
+}
+
+/** Everything one attempt carries between steps. */
+interface Attempt extends Session {
+  req: SubmitCodeReviewReq
+  orgId?: string
+  attemptId: string
+  fence: string
+  serviceAccountUserId: string
+  /** Per-kind monotonic operation-record counter; a retried mutation takes the next one. */
+  ordinals: Map<CodeHostReviewOpKind, number>
+  /** Draft ordinal (0 = summary) → provider draft id, for the exact-set check. */
+  drafts: Map<number, string>
+  externalIds: CodeHostReviewExternalRef[]
+  reviewerBefore?: ReviewerRecord
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+}
+
+/** A big-int-safe numeric id as a decimal string; undefined when the value is not one. */
+function idOf(value: unknown): string | undefined {
+  if (typeof value === 'string' && /^[1-9]\d*$/.test(value)) return value
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return String(value)
+  return undefined
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function mergeRequestFacts(parsed: unknown): MergeRequestFacts | undefined {
+  const mr = record(parsed)
+  const refs = record(mr.diff_refs)
+  const headSha = text(mr.sha) ?? text(refs.head_sha)
+  if (!headSha) return undefined
+  return {
+    headSha,
+    ...(text(refs.base_sha) ? { baseSha: text(refs.base_sha)! } : {}),
+    ...(text(refs.start_sha) ? { startSha: text(refs.start_sha)! } : {}),
+    ...(text(mr.state) ? { state: text(mr.state)! } : {}),
+    ...(text(mr.detailed_merge_status) ? { detailedMergeStatus: text(mr.detailed_merge_status)! } : {}),
+    ...(idOf(mr.id) ? { numericId: idOf(mr.id)! } : {})
+  }
+}
+
+function reviewerRecords(parsed: unknown): ReviewerRecord[] {
+  if (!Array.isArray(parsed)) return []
+  return parsed.flatMap((row) => {
+    const entry = record(row)
+    const userId = idOf(record(entry.user).id)
+    if (!userId) return []
+    return [{ userId, ...(text(entry.state) ? { state: text(entry.state)! } : {}) }]
+  })
+}
+
+function draftNotes(parsed: unknown): DraftNote[] {
+  if (!Array.isArray(parsed)) return []
+  return parsed.slice(0, MAX_DRAFTS).flatMap((row) => {
+    const entry = record(row)
+    const id = idOf(entry.id)
+    return id ? [{ id, note: text(entry.note) ?? '' }] : []
+  })
+}
+
+export class GitlabReviewAdapter implements CodeHostReviewAdapter {
+  readonly provider = 'gitlab' as const
+
+  private readonly turns = new Map<string, GitlabReviewTurn>()
+  private readonly signer: ReviewMarkerSigner
+  private readonly now: () => number
+  private readonly sleep: (ms: number) => Promise<void>
+
+  constructor(private readonly deps: GitlabReviewAdapterDeps) {
+    this.signer = new ReviewMarkerSigner(deps.markerKey)
+    this.now = deps.now ?? (() => Date.now())
+    this.sleep = deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+  }
+
+  /**
+   * Install the active review turn for one logical session key. Returns undefined
+   * for every delivery that is not an authorized merge-request review generation.
+   */
+  openTurn(
+    key: string,
+    hook: HookDispatchContext | undefined,
+    sessionId: string,
+    daemonId?: string
+  ): GitlabReviewTurn | undefined {
+    const gitlab = hook?.gitlab
+    const snapshot = hook?.snapshot
+    if (!hook || !gitlab || !snapshot || snapshot.reviewPolicy === 'off') return undefined
+    if (gitlab.target.kind !== 'merge_request' || !gitlab.target.headSha) return undefined
+    if (daemonId && snapshot.dispatchDaemonId !== daemonId) return undefined
+    const turn: GitlabReviewTurn = {
+      hookId: hook.hookId,
+      agentId: hook.agentId,
+      deliveryKey: hook.deliveryKey,
+      snapshot,
+      projectId: gitlab.projectId,
+      projectPath: gitlab.projectPath,
+      mergeRequestIid: gitlab.target.iid,
+      expectedHeadSha: gitlab.target.headSha,
+      ...(gitlab.target.baseSha ? { expectedBaseSha: gitlab.target.baseSha } : {}),
+      sessionId,
+      state: 'idle'
+    }
+    this.turns.set(key, turn)
+    return turn
+  }
+
+  closeTurn(key: string, turn?: GitlabReviewTurn): void {
+    if (turn && this.turns.get(key) !== turn) return
+    this.turns.delete(key)
+  }
+
+  owns(key: string, agentId: string): boolean {
+    return this.turns.get(key)?.agentId === agentId
+  }
+
+  async submit(key: string, req: SubmitCodeReviewReq): Promise<GitlabReviewOutcome> {
+    const turn = this.turns.get(key)
+    if (!turn || turn.agentId !== req.agentId) {
+      throw new Error('a formal GitLab review is only available during the active merge-request hook turn')
+    }
+    // §15: an incompatible pair or unusable body is rejected before any provider effect.
+    const invalid = validateCodeReviewInput(req)
+    if (invalid) throw new Error(invalid)
+    if (!reviewPolicyAllows(turn.snapshot.reviewPolicy, req.event)) {
+      throw new Error(`${req.event} exceeds this hook's ${turn.snapshot.reviewPolicy} review policy`)
+    }
+    if (turn.state !== 'idle') throw new Error('this merge-request hook turn already has a formal review attempt')
+    // §15 step 1: turn-local CAS before the first await.
+    turn.state = 'submitting'
+    const cp = this.deps.cp()
+    if (!cp) {
+      turn.state = 'done'
+      throw new Error('control plane is not connected; formal review denied')
+    }
+    if (!cp.supportsReview()) {
+      turn.state = 'done'
+      throw new Error('the control plane does not serve formal code-host reviews yet (codehost-review-v1)')
+    }
+    try {
+      const outcome = await this.run(turn, req, cp)
+      // A proven no-effect outcome leaves the turn free to correct its input and retry.
+      turn.state = codeHostReviewPublicEffect(outcome.state) === 'absent' ? 'idle' : 'done'
+      return outcome
+    } catch (err) {
+      turn.state = 'done'
+      throw err
+    }
+  }
+
+  private async run(
+    turn: GitlabReviewTurn,
+    req: SubmitCodeReviewReq,
+    cp: GitlabReviewControlPlane
+  ): Promise<GitlabReviewOutcome> {
+    const orgId = this.deps.orgForAgent(turn.agentId)
+    const attemptId = (this.deps.newAttemptId ?? randomUUID)()
+    const session: Session = { turn, token: await this.deps.token(turn) }
+
+    // Read pre-lease so the authz can carry the §15 step 6/7 reviewer fact and prove the leased account is ours.
+    const serviceAccountUserId = idOf(record(await this.get(session, '/user')).id)
+    if (!serviceAccountUserId) throw new Error('GitLab did not identify the review publishing account')
+    const reviewersBefore = reviewerRecords(await this.get(session, this.mrPath(turn, '/reviewers')))
+    const reviewerBefore = reviewersBefore.find((row) => row.userId === serviceAccountUserId)
+
+    // §15 steps 2-3: the durable publication lease and the CP's authorization in one round trip.
+    const authorized = await cp.authorize(
+      {
+        hookId: turn.hookId,
+        deliveryKey: turn.deliveryKey,
+        attemptId,
+        provider: 'gitlab',
+        projectId: turn.projectId,
+        mergeRequestIid: turn.mergeRequestIid,
+        requestedEvent: req.event,
+        requestedVerdict: req.verdict,
+        snapshot: turn.snapshot,
+        headSha: turn.expectedHeadSha,
+        ...(turn.expectedBaseSha ? { baseSha: turn.expectedBaseSha } : {}),
+        serviceAccountIsReviewer: reviewerBefore !== undefined
+      },
+      orgId
+    )
+    if (!authorized.authorized) return this.refused(req, authorized)
+    if (
+      authorized.projectId !== turn.projectId ||
+      authorized.mergeRequestIid !== turn.mergeRequestIid ||
+      authorized.expectedHeadSha !== turn.expectedHeadSha
+    ) {
+      throw new Error('control plane returned a mismatched formal-review target')
+    }
+
+    const attempt: Attempt = {
+      turn,
+      req,
+      ...(orgId ? { orgId } : {}),
+      attemptId,
+      fence: authorized.lease.fence,
+      token: session.token,
+      serviceAccountUserId,
+      ordinals: new Map(),
+      drafts: new Map(),
+      externalIds: [],
+      ...(reviewerBefore ? { reviewerBefore } : {})
+    }
+    // The leased publishing identity must be the account this effect token speaks as.
+    if (authorized.lease.serviceAccountUserId !== serviceAccountUserId) {
+      return this.settle(cp, attempt, 'not_submitted')
+    }
+    return await this.publish(cp, attempt)
+  }
+
+  private async publish(cp: GitlabReviewControlPlane, attempt: Attempt): Promise<GitlabReviewOutcome> {
+    const { turn, req } = attempt
+
+    // §15 step 4: reconcile every pending draft this account owns before creating one.
+    const reconciled = await this.reconcileDrafts(cp, attempt)
+    if (reconciled) return reconciled
+
+    // §15 step 5: re-fetch the merge request and reject a changed head.
+    const before = mergeRequestFacts(await this.get(attempt, this.mrPath(turn)))
+    if (!before) throw new Error('GitLab did not return the merge request revision')
+    if (before.headSha !== turn.expectedHeadSha) return this.settle(cp, attempt, 'not_submitted')
+
+    // §15 step 10 is the authoritative reviewer read; step 6/7 already ran pre-lease.
+    if (req.event === 'REQUEST_CHANGES' && attempt.reviewerBefore === undefined) {
+      return this.settle(cp, attempt, 'reviewer_assignment_required')
+    }
+
+    // §15 step 8: the summary rides draft ordinal 0, so ONE bulk publish leaves its marker on a published note.
+    const created = await this.createDrafts(cp, attempt, before)
+    if (created) return created
+
+    // §15 step 9: the current attempt must own the complete, exact draft set.
+    if (!(await this.draftSetIsExact(attempt))) {
+      return this.settle(cp, attempt, 'review_reconciliation_required')
+    }
+
+    // §15 step 10: reviewer state immediately before publication.
+    const reviewerNow = await this.readReviewer(attempt)
+    if (req.event === 'REQUEST_CHANGES' && reviewerNow === undefined) {
+      await this.deleteAttemptDrafts(cp, attempt)
+      return this.settle(cp, attempt, 'reviewer_assignment_required')
+    }
+
+    // §15 step 11: renew the lease, re-verify head and fence, re-list drafts, publish once.
+    const renewed = await cp.renew({ attemptId: attempt.attemptId, fence: attempt.fence }, attempt.orgId)
+    if (renewed.phase === 'ambiguous_locked') return this.settle(cp, attempt, 'ambiguous_locked')
+    attempt.fence = renewed.fence
+    const atPublish = mergeRequestFacts(await this.get(attempt, this.mrPath(turn)))
+    if (!atPublish || atPublish.headSha !== turn.expectedHeadSha) {
+      await this.deleteAttemptDrafts(cp, attempt)
+      return this.settle(cp, attempt, 'not_submitted')
+    }
+    if (!(await this.draftSetIsExact(attempt))) {
+      return this.settle(cp, attempt, 'review_reconciliation_required')
+    }
+
+    const published = await this.bulkPublish(cp, attempt)
+    if (published !== 'published') return this.settle(cp, attempt, published)
+
+    // §15 step 12: classify the postcondition from reviewer state and mergeability.
+    const postcondition = await this.classifyPostcondition(attempt, reviewerNow)
+    if (postcondition !== 'submitted') return this.settle(cp, attempt, postcondition)
+
+    // §15 step 13: APPROVE only after the unchanged-state postcondition holds.
+    if (req.event === 'APPROVE') {
+      return this.settle(cp, attempt, await this.approve(cp, attempt, atPublish))
+    }
+    return this.settle(cp, attempt, 'submitted')
+  }
+
+  /** §15.1 orphan recovery, run while holding the lease and before any create. */
+  private async reconcileDrafts(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt
+  ): Promise<GitlabReviewOutcome | undefined> {
+    const { turn } = attempt
+    const pending = draftNotes(await this.get(attempt, this.mrPath(turn, '/draft_notes')))
+    const stale: string[] = []
+    for (const draft of pending) {
+      const marker = this.signer.read(draft.note, turn.expectedHeadSha)
+      // Unmarked, invalid, or unverifiable: nothing proves what it is, so fail closed.
+      if (!marker) return this.settle(cp, attempt, 'review_reconciliation_required')
+      if (marker.attemptId === attempt.attemptId.toLowerCase()) {
+        attempt.drafts.set(marker.ordinal, draft.id)
+        continue
+      }
+      // The grant certifies every prior attempt here was classified, so a signed foreign draft is expired (§15.1).
+      stale.push(draft.id)
+    }
+    for (const draftId of stale) {
+      const deleted = await this.deleteDraft(cp, attempt, draftId)
+      if (!deleted) return this.settle(cp, attempt, 'review_reconciliation_required')
+    }
+    return undefined
+  }
+
+  /** Delete one stale draft, with the read-after-ambiguous-delete §15.1 requires. */
+  private async deleteDraft(cp: GitlabReviewControlPlane, attempt: Attempt, draftId: string): Promise<boolean> {
+    const path = this.mrPath(attempt.turn, `/draft_notes/${draftId}`)
+    const outcome = await this.mutate(cp, attempt, 'draft_delete', 'DELETE', path, undefined)
+    if (outcome.kind === 'sent') return true
+    // A 404 is the same proven absence the delete was asking for.
+    if (outcome.kind === 'rejected') return outcome.status === 404
+    const remaining = await this.listDraftIds(attempt).catch(() => undefined)
+    return remaining !== undefined && !remaining.has(draftId)
+  }
+
+  private async deleteAttemptDrafts(cp: GitlabReviewControlPlane, attempt: Attempt): Promise<void> {
+    for (const draftId of [...attempt.drafts.values()]) {
+      await this.deleteDraft(cp, attempt, draftId).catch(() => false)
+    }
+    attempt.drafts.clear()
+  }
+
+  /** §15 step 8: one regular summary draft plus one diff draft per inline comment. */
+  private async createDrafts(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt,
+    facts: MergeRequestFacts
+  ): Promise<GitlabReviewOutcome | undefined> {
+    const { turn, req } = attempt
+    const attribution = await this.deps.attribution?.(turn)
+    const bodies: Array<{ ordinal: number; note: string; position?: Record<string, unknown> }> = []
+    if (!attempt.drafts.has(0)) {
+      bodies.push({
+        ordinal: 0,
+        note: this.render(req.body, attribution, this.signer.mint(attempt.attemptId, 0, turn.expectedHeadSha))
+      })
+    }
+    ;(req.comments ?? []).forEach((comment, index) => {
+      const ordinal = index + 1
+      if (attempt.drafts.has(ordinal)) return
+      bodies.push({
+        ordinal,
+        note: `${ReviewMarkerSigner.neutralize(comment.body)}\n\n${this.signer.mint(attempt.attemptId, ordinal, turn.expectedHeadSha)}`,
+        position: diffPosition(comment, facts)
+      })
+    })
+    for (const draft of bodies) {
+      const outcome = await this.mutate(cp, attempt, 'draft_create', 'POST', this.mrPath(turn, '/draft_notes'), {
+        note: draft.note,
+        ...(draft.position ? { position: draft.position } : {})
+      })
+      if (outcome.kind === 'rejected') {
+        await this.deleteAttemptDrafts(cp, attempt)
+        return this.settle(cp, attempt, 'not_submitted')
+      }
+      if (outcome.kind === 'ambiguous') {
+        // A draft is not a public effect: re-read by marker instead of retrying the POST.
+        const recovered = await this.findDraftByOrdinal(attempt, draft.ordinal)
+        if (!recovered) return this.settle(cp, attempt, 'review_reconciliation_required')
+        attempt.drafts.set(draft.ordinal, recovered)
+        continue
+      }
+      const draftId = idOf(record(outcome.parsed).id)
+      if (!draftId) return this.settle(cp, attempt, 'review_reconciliation_required')
+      attempt.drafts.set(draft.ordinal, draftId)
+    }
+    return undefined
+  }
+
+  private async findDraftByOrdinal(attempt: Attempt, ordinal: number): Promise<string | undefined> {
+    const pending = draftNotes(await this.get(attempt, this.mrPath(attempt.turn, '/draft_notes')).catch(() => []))
+    for (const draft of pending) {
+      const marker = this.signer.read(draft.note, attempt.turn.expectedHeadSha)
+      if (marker?.attemptId === attempt.attemptId.toLowerCase() && marker.ordinal === ordinal) return draft.id
+    }
+    return undefined
+  }
+
+  private async listDraftIds(attempt: Attempt): Promise<Set<string>> {
+    const pending = draftNotes(await this.get(attempt, this.mrPath(attempt.turn, '/draft_notes')))
+    return new Set(pending.map((draft) => draft.id))
+  }
+
+  /** §15 step 9/11: every pending draft carries this attempt's marker and the ordinal set is exact. */
+  private async draftSetIsExact(attempt: Attempt): Promise<boolean> {
+    const pending = draftNotes(
+      await this.get(attempt, this.mrPath(attempt.turn, '/draft_notes')).catch(() => undefined)
+    )
+    if (pending.length !== attempt.drafts.size) return false
+    const seen = new Set<number>()
+    for (const draft of pending) {
+      const marker = this.signer.read(draft.note, attempt.turn.expectedHeadSha)
+      if (!marker || marker.attemptId !== attempt.attemptId.toLowerCase()) return false
+      if (attempt.drafts.get(marker.ordinal) !== draft.id) return false
+      seen.add(marker.ordinal)
+    }
+    return seen.size === attempt.drafts.size
+  }
+
+  private async readReviewer(attempt: Attempt): Promise<ReviewerRecord | undefined> {
+    const rows = reviewerRecords(await this.get(attempt, this.mrPath(attempt.turn, '/reviewers')))
+    return rows.find((row) => row.userId === attempt.serviceAccountUserId)
+  }
+
+  /** §15 step 11 + §15.2: ONE bulk publish, then marker-first recovery when it is unknown. */
+  private async bulkPublish(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt
+  ): Promise<'published' | 'not_submitted' | 'ambiguous_locked'> {
+    const outcome = await this.mutate(
+      cp,
+      attempt,
+      'bulk_publish',
+      'POST',
+      this.mrPath(attempt.turn, '/draft_notes/bulk_publish'),
+      attempt.req.event === 'REQUEST_CHANGES' ? { reviewer_state: 'requested_changes' } : {}
+    )
+    if (outcome.kind === 'rejected') return 'not_submitted'
+    if (outcome.kind === 'sent') {
+      const note = await this.findSummaryNote(attempt).catch(() => undefined)
+      if (note) attempt.externalIds.push({ kind: 'note', externalId: note })
+      return 'published'
+    }
+    // §15.2: retain ownership and search the merge request for THIS attempt's summary marker.
+    const deadline = this.now() + (this.deps.ambiguousWindowMs ?? DEFAULT_AMBIGUOUS_WINDOW_MS)
+    for (;;) {
+      const note = await this.findSummaryNote(attempt).catch(() => undefined)
+      if (note) {
+        attempt.externalIds.push({ kind: 'note', externalId: note })
+        await this.settleOperation(cp, attempt, outcome.recordId, {
+          kind: 'deterministic',
+          status: 201,
+          externalId: note
+        })
+        return 'published'
+      }
+      if (this.now() >= deadline) break
+      await this.sleep(this.deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS)
+    }
+    return 'ambiguous_locked'
+  }
+
+  private async findSummaryNote(attempt: Attempt): Promise<string | undefined> {
+    for (let page = 1; page <= MAX_NOTE_PAGES; page += 1) {
+      const parsed = await this.get(
+        attempt,
+        this.mrPath(attempt.turn, '/notes'),
+        `per_page=${NOTES_PER_PAGE}&page=${page}`
+      )
+      if (!Array.isArray(parsed)) return undefined
+      for (const row of parsed) {
+        const note = record(row)
+        const marker = this.signer.read(text(note.body), attempt.turn.expectedHeadSha)
+        if (marker?.attemptId === attempt.attemptId.toLowerCase() && marker.ordinal === 0) return idOf(note.id)
+      }
+      if (parsed.length < NOTES_PER_PAGE) return undefined
+    }
+    return undefined
+  }
+
+  /** §15 step 12 / §15.2: publication success alone never proves the recorded state. */
+  private async classifyPostcondition(
+    attempt: Attempt,
+    before: ReviewerRecord | undefined
+  ): Promise<CodeHostReviewState> {
+    let after: ReviewerRecord | undefined
+    try {
+      after = await this.readReviewer(attempt)
+    } catch {
+      return attempt.req.event === 'REQUEST_CHANGES' ? 'requested_changes_state_ambiguous' : 'review_state_not_recorded'
+    }
+    if (attempt.req.event !== 'REQUEST_CHANGES') {
+      if (before === undefined && after === undefined) return 'submitted'
+      if (before !== undefined && after !== undefined && before.state === after.state) return 'submitted'
+      return 'review_state_changed_unexpectedly'
+    }
+    if (after?.state === 'requested_changes') return 'submitted'
+    // Reviewer absence is NOT evidence of failure: GitLab persists the block separately.
+    const status = await this.stableMergeStatus(attempt, true)
+    if (status === 'requested_changes') return 'requested_changes_block_observed'
+    return 'requested_changes_state_ambiguous'
+  }
+
+  /** Read `detailed_merge_status` after it leaves its unstable values, optionally forcing a recheck. */
+  private async stableMergeStatus(attempt: Attempt, recheck: boolean): Promise<string | undefined> {
+    const deadline = this.now() + (this.deps.mergeStatusWindowMs ?? DEFAULT_MERGE_STATUS_WINDOW_MS)
+    for (;;) {
+      const facts = mergeRequestFacts(
+        await this.get(
+          attempt,
+          this.mrPath(attempt.turn),
+          recheck ? 'with_merge_status_recheck=true' : undefined
+        ).catch(() => undefined)
+      )
+      const status = facts?.detailedMergeStatus
+      if (status !== undefined && !UNSTABLE_MERGE_STATUS.has(status)) return status
+      if (this.now() >= deadline) return undefined
+      await this.sleep(this.deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS)
+    }
+  }
+
+  /** §15 step 13: the SHA-fenced approval, and its readback. A failure here never falls back. */
+  private async approve(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt,
+    facts: MergeRequestFacts
+  ): Promise<CodeHostReviewState> {
+    const status = await this.stableMergeStatus(attempt, false)
+    if (status === undefined) return 'approval_not_recorded'
+    if (!(await this.diffIsReady(attempt))) return 'approval_not_recorded'
+    const outcome = await this.mutate(cp, attempt, 'approval', 'POST', this.mrPath(attempt.turn, '/approve'), {
+      sha: attempt.turn.expectedHeadSha
+    })
+    if (outcome.kind === 'rejected') return 'approval_not_recorded'
+    const approvalId = facts.numericId
+    if (outcome.kind === 'sent' && this.approvalReadback(outcome.parsed, attempt)) {
+      if (approvalId) attempt.externalIds.push({ kind: 'approval', externalId: approvalId })
+      return 'submitted'
+    }
+    // Ambiguous or unconvincing: one read-only readback decides, and nothing retries.
+    const readback = await this.get(attempt, this.mrPath(attempt.turn, '/approvals')).catch(() => undefined)
+    if (!this.approvalReadback(readback, attempt)) return 'approval_not_recorded'
+    if (approvalId) attempt.externalIds.push({ kind: 'approval', externalId: approvalId })
+    if (outcome.kind === 'ambiguous') {
+      // Positive identification of an ambiguous request, per §15.1's fourth condition.
+      await this.settleOperation(cp, attempt, outcome.recordId, {
+        kind: 'deterministic',
+        status: 201,
+        ...(approvalId ? { externalId: approvalId } : {})
+      })
+    }
+    return 'submitted'
+  }
+
+  /** The approval endpoint needs a settled diff; a null `patch_id_sha` means GitLab is still computing. */
+  private async diffIsReady(attempt: Attempt): Promise<boolean> {
+    const deadline = this.now() + (this.deps.mergeStatusWindowMs ?? DEFAULT_MERGE_STATUS_WINDOW_MS)
+    for (;;) {
+      const versions = await this.get(attempt, this.mrPath(attempt.turn, '/versions')).catch(() => undefined)
+      const latest = Array.isArray(versions) ? record(versions[0]) : {}
+      if (text(latest.patch_id_sha)) return true
+      if (this.now() >= deadline) return false
+      await this.sleep(this.deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS)
+    }
+  }
+
+  private approvalReadback(parsed: unknown, attempt: Attempt): boolean {
+    const body = record(parsed)
+    const sha = text(body.sha)
+    if (sha !== undefined && sha !== attempt.turn.expectedHeadSha) return false
+    const approvers = Array.isArray(body.approved_by) ? body.approved_by : []
+    return approvers.some((row) => idOf(record(record(row).user).id) === attempt.serviceAccountUserId)
+  }
+
+  /**
+   * One provider mutation under one single-use operation record: issue → start →
+   * one outbound request → settle. A definite 401/403 buys exactly ONE lease
+   * refresh, and the retry runs under a NEW record — one record permits one request.
+   */
+  private async mutate(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt,
+    kind: CodeHostReviewOpKind,
+    method: CodeHostReviewOpMethod,
+    target: string,
+    body: Record<string, unknown> | undefined
+  ): Promise<
+    | { kind: 'sent'; status: number; parsed: unknown; recordId: string }
+    | { kind: 'rejected'; status: number; recordId: string }
+    | { kind: 'ambiguous'; recordId: string }
+  > {
+    for (let attemptNo = 0; attemptNo < 2; attemptNo += 1) {
+      const ordinal = attempt.ordinals.get(kind) ?? 0
+      attempt.ordinals.set(kind, ordinal + 1)
+      const issued = await cp.operate(
+        { op: 'issue', attemptId: attempt.attemptId, fence: attempt.fence, kind, method, target, ordinal },
+        attempt.orgId
+      )
+      const startToken = (this.deps.newStartToken ?? randomUUID)()
+      await this.startOperation(cp, attempt, issued.recordId, startToken)
+      let result: SendResult
+      try {
+        result = await this.send(method, target, undefined, body, attempt.token)
+      } catch (err) {
+        if (err instanceof AmbiguousSend) {
+          await this.settleOperation(cp, attempt, issued.recordId, { kind: 'ambiguous', code: err.code })
+          return { kind: 'ambiguous', recordId: issued.recordId }
+        }
+        throw err
+      }
+      const authRejected = result.status === 401 || result.status === 403
+      const externalId = idOf(record(result.parsed).id)
+      await this.settleOperation(cp, attempt, issued.recordId, {
+        kind: 'deterministic',
+        status: result.status,
+        ...(externalId ? { externalId } : {})
+      })
+      if (result.status < 300) {
+        return { kind: 'sent', status: result.status, parsed: result.parsed, recordId: issued.recordId }
+      }
+      if (!authRejected || attemptNo === 1) {
+        return { kind: 'rejected', status: result.status, recordId: issued.recordId }
+      }
+      this.deps.invalidateToken(attempt.turn, attempt.token)
+      attempt.token = await this.deps.token(attempt.turn)
+    }
+    throw new Error('GitLab review mutation exhausted its single authorization refresh')
+  }
+
+  /** `startToken` names the one intended request, so a lost reply is retransmitted with the SAME token. */
+  private async startOperation(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt,
+    recordId: string,
+    startToken: string
+  ): Promise<void> {
+    let last: unknown
+    for (let tries = 0; tries < 2; tries += 1) {
+      try {
+        await cp.operate(
+          { op: 'start', attemptId: attempt.attemptId, fence: attempt.fence, recordId, startToken },
+          attempt.orgId
+        )
+        return
+      } catch (err) {
+        last = err
+      }
+    }
+    throw last instanceof Error ? last : new Error('the control plane refused to start the review operation')
+  }
+
+  private async settleOperation(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt,
+    recordId: string,
+    outcome: CodeHostReviewOpOutcome
+  ): Promise<void> {
+    try {
+      await cp.operate(
+        { op: 'settle', attemptId: attempt.attemptId, fence: attempt.fence, recordId, outcome },
+        attempt.orgId
+      )
+    } catch (err) {
+      this.deps.log.warn(`gitlab review: operation settle deferred (${err instanceof Error ? err.message : err})`)
+    }
+  }
+
+  /** Record the terminal classification, releasing (or locking) the publication lease. */
+  private async settle(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt,
+    state: CodeHostReviewState
+  ): Promise<GitlabReviewOutcome> {
+    const externalIds = codeHostReviewPublicEffect(state) === 'absent' ? [] : attempt.externalIds
+    try {
+      await cp.report(
+        {
+          hookId: attempt.turn.hookId,
+          deliveryKey: attempt.turn.deliveryKey,
+          attemptId: attempt.attemptId,
+          snapshot: attempt.turn.snapshot,
+          provider: 'gitlab',
+          projectId: attempt.turn.projectId,
+          mergeRequestIid: attempt.turn.mergeRequestIid,
+          event: attempt.req.event,
+          verdict: attempt.req.verdict,
+          headSha: attempt.turn.expectedHeadSha,
+          state,
+          ...(externalIds.length ? { externalIds } : {})
+        },
+        attempt.orgId
+      )
+    } catch (err) {
+      this.deps.log.warn(`gitlab review: result report deferred (${err instanceof Error ? err.message : err})`)
+    }
+    return {
+      provider: 'gitlab',
+      state,
+      event: attempt.req.event,
+      verdict: attempt.req.verdict,
+      message: OUTCOME_SENTENCE[state],
+      ...(externalIds.length ? { externalIds } : {})
+    }
+  }
+
+  /** A typed CP refusal is an ordinary control outcome the model must read precisely. */
+  private refused(
+    req: SubmitCodeReviewReq,
+    answer: Extract<CodeHostReviewAuthorized, { authorized: false }>
+  ): GitlabReviewOutcome {
+    const state: CodeHostReviewState =
+      answer.reason === 'reviewer_assignment_required'
+        ? 'reviewer_assignment_required'
+        : answer.reason === 'ambiguous_locked'
+          ? 'ambiguous_locked'
+          : 'not_submitted'
+    const detail =
+      answer.reason === 'lease_held'
+        ? ' Another review attempt currently owns publication on this merge request.'
+        : answer.reason === 'head_changed'
+          ? ' The merge request head changed while this turn was running.'
+          : answer.reason === 'policy_denied'
+            ? " This hook's review policy does not permit that review event."
+            : answer.reason === 'binding_unavailable'
+              ? ' This project has no ready GitLab binding to publish as.'
+              : ''
+    return {
+      provider: 'gitlab',
+      state,
+      event: req.event,
+      verdict: req.verdict,
+      message: `${OUTCOME_SENTENCE[state]}${detail}`
+    }
+  }
+
+  private render(body: string, attribution: GithubCommentAttribution | undefined, marker: string): string {
+    return appendGithubMarkdownChrome(
+      ReviewMarkerSigner.neutralize(body),
+      `${githubAttributionFooter(attribution)}\n\n${marker}`
+    )
+  }
+
+  private mrPath(turn: GitlabReviewTurn, suffix = ''): string {
+    return `/projects/${turn.projectId}/merge_requests/${turn.mergeRequestIid}${suffix}`
+  }
+
+  private async get(session: Session, path: string, query?: string): Promise<unknown> {
+    for (let tries = 0; tries < 2; tries += 1) {
+      let result: SendResult
+      try {
+        result = await this.send('GET', path, query, undefined, session.token)
+      } catch {
+        throw new Error(`GitLab GET ${path} did not complete`)
+      }
+      if (result.status < 300) return result.parsed
+      if ((result.status !== 401 && result.status !== 403) || tries === 1) {
+        throw new Error(`GitLab GET ${path} failed with ${result.status}`)
+      }
+      this.deps.invalidateToken(session.turn, session.token)
+      session.token = await this.deps.token(session.turn)
+    }
+    throw new Error(`GitLab GET ${path} failed`)
+  }
+
+  private async send(
+    method: 'GET' | CodeHostReviewOpMethod,
+    path: string,
+    query: string | undefined,
+    body: Record<string, unknown> | undefined,
+    token: string
+  ): Promise<SendResult> {
+    const doFetch = this.deps.fetchImpl ?? fetch
+    const url = `${this.deps.baseUrl ?? DEFAULT_BASE_URL}${path}${query ? `?${query}` : ''}`
+    let response: Response
+    try {
+      response = await doFetch(url, {
+        method,
+        headers: {
+          'private-token': token,
+          ...(body !== undefined ? { 'content-type': 'application/json' } : {})
+        },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS)
+      })
+    } catch {
+      // Nothing was received, so a mutation's effect is unknown; GETs treat it the same.
+      throw new AmbiguousSend('transport_failed')
+    }
+    // A 5xx may or may not have applied the effect; only a received 4xx is definite.
+    if (response.status >= 500) throw new AmbiguousSend(`upstream_${response.status}`)
+    const raw = await response.text().catch(() => '')
+    let parsed: unknown
+    try {
+      parsed = raw ? parseGitlabJson(raw) : undefined
+    } catch {
+      parsed = undefined
+    }
+    return { status: response.status, parsed }
+  }
+}
+
+/** The exact diff refs one inline comment is anchored to (§15 step 8). */
+function diffPosition(
+  comment: NonNullable<SubmitCodeReviewReq['comments']>[number],
+  facts: MergeRequestFacts
+): Record<string, unknown> {
+  const lineKey = comment.side === 'LEFT' ? 'old_line' : 'new_line'
+  const startKey = comment.startSide === 'LEFT' ? 'old_line' : 'new_line'
+  return {
+    position_type: 'text',
+    base_sha: facts.baseSha ?? '',
+    start_sha: facts.startSha ?? facts.baseSha ?? '',
+    head_sha: facts.headSha,
+    old_path: comment.path,
+    new_path: comment.path,
+    [lineKey]: comment.line,
+    ...(comment.startLine !== undefined
+      ? {
+          line_range: {
+            start: { type: comment.startSide === 'LEFT' ? 'old' : 'new', [startKey]: comment.startLine },
+            end: { type: comment.side === 'LEFT' ? 'old' : 'new', [lineKey]: comment.line }
+          }
+        }
+      : {})
+  }
+}

--- a/packages/daemon/src/gitlab/review-adapter.ts
+++ b/packages/daemon/src/gitlab/review-adapter.ts
@@ -29,7 +29,7 @@ import {
   type CodeHostReviewState,
   type HookConfigSnapshot
 } from '@agentconnect.md/protocol'
-import { reviewPolicyAllows, type HookDispatchContext } from '../github/hook-coords.js'
+import { reviewPolicyAllows, type CodeReviewOperation, type HookDispatchContext } from '../github/hook-coords.js'
 import { gitlabOpensReviewGeneration } from '../messages/hook-message.js'
 import {
   validateCodeReviewInput,
@@ -143,6 +143,8 @@ const DEFAULT_MERGE_STATUS_WINDOW_MS = 30_000
 const DEFAULT_POLL_INTERVAL_MS = 2_000
 const DEFAULT_RESWEEP_BASE_MS = 30_000
 const DEFAULT_RESWEEP_CAP_MS = 300_000
+/** Pages of owed frames one sweep drains; the store answers a bounded page at a time. */
+const MAX_SWEEP_PAGES = 50
 const MAX_NOTE_PAGES = 10
 const NOTES_PER_PAGE = 100
 const MAX_DRAFTS = 100
@@ -282,6 +284,8 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   private readonly sleep: (ms: number) => Promise<void>
   private readonly sched: PosterScheduler
   private signerPromise?: Promise<ReviewMarkerSigner>
+  /** Owed frames whose durable write has not landed yet; replayed and re-written from here. */
+  private readonly unwritten = new Map<string, ReviewIntentRow>()
   private resweepHandle?: unknown
   private resweepAttempt = 0
   /** Monotonic count of arm REQUESTS, so a zero-work disarm can tell whether it raced new work. */
@@ -479,7 +483,10 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       fence: authorized.lease.fence,
       token: session.token,
       serviceAccountUserId,
-      ordinals: new Map(),
+      // Seeded from the durable record: a replayed attempt must never reuse a spent coordinate.
+      ordinals: new Map(
+        Object.entries(turn.hook.codeReview?.ordinals ?? {}).map(([kind, next]) => [kind as CodeHostReviewOpKind, next])
+      ),
       drafts: new Map(),
       externalIds: [],
       ...(reviewerBefore ? { reviewerBefore } : {})
@@ -493,6 +500,11 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
 
   private async publish(cp: GitlabReviewControlPlane, attempt: Attempt): Promise<GitlabReviewOutcome> {
     const { turn, req } = attempt
+
+    // §15.1: a request this attempt already permitted must be classified against the
+    // control plane's ledger before another one is issued.
+    const recovered = await this.reconcileOperations(cp, attempt)
+    if (recovered) return recovered
 
     // §15 step 4: reconcile every pending draft this account owns before creating one.
     const reconciled = await this.reconcileDrafts(cp, attempt)
@@ -549,6 +561,117 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       return this.settle(cp, attempt, await this.approve(cp, attempt, atPublish))
     }
     return this.settle(cp, attempt, 'submitted')
+  }
+
+  /**
+   * §15.1 ledger recovery: every operation whose one request was permitted but never
+   * settled is classified by its provider effect and settled before this attempt
+   * issues another. A publication or approval that got that far is TERMINAL — the
+   * attempt must never create or publish again.
+   */
+  private async reconcileOperations(
+    cp: GitlabReviewControlPlane,
+    attempt: Attempt
+  ): Promise<GitlabReviewOutcome | undefined> {
+    const pending = [...(attempt.turn.hook.codeReview?.operations ?? [])]
+    if (pending.length === 0) return undefined
+    const marked = new Map<number, string>()
+    for (const draft of draftNotes(
+      await this.get(attempt, this.mrPath(attempt.turn, '/draft_notes')).catch(() => undefined)
+    )) {
+      const marker = attempt.signer.read(draft.note, attempt.turn.expectedHeadSha)
+      if (marker?.attemptId === attempt.attemptId.toLowerCase()) marked.set(marker.ordinal, draft.id)
+    }
+    for (const op of pending) {
+      if (op.kind === 'bulk_publish' || op.kind === 'approval') continue
+      await this.settleOperation(cp, attempt, op.recordId, this.classifyDraftOperation(op, marked, attempt))
+      await this.clearOperation(attempt, op.recordId)
+    }
+    const publish = pending.find((op) => op.kind === 'bulk_publish')
+    const approval = pending.find((op) => op.kind === 'approval')
+    if (!publish && !approval) return undefined
+
+    // Only positive provider evidence can classify a permitted publication.
+    const note = await this.findSummaryNote(attempt).catch(() => undefined)
+    if (publish) {
+      if (!note) {
+        await this.settleOperation(cp, attempt, publish.recordId, {
+          kind: 'ambiguous',
+          code: 'publish_unreconciled'
+        })
+        await this.clearOperation(attempt, publish.recordId)
+        return await this.settle(cp, attempt, 'ambiguous_locked')
+      }
+      await this.settleOperation(cp, attempt, publish.recordId, {
+        kind: 'deterministic',
+        status: 201,
+        externalId: note
+      })
+      await this.clearOperation(attempt, publish.recordId)
+    }
+    if (note) attempt.externalIds.push({ kind: 'note', externalId: note })
+    if (approval) {
+      const readback = await this.get(attempt, this.mrPath(attempt.turn, '/approvals')).catch(() => undefined)
+      const approved = this.approvalReadback(readback, attempt)
+      const approvalId = idOf(record(readback).id)
+      await this.settleOperation(cp, attempt, approval.recordId, {
+        kind: 'deterministic',
+        status: approved ? 201 : 422,
+        ...(approved && approvalId ? { externalId: approvalId } : {})
+      })
+      await this.clearOperation(attempt, approval.recordId)
+      if (approved && approvalId) attempt.externalIds.push({ kind: 'approval', externalId: approvalId })
+      return await this.settle(cp, attempt, approved ? 'submitted' : 'approval_not_recorded')
+    }
+    // A recovered publication cannot prove the unchanged-state postcondition, so only the
+    // baseline-free requested-changes classification stays available (§15.2).
+    if (attempt.req.event === 'REQUEST_CHANGES') {
+      const status = await this.stableMergeStatus(attempt, true)
+      return await this.settle(
+        cp,
+        attempt,
+        status === 'requested_changes' ? 'requested_changes_block_observed' : 'requested_changes_state_ambiguous'
+      )
+    }
+    return await this.settle(cp, attempt, 'review_state_not_recorded')
+  }
+
+  /** A draft create is proven by its marker; a draft delete is proven by the absence it asked for. */
+  private classifyDraftOperation(
+    op: CodeReviewOperation,
+    marked: Map<number, string>,
+    attempt: Attempt
+  ): CodeHostReviewOpOutcome {
+    if (op.kind === 'draft_create') {
+      const draftId = op.draftOrdinal === undefined ? undefined : marked.get(op.draftOrdinal)
+      if (draftId) {
+        attempt.drafts.set(op.draftOrdinal!, draftId)
+        return { kind: 'deterministic', status: 201, externalId: draftId }
+      }
+      return { kind: 'deterministic', status: 422, code: 'draft_absent' }
+    }
+    const draftId = op.target.split('/').at(-1) ?? ''
+    const present = [...marked.values()].includes(draftId)
+    return present
+      ? { kind: 'deterministic', status: 422, code: 'draft_present' }
+      : { kind: 'deterministic', status: 204 }
+  }
+
+  /** RECORD-FIRST: the coordinates of the one permitted request, before it is permitted. */
+  private async noteOperation(attempt: Attempt, op: CodeReviewOperation): Promise<void> {
+    const attemptRecord = attempt.turn.hook.codeReview
+    if (!attemptRecord) return
+    attemptRecord.ordinals = Object.fromEntries(attempt.ordinals)
+    attemptRecord.operations = [...(attemptRecord.operations ?? []).filter((e) => e.recordId !== op.recordId), op]
+    await attempt.turn.persist(true)
+  }
+
+  /** Settled, so the coordinates are no longer owed. A lost removal costs one idempotent re-settle. */
+  private async clearOperation(attempt: Attempt, recordId: string): Promise<void> {
+    const attemptRecord = attempt.turn.hook.codeReview
+    if (!attemptRecord?.operations) return
+    attemptRecord.operations = attemptRecord.operations.filter((op) => op.recordId !== recordId)
+    await attempt.turn.persist().catch(() => undefined)
   }
 
   /** §15.1 orphan recovery, run while holding the lease and before any create. */
@@ -620,10 +743,15 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       })
     })
     for (const draft of bodies) {
-      const outcome = await this.mutate(cp, attempt, 'draft_create', 'POST', this.mrPath(turn, '/draft_notes'), {
-        note: draft.note,
-        ...(draft.position ? { position: draft.position } : {})
-      })
+      const outcome = await this.mutate(
+        cp,
+        attempt,
+        'draft_create',
+        'POST',
+        this.mrPath(turn, '/draft_notes'),
+        { note: draft.note, ...(draft.position ? { position: draft.position } : {}) },
+        draft.ordinal
+      )
       if (outcome.kind === 'rejected') {
         await this.deleteAttemptDrafts(cp, attempt)
         return this.settle(cp, attempt, 'not_submitted')
@@ -838,7 +966,8 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     kind: CodeHostReviewOpKind,
     method: CodeHostReviewOpMethod,
     target: string,
-    body: Record<string, unknown> | undefined
+    body: Record<string, unknown> | undefined,
+    draftOrdinal?: number
   ): Promise<
     | { kind: 'sent'; status: number; parsed: unknown; recordId: string }
     | { kind: 'rejected'; status: number; recordId: string }
@@ -852,6 +981,15 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
         attempt.orgId
       )
       const startToken = (this.deps.newStartToken ?? randomUUID)()
+      // Durable BEFORE the request is permitted, so a crash between them is reconcilable.
+      await this.noteOperation(attempt, {
+        recordId: issued.recordId,
+        startToken,
+        kind,
+        ordinal,
+        target,
+        ...(draftOrdinal !== undefined ? { draftOrdinal } : {})
+      })
       await this.startOperation(cp, attempt, issued.recordId, startToken)
       let result: SendResult
       try {
@@ -859,6 +997,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       } catch (err) {
         if (err instanceof AmbiguousSend) {
           await this.settleOperation(cp, attempt, issued.recordId, { kind: 'ambiguous', code: err.code })
+          await this.clearOperation(attempt, issued.recordId)
           return { kind: 'ambiguous', recordId: issued.recordId }
         }
         throw err
@@ -870,6 +1009,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
         status: result.status,
         ...(externalId ? { externalId } : {})
       })
+      await this.clearOperation(attempt, issued.recordId)
       if (result.status < 300) {
         return { kind: 'sent', status: result.status, parsed: result.parsed, recordId: issued.recordId }
       }
@@ -1024,14 +1164,28 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
    * permanently refused frame is dropped rather than replayed forever (§15.1).
    */
   private async owe(cp: GitlabReviewControlPlane, row: ReviewIntentRow): Promise<void> {
-    try {
-      await this.deps.store.recordReviewIntent(row, this.now())
-    } catch (err) {
-      this.warn(`gitlab review: owed frame could not be recorded (${err instanceof Error ? err.message : err})`)
-    }
+    // Relying on replay requires the row to EXIST: a frame whose durable write failed is
+    // kept in memory and its write retried on the same backoff, never warned away.
+    if (!(await this.persistIntent(row))) this.unwritten.set(row.intentId, row)
     const answer = await this.deliver(cp, row)
     if (answer === 'retry') this.arm()
     else await this.forget(row.intentId)
+  }
+
+  /** Bounded local-write retry; false means the row is only in memory for now. */
+  private async persistIntent(row: ReviewIntentRow): Promise<boolean> {
+    for (let tries = 0; tries < 3; tries += 1) {
+      try {
+        await this.deps.store.recordReviewIntent(row, this.now())
+        this.unwritten.delete(row.intentId)
+        return true
+      } catch (err) {
+        if (tries === 2) {
+          this.warn(`gitlab review: owed frame write deferred (${err instanceof Error ? err.message : err})`)
+        }
+      }
+    }
+    return false
   }
 
   /** Send one owed frame verbatim. `retry` keeps it; anything else is finished with. */
@@ -1051,6 +1205,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   }
 
   private async forget(intentId: string): Promise<void> {
+    this.unwritten.delete(intentId)
     try {
       await this.deps.store.clearReviewIntent(intentId)
     } catch (err) {
@@ -1078,33 +1233,58 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     }
   }
 
-  /** One pass over the owed frames; the count still outstanding after it, or undefined. */
+  /**
+   * One pass over the owed frames; the count still outstanding after it, or undefined.
+   *
+   * The store answers one PAGE at a time, so the pass drains successive pages until it
+   * sees nothing new — a page of acked rows must never be mistaken for an empty store.
+   */
   private async sweepOnce(): Promise<number | undefined> {
     const daemonId = this.deps.daemonId()
     // Before the control plane adopts an id there is no identity to recover rows under.
     if (!daemonId) return 0
     const cp = this.deps.cp()
     if (!cp) return undefined
-    let rows: ReviewIntentRow[]
-    try {
-      rows = await this.deps.store.listReviewIntents(daemonId)
-    } catch (err) {
-      this.warn(`gitlab review: owed frame scan failed (${err instanceof Error ? err.message : err})`)
-      return undefined
-    }
+    const seen = new Set<string>()
     let outstanding = 0
-    for (const row of rows) {
-      const answer = await this.deliver(cp, row)
-      if (answer === 'retry') {
-        outstanding += 1
-        await this.deps.store
-          .recordReviewIntent({ ...row, attempts: row.attempts + 1 }, this.now())
-          .catch(() => undefined)
-      } else {
-        await this.forget(row.intentId)
+    let unreadable = false
+    for (let page = 0; page < MAX_SWEEP_PAGES; page += 1) {
+      let rows: ReviewIntentRow[]
+      try {
+        rows = await this.deps.store.listReviewIntents(daemonId)
+      } catch (err) {
+        this.warn(`gitlab review: owed frame scan failed (${err instanceof Error ? err.message : err})`)
+        unreadable = true
+        break
+      }
+      const fresh = rows.filter((row) => !seen.has(row.intentId))
+      if (fresh.length === 0) break
+      for (const row of fresh) {
+        seen.add(row.intentId)
+        outstanding += await this.replay(cp, row)
       }
     }
-    return outstanding
+    // Frames whose durable write never landed live only here; they are owed all the same.
+    for (const row of [...this.unwritten.values()]) {
+      if (seen.has(row.intentId)) continue
+      seen.add(row.intentId)
+      await this.persistIntent(row)
+      outstanding += await this.replay(cp, row)
+    }
+    return unreadable ? undefined : outstanding
+  }
+
+  /** Deliver one owed frame; 1 when it is still owed afterwards, 0 when it is finished with. */
+  private async replay(cp: GitlabReviewControlPlane, row: ReviewIntentRow): Promise<number> {
+    const answer = await this.deliver(cp, row)
+    if (answer !== 'retry') {
+      await this.forget(row.intentId)
+      return 0
+    }
+    const next = { ...row, attempts: row.attempts + 1 }
+    if (this.unwritten.has(row.intentId)) this.unwritten.set(row.intentId, next)
+    await this.deps.store.recordReviewIntent(next, this.now()).catch(() => undefined)
+    return 1
   }
 
   /** Arm the next resweep on exponential backoff, capped. An armed timer is never restarted early. */

--- a/packages/daemon/src/gitlab/review-adapter.ts
+++ b/packages/daemon/src/gitlab/review-adapter.ts
@@ -29,6 +29,8 @@ import {
   type CodeHostReviewState,
   type HookConfigSnapshot
 } from '@agentconnect.md/protocol'
+import { reviewPolicyAllows, type HookDispatchContext } from '../github/hook-coords.js'
+import { gitlabOpensReviewGeneration } from '../messages/hook-message.js'
 import {
   validateCodeReviewInput,
   type CodeHostReviewAdapter,
@@ -36,8 +38,12 @@ import {
   type CodeReviewVerdict,
   type SubmitCodeReviewReq
 } from '../codehost/review-adapter.js'
-import { reviewPolicyAllows, type HookDispatchContext } from '../github/hook-coords.js'
-import { appendGithubMarkdownChrome, githubAttributionFooter, type GithubCommentAttribution } from '../github/poster.js'
+import {
+  appendGithubMarkdownChrome,
+  githubAttributionFooter,
+  type GithubCommentAttribution,
+  type PosterScheduler
+} from '../github/poster.js'
 import { parseGitlabJson } from './broker.js'
 import { ReviewMarkerSigner } from './review-marker.js'
 
@@ -54,8 +60,30 @@ export interface GitlabReviewTurn {
   expectedHeadSha: string
   expectedBaseSha?: string
   sessionId: string
+  /** The durable hook row this attempt's identity and outcome live on (§15, §15.2). */
+  hook: HookDispatchContext
+  /** Persist that row; `required` makes a failed write fail the caller. */
+  persist: (required?: boolean) => Promise<void>
   /** §15 step 1: one review attempt per turn, reserved synchronously. */
   state: 'idle' | 'submitting' | 'done'
+}
+
+/** One control-plane frame a finished attempt still owes, replayed verbatim until acked (§15.1). */
+export interface ReviewIntentRow {
+  intentId: string
+  daemonId: string
+  attemptId: string
+  orgId?: string
+  kind: 'operation' | 'result'
+  /** The exact JSON payload; both frames are idempotent REQs by contract. */
+  frame: string
+  attempts: number
+}
+
+export interface ReviewIntentStore {
+  recordReviewIntent(row: ReviewIntentRow, now: number): Promise<void>
+  clearReviewIntent(intentId: string): Promise<void>
+  listReviewIntents(daemonId: string): Promise<ReviewIntentRow[]>
 }
 
 /** The narrow Control-Plane surface this adapter needs (§15.1 lease + operation ledger). */
@@ -71,6 +99,11 @@ export interface GitlabReviewControlPlane {
 export interface GitlabReviewAdapterDeps {
   cp: () => GitlabReviewControlPlane | undefined
   orgForAgent: (agentId: string) => string | undefined
+  /** The STABLE daemon identity owed frames are recovered under — never a process incarnation. */
+  daemonId: () => string | undefined
+  store: ReviewIntentStore
+  /** Restart-stable marker key; see the trust model on {@link ReviewMarkerSigner}. */
+  markerKey: () => Promise<Buffer>
   /** §14.1 effect lease: the binding's effect PAT; it never enters the agent environment. */
   token: (turn: GitlabReviewTurn) => Promise<string>
   invalidateToken: (turn: GitlabReviewTurn, token: string) => void
@@ -78,8 +111,6 @@ export interface GitlabReviewAdapterDeps {
   log: { warn: (message: string) => void }
   baseUrl?: string
   fetchImpl?: typeof fetch
-  /** Daemon-local marker key; see the trust model on {@link ReviewMarkerSigner}. */
-  markerKey?: Buffer
   newAttemptId?: () => string
   newStartToken?: () => string
   now?: () => number
@@ -89,6 +120,10 @@ export interface GitlabReviewAdapterDeps {
   /** §15.2/§15 step 13 bounded wait for `detailed_merge_status` to leave its unstable values. */
   mergeStatusWindowMs?: number
   pollIntervalMs?: number
+  /** Timer seam for the owed-frame resweep; tests drive it, production uses real timers. */
+  scheduler?: PosterScheduler
+  resweepBaseMs?: number
+  resweepCapMs?: number
 }
 
 /** The model-visible outcome: one normalized state plus a plain-English sentence. */
@@ -106,6 +141,8 @@ const DEFAULT_TIMEOUT_MS = 20_000
 const DEFAULT_AMBIGUOUS_WINDOW_MS = 30_000
 const DEFAULT_MERGE_STATUS_WINDOW_MS = 30_000
 const DEFAULT_POLL_INTERVAL_MS = 2_000
+const DEFAULT_RESWEEP_BASE_MS = 30_000
+const DEFAULT_RESWEEP_CAP_MS = 300_000
 const MAX_NOTE_PAGES = 10
 const NOTES_PER_PAGE = 100
 const MAX_DRAFTS = 100
@@ -175,6 +212,7 @@ interface Session {
 /** Everything one attempt carries between steps. */
 interface Attempt extends Session {
   req: SubmitCodeReviewReq
+  signer: ReviewMarkerSigner
   orgId?: string
   attemptId: string
   fence: string
@@ -240,31 +278,55 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   readonly provider = 'gitlab' as const
 
   private readonly turns = new Map<string, GitlabReviewTurn>()
-  private readonly signer: ReviewMarkerSigner
   private readonly now: () => number
   private readonly sleep: (ms: number) => Promise<void>
+  private readonly sched: PosterScheduler
+  private signerPromise?: Promise<ReviewMarkerSigner>
+  private resweepHandle?: unknown
+  private resweepAttempt = 0
+  /** Monotonic count of arm REQUESTS, so a zero-work disarm can tell whether it raced new work. */
+  private armGeneration = 0
+  private sweeping = false
+  private stopped = false
 
   constructor(private readonly deps: GitlabReviewAdapterDeps) {
-    this.signer = new ReviewMarkerSigner(deps.markerKey)
     this.now = deps.now ?? (() => Date.now())
     this.sleep = deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+    this.sched = deps.scheduler ?? {
+      now: () => Date.now(),
+      setTimeout: (fn, ms) => setTimeout(fn, ms),
+      clearTimeout: (h) => clearTimeout(h as NodeJS.Timeout)
+    }
+  }
+
+  /** Drop the pending resweep so a shutting-down daemon leaves no timer behind. */
+  stop(): void {
+    this.stopped = true
+    this.clearTimer()
   }
 
   /**
    * Install the active review turn for one logical session key. Returns undefined
-   * for every delivery that is not an authorized merge-request review generation.
+   * for every delivery that is not an authorized merge-request review generation —
+   * an ordinary merge-request conversation must not own the structured tool.
    */
   openTurn(
     key: string,
     hook: HookDispatchContext | undefined,
     sessionId: string,
-    daemonId?: string
+    options: { daemonId?: string; persist: (required?: boolean) => Promise<void> }
   ): GitlabReviewTurn | undefined {
     const gitlab = hook?.gitlab
     const snapshot = hook?.snapshot
-    if (!hook || !gitlab || !snapshot || snapshot.reviewPolicy === 'off') return undefined
+    if (!hook || !gitlab || !snapshot) return undefined
     if (gitlab.target.kind !== 'merge_request' || !gitlab.target.headSha) return undefined
-    if (daemonId && snapshot.dispatchDaemonId !== daemonId) return undefined
+    // The same trusted predicate the prompt uses: only a delivery that OPENS a review
+    // generation for this head may publish one (§15).
+    if (!gitlabOpensReviewGeneration(hook.event, gitlab, snapshot.reviewPolicy)) return undefined
+    if (options.daemonId && snapshot.dispatchDaemonId !== options.daemonId) return undefined
+    // A durable attempt that already reached a present or unknown effect is terminal for this turn.
+    const prior = hook.codeReview
+    const terminal = prior?.state !== undefined && codeHostReviewPublicEffect(prior.state) !== 'absent'
     const turn: GitlabReviewTurn = {
       hookId: hook.hookId,
       agentId: hook.agentId,
@@ -276,10 +338,18 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       expectedHeadSha: gitlab.target.headSha,
       ...(gitlab.target.baseSha ? { expectedBaseSha: gitlab.target.baseSha } : {}),
       sessionId,
-      state: 'idle'
+      hook,
+      persist: options.persist,
+      state: terminal ? 'done' : 'idle'
     }
     this.turns.set(key, turn)
     return turn
+  }
+
+  /** The restart-stable signer, minted from the daemon store on first use. */
+  private markerSigner(): Promise<ReviewMarkerSigner> {
+    this.signerPromise ??= this.deps.markerKey().then((key) => new ReviewMarkerSigner(key))
+    return this.signerPromise
   }
 
   closeTurn(key: string, turn?: GitlabReviewTurn): void {
@@ -325,13 +395,46 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     }
   }
 
+  /**
+   * RECORD-FIRST (§15, §15.1): the attempt identity lands on the durable hook row
+   * before any provider or control-plane call, so a crash replays the SAME attempt —
+   * its lease is reacquired idempotently and its marked drafts are recoverable. A
+   * prior attempt that proved no effect is superseded by a fresh id.
+   */
+  private async reserveAttempt(turn: GitlabReviewTurn, req: SubmitCodeReviewReq): Promise<string> {
+    const prior = turn.hook.codeReview
+    const recovering = prior !== undefined && prior.state === undefined
+    if (recovering) {
+      if (prior.event !== req.event || prior.verdict !== req.verdict || prior.headSha !== turn.expectedHeadSha) {
+        throw new Error('a recovered formal-review attempt must keep its original event, verdict, and head')
+      }
+      return prior.attemptId
+    }
+    const attemptId = (this.deps.newAttemptId ?? randomUUID)()
+    turn.hook.codeReview = {
+      attemptId,
+      event: req.event,
+      verdict: req.verdict,
+      headSha: turn.expectedHeadSha
+    }
+    try {
+      await turn.persist(true)
+    } catch (err) {
+      if (prior) turn.hook.codeReview = prior
+      else delete turn.hook.codeReview
+      throw new Error(`formal review durability barrier failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+    return attemptId
+  }
+
   private async run(
     turn: GitlabReviewTurn,
     req: SubmitCodeReviewReq,
     cp: GitlabReviewControlPlane
   ): Promise<GitlabReviewOutcome> {
     const orgId = this.deps.orgForAgent(turn.agentId)
-    const attemptId = (this.deps.newAttemptId ?? randomUUID)()
+    const attemptId = await this.reserveAttempt(turn, req)
+    const signer = await this.markerSigner()
     const session: Session = { turn, token: await this.deps.token(turn) }
 
     // Read pre-lease so the authz can carry the §15 step 6/7 reviewer fact and prove the leased account is ours.
@@ -358,7 +461,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       },
       orgId
     )
-    if (!authorized.authorized) return this.refused(req, authorized)
+    if (!authorized.authorized) return await this.refused(turn, req, authorized)
     if (
       authorized.projectId !== turn.projectId ||
       authorized.mergeRequestIid !== turn.mergeRequestIid ||
@@ -370,6 +473,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     const attempt: Attempt = {
       turn,
       req,
+      signer,
       ...(orgId ? { orgId } : {}),
       attemptId,
       fence: authorized.lease.fence,
@@ -456,7 +560,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     const pending = draftNotes(await this.get(attempt, this.mrPath(turn, '/draft_notes')))
     const stale: string[] = []
     for (const draft of pending) {
-      const marker = this.signer.read(draft.note, turn.expectedHeadSha)
+      const marker = attempt.signer.read(draft.note, turn.expectedHeadSha)
       // Unmarked, invalid, or unverifiable: nothing proves what it is, so fail closed.
       if (!marker) return this.settle(cp, attempt, 'review_reconciliation_required')
       if (marker.attemptId === attempt.attemptId.toLowerCase()) {
@@ -503,7 +607,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     if (!attempt.drafts.has(0)) {
       bodies.push({
         ordinal: 0,
-        note: this.render(req.body, attribution, this.signer.mint(attempt.attemptId, 0, turn.expectedHeadSha))
+        note: this.render(req.body, attribution, attempt.signer.mint(attempt.attemptId, 0, turn.expectedHeadSha))
       })
     }
     ;(req.comments ?? []).forEach((comment, index) => {
@@ -511,7 +615,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       if (attempt.drafts.has(ordinal)) return
       bodies.push({
         ordinal,
-        note: `${ReviewMarkerSigner.neutralize(comment.body)}\n\n${this.signer.mint(attempt.attemptId, ordinal, turn.expectedHeadSha)}`,
+        note: `${ReviewMarkerSigner.neutralize(comment.body)}\n\n${attempt.signer.mint(attempt.attemptId, ordinal, turn.expectedHeadSha)}`,
         position: diffPosition(comment, facts)
       })
     })
@@ -541,7 +645,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   private async findDraftByOrdinal(attempt: Attempt, ordinal: number): Promise<string | undefined> {
     const pending = draftNotes(await this.get(attempt, this.mrPath(attempt.turn, '/draft_notes')).catch(() => []))
     for (const draft of pending) {
-      const marker = this.signer.read(draft.note, attempt.turn.expectedHeadSha)
+      const marker = attempt.signer.read(draft.note, attempt.turn.expectedHeadSha)
       if (marker?.attemptId === attempt.attemptId.toLowerCase() && marker.ordinal === ordinal) return draft.id
     }
     return undefined
@@ -560,7 +664,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     if (pending.length !== attempt.drafts.size) return false
     const seen = new Set<number>()
     for (const draft of pending) {
-      const marker = this.signer.read(draft.note, attempt.turn.expectedHeadSha)
+      const marker = attempt.signer.read(draft.note, attempt.turn.expectedHeadSha)
       if (!marker || marker.attemptId !== attempt.attemptId.toLowerCase()) return false
       if (attempt.drafts.get(marker.ordinal) !== draft.id) return false
       seen.add(marker.ordinal)
@@ -621,7 +725,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       if (!Array.isArray(parsed)) return undefined
       for (const row of parsed) {
         const note = record(row)
-        const marker = this.signer.read(text(note.body), attempt.turn.expectedHeadSha)
+        const marker = attempt.signer.read(text(note.body), attempt.turn.expectedHeadSha)
         if (marker?.attemptId === attempt.attemptId.toLowerCase() && marker.ordinal === 0) return idOf(note.id)
       }
       if (parsed.length < NOTES_PER_PAGE) return undefined
@@ -800,20 +904,28 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     throw last instanceof Error ? last : new Error('the control plane refused to start the review operation')
   }
 
+  /** The settle is owed durably first: a lost ack must never strand a started record. */
   private async settleOperation(
     cp: GitlabReviewControlPlane,
     attempt: Attempt,
     recordId: string,
     outcome: CodeHostReviewOpOutcome
   ): Promise<void> {
-    try {
-      await cp.operate(
-        { op: 'settle', attemptId: attempt.attemptId, fence: attempt.fence, recordId, outcome },
-        attempt.orgId
-      )
-    } catch (err) {
-      this.deps.log.warn(`gitlab review: operation settle deferred (${err instanceof Error ? err.message : err})`)
-    }
+    await this.owe(cp, {
+      intentId: `${attempt.attemptId}:op:${recordId}`,
+      daemonId: this.deps.daemonId() ?? '',
+      attemptId: attempt.attemptId,
+      ...(attempt.orgId ? { orgId: attempt.orgId } : {}),
+      kind: 'operation',
+      frame: JSON.stringify({
+        op: 'settle',
+        attemptId: attempt.attemptId,
+        fence: attempt.fence,
+        recordId,
+        outcome
+      } satisfies CodeHostReviewOpRequest),
+      attempts: 0
+    })
   }
 
   /** Record the terminal classification, releasing (or locking) the publication lease. */
@@ -823,27 +935,31 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     state: CodeHostReviewState
   ): Promise<GitlabReviewOutcome> {
     const externalIds = codeHostReviewPublicEffect(state) === 'absent' ? [] : attempt.externalIds
-    try {
-      await cp.report(
-        {
-          hookId: attempt.turn.hookId,
-          deliveryKey: attempt.turn.deliveryKey,
-          attemptId: attempt.attemptId,
-          snapshot: attempt.turn.snapshot,
-          provider: 'gitlab',
-          projectId: attempt.turn.projectId,
-          mergeRequestIid: attempt.turn.mergeRequestIid,
-          event: attempt.req.event,
-          verdict: attempt.req.verdict,
-          headSha: attempt.turn.expectedHeadSha,
-          state,
-          ...(externalIds.length ? { externalIds } : {})
-        },
-        attempt.orgId
-      )
-    } catch (err) {
-      this.deps.log.warn(`gitlab review: result report deferred (${err instanceof Error ? err.message : err})`)
-    }
+    // The durable single-writer gate first: only a PROVEN no-effect attempt may be followed
+    // by the ordinary note, and a replay must read the same verdict this turn reached (§15.2).
+    await this.recordOutcome(attempt.turn, state)
+    await this.owe(cp, {
+      intentId: `${attempt.attemptId}:result`,
+      daemonId: this.deps.daemonId() ?? '',
+      attemptId: attempt.attemptId,
+      ...(attempt.orgId ? { orgId: attempt.orgId } : {}),
+      kind: 'result',
+      frame: JSON.stringify({
+        hookId: attempt.turn.hookId,
+        deliveryKey: attempt.turn.deliveryKey,
+        attemptId: attempt.attemptId,
+        snapshot: attempt.turn.snapshot,
+        provider: 'gitlab',
+        projectId: attempt.turn.projectId,
+        mergeRequestIid: attempt.turn.mergeRequestIid,
+        event: attempt.req.event,
+        verdict: attempt.req.verdict,
+        headSha: attempt.turn.expectedHeadSha,
+        state,
+        ...(externalIds.length ? { externalIds } : {})
+      } satisfies CodeHostReviewResultReport),
+      attempts: 0
+    })
     return {
       provider: 'gitlab',
       state,
@@ -855,10 +971,11 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   }
 
   /** A typed CP refusal is an ordinary control outcome the model must read precisely. */
-  private refused(
+  private async refused(
+    turn: GitlabReviewTurn,
     req: SubmitCodeReviewReq,
     answer: Extract<CodeHostReviewAuthorized, { authorized: false }>
-  ): GitlabReviewOutcome {
+  ): Promise<GitlabReviewOutcome> {
     const state: CodeHostReviewState =
       answer.reason === 'reviewer_assignment_required'
         ? 'reviewer_assignment_required'
@@ -875,12 +992,162 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
             : answer.reason === 'binding_unavailable'
               ? ' This project has no ready GitLab binding to publish as.'
               : ''
+    // No lease was granted, so nothing is owed to the control plane — but the durable
+    // gate still has to learn whether the ordinary note may follow this attempt.
+    await this.recordOutcome(turn, state)
     return {
       provider: 'gitlab',
       state,
       event: req.event,
       verdict: req.verdict,
       message: `${OUTCOME_SENTENCE[state]}${detail}`
+    }
+  }
+
+  /** Stamp the durable attempt with its classification; the in-memory copy guards this process. */
+  private async recordOutcome(turn: GitlabReviewTurn, state: CodeHostReviewState): Promise<void> {
+    if (!turn.hook.codeReview) return
+    turn.hook.codeReview.state = state
+    try {
+      await turn.persist(true)
+    } catch (err) {
+      // A stateless durable attempt reads as unknown, which blocks the fallback — the safe direction.
+      this.warn(`gitlab review: outcome persistence deferred (${err instanceof Error ? err.message : err})`)
+    }
+  }
+
+  /**
+   * Owe one control-plane frame, then try to deliver it.
+   *
+   * The row lands BEFORE the send, so a crash in between still replays it; both frames
+   * are idempotent REQs, so replaying one the control plane already took is a no-op. A
+   * permanently refused frame is dropped rather than replayed forever (§15.1).
+   */
+  private async owe(cp: GitlabReviewControlPlane, row: ReviewIntentRow): Promise<void> {
+    try {
+      await this.deps.store.recordReviewIntent(row, this.now())
+    } catch (err) {
+      this.warn(`gitlab review: owed frame could not be recorded (${err instanceof Error ? err.message : err})`)
+    }
+    const answer = await this.deliver(cp, row)
+    if (answer === 'retry') this.arm()
+    else await this.forget(row.intentId)
+  }
+
+  /** Send one owed frame verbatim. `retry` keeps it; anything else is finished with. */
+  private async deliver(cp: GitlabReviewControlPlane, row: ReviewIntentRow): Promise<'sent' | 'retry' | 'refused'> {
+    try {
+      if (row.kind === 'operation') await cp.operate(JSON.parse(row.frame) as CodeHostReviewOpRequest, row.orgId)
+      else await cp.report(JSON.parse(row.frame) as CodeHostReviewResultReport, row.orgId)
+      return 'sent'
+    } catch (err) {
+      // A control plane that answered `retryable: false` has decided; replaying cannot change it.
+      const permanent = (err as { retryable?: unknown }).retryable === false
+      this.warn(
+        `gitlab review: owed ${row.kind} frame ${permanent ? 'refused' : 'deferred'} (${err instanceof Error ? err.message : err})`
+      )
+      return permanent ? 'refused' : 'retry'
+    }
+  }
+
+  private async forget(intentId: string): Promise<void> {
+    try {
+      await this.deps.store.clearReviewIntent(intentId)
+    } catch (err) {
+      // The frame is delivered; a stale row only costs one idempotent replay later.
+      this.warn(`gitlab review: owed frame could not be cleared (${err instanceof Error ? err.message : err})`)
+    }
+  }
+
+  /**
+   * Replay everything this daemon identity still owes the control plane (§15.1). Runs at
+   * startup and on reconnect, and re-arms itself on backoff while anything remains, so a
+   * dropped ack cannot leave an operation record started or an outcome unreconciled.
+   */
+  async reconcilePending(): Promise<void> {
+    if (this.sweeping) return
+    this.sweeping = true
+    // Read BEFORE the scan: work that arms after this point owns the timer, not this sweep.
+    const armedThrough = this.armGeneration
+    try {
+      const remaining = await this.sweepOnce()
+      if (remaining === undefined || remaining > 0) this.arm()
+      else this.disarm(armedThrough)
+    } finally {
+      this.sweeping = false
+    }
+  }
+
+  /** One pass over the owed frames; the count still outstanding after it, or undefined. */
+  private async sweepOnce(): Promise<number | undefined> {
+    const daemonId = this.deps.daemonId()
+    // Before the control plane adopts an id there is no identity to recover rows under.
+    if (!daemonId) return 0
+    const cp = this.deps.cp()
+    if (!cp) return undefined
+    let rows: ReviewIntentRow[]
+    try {
+      rows = await this.deps.store.listReviewIntents(daemonId)
+    } catch (err) {
+      this.warn(`gitlab review: owed frame scan failed (${err instanceof Error ? err.message : err})`)
+      return undefined
+    }
+    let outstanding = 0
+    for (const row of rows) {
+      const answer = await this.deliver(cp, row)
+      if (answer === 'retry') {
+        outstanding += 1
+        await this.deps.store
+          .recordReviewIntent({ ...row, attempts: row.attempts + 1 }, this.now())
+          .catch(() => undefined)
+      } else {
+        await this.forget(row.intentId)
+      }
+    }
+    return outstanding
+  }
+
+  /** Arm the next resweep on exponential backoff, capped. An armed timer is never restarted early. */
+  private arm(): void {
+    if (this.stopped) return
+    this.armGeneration += 1
+    if (this.resweepHandle !== undefined) return
+    const base = this.deps.resweepBaseMs ?? DEFAULT_RESWEEP_BASE_MS
+    const cap = this.deps.resweepCapMs ?? DEFAULT_RESWEEP_CAP_MS
+    const delay = Math.min(base * 2 ** Math.min(this.resweepAttempt, 16), cap)
+    this.resweepAttempt += 1
+    try {
+      this.resweepHandle = this.sched.setTimeout(() => {
+        this.resweepHandle = undefined
+        void this.reconcilePending()
+      }, delay)
+    } catch (err) {
+      this.warn(`gitlab review: resweep scheduling failed (${err instanceof Error ? err.message : err})`)
+    }
+  }
+
+  /** Go quiet — but only if nothing armed after the sweep that decided there was no work left. */
+  private disarm(armedThrough: number): void {
+    if (this.armGeneration !== armedThrough) return
+    this.resweepAttempt = 0
+    this.clearTimer()
+  }
+
+  private clearTimer(): void {
+    if (this.resweepHandle === undefined) return
+    try {
+      this.sched.clearTimeout(this.resweepHandle)
+    } catch {
+      // A failed clear only leaves a sweep that finds nothing to do.
+    }
+    this.resweepHandle = undefined
+  }
+
+  private warn(message: string): void {
+    try {
+      this.deps.log.warn(message)
+    } catch {
+      // A broken logger must not break a settlement path.
     }
   }
 

--- a/packages/daemon/src/gitlab/review-marker.ts
+++ b/packages/daemon/src/gitlab/review-marker.ts
@@ -1,0 +1,74 @@
+/**
+ * Signed hidden attempt markers for GitLab formal reviews
+ * (gitlab-com-integration.md §15.1, §15.2).
+ *
+ * GitLab's note APIs have no idempotency key and its bulk publish has no attempt
+ * identifier, so an ambiguous create or publish is recovered by reading the
+ * marker back rather than by guessing from the text. Ordinal 0 is the review
+ * summary; 1..n are that attempt's inline diff comments, in creation order.
+ *
+ * Trust model: the HMAC key is daemon-local and the only claim it has to make is
+ * "this daemon's attempt authored this draft", which stops a model-authored body
+ * from planting a marker; a marker this daemon cannot verify is unrecognized and
+ * fails closed as `review_reconciliation_required`, never as someone else's.
+ */
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+
+const MARKER_VERSION = '1'
+const SIGNATURE_CHARS = 32
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const MARKER = /<!-- agentconnect-review:(\d+):([0-9a-fA-F-]{36}):(\d+):([A-Za-z0-9_-]+) -->/g
+
+export interface ReviewMarker {
+  attemptId: string
+  ordinal: number
+}
+
+/** One attempt's marker minting and verification; the key never leaves the daemon. */
+export class ReviewMarkerSigner {
+  private readonly key: Buffer
+
+  constructor(key?: Buffer) {
+    this.key = key ?? randomBytes(32)
+  }
+
+  /** The hidden marker chrome for one draft of one attempt at one head. */
+  mint(attemptId: string, ordinal: number, headSha: string): string {
+    const signature = this.sign(attemptId, ordinal, headSha)
+    return `<!-- agentconnect-review:${MARKER_VERSION}:${attemptId}:${ordinal}:${signature} -->`
+  }
+
+  /**
+   * The verified marker carried by one draft body, or undefined when it carries
+   * none, several, or one this daemon cannot verify. Several is refused because a
+   * body that mentions a marker cannot be allowed to shadow the appended chrome.
+   */
+  read(body: string | undefined, headSha: string): ReviewMarker | undefined {
+    if (!body) return undefined
+    const found = [...body.matchAll(MARKER)]
+    if (found.length !== 1) return undefined
+    const [, version, attemptId, ordinal, signature] = found[0]!
+    if (version !== MARKER_VERSION || !UUID.test(attemptId!)) return undefined
+    const index = Number(ordinal)
+    if (!Number.isSafeInteger(index) || index < 0) return undefined
+    if (!this.matches(this.sign(attemptId!, index, headSha), signature!)) return undefined
+    return { attemptId: attemptId!.toLowerCase(), ordinal: index }
+  }
+
+  /** Defang marker-shaped text the model authored so it can never shadow our chrome. */
+  static neutralize(body: string): string {
+    return body.replace(/agentconnect-review:/gi, 'agentconnect-review​:')
+  }
+
+  private sign(attemptId: string, ordinal: number, headSha: string): string {
+    return createHmac('sha256', this.key)
+      .update(`${MARKER_VERSION}|${attemptId.toLowerCase()}|${ordinal}|${headSha}`)
+      .digest('base64url')
+      .slice(0, SIGNATURE_CHARS)
+  }
+
+  private matches(expected: string, actual: string): boolean {
+    if (expected.length !== actual.length) return false
+    return timingSafeEqual(Buffer.from(expected, 'utf8'), Buffer.from(actual, 'utf8'))
+  }
+}

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -43,8 +43,8 @@ import {
 import {
   replyGithubReviewThreads,
   REPLY_GITHUB_REVIEW_THREADS_ARGS,
-  submitGithubReview,
-  SUBMIT_GITHUB_REVIEW_ARGS,
+  submitCodeReview,
+  SUBMIT_CODE_REVIEW_ARGS,
   type GithubReviewDeps
 } from './ops/github.js'
 import {
@@ -95,6 +95,7 @@ export type {
   ReplyGithubReviewThreadsResult,
   SubmitGithubReviewReq
 } from './ops/github.js'
+export type { SubmitCodeReviewReq } from '../codehost/review-adapter.js'
 export type { CodeHostEffectReq } from './ops/code-host.js'
 export { SEND_MESSAGE_BRANCHES } from './ops/messaging.js'
 export type { MessageAgentReq, MessageAgentResult, ReplyToSessionReq, ReplyToSessionResult } from './ops/messaging.js'
@@ -164,7 +165,9 @@ const HANDLERS: Map<string, ToolHandler<OpsDeps>> = new Map<string, ToolHandler<
   ['startOrchestration', startOrchestration],
   ['getOrchestration', getOrchestration],
   ['cancelOrchestration', cancelOrchestration],
-  ['submitGithubReview', submitGithubReview],
+  ['submitCodeReview', submitCodeReview],
+  // A working alias so sessions already warm with the pre-promotion tool set keep resolving.
+  ['submitGithubReview', submitCodeReview],
   ['replyGithubReviewThreads', replyGithubReviewThreads],
   ['createCodeHostComment', createCodeHostComment],
   ['updateCodeHostComment', updateCodeHostComment],
@@ -205,7 +208,8 @@ export const TOOL_ARG_SCHEMAS: Map<string, ZodType> = new Map<string, ZodType>([
   ['startOrchestration', START_ORCHESTRATION_ARGS],
   ['getOrchestration', ORCHESTRATION_OWNER_ARGS],
   ['cancelOrchestration', ORCHESTRATION_OWNER_ARGS],
-  ['submitGithubReview', SUBMIT_GITHUB_REVIEW_ARGS],
+  ['submitCodeReview', SUBMIT_CODE_REVIEW_ARGS],
+  ['submitGithubReview', SUBMIT_CODE_REVIEW_ARGS],
   ['replyGithubReviewThreads', REPLY_GITHUB_REVIEW_THREADS_ARGS],
   ['createCodeHostComment', CREATE_CODE_HOST_COMMENT_ARGS],
   ['updateCodeHostComment', UPDATE_CODE_HOST_COMMENT_ARGS],

--- a/packages/daemon/src/mcp/ops/args.ts
+++ b/packages/daemon/src/mcp/ops/args.ts
@@ -22,7 +22,7 @@ export function requiredString(key: string): z.ZodString {
   return z.string(message).min(1, message)
 }
 
-/** Like {@link requiredString} but accepts `''` — for `updateMemory`/`submitGithubReview`, where
+/** Like {@link requiredString} but accepts `''` — for `updateMemory`/`submitCodeReview`, where
  *  an empty string is a valid value. */
 export function requiredStringAllowEmpty(key: string): z.ZodString {
   return z.string(`missing required string argument: ${key}`)

--- a/packages/daemon/src/mcp/ops/github.ts
+++ b/packages/daemon/src/mcp/ops/github.ts
@@ -9,7 +9,7 @@ import {
   requiredString,
   requiredStringAllowEmpty
 } from './args.js'
-import type { GithubReviewEffect, SubmitGithubReviewInput } from '../../github/review.js'
+import type { SubmitCodeReviewReq } from '../../codehost/review-adapter.js'
 
 const REVIEW_SIDES = ['LEFT', 'RIGHT'] as const
 
@@ -29,8 +29,8 @@ const REVIEW_COMMENT = z.object(
   }
 )
 
-/** `submitGithubReview` arguments. `body` may be empty; the review target is never model input. */
-export const SUBMIT_GITHUB_REVIEW_ARGS = z.object({
+/** `submitCodeReview` arguments. `body` may be empty; the review target is never model input. */
+export const SUBMIT_CODE_REVIEW_ARGS = z.object({
   event: requiredEnum('event', ['COMMENT', 'REQUEST_CHANGES', 'APPROVE']),
   verdict: requiredEnum('verdict', ['pass', 'fail', 'neutral']),
   body: requiredStringAllowEmpty('body'),
@@ -75,15 +75,8 @@ export const REPLY_GITHUB_REVIEW_THREADS_ARGS = z.object({
     })
 })
 
-/** A formal PR review request with its caller identity/session coordinates
- * filled from the trusted MCP SessionContext. No GitHub target is model input. */
-export interface SubmitGithubReviewReq extends SubmitGithubReviewInput {
-  agentId: string
-  platform: string
-  channel: string
-  thread: string
-  transportScope?: string
-}
+/** The pre-promotion name of {@link SubmitCodeReviewReq}; the shape is unchanged. */
+export type SubmitGithubReviewReq = SubmitCodeReviewReq
 
 export interface ReplyGithubReviewThreadsReq {
   agentId: string
@@ -102,28 +95,28 @@ export interface ReplyGithubReviewThreadsResult {
   }>
 }
 
-/** The GitHub-review deps. Both are optional: an ordinary daemon carries the tool
+/** The formal-review deps. Both are optional: an ordinary daemon carries the tool
  *  descriptors but fails closed when the review seam is not wired. */
 export interface GithubReviewDeps {
-  /** Execute the R1 formal-review effect against the daemon-private active PR
-   * turn. The implementation owns action-time CP authorization and head/base
-   * fencing; ordinary sessions fail closed. */
-  submitGithubReview?: (req: SubmitGithubReviewReq) => Promise<GithubReviewEffect>
+  /** Execute the formal-review effect against the daemon-private active hook turn.
+   * The implementation routes by the turn's code host and owns action-time CP
+   * authorization and revision fencing; ordinary sessions fail closed. */
+  submitCodeReview?: (req: SubmitCodeReviewReq) => Promise<unknown>
   /** Publish the independently authored replies for one trusted inline-review batch. */
   replyGithubReviewThreads?: (req: ReplyGithubReviewThreadsReq) => Promise<ReplyGithubReviewThreadsResult>
 }
 
-// Structured formal PR review. Target identity is intentionally absent from
+// Structured formal code review. Target identity is intentionally absent from
 // args; the daemon recomputes the logical session key from these trusted
 // SessionContext fields and resolves the CURRENT active hook turn.
-export function submitGithubReview(
+export function submitCodeReview(
   ctx: SessionContext,
   args: Record<string, unknown>,
   deps: GithubReviewDeps
 ): Promise<unknown> {
-  if (!deps.submitGithubReview) throw new Error('formal GitHub reviews are unavailable on this daemon')
-  const { event, verdict, body, comments } = parseArgs(SUBMIT_GITHUB_REVIEW_ARGS, args)
-  return deps.submitGithubReview({
+  if (!deps.submitCodeReview) throw new Error('formal code reviews are unavailable on this daemon')
+  const { event, verdict, body, comments } = parseArgs(SUBMIT_CODE_REVIEW_ARGS, args)
+  return deps.submitCodeReview({
     agentId: ctx.agentId,
     platform: ctx.platform,
     channel: ctx.channel,

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -617,20 +617,24 @@ export const RETIRED_ORCHESTRATION_TOOLS: ToolDescriptor[] = [
 ]
 
 /**
- * Formal GitHub PR review effect. The descriptor may remain attached to a
- * long-lived per-thread ACP session, but availability is not authorization:
- * execution resolves the daemon-private active hook turn and fails closed for
- * every ordinary/non-PR/policy-off turn. The target is intentionally absent.
+ * Formal code-host review effect (gitlab-com-integration.md §15). The descriptor
+ * may remain attached to a long-lived per-thread ACP session, but availability is
+ * not authorization: execution resolves the daemon-private active hook turn, routes
+ * to that turn's code host, and fails closed for every ordinary/non-review turn.
+ * The target is intentionally absent.
  */
 export const GITHUB_REVIEW_TOOLS: ToolDescriptor[] = [
   {
-    name: 'submitGithubReview',
+    name: 'submitCodeReview',
     description:
-      'Submit the formal review for the active GitHub pull-request hook turn. The repository, pull request, and ' +
-      'commit are fixed by trusted turn metadata and cannot be selected here. Use COMMENT for a formal non-blocking ' +
-      'review, REQUEST_CHANGES for a failing review, or APPROVE for a passing review. This tool is unavailable ' +
-      'outside an authorized active PR hook turn, and at most one review can be submitted per turn. The review body ' +
-      'is the complete public response: once an attempt starts, only a definite not_submitted result preserves the ordinary-comment fallback.',
+      'Submit the formal review for the active pull-request or merge-request hook turn. The repository or project, ' +
+      'the pull/merge request, and the commit are fixed by trusted turn metadata and cannot be selected here. Use ' +
+      'COMMENT for a formal non-blocking review, REQUEST_CHANGES for a failing review, or APPROVE for a passing ' +
+      'review; REQUEST_CHANGES requires verdict fail and APPROVE requires verdict pass. On GitLab, REQUEST_CHANGES ' +
+      'is available only while the project service account is already a current reviewer — otherwise record the ' +
+      'finding with COMMENT and verdict fail. This tool is unavailable outside an authorized active review hook ' +
+      'turn, and at most one review can be submitted per turn. The review body is the complete public response: ' +
+      'once an attempt starts, only a definite not_submitted result preserves the ordinary-comment fallback.',
     inputSchema: obj(
       {
         event: { type: 'string', enum: ['COMMENT', 'REQUEST_CHANGES', 'APPROVE'] },
@@ -874,6 +878,8 @@ export const ALL_TOOL_NAMES = [
       .map((t) => t.name)
       // External-memory record tools: only their names are core knowledge here, the descriptors live in memory/.
       .concat([...EXTERNAL_MEMORY_TOOL_NAMES])
+      // The pre-promotion review name: no longer injected, still dispatched for warm sessions.
+      .concat(['submitGithubReview'])
   )
 ]
 

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -186,7 +186,7 @@ function githubReviewDecisionHint(
   const failingEvent = reviewPolicy === 'comment' ? 'COMMENT' : 'REQUEST_CHANGES'
   return (
     ' This delivery opens a review generation for the current PR revision. If you finish reviewing this revision, ' +
-    `record the actual verdict through \`submitGithubReview\`: use ${passingEvent} + pass when it passes, or ` +
+    `record the actual verdict through \`submitCodeReview\`: use ${passingEvent} + pass when it passes, or ` +
     `${failingEvent} + fail when it has blocking findings. An approval or rejection from an earlier revision does ` +
     'not complete this revision; do not merely describe the verdict in your final reply.'
   )
@@ -271,7 +271,7 @@ function githubReplyHint(
   }
   return [
     '',
-    `Your final reply is kept in the session transcript and is posted back to ${where} automatically as an ordinary GitHub comment only when no formal review was attempted or the current attempt definitively returns \`not_submitted\`. Keep it self-contained; the daemon exclusively owns that fallback reply comment. Use only the structured \`submitGithubReview\` tool for COMMENT / REQUEST_CHANGES / APPROVE and inline review comments. Its \`body\` must be a complete, self-contained, non-empty public review summary (including for APPROVE), because a submitted, ambiguous, or otherwise unresolved formal attempt suppresses the ordinary comment.${githubReviewDecisionHint(c, github, reviewPolicy)} Do NOT create, update, or delete GitHub comments or formal reviews through \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return a self-contained final reply for the transcript and fallback path.${githubWorkspaceCheckHint(github, true)}`
+    `Your final reply is kept in the session transcript and is posted back to ${where} automatically as an ordinary GitHub comment only when no formal review was attempted or the current attempt definitively returns \`not_submitted\`. Keep it self-contained; the daemon exclusively owns that fallback reply comment. Use only the structured \`submitCodeReview\` tool for COMMENT / REQUEST_CHANGES / APPROVE and inline review comments. Its \`body\` must be a complete, self-contained, non-empty public review summary (including for APPROVE), because a submitted, ambiguous, or otherwise unresolved formal attempt suppresses the ordinary comment.${githubReviewDecisionHint(c, github, reviewPolicy)} Do NOT create, update, or delete GitHub comments or formal reviews through \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return a self-contained final reply for the transcript and fallback path.${githubWorkspaceCheckHint(github, true)}`
   ].join('\n')
 }
 
@@ -315,20 +315,75 @@ function buildGithubHookText(
   )
 }
 
+/** GitLab deliveries that open a review generation for the current merge-request head. */
+const GITLAB_REVISION_REVIEW_EVENTS = new Set([
+  'merge_request:opened',
+  'merge_request:synchronize',
+  'merge_request:review_requested',
+  'merge_request:rerun'
+])
+
+/** True only when this delivery opens a formal review generation for the current MR head (§15). */
+export function gitlabOpensReviewGeneration(
+  event: string | undefined,
+  gitlab: GitlabHookMetadata | undefined,
+  reviewPolicy: RdMsgHook['reviewPolicy']
+): boolean {
+  const target = gitlab?.target
+  return Boolean(
+    target?.kind === 'merge_request' &&
+    target.headSha &&
+    reviewPolicy !== undefined &&
+    reviewPolicy !== 'off' &&
+    (target.explicitReviewRequest || GITLAB_REVISION_REVIEW_EVENTS.has(event ?? ''))
+  )
+}
+
+/** The §15 verdict instruction. REQUEST_CHANGES availability is stated rather than
+ *  omitted: no relay-delivered metadata carries the service account's reviewer record,
+ *  so the adapter is the first place that fact exists and it refuses before any draft. */
+function gitlabReviewDecisionHint(reviewPolicy: RdMsgHook['reviewPolicy']): string {
+  const passingEvent = reviewPolicy === 'full' ? 'APPROVE' : 'COMMENT'
+  const failingEvent = reviewPolicy === 'comment' ? 'COMMENT' : 'REQUEST_CHANGES'
+  return (
+    ' This delivery opens a review generation for the current merge-request revision. If you finish reviewing this ' +
+    `revision, record the actual verdict through \`submitCodeReview\`: use ${passingEvent} + pass when it passes, or ` +
+    `${failingEvent} + fail when it has blocking findings.${
+      failingEvent === 'REQUEST_CHANGES'
+        ? ' REQUEST_CHANGES works only while a user has requested the project service account as a reviewer in ' +
+          'GitLab; if it is refused for that reason, record the same finding with COMMENT + fail.'
+        : ''
+    } An approval or rejection from an earlier revision does not complete this revision; do not merely describe the ` +
+    'verdict in your final reply.'
+  )
+}
+
 /** The daemon-owned GitLab reply promise (§14.1) — issue/MR subjects only; a push has no thread to answer. */
-function gitlabReplyHint(c: HookContext, gitlab: GitlabHookMetadata): string {
+function gitlabReplyHint(c: HookContext, gitlab: GitlabHookMetadata, reviewPolicy: RdMsgHook['reviewPolicy']): string {
   if (gitlab.target.kind === 'push') return ''
+  const where = gitlabSubjectRef(c, gitlab)
+  const event = c.action ? `${c.event}:${c.action}` : (c.event ?? '')
+  if (gitlabOpensReviewGeneration(event, gitlab, reviewPolicy)) {
+    return [
+      '',
+      `Your final reply is kept in the session transcript and is posted back to ${where} automatically as one ordinary GitLab note only when no formal review was attempted or the current attempt definitively returns \`not_submitted\`. Keep it self-contained; the daemon exclusively owns that fallback note. Use only the structured \`submitCodeReview\` tool for COMMENT / REQUEST_CHANGES / APPROVE and inline diff comments. Its \`body\` must be a complete, self-contained, non-empty public review summary (including for APPROVE), because a submitted, ambiguous, or otherwise unresolved formal attempt suppresses the ordinary note.${gitlabReviewDecisionHint(reviewPolicy)} Do NOT create, update, or delete GitLab notes, drafts, or approvals through \`glab\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Every other GitLab access is READ-only inspection.`
+    ].join('\n')
+  }
   return [
     '',
-    `Return one self-contained final answer for ${gitlabSubjectRef(c, gitlab)}. The daemon posts it back to that GitLab thread automatically as one note and exclusively owns the reply. Do NOT create, update, or delete GitLab notes through \`glab\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Any other effect — a separate comment, a discussion reply, a merge request, a pipeline action — goes through the structured code-host tools when you have them; every other GitLab access is READ-only inspection.`
+    `Return one self-contained final answer for ${where}. The daemon posts it back to that GitLab thread automatically as one note and exclusively owns the reply. Do NOT create, update, or delete GitLab notes through \`glab\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Any other effect — a separate comment, a discussion reply, a merge request, a pipeline action — goes through the structured code-host tools when you have them; every other GitLab access is READ-only inspection.`
   ].join('\n')
 }
 
 /** The gitlab-kind turn text: a trusted metadata header + the FENCED excerpt + the reply promise. */
-function buildGitlabHookText(c: HookContext, gitlab: GitlabHookMetadata): string {
+function buildGitlabHookText(
+  c: HookContext,
+  gitlab: GitlabHookMetadata,
+  reviewPolicy: RdMsgHook['reviewPolicy']
+): string {
   const event = c.action ? `${c.event}:${c.action}` : (c.event ?? 'event')
   const target = gitlab.target
-  const tail = gitlabReplyHint(c, gitlab)
+  const tail = gitlabReplyHint(c, gitlab, reviewPolicy)
   const head = [
     `GitLab ${event} — ${gitlabSubjectRef(c, gitlab)}${c.title ? ` "${c.title}"` : ''}`,
     `From: ${c.senderLogin ?? 'unknown'}${c.labels?.length ? ` · labels: ${c.labels.join(', ')}` : ''}`,
@@ -352,7 +407,9 @@ function buildGitlabHookText(c: HookContext, gitlab: GitlabHookMetadata): string
 
 /** The turn text: the caller's payload-borne message (+ leftover fields as context). */
 export function buildHookText(msg: RdMsgHook): string {
-  if (msg.context?.source === 'gitlab' && msg.gitlab) return buildGitlabHookText(msg.context, msg.gitlab)
+  if (msg.context?.source === 'gitlab' && msg.gitlab) {
+    return buildGitlabHookText(msg.context, msg.gitlab, msg.reviewPolicy)
+  }
   if (msg.context?.source === 'github') return buildGithubHookText(msg.context, msg.github, msg.reviewPolicy)
   const parts: string[] = []
   const body = msg.context?.body

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -10,6 +10,7 @@ import {
   type SessionImageAttachment
 } from '@agentconnect.md/protocol'
 import type { NoteProjectionOutcome, NoteProjectionPhase, NoteProjectionRow } from '../gitlab/note-projection.js'
+import type { ReviewIntentRow } from '../gitlab/review-adapter.js'
 import { SESSION_TITLE_TOOL_TITLES } from '../mcp/session-title-tool.js'
 import type { ScheduleRun } from '../scheduler/scheduler.js'
 import { AsyncMutex } from './async-mutex.js'
@@ -1502,6 +1503,31 @@ export class LocalStore {
       );
       CREATE INDEX IF NOT EXISTS code_host_note_projection_pending
         ON code_host_note_projection (daemonId, phase, updatedAt);
+      -- Daemon-local secrets that must survive a restart. Nothing here authenticates to a peer:
+      -- the only entry today is the formal-review marker key, whose whole claim is "this daemon's
+      -- attempt authored this draft", so a key that changed every boot would make same-attempt
+      -- crash recovery unverifiable (gitlab-com-integration.md §15.1).
+      CREATE TABLE IF NOT EXISTS daemon_secret (
+        name TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        createdAt INTEGER NOT NULL
+      );
+      -- gitlab-com-integration.md §15.1: control-plane frames a finished review still OWES. Both
+      -- the operation settle and the terminal result are idempotent REQs, so an unacknowledged one
+      -- is replayed verbatim until the control plane takes it; a lost ack must never leave an
+      -- operation record started forever or an outcome unreconciled.
+      CREATE TABLE IF NOT EXISTS code_host_review_intent (
+        intentId TEXT PRIMARY KEY,
+        daemonId TEXT NOT NULL,
+        attemptId TEXT NOT NULL,
+        orgId TEXT,
+        kind TEXT NOT NULL CHECK (kind IN ('operation', 'result')),
+        frame TEXT NOT NULL,              -- the exact payload replayed, verbatim
+        attempts INTEGER NOT NULL DEFAULT 0,
+        updatedAt INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS code_host_review_intent_pending
+        ON code_host_review_intent (daemonId, updatedAt);
     `)
     // Stamped only once the CREATE block above has actually emitted that schema, so
     // a store that failed halfway through creation is not left claiming to be current.
@@ -5283,6 +5309,67 @@ export class LocalStore {
       )
       .all({ daemonId, limit })) as unknown as CodeHostNoteProjectionRow[]
     return rows.map(toNoteProjectionRow)
+  }
+
+  /**
+   * A restart-stable daemon-local secret, minted once on first use.
+   *
+   * The insert is `ON CONFLICT DO NOTHING` and the read follows it, so two callers racing
+   * the same name both observe the one stored value rather than each keeping its own.
+   */
+  async getOrCreateDaemonSecret(name: string, mint: () => string, now: number): Promise<string> {
+    await this.db
+      .prepare('INSERT INTO daemon_secret (name, value, createdAt) VALUES (@name, @value, @now) ON CONFLICT DO NOTHING')
+      .run({ name, value: mint(), now })
+    const row = (await this.db.prepare('SELECT value FROM daemon_secret WHERE name = @name').get({ name })) as
+      { value: string } | undefined
+    if (!row) throw new Error(`daemon secret ${name} could not be stored`)
+    return row.value
+  }
+
+  /** Remember a control-plane frame this review attempt still owes, so a lost ack is replayed. */
+  async recordReviewIntent(row: ReviewIntentRow, now: number): Promise<void> {
+    await this.db
+      .prepare(
+        `INSERT INTO code_host_review_intent (intentId, daemonId, attemptId, orgId, kind, frame, attempts, updatedAt)
+         VALUES (@intentId, @daemonId, @attemptId, @orgId, @kind, @frame, @attempts, @now)
+         ON CONFLICT (intentId) DO UPDATE SET
+           attempts = excluded.attempts, frame = excluded.frame, updatedAt = excluded.updatedAt`
+      )
+      .run({
+        intentId: row.intentId,
+        daemonId: row.daemonId,
+        attemptId: row.attemptId,
+        orgId: row.orgId ?? null,
+        kind: row.kind,
+        frame: row.frame,
+        attempts: row.attempts,
+        now
+      })
+  }
+
+  /** The control plane took it; nothing is owed for that frame any more. */
+  async clearReviewIntent(intentId: string): Promise<void> {
+    await this.db.prepare('DELETE FROM code_host_review_intent WHERE intentId = @intentId').run({ intentId })
+  }
+
+  /** Scoped to the stable daemon identity, so a restart replays its own frames and no peer's. */
+  async listReviewIntents(daemonId: string, limit = 100): Promise<ReviewIntentRow[]> {
+    const rows = (await this.db
+      .prepare(
+        `SELECT intentId, daemonId, attemptId, orgId, kind, frame, attempts FROM code_host_review_intent
+         WHERE daemonId = @daemonId ORDER BY updatedAt ASC LIMIT @limit`
+      )
+      .all({ daemonId, limit })) as unknown as Array<ReviewIntentRow & { orgId: string | null }>
+    return rows.map((row) => ({
+      intentId: row.intentId,
+      daemonId: row.daemonId,
+      attemptId: row.attemptId,
+      ...(row.orgId ? { orgId: row.orgId } : {}),
+      kind: row.kind,
+      frame: row.frame,
+      attempts: row.attempts
+    }))
   }
 
   /** Record one turn admission against a conversation-wide fixed window. A trusted

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -3361,7 +3361,7 @@ describe('buildHookMessage', () => {
       expect(draftText).toContain('Draft: true')
       expect(draftText).toContain('opens a review generation for the current PR revision')
       expect(draftText).toContain('use APPROVE + pass when it passes')
-      expect(draftText).toContain('submitGithubReview')
+      expect(draftText).toContain('submitCodeReview')
       expect(draftText).not.toContain('cannot accept a formal review')
 
       const convertedText = buildHookText(
@@ -3426,7 +3426,7 @@ describe('buildHookMessage', () => {
       expect(withThread).toContain('posts that final back to acme/infra#42 automatically')
       expect(withThread).toContain('exclusively owns the reply')
       expect(withThread).toContain('Formal GitHub review submission is unavailable')
-      expect(withThread).not.toContain('submitGithubReview')
+      expect(withThread).not.toContain('submitCodeReview')
       expect(withThread).toContain('Do NOT create, update, or delete GitHub comments or formal reviews')
       expect(withThread).toContain('`gh`, another CLI, a connector, or a direct API call')
       expect(withThread).toContain('Other GitHub tools are for READ-only inspection')
@@ -3434,7 +3434,7 @@ describe('buildHookMessage', () => {
       // formal verdict. A mention identified by the relay opens a review below.
       const issueComment = buildHookText(ghFire({ event: 'issue_comment', action: 'created' }))
       expect(issueComment).toContain('Formal GitHub review submission is unavailable')
-      expect(issueComment).not.toContain('submitGithubReview')
+      expect(issueComment).not.toContain('submitCodeReview')
       const prConversation = buildHookText(
         ghFire(
           { event: 'issue_comment', action: 'created' },
@@ -3452,7 +3452,7 @@ describe('buildHookMessage', () => {
       )
       expect(prConversation).toContain('does not prove its files match the PR revision')
       expect(prConversation).toContain('revision-addressed Git object reads')
-      expect(prConversation).not.toContain('submitGithubReview')
+      expect(prConversation).not.toContain('submitCodeReview')
       const revisionReview = buildHookText(
         ghFire(
           { event: 'pull_request', action: 'synchronize' },
@@ -3472,7 +3472,7 @@ describe('buildHookMessage', () => {
         )
       )
       expect(revisionReview).toContain('opens a review generation for the current PR revision')
-      expect(revisionReview).toContain('structured `submitGithubReview` tool')
+      expect(revisionReview).toContain('structured `submitCodeReview` tool')
       expect(revisionReview).toContain(`Base SHA: ${'b'.repeat(40)}`)
       expect(revisionReview).toContain(`Head SHA: ${'a'.repeat(40)}`)
       expect(revisionReview).toContain('Before trusting local files or repository traces')
@@ -3518,7 +3518,7 @@ describe('buildHookMessage', () => {
       )
       expect(inlineReply).toContain('daemon posts it back to the existing review thread automatically')
       expect(inlineReply).toContain('exclusively owns every inline reply')
-      expect(inlineReply).not.toContain('submitGithubReview')
+      expect(inlineReply).not.toContain('submitCodeReview')
       expect(inlineReply).not.toContain('ordinary GitHub comment')
       const batchableInline = buildHookText(
         ghFire(
@@ -3562,7 +3562,7 @@ describe('buildHookMessage', () => {
       expect(missingRoot).toContain('automatically as one ordinary GitHub comment')
       expect(missingRoot).toContain('Formal GitHub reviews are unavailable')
       expect(missingRoot).not.toContain('existing review thread')
-      expect(missingRoot).not.toContain('submitGithubReview')
+      expect(missingRoot).not.toContain('submitCodeReview')
       // push events have no issue/PR number → no poster runs → no hint.
       const push = buildHookText(
         ghFire({ event: 'push', action: undefined, number: undefined, bodyExcerpt: undefined })
@@ -3637,7 +3637,7 @@ describe('buildHookMessage', () => {
       expect(text).not.toContain('opens a review generation for the current PR revision')
       expect(text).not.toContain('use APPROVE + pass when it passes')
       expect(text).toContain('Formal GitHub review submission is unavailable')
-      expect(text).not.toContain('submitGithubReview')
+      expect(text).not.toContain('submitCodeReview')
     })
 
     it('a body quoting the delimiters cannot close the fence (delimiter lines are defanged)', async () => {

--- a/packages/daemon/test/gitlab-hook-message.test.ts
+++ b/packages/daemon/test/gitlab-hook-message.test.ts
@@ -155,6 +155,46 @@ describe('gitlab hook normalization (§12.3)', () => {
     expect(hookAnchorText(msg)).toContain('merge_request:synchronize — example-group/example-project!77')
   })
 
+  it('opens the formal-review prompt only for an MR revision that carries a head and a policy', () => {
+    const mr = (overrides: Partial<RdMsgHook> = {}) =>
+      fire({
+        sessionKey: `gitlab:${PROJECT}:merge_request:77`,
+        event: 'merge_request:opened',
+        reviewPolicy: 'full',
+        gitlab: {
+          projectId: PROJECT,
+          projectPath: 'example-group/example-project',
+          target: { kind: 'merge_request', iid: 77, headSha: 'a'.repeat(40) }
+        },
+        context: { source: 'gitlab', event: 'merge_request', action: 'opened', number: 77, truncated: false },
+        ...overrides
+      })
+    const review = buildHookText(mr())
+    expect(review).toContain('structured `submitCodeReview` tool')
+    expect(review).toContain('opens a review generation for the current merge-request revision')
+    expect(review).toContain('APPROVE + pass')
+    expect(review).toContain('REQUEST_CHANGES works only while a user has requested the project service account')
+    expect(review).toContain('Do NOT create, update, or delete GitLab notes, drafts, or approvals')
+    // A comment-only policy promises only what it can deliver.
+    expect(buildHookText(mr({ reviewPolicy: 'comment' }))).toContain('COMMENT + fail')
+    // Off, an ordinary conversation event, and a headless MR keep the plain reply promise.
+    for (const plain of [
+      mr({ reviewPolicy: 'off' }),
+      mr({ context: { source: 'gitlab', event: 'merge_request', action: 'labeled', number: 77, truncated: false } }),
+      mr({
+        gitlab: {
+          projectId: PROJECT,
+          projectPath: 'example-group/example-project',
+          target: { kind: 'merge_request', iid: 77 }
+        }
+      })
+    ]) {
+      const text = buildHookText(plain)
+      expect(text).not.toContain('submitCodeReview')
+      expect(text).toContain('Return one self-contained final answer')
+    }
+  })
+
   it('maps merged MRs and closed issues to the shared worktree-cleanup family, fenced on metadata', () => {
     const gitlab = { projectId: PROJECT, projectPath: 'p', target: { kind: 'merge_request' as const, iid: 77 } }
     expect(githubThreadWorktreeCleanup({ event: 'merge_request:merged', gitlab })).toBe('pull_request_merged')

--- a/packages/daemon/test/gitlab-review-adapter.test.ts
+++ b/packages/daemon/test/gitlab-review-adapter.test.ts
@@ -1,0 +1,930 @@
+// The GitLab formal merge-request review adapter (gitlab-com-integration.md §15, §15.1,
+// §15.2) and the §23 review matrix rows that belong to the daemon: the thirteen steps,
+// the publication lease and its single-use operation ledger, marker reconciliation, and
+// every ambiguous effect failing closed instead of publishing a fallback.
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CODEHOST_REVIEW_V1_FEATURE,
+  type CodeHostReviewAuthorize,
+  type CodeHostReviewAuthorized,
+  type CodeHostReviewLeasePhase,
+  type CodeHostReviewOpAccepted,
+  type CodeHostReviewOpRequest,
+  type CodeHostReviewRefusalReason,
+  type CodeHostReviewResultReport,
+  type HookConfigSnapshot
+} from '@agentconnect.md/protocol'
+import { Daemon } from '../src/daemon.js'
+import { sessionKey } from '../src/store/local-store.js'
+import { CodeHostReviewRouter, type SubmitCodeReviewReq } from '../src/codehost/review-adapter.js'
+import type { HookDispatchContext } from '../src/github/hook-coords.js'
+import {
+  GitlabReviewAdapter,
+  type GitlabReviewControlPlane,
+  type GitlabReviewOutcome
+} from '../src/gitlab/review-adapter.js'
+import { ReviewMarkerSigner } from '../src/gitlab/review-marker.js'
+
+const BASE = 'https://gitlab.example.test/api/v4'
+const PROJECT = '4455667'
+const IID = 77
+const HEAD = 'a'.repeat(40)
+const BASE_SHA = 'b'.repeat(40)
+const OTHER_HEAD = 'c'.repeat(40)
+// Deliberately past 2^53 so every id path stays a decimal string end to end.
+const SA_USER = '9007199254740993'
+const MR_ID = '9007199254740995'
+const HUMAN_USER = '9007199254740999'
+const ATTEMPT = '11111111-1111-4111-8111-111111111111'
+const OLD_ATTEMPT = '22222222-2222-4222-8222-222222222222'
+const HOOK_ID = '33333333-3333-4333-8333-333333333333'
+const DAEMON_ID = '44444444-4444-4444-8444-444444444444'
+const AGENT_ID = 'bot-a'
+const THREAD = `gitlab:${PROJECT}:merge_request:${IID}`
+const KEY = sessionKey('hook', HOOK_ID, THREAD, AGENT_ID)
+const MARKER_KEY = Buffer.from('gitlab-review-marker-test-key-01')
+
+const signer = new ReviewMarkerSigner(MARKER_KEY)
+
+const SNAPSHOT: HookConfigSnapshot = {
+  configRevision: '4',
+  dispatchRevision: '9',
+  dispatchDaemonId: DAEMON_ID,
+  reviewPolicy: 'full',
+  reportingMode: 'off',
+  gateMode: 'informational'
+}
+
+function hookContext(overrides: Partial<HookDispatchContext> = {}): HookDispatchContext {
+  return {
+    hookId: HOOK_ID,
+    agentId: AGENT_ID,
+    deliveryKey: 'delivery-1',
+    firedAt: '2026-01-01T00:00:00.000Z',
+    event: 'merge_request:opened',
+    snapshot: SNAPSHOT,
+    gitlab: {
+      projectId: PROJECT,
+      projectPath: 'example-group/example-project',
+      target: { kind: 'merge_request', iid: IID, headSha: HEAD, baseSha: BASE_SHA }
+    },
+    ...overrides
+  }
+}
+
+function request(overrides: Partial<SubmitCodeReviewReq> = {}): SubmitCodeReviewReq {
+  return {
+    agentId: AGENT_ID,
+    platform: 'hook',
+    channel: HOOK_ID,
+    thread: THREAD,
+    event: 'COMMENT',
+    verdict: 'neutral',
+    body: 'Looks reasonable overall.',
+    ...overrides
+  }
+}
+
+interface GitlabState {
+  userId: string
+  sha: string
+  detailedMergeStatus: string
+  mergeStatusSequence: string[]
+  patchIdSha: string | null
+  reviewers: Array<{ user: { id: string }; state?: string }>
+  drafts: Array<{ id: string; note: string; position?: unknown }>
+  notes: Array<{ id: string; body: string }>
+  approvedBy: Array<{ user: { id: string } }>
+  nextId: bigint
+}
+
+function gitlabState(overrides: Partial<GitlabState> = {}): GitlabState {
+  return {
+    userId: SA_USER,
+    sha: HEAD,
+    detailedMergeStatus: 'mergeable',
+    mergeStatusSequence: [],
+    patchIdSha: 'p'.repeat(40),
+    reviewers: [],
+    drafts: [],
+    notes: [],
+    approvedBy: [],
+    nextId: 9007199254741001n,
+    ...overrides
+  }
+}
+
+interface Call {
+  method: string
+  path: string
+  query: string
+  token: string
+  body?: Record<string, unknown>
+}
+
+type Reply = 'network' | { status: number; body?: unknown }
+
+interface ScriptEntry {
+  method: string
+  path: RegExp
+  reply: Reply
+  /** Provider-side effect this scripted reply also had. */
+  then?: () => void
+  used?: boolean
+}
+
+/** Ids are written as strings here and emitted UNQUOTED, so every response exercises the
+ *  daemon's big-int-safe re-quoting exactly as GitLab's own numeric ids would. */
+function json(value: unknown, status = 200): Response {
+  const text = JSON.stringify(value).replace(/"((?:[a-z][a-z0-9_]*_)?id)":"(\d{15,})"/g, '"$1":$2')
+  return new Response(text, { status, headers: { 'content-type': 'application/json' } })
+}
+
+/** A route-driven fake GitLab; `script` intercepts the first matching call per entry. */
+function fakeGitlab(state: GitlabState, script: ScriptEntry[] = []) {
+  const calls: Call[] = []
+  const mr = () => ({
+    id: MR_ID,
+    iid: IID,
+    state: 'opened',
+    sha: state.sha,
+    detailed_merge_status: state.mergeStatusSequence.length
+      ? state.mergeStatusSequence.shift()
+      : state.detailedMergeStatus,
+    diff_refs: { base_sha: BASE_SHA, start_sha: BASE_SHA, head_sha: state.sha }
+  })
+  const nextId = () => {
+    const id = state.nextId
+    state.nextId += 1n
+    return id
+  }
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const parsed = new URL(String(url))
+    const path = parsed.pathname.replace('/api/v4', '')
+    const method = init?.method ?? 'GET'
+    const headers = (init?.headers ?? {}) as Record<string, string>
+    const body = init?.body === undefined ? undefined : (JSON.parse(String(init.body)) as Record<string, unknown>)
+    calls.push({
+      method,
+      path,
+      query: parsed.search,
+      token: headers['private-token'] ?? '',
+      ...(body === undefined ? {} : { body })
+    })
+    const hit = script.find((entry) => !entry.used && entry.method === method && entry.path.test(path))
+    if (hit) {
+      hit.used = true
+      hit.then?.()
+      if (hit.reply === 'network') throw new Error('socket hang up')
+      return new Response(hit.reply.body === undefined ? null : JSON.stringify(hit.reply.body), {
+        status: hit.reply.status,
+        ...(hit.reply.body === undefined ? {} : { headers: { 'content-type': 'application/json' } })
+      })
+    }
+    if (path === '/user') return json({ id: state.userId })
+    const mrPath = `/projects/${PROJECT}/merge_requests/${IID}`
+    if (path === mrPath) return json(mr())
+    if (path === `${mrPath}/reviewers`) return json(state.reviewers)
+    if (path === `${mrPath}/versions`) return json([{ id: 1, patch_id_sha: state.patchIdSha }])
+    if (path === `${mrPath}/notes`) return json(state.notes)
+    if (path === `${mrPath}/approvals`) {
+      return json({ id: MR_ID, sha: state.sha, approved_by: state.approvedBy })
+    }
+    if (path === `${mrPath}/draft_notes`) {
+      if (method === 'GET') return json(state.drafts)
+      const draft = { id: String(nextId()), note: String(body?.note ?? ''), position: body?.position }
+      state.drafts.push(draft)
+      return json(draft, 201)
+    }
+    if (path === `${mrPath}/draft_notes/bulk_publish`) {
+      for (const draft of state.drafts) state.notes.push({ id: String(nextId()), body: draft.note })
+      state.drafts = []
+      const reviewerState = body?.reviewer_state
+      if (typeof reviewerState === 'string') {
+        const row = state.reviewers.find((entry) => entry.user.id === state.userId)
+        if (row) row.state = reviewerState
+      }
+      return new Response(null, { status: 204 })
+    }
+    if (path.startsWith(`${mrPath}/draft_notes/`) && method === 'DELETE') {
+      const id = path.slice(`${mrPath}/draft_notes/`.length)
+      state.drafts = state.drafts.filter((draft) => draft.id !== id)
+      return new Response(null, { status: 204 })
+    }
+    if (path === `${mrPath}/approve` && method === 'POST') {
+      state.approvedBy.push({ user: { id: SA_USER } })
+      return json({ id: MR_ID, sha: state.sha, approved_by: state.approvedBy })
+    }
+    return json({ message: 'not found' }, 404)
+  }) as unknown as typeof fetch
+  return { fetchImpl, calls }
+}
+
+interface CpOptions {
+  refuse?: CodeHostReviewRefusalReason
+  supports?: boolean
+  renewPhase?: CodeHostReviewLeasePhase
+  serviceAccountUserId?: string
+}
+
+function fakeCp(opts: CpOptions = {}) {
+  const authorizations: CodeHostReviewAuthorize[] = []
+  const ops: CodeHostReviewOpRequest[] = []
+  const results: CodeHostReviewResultReport[] = []
+  const cp: GitlabReviewControlPlane = {
+    supportsReview: () => opts.supports !== false,
+    authorize: async (payload): Promise<CodeHostReviewAuthorized> => {
+      authorizations.push(payload)
+      if (opts.refuse) {
+        return { authorized: false, attemptId: payload.attemptId, reason: opts.refuse, retryable: false }
+      }
+      // The real broker refuses REQUEST_CHANGES without a current reviewer record.
+      if (payload.requestedEvent === 'REQUEST_CHANGES' && payload.serviceAccountIsReviewer !== true) {
+        return {
+          authorized: false,
+          attemptId: payload.attemptId,
+          reason: 'reviewer_assignment_required',
+          retryable: false
+        }
+      }
+      return {
+        authorized: true,
+        attemptId: payload.attemptId,
+        provider: 'gitlab',
+        projectId: payload.projectId,
+        mergeRequestIid: payload.mergeRequestIid,
+        expectedHeadSha: payload.headSha,
+        lease: {
+          attemptId: payload.attemptId,
+          fence: '7',
+          leaseUntil: '2026-01-01T00:05:00.000Z',
+          serviceAccountUserId: opts.serviceAccountUserId ?? SA_USER
+        }
+      }
+    },
+    operate: async (payload): Promise<CodeHostReviewOpAccepted> => {
+      ops.push(payload)
+      if (payload.op === 'issue') {
+        return {
+          op: 'issue',
+          recordId: `rec-${payload.kind}-${payload.ordinal}`,
+          attemptId: payload.attemptId,
+          fence: payload.fence,
+          kind: payload.kind,
+          ordinal: payload.ordinal,
+          state: 'issued',
+          phase: 'open'
+        }
+      }
+      const [, kind, ordinal] = payload.recordId.split('-')
+      return {
+        op: payload.op,
+        recordId: payload.recordId,
+        attemptId: payload.attemptId,
+        fence: payload.fence,
+        kind: kind as CodeHostReviewOpAccepted['kind'],
+        ordinal: Number(ordinal),
+        state: payload.op === 'start' ? 'request_started' : 'settled',
+        phase: 'open'
+      }
+    },
+    renew: async ({ attemptId, fence }) => ({
+      attemptId,
+      fence,
+      leaseUntil: '2026-01-01T00:10:00.000Z',
+      phase: opts.renewPhase ?? 'open'
+    }),
+    report: async (payload) => {
+      results.push(payload)
+      return { accepted: true, phase: 'settled' }
+    }
+  }
+  return { cp, authorizations, ops, results }
+}
+
+interface Harness {
+  adapter: GitlabReviewAdapter
+  state: GitlabState
+  calls: Call[]
+  ops: CodeHostReviewOpRequest[]
+  results: CodeHostReviewResultReport[]
+  authorizations: CodeHostReviewAuthorize[]
+  tokens: () => string[]
+  invalidated: () => string[]
+}
+
+function harness(
+  opts: {
+    state?: GitlabState
+    script?: ScriptEntry[]
+    cp?: CpOptions
+    tokens?: string[]
+    hook?: HookDispatchContext
+  } = {}
+): Harness {
+  const state = opts.state ?? gitlabState()
+  const gitlab = fakeGitlab(state, opts.script ?? [])
+  const control = fakeCp(opts.cp ?? {})
+  const supply = opts.tokens ?? ['glpat-effect-1']
+  const minted: string[] = []
+  const invalidated: string[] = []
+  let clock = 1_000
+  const adapter = new GitlabReviewAdapter({
+    cp: () => control.cp,
+    orgForAgent: () => 'org-1',
+    token: async () => {
+      const token = supply[Math.min(minted.length, supply.length - 1)]!
+      minted.push(token)
+      return token
+    },
+    invalidateToken: (_turn, token) => void invalidated.push(token),
+    log: { warn: () => {} },
+    baseUrl: BASE,
+    fetchImpl: gitlab.fetchImpl,
+    markerKey: MARKER_KEY,
+    newAttemptId: () => ATTEMPT,
+    newStartToken: () => `start-${control.ops.filter((op) => op.op === 'issue').length}`,
+    now: () => clock,
+    sleep: async (ms) => void (clock += ms),
+    ambiguousWindowMs: 4_000,
+    mergeStatusWindowMs: 4_000,
+    pollIntervalMs: 1_000
+  })
+  adapter.openTurn(KEY, opts.hook ?? hookContext(), 'acp-session-1', DAEMON_ID)
+  return {
+    adapter,
+    state,
+    calls: gitlab.calls,
+    ops: control.ops,
+    results: control.results,
+    authorizations: control.authorizations,
+    tokens: () => minted,
+    invalidated: () => invalidated
+  }
+}
+
+const mutations = (calls: Call[]) =>
+  calls.filter((call) => call.method !== 'GET').map((call) => `${call.method} ${call.path}`)
+const drafted = (calls: Call[]) => calls.filter((call) => call.method === 'POST' && call.path.endsWith('/draft_notes'))
+const published = (calls: Call[]) => calls.filter((call) => call.path.endsWith('/bulk_publish'))
+
+function seedDraft(state: GitlabState, attemptId: string, ordinal: number, headSha = HEAD, id?: string): string {
+  const draftId = id ?? String(state.nextId++)
+  state.drafts.push({ id: draftId, note: `stale body\n\n${signer.mint(attemptId, ordinal, headSha)}` })
+  return draftId
+}
+
+describe('GitLab review adapter — pre-effect rejections (§15)', () => {
+  it('rejects an incompatible event/verdict pair before any provider or control-plane call', async () => {
+    const h = harness()
+    await expect(h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'fail' }))).rejects.toThrow(
+      /APPROVE requires verdict=pass/
+    )
+    await expect(h.adapter.submit(KEY, request({ event: 'REQUEST_CHANGES', verdict: 'neutral' }))).rejects.toThrow(
+      /REQUEST_CHANGES requires verdict=fail/
+    )
+    expect(h.calls).toEqual([])
+    expect(h.authorizations).toEqual([])
+  })
+
+  it('rejects an empty body and an event above the hook policy before any provider call', async () => {
+    const h = harness({ hook: hookContext({ snapshot: { ...SNAPSHOT, reviewPolicy: 'comment' } }) })
+    await expect(h.adapter.submit(KEY, request({ body: '   ' }))).rejects.toThrow(/non-empty body/)
+    await expect(h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))).rejects.toThrow(
+      /exceeds this hook's comment review policy/
+    )
+    expect(h.calls).toEqual([])
+  })
+
+  it('refuses when the control plane does not advertise codehost-review-v1', async () => {
+    const h = harness({ cp: { supports: false } })
+    await expect(h.adapter.submit(KEY, request())).rejects.toThrow(/codehost-review-v1/)
+    expect(h.calls).toEqual([])
+  })
+
+  it('allows only one review attempt per turn', async () => {
+    const h = harness()
+    await h.adapter.submit(KEY, request())
+    await expect(h.adapter.submit(KEY, request())).rejects.toThrow(/already has a formal review attempt/)
+    expect(published(h.calls)).toHaveLength(1)
+  })
+
+  it('is unavailable outside an authorized active merge-request turn', async () => {
+    const h = harness()
+    await expect(h.adapter.submit('other-key', request())).rejects.toThrow(/active merge-request hook turn/)
+    h.adapter.closeTurn(KEY)
+    expect(h.adapter.owns(KEY, AGENT_ID)).toBe(false)
+  })
+
+  it('opens no review turn for a non-review delivery', () => {
+    const h = harness()
+    expect(
+      h.adapter.openTurn('k2', hookContext({ snapshot: { ...SNAPSHOT, reviewPolicy: 'off' } }), 's', DAEMON_ID)
+    ).toBeUndefined()
+    expect(
+      h.adapter.openTurn(
+        'k3',
+        hookContext({
+          gitlab: { projectId: PROJECT, projectPath: 'g/p', target: { kind: 'issue', iid: 5 } }
+        }),
+        's',
+        DAEMON_ID
+      )
+    ).toBeUndefined()
+    expect(h.adapter.openTurn('k4', hookContext(), 's', 'another-daemon')).toBeUndefined()
+  })
+})
+
+describe('GitLab review adapter — the happy COMMENT path (§15 steps 4-12)', () => {
+  it('creates marker-signed drafts, verifies the exact set, publishes once, and reports submitted', async () => {
+    const h = harness()
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({ comments: [{ path: 'src/a.ts', body: 'Bug here.', line: 9, side: 'RIGHT' }] })
+    )) as GitlabReviewOutcome
+
+    expect(outcome.state).toBe('submitted')
+    expect(outcome.message).toContain('published on the merge request')
+    expect(drafted(h.calls)).toHaveLength(2)
+    expect(published(h.calls)).toHaveLength(1)
+    // The summary is draft ordinal 0 and the inline comment carries the exact diff refs.
+    const [summary, inline] = drafted(h.calls)
+    expect(String(summary!.body!.note)).toContain('Looks reasonable overall.')
+    expect(String(summary!.body!.note)).toContain(signer.mint(ATTEMPT, 0, HEAD))
+    expect(String(inline!.body!.note)).toContain(signer.mint(ATTEMPT, 1, HEAD))
+    expect(inline!.body!.position).toMatchObject({
+      position_type: 'text',
+      base_sha: BASE_SHA,
+      head_sha: HEAD,
+      new_path: 'src/a.ts',
+      new_line: 9
+    })
+    // COMMENT omits reviewer_state per the §15 table.
+    expect(published(h.calls)[0]!.body).toEqual({})
+    // Body-free result: ids and one normalized state, never review text.
+    const report = h.results.at(-1)!
+    expect(report).toMatchObject({ provider: 'gitlab', projectId: PROJECT, mergeRequestIid: IID, state: 'submitted' })
+    expect(JSON.stringify(report)).not.toContain('Looks reasonable overall.')
+    expect(report.externalIds?.[0]).toMatchObject({ kind: 'note' })
+    // Big-int ids survive as decimal strings.
+    expect(report.externalIds?.[0]?.externalId).toMatch(/^\d{16}$/)
+  })
+
+  it('runs issue → start → settle for every provider mutation, with one start token per record', async () => {
+    const h = harness()
+    await h.adapter.submit(KEY, request())
+    const sequence = h.ops.map((op) => (op.op === 'issue' ? `issue:${op.kind}:${op.ordinal}` : `${op.op}`))
+    expect(sequence).toEqual(['issue:draft_create:0', 'start', 'settle', 'issue:bulk_publish:0', 'start', 'settle'])
+    const starts = h.ops.filter((op) => op.op === 'start')
+    expect(new Set(starts.map((op) => (op as { startToken: string }).startToken)).size).toBe(starts.length)
+    // Every start names a record that was issued first, and the ledger stays fenced.
+    expect(h.ops.every((op) => op.fence === '7')).toBe(true)
+  })
+
+  it('carries the reviewer fact into the authorization and keeps an unchanged state as submitted', async () => {
+    const state = gitlabState({ reviewers: [{ user: { id: SA_USER }, state: 'unreviewed' }] })
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(h.authorizations[0]).toMatchObject({
+      provider: 'gitlab',
+      projectId: PROJECT,
+      mergeRequestIid: IID,
+      headSha: HEAD,
+      serviceAccountIsReviewer: true
+    })
+    expect(outcome.state).toBe('submitted')
+  })
+
+  it('records review_state_changed_unexpectedly when the reviewer record moves under a COMMENT', async () => {
+    const before = [{ user: { id: SA_USER }, state: 'unreviewed' }]
+    const h = harness({
+      state: gitlabState({ reviewers: before }),
+      // The pre-lease and step-10 reads agree; only the postcondition read differs.
+      script: [
+        { method: 'GET', path: /\/reviewers$/, reply: { status: 200, body: before } },
+        { method: 'GET', path: /\/reviewers$/, reply: { status: 200, body: before } },
+        { method: 'GET', path: /\/reviewers$/, reply: { status: 200, body: [] } }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('review_state_changed_unexpectedly')
+    expect(h.results.at(-1)!.state).toBe('review_state_changed_unexpectedly')
+    expect(published(h.calls)).toHaveLength(1)
+  })
+})
+
+describe('GitLab review adapter — reviewer prerequisites (§15 steps 7 and 10)', () => {
+  it('refuses REQUEST_CHANGES without a reviewer record before any draft exists', async () => {
+    const h = harness()
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({ event: 'REQUEST_CHANGES', verdict: 'fail' })
+    )) as GitlabReviewOutcome
+    expect(outcome.state).toBe('reviewer_assignment_required')
+    expect(outcome.message).toContain('COMMENT and verdict fail')
+    expect(h.authorizations[0]!.serviceAccountIsReviewer).toBe(false)
+    expect(mutations(h.calls)).toEqual([])
+  })
+
+  it('deletes this attempt’s drafts when the reviewer record disappears immediately before publication', async () => {
+    const state = gitlabState({ reviewers: [{ user: { id: SA_USER }, state: 'unreviewed' }] })
+    const h = harness({
+      state,
+      // The step-10 read is the third `/reviewers` GET; drop the record only there.
+      script: [
+        { method: 'GET', path: /\/reviewers$/, reply: { status: 200, body: state.reviewers } },
+        { method: 'GET', path: /\/reviewers$/, reply: { status: 200, body: [] } }
+      ]
+    })
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({ event: 'REQUEST_CHANGES', verdict: 'fail' })
+    )) as GitlabReviewOutcome
+    expect(outcome.state).toBe('reviewer_assignment_required')
+    expect(published(h.calls)).toEqual([])
+    expect(mutations(h.calls).filter((call) => call.startsWith('DELETE'))).toHaveLength(1)
+    expect(state.drafts).toEqual([])
+  })
+
+  it('publishes REQUEST_CHANGES with the reviewer_state parameter and confirms the recorded state', async () => {
+    const state = gitlabState({ reviewers: [{ user: { id: SA_USER }, state: 'unreviewed' }] })
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({ event: 'REQUEST_CHANGES', verdict: 'fail' })
+    )) as GitlabReviewOutcome
+    expect(published(h.calls)[0]!.body).toEqual({ reviewer_state: 'requested_changes' })
+    expect(outcome.state).toBe('submitted')
+  })
+
+  it('classifies a missing requested-changes record from the refreshed merge status', async () => {
+    const blocked = gitlabState({
+      reviewers: [{ user: { id: SA_USER }, state: 'unreviewed' }],
+      mergeStatusSequence: ['mergeable', 'mergeable', 'checking', 'requested_changes']
+    })
+    // The publish leaves the reviewer record behind, so only mergeability can answer.
+    const h = harness({
+      state: blocked,
+      script: [{ method: 'POST', path: /bulk_publish$/, reply: { status: 204 } }]
+    })
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({ event: 'REQUEST_CHANGES', verdict: 'fail' })
+    )) as GitlabReviewOutcome
+    expect(outcome.state).toBe('requested_changes_block_observed')
+    // The recheck is requested rather than read from a stale value.
+    expect(h.calls.some((call) => call.query.includes('with_merge_status_recheck=true'))).toBe(true)
+    expect(published(h.calls)).toHaveLength(1)
+  })
+
+  it('records requested_changes_state_ambiguous when mergeability never settles on the block', async () => {
+    const unstable = gitlabState({
+      reviewers: [{ user: { id: SA_USER }, state: 'unreviewed' }],
+      detailedMergeStatus: 'checking'
+    })
+    const h = harness({
+      state: unstable,
+      script: [{ method: 'POST', path: /bulk_publish$/, reply: { status: 204 } }]
+    })
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({ event: 'REQUEST_CHANGES', verdict: 'fail' })
+    )) as GitlabReviewOutcome
+    expect(outcome.state).toBe('requested_changes_state_ambiguous')
+    expect(published(h.calls)).toHaveLength(1)
+  })
+})
+
+describe('GitLab review adapter — head and draft-set fencing (§15 steps 5, 9, 11)', () => {
+  it('rejects a changed head before creating any draft', async () => {
+    const h = harness({ state: gitlabState({ sha: OTHER_HEAD }) })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('not_submitted')
+    expect(mutations(h.calls)).toEqual([])
+    expect(h.results.at(-1)!.state).toBe('not_submitted')
+  })
+
+  it('rejects a head that changes at the pre-publication re-verification and deletes its drafts', async () => {
+    const state = gitlabState()
+    const h = harness({
+      state,
+      script: [
+        {
+          method: 'GET',
+          path: /merge_requests\/77$/,
+          reply: {
+            status: 200,
+            body: {
+              sha: HEAD,
+              diff_refs: { base_sha: BASE_SHA, start_sha: BASE_SHA, head_sha: HEAD },
+              detailed_merge_status: 'mergeable'
+            }
+          }
+        },
+        {
+          method: 'GET',
+          path: /merge_requests\/77$/,
+          reply: {
+            status: 200,
+            body: {
+              sha: OTHER_HEAD,
+              diff_refs: { base_sha: BASE_SHA, start_sha: BASE_SHA, head_sha: OTHER_HEAD },
+              detailed_merge_status: 'mergeable'
+            }
+          }
+        }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('not_submitted')
+    expect(published(h.calls)).toEqual([])
+    expect(state.drafts).toEqual([])
+  })
+
+  it('fails closed when the pending draft set is not exactly this attempt’s', async () => {
+    const foreign = { id: '9007199254749999', note: `foreign\n\n${signer.mint(OLD_ATTEMPT, 0, HEAD)}` }
+    const h = harness({
+      // Reconcile sees nothing; a concurrent draft appears by the step-9 exact-set check.
+      script: [
+        { method: 'GET', path: /draft_notes$/, reply: { status: 200, body: [] } },
+        { method: 'GET', path: /draft_notes$/, reply: { status: 200, body: [foreign] } }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('review_reconciliation_required')
+    expect(published(h.calls)).toEqual([])
+    expect(h.results.at(-1)!.state).toBe('review_reconciliation_required')
+  })
+})
+
+describe('GitLab review adapter — orphan reconciliation (§15.1)', () => {
+  it('recovers this attempt’s own pending drafts by ordinal instead of creating them again', async () => {
+    const state = gitlabState()
+    const recovered = seedDraft(state, ATTEMPT, 0)
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(drafted(h.calls)).toEqual([])
+    expect(h.results.at(-1)!.state).toBe('submitted')
+    expect(recovered).toMatch(/^\d+$/)
+  })
+
+  it('deletes an expired attempt’s drafts individually before starting a new one', async () => {
+    const state = gitlabState()
+    const stale = seedDraft(state, OLD_ATTEMPT, 0)
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    const deletes = h.calls.filter((call) => call.method === 'DELETE')
+    expect(deletes).toHaveLength(1)
+    expect(deletes[0]!.path).toContain(stale)
+    expect(h.ops.some((op) => op.op === 'issue' && op.kind === 'draft_delete')).toBe(true)
+    // The delete precedes the first create.
+    const deleteAt = h.calls.findIndex((call) => call.method === 'DELETE')
+    const createAt = h.calls.findIndex((call) => call.method === 'POST' && call.path.endsWith('/draft_notes'))
+    expect(deleteAt).toBeLessThan(createAt)
+  })
+
+  it('reads back after an ambiguous delete and fails closed when the draft is still pending', async () => {
+    const state = gitlabState()
+    seedDraft(state, OLD_ATTEMPT, 0, HEAD, '9007199254742222')
+    const h = harness({
+      state,
+      script: [{ method: 'DELETE', path: /draft_notes\//, reply: 'network' }]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('review_reconciliation_required')
+    expect(drafted(h.calls)).toEqual([])
+    expect(h.results.at(-1)!.state).toBe('review_reconciliation_required')
+  })
+
+  it('treats a 404 on a stale draft as the absence it asked for', async () => {
+    const state = gitlabState()
+    seedDraft(state, OLD_ATTEMPT, 0, HEAD, '9007199254747777')
+    const h = harness({
+      state,
+      script: [
+        {
+          method: 'DELETE',
+          path: /draft_notes\//,
+          reply: { status: 404, body: { message: '404 Not found' } },
+          then: () => void (state.drafts = [])
+        }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+  })
+
+  it('fails closed on an unmarked pending draft', async () => {
+    const state = gitlabState()
+    state.drafts.push({ id: '9007199254743333', note: 'someone else was here' })
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('review_reconciliation_required')
+    expect(mutations(h.calls)).toEqual([])
+  })
+
+  it('fails closed on a marker this daemon cannot verify', async () => {
+    const state = gitlabState()
+    const foreign = new ReviewMarkerSigner(Buffer.from('a-different-daemons-marker-key-01'))
+    state.drafts.push({ id: '9007199254744444', note: `x\n\n${foreign.mint(OLD_ATTEMPT, 0, HEAD)}` })
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('review_reconciliation_required')
+  })
+
+  it('cannot be confused by a marker the model planted in its own review body', async () => {
+    const h = harness()
+    const planted = signer.mint(ATTEMPT, 0, HEAD)
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({ body: `Please look here.\n${planted}` })
+    )) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    const note = String(drafted(h.calls)[0]!.body!.note)
+    // The authored copy is defanged so exactly one verifiable marker remains.
+    expect(note.split('<!-- agentconnect-review:')).toHaveLength(2)
+  })
+})
+
+describe('GitLab review adapter — ambiguous publication (§15.2)', () => {
+  it('identifies an ambiguous publish by its summary marker and never publishes twice', async () => {
+    const state = gitlabState()
+    const h = harness({
+      state,
+      script: [
+        {
+          method: 'POST',
+          path: /bulk_publish$/,
+          reply: 'network'
+        }
+      ]
+    })
+    // The request actually landed: the summary note is visible under this attempt's marker.
+    state.notes.push({ id: '9007199254745555', body: `summary\n\n${signer.mint(ATTEMPT, 0, HEAD)}` })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(published(h.calls)).toHaveLength(1)
+    expect(outcome.externalIds).toEqual([{ kind: 'note', externalId: '9007199254745555' }])
+    // The ambiguous record is settled by positive identification, not left ambiguous.
+    const settle = h.ops.filter((op) => op.op === 'settle').at(-1) as { outcome: { kind: string; externalId?: string } }
+    expect(settle.outcome).toMatchObject({ kind: 'deterministic', externalId: '9007199254745555' })
+  })
+
+  it('locks the merge request when no marker appears within the observation window', async () => {
+    const h = harness({
+      script: [{ method: 'POST', path: /bulk_publish$/, reply: 'network' }]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('ambiguous_locked')
+    expect(outcome.message).toContain('no fallback comment was posted')
+    expect(published(h.calls)).toHaveLength(1)
+    expect(h.results.at(-1)).toMatchObject({ state: 'ambiguous_locked' })
+    expect(h.results.at(-1)!.externalIds).toBeUndefined()
+    const settle = h.ops.filter((op) => op.op === 'settle').at(-1) as { outcome: { kind: string } }
+    expect(settle.outcome.kind).toBe('ambiguous')
+  })
+
+  it('reports not_submitted for a deterministic publish rejection', async () => {
+    const h = harness({
+      script: [{ method: 'POST', path: /bulk_publish$/, reply: { status: 422, body: { message: 'no drafts' } } }]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('not_submitted')
+    expect(h.results.at(-1)!.externalIds).toBeUndefined()
+  })
+
+  it('surfaces a control-plane ambiguous_locked refusal without touching the provider', async () => {
+    const h = harness({ cp: { refuse: 'ambiguous_locked' } })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('ambiguous_locked')
+    expect(mutations(h.calls)).toEqual([])
+  })
+
+  it('stops before publication when the lease has already locked at renewal', async () => {
+    const h = harness({ cp: { renewPhase: 'ambiguous_locked' } })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('ambiguous_locked')
+    expect(published(h.calls)).toEqual([])
+  })
+})
+
+describe('GitLab review adapter — approval (§15 step 13)', () => {
+  it('waits for a settled merge status and diff, approves on the exact head, and verifies approved_by', async () => {
+    const state = gitlabState({
+      mergeStatusSequence: ['mergeable', 'mergeable', 'mergeable', 'checking', 'approvals_syncing', 'mergeable']
+    })
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    const approve = h.calls.find((call) => call.path.endsWith('/approve'))!
+    expect(approve.body).toEqual({ sha: HEAD })
+    expect(published(h.calls)[0]!.body).toEqual({})
+    expect(h.ops.some((op) => op.op === 'issue' && op.kind === 'approval')).toBe(true)
+    expect(outcome.externalIds).toContainEqual({ kind: 'approval', externalId: MR_ID })
+  })
+
+  it('records approval_not_recorded, with no fallback, when the approval is rejected after publication', async () => {
+    const h = harness({
+      script: [
+        { method: 'POST', path: /\/approve$/, reply: { status: 422, body: { message: 'not an eligible approver' } } }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))) as GitlabReviewOutcome
+    expect(outcome.state).toBe('approval_not_recorded')
+    expect(published(h.calls)).toHaveLength(1)
+    // A published effect exists, so the result keeps its external ids and never republishes.
+    expect(h.results.at(-1)!.state).toBe('approval_not_recorded')
+  })
+
+  it('records approval_not_recorded when the diff never produces a patch id', async () => {
+    const h = harness({ state: gitlabState({ patchIdSha: null }) })
+    const outcome = (await h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))) as GitlabReviewOutcome
+    expect(outcome.state).toBe('approval_not_recorded')
+    expect(h.calls.some((call) => call.path.endsWith('/approve'))).toBe(false)
+  })
+
+  it('identifies an ambiguous approval from the readback instead of retrying it', async () => {
+    const state = gitlabState()
+    const h = harness({
+      state,
+      script: [{ method: 'POST', path: /\/approve$/, reply: 'network' }]
+    })
+    state.approvedBy.push({ user: { id: SA_USER } })
+    const outcome = (await h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(h.calls.filter((call) => call.path.endsWith('/approve'))).toHaveLength(1)
+  })
+
+  it('does not accept an approval recorded for somebody else', async () => {
+    const state = gitlabState()
+    const h = harness({
+      state,
+      script: [
+        {
+          method: 'POST',
+          path: /\/approve$/,
+          reply: { status: 201, body: { id: MR_ID, sha: HEAD, approved_by: [{ user: { id: HUMAN_USER } }] } }
+        }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))) as GitlabReviewOutcome
+    expect(outcome.state).toBe('approval_not_recorded')
+  })
+})
+
+describe('GitLab review adapter — credentials and features', () => {
+  it('refreshes the effect lease exactly once after a definite 401 and retries under a new record', async () => {
+    const h = harness({
+      tokens: ['glpat-stale', 'glpat-fresh'],
+      script: [{ method: 'POST', path: /draft_notes$/, reply: { status: 401, body: { message: 'unauthorized' } } }]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(h.invalidated()).toEqual(['glpat-stale'])
+    const creates = drafted(h.calls)
+    expect(creates).toHaveLength(2)
+    expect(creates[0]!.token).toBe('glpat-stale')
+    expect(creates[1]!.token).toBe('glpat-fresh')
+    // One record permits one request, so the retry took the next ordinal.
+    const issued = h.ops.filter((op) => op.op === 'issue' && op.kind === 'draft_create')
+    expect(issued.map((op) => (op as { ordinal: number }).ordinal)).toEqual([0, 1])
+  })
+
+  it('routes a code review to the adapter that owns the active turn', async () => {
+    const h = harness()
+    const router = new CodeHostReviewRouter()
+    const github = { provider: 'github' as const, owns: () => false, submit: vi.fn() }
+    router.register(github)
+    router.register(h.adapter)
+    const outcome = (await router.submit(request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(github.submit).not.toHaveBeenCalled()
+    await expect(router.submit(request({ channel: 'nowhere' }))).rejects.toThrow(/active pull\/merge request hook turn/)
+  })
+
+  it('advertises codehost-review-v1 in the daemon registration features', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-review-feature-'))
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({ version: 1, controlPlane: { enabled: false }, runtimes: {} })
+    )
+    mkdirSync(join(root, 'agents'), { recursive: true })
+    const daemon = new Daemon({
+      root,
+      hostFactory: () => ({ start: vi.fn(async () => {}), stop: vi.fn(async () => {}) }) as never
+    })
+    await daemon.start()
+    try {
+      expect((daemon as never as Record<string, () => string[]>).registrationFeatures()).toContain(
+        CODEHOST_REVIEW_V1_FEATURE
+      )
+    } finally {
+      await daemon.stop().catch(() => {})
+    }
+  }, 20_000)
+})

--- a/packages/daemon/test/gitlab-review-adapter.test.ts
+++ b/packages/daemon/test/gitlab-review-adapter.test.ts
@@ -23,6 +23,7 @@ import { CodeHostReviewRouter, type SubmitCodeReviewReq } from '../src/codehost/
 import {
   codeHostReviewFallbackAllowed,
   hookOutputFallbackAllowed,
+  type CodeReviewAttempt,
   type HookDispatchContext
 } from '../src/github/hook-coords.js'
 import {
@@ -237,6 +238,8 @@ interface CpOptions {
   seedStarted?: string[]
   /** Return an error to fail that delivery; the frame is then owed and replayed. */
   operateFails?: (op: CodeHostReviewOpRequest) => Error | undefined
+  /** Return an error to refuse a `return-unused` frame. */
+  returnUnusedFails?: () => Error | undefined
   reportFails?: (result: CodeHostReviewResultReport) => Error | undefined
 }
 
@@ -280,7 +283,12 @@ function fakeCp(opts: CpOptions = {}) {
     },
     operate: async (payload): Promise<CodeHostReviewOpAccepted> => {
       ops.push(payload)
-      const failure = payload.op === 'settle' ? opts.operateFails?.(payload) : undefined
+      const failure =
+        payload.op === 'settle'
+          ? opts.operateFails?.(payload)
+          : payload.op === 'return-unused'
+            ? opts.returnUnusedFails?.()
+            : undefined
       if (failure) throw failure
       if (payload.op === 'issue') {
         const recordId = `rec-${payload.kind}-${payload.ordinal}`
@@ -299,6 +307,7 @@ function fakeCp(opts: CpOptions = {}) {
       }
       const [, kind, ordinal] = payload.recordId.split('-')
       records.set(payload.recordId, payload.op === 'start' ? 'request_started' : 'settled')
+      if (payload.op === 'return-unused') records.set(payload.recordId, 'settled')
       return {
         op: payload.op,
         recordId: payload.recordId,
@@ -1185,6 +1194,7 @@ describe('GitLab review adapter — started-operation recovery (round 3)', () =>
             kind: 'draft_create',
             ordinal: 0,
             target: `/projects/${PROJECT}/merge_requests/${IID}/draft_notes`,
+            phase: 'started',
             draftOrdinal: 0
           }
         ]
@@ -1255,7 +1265,8 @@ describe('GitLab review adapter — started-operation recovery (round 3)', () =>
             startToken: 'start-1',
             kind: 'bulk_publish',
             ordinal: 0,
-            target: `/projects/${PROJECT}/merge_requests/${IID}/draft_notes/bulk_publish`
+            target: `/projects/${PROJECT}/merge_requests/${IID}/draft_notes/bulk_publish`,
+            phase: 'started'
           }
         ]
       }
@@ -1283,7 +1294,8 @@ describe('GitLab review adapter — started-operation recovery (round 3)', () =>
             startToken: 'start-1',
             kind: 'bulk_publish',
             ordinal: 0,
-            target: `/projects/${PROJECT}/merge_requests/${IID}/draft_notes/bulk_publish`
+            target: `/projects/${PROJECT}/merge_requests/${IID}/draft_notes/bulk_publish`,
+            phase: 'started'
           }
         ]
       }
@@ -1295,6 +1307,132 @@ describe('GitLab review adapter — started-operation recovery (round 3)', () =>
     expect(published(h.calls)).toEqual([])
     expect(outcome.externalIds).toEqual([{ kind: 'note', externalId: '9007199254746777' }])
     expect(codeHostReviewFallbackAllowed(h.hook)).toBe(false)
+  })
+})
+
+describe('GitLab review adapter — the durable chain across every crash point (round 4)', () => {
+  /** A crash at a chosen point, as the durable hook row records it. */
+  function crashedAt(phase: 'issued' | 'started', overrides: Partial<CodeReviewAttempt> = {}): HookDispatchContext {
+    return hookContext({
+      codeReview: {
+        attemptId: ATTEMPT,
+        event: 'COMMENT',
+        verdict: 'neutral',
+        headSha: HEAD,
+        fence: '7',
+        ordinals: { draft_create: 1 },
+        operations: [
+          {
+            recordId: 'rec-draft_create-0',
+            startToken: 'start-0',
+            kind: 'draft_create',
+            ordinal: 0,
+            target: `/projects/${PROJECT}/merge_requests/${IID}/draft_notes`,
+            phase,
+            draftOrdinal: 0
+          }
+        ],
+        ...overrides
+      }
+    })
+  }
+
+  it('returns a permit whose start was never acknowledged instead of settling it', async () => {
+    const hook = crashedAt('issued')
+    const h = harness({ hook, seedStarted: [] })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    // The unstarted permit is handed back, never settled — settling one is refused as `not_started`.
+    expect(h.ops.some((op) => op.op === 'return-unused' && op.recordId === 'rec-draft_create-0')).toBe(true)
+    expect(h.ops.some((op) => op.op === 'settle' && op.recordId === 'rec-draft_create-0')).toBe(false)
+    expect(h.hook.codeReview?.operations).toEqual([])
+    expect([...h.records.values()].filter((state) => state === 'request_started')).toEqual([])
+  })
+
+  it('falls through to marker reconciliation when the start had raced ahead of the local flip', async () => {
+    const state = gitlabState()
+    const draftId = '9007199254746333'
+    state.drafts.push({ id: draftId, note: `summary\n\n${signer.mint(ATTEMPT, 0, HEAD)}` })
+    const h = harness({
+      state,
+      hook: crashedAt('issued'),
+      // The control plane had already started it, so the return is permanently refused.
+      cp: { returnUnusedFails: () => Object.assign(new Error('already started'), { retryable: false }) }
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    const settle = h.ops.find((op) => op.op === 'settle' && op.recordId === 'rec-draft_create-0') as {
+      outcome: { kind: string; externalId?: string }
+    }
+    expect(settle.outcome).toEqual({ kind: 'deterministic', status: 201, externalId: draftId })
+  })
+
+  it('never clears coordinates on a refusal it could not classify', async () => {
+    const h = harness({
+      hook: crashedAt('issued'),
+      // A transport failure decides nothing, so the permit stays exactly where it was.
+      cp: { returnUnusedFails: () => Object.assign(new Error('unreachable'), { retryable: true }) }
+    })
+    await h.adapter.submit(KEY, request())
+    expect(h.hook.codeReview?.operations?.map((op) => op.recordId)).toEqual(['rec-draft_create-0'])
+  })
+
+  it('keeps a started operation’s coordinates when its settle is neither durable nor acked', async () => {
+    const store = new FakeReviewStore()
+    store.failWrites = Number.POSITIVE_INFINITY
+    const h = harness({
+      reviewStore: store,
+      cp: { operateFails: () => Object.assign(new Error('unreachable'), { retryable: true }) }
+    })
+    await h.adapter.submit(KEY, request())
+    // Nothing durable owes the settle, so the only record that could rebuild it survives.
+    expect(store.rows.size).toBe(0)
+    expect((h.hook.codeReview?.operations ?? []).length).toBeGreaterThan(0)
+    // The result frame WAS acknowledged, so its own upstream marker is released independently.
+    expect(h.hook.codeReview?.resultOwed).toBeUndefined()
+  })
+
+  it('rebuilds the owed settle and result from the upstream records after the process dies', async () => {
+    const store = new FakeReviewStore()
+    store.failWrites = Number.POSITIVE_INFINITY
+    const first = harness({
+      reviewStore: store,
+      cp: {
+        operateFails: () => Object.assign(new Error('unreachable'), { retryable: true }),
+        reportFails: () => Object.assign(new Error('unreachable'), { retryable: true })
+      }
+    })
+    await first.adapter.submit(KEY, request())
+    expect(store.rows.size).toBe(0)
+    const owedOps = (first.hook.codeReview?.operations ?? []).filter((op) => op.phase === 'issued')
+
+    // A NEW adapter over the SAME store and hook row, with a control plane that answers.
+    store.failWrites = 0
+    const replay = harness({ reviewStore: store, hook: first.hook, open: false })
+    const turn = replay.adapter.openTurn(KEY, first.hook, 'acp-session-2', {
+      daemonId: DAEMON_ID,
+      persist: async () => {}
+    })!
+    await replay.adapter.recoverTurn(turn)
+    // The result frame is rebuilt from the attempt record alone and taken by the control plane.
+    expect(replay.results.at(-1)).toMatchObject({ attemptId: ATTEMPT, state: 'submitted', provider: 'gitlab' })
+    expect(first.hook.codeReview?.resultOwed).toBeUndefined()
+    // Coordinates whose settle is still unowed are kept, not silently dropped.
+    expect((first.hook.codeReview?.operations ?? []).length).toBeGreaterThan(0)
+    expect(owedOps).toEqual([])
+    expect(store.rows.size).toBe(0)
+  })
+
+  it('hands back an unstarted permit from its coordinates alone, with no turn replay', async () => {
+    const hook = crashedAt('issued', { state: 'not_submitted', resultOwed: true })
+    const h = harness({ hook, open: false })
+    const turn = h.adapter.openTurn(KEY, hook, 'acp-session-2', { daemonId: DAEMON_ID, persist: async () => {} })!
+    await h.adapter.recoverTurn(turn)
+    expect(h.ops.some((op) => op.op === 'return-unused' && op.recordId === 'rec-draft_create-0')).toBe(true)
+    expect(hook.codeReview?.operations).toEqual([])
+    // ...and the classified-but-unreported result goes with it.
+    expect(h.results.at(-1)).toMatchObject({ attemptId: ATTEMPT, state: 'not_submitted' })
+    expect(hook.codeReview?.resultOwed).toBeUndefined()
   })
 })
 
@@ -1332,6 +1470,39 @@ describe('GitLab review adapter — owed frames are never dropped (round 3)', ()
     expect(h.results.filter((row) => row.attemptId === ATTEMPT)).toHaveLength(2)
     expect(store.rows.size).toBe(0)
     expect(h.timer.armed()).toBe(0)
+  })
+
+  it('stays armed when a sweep hits its page cap with rows still unseen', async () => {
+    const store = new FakeReviewStore()
+    // Two rows per page against a 50-page cap leaves the 101st row unseen.
+    store.pageSize = 2
+    for (let index = 0; index < 101; index += 1) {
+      await store.recordReviewIntent({
+        intentId: `capped-${index}`,
+        daemonId: DAEMON_ID,
+        attemptId: ATTEMPT,
+        kind: 'result',
+        frame: JSON.stringify({
+          hookId: HOOK_ID,
+          deliveryKey: 'delivery-1',
+          attemptId: ATTEMPT,
+          snapshot: SNAPSHOT,
+          provider: 'gitlab',
+          projectId: PROJECT,
+          mergeRequestIid: IID,
+          event: 'COMMENT',
+          verdict: 'neutral',
+          headSha: HEAD,
+          state: 'submitted'
+        }),
+        attempts: 0
+      })
+    }
+    const h = harness({ reviewStore: store, open: false })
+    await h.adapter.reconcilePending()
+    // The cap proves nothing about what is left, so the scheduler keeps the chain alive.
+    expect(store.rows.size).toBeGreaterThan(0)
+    expect(h.timer.armed()).toBe(1)
   })
 
   it('drains every page of owed frames before it goes quiet', async () => {

--- a/packages/daemon/test/gitlab-review-adapter.test.ts
+++ b/packages/daemon/test/gitlab-review-adapter.test.ts
@@ -233,12 +233,17 @@ interface CpOptions {
   supports?: boolean
   renewPhase?: CodeHostReviewLeasePhase
   serviceAccountUserId?: string
+  /** Operation records a previous incarnation left permitted but unsettled. */
+  seedStarted?: string[]
   /** Return an error to fail that delivery; the frame is then owed and replayed. */
   operateFails?: (op: CodeHostReviewOpRequest) => Error | undefined
   reportFails?: (result: CodeHostReviewResultReport) => Error | undefined
 }
 
 function fakeCp(opts: CpOptions = {}) {
+  const records = new Map<string, 'issued' | 'request_started' | 'settled'>(
+    (opts.seedStarted ?? []).map((id) => [id, 'request_started' as const])
+  )
   const authorizations: CodeHostReviewAuthorize[] = []
   const ops: CodeHostReviewOpRequest[] = []
   const results: CodeHostReviewResultReport[] = []
@@ -278,9 +283,12 @@ function fakeCp(opts: CpOptions = {}) {
       const failure = payload.op === 'settle' ? opts.operateFails?.(payload) : undefined
       if (failure) throw failure
       if (payload.op === 'issue') {
+        const recordId = `rec-${payload.kind}-${payload.ordinal}`
+        if (records.get(recordId) === 'settled') throw new Error('permit conflict')
+        records.set(recordId, 'issued')
         return {
           op: 'issue',
-          recordId: `rec-${payload.kind}-${payload.ordinal}`,
+          recordId,
           attemptId: payload.attemptId,
           fence: payload.fence,
           kind: payload.kind,
@@ -290,6 +298,7 @@ function fakeCp(opts: CpOptions = {}) {
         }
       }
       const [, kind, ordinal] = payload.recordId.split('-')
+      records.set(payload.recordId, payload.op === 'start' ? 'request_started' : 'settled')
       return {
         op: payload.op,
         recordId: payload.recordId,
@@ -314,17 +323,23 @@ function fakeCp(opts: CpOptions = {}) {
       return { accepted: true, phase: 'settled' }
     }
   }
-  return { cp, authorizations, ops, results }
+  return { cp, authorizations, ops, results, records }
 }
 
 /** The daemon-local durability the adapter depends on, in memory. */
 class FakeReviewStore {
   readonly rows = new Map<string, ReviewIntentRow>()
   private secret?: string
-  failRecord = false
+  /** Writes still to be refused; Infinity models a store that never comes back. */
+  failWrites = 0
+  /** The real store answers one bounded page at a time. */
+  pageSize = 100
 
   async recordReviewIntent(row: ReviewIntentRow): Promise<void> {
-    if (this.failRecord) throw new Error('store unavailable')
+    if (this.failWrites > 0) {
+      this.failWrites -= 1
+      throw new Error('store unavailable')
+    }
     this.rows.set(row.intentId, { ...row })
   }
 
@@ -333,7 +348,7 @@ class FakeReviewStore {
   }
 
   async listReviewIntents(daemonId: string): Promise<ReviewIntentRow[]> {
-    return [...this.rows.values()].filter((row) => row.daemonId === daemonId)
+    return [...this.rows.values()].filter((row) => row.daemonId === daemonId).slice(0, this.pageSize)
   }
 
   /** One value for the process's lifetime, exactly like the store row it stands in for. */
@@ -380,6 +395,7 @@ interface Harness {
   authorizations: CodeHostReviewAuthorize[]
   reviewStore: FakeReviewStore
   timer: ReturnType<typeof fakeScheduler>
+  records: Map<string, 'issued' | 'request_started' | 'settled'>
   persisted: () => number
   tokens: () => string[]
   invalidated: () => string[]
@@ -393,6 +409,7 @@ function harness(
     tokens?: string[]
     hook?: HookDispatchContext
     reviewStore?: FakeReviewStore
+    seedStarted?: string[]
     attemptIds?: string[]
     open?: boolean
     failPersist?: boolean
@@ -400,7 +417,7 @@ function harness(
 ): Harness {
   const state = opts.state ?? gitlabState()
   const gitlab = fakeGitlab(state, opts.script ?? [])
-  const control = fakeCp(opts.cp ?? {})
+  const control = fakeCp({ ...(opts.cp ?? {}), ...(opts.seedStarted ? { seedStarted: opts.seedStarted } : {}) })
   const supply = opts.tokens ?? ['glpat-effect-1']
   const minted: string[] = []
   const invalidated: string[] = []
@@ -455,6 +472,7 @@ function harness(
     authorizations: control.authorizations,
     reviewStore,
     timer,
+    records: control.records,
     persisted: () => persisted,
     tokens: () => minted,
     invalidated: () => invalidated
@@ -1150,6 +1168,206 @@ describe('GitLab review adapter — durable ownership and ack replay (round 2)',
   })
 })
 
+describe('GitLab review adapter — started-operation recovery (round 3)', () => {
+  /** The durable record a crash between the permitted request and its settlement leaves behind. */
+  function crashedAttempt(): HookDispatchContext {
+    return hookContext({
+      codeReview: {
+        attemptId: ATTEMPT,
+        event: 'COMMENT',
+        verdict: 'neutral',
+        headSha: HEAD,
+        ordinals: { draft_create: 1 },
+        operations: [
+          {
+            recordId: 'rec-draft_create-0',
+            startToken: 'start-0',
+            kind: 'draft_create',
+            ordinal: 0,
+            target: `/projects/${PROJECT}/merge_requests/${IID}/draft_notes`,
+            draftOrdinal: 0
+          }
+        ]
+      }
+    })
+  }
+
+  it('settles the exact started record from provider evidence before creating anything new', async () => {
+    const state = gitlabState()
+    const draftId = '9007199254746001'
+    state.drafts.push({ id: draftId, note: `summary\n\n${signer.mint(ATTEMPT, 0, HEAD)}` })
+    const h = harness({ state, hook: crashedAttempt(), seedStarted: ['rec-draft_create-0'] })
+
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    // The recovered record is settled deterministically, naming the draft that proves the effect.
+    const settle = h.ops.find((op) => op.op === 'settle' && op.recordId === 'rec-draft_create-0') as {
+      outcome: { kind: string; externalId?: string }
+    }
+    expect(settle.outcome).toEqual({ kind: 'deterministic', status: 201, externalId: draftId })
+    // ...and it is settled BEFORE the attempt issues another operation.
+    const settledAt = h.ops.findIndex((op) => op.op === 'settle' && op.recordId === 'rec-draft_create-0')
+    const nextIssue = h.ops.findIndex((op) => op.op === 'issue' && op.kind === 'draft_create')
+    expect(settledAt).toBeGreaterThanOrEqual(0)
+    expect(nextIssue === -1 || settledAt < nextIssue).toBe(true)
+    // Nothing is left permitted-but-unsettled on the control plane.
+    expect([...h.records.values()].filter((phase) => phase === 'request_started')).toEqual([])
+    // The recovered draft is reused rather than created again, and the coordinate is not reused.
+    expect(drafted(h.calls)).toEqual([])
+    expect(h.hook.codeReview?.operations).toEqual([])
+  })
+
+  it('never reuses a spent operation coordinate after a recovery', async () => {
+    const state = gitlabState()
+    const h = harness({ state, hook: crashedAttempt(), seedStarted: ['rec-draft_create-0'] })
+    await h.adapter.submit(KEY, request())
+    // Ordinal 0 belongs to the crashed request; the replacement draft takes the next one.
+    const issued = h.ops.filter((op) => op.op === 'issue' && op.kind === 'draft_create') as Array<{ ordinal: number }>
+    expect(issued.map((op) => op.ordinal)).toEqual([1])
+    expect(h.hook.codeReview?.ordinals).toMatchObject({ draft_create: 2 })
+  })
+
+  it('proves a started draft create had no effect when no marker exists', async () => {
+    const h = harness({ hook: crashedAttempt(), seedStarted: ['rec-draft_create-0'] })
+    await h.adapter.submit(KEY, request())
+    const settle = h.ops.find((op) => op.op === 'settle' && op.recordId === 'rec-draft_create-0') as {
+      outcome: { kind: string; code?: string }
+    }
+    expect(settle.outcome).toMatchObject({ kind: 'deterministic', code: 'draft_absent' })
+    // The replacement draft is issued only AFTER the crashed record is accounted for.
+    const settledAt = h.ops.findIndex((op) => op.op === 'settle' && op.recordId === 'rec-draft_create-0')
+    const nextIssue = h.ops.findIndex((op) => op.op === 'issue' && op.kind === 'draft_create')
+    expect(nextIssue).toBeGreaterThan(settledAt)
+    expect([...h.records.values()].filter((phase) => phase === 'request_started')).toEqual([])
+  })
+
+  it('locks instead of republishing when a started bulk publish left no marker', async () => {
+    const hook = hookContext({
+      codeReview: {
+        attemptId: ATTEMPT,
+        event: 'COMMENT',
+        verdict: 'neutral',
+        headSha: HEAD,
+        ordinals: { bulk_publish: 1 },
+        operations: [
+          {
+            recordId: 'rec-bulk_publish-0',
+            startToken: 'start-1',
+            kind: 'bulk_publish',
+            ordinal: 0,
+            target: `/projects/${PROJECT}/merge_requests/${IID}/draft_notes/bulk_publish`
+          }
+        ]
+      }
+    })
+    const h = harness({ hook, seedStarted: ['rec-bulk_publish-0'] })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('ambiguous_locked')
+    expect(published(h.calls)).toEqual([])
+    expect([...h.records.values()].filter((phase) => phase === 'request_started')).toEqual([])
+  })
+
+  it('adopts a started bulk publish that DID land, and never publishes a second time', async () => {
+    const state = gitlabState()
+    state.notes.push({ id: '9007199254746777', body: `summary\n\n${signer.mint(ATTEMPT, 0, HEAD)}` })
+    const hook = hookContext({
+      codeReview: {
+        attemptId: ATTEMPT,
+        event: 'COMMENT',
+        verdict: 'neutral',
+        headSha: HEAD,
+        ordinals: { bulk_publish: 1 },
+        operations: [
+          {
+            recordId: 'rec-bulk_publish-0',
+            startToken: 'start-1',
+            kind: 'bulk_publish',
+            ordinal: 0,
+            target: `/projects/${PROJECT}/merge_requests/${IID}/draft_notes/bulk_publish`
+          }
+        ]
+      }
+    })
+    const h = harness({ state, hook, seedStarted: ['rec-bulk_publish-0'] })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    // A recovered publication cannot prove the unchanged-state postcondition.
+    expect(outcome.state).toBe('review_state_not_recorded')
+    expect(published(h.calls)).toEqual([])
+    expect(outcome.externalIds).toEqual([{ kind: 'note', externalId: '9007199254746777' }])
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(false)
+  })
+})
+
+describe('GitLab review adapter — owed frames are never dropped (round 3)', () => {
+  it('absorbs a transient local write failure and still delivers the frame', async () => {
+    const store = new FakeReviewStore()
+    store.failWrites = 1
+    const h = harness({ reviewStore: store })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(store.rows.size).toBe(0)
+    expect(h.results.at(-1)).toMatchObject({ state: 'submitted' })
+  })
+
+  it('replays a frame whose durable write never landed, from memory, on the resweep', async () => {
+    const store = new FakeReviewStore()
+    store.failWrites = Number.POSITIVE_INFINITY
+    let refuse = true
+    const h = harness({
+      reviewStore: store,
+      cp: {
+        reportFails: () => {
+          const err = refuse ? Object.assign(new Error('control plane unreachable'), { retryable: true }) : undefined
+          refuse = false
+          return err
+        }
+      }
+    })
+    await h.adapter.submit(KEY, request())
+    // Nothing reached the store, so only the in-memory copy can save the frame.
+    expect(store.rows.size).toBe(0)
+    expect(h.timer.armed()).toBe(1)
+    store.failWrites = 0
+    await h.timer.fire()
+    expect(h.results.filter((row) => row.attemptId === ATTEMPT)).toHaveLength(2)
+    expect(store.rows.size).toBe(0)
+    expect(h.timer.armed()).toBe(0)
+  })
+
+  it('drains every page of owed frames before it goes quiet', async () => {
+    const store = new FakeReviewStore()
+    for (let index = 0; index < 101; index += 1) {
+      await store.recordReviewIntent({
+        intentId: `owed-${index}`,
+        daemonId: DAEMON_ID,
+        attemptId: ATTEMPT,
+        orgId: 'org-1',
+        kind: 'result',
+        frame: JSON.stringify({
+          hookId: HOOK_ID,
+          deliveryKey: 'delivery-1',
+          attemptId: ATTEMPT,
+          snapshot: SNAPSHOT,
+          provider: 'gitlab',
+          projectId: PROJECT,
+          mergeRequestIid: IID,
+          event: 'COMMENT',
+          verdict: 'neutral',
+          headSha: HEAD,
+          state: 'submitted'
+        }),
+        attempts: 0
+      })
+    }
+    const h = harness({ reviewStore: store, open: false })
+    await h.adapter.reconcilePending()
+    // The store answers 100 at a time; a page of acked rows is not an empty store.
+    expect(store.rows.size).toBe(0)
+    expect(h.results).toHaveLength(101)
+    expect(h.timer.armed()).toBe(0)
+  })
+})
+
 describe('GitLab review durability in the real daemon store', () => {
   let root: string
   let store: LocalStore
@@ -1243,9 +1461,8 @@ describe('GitLab review adapter — credentials and features', () => {
     })
     await daemon.start()
     try {
-      expect((daemon as never as Record<string, () => string[]>).registrationFeatures()).toContain(
-        CODEHOST_REVIEW_V1_FEATURE
-      )
+      const features = (daemon as unknown as { registrationFeatures(): string[] }).registrationFeatures()
+      expect(features).toContain(CODEHOST_REVIEW_V1_FEATURE)
     } finally {
       await daemon.stop().catch(() => {})
     }

--- a/packages/daemon/test/gitlab-review-adapter.test.ts
+++ b/packages/daemon/test/gitlab-review-adapter.test.ts
@@ -244,7 +244,7 @@ interface CpOptions {
 }
 
 function fakeCp(opts: CpOptions = {}) {
-  const records = new Map<string, 'issued' | 'request_started' | 'settled'>(
+  const records = new Map<string, 'issued' | 'request_started' | 'settled' | 'ambiguous'>(
     (opts.seedStarted ?? []).map((id) => [id, 'request_started' as const])
   )
   const authorizations: CodeHostReviewAuthorize[] = []
@@ -306,8 +306,16 @@ function fakeCp(opts: CpOptions = {}) {
         }
       }
       const [, kind, ordinal] = payload.recordId.split('-')
-      records.set(payload.recordId, payload.op === 'start' ? 'request_started' : 'settled')
-      if (payload.op === 'return-unused') records.set(payload.recordId, 'settled')
+      if (payload.op === 'start') records.set(payload.recordId, 'request_started')
+      else if (payload.op === 'return-unused') records.set(payload.recordId, 'settled')
+      else if (payload.op === 'settle') {
+        // The control-plane contract: an ambiguous record stays non-terminal until a
+        // deterministic settle NAMES the provider object it left behind.
+        if (payload.outcome.kind === 'ambiguous') records.set(payload.recordId, 'ambiguous')
+        else if (records.get(payload.recordId) !== 'ambiguous' || payload.outcome.externalId) {
+          records.set(payload.recordId, 'settled')
+        }
+      }
       return {
         op: payload.op,
         recordId: payload.recordId,
@@ -404,7 +412,7 @@ interface Harness {
   authorizations: CodeHostReviewAuthorize[]
   reviewStore: FakeReviewStore
   timer: ReturnType<typeof fakeScheduler>
-  records: Map<string, 'issued' | 'request_started' | 'settled'>
+  records: Map<string, 'issued' | 'request_started' | 'settled' | 'ambiguous'>
   persisted: () => number
   tokens: () => string[]
   invalidated: () => string[]
@@ -1069,7 +1077,14 @@ describe('GitLab review adapter — durable ownership and ack replay (round 2)',
 
   it('replays the SAME attempt after a crash and recovers its marked drafts', async () => {
     const state = gitlabState()
-    const first = harness({ state, script: [{ method: 'POST', path: /bulk_publish$/, reply: 'network' }] })
+    const first = harness({
+      state,
+      // The pass dies at the exact-set check: the draft exists, publication was never permitted.
+      script: [
+        { method: 'GET', path: /draft_notes$/, reply: { status: 200, body: [] } },
+        { method: 'GET', path: /draft_notes$/, reply: { status: 200, body: [] } }
+      ]
+    })
     // Crash after the draft was created and before publication settled: the durable row keeps
     // the attempt, unclassified, and the marked draft is still pending on the merge request.
     await first.adapter.submit(KEY, request()).catch(() => undefined)
@@ -1577,6 +1592,131 @@ describe('GitLab review adapter — a terminal result waits for a replayable set
       outcome: { externalId?: string }
     }
     expect(settle.outcome.externalId).toBe(draftId)
+  })
+})
+
+describe('GitLab review adapter — an identified ambiguous mutation upgrades its record (round 6)', () => {
+  /** §15.1: the lease may only be released once no record is still ambiguous. */
+  const releasable = (records: Harness['records']) => ![...records.values()].includes('ambiguous')
+
+  it('upgrades an ambiguous draft create once its signed marker identifies the draft', async () => {
+    const state = gitlabState()
+    let created: string | undefined
+    const h = harness({
+      state,
+      script: [
+        {
+          method: 'POST',
+          path: /draft_notes$/,
+          reply: 'network',
+          // The request DID land; only its response was lost.
+          then: () => {
+            created = String(state.nextId++)
+            state.drafts.push({ id: created, note: `summary\n\n${signer.mint(ATTEMPT, 0, HEAD)}` })
+          }
+        }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    // The ambiguous settle is followed by the deterministic upgrade that names the draft.
+    const settles = h.ops.filter((op) => op.op === 'settle' && op.recordId === 'rec-draft_create-0') as Array<{
+      outcome: { kind: string; externalId?: string }
+    }>
+    expect(settles.map((op) => op.outcome.kind)).toEqual(['ambiguous', 'deterministic'])
+    expect(settles.at(-1)!.outcome.externalId).toBe(created)
+    // ...so nothing is left ambiguous and the publication lease can be released.
+    expect(h.records.get('rec-draft_create-0')).toBe('settled')
+    expect(releasable(h.records)).toBe(true)
+  })
+
+  it('upgrades an ambiguous draft delete once the read-after proves the absence', async () => {
+    const state = gitlabState()
+    const stale = seedDraft(state, OLD_ATTEMPT, 0, HEAD, '9007199254746901')
+    const h = harness({
+      state,
+      script: [
+        {
+          method: 'DELETE',
+          path: /draft_notes\//,
+          reply: 'network',
+          // The delete landed; the response did not.
+          then: () => void (state.drafts = state.drafts.filter((draft) => draft.id !== stale))
+        }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    const settles = h.ops.filter((op) => op.op === 'settle' && op.recordId === 'rec-draft_delete-0') as Array<{
+      outcome: { kind: string; externalId?: string; status?: number }
+    }>
+    expect(settles.map((op) => op.outcome.kind)).toEqual(['ambiguous', 'deterministic'])
+    expect(settles.at(-1)!.outcome).toMatchObject({ status: 204, externalId: stale })
+    expect(h.records.get('rec-draft_delete-0')).toBe('settled')
+    expect(releasable(h.records)).toBe(true)
+  })
+
+  it('keeps the record ambiguous — and the lease unreleasable — when nothing identifies it', async () => {
+    // The control: an ambiguous create whose marker never appears is exactly the state the
+    // upgrade exists to leave behind, and the lease is retained until it is resolved.
+    const h = harness({ script: [{ method: 'POST', path: /draft_notes$/, reply: 'network' }] })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('review_reconciliation_required')
+    expect(h.records.get('rec-draft_create-0')).toBe('ambiguous')
+    expect(releasable(h.records)).toBe(false)
+  })
+
+  it('routes the upgrade through the durable chain, so an unsafe one is parked and replayed', async () => {
+    const state = gitlabState()
+    const store = new FakeReviewStore()
+    let created: string | undefined
+    let refuseUpgrade = true
+    const h = harness({
+      state,
+      reviewStore: store,
+      script: [
+        {
+          method: 'POST',
+          path: /draft_notes$/,
+          reply: 'network',
+          then: () => {
+            created = String(state.nextId++)
+            state.drafts.push({ id: created, note: `summary\n\n${signer.mint(ATTEMPT, 0, HEAD)}` })
+          }
+        }
+      ],
+      cp: {
+        // Local writes stop the moment the ambiguous settle lands, so the upgrade that follows
+        // is neither durable nor acknowledged and must fall back to its parked coordinates.
+        operateFails: (op) => {
+          if (!('outcome' in op)) return undefined
+          if (op.outcome.kind === 'ambiguous') {
+            store.failWrites = Number.POSITIVE_INFINITY
+            return undefined
+          }
+          return refuseUpgrade ? Object.assign(new Error('unreachable'), { retryable: true }) : undefined
+        }
+      }
+    })
+    await h.adapter.submit(KEY, request())
+    // The upgrade is parked on the coordinates the ambiguous settle deliberately retained.
+    const parked = (h.hook.codeReview?.operations ?? []).find((op) => op.recordId === 'rec-draft_create-0')
+    expect(parked?.outcome).toMatchObject({ kind: 'deterministic', externalId: created })
+
+    // A restart replays it from there, and the record finally leaves `ambiguous`.
+    refuseUpgrade = false
+    store.failWrites = 0
+    const replay = harness({ reviewStore: store, hook: h.hook, open: false })
+    const turn = replay.adapter.openTurn(KEY, h.hook, 'acp-session-2', {
+      daemonId: DAEMON_ID,
+      persist: async () => {}
+    })!
+    await replay.adapter.recoverTurn(turn)
+    const upgraded = replay.ops.find((op) => op.op === 'settle' && op.recordId === 'rec-draft_create-0') as {
+      outcome: { externalId?: string }
+    }
+    expect(upgraded.outcome.externalId).toBe(created)
+    expect(h.hook.codeReview?.operations).toEqual([])
   })
 })
 

--- a/packages/daemon/test/gitlab-review-adapter.test.ts
+++ b/packages/daemon/test/gitlab-review-adapter.test.ts
@@ -422,6 +422,8 @@ function harness(
     attemptIds?: string[]
     open?: boolean
     failPersist?: boolean
+    /** Fail only the hook-row writes this predicate selects. */
+    persistFails?: () => boolean
   } = {}
 ): Harness {
   const state = opts.state ?? gitlabState()
@@ -467,7 +469,7 @@ function harness(
       daemonId: DAEMON_ID,
       persist: async () => {
         persisted += 1
-        if (opts.failPersist) throw new Error('inbox row is missing')
+        if (opts.failPersist || opts.persistFails?.()) throw new Error('inbox row is missing')
       }
     })
   }
@@ -1417,8 +1419,9 @@ describe('GitLab review adapter — the durable chain across every crash point (
     // The result frame is rebuilt from the attempt record alone and taken by the control plane.
     expect(replay.results.at(-1)).toMatchObject({ attemptId: ATTEMPT, state: 'submitted', provider: 'gitlab' })
     expect(first.hook.codeReview?.resultOwed).toBeUndefined()
-    // Coordinates whose settle is still unowed are kept, not silently dropped.
-    expect((first.hook.codeReview?.operations ?? []).length).toBeGreaterThan(0)
+    // The settle is replayed from the outcome parked on its coordinates, which then release.
+    expect(replay.ops.some((frame) => frame.op === 'settle')).toBe(true)
+    expect(first.hook.codeReview?.operations).toEqual([])
     expect(owedOps).toEqual([])
     expect(store.rows.size).toBe(0)
   })
@@ -1433,6 +1436,147 @@ describe('GitLab review adapter — the durable chain across every crash point (
     // ...and the classified-but-unreported result goes with it.
     expect(h.results.at(-1)).toMatchObject({ attemptId: ATTEMPT, state: 'not_submitted' })
     expect(hook.codeReview?.resultOwed).toBeUndefined()
+  })
+})
+
+describe('GitLab review adapter — a terminal result waits for a replayable settle (round 5)', () => {
+  /** A control plane that refuses settles but takes everything else. */
+  const settlesRefused = { operateFails: () => Object.assign(new Error('unreachable'), { retryable: true }) }
+
+  it('parks the exact settle outcome on the coordinates when its frame cannot be made durable', async () => {
+    const store = new FakeReviewStore()
+    store.failWrites = Number.POSITIVE_INFINITY
+    const h = harness({ reviewStore: store, cp: settlesRefused })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    // The result still lands, because the settle now HAS a durable replay source.
+    expect(outcome.state).toBe('submitted')
+    const parked = h.hook.codeReview?.operations ?? []
+    expect(parked.length).toBeGreaterThan(0)
+    expect(parked.every((op) => op.phase === 'started' && op.outcome !== undefined)).toBe(true)
+    expect(parked.find((op) => op.kind === 'draft_create')?.outcome).toMatchObject({
+      kind: 'deterministic',
+      status: 201
+    })
+  })
+
+  it('replays the parked settle after the process dies, and the lease releases', async () => {
+    const store = new FakeReviewStore()
+    store.failWrites = Number.POSITIVE_INFINITY
+    const first = harness({ reviewStore: store, cp: settlesRefused })
+    await first.adapter.submit(KEY, request())
+    expect(store.rows.size).toBe(0)
+
+    // A NEW adapter over the SAME store and hook row, with a control plane that answers.
+    store.failWrites = 0
+    const replay = harness({ reviewStore: store, hook: first.hook, open: false })
+    const turn = replay.adapter.openTurn(KEY, first.hook, 'acp-session-2', {
+      daemonId: DAEMON_ID,
+      persist: async () => {}
+    })!
+    await replay.adapter.recoverTurn(turn)
+    // Every started record reaches `settled`, so nothing keeps the publication lease.
+    expect(replay.ops.filter((op) => op.op === 'settle').length).toBeGreaterThan(0)
+    expect([...replay.records.values()].filter((state) => state === 'request_started')).toEqual([])
+    expect(first.hook.codeReview?.operations).toEqual([])
+    expect(store.rows.size).toBe(0)
+  })
+
+  it('withholds the terminal result when even the parked outcome cannot be written', async () => {
+    const store = new FakeReviewStore()
+    store.failWrites = Number.POSITIVE_INFINITY
+    let allowPersist = true
+    const h = harness({
+      reviewStore: store,
+      // The hook row stops accepting writes exactly when the first settle is refused, so
+      // the parking write fails too and the settle has NO replay source at all.
+      cp: {
+        operateFails: (op) => {
+          if (!('recordId' in op) || !op.recordId.includes('bulk_publish')) return undefined
+          allowPersist = false
+          return Object.assign(new Error('unreachable'), { retryable: true })
+        }
+      },
+      persistFails: () => !allowPersist
+    })
+    await expect(h.adapter.submit(KEY, request())).rejects.toThrow(/could not be made durable/)
+    // No result reached the control plane, and the attempt stays pre-terminal.
+    expect(h.results).toEqual([])
+    expect(h.hook.codeReview?.state).toBeUndefined()
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(false)
+    // The turn stays open and the retry is armed.
+    expect(h.timer.armed()).toBe(1)
+    expect(h.adapter.owns(KEY, AGENT_ID)).toBe(true)
+  })
+
+  it('completes both halves on a later pass once the store recovers', async () => {
+    const store = new FakeReviewStore()
+    store.failWrites = Number.POSITIVE_INFINITY
+    let allowPersist = true
+    let refuseSettles = true
+    const h = harness({
+      reviewStore: store,
+      cp: {
+        operateFails: (op) => {
+          if (!refuseSettles || !('recordId' in op) || !op.recordId.includes('bulk_publish')) return undefined
+          allowPersist = false
+          return Object.assign(new Error('unreachable'), { retryable: true })
+        }
+      },
+      persistFails: () => !allowPersist
+    })
+    await expect(h.adapter.submit(KEY, request())).rejects.toThrow(/could not be made durable/)
+    expect(h.results).toEqual([])
+
+    // The turn stayed open, so the SAME attempt runs again once the store and control plane recover.
+    allowPersist = true
+    refuseSettles = false
+    store.failWrites = 0
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    // The publication already landed, so the replay classifies it rather than repeating it.
+    expect(outcome.state).toBe('review_state_not_recorded')
+    expect(h.results.at(-1)).toMatchObject({ attemptId: ATTEMPT, state: 'review_state_not_recorded' })
+    expect(published(h.calls)).toHaveLength(1)
+    expect([...h.records.values()].filter((state) => state === 'request_started')).toEqual([])
+  })
+
+  it('leaves a started operation without a parked outcome on the marker-reconciliation path', async () => {
+    const state = gitlabState()
+    const draftId = '9007199254746555'
+    state.drafts.push({ id: draftId, note: `summary\n\n${signer.mint(ATTEMPT, 0, HEAD)}` })
+    const hook = hookContext({
+      codeReview: {
+        attemptId: ATTEMPT,
+        event: 'COMMENT',
+        verdict: 'neutral',
+        headSha: HEAD,
+        fence: '7',
+        ordinals: { draft_create: 1 },
+        operations: [
+          {
+            recordId: 'rec-draft_create-0',
+            startToken: 'start-0',
+            kind: 'draft_create',
+            ordinal: 0,
+            target: `/projects/${PROJECT}/merge_requests/${IID}/draft_notes`,
+            phase: 'started',
+            draftOrdinal: 0
+          }
+        ]
+      }
+    })
+    const h = harness({ state, hook, open: false })
+    const turn = h.adapter.openTurn(KEY, hook, 'acp-session-2', { daemonId: DAEMON_ID, persist: async () => {} })!
+    // Recovery without evidence cannot classify it, so it is left for the turn's own replay.
+    await h.adapter.recoverTurn(turn)
+    expect(h.ops).toEqual([])
+    expect(hook.codeReview?.operations).toHaveLength(1)
+    // The turn replay then settles it from the marker, as before.
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    const settle = h.ops.find((op) => op.op === 'settle' && op.recordId === 'rec-draft_create-0') as {
+      outcome: { externalId?: string }
+    }
+    expect(settle.outcome.externalId).toBe(draftId)
   })
 })
 

--- a/packages/daemon/test/gitlab-review-adapter.test.ts
+++ b/packages/daemon/test/gitlab-review-adapter.test.ts
@@ -2,10 +2,10 @@
 // §15.2) and the §23 review matrix rows that belong to the daemon: the thirteen steps,
 // the publication lease and its single-use operation ledger, marker reconciliation, and
 // every ambiguous effect failing closed instead of publishing a fallback.
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   CODEHOST_REVIEW_V1_FEATURE,
   type CodeHostReviewAuthorize,
@@ -18,13 +18,18 @@ import {
   type HookConfigSnapshot
 } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
-import { sessionKey } from '../src/store/local-store.js'
+import { LocalStore, sessionKey } from '../src/store/local-store.js'
 import { CodeHostReviewRouter, type SubmitCodeReviewReq } from '../src/codehost/review-adapter.js'
-import type { HookDispatchContext } from '../src/github/hook-coords.js'
+import {
+  codeHostReviewFallbackAllowed,
+  hookOutputFallbackAllowed,
+  type HookDispatchContext
+} from '../src/github/hook-coords.js'
 import {
   GitlabReviewAdapter,
   type GitlabReviewControlPlane,
-  type GitlabReviewOutcome
+  type GitlabReviewOutcome,
+  type ReviewIntentRow
 } from '../src/gitlab/review-adapter.js'
 import { ReviewMarkerSigner } from '../src/gitlab/review-marker.js'
 
@@ -45,9 +50,9 @@ const DAEMON_ID = '44444444-4444-4444-8444-444444444444'
 const AGENT_ID = 'bot-a'
 const THREAD = `gitlab:${PROJECT}:merge_request:${IID}`
 const KEY = sessionKey('hook', HOOK_ID, THREAD, AGENT_ID)
-const MARKER_KEY = Buffer.from('gitlab-review-marker-test-key-01')
+const MARKER_SEED = 'gitlab-review-marker-test-key-01'
 
-const signer = new ReviewMarkerSigner(MARKER_KEY)
+const signer = new ReviewMarkerSigner(Buffer.from(MARKER_SEED, 'utf8'))
 
 const SNAPSHOT: HookConfigSnapshot = {
   configRevision: '4',
@@ -228,6 +233,9 @@ interface CpOptions {
   supports?: boolean
   renewPhase?: CodeHostReviewLeasePhase
   serviceAccountUserId?: string
+  /** Return an error to fail that delivery; the frame is then owed and replayed. */
+  operateFails?: (op: CodeHostReviewOpRequest) => Error | undefined
+  reportFails?: (result: CodeHostReviewResultReport) => Error | undefined
 }
 
 function fakeCp(opts: CpOptions = {}) {
@@ -267,6 +275,8 @@ function fakeCp(opts: CpOptions = {}) {
     },
     operate: async (payload): Promise<CodeHostReviewOpAccepted> => {
       ops.push(payload)
+      const failure = payload.op === 'settle' ? opts.operateFails?.(payload) : undefined
+      if (failure) throw failure
       if (payload.op === 'issue') {
         return {
           op: 'issue',
@@ -299,19 +309,78 @@ function fakeCp(opts: CpOptions = {}) {
     }),
     report: async (payload) => {
       results.push(payload)
+      const failure = opts.reportFails?.(payload)
+      if (failure) throw failure
       return { accepted: true, phase: 'settled' }
     }
   }
   return { cp, authorizations, ops, results }
 }
 
+/** The daemon-local durability the adapter depends on, in memory. */
+class FakeReviewStore {
+  readonly rows = new Map<string, ReviewIntentRow>()
+  private secret?: string
+  failRecord = false
+
+  async recordReviewIntent(row: ReviewIntentRow): Promise<void> {
+    if (this.failRecord) throw new Error('store unavailable')
+    this.rows.set(row.intentId, { ...row })
+  }
+
+  async clearReviewIntent(intentId: string): Promise<void> {
+    this.rows.delete(intentId)
+  }
+
+  async listReviewIntents(daemonId: string): Promise<ReviewIntentRow[]> {
+    return [...this.rows.values()].filter((row) => row.daemonId === daemonId)
+  }
+
+  /** One value for the process's lifetime, exactly like the store row it stands in for. */
+  async getOrCreateDaemonSecret(mint: () => string): Promise<string> {
+    this.secret ??= mint()
+    return this.secret
+  }
+}
+
+/** A hand-driven timer so the resweep backoff is deterministic. */
+function fakeScheduler() {
+  const pending: Array<{ fn: () => void; id: number }> = []
+  let next = 1
+  const scheduler = {
+    now: () => 0,
+    setTimeout: (fn: () => void) => {
+      const id = next++
+      pending.push({ fn, id })
+      return id
+    },
+    clearTimeout: (handle: unknown) => {
+      const index = pending.findIndex((entry) => entry.id === handle)
+      if (index >= 0) pending.splice(index, 1)
+    }
+  }
+  return {
+    scheduler,
+    armed: () => pending.length,
+    async fire(): Promise<void> {
+      const entry = pending.shift()
+      entry?.fn()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+  }
+}
+
 interface Harness {
   adapter: GitlabReviewAdapter
   state: GitlabState
+  hook: HookDispatchContext
   calls: Call[]
   ops: CodeHostReviewOpRequest[]
   results: CodeHostReviewResultReport[]
   authorizations: CodeHostReviewAuthorize[]
+  reviewStore: FakeReviewStore
+  timer: ReturnType<typeof fakeScheduler>
+  persisted: () => number
   tokens: () => string[]
   invalidated: () => string[]
 }
@@ -323,6 +392,10 @@ function harness(
     cp?: CpOptions
     tokens?: string[]
     hook?: HookDispatchContext
+    reviewStore?: FakeReviewStore
+    attemptIds?: string[]
+    open?: boolean
+    failPersist?: boolean
   } = {}
 ): Harness {
   const state = opts.state ?? gitlabState()
@@ -331,10 +404,19 @@ function harness(
   const supply = opts.tokens ?? ['glpat-effect-1']
   const minted: string[] = []
   const invalidated: string[] = []
+  const reviewStore = opts.reviewStore ?? new FakeReviewStore()
+  const timer = fakeScheduler()
+  const hook = opts.hook ?? hookContext()
+  const attemptIds = opts.attemptIds ?? [ATTEMPT]
+  let mintedAttempts = 0
+  let persisted = 0
   let clock = 1_000
   const adapter = new GitlabReviewAdapter({
     cp: () => control.cp,
     orgForAgent: () => 'org-1',
+    daemonId: () => DAEMON_ID,
+    store: reviewStore,
+    markerKey: async () => Buffer.from(await reviewStore.getOrCreateDaemonSecret(() => MARKER_SEED), 'utf8'),
     token: async () => {
       const token = supply[Math.min(minted.length, supply.length - 1)]!
       minted.push(token)
@@ -344,23 +426,36 @@ function harness(
     log: { warn: () => {} },
     baseUrl: BASE,
     fetchImpl: gitlab.fetchImpl,
-    markerKey: MARKER_KEY,
-    newAttemptId: () => ATTEMPT,
+    newAttemptId: () => attemptIds[Math.min(mintedAttempts++, attemptIds.length - 1)]!,
     newStartToken: () => `start-${control.ops.filter((op) => op.op === 'issue').length}`,
     now: () => clock,
     sleep: async (ms) => void (clock += ms),
     ambiguousWindowMs: 4_000,
     mergeStatusWindowMs: 4_000,
-    pollIntervalMs: 1_000
+    pollIntervalMs: 1_000,
+    scheduler: timer.scheduler,
+    resweepBaseMs: 1_000
   })
-  adapter.openTurn(KEY, opts.hook ?? hookContext(), 'acp-session-1', DAEMON_ID)
+  if (opts.open !== false) {
+    adapter.openTurn(KEY, hook, 'acp-session-1', {
+      daemonId: DAEMON_ID,
+      persist: async () => {
+        persisted += 1
+        if (opts.failPersist) throw new Error('inbox row is missing')
+      }
+    })
+  }
   return {
     adapter,
     state,
+    hook,
     calls: gitlab.calls,
     ops: control.ops,
     results: control.results,
     authorizations: control.authorizations,
+    reviewStore,
+    timer,
+    persisted: () => persisted,
     tokens: () => minted,
     invalidated: () => invalidated
   }
@@ -419,22 +514,41 @@ describe('GitLab review adapter — pre-effect rejections (§15)', () => {
     expect(h.adapter.owns(KEY, AGENT_ID)).toBe(false)
   })
 
-  it('opens no review turn for a non-review delivery', () => {
+  it('opens no review turn for a delivery the review-generation gate does not open', () => {
     const h = harness()
+    const open = (key: string, hook: HookDispatchContext, daemonId = DAEMON_ID) =>
+      h.adapter.openTurn(key, hook, 's', { daemonId, persist: async () => {} })
+    expect(open('k2', hookContext({ snapshot: { ...SNAPSHOT, reviewPolicy: 'off' } }))).toBeUndefined()
     expect(
-      h.adapter.openTurn('k2', hookContext({ snapshot: { ...SNAPSHOT, reviewPolicy: 'off' } }), 's', DAEMON_ID)
+      open('k3', hookContext({ gitlab: { projectId: PROJECT, projectPath: 'g/p', target: { kind: 'issue', iid: 5 } } }))
     ).toBeUndefined()
+    expect(open('k4', hookContext(), 'another-daemon')).toBeUndefined()
+    // An ordinary merge-request conversation must not own the structured tool.
+    expect(open('k5', hookContext({ event: 'merge_request:labeled' }))).toBeUndefined()
+    expect(open('k6', hookContext({ event: 'note:created' }))).toBeUndefined()
+    // A head-less merge-request delivery has nothing to fence a review on.
     expect(
-      h.adapter.openTurn(
-        'k3',
+      open(
+        'k7',
         hookContext({
-          gitlab: { projectId: PROJECT, projectPath: 'g/p', target: { kind: 'issue', iid: 5 } }
-        }),
-        's',
-        DAEMON_ID
+          gitlab: { projectId: PROJECT, projectPath: 'g/p', target: { kind: 'merge_request', iid: IID } }
+        })
       )
     ).toBeUndefined()
-    expect(h.adapter.openTurn('k4', hookContext(), 's', 'another-daemon')).toBeUndefined()
+    // A relay-flagged review request opens one even on an otherwise ordinary event.
+    expect(
+      open(
+        'k8',
+        hookContext({
+          event: 'merge_request:labeled',
+          gitlab: {
+            projectId: PROJECT,
+            projectPath: 'g/p',
+            target: { kind: 'merge_request', iid: IID, headSha: HEAD, explicitReviewRequest: true }
+          }
+        })
+      )
+    ).toBeDefined()
   })
 })
 
@@ -874,6 +988,215 @@ describe('GitLab review adapter — approval (§15 step 13)', () => {
     })
     const outcome = (await h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))) as GitlabReviewOutcome
     expect(outcome.state).toBe('approval_not_recorded')
+  })
+})
+
+describe('GitLab review adapter — durable ownership and ack replay (round 2)', () => {
+  it('claims the reply gate durably for a submitted review, and keeps it across a restart', async () => {
+    const h = harness()
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    // The durable hook row — not adapter memory — is what the ordinary-note gate reads.
+    expect(h.hook.codeReview).toMatchObject({ attemptId: ATTEMPT, state: 'submitted', headSha: HEAD })
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(false)
+    // The turn-final surface asks ONE question, and a GitLab attempt answers it too.
+    expect(hookOutputFallbackAllowed(h.hook)).toBe(false)
+    // A restart replays that row into a fresh adapter: still no ordinary note, and no second attempt.
+    const restarted = harness({ hook: h.hook, reviewStore: h.reviewStore })
+    expect(codeHostReviewFallbackAllowed(restarted.hook)).toBe(false)
+    await expect(restarted.adapter.submit(KEY, request())).rejects.toThrow(/already has a formal review attempt/)
+    expect(mutations(restarted.calls)).toEqual([])
+  })
+
+  it('claims the reply gate for an ambiguous publication too', async () => {
+    const h = harness({ script: [{ method: 'POST', path: /bulk_publish$/, reply: 'network' }] })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('ambiguous_locked')
+    expect(h.hook.codeReview?.state).toBe('ambiguous_locked')
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(false)
+  })
+
+  it('leaves the ordinary reply available only for a proven no-effect attempt', async () => {
+    const h = harness({ state: gitlabState({ sha: OTHER_HEAD }) })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('not_submitted')
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(true)
+    expect(hookOutputFallbackAllowed(h.hook)).toBe(true)
+    // A reserved attempt with no classification yet is unknown, so it blocks the note.
+    expect(codeHostReviewFallbackAllowed({ ...h.hook, codeReview: { ...h.hook.codeReview!, state: undefined } })).toBe(
+      false
+    )
+  })
+
+  it('records the attempt before the first provider call and refuses when that write fails', async () => {
+    const h = harness({ failPersist: true })
+    await expect(h.adapter.submit(KEY, request())).rejects.toThrow(/durability barrier failed/)
+    expect(h.calls).toEqual([])
+    expect(h.authorizations).toEqual([])
+    // The rolled-back record must not leave a phantom attempt blocking the ordinary note.
+    expect(h.hook.codeReview).toBeUndefined()
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(true)
+  })
+
+  it('replays the SAME attempt after a crash and recovers its marked drafts', async () => {
+    const state = gitlabState()
+    const first = harness({ state, script: [{ method: 'POST', path: /bulk_publish$/, reply: 'network' }] })
+    // Crash after the draft was created and before publication settled: the durable row keeps
+    // the attempt, unclassified, and the marked draft is still pending on the merge request.
+    await first.adapter.submit(KEY, request()).catch(() => undefined)
+    delete first.hook.codeReview!.state
+    expect(state.drafts).toHaveLength(1)
+    expect(signer.read(state.drafts[0]!.note, HEAD)).toEqual({ attemptId: ATTEMPT, ordinal: 0 })
+
+    // A NEW adapter over the SAME store and hook row: same attempt id, same verifiable marker.
+    const replay = harness({ state, hook: first.hook, reviewStore: first.reviewStore, attemptIds: ['ignored-id'] })
+    const outcome = (await replay.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(replay.authorizations[0]!.attemptId).toBe(ATTEMPT)
+    // The recovered draft was reused, not created again.
+    expect(drafted(replay.calls)).toEqual([])
+  })
+
+  it('refuses a recovered attempt that changes its event or verdict', async () => {
+    const h = harness()
+    h.hook.codeReview = { attemptId: ATTEMPT, event: 'COMMENT', verdict: 'neutral', headSha: HEAD }
+    const replay = harness({ hook: h.hook, reviewStore: h.reviewStore })
+    await expect(replay.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))).rejects.toThrow(
+      /must keep its original event, verdict, and head/
+    )
+    expect(replay.calls).toEqual([])
+  })
+
+  it('replays an unacknowledged settle until the control plane takes it', async () => {
+    let refusals = 2
+    const h = harness({
+      cp: {
+        operateFails: () => {
+          if (refusals <= 0) return undefined
+          refusals -= 1
+          return Object.assign(new Error('control plane unreachable'), { retryable: true })
+        }
+      }
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GitlabReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    // Both settles were refused, so both are owed durably and the resweep is armed.
+    expect([...h.reviewStore.rows.keys()].filter((id) => id.includes(':op:'))).toHaveLength(2)
+    expect(h.timer.armed()).toBe(1)
+    await h.timer.fire()
+    // The replayed frames are the identical settles, and the ledger is clear once acked.
+    const replayed = h.ops.filter((op) => op.op === 'settle')
+    expect(replayed.length).toBeGreaterThanOrEqual(4)
+    expect([...h.reviewStore.rows.keys()].filter((id) => id.includes(':op:'))).toEqual([])
+  })
+
+  it('replays an unacknowledged result report and clears it once acked', async () => {
+    let refuse = true
+    const h = harness({
+      cp: {
+        reportFails: () => {
+          const err = refuse ? Object.assign(new Error('control plane unreachable'), { retryable: true }) : undefined
+          refuse = false
+          return err
+        }
+      }
+    })
+    await h.adapter.submit(KEY, request())
+    expect([...h.reviewStore.rows.keys()]).toEqual([`${ATTEMPT}:result`])
+    expect(h.timer.armed()).toBe(1)
+    await h.timer.fire()
+    expect(h.reviewStore.rows.size).toBe(0)
+    const reports = h.results.filter((row) => row.attemptId === ATTEMPT)
+    expect(reports.at(-1)).toMatchObject({ state: 'submitted', provider: 'gitlab' })
+  })
+
+  it('drops an owed frame the control plane permanently refuses instead of replaying forever', async () => {
+    const h = harness({
+      cp: { reportFails: () => Object.assign(new Error('does not own the lease'), { retryable: false }) }
+    })
+    await h.adapter.submit(KEY, request())
+    expect(h.reviewStore.rows.size).toBe(0)
+    expect(h.timer.armed()).toBe(0)
+  })
+
+  it('recovers owed frames written by a previous process', async () => {
+    const store = new FakeReviewStore()
+    await store.recordReviewIntent({
+      intentId: `${ATTEMPT}:result`,
+      daemonId: DAEMON_ID,
+      attemptId: ATTEMPT,
+      orgId: 'org-1',
+      kind: 'result',
+      frame: JSON.stringify({
+        hookId: HOOK_ID,
+        deliveryKey: 'delivery-1',
+        attemptId: ATTEMPT,
+        snapshot: SNAPSHOT,
+        provider: 'gitlab',
+        projectId: PROJECT,
+        mergeRequestIid: IID,
+        event: 'COMMENT',
+        verdict: 'neutral',
+        headSha: HEAD,
+        state: 'submitted'
+      }),
+      attempts: 3
+    })
+    const h = harness({ reviewStore: store, open: false })
+    await h.adapter.reconcilePending()
+    expect(store.rows.size).toBe(0)
+    expect(h.results.at(-1)).toMatchObject({ attemptId: ATTEMPT, state: 'submitted' })
+    expect(h.timer.armed()).toBe(0)
+  })
+})
+
+describe('GitLab review durability in the real daemon store', () => {
+  let root: string
+  let store: LocalStore
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), 'gitlab-review-store-'))
+    store = await LocalStore.open(join(root, 'state.db'))
+  })
+
+  afterEach(async () => {
+    await store.close()
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('mints the marker key once and returns the same value to every later caller', async () => {
+    const first = await store.getOrCreateDaemonSecret('gitlab-review-marker-key', () => 'first', 1)
+    const second = await store.getOrCreateDaemonSecret('gitlab-review-marker-key', () => 'second', 2)
+    expect(second).toBe(first)
+    // A restart over the same file reads the stored key rather than minting a new one.
+    await store.close()
+    const reopened = await LocalStore.open(join(root, 'state.db'))
+    expect(await reopened.getOrCreateDaemonSecret('gitlab-review-marker-key', () => 'third', 3)).toBe(first)
+    store = reopened
+  })
+
+  it('keeps owed frames per daemon identity, upserts by intent, and clears on ack', async () => {
+    const row: ReviewIntentRow = {
+      intentId: `${ATTEMPT}:result`,
+      daemonId: DAEMON_ID,
+      attemptId: ATTEMPT,
+      orgId: 'org-1',
+      kind: 'result',
+      frame: '{"state":"submitted"}',
+      attempts: 0
+    }
+    await store.recordReviewIntent(row, 1)
+    await store.recordReviewIntent({ ...row, attempts: 4, frame: '{"state":"ambiguous_locked"}' }, 2)
+    await store.recordReviewIntent({ ...row, intentId: 'other', daemonId: 'peer-daemon' }, 3)
+
+    const mine = await store.listReviewIntents(DAEMON_ID)
+    expect(mine).toHaveLength(1)
+    expect(mine[0]).toMatchObject({ attempts: 4, frame: '{"state":"ambiguous_locked"}', orgId: 'org-1' })
+    // A peer's owed frame is never replayed by this identity.
+    expect(await store.listReviewIntents('peer-daemon')).toHaveLength(1)
+
+    await store.clearReviewIntent(row.intentId)
+    expect(await store.listReviewIntents(DAEMON_ID)).toEqual([])
   })
 })
 

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -1709,9 +1709,9 @@ describe('executeTool: viewSessionStatus', () => {
   })
 })
 
-describe('executeTool: submitGithubReview', () => {
+describe('executeTool: submitCodeReview', () => {
   it('takes agent/session identity from trusted context and passes only semantic review input', async () => {
-    const submitGithubReview = vi.fn(async () => ({
+    const submitCodeReview = vi.fn(async () => ({
       state: 'submitted' as const,
       reviewId: '99',
       event: 'REQUEST_CHANGES' as const,
@@ -1719,11 +1719,11 @@ describe('executeTool: submitGithubReview', () => {
       commitId: 'a'.repeat(40)
     }))
     const { deps: d } = deps(fakeGateway())
-    d.submitGithubReview = submitGithubReview
+    d.submitCodeReview = submitCodeReview
 
     const result = await executeTool(
       ctx,
-      'submitGithubReview',
+      'submitCodeReview',
       {
         // These attacker-supplied target fields are ignored.
         repoFullName: 'evil/repo',
@@ -1738,7 +1738,7 @@ describe('executeTool: submitGithubReview', () => {
     )
 
     expect(result).toMatchObject({ state: 'submitted', reviewId: '99' })
-    expect(submitGithubReview).toHaveBeenCalledWith({
+    expect(submitCodeReview).toHaveBeenCalledWith({
       agentId: 'bot-a',
       platform: 'slack',
       channel: 'C_CURRENT',
@@ -1753,18 +1753,28 @@ describe('executeTool: submitGithubReview', () => {
   it('fails closed when no review effect boundary is wired', async () => {
     const { deps: d } = deps(fakeGateway())
     await expect(
-      executeTool(ctx, 'submitGithubReview', { event: 'COMMENT', verdict: 'neutral', body: 'note' }, d)
+      executeTool(ctx, 'submitCodeReview', { event: 'COMMENT', verdict: 'neutral', body: 'note' }, d)
     ).rejects.toThrow(/unavailable/)
   })
 
-  it('validates inline coordinates before calling the effect boundary', async () => {
-    const submitGithubReview = vi.fn()
+  it('still dispatches the pre-promotion `submitGithubReview` name to the same entry', async () => {
+    const submitCodeReview = vi.fn(async () => ({ provider: 'gitlab', state: 'submitted' }))
     const { deps: d } = deps(fakeGateway())
-    d.submitGithubReview = submitGithubReview
+    d.submitCodeReview = submitCodeReview
+    await executeTool(ctx, 'submitGithubReview', { event: 'COMMENT', verdict: 'neutral', body: 'note' }, d)
+    expect(submitCodeReview).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'bot-a', event: 'COMMENT', verdict: 'neutral', body: 'note' })
+    )
+  })
+
+  it('validates inline coordinates before calling the effect boundary', async () => {
+    const submitCodeReview = vi.fn()
+    const { deps: d } = deps(fakeGateway())
+    d.submitCodeReview = submitCodeReview
     await expect(
       executeTool(
         ctx,
-        'submitGithubReview',
+        'submitCodeReview',
         {
           event: 'COMMENT',
           verdict: 'neutral',
@@ -1774,14 +1784,14 @@ describe('executeTool: submitGithubReview', () => {
         d
       )
     ).rejects.toThrow(/positive integer/)
-    expect(submitGithubReview).not.toHaveBeenCalled()
+    expect(submitCodeReview).not.toHaveBeenCalled()
   })
 
   // A malformed entry must name its own INDEX — that is the whole repair instruction for a
   // model holding a long batch, so the number has to survive the argument-schema plumbing.
   it.each([
     {
-      tool: 'submitGithubReview',
+      tool: 'submitCodeReview',
       args: {
         event: 'COMMENT',
         verdict: 'neutral',
@@ -1798,7 +1808,7 @@ describe('executeTool: submitGithubReview', () => {
     { tool: 'startOrchestration', args: { subtasks: ['nope'] }, expected: 'subtasks[0] must be an object' }
   ])('$tool names the offending entry by index', async ({ tool, args, expected }) => {
     const { deps: d } = deps(fakeGateway())
-    d.submitGithubReview = vi.fn()
+    d.submitCodeReview = vi.fn()
     d.replyGithubReviewThreads = vi.fn()
     await expect(executeTool(ctx, tool, args, d)).rejects.toThrow(expected)
   })

--- a/packages/daemon/test/mcp-tool-args.test.ts
+++ b/packages/daemon/test/mcp-tool-args.test.ts
@@ -60,13 +60,13 @@ describe('advertised tool schemas agree with their zod validators', () => {
 
   it('advertises every dispatchable tool that takes arguments', () => {
     const missing = [...TOOL_ARG_SCHEMAS.keys()].filter(
-      // `listChannelAgents` is a dispatch-only alias, and the orchestration triple is retired.
-      (name) => !byName.has(name) && name !== 'listChannelAgents'
+      // `listChannelAgents` and `submitGithubReview` are dispatch-only aliases, and the orchestration triple is retired.
+      (name) => !byName.has(name) && name !== 'listChannelAgents' && name !== 'submitGithubReview'
     )
     expect(missing).toEqual([])
   })
 
-  it.each([...TOOL_ARG_SCHEMAS.keys()].filter((name) => name !== 'listChannelAgents'))(
+  it.each([...TOOL_ARG_SCHEMAS.keys()].filter((name) => name !== 'listChannelAgents' && name !== 'submitGithubReview'))(
     '%s takes exactly the advertised arguments',
     (name) => {
       const descriptor = byName.get(name)!

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -388,6 +388,8 @@ describe('toolsForIntegrations', () => {
         'getMemory',
         'updateMemory',
         'deleteMemory',
+        'submitCodeReview',
+        // The pre-promotion alias stays reserved and auto-allowed for warm sessions.
         'submitGithubReview'
       ])
     )
@@ -411,16 +413,19 @@ describe('toolsForIntegrations', () => {
     }
   })
 
-  it('formal review descriptor has no model-selectable GitHub target', () => {
-    const tool = GITHUB_REVIEW_TOOLS.find((candidate) => candidate.name === 'submitGithubReview')!
-    expect(tool.name).toBe('submitGithubReview')
+  it('formal review descriptor has no model-selectable code-host target', () => {
+    const tool = GITHUB_REVIEW_TOOLS.find((candidate) => candidate.name === 'submitCodeReview')!
+    expect(tool.name).toBe('submitCodeReview')
     const properties = (tool.inputSchema.properties ?? {}) as Record<string, unknown>
     expect(Object.keys(properties)).toEqual(['event', 'verdict', 'body', 'comments'])
     expect(properties).not.toHaveProperty('repoFullName')
     expect(properties).not.toHaveProperty('pullNumber')
     expect(properties).not.toHaveProperty('commitId')
+    expect(properties).not.toHaveProperty('projectId')
+    expect(properties).not.toHaveProperty('mergeRequestIid')
     expect(properties.body).toMatchObject({ minLength: 1 })
     expect(tool.description).toContain('only a definite not_submitted result preserves')
+    expect(tool.description).toContain('REQUEST_CHANGES requires verdict fail')
   })
 
   it('batched review replies select only trusted thread roots exposed by the prompt', () => {


### PR DESCRIPTION
## What

Formal GitLab merge-request reviews (gitlab-com-integration.md section 15), the daemon half, behind `codehost-review-v1` — the last implementation slice of the design's spine.

- **`submitCodeReview`**: the structured review tool becomes provider-routed with an unchanged argument schema; `submitGithubReview` stays as a dispatch-only alias, and the hook prompt text migrates on both providers. The routing goes through a new daemon code-host seam (`codehost/review-adapter.ts`): core never compares a provider name — the adapter that owns the active review turn for the logical session key publishes. GitHub's member is a five-line delegation to the untouched orchestrator; GitLab's is the new adapter.
- **The thirteen-step adapter** (`gitlab/review-adapter.ts`): one attempt per turn, the control-plane publication lease and single-use operation records around every provider mutation, reconcile-before-create per section 15.1 (same-attempt drafts recovered by ordinal, expired attempts deleted with read-after-ambiguous-delete, anything unverifiable failing closed), head re-verified at fetch and again with lease renewal and a draft re-list immediately before the single bulk publish, reviewer state read before drafts and re-read before publication, the reviewer-state parameter exactly per the section 15 table, tier-aware postcondition classification (`requested_changes_block_observed` vs `_state_ambiguous` via the merge-status recheck), and an approval that waits out `checking`/`approvals_syncing` and a null `patch_id_sha`, fences on the exact head SHA, and verifies `approved_by`. Every ambiguous effect fails closed — marker search recovers a published summary, and an unrecovered ambiguity reports `ambiguous_locked` with no fallback and no second publish.
- **Markers**: a hidden versioned attempt-and-ordinal marker, HMAC-signed with a daemon-local key and compared in constant time; model-authored bodies are defanged and multi-marker bodies refused, so planted text can never shadow the adapter's own chrome. The summary rides as draft ordinal zero, keeping publication one bulk operation while leaving a searchable published marker.
- Two review notes: the reviewer read is hoisted before authorization because the authz frame carries `serviceAccountIsReviewer`; and the GitLab prompt states the REQUEST_CHANGES reviewer condition rather than omitting the event — no relay-delivered metadata carries the reviewer record, so the adapter is the first place that fact exists and refuses before any draft.

## Tests

38 adapter tests against a route-driven fake GitLab and fake control plane covering the section 23 review matrix's daemon rows: pre-effect rejections, the happy paths per event, reviewer prerequisites at both read points, head changes at both fences, draft-set mismatch, the full reconciliation table, ambiguous publish in every classification, the approval pipeline including a foreign approval, the one-permit-per-request ledger asserted per outbound call, and big-int ids throughout. Prompt and alias-dispatch tests included; the full gate suite (432 tests across ten files) green; typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
