### PR TITLE
docs: record the completed GitLab integration status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,9 @@ callback endpoint is required; the CP only orchestrates. Concretely:
   It also accepts pre-addressed public ingress from the relay. It is a self-contained
   "message + agent execution unit" and keeps running established sessions even if the
   CP is down (graceful degradation).
-- The optional **relay** terminates Slack HTTP callbacks, GitHub and generic webhooks,
-  and webchat, then forwards content directly to the owning daemon. It does not persist
-  message content.
+- The optional **relay** terminates Slack HTTP callbacks, GitHub and GitLab webhooks,
+  generic webhooks, and webchat, then forwards content directly to the owning
+  daemon. It does not persist message content.
 - The **Control Plane** does orchestration/registry/auth + serves the Web UI BFF. It
   stores **only control-plane metadata** — never message bodies, ACP `session/update`
   streams, or attachment bytes. Authorized BFF reads may proxy bounded
@@ -80,16 +80,24 @@ Each host keeps its own per-platform directory plus a static `registry.ts` —
 
 **GitHub and GitLab are deliberately NOT platform modules.** They have no chat
 ingress, so they stay on the webhook / code-host seam (`relay/src/hooks/`,
-`control-plane/src/github/`, the daemon poster) and implement only the narrower
-Layer-2 turn-output surface, which is what removed the hardcoded `github` case
-from the dispatch path. Webchat is core-owned for the same kind of reason: it is
-the console's own surface and shares almost nothing with an external transport.
-Do not "finish the job" by forcing either into `WebPlatformModule` — §2 of the
-design records why that is the wrong shape. The code-host seam gets its own
-provider contract when GitLab arrives and makes it a two-implementer seam
-([`gitlab-com-integration.md`](docs/designs/gitlab-com-integration.md) §1.6,
-§8.1 `CodeHostRepository`); extracting it earlier, from one implementer, would
-be guessing at an interface.
+`control-plane/src/{codehost,github,gitlab}/`,
+`daemon/src/{codehost,github,gitlab}/`) and implement a much narrower
+per-provider surface than a chat platform does. Webchat is core-owned for the
+same kind of reason: it is the console's own surface and shares almost nothing
+with an external transport. Do not "finish the job" by forcing either into
+`WebPlatformModule` — §2 of the design records why that is the wrong shape.
+GitLab has now arrived and made the seam a two-implementer one
+([`gitlab-com-integration.md`](docs/designs/gitlab-com-integration.md) §6.5,
+§8.1 `CodeHostRepository`), so its members exist: the Layer-2 turn output that
+removed the hardcoded `github` case from the dispatch path, and
+`daemon/src/codehost/review-adapter.ts` — `CodeHostReviewAdapter` plus the
+router that hands provider-routed `submitCodeReview` to whichever adapter owns
+the active review turn, the GitHub review orchestrator's member or the GitLab
+adapter (`submitGithubReview` survives as a dispatch alias), over the CP's
+provider-neutral publication lease and operation ledger behind
+`codehost-review-v1`. Each member was extracted in the change that added its
+second implementer; extracting from one implementer would have been guessing at
+an interface.
 
 Two rules this refactor exists to enforce: **a platform name is never core
 knowledge** — core reads a capability, a manifest field, or a registry entry

--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1,6 +1,7 @@
 # GitLab.com Integration
 
-> Status: **Proposed**
+> Status: **Implemented** — the Section 22 M0–M7 spine is merged; that
+> section records the two deliberate leftovers.
 >
 > Platform assumptions last verified: **2026-07-28**
 >
@@ -1590,6 +1591,21 @@ bindings remain visible for repair or disconnect; rollback must not orphan
 external credentials by deleting only local metadata.
 
 ## 22. Implementation Plan
+
+> **Implementation status.** The M0–M7 spine below is implemented. Its
+> rolling-compatibility seams are gated by six feature strings, all declared in
+> `packages/protocol/src/consts.ts`: `gitcred-provider-v2` (provider-qualified
+> Git credentials), `gitlab-com-v1` (the complete daemon and relay GitLab
+> slice), `gitlab-effect-v1` (the Section 14.2 broker effect lease),
+> `gitlab-rerun-v1` (the relay's `rc/hook-rerun` admission),
+> `codehost-note-projection-v1` (the daemon-owned status-note projection), and
+> `codehost-review-v1` (the provider-routed formal-review surface). Two gaps
+> are deliberate. The `hook/start` barrier is a provider one-of on the wire but
+> is still served GitHub-only in the Control Plane, so the note projection's
+> `running` edge waits on its GitLab arm
+> (`packages/control-plane/src/codehost/note-projection.service.ts`); that arm
+> is being finished as follow-up work. The session merge-request dock panel
+> stays out of scope per Section 18.1.
 
 Milestones are merge order, not calendar. Each milestone is several small,
 independently mergeable PRs; GitHub behavior stays green at every merge; each

--- a/docs/designs/integration-plugin-architecture.md
+++ b/docs/designs/integration-plugin-architecture.md
@@ -61,10 +61,12 @@ design toward generality nobody can consume yet.
   connection, CP conversation tables, MCP delegation) and shares almost
   nothing with external chat-platform transports.
 - **GitHub/GitLab do not adopt the full platform contract.** They remain on
-  the webhook/code-host seam (`relay/src/hooks/`, `control-plane/src/github/`,
-  the daemon poster). They _do_ participate in the narrower Layer-2 output
-  surface (§7.6) so the dispatch path stops carrying a hardcoded GitHub
-  special case.
+  the webhook/code-host seam (`relay/src/hooks/`,
+  `control-plane/src/{codehost,github,gitlab}/`,
+  `daemon/src/{codehost,github,gitlab}/`). They _do_ participate in the
+  narrower Layer-2 output surface (§7.6) so the dispatch path stops carrying a
+  hardcoded GitHub special case, and in the review-adapter member the seam
+  gained when GitLab became its second implementer.
 - **No product-behavior changes.** The contracts are a structural seam; where
   a platform's behavior differs, that difference is a manifest field or a
   strategy function, never a core branch.
@@ -94,8 +96,9 @@ Two rules keep the seam from eroding:
    capability flag with better branding and belongs in a host contract (§5.2).
 
 GitHub and GitLab are deliberately outside this set — they have no chat
-ingress and implement only the narrower Layer-2 turn-output surface (§2,
-§7.6). Webchat is core-owned for the same class of reason.
+ingress and implement only the narrower code-host surface: Layer-2 turn output
+(§2, §7.6) plus the review adapter. Webchat is core-owned for the same class of
+reason.
 
 ## 4. Decision Summary
 
@@ -754,10 +757,10 @@ Two decisions specific to this host:
 Routing rules and the mention ladder, bot arbitration, thread-affinity maps
 and their CP legs, session keys and fencing, visibility, cron/hook
 scheduling, the webhook ingress seam (shared signature primitives), webchat
-end-to-end, GitHub/GitLab services (participating only via Layer 2), the
-drain/lease machinery, and the common CP create skeleton. The registries
-themselves are core files; adding a platform edits exactly one line per
-host.
+end-to-end, GitHub/GitLab services (participating via Layer 2 and the review
+adapter), the drain/lease machinery, and the common CP create skeleton. The
+registries themselves are core files; adding a platform edits exactly one line
+per host.
 
 ## 13. Third-Party Extensibility: Deferred, Not Foreclosed
 

--- a/docs/designs/integration-plugin-architecture.md
+++ b/docs/designs/integration-plugin-architecture.md
@@ -32,9 +32,9 @@ contracts**, so that:
    implement a published interface instead of duck-typing internals of an
    18k-line class.
 
-Two upcoming designs pay the current scatter cost imminently —
-[linear-integration.md](linear-integration.md) and
-[gitlab-com-integration.md](gitlab-com-integration.md) are both Proposed —
+Two designs pay the current scatter cost —
+[linear-integration.md](linear-integration.md) is still Proposed and
+[gitlab-com-integration.md](gitlab-com-integration.md) is now Implemented —
 so the refactor amortizes immediately.
 
 **Scope decision (honest goal):** this design delivers **first-party


### PR DESCRIPTION
## What

Brings the in-repo prose in line with the completed GitLab integration.

- `CLAUDE.md`: the code-host seam paragraph described the review-adapter contract as future work ("gets its own provider contract when GitLab arrives"); GitLab is now its second implementer, so the paragraph names the actual members — `CodeHostReviewAdapter` + router with ownership-based routing, the provider-routed `submitCodeReview` with the GitHub alias, and the control plane's provider-neutral publication lease and operation-record machinery behind `codehost-review-v1` — while keeping the paragraph's original warning (do not force code hosts or webchat into `WebPlatformModule`) intact. The relay bullet and the seam directory list are updated to match the tree.
- `docs/designs/gitlab-com-integration.md`: the header status moves from Proposed to Implemented, and section 22 gains a one-paragraph status note naming the six feature strings that gate the rolling-compatibility seams (each verified against `packages/protocol/src/consts.ts`) and the two deliberate leftovers — the GitLab arm of the hook/start barrier (wire-level shape shipped, control-plane arm outstanding, being finished as follow-up work) and the session merge-request dock panel (scoped out per section 18.1).

Every claim was verified against the code before writing; nothing beyond factually stale statements was rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
