### PR TITLE
feat(control-plane): provider-neutral hook start records the GitLab head

### DIFF
--- a/packages/control-plane/src/codehost/note-projection.service.test.ts
+++ b/packages/control-plane/src/codehost/note-projection.service.test.ts
@@ -209,6 +209,28 @@ describe('CodeHostNoteProjectionService', () => {
     expect(desired.writeMarker).not.toBe(desired.projectionKey)
   })
 
+  it('advances the generation to running when the start barrier is crossed', async () => {
+    const { service, projections, sent } = harness({ row: projection({ desiredState: 'running' }) })
+    await service.afterStart(edge({ state: 'running', sessionId: 'sess-1' }))
+    expect(projections.upsert.mock.calls[0]![0]).toMatchObject({
+      desiredState: 'running',
+      startedAt: new Date(NOW),
+      sessionId: 'sess-1'
+    })
+    // A running edge is a lifecycle hint, not terminal authority, so it seals nothing.
+    expect(projections.upsert.mock.calls[0]![0]).not.toHaveProperty('completedAt')
+    expect(projections.setDesired).toHaveBeenCalledWith(expect.any(String), 1n, 'running', new Date(NOW), undefined)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.desired.state).toBe('running')
+  })
+
+  it('leaves a running edge pending when the daemon does not advertise the feature', async () => {
+    const { service, projections, sent } = harness({ features: [], row: projection({ desiredState: 'running' }) })
+    await service.afterStart(edge({ state: 'running' }))
+    expect(projections.upsert).toHaveBeenCalledOnce()
+    expect(sent).toHaveLength(0)
+  })
+
   it('supersedes older heads on the same merge request before opening the new generation', async () => {
     const { service, projections } = harness()
     await service.afterAccepted(edge({ gitlab: gitlab({ headSha: 'b'.repeat(40) }) }))

--- a/packages/control-plane/src/codehost/note-projection.service.ts
+++ b/packages/control-plane/src/codehost/note-projection.service.ts
@@ -151,7 +151,10 @@ export class CodeHostNoteProjectionService {
     await this.converge(edge)
   }
 
-  // The `running` edge waits on the GitLab arm of the `hook/start` barrier, which is GitHub-only today.
+  /** The provider-neutral `hook/start` barrier crossed: the accepted turn is entering the prompt. */
+  async afterStart(edge: NoteProjectionEdge): Promise<void> {
+    await this.converge({ ...edge, state: 'running' })
+  }
 
   /**
    * The daemon settled one desired generation: persist the observed note and drain any parked intent.
@@ -248,6 +251,7 @@ export class CodeHostNoteProjectionService {
       ...(reason ? { reason } : {}),
       ...(edge.sessionId ? { sessionId: edge.sessionId } : {}),
       ...(edge.state === 'queued' ? { queuedAt: edge.at } : {}),
+      ...(edge.state === 'running' ? { startedAt: edge.at } : {}),
       ...(terminal ? { completedAt: edge.at } : {}),
       nextAttemptAt: edge.at
     })

--- a/packages/control-plane/src/codehost/review-lease.service.test.ts
+++ b/packages/control-plane/src/codehost/review-lease.service.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { randomUUID } from 'node:crypto'
-import type { CodeHostReviewAuthorize, CodeHostReviewResultReport } from '@agentconnect.md/protocol'
+import type { CodeHostReviewAuthorize, CodeHostReviewResultReport, HookStart } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, HookId, OrgId } from '../domain/ids.js'
-import type { AgentRecord, HookRecord, HookRunRecord } from '../persistence/ports.js'
+import type { AgentRecord, HookRecord, HookRunRecord, HookStartInput } from '../persistence/ports.js'
 import { FakeCodeHostReviewLeaseRepo } from '../../test/fakes/code-host-review-lease.js'
 import {
   CodeHostReviewBrokerError,
@@ -128,13 +128,18 @@ const SECOND_SNAPSHOT = { ...snapshot, dispatchDaemonId: OTHER_DAEMON }
 
 function build(overrides: Partial<CodeHostReviewBrokerDeps> = {}) {
   const leases = new FakeCodeHostReviewLeaseRepo()
+  const starts: HookStartInput[] = []
   let nowMs = 1_000_000
   const deps: CodeHostReviewBrokerDeps = {
     leases,
     hook: {
       getRun: async (_hookId, deliveryKey) =>
         deliveryKey === SECOND_DELIVERY ? run({ deliveryKey: SECOND_DELIVERY, dispatchDaemonId: OTHER_DAEMON }) : run(),
-      getUnscoped: async () => hook()
+      getUnscoped: async () => hook(),
+      recordStart: async (_hookId, _daemonId, input) => {
+        starts.push(input)
+        return true
+      }
     } as CodeHostReviewBrokerDeps['hook'],
     agent: { getUnscoped: async () => agent } as CodeHostReviewBrokerDeps['agent'],
     // A pool member serves agents its row does not name, so placement equality is not the fence.
@@ -148,6 +153,7 @@ function build(overrides: Partial<CodeHostReviewBrokerDeps> = {}) {
   }
   return {
     leases,
+    starts,
     service: new CodeHostReviewBrokerService(deps),
     advance: (ms: number) => {
       nowMs += ms
@@ -187,6 +193,104 @@ function resultInput(attemptId: string, overrides: Partial<CodeHostReviewResultR
     ...overrides
   }
 }
+
+function startInput(overrides: Partial<HookStart> = {}): HookStart {
+  return {
+    hookId: HOOK,
+    agentId: AGENT,
+    deliveryKey: 'delivery-1',
+    sessionId: 'acp-gitlab-1',
+    event: 'merge_request:update',
+    gitlab: {
+      projectId: PROJECT.toString(),
+      projectPath: 'example-group/example-project',
+      target: { kind: 'merge_request', iid: IID, headSha: HEAD, baseSha: 'b'.repeat(40) }
+    },
+    ...snapshot,
+    ...overrides
+  }
+}
+
+describe('provider-neutral hook start (gitlab-com-integration.md §17.2)', () => {
+  it('records the started head and turn time on the accepted run', async () => {
+    const { service, starts } = build()
+    await service.start(startInput(), DAEMON, ORG)
+    expect(starts).toEqual([
+      expect.objectContaining({
+        deliveryKey: 'delivery-1',
+        agentId: AGENT,
+        sessionId: 'acp-gitlab-1',
+        configRevision: 7n,
+        dispatchRevision: 9n,
+        dispatchDaemonId: DAEMON,
+        headSha: HEAD,
+        baseSha: 'b'.repeat(40),
+        startedAt: new Date(1_000_000)
+      })
+    ])
+  })
+
+  it('reuses the persisted barrier time so a retry stays idempotent', async () => {
+    const persisted = new Date(500)
+    const seen: HookStartInput[] = []
+    const { service } = build({
+      hook: {
+        getRun: async () => run({ turnStartedAt: persisted, headSha: HEAD }),
+        getUnscoped: async () => hook(),
+        recordStart: async (_hookId, _daemonId, input) => {
+          seen.push(input)
+          return true
+        }
+      } as CodeHostReviewBrokerDeps['hook']
+    })
+    await service.start(startInput(), DAEMON, ORG)
+    // CP time is not part of the request, so a retry re-asserts the barrier already on the row.
+    expect(seen[0]?.startedAt).toEqual(persisted)
+  })
+
+  it('records only the turn for a subject that has no revision', async () => {
+    const { service, starts } = build()
+    await service.start(
+      startInput({
+        gitlab: {
+          projectId: PROJECT.toString(),
+          projectPath: 'example-group/example-project',
+          target: { kind: 'push', ref: 'refs/heads/main' }
+        }
+      }),
+      DAEMON,
+      ORG
+    )
+    expect(starts[0]?.headSha).toBeUndefined()
+    expect(starts[0]?.startedAt).toEqual(new Date(1_000_000))
+  })
+
+  it('refuses a start with no provider-neutral metadata', async () => {
+    const { service, starts } = build()
+    await expect(service.start(startInput({ gitlab: undefined }), DAEMON, ORG)).rejects.toBeInstanceOf(
+      CodeHostReviewBrokerError
+    )
+    expect(starts).toEqual([])
+  })
+
+  it('refuses a start whose dispatch fence does not match the accepted run', async () => {
+    const { service, starts } = build()
+    await expect(service.start(startInput(), OTHER_DAEMON, ORG)).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
+    await expect(service.start(startInput(), DAEMON, OrgId('org-2'))).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
+    expect(starts).toEqual([])
+  })
+
+  it('refuses a start whose hook was disabled or retargeted', async () => {
+    const { service } = build({
+      hook: {
+        getRun: async () => run(),
+        getUnscoped: async () => hook({ enabled: false }),
+        recordStart: async () => true
+      } as CodeHostReviewBrokerDeps['hook']
+    })
+    await expect(service.start(startInput(), DAEMON, ORG)).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
+  })
+})
 
 describe('code-host review authorization (gitlab-com-integration.md §15)', () => {
   it('grants the publication lease with a fence and the shared publisher identity', async () => {
@@ -301,11 +405,47 @@ describe('code-host review authorization (gitlab-com-integration.md §15)', () =
     })
   })
 
+  it('fences the head of every run the start barrier crossed', async () => {
+    const { service } = build({
+      hook: {
+        getRun: async () => run({ turnStartedAt: new Date(1_000), headSha: HEAD }),
+        getUnscoped: async () => hook(),
+        recordStart: async () => true
+      } as CodeHostReviewBrokerDeps['hook']
+    })
+    expect(await service.authorize(authorizeInput(), DAEMON, ORG)).toMatchObject({ authorized: true })
+    const moved = authorizeInput({ headSha: 'c'.repeat(40) })
+    expect(await service.authorize(moved, DAEMON, ORG)).toEqual({
+      authorized: false,
+      attemptId: moved.attemptId,
+      reason: 'head_changed',
+      retryable: false
+    })
+  })
+
+  it('refuses a started run whose barrier recorded no head at all', async () => {
+    const { service } = build({
+      hook: {
+        getRun: async () => run({ turnStartedAt: new Date(1_000) }),
+        getUnscoped: async () => hook(),
+        recordStart: async () => true
+      } as CodeHostReviewBrokerDeps['hook']
+    })
+    const input = authorizeInput()
+    expect(await service.authorize(input, DAEMON, ORG)).toMatchObject({ reason: 'head_changed', retryable: false })
+  })
+
+  it('stays graceful for a run started before the provider-neutral barrier existed', async () => {
+    const { service } = build()
+    expect(await service.authorize(authorizeInput(), DAEMON, ORG)).toMatchObject({ authorized: true })
+  })
+
   it('refuses an event the live review policy does not allow', async () => {
     const { service } = build({
       hook: {
         getRun: async () => run(),
-        getUnscoped: async () => hook({ reviewPolicy: 'comment' })
+        getUnscoped: async () => hook({ reviewPolicy: 'comment' }),
+        recordStart: async () => true
       } as CodeHostReviewBrokerDeps['hook']
     })
     const input = authorizeInput({ requestedEvent: 'APPROVE', requestedVerdict: 'pass' })

--- a/packages/control-plane/src/codehost/review-lease.service.ts
+++ b/packages/control-plane/src/codehost/review-lease.service.ts
@@ -27,7 +27,8 @@ import {
   type ErrorCode,
   type HookConfigSnapshot,
   type HookReviewEvent,
-  type HookReviewVerdict
+  type HookReviewVerdict,
+  type HookStart
 } from '@agentconnect.md/protocol'
 import type { Clock } from '../domain/clock.js'
 import { encodeExternalRef } from '../domain/code-host-review.js'
@@ -86,7 +87,7 @@ export type CodeHostReviewPublisherResolver = (
 
 export interface CodeHostReviewBrokerDeps {
   leases: CodeHostReviewLeaseRepo
-  hook: Pick<HookRepo, 'getUnscoped' | 'getRun'>
+  hook: Pick<HookRepo, 'getUnscoped' | 'getRun' | 'recordStart'>
   agent: Pick<AgentRepo, 'getUnscoped'>
   publisher: CodeHostReviewPublisherResolver
   clock: Pick<Clock, 'now'>
@@ -137,6 +138,56 @@ export class CodeHostReviewBrokerService {
   }
 
   /**
+   * Persist the provider-neutral start barrier before an accepted GitLab hook turn is prompted
+   * (§17.2). It attaches the started head and turn time to the accepted run, which is what gives
+   * every later review authorization a head to fence against and the §16 ledger its `running` edge.
+   *
+   * The GitHub review broker is deliberately not involved: its fence is repository/pull-shaped and
+   * its claimed-offline recovery belongs to GitHub webhook redelivery, which GitLab has no claim on.
+   */
+  async start(input: HookStart, reportingDaemonId: DaemonId, reportingOrgId: string): Promise<void> {
+    const gitlab = input.gitlab
+    if (!gitlab) denied('this start barrier carries provider-neutral metadata only')
+    const hookId = HookId(input.hookId)
+    const run = await this.deps.hook.getRun(hookId, input.deliveryKey)
+    if (
+      !run ||
+      run.status !== 'running' ||
+      run.agentId === null ||
+      run.agentId !== AgentId(input.agentId) ||
+      !snapshotMatches(run, input, reportingDaemonId)
+    ) {
+      denied('start dispatch fence does not match the accepted hook run')
+    }
+    if (run.orgId !== reportingOrgId) denied('organization does not match the accepted hook run')
+    const projectId = BigInt(gitlab.projectId)
+    const hook = await this.deps.hook.getUnscoped(hookId)
+    const agent = await this.deps.agent.getUnscoped(run.agentId)
+    if (!this.hookAuthorizes(hook, run, 'gitlab', projectId)) denied('hook is disabled or its project changed')
+    if (!agent || agent.status !== 'active' || !(await this.serves(agent, reportingDaemonId))) {
+      denied('agent is no longer active on the accepted dispatch daemon')
+    }
+    // Only a merge request has a revision; an issue or push subject records the turn time alone.
+    const head = gitlab.target.kind === 'merge_request' ? gitlab.target : undefined
+    const accepted = await this.deps.hook.recordStart(hookId, reportingDaemonId, {
+      deliveryKey: input.deliveryKey,
+      agentId: AgentId(input.agentId),
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+      configRevision: BigInt(input.configRevision),
+      dispatchRevision: BigInt(input.dispatchRevision),
+      dispatchDaemonId: DaemonId(input.dispatchDaemonId),
+      reviewPolicySnapshot: input.reviewPolicy,
+      reportingModeSnapshot: input.reportingMode,
+      gateModeSnapshot: input.gateMode,
+      // CP time is not part of the daemon request; a retry reuses the persisted barrier.
+      startedAt: run.turnStartedAt ?? new Date(this.deps.clock.now()),
+      ...(head?.headSha ? { headSha: head.headSha } : {}),
+      ...(head?.baseSha ? { baseSha: head.baseSha } : {})
+    })
+    if (!accepted) denied('hook start reservation was rejected', 'CONFLICT')
+  }
+
+  /**
    * Authorize one attempt and acquire its publication lease.
    *
    * Authority is the accepted hook delivery plus the LIVE hook, agent, placement,
@@ -181,9 +232,9 @@ export class CodeHostReviewBrokerService {
     if (input.requestedEvent === 'REQUEST_CHANGES' && input.serviceAccountIsReviewer !== true) {
       return refuse(input.attemptId, 'reviewer_assignment_required', false)
     }
-    // The accepted run carries a head only once a provider-neutral start barrier
-    // has filled it; where it does, a changed head is refused before any effect.
-    if (run.headSha !== null && run.headSha !== input.headSha) {
+    // A run the start barrier crossed always carries the head it was started on, so this binds for
+    // every fresh attempt. A row started before that barrier existed carries none and stays graceful.
+    if (run.headSha !== null ? run.headSha !== input.headSha : run.turnStartedAt !== null) {
       return refuse(input.attemptId, 'head_changed', false)
     }
 

--- a/packages/control-plane/src/ws/handlers/hook-start.test.ts
+++ b/packages/control-plane/src/ws/handlers/hook-start.test.ts
@@ -1,0 +1,159 @@
+import type { AnyFrame } from '@agentconnect.md/protocol'
+import { describe, expect, it, vi } from 'vitest'
+import type { DaemonConnection } from '../connection.js'
+import type { DaemonWsDeps } from '../deps.js'
+import { handleHookStart } from './hook-start.js'
+
+const DAEMON_ID = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
+const HOOK_ID = '11111111-1111-4111-8111-111111111111'
+const AGENT_ID = '22222222-2222-4222-8222-222222222222'
+const NOW = 1_700_000_000_000
+const snapshot = {
+  configRevision: '1',
+  dispatchRevision: '2',
+  dispatchDaemonId: DAEMON_ID,
+  reviewPolicy: 'full' as const,
+  reportingMode: 'off' as const,
+  gateMode: 'informational' as const
+}
+const gitlab = {
+  projectId: '4455667',
+  projectPath: 'example-group/example-project',
+  target: { kind: 'merge_request' as const, iid: 42, headSha: 'a'.repeat(40), baseSha: 'b'.repeat(40) }
+}
+
+function fakeConn() {
+  return {
+    daemonId: DAEMON_ID,
+    orgId: 'org-a',
+    replyTo: vi.fn(),
+    sendError: vi.fn()
+  } as unknown as DaemonConnection & { replyTo: ReturnType<typeof vi.fn>; sendError: ReturnType<typeof vi.fn> }
+}
+
+function startFrame(payload: Record<string, unknown>): AnyFrame {
+  return {
+    v: 1,
+    id: crypto.randomUUID(),
+    ts: new Date().toISOString(),
+    type: 'hook/start',
+    payload: {
+      hookId: HOOK_ID,
+      agentId: AGENT_ID,
+      deliveryKey: 'delivery-1',
+      sessionId: 'acp-gitlab-1',
+      event: 'merge_request:update',
+      ...snapshot,
+      ...payload
+    }
+  } as AnyFrame
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  return { promise: new Promise<void>((done) => (resolve = done)), resolve }
+}
+
+function gitlabDeps(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    hook: { get: vi.fn(async () => ({ id: HOOK_ID, kind: 'gitlab', projectionEpoch: 3n })) },
+    codeHostReviewBroker: { start: vi.fn(async () => {}) },
+    codeHostNoteProjection: { afterStart: vi.fn(async () => {}) },
+    githubReviewBroker: { start: vi.fn(async () => {}) },
+    githubRunCoordinator: { afterStart: vi.fn(async () => {}) },
+    clock: { now: () => NOW },
+    ...over
+  } as unknown as DaemonWsDeps
+}
+
+describe('hook/start provider one-of (gitlab-com-integration.md §17.2)', () => {
+  it('records the gitlab start and opens the running projection before it ACKs', async () => {
+    const barrier = deferred()
+    const conn = fakeConn()
+    const frame = startFrame({ gitlab })
+    const deps = gitlabDeps({ codeHostNoteProjection: { afterStart: vi.fn(() => barrier.promise) } })
+
+    const handling = handleHookStart(frame, conn, deps)
+    await vi.waitFor(() => expect(deps.codeHostNoteProjection!.afterStart).toHaveBeenCalledOnce())
+    expect(conn.replyTo).not.toHaveBeenCalled()
+
+    barrier.resolve()
+    await handling
+
+    expect(deps.codeHostReviewBroker!.start).toHaveBeenCalledWith(frame.payload, DAEMON_ID, 'org-a')
+    expect(deps.codeHostNoteProjection!.afterStart).toHaveBeenCalledWith({
+      hookId: HOOK_ID,
+      agentId: AGENT_ID,
+      deliveryKey: 'delivery-1',
+      orgId: 'org-a',
+      state: 'running',
+      sessionId: 'acp-gitlab-1',
+      gitlab,
+      snapshot: frame.payload,
+      projectionEpoch: 3n,
+      at: new Date(NOW)
+    })
+    expect(conn.replyTo).toHaveBeenCalledWith(frame, 'hook/start/ok', { accepted: true })
+  })
+
+  it('never routes a gitlab start through the github review broker', async () => {
+    const conn = fakeConn()
+    const deps = gitlabDeps()
+
+    await handleHookStart(startFrame({ gitlab }), conn, deps)
+
+    expect(deps.githubReviewBroker!.start).not.toHaveBeenCalled()
+    expect(deps.githubRunCoordinator!.afterStart).not.toHaveBeenCalled()
+  })
+
+  it('still records the start when the hook subject has no revision to project', async () => {
+    const conn = fakeConn()
+    const deps = gitlabDeps()
+    const issue = { ...gitlab, target: { kind: 'issue' as const, iid: 7 } }
+
+    await handleHookStart(startFrame({ gitlab: issue }), conn, deps)
+
+    expect(deps.codeHostReviewBroker!.start).toHaveBeenCalledOnce()
+    // The ledger drops a subject with nothing to project; the edge is still offered to it.
+    expect(deps.codeHostNoteProjection!.afterStart).toHaveBeenCalledWith(expect.objectContaining({ gitlab: issue }))
+    expect(conn.replyTo).toHaveBeenCalledWith(expect.anything(), 'hook/start/ok', { accepted: true })
+  })
+
+  it('refuses a gitlab start whose hook is not a gitlab hook in this organization', async () => {
+    const conn = fakeConn()
+    const deps = gitlabDeps({ hook: { get: vi.fn(async () => null) } })
+
+    await handleHookStart(startFrame({ gitlab }), conn, deps)
+
+    expect(deps.codeHostReviewBroker!.start).not.toHaveBeenCalled()
+    expect(conn.sendError).toHaveBeenCalledWith(
+      expect.any(String),
+      'SCOPE_DENIED',
+      'hook is not a gitlab hook in this organization',
+      false
+    )
+  })
+
+  it('leaves the github arm on the github broker and its check coordinator', async () => {
+    const conn = fakeConn()
+    const deps = gitlabDeps()
+    const github = {
+      repoId: '42',
+      repoFullName: 'acme/repo',
+      sourceInstallationId: '77',
+      subjectKind: 'pull_request',
+      pullNumber: 9,
+      headSha: 'head',
+      baseSha: 'base',
+      reportSha: 'head'
+    }
+
+    await handleHookStart(startFrame({ event: 'pull_request:synchronize', github }), conn, deps)
+
+    expect(deps.githubReviewBroker!.start).toHaveBeenCalledOnce()
+    expect(deps.githubRunCoordinator!.afterStart).toHaveBeenCalledWith(HOOK_ID, 'delivery-1')
+    expect(deps.codeHostReviewBroker!.start).not.toHaveBeenCalled()
+    expect(deps.codeHostNoteProjection!.afterStart).not.toHaveBeenCalled()
+    expect(conn.replyTo).toHaveBeenCalledWith(expect.anything(), 'hook/start/ok', { accepted: true })
+  })
+})

--- a/packages/control-plane/src/ws/handlers/hook-start.ts
+++ b/packages/control-plane/src/ws/handlers/hook-start.ts
@@ -1,19 +1,58 @@
 /** `hook/start` metadata barrier: persist before the accepted turn is prompted. */
 import { isFrame } from '@agentconnect.md/protocol'
 import { DaemonId, HookId } from '../../domain/ids.js'
+import { CodeHostReviewBrokerError } from '../../codehost/review-lease.service.js'
 import { GithubReviewBrokerError } from '../../github/review-broker.service.js'
 import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 
 export const handleHookStart: Handler = async (frame, conn, deps) => {
   if (!isFrame('hook/start')(frame)) return
-  if (!deps.githubReviewBroker) {
-    conn.sendError(frame.id, 'SCOPE_DENIED', 'github review broker is not enabled', false)
-    return
-  }
   const orgId = frameOrgId(frame, conn)
   if (!orgId) {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'organization is required', false)
+    return
+  }
+  // The provider one-of routes the barrier (§17.2): the GitLab arm records the started head on the
+  // accepted run and opens the §16 projection's `running` edge, with no GitHub review broker in it.
+  if (frame.payload.gitlab) {
+    if (!deps.codeHostReviewBroker) {
+      conn.sendError(frame.id, 'SCOPE_DENIED', 'code-host reviews are not enabled on this control plane', false)
+      return
+    }
+    const hook = await deps.hook.get(orgId, HookId(frame.payload.hookId))
+    if (!hook || hook.kind !== 'gitlab') {
+      conn.sendError(frame.id, 'SCOPE_DENIED', 'hook is not a gitlab hook in this organization', false)
+      return
+    }
+    try {
+      await deps.codeHostReviewBroker.start(frame.payload, DaemonId(conn.daemonId), orgId)
+      // The OK is the daemon's prompt barrier, so the durable start and its projection generation
+      // both converge before it is sent; a retry is safe because both writes are idempotent.
+      await deps.codeHostNoteProjection?.afterStart({
+        hookId: frame.payload.hookId,
+        agentId: frame.payload.agentId,
+        deliveryKey: frame.payload.deliveryKey,
+        orgId,
+        state: 'running',
+        ...(frame.payload.sessionId ? { sessionId: frame.payload.sessionId } : {}),
+        gitlab: frame.payload.gitlab,
+        snapshot: frame.payload,
+        projectionEpoch: hook.projectionEpoch,
+        at: new Date(deps.clock.now())
+      })
+      conn.replyTo(frame, 'hook/start/ok', { accepted: true })
+    } catch (error) {
+      if (error instanceof CodeHostReviewBrokerError) {
+        conn.sendError(frame.id, error.code, error.message, error.retryable)
+        return
+      }
+      conn.sendError(frame.id, 'INTERNAL', 'hook start barrier failed', true)
+    }
+    return
+  }
+  if (!deps.githubReviewBroker) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'github review broker is not enabled', false)
     return
   }
   try {

--- a/packages/control-plane/src/ws/handlers/register.ts
+++ b/packages/control-plane/src/ws/handlers/register.ts
@@ -13,6 +13,7 @@
 import {
   isFrame,
   AGENT_EXISTS_FEATURE,
+  CODEHOST_NOTE_PROJECTION_V1_FEATURE,
   CODEHOST_REVIEW_V1_FEATURE,
   ORGANIZATION_KNOWLEDGE_FEATURE,
   GITCRED_PROVIDER_V2_FEATURE,
@@ -93,6 +94,10 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
       // §15.1/§17.2: this CP serves the provider-neutral review authorization, the
       // publication lease with its operation ledger, and the body-free result.
       CODEHOST_REVIEW_V1_FEATURE,
+      // §16/§17.2: …and drives the run-projection ledger end to end, including the gitlab arm of
+      // `hook/start` that records the started head and opens `running`. A daemon must not send
+      // that arm before seeing this: a provider member an older CP cannot route is a fatal frame.
+      CODEHOST_NOTE_PROJECTION_V1_FEATURE,
       'agent-directory-org-scope-v1',
       SESSION_LIVE_TAIL_FEATURE,
       SESSION_METADATA_ACK_FEATURE,

--- a/packages/control-plane/test/integration/hook-report.test.ts
+++ b/packages/control-plane/test/integration/hook-report.test.ts
@@ -18,7 +18,9 @@ import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent } from '../fixtures/seed.js'
 import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
-import { handleHookReport } from '../../src/ws/handlers/index.js'
+import { PgAgentRepo } from '../../src/persistence/index.js'
+import { CodeHostReviewBrokerService } from '../../src/codehost/review-lease.service.js'
+import { handleHookReport, handleHookStart } from '../../src/ws/handlers/index.js'
 import { AgentId, DaemonId, HookId, OrgId } from '../../src/domain/ids.js'
 import { systemClock } from '../../src/domain/clock.js'
 import type { DaemonConnection } from '../../src/ws/connection.js'
@@ -1053,5 +1055,125 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
       status: 'success',
       sessionId: 'ses_late'
     })
+  })
+})
+
+/** gitlab-com-integration.md §17.2: the provider-neutral start barrier, end to end on real rows. */
+describe('gitlab hook/start records the started head', () => {
+  const PROJECT = 4455667n
+  const HEAD = 'a'.repeat(40)
+
+  async function placedGitlabHook(): Promise<{ agentId: string; hookId: string }> {
+    await seedDaemon(prisma, DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    await prisma.agent.update({ where: { id: agentId }, data: { status: 'active' } })
+    const hookId = randomUUID()
+    await repo().upsert({
+      hookId: HookId(hookId),
+      orgId: OrgId(DEFAULT_ORG_ID),
+      agentId: AgentId(agentId),
+      kind: 'gitlab',
+      name: 'gitlab-review',
+      sessionMode: 'perThread',
+      repoId: PROJECT,
+      repoFullName: 'example-group/example-project',
+      events: ['merge_request:*'],
+      reviewPolicy: 'full',
+      reportingMode: 'off',
+      gateMode: 'informational',
+      targetPlatform: 'slack'
+    })
+    return { agentId, hookId }
+  }
+
+  async function start(hookId: string, agentId: string, deliveryKey: string) {
+    const hook = (await repo().getUnscoped(HookId(hookId)))!
+    const frame = {
+      v: 1,
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+      type: 'hook/start',
+      payload: {
+        hookId,
+        agentId,
+        deliveryKey,
+        sessionId: 'ses_gitlab',
+        event: 'merge_request:update',
+        gitlab: {
+          projectId: PROJECT.toString(),
+          projectPath: 'example-group/example-project',
+          target: { kind: 'merge_request', iid: 42, headSha: HEAD, baseSha: 'b'.repeat(40) }
+        },
+        configRevision: hook.configRevision.toString(),
+        dispatchRevision: hook.dispatchRevision.toString(),
+        dispatchDaemonId: DAEMON,
+        reviewPolicy: hook.reviewPolicy,
+        reportingMode: hook.reportingMode,
+        gateMode: hook.gateMode
+      }
+    } as AnyFrame
+    const afterStart = vi.fn(async () => {})
+    const deps = {
+      hook: repo(),
+      clock: systemClock,
+      codeHostReviewBroker: new CodeHostReviewBrokerService({
+        leases: {} as never,
+        hook: repo(),
+        agent: new PgAgentRepo(prisma),
+        publisher: async () => null,
+        clock: systemClock
+      }),
+      codeHostNoteProjection: { afterStart } as never
+    } as unknown as DaemonWsDeps
+    const conn = { daemonId: DAEMON, orgId: DEFAULT_ORG_ID, replyTo: vi.fn(), sendError: vi.fn() }
+    await handleHookStart(frame, conn as unknown as DaemonConnection, deps)
+    return { frame, conn, afterStart, hook }
+  }
+
+  it('fills the head and turn time on the accepted run and offers the running edge', async () => {
+    const { agentId, hookId } = await placedGitlabHook()
+    const hook = (await repo().getUnscoped(HookId(hookId)))!
+    await repo().recordDelivery(HookId(hookId), {
+      deliveryKey: 'gl-1',
+      firedAt: new Date('2026-07-03T09:00:00.000Z'),
+      event: 'merge_request:update',
+      status: 'accepted',
+      agentId: AgentId(agentId),
+      configRevision: hook.configRevision,
+      dispatchRevision: hook.dispatchRevision,
+      dispatchDaemonId: DaemonId(DAEMON),
+      reviewPolicySnapshot: hook.reviewPolicy,
+      reportingModeSnapshot: hook.reportingMode,
+      gateModeSnapshot: hook.gateMode
+    })
+    // The relay's accepted report carries no revision for a gitlab run — the barrier is what does.
+    expect(await repo().getRun(HookId(hookId), 'gl-1')).toMatchObject({ headSha: null, turnStartedAt: null })
+
+    const first = await start(hookId, agentId, 'gl-1')
+    expect(first.conn.sendError).not.toHaveBeenCalled()
+    expect(first.conn.replyTo).toHaveBeenCalledWith(first.frame, 'hook/start/ok', { accepted: true })
+    const started = (await repo().getRun(HookId(hookId), 'gl-1'))!
+    expect(started).toMatchObject({ headSha: HEAD, baseSha: 'b'.repeat(40), sessionId: 'ses_gitlab' })
+    expect(started.turnStartedAt).not.toBeNull()
+    expect(first.afterStart).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'running', projectionEpoch: hook.projectionEpoch })
+    )
+
+    // A retried barrier re-asserts the same row rather than moving the recorded head.
+    const retry = await start(hookId, agentId, 'gl-1')
+    expect(retry.conn.replyTo).toHaveBeenCalledWith(retry.frame, 'hook/start/ok', { accepted: true })
+    expect(await repo().getRun(HookId(hookId), 'gl-1')).toMatchObject({
+      headSha: HEAD,
+      turnStartedAt: started.turnStartedAt
+    })
+  })
+
+  it('refuses a barrier whose delivery was never accepted', async () => {
+    const { agentId, hookId } = await placedGitlabHook()
+    const { conn, afterStart } = await start(hookId, agentId, 'gl-missing')
+    expect(conn.replyTo).not.toHaveBeenCalled()
+    expect(conn.sendError).toHaveBeenCalledWith(expect.any(String), 'SCOPE_DENIED', expect.any(String), false)
+    expect(afterStart).not.toHaveBeenCalled()
   })
 })

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -765,11 +765,11 @@ export class CpClient {
     }
   }
 
-  /** Durable start barrier for an accepted GitHub hook turn. Formal review is
-   * not exposed until this correlated request succeeds. */
-  async startHook(payload: HookStart): Promise<HookStartOk> {
+  /** Durable start barrier for an accepted hook turn. Formal review is not exposed until this
+   * correlated request succeeds. The gitlab arm of the one-of is organization-scoped (§17.2). */
+  async startHook(payload: HookStart, orgId?: string): Promise<HookStartOk> {
     this.requireReady('hook/start')
-    const rep = await this.request('hook/start', payload)
+    const rep = await this.request('hook/start', payload, orgId)
     if (rep.type !== 'hook/start/ok') {
       throw new WireError('INTERNAL', `expected hook/start/ok, got ${rep.type}`, false)
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9584,11 +9584,16 @@ export class Daemon {
     if (activeGithub) this.activeGithubTurnMeta.set(key, activeGithub)
     // §17.2: the provider-neutral start barrier attaches the head this turn runs on to the accepted
     // run before the prompt, which is what a review authorization fences and §16 opens `running` on.
-    await this.startGitlabHookTurn(hookContext, sessionId)
-    const gitlabReview = this.gitlabReviews.openTurn(key, hookContext, sessionId, {
-      ...(this.cfg.daemonId ? { daemonId: this.cfg.daemonId } : {}),
-      persist: (required) => this.persistHookState(entry, undefined, required)
-    })
+    const barrier = await this.startGitlabHookTurn(hookContext, sessionId)
+    // A refused barrier keeps the ordinary turn but withholds the formal-review surface, exactly as a
+    // failed GitHub barrier does: a run whose started head was not recorded must never reach a lease.
+    const gitlabReview =
+      barrier === 'failed'
+        ? undefined
+        : this.gitlabReviews.openTurn(key, hookContext, sessionId, {
+            ...(this.cfg.daemonId ? { daemonId: this.cfg.daemonId } : {}),
+            persist: (required) => this.persistHookState(entry, undefined, required)
+          })
     // A replayed delivery may still owe the control plane frames a previous incarnation
     // recorded; the ones needing no provider evidence are handed back before the turn runs.
     if (gitlabReview) {
@@ -9605,16 +9610,20 @@ export class Daemon {
     }
   }
 
-  /** Cross the gitlab `hook/start` barrier (§17.2). A refusal costs only the head fence and the
-   *  §16 `running` edge — the turn continues, exactly as the GitHub barrier does. */
-  private async startGitlabHookTurn(hook: HookDispatchContext | undefined, sessionId: string): Promise<void> {
+  /** Cross the gitlab `hook/start` barrier (§17.2): `started` durably recorded the head, `legacy` is a
+   *  control plane that does not serve the barrier, `failed` is an advertised barrier that refused. */
+  private async startGitlabHookTurn(
+    hook: HookDispatchContext | undefined,
+    sessionId: string
+  ): Promise<'started' | 'legacy' | 'failed'> {
     const gitlab = hook?.gitlab
     const snapshot = hook?.snapshot
-    if (!hook || !gitlab || !snapshot) return
+    if (!hook || !gitlab || !snapshot) return 'legacy'
     const client = this.cpClient
     // An older CP cannot route the gitlab member of the one-of, so the send waits on its bit.
-    if (!client || client.supportsServerFeature?.(CODEHOST_NOTE_PROJECTION_V1_FEATURE) !== true) return
-    if (this.cfg.daemonId && snapshot.dispatchDaemonId !== this.cfg.daemonId) return
+    if (!client || client.supportsServerFeature?.(CODEHOST_NOTE_PROJECTION_V1_FEATURE) !== true) return 'legacy'
+    // A stale dispatch target opens no review turn anyway; the barrier is not this daemon's to cross.
+    if (this.cfg.daemonId && snapshot.dispatchDaemonId !== this.cfg.daemonId) return 'legacy'
     const payload = {
       hookId: hook.hookId,
       agentId: hook.agentId,
@@ -9628,17 +9637,18 @@ export class Daemon {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
         await client.startHook(payload, orgId)
-        return
+        return 'started'
       } catch (err) {
         if (attempt === 2) {
-          this.log.warn(`gitlab hook: hook/start rejected (${formatErr(err)})`)
-          return
+          this.log.warn(`gitlab review: hook/start rejected (${formatErr(err)})`)
+          return 'failed'
         }
         // The daemon ACK and the relay's accepted report travel on different sockets;
         // let the accepted row land before repeating this idempotent barrier.
         await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)))
       }
     }
+    return 'failed'
   }
 
   /** Resolve the exact host this turn runs on and re-apply the session's sticky runtime controls

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9582,7 +9582,9 @@ export class Daemon {
       return undefined
     })
     if (activeGithub) this.activeGithubTurnMeta.set(key, activeGithub)
-    // §15: no hook/start barrier — the accepted delivery report already carries the fence review authz checks.
+    // §17.2: the provider-neutral start barrier attaches the head this turn runs on to the accepted
+    // run before the prompt, which is what a review authorization fences and §16 opens `running` on.
+    await this.startGitlabHookTurn(hookContext, sessionId)
     const gitlabReview = this.gitlabReviews.openTurn(key, hookContext, sessionId, {
       ...(this.cfg.daemonId ? { daemonId: this.cfg.daemonId } : {}),
       persist: (required) => this.persistHookState(entry, undefined, required)
@@ -9600,6 +9602,42 @@ export class Daemon {
       ...(activeGithub ? { github: activeGithub } : {}),
       ...(gitlabReview ? { gitlabReview } : {}),
       ...(activeGithubReplyBatch ? { githubReplyBatch: activeGithubReplyBatch } : {})
+    }
+  }
+
+  /** Cross the gitlab `hook/start` barrier (§17.2). A refusal costs only the head fence and the
+   *  §16 `running` edge — the turn continues, exactly as the GitHub barrier does. */
+  private async startGitlabHookTurn(hook: HookDispatchContext | undefined, sessionId: string): Promise<void> {
+    const gitlab = hook?.gitlab
+    const snapshot = hook?.snapshot
+    if (!hook || !gitlab || !snapshot) return
+    const client = this.cpClient
+    // An older CP cannot route the gitlab member of the one-of, so the send waits on its bit.
+    if (!client || client.supportsServerFeature?.(CODEHOST_NOTE_PROJECTION_V1_FEATURE) !== true) return
+    if (this.cfg.daemonId && snapshot.dispatchDaemonId !== this.cfg.daemonId) return
+    const payload = {
+      hookId: hook.hookId,
+      agentId: hook.agentId,
+      deliveryKey: hook.deliveryKey,
+      sessionId,
+      ...(hook.event ? { event: hook.event } : {}),
+      gitlab,
+      ...snapshot
+    }
+    const orgId = this.cpAgents?.orgForAgent(hook.agentId) ?? this.cpCollab.orgForAgent(hook.agentId)
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        await client.startHook(payload, orgId)
+        return
+      } catch (err) {
+        if (attempt === 2) {
+          this.log.warn(`gitlab hook: hook/start rejected (${formatErr(err)})`)
+          return
+        }
+        // The daemon ACK and the relay's accepted report travel on different sockets;
+        // let the accepted row land before repeating this idempotent barrier.
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)))
+      }
     }
   }
 

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -12,10 +12,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
 import {
+  CODEHOST_NOTE_PROJECTION_V1_FEATURE,
   HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED,
   HOOK_REPORT_REASON_PROVIDER_QUOTA_EXHAUSTED,
   type EventSession,
   type HookReport,
+  type HookStart,
   type RdMsgHook
 } from '@agentconnect.md/protocol'
 import {
@@ -152,6 +154,24 @@ const gitlabFire = (): RdMsgHook =>
     }
   })
 
+/** The same delivery with a complete accepted dispatch tuple and an authoritative head (§17.2). */
+const gitlabReviewFire = (dispatchDaemonId: string): RdMsgHook => {
+  const base = gitlabFire()
+  return {
+    ...base,
+    configRevision: '1',
+    dispatchRevision: '1',
+    dispatchDaemonId,
+    reviewPolicy: 'full',
+    reportingMode: 'off',
+    gateMode: 'informational',
+    gitlab: {
+      ...base.gitlab!,
+      target: { kind: 'merge_request', iid: 42, headSha: 'a'.repeat(40), baseSha: 'b'.repeat(40) }
+    }
+  }
+}
+
 describe('Daemon rd/msg hook fires', () => {
   it('uses the display agent, runtime, and session model in GitHub attribution', async () => {
     const { factory, host } = streamingHost()
@@ -257,6 +277,53 @@ describe('Daemon rd/msg hook fires', () => {
     })
     await daemon.stop()
   }, 15_000)
+
+  // §17.2: the gitlab arm of `hook/start` records the head this turn runs on, but only against a CP
+  // that advertises it — an older one cannot route a provider member and the frame would be fatal.
+  it.each([
+    { name: 'advertises the run-projection feature', features: [CODEHOST_NOTE_PROJECTION_V1_FEATURE], calls: 1 },
+    { name: 'advertises no code-host features', features: [] as string[], calls: 0 }
+  ])(
+    'sends the gitlab hook/start barrier only when the control plane $name',
+    async ({ features, calls }) => {
+      const { factory } = streamingHost()
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
+      await daemon.start()
+      const startHook = vi.fn(async (_payload: HookStart, _orgId?: string) => ({ accepted: true }))
+      const cp = {
+        ...fakeCpClient(),
+        startHook,
+        supportsServerFeature: (feature: string) => features.includes(feature)
+      }
+      ;(daemon as never as { cpClient: unknown }).cpClient = cp
+      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+        poster: { publish: vi.fn(async () => ({ provider: 'gitlab', kind: 'note', externalId: '9001' })) },
+        collector: new GithubReplyCollector()
+      }))
+      const dispatchDaemonId = (daemon as any).cfg.daemonId as string
+
+      await (daemon as any).handleRelayMsg(gitlabReviewFire(dispatchDaemonId), () => {})
+
+      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
+      expect(startHook).toHaveBeenCalledTimes(calls)
+      if (calls === 1) {
+        const payload = startHook.mock.calls[0]![0]
+        expect(payload).toMatchObject({
+          hookId: HOOK_ID,
+          deliveryKey: 'd-1',
+          event: 'merge_request:opened',
+          dispatchDaemonId,
+          reviewPolicy: 'full',
+          gitlab: { projectId: GITLAB_PROJECT, target: { iid: 42, headSha: 'a'.repeat(40) } }
+        })
+        // The one-of is exclusive on the wire: a gitlab start never carries github metadata.
+        expect(payload.github).toBeUndefined()
+        expect(payload.sessionId).toBeTruthy()
+      }
+      await daemon.stop()
+    },
+    15_000
+  )
 
   // gitlab-com-integration.md 14.1/19.3: a note the poster could not publish must fail the run.
   it.each([

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
 import {
   CODEHOST_NOTE_PROJECTION_V1_FEATURE,
+  CODEHOST_REVIEW_V1_FEATURE,
   HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED,
   HOOK_REPORT_REASON_PROVIDER_QUOTA_EXHAUSTED,
   type EventSession,
@@ -28,6 +29,7 @@ import {
   UNTRUSTED_CONTENT_END
 } from '../src/messages/hook-message.js'
 import { GithubReplyCollector } from '../src/github/poster.js'
+import { NO_ACTIVE_REVIEW_TURN } from '../src/codehost/review-adapter.js'
 import { transcriptCoords } from '../src/session/session-manager.js'
 import { DatabaseSync } from 'node:sqlite'
 import { sessionKey } from '../src/store/local-store.js'
@@ -319,6 +321,96 @@ describe('Daemon rd/msg hook fires', () => {
         // The one-of is exclusive on the wire: a gitlab start never carries github metadata.
         expect(payload.github).toBeUndefined()
         expect(payload.sessionId).toBeTruthy()
+      }
+      await daemon.stop()
+    },
+    15_000
+  )
+
+  // Round 2: an advertised barrier that is refused must not fall through to the pre-barrier legacy
+  // branch — the ordinary turn continues, but no formal-review surface exists to reach a lease.
+  it.each([
+    {
+      name: 'refuses an advertised barrier',
+      features: [CODEHOST_NOTE_PROJECTION_V1_FEATURE, CODEHOST_REVIEW_V1_FEATURE],
+      barrierFails: true,
+      startCalls: 3,
+      installed: 0
+    },
+    {
+      name: 'does not advertise the barrier at all',
+      features: [CODEHOST_REVIEW_V1_FEATURE],
+      barrierFails: true,
+      startCalls: 0,
+      installed: 1
+    },
+    {
+      name: 'accepts the barrier',
+      features: [CODEHOST_NOTE_PROJECTION_V1_FEATURE, CODEHOST_REVIEW_V1_FEATURE],
+      barrierFails: false,
+      startCalls: 1,
+      installed: 1
+    }
+  ])(
+    'installs the formal-review turn only when the control plane $name',
+    async ({ features, barrierFails, startCalls, installed }) => {
+      let observed = -1
+      let submitError: Error | undefined
+      const { factory, host } = streamingHost()
+      const stream = host.prompt.getMockImplementation()!
+      host.prompt.mockImplementation(async (sid: string) => {
+        observed = (daemon as any).gitlabReviews.turns.size
+        // With no turn installed, nothing owns the session key and the router refuses the tool
+        // before any control-plane or provider call — the agent keeps its ordinary reply.
+        if (observed === 0) {
+          await (daemon as any).codeReviews
+            .submit({
+              agentId: AGENT_ID,
+              platform: 'hook',
+              channel: HOOK_ID,
+              thread: `gitlab:${GITLAB_PROJECT}:merge_request:42`,
+              transportScope: `gitlab:${GITLAB_PROJECT}`,
+              event: 'COMMENT',
+              verdict: 'neutral',
+              body: 'This must not reach a publication lease.'
+            })
+            .catch((err: Error) => {
+              submitError = err
+            })
+        }
+        return stream(sid)
+      })
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
+      await daemon.start()
+      const authorizeCodeHostReview = vi.fn(async () => {
+        throw new Error('must not authorize')
+      })
+      const cp = {
+        ...fakeCpClient(),
+        startHook: vi.fn(async () => {
+          if (barrierFails) throw new Error('start barrier refused')
+          return { accepted: true }
+        }),
+        authorizeCodeHostReview,
+        supportsServerFeature: (feature: string) => features.includes(feature)
+      }
+      ;(daemon as never as { cpClient: unknown }).cpClient = cp
+      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+        poster: { publish: vi.fn(async () => ({ provider: 'gitlab', kind: 'note', externalId: '9001' })) },
+        collector: new GithubReplyCollector()
+      }))
+      const dispatchDaemonId = (daemon as any).cfg.daemonId as string
+
+      await (daemon as any).handleRelayMsg(gitlabReviewFire(dispatchDaemonId), () => {})
+
+      // The ordinary turn always runs to completion; only the review surface is withheld.
+      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
+      expect(cp.hookReports[0]).toMatchObject({ status: 'success' })
+      expect(cp.startHook).toHaveBeenCalledTimes(startCalls)
+      expect(observed).toBe(installed)
+      if (installed === 0) {
+        expect(submitError?.message).toBe(NO_ACTIVE_REVIEW_TURN)
+        expect(authorizeCodeHostReview).not.toHaveBeenCalled()
       }
       await daemon.stop()
     },

--- a/packages/protocol/src/consts.ts
+++ b/packages/protocol/src/consts.ts
@@ -312,7 +312,9 @@ export const GITCRED_PROVIDER_V2_FEATURE = 'gitcred-provider-v2'
  *  review authorization/result frames). */
 export const CODEHOST_REVIEW_V1_FEATURE = 'codehost-review-v1'
 
-/** Daemon-owned informational status-note projection (desired/result frame pair). */
+/** Informational status-note projection, each side attesting to its own half: the daemon renders
+ *  and updates the note (desired/result frame pair), the CP drives the ledger end to end including
+ *  the gitlab arm of `hook/start` that records the started head and opens `running`. */
 export const CODEHOST_NOTE_PROJECTION_V1_FEATURE = 'codehost-note-projection-v1'
 
 /** CP mints the §14.2 broker effect lease — `purpose: 'gitlab_effect'` on a gitcred v2 request,

--- a/packages/protocol/src/frames/hook.test.ts
+++ b/packages/protocol/src/frames/hook.test.ts
@@ -290,6 +290,29 @@ describe('code-host M0 shapes (gitlab-com-integration.md §17.2)', () => {
     expect(HookStart.safeParse({ ...base, github, gitlab }).success).toBe(false)
   })
 
+  it('round-trips a gitlab hook/start and its correlated barrier reply', () => {
+    const start = buildEnvelope('hook/start', {
+      hookId: HOOK_ID,
+      agentId: AGENT_ID,
+      deliveryKey: 'delivery-1',
+      sessionId: 'acp-gitlab-1',
+      event: 'merge_request:update',
+      gitlab,
+      ...snapshot
+    })
+    const decoded = decodeEnvelope(JSON.stringify(start))
+    expect(decoded.ok).toBe(true)
+    if (!decoded.ok || !isFrame('hook/start')(decoded.frame)) throw new Error('expected hook/start')
+    // The trusted subject discriminator survives the wire: the head the CP fences reviews on.
+    expect(decoded.frame.payload.github).toBeUndefined()
+    expect(decoded.frame.payload.gitlab?.projectId).toBe(gitlab.projectId)
+    const target = decoded.frame.payload.gitlab?.target
+    expect(target?.kind === 'merge_request' ? target.headSha : undefined).toBe('a'.repeat(40))
+    expect(
+      decodeEnvelope(JSON.stringify(buildEnvelope('hook/start/ok', { accepted: true }, { corr: start.id }))).ok
+    ).toBe(true)
+  })
+
   it('accepts gitlab metadata and a provider-neutral published output on hook/report', () => {
     const base = { hookId: HOOK_ID, agentId: AGENT_ID, deliveryKey: 'delivery-1', status: 'success' as const }
     const note = { provider: 'gitlab', kind: 'note', externalId: '123456' }


### PR DESCRIPTION
## What

Closes the two documented leftovers of the GitLab integration by making the hook start barrier provider-neutral (the wire one-of shipped in M0; every consumer of it was GitHub-only).

- **Daemon**: the GitLab hook turn now sends `hook/start` at the same pre-prompt point as the GitHub barrier, org-scoped per section 17.2, with the same short retry against the ACK/run-report race. The send is gated on the control plane advertising `codehost-note-projection-v1` — reused rather than minting a new string because a control plane advertising it now attests to exactly the slice this PR completes (it can route the barrier and drive the projection ledger end to end), following the existing bidirectional-attestation convention of `codehost-review-v1`; section 17.3's four-string enumeration stays intact.
- **Control plane**: the handler routes the gitlab arm to the code-host broker and the projection ledger — never the GitHub review broker — recording the started head and base (merge-request subjects), idempotent on retry; the projection ledger finally reaches `running` with its `startedAt`.
- **Head fence**: the review authorization now binds the head for every started GitLab run; a run started before this barrier existed stays graceful.
- One unreachable GitHub-only gate inside the webhook-redelivery recovery branch is deliberately untouched — every redelivery claim is scoped to GitHub, and widening that path would have been speculative.

## Tests

Protocol envelope round-trip for the gitlab arm; broker start fences (missing metadata, fence mismatch, disabled hook, push subjects record the turn only); ledger `running` edge and pending-without-feature; handler provider routing; an integration test driving the real handler against Postgres asserting the head and turn time land and a retry does not move them; daemon tests for the feature gate and frame shape. Full protocol + CP unit suites, the touched integration suites, daemon gate suites, typecheck (test files included), lint, format all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
