### PR TITLE
fix(daemon): align transcript row types with the rows readers return

### DIFF
--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -373,7 +373,7 @@ export function createSessionReader(
           return base // unparseable body → fall back to the title-only row
         }
         const bytes = Buffer.byteLength(r.body)
-        base.toolCallId = full.toolCallId ?? r.toolCallId ?? undefined
+        base.toolCallId = full.toolCallId ?? r.tool_call_id ?? undefined
         if (full.status !== undefined) base.toolStatus = full.status
         if (full.kind !== undefined) base.toolKind = full.kind
         if (bytes <= PREVIEW_CAP) {

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -387,15 +387,14 @@ export interface TranscriptEntry {
   orgAgentId?: string
 }
 
-/** A transcript row as read back, including its insertion-order sequence. The
- *  `toolCallId`/`body` columns carry through raw (NULL on text/reasoning rows). */
+/** A transcript row as read back (raw `SELECT *`), including its insertion-order sequence. */
 export interface TranscriptRow extends TranscriptEntry {
   seq: number
   /** Monotonic mutation watermark; changes when a stable row is updated in place. */
   revision: number
   /** Normalized epoch microseconds used by chronological Slack history pagination. */
   eventTimeUs: number
-  toolCallId?: string | null
+  tool_call_id?: string | null // the one snake_case column; readers never alias it. NULL off tool rows
   body?: string | null // JSON.stringify(ToolBody); NULL for text/reasoning rows
   attachmentsJson?: string | null // JSON.stringify(SessionImageAttachment[]); inline webchat only
 }
@@ -3445,7 +3444,7 @@ export class LocalStore {
     limit: number,
     includeTools = false,
     transportScope?: string | null
-  ): Promise<{ sender: string; text: string; kind?: string }[]> {
+  ): Promise<{ sender: string; text: string; kind?: string; input?: string }[]> {
     const transcriptChannel = transcriptChannelKey(channel, transportScope)
     const rows = (await this.db
       .prepare(

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -2196,9 +2196,6 @@ describe('DreamRunner skill mining — review findings', () => {
   })
 })
 
-// `dreamTranscriptText` returns a bounded `input` on tool rows; its declared row type omits it.
-type ToolRow = { sender: string; text: string; kind?: string; input?: string }
-
 describe('dreamTranscriptText tool rows (real LocalStore)', () => {
   const CH = 'C1'
   const TH = 'T1'
@@ -2242,7 +2239,7 @@ describe('dreamTranscriptText tool rows (real LocalStore)', () => {
 
   it('never returns a peer-private tool row via the shared delivery table', async () => {
     const store = await storeWithPeerToolRow()
-    const rows = (await store.dreamTranscriptText(CH, TH, 'me', 100, true)) as ToolRow[]
+    const rows = await store.dreamTranscriptText(CH, TH, 'me', 100, true)
     const text = rows.map((r) => `${r.text} ${r.input ?? ''}`).join('\n')
     expect(text).not.toContain('peer-secret-command')
     expect(text).not.toContain('hunter2')
@@ -2254,9 +2251,7 @@ describe('dreamTranscriptText tool rows (real LocalStore)', () => {
 
   it('carries a bounded rawInput so a generic title still identifies the command', async () => {
     const store = await storeWithPeerToolRow()
-    const mine = ((await store.dreamTranscriptText(CH, TH, 'me', 100, true)) as ToolRow[]).find(
-      (r) => r.kind === 'tool'
-    )
+    const mine = (await store.dreamTranscriptText(CH, TH, 'me', 100, true)).find((r) => r.kind === 'tool')
     expect(mine?.text).toBe('Bash') // the title alone says nothing
     expect(mine?.input).toBe('npm run deploy --prod')
     // rawOutput is the bulk/secret-bearing half and never leaves the store.

--- a/packages/daemon/test/store-concurrency.test.ts
+++ b/packages/daemon/test/store-concurrency.test.ts
@@ -8,7 +8,7 @@
  * covers the other half of that shift: a shutdown now has to await what it used to preempt.
  */
 import { describe, expect, it } from 'vitest'
-import { sessionKey, type LocalStore, type TranscriptRow } from '../src/store/local-store.js'
+import { sessionKey, type LocalStore } from '../src/store/local-store.js'
 import { openTestStore, tempStorePath } from './store-support.js'
 
 const seedSession = async (s: LocalStore, key: string, agentId: string, acpSessionId: string | null) =>
@@ -82,9 +82,7 @@ describe('LocalStore under interleaved turns', () => {
     expect(Math.max(...revisions)).toBe(await s.threadTranscriptRevision(channel, thread))
     // Every tool row carries its own turn's final body: no flush wrote another turn's overlay.
     for (const row of rows.filter((entry) => entry.kind === 'tool')) {
-      // `threadTranscript` is a raw `SELECT *`, so the id arrives under its snake_case column.
-      const toolCallId = (row as TranscriptRow & { tool_call_id?: string }).tool_call_id
-      expect(row.body).toBe(`{"status":"completed","turn":${toolCallId?.slice('tc-'.length)}}`)
+      expect(row.body).toBe(`{"status":"completed","turn":${row.tool_call_id?.slice('tc-'.length)}}`)
     }
     await s.close()
   })


### PR DESCRIPTION
Two declared types in `packages/daemon/src/store/local-store.ts` didn't match the rows their readers actually return, surfaced when #1386 widened the typecheck surface to test files:

- **`TranscriptRow.toolCallId` never existed at runtime.** Every raw `SELECT *` transcript reader (`threadTranscript`, `transcriptSinceRevision`, the page readers) returns the snake_case `tool_call_id` column unaliased — on SQLite trivially, and on PostgreSQL too, since the dialect's column-name restoration only maps identifiers the fold lowercased, and `tool_call_id` is already lowercase. The declaration now names the column as it arrives, with a comment marking it as the table's one snake_case column.
- That mismatch hid a dead defensive fallback: `session-reader.ts` enriched tool rows with `full.toolCallId ?? r.toolCallId`, where the second operand was always `undefined`. It now reads `r.tool_call_id`, so a stored body missing its id actually falls back to the column.
- **`dreamTranscriptText` under-declared its rows.** The mapper returns a bounded `input` on tool rows and the dream runner's `DreamStorePort` contract already declares `input?: string`; the store method's own return type was missing it.

With the declarations truthful, the two local type workarounds #1386 had to add (`store-concurrency.test.ts`, `dream-runner.test.ts`) are removed.

Verified: `tsc -p tsconfig.typecheck.json` clean; `vitest run test/store-concurrency.test.ts test/dream-runner.test.ts test/local-store.test.ts test/session-reader.test.ts` all green (195 tests); eslint clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
