### PR TITLE
fix(web): use the official GitLab tanuki for the platform mark

### DIFF
--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -158,7 +158,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
       <div className="cardhead justify-between">
         <span className="cardtitle flex items-center gap-2">
           <span className="flex h-[15px] w-[15px] items-center justify-center">
-            <GitlabMark color="var(--text-primary)" />
+            <GitlabMark />
           </span>
           GitLab
         </span>
@@ -204,7 +204,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
               <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
                 <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
                   <span className="flex h-[14px] w-[14px] items-center justify-center">
-                    <GitlabMark color="var(--text-primary)" />
+                    <GitlabMark />
                   </span>
                 </span>
                 <span className="mono min-w-0 truncate text-[12.5px]">{c.gitlabUsername}</span>
@@ -386,7 +386,7 @@ function ConfirmGitlab({
       <div className="modalhead">
         <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
           <span className="flex h-4 w-4 items-center justify-center">
-            <GitlabMark color="var(--status-error)" />
+            <GitlabMark />
           </span>
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">{title}</span>

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -188,7 +188,7 @@ export function WorkspaceCard({
 
         {isGit ? (
           <span className="flex h-5 w-5 flex-none items-center justify-center">
-            {isGitlab ? <GitlabMark color="var(--text-secondary)" /> : <GithubMark color="var(--text-secondary)" />}
+            {isGitlab ? <GitlabMark /> : <GithubMark color="var(--text-secondary)" />}
           </span>
         ) : (
           <Icon name="folder" size={16} color="var(--text-tertiary)" />

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -95,7 +95,7 @@ export function WorkspaceModeField({
             className={value === 'gitlab' ? 'ptile on items-start text-left' : 'ptile items-start text-left'}
             onClick={() => onChange('gitlab')}
           >
-            {tileIcon(<GitlabMark color="var(--text-primary)" />)}
+            {tileIcon(<GitlabMark />)}
             <span className="min-w-0 flex-1">
               <span className="block font-sans text-[13px] font-semibold leading-normal">From GitLab</span>
               <span className="mt-[2px] block truncate font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
@@ -356,7 +356,7 @@ export function GitlabProjectField(props: RepositoryPickerProps) {
     <RepositoryPickerField
       {...props}
       label={props.label ?? 'GitLab project'}
-      mark={<GitlabMark color="var(--text-secondary)" />}
+      mark={<GitlabMark />}
       emptyLabel="Pick a project"
       loadingLabel="Loading projects…"
       searchPlaceholder="Search your added projects…"
@@ -391,7 +391,7 @@ export function GitlabProjectOption({
       onClick={() => selectable && onSelect()}
     >
       <span className="flex h-4 w-4 flex-none items-center justify-center">
-        <GitlabMark color="var(--text-tertiary)" />
+        <GitlabMark />
       </span>
       <span className="flex min-w-0 flex-1 flex-col items-start gap-[2px] overflow-hidden">
         <span
@@ -415,7 +415,7 @@ export function GitlabNoProjectsNotice({ integrationsHref }: { integrationsHref:
   return (
     <div className="flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">
       <span className="mt-[1px] flex h-[14px] w-[14px] flex-none items-center justify-center">
-        <GitlabMark color="var(--text-tertiary)" fillPct={100} />
+        <GitlabMark fillPct={100} />
       </span>
       <span>
         No GitLab projects have been added yet. Connect GitLab and add a project under{' '}

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -441,7 +441,7 @@ export default function SessionsView() {
       kind: 'gitlab' as const,
       face: (
         <span className="flex h-[15px] w-[15px] items-center justify-center">
-          <GitlabMark color="var(--text-tertiary)" />
+          <GitlabMark />
         </span>
       )
     }))

--- a/packages/web/src/components/marks.test.tsx
+++ b/packages/web/src/components/marks.test.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { AgentIconView, OrgIconView, PlatformMark, modelProviderSlug } from './marks'
+import { AgentIconView, GitlabMark, OrgIconView, PlatformMark, modelProviderSlug } from './marks'
 
 describe('modelProviderSlug', () => {
   it('reads the provider prefix from provider/model ids', () => {
@@ -84,6 +84,26 @@ describe('icon views', () => {
   })
 })
 
+describe('GitlabMark', () => {
+  it('renders the official multi-color tanuki rather than a monochrome glyph', () => {
+    const markup = renderToStaticMarkup(<GitlabMark />)
+
+    expect(markup).toContain('<svg')
+    // The brand triad, straight from the official logo artwork.
+    expect(markup).toContain('#E24329')
+    expect(markup).toContain('#FC6D26')
+    expect(markup).toContain('#FCA326')
+    expect(markup).not.toContain('currentColor')
+    expect(markup).toContain('width:60%')
+  })
+
+  it('applies a caller fill verbatim so it matches the GitHub mark beside it', () => {
+    // Only PlatformMark caps a full-bleed request; both code-host marks pass it through.
+    expect(renderToStaticMarkup(<GitlabMark fillPct={100} />)).toContain('width:100%')
+    expect(renderToStaticMarkup(<GitlabMark fillPct={90} />)).toContain('width:90%')
+  })
+})
+
 describe('PlatformMark', () => {
   it('applies the requested fill once to the GitHub mark', () => {
     const inset = renderToStaticMarkup(<PlatformMark platform="github" />)
@@ -104,11 +124,9 @@ describe('PlatformMark', () => {
   })
 
   it('caps the square brand glyphs at 80% while other marks honour a full-bleed box', () => {
-    // Slack / GitHub / Discord have no padding inside their artwork, so a
-    // fillPct=100 caller (the session rail rows) would draw them larger than the
-    // marks beside them. Slack is an Iconify mark, which renders an empty <span>
-    // until it hydrates, so only the react-icons pair is assertable from SSR.
-    for (const platform of ['github', 'discord']) {
+    // No padding inside this artwork, so an uncapped fillPct=100 would outsize the marks beside it.
+    for (const platform of ['github', 'gitlab', 'discord']) {
+      // Slack belongs here too, but renders without `ssr`, so SSR gives it an empty <span>.
       const markup = renderToStaticMarkup(<PlatformMark platform={platform} fillPct={100} />)
       expect(markup, platform).toContain('width:80%')
       expect(markup, platform).not.toContain('width:100%')

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -6,11 +6,12 @@
 import { useState } from 'react'
 import { Icon } from './ui'
 import { withIconUrl, type AgentIcon } from '@/lib/agent-icon'
+import gitlabIcon from '@iconify-icons/logos/gitlab'
 import slackIcon from '@iconify-icons/logos/slack-icon'
 import webhooksLogoFillIcon from '@iconify-icons/ph/webhooks-logo-fill'
 import { Icon as IconifyIcon } from '@iconify/react'
 import { FcGoogle } from 'react-icons/fc'
-import { SiGithub, SiGitlab } from 'react-icons/si'
+import { SiGithub } from 'react-icons/si'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { LARK_MARK_SRC } from './console/platforms/feishu/mark'
 import { platformMark } from './console/platforms/marks'
@@ -222,11 +223,9 @@ export function GithubMark({ color = 'currentColor', fillPct = 60 }: { color?: s
   )
 }
 
-// GitLab tanuki mark — the code-host counterpart of {@link GithubMark}.
-export function GitlabMark({ color = 'currentColor', fillPct = 60 }: { color?: string; fillPct?: number }) {
-  return (
-    <SiGitlab style={{ width: `${fillPct}%`, height: `${fillPct}%`, display: 'block' }} color={color} aria-hidden />
-  )
+// GitLab tanuki mark — {@link GithubMark}'s multi-color counterpart, hence no `color`; `ssr` draws it before mount.
+export function GitlabMark({ fillPct = 60 }: { fillPct?: number }) {
+  return <IconifyIcon icon={gitlabIcon} ssr style={markBox(fillPct)} aria-hidden />
 }
 
 /**
@@ -258,7 +257,7 @@ export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fil
   }
   // The other code host, capped the same way: the tanuki is a full-bleed glyph too.
   if (x.includes('gitlab')) {
-    return <SiGitlab style={sq} color="currentColor" aria-hidden />
+    return <IconifyIcon icon={gitlabIcon} ssr style={sq} aria-hidden />
   }
   if (x.includes('hook')) {
     return <IconifyIcon icon={webhooksLogoFillIcon} style={s} color="var(--brand)" aria-hidden />


### PR DESCRIPTION
## What

The GitLab platform mark rendered a third-party monochrome simplification (`react-icons/si`) while the other platform marks carry their official brand logos. It now uses the official multi-color tanuki from the already-installed `@iconify-icons/logos` set — no dependency change — in both `GitlabMark` and `PlatformMark`'s gitlab arm. GitHub is untouched: monochrome is its official mark.

- Rendered with `ssr` so the logo is in the first paint (Iconify otherwise mounts an empty span, which is also why the mark was previously untestable from SSR); the icon is static, so no hydration mismatch.
- The `color` prop is dropped: every passing site inherited text-tone styling copied from the GitHub mark, and the console's other multi-color brand marks already take only `fillPct`, matching the module contract. The disconnect-confirm modal head keeps its destructive signal through the error-soft plate.
- Sizing is unchanged — `markBox` like the GitHub mark, so GitLab does not render smaller than GitHub where they stand side by side; the 80% cap stays where it already was.

## Tests

New mark tests assert the SVG carries all three brand fills and no `currentColor`, with fill pass-through at three sizes; the square-glyph cap loop now covers gitlab. Full web suite (169 files / 1833 tests), typecheck, lint, format all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
